### PR TITLE
Changelog: correct small typo and add DNS over TCP

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -49,7 +49,7 @@ https://github.com/elastic/beats/compare/1.0.0...master[Check the HEAD diff]
 *Packetbeat*
 
 *Topbeat*
-- group all cpu usage per core statistics and export them optionally if cpu_per_core is configured {pull}496[496]
+- Group all cpu usage per core statistics and export them optionally if cpu_per_core is configured {pull}496[496]
 
 *Filebeat*
 - Add multiline support for combining multiple related lines into one event. {issue}461[461]

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -47,6 +47,7 @@ https://github.com/elastic/beats/compare/1.0.0...master[Check the HEAD diff]
 - Update builds to Golang version 1.5.2
 
 *Packetbeat*
+- Add support for capturing DNS over TCP network traffic. {pull}486[486] {pull}554[554]
 
 *Topbeat*
 - Group all cpu usage per core statistics and export them optionally if cpu_per_core is configured {pull}496[496]


### PR DESCRIPTION
* Typo: Correct a lower case to upper case. By the way, some lines have a period and others don't. But I didn't go that far.
* DNS over TCP: Add a new entry in the Changelog. See #554 #643.