### PR TITLE
Regenerate field docs

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -51,7 +51,7 @@ https://github.com/elastic/beats/compare/v1.1.0...master[Check the HEAD diff]
 - Check column length in pgsql parser. {issue}565{565
 
 *Topbeat*
-- Fix issue with cpu.system_p being abnormally high {pull}1200[1200]
+- Fix issue with cpu.system_p being greater than 1 on Windows {pull}1128[1128]
 
 *Filebeat*
 - Stop filebeat if filebeat is started without any prospectors defined or empty prospectors {pull}644[644] {pull}647[647]

--- a/filebeat/filebeat.yml
+++ b/filebeat/filebeat.yml
@@ -294,9 +294,8 @@ output:
     # Optional load balance the events between the Logstash hosts
     #loadbalance: true
 
-    # Optional index name. The default index name depends on the each beat.
-    # For Packetbeat, the default is set to packetbeat, for Topbeat
-    # top topbeat and for Filebeat to filebeat.
+    # Optional index name. The default index name is set to name of the beat
+    # in all lowercase.
     #index: filebeat
 
     # SOCKS5 proxy server URL
@@ -338,7 +337,7 @@ output:
     #filename: filebeat
 
     # Maximum size in kilobytes of each file. When this size is reached, the files are
-    # rotated. The default value is 10 MB.
+    # rotated. The default value is 10240 kB.
     #rotate_every_kb: 10000
 
     # Maximum number of files under path. When this number of files is reached, the

--- a/libbeat/etc/libbeat.yml
+++ b/libbeat/etc/libbeat.yml
@@ -122,9 +122,8 @@ output:
     # Optional load balance the events between the Logstash hosts
     #loadbalance: true
 
-    # Optional index name. The default index name depends on the each beat.
-    # For Packetbeat, the default is set to packetbeat, for Topbeat
-    # top topbeat and for Filebeat to filebeat.
+    # Optional index name. The default index name is set to name of the beat
+    # in all lowercase.
     #index: beatname
 
     # SOCKS5 proxy server URL
@@ -166,7 +165,7 @@ output:
     #filename: beatname
 
     # Maximum size in kilobytes of each file. When this size is reached, the files are
-    # rotated. The default value is 10 MB.
+    # rotated. The default value is 10240 kB.
     #rotate_every_kb: 10000
 
     # Maximum number of files under path. When this number of files is reached, the

--- a/metricbeat/metricbeat.yml
+++ b/metricbeat/metricbeat.yml
@@ -144,9 +144,8 @@ output:
     # Optional load balance the events between the Logstash hosts
     #loadbalance: true
 
-    # Optional index name. The default index name depends on the each beat.
-    # For Packetbeat, the default is set to packetbeat, for Topbeat
-    # top topbeat and for Filebeat to filebeat.
+    # Optional index name. The default index name is set to name of the beat
+    # in all lowercase.
     #index: metricbeat
 
     # SOCKS5 proxy server URL
@@ -188,7 +187,7 @@ output:
     #filename: metricbeat
 
     # Maximum size in kilobytes of each file. When this size is reached, the files are
-    # rotated. The default value is 10 MB.
+    # rotated. The default value is 10240 kB.
     #rotate_every_kb: 10000
 
     # Maximum number of files under path. When this number of files is reached, the

--- a/packetbeat/docs/fields.asciidoc
+++ b/packetbeat/docs/fields.asciidoc
@@ -6,7 +6,7 @@ This file is generated! See etc/fields.yml and scripts/generate_field_docs.py
 [[exported-fields]]
 == Exported Fields
 
-This document describes the fields that are exported by Docs/Fields.Asciidoc. They are
+This document describes the fields that are exported by Packetbeat. They are
 grouped in the following categories:
 
 * <<exported-fields-flows_event>>
@@ -650,7 +650,7 @@ AMQP reply code to an error, similar to http reply-code
 
 type: string
 
-Text expliciting the error.
+Text explaining the error.
 
 
 ==== amqp.class-id

--- a/packetbeat/etc/fields.yml
+++ b/packetbeat/etc/fields.yml
@@ -655,7 +655,7 @@ trans_event:
         - name: amqp.reply-text
           type: string
           description: >
-            Text expliciting the error.
+            Text explaining the error.
 
         - name: amqp.class-id
           type: int

--- a/packetbeat/packetbeat.yml
+++ b/packetbeat/packetbeat.yml
@@ -294,9 +294,8 @@ output:
     # Optional load balance the events between the Logstash hosts
     #loadbalance: true
 
-    # Optional index name. The default index name depends on the each beat.
-    # For Packetbeat, the default is set to packetbeat, for Topbeat
-    # top topbeat and for Filebeat to filebeat.
+    # Optional index name. The default index name is set to name of the beat
+    # in all lowercase.
     #index: packetbeat
 
     # SOCKS5 proxy server URL
@@ -338,7 +337,7 @@ output:
     #filename: packetbeat
 
     # Maximum size in kilobytes of each file. When this size is reached, the files are
-    # rotated. The default value is 10 MB.
+    # rotated. The default value is 10240 kB.
     #rotate_every_kb: 10000
 
     # Maximum number of files under path. When this number of files is reached, the

--- a/topbeat/docs/fields.asciidoc
+++ b/topbeat/docs/fields.asciidoc
@@ -529,3 +529,5 @@ The used disk space in bytes.
 type: float
 
 The percentage of used disk space.
+
+

--- a/topbeat/topbeat.yml
+++ b/topbeat/topbeat.yml
@@ -148,9 +148,8 @@ output:
     # Optional load balance the events between the Logstash hosts
     #loadbalance: true
 
-    # Optional index name. The default index name depends on the each beat.
-    # For Packetbeat, the default is set to packetbeat, for Topbeat
-    # top topbeat and for Filebeat to filebeat.
+    # Optional index name. The default index name is set to name of the beat
+    # in all lowercase.
     #index: topbeat
 
     # SOCKS5 proxy server URL
@@ -192,7 +191,7 @@ output:
     #filename: topbeat
 
     # Maximum size in kilobytes of each file. When this size is reached, the files are
-    # rotated. The default value is 10 MB.
+    # rotated. The default value is 10240 kB.
     #rotate_every_kb: 10000
 
     # Maximum number of files under path. When this number of files is reached, the

--- a/winlogbeat/winlogbeat.yml
+++ b/winlogbeat/winlogbeat.yml
@@ -147,9 +147,8 @@ output:
     # Optional load balance the events between the Logstash hosts
     #loadbalance: true
 
-    # Optional index name. The default index name depends on the each beat.
-    # For Packetbeat, the default is set to packetbeat, for Topbeat
-    # top topbeat and for Filebeat to filebeat.
+    # Optional index name. The default index name is set to name of the beat
+    # in all lowercase.
     #index: winlogbeat
 
     # SOCKS5 proxy server URL
@@ -191,7 +190,7 @@ output:
     #filename: winlogbeat
 
     # Maximum size in kilobytes of each file. When this size is reached, the files are
-    # rotated. The default value is 10 MB.
+    # rotated. The default value is 10240 kB.
     #rotate_every_kb: 10000
 
     # Maximum number of files under path. When this number of files is reached, the


### PR DESCRIPTION
There were changes to Topbeat docs when I ran the `make update`.