### PR TITLE
Fix packetbeat build with recent thrift

### DIFF
--- a/packetbeat/protos/thrift/thrift_idl.go
+++ b/packetbeat/protos/thrift/thrift_idl.go
@@ -27,8 +27,8 @@ func fieldsToArrayById(fields []*parser.Field) []*string {
 
 	max := 0
 	for _, field := range fields {
-		if field.Id > max {
-			max = field.Id
+		if field.ID > max {
+			max = field.ID
 		}
 	}
 
@@ -36,7 +36,7 @@ func fieldsToArrayById(fields []*parser.Field) []*string {
 
 	for _, field := range fields {
 		if len(field.Name) > 0 {
-			output[field.Id] = &field.Name
+			output[field.ID] = &field.Name
 		}
 	}
 


### PR DESCRIPTION
packetbeat fails to compile on OpenBSD for various reasons, but one of them is:
```
# github.com/elastic/beats/packetbeat/protos/thrift
/home/jasper/hack/Go/src/github.com/elastic/beats/packetbeat/protos/thrift/thrift_idl.go:30: field.Id undefined (type *parser.Field has no field or method Id, but does have ID)
/home/jasper/hack/Go/src/github.com/elastic/beats/packetbeat/protos/thrift/thrift_idl.go:31: field.Id undefined (type *parser.Field has no field or method Id, but does have ID)
/home/jasper/hack/Go/src/github.com/elastic/beats/packetbeat/protos/thrift/thrift_idl.go:39: field.Id undefined (type *parser.Field has no field or method Id, but does have ID)
```

It seems the `go-thrift` API changed with https://github.com/samuel/go-thrift/commit/9f463992ae355c4ce67c25981d34b0307cbf05cd#diff-1461ac18f2b1c20ac215c7c68fbe3ab9L30 though I wonder why nobody has noticed this before?