### PR TITLE
Proposal: JSON support in Filebeat

### DIFF
--- a/filebeat/config/config.go
+++ b/filebeat/config/config.go
@@ -71,11 +71,12 @@ type HarvesterConfig struct {
 	MaxBackoffDuration time.Duration
 	CloseOlder         string `config:"close_older"`
 	CloseOlderDuration time.Duration
-	ForceCloseFiles    bool             `config:"force_close_files"`
-	ExcludeLines       []string         `config:"exclude_lines"`
-	IncludeLines       []string         `config:"include_lines"`
-	MaxBytes           int              `config:"max_bytes"`
-	Multiline          *MultilineConfig `config:"multiline"`
+	ForceCloseFiles    bool               `config:"force_close_files"`
+	ExcludeLines       []string           `config:"exclude_lines"`
+	IncludeLines       []string           `config:"include_lines"`
+	MaxBytes           int                `config:"max_bytes"`
+	Multiline          *MultilineConfig   `config:"multiline"`
+	JsonDecoder        *JsonDecoderConfig `yaml:"json_decoder"`
 }
 
 type MultilineConfig struct {
@@ -84,6 +85,12 @@ type MultilineConfig struct {
 	MaxLines *int   `config:"max_lines"`
 	Pattern  string `config:"pattern"`
 	Timeout  string `config:"timeout"`
+}
+
+type JsonDecoderConfig struct {
+	OnUnmarshalError string `yaml:"on_unmarshal_error"`
+	OverwriteKeys    bool   `yaml:"overwrite_keys"`
+	KeepOriginal     bool   `yaml:"keep_original"`
 }
 
 const (

--- a/filebeat/etc/beat.yml
+++ b/filebeat/etc/beat.yml
@@ -140,10 +140,14 @@ filebeat:
       # file is skipped, as the reading starts at the end. We recommend to leave this option on false
       # but lower the ignore_older value to release files faster.
       #force_close_files: false
+      json_decoder:
+        on_unmarshal_error: add_error_key
+        overwrite_keys: true
+        keep_original: false
 
     # Additional stdin prospector
 
-      # Configuration to use stdin input
+    # Configuration to use stdin input
     #- input_type: stdin
 
 

--- a/filebeat/harvester/log.go
+++ b/filebeat/harvester/log.go
@@ -139,6 +139,7 @@ func (h *Harvester) Harvest() {
 				Fileinfo:      &info,
 			}
 
+			event.SetJsonDecoder(h.Config.JsonDecoder)
 			h.SpoolerChan <- event // ship the new event downstream
 		}
 

--- a/filebeat/input/file.go
+++ b/filebeat/input/file.go
@@ -1,9 +1,12 @@
 package input
 
 import (
+	"encoding/json"
+	"fmt"
 	"os"
 	"time"
 
+	"github.com/elastic/beats/filebeat/config"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 )
@@ -18,14 +21,16 @@ type File struct {
 // FileEvent is sent to the output and must contain all relevant information
 type FileEvent struct {
 	common.EventMetadata
-	ReadTime     time.Time
-	Source       *string
-	InputType    string
-	DocumentType string
-	Offset       int64
-	Bytes        int
-	Text         *string
-	Fileinfo     *os.FileInfo
+	ReadTime        time.Time
+	Source          *string
+	InputType       string
+	DocumentType    string
+	Offset          int64
+	Bytes           int
+	Text            *string
+	Fileinfo        *os.FileInfo
+	fieldsUnderRoot bool
+	jsonDecoder     *config.JsonDecoderConfig
 }
 
 type FileState struct {
@@ -55,6 +60,12 @@ func (f *FileEvent) GetState() *FileState {
 	return state
 }
 
+// SetJsonDecoder configures how to do JSON parsing. If nil is passed,
+// JSON decoding is disabled.
+func (f *FileEvent) SetJsonDecoder(jsonDecoder *config.JsonDecoderConfig) {
+	f.jsonDecoder = jsonDecoder
+}
+
 func (f *FileEvent) ToMapStr() common.MapStr {
 	event := common.MapStr{
 		common.EventMetadataKey: f.EventMetadata,
@@ -65,6 +76,29 @@ func (f *FileEvent) ToMapStr() common.MapStr {
 		"type":                  f.DocumentType,
 		"input_type":            f.InputType,
 		"count":                 1,
+	}
+
+	if f.jsonDecoder != nil {
+		var jsonObj common.MapStr
+		err := json.Unmarshal([]byte(*f.Text), &jsonObj)
+		if err != nil {
+			logp.Err("Error decoding JSON: %v", err)
+			if f.jsonDecoder.OnUnmarshalError == "add_error_key" {
+				event["json_error"] = fmt.Sprintf("Error decoding JSON: %v", err)
+			}
+		} else {
+			// no error, move keys into the object
+			for key, value := range jsonObj {
+				_, found := event[key]
+				if !found || f.jsonDecoder.OverwriteKeys {
+					event[key] = value
+				}
+			}
+
+			if !f.jsonDecoder.KeepOriginal {
+				delete(event, "message")
+			}
+		}
 	}
 
 	return event

--- a/filebeat/tests/files/logs/json.log
+++ b/filebeat/tests/files/logs/json.log
@@ -1,0 +1,3 @@
+{"host": "test", "timestamp": "2016-02-25 13:00:00", "module": "libbeat", "message": "hello json world"}
+{"host": "test", "timestamp": "2016-02-25 13:00:01", "module": "topbeat", "message": "hello topbeat"}
+{"host": "test", "timestamp": "2016-02-25 13:00:01", "module": "filebeat", "message": "hello filebeat"}


### PR DESCRIPTION
Played with this while in the air. Basic support for for JSON in Filebeat seems pretty easy to add, although I didn't yet add any tests as I first want to check some design choices with the team.

## Design choices

* Keys are copied top level into the document, to make it simple for the most common use cases. There is some configuration flexibility in terms of what to do in case of fields conflicts. See the **Config** section.
* The decoding happens after line filtering and before enriching the event with metadata. See the **Order of operations** section.

### Order of operations

With this PR, Filebeat will apply transformations in the following on each log line. The JSON decoding is at step 4:

1. Encoding decode
2. Multiline
3. Line Filtering
4. JSON decoding
5. Add custom and metadata fields
6. Generic filtering

### Config

This block can be placed per prospector:

```
      json_decoder:
        on_unmarshal_error: ignore | add_error_key
        overwrite_keys: true | false
        keep_original: false
```

The JSON decoder is enabled if the section is un-commented. In case of unmarshaling errors from JSON, you can choose between ignoring the error, which means that the event will still be published with the original `message` key, and adding a dedicated `json_error` key with information about the error. Default is `ignore`.

The `overwrite_keys` settings decides what to do if a top-level key from the decoded JSON already exists in the dictionary (things like `@timestamp`, `message`, `offset`, etc.). Default is `false`.

If set to `true`, the `keep_original` setting allows removing the `message` key in case of successful unmarshaling. In case of errors, the original `message` key is always kept.

Pinging @ruflin @urso @andrewkroh @monicasarbu 