### PR TITLE
Update getting started to include link to apt and yum repositories

### DIFF
--- a/filebeat/docs/getting-started.asciidoc
+++ b/filebeat/docs/getting-started.asciidoc
@@ -16,8 +16,14 @@ To download and install Filebeat, use the commands that work with your system
 (<<deb, deb>> for Debian/Ubuntu, <<rpm, rpm>> for Redhat/Centos/Fedora, <<mac,
 mac>> for OS X, and <<win, win>> for Windows).
 
-NOTE: We also provide 32-bit images that you can get from our
-https://www.elastic.co/downloads/beats/filebeat[download page].
+.Other Installation Options
+[NOTE]
+===============================
+We also provide 32-bit images that you can get from our
+https://www.elastic.co/downloads/beats/filebeat[download page]. 
+
+Or you can install Filebeat from our {libbeat}/setup-repositories.html[repositories] using apt or yum.
+===============================
 
 [[deb]]
 *deb:*

--- a/packetbeat/docs/gettingstarted.asciidoc
+++ b/packetbeat/docs/gettingstarted.asciidoc
@@ -19,8 +19,14 @@ To download and install Packetbeat on your application servers, use the commands
 that work with your system (<<deb, deb>> for Debian/Ubuntu, <<rpm, rpm>> for
 Redhat/Centos/Fedora, <<mac, mac>> for OS X, and <<win, win>> for Windows).
 
-NOTE: We also provide 32-bit images that you can get from our
-https://www.elastic.co/downloads/beats/packetbeat[download page].
+.Other Installation Options
+[NOTE]
+===============================
+We also provide 32-bit images that you can get from our
+https://www.elastic.co/downloads/beats/packetbeat[download page]. 
+
+Or you can install Packetbeat from our {libbeat}/setup-repositories.html[repositories] using apt or yum.
+===============================
 
 [[deb]]
 *deb:*

--- a/topbeat/docs/gettingstarted.asciidoc
+++ b/topbeat/docs/gettingstarted.asciidoc
@@ -20,8 +20,14 @@ To download and install Topbeat, use the commands that work with your system
 (<<deb, deb>> for Debian/Ubuntu, <<rpm, rpm>> for Redhat/Centos/Fedora, <<mac,
 mac>> for OS X, and <<win, win>> for Windows).
 
-NOTE: We also provide 32-bit images that you can get from our
-https://www.elastic.co/downloads/beats/topbeat[download page].
+.Other Installation Options
+[NOTE]
+===============================
+We also provide 32-bit images that you can get from our
+https://www.elastic.co/downloads/beats/topbeat[download page]. 
+
+Or you can install Topbeat from our {libbeat}/setup-repositories.html[repositories] using apt or yum.
+===============================
 
 [[deb]]
 *deb:*


### PR DESCRIPTION
Closes https://github.com/elastic/topbeat/issues/135. Added the link to the getting started topics for Topbeat, Filebeat, and Packetbeat.