### PR TITLE
Exclude files in filebeat

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -27,6 +27,7 @@ https://github.com/elastic/beats/compare/1.0.0...master[Check the HEAD diff]
 *Topbeat*
 
 *Filebeat*
+- Add exclude_files configuration option {pull}563[563]
 
 *Winlogbeat*
 

--- a/filebeat/config/config.go
+++ b/filebeat/config/config.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"regexp"
 	"time"
 
 	"github.com/elastic/beats/libbeat/cfgfile"
@@ -49,6 +50,8 @@ type ProspectorConfig struct {
 	ScanFrequency         string `yaml:"scan_frequency"`
 	ScanFrequencyDuration time.Duration
 	Harvester             HarvesterConfig `yaml:",inline"`
+	ExcludeFiles          []string        `yaml:"exclude_files"`
+	ExcludeFilesRegexp    []*regexp.Regexp
 }
 
 type HarvesterConfig struct {

--- a/filebeat/crawler/prospector_test.go
+++ b/filebeat/crawler/prospector_test.go
@@ -171,3 +171,23 @@ func TestProspectorInitInputTypeWrong(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, "log", prospector.ProspectorConfig.Harvester.InputType)
 }
+
+func TestProspectorFileExclude(t *testing.T) {
+
+	prospectorConfig := config.ProspectorConfig{
+		ExcludeFiles: []string{"\\.gz$"},
+		Harvester: config.HarvesterConfig{
+			BufferSize: 0,
+		},
+	}
+
+	prospector := Prospector{
+		ProspectorConfig: prospectorConfig,
+	}
+
+	prospector.Init()
+
+	assert.True(t, prospector.isFileExcluded("/tmp/log/logw.gz"))
+	assert.False(t, prospector.isFileExcluded("/tmp/log/logw.log"))
+
+}

--- a/filebeat/docs/configuration.asciidoc
+++ b/filebeat/docs/configuration.asciidoc
@@ -91,6 +91,16 @@ If both `include_lines` and `exclude_lines` are defined, then include_lines is c
  exclude_lines: ["^DBG"]
 -------------------------------------------------------------------------------------
 
+===== exclude_files
+
+A list of regular expressions to match the files to be ignored. By default no file is excluded. 
+
+[source,yaml]
+-------------------------------------------------------------------------------------
+  exclude_files: [".gz$"]
+-------------------------------------------------------------------------------------
+To ignore all the files with the `gz` extension.
+
 [[configuration-fields]]
 ===== fields
 

--- a/filebeat/etc/beat.yml
+++ b/filebeat/etc/beat.yml
@@ -40,6 +40,10 @@ filebeat:
       # exclude_lines. By default, all the lines are exported.
       # include_lines: ["^ERR", "^WARN"]
 
+      # Exclude files. A list of regular expressions to match. Filebeat drops the files that
+      # are matching any regular expression from the list. By default, no files are dropped.
+      # exclude_files: [".gz$"]
+
       # Optional additional fields. These field can be freely picked
       # to add additional information to the crawled log files for filtering
       #fields:

--- a/filebeat/etc/filebeat.yml
+++ b/filebeat/etc/filebeat.yml
@@ -40,6 +40,10 @@ filebeat:
       # exclude_lines. By default, all the lines are exported.
       # include_lines: ["^ERR", "^WARN"]
 
+      # Exclude files. A list of regular expressions to match. Filebeat drops the files that
+      # are matching any regular expression from the list. By default, no files are dropped.
+      # exclude_files: [".gz$"]
+
       # Optional additional fields. These field can be freely picked
       # to add additional information to the crawled log files for filtering
       #fields:

--- a/filebeat/harvester/log.go
+++ b/filebeat/harvester/log.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"regexp"
 	"time"
 
 	"github.com/elastic/beats/filebeat/config"
@@ -330,35 +329,6 @@ func (h *Harvester) handleReadlineError(lastTimeRead time.Time, err error) error
 }
 
 func (h *Harvester) Stop() {
-}
-
-func InitRegexps(exprs []string) ([]*regexp.Regexp, error) {
-
-	result := []*regexp.Regexp{}
-
-	for _, exp := range exprs {
-
-		rexp, err := regexp.CompilePOSIX(exp)
-		if err != nil {
-			logp.Err("Fail to compile the regexp %s: %s", exp, err)
-			return nil, err
-		}
-		result = append(result, rexp)
-	}
-	return result, nil
-}
-
-func MatchAnyRegexps(regexps []*regexp.Regexp, text string) bool {
-
-	for _, rexp := range regexps {
-		if rexp.MatchString(text) {
-			// drop line
-			return true
-
-		}
-	}
-
-	return false
 }
 
 const maxConsecutiveEmptyReads = 100

--- a/filebeat/harvester/util.go
+++ b/filebeat/harvester/util.go
@@ -1,9 +1,11 @@
 package harvester
 
 import (
+	"regexp"
+	"time"
+
 	"github.com/elastic/beats/filebeat/harvester/encoding"
 	"github.com/elastic/beats/libbeat/logp"
-	"time"
 )
 
 // isLine checks if the given byte array is a line, means has a line ending \n
@@ -59,4 +61,33 @@ func readLine(
 func readlineString(bytes []byte, size int) (string, int, error) {
 	s := string(bytes)[:len(bytes)-lineEndingChars(bytes)]
 	return s, size, nil
+}
+
+// InitRegexps initializes a list of compiled regular expressions.
+func InitRegexps(exprs []string) ([]*regexp.Regexp, error) {
+
+	result := []*regexp.Regexp{}
+
+	for _, exp := range exprs {
+
+		rexp, err := regexp.CompilePOSIX(exp)
+		if err != nil {
+			logp.Err("Fail to compile the regexp %s: %s", exp, err)
+			return nil, err
+		}
+		result = append(result, rexp)
+	}
+	return result, nil
+}
+
+// MatchAnyRegexps checks if the text matches any of the regular expressions
+func MatchAnyRegexps(regexps []*regexp.Regexp, text string) bool {
+
+	for _, rexp := range regexps {
+		if rexp.MatchString(text) {
+			return true
+		}
+	}
+
+	return false
 }

--- a/filebeat/harvester/util_test.go
+++ b/filebeat/harvester/util_test.go
@@ -1,0 +1,19 @@
+package harvester
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMatchAnyRegexps(t *testing.T) {
+
+	patterns := []string{"\\.gz$"}
+
+	regexps, err := InitRegexps(patterns)
+
+	assert.Nil(t, err)
+
+	assert.Equal(t, MatchAnyRegexps(regexps, "/var/log/log.gz"), true)
+
+}

--- a/filebeat/tests/system/config/filebeat.yml.j2
+++ b/filebeat/tests/system/config/filebeat.yml.j2
@@ -29,7 +29,10 @@ filebeat:
       {% if exclude_lines %}
       exclude_lines: {{exclude_lines}}
       {% endif %}
-      
+      {% if exclude_files %}
+      exclude_files: {{exclude_files}}
+      {% endif %}
+     
   spool_size:
   idle_timeout: 0.1s
   registry_file: {{ fb.working_dir + '/' }}{{ registryFile|default(".filebeat")}}


### PR DESCRIPTION
This PR fixes https://github.com/elastic/filebeat/issues/298 by adding `exclude_files` config option to the prospector. 

You can specify a list of regular expressions to match the files that will be ignored.