### PR TITLE
Redis profiling experiment

### DIFF
--- a/libbeat/common/streambuf/ascii.go
+++ b/libbeat/common/streambuf/ascii.go
@@ -14,7 +14,7 @@ var ErrExpectedDigit = errors.New("Expected digit")
 // If CRLF was not found yet one of ErrNoMoreBytes or ErrUnexpectedEOB will be
 // reported.
 func (b *Buffer) UntilCRLF() ([]byte, error) {
-	if b.Failed() {
+	if b.err != nil {
 		return nil, b.err
 	}
 
@@ -48,7 +48,7 @@ func (b *Buffer) UntilCRLF() ([]byte, error) {
 // Ignore symbol will advance the read pointer until the first symbol not
 // matching s is found.
 func (b *Buffer) IgnoreSymbol(s uint8) error {
-	if b.Failed() {
+	if b.err != nil {
 		return b.err
 	}
 
@@ -67,7 +67,7 @@ func (b *Buffer) IgnoreSymbol(s uint8) error {
 // true, the collected byte slice will be returned if no more bytes are available
 // for parsing, but s has not matched yet.
 func (b *Buffer) UntilSymbol(s uint8, errOnEnd bool) ([]byte, error) {
-	if b.Failed() {
+	if b.err != nil {
 		return nil, b.err
 	}
 
@@ -92,7 +92,7 @@ func (b *Buffer) UntilSymbol(s uint8, errOnEnd bool) ([]byte, error) {
 
 // AsciiUint will parse unsigned number from Buffer.
 func (b *Buffer) AsciiUint(errOnEnd bool) (uint64, error) {
-	if b.Failed() {
+	if b.err != nil {
 		return 0, b.err
 	}
 	if len(b.data) <= b.mark { // end of buffer
@@ -115,7 +115,7 @@ func (b *Buffer) AsciiUint(errOnEnd bool) (uint64, error) {
 
 // AsciiInt will parse (optionally) signed number from Buffer.
 func (b *Buffer) AsciiInt(errOnEnd bool) (int64, error) {
-	if b.Failed() {
+	if b.err != nil {
 		return 0, b.err
 	}
 	if len(b.data) <= b.mark { // end of buffer
@@ -164,7 +164,7 @@ func (b *Buffer) AsciiInt(errOnEnd bool) (int64, error) {
 // AsciiMatch checks the Buffer it's next byte sequence matched prefix. The
 // read pointer is not advanced by AsciiPrefix.
 func (b *Buffer) AsciiMatch(prefix []byte) (bool, error) {
-	if b.Failed() {
+	if b.err != nil {
 		return false, b.err
 	}
 	if !b.Avail(len(prefix)) {

--- a/libbeat/common/streambuf/io.go
+++ b/libbeat/common/streambuf/io.go
@@ -80,7 +80,7 @@ func (b *Buffer) Read(p []byte) (int, error) {
 // Write writes p to the buffer if buffer is not fixed. Returns the number of
 // bytes written or ErrOperationNotAllowed if buffer is fixed.
 func (b *Buffer) Write(p []byte) (int, error) {
-	err := b.doAppend(p, false)
+	err := b.doAppend(p, false, -1)
 	if err != nil {
 		return 0, b.ioErr()
 	}

--- a/libbeat/common/string.go
+++ b/libbeat/common/string.go
@@ -1,0 +1,10 @@
+package common
+
+type NetString []byte
+
+// implement encoding.TextMarshaller interface to treat []byte as raw string
+// by other encoders/serializers (e.g. JSON)
+
+func (n NetString) MarshalText() ([]byte, error) {
+	return n, nil
+}

--- a/libbeat/docs/command-line.asciidoc
+++ b/libbeat/docs/command-line.asciidoc
@@ -23,6 +23,9 @@ list of components, or you can use `-d "*"` to enable debugging for all componen
 *`-e`*::
 Log to stderr and disable syslog/file output.
 
+*`-httpprof [<host>]:<port>`*::
+Start http server for profiling. This option is useful for troubleshooting and profiling the Beat.
+
 *`-memprofile <output file>`*::
 Write memory profile data to the specified output file. This option is useful for
 troubleshooting the Beat.

--- a/libbeat/publisher/async.go
+++ b/libbeat/publisher/async.go
@@ -15,10 +15,6 @@ type asyncPublisher struct {
 	ws      workerSignal
 }
 
-type asyncClient struct {
-	publisher *asyncPublisher
-}
-
 const (
 	defaultFlushInterval = 1000 * time.Millisecond // 1s
 	defaultBulkSize      = 10000
@@ -58,16 +54,16 @@ func (p *asyncPublisher) onMessage(m message) {
 }
 
 func (p *asyncPublisher) client() eventPublisher {
-	return asyncClient{p}
+	return p
 }
 
-func (c asyncClient) PublishEvent(ctx context, event common.MapStr) bool {
-	c.publisher.send(message{context: ctx, event: event})
+func (p *asyncPublisher) PublishEvent(ctx context, event common.MapStr) bool {
+	p.send(message{context: ctx, event: event})
 	return true
 }
 
-func (c asyncClient) PublishEvents(ctx context, events []common.MapStr) bool {
-	c.publisher.send(message{context: ctx, events: events})
+func (p *asyncPublisher) PublishEvents(ctx context, events []common.MapStr) bool {
+	p.send(message{context: ctx, events: events})
 	return true
 }
 

--- a/libbeat/publisher/client.go
+++ b/libbeat/publisher/client.go
@@ -25,37 +25,38 @@ type client struct {
 }
 
 // ClientOption allows API users to set additional options when publishing events.
-type ClientOption func(option *publishOptions)
+type ClientOption func(option publishOptions) publishOptions
 
 // Confirm option will block the event publisher until event has been send and ACKed
 // by output plugin or fail is reported.
-func Confirm(options *publishOptions) {
-	options.confirm = true
+func Confirm(o publishOptions) publishOptions {
+	o.confirm = true
+	return o
 }
 
 // Sync option will block the event publisher until an event has been ACKed by
 // the output plugin. If output plugin signals failure, the client will retry
 // until success is signaled.
-func Sync(options *publishOptions) {
-	options.confirm = true
-	options.sync = true
+func Sync(o publishOptions) publishOptions {
+	o.confirm = true
+	o.sync = true
+	return o
 }
 
 func (c *client) PublishEvent(event common.MapStr, opts ...ClientOption) bool {
 	options, client := c.getClient(opts)
-	return client.PublishEvent(&context{publishOptions: options}, event)
+	return client.PublishEvent(context{publishOptions: options}, event)
 }
 
 func (c *client) PublishEvents(events []common.MapStr, opts ...ClientOption) bool {
 	options, client := c.getClient(opts)
-	return client.PublishEvents(&context{publishOptions: options}, events)
+	return client.PublishEvents(context{publishOptions: options}, events)
 }
 
 func (c *client) getClient(opts []ClientOption) (publishOptions, eventPublisher) {
-	debug("send event")
-	options := publishOptions{}
+	var options publishOptions
 	for _, opt := range opts {
-		opt(&options)
+		options = opt(options)
 	}
 
 	if options.confirm {

--- a/libbeat/publisher/common_test.go
+++ b/libbeat/publisher/common_test.go
@@ -159,22 +159,22 @@ func newTestPublisher(bulkSize int, response OutputResponse) *testPublisher {
 
 func (t *testPublisher) asyncPublishEvent(event common.MapStr) bool {
 	ctx := context{}
-	return t.pub.asyncPublisher.client().PublishEvent(&ctx, event)
+	return t.pub.asyncPublisher.client().PublishEvent(ctx, event)
 }
 
 func (t *testPublisher) asyncPublishEvents(events []common.MapStr) bool {
 	ctx := context{}
-	return t.pub.asyncPublisher.client().PublishEvents(&ctx, events)
+	return t.pub.asyncPublisher.client().PublishEvents(ctx, events)
 }
 
 func (t *testPublisher) syncPublishEvent(event common.MapStr) bool {
 	ctx := context{publishOptions: publishOptions{confirm: true}}
-	return t.pub.syncPublisher.client().PublishEvent(&ctx, event)
+	return t.pub.syncPublisher.client().PublishEvent(ctx, event)
 }
 
 func (t *testPublisher) syncPublishEvents(events []common.MapStr) bool {
 	ctx := context{publishOptions: publishOptions{confirm: true}}
-	return t.pub.syncPublisher.client().PublishEvents(&ctx, events)
+	return t.pub.syncPublisher.client().PublishEvents(ctx, events)
 }
 
 // newTestPublisherWithBulk returns a new testPublisher with bulk message

--- a/libbeat/publisher/publish.go
+++ b/libbeat/publisher/publish.go
@@ -27,8 +27,8 @@ var debug = logp.MakeDebug("publish")
 
 // EventPublisher provides the interface for beats to publish events.
 type eventPublisher interface {
-	PublishEvent(ctx *context, event common.MapStr) bool
-	PublishEvents(ctx *context, events []common.MapStr) bool
+	PublishEvent(ctx context, event common.MapStr) bool
+	PublishEvents(ctx context, events []common.MapStr) bool
 }
 
 type context struct {

--- a/libbeat/publisher/sync.go
+++ b/libbeat/publisher/sync.go
@@ -32,12 +32,12 @@ func (p *syncPublisher) onMessage(m message) {
 	}
 }
 
-func (c syncClient) PublishEvent(ctx *context, event common.MapStr) bool {
-	return c(message{context: *ctx, event: event})
+func (c syncClient) PublishEvent(ctx context, event common.MapStr) bool {
+	return c(message{context: ctx, event: event})
 }
 
-func (c syncClient) PublishEvents(ctx *context, events []common.MapStr) bool {
-	return c(message{context: *ctx, events: events})
+func (c syncClient) PublishEvents(ctx context, events []common.MapStr) bool {
+	return c(message{context: ctx, events: events})
 }
 
 func (p *syncPublisher) forward(m message) bool {

--- a/packetbeat/CHANGELOG.md
+++ b/packetbeat/CHANGELOG.md
@@ -16,6 +16,9 @@ All notable changes to this project will be documented in this file based on the
 ### Added
 - Added piping support to redis protocol. #402
 
+### Improvements
+- Improve redis parser performance. #442
+
 ### Deprecated
 
 ## [1.0.0](https://github.com/elastic/packetbeat/compare/1.0.0-rc2...1.0.0) 2015-11-24

--- a/packetbeat/protos/redis/redis_parse.go
+++ b/packetbeat/protos/redis/redis_parse.go
@@ -1,8 +1,6 @@
 package redis
 
 import (
-	"strconv"
-	"strings"
 	"time"
 
 	"github.com/elastic/beats/libbeat/common"
@@ -25,10 +23,10 @@ type redisMessage struct {
 
 	IsRequest bool
 	IsError   bool
-	Message   string
-	Method    string
-	Path      string
 	Size      int
+	Message   common.NetString
+	Method    common.NetString
+	Path      common.NetString
 
 	next *redisMessage
 }
@@ -37,6 +35,12 @@ const (
 	START = iota
 	BULK_ARRAY
 	SIMPLE_MESSAGE
+)
+
+var (
+	empty    = common.NetString("")
+	emptyArr = common.NetString("[]")
+	nilStr   = common.NetString("nil")
 )
 
 // Keep sorted for future command addition
@@ -201,8 +205,40 @@ var redisCommands = map[string]struct{}{
 	"ZUNIONSTORE":      {},
 }
 
-func isRedisCommand(key string) bool {
-	_, exists := redisCommands[strings.ToUpper(key)]
+var maxCommandLen = 0
+
+const commandLenBuffer = 50
+
+func init() {
+	for k := range redisCommands {
+		l := len(k)
+		if l > maxCommandLen {
+			maxCommandLen = l
+		}
+	}
+
+	// panic normally triggered during testing to give a note about small buffer sizes
+	if maxCommandLen > commandLenBuffer {
+		panic("commandLenBuffer small")
+	}
+}
+
+func isRedisCommand(key common.NetString) bool {
+	if len(key) > maxCommandLen {
+		return false
+	}
+
+	// key to upper into pre-allocated buffer (commands use ASCII only)
+	var buf [commandLenBuffer]byte
+	upper := buf[:len(key)]
+	for i, b := range key {
+		if 'a' <= b && b <= 'z' {
+			b = b - 'a' + 'A'
+		}
+		upper[i] = b
+	}
+
+	_, exists := redisCommands[string(upper)]
 	return exists
 }
 
@@ -229,12 +265,12 @@ func (parser *parser) parse(buf *streambuf.Buffer) (bool, bool) {
 	return true, true
 }
 
-func (p *parser) dispatch(depth int, buf *streambuf.Buffer) (string, bool, bool, bool) {
+func (p *parser) dispatch(depth int, buf *streambuf.Buffer) (common.NetString, bool, bool, bool) {
 	if buf.Len() == 0 {
-		return "", false, true, false
+		return empty, false, true, false
 	}
 
-	var value string
+	var value common.NetString
 	var iserror, ok, complete bool
 	snapshot := buf.Snapshot()
 
@@ -252,7 +288,7 @@ func (p *parser) dispatch(depth int, buf *streambuf.Buffer) (string, bool, bool,
 		value, ok, complete = p.parseSimpleString(buf)
 	default:
 		debug("Unexpected message starting with %s", buf.Bytes()[0])
-		return "", false, false, false
+		return empty, false, false, false
 	}
 
 	if !ok || !complete {
@@ -261,100 +297,108 @@ func (p *parser) dispatch(depth int, buf *streambuf.Buffer) (string, bool, bool,
 	return value, iserror, ok, complete
 }
 
-func (p *parser) parseInt(buf *streambuf.Buffer) (string, bool, bool) {
-	line, err := buf.UntilCRLF()
-	if err != nil {
-		return "", true, false
+func (p *parser) parseInt(buf *streambuf.Buffer) (common.NetString, bool, bool) {
+	value, ok, complete := p.parseSimpleString(buf)
+	if ok && complete {
+		if _, err := parseInt(value); err != nil {
+			logp.Err("Failed to read integer reply: %s", err)
+		}
 	}
-
-	number := string(line[1:])
-	if _, err := strconv.ParseInt(number, 10, 64); err != nil {
-		logp.Err("Failed to read integer reply: %s", err)
-	}
-
-	return number, true, true
+	return value, ok, complete
 }
 
-func (p *parser) parseSimpleString(buf *streambuf.Buffer) (string, bool, bool) {
+func (p *parser) parseSimpleString(buf *streambuf.Buffer) (common.NetString, bool, bool) {
 	line, err := buf.UntilCRLF()
 	if err != nil {
-		return "", true, false
+		return empty, true, false
 	}
 
-	return string(line[1:]), true, true
+	return common.NetString(line[1:]), true, true
 }
 
-func (p *parser) parseString(buf *streambuf.Buffer) (string, bool, bool) {
+func (p *parser) parseString(buf *streambuf.Buffer) (common.NetString, bool, bool) {
 	line, err := buf.UntilCRLF()
 	if err != nil {
-		return "", true, false
+		return empty, true, false
 	}
 
 	if len(line) == 3 && line[1] == '-' && line[2] == '1' {
-		return "nil", true, true
+		return nilStr, true, true
 	}
 
-	length, err := strconv.ParseInt(string(line[1:]), 10, 64)
+	length, err := parseInt(line[1:])
 	if err != nil {
 		logp.Err("Failed to read bulk message: %s", err)
-		return "", false, false
+		return empty, false, false
 	}
 
 	content, err := buf.CollectWithSuffix(int(length), []byte("\r\n"))
 	if err != nil {
 		if err != streambuf.ErrNoMoreBytes {
-			return "", false, false
+			return common.NetString{}, false, false
 		}
-		return "", true, false
+		return common.NetString{}, true, false
 	}
 
-	return string(content), true, true
+	return common.NetString(content), true, true
 }
 
-func (p *parser) parseArray(depth int, buf *streambuf.Buffer) (string, bool, bool, bool) {
+func (p *parser) parseArray(depth int, buf *streambuf.Buffer) (common.NetString, bool, bool, bool) {
 	line, err := buf.UntilCRLF()
 	if err != nil {
 		debug("End of line not found, waiting for more data")
-		return "", false, false, false
+		return empty, false, false, false
 	}
 	debug("line %s: %d", line, buf.BufferConsumed())
 
 	if len(line) == 3 && line[1] == '-' && line[2] == '1' {
-		return "nil", false, true, true
+		return nilStr, false, true, true
 	}
 
 	if len(line) == 2 && line[1] == '0' {
-		return "[]", false, true, true
+		return emptyArr, false, true, true
 	}
 
-	count, err := strconv.ParseInt(string(line[1:]), 10, 64)
+	count, err := parseInt(line[1:])
 	if err != nil {
 		logp.Err("Failed to read number of bulk messages: %s", err)
-		return "", false, false, false
+		return empty, false, false, false
 	}
 	if count < 0 {
-		return "nil", false, true, true
+		return nilStr, false, true, true
 	} else if count == 0 {
 		// should not happen, but handle just in case ParseInt did return 0
-		return "[]", false, true, true
+		return emptyArr, false, true, true
 	}
 
 	// invariant: count > 0
-	content := make([]string, 0, count)
+
+	// try to allocate content array right on stack
+	var content [][]byte
+	const arrayBufferSize = 32
+	if int(count) <= arrayBufferSize {
+		var arrayBuffer [arrayBufferSize][]byte
+		content = arrayBuffer[:0]
+	} else {
+		content = make([][]byte, 0, count)
+	}
+
+	contentLen := 0
 	// read sub elements
 
 	iserror := false
 	for i := 0; i < int(count); i++ {
-		var value string
+		var value common.NetString
 		var ok, complete bool
 
 		value, iserror, ok, complete := p.dispatch(depth+1, buf)
 		if !ok || !complete {
 			debug("Array incomplete")
-			return "", iserror, ok, complete
+			return empty, iserror, ok, complete
 		}
 
-		content = append(content, value)
+		content = append(content, []byte(value))
+		contentLen += len(value)
 	}
 
 	// handle top-level request command
@@ -365,11 +409,38 @@ func (p *parser) parseArray(depth int, buf *streambuf.Buffer) (string, bool, boo
 			p.message.Path = content[1]
 		}
 
-		value := strings.Join(content, " ")
+		var value common.NetString
+		if contentLen > 1 {
+			tmp := make([]byte, contentLen+(len(content)-1)*1)
+			join(tmp, content, []byte(" "))
+			value = common.NetString(tmp)
+		} else {
+			value = common.NetString(content[0])
+		}
 		return value, iserror, true, true
 	}
 
-	// return redis array
-	value := "[" + strings.Join(content, ", ") + "]"
+	// return redis array: [a, b, c]
+	tmp := make([]byte, 2+contentLen+(len(content)-1)*2)
+	tmp[0] = '['
+	join(tmp[1:], content, []byte(", "))
+	tmp[len(tmp)-1] = ']'
+	value := common.NetString(tmp)
 	return value, iserror, true, true
+}
+
+func parseInt(line []byte) (int64, error) {
+	buf := streambuf.NewFixed(line)
+	return buf.AsciiInt(false)
+	// TODO: is it an error if 'buf.Len() != 0 {}' ?
+}
+
+func join(to []byte, content [][]byte, sep []byte) {
+	if len(content) > 0 {
+		off := copy(to, content[0])
+		for i := 1; i < len(content); i++ {
+			off += copy(to[off:], sep)
+			off += copy(to[off:], content[i])
+		}
+	}
 }

--- a/packetbeat/protos/redis/redis_parse.go
+++ b/packetbeat/protos/redis/redis_parse.go
@@ -287,7 +287,9 @@ func (p *parser) dispatch(depth int, buf *streambuf.Buffer) (common.NetString, b
 		iserror = true
 		value, ok, complete = p.parseSimpleString(buf)
 	default:
-		debug("Unexpected message starting with %s", buf.Bytes()[0])
+		if isDebug {
+			debugf("Unexpected message starting with %s", buf.Bytes()[0])
+		}
 		return empty, false, false, false
 	}
 
@@ -346,10 +348,14 @@ func (p *parser) parseString(buf *streambuf.Buffer) (common.NetString, bool, boo
 func (p *parser) parseArray(depth int, buf *streambuf.Buffer) (common.NetString, bool, bool, bool) {
 	line, err := buf.UntilCRLF()
 	if err != nil {
-		debug("End of line not found, waiting for more data")
+		if isDebug {
+			debugf("End of line not found, waiting for more data")
+		}
 		return empty, false, false, false
 	}
-	debug("line %s: %d", line, buf.BufferConsumed())
+	if isDebug {
+		debugf("line %s: %d", line, buf.BufferConsumed())
+	}
 
 	if len(line) == 3 && line[1] == '-' && line[2] == '1' {
 		return nilStr, false, true, true
@@ -393,7 +399,9 @@ func (p *parser) parseArray(depth int, buf *streambuf.Buffer) (common.NetString,
 
 		value, iserror, ok, complete := p.dispatch(depth+1, buf)
 		if !ok || !complete {
-			debug("Array incomplete")
+			if isDebug {
+				debugf("Array incomplete")
+			}
 			return empty, iserror, ok, complete
 		}
 

--- a/packetbeat/protos/tcp/tcp.go
+++ b/packetbeat/protos/tcp/tcp.go
@@ -12,7 +12,7 @@ import (
 	"github.com/tsg/gopacket/layers"
 )
 
-const TCP_MAX_DATA_IN_STREAM = 10 * 1e6
+const TCP_MAX_DATA_IN_STREAM = 10 * (1 << 20)
 
 const (
 	TcpDirectionReverse  = 0


### PR DESCRIPTION
Did play with golang pprof tool today + redis pcap files. This PR hugely reduces number of objects allocated by redis-module itself. When replaying redis traffic only object allocations are mostly dominated by the json encoder (the output worker directly calls console outputer doing json encoding):

    (pprof) top20 -cum
    2809008 of 6861983 total (40.94%)
    Dropped 48 nodes (cum <= 34309)
    Showing top 20 nodes out of 61 (cum >= 1385433)
        flat  flat%   sum%        cum   cum%
            0     0%     0%    6860618   100%  runtime.goexit
            0     0%     0%    3767472 54.90%  github.com/elastic/beats/libbeat/publisher.(*messageWorker).run
            0     0%     0%    2834909 41.31%  github.com/elastic/beats/libbeat/publisher.(*outputWorker).onBulk
            0     0%     0%    2834909 41.31%  github.com/elastic/beats/libbeat/publisher.(*outputWorker).onMessage
        229379  3.34%  3.34%    2834909 41.31%  github.com/elastic/beats/libbeat/publisher.(*outputWorker).sendBulk
        56608  0.82%  4.17%    2605530 37.97%  encoding/json.Marshal
            0     0%  4.17%    2605530 37.97%  github.com/elastic/beats/libbeat/outputs.(*bulkOutputAdapter).BulkPublish
            0     0%  4.17%    2605530 37.97%  github.com/elastic/beats/libbeat/outputs/console.(*console).PublishEvent
            0     0%  4.17%    2578716 37.58%  encoding/json.(*encodeState).marshal
            0     0%  4.17%    2578716 37.58%  encoding/json.(*encodeState).reflectValue
            0     0%  4.17%    2578716 37.58%  encoding/json.(*mapEncoder).(encoding/json.encode)-fm
        81922  1.19%  5.36%    2578716 37.58%  encoding/json.(*mapEncoder).encode
            0     0%  5.36%    2220027 32.35%  github.com/elastic/beats/packetbeat/beat.(*Packetbeat).Run.func1
        196612  2.87%  8.23%    2220027 32.35%  github.com/elastic/beats/packetbeat/sniffer.(*SnifferSetup).Run
        71010  1.03%  9.26%    1849392 26.95%  github.com/elastic/beats/packetbeat/decoder.(*DecoderStruct).DecodePacketData
        377929  5.51% 14.77%    1774285 25.86%  github.com/elastic/beats/packetbeat/protos/tcp.(*Tcp).Process
    1458197 21.25% 36.02%    1458197 21.25%  reflect.unsafe_New
            0     0% 36.02%    1396356 20.35%  github.com/elastic/beats/packetbeat/protos/redis.(*Redis).Parse
            0     0% 36.02%    1396356 20.35%  github.com/elastic/beats/packetbeat/protos/tcp.(*TcpStream).addPacket
        337351  4.92% 40.94%    1385433 20.19%  github.com/elastic/beats/packetbeat/protos/redis.(*Redis).doParse
  
TODO: some benchmarking on redis module to check if allocations really make a big difference.

changes
=======

- added commandline flag '-httpprof' to start HTTP pprof endpoint for doing
  some live profiling of beat services (heap profiling, cpu profiling)

- add streambuf.AppendWithCapLimits which guarantees newly allocated
  buffers have at least configured capacity in case the buffer
  must grow when appending new content (excert more control on buffer sizing)
  => not used, as number of objects allocated was minor in contrast to
     other object types. Plus bad policy can increase overal memory usage
     dramatically due to pointers back into original slice

- add common.NetString basically being []byte. Difference to []byte is, this
  type implements the encoding.TextMarhsaller interface. NetString objects
  will be handled by JSON encoder like normal strings, thusly no allocation
  and copy is required when extracting strings from parsed messages.
  NetString being []byte will directly point into original message buffer.

  NetString also provides UnsafeString to cast a NetString into a string
  without allocation + copy

  => Using NetString over string reduce allocations + copy operations +
     less object to be GCed

- remove some unwanted allocation in async publisher client

- redis 'optimizations':
  - replace all string types with common.NetString to reduce allocations
  - pre-allocate command buffer holding command + 4 arguments by default
  - remove some more allocations + copies by 'low-level code'
  - remove transaction object type (not required anymore due to correlation
    supporting piping), but generate event type directly from correlated
    messages => reduces allocation once more + removes computation of unused
    fields