### PR TITLE
harden pgsql parser

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -45,6 +45,7 @@ https://github.com/elastic/beats/compare/1.0.0...master[Check the HEAD diff]
 - Allow PF_RING sniffer type to be configured using pf_ring or pfring {pull}671[671]
 - Create a proper BPF filter when ICMP is the only enabled protocol {issue}757[757]
 - Check column length in pgsql parser. {issue}565{565
+- Harden pgsql parser. {issue}565[565]
 
 *Topbeat*
 

--- a/packetbeat/protos/pgsql/parse.go
+++ b/packetbeat/protos/pgsql/parse.go
@@ -1,0 +1,567 @@
+package pgsql
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/logp"
+)
+
+var (
+	errInvalidString     = errors.New("invalid pgsql string")
+	errEmptyFieldsBuffer = errors.New("empty fields buffer")
+	errNoFieldName       = errors.New("can not read column field")
+	errFieldBufferShort  = errors.New("field buffer to small for field count")
+	errFieldBufferBig    = errors.New("field count to small for field buffer size")
+)
+
+func (pgsql *Pgsql) pgsqlMessageParser(s *PgsqlStream) (bool, bool) {
+	debugf("pgsqlMessageParser, off=%v", s.parseOffset)
+
+	var ok, complete bool
+
+	switch s.parseState {
+	case PgsqlStartState:
+		ok, complete = pgsql.parseMessageStart(s)
+	case PgsqlGetDataState:
+		ok, complete = pgsql.parseMessageData(s)
+	default:
+		logp.Critical("Pgsql invalid parser state")
+	}
+
+	detailedf("pgsqlMessageParser return: ok=%v, complete=%v, off=%v",
+		ok, complete, s.parseOffset)
+
+	return ok, complete
+}
+
+func (pgsql *Pgsql) parseMessageStart(s *PgsqlStream) (bool, bool) {
+	detailedf("parseMessageStart")
+
+	m := s.message
+
+	for len(s.data[s.parseOffset:]) >= 5 {
+		isSpecial, length, command := isSpecialPgsqlCommand(s.data[s.parseOffset:])
+		if !isSpecial {
+			return pgsql.parseCommand(s)
+		}
+
+		// In case of Commands: StartupMessage, SSLRequest, CancelRequest that don't have
+		// their type in the first byte
+
+		// check buffer available
+		if len(s.data[s.parseOffset:]) <= length {
+			detailedf("Wait for more data 1")
+			return true, false
+		}
+
+		// ignore non SSLRequest commands
+		if command != SSLRequest {
+			s.parseOffset += length
+			continue
+		}
+
+		// if SSLRequest is received, expect for one byte reply (S or N)
+		m.start = s.parseOffset
+		s.parseOffset += length
+		m.end = s.parseOffset
+		m.isSSLRequest = true
+		m.Size = uint64(m.end - m.start)
+
+		return true, true
+	}
+	return true, false
+}
+
+func (pgsql *Pgsql) parseCommand(s *PgsqlStream) (bool, bool) {
+	// read type
+	typ := byte(s.data[s.parseOffset])
+
+	if s.expectSSLResponse {
+		// SSLRequest was received in the other stream
+		if typ == 'N' || typ == 'S' {
+			m := s.message
+
+			// one byte reply to SSLRequest
+			detailedf("Reply for SSLRequest %c", typ)
+			m.start = s.parseOffset
+			s.parseOffset += 1
+			m.end = s.parseOffset
+			m.isSSLResponse = true
+			m.Size = uint64(m.end - m.start)
+
+			return true, true
+		}
+	}
+
+	// read length
+	length := readLength(s.data[s.parseOffset+1:])
+	if length < 4 {
+		// length should include the size of itself (int32)
+		detailedf("Invalid pgsql command length.")
+		return false, false
+	}
+	if len(s.data[s.parseOffset:]) <= length {
+		detailedf("Wait for more data")
+		return true, false
+	}
+
+	detailedf("Pgsql type %c, length=%d", typ, length)
+
+	switch typ {
+	case 'Q':
+		return pgsql.parseSimpleQuery(s, length)
+	case 'T':
+		return pgsql.parseRowDescription(s, length)
+	case 'I':
+		return pgsql.parseEmptyQueryResponse(s)
+	case 'C':
+		return pgsql.parseCommandComplete(s, length)
+	case 'Z':
+		return pgsql.parseReadyForQuery(s, length)
+	case 'E':
+		return pgsql.parseErrorResponse(s, length)
+	default:
+		if !pgsqlValidType(typ) {
+			detailedf("invalid frame type: '%c'", typ)
+			return false, false
+		}
+		return pgsql.parseSkipMessage(s, length)
+	}
+}
+
+func (pgsql *Pgsql) parseSimpleQuery(s *PgsqlStream, length int) (bool, bool) {
+	m := s.message
+	m.start = s.parseOffset
+	m.IsRequest = true
+
+	s.parseOffset += 1 //type
+	s.parseOffset += length
+	m.end = s.parseOffset
+	m.Size = uint64(m.end - m.start)
+
+	query, err := pgsqlString(s.data[m.start+5:], length-4)
+	if err != nil {
+		return false, false
+	}
+
+	m.Query = query
+
+	m.toExport = true
+	detailedf("Simple Query: %s", m.Query)
+	return true, true
+}
+
+func (pgsql *Pgsql) parseRowDescription(s *PgsqlStream, length int) (bool, bool) {
+	// RowDescription
+	m := s.message
+	m.start = s.parseOffset
+	m.IsRequest = false
+	m.IsOK = true
+	m.toExport = true
+
+	err := pgsqlFieldsParser(s, s.data[s.parseOffset+5:s.parseOffset+length+1])
+	if err != nil {
+		detailedf("fields parse failed with: %v", err)
+		return false, false
+	}
+	detailedf("Fields: %s", m.Fields)
+
+	s.parseOffset += 1      //type
+	s.parseOffset += length //length
+	s.parseState = PgsqlGetDataState
+	return pgsql.parseMessageData(s)
+}
+
+// Parse a list of commands separated by semicolon from the query
+func pgsqlQueryParser(query string) []string {
+	array := strings.Split(query, ";")
+
+	queries := []string{}
+
+	for _, q := range array {
+		qt := strings.TrimSpace(q)
+		if len(qt) > 0 {
+			queries = append(queries, qt)
+		}
+	}
+	return queries
+}
+
+func (pgsql *Pgsql) parseEmptyQueryResponse(s *PgsqlStream) (bool, bool) {
+	// EmptyQueryResponse, appears as a response for empty queries
+	// substitutes CommandComplete
+
+	m := s.message
+
+	detailedf("EmptyQueryResponse")
+	m.start = s.parseOffset
+	m.IsOK = true
+	m.IsRequest = false
+	m.toExport = true
+	s.parseOffset += 5 // type + length
+	m.end = s.parseOffset
+	m.Size = uint64(m.end - m.start)
+
+	return true, true
+}
+
+func (pgsql *Pgsql) parseCommandComplete(s *PgsqlStream, length int) (bool, bool) {
+	// CommandComplete -> Successful response
+
+	m := s.message
+	m.start = s.parseOffset
+	m.IsRequest = false
+	m.IsOK = true
+	m.toExport = true
+
+	s.parseOffset += 1 //type
+	name, err := pgsqlString(s.data[s.parseOffset+4:], length-4)
+	if err != nil {
+		return false, false
+	}
+
+	detailedf("CommandComplete length=%d, tag=%s", length, name)
+
+	s.parseOffset += length
+	m.end = s.parseOffset
+	m.Size = uint64(m.end - m.start)
+
+	return true, true
+}
+
+func (pgsql *Pgsql) parseReadyForQuery(s *PgsqlStream, length int) (bool, bool) {
+
+	// ReadyForQuery -> backend ready for a new query cycle
+	m := s.message
+	m.start = s.parseOffset
+	m.Size = uint64(m.end - m.start)
+
+	s.parseOffset += 1 // type
+	s.parseOffset += length
+	m.end = s.parseOffset
+
+	return true, true
+}
+
+func (pgsql *Pgsql) parseErrorResponse(s *PgsqlStream, length int) (bool, bool) {
+	// ErrorResponse
+	detailedf("ErrorResponse")
+
+	m := s.message
+	m.start = s.parseOffset
+	m.IsRequest = false
+	m.IsError = true
+	m.toExport = true
+
+	s.parseOffset += 1 //type
+	pgsqlErrorParser(s, s.data[s.parseOffset+4:s.parseOffset+length])
+
+	s.parseOffset += length //length
+	m.end = s.parseOffset
+	m.Size = uint64(m.end - m.start)
+
+	return true, true
+}
+
+func (pgsql *Pgsql) parseSkipMessage(s *PgsqlStream, length int) (bool, bool) {
+
+	// TODO: add info from NoticeResponse in case there are warning messages for a query
+	// ignore command
+	s.parseOffset += 1 //type
+	s.parseOffset += length
+
+	m := s.message
+	m.end = s.parseOffset
+	m.Size = uint64(m.end - m.start)
+
+	// ok and complete, but ignore
+	m.toExport = false
+	return true, true
+}
+
+func pgsqlFieldsParser(s *PgsqlStream, buf []byte) error {
+	m := s.message
+
+	if len(buf) < 2 {
+		return errEmptyFieldsBuffer
+	}
+
+	// read field count (int16)
+	off := 2
+	fieldCount := readCount(buf)
+	detailedf("Row Description field count=%d", fieldCount)
+
+	fields := []string{}
+	fieldsFormat := []byte{}
+
+	for i := 0; i < fieldCount; i++ {
+		if len(buf) <= off {
+			return errFieldBufferShort
+		}
+
+		// read field name (null terminated string)
+		fieldName, err := common.ReadString(buf[off:])
+		if err != nil {
+			return errNoFieldName
+		}
+		fields = append(fields, fieldName)
+		m.NumberOfFields += 1
+		off += len(fieldName) + 1
+
+		// read Table OID (int32)
+		off += 4
+
+		// read Column Index (int16)
+		off += 2
+
+		// read Type OID (int32)
+		off += 4
+
+		// read column length (int16)
+		off += 2
+
+		// read type modifier (int32)
+		off += 4
+
+		// read format (int16)
+		format := common.Bytes_Ntohs(buf[off : off+2])
+		off += 2
+		fieldsFormat = append(fieldsFormat, byte(format))
+
+		detailedf("Field name=%s, format=%d", fieldName, format)
+	}
+
+	if off < len(buf) {
+		return errFieldBufferBig
+	}
+
+	m.Fields = fields
+	m.FieldsFormat = fieldsFormat
+	if m.NumberOfFields != fieldCount {
+		logp.Err("Missing fields from RowDescription. Expected %d. Received %d",
+			fieldCount, m.NumberOfFields)
+	}
+	return nil
+}
+
+func pgsqlErrorParser(s *PgsqlStream, buf []byte) {
+	m := s.message
+	off := 0
+	for off < len(buf) {
+		// read field type(byte1)
+		typ := buf[off]
+		if typ == 0 {
+			break
+		}
+
+		// read field value(string)
+		val, err := common.ReadString(buf[off+1:])
+		if err != nil {
+			logp.Err("Failed to read the column field")
+			break
+		}
+		off += len(val) + 2
+
+		switch typ {
+		case 'M':
+			m.ErrorInfo = val
+		case 'C':
+			m.ErrorCode = val
+		case 'S':
+			m.ErrorSeverity = val
+		}
+	}
+	detailedf("%s %s %s", m.ErrorSeverity, m.ErrorCode, m.ErrorInfo)
+}
+
+func (pgsql *Pgsql) parseMessageData(s *PgsqlStream) (bool, bool) {
+	detailedf("parseMessageData")
+
+	// The response to queries that return row sets contains:
+	// RowDescription
+	// zero or more DataRow
+	// CommandComplete
+	// ReadyForQuery
+
+	m := s.message
+
+	for len(s.data[s.parseOffset:]) > 5 {
+		// read type
+		typ := byte(s.data[s.parseOffset])
+
+		// read message length
+		length := readLength(s.data[s.parseOffset+1:])
+		if length < 4 {
+			// length should include the size of itself (int32)
+			detailedf("Invalid pgsql command length.")
+			return false, false
+		}
+		if len(s.data[s.parseOffset:]) <= length {
+			// wait for more
+			detailedf("Wait for more data")
+			return true, false
+		}
+
+		switch typ {
+		case 'D':
+			err := pgsql.parseDataRow(s, s.data[s.parseOffset+5:s.parseOffset+length+1])
+			if err != nil {
+				return false, false
+			}
+			s.parseOffset += 1
+			s.parseOffset += length
+		case 'C':
+			// CommandComplete
+
+			// skip type
+			s.parseOffset += 1
+
+			name, err := pgsqlString(s.data[s.parseOffset+4:], length-4)
+			if err != nil {
+				detailedf("pgsql string invalid")
+				return false, false
+			}
+
+			detailedf("CommandComplete length=%d, tag=%s", length, name)
+			s.parseOffset += length
+			m.end = s.parseOffset
+			m.Size = uint64(m.end - m.start)
+			s.parseState = PgsqlStartState
+
+			detailedf("Rows: %s", m.Rows)
+
+			return true, true
+		default:
+			// shouldn't happen -> return error
+			logp.Warn("Pgsql parser expected data message, but received command of type %v", typ)
+			s.parseState = PgsqlStartState
+			return false, false
+		}
+	}
+
+	return true, false
+}
+
+func (pgsql *Pgsql) parseDataRow(s *PgsqlStream, buf []byte) error {
+	m := s.message
+
+	// read field count (int16)
+	off := 2
+	fieldCount := readCount(buf)
+	detailedf("DataRow field count=%d", fieldCount)
+
+	rows := []string{}
+	rowLength := 0
+
+	for i := 0; i < fieldCount; i++ {
+		if len(buf) <= off {
+			return errFieldBufferShort
+		}
+
+		// read column length (int32)
+		columnLength := readLength(buf[off:])
+		off += 4
+
+		if columnLength > 0 && columnLength > len(buf[off:]) {
+			logp.Err("Pgsql invalid column_length=%v, buffer_length=%v, i=%v",
+				columnLength, len(buf[off:]), i)
+			return errInvalidLength
+		}
+
+		// read column value (byten)
+		var columnValue []byte
+		if m.FieldsFormat[i] == 0 {
+			// field value in text format
+			if columnLength > 0 {
+				columnValue = buf[off : off+columnLength]
+				off += columnLength
+			}
+		}
+
+		if rowLength < pgsql.maxRowLength {
+			if rowLength+len(columnValue) > pgsql.maxRowLength {
+				columnValue = columnValue[:pgsql.maxRowLength-rowLength]
+			}
+			rows = append(rows, string(columnValue))
+			rowLength += len(columnValue)
+		}
+
+		detailedf("Value %s, length=%d, off=%d", string(columnValue), columnLength, off)
+	}
+
+	if off < len(buf) {
+		return errFieldBufferBig
+	}
+
+	m.NumberOfRows += 1
+	if len(m.Rows) < pgsql.maxStoreRows {
+		m.Rows = append(m.Rows, rows)
+	}
+
+	return nil
+}
+
+func isSpecialPgsqlCommand(data []byte) (bool, int, int) {
+
+	if len(data) < 8 {
+		// 8 bytes required
+		return false, 0, 0
+	}
+
+	// read length
+	length := readLength(data[0:])
+
+	// read command identifier
+	code := int(common.Bytes_Ntohl(data[4:]))
+
+	if length == 16 && code == 80877102 {
+		// Cancel Request
+		logp.Debug("pgsqldetailed", "Cancel Request, length=%d", length)
+		return true, length, CancelRequest
+	} else if length == 8 && code == 80877103 {
+		// SSL Request
+		logp.Debug("pgsqldetailed", "SSL Request, length=%d", length)
+		return true, length, SSLRequest
+	} else if code == 196608 {
+		// Startup Message
+		logp.Debug("pgsqldetailed", "Startup Message, length=%d", length)
+		return true, length, StartupMessage
+	}
+	return false, 0, 0
+}
+
+// length field in pgsql counts total length of length field + payload, not
+// including the message identifier. => Always check buffer size >= length + 1
+func readLength(b []byte) int {
+	return int(common.Bytes_Ntohl(b))
+}
+
+func readCount(b []byte) int {
+	return int(common.Bytes_Ntohs(b))
+}
+
+func pgsqlString(b []byte, sz int) (string, error) {
+	if sz == 0 {
+		return "", nil
+	}
+
+	if b[sz-1] != 0 {
+		return "", errInvalidString
+	}
+
+	return string(b[:sz-1]), nil
+}
+
+func pgsqlValidType(t byte) bool {
+	switch t {
+	case '1', '2', '3',
+		'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'K',
+		'N', 'P', 'Q', 'R', 'S', 'T', 'V', 'W', 'X', 'Z',
+		'c', 'd', 'f', 'n', 'p', 's', 't':
+		return true
+	default:
+		return false
+	}
+}

--- a/packetbeat/protos/pgsql/pgsql.go
+++ b/packetbeat/protos/pgsql/pgsql.go
@@ -92,6 +92,11 @@ var (
 	errInvalidLength = errors.New("invalid length")
 )
 
+var (
+	debugf    = logp.MakeDebug("pgsql")
+	detailedf = logp.MakeDebug("pgsqldetailed")
+)
+
 type Pgsql struct {
 
 	// config
@@ -180,21 +185,6 @@ func (stream *PgsqlStream) PrepareForNewMessage() {
 	stream.message = nil
 }
 
-// Parse a list of commands separated by semicolon from the query
-func pgsqlQueryParser(query string) []string {
-	array := strings.Split(query, ";")
-
-	queries := []string{}
-
-	for _, q := range array {
-		qt := strings.TrimSpace(q)
-		if len(qt) > 0 {
-			queries = append(queries, qt)
-		}
-	}
-	return queries
-}
-
 // Extract the method from a SQL query
 func getQueryMethod(q string) string {
 
@@ -206,146 +196,6 @@ func getQueryMethod(q string) string {
 		method = strings.ToUpper(q)
 	}
 	return method
-}
-
-func pgsqlFieldsParser(s *PgsqlStream) {
-	m := s.message
-
-	// read field count (int16)
-	field_count := int(common.Bytes_Ntohs(s.data[s.parseOffset : s.parseOffset+2]))
-	s.parseOffset += 2
-	logp.Debug("pgsqldetailed", "Row Description field count=%d", field_count)
-
-	fields := []string{}
-	fields_format := []byte{}
-
-	for i := 0; i < field_count; i++ {
-		// read field name (null terminated string)
-		field_name, err := common.ReadString(s.data[s.parseOffset:])
-		if err != nil {
-			logp.Err("Fail to read the column field")
-		}
-		fields = append(fields, field_name)
-		m.NumberOfFields += 1
-		s.parseOffset += len(field_name) + 1
-
-		// read Table OID (int32)
-		s.parseOffset += 4
-
-		// read Column Index (int16)
-		s.parseOffset += 2
-
-		// read Type OID (int32)
-		s.parseOffset += 4
-
-		// read column length (int16)
-		s.parseOffset += 2
-
-		// read type modifier (int32)
-		s.parseOffset += 4
-
-		// read format (int16)
-		format := common.Bytes_Ntohs(s.data[s.parseOffset : s.parseOffset+2])
-		fields_format = append(fields_format, byte(format))
-		s.parseOffset += 2
-
-		logp.Debug("pgsqldetailed", "Field name=%s, format=%d", field_name, format)
-	}
-	m.Fields = fields
-	m.FieldsFormat = fields_format
-	if m.NumberOfFields != field_count {
-		logp.Err("Missing fields from RowDescription. Expected %d. Received %d", field_count, m.NumberOfFields)
-	}
-}
-
-func (pgsql *Pgsql) pgsqlRowsParser(s *PgsqlStream) error {
-	m := s.message
-
-	// read field count (int16)
-	field_count := int(common.Bytes_Ntohs(s.data[s.parseOffset : s.parseOffset+2]))
-	s.parseOffset += 2
-	logp.Debug("pgsqldetailed", "DataRow field count=%d", field_count)
-
-	row := []string{}
-	var row_len int
-
-	for i := 0; i < field_count; i++ {
-
-		// read column length (int32)
-		column_length := int32(common.Bytes_Ntohl(s.data[s.parseOffset : s.parseOffset+4]))
-		s.parseOffset += 4
-
-		if column_length > 0 && int(column_length) > len(s.data[s.parseOffset:]) {
-			logp.Err("Pgsql invalid column_length=%v, buffer_length=%v, i=%v",
-				column_length, len(s.data[s.parseOffset:]), i)
-			return errInvalidLength
-		}
-
-		// read column value (byten)
-		column_value := []byte{}
-
-		if m.FieldsFormat[i] == 0 {
-			// field value in text format
-			if column_length > 0 {
-				column_value = s.data[s.parseOffset : s.parseOffset+int(column_length)]
-			} else if column_length == -1 {
-				column_value = nil
-			}
-		}
-
-		if row_len < pgsql.maxRowLength {
-			if row_len+len(column_value) > pgsql.maxRowLength {
-				column_value = column_value[:pgsql.maxRowLength-row_len]
-			}
-			row = append(row, string(column_value))
-			row_len += len(column_value)
-		}
-
-		if column_length > 0 {
-			s.parseOffset += int(column_length)
-		}
-
-		logp.Debug("pgsqldetailed", "Value %s, length=%d", string(column_value), column_length)
-
-	}
-	m.NumberOfRows += 1
-	if len(m.Rows) < pgsql.maxStoreRows {
-		m.Rows = append(m.Rows, row)
-	}
-
-	return nil
-}
-
-func pgsqlErrorParser(s *PgsqlStream) {
-
-	m := s.message
-
-	for len(s.data[s.parseOffset:]) > 0 {
-		// read field type(byte1)
-		field_type := s.data[s.parseOffset]
-		s.parseOffset += 1
-
-		if field_type == 0 {
-			break
-		}
-
-		// read field value(string)
-		field_value, err := common.ReadString(s.data[s.parseOffset:])
-		if err != nil {
-			logp.Err("Fail to read the column field")
-		}
-		s.parseOffset += len(field_value) + 1
-
-		if field_type == 'M' {
-			m.ErrorInfo = field_value
-		} else if field_type == 'C' {
-			m.ErrorCode = field_value
-		} else if field_type == 'S' {
-			m.ErrorSeverity = field_value
-		}
-
-	}
-	logp.Debug("pgsqldetailed", "%s %s %s", m.ErrorSeverity, m.ErrorCode, m.ErrorInfo)
 }
 
 func isSpecialPgsqlCommand(data []byte) (bool, int) {
@@ -375,296 +225,6 @@ func isSpecialPgsqlCommand(data []byte) (bool, int) {
 		return true, StartupMessage
 	}
 	return false, 0
-}
-
-func (pgsql *Pgsql) pgsqlMessageParser(s *PgsqlStream) (bool, bool) {
-
-	m := s.message
-	for s.parseOffset < len(s.data) {
-		switch s.parseState {
-		case PgsqlStartState:
-			if len(s.data[s.parseOffset:]) < 5 {
-				logp.Warn("Postgresql Message too short. %X (length=%d). Wait for more.", s.data[s.parseOffset:], len(s.data[s.parseOffset:]))
-				return true, false
-			}
-
-			is_special, command := isSpecialPgsqlCommand(s.data[s.parseOffset:])
-
-			if is_special {
-				// In case of Commands: StartupMessage, SSLRequest, CancelRequest that don't have
-				// their type in the first byte
-
-				// read length
-				length := int(common.Bytes_Ntohl(s.data[s.parseOffset : s.parseOffset+4]))
-
-				// ignore command
-				if len(s.data[s.parseOffset:]) >= length {
-
-					if command == SSLRequest {
-						// if SSLRequest is received, expect for one byte reply (S or N)
-						m.start = s.parseOffset
-						s.parseOffset += length
-						m.end = s.parseOffset
-						m.isSSLRequest = true
-						m.Size = uint64(m.end - m.start)
-
-						return true, true
-					}
-					s.parseOffset += length
-				} else {
-					// wait for more
-					logp.Debug("pgsqldetailed", "Wait for more data 1")
-					return true, false
-				}
-
-			} else {
-				// In case of Commands that have their type in the first byte
-
-				// read type
-				typ := byte(s.data[s.parseOffset])
-
-				if s.expectSSLResponse {
-					// SSLRequest was received in the other stream
-					if typ == 'N' || typ == 'S' {
-						// one byte reply to SSLRequest
-						logp.Debug("pgsqldetailed", "Reply for SSLRequest %c", typ)
-						m.start = s.parseOffset
-						s.parseOffset += 1
-						m.end = s.parseOffset
-						m.isSSLResponse = true
-						m.Size = uint64(m.end - m.start)
-
-						return true, true
-					}
-				}
-
-				// read length
-				length := int(common.Bytes_Ntohl(s.data[s.parseOffset+1 : s.parseOffset+5]))
-
-				if length < 4 {
-					// length should include the size of itself (int32)
-					logp.Debug("pgsqldetailed", "Invalid pgsql command length.")
-					return false, false
-				}
-
-				logp.Debug("pgsqldetailed", "Pgsql type %c, length=%d", typ, length)
-
-				if typ == 'Q' {
-					// SimpleQuery
-					m.start = s.parseOffset
-					m.IsRequest = true
-
-					if len(s.data[s.parseOffset:]) >= length+1 {
-						s.parseOffset += 1 //type
-						s.parseOffset += length
-						m.end = s.parseOffset
-						m.Size = uint64(m.end - m.start)
-
-						m.Query = string(s.data[m.start+5 : m.end-1]) //without string termination
-
-						m.toExport = true
-						logp.Debug("pgsqldetailed", "Simple Query: %s", m.Query)
-						return true, true
-					} else {
-						// wait for more
-						logp.Debug("pgsqldetailed", "Wait for more data 2")
-						return true, false
-					}
-				} else if typ == 'T' {
-					// RowDescription
-
-					m.start = s.parseOffset
-					m.IsRequest = false
-					m.IsOK = true
-					m.toExport = true
-
-					if len(s.data[s.parseOffset:]) >= length+1 {
-						s.parseOffset += 1 //type
-						s.parseOffset += 4 //length
-
-						pgsqlFieldsParser(s)
-						logp.Debug("pgsqldetailed", "Fields: %s", m.Fields)
-
-						s.parseState = PgsqlGetDataState
-					} else {
-						// wait for more
-						logp.Debug("pgsqldetailed", "Wait for more data 3")
-						return true, false
-					}
-
-				} else if typ == 'I' {
-					// EmptyQueryResponse, appears as a response for empty queries
-					// substitutes CommandComplete
-
-					logp.Debug("pgsqldetailed", "EmptyQueryResponse")
-					m.start = s.parseOffset
-					m.IsOK = true
-					m.IsRequest = false
-					m.toExport = true
-					s.parseOffset += 5 // type + length
-					m.end = s.parseOffset
-					m.Size = uint64(m.end - m.start)
-
-					return true, true
-
-				} else if typ == 'E' {
-					// ErrorResponse
-
-					logp.Debug("pgsqldetailed", "ErrorResponse")
-					m.start = s.parseOffset
-					m.IsRequest = false
-					m.IsError = true
-					m.toExport = true
-
-					if len(s.data[s.parseOffset:]) >= length+1 {
-						s.parseOffset += 1 //type
-						s.parseOffset += 4 //length
-
-						pgsqlErrorParser(s)
-
-						m.end = s.parseOffset
-						m.Size = uint64(m.end - m.start)
-
-						return true, true
-					} else {
-						// wait for more
-						logp.Debug("pgsqldetailed", "Wait for more data 4")
-						return true, false
-					}
-				} else if typ == 'C' {
-					// CommandComplete -> Successful response
-
-					m.start = s.parseOffset
-					m.IsRequest = false
-					m.IsOK = true
-					m.toExport = true
-
-					if len(s.data[s.parseOffset:]) >= length+1 {
-						s.parseOffset += 1 //type
-
-						name := string(s.data[s.parseOffset+4 : s.parseOffset+length-1]) //without \0
-						logp.Debug("pgsqldetailed", "CommandComplete length=%d, tag=%s", length, name)
-
-						s.parseOffset += length
-						m.end = s.parseOffset
-						m.Size = uint64(m.end - m.start)
-
-						return true, true
-					} else {
-						// wait for more
-						logp.Debug("pgsqldetailed", "Wait for more data 5")
-						return true, false
-					}
-				} else if typ == 'Z' {
-					// ReadyForQuery -> backend ready for a new query cycle
-					if len(s.data[s.parseOffset:]) >= length+1 {
-						m.start = s.parseOffset
-						s.parseOffset += 1 // type
-						s.parseOffset += length
-						m.end = s.parseOffset
-						m.Size = uint64(m.end - m.start)
-
-						return true, true
-					} else {
-						// wait for more
-						logp.Debug("pgsqldetailed", "Wait for more 5b")
-						return true, false
-					}
-				} else {
-					// TODO: add info from NoticeResponse in case there are warning messages for a query
-					// ignore command
-					if len(s.data[s.parseOffset:]) >= length+1 {
-						s.parseOffset += 1 //type
-						s.parseOffset += length
-						m.end = s.parseOffset
-						m.Size = uint64(m.end - m.start)
-
-						// ok and complete, but ignore
-						m.toExport = false
-						return true, true
-					} else {
-						// wait for more
-						logp.Debug("pgsqldetailed", "Wait for more data 6")
-						return true, false
-					}
-				}
-			}
-
-			break
-
-		case PgsqlGetDataState:
-
-			// The response to queries that return row sets contains:
-			// RowDescription
-			// zero or more DataRow
-			// CommandComplete
-			// ReadyForQuery
-
-			if len(s.data[s.parseOffset:]) < 5 {
-				logp.Warn("Postgresql Message too short (length=%d). Wait for more.", len(s.data[s.parseOffset:]))
-				return true, false
-			}
-
-			// read type
-			typ := byte(s.data[s.parseOffset])
-
-			// read message length
-			length := int(common.Bytes_Ntohl(s.data[s.parseOffset+1 : s.parseOffset+5]))
-
-			if typ == 'D' {
-				// DataRow
-
-				if len(s.data[s.parseOffset:]) >= length+1 {
-					// skip type
-					s.parseOffset += 1
-					// skip length size
-					s.parseOffset += 4
-
-					if err := pgsql.pgsqlRowsParser(s); err != nil {
-						return false, false
-					}
-
-				} else {
-					// wait for more
-					logp.Debug("pgsqldetailed", "Wait for more data 7")
-					return true, false
-				}
-
-			} else if typ == 'C' {
-				// CommandComplete
-
-				if len(s.data[s.parseOffset:]) >= length+1 {
-
-					// skip type
-					s.parseOffset += 1
-
-					name := string(s.data[s.parseOffset+4 : s.parseOffset+length-1]) //without \0
-					logp.Debug("pgsqldetailed", "CommandComplete length=%d, tag=%s", length, name)
-
-					s.parseOffset += length
-					m.end = s.parseOffset
-					m.Size = uint64(m.end - m.start)
-
-					s.parseState = PgsqlStartState
-
-					logp.Debug("pgsqldetailed", "Rows: %s", m.Rows)
-
-					return true, true
-				} else {
-					// wait for more
-					logp.Debug("pgsqldetailed", "Wait for more data 8")
-					return true, false
-				}
-			} else {
-				// shouldn't happen
-				logp.Debug("pgsqldetailed", "Skip command of type %c", typ)
-				s.parseState = PgsqlStartState
-			}
-			break
-		}
-	}
-
-	return true, false
 }
 
 type pgsqlPrivateData struct {
@@ -701,7 +261,7 @@ func (pgsql *Pgsql) Parse(pkt *protos.Packet, tcptuple *common.TcpTuple,
 		priv.Data[dir].data = append(priv.Data[dir].data, pkt.Payload...)
 		logp.Debug("pgsqldetailed", "Len data: %d cap data: %d", len(priv.Data[dir].data), cap(priv.Data[dir].data))
 		if len(priv.Data[dir].data) > tcp.TCP_MAX_DATA_IN_STREAM {
-			logp.Debug("pgsql", "Stream data too large, dropping TCP stream")
+			debugf("Stream data too large, dropping TCP stream")
 			priv.Data[dir] = nil
 			return priv
 		}
@@ -725,7 +285,7 @@ func (pgsql *Pgsql) Parse(pkt *protos.Packet, tcptuple *common.TcpTuple,
 			// drop this tcp stream. Will retry parsing with the next
 			// segment in it
 			priv.Data[dir] = nil
-			logp.Debug("pgsql", "Ignore Postgresql message. Drop tcp stream. Try parsing with the next segment")
+			debugf("Ignore Postgresql message. Drop tcp stream. Try parsing with the next segment")
 			return priv
 		}
 
@@ -792,7 +352,7 @@ func (pgsql *Pgsql) GapInStream(tcptuple *common.TcpTuple, dir uint8,
 	// next layer but mark it as incomplete.
 	stream := pgsqlData.Data[dir]
 	if messageHasEnoughData(stream.message) {
-		logp.Debug("pgsql", "Message not complete, but sending to the next layer")
+		debugf("Message not complete, but sending to the next layer")
 		m := stream.message
 		m.toExport = true
 		m.end = stream.parseOffset
@@ -917,7 +477,7 @@ func (pgsql *Pgsql) receivedPgsqlResponse(msg *PgsqlMessage) {
 
 	pgsql.publishTransaction(trans)
 
-	logp.Debug("pgsql", "Postgres transaction completed: %s\n%s", trans.Pgsql, trans.Response_raw)
+	debugf("Postgres transaction completed: %s\n%s", trans.Pgsql, trans.Response_raw)
 }
 
 func (pgsql *Pgsql) publishTransaction(t *PgsqlTransaction) {

--- a/packetbeat/protos/pgsql/pgsql.go
+++ b/packetbeat/protos/pgsql/pgsql.go
@@ -198,35 +198,6 @@ func getQueryMethod(q string) string {
 	return method
 }
 
-func isSpecialPgsqlCommand(data []byte) (bool, int) {
-
-	if len(data) < 8 {
-		// 8 bytes required
-		return false, 0
-	}
-
-	// read length
-	length := int(common.Bytes_Ntohl(data[0:4]))
-
-	// read command identifier
-	code := int(common.Bytes_Ntohl(data[4:8]))
-
-	if length == 16 && code == 80877102 {
-		// Cancel Request
-		logp.Debug("pgsqldetailed", "Cancel Request, length=%d", length)
-		return true, CancelRequest
-	} else if length == 8 && code == 80877103 {
-		// SSL Request
-		logp.Debug("pgsqldetailed", "SSL Request, length=%d", length)
-		return true, SSLRequest
-	} else if code == 196608 {
-		// Startup Message
-		logp.Debug("pgsqldetailed", "Startup Message, length=%d", length)
-		return true, StartupMessage
-	}
-	return false, 0
-}
-
 type pgsqlPrivateData struct {
 	Data [2]*PgsqlStream
 }

--- a/packetbeat/protos/pgsql/pgsql_test.go
+++ b/packetbeat/protos/pgsql/pgsql_test.go
@@ -56,6 +56,9 @@ func TestPgsqlParser_simpleRequest(t *testing.T) {
 
 // Test parsing a response with data attached
 func TestPgsqlParser_dataResponse(t *testing.T) {
+	if testing.Verbose() {
+		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"pgsql", "pgsqldetailed"})
+	}
 
 	pgsql := PgsqlModForTests()
 	data := []byte(
@@ -215,6 +218,10 @@ func TestPgsqlParser_threeResponses(t *testing.T) {
 
 // Test parsing an error response
 func TestPgsqlParser_errorResponse(t *testing.T) {
+	if testing.Verbose() {
+		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"pgsql", "pgsqldetailed"})
+	}
+
 	pgsql := PgsqlModForTests()
 	data := []byte(
 		"4500000088534552524f5200433235503032004d63757272656e74207472616e73616374696f6e2069732061626f727465642c20636f6d6d616e64732069676e6f72656420756e74696c20656e64206f66207472616e73616374696f6e20626c6f636b0046706f7374677265732e63004c3932310052657865635f73696d706c655f71756572790000")


### PR DESCRIPTION
Resolves #565

- Split parser loop in more fine-grained parser functions
- check pgsql strings really end with \0
- check pgsql message type
- limit data row/column/fields parsing buffer regarding to length field
- check row/column/fields parser consumed exactly `length` bytes
- do not skip some parsing errors, but report to kill stream