### PR TITLE
Fix 769: building the test binary includes all vendor package

### DIFF
--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -20,6 +20,9 @@ GOPACKAGES?=${BEAT_DIR}/${BEATNAME}/...
 #     GOPACKAGES=$(shell go list ${BEAT_DIR}/... | grep -v /vendor/)
 #     include $(ES_BEATS)/libbeat/scripts/Makefile
 
+space:=$() #
+comma:=,
+
 ARCH?=$(shell uname -m)
 # Hidden directory to install dependencies for jenkins
 export PATH := ./bin:$(PATH)
@@ -35,7 +38,7 @@ TEST_ENVIRONMENT?=false
 SYSTEM_TESTS?=false
 GOX_OS?=linux darwin windows solaris freebsd netbsd openbsd
 DOCKER_COMPOSE?=docker-compose -f docker-compose.yml
-
+GOPACKAGES_COMMA_SEP=$(subst $(space),$(comma),$(strip ${GOPACKAGES}))
 
 ### BUILDING ###
 
@@ -45,9 +48,9 @@ build: $(GOFILES)
 	go build
 
 # Create test coverage binary
-.PHONY: libbeat.test
-libbeat.test: $(GOFILES)
-	go test -c -covermode=atomic -coverpkg ./...
+.PHONY: buildbeat.test
+buildbeat.test: $(GOFILES)
+	go test -c -covermode=atomic -coverpkg ${GOPACKAGES_COMMA_SEP}
 
 # Cross-compile beat for the OS'es specified in GOX_OS variable.
 # The binaries are placed in the build/bin directory.
@@ -132,13 +135,13 @@ integration-tests-environment:
 
 # Runs the system tests
 .PHONY: system-tests
-system-tests: libbeat.test prepare-tests system-tests-setup
+system-tests: buildbeat.test prepare-tests system-tests-setup
 	. build/system-tests/env/bin/activate; nosetests -w tests/system --process-timeout=$(TIMEOUT) --with-timer
 	python ${ES_BEATS}/dev-tools/aggregate_coverage.py -o ${COVERAGE_DIR}/system.cov ./build/system-tests/run
 
 # Runs system tests without coverage reports and in parallel
 .PHONY: fast-system-tests
-fast-system-tests: libbeat.test system-tests-setup
+fast-system-tests: buildbeat.test system-tests-setup
 	. build/system-tests/env/bin/activate; nosetests -w tests/system --processes=$(PROCESSES) --process-timeout=$(TIMEOUT)
 
 .PHONY: system-tests-setup


### PR DESCRIPTION
"go test -c -covermode=atomic -coverpkg" is called with a list of packages isntead of "./..."