### PR TITLE
update mockbeat to reveals a data race when stopping the application

### DIFF
--- a/libbeat/libbeat.go
+++ b/libbeat/libbeat.go
@@ -8,8 +8,7 @@ import (
 )
 
 func main() {
-	err := beat.Run(mock.Name, mock.Version, &mock.Mockbeat{})
-	if err != nil {
+	if err := beat.Run(mock.Name, mock.Version, mock.New()); err != nil {
 		os.Exit(1)
 	}
 }

--- a/libbeat/mock/mockbeat.go
+++ b/libbeat/mock/mockbeat.go
@@ -10,7 +10,17 @@ var Version = "9.9.9"
 var Name = "mockbeat"
 
 type Mockbeat struct {
+	done chan struct{}
 }
+
+// Creates beater
+func New() *Mockbeat {
+	return &Mockbeat{
+		done: make(chan struct{}),
+	}
+}
+
+/// *** Beater interface methods ***///
 
 func (mb *Mockbeat) Config(b *beat.Beat) error {
 	return nil
@@ -21,6 +31,8 @@ func (mb *Mockbeat) Setup(b *beat.Beat) error {
 }
 
 func (mb *Mockbeat) Run(b *beat.Beat) error {
+	// Wait until mockbeat is done
+	<-mb.done
 	return nil
 }
 
@@ -29,5 +41,5 @@ func (mb *Mockbeat) Cleanup(b *beat.Beat) error {
 }
 
 func (mb *Mockbeat) Stop() {
-
+	close(mb.done)
 }

--- a/libbeat/tests/system/test_base.py
+++ b/libbeat/tests/system/test_base.py
@@ -15,7 +15,9 @@ class Test(BaseTest):
             path=os.path.abspath(self.working_dir) + "/log/*"
         )
 
-        exit_code = self.run_beat()
+        proc = self.start_beat()
+        self.wait_until( lambda: self.log_contains("Init Beat"))
+        exit_code = proc.kill_and_wait()
         assert exit_code == 0
 
     def test_no_config(self):


### PR DESCRIPTION
When this patch is applied, running 
```
cd $GOPATH/src/github.com/elastic/beats/libbeat/
RACE_DETECTOR=1 make system-tests
```

This triggers the following data race detection:
```
2016/01/27 10:22:46.388070 beat.go:242: DBG  Initializing output plugins
2016/01/27 10:22:46.388145 geolite.go:30: INFO GeoIP disabled: No paths were set under output.geoip.paths
2016/01/27 10:22:46.388186 file.go:48: INFO File output base filename set to: mockbeat
2016/01/27 10:22:46.388219 file.go:60: INFO Rotate every bytes set to: 1024000
2016/01/27 10:22:46.388245 file.go:69: INFO Number of files set to: 7
2016/01/27 10:22:46.388350 outputs.go:129: INFO Activated file as output plugin.
2016/01/27 10:22:46.388379 publish.go:273: DBG  Create output worker
2016/01/27 10:22:46.388552 publish.go:327: DBG  No output is defined to store the topology. The server fields might not be filled.
2016/01/27 10:22:46.388603 publish.go:347: INFO Publisher name: dell
2016/01/27 10:22:46.388925 async.go:91: INFO Flush Interval set to: -1ms
2016/01/27 10:22:46.388954 async.go:99: INFO Max Bulk Size set to: -1
2016/01/27 10:22:46.388993 beat.go:254: INFO Init Beat: mockbeat; Version: 9.9.9
2016/01/27 10:22:46.389394 beat.go:283: INFO mockbeat sucessfully setup. Start running.
2016/01/27 10:22:46.471014 service.go:33: DBG  Received sigterm/sigint, stopping
2016/01/27 10:22:46.471087 beat.go:333: INFO Start exiting beat
2016/01/27 10:22:46.471137 beat.go:301: INFO Stopping Beat
==================
WARNING: DATA RACE
Read by goroutine 8:
  github.com/elastic/beats/libbeat/beat.(*Beat).Stop()
      github.com/elastic/beats/libbeat/beat/_obj/beat.go:303 +0x9a
  github.com/elastic/beats/libbeat/beat.Run()
      github.com/elastic/beats/libbeat/beat/_obj/beat.go:145 +0x144
  github.com/elastic/beats/libbeat.main()
      github.com/elastic/beats/libbeat/_test/_obj_test/libbeat.go:14 +0xd3
  github.com/elastic/beats/libbeat.TestSystem()
      /home/cyrille/code/go/workspace/src/github.com/elastic/beats/libbeat/libbeat_test.go:17 +0x54
  testing.tRunner()
      /usr/lib/go/src/testing/testing.go:456 +0xdc

Previous write by goroutine 9:
  github.com/elastic/beats/libbeat/beat.(*Beat).Run()
      github.com/elastic/beats/libbeat/beat/_obj/beat.go:285 +0x492
  github.com/elastic/beats/libbeat/beat.(*Beat).Start()
      github.com/elastic/beats/libbeat/beat/_obj/beat.go:186 +0x27e
  github.com/elastic/beats/libbeat/beat.Run.func1()
      github.com/elastic/beats/libbeat/beat/_obj/beat.go:127 +0x68

Goroutine 8 (running) created at:
  testing.RunTests()
      /usr/lib/go/src/testing/testing.go:561 +0xaa3
  testing.(*M).Run()
      /usr/lib/go/src/testing/testing.go:494 +0xe4
  main.main()
      github.com/elastic/beats/libbeat/_test/_testmain.go:270 +0x38d

Goroutine 9 (running) created at:
  github.com/elastic/beats/libbeat/beat.Run()
      github.com/elastic/beats/libbeat/beat/_obj/beat.go:139 +0xb6
  github.com/elastic/beats/libbeat.main()
      github.com/elastic/beats/libbeat/_test/_obj_test/libbeat.go:14 +0xd3
  github.com/elastic/beats/libbeat.TestSystem()
      /home/cyrille/code/go/workspace/src/github.com/elastic/beats/libbeat/libbeat_test.go:17 +0x54
  testing.tRunner()
      /usr/lib/go/src/testing/testing.go:456 +0xdc
==================
2016/01/27 10:22:46.471560 beat.go:311: INFO Cleaning up mockbeat before shutting down.
2016/01/27 10:22:46.471679 beat.go:146: INFO Exit beat completed
PASS
coverage: 11.3% of statements in github.com/elastic/beats/libbeat/...
Found 1 data race(s)
```

The variable `b.state` in `beat.go` is read and written by 2 go routines:  Run() and the go func started by Run()

