### PR TITLE
Dynamic fields path in fields generator script

### DIFF
--- a/filebeat/etc/beat.yml
+++ b/filebeat/etc/beat.yml
@@ -121,7 +121,7 @@ filebeat:
       #backoff: 1s
 
       # Max backoff defines what the maximum backoff time is. After having backed off multiple times
-      # from checking the files, the waiting time will never exceed max_backoff idenependent of the
+      # from checking the files, the waiting time will never exceed max_backoff independent of the
       # backoff factor. Having it set to 10s means in the worst case a new line can be added to a log
       # file after having backed off multiple times, it takes a maximum of 10s to read the new line
       #max_backoff: 10s

--- a/filebeat/filebeat.yml
+++ b/filebeat/filebeat.yml
@@ -121,7 +121,7 @@ filebeat:
       #backoff: 1s
 
       # Max backoff defines what the maximum backoff time is. After having backed off multiple times
-      # from checking the files, the waiting time will never exceed max_backoff idenependent of the
+      # from checking the files, the waiting time will never exceed max_backoff independent of the
       # backoff factor. Having it set to 10s means in the worst case a new line can be added to a log
       # file after having backed off multiple times, it takes a maximum of 10s to read the new line
       #max_backoff: 10s

--- a/libbeat/scripts/generate_fields_docs.py
+++ b/libbeat/scripts/generate_fields_docs.py
@@ -1,9 +1,13 @@
 import yaml
 import sys
 
-def document_fields(output, section, sections):
+def document_fields(output, section, sections, path):
     if "anchor" in section:
         output.write("[[exported-fields-{}]]\n".format(section["anchor"]))
+
+    if "prefix" in section:
+        output.write("{}\n".format(section["prefix"]))
+
     output.write("=== {} Fields\n\n".format(section["name"]))
 
     if "description" in section:
@@ -15,6 +19,11 @@ def document_fields(output, section, sections):
     output.write("\n")
     for field in section["fields"]:
 
+        if path == "":
+            newpath = field["name"]
+        else:
+            newpath = path + "." + field["name"]
+
         if "type" in field and field["type"] == "group":
 
             for value in sections:
@@ -24,15 +33,15 @@ def document_fields(output, section, sections):
                     field["anchor"] = field["name"]
                     field["name"] = name
                     break
-            document_fields(output, field, sections)
+            document_fields(output, field, sections, newpath)
         else:
-            document_field(output, field)
+            document_field(output, field, newpath)
 
 
-def document_field(output, field):
+def document_field(output, field, path):
 
     if "path" not in field:
-        field["path"] = field["name"]
+        field["path"] = path
 
     output.write("==== {}\n\n".format(field["path"]))
 
@@ -101,7 +110,7 @@ grouped in the following categories:
                 if section["type"] == "group":
                     section["name"] = name
                     section["anchor"] = doc
-                    document_fields(output, section, sections)
+                    document_fields(output, section, sections, "")
 
 
 if __name__ == "__main__":

--- a/libbeat/tests/system/beat/beat.py
+++ b/libbeat/tests/system/beat/beat.py
@@ -348,18 +348,25 @@ class TestCase(unittest.TestCase):
 
         Reads these lists from the fields documentation.
         """
-        def extract_fields(doc_list):
+        def extract_fields(doc_list, name):
             fields = []
             dictfields = []
             for field in doc_list:
+
+                # Chain together names
+                if name != "":
+                    newName = name + "." + field["name"]
+                else:
+                    newName = field["name"]
+
                 if field.get("type") == "group":
-                    subfields, subdictfields = extract_fields(field["fields"])
+                    subfields, subdictfields = extract_fields(field["fields"], newName)
                     fields.extend(subfields)
                     dictfields.extend(subdictfields)
                 else:
-                    fields.append(field["name"])
+                    fields.append(newName)
                     if field.get("type") == "dict":
-                        dictfields.append(field["name"])
+                        dictfields.append(newName)
             return fields, dictfields
 
         with open(fields_doc, "r") as f:
@@ -369,7 +376,7 @@ class TestCase(unittest.TestCase):
             for key, value in doc.items():
                 if isinstance(value, dict) and \
                         value.get("type") == "group":
-                    subfields, subdictfields = extract_fields(value["fields"])
+                    subfields, subdictfields = extract_fields(value["fields"], "")
                     fields.extend(subfields)
                     dictfields.extend(subdictfields)
             return fields, dictfields

--- a/packetbeat/etc/fields.yml
+++ b/packetbeat/etc/fields.yml
@@ -306,11 +306,11 @@ flows_event:
       description: >
         Object with source to destination flow measurements.
       fields:
-        - name: stats_source.net_packets_total
+        - name: net_packets_total
           description: >
             Total number of packets
 
-        - name: stats_source.net_bytes_total
+        - name: net_bytes_total
           description: >
             Total number of bytes
 
@@ -319,11 +319,11 @@ flows_event:
       description: >
         Object with destination to source flow measurements.
       fields:
-        - name: stats_dest.net_packets_total
+        - name: net_packets_total
           description: >
             Total number of packets
 
-        - name: stats_dest.net_bytes_total
+        - name: net_bytes_total
           description: >
             Total number of bytes
 
@@ -422,33 +422,33 @@ trans_event:
       type: group
       description: ICMP specific event fields.
       fields:
-        - name: icmp.version
+        - name: version
           description: The version of the ICMP protocol.
           possible_values:
             - 4
             - 6
 
-        - name: icmp.request.message
+        - name: request.message
           type: string
           description: A human readable form of the request.
 
-        - name: icmp.request.type
+        - name: request.type
           type: int
           description: The request type.
 
-        - name: icmp.request.code
+        - name: request.code
           type: int
           description: The request code.
 
-        - name: icmp.response.message
+        - name: response.message
           type: string
           description: A human readable form of the response.
 
-        - name: icmp.response.type
+        - name: response.type
           type: int
           description: The response type.
 
-        - name: icmp.response.code
+        - name: response.code
           type: int
           description: The response code.
 
@@ -456,60 +456,60 @@ trans_event:
       type: group
       description: DNS-specific event fields.
       fields:
-        - name: dns.id
+        - name: id
           type: int
           description: >
             The DNS packet identifier assigned by the program that generated the
             query. The identifier is copied to the response.
 
-        - name: dns.op_code
+        - name: op_code
           description: >
             The DNS operation code that specifies the kind of query in the message.
             This value is set by the originator of a query and copied into the
             response.
           example: QUERY
 
-        - name: dns.flags.authoritative
+        - name: flags.authoritative
           type: bool
           description: >
             A DNS flag specifying that the responding server is an authority for
             the domain name used in the question.
 
-        - name: dns.flags.recursion_available
+        - name: flags.recursion_available
           type: bool
           description: >
             A DNS flag specifying whether recursive query support is available in the
             name server.
 
-        - name: dns.flags.recursion_desired
+        - name: flags.recursion_desired
           type: bool
           description: >
             A DNS flag specifying that the client directs the server to pursue a
             query recursively. Recursive query support is optional.
 
-        - name: dns.flags.authentic_data
+        - name: flags.authentic_data
           type: bool
           description: >
             A DNS flag specifying that the recursive server considers the response
             authentic.
 
-        - name: dns.flags.checking_disabled
+        - name: flags.checking_disabled
           type: bool
           description: >
             A DNS flag specifying that the client disables the server
             signature validation of the query.
 
-        - name: dns.flags.truncated_response
+        - name: flags.truncated_response
           type: bool
           description: >
             A DNS flag specifying that only the first 512 bytes of the reply were
             returned.
 
-        - name: dns.response_code
+        - name: response_code
           description: The DNS status code.
           example: NOERROR
 
-        - name: dns.question.name
+        - name: question.name
           description: >
             The domain name being queried. If the name field contains non-printable
             characters (below 32 or above 126), then those characters are represented
@@ -518,126 +518,126 @@ trans_event:
             \n respectively.
           example: www.google.com.
 
-        - name: dns.question.type
+        - name: question.type
           description: The type of records being queried.
           example: AAAA
 
-        - name: dns.question.class
+        - name: question.class
           description: The class of of records being queried.
           example: IN
 
-        - name: dns.question.etld_plus_one
+        - name: question.etld_plus_one
           description: The effective top-level domain (eTLD) plus one more label.
             For example, the eTLD+1 for "foo.bar.golang.org." is "golang.org.".
             The data for determining the eTLD comes from an embedded copy of the
             data from http://publicsuffix.org.
           example: amazon.co.uk.
 
-        - name: dns.answers_count
+        - name: answers_count
           type: int
           description: >
             The number of resource records contained in the `dns.answers` field.
 
-        - name: dns.answers.name
+        - name: answers.name
           description: The domain name to which this resource record pertains.
           example: example.com.
 
-        - name: dns.answers.type
+        - name: answers.type
           description: The type of data contained in this resource record.
           example: MX
 
-        - name: dns.answers.class
+        - name: answers.class
           description: The class of DNS data contained in this resource record.
           example: IN
 
-        - name: dns.answers.ttl
+        - name: answers.ttl
           description: >
             The time interval in seconds that this resource record may be cached
             before it should be discarded. Zero values mean that the data should
             not be cached.
           type: int
 
-        - name: dns.answers.data
+        - name: answers.data
           description: >
             The data describing the resource. The meaning of this data depends
             on the type and class of the resource record.
 
-        - name: dns.authorities
+        - name: authorities
           type: dict
           description: >
             An array containing a dictionary for each authority section from the
             answer.
 
-        - name: dns.authorities_count
+        - name: authorities_count
           type: int
           description: >
             The number of resource records contained in the `dns.authorities` field.
             The `dns.authorities` field may or may not be included depending on the
             configuration of Packetbeat.
 
-        - name: dns.authorities.name
+        - name: authorities.name
           description: The domain name to which this resource record pertains.
           example: example.com.
 
-        - name: dns.authorities.type
+        - name: authorities.type
           description: The type of data contained in this resource record.
           example: NS
 
-        - name: dns.authorities.class
+        - name: authorities.class
           description: The class of DNS data contained in this resource record.
           example: IN
 
-        - name: dns.answers
+        - name: answers
           type: dict
           description: >
             An array containing a dictionary about each answer section returned by
             the server.
 
-        - name: dns.answers.ttl
+        - name: answers.ttl
           description: >
             The time interval in seconds that this resource record may be cached
             before it should be discarded. Zero values mean that the data should
             not be cached.
           type: int
 
-        - name: dns.answers.data
+        - name: answers.data
           description: >
             The data describing the resource. The meaning of this data depends
             on the type and class of the resource record.
 
-        - name: dns.additionals
+        - name: additionals
           type: dict
           description: >
             An array containing a dictionary for each additional section from the
             answer.
 
-        - name: dns.additionals_count
+        - name: additionals_count
           type: int
           description: >
             The number of resource records contained in the `dns.additionals` field.
             The `dns.additionals` field may or may not be included depending on the
             configuration of Packetbeat.
 
-        - name: dns.additionals.name
+        - name: additionals.name
           description: The domain name to which this resource record pertains.
           example: example.com.
 
-        - name: dns.additionals.type
+        - name: additionals.type
           description: The type of data contained in this resource record.
           example: NS
 
-        - name: dns.additionals.class
+        - name: additionals.class
           description: The class of DNS data contained in this resource record.
           example: IN
 
-        - name: dns.additionals.ttl
+        - name: additionals.ttl
           description: >
             The time interval in seconds that this resource record may be cached
             before it should be discarded. Zero values mean that the data should
             not be cached.
           type: int
 
-        - name: dns.additionals.data
+        - name: additionals.data
           description: >
             The data describing the resource. The meaning of this data depends
             on the type and class of the resource record.
@@ -646,201 +646,201 @@ trans_event:
       type: group
       description: AMQP specific event fields.
       fields:
-        - name: amqp.reply-code
+        - name: reply-code
           type: int
           description: >
             AMQP reply code to an error, similar to http reply-code
           example: 404
 
-        - name: amqp.reply-text
+        - name: reply-text
           type: string
           description: >
             Text explaining the error.
 
-        - name: amqp.class-id
+        - name: class-id
           type: int
           description: >
             Failing method class.
 
-        - name: amqp.method-id
+        - name: method-id
           type: int
           description: >
             Failing method ID.
 
-        - name: amqp.exchange
+        - name: exchange
           type: string
           description: >
             Name of the exchange.
 
-        - name: amqp.exchange-type
+        - name: exchange-type
           type: string
           description: >
             Exchange type.
           example: fanout
 
-        - name: amqp.passive
+        - name: passive
           type: bool
           description: >
             If set, do not create exchange/queue.
 
-        - name: amqp.durable
+        - name: durable
           type: bool
           description: >
             If set, request a durable exchange/queue.
 
-        - name: amqp.exclusive
+        - name: exclusive
           type: bool
           description: >
             If set, request an exclusive queue.
 
-        - name: amqp.auto-delete
+        - name: auto-delete
           type: bool
           description: >
             If set, auto-delete queue when unused.
 
-        - name: amqp.no-wait
+        - name: no-wait
           type: bool
           description: >
             If set, the server will not respond to the method.
 
-        - name: amqp.consumer-tag
+        - name: consumer-tag
           description: >
             Identifier for the consumer, valid within the current channel.
 
-        - name: amqp.delivery-tag
+        - name: delivery-tag
           type: int
           description: >
             The server-assigned and channel-specific delivery tag.
 
-        - name: amqp.message-count
+        - name: message-count
           type: int
           description: >
             The number of messages in the queue, which will be zero for
             newly-declared queues.
 
-        - name: amqp.consumer-count
+        - name: consumer-count
           type: int
           description: >
             The number of consumers of a queue.
 
-        - name: amqp.routing-key
+        - name: routing-key
           type: int
           description: >
             Message routing key.
 
-        - name: amqp.no-ack
+        - name: no-ack
           type: bool
           description: >
             If set, the server does not expect acknowledgements for messages.
 
-        - name: amqp.no-local
+        - name: no-local
           type: bool
           description: >
             If set, the server will not send messages to the connection that
             published them.
 
-        - name: amqp.if-unused
+        - name: if-unused
           type: bool
           description: >
             Delete only if unused.
 
-        - name: amqp.if-empty
+        - name: if-empty
           type: bool
           description: >
             Delete only if empty.
 
-        - name: amqp.queue
+        - name: queue
           type: string
           description: >
             The queue name identifies the queue within the vhost.
 
-        - name: amqp.redelivered
+        - name: redelivered
           type: bool
           description: >
             Indicates that the message has been previously delivered to this
             or another client.
 
-        - name: amqp.multiple
+        - name: multiple
           type: bool
           description: >
             Acknowledge multiple messages.
 
-        - name: amqp.arguments.*
+        - name: arguments.*
           description: >
             Optional additional arguments passed to some methods. Can be of
             various types.
 
-        - name: amqp.mandatory
+        - name: mandatory
           type: bool
           description: >
             Indicates mandatory routing.
 
-        - name: amqp.immediate
+        - name: immediate
           type: bool
           description: >
             Request immediate delivery.
 
-        - name: amqp.content-type
+        - name: content-type
           type: string
           description: >
             MIME content type.
           example: text/plain
 
-        - name: amqp.content-encoding
+        - name: content-encoding
           type: string
           description: >
             MIME content encoding.
 
-        - name: amqp.headers.*
+        - name: headers.*
           description: >
             Message header field table.
 
-        - name: amqp.delivery-mode
+        - name: delivery-mode
           type: int
           description: >
             Non-persistent (1) or persistent (2).
 
-        - name: amqp.priority
+        - name: priority
           type: int
           description: >
             Message priority, 0 to 9.
 
-        - name: amqp.correlation-id
+        - name: correlation-id
           type: string
           description: >
             Application correlation identifier.
 
-        - name: amqp.reply-to
+        - name: reply-to
           type: string
           description: >
             Address to reply to.
 
-        - name: amqp.expiration
+        - name: expiration
           type: string
           description: >
             Message expiration specification.
 
-        - name: amqp.message-id
+        - name: message-id
           type: string
           description: >
             Application message identifier.
 
-        - name: amqp.timestamp
+        - name: timestamp
           type: string
           description: >
             Message timestamp.
 
-        - name: amqp.type
+        - name: type
           type: string
           description: >
             Message type name.
 
-        - name: amqp.user-id
+        - name: user-id
           type: string
           description: >
             Creating user id.
 
-        - name: amqp.app-id
+        - name: app-id
           type: string
           description: >
             Creating application id.
@@ -849,15 +849,15 @@ trans_event:
       type: group
       description: HTTP-specific event fields.
       fields:
-        - name: http.code
+        - name: code
           description: The HTTP status code.
           example: 404
 
-        - name: http.phrase
+        - name: phrase
           description: The HTTP status phrase.
           example: Not found.
 
-        - name: http.request_headers
+        - name: request_headers
           type: dict
           description: >
             A map containing the captured header fields from the request.
@@ -865,7 +865,7 @@ trans_event:
             header name are present in the message, they will be separated by
             commas.
 
-        - name: http.response_headers
+        - name: response_headers
           type: dict
           description: >
             A map containing the captured header fields from the response.
@@ -873,7 +873,7 @@ trans_event:
             same header name are present in the message, they will be separated
             by commas.
 
-        - name: http.content_length
+        - name: content_length
           type: int
           description: >
             The value of the Content-Length header if present.
@@ -882,19 +882,19 @@ trans_event:
       type: group
       description: Memcached-specific event fields
       fields:
-        - name: memcache.protocol_type
+        - name: protocol_type
           type: string
           description: >
             The memcache protocol implementation. The value can be "binary"
             for binary-based, "text" for text-based, or "unknown" for an unknown
             memcache protocol type.
 
-        - name: memcache.request.line
+        - name: request.line
           type: string
           description: >
             The raw command line for unknown commands ONLY.
 
-        - name: memcache.request.command
+        - name: request.command
           type: string
           description: >
             The memcache command being requested in the memcache text protocol.
@@ -902,20 +902,20 @@ trans_event:
             The binary protocol opcodes are translated into memcache text protocol
             commands.
 
-        - name: memcache.response.command
+        - name: response.command
           type: string
           description: >
             Either the text based protocol response message type
             or the name of the originating request if binary protocol is used.
 
-        - name: memcache.request.type
+        - name: request.type
           type: string
           description: >
             The memcache command classification. This value can be "UNKNOWN", "Load",
             "Store", "Delete", "Counter", "Info", "SlabCtrl", "LRUCrawler",
             "Stats", "Success", "Fail", or "Auth".
 
-        - name: memcache.response.type
+        - name: response.type
           type: string
           description: >
             The memcache command classification. This value can be "UNKNOWN", "Load",
@@ -925,194 +925,194 @@ trans_event:
             binary based protocol will mirror the request commands only (see
             `memcache.response.status` for binary protocol).
 
-        - name: memcache.response.error_msg
+        - name: response.error_msg
           type: string
           description: >
             The optional error message in the memcache response (text based protocol only).
 
-        - name: memcache.request.opcode
+        - name: request.opcode
           type: string
           description: >
             The binary protocol message opcode name.
 
-        - name: memcache.response.opcode
+        - name: response.opcode
           type: string
           description: >
             The binary protocol message opcode name.
 
-        - name: memcache.request.opcode_value
+        - name: request.opcode_value
           type: int
           description: >
             The binary protocol message opcode value.
 
-        - name: memcache.response.opcode_value
+        - name: response.opcode_value
           type: int
           description: >
             The binary protocol message opcode value.
 
-        - name: memcache.request.opaque
+        - name: request.opaque
           type: int
           description: >
             The binary protocol opaque header value used for correlating request
             with response messages.
 
-        - name: memcache.response.opaque
+        - name: response.opaque
           type: int
           description: >
             The binary protocol opaque header value used for correlating request
             with response messages.
 
-        - name: memcache.request.vbucket
+        - name: request.vbucket
           type: int
           description: >
             The vbucket index sent in the binary message.
 
-        - name: memcache.response.status
+        - name: response.status
           type: string
           description: >
             The textual representation of the response error code
             (binary protocol only).
 
-        - name: memcache.response.status_code
+        - name: response.status_code
           type: int
           description: >
             The status code value returned in the response (binary protocol only).
 
-        - name: memcache.request.keys
+        - name: request.keys
           type: list
           description: >
             The list of keys sent in the store or load commands.
 
-        - name: memcache.response.keys
+        - name: response.keys
           type: list
           description: >
             The list of keys returned for the load command (if present).
 
-        - name: memcache.request.count_values
+        - name: request.count_values
           type: int
           description: >
             The number of values found in the memcache request message.
             If the command does not send any data, this field is missing.
 
-        - name: memcache.response.count_values
+        - name: response.count_values
           type: int
           description: >
             The number of values found in the memcache response message.
             If the command does not send any data, this field is missing.
 
-        - name: memcache.request.values
+        - name: request.values
           type: list
           description: >
             The list of base64 encoded values sent with the request (if present).
 
-        - name: memcache.response.values
+        - name: response.values
           type: list
           description: >
             The list of base64 encoded values sent with the response (if present).
 
-        - name: memcache.request.bytes
+        - name: request.bytes
           type: int
           description: >
             The byte count of the values being transfered.
 
-        - name: memcache.response.bytes
+        - name: response.bytes
           type: int
           description: >
             The byte count of the values being transfered.
 
-        - name: memcache.request.delta
+        - name: request.delta
           type: int
           description: >
             The counter increment/decrement delta value.
 
-        - name: memcache.request.initial
+        - name: request.initial
           type: int
           description: >
             The counter increment/decrement initial value parameter (binary protocol only).
 
-        - name: memcache.request.verbosity
+        - name: request.verbosity
           type: int
           description: >
             The value of the memcache "verbosity" command.
 
-        - name: memcache.request.raw_args
+        - name: request.raw_args
           type: string
           description: >
             The text protocol raw arguments for the "stats ..." and "lru crawl ..." commands.
 
-        - name: memcache.request.source_class
+        - name: request.source_class
           type: int
           description: >
             The source class id in 'slab reassign' command.
 
-        - name: memcache.request.dest_class
+        - name: request.dest_class
           type: int
           description: >
             The destination class id in 'slab reassign' command.
 
-        - name: memcache.request.automove
+        - name: request.automove
           type: string
           description: >
               The automove mode in the 'slab automove' command expressed as a string.
               This value can be "standby"(=0), "slow"(=1), "aggressive"(=2), or the raw value if
               the value is unknown.
 
-        - name: memcache.request.flags
+        - name: request.flags
           type: int
           description: >
             The memcache command flags sent in the request (if present).
 
-        - name: memcache.response.flags
+        - name: response.flags
           type: int
           description: >
             The memcache message flags sent in the response (if present).
 
-        - name: memcache.request.exptime
+        - name: request.exptime
           type: int
           description: >
             The data expiry time in seconds sent with the memcache command (if present).
             If the value is <30 days, the expiry time is relative to "now", or else it
             is an absolute Unix time in seconds (32-bit).
 
-        - name: memcache.request.sleep_us
+        - name: request.sleep_us
           type: int
           description: >
             The sleep setting in microseconds for the 'lru_crawler sleep' command.
 
-        - name: memcache.response.value
+        - name: response.value
           type: int
           description: >
             The counter value returned by a counter operation.
 
-        - name: memcache.request.noreply
+        - name: request.noreply
           type: bool
           description: >
             Set to true if noreply was set in the request.
             The `memcache.response` field will be missing.
 
-        - name: memcache.request.quiet
+        - name: request.quiet
           type: bool
           description: >
             Set to true if the binary protocol message is to be treated as a quiet message.
 
-        - name: memcache.request.cas_unique
+        - name: request.cas_unique
           type: int
           description: >
             The CAS (compare-and-swap) identifier if present.
 
-        - name: memcache.response.cas_unique
+        - name: response.cas_unique
           type: int
           description: >
             The CAS (compare-and-swap) identifier to be used with CAS-based updates
             (if present).
 
-        - name: memcache.response.stats
+        - name: response.stats
           type: list
           description: >
             The list of statistic values returned. Each entry is a dictionary with the
             fields "name" and "value".
 
-        - name: memcache.response.version
+        - name: response.version
           type: string
           description: >
             The returned memcache version string.
@@ -1122,42 +1122,42 @@ trans_event:
       type: group
       description: MySQL-specific event fields.
       fields:
-        - name: mysql.iserror
+        - name: iserror
           type: bool
           description: >
            If the MySQL query returns an error, this field is set to true.
 
-        - name: mysql.affected_rows
+        - name: affected_rows
           type: int
           description: >
             If the MySQL command is successful, this field contains the affected
             number of rows of the last statement.
 
-        - name: mysql.insert_id
+        - name: insert_id
           description: >
             If the INSERT query is successful, this field contains the id of the
             newly inserted row.
 
-        - name: mysql.num_fields
+        - name: num_fields
           description: >
             If the SELECT query is successful, this field is set to the number
             of fields returned.
 
-        - name: mysql.num_rows
+        - name: num_rows
           description: >
             If the SELECT query is successful, this field is set to the number
             of rows returned.
 
-        - name: mysql.query
+        - name: query
           description: >
             The row mysql query as read from the transaction's request.
 
-        - name: mysql.error_code
+        - name: error_code
           type: int
           description: >
             The error code returned by MySQL.
 
-        - name: mysql.error_message
+        - name: error_message
           description: >
             The error info message returned by MySQL.
 
@@ -1165,35 +1165,35 @@ trans_event:
       type: group
       description: PostgreSQL-specific event fields.
       fields:
-        - name: pgsql.query
+        - name: query
           description: >
             The row pgsql query as read from the transaction's request.
 
-        - name: pgsql.iserror
+        - name: iserror
           type: bool
           description: >
             If the PgSQL query returns an error, this field is set to true.
 
-        - name: pgsql.error_code
+        - name: error_code
           description: The PostgreSQL error code.
           type: int
 
-        - name: pgsql.error_message
+        - name: error_message
           description: The PostgreSQL error message.
 
-        - name: pgsql.error_severity
+        - name: error_severity
           description: The PostgreSQL error severity.
           possible_values:
             - ERROR
             - FATAL
             - PANIC
 
-        - name: pgsql.num_fields
+        - name: num_fields
           description: >
             If the SELECT query if successful, this field is set to the number
             of fields returned.
 
-        - name: pgsql.num_rows
+        - name: num_rows
           description: >
             If the SELECT query if successful, this field is set to the number
             of rows returned.
@@ -1202,22 +1202,22 @@ trans_event:
       type: group
       description: Thrift-RPC specific event fields.
       fields:
-        - name: thrift.params
+        - name: params
           description: >
             The RPC method call parameters in a human readable format. If the IDL
             files are available, the parameters use names whenever possible.
             Otherwise, the IDs from the message are used.
 
-        - name: thrift.service
+        - name: service
           description: >
             The name of the Thrift-RPC service as defined in the IDL files.
 
-        - name: thrift.return_value
+        - name: return_value
           description: >
             The value returned by the Thrift-RPC call. This is encoded in a human
             readable format.
 
-        - name: thrift.exceptions
+        - name: exceptions
           description: >
             If the call resulted in exceptions, this field contains the exceptions in a human
             readable format.
@@ -1226,11 +1226,11 @@ trans_event:
       type: group
       description: Redis-specific event fields.
       fields:
-        - name: redis.return_value
+        - name: return_value
           description: >
             The return value of the Redis command in a human readable format.
 
-        - name: redis.error
+        - name: error
           description: >
             If the Redis command has resulted in an error, this field contains the
             error message returned by the Redis server.
@@ -1242,51 +1242,51 @@ trans_event:
          the fields for the MongoDB wire protocol. The higher level fields
          (for example, `query` and `resource`) apply to MongoDB events as well.
       fields:
-        - name: mongodb.error
+        - name: error
           description: >
             If the MongoDB request has resulted in an error, this field contains the
             error message returned by the server.
-        - name: mongodb.fullCollectionName
+        - name: fullCollectionName
           description: >
             The full collection name.
             The full collection name is the concatenation of the database name with the collection name,
             using a dot (.) for the concatenation.
             For example, for the database foo and the collection bar, the full collection name is foo.bar.
-        - name: mongodb.numberToSkip
+        - name: numberToSkip
           type: number
           description: >
             Sets the number of documents to omit - starting from the first document in the resulting dataset -
             when returning the result of the query.
-        - name: mongodb.numberToReturn
+        - name: numberToReturn
           type: number
           description: >
             The requested maximum number of documents to be returned.
-        - name: mongodb.numberReturned
+        - name: numberReturned
           type: number
           description: >
             The number of documents in the reply.
-        - name: mongodb.startingFrom
+        - name: startingFrom
           description: >
             Where in the cursor this reply is starting.
-        - name: mongodb.query
+        - name: query
           description: >
             A JSON document that represents the query.
             The query will contain one or more elements, all of which must match for a document
             to be included in the result set.
             Possible elements include $query, $orderby, $hint, $explain, and $snapshot.
-        - name: mongodb.returnFieldsSelector
+        - name: returnFieldsSelector
           description: >
             A JSON document that limits the fields in the returned documents.
             The returnFieldsSelector contains one or more elements, each of which is the name of a field that should be returned,
             and the integer value 1.
-        - name: mongodb.selector
+        - name: selector
           description: >
             A BSON document that specifies the query for selecting the document to update or delete.
-        - name: mongodb.update
+        - name: update
           description: >
             A BSON document that specifies the update to be performed.
             For information on specifying updates, see the Update Operations documentation from the MongoDB Manual.
-        - name: mongodb.cursorId
+        - name: cursorId
           description: >
             The cursor identifier returned in the OP_REPLY. This must be the value that was returned from the database.
 

--- a/topbeat/docs/fields.asciidoc
+++ b/topbeat/docs/fields.asciidoc
@@ -66,6 +66,7 @@ The hostname as returned by the operating system on which the Beat is running.
 Contains system-wide statistics. These statistics are the details that you can get by running the *top* command on Unix systems.
 
 
+
 [float]
 === load Fields
 
@@ -168,10 +169,12 @@ type: int
 
 The amount of CPU time spent in involuntary wait by the virtual CPU while the hypervisor was servicing another processor. Available only on Unix.
 
+
 [float]
 === cpus Fields
 
 This group contains CPU usage per core statistics.
+
 
 [float]
 === cpuX Fields

--- a/topbeat/etc/fields.yml
+++ b/topbeat/etc/fields.yml
@@ -53,90 +53,78 @@ system:
   fields:
     - name: load
       type: group
+      prefix: "[float]"
       description: >
         The system load average. The load average is the average number
         of jobs in the run queue.
       fields:
         - name: load1
-          path: load.load1
           type: float
           description: >
             The load average over 1 minute.
 
         - name: load5
-          path: load.load5
           type: float
           description: >
             The load average over 5 minutes.
 
         - name: load15
-          path: load.load15
           type: float
           description: >
             The load average over 15 minutes.
 
     - name: cpu
       type: group
+      prefix: "[float]"
       description: This group contains statistics related to CPU usage.
       fields:
         - name: user
-          path: cpu.user
           type: int
           description: >
            The amount of CPU time spent in user space.
 
         - name: user_p
-          path: cpu.user_p
           type: float
           description: >
             The percentage of CPU time spent in user space. On multi-core systems, you can have percentages that are greater than 100%.
             For example, if 3 cores are at 60% use, then the `cpu.user_p` will be 180%.
 
         - name: nice
-          path: cpu.nice
           type: int
           description: >
             The amount of CPU time spent on low-priority processes.
 
-
         - name: system
-          path: cpu.system
           type: int
           description: >
             The amount of CPU time spent in kernel space.
 
         - name: system_p
-          path: cpu.system_p
           type: float
           description: >
             The percentage of CPU time spent in kernel space.
 
         - name: idle
-          path: cpu.idle
           type: int
           description: >
             The amount of CPU time spent idle.
 
         - name: iowait
-          path: cpu.iowait
           type: int
           description: >
             The amount of CPU time spent in wait (on disk).
 
         - name: irq
-          path: cpu.irq
           type: int
           description: >
             The amount of CPU time spent servicing and handling hardware interrupts.
 
         - name: softirq
-          path: cpu.softirq
           type: int
           description:
             The amount of CPU time spent servicing and handling software interrupts.
 
         - name: steal
-          path: cpu.steal
           type: int
           description: >
             The amount of CPU time spent in involuntary wait by the virtual CPU while the hypervisor
@@ -145,65 +133,56 @@ system:
 
     - name: cpus
       type: group
+      prefix: "[float]"
       description: This group contains CPU usage per core statistics.
       fields:
         - name: cpuX
+          prefix: "[float]"
           type: group
           description: This group contains CPU usage statistics of the core X, where 0<X<N and N is the number of cores.
           fields:
 
           - name: user
-            path: cpus.cpuX.user
             type: int
             description: >
              The amount of CPU time spent in user space on core X.
 
           - name: user_p
-            path: cpus.cpuX.user_p
             type: float
             description: >
               The percentage of CPU time spent in user space on core X.
 
           - name: nice
-            path: cpus.cpuX.nice
             type: int
             description: >
               The amount of CPU time spent on low-priority processes on core X.
 
-
           - name: system
-            path: cpus.cpuX.system
             type: int
             description: >
               The amount of CPU time spent in kernel space on core X.
 
           - name: system_p
-            path: cpus.cpuX.system_p
             type: float
             description: >
               The percentage of CPU time spent in kernel space on core X.
 
           - name: idle
-            path: cpus.cpuX.idle
             type: int
             description: >
               The amount of CPU time spent idle on core X.
 
           - name: iowait
-            path: cpus.cpuX.iowait
             type: int
             description: >
               The amount of CPU time spent in wait (on disk) on core X.
 
           - name: softirq
-            path: cpus.cpuX.softirq
             type: int
             description:
               The amount of CPU time spent servicing and handling software interrupts on core X.
 
-
           - name: steal
-            path: cpus.cpuX.steal
             type: int
             description: >
               The amount of CPU time spent in involuntary wait by the virtual CPU while the hypervisor
@@ -214,76 +193,67 @@ system:
 
     - name: mem
       type: group
+      prefix: "[float]"
       description: This group contains statistics related to the memory usage on the system.
       fields:
         - name: total
-          path: mem.total
           type: int
           description: >
             Total memory.
 
         - name: used
-          path: mem.used
           type: int
           description: >
             Used memory.
 
         - name: free
-          path: mem.free
           type: int
           description: >
             Available memory.
 
         - name: used_p
-          path: mem.used_p
           type: float
           description: >
             The percentage of used memory.
 
         - name: actual_used
-          path: mem.actual_used
           type: int
           description: >
             Actual used memory. This value is the "used" memory minus the memory used for disk caches and buffers.
             Available only on Unix.
 
         - name: actual_free
-          path: mem.actual_free
           type: int
           description: >
             Actual available memory. This value is the "free" memory plus the memory used for disk caches and
             buffers. Available only on Unix.
 
         - name: actual_used_p
-          path: mem.actual_used_p
           type: float
           description: >
             The percentage of actual used memory.
 
     - name: swap
       type: group
+      prefix: "[float]"
       description: This group contains statistics related to the swap memory usage on the system.
       fields:
         - name: total
-          path: swap.total
           type: int
           description: >
             Total swap memory.
 
         - name: used
-          path: swap.used
           type: int
           description: >
             Used swap memory.
 
         - name: free
-          path: swap.free
           type: int
           description: >
             Available swap memory.
 
         - name: used_p
-          path: swap.used_p
           type: float
           description: >
             The percentage of used swap memory.
@@ -295,43 +265,38 @@ process:
   fields:
     - name: proc
       type: group
+      prefix: "[float]"
       description: >
         Contains per-process statistics like memory usage, CPU usage, and details about each process, such as state, name,
         pid, and ppid.
       fields:
         - name: name
-          path: proc.name
           type: string
           description: >
             The process name.
 
         - name: state
-          path: proc.state
           type: string
           description: >
             The process state. For example: "running"
 
         - name: pid
-          path: proc.pid
           type: int
           description: >
             The process pid.
 
         - name: ppid
-          path: proc.ppid
           type: int
           description: >
             The process parent pid.
 
         - name: cmdline
-          path: proc.cmdline
           type: string
           description: >
             The full command-line used to start the process, including the
             arguments separated by space.
 
         - name: username
-          path: proc.username
           type: string
           description: >
             The username of the user that created the process. If the username
@@ -341,35 +306,31 @@ process:
 
         - name: cpu
           type: group
+          prefix: "[float]"
           description: CPU-specific statistics per process.
           fields:
             - name: user
-              path: proc.cpu.user
               type: int
               description: >
                 The amount of CPU time the process spent in user space.
 
             - name: total_p
-              path: proc.cpu.total_p
               type: float
               description: >
                 The percentage of CPU time spent by the process since the last update. Its value is similar with the
                 %CPU value of the process displayed by the top command on unix systems.
 
             - name: system
-              path: proc.cpu.system
               type: int
               description: >
                 The amount of CPU time the process spent in kernel space.
 
             - name: total
-              path: proc.cpu.total
               type: int
               description: >
                 The total CPU time spent by the process.
 
             - name: start_time
-              path: proc.cpu.start_time
               type: string
               description: >
                 The time when the process was started. Example: "17:45".
@@ -377,27 +338,24 @@ process:
         - name: mem
           type: group
           description: Memory-specific statistics per process.
+          prefix: "[float]"
           fields:
             - name: size
-              path: proc.mem.size
               type: int
               description: >
                 The total virtual memory the process has.
 
             - name: rss
-              path: proc.mem.rss
               type: int
               description: >
                 The Resident Set Size. The amount of memory the process occupied in main memory (RAM).
 
             - name: rss_p
-              path: proc.mem.rss_p
               type: float
               description: >
                 The percentage of memory the process occupied in main memory (RAM).
 
             - name: share
-              path: proc.mem.share
               type: int
               description: >
                 The shared memory the process uses.
@@ -409,54 +367,47 @@ filesystem:
   fields:
     - name: fs
       type: group
+      prefix: "[float]"
       description: >
         Contains details about the mounted disks, such as the total or used disk space, and details about each disk, such as
         the device name and the mounting place.
       fields:
         - name: avail
-          path: fs.avail
           type: int
           description: >
             The available disk space in bytes.
 
         - name: device_name
-          path: fs.device_name
           type: string
           description: >
             The disk name. For example: `/dev/disk1`
 
         - name: mount_point
-          path: fs.mount_point
           type: string
           description: >
             The mounting point. For example: `/`
 
         - name: files
-          path: fs.files
           type: int
           description: >
             The total number of file nodes in the file system.
 
         - name: free_files
-          path: fs.free_files
           type: int
           description: >
             The number of free file nodes in the file system.
 
         - name: total
-          path: fs.total
           type: int
           description: >
             The total disk space in bytes.
 
         - name: used
-          path: fs.used
           type: int
           description: >
             The used disk space in bytes.
 
         - name: used_p
-          path: fs.used_p
           type: float
           description: >
             The percentage of used disk space.


### PR DESCRIPTION
For nested fields, it was necessary to either define the name with the dot nation based on its hierarchy or using the path variable. The generation script was now adjusted to automatically keep track of the hierarchy and generate the names correctly. This simplifies the fields.yml.

In addition it does not require knowledge of the full hierarchy in nested documents. This is especially useful for metricset fields docs as they should not require to have information about the path of their module.

Packetbeat and Topbeat files were adjusted to meet the new logic.