### PR TITLE
Fix coverage aggregation script

### DIFF
--- a/libbeat/scripts/aggregate_coverage.py
+++ b/libbeat/scripts/aggregate_coverage.py
@@ -27,10 +27,11 @@ def main(arguments):
     # Write to output.
     args.outfile.write('mode: atomic\n')
     for m in matches:
-        with open(m) as f:
-            for line in f:
-                if not line.startswith('mode:'):
-                    args.outfile.write(line)
+        if os.path.abspath(args.outfile.name) != os.path.abspath(m):
+            with open(m) as f:
+                for line in f:
+                    if not line.startswith('mode:'):
+                        args.outfile.write(line)
 
 if __name__ == '__main__':
     sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
Fix a possible bug with coverage aggregation when the output file is
globbed and becomes an input resulting in a loop that fills the disk.