### PR TITLE
Adding ability to expand environment variables used in config file

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -53,6 +53,7 @@ https://github.com/elastic/beats/compare/1.0.0...master[Check the HEAD diff]
 *Affecting all Beats*
 - Update builds to Golang version 1.5.2
 - Make logstash output compression level configurable. {pull}630[630]
+- Add ability to override configuration settings using environment variables {issue}114[114]
 
 *Packetbeat*
 - Add support for capturing DNS over TCP network traffic. {pull}486[486] {pull}554[554]

--- a/libbeat/cfgfile/cfgfile_test.go
+++ b/libbeat/cfgfile/cfgfile_test.go
@@ -1,6 +1,7 @@
 package cfgfile
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -36,4 +37,33 @@ func TestRead(t *testing.T) {
 
 	// Chat that it is integer
 	assert.Equal(t, 9200, config.Output.Elasticsearch.Port)
+}
+
+func TestExpandEnv(t *testing.T) {
+	var tests = []struct {
+		in  string
+		out string
+	}{
+		// Environment variables can be specified as ${env} or $env.
+		{"x$y", "xy"},
+		{"x${y}", "xy"},
+
+		// Environment variables are case-sensitive. Neither are replaced.
+		{"x$Y", "x"},
+		{"x${Y}", "x"},
+
+		// Defaults can only be specified when using braces.
+		{"x${Z:D}", "xD"},
+		{"x${Z:A B C D}", "xA B C D"}, // Spaces are allowed in the default.
+		{"x${Z:}", "x"},
+
+		// Defaults don't work unless braces are used.
+		{"x$y:D", "xy:D"},
+	}
+
+	for _, test := range tests {
+		os.Setenv("y", "y")
+		output := expandEnv([]byte(test.in))
+		assert.Equal(t, test.out, string(output), "Input: %s", test.in)
+	}
 }


### PR DESCRIPTION
Adds feature requested in #114. If we choose to accept this enhancement then the documentation will need updated.

### Overview

This feature replaces `${var}` or `$var` in config files according to the values of the current environment variables.
- The replacement is case-sensitive and occurs before the YAML is parsed.
- References to undefined variables are replaced by an empty string.
- A default value can be given by using the form `${var:default value}`.

### Examples

Input | Environment | Output
-------|------------------|---------
`name: $NAME`|`export NAME=elastic`|`name: elastic`
`name: ${NAME}`|`export NAME=elastic`|`name: elastic`
`name: ${NAME:beats}`||`name: beats`
`name: ${NAME:beats}`|`export NAME=elastic`|`name: elastic`
`hosts: [$HOSTS]`|`export HOSTS="'localhost:9200', 'localhost:9202'"`|`hosts: ['localhost:9200', 'localhost:9202']`

### Troubleshooting

When logging is enabled at the `info` level or higher, a message is logged for each environment variable replacement. For example:

```
2016/01/13 23:00:27.925523 cfgfile.go:87: INFO Replacing config environment variable '${NAME}' with 'elastic'
2016/01/13 23:00:27.925786 cfgfile.go:87: INFO Replacing config environment variable '${HOSTS}' with ''localhost:9200', 'localhost:9202''
```