### PR TITLE
Fix links that point to old beats dirs

### DIFF
--- a/filebeat/docs/support.asciidoc
+++ b/filebeat/docs/support.asciidoc
@@ -1,7 +1,7 @@
 
 == Getting Support
 If you have an issue with Filebeat, contact us in the https://discuss.elastic.co/c/beats/filebeat[Filebeat forum].
-If you want to contribute to Filebeat, check out our https://github.com/elastic/filebeat[Github repository].
+If you want to contribute to Filebeat, check out our https://github.com/elastic/beats[Github repository].
 
 === Known Issues
 ==== Network Volumes

--- a/libbeat/docs/newbeat.asciidoc
+++ b/libbeat/docs/newbeat.asciidoc
@@ -21,7 +21,7 @@ original Packetbeat authors.
 
 After you have https://golang.org/doc/install[installed Go] and set up the
 https://golang.org/doc/code.html#GOPATH[GOPATH] environment variable to point to
-your preferred workspace location, a simple way of getting the source code for the 
+your preferred workspace location, a simple way of getting the source code for 
 Beats, including Topbeat and libbeat, and compiling them at the same time is to do:
 
 [source,shell]
@@ -29,7 +29,7 @@ Beats, including Topbeat and libbeat, and compiling them at the same time is to 
 go get github.com/elastic/beats
 ----------------------------------------------------------------------
 
-In this guide, we use working examples from the Tobeat source code in https://github.com/elastic/beats[GitHub]
+In this guide, we use working examples from the Topbeat source code in https://github.com/elastic/beats[GitHub]
 to demonstrate how to implement a Beat. Topbeat is similar to
 the `top` command line tool, but instead of printing the statistics to the screen,
 Topbeat periodically ships them to Elasticsearch for storage.

--- a/libbeat/docs/newbeat.asciidoc
+++ b/libbeat/docs/newbeat.asciidoc
@@ -21,16 +21,16 @@ original Packetbeat authors.
 
 After you have https://golang.org/doc/install[installed Go] and set up the
 https://golang.org/doc/code.html#GOPATH[GOPATH] environment variable to point to
-your preferred workspace location, a simple way of getting the source code for
-Topbeat and libbeat and compiling them at the same time is to do:
+your preferred workspace location, a simple way of getting the source code for the 
+Beats, including Topbeat and libbeat, and compiling them at the same time is to do:
 
 [source,shell]
 ----------------------------------------------------------------------
-go get github.com/elastic/topbeat
+go get github.com/elastic/beats
 ----------------------------------------------------------------------
 
-In this guide, we use working examples from the https://github.com/elastic/topbeat[Topbeat]
-source code to demonstrate how to implement a Beat. Topbeat is similar to
+In this guide, we use working examples from the Tobeat source code in https://github.com/elastic/beats[GitHub]
+to demonstrate how to implement a Beat. Topbeat is similar to
 the `top` command line tool, but instead of printing the statistics to the screen,
 Topbeat periodically ships them to Elasticsearch for storage.
 
@@ -133,8 +133,7 @@ You can use the `FlagsHandler` interface to add additional command line flags to
 your Beat. The `HandleFlags` callback is called after the Beat parses the
 command line arguments inherited from libbeat and handles the `--help` and
 `--version` flags. For an example of how to implement `HandleFlags`, take a look
-at the
-https://github.com/elastic/packetbeat/blob/master/beat/packetbeat.go[Packetbeat]
+at the https://github.com/elastic/beats/blob/master/packetbeat/beat/packetbeat.go[Packetbeat]
 code.
 
 We strongly recommend that you create a main package that contains only the main

--- a/packetbeat/docs/troubleshooting.asciidoc
+++ b/packetbeat/docs/troubleshooting.asciidoc
@@ -7,7 +7,7 @@ Please contact us on the https://discuss.elastic.co/c/beats/packetbeat[forums], 
 we'll help you troubleshoot the problem.
 
 If you're sure you found a bug, you can open a ticket on
-https://github.com/elastic/packetbeat/issues?state=open[GitHub]. Note, however,
+https://github.com/elastic/beats/issues?state=open[GitHub]. Note, however,
 that we close GitHub issues containing questions or requests for help if they
 don't indicate the presence of a bug.
 


### PR DESCRIPTION
Fixed a few incorrect links that pointed to our old repos.

Also changed this command. I assume this would work, no?  no?
go get github.com/elastic/beats
