### PR TITLE
Let 1.1.0 in the docs

### DIFF
--- a/filebeat/docs/index.asciidoc
+++ b/filebeat/docs/index.asciidoc
@@ -1,6 +1,6 @@
 = Filebeat Reference
 :libbeat: http://www.elastic.co/guide/en/beats/libbeat/1.1
-:version: 1.1.1
+:version: 1.1.0
 :beatname_lc: filebeat
 :beatname_uc: Filebeat
 

--- a/packetbeat/docs/index.asciidoc
+++ b/packetbeat/docs/index.asciidoc
@@ -1,6 +1,6 @@
 = Packetbeat Reference
 :libbeat: http://www.elastic.co/guide/en/beats/libbeat/1.1
-:version: 1.1.1
+:version: 1.1.0
 :beatname_lc: packetbeat
 :beatname_uc: Packetbeat
 

--- a/topbeat/docs/index.asciidoc
+++ b/topbeat/docs/index.asciidoc
@@ -1,6 +1,6 @@
 = Topbeat Reference
 :libbeat: http://www.elastic.co/guide/en/beats/libbeat/1.1
-:version: 1.1.1
+:version: 1.1.0
 :beatname_lc: topbeat
 :beatname_uc: Topbeat
 

--- a/winlogbeat/docs/index.asciidoc
+++ b/winlogbeat/docs/index.asciidoc
@@ -1,6 +1,6 @@
 = Winlogbeat Reference
 :libbeat: http://www.elastic.co/guide/en/beats/libbeat/1.1
-:version: 1.1.1
+:version: 1.1.0
 :beatname_lc: winlogbeat
 :beatname_uc: Winlogbeat
 


### PR DESCRIPTION
The 1.1.1 already showed up in the docs, with the software not being
available yet. We have to update the docs closer to the release time.