### PR TITLE
Handle errors when looking up Windows user name

### DIFF
--- a/winlogbeat/docs/fields.asciidoc
+++ b/winlogbeat/docs/fields.asciidoc
@@ -156,13 +156,24 @@ required: True
 The source of the event log record (the application or service that logged the record).
 
 
+==== user.identifier
+
+type: string
+
+example: S-1-5-21-3541430928-2051711210-1391384369-1001
+
+required: False
+
+The Windows security identifier (SID) of the account associated with this event.
+
+
 ==== user.name
 
 type: string
 
 required: False
 
-The name of the user associated with this event.
+The name of the account associated with this event.
 
 
 ==== user.domain
@@ -171,7 +182,7 @@ type: string
 
 required: False
 
-The domain that the user associated with this event is a member of.
+The domain that the account associated with this event is a member of.
 
 
 ==== user.type
@@ -180,6 +191,6 @@ type: string
 
 required: False
 
-The type of user account associated with this event.
+The type of account associated with this event.
 
 

--- a/winlogbeat/etc/fields.yml
+++ b/winlogbeat/etc/fields.yml
@@ -128,20 +128,28 @@ eventlog:
         The source of the event log record (the application or service that
         logged the record).
 
+    - name: user.identifier
+      type: string
+      required: false
+      example: S-1-5-21-3541430928-2051711210-1391384369-1001
+      description: >
+        The Windows security identifier (SID) of the account associated with
+        this event.
+
     - name: user.name
       type: string
       required: false
       description: >
-        The name of the user associated with this event.
+        The name of the account associated with this event.
 
     - name: user.domain
       type: string
       required: false
       description: >
-        The domain that the user associated with this event is a member of.
+        The domain that the account associated with this event is a member of.
 
     - name: user.type
       type: string
       required: false
       description: >
-        The type of user account associated with this event.
+        The type of account associated with this event.

--- a/winlogbeat/eventlog/eventlog.go
+++ b/winlogbeat/eventlog/eventlog.go
@@ -95,21 +95,32 @@ func (r Record) ToMapStr() common.MapStr {
 	}
 
 	if r.User != nil {
-		m["user"] = common.MapStr{
-			"name":   r.User.Name,
-			"domain": r.User.Domain,
-			"type":   r.User.Type,
+		user := common.MapStr{
+			"identifier": r.User.Identifier,
+		}
+		m["user"] = user
+
+		// Optional fields.
+		if r.User.Name != "" {
+			user["name"] = r.User.Name
+		}
+		if r.User.Domain != "" {
+			user["domain"] = r.User.Domain
+		}
+		if r.User.Type != "" {
+			user["type"] = r.User.Type
 		}
 	}
 
 	return m
 }
 
-// User contain information about a Windows user.
+// User contains information about a Windows account.
 type User struct {
-	Name   string // User name
-	Domain string // Domain that the user is a member of
-	Type   string // Type of account (e.g. User, Computer, Service)
+	Identifier string // Unique identifier used by Windows to ID the account.
+	Name       string // User name
+	Domain     string // Domain that the user is a member of
+	Type       string // Type of account (e.g. User, Computer, Service)
 }
 
 // String returns a string representation of Record.

--- a/winlogbeat/eventlog/eventlogging.go
+++ b/winlogbeat/eventlog/eventlogging.go
@@ -142,9 +142,10 @@ func (l *eventLogging) Read() ([]Record, error) {
 
 		if e.UserSID != nil {
 			r.User = &User{
-				Name:   e.UserSID.Name,
-				Domain: e.UserSID.Domain,
-				Type:   e.UserSID.SIDType.String(),
+				Identifier: e.UserSID.Identifier,
+				Name:       e.UserSID.Name,
+				Domain:     e.UserSID.Domain,
+				Type:       e.UserSID.Type.String(),
 			}
 		}
 

--- a/winlogbeat/eventlog/wineventlog.go
+++ b/winlogbeat/eventlog/wineventlog.go
@@ -87,7 +87,7 @@ func (l *winEventLog) Read() ([]Record, error) {
 	for _, h := range handles {
 		e, err := sys.RenderEvent(h, 0, 0, l.renderBuf, nil)
 		if err != nil {
-			logp.Err("%s Error rendering event. %v", l.logPrefix, err)
+			logp.Err("%s Dropping event with rendering error. %v", l.logPrefix, err)
 			continue
 		}
 
@@ -110,9 +110,10 @@ func (l *winEventLog) Read() ([]Record, error) {
 
 		if e.UserSID != nil {
 			r.User = &User{
-				Name:   e.UserSID.Name,
-				Domain: e.UserSID.Domain,
-				Type:   e.UserSID.SIDType.String(),
+				Identifier: e.UserSID.Identifier,
+				Name:       e.UserSID.Name,
+				Domain:     e.UserSID.Domain,
+				Type:       e.UserSID.Type.String(),
 			}
 		}
 

--- a/winlogbeat/sys/eventlogging/common.go
+++ b/winlogbeat/sys/eventlogging/common.go
@@ -1,18 +1,21 @@
 package eventlogging
 
-import "fmt"
+import (
+	"fmt"
+)
 
 // SID represents the Windows Security Identifier for an account.
 type SID struct {
-	Name    string
-	Domain  string
-	SIDType SIDType
+	Identifier string
+	Name       string
+	Domain     string
+	Type       SIDType
 }
 
 // String returns string representation of SID.
 func (a SID) String() string {
-	return fmt.Sprintf("SID Name[%s] Domain[%s] SIDType[%s]",
-		a.Name, a.Domain, a.SIDType)
+	return fmt.Sprintf("SID Identifier[%s] Name[%s] Domain[%s] Type[%s]",
+		a.Identifier, a.Name, a.Domain, a.Type)
 }
 
 // SIDType identifies the type of a security identifier (SID).

--- a/winlogbeat/sys/eventlogging/eventlogging_windows.go
+++ b/winlogbeat/sys/eventlogging/eventlogging_windows.go
@@ -393,15 +393,22 @@ func parseSID(record eventLogRecord, buffer []byte) (*SID, error) {
 	}
 
 	sid := (*windows.SID)(unsafe.Pointer(&buffer[record.userSidOffset]))
-	account, domain, accountType, err := sid.LookupAccount("")
+	identifier, err := sid.String()
 	if err != nil {
 		return nil, err
 	}
 
+	account, domain, accountType, err := sid.LookupAccount("")
+	if err != nil {
+		// Ignore the error and return a partially populated SID.
+		return &SID{Identifier: identifier}, nil
+	}
+
 	return &SID{
-		Name:    account,
-		Domain:  domain,
-		SIDType: SIDType(accountType),
+		Identifier: identifier,
+		Name:       account,
+		Domain:     domain,
+		Type:       SIDType(accountType),
 	}, nil
 }
 

--- a/winlogbeat/sys/wineventlog/syscall_windows.go
+++ b/winlogbeat/sys/wineventlog/syscall_windows.go
@@ -12,6 +12,7 @@ type EvtHandle uintptr
 const (
 	ERROR_INSUFFICIENT_BUFFER             syscall.Errno = 122
 	ERROR_NO_MORE_ITEMS                   syscall.Errno = 259
+	ERROR_NONE_MAPPED                     syscall.Errno = 1332
 	ERROR_INVALID_OPERATION               syscall.Errno = 4317
 	ERROR_EVT_MESSAGE_NOT_FOUND           syscall.Errno = 15027
 	ERROR_EVT_MESSAGE_ID_NOT_FOUND        syscall.Errno = 15028

--- a/winlogbeat/sys/wineventlog/wineventlog_windows.go
+++ b/winlogbeat/sys/wineventlog/wineventlog_windows.go
@@ -494,15 +494,22 @@ func readSID(buffer []byte, reader io.Reader) (*eventlogging.SID, error) {
 		return nil, err
 	}
 	sid := (*windows.SID)(unsafe.Pointer(&buffer[offset]))
-	account, domain, accountType, err := sid.LookupAccount("")
+	identifier, err := sid.String()
 	if err != nil {
 		return nil, err
 	}
 
+	account, domain, accountType, err := sid.LookupAccount("")
+	if err != nil {
+		// Ignore the error and return a partially populated SID.
+		return &eventlogging.SID{Identifier: identifier}, nil
+	}
+
 	return &eventlogging.SID{
-		Name:    account,
-		Domain:  domain,
-		SIDType: eventlogging.SIDType(accountType),
+		Identifier: identifier,
+		Name:       account,
+		Domain:     domain,
+		Type:       eventlogging.SIDType(accountType),
 	}, nil
 }
 

--- a/winlogbeat/tests/system/test_eventlog.py
+++ b/winlogbeat/tests/system/test_eventlog.py
@@ -16,6 +16,8 @@ Contains tests for reading from the Windows Event Log (both APIs).
 class Test(TestCase):
     providerName = "WinlogbeatTestPython"
     applicationName = "SystemTest"
+    sid = None
+    sidString = None
 
     def setUp(self):
         super(Test, self).setUp()
@@ -33,16 +35,29 @@ class Test(TestCase):
         win32evtlog.ClearEventLog(hlog, None)
         win32evtlog.CloseEventLog(hlog)
 
-    def write_event_log(self, message, eventID):
-        ph = win32api.GetCurrentProcess()
-        th = win32security.OpenProcessToken(ph, win32con.TOKEN_READ)
-        my_sid = win32security.GetTokenInformation(th, win32security.TokenUser)[0]
+    def write_event_log(self, message, eventID, sid = None):
+        if sid == None:
+            sid = self.get_sid()
 
         level= win32evtlog.EVENTLOG_INFORMATION_TYPE
         descr = [message]
 
         win32evtlogutil.ReportEvent(self.applicationName, eventID,
-            eventType=level, strings=descr, sid=my_sid)
+            eventType=level, strings=descr, sid=sid)
+
+    def get_sid(self):
+        if self.sid == None:
+            ph = win32api.GetCurrentProcess()
+            th = win32security.OpenProcessToken(ph, win32con.TOKEN_READ)
+            self.sid = win32security.GetTokenInformation(th, win32security.TokenUser)[0]
+
+        return self.sid
+
+    def get_sid_string(self):
+        if self.sidString == None:
+            self.sidString = win32security.ConvertSidToStringSid(self.get_sid())
+
+        return self.sidString
 
     @unittest.skipUnless(sys.platform.startswith("win"), "requires Windows")
     def test_eventlogging_read_one_event(self):
@@ -83,6 +98,7 @@ class Test(TestCase):
         assert evt["eventLogName"] == self.providerName
         assert evt["sourceName"] == self.applicationName
         assert evt["computerName"].lower() == win32api.GetComputerName().lower()
+        assert evt["user.identifier"] == self.get_sid_string()
         assert evt["user.name"] == win32api.GetUserName()
         assert "user.type" in evt
         assert "user.domain" in evt
@@ -142,6 +158,7 @@ class Test(TestCase):
         assert evt["eventLogName"] == self.providerName
         assert evt["sourceName"] == self.applicationName
         assert evt["computerName"].lower() == win32api.GetComputerName().lower()
+        assert evt["user.identifier"] == self.get_sid_string()
         assert evt["user.name"] == win32api.GetUserName()
         assert "user.type" in evt
         assert "user.domain" in evt
@@ -152,3 +169,56 @@ class Test(TestCase):
 
         return evt
 
+    @unittest.skipUnless(sys.platform.startswith("win"), "requires Windows")
+    def test_eventlogging_read_unknown_sid(self):
+        """
+        Event Logging - Read event with unknown SID
+        """
+        self.read_unknown_sid("eventlogging")
+
+    @unittest.skipUnless(sys.platform.startswith("win"), "requires Windows")
+    def test_wineventlog_read_unknown_sid(self):
+        """
+        Win Event Log - Read event with unknown SID
+        """
+        self.read_unknown_sid("wineventlog")
+
+    def read_unknown_sid(self, api):
+        # Fake SID that was made up.
+        accountIdentifier = "S-1-5-21-3623811015-3361044348-30300820-1013"
+        sid = win32security.ConvertStringSidToSid(accountIdentifier)
+
+        msg = "Unknown SID of " + accountIdentifier
+        eventID = 40
+        self.write_event_log(msg, eventID, sid)
+
+        # Run Winlogbeat
+        self.render_config_template(
+            event_logs=[
+                {"name": self.providerName, "api": api}
+            ]
+        )
+        proc = self.start_winlogbeat()
+        self.wait_until(lambda: self.output_has(1))
+        proc.kill()
+
+        # Verify output
+        events = self.read_output()
+        assert len(events) == 1
+        evt = events[0]
+        assert evt["type"] == api
+        assert evt["eventID"] == eventID
+        assert evt["level"] == "Information"
+        assert evt["eventLogName"] == self.providerName
+        assert evt["sourceName"] == self.applicationName
+        assert evt["computerName"].lower() == win32api.GetComputerName().lower()
+        assert evt["user.identifier"] == accountIdentifier
+        assert "user.name" not in evt
+        assert "user.type" not in evt
+        assert "user.domain" not in evt
+        assert evt["message"] == msg
+
+        exit_code = proc.wait()
+        assert exit_code == 0
+
+        return evt


### PR DESCRIPTION
Fixes #627 

If an error occurs while looking up the name and domain associated with a Windows SID, Winlogbeat will now report the event. In this case, it omits the `user.name`, `user.domain`, and `user.type` fields and only populates the new `user.identifier` field.