### PR TITLE
Packetbeat: wait for publisher and outputers to finish (i.e. proper shutdown)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -19,6 +19,7 @@ https://github.com/elastic/beats/compare/v1.1.0...master[Check the HEAD diff]
 - Rename output fields in the dns package. Former flag `recursion_allowed` becomes `recursion_available`. {pull}803[803]
   Former SOA field `ttl` becomes `minimum`. {pull}803[803]
 - The fully qualified domain names which are part of output fields values of the dns package now terminate with a dot. {pull}803[803]
+- Remove the waitstop CLI option. At shutdown, Packetbeat now waits for all events to be published and outputed. {pull}1057[1057]
 
 *Topbeat*
 - Rename proc.cpu.user_p with proc.cpu.total_p as includes CPU time spent in kernel space {pull}631[631]

--- a/libbeat/publisher/async_test.go
+++ b/libbeat/publisher/async_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestAsyncPublishEvent(t *testing.T) {
+	enableLogging([]string{"*"})
 	// Init
 	testPub := newTestPublisherNoBulk(CompletedResponse)
 	event := testEvent()
@@ -21,6 +22,11 @@ func TestAsyncPublishEvent(t *testing.T) {
 		t.Fatal(err)
 	}
 	assert.Equal(t, event, msgs[0].event)
+
+	err = testPub.stopTestPublisher()
+	if err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestAsyncPublishEvents(t *testing.T) {
@@ -38,6 +44,11 @@ func TestAsyncPublishEvents(t *testing.T) {
 	}
 	assert.Equal(t, events[0], msgs[0].events[0])
 	assert.Equal(t, events[1], msgs[0].events[1])
+
+	err = testPub.stopTestPublisher()
+	if err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestBulkAsyncPublishEvent(t *testing.T) {
@@ -56,6 +67,11 @@ func TestBulkAsyncPublishEvent(t *testing.T) {
 	// Bulk outputer always sends bulk messages (even if only one event is
 	// present)
 	assert.Equal(t, event, msgs[0].events[0])
+
+	err = testPub.stopTestPublisher()
+	if err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestBulkAsyncPublishEvents(t *testing.T) {
@@ -72,4 +88,9 @@ func TestBulkAsyncPublishEvents(t *testing.T) {
 	}
 	assert.Equal(t, events[0], msgs[0].events[0])
 	assert.Equal(t, events[1], msgs[0].events[1])
+
+	err = testPub.stopTestPublisher()
+	if err != nil {
+		t.Fatal(err)
+	}
 }

--- a/libbeat/publisher/bulk.go
+++ b/libbeat/publisher/bulk.go
@@ -1,15 +1,17 @@
 package publisher
 
 import (
+	"sync"
 	"time"
 
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/outputs"
 )
 
 type bulkWorker struct {
 	output worker
-	ws     *workerSignal
+	wg     *sync.WaitGroup
 
 	queue       chan message
 	bulkQueue   chan message
@@ -22,14 +24,15 @@ type bulkWorker struct {
 }
 
 func newBulkWorker(
-	ws *workerSignal, hwm int, bulkHWM int,
+	wg *sync.WaitGroup, hwm int, bulkHWM int,
 	output worker,
 	flushInterval time.Duration,
 	maxBatchSize int,
 ) *bulkWorker {
+	logp.Debug("publish", "newBulkWorker init with %p", wg)
 	b := &bulkWorker{
 		output:       output,
-		ws:           ws,
+		wg:           wg,
 		queue:        make(chan message, hwm),
 		bulkQueue:    make(chan message, bulkHWM),
 		flushTicker:  time.NewTicker(flushInterval),
@@ -38,35 +41,56 @@ func newBulkWorker(
 		pending:      nil,
 	}
 
-	ws.wg.Add(1)
+	wg.Add(1)
 	go b.run()
 	return b
 }
 
 func (b *bulkWorker) send(m message) {
 	if m.events == nil {
+		b.wg.Add(1)
 		b.queue <- m
 	} else {
+		b.wg.Add(len(m.events))
 		b.bulkQueue <- m
 	}
 }
 
 func (b *bulkWorker) run() {
-	defer b.shutdown()
+	defer func() {
+		b.wg.Done()
+	}()
+
+	var queueClosed bool
+	var bulkQueueClosed bool
 
 	for {
 		select {
-		case <-b.ws.done:
-			return
-		case m := <-b.queue:
-			b.onEvent(&m.context, m.event)
-		case m := <-b.bulkQueue:
-			b.onEvents(&m.context, m.events)
-		case <-b.flushTicker.C:
-			if len(b.events) > 0 {
-				b.publish()
+		case m, ok := <-b.queue:
+			if !ok {
+				queueClosed = true
+			} else {
+				b.onEvent(&m.context, m.event)
 			}
+		case m, ok := <-b.bulkQueue:
+			if !ok {
+				bulkQueueClosed = true
+			} else {
+				b.onEvents(&m.context, m.events)
+			}
+		case <-b.flushTicker.C:
+			b.flush()
 		}
+		if queueClosed && bulkQueueClosed {
+			b.flush()
+			return
+		}
+	}
+}
+
+func (b *bulkWorker) flush() {
+	if len(b.events) > 0 {
+		b.publish()
 	}
 }
 
@@ -127,6 +151,7 @@ func (b *bulkWorker) publish() {
 		events: b.events,
 	})
 
+	b.wg.Add(-len(b.events))
 	b.pending = nil
 	b.guaranteed = false
 	b.events = make([]common.MapStr, 0, b.maxBatchSize)
@@ -134,7 +159,7 @@ func (b *bulkWorker) publish() {
 
 func (b *bulkWorker) shutdown() {
 	b.flushTicker.Stop()
-	stopQueue(b.queue)
-	stopQueue(b.bulkQueue)
-	b.ws.wg.Done()
+	close(b.queue)
+	close(b.bulkQueue)
+	b.wg.Wait()
 }

--- a/libbeat/publisher/output.go
+++ b/libbeat/publisher/output.go
@@ -2,6 +2,7 @@ package publisher
 
 import (
 	"errors"
+	"sync"
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
@@ -22,7 +23,7 @@ var (
 func newOutputWorker(
 	config outputs.MothershipConfig,
 	out outputs.Outputer,
-	ws *workerSignal,
+	wg *sync.WaitGroup,
 	hwm int,
 	bulkHWM int,
 ) *outputWorker {
@@ -36,7 +37,7 @@ func newOutputWorker(
 		config:      config,
 		maxBulkSize: maxBulkSize,
 	}
-	o.messageWorker.init(ws, hwm, bulkHWM, o)
+	o.messageWorker.init(wg, hwm, bulkHWM, o)
 	return o
 }
 

--- a/libbeat/publisher/output_test.go
+++ b/libbeat/publisher/output_test.go
@@ -1,6 +1,7 @@
 package publisher
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/elastic/beats/libbeat/common"
@@ -26,11 +27,12 @@ func (t *testOutputer) PublishEvent(trans outputs.Signaler, opts outputs.Options
 
 // Test OutputWorker by calling onStop() and onMessage() with various inputs.
 func TestOutputWorker(t *testing.T) {
+	var wg sync.WaitGroup
 	outputer := &testOutputer{events: make(chan common.MapStr, 10)}
 	ow := newOutputWorker(
 		outputs.MothershipConfig{},
 		outputer,
-		newWorkerSignal(),
+		&wg,
 		1, 0)
 
 	ow.onStop() // Noop

--- a/libbeat/publisher/publish.go
+++ b/libbeat/publisher/publish.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"flag"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/elastic/beats/libbeat/common"
@@ -61,13 +62,11 @@ type PublisherType struct {
 
 	RefreshTopologyTimer <-chan time.Time
 
-	// wsOutput and wsPublisher should be used for proper shutdown of publisher
-	// (not implemented yet). On shutdown the publisher should be finished first
-	// and the outputers next, so no publisher will attempt to send messages on
-	// closed channels.
+	// On shutdown the publisher is finished first and the outputers next,
+	// so no publisher will attempt to send messages on closed channels.
 	// Note: beat data producers must be shutdown before the publisher plugin
-	wsOutput    workerSignal
-	wsPublisher workerSignal
+	wgPublisher sync.WaitGroup
+	wgOutput    sync.WaitGroup
 
 	syncPublisher  *syncPublisher
 	asyncPublisher *asyncPublisher
@@ -217,9 +216,6 @@ func (publisher *PublisherType) init(
 
 	publisher.GeoLite = common.LoadGeoIPData(shipper.Geoip)
 
-	publisher.wsOutput.Init()
-	publisher.wsPublisher.Init()
-
 	if !publisher.disabled {
 		plugins, err := outputs.InitOutputs(beatName, configs, shipper.Topology_expire)
 		if err != nil {
@@ -238,7 +234,7 @@ func (publisher *PublisherType) init(
 				newOutputWorker(
 					config,
 					output,
-					&publisher.wsOutput,
+					&publisher.wgOutput,
 					hwm,
 					bulkHWM))
 
@@ -318,9 +314,19 @@ func (publisher *PublisherType) init(
 		go publisher.UpdateTopologyPeriodically()
 	}
 
-	publisher.asyncPublisher = newAsyncPublisher(publisher, hwm, bulkHWM)
+	publisher.asyncPublisher = newAsyncPublisher(publisher, hwm, bulkHWM, &publisher.wgPublisher)
 	publisher.syncPublisher = newSyncPublisher(publisher, hwm, bulkHWM)
 
 	publisher.client = newClient(publisher)
 	return nil
+}
+
+func (publisher *PublisherType) Stop() {
+	publisher.asyncPublisher.onStop()
+	publisher.wgPublisher.Wait()
+
+	for _, output := range publisher.Output {
+		output.shutdown()
+	}
+	publisher.wgOutput.Wait()
 }

--- a/libbeat/publisher/sync_test.go
+++ b/libbeat/publisher/sync_test.go
@@ -4,11 +4,11 @@ import (
 	"testing"
 
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/logp"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestSyncPublishEventSuccess(t *testing.T) {
+	enableLogging([]string{"*"})
 	testPub := newTestPublisherNoBulk(CompletedResponse)
 	event := testEvent()
 
@@ -64,10 +64,6 @@ func TestSyncPublishEventsFailed(t *testing.T) {
 
 // Test that PublishEvent returns true when publishing is disabled.
 func TestSyncPublisherDisabled(t *testing.T) {
-	if testing.Verbose() {
-		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"*"})
-	}
-
 	testPub := newTestPublisherNoBulk(FailedResponse)
 	testPub.pub.disabled = true
 	event := testEvent()

--- a/libbeat/publisher/worker_test.go
+++ b/libbeat/publisher/worker_test.go
@@ -1,6 +1,8 @@
 package publisher
 
 import (
+	"errors"
+	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -9,11 +11,11 @@ import (
 
 // Test sending events through the messageWorker.
 func TestMessageWorkerSend(t *testing.T) {
+	enableLogging([]string{"*"})
+	var wg sync.WaitGroup
 	// Setup
-	ws := &workerSignal{}
-	ws.Init()
 	mh := &testMessageHandler{msgs: make(chan message, 10), response: true}
-	mw := newMessageWorker(ws, 10, 0, mh)
+	mw := newMessageWorker(&wg, 10, 0, mh)
 
 	// Send an event.
 	s1 := newTestSignaler()
@@ -38,25 +40,10 @@ func TestMessageWorkerSend(t *testing.T) {
 	assert.Contains(t, msgs, m2)
 	assert.True(t, s2.wait())
 
-	// Verify that stopping workerSignal causes a onStop notification
-	// in the messageHandler.
-	ws.stop()
+	err = wait(mw.shutdown, errors.New("Failed to stop messageWorker"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	assert.True(t, atomic.LoadUint32(&mh.stopped) == 1)
-}
-
-// Test that stopQueue invokes the Failed callback on all events in the queue.
-func TestMessageWorkerStopQueue(t *testing.T) {
-	s1 := newTestSignaler()
-	m1 := message{context: Context{Signal: s1}}
-
-	s2 := newTestSignaler()
-	m2 := message{context: Context{Signal: s2}}
-
-	qu := make(chan message, 2)
-	qu <- m1
-	qu <- m2
-
-	stopQueue(qu)
-	assert.False(t, s1.wait())
-	assert.False(t, s2.wait())
 }

--- a/packetbeat/docs/command-line.asciidoc
+++ b/packetbeat/docs/command-line.asciidoc
@@ -33,8 +33,6 @@ Usage of ./packetbeat:
   -v  Log at INFO level
   -version
       Print version and exit
-  -waitstop int
-      Additional seconds to wait before shutting down
 ----------------------------------------------------------------------------
 
 ==== Packet-Beat Specific Options
@@ -59,9 +57,6 @@ For an infinite loop, use _0_. The `-l` option is useful only for testing Packet
 
 *`-t`*::
 Read the packets from the pcap file as fast as possible without sleeping. Use this option in combination with the `-I` option. The `-t` option is useful only for testing Packetbeat.
-
-*`-waitstop <n>`*::
-Wait an additional `n` seconds before exiting.
 
 ==== Other Options
 

--- a/packetbeat/protos/dns/dns.go
+++ b/packetbeat/protos/dns/dns.go
@@ -253,14 +253,8 @@ func (dns *Dns) Init(test_mode bool, results publish.Transactions) error {
 	dns.transactions = common.NewCacheWithRemovalListener(
 		dns.transactionTimeout,
 		protos.DefaultTransactionHashSize,
-		func(k common.Key, v common.Value) {
-			trans, ok := v.(*DnsTransaction)
-			if !ok {
-				logp.Err("Expired value is not a *DnsTransaction.")
-				return
-			}
-			dns.expireTransaction(trans)
-		})
+		dns.removalListener,
+	)
 	dns.transactions.StartJanitor(dns.transactionTimeout)
 
 	dns.results = results
@@ -385,10 +379,28 @@ func (dns *Dns) publishTransaction(t *DnsTransaction) {
 	dns.results.PublishTransaction(event)
 }
 
+func (dns *Dns) removalListener(k common.Key, v common.Value) {
+	trans, ok := v.(*DnsTransaction)
+	if !ok {
+		logp.Err("Expired value is not a *DnsTransaction.")
+		return
+	}
+	dns.expireTransaction(trans)
+}
+
 func (dns *Dns) expireTransaction(t *DnsTransaction) {
 	t.Notes = append(t.Notes, NoResponse.Error())
 	logp.Debug("dns", "%s %s", NoResponse.Error(), t.tuple.String())
 	dns.publishTransaction(t)
+}
+
+func (dns *Dns) Flush() {
+	dns.transactions.StopJanitor()
+	dns.transactions.CleanUp()
+
+	for k, v := range dns.transactions.Entries() {
+		dns.removalListener(k, v)
+	}
 }
 
 // Adds the DNS message data to the supplied MapStr.

--- a/packetbeat/protos/http/http.go
+++ b/packetbeat/protos/http/http.go
@@ -151,6 +151,8 @@ func (http *HTTP) Init(testMode bool, results publish.Transactions) error {
 	return nil
 }
 
+func (http *HTTP) Flush() {} // To implement ProtocolPlugin
+
 // messageGap is called when a gap of size `nbytes` is found in the
 // tcp stream. Decides if we can ignore the gap or it's a parser error
 // and we need to drop the stream.
@@ -418,7 +420,7 @@ func (http *HTTP) correlate(conn *httpConnectionData) {
 	// drop responses with missing requests
 	if conn.requests.empty() {
 		for !conn.responses.empty() {
-			logp.Warn("Response from unknown transaction. Ingoring.")
+			logp.Warn("Response from unknown transaction. Ignoring.")
 			conn.responses.pop()
 		}
 		return

--- a/packetbeat/protos/memcache/memcache.go
+++ b/packetbeat/protos/memcache/memcache.go
@@ -110,6 +110,8 @@ func (mc *Memcache) Init(testMode bool, results publish.Transactions) error {
 	)
 }
 
+func (mc *Memcache) Flush() {} // To implement ProtocolPlugin
+
 func (mc *Memcache) InitDefaults() {
 	if err := mc.Ports.Init(11211); err != nil {
 		logp.WTF("memcache default port number invalid")

--- a/packetbeat/protos/mongodb/mongodb.go
+++ b/packetbeat/protos/mongodb/mongodb.go
@@ -93,6 +93,8 @@ func (mongodb *Mongodb) Init(test_mode bool, results publish.Transactions) error
 	return nil
 }
 
+func (mongodb *Mongodb) Flush() {} // To implement ProtocolPlugin
+
 func (mongodb *Mongodb) ConnectionTimeout() time.Duration {
 	return mongodb.transactionTimeout
 }

--- a/packetbeat/protos/mysql/mysql.go
+++ b/packetbeat/protos/mysql/mysql.go
@@ -192,6 +192,8 @@ func (mysql *Mysql) Init(test_mode bool, results publish.Transactions) error {
 	return nil
 }
 
+func (stream *Mysql) Flush() {} // To implement ProtocolPlugin
+
 func (stream *MysqlStream) PrepareForNewMessage() {
 	stream.data = stream.data[stream.parseOffset:]
 	stream.parseState = mysqlStateStart

--- a/packetbeat/protos/pgsql/pgsql.go
+++ b/packetbeat/protos/pgsql/pgsql.go
@@ -179,6 +179,8 @@ func (pgsql *Pgsql) Init(test_mode bool, results publish.Transactions) error {
 	return nil
 }
 
+func (stream *Pgsql) Flush() {} // To implement ProtocolPlugin
+
 func (stream *PgsqlStream) PrepareForNewMessage() {
 	stream.data = stream.data[stream.message.end:]
 	stream.parseState = PgsqlStartState

--- a/packetbeat/protos/protos.go
+++ b/packetbeat/protos/protos.go
@@ -63,6 +63,9 @@ type ProtocolPlugin interface {
 
 	// Called to return the configured ports
 	GetPorts() []int
+
+	// Called to stop the janitor and publish all events
+	Flush()
 }
 
 type TcpProtocolPlugin interface {

--- a/packetbeat/protos/protos_test.go
+++ b/packetbeat/protos/protos_test.go
@@ -20,6 +20,10 @@ func (proto *TcpProtocol) Init(test_mode bool, results publish.Transactions) err
 	return nil
 }
 
+func (proto *TcpProtocol) Flush() {
+	return
+}
+
 func (proto *TcpProtocol) GetPorts() []int {
 	return proto.Ports
 }
@@ -47,6 +51,10 @@ func (proto *UdpProtocol) Init(test_mode bool, results publish.Transactions) err
 	return nil
 }
 
+func (proto *UdpProtocol) Flush() {
+	return
+}
+
 func (proto *UdpProtocol) GetPorts() []int {
 	return proto.Ports
 }
@@ -59,6 +67,10 @@ type TcpUdpProtocol TestProtocol
 
 func (proto *TcpUdpProtocol) Init(test_mode bool, results publish.Transactions) error {
 	return nil
+}
+
+func (proto *TcpUdpProtocol) Flush() {
+	return
 }
 
 func (proto *TcpUdpProtocol) GetPorts() []int {

--- a/packetbeat/protos/redis/redis.go
+++ b/packetbeat/protos/redis/redis.go
@@ -86,6 +86,8 @@ func (redis *Redis) Init(test_mode bool, results publish.Transactions) error {
 	return nil
 }
 
+func (redis *Redis) Flush() {} // To implement ProtocolPlugin
+
 func (s *stream) PrepareForNewMessage() {
 	parser := &s.parser
 	s.Stream.Reset()

--- a/packetbeat/protos/tcp/tcp_test.go
+++ b/packetbeat/protos/tcp/tcp_test.go
@@ -48,6 +48,10 @@ func (proto *TestProtocol) Init(test_mode bool, results publish.Transactions) er
 	return proto.init(test_mode, results)
 }
 
+func (proto *TestProtocol) Flush() {
+	return
+}
+
 func (proto TestProtocol) GetPorts() []int {
 	return proto.Ports
 }

--- a/packetbeat/protos/thrift/thrift.go
+++ b/packetbeat/protos/thrift/thrift.go
@@ -266,6 +266,8 @@ func (thrift *Thrift) Init(test_mode bool, results publish.Transactions) error {
 	return nil
 }
 
+func (m *Thrift) Flush() {} // To implement ProtocolPlugin
+
 func (m *ThriftMessage) String() string {
 	return fmt.Sprintf("IsRequest: %t Type: %d Method: %s SeqId: %d Params: %s ReturnValue: %s Exceptions: %s",
 		m.IsRequest, m.Type, m.Method, m.SeqId, m.Params, m.ReturnValue, m.Exceptions)

--- a/packetbeat/protos/udp/udp_test.go
+++ b/packetbeat/protos/udp/udp_test.go
@@ -60,6 +60,10 @@ func (proto *TestProtocol) Init(test_mode bool, results publish.Transactions) er
 	return nil
 }
 
+func (proto *TestProtocol) Flush() {
+	return
+}
+
 func (proto *TestProtocol) GetPorts() []int {
 	return proto.Ports
 }

--- a/packetbeat/tests/system/packetbeat.py
+++ b/packetbeat/tests/system/packetbeat.py
@@ -51,7 +51,6 @@ class BaseTest(TestCase):
             "-t",
             "-systemTest",
             "-test.coverprofile", os.path.join(self.working_dir, "coverage.cov"),
-            "-waitstop", str(wait_stop),
         ])
 
         if extra_args:

--- a/packetbeat/tests/system/test_0041_memcache_udp_bin_basic.py
+++ b/packetbeat/tests/system/test_0041_memcache_udp_bin_basic.py
@@ -16,7 +16,6 @@ class Test(BaseTest):
             memcache_udp_transaction_timeout=10
         )
         self.run_packetbeat(pcap=pcap,
-                            extra_args=['-waitstop', '1'],
                             debug_selectors=["memcache", "udp", "publish"])
         objs = self.read_output()
         self.assert_common(objs)

--- a/packetbeat/tests/system/test_0041_memcache_udp_text_basic.py
+++ b/packetbeat/tests/system/test_0041_memcache_udp_text_basic.py
@@ -16,7 +16,6 @@ class Test(BaseTest):
             memcache_udp_transaction_timeout=10
         )
         self.run_packetbeat(pcap=pcap,
-                            extra_args=['-waitstop', '1'],
                             debug_selectors=["memcache", "udp", "publish"])
         objs = self.read_output()
         self.assert_common(objs)


### PR DESCRIPTION
Requires #1056

#####  Packetbeat
* Use Libbeat new capability to wait for all go routines to finish before exiting from Packetbeat
* Add a Flush method to ProtocolPlugin that publishes all cached events. The method is called during cleanup, once the sniffer is stopped
* Remove waitstop CLI option

#####  Also
* Edit CHANGELOG