### PR TITLE
Added some basic instrumentation for the publisher/outputs

### DIFF
--- a/libbeat/outputs/mode/balance.go
+++ b/libbeat/outputs/mode/balance.go
@@ -117,6 +117,7 @@ func (m *LoadBalancerMode) PublishEvent(
 
 func (m *LoadBalancerMode) publishEventsMessage(msg eventsMessage) error {
 	if ok := m.forwardEvent(m.work, msg); !ok {
+		messagesDropped.Add(1)
 		outputs.SignalFailed(msg.signaler, nil)
 	}
 	return nil
@@ -200,6 +201,7 @@ func (m *LoadBalancerMode) onMessage(client ProtocolClient, msg eventsMessage) {
 
 				if m.maxAttempts > 0 && msg.attemptsLeft <= 0 {
 					// no more attempts left => drop
+					messagesDropped.Add(1)
 					outputs.SignalFailed(msg.signaler, err)
 					return
 				}
@@ -231,6 +233,7 @@ func (m *LoadBalancerMode) onFail(msg eventsMessage, err error) {
 	logp.Info("Error publishing events (retrying): %s", err)
 
 	if ok := m.forwardEvent(m.retries, msg); !ok {
+		messagesDropped.Add(1)
 		outputs.SignalFailed(msg.signaler, err)
 	}
 }

--- a/libbeat/outputs/mode/balance.go
+++ b/libbeat/outputs/mode/balance.go
@@ -117,8 +117,7 @@ func (m *LoadBalancerMode) PublishEvent(
 
 func (m *LoadBalancerMode) publishEventsMessage(msg eventsMessage) error {
 	if ok := m.forwardEvent(m.work, msg); !ok {
-		messagesDropped.Add(1)
-		outputs.SignalFailed(msg.signaler, nil)
+		dropping(msg)
 	}
 	return nil
 }
@@ -201,8 +200,7 @@ func (m *LoadBalancerMode) onMessage(client ProtocolClient, msg eventsMessage) {
 
 				if m.maxAttempts > 0 && msg.attemptsLeft <= 0 {
 					// no more attempts left => drop
-					messagesDropped.Add(1)
-					outputs.SignalFailed(msg.signaler, err)
+					dropping(msg)
 					return
 				}
 
@@ -233,8 +231,7 @@ func (m *LoadBalancerMode) onFail(msg eventsMessage, err error) {
 	logp.Info("Error publishing events (retrying): %s", err)
 
 	if ok := m.forwardEvent(m.retries, msg); !ok {
-		messagesDropped.Add(1)
-		outputs.SignalFailed(msg.signaler, err)
+		dropping(msg)
 	}
 }
 
@@ -261,4 +258,11 @@ func (m *LoadBalancerMode) forwardEvent(
 		}
 	}
 	return false
+}
+
+// dropping is called when a message is dropped. It updates the
+// relevant counters and sends a failed signal.
+func dropping(msg eventsMessage) {
+	messagesDropped.Add(1)
+	outputs.SignalFailed(msg.signaler, nil)
 }

--- a/libbeat/outputs/mode/failover.go
+++ b/libbeat/outputs/mode/failover.go
@@ -183,13 +183,13 @@ func (f *FailOverConnectionMode) publish(
 		}
 		if f.maxAttempts > 0 && fails == f.maxAttempts {
 			// max number of attempts reached
-			messagesDropped.Add(1)
 			break
 		}
 
 		time.Sleep(f.waitRetry)
 	}
 
+	messagesDropped.Add(1)
 	outputs.SignalFailed(signaler, err)
 	return nil
 }

--- a/libbeat/outputs/mode/failover.go
+++ b/libbeat/outputs/mode/failover.go
@@ -183,6 +183,7 @@ func (f *FailOverConnectionMode) publish(
 		}
 		if f.maxAttempts > 0 && fails == f.maxAttempts {
 			// max number of attempts reached
+			messagesDropped.Add(1)
 			break
 		}
 

--- a/libbeat/outputs/mode/mode.go
+++ b/libbeat/outputs/mode/mode.go
@@ -4,10 +4,16 @@ package mode
 
 import (
 	"errors"
+	"expvar"
 	"time"
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/outputs"
+)
+
+// Metrics that can retrieved through the expvar web interface.
+var (
+	messagesDropped = expvar.NewInt("libbeatMessagesDropped")
 )
 
 // ErrNoHostsConfigured indicates missing host or hosts configuration

--- a/libbeat/outputs/mode/single.go
+++ b/libbeat/outputs/mode/single.go
@@ -137,6 +137,7 @@ func (s *SingleConnectionMode) publish(
 		}
 		if s.maxAttempts > 0 && fails == s.maxAttempts {
 			// max number of attempts reached
+			messagesDropped.Add(1)
 			break
 		}
 

--- a/libbeat/outputs/mode/single.go
+++ b/libbeat/outputs/mode/single.go
@@ -137,7 +137,6 @@ func (s *SingleConnectionMode) publish(
 		}
 		if s.maxAttempts > 0 && fails == s.maxAttempts {
 			// max number of attempts reached
-			messagesDropped.Add(1)
 			break
 		}
 
@@ -152,6 +151,7 @@ func (s *SingleConnectionMode) publish(
 		time.Sleep(backoff)
 	}
 
+	messagesDropped.Add(1)
 	outputs.SignalFailed(signaler, err)
 	return nil
 }

--- a/libbeat/publisher/client.go
+++ b/libbeat/publisher/client.go
@@ -1,6 +1,15 @@
 package publisher
 
-import "github.com/elastic/beats/libbeat/common"
+import (
+	"expvar"
+
+	"github.com/elastic/beats/libbeat/common"
+)
+
+// Metrics that can retrieved through the expvar web interface.
+var (
+	publishedEvents = expvar.NewInt("libbeatPublishedEvents")
+)
 
 // Client is used by beats to publish new events.
 type Client interface {
@@ -45,11 +54,13 @@ func Sync(o publishOptions) publishOptions {
 
 func (c *client) PublishEvent(event common.MapStr, opts ...ClientOption) bool {
 	options, client := c.getClient(opts)
+	publishedEvents.Add(1)
 	return client.PublishEvent(context{publishOptions: options}, event)
 }
 
 func (c *client) PublishEvents(events []common.MapStr, opts ...ClientOption) bool {
 	options, client := c.getClient(opts)
+	publishedEvents.Add(int64(len(events)))
 	return client.PublishEvents(context{publishOptions: options}, events)
 }
 


### PR DESCRIPTION
The following metrics are exported via expvars (i.e. -httpprof interface):

* libbeatPublishedEvents - For how many events PublishEvent or PublishEvents
  are called. I.e. how many events the Beat is creating.
* libbeatMessagesInWorkerQueues - How many messages (note that a message can
  have lots of events inside - default 10k) are sitting in the publisher worker
  queues.
* libbeatMessagesDropped - How many messages are dropped by the outputs using
  one of the load balancing, single or failover modes
* libbeatEsPublishedAndAckedEvents - How many events were ack-ed by Elasticsearch
* libbeatLogstashPublishedAndAckedEvents - How many events were ack-ed by
  Logstash