### PR TITLE
add a line  "BuildRoot" to packetbeat.spec

### DIFF
--- a/rpm/packetbeat.spec
+++ b/rpm/packetbeat.spec
@@ -3,6 +3,7 @@ Name:		packetbeat
 Version:	0.3.2
 Release:	1%{?dist}
 Source:		%{name}.tar.gz
+BuildRoot: %{_tmppath}/%{name}
 
 Group:		Network
 License:	GPLv2


### PR DESCRIPTION
add a line  " BuildRoot: %{_tmppath}/%{name}"  to fix rpm build errs on some systems ;please see here for detail:  http://stackoverflow.com/questions/1879734/rpm-build-error
