### PR TITLE
Fix #722: aggregate_coverage.py does not aggregate 

### DIFF
--- a/scripts/aggregate_coverage.py
+++ b/scripts/aggregate_coverage.py
@@ -25,13 +25,25 @@ def main(arguments):
             matches.append(os.path.join(root, filename))
 
     # Write to output.
+    lines = {}
     args.outfile.write('mode: atomic\n')
     for m in matches:
         if os.path.abspath(args.outfile.name) != os.path.abspath(m):
             with open(m) as f:
                 for line in f:
-                    if not line.startswith('mode:'):
-                        args.outfile.write(line)
+                    if not line.startswith('mode:') and "vendor" not in line:
+                        (position, stmt, count) = line.split(" ")
+                        stmt = int(stmt)
+                        count = int (count)
+                        prev_count = 0
+                        if lines.has_key(position):
+                            (_, prev_stmt, prev_count) = lines[position]
+                            assert prev_stmt == stmt
+                        lines[position] = (position, stmt, prev_count + count)
+
+    for line in sorted(["%s %d %d\n" % lines[key] for key in lines.keys()]):
+        args.outfile.write(line)
+
 
 if __name__ == '__main__':
     sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
Fix #722: aggregate_coverage.py does not aggregate the coverage reports of the same tracked lines

Accumulate the counters of the same tracked blocks of code from multiple coverage files