### PR TITLE
Close event handles returned by EvtNext when using wineventlog API

### DIFF
--- a/winlogbeat/eventlog/wineventlog.go
+++ b/winlogbeat/eventlog/wineventlog.go
@@ -48,6 +48,7 @@ func (l *winEventLog) Open(recordNumber uint64) error {
 	if err != nil {
 		return err
 	}
+	defer sys.Close(bookmark)
 
 	// Using a pull subscription to receive events. See:
 	// https://msdn.microsoft.com/en-us/library/windows/desktop/aa385771(v=vs.85).aspx#pull
@@ -81,6 +82,11 @@ func (l *winEventLog) Read() ([]Record, error) {
 		logp.Warn("%s EventHandles returned error %v Errno: %d", l.logPrefix, err)
 		return nil, err
 	}
+	defer func() {
+		for _, h := range handles {
+			sys.Close(h)
+		}
+	}()
 	detailf("%s EventHandles returned %d handles", l.logPrefix, len(handles))
 
 	var records []Record

--- a/winlogbeat/sys/wineventlog/wineventlog_windows.go
+++ b/winlogbeat/sys/wineventlog/wineventlog_windows.go
@@ -116,7 +116,8 @@ func Subscribe(
 
 // EventHandles reads the event handles from a subscription. It attempt to read
 // at most maxHandles. ErrorNoMoreHandles is returned when there are no more
-// handles available to return.
+// handles available to return. Close must be called on each returned EvtHandle
+// when finished with the handle.
 func EventHandles(subscription EvtHandle, maxHandles int) ([]EvtHandle, error) {
 	eventHandles := make([]EvtHandle, maxHandles)
 	var numRead uint32
@@ -153,6 +154,7 @@ func RenderEvent(
 		if err != nil {
 			return Event{}, err
 		}
+		defer _EvtClose(systemContext)
 	}
 
 	var bufferUsed, propertyCount uint32
@@ -309,8 +311,8 @@ func CreateBookmark(channel string, recordID uint64) (EvtHandle, error) {
 	return h, nil
 }
 
-// OpenPublisherMetadata opens a handle to the publisher's metadata. Close must be called on
-// returned EvtHandle when finished with the handle.
+// OpenPublisherMetadata opens a handle to the publisher's metadata. Close must
+// be called on returned EvtHandle when finished with the handle.
 func OpenPublisherMetadata(
 	session EvtHandle,
 	publisherName string,


### PR DESCRIPTION
I found a few places where handles were not being closed.