### PR TITLE
Backport Logstash client window size enhancement

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ https://github.com/elastic/beats/compare/v1.1.0...master[Check the HEAD diff]
 ==== Bugfixes
 
 *Affecting all Beats*
+- Fix logstash window size of 1 not increasing. {pull}598[598]
 
 *Packetbeat*
 


### PR DESCRIPTION
- Have window size converge towards batch size requested to be published.  If
  maximum batch size ever published is less then maximum allowed window size.

- Always shrink window size on error. If connection was lost due to logstash
  closing it by internal timeouts (circuite breaker) we want to decrease
  the window size on next try.

- Add unit tests for logstash client window sizing behavior

- Add changelog entry