### PR TITLE
Allow running unit and system tests in docker environment

### DIFF
--- a/libbeat/Dockerfile
+++ b/libbeat/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Nicolas Ruflin <ruflin@elastic.co>
 
 RUN set -x && \
     apt-get update && \
-    apt-get install -y netcat && \
+    apt-get install -y netcat python-virtualenv python-pip && \
     apt-get clean
 
 ## Install go package dependencies
@@ -16,5 +16,12 @@ RUN set -x \
 	golang.org/x/tools/cmd/vet
 
 ENV GO15VENDOREXPERIMENT=1
+ENV PYTHON_ENV=/tmp/python-env
+
+
+RUN test -d ${PYTHON_ENV} || virtualenv ${PYTHON_ENV}
+COPY ./tests/system/requirements.txt /tmp/requirements.txt
+RUN . ${PYTHON_ENV}/bin/activate && pip install -Ur /tmp/requirements.txt
+
 
 RUN mkdir -p /etc/pki/tls/certs

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -40,7 +40,7 @@ SYSTEM_TESTS?=false
 GOX_OS?=linux darwin windows solaris freebsd netbsd openbsd
 DOCKER_COMPOSE?=docker-compose -f docker-compose.yml
 GOPACKAGES_COMMA_SEP=$(subst $(space),$(comma),$(strip ${GOPACKAGES}))
-PYTHON_ENV=${BUILD_DIR}/python-env/
+PYTHON_ENV?=${BUILD_DIR}/python-env/
 
 # Conditionally enable the race detector when RACE_DETECTOR=1.
 ifeq ($(RACE_DETECTOR),1)


### PR DESCRIPTION
This change allows to run unit-tests and system-tests inside the docker enviornment without
having to setup python and virutalenv locally. Tests can be run with:

* docker-compose run beat make system-tests
* docker-compose run beat make unit-tests

This is the foundation so in the future system tests can also depend on the virtual environment.
In addition it should simplify the setup of the CI system.