### PR TITLE
Adds doc for using environment variables in config files

### DIFF
--- a/filebeat/docs/index.asciidoc
+++ b/filebeat/docs/index.asciidoc
@@ -12,6 +12,8 @@ include::./command-line.asciidoc[]
 
 include::./configuring-howto.asciidoc[]
 
+include::../../libbeat/docs/shared-env-vars.asciidoc[]
+
 include::../../libbeat/docs/https.asciidoc[]
 
 include::./multiple-prospectors.asciidoc[]

--- a/libbeat/docs/shared-env-vars.asciidoc
+++ b/libbeat/docs/shared-env-vars.asciidoc
@@ -1,0 +1,49 @@
+//////////////////////////////////////////////////////////////////////////
+//// This content is shared by all Elastic Beats. Make sure you keep the
+//// descriptions here generic enough to work for all Beats that include
+//// this file. When using cross references, make sure that the cross
+//// references resolve correctly for any files that include this one.
+//// Use the appropriate variables defined in the index.asciidoc file to
+//// resolve Beat names: beatname_uc and beatname_lc.
+//// Use the following include to pull this content into a doc file:
+//// include::../../libbeat/docs/shared-env-vars.asciidoc[]
+//////////////////////////////////////////////////////////////////////////
+
+[[using-environ-vars]]
+=== Using Environment Variables in the Configuration
+
+You can use environment variable references in the +{beatname_lc}.yml+ file to set values
+that need to be configurable during deployment. To do this, use:
+
+`$VAR` or `${VAR}`
+
+Where `VAR` is the name of the environment variable.
+
+Each variable reference is replaced at startup by the value of the environment variable.
+The replacement is case-sensitive and occurs before the YAML file is parsed. References
+to undefined variables are replaced by empty strings unless you specify a default value.
+To specify a default value, use:
+
+`${VAR:default_value}`
+
+Where `default_value` is the value to use if the environment variable is undefined.
+
+After changing the value of an environment variable, you need to restart {beatname_uc} to
+pick up the new value.
+
+==== Examples
+
+Here are some examples of configurations that use environment variables
+and what each configuration looks like after replacement: 
+
+[options="header"]
+|==================================
+|Config source	       |Environment setting   |Config after replacement
+|`name: $NAME`         |`export NAME=elastic` |`name: elastic`
+|`name: ${NAME}`       |`export NAME=elastic` |`name: elastic`
+|`name: ${NAME:beats}` |no setting            |`name: beats`
+|`name: ${NAME:beats}` |`export NAME=elastic` |`name: elastic`
+|`hosts: [$HOSTS]`     |`export HOSTS="'localhost:9200', 'localhost:9202'"` |`hosts: ['localhost:9200', 'localhost:9202']`
+|==================================
+
+

--- a/packetbeat/docs/index.asciidoc
+++ b/packetbeat/docs/index.asciidoc
@@ -12,6 +12,8 @@ include::./command-line.asciidoc[]
 
 include::./configuring-howto.asciidoc[]
 
+include::../../libbeat/docs/shared-env-vars.asciidoc[]
+
 include::../../libbeat/docs/https.asciidoc[]
 
 include::./capturing.asciidoc[]

--- a/topbeat/docs/index.asciidoc
+++ b/topbeat/docs/index.asciidoc
@@ -12,6 +12,8 @@ include::./command-line.asciidoc[]
 
 include::./configuring-howto.asciidoc[]
 
+include::../../libbeat/docs/shared-env-vars.asciidoc[]
+
 include::../../libbeat/docs/https.asciidoc[]
 
 include::./troubleshooting.asciidoc[]

--- a/winlogbeat/docs/index.asciidoc
+++ b/winlogbeat/docs/index.asciidoc
@@ -12,6 +12,8 @@ include::./command-line.asciidoc[]
 
 include::./configuring-howto.asciidoc[]
 
+include::../../libbeat/docs/shared-env-vars.asciidoc[]
+
 include::../../libbeat/docs/https.asciidoc[]
 
 include::./troubleshooting.asciidoc[]


### PR DESCRIPTION
These changes close #728. Added doc to a shared file so that we can make it available to all beats as needed.

Doc also needs to be backported to 1.2. 