### PR TITLE
Removed duplicate changelog items

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -35,16 +35,10 @@ https://github.com/elastic/beats/compare/v1.1.0...master[Check the HEAD diff]
 
 *Affecting all Beats*
 - Fix logstash window size of 1 not increasing. {pull}598[598]
-- Fix logging issue with file based output where newlines could be misplaced
-  during concurrent logging {pull}650[650]
-- Reduce memory usage by separate queue sizes for single events and bulk events. {pull}649[649] {issue}516[516]
-- Set default default bulk_max_size value to 2048 {pull}628[628]
 
 *Packetbeat*
-- Fix setting direction to out and use its value to decide when dropping events if ignore_outgoing is enabled {pull}557[557]
-- Allow PF_RING sniffer type to be configured using pf_ring or pfring {pull}671[671]
 - Create a proper BPF filter when ICMP is the only enabled protocol {issue}757[757]
-- Check column length in pgsql parser. {issue}565{565
+- Check column length in pgsql parser. {issue}565[565]
 - Harden pgsql parser. {issue}565[565]
 
 *Packetbeat*
@@ -52,10 +46,8 @@ https://github.com/elastic/beats/compare/v1.1.0...master[Check the HEAD diff]
 *Topbeat*
 
 *Filebeat*
-- Add exclude_files configuration option {pull}563[563]
 - Stop filebeat if filebeat is started without any prospectors defined or empty prospectors {pull}644[644] {pull}647[647]
 - Improve shutdown of crawler and prospector to wait for clean completion {pull}720[720]
-- Set spool_size default value to 2048 {pull}628[628]
 
 *Winlogbeat*
 
@@ -64,12 +56,10 @@ https://github.com/elastic/beats/compare/v1.1.0...master[Check the HEAD diff]
 
 *Affecting all Beats*
 - Update builds to Golang version 1.5.3
-- Make logstash output compression level configurable. {pull}630[630]
 - Add ability to override configuration settings using environment variables {issue}114[114]
 - Libbeat now always exits through a single exit method for proper cleanup and control {pull}736[736]
 
 *Packetbeat*
-- Add support for capturing DNS over TCP network traffic. {pull}486[486] {pull}554[554]
 - Change the DNS library used throughout the dns package to github.com/miekg/dns. {pull}803[803]
 
 *Topbeat*


### PR DESCRIPTION
Duplicates tend to happen because of the union merge strategy. This
removes all items from master that were actually present in 1.1.