### PR TITLE
Add changes for 891, 893, and some misc consistency issues

### DIFF
--- a/filebeat/docs/command-line.asciidoc
+++ b/filebeat/docs/command-line.asciidoc
@@ -4,7 +4,8 @@
 Filebeat does not have any Filebeat-specific command line options. Instead, you
 configure the behaviour of Filebeat by specifying options in the configuration file.
 
-The following command line options from libbeat are also available for Filebeat.
+The following command line options from libbeat are also available for Filebeat. To
+use these options, you need to start Filebeat in the foreground.
 
 To start Filebeat, you must use the `-c config/path` option to specify the path to the
 configuration file.

--- a/filebeat/docs/getting-started.asciidoc
+++ b/filebeat/docs/getting-started.asciidoc
@@ -96,8 +96,7 @@ filebeat:
       # Paths that should be crawled and fetched. Glob based paths.
       # For each file found under this path, a harvester is started.
       paths:
-        - "/private/var/log/*.log"
-        - "/Users/Shared/testlogs/*.log"
+        - "/var/log/*.log"
         #- c:\programdata\elasticsearch\logs\*
 
       # Type of the files. Based on this the way the file is read is decided.
@@ -121,16 +120,16 @@ filebeat:
   prospectors:
     -
       paths:
-        - "/private/var/log/*.log"
+        - "/var/log/*.log"
 -------------------------------------------------------------------------------------
 +
-The prospector in this example harvests all files in the path `/private/var/log/*.log`, which means
-that Filebeat will harvest all files in the directory `/private/var/log/` that end with `.log`. All patterns supported
+The prospector in this example harvests all files in the path `/var/log/*.log`, which means
+that Filebeat will harvest all files in the directory `/var/log/` that end with `.log`. All patterns supported
 by https://golang.org/pkg/path/filepath/#Glob[Golang Glob] are also supported here.
 +
 To fetch all files from a predefined level of subdirectories, the following pattern can be used:
-`/private/var/log/*/*.log`. This fetches all `.log` files from the subfolders of `/private/var/log`. It does not
-fetch log files from the `/private/var/log` folder itself. Currently it is not possible to recursively
+`/var/log/*/*.log`. This fetches all `.log` files from the subfolders of `/var/log`. It does not
+fetch log files from the `/var/log` folder itself. Currently it is not possible to recursively
 fetch all files in all subdirectories of a directory.
 +
 A config file can contain multiple prospectors and multiple paths per prospector
@@ -145,11 +144,11 @@ filebeat:
   prospectors:
     -
       paths:
-        - /private/var/log/system.log
-        - /private/var/log/wifi.log
+        - /var/log/system.log
+        - /var/log/wifi.log
     -
       paths:
-        - "/private/var/log/apache2/*"
+        - "/var/log/apache2/*"
 -------------------------------------------------------------------------------------
 +
 The config file in the example starts two prospectors. The first prospector has two harvesters,

--- a/filebeat/docs/getting-started.asciidoc
+++ b/filebeat/docs/getting-started.asciidoc
@@ -79,8 +79,12 @@ see <<filebeat-configuration-details>>.
 [[filebeat-configuration]]
 === Configuring Filebeat
 
-To configure Filebeat, you edit the _filebeat.yml_ file. Here is a sample of
-`filebeat` section of the _filebeat.yml_ file:
+To configure Filebeat, you edit the configuration file. For rpm and deb, you'll
+find the configuration file at `/etc/filebeat/filebeat.yml`. For mac and win, look in
+the archive that you just extracted.
+
+Here is a sample of the `filebeat` section of the `filebeat.yml` file. Filebeat uses predefined
+default values for most configuration options. 
 
 [source,yaml]
 -------------------------------------------------------------------------------------
@@ -92,8 +96,9 @@ filebeat:
       # Paths that should be crawled and fetched. Glob based paths.
       # For each file found under this path, a harvester is started.
       paths:
-        - "/var/log/*.log"
-      # - c:\programdata\elasticsearch\logs\*
+        - "/private/var/log/*.log"
+        - "/Users/Shared/testlogs/*.log"
+        #- c:\programdata\elasticsearch\logs\*
 
       # Type of the files. Based on this the way the file is read is decided.
       # The different types cannot be mixed in one prospector
@@ -104,52 +109,71 @@ filebeat:
       input_type: log
 -------------------------------------------------------------------------------------
 
-Filebeat uses predefined default values for most configuration options. For the most basic
-Filebeat configuration, you can define a single prospector with a single path. For example:
+To configure Filebeat:
 
+. Define the path (or paths) to your log files.
++
+For the most basic Filebeat configuration, you can define a single prospector with a single path. For example:
++
 [source,yaml]
 -------------------------------------------------------------------------------------
 filebeat:
   prospectors:
     -
       paths:
-        - "/var/log/*.log"
+        - "/private/var/log/*.log"
 -------------------------------------------------------------------------------------
-
-The prospector in this example harvests all files in the path `/var/log/*.log`, which means
-that Filebeat will harvest all files in the directory `/var/log/` that end with `.log`. All patterns supported
++
+The prospector in this example harvests all files in the path `/private/var/log/*.log`, which means
+that Filebeat will harvest all files in the directory `/private/var/log/` that end with `.log`. All patterns supported
 by https://golang.org/pkg/path/filepath/#Glob[Golang Glob] are also supported here.
-
++
 To fetch all files from a predefined level of subdirectories, the following pattern can be used:
-`/var/log/*/*.log`. This fetches all `.log` files from the subfolders of `/var/log`. It does not
-fetch log files from the `/var/log` folder itself. Currently it is not possible to recursively
+`/private/var/log/*/*.log`. This fetches all `.log` files from the subfolders of `/private/var/log`. It does not
+fetch log files from the `/private/var/log` folder itself. Currently it is not possible to recursively
 fetch all files in all subdirectories of a directory.
-
++
 A config file can contain multiple prospectors and multiple paths per prospector
 as shown in the following example.
-
++
 NOTE: Make sure a file is not defined more than once across all prospectors because this can lead
 to unexpected behaviour.
-
++
 [source,yaml]
 -------------------------------------------------------------------------------------
 filebeat:
   prospectors:
     -
       paths:
-        - /var/log/system.log
-        - /var/log/wifi.log
+        - /private/var/log/system.log
+        - /private/var/log/wifi.log
     -
       paths:
-        - "/var/log/apache/*"
+        - "/private/var/log/apache2/*"
 -------------------------------------------------------------------------------------
-
++
 The config file in the example starts two prospectors. The first prospector has two harvesters,
 one harvesting the `system.log` file, and the other harvesting `wifi.log`. The second prospector
 starts a harvester for each file in the apache directory.
 
+. If you are sending output to Elasticsearch, set the IP address and port where Filebeat can find the Elasticsearch installation:
++
+[source,yaml]
+----------------------------------------------------------------------
+# Configure what outputs to use when sending the data collected by the beat.
+# Multiple outputs may be used.
+output:
+  ### Elasticsearch as output
+  elasticsearch:
+    # Array of hosts to connect to.
+     hosts: ["192.168.1.42:9200"]
+----------------------------------------------------------------------
++
+If you are sending output to Logstash, see <<config-filebeat-logstash>> instead.
+
 See <<filebeat-configuration-details>> for more details about each configuration option.
 
+[[config-filebeat-logstash]]
 === Configuring Filebeat to Use Logstash
 
 include::../../libbeat/docs/shared-logstash-config.asciidoc[]

--- a/filebeat/docs/migration.asciidoc
+++ b/filebeat/docs/migration.asciidoc
@@ -117,8 +117,8 @@ filebeat:
     # Each - is a prospector. Below are the prospector specific configurations
     -
       paths:
-        - /var/log/messages
-        - "/var/log/*.log"
+        - /system/var/log/messages
+        - "/system/var/log/*.log"
       document_type: syslog <1>
       fields:
         service: apache
@@ -128,7 +128,7 @@ filebeat:
       document_type: stdin
     -
       paths:
-        - "/var/log/apache/httpd-*.log"
+        - "/system/var/log/apache2/httpd-*.log"
       document_type: apache
 -------------------------------------------------------------------------------------
 
@@ -190,26 +190,23 @@ The equivalent in Filebeat would look like this:
 -------------------------------------------------------------------------------------
 output:
   logstash:
-    enabled: true
-
-    # The list of downstream Logstash servers. <1>
+    # The Logstash hosts. <1>
     hosts:
       - localhost:5043
+      
+    # Network timeout in seconds.
+    timeout: 15
 
     tls: <2>
-      # The path to your SSL client certificate.
+      # List of root certificates for HTTPS server verifications
+      certificate_authorities: 
+        - ./logstash-forwarder.crt
+        
+      # Certificate for TLS client authentication
       certificate: ./logstash-forwarder.crt
 
-      # The path to your SSL client certificate key.
-      certificate_key: ./logstash-forwarder.key
-
-      # The path to your trusted SSL CA file. This is used
-      # to authenticate your downstream server.
-      certificate_authorities:
-        - ./logstash-forwarder.crt
-
-      # Network timeout in seconds.
-      timeout: 15
+      # Client Certificate Key
+      certificate_key: ./logstash-forwarder.key    
 -------------------------------------------------------------------------------------
 
 <1> When multiple hosts are defined, the default behavior in Filebeat is to
@@ -285,7 +282,6 @@ filebeat:
         service: test01
 output:
   elasticsearch:
-    enabled: true
     hosts: ["http://localhost:5043"]
 -------------------------------------------------------------------------------------
 

--- a/filebeat/docs/migration.asciidoc
+++ b/filebeat/docs/migration.asciidoc
@@ -117,8 +117,8 @@ filebeat:
     # Each - is a prospector. Below are the prospector specific configurations
     -
       paths:
-        - /system/var/log/messages
-        - "/system/var/log/*.log"
+        - /var/log/messages
+        - "/var/log/*.log"
       document_type: syslog <1>
       fields:
         service: apache
@@ -128,7 +128,7 @@ filebeat:
       document_type: stdin
     -
       paths:
-        - "/system/var/log/apache2/httpd-*.log"
+        - "/var/log/apache2/httpd-*.log"
       document_type: apache
 -------------------------------------------------------------------------------------
 

--- a/libbeat/docs/command-line.asciidoc
+++ b/libbeat/docs/command-line.asciidoc
@@ -1,7 +1,8 @@
 [[command-line-options]]
 == Command Line Options
 
-The following command line options are available for all Beats. For additional
-command line options, see the documentation for your Beat.
+The following command line options are available for all Beats. To use these
+options, you need to start the Beat in the foreground. For additional command
+line options, see the documentation for your Beat.
 
 include::./shared-command-line.asciidoc[]

--- a/libbeat/docs/gettingstarted.asciidoc
+++ b/libbeat/docs/gettingstarted.asciidoc
@@ -110,18 +110,17 @@ You should see a response similar to this:
 [source,shell]
 ----------------------------------------------------------------------
 {
-  "name" : "Banshee",
+  "name" : "Angela Del Toro",
   "cluster_name" : "elasticsearch",
   "version" : {
     "number" : "2.2.0",
-    "build_hash" : "72cd1f1a3eee09505e036106146dc1949dc5dc87",
-    "build_timestamp" : "2015-11-18T22:40:03Z",
+    "build_hash" : "8ff36d139e16f8720f2947ef62c8167a888992fe",
+    "build_timestamp" : "2016-01-27T13:32:39Z",
     "build_snapshot" : false,
-    "lucene_version" : "5.3.1"
+    "lucene_version" : "5.4.1"
   },
   "tagline" : "You Know, for Search"
 }
-
 ----------------------------------------------------------------------
 
 [[logstash-installation]]
@@ -403,12 +402,11 @@ Use the following commands to run the script:
 curl -L -O http://download.elastic.co/beats/dashboards/beats-dashboards-{Dashboards-version}.zip
 unzip beats-dashboards-{Dashboards-version}.zip
 cd beats-dashboards-{Dashboards-version}/
-./load.sh -url http://localhost:9200
+./load.sh
 ----------------------------------------------------------------------
 
-Replace `localhost:9200` with the location where Elasticsearch is running.
-For example, `./load.sh -url http://192.168.33.60:9200`. For more command-line options,
-see <<dashboard-load-options>>.
+By default, the script assumes that you are running Elasticsearch on `127.0.0.1:9200`. Use the `-url` option
+to specify a different location. For example: `./load.sh -url http://192.168.33.60:9200`. To specify a Kibana index pattern or pass in user credentials, see <<dashboard-load-options>>.
 
 *win:*
 
@@ -426,47 +424,41 @@ to download and install PowerShell.
 ["source","sh",subs="attributes,callouts"]
 ----------------------------------------------------------------------
 PS > cd beats-dashboards-{Dashboards-version}
-PS > .\load.ps1 -url http://localhost:9200
+PS > .\load.ps1
 ----------------------------------------------------------------------
 +
-Replace `localhost:9200` with the location where Elasticsearch is running. For example,
-`.\load.ps1 -url http://192.168.33.60:9200`. For more command-line options,
-see <<dashboard-load-options>>.
+By default, the script assumes that you are running Elasticsearch on `127.0.0.1:9200`. Use the `-url` option
+to specify a different location. For example: `.\load.ps1 -url http://192.168.33.60:9200`. To specify a Kibana index pattern or pass in user credentials, see <<dashboard-load-options>>.
 +
-NOTE: If script execution is disabled on your system, you need to set the execution policy for the current session to allow the script to run. For example: `PowerShell.exe -ExecutionPolicy UnRestricted -File .\load.ps1 -url http://localhost:9200`.
+NOTE: If script execution is disabled on your system, you need to set the execution policy for the current session to allow the script to run. For example: `PowerShell.exe -ExecutionPolicy UnRestricted -File .\load.ps1 -url http://192.168.33.60:9200`.
 
 [[dashboard-load-options]]
-===== Dashboard Load Options
+===== Other Dashboard Load Options
+When you load the dashboards, you can also specify:
 
-You can specify the following options when you run the load script (`load.sh` or
-`load.ps1`) to load Kibana dashboards. If you specify no options, the script
-assumes that Elasticsearch is running at `http://localhost:9200`.
-
-[[horizontal]]
-*`-h | -help`*::
-Print the help menu.
-
-*`-l | -url <Elasticsearch_url>`*::
-The URL of the server where Elasticsearch is running. For example,
-`-url http://192.168.33.60:9200`.
-
-*`-u | -user <username>:<password>`*::
-The username and password for authenticating to Elasticsearch using Basic
-Authentication. Specify the username and password separated by a colon
-(for example, `-user admin:secret`). By default no username and password are
-used.
-
-*`-i | -index <index_pattern>`*::
-The Kibana index pattern where you want to save the Beats dashboards,
-visualizations, and index patterns. You can use this option to upload the Beats
-dashboards into multiple Kibana installations. For example: 
+* The Kibana index pattern where you want to load the dashboards in Elasticsearch. For example:
 +
 ["source","sh",subs="attributes,callouts"]
 ----------------------------------------------------------------------
-./load.sh -url http://localhost:9200 -index .kibana_env1
-./load.sh -url http://localhost:9200 -index .kibana_env2
-./load.sh -url http://localhost:9200 -index .kibana_env3
+./load.sh -url http://test.com:9200 -index .kibana_env
 ----------------------------------------------------------------------
+
+* The username and password to use for authentication. There are a few ways to pass in the username and password. For example:
++
+["source","sh",subs="attributes,callouts"]
+----------------------------------------------------------------------
+./load.sh -url https://xyz.found.io -u user:password <1>
+
+./load.sh -url https://xyz.found.io -u admin:$(cat ~/pass-file) <2> 
+
+./load.sh -url https://user:password@xyz.found.io <3>
+----------------------------------------------------------------------
++
+<1> Specify the username and password separated by a colon.
+<2> Use a file to avoid polluting the bash history with the password.
+<3> Put the username and password in the URL.
+
+These options are also available when you run `.\load.ps` on Windows.
 
 [[view-kibana-dashboards]]
 ==== Opening the Beats Dashboards in Kibana

--- a/libbeat/docs/shared-logstash-config.asciidoc
+++ b/libbeat/docs/shared-logstash-config.asciidoc
@@ -22,9 +22,8 @@ output:
   logstash:
     hosts: ["127.0.0.1:5044"]
 
-    # configure logstash plugin to loadbalance events between
-    # configured logstash hosts
-    #loadbalance: false
+    # Optional load balance the events between the Logstash hosts
+    #loadbalance: true
 ------------------------------------------------------------------------------
 
 In this configuration, `hosts` specifies the Logstash server and the port (`5044`)

--- a/packetbeat/docs/command-line.asciidoc
+++ b/packetbeat/docs/command-line.asciidoc
@@ -1,6 +1,7 @@
 == Command Line Options
 
-The following command line options are available for Packetbeat.
+The following command line options are available for Packetbeat. To use these options,
+you need to start Packetbeat in the foreground.
 
 [source,shell]
 ------------------------------------------------------------------------

--- a/packetbeat/docs/gettingstarted.asciidoc
+++ b/packetbeat/docs/gettingstarted.asciidoc
@@ -88,7 +88,7 @@ more information about these options, see <<packetbeat-configuration>>.
 [[configuring-packetbeat]]
 === Configuring Packetbeat
 
-Before starting Packetbeat, you need to edit the configuration file. For rpm and deb, you'll
+To configure Packetbeat, you edit the configuration file. For rpm and deb, you'll
 find the configuration file at `/etc/packetbeat/packetbeat.yml`. For mac and win, look in
 the archive that you just extracted.
 
@@ -102,9 +102,9 @@ server on which Packetbeat is installed. For this, use `any` as the device:
 +
 [source,yaml]
 ----------------------------------------------------------------------
+# Select the network interfaces to sniff the data. You can use the "any"
+# keyword to sniff on all connected interfaces.
 interfaces:
-  # Select on which network interfaces to sniff. You can use the "any"
-  # keyword to sniff on all connected interfaces.
   device: any
 ----------------------------------------------------------------------
 
@@ -140,9 +140,12 @@ default values should do just fine.
 [source,yaml]
 ----------------------------------------------------------------------
 protocols:
-  # Configure which protocols to monitor and on which ports are they
-  # running. You can disable a given protocol by commenting out its
-  # configuration.
+  dns:
+    ports: [53]
+    
+    include_authorities: true
+    include_additionals: true
+    
   http:
     ports: [80, 8080, 8081, 5000, 8002]
 
@@ -151,15 +154,18 @@ protocols:
 
   mysql:
     ports: [3306]
+    
+  pgsql:
+    ports: [5432]
 
   redis:
     ports: [6379]
 
-  pgsql:
-    ports: [5432]
-
   thrift:
     ports: [9090]
+    
+  mongodb:
+    ports: [27017]
 ----------------------------------------------------------------------
 +
 . Set the IP address and port where Packetbeat can find the Elasticsearch
@@ -167,23 +173,18 @@ installation:
 +
 [source,yaml]
 ----------------------------------------------------------------------
+# Configure what outputs to use when sending the data collected by the beat.
+# Multiple outputs may be used.
 output:
-
+  ### Elasticsearch as output
   elasticsearch:
-    # Uncomment out this option if you want to output to Elasticsearch. The
-    # default is false.
-    enabled: true
-
-    # Set the host and port where to find Elasticsearch.
-    host: 192.168.1.42
-    port: 9200
-
-    # Uncomment this option and set it to true if you want to store the topology in
-    # Elasticsearch. Default behavior if this setting is left out of the
-    # config file is equivalent to setting "save_topology" to "false"
-    #save_topology: false
+    # Array of hosts to connect to.
+     hosts: ["192.168.1.42:9200"]
 ----------------------------------------------------------------------
++
+If you are sending output to Logstash, see <<config-filebeat-logstash>> instead.
 
+[[config-filebeat-logstash]]
 === Configuring Packetbeat to Use Logstash
 
 include::../../libbeat/docs/shared-logstash-config.asciidoc[]

--- a/topbeat/docs/command-line.asciidoc
+++ b/topbeat/docs/command-line.asciidoc
@@ -2,6 +2,7 @@
 == Command Line Options
 
 The following command line options from libbeat are also available for Topbeat.
+To use these options, you need to start Topbeat in the foreground.
 
 [source,shell]
 ---------------------------------------------------------

--- a/topbeat/docs/gettingstarted.asciidoc
+++ b/topbeat/docs/gettingstarted.asciidoc
@@ -82,8 +82,12 @@ for example `C:\Program Files\Topbeat\topbeat.yml`. For more information about t
 [[topbeat-configuration]]
 === Configuring Topbeat
 
-To configure Topbeat, you edit the _topbeat.yml_ file. Here is a sample of
-the _topbeat.yml_ file:
+To configure Topbeat, you edit the configuration file. For rpm and deb, you'll
+find the configuration file at `/etc/topbeat/topbeat.yml`. For mac and win, look in
+the archive that you just extracted.
+
+Here is a sample of the `topbeat.yml` file. Topbeat uses predefined
+default values for most configuration options. 
 
 [source, shell]
 -------------------------------------
@@ -92,13 +96,18 @@ input:
   procs: [".*"]
 -------------------------------------
 
-The `period` option defines how often to read system-wide and per-process statistics from your servers. The interval is in seconds.
+To configure Topbeat:
+
+. Set the following options to specify how often Topbeat reads
+statistics and control which processes it monitors:
++
+* The `period` option defines how often to read system-wide and per-process statistics from your servers. The interval is in seconds.
 By default, it's set to 10 seconds.
 
-The `procs` option defines a list of regular expressions to match all the processes that need to be monitored. By default, all the running processes are monitored.
-
-If you are not interested in monitoring your processes, you can use:
-
+* The `procs` option defines a list of regular expressions to match all the processes that need to be monitored. By default, all the running processes are monitored.
++
+If you are not interested in monitoring processes, you can use:
++
 [source, shell]
 -------------------------------------
 input:
@@ -106,6 +115,22 @@ input:
   procs: ["^$"]
 -------------------------------------
 
+. If you are sending output to Elasticsearch, set the IP address and port where Topbeat can find the Elasticsearch installation:
++
+[source,yaml]
+----------------------------------------------------------------------
+# Configure what outputs to use when sending the data collected by the beat.
+# Multiple outputs may be used.
+output:
+  ### Elasticsearch as output
+  elasticsearch:
+    # Array of hosts to connect to.
+     hosts: ["192.168.1.42:9200"]
+----------------------------------------------------------------------
++
+If you are sending output to Logstash, see <<config-filebeat-logstash>> instead.
+
+[[config-filebeat-logstash]]
 === Configuring Topbeat to Use Logstash
 
 include::../../libbeat/docs/shared-logstash-config.asciidoc[]

--- a/topbeat/docs/gettingstarted.asciidoc
+++ b/topbeat/docs/gettingstarted.asciidoc
@@ -98,8 +98,7 @@ input:
 
 To configure Topbeat:
 
-. Set the following options to specify how often Topbeat reads
-statistics and control which processes it monitors:
+. Set the following options to specify how often Topbeat reads statistics and specify which processes it monitors:
 +
 * The `period` option defines how often to read system-wide and per-process statistics from your servers. The interval is in seconds.
 By default, it's set to 10 seconds.

--- a/winlogbeat/docs/getting-started.asciidoc
+++ b/winlogbeat/docs/getting-started.asciidoc
@@ -47,8 +47,8 @@ For more information about these options, see <<winlogbeat-configuration-details
 [[winlogbeat-configuration]]
 === Configuring Winlogbeat
 
-To configure Winlogbeat, you edit the _winlogbeat.yml_ file. Here is a sample of
-the _winlogbeat.yml_ file:
+To configure Winlogbeat, you edit the `winlogbeat.yml` configuration file. Here is a sample of
+the `winlogbeat.yml` file:
 
 [source,yaml]
 --------------------------------------------------------------------------------
@@ -72,17 +72,44 @@ logging:
   level: info
 --------------------------------------------------------------------------------
 
+To configure Winlogbeat:
+
+. In the `event_logs` section, specify the event logs that you want to monitor. By
+default, Winlogbeat is set to monitor application, security, and system logs: 
++
+[source,yaml]
+----------------------------------------------------------------------
+  event_logs:
+    - name: Application
+    - name: Security
+    - name: System
+----------------------------------------------------------------------
++
 To obtain a list of available event logs, run `Get-EventLog *` in PowerShell. For more
 information about this command, see the configuration details for 
 <<configuration-winlogbeat-options-event_logs-name,event_logs.name>>.
 
-After you save your configuration file, test it with the following command.
+. If you are sending output to Elasticsearch, set the IP address and port where
+Winlogbeat can find the Elasticsearch installation:
++
+[source,yaml]
+----------------------------------------------------------------------
+output:
+  elasticsearch:
+    hosts:
+      - localhost:9200
+----------------------------------------------------------------------
++
+If you are sending output to Logstash, see <<config-filebeat-logstash>> instead.
 
+. After you save your configuration file, test it with the following command.
++
 [source,shell]
 ----------------------------------------------------------------------
 PS C:\Program Files\Winlogbeat> .\winlogbeat.exe -c .\winlogbeat.yml -configtest -e
 ----------------------------------------------------------------------
 
+[[config-filebeat-logstash]]
 === Configuring Winlogbeat to Use Logstash
 
 include::../../libbeat/docs/shared-logstash-config.asciidoc[]


### PR DESCRIPTION
- Changes to fix issues identified in #891  and #893 
- Updated example configuration (as much as practical) to match the config files in 1.1. Note that I added the dns section to Packetbeat because it was in the default config.
- Broke configuration section down into steps so that I could add info about configuring Elasticsearch without making the section too hard to read. The steps break up the information into logical chunks. 
- Added mention that command line options are only available if you start the beat in the foreground. This was  quick fix.

@urso Many of these changes relate to the issues that you raised, so you should probably review. 
@monicasarbu Check out the changes that I made to the section about the load command options in the Beats Platform Reference. I could see that you wanted me to simplify that section.