### PR TITLE
Move host handling to MetricSet from MetricSeter

### DIFF
--- a/metricbeat/etc/beat.yml
+++ b/metricbeat/etc/beat.yml
@@ -1,17 +1,25 @@
 metricbeat:
   modules:
+
+    # Apache Module
     - module: apache
       metricsets: ["status"]
       hosts: ["http://127.0.0.1/"]
       period: 1s
       enabled: true
+
+    # Redis Module
     - module: redis
       metricsets: ["info"]
       period: 1s
       hosts: ["127.0.0.1:6379"]
       enabled: true
-      network: tcp
-      maxconn: 10
+
+      # Network type to be used for redis connection. Default: tcp
+      #network: tcp
+
+      # Max number of concurrent connections. Default: 10
+      #maxconn: 10
       fields:
         datacenter: west
       #filter: ...

--- a/metricbeat/helper/interfacer.go
+++ b/metricbeat/helper/interfacer.go
@@ -24,8 +24,11 @@ type MetricSeter interface {
 	// and the module.
 	Setup(ms *MetricSet) error
 
-	// Method to periodically fetch new events
-	Fetch(ms *MetricSet) ([]common.MapStr, error)
+	// Method to periodically fetch a new event from a host
+	// Fetch is called for each host. In case where host does not exist, it can be transferred
+	// differently in the setup to have a different meaning. An example here is for filesystem
+	// of topbeat, where each host could be a filesystem.
+	Fetch(ms *MetricSet, host string) (common.MapStr, error)
 }
 
 // Interface for each module

--- a/metricbeat/helper/metricset.go
+++ b/metricbeat/helper/metricset.go
@@ -1,6 +1,8 @@
 package helper
 
 import (
+	"time"
+
 	"github.com/elastic/beats/libbeat/common"
 )
 
@@ -29,14 +31,71 @@ func NewMetricSet(name string, new func() MetricSeter, module *Module) (*MetricS
 }
 
 func (m *MetricSet) Setup() error {
-	// TODO: Call fetch for each host if hosts are set.
+
+	// In case no hosts are set, set at least an empty string
+	// This ensure that also for metricsets where host is not used
+	// That fetch is at least called once
+	if len(m.Config.Hosts) == 0 {
+		m.Config.Hosts = append(m.Config.Hosts, "")
+	}
+
 	// Host is a first class citizen and does not have to be handled by the metricset itself
 	return m.MetricSeter.Setup(m)
 }
 
 // RunMetric runs the given metricSet and returns the event
-func (m *MetricSet) Fetch() ([]common.MapStr, error) {
-	// TODO: Call fetch for each host if hosts are set.
-	// Host is a first class citizen and does not have to be handled by the metricset itself
-	return m.MetricSeter.Fetch(m)
+func (m *MetricSet) Fetch() error {
+
+	for _, host := range m.Config.Hosts {
+		// TODO Improve fetching in go routing -> how are go routines stopped if they take too long? - @ruflin,20160314
+		m.Module.wg.Add(1)
+		go func(h string) {
+			defer m.Module.wg.Done()
+
+			event, err := m.MetricSeter.Fetch(m, h)
+
+			if err != nil {
+				event["error"] = err
+			}
+			event = m.createEvent(event)
+			m.Module.Publish <- event
+		}(host)
+	}
+	return nil
+}
+
+func (m *MetricSet) createEvent(event common.MapStr) common.MapStr {
+
+	timestamp := common.Time(time.Now())
+
+	// Default name is empty, means it will be metricbeat
+	indexName := ""
+	typeName := "metricsets"
+
+	// Set meta information dynamic if set
+	indexName = getIndex(event, indexName)
+	typeName = getType(event, typeName)
+	timestamp = getTimestamp(event, timestamp)
+
+	// Each metricset has a unique eventfieldname to prevent type conflicts
+	eventFieldName := m.Module.name + "-" + m.Name
+
+	// TODO: Add fields_under_root option for "metrics"?
+	event = common.MapStr{
+		"type":                  typeName,
+		eventFieldName:          event,
+		"metricset":             m.Name,
+		"module":                m.Module.name,
+		"@timestamp":            timestamp,
+		common.EventMetadataKey: m.Config.EventMetadata,
+	}
+
+	// Overwrite index in case it is set
+	if indexName != "" {
+		event["beat"] = common.MapStr{
+			"index": indexName,
+		}
+	}
+
+	return event
 }

--- a/metricbeat/helper/metricset_test.go
+++ b/metricbeat/helper/metricset_test.go
@@ -15,11 +15,11 @@ func TestMetricSeterState(t *testing.T) {
 	metricSet, err := NewMetricSet("mockmetricset", NewMockMetricSeter, module)
 	assert.NoError(t, err)
 
-	events, _ := metricSet.MetricSeter.Fetch(metricSet)
-	assert.Equal(t, 1, events[0]["counter"])
+	event, _ := metricSet.MetricSeter.Fetch(metricSet, "")
+	assert.Equal(t, 1, event["counter"])
 
-	events, _ = metricSet.MetricSeter.Fetch(metricSet)
-	assert.Equal(t, 2, events[0]["counter"])
+	event, _ = metricSet.MetricSeter.Fetch(metricSet, "")
+	assert.Equal(t, 2, event["counter"])
 }
 
 // TestMetricSetTwoInstances makes sure that in case of two different MetricSet instance, MetricSeter don't share state
@@ -31,11 +31,11 @@ func TestMetricSetTwoInstances(t *testing.T) {
 	assert.NoError(t, err1)
 	assert.NoError(t, err2)
 
-	events, _ := metricSet1.MetricSeter.Fetch(metricSet1)
-	assert.Equal(t, 1, events[0]["counter"], 1)
+	event, _ := metricSet1.MetricSeter.Fetch(metricSet1, "")
+	assert.Equal(t, 1, event["counter"])
 
-	events, _ = metricSet2.MetricSeter.Fetch(metricSet2)
-	assert.Equal(t, 1, events[0]["counter"], 1)
+	event, _ = metricSet2.MetricSeter.Fetch(metricSet2, "")
+	assert.Equal(t, 1, event["counter"])
 }
 
 /*** Mock tests objects ***/
@@ -55,14 +55,12 @@ func (m *MockMetricSeter) Setup(ms *MetricSet) error {
 	return nil
 }
 
-func (m *MockMetricSeter) Fetch(ms *MetricSet) (events []common.MapStr, err error) {
+func (m *MockMetricSeter) Fetch(ms *MetricSet, host string) (event common.MapStr, err error) {
 	m.counter += 1
 
-	event := common.MapStr{
+	event = common.MapStr{
 		"counter": m.counter,
 	}
 
-	events = append(events, event)
-
-	return events, nil
+	return event, nil
 }

--- a/metricbeat/metricbeat.yml
+++ b/metricbeat/metricbeat.yml
@@ -1,17 +1,25 @@
 metricbeat:
   modules:
+
+    # Apache Module
     - module: apache
       metricsets: ["status"]
       hosts: ["http://127.0.0.1/"]
       period: 1s
       enabled: true
+
+    # Redis Module
     - module: redis
       metricsets: ["info"]
       period: 1s
       hosts: ["127.0.0.1:6379"]
       enabled: true
-      network: tcp
-      maxconn: 10
+
+      # Network type to be used for redis connection. Default: tcp
+      #network: tcp
+
+      # Max number of concurrent connections. Default: 10
+      #maxconn: 10
       fields:
         datacenter: west
       #filter: ...

--- a/metricbeat/module/mysql/status/status.go
+++ b/metricbeat/module/mysql/status/status.go
@@ -33,26 +33,21 @@ func (m *MetricSeter) Setup(ms *helper.MetricSet) error {
 }
 
 // Fetches status messages from mysql hosts
-func (m *MetricSeter) Fetch(ms *helper.MetricSet) (events []common.MapStr, err error) {
+func (m *MetricSeter) Fetch(ms *helper.MetricSet, host string) (event common.MapStr, err error) {
 
-	// Load status for all hosts and add it to events
-	for _, host := range ms.Config.Hosts {
-		db, err := m.getConnection(host)
-		if err != nil {
-			logp.Err("MySQL conenction error: %s", err)
-		}
-
-		status, err := m.loadStatus(db)
-
-		if err != nil {
-			return nil, err
-		}
-
-		event := eventMapping(status)
-		events = append(events, event)
+	db, err := m.getConnection(host)
+	if err != nil {
+		logp.Err("MySQL conenction error: %s", err)
 	}
 
-	return events, nil
+	status, err := m.loadStatus(db)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return eventMapping(status), nil
+
 }
 
 // getConnection returns the connection object for the given dsn

--- a/metricbeat/module/mysql/status/status_test.go
+++ b/metricbeat/module/mysql/status/status_test.go
@@ -23,14 +23,14 @@ func TestFetch(t *testing.T) {
 	assert.NoError(t, msErr)
 
 	// Load events
-	events, err := ms.MetricSeter.Fetch(ms)
+	event, err := ms.MetricSeter.Fetch(ms, module.Config.Hosts[0])
 	assert.NoError(t, err)
 
 	// Check event fields
-	connections := events[0]["Connections"].(int)
-	openTables := events[0]["Open_tables"].(int)
-	openFiles := events[0]["Open_files"].(int)
-	openStreams := events[0]["Open_streams"].(int)
+	connections := event["Connections"].(int)
+	openTables := event["Open_tables"].(int)
+	openFiles := event["Open_files"].(int)
+	openStreams := event["Open_streams"].(int)
 
 	assert.True(t, connections > 0)
 	assert.True(t, openTables > 0)

--- a/metricbeat/module/redis/info/info.go
+++ b/metricbeat/module/redis/info/info.go
@@ -151,15 +151,20 @@ func (m *MetricSeter) Setup(ms *helper.MetricSet) error {
 
 	// Additional configuration options
 	config := struct {
+		// TODO: Introduce default value for network
 		Network string `config:"network"`
 		MaxConn int    `config:"maxconn"`
-	}{}
+	}{
+		Network: "tcp",
+		MaxConn: 10,
+	}
 
 	if err := ms.Module.ProcessConfig(&config); err != nil {
 		return err
 	}
 
 	for _, host := range ms.Config.Hosts {
+
 		// Set up redis pool
 		redisPool := rd.NewPool(func() (rd.Conn, error) {
 			c, err := rd.Dial(config.Network, host)
@@ -175,19 +180,16 @@ func (m *MetricSeter) Setup(ms *helper.MetricSet) error {
 		// TODO: add AUTH
 		m.redisPools[host] = redisPool
 	}
+
 	return nil
 }
 
-func (m *MetricSeter) Fetch(ms *helper.MetricSet) (events []common.MapStr, err error) {
+func (m *MetricSeter) Fetch(ms *helper.MetricSet, host string) (events common.MapStr, err error) {
 
-	for _, host := range ms.Config.Hosts {
-		// Fetch default INFO
-		info := m.fetchRedisStats(host, "default")
-		event := eventMapping(info)
-		events = append(events, event)
-	}
-
-	return events, nil
+	// Fetch default INFO
+	info := m.fetchRedisStats(host, "default")
+	event := eventMapping(info)
+	return event, nil
 }
 
 // fetchRedisStats returns a map of requested stats


### PR DESCRIPTION
This simplifies the handling of multiple hosts for a metricset as the iteration of hosts is automatically done.

Following changes were done:

* MetricSeter interface was updated to also pass host
* Error handling was improved
* Each metric fetching is now happening in a go routing to no block each other
* Event generation was moved to metricset. This improves the error handling
* Channel to send events to Module was introduced. This could be used for example for filtering
* Adjust tests to fit new model