### PR TITLE
Added `/etc/topbeat/topbeat.yml` file path to docs

### DIFF
--- a/topbeat/docs/gettingstarted.asciidoc
+++ b/topbeat/docs/gettingstarted.asciidoc
@@ -73,7 +73,7 @@ PS C:\Program Files\Topbeat> .\install-service-topbeat.ps1
 NOTE: If script execution is disabled on your system, you need to set the execution policy for the current session to allow the script to run. For example: `PowerShell.exe -ExecutionPolicy UnRestricted -File .\install-service-topbeat.ps1`. 
 
 Before starting Topbeat, you should look at the configuration options in the configuration file,
-for example `C:\Program Files\Topbeat\topbeat.yml`. For more information about these options, see <<topbeat-configuration-options>>.
+for example `C:\Program Files\Topbeat\topbeat.yml` or `/etc/topbeat/topbeat.yml`. For more information about these options, see <<topbeat-configuration-options>>.
 
 [[topbeat-configuration]]
 === Configuring Topbeat


### PR DESCRIPTION
It would be helpful to have a sample link for installation on Linux - as I've added - since there isn't any other pointer to where the beat is installed to. It probably should be obvious but a few of my crew were digging around looking for it not realizing that the *.deb package installs the contents to /etc/whateverbeat/*