### PR TITLE
Fix community beats link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ You don't need to submit the code to this repository. Most new Beats start in
 their own repository and just make use of the libbeat packages. After you have
 a working Beat that you'd like to share with others, open a PR to add it to our
 list of [community
-Beats](https://github.com/tsg/beats-onerepo/blob/master/libbeat/docs/communitybeats.asciidoc).
+Beats](https://github.com/elastic/beats/blob/master/libbeat/docs/communitybeats.asciidoc).
 
 
 ## Setting up your dev environment


### PR DESCRIPTION
Fixed link that pointed to old directory that (I guess) was set up before the migration to the new repo.