### PR TITLE
Add unit tests for Guaranteed flag being handled correctly

### DIFF
--- a/libbeat/outputs/mode/failover_test.go
+++ b/libbeat/outputs/mode/failover_test.go
@@ -29,7 +29,7 @@ func testFailoverSend(t *testing.T, events []eventInfo) {
 		0,
 		100*time.Millisecond,
 	)
-	testMode(t, mode, events, signals(true), &collected)
+	testMode(t, mode, testNoOpts, events, signals(true), &collected)
 }
 
 func TestFailoverSingleSendOne(t *testing.T) {
@@ -62,7 +62,7 @@ func testFailoverConnectFailAndSend(t *testing.T, events []eventInfo) {
 		1*time.Millisecond,
 		100*time.Millisecond,
 	)
-	testMode(t, mode, events, signals(true), &collected)
+	testMode(t, mode, testNoOpts, events, signals(true), &collected)
 }
 
 func TestFailoverConnectFailAndSend(t *testing.T) {
@@ -95,7 +95,7 @@ func testFailoverConnectionFail(t *testing.T, events []eventInfo) {
 		1*time.Millisecond,
 		100*time.Millisecond,
 	)
-	testMode(t, mode, events, signals(false), &collected)
+	testMode(t, mode, testNoOpts, events, signals(false), &collected)
 }
 
 func TestFailoverConnectionFail(t *testing.T) {
@@ -127,7 +127,7 @@ func testFailoverSendFlaky(t *testing.T, events []eventInfo) {
 		1*time.Millisecond,
 		100*time.Millisecond,
 	)
-	testMode(t, mode, events, signals(true), &collected)
+	testMode(t, mode, testNoOpts, events, signals(true), &collected)
 }
 
 func TestFailoverSendFlaky(t *testing.T) {
@@ -159,7 +159,7 @@ func testFailoverSendFlakyFail(t *testing.T, events []eventInfo) {
 		1*time.Millisecond,
 		100*time.Millisecond,
 	)
-	testMode(t, mode, events, signals(false), &collected)
+	testMode(t, mode, testNoOpts, events, signals(false), &collected)
 }
 
 func TestFailoverSendFlakyFail(t *testing.T) {
@@ -191,7 +191,7 @@ func testFailoverSendFlakyInfAttempts(t *testing.T, events []eventInfo) {
 		1*time.Millisecond,
 		100*time.Millisecond,
 	)
-	testMode(t, mode, events, signals(true), &collected)
+	testMode(t, mode, testNoOpts, events, signals(true), &collected)
 }
 
 func TestFailoverSendFlakyInfAttempts(t *testing.T) {
@@ -200,4 +200,36 @@ func TestFailoverSendFlakyInfAttempts(t *testing.T) {
 
 func TestFailoverSendMultiFlakyInfAttempts(t *testing.T) {
 	testFailoverSendFlakyInfAttempts(t, multiEvent(10, testEvent))
+}
+
+func testFailoverSendFlakyGuaranteed(t *testing.T, events []eventInfo) {
+	var collected [][]common.MapStr
+	mode, _ := NewFailOverConnectionMode(
+		[]ProtocolClient{
+			&mockClient{
+				connected: false,
+				close:     closeOK,
+				connect:   connectOK,
+				publish:   publishFailStart(50, collectPublish(&collected)),
+			},
+			&mockClient{
+				connected: false,
+				close:     closeOK,
+				connect:   connectOK,
+				publish:   publishFailStart(50, collectPublish(&collected)),
+			},
+		},
+		3,
+		1*time.Millisecond,
+		100*time.Millisecond,
+	)
+	testMode(t, mode, testGuaranteed, events, signals(true), &collected)
+}
+
+func TestFailoverSendFlakyGuaranteed(t *testing.T) {
+	testFailoverSendFlakyGuaranteed(t, singleEvent(testEvent))
+}
+
+func TestFailoverSendMultiFlakyGuaranteed(t *testing.T) {
+	testFailoverSendFlakyGuaranteed(t, multiEvent(10, testEvent))
 }

--- a/libbeat/outputs/mode/mode_test.go
+++ b/libbeat/outputs/mode/mode_test.go
@@ -126,11 +126,13 @@ var testEvent = common.MapStr{
 	"msg": "hello world",
 }
 
-var testOpts = outputs.Options{}
+var testNoOpts = outputs.Options{}
+var testGuaranteed = outputs.Options{Guaranteed: true}
 
 func testMode(
 	t *testing.T,
 	mode ConnectionMode,
+	opts outputs.Options,
 	events []eventInfo,
 	expectedSignals []bool,
 	collectedEvents *[][]common.MapStr,
@@ -157,14 +159,14 @@ func testMode(
 	for _, pubEvents := range events {
 		if pubEvents.single {
 			for _, event := range pubEvents.events {
-				_ = mode.PublishEvent(signal, testOpts, event)
+				_ = mode.PublishEvent(signal, opts, event)
 				if expectedSignals[idx] {
 					expectedEvents = append(expectedEvents, []common.MapStr{event})
 				}
 				idx++
 			}
 		} else {
-			_ = mode.PublishEvents(signal, testOpts, pubEvents.events)
+			_ = mode.PublishEvents(signal, opts, pubEvents.events)
 			if expectedSignals[idx] {
 				expectedEvents = append(expectedEvents, pubEvents.events)
 			}

--- a/libbeat/outputs/mode/single_test.go
+++ b/libbeat/outputs/mode/single_test.go
@@ -22,7 +22,7 @@ func testSingleSendOneEvent(t *testing.T, events []eventInfo) {
 		100*time.Millisecond,
 		1*time.Second,
 	)
-	testMode(t, mode, events, signals(true), &collected)
+	testMode(t, mode, testNoOpts, events, signals(true), &collected)
 }
 
 func TestSingleSendOneEvent(t *testing.T) {
@@ -48,7 +48,7 @@ func testSingleConnectFailConnectAndSend(t *testing.T, events []eventInfo) {
 		100*time.Millisecond,
 		100*time.Millisecond,
 	)
-	testMode(t, mode, events, signals(true), &collected)
+	testMode(t, mode, testNoOpts, events, signals(true), &collected)
 }
 
 func TestSingleConnectFailConnectAndSend(t *testing.T) {
@@ -74,7 +74,7 @@ func testSingleConnectionFail(t *testing.T, events []eventInfo) {
 		100*time.Millisecond,
 		1*time.Second,
 	)
-	testMode(t, mode, events, signals(false), &collected)
+	testMode(t, mode, testNoOpts, events, signals(false), &collected)
 }
 
 func TestSingleConnectionFail(t *testing.T) {
@@ -99,7 +99,7 @@ func testSingleSendFlaky(t *testing.T, events []eventInfo) {
 		100*time.Millisecond,
 		1*time.Second,
 	)
-	testMode(t, mode, events, signals(true), &collected)
+	testMode(t, mode, testNoOpts, events, signals(true), &collected)
 }
 
 func TestSingleSendFlaky(t *testing.T) {
@@ -124,7 +124,7 @@ func testSingleSendFlakyFail(t *testing.T, events []eventInfo) {
 		100*time.Millisecond,
 		1*time.Second,
 	)
-	testMode(t, mode, events, signals(false), &collected)
+	testMode(t, mode, testNoOpts, events, signals(false), &collected)
 }
 
 func TestSingleSendFlakyFail(t *testing.T) {
@@ -149,7 +149,7 @@ func testSingleSendFlakyInfAttempts(t *testing.T, events []eventInfo) {
 		100*time.Millisecond,
 		1*time.Second,
 	)
-	testMode(t, mode, events, signals(true), &collected)
+	testMode(t, mode, testNoOpts, events, signals(true), &collected)
 }
 
 func TestSingleSendFlakyInfAttempts(t *testing.T) {
@@ -158,4 +158,29 @@ func TestSingleSendFlakyInfAttempts(t *testing.T) {
 
 func TestSingleSendMultiFlakyInfAttempts(t *testing.T) {
 	testSingleSendFlakyInfAttempts(t, multiEvent(10, testEvent))
+}
+
+func testSingleSendFlakyGuaranteed(t *testing.T, events []eventInfo) {
+	var collected [][]common.MapStr
+	mode, _ := NewSingleConnectionMode(
+		&mockClient{
+			connected: false,
+			close:     closeOK,
+			connect:   connectOK,
+			publish:   publishFailStart(50, collectPublish(&collected)),
+		},
+		3,
+		0,
+		100*time.Millisecond,
+		1*time.Second,
+	)
+	testMode(t, mode, testGuaranteed, events, signals(true), &collected)
+}
+
+func TestSingleSendFlakyGuaranteed(t *testing.T) {
+	testSingleSendFlakyGuaranteed(t, singleEvent(testEvent))
+}
+
+func TestSingleSendMultiFlakyGuaranteed(t *testing.T) {
+	testSingleSendFlakyGuaranteed(t, multiEvent(10, testEvent))
 }


### PR DESCRIPTION
Checked tests do fail with Guaranteed flag handling before fix has been applied.