### PR TITLE
Change value of version var back to 1.1.0 in index.asciidoc

### DIFF
--- a/filebeat/docs/index.asciidoc
+++ b/filebeat/docs/index.asciidoc
@@ -1,6 +1,6 @@
 = Filebeat Reference
 :libbeat: http://www.elastic.co/guide/en/beats/libbeat/1.1
-:version: 1.1
+:version: 1.1.0
 :beatname_lc: filebeat
 :beatname_uc: Filebeat
 

--- a/packetbeat/docs/index.asciidoc
+++ b/packetbeat/docs/index.asciidoc
@@ -1,6 +1,6 @@
 = Packetbeat Reference
 :libbeat: http://www.elastic.co/guide/en/beats/libbeat/1.1
-:version: 1.1
+:version: 1.1.0
 :beatname_lc: packetbeat
 :beatname_uc: Packetbeat
 

--- a/topbeat/docs/index.asciidoc
+++ b/topbeat/docs/index.asciidoc
@@ -1,6 +1,6 @@
 = Topbeat Reference
 :libbeat: http://www.elastic.co/guide/en/beats/libbeat/1.1
-:version: 1.1
+:version: 1.1.0
 :beatname_lc: topbeat
 :beatname_uc: Topbeat
 

--- a/winlogbeat/docs/index.asciidoc
+++ b/winlogbeat/docs/index.asciidoc
@@ -1,6 +1,6 @@
 = Winlogbeat Reference
 :libbeat: http://www.elastic.co/guide/en/beats/libbeat/1.1
-:version: 1.1
+:version: 1.1.0
 :beatname_lc: winlogbeat
 :beatname_uc: Winlogbeat
 


### PR DESCRIPTION
This closes #855 

@tsg The download links will include the 3-digit version number, correct? All the builds I've seen have 1.1.0 in the links. :-) 