### PR TITLE
Fix bug that state was not persisted for rotated files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 .DS_Store
 /glide.lock
 /beats.iml
+*.dev.yml
 
 # Editor swap files
 *.swp

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -48,6 +48,7 @@ https://github.com/elastic/beats/compare/v1.1.0...master[Check the HEAD diff]
 - Stop filebeat if filebeat is started without any prospectors defined or empty prospectors {pull}644[644] {pull}647[647]
 - Improve shutdown of crawler and prospector to wait for clean completion {pull}720[720]
 - Omit `fields` from Filebeat events when null {issue}899[899]
+- - Fix registrar bug for rotated files {pull}1010[1010]
 
 *Winlogbeat*
 

--- a/filebeat/crawler/prospector_log.go
+++ b/filebeat/crawler/prospector_log.go
@@ -149,11 +149,12 @@ func (p ProspectorLog) checkNewFile(h *harvester.Harvester) {
 
 	logp.Debug("prospector", "Start harvesting unknown file: %s", h.Path)
 
+	// Call crawler if there if there exists a state for the given file
+	offset, resuming := p.Prospector.registrar.fetchState(h.Path, h.Stat.Fileinfo)
+
 	if p.checkOldFile(h) {
 
 		logp.Debug("prospector", "Fetching old state of file to resume: %s", h.Path)
-		// Call crawler if there if there exists a state for the given file
-		offset, resuming := p.Prospector.registrar.fetchState(h.Path, h.Stat.Fileinfo)
 
 		// Are we resuming a dead file? We have to resume even if dead so we catch any old updates to the file
 		// This is safe as the harvester, once it hits the EOF and a timeout, will stop harvesting
@@ -172,8 +173,6 @@ func (p ProspectorLog) checkNewFile(h *harvester.Harvester) {
 	} else if previousFile, err := p.getPreviousFile(h.Path, h.Stat.Fileinfo); err == nil {
 		p.continueExistingFile(h, previousFile)
 	} else {
-		// Call crawler if there if there exists a state for the given file
-		offset, _ := p.Prospector.registrar.fetchState(h.Path, h.Stat.Fileinfo)
 		p.resumeHarvesting(h, offset)
 	}
 }


### PR DESCRIPTION
Closes #1010

The problem was on line https://github.com/elastic/beats/compare/master...ruflin:filebeat-registry?expand=1#diff-2a61e3365287cd64ed0f6bf918cd7160R174 where fetchState was not called.