### PR TITLE
Added `/etc/filebeat/filebeat.yml` file path to docs

### DIFF
--- a/filebeat/docs/getting-started.asciidoc
+++ b/filebeat/docs/getting-started.asciidoc
@@ -69,7 +69,7 @@ PS C:\Program Files\Filebeat> .\install-service-filebeat.ps1
 NOTE: If script execution is disabled on your system, you need to set the execution policy for the current session to allow the script to run. For example: `PowerShell.exe -ExecutionPolicy UnRestricted -File .\install-service-filebeat.ps1`. 
 
 Before starting Filebeat, you should look at the configuration options in the configuration
-file, for example `C:\Program Files\Filebeat\filebeat.yml`. For more information about these options,
+file, for example `C:\Program Files\Filebeat\filebeat.yml` or `/etc/Filebeat/filebeat.yml`. For more information about these options,
 see <<filebeat-configuration-details>>.
 
 [[filebeat-configuration]]


### PR DESCRIPTION
It would be helpful to have a sample link for installation on Linux - as I've added - since there isn't any other pointer to where the beat is installed to. It probably should be obvious but a few of my crew were digging around looking for it not realizing that the *.deb package installs the contents to /etc/whateverbeat/*