### PR TITLE
Accept pf_ring or pfring in Packetbeat configuration

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -33,6 +33,7 @@ https://github.com/elastic/beats/compare/1.0.0...master[Check the HEAD diff]
 
 *Packetbeat*
 - Fix setting direction to out and use its value to decide when dropping events if ignore_outgoing is enabled {pull}557[557]
+- Allow PF_RING sniffer type to be configured using pf_ring or pfring {pull}671[671]
 
 *Topbeat*
 

--- a/packetbeat/sniffer/sniffer.go
+++ b/packetbeat/sniffer/sniffer.go
@@ -182,7 +182,7 @@ func (sniffer *SnifferSetup) setFromConfig(config *config.InterfacesConfig) erro
 		}
 
 		sniffer.DataSource = gopacket.PacketDataSource(sniffer.afpacketHandle)
-	case "pfring":
+	case "pfring", "pf_ring":
 		sniffer.pfringHandle, err = NewPfringHandle(
 			sniffer.config.Device,
 			sniffer.config.Snaplen,
@@ -371,7 +371,7 @@ func (sniffer *SnifferSetup) Close() error {
 		sniffer.pcapHandle.Close()
 	case "af_packet":
 		sniffer.afpacketHandle.Close()
-	case "pfring":
+	case "pfring", "pf_ring":
 		sniffer.pfringHandle.Close()
 	}
 	return nil


### PR DESCRIPTION
The [documentation](https://www.elastic.co/guide/en/beats/packetbeat/current/packetbeat-configuration.html#_type) says to use `type: pf_ring` but the code only accepts `type: pfring`. This change allows the code to accept either `pfring` or `pf_ring` (to not break existing config).

`packetbeat.go:202: CRIT Initializing sniffer failed: Error creating sniffer: Unknown sniffer type: pf_ring`