### PR TITLE
Packer save squeeze

### DIFF
--- a/dev-tools/packer/docker/xgo-image-deb6/base/Dockerfile
+++ b/dev-tools/packer/docker/xgo-image-deb6/base/Dockerfile
@@ -7,6 +7,9 @@ FROM debian:6
 
 MAINTAINER Tudor Golubenco <tudor@elastic.co>
 
+# Use sources list from the archive
+ADD sources.list /etc/apt/sources.list
+
 # Configure the Go environment, since it's not going to change
 ENV PATH   /usr/local/go/bin:$PATH
 ENV GOPATH /go
@@ -20,7 +23,7 @@ RUN chmod +x $FETCH
 
 # Make sure apt-get is up to date and dependent packages are installed
 RUN \
-  apt-get update && \
+  apt-get -o Acquire::Check-Valid-Until=false update && \
   apt-get install -y automake autogen build-essential ca-certificates \
     gcc-multilib \
     clang llvm-dev  libtool libxml2-dev uuid-dev libssl-dev pkg-config \

--- a/dev-tools/packer/docker/xgo-image-deb6/base/sources.list
+++ b/dev-tools/packer/docker/xgo-image-deb6/base/sources.list
@@ -1,0 +1,3 @@
+deb http://snapshot.debian.org/archive/debian/20160229T214851Z squeeze main
+deb http://snapshot.debian.org/archive/debian/20160229T214851Z squeeze-updates main
+deb http://snapshot.debian.org/archive/debian/20160229T214851Z squeeze-lts main

--- a/dev-tools/packer/docker/xgo-image-deb6/beats-builder/Dockerfile
+++ b/dev-tools/packer/docker/xgo-image-deb6/beats-builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM tudorg/xgo-deb6-1.5.3
+FROM tudorg/xgo-deb6-1.6
 
 MAINTAINER Tudor Golubenco <tudor@elastic.co>
 

--- a/dev-tools/packer/docker/xgo-image-deb6/beats-builder/Dockerfile
+++ b/dev-tools/packer/docker/xgo-image-deb6/beats-builder/Dockerfile
@@ -11,7 +11,7 @@ RUN \
 	dpkg -x libpcap0.8-dev_*_amd64.deb /libpcap/amd64 && \
 	rm libpcap0.8-dev*.deb
 RUN \
-	apt-get update && \
+	apt-get -o Acquire::Check-Valid-Until=false update && \
 	apt-get install -y libpcap0.8-dev
 
 # add patch for gopacket

--- a/dev-tools/packer/docker/xgo-image-deb6/build.sh
+++ b/dev-tools/packer/docker/xgo-image-deb6/build.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 docker build --rm=true -t tudorg/xgo-deb6-base base/ && \
-    docker build --rm=true -t tudorg/xgo-deb6-1.5.3 go-1.5.3/ &&
+    docker build --rm=true -t tudorg/xgo-deb6-1.6 go-1.6/ &&
     docker build --rm=true -t tudorg/beats-builder-deb6 beats-builder

--- a/dev-tools/packer/docker/xgo-image-deb6/go-1.6/Dockerfile
+++ b/dev-tools/packer/docker/xgo-image-deb6/go-1.6/Dockerfile
@@ -1,4 +1,4 @@
-# Go cross compiler (xgo): Go 1.5.3 layer
+# Go cross compiler (xgo): Go 1.6 layer
 # Copyright (c) 2014 Péter Szilágyi. All rights reserved.
 #
 # Released under the MIT license.
@@ -9,7 +9,7 @@ MAINTAINER Tudor Golubenco <tudor@elastic.co>
 
 # Configure the root Go distribution and bootstrap based on it
 RUN \
-  export ROOT_DIST=https://storage.googleapis.com/golang/go1.5.3.linux-amd64.tar.gz && \
-  export ROOT_DIST_SHA1=c5377eca4837968d043b681f00a852a262f0f5f6 && \
+  export ROOT_DIST="https://storage.googleapis.com/golang/go1.6.linux-amd64.tar.gz" && \
+  export ROOT_DIST_SHA1="01a6a28dbe31a53103b600979bbbbd63a8104456" && \
   \
   $BOOTSTRAP_PURE

--- a/dev-tools/packer/docker/xgo-image/beats-builder/Dockerfile
+++ b/dev-tools/packer/docker/xgo-image/beats-builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM tudorg/xgo-1.5.3
+FROM tudorg/xgo-1.6
 
 MAINTAINER Tudor Golubenco <tudor@elastic.co>
 

--- a/dev-tools/packer/docker/xgo-image/build.sh
+++ b/dev-tools/packer/docker/xgo-image/build.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 docker build --rm=true -t tudorg/xgo-base base/ && \
-    docker build --rm=true -t tudorg/xgo-1.5.3 go-1.5.3/ &&
+    docker build --rm=true -t tudorg/xgo-1.6 go-1.6/ &&
     docker build --rm=true -t tudorg/beats-builder beats-builder

--- a/dev-tools/packer/docker/xgo-image/go-1.6/Dockerfile
+++ b/dev-tools/packer/docker/xgo-image/go-1.6/Dockerfile
@@ -1,4 +1,4 @@
-# Go cross compiler (xgo): Go 1.5.3 layer
+# Go cross compiler (xgo): Go 1.6 layer
 # Copyright (c) 2014 Péter Szilágyi. All rights reserved.
 #
 # Released under the MIT license.
@@ -9,7 +9,7 @@ MAINTAINER Tudor Golubenco <tudor@elastic.co>
 
 # Configure the root Go distribution and bootstrap based on it
 RUN \
-  export ROOT_DIST=https://storage.googleapis.com/golang/go1.5.3.linux-amd64.tar.gz && \
-  export ROOT_DIST_SHA1=c5377eca4837968d043b681f00a852a262f0f5f6 && \
+  export ROOT_DIST="https://storage.googleapis.com/golang/go1.6.linux-amd64.tar.gz" && \
+  export ROOT_DIST_SHA1="01a6a28dbe31a53103b600979bbbbd63a8104456" && \
   \
   $BOOTSTRAP_PURE


### PR DESCRIPTION
This fixes the errors cause by the Squeeze EOL in the packer (see https://github.com/elastic/beats-packer/pull/53) and switches the Go version to 1.6.