### PR TITLE
Remove exits from filebeat

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -35,6 +35,7 @@ https://github.com/elastic/beats/compare/1.0.0...master[Check the HEAD diff]
 
 *Filebeat*
 - Add exclude_files configuration option {pull}563[563]
+- Stop filebeat if filebeat is started without any prospectors defined {pull}644[644]
 
 *Winlogbeat*
 

--- a/filebeat/beat/filebeat.go
+++ b/filebeat/beat/filebeat.go
@@ -2,7 +2,6 @@ package beat
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/cfgfile"
@@ -49,16 +48,6 @@ func (fb *Filebeat) Setup(b *beat.Beat) error {
 }
 
 func (fb *Filebeat) Run(b *beat.Beat) error {
-
-	defer func() {
-		p := recover()
-		if p == nil {
-			return
-		}
-
-		fmt.Printf("recovered panic: %v", p)
-		os.Exit(1)
-	}()
 
 	var err error
 

--- a/filebeat/crawler/crawler.go
+++ b/filebeat/crawler/crawler.go
@@ -2,7 +2,6 @@ package crawler
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/elastic/beats/filebeat/config"
 	"github.com/elastic/beats/filebeat/input"
@@ -48,9 +47,7 @@ func (crawler *Crawler) Start(prospectorConfigs []config.ProspectorConfig, event
 
 		err := prospector.Init()
 		if err != nil {
-			logp.Critical("Error in initing prospector: %s", err)
-			fmt.Printf("Error in initing prospector: %s", err)
-			os.Exit(1)
+			return fmt.Errorf("Error in initing prospector: %s", err)
 		}
 
 		go prospector.Run(eventChan)

--- a/libbeat/beat/beat.go
+++ b/libbeat/beat/beat.go
@@ -180,7 +180,7 @@ func (b *Beat) Run() {
 	// Run beater specific stuff
 	err = b.BT.Run(b)
 	if err != nil {
-		logp.Critical("Run returned an error: %v", err)
+		logp.Critical("Running the beat returned an error: %v", err)
 	}
 
 	service.Cleanup()


### PR DESCRIPTION
Remove panic recovery as should not be handled inside the beat. Same for exists. Beats should always properly be shut down whenever possible.

Add changelog for missing changelog in #644 