### PR TITLE
Fixed filebeat path in installation docs.

### DIFF
--- a/filebeat/docs/getting-started.asciidoc
+++ b/filebeat/docs/getting-started.asciidoc
@@ -69,7 +69,7 @@ PS C:\Program Files\Filebeat> .\install-service-filebeat.ps1
 NOTE: If script execution is disabled on your system, you need to set the execution policy for the current session to allow the script to run. For example: `PowerShell.exe -ExecutionPolicy UnRestricted -File .\install-service-filebeat.ps1`. 
 
 Before starting Filebeat, you should look at the configuration options in the configuration
-file, for example `C:\Program Files\Filebeat\filebeat.yml` or `/etc/topbeat/topbeat.yml`. For more information about these options,
+file, for example `C:\Program Files\Filebeat\filebeat.yml` or `/etc/filebeat/filebeat.yml`. For more information about these options,
 see <<filebeat-configuration-details>>.
 
 [[filebeat-configuration]]


### PR DESCRIPTION
(It had shown Topbeat\filebeat)  Replaces https://github.com/elastic/beats/pull/790