### PR TITLE
Clarify description of max_retries

### DIFF
--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -183,17 +183,14 @@ For example "{beatname_lc}" generates "[{beatname_lc}-]YYYY.MM.DD" indexes (for 
 
 ===== max_retries
 
-The number of times to try a particular Logstash send attempt. If
-the send operation doesn't succeed after the specified number of retries, the events are
-dropped. The default is 3.
+The number of times to retry publishing an event after a publishing failure.
+After the specified number of retries, the events are typically dropped.
+Some Beats, such as Filebeat, ignore the `max_retries` setting and retry until all
+events are published.
 
-A value of 0 disables retrying and a value <0 will enable infinite retry until
-events have been published.
+Set `max_retries` to a value less than 0 to retry until all events are published. 
 
-If an event is dropped by the output plugin, each Beat implementation must
-determine whether to drop the event or try sending it again. If the send
-operation doesn't succeed after
-`max_retries`, the Beat is optionally notified.
+The default is 3.
 
 ===== bulk_max_size
 
@@ -377,17 +374,14 @@ The number of seconds to wait for responses from the Logstash server before timi
 
 ===== max_retries
 
-The number of times to try a particular Logstash send attempt. If
-the send operation doesn't succeed after the specified number of retries, the events are
-dropped. The default is 3.
+The number of times to retry publishing an event after a publishing failure.
+After the specified number of retries, the events are typically dropped.
+Some Beats, such as Filebeat, ignore the `max_retries` setting and retry until all
+events are published.
 
-A value of 0 disables retrying and a value <0 will enable infinite retry until
-events have been published.
+Set `max_retries` to a value less than 0 to retry until all events are published. 
 
-If an event is dropped by the output plugin, each Beat implementation must
-determine whether to drop the event or try sending it again. If the send
-operation doesn't succeed after `max_retries`, the Beat is optionally notified.
-
+The default is 3.
 
 [[redis-output]]
 ==== Redis Output (DEPRECATED)


### PR DESCRIPTION
Changes are based on hipchat exchange related to #608.

@urso Can you please confirm that this is accurate (I made some changes to the text that you suggested). 

I've also opened #652 because I think we need to do a better job of describing how max_retries and the backoff options are related, but I don't think we should do this in the reference topic.