### PR TITLE
Clarify when to define multiple prospectors (cherry pick into master)

### DIFF
--- a/filebeat/docs/multiple-prospectors.asciidoc
+++ b/filebeat/docs/multiple-prospectors.asciidoc
@@ -16,11 +16,11 @@ to unexpected behaviour.
 -------------------------------------------------------------------------------------
 filebeat:
   prospectors:
-    -
+    - input_type: log
       paths:
         - /var/log/system.log
         - /var/log/wifi.log
-    -
+    - input_type: log
       paths:
         - "/var/log/apache2/*"
       fields:

--- a/filebeat/docs/multiple-prospectors.asciidoc
+++ b/filebeat/docs/multiple-prospectors.asciidoc
@@ -1,8 +1,13 @@
 [[multiple-prospectors]]
 === Specifying Multiple Prospectors
 
-A config file can contain multiple prospectors and multiple paths per prospector
-as shown in the following example.
+When you need to collect lines from multiple files, you can simply configure a single prospector and specify multiple
+paths to start a harvester for each file. However, if you want to apply additional prospector-specific
+<<configuration-filebeat-options,configuration settings>> (such as `fields`, `include_lines`, `exclude_lines`, `multiline`, and so on)
+to the lines harvested from specific files, you need to define multiple prospectors in the Filebeat config file. 
+
+Within the config file, you can specify multiple prospectors, and each prospector can define multiple paths to crawl, as
+shown in the following example. 
 
 NOTE: Make sure a file is not defined more than once across all prospectors because this can lead
 to unexpected behaviour.
@@ -18,8 +23,13 @@ filebeat:
     -
       paths:
         - "/var/log/apache2/*"
+      fields:
+        apache: true
+      fields_under_root: true
 -------------------------------------------------------------------------------------
 
-The config file in the example starts two prospectors. The first prospector has two harvesters,
+The config file in the example starts two prospectors (the list of prospectors is a http://yaml.org/[YAML]
+array, so each prospector begins with a `-`). The first prospector has two harvesters,
 one harvesting the `system.log` file, and the other harvesting `wifi.log`. The second prospector
-starts a harvester for each file in the apache directory.
+starts a harvester for each file in the `apache2` directory and uses the `fields` configuration
+option to add a field called `apache` to the output.

--- a/filebeat/docs/reference/configuration/filebeat-options.asciidoc
+++ b/filebeat/docs/reference/configuration/filebeat-options.asciidoc
@@ -47,6 +47,7 @@ The value that you specify here is used as the `input_type` for each event publi
 A list of glob-based paths that should be crawled and fetched. Filebeat starts a harvester for
 each file that it finds under the specified paths. You can specify one path per line. Each line begins with a dash (-).
 
+[[exclude-lines]]
 ===== exclude_lines
 
 A list of regular expressions to match the lines that you want Filebeat to exclude. Filebeat drops any lines that match a regular expression in the list. By default, no lines are dropped.
@@ -60,6 +61,7 @@ The following example configures Filebeat to drop any lines that start with "DBG
 exclude_lines: ["^DBG"]
 -------------------------------------------------------------------------------------
 
+[[include-lines]]
 ===== include_lines
 
 A list of regular expressions to match the lines that you want Filebeat to include. Filebeat exports only the lines that match a regular expression in the list. By default, all lines are exported.


### PR DESCRIPTION
Cherry pick of #1091 into master.

Also modified example to show the changed YAML syntax for specifying prospectors (input_type is specified after the dash).

Closes #685