### PR TITLE
Ensure proper shutdown of libbeat

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -74,6 +74,7 @@ https://github.com/elastic/beats/compare/v1.1.0...master[Check the HEAD diff]
 - Add experimental Kafka output. {pull}942[942]
 - Add config file option to configure GOMAXPROCS. {pull}969[969]
 - Added a `fields` and `fields_under_root` as options available under the `shipper` configuration {pull}1092[1092]
+- Ensure proper shutdown of libbeat. {pull}1075[1075]
 
 *Packetbeat*
 - Change the DNS library used throughout the dns package to github.com/miekg/dns. {pull}803[803]

--- a/libbeat/common/worker.go
+++ b/libbeat/common/worker.go
@@ -1,0 +1,45 @@
+package common
+
+import (
+	"sync"
+)
+
+// WorkerSignal ensure all events have been
+// treated before closing Go routines
+type WorkerSignal struct {
+	Done     chan struct{}
+	wgEvent  sync.WaitGroup
+	wgWorker sync.WaitGroup
+}
+
+func NewWorkerSignal() *WorkerSignal {
+	w := &WorkerSignal{}
+	w.Init()
+	return w
+}
+
+func (ws *WorkerSignal) Init() {
+	ws.Done = make(chan struct{})
+}
+
+func (ws *WorkerSignal) AddEvent(delta int) {
+	ws.wgEvent.Add(delta)
+}
+
+func (ws *WorkerSignal) DoneEvent() {
+	ws.wgEvent.Done()
+}
+
+func (ws *WorkerSignal) WorkerStart() {
+	ws.wgWorker.Add(1)
+}
+
+func (ws *WorkerSignal) WorkerFinished() {
+	ws.wgWorker.Done()
+}
+
+func (ws *WorkerSignal) Stop() {
+	ws.wgEvent.Wait()  // Wait for all events to be dealt with
+	close(ws.Done)     // Ask Go routines to exit
+	ws.wgWorker.Wait() // Wait for Go routines to finish
+}

--- a/libbeat/outputs/console/console.go
+++ b/libbeat/outputs/console/console.go
@@ -45,6 +45,11 @@ func writeBuffer(buf []byte) error {
 	return nil
 }
 
+// Implement Outputer
+func (c *console) Close() error {
+	return nil
+}
+
 func (c *console) PublishEvent(
 	s outputs.Signaler,
 	opts outputs.Options,

--- a/libbeat/outputs/elasticsearch/output.go
+++ b/libbeat/outputs/elasticsearch/output.go
@@ -204,6 +204,10 @@ func makeClientFactory(
 	}
 }
 
+func (out *elasticsearchOutput) Close() error {
+	return out.mode.Close()
+}
+
 func (out *elasticsearchOutput) PublishEvent(
 	signaler outputs.Signaler,
 	opts outputs.Options,

--- a/libbeat/outputs/fileout/file.go
+++ b/libbeat/outputs/fileout/file.go
@@ -64,6 +64,11 @@ func (out *fileOutput) init(config config) error {
 	return nil
 }
 
+// Implement Outputer
+func (out *fileOutput) Close() error {
+	return nil
+}
+
 func (out *fileOutput) PublishEvent(
 	trans outputs.Signaler,
 	opts outputs.Options,

--- a/libbeat/outputs/kafka/kafka.go
+++ b/libbeat/outputs/kafka/kafka.go
@@ -109,6 +109,10 @@ func (k *kafka) init(cfg *ucfg.Config) error {
 	return nil
 }
 
+func (k *kafka) Close() error {
+	return k.mode.Close()
+}
+
 func (k *kafka) PublishEvent(
 	signal outputs.Signaler,
 	opts outputs.Options,

--- a/libbeat/outputs/logstash/logstash.go
+++ b/libbeat/outputs/logstash/logstash.go
@@ -112,6 +112,10 @@ func makeTLSClient(port int, tls *tls.Config) func(string) (TransportClient, err
 	}
 }
 
+func (lj *logstash) Close() error {
+	return lj.mode.Close()
+}
+
 // TODO: update Outputer interface to support multiple events for batch-like
 //       processing (e.g. for filebeat). Batch like processing might reduce
 //       send/receive overhead per event for other implementors too.

--- a/libbeat/outputs/mode/balance_async_test.go
+++ b/libbeat/outputs/mode/balance_async_test.go
@@ -22,9 +22,8 @@ func TestAsyncLBStartStop(t *testing.T) {
 }
 
 func testAsyncLBFailSendWithoutActiveConnection(t *testing.T, events []eventInfo) {
-	if testing.Verbose() {
-		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"*"})
-	}
+	enableLogging([]string{"*"})
+
 	errFail := errors.New("fail connect")
 	mode, _ := NewAsyncConnectionMode(
 		[]AsyncProtocolClient{
@@ -57,6 +56,8 @@ func TestAsyncLBFailSendMultWithoutActiveConnections(t *testing.T) {
 }
 
 func testAsyncLBOKSend(t *testing.T, events []eventInfo) {
+	enableLogging([]string{"*"})
+
 	var collected [][]common.MapStr
 	mode, _ := NewAsyncConnectionMode(
 		[]AsyncProtocolClient{

--- a/libbeat/outputs/mode/mode_test.go
+++ b/libbeat/outputs/mode/mode_test.go
@@ -217,7 +217,12 @@ func testMode(
 	expectedSignals []bool,
 	collectedEvents *[][]common.MapStr,
 ) {
-	defer mode.Close()
+	defer func() {
+		err := mode.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
 
 	if events == nil {
 		return

--- a/libbeat/outputs/outputs.go
+++ b/libbeat/outputs/outputs.go
@@ -13,8 +13,9 @@ type Options struct {
 
 type Outputer interface {
 	// Publish event
-
 	PublishEvent(trans Signaler, opts Options, event common.MapStr) error
+
+	Close() error
 }
 
 type TopologyOutputer interface {

--- a/libbeat/outputs/redis/redis.go
+++ b/libbeat/outputs/redis/redis.go
@@ -160,8 +160,8 @@ func (out *redisOutput) Connect() error {
 	return nil
 }
 
-func (out *redisOutput) Close() {
-	_ = out.Conn.Close()
+func (out *redisOutput) Close() error {
+	return out.Conn.Close()
 }
 
 func (out *redisOutput) Reconnect() {

--- a/libbeat/publisher/bulk_test.go
+++ b/libbeat/publisher/bulk_test.go
@@ -18,12 +18,14 @@ const (
 // Send a single event to the bulkWorker and verify that the event
 // is sent after the flush timeout occurs.
 func TestBulkWorkerSendSingle(t *testing.T) {
+	enableLogging([]string{"*"})
+	ws := common.NewWorkerSignal()
+	defer ws.Stop()
+
 	mh := &testMessageHandler{
 		response: CompletedResponse,
 		msgs:     make(chan message, queueSize),
 	}
-	ws := newWorkerSignal()
-	defer ws.stop()
 	bw := newBulkWorker(ws, queueSize, bulkQueueSize, mh, flushInterval, maxBatchSize)
 
 	s := newTestSignaler()
@@ -37,16 +39,39 @@ func TestBulkWorkerSendSingle(t *testing.T) {
 	assert.Equal(t, m.event, msgs[0].events[0])
 }
 
-// Send a batch of events to the bulkWorker and verify that a single
-// message is distributed (not triggered by flush timeout).
-func TestBulkWorkerSendBatch(t *testing.T) {
-	// Setup
+// Send a single event to a bulkWorker and verify that the event
+// is sent (flushed) after shutdown.
+func TestBulkWorkerShutdownSendSingle(t *testing.T) {
+	ws := common.NewWorkerSignal()
 	mh := &testMessageHandler{
 		response: CompletedResponse,
 		msgs:     make(chan message, queueSize),
 	}
-	ws := newWorkerSignal()
-	defer ws.stop()
+	bw := newBulkWorker(ws, queueSize, bulkQueueSize, mh, flushInterval, maxBatchSize)
+
+	s := newTestSignaler()
+	m := testMessage(s, testEvent())
+	bw.send(m)
+
+	ws.Stop()
+
+	close(mh.msgs)
+	assert.Equal(t, 1, len(mh.msgs))
+	assert.True(t, s.wait())
+	assert.Equal(t, m.event, (<-mh.msgs).events[0])
+}
+
+// Send a batch of events to the bulkWorker and verify that a single
+// message is distributed (not triggered by flush timeout).
+func TestBulkWorkerSendBatch(t *testing.T) {
+	// Setup
+	ws := common.NewWorkerSignal()
+	defer ws.Stop()
+
+	mh := &testMessageHandler{
+		response: CompletedResponse,
+		msgs:     make(chan message, queueSize),
+	}
 	bw := newBulkWorker(ws, queueSize, 0, mh, time.Duration(time.Hour), maxBatchSize)
 
 	events := make([]common.MapStr, maxBatchSize)
@@ -71,12 +96,13 @@ func TestBulkWorkerSendBatch(t *testing.T) {
 // that the events are split across two messages.
 func TestBulkWorkerSendBatchGreaterThanMaxBatchSize(t *testing.T) {
 	// Setup
+	ws := common.NewWorkerSignal()
+	defer ws.Stop()
+
 	mh := &testMessageHandler{
 		response: CompletedResponse,
 		msgs:     make(chan message),
 	}
-	ws := newWorkerSignal()
-	defer ws.stop()
 	bw := newBulkWorker(ws, queueSize, 0, mh, flushInterval, maxBatchSize)
 
 	// Send

--- a/libbeat/publisher/output.go
+++ b/libbeat/publisher/output.go
@@ -36,7 +36,7 @@ var (
 func newOutputWorker(
 	cfg *ucfg.Config,
 	out outputs.Outputer,
-	ws *workerSignal,
+	ws *common.WorkerSignal,
 	hwm int,
 	bulkHWM int,
 ) *outputWorker {
@@ -56,7 +56,12 @@ func newOutputWorker(
 	return o
 }
 
-func (o *outputWorker) onStop() {}
+func (o *outputWorker) onStop() {
+	err := o.out.Close()
+	if err != nil {
+		logp.Info("Failed to close outputer: %s", err)
+	}
+}
 
 func (o *outputWorker) onMessage(m message) {
 	if m.event != nil {

--- a/libbeat/publisher/output_test.go
+++ b/libbeat/publisher/output_test.go
@@ -17,6 +17,10 @@ type testOutputer struct {
 
 var _ outputs.Outputer = &testOutputer{}
 
+func (t *testOutputer) Close() error {
+	return nil
+}
+
 // PublishEvent writes events to a channel then calls Completed on trans.
 // It always returns nil.
 func (t *testOutputer) PublishEvent(trans outputs.Signaler, opts outputs.Options,
@@ -32,7 +36,7 @@ func TestOutputWorker(t *testing.T) {
 	ow := newOutputWorker(
 		ucfg.New(),
 		outputer,
-		newWorkerSignal(),
+		common.NewWorkerSignal(),
 		1, 0)
 
 	ow.onStop() // Noop

--- a/libbeat/publisher/sync_test.go
+++ b/libbeat/publisher/sync_test.go
@@ -4,11 +4,11 @@ import (
 	"testing"
 
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/logp"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestSyncPublishEventSuccess(t *testing.T) {
+	enableLogging([]string{"*"})
 	testPub := newTestPublisherNoBulk(CompletedResponse)
 	event := testEvent()
 
@@ -64,10 +64,6 @@ func TestSyncPublishEventsFailed(t *testing.T) {
 
 // Test that PublishEvent returns true when publishing is disabled.
 func TestSyncPublisherDisabled(t *testing.T) {
-	if testing.Verbose() {
-		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"*"})
-	}
-
 	testPub := newTestPublisherNoBulk(FailedResponse)
 	testPub.pub.disabled = true
 	event := testEvent()

--- a/libbeat/publisher/worker.go
+++ b/libbeat/publisher/worker.go
@@ -2,10 +2,8 @@ package publisher
 
 import (
 	"expvar"
-	"sync"
 
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/outputs"
 )
 
 // Metrics that can retrieved through the expvar web interface.
@@ -20,7 +18,7 @@ type worker interface {
 type messageWorker struct {
 	queue     chan message
 	bulkQueue chan message
-	ws        *workerSignal
+	ws        *common.WorkerSignal
 	handler   messageHandler
 }
 
@@ -30,28 +28,23 @@ type message struct {
 	events  []common.MapStr
 }
 
-type workerSignal struct {
-	done chan struct{}
-	wg   sync.WaitGroup
-}
-
 type messageHandler interface {
 	onMessage(m message)
 	onStop()
 }
 
-func newMessageWorker(ws *workerSignal, hwm, bulkHWM int, h messageHandler) *messageWorker {
+func newMessageWorker(ws *common.WorkerSignal, hwm, bulkHWM int, h messageHandler) *messageWorker {
 	p := &messageWorker{}
 	p.init(ws, hwm, bulkHWM, h)
 	return p
 }
 
-func (p *messageWorker) init(ws *workerSignal, hwm, bulkHWM int, h messageHandler) {
+func (p *messageWorker) init(ws *common.WorkerSignal, hwm, bulkHWM int, h messageHandler) {
 	p.queue = make(chan message, hwm)
 	p.bulkQueue = make(chan message, bulkHWM)
 	p.ws = ws
 	p.handler = h
-	ws.wg.Add(1)
+	defer p.ws.WorkerStart()
 	go p.run()
 }
 
@@ -59,52 +52,35 @@ func (p *messageWorker) run() {
 	defer p.shutdown()
 	for {
 		select {
-		case <-p.ws.done:
+		case <-p.ws.Done:
 			return
 		case m := <-p.queue:
-			messagesInWorkerQueues.Add(-1)
-			p.handler.onMessage(m)
+			p.onEvent(m)
 		case m := <-p.bulkQueue:
-			messagesInWorkerQueues.Add(-1)
-			p.handler.onMessage(m)
+			p.onEvent(m)
 		}
 	}
 }
 
 func (p *messageWorker) shutdown() {
 	p.handler.onStop()
-	stopQueue(p.queue)
-	stopQueue(p.bulkQueue)
-	p.ws.wg.Done()
+	close(p.queue)
+	close(p.bulkQueue)
+	p.ws.WorkerFinished()
+}
+
+func (p *messageWorker) onEvent(m message) {
+	messagesInWorkerQueues.Add(-1)
+	p.handler.onMessage(m)
+	p.ws.DoneEvent()
 }
 
 func (p *messageWorker) send(m message) {
+	p.ws.AddEvent(1)
 	if m.event != nil {
 		p.queue <- m
 	} else {
 		p.bulkQueue <- m
 	}
 	messagesInWorkerQueues.Add(1)
-}
-
-func (ws *workerSignal) stop() {
-	close(ws.done)
-	ws.wg.Wait()
-}
-
-func newWorkerSignal() *workerSignal {
-	w := &workerSignal{}
-	w.Init()
-	return w
-}
-
-func (ws *workerSignal) Init() {
-	ws.done = make(chan struct{})
-}
-
-func stopQueue(qu chan message) {
-	close(qu)
-	for msg := range qu { // clear queue and send fail signal
-		outputs.SignalFailed(msg.context.Signal, nil)
-	}
 }

--- a/libbeat/publisher/worker_test.go
+++ b/libbeat/publisher/worker_test.go
@@ -4,14 +4,16 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/elastic/beats/libbeat/common"
 	"github.com/stretchr/testify/assert"
 )
 
 // Test sending events through the messageWorker.
 func TestMessageWorkerSend(t *testing.T) {
+	enableLogging([]string{"*"})
+
 	// Setup
-	ws := &workerSignal{}
-	ws.Init()
+	ws := common.NewWorkerSignal()
 	mh := &testMessageHandler{msgs: make(chan message, 10), response: true}
 	mw := newMessageWorker(ws, 10, 0, mh)
 
@@ -25,7 +27,7 @@ func TestMessageWorkerSend(t *testing.T) {
 	m2 := message{context: Context{Signal: s2}}
 	mw.send(m2)
 
-	// Verify that the messageWorker pushed to two messages to the
+	// Verify that the messageWorker pushed the two messages to the
 	// messageHandler.
 	msgs, err := mh.waitForMessages(2)
 	if err != nil {
@@ -38,25 +40,40 @@ func TestMessageWorkerSend(t *testing.T) {
 	assert.Contains(t, msgs, m2)
 	assert.True(t, s2.wait())
 
-	// Verify that stopping workerSignal causes a onStop notification
-	// in the messageHandler.
-	ws.stop()
+	ws.Stop()
 	assert.True(t, atomic.LoadUint32(&mh.stopped) == 1)
 }
 
-// Test that stopQueue invokes the Failed callback on all events in the queue.
-func TestMessageWorkerStopQueue(t *testing.T) {
+// Test that events sent before shutdown are pushed to the messageHandler.
+func TestMessageWorkerShutdownSend(t *testing.T) {
+	enableLogging([]string{"*"})
+
+	// Setup
+	ws := common.NewWorkerSignal()
+	mh := &testMessageHandler{msgs: make(chan message, 10), response: true}
+	mw := newMessageWorker(ws, 10, 0, mh)
+
+	// Send an event.
 	s1 := newTestSignaler()
 	m1 := message{context: Context{Signal: s1}}
+	mw.send(m1)
 
+	// Send another event.
 	s2 := newTestSignaler()
 	m2 := message{context: Context{Signal: s2}}
+	mw.send(m2)
 
-	qu := make(chan message, 2)
-	qu <- m1
-	qu <- m2
+	ws.Stop()
+	assert.True(t, atomic.LoadUint32(&mh.stopped) == 1)
 
-	stopQueue(qu)
-	assert.False(t, s1.wait())
-	assert.False(t, s2.wait())
+	// Verify that the messageWorker pushed the two messages to the
+	// messageHandler.
+	close(mh.msgs)
+	assert.Equal(t, 2, len(mh.msgs))
+
+	// Verify the messages and the signals.
+	assert.Equal(t, <-mh.msgs, m1)
+	assert.True(t, s1.wait())
+	assert.Equal(t, <-mh.msgs, m2)
+	assert.True(t, s2.wait())
 }


### PR DESCRIPTION
Libbeat publisher now exits once all async events are published, all
events outputed and ConnectionModes closed.

* Move WorkerSignal to libbeat/common: WorkerSignals are used in packages publisher and outputs
* Add a second WaitGroup to WorkerSignal. WaitGroups are used to track events and shutdown of goroutines
* Remove TestMessageWorkerStopQueue and stopQueue function in WorkerSignal: events are not considered
failed at shutdown anymore
* Adapt existing Libbeat tests
* Add a few tests for published events after shutdown
* Add method Close to outputs/Outputer. The method is called by publisher/outputWorker onStop()
* Edit CHANGELOG