### PR TITLE
http parser performance

### DIFF
--- a/libbeat/publisher/preprocess.go
+++ b/libbeat/publisher/preprocess.go
@@ -170,8 +170,8 @@ func updateEventAddresses(publisher *PublisherType, event common.MapStr) bool {
 
 	if publisher.GeoLite != nil {
 		realIP, exists := event["real_ip"]
-		if exists && len(realIP.(string)) > 0 {
-			loc := publisher.GeoLite.GetLocationByIP(realIP.(string))
+		if exists && len(realIP.(common.NetString)) > 0 {
+			loc := publisher.GeoLite.GetLocationByIP(string(realIP.(common.NetString)))
 			if loc != nil && loc.Latitude != 0 && loc.Longitude != 0 {
 				loc := fmt.Sprintf("%f, %f", loc.Latitude, loc.Longitude)
 				event["client_location"] = loc

--- a/packetbeat/protos/http/http_test.go
+++ b/packetbeat/protos/http/http_test.go
@@ -1103,7 +1103,85 @@ func TestHttp_configsSettingHeaders(t *testing.T) {
 	}
 }
 
-func BenchmarkHttpRequestResponse(b *testing.B) {
+func benchmarkHTTPMessage(b *testing.B, data []byte) {
+	http := httpModForTests()
+	parser := newParser(&http.parserConfig)
+
+	for i := 0; i < b.N; i++ {
+		stream := &stream{data: data, message: new(message)}
+		ok, complete := parser.parse(stream)
+		if !ok || !complete {
+			b.Errorf("failed to parse message")
+		}
+	}
+}
+
+func BenchmarkHTTPSimpleResponse(b *testing.B) {
+	data := []byte("HTTP/1.1 200 OK\r\n" +
+		"Date: Tue, 14 Aug 2012 22:31:45 GMT\r\n" +
+		"Expires: -1\r\n" +
+		"Cache-Control: private, max-age=0\r\n" +
+		"Content-Type: text/html; charset=UTF-8\r\n" +
+		"Content-Encoding: gzip\r\n" +
+		"Server: gws\r\n" +
+		"Content-Length: 0\r\n" +
+		"X-XSS-Protection: 1; mode=block\r\n" +
+		"X-Frame-Options: SAMEORIGIN\r\n" +
+		"\r\n")
+
+	benchmarkHTTPMessage(b, data)
+}
+
+func BenchmarkHTTPSimpleRequest(b *testing.B) {
+	data := []byte("GET / HTTP/1.1\r\n" +
+		"Host: www.google.ro\r\n" +
+		"Connection: keep-alive\r\n" +
+		"User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_4) AppleWebKit/537.1 (KHTML, like Gecko) Chrome/21.0.1180.75 Safari/537.1\r\n" +
+		"Accept: */*\r\n" +
+		"X-Chrome-Variations: CLa1yQEIj7bJAQiftskBCKS2yQEIp7bJAQiptskBCLSDygE=\r\n" +
+		"Referer: http://www.google.ro/\r\n" +
+		"Accept-Encoding: gzip,deflate,sdch\r\n" +
+		"Accept-Language: en-US,en;q=0.8\r\n" +
+		"Accept-Charset: ISO-8859-1,utf-8;q=0.7,*;q=0.3\r\n" +
+		"Cookie: PREF=ID=6b67d166417efec4:U=69097d4080ae0e15:FF=0:TM=1340891937:LM=1340891938:S=8t97UBiUwKbESvVX; NID=61=sf10OV-t02wu5PXrc09AhGagFrhSAB2C_98ZaI53-uH4jGiVG_yz9WmE3vjEBcmJyWUogB1ZF5puyDIIiB-UIdLd4OEgPR3x1LHNyuGmEDaNbQ_XaxWQqqQ59mX1qgLQ\r\n" +
+		"\r\n" +
+		"garbage")
+
+	benchmarkHTTPMessage(b, data)
+}
+
+func BenchmarkHTTPSplitResponse(b *testing.B) {
+	data1 := []byte("HTTP/1.1 200 OK\r\n" +
+		"Date: Tue, 14 Aug 2012 22:31:45 GMT\r\n" +
+		"Expires: -1\r\n" +
+		"Cache-Control: private, max-age=0\r\n" +
+		"Content-Type: text/html; charset=UTF-8\r\n")
+	data2 := []byte("Content-Encoding: gzip\r\n" +
+		"Server: gws\r\n" +
+		"Content-Length: 0\r\n" +
+		"X-XSS-Protection: 1; mode=block\r\n" +
+		"X-Frame-Options: SAMEORIGIN\r\n" +
+		"\r\n")
+
+	http := httpModForTests()
+	parser := newParser(&http.parserConfig)
+
+	for i := 0; i < b.N; i++ {
+		stream := &stream{data: data1, message: new(message)}
+		ok, complete := parser.parse(stream)
+		if !ok || complete {
+			b.Errorf("parse failure. Expected message to be incomplete, but no parse failures")
+		}
+
+		stream.data = append(stream.data, data2...)
+		ok, complete = parser.parse(stream)
+		if !ok || !complete {
+			b.Errorf("failed to parse message")
+		}
+	}
+}
+
+func BenchmarkHttpSimpleTransaction(b *testing.B) {
 	data1 := "GET / HTTP/1.1\r\n" +
 		"Host: www.google.ro\r\n" +
 		"Connection: keep-alive\r\n" +

--- a/packetbeat/protos/http/http_test.go
+++ b/packetbeat/protos/http/http_test.go
@@ -83,7 +83,7 @@ func TestHttpParser_simpleResponse(t *testing.T) {
 	assert.True(t, complete)
 	assert.False(t, message.IsRequest)
 	assert.Equal(t, 200, int(message.StatusCode))
-	assert.Equal(t, "OK", message.StatusPhrase)
+	assert.Equal(t, "OK", string(message.StatusPhrase))
 	assert.True(t, isVersion(message.version, 1, 1))
 	assert.Equal(t, 262, int(message.Size))
 	assert.Equal(t, 0, message.ContentLength)
@@ -107,7 +107,7 @@ func TestHttpParser_simpleResponseCaseInsensitive(t *testing.T) {
 	assert.True(t, complete)
 	assert.False(t, message.IsRequest)
 	assert.Equal(t, 200, int(message.StatusCode))
-	assert.Equal(t, "OK", message.StatusPhrase)
+	assert.Equal(t, "OK", string(message.StatusPhrase))
 	assert.True(t, isVersion(message.version, 1, 1))
 	assert.Equal(t, 262, int(message.Size))
 	assert.Equal(t, 0, message.ContentLength)
@@ -139,9 +139,9 @@ func TestHttpParser_simpleRequest(t *testing.T) {
 	assert.True(t, message.IsRequest)
 	assert.True(t, isVersion(message.version, 1, 1))
 	assert.Equal(t, 669, int(message.Size))
-	assert.Equal(t, "GET", message.Method)
-	assert.Equal(t, "/", message.RequestURI)
-	assert.Equal(t, "www.google.ro", message.Headers["host"])
+	assert.Equal(t, "GET", string(message.Method))
+	assert.Equal(t, "/", string(message.RequestURI))
+	assert.Equal(t, "www.google.ro", string(message.Headers["host"]))
 }
 
 func TestHttpParser_Request_ContentLength_0(t *testing.T) {
@@ -213,7 +213,7 @@ func TestHttpParser_splitResponse_midHeaderName(t *testing.T) {
 	assert.True(t, complete)
 	assert.False(t, message.IsRequest)
 	assert.Equal(t, 200, int(message.StatusCode))
-	assert.Equal(t, "OK", message.StatusPhrase)
+	assert.Equal(t, "OK", string(message.StatusPhrase))
 	assert.True(t, isVersion(message.version, 1, 1))
 	assert.Equal(t, 262, int(message.Size))
 	assert.Equal(t, 0, message.ContentLength)
@@ -725,28 +725,18 @@ func TestHttpParser_RedactAuthorization(t *testing.T) {
 	http.hideHeaders(st.message)
 	msg := st.message.Raw
 
-	if !ok {
-		t.Errorf("Parsing returned error")
-	}
+	assert.True(t, ok)
+	assert.Equal(t, "*", string(st.message.Headers["authorization"]))
 
-	if st.message.Headers["authorization"] != "*" {
-		t.Errorf("Failed to redact authorization header: " + st.message.Headers["authorization"])
-	}
 	authPattern, _ := regexp.Compile(`(?m)^[Aa]uthorization:\*+`)
 	authObscured := authPattern.Match(msg)
-	if !authObscured {
-		t.Errorf("Obscured authorization string not found: " + string(msg[:]))
-	}
+	assert.True(t, authObscured)
 
-	if st.message.Headers["proxy-authorization"] != "*" {
-		t.Errorf("Failed to redact proxy authorization header: " + st.message.Headers["proxy-authorization"])
-	}
+	assert.Equal(t, "*", string(st.message.Headers["proxy-authorization"]))
+
 	proxyPattern, _ := regexp.Compile(`(?m)^[Pp]roxy-[Aa]uthorization:\*+`)
 	proxyObscured := proxyPattern.Match(msg)
-	if !proxyObscured {
-		t.Errorf("Obscured proxy-authorization string not found: " + string(msg[:]))
-	}
-
+	assert.True(t, proxyObscured)
 }
 
 func TestHttpParser_RedactAuthorization_raw(t *testing.T) {


### PR DESCRIPTION
requires #442 and #453 + some rebase and history updated after merging these two.

Reduce allocations in http parser.

benchmarks:

    original:
    BenchmarkHTTPSimpleResponse-4   	  100000	     15197 ns/op	    3552 B/op	     140 allocs/op
    BenchmarkHTTPSimpleRequest-4    	  100000	     17538 ns/op	    4320 B/op	     154 allocs/op
    BenchmarkHTTPSplitResponse-4    	  100000	     15665 ns/op	    3840 B/op	     141 allocs/op
    BenchmarkHttpSimpleTransaction-4	   30000	     44417 ns/op	   11039 B/op	     348 allocs/op

    optimized
    BenchmarkHTTPSimpleResponse-4   	  500000	      2837 ns/op	     560 B/op	       2 allocs/op
    BenchmarkHTTPSimpleRequest-4    	  500000	      3217 ns/op	     640 B/op	       3 allocs/op
    BenchmarkHTTPSplitResponse-4    	 1000000	      3454 ns/op	     848 B/op	       3 allocs/op
    BenchmarkHttpSimpleTransaction-4	  100000	     17065 ns/op	    4398 B/op	      58 allocs/op
