### PR TITLE
Config file read based on ucfg

### DIFF
--- a/filebeat/beater/spooler_test.go
+++ b/filebeat/beater/spooler_test.go
@@ -4,15 +4,31 @@ import (
 	"testing"
 	"time"
 
+	"github.com/urso/ucfg/yaml"
+
 	cfg "github.com/elastic/beats/filebeat/config"
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v2"
 )
 
-func TestNewSpoolerDefaultConfig(t *testing.T) {
+func load(t *testing.T, in string) cfg.FilebeatConfig {
+	yaml, err := yaml.NewConfig([]byte(in))
+	if err != nil {
+		t.Fatalf("Failed to parse config input: %v", err)
+	}
+
 	var config cfg.FilebeatConfig
+	err = yaml.Unpack(&config)
+	if err != nil {
+		t.Fatalf("Failed to unpack config: %v", err)
+	}
+
+	return config
+}
+
+func TestNewSpoolerDefaultConfig(t *testing.T) {
+	config := load(t, "")
+
 	// Read from empty yaml config
-	yaml.Unmarshal([]byte(""), &config)
 	spooler := NewSpooler(config, nil)
 
 	assert.Equal(t, cfg.DefaultSpoolSize, spooler.spoolSize)
@@ -28,8 +44,7 @@ func TestNewSpoolerSpoolSize(t *testing.T) {
 }
 
 func TestNewSpoolerIdleTimeout(t *testing.T) {
-	var config cfg.FilebeatConfig
-	yaml.Unmarshal([]byte("idle_timeout: 10s"), &config)
+	config := load(t, "idle_timeout: 10s")
 	spooler := NewSpooler(config, nil)
 
 	assert.Equal(t, time.Duration(10*time.Second), spooler.idleTimeout)

--- a/filebeat/config/config.go
+++ b/filebeat/config/config.go
@@ -37,53 +37,53 @@ type Config struct {
 
 type FilebeatConfig struct {
 	Prospectors  []ProspectorConfig
-	SpoolSize    uint64        `yaml:"spool_size"`
-	PublishAsync bool          `yaml:"publish_async"`
-	IdleTimeout  time.Duration `yaml:"idle_timeout"`
-	RegistryFile string        `yaml:"registry_file"`
-	ConfigDir    string        `yaml:"config_dir"`
+	SpoolSize    uint64        `config:"spool_size"`
+	PublishAsync bool          `config:"publish_async"`
+	IdleTimeout  time.Duration `config:"idle_timeout"`
+	RegistryFile string        `config:"registry_file"`
+	ConfigDir    string        `config:"config_dir"`
 }
 
 type ProspectorConfig struct {
-	ExcludeFiles          []string `yaml:"exclude_files"`
+	ExcludeFiles          []string `config:"exclude_files"`
 	ExcludeFilesRegexp    []*regexp.Regexp
-	Harvester             HarvesterConfig `yaml:",inline"`
+	Harvester             HarvesterConfig `config:",inline"`
 	Input                 string
-	IgnoreOlder           string `yaml:"ignore_older"`
+	IgnoreOlder           string `config:"ignore_older"`
 	IgnoreOlderDuration   time.Duration
 	Paths                 []string
-	ScanFrequency         string `yaml:"scan_frequency"`
+	ScanFrequency         string `config:"scan_frequency"`
 	ScanFrequencyDuration time.Duration
 }
 
 type HarvesterConfig struct {
-	BufferSize         int    `yaml:"harvester_buffer_size"`
-	DocumentType       string `yaml:"document_type"`
-	Encoding           string `yaml:"encoding"`
+	BufferSize         int    `config:"harvester_buffer_size"`
+	DocumentType       string `config:"document_type"`
+	Encoding           string `config:"encoding"`
 	Fields             common.MapStr
-	FieldsUnderRoot    bool   `yaml:"fields_under_root"`
-	InputType          string `yaml:"input_type"`
-	TailFiles          bool   `yaml:"tail_files"`
-	Backoff            string `yaml:"backoff"`
+	FieldsUnderRoot    bool   `config:"fields_under_root"`
+	InputType          string `config:"input_type"`
+	TailFiles          bool   `config:"tail_files"`
+	Backoff            string `config:"backoff"`
 	BackoffDuration    time.Duration
-	BackoffFactor      int    `yaml:"backoff_factor"`
-	MaxBackoff         string `yaml:"max_backoff"`
+	BackoffFactor      int    `config:"backoff_factor"`
+	MaxBackoff         string `config:"max_backoff"`
 	MaxBackoffDuration time.Duration
-	CloseOlder         string `yaml:"close_older"`
+	CloseOlder         string `config:"close_older"`
 	CloseOlderDuration time.Duration
-	ForceCloseFiles    bool             `yaml:"force_close_files"`
-	ExcludeLines       []string         `yaml:"exclude_lines"`
-	IncludeLines       []string         `yaml:"include_lines"`
-	MaxBytes           int              `yaml:"max_bytes"`
-	Multiline          *MultilineConfig `yaml:"multiline"`
+	ForceCloseFiles    bool             `config:"force_close_files"`
+	ExcludeLines       []string         `config:"exclude_lines"`
+	IncludeLines       []string         `config:"include_lines"`
+	MaxBytes           int              `config:"max_bytes"`
+	Multiline          *MultilineConfig `config:"multiline"`
 }
 
 type MultilineConfig struct {
-	Negate   bool   `yaml:"negate"`
-	Match    string `yaml:"match"`
-	MaxLines *int   `yaml:"max_lines"`
-	Pattern  string `yaml:"pattern"`
-	Timeout  string `yaml:"timeout"`
+	Negate   bool   `config:"negate"`
+	Match    string `config:"match"`
+	MaxLines *int   `config:"max_lines"`
+	Pattern  string `config:"pattern"`
+	Timeout  string `config:"timeout"`
 }
 
 const (

--- a/filebeat/config/config_test.go
+++ b/filebeat/config/config_test.go
@@ -33,7 +33,7 @@ func TestReadConfig(t *testing.T) {
 	assert.Equal(t, "/var/log/s*.log", prospectors[0].Paths[1])
 	assert.Equal(t, "log", prospectors[0].Input)
 	assert.Equal(t, 3, len(prospectors[0].Harvester.Fields))
-	assert.Equal(t, "1", prospectors[0].Harvester.Fields["review"])
+	assert.Equal(t, int64(1), prospectors[0].Harvester.Fields["review"])
 	assert.Equal(t, "0", prospectors[0].IgnoreOlder)
 	assert.Equal(t, "1h", prospectors[0].Harvester.CloseOlder)
 	assert.Equal(t, "10s", prospectors[0].ScanFrequency)

--- a/filebeat/tests/system/test_fields.py
+++ b/filebeat/tests/system/test_fields.py
@@ -56,7 +56,7 @@ class Test(BaseTest):
         print doc
         assert doc["hello"] == "world"
         assert doc["type"] == "log2"
-        assert doc["timestamp"] == "2"
+        assert doc["timestamp"] == 2
         assert "fields" not in doc
 
     def test_beat_fields(self):

--- a/libbeat/cfgfile/cfgfile.go
+++ b/libbeat/cfgfile/cfgfile.go
@@ -8,8 +8,10 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/urso/ucfg"
+	"github.com/urso/ucfg/yaml"
+
 	"github.com/elastic/beats/libbeat/logp"
-	"gopkg.in/yaml.v2"
 )
 
 // Command line flags
@@ -53,13 +55,17 @@ func Read(out interface{}, path string) error {
 	if err != nil {
 		return fmt.Errorf("Failed to read %s: %v. Exiting.", path, err)
 	}
-
 	filecontent = expandEnv(filecontent)
 
-	if err = yaml.Unmarshal(filecontent, out); err != nil {
-		return fmt.Errorf("YAML config parsing failed on %s: %v. Exiting", path, err)
+	config, err := yaml.NewConfig(filecontent, ucfg.PathSep("."))
+	if err != nil {
+		return fmt.Errorf("YAML config parsing failed on %s: %v. Exiting.", path, err)
 	}
 
+	err = config.Unpack(out, ucfg.PathSep("."))
+	if err != nil {
+		return fmt.Errorf("Failed to apply config %s: %v. Exiting. ", path, err)
+	}
 	return nil
 }
 

--- a/libbeat/common/datetime_test.go
+++ b/libbeat/common/datetime_test.go
@@ -28,20 +28,6 @@ func TestParseTime(t *testing.T) {
 			Input:  "2015-02-28T11:19:05.112Z",
 			Output: time.Date(2015, time.February, 28, 11, 19, 05, 112*1e6, time.UTC),
 		},
-		// Golang time pkg happily parses 'wrong' dates like these.
-		// Just to have in mind.
-		{
-			Input:  "2015-02-29T11:19:05.112Z",
-			Output: time.Date(2015, time.March, 01, 11, 19, 05, 112*1e6, time.UTC),
-		},
-		{
-			Input:  "2015-03-31T11:19:05.112Z",
-			Output: time.Date(2015, time.March, 31, 11, 19, 05, 112*1e6, time.UTC),
-		},
-		{
-			Input:  "2015-04-31T11:19:05.112Z",
-			Output: time.Date(2015, time.April, 31, 11, 19, 05, 112*1e6, time.UTC),
-		},
 	}
 
 	for _, test := range tests {

--- a/libbeat/logp/logp.go
+++ b/libbeat/logp/logp.go
@@ -17,8 +17,8 @@ var debugSelectorsStr *string
 type Logging struct {
 	Selectors []string
 	Files     *FileRotator
-	ToSyslog  *bool `yaml:"to_syslog"`
-	ToFiles   *bool `yaml:"to_files"`
+	ToSyslog  *bool `config:"to_syslog"`
+	ToFiles   *bool `config:"to_files"`
 	Level     string
 }
 

--- a/libbeat/outputs/outputs.go
+++ b/libbeat/outputs/outputs.go
@@ -6,42 +6,42 @@ import (
 )
 
 type MothershipConfig struct {
-	SaveTopology      bool `yaml:"save_topology"`
+	SaveTopology      bool `config:"save_topology"`
 	Host              string
 	Port              int
 	Hosts             []string
-	LoadBalance       *bool `yaml:"loadbalance"`
+	LoadBalance       *bool `config:"loadbalance"`
 	Protocol          string
 	Username          string
 	Password          string
-	ProxyURL          string `yaml:"proxy_url"`
+	ProxyURL          string `config:"proxy_url"`
 	Index             string
 	Path              string
 	Template          Template
-	Params            map[string]string `yaml:"parameters"`
+	Params            map[string]string `config:"parameters"`
 	Db                int
-	DbTopology        int `yaml:"db_topology"`
+	DbTopology        int `config:"db_topology"`
 	Timeout           int
-	ReconnectInterval int    `yaml:"reconnect_interval"`
-	Filename          string `yaml:"filename"`
-	RotateEveryKb     int    `yaml:"rotate_every_kb"`
-	NumberOfFiles     int    `yaml:"number_of_files"`
+	ReconnectInterval int    `config:"reconnect_interval"`
+	Filename          string `config:"filename"`
+	RotateEveryKb     int    `config:"rotate_every_kb"`
+	NumberOfFiles     int    `config:"number_of_files"`
 	DataType          string
-	FlushInterval     *int  `yaml:"flush_interval"`
-	BulkMaxSize       *int  `yaml:"bulk_max_size"`
-	MaxRetries        *int  `yaml:"max_retries"`
-	Pretty            *bool `yaml:"pretty"`
+	FlushInterval     *int  `config:"flush_interval"`
+	BulkMaxSize       *int  `config:"bulk_max_size"`
+	MaxRetries        *int  `config:"max_retries"`
+	Pretty            *bool `config:"pretty"`
 	TLS               *TLSConfig
 	Worker            int
-	CompressionLevel  *int   `yaml:"compression_level"`
-	KeepAlive         string `yaml:"keep_alive"`
-	MaxMessageBytes   *int   `yaml:"max_message_bytes"`
-	RequiredACKs      *int   `yaml:"required_acks"`
-	BrokerTimeout     string `yaml:"broker_timeout"`
-	Compression       string `yaml:"compression"`
-	ClientID          string `yaml:"client_id"`
-	Topic             string `yaml:"topic"`
-	UseType           *bool  `yaml:"use_type"`
+	CompressionLevel  *int   `config:"compression_level"`
+	KeepAlive         string `config:"keep_alive"`
+	MaxMessageBytes   *int   `config:"max_message_bytes"`
+	RequiredACKs      *int   `config:"required_acks"`
+	BrokerTimeout     string `config:"broker_timeout"`
+	Compression       string `config:"compression"`
+	ClientID          string `config:"client_id"`
+	Topic             string `config:"topic"`
+	UseType           *bool  `config:"use_type"`
 }
 
 type Template struct {

--- a/libbeat/outputs/tls.go
+++ b/libbeat/outputs/tls.go
@@ -32,14 +32,14 @@ var (
 
 // TLSConfig defines config file options for TLS clients.
 type TLSConfig struct {
-	Certificate    string   `yaml:"certificate"`
-	CertificateKey string   `yaml:"certificate_key"`
-	CAs            []string `yaml:"certificate_authorities"`
-	Insecure       bool     `yaml:"insecure,omitempty"`
-	CipherSuites   []string `yaml:"cipher_suites"`
-	MinVersion     string   `yaml:"min_version,omitempty"`
-	MaxVersion     string   `yaml:"max_version,omitempty"`
-	CurveTypes     []string `yaml:"curve_types"`
+	Certificate    string   `config:"certificate"`
+	CertificateKey string   `config:"certificate_key"`
+	CAs            []string `config:"certificate_authorities"`
+	Insecure       bool     `config:"insecure"`
+	CipherSuites   []string `config:"cipher_suites"`
+	MinVersion     string   `config:"min_version"`
+	MaxVersion     string   `config:"max_version"`
+	CurveTypes     []string `config:"curve_types"`
 }
 
 // LoadTLSConfig will load a certificate from config with all TLS based keys

--- a/libbeat/outputs/tls_test.go
+++ b/libbeat/outputs/tls_test.go
@@ -4,16 +4,21 @@ import (
 	"crypto/tls"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/urso/ucfg/yaml"
 
-	"gopkg.in/yaml.v2"
+	"github.com/stretchr/testify/assert"
 )
 
 // test TLS config loading
 
 func load(yamlStr string) (*TLSConfig, error) {
 	var cfg TLSConfig
-	if err := yaml.Unmarshal([]byte(yamlStr), &cfg); err != nil {
+	config, err := yaml.NewConfig([]byte(yamlStr))
+	if err != nil {
+		return nil, err
+	}
+
+	if err = config.Unpack(&cfg); err != nil {
 		return nil, err
 	}
 	return &cfg, nil

--- a/libbeat/publisher/publish.go
+++ b/libbeat/publisher/publish.go
@@ -7,10 +7,11 @@ import (
 	"os"
 	"time"
 
+	"github.com/nranchev/go-libGeoIP"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/outputs"
-	"github.com/nranchev/go-libGeoIP"
 
 	// load supported output plugins
 	_ "github.com/elastic/beats/libbeat/outputs/console"
@@ -84,10 +85,9 @@ type ShipperConfig struct {
 	Geoip                 common.Geoip
 
 	// internal publisher queue sizes
-	QueueSize     *int `yaml:"queue_size"`
-	BulkQueueSize *int `yaml:"bulk_queue_size"`
-
-	MaxProcs *int `yaml:"max_procs"`
+	QueueSize     *int `config:"queue_size"`
+	BulkQueueSize *int `config:"bulk_queue_size"`
+	MaxProcs      *int `config:"max_procs"`
 }
 
 type Topology struct {

--- a/packetbeat/config/config.go
+++ b/packetbeat/config/config.go
@@ -53,35 +53,35 @@ type Protocols struct {
 }
 
 type ProtocolCommon struct {
-	Ports              []int `yaml:"ports"`
-	SendRequest        *bool `yaml:"send_request"`
-	SendResponse       *bool `yaml:"send_response"`
-	TransactionTimeout *int  `yaml:"transaction_timeout"`
+	Ports              []int `config:"ports"`
+	SendRequest        *bool `config:"send_request"`
+	SendResponse       *bool `config:"send_response"`
+	TransactionTimeout *int  `config:"transaction_timeout"`
 }
 
 type Icmp struct {
 	Enabled            bool
-	SendRequest        *bool `yaml:"send_request"`
-	SendResponse       *bool `yaml:"send_response"`
-	TransactionTimeout *int  `yaml:"transaction_timeout"`
+	SendRequest        *bool `config:"send_request"`
+	SendResponse       *bool `config:"send_response"`
+	TransactionTimeout *int  `config:"transaction_timeout"`
 }
 
 type Amqp struct {
-	ProtocolCommon            `yaml:",inline"`
-	ParseHeaders              *bool `yaml:"parse_headers"`
-	ParseArguments            *bool `yaml:"parse_arguments"`
-	MaxBodyLength             *int  `yaml:"max_body_length"`
-	HideConnectionInformation *bool `yaml:"hide_connection_information"`
+	ProtocolCommon            `config:",inline"`
+	ParseHeaders              *bool `config:"parse_headers"`
+	ParseArguments            *bool `config:"parse_arguments"`
+	MaxBodyLength             *int  `config:"max_body_length"`
+	HideConnectionInformation *bool `config:"hide_connection_information"`
 }
 
 type Dns struct {
-	ProtocolCommon      `yaml:",inline"`
+	ProtocolCommon      `config:",inline"`
 	Include_authorities *bool
 	Include_additionals *bool
 }
 
 type Http struct {
-	ProtocolCommon       `yaml:",inline"`
+	ProtocolCommon       `config:",inline"`
 	Send_all_headers     *bool
 	Send_headers         []string
 	Split_cookie         *bool
@@ -92,7 +92,7 @@ type Http struct {
 }
 
 type Memcache struct {
-	ProtocolCommon        `yaml:",inline"`
+	ProtocolCommon        `config:",inline"`
 	MaxValues             int
 	MaxBytesPerValue      int
 	UdpTransactionTimeout *int
@@ -100,25 +100,25 @@ type Memcache struct {
 }
 
 type Mysql struct {
-	ProtocolCommon `yaml:",inline"`
+	ProtocolCommon `config:",inline"`
 	Max_row_length *int
 	Max_rows       *int
 }
 
 type Mongodb struct {
-	ProtocolCommon `yaml:",inline"`
+	ProtocolCommon `config:",inline"`
 	Max_doc_length *int
 	Max_docs       *int
 }
 
 type Pgsql struct {
-	ProtocolCommon `yaml:",inline"`
+	ProtocolCommon `config:",inline"`
 	Max_row_length *int
 	Max_rows       *int
 }
 
 type Thrift struct {
-	ProtocolCommon             `yaml:",inline"`
+	ProtocolCommon             `config:",inline"`
 	String_max_size            *int
 	Collection_max_size        *int
 	Drop_after_n_struct_fields *int
@@ -130,7 +130,7 @@ type Thrift struct {
 }
 
 type Redis struct {
-	ProtocolCommon `yaml:",inline"`
+	ProtocolCommon `config:",inline"`
 }
 
 // Config Singleton

--- a/topbeat/beater/config.go
+++ b/topbeat/beater/config.go
@@ -4,10 +4,10 @@ type TopConfig struct {
 	Period *int64
 	Procs  *[]string
 	Stats  struct {
-		System     *bool `yaml:"system"`
-		Proc       *bool `yaml:"process"`
-		Filesystem *bool `yaml:"filesystem"`
-		CpuPerCore *bool `yaml:"cpu_per_core"`
+		System     *bool `config:"system"`
+		Proc       *bool `config:"process"`
+		Filesystem *bool `config:"filesystem"`
+		CpuPerCore *bool `config:"cpu_per_core"`
 	}
 }
 

--- a/winlogbeat/checkpoint/checkpoint.go
+++ b/winlogbeat/checkpoint/checkpoint.go
@@ -35,15 +35,15 @@ type Checkpoint struct {
 
 // PersistedState represents the format of the data persisted to disk.
 type PersistedState struct {
-	UpdateTime time.Time       `yaml:"update_time"`
-	States     []EventLogState `yaml:"event_logs"`
+	UpdateTime time.Time       `config:"update_time"`
+	States     []EventLogState `config:"event_logs"`
 }
 
 // EventLogState represents the state of an individual event log.
 type EventLogState struct {
-	Name         string    `yaml:"name"`
-	RecordNumber uint64    `yaml:"record_number"`
-	Timestamp    time.Time `yaml:"timestamp"`
+	Name         string    `config:"name"`
+	RecordNumber uint64    `config:"record_number"`
+	Timestamp    time.Time `config:"timestamp"`
 }
 
 // NewCheckpoint creates and returns a new Checkpoint. This method loads state

--- a/winlogbeat/config/config.go
+++ b/winlogbeat/config/config.go
@@ -32,10 +32,10 @@ type Settings struct {
 
 // WinlogbeatConfig contains all of Winlogbeat configuration data.
 type WinlogbeatConfig struct {
-	IgnoreOlder  string           `yaml:"ignore_older"`
-	EventLogs    []EventLogConfig `yaml:"event_logs"`
-	Metrics      MetricsConfig    `yaml:"metrics"`
-	RegistryFile string           `yaml:"registry_file"`
+	IgnoreOlder  string           `config:"ignore_older"`
+	EventLogs    []EventLogConfig `config:"event_logs"`
+	Metrics      MetricsConfig    `config:"metrics"`
+	RegistryFile string           `config:"registry_file"`
 }
 
 // Validate validates the WinlogbeatConfig data and returns an error describing
@@ -106,7 +106,7 @@ func (mc MetricsConfig) Validate() error {
 // to monitor.
 type EventLogConfig struct {
 	Name        string
-	IgnoreOlder string `yaml:"ignore_older"`
+	IgnoreOlder string `config:"ignore_older"`
 	API         string
 }
 


### PR DESCRIPTION
Use ucfg to parse configuration files and populate configuration.

Introduces support for dotted names in config files. e.g. use `output.elasticsearch.hosts: [...]` instead of indents.

based on #973 adding ucfg to beats