### PR TITLE
Winlogbeat - create state directory when it does not exist.

### DIFF
--- a/winlogbeat/checkpoint/checkpoint.go
+++ b/winlogbeat/checkpoint/checkpoint.go
@@ -255,5 +255,6 @@ func (c *Checkpoint) read() (*PersistedState, error) {
 // directory does not already exist.
 func (c *Checkpoint) createDir() error {
 	dir := filepath.Dir(c.file)
+	logp.Info("Creating %s if it does not exist.", dir)
 	return os.MkdirAll(dir, os.FileMode(0750))
 }


### PR DESCRIPTION
Create the directory in which the persisted data is saved to when the directory does not exist. Also verify the write permissions on the file at start up so that an error can be returned.