### PR TITLE
Filebeat: Support array and dictionary fields

### DIFF
--- a/filebeat/config/config.go
+++ b/filebeat/config/config.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/elastic/beats/libbeat/cfgfile"
+	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 )
 
@@ -52,7 +53,7 @@ type ProspectorConfig struct {
 
 type HarvesterConfig struct {
 	InputType          string `yaml:"input_type"`
-	Fields             map[string]string
+	Fields             common.MapStr
 	FieldsUnderRoot    bool   `yaml:"fields_under_root"`
 	BufferSize         int    `yaml:"harvester_buffer_size"`
 	TailFiles          bool   `yaml:"tail_files"`

--- a/filebeat/config/config_test.go
+++ b/filebeat/config/config_test.go
@@ -33,7 +33,7 @@ func TestReadConfig(t *testing.T) {
 	assert.Equal(t, "/var/log/s*.log", prospectors[0].Paths[1])
 	assert.Equal(t, "log", prospectors[0].Input)
 	assert.Equal(t, 3, len(prospectors[0].Harvester.Fields))
-	assert.Equal(t, 1, len(prospectors[0].Harvester.Fields["review"]))
+	assert.Equal(t, "1", prospectors[0].Harvester.Fields["review"])
 	assert.Equal(t, "24h", prospectors[0].IgnoreOlder)
 	assert.Equal(t, "10s", prospectors[0].ScanFrequency)
 

--- a/filebeat/docs/configuration.asciidoc
+++ b/filebeat/docs/configuration.asciidoc
@@ -99,7 +99,8 @@ If both `include_lines` and `exclude_lines` are defined, then include_lines is c
 ===== fields
 
 Optional fields that you can specify to add additional information to the output. For
-example, you might add fields that you can use for filtering log data. By default,
+example, you might add fields that you can use for filtering log data. Fields can be
+scalar values, arrays, dictionaries, or any nested combination of these. All scalar values will be interpreted as strings. By default,
 the fields that you specify here will be grouped under a `fields` sub-dictionary in the output document. To store the custom fields as top-level fields, set the `fields_under_root` option to true.
 
 [source,yaml]

--- a/filebeat/input/file.go
+++ b/filebeat/input/file.go
@@ -24,7 +24,7 @@ type FileEvent struct {
 	Offset       int64
 	Bytes        int
 	Text         *string
-	Fields       *map[string]string
+	Fields       *common.MapStr
 	Fileinfo     *os.FileInfo
 
 	fieldsUnderRoot bool

--- a/filebeat/input/file_test.go
+++ b/filebeat/input/file_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/elastic/beats/libbeat/common"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -114,7 +115,7 @@ func TestFileEventToMapStr(t *testing.T) {
 
 func TestFieldsUnderRoot(t *testing.T) {
 	event := FileEvent{
-		Fields: &map[string]string{
+		Fields: &common.MapStr{
 			"hello": "world",
 		},
 	}


### PR DESCRIPTION
The fields parameter in the prospector configuration was previously of the type map[string]string and therefore only supported string fields. This has been changed to MapStr (i.e. map[string]interface{}) since that's what libbeat sends over the wire anyway, hence Filebeat now supports not only strings but any kind of arrays or dictionaries you can have in a YAML file.

The relevant unit tests pass but I haven't been able to run the integration tests since my kernel doesn't support aufs so I can't run Docker without extra work.

Fixes https://github.com/elastic/filebeat/issues/69