### PR TITLE
Adding Vagrantbox for Solaris and FreeBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,17 +6,17 @@ PROJECTS=libbeat ${BEATS}
 # Runs complete testsuites (unit, system, integration) for all beats,
 # with coverage and race detection.
 testsuite:
-	$(foreach var,$(PROJECTS),make -C $(var) testsuite || exit 1;)
+	$(foreach var,$(PROJECTS),$(MAKE) -C $(var) testsuite || exit 1;)
 
 # Runs unit and system tests without coverage and race detection.
 .PHONY: test
 test:
-	$(foreach var,$(PROJECTS),make -C $(var) test || exit 1;)
+	$(foreach var,$(PROJECTS),$(MAKE) -C $(var) test || exit 1;)
 
 # Runs unit tests without coverage and race detection.
 .PHONY: unit
 unit:
-	$(foreach var,$(PROJECTS),make -C $(var) unit || exit 1;)
+	$(foreach var,$(PROJECTS),$(MAKE) -C $(var) unit || exit 1;)
 
 .PHONY: coverage-report
 coverage-report:
@@ -32,16 +32,16 @@ coverage-report:
 	go tool cover -html=./${COVERAGE_DIR}/full.cov -o ${COVERAGE_DIR}/full.html
 
 update:
-	$(foreach var,$(BEATS),make -C $(var) update || exit 1;)
+	$(foreach var,$(BEATS),$(MAKE) -C $(var) update || exit 1;)
 
 clean:
-	$(foreach var,$(PROJECTS),make -C $(var) clean || exit 1;)
+	$(foreach var,$(PROJECTS),$(MAKE) -C $(var) clean || exit 1;)
 
 check:
-	$(foreach var,$(PROJECTS),make -C $(var) check || exit 1;)
+	$(foreach var,$(PROJECTS),$(MAKE) -C $(var) check || exit 1;)
 
 fmt:
-	$(foreach var,$(PROJECTS),make -C $(var) fmt || exit 1;)
+	$(foreach var,$(PROJECTS),$(MAKE) -C $(var) fmt || exit 1;)
 
 simplify:
-	$(foreach var,$(PROJECTS),make -C $(var) simplify || exit 1;)
+	$(foreach var,$(PROJECTS),$(MAKE) -C $(var) simplify || exit 1;)

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -29,7 +29,7 @@ export PATH := ./bin:$(PATH)
 export GO15VENDOREXPERIMENT=1
 GOFILES = $(shell find . -type f -name '*.go')
 GOFILES_NOVENDOR = $(shell find . -type f -name '*.go' -not -path "./vendor/*")
-SHELL=/bin/bash
+SHELL=bash
 ES_HOST?="elasticsearch"
 BUILD_DIR?=build
 COVERAGE_DIR=${BUILD_DIR}/coverage
@@ -88,9 +88,9 @@ clean:
 # This should always run before merging.
 .PHONY: ci
 ci:
-	make
-	make check
-	make testsuite
+	$(MAKE)
+	$(MAKE) check
+	$(MAKE) testsuite
 
 ### Testing ###
 # Unless stated otherwise, all tests are always run with coverage reporting enabled.
@@ -124,8 +124,8 @@ integration-tests: prepare-tests
 # Runs the integration inside a virtual environment. This can be run on any docker-machine (local, remote)
 .PHONY: integration-tests-environment
 integration-tests-environment:
-	make prepare-tests
-	make build-image
+	$(MAKE) prepare-tests
+	$(MAKE) build-image
 	NAME=$$(${DOCKER_COMPOSE} run -d beat make integration-tests | awk 'END{print}') || exit 1; \
 	echo "docker beat test container: '$$NAME'"; \
 	docker attach $$NAME; CODE=$$?;\
@@ -162,7 +162,7 @@ benchmark-tests:
 .PHONY: test
 test: unit
 	if [ $(SYSTEM_TESTS) = true ]; then \
-		 make fast-system-tests; \
+		 $(MAKE) fast-system-tests; \
 	fi
 
 # Runs all tests and generates the coverage reports
@@ -170,18 +170,18 @@ test: unit
 testsuite:
 	# Setups environment if TEST_ENVIRONMENT is set to true
 	if [ $(TEST_ENVIRONMENT) = true ]; then \
-		 make integration-tests-environment; \
+		 $(MAKE) integration-tests-environment; \
 	else \
-		make integration-tests; \
+		$(MAKE) integration-tests; \
 	fi
 
 	# Runs system tests if SYSTEM_TESTS is set to true
 	if [ $(SYSTEM_TESTS) = true ]; then \
-		 make system-tests; \
+		 $(MAKE) system-tests; \
 	fi
 
-	make benchmark-tests
-	make coverage-report
+	$(MAKE) benchmark-tests
+	$(MAKE) coverage-report
 
 # Generates a coverage report from the existing coverage files
 .PHONY: coverage-report


### PR DESCRIPTION
To use these boxes you must provide their name to the vagrant command as shown below. The default box remains as `win2012`, so when you run `vagrant up` it's the same as running `vagrant up win2012`.

`vagrant up freebsd`
`vagrant ssh freebsd`
`vagrant destroy freebsd`

###### Other Changes
- Changed `make` to `$(MAKE)` within the Makefile's to _make_ them more portable. This is required for Solaris and FreeBSD where you use `gmake` instead of `make`.
- Removed the full path to `bash` from the `SHELL` variable because the full path wan't portable.

###### Jenkins

http://build-eu-00.elastic.co/view/Beats/job/beats-freebsd/
http://build-eu-00.elastic.co/view/Beats/job/beats-solaris/