### PR TITLE
Add the ability to set custom fields

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -28,6 +28,7 @@ https://github.com/elastic/beats/compare/v1.1.0...master[Check the HEAD diff]
 
 *Filebeat*
 - Default config for ignore_older is now infinite instead of 24h, means ignore_older is disabled by default. Use close_older to only close file handlers.
+- Scalar values in used in the `fields` configuration setting are no longer automatically converted to strings. {pull}1092[1092]
 
 *Winlogbeat*
 
@@ -72,6 +73,7 @@ https://github.com/elastic/beats/compare/v1.1.0...master[Check the HEAD diff]
 - Improve logstash and elasticsearch backoff behavior. {pull}927[927]
 - Add experimental Kafka output. {pull}942[942]
 - Add config file option to configure GOMAXPROCS. {pull}969[969]
+- Added a `fields` and `fields_under_root` as options available under the `shipper` configuration {pull}1092[1092]
 
 *Packetbeat*
 - Change the DNS library used throughout the dns package to github.com/miekg/dns. {pull}803[803]
@@ -84,10 +86,12 @@ https://github.com/elastic/beats/compare/v1.1.0...master[Check the HEAD diff]
 - Add multiline support for combining multiple related lines into one event. {issue}461[461]
 - Add close_older configuration option to complete ignore_older https://github.com/elastic/filebeat/issues/181[181]
 - Add experimental option to enable filebeat publisher pipeline to operate asynchonrously {pull}782[782]
+- Added the ability to set a list of tags for each prospector {pull}1092[1092]
 
 *Winlogbeat*
 - Add caching of event metadata handles and the system render context for the wineventlog API {pull}888[888]
 - Improve config validation by checking for unknown top-level YAML keys. {pull}1100[1100]
+- Added the ability to set tags, fields, and fields_under_root as options for each event log {pull}1092[1092]
 
 ==== Deprecated
 

--- a/filebeat/config/config.go
+++ b/filebeat/config/config.go
@@ -57,11 +57,11 @@ type ProspectorConfig struct {
 }
 
 type HarvesterConfig struct {
+	common.EventMetadata `config:",inline"` // Fields and tags to add to events.
+
 	BufferSize         int    `config:"harvester_buffer_size"`
 	DocumentType       string `config:"document_type"`
 	Encoding           string `config:"encoding"`
-	Fields             common.MapStr
-	FieldsUnderRoot    bool   `config:"fields_under_root"`
 	InputType          string `config:"input_type"`
 	TailFiles          bool   `config:"tail_files"`
 	Backoff            string `config:"backoff"`

--- a/filebeat/docs/reference/configuration/filebeat-options.asciidoc
+++ b/filebeat/docs/reference/configuration/filebeat-options.asciidoc
@@ -92,27 +92,51 @@ The following example configures Filebeat to ignore all the files that have a `g
   exclude_files: [".gz$"]
 -------------------------------------------------------------------------------------
 
+===== tags
+
+A list of tags that the Beat includes in the `tags` field of each published
+event. Tags make it easy to select specific events in Kibana or apply
+conditional filtering in Logstash. These tags will be appended to the list of
+tags specified in the `shipper` configuration.
+
+Example:
+
+[source,yaml]
+--------------------------------------------------------------------------------
+filebeat:
+  prospectors:
+    - paths: ["/var/log/app/*.json"]
+      tags: ["json"]
+--------------------------------------------------------------------------------
+
 [[configuration-fields]]
 ===== fields
 
-Optional fields that you can specify to add additional information to the output. For
-example, you might add fields that you can use for filtering log data. Fields can be
-scalar values, arrays, dictionaries, or any nested combination of these. All scalar values will be interpreted as strings. By default,
-the fields that you specify here will be grouped under a `fields` sub-dictionary in the output document. To store the custom fields as top-level fields, set the `fields_under_root` option to true.
+Optional fields that you can specify to add additional information to the
+output. For example, you might add fields that you can use for filtering log
+data. Fields can be scalar values, arrays, dictionaries, or any nested
+combination of these. By default, the fields that you specify here will be
+grouped under a `fields` sub-dictionary in the output document. To store the
+custom fields as top-level fields, set the `fields_under_root` option to true.
+If a duplicate field is declared in the `shipper` configuration, then its value
+will be overwritten by the value declared here.
 
 [source,yaml]
--------------------------------------------------------------------------------------
-fields:
-    level: debug
-    review: 1
+--------------------------------------------------------------------------------
+filebeat:
+  prospectors:
+    - paths: ["/var/log/app/*.log"]
+      fields:
+        app_id: query_engine_12
+--------------------------------------------------------------------------------
 
--------------------------------------------------------------------------------------
 [[fields-under-root]]
 ===== fields_under_root
 
-If this option is set to true, the custom <<configuration-fields>> are stored as top-level fields
-in the output document instead of being grouped under a `fields` sub-dictionary.
-If the custom field names conflict with other field names added by Filebeat, the custom fields overwrite the other fields.
+If this option is set to true, the custom <<configuration-fields>> are stored as
+top-level fields in the output document instead of being grouped under a
+`fields` sub-dictionary. If the custom field names conflict with other field
+names added by Filebeat, then the custom fields overwrite the other fields.
 
 [[ignore-older]]
 ===== ignore_older

--- a/filebeat/filebeat.yml
+++ b/filebeat/filebeat.yml
@@ -360,6 +360,17 @@ shipper:
   # logical properties.
   #tags: ["service-X", "web-tier"]
 
+  # Optional fields that you can specify to add additional information to the
+  # output. Fields can be scalar values, arrays, dictionaries, or any nested
+  # combination of these. 
+  #fields:
+  #  env: staging
+
+  # If this option is set to true, the custom fields are stored as top-level
+  # fields in the output document instead of being grouped under a fields
+  # sub-dictionary. Default is false.
+  #fields_under_root: false
+
   # Uncomment the following if you want to ignore transactions created
   # by the server on which the shipper is installed. This option is useful
   # to remove duplicates if shippers are installed on multiple servers.

--- a/filebeat/harvester/log.go
+++ b/filebeat/harvester/log.go
@@ -127,20 +127,18 @@ func (h *Harvester) Harvest() {
 		}
 
 		if h.shouldExportLine(text) {
-			// Sends text to spooler
 			event := &input.FileEvent{
-				ReadTime:     ts,
-				Source:       &h.Path,
-				InputType:    h.Config.InputType,
-				DocumentType: h.Config.DocumentType,
-				Offset:       h.Offset,
-				Bytes:        bytesRead,
-				Text:         &text,
-				Fields:       h.Config.Fields,
-				Fileinfo:     &info,
+				EventMetadata: h.Config.EventMetadata,
+				ReadTime:      ts,
+				Source:        &h.Path,
+				InputType:     h.Config.InputType,
+				DocumentType:  h.Config.DocumentType,
+				Offset:        h.Offset,
+				Bytes:         bytesRead,
+				Text:          &text,
+				Fileinfo:      &info,
 			}
 
-			event.SetFieldsUnderRoot(h.Config.FieldsUnderRoot)
 			h.SpoolerChan <- event // ship the new event downstream
 		}
 

--- a/filebeat/input/file.go
+++ b/filebeat/input/file.go
@@ -17,6 +17,7 @@ type File struct {
 
 // FileEvent is sent to the output and must contain all relevant information
 type FileEvent struct {
+	common.EventMetadata
 	ReadTime     time.Time
 	Source       *string
 	InputType    string
@@ -24,10 +25,7 @@ type FileEvent struct {
 	Offset       int64
 	Bytes        int
 	Text         *string
-	Fields       common.MapStr
 	Fileinfo     *os.FileInfo
-
-	fieldsUnderRoot bool
 }
 
 type FileState struct {
@@ -57,37 +55,16 @@ func (f *FileEvent) GetState() *FileState {
 	return state
 }
 
-// SetFieldsUnderRoot sets whether the fields should be added
-// top level to the output documentation (fieldsUnderRoot = true) or
-// under a fields dictionary.
-func (f *FileEvent) SetFieldsUnderRoot(fieldsUnderRoot bool) {
-	f.fieldsUnderRoot = fieldsUnderRoot
-}
-
 func (f *FileEvent) ToMapStr() common.MapStr {
 	event := common.MapStr{
-		"@timestamp": common.Time(f.ReadTime),
-		"source":     f.Source,
-		"offset":     f.Offset, // Offset here is the offset before the starting char.
-		"message":    f.Text,
-		"type":       f.DocumentType,
-		"input_type": f.InputType,
-		"count":      1,
-	}
-
-	if f.Fields != nil {
-		if f.fieldsUnderRoot {
-			for key, value := range f.Fields {
-				// in case of conflicts, overwrite
-				_, found := event[key]
-				if found {
-					logp.Warn("Overwriting %s key", key)
-				}
-				event[key] = value
-			}
-		} else {
-			event["fields"] = f.Fields
-		}
+		common.EventMetadataKey: f.EventMetadata,
+		"@timestamp":            common.Time(f.ReadTime),
+		"source":                f.Source,
+		"offset":                f.Offset, // Offset here is the offset before the starting char.
+		"message":               f.Text,
+		"type":                  f.DocumentType,
+		"input_type":            f.InputType,
+		"count":                 1,
 	}
 
 	return event

--- a/filebeat/input/file_test.go
+++ b/filebeat/input/file_test.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/elastic/beats/libbeat/common"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -111,24 +110,4 @@ func TestFileEventToMapStr(t *testing.T) {
 	mapStr := event.ToMapStr()
 	_, found := mapStr["fields"]
 	assert.False(t, found)
-}
-
-func TestFieldsUnderRoot(t *testing.T) {
-	event := FileEvent{
-		Fields: common.MapStr{
-			"hello": "world",
-		},
-	}
-	event.SetFieldsUnderRoot(true)
-	mapStr := event.ToMapStr()
-	_, found := mapStr["fields"]
-	assert.False(t, found)
-	assert.Equal(t, "world", mapStr["hello"])
-
-	event.SetFieldsUnderRoot(false)
-	mapStr = event.ToMapStr()
-	_, found = mapStr["hello"]
-	assert.False(t, found)
-	_, found = mapStr["fields"]
-	assert.True(t, found)
 }

--- a/filebeat/tests/system/test_fields.py
+++ b/filebeat/tests/system/test_fields.py
@@ -15,7 +15,7 @@ class Test(BaseTest):
         """
         self.render_config_template(
             path=os.path.abspath(self.working_dir) + "/test.log",
-            fields={"hello": "world"}
+            fields={"hello": "world", "number": 2}
         )
 
         with open(self.working_dir + "/test.log", "w") as f:
@@ -28,6 +28,7 @@ class Test(BaseTest):
         output = self.read_output()
         doc = output[0]
         assert doc["fields.hello"] == "world"
+        assert doc["fields.number"] == 2
 
     def test_custom_fields_under_root(self):
         """

--- a/libbeat/docs/shipperconfig.asciidoc
+++ b/libbeat/docs/shipperconfig.asciidoc
@@ -89,16 +89,51 @@ shipper:
 
 A list of tags that the Beat includes in the `tags` field of each published
 transaction. Tags make it easy to group servers by different logical properties.
-For example, if you have a cluster of web servers, you can add the "webservers" tag
-to the Beat on each server, and then use filters and queries in the
-Kibana web interface to get visualisations for the whole group of servers.
+For example, if you have a cluster of web servers, you can add the "webservers"
+tag to the Beat on each server, and then use filters and queries in the Kibana
+web interface to get visualisations for the whole group of servers.
+
+Example:
+
+[source,yaml]
+--------------------------------------------------------------------------------
+shipper:
+  tags: ["my-service", "hardware", "test"]
+--------------------------------------------------------------------------------
+
+[[configuration-fields]]
+===== fields
+
+Optional fields that you can specify to add additional information to the
+output. Fields can be scalar values, arrays, dictionaries, or any nested
+combination of these. By default, the fields that you specify here will be
+grouped under a `fields` sub-dictionary in the output document. To store the
+custom fields as top-level fields, set the `fields_under_root` option to true.
 
 Example:
 
 [source,yaml]
 ------------------------------------------------------------------------------
 shipper:
-  tags: ["my-service", "hardware", "test"]
+  fields: {project: "myproject", instance-id: "574734885120952459"}
+------------------------------------------------------------------------------
+
+===== fields_under_root
+
+If this option is set to true, the custom <<configuration-fields>> are stored as
+top-level fields in the output document instead of being grouped under a
+`fields` sub-dictionary. If the custom field names conflict with other field
+names, then the custom fields overwrite the other fields.
+
+Example:
+
+[source,yaml]
+------------------------------------------------------------------------------
+shipper:
+  fields_under_root: true
+  fields:
+    instance_id: i-10a64379
+    region: us-east-1
 ------------------------------------------------------------------------------
 
 ===== ignore_outgoing

--- a/libbeat/etc/libbeat.yml
+++ b/libbeat/etc/libbeat.yml
@@ -188,6 +188,17 @@ shipper:
   # logical properties.
   #tags: ["service-X", "web-tier"]
 
+  # Optional fields that you can specify to add additional information to the
+  # output. Fields can be scalar values, arrays, dictionaries, or any nested
+  # combination of these. 
+  #fields:
+  #  env: staging
+
+  # If this option is set to true, the custom fields are stored as top-level
+  # fields in the output document instead of being grouped under a fields
+  # sub-dictionary. Default is false.
+  #fields_under_root: false
+
   # Uncomment the following if you want to ignore transactions created
   # by the server on which the shipper is installed. This option is useful
   # to remove duplicates if shippers are installed on multiple servers.

--- a/libbeat/publisher/client.go
+++ b/libbeat/publisher/client.go
@@ -14,6 +14,30 @@ var (
 )
 
 // Client is used by beats to publish new events.
+//
+// The publish methods add fields that are common to all events. Both methods
+// add the 'beat' field that contains name and hostname. Also they add 'tags'
+// and 'fields'.
+//
+// Event publishers can override the default index for an event by adding a
+// 'beat' field whose value is a common.MapStr that contains an 'index' field
+// specifying the destination index.
+//
+//  event := common.MapStr{
+//      // Setting a custom index for a single event.
+//      "beat": common.MapStr{"index": "custom-index"},
+//  }
+//
+// Event publishers can add fields and tags to an event. The fields will take
+// precedence over the global fields defined in the shipper configuration.
+//
+//  event := common.MapStr{
+//      // Add custom fields to the root of the event.
+//      common.EventMetadataKey: common.EventMetadata{
+//          UnderRoot: true,
+//          Fields:    common.MapStr{"env": "production"}
+//      }
+//  }
 type Client interface {
 	// PublishEvent publishes one event with given options. If Sync option is set,
 	// PublishEvent will block until output plugins report success or failure state
@@ -41,10 +65,9 @@ type PublishMessage struct {
 }
 
 type client struct {
-	publisher *PublisherType
-
-	beatMeta common.MapStr
-	tags     []string
+	publisher           *PublisherType
+	beatMeta            common.MapStr        // Beat metadata that is added to all events.
+	globalEventMetadata common.EventMetadata // Fields and tags that are added to all events.
 }
 
 // ClientOption allows API users to set additional options when publishing events.
@@ -82,7 +105,7 @@ func newClient(pub *PublisherType) *client {
 			"name":     pub.name,
 			"hostname": pub.hostname,
 		},
-		tags: pub.tags,
+		globalEventMetadata: pub.globalEventMetadata,
 	}
 }
 
@@ -104,19 +127,34 @@ func (c *client) PublishEvents(events []common.MapStr, opts ...ClientOption) boo
 	return client.PublishEvents(ctx, events)
 }
 
+// annotateEvent adds fields that are common to all events. This adds the 'beat'
+// field that contains name and hostname. It also adds 'tags' and 'fields'. See
+// the documentation for Client for more information.
 func (c *client) annotateEvent(event common.MapStr) {
-
-	// Check if index was set dynamically
-	if _, ok := event["beat"]; ok {
-		beatTemp := event["beat"].(common.MapStr)
-		if _, ok := beatTemp["index"]; ok {
-			c.beatMeta["index"] = beatTemp["index"]
+	// Allow an event to override the destination index for an event by setting
+	// beat.index in an event.
+	beatMeta := c.beatMeta
+	if beatIfc, ok := event["beat"]; ok {
+		ms, ok := beatIfc.(common.MapStr)
+		if ok {
+			// Copy beatMeta so the defaults are not changed.
+			beatMeta = common.MapStrUnion(beatMeta, ms)
 		}
 	}
+	event["beat"] = beatMeta
 
-	event["beat"] = c.beatMeta
-	if len(c.tags) > 0 {
-		event["tags"] = c.tags
+	// Add the global tags and fields defined under shipper.
+	common.AddTags(event, c.globalEventMetadata.Tags)
+	common.MergeFields(event, c.globalEventMetadata.Fields, c.globalEventMetadata.FieldsUnderRoot)
+
+	// Add the event specific fields last so that they precedence over globals.
+	if metaIfc, ok := event[common.EventMetadataKey]; ok {
+		eventMetadata, ok := metaIfc.(common.EventMetadata)
+		if ok {
+			common.AddTags(event, eventMetadata.Tags)
+			common.MergeFields(event, eventMetadata.Fields, eventMetadata.FieldsUnderRoot)
+		}
+		delete(event, common.EventMetadataKey)
 	}
 
 	if logp.IsDebug("publish") {

--- a/libbeat/publisher/publish.go
+++ b/libbeat/publisher/publish.go
@@ -53,13 +53,14 @@ type PublisherType struct {
 	hostname       string // Host name as returned by the operation system
 	name           string // The shipperName if configured, the hostname otherwise
 	IpAddrs        []string
-	tags           []string
 	disabled       bool
 	Index          string
 	Output         []*outputWorker
 	TopologyOutput outputs.TopologyOutputer
 	IgnoreOutgoing bool
 	GeoLite        *libgeo.GeoIP
+
+	globalEventMetadata common.EventMetadata // Fields and tags to add to each event.
 
 	RefreshTopologyTimer <-chan time.Time
 
@@ -78,11 +79,11 @@ type PublisherType struct {
 }
 
 type ShipperConfig struct {
+	common.EventMetadata  `config:",inline"` // Fields and tags to add to each event.
 	Name                  string
 	Refresh_topology_freq int
 	Ignore_outgoing       bool
 	Topology_expire       int
-	Tags                  []string
 	Geoip                 common.Geoip
 
 	// internal publisher queue sizes
@@ -291,7 +292,7 @@ func (publisher *PublisherType) init(
 	}
 	logp.Info("Publisher name: %s", publisher.name)
 
-	publisher.tags = shipper.Tags
+	publisher.globalEventMetadata = shipper.EventMetadata
 
 	//Store the publisher's IP addresses
 	publisher.IpAddrs, err = common.LocalIpAddrsAsStrings(false)

--- a/metricbeat/metricbeat.yml
+++ b/metricbeat/metricbeat.yml
@@ -209,6 +209,17 @@ shipper:
   # logical properties.
   #tags: ["service-X", "web-tier"]
 
+  # Optional fields that you can specify to add additional information to the
+  # output. Fields can be scalar values, arrays, dictionaries, or any nested
+  # combination of these. 
+  #fields:
+  #  env: staging
+
+  # If this option is set to true, the custom fields are stored as top-level
+  # fields in the output document instead of being grouped under a fields
+  # sub-dictionary. Default is false.
+  #fields_under_root: false
+
   # Uncomment the following if you want to ignore transactions created
   # by the server on which the shipper is installed. This option is useful
   # to remove duplicates if shippers are installed on multiple servers.

--- a/packetbeat/packetbeat.yml
+++ b/packetbeat/packetbeat.yml
@@ -29,6 +29,28 @@ protocols:
     # Enable ICMPv4 and ICMPv6 monitoring. Default: false
     enabled: true
 
+  amqp:
+    # Configure the ports where to listen for AMQP traffic. You can disable
+    # the AMQP protocol by commenting out the list of ports.
+    ports: [5672]
+    # Truncate messages that are published and avoid huge messages being
+    # indexed.
+    # Default: 1000
+    #max_body_length: 1000
+
+    # Hide the header fields in header frames.
+    # Default: false
+    #parse_headers: false
+
+    # Hide the additional arguments of method frames.
+    # Default: false
+    #parse_arguments: false
+
+    # Hide all methods relative to connection negociation between server and
+    # client.
+    # Default: true
+    #hide_connection_information: true
+
   dns:
     # Configure the ports where to listen for DNS traffic. You can disable
     # the DNS protocol by commenting out the list of ports.
@@ -51,24 +73,6 @@ protocols:
     # Default: false
     # send_request:  true
     # send_response: true
-
-  amqp:
-    # Configure the ports where to listen for AMQP traffic. You can disable
-    # the AMQP protocol by commenting out the list of ports.
-    ports: [5672]
-    # Truncate messages that are published and avoid huge messages being
-    # indexed.
-    # Default: 1000
-    #max_body_length: 1000
-    # Hide the header fields in header frames.
-    # Default: false
-    #parse_headers: false
-    # Hide the additional arguments of method frames.
-    # Default: false
-    #parse_arguments: false
-    # See all methods relative to connection negociation between server and
-    # client.
-    #hide_connection_information: false
 
   http:
     # Configure the ports where to listen for HTTP traffic. You can disable
@@ -166,7 +170,6 @@ protocols:
 #
 #    - process: app
 #      cmdline_grep: gunicorn
-
 ###############################################################################
 ############################# Libbeat Config ##################################
 # Base config file used by all other beats for using libbeat features
@@ -357,6 +360,17 @@ shipper:
   # logical properties.
   #tags: ["service-X", "web-tier"]
 
+  # Optional fields that you can specify to add additional information to the
+  # output. Fields can be scalar values, arrays, dictionaries, or any nested
+  # combination of these. 
+  #fields:
+  #  env: staging
+
+  # If this option is set to true, the custom fields are stored as top-level
+  # fields in the output document instead of being grouped under a fields
+  # sub-dictionary. Default is false.
+  #fields_under_root: false
+
   # Uncomment the following if you want to ignore transactions created
   # by the server on which the shipper is installed. This option is useful
   # to remove duplicates if shippers are installed on multiple servers.
@@ -424,3 +438,5 @@ logging:
   # Sets log level. The default log level is error.
   # Available log levels are: critical, error, warning, info, debug
   #level: error
+
+

--- a/topbeat/topbeat.yml
+++ b/topbeat/topbeat.yml
@@ -214,6 +214,17 @@ shipper:
   # logical properties.
   #tags: ["service-X", "web-tier"]
 
+  # Optional fields that you can specify to add additional information to the
+  # output. Fields can be scalar values, arrays, dictionaries, or any nested
+  # combination of these. 
+  #fields:
+  #  env: staging
+
+  # If this option is set to true, the custom fields are stored as top-level
+  # fields in the output document instead of being grouped under a fields
+  # sub-dictionary. Default is false.
+  #fields_under_root: false
+
   # Uncomment the following if you want to ignore transactions created
   # by the server on which the shipper is installed. This option is useful
   # to remove duplicates if shippers are installed on multiple servers.

--- a/winlogbeat/beater/winlogbeat.go
+++ b/winlogbeat/beater/winlogbeat.go
@@ -140,8 +140,9 @@ func (eb *Winlogbeat) Run(b *beat.Beat) error {
 		debugf("Initializing EventLog[%s]", eventLogConfig.Name)
 
 		eventLog, err := eventlog.New(eventlog.Config{
-			Name: eventLogConfig.Name,
-			API:  eventLogConfig.API,
+			Name:          eventLogConfig.Name,
+			API:           eventLogConfig.API,
+			EventMetadata: eventLogConfig.EventMetadata,
 		})
 		if err != nil {
 			return fmt.Errorf("Failed to create new event log for %s. %v",

--- a/winlogbeat/config/config.go
+++ b/winlogbeat/config/config.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/elastic/beats/libbeat/common"
 	"github.com/joeshaw/multierror"
 )
 
@@ -132,9 +133,10 @@ func (mc MetricsConfig) Validate() error {
 // EventLogConfig holds the configuration data that specifies which event logs
 // to monitor.
 type EventLogConfig struct {
-	Name        string
-	IgnoreOlder string `config:"ignore_older"`
-	API         string
+	common.EventMetadata `config:",inline"`
+	Name                 string
+	IgnoreOlder          string `config:"ignore_older"`
+	API                  string
 }
 
 // Validate validates the EventLogConfig data and returns an error describing

--- a/winlogbeat/docs/reference/configuration/winlogbeat-options.asciidoc
+++ b/winlogbeat/docs/reference/configuration/winlogbeat-options.asciidoc
@@ -124,6 +124,52 @@ winlogbeat:
       ignore_older: 168h
 --------------------------------------------------------------------------------
 
+===== event_logs.tags
+
+A list of tags that the Beat includes in the `tags` field of each published
+event. Tags make it easy to select specific events in Kibana or apply
+conditional filtering in Logstash. These tags will be appended to the list of
+tags specified in the `shipper` configuration.
+
+Example:
+
+[source,yaml]
+--------------------------------------------------------------------------------
+winlogbeat:
+  event_logs:
+    - name: CustomLog
+      tags: ["web"]
+--------------------------------------------------------------------------------
+
+[[configuration-fields]]
+===== event_logs.fields
+
+Optional fields that you can specify to add additional information to the
+output. For example, you might add fields that you can use for filtering event
+data. Fields can be scalar values, arrays, dictionaries, or any nested
+combination of these. By default, the fields that you specify here will be
+grouped under a `fields` sub-dictionary in the output document. To store the
+custom fields as top-level fields, set the `fields_under_root` option to true.
+If a duplicate field is declared in the `shipper` configuration, then its value
+will be overwritten by the value declared here.
+
+[source,yaml]
+--------------------------------------------------------------------------------
+winlogbeat:
+  event_logs:
+    - name: CustomLog
+      fields:
+        customer_id: 51415432
+--------------------------------------------------------------------------------
+
+[[fields-under-root]]
+===== event_logs.fields_under_root
+
+If this option is set to true, the custom <<configuration-fields>> are stored as
+top-level fields in the output document instead of being grouped under a
+`fields` sub-dictionary. If the custom field names conflict with other field
+names added by Winlogbeat, then the custom fields overwrite the other fields.
+
 ===== metrics.bindaddress
 
 The hostname and port where the Beat will host an HTTP web service that provides

--- a/winlogbeat/eventlog/eventlog.go
+++ b/winlogbeat/eventlog/eventlog.go
@@ -50,6 +50,8 @@ type Record struct {
 	Message        string   // The message from the event log.
 	MessageInserts []string // The raw message data logged by an application.
 	MessageErr     error    // The error that occurred while reading and formatting the message from the event log.
+
+	common.EventMetadata // Fields and tags to add to the event.
 }
 
 // String returns a string representation of Record.
@@ -66,10 +68,11 @@ func (r Record) String() string {
 // ToMapStr returns a new MapStr containing the data from this Record.
 func (r Record) ToMapStr() common.MapStr {
 	m := common.MapStr{
-		"@timestamp":    common.Time(r.TimeGenerated),
-		"log_name":      r.EventLogName,
-		"source_name":   r.SourceName,
-		"computer_name": r.ComputerName,
+		common.EventMetadataKey: r.EventMetadata,
+		"@timestamp":            common.Time(r.TimeGenerated),
+		"log_name":              r.EventLogName,
+		"source_name":           r.SourceName,
+		"computer_name":         r.ComputerName,
 		// Use a string to represent this uint64 data because its value can
 		// be outside the range represented by a Java long.
 		"record_number": strconv.FormatUint(r.RecordNumber, 10),

--- a/winlogbeat/eventlog/factory.go
+++ b/winlogbeat/eventlog/factory.go
@@ -4,12 +4,15 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+
+	"github.com/elastic/beats/libbeat/common"
 )
 
 // Config is the configuration data used to instantiate a new EventLog.
 type Config struct {
-	Name          string // Name of the event log or channel.
-	RemoteAddress string // Remote computer to connect to. Optional.
+	Name                 string // Name of the event log or channel.
+	RemoteAddress        string // Remote computer to connect to. Optional.
+	common.EventMetadata        // Fields and tags to add to each event.
 
 	API string // Name of the API to use. Optional.
 }

--- a/winlogbeat/tests/system/config/winlogbeat.yml.j2
+++ b/winlogbeat/tests/system/config/winlogbeat.yml.j2
@@ -1,21 +1,34 @@
 ###############################################################################
 ############################# Winlogbeat ######################################
 winlogbeat:
-  {% if ignore_older %}
+  {%- if ignore_older %}
   ignore_older: {{ignore_older}}
   {% endif %}
 
-  {% if event_logs %}
+  {%- if event_logs %}
   event_logs:
-    {% for log in event_logs %}
+    {% for log in event_logs -%}
     - name: {{ log.name }}
-      {% if log.ignore_older %}
+      {%- if log.ignore_older %}
       ignore_older: {{ log.ignore_older }}
       {% endif %}
-      {% if log.api %}
+      {%- if log.api %}
       api: {{ log.api }}
       {% endif %}
-    {% endfor %}
+      {%- if log.tags %}
+      tags:
+        {% for tag in log.tags -%}
+        - {{ tag }}
+        {% endfor -%}
+      {% endif -%}
+      {%- if log.fields %}
+      {% if log.fields_under_root %}fields_under_root: true{% endif %}
+      fields:
+        {% for k, v in log.fields.items() -%}
+        {{ k }}: {{ v }}
+        {% endfor -%}
+      {% endif %}
+    {% endfor -%}
   {% endif %}
 
 ###############################################################################
@@ -35,18 +48,23 @@ output:
 ############################# Shipper #########################################
 
 shipper:
- {% if shipper_name %}
- name: {{ shipper_name }}
- {% endif %}
+  {%- if shipper_name %}
+  name: {{ shipper_name }}
+  {% endif %}
 
- {% if tags %}
- tags: [
-    {%- if agent_tags -%}
-        {%- for tag in agent_tags -%}
-            "{{ tag }}"
-            {%- if not loop.last %}, {% endif -%}
-        {%- endfor -%}
-    {%- endif -%}]
- {% endif %}
+  {%- if tags %}
+  tags:
+    {% for tag in tags -%}
+    - {{ tag }}
+    {% endfor -%}
+  {% endif %}
+
+  {%- if fields %}
+  {% if fields_under_root %}fields_under_root: true{% endif %}
+  fields:
+    {% for k, v in fields.items() -%}
+    {{ k }}: {{ v }}
+    {% endfor -%}
+  {% endif %}
 
 # vim: set ft=jinja:

--- a/winlogbeat/tests/system/test_config.py
+++ b/winlogbeat/tests/system/test_config.py
@@ -9,8 +9,8 @@ class Test(BaseTest):
 
     def test_valid_config(self):
         """
-        With -configtest and an error in the configuration, it should
-        return a non-zero error code.
+        With -configtest and valid config, it should return a non-zero error
+        code.
         """
         self.render_config_template(
             ignore_older="1h",

--- a/winlogbeat/winlogbeat.yml
+++ b/winlogbeat/winlogbeat.yml
@@ -213,6 +213,17 @@ shipper:
   # logical properties.
   #tags: ["service-X", "web-tier"]
 
+  # Optional fields that you can specify to add additional information to the
+  # output. Fields can be scalar values, arrays, dictionaries, or any nested
+  # combination of these. 
+  #fields:
+  #  env: staging
+
+  # If this option is set to true, the custom fields are stored as top-level
+  # fields in the output document instead of being grouped under a fields
+  # sub-dictionary. Default is false.
+  #fields_under_root: false
+
   # Uncomment the following if you want to ignore transactions created
   # by the server on which the shipper is installed. This option is useful
   # to remove duplicates if shippers are installed on multiple servers.


### PR DESCRIPTION
This pull request implements the feature requested in #726.

##### Changes Affecting All Beats

- Added a `fields` and `fields_under_root` as options available
  under the `shipper` configuration. These settings are analogous to settings
  currently available in Filebeat. `fields` defined in the prospector
  configuration take precedence over fields define in the `shipper`
  configuration.

##### Changes Affecting Filebeat

- Added the ability to set a list of `tags` for each prospector. These tags will
  be appended to the list of tags specified in the `shipper` configuration.
- Scalar values under `fields` are not longer automatically converted to strings.

##### Changes Affecting Winlogbeat

- Added the ability to set `tags`, `fields`, and `fields_under_root` as options
  for each event log.

#### Examples

_Topbeat_

```yaml
shipper:
  fields_under_root: true
  fields:
    aws:
      instance_id: i-33458498
      region: us-east-1
output:
  console:
    pretty: true
```

```json
{
  "@timestamp": "2016-03-02T03:53:49.793Z",
  "aws": {
    "instance_id": "i-33458498",
    "region": "us-east-1"
  },
  "beat": {
    "hostname": "x",
    "name": "x"
  },
  "count": 1,
  "proc": {
    "cmdline": "/usr/bin/agentX",
    "cpu": {
      "start_time": "Feb05",
      "system": 7178,
      "total": 10789,
      "total_p": 0,
      "user": 3611
    },
    "mem": {
      "rss": 2162688,
      "rss_p": 0,
      "share": 0,
      "size": 2593021952
    },
    "name": "agentX",
    "pid": 395,
    "ppid": 1,
    "state": "running",
    "username": "someuser"
  },
  "type": "process"
}
```

_Filebeat_

```yaml
filebeat:
  prospectors:
    - paths: ["/var/log/myapp/log.json"]
      fields: {app_id: 456789}
      tags: [json]
output:
  logstash:
    hosts: ["localhost:5044"]
shipper:
  tags: ['digital ocean', centos7]
  fields:
    customer_id: 1234567
```

```json
{
  "@timestamp": "2016-03-02T04:12:32.491Z",
  "beat": {
    "hostname": "x",
    "name": "x"
  },
  "count": 1,
  "fields": {
    "app_id": 456789,
    "customer_id": 1234567
  },
  "input_type": "log",
  "message": "{ \"threadName\": \"MainThread\", \"name\": \"root\", \"thread\": 140735202359648, \"created\": 1336281068.506248, \"process\": 41937, \"processName\": \"MainProcess\", \"relativeCreated\": 9.100914001464844, \"module\": \"tests\", \"funcName\": \"testFormatKeys\", \"levelno\": 20, \"msecs\": 506.24799728393555, \"pathname\": \"tests/tests.py\", \"lineno\": 60, \"asctime\": [\"12-05-05 22:11:08,506248\"], \"message\": \"testing logging format\", \"filename\": \"tests.py\", \"levelname\": \"INFO\", \"special\": \"value\", \"run\": 12 }",
  "offset": 0,
  "source": "/var/log/myapp/log.json",
  "tags": [
    "digital ocean",
    "centos7",
    "json"
  ],
  "type": "log"
}
```

_Winlogbeat_

```yaml
winlogbeat:
  event_logs:
    - name: MyCustomEventLog
      tags: [web]
      fields_under_root: true
      fields: {service_id: web01}
shipper:
  fields_under_root: true
  fields:
    aws:
      instance_id: i-33458498
      region: us-east-1
output:
  console:
    pretty: true
```

See the test cases for more examples.

#### Open Questions

- Are you happy with keeping this called `fields`? (same as it's called in Filebeat)