### PR TITLE
added failing test for ignore_older with file rename

### DIFF
--- a/filebeat/tests/system/test_prospector.py
+++ b/filebeat/tests/system/test_prospector.py
@@ -103,3 +103,56 @@ class Test(TestCase):
             max_timeout=15)
 
         proc.kill_and_wait()
+
+    def test_rotating_ignore_older_low_write_rate(self):
+        self.render_config_template(
+            path=os.path.abspath(self.working_dir) + "/log/*",
+            ignoreOlder="1s",
+            scan_frequency="0.1s",
+        )
+
+        os.mkdir(self.working_dir + "/log/")
+        testfile = self.working_dir + "/log/test.log"
+
+        proc = self.start_filebeat(debug_selectors=['*'])
+
+        # wait for first  "Start next scan" log message
+        self.wait_until(
+            lambda: self.log_contains(
+                "Start next scan"),
+            max_timeout=10)
+
+        lines = 0
+
+        # write first line
+        lines += 1
+        with open(testfile, 'a') as file:
+            file.write("Line {}\n".format(lines))
+
+        # wait for log to be read
+        self.wait_until(
+            lambda: self.output_has(lines=lines),
+            max_timeout=15)
+
+        # log rotate
+        os.rename(testfile, testfile + ".1")
+        open(testfile, 'w').close()
+
+        # wait for file to be closed due to ignore_older
+        self.wait_until(
+            lambda: self.log_contains(
+              "Error: Stop harvesting as file is older then ignore_older: {};".format(os.path.abspath(testfile))),
+            max_timeout=10)
+        time.sleep(2)
+
+        # write second line
+        lines += 1
+        with open(testfile, 'a') as file:
+            file.write("Line {}\n".format(lines))
+
+        self.wait_until(
+            # allow for events to be send multiple times due to log rotation
+            lambda: self.output_count(lambda x: x >= lines),
+            max_timeout=5)
+
+        proc.kill_and_wait()


### PR DESCRIPTION
Just adding this for illustrative purposes related to #601 - not expecting a failing test to be merged.
Once the cause is identified I suspect a better test could be formulated