### PR TITLE
Metricbeat config refactoring

### DIFF
--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -121,7 +121,7 @@ unit-tests: prepare-tests
 # Runs the unit tests without coverage reports.
 .PHONY: unit
 unit:
-	go test $(RACE) -short ./...
+	go test $(RACE) -short ${GOPACKAGES}
 
 # Run integration tests. Unit tests are run as part of the integration tests.
 .PHONY: integration-tests

--- a/metricbeat/beater/config.go
+++ b/metricbeat/beater/config.go
@@ -4,27 +4,10 @@ import (
 	"github.com/elastic/beats/metricbeat/helper"
 )
 
+type Config struct {
+	Metricbeat MetricbeatConfig
+}
+
 type MetricbeatConfig struct {
-	Metricbeat helper.ModulesConfig
-}
-
-// Raw module config to be processed later by the module
-type RawModulesConfig struct {
-	Metricbeat struct {
-		Modules map[string]interface{}
-	}
-}
-
-// Raw metric config to be processed later by the metric
-type RawMetricsConfig struct {
-	Metricbeat struct {
-		Modules map[string]struct {
-			MetricSets map[string]interface{} `yaml:"metricsets"`
-		}
-	}
-}
-
-// getModuleConfig returns config for the specified module
-func (config *MetricbeatConfig) getModuleConfig(moduleName string) helper.ModuleConfig {
-	return config.Metricbeat.Modules[moduleName]
+	Modules []helper.ModuleConfig
 }

--- a/metricbeat/beater/metricbeat.go
+++ b/metricbeat/beater/metricbeat.go
@@ -27,8 +27,6 @@ for each MetricSet to prevent type conflicts. Also all values are stored under t
 package beater
 
 import (
-	"fmt"
-
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/cfgfile"
 	"github.com/elastic/beats/libbeat/logp"
@@ -36,10 +34,8 @@ import (
 )
 
 type Metricbeat struct {
-	done          chan struct{}
-	MbConfig      *MetricbeatConfig
-	ModulesConfig *RawModulesConfig
-	MetricsConfig *RawMetricsConfig
+	done     chan struct{}
+	MbConfig *Config
 }
 
 // New creates a new Metricbeat instance
@@ -49,50 +45,11 @@ func New() *Metricbeat {
 
 func (mb *Metricbeat) Config(b *beat.Beat) error {
 
-	mb.MbConfig = &MetricbeatConfig{}
+	mb.MbConfig = &Config{}
 	err := cfgfile.Read(mb.MbConfig, "")
 	if err != nil {
-		fmt.Println(err)
 		logp.Err("Error reading configuration file: %v", err)
 		return err
-	}
-
-	mb.ModulesConfig = &RawModulesConfig{}
-	err = cfgfile.Read(mb.ModulesConfig, "")
-	if err != nil {
-		fmt.Println(err)
-		logp.Err("Error reading configuration file: %v", err)
-		return err
-	}
-
-	mb.MetricsConfig = &RawMetricsConfig{}
-	err = cfgfile.Read(mb.MetricsConfig, "")
-	if err != nil {
-		fmt.Println(err)
-		logp.Err("Error reading configuration file: %v", err)
-		return err
-	}
-
-	logp.Info("Setup base and raw configuration for Modules and Metrics")
-	// Apply the base configuration to each module and metric
-	for moduleName, module := range helper.Registry {
-		// Check if config for module exist. Only configured modules are loaded
-		if _, ok := mb.MbConfig.Metricbeat.Modules[moduleName]; !ok {
-			continue
-		}
-		module.BaseConfig = mb.MbConfig.getModuleConfig(moduleName)
-		module.RawConfig = mb.ModulesConfig.Metricbeat.Modules[moduleName]
-		module.Enabled = true
-
-		for metricSetName, metricSet := range module.MetricSets {
-			// Check if config for metricset exist. Only configured metricset are loaded
-			if _, ok := mb.MbConfig.getModuleConfig(moduleName).MetricSets[metricSetName]; !ok {
-				continue
-			}
-			metricSet.BaseConfig = mb.MbConfig.getModuleConfig(moduleName).MetricSets[metricSetName]
-			metricSet.RawConfig = mb.MetricsConfig.Metricbeat.Modules[moduleName].MetricSets[metricSetName]
-			metricSet.Enabled = true
-		}
 	}
 
 	return nil
@@ -105,7 +62,17 @@ func (mb *Metricbeat) Setup(b *beat.Beat) error {
 
 func (mb *Metricbeat) Run(b *beat.Beat) error {
 
-	helper.StartModules(b)
+	// Checks all defined metricsets and starts a module for each entry with the defined metricsets
+	for _, moduleConfig := range mb.MbConfig.Metricbeat.Modules {
+
+		module, err := helper.Registry.GetModule(moduleConfig)
+		if err != nil {
+			return err
+		}
+
+		module.Start(b)
+	}
+
 	<-mb.done
 
 	return nil

--- a/metricbeat/etc/beat.yml
+++ b/metricbeat/etc/beat.yml
@@ -1,25 +1,21 @@
 metricbeat:
   modules:
-    #golang:
-    #  metrics:
-    #    expvar:
-    #      period: 10s
-    apache:
+    - module: apache
+      metricsets: ["status"]
       hosts: ["http://127.0.0.1/"]
-      metricsets:
-        status:
-          period: 1s
-    redis:
-      hosts:
-        - "127.0.0.1:6379"
-      metricsets:
-        info:
-          period: 1s
-    mysql:
-      # This expectd a full mysql dsn
-      # Example: [username[:password]@][protocol[(address)]]/
-      hosts:
-        - "root@tcp(127.0.0.1:3306)/"
-      metricsets:
-        status:
-          period: 1s
+      period: 1s
+      #fields: ["aaa", "bbb"]
+      enabled: true
+    - module: redis
+      metricsets: ["info"]
+      period: 1s
+      hosts: ["127.0.0.1:6379"]
+      enabled: true
+      #filter: ...
+      #username: name
+      #password: hello world
+    - module: mysql
+      metricsets: ["status"]
+      enabled: true
+      period: 2s
+      hosts: ["root@tcp(127.0.0.1:3306)/"]

--- a/metricbeat/helper/interfacer.go
+++ b/metricbeat/helper/interfacer.go
@@ -1,0 +1,30 @@
+package helper
+
+import "github.com/elastic/beats/libbeat/common"
+
+// Base configuration for each module/metricsets combination
+type ModuleConfig struct {
+	Hosts      []string
+	Period     string
+	Module     string
+	MetricSets []string
+	Enabled    bool
+}
+
+// Interface for each metric
+type MetricSeter interface {
+	// Setup needed for all upcoming fetches
+	// Typically special config varialbes are loaded here
+	Setup() error
+
+	// Method to periodically fetch new events
+	Fetch(m *MetricSet) ([]common.MapStr, error)
+
+	// Cleanup when stopping metricset
+	Cleanup() error
+}
+
+// Interface for each module
+type Moduler interface {
+	Setup() error
+}

--- a/metricbeat/helper/metricset.go
+++ b/metricbeat/helper/metricset.go
@@ -1,195 +1,97 @@
 package helper
 
 import (
-	"github.com/elastic/beats/libbeat/beat"
+	"time"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
-	"gopkg.in/yaml.v2"
-	"sync"
-	"time"
 )
-
-// Base metric configuration
-type MetricSetConfig struct {
-	Period string
-}
 
 // Metric specific data
 // This must be defined by each metric
 type MetricSet struct {
-	Name    string
-	Enabled bool
-
-	// Generic Config existing in all metrics
-	BaseConfig MetricSetConfig
-
-	// Raw metric specific config
-	// This is provided to convert it into Config later
-	RawConfig interface{}
-
-	// Metric specific config
-	Config interface{}
-
+	Name        string
 	MetricSeter MetricSeter
-	Module      *Module
-
-	// Control channel
-	done chan struct{}
-}
-
-// Interface for each metric
-type MetricSeter interface {
-	// Setup needed for all upcoming fetches
-	// Typically config is loaded here
-	Setup() error
-
-	// Method to periodically fetch new events
-	Fetch() ([]common.MapStr, error)
-
-	// Cleanup when stopping metricset
-	Cleanup() error
+	// Inherits config from module
+	Config ModuleConfig
 }
 
 // Creates a new MetricSet
-func NewMetricSet(name string, metricset MetricSeter, module *Module) *MetricSet {
+func NewMetricSet(name string, metricset MetricSeter, config ModuleConfig) *MetricSet {
 	return &MetricSet{
 		Name:        name,
 		MetricSeter: metricset,
-		Module:      module,
-		Enabled:     false,
-		done:        make(chan struct{}),
+		Config:      config,
 	}
 }
 
-func (m *MetricSet) LoadConfig(config interface{}) {
+// RunMetric runs the given metricSet and returns the event
+func (m *MetricSet) Fetch() ([]common.MapStr, error) {
 
-	bytes, err := yaml.Marshal(m.RawConfig)
-
-	if err != nil {
-		logp.Err("Load metric config error: %v", err)
-	}
-	yaml.Unmarshal(bytes, config)
-}
-
-// Registers metric with module
-func (m *MetricSet) Register() {
-	m.Module.AddMetric(m)
-}
-
-// RunMetric runs the given metric
-func (m *MetricSet) Start(b *beat.Beat, wg sync.WaitGroup) {
-
-	// Catches metric in case of panic. Keeps other metricsets running
-	defer func() {
-		if r := recover(); r != nil {
-			logp.Err("Metric %s paniced and stopped running. Reason: %+v", m.Name, r)
-		}
-		wg.Done()
-	}()
-
-	// Only starts metricset if enabled
-	if !m.Enabled {
-		logp.Debug("helper", "Not starting metric %s as not enabled.", m.Name)
-		return
-	}
-
-	// Setup
-	err := m.MetricSeter.Setup()
-	if err != nil {
-		logp.Err("Error happening during metricseter setup: %s", err)
-	}
-	period, err := time.ParseDuration(m.BaseConfig.Period)
+	events, err := m.MetricSeter.Fetch(m)
 
 	if err != nil {
-		logp.Info("Error in parsing period of metric %s: %v", m.Name, err)
+		return nil, err
 	}
+	newEvents := []common.MapStr{}
 
-	// If no period set, set default
-	if period == 0 {
-		logp.Info("Setting default period for metric %s as not set.", m.Name)
-		period = 1 * time.Second
-	}
+	// Default names based on module and metric
+	// These can be overwritten by setting index or / and type in the event
+	indexName := ""
 
-	ticker := time.NewTicker(period)
-	defer ticker.Stop()
+	// Type is the same for all metricsets
+	typeName := "metricsets"
+	timestamp := common.Time(time.Now())
 
-	logp.Info("Start metric %s with period %v", m.Name, period)
-
-	for {
-		select {
-		case <-m.done:
-			logp.Info("Stopping metricset: %s", m.Name)
-			return
-		case <-ticker.C:
+	for _, event := range events {
+		// Set index from event if set
+		if _, ok := event["index"]; ok {
+			indexName, ok = event["index"].(string)
+			if !ok {
+				logp.Err("Index couldn't be overwritten because event index is not string")
+			}
+			delete(event, "index")
 		}
 
-		events, err := m.MetricSeter.Fetch()
-		if err != nil {
-			logp.Err("Fetching events in MetricSet %s returned error: %s", m.Name, err)
-			continue
-		}
-		newEvents := []common.MapStr{}
-
-		// Default names based on module and metric
-		// These can be overwritten by setting index or / and type in the event
-		indexName := ""
-
-		// Type is the same for all metricsets
-		typeName := "metricsets"
-		timestamp := common.Time(time.Now())
-
-		for _, event := range events {
-			// Set index from event if set
-			if _, ok := event["index"]; ok {
-				indexName = event["index"].(string)
-				delete(event, "index")
+		// Set type from event if set
+		if _, ok := event["type"]; ok {
+			typeName, ok = event["type"].(string)
+			if !ok {
+				logp.Err("Type couldn't be overwritten because event type is not string")
 			}
-
-			// Set type from event if set
-			if _, ok := event["type"]; ok {
-				typeName = event["type"].(string)
-				delete(event, "type")
-			}
-
-			// Set timestamp from event if set, move it to the top level
-			// If not set, timestamp is created
-			if _, ok := event["@timestamp"]; ok {
-				timestamp = event["@timestamp"].(common.Time)
-				delete(event, "@timestamp")
-			}
-
-			eventFieldName := m.Module.Name + "-" + m.Name
-			// TODO: Add fields_under_root option for "metrics"?
-			event = common.MapStr{
-				"type":         typeName,
-				eventFieldName: event,
-				"metricset":    m.Name,
-				"module":       m.Module.Name,
-				"@timestamp":   timestamp,
-			}
-
-			// Overwrite index in case it is set
-			if indexName != "" {
-				event["beat"] = common.MapStr{
-					"index": indexName,
-				}
-			}
-
-			newEvents = append(newEvents, event)
+			delete(event, "type")
 		}
 
-		// Async publishing of event
-		b.Events.PublishEvents(newEvents)
-	}
-}
+		// Set timestamp from event if set, move it to the top level
+		// If not set, timestamp is created
+		if _, ok := event["@timestamp"]; ok {
+			timestamp, ok = event["@timestamp"].(common.Time)
+			if !ok {
+				logp.Err("Timestamp couldn't be overwritten because event @timestamp is not common.Time")
+			}
+			delete(event, "@timestamp")
+		}
 
-// Stop stops the metricset
-func (m *MetricSet) Stop() {
-	logp.Info("Stopping metricset: %s", m.Name)
-	close(m.done)
+		eventFieldName := m.Config.Module + "-" + m.Name
 
-	err := m.MetricSeter.Cleanup()
-	if err != nil {
-		logp.Err("Error cleaning up metricset %s: %s", m.Name, err)
+		// TODO: Add fields_under_root option for "metrics"?
+		event = common.MapStr{
+			"type":         typeName,
+			eventFieldName: event,
+			"metricset":    m.Name,
+			"module":       m.Config.Module,
+			"@timestamp":   timestamp,
+		}
+
+		// Overwrite index in case it is set
+		if indexName != "" {
+			event["beat"] = common.MapStr{
+				"index": indexName,
+			}
+		}
+
+		newEvents = append(newEvents, event)
 	}
+
+	return newEvents, nil
 }

--- a/metricbeat/helper/register.go
+++ b/metricbeat/helper/register.go
@@ -1,28 +1,58 @@
 package helper
 
 import (
-	"github.com/elastic/beats/libbeat/beat"
+	"fmt"
+	"github.com/elastic/beats/libbeat/logp"
 )
 
-// Global register for modules and metrics
-// Each module name must be unique
-// Each module-metric name combination must be unique
+// Global register for moduler and metricseter
+// The Register keeps a global list of moduler and metricseter
+// A copy of the moduler or metricset instance can be used to create a module or metricset
 
 // TODO: Global variables should be prevent.
 // 	This should be moved into the metricbeat object but can't because the init()
 //	functions in each metricset are called before the beater object exists.
 var Registry = Register{}
 
-type Register map[string]*Module
-
-// StartModules starts all configured modules
-func StartModules(b *beat.Beat) {
-	for _, module := range Registry {
-		go module.Start(b)
-	}
+type Register struct {
+	Modulers     map[string]Moduler
+	MetricSeters map[string]map[string]MetricSeter
 }
 
 // AddModule registers the given module with the registry
-func (r Register) AddModule(m *Module) {
-	r[m.Name] = m
+func (r *Register) AddModuler(name string, m Moduler) {
+
+	if r.Modulers == nil {
+		r.Modulers = map[string]Moduler{}
+	}
+
+	logp.Info("Register module: %s", name)
+
+	r.Modulers[name] = m
+}
+
+func (r *Register) AddMetricSeter(module string, name string, m MetricSeter) {
+
+	if r.MetricSeters == nil {
+		r.MetricSeters = map[string]map[string]MetricSeter{}
+	}
+
+	if _, ok := r.MetricSeters[module]; !ok {
+		r.MetricSeters[module] = map[string]MetricSeter{}
+	}
+
+	logp.Info("Register metricset %s for module %s", name, module)
+
+	r.MetricSeters[module][name] = m
+}
+
+// GetModule returns a new module instance for the given moduler name
+func (r *Register) GetModule(config ModuleConfig) (*Module, error) {
+	moduler, ok := Registry.Modulers[config.Module]
+
+	if !ok {
+		return nil, fmt.Errorf("Module %s does not exist", config.Module)
+	}
+
+	return NewModule(config, moduler), nil
 }

--- a/metricbeat/helper/register_test.go
+++ b/metricbeat/helper/register_test.go
@@ -1,0 +1,20 @@
+package helper
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetModuleInvalid(t *testing.T) {
+
+	registry := Register{}
+
+	config := ModuleConfig{
+		Module: "test",
+	}
+	module, err := registry.GetModule(config)
+
+	assert.Nil(t, module)
+	assert.Error(t, err)
+}

--- a/metricbeat/include/list.go
+++ b/metricbeat/include/list.go
@@ -11,21 +11,21 @@ package include
 // TODO: create a script to automatically generate this list
 import (
 	"github.com/elastic/beats/libbeat/logp"
-	"github.com/elastic/beats/metricbeat/helper"
+	_ "github.com/elastic/beats/metricbeat/helper"
 
 	// List of all metrics to make sure they are registred
 	// Every new metric must be added here
 	_ "github.com/elastic/beats/metricbeat/module/apache/status"
-	_ "github.com/elastic/beats/metricbeat/module/golang"
+	_ "github.com/elastic/beats/metricbeat/module/golang/expvar"
 	_ "github.com/elastic/beats/metricbeat/module/mysql/status"
 	_ "github.com/elastic/beats/metricbeat/module/redis/info"
 )
 
 func ListAll() {
 	logp.Debug("beat", "Registered Modules and Metrics")
-	for moduleName, module := range helper.Registry {
-		for metricName, _ := range module.MetricSets {
-			logp.Debug("beat", "Registred: Module: %v, Metric: %v", moduleName, metricName)
-		}
-	}
+	//for moduleName, module := range helper.Registry {
+	//	for metricName, _ := range module.MetricSets {
+	//		logp.Debug("beat", "Registred: Module: %v, Metric: %v", moduleName, metricName)
+	//	}
+	//}
 }

--- a/metricbeat/metricbeat.yml
+++ b/metricbeat/metricbeat.yml
@@ -1,28 +1,24 @@
 metricbeat:
   modules:
-    #golang:
-    #  metrics:
-    #    expvar:
-    #      period: 10s
-    apache:
+    - module: apache
+      metricsets: ["status"]
       hosts: ["http://127.0.0.1/"]
-      metricsets:
-        status:
-          period: 1s
-    redis:
-      hosts:
-        - "127.0.0.1:6379"
-      metricsets:
-        info:
-          period: 1s
-    mysql:
-      # This expectd a full mysql dsn
-      # Example: [username[:password]@][protocol[(address)]]/
-      hosts:
-        - "root@tcp(127.0.0.1:3306)/"
-      metricsets:
-        status:
-          period: 1s
+      period: 1s
+      #fields: ["aaa", "bbb"]
+      enabled: true
+    - module: redis
+      metricsets: ["info"]
+      period: 1s
+      hosts: ["127.0.0.1:6379"]
+      enabled: true
+      #filter: ...
+      #username: name
+      #password: hello world
+    - module: mysql
+      metricsets: ["status"]
+      enabled: true
+      period: 2s
+      hosts: ["root@tcp(127.0.0.1:3306)/"]
 ###############################################################################
 ############################# Libbeat Config ##################################
 # Base config file used by all other beats for using libbeat features

--- a/metricbeat/module/apache/apache.go
+++ b/metricbeat/module/apache/apache.go
@@ -1,36 +1,18 @@
 package apache
 
 import (
-	//"github.com/elastic/beats/libbeat/logp"
+	"os"
 
 	"github.com/elastic/beats/metricbeat/helper"
-
-	"os"
 )
 
 func init() {
-	Module.Register()
+	helper.Registry.AddModuler("apache", Moduler{})
 }
 
-var Module = helper.NewModule("apache", Apache{})
+type Moduler struct{}
 
-var Config = &ApacheModuleConfig{}
-
-type ApacheModuleConfig struct {
-	Metrics map[string]interface{}
-	Hosts   []string
-}
-
-type Apache struct {
-	Name   string
-	Config ApacheModuleConfig
-}
-
-func (r Apache) Setup() error {
-
-	// Loads module config
-	// This is module specific config object
-	Module.LoadConfig(&Config)
+func (r Moduler) Setup() error {
 	return nil
 }
 

--- a/metricbeat/module/apache/status/status.go
+++ b/metricbeat/module/apache/status/status.go
@@ -9,28 +9,29 @@ import (
 
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/metricbeat/helper"
-	"github.com/elastic/beats/metricbeat/module/apache"
+	_ "github.com/elastic/beats/metricbeat/module/apache"
 )
 
 func init() {
-	MetricSet.Register()
+	helper.Registry.AddMetricSeter("apache", "status", MetricSeter{})
 }
 
-var MetricSet = helper.NewMetricSet("status", MetricSeter{}, apache.Module)
-
-type MetricSeter struct {
-}
+type MetricSeter struct{}
 
 func (m MetricSeter) Setup() error {
 	return nil
 }
 
-func (m MetricSeter) Fetch() (events []common.MapStr, err error) {
+func (m MetricSeter) Fetch(ms *helper.MetricSet) (events []common.MapStr, err error) {
 
-	hosts := MetricSet.Module.GetHosts()
+	hosts := ms.Config.Hosts
 
 	for _, host := range hosts {
 		resp, err := http.Get(host + "server-status?auto")
+
+		if resp == nil {
+			continue
+		}
 		defer resp.Body.Close()
 
 		if err != nil {

--- a/metricbeat/module/golang/beat.go
+++ b/metricbeat/module/golang/beat.go
@@ -7,11 +7,9 @@ import (
 
 // This one comabines module and metric
 func init() {
-	Module.Register()
+	helper.Registry.AddModuler("golang", Golang{})
+	//helper.NewModule("golang", Golang{}).Register()
 }
-
-// Module object
-var Module = helper.NewModule("golang", Golang{})
 
 type Golang struct {
 }

--- a/metricbeat/module/golang/expvar/expvar.go
+++ b/metricbeat/module/golang/expvar/expvar.go
@@ -4,27 +4,21 @@ package expvar
 import (
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/metricbeat/helper"
-	"github.com/elastic/beats/metricbeat/module/golang"
+	_ "github.com/elastic/beats/metricbeat/module/golang"
 )
 
 func init() {
-	MetricSet.Register()
+	helper.Registry.AddMetricSeter("golang", "expvar", MetricSeter{})
 }
 
-// MetricSet Setup
-var MetricSet = helper.NewMetricSet("expvar", ExpvarMetric{}, golang.Module)
+type MetricSeter struct{}
 
-// MetricSetter object
-type ExpvarMetric struct {
-	helper.MetricSetConfig
-}
-
-func (b ExpvarMetric) Setup() error {
+func (m MetricSeter) Setup() error {
 	return nil
 }
 
 // Fetch expvars from a running beat
-func (b ExpvarMetric) Fetch() (events []common.MapStr, err error) {
+func (m MetricSeter) Fetch(ms *helper.MetricSet) (events []common.MapStr, err error) {
 
 	//path := "http://localhost:6060/debug/vars"
 
@@ -39,6 +33,6 @@ func (b ExpvarMetric) Fetch() (events []common.MapStr, err error) {
 	return events, nil
 }
 
-func (b ExpvarMetric) Cleanup() error {
+func (m MetricSeter) Cleanup() error {
 	return nil
 }

--- a/metricbeat/module/mysql/mysql.go
+++ b/metricbeat/module/mysql/mysql.go
@@ -1,25 +1,21 @@
 package mysql
 
 import (
+	"os"
+
 	"github.com/elastic/beats/metricbeat/helper"
 
 	"database/sql"
 	_ "github.com/go-sql-driver/mysql"
-
-	"os"
 )
 
 func init() {
-	Module.Register()
+	helper.Registry.AddModuler("mysql", Moduler{})
 }
 
-// Module object
-var Module = helper.NewModule("mysql", Mysql{})
+type Moduler struct{}
 
-type Mysql struct {
-}
-
-func (b Mysql) Setup() error {
+func (b Moduler) Setup() error {
 	// TODO: Ping available servers to check if available
 	return nil
 }

--- a/metricbeat/module/mysql/status/status.go
+++ b/metricbeat/module/mysql/status/status.go
@@ -11,15 +11,11 @@ import (
 )
 
 func init() {
-	MetricSet.Register()
+	helper.Registry.AddMetricSeter("mysql", "status", MetricSeter{})
 }
-
-// Metric Setup
-var MetricSet = helper.NewMetricSet("status", MetricSeter{}, mysql.Module)
 
 // MetricSetter object
 type MetricSeter struct {
-	helper.MetricSetConfig
 }
 
 func (m MetricSeter) Setup() error {
@@ -27,10 +23,10 @@ func (m MetricSeter) Setup() error {
 }
 
 // Fetches status messages from mysql hosts
-func (m MetricSeter) Fetch() (events []common.MapStr, err error) {
+func (m MetricSeter) Fetch(ms *helper.MetricSet) (events []common.MapStr, err error) {
 
 	// Load status for all hosts and add it to events
-	for _, host := range MetricSet.Module.GetHosts() {
+	for _, host := range ms.Config.Hosts {
 		db, err := mysql.Connect(host)
 		if err != nil {
 			logp.Err("MySQL conenction error: %s", err)

--- a/metricbeat/module/mysql/status/status_test.go
+++ b/metricbeat/module/mysql/status/status_test.go
@@ -3,6 +3,7 @@ package status
 import (
 	"testing"
 
+	"github.com/elastic/beats/metricbeat/helper"
 	"github.com/elastic/beats/metricbeat/module/mysql"
 	"github.com/stretchr/testify/assert"
 )
@@ -14,15 +15,20 @@ func TestFetch(t *testing.T) {
 	}
 
 	// Setup Module config
-	mysql.Module.BaseConfig.Hosts = []string{mysql.GetMySQLEnvDSN()}
 
 	// Setup Metric
 	m := MetricSeter{}
 	err := m.Setup()
 	assert.NoError(t, err)
 
+	config := helper.ModuleConfig{
+		Hosts: []string{mysql.GetMySQLEnvDSN()},
+	}
+
+	ms := helper.NewMetricSet("status", m, config)
+
 	// Load events
-	events, err := m.Fetch()
+	events, err := m.Fetch(ms)
 	assert.NoError(t, err)
 
 	// Check event fields

--- a/metricbeat/module/redis/info/info.go
+++ b/metricbeat/module/redis/info/info.go
@@ -2,6 +2,7 @@
 package info
 
 import (
+	"fmt"
 	"strings"
 
 	rd "github.com/garyburd/redigo/redis"
@@ -14,32 +15,20 @@ import (
 )
 
 func init() {
-	MetricSet.Register()
+	helper.Registry.AddMetricSeter("redis", "info", MetricSeter{})
 }
 
-// Metric object
-var MetricSet = helper.NewMetricSet("info", MetricSeter{}, redis.Module)
-
-var Config = &MetricSetConfig{}
-
-type MetricSetConfig struct {
-}
-
-type MetricSeter struct {
-	Name   string
-	Config MetricSetConfig
-}
+type MetricSeter struct{}
 
 func (m MetricSeter) Setup() error {
-	// Loads module config
-	// This is module specific config object
-	MetricSet.LoadConfig(&Config)
 	return nil
 }
 
-func (m MetricSeter) Fetch() (events []common.MapStr, err error) {
+func (m MetricSeter) Fetch(ms *helper.MetricSet) (events []common.MapStr, err error) {
 
-	hosts := MetricSet.Module.GetHosts()
+	hosts := ms.Config.Hosts
+
+	fmt.Printf("Hosts: %+v", hosts)
 
 	for _, host := range hosts {
 

--- a/metricbeat/module/redis/info/info_test.go
+++ b/metricbeat/module/redis/info/info_test.go
@@ -3,6 +3,7 @@ package info
 import (
 	"testing"
 
+	"github.com/elastic/beats/metricbeat/helper"
 	"github.com/elastic/beats/metricbeat/module/redis"
 	"github.com/stretchr/testify/assert"
 )
@@ -14,12 +15,16 @@ func TestConnect(t *testing.T) {
 	}
 
 	// Setup
-	redis.Module.BaseConfig.Hosts = []string{redis.GetRedisEnvHost() + ":" + redis.GetRedisEnvPort()}
 	r := MetricSeter{}
 	err := r.Setup()
 	assert.NoError(t, err)
 
-	data, err := r.Fetch()
+	config := helper.ModuleConfig{
+		Hosts: []string{redis.GetRedisEnvHost() + ":" + redis.GetRedisEnvPort()},
+	}
+	ms := helper.NewMetricSet("info", r, config)
+
+	data, err := r.Fetch(ms)
 	assert.NoError(t, err)
 
 	// Check fields

--- a/metricbeat/module/redis/redis.go
+++ b/metricbeat/module/redis/redis.go
@@ -1,37 +1,22 @@
 package redis
 
 import (
-	"github.com/elastic/beats/libbeat/logp"
-
-	"github.com/elastic/beats/metricbeat/helper"
+	"os"
 
 	"github.com/garyburd/redigo/redis"
 
-	"os"
+	"github.com/elastic/beats/libbeat/logp"
+
+	"github.com/elastic/beats/metricbeat/helper"
 )
 
 func init() {
-	Module.Register()
+	helper.Registry.AddModuler("redis", Moduler{})
 }
 
-var Module = helper.NewModule("redis", Redis{})
+type Moduler struct{}
 
-var Config = &RedisModuleConfig{}
-
-type RedisModuleConfig struct {
-	Metrics map[string]interface{}
-	Hosts   []string
-}
-
-type Redis struct {
-	Name   string
-	Config RedisModuleConfig
-}
-
-func (r Redis) Setup() error {
-	// Loads module config
-	// This is module specific config object
-	Module.LoadConfig(&Config)
+func (r Moduler) Setup() error {
 	return nil
 }
 

--- a/metricbeat/tests/system/config/metricbeat.yml.j2
+++ b/metricbeat/tests/system/config/metricbeat.yml.j2
@@ -1,22 +1,24 @@
 metricbeat:
   modules:
     {% if redis %}
-    redis:
+    - module: redis
       hosts:
         - "{{ redis_host | default("127.0.0.1", true) }}:6379"
       metricsets:
-        info:
-          period: 1s
+        - info
+      period: 1s
+      enabled: true
     {% endif %}
     {% if mysql %}
-    mysql:
+    - module: mysql:
       # This expectd a full mysql dsn
       # Example: [username[:password]@][protocol[(address)]]/
       hosts:
         - "@tcp(127.0.0.1:3306)/"
       metricsets:
-        status:
-          period: 5s
+        - status
+      period: 5s
+      enabled: true
     {% endif %}
 
 


### PR DESCRIPTION
This change to the configuration file makes it possible to configure each module and metricset multiple times. This allows to run each metricset of a module independent of the module with different configuration. In addition it allows to run a metricset with different configuration like period for different hosts.

An example use case can be, that the basic apache metricset is run every second for localhost, but the extended apache metricset for localhost is only run every 10 seconds. This also allows to add different filters and fields if needed.

Based on this config change, metricbeat was refactored to decouple modules and metricsets.