### PR TITLE
Unique version constant for the official Beats

### DIFF
--- a/filebeat/main.go
+++ b/filebeat/main.go
@@ -5,7 +5,6 @@ import (
 	"github.com/elastic/beats/libbeat/beat"
 )
 
-var Version = "1.2.0"
 var Name = "filebeat"
 
 // The basic model of execution:
@@ -18,5 +17,5 @@ var Name = "filebeat"
 // determine where in each file to restart a harvester.
 
 func main() {
-	beat.Run(Name, Version, filebeat.New())
+	beat.Run(Name, "", filebeat.New())
 }

--- a/libbeat/beat/beat.go
+++ b/libbeat/beat/beat.go
@@ -57,6 +57,9 @@ func init() {
 
 // Initiates a new beat object
 func NewBeat(name string, version string, bt Beater) *Beat {
+	if version == "" {
+		version = defaultBeatVersion
+	}
 	b := Beat{
 		Version: version,
 		Name:    name,

--- a/libbeat/beat/version.go
+++ b/libbeat/beat/version.go
@@ -1,0 +1,3 @@
+package beat
+
+const defaultBeatVersion = "1.2.0-SNAPSHOT"

--- a/packetbeat/main.go
+++ b/packetbeat/main.go
@@ -6,11 +6,9 @@ import (
 	"github.com/elastic/beats/libbeat/beat"
 )
 
-// You can overwrite these, e.g.: go build -ldflags "-X main.Version 1.0.0-beta3"
-var Version = "1.2.0"
 var Name = "packetbeat"
 
 // Setups and Runs Packetbeat
 func main() {
-	beat.Run(Name, Version, packetbeat.New())
+	beat.Run(Name, "", packetbeat.New())
 }

--- a/topbeat/main.go
+++ b/topbeat/main.go
@@ -6,10 +6,8 @@ import (
 	"github.com/elastic/beats/libbeat/beat"
 )
 
-// You can overwrite these, e.g.: go build -ldflags "-X main.Version 1.0.0-beta3"
-var Version = "1.2.0"
 var Name = "topbeat"
 
 func main() {
-	beat.Run(Name, Version, topbeat.New())
+	beat.Run(Name, "", topbeat.New())
 }

--- a/winlogbeat/main.go
+++ b/winlogbeat/main.go
@@ -5,12 +5,9 @@ import (
 	winlogbeat "github.com/elastic/beats/winlogbeat/beat"
 )
 
-// Version of Winlogbeat.
-var Version = "1.2.0"
-
 // Name of this beat.
 var Name = "winlogbeat"
 
 func main() {
-	beat.Run(Name, Version, winlogbeat.New())
+	beat.Run(Name, "", winlogbeat.New())
 }


### PR DESCRIPTION
This makes libbeat have a default for the version string. The beats
can still overwrite this, but the Beats from the main repo won't, because
their versions are in sync.

Main motivation is to make this friendlier to automatic modifying of the
version. That is also why the constant is split in its own file.