### PR TITLE
Added `/etc/packetbeat/packetbeat.yml` file path to docs

### DIFF
--- a/packetbeat/docs/gettingstarted.asciidoc
+++ b/packetbeat/docs/gettingstarted.asciidoc
@@ -78,7 +78,7 @@ PS C:\Program Files\Packetbeat> .\install-service-packetbeat.ps1
 NOTE: If script execution is disabled on your system, you need to set the execution policy for the current session to allow the script to run. For example: `PowerShell.exe -ExecutionPolicy UnRestricted -File .\install-service-packetbeat.ps1`. 
 
 Before starting Packetbeat, you should look at the configuration options in the
-configuration file, for example `C:\Program Files\Packetbeat\packetbeat.yml`. For
+configuration file, for example `C:\Program Files\Packetbeat\packetbeat.yml` or `/etc/Packetbeat/packetbeat.yml`. For
 more information about these options, see <<packetbeat-configuration>>.
 
 [[configuring-packetbeat]]


### PR DESCRIPTION
It would be helpful to have a sample link for installation on Linux - as I've added - since there isn't any other pointer to where the beat is installed to. It probably should be obvious but a few of my crew were digging around looking for it not realizing that the .deb package installs the contents to /etc/whateverbeat/