### PR TITLE
Publisher options cleanup

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -13,6 +13,7 @@ https://github.com/elastic/beats/compare/1.0.0...master[Check the HEAD diff]
 ==== Breaking changes
 
 *Affecting all Beats*
+- Some publisher options refactoring in libbeat {pull}684[684]
 
 *Packetbeat*
 

--- a/filebeat/beat/filebeat.go
+++ b/filebeat/beat/filebeat.go
@@ -125,7 +125,7 @@ func Publish(beat *beat.Beat, fb *Filebeat) {
 			pubEvents = append(pubEvents, event.ToMapStr())
 		}
 
-		beat.Events.PublishEvents(pubEvents, publisher.Sync)
+		beat.Events.PublishEvents(pubEvents, publisher.Sync, publisher.Guaranteed)
 
 		logp.Info("Events sent: %d", len(events))
 

--- a/libbeat/outputs/console/console.go
+++ b/libbeat/outputs/console/console.go
@@ -3,7 +3,6 @@ package console
 import (
 	"encoding/json"
 	"os"
-	"time"
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
@@ -47,7 +46,7 @@ func writeBuffer(buf []byte) error {
 
 func (c *console) PublishEvent(
 	s outputs.Signaler,
-	ts time.Time,
+	opts outputs.Options,
 	event common.MapStr,
 ) error {
 	var jsonEvent []byte
@@ -74,6 +73,9 @@ func (c *console) PublishEvent(
 	outputs.SignalCompleted(s)
 	return nil
 fail:
+	if opts.Guaranteed {
+		logp.Critical("Unable to publish events to console: %v", err)
+	}
 	outputs.SignalFailed(s, err)
 	return err
 }

--- a/libbeat/outputs/console/console_test.go
+++ b/libbeat/outputs/console/console_test.go
@@ -5,9 +5,9 @@ import (
 	"io"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/outputs"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -47,7 +47,7 @@ func event(k, v string) common.MapStr {
 func run(c *console, events ...common.MapStr) (string, error) {
 	return withStdout(func() {
 		for _, event := range events {
-			c.PublishEvent(nil, time.Now(), event)
+			c.PublishEvent(nil, outputs.Options{}, event)
 		}
 	})
 }

--- a/libbeat/outputs/elasticsearch/api_integration_test.go
+++ b/libbeat/outputs/elasticsearch/api_integration_test.go
@@ -32,7 +32,7 @@ func TestIndex(t *testing.T) {
 	}
 	_, resp, err := client.Index(index, "test", "1", params, body)
 	if err != nil {
-		t.Errorf("Index() returns error: %s", err)
+		t.Fatalf("Index() returns error: %s", err)
 	}
 	if !resp.Created {
 		t.Errorf("Index() fails: %s", resp)

--- a/libbeat/outputs/elasticsearch/output.go
+++ b/libbeat/outputs/elasticsearch/output.go
@@ -180,16 +180,16 @@ func makeClientFactory(
 
 func (out *elasticsearchOutput) PublishEvent(
 	signaler outputs.Signaler,
-	ts time.Time,
+	opts outputs.Options,
 	event common.MapStr,
 ) error {
-	return out.mode.PublishEvent(signaler, event)
+	return out.mode.PublishEvent(signaler, opts, event)
 }
 
 func (out *elasticsearchOutput) BulkPublish(
 	trans outputs.Signaler,
-	ts time.Time,
+	opts outputs.Options,
 	events []common.MapStr,
 ) error {
-	return out.mode.PublishEvents(trans, events)
+	return out.mode.PublishEvents(trans, opts, events)
 }

--- a/libbeat/outputs/elasticsearch/output_test.go
+++ b/libbeat/outputs/elasticsearch/output_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/elastic/beats/libbeat/outputs"
 )
 
+var testOptions = outputs.Options{}
+
 func createElasticsearchConnection(flushInterval int, bulkSize int) elasticsearchOutput {
 	index := fmt.Sprintf("packetbeat-unittest-%d", os.Getpid())
 
@@ -117,7 +119,7 @@ func TestOneEvent(t *testing.T) {
 		},
 	})
 
-	err := output.PublishEvent(nil, ts, event)
+	err := output.PublishEvent(nil, testOptions, event)
 	if err != nil {
 		t.Errorf("Failed to publish the event: %s", err)
 	}
@@ -189,7 +191,7 @@ func TestEvents(t *testing.T) {
 		},
 	})
 
-	err := output.PublishEvent(nil, ts, event)
+	err := output.PublishEvent(nil, testOptions, event)
 	if err != nil {
 		t.Errorf("Failed to publish the event: %s", err)
 	}
@@ -199,7 +201,7 @@ func TestEvents(t *testing.T) {
 	r["response"] = 0
 	event["redis"] = r
 
-	err = output.PublishEvent(nil, ts, event)
+	err = output.PublishEvent(nil, testOptions, event)
 	if err != nil {
 		t.Errorf("Failed to publish the event: %s", err)
 	}
@@ -259,7 +261,7 @@ func testBulkWithParams(t *testing.T, output elasticsearchOutput) {
 		r["response"] = "value" + strconv.Itoa(i)
 		event["redis"] = r
 
-		err := output.PublishEvent(nil, ts, event)
+		err := output.PublishEvent(nil, testOptions, event)
 		if err != nil {
 			t.Errorf("Failed to publish the event: %s", err)
 		}

--- a/libbeat/outputs/logstash/logstash.go
+++ b/libbeat/outputs/logstash/logstash.go
@@ -150,24 +150,24 @@ func makeClientFactory(
 //       send/receive overhead per event for other implementors too.
 func (lj *logstash) PublishEvent(
 	signaler outputs.Signaler,
-	ts time.Time,
+	opts outputs.Options,
 	event common.MapStr,
 ) error {
 	lj.addMeta(event)
-	return lj.mode.PublishEvent(signaler, event)
+	return lj.mode.PublishEvent(signaler, opts, event)
 }
 
 // BulkPublish implements the BulkOutputer interface pushing a bulk of events
 // via lumberjack.
 func (lj *logstash) BulkPublish(
 	trans outputs.Signaler,
-	ts time.Time,
+	opts outputs.Options,
 	events []common.MapStr,
 ) error {
 	for _, event := range events {
 		lj.addMeta(event)
 	}
-	return lj.mode.PublishEvents(trans, events)
+	return lj.mode.PublishEvents(trans, opts, events)
 }
 
 // addMeta adapts events to be compatible with logstash forwarer messages by renaming

--- a/libbeat/outputs/logstash/logstash_integration_test.go
+++ b/libbeat/outputs/logstash/logstash_integration_test.go
@@ -276,7 +276,7 @@ func testSendMessageViaLogstash(t *testing.T, name string, tls bool) {
 		"type":       "log",
 		"message":    "hello world",
 	}
-	ls.PublishEvent(nil, time.Now(), event)
+	ls.PublishEvent(nil, testOptions, event)
 
 	// wait for logstash event flush + elasticsearch
 	waitUntilTrue(5*time.Second, checkIndex(ls, 1))
@@ -313,7 +313,7 @@ func testSendMultipleViaLogstash(t *testing.T, name string, tls bool) {
 			"type":       "log",
 			"message":    fmt.Sprintf("hello world - %v", i),
 		}
-		ls.PublishEvent(nil, time.Now(), event)
+		ls.PublishEvent(nil, testOptions, event)
 	}
 
 	// wait for logstash event flush + elasticsearch
@@ -384,7 +384,7 @@ func testSendMultipleBatchesViaLogstash(
 
 	for _, batch := range batches {
 		sig := outputs.NewSyncSignal()
-		ls.BulkPublish(sig, time.Now(), batch)
+		ls.BulkPublish(sig, testOptions, batch)
 		ok := sig.Wait()
 		assert.Equal(t, true, ok)
 	}
@@ -432,10 +432,10 @@ func testLogstashElasticOutputPluginCompatibleMessage(t *testing.T, name string,
 		"message":    "hello world",
 	}
 
-	es.PublishEvent(nil, ts, event)
+	es.PublishEvent(nil, testOptions, event)
 	waitUntilTrue(timeout, checkIndex(es, 1))
 
-	ls.PublishEvent(nil, ts, event)
+	ls.PublishEvent(nil, testOptions, event)
 	waitUntilTrue(timeout, checkIndex(ls, 1))
 
 	// search value in logstash elasticsearch index
@@ -487,10 +487,10 @@ func testLogstashElasticOutputPluginBulkCompatibleMessage(t *testing.T, name str
 			"message":    "hello world",
 		},
 	}
-	es.BulkPublish(nil, ts, events)
+	es.BulkPublish(nil, testOptions, events)
 	waitUntilTrue(timeout, checkIndex(es, 1))
 
-	ls.BulkPublish(nil, ts, events)
+	ls.BulkPublish(nil, testOptions, events)
 	waitUntilTrue(timeout, checkIndex(ls, 1))
 
 	// search value in logstash elasticsearch index

--- a/libbeat/outputs/logstash/logstash_test.go
+++ b/libbeat/outputs/logstash/logstash_test.go
@@ -31,6 +31,8 @@ type mockLSServer struct {
 	handshake func(net.Conn)
 }
 
+var testOptions = outputs.Options{}
+
 func newMockTLSServer(t *testing.T, to time.Duration, cert string) *mockLSServer {
 	tcpListener, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
@@ -394,7 +396,7 @@ func testConnectionType(
 		output := makeOutputer()
 
 		signal := outputs.NewSyncSignal()
-		output.PublishEvent(signal, time.Now(), testEvent())
+		output.PublishEvent(signal, testOptions, testEvent())
 		result.signal = signal.Wait()
 	}()
 
@@ -472,7 +474,7 @@ func TestLogstashInvalidTLS(t *testing.T) {
 		output := newTestLumberjackOutput(t, "", &config)
 
 		signal := outputs.NewSyncSignal()
-		output.PublishEvent(signal, time.Now(), testEvent())
+		output.PublishEvent(signal, testOptions, testEvent())
 		result.signal = signal.Wait()
 	}()
 

--- a/libbeat/outputs/mode/mode.go
+++ b/libbeat/outputs/mode/mode.go
@@ -28,10 +28,10 @@ type ConnectionMode interface {
 
 	// PublishEvents will send all events (potentially asynchronous) to its
 	// clients.
-	PublishEvents(trans outputs.Signaler, events []common.MapStr) error
+	PublishEvents(trans outputs.Signaler, opts outputs.Options, events []common.MapStr) error
 
 	// PublishEvent will send an event to its clients.
-	PublishEvent(trans outputs.Signaler, event common.MapStr) error
+	PublishEvent(trans outputs.Signaler, opts outputs.Options, event common.MapStr) error
 }
 
 // ProtocolClient interface is a output plugin specific client implementation

--- a/libbeat/outputs/mode/mode_test.go
+++ b/libbeat/outputs/mode/mode_test.go
@@ -126,6 +126,8 @@ var testEvent = common.MapStr{
 	"msg": "hello world",
 }
 
+var testOpts = outputs.Options{}
+
 func testMode(
 	t *testing.T,
 	mode ConnectionMode,
@@ -155,14 +157,14 @@ func testMode(
 	for _, pubEvents := range events {
 		if pubEvents.single {
 			for _, event := range pubEvents.events {
-				_ = mode.PublishEvent(signal, event)
+				_ = mode.PublishEvent(signal, testOpts, event)
 				if expectedSignals[idx] {
 					expectedEvents = append(expectedEvents, []common.MapStr{event})
 				}
 				idx++
 			}
 		} else {
-			_ = mode.PublishEvents(signal, pubEvents.events)
+			_ = mode.PublishEvents(signal, testOpts, pubEvents.events)
 			if expectedSignals[idx] {
 				expectedEvents = append(expectedEvents, pubEvents.events)
 			}

--- a/libbeat/publisher/client_test.go
+++ b/libbeat/publisher/client_test.go
@@ -18,8 +18,9 @@ func TestGetClient(t *testing.T) {
 		},
 	}
 	asyncClient := c.publisher.asyncPublisher.client()
-	confirmClient := c.publisher.syncPublisher.client()
 	syncClient := c.publisher.syncPublisher.client()
+	guaranteedClient := asyncClient
+	guaranteedSyncClient := syncClient
 
 	var testCases = []struct {
 		in  []ClientOption
@@ -28,8 +29,8 @@ func TestGetClient(t *testing.T) {
 		// Add new client options here:
 		{[]ClientOption{}, asyncClient},
 		{[]ClientOption{Sync}, syncClient},
-		{[]ClientOption{Confirm}, confirmClient},
-		{[]ClientOption{Confirm, Sync}, syncClient},
+		{[]ClientOption{Guaranteed}, guaranteedClient},
+		{[]ClientOption{Guaranteed, Sync}, guaranteedSyncClient},
 	}
 
 	for _, test := range testCases {

--- a/libbeat/publisher/common_test.go
+++ b/libbeat/publisher/common_test.go
@@ -168,12 +168,12 @@ func (t *testPublisher) asyncPublishEvents(events []common.MapStr) bool {
 }
 
 func (t *testPublisher) syncPublishEvent(event common.MapStr) bool {
-	ctx := context{publishOptions: publishOptions{confirm: true}}
+	ctx := context{publishOptions: publishOptions{guaranteed: true}}
 	return t.pub.syncPublisher.client().PublishEvent(ctx, event)
 }
 
 func (t *testPublisher) syncPublishEvents(events []common.MapStr) bool {
-	ctx := context{publishOptions: publishOptions{confirm: true}}
+	ctx := context{publishOptions: publishOptions{guaranteed: true}}
 	return t.pub.syncPublisher.client().PublishEvents(ctx, events)
 }
 

--- a/libbeat/publisher/output.go
+++ b/libbeat/publisher/output.go
@@ -1,7 +1,7 @@
 package publisher
 
 import (
-	"time"
+	"errors"
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
@@ -14,6 +14,10 @@ type outputWorker struct {
 	config      outputs.MothershipConfig
 	maxBulkSize int
 }
+
+var (
+	errSendFailed = errors.New("failed send attempt")
+)
 
 func newOutputWorker(
 	config outputs.MothershipConfig,
@@ -48,21 +52,7 @@ func (o *outputWorker) onMessage(m message) {
 
 func (o *outputWorker) onEvent(ctx *context, event common.MapStr) {
 	debug("output worker: publish single event")
-	ts := time.Time(event["@timestamp"].(common.Time)).UTC()
-
-	if !ctx.sync {
-		_ = o.out.PublishEvent(ctx.signal, ts, event)
-		return
-	}
-
-	signal := outputs.NewSyncSignal()
-	for {
-		o.out.PublishEvent(signal, ts, event)
-		if signal.Wait() {
-			outputs.SignalCompleted(ctx.signal)
-			break
-		}
-	}
+	o.out.PublishEvent(ctx.signal, outputs.Options{ctx.guaranteed}, event)
 }
 
 func (o *outputWorker) onBulk(ctx *context, events []common.MapStr) {
@@ -72,13 +62,8 @@ func (o *outputWorker) onBulk(ctx *context, events []common.MapStr) {
 		return
 	}
 
-	var sync *outputs.SyncSignal
-	if ctx.sync {
-		sync = outputs.NewSyncSignal()
-	}
-
 	if o.maxBulkSize < 0 || len(events) <= o.maxBulkSize {
-		o.sendBulk(sync, ctx, events)
+		o.sendBulk(ctx, events)
 		return
 	}
 
@@ -90,29 +75,19 @@ func (o *outputWorker) onBulk(ctx *context, events []common.MapStr) {
 		if sz > len(events) {
 			sz = len(events)
 		}
-		o.sendBulk(sync, ctx, events[:sz])
+		o.sendBulk(ctx, events[:sz])
 		events = events[sz:]
 	}
 }
 
 func (o *outputWorker) sendBulk(
-	sync *outputs.SyncSignal,
 	ctx *context,
 	events []common.MapStr,
 ) {
 	debug("output worker: publish %v events", len(events))
-	ts := time.Time(events[0]["@timestamp"].(common.Time)).UTC()
 
-	if sync == nil {
-		err := o.out.BulkPublish(ctx.signal, ts, events)
-		if err != nil {
-			logp.Info("Error bulk publishing events: %s", err)
-		}
-		return
+	err := o.out.BulkPublish(ctx.signal, outputs.Options{ctx.guaranteed}, events)
+	if err != nil {
+		logp.Info("Error bulk publishing events: %s", err)
 	}
-
-	for done := false; !done; done = sync.Wait() {
-		o.out.BulkPublish(sync, ts, events)
-	}
-	outputs.SignalCompleted(ctx.signal)
 }

--- a/libbeat/publisher/output_test.go
+++ b/libbeat/publisher/output_test.go
@@ -2,7 +2,6 @@ package publisher
 
 import (
 	"testing"
-	"time"
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/outputs"
@@ -18,7 +17,7 @@ var _ outputs.Outputer = &testOutputer{}
 
 // PublishEvent writes events to a channel then calls Completed on trans.
 // It always returns nil.
-func (t *testOutputer) PublishEvent(trans outputs.Signaler, ts time.Time,
+func (t *testOutputer) PublishEvent(trans outputs.Signaler, opts outputs.Options,
 	event common.MapStr) error {
 	t.events <- event
 	outputs.SignalCompleted(trans)

--- a/libbeat/publisher/publish.go
+++ b/libbeat/publisher/publish.go
@@ -37,8 +37,8 @@ type context struct {
 }
 
 type publishOptions struct {
-	confirm bool
-	sync    bool
+	guaranteed bool
+	sync       bool
 }
 
 type TransactionalEventPublisher interface {

--- a/libbeat/publisher/sync.go
+++ b/libbeat/publisher/sync.go
@@ -42,7 +42,15 @@ func (c syncClient) PublishEvents(ctx context, events []common.MapStr) bool {
 
 func (p *syncPublisher) forward(m message) bool {
 	sync := outputs.NewSyncSignal()
+	signal := m.context.signal
 	m.context.signal = sync
 	p.send(m)
-	return sync.Wait()
+	if sync.Wait() {
+		outputs.SignalCompleted(signal)
+		return true
+	}
+	if signal != nil {
+		signal.Failed()
+	}
+	return false
 }

--- a/winlogbeat/beat/winlogbeat.go
+++ b/winlogbeat/beat/winlogbeat.go
@@ -252,7 +252,7 @@ loop:
 
 		// Publish events.
 		numEvents := int64(len(events))
-		ok := eb.client.PublishEvents(events, publisher.Sync)
+		ok := eb.client.PublishEvents(events, publisher.Sync, publisher.Guaranteed)
 		if ok {
 			publishedEvents.Add("total", numEvents)
 			publishedEvents.Add(api.Name(), numEvents)


### PR DESCRIPTION
- have separate sync and guaranteed options:
  - sync: just blocks until output plugin finished processing events
    to be published
  - guaranteed: is passed and handled in output plugin. If options is set,
    sending is retried until success.

- guaranteed sending is handled by output plugin retrying infinitely until
  events have been ACKed.

- introduce Signal options for async confirmation about success/failure