### PR TITLE
Adds doc change for beats-dashboards issue #38

### DIFF
--- a/libbeat/docs/gettingstarted.asciidoc
+++ b/libbeat/docs/gettingstarted.asciidoc
@@ -318,8 +318,9 @@ cd beats-dashboards-{Dashboards-version}/
 ----------------------------------------------------------------------
 
 NOTE: If Elasticsearch is not running on `127.0.0.1:9200`, you need to
-specify the Elasticsearch location as an argument to the `load.sh` command:
-`./load.sh http://192.168.33.60:9200`
+specify the Elasticsearch location as an argument to the `load.sh` command.
+For example: `./load.sh -url http://192.168.33.60:9200`. Use the
+`-help` option to see other available options.
 
 The load command uploads the example dashboards, visualizations, and searches
 that you can use. The load command also creates index patterns for each Beat:


### PR DESCRIPTION
Adds the -url option for load.sh command line options introduced in https://github.com/elastic/beats-dashboards/issues/38. Decided to mention the -help option rather than listing all the possibilities in the doc.