### PR TITLE
Introduction of build flags for tests

### DIFF
--- a/filebeat/beater/filebeat_test.go
+++ b/filebeat/beater/filebeat_test.go
@@ -1,1 +1,3 @@
+// +build !integration
+
 package beater

--- a/filebeat/beater/publish_test.go
+++ b/filebeat/beater/publish_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package beater
 
 import (

--- a/filebeat/beater/spooler_test.go
+++ b/filebeat/beater/spooler_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package beater
 
 import (

--- a/filebeat/config/config_test.go
+++ b/filebeat/config/config_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package config
 
 import (

--- a/filebeat/crawler/crawler_test.go
+++ b/filebeat/crawler/crawler_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package crawler
 
 import (

--- a/filebeat/crawler/prospector_test.go
+++ b/filebeat/crawler/prospector_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package crawler
 
 import (

--- a/filebeat/harvester/encoding/reader_test.go
+++ b/filebeat/harvester/encoding/reader_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package encoding
 
 import (

--- a/filebeat/harvester/encoding/utf16_test.go
+++ b/filebeat/harvester/encoding/utf16_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package encoding
 
 import (

--- a/filebeat/harvester/harvester_test.go
+++ b/filebeat/harvester/harvester_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package harvester
 
 import (

--- a/filebeat/harvester/log_test.go
+++ b/filebeat/harvester/log_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package harvester
 
 import (

--- a/filebeat/harvester/processor/multiline_test.go
+++ b/filebeat/harvester/processor/multiline_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package processor
 
 import (

--- a/filebeat/harvester/processor/processor_test.go
+++ b/filebeat/harvester/processor/processor_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package processor
 
 import (

--- a/filebeat/harvester/util_test.go
+++ b/filebeat/harvester/util_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package harvester
 
 import (

--- a/filebeat/input/file_other_test.go
+++ b/filebeat/input/file_other_test.go
@@ -1,4 +1,4 @@
-// +build !windows
+// +build !windows,!integration
 
 package input
 

--- a/filebeat/input/file_test.go
+++ b/filebeat/input/file_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package input
 
 import (

--- a/filebeat/input/file_windows_test.go
+++ b/filebeat/input/file_windows_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package input
 
 import (

--- a/libbeat/beat/beat_test.go
+++ b/libbeat/beat/beat_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package beat
 
 import (

--- a/libbeat/cfgfile/cfgfile_test.go
+++ b/libbeat/cfgfile/cfgfile_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package cfgfile
 
 import (

--- a/libbeat/common/bytes_test.go
+++ b/libbeat/common/bytes_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package common
 
 import (

--- a/libbeat/common/cache_test.go
+++ b/libbeat/common/cache_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package common
 
 import (

--- a/libbeat/common/csv_test.go
+++ b/libbeat/common/csv_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package common
 
 import (

--- a/libbeat/common/datetime_test.go
+++ b/libbeat/common/datetime_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package common
 
 import (

--- a/libbeat/common/mapstr_test.go
+++ b/libbeat/common/mapstr_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package common
 
 import (

--- a/libbeat/common/net_test.go
+++ b/libbeat/common/net_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package common
 
 import (

--- a/libbeat/common/streambuf/ascii_test.go
+++ b/libbeat/common/streambuf/ascii_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package streambuf
 
 import (

--- a/libbeat/common/streambuf/io_test.go
+++ b/libbeat/common/streambuf/io_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package streambuf
 
 import (

--- a/libbeat/common/streambuf/net_test.go
+++ b/libbeat/common/streambuf/net_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package streambuf
 
 import (

--- a/libbeat/common/streambuf/streambuf_test.go
+++ b/libbeat/common/streambuf/streambuf_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package streambuf
 
 import (

--- a/libbeat/common/tuples_test.go
+++ b/libbeat/common/tuples_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package common
 
 import (

--- a/libbeat/logp/file_rotator_test.go
+++ b/libbeat/logp/file_rotator_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package logp
 
 import (

--- a/libbeat/outputs/console/console_test.go
+++ b/libbeat/outputs/console/console_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package console
 
 import (

--- a/libbeat/outputs/elasticsearch/api_integration_test.go
+++ b/libbeat/outputs/elasticsearch/api_integration_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package elasticsearch
 
 import (
@@ -12,10 +14,6 @@ func TestIndex(t *testing.T) {
 
 	if testing.Verbose() {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"elasticsearch"})
-	}
-
-	if testing.Short() {
-		t.Skip("Skipping in short mode, because it requires Elasticsearch")
 	}
 
 	client := GetTestingElasticsearch()

--- a/libbeat/outputs/elasticsearch/api_mock_test.go
+++ b/libbeat/outputs/elasticsearch/api_mock_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package elasticsearch
 
 import (

--- a/libbeat/outputs/elasticsearch/api_test.go
+++ b/libbeat/outputs/elasticsearch/api_test.go
@@ -1,3 +1,4 @@
+// Need for unit and integration tests
 package elasticsearch
 
 import (

--- a/libbeat/outputs/elasticsearch/bulkapi_integration_test.go
+++ b/libbeat/outputs/elasticsearch/bulkapi_integration_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package elasticsearch
 
 import (
@@ -11,9 +13,6 @@ import (
 func TestBulk(t *testing.T) {
 	if testing.Verbose() {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"elasticsearch"})
-	}
-	if testing.Short() {
-		t.Skip("Skipping in short mode, because it requires Elasticsearch")
 	}
 
 	client := GetTestingElasticsearch()
@@ -66,9 +65,6 @@ func TestEmptyBulk(t *testing.T) {
 	if testing.Verbose() {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"elasticsearch"})
 	}
-	if testing.Short() {
-		t.Skip("Skipping in short mode, because it requires Elasticsearch")
-	}
 
 	client := GetTestingElasticsearch()
 	index := fmt.Sprintf("packetbeat-unittest-%d", os.Getpid())
@@ -90,9 +86,6 @@ func TestEmptyBulk(t *testing.T) {
 func TestBulkMoreOperations(t *testing.T) {
 	if testing.Verbose() {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"elasticsearch"})
-	}
-	if testing.Short() {
-		t.Skip("Skipping in short mode, because it requires Elasticsearch")
 	}
 
 	client := GetTestingElasticsearch()

--- a/libbeat/outputs/elasticsearch/bulkapi_mock_test.go
+++ b/libbeat/outputs/elasticsearch/bulkapi_mock_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package elasticsearch
 
 import (

--- a/libbeat/outputs/elasticsearch/client_integration_test.go
+++ b/libbeat/outputs/elasticsearch/client_integration_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package elasticsearch
 
 import (
@@ -11,9 +13,6 @@ import (
 )
 
 func TestClientConnect(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping test in short mode because it requires ES")
-	}
 
 	client := GetTestingElasticsearch()
 	err := client.Connect(5 * time.Second)
@@ -23,9 +22,6 @@ func TestClientConnect(t *testing.T) {
 }
 
 func TestCheckTemplate(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping test in short mode because it requires ES")
-	}
 
 	client := GetTestingElasticsearch()
 	err := client.Connect(5 * time.Second)
@@ -36,9 +32,6 @@ func TestCheckTemplate(t *testing.T) {
 }
 
 func TestLoadTemplate(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping test in short mode because it requires ES")
-	}
 
 	// Load template
 	absPath, err := filepath.Abs("../../tests/files/")
@@ -73,9 +66,6 @@ func TestLoadTemplate(t *testing.T) {
 }
 
 func TestLoadInvalidTemplate(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping test in short mode because it requires ES")
-	}
 
 	// Invalid Template
 	reader := bytes.NewReader([]byte("{json:invalid}"))

--- a/libbeat/outputs/elasticsearch/client_test.go
+++ b/libbeat/outputs/elasticsearch/client_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package elasticsearch
 
 import (

--- a/libbeat/outputs/elasticsearch/output_test.go
+++ b/libbeat/outputs/elasticsearch/output_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package elasticsearch
 
 import (
@@ -44,9 +46,7 @@ func createElasticsearchConnection(flushInterval int, bulkSize int) elasticsearc
 }
 
 func TestTopologyInES(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping topology tests in short mode, because they require Elasticsearch")
-	}
+
 	if testing.Verbose() {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"topology", "output_elasticsearch"})
 	}
@@ -86,9 +86,7 @@ func TestTopologyInES(t *testing.T) {
 }
 
 func TestOneEvent(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping events publish in short mode, because they require Elasticsearch")
-	}
+
 	if testing.Verbose() {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"elasticsearch", "output_elasticsearch"})
 	}
@@ -160,9 +158,7 @@ func TestOneEvent(t *testing.T) {
 }
 
 func TestEvents(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping events publish in short mode, because they require Elasticsearch")
-	}
+
 	if testing.Verbose() {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"topology", "output_elasticsearch"})
 	}
@@ -300,9 +296,7 @@ func testBulkWithParams(t *testing.T, output elasticsearchOutput) {
 }
 
 func TestBulkEvents(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping events publish in short mode, because they require Elasticsearch")
-	}
+
 	if testing.Verbose() {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"topology", "output_elasticsearch", "elasticsearch"})
 	}
@@ -318,9 +312,7 @@ func TestBulkEvents(t *testing.T) {
 }
 
 func TestEnableTTL(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping events publish in short mode, because they require Elasticsearch")
-	}
+
 	if testing.Verbose() {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"topology", "output_elasticsearch", "elasticsearch"})
 	}

--- a/libbeat/outputs/elasticsearch/url_test.go
+++ b/libbeat/outputs/elasticsearch/url_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package elasticsearch
 
 import (

--- a/libbeat/outputs/fileout/file_test.go
+++ b/libbeat/outputs/fileout/file_test.go
@@ -1,1 +1,3 @@
+// +build !integration
+
 package fileout

--- a/libbeat/outputs/kafka/kafka_integration_test.go
+++ b/libbeat/outputs/kafka/kafka_integration_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package kafka
 
 import (

--- a/libbeat/outputs/logstash/client_test.go
+++ b/libbeat/outputs/logstash/client_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package logstash
 
 import (

--- a/libbeat/outputs/logstash/logstash_integration_test.go
+++ b/libbeat/outputs/logstash/logstash_integration_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package logstash
 
 import (
@@ -16,8 +18,6 @@ import (
 )
 
 const (
-	logstashDefaultHost        = "localhost"
-	logstashTestDefaultPort    = "5044"
 	logstashTestDefaultTLSPort = "5055"
 
 	elasticsearchDefaultHost = "localhost"
@@ -49,24 +49,6 @@ type esValueReader interface {
 type esCountReader interface {
 	esSoure
 	Count() (int, error)
-}
-
-func strDefault(a, defaults string) string {
-	if len(a) == 0 {
-		return defaults
-	}
-	return a
-}
-
-func getenv(name, defaultValue string) string {
-	return strDefault(os.Getenv(name), defaultValue)
-}
-
-func getLogstashHost() string {
-	return fmt.Sprintf("%v:%v",
-		getenv("LS_HOST", logstashDefaultHost),
-		getenv("LS_TCP_PORT", logstashTestDefaultPort),
-	)
 }
 
 func getLogstashTLSHost() string {
@@ -262,9 +244,6 @@ func TestSendMessageViaLogstashTLS(t *testing.T) {
 }
 
 func testSendMessageViaLogstash(t *testing.T, name string, tls bool) {
-	if testing.Short() {
-		t.Skip("Skipping in short mode. Requires Logstash and Elasticsearch")
-	}
 
 	ls := newTestLogstashOutput(t, name, tls)
 	defer ls.Cleanup()
@@ -299,9 +278,6 @@ func TestSendMultipleViaLogstashTLS(t *testing.T) {
 }
 
 func testSendMultipleViaLogstash(t *testing.T, name string, tls bool) {
-	if testing.Short() {
-		t.Skip("Skipping in short mode. Requires Logstash and Elasticsearch")
-	}
 
 	ls := newTestLogstashOutput(t, name, tls)
 	defer ls.Cleanup()
@@ -359,9 +335,6 @@ func testSendMultipleBatchesViaLogstash(
 	batchSize int,
 	tls bool,
 ) {
-	if testing.Short() {
-		t.Skip("Skipping in short mode. Requires Logstash and Elasticsearch")
-	}
 
 	ls := newTestLogstashOutput(t, name, tls)
 	defer ls.Cleanup()
@@ -411,9 +384,6 @@ func TestLogstashElasticOutputPluginCompatibleMessageTLS(t *testing.T) {
 }
 
 func testLogstashElasticOutputPluginCompatibleMessage(t *testing.T, name string, tls bool) {
-	if testing.Short() {
-		t.Skip("Skipping in short mode. Requires Logstash and Elasticsearch")
-	}
 
 	timeout := 10 * time.Second
 
@@ -465,9 +435,6 @@ func TestLogstashElasticOutputPluginBulkCompatibleMessageTLS(t *testing.T) {
 }
 
 func testLogstashElasticOutputPluginBulkCompatibleMessage(t *testing.T, name string, tls bool) {
-	if testing.Short() {
-		t.Skip("Skipping in short mode. Requires Logstash and Elasticsearch")
-	}
 
 	timeout := 10 * time.Second
 

--- a/libbeat/outputs/logstash/logstash_test.go
+++ b/libbeat/outputs/logstash/logstash_test.go
@@ -1,3 +1,5 @@
+// Need for unit and integration tests
+
 package logstash
 
 import (
@@ -21,6 +23,11 @@ import (
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/streambuf"
 	"github.com/elastic/beats/libbeat/outputs"
+)
+
+const (
+	logstashDefaultHost     = "localhost"
+	logstashTestDefaultPort = "5044"
 )
 
 type mockLSServer struct {
@@ -56,6 +63,24 @@ func (m *mockLSServer) sendACK(client net.Conn, seq uint32) {
 	if m.err == nil {
 		m.err = sockSendACK(client, seq)
 	}
+}
+
+func strDefault(a, defaults string) string {
+	if len(a) == 0 {
+		return defaults
+	}
+	return a
+}
+
+func getenv(name, defaultValue string) string {
+	return strDefault(os.Getenv(name), defaultValue)
+}
+
+func getLogstashHost() string {
+	return fmt.Sprintf("%v:%v",
+		getenv("LS_HOST", logstashDefaultHost),
+		getenv("LS_TCP_PORT", logstashTestDefaultPort),
+	)
 }
 
 func testEvent() common.MapStr {

--- a/libbeat/outputs/logstash/protocol_test.go
+++ b/libbeat/outputs/logstash/protocol_test.go
@@ -1,3 +1,5 @@
+// Need for unit and integration tests
+
 package logstash
 
 import (

--- a/libbeat/outputs/logstash/sync_test.go
+++ b/libbeat/outputs/logstash/sync_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package logstash
 
 import (

--- a/libbeat/outputs/logstash/transport_test.go
+++ b/libbeat/outputs/logstash/transport_test.go
@@ -1,3 +1,5 @@
+// Need for unit and integration tests
+
 package logstash
 
 import (

--- a/libbeat/outputs/logstash/window_test.go
+++ b/libbeat/outputs/logstash/window_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package logstash
 
 import (

--- a/libbeat/outputs/mode/balance_async_test.go
+++ b/libbeat/outputs/mode/balance_async_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package mode
 
 import (

--- a/libbeat/outputs/mode/balance_test.go
+++ b/libbeat/outputs/mode/balance_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package mode
 
 import (

--- a/libbeat/outputs/mode/failover_test.go
+++ b/libbeat/outputs/mode/failover_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package mode
 
 import (

--- a/libbeat/outputs/mode/mode_test.go
+++ b/libbeat/outputs/mode/mode_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package mode
 
 import (

--- a/libbeat/outputs/mode/single_test.go
+++ b/libbeat/outputs/mode/single_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package mode
 
 import (

--- a/libbeat/outputs/redis/redis_test.go
+++ b/libbeat/outputs/redis/redis_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package redis
 
 import (
@@ -26,9 +28,6 @@ func GetRedisAddr() string {
 }
 
 func TestTopologyInRedis(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping topology tests in short mode, because they require REDIS")
-	}
 
 	var redisOutput1 = redisOutput{
 		Index:          "packetbeat",

--- a/libbeat/outputs/tls_test.go
+++ b/libbeat/outputs/tls_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package outputs
 
 import (

--- a/libbeat/publisher/async_test.go
+++ b/libbeat/publisher/async_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package publisher
 
 import (

--- a/libbeat/publisher/bulk_test.go
+++ b/libbeat/publisher/bulk_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package publisher
 
 import (

--- a/libbeat/publisher/client_test.go
+++ b/libbeat/publisher/client_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package publisher
 
 import (

--- a/libbeat/publisher/common_test.go
+++ b/libbeat/publisher/common_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package publisher
 
 import (
@@ -141,6 +143,9 @@ const (
 
 func newTestPublisher(bulkSize int, response OutputResponse) *testPublisher {
 	pub := &PublisherType{}
+	pub.wsOutput.Init()
+	pub.wsPublisher.Init()
+
 	mh := &testMessageHandler{
 		msgs:     make(chan message, 10),
 		response: response,
@@ -153,8 +158,6 @@ func newTestPublisher(bulkSize int, response OutputResponse) *testPublisher {
 
 	pub.Output = []*outputWorker{ow}
 
-	pub.wsOutput.Init()
-	pub.wsPublisher.Init()
 	pub.syncPublisher = newSyncPublisher(pub, defaultChanSize, defaultBulkChanSize)
 	pub.asyncPublisher = newAsyncPublisher(pub, defaultChanSize, defaultBulkChanSize, &pub.wsPublisher)
 	return &testPublisher{

--- a/libbeat/publisher/output_test.go
+++ b/libbeat/publisher/output_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package publisher
 
 import (

--- a/libbeat/publisher/publish_test.go
+++ b/libbeat/publisher/publish_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package publisher
 
 import (

--- a/libbeat/publisher/sync_test.go
+++ b/libbeat/publisher/sync_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package publisher
 
 import (

--- a/libbeat/publisher/worker_test.go
+++ b/libbeat/publisher/worker_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package publisher
 
 import (

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -114,24 +114,25 @@ prepare-tests:
 # Race is not enabled for unit tests because tests run much slower.
 .PHONY: unit-tests
 unit-tests: prepare-tests
-	$(GOPATH)/bin/gotestcover $(RACE) -coverprofile=${COVERAGE_DIR}/unit.cov -short ${GOPACKAGES}
+	$(GOPATH)/bin/gotestcover $(RACE) -coverprofile=${COVERAGE_DIR}/unit.cov  ${GOPACKAGES}
+
 
 # Runs the unit tests without coverage reports.
 .PHONY: unit
 unit:
-	go test $(RACE) -short ${GOPACKAGES}
+	go test $(RACE) ${GOPACKAGES}
 
 # Run integration tests. Unit tests are run as part of the integration tests.
 .PHONY: integration-tests
 integration-tests: prepare-tests
-	$(GOPATH)/bin/gotestcover $(RACE) -coverprofile=${COVERAGE_DIR}/integration.cov ${GOPACKAGES}
+	$(GOPATH)/bin/gotestcover -tags=integration $(RACE) -coverprofile=${COVERAGE_DIR}/integration.cov  ${GOPACKAGES}
 
 # Runs the integration inside a virtual environment. This can be run on any docker-machine (local, remote)
 .PHONY: integration-tests-environment
 integration-tests-environment:
 	$(MAKE) prepare-tests
 	$(MAKE) build-image
-	${DOCKER_COMPOSE} run beat make integration-tests
+	${DOCKER_COMPOSE} run beat make integration-tests RACE_DETECTOR=$(RACE_DETECTOR)
 
 # Runs the system tests
 .PHONY: system-tests
@@ -144,6 +145,12 @@ system-tests: buildbeat.test prepare-tests python-env
 fast-system-tests: buildbeat.test python-env
 	. ${PYTHON_ENV}/bin/activate; nosetests -w tests/system --processes=$(PROCESSES) --process-timeout=$(TIMEOUT)
 
+# Run benchmark tests
+.PHONY: benchmark-tests
+benchmark-tests:
+	# No benchmark tests exist so far
+	#go test -bench=. ${GOPACKAGES}
+
 # Sets up the virtual python environment
 .PHONY: python-env
 python-env: ${ES_BEATS}/libbeat/tests/system/requirements.txt
@@ -153,12 +160,6 @@ python-env: ${ES_BEATS}/libbeat/tests/system/requirements.txt
 	else \
 		. ${PYTHON_ENV}/bin/activate && pip install -Ur ${ES_BEATS}/libbeat/tests/system/requirements.txt ; \
 	fi
-
-# Run benchmark tests
-.PHONY: benchmark-tests
-benchmark-tests:
-	# No benchmark tests exist so far
-	#go test -short -bench=. ./...
 
 # Runs unit and system tests without coverage reports
 .PHONY: test
@@ -170,6 +171,8 @@ test: unit
 # Runs all tests and generates the coverage reports
 .PHONY: testsuite
 testsuite:
+	$(MAKE) unit-tests
+
 	# Setups environment if TEST_ENVIRONMENT is set to true
 	if [ $(TEST_ENVIRONMENT) = true ]; then \
 		 $(MAKE) integration-tests-environment; \

--- a/metricbeat/helper/register_test.go
+++ b/metricbeat/helper/register_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package helper
 
 import (

--- a/metricbeat/module/mysql/mysql_test.go
+++ b/metricbeat/module/mysql/mysql_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package mysql
 
 import (
@@ -7,10 +9,6 @@ import (
 )
 
 func TestConnect(t *testing.T) {
-
-	if testing.Short() {
-		t.Skip("Skipping in short mode, because it requires MySQL")
-	}
 
 	db, err := Connect(GetMySQLEnvDSN())
 	assert.NoError(t, err)

--- a/metricbeat/module/mysql/status/status_test.go
+++ b/metricbeat/module/mysql/status/status_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package status
 
 import (
@@ -10,10 +12,6 @@ import (
 )
 
 func TestFetch(t *testing.T) {
-
-	if testing.Short() {
-		t.Skip("Skipping in short mode, because it requires MySQL")
-	}
 
 	config := helper.ModuleConfig{
 		Hosts: []string{mysql.GetMySQLEnvDSN()},

--- a/metricbeat/module/redis/info/info_test.go
+++ b/metricbeat/module/redis/info/info_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package info
 
 import (
@@ -25,10 +27,6 @@ type RedisModuleConfig struct {
 }
 
 func TestConnect(t *testing.T) {
-
-	if testing.Short() {
-		t.Skip("Skipping in short mode, because it requires Redis")
-	}
 
 	config, _ := ucfg.NewFrom(RedisModuleConfig{
 		Module:  "redis",

--- a/metricbeat/module/redis/redis_test.go
+++ b/metricbeat/module/redis/redis_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package redis
 
 import (
@@ -8,10 +10,6 @@ import (
 )
 
 func TestConnect(t *testing.T) {
-
-	if testing.Short() {
-		t.Skip("Skipping in short mode, because it requires Redis")
-	}
 
 	_, err := Connect(GetRedisEnvHost() + ":" + GetRedisEnvPort())
 	assert.NoError(t, err)

--- a/packetbeat/decoder/decoder_test.go
+++ b/packetbeat/decoder/decoder_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package decoder
 
 import (

--- a/packetbeat/flows/flowid_test.go
+++ b/packetbeat/flows/flowid_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package flows
 
 import (

--- a/packetbeat/flows/flows_test.go
+++ b/packetbeat/flows/flows_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package flows
 
 import (

--- a/packetbeat/procs/procs_test.go
+++ b/packetbeat/procs/procs_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package procs
 
 import (

--- a/packetbeat/protos/dns/dns_tcp_test.go
+++ b/packetbeat/protos/dns/dns_tcp_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 // Unit tests and benchmarks for the dns package.
 //
 // The byte array test data was generated from pcap files using the gopacket

--- a/packetbeat/protos/dns/dns_test.go
+++ b/packetbeat/protos/dns/dns_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 // Common variables, functions and tests for the dns package tests
 
 package dns

--- a/packetbeat/protos/dns/dns_udp_test.go
+++ b/packetbeat/protos/dns/dns_udp_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 // Unit tests and benchmarks for the dns package.
 //
 // The byte array test data was generated from pcap files using the gopacket

--- a/packetbeat/protos/http/http_test.go
+++ b/packetbeat/protos/http/http_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package http
 
 import (

--- a/packetbeat/protos/icmp/icmp_test.go
+++ b/packetbeat/protos/icmp/icmp_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package icmp
 
 import (

--- a/packetbeat/protos/icmp/message_test.go
+++ b/packetbeat/protos/icmp/message_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package icmp
 
 import (

--- a/packetbeat/protos/icmp/transaction_test.go
+++ b/packetbeat/protos/icmp/transaction_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package icmp
 
 import (

--- a/packetbeat/protos/icmp/tuple_test.go
+++ b/packetbeat/protos/icmp/tuple_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package icmp
 
 import (

--- a/packetbeat/protos/memcache/binary_test.go
+++ b/packetbeat/protos/memcache/binary_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package memcache
 
 import (

--- a/packetbeat/protos/memcache/memcache_test.go
+++ b/packetbeat/protos/memcache/memcache_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package memcache
 
 import (

--- a/packetbeat/protos/memcache/parse_test.go
+++ b/packetbeat/protos/memcache/parse_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package memcache
 
 import (

--- a/packetbeat/protos/memcache/plugin_udp_test.go
+++ b/packetbeat/protos/memcache/plugin_udp_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package memcache
 
 import (

--- a/packetbeat/protos/memcache/text_test.go
+++ b/packetbeat/protos/memcache/text_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package memcache
 
 import (

--- a/packetbeat/protos/mongodb/mongodb_parser_test.go
+++ b/packetbeat/protos/mongodb/mongodb_parser_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package mongodb
 
 import (

--- a/packetbeat/protos/mongodb/mongodb_test.go
+++ b/packetbeat/protos/mongodb/mongodb_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package mongodb
 
 import (

--- a/packetbeat/protos/mysql/mysql_test.go
+++ b/packetbeat/protos/mysql/mysql_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package mysql
 
 import (

--- a/packetbeat/protos/pgsql/pgsql_test.go
+++ b/packetbeat/protos/pgsql/pgsql_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package pgsql
 
 import (

--- a/packetbeat/protos/protos_test.go
+++ b/packetbeat/protos/protos_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package protos
 
 import (

--- a/packetbeat/protos/redis/redis_test.go
+++ b/packetbeat/protos/redis/redis_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package redis
 
 import (

--- a/packetbeat/protos/tcp/tcp_test.go
+++ b/packetbeat/protos/tcp/tcp_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package tcp
 
 import (

--- a/packetbeat/protos/thrift/thrift_test.go
+++ b/packetbeat/protos/thrift/thrift_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package thrift
 
 import (

--- a/packetbeat/protos/udp/udp_test.go
+++ b/packetbeat/protos/udp/udp_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package udp
 
 import (

--- a/packetbeat/publish/publish_test.go
+++ b/packetbeat/publish/publish_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package publish
 
 import (

--- a/packetbeat/sniffer/sniffer_test.go
+++ b/packetbeat/sniffer/sniffer_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package sniffer
 
 import (

--- a/topbeat/beater/sigar_test.go
+++ b/topbeat/beater/sigar_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package beater
 
 import (

--- a/topbeat/beater/topbeat_test.go
+++ b/topbeat/beater/topbeat_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package beater
 
 import (

--- a/winlogbeat/checkpoint/checkpoint_test.go
+++ b/winlogbeat/checkpoint/checkpoint_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package checkpoint
 
 import (

--- a/winlogbeat/config/config_test.go
+++ b/winlogbeat/config/config_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package config
 
 import (

--- a/winlogbeat/eventlog/eventlogging_test.go
+++ b/winlogbeat/eventlog/eventlogging_test.go
@@ -1,4 +1,4 @@
-// +build windows
+// +build windows,integration
 
 package eventlog
 
@@ -145,9 +145,7 @@ func uninstallLog(provider, source string, log *elog.Log) error {
 
 // Verify that all messages are read from the event log.
 func TestRead(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping integration test in short mode.")
-	}
+
 	configureLogp()
 	log, err := initLog(providerName, sourceName, eventCreateMsgFile)
 	if err != nil {
@@ -210,9 +208,7 @@ func TestRead(t *testing.T) {
 // Test that when an unknown Event ID is found, that a message containing the
 // insert strings (the message parameters) is returned.
 func TestReadUnknownEventId(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping integration test in short mode.")
-	}
+
 	configureLogp()
 	log, err := initLog(providerName, sourceName, servicesMsgFile)
 	if err != nil {
@@ -268,9 +264,7 @@ func TestReadUnknownEventId(t *testing.T) {
 // separated list of files. If the message for an event ID is not found in one
 // of the files then the next file should be checked.
 func TestReadTriesMultipleEventMsgFiles(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping integration test in short mode.")
-	}
+
 	configureLogp()
 	log, err := initLog(providerName, sourceName,
 		servicesMsgFile+";"+eventCreateMsgFile)
@@ -322,9 +316,7 @@ func TestReadTriesMultipleEventMsgFiles(t *testing.T) {
 
 // Test event messages that require more than one message parameter.
 func TestReadMultiParameterMsg(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping integration test in short mode.")
-	}
+
 	configureLogp()
 	log, err := initLog(providerName, sourceName, servicesMsgFile)
 	if err != nil {
@@ -382,9 +374,7 @@ func TestReadMultiParameterMsg(t *testing.T) {
 // Verify that opening an invalid provider succeeds. Windows opens the
 // Application event log provider when this happens (unfortunately).
 func TestOpenInvalidProvider(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping integration test in short mode.")
-	}
+
 	configureLogp()
 
 	el, err := newEventLogging(Config{Name: "nonExistentProvider"})
@@ -399,9 +389,7 @@ func TestOpenInvalidProvider(t *testing.T) {
 
 // Test event messages that require no parameters.
 func TestReadNoParameterMsg(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping integration test in short mode.")
-	}
+
 	configureLogp()
 	log, err := initLog(providerName, sourceName, netEventMsgFile)
 	if err != nil {
@@ -455,9 +443,7 @@ func TestReadNoParameterMsg(t *testing.T) {
 // TestReadWhileCleared tests that the Read method recovers from the event log
 // being cleared or reset while reading.
 func TestReadWhileCleared(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping integration test in short mode.")
-	}
+
 	configureLogp()
 	log, err := initLog(providerName, sourceName, eventCreateMsgFile)
 	if err != nil {

--- a/winlogbeat/sys/eventlogging/common_test.go
+++ b/winlogbeat/sys/eventlogging/common_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package eventlogging
 
 import (

--- a/winlogbeat/sys/eventlogging/syscall_windows_test.go
+++ b/winlogbeat/sys/eventlogging/syscall_windows_test.go
@@ -1,4 +1,4 @@
-// build +windows
+// build +windows,!integration
 
 package eventlogging
 


### PR DESCRIPTION
Every test file must now have a build flag, either unit or integration. Further test flags like benachmark can be added later if needed.

Before integration tests included unit tests. This is not the case anymore as now the test can be differentiated from each other. This also means testing.Short() is not needed anymore.

Closes https://github.com/elastic/beats/issues/950