### PR TITLE
Auto creation of template

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -58,6 +58,7 @@ https://github.com/elastic/beats/compare/v1.1.0...master[Check the HEAD diff]
 - Update builds to Golang version 1.5.3
 - Add ability to override configuration settings using environment variables {issue}114[114]
 - Libbeat now always exits through a single exit method for proper cleanup and control {pull}736[736]
+- Possibility to create elasticsearch mapping on startup {pull}639[639]
 
 *Packetbeat*
 - Change the DNS library used throughout the dns package to github.com/miekg/dns. {pull}803[803]

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -58,7 +58,7 @@ https://github.com/elastic/beats/compare/v1.1.0...master[Check the HEAD diff]
 - Update builds to Golang version 1.5.3
 - Add ability to override configuration settings using environment variables {issue}114[114]
 - Libbeat now always exits through a single exit method for proper cleanup and control {pull}736[736]
-- Possibility to create elasticsearch mapping on startup {pull}639[639]
+- Add ability to create Elasticsearch mapping on startup {pull}639[639]
 
 *Packetbeat*
 - Change the DNS library used throughout the dns package to github.com/miekg/dns. {pull}803[803]

--- a/filebeat/filebeat.yml
+++ b/filebeat/filebeat.yml
@@ -151,6 +151,9 @@ filebeat:
   # Event count spool threshold - forces network flush if exceeded
   #spool_size: 2048
 
+  # Enable async publisher pipeline in filebeat (Experimental!)
+  #publish_async: false
+
   # Defines how often the spooler is flushed. After idle_timeout the spooler is
   # Flush even though spool_size is not reached.
   #idle_timeout: 5s
@@ -195,6 +198,20 @@ output:
     # Optional index name. The default is "filebeat" and generates
     # [filebeat-]YYYY.MM.DD keys.
     #index: "filebeat"
+
+    # A template is used to set the mapping in elasticsearch
+    # By default template loading is disabled an not template is loaded.
+    # These settings can be adjusted to load your own template or overwrite existing ones
+    #template:
+
+      # Template name. By default the template name is the same as the filebeat
+      #name: "filebeat"
+
+      # Path to template file
+      #path: "filebeat.template.json"
+
+      # Overwrite existing template
+      #overwrite: false
 
     # Optional HTTP Path
     #path: "/elasticsearch"

--- a/filebeat/filebeat.yml
+++ b/filebeat/filebeat.yml
@@ -199,12 +199,12 @@ output:
     # [filebeat-]YYYY.MM.DD keys.
     #index: "filebeat"
 
-    # A template is used to set the mapping in elasticsearch
-    # By default template loading is disabled an not template is loaded.
+    # A template is used to set the mapping in Elasticsearch
+    # By default template loading is disabled and no template is loaded.
     # These settings can be adjusted to load your own template or overwrite existing ones
     #template:
 
-      # Template name. By default the template name is the same as the filebeat
+      # Template name. By default the template name is filebeat.
       #name: "filebeat"
 
       # Path to template file

--- a/libbeat/etc/libbeat.yml
+++ b/libbeat/etc/libbeat.yml
@@ -28,6 +28,20 @@ output:
     # [beatname-]YYYY.MM.DD keys.
     #index: "beatname"
 
+    # A template is used to set the mapping in elasticsearch
+    # By default template loading is disabled an not template is loaded.
+    # These settings can be adjusted to load your own template or overwrite existing ones
+    #template:
+
+      # Template name. By default the template name is the same as the beatname
+      #name: "beatname"
+
+      # Path to template file
+      #path: "beatname.template.json"
+
+      # Overwrite existing template
+      #overwrite: false
+
     # Optional HTTP Path
     #path: "/elasticsearch"
 

--- a/libbeat/etc/libbeat.yml
+++ b/libbeat/etc/libbeat.yml
@@ -28,12 +28,12 @@ output:
     # [beatname-]YYYY.MM.DD keys.
     #index: "beatname"
 
-    # A template is used to set the mapping in elasticsearch
-    # By default template loading is disabled an not template is loaded.
+    # A template is used to set the mapping in Elasticsearch
+    # By default template loading is disabled and no template is loaded.
     # These settings can be adjusted to load your own template or overwrite existing ones
     #template:
 
-      # Template name. By default the template name is the same as the beatname
+      # Template name. By default the template name is beatname.
       #name: "beatname"
 
       # Path to template file

--- a/libbeat/outputs/elasticsearch/client.go
+++ b/libbeat/outputs/elasticsearch/client.go
@@ -349,6 +349,38 @@ func (client *Client) PublishEvent(event common.MapStr) error {
 	return nil
 }
 
+// LoadTemplate loads a template into Elasticsearch overwriting the existing
+// template if it exists. If you wish to not overwrite an existing template
+// then use CheckTemplate prior to calling this method.
+func (client *Client) LoadTemplate(templateName string, reader *bytes.Reader) error {
+
+	status, _, err := client.execRequest("PUT", client.URL+"/_template/"+templateName, reader)
+
+	if err != nil {
+		return fmt.Errorf("Template could not be loaded. Error: %s", err)
+	}
+	if status != 200 {
+		return fmt.Errorf("Template could not be loaded. Status: %v", status)
+	}
+
+	logp.Info("Elasticsearch template with name '%s' loaded", templateName)
+
+	return nil
+}
+
+// CheckTemplate checks if a given template already exist. It returns true if
+// and only if Elasticsearch returns with HTTP status code 200.
+func (client *Client) CheckTemplate(templateName string) bool {
+
+	status, _, _ := client.request("HEAD", "/_template/"+templateName, nil, nil)
+
+	if status != 200 {
+		return false
+	}
+
+	return true
+}
+
 func (conn *Connection) Connect(timeout time.Duration) error {
 	var err error
 	conn.connected, err = conn.Ping(timeout)
@@ -390,7 +422,7 @@ func (conn *Connection) request(
 	body interface{},
 ) (int, []byte, error) {
 	url := makeURL(conn.URL, path, params)
-	logp.Debug("elasticsearch", "%s %s %s", method, url, body)
+	logp.Debug("elasticsearch", "%s %s %v", method, url, body)
 
 	var obj []byte
 	if body != nil {

--- a/libbeat/outputs/elasticsearch/client_integration_test.go
+++ b/libbeat/outputs/elasticsearch/client_integration_test.go
@@ -4,7 +4,10 @@ import (
 	"testing"
 	"time"
 
+	"bytes"
 	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	"path/filepath"
 )
 
 func TestClientConnect(t *testing.T) {
@@ -17,4 +20,77 @@ func TestClientConnect(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.True(t, client.IsConnected())
+}
+
+func TestCheckTemplate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping test in short mode because it requires ES")
+	}
+
+	client := GetTestingElasticsearch()
+	err := client.Connect(5 * time.Second)
+	assert.Nil(t, err)
+
+	// Check for non existant template
+	assert.False(t, client.CheckTemplate("libbeat"))
+}
+
+func TestLoadTemplate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping test in short mode because it requires ES")
+	}
+
+	// Load template
+	absPath, err := filepath.Abs("../../tests/files/")
+	assert.NotNil(t, absPath)
+	assert.Nil(t, err)
+
+	templatePath := absPath + "/template.json"
+	content, err := ioutil.ReadFile(templatePath)
+	reader := bytes.NewReader(content)
+	assert.Nil(t, err)
+
+	// Setup ES
+	client := GetTestingElasticsearch()
+	err = client.Connect(5 * time.Second)
+	assert.Nil(t, err)
+
+	templateName := "testbeat"
+
+	// Load template
+	err = client.LoadTemplate(templateName, reader)
+	assert.Nil(t, err)
+
+	// Make sure template was loaded
+	assert.True(t, client.CheckTemplate(templateName))
+
+	// Delete template again to clean up
+	client.request("DELETE", "/_template/"+templateName, nil, nil)
+
+	// Make sure it was removed
+	assert.False(t, client.CheckTemplate(templateName))
+
+}
+
+func TestLoadInvalidTemplate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping test in short mode because it requires ES")
+	}
+
+	// Invalid Template
+	reader := bytes.NewReader([]byte("{json:invalid}"))
+
+	// Setup ES
+	client := GetTestingElasticsearch()
+	err := client.Connect(5 * time.Second)
+	assert.Nil(t, err)
+
+	templateName := "invalidtemplate"
+
+	// Try to load invalid template
+	err = client.LoadTemplate(templateName, reader)
+	assert.Error(t, err)
+
+	// Make sure template was not loaded
+	assert.False(t, client.CheckTemplate(templateName))
 }

--- a/libbeat/outputs/outputs.go
+++ b/libbeat/outputs/outputs.go
@@ -17,6 +17,7 @@ type MothershipConfig struct {
 	ProxyURL          string `yaml:"proxy_url"`
 	Index             string
 	Path              string
+	Template          Template
 	Db                int
 	Db_topology       int
 	Timeout           int
@@ -32,6 +33,12 @@ type MothershipConfig struct {
 	TLS               *TLSConfig
 	Worker            int
 	CompressionLevel  *int `yaml:"compression_level"`
+}
+
+type Template struct {
+	Name      string
+	Path      string
+	Overwrite bool
 }
 
 type Options struct {

--- a/libbeat/tests/files/template.json
+++ b/libbeat/tests/files/template.json
@@ -1,0 +1,42 @@
+{
+  "mappings": {
+    "_default_": {
+      "_all": {
+        "enabled": true,
+        "norms": {
+          "enabled": false
+        }
+      },
+      "dynamic_templates": [
+        {
+          "template1": {
+            "mapping": {
+              "doc_values": true,
+              "ignore_above": 1024,
+              "index": "not_analyzed",
+              "type": "{dynamic_type}"
+            },
+            "match": "*"
+          }
+        }
+      ],
+      "properties": {
+        "@timestamp": {
+          "type": "date"
+        },
+        "message": {
+          "type": "string",
+          "index": "analyzed"
+        },
+        "offset": {
+          "type": "long",
+          "doc_values": "true"
+        }
+      }
+    }
+  },
+  "settings": {
+    "index.refresh_interval": "5s"
+  },
+  "template": "mockbeat-*"
+}

--- a/libbeat/tests/system/test_base.py
+++ b/libbeat/tests/system/test_base.py
@@ -12,7 +12,6 @@ class Test(BaseTest):
         Basic test with exiting Mockbeat normally
         """
         self.render_config_template(
-            path=os.path.abspath(self.working_dir) + "/log/*"
         )
 
         exit_code = self.run_beat()

--- a/packetbeat/packetbeat.yml
+++ b/packetbeat/packetbeat.yml
@@ -171,12 +171,12 @@ output:
     # [packetbeat-]YYYY.MM.DD keys.
     #index: "packetbeat"
 
-    # A template is used to set the mapping in elasticsearch
-    # By default template loading is disabled an not template is loaded.
+    # A template is used to set the mapping in Elasticsearch
+    # By default template loading is disabled and no template is loaded.
     # These settings can be adjusted to load your own template or overwrite existing ones
     #template:
 
-      # Template name. By default the template name is the same as the packetbeat
+      # Template name. By default the template name is packetbeat.
       #name: "packetbeat"
 
       # Path to template file

--- a/packetbeat/packetbeat.yml
+++ b/packetbeat/packetbeat.yml
@@ -171,6 +171,20 @@ output:
     # [packetbeat-]YYYY.MM.DD keys.
     #index: "packetbeat"
 
+    # A template is used to set the mapping in elasticsearch
+    # By default template loading is disabled an not template is loaded.
+    # These settings can be adjusted to load your own template or overwrite existing ones
+    #template:
+
+      # Template name. By default the template name is the same as the packetbeat
+      #name: "packetbeat"
+
+      # Path to template file
+      #path: "packetbeat.template.json"
+
+      # Overwrite existing template
+      #overwrite: false
+
     # Optional HTTP Path
     #path: "/elasticsearch"
 

--- a/topbeat/topbeat.yml
+++ b/topbeat/topbeat.yml
@@ -54,12 +54,12 @@ output:
     # [topbeat-]YYYY.MM.DD keys.
     #index: "topbeat"
 
-    # A template is used to set the mapping in elasticsearch
-    # By default template loading is disabled an not template is loaded.
+    # A template is used to set the mapping in Elasticsearch
+    # By default template loading is disabled and no template is loaded.
     # These settings can be adjusted to load your own template or overwrite existing ones
     #template:
 
-      # Template name. By default the template name is the same as the topbeat
+      # Template name. By default the template name is topbeat.
       #name: "topbeat"
 
       # Path to template file

--- a/topbeat/topbeat.yml
+++ b/topbeat/topbeat.yml
@@ -54,6 +54,20 @@ output:
     # [topbeat-]YYYY.MM.DD keys.
     #index: "topbeat"
 
+    # A template is used to set the mapping in elasticsearch
+    # By default template loading is disabled an not template is loaded.
+    # These settings can be adjusted to load your own template or overwrite existing ones
+    #template:
+
+      # Template name. By default the template name is the same as the topbeat
+      #name: "topbeat"
+
+      # Path to template file
+      #path: "topbeat.template.json"
+
+      # Overwrite existing template
+      #overwrite: false
+
     # Optional HTTP Path
     #path: "/elasticsearch"
 

--- a/winlogbeat/winlogbeat.yml
+++ b/winlogbeat/winlogbeat.yml
@@ -53,6 +53,20 @@ output:
     # [winlogbeat-]YYYY.MM.DD keys.
     #index: "winlogbeat"
 
+    # A template is used to set the mapping in elasticsearch
+    # By default template loading is disabled an not template is loaded.
+    # These settings can be adjusted to load your own template or overwrite existing ones
+    #template:
+
+      # Template name. By default the template name is the same as the winlogbeat
+      #name: "winlogbeat"
+
+      # Path to template file
+      #path: "winlogbeat.template.json"
+
+      # Overwrite existing template
+      #overwrite: false
+
     # Optional HTTP Path
     #path: "/elasticsearch"
 

--- a/winlogbeat/winlogbeat.yml
+++ b/winlogbeat/winlogbeat.yml
@@ -53,12 +53,12 @@ output:
     # [winlogbeat-]YYYY.MM.DD keys.
     #index: "winlogbeat"
 
-    # A template is used to set the mapping in elasticsearch
-    # By default template loading is disabled an not template is loaded.
+    # A template is used to set the mapping in Elasticsearch
+    # By default template loading is disabled and no template is loaded.
     # These settings can be adjusted to load your own template or overwrite existing ones
     #template:
 
-      # Template name. By default the template name is the same as the winlogbeat
+      # Template name. By default the template name is winlogbeat.
       #name: "winlogbeat"
 
       # Path to template file


### PR DESCRIPTION
# Problem
Each beat loads structured documents into elasticsearch. To make sure every document has the correct mapping, before starting a beat the predefined mapping should be loaded. Currently this is a [manual step](https://www.elastic.co/guide/en/beats/topbeat/current/topbeat-getting-started.html#topbeat-template) and is often forgotten. This can lead to problems as elasticsearch automatically assumes types. A mapping can't be changed anymore at a later stage.

See also https://github.com/elastic/libbeat/issues/62

## Versioning

An additional problem is, that the templates can change with the different versions of a beat. This means having data of 2 different beat versions can lead to problems.

## Logstash Template

Logstash provides its own template to elasticsearch as part of the [logstash-output-elasticsearch](https://github.com/logstash-plugins/logstash-output-elasticsearch). [This is a generic template](https://github.com/logstash-plugins/logstash-output-elasticsearch/blob/master/lib/logstash/outputs/elasticsearch/elasticsearch-template.json) and does not necessarly cover all cases from the beats. The template applies to all indices starting with logstash-,  by default the beats templates apply to all indices starting with beatname-

# Proposed solution

To not have to implement all possibilities with the first version and better understand on how the feature will be used, I suggest to split it up in two phases:

### Phase 1 - Manual phase / opt in

Phase 1 will be fully backward compatible. It allows the user to load the template if he configures it so. By default, the template will not be loaded.

* Manually configure template in config file
* No default behaviour
* Getting started guide on how to do it

### Phase 2 - Automated / versioning

Phase 2 always loads the template on startup and adds versioning for each template, so no conflicts between the different template versions happen.

* Automatic loading of templates
* Versioning of templates
* Disabling by user needed if does not want to have behaviour


## Configuration

The configuration will look as following. It is part of the elasticsearch output as a direct connection to elasticsearch is needed to apply the template. People using Logstash for example for filebeat must apply the manually or use the logstasth-elasticsearch-output.

```
output:
  elasticsearch:

     # A template is used ot set the mapping in elasticsearch
     # By default in phase 1, if this is commented out, no template is loaded
     # These settings can be adjusted to load your own template or overwrite existing ones
     template:

     # Template name. By default the template name is the same as the beatname
     name: "beatname"

     # Path to template file
     # TODO: make this platform specific?
     path:

     # Overwrite existing template
     overwrite: false
```
This configuration is taken from Logstash: https://www.elastic.co/guide/en/logstash/current/plugins-outputs-elasticsearch.html#plugins-outputs-elasticsearch-manage_template


## Versioning

To support the different version of templates, each template must be versioned. In the first version, by default templates would not be applied. In a second version when versioning of templates is in place, templates should be loaded automatically. Versioning is required for the automated behaviour as otherwise this would lead very soon to conflicts. With versioning in place, it is possible to keep using older beats running and writing to indices with the old mapping and having a newer beat running at the same time, writing in new indices with the new mapping.

To solve this problem, it is probably not only required to version the templates but also the indices, so the correct templates can be applied. It should be checked with Kibana / Marvel / Logstash on how they are solving this problem.



## Logstash

Logstash has with the elasticsearch-logstash-output its own plugin which already applies a template to elasticsearch. This template is a general template and is intended for all indices starting with `logstash-`. Especially filebeat is normally connected to LS and sends data to ES over the output plugin. Depending on the LS configuration, either the index pattern logstash- or filebeat- is used. The question is which mapping should be used when sending data over LS.

### Option 1
* Only use default logstash mapping
* Use the logstash- index
* Add filebeat specific offset field to ls mapping

The disadvantage of option 1 is, that it only applies to filebeat and not the other beats. The assumptionis made, that the other beats send data directly to ES.

### Option 2
* Apply Filebeat Mapping manually
* Configure filebeat- index pattern in LS

The main disadvantage here is that the mapping has to be applied manually. People updating a beat will probably not apply the updated (versioned) mapping. The advantage is that it works with all beats. 


### Suggestion
I would suggest to go with option 2, as filebeat has one of the simplest patterns of all beats, means there will be very rare BC breaks and in the long term, also nodeingest could be used for filebeat.


## Note
Similar to logstash, there should be a generic base pattern provided by libbeat which applies to all beats.