### PR TITLE
[Winlogbeat] Handle Event Log File Changed Errors

### DIFF
--- a/winlogbeat/eventlog/retry.go
+++ b/winlogbeat/eventlog/retry.go
@@ -1,0 +1,24 @@
+package eventlog
+
+// retry invokes the retriable function. If the retriable function returns an
+// error then the corrective action function is invoked and passed the error.
+// The correctiveAction function should attempt to correct the error so that
+// retriable can be invoked again.
+func retry(retriable func() error, correctiveAction func(error) error) error {
+	err := retriable()
+	if err != nil {
+		caErr := correctiveAction(err)
+		if caErr != nil {
+			// Something went wrong, return original error.
+			return err
+		}
+
+		retryErr := retriable()
+		if retryErr != nil {
+			// The second attempt failed, return original error.
+			return err
+		}
+	}
+
+	return nil
+}

--- a/winlogbeat/eventlog/syscall_windows.go
+++ b/winlogbeat/eventlog/syscall_windows.go
@@ -31,6 +31,13 @@ const (
 	EVENTLOG_BACKWARDS_READ
 )
 
+// Event Log Error Codes
+// https://msdn.microsoft.com/en-us/library/windows/desktop/ms681385(v=vs.85).aspx
+const (
+	ERROR_EVENTLOG_FILE_CORRUPT syscall.Errno = 1500
+	ERROR_EVENTLOG_FILE_CHANGED syscall.Errno = 1503
+)
+
 // Handle to a the OS specific event log.
 type Handle uintptr
 


### PR DESCRIPTION
This pull request enhances Winlogbeat to recover from [ERROR_EVENTLOG_FILE_CHANGED](https://msdn.microsoft.com/en-us/library/windows/desktop/ms681385(v=vs.85).aspx#ERROR_EVENTLOG_FILE_CHANGED) if encountered while reading. Winlogbeat will close the current handle to the event log and re-open the event log.