### PR TITLE
Use fixed indentation when generating fields.asciidoc

### DIFF
--- a/libbeat/scripts/generate_fields_docs.py
+++ b/libbeat/scripts/generate_fields_docs.py
@@ -1,10 +1,12 @@
 import yaml
+import sys
 
-def document_fields(output, section, SECTIONS, level=3):
+
+def document_fields(output, section, SECTIONS):
 
     if "anchor" in section:
         output.write("[[exported-fields-{}]]\n".format(section["anchor"]))
-    output.write("{} {} Fields\n\n".format(level*'=', section["name"]))
+    output.write("=== {} Fields\n\n".format(section["name"]))
 
     if "description" in section:
         output.write("{}\n\n".format(section["description"]))
@@ -21,17 +23,17 @@ def document_fields(output, section, SECTIONS, level=3):
                     field["anchor"] = field["name"]
                     field["name"] = name
                     break
-            document_fields(output, field, SECTIONS, level + 1)
+            document_fields(output, field, SECTIONS)
         else:
-            document_field(output, field, level + 1)
+            document_field(output, field)
 
 
-def document_field(output, field, level):
+def document_field(output, field):
 
     if "path" not in field:
         field["path"] = field["name"]
 
-    output.write("{} {}\n\n".format(level*'=', field["path"]))
+    output.write("==== {}\n\n".format(field["path"]))
 
     if "type" in field:
         output.write("type: {}\n\n".format(field["type"]))
@@ -77,11 +79,6 @@ grouped in the following categories:
                     section["name"] = name
                     section["anchor"] = doc
                     document_fields(output, section, SECTIONS)
-
-
-
-
-
 
 if __name__ == "__main__":
     if len(sys.argv) != 3:

--- a/packetbeat/docs/fields.asciidoc
+++ b/packetbeat/docs/fields.asciidoc
@@ -108,303 +108,303 @@ Messages from Packetbeat itself. This field usually contains error messages for 
 
 
 [[exported-fields-icmp]]
-==== ICMP Fields
+=== ICMP Fields
 
 ICMP specific event fields.
 
 
-===== icmp.version
+==== icmp.version
 
 The version of the ICMP protocol.
 
-===== icmp.request.message
+==== icmp.request.message
 
 type: string
 
 A human readable form of the request.
 
-===== icmp.request.type
+==== icmp.request.type
 
 type: int
 
 The request type.
 
-===== icmp.request.code
+==== icmp.request.code
 
 type: int
 
 The request code.
 
-===== icmp.response.message
+==== icmp.response.message
 
 type: string
 
 A human readable form of the response.
 
-===== icmp.response.type
+==== icmp.response.type
 
 type: int
 
 The response type.
 
-===== icmp.response.code
+==== icmp.response.code
 
 type: int
 
 The response code.
 
 [[exported-fields-dns]]
-==== DNS Fields
+=== DNS Fields
 
 DNS-specific event fields.
 
 
-===== dns.id
+==== dns.id
 
 type: int
 
 The DNS packet identifier assigned by the program that generated the query. The identifier is copied to the response.
 
 
-===== dns.op_code
+==== dns.op_code
 
 example: QUERY
 
 The DNS operation code that specifies the kind of query in the message. This value is set by the originator of a query and copied into the response.
 
 
-===== dns.flags.authoritative
+==== dns.flags.authoritative
 
 type: bool
 
 A DNS flag specifying that the responding server is an authority for the domain name used in the question.
 
 
-===== dns.flags.recursion_available
+==== dns.flags.recursion_available
 
 type: bool
 
 A DNS flag specifying whether recursive query support is available in the name server.
 
 
-===== dns.flags.recursion_desired
+==== dns.flags.recursion_desired
 
 type: bool
 
 A DNS flag specifying that the client directs the server to pursue a query recursively. Recursive query support is optional.
 
 
-===== dns.flags.authentic_data
+==== dns.flags.authentic_data
 
 type: bool
 
 A DNS flag specifying that the recursive server considers the response authentic.
 
 
-===== dns.flags.checking_disabled
+==== dns.flags.checking_disabled
 
 type: bool
 
 A DNS flag specifying that the client disables the server signature validation of the query.
 
 
-===== dns.flags.truncated_response
+==== dns.flags.truncated_response
 
 type: bool
 
 A DNS flag specifying that only the first 512 bytes of the reply were returned.
 
 
-===== dns.response_code
+==== dns.response_code
 
 example: NOERROR
 
 The DNS status code.
 
-===== dns.question.name
+==== dns.question.name
 
 example: www.google.com
 
 The domain name being queried. If the name field contains non-printable characters (below 32 or above 126), then those characters are represented as escaped base 10 integers (\DDD). Back slashes and quotes are escaped. Tabs, carriage returns, and line feeds are converted to \t, \r, and \n respectively.
 
 
-===== dns.question.type
+==== dns.question.type
 
 example: AAAA
 
 The type of records being queried.
 
-===== dns.question.class
+==== dns.question.class
 
 example: IN
 
 The class of of records being queried.
 
-===== dns.answers_count
+==== dns.answers_count
 
 type: int
 
 The number of resource records contained in the `dns.answers` field.
 
 
-===== dns.answers.name
+==== dns.answers.name
 
 example: example.com
 
 The domain name to which this resource record pertains.
 
-===== dns.answers.type
+==== dns.answers.type
 
 example: MX
 
 The type of data contained in this resource record.
 
-===== dns.answers.class
+==== dns.answers.class
 
 example: IN
 
 The class of DNS data contained in this resource record.
 
-===== dns.answers.ttl
+==== dns.answers.ttl
 
 type: int
 
 The time interval in seconds that this resource record may be cached before it should be discarded. Zero values mean that the data should  not be cached.
 
 
-===== dns.answers.data
+==== dns.answers.data
 
 The data describing the resource. The meaning of this data depends on the type and class of the resource record.
 
 
-===== dns.authorities
+==== dns.authorities
 
 type: dict
 
 An array containing a dictionary for each authority section from the answer.
 
 
-===== dns.authorities_count
+==== dns.authorities_count
 
 type: int
 
 The number of resource records contained in the `dns.authorities` field. The `dns.authorities` field may or may not be included depending on the configuration of Packetbeat.
 
 
-===== dns.authorities.name
+==== dns.authorities.name
 
 example: example.com
 
 The domain name to which this resource record pertains.
 
-===== dns.authorities.type
+==== dns.authorities.type
 
 example: NS
 
 The type of data contained in this resource record.
 
-===== dns.authorities.class
+==== dns.authorities.class
 
 example: IN
 
 The class of DNS data contained in this resource record.
 
-===== dns.answers
+==== dns.answers
 
 type: dict
 
 An array containing a dictionary about each answer section returned by the server.
 
 
-===== dns.answers.ttl
+==== dns.answers.ttl
 
 type: int
 
 The time interval in seconds that this resource record may be cached before it should be discarded. Zero values mean that the data should  not be cached.
 
 
-===== dns.answers.data
+==== dns.answers.data
 
 The data describing the resource. The meaning of this data depends on the type and class of the resource record.
 
 
-===== dns.additionals
+==== dns.additionals
 
 type: dict
 
 An array containing a dictionary for each additional section from the answer.
 
 
-===== dns.additionals_count
+==== dns.additionals_count
 
 type: int
 
 The number of resource records contained in the `dns.additionals` field. The `dns.additionals` field may or may not be included depending on the configuration of Packetbeat.
 
 
-===== dns.additionals.name
+==== dns.additionals.name
 
 example: example.com
 
 The domain name to which this resource record pertains.
 
-===== dns.additionals.type
+==== dns.additionals.type
 
 example: NS
 
 The type of data contained in this resource record.
 
-===== dns.additionals.class
+==== dns.additionals.class
 
 example: IN
 
 The class of DNS data contained in this resource record.
 
-===== dns.additionals.ttl
+==== dns.additionals.ttl
 
 type: int
 
 The time interval in seconds that this resource record may be cached before it should be discarded. Zero values mean that the data should  not be cached.
 
 
-===== dns.additionals.data
+==== dns.additionals.data
 
 The data describing the resource. The meaning of this data depends on the type and class of the resource record.
 
 
 [[exported-fields-http]]
-==== Http Fields
+=== Http Fields
 
 HTTP-specific event fields.
 
 
-===== http.code
+==== http.code
 
 example: 404
 
 The HTTP status code.
 
-===== http.phrase
+==== http.phrase
 
 example: Not found.
 
 The HTTP status phrase.
 
-===== http.request_headers
+==== http.request_headers
 
 type: dict
 
 A map containing the captured header fields from the request.  Which headers to capture is configurable. If headers with the same header name are present in the message, they will be separated by commas.
 
 
-===== http.response_headers
+==== http.response_headers
 
 type: dict
 
 A map containing the captured header fields from the response.  Which headers to capture is configurable. If headers with the same header name are present in the message, they will be separated by commas.
 
 
-===== http.content_length
+==== http.content_length
 
 type: int
 
@@ -412,299 +412,299 @@ The value of the Content-Length header if present.
 
 
 [[exported-fields-memcache]]
-==== Memcache Fields
+=== Memcache Fields
 
 Memcached-specific event fields
 
 
-===== memcache.protocol_type
+==== memcache.protocol_type
 
 type: string
 
 The memcache protocol implementation. The value can be "binary"  for binary-based, "text" for text-based, or "unknown" for an unknown  memcache protocol type.
 
 
-===== memcache.request.line
+==== memcache.request.line
 
 type: string
 
 The raw command line for unknown commands ONLY.
 
 
-===== memcache.request.command
+==== memcache.request.command
 
 type: string
 
 The memcache command being requested in the memcache text protocol. For example "set" or "get". The binary protocol opcodes are translated into memcache text protocol commands.
 
 
-===== memcache.response.command
+==== memcache.response.command
 
 type: string
 
 Either the text based protocol response message type or the name of the originating request if binary protocol is used.
 
 
-===== memcache.request.type
+==== memcache.request.type
 
 type: string
 
 The memcache command classification. This value can be "UNKNOWN", "Load", "Store", "Delete", "Counter", "Info", "SlabCtrl", "LRUCrawler", "Stats", "Success", "Fail", or "Auth".
 
 
-===== memcache.response.type
+==== memcache.response.type
 
 type: string
 
 The memcache command classification. This value can be "UNKNOWN", "Load", "Store", "Delete", "Counter", "Info", "SlabCtrl", "LRUCrawler", "Stats", "Success", "Fail", or "Auth". The text based protocol will employ any of these, whereas the binary based protocol will mirror the request commands only (see `memcache.response.status` for binary protocol).
 
 
-===== memcache.response.error_msg
+==== memcache.response.error_msg
 
 type: string
 
 The optional error message in the memcache response (text based protocol only).
 
 
-===== memcache.request.opcode
+==== memcache.request.opcode
 
 type: string
 
 The binary protocol message opcode name.
 
 
-===== memcache.response.opcode
+==== memcache.response.opcode
 
 type: string
 
 The binary protocol message opcode name.
 
 
-===== memcache.request.opcode_value
+==== memcache.request.opcode_value
 
 type: int
 
 The binary protocol message opcode value.
 
 
-===== memcache.response.opcode_value
+==== memcache.response.opcode_value
 
 type: int
 
 The binary protocol message opcode value.
 
 
-===== memcache.request.opaque
+==== memcache.request.opaque
 
 type: int
 
 The binary protocol opaque header value used for correlating request with response messages.
 
 
-===== memcache.response.opaque
+==== memcache.response.opaque
 
 type: int
 
 The binary protocol opaque header value used for correlating request with response messages.
 
 
-===== memcache.request.vbucket
+==== memcache.request.vbucket
 
 type: int
 
 The vbucket index sent in the binary message.
 
 
-===== memcache.response.status
+==== memcache.response.status
 
 type: string
 
 The textual representation of the response error code (binary protocol only).
 
 
-===== memcache.response.status_code
+==== memcache.response.status_code
 
 type: int
 
 The status code value returned in the response (binary protocol only).
 
 
-===== memcache.request.keys
+==== memcache.request.keys
 
 type: list
 
 The list of keys sent in the store or load commands.
 
 
-===== memcache.response.keys
+==== memcache.response.keys
 
 type: list
 
 The list of keys returned for the load command (if present).
 
 
-===== memcache.request.count_values
+==== memcache.request.count_values
 
 type: int
 
 The number of values found in the memcache request message. If the command does not send any data, this field is missing.
 
 
-===== memcache.response.count_values
+==== memcache.response.count_values
 
 type: int
 
 The number of values found in the memcache response message. If the command does not send any data, this field is missing.
 
 
-===== memcache.request.values
+==== memcache.request.values
 
 type: list
 
 The list of base64 encoded values sent with the request (if present).
 
 
-===== memcache.response.values
+==== memcache.response.values
 
 type: list
 
 The list of base64 encoded values sent with the response (if present).
 
 
-===== memcache.request.bytes
+==== memcache.request.bytes
 
 type: int
 
 The byte count of the values being transfered.
 
 
-===== memcache.response.bytes
+==== memcache.response.bytes
 
 type: int
 
 The byte count of the values being transfered.
 
 
-===== memcache.request.delta
+==== memcache.request.delta
 
 type: int
 
 The counter increment/decrement delta value.
 
 
-===== memcache.request.initial
+==== memcache.request.initial
 
 type: int
 
 The counter increment/decrement initial value parameter (binary protocol only).
 
 
-===== memcache.request.verbosity
+==== memcache.request.verbosity
 
 type: int
 
 The value of the memcache "verbosity" command.
 
 
-===== memcache.request.raw_args
+==== memcache.request.raw_args
 
 type: string
 
 The text protocol raw arguments for the "stats ..." and "lru crawl ..." commands.
 
 
-===== memcache.request.source_class
+==== memcache.request.source_class
 
 type: int
 
 The source class id in 'slab reassign' command.
 
 
-===== memcache.request.dest_class
+==== memcache.request.dest_class
 
 type: int
 
 The destination class id in 'slab reassign' command.
 
 
-===== memcache.request.automove
+==== memcache.request.automove
 
 type: string
 
 The automove mode in the 'slab automove' command expressed as a string. This value can be "standby"(=0), "slow"(=1), "aggressive"(=2), or the raw value if the value is unknown.
 
 
-===== memcache.request.flags
+==== memcache.request.flags
 
 type: int
 
 The memcache command flags sent in the request (if present).
 
 
-===== memcache.response.flags
+==== memcache.response.flags
 
 type: int
 
 The memcache message flags sent in the response (if present).
 
 
-===== memcache.request.exptime
+==== memcache.request.exptime
 
 type: int
 
 The data expiry time in seconds sent with the memcache command (if present). If the value is <30 days, the expiry time is relative to "now", or else it is an absolute Unix time in seconds (32-bit).
 
 
-===== memcache.request.sleep_us
+==== memcache.request.sleep_us
 
 type: int
 
 The sleep setting in microseconds for the 'lru_crawler sleep' command.
 
 
-===== memcache.response.value
+==== memcache.response.value
 
 type: int
 
 The counter value returned by a counter operation.
 
 
-===== memcache.request.noreply
+==== memcache.request.noreply
 
 type: bool
 
 Set to true if noreply was set in the request. The `memcache.response` field will be missing.
 
 
-===== memcache.request.quiet
+==== memcache.request.quiet
 
 type: bool
 
 Set to true if the binary protocol message is to be treated as a quiet message.
 
 
-===== memcache.request.cas_unique
+==== memcache.request.cas_unique
 
 type: int
 
 The CAS (compare-and-swap) identifier if present.
 
 
-===== memcache.response.cas_unique
+==== memcache.response.cas_unique
 
 type: int
 
 The CAS (compare-and-swap) identifier to be used with CAS-based updates (if present).
 
 
-===== memcache.response.stats
+==== memcache.response.stats
 
 type: list
 
 The list of statistic values returned. Each entry is a dictionary with the  fields "name" and "value".
 
 
-===== memcache.response.version
+==== memcache.response.version
 
 type: string
 
@@ -712,205 +712,205 @@ The returned memcache version string.
 
 
 [[exported-fields-mysql]]
-==== Mysql Fields
+=== Mysql Fields
 
 MySQL-specific event fields.
 
 
-===== mysql.iserror
+==== mysql.iserror
 
 type: bool
 
 If the MySQL query returns an error, this field is set to true.
 
 
-===== mysql.affected_rows
+==== mysql.affected_rows
 
 type: int
 
 If the MySQL command is successful, this field contains the affected number of rows of the last statement.
 
 
-===== mysql.insert_id
+==== mysql.insert_id
 
 If the INSERT query is successful, this field contains the id of the newly inserted row.
 
 
-===== mysql.num_fields
+==== mysql.num_fields
 
 If the SELECT query is successful, this field is set to the number of fields returned.
 
 
-===== mysql.num_rows
+==== mysql.num_rows
 
 If the SELECT query is successful, this field is set to the number of rows returned.
 
 
-===== mysql.query
+==== mysql.query
 
 The row mysql query as read from the transaction's request.
 
 
-===== mysql.error_code
+==== mysql.error_code
 
 type: int
 
 The error code returned by MySQL.
 
 
-===== mysql.error_message
+==== mysql.error_message
 
 The error info message returned by MySQL.
 
 
 [[exported-fields-pgsql]]
-==== PostgreSQL Fields
+=== PostgreSQL Fields
 
 PostgreSQL-specific event fields.
 
 
-===== pgsql.query
+==== pgsql.query
 
 The row pgsql query as read from the transaction's request.
 
 
-===== pgsql.iserror
+==== pgsql.iserror
 
 type: bool
 
 If the PgSQL query returns an error, this field is set to true.
 
 
-===== pgsql.error_code
+==== pgsql.error_code
 
 type: int
 
 The PostgreSQL error code.
 
-===== pgsql.error_message
+==== pgsql.error_message
 
 The PostgreSQL error message.
 
-===== pgsql.error_severity
+==== pgsql.error_severity
 
 The PostgreSQL error severity.
 
-===== pgsql.num_fields
+==== pgsql.num_fields
 
 If the SELECT query if successful, this field is set to the number of fields returned.
 
 
-===== pgsql.num_rows
+==== pgsql.num_rows
 
 If the SELECT query if successful, this field is set to the number of rows returned.
 
 
 [[exported-fields-thrift]]
-==== Thrift-RPC Fields
+=== Thrift-RPC Fields
 
 Thrift-RPC specific event fields.
 
 
-===== thrift.params
+==== thrift.params
 
 The RPC method call parameters in a human readable format. If the IDL files are available, the parameters use names whenever possible. Otherwise, the IDs from the message are used.
 
 
-===== thrift.service
+==== thrift.service
 
 The name of the Thrift-RPC service as defined in the IDL files.
 
 
-===== thrift.return_value
+==== thrift.return_value
 
 The value returned by the Thrift-RPC call. This is encoded in a human readable format.
 
 
-===== thrift.exceptions
+==== thrift.exceptions
 
 If the call resulted in exceptions, this field contains the exceptions in a human readable format.
 
 
 [[exported-fields-redis]]
-==== Redis Fields
+=== Redis Fields
 
 Redis-specific event fields.
 
 
-===== redis.return_value
+==== redis.return_value
 
 The return value of the Redis command in a human readable format.
 
 
-===== redis.error
+==== redis.error
 
 If the Redis command has resulted in an error, this field contains the error message returned by the Redis server.
 
 
 [[exported-fields-mongodb]]
-==== MongoDb Fields
+=== MongoDb Fields
 
 MongoDB-specific event fields. These fields mirror closely the fields for the MongoDB wire protocol. The higher level fields (for example, `query` and `resource`) apply to MongoDB events as well.
 
 
 
-===== mongodb.error
+==== mongodb.error
 
 If the MongoDB request has resulted in an error, this field contains the error message returned by the server.
 
 
-===== mongodb.fullCollectionName
+==== mongodb.fullCollectionName
 
 The full collection name. The full collection name is the concatenation of the database name with the collection name, using a dot (.) for the concatenation. For example, for the database foo and the collection bar, the full collection name is foo.bar.
 
 
-===== mongodb.numberToSkip
+==== mongodb.numberToSkip
 
 type: number
 
 Sets the number of documents to omit - starting from the first document in the resulting dataset - when returning the result of the query.
 
 
-===== mongodb.numberToReturn
+==== mongodb.numberToReturn
 
 type: number
 
 The requested maximum number of documents to be returned.
 
 
-===== mongodb.numberReturned
+==== mongodb.numberReturned
 
 type: number
 
 The number of documents in the reply.
 
 
-===== mongodb.startingFrom
+==== mongodb.startingFrom
 
 Where in the cursor this reply is starting.
 
 
-===== mongodb.query
+==== mongodb.query
 
 A JSON document that represents the query. The query will contain one or more elements, all of which must match for a document to be included in the result set. Possible elements include $query, $orderby, $hint, $explain, and $snapshot.
 
 
-===== mongodb.returnFieldsSelector
+==== mongodb.returnFieldsSelector
 
 A JSON document that limits the fields in the returned documents. The returnFieldsSelector contains one or more elements, each of which is the name of a field that should be returned, and the integer value 1.
 
 
-===== mongodb.selector
+==== mongodb.selector
 
 A BSON document that specifies the query for selecting the document to update or delete.
 
 
-===== mongodb.update
+==== mongodb.update
 
 A BSON document that specifies the update to be performed. For information on specifying updates, see the Update Operations documentation from the MongoDB Manual.
 
 
-===== mongodb.cursorId
+==== mongodb.cursorId
 
 The cursor identifier returned in the OP_REPLY. This must be the value that was returned from the database.
 

--- a/topbeat/docs/fields.asciidoc
+++ b/topbeat/docs/fields.asciidoc
@@ -67,260 +67,260 @@ Contains system-wide statistics. These statistics are the details that you can g
 
 
 
-==== load Fields
+=== load Fields
 
 The system load average. The load average is the average number  of jobs in the run queue.
 
 
 
-===== load.load1
+==== load.load1
 
 type: float
 
 The load average over 1 minute. 
 
 
-===== load.load5
+==== load.load5
 
 type: float
 
 The load average over 5 minutes.
 
 
-===== load.load15
+==== load.load15
 
 type: float
 
 The load average over 15 minutes. 
 
 
-==== cpu Fields
+=== cpu Fields
 
 This group contains statistics related to CPU usage.
 
 
-===== cpu.user
+==== cpu.user
 
 type: int
 
 The amount of CPU time spent in user space.
 
 
-===== cpu.user_p
+==== cpu.user_p
 
 type: float
 
 The percentage of CPU time spent in user space. On multi-core systems, you can have percentages that are greater than 100%.  For example, if 3 cores are at 60% use, then the `cpu.user_p` will be 180%.
 
 
-===== cpu.nice
+==== cpu.nice
 
 type: int
 
 The amount of CPU time spent on low-priority processes.
 
 
-===== cpu.system
+==== cpu.system
 
 type: int
 
 The amount of CPU time spent in kernel space.
 
 
-===== cpu.system_p
+==== cpu.system_p
 
 type: float
 
 The percentage of CPU time spent in kernel space.
 
 
-===== cpu.idle
+==== cpu.idle
 
 type: int
 
 The amount of CPU time spent idle.
 
 
-===== cpu.iowait
+==== cpu.iowait
 
 type: int
 
 The amount of CPU time spent in wait (on disk).
 
 
-===== cpu.irq
+==== cpu.irq
 
 type: int
 
 The amount of CPU time spent servicing and handling hardware interrupts.
 
 
-===== cpu.softirq
+==== cpu.softirq
 
 type: int
 
 The amount of CPU time spent servicing and handling software interrupts.
 
-===== cpu.steal
+==== cpu.steal
 
 type: int
 
 The amount of CPU time spent in involuntary wait by the virtual CPU while the hypervisor was servicing another processor. Available only on Unix.
 
 
-==== cpus Fields
+=== cpus Fields
 
 This group contains CPU usage per core statistics.
 
 
-===== cpuX Fields
+=== cpuX Fields
 
 This group contains CPU usage statistics of the core X, where 0<X<N and N is the number of cores.
 
 
-====== cpus.cpuX.user
+==== cpus.cpuX.user
 
 type: int
 
 The amount of CPU time spent in user space on core X.
 
 
-====== cpus.cpuX.user_p
+==== cpus.cpuX.user_p
 
 type: float
 
 The percentage of CPU time spent in user space on core X.
 
 
-====== cpus.cpuX.nice
+==== cpus.cpuX.nice
 
 type: int
 
 The amount of CPU time spent on low-priority processes on core X.
 
 
-====== cpus.cpuX.system
+==== cpus.cpuX.system
 
 type: int
 
 The amount of CPU time spent in kernel space on core X.
 
 
-====== cpus.cpuX.system_p
+==== cpus.cpuX.system_p
 
 type: float
 
 The percentage of CPU time spent in kernel space on core X.
 
 
-====== cpus.cpuX.idle
+==== cpus.cpuX.idle
 
 type: int
 
 The amount of CPU time spent idle on core X.
 
 
-====== cpus.cpuX.iowait
+==== cpus.cpuX.iowait
 
 type: int
 
 The amount of CPU time spent in wait (on disk) on core X.
 
 
-====== cpus.cpuX.softirq
+==== cpus.cpuX.softirq
 
 type: int
 
 The amount of CPU time spent servicing and handling software interrupts on core X.
 
-====== cpus.cpuX.steal
+==== cpus.cpuX.steal
 
 type: int
 
 The amount of CPU time spent in involuntary wait by the virtual CPU while the hypervisor was servicing another processor on core X. Available only on Unix.
 
 
-==== mem Fields
+=== mem Fields
 
 This group contains statistics related to the memory usage on the system.
 
 
-===== mem.total
+==== mem.total
 
 type: int
 
 Total memory.
 
 
-===== mem.used
+==== mem.used
 
 type: int
 
 Used memory.
 
 
-===== mem.free
+==== mem.free
 
 type: int
 
 Available memory.
 
 
-===== mem.used_p
+==== mem.used_p
 
 type: float
 
 The percentage of used memory.
 
 
-===== mem.actual_used
+==== mem.actual_used
 
 type: int
 
 Actual used memory. This value is the "used" memory minus the memory used for disk caches and buffers.  Available only on Unix.
 
 
-===== mem.actual_free
+==== mem.actual_free
 
 type: int
 
 Actual available memory. This value is the "free" memory plus the memory used for disk caches and buffers. Available only on Unix.
 
 
-===== mem.actual_used_p
+==== mem.actual_used_p
 
 type: float
 
 The percentage of actual used memory.
 
 
-==== swap Fields
+=== swap Fields
 
 This group contains statistics related to the swap memory usage on the system.
 
 
-===== swap.total
+==== swap.total
 
 type: int
 
 Total swap memory.
 
 
-===== swap.used
+==== swap.used
 
 type: int
 
 Used swap memory.
 
 
-===== swap.free
+==== swap.free
 
 type: int
 
 Available swap memory.
 
 
-===== swap.used_p
+==== swap.used_p
 
 type: float
 
@@ -334,121 +334,121 @@ Per-process statistics that you can get by running the *top* or *ps* command on 
 
 
 
-==== proc Fields
+=== proc Fields
 
 Contains per-process statistics like memory usage, CPU usage, and details about each process, such as state, name, pid, and ppid.
 
 
 
-===== proc.name
+==== proc.name
 
 type: string
 
 The process name.
 
 
-===== proc.state
+==== proc.state
 
 type: string
 
 The process state. For example: "running"
 
 
-===== proc.pid
+==== proc.pid
 
 type: int
 
 The process pid.
 
 
-===== proc.ppid
+==== proc.ppid
 
 type: int
 
 The process parent pid.
 
 
-===== proc.cmdline
+==== proc.cmdline
 
 type: string
 
 The full command-line used to start the process, including the arguments separated by space.
 
 
-===== proc.username
+==== proc.username
 
 type: string
 
 The username of the user that created the process. If the username can not be determined then the the field will contain the user's numeric identifier (UID). On Windows, this field includes the user's domain and is formatted as `domain\username`.
 
 
-===== cpu Fields
+=== cpu Fields
 
 CPU-specific statistics per process.
 
 
-====== proc.cpu.user
+==== proc.cpu.user
 
 type: int
 
 The amount of CPU time the process spent in user space.
 
 
-====== proc.cpu.total_p
+==== proc.cpu.total_p
 
 type: float
 
 The percentage of CPU time spent by the process since the last update. Its value is similar with the %CPU value of the process displayed by the top command on unix systems.
 
 
-====== proc.cpu.system
+==== proc.cpu.system
 
 type: int
 
 The amount of CPU time the process spent in kernel space.
 
 
-====== proc.cpu.total
+==== proc.cpu.total
 
 type: int
 
 The total CPU time spent by the process.
 
 
-====== proc.cpu.start_time
+==== proc.cpu.start_time
 
 type: string
 
 The time when the process was started. Example: "17:45".
 
 
-===== mem Fields
+=== mem Fields
 
 Memory-specific statistics per process.
 
 
-====== proc.mem.size
+==== proc.mem.size
 
 type: int
 
 The total virtual memory the process has.
 
 
-====== proc.mem.rss
+==== proc.mem.rss
 
 type: int
 
 The Resident Set Size. The amount of memory the process occupied in main memory (RAM).
 
 
-====== proc.mem.rss_p
+==== proc.mem.rss_p
 
 type: float
 
 The percentage of memory the process occupied in main memory (RAM).
 
 
-====== proc.mem.share
+==== proc.mem.share
 
 type: int
 
@@ -462,62 +462,62 @@ File system-related statistics that you can get by using the *df* command on Uni
 
 
 
-==== fs Fields
+=== fs Fields
 
 Contains details about the mounted disks, such as the total or used disk space, and details about each disk, such as  the device name and the mounting place.
 
 
 
-===== fs.avail
+==== fs.avail
 
 type: int
 
 The available disk space in bytes.
 
 
-===== fs.device_name
+==== fs.device_name
 
 type: string
 
 The disk name. For example: `/dev/disk1`
 
 
-===== fs.mount_point
+==== fs.mount_point
 
 type: string
 
 The mounting point. For example: `/`
 
 
-===== fs.files
+==== fs.files
 
 type: int
 
 The total number of file nodes in the file system. 
 
 
-===== fs.free_files
+==== fs.free_files
 
 type: int
 
 The number of free file nodes in the file system.
 
 
-===== fs.total
+==== fs.total
 
 type: int
 
 The total disk space in bytes.
 
 
-===== fs.used
+==== fs.used
 
 type: int
 
 The used disk space in bytes.
 
 
-===== fs.used_p
+==== fs.used_p
 
 type: float
 


### PR DESCRIPTION
When generating the fields docs use "===" for the fields group section and "====" for each field. Basically I rolled-back to the previous version of the script.