### PR TITLE
Add doc about loading templates to all Beats

### DIFF
--- a/filebeat/docs/getting-started.asciidoc
+++ b/filebeat/docs/getting-started.asciidoc
@@ -159,43 +159,8 @@ include::../../libbeat/docs/shared-logstash-config.asciidoc[]
 [[filebeat-template]]
 === Step 4: Loading the Index Template in Elasticsearch
 
-Before starting Filebeat, you need to load the
-http://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates.html[index
-template], which lets Elasticsearch know which fields should be analyzed
-in which way.
-
-The recommended template file is installed by the Filebeat packages. Load it with the
-following command:
-
-*deb or rpm:*
-
-[source,shell]
-----------------------------------------------------------------------
-curl -XPUT 'http://localhost:9200/_template/filebeat?pretty' -d@/etc/filebeat/filebeat.template.json
-----------------------------------------------------------------------
-
-*mac:*
-
-["source","sh",subs="attributes,callouts"]
-----------------------------------------------------------------------
-cd filebeat-{version}-darwin
-curl -XPUT 'http://localhost:9200/_template/filebeat?pretty' -d@filebeat.template.json
-----------------------------------------------------------------------
-
-*win:*
-
-["source","sh",subs="attributes,callouts"]
-----------------------------------------------------------------------
-PS C:\Program Files\Filebeat> Invoke-WebRequest -Method Put -InFile filebeat.template.json -Uri http://localhost:9200/_template/filebeat?pretty
-----------------------------------------------------------------------
-
-where `localhost:9200` is the IP and port where Elasticsearch is listening.
-
-NOTE: If you've already used Filebeat to index data into Elasticsearch,
-the index may contain old documents. After you load the index template,
-you can delete the old documents from `filebeat-*` to force Kibana to look
-at the newest documents. Use this command:
-`curl -XDELETE 'http://localhost:9200/filebeat-*'`.
+:allplatforms:
+include::../../libbeat/docs/shared-template-load.asciidoc[]
 
 === Step 5: Starting Filebeat
 

--- a/libbeat/docs/shared-template-load.asciidoc
+++ b/libbeat/docs/shared-template-load.asciidoc
@@ -1,0 +1,103 @@
+//////////////////////////////////////////////////////////////////////////
+//// This content is shared by all Elastic Beats. Make sure you keep the
+//// descriptions here generic enough to work for all Beats that include
+//// this file. When using cross references, make sure that the cross
+//// references resolve correctly for any files that include this one.
+//// Use the appropriate variables defined in the index.asciidoc file to
+//// resolve Beat names: beatname_uc and beatname_lc
+//// Use the following include to pull this content into a doc file:
+//// include::../../libbeat/docs/shared-template-load.asciidoc[]
+//// If you want to include conditional content, you also need to
+//// add the following doc attribute definition  before the
+//// include statement so that you have:
+//// :allplatforms:
+//// include::../../libbeat/docs/shared-template-load.asciidoc[]
+//// This content must be embedded underneath a level 3 heading.
+//////////////////////////////////////////////////////////////////////////
+
+
+Before starting {beatname_uc}, you need to load the
+http://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates.html[index
+template], which lets Elasticsearch know which fields should be analyzed
+in which way.
+
+The recommended template file is installed by the {beatname_uc} packages. You can either configure 
+{beatname_uc} to load the template automatically, or you can run a shell script to load the template:
+
+* <<load-template-auto>>
+* <<load-template-shell>>
+
+[[load-template-auto]]
+==== Configuring {beatname_uc} to Load the Template
+
+To configure {beatname_uc} to load the template, you must enable the elasticsearch output. In the
+{beatname_uc} configuration file, uncomment the template part under elasticsearch output. By default
+the template is named {beatname_lc}. Adjust the path to your template file. 
+
+["source","yaml",subs="attributes,callouts"]
+----------------------------------------------------------------------
+output:
+  elasticsearch:
+    hosts: ["localhost:9200"]
+
+    # A template is used to set the mapping in Elasticsearch
+    # By default template loading is disabled and no template is loaded.
+    # These settings can be adjusted to load your own template or overwrite existing ones
+    template:
+
+      # Template name. By default the template name is {beatname_lc}.
+      #name: "{beatname_lc}"
+
+      # Path to template file
+      path: "{beatname_lc}.template.json"
+
+      # Overwrite existing template
+      #overwrite: false
+----------------------------------------------------------------------
+
+The template is loaded when you start {beatname_uc}. By default, if a template
+already exists in the index, it is not overwritten. To overwrite an existing template,
+set `overwrite: true` in the configuration file.
+
+[[load-template-shell]]
+==== Running a Shell Script to Load the Template
+
+You can load the template by running the following command:
+
+ifdef::allplatforms[]
+
+*deb or rpm:*
+
+["source","sh",subs="attributes,callouts"]
+----------------------------------------------------------------------
+curl -XPUT 'http://localhost:9200/_template/{beatname_lc}' -d@/etc/{beatname_lc}/{beatname_lc}.template.json
+----------------------------------------------------------------------
+
+*mac:*
+
+["source","sh",subs="attributes,callouts"]
+----------------------------------------------------------------------
+cd {beatname_lc}-{version}-darwin
+curl -XPUT 'http://localhost:9200/_template/{beatname_lc}' -d@{beatname_lc}.template.json
+----------------------------------------------------------------------
+
+endif::allplatforms[]
+
+*win:*
+
+["source","sh",subs="attributes,callouts"]
+----------------------------------------------------------------------
+PS C:\Program Files{backslash}{beatname_uc}> Invoke-WebRequest -Method Put -InFile {beatname_lc}.template.json -Uri http://localhost:9200/_template/{beatname_lc}?pretty
+----------------------------------------------------------------------
+
+where `localhost:9200` is the IP and port where Elasticsearch is listening.
+
+NOTE: If you've already used {beatname_uc} to index data into Elasticsearch,
+the index may contain old documents. After you load the index template,
+you can delete the old documents from {beatname_lc}-* to force Kibana to look
+at the newest documents. Use this command:
+
+["source","sh",subs="attributes,callouts"]
+----------------------------------------------------------------------
+curl -XDELETE 'http://localhost:9200/{beatname_lc}-*'
+----------------------------------------------------------------------

--- a/packetbeat/docs/gettingstarted.asciidoc
+++ b/packetbeat/docs/gettingstarted.asciidoc
@@ -194,43 +194,8 @@ include::../../libbeat/docs/shared-logstash-config.asciidoc[]
 [[packetbeat-template]]
 === Step 4: Loading the Index Template in Elasticsearch
 
-Before starting Packetbeat, you need to load the
-http://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates.html[index
-template], which lets Elasticsearch know which fields should be analyzed
-in which way.
-
-The recommended template file is installed by the Packetbeat packages. Load it with the
-following command:
-
-*deb or rpm:*
-
-[source,shell]
-----------------------------------------------------------------------
-curl -XPUT 'http://localhost:9200/_template/packetbeat' -d@/etc/packetbeat/packetbeat.template.json
-----------------------------------------------------------------------
-
-*mac:*
-
-["source","sh",subs="attributes,callouts"]
-----------------------------------------------------------------------
-cd packetbeat-{version}-darwin
-curl -XPUT 'http://localhost:9200/_template/packetbeat' -d@packetbeat.template.json
-----------------------------------------------------------------------
-
-*win:*
-
-["source","sh",subs="attributes,callouts"]
-----------------------------------------------------------------------
-PS C:\Program Files\Packetbeat> Invoke-WebRequest -Method Put -InFile packetbeat.template.json -Uri http://localhost:9200/_template/packetbeat?pretty
-----------------------------------------------------------------------
-
-where `localhost:9200` is the IP and port where Elasticsearch is listening.
-
-NOTE: If you've already used Packetbeat to index data into Elasticsearch,
-the index may contain old documents. After you load the index template,
-you can delete the old documents from `packetbeat-*` to force Kibana to look
-at the newest documents. Use this command:
-`curl -XDELETE 'http://localhost:9200/packetbeat-*'`.
+:allplatforms:
+include::../../libbeat/docs/shared-template-load.asciidoc[]
 
 === Step 5: Starting Packetbeat
 

--- a/topbeat/docs/gettingstarted.asciidoc
+++ b/topbeat/docs/gettingstarted.asciidoc
@@ -139,78 +139,8 @@ include::../../libbeat/docs/shared-logstash-config.asciidoc[]
 [[topbeat-template]]
 === Step 4: Loading the Index Template in Elasticsearch
 
-Before starting Topbeat, you need to load the
-http://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates.html[index
-template], which lets Elasticsearch know which fields should be analyzed
-in which way.
-
-The recommended template file is installed by the Topbeat packages. It can be either loaded by the beat
-or through a bash / powershell script.
-
-==== Load Template with Beat
-
-To load the template through your beat, the elasticsearch output must be enabled. In your configuration file,
-uncomment the template part under elasticsearch output. By default the template is named the same as the beat.
-Adjust the path to your template file. In case a template already exists in the index, it is not overwritten.
-To overwrite an existing template, enable `overwrite: true`.
-
-[source,yaml]
-----------------------------------------------------------------------
-output:
-  elasticsearch:
-    hosts: ["localhost:9200"]
-
-    # A template is used to set the mapping in Elasticsearch
-    # By default template loading is disabled and no template is loaded.
-    # These settings can be adjusted to load your own template or overwrite existing ones
-    template:
-
-      # Template name. By default the template name is filebeat.
-      #name: "topbeat"
-
-      # Path to template file
-      path: "topbeat.template.json"
-
-      # Overwrite existing template
-      #overwrite: false
-----------------------------------------------------------------------
-
-The template is then loaded as soon as the beat is started up.
-
-
-==== Load Template with Shell Script
-
-The template can be loaded with the following command
-
-*deb or rpm:*
-
-[source,shell]
-----------------------------------------------------------------------
-curl -XPUT 'http://localhost:9200/_template/topbeat' -d@/etc/topbeat/topbeat.template.json
-----------------------------------------------------------------------
-
-*mac:*
-
-["source","sh",subs="attributes,callouts"]
-----------------------------------------------------------------------
-cd topbeat-{version}-darwin
-curl -XPUT 'http://localhost:9200/_template/topbeat' -d@topbeat.template.json
-----------------------------------------------------------------------
-
-*win:*
-
-["source","sh",subs="attributes,callouts"]
-----------------------------------------------------------------------
-PS C:\Program Files\Topbeat> Invoke-WebRequest -Method Put -InFile topbeat.template.json -Uri http://localhost:9200/_template/topbeat?pretty
-----------------------------------------------------------------------
-
-where `localhost:9200` is the IP and port where Elasticsearch is listening.
-
-NOTE: If you've already used Topbeat to index data into Elasticsearch,
-the index may contain old documents. After you load the index template,
-you can delete the old documents from `topbeat-*` to force Kibana to look
-at the newest documents. Use this command:
-`curl -XDELETE 'http://localhost:9200/topbeat-*'`.
+:allplatforms:
+include::../../libbeat/docs/shared-template-load.asciidoc[]
 
 === Step 5: Starting Topbeat
 

--- a/winlogbeat/docs/getting-started.asciidoc
+++ b/winlogbeat/docs/getting-started.asciidoc
@@ -120,20 +120,7 @@ include::../../libbeat/docs/shared-logstash-config.asciidoc[]
 [[winlogbeat-template]]
 === Step 4: Loading the Index Template in Elasticsearch
 
-Before starting Winlogbeat, you need to load the
-http://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates.html[index
-template], which lets Elasticsearch know which fields should be analyzed
-in which way.
-
-The recommended template file is installed by the Winlogbeat packages. Load it
-with the following command:
-
-[source,shell]
-----------------------------------------------------------------------
-PS C:\Program Files\Winlogbeat> Invoke-WebRequest -Method Put -InFile winlogbeat.template.json -Uri http://localhost:9200/_template/winlogbeat?pretty
-----------------------------------------------------------------------
-
-where `localhost:9200` is the IP and port where Elasticsearch is listening.
+include::../../libbeat/docs/shared-template-load.asciidoc[]
 
 === Step 5: Starting Winlogbeat
 


### PR DESCRIPTION
Summary of changes:
- Edited the doc content added by #1137
- Moved content to a shared file and used asciidoc include statements to pull content into the doc for all the beats
- Used variable for beat names 
- Added conditional section so steps for running the script on deb/rpm/mac do not how up for Winlogbeat

Closes #1142.

@ruflin I'm assuming I need to cherry-pick this into master after it's reviewed and merged, correct?