### PR TITLE
Cache process arguments in Topbeat

### DIFF
--- a/topbeat/beater/sigar.go
+++ b/topbeat/beater/sigar.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/elastic/gosigar"
+	sigar "github.com/elastic/gosigar"
 )
 
 type SystemLoad struct {
@@ -145,34 +145,29 @@ func getProcState(b byte) string {
 	return "unknown"
 }
 
-func GetProcess(pid int) (*Process, error) {
-
+func GetProcess(pid int, cmdline string) (*Process, error) {
 	state := sigar.ProcState{}
+	if err := state.Get(pid); err != nil {
+		return nil, fmt.Errorf("error getting process state for pid=%d: %v", pid, err)
+	}
+
 	mem := sigar.ProcMem{}
+	if err := mem.Get(pid); err != nil {
+		return nil, fmt.Errorf("error getting process mem for pid=%d: %v", pid, err)
+	}
+
 	cpu := sigar.ProcTime{}
-	args := sigar.ProcArgs{}
-
-	err := state.Get(pid)
-	if err != nil {
-		return nil, fmt.Errorf("Error getting state info: %v", err)
+	if err := cpu.Get(pid); err != nil {
+		return nil, fmt.Errorf("error getting process cpu time for pid=%d: %v", pid, err)
 	}
 
-	err = mem.Get(pid)
-	if err != nil {
-		return nil, fmt.Errorf("Error getting mem info: %v", err)
+	if cmdline == "" {
+		args := sigar.ProcArgs{}
+		if err := args.Get(pid); err != nil {
+			return nil, fmt.Errorf("error getting process arguments for pid=%d: %v", pid, err)
+		}
+		cmdline = strings.Join(args.List, " ")
 	}
-
-	err = cpu.Get(pid)
-	if err != nil {
-		return nil, fmt.Errorf("Error getting cpu info: %v", err)
-	}
-
-	err = args.Get(pid)
-	if err != nil {
-		return nil, fmt.Errorf("Error getting command line: %v", err)
-	}
-
-	cmdLine := strings.Join(args.List, " ")
 
 	proc := Process{
 		Pid:      pid,
@@ -180,11 +175,11 @@ func GetProcess(pid int) (*Process, error) {
 		Name:     state.Name,
 		State:    getProcState(byte(state.State)),
 		Username: state.Username,
-		CmdLine:  cmdLine,
+		CmdLine:  cmdline,
 		Mem:      mem,
 		Cpu:      cpu,
+		ctime:    time.Now(),
 	}
-	proc.ctime = time.Now()
 
 	return &proc, nil
 }

--- a/topbeat/beater/sigar_test.go
+++ b/topbeat/beater/sigar_test.go
@@ -83,7 +83,7 @@ func TestGetProcess(t *testing.T) {
 
 	for _, pid := range pids {
 
-		process, err := GetProcess(pid)
+		process, err := GetProcess(pid, "")
 
 		if err != nil {
 			continue
@@ -144,5 +144,33 @@ func TestFileSystemList(t *testing.T) {
 		assert.True(t, (stat.Free >= 0))
 		assert.True(t, (stat.Avail >= 0))
 		assert.True(t, (stat.Used >= 0))
+	}
+}
+
+// BenchmarkGetProcess runs a benchmark of the GetProcess method with caching
+// of the command line arguments enabled.
+func BenchmarkGetProcess(b *testing.B) {
+	pids, err := Pids()
+	if err != nil {
+		b.Fatal(err)
+	}
+	nPids := len(pids)
+	procs := make(ProcsMap, nPids)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		pid := pids[i%nPids]
+
+		var cmdline string
+		if p := procs[pid]; p != nil {
+			cmdline = p.CmdLine
+		}
+
+		process, err := GetProcess(pid, cmdline)
+		if err != nil {
+			continue
+		}
+
+		procs[pid] = process
 	}
 }

--- a/topbeat/beater/topbeat_test.go
+++ b/topbeat/beater/topbeat_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/elastic/gosigar"
+	sigar "github.com/elastic/gosigar"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/topbeat/tests/system/test_procs.py
+++ b/topbeat/tests/system/test_procs.py
@@ -22,7 +22,7 @@ class Test(BaseTest):
             proc_patterns=["(?i)topbeat.test"]  # monitor itself
         )
         topbeat = self.start_beat()
-        self.wait_until(lambda: self.output_has(lines=1))
+        self.wait_until(lambda: self.output_count(lambda x: x >= 1))
         topbeat.check_kill_and_wait()
 
         output = self.read_output()[0]


### PR DESCRIPTION
Fixes #1043

#### Windows

```
# Caching off:
C:\Gopath\src\github.com\elastic\beats\topbeat>go test github.com/elastic/beats/topbeat/beater -bench ^BenchmarkGetProcess$ -run ^$ -benchmem -benchtime 10s
PASS
BenchmarkGetProcess-2       2000          11691894 ns/op            1271 B/op         31 allocs/op
ok      github.com/elastic/beats/topbeat/beater 24.593s

# Caching on:
C:\Gopath\src\github.com\elastic\beats\topbeat>go test github.com/elastic/beats/topbeat/beater -bench ^BenchmarkGetProcess$ -run ^$ -benchmem -benchtime 10s
PASS
BenchmarkGetProcess-2      20000           1035105 ns/op             702 B/op         13 allocs/op
ok      github.com/elastic/beats/topbeat/beater 24.989s
```

#### OSX

```
# Caching off:
$ go test -v github.com/elastic/beats/topbeat/beater -bench ^BenchmarkGetProcess$ -run ^$ -benchmem -benchtime 10s
PASS
BenchmarkGetProcess-4     200000             68873 ns/op          153209 B/op         18 allocs/op
ok      github.com/elastic/beats/topbeat/beater 14.538s

# Caching on:
$ go test -v github.com/elastic/beats/topbeat/beater -bench ^BenchmarkGetProcess$ -run ^$ -benchmem -benchtime 10s
PASS
BenchmarkGetProcess-4    2000000              7131 ns/op             905 B/op         11 allocs/op
ok      github.com/elastic/beats/topbeat/beater 21.425s
```

/cc @dr-toboggan