### PR TITLE
Add support for include_fields and drop_fields

### DIFF
--- a/filebeat/tests/system/config/filebeat.yml.j2
+++ b/filebeat/tests/system/config/filebeat.yml.j2
@@ -124,4 +124,18 @@ output:
     rotate_every_kb: 1000
     #number_of_files: 7
 
+{% if filter_enabled %}
+
+filter:
+
+    {%- if drop_fields %}
+    - drop_fields:
+        fields: {{drop_fields}}
+    {%- endif %}
+    {%- if include_fields is not none %}
+    - include_fields:
+        fields: {{include_fields}}
+    {%- endif %}
+{% endif %}
+
 # vim: set ft=jinja:

--- a/filebeat/tests/system/test_filtering.py
+++ b/filebeat/tests/system/test_filtering.py
@@ -1,0 +1,53 @@
+from filebeat import BaseTest
+import os
+
+"""
+Contains tests for filtering.
+"""
+
+
+class Test(BaseTest):
+    def test_dropfields(self):
+        """
+        Check drop_fields filtering action
+        """
+        self.render_config_template(
+            path=os.path.abspath(self.working_dir) + "/test.log",
+            filter_enabled=True,
+            drop_fields=["beat"],
+            include_fields=None,
+        )
+        with open(self.working_dir + "/test.log", "w") as f:
+            f.write("test message\n")
+
+        filebeat = self.start_beat()
+        self.wait_until(lambda: self.output_has(lines=1))
+        filebeat.check_kill_and_wait()
+
+        output = self.read_output(
+            required_fields=["@timestamp", "type"],
+        )[0]
+        assert "beat.name" not in output
+        assert "message" in output
+
+    def test_include_fields(self):
+        """
+        Check drop_fields filtering action
+        """
+        self.render_config_template(
+            path=os.path.abspath(self.working_dir) + "/test.log",
+            filter_enabled=True,
+            include_fields=["source", "offset", "message"]
+        )
+        with open(self.working_dir + "/test.log", "w") as f:
+            f.write("test message\n")
+
+        filebeat = self.start_beat()
+        self.wait_until(lambda: self.output_has(lines=1))
+        filebeat.check_kill_and_wait()
+
+        output = self.read_output(
+            required_fields=["@timestamp", "type"],
+        )[0]
+        assert "beat.name" not in output
+        assert "message" in output

--- a/libbeat/beat/beat.go
+++ b/libbeat/beat/beat.go
@@ -32,6 +32,7 @@ import (
 	"github.com/urso/ucfg"
 
 	"github.com/elastic/beats/libbeat/cfgfile"
+	"github.com/elastic/beats/libbeat/filter"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/publisher"
 	"github.com/elastic/beats/libbeat/service"
@@ -84,6 +85,7 @@ type BeatConfig struct {
 	Output  map[string]*ucfg.Config
 	Logging logp.Logging
 	Shipper publisher.ShipperConfig
+	Filter  []filter.FilterConfig
 }
 
 var printVersion *bool
@@ -149,7 +151,7 @@ func (b *Beat) Start() error {
 	// Additional command line args are used to overwrite config options
 	err, exit := b.CommandLineSetup()
 	if err != nil {
-		return err
+		return fmt.Errorf("fails to load command line setup: %v\n", err)
 	}
 
 	if exit {
@@ -159,13 +161,13 @@ func (b *Beat) Start() error {
 	// Loads base config
 	err = b.LoadConfig()
 	if err != nil {
-		return err
+		return fmt.Errorf("fails to load the config: %v\n", err)
 	}
 
 	// Configures beat
 	err = b.BT.Config(b)
 	if err != nil {
-		return err
+		return fmt.Errorf("fails to load the beat config: %v\n", err)
 	}
 	b.setState(ConfigState)
 
@@ -229,13 +231,20 @@ func (b *Beat) LoadConfig() error {
 
 	pub, err := publisher.New(b.Name, b.Config.Output, b.Config.Shipper)
 	if err != nil {
-		return fmt.Errorf("error Initialising publisher: %v\n", err)
+		return fmt.Errorf("error initializing publisher: %v\n", err)
+	}
+
+	filters, err := filter.New(b.Config.Filter)
+	if err != nil {
+		return fmt.Errorf("error initializing filters: %v\n", err)
 	}
 
 	b.Publisher = pub
+	pub.RegisterFilter(filters)
 	b.Events = pub.Client()
 
 	logp.Info("Init Beat: %s; Version: %s", b.Name, b.Version)
+	logp.Info("Filter %v", filters)
 
 	return nil
 }

--- a/libbeat/common/event.go
+++ b/libbeat/common/event.go
@@ -1,0 +1,86 @@
+package common
+
+import (
+	"encoding/json"
+	"reflect"
+	"time"
+
+	"github.com/elastic/beats/libbeat/logp"
+)
+
+func MarshallUnmarshall(v interface{}) (MapStr, error) {
+	// decode and encode JSON
+	marshaled, err := json.Marshal(v)
+	if err != nil {
+		logp.Warn("marshal err: %v", err)
+		return nil, err
+	}
+	var v1 MapStr
+	err = json.Unmarshal(marshaled, &v1)
+	if err != nil {
+		logp.Warn("unmarshal err: %v")
+		return nil, err
+	}
+
+	return v1, nil
+}
+
+func ConvertToGenericEvent(v MapStr) MapStr {
+
+	for key, value := range v {
+
+		switch value.(type) {
+		case Time, *Time:
+			continue
+		case time.Location, *time.Location:
+			continue
+		case MapStr:
+			v[key] = ConvertToGenericEvent(value.(MapStr))
+			continue
+		case *MapStr:
+			v[key] = ConvertToGenericEvent(*value.(*MapStr))
+			continue
+		default:
+
+			typ := reflect.TypeOf(value)
+
+			if typ.Kind() == reflect.Ptr {
+				typ = typ.Elem()
+			}
+
+			switch typ.Kind() {
+			case reflect.Bool:
+			case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			case reflect.Uintptr:
+			case reflect.Float32, reflect.Float64:
+			case reflect.Complex64, reflect.Complex128:
+			case reflect.String:
+			case reflect.UnsafePointer:
+			case reflect.Array, reflect.Slice:
+			//case reflect.Chan:
+			//case reflect.Func:
+			//case reflect.Interface:
+			case reflect.Map:
+				anothermap, err := MarshallUnmarshall(value)
+				if err != nil {
+					logp.Warn("fail to marschall & unmarshall map %v", key)
+					continue
+				}
+				v[key] = anothermap
+
+			case reflect.Struct:
+				anothermap, err := MarshallUnmarshall(value)
+				if err != nil {
+					logp.Warn("fail to marschall & unmarshall struct %v", key)
+					continue
+				}
+				v[key] = anothermap
+			default:
+				logp.Warn("unknown type %v", typ)
+				continue
+			}
+		}
+	}
+	return v
+}

--- a/libbeat/common/event_test.go
+++ b/libbeat/common/event_test.go
@@ -1,0 +1,123 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/elastic/beats/libbeat/logp"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConvertNestedMapStr(t *testing.T) {
+	logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"*"})
+
+	type io struct {
+		Input  MapStr
+		Output MapStr
+	}
+
+	type String string
+
+	tests := []io{
+		io{
+			Input: MapStr{
+				"key": MapStr{
+					"key1": "value1",
+				},
+			},
+			Output: MapStr{
+				"key": MapStr{
+					"key1": "value1",
+				},
+			},
+		},
+		io{
+			Input: MapStr{
+				"key": MapStr{
+					"key1": String("value1"),
+				},
+			},
+			Output: MapStr{
+				"key": MapStr{
+					"key1": String("value1"),
+				},
+			},
+		},
+		io{
+			Input: MapStr{
+				"key": MapStr{
+					"key1": []string{"value1", "value2"},
+				},
+			},
+			Output: MapStr{
+				"key": MapStr{
+					"key1": []string{"value1", "value2"},
+				},
+			},
+		},
+		io{
+			Input: MapStr{
+				"key": MapStr{
+					"key1": []String{"value1", "value2"},
+				},
+			},
+			Output: MapStr{
+				"key": MapStr{
+					"key1": []String{"value1", "value2"},
+				},
+			},
+		},
+		io{
+			Input: MapStr{
+				"@timestamp": MustParseTime("2015-03-01T12:34:56.123Z"),
+			},
+			Output: MapStr{
+				"@timestamp": MustParseTime("2015-03-01T12:34:56.123Z"),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		assert.EqualValues(t, test.Output, ConvertToGenericEvent(test.Input))
+	}
+
+}
+
+func TestConvertNestedStruct(t *testing.T) {
+	logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"*"})
+
+	type io struct {
+		Input  MapStr
+		Output MapStr
+	}
+
+	type TestStruct struct {
+		A string
+		B int
+	}
+
+	tests := []io{
+		io{
+			Input: MapStr{
+				"key": MapStr{
+					"key1": TestStruct{
+						A: "hello",
+						B: 5,
+					},
+				},
+			},
+			Output: MapStr{
+				"key": MapStr{
+					"key1": MapStr{
+						"A": "hello",
+						"B": float64(5),
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		assert.EqualValues(t, test.Output, ConvertToGenericEvent(test.Input))
+	}
+
+}

--- a/libbeat/filter/config.go
+++ b/libbeat/filter/config.go
@@ -1,0 +1,17 @@
+package filter
+
+type DropFieldsConfig struct {
+	Fields []string `config:"fields"`
+}
+
+type IncludeFieldsConfig struct {
+	Fields []string `config:"fields"`
+}
+
+type FilterConfig struct {
+	DropFields    *DropFieldsConfig    `config:"drop_fields"`
+	IncludeFields *IncludeFieldsConfig `config:"include_fields"`
+}
+
+// fields that should be always exported
+var MandatoryExportedFields = []string{"@timestamp", "type"}

--- a/libbeat/filter/filter.go
+++ b/libbeat/filter/filter.go
@@ -1,0 +1,165 @@
+package filter
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/logp"
+)
+
+type FilterCondition struct {
+}
+
+type FilterRule interface {
+	Filter(event common.MapStr) (common.MapStr, error)
+	String() string
+}
+
+/* extends FilterRule */
+type IncludeFields struct {
+	Fields []string
+	// condition
+}
+
+/* extend FilterRule */
+type DropFields struct {
+	Fields []string
+	// condition
+}
+
+type FilterList struct {
+	filters []FilterRule
+}
+
+/* FilterList methods */
+func New(config []FilterConfig) (*FilterList, error) {
+
+	Filters := &FilterList{}
+	Filters.filters = []FilterRule{}
+
+	logp.Debug("filter", "configuration %v", config)
+	for _, filterConfig := range config {
+		if filterConfig.DropFields != nil {
+			Filters.Register(NewDropFields(filterConfig.DropFields.Fields))
+		}
+
+		if filterConfig.IncludeFields != nil {
+			Filters.Register(NewIncludeFields(filterConfig.IncludeFields.Fields))
+		}
+	}
+
+	logp.Debug("filter", "filters: %v", Filters)
+	return Filters, nil
+}
+
+func (filters *FilterList) Register(filter FilterRule) {
+	filters.filters = append(filters.filters, filter)
+	logp.Debug("filter", "Register filter: %v", filter)
+}
+
+func (filters *FilterList) Get(index int) FilterRule {
+	return filters.filters[index]
+}
+
+// Applies a sequence of filtering rules and returns the filtered event
+func (filters *FilterList) Filter(event common.MapStr) common.MapStr {
+
+	// clone the event at first, before starting filtering
+	filtered := event.Clone()
+	var err error
+
+	for _, filter := range filters.filters {
+		filtered, err = filter.Filter(filtered)
+		if err != nil {
+			logp.Err("fail to apply filtering rule %s: %s", filter, err)
+		}
+	}
+
+	return filtered
+}
+
+func (filters *FilterList) String() string {
+	s := []string{}
+
+	for _, filter := range filters.filters {
+
+		s = append(s, filter.String())
+	}
+	return strings.Join(s, ", ")
+}
+
+/* IncludeFields methods */
+func NewIncludeFields(fields []string) *IncludeFields {
+
+	/* add read only fields if they are not yet */
+	for _, readOnly := range MandatoryExportedFields {
+		found := false
+		for _, field := range fields {
+			if readOnly == field {
+				found = true
+			}
+		}
+		if !found {
+			fields = append(fields, readOnly)
+		}
+	}
+
+	return &IncludeFields{Fields: fields}
+}
+
+func (f *IncludeFields) Filter(event common.MapStr) (common.MapStr, error) {
+
+	filtered := common.MapStr{}
+
+	for _, field := range f.Fields {
+		hasKey, err := event.HasKey(field)
+		if err != nil {
+			return filtered, fmt.Errorf("Fail to check the key %s: %s", field, err)
+		}
+
+		if hasKey {
+			errorOnCopy := event.CopyFieldsTo(filtered, field)
+			if errorOnCopy != nil {
+				return filtered, fmt.Errorf("Fail to copy key %s: %s", field, err)
+			}
+		}
+	}
+
+	return filtered, nil
+}
+
+func (f *IncludeFields) String() string {
+	return "include_fields=" + strings.Join(f.Fields, ", ")
+}
+
+/* DropFields methods */
+func NewDropFields(fields []string) *DropFields {
+
+	/* remove read only fields */
+	for _, readOnly := range MandatoryExportedFields {
+		for i, field := range fields {
+			if readOnly == field {
+				fields = append(fields[:i], fields[i+1:]...)
+			}
+		}
+	}
+	return &DropFields{Fields: fields}
+}
+
+func (f *DropFields) Filter(event common.MapStr) (common.MapStr, error) {
+
+	for _, field := range f.Fields {
+		err := event.Delete(field)
+		if err != nil {
+			return event, fmt.Errorf("Fail to delete key %s: %s", field, err)
+		}
+
+	}
+	return event, nil
+}
+
+func (f *DropFields) String() string {
+
+	return "drop_fields=" + strings.Join(f.Fields, ", ")
+}

--- a/libbeat/filter/filter_test.go
+++ b/libbeat/filter/filter_test.go
@@ -1,0 +1,249 @@
+package filter
+
+import (
+	"testing"
+
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/logp"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIncludeFields(t *testing.T) {
+
+	if testing.Verbose() {
+		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"*"})
+	}
+
+	Filters := FilterList{}
+
+	Filters.Register(NewIncludeFields([]string{"proc.cpu.total_p", "proc.mem", "dd"}))
+
+	event := common.MapStr{
+		"@timestamp": "2016-01-24T18:35:19.308Z",
+		"beat": common.MapStr{
+			"hostname": "mar",
+			"name":     "my-shipper-1",
+		},
+		"count": 1,
+		"proc": common.MapStr{
+			"cpu": common.MapStr{
+				"start_time": "Jan14",
+				"system":     26027,
+				"total":      79390,
+				"total_p":    0,
+				"user":       53363,
+			},
+			"cmdline": "/sbin/launchd",
+			"mem": common.MapStr{
+				"rss":   11194368,
+				"rss_p": 0,
+				"share": 0,
+				"size":  2555572224,
+			},
+		},
+		"type": "process",
+	}
+
+	filteredEvent := Filters.Filter(event)
+
+	expectedEvent := common.MapStr{
+		"@timestamp": "2016-01-24T18:35:19.308Z",
+		"proc": common.MapStr{
+			"cpu": common.MapStr{
+				"total_p": 0,
+			},
+			"mem": common.MapStr{
+				"rss":   11194368,
+				"rss_p": 0,
+				"share": 0,
+				"size":  2555572224,
+			},
+		},
+		"type": "process",
+	}
+
+	assert.Equal(t, expectedEvent, filteredEvent)
+}
+
+func TestIncludeFields1(t *testing.T) {
+
+	if testing.Verbose() {
+		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"*"})
+	}
+
+	Filters := FilterList{}
+
+	Filters.Register(NewIncludeFields([]string{"proc.cpu.total_ddd"}))
+
+	event := common.MapStr{
+		"@timestamp": "2016-01-24T18:35:19.308Z",
+		"beat": common.MapStr{
+			"hostname": "mar",
+			"name":     "my-shipper-1",
+		},
+		"count": 1,
+
+		"proc": common.MapStr{
+			"cpu": common.MapStr{
+				"start_time": "Jan14",
+				"system":     26027,
+				"total":      79390,
+				"total_p":    0,
+				"user":       53363,
+			},
+			"cmdline": "/sbin/launchd",
+			"mem": common.MapStr{
+				"rss":   11194368,
+				"rss_p": 0,
+				"share": 0,
+				"size":  2555572224,
+			},
+		},
+		"type": "process",
+	}
+
+	filteredEvent := Filters.Filter(event)
+
+	expectedEvent := common.MapStr{
+		"@timestamp": "2016-01-24T18:35:19.308Z",
+		"type":       "process",
+	}
+
+	assert.Equal(t, expectedEvent, filteredEvent)
+}
+
+func TestDropFields(t *testing.T) {
+
+	Filters := FilterList{}
+
+	Filters.Register(NewDropFields([]string{"proc.cpu.start_time", "mem", "proc.cmdline", "beat", "dd"}))
+
+	event := common.MapStr{
+		"@timestamp": "2016-01-24T18:35:19.308Z",
+		"beat": common.MapStr{
+			"hostname": "mar",
+			"name":     "my-shipper-1",
+		},
+		"count": 1,
+
+		"proc": common.MapStr{
+			"cpu": common.MapStr{
+				"start_time": "Jan14",
+				"system":     26027,
+				"total":      79390,
+				"total_p":    0,
+				"user":       53363,
+			},
+			"cmdline": "/sbin/launchd",
+		},
+		"mem": common.MapStr{
+			"rss":   11194368,
+			"rss_p": 0,
+			"share": 0,
+			"size":  2555572224,
+		},
+		"type": "process",
+	}
+
+	filteredEvent := Filters.Filter(event)
+
+	expectedEvent := common.MapStr{
+		"@timestamp": "2016-01-24T18:35:19.308Z",
+		"count":      1,
+		"proc": common.MapStr{
+			"cpu": common.MapStr{
+				"system":  26027,
+				"total":   79390,
+				"total_p": 0,
+				"user":    53363,
+			},
+		},
+		"type": "process",
+	}
+
+	assert.Equal(t, expectedEvent, filteredEvent)
+}
+
+func TestMultipleIncludeFields(t *testing.T) {
+
+	if testing.Verbose() {
+		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"*"})
+	}
+	Filters := FilterList{}
+
+	Filters.Register(NewIncludeFields([]string{"proc"}))
+	Filters.Register(NewIncludeFields([]string{"proc.cpu.start_time", "proc.cpu.total_p",
+		"proc.mem.rss_p", "proc.cmdline"}))
+
+	event1 := common.MapStr{
+		"@timestamp": "2016-01-24T18:35:19.308Z",
+		"beat": common.MapStr{
+			"hostname": "mar",
+			"name":     "my-shipper-1",
+		},
+		"count": 1,
+
+		"proc": common.MapStr{
+			"cpu": common.MapStr{
+				"start_time": "Jan14",
+				"system":     26027,
+				"total":      79390,
+				"total_p":    0,
+				"user":       53363,
+			},
+			"cmdline": "/sbin/launchd",
+		},
+		"mem": common.MapStr{
+			"rss":   11194368,
+			"rss_p": 0,
+			"share": 0,
+			"size":  2555572224,
+		},
+		"type": "process",
+	}
+
+	event2 := common.MapStr{
+		"@timestamp": "2016-01-24T18:35:19.308Z",
+		"beat": common.MapStr{
+			"hostname": "mar",
+			"name":     "my-shipper-1",
+		},
+		"count": 1,
+		"fs": common.MapStr{
+			"device_name": "devfs",
+			"total":       198656,
+			"used":        198656,
+			"used_p":      1,
+			"free":        0,
+			"avail":       0,
+			"files":       677,
+			"free_files":  0,
+			"mount_point": "/dev",
+		},
+		"type": "process",
+	}
+
+	expected1 := common.MapStr{
+		"@timestamp": "2016-01-24T18:35:19.308Z",
+		"proc": common.MapStr{
+			"cpu": common.MapStr{
+				"start_time": "Jan14",
+				"total_p":    0,
+			},
+			"cmdline": "/sbin/launchd",
+		},
+
+		"type": "process",
+	}
+
+	expected2 := common.MapStr{
+		"@timestamp": "2016-01-24T18:35:19.308Z",
+		"type":       "process",
+	}
+
+	actual1 := Filters.Filter(event1)
+	actual2 := Filters.Filter(event2)
+
+	assert.Equal(t, expected1, actual1)
+	assert.Equal(t, expected2, actual2)
+}

--- a/libbeat/publisher/publish.go
+++ b/libbeat/publisher/publish.go
@@ -1,7 +1,6 @@
 package publisher
 
 import (
-	"encoding/json"
 	"errors"
 	"flag"
 	"os"
@@ -11,6 +10,7 @@ import (
 	"github.com/urso/ucfg"
 
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/filter"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/outputs"
 
@@ -59,6 +59,7 @@ type PublisherType struct {
 	TopologyOutput outputs.TopologyOutputer
 	IgnoreOutgoing bool
 	GeoLite        *libgeo.GeoIP
+	Filters        *filter.FilterList
 
 	globalEventMetadata common.EventMetadata // Fields and tags to add to each event.
 
@@ -102,15 +103,6 @@ const (
 
 func init() {
 	publishDisabled = flag.Bool("N", false, "Disable actual publishing for testing")
-}
-
-func PrintPublishEvent(event common.MapStr) {
-	json, err := json.MarshalIndent(event, "", "  ")
-	if err != nil {
-		logp.Err("json.Marshal: %s", err)
-	} else {
-		debug("Publish: %s", string(json))
-	}
 }
 
 func (publisher *PublisherType) IsPublisherIP(ip string) bool {
@@ -174,6 +166,12 @@ func (publisher *PublisherType) PublishTopology(params ...string) error {
 		}
 	}
 
+	return nil
+}
+
+func (publisher *PublisherType) RegisterFilter(filters *filter.FilterList) error {
+
+	publisher.Filters = filters
 	return nil
 }
 

--- a/libbeat/publisher/publish_test.go
+++ b/libbeat/publisher/publish_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/outputs"
 	"github.com/stretchr/testify/assert"
 )
@@ -34,14 +33,6 @@ func (topo testTopology) PublishIPs(name string, localAddrs []string) error {
 
 func (topo testTopology) GetNameByIP(ip string) string {
 	return topo.hostname
-}
-
-// Smoke test PrintPublishEvent. The method has no observable outputs so this
-// is only verifying there are no panics.
-func TestPrintPublishEvent(t *testing.T) {
-	PrintPublishEvent(nil)
-	PrintPublishEvent(common.MapStr{})
-	PrintPublishEvent(testEvent())
 }
 
 // Test GetServerName.

--- a/libbeat/tests/system/beat/beat.py
+++ b/libbeat/tests/system/beat/beat.py
@@ -11,6 +11,9 @@ import time
 import yaml
 from datetime import datetime, timedelta
 
+BEAT_REQUIRED_FIELDS = ["@timestamp", "type",
+                        "beat.name", "beat.hostname"]
+
 
 class Proc(object):
     """
@@ -204,7 +207,9 @@ class TestCase(unittest.TestCase):
             f.write(output_str)
 
     # Returns output as JSON object with flattened fields (. notation)
-    def read_output(self, output_file=None):
+    def read_output(self,
+                    output_file=None,
+                    required_fields=None):
 
         # Init defaults
         if output_file is None:
@@ -215,8 +220,7 @@ class TestCase(unittest.TestCase):
             for line in f:
                 jsons.append(self.flatten_object(json.loads(line),
                                                  []))
-        self.all_have_fields(jsons, ["@timestamp", "type",
-                                     "beat.name", "beat.hostname"])
+        self.all_have_fields(jsons, required_fields or BEAT_REQUIRED_FIELDS)
         return jsons
 
     # Returns output as JSON object

--- a/packetbeat/beater/packetbeat.go
+++ b/packetbeat/beater/packetbeat.go
@@ -106,6 +106,9 @@ func (pb *Packetbeat) Config(b *beat.Beat) error {
 
 	// Read beat implementation config as needed for setup
 	err := cfgfile.Read(&pb.PbConfig, "")
+	if err != nil {
+		logp.Err("fails to read the beat config: %v, %v", err, pb.PbConfig)
+	}
 
 	// CLI flags over-riding config
 	if *pb.CmdLineArgs.TopSpeed {

--- a/packetbeat/config/config.go
+++ b/packetbeat/config/config.go
@@ -16,7 +16,6 @@ type Config struct {
 	Procs      procs.ProcsConfig
 	RunOptions droppriv.RunOptions
 	Logging    logp.Logging
-	Filter     map[string]interface{}
 }
 
 type InterfacesConfig struct {

--- a/packetbeat/tests/system/config/packetbeat.yml.j2
+++ b/packetbeat/tests/system/config/packetbeat.yml.j2
@@ -51,28 +51,28 @@ flows:
 protocols:
   icmp:
     enabled: true
-{% if icmp_send_request %}    send_request: true{% endif %}
-{% if icmp_send_response %}    send_response: true{% endif %}
+{% if icmp_send_request %}    send_request: true{%- endif %}
+{% if icmp_send_response %}    send_response: true{%- endif %}
 
   dns:
     ports: [{{ dns_ports|default([53])|join(", ") }}]
-{% if dns_include_authorities %}    include_authorities: true{% endif %}
-{% if dns_include_additionals %}    include_additionals: true{% endif %}
-{% if dns_send_request %}    send_request: true{% endif %}
-{% if dns_send_response %}    send_response: true{% endif %}
+{% if dns_include_authorities %}    include_authorities: true{%- endif %}
+{% if dns_include_additionals %}    include_additionals: true{%- endif %}
+{% if dns_send_request %}    send_request: true{%- endif %}
+{% if dns_send_response %}    send_response: true{%- endif %}
 
   amqp:
     ports: [{{ amqp_ports|default([5672])|join(", ") }}]
-{% if amqp_send_request %}    send_request: true{% endif %}
-{% if amqp_send_response %}    send_response: true{% endif %}
+{% if amqp_send_request %}    send_request: true{%- endif %}
+{% if amqp_send_response %}    send_response: true{%- endif %}
 
   http:
     ports: [{{ http_ports|default([80])|join(", ") }}]
-{% if http_send_request %}    send_request: true{% endif %}
-{% if http_send_response %}    send_response: true{% endif %}
-{% if http_send_all_headers %}    send_all_headers: true{% endif %}
-{% if http_split_cookie %}    split_cookie: true{% endif %}
-{%- if http_send_headers %}
+{% if http_send_request %}    send_request: true{%- endif %}
+{% if http_send_response %}    send_response: true{%- endif %}
+{% if http_send_all_headers %}    send_all_headers: true{%- endif %}
+{% if http_split_cookie %}    split_cookie: true{%- endif %}
+{% if http_send_headers %}
     send_headers: [
         {%- for hdr in http_send_headers -%}
                    "{{ hdr }}"
@@ -101,25 +101,25 @@ protocols:
 
   memcache:
     ports: [{{ memcache_ports|default([11211])|join(", ") }}]
-{% if memcache_send_request %}    send_request: true{% endif %}
-{% if memcache_send_response %}    send_response: true{% endif %}
-{% if memcache_parse_unknown %}    parseunknown: true{% endif %}
-{% if memcache_max_values %}    maxvalues: {{ memcache_max_values }}{% endif %}
-{% if memcache_udp_transaction_timeout %}    udptransactiontimeout: {{ memcache_udp_transaction_timeout}}{% endif %}
+{% if memcache_send_request %}    send_request: true{%- endif %}
+{% if memcache_send_response %}    send_response: true{%- endif %}
+{% if memcache_parse_unknown %}    parseunknown: true{%- endif %}
+{% if memcache_max_values %}    maxvalues: {{ memcache_max_values }}{%- endif %}
+{% if memcache_udp_transaction_timeout %}    udptransactiontimeout: {{ memcache_udp_transaction_timeout}}{%- endif %}
 
   mysql:
     ports: [{{ mysql_ports|default([3306])|join(", ") }}]
-{% if mysql_max_rows %}    max_rows: {{mysql_max_rows}}{% endif %}
-{% if mysql_max_row_length %}    max_row_length: {{mysql_max_row_length}}{% endif %}
-{% if mysql_send_request %}    send_request: true{% endif %}
-{% if mysql_send_response %}    send_response: true{% endif %}
+{% if mysql_max_rows %}    max_rows: {{mysql_max_rows}}{%- endif %}
+{% if mysql_max_row_length %}    max_row_length: {{mysql_max_row_length}}{%- endif %}
+{% if mysql_send_request %}    send_request: true{%- endif %}
+{% if mysql_send_response %}    send_response: true{%- endif %}
 
   pgsql:
     ports: [{{ pgsql_ports|default([5432])|join(", ") }}]
-{% if pgsql_max_rows %}    max_rows: {{pgsql_max_rows}}{% endif %}
-{% if pgsql_max_row_length %}    max_row_length: {{pgsql_max_row_length}}{% endif %}
-{% if pgsql_send_request %}    send_request: true{% endif %}
-{% if pgsql_send_response %}    send_response: true{% endif %}
+{% if pgsql_max_rows %}    max_rows: {{pgsql_max_rows}}{%- endif %}
+{% if pgsql_max_row_length %}    max_row_length: {{pgsql_max_row_length}}{%- endif %}
+{% if pgsql_send_request %}    send_request: true{%- endif %}
+{% if pgsql_send_response %}    send_response: true{%- endif %}
 
   redis:
     ports: [{{ redis_ports|default([6379])|join(", ") }}]
@@ -129,7 +129,7 @@ protocols:
   thrift:
     ports: [{{ thrift_ports|default([9090])|join(", ") }}]
     transport_type: "{{ thrift_transport_type|default('socket') }}"
-{%- if thrift_idl_files %}
+{% if thrift_idl_files %}
     idl_files: [
         {%- for file in thrift_idl_files -%}
                 "{{ beat.working_dir + '/' + file }}"
@@ -137,12 +137,12 @@ protocols:
         {%- endfor -%}
     ]
 {%- endif %}
-{% if thrift_send_request %}    send_request: true{% endif %}
-{% if thrift_send_response %}    send_response: true{% endif %}
+{% if thrift_send_request %}    send_request: true{%- endif %}
+{% if thrift_send_response %}    send_response: true{%- endif %}
 
   mongodb:
     ports: [{{ mongodb_ports|default([27017])|join(", ") }}]
-{% if mongodb_send_request %}    send_request: true{% endif %}
+{% if mongodb_send_request %}    send_request: true{%endif %}
 {% if mongodb_send_response %}    send_response: true{% endif %}
 {% if mongodb_max_docs is not none %}    max_docs: {{mongodb_max_docs}}{% endif %}
 {% if mongodb_max_doc_length is not none %}    max_doc_length: {{mongodb_max_doc_length}}{% endif %}
@@ -205,4 +205,17 @@ procs:
       cmdline_grep: memcached
 {% endif %}
 
+{% if filter_enabled %}
+
+filter:
+
+    {%- if drop_fields %}
+    - drop_fields:
+        fields: {{drop_fields}}
+    {%- endif %}
+    {%- if include_fields is not none %}
+    - include_fields:
+        fields: {{include_fields}}
+    {%- endif %}
+{% endif %}
 # vim: set ft=jinja:

--- a/packetbeat/tests/system/test_0007_tags.py
+++ b/packetbeat/tests/system/test_0007_tags.py
@@ -21,6 +21,7 @@ class Test(BaseTest):
         assert len(objs) == 1
 
         o = objs[0]
+        assert "tags" in o
         assert o["tags"] == ["nginx", "wsgi", "drum"]
 
     def test_empty_tags(self):

--- a/packetbeat/tests/system/test_0060_filtering.py
+++ b/packetbeat/tests/system/test_0060_filtering.py
@@ -1,0 +1,124 @@
+from packetbeat import BaseTest
+
+
+class Test(BaseTest):
+
+    def test_drop_map_fields(self):
+
+        self.render_config_template(
+            http_send_all_headers=True,
+            drop_fields=["http.request_headers"],
+            # export all fields
+            include_fields=None,
+            filter_enabled=True,
+        )
+
+        self.run_packetbeat(pcap="http_minitwit.pcap",
+                            debug_selectors=["http", "httpdetailed"])
+        objs = self.read_output()
+
+        assert len(objs) == 3
+        assert all([o["type"] == "http" for o in objs])
+
+        assert objs[0]["status"] == "OK"
+        assert objs[1]["status"] == "OK"
+        assert objs[2]["status"] == "Error"
+
+        assert "http.request_headers" not in objs[0]
+        assert "http.response_headers" in objs[0]
+
+    def test_drop_end_fields(self):
+
+        self.render_config_template(
+            http_send_all_headers=True,
+            drop_fields=["http.response_headers.transfer-encoding"],
+            # export all fields
+            include_fields=None,
+            filter_enabled=True,
+        )
+
+        self.run_packetbeat(pcap="http_minitwit.pcap",
+                            debug_selectors=["http", "httpdetailed"])
+        objs = self.read_output()
+
+        assert len(objs) == 3
+        assert all([o["type"] == "http" for o in objs])
+
+        assert objs[0]["status"] == "OK"
+        assert objs[1]["status"] == "OK"
+        assert objs[2]["status"] == "Error"
+
+        assert "http.request_headers" in objs[0]
+        assert "http.response_headers" in objs[0]
+
+        # check if filtering deleted the
+        # htp.response_headers.transfer-encoding
+        assert "transfer-encoding" not in objs[0]["http.response_headers"]
+
+    def test_drop_unknown_field(self):
+
+        self.render_config_template(
+            http_send_all_headers=True,
+            drop_fields=["http.response_headers.transfer-encoding-test"],
+            # export all fields
+            include_fields=None,
+            filter_enabled=True,
+        )
+
+        self.run_packetbeat(pcap="http_minitwit.pcap",
+                            debug_selectors=["http", "httpdetailed"])
+        objs = self.read_output()
+
+        assert len(objs) == 3
+        assert all([o["type"] == "http" for o in objs])
+
+        assert objs[0]["status"] == "OK"
+        assert objs[1]["status"] == "OK"
+        assert objs[2]["status"] == "Error"
+
+        assert "http.request_headers" in objs[0]
+        assert "http.response_headers" in objs[0]
+
+        # check that htp.response_headers.transfer-encoding
+        # still exists
+        assert "transfer-encoding" in objs[0]["http.response_headers"]
+
+    def test_include_empty_list(self):
+
+        self.render_config_template(
+            http_send_all_headers=True,
+            # export all mandatory fields
+            include_fields=[],
+            filter_enabled=True,
+        )
+
+        self.run_packetbeat(pcap="http_minitwit.pcap",
+                            debug_selectors=["http", "httpdetailed"])
+        objs = self.read_output(
+            required_fields=["@timestamp", "type"],
+        )
+
+        assert len(objs) == 3
+        assert "http.request_headers" not in objs[0]
+        assert "http.response_headers" not in objs[0]
+
+    def test_drop_no_fields(self):
+
+        self.render_config_template(
+            http_send_all_headers=True,
+            drop_fields=[],
+            # export all fields
+            include_fields=None,
+            filter_enabled=True,
+        )
+
+        self.run_packetbeat(pcap="http_minitwit.pcap",
+                            debug_selectors=["http", "httpdetailed"])
+        objs = self.read_output()
+
+        assert len(objs) == 3
+        assert all([o["type"] == "http" for o in objs])
+
+        assert objs[0]["status"] == "OK"
+        assert objs[1]["status"] == "OK"
+        assert objs[2]["status"] == "Error"

--- a/topbeat/tests/system/config/topbeat.yml.j2
+++ b/topbeat/tests/system/config/topbeat.yml.j2
@@ -98,3 +98,16 @@ shipper:
 
     # Number of rotated log files to keep. Oldest files will be deleted first.
     #keepfiles: 7
+
+filter:
+
+    {% if include_fields %}
+
+    - include_fields:
+        fields: {{ include_fields }}
+
+    {% endif %}
+
+    - drop_fields:
+        fields: {{ drop_fields | default([]) }}
+

--- a/topbeat/tests/system/test_filtering.py
+++ b/topbeat/tests/system/test_filtering.py
@@ -1,0 +1,156 @@
+from topbeat import BaseTest
+
+"""
+Contains tests for filtering.
+"""
+
+
+class Test(BaseTest):
+    def test_dropfields(self):
+        """
+        Check drop_fields filtering action
+        """
+        self.render_config_template(
+            system_stats=False,
+            process_stats=True,
+            filesystem_stats=False,
+            drop_fields=["proc"]
+        )
+        topbeat = self.start_beat()
+        self.wait_until(
+            lambda: self.log_contains(
+                "output worker: publish"))
+        topbeat.kill_and_wait()
+
+        output = self.read_output(
+            required_fields=["@timestamp", "type"],
+        )[0]
+
+        for key in [
+            "proc.cpu.start_time",
+            "proc.cpu.total",
+            "proc.cpu.total_p",
+            "proc.cpu.user",
+            "proc.cpu.system",
+            "proc.name",
+            "proc.state",
+            "proc.pid",
+        ]:
+            assert key not in output
+
+    def test_include_fields(self):
+        """
+        Check include_fields filtering action
+        """
+        self.render_config_template(
+            system_stats=False,
+            process_stats=True,
+            filesystem_stats=False,
+            include_fields=["proc.cpu", "proc.mem"]
+        )
+        topbeat = self.start_beat()
+        self.wait_until(
+            lambda: self.log_contains(
+                "output worker: publish"))
+
+        topbeat.kill_and_wait()
+
+        output = self.read_output(
+            required_fields=["@timestamp", "type"],
+        )[0]
+        print(output)
+
+        for key in [
+            "proc.cpu.start_time",
+            "proc.cpu.total",
+            "proc.cpu.total_p",
+            "proc.cpu.user",
+            "proc.cpu.system",
+            "proc.mem.size",
+            "proc.mem.rss",
+            "proc.mem.rss_p"
+        ]:
+            assert key in output
+
+        for key in [
+            "proc.name",
+            "proc.pid",
+        ]:
+            assert key not in output
+
+    def test_multiple_actions(self):
+        """
+        Check the result when configuring two actions: include_fields
+        and drop_fields.
+        """
+        self.render_config_template(
+            system_stats=False,
+            process_stats=True,
+            filesystem_stats=False,
+            include_fields=["proc"],
+            drop_fields=["proc.mem"],
+        )
+        topbeat = self.start_beat()
+        self.wait_until(
+            lambda: self.log_contains(
+                "output worker: publish"))
+
+        topbeat.kill_and_wait()
+
+        output = self.read_output(
+            required_fields=["@timestamp", "type"],
+        )[0]
+
+        for key in [
+            "proc.cpu.start_time",
+            "proc.cpu.total",
+            "proc.cpu.total_p",
+            "proc.cpu.user",
+            "proc.cpu.system",
+            "proc.name",
+            "proc.pid",
+        ]:
+            assert key in output
+
+        for key in [
+            "proc.mem.size",
+            "proc.mem.rss",
+            "proc.mem.rss_p"
+        ]:
+            assert key not in output
+
+    def test_contradictory_multiple_actions(self):
+        """
+        Check the behaviour of a contradictory multiple actions
+        """
+        self.render_config_template(
+            system_stats=False,
+            process_stats=True,
+            filesystem_stats=False,
+            include_fields=["proc.mem.size", "proc.mem.rss_p"],
+            drop_fields=["proc.mem.size", "proc.mem.rss_p"],
+        )
+        topbeat = self.start_beat()
+        self.wait_until(
+            lambda: self.log_contains(
+                "output worker: publish"))
+
+        topbeat.kill_and_wait()
+
+        output = self.read_output(
+            required_fields=["@timestamp", "type"],
+        )[0]
+
+        for key in [
+            "proc.mem.size",
+            "proc.mem.rss",
+            "proc.cpu.start_time",
+            "proc.cpu.total",
+            "proc.cpu.total_p",
+            "proc.cpu.user",
+            "proc.cpu.system",
+            "proc.name",
+            "proc.pid",
+            "proc.mem.rss_p"
+        ]:
+            assert key not in output


### PR DESCRIPTION
This PR adds two configuration options: `include_fields` and `drop_fields`. 

There is a list of mandatory fields like: `@timestamp`, `beat`, `count`, `status` that cannot be removed and they are always available in the exported fields. With the two configuration options you can configure the additional fields that will be exported or not exported. By default, all fields are exported.

Here are the options:

- `include_fields=[]` -> exports only the mandatory fields
- `include_fields is not defined` (commented) -> export all fields (the default option)
- `drop_fields=[]` -> export all fields (the default option)
 
As fields, they accept a map like `proc` or a value like `proc.cpu.total_p`. 

In case there is a field to include that is not available in the event, then just ignore the field. 

When multiple filtering rules are defined, we start with a copy of the event and apply the filtering rules one by to the
event.

<pre>
   event -> filter rule 1 -> event 1 -> filter rule 2 -> event 2 ...
</pre>

   where event is the initial event, event1 is the event resulted after applying "filter rule1" and it's considered input for the "filter rule 2" and so on.