### PR TITLE
Make structural changes to the Filebeat doc

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -7,10 +7,10 @@
 ////////////////////////////////////////////////////////////
 // Template, add newest changes here
 
-=== Beats version HEAD
+== Beats version HEAD
 https://github.com/elastic/beats/compare/v1.1.0...master[Check the HEAD diff]
 
-==== Breaking changes
+=== Breaking changes
 
 *Affecting all Beats*
 
@@ -23,7 +23,7 @@ https://github.com/elastic/beats/compare/v1.1.0...master[Check the HEAD diff]
 *Winlogbeat*
 
 
-==== Bugfixes
+=== Bugfixes
 
 *Affecting all Beats*
 
@@ -36,7 +36,7 @@ https://github.com/elastic/beats/compare/v1.1.0...master[Check the HEAD diff]
 *Winlogbeat*
 
 
-==== Added
+=== Added
 
 *Affecting all Beats*
 
@@ -48,7 +48,7 @@ https://github.com/elastic/beats/compare/v1.1.0...master[Check the HEAD diff]
 
 *Winlogbeat*
 
-==== Deprecated
+=== Deprecated
 
 *Affecting all Beats*
 
@@ -62,11 +62,27 @@ https://github.com/elastic/beats/compare/v1.1.0...master[Check the HEAD diff]
 
 ////////////////////////////////////////////////////////////
 
+[[release-notes]]
+= Release notes
+
+[partintro]
+--
+This section summarizes the changes in each release.
+
+* <<release-notes-1.1.0>>
+* <<release-notes-1.0.1>>
+* <<release-notes-1.0.0>>
+* <<release-notes-1.0.0-rc2>>
+* <<release-notes-1.0.0-rc1>>
+* <<release-notes-1.0.0-beta4>>
+
+--
+
 [[release-notes-1.1.0]]
-=== Beats version 1.1.0
+== Beats version 1.1.0
 https://github.com/elastic/beats/compare/v1.0.1...v1.1.0[View commits]
 
-==== Bugfixes
+=== Bugfixes
 
 *Affecting all Beats*
 
@@ -86,7 +102,7 @@ https://github.com/elastic/beats/compare/v1.0.1...v1.1.0[View commits]
 
 - Set spool_size default value to 2048 {pull}628[628]
 
-==== Added
+=== Added
 
 *Affecting all Beats*
 
@@ -114,10 +130,10 @@ https://github.com/elastic/beats/compare/v1.0.1...v1.1.0[View commits]
 - First public release of Winlogbeat
 
 [[release-notes-1.0.1]]
-=== Beats version 1.0.1
+== Beats version 1.0.1
 https://github.com/elastic/beats/compare/v1.0.0...v1.0.1[Check 1.0.1 diff]
 
-==== Bugfixes
+=== Bugfixes
 
 *Filebeat*
 
@@ -133,17 +149,17 @@ https://github.com/elastic/beats/compare/v1.0.0...v1.0.1[Check 1.0.1 diff]
 - Fix errors in redis parser when dealing with nested arrays. {issue}402[402]
 
 [[release-notes-1.0.0]]
-=== Beats version 1.0.0
+== Beats version 1.0.0
 https://github.com/elastic/beats/compare/1.0.0-rc2...1.0.0[Check 1.0.0 diff]
 
-==== Breaking changes
+=== Breaking changes
 
 *Topbeat*
 
 - Change proc type to process #138
 
 
-==== Bugfixes
+=== Bugfixes
 
 *Affecting all Beats*
 
@@ -160,11 +176,11 @@ https://github.com/elastic/beats/compare/1.0.0-rc2...1.0.0[Check 1.0.0 diff]
 
 
 [[release-notes-1.0.0-rc2]]
-=== Beats version 1.0.0-rc2
+== Beats version 1.0.0-rc2
 https://github.com/elastic/beats/compare/1.0.0-rc1...1.0.0-rc2[Check 1.0.0-rc2
 diff]
 
-==== Breaking changes
+=== Breaking changes
 
 *Affecting all Beats*
 
@@ -182,7 +198,7 @@ diff]
 - Rename force_close_windows_files to force_close_files and make it available for all platforms.
 
 
-==== Bugfixes
+=== Bugfixes
 
 *Affecting all Beats*
 
@@ -211,7 +227,7 @@ diff]
 - Set input_type by default to "log"
 
 
-==== Added
+=== Added
 
 *Affecting all Beats*
 
@@ -226,11 +242,11 @@ diff]
 
 
 [[release-notes-1.0.0-rc1]]
-=== Beats version 1.0.0-rc1
+== Beats version 1.0.0-rc1
 https://github.com/elastic/beats/compare/1.0.0-beta4...1.0.0-rc1[Check
 1.0.0-rc1 diff]
 
-==== Breaking changes
+=== Breaking changes
 
 *Affecting all Beats*
 
@@ -252,7 +268,7 @@ Logstash. #80
 - Removal of line field in event. Line number was not correct and does not add value. #217
 
 
-==== Bugfixes
+=== Bugfixes
 
 *Affecting all Beats*
 
@@ -290,7 +306,7 @@ Logstash. #80
 - Fix issue that files were not crawled anymore when encoding was set to something other then plain. #182
 
 
-==== Added
+=== Added
 
 *Affecting all Beats*
 
@@ -322,12 +338,12 @@ level in the output dictionary. #188
 
 
 [[release-notes-1.0.0-beta4]]
-=== Beats version 1.0.0-beta4
+== Beats version 1.0.0-beta4
 https://github.com/elastic/beats/compare/1.0.0-beta3...1.0.0-beta4[Check
 1.0.0-beta4 diff]
 
 
-==== Breaking changes
+=== Breaking changes
 
 *Affecting all Beats*
 
@@ -345,7 +361,7 @@ https://github.com/elastic/beats/compare/1.0.0-beta3...1.0.0-beta4[Check
 - Percentage fields (e.g user_p) are exported as a float between 0 and 1 #34
 
 
-==== Bugfixes
+=== Bugfixes
 
 *Affecting all Beats*
 
@@ -369,7 +385,7 @@ https://github.com/elastic/beats/compare/1.0.0-beta3...1.0.0-beta4[Check
 - Don't divide the reported memory by an extra 1024 #60
 
 
-==== Added
+=== Added
 
 *Affecting all Beats*
 
@@ -413,7 +429,7 @@ https://github.com/elastic/beats/compare/1.0.0-beta3...1.0.0-beta4[Check
 - Documentation improvements
 
 
-==== Deprecated
+=== Deprecated
 
 *Affecting all Beats*
 

--- a/libbeat/docs/command-line.asciidoc
+++ b/libbeat/docs/command-line.asciidoc
@@ -2,7 +2,15 @@
 == Command Line Options
 
 The following command line options are available for all Beats. To use these
-options, you need to start the Beat in the foreground. For additional command
+options, you need to start the Beat in the foreground. For example, the
+following command starts Filebeat in debugging mode:
+
+["source","sh",subs="attributes,callouts"]
+----------------------------------------------------------------------
+./filebeat -c filebeat.yml -e -d “*”
+----------------------------------------------------------------------
+
+For additional command
 line options, see the documentation for your Beat.
 
 include::./shared-command-line.asciidoc[]

--- a/libbeat/docs/communitybeats.asciidoc
+++ b/libbeat/docs/communitybeats.asciidoc
@@ -29,6 +29,7 @@ https://github.com/elastic/beats/blob/master/libbeat/docs/communitybeats.asciido
 
 NOTE: Elastic provides no warranty or support for community-sourced Beats.
 
+
 [[contributing-beats]]
 === Contributing to Beats
 

--- a/libbeat/docs/configuration.asciidoc
+++ b/libbeat/docs/configuration.asciidoc
@@ -15,8 +15,16 @@
 ///// include::../../libbeat/docs/runconfig.asciidoc[]
 ////////////////////////////////////////////////////////////////////
 
-== Installing and Configuring Beats
+[[installing-beats]]
+== Installing Beats
 
-After <<getting-started,installing and configuring>> Elasticsearch, Kibana, and, optionally, Logstash, you need to install and configure your Beat.
+After <<getting-started,installing and configuring>> the Elastic stack, you need to install and configure your Beat.
 
-For more information, see the Getting Started topic in the https://www.elastic.co/guide/index.html[Reference Guide] for your Beat.
+Each Beat is a separately installable product. To get up and running quickly with a Beat, see the Getting Started guide:
+
+* {packetbeat}/packetbeat-getting-started.html[Packetbeat]
+* {topbeat}/topbeat-getting-started.html[Topbeat]
+* {filebeat}/filebeat-getting-started.html[Filebeat]
+* {winlogbeat}/winlogbeat-getting-started.html[Winlogbeat]
+
+

--- a/libbeat/docs/gettingstarted.asciidoc
+++ b/libbeat/docs/gettingstarted.asciidoc
@@ -1,17 +1,21 @@
 [[getting-started]]
-== Getting Started with Beats and the Elastic Stack
+= Getting Started with Beats and the Elastic Stack
+
+[partintro]
+--
 
 Looking for an "ELK tutorial" that shows how to set up the Elastic stack for Beats? You've come to the right place.
+Follow the steps in this section to install and configure the Elastic stack for Beats.
 
 A regular _Beats setup_ consists of:
 
- * One or more Beats. You install Beats on your servers to capture the data.
- For installation steps, see the documentation for your Beat.
- * Elasticsearch for storage and indexing. See <<elasticsearch-installation>>.
- * Optionally Logstash for inserting data into Elasticsearch. See <<logstash-installation>>.
- * Kibana for the UI. See <<kibana-installation>>.
+ * One or more Beats. You install the Beats on your servers to capture operational data.
+ * Elasticsearch for storage and indexing.
+ * Logstash (optional) for inserting data into Elasticsearch. 
+ * Kibana for the UI. 
  * Kibana dashboards for visualizing the data. See <<load-kibana-dashboards>>.
-  
+ 
+ 
 See the https://www.elastic.co/support/matrix[Elastic Support Matrix] for information 
 about supported operating systems and product compatibility.
 
@@ -20,9 +24,10 @@ single VM or even on your laptop. The only condition is that the machine must be
 accessible from the servers you want to monitor. As you add more Beats and
 your traffic grows, you'll want to replace the single Elasticsearch instance with
 a cluster. You'll probably also want to automate the installation process.
+--
 
 [[elasticsearch-installation]]
-=== Installing Elasticsearch
+== Installing Elasticsearch
 
 https://www.elastic.co/products/elasticsearch[Elasticsearch] is a real-time,
 distributed storage, search, and analytics engine. It can be used for many
@@ -92,7 +97,7 @@ bin\elasticsearch.bat
 You can learn more about installing, configuring, and running Elasticsearch in the
 https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html[Elasticsearch Reference].
 
-==== Making Sure Elasticsearch is Up and Running
+=== Making Sure Elasticsearch is Up and Running
 
 
 To test that the Elasticsearch daemon is up and running, try sending an HTTP GET
@@ -124,16 +129,18 @@ You should see a response similar to this:
 ----------------------------------------------------------------------
 
 [[logstash-installation]]
-=== Installing Logstash (Optional)
+== Installing Logstash (Optional)
 
 The simplest architecture for the Beats platform setup consists of one or more Beats,
 Elasticsearch, and Kibana. This architecture is easy to get started
 with and sufficient for networks with low traffic. It also uses the minimum amount of
 servers: a single machine running Elasticsearch and Kibana. The Beats
-insert the transactions directly into the Elasticsearch instance.
+insert the transactions directly into the Elasticsearch instance. 
 
-This section explains how to use the Beats together with Logstash to provide
-additional buffering. An important advantage to this approach is that you can
+If you want to perform additional processing or buffering on the data, however,
+you'll want to install Logstash. 
+
+An important advantage to this approach is that you can
 use Logstash to modify the data captured by Beats in any way you like. You can also
 use Logstash's many output plugins to integrate with other systems.
 
@@ -181,7 +188,7 @@ https://www.elastic.co/downloads/logstash[downloads page].
 Don't start Logstash yet. You need to set a couple of configuration options first.
 
 [[logstash-setup]]
-==== Setting Up Logstash
+=== Setting Up Logstash
 
 In this setup, the Beat sends events to Logstash. Logstash receives
 these events by using the
@@ -190,31 +197,38 @@ http://www.elastic.co/guide/en/logstash/current/plugins-outputs-elasticsearch.ht
 output plugin for Logstash]. The Elasticsearch output plugin uses the bulk API, making
 indexing very efficient.
 
+To set up Logstash:
+
+. Make sure you have the latest compatible version of the Beats input plugin for
+Logstash installed.
++
 The Beats input plugin requires Logstash 1.5.4 or later. If you are using
 Logstash 1.5.4, you must install the Beats input plugin before applying this
-configuration because the plugin is not shipped with 1.5.4. To install
+configuration because the plugin is not shipped with 1.5.4. 
++
+To install
 the required plugin, run the following command inside the logstash directory
 (for deb and rpm installs, the directory is `/opt/logstash`).
-
++
 *deb, rpm, and mac:*
-
++
 ["source","sh",subs="attributes,callouts"]
 ----------------------------------------------------------------------
 ./bin/plugin install logstash-input-beats
 ----------------------------------------------------------------------
-
++
 *win:*
-
++
 ["source","sh",subs="attributes,callouts"]
 ----------------------------------------------------------------------
 bin\plugin install logstash-input-beats
 ----------------------------------------------------------------------
 
-Next configure Logstash to listen on port 5044 for incoming Beats connections
+. Configure Logstash to listen on port 5044 for incoming Beats connections
 and to index into Elasticsearch. You configure Logstash by creating a
 configuration file. For example, you can save the following example configuration
 to a file called `config.json`:
-
++
 [source,ruby]
 ------------------------------------------------------------------------------
 input {
@@ -232,7 +246,7 @@ output {
   }
 }
 ------------------------------------------------------------------------------
-
++
 Logstash uses this configuration to index events in Elasticsearch in the same
 way that the Beat would, but you get additional buffering and other capabilities
 provided by Logstash.
@@ -240,7 +254,7 @@ provided by Logstash.
 To use this setup, you'll also need to configure your Beat to use Logstash. For more information, see the documentation for your Beat.
 
 [[logstash-input-update]]
-==== Updating the Beats Input Plugin for Logstash
+=== Updating the Beats Input Plugin for Logstash
 
 Plugins have their own release cycle and are often released independent of
 Logstash’s core release cycle. To ensure that you have the latest version of
@@ -267,7 +281,7 @@ with input plugins in Logstash are available
 https://www.elastic.co/guide/en/logstash/current/working-with-plugins.html[here].
 
 
-==== Running Logstash
+=== Running Logstash
 
 Now you can start Logstash. Use the command that works with your system. If you
 installed Logstash as a deb or rpm package, make sure the config file is in the
@@ -308,7 +322,7 @@ You can learn more about installing, configuring, and running Logstash
 https://www.elastic.co/guide/en/logstash/current/getting-started-with-logstash.html[here].
 
 [[kibana-installation]]
-=== Installing Kibana
+== Installing Kibana
 
 https://www.elastic.co/products/kibana[Kibana] is a visualization application
 that gets its data from Elasticsearch. It provides a customizable and
@@ -367,116 +381,10 @@ bin\kibana.bat
 You can find Kibana binaries for other operating systems on the
 https://www.elastic.co/downloads/kibana[Kibana downloads page].
 
-==== Launching the Kibana Web Interface
+=== Launching the Kibana Web Interface
 
 To launch the Kibana web interface, point your browser to port 5601. For example, `http://127.0.0.1:5601`.
 
 You can learn more about Kibana in the
 http://www.elastic.co/guide/en/kibana/current/index.html[Kibana User Guide].
 
-[[load-kibana-dashboards]]
-==== Loading Kibana Dashboards
-
-Kibana has a large set of visualization types that you can combine to create
-the perfect dashboards for your needs. But this flexibility can be a bit
-overwhelming at the beginning, so we have created a couple of
-https://github.com/elastic/beats-dashboards[Sample Dashboards] to get you
-started and to demonstrate what is possible based on the Beats data.
-
-NOTE: The Beats dashboards require Kibana 4.
-
-To load the sample dashboards, you run a load script. The load script
-uploads the example dashboards, visualizations, and searches
-that you can use. The load command also creates index patterns for each Beat:
-
-   - [packetbeat-]YYYY.MM.DD
-   - [topbeat-]YYYY.MM.DD
-   - [filebeat-]YYYY.MM.DD
-   
-Use the following commands to run the script:
-
-*deb, rpm, and mac:*
-
-["source","sh",subs="attributes,callouts"]
-----------------------------------------------------------------------
-curl -L -O http://download.elastic.co/beats/dashboards/beats-dashboards-{Dashboards-version}.zip
-unzip beats-dashboards-{Dashboards-version}.zip
-cd beats-dashboards-{Dashboards-version}/
-./load.sh
-----------------------------------------------------------------------
-
-By default, the script assumes that you are running Elasticsearch on `127.0.0.1:9200`. Use the `-url` option
-to specify a different location. For example: `./load.sh -url http://192.168.33.60:9200`. To specify a Kibana index pattern or pass in user credentials, see <<dashboard-load-options>>.
-
-*win:*
-
-. Download the Beats dashboards from 
-http://download.elastic.co/beats/dashboards/beats-dashboards-{Dashboards-version}.zip. 
-
-. Extract the contents of the archive.
-
-. Open a PowerShell prompt as an Administrator (right-click the PowerShell icon
-and select *Run As Administrator*). If you are running Windows XP, you may need
-to download and install PowerShell. 
-
-. Run the following commands to load the dashboards:
-+
-["source","sh",subs="attributes,callouts"]
-----------------------------------------------------------------------
-PS > cd beats-dashboards-{Dashboards-version}
-PS > .\load.ps1
-----------------------------------------------------------------------
-+
-By default, the script assumes that you are running Elasticsearch on `127.0.0.1:9200`. Use the `-url` option
-to specify a different location. For example: `.\load.ps1 -url http://192.168.33.60:9200`. To specify a Kibana index pattern or pass in user credentials, see <<dashboard-load-options>>.
-+
-NOTE: If script execution is disabled on your system, you need to set the execution policy for the current session to allow the script to run. For example: `PowerShell.exe -ExecutionPolicy UnRestricted -File .\load.ps1 -url http://192.168.33.60:9200`.
-
-[[dashboard-load-options]]
-===== Other Dashboard Load Options
-When you load the dashboards, you can also specify:
-
-* The Kibana index pattern where you want to load the dashboards in Elasticsearch. For example:
-+
-["source","sh",subs="attributes,callouts"]
-----------------------------------------------------------------------
-./load.sh -url http://test.com:9200 -index .kibana_env
-----------------------------------------------------------------------
-
-* The username and password to use for authentication. There are a few ways to pass in the username and password. For example:
-+
-["source","sh",subs="attributes,callouts"]
-----------------------------------------------------------------------
-./load.sh -url https://xyz.found.io -u user:password <1>
-
-./load.sh -url https://xyz.found.io -u admin:$(cat ~/pass-file) <2> 
-
-./load.sh -url https://user:password@xyz.found.io <3>
-----------------------------------------------------------------------
-+
-<1> Specify the username and password separated by a colon.
-<2> Use a file to avoid polluting the bash history with the password.
-<3> Put the username and password in the URL.
-
-These options are also available when you run `.\load.ps` on Windows.
-
-[[view-kibana-dashboards]]
-==== Opening the Beats Dashboards in Kibana
-
-After loading the dashboards, Kibana raises a `No default index
-pattern` error. You must select or create an index pattern to continue. You can
-resolve the error by refreshing the page in the browser and then setting one of
-the predefined index patterns as the default.
-
-image:./images/kibana-created-indexes.png[Kibana configured indexes]
-
-To open the loaded dashboards, go to the `Dashboard` page and click the
-*Load Saved Dashboard* icon. Select `Packetbeat Dashboard` from the list.
-You can then easily switch between the dashboards by using the `Navigation` widget.
-
-image:./images/kibana-navigation-vis.png[Navigation widget in Kibana]
-
-Of course, you won't see actual data until you've installed and
-configured your Beat.
-
-Enjoy!

--- a/libbeat/docs/index.asciidoc
+++ b/libbeat/docs/index.asciidoc
@@ -1,5 +1,9 @@
 [[beats-reference]]
 = Beats Platform Reference
+:packetbeat: http://www.elastic.co/guide/en/beats/packetbeat/1.1
+:topbeat: http://www.elastic.co/guide/en/beats/topbeat/1.1
+:filebeat: http://www.elastic.co/guide/en/beats/filebeat/1.1
+:winlogbeat: http://www.elastic.co/guide/en/beats/winlogbeat/1.1
 :ES-version: 2.2.0
 :LS-version: 2.2.0
 :Kibana-version: 4.4.0
@@ -14,10 +18,14 @@ include::./gettingstarted.asciidoc[]
 
 include::./configuration.asciidoc[]
 
+include::./repositories.asciidoc[]
+
 include::./command-line.asciidoc[]
+
+include::./visualizing-data.asciidoc[]
 
 include::./newbeat.asciidoc[]
 
-include::./repositories.asciidoc[]
+//include::./release.asciidoc[]
 
-include::./release.asciidoc[]
+include::./../../../beats/CHANGELOG.asciidoc[]

--- a/libbeat/docs/newbeat.asciidoc
+++ b/libbeat/docs/newbeat.asciidoc
@@ -1,6 +1,8 @@
 [[new-beat]]
-== Developer Guide: Creating a New Beat
+= Developer Guide: Creating a New Beat
 
+[partintro]
+--
 This guide walks you through the steps for creating a new Elastic Beat.  The
 Beats are a collection of lightweight daemons that collect operational data from
 your servers and ship it to Elasticsearch or Logstash.  The common parts for
@@ -10,7 +12,9 @@ handling, for logging, and more. By using this common framework, you can ensure
 that all Beats behave consistently and that they are easy to package and run
 with common tools.
 
-=== Getting Ready
+--
+
+== Getting Ready
 
 All Beats are written in http://golang.org/[Go], so having Go installed and knowing
 the basics are prerequisites for understanding this guide.
@@ -37,7 +41,7 @@ Topbeat periodically ships them to Elasticsearch for storage.
 You can use Topbeat as an example implementation for creating a new Beat. Just copy
 the source files and modify them as necessary for your Beat.
 
-=== Overview
+== Overview
 
 At the high level, a simple Beat like Topbeat has two main components:
 
@@ -89,7 +93,7 @@ The following example shows an event object in Topbeat:
 
 Now that you have the big picture, let's dig into the code.
 
-=== Developing the Beat-Specific Code
+== Developing the Beat-Specific Code
 
 The Beat-specific code should implement the `Beater` interface defined
 in libbeat.
@@ -147,7 +151,7 @@ Let's go through each of the methods in the `Beater` interface and look at a
 sample implementation.
 
 [[config-method]]
-==== Config Method
+=== Config Method
 
 The `Config` method deals with the configuration file and optionally with
 custom CLI flags.
@@ -212,7 +216,7 @@ func (tb *Topbeat) Config(b *beat.Beat) error {
     file.
 
 [[setup-method]]
-==== Setup Method
+=== Setup Method
 
 The `Setup` method enables you to execute logic before the main
 loop, usually for initialization. In the Topbeat implementation, this method
@@ -229,7 +233,7 @@ func (tb *Topbeat) Setup(b *beat.Beat) error {
 ----------------------------------------------------------------------
 
 [[run-method]]
-==== Run Method
+=== Run Method
 
 The `Run` method should contain your main application loop. For Topbeat it looks
 like this:
@@ -298,7 +302,7 @@ func (t *Topbeat) exportSystemStats() error {
 <3> Send the event.
 
 [[cleanup-method]]
-==== Cleanup Method
+=== Cleanup Method
 
 The `Cleanup` method is executed after the main loop finishes (or is interrupted)
 and gives you the opportunity to release any resources you might use. For
@@ -312,7 +316,7 @@ func (tb *Topbeat) Cleanup(b *beat.Beat) error {
 ----------------------------------------------------------------------
 
 [[stop-method]]
-==== Stop Method
+=== Stop Method
 
 The `Stop` method is called when the Beat is signaled to stop, for
 example through the SIGTERM signal on Unix systems or the service control
@@ -326,7 +330,7 @@ func (t *Topbeat) Stop() {
 }
 ----------------------------------------------------------------------
 
-==== The main Function
+=== The main Function
 
 If you follow the Topbeat model and put your Beat-specific code in its own type
 that implements the `Beater` interface, the code from your main package is
@@ -344,7 +348,7 @@ func main() {
 
 We recommend that you implement a `New` function that creates your Beats object.
 
-=== Sharing Your Beat with the Community
+== Sharing Your Beat with the Community
 
 When you're done with your new Beat, how about letting everyone know? Open
 a pull request to add your link <<community-beats, here>>.

--- a/libbeat/docs/release.asciidoc
+++ b/libbeat/docs/release.asciidoc
@@ -1,8 +1,9 @@
 :beats-dir: ../../../beats
 
 [[release-notes]]
-== Release notes
+= Release notes
 
+[partintro]
 --
 This section summarizes the changes in each release.
 
@@ -14,5 +15,5 @@ This section summarizes the changes in each release.
 * <<release-notes-1.0.0-beta4>>
 
 --
-
 include::{beats-dir}/CHANGELOG.asciidoc[]
+

--- a/libbeat/docs/visualizing-data.asciidoc
+++ b/libbeat/docs/visualizing-data.asciidoc
@@ -1,0 +1,118 @@
+[[visualizing-data]]
+= Visualizing Your Data in Kibana
+
+[partintro]
+--
+
+This section describes how to load the sample Beats dashboards. After loading
+the dashboards in Kibana, you can modify them to meet your needs. 
+
+--
+
+[[load-kibana-dashboards]]
+== Loading the Beats Dashboards
+
+Kibana has a large set of visualization types that you can combine to create
+the perfect dashboards for your needs. But this flexibility can be a bit
+overwhelming at the beginning, so we have created a couple of
+https://github.com/elastic/beats-dashboards[Sample Dashboards] to get you
+started and to demonstrate what is possible based on the Beats data.
+
+NOTE: The Beats dashboards require Kibana 4.
+
+To load the sample dashboards, you run a load script. The load script
+uploads the example dashboards, visualizations, and searches
+that you can use. The load command also creates index patterns for each Beat:
+
+   - [packetbeat-]YYYY.MM.DD
+   - [topbeat-]YYYY.MM.DD
+   - [filebeat-]YYYY.MM.DD
+   
+Use the following commands to run the script:
+
+*deb, rpm, and mac:*
+
+["source","sh",subs="attributes,callouts"]
+----------------------------------------------------------------------
+curl -L -O http://download.elastic.co/beats/dashboards/beats-dashboards-{Dashboards-version}.zip
+unzip beats-dashboards-{Dashboards-version}.zip
+cd beats-dashboards-{Dashboards-version}/
+./load.sh
+----------------------------------------------------------------------
+
+By default, the script assumes that you are running Elasticsearch on `127.0.0.1:9200`. Use the `-url` option
+to specify a different location. For example: `./load.sh -url http://192.168.33.60:9200`. To specify a Kibana index pattern or pass in user credentials, see <<dashboard-load-options>>.
+
+*win:*
+
+. Download the Beats dashboards from 
+http://download.elastic.co/beats/dashboards/beats-dashboards-{Dashboards-version}.zip. 
+
+. Extract the contents of the archive.
+
+. Open a PowerShell prompt as an Administrator (right-click the PowerShell icon
+and select *Run As Administrator*). If you are running Windows XP, you may need
+to download and install PowerShell. 
+
+. Run the following commands to load the dashboards:
++
+["source","sh",subs="attributes,callouts"]
+----------------------------------------------------------------------
+PS > cd beats-dashboards-{Dashboards-version}
+PS > .\load.ps1
+----------------------------------------------------------------------
++
+By default, the script assumes that you are running Elasticsearch on `127.0.0.1:9200`. Use the `-url` option
+to specify a different location. For example: `.\load.ps1 -url http://192.168.33.60:9200`. To specify a Kibana index pattern or pass in user credentials, see <<dashboard-load-options>>.
++
+NOTE: If script execution is disabled on your system, you need to set the execution policy for the current session to allow the script to run. For example: `PowerShell.exe -ExecutionPolicy UnRestricted -File .\load.ps1 -url http://192.168.33.60:9200`.
+
+[[dashboard-load-options]]
+== Other Dashboard Load Options
+When you load the Beats dashboards, you can also specify:
+
+* The Kibana index pattern where you want to load the dashboards in Elasticsearch. For example:
++
+["source","sh",subs="attributes,callouts"]
+----------------------------------------------------------------------
+./load.sh -url http://test.com:9200 -index .kibana_env
+----------------------------------------------------------------------
+
+* The username and password to use for authentication. There are a few ways to pass in the username and password. For example:
++
+["source","sh",subs="attributes,callouts"]
+----------------------------------------------------------------------
+./load.sh -url https://xyz.found.io -u user:password <1>
+
+./load.sh -url https://xyz.found.io -u admin:$(cat ~/pass-file) <2> 
+
+./load.sh -url https://user:password@xyz.found.io <3>
+----------------------------------------------------------------------
++
+<1> Specify the username and password separated by a colon.
+<2> Use a file to avoid polluting the bash history with the password.
+<3> Put the username and password in the URL.
+
+These options are also available when you run `.\load.ps1` on Windows.
+
+[[view-kibana-dashboards]]
+== Opening the Beats Dashboards in Kibana
+
+After <<load-kibana-dashboards,loading the Beats dashboards>>,
+launch the Kibana web interface by pointing your browser
+to port 5601. For example, `http://127.0.0.1:5601`.
+
+If Kibana raises a `No default index pattern` error, you must select or create
+an index pattern to continue. You can resolve the error by refreshing the page
+in the browser and then setting one of the predefined index patterns as the default.
+
+image:./images/kibana-created-indexes.png[Kibana configured indexes]
+
+To open the loaded dashboards, go to the `Dashboard` page and click the
+*Load Saved Dashboard* icon. Select `Packetbeat Dashboard` from the list.
+You can then easily switch between the dashboards by using the `Navigation` widget.
+
+image:./images/kibana-navigation-vis.png[Navigation widget in Kibana]
+
+Of course, you won't see actual data until you've installed and
+configured your Beat.


### PR DESCRIPTION
Here's my first pass at the structural changes to the Filebeat doc. You can see a preview of the doc here:

https://docstructuralchanges.firebaseapp.com

I couldn't get the release notes to show up without adding an extra navigational container, which looked weird. So my solution was to put the intro stuff in the CHANGELOG, change the heading levels, and import the CHANGELOG directly into the doc. I think it still looks OK when viewed in GitHub because the part-related info doesn't show up, but let me know if you think this is a bad plan. I think it's nicely organized now because users can navigate directly to the relevant release info.

asciidoc is not super flexible when it comes to assembling topics into a logical structure, so I had to make some other modifications. I also thought that some of the chunking that asciidoc does by default made the content easier to scan, so I didn't try to override the behavior with float tags. We can always change that if we find that we want to add more content to a container. For example, under Visualizing Your Data in Kibana, if someday we want to add more content that isn't related to loading the sample dashboards, we can just collapse that content down into one topic and add other stuff. 
