### PR TITLE
Adding the same .gitattributes from master to 1.0.0

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+CHANGELOG.md  merge=union
+
+# Keep these file types as CRLF (Windows).
+*.bat    text eol=crlf
+*.cmd    text eol=crlf


### PR DESCRIPTION
Fixes this issue when switching branches:

```
$ git checkout 1.0.0
error: Your local changes to the following files would be overwritten by checkout:
	winlogbeat/make.bat
Please, commit your changes or stash them before you can switch branches.
Aborting
```

This fixes an issue with the docs build which switches between branches. Clint is also going to fix the docs script to use `git checkout --force` so this doesn't happen in the future with other products/branches.