### PR TITLE
Make beats properly exit

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -55,6 +55,7 @@ https://github.com/elastic/beats/compare/1.0.0...master[Check the HEAD diff]
 - Update builds to Golang version 1.5.2
 - Make logstash output compression level configurable. {pull}630[630]
 - Add ability to override configuration settings using environment variables {issue}114[114]
+- Libbeat now always exits through a single exit method for proper cleanup and control {pull}736[736]
 
 *Packetbeat*
 - Add support for capturing DNS over TCP network traffic. {pull}486[486] {pull}554[554]

--- a/libbeat/mock/mockbeat.go
+++ b/libbeat/mock/mockbeat.go
@@ -1,21 +1,18 @@
 package mock
 
 import (
-	"fmt"
-
 	"github.com/elastic/beats/libbeat/beat"
 )
 
 ///*** Mock Beat Setup ***///
 
-var Version = "0.0.1"
+var Version = "9.9.9"
 var Name = "mockbeat"
 
 type Mockbeat struct {
 }
 
 func (mb *Mockbeat) Config(b *beat.Beat) error {
-	fmt.Print("hello world")
 	return nil
 }
 

--- a/libbeat/tests/files/invalid.yml
+++ b/libbeat/tests/files/invalid.yml
@@ -1,0 +1,3 @@
+test:
+  test were
+  : invalid yml

--- a/libbeat/tests/system/test_base.py
+++ b/libbeat/tests/system/test_base.py
@@ -1,6 +1,8 @@
 from mockbeat import TestCase
 
 import os
+import shutil
+import subprocess
 
 
 # Additional tests to be added:
@@ -9,22 +11,76 @@ import os
 class Test(TestCase):
     def test_base(self):
         """
-        Checks if all lines are read from the log file.
+        Basic test with exiting Mockbeat normally
         """
 
         self.render_config_template(
             path=os.path.abspath(self.working_dir) + "/log/*"
         )
-        os.mkdir(self.working_dir + "/log/")
 
-        testfile = self.working_dir + "/log/test.log"
-        file = open(testfile, 'w')
+        exit_code = self.run_mockbeat()
+        assert exit_code == 0
 
-        iterations = 80
-        for n in range(0, iterations):
-            file.write("hello world" + str(n))
-            file.write("\n")
 
-        file.close()
+    def test_no_config(self):
+        """
+        Tests starting without a config
+        """
+        exit_code = self.run_mockbeat()
 
-        mockbeat = self.run_mockbeat()
+        assert exit_code == 1
+        assert True == self.log_contains("loading config file error")
+        assert True == self.log_contains("Failed to read")
+
+
+    def test_invalid_config(self):
+        """
+        Checks stop on invalid config
+        """
+        shutil.copy("../files/invalid.yml", os.path.join(self.working_dir, "invalid.yml"))
+
+        exit_code = self.run_mockbeat(config="invalid.yml")
+
+        assert exit_code == 1
+        assert True == self.log_contains("loading config file error")
+        assert True == self.log_contains("YAML config parsing failed")
+
+
+    def test_config_test(self):
+        """
+        Checks if -configtest works as expected
+        """
+        shutil.copy("../../etc/libbeat.yml", os.path.join(self.working_dir, "libbeat.yml"))
+
+        exit_code = self.run_mockbeat(config="libbeat.yml", extra_args=["-configtest"])
+
+        assert exit_code == 0
+        assert True == self.log_contains("Testing configuration file")
+
+    def test_version(self):
+        """
+        Checks if version param works
+        """
+        args = ["../../libbeat.test"]
+
+        args.extend(["-version",
+                     "-e",
+                     "-systemTest",
+                     "-v",
+                     "-d", "*",
+                     "-test.coverprofile",
+                     os.path.join(self.working_dir, "coverage.cov")
+                     ])
+
+        assert False == self.log_contains("loading config file error")
+
+        with open(os.path.join(self.working_dir, "mockbeat.log"), "wb") as outputfile:
+            proc = subprocess.Popen(args,
+                                    stdout=outputfile,
+                                    stderr=subprocess.STDOUT)
+            exit_code = proc.wait()
+            assert exit_code == 0
+
+        assert True == self.log_contains("mockbeat")
+        assert True == self.log_contains("version")
+        assert True == self.log_contains("9.9.9")

--- a/winlogbeat/.gitignore
+++ b/winlogbeat/.gitignore
@@ -21,7 +21,7 @@ _testmain.go
 *.out
 *.log
 *.bak
-*.winlogbeat.yaml
+*.winlogbeat.yml
 etc/*.dev.yml
 
 cover/


### PR DESCRIPTION
Parts of libbeat were exiting the application directly by using os.Exit(). This makes it impossible always clean up the application before cleanup. In addition, a manager which is part of a beat gets also exited in case the beat exits, which is not inteded.

* os.Exit() was removed from all places
* Additional tests were added to test exit behaviour
* Test for version check was added