### PR TITLE
Document NetString & MarshalText interface

### DIFF
--- a/libbeat/common/string.go
+++ b/libbeat/common/string.go
@@ -1,10 +1,13 @@
 package common
 
+// NetString store the byte length of the data that follows, making it easier
+// to unambiguously pass text and byte data between programs that could be
+// sensitive to values that could be interpreted as delimiters or terminators
+// (such as a null character).
 type NetString []byte
 
-// implement encoding.TextMarshaller interface to treat []byte as raw string
-// by other encoders/serializers (e.g. JSON)
-
+// MarshalText exists to implement encoding.TextMarshaller interface to
+// treat []byte as raw string by other encoders/serializers (e.g. JSON)
 func (n NetString) MarshalText() ([]byte, error) {
 	return n, nil
 }


### PR DESCRIPTION
This adds GoLint documentation that explains what a netstring is and why the MarshalText function exists.