### PR TITLE
Update travis testing to use Golang 1.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
 language: go
 
 go:
-  - 1.5.3
+  - 1.6.0
 
 os:
   - linux


### PR DESCRIPTION
Use 1.6.0 for testing