### PR TITLE
Begin fixing libbeat GoLint errors

### DIFF
--- a/libbeat/beat/beat.go
+++ b/libbeat/beat/beat.go
@@ -1,6 +1,6 @@
 /*
 
-Beat provides the basic environment for each beat.
+Package beat provides the basic environment for each beat.
 
 Each beat implementation has to implement the beater interface.
 
@@ -54,7 +54,7 @@ type FlagsHandler interface {
 	HandleFlags(*Beat)
 }
 
-// Basic beat information
+// Beat struct contains the basic beat information
 type Beat struct {
 	Name      string
 	Version   string
@@ -79,7 +79,7 @@ const (
 	RunState    = 3
 )
 
-// Basic configuration of every beat
+// BeatConfig struct contains the basic configuration of every beat
 type BeatConfig struct {
 	Output  map[string]outputs.MothershipConfig
 	Logging logp.Logging
@@ -93,7 +93,7 @@ func init() {
 	printVersion = flag.Bool("version", false, "Print version and exit")
 }
 
-// Initiates a new beat object
+// NewBeat initiates a new beat object
 func NewBeat(name string, version string, bt Beater) *Beat {
 	if version == "" {
 		version = defaultBeatVersion
@@ -111,7 +111,7 @@ func NewBeat(name string, version string, bt Beater) *Beat {
 	return &b
 }
 
-// Initiates and runs a new beat object
+// Run initiates and runs a new beat object
 func Run(name string, version string, bt Beater) error {
 
 	b := NewBeat(name, version, bt)
@@ -174,7 +174,7 @@ func (b *Beat) Start() error {
 	return b.Run()
 }
 
-// Reads and parses the default command line params
+// CommandLineSetup reads and parses the default command line params
 // To set additional cmd line args use the beat.CmdLine type before calling the function
 // The second return param is to detect if system should exit. True if should exit
 // Exit can also be without error
@@ -300,7 +300,7 @@ func (b *Beat) Stop() {
 	b.setState(StopState)
 }
 
-// Exiting beat -> shutdown
+// Exit begins exiting the beat and initiating shutdown
 func (b *Beat) Exit() {
 
 	b.callback.Do(func() {
@@ -309,14 +309,14 @@ func (b *Beat) Exit() {
 	})
 }
 
-// Updates the state
+// setState updates the state
 func (b *Beat) setState(state int8) {
 	b.stateMutex.Lock()
 	defer b.stateMutex.Unlock()
 	b.state = state
 }
 
-// Fetches the state
+// getState fetches the state
 func (b *Beat) getState() int8 {
 	b.stateMutex.Lock()
 	defer b.stateMutex.Unlock()

--- a/libbeat/cfgfile/cfgfile.go
+++ b/libbeat/cfgfile/cfgfile.go
@@ -57,12 +57,13 @@ func Read(out interface{}, path string) error {
 	filecontent = expandEnv(filecontent)
 
 	if err = yaml.Unmarshal(filecontent, out); err != nil {
-		return fmt.Errorf("YAML config parsing failed on %s: %v. Exiting.", path, err)
+		return fmt.Errorf("YAML config parsing failed on %s: %v. Exiting", path, err)
 	}
 
 	return nil
 }
 
+// IsTestConfig returns whether or not this is configuration used for testing
 func IsTestConfig() bool {
 	return *testConfig
 }

--- a/libbeat/common/cache.go
+++ b/libbeat/common/cache.go
@@ -18,7 +18,7 @@ type RemovalListener func(k Key, v Value)
 // Clock is the function type used to get the current time.
 type clock func() time.Time
 
-// An element stored in the cache.
+// element represents an element stored in the cache.
 type element struct {
 	expiration time.Time
 	timeout    time.Duration

--- a/libbeat/common/csv.go
+++ b/libbeat/common/csv.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-// Takes a set of fields and rows and returns a string
+// DumpInCSVFormat takes a set of fields and rows and returns a string
 // representing the CSV representation for the fields and rows.
 func DumpInCSVFormat(fields []string, rows [][]string) string {
 

--- a/libbeat/common/datetime.go
+++ b/libbeat/common/datetime.go
@@ -6,10 +6,11 @@ import (
 	"time"
 )
 
-// Layout to be used in the timestamp marshaling/unmarshaling everywhere.
+// TsLayout is the layout to be used in the timestamp marshaling/unmarshaling everywhere.
 // The timezone must always be UTC.
 const TsLayout = "2006-01-02T15:04:05.000Z"
 
+// Time is an abstraction for the time.Time type
 type Time time.Time
 
 // MarshalJSON implements json.Marshaler interface.

--- a/libbeat/common/endpoint.go
+++ b/libbeat/common/endpoint.go
@@ -1,6 +1,6 @@
 package common
 
-// Representing an endpoint in the communication.
+// Endpoint represents an endpoint in the communication.
 type Endpoint struct {
 	Ip      string
 	Port    uint16

--- a/libbeat/common/geolite.go
+++ b/libbeat/common/geolite.go
@@ -9,12 +9,12 @@ import (
 	"github.com/nranchev/go-libGeoIP"
 )
 
+// Geoip represents a string slice of GeoIP paths
 type Geoip struct {
 	Paths *[]string
 }
 
 func LoadGeoIPData(config Geoip) *libgeo.GeoIP {
-
 	geoipPaths := []string{}
 
 	if config.Paths != nil {


### PR DESCRIPTION
This commit begins to fix some of the libbeat golint errors. Some of the errors are not able to be fixed without backward compatibility breaks. For example, line 181 of libbeat/beat/beat.go which has error returned as the first argument instead of the boolean.