### PR TITLE
Update configuration doc

### DIFF
--- a/packetbeat/docs/configuration.asciidoc
+++ b/packetbeat/docs/configuration.asciidoc
@@ -268,7 +268,7 @@ default, only the HTTP headers.
 
 If this option is enabled, the raw message of the response (`response` field)
 is sent to Elasticsearch. The default is false.  This option is useful when you
-want to index the whole request. Note that for HTTP, the body is not included
+want to index the whole response. Note that for HTTP, the body is not included
 by default, only the HTTP headers.
 
 ===== transaction_timeout


### PR DESCRIPTION
fix send_response description - replace "request" with "response"