### PR TITLE
Change yaml extension to yml for Winlogbeat registry file

### DIFF
--- a/winlogbeat/Makefile
+++ b/winlogbeat/Makefile
@@ -20,7 +20,7 @@ install-cfg:
 	cp etc/$(BEATNAME).template.json $(PREFIX)/$(BEATNAME).template.json
 	# Windows
 	cp etc/${BEATNAME}.yml $(PREFIX)/${BEATNAME}-win.yml
-	sed -i 's|#\{0,1\}\(registry_file:\).*|\1 C:/ProgramData/winlogbeat/.winlogbeat.yaml|' $(PREFIX)/$(BEATNAME)-win.yml
+	sed -i 's|#\{0,1\}\(registry_file:\).*|\1 C:/ProgramData/winlogbeat/.winlogbeat.yml|' $(PREFIX)/$(BEATNAME)-win.yml
 	sed -i 's|#\{0,1\}\(to_files:\).*|\1 true|' $(PREFIX)/$(BEATNAME)-win.yml
 	sed -i 's|#\{0,1\}\(level:\).*|\1 info|' $(PREFIX)/$(BEATNAME)-win.yml
 	sed -i '/log files/{n;s|#\{0,1\}path:.*|path: C:/ProgramData/winlogbeat/Logs|}' $(PREFIX)/$(BEATNAME)-win.yml

--- a/winlogbeat/checkpoint/checkpoint_test.go
+++ b/winlogbeat/checkpoint/checkpoint_test.go
@@ -24,7 +24,7 @@ func TestWriteMaxUpdates(t *testing.T) {
 		}
 	}()
 
-	file := filepath.Join(dir, "some", "new", "dir", ".winlogbeat.yaml")
+	file := filepath.Join(dir, "some", "new", "dir", ".winlogbeat.yml")
 	assert.False(t, fileExists(file), "%s should not exist", file)
 	cp, err := NewCheckpoint(file, 2, time.Hour)
 	if err != nil {
@@ -65,7 +65,7 @@ func TestWriteTimedFlush(t *testing.T) {
 		}
 	}()
 
-	file := filepath.Join(dir, ".winlogbeat.yaml")
+	file := filepath.Join(dir, ".winlogbeat.yml")
 	assert.False(t, fileExists(file), "%s should not exist", file)
 	cp, err := NewCheckpoint(file, 100, time.Second)
 	if err != nil {
@@ -98,7 +98,7 @@ func TestCreateDir(t *testing.T) {
 	}()
 
 	stateDir := filepath.Join(dir, "state", "dir", "does", "not", "exists")
-	file := filepath.Join(stateDir, ".winlogbeat.yaml")
+	file := filepath.Join(stateDir, ".winlogbeat.yml")
 	cp := &Checkpoint{file: file}
 
 	assert.False(t, fileExists(stateDir), "%s should not exist", file)
@@ -129,7 +129,7 @@ func TestCreateDirAlreadyExists(t *testing.T) {
 		}
 	}()
 
-	file := filepath.Join(dir, ".winlogbeat.yaml")
+	file := filepath.Join(dir, ".winlogbeat.yml")
 	cp := &Checkpoint{file: file}
 
 	assert.True(t, fileExists(dir), "%s should exist", file)

--- a/winlogbeat/docs/configuration.asciidoc
+++ b/winlogbeat/docs/configuration.asciidoc
@@ -24,7 +24,7 @@ Here is a sample configuration:
 [source,yaml]
 --------------------------------------------------------------------------------
 winlogbeat:
-  registry_file: C:/ProgramData/winlogbeat/.winlogbeat.yaml
+  registry_file: C:/ProgramData/winlogbeat/.winlogbeat.yml
   event_logs:
     - name: Application
       ignore_older: 72h
@@ -38,15 +38,15 @@ winlogbeat:
 ===== registry_file
 
 The name of the file where Winlogbeat stores information that it uses to resume
-monitoring after a restart. By default the file is stored as `.winlogbeat.yaml`
+monitoring after a restart. By default the file is stored as `.winlogbeat.yml`
 in the directory where the Beat was started. When you run the process as a
 Windows service, it's recommended that you set the value to
-`C:/ProgramData/winlogbeat/.winlogbeat.yaml`.
+`C:/ProgramData/winlogbeat/.winlogbeat.yml`.
 
 [source,yaml]
 --------------------------------------------------------------------------------
 winlogbeat:
-  registry_file: C:/ProgramData/winlogbeat/.winlogbeat.yaml
+  registry_file: C:/ProgramData/winlogbeat/.winlogbeat.yml
 --------------------------------------------------------------------------------
 
 NOTE: The forward slashes (/) in the path are automatically changed to backslashes

--- a/winlogbeat/docs/getting-started.asciidoc
+++ b/winlogbeat/docs/getting-started.asciidoc
@@ -51,7 +51,7 @@ the _winlogbeat.yml_ file:
 [source,yaml]
 --------------------------------------------------------------------------------
 winlogbeat:
-  registry_file: C:/ProgramData/winlogbeat/.winlogbeat.yaml
+  registry_file: C:/ProgramData/winlogbeat/.winlogbeat.yml
 
   event_logs:
     - name: Application

--- a/winlogbeat/etc/beat.yml
+++ b/winlogbeat/etc/beat.yml
@@ -2,9 +2,9 @@
 ############################# Winlogbeat ######################################
 winlogbeat:
   # The registry file is where Winlogbeat persists its state so that the beat
-  # can resume after shutdown or an outage. The default is .winlogbeat.yaml
+  # can resume after shutdown or an outage. The default is .winlogbeat.yml
   # in the directory in which it was started.
-  #registry_file: .winlogbeat.yaml
+  #registry_file: .winlogbeat.yml
 
   # List of event logs to monitor.
   #

--- a/winlogbeat/etc/winlogbeat.yml
+++ b/winlogbeat/etc/winlogbeat.yml
@@ -2,9 +2,9 @@
 ############################# Winlogbeat ######################################
 winlogbeat:
   # The registry file is where Winlogbeat persists its state so that the beat
-  # can resume after shutdown or an outage. The default is .winlogbeat.yaml
+  # can resume after shutdown or an outage. The default is .winlogbeat.yml
   # in the directory in which it was started.
-  #registry_file: .winlogbeat.yaml
+  #registry_file: .winlogbeat.yml
 
   # List of event logs to monitor.
   #


### PR DESCRIPTION
This is for consistency with all other YAML files used in Beats. It'd like to fix this before it gets released to users.

The [YAML FAQ](http://www.yaml.org/faq.html) advises usings `.yaml`.

It needs backported to 1.1.