### PR TITLE
Update Golang build version to 1.5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
 language: go
 
 go:
-  - 1.5.1
+  - 1.5.2
 
 os:
   - linux

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -35,6 +35,7 @@ https://github.com/elastic/beats/compare/1.0.0...master[Check the HEAD diff]
 ==== Added
 
 *Affecting all Beats*
+- Update builds to Golang version 1.5.2
 
 *Packetbeat*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.5.1
+FROM golang:1.5.2
 MAINTAINER Nicolas Ruflin <ruflin@elastic.co>
 
 RUN set -x && \


### PR DESCRIPTION
Golang 1.5.2 changes can be found here: https://github.com/golang/go/issues?q=milestone%3AGo1.5.2