### PR TITLE
Document regexp support in Beats

### DIFF
--- a/filebeat/docs/index.asciidoc
+++ b/filebeat/docs/index.asciidoc
@@ -10,6 +10,8 @@ include::./getting-started.asciidoc[]
 
 include::./configuration.asciidoc[]
 
+include::../../libbeat/docs/regexp.asciidoc[]
+
 include::./command-line.asciidoc[]
 
 include::./fields.asciidoc[]

--- a/libbeat/docs/regexp.asciidoc
+++ b/libbeat/docs/regexp.asciidoc
@@ -1,0 +1,129 @@
+//////////////////////////////////////////////////////////////////////////
+//// This content is shared by all Elastic Beats. Make sure you keep the
+//// descriptions here generic enough to work for all Beats that include
+//// this file. When using cross references, make sure that the cross
+//// references resolve correctly for any files that include this one.
+//// Use the appropriate variables defined in the index.asciidoc file to
+//// resolve Beat names: beatname_uc and beatname_lc.
+//// Use the following include to pull this content into a doc file:
+//// include::../../libbeat/docs/regexp.asciidoc[]
+//////////////////////////////////////////////////////////////////////////
+
+[[regexp-support]]
+== Regular Expression Support
+
+{beatname_uc} supports a subset of the regular expression syntax accepted by https://golang.org/s/re2syntax[RE2]. Because we use the POSIX implementation, some patterns are currently <<unsupported-regexp-patterns, not supported>>. 
+
+NOTE: We recommend that you wrap regular expressions in single quotation marks to work around YAML's string escaping rules. For example, `'^\[?[0-9][0-9]:?[0-9][0-9]|^[[:graph:]]+'`.
+
+=== Supported Patterns
+The following patterns are supported:
+
+* <<single-characters, Single Characters>>
+* <<composites, Composites>>
+* <<repetitions, Repetitions>>
+* <<grouping, Groupings>>
+* <<empty-strings, Empty Strings>>
+* <<escape-sequences, Escape Sequences>>
+* <<ascii-character-classes, ASCII Character Classes>>
+
+[options="header"]
+|=======================
+|Pattern          |Description
+|[[single-characters]]*Single Characters* 1+|  
+|`x`              |single character
+|`.`              |any character
+|`[xyz]`          |character class
+|`[^xyz]`         |negated character class
+|`[[:alpha:]]`    |ASCII character class
+|`[[:^alpha:]]`   |negated ASCII character class
+|[[composites]]*Composites* 1+|
+|`xy`             |`x` followed by `y`
+|`x\|y`           |`x` or `y` (prefer `x`)
+|[[repetitions]]*Repetitions* 1+| 
+|`x*`             |zero or more `x`
+|`x+`             |one or more `x`
+|`x?`             |zero or one `x`
+|`x{n,m}`         |`n` or `n+1` or ... or `m` `x`, prefer more
+|`x{n,}`          |`n` or more `x`, prefer more
+|`x{n}`           |exactly `n` `x`
+|`x*?`            |zero or more `x`, prefer fewer
+|`x+?`            |one or more `x`, prefer fewer
+|`x??`            |zero or one `x`, prefer zero
+|`x{n,m}?`        |`n` or `n+1` or ... or `m` `x`, prefer fewer
+|`x{n,}?`         |`n` or more `x`, prefer fewer
+|`x{n}?`          |exactly `n` `x`
+|[[grouping]]*Grouping* 1+|
+|`(re)`           |numbered capturing group (submatch)
+|[[empty-strings]]*Empty Strings* 1+|
+|`^`              |at beginning of text or line (`m`=true)
+|`$`              |at end of text (like `\z` not `\Z`) or line (`m`=true)
+|[[escape-sequences]]*Escape Sequences* 1+|
+|`\a`             |bell (≡ `\007`)
+|`\f`             |form feed (≡ `\014`)
+|`\t`             |horizontal tab (≡ `\011`)
+|`\n`             |newline (≡ `\012`)
+|`\r`             |carriage return (≡ `\015`)
+|`\v`             |vertical tab character (≡ `\013`)
+|`\*`             |literal `*`, for any punctuation character `*`
+|`\123`           |octal character code (up to three digits)
+|`\x7F`           |hex character code (exactly two digits)
+|`\x{10FFFF}`     |hex character code
+|[[ascii-character-classes]]*ASCII Character Classes* 1+|
+|`[[:alnum:]]`    |alphanumeric (≡ `[0-9A-Za-z]`)
+|`[[:alpha:]]`    |alphabetic (≡ `[A-Za-z]`)
+|`[[:ascii:]]`    |ASCII (≡ `\x00-\x7F]`)
+|`[[:blank:]]`    |blank (≡ `[\t ]`)
+|`[[:cntrl:]]`    |control (≡ `[\x00-\x1F\x7F]`)
+|`[[:digit:]]`    |digits (≡ `[0-9]`)
+|`[[:graph:]]`    |graphical (≡ `[!-~] == [A-Za-z0-9!"#$%&'()*+,\-./:;<=>?@[\\\\]^_`` `{\|}~]`)
+|`[[:lower:]]`    |lower case (≡ `[a-z]`)
+|`[[:print:]]`    |printable (≡ `[ -~] == [ [:graph:]]`)
+|`[[:punct:]]`    |punctuation (≡ ++[!-/:-@[-`{-~]++)
+|`[[:space:]]`    |whitespace (≡ `[\t\n\v\f\r ]`)
+|`[[:upper:]]`    |upper case (≡ `[A-Z]`)
+|`[[:word:]]`     |word characters (≡ `[0-9A-Za-z_]`)
+|`[[:xdigit:]]`   |hex digit (≡ `[0-9A-Fa-f]`)
+|=======================
+
+[[unsupported-regexp-patterns]]
+=== Unsupported Patterns
+The following patterns are not supported.
+
+[options="header"]
+|=======================
+|Pattern           |Description
+|*Unsupported Single Characters* 1+|  
+|`\d`              |Perl character class
+|`\D`              |negated Perl character class
+|`\pN`             |Unicode character class (one-letter name)
+|`\p{Greek}`       |Unicode character class
+|`\PN`             |negated Unicode character class (one-letter name)
+|`\P{Greek}`       |negated Unicode character class
+|*Unsupported Grouping*      1+|
+|`(?P<name>re)`    |named & numbered capturing group (submatch)
+|`(?:re)`          |non-capturing group
+|`(?i)abc`        |set flags within current group; non-capturing
+|`(?i:re)`         |set flags during re; non-capturing
+|`(?i)PaTTeRN`     |case-insensitive (default false)
+|`(?m)multiline`   |multi-line mode: `^` and `$` match begin/end line in addition to begin/end text (default false)
+|`(?s)pattern.`    |let `.` match `\n` (default false)
+|`(?U)x*abc`      |ungreedy: swap meaning of `x*` and `x*?`, `x+` and `x+?`, etc (default false)
+|*Unsupported Empty Strings* 1+|
+|`\A`              |at beginning of text
+|`\b`              |at ASCII word boundary (`\w` on one side and `\W`, `\A`, or `\z` on the other)
+|`\B`              |not at ASCII word boundary
+|`\z`              |at end of text
+|*Unsupported Escape Sequences* 1+|
+|`\C`              |match a single byte even in UTF-8 mode
+|`\Q...\E`         |literal text `...` even if `...` has punctuation
+|*Unsupported Perl Character Classes*  1+|
+|`\d`              |digits (≡ `[0-9]`)
+|`\D`              |not digits (≡ `[^0-9]`)
+|`\s`              |whitespace (≡ `[\t\n\f\r ]`)
+|`\S`              |not whitespace (≡ `[^\t\n\f\r ]`)
+|`\w`              |word characters (≡ `[0-9A-Za-z_]`)
+|`\W`              |not word characters (≡ `[^0-9A-Za-z_]`)
+|=======================
+
+

--- a/libbeat/docs/regexp.asciidoc
+++ b/libbeat/docs/regexp.asciidoc
@@ -59,31 +59,31 @@ The following patterns are supported:
 |`^`              |at beginning of text or line (`m`=true)
 |`$`              |at end of text (like `\z` not `\Z`) or line (`m`=true)
 |[[escape-sequences]]*Escape Sequences* 1+|
-|`\a`             |bell (≡ `\007`)
-|`\f`             |form feed (≡ `\014`)
-|`\t`             |horizontal tab (≡ `\011`)
-|`\n`             |newline (≡ `\012`)
-|`\r`             |carriage return (≡ `\015`)
-|`\v`             |vertical tab character (≡ `\013`)
+|`\a`             |bell (same as `\007`)
+|`\f`             |form feed (same as `\014`)
+|`\t`             |horizontal tab (same as `\011`)
+|`\n`             |newline (same as `\012`)
+|`\r`             |carriage return (same as `\015`)
+|`\v`             |vertical tab character (same as `\013`)
 |`\*`             |literal `*`, for any punctuation character `*`
 |`\123`           |octal character code (up to three digits)
-|`\x7F`           |hex character code (exactly two digits)
+|`\x7F`           |two-digit hex character code
 |`\x{10FFFF}`     |hex character code
 |[[ascii-character-classes]]*ASCII Character Classes* 1+|
-|`[[:alnum:]]`    |alphanumeric (≡ `[0-9A-Za-z]`)
-|`[[:alpha:]]`    |alphabetic (≡ `[A-Za-z]`)
-|`[[:ascii:]]`    |ASCII (≡ `\x00-\x7F]`)
-|`[[:blank:]]`    |blank (≡ `[\t ]`)
-|`[[:cntrl:]]`    |control (≡ `[\x00-\x1F\x7F]`)
-|`[[:digit:]]`    |digits (≡ `[0-9]`)
-|`[[:graph:]]`    |graphical (≡ `[!-~] == [A-Za-z0-9!"#$%&'()*+,\-./:;<=>?@[\\\\]^_`` `{\|}~]`)
-|`[[:lower:]]`    |lower case (≡ `[a-z]`)
-|`[[:print:]]`    |printable (≡ `[ -~] == [ [:graph:]]`)
-|`[[:punct:]]`    |punctuation (≡ ++[!-/:-@[-`{-~]++)
-|`[[:space:]]`    |whitespace (≡ `[\t\n\v\f\r ]`)
-|`[[:upper:]]`    |upper case (≡ `[A-Z]`)
-|`[[:word:]]`     |word characters (≡ `[0-9A-Za-z_]`)
-|`[[:xdigit:]]`   |hex digit (≡ `[0-9A-Fa-f]`)
+|`[[:alnum:]]`    |alphanumeric (same as `[0-9A-Za-z]`)
+|`[[:alpha:]]`    |alphabetic (same as `[A-Za-z]`)
+|`[[:ascii:]]`    |ASCII (same as `\x00-\x7F]`)
+|`[[:blank:]]`    |blank (same as `[\t ]`)
+|`[[:cntrl:]]`    |control (same as `[\x00-\x1F\x7F]`)
+|`[[:digit:]]`    |digits (same as `[0-9]`)
+|`[[:graph:]]`    |graphical (same as `[!-~] == [A-Za-z0-9!"#$%&'()*+,\-./:;<=>?@[\\\\]^_`` `{\|}~]`)
+|`[[:lower:]]`    |lower case (same as `[a-z]`)
+|`[[:print:]]`    |printable (same as `[ -~] == [ [:graph:]]`)
+|`[[:punct:]]`    |punctuation (same as ++[!-/:-@[-`{-~]++)
+|`[[:space:]]`    |whitespace (same as `[\t\n\v\f\r ]`)
+|`[[:upper:]]`    |upper case (same as `[A-Z]`)
+|`[[:word:]]`     |word characters (same as `[0-9A-Za-z_]`)
+|`[[:xdigit:]]`   |hex digit (same as `[0-9A-Fa-f]`)
 |=======================
 
 [[unsupported-regexp-patterns]]
@@ -103,8 +103,8 @@ The following patterns are not supported.
 |*Unsupported Grouping*      1+|
 |`(?P<name>re)`    |named & numbered capturing group (submatch)
 |`(?:re)`          |non-capturing group
-|`(?i)abc`        |set flags within current group; non-capturing
-|`(?i:re)`         |set flags during re; non-capturing
+|`(?i)abc`         |set flags within current group, non-capturing
+|`(?i:re)`         |set flags during re, non-capturing
 |`(?i)PaTTeRN`     |case-insensitive (default false)
 |`(?m)multiline`   |multi-line mode: `^` and `$` match begin/end line in addition to begin/end text (default false)
 |`(?s)pattern.`    |let `.` match `\n` (default false)
@@ -118,12 +118,12 @@ The following patterns are not supported.
 |`\C`              |match a single byte even in UTF-8 mode
 |`\Q...\E`         |literal text `...` even if `...` has punctuation
 |*Unsupported Perl Character Classes*  1+|
-|`\d`              |digits (≡ `[0-9]`)
-|`\D`              |not digits (≡ `[^0-9]`)
-|`\s`              |whitespace (≡ `[\t\n\f\r ]`)
-|`\S`              |not whitespace (≡ `[^\t\n\f\r ]`)
-|`\w`              |word characters (≡ `[0-9A-Za-z_]`)
-|`\W`              |not word characters (≡ `[^0-9A-Za-z_]`)
+|`\d`              |digits (same as `[0-9]`)
+|`\D`              |not digits (same as `[^0-9]`)
+|`\s`              |whitespace (same as `[\t\n\f\r ]`)
+|`\S`              |not whitespace (same as `[^\t\n\f\r ]`)
+|`\w`              |word characters (same as `[0-9A-Za-z_]`)
+|`\W`              |not word characters (same as `[^0-9A-Za-z_]`)
 |=======================
 
 

--- a/libbeat/docs/regexp.asciidoc
+++ b/libbeat/docs/regexp.asciidoc
@@ -12,7 +12,7 @@
 [[regexp-support]]
 == Regular Expression Support
 
-{beatname_uc} supports a subset of the regular expression syntax accepted by https://golang.org/s/re2syntax[RE2]. Because we use the POSIX implementation, some patterns are currently <<unsupported-regexp-patterns, not supported>>. 
+{beatname_uc} supports a subset of the https://godoc.org/regexp/syntax[regular expression syntax] accepted by RE2. Because we use the POSIX implementation, some patterns are currently <<unsupported-regexp-patterns, not supported>>. 
 
 NOTE: We recommend that you wrap regular expressions in single quotation marks to work around YAML's string escaping rules. For example, `'^\[?[0-9][0-9]:?[0-9][0-9]|^[[:graph:]]+'`.
 

--- a/topbeat/docs/index.asciidoc
+++ b/topbeat/docs/index.asciidoc
@@ -10,6 +10,8 @@ include::./gettingstarted.asciidoc[]
 
 include::./configuration.asciidoc[]
 
+include::../../libbeat/docs/regexp.asciidoc[]
+
 include::./command-line.asciidoc[]
 
 include::./fields.asciidoc[]


### PR DESCRIPTION
Note that special characters are not showing up correctly in the preview in GitHub, so you'll need to go to the following location to review the content: https://doctesting.firebaseapp.com/regexp-support.html. Let me know if you have any trouble accessing this page.

This doc simply explains which patterns we do and do not support. I realize that we need to provide specific examples, especially of common patterns. Mainly I wanted to get the limitations documented right away because users are getting confused. I'm planning to add more examples to the doc (for example, to the doc for multiline and include/exclude_lines). I hope that we can get around having to document how to write regular expressions. However, it's possible that I might update this topic later with some examples and more guidance.

I'm including this content only for the Beats that have configuration options that accept regexp patterns. Let me know if I've overlooked any Beats that need this content, though, because I just did a quick search.

@urso This is based on the table that you created in #740 plus some minor tweaks to make the descriptions a bit more consistent with what is documented for RE2. Please review.