### PR TITLE
Gracefully kill_and_wait on Windows

### DIFF
--- a/libbeat/tests/system/beat/beat.py
+++ b/libbeat/tests/system/beat/beat.py
@@ -60,18 +60,20 @@ class Proc(object):
         return self.proc.wait()
 
     def kill_and_wait(self):
-        self.proc.terminate()
+        self.kill()
         os.close(self.stdin_write)
         return self.proc.wait()
 
     def __del__(self):
-        try:
-            self.output.close()
-        except:
-            pass
+        # Ensure the process is stopped.
         try:
             self.proc.terminate()
             self.proc.kill()
+        except:
+            pass
+        # Ensure the output is closed.
+        try:
+            self.output.close()
         except:
             pass
 


### PR DESCRIPTION
This PR changes the system tests' `kill_and_wait()` method to gracefully stop processes on Windows (see #599 for details). Previously when you called `kill_and_wait` on Windows the process would terminate hard.

#765 partially merged the changes required to fix #599, but a few lines were missing. This should allow coverage reports to be generated by each test case on AppVeyor. It will also allow the process to flush any outputs to file before exiting.