### PR TITLE
Change wording in GS to make apt and yum installation more obvious

### DIFF
--- a/filebeat/docs/getting-started.asciidoc
+++ b/filebeat/docs/getting-started.asciidoc
@@ -16,14 +16,12 @@ To download and install Filebeat, use the commands that work with your system
 (<<deb, deb>> for Debian/Ubuntu, <<rpm, rpm>> for Redhat/Centos/Fedora, <<mac,
 mac>> for OS X, and <<win, win>> for Windows).
 
-.Other Installation Options
 [NOTE]
-===============================
-We also provide 32-bit images that you can get from our
-https://www.elastic.co/downloads/beats/filebeat[download page]. 
+==================================================
+If you use Apt or Yum, you can {libbeat}/setup-repositories.html[install Filebeat from our repositories] to update to the newest version more easily. 
 
-Or you can install Filebeat from our {libbeat}/setup-repositories.html[repositories] using apt or yum.
-===============================
+See our https://www.elastic.co/downloads/beats/filebeat[download page] for other installation options, such as 32-bit images. 
+==================================================
 
 [[deb]]
 *deb:*

--- a/packetbeat/docs/gettingstarted.asciidoc
+++ b/packetbeat/docs/gettingstarted.asciidoc
@@ -19,14 +19,12 @@ To download and install Packetbeat on your application servers, use the commands
 that work with your system (<<deb, deb>> for Debian/Ubuntu, <<rpm, rpm>> for
 Redhat/Centos/Fedora, <<mac, mac>> for OS X, and <<win, win>> for Windows).
 
-.Other Installation Options
 [NOTE]
-===============================
-We also provide 32-bit images that you can get from our
-https://www.elastic.co/downloads/beats/packetbeat[download page]. 
+==================================================
+If you use Apt or Yum, you can {libbeat}/setup-repositories.html[install Packetbeat from our repositories] to update to the newest version more easily. 
 
-Or you can install Packetbeat from our {libbeat}/setup-repositories.html[repositories] using apt or yum.
-===============================
+See our https://www.elastic.co/downloads/beats/packetbeat[download page] for other installation options, such as 32-bit images. 
+==================================================
 
 [[deb]]
 *deb:*

--- a/topbeat/docs/gettingstarted.asciidoc
+++ b/topbeat/docs/gettingstarted.asciidoc
@@ -20,14 +20,12 @@ To download and install Topbeat, use the commands that work with your system
 (<<deb, deb>> for Debian/Ubuntu, <<rpm, rpm>> for Redhat/Centos/Fedora, <<mac,
 mac>> for OS X, and <<win, win>> for Windows).
 
-.Other Installation Options
 [NOTE]
-===============================
-We also provide 32-bit images that you can get from our
-https://www.elastic.co/downloads/beats/topbeat[download page]. 
+==================================================
+If you use Apt or Yum, you can {libbeat}/setup-repositories.html[install Topbeat from our repositories] to update to the newest version more easily. 
 
-Or you can install Topbeat from our {libbeat}/setup-repositories.html[repositories] using apt or yum.
-===============================
+See our https://www.elastic.co/downloads/beats/topbeat[download page] for other installation options, such as 32-bit images. 
+==================================================
 
 [[deb]]
 *deb:*


### PR DESCRIPTION
Edits/tweaks to the text originally added in https://github.com/elastic/beats/pull/667. Closes Topbeat issue https://github.com/elastic/topbeat/issues/135. 