### PR TITLE
Add description of bulk_max_size to all outputs

### DIFF
--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -203,8 +203,7 @@ The default is 3.
 
 ===== bulk_max_size
 
-The maximum number of events to bulk in a single Elasticsearch bulk API index request.
-The default is 50.
+The maximum number of events to bulk in a single Elasticsearch bulk API index request. The default is 50.
 
 If the Beat sends single events, the events are collected into batches. If the Beat publishes
 a large batch of events (larger than the value specified by `bulk_max_size`), the batch is
@@ -351,6 +350,7 @@ is used as the default port number.
 
 The gzip compression level. Setting this value to values less than or equal to 0 disables compression.
 The compression level must be in the range of 1 (best speed) to 9 (best compression).
+
 The default value is 3.
 
 ===== worker

--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -206,6 +206,20 @@ The default is 3.
 The maximum number of events to bulk in a single Elasticsearch bulk API index request.
 The default is 50.
 
+If the Beat sends single events, the events are collected into batches. If the Beat publishes
+a large batch of events (larger than the value specified by `bulk_max_size`), the batch is
+split.
+
+Specifying a larger batch size can improve performance by lowering the overhead of sending events. 
+However big batch sizes can also increase processing times, which might result in
+API errors, killed connections, timed-out publishing requests, and, ultimately, lower
+throughput.
+
+Setting `bulk_max_size` to values less than or equal to 0 disables buffering in libbeat. When buffering is disabled,
+Beats that publish single events (such as Packetbeat and Topbeat) send each event directly to
+Elasticsearch. Beats that publish data in batches (such as Filebeat) send events in batches based on the
+spooler size.
+
 ===== timeout
 
 The http request timeout in seconds for the Elasticsearch request. The default is 90.
@@ -399,6 +413,24 @@ Set `max_retries` to a value less than 0 to retry until all events are published
 
 The default is 3.
 
+===== bulk_max_size
+
+The maximum number of events to bulk in a single Logstash request. The default is 2048.
+
+If the Beat sends single events, the events are collected into batches. If the Beat publishes
+a large batch of events (larger than the value specified by `bulk_max_size`), the batch is
+split.
+
+Specifying a larger batch size can improve performance by lowering the overhead of sending events. 
+However big batch sizes can also increase processing times, which might result in
+API errors, killed connections, timed-out publishing requests, and, ultimately, lower
+throughput.
+
+Setting `bulk_max_size` to values less than or equal to 0 disables buffering in libbeat. When buffering is disabled,
+Beats that publish single events (such as Packetbeat and Topbeat) send each event directly to
+Elasticsearch. Beats that publish data in batches (such as Filebeat) send events in batches based on the
+spooler size.
+
 [[redis-output]]
 ==== Redis Output (DEPRECATED)
 
@@ -478,6 +510,15 @@ The Redis initial connection timeout in seconds. The default is 5 seconds.
 
 The interval for reconnecting failed Redis connections. The default is 1 second.
 
+===== bulk_max_size
+
+The maximum number of events to buffer internally during publishing. The default is 2048. 
+
+Specifying a larger batch size may add some latency and buffering during publishing. However, for Redis output, this 
+setting does not affect how events are published.
+
+Setting `bulk_max_size` to values less than or equal to 0 disables buffering in libbeat. 
+
 [[file-output]]
 ==== File Output
 
@@ -539,6 +580,15 @@ output:
 ===== pretty
 
 If `pretty` is set to true, events written to stdout will be nicely formatted. The default is false.
+
+===== bulk_max_size
+
+The maximum number of events to buffer internally during publishing. The default is 2048.
+
+Specifying a larger batch size may add some latency and buffering during publishing. However, for Console output, this 
+setting does not affect how events are published.
+
+Setting `bulk_max_size` to values less than or equal to 0 disables buffering in libbeat. 
 
 [[configuration-output-tls]]
 

--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -207,7 +207,7 @@ The maximum number of events to bulk in a single Elasticsearch bulk API index re
 
 If the Beat sends single events, the events are collected into batches. If the Beat publishes
 a large batch of events (larger than the value specified by `bulk_max_size`), the batch is
-split.
+split. 
 
 Specifying a larger batch size can improve performance by lowering the overhead of sending events. 
 However big batch sizes can also increase processing times, which might result in


### PR DESCRIPTION
Closes issue #586 
-  Adds info about performance implications of changing bulk_max_size
-  Adds bulk_max_size to documentation of other outputs (besides Elasticsearch, where it was already documented): logstash, file, and console.

@urso Please review. BTW, when I look at the Beats config files, I only see max_bulk_size under the Elasticsearch output. If it's important for Logstash, too, seems like it should at least appear commented out in the Logstash output, no? I'm not sure about the other outputs.