### PR TITLE
output plugins config via ucfg

### DIFF
--- a/libbeat/beat/beat.go
+++ b/libbeat/beat/beat.go
@@ -29,10 +29,10 @@ import (
 	"sync"
 
 	"github.com/satori/go.uuid"
+	"github.com/urso/ucfg"
 
 	"github.com/elastic/beats/libbeat/cfgfile"
 	"github.com/elastic/beats/libbeat/logp"
-	"github.com/elastic/beats/libbeat/outputs"
 	"github.com/elastic/beats/libbeat/publisher"
 	"github.com/elastic/beats/libbeat/service"
 )
@@ -81,7 +81,7 @@ const (
 
 // BeatConfig struct contains the basic configuration of every beat
 type BeatConfig struct {
-	Output  map[string]outputs.MothershipConfig
+	Output  map[string]*ucfg.Config
 	Logging logp.Logging
 	Shipper publisher.ShipperConfig
 }

--- a/libbeat/outputs/console/config.go
+++ b/libbeat/outputs/console/config.go
@@ -1,0 +1,11 @@
+package console
+
+type config struct {
+	Pretty bool `config:"pretty"`
+}
+
+var (
+	defaultConfig = config{
+		Pretty: false,
+	}
+)

--- a/libbeat/outputs/console/console.go
+++ b/libbeat/outputs/console/console.go
@@ -12,16 +12,14 @@ import (
 )
 
 func init() {
-	outputs.RegisterOutputPlugin("console", plugin{})
+	outputs.RegisterOutputPlugin("console", New)
 }
-
-type plugin struct{}
 
 type console struct {
 	config config
 }
 
-func (p plugin) NewOutput(config *ucfg.Config, _ int) (outputs.Outputer, error) {
+func New(config *ucfg.Config, _ int) (outputs.Outputer, error) {
 	c := &console{config: defaultConfig}
 	err := config.Unpack(&c.config)
 	if err != nil {

--- a/libbeat/outputs/elasticsearch/config.go
+++ b/libbeat/outputs/elasticsearch/config.go
@@ -1,0 +1,44 @@
+package elasticsearch
+
+import "github.com/elastic/beats/libbeat/outputs"
+
+type elasticsearchConfig struct {
+	Protocol     string             `config:"protocol"`
+	Path         string             `config:"path"`
+	Params       map[string]string  `config:"parameters"`
+	Username     string             `config:"username"`
+	Password     string             `config:"password"`
+	ProxyURL     string             `config:"proxy_url"`
+	Index        string             `config:"index"`
+	LoadBalance  bool               `config:"loadbalance"`
+	TLS          *outputs.TLSConfig `config:"tls"`
+	MaxRetries   int                `config:"max_retries"`
+	Timeout      int                `config:"timeout"`
+	SaveTopology bool               `config:"save_topology"`
+	Template     Template           `config:"template"`
+}
+
+type Template struct {
+	Name      string `config:"name"`
+	Path      string `config:"path"`
+	Overwrite bool   `config:"overwrite"`
+}
+
+const (
+	defaultBulkSize = 50
+)
+
+var (
+	defaultConfig = elasticsearchConfig{
+		Protocol:    "",
+		Path:        "",
+		ProxyURL:    "",
+		Params:      nil,
+		Username:    "",
+		Password:    "",
+		Timeout:     90,
+		MaxRetries:  3,
+		TLS:         nil,
+		LoadBalance: true,
+	}
+)

--- a/libbeat/outputs/elasticsearch/output.go
+++ b/libbeat/outputs/elasticsearch/output.go
@@ -17,12 +17,14 @@ import (
 	"github.com/elastic/beats/libbeat/outputs/mode"
 )
 
-type elasticsearchOutputPlugin struct{}
-
 type elasticsearchOutput struct {
 	index string
 	mode  mode.ConnectionMode
 	topology
+}
+
+func init() {
+	outputs.RegisterOutputPlugin("elasticsearch", New)
 }
 
 var (
@@ -40,15 +42,8 @@ var (
 	ErrResponseRead = errors.New("bulk item status parse failed.")
 )
 
-func init() {
-	outputs.RegisterOutputPlugin("elasticsearch", elasticsearchOutputPlugin{})
-}
-
 // NewOutput instantiates a new output plugin instance publishing to elasticsearch.
-func (f elasticsearchOutputPlugin) NewOutput(
-	cfg *ucfg.Config,
-	topologyExpire int,
-) (outputs.Outputer, error) {
+func New(cfg *ucfg.Config, topologyExpire int) (outputs.Outputer, error) {
 	if !cfg.HasField("bulk_max_size") {
 		cfg.SetInt("bulk_max_size", 0, defaultBulkSize)
 	}

--- a/libbeat/outputs/elasticsearch/output.go
+++ b/libbeat/outputs/elasticsearch/output.go
@@ -1,14 +1,15 @@
 package elasticsearch
 
 import (
+	"bytes"
 	"crypto/tls"
 	"errors"
+	"io/ioutil"
 	"net/url"
 	"strings"
 	"time"
 
-	"bytes"
-	"io/ioutil"
+	"github.com/urso/ucfg"
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
@@ -16,7 +17,17 @@ import (
 	"github.com/elastic/beats/libbeat/outputs/mode"
 )
 
-var debug = logp.MakeDebug("elasticsearch")
+type elasticsearchOutputPlugin struct{}
+
+type elasticsearchOutput struct {
+	index string
+	mode  mode.ConnectionMode
+	topology
+}
+
+var (
+	debug = logp.MakeDebug("elasticsearch")
+)
 
 var (
 	// ErrNotConnected indicates failure due to client having no valid connection
@@ -29,41 +40,21 @@ var (
 	ErrResponseRead = errors.New("bulk item status parse failed.")
 )
 
-const (
-	defaultMaxRetries = 3
-
-	defaultBulkSize = 50
-
-	elasticsearchDefaultTimeout = 90 * time.Second
-)
-
 func init() {
 	outputs.RegisterOutputPlugin("elasticsearch", elasticsearchOutputPlugin{})
 }
 
-type elasticsearchOutputPlugin struct{}
-
-type elasticsearchOutput struct {
-	index string
-	mode  mode.ConnectionMode
-
-	topology
-}
-
 // NewOutput instantiates a new output plugin instance publishing to elasticsearch.
 func (f elasticsearchOutputPlugin) NewOutput(
-	config *outputs.MothershipConfig,
+	cfg *ucfg.Config,
 	topologyExpire int,
 ) (outputs.Outputer, error) {
-
-	// configure bulk size in config in case it is not set
-	if config.BulkMaxSize == nil {
-		bulkSize := defaultBulkSize
-		config.BulkMaxSize = &bulkSize
+	if !cfg.HasField("bulk_max_size") {
+		cfg.SetInt("bulk_max_size", 0, defaultBulkSize)
 	}
 
 	output := &elasticsearchOutput{}
-	err := output.init(*config, topologyExpire)
+	err := output.init(cfg, topologyExpire)
 	if err != nil {
 		return nil, err
 	}
@@ -71,29 +62,27 @@ func (f elasticsearchOutputPlugin) NewOutput(
 }
 
 func (out *elasticsearchOutput) init(
-	config outputs.MothershipConfig,
+	cfg *ucfg.Config,
 	topologyExpire int,
 ) error {
+	config := defaultConfig
+	if err := cfg.Unpack(&config); err != nil {
+		return err
+	}
+
 	tlsConfig, err := outputs.LoadTLSConfig(config.TLS)
 	if err != nil {
 		return err
 	}
 
-	clients, err := mode.MakeClients(config, makeClientFactory(tlsConfig, config))
-
+	clients, err := mode.MakeClients(cfg, makeClientFactory(tlsConfig, &config))
 	if err != nil {
 		return err
 	}
 
-	timeout := elasticsearchDefaultTimeout
-	if config.Timeout != 0 {
-		timeout = time.Duration(config.Timeout) * time.Second
-	}
+	timeout := time.Duration(config.Timeout) * time.Second
 
-	maxRetries := defaultMaxRetries
-	if config.MaxRetries != nil {
-		maxRetries = *config.MaxRetries
-	}
+	maxRetries := config.MaxRetries
 	maxAttempts := maxRetries + 1 // maximum number of send attempts (-1 = infinite)
 	if maxRetries < 0 {
 		maxAttempts = 0
@@ -103,7 +92,7 @@ func (out *elasticsearchOutput) init(
 	var maxWaitRetry = time.Duration(60) * time.Second
 
 	out.clients = clients
-	loadBalance := config.LoadBalance == nil || *config.LoadBalance
+	loadBalance := config.LoadBalance
 	m, err := mode.NewConnectionMode(clients, !loadBalance,
 		maxAttempts, waitRetry, timeout, maxWaitRetry)
 	if err != nil {
@@ -143,7 +132,7 @@ func (out *elasticsearchOutput) init(
 
 // loadTemplate checks if the index mapping template should be loaded
 // In case template loading is enabled, template is written to index
-func loadTemplate(config outputs.Template, clients []mode.ProtocolClient) {
+func loadTemplate(config Template, clients []mode.ProtocolClient) {
 	// Check if template should be loaded
 	// Not being able to load the template will output an error but will not stop execution
 	if config.Name != "" && len(clients) > 0 {
@@ -183,7 +172,7 @@ func loadTemplate(config outputs.Template, clients []mode.ProtocolClient) {
 
 func makeClientFactory(
 	tls *tls.Config,
-	config outputs.MothershipConfig,
+	config *elasticsearchConfig,
 ) func(string) (mode.ProtocolClient, error) {
 	return func(host string) (mode.ProtocolClient, error) {
 		esURL, err := getURL(config.Protocol, config.Path, host)

--- a/libbeat/outputs/elasticsearch/output_test.go
+++ b/libbeat/outputs/elasticsearch/output_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/urso/ucfg"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/outputs"
@@ -23,20 +25,21 @@ func createElasticsearchConnection(flushInterval int, bulkSize int) elasticsearc
 		logp.Err("Invalid port. Cannot be converted to in: %s", GetEsPort())
 	}
 
-	var output elasticsearchOutput
-	output.init(outputs.MothershipConfig{
-		SaveTopology:  true,
-		Host:          GetEsHost(),
-		Port:          esPort,
-		Username:      os.Getenv("ES_USER"),
-		Password:      os.Getenv("ES_PASS"),
-		Path:          "",
-		Index:         index,
-		Protocol:      "http",
-		FlushInterval: &flushInterval,
-		BulkMaxSize:   &bulkSize,
-	}, 10)
+	config, _ := ucfg.NewFrom(map[string]interface{}{
+		"save_topology":  true,
+		"hosts":          []string{GetEsHost()},
+		"port":           esPort,
+		"username":       os.Getenv("ES_USER"),
+		"password":       os.Getenv("ES_PASS"),
+		"path":           "",
+		"index":          index,
+		"protocol":       "http",
+		"flush_interval": flushInterval,
+		"bulk_max_size":  bulkSize,
+	})
 
+	var output elasticsearchOutput
+	output.init(config, 10)
 	return output
 }
 

--- a/libbeat/outputs/fileout/config.go
+++ b/libbeat/outputs/fileout/config.go
@@ -1,0 +1,16 @@
+package fileout
+
+type config struct {
+	Index         string `config:"index"`
+	Path          string `config:"path"`
+	Filename      string `config:"filename"`
+	RotateEveryKb int    `config:"rotate_every_kb"`
+	NumberOfFiles int    `config:"number_of_files"`
+}
+
+var (
+	defaultConfig = config{
+		NumberOfFiles: 7,
+		RotateEveryKb: 10 * 1024,
+	}
+)

--- a/libbeat/outputs/fileout/file.go
+++ b/libbeat/outputs/fileout/file.go
@@ -11,19 +11,14 @@ import (
 )
 
 func init() {
-	outputs.RegisterOutputPlugin("file", FileOutputPlugin{})
+	outputs.RegisterOutputPlugin("file", New)
 }
-
-type FileOutputPlugin struct{}
 
 type fileOutput struct {
 	rotator logp.FileRotator
 }
 
-func (f FileOutputPlugin) NewOutput(
-	cfg *ucfg.Config,
-	_ int,
-) (outputs.Outputer, error) {
+func New(cfg *ucfg.Config, _ int) (outputs.Outputer, error) {
 	config := defaultConfig
 	if err := cfg.Unpack(&config); err != nil {
 		return nil, err

--- a/libbeat/outputs/kafka/config.go
+++ b/libbeat/outputs/kafka/config.go
@@ -1,0 +1,32 @@
+package kafka
+
+import (
+	"time"
+
+	"github.com/elastic/beats/libbeat/outputs"
+)
+
+type kafkaConfig struct {
+	Hosts           []string           `config:"hosts"`
+	TLS             *outputs.TLSConfig `config:"tls"`
+	Timeout         int                `config:"timeout"`
+	Worker          int                `config:"worker"`
+	UseType         bool               `config:"use_type"`
+	Topic           string             `config:"topic"`
+	KeepAlive       time.Duration      `config:"keep_alive"`
+	MaxMessageBytes *int               `config:"max_message_bytes"`
+	RequiredACKs    *int               `config:"required_acks"`
+	BrokerTimeout   time.Duration      `config:"broker_timeout"`
+	Compression     string             `config:"compression"`
+	MaxRetries      *int               `config:"max_retries"`
+	ClientID        string             `config:"client_id"`
+}
+
+var (
+	defaultConfig = kafkaConfig{
+		Timeout:     30,
+		Worker:      1,
+		Compression: "gzip",
+		ClientID:    "beats",
+	}
+)

--- a/libbeat/outputs/kafka/kafka.go
+++ b/libbeat/outputs/kafka/kafka.go
@@ -15,10 +15,13 @@ import (
 	"github.com/elastic/beats/libbeat/outputs/mode"
 )
 
-type kafkaOutputPlugin struct{}
-
 type kafka struct {
 	mode mode.ConnectionMode
+}
+
+func init() {
+	sarama.Logger = kafkaLogger{}
+	outputs.RegisterOutputPlugin("kafka", New)
 }
 
 var debugf = logp.MakeDebug("kafka")
@@ -38,16 +41,7 @@ var (
 	}
 )
 
-func init() {
-	sarama.Logger = kafkaLogger{}
-
-	outputs.RegisterOutputPlugin("kafka", kafkaOutputPlugin{})
-}
-
-func (p kafkaOutputPlugin) NewOutput(
-	cfg *ucfg.Config,
-	topologyExpire int,
-) (outputs.Outputer, error) {
+func New(cfg *ucfg.Config, topologyExpire int) (outputs.Outputer, error) {
 	output := &kafka{}
 	err := output.init(cfg)
 	if err != nil {

--- a/libbeat/outputs/logstash/config.go
+++ b/libbeat/outputs/logstash/config.go
@@ -1,0 +1,26 @@
+package logstash
+
+import "github.com/elastic/beats/libbeat/outputs"
+
+type logstashConfig struct {
+	Index            string             `config:"index"`
+	Port             int                `config:"port"`
+	LoadBalance      bool               `config:"loadbalance"`
+	BulkMaxSize      int                `config:"bulk_max_size"`
+	Timeout          int                `config:"timeout"`
+	CompressionLevel int                `config:"compression_level"`
+	MaxRetries       int                `config:"max_retries"`
+	TLS              *outputs.TLSConfig `config:"tls"`
+}
+
+var (
+	defaultConfig = logstashConfig{
+		Port:             10200,
+		LoadBalance:      false,
+		BulkMaxSize:      2048,
+		CompressionLevel: 3,
+		Timeout:          30,
+		MaxRetries:       3,
+		TLS:              nil,
+	}
+)

--- a/libbeat/outputs/logstash/logstash.go
+++ b/libbeat/outputs/logstash/logstash.go
@@ -17,16 +17,11 @@ import (
 
 var debug = logp.MakeDebug("logstash")
 
-type logstashOutputPlugin struct{}
-
 func init() {
-	outputs.RegisterOutputPlugin("logstash", logstashOutputPlugin{})
+	outputs.RegisterOutputPlugin("logstash", New)
 }
 
-func (p logstashOutputPlugin) NewOutput(
-	cfg *ucfg.Config,
-	_ int,
-) (outputs.Outputer, error) {
+func New(cfg *ucfg.Config, _ int) (outputs.Outputer, error) {
 	output := &logstash{}
 	if err := output.init(cfg); err != nil {
 		return nil, err

--- a/libbeat/outputs/logstash/logstash_integration_test.go
+++ b/libbeat/outputs/logstash/logstash_integration_test.go
@@ -164,7 +164,7 @@ func newTestElasticsearchOutput(t *testing.T, test string) *testOutputer {
 		"password":       os.Getenv("ES_PASS"),
 	})
 
-	output, err := plugin.NewOutput(config, 10)
+	output, err := plugin(config, 10)
 	if err != nil {
 		t.Fatalf("init elasticsearch output plugin failed: %v", err)
 	}

--- a/libbeat/outputs/logstash/logstash_test.go
+++ b/libbeat/outputs/logstash/logstash_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/urso/ucfg"
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/streambuf"
@@ -73,15 +74,13 @@ func testLogstashIndex(test string) string {
 func newTestLumberjackOutput(
 	t *testing.T,
 	test string,
-	config *outputs.MothershipConfig,
+	config map[string]interface{},
 ) outputs.BulkOutputer {
 	if config == nil {
-		config = &outputs.MothershipConfig{
-			TLS:   nil,
-			Hosts: []string{getLogstashHost()},
-			Index: testLogstashIndex(test),
+		config = map[string]interface{}{
+			"hosts": []string{getLogstashHost()},
+			"index": testLogstashIndex(test),
 		}
-
 	}
 
 	plugin := outputs.FindOutputPlugin("logstash")
@@ -89,7 +88,8 @@ func newTestLumberjackOutput(
 		t.Fatalf("No logstash output plugin found")
 	}
 
-	output, err := plugin.NewOutput(config, 0)
+	cfg, _ := ucfg.NewFrom(config, ucfg.PathSep("."))
+	output, err := plugin.NewOutput(cfg, 0)
 	if err != nil {
 		t.Fatalf("init logstash output plugin failed: %v", err)
 	}
@@ -100,7 +100,7 @@ func newTestLumberjackOutput(
 func testOutputerFactory(
 	t *testing.T,
 	test string,
-	config *outputs.MothershipConfig,
+	config map[string]interface{},
 ) func() outputs.BulkOutputer {
 	return func() outputs.BulkOutputer {
 		return newTestLumberjackOutput(t, test, config)
@@ -238,12 +238,11 @@ func TestLogstashTCP(t *testing.T) {
 	server := newMockTCPServer(t, timeout)
 
 	// create lumberjack output client
-	config := outputs.MothershipConfig{
-		Timeout: 2,
-		Hosts:   []string{server.Addr()},
+	config := map[string]interface{}{
+		"hosts":   []string{server.Addr()},
+		"timeout": 2,
 	}
-
-	testConnectionType(t, server, testOutputerFactory(t, "", &config))
+	testConnectionType(t, server, testOutputerFactory(t, "", config))
 }
 
 func TestLogstashTLS(t *testing.T) {
@@ -254,15 +253,12 @@ func TestLogstashTLS(t *testing.T) {
 	genCertsForIPIfMIssing(t, ip, certName)
 	server := newMockTLSServer(t, timeout, certName)
 
-	config := outputs.MothershipConfig{
-		TLS: &outputs.TLSConfig{
-			CAs: []string{certName + ".pem"},
-		},
-		Timeout: 2,
-		Hosts:   []string{server.Addr()},
+	config := map[string]interface{}{
+		"hosts":                       []string{server.Addr()},
+		"timeout":                     2,
+		"tls.certificate_authorities": []string{certName + ".pem"},
 	}
-
-	testConnectionType(t, server, testOutputerFactory(t, "", &config))
+	testConnectionType(t, server, testOutputerFactory(t, "", config))
 }
 
 func TestLogstashInvalidTLSInsecure(t *testing.T) {
@@ -273,18 +269,14 @@ func TestLogstashInvalidTLSInsecure(t *testing.T) {
 	genCertsForIPIfMIssing(t, ip, certName)
 	server := newMockTLSServer(t, timeout, certName)
 
-	retries := 1
-	config := outputs.MothershipConfig{
-		TLS: &outputs.TLSConfig{
-			CAs:      []string{certName + ".pem"},
-			Insecure: true,
-		},
-		Timeout:    2,
-		MaxRetries: &retries,
-		Hosts:      []string{server.Addr()},
+	config := map[string]interface{}{
+		"hosts":                       []string{server.Addr()},
+		"timeout":                     2,
+		"max_retries":                 1,
+		"tls.insecure":                true,
+		"tls.certificate_authorities": []string{certName + ".pem"},
 	}
-
-	testConnectionType(t, server, testOutputerFactory(t, "", &config))
+	testConnectionType(t, server, testOutputerFactory(t, "", config))
 }
 
 func testConnectionType(
@@ -361,14 +353,11 @@ func TestLogstashInvalidTLS(t *testing.T) {
 	genCertsForIPIfMIssing(t, ip, certName)
 	server := newMockTLSServer(t, timeout, certName)
 
-	retries := 0
-	config := outputs.MothershipConfig{
-		TLS: &outputs.TLSConfig{
-			CAs: []string{certName + ".pem"},
-		},
-		Timeout:    1,
-		MaxRetries: &retries,
-		Hosts:      []string{server.Addr()},
+	config := map[string]interface{}{
+		"hosts":                       []string{server.Addr()},
+		"timeout":                     1,
+		"max_retries":                 0,
+		"tls.certificate_authorities": []string{certName + ".pem"},
 	}
 
 	var result struct {
@@ -404,7 +393,7 @@ func TestLogstashInvalidTLS(t *testing.T) {
 		defer wg.finish.Done()
 		wg.ready.Wait()
 
-		output := newTestLumberjackOutput(t, "", &config)
+		output := newTestLumberjackOutput(t, "", config)
 
 		signal := outputs.NewSyncSignal()
 		output.PublishEvent(signal, testOptions, testEvent())

--- a/libbeat/outputs/logstash/logstash_test.go
+++ b/libbeat/outputs/logstash/logstash_test.go
@@ -89,7 +89,7 @@ func newTestLumberjackOutput(
 	}
 
 	cfg, _ := ucfg.NewFrom(config, ucfg.PathSep("."))
-	output, err := plugin.NewOutput(cfg, 0)
+	output, err := plugin(cfg, 0)
 	if err != nil {
 		t.Fatalf("init logstash output plugin failed: %v", err)
 	}

--- a/libbeat/outputs/logstash/sync_test.go
+++ b/libbeat/outputs/logstash/sync_test.go
@@ -52,7 +52,7 @@ func (s *clientServer) connectPair(compressLevel int) (*mockConn, *client, error
 	}
 
 	lc, err := newLumberjackClient(transp, compressLevel,
-		defaultMaxWindowSize, 100*time.Millisecond)
+		defaultConfig.BulkMaxSize, 100*time.Millisecond)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/libbeat/outputs/logstash/window_test.go
+++ b/libbeat/outputs/logstash/window_test.go
@@ -11,7 +11,7 @@ func TestShrinkWindowSizeNeverZero(t *testing.T) {
 
 	windowSize := 124
 	var w window
-	w.init(windowSize, defaultMaxWindowSize)
+	w.init(windowSize, defaultConfig.BulkMaxSize)
 
 	w.windowSize = int32(windowSize)
 	for i := 0; i < 100; i++ {

--- a/libbeat/outputs/outputs.go
+++ b/libbeat/outputs/outputs.go
@@ -32,12 +32,8 @@ type BulkOutputer interface {
 	BulkPublish(trans Signaler, opts Options, event []common.MapStr) error
 }
 
-type OutputBuilder interface {
-	// Create and initialize the output plugin
-	NewOutput(
-		config *ucfg.Config,
-		topologyExpire int) (Outputer, error)
-}
+// Create and initialize the output plugin
+type OutputBuilder func(config *ucfg.Config, topologyExpire int) (Outputer, error)
 
 // Functions to be exported by a output plugin
 type OutputInterface interface {
@@ -81,7 +77,7 @@ func InitOutputs(
 			config.SetString("index", 0, beatName)
 		}
 
-		output, err := plugin.NewOutput(config, topologyExpire)
+		output, err := plugin(config, topologyExpire)
 		if err != nil {
 			logp.Err("failed to initialize %s plugin as output: %s", name, err)
 			return nil, err

--- a/libbeat/outputs/outputs.go
+++ b/libbeat/outputs/outputs.go
@@ -1,54 +1,11 @@
 package outputs
 
 import (
+	"github.com/urso/ucfg"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 )
-
-type MothershipConfig struct {
-	SaveTopology      bool `config:"save_topology"`
-	Host              string
-	Port              int
-	Hosts             []string
-	LoadBalance       *bool `config:"loadbalance"`
-	Protocol          string
-	Username          string
-	Password          string
-	ProxyURL          string `config:"proxy_url"`
-	Index             string
-	Path              string
-	Template          Template
-	Params            map[string]string `config:"parameters"`
-	Db                int
-	DbTopology        int `config:"db_topology"`
-	Timeout           int
-	ReconnectInterval int    `config:"reconnect_interval"`
-	Filename          string `config:"filename"`
-	RotateEveryKb     int    `config:"rotate_every_kb"`
-	NumberOfFiles     int    `config:"number_of_files"`
-	DataType          string
-	FlushInterval     *int  `config:"flush_interval"`
-	BulkMaxSize       *int  `config:"bulk_max_size"`
-	MaxRetries        *int  `config:"max_retries"`
-	Pretty            *bool `config:"pretty"`
-	TLS               *TLSConfig
-	Worker            int
-	CompressionLevel  *int   `config:"compression_level"`
-	KeepAlive         string `config:"keep_alive"`
-	MaxMessageBytes   *int   `config:"max_message_bytes"`
-	RequiredACKs      *int   `config:"required_acks"`
-	BrokerTimeout     string `config:"broker_timeout"`
-	Compression       string `config:"compression"`
-	ClientID          string `config:"client_id"`
-	Topic             string `config:"topic"`
-	UseType           *bool  `config:"use_type"`
-}
-
-type Template struct {
-	Name      string
-	Path      string
-	Overwrite bool
-}
 
 type Options struct {
 	Guaranteed bool
@@ -78,7 +35,7 @@ type BulkOutputer interface {
 type OutputBuilder interface {
 	// Create and initialize the output plugin
 	NewOutput(
-		config *MothershipConfig,
+		config *ucfg.Config,
 		topologyExpire int) (Outputer, error)
 }
 
@@ -90,7 +47,7 @@ type OutputInterface interface {
 
 type OutputPlugin struct {
 	Name   string
-	Config MothershipConfig
+	Config *ucfg.Config
 	Output Outputer
 }
 
@@ -110,7 +67,7 @@ func FindOutputPlugin(name string) OutputBuilder {
 
 func InitOutputs(
 	beatName string,
-	configs map[string]MothershipConfig,
+	configs map[string]*ucfg.Config,
 	topologyExpire int,
 ) ([]OutputPlugin, error) {
 	var plugins []OutputPlugin = nil
@@ -120,11 +77,11 @@ func InitOutputs(
 			continue
 		}
 
-		if config.Index == "" {
-			config.Index = beatName
+		if !config.HasField("index") {
+			config.SetString("index", 0, beatName)
 		}
 
-		output, err := plugin.NewOutput(&config, topologyExpire)
+		output, err := plugin.NewOutput(config, topologyExpire)
 		if err != nil {
 			logp.Err("failed to initialize %s plugin as output: %s", name, err)
 			return nil, err

--- a/libbeat/outputs/redis/config.go
+++ b/libbeat/outputs/redis/config.go
@@ -1,0 +1,21 @@
+package redis
+
+type redisConfig struct {
+	Host              string `config:"host"`
+	Port              int    `config:"port"`
+	Password          string `config:"password"`
+	Db                int    `config:"db"`
+	DbTopology        int    `config:"db_topology"`
+	Timeout           int    `config:"timeout"`
+	Index             string `config:"index"`
+	ReconnectInterval int    `config:"reconnect_interval"`
+	DataType          string `config:"datatype"`
+}
+
+var (
+	defaultConfig = redisConfig{
+		DbTopology:        1,
+		Timeout:           5,
+		ReconnectInterval: 1,
+	}
+)

--- a/libbeat/outputs/redis/redis.go
+++ b/libbeat/outputs/redis/redis.go
@@ -11,31 +11,16 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/garyburd/redigo/redis"
+
+	"github.com/urso/ucfg"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/outputs"
-
-	"github.com/garyburd/redigo/redis"
 )
 
-func init() {
-
-	outputs.RegisterOutputPlugin("redis", RedisOutputPlugin{})
-}
-
 type RedisOutputPlugin struct{}
-
-func (f RedisOutputPlugin) NewOutput(
-	config *outputs.MothershipConfig,
-	topology_expire int,
-) (outputs.Outputer, error) {
-	output := &redisOutput{}
-	err := output.Init(*config, topology_expire)
-	if err != nil {
-		return nil, err
-	}
-	return output, nil
-}
 
 type redisDataType uint16
 
@@ -67,34 +52,43 @@ type message struct {
 	msg   string
 }
 
-func (out *redisOutput) Init(config outputs.MothershipConfig, topology_expire int) error {
+func init() {
+	outputs.RegisterOutputPlugin("redis", RedisOutputPlugin{})
+}
+
+func (f RedisOutputPlugin) NewOutput(
+	cfg *ucfg.Config,
+	topologyExpire int,
+) (outputs.Outputer, error) {
+	config := defaultConfig
+	if err := cfg.Unpack(&config); err != nil {
+		return nil, err
+	}
+
+	output := &redisOutput{}
+	if err := output.Init(&config, topologyExpire); err != nil {
+		return nil, err
+	}
+	return output, nil
+}
+
+func (out *redisOutput) Init(config *redisConfig, topology_expire int) error {
 
 	logp.Warn("Redis Output is deprecated. Please use the Redis Output Plugin from Logstash instead.")
 
 	out.Hostname = fmt.Sprintf("%s:%d", config.Host, config.Port)
-
-	if config.Password != "" {
-		out.Password = config.Password
-	}
-
-	if config.Db != 0 {
-		out.Db = config.Db
-	}
-
-	out.DbTopology = 1
-	if config.DbTopology != 0 {
-		out.DbTopology = config.DbTopology
-	}
+	out.Password = config.Password
+	out.Index = config.Index
+	out.Db = config.Db
+	out.DbTopology = config.DbTopology
 
 	out.Timeout = 5 * time.Second
-	if config.Timeout != 0 {
+	if config.Timeout > 0 {
 		out.Timeout = time.Duration(config.Timeout) * time.Second
 	}
 
-	out.Index = config.Index
-
 	out.ReconnectInterval = time.Duration(1) * time.Second
-	if config.ReconnectInterval != 0 {
+	if config.ReconnectInterval >= 0 {
 		out.ReconnectInterval = time.Duration(config.ReconnectInterval) * time.Second
 	}
 	logp.Info("Reconnect Interval set to: %v", out.ReconnectInterval)

--- a/libbeat/outputs/redis/redis.go
+++ b/libbeat/outputs/redis/redis.go
@@ -20,10 +20,6 @@ import (
 	"github.com/elastic/beats/libbeat/outputs"
 )
 
-type RedisOutputPlugin struct{}
-
-type redisDataType uint16
-
 const (
 	RedisListType redisDataType = iota
 	RedisChannelType
@@ -46,6 +42,8 @@ type redisOutput struct {
 	connected   bool
 }
 
+type redisDataType uint16
+
 type message struct {
 	trans outputs.Signaler
 	index string
@@ -53,13 +51,10 @@ type message struct {
 }
 
 func init() {
-	outputs.RegisterOutputPlugin("redis", RedisOutputPlugin{})
+	outputs.RegisterOutputPlugin("redis", New)
 }
 
-func (f RedisOutputPlugin) NewOutput(
-	cfg *ucfg.Config,
-	topologyExpire int,
-) (outputs.Outputer, error) {
+func New(cfg *ucfg.Config, topologyExpire int) (outputs.Outputer, error) {
 	config := defaultConfig
 	if err := cfg.Unpack(&config); err != nil {
 		return nil, err

--- a/libbeat/publisher/async.go
+++ b/libbeat/publisher/async.go
@@ -15,8 +15,7 @@ type asyncPublisher struct {
 }
 
 const (
-	defaultFlushInterval = 1000 * time.Millisecond // 1s
-	defaultBulkSize      = 2048
+	defaultBulkSize = 2048
 )
 
 func newAsyncPublisher(pub *PublisherType, hwm, bulkHWM int) *asyncPublisher {
@@ -71,16 +70,9 @@ func (p *asyncPublisher) send(m message) {
 func asyncOutputer(ws *workerSignal, hwm, bulkHWM int, worker *outputWorker) worker {
 	config := worker.config
 
-	flushInterval := defaultFlushInterval
-	if config.FlushInterval != nil {
-		flushInterval = time.Duration(*config.FlushInterval) * time.Millisecond
-	}
+	flushInterval := time.Duration(config.FlushInterval) * time.Second
+	maxBulkSize := config.BulkMaxSize
 	logp.Info("Flush Interval set to: %v", flushInterval)
-
-	maxBulkSize := defaultBulkSize
-	if config.BulkMaxSize != nil {
-		maxBulkSize = *config.BulkMaxSize
-	}
 	logp.Info("Max Bulk Size set to: %v", maxBulkSize)
 
 	// batching disabled

--- a/libbeat/publisher/async_test.go
+++ b/libbeat/publisher/async_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/logp"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -41,6 +42,10 @@ func TestAsyncPublishEvents(t *testing.T) {
 }
 
 func TestBulkAsyncPublishEvent(t *testing.T) {
+	if testing.Verbose() {
+		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"*"})
+	}
+
 	// Init
 	testPub := newTestPublisherWithBulk(CompletedResponse)
 	event := testEvent()
@@ -53,9 +58,10 @@ func TestBulkAsyncPublishEvent(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	// Bulk outputer always sends bulk messages (even if only one event is
 	// present)
-	assert.Equal(t, event, msgs[0].events[0])
+	assert.Equal(t, event, msgs[0].event)
 }
 
 func TestBulkAsyncPublishEvents(t *testing.T) {

--- a/libbeat/publisher/common_test.go
+++ b/libbeat/publisher/common_test.go
@@ -138,7 +138,7 @@ func newTestPublisher(bulkSize int, response OutputResponse) *testPublisher {
 	}
 
 	ow := &outputWorker{}
-	ow.config.BulkMaxSize = &bulkSize
+	ow.config.BulkMaxSize = bulkSize
 	ow.handler = mh
 	ws := workerSignal{}
 	ow.messageWorker.init(&ws, defaultChanSize, defaultBulkChanSize, mh)

--- a/libbeat/publisher/output_test.go
+++ b/libbeat/publisher/output_test.go
@@ -3,6 +3,8 @@ package publisher
 import (
 	"testing"
 
+	"github.com/urso/ucfg"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/outputs"
 	"github.com/stretchr/testify/assert"
@@ -28,7 +30,7 @@ func (t *testOutputer) PublishEvent(trans outputs.Signaler, opts outputs.Options
 func TestOutputWorker(t *testing.T) {
 	outputer := &testOutputer{events: make(chan common.MapStr, 10)}
 	ow := newOutputWorker(
-		outputs.MothershipConfig{},
+		ucfg.New(),
 		outputer,
 		newWorkerSignal(),
 		1, 0)

--- a/libbeat/publisher/publish.go
+++ b/libbeat/publisher/publish.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/nranchev/go-libGeoIP"
+	"github.com/urso/ucfg"
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
@@ -180,7 +181,7 @@ func (publisher *PublisherType) PublishTopology(params ...string) error {
 // Create new PublisherType
 func New(
 	beatName string,
-	configs map[string]outputs.MothershipConfig,
+	configs map[string]*ucfg.Config,
 	shipper ShipperConfig,
 ) (*PublisherType, error) {
 
@@ -194,7 +195,7 @@ func New(
 
 func (publisher *PublisherType) init(
 	beatName string,
-	configs map[string]outputs.MothershipConfig,
+	configs map[string]*ucfg.Config,
 	shipper ShipperConfig,
 ) error {
 	var err error
@@ -242,7 +243,7 @@ func (publisher *PublisherType) init(
 					hwm,
 					bulkHWM))
 
-			if !config.SaveTopology {
+			if ok, _ := config.Bool("save_topology", 0); !ok {
 				continue
 			}
 

--- a/packetbeat/config/config.go
+++ b/packetbeat/config/config.go
@@ -3,7 +3,6 @@ package config
 import (
 	"github.com/elastic/beats/libbeat/common/droppriv"
 	"github.com/elastic/beats/libbeat/logp"
-	"github.com/elastic/beats/libbeat/outputs"
 	"github.com/elastic/beats/libbeat/publisher"
 	"github.com/elastic/beats/packetbeat/procs"
 )
@@ -12,7 +11,6 @@ type Config struct {
 	Interfaces InterfacesConfig
 	Flows      *Flows
 	Protocols  Protocols
-	Output     map[string]outputs.MothershipConfig
 	Shipper    publisher.ShipperConfig
 	Procs      procs.ProcsConfig
 	RunOptions droppriv.RunOptions


### PR DESCRIPTION
Remove requirement for global MothershipConfig and have each output plugin define it's own config setting.

Each output plugin define local configuration options in `config.go` file.