### PR TITLE
Removal of golang.org/x/tools/cmd/cover

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -37,7 +37,7 @@ install:
   - ps: Push-AppveyorArtifact mingw-install.txt
   - set PATH=C:\tools\mingw64\bin;%GOROOT%\bin;%PATH%
   - set PATH=%GOPATH%\bin;%PATH%
-  - go get github.com/pierrre/gotestcover golang.org/x/tools/cmd/cover
+  - go get github.com/pierrre/gotestcover
   - set GO15VENDOREXPERIMENT=1
   - go version
   - go env

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,6 @@ RUN set -x \
   go get \
 	github.com/pierrre/gotestcover \
 	github.com/tsg/goautotest \
-	golang.org/x/tools/cmd/cover \
 	golang.org/x/tools/cmd/vet
 
 COPY libbeat/scripts/docker-entrypoint.sh /entrypoint.sh

--- a/libbeat/Dockerfile
+++ b/libbeat/Dockerfile
@@ -12,7 +12,6 @@ RUN set -x \
   go get \
 	github.com/pierrre/gotestcover \
 	github.com/tsg/goautotest \
-	golang.org/x/tools/cmd/cover \
 	golang.org/x/tools/cmd/vet
 
 ENV GO15VENDOREXPERIMENT=1

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -107,8 +107,6 @@ ci:
 .PHONY: prepare-tests
 prepare-tests:
 	mkdir -p ${COVERAGE_DIR}
-	# coverage tools
-	go get golang.org/x/tools/cmd/cover
 	# gotestcover is needed to fetch coverage for multiple packages
 	go get github.com/pierrre/gotestcover
 

--- a/metricbeat/Dockerfile
+++ b/metricbeat/Dockerfile
@@ -12,7 +12,6 @@ RUN set -x \
   go get \
 	github.com/pierrre/gotestcover \
 	github.com/tsg/goautotest \
-	golang.org/x/tools/cmd/cover \
 	golang.org/x/tools/cmd/vet
 
 # Setup work environment

--- a/packetbeat/Dockerfile
+++ b/packetbeat/Dockerfile
@@ -12,7 +12,6 @@ RUN set -x \
   go get \
 	github.com/pierrre/gotestcover \
 	github.com/tsg/goautotest \
-	golang.org/x/tools/cmd/cover \
 	golang.org/x/tools/cmd/vet
 
 ENV GO15VENDOREXPERIMENT=1


### PR DESCRIPTION
golang.org/x/tools/cmd/cover loading is not needed anymore as it is part of Golang 1.5

See https://github.com/mrkschan/nginxbeat/pull/41