### PR TITLE
Make clean with force, ignore nonexistent

### DIFF
--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -49,8 +49,8 @@ check:
 clean:
 	go fmt ./...
 	gofmt -w .
-	-rm -r build
-	-rm ${BEATNAME} ${BEATNAME}.test
+	-rm -rf build
+	-rm -f ${BEATNAME} ${BEATNAME}.test
 
 # Shortcut for continuous integration
 # This should always run before merging.


### PR DESCRIPTION
This patch allows `make clean` to be reentrant.