### PR TITLE
Change title of Beats GS for SEO

### DIFF
--- a/libbeat/docs/gettingstarted.asciidoc
+++ b/libbeat/docs/gettingstarted.asciidoc
@@ -1,5 +1,7 @@
 [[getting-started]]
-== Getting Started
+== Getting Started with Beats and the Elastic Stack
+
+Looking for an "ELK tutorial" that shows how to set up the Elastic stack for Beats? You've come to the right place.
 
 A regular _Beats setup_ consists of:
 


### PR DESCRIPTION
- Made the title more descriptive to improve SEO.
- Added a referenced to "ELK tutorial" (in quotation marks to signify that it's not an Elastic term...we prefer to use Elastic stack).

The other Beats getting started guides get high rankings in google, so I'm not changing the titles right now.

This closes #674 