### PR TITLE
Add changelog entries for critical fixes in 1.1.1

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -70,7 +70,8 @@ https://github.com/elastic/beats/compare/v1.1.0...v1.1.1[View commits]
 
 *Affecting all Beats*
 
-- Fix logstash output loop hanging in infinite loop on too many output errors.
+- Fix logstash output loop hanging in infinite loop on too many output errors. {pull}944[944]
+- Fix critical bug in filebeat and winlogbeat potentially dropping events. {pull}953[953]
 
 [[release-notes-1.1.0]]
 === Beats version 1.1.0


### PR DESCRIPTION
for reference. Bug in #944 has been introduced in beta4 when logstash output was added and #953 has been introduced in 1.1.0. Unit tests reproducing and validating fix for first one have been pushed to master. Later one has been validated via debug logs, but unit/integration tests to master will follow.