### PR TITLE
Add ICMP to Packetbeat config file

### DIFF
--- a/packetbeat/docs/configuration.asciidoc
+++ b/packetbeat/docs/configuration.asciidoc
@@ -285,7 +285,7 @@ The per protocol transaction timeout. Expired transactions will no longer be cor
 
 ===== enabled
 
-The ICMP protocol can be enabled/disabled via this option.
+The ICMP protocol can be enabled/disabled via this option. The default is false.
 
 If enabled Packetbeat will generate the following BPF filter: `"icmp or icmp6"`.
 

--- a/packetbeat/etc/beat.yml
+++ b/packetbeat/etc/beat.yml
@@ -17,6 +17,10 @@ interfaces:
 
 ############################# Protocols #######################################
 protocols:
+  icmp:
+    # Enable ICMPv4 and ICMPv6 monitoring. Default: false
+    enabled: true
+
   dns:
     # Configure the ports where to listen for DNS traffic. You can disable
     # the DNS protocol by commenting out the list of ports.

--- a/packetbeat/etc/packetbeat.yml
+++ b/packetbeat/etc/packetbeat.yml
@@ -17,6 +17,10 @@ interfaces:
 
 ############################# Protocols #######################################
 protocols:
+  icmp:
+    # Enable ICMPv4 and ICMPv6 monitoring. Default: false
+    enabled: true
+
   dns:
     # Configure the ports where to listen for DNS traffic. You can disable
     # the DNS protocol by commenting out the list of ports.


### PR DESCRIPTION
Somehow we [lost](https://github.com/elastic/beats/pull/285/files#diff-849b2184f62b48e455fd49c22c55fe68) the `icmp` option from the Packetbeat config file.

This change will enable icmp out-of-the-box.