### PR TITLE
Update file copy in multiline tests

### DIFF
--- a/filebeat/tests/system/filebeat.py
+++ b/filebeat/tests/system/filebeat.py
@@ -137,10 +137,14 @@ class TestCase(unittest.TestCase):
                                      "beat.name", "beat.hostname", "count"])
         return jsons
 
-    def copy_files(self, files, source_dir="files/"):
+    def copy_files(self, files, source_dir="files/", target_dir=""):
+        if target_dir:
+            target_dir = os.path.join(self.working_dir, target_dir)
+        else:
+            target_dir = self.working_dir
         for file_ in files:
             shutil.copy(os.path.join(source_dir, file_),
-                        self.working_dir)
+                        target_dir)
 
     def setUp(self):
 

--- a/filebeat/tests/system/test_multiline.py
+++ b/filebeat/tests/system/test_multiline.py
@@ -23,7 +23,9 @@ class Test(TestCase):
         )
 
         os.mkdir(self.working_dir + "/log/")
-        shutil.copy2("../files/logs/elasticsearch-multiline-log.log", os.path.abspath(self.working_dir) + "/log/elasticsearch-multiline-log.log")
+        self.copy_files(["logs/elasticsearch-multiline-log.log"],
+                        source_dir="../files",
+                        target_dir="log")
 
         proc = self.start_filebeat()
 
@@ -48,11 +50,13 @@ class Test(TestCase):
             path=os.path.abspath(self.working_dir) + "/log/*",
             multiline=True,
             pattern="\\\\$",
-            match="after"
+            match="before"
         )
 
         os.mkdir(self.working_dir + "/log/")
-        shutil.copy2("../files/logs/multiline-c-log.log", os.path.abspath(self.working_dir) + "/log/multiline-c-log.log")
+        self.copy_files(["logs/multiline-c-log.log"],
+                        source_dir="../files",
+                        target_dir="log")
 
         proc = self.start_filebeat()
 
@@ -83,7 +87,9 @@ class Test(TestCase):
         )
 
         os.mkdir(self.working_dir + "/log/")
-        shutil.copy2("../files/logs/elasticsearch-multiline-log.log", os.path.abspath(self.working_dir) + "/log/elasticsearch-multiline-log.log")
+        self.copy_files(["logs/elasticsearch-multiline-log.log"],
+                        source_dir="../files",
+                        target_dir="log")
 
         proc = self.start_filebeat()
 
@@ -162,7 +168,9 @@ class Test(TestCase):
         )
 
         os.mkdir(self.working_dir + "/log/")
-        shutil.copy2("../files/logs/elasticsearch-multiline-log.log", os.path.abspath(self.working_dir) + "/log/elasticsearch-multiline-log.log")
+        self.copy_files(["logs/elasticsearch-multiline-log.log"],
+                        source_dir="../files",
+                        target_dir="log")
 
         proc = self.start_filebeat()
 


### PR DESCRIPTION
using shutil.copy2 preserves the last modified timestamps on some systems,
making tests fail (ignore_older kicks in)