### PR TITLE
Elasticsearch output bulk response parsing

### DIFF
--- a/libbeat/common/streambuf/ascii.go
+++ b/libbeat/common/streambuf/ascii.go
@@ -63,6 +63,30 @@ func (b *Buffer) IgnoreSymbol(s uint8) error {
 	return b.bufferEndError()
 }
 
+// IgnoreSymbols will advance the read pointer until the first symbol not matching
+// set of symbols is found
+func (b *Buffer) IgnoreSymbols(syms []byte) error {
+	if b.err != nil {
+		return b.err
+	}
+
+	data := b.data[b.offset:]
+	for i, byte := range data {
+		for _, other := range syms {
+			if byte == other {
+				goto next
+			}
+		}
+		// no match
+		b.Advance(b.offset + i - b.mark)
+		return nil
+
+	next:
+	}
+	b.offset += len(data)
+	return b.bufferEndError()
+}
+
 // UntilSymbol collects all bytes until symbol s is found. If errOnEnd is set to
 // true, the collected byte slice will be returned if no more bytes are available
 // for parsing, but s has not matched yet.

--- a/libbeat/common/streambuf/streambuf.go
+++ b/libbeat/common/streambuf/streambuf.go
@@ -386,11 +386,25 @@ func (b *Buffer) IndexByte(byte byte) int {
 		return -1
 	}
 
-	idx := bytes.IndexByte(b.data[b.mark:], byte)
+	idx := bytes.IndexByte(b.data[b.offset:], byte)
 	if idx < 0 {
 		return -1
 	}
-	return idx + b.mark
+	return idx + (b.offset - b.mark)
+}
+
+// IndexByteFrom returns offset of byte in unpressed buffer starting at off.
+// Returns -1 if byte not in buffer
+func (b *Buffer) IndexByteFrom(off int, byte byte) int {
+	if b.err != nil {
+		return -1
+	}
+
+	idx := bytes.IndexByte(b.data[b.offset+off:], byte)
+	if idx < 0 {
+		return -1
+	}
+	return idx + (b.offset - b.mark) + off
 }
 
 // CollectUntil collects all bytes until delim was found (including delim).
@@ -426,4 +440,40 @@ func (b *Buffer) CollectUntilByte(delim byte) ([]byte, error) {
 	data := b.data[b.mark:end]
 	b.Advance(len(data))
 	return data, nil
+}
+
+// CollectWhile collects all bytes until predicate returns false
+func (b *Buffer) CollectWhile(pred func(byte) bool) ([]byte, error) {
+	if b.err != nil {
+		return nil, b.err
+	}
+
+	data := b.data[b.offset:]
+	for i, byte := range data {
+		if !pred(byte) {
+			end := b.offset + i + 1
+			data := b.data[b.mark:end]
+			b.Advance(len(data))
+			return data, nil
+		}
+	}
+
+	b.offset = b.mark + b.available
+	return nil, b.bufferEndError()
+}
+
+func (b *Buffer) PeekByte() (byte, error) {
+	return b.PeekByteFrom(0)
+}
+
+func (b *Buffer) PeekByteFrom(off int) (byte, error) {
+	if b.err != nil {
+		return 0, b.err
+	}
+
+	if !b.Avail(off + 1) {
+		return 0, b.bufferEndError()
+	}
+
+	return b.data[b.mark+off], nil
 }

--- a/libbeat/common/streambuf/streambuf.go
+++ b/libbeat/common/streambuf/streambuf.go
@@ -65,8 +65,11 @@ type Buffer struct {
 // buffer. Usage of Init is optional as zero value Buffer is already in valid state.
 func (b *Buffer) Init(d []byte, fixed bool) {
 	b.data = d
-	b.available = len(d)
+	b.err = nil
 	b.fixed = fixed
+	b.mark = 0
+	b.offset = 0
+	b.available = len(d)
 }
 
 // New creates new extensible buffer from data slice being retained by the buffer.

--- a/libbeat/outputs/elasticsearch/bulkapi.go
+++ b/libbeat/outputs/elasticsearch/bulkapi.go
@@ -162,9 +162,5 @@ func bulkEncode(metaBuilder MetaBuilder, body []interface{}) bytes.Buffer {
 }
 
 func readBulkResult(obj []byte) (BulkResult, error) {
-	if obj == nil {
-		return BulkResult{}, nil
-	}
-
 	return BulkResult{obj}, nil
 }

--- a/libbeat/outputs/elasticsearch/client_test.go
+++ b/libbeat/outputs/elasticsearch/client_test.go
@@ -2,14 +2,21 @@ package elasticsearch
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
+	"github.com/elastic/beats/libbeat/common"
 	"github.com/stretchr/testify/assert"
 )
 
+func readStatusItem(in []byte) (int, string, error) {
+	code, msg, err := itemStatus(in)
+	return code, string(msg), err
+}
+
 func TestESNoErrorStatus(t *testing.T) {
-	response := json.RawMessage(`{"create": {"status": 200}}`)
-	code, msg, err := itemStatus(response)
+	response := []byte(`{"create": {"status": 200}}`)
+	code, msg, err := readStatusItem(response)
 
 	assert.Nil(t, err)
 	assert.Equal(t, 200, code)
@@ -18,7 +25,7 @@ func TestESNoErrorStatus(t *testing.T) {
 
 func TestES1StyleErrorStatus(t *testing.T) {
 	response := json.RawMessage(`{"create": {"status": 400, "error": "test error"}}`)
-	code, msg, err := itemStatus(response)
+	code, msg, err := readStatusItem(response)
 
 	assert.Nil(t, err)
 	assert.Equal(t, 400, code)
@@ -27,9 +34,132 @@ func TestES1StyleErrorStatus(t *testing.T) {
 
 func TestES2StyleErrorStatus(t *testing.T) {
 	response := json.RawMessage(`{"create": {"status": 400, "error": {"reason": "test_error"}}}`)
-	code, msg, err := itemStatus(response)
+	code, msg, err := readStatusItem(response)
 
 	assert.Nil(t, err)
 	assert.Equal(t, 400, code)
 	assert.Equal(t, `{"reason": "test_error"}`, msg)
+}
+
+func TestCollectPublishFailsNone(t *testing.T) {
+	N := 100
+	item := `{"create": {"status": 200}},`
+	items := strings.Repeat(item, N)
+	response := []byte(`{"items": [` + items[:len(items)-1] + `]}`)
+
+	event := common.MapStr{"field": 1}
+	events := make([]common.MapStr, N)
+	for i := 0; i < N; i++ {
+		events[i] = event
+	}
+
+	bs, _ := readBulkResult(response)
+	res := bulkCollectPublishFails(bs, events)
+	assert.Equal(t, 0, len(res))
+}
+
+func TestCollectPublishFailMiddle(t *testing.T) {
+	response := []byte(`
+    { "items": [
+      {"create": {"status": 200}},
+      {"create": {"status": 429, "error": "ups"}},
+      {"create": {"status": 200}}
+    ]}
+  `)
+
+	event := common.MapStr{"field": 1}
+	eventFail := common.MapStr{"field": 2}
+	events := []common.MapStr{event, eventFail, event}
+
+	bs, _ := readBulkResult(response)
+	res := bulkCollectPublishFails(bs, events)
+	assert.Equal(t, 1, len(res))
+	if len(res) == 1 {
+		assert.Equal(t, eventFail, res[0])
+	}
+}
+
+func TestCollectPublishFailAll(t *testing.T) {
+	response := []byte(`
+    { "items": [
+      {"create": {"status": 429, "error": "ups"}},
+      {"create": {"status": 429, "error": "ups"}},
+      {"create": {"status": 429, "error": "ups"}}
+    ]}
+  `)
+
+	event := common.MapStr{"field": 2}
+	events := []common.MapStr{event, event, event}
+
+	bs, _ := readBulkResult(response)
+	res := bulkCollectPublishFails(bs, events)
+	assert.Equal(t, 3, len(res))
+	assert.Equal(t, events, res)
+}
+
+func BenchmarkCollectPublishFailsNone(b *testing.B) {
+	response := []byte(`
+    { "items": [
+      {"create": {"status": 200}},
+      {"create": {"status": 200}},
+      {"create": {"status": 200}}
+    ]}
+  `)
+
+	event := common.MapStr{"field": 1}
+	events := []common.MapStr{event, event, event}
+	bs, err := readBulkResult(response)
+	if err != nil {
+		b.Fatalf("test setup failed with: %v", err)
+	}
+
+	for i := 0; i < b.N; i++ {
+		res := bulkCollectPublishFails(bs, events)
+		if len(res) != 0 {
+			b.Fail()
+		}
+	}
+}
+
+func BenchmarkCollectPublishFailMiddle(b *testing.B) {
+	response := []byte(`
+    { "items": [
+      {"create": {"status": 200}},
+      {"create": {"status": 429, "error": "ups"}},
+      {"create": {"status": 200}}
+    ]}
+  `)
+
+	event := common.MapStr{"field": 1}
+	eventFail := common.MapStr{"field": 2}
+	events := []common.MapStr{event, eventFail, event}
+	bs, _ := readBulkResult(response)
+
+	for i := 0; i < b.N; i++ {
+		res := bulkCollectPublishFails(bs, events)
+		if len(res) != 1 {
+			b.Fail()
+		}
+	}
+}
+
+func BenchmarkCollectPublishFailAll(b *testing.B) {
+	response := []byte(`
+    { "items": [
+      {"creatMiddlee": {"status": 429, "error": "ups"}},
+      {"creatMiddlee": {"status": 429, "error": "ups"}},
+      {"creatMiddlee": {"status": 429, "error": "ups"}}
+    ]}
+  `)
+
+	event := common.MapStr{"field": 2}
+	events := []common.MapStr{event, event, event}
+	bs, _ := readBulkResult(response)
+
+	for i := 0; i < b.N; i++ {
+		res := bulkCollectPublishFails(bs, events)
+		if len(res) != 3 {
+			b.Fail()
+		}
+	}
 }

--- a/libbeat/outputs/elasticsearch/client_test.go
+++ b/libbeat/outputs/elasticsearch/client_test.go
@@ -41,6 +41,24 @@ func TestES2StyleErrorStatus(t *testing.T) {
 	assert.Equal(t, `{"reason": "test_error"}`, msg)
 }
 
+func TestES2StyleExtendedErrorStatus(t *testing.T) {
+	response := []byte(`
+    {
+      "create": {
+        "status": 400,
+        "error": {
+          "reason": "test_error",
+          "transient": false,
+          "extra": null
+        }
+      }
+    }`)
+	code, _, err := readStatusItem(response)
+
+	assert.Nil(t, err)
+	assert.Equal(t, 400, code)
+}
+
 func TestCollectPublishFailsNone(t *testing.T) {
 	N := 100
 	item := `{"create": {"status": 200}},`
@@ -108,10 +126,9 @@ func BenchmarkCollectPublishFailsNone(b *testing.B) {
 	event := common.MapStr{"field": 1}
 	events := []common.MapStr{event, event, event}
 
-	reader := newJSONReader(response)
-	snapshot := reader.Snapshot()
+	reader := newJSONReader(nil)
 	for i := 0; i < b.N; i++ {
-		reader.Restore(snapshot)
+		reader.init(response)
 		res := bulkCollectPublishFails(reader, events)
 		if len(res) != 0 {
 			b.Fail()
@@ -132,10 +149,9 @@ func BenchmarkCollectPublishFailMiddle(b *testing.B) {
 	eventFail := common.MapStr{"field": 2}
 	events := []common.MapStr{event, eventFail, event}
 
-	reader := newJSONReader(response)
-	snapshot := reader.Snapshot()
+	reader := newJSONReader(nil)
 	for i := 0; i < b.N; i++ {
-		reader.Restore(snapshot)
+		reader.init(response)
 		res := bulkCollectPublishFails(reader, events)
 		if len(res) != 1 {
 			b.Fail()
@@ -155,10 +171,9 @@ func BenchmarkCollectPublishFailAll(b *testing.B) {
 	event := common.MapStr{"field": 2}
 	events := []common.MapStr{event, event, event}
 
-	reader := newJSONReader(response)
-	snapshot := reader.Snapshot()
+	reader := newJSONReader(nil)
 	for i := 0; i < b.N; i++ {
-		reader.Restore(snapshot)
+		reader.init(response)
 		res := bulkCollectPublishFails(reader, events)
 		if len(res) != 3 {
 			b.Fail()

--- a/libbeat/outputs/elasticsearch/json_read.go
+++ b/libbeat/outputs/elasticsearch/json_read.go
@@ -78,22 +78,19 @@ const (
 	dictFieldStateEnd
 )
 
+var stateNames = map[state]string{
+	failedState:       "failed",
+	startState:        "start",
+	arrState:          "array",
+	arrStateNext:      "arrayNext",
+	dictState:         "dict",
+	dictFieldState:    "dictValue",
+	dictFieldStateEnd: "dictNext",
+}
+
 func (s state) String() string {
-	switch s {
-	case failedState:
-		return "failed"
-	case startState:
-		return "start"
-	case arrState:
-		return "array"
-	case arrStateNext:
-		return "arrayNext"
-	case dictState:
-		return "dict"
-	case dictFieldState:
-		return "dictValue"
-	case dictFieldStateEnd:
-		return "dictNext"
+	if name, ok := stateNames[s]; ok {
+		return name
 	}
 	return "unknown"
 }

--- a/libbeat/outputs/elasticsearch/json_read.go
+++ b/libbeat/outputs/elasticsearch/json_read.go
@@ -1,0 +1,358 @@
+package elasticsearch
+
+import (
+	"errors"
+
+	"github.com/elastic/beats/libbeat/common/streambuf"
+)
+
+// SAX like json parser. But instead of relying on callbacks, state machine
+// returns raw item plus entity. On top of state machine additional helper methods
+// like expectDict, expectArray, nextFieldName and nextInt are available for
+// low-level parsing/stepping through a json document.
+//
+// Due to parser simply stepping through the input buffer, almost no additional
+// allocations are required.
+type jsonReader struct {
+	streambuf.Buffer
+
+	// parser state machine
+	states       []entity // state stack for nested arrays/objects
+	currentState entity
+
+	// preallocate stack memory for up to 32 nested arrays/objects
+	statesBuf [32]entity
+}
+
+type entity uint8
+
+var (
+	errUnknownChar         = errors.New("unknown character")
+	errQuoteMissing        = errors.New("missing closing quote")
+	errExpectColon         = errors.New("expected ':' after map key")
+	errExpectStringKey     = errors.New("expected string key")
+	errUnexpectedComma     = errors.New("unexpected ','")
+	errUnexpectedDictClose = errors.New("unexpected '}'")
+	errUnexpectedArrClose  = errors.New("unexpected ']'")
+	errExpectedDigit       = errors.New("expected a digit")
+	errExpectedObject      = errors.New("expected JSON object")
+	errExpectedArray       = errors.New("expected JSON array")
+	errExpectedFieldName   = errors.New("expected JSON object field name")
+	errExpectedInteger     = errors.New("expected integer value")
+)
+
+const (
+	unknownState entity = iota
+	dictStart
+	dictEnd
+	dictField
+	arrStart
+	arrEnd
+	stringEntity
+	mapKeyEntity
+	intEntity
+	doubleEntity
+)
+
+func newJSONReader(in []byte) *jsonReader {
+	r := &jsonReader{}
+	r.init(in)
+	return r
+}
+
+func (r *jsonReader) init(in []byte) {
+	r.Buffer.Init(in, true)
+	r.currentState = unknownState
+	r.states = r.statesBuf[:0]
+}
+
+var whitespace = []byte(" \t\r\n")
+
+func (r *jsonReader) skipWS() {
+	r.IgnoreSymbols(whitespace)
+}
+
+func (r *jsonReader) pushState(next entity) {
+	if r.currentState != unknownState {
+		r.states = append(r.states, r.currentState)
+	}
+	r.currentState = next
+}
+
+func (r *jsonReader) popState() {
+	if len(r.states) == 0 {
+		r.currentState = unknownState
+	} else {
+		last := len(r.states) - 1
+		r.currentState = r.states[last]
+		r.states = r.states[:last]
+	}
+}
+
+func (r *jsonReader) expectDict() error {
+	entity, _, err := r.step()
+	if err != nil {
+		return err
+	}
+
+	if entity != dictStart {
+		return r.SetError(errExpectedObject)
+	}
+
+	return nil
+}
+
+func (r *jsonReader) expectArray() error {
+	entity, _, err := r.step()
+	if err != nil {
+		return err
+	}
+
+	if entity != arrStart {
+		return r.SetError(errExpectedArray)
+	}
+
+	return nil
+}
+
+func (r *jsonReader) nextFieldName() (entity, []byte, error) {
+	entity, raw, err := r.step()
+	if err != nil {
+		return entity, raw, err
+	}
+
+	if entity != mapKeyEntity && entity != dictEnd {
+		return entity, nil, r.SetError(errExpectedFieldName)
+	}
+
+	return entity, raw, err
+}
+
+func (r *jsonReader) nextInt() (int, error) {
+	entity, raw, err := r.step()
+	if err != nil {
+		return 0, err
+	}
+
+	if entity != intEntity {
+		return 0, errExpectedInteger
+	}
+
+	tmp := streambuf.NewFixed(raw)
+	i, err := tmp.AsciiInt(false)
+	return int(i), err
+}
+
+// ignore type of next element and return raw content.
+func (r *jsonReader) ignoreNext() (raw []byte, err error) {
+	r.skipWS()
+
+	snapshot := r.Snapshot()
+	before := r.Len()
+
+	var ignoreKind func(*jsonReader, entity) error
+	ignoreKind = func(r *jsonReader, kind entity) error {
+
+		for {
+			entity, _, err := r.step()
+			if err != nil {
+				return err
+			}
+
+			switch entity {
+			case kind:
+				return nil
+			case arrStart:
+				return ignoreKind(r, arrEnd)
+			case dictStart:
+				return ignoreKind(r, dictEnd)
+			}
+		}
+	}
+
+	entity, _, err := r.step()
+	if err != nil {
+		return nil, err
+	}
+
+	switch entity {
+	case dictStart:
+		err = ignoreKind(r, dictEnd)
+	case arrStart:
+		err = ignoreKind(r, arrEnd)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	after := r.Len()
+	r.Restore(snapshot)
+
+	bytes, _ := r.Collect(before - after)
+	return bytes, nil
+}
+
+// step continues the JSON parser state machine until next entity has been parsed.
+func (r *jsonReader) step() (entity, []byte, error) {
+	for r.Len() > 0 {
+		r.skipWS()
+
+		c, _ := r.PeekByte()
+		if r.currentState == dictStart && c != '"' {
+			return unknownState, nil, r.SetError(errExpectStringKey)
+		}
+
+		switch c {
+		case '{': // start dictionary
+			r.Advance(1)
+			r.pushState(dictStart)
+			return dictStart, nil, nil
+		case '}': // end dictionary
+			// validate dictionary end (+ allow for trailing comma)
+			if r.currentState != dictStart && r.currentState != dictField {
+				return unknownState, nil, r.SetError(errUnexpectedDictClose)
+			}
+
+			r.Advance(1)
+			r.popState()
+			return dictEnd, nil, nil
+		case '[': // start array
+			r.Advance(1)
+			r.pushState(arrStart)
+			return arrStart, nil, nil
+		case ']': // end array
+			// validate array end (+ allow for trailing comma)
+			if r.currentState != arrStart {
+				return unknownState, nil, r.SetError(errUnexpectedArrClose)
+			}
+
+			r.Advance(1)
+			r.popState()
+			return arrEnd, nil, nil
+		case ',':
+			if r.currentState != arrStart && r.currentState != dictField {
+				return unknownState, nil, r.SetError(errUnexpectedComma)
+			}
+
+			// next dictionary/array entry
+			if r.currentState == dictField {
+				r.currentState = dictStart
+			}
+			r.Advance(1)
+		case '"':
+			if r.currentState == dictStart {
+				r.currentState = dictField
+				return r.stepMapKey()
+			}
+			return r.stepString()
+		default:
+			// parse number?
+			if c == '-' || c == '+' || c == '.' || ('0' <= c && c <= '9') {
+				return r.stepNumber()
+			}
+
+			err := r.Err()
+			if err == nil {
+				err = errUnknownChar
+				r.SetError(err)
+			}
+			return unknownState, nil, err
+		}
+	}
+
+	return unknownState, nil, r.Err()
+}
+
+func (r *jsonReader) stepMapKey() (entity, []byte, error) {
+	entity, key, err := r.stepString()
+	if err != nil {
+		return entity, key, err
+	}
+
+	r.skipWS()
+	c, err := r.ReadByte()
+	if err != nil {
+		return unknownState, nil, err
+	}
+
+	if c != ':' {
+		return unknownState, nil, r.SetError(errExpectColon)
+	}
+
+	return mapKeyEntity, key, r.Err()
+}
+
+func (r *jsonReader) stepString() (entity, []byte, error) {
+	start := 1
+	for {
+		idxQuote := r.IndexByteFrom(start, '"')
+		if idxQuote == -1 {
+			return unknownState, nil, r.SetError(errQuoteMissing)
+		}
+
+		if b, _ := r.PeekByteFrom(idxQuote - 1); b == '\\' { // escaped quote?
+			start = idxQuote + 1
+			continue
+		}
+
+		// found string end
+		str, err := r.Collect(idxQuote + 1)
+		str = str[1 : len(str)-1]
+		return stringEntity, str, err
+	}
+}
+
+func (r *jsonReader) stepNumber() (entity, []byte, error) {
+	snapshot := r.Snapshot()
+	lenBefore := r.Len()
+	isDouble := false
+
+	if err := r.Err(); err != nil {
+		return unknownState, nil, err
+	}
+
+	// parse '+', '-' or '.'
+	if b, _ := r.PeekByte(); b == '-' || b == '+' {
+		r.Advance(1)
+	}
+	if b, _ := r.PeekByte(); b == '.' {
+		r.Advance(1)
+		isDouble = true
+	}
+
+	// parse digits
+	buf, _ := r.CollectWhile(isDigit)
+	if len(buf) == 0 {
+		return unknownState, nil, r.SetError(errExpectedDigit)
+	}
+
+	if !isDouble {
+		// parse optional '.'
+		if b, _ := r.PeekByte(); b == '.' {
+			r.Advance(1)
+			isDouble = true
+
+			// parse optional digits
+			r.CollectWhile(isDigit)
+		}
+	}
+
+	lenAfter := r.Len()
+	r.Restore(snapshot)
+	total := lenBefore - lenAfter - 1
+	if total == 0 {
+		return unknownState, nil, r.SetError(errExpectedDigit)
+	}
+
+	raw, _ := r.Collect(total)
+	state := intEntity
+	if isDouble {
+		state = doubleEntity
+	}
+
+	return state, raw, nil
+}
+
+func isDigit(c byte) bool {
+	return '0' <= c && c <= '9'
+}


### PR DESCRIPTION
Implement simple low-level JSON parser state machine for reading elasticsearch bulk response JSON. The JSON parser requires no allocations.

benchmarks

    original (json.Umarshal):
    BenchmarkCollectPublishFailsNone-4 	  200000	      6221 ns/op	    2760 B/op	      39 allocs/op
    BenchmarkCollectPublishFailMiddle-4	  200000	      7026 ns/op	    2888 B/op	      46 allocs/op
    BenchmarkCollectPublishFailAll-4   	  200000	      8602 ns/op	    3144 B/op	      60 allocs/op

    new (manual JSON document walker):
    BenchmarkCollectPublishFailsNone-4 	 1000000	      1606 ns/op	      11 B/op	       0 allocs/op
    BenchmarkCollectPublishFailMiddle-4	 1000000	      2011 ns/op	      75 B/op	       3 allocs/op
    BenchmarkCollectPublishFailAll-4   	  500000	      2810 ns/op	     203 B/op	       9 allocs/op

Reported allocations are due to the logging system for failed items being logged (Bulk requests in tests contain only 3 elements).