### PR TITLE
Document Kibana version compatible with the Beats dashboards

### DIFF
--- a/libbeat/docs/gettingstarted.asciidoc
+++ b/libbeat/docs/gettingstarted.asciidoc
@@ -385,6 +385,8 @@ overwhelming at the beginning, so we have created a couple of
 https://github.com/elastic/beats-dashboards[Sample Dashboards] to get you
 started and to demonstrate what is possible based on the Beats data.
 
+NOTE: The Beats dashboards require Kibana 4.
+
 To load the sample dashboards, you run a load script. The load script
 uploads the example dashboards, visualizations, and searches
 that you can use. The load command also creates index patterns for each Beat:


### PR DESCRIPTION
This closes https://github.com/elastic/beats-dashboards/issues/72.