### PR TITLE
Proposal: Default to Elasticsearch output if no outputs are configured

### DIFF
--- a/libbeat/publisher/publish.go
+++ b/libbeat/publisher/publish.go
@@ -193,6 +193,12 @@ func (publisher *PublisherType) init(
 	publisher.disabled = *publishDisabled
 	if publisher.disabled {
 		logp.Info("Dry run mode. All output types except the file based one are disabled.")
+	} else if len(configs) == 0 {
+		logp.Info("No output set. Fall back to standard output elasticsearch on localhost:9200")
+		configs = make(map[string]outputs.MothershipConfig)
+		configs["elasticsearch"] = outputs.MothershipConfig{
+			Hosts: []string{"localhost:9200"},
+		}
 	}
 
 	publisher.GeoLite = common.LoadGeoIPData(shipper.Geoip)


### PR DESCRIPTION
* Make beatstart without setting a host possible by setting a default host.
* Config file is now always search by default in the binary directory itself. (https://github.com/elastic/beats/issues/419)

In case the config file has to be loaded from a different directory, it must be set in the startup / service script. This is already the case so this should not break BC. For debian for example here: https://github.com/elastic/beats-packer/blob/master/platforms/debian/init.j2#L20

For Windows I'm not sure if it is equal to our default directory we had? https://github.com/elastic/beats-packer/blob/master/platforms/windows/install-service.ps1.j2#L14 @andrewkroh 

The advantage of having the config per default in the same directory is, that it make it much easier to start the beat the first time.