### PR TITLE
Update MetricSeter creation

### DIFF
--- a/metricbeat/helper/interfacer.go
+++ b/metricbeat/helper/interfacer.go
@@ -20,7 +20,7 @@ type ModuleConfig struct {
 // Interface for each metric
 type MetricSeter interface {
 	// Method to periodically fetch new events
-	Fetch(m *MetricSet) ([]common.MapStr, error)
+	Fetch(ms *MetricSet) ([]common.MapStr, error)
 }
 
 // Interface for each module

--- a/metricbeat/helper/metricset.go
+++ b/metricbeat/helper/metricset.go
@@ -15,10 +15,12 @@ type MetricSet struct {
 }
 
 // Creates a new MetricSet
-func NewMetricSet(name string, metricset MetricSeter, module *Module) *MetricSet {
+func NewMetricSet(name string, new func() MetricSeter, module *Module) *MetricSet {
+	metricSeter := new()
+
 	return &MetricSet{
 		Name:        name,
-		MetricSeter: metricset,
+		MetricSeter: metricSeter,
 		Config:      module.Config,
 		Module:      module,
 	}

--- a/metricbeat/helper/metricset_test.go
+++ b/metricbeat/helper/metricset_test.go
@@ -1,0 +1,61 @@
+package helper
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/libbeat/common"
+)
+
+// TestMetricSeterState tests if a metricset persists its state during multiple Fetch requests
+func TestMetricSeterState(t *testing.T) {
+	module := &Module{}
+
+	metricSet := NewMetricSet("mockmetricset", NewMockMetricSeter, module)
+
+	events, _ := metricSet.MetricSeter.Fetch(metricSet)
+	assert.Equal(t, 1, events[0]["counter"])
+
+	events, _ = metricSet.MetricSeter.Fetch(metricSet)
+	assert.Equal(t, 2, events[0]["counter"])
+}
+
+// TestMetricSetTwoInstances makes sure that in case of two different MetricSet instance, MetricSeter don't share state
+func TestMetricSetTwoInstances(t *testing.T) {
+	module := &Module{}
+
+	metricSet1 := NewMetricSet("mockmetricset1", NewMockMetricSeter, module)
+	metricSet2 := NewMetricSet("mockmetricset2", NewMockMetricSeter, module)
+
+	events, _ := metricSet1.MetricSeter.Fetch(metricSet1)
+	assert.Equal(t, 1, events[0]["counter"], 1)
+
+	events, _ = metricSet2.MetricSeter.Fetch(metricSet2)
+	assert.Equal(t, 1, events[0]["counter"], 1)
+}
+
+/*** Mock tests objects ***/
+
+// New creates new instance of MetricSeter
+func NewMockMetricSeter() MetricSeter {
+	return &MockMetricSeter{
+		counter: 0,
+	}
+}
+
+type MockMetricSeter struct {
+	counter int
+}
+
+func (m *MockMetricSeter) Fetch(ms *MetricSet) (events []common.MapStr, err error) {
+	m.counter = m.counter + 1
+
+	event := common.MapStr{
+		"counter": m.counter,
+	}
+
+	events = append(events, event)
+
+	return events, nil
+}

--- a/metricbeat/helper/register.go
+++ b/metricbeat/helper/register.go
@@ -19,7 +19,7 @@ var Registry = Register{}
 
 type Register struct {
 	Modulers     map[string]Moduler
-	MetricSeters map[string]map[string]MetricSeter
+	MetricSeters map[string]map[string]func() MetricSeter
 }
 
 // AddModule registers the given module with the registry
@@ -34,19 +34,19 @@ func (r *Register) AddModuler(name string, m Moduler) {
 	r.Modulers[name] = m
 }
 
-func (r *Register) AddMetricSeter(module string, name string, m MetricSeter) {
+func (r *Register) AddMetricSeter(module string, name string, new func() MetricSeter) {
 
 	if r.MetricSeters == nil {
-		r.MetricSeters = map[string]map[string]MetricSeter{}
+		r.MetricSeters = map[string]map[string]func() MetricSeter{}
 	}
 
 	if _, ok := r.MetricSeters[module]; !ok {
-		r.MetricSeters[module] = map[string]MetricSeter{}
+		r.MetricSeters[module] = map[string]func() MetricSeter{}
 	}
 
 	logp.Info("Register metricset %s for module %s", name, module)
 
-	r.MetricSeters[module][name] = m
+	r.MetricSeters[module][name] = new
 }
 
 // GetModule returns a new module instance for the given moduler name
@@ -79,8 +79,8 @@ func (r *Register) GetMetricSet(module *Module, metricsetName string) (*MetricSe
 		return nil, fmt.Errorf("Metricset %s in module %s does not exist", metricsetName, module.name)
 	}
 
-	metricSeter := Registry.MetricSeters[module.name][metricsetName]
+	newMetricSeter := Registry.MetricSeters[module.name][metricsetName]
 
-	return NewMetricSet(metricsetName, metricSeter, module), nil
+	return NewMetricSet(metricsetName, newMetricSeter, module), nil
 
 }

--- a/metricbeat/module/apache/status/status.go
+++ b/metricbeat/module/apache/status/status.go
@@ -13,7 +13,12 @@ import (
 )
 
 func init() {
-	helper.Registry.AddMetricSeter("apache", "status", &MetricSeter{})
+	helper.Registry.AddMetricSeter("apache", "status", New)
+}
+
+// New creates new instance of MetricSeter
+func New() helper.MetricSeter {
+	return &MetricSeter{}
 }
 
 type MetricSeter struct{}

--- a/metricbeat/module/mysql/status/status.go
+++ b/metricbeat/module/mysql/status/status.go
@@ -12,11 +12,11 @@ import (
 )
 
 func init() {
-	helper.Registry.AddMetricSeter("mysql", "status", New())
+	helper.Registry.AddMetricSeter("mysql", "status", New)
 }
 
 // New creates new instance of MetricSeter
-func New() *MetricSeter {
+func New() helper.MetricSeter {
 	return &MetricSeter{
 		connections: map[string]*sql.DB{},
 	}

--- a/metricbeat/module/mysql/status/status_test.go
+++ b/metricbeat/module/mysql/status/status_test.go
@@ -15,19 +15,16 @@ func TestFetch(t *testing.T) {
 		t.Skip("Skipping in short mode, because it requires MySQL")
 	}
 
-	// Setup Metric
-	m := New()
-
 	config := helper.ModuleConfig{
 		Hosts: []string{mysql.GetMySQLEnvDSN()},
 	}
 	module := &helper.Module{
 		Config: config,
 	}
-	ms := helper.NewMetricSet("status", m, module)
+	ms := helper.NewMetricSet("status", New, module)
 
 	// Load events
-	events, err := m.Fetch(ms)
+	events, err := ms.MetricSeter.Fetch(ms)
 	assert.NoError(t, err)
 
 	// Check event fields

--- a/metricbeat/module/redis/info/info.go
+++ b/metricbeat/module/redis/info/info.go
@@ -124,7 +124,12 @@ import (
 )
 
 func init() {
-	helper.Registry.AddMetricSeter("redis", "info", &MetricSeter{})
+	helper.Registry.AddMetricSeter("redis", "info", New)
+}
+
+// New creates new instance of MetricSeter
+func New() helper.MetricSeter {
+	return &MetricSeter{}
 }
 
 type MetricSeter struct{}

--- a/metricbeat/module/redis/info/info_test.go
+++ b/metricbeat/module/redis/info/info_test.go
@@ -16,18 +16,15 @@ func TestConnect(t *testing.T) {
 		t.Skip("Skipping in short mode, because it requires Redis")
 	}
 
-	// Setup
-	r := &MetricSeter{}
-
 	config := helper.ModuleConfig{
 		Hosts: []string{redis.GetRedisEnvHost() + ":" + redis.GetRedisEnvPort()},
 	}
 	module := &helper.Module{
 		Config: config,
 	}
-	ms := helper.NewMetricSet("info", r, module)
+	ms := helper.NewMetricSet("info", New, module)
 
-	data, err := r.Fetch(ms)
+	data, err := ms.MetricSeter.Fetch(ms)
 	assert.NoError(t, err)
 
 	// Check fields


### PR DESCRIPTION
Update MetricSeter creation to make sure copy or pointer is used in the right environment