### PR TITLE
Prospector and Harvester Cleanup

### DIFF
--- a/filebeat/crawler/prospector_stdin.go
+++ b/filebeat/crawler/prospector_stdin.go
@@ -34,15 +34,14 @@ func (p ProspectorStdin) Init() {
 	p.started = false
 }
 
-func (prospector ProspectorStdin) Run() {
+func (p ProspectorStdin) Run() {
 
 	// Make sure stdin harvester is only started once
-	if !prospector.started {
-		prospector.harvester.Start()
+	if !p.started {
+		p.harvester.Start()
 	}
 
 	// Wait time during endless loop
 	oneSecond, _ := time.ParseDuration("1s")
 	time.Sleep(oneSecond)
-
 }

--- a/filebeat/crawler/registrar.go
+++ b/filebeat/crawler/registrar.go
@@ -181,7 +181,7 @@ func (r *Registrar) fetchState(filePath string, fileInfo os.FileInfo) (int64, bo
 		logp.Info("Not resuming rotated file: %s", filePath)
 	}
 
-	logp.Info("prospector", "New file. Start reading from the beginning: %s", filePath)
+	logp.Info("New file. Start reading from the beginning: %s", filePath)
 
 	// New file so just start from the beginning
 	return 0, false

--- a/filebeat/harvester/log.go
+++ b/filebeat/harvester/log.go
@@ -251,6 +251,3 @@ func (h *Harvester) initFileOffset(file *os.File) error {
 
 	return err
 }
-
-func (h *Harvester) Stop() {
-}

--- a/filebeat/harvester/util.go
+++ b/filebeat/harvester/util.go
@@ -12,16 +12,14 @@ import (
 // In case of partial lines, readLine does return and error and en empty string
 // This could potentialy be improved / replaced by https://github.com/elastic/beats/libbeat/tree/master/common/streambuf
 func readLine(reader processor.LineProcessor) (time.Time, string, int, error) {
-	for {
-		l, err := reader.Next()
+	l, err := reader.Next()
 
-		// Full line read to be returned
-		if l.Bytes != 0 && err == nil {
-			return l.Ts, string(l.Content), l.Bytes, err
-		}
-
-		return time.Time{}, "", 0, err
+	// Full line read to be returned
+	if l.Bytes != 0 && err == nil {
+		return l.Ts, string(l.Content), l.Bytes, err
 	}
+
+	return time.Time{}, "", 0, err
 }
 
 // InitRegexps initializes a list of compiled regular expressions.


### PR DESCRIPTION
This PR simplifies https://github.com/elastic/beats/pull/964 by already applying the non related parts.

* Remove unnecessary for loop in readline
* Introduce uuid for harvester to be able to uniquely track and identify harvesters in the future