### PR TITLE
Simplify Test Environment

### DIFF
--- a/filebeat/tests/system/filebeat.py
+++ b/filebeat/tests/system/filebeat.py
@@ -12,8 +12,7 @@ class BaseTest(TestCase):
     @classmethod
     def setUpClass(self):
         self.beat_name = "filebeat"
-        self.build_path = "../../build/system-tests/"
-        self.beat_path = "../../filebeat.test"
+        super(BaseTest, self).setUpClass()
 
     def get_dot_filebeat(self):
         # Returns content of the .filebeat file

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -31,7 +31,7 @@ GOFILES = $(shell find . -type f -name '*.go')
 GOFILES_NOVENDOR = $(shell find . -type f -name '*.go' -not -path "./vendor/*")
 SHELL=bash
 ES_HOST?="elasticsearch"
-BUILD_DIR?=build
+BUILD_DIR?=$(shell pwd)/build
 COVERAGE_DIR=${BUILD_DIR}/coverage
 PROCESSES?= 4
 TIMEOUT?= 90
@@ -40,7 +40,7 @@ SYSTEM_TESTS?=false
 GOX_OS?=linux darwin windows solaris freebsd netbsd openbsd
 DOCKER_COMPOSE?=docker-compose -f docker-compose.yml
 GOPACKAGES_COMMA_SEP=$(subst $(space),$(comma),$(strip ${GOPACKAGES}))
-PYTHON_ENV?=${BUILD_DIR}/python-env/
+PYTHON_ENV?=${BUILD_DIR}/python-env
 
 # Conditionally enable the race detector when RACE_DETECTOR=1.
 ifeq ($(RACE_DETECTOR),1)
@@ -187,11 +187,11 @@ testsuite:
 # Generates a coverage report from the existing coverage files
 .PHONY: coverage-report
 coverage-report:
-	python ${ES_BEATS}/dev-tools/aggregate_coverage.py -o ./${COVERAGE_DIR}/full.cov ./${COVERAGE_DIR}
-	go tool cover -html=./${COVERAGE_DIR}/full.cov -o ${COVERAGE_DIR}/full.html
-	test ! -s ./${COVERAGE_DIR}/integration.cov   || go tool cover -html=./${COVERAGE_DIR}/integration.cov   -o ${COVERAGE_DIR}/integration.html
-	test ! -s ./${COVERAGE_DIR}/system.cov || go tool cover -html=./${COVERAGE_DIR}/system.cov -o ${COVERAGE_DIR}/system.html
-	test ! -s ./${COVERAGE_DIR}/unit.cov   || go tool cover -html=./${COVERAGE_DIR}/unit.cov   -o ${COVERAGE_DIR}/unit.html
+	python ${ES_BEATS}/dev-tools/aggregate_coverage.py -o ${COVERAGE_DIR}/full.cov ${COVERAGE_DIR}
+	go tool cover -html=${COVERAGE_DIR}/full.cov -o ${COVERAGE_DIR}/full.html
+	test ! -s ${COVERAGE_DIR}/integration.cov   || go tool cover -html=${COVERAGE_DIR}/integration.cov   -o ${COVERAGE_DIR}/integration.html
+	test ! -s ${COVERAGE_DIR}/system.cov || go tool cover -html=${COVERAGE_DIR}/system.cov -o ${COVERAGE_DIR}/system.html
+	test ! -s ${COVERAGE_DIR}/unit.cov   || go tool cover -html=${COVERAGE_DIR}/unit.cov   -o ${COVERAGE_DIR}/unit.html
 
 # Update expects the most recent version of libbeat in the GOPATH
 .PHONY: update

--- a/libbeat/tests/system/beat/beat.py
+++ b/libbeat/tests/system/beat/beat.py
@@ -92,9 +92,21 @@ class TestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(self):
-        self.beat_name = "beat"
-        self.build_path = "../../build/system-tests/"
-        self.beat_path = "../../" + self.beat_name + ".test"
+
+        # Create build path
+        build_dir = "../../build"
+        if 'BUILD_DIR' in os.environ.keys() and os.environ['BUILD_DIR'] != '':
+            build_dir = os.environ['BUILD_DIR']
+        self.build_path = build_dir + "/system-tests/"
+
+        # Path to test binary
+        if not hasattr(self, 'beat_name'):
+            self.beat_name = "beat"
+
+        # Path to test binary
+        if not hasattr(self, 'beat_path'):
+            self.beat_path = "../../" + self.beat_name + ".test"
+
 
     def run_beat(self, cmd=None,
                  config=None,

--- a/packetbeat/Dockerfile
+++ b/packetbeat/Dockerfile
@@ -20,8 +20,8 @@ ENV PYTHON_ENV=/tmp/python-env
 
 
 RUN test -d ${PYTHON_ENV} || virtualenv ${PYTHON_ENV}
-COPY ./tests/system/requirements.txt /tmp/requirements.txt
-RUN . ${PYTHON_ENV}/bin/activate && pip install -Ur /tmp/requirements.txt
+RUN . ${PYTHON_ENV}/bin/activate && pip install nose jinja2 PyYAML nose-timer
 
-# Libbeat specific
-RUN mkdir -p /etc/pki/tls/certs
+# Packetbeat specifics
+RUN apt-get install -y libpcap-dev geoip-database && apt-get clean
+

--- a/packetbeat/docker-compose.yml
+++ b/packetbeat/docker-compose.yml
@@ -1,0 +1,10 @@
+beat:
+  build: .
+  environment:
+    - LIBBEAT_PATH=/go/src/github.com/elastic/beats/libbeat
+    # Puts build dir outside of shared file system to prevent issues
+    # This means artifacts are not shared locally
+    - BUILD_DIR=/tmp/build
+  volumes:
+    - ..:/go/src/github.com/elastic/beats/
+  working_dir: /go/src/github.com/elastic/beats/packetbeat

--- a/packetbeat/tests/system/packetbeat.py
+++ b/packetbeat/tests/system/packetbeat.py
@@ -15,8 +15,8 @@ class BaseTest(TestCase):
     @classmethod
     def setUpClass(self):
         self.beat_name = "packetbeat"
-        self.build_path = "../../build/system-tests/"
-        self.beat_path = "../../packetbeat.test"
+        super(BaseTest, self).setUpClass()
+
 
     def run_packetbeat(self, pcap,
                        cmd="../../packetbeat.test",

--- a/topbeat/tests/system/topbeat.py
+++ b/topbeat/tests/system/topbeat.py
@@ -8,5 +8,4 @@ class BaseTest(TestCase):
     @classmethod
     def setUpClass(self):
         self.beat_name = "topbeat"
-        self.build_path = "../../build/system-tests/"
-        self.beat_path = "../../topbeat.test"
+        super(BaseTest, self).setUpClass()

--- a/winlogbeat/tests/system/winlogbeat.py
+++ b/winlogbeat/tests/system/winlogbeat.py
@@ -10,5 +10,4 @@ class BaseTest(TestCase):
     @classmethod
     def setUpClass(self):
         self.beat_name = "winlogbeat"
-        self.build_path = "../../build/system-tests/"
-        self.beat_path = "../../winlogbeat.test"
+        super(BaseTest, self).setUpClass()


### PR DESCRIPTION
* Make BUILD_DIR configurable. This can be useful to move the build artifacts to a different path
* Create system-test base variables based on environment vars. This simplifies setup in each beat
* Introduce basic Dockerfile and docker-compose in Packetbeat to run tests in virtual environment. This could be later added to all beats.