### PR TITLE
Added faster test and unit targets to the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,20 @@ COVERAGE_DIR=${BUILD_DIR}/coverage
 BEATS=packetbeat topbeat filebeat winlogbeat
 PROJECTS=libbeat ${BEATS}
 
-# Runs testsuites for all beats
+# Runs complete testsuites (unit, system, integration) for all beats,
+# with coverage and race detection.
 testsuite:
 	$(foreach var,$(PROJECTS),make -C $(var) testsuite || exit 1;)
+
+# Runs unit and system tests without coverage and race detection.
+.PHONY: test
+test:
+	$(foreach var,$(PROJECTS),make -C $(var) test || exit 1;)
+
+# Runs unit tests without coverage and race detection.
+.PHONY: unit
+unit:
+	$(foreach var,$(PROJECTS),make -C $(var) unit || exit 1;)
 
 .PHONY: coverage-report
 coverage-report:

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -11,6 +11,7 @@ ES_HOST?="elasticsearch"
 BEAT_DIR?=github.com/elastic/beats
 BUILD_DIR=build
 COVERAGE_DIR=${BUILD_DIR}/coverage
+PROCESSES?= 4
 TIMEOUT?= 90
 BEATNAME?=libbeat
 TEST_ENVIRONMENT?=false
@@ -70,7 +71,7 @@ ci:
 	make testsuite
 
 ### Testing ###
-# All tests are always run with coverage reporting enabled
+# Unless stated otherwise, all tests are always run with coverage reporting enabled.
 
 
 # Prepration for tests
@@ -82,12 +83,16 @@ prepare-tests:
 	# gotestcover is needed to fetch coverage for multiple packages
 	go get github.com/pierrre/gotestcover
 
-# Runs the unit tests
+# Runs the unit tests with coverage
 # Race is not enabled for unit tests because tests run much slower.
 .PHONY: unit-tests
 unit-tests: prepare-tests
-	#go test -short ./...
 	$(GOPATH)/bin/gotestcover -coverprofile=${COVERAGE_DIR}/unit.cov -short -covermode=atomic ${BEAT_DIR}/${BEATNAME}/...
+
+# Runs the unit tests without coverage reports.
+.PHONY: unit
+unit:
+	go test -short ./...
 
 # Run integration tests. Unit tests are run as part of the integration tests. It runs all tests with race detection enabled.
 .PHONY: integration-tests
@@ -113,7 +118,11 @@ system-tests: libbeat.test prepare-tests system-tests-setup
 	. build/system-tests/env/bin/activate; nosetests -w tests/system --process-timeout=$(TIMEOUT) --with-timer
 	python ../scripts/aggregate_coverage.py -o ${COVERAGE_DIR}/system.cov ./build/system-tests/run
 
-# Runs the system tests
+# Runs system tests without coverage reports and in parallel
+.PHONY: fast-system-tests
+fast-system-tests: libbeat.test system-tests-setup
+	. build/system-tests/env/bin/activate; nosetests -w tests/system --processes=$(PROCESSES) --process-timeout=$(TIMEOUT)
+
 .PHONY: system-tests-setup
 system-tests-setup: tests/system/requirements.txt
 	test -d env || virtualenv build/system-tests/env > /dev/null
@@ -126,6 +135,13 @@ system-tests-setup: tests/system/requirements.txt
 benchmark-tests:
 	# No benchmark tests exist so far
 	#go test -short -bench=. ./...
+
+# Runs unit and system tests without coverage reports
+.PHONY: test
+test: unit
+	if [ $(SYSTEM_TESTS) = true ]; then \
+		 make fast-system-tests; \
+	fi
 
 # Runs all tests and generates the coverage reports
 .PHONY: testsuite


### PR DESCRIPTION
This adds two new targets, for developer convenience:

 * `make unit` runs the unit tests, it's simply `go test -short ./...` in each
   beat
 * `make test` runs the unit target above and the system tests. To make the
   system tests faster, they are run in parallel with 4 processes by default.

The main motivation is that `make testsuite` takes really long on my computer, and
also uses so much CPU time that I can hardly use the computer for something else.
Some timings (best of 2 runs):

    time make testsuite
    688.00 real      1349.87 user       198.75 sys

    time make test
    143.13 real       281.54 user        37.95 sys

    time make unit
    58.12 real       148.43 user        17.85 sys

These two targets also don't need docker, which makes them easier to use for the
occasional contributor.