### PR TITLE
Reduced the default bulk size for the async publisher

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -71,6 +71,11 @@ https://github.com/elastic/beats/compare/1.0.0...1.0.1[Check 1.0.0 diff]
 
 ==== Bugfixes
 
+*Affecting all Beats*
+
+- Reduced the output bulk size default from 10k to 200. This avoids high
+  memory usage in case Logstash is not available or slow to process request. {pull}550[550]
+
 *Filebeat*
 
 - Fix force_close_files in case renamed file appeared very fast. https://github.com/elastic/filebeat/pull/302[302]
@@ -82,7 +87,7 @@ https://github.com/elastic/beats/compare/1.0.0...1.0.1[Check 1.0.0 diff]
 - Fix panic on nil in redis protocol parser. {issue}384[384]
 - Fix errors redis parser when messages are split in multiple TCP segments. {issue}402[402]
 - Fix errors in redis parser when length prefixed strings contain sequences of CRLF. {issue}#402[402]
-- Fix errors in redis parser when dealing with nested arrays. {issue}#402[402]
+- Fix errors in redis parser when dealing with nested arrays. {issue}402[402]
 
 [[release-notes-1.0.0]]
 === Beats version 1.0.0

--- a/libbeat/publisher/async.go
+++ b/libbeat/publisher/async.go
@@ -19,7 +19,7 @@ type asyncClient func(message)
 
 const (
 	defaultFlushInterval = 1000 * time.Millisecond // 1s
-	defaultBulkSize      = 10000
+	defaultBulkSize      = 200
 )
 
 func newAsyncPublisher(pub *PublisherType) *asyncPublisher {


### PR DESCRIPTION
The high value of 10k caused memory issues when Logstash was not
available or slow to process data. This is because the 10k gets
multiplied with the worker queue size (1000). See for example #516.