### PR TITLE
Replace magic value with magic const

### DIFF
--- a/libbeat/publisher/async.go
+++ b/libbeat/publisher/async.go
@@ -31,7 +31,7 @@ func newAsyncPublisher(pub *PublisherType) *asyncPublisher {
 	}
 
 	p.outputs = outputs
-	p.messageWorker.init(&pub.wsPublisher, 1000, newPreprocessor(pub, p))
+	p.messageWorker.init(&pub.wsPublisher, defaultChanSize, newPreprocessor(pub, p))
 	return p
 }
 
@@ -89,5 +89,5 @@ func asyncOutputer(ws *workerSignal, worker *outputWorker) worker {
 
 	debug("create bulk processing worker (interval=%v, bulk size=%v)",
 		flushInterval, maxBulkSize)
-	return newBulkWorker(ws, 1000, worker, flushInterval, maxBulkSize)
+	return newBulkWorker(ws, defaultChanSize, worker, flushInterval, maxBulkSize)
 }

--- a/libbeat/publisher/common_test.go
+++ b/libbeat/publisher/common_test.go
@@ -141,7 +141,7 @@ func newTestPublisher(bulkSize int, response OutputResponse) *testPublisher {
 	ow.config.BulkMaxSize = &bulkSize
 	ow.handler = mh
 	ws := workerSignal{}
-	ow.messageWorker.init(&ws, 1000, mh)
+	ow.messageWorker.init(&ws, defaultChanSize, mh)
 
 	pub := &PublisherType{
 		Output:   []*outputWorker{ow},

--- a/libbeat/publisher/publish.go
+++ b/libbeat/publisher/publish.go
@@ -86,6 +86,10 @@ type Topology struct {
 	Ip   string `json:"ip"`
 }
 
+const (
+	defaultChanSize = 1000
+)
+
 func init() {
 	publishDisabled = flag.Bool("N", false, "Disable actual publishing for testing")
 }
@@ -211,7 +215,7 @@ func (publisher *PublisherType) init(
 			debug("Create output worker")
 
 			outputers = append(outputers,
-				newOutputWorker(config, output, &publisher.wsOutput, 1000))
+				newOutputWorker(config, output, &publisher.wsOutput, defaultChanSize))
 
 			if !config.Save_topology {
 				continue

--- a/libbeat/publisher/sync.go
+++ b/libbeat/publisher/sync.go
@@ -14,7 +14,7 @@ type syncClient func(message) bool
 
 func newSyncPublisher(pub *PublisherType) *syncPublisher {
 	s := &syncPublisher{pub: pub}
-	s.messageWorker.init(&pub.wsPublisher, 1000, newPreprocessor(pub, s))
+	s.messageWorker.init(&pub.wsPublisher, defaultChanSize, newPreprocessor(pub, s))
 	return s
 }
 


### PR DESCRIPTION
channel sizes in libbeat/publish are all hard-coded.

At least use a const for finding and modifying magic channel size easier in code.