### PR TITLE
Metricbeat improvements and Cleanup

### DIFF
--- a/metricbeat/Makefile
+++ b/metricbeat/Makefile
@@ -3,5 +3,6 @@
 BEATNAME=metricbeat
 SYSTEM_TESTS=true
 TEST_ENVIRONMENT?=true
+GOPACKAGES=$(shell go list ${BEAT_DIR}/${BEATNAME}/... | grep -v /vendor/)
 
 include ../libbeat/scripts/Makefile

--- a/metricbeat/TODO.md
+++ b/metricbeat/TODO.md
@@ -1,13 +1,12 @@
 List of things to keep track on:
 
 * Create dashboard for each implemented metricset
-* validate schema with topbeat -> will it work as expected
 * send also document if remote system is not reachable -> error document
   * What happens on error of fetch?
 * disable _all for all fields
 * disable _source? for all fields
 * Filters on metricset level
-  * Idea: Basic, Medium, All data to have predefined sets / levels
+  * Idea: Minimum, Basic, Full data to have predefined sets / levels
   * Or is this done via filter implementation
 * Add fields per module / metricsets
-* Improve apache docker image
+* Add templates

--- a/metricbeat/beater/metricbeat.go
+++ b/metricbeat/beater/metricbeat.go
@@ -31,6 +31,7 @@ import (
 	"github.com/elastic/beats/libbeat/cfgfile"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/metricbeat/helper"
+	"github.com/elastic/beats/metricbeat/include"
 )
 
 type Metricbeat struct {
@@ -52,6 +53,9 @@ func (mb *Metricbeat) Config(b *beat.Beat) error {
 		return err
 	}
 
+	// List all registered modules and metricsets
+	include.ListAll()
+
 	return nil
 }
 
@@ -70,7 +74,10 @@ func (mb *Metricbeat) Run(b *beat.Beat) error {
 			return err
 		}
 
-		module.Start(b)
+		err = module.Start(b)
+		if err != nil {
+			return err
+		}
 	}
 
 	<-mb.done

--- a/metricbeat/helper/event.go
+++ b/metricbeat/helper/event.go
@@ -1,0 +1,47 @@
+package helper
+
+import (
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/logp"
+)
+
+func getIndex(event common.MapStr, indexName string) string {
+	// Set index from event if set
+
+	if _, ok := event["index"]; ok {
+		indexName, ok = event["index"].(string)
+		if !ok {
+			logp.Err("Index couldn't be overwritten because event index is not string")
+		}
+		delete(event, "index")
+	}
+	return indexName
+}
+
+func getType(event common.MapStr, typeName string) string {
+
+	// Set type from event if set
+	if _, ok := event["type"]; ok {
+		typeName, ok = event["type"].(string)
+		if !ok {
+			logp.Err("Type couldn't be overwritten because event type is not string")
+		}
+		delete(event, "type")
+	}
+
+	return typeName
+}
+
+func getTimestamp(event common.MapStr, timestamp common.Time) common.Time {
+
+	// Set timestamp from event if set, move it to the top level
+	// If not set, timestamp is created
+	if _, ok := event["@timestamp"]; ok {
+		timestamp, ok = event["@timestamp"].(common.Time)
+		if !ok {
+			logp.Err("Timestamp couldn't be overwritten because event @timestamp is not common.Time")
+		}
+		delete(event, "@timestamp")
+	}
+	return timestamp
+}

--- a/metricbeat/helper/interfacer.go
+++ b/metricbeat/helper/interfacer.go
@@ -13,15 +13,8 @@ type ModuleConfig struct {
 
 // Interface for each metric
 type MetricSeter interface {
-	// Setup needed for all upcoming fetches
-	// Typically special config varialbes are loaded here
-	Setup() error
-
 	// Method to periodically fetch new events
 	Fetch(m *MetricSet) ([]common.MapStr, error)
-
-	// Cleanup when stopping metricset
-	Cleanup() error
 }
 
 // Interface for each module

--- a/metricbeat/helper/metricset.go
+++ b/metricbeat/helper/metricset.go
@@ -1,10 +1,7 @@
 package helper
 
 import (
-	"time"
-
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/logp"
 )
 
 // Metric specific data
@@ -14,84 +11,22 @@ type MetricSet struct {
 	MetricSeter MetricSeter
 	// Inherits config from module
 	Config ModuleConfig
+	Module *Module
 }
 
 // Creates a new MetricSet
-func NewMetricSet(name string, metricset MetricSeter, config ModuleConfig) *MetricSet {
+func NewMetricSet(name string, metricset MetricSeter, module *Module) *MetricSet {
 	return &MetricSet{
 		Name:        name,
 		MetricSeter: metricset,
-		Config:      config,
+		Config:      module.Config,
+		Module:      module,
 	}
 }
 
 // RunMetric runs the given metricSet and returns the event
 func (m *MetricSet) Fetch() ([]common.MapStr, error) {
-
-	events, err := m.MetricSeter.Fetch(m)
-
-	if err != nil {
-		return nil, err
-	}
-	newEvents := []common.MapStr{}
-
-	// Default names based on module and metric
-	// These can be overwritten by setting index or / and type in the event
-	indexName := ""
-
-	// Type is the same for all metricsets
-	typeName := "metricsets"
-	timestamp := common.Time(time.Now())
-
-	for _, event := range events {
-		// Set index from event if set
-		if _, ok := event["index"]; ok {
-			indexName, ok = event["index"].(string)
-			if !ok {
-				logp.Err("Index couldn't be overwritten because event index is not string")
-			}
-			delete(event, "index")
-		}
-
-		// Set type from event if set
-		if _, ok := event["type"]; ok {
-			typeName, ok = event["type"].(string)
-			if !ok {
-				logp.Err("Type couldn't be overwritten because event type is not string")
-			}
-			delete(event, "type")
-		}
-
-		// Set timestamp from event if set, move it to the top level
-		// If not set, timestamp is created
-		if _, ok := event["@timestamp"]; ok {
-			timestamp, ok = event["@timestamp"].(common.Time)
-			if !ok {
-				logp.Err("Timestamp couldn't be overwritten because event @timestamp is not common.Time")
-			}
-			delete(event, "@timestamp")
-		}
-
-		eventFieldName := m.Config.Module + "-" + m.Name
-
-		// TODO: Add fields_under_root option for "metrics"?
-		event = common.MapStr{
-			"type":         typeName,
-			eventFieldName: event,
-			"metricset":    m.Name,
-			"module":       m.Config.Module,
-			"@timestamp":   timestamp,
-		}
-
-		// Overwrite index in case it is set
-		if indexName != "" {
-			event["beat"] = common.MapStr{
-				"index": indexName,
-			}
-		}
-
-		newEvents = append(newEvents, event)
-	}
-
-	return newEvents, nil
+	// TODO: Call fetch for each host if hosts are set.
+	// Host is a first class citizen and does not have to be handled by the metricset itself
+	return m.MetricSeter.Fetch(m)
 }

--- a/metricbeat/helper/module.go
+++ b/metricbeat/helper/module.go
@@ -6,7 +6,9 @@ import (
 
 	"fmt"
 	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
+	"sort"
 )
 
 // Module specifics. This must be defined by each module
@@ -17,7 +19,7 @@ type Module struct {
 	moduler Moduler
 
 	// Module config
-	config ModuleConfig
+	Config ModuleConfig
 
 	// List of all metricsets in this module. Use to keep track of metricsets
 	metricSets map[string]*MetricSet
@@ -32,7 +34,7 @@ type Module struct {
 func NewModule(config ModuleConfig, moduler Moduler) *Module {
 	return &Module{
 		name:       config.Module,
-		config:     config,
+		Config:     config,
 		moduler:    moduler,
 		metricSets: map[string]*MetricSet{},
 		wg:         sync.WaitGroup{},
@@ -41,39 +43,30 @@ func NewModule(config ModuleConfig, moduler Moduler) *Module {
 }
 
 // Starts the given module
-func (m *Module) Start(b *beat.Beat) {
+func (m *Module) Start(b *beat.Beat) error {
 
 	defer logp.Recover(fmt.Sprintf("Module %s paniced and stopped running.", m.name))
 
-	if !m.config.Enabled {
-		logp.Debug("helper", "Not starting module %s as not enabled.", m.name)
-		return
+	if !m.Config.Enabled {
+		logp.Debug("helper", "Not starting module %s with metricsets %s as not enabled.", m.name, m.getMetricSetsList())
+		return nil
 	}
 
 	logp.Info("Setup moduler: %s", m.name)
 	err := m.moduler.Setup()
 	if err != nil {
-		logp.Err("Error setting up module: %s. Not starting metricsets for this module.", err)
-		return
+		return fmt.Errorf("Error setting up module: %s. Not starting metricsets for this module.", err)
 	}
 
-	// Setup - Create metricSets for the module
-	for _, metricsetName := range m.config.MetricSets {
-		metricSeter := Registry.MetricSeters[m.name][metricsetName]
-		// Setup
-		err := metricSeter.Setup()
-		if err != nil {
-			logp.Err("Error happening during metricseter setup: %s", err)
-		}
-
-		metricSet := NewMetricSet(metricsetName, metricSeter, m.config)
-		m.metricSets[metricsetName] = metricSet
+	err = m.loadMetricsets()
+	if err != nil {
+		return fmt.Errorf("Error loading metricsets: %s", err)
 	}
 
 	// Setup period
-	period, err := time.ParseDuration(m.config.Period)
+	period, err := time.ParseDuration(m.Config.Period)
 	if err != nil {
-		logp.Info("Error in parsing period of metric %s: %v", m.name, err)
+		return fmt.Errorf("Error in parsing period of metric %s: %v", m.name, err)
 	}
 
 	// If no period set, set default
@@ -83,15 +76,18 @@ func (m *Module) Start(b *beat.Beat) {
 	}
 
 	// TODO: Improve logging information with list (names of metricSets)
-	logp.Info("Start Module %s with metricsets %v and period %v", m.name, m.metricSets, period)
+	logp.Info("Start Module %s with metricsets [%s] and period %v", m.name, m.getMetricSetsList(), period)
 
 	go m.Run(period, b)
+
+	return nil
 }
 
 func (m *Module) Run(period time.Duration, b *beat.Beat) {
 	ticker := time.NewTicker(period)
+
 	defer func() {
-		logp.Info("Stopped module %s with metricsets ... TODO", m.name)
+		logp.Info("Stopped module %s with metricsets %s", m.name, m.getMetricSetsList())
 		ticker.Stop()
 	}()
 
@@ -155,6 +151,8 @@ func (m *Module) FetchMetricSets(b *beat.Beat, metricSet *MetricSet) {
 		return
 	}
 
+	events, err = m.processEvents(events, metricSet)
+
 	// Async publishing of event
 	b.Events.PublishEvents(events)
 
@@ -164,4 +162,83 @@ func (m *Module) FetchMetricSets(b *beat.Beat, metricSet *MetricSet) {
 func (m *Module) Stop() {
 	logp.Info("Stopping module: %v", m.name)
 	m.wg.Wait()
+}
+
+// loadMetricsets creates and setups the metricseter for the module
+func (m *Module) loadMetricsets() error {
+	// Setup - Create metricSets for the module
+	for _, metricsetName := range m.Config.MetricSets {
+
+		metricSet, err := Registry.GetMetricSet(m, metricsetName)
+		if err != nil {
+			return err
+		}
+		m.metricSets[metricsetName] = metricSet
+	}
+	return nil
+}
+
+// getMetricSetsList is a helper function that returns a list of all module metricsets as string
+// This is mostly used for logging
+func (m *Module) getMetricSetsList() string {
+
+	// Sort list first alphabetically
+	keys := make([]string, 0, len(m.metricSets))
+	for key := range m.metricSets {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	// Create output string
+	list := ""
+	first := true
+
+	for _, value := range keys {
+		if !first {
+			list = list + ", "
+		}
+		first = false
+		list = list + value
+	}
+
+	return list
+}
+
+func (m *Module) processEvents(events []common.MapStr, metricSet *MetricSet) ([]common.MapStr, error) {
+	newEvents := []common.MapStr{}
+
+	// Default name is empty, means it will be metricbeat
+	indexName := ""
+	typeName := "metricsets"
+	timestamp := common.Time(time.Now())
+
+	for _, event := range events {
+		// Set meta information dynamic if set
+		indexName = getIndex(event, indexName)
+		typeName = getType(event, typeName)
+		timestamp = getTimestamp(event, timestamp)
+
+		// Each metricset has a unique eventfieldname to prevent type conflicts
+		eventFieldName := m.name + "-" + metricSet.Name
+
+		// TODO: Add fields_under_root option for "metrics"?
+		event = common.MapStr{
+			"type":         typeName,
+			eventFieldName: event,
+			"metricset":    metricSet.Name,
+			"module":       m.name,
+			"@timestamp":   timestamp,
+		}
+
+		// Overwrite index in case it is set
+		if indexName != "" {
+			event["beat"] = common.MapStr{
+				"index": indexName,
+			}
+		}
+
+		newEvents = append(newEvents, event)
+	}
+
+	return newEvents, nil
 }

--- a/metricbeat/helper/module_test.go
+++ b/metricbeat/helper/module_test.go
@@ -1,0 +1,21 @@
+package helper
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetMetricSetsList(t *testing.T) {
+
+	metricSets := map[string]*MetricSet{}
+	metricSets["test1"] = &MetricSet{}
+	metricSets["test2"] = &MetricSet{}
+
+	module := Module{
+		metricSets: metricSets,
+	}
+
+	assert.Equal(t, "test1, test2", module.getMetricSetsList())
+
+}

--- a/metricbeat/helper/register.go
+++ b/metricbeat/helper/register.go
@@ -56,3 +56,20 @@ func (r *Register) GetModule(config ModuleConfig) (*Module, error) {
 
 	return NewModule(config, moduler), nil
 }
+
+// GetMetricSet returns a new metricset instance for the given metricset name combined with the module name
+func (r *Register) GetMetricSet(module *Module, metricsetName string) (*MetricSet, error) {
+
+	if _, ok := Registry.MetricSeters[module.name]; !ok {
+		return nil, fmt.Errorf("Module %s does not exist", module.name)
+	}
+
+	if _, ok := Registry.MetricSeters[module.name][metricsetName]; !ok {
+		return nil, fmt.Errorf("Metricset %s in module %s does not exist", metricsetName, module.name)
+	}
+
+	metricSeter := Registry.MetricSeters[module.name][metricsetName]
+
+	return NewMetricSet(metricsetName, metricSeter, module), nil
+
+}

--- a/metricbeat/include/list.go
+++ b/metricbeat/include/list.go
@@ -11,7 +11,7 @@ package include
 // TODO: create a script to automatically generate this list
 import (
 	"github.com/elastic/beats/libbeat/logp"
-	_ "github.com/elastic/beats/metricbeat/helper"
+	"github.com/elastic/beats/metricbeat/helper"
 
 	// List of all metrics to make sure they are registred
 	// Every new metric must be added here
@@ -22,9 +22,9 @@ import (
 
 func ListAll() {
 	logp.Debug("beat", "Registered Modules and Metrics")
-	//for moduleName, module := range helper.Registry {
-	//	for metricName, _ := range module.MetricSets {
-	//		logp.Debug("beat", "Registred: Module: %v, Metric: %v", moduleName, metricName)
-	//	}
-	//}
+	for module := range helper.Registry.Modulers {
+		for metricset := range helper.Registry.MetricSeters[module] {
+			logp.Debug("metricbeat", "Registred: Module: %v, MetricSet: %v", module, metricset)
+		}
+	}
 }

--- a/metricbeat/module/apache/status/status.go
+++ b/metricbeat/module/apache/status/status.go
@@ -13,16 +13,12 @@ import (
 )
 
 func init() {
-	helper.Registry.AddMetricSeter("apache", "status", MetricSeter{})
+	helper.Registry.AddMetricSeter("apache", "status", &MetricSeter{})
 }
 
 type MetricSeter struct{}
 
-func (m MetricSeter) Setup() error {
-	return nil
-}
-
-func (m MetricSeter) Fetch(ms *helper.MetricSet) (events []common.MapStr, err error) {
+func (m *MetricSeter) Fetch(ms *helper.MetricSet) (events []common.MapStr, err error) {
 
 	hosts := ms.Config.Hosts
 
@@ -47,8 +43,4 @@ func (m MetricSeter) Fetch(ms *helper.MetricSet) (events []common.MapStr, err er
 	}
 
 	return events, nil
-}
-
-func (m MetricSeter) Cleanup() error {
-	return nil
 }

--- a/metricbeat/module/mysql/status/status_test.go
+++ b/metricbeat/module/mysql/status/status_test.go
@@ -3,9 +3,10 @@ package status
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/beats/metricbeat/helper"
 	"github.com/elastic/beats/metricbeat/module/mysql"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestFetch(t *testing.T) {
@@ -14,18 +15,16 @@ func TestFetch(t *testing.T) {
 		t.Skip("Skipping in short mode, because it requires MySQL")
 	}
 
-	// Setup Module config
-
 	// Setup Metric
-	m := MetricSeter{}
-	err := m.Setup()
-	assert.NoError(t, err)
+	m := New()
 
 	config := helper.ModuleConfig{
 		Hosts: []string{mysql.GetMySQLEnvDSN()},
 	}
-
-	ms := helper.NewMetricSet("status", m, config)
+	module := &helper.Module{
+		Config: config,
+	}
+	ms := helper.NewMetricSet("status", m, module)
 
 	// Load events
 	events, err := m.Fetch(ms)

--- a/metricbeat/module/redis/info/info_test.go
+++ b/metricbeat/module/redis/info/info_test.go
@@ -15,14 +15,15 @@ func TestConnect(t *testing.T) {
 	}
 
 	// Setup
-	r := MetricSeter{}
-	err := r.Setup()
-	assert.NoError(t, err)
+	r := &MetricSeter{}
 
 	config := helper.ModuleConfig{
 		Hosts: []string{redis.GetRedisEnvHost() + ":" + redis.GetRedisEnvPort()},
 	}
-	ms := helper.NewMetricSet("info", r, config)
+	module := &helper.Module{
+		Config: config,
+	}
+	ms := helper.NewMetricSet("info", r, module)
 
 	data, err := r.Fetch(ms)
 	assert.NoError(t, err)


### PR DESCRIPTION
* Add error handling during module start
* Remove Setup and Cleanup method from MetricSeter interface. Not needed anymore in new structure as all setup has to be provided by the module.
* Add module tests
* Move event processing to module from metricset