### PR TITLE
Winlogbeat Fix an issue with caching

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -87,6 +87,7 @@ https://github.com/elastic/beats/compare/v1.1.0...master[Check the HEAD diff]
 
 *Winlogbeat*
 - Add caching of event metadata handles and the system render context for the wineventlog API {pull}888[888]
+- Improve config validation by checking for unknown top-level YAML keys. {pull}1100[1100]
 
 ==== Deprecated
 

--- a/libbeat/common/cache.go
+++ b/libbeat/common/cache.go
@@ -188,7 +188,7 @@ func (c *Cache) CleanUp() int {
 	return count
 }
 
-// Entries returns a copy of the non-expired elements in the cache.
+// Entries returns a shallow copy of the non-expired elements in the cache.
 func (c *Cache) Entries() map[Key]Value {
 	c.RLock()
 	defer c.RUnlock()

--- a/winlogbeat/beater/winlogbeat.go
+++ b/winlogbeat/beater/winlogbeat.go
@@ -69,7 +69,7 @@ func (eb *Winlogbeat) Config(b *beat.Beat) error {
 	}
 
 	// Validate configuration.
-	err = eb.config.Winlogbeat.Validate()
+	err = eb.config.Validate()
 	if err != nil {
 		return fmt.Errorf("Error validating configuration file. %v", err)
 	}

--- a/winlogbeat/config/config_test.go
+++ b/winlogbeat/config/config_test.go
@@ -31,6 +31,18 @@ func TestConfigValidate(t *testing.T) {
 			"", // No Error
 		},
 		{
+			Settings{
+				WinlogbeatConfig{
+					EventLogs: []EventLogConfig{
+						{Name: "App"},
+					},
+				},
+				map[string]interface{}{"other": "value"},
+			},
+			"1 error: Invalid top-level key 'other' found. Valid keys are " +
+				"logging, output, shipper, winlogbeat",
+		},
+		{
 			WinlogbeatConfig{},
 			"1 error: At least one event log must be configured as part of " +
 				"event_logs",

--- a/winlogbeat/eventlog/wineventlog.go
+++ b/winlogbeat/eventlog/wineventlog.go
@@ -143,7 +143,7 @@ func (l *winEventLog) Close() error {
 func newWinEventLog(c Config) (EventLog, error) {
 	eventMetadataHandle := func(providerName, sourceName string) eventlogging.MessageFiles {
 		mf := eventlogging.MessageFiles{SourceName: sourceName}
-		h, err := sys.OpenPublisherMetadata(0, providerName, 0)
+		h, err := sys.OpenPublisherMetadata(0, sourceName, 0)
 		if err != nil {
 			mf.Err = err
 			return mf


### PR DESCRIPTION
- Fix an issue with caching (an unreleased feature) that was introduced in #888
- Add expvar metrics for the event message file cache (hits/misses/size)
- Add strict validation for top-level YAML keys in winlogbeat config

Example expvar cache metrics are shown below. I just wanted to make the cache a bit more "observable" for the debugging purposes.

```yaml
...
"msgFileCacheStats": {"ApplicationHits": 48808, "ApplicationMisses": 4, "ApplicationSize": 0, "SecurityHits": 1378, "SecurityMisses": 2, "SecuritySize": 0, "SetupMisses": 1, "SetupSize": 0},
...
```