### PR TITLE
Second proposal for JSON support

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -93,6 +93,7 @@ https://github.com/elastic/beats/compare/v1.1.2...master[Check the HEAD diff]
 - Add close_older configuration option to complete ignore_older https://github.com/elastic/filebeat/issues/181[181]
 - Add experimental option to enable filebeat publisher pipeline to operate asynchonrously {pull}782[782]
 - Add the ability to set a list of tags for each prospector {pull}1092[1092]
+- Add JSON decoding support {pull}1143[1143]
 
 *Winlogbeat*
 - Add caching of event metadata handles and the system render context for the wineventlog API {pull}888[888]

--- a/filebeat/config/config.go
+++ b/filebeat/config/config.go
@@ -76,6 +76,14 @@ type HarvesterConfig struct {
 	IncludeLines       []string         `config:"include_lines"`
 	MaxBytes           int              `config:"max_bytes"`
 	Multiline          *MultilineConfig `config:"multiline"`
+	JSON               *JSONConfig      `config:"json"`
+}
+
+type JSONConfig struct {
+	MessageKey    string `config:"message_key"`
+	KeysUnderRoot bool   `config:"keys_under_root"`
+	OverwriteKeys bool   `config:"overwrite_keys"`
+	AddErrorKey   bool   `config:"add_error_key"`
 }
 
 type MultilineConfig struct {

--- a/filebeat/crawler/prospector.go
+++ b/filebeat/crawler/prospector.go
@@ -133,6 +133,18 @@ func (p *Prospector) setupProspectorConfig() error {
 		return fmt.Errorf("No paths were defined for prospector")
 	}
 
+	if config.Harvester.JSON != nil && len(config.Harvester.JSON.MessageKey) == 0 &&
+		config.Harvester.Multiline != nil {
+
+		return fmt.Errorf("When using the JSON decoder and multiline together, you need to specify a message_key value")
+	}
+
+	if config.Harvester.JSON != nil && len(config.Harvester.JSON.MessageKey) == 0 &&
+		(len(config.Harvester.IncludeLines) > 0 || len(config.Harvester.ExcludeLines) > 0) {
+
+		return fmt.Errorf("When using the JSON decoder and line filtering together, you need to specify a message_key value")
+	}
+
 	return nil
 }
 

--- a/filebeat/docs/reference/configuration/filebeat-options.asciidoc
+++ b/filebeat/docs/reference/configuration/filebeat-options.asciidoc
@@ -191,6 +191,40 @@ The buffer size every harvester uses when fetching the file. The default is 1638
 The maximum number of bytes that a single log message can have. All bytes after `max_bytes` are discarded and not sent.
 This setting is especially useful for multiline log messages, which can get large. The default is 10MB (10485760).
 
+[[config-json]]
+===== json
+These options make it possible for Filebeat to decode logs structured as JSON messages. Filebeat
+processes the logs line by line, so the JSON decoding only works if there is one JSON object per
+line.
+
+The decoding happens before line filtering and multiline. You can combine JSON decoding with filtering
+and multiline if you set the `message_key` option. This can be helpful in situations where the application
+logs are wrapped in JSON objects, like it happens for example with Docker.
+
+Example configuration:
+
+[source,yaml]
+-------------------------------------------------------------------------------------
+json:
+  message_key: log
+  keys_under_root: true
+  add_error_key: true
+-------------------------------------------------------------------------------------
+
+
+*`message_key`*:: JSON key on which to apply the line filtering and multiline settings. This key must be top level
+and its value must be string, otherwise it is ignored. If no text key is defined, the line
+filtering and multiline features cannot be used.
+
+*`keys_under_root`*:: By default, the decoded JSON is placed under a "json" key in the output document.
+If you enable this setting, the keys are copied top level in the output document. The default is false.
+
+*`overwrite_keys`*:: If `keys_under_root` and this setting are enabled, then the values from the decoded
+JSON object overwrite the fields that Filebeat normally adds (type, source, offset, etc.) in case of conflicts.
+
+*`add_error_key`*:: If this setting is enabled, Filebeat adds a "json_error" key in case of JSON
+unmarshaling errors or when a text key is defined in the configuration but cannot be used.
+
 [[multiline]]
 ===== multiline
 

--- a/filebeat/etc/beat.yml
+++ b/filebeat/etc/beat.yml
@@ -30,6 +30,28 @@ filebeat:
       #    hz-gb-2312, euc-kr, euc-jp, iso-2022-jp, shift-jis, ...
       #encoding: plain
 
+
+      # Decode JSON options. Enable this if your logs are structured in JSON.
+      #json:
+        # JSON key on which to apply the line filtering and multiline settings. This key
+        # must be top level and its value must be string, otherwise it is ignored. If
+        # no text key is defined, the line filtering and multiline features cannot be used.
+        #message_key:
+
+        # By default, the decoded JSON is placed under a "json" key in the output document.
+        # If you enable this setting, the keys are copied top level in the output document.
+        #keys_under_root: false
+
+        # If keys_under_root and this setting are enabled, then the values from the decoded
+        # JSON object overwrite the fields that Filebeat normally adds (type, source, offset, etc.)
+        # in case of conflicts.
+        #overwrite_keys: false
+
+        # If this setting is enabled, Filebeat adds a "json_error" key in case of JSON
+        # unmarshaling errors or when a text key is defined in the configuration but cannot
+        # be used.
+        #add_error_key: false
+
       # Exclude lines. A list of regular expressions to match. It drops the lines that are
       # matching any regular expression from the list. The include_lines is called before
       # exclude_lines. By default, no lines are dropped.

--- a/filebeat/harvester/log.go
+++ b/filebeat/harvester/log.go
@@ -23,6 +23,7 @@ func createLineReader(
 	bufferSize int,
 	maxBytes int,
 	readerConfig logFileReaderConfig,
+	jsonConfig *config.JSONConfig,
 	mlrConfig *config.MultilineConfig,
 ) (processor.LineProcessor, error) {
 	var p processor.LineProcessor
@@ -36,6 +37,10 @@ func createLineReader(
 	p, err = processor.NewLineSource(fileReader, codec, bufferSize)
 	if err != nil {
 		return nil, err
+	}
+
+	if jsonConfig != nil {
+		p = processor.NewJSONProcessor(p, jsonConfig)
 	}
 
 	if mlrConfig != nil {
@@ -98,7 +103,8 @@ func (h *Harvester) Harvest() {
 	}
 
 	reader, err := createLineReader(
-		h.file, enc, config.BufferSize, config.MaxBytes, readerConfig, config.Multiline)
+		h.file, enc, config.BufferSize, config.MaxBytes, readerConfig,
+		config.JSON, config.Multiline)
 	if err != nil {
 		logp.Err("Stop Harvesting. Unexpected encoding line reader error: %s", err)
 		return
@@ -106,7 +112,7 @@ func (h *Harvester) Harvest() {
 
 	for {
 		// Partial lines return error and are only read on completion
-		ts, text, bytesRead, err := readLine(reader)
+		ts, text, bytesRead, jsonFields, err := readLine(reader)
 		if err != nil {
 			if err == errFileTruncate {
 				seeker, ok := h.file.(io.Seeker)
@@ -137,6 +143,8 @@ func (h *Harvester) Harvest() {
 				Bytes:         bytesRead,
 				Text:          &text,
 				Fileinfo:      &info,
+				JSONFields:    jsonFields,
+				JSONConfig:    h.Config.JSON,
 			}
 
 			h.SpoolerChan <- event // ship the new event downstream

--- a/filebeat/harvester/log_test.go
+++ b/filebeat/harvester/log_test.go
@@ -64,24 +64,24 @@ func TestReadLine(t *testing.T) {
 		maxBackoffDuration: 1 * time.Second,
 		backoffFactor:      2,
 	}
-	reader, _ := createLineReader(fileSource{readFile}, codec, 100, 1000, readConfig, nil)
+	reader, _ := createLineReader(fileSource{readFile}, codec, 100, 1000, readConfig, nil, nil)
 
 	// Read third line
-	_, text, bytesread, err := readLine(reader)
+	_, text, bytesread, _, err := readLine(reader)
 	fmt.Printf("received line: '%s'\n", text)
 	assert.Nil(t, err)
 	assert.Equal(t, text, firstLineString[0:len(firstLineString)-1])
 	assert.Equal(t, bytesread, len(firstLineString))
 
 	// read second line
-	_, text, bytesread, err = readLine(reader)
+	_, text, bytesread, _, err = readLine(reader)
 	fmt.Printf("received line: '%s'\n", text)
 	assert.Equal(t, text, secondLineString[0:len(secondLineString)-1])
 	assert.Equal(t, bytesread, len(secondLineString))
 	assert.Nil(t, err)
 
 	// Read third line, which doesn't exist
-	_, text, bytesread, err = readLine(reader)
+	_, text, bytesread, _, err = readLine(reader)
 	fmt.Printf("received line: '%s'\n", text)
 	assert.Equal(t, "", text)
 	assert.Equal(t, bytesread, 0)

--- a/filebeat/harvester/processor/processor_test.go
+++ b/filebeat/harvester/processor/processor_test.go
@@ -5,6 +5,8 @@ package processor
 import (
 	"testing"
 
+	"github.com/elastic/beats/filebeat/config"
+	"github.com/elastic/beats/libbeat/common"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -39,4 +41,84 @@ func TestLineEndingChars(t *testing.T) {
 	// This is an invalid option
 	line = []byte("NR ending \n\r")
 	assert.Equal(t, 0, lineEndingChars(line))
+}
+
+func TestDecodeJSON(t *testing.T) {
+	type io struct {
+		Text         string
+		Config       config.JSONConfig
+		ExpectedText string
+		ExpectedMap  common.MapStr
+	}
+
+	var tests = []io{
+		{
+			Text:         `{"message": "test", "value": 1}`,
+			Config:       config.JSONConfig{MessageKey: "message"},
+			ExpectedText: "test",
+			ExpectedMap:  common.MapStr{"message": "test", "value": float64(1)},
+		},
+		{
+			Text:         `{"message": "test", "value": 1}`,
+			Config:       config.JSONConfig{MessageKey: "message1"},
+			ExpectedText: "",
+			ExpectedMap:  common.MapStr{"message": "test", "value": float64(1)},
+		},
+		{
+			Text:         `{"message": "test", "value": 1}`,
+			Config:       config.JSONConfig{MessageKey: "value"},
+			ExpectedText: "",
+			ExpectedMap:  common.MapStr{"message": "test", "value": float64(1)},
+		},
+		{
+			Text:         `{"message": "test", "value": "1"}`,
+			Config:       config.JSONConfig{MessageKey: "value"},
+			ExpectedText: "1",
+			ExpectedMap:  common.MapStr{"message": "test", "value": "1"},
+		},
+		{
+			// in case of JSON decoding errors, the text is passed as is
+			Text:         `{"message": "test", "value": "`,
+			Config:       config.JSONConfig{MessageKey: "value"},
+			ExpectedText: `{"message": "test", "value": "`,
+			ExpectedMap:  nil,
+		},
+		{
+			// Add key error helps debugging this
+			Text:         `{"message": "test", "value": "`,
+			Config:       config.JSONConfig{MessageKey: "value", AddErrorKey: true},
+			ExpectedText: `{"message": "test", "value": "`,
+			ExpectedMap:  common.MapStr{"json_error": "Error decoding JSON: unexpected end of JSON input"},
+		},
+		{
+			// If the text key is not found, put an error
+			Text:         `{"message": "test", "value": "1"}`,
+			Config:       config.JSONConfig{MessageKey: "hello", AddErrorKey: true},
+			ExpectedText: ``,
+			ExpectedMap:  common.MapStr{"message": "test", "value": "1", "json_error": "Key 'hello' not found"},
+		},
+		{
+			// If the text key is found, but not a string, put an error
+			Text:         `{"message": "test", "value": 1}`,
+			Config:       config.JSONConfig{MessageKey: "value", AddErrorKey: true},
+			ExpectedText: ``,
+			ExpectedMap:  common.MapStr{"message": "test", "value": float64(1), "json_error": "Value of key 'value' is not a string"},
+		},
+		{
+			// Without a text key, simple return the json and an empty text
+			Text:         `{"message": "test", "value": 1}`,
+			Config:       config.JSONConfig{AddErrorKey: true},
+			ExpectedText: ``,
+			ExpectedMap:  common.MapStr{"message": "test", "value": float64(1)},
+		},
+	}
+
+	for _, test := range tests {
+
+		var p JSONProcessor
+		p.cfg = &test.Config
+		text, map_ := p.decodeJSON([]byte(test.Text))
+		assert.Equal(t, test.ExpectedText, string(text))
+		assert.Equal(t, test.ExpectedMap, map_)
+	}
 }

--- a/filebeat/harvester/util.go
+++ b/filebeat/harvester/util.go
@@ -5,21 +5,22 @@ import (
 	"time"
 
 	"github.com/elastic/beats/filebeat/harvester/processor"
+	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 )
 
 // readLine reads a full line into buffer and returns it.
 // In case of partial lines, readLine does return and error and en empty string
 // This could potentialy be improved / replaced by https://github.com/elastic/beats/libbeat/tree/master/common/streambuf
-func readLine(reader processor.LineProcessor) (time.Time, string, int, error) {
+func readLine(reader processor.LineProcessor) (time.Time, string, int, common.MapStr, error) {
 	l, err := reader.Next()
 
 	// Full line read to be returned
 	if l.Bytes != 0 && err == nil {
-		return l.Ts, string(l.Content), l.Bytes, err
+		return l.Ts, string(l.Content), l.Bytes, l.Fields, err
 	}
 
-	return time.Time{}, "", 0, err
+	return time.Time{}, "", 0, nil, err
 }
 
 // InitRegexps initializes a list of compiled regular expressions.

--- a/filebeat/input/file.go
+++ b/filebeat/input/file.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/elastic/beats/filebeat/config"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 )
@@ -26,6 +27,8 @@ type FileEvent struct {
 	Bytes        int
 	Text         *string
 	Fileinfo     *os.FileInfo
+	JSONFields   common.MapStr
+	JSONConfig   *config.JSONConfig
 }
 
 type FileState struct {
@@ -55,15 +58,44 @@ func (f *FileEvent) GetState() *FileState {
 	return state
 }
 
+// mergeJSONFields writes the JSON fields in the event map,
+// respecting the KeysUnderRoot and OverwriteKeys configuration options.
+// If MessageKey is defined, the Text value from the event always
+// takes precedence.
+func mergeJSONFields(f *FileEvent, event common.MapStr) {
+
+	// The message key might have been modified by multiline
+	if len(f.JSONConfig.MessageKey) > 0 && f.Text != nil {
+		f.JSONFields[f.JSONConfig.MessageKey] = *f.Text
+	}
+
+	if f.JSONConfig.KeysUnderRoot {
+		for k, v := range f.JSONFields {
+			if f.JSONConfig.OverwriteKeys {
+				event[k] = v
+			} else if _, exists := event[k]; !exists {
+				event[k] = v
+			}
+		}
+	} else {
+		event["json"] = f.JSONFields
+	}
+}
+
 func (f *FileEvent) ToMapStr() common.MapStr {
 	event := common.MapStr{
 		common.EventMetadataKey: f.EventMetadata,
 		"@timestamp":            common.Time(f.ReadTime),
 		"source":                f.Source,
 		"offset":                f.Offset, // Offset here is the offset before the starting char.
-		"message":               f.Text,
 		"type":                  f.DocumentType,
 		"input_type":            f.InputType,
+	}
+
+	if f.JSONConfig != nil && len(f.JSONFields) > 0 {
+		mergeJSONFields(f, event)
+	} else {
+		event["message"] = f.Text
 	}
 
 	return event

--- a/filebeat/tests/files/logs/docker.log
+++ b/filebeat/tests/files/logs/docker.log
@@ -1,0 +1,21 @@
+{"log":"Fetching main repository github.com/elastic/beats...\n","stream":"stdout","time":"2016-03-02T22:58:51.338462311Z"}
+{"log":"Fetching dependencies...\n","stream":"stdout","time":"2016-03-02T22:59:04.609292428Z"}
+{"log":"Execute /scripts/packetbeat_before_build.sh\n","stream":"stdout","time":"2016-03-02T22:59:04.617434682Z"}
+{"log":"patching file vendor/github.com/tsg/gopacket/pcap/pcap.go\n","stream":"stdout","time":"2016-03-02T22:59:04.626534779Z"}
+{"log":"cp etc/packetbeat.template.json /build/packetbeat.template.json\n","stream":"stdout","time":"2016-03-02T22:59:04.639782988Z"}
+{"log":"# linux\n","stream":"stdout","time":"2016-03-02T22:59:04.646276053Z"}
+{"log":"cp packetbeat.yml /build/packetbeat-linux.yml\n","stream":"stdout","time":"2016-03-02T22:59:04.647847045Z"}
+{"log":"# binary\n","stream":"stdout","time":"2016-03-02T22:59:04.653740138Z"}
+{"log":"cp packetbeat.yml /build/packetbeat-binary.yml\n","stream":"stdout","time":"2016-03-02T22:59:04.655979016Z"}
+{"log":"# darwin\n","stream":"stdout","time":"2016-03-02T22:59:04.661181197Z"}
+{"log":"cp packetbeat.yml /build/packetbeat-darwin.yml\n","stream":"stdout","time":"2016-03-02T22:59:04.662859769Z"}
+{"log":"sed -i.bk 's/device: any/device: en0/' /build/packetbeat-darwin.yml\n","stream":"stdout","time":"2016-03-02T22:59:04.66649744Z"}
+{"log":"rm /build/packetbeat-darwin.yml.bk\n","stream":"stdout","time":"2016-03-02T22:59:04.701199002Z"}
+{"log":"# win\n","stream":"stdout","time":"2016-03-02T22:59:04.705067809Z"}
+{"log":"cp packetbeat.yml /build/packetbeat-win.yml\n","stream":"stdout","time":"2016-03-02T22:59:04.706629907Z"}
+{"log":"sed -i.bk 's/device: any/device: 0/' /build/packetbeat-win.yml\n","stream":"stdout","time":"2016-03-02T22:59:04.711993313Z"}
+{"log":"rm /build/packetbeat-win.yml.bk\n","stream":"stdout","time":"2016-03-02T22:59:04.757913979Z"}
+{"log":"Compiling for windows/amd64...\n","stream":"stdout","time":"2016-03-02T22:59:04.761895467Z"}
+{"log":"Compiling for windows/386...\n","stream":"stdout","time":"2016-03-02T22:59:29.481736885Z"}
+{"log":"Compiling for darwin/amd64...\n","stream":"stdout","time":"2016-03-02T22:59:55.205334574Z"}
+{"log":"Moving binaries to host...\n","stream":"stdout","time":"2016-03-02T23:00:15.140397826Z"}

--- a/filebeat/tests/files/logs/docker_multiline.log
+++ b/filebeat/tests/files/logs/docker_multiline.log
@@ -1,0 +1,5 @@
+{"log":"[log] The following are log messages\n","stream":"stdout","time":"2016-03-02T22:58:51.338462311Z"}
+{"log":"[log] This one is\n","stream":"stdout","time":"2016-03-02T22:58:51.338462311Z"}
+{"log":" on multiple\n","stream":"stdout","time":"2016-03-02T22:58:51.338462311Z"}
+{"log":" lines","stream":"stdout","time":"2016-03-02T22:58:51.338462311Z"}
+{"log":"[log] In total there should be 3 events\n","stream":"stdout","time":"2016-03-02T22:58:51.338462311Z"}

--- a/filebeat/tests/files/logs/json.log
+++ b/filebeat/tests/files/logs/json.log
@@ -1,0 +1,3 @@
+{"host": "test", "timestamp": "2016-02-25 13:00:00", "module": "libbeat", "message": "hello json world"}
+{"host": "test", "timestamp": "2016-02-25 13:00:01", "module": "topbeat", "message": "hello topbeat"}
+{"host": "test", "timestamp": "2016-02-25 13:00:01", "module": "filebeat", "message": "hello filebeat"}

--- a/filebeat/tests/files/logs/json_override.log
+++ b/filebeat/tests/files/logs/json_override.log
@@ -1,0 +1,1 @@
+{"source": "hello", "message": "test source"}

--- a/filebeat/tests/system/config/filebeat.yml.j2
+++ b/filebeat/tests/system/config/filebeat.yml.j2
@@ -44,6 +44,14 @@ filebeat:
 
       max_bytes: {{ max_bytes|default(10485760) }}
 
+      {% if json %}
+      json:
+        {% if json.message_key %}message_key: {{json.message_key}}{% endif %}
+        {% if json.keys_under_root %}keys_under_root: true{% endif %}
+        {% if json.overwrite_keys %}overwrite_keys: true{% endif %}
+        {% if json.add_error_key %}add_error_key: true{% endif %}
+      {% endif %}
+
       {% if multiline %}
       multiline:
         pattern: {{pattern}}

--- a/filebeat/tests/system/test_json.py
+++ b/filebeat/tests/system/test_json.py
@@ -1,0 +1,168 @@
+from filebeat import BaseTest
+import os
+
+"""
+Tests for the JSON decoding functionality.
+"""
+
+
+class Test(BaseTest):
+    def test_docker_logs(self):
+        """
+        Should be able to interpret docker logs.
+        """
+        self.render_config_template(
+            path=os.path.abspath(self.working_dir) + "/log/*",
+            json=dict(message_key="log")
+        )
+
+        os.mkdir(self.working_dir + "/log/")
+        self.copy_files(["logs/docker.log"],
+                        source_dir="../files",
+                        target_dir="log")
+
+        proc = self.start_beat()
+        self.wait_until(
+            lambda: self.output_has(lines=21),
+            max_timeout=10)
+
+        proc.check_kill_and_wait()
+
+        output = self.read_output()
+        assert len(output) == 21
+        assert all("json.log" in o for o in output)
+        assert all("json.time" in o for o in output)
+        assert all(o["json.stream"] == "stdout" for o in output)
+
+    def test_docker_logs_filtering(self):
+        """
+        Should be able to do line filtering on docker logs.
+        """
+        self.render_config_template(
+            path=os.path.abspath(self.working_dir) + "/log/*",
+            json=dict(message_key="log", keys_under_root=True),
+            exclude_lines=["windows"]
+        )
+
+        os.mkdir(self.working_dir + "/log/")
+        self.copy_files(["logs/docker.log"],
+                        source_dir="../files",
+                        target_dir="log")
+
+        proc = self.start_beat()
+        self.wait_until(
+            lambda: self.output_has(lines=19),
+            max_timeout=10)
+
+        proc.check_kill_and_wait()
+
+        output = self.read_output()
+        assert len(output) == 19
+
+        assert all("log" in o for o in output)
+        assert all("time" in o for o in output)
+        assert all(o["stream"] == "stdout" for o in output)
+        assert all("windows" not in o["log"] for o in output)
+
+    def test_docker_logs_multiline(self):
+        """
+        Should be able to do multiline on docker logs.
+        """
+        self.render_config_template(
+            path=os.path.abspath(self.working_dir) + "/log/*",
+            json=dict(message_key="log", keys_under_root=True),
+            multiline=True,
+            pattern="^\[log\]",
+            match="after",
+            negate="true"
+        )
+
+        os.mkdir(self.working_dir + "/log/")
+        self.copy_files(["logs/docker_multiline.log"],
+                        source_dir="../files",
+                        target_dir="log")
+
+        proc = self.start_beat()
+        self.wait_until(
+            lambda: self.output_has(lines=3),
+            max_timeout=10)
+
+        proc.check_kill_and_wait()
+
+        output = self.read_output()
+        assert len(output) == 3
+
+        assert all("time" in o for o in output)
+        assert all("log" in o for o in output)
+        assert all("message" not in o for o in output)
+        assert all(o["stream"] == "stdout" for o in output)
+        assert output[1]["log"] == \
+            "[log] This one is\n on multiple\n lines"
+
+    def test_simple_json_overwrite(self):
+        """
+        Should be able to overwrite keys when requested.
+        """
+        self.render_config_template(
+            path=os.path.abspath(self.working_dir) + "/log/*",
+            json=dict(
+                message_key="message",
+                keys_under_root=True,
+                overwrite_keys=True),
+            exclude_lines=["windows"]
+        )
+
+        os.mkdir(self.working_dir + "/log/")
+        self.copy_files(["logs/json_override.log"],
+                        source_dir="../files",
+                        target_dir="log")
+
+        proc = self.start_beat()
+        self.wait_until(
+            lambda: self.output_has(lines=1),
+            max_timeout=10)
+
+        proc.check_kill_and_wait()
+
+        output = self.read_output()[0]
+        assert output["source"] == "hello"
+        assert output["message"] == "test source"
+
+    def test_config_no_msg_key_filtering(self):
+        """
+        Should raise an error if line filtering and JSON are defined,
+        but the message key is not defined.
+        """
+        self.render_config_template(
+            path=os.path.abspath(self.working_dir) + "/log/*",
+            json=dict(
+                keys_under_root=True),
+            exclude_lines=["windows"]
+        )
+
+        proc = self.start_beat()
+        status = proc.wait()
+        assert status != 0
+        assert self.log_contains("When using the JSON decoder and line" +
+                                 " filtering together, you need to specify" +
+                                 " a message_key value")
+
+    def test_config_no_msg_key_multiline(self):
+        """
+        Should raise an error if line filtering and JSON are defined,
+        but the message key is not defined.
+        """
+        self.render_config_template(
+            path=os.path.abspath(self.working_dir) + "/log/*",
+            json=dict(
+                keys_under_root=True),
+            multiline=True,
+            pattern="^["
+        )
+
+        proc = self.start_beat()
+        status = proc.wait()
+        assert status != 0
+        assert self.log_contains("When using the JSON decoder and multiline" +
+                                 " together, you need to specify a" +
+                                 " message_key value")


### PR DESCRIPTION
I tried another option for #1069. The main change is that JSON processing now happens before multiline, so the order is:

* Encoding decoding
* JSON decoding
* Multiline
* Line/file filtering
* Add custom fields
* Generic filtering

The main advantage of this over #1069 is that it supports uses cases like Docker where normal log lines are wrapped in JSON. It should also work fine for most of the structured logging use cases. 

Here is a sample config:
```
      json:
        message_key: log
        keys_under_root: true
        overwrite_keys: true
```

The idea is that when configuring the JSON decoder, you can select a "message" key that will be used in the next stages (multiline and line filtering). If you don't choose a "message" key but still try to configure line filtering or multiline, you will get a configuration error.

Compared to the #1069, this is more complex and contains a bit more corner cases (e.g. what happens if the text key is not a string) but the code is still simple enough I think.

This still requires the JSON objects to be one per line, but I think that's the safer assumption to make anyway (see comment from #1069). 