### PR TITLE
Refactor Topbeat to export MapStr instead of Struct

### DIFF
--- a/topbeat/beat/sigar_test.go
+++ b/topbeat/beat/sigar_test.go
@@ -33,7 +33,7 @@ func TestGetCpuTimes(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.True(t, (cpu_stat.User > 0))
-	assert.True(t, (cpu_stat.System > 0))
+	assert.True(t, (cpu_stat.Sys > 0))
 
 }
 
@@ -97,14 +97,14 @@ func TestGetProcess(t *testing.T) {
 
 		// Memory Checks
 		assert.True(t, (process.Mem.Size >= 0))
-		assert.True(t, (process.Mem.Rss >= 0))
+		assert.True(t, (process.Mem.Resident >= 0))
 		assert.True(t, (process.Mem.Share >= 0))
 
 		// CPU Checks
-		assert.True(t, (len(process.Cpu.Start) > 0))
+		assert.True(t, (process.Cpu.StartTime > 0))
 		assert.True(t, (process.Cpu.Total >= 0))
 		assert.True(t, (process.Cpu.User >= 0))
-		assert.True(t, (process.Cpu.System >= 0))
+		assert.True(t, (process.Cpu.Sys >= 0))
 
 		assert.True(t, (process.ctime.Unix() <= time.Now().Unix()))
 

--- a/topbeat/beat/topbeat.go
+++ b/topbeat/beat/topbeat.go
@@ -202,9 +202,6 @@ func (t *Topbeat) exportProcStats() error {
 
 		if t.MatchProcess(process.Name) {
 
-			t.addProcCpuPercentage(process)
-			t.addProcMemPercentage(process, 0 /*read total mem usage */)
-
 			newProcs[process.Pid] = process
 
 			proc := common.MapStr{
@@ -212,8 +209,19 @@ func (t *Topbeat) exportProcStats() error {
 				"ppid":  process.Ppid,
 				"name":  process.Name,
 				"state": process.State,
-				"mem":   process.Mem,
-				"cpu":   process.Cpu,
+				"mem": common.MapStr{
+					"size":  process.Mem.Size,
+					"rss":   process.Mem.Resident,
+					"rss_p": t.getProcMemPercentage(process, 0 /* read total mem usage */),
+					"share": process.Mem.Share,
+				},
+				"cpu": common.MapStr{
+					"user":       process.Cpu.User,
+					"system":     process.Cpu.Sys,
+					"total":      process.Cpu.Total,
+					"total_p":    t.getProcCpuPercentage(process),
+					"start_time": process.Cpu.FormatStartTime(),
+				},
 			}
 
 			if process.CmdLine != "" {
@@ -223,8 +231,8 @@ func (t *Topbeat) exportProcStats() error {
 			event := common.MapStr{
 				"@timestamp": common.Time(time.Now()),
 				"type":       "process",
-				"proc":       proc,
 				"count":      1,
+				"proc":       proc,
 			}
 
 			t.events.PublishEvent(event)
@@ -248,13 +256,6 @@ func (t *Topbeat) exportSystemStats() error {
 
 	t.addCpuPercentage(cpu_stat)
 
-	cpu_core_stat, err := GetCpuTimesList()
-	if err != nil {
-		logp.Warn("Getting cpu core times: %v", err)
-		return err
-	}
-	t.addCpuPercentageList(cpu_core_stat)
-
 	mem_stat, err := GetMemory()
 	if err != nil {
 		logp.Warn("Getting memory details: %v", err)
@@ -273,18 +274,60 @@ func (t *Topbeat) exportSystemStats() error {
 		"@timestamp": common.Time(time.Now()),
 		"type":       "system",
 		"load":       load_stat,
-		"cpu":        cpu_stat,
-		"mem":        mem_stat,
-		"swap":       swap_stat,
 		"count":      1,
+		"cpu": common.MapStr{
+			"user":     cpu_stat.User,
+			"system":   cpu_stat.Sys,
+			"nice":     cpu_stat.Nice,
+			"idle":     cpu_stat.Idle,
+			"iowait":   cpu_stat.Wait,
+			"irq":      cpu_stat.Irq,
+			"softirq":  cpu_stat.SoftIrq,
+			"steal":    cpu_stat.Stolen,
+			"user_p":   cpu_stat.UserPercent,
+			"system_p": cpu_stat.SystemPercent,
+		},
+		"mem": common.MapStr{
+			"total":         mem_stat.Total,
+			"used":          mem_stat.Used,
+			"free":          mem_stat.Free,
+			"actual_used":   mem_stat.ActualUsed,
+			"actual_free":   mem_stat.ActualFree,
+			"used_p":        mem_stat.UsedPercent,
+			"actual_used_p": mem_stat.ActualUsedPercent,
+		},
+		"swap": common.MapStr{
+			"total":  swap_stat.Total,
+			"used":   swap_stat.Used,
+			"free":   swap_stat.Free,
+			"used_p": swap_stat.UsedPercent,
+		},
 	}
 
 	if t.cpuPerCore {
 
+		cpu_core_stat, err := GetCpuTimesList()
+		if err != nil {
+			logp.Warn("Getting cpu core times: %v", err)
+			return err
+		}
+		t.addCpuPercentageList(cpu_core_stat)
+
 		cpus := common.MapStr{}
 
 		for coreNumber, stat := range cpu_core_stat {
-			cpus["cpu"+strconv.Itoa(coreNumber)] = stat
+			cpus["cpu"+strconv.Itoa(coreNumber)] = common.MapStr{
+				"user":     stat.User,
+				"system":   stat.Sys,
+				"nice":     stat.Nice,
+				"idle":     stat.Idle,
+				"iowait":   stat.Wait,
+				"irq":      stat.Irq,
+				"softirq":  stat.SoftIrq,
+				"steal":    stat.Stolen,
+				"user_p":   stat.UserPercent,
+				"system_p": stat.SystemPercent,
+			}
 		}
 		event["cpus"] = cpus
 	}
@@ -318,8 +361,18 @@ func collectFileSystemStats(fss []sigar.FileSystem) []common.MapStr {
 		event := common.MapStr{
 			"@timestamp": common.Time(time.Now()),
 			"type":       "filesystem",
-			"fs":         fsStat,
 			"count":      1,
+			"fs": common.MapStr{
+				"device_name": fsStat.DevName,
+				"mount_point": fsStat.Mount,
+				"total":       fsStat.Total,
+				"used":        fsStat.Used,
+				"free":        fsStat.Free,
+				"avail":       fsStat.Avail,
+				"files":       fsStat.Files,
+				"free_files":  fsStat.FreeFiles,
+				"used_p":      fsStat.UsedPercent,
+			},
 		}
 		events = append(events, event)
 	}
@@ -339,23 +392,23 @@ func (t *Topbeat) MatchProcess(name string) bool {
 
 func (t *Topbeat) addMemPercentage(m *MemStat) {
 
-	if m.Total == 0 {
+	if m.Mem.Total == 0 {
 		return
 	}
 
-	perc := float64(m.Used) / float64(m.Total)
+	perc := float64(m.Mem.Used) / float64(m.Mem.Total)
 	m.UsedPercent = Round(perc, .5, 2)
 
-	actual_perc := float64(m.ActualUsed) / float64(m.Total)
+	actual_perc := float64(m.Mem.ActualUsed) / float64(m.Mem.Total)
 	m.ActualUsedPercent = Round(actual_perc, .5, 2)
 }
 
 func (t *Topbeat) addSwapPercentage(s *SwapStat) {
-	if s.Total == 0 {
+	if s.Swap.Total == 0 {
 		return
 	}
 
-	perc := float64(s.Used) / float64(s.Total)
+	perc := float64(s.Swap.Used) / float64(s.Swap.Total)
 	s.UsedPercent = Round(perc, .5, 2)
 }
 
@@ -373,7 +426,7 @@ func (t *Topbeat) addCpuPercentage(t2 *CpuTimes) {
 	t1 := t.lastCpuTimes
 
 	if t1 != nil && t2 != nil {
-		all_delta := t2.sum() - t1.sum()
+		all_delta := t2.Cpu.Total() - t1.Cpu.Total()
 
 		calculate := func(field2 uint64, field1 uint64) float64 {
 
@@ -383,8 +436,8 @@ func (t *Topbeat) addCpuPercentage(t2 *CpuTimes) {
 			return Round(perc, .5, 2)
 		}
 
-		t2.UserPercent = calculate(t2.User, t1.User)
-		t2.SystemPercent = calculate(t2.System, t1.System)
+		t2.UserPercent = calculate(t2.Cpu.User, t1.Cpu.User)
+		t2.SystemPercent = calculate(t2.Cpu.Sys, t1.Cpu.Sys)
 	}
 
 	t.lastCpuTimes = t2
@@ -406,9 +459,9 @@ func (t *Topbeat) addCpuPercentageList(t2 []CpuTimes) {
 		}
 
 		for i := 0; i < len(t1); i++ {
-			all_delta := t2[i].sum() - t1[i].sum()
-			t2[i].UserPercent = calculate(t2[i].User, t1[i].User, all_delta)
-			t2[i].SystemPercent = calculate(t2[i].System, t1[i].System, all_delta)
+			all_delta := t2[i].Cpu.Total() - t1[i].Cpu.Total()
+			t2[i].UserPercent = calculate(t2[i].Cpu.User, t1[i].Cpu.User, all_delta)
+			t2[i].SystemPercent = calculate(t2[i].Cpu.Sys, t1[i].Cpu.Sys, all_delta)
 		}
 
 	}
@@ -417,7 +470,7 @@ func (t *Topbeat) addCpuPercentageList(t2 []CpuTimes) {
 
 }
 
-func (t *Topbeat) addProcMemPercentage(proc *Process, total_phymem uint64) {
+func (t *Topbeat) getProcMemPercentage(proc *Process, total_phymem uint64) float64 {
 
 	// in unit tests, total_phymem is set to a value greater than zero
 
@@ -425,30 +478,31 @@ func (t *Topbeat) addProcMemPercentage(proc *Process, total_phymem uint64) {
 		mem_stat, err := GetMemory()
 		if err != nil {
 			logp.Warn("Getting memory details: %v", err)
-			return
+			return 0
 		}
-		total_phymem = mem_stat.Total
+		total_phymem = mem_stat.Mem.Total
 	}
 
-	perc := (float64(proc.Mem.Rss) / float64(total_phymem))
+	perc := (float64(proc.Mem.Resident) / float64(total_phymem))
 
-	proc.Mem.RssPercent = Round(perc, .5, 2)
+	return Round(perc, .5, 2)
 }
 
-func (t *Topbeat) addProcCpuPercentage(proc *Process) {
+func (t *Topbeat) getProcCpuPercentage(proc *Process) float64 {
 
 	oproc, ok := t.procsMap[proc.Pid]
 	if ok {
 
-		delta_proc := (proc.Cpu.User - oproc.Cpu.User) + (proc.Cpu.System - oproc.Cpu.System)
+		delta_proc := (proc.Cpu.User - oproc.Cpu.User) + (proc.Cpu.Sys - oproc.Cpu.Sys)
 		delta_time := proc.ctime.Sub(oproc.ctime).Nanoseconds() / 1e6 // in milliseconds
 		perc := float64(delta_proc) / float64(delta_time)
 
 		t.procsMap[proc.Pid] = proc
 
-		proc.Cpu.TotalPercent = Round(perc, .5, 4)
+		return Round(perc, .5, 4)
 
 	}
+	return 0
 }
 
 func Round(val float64, roundOn float64, places int) (newVal float64) {
@@ -463,8 +517,4 @@ func Round(val float64, roundOn float64, places int) (newVal float64) {
 	}
 	newVal = round / pow
 	return
-}
-
-func (t *CpuTimes) sum() uint64 {
-	return t.User + t.Nice + t.System + t.Idle + t.IOWait + t.Irq + t.SoftIrq + t.Steal
 }

--- a/topbeat/beat/topbeat_test.go
+++ b/topbeat/beat/topbeat_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/elastic/gosigar"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -27,15 +28,17 @@ func TestMemPercentage(t *testing.T) {
 	beat := Topbeat{}
 
 	m := MemStat{
-		Total: 7,
-		Used:  5,
-		Free:  2,
+		Mem: sigar.Mem{
+			Total: 7,
+			Used:  5,
+			Free:  2,
+		},
 	}
 	beat.addMemPercentage(&m)
 	assert.Equal(t, m.UsedPercent, 0.71)
 
 	m = MemStat{
-		Total: 0,
+		Mem: sigar.Mem{Total: 0},
 	}
 	beat.addMemPercentage(&m)
 	assert.Equal(t, m.UsedPercent, 0.0)
@@ -46,15 +49,19 @@ func TestActualMemPercentage(t *testing.T) {
 	beat := Topbeat{}
 
 	m := MemStat{
-		Total:      7,
-		ActualUsed: 5,
-		ActualFree: 2,
+		Mem: sigar.Mem{
+			Total:      7,
+			ActualUsed: 5,
+			ActualFree: 2,
+		},
 	}
 	beat.addMemPercentage(&m)
 	assert.Equal(t, m.ActualUsedPercent, 0.71)
 
 	m = MemStat{
-		Total: 0,
+		Mem: sigar.Mem{
+			Total: 0,
+		},
 	}
 	beat.addMemPercentage(&m)
 	assert.Equal(t, m.ActualUsedPercent, 0.0)
@@ -65,14 +72,16 @@ func TestCpuPercentage(t *testing.T) {
 	beat := Topbeat{}
 
 	cpu1 := CpuTimes{
-		User:    10855311,
-		Nice:    0,
-		System:  2021040,
-		Idle:    17657874,
-		IOWait:  0,
-		Irq:     0,
-		SoftIrq: 0,
-		Steal:   0,
+		Cpu: sigar.Cpu{
+			User:    10855311,
+			Nice:    0,
+			Sys:     2021040,
+			Idle:    17657874,
+			Wait:    0,
+			Irq:     0,
+			SoftIrq: 0,
+			Stolen:  0,
+		},
 	}
 
 	beat.addCpuPercentage(&cpu1)
@@ -81,14 +90,16 @@ func TestCpuPercentage(t *testing.T) {
 	assert.Equal(t, cpu1.SystemPercent, 0.0)
 
 	cpu2 := CpuTimes{
-		User:    10855693,
-		Nice:    0,
-		System:  2021058,
-		Idle:    17657876,
-		IOWait:  0,
-		Irq:     0,
-		SoftIrq: 0,
-		Steal:   0,
+		Cpu: sigar.Cpu{
+			User:    10855693,
+			Nice:    0,
+			Sys:     2021058,
+			Idle:    17657876,
+			Wait:    0,
+			Irq:     0,
+			SoftIrq: 0,
+			Stolen:  0,
+		},
 	}
 
 	beat.addCpuPercentage(&cpu2)
@@ -103,17 +114,17 @@ func TestProcMemPercentage(t *testing.T) {
 
 	p := Process{
 		Pid: 3456,
-		Mem: &ProcMemStat{
-			Rss:  1416,
-			Size: 145164088,
+		Mem: sigar.ProcMem{
+			Resident: 1416,
+			Size:     145164088,
 		},
 	}
 
 	beat.procsMap = make(ProcsMap)
 	beat.procsMap[p.Pid] = &p
 
-	beat.addProcMemPercentage(&p, 10000)
-	assert.Equal(t, p.Mem.RssPercent, 0.14)
+	rssPercent := beat.getProcMemPercentage(&p, 10000)
+	assert.Equal(t, rssPercent, 0.14)
 }
 
 func TestProcCpuPercentage(t *testing.T) {
@@ -124,20 +135,20 @@ func TestProcCpuPercentage(t *testing.T) {
 
 	p2 := Process{
 		Pid: 3545,
-		Cpu: &ProcCpuTime{
-			User:   14794,
-			System: 47,
-			Total:  14841,
+		Cpu: sigar.ProcTime{
+			User:  14794,
+			Sys:   47,
+			Total: 14841,
 		},
 		ctime: ctime,
 	}
 
 	p1 := Process{
 		Pid: 3545,
-		Cpu: &ProcCpuTime{
-			User:   11345,
-			System: 37,
-			Total:  11382,
+		Cpu: sigar.ProcTime{
+			User:  11345,
+			Sys:   37,
+			Total: 11382,
 		},
 		ctime: ctime.Add(-1 * time.Second),
 	}
@@ -145,6 +156,6 @@ func TestProcCpuPercentage(t *testing.T) {
 	beat.procsMap = make(ProcsMap)
 	beat.procsMap[p1.Pid] = &p1
 
-	beat.addProcCpuPercentage(&p2)
-	assert.Equal(t, p2.Cpu.TotalPercent, 3.459)
+	totalPercent := beat.getProcCpuPercentage(&p2)
+	assert.Equal(t, totalPercent, 3.459)
 }


### PR DESCRIPTION
Update Topbeat to export a MapStr object instead of a structure in order to be able to do filtering on a more generic json object, This change is needed for filtering phase 2.

Nothing really changes from the user perspective here. It just a code re-structure.