### PR TITLE
Update to golang 1.5.3

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,7 +6,7 @@ os: Windows Server 2012 R2
 
 # Environment variables
 environment:
-  GOROOT: c:\go
+  GOROOT: c:\go1.5.3
   GOPATH: c:\gopath
   PYWIN_DL: https://downloads.sourceforge.net/project/pywin32/pywin32/Build%20219/pywin32-219.win32-py2.7.exe
   matrix:
@@ -24,11 +24,14 @@ clone_folder: c:\gopath\src\github.com\elastic\beats
 cache:
 - C:\ProgramData\chocolatey\bin -> .appveyor.yml
 - C:\ProgramData\chocolatey\lib -> .appveyor.yml
+- C:\go1.5.3 -> .appveyor.yml
 - C:\tools\mingw64 -> .appveyor.yml
 - C:\pywin_inst.exe -> .appveyor.yml
 
 # Scripts that run after cloning repository
 install:
+  - ps: c:\gopath\src\github.com\elastic\beats\libbeat\scripts\install-go.ps1 -version 1.5.3
+  - set PATH=%GOROOT%\bin;%PATH%
   # AppVeyor installed mingw is 32-bit only.
   - cinst mingw > mingw-install.txt
   - ps: Push-AppveyorArtifact mingw-install.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
 language: go
 
 go:
-  - 1.5.2
+  - 1.5.3
 
 os:
   - linux

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -52,7 +52,7 @@ https://github.com/elastic/beats/compare/1.0.0...master[Check the HEAD diff]
 ==== Added
 
 *Affecting all Beats*
-- Update builds to Golang version 1.5.2
+- Update builds to Golang version 1.5.3
 - Make logstash output compression level configurable. {pull}630[630]
 - Add ability to override configuration settings using environment variables {issue}114[114]
 - Libbeat now always exits through a single exit method for proper cleanup and control {pull}736[736]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ Beats](https://github.com/elastic/beats/blob/master/libbeat/docs/communitybeats.
 
 The Beats are Go programs, so install the latest version of
 [golang](http://golang.org/) if you don't have it already. The current Go version
-used for development is Golang 1.5.2.
+used for development is Golang 1.5.3.
 
 The Beats are Go programs, so install the latest version of
 [golang](http://golang.org/) if you don't have it already.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.5.2
+FROM golang:1.5.3
 MAINTAINER Nicolas Ruflin <ruflin@elastic.co>
 
 RUN set -x && \

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,7 +19,7 @@
 # add more boxes here
 # -------------------
 # More development boxes can be added to this file and you can run commands
-# like "vagrant up solaris" or "vargrant up winxp" to start them.
+# like "vagrant up solaris" or "vagrant up winxp" to start them.
 
 # Provisioning for Windows PowerShell
 $winPsProvision = <<SCRIPT
@@ -45,7 +45,7 @@ Vagrant.configure(2) do |config|
 
   config.vm.define "win2012", primary: true do |win2012|
     # Windows Server 2012 R2
-    win2012.vm.box = "https://s3.amazonaws.com/beats-files/vagrant/beats-win2012-r2-virtualbox-2015-12-10_1222.box"
+    win2012.vm.box = "https://s3.amazonaws.com/beats-files/vagrant/beats-win2012-r2-virtualbox-2016-01-19_0544.box"
     win2012.vm.guest = :windows
 
     # Communicator for windows boxes

--- a/dev-tools/packer/.travis.yml
+++ b/dev-tools/packer/.travis.yml
@@ -5,7 +5,7 @@ services:
 language: go
 
 go:
-  - 1.5.1
+  - 1.5.3
 
 script:
   #- make pull-images

--- a/dev-tools/packer/docker/xgo-image-deb6/beats-builder/Dockerfile
+++ b/dev-tools/packer/docker/xgo-image-deb6/beats-builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM tudorg/xgo-deb6-1.5.1
+FROM tudorg/xgo-deb6-1.5.3
 
 MAINTAINER Tudor Golubenco <tudor@elastic.co>
 

--- a/dev-tools/packer/docker/xgo-image-deb6/build.sh
+++ b/dev-tools/packer/docker/xgo-image-deb6/build.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 docker build --rm=true -t tudorg/xgo-deb6-base base/ && \
-    docker build --rm=true -t tudorg/xgo-deb6-1.5.1 go-1.5.1/ &&
+    docker build --rm=true -t tudorg/xgo-deb6-1.5.3 go-1.5.3/ &&
     docker build --rm=true -t tudorg/beats-builder-deb6 beats-builder

--- a/dev-tools/packer/docker/xgo-image-deb6/go-1.5.3/Dockerfile
+++ b/dev-tools/packer/docker/xgo-image-deb6/go-1.5.3/Dockerfile
@@ -1,15 +1,15 @@
-# Go cross compiler (xgo): Go 1.5.1 layer
+# Go cross compiler (xgo): Go 1.5.3 layer
 # Copyright (c) 2014 Péter Szilágyi. All rights reserved.
 #
 # Released under the MIT license.
 
-FROM tudorg/xgo-base
+FROM tudorg/xgo-deb6-base
 
 MAINTAINER Tudor Golubenco <tudor@elastic.co>
 
 # Configure the root Go distribution and bootstrap based on it
 RUN \
-  export ROOT_DIST=https://storage.googleapis.com/golang/go1.5.1.linux-amd64.tar.gz && \
-  export ROOT_DIST_SHA1=46eecd290d8803887dec718c691cc243f2175fe0 && \
+  export ROOT_DIST=https://storage.googleapis.com/golang/go1.5.3.linux-amd64.tar.gz && \
+  export ROOT_DIST_SHA1=c5377eca4837968d043b681f00a852a262f0f5f6 && \
   \
   $BOOTSTRAP_PURE

--- a/dev-tools/packer/docker/xgo-image/beats-builder/Dockerfile
+++ b/dev-tools/packer/docker/xgo-image/beats-builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM tudorg/xgo-1.5.1
+FROM tudorg/xgo-1.5.3
 
 MAINTAINER Tudor Golubenco <tudor@elastic.co>
 

--- a/dev-tools/packer/docker/xgo-image/build.sh
+++ b/dev-tools/packer/docker/xgo-image/build.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 docker build --rm=true -t tudorg/xgo-base base/ && \
-    docker build --rm=true -t tudorg/xgo-1.5.1 go-1.5.1/ &&
+    docker build --rm=true -t tudorg/xgo-1.5.3 go-1.5.3/ &&
     docker build --rm=true -t tudorg/beats-builder beats-builder

--- a/dev-tools/packer/docker/xgo-image/go-1.5.3/Dockerfile
+++ b/dev-tools/packer/docker/xgo-image/go-1.5.3/Dockerfile
@@ -1,15 +1,15 @@
-# Go cross compiler (xgo): Go 1.5.1 layer
+# Go cross compiler (xgo): Go 1.5.3 layer
 # Copyright (c) 2014 Péter Szilágyi. All rights reserved.
 #
 # Released under the MIT license.
 
-FROM tudorg/xgo-deb6-base
+FROM tudorg/xgo-base
 
 MAINTAINER Tudor Golubenco <tudor@elastic.co>
 
 # Configure the root Go distribution and bootstrap based on it
 RUN \
-  export ROOT_DIST=https://storage.googleapis.com/golang/go1.5.1.linux-amd64.tar.gz && \
-  export ROOT_DIST_SHA1=46eecd290d8803887dec718c691cc243f2175fe0 && \
+  export ROOT_DIST=https://storage.googleapis.com/golang/go1.5.3.linux-amd64.tar.gz && \
+  export ROOT_DIST_SHA1=c5377eca4837968d043b681f00a852a262f0f5f6 && \
   \
   $BOOTSTRAP_PURE

--- a/libbeat/scripts/README.md
+++ b/libbeat/scripts/README.md
@@ -7,3 +7,4 @@ Below is a brief description of each file / folder.
 | docker-entrypoint.sh | Entrypoint file used for the Dockerfile                                                                                                                |
 | Makefile             | General Makefile which is copied over to all beats. This contains the basic methods which are shared across all beat                                   |
 | update.sh            | This scripts brings a beat up-to-date based on the files in libbeat. This script should only be executed in a beat itself through running make update. |
+|install-go.ps1        | PowerShell script for automating the install of Go on Windows.|

--- a/libbeat/scripts/install-go.ps1
+++ b/libbeat/scripts/install-go.ps1
@@ -1,0 +1,87 @@
+# Installs golang on Windows.
+#
+# # Run script:
+# .\install-go.ps1 -version 1.5.3 
+#
+# # Download and run script:
+# $env:GOVERSION = '1.5.3'
+# iex ((new-object net.webclient).DownloadString('SCRIPT_URL_HERE'))
+Param(
+    [String]$version,
+    [switch]$h = $false,
+    [switch]$help = $false
+)
+
+$SCRIPT=$MyInvocation.MyCommand.Name
+
+function print_usage() {
+  echo @"
+Download and install Golang on Windows. It sets the GOROOT environment
+variable and adds GOROOT\bin to the PATH environment variable.
+
+Usage:
+  $SCRIPT -version 1.5.3
+Options:
+  -h | -help
+    Print the help menu.
+  -version
+    Golang version to install. Required.
+"@
+}
+
+if ($help -or $h) {
+  print_usage
+  exit 0
+}
+if ($args -ne "") {
+  Write-Error "Error: Unknown option $args"
+  print_usage
+  exit 1
+}
+if ($version -eq "") {
+    $version = $env:GOVERSION
+}
+if ($version -eq "" ) {
+  Write-Error "Error: -version is required"
+  print_usage
+  exit 1
+}
+
+$downloadDir = $env:TEMP
+$packageName = 'golang'
+$url32 = 'https://storage.googleapis.com/golang/go' + $version + '.windows-386.zip'
+$url64 = 'https://storage.googleapis.com/golang/go' + $version + '.windows-amd64.zip'
+$goroot = "C:\go$version"
+
+# Determine type of system
+if ($ENV:PROCESSOR_ARCHITECTURE -eq "AMD64") {
+  $url = $url64
+} else {
+  $url = $url32
+}
+
+if (Test-Path "$goroot\bin\go") {
+  Write-Host "Go is installed to $goroot"
+  exit
+}
+
+echo "Downloading $url"
+$zip = "$downloadDir\golang-$version.zip"
+if (!(Test-Path "$zip")) {
+  $downloader = new-object System.Net.WebClient
+  $downloader.DownloadFile($url, $zip)
+}
+
+echo "Extracting $zip to $goroot"
+if (Test-Path "$downloadDir\go") {
+  rm -Force -Recurse -Path "$downloadDir\go"
+}
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+[System.IO.Compression.ZipFile]::ExtractToDirectory("$zip", $downloadDir)
+mv "$downloadDir\go" $goroot
+
+echo "Setting GOROOT and PATH for Machine"
+[System.Environment]::SetEnvironmentVariable("GOROOT", "$goroot", "Machine")
+$p = [System.Environment]::GetEnvironmentVariable("PATH", "Machine")
+$p = "$goroot\bin;$p"
+[System.Environment]::SetEnvironmentVariable("PATH", "$p", "Machine")


### PR DESCRIPTION
- Updates master to [Golang 1.5.3](https://golang.org/doc/devel/release.html) (security release)
  - AppVeyor
  - Vagrant Windows 2012
  - Travis
  - Docker images