### PR TITLE
Fixed a typo in a topbeat log message

### DIFF
--- a/topbeat/beat/topbeat.go
+++ b/topbeat/beat/topbeat.go
@@ -83,7 +83,7 @@ func (tb *Topbeat) Config(b *beat.Beat) error {
 		return errors.New("Invalid statistics configuration")
 	}
 
-	logp.Debug("topbeat", "Init toppbeat")
+	logp.Debug("topbeat", "Init topbeat")
 	logp.Debug("topbeat", "Follow processes %q\n", tb.procs)
 	logp.Debug("topbeat", "Period %v\n", tb.period)
 	logp.Debug("topbeat", "System statistics %t\n", tb.sysStats)


### PR DESCRIPTION
It should probably say 'topbeat' instead of 'toppbeat'.