### PR TITLE
Add exclude_lines and include_lines options

### DIFF
--- a/filebeat/config/config.go
+++ b/filebeat/config/config.go
@@ -63,7 +63,9 @@ type HarvesterConfig struct {
 	BackoffFactor      int    `yaml:"backoff_factor"`
 	MaxBackoff         string `yaml:"max_backoff"`
 	MaxBackoffDuration time.Duration
-	ForceCloseFiles    bool `yaml:"force_close_files"`
+	ForceCloseFiles    bool     `yaml:"force_close_files"`
+	ExcludeLines       []string `yaml:"exclude_lines"`
+	IncludeLines       []string `yaml:"include_lines"`
 }
 
 const (

--- a/filebeat/docs/configuration.asciidoc
+++ b/filebeat/docs/configuration.asciidoc
@@ -65,6 +65,36 @@ One of the following input types:
 
 The value that you specify here is used as the `input_type` for each event published to Logstash and Elasticsearch.
 
+===== exclude_lines
+
+A list of regular expressions to match the lines that are dropped. It drops the lines that are matching any regular
+expression from the list. By default, no lines are dropped.
+
+[source,yaml]
+-------------------------------------------------------------------------------------
+exclude_lines: ["^DBG"]
+-------------------------------------------------------------------------------------
+To exclude the lines starting with "DBG".
+
+===== include_lines
+
+A list of regular expressions to match the lines that are exported. It exports only the lines that are matching any regular expression from the list. By default, all lines are exported.
+
+[source,yaml]
+-------------------------------------------------------------------------------------
+include_lines: ["^ERR", "^WARN"]
+-------------------------------------------------------------------------------------
+To include only the lines starting with "ERR" or "WARN".
+
+Note::
+If both `include_lines` and `exclude_lines` are defined, then include_lines is called first. To export all the apache logs except the DBGs, then you can use:
+
+[source,yaml]
+-------------------------------------------------------------------------------------
+ include_lines: ["apache"]
+ exclude_lines: ["^DBG"]
+-------------------------------------------------------------------------------------
+
 [[configuration-fields]]
 ===== fields
 

--- a/filebeat/etc/beat.yml
+++ b/filebeat/etc/beat.yml
@@ -30,6 +30,16 @@ filebeat:
       # * stdin: Reads the standard in
       input_type: log
 
+      # Exclude lines. A list of regular expressions to match. It drops the lines that are
+      # matching any regular expression from the list. The include_lines is called before
+      # exclude_lines. By default, no lines are dropped. 
+      # exclude_lines: ["^DBG"]
+
+      # Include lines. A list of regular expressions to match. It exports the lines that are
+      # matching any regular expression from the list. The include_lines is called before 
+      # exclude_lines. By default, all the lines are exported.
+      # include_lines: ["^ERR", "^WARN"]
+
       # Optional additional fields. These field can be freely picked
       # to add additional information to the crawled log files for filtering
       #fields:

--- a/filebeat/etc/filebeat.yml
+++ b/filebeat/etc/filebeat.yml
@@ -30,6 +30,16 @@ filebeat:
       # * stdin: Reads the standard in
       input_type: log
 
+      # Exclude lines. A list of regular expressions to match. It drops the lines that are
+      # matching any regular expression from the list. The include_lines is called before
+      # exclude_lines. By default, no lines are dropped. 
+      # exclude_lines: ["^DBG"]
+
+      # Include lines. A list of regular expressions to match. It exports the lines that are
+      # matching any regular expression from the list. The include_lines is called before 
+      # exclude_lines. By default, all the lines are exported.
+      # include_lines: ["^ERR", "^WARN"]
+
       # Optional additional fields. These field can be freely picked
       # to add additional information to the crawled log files for filtering
       #fields:
@@ -162,9 +172,6 @@ output:
 
     # Optional HTTP Path
     #path: "/elasticsearch"
-
-    # Proxy server URL
-    # proxy_url: http://proxy:3128
 
     # The number of times a particular Elasticsearch index operation is attempted. If
     # the indexing operation doesn't succeed after this many retries, the events are

--- a/filebeat/harvester/harvester.go
+++ b/filebeat/harvester/harvester.go
@@ -16,6 +16,7 @@ package harvester
 import (
 	"io"
 	"os"
+	"regexp"
 	"time"
 
 	"github.com/elastic/beats/filebeat/config"
@@ -24,15 +25,17 @@ import (
 )
 
 type Harvester struct {
-	Path             string /* the file path to harvest */
-	ProspectorConfig config.ProspectorConfig
-	Config           *config.HarvesterConfig
-	Offset           int64
-	Stat             *FileStat
-	SpoolerChan      chan *input.FileEvent
-	encoding         encoding.EncodingFactory
-	file             FileSource /* the file being watched */
-	backoff          time.Duration
+	Path               string /* the file path to harvest */
+	ProspectorConfig   config.ProspectorConfig
+	Config             *config.HarvesterConfig
+	Offset             int64
+	Stat               *FileStat
+	SpoolerChan        chan *input.FileEvent
+	encoding           encoding.EncodingFactory
+	file               FileSource /* the file being watched */
+	backoff            time.Duration
+	ExcludeLinesRegexp []*regexp.Regexp
+	IncludeLinesRegexp []*regexp.Regexp
 }
 
 // Contains statistic about file when it was last seend by the prospector

--- a/filebeat/harvester/log_test.go
+++ b/filebeat/harvester/log_test.go
@@ -111,3 +111,30 @@ func TestLineEndingChars(t *testing.T) {
 	line = []byte("NR ending \n\r")
 	assert.Equal(t, 0, lineEndingChars(line))
 }
+
+func TestExcludeLine(t *testing.T) {
+
+	regexp, err := InitRegexps([]string{"^DBG"})
+
+	assert.Nil(t, err)
+
+	assert.True(t, MatchAnyRegexps(regexp, "DBG: a debug message"))
+	assert.False(t, MatchAnyRegexps(regexp, "ERR: an error message"))
+}
+
+func TestIncludeLine(t *testing.T) {
+
+	regexp, err := InitRegexps([]string{"^ERR", "^WARN"})
+
+	assert.Nil(t, err)
+
+	assert.False(t, MatchAnyRegexps(regexp, "DBG: a debug message"))
+	assert.True(t, MatchAnyRegexps(regexp, "ERR: an error message"))
+	assert.True(t, MatchAnyRegexps(regexp, "WARNING: a simple warning message"))
+}
+
+func TestInitRegexp(t *testing.T) {
+
+	_, err := InitRegexps([]string{"((((("})
+	assert.NotNil(t, err)
+}

--- a/filebeat/tests/system/config/filebeat.yml.j2
+++ b/filebeat/tests/system/config/filebeat.yml.j2
@@ -23,6 +23,13 @@ filebeat:
       {% endfor %}
       {% endif %}
       fields_under_root: {{"true" if fieldsUnderRoot else "false"}}
+      {% if include_lines %}
+      include_lines: {{include_lines}}
+      {% endif %}
+      {% if exclude_lines %}
+      exclude_lines: {{exclude_lines}}
+      {% endif %}
+      
   spool_size:
   idle_timeout: 0.1s
   registry_file: {{ fb.working_dir + '/' }}{{ registryFile|default(".filebeat")}}


### PR DESCRIPTION
- exclude_lines option accepts a list of regular expressions to match. If any line matches at least one of the regular
  expressions, the line is dropped and not exported
- include_lines option accepts a list of regular expressions to match. If any line matches at least one of the regular
  expressions, the line is exported

Example:

 - include_lines: ["^ERR", "^WARN"]

Results in exporting only the lines that start with "ERR" or "WARN".
Note: First executes the include_lines and then exclude_lines.

This fixes the issue: https://github.com/elastic/filebeat/issues/78
