### PR TITLE
Fix variables in index.asciidoc for libbeat

### DIFF
--- a/libbeat/docs/index.asciidoc
+++ b/libbeat/docs/index.asciidoc
@@ -1,9 +1,9 @@
 [[beats-reference]]
 = Beats Platform Reference
-:packetbeat: http://www.elastic.co/guide/en/beats/packetbeat/1.1
-:topbeat: http://www.elastic.co/guide/en/beats/topbeat/1.1
-:filebeat: http://www.elastic.co/guide/en/beats/filebeat/1.1
-:winlogbeat: http://www.elastic.co/guide/en/beats/winlogbeat/1.1
+:packetbeat: http://www.elastic.co/guide/en/beats/packetbeat/master
+:topbeat: http://www.elastic.co/guide/en/beats/topbeat/master
+:filebeat: http://www.elastic.co/guide/en/beats/filebeat/master
+:winlogbeat: http://www.elastic.co/guide/en/beats/winlogbeat/master
 :ES-version: 2.2.0
 :LS-version: 2.2.0
 :Kibana-version: 4.4.0
@@ -29,5 +29,3 @@ include::./dashboards.asciidoc[]
 include::./newbeat.asciidoc[]
 
 include::./release.asciidoc[]
-
-//include::./../../../beats/CHANGELOG.asciidoc[]


### PR DESCRIPTION
The pointers I added from the Platform Ref to the Beats doc were pointing to the wrong version because the updated file was merged from 1.1. 

Also removed a commented-out line 'cause we don't need it.