### PR TITLE
Adds note explaining how to delete old documents after loading index template

### DIFF
--- a/filebeat/docs/getting-started.asciidoc
+++ b/filebeat/docs/getting-started.asciidoc
@@ -185,6 +185,12 @@ PS C:\Program Files\Filebeat> Invoke-WebRequest -Method Put -InFile filebeat.tem
 
 where `localhost:9200` is the IP and port where Elasticsearch is listening.
 
+NOTE: If you've already used Filebeat to index data into Elasticsearch,
+the index may contain old documents. After you load the index template,
+you can delete the old documents from `filebeat-*` to force Kibana to look
+at the newest documents. Use this command:
+`curl -XDELETE 'http://localhost:9200/filebeat-*'`.
+
 === Running Filebeat
 
 Run Filebeat by issuing the appropriate command for your platform.

--- a/packetbeat/docs/gettingstarted.asciidoc
+++ b/packetbeat/docs/gettingstarted.asciidoc
@@ -221,6 +221,12 @@ PS C:\Program Files\Packetbeat> Invoke-WebRequest -Method Put -InFile packetbeat
 
 where `localhost:9200` is the IP and port where Elasticsearch is listening.
 
+NOTE: If you've already used Packetbeat to index data into Elasticsearch,
+the index may contain old documents. After you load the index template,
+you can delete the old documents from `packetbeat-*` to force Kibana to look
+at the newest documents. Use this command:
+`curl -XDELETE 'http://localhost:9200/packetbeat-*'`.
+
 === Running Packetbeat
 
 Run Packetbeat by issuing the following command:

--- a/topbeat/docs/gettingstarted.asciidoc
+++ b/topbeat/docs/gettingstarted.asciidoc
@@ -143,6 +143,11 @@ PS C:\Program Files\Topbeat> Invoke-WebRequest -Method Put -InFile topbeat.templ
 
 where `localhost:9200` is the IP and port where Elasticsearch is listening.
 
+NOTE: If you've already used Topbeat to index data into Elasticsearch,
+the index may contain old documents. After you load the index template,
+you can delete the old documents from `topbeat-*` to force Kibana to look
+at the newest documents. Use this command:
+`curl -XDELETE 'http://localhost:9200/topbeat-*'`.
 
 === Running Topbeat
 


### PR DESCRIPTION
Fixes issue #538 (note that PR #523 has a more complete description for why this request was made).

I'm assuming with my changes that the recommendation is valid for all three Beats. 