### PR TITLE
Enhancing Winlogbeat docs

### DIFF
--- a/filebeat/docs/getting-started.asciidoc
+++ b/filebeat/docs/getting-started.asciidoc
@@ -72,7 +72,7 @@ PS > cd 'C:\Program Files\Filebeat'
 PS C:\Program Files\Filebeat> .\install-service-filebeat.ps1
 ----------------------------------------------------------------------
 
-NOTE: If script execution is disabled on your system, you need to set the execution policy for the current session to allow the script to run. For example: `PowerShell.exe -ExecutionPolicy RemoteSigned -File .\install-service-filebeat.ps1`. 
+NOTE: If script execution is disabled on your system, you need to set the execution policy for the current session to allow the script to run. For example: `PowerShell.exe -ExecutionPolicy UnRestricted -File .\install-service-filebeat.ps1`. 
 
 Before starting Filebeat, you should look at the configuration options in the configuration
 file, for example `C:\Program Files\Filebeat\filebeat.yml`. For more information about these options,

--- a/packetbeat/docs/gettingstarted.asciidoc
+++ b/packetbeat/docs/gettingstarted.asciidoc
@@ -81,7 +81,7 @@ PS > cd 'C:\Program Files\Packetbeat'
 PS C:\Program Files\Packetbeat> .\install-service-packetbeat.ps1
 ----------------------------------------------------------------------
 
-NOTE: If script execution is disabled on your system, you need to set the execution policy for the current session to allow the script to run. For example: `PowerShell.exe -ExecutionPolicy RemoteSigned -File .\install-service-packetbeat.ps1`. 
+NOTE: If script execution is disabled on your system, you need to set the execution policy for the current session to allow the script to run. For example: `PowerShell.exe -ExecutionPolicy UnRestricted -File .\install-service-packetbeat.ps1`. 
 
 Before starting Packetbeat, you should look at the configuration options in the
 configuration file, for example `C:\Program Files\Packetbeat\packetbeat.yml`. For

--- a/topbeat/docs/gettingstarted.asciidoc
+++ b/topbeat/docs/gettingstarted.asciidoc
@@ -76,7 +76,7 @@ PS > cd 'C:\Program Files\Topbeat'
 PS C:\Program Files\Topbeat> .\install-service-topbeat.ps1
 ----------------------------------------------------------------------
 
-NOTE: If script execution is disabled on your system, you need to set the execution policy for the current session to allow the script to run. For example: `PowerShell.exe -ExecutionPolicy RemoteSigned -File .\install-service-topbeat.ps1`. 
+NOTE: If script execution is disabled on your system, you need to set the execution policy for the current session to allow the script to run. For example: `PowerShell.exe -ExecutionPolicy UnRestricted -File .\install-service-topbeat.ps1`. 
 
 Before starting Topbeat, you should look at the configuration options in the configuration file,
 for example `C:\Program Files\Topbeat\topbeat.yml`. For more information about these options, see <<topbeat-configuration-options>>.

--- a/winlogbeat/docs/configuration.asciidoc
+++ b/winlogbeat/docs/configuration.asciidoc
@@ -67,12 +67,59 @@ winlogbeat:
     - name: Application
 --------------------------------------------------------------------------------
 
+[[configuration-winlogbeat-options-event_logs-name]]
 ===== event_logs.name
 
 The name of the event log to monitor. Each dictionary under `event_logs` must
 have a `name` field. You can get a list of available event logs by running
-`Get-EventLog *` in PowerShell. Alternatively, you can look at the registry keys
-found under `HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\eventlog`.
+`Get-EventLog *` in PowerShell.  Here is a sample of the output from the command:
+
+[source,sh]
+--------------------------------------------------------------------------------
+PS C:\Users\vagrant> Get-EventLog *
+
+  Max(K) Retain OverflowAction        Entries Log
+  ------ ------ --------------        ------- ---
+  20,480      0 OverwriteAsNeeded          75 Application
+  20,480      0 OverwriteAsNeeded           0 HardwareEvents
+     512      7 OverwriteOlder              0 Internet Explorer
+  20,480      0 OverwriteAsNeeded           0 Key Management Service
+  20,480      0 OverwriteAsNeeded       1,609 Security
+  20,480      0 OverwriteAsNeeded       1,184 System
+  15,360      0 OverwriteAsNeeded         464 Windows PowerShell
+--------------------------------------------------------------------------------
+
+Channel names can also be specified if running on Windows Vista or newer.
+A channel is a named stream of events that transports events from an event
+source to an event log. Most channels are tied to specific event publishers.
+Here is an example showing how to list all channels using PowerShell.
+
+[source,sh]
+--------------------------------------------------------------------------------
+PS C:\> Get-WinEvent -ListLog * | Format-List -Property LogName
+LogName : Application
+LogName : HardwareEvents
+LogName : Internet Explorer
+LogName : Key Management Service
+LogName : Security
+LogName : System
+LogName : Windows PowerShell
+LogName : ForwardedEvents
+LogName : Microsoft-Management-UI/Admin
+LogName : Microsoft-Rdms-UI/Admin
+LogName : Microsoft-Rdms-UI/Operational
+LogName : Microsoft-Windows-Windows Firewall With Advanced Security/Firewall
+...
+--------------------------------------------------------------------------------
+
+You must specify the full name of the channel in the configuration file.
+
+[source,yaml]
+--------------------------------------------------------------------------------
+winlogbeat:
+  event_logs:
+    - name: Microsoft-Windows-Windows Firewall With Advanced Security/Firewall
+--------------------------------------------------------------------------------
 
 ===== event_logs.ignore_older
 

--- a/winlogbeat/docs/fields.asciidoc
+++ b/winlogbeat/docs/fields.asciidoc
@@ -166,6 +166,8 @@ required: False
 
 The Windows security identifier (SID) of the account associated with this event.
 
+If Winlogbeat cannot resolve the SID to a name, then the `user.name`, `user.domain`, and `user.type` fields will be omitted from the event. If you discover Winlogbeat not resolving SIDs, review the log for clues as to what the problem may be.
+
 
 ==== user.name
 

--- a/winlogbeat/docs/getting-started.asciidoc
+++ b/winlogbeat/docs/getting-started.asciidoc
@@ -36,7 +36,9 @@ Status   Name               DisplayName
 Stopped  winlogbeat         winlogbeat
 ------------------------------------------------
 
-NOTE: If script execution is disabled on your system, you need to set the execution policy for the current session to allow the script to run. For example: `PowerShell.exe -ExecutionPolicy RemoteSigned -File .\install-service-winlogbeat.ps1`. 
+NOTE: If script execution is disabled on your system, you need to set the
+execution policy for the current session to allow the script to run. For example:
+`PowerShell.exe -ExecutionPolicy UnRestricted -File .\install-service-winlogbeat.ps1`.
 
 Before starting Winlogbeat, you should look at the configuration options in the
 configuration file, for example `C:\Program Files\Winlogbeat\winlogbeat.yml`.
@@ -70,11 +72,15 @@ logging:
   level: info
 --------------------------------------------------------------------------------
 
+For instructions on how to obtain a list of available event logs see the
+configuration details for
+<<configuration-winlogbeat-options-event_logs-name,event_logs.name>>.
+
 After you save your configuration file, test it with the following command.
 
 [source,shell]
 ----------------------------------------------------------------------
-PS C:\Program Files\Winlogbeat> .\winlogbeat.exe -c .\winlogbeat.yml -configtest
+PS C:\Program Files\Winlogbeat> .\winlogbeat.exe -c .\winlogbeat.yml -configtest -e
 ----------------------------------------------------------------------
 
 === Configuring Winlogbeat to Use Logstash

--- a/winlogbeat/docs/overview.asciidoc
+++ b/winlogbeat/docs/overview.asciidoc
@@ -3,11 +3,12 @@
 Winlogbeat ships Windows event logs to Elasticsearch or Logstash. You can
 install it as a Windows service on Windows XP or later.
 
-Winlogbeat reads from one or more event logs, filters the events based on
-user-configured criteria, then sends the event data to the configured outputs
-(Elasticsearch or Logstash). Winlogbeat watches the event logs so that new event
-data is sent in a timely manner. The read position for each event log is
-persisted to disk to allow Winlogbeat to resume after restarts.
+Winlogbeat reads from one or more event logs using Windows APIs, filters the
+events based on user-configured criteria, then sends the event data to the
+configured outputs (Elasticsearch or Logstash). Winlogbeat watches the event
+logs so that new event data is sent in a timely manner. The read position for
+each event log is persisted to disk to allow Winlogbeat to resume after
+restarts.
 
 Winlogbeat can capture event data from any event logs running
 on your system. For example, you can capture events such as:

--- a/winlogbeat/etc/fields.yml
+++ b/winlogbeat/etc/fields.yml
@@ -136,6 +136,12 @@ eventlog:
         The Windows security identifier (SID) of the account associated with
         this event.
 
+
+        If Winlogbeat cannot resolve the SID to a name, then the `user.name`,
+        `user.domain`, and `user.type` fields will be omitted from the event.
+        If you discover Winlogbeat not resolving SIDs, review the log for
+        clues as to what the problem may be.
+
     - name: user.name
       type: string
       required: false


### PR DESCRIPTION
- Changed RemoteSigned to UnRestricted because I found a case where RemoteSigned didn't work
- Added details on how to use list event log channels and configure them
- Added a note to the SID field explaining why user.name, user.domain, user.type may not be present