### PR TITLE
Warn while protocol plugin register failed

### DIFF
--- a/packetbeat/protos/protos.go
+++ b/packetbeat/protos/protos.go
@@ -238,10 +238,10 @@ func (protos ProtocolsStruct) Register(proto Protocol, plugin ProtocolPlugin) {
 	}
 	if udp, ok := plugin.(UdpProtocolPlugin); ok {
 		protos.udp[proto] = udp
-		success = true;
+		success = true
 	}
-	if(!success){
-		logp.Warn("Protocol (%s) register failed, port: %v",proto.String(),plugin.GetPorts())
+	if !success {
+		logp.Warn("Protocol (%s) register failed, port: %v", proto.String(), plugin.GetPorts())
 	}
 }
 

--- a/packetbeat/protos/protos.go
+++ b/packetbeat/protos/protos.go
@@ -231,11 +231,17 @@ func (protocols ProtocolsStruct) BpfFilter(with_vlans bool, with_icmp bool) stri
 
 func (protos ProtocolsStruct) Register(proto Protocol, plugin ProtocolPlugin) {
 	protos.all[proto] = plugin
+	var success bool = false
 	if tcp, ok := plugin.(TcpProtocolPlugin); ok {
 		protos.tcp[proto] = tcp
+		success = true
 	}
 	if udp, ok := plugin.(UdpProtocolPlugin); ok {
 		protos.udp[proto] = udp
+		success = true;
+	}
+	if(!success){
+		logp.Warn("Protocol (%s) register failed, port: %v",proto.String(),plugin.GetPorts())
 	}
 }
 


### PR DESCRIPTION
I just pick up code and try to finish my Stmp protocol,but didn't found the plugin interface has already changed,it took me some time to debug out,and i think it is better to print a warn message if the protocol plugin is not successful registered.