### PR TITLE
system_tests: use requirements.txt from both libbeat and beater 

### DIFF
--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -150,8 +150,11 @@ fast-system-tests: buildbeat.test python-env
 .PHONY: python-env
 python-env: ${ES_BEATS}/libbeat/tests/system/requirements.txt
 	test -d ${PYTHON_ENV} || virtualenv ${PYTHON_ENV}
-	. ${PYTHON_ENV}/bin/activate && pip install -Ur ${ES_BEATS}/libbeat/tests/system/requirements.txt
-
+	if [ -a ./tests/system/requirements.txt ] && [ ! ${ES_BEATS}/libbeat/tests/system/requirements.txt -ef ./tests/system/requirements.txt ] ; then \
+		. ${PYTHON_ENV}/bin/activate && pip install -Ur ${ES_BEATS}/libbeat/tests/system/requirements.txt -Ur ./tests/system/requirements.txt ; \
+	else \
+		. ${PYTHON_ENV}/bin/activate && pip install -Ur ${ES_BEATS}/libbeat/tests/system/requirements.txt ; \
+	fi
 
 # Run benchmark tests
 .PHONY: benchmark-tests

--- a/libbeat/tests/system/requirements.txt
+++ b/libbeat/tests/system/requirements.txt
@@ -2,3 +2,5 @@ nose
 jinja2
 PyYAML
 nose-timer
+pip
+


### PR DESCRIPTION
Community beats can add `./tests/system/requirements.txt` to install additional Python libraries, in addition to `libbeat/tests/system/requirements.txt`

