### PR TITLE
Prospector harvester cleanup

### DIFF
--- a/filebeat/config/config.go
+++ b/filebeat/config/config.go
@@ -44,32 +44,32 @@ type FilebeatConfig struct {
 }
 
 type ProspectorConfig struct {
-	Paths                 []string
+	ExcludeFiles          []string `yaml:"exclude_files"`
+	ExcludeFilesRegexp    []*regexp.Regexp
+	Harvester             HarvesterConfig `yaml:",inline"`
 	Input                 string
 	IgnoreOlder           string `yaml:"ignore_older"`
 	IgnoreOlderDuration   time.Duration
-	CloseOlder            string `yaml:"close_older"`
-	CloseOlderDuration    time.Duration
+	Paths                 []string
 	ScanFrequency         string `yaml:"scan_frequency"`
 	ScanFrequencyDuration time.Duration
-	Harvester             HarvesterConfig `yaml:",inline"`
-	ExcludeFiles          []string        `yaml:"exclude_files"`
-	ExcludeFilesRegexp    []*regexp.Regexp
 }
 
 type HarvesterConfig struct {
-	InputType          string `yaml:"input_type"`
+	BufferSize         int    `yaml:"harvester_buffer_size"`
+	DocumentType       string `yaml:"document_type"`
+	Encoding           string `yaml:"encoding"`
 	Fields             common.MapStr
 	FieldsUnderRoot    bool   `yaml:"fields_under_root"`
-	BufferSize         int    `yaml:"harvester_buffer_size"`
+	InputType          string `yaml:"input_type"`
 	TailFiles          bool   `yaml:"tail_files"`
-	Encoding           string `yaml:"encoding"`
-	DocumentType       string `yaml:"document_type"`
 	Backoff            string `yaml:"backoff"`
 	BackoffDuration    time.Duration
 	BackoffFactor      int    `yaml:"backoff_factor"`
 	MaxBackoff         string `yaml:"max_backoff"`
 	MaxBackoffDuration time.Duration
+	CloseOlder         string `yaml:"close_older"`
+	CloseOlderDuration time.Duration
 	ForceCloseFiles    bool             `yaml:"force_close_files"`
 	ExcludeLines       []string         `yaml:"exclude_lines"`
 	IncludeLines       []string         `yaml:"include_lines"`
@@ -78,10 +78,10 @@ type HarvesterConfig struct {
 }
 
 type MultilineConfig struct {
-	Pattern  string `yaml:"pattern"`
 	Negate   bool   `yaml:"negate"`
 	Match    string `yaml:"match"`
 	MaxLines *int   `yaml:"max_lines"`
+	Pattern  string `yaml:"pattern"`
 	Timeout  string `yaml:"timeout"`
 }
 

--- a/filebeat/config/config_test.go
+++ b/filebeat/config/config_test.go
@@ -35,7 +35,7 @@ func TestReadConfig(t *testing.T) {
 	assert.Equal(t, 3, len(prospectors[0].Harvester.Fields))
 	assert.Equal(t, "1", prospectors[0].Harvester.Fields["review"])
 	assert.Equal(t, "0", prospectors[0].IgnoreOlder)
-	assert.Equal(t, "1h", prospectors[0].CloseOlder)
+	assert.Equal(t, "1h", prospectors[0].Harvester.CloseOlder)
 	assert.Equal(t, "10s", prospectors[0].ScanFrequency)
 
 	assert.Equal(t, "stdin", prospectors[2].Input)

--- a/filebeat/crawler/prospector_stdin.go
+++ b/filebeat/crawler/prospector_stdin.go
@@ -4,9 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	cfg "github.com/elastic/beats/filebeat/config"
 	"github.com/elastic/beats/filebeat/harvester"
-	"github.com/elastic/beats/filebeat/input"
 )
 
 type ProspectorStdin struct {
@@ -15,18 +13,15 @@ type ProspectorStdin struct {
 	started    bool
 }
 
-func NewProspectorStdin(config cfg.ProspectorConfig, channel chan *input.FileEvent) (*ProspectorStdin, error) {
+func NewProspectorStdin(p *Prospector) (*ProspectorStdin, error) {
 
-	prospectorer := &ProspectorStdin{}
+	prospectorer := &ProspectorStdin{
+		Prospector: p,
+	}
 
 	var err error
-	prospectorer.harvester, err = harvester.NewHarvester(
-		config,
-		&config.Harvester,
-		"-",
-		nil,
-		channel,
-	)
+
+	prospectorer.harvester, err = p.AddHarvester("-", nil)
 
 	if err != nil {
 		return nil, fmt.Errorf("Error initializing stdin harvester: %v", err)

--- a/filebeat/crawler/prospector_test.go
+++ b/filebeat/crawler/prospector_test.go
@@ -96,7 +96,9 @@ func TestProspectorInitScanFrequency0(t *testing.T) {
 func TestProspectorInitCloseOlder0(t *testing.T) {
 
 	prospectorConfig := config.ProspectorConfig{
-		CloseOlder: "0",
+		Harvester: config.HarvesterConfig{
+			CloseOlder: "0",
+		},
 	}
 
 	prospector := Prospector{
@@ -107,7 +109,7 @@ func TestProspectorInitCloseOlder0(t *testing.T) {
 
 	var zero time.Duration = 0
 	// 0 expected
-	assert.Equal(t, zero, prospector.ProspectorConfig.CloseOlderDuration)
+	assert.Equal(t, zero, prospector.ProspectorConfig.Harvester.CloseOlderDuration)
 }
 
 func TestProspectorInitInvalidScanFrequency(t *testing.T) {

--- a/filebeat/harvester/filestat.go
+++ b/filebeat/harvester/filestat.go
@@ -1,0 +1,39 @@
+package harvester
+
+import "os"
+
+// Contains statistic about file when it was last seend by the prospector
+type FileStat struct {
+	Fileinfo      os.FileInfo /* the file info */
+	Return        chan int64  /* the harvester will send an event with its offset when it closes */
+	LastIteration uint32      /* int number of the last iterations in which we saw this file */
+}
+
+func NewFileStat(fi os.FileInfo, lastIteration uint32) *FileStat {
+	fs := &FileStat{
+		Fileinfo:      fi,
+		Return:        make(chan int64, 1),
+		LastIteration: lastIteration,
+	}
+	return fs
+}
+
+func (fs *FileStat) Finished() bool {
+	return len(fs.Return) != 0
+}
+
+// Ignore forgets about the previous harvester results and let it continue on the old
+// file - start a new channel to use with the new harvester.
+func (fs *FileStat) Ignore() {
+	fs.Return = make(chan int64, 1)
+}
+
+func (fs *FileStat) Continue(old *FileStat) {
+	if old != nil {
+		fs.Return = old.Return
+	}
+}
+
+func (fs *FileStat) Skip(returnOffset int64) {
+	fs.Return <- returnOffset
+}

--- a/filebeat/harvester/harvester.go
+++ b/filebeat/harvester/harvester.go
@@ -14,8 +14,7 @@
 package harvester
 
 import (
-	"io"
-	"os"
+	"fmt"
 	"regexp"
 
 	"github.com/elastic/beats/filebeat/config"
@@ -25,7 +24,6 @@ import (
 
 type Harvester struct {
 	Path               string /* the file path to harvest */
-	ProspectorConfig   config.ProspectorConfig
 	Config             *config.HarvesterConfig
 	Offset             int64
 	Stat               *FileStat
@@ -36,75 +34,39 @@ type Harvester struct {
 	IncludeLinesRegexp []*regexp.Regexp
 }
 
-// Contains statistic about file when it was last seend by the prospector
-type FileStat struct {
-	Fileinfo      os.FileInfo /* the file info */
-	Return        chan int64  /* the harvester will send an event with its offset when it closes */
-	LastIteration uint32      /* int number of the last iterations in which we saw this file */
+func NewHarvester(
+	cfg *config.HarvesterConfig,
+	path string,
+	stat *FileStat,
+	spooler chan *input.FileEvent,
+) (*Harvester, error) {
+
+	var err error
+	encoding, ok := encoding.FindEncoding(cfg.Encoding)
+	if !ok || encoding == nil {
+		return nil, fmt.Errorf("unknown encoding('%v')", cfg.Encoding)
+	}
+
+	h := &Harvester{
+		Path:        path,
+		Config:      cfg,
+		Stat:        stat,
+		SpoolerChan: spooler,
+		encoding:    encoding,
+	}
+	h.ExcludeLinesRegexp, err = InitRegexps(cfg.ExcludeLines)
+	if err != nil {
+		return h, err
+	}
+	h.IncludeLinesRegexp, err = InitRegexps(cfg.IncludeLines)
+	if err != nil {
+		return h, err
+	}
+	return h, nil
 }
-
-type LogSource interface {
-	io.ReadCloser
-	Name() string
-}
-
-type FileSource interface {
-	LogSource
-	Stat() (os.FileInfo, error)
-	Continuable() bool // can we continue processing after EOF?
-}
-
-// Interface for the different harvester types
-type Typer interface {
-	open()
-	read()
-}
-
-// restrict file to minimal interface of FileSource to prevent possible casts
-// to additional interfaces supported by underlying file
-type pipeSource struct{ file *os.File }
-
-func (p pipeSource) Read(b []byte) (int, error) { return p.file.Read(b) }
-func (p pipeSource) Close() error               { return p.file.Close() }
-func (p pipeSource) Name() string               { return p.file.Name() }
-func (p pipeSource) Stat() (os.FileInfo, error) { return p.file.Stat() }
-func (p pipeSource) Continuable() bool          { return false }
-
-type fileSource struct{ *os.File }
-
-func (fileSource) Continuable() bool { return true }
 
 func (h *Harvester) Start() {
 	// Starts harvester and picks the right type. In case type is not set, set it to defeault (log)
 
 	go h.Harvest()
-}
-
-func NewFileStat(fi os.FileInfo, lastIteration uint32) *FileStat {
-	fs := &FileStat{
-		Fileinfo:      fi,
-		Return:        make(chan int64, 1),
-		LastIteration: lastIteration,
-	}
-	return fs
-}
-
-func (fs *FileStat) Finished() bool {
-	return len(fs.Return) != 0
-}
-
-// Ignore forgets about the previous harvester results and let it continue on the old
-// file - start a new channel to use with the new harvester.
-func (fs *FileStat) Ignore() {
-	fs.Return = make(chan int64, 1)
-}
-
-func (fs *FileStat) Continue(old *FileStat) {
-	if old != nil {
-		fs.Return = old.Return
-	}
-}
-
-func (fs *FileStat) Skip(returnOffset int64) {
-	fs.Return <- returnOffset
 }

--- a/filebeat/harvester/log.go
+++ b/filebeat/harvester/log.go
@@ -2,7 +2,6 @@ package harvester
 
 import (
 	"errors"
-	"fmt"
 	"io"
 	"os"
 
@@ -17,38 +16,6 @@ import (
 const (
 	defaultMaxBytes = 10 * (1 << 20) // 10MB
 )
-
-func NewHarvester(
-	prospectorCfg config.ProspectorConfig,
-	cfg *config.HarvesterConfig,
-	path string,
-	stat *FileStat,
-	spooler chan *input.FileEvent,
-) (*Harvester, error) {
-	var err error
-	encoding, ok := encoding.FindEncoding(cfg.Encoding)
-	if !ok || encoding == nil {
-		return nil, fmt.Errorf("unknown encoding('%v')", cfg.Encoding)
-	}
-
-	h := &Harvester{
-		Path:             path,
-		ProspectorConfig: prospectorCfg,
-		Config:           cfg,
-		Stat:             stat,
-		SpoolerChan:      spooler,
-		encoding:         encoding,
-	}
-	h.ExcludeLinesRegexp, err = InitRegexps(cfg.ExcludeLines)
-	if err != nil {
-		return h, err
-	}
-	h.IncludeLinesRegexp, err = InitRegexps(cfg.IncludeLines)
-	if err != nil {
-		return h, err
-	}
-	return h, nil
-}
 
 func createLineReader(
 	in FileSource,
@@ -120,7 +87,7 @@ func (h *Harvester) Harvest() {
 	config := h.Config
 	readerConfig := logFileReaderConfig{
 		forceClose:         config.ForceCloseFiles,
-		closeOlder:         h.ProspectorConfig.CloseOlderDuration,
+		closeOlder:         config.CloseOlderDuration,
 		backoffDuration:    config.BackoffDuration,
 		maxBackoffDuration: config.MaxBackoffDuration,
 		backoffFactor:      config.BackoffFactor,
@@ -290,5 +257,3 @@ func (h *Harvester) initFileOffset(file *os.File) error {
 
 func (h *Harvester) Stop() {
 }
-
-const maxConsecutiveEmptyReads = 100

--- a/filebeat/harvester/sources.go
+++ b/filebeat/harvester/sources.go
@@ -1,0 +1,31 @@
+package harvester
+
+import (
+	"io"
+	"os"
+)
+
+type LogSource interface {
+	io.ReadCloser
+	Name() string
+}
+
+type FileSource interface {
+	LogSource
+	Stat() (os.FileInfo, error)
+	Continuable() bool // can we continue processing after EOF?
+}
+
+// restrict file to minimal interface of FileSource to prevent possible casts
+// to additional interfaces supported by underlying file
+type pipeSource struct{ file *os.File }
+
+func (p pipeSource) Read(b []byte) (int, error) { return p.file.Read(b) }
+func (p pipeSource) Close() error               { return p.file.Close() }
+func (p pipeSource) Name() string               { return p.file.Name() }
+func (p pipeSource) Stat() (os.FileInfo, error) { return p.file.Stat() }
+func (p pipeSource) Continuable() bool          { return false }
+
+type fileSource struct{ *os.File }
+
+func (fileSource) Continuable() bool { return true }


### PR DESCRIPTION
No logical changes in this PR, only code refactoring.

The goal of this refactoring is to simplify the introduction of tracking harvesters.

* Pass prospector to Prospectorer to simplify variable handling and simplify prospectorer
* Abstract adding of a harvester to a prospector
* Simplify harvester by removing dependency on prospector config
* Restructure harvester and split up sources and filestat
* Remove unused Typer interface and const maxConsecuitiveReads
* Simplify variable handling in ProspectorLog
* Sort configuration variables