### PR TITLE
Group all cpu usage per core statistics under cpus

### DIFF
--- a/topbeat/beat/config.go
+++ b/topbeat/beat/config.go
@@ -4,9 +4,10 @@ type TopConfig struct {
 	Period *int64
 	Procs  *[]string
 	Stats  struct {
-		System     *bool
-		Proc       *bool
-		Filesystem *bool
+		System     *bool `yaml:"system"`
+		Proc       *bool `yaml:"process"`
+		Filesystem *bool `yaml:"filesystem"`
+		CpuPerCore *bool `yaml:"cpu_per_core"`
 	}
 }
 

--- a/topbeat/docs/configuration.asciidoc
+++ b/topbeat/docs/configuration.asciidoc
@@ -36,9 +36,19 @@ input:
 
   # Statistics to collect (all enabled by default)
   stats:
+    # per system statistics, by default is true
     system: true
-    proc: true
+
+    # per process statistics, by default is true
+    process: true
+
+    # file system information, by default is true
     filesystem: true
+
+    # cpu usage per core, by default is false
+    cpu_per_core: false
+
+
 ------------------------------------------------------------------------------
 
 ==== Options
@@ -58,11 +68,32 @@ default, all the running processes are monitored.
 
 The statistics to collect. You can specify the following settings:
 
-* `system: true` to capture system-wide statistics, including statistics about
+* `system` to export system-wide statistics, including statistics about
 system load, CPU usage, memory usage, and swap usage.
-* `proc: true` to capture per-process statistics, such as the process name,
+* `process` to export per-process statistics, such as the process name,
 parent pid, state, pid, CPU usage, and memory usage.
-* `filesystem: true` to capture file system statistics, including details about the
+* `filesystem` to export file system statistics, including details about the
 mounted disks, such as the total and used disk space, and details about each
 disk, such as the device name and the mounting place.
+* `cpu_per_core` to export the cpu usage per core. By default is false and it makes sense only if `system: true`. 
+The details are grouped under `cpus`. For each core of the server, few details are exported like:
+
+[source,json]
+----------------------------------------------------------------------------------
+    "cpus": {
+      "cpu0": {
+        "user": 373170,
+        "user_p": 0,
+        "nice": 0,
+        "system": 463408,
+        "system_p": 0,
+        "idle": 2904305,
+        "iowait": 0,
+        "irq": 0,
+        "softirq": 0,
+        "steal": 0
+      },
+      ...
+  }
+----------------------------------------------------------------------------------
 

--- a/topbeat/docs/fields.asciidoc
+++ b/topbeat/docs/fields.asciidoc
@@ -174,71 +174,71 @@ The amount of CPU time spent in involuntary wait by the virtual CPU while the hy
 This group contains cpu usage per core statistics.
 
 
-=== cpui Fields
+=== cpuX Fields
 
-This group contains cpu usage statistics of the core i, where i is the core number
+This group contains cpu usage statistics of the core X, where 0<X<N and N is the number of cores.
 
 
-==== cpus.cpui.user
+==== cpus.cpuX.user
 
 type: int
 
-The amount of CPU time spent in user space on core i.
+The amount of CPU time spent in user space on core X.
 
 
-==== cpus.cpui.user_p
+==== cpus.cpuX.user_p
 
 type: float
 
-The percentage of CPU time spent in user space on core i.
+The percentage of CPU time spent in user space on core X.
 
 
-==== cpus.cpui.nice
-
-type: int
-
-The amount of CPU time spent on low-priority processes on core i.
-
-
-==== cpus.cpui.system
+==== cpus.cpuX.nice
 
 type: int
 
-The amount of CPU time spent in kernel space on core i.
+The amount of CPU time spent on low-priority processes on core X.
 
 
-==== cpus.cpui.system_p
+==== cpus.cpuX.system
+
+type: int
+
+The amount of CPU time spent in kernel space on core X.
+
+
+==== cpus.cpuX.system_p
 
 type: float
 
-The percentage of CPU time spent in kernel space on core i.
+The percentage of CPU time spent in kernel space on core X.
 
 
-==== cpus.cpui.idle
-
-type: int
-
-The amount of CPU time spent idle on core i.
-
-
-==== cpus.cpui.iowait
+==== cpus.cpuX.idle
 
 type: int
 
-The amount of CPU time spent in wait (on disk) on core i.
+The amount of CPU time spent idle on core X.
 
 
-==== cpus.cpui.softirq
-
-type: int
-
-The amount of CPU time spent servicing and handling software interrupts on core i.
-
-==== cpus.cpui.steal
+==== cpus.cpuX.iowait
 
 type: int
 
-The amount of CPU time spent in involuntary wait by the virtual CPU while the hypervisor was servicing another processor on core i. Available only on Unix.
+The amount of CPU time spent in wait (on disk) on core X.
+
+
+==== cpus.cpuX.softirq
+
+type: int
+
+The amount of CPU time spent servicing and handling software interrupts on core X.
+
+==== cpus.cpuX.steal
+
+type: int
+
+The amount of CPU time spent in involuntary wait by the virtual CPU while the hypervisor was servicing another processor on core X. Available only on Unix.
 
 
 === mem Fields

--- a/topbeat/docs/fields.asciidoc
+++ b/topbeat/docs/fields.asciidoc
@@ -169,6 +169,78 @@ type: int
 The amount of CPU time spent in involuntary wait by the virtual CPU while the hypervisor was servicing another processor. Available only on Unix.
 
 
+=== cpus Fields
+
+This group contains cpu usage per core statistics.
+
+
+=== cpui Fields
+
+This group contains cpu usage statistics of the core i, where i is the core number
+
+
+==== cpus.cpui.user
+
+type: int
+
+The amount of CPU time spent in user space on core i.
+
+
+==== cpus.cpui.user_p
+
+type: float
+
+The percentage of CPU time spent in user space on core i.
+
+
+==== cpus.cpui.nice
+
+type: int
+
+The amount of CPU time spent on low-priority processes on core i.
+
+
+==== cpus.cpui.system
+
+type: int
+
+The amount of CPU time spent in kernel space on core i.
+
+
+==== cpus.cpui.system_p
+
+type: float
+
+The percentage of CPU time spent in kernel space on core i.
+
+
+==== cpus.cpui.idle
+
+type: int
+
+The amount of CPU time spent idle on core i.
+
+
+==== cpus.cpui.iowait
+
+type: int
+
+The amount of CPU time spent in wait (on disk) on core i.
+
+
+==== cpus.cpui.softirq
+
+type: int
+
+The amount of CPU time spent servicing and handling software interrupts on core i.
+
+==== cpus.cpui.steal
+
+type: int
+
+The amount of CPU time spent in involuntary wait by the virtual CPU while the hypervisor was servicing another processor on core i. Available only on Unix.
+
+
 === mem Fields
 
 This group contains statistics related to the memory usage on the system.

--- a/topbeat/etc/beat.yml
+++ b/topbeat/etc/beat.yml
@@ -11,6 +11,16 @@ input:
 
   # Statistics to collect (all enabled by default)
   stats:
+    # per system statistics, by default is true
     system: true
+
+    # per process statistics, by default is true
     proc: true
+
+    # file system information, by default is true
     filesystem: true
+
+    # cpu usage per core, by default is false
+    cpu_per_core: false
+
+

--- a/topbeat/etc/fields.yml
+++ b/topbeat/etc/fields.yml
@@ -143,6 +143,74 @@ system:
             was servicing another processor.
             Available only on Unix.
 
+    - name: cpus
+      type: group
+      description: This group contains cpu usage per core statistics.
+      fields:
+        - name: cpui
+          type: group
+          description: This group contains cpu usage statistics of the core i, where 0<i<n and n is the number of cores.
+          fields:
+
+          - name: user
+            path: cpus.cpui.user
+            type: int
+            description: >
+             The amount of CPU time spent in user space on core i.
+
+          - name: user_p
+            path: cpus.cpui.user_p
+            type: float
+            description: >
+              The percentage of CPU time spent in user space on core i.
+
+          - name: nice
+            path: cpus.cpui.nice
+            type: int
+            description: >
+              The amount of CPU time spent on low-priority processes on core i.
+
+
+          - name: system
+            path: cpus.cpui.system
+            type: int
+            description: >
+              The amount of CPU time spent in kernel space on core i.
+
+          - name: system_p
+            path: cpus.cpui.system_p
+            type: float
+            description: >
+              The percentage of CPU time spent in kernel space on core i.
+
+          - name: idle
+            path: cpus.cpui.idle
+            type: int
+            description: >
+              The amount of CPU time spent idle on core i.
+
+          - name: iowait
+            path: cpus.cpui.iowait
+            type: int
+            description: >
+              The amount of CPU time spent in wait (on disk) on core i.
+
+          - name: softirq
+            path: cpus.cpui.softirq
+            type: int
+            description:
+              The amount of CPU time spent servicing and handling software interrupts on core i.
+
+
+          - name: steal
+            path: cpus.cpui.steal
+            type: int
+            description: >
+              The amount of CPU time spent in involuntary wait by the virtual CPU while the hypervisor
+              was servicing another processor on core i.
+              Available only on Unix.
+
+
 
     - name: mem
       type: group

--- a/topbeat/etc/fields.yml
+++ b/topbeat/etc/fields.yml
@@ -147,67 +147,67 @@ system:
       type: group
       description: This group contains cpu usage per core statistics.
       fields:
-        - name: cpui
+        - name: cpuX
           type: group
-          description: This group contains cpu usage statistics of the core i, where 0<i<n and n is the number of cores.
+          description: This group contains cpu usage statistics of the core X, where 0<X<N and N is the number of cores.
           fields:
 
           - name: user
-            path: cpus.cpui.user
+            path: cpus.cpuX.user
             type: int
             description: >
-             The amount of CPU time spent in user space on core i.
+             The amount of CPU time spent in user space on core X.
 
           - name: user_p
-            path: cpus.cpui.user_p
+            path: cpus.cpuX.user_p
             type: float
             description: >
-              The percentage of CPU time spent in user space on core i.
+              The percentage of CPU time spent in user space on core X.
 
           - name: nice
-            path: cpus.cpui.nice
+            path: cpus.cpuX.nice
             type: int
             description: >
-              The amount of CPU time spent on low-priority processes on core i.
+              The amount of CPU time spent on low-priority processes on core X.
 
 
           - name: system
-            path: cpus.cpui.system
+            path: cpus.cpuX.system
             type: int
             description: >
-              The amount of CPU time spent in kernel space on core i.
+              The amount of CPU time spent in kernel space on core X.
 
           - name: system_p
-            path: cpus.cpui.system_p
+            path: cpus.cpuX.system_p
             type: float
             description: >
-              The percentage of CPU time spent in kernel space on core i.
+              The percentage of CPU time spent in kernel space on core X.
 
           - name: idle
-            path: cpus.cpui.idle
+            path: cpus.cpuX.idle
             type: int
             description: >
-              The amount of CPU time spent idle on core i.
+              The amount of CPU time spent idle on core X.
 
           - name: iowait
-            path: cpus.cpui.iowait
+            path: cpus.cpuX.iowait
             type: int
             description: >
-              The amount of CPU time spent in wait (on disk) on core i.
+              The amount of CPU time spent in wait (on disk) on core X.
 
           - name: softirq
-            path: cpus.cpui.softirq
+            path: cpus.cpuX.softirq
             type: int
             description:
-              The amount of CPU time spent servicing and handling software interrupts on core i.
+              The amount of CPU time spent servicing and handling software interrupts on core X.
 
 
           - name: steal
-            path: cpus.cpui.steal
+            path: cpus.cpuX.steal
             type: int
             description: >
               The amount of CPU time spent in involuntary wait by the virtual CPU while the hypervisor
-              was servicing another processor on core i.
+              was servicing another processor on core X.
               Available only on Unix.
 
 

--- a/topbeat/etc/topbeat.yml
+++ b/topbeat/etc/topbeat.yml
@@ -11,9 +11,19 @@ input:
 
   # Statistics to collect (all enabled by default)
   stats:
+    # per system statistics, by default is true
     system: true
+
+    # per process statistics, by default is true
     proc: true
+
+    # file system information, by default is true
     filesystem: true
+
+    # cpu usage per core, by default is false
+    cpu_per_core: false
+
+
 ###############################################################################
 ############################# Libbeat Config ##################################
 # Base config file used by all other beats for using libbeat features

--- a/topbeat/output.json
+++ b/topbeat/output.json
@@ -1,0 +1,209 @@
+type: system 
+
+{
+  "_index": "topbeat-2015.12.10",
+  "_type": "system",
+  "_id": "AVGL4gp3-qPEyihyAYjW",
+  "_score": null,
+  "_source": {
+    "@timestamp": "2015-12-10T12:33:45.584Z",
+    "beat": {
+      "hostname": "mar",
+      "name": "mar"
+    },
+    "count": 1,
+    "cpu": {
+      "user": 1124477,
+      "user_p": 0,
+      "nice": 0,
+      "system": 937191,
+      "system_p": 0,
+      "idle": 12901569,
+      "iowait": 0,
+      "irq": 0,
+      "softirq": 0,
+      "steal": 0
+    },
+    "cpus": {
+      "cpu0": {
+        "user": 373170,
+        "user_p": 0,
+        "nice": 0,
+        "system": 463408,
+        "system_p": 0,
+        "idle": 2904305,
+        "iowait": 0,
+        "irq": 0,
+        "softirq": 0,
+        "steal": 0
+      },
+      "cpu1": {
+        "user": 183293,
+        "user_p": 0,
+        "nice": 0,
+        "system": 87867,
+        "system_p": 0,
+        "idle": 3469625,
+        "iowait": 0,
+        "irq": 0,
+        "softirq": 0,
+        "steal": 0
+      },
+      "cpu2": {
+        "user": 376911,
+        "user_p": 0,
+        "nice": 0,
+        "system": 296693,
+        "system_p": 0,
+        "idle": 3067182,
+        "iowait": 0,
+        "irq": 0,
+        "softirq": 0,
+        "steal": 0
+      },
+      "cpu3": {
+        "user": 191103,
+        "user_p": 0,
+        "nice": 0,
+        "system": 89223,
+        "system_p": 0,
+        "idle": 3460457,
+        "iowait": 0,
+        "irq": 0,
+        "softirq": 0,
+        "steal": 0
+      }
+    },
+    "load": {
+      "load1": 1.66357421875,
+      "load5": 1.81396484375,
+      "load15": 1.78466796875
+    },
+    "mem": {
+      "total": 17179869184,
+      "used": 14505914368,
+      "free": 2673954816,
+      "used_p": 0.84,
+      "actual_used": 10005078016,
+      "actual_free": 7174791168,
+      "actual_used_p": 0.58
+    },
+    "swap": {
+      "total": 0,
+      "used": 0,
+      "free": 0,
+      "used_p": 0,
+      "actual_used": 0,
+      "actual_free": 0,
+      "actual_used_p": 0
+    },
+    "type": "system"
+  },
+  "fields": {
+    "@timestamp": [
+      1449750825584
+    ]
+  },
+  "highlight": {
+    "type": [
+      "@kibana-highlighted-field@system@/kibana-highlighted-field@"
+    ]
+  },
+  "sort": [
+    1449750825584
+  ]
+}
+
+type: process
+
+
+{
+  "_index": "topbeat-2015.12.10",
+  "_type": "process",
+  "_id": "AVGL44HJ-qPEyihyAY4q",
+  "_score": null,
+  "_source": {
+    "@timestamp": "2015-12-10T12:35:20.684Z",
+    "beat": {
+      "hostname": "mar",
+      "name": "mar"
+    },
+    "count": 1,
+    "proc": {
+      "cpu": {
+        "user": 3397,
+        "user_p": 0,
+        "system": 2972,
+        "total": 6369,
+        "start_time": "17:48"
+      },
+      "mem": {
+        "size": 2532204544,
+        "rss": 3616768,
+        "rss_p": 0,
+        "share": 0
+      },
+      "name": "cfprefsd",
+      "pid": 228,
+      "ppid": 1,
+      "state": "running"
+    },
+    "type": "process"
+  },
+  "fields": {
+    "@timestamp": [
+      1449750920684
+    ]
+  },
+  "highlight": {
+    "type": [
+      "@kibana-highlighted-field@process@/kibana-highlighted-field@"
+    ]
+  },
+  "sort": [
+    1449750920684
+  ]
+}
+
+type: filesystem
+
+{
+  "_index": "topbeat-2015.12.10",
+  "_type": "filesystem",
+  "_id": "AVGL5B4F-qPEyihyAZDq",
+  "_score": null,
+  "_source": {
+    "@timestamp": "2015-12-10T12:36:00.678Z",
+    "beat": {
+      "hostname": "mar",
+      "name": "mar"
+    },
+    "count": 1,
+    "fs": {
+      "device_name": "/dev/disk1",
+      "total": 249779191808,
+      "used": 207223169024,
+      "used_p": 0.83,
+      "free": 42556022784,
+      "avail": 42293878784,
+      "files": 60981246,
+      "free_files": 10325654,
+      "mount_point": "/"
+    },
+    "type": "filesystem"
+  },
+  "fields": {
+    "@timestamp": [
+      1449750960678
+    ]
+  },
+  "highlight": {
+    "type": [
+      "@kibana-highlighted-field@filesystem@/kibana-highlighted-field@"
+    ]
+  },
+  "sort": [
+    1449750960678
+  ]
+}
+

--- a/topbeat/tests/system/config/topbeat.yml.j2
+++ b/topbeat/tests/system/config/topbeat.yml.j2
@@ -15,8 +15,9 @@ input:
   # Statistics to collect (all enabled by default)
   stats:
     system: {{ "false" if system_stats == false else "true" }}
-    proc: {{ "false" if proc_stats == false else "true" }}
+    process: {{ "false" if process_stats == false else "true" }}
     filesystem: {{ "false" if filesystem_stats == false else "true" }}
+    cpu_per_core: {{ "false" if cpu_per_core == false else "true" }}
 
 ############################# Output ##########################################
 

--- a/topbeat/tests/system/test_cpu_per_core.py
+++ b/topbeat/tests/system/test_cpu_per_core.py
@@ -1,0 +1,45 @@
+from topbeat import TestCase
+
+import os
+
+"""
+Contains tests for ide statistics.
+"""
+
+
+class Test(TestCase):
+    def test_cpu_per_core(self):
+        """
+        Checks that cpu usage per core statistics are exported
+        when the config option is enabled.
+        """
+        # the test applies only for Unix systems
+        if os.name == "nt":
+            return
+
+        self.render_config_template(
+            system_stats=True,
+            process_stats=False,
+            filesystem_stats=False,
+            cpu_per_core=True
+        )
+        topbeat = self.start_topbeat()
+        self.wait_until(lambda: self.output_has(lines=1))
+        topbeat.kill_and_wait()
+
+        output = self.read_output()[0]
+
+        for key in [
+            "cpus.cpu0.user_p",
+            "cpus.cpu0.system_p",
+            "cpus.cpu0.user",
+            "cpus.cpu0.system",
+            "cpus.cpu0.nice",
+            "cpus.cpu0.idle",
+            "cpus.cpu0.iowait",
+            "cpus.cpu0.irq",
+            "cpus.cpu0.softirq",
+            "cpus.cpu0.steal",
+
+        ]:
+            assert type(output[key]) in [int, float]

--- a/topbeat/tests/system/test_filesystem.py
+++ b/topbeat/tests/system/test_filesystem.py
@@ -14,7 +14,7 @@ class Test(TestCase):
         """
         self.render_config_template(
             system_stats=False,
-            proc_stats=False,
+            process_stats=False,
             filesystem_stats=True
         )
         topbeat = self.start_topbeat()

--- a/topbeat/tests/system/test_procs.py
+++ b/topbeat/tests/system/test_procs.py
@@ -15,7 +15,7 @@ class Test(TestCase):
         """
         self.render_config_template(
             system_stats=False,
-            proc_stats=True,
+            process_stats=True,
             filesystem_stats=False,
             proc_patterns=["topbeat.test"]  # monitor itself
         )

--- a/topbeat/tests/system/test_system.py
+++ b/topbeat/tests/system/test_system.py
@@ -15,7 +15,7 @@ class Test(TestCase):
         """
         self.render_config_template(
             system_stats=True,
-            proc_stats=False,
+            process_stats=False,
             filesystem_stats=False
         )
         topbeat = self.start_topbeat()


### PR DESCRIPTION
The goal of this PR is to group all the cpu usage per core statistics under `cpus` and add a configuration option `cpu_per_core` to enable it. By default it is set to false as it exports a lot of data. 

The number of fields that are exports depends on the number of cores, so for these data we are not providing sample dashboards as it depends on the number of cores.

This is the first change out of multiple changes requested by #424.
