### PR TITLE
Libbeat: wait for publisher and outputers to finish (i.e. proper shutdown)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -63,6 +63,7 @@ https://github.com/elastic/beats/compare/v1.1.0...master[Check the HEAD diff]
 - Improve logstash and elasticsearch backoff behavior. {pull}927[927]
 - Add experimental Kafka output. {pull}942[942]
 - Add config file option to configure GOMAXPROCS. {pull}969[969]
+- Add proper shutdown to libbeat. When the publisher exits, it first waits for all events in go routines to be published and outputed. {pull}1056[1056]
 
 *Packetbeat*
 - Change the DNS library used throughout the dns package to github.com/miekg/dns. {pull}803[803]

--- a/libbeat/publisher/async_test.go
+++ b/libbeat/publisher/async_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestAsyncPublishEvent(t *testing.T) {
+	enableLogging([]string{"*"})
 	// Init
 	testPub := newTestPublisherNoBulk(CompletedResponse)
 	event := testEvent()
@@ -21,6 +22,11 @@ func TestAsyncPublishEvent(t *testing.T) {
 		t.Fatal(err)
 	}
 	assert.Equal(t, event, msgs[0].event)
+
+	err = testPub.stopTestPublisher()
+	if err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestAsyncPublishEvents(t *testing.T) {
@@ -38,6 +44,11 @@ func TestAsyncPublishEvents(t *testing.T) {
 	}
 	assert.Equal(t, events[0], msgs[0].events[0])
 	assert.Equal(t, events[1], msgs[0].events[1])
+
+	err = testPub.stopTestPublisher()
+	if err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestBulkAsyncPublishEvent(t *testing.T) {
@@ -56,6 +67,11 @@ func TestBulkAsyncPublishEvent(t *testing.T) {
 	// Bulk outputer always sends bulk messages (even if only one event is
 	// present)
 	assert.Equal(t, event, msgs[0].events[0])
+
+	err = testPub.stopTestPublisher()
+	if err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestBulkAsyncPublishEvents(t *testing.T) {
@@ -72,4 +88,9 @@ func TestBulkAsyncPublishEvents(t *testing.T) {
 	}
 	assert.Equal(t, events[0], msgs[0].events[0])
 	assert.Equal(t, events[1], msgs[0].events[1])
+
+	err = testPub.stopTestPublisher()
+	if err != nil {
+		t.Fatal(err)
+	}
 }

--- a/libbeat/publisher/output.go
+++ b/libbeat/publisher/output.go
@@ -2,6 +2,7 @@ package publisher
 
 import (
 	"errors"
+	"sync"
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
@@ -22,7 +23,7 @@ var (
 func newOutputWorker(
 	config outputs.MothershipConfig,
 	out outputs.Outputer,
-	ws *workerSignal,
+	wg *sync.WaitGroup,
 	hwm int,
 	bulkHWM int,
 ) *outputWorker {
@@ -36,7 +37,7 @@ func newOutputWorker(
 		config:      config,
 		maxBulkSize: maxBulkSize,
 	}
-	o.messageWorker.init(ws, hwm, bulkHWM, o)
+	o.messageWorker.init(wg, hwm, bulkHWM, o)
 	return o
 }
 

--- a/libbeat/publisher/output_test.go
+++ b/libbeat/publisher/output_test.go
@@ -1,6 +1,7 @@
 package publisher
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/elastic/beats/libbeat/common"
@@ -26,11 +27,12 @@ func (t *testOutputer) PublishEvent(trans outputs.Signaler, opts outputs.Options
 
 // Test OutputWorker by calling onStop() and onMessage() with various inputs.
 func TestOutputWorker(t *testing.T) {
+	var wg sync.WaitGroup
 	outputer := &testOutputer{events: make(chan common.MapStr, 10)}
 	ow := newOutputWorker(
 		outputs.MothershipConfig{},
 		outputer,
-		newWorkerSignal(),
+		&wg,
 		1, 0)
 
 	ow.onStop() // Noop

--- a/libbeat/publisher/publish.go
+++ b/libbeat/publisher/publish.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"flag"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/elastic/beats/libbeat/common"
@@ -61,13 +62,11 @@ type PublisherType struct {
 
 	RefreshTopologyTimer <-chan time.Time
 
-	// wsOutput and wsPublisher should be used for proper shutdown of publisher
-	// (not implemented yet). On shutdown the publisher should be finished first
-	// and the outputers next, so no publisher will attempt to send messages on
-	// closed channels.
+	// On shutdown the publisher is finished first and the outputers next,
+	// so no publisher will attempt to send messages on closed channels.
 	// Note: beat data producers must be shutdown before the publisher plugin
-	wsOutput    workerSignal
-	wsPublisher workerSignal
+	wgPublisher sync.WaitGroup
+	wgOutput    sync.WaitGroup
 
 	syncPublisher  *syncPublisher
 	asyncPublisher *asyncPublisher
@@ -217,9 +216,6 @@ func (publisher *PublisherType) init(
 
 	publisher.GeoLite = common.LoadGeoIPData(shipper.Geoip)
 
-	publisher.wsOutput.Init()
-	publisher.wsPublisher.Init()
-
 	if !publisher.disabled {
 		plugins, err := outputs.InitOutputs(beatName, configs, shipper.Topology_expire)
 		if err != nil {
@@ -238,7 +234,7 @@ func (publisher *PublisherType) init(
 				newOutputWorker(
 					config,
 					output,
-					&publisher.wsOutput,
+					&publisher.wgOutput,
 					hwm,
 					bulkHWM))
 
@@ -318,9 +314,19 @@ func (publisher *PublisherType) init(
 		go publisher.UpdateTopologyPeriodically()
 	}
 
-	publisher.asyncPublisher = newAsyncPublisher(publisher, hwm, bulkHWM)
+	publisher.asyncPublisher = newAsyncPublisher(publisher, hwm, bulkHWM, &publisher.wgPublisher)
 	publisher.syncPublisher = newSyncPublisher(publisher, hwm, bulkHWM)
 
 	publisher.client = newClient(publisher)
 	return nil
+}
+
+func (publisher *PublisherType) Stop() {
+	publisher.asyncPublisher.onStop()
+	publisher.wgPublisher.Wait()
+
+	for _, output := range publisher.Output {
+		output.shutdown()
+	}
+	publisher.wgOutput.Wait()
 }

--- a/libbeat/publisher/sync_test.go
+++ b/libbeat/publisher/sync_test.go
@@ -4,11 +4,11 @@ import (
 	"testing"
 
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/logp"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestSyncPublishEventSuccess(t *testing.T) {
+	enableLogging([]string{"*"})
 	testPub := newTestPublisherNoBulk(CompletedResponse)
 	event := testEvent()
 
@@ -64,10 +64,6 @@ func TestSyncPublishEventsFailed(t *testing.T) {
 
 // Test that PublishEvent returns true when publishing is disabled.
 func TestSyncPublisherDisabled(t *testing.T) {
-	if testing.Verbose() {
-		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"*"})
-	}
-
 	testPub := newTestPublisherNoBulk(FailedResponse)
 	testPub.pub.disabled = true
 	event := testEvent()

--- a/libbeat/publisher/worker_test.go
+++ b/libbeat/publisher/worker_test.go
@@ -1,6 +1,8 @@
 package publisher
 
 import (
+	"errors"
+	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -9,11 +11,11 @@ import (
 
 // Test sending events through the messageWorker.
 func TestMessageWorkerSend(t *testing.T) {
+	enableLogging([]string{"*"})
+	var wg sync.WaitGroup
 	// Setup
-	ws := &workerSignal{}
-	ws.Init()
 	mh := &testMessageHandler{msgs: make(chan message, 10), response: true}
-	mw := newMessageWorker(ws, 10, 0, mh)
+	mw := newMessageWorker(&wg, 10, 0, mh)
 
 	// Send an event.
 	s1 := newTestSignaler()
@@ -38,25 +40,10 @@ func TestMessageWorkerSend(t *testing.T) {
 	assert.Contains(t, msgs, m2)
 	assert.True(t, s2.wait())
 
-	// Verify that stopping workerSignal causes a onStop notification
-	// in the messageHandler.
-	ws.stop()
+	err = wait(mw.shutdown, errors.New("Failed to stop messageWorker"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	assert.True(t, atomic.LoadUint32(&mh.stopped) == 1)
-}
-
-// Test that stopQueue invokes the Failed callback on all events in the queue.
-func TestMessageWorkerStopQueue(t *testing.T) {
-	s1 := newTestSignaler()
-	m1 := message{context: Context{Signal: s1}}
-
-	s2 := newTestSignaler()
-	m2 := message{context: Context{Signal: s2}}
-
-	qu := make(chan message, 2)
-	qu <- m1
-	qu <- m2
-
-	stopQueue(qu)
-	assert.False(t, s1.wait())
-	assert.False(t, s2.wait())
 }


### PR DESCRIPTION
##### Libbeat
* Libbeat publisher now exits once all async events are published and all events outputed
* Replace signalWorker with a sync.WaitGroup and remove done channels in publishers: wait for all channels to be empty
* Remove unit test TestMessageWorkerStopQueue: there are no failed events at shutdown anymore
* Adapt existing Libbeat tests

##### Also
* Edit CHANGELOG