### PR TITLE
Corrects typo on default debian PID

### DIFF
--- a/debian/packetbeat.init
+++ b/debian/packetbeat.init
@@ -22,7 +22,7 @@ DESC="Packetbeat agent software"
 NAME=packetbeat
 DAEMON=/usr/bin/$NAME
 DAEMON_ARGS="-c /etc/packetbeat/packetbeat.conf"
-PIDFILE=/var/run/acketbeat.pid
+PIDFILE=/var/run/packetbeat.pid
 SCRIPTNAME=/etc/init.d/$NAME
 
 # Exit if the package is not installed


### PR DESCRIPTION
Hey guys,

Just trying this out for the first time -- wouldn't have noticed the typo, except that I tried to start the service without appropriate permission.

Can't wait to dive deeper.
