### PR TITLE
Check the exit code of the Beats in system tests

### DIFF
--- a/filebeat/beat/filebeat.go
+++ b/filebeat/beat/filebeat.go
@@ -71,8 +71,7 @@ func (fb *Filebeat) Run(b *beat.Beat) error {
 	fb.registrar.LoadState()
 
 	// Init and Start spooler: Harvesters dump events into the spooler.
-	fb.spooler = NewSpooler(fb)
-	err = fb.spooler.Config()
+	fb.spooler = NewSpooler(fb.FbConfig.Filebeat, fb.publisherChan)
 
 	if err != nil {
 		logp.Err("Could not init spooler: %v", err)
@@ -80,7 +79,7 @@ func (fb *Filebeat) Run(b *beat.Beat) error {
 	}
 
 	// Start up spooler
-	go fb.spooler.Run()
+	fb.spooler.Start()
 
 	// registrar records last acknowledged positions in all files.
 	go fb.registrar.Run()

--- a/filebeat/beat/spooler_test.go
+++ b/filebeat/beat/spooler_test.go
@@ -2,6 +2,7 @@ package beat
 
 import (
 	"testing"
+	"time"
 
 	cfg "github.com/elastic/beats/filebeat/config"
 	"github.com/stretchr/testify/assert"
@@ -9,47 +10,27 @@ import (
 )
 
 func TestNewSpoolerDefaultConfig(t *testing.T) {
-
 	var config cfg.FilebeatConfig
 	// Read from empty yaml config
 	yaml.Unmarshal([]byte(""), &config)
-	fbConfig := &cfg.Config{Filebeat: config}
+	spooler := NewSpooler(config, nil)
 
-	fb := &Filebeat{FbConfig: fbConfig}
-	spooler := NewSpooler(fb)
-	err := spooler.Config()
-	assert.Nil(t, err)
-
-	assert.Equal(t, cfg.DefaultSpoolSize, fb.FbConfig.Filebeat.SpoolSize)
-	assert.Equal(t, cfg.DefaultIdleTimeout, fb.FbConfig.Filebeat.IdleTimeoutDuration)
+	assert.Equal(t, cfg.DefaultSpoolSize, spooler.spoolSize)
+	assert.Equal(t, cfg.DefaultIdleTimeout, spooler.idleTimeout)
 }
 
 func TestNewSpoolerSpoolSize(t *testing.T) {
-
 	spoolSize := uint64(19)
 	config := cfg.FilebeatConfig{SpoolSize: spoolSize}
+	spooler := NewSpooler(config, nil)
 
-	fbConfig := &cfg.Config{Filebeat: config}
-
-	fb := &Filebeat{FbConfig: fbConfig}
-	spooler := NewSpooler(fb)
-	err := spooler.Config()
-	assert.Nil(t, err)
-
-	assert.Equal(t, spoolSize, fb.FbConfig.Filebeat.SpoolSize)
+	assert.Equal(t, spoolSize, spooler.spoolSize)
 }
 
 func TestNewSpoolerIdleTimeout(t *testing.T) {
+	var config cfg.FilebeatConfig
+	yaml.Unmarshal([]byte("idle_timeout: 10s"), &config)
+	spooler := NewSpooler(config, nil)
 
-	idleTimoeout := "10s"
-	config := cfg.FilebeatConfig{IdleTimeout: idleTimoeout}
-
-	fbConfig := &cfg.Config{Filebeat: config}
-
-	fb := &Filebeat{FbConfig: fbConfig}
-	spooler := NewSpooler(fb)
-	err := spooler.Config()
-	assert.Nil(t, err)
-
-	assert.Equal(t, idleTimoeout, fb.FbConfig.Filebeat.IdleTimeout)
+	assert.Equal(t, time.Duration(10*time.Second), spooler.idleTimeout)
 }

--- a/filebeat/config/config.go
+++ b/filebeat/config/config.go
@@ -35,13 +35,12 @@ type Config struct {
 }
 
 type FilebeatConfig struct {
-	Prospectors         []ProspectorConfig
-	SpoolSize           uint64 `yaml:"spool_size"`
-	PublishAsync        bool   `yaml:"publish_async"`
-	IdleTimeout         string `yaml:"idle_timeout"`
-	IdleTimeoutDuration time.Duration
-	RegistryFile        string `yaml:"registry_file"`
-	ConfigDir           string `yaml:"config_dir"`
+	Prospectors  []ProspectorConfig
+	SpoolSize    uint64        `yaml:"spool_size"`
+	PublishAsync bool          `yaml:"publish_async"`
+	IdleTimeout  time.Duration `yaml:"idle_timeout"`
+	RegistryFile string        `yaml:"registry_file"`
+	ConfigDir    string        `yaml:"config_dir"`
 }
 
 type ProspectorConfig struct {

--- a/filebeat/harvester/log.go
+++ b/filebeat/harvester/log.go
@@ -88,7 +88,9 @@ func createLineReader(
 func (h *Harvester) Harvest() {
 	defer func() {
 		// On completion, push offset so we can continue where we left off if we relaunch on the same file
-		h.Stat.Return <- h.Offset
+		if h.Stat != nil {
+			h.Stat.Return <- h.Offset
+		}
 
 		// Make sure file is closed as soon as harvester exits
 		// If file was never properly opened, it can't be closed

--- a/filebeat/tests/system/test_crawler.py
+++ b/filebeat/tests/system/test_crawler.py
@@ -44,7 +44,7 @@ class Test(BaseTest):
         # TODO: Find better solution when filebeat did crawl the file
         # Idea: Special flag to filebeat so that filebeat is only doing and
         # crawl and then finishes
-        filebeat.kill_and_wait()
+        filebeat.check_kill_and_wait()
 
         output = self.read_output()
 
@@ -81,7 +81,7 @@ class Test(BaseTest):
             max_timeout=15)
 
         # Give it more time to make sure it doesn't read the unfinished line
-        # This mus be smaller then partial_line_waiting
+        # This must be smaller then partial_line_waiting
         time.sleep(1)
 
         output = self.read_output()
@@ -103,7 +103,7 @@ class Test(BaseTest):
             lambda: self.output_has(lines=82),
             max_timeout=15)
 
-        filebeat.kill_and_wait()
+        filebeat.check_kill_and_wait()
 
         output = self.read_output()
 
@@ -157,7 +157,7 @@ class Test(BaseTest):
             lambda: self.output_has(lines=3),
             max_timeout=15)
 
-        filebeat.kill_and_wait()
+        filebeat.check_kill_and_wait()
 
     def test_file_renaming(self):
         """
@@ -206,7 +206,7 @@ class Test(BaseTest):
                 "Processing 6 events"),
             max_timeout=20)
 
-        filebeat.kill_and_wait()
+        filebeat.check_kill_and_wait()
 
         output = self.read_output()
 
@@ -259,7 +259,7 @@ class Test(BaseTest):
                 "Processing 6 events"),
             max_timeout=15)
 
-        filebeat.kill_and_wait()
+        filebeat.check_kill_and_wait()
 
         data = self.get_dot_filebeat()
 
@@ -323,7 +323,7 @@ class Test(BaseTest):
         self.wait_until(
             lambda: self.output_has(lines=iterations1 + iterations2), max_timeout=10)
 
-        filebeat.kill_and_wait()
+        filebeat.check_kill_and_wait()
 
         data = self.get_dot_filebeat()
 
@@ -381,7 +381,7 @@ class Test(BaseTest):
         self.wait_until(
             lambda: self.output_has(lines=iterations1 + 1), max_timeout=10)
 
-        filebeat.kill_and_wait()
+        filebeat.check_kill_and_wait()
 
         data = self.get_dot_filebeat()
 
@@ -426,7 +426,7 @@ class Test(BaseTest):
                 "Processing 2 events"),
             max_timeout=15)
 
-        filebeat.kill_and_wait()
+        filebeat.check_kill_and_wait()
 
         # Check that output file has the same number of lines as the log file
         output = self.read_output()
@@ -471,7 +471,7 @@ class Test(BaseTest):
                     lambda: self.output_has(lines_written + 1),
                     max_timeout=15)
 
-        filebeat.kill_and_wait()
+        filebeat.check_kill_and_wait()
 
         # Check that output file has the same number of lines as the log file
         output = self.read_output()
@@ -511,7 +511,7 @@ class Test(BaseTest):
                     "Processing 2 events"),
                 max_timeout=15)
 
-        filebeat.kill_and_wait()
+        filebeat.check_kill_and_wait()
 
         # Check that output file has the same number of lines as the log file
         output = self.read_output()
@@ -552,7 +552,7 @@ class Test(BaseTest):
             lambda: self.output_has(lines=2),
             max_timeout=15)
 
-        filebeat.kill_and_wait()
+        filebeat.check_kill_and_wait()
 
         # Make sure output has only 2 and not 4 lines, means it started at
         # the end
@@ -603,7 +603,7 @@ class Test(BaseTest):
                     "Processing 2 events"),
                 max_timeout=15)
 
-        filebeat.kill_and_wait()
+        filebeat.check_kill_and_wait()
 
         # Make sure output has 3
         output = self.read_output()
@@ -665,7 +665,7 @@ class Test(BaseTest):
         # wait again
         self.wait_until(lambda: self.output_has(lines=len(encodings) * 2),
                         max_timeout=15)
-        filebeat.kill_and_wait()
+        filebeat.check_kill_and_wait()
 
         # check that all outputs are present in the JSONs in UTF-8
         # encoding
@@ -709,7 +709,7 @@ class Test(BaseTest):
         # TODO: Find better solution when filebeat did crawl the file
         # Idea: Special flag to filebeat so that filebeat is only doing and
         # crawl and then finishes
-        filebeat.kill_and_wait()
+        filebeat.check_kill_and_wait()
 
         output = self.read_output()
 
@@ -749,7 +749,7 @@ class Test(BaseTest):
         # TODO: Find better solution when filebeat did crawl the file
         # Idea: Special flag to filebeat so that filebeat is only doing and
         # crawl and then finishes
-        filebeat.kill_and_wait()
+        filebeat.check_kill_and_wait()
 
         output = self.read_output()
 
@@ -790,7 +790,7 @@ class Test(BaseTest):
         # TODO: Find better solution when filebeat did crawl the file
         # Idea: Special flag to filebeat so that filebeat is only doing and
         # crawl and then finishes
-        filebeat.kill_and_wait()
+        filebeat.check_kill_and_wait()
 
         output = self.read_output()
 
@@ -832,7 +832,7 @@ class Test(BaseTest):
         # TODO: Find better solution when filebeat did crawl the file
         # Idea: Special flag to filebeat so that filebeat is only doing and
         # crawl and then finishes
-        filebeat.kill_and_wait()
+        filebeat.check_kill_and_wait()
 
         output = self.read_output()
 
@@ -896,7 +896,7 @@ class Test(BaseTest):
             lambda: self.log_contains("permission denied"),
             max_timeout=15)
 
-        filebeat.kill_and_wait()
+        filebeat.check_kill_and_wait()
 
         os.chmod(testfile, 0o755)
 

--- a/filebeat/tests/system/test_fields.py
+++ b/filebeat/tests/system/test_fields.py
@@ -23,7 +23,7 @@ class Test(BaseTest):
 
         filebeat = self.start_beat()
         self.wait_until(lambda: self.output_has(lines=1))
-        filebeat.kill_and_wait()
+        filebeat.check_kill_and_wait()
 
         output = self.read_output()
         doc = output[0]
@@ -49,7 +49,7 @@ class Test(BaseTest):
 
         filebeat = self.start_beat()
         self.wait_until(lambda: self.output_has(lines=1))
-        filebeat.kill_and_wait()
+        filebeat.check_kill_and_wait()
 
         output = self.read_output()
         doc = output[0]
@@ -74,7 +74,7 @@ class Test(BaseTest):
 
         filebeat = self.start_beat()
         self.wait_until(lambda: self.output_has(lines=1))
-        filebeat.kill_and_wait()
+        filebeat.check_kill_and_wait()
 
         output = self.read_output()
         doc = output[0]

--- a/filebeat/tests/system/test_multiline.py
+++ b/filebeat/tests/system/test_multiline.py
@@ -33,7 +33,7 @@ class Test(BaseTest):
             lambda: self.output_has(lines=20),
             max_timeout=10)
 
-        proc.kill_and_wait()
+        proc.check_kill_and_wait()
 
         output = self.read_output()
 
@@ -64,7 +64,7 @@ class Test(BaseTest):
             lambda: self.output_has(lines=4),
             max_timeout=10)
 
-        proc.kill_and_wait()
+        proc.check_kill_and_wait()
 
         output = self.read_output()
 
@@ -96,7 +96,7 @@ class Test(BaseTest):
             lambda: self.output_has(lines=20),
             max_timeout=10)
 
-        proc.kill_and_wait()
+        proc.check_kill_and_wait()
 
         output = self.read_output()
 
@@ -150,7 +150,7 @@ class Test(BaseTest):
         self.wait_until(
             lambda: self.output_has(lines=3),
             max_timeout=10)
-        proc.kill_and_wait()
+        proc.check_kill_and_wait()
 
         output = self.read_output()
         assert 3 == len(output)
@@ -179,7 +179,7 @@ class Test(BaseTest):
             lambda: self.output_has(lines=20),
             max_timeout=10)
 
-        proc.kill_and_wait()
+        proc.check_kill_and_wait()
 
         output = self.read_output()
 

--- a/filebeat/tests/system/test_prospector.py
+++ b/filebeat/tests/system/test_prospector.py
@@ -40,7 +40,7 @@ class Test(BaseTest):
                 "Skipping file (older than ignore older of 1s"),
             max_timeout=10)
 
-        proc.kill_and_wait()
+        proc.check_kill_and_wait()
 
     def test_not_ignore_old_files(self):
         """
@@ -69,7 +69,7 @@ class Test(BaseTest):
                 "Processing 5 events"),
             max_timeout=10)
 
-        proc.kill_and_wait()
+        proc.check_kill_and_wait()
 
         objs = self.read_output()
         assert len(objs) == 5
@@ -105,7 +105,7 @@ class Test(BaseTest):
             lambda: self.output_has(lines=iterations1 + iterations2),
             max_timeout=15)
 
-        proc.kill_and_wait()
+        proc.check_kill_and_wait()
 
         objs = self.read_output()
         assert len(objs) == iterations1 + iterations2
@@ -138,7 +138,7 @@ class Test(BaseTest):
             lambda: self.output_count(lambda x: x >= lines),
             max_timeout=15)
 
-        proc.kill_and_wait()
+        proc.check_kill_and_wait()
 
     def test_exclude_files(self):
 
@@ -167,7 +167,7 @@ class Test(BaseTest):
         # TODO: Find better solution when filebeat did crawl the file
         # Idea: Special flag to filebeat so that filebeat is only doing and
         # crawl and then finishes
-        filebeat.kill_and_wait()
+        filebeat.check_kill_and_wait()
 
         output = self.read_output()
 
@@ -231,7 +231,7 @@ class Test(BaseTest):
             lambda: self.output_count(lambda x: x >= lines),
             max_timeout=5)
 
-        filebeat.kill_and_wait()
+        filebeat.check_kill_and_wait()
 
     def test_shutdown_no_prospectors(self):
         """
@@ -254,7 +254,7 @@ class Test(BaseTest):
                 "shutting down"),
             max_timeout=10)
 
-        filebeat.kill_and_wait()
+        filebeat.check_kill_and_wait()
 
     def test_no_paths_defined(self):
         """
@@ -277,7 +277,7 @@ class Test(BaseTest):
                 "shutting down"),
             max_timeout=10)
 
-        filebeat.kill_and_wait()
+        filebeat.check_kill_and_wait()
 
     def test_files_added_late(self):
         """
@@ -307,7 +307,7 @@ class Test(BaseTest):
             lambda: self.output_has(lines=2),
             max_timeout=15)
 
-        filebeat.kill_and_wait()
+        filebeat.check_kill_and_wait()
 
     def test_close_older(self):
         """
@@ -360,4 +360,4 @@ class Test(BaseTest):
                 lambda: self.output_count(lambda x: x >= lines),
                 max_timeout=5)
 
-        filebeat.kill_and_wait()
+        filebeat.check_kill_and_wait()

--- a/filebeat/tests/system/test_registrar.py
+++ b/filebeat/tests/system/test_registrar.py
@@ -41,7 +41,7 @@ class Test(BaseTest):
             lambda: os.path.isfile(os.path.join(self.working_dir,
                                                 ".filebeat")),
             max_timeout=1)
-        filebeat.kill_and_wait()
+        filebeat.check_kill_and_wait()
 
         # Check that file exist
         data = self.get_dot_filebeat()
@@ -117,7 +117,7 @@ class Test(BaseTest):
             lambda: os.path.isfile(os.path.join(self.working_dir,
                                                 ".filebeat")),
             max_timeout=1)
-        filebeat.kill_and_wait()
+        filebeat.check_kill_and_wait()
 
         # Check that file exist
         data = self.get_dot_filebeat()
@@ -150,6 +150,6 @@ class Test(BaseTest):
                                                 "a/b/c/registry")),
 
             max_timeout=1)
-        filebeat.kill_and_wait()
+        filebeat.check_kill_and_wait()
 
         assert os.path.isfile(os.path.join(self.working_dir, "a/b/c/registry"))

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -41,6 +41,12 @@ GOX_OS?=linux darwin windows solaris freebsd netbsd openbsd
 DOCKER_COMPOSE?=docker-compose -f docker-compose.yml
 GOPACKAGES_COMMA_SEP=$(subst $(space),$(comma),$(strip ${GOPACKAGES}))
 
+# Conditionally enable the race detector when RACE_DETECTOR=1.
+ifeq ($(RACE_DETECTOR),1)
+    RACE=-race
+endif
+
+
 ### BUILDING ###
 
 # Builds beat
@@ -51,7 +57,7 @@ build: $(GOFILES)
 # Create test coverage binary
 .PHONY: buildbeat.test
 buildbeat.test: $(GOFILES)
-	go test -c -race -covermode=atomic -coverpkg ${GOPACKAGES_COMMA_SEP}
+	go test $(RACE) -c -coverpkg ${GOPACKAGES_COMMA_SEP}
 
 # Cross-compile beat for the OS'es specified in GOX_OS variable.
 # The binaries are placed in the build/bin directory.
@@ -109,17 +115,17 @@ prepare-tests:
 # Race is not enabled for unit tests because tests run much slower.
 .PHONY: unit-tests
 unit-tests: prepare-tests
-	$(GOPATH)/bin/gotestcover -coverprofile=${COVERAGE_DIR}/unit.cov -short -covermode=atomic ${GOPACKAGES}
+	$(GOPATH)/bin/gotestcover -coverprofile=${COVERAGE_DIR}/unit.cov -short ${GOPACKAGES}
 
 # Runs the unit tests without coverage reports.
 .PHONY: unit
 unit:
-	go test -short ./...
+	go test $(RACE) -short ./...
 
-# Run integration tests. Unit tests are run as part of the integration tests. It runs all tests with race detection enabled.
+# Run integration tests. Unit tests are run as part of the integration tests.
 .PHONY: integration-tests
 integration-tests: prepare-tests
-	$(GOPATH)/bin/gotestcover -race -coverprofile=${COVERAGE_DIR}/integration.cov -covermode=atomic ${GOPACKAGES}
+	$(GOPATH)/bin/gotestcover $(RACE) -coverprofile=${COVERAGE_DIR}/integration.cov ${GOPACKAGES}
 
 # Runs the integration inside a virtual environment. This can be run on any docker-machine (local, remote)
 .PHONY: integration-tests-environment

--- a/libbeat/tests/system/base.py
+++ b/libbeat/tests/system/base.py
@@ -8,3 +8,10 @@ class BaseTest(TestCase):
         self.beat_name = "mockbeat"
         self.build_path = "../../build/system-tests/"
         self.beat_path = "../../libbeat.test"
+
+    def test_version(self):
+        """
+        Tests -version prints a version and exits.
+        """
+        self.start_beat(extra_args=["-version"]).check_wait()
+        assert self.log_contains("beat version") is True

--- a/libbeat/tests/system/beat/beat.py
+++ b/libbeat/tests/system/beat/beat.py
@@ -59,10 +59,20 @@ class Proc(object):
     def wait(self):
         return self.proc.wait()
 
+    def check_wait(self, exit_code=0):
+        actual_exit_code = self.wait()
+        assert actual_exit_code == exit_code, "Expected exit code to be %d, but it was %d" % (exit_code, actual_exit_code)
+        return actual_exit_code
+
     def kill_and_wait(self):
         self.kill()
         os.close(self.stdin_write)
         return self.proc.wait()
+
+    def check_kill_and_wait(self, exit_code=0):
+        self.kill()
+        os.close(self.stdin_write)
+        return self.check_wait()
 
     def __del__(self):
         # Ensure the process is stopped.

--- a/packetbeat/tests/system/packetbeat.py
+++ b/packetbeat/tests/system/packetbeat.py
@@ -23,7 +23,8 @@ class BaseTest(TestCase):
                        config="packetbeat.yml",
                        output="packetbeat.log",
                        extra_args=[],
-                       debug_selectors=[]):
+                       debug_selectors=[],
+                       exit_code=0):
         """
         Executes packetbeat on an input pcap file.
         Waits for the process to finish before returning to
@@ -50,7 +51,9 @@ class BaseTest(TestCase):
             proc = subprocess.Popen(args,
                                     stdout=outputfile,
                                     stderr=subprocess.STDOUT)
-            return proc.wait()
+            actual_exit_code = proc.wait()
+            assert actual_exit_code == exit_code, "Expected exit code to be %d, but it was %d" % (exit_code, actual_exit_code)
+            return actual_exit_code
 
     def start_packetbeat(self,
                          cmd="../../packetbeat.test",

--- a/packetbeat/tests/system/test_0026_test_config.py
+++ b/packetbeat/tests/system/test_0026_test_config.py
@@ -2,7 +2,7 @@ from packetbeat import BaseTest
 import os
 
 """
-Tests for checking the -test CLI option and the
+Tests for checking the -configtest CLI option and the
 return codes.
 """
 
@@ -11,26 +11,22 @@ class Test(BaseTest):
 
     def test_ok_config(self):
         """
-        With -test and correct configuration, it should exit with
+        With -configtest and correct configuration, it should exit with
         status 0 but not actually process any packets.
         """
         self.render_config_template()
-        exit_code = self.run_packetbeat(pcap="http_post.pcap",
-                                        extra_args=["-configtest"])
-        assert exit_code == 0
+        self.run_packetbeat(pcap="http_post.pcap",
+                            extra_args=["-configtest"])
 
         assert not os.path.isfile(
             os.path.join(self.working_dir, "output/packetbeat"))
 
     def test_config_error(self):
         """
-        With -test and an error in the configuration, it should
+        With -configtest and an error in the configuration, it should
         return a non-zero error code.
         """
         self.render_config_template(
             iface_device="NoSuchDevice"
         )
-        proc = self.start_packetbeat(extra_args=["-configtest"])
-        exit_code = proc.wait()
-        print exit_code
-        assert exit_code == 1
+        self.start_packetbeat(extra_args=["-configtest"]).check_wait(exit_code=1)

--- a/topbeat/tests/system/test_cpu_per_core.py
+++ b/topbeat/tests/system/test_cpu_per_core.py
@@ -1,22 +1,18 @@
+import sys
+import unittest
 from topbeat import BaseTest
 
-import os
-
 """
-Contains tests for ide statistics.
+Contains tests for CPU statistics.
 """
-
 
 class Test(BaseTest):
+    @unittest.skipIf(sys.platform.startswith("win"), "CPU core stats require unix")
     def test_cpu_per_core(self):
         """
         Checks that cpu usage per core statistics are exported
         when the config option is enabled.
         """
-        # the test applies only for Unix systems
-        if os.name == "nt":
-            return
-
         self.render_config_template(
             system_stats=True,
             process_stats=False,
@@ -25,7 +21,7 @@ class Test(BaseTest):
         )
         topbeat = self.start_beat()
         self.wait_until(lambda: self.output_has(lines=1))
-        topbeat.kill_and_wait()
+        topbeat.check_kill_and_wait()
 
         output = self.read_output()[0]
 

--- a/topbeat/tests/system/test_filesystem.py
+++ b/topbeat/tests/system/test_filesystem.py
@@ -2,7 +2,7 @@ from topbeat import BaseTest
 import numbers
 
 """
-Contains tests for ide statistics.
+Contains tests for filesystem statistics.
 """
 
 
@@ -19,7 +19,7 @@ class Test(BaseTest):
         )
         topbeat = self.start_beat()
         self.wait_until(lambda: self.log_contains(msg="output worker: publish"))
-        topbeat.kill_and_wait()
+        topbeat.check_kill_and_wait()
 
         output = self.read_output()[0]
 

--- a/topbeat/tests/system/test_procs.py
+++ b/topbeat/tests/system/test_procs.py
@@ -22,7 +22,7 @@ class Test(BaseTest):
         )
         topbeat = self.start_beat()
         self.wait_until(lambda: self.output_has(lines=1))
-        topbeat.kill_and_wait()
+        topbeat.check_kill_and_wait()
 
         output = self.read_output()[0]
 

--- a/topbeat/tests/system/test_system.py
+++ b/topbeat/tests/system/test_system.py
@@ -22,7 +22,7 @@ class Test(BaseTest):
 
         topbeat = self.start_beat()
         self.wait_until(lambda: self.output_has(lines=1))
-        topbeat.kill_and_wait()
+        topbeat.check_kill_and_wait()
         output = self.read_output()[0]
 
         if os.name != "nt":

--- a/winlogbeat/tests/system/test_config.py
+++ b/winlogbeat/tests/system/test_config.py
@@ -18,9 +18,7 @@ class Test(BaseTest):
                 {"name": "Application", "ignore_older": "48h"}
             ]
         )
-        proc = self.start_beat(extra_args=["-configtest"])
-        exit_code = proc.wait()
-        assert exit_code == 0
+        self.start_beat(extra_args=["-configtest"]).check_wait()
 
     def test_invalid_ignore_older(self):
         """
@@ -33,8 +31,6 @@ class Test(BaseTest):
                 {"name": "Application"}
             ]
         )
-        proc = self.start_beat(extra_args=["-configtest"])
-        exit_code = proc.wait()
-        assert exit_code == 1
+        self.start_beat(extra_args=["-configtest"]).check_wait(exit_code=1)
         assert self.log_contains(
             "Invalid top level ignore_older value '1 hour'")

--- a/winlogbeat/tests/system/test_eventlog.py
+++ b/winlogbeat/tests/system/test_eventlog.py
@@ -90,7 +90,7 @@ class Test(BaseTest):
         )
         proc = self.start_beat()
         self.wait_until(lambda: self.output_has(1))
-        proc.kill()
+        proc.check_kill_and_wait()
 
         # Verify output
         events = self.read_output()
@@ -108,9 +108,6 @@ class Test(BaseTest):
         assert "user.type" in evt
         assert "user.domain" in evt
         assert evt["message"] == msg
-
-        exit_code = proc.wait()
-        assert exit_code == 0
 
         return evt
 
@@ -151,7 +148,7 @@ class Test(BaseTest):
         )
         proc = self.start_beat()
         self.wait_until(lambda: self.output_has(1))
-        proc.kill()
+        proc.check_kill_and_wait()
 
         # Verify output
         events = self.read_output()
@@ -169,9 +166,6 @@ class Test(BaseTest):
         assert "user.type" in evt
         assert "user.domain" in evt
         assert "message" not in evt
-
-        exit_code = proc.wait()
-        assert exit_code == 0
 
         return evt
 
@@ -206,7 +200,7 @@ class Test(BaseTest):
         )
         proc = self.start_beat()
         self.wait_until(lambda: self.output_has(1))
-        proc.kill()
+        proc.check_kill_and_wait()
 
         # Verify output
         events = self.read_output()
@@ -224,8 +218,5 @@ class Test(BaseTest):
         assert "user.type" not in evt
         assert "user.domain" not in evt
         assert evt["message"] == msg
-
-        exit_code = proc.wait()
-        assert exit_code == 0
 
         return evt


### PR DESCRIPTION
This PR verifies that Beats are exiting cleaning while running system tests. It will help to catch panics and data races.

The Filebeat tests on Windows are going to fail because there is a panic in one test case and data races in the rest. On OSX/Linux we don't run the system tests with the race detector so the tests should pass.

- [Filebeat data race output](http://pastebin.com/raw/YX7eBcbR)
- [Filebeat stdin test panic](http://pastebin.com/raw/AHs1CQ6u)