### PR TITLE
fix: bulk mode merge guaranteed flag

### DIFF
--- a/libbeat/publisher/output.go
+++ b/libbeat/publisher/output.go
@@ -86,7 +86,8 @@ func (o *outputWorker) sendBulk(
 ) {
 	debug("output worker: publish %v events", len(events))
 
-	err := o.out.BulkPublish(ctx.Signal, outputs.Options{ctx.Guaranteed}, events)
+	opts := outputs.Options{ctx.Guaranteed}
+	err := o.out.BulkPublish(ctx.Signal, opts, events)
 	if err != nil {
 		logp.Info("Error bulk publishing events: %s", err)
 	}


### PR DESCRIPTION
fix problem in filebeat of 'guaranteed' flag not being forwarded correcly to output plugin.

Simple workaround in 1.1.0 is to set `max_retries: -1` in output configuration.