### PR TITLE
Refactor prospector to split up different types

### DIFF
--- a/filebeat/crawler/prospector.go
+++ b/filebeat/crawler/prospector.go
@@ -2,8 +2,6 @@ package crawler
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 	"time"
 
 	cfg "github.com/elastic/beats/filebeat/config"
@@ -14,12 +12,31 @@ import (
 
 type Prospector struct {
 	ProspectorConfig cfg.ProspectorConfig
-	prospectorList   map[string]harvester.FileStat
-	iteration        uint32
-	lastscan         time.Time
+	prospectorer     Prospectorer
+	channel          chan *input.FileEvent
 	registrar        *Registrar
-	missingFiles     map[string]os.FileInfo
 	running          bool
+}
+
+type Prospectorer interface {
+	Run(spoolChan chan *input.FileEvent)
+	Init()
+}
+
+func NewProspector(prospectorConfig cfg.ProspectorConfig, registrar *Registrar, channel chan *input.FileEvent) (*Prospector, error) {
+	prospector := &Prospector{
+		ProspectorConfig: prospectorConfig,
+		registrar:        registrar,
+		channel:          channel,
+	}
+
+	err := prospector.Init()
+
+	if err != nil {
+		return nil, err
+	}
+
+	return prospector, nil
 }
 
 // Init sets up default config for prospector
@@ -35,7 +52,40 @@ func (p *Prospector) Init() error {
 		return err
 	}
 
+	var prospectorer Prospectorer
+
+	switch p.ProspectorConfig.Harvester.InputType {
+	case cfg.StdinInputType:
+		prospectorer, err = NewProspectorStdin(p.ProspectorConfig, p.channel)
+		prospectorer.Init()
+	case cfg.LogInputType:
+		prospectorer, err = NewProspectorLog(p.ProspectorConfig, p.channel, p.registrar)
+		prospectorer.Init()
+	default:
+		return fmt.Errorf("Invalid prospector type: %v", p.ProspectorConfig.Harvester.InputType)
+	}
+
+	p.prospectorer = prospectorer
+
 	return nil
+}
+
+// Starts scanning through all the file paths and fetch the related files. Start a harvester for each file
+func (p *Prospector) Run() {
+
+	p.running = true
+	logp.Info("Starting prospector of type: %v", p.ProspectorConfig.Harvester.InputType)
+
+	for {
+		p.prospectorer.Run(p.channel)
+		if !p.running {
+			break
+		}
+	}
+}
+
+func (p *Prospector) Stop() {
+	// TODO: Stopping is currently not implemented
 }
 
 // Setup Prospector Config
@@ -56,9 +106,6 @@ func (p *Prospector) setupProspectorConfig() error {
 	if err != nil {
 		return err
 	}
-
-	// Init File Stat list
-	p.prospectorList = make(map[string]harvester.FileStat)
 
 	if config.Harvester.InputType == cfg.LogInputType && len(config.Paths) == 0 {
 		return fmt.Errorf("No paths were defined for prospector")
@@ -131,332 +178,4 @@ func getConfigDuration(config string, duration time.Duration, name string) (time
 	logp.Info("Set %s duration to %s", name, duration)
 
 	return duration, nil
-}
-
-// Starts scanning through all the file paths and fetch the related files. Start a harvester for each file
-func (p *Prospector) Run(spoolChan chan *input.FileEvent) {
-
-	p.running = true
-
-	logp.Info("Starting prospector of type: %v", p.ProspectorConfig.Harvester.InputType)
-	switch p.ProspectorConfig.Harvester.InputType {
-	case cfg.StdinInputType:
-		p.stdinRun(spoolChan)
-		return
-	case cfg.LogInputType:
-		p.logRun(spoolChan)
-		return
-	}
-
-	logp.Info("Invalid prospector type: %v")
-}
-
-func (p *Prospector) logRun(spoolChan chan *input.FileEvent) {
-
-	// Seed last scan time
-	p.lastscan = time.Now()
-
-	logp.Debug("prospector", "exclude_files: %s", p.ProspectorConfig.ExcludeFiles)
-
-	// Now let's do one quick scan to pick up new files
-	for _, path := range p.ProspectorConfig.Paths {
-		p.scan(path, spoolChan)
-	}
-
-	// This signals we finished considering the previous state
-	event := &input.FileState{
-		Source: nil,
-	}
-	p.registrar.Persist <- event
-
-	for {
-		newlastscan := time.Now()
-
-		for _, path := range p.ProspectorConfig.Paths {
-			p.scan(path, spoolChan)
-		}
-
-		p.lastscan = newlastscan
-
-		// Defer next scan for the defined scanFrequency
-		time.Sleep(p.ProspectorConfig.ScanFrequencyDuration)
-		logp.Debug("prospector", "Start next scan")
-
-		// Clear out files that disappeared and we've stopped harvesting
-		for file, lastinfo := range p.prospectorList {
-			if lastinfo.Finished() && lastinfo.LastIteration < p.iteration {
-				delete(p.prospectorList, file)
-			}
-		}
-
-		p.iteration++ // Overflow is allowed
-
-		if !p.running {
-			break
-		}
-	}
-}
-
-func (p *Prospector) stdinRun(spoolChan chan *input.FileEvent) {
-	h, err := harvester.NewHarvester(
-		p.ProspectorConfig,
-		&p.ProspectorConfig.Harvester,
-		"-",
-		nil,
-		spoolChan,
-	)
-
-	if err != nil {
-		logp.Err("Error initializing stdin harvester: %v", err)
-		return
-	}
-
-	// This signals we finished considering the previous state
-	event := &input.FileState{
-		Source: nil,
-	}
-	p.registrar.Persist <- event
-
-	h.Start()
-
-	for {
-		if !p.running {
-			break
-		}
-		// Wait time during endless loop
-		oneSecond, _ := time.ParseDuration("1s")
-		time.Sleep(oneSecond)
-	}
-}
-
-func (p *Prospector) isFileExcluded(file string) bool {
-
-	config := &p.ProspectorConfig
-
-	if len(config.ExcludeFilesRegexp) > 0 {
-
-		if harvester.MatchAnyRegexps(config.ExcludeFilesRegexp, file) {
-			return true
-		}
-	}
-
-	return false
-}
-
-// Scans the specific path which can be a glob (/**/**/*.log)
-// For all found files it is checked if a harvester should be started
-func (p *Prospector) scan(path string, output chan *input.FileEvent) {
-
-	logp.Debug("prospector", "scan path %s", path)
-
-	// Evaluate the path as a wildcards/shell glob
-	matches, err := filepath.Glob(path)
-	if err != nil {
-		logp.Debug("prospector", "glob(%s) failed: %v", path, err)
-		return
-	}
-
-	p.missingFiles = map[string]os.FileInfo{}
-
-	// Check any matched files to see if we need to start a harvester
-	for _, file := range matches {
-		logp.Debug("prospector", "Check file for harvesting: %s", file)
-
-		// check if the file is in the exclude_files list
-		if p.isFileExcluded(file) {
-			logp.Debug("prospector", "Exclude file: %s", file)
-			continue
-		}
-
-		// Stat the file, following any symlinks.
-		fileinfo, err := os.Stat(file)
-
-		// TODO(sissel): check err
-		if err != nil {
-			logp.Debug("prospector", "stat(%s) failed: %s", file, err)
-			continue
-		}
-
-		newFile := input.File{
-			FileInfo: fileinfo,
-		}
-
-		if newFile.FileInfo.IsDir() {
-			logp.Debug("prospector", "Skipping directory: %s", file)
-			continue
-		}
-
-		// Check the current info against p.prospectorinfo[file]
-		lastinfo, isKnown := p.prospectorList[file]
-
-		oldFile := input.File{
-			FileInfo: lastinfo.Fileinfo,
-		}
-
-		// Create a new prospector info with the stat info for comparison
-		newInfo := harvester.NewFileStat(newFile.FileInfo, p.iteration)
-
-		// Conditions for starting a new harvester:
-		// - file path hasn't been seen before
-		// - the file's inode or device changed
-		if !isKnown {
-			p.checkNewFile(newInfo, file, output)
-		} else {
-			newInfo.Continue(&lastinfo)
-			p.checkExistingFile(newInfo, &newFile, &oldFile, file, output)
-		}
-
-		// Track the stat data for this file for later comparison to check for
-		// rotation/etc
-		p.prospectorList[file] = *newInfo
-	} // for each file matched by the glob
-}
-
-// Check if harvester for new file has to be started
-// For a new file the following options exist:
-func (p *Prospector) checkNewFile(newinfo *harvester.FileStat, file string, output chan *input.FileEvent) {
-
-	logp.Debug("prospector", "Start harvesting unknown file: %s", file)
-
-	// Init harvester with info
-	h, err := harvester.NewHarvester(
-		p.ProspectorConfig, &p.ProspectorConfig.Harvester, file, newinfo, output)
-	if err != nil {
-		logp.Err("Error initializing harvester: %v", err)
-		return
-	}
-
-	// Check for unmodified time, but only if the file modification time is before the last scan started
-	// This ensures we don't skip genuine creations with dead times less than 10s
-	if newinfo.Fileinfo.ModTime().Before(p.lastscan) &&
-		time.Since(newinfo.Fileinfo.ModTime()) > p.ProspectorConfig.IgnoreOlderDuration {
-
-		logp.Debug("prospector", "Fetching old state of file to resume: %s", file)
-		// Call crawler if there if there exists a state for the given file
-		offset, resuming := p.registrar.fetchState(file, newinfo.Fileinfo)
-
-		// Are we resuming a dead file? We have to resume even if dead so we catch any old updates to the file
-		// This is safe as the harvester, once it hits the EOF and a timeout, will stop harvesting
-		// Once we detect changes again we can resume another harvester again - this keeps number of go routines to a minimum
-		if resuming {
-			logp.Debug("prospector", "Resuming harvester on a previously harvested file: %s", file)
-
-			h.Offset = offset
-			h.Start()
-		} else {
-			// Old file, skip it, but push offset of file size so we start from the end if this file changes and needs picking up
-			logp.Debug("prospector", "Skipping file (older than ignore older of %v, %v): %s",
-				p.ProspectorConfig.IgnoreOlderDuration,
-				time.Since(newinfo.Fileinfo.ModTime()),
-				file)
-			newinfo.Skip(newinfo.Fileinfo.Size())
-		}
-	} else if previousFile, err := p.getPreviousFile(file, newinfo.Fileinfo); err == nil {
-		// This file was simply renamed (known inode+dev) - link the same harvester channel as the old file
-		logp.Debug("prospector", "File rename was detected: %s -> %s", previousFile, file)
-		lastinfo := p.prospectorList[previousFile]
-		newinfo.Continue(&lastinfo)
-	} else {
-
-		// Call crawler if there if there exists a state for the given file
-		offset, resuming := p.registrar.fetchState(file, newinfo.Fileinfo)
-
-		// Are we resuming a file or is this a completely new file?
-		if resuming {
-			logp.Debug("prospector", "Resuming harvester on a previously harvested file: %s", file)
-		} else {
-			logp.Debug("prospector", "Launching harvester on new file: %s", file)
-		}
-
-		// Launch the harvester
-		h.Offset = offset
-		h.Start()
-	}
-}
-
-// checkExistingFile checks if a harvester has to be started for a already known file
-// For existing files the following options exist:
-// * Last reading position is 0, no harvester has to be started as old harvester probably still busy
-// * The old known modification time is older then the current one. Start at last known position
-// * The new file is not the same as the old file, means file was renamed
-// ** New file is actually really a new file, start a new harvester
-// ** Renamed file has a state, continue there
-func (p *Prospector) checkExistingFile(newinfo *harvester.FileStat, newFile *input.File, oldFile *input.File, file string, output chan *input.FileEvent) {
-
-	logp.Debug("prospector", "Update existing file for harvesting: %s", file)
-
-	h, err := harvester.NewHarvester(
-		p.ProspectorConfig, &p.ProspectorConfig.Harvester,
-		file, newinfo, output)
-	if err != nil {
-		logp.Err("Error initializing harvester: %v", err)
-		return
-	}
-
-	if !oldFile.IsSameFile(newFile) {
-
-		if previousFile, err := p.getPreviousFile(file, newinfo.Fileinfo); err == nil {
-			// This file was renamed from another file we know - link the same harvester channel as the old file
-			logp.Debug("prospector", "File rename was detected: %s -> %s", previousFile, file)
-			logp.Debug("prospector", "Launching harvester on renamed file: %s", file)
-
-			lastinfo := p.prospectorList[previousFile]
-			newinfo.Continue(&lastinfo)
-		} else {
-			// File is not the same file we saw previously, it must have rotated and is a new file
-			logp.Debug("prospector", "Launching harvester on rotated file: %s", file)
-
-			// Forget about the previous harvester and let it continue on the old file - so start a new channel to use with the new harvester
-			newinfo.Ignore()
-
-			// Start a new harvester on the path
-			h.Start()
-		}
-
-		// Keep the old file in missingFiles so we don't rescan it if it was renamed and we've not yet reached the new filename
-		// We only need to keep it for the remainder of this iteration then we can assume it was deleted and forget about it
-		p.missingFiles[file] = oldFile.FileInfo
-
-	} else if newinfo.Finished() && oldFile.FileInfo.ModTime() != newinfo.Fileinfo.ModTime() {
-		// Resume harvesting of an old file we've stopped harvesting from
-		logp.Debug("prospector", "Resuming harvester on an old file that was just modified: %s", file)
-
-		// Start a harvester on the path; an old file was just modified and it doesn't have a harvester
-		// The offset to continue from will be stored in the harvester channel - so take that to use and also clear the channel
-		h.Offset = <-newinfo.Return
-		h.Start()
-	} else {
-		logp.Debug("prospector", "Not harvesting, file didn't change: %s", file)
-	}
-}
-
-func (p *Prospector) Stop() {
-	// TODO: Stopping is currently not implemented
-}
-
-// Check if the given file was renamed. If file is known but with different path,
-// the previous file path will be returned. If no file is found, an error
-// will be returned.
-func (p *Prospector) getPreviousFile(file string, info os.FileInfo) (string, error) {
-
-	for path, pFileStat := range p.prospectorList {
-		if path == file {
-			continue
-		}
-
-		if os.SameFile(info, pFileStat.Fileinfo) {
-			return path, nil
-		}
-	}
-
-	// Now check the missingfiles
-	for path, fileInfo := range p.missingFiles {
-
-		if os.SameFile(info, fileInfo) {
-			return path, nil
-		}
-	}
-
-	// NOTE(ruflin): should instead an error be returned if not previous file?
-	return "", fmt.Errorf("No previous file found")
 }

--- a/filebeat/crawler/prospector_log.go
+++ b/filebeat/crawler/prospector_log.go
@@ -1,0 +1,303 @@
+package crawler
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	cfg "github.com/elastic/beats/filebeat/config"
+	"github.com/elastic/beats/filebeat/harvester"
+	"github.com/elastic/beats/filebeat/input"
+	"github.com/elastic/beats/libbeat/logp"
+)
+
+type ProspectorLog struct {
+	Prospector *Prospector
+
+	iteration      uint32
+	lastscan       time.Time
+	missingFiles   map[string]os.FileInfo
+	prospectorList map[string]harvester.FileStat
+	config         cfg.ProspectorConfig
+	channel        chan *input.FileEvent
+	registrar      *Registrar
+}
+
+func NewProspectorLog(config cfg.ProspectorConfig, channel chan *input.FileEvent, registrar *Registrar) (*ProspectorLog, error) {
+
+	prospectorer := &ProspectorLog{
+		config:    config,
+		channel:   channel,
+		registrar: registrar,
+	}
+
+	// Init File Stat list
+	prospectorer.prospectorList = make(map[string]harvester.FileStat)
+
+	return prospectorer, nil
+}
+
+func (prospector ProspectorLog) Init() {
+
+	// Seed last scan time
+	prospector.lastscan = time.Now()
+
+	logp.Debug("prospector", "exclude_files: %s", prospector.config.ExcludeFiles)
+
+	// Now let's do one quick scan to pick up new files
+	for _, path := range prospector.config.Paths {
+		prospector.scan(path, prospector.channel)
+	}
+}
+
+func (prospector ProspectorLog) Run(spoolChan chan *input.FileEvent) {
+
+	newlastscan := time.Now()
+
+	for _, path := range prospector.config.Paths {
+		prospector.scan(path, spoolChan)
+	}
+
+	prospector.lastscan = newlastscan
+
+	// Defer next scan for the defined scanFrequency
+	time.Sleep(prospector.config.ScanFrequencyDuration)
+	logp.Debug("prospector", "Start next scan")
+
+	// Clear out files that disappeared and we've stopped harvesting
+	for file, lastinfo := range prospector.prospectorList {
+		if lastinfo.Finished() && lastinfo.LastIteration < prospector.iteration {
+			delete(prospector.prospectorList, file)
+		}
+	}
+
+	prospector.iteration++ // Overflow is allowed
+
+}
+
+// Scans the specific path which can be a glob (/**/**/*.log)
+// For all found files it is checked if a harvester should be started
+func (prospector ProspectorLog) scan(path string, output chan *input.FileEvent) {
+
+	logp.Debug("prospector", "scan path %s", path)
+
+	// Evaluate the path as a wildcards/shell glob
+	matches, err := filepath.Glob(path)
+	if err != nil {
+		logp.Debug("prospector", "glob(%s) failed: %v", path, err)
+		return
+	}
+
+	prospector.missingFiles = map[string]os.FileInfo{}
+
+	// Check any matched files to see if we need to start a harvester
+	for _, file := range matches {
+		logp.Debug("prospector", "Check file for harvesting: %s", file)
+
+		// check if the file is in the exclude_files list
+		if prospector.isFileExcluded(file) {
+			logp.Debug("prospector", "Exclude file: %s", file)
+			continue
+		}
+
+		// Stat the file, following any symlinks.
+		fileinfo, err := os.Stat(file)
+
+		// TODO(sissel): check err
+		if err != nil {
+			logp.Debug("prospector", "stat(%s) failed: %s", file, err)
+			continue
+		}
+
+		newFile := input.File{
+			FileInfo: fileinfo,
+		}
+
+		if newFile.FileInfo.IsDir() {
+			logp.Debug("prospector", "Skipping directory: %s", file)
+			continue
+		}
+
+		// Check the current info against p.prospectorinfo[file]
+		lastinfo, isKnown := prospector.prospectorList[file]
+
+		oldFile := input.File{
+			FileInfo: lastinfo.Fileinfo,
+		}
+
+		// Create a new prospector info with the stat info for comparison
+		newInfo := harvester.NewFileStat(newFile.FileInfo, prospector.iteration)
+
+		// Conditions for starting a new harvester:
+		// - file path hasn't been seen before
+		// - the file's inode or device changed
+		if !isKnown {
+			prospector.checkNewFile(newInfo, file, output)
+		} else {
+			newInfo.Continue(&lastinfo)
+			prospector.checkExistingFile(newInfo, &newFile, &oldFile, file, output)
+		}
+
+		// Track the stat data for this file for later comparison to check for
+		// rotation/etc
+		prospector.prospectorList[file] = *newInfo
+	} // for each file matched by the glob
+}
+
+// Check if harvester for new file has to be started
+// For a new file the following options exist:
+func (prospector ProspectorLog) checkNewFile(newinfo *harvester.FileStat, file string, output chan *input.FileEvent) {
+
+	logp.Debug("prospector", "Start harvesting unknown file: %s", file)
+
+	// Init harvester with info
+	h, err := harvester.NewHarvester(
+		prospector.config, &prospector.config.Harvester, file, newinfo, output)
+	if err != nil {
+		logp.Err("Error initializing harvester: %v", err)
+		return
+	}
+
+	// Check for unmodified time, but only if the file modification time is before the last scan started
+	// This ensures we don't skip genuine creations with dead times less than 10s
+	if newinfo.Fileinfo.ModTime().Before(prospector.lastscan) &&
+		time.Since(newinfo.Fileinfo.ModTime()) > prospector.config.IgnoreOlderDuration {
+
+		logp.Debug("prospector", "Fetching old state of file to resume: %s", file)
+		// Call crawler if there if there exists a state for the given file
+		offset, resuming := prospector.registrar.fetchState(file, newinfo.Fileinfo)
+
+		// Are we resuming a dead file? We have to resume even if dead so we catch any old updates to the file
+		// This is safe as the harvester, once it hits the EOF and a timeout, will stop harvesting
+		// Once we detect changes again we can resume another harvester again - this keeps number of go routines to a minimum
+		if resuming {
+			logp.Debug("prospector", "Resuming harvester on a previously harvested file: %s", file)
+
+			h.Offset = offset
+			h.Start()
+		} else {
+			// Old file, skip it, but push offset of file size so we start from the end if this file changes and needs picking up
+			logp.Debug("prospector", "Skipping file (older than ignore older of %v, %v): %s",
+				prospector.config.IgnoreOlderDuration,
+				time.Since(newinfo.Fileinfo.ModTime()),
+				file)
+			newinfo.Skip(newinfo.Fileinfo.Size())
+		}
+	} else if previousFile, err := prospector.getPreviousFile(file, newinfo.Fileinfo); err == nil {
+		// This file was simply renamed (known inode+dev) - link the same harvester channel as the old file
+		logp.Debug("prospector", "File rename was detected: %s -> %s", previousFile, file)
+		lastinfo := prospector.prospectorList[previousFile]
+		newinfo.Continue(&lastinfo)
+	} else {
+
+		// Call crawler if there if there exists a state for the given file
+		offset, resuming := prospector.registrar.fetchState(file, newinfo.Fileinfo)
+
+		// Are we resuming a file or is this a completely new file?
+		if resuming {
+			logp.Debug("prospector", "Resuming harvester on a previously harvested file: %s", file)
+		} else {
+			logp.Debug("prospector", "Launching harvester on new file: %s", file)
+		}
+
+		// Launch the harvester
+		h.Offset = offset
+		h.Start()
+	}
+}
+
+// checkExistingFile checks if a harvester has to be started for a already known file
+// For existing files the following options exist:
+// * Last reading position is 0, no harvester has to be started as old harvester probably still busy
+// * The old known modification time is older then the current one. Start at last known position
+// * The new file is not the same as the old file, means file was renamed
+// ** New file is actually really a new file, start a new harvester
+// ** Renamed file has a state, continue there
+func (prospector ProspectorLog) checkExistingFile(newinfo *harvester.FileStat, newFile *input.File, oldFile *input.File, file string, output chan *input.FileEvent) {
+
+	logp.Debug("prospector", "Update existing file for harvesting: %s", file)
+
+	h, err := harvester.NewHarvester(
+		prospector.config, &prospector.config.Harvester,
+		file, newinfo, output)
+	if err != nil {
+		logp.Err("Error initializing harvester: %v", err)
+		return
+	}
+
+	if !oldFile.IsSameFile(newFile) {
+
+		if previousFile, err := prospector.getPreviousFile(file, newinfo.Fileinfo); err == nil {
+			// This file was renamed from another file we know - link the same harvester channel as the old file
+			logp.Debug("prospector", "File rename was detected: %s -> %s", previousFile, file)
+			logp.Debug("prospector", "Launching harvester on renamed file: %s", file)
+
+			lastinfo := prospector.prospectorList[previousFile]
+			newinfo.Continue(&lastinfo)
+		} else {
+			// File is not the same file we saw previously, it must have rotated and is a new file
+			logp.Debug("prospector", "Launching harvester on rotated file: %s", file)
+
+			// Forget about the previous harvester and let it continue on the old file - so start a new channel to use with the new harvester
+			newinfo.Ignore()
+
+			// Start a new harvester on the path
+			h.Start()
+		}
+
+		// Keep the old file in missingFiles so we don't rescan it if it was renamed and we've not yet reached the new filename
+		// We only need to keep it for the remainder of this iteration then we can assume it was deleted and forget about it
+		prospector.missingFiles[file] = oldFile.FileInfo
+
+	} else if newinfo.Finished() && oldFile.FileInfo.ModTime() != newinfo.Fileinfo.ModTime() {
+		// Resume harvesting of an old file we've stopped harvesting from
+		logp.Debug("prospector", "Resuming harvester on an old file that was just modified: %s", file)
+
+		// Start a harvester on the path; an old file was just modified and it doesn't have a harvester
+		// The offset to continue from will be stored in the harvester channel - so take that to use and also clear the channel
+		h.Offset = <-newinfo.Return
+		h.Start()
+	} else {
+		logp.Debug("prospector", "Not harvesting, file didn't change: %s", file)
+	}
+}
+
+// Check if the given file was renamed. If file is known but with different path,
+// the previous file path will be returned. If no file is found, an error
+// will be returned.
+func (prospector ProspectorLog) getPreviousFile(file string, info os.FileInfo) (string, error) {
+
+	for path, pFileStat := range prospector.prospectorList {
+		if path == file {
+			continue
+		}
+
+		if os.SameFile(info, pFileStat.Fileinfo) {
+			return path, nil
+		}
+	}
+
+	// Now check the missingfiles
+	for path, fileInfo := range prospector.missingFiles {
+
+		if os.SameFile(info, fileInfo) {
+			return path, nil
+		}
+	}
+
+	// NOTE(ruflin): should instead an error be returned if not previous file?
+	return "", fmt.Errorf("No previous file found")
+}
+
+func (prospector ProspectorLog) isFileExcluded(file string) bool {
+
+	if len(prospector.config.ExcludeFilesRegexp) > 0 {
+
+		if harvester.MatchAnyRegexps(prospector.config.ExcludeFilesRegexp, file) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/filebeat/crawler/prospector_stdin.go
+++ b/filebeat/crawler/prospector_stdin.go
@@ -1,0 +1,53 @@
+package crawler
+
+import (
+	"fmt"
+	"time"
+
+	cfg "github.com/elastic/beats/filebeat/config"
+	"github.com/elastic/beats/filebeat/harvester"
+	"github.com/elastic/beats/filebeat/input"
+)
+
+type ProspectorStdin struct {
+	Prospector *Prospector
+	harvester  *harvester.Harvester
+	started    bool
+}
+
+func NewProspectorStdin(config cfg.ProspectorConfig, channel chan *input.FileEvent) (*ProspectorStdin, error) {
+
+	prospectorer := &ProspectorStdin{}
+
+	var err error
+	prospectorer.harvester, err = harvester.NewHarvester(
+		config,
+		&config.Harvester,
+		"-",
+		nil,
+		channel,
+	)
+
+	if err != nil {
+		return nil, fmt.Errorf("Error initializing stdin harvester: %v", err)
+	}
+
+	return prospectorer, nil
+}
+
+func (p ProspectorStdin) Init() {
+	p.started = false
+}
+
+func (prospector ProspectorStdin) Run(spoolChan chan *input.FileEvent) {
+
+	// Make sure stdin harvester is only started once
+	if !prospector.started {
+		prospector.harvester.Start()
+	}
+
+	// Wait time during endless loop
+	oneSecond, _ := time.ParseDuration("1s")
+	time.Sleep(oneSecond)
+
+}

--- a/filebeat/crawler/prospector_test.go
+++ b/filebeat/crawler/prospector_test.go
@@ -204,8 +204,9 @@ func TestProspectorFileExclude(t *testing.T) {
 	}
 
 	prospector.Init()
+	prospectorer := prospector.prospectorer.(*ProspectorLog)
 
-	assert.True(t, prospector.isFileExcluded("/tmp/log/logw.gz"))
-	assert.False(t, prospector.isFileExcluded("/tmp/log/logw.log"))
+	assert.True(t, prospectorer.isFileExcluded("/tmp/log/logw.gz"))
+	assert.False(t, prospectorer.isFileExcluded("/tmp/log/logw.log"))
 
 }


### PR DESCRIPTION
The goal is to simplify the prospector handling and making extending easier.