### PR TITLE
Edit new/changed content added to Filebeat and changelog for 1.1

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -32,6 +32,9 @@ https://github.com/elastic/beats/compare/v1.1.0...master[Check the HEAD diff]
 - Set default bulk_max_size value to 2048 {pull}628[628]
 
 *Packetbeat*
+- Fix the condition that determines whether the direction of the transaction is set to "outgoing". Packetbeat uses the 
+  direction field to determine which transactions to drop when dropping outgoing transactions. {pull}557[557]
+- Allow PF_RING sniffer type to be configured using pf_ring or pfring {pull}671[671]
 
 *Topbeat*
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,10 @@ https://github.com/elastic/beats/compare/v1.1.0...master[Check the HEAD diff]
 ==== Bugfixes
 
 *Affecting all Beats*
+- Fix logging issue with file-based output where newlines could be misplaced
+  during concurrent logging {pull}650[650]
+- Reduce memory usage by having separate queue sizes for single events and bulk events. {pull}649[649] {issue}516[516]
+- Set default bulk_max_size value to 2048 {pull}628[628]
 
 *Packetbeat*
 
@@ -43,10 +47,14 @@ https://github.com/elastic/beats/compare/v1.1.0...master[Check the HEAD diff]
 *Packetbeat*
 
 *Topbeat*
+- Group all CPU usage per core statistics and export them optionally if cpu_per_core is configured {pull}496[496]
 
 *Filebeat*
 
 *Winlogbeat*
+- Add support for reading event logs using the Windows Event Log API {pull}576[576]
+- Modify the event schema to clarify the field meanings. {pull}607[607]
+
 
 ==== Deprecated
 

--- a/filebeat/docs/migration.asciidoc
+++ b/filebeat/docs/migration.asciidoc
@@ -12,23 +12,22 @@ Filebeat introduces the following major changes:
   changed.
 * Command line options were removed and moved to the configuration file.
 * Configuration options for outputs are now inherited from libbeat. For details, see the {libbeat}/index.html[Beats Platform Reference].
-* A new Logstash input plugin called https://www.elastic.co/guide/en/logstash/current/plugins-inputs-beats.html[logstash-input-beats] is required.
+* The https://www.elastic.co/guide/en/logstash/current/plugins-inputs-beats.html[Beats input plugin for Logstash] is required.
 
 
-=== Migrating to the Logstash Input Beats Plugin
+=== Migrating to the Beats Input Plugin for Logstash
 
-Filebeat requires a new input plugin in Logstash, called
-https://www.elastic.co/guide/en/logstash/current/plugins-inputs-beats.html[logstash-input-beats].
+Filebeat requires the https://www.elastic.co/guide/en/logstash/current/plugins-inputs-beats.html[Beats input plugin for Logstash].
 For information about getting started with this plugin, see {libbeat}/getting-started.html#logstash-setup[Setting up Logstash].
 
 In both the 1.5.x and 2.x versions of Logstash, this plugin can be loaded in
 parallel with the
-https://github.com/logstash-plugins/logstash-input-lumberjack[logstash-input-lumberjack]
+https://github.com/logstash-plugins/logstash-input-lumberjack[Lumberjack]
 plugin used by the Logstash Forwarder.
 
 If you have a large number of servers that you want to migrate from
 Logstash Forwarder to Filebeat, we recommend that you keep the Lumberjack plugin and load the
-Beats plugin on the same Logstash instances, but set up the Beats plugin to use a different port. After you have migrated
+Beats input plugin on the same Logstash instances, but set up the Beats input plugin to use a different port. After you have migrated
 all the machines to Filebeat, you can remove the Lumberjack plugin.
 
 ===  Updating the Registry File


### PR DESCRIPTION
Copy edits for style/consistency.  I wasn't planning to edit the CHANGELOG, but I noticed a typo and decided to give the new info for 1.1 (in the commented out section) a quick edit. 

@monicasarbu The following description in the CHANGELOG is not very end user friendly, and it's hard to follow: "Fix setting direction to out and use its value to decide when dropping events if ignore_outgoing is enabled {pull}557[557]." Can you rephrase this sentence to more accurately reflect how the change affects the user? If you want to suggest a change in the comments here, I can add it and submit the change with this PR. Thanks!