### PR TITLE
Winlogbeat: add caching of metadata handles

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -68,13 +68,8 @@ https://github.com/elastic/beats/compare/v1.1.0...master[Check the HEAD diff]
 - Add close_older configuration option to complete ignore_older https://github.com/elastic/filebeat/issues/181[181]
 - Add experimental option to enable filebeat publisher pipeline to operate asynchonrously {pull}782[782]
 
-*Packetbeat*
-
-*Topbeat*
-
-*Filebeat*
-
 *Winlogbeat*
+- Add caching of event metadata handles and the system render context for the wineventlog API {pull}888[888]
 
 ==== Deprecated
 


### PR DESCRIPTION
Caching is already part of the eventlogging implementation, but it wasn't yet added to the wineventlog implementation. This gives a performance boost to Winlogbeat.

- Add caching of event metadata handles (a file handle to a DLL or EXE containing message resources)
- Reuse a single system render context when rendering events