### PR TITLE
Winlogbeat Rename Fields

### DIFF
--- a/winlogbeat/docs/fields.asciidoc
+++ b/winlogbeat/docs/fields.asciidoc
@@ -66,7 +66,7 @@ Contains data from a Windows event log record.
 
 
 
-==== computerName
+==== computer_name
 
 type: string
 
@@ -84,7 +84,7 @@ required: False
 The category for this event. The meaning of this value depends on the event source.
 
 
-==== eventID
+==== event_id
 
 type: long
 
@@ -93,7 +93,7 @@ required: True
 The event identifier. The value is specific to the source of the event.
 
 
-==== eventLogName
+==== log_name
 
 type: string
 
@@ -120,7 +120,7 @@ required: False
 The message from the event log record.
 
 
-==== messageError
+==== message_error
 
 type: string
 
@@ -129,7 +129,7 @@ required: False
 The error that occurred while reading and formatting the message from the log. This field is mutually exclusive with `message`.
 
 
-==== messageInserts
+==== message_inserts
 
 type: list
 
@@ -138,16 +138,16 @@ required: False
 The raw message data logged by an application. Normally this data is inserted into parameterized string to create `message`, but in case of an error Winlogbeat attempts to provide this raw data. This field is mutually exclusive with `message`.
 
 
-==== recordNumber
+==== record_number
 
 type: string
 
 required: True
 
-The record number of the event log record. The first record written to an event log is record number 1, and other records are numbered sequentially. If the record number reaches 4294967295, the next record number will be 0.
+The record number of the event log record. The first record written to an event log is record number 1, and other records are numbered sequentially. If the record number reaches the maximum value (2^32^ for the Event Logging API and 2^64^ for Window Event Log API), the next record number will be 0.
 
 
-==== sourceName
+==== source_name
 
 type: string
 
@@ -165,6 +165,8 @@ example: S-1-5-21-3541430928-2051711210-1391384369-1001
 required: False
 
 The Windows security identifier (SID) of the account associated with this event.
+
+If Winlogbeat cannot resolve the SID to a name, then the `user.name`, `user.domain`, and `user.type` fields will be omitted from the event. If you discover Winlogbeat not resolving SIDs, review the log for clues as to what the problem may be.
 
 
 ==== user.name

--- a/winlogbeat/etc/fields.yml
+++ b/winlogbeat/etc/fields.yml
@@ -56,7 +56,7 @@ eventlog:
   description: >
     Contains data from a Windows event log record.
   fields:
-    - name: computerName
+    - name: computer_name
       type: string
       required: true
       description: >
@@ -70,13 +70,13 @@ eventlog:
         The category for this event. The meaning of this value depends on the
         event source.
 
-    - name: eventID
+    - name: event_id
       type: long
       required: true
       description: >
         The event identifier. The value is specific to the source of the event.
 
-    - name: eventLogName
+    - name: log_name
       type: string
       required: true
       description: >
@@ -96,14 +96,14 @@ eventlog:
       description: >
         The message from the event log record.
 
-    - name: messageError
+    - name: message_error
       type: string
       required: false
       description: >
         The error that occurred while reading and formatting the message from
         the log. This field is mutually exclusive with `message`.
 
-    - name: messageInserts
+    - name: message_inserts
       type: list
       required: false
       description: >
@@ -112,16 +112,17 @@ eventlog:
         an error Winlogbeat attempts to provide this raw data. This field is
         mutually exclusive with `message`.
 
-    - name: recordNumber
+    - name: record_number
       type: string
       required: true
       description: >
         The record number of the event log record. The first record written
         to an event log is record number 1, and other records are numbered
-        sequentially. If the record number reaches 4294967295, the next record
-        number will be 0.
+        sequentially. If the record number reaches the maximum value (2^32^
+        for the Event Logging API and 2^64^ for Window Event Log API), the next
+        record number will be 0.
 
-    - name: sourceName
+    - name: source_name
       type: string
       required: true
       description: >
@@ -135,6 +136,12 @@ eventlog:
       description: >
         The Windows security identifier (SID) of the account associated with
         this event.
+
+
+        If Winlogbeat cannot resolve the SID to a name, then the `user.name`,
+        `user.domain`, and `user.type` fields will be omitted from the event.
+        If you discover Winlogbeat not resolving SIDs, review the log for
+        clues as to what the problem may be.
 
     - name: user.name
       type: string

--- a/winlogbeat/eventlog/eventlog.go
+++ b/winlogbeat/eventlog/eventlog.go
@@ -66,27 +66,27 @@ func (r Record) String() string {
 // ToMapStr returns a new MapStr containing the data from this Record.
 func (r Record) ToMapStr() common.MapStr {
 	m := common.MapStr{
-		"@timestamp":   common.Time(r.TimeGenerated),
-		"eventLogName": r.EventLogName,
-		"sourceName":   r.SourceName,
-		"computerName": r.ComputerName,
+		"@timestamp":    common.Time(r.TimeGenerated),
+		"log_name":      r.EventLogName,
+		"source_name":   r.SourceName,
+		"computer_name": r.ComputerName,
 		// Use a string to represent this uint64 data because its value can
 		// be outside the range represented by a Java long.
-		"recordNumber": strconv.FormatUint(r.RecordNumber, 10),
-		"eventID":      r.EventID,
-		"level":        r.Level,
-		"type":         r.API,
+		"record_number": strconv.FormatUint(r.RecordNumber, 10),
+		"event_id":      r.EventID,
+		"level":         r.Level,
+		"type":          r.API,
 	}
 
 	if r.Message != "" {
 		m["message"] = r.Message
 	} else {
 		if len(r.MessageInserts) > 0 {
-			m["messageInserts"] = r.MessageInserts
+			m["message_inserts"] = r.MessageInserts
 		}
 
 		if r.MessageErr != nil {
-			m["messageError"] = r.MessageErr.Error()
+			m["message_error"] = r.MessageErr.Error()
 		}
 	}
 

--- a/winlogbeat/tests/system/test_eventlog.py
+++ b/winlogbeat/tests/system/test_eventlog.py
@@ -93,11 +93,11 @@ class Test(TestCase):
         assert len(events) == 1
         evt = events[0]
         assert evt["type"] == api
-        assert evt["eventID"] == eventID
+        assert evt["event_id"] == eventID
         assert evt["level"] == "Information"
-        assert evt["eventLogName"] == self.providerName
-        assert evt["sourceName"] == self.applicationName
-        assert evt["computerName"].lower() == win32api.GetComputerName().lower()
+        assert evt["log_name"] == self.providerName
+        assert evt["source_name"] == self.applicationName
+        assert evt["computer_name"].lower() == win32api.GetComputerName().lower()
         assert evt["user.identifier"] == self.get_sid_string()
         assert evt["user.name"] == win32api.GetUserName()
         assert "user.type" in evt
@@ -116,8 +116,8 @@ class Test(TestCase):
         """
         evt = self.read_unknown_event_id("eventlogging")
 
-        assert "messageInserts" in evt
-        assert evt["messageError"].lower() == ("The system cannot find "
+        assert "message_inserts" in evt
+        assert evt["message_error"].lower() == ("The system cannot find "
             "message text for message number 1111 in the message file for "
             "C:\\Windows\\system32\\EventCreate.exe.").lower()
 
@@ -130,7 +130,7 @@ class Test(TestCase):
 
         # TODO: messageInserts has not been implemented for wineventlog.
         # assert "messageInserts" in evt
-        assert evt["messageError"] == ("the message resource is present but "
+        assert evt["message_error"] == ("the message resource is present but "
             "the message is not found in the string/message table")
 
     def read_unknown_event_id(self, api):
@@ -153,11 +153,11 @@ class Test(TestCase):
         assert len(events) == 1
         evt = events[0]
         assert evt["type"] == api
-        assert evt["eventID"] == eventID
+        assert evt["event_id"] == eventID
         assert evt["level"] == "Information"
-        assert evt["eventLogName"] == self.providerName
-        assert evt["sourceName"] == self.applicationName
-        assert evt["computerName"].lower() == win32api.GetComputerName().lower()
+        assert evt["log_name"] == self.providerName
+        assert evt["source_name"] == self.applicationName
+        assert evt["computer_name"].lower() == win32api.GetComputerName().lower()
         assert evt["user.identifier"] == self.get_sid_string()
         assert evt["user.name"] == win32api.GetUserName()
         assert "user.type" in evt
@@ -207,11 +207,11 @@ class Test(TestCase):
         assert len(events) == 1
         evt = events[0]
         assert evt["type"] == api
-        assert evt["eventID"] == eventID
+        assert evt["event_id"] == eventID
         assert evt["level"] == "Information"
-        assert evt["eventLogName"] == self.providerName
-        assert evt["sourceName"] == self.applicationName
-        assert evt["computerName"].lower() == win32api.GetComputerName().lower()
+        assert evt["log_name"] == self.providerName
+        assert evt["source_name"] == self.applicationName
+        assert evt["computer_name"].lower() == win32api.GetComputerName().lower()
         assert evt["user.identifier"] == accountIdentifier
         assert "user.name" not in evt
         assert "user.type" not in evt


### PR DESCRIPTION
- Changed from lower-camel-case field names to underscore separate field names.
- Renamed `event_log_name` to `log_name`.

For reference and review purposes, here is an example event.

From the Windows Event Viewer (right-click -> "copy details as text"):

```
Log Name:      System
Source:        Service Control Manager
Date:          1/11/2016 4:35:09 PM
Event ID:      7036
Task Category: None
Level:         Information
Keywords:      Classic
User:          N/A
Computer:      bert
Description:
The winlogbeat service entered the running state.

Event Xml:
<Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
  <System>
    <Provider Name="Service Control Manager" Guid="{555908d1-a6d7-4695-8e1e-26931d2012f4}" EventSourceName="Service Control Manager" />
    <EventID Qualifiers="16384">7036</EventID>
    <Version>0</Version>
    <Level>4</Level>
    <Task>0</Task>
    <Opcode>0</Opcode>
    <Keywords>0x8080000000000000</Keywords>
    <TimeCreated SystemTime="2016-01-11T21:35:09.417973800Z" />
    <EventRecordID>4067</EventRecordID>
    <Correlation />
    <Execution ProcessID="656" ThreadID="1028" />
    <Channel>System</Channel>
    <Computer>bert</Computer>
    <Security />
  </System>
  <EventData>
    <Data Name="param1">winlogbeat</Data>
    <Data Name="param2">running</Data>
    <Binary>770069006E006C006F00670062006500610074002F0034000000</Binary>
  </EventData>
</Event>
```

Winlogbeat Event JSON:
```
{
   "@timestamp":"2016-01-11T21:35:09.417Z",
   "beat":{
      "hostname":"bert",
      "name":"bert"
   },
   "computer_name":"bert",
   "count":1,
   "event_id":7036,
   "level":"Information",
   "log_name":"System",
   "message":"The winlogbeat service entered the running state.",
   "record_number":"4067",
   "source_name":"Service Control Manager",
   "type":"wineventlog"
}
```
