### PR TITLE
Fix links and problems caused by changing chunk level to 1 in doc build

### DIFF
--- a/filebeat/docs/getting-started.asciidoc
+++ b/filebeat/docs/getting-started.asciidoc
@@ -3,9 +3,9 @@
 
 To get started with your own Filebeat setup, install and configure these related products:
 
- * Elasticsearch for storage and indexing the data. {libbeat}/getting-started.html#elasticsearch-installation[More details]
- * Kibana for the UI. {libbeat}/getting-started.html#kibana-installation[More details]
- * Optionally Logstash for inserting data into Elasticsearch. {libbeat}/getting-started.html#logstash-installation[More details]
+ * Elasticsearch for storage and indexing the data. {libbeat}/elasticsearch-installation.html[More details]
+ * Kibana for the UI. {libbeat}/kibana-installation.html[More details]
+ * Optionally Logstash for inserting data into Elasticsearch. {libbeat}/logstash-installation.html[More details]
 
 After you have installed these products, you can start <<filebeat-installation>>.
 

--- a/filebeat/docs/migration.asciidoc
+++ b/filebeat/docs/migration.asciidoc
@@ -19,7 +19,7 @@ Filebeat introduces the following major changes:
 
 Filebeat requires a new input plugin in Logstash, called
 https://www.elastic.co/guide/en/logstash/current/plugins-inputs-beats.html[logstash-input-beats].
-For information about getting started with this plugin, see {libbeat}/getting-started.html#logstash-setup[Setting up Logstash].
+For information about getting started with this plugin, see {libbeat}/logstash-installation.html#logstash-setup[Setting up Logstash].
 
 In both the 1.5.x and 2.x versions of Logstash, this plugin can be loaded in
 parallel with the

--- a/filebeat/docs/support.asciidoc
+++ b/filebeat/docs/support.asciidoc
@@ -3,7 +3,10 @@
 If you have an issue with Filebeat, contact us in the https://discuss.elastic.co/c/beats/filebeat[Filebeat forum].
 If you want to contribute to Filebeat, check out our https://github.com/elastic/beats[Github repository].
 
+[float]
 === Known Issues
+
+[float]
 ==== Network Volumes
 
 We do not recommend reading log files from network volumes. Whenever possible, install Filebeat on the host machine and

--- a/libbeat/docs/communitybeats.asciidoc
+++ b/libbeat/docs/communitybeats.asciidoc
@@ -18,6 +18,7 @@ here: https://github.com/elastic/libbeat/blob/master/docs/communitybeats.asciido
 NOTE: Elastic provides no warranty or support for community-sourced Beats.
 
 [[contributing-beats]]
+[float]
 === Contributing to Beats
 
 Remember, you can be a Beats developer, too. <<new-beat, Learn how>>

--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -233,7 +233,7 @@ See <<configuration-output-tls>> for more information.
 ==== Logstash Output
 
 The Logstash output sends the events directly to Logstash by using the lumberjack
-protocol. To use this option, you must {libbeat}/getting-started.html#logstash-setup[install and configure] the logstash-input-beats
+protocol. To use this option, you must {libbeat}/logstash-installation.html#logstash-setup[install and configure] the logstash-input-beats
 plugin in Logstash. Logstash allows for additional processing and routing of
 generated events.
 

--- a/libbeat/docs/shared-logstash-config.asciidoc
+++ b/libbeat/docs/shared-logstash-config.asciidoc
@@ -30,5 +30,5 @@ In this configuration, `hosts` specifies the Logstash server and the port (`5044
 where Logstash is configured to listen for incoming Beats connections.
 
 To use this configuration, you must also
-{libbeat}/getting-started.html#logstash-setup[set up Logstash] to receive events
+{libbeat}/logstash-installation.html#logstash-setup[set up Logstash] to receive events
 from Beats.

--- a/packetbeat/docs/command-line.asciidoc
+++ b/packetbeat/docs/command-line.asciidoc
@@ -35,6 +35,7 @@ Usage of ./packetbeat:
       Additional seconds to wait before shutting down
 ----------------------------------------------------------------------------
 
+[float]
 === Packet-Beat Specific Options
 These command line options are specific to Packetbeat:
 
@@ -61,6 +62,7 @@ Read the packets from the pcap file as fast as possible without sleeping. Use th
 *`-waitstop <n>`*::
 Wait an additional `n` seconds before exiting.
 
+[float]
 === Other Options
 
 These command line options from libbeat are also available for Packetbeat:

--- a/packetbeat/docs/filtering.asciidoc
+++ b/packetbeat/docs/filtering.asciidoc
@@ -2,6 +2,7 @@
 
 In Kibana, you can filter transactions either by entering a search query or by clicking on elements within a visualization. 
 
+[float]
 === Creating Queries
 
 The search field on the *Discover* page provides a way to query 
@@ -14,6 +15,7 @@ you want to find the HTTP redirects, you can search for
 
 image:./images/kibana-query-filtering.png[Kibana query]
 
+[float]
 ==== String Queries
 
 A query may consist of one or more words or a phrase. A phrase is a
@@ -43,6 +45,7 @@ To search for all transactions with the "chunked" encoding:
 "Transfer-Encoding: chunked"
 -----------------------------
 
+[float]
 ==== Field-Based Queries
 
 Kibana allows you to search specific fields.
@@ -69,6 +72,7 @@ To view MySQL INSERT queries only:
 mysql.method: INSERT
 ---------------------
 
+[float]
 ==== Regexp Queries
 
 Kibana supports regular expression for filters and expressions. For example,
@@ -83,7 +87,7 @@ See
 http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-regexp-query.html[Elasticsearch regexp query]
 for more details about the syntax.
 
-
+[float]
 ==== Range Queries
 
 Range queries allow a field to have values between the lower and upper bounds.
@@ -104,6 +108,7 @@ To search for slow transactions with a response time greater than 10ms:
 responsetime: {10 TO *}
 -------------------------
 
+[float]
 ==== Boolean Queries
 
 Boolean operators (AND, OR, NOT) allow combining multiple sub-queries through logic operators.
@@ -135,6 +140,7 @@ To search for either INSERT or UPDATE MySQL queries with a response time greater
 (mysql.method: INSERT OR mysql.method: UPDATE) AND responsetime: [30 TO *]
 ---------------------------------------------------------------------------
 
+[float]
 === Creating Filters
 
 In Kibana, you can also filter transactions by clicking on

--- a/packetbeat/docs/gettingstarted.asciidoc
+++ b/packetbeat/docs/gettingstarted.asciidoc
@@ -6,9 +6,9 @@ Packetbeat is to try it on your own traffic.
 
 To get started with your own Packetbeat setup, install and configure these related products:
 
- * Elasticsearch for storage and indexing the data. {libbeat}/getting-started.html#elasticsearch-installation[More details]
- * Kibana for the UI. {libbeat}/getting-started.html#kibana-installation[More details]
- * Optionally Logstash for inserting data into Elasticsearch. {libbeat}/getting-started.html#logstash-installation[More details]
+ * Elasticsearch for storage and indexing the data. {libbeat}/elasticsearch-installation.html[More details]
+ * Kibana for the UI. {libbeat}/kibana-installation.html[More details]
+ * Optionally Logstash for inserting data into Elasticsearch. {libbeat}/logstash-installation.html[More details]
 
 After you have installed these products, you can start <<packetbeat-installation>>.
 
@@ -293,7 +293,7 @@ dashboards are maintained in this
 https://github.com/elastic/beats-dashboards[GitHub repository], which also
 includes instructions for loading the dashboards.
 
-You can load all of the sample dashboards automatically by following {libbeat}/getting-started.html#load-kibana-dashboards[these steps].
+You can load all of the sample dashboards automatically by following {libbeat}/kibana-installation.html#load-kibana-dashboards[these steps].
 
 
 image:./images/packetbeat-statistics.png[Packetbeat statistics]

--- a/packetbeat/docs/kibana3.asciidoc
+++ b/packetbeat/docs/kibana3.asciidoc
@@ -10,6 +10,7 @@ This page walks you through the steps required to install the forked Kibana 3
 and load the Packetbeat dashboards. You can install Kibana 3 on the same system
 as Kibana 4.
 
+[float]
 === Downloading the Kibana 3 Fork
 
 Download and install the Kibana 3 fork by issuing the following commands:
@@ -60,6 +61,7 @@ sudo /etc/init.d/elasticsearch restart
 And try again to access Kibana in your browser. You should now see
 Kibana's welcome page.
 
+[float]
 === Loading Packetbeat Dashboards
 
 To load our sample Kibana 3 dashboards, use the following commands:

--- a/topbeat/docs/fields.asciidoc
+++ b/topbeat/docs/fields.asciidoc
@@ -67,7 +67,7 @@ The hostname as returned by the operating system on which the Beat is running.
 Contains system-wide statistics. These statistics are the details that you can get by running the *top* command on Unix systems.
 
 
-
+[float]
 === load Fields
 
 The system load average. The load average is the average number  of jobs in the run queue.
@@ -94,7 +94,7 @@ type: float
 
 The load average over 15 minutes. 
 
-
+[float]
 === cpu Fields
 
 This group contains statistics related to CPU usage.
@@ -168,7 +168,7 @@ type: int
 
 The amount of CPU time spent in involuntary wait by the virtual CPU while the hypervisor was servicing another processor. Available only on Unix.
 
-
+[float]
 === mem Fields
 
 This group contains statistics related to the memory usage on the system.
@@ -222,7 +222,7 @@ type: float
 
 The percentage of actual used memory.
 
-
+[float]
 === swap Fields
 
 This group contains statistics related to the swap memory usage on the system.
@@ -283,7 +283,7 @@ The percentage of actual used swap memory.
 Per-process statistics that you can get by running the *top* or *ps* command on Unix systems.
 
 
-
+[float]
 === proc Fields
 
 Contains per-process statistics like memory usage, CPU usage, and details about each process, such as state, name, pid, and ppid.
@@ -317,7 +317,7 @@ type: int
 
 The process parent pid.
 
-
+[float]
 === cpu Fields
 
 CPU-specific statistics per process.
@@ -357,7 +357,7 @@ type: string
 
 The time when the process was started. Example: "17:45".
 
-
+[float]
 === mem Fields
 
 Memory-specific statistics per process.
@@ -397,7 +397,7 @@ The shared memory the process uses.
 File system-related statistics that you can get by using the *df* command on Unix systems.
 
 
-
+[float]
 === fs Fields
 
 Contains details about the mounted disks, such as the total or used disk space, and details about each disk, such as  the device name and the mounting place.

--- a/topbeat/docs/gettingstarted.asciidoc
+++ b/topbeat/docs/gettingstarted.asciidoc
@@ -6,9 +6,9 @@ statistics along with a disk usage overview.
 
 To get started with your own Topbeat setup, install and configure these related products:
 
- * Elasticsearch for storage and indexing the data. {libbeat}/getting-started.html#elasticsearch-installation[More details]
- * Kibana for the UI. {libbeat}/getting-started.html#kibana-installation[More details]
- * Optionally Logstash for inserting data into Elasticsearch. {libbeat}/getting-started.html#logstash-installation[More details]
+ * Elasticsearch for storage and indexing the data. {libbeat}/elasticsearch-installation.html[More details]
+ * Kibana for the UI. {libbeat}/kibana-installation.html[More details]
+ * Optionally Logstash for inserting data into Elasticsearch. {libbeat}/logstash-installation.html[More details]
 
 After you have installed these products, you can start <<topbeat-installation>>.
 
@@ -212,7 +212,7 @@ https://github.com/elastic/beats-dashboards[GitHub repository], which also
 includes instructions for loading the dashboards.
 
 You can load all of the sample dashboards automatically by following
-{libbeat}/getting-started.html#load-kibana-dashboards[these steps].
+{libbeat}/kibana-installation.html#load-kibana-dashboards[these steps].
 
 image:./images/topbeat-dashboard.png[Topbeat statistics]
 


### PR DESCRIPTION
Do not merge this PR until you are ready to merge all PRs described in #970. Actually, it looks like the conf.yaml isn't building 1.0.1 (unless I am confused). We might not need this PR after all....

This PR contains changes to fix issues in the 1.0.1 doc due to changing the Beats chunk level to 1 in the conf.yaml.

Changes:
—added float tabs
—updated cross references to libbeat doc
—manually added float tags to fields.asciidoc in some books to get the chunking to work properly 