### PR TITLE
Add selectors for module config

### DIFF
--- a/libbeat/tests/system/beat/beat.py
+++ b/libbeat/tests/system/beat/beat.py
@@ -203,6 +203,7 @@ class TestCase(unittest.TestCase):
         with open(os.path.join(self.working_dir, output), "wb") as f:
             f.write(output_str)
 
+    # Returns output as JSON object with flattened fields (. notation)
     def read_output(self, output_file=None):
 
         # Init defaults
@@ -217,6 +218,19 @@ class TestCase(unittest.TestCase):
         self.all_have_fields(jsons, ["@timestamp", "type",
                                      "beat.name", "beat.hostname",
                                      "count"])
+        return jsons
+
+    # Returns output as JSON object
+    def read_output_json(self, output_file=None):
+
+        # Init defaults
+        if output_file is None:
+            output_file = "output/" + self.beat_name
+
+        jsons = []
+        with open(os.path.join(self.working_dir, output_file), "r") as f:
+            for line in f:
+                jsons.append(json.loads(line))
         return jsons
 
     def copy_files(self, files, source_dir="files/"):

--- a/metricbeat/etc/beat.yml
+++ b/metricbeat/etc/beat.yml
@@ -15,13 +15,21 @@ metricbeat:
       hosts: ["127.0.0.1:6379"]
       enabled: true
 
+      # Selectors to only fetch a subset of metrics (whitelisting)
+      # If no selectors are set, all metrics are sent.
+      # Use filters for a more fine grained filtering.
+      #selectors: []
+
+      # Optional fields to be added to each event
+      #fields:
+      #  datacenter: west
+
       # Network type to be used for redis connection. Default: tcp
       #network: tcp
 
       # Max number of concurrent connections. Default: 10
       #maxconn: 10
-      fields:
-        datacenter: west
+
       #filter: ...
       #username: name
       #password: hello world

--- a/metricbeat/helper/interfacer.go
+++ b/metricbeat/helper/interfacer.go
@@ -13,6 +13,7 @@ type ModuleConfig struct {
 	Module     string   `config:"module"`
 	MetricSets []string `config:"metricsets"`
 	Enabled    bool     `config:"enabled"`
+	Selectors  []string `config:"selectors"`
 
 	common.EventMetadata `config:",inline"` // Fields and tags to add to events.
 }

--- a/metricbeat/helper/metricset.go
+++ b/metricbeat/helper/metricset.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/logp"
 )
 
 // Metric specific data
@@ -80,6 +81,8 @@ func (m *MetricSet) createEvent(event common.MapStr) common.MapStr {
 	// Each metricset has a unique eventfieldname to prevent type conflicts
 	eventFieldName := m.Module.name + "-" + m.Name
 
+	event = applySelector(event, m.Config.Selectors)
+
 	// TODO: Add fields_under_root option for "metrics"?
 	event = common.MapStr{
 		"type":                  typeName,
@@ -98,4 +101,25 @@ func (m *MetricSet) createEvent(event common.MapStr) common.MapStr {
 	}
 
 	return event
+}
+
+func applySelector(event common.MapStr, selectors []string) common.MapStr {
+
+	// No selectors set means return full events
+	if len(selectors) == 0 {
+		return event
+	}
+
+	newEvent := common.MapStr{}
+	logp.Debug("metricset", "Applying selectors: %v", selectors)
+
+	for _, selector := range selectors {
+
+		if value, ok := event[selector]; ok {
+			newEvent[selector] = value
+		}
+
+	}
+
+	return newEvent
 }

--- a/metricbeat/helper/metricset_test.go
+++ b/metricbeat/helper/metricset_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package helper
 
 import (
@@ -36,6 +38,60 @@ func TestMetricSetTwoInstances(t *testing.T) {
 
 	event, _ = metricSet2.MetricSeter.Fetch(metricSet2, "")
 	assert.Equal(t, 1, event["counter"])
+}
+
+func TestApplySelectorEmpty(t *testing.T) {
+	event := common.MapStr{
+		"hello": "world",
+	}
+
+	newEvent := applySelector(event, []string{})
+
+	assert.Equal(t, event, newEvent)
+}
+
+func TestApplySelectorOne(t *testing.T) {
+	event := common.MapStr{
+		"hello": "world",
+		"test":  "value",
+	}
+
+	newEvent := applySelector(event, []string{"hello"})
+
+	assert.Equal(t, common.MapStr{"hello": "world"}, newEvent)
+}
+
+func TestApplySelectorNotExistant(t *testing.T) {
+	event := common.MapStr{
+		"hello": "world",
+		"test":  "value",
+		"cpu":   100,
+	}
+
+	newEvent := applySelector(event, []string{"hello", "notexistant"})
+
+	assert.Equal(t, common.MapStr{"hello": "world"}, newEvent)
+}
+
+func TestApplySelectorTwoNested(t *testing.T) {
+	event := common.MapStr{
+		"cpu": common.MapStr{
+			"p0": 100,
+		},
+		"test": "value",
+		"disk": common.MapStr{
+			"hd": "not available",
+		},
+	}
+
+	newEvent := applySelector(event, []string{"test", "disk"})
+
+	assert.Equal(t, common.MapStr{
+		"test": "value",
+		"disk": common.MapStr{
+			"hd": "not available",
+		},
+	}, newEvent)
 }
 
 /*** Mock tests objects ***/

--- a/metricbeat/helper/module_test.go
+++ b/metricbeat/helper/module_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package helper
 
 import (

--- a/metricbeat/metricbeat.yml
+++ b/metricbeat/metricbeat.yml
@@ -15,13 +15,21 @@ metricbeat:
       hosts: ["127.0.0.1:6379"]
       enabled: true
 
+      # Selectors to only fetch a subset of metrics (whitelisting)
+      # If no selectors are set, all metrics are sent.
+      # Use filters for a more fine grained filtering.
+      #selectors: []
+
+      # Optional fields to be added to each event
+      #fields:
+      #  datacenter: west
+
       # Network type to be used for redis connection. Default: tcp
       #network: tcp
 
       # Max number of concurrent connections. Default: 10
       #maxconn: 10
-      fields:
-        datacenter: west
+
       #filter: ...
       #username: name
       #password: hello world

--- a/metricbeat/tests/system/config/metricbeat.yml.j2
+++ b/metricbeat/tests/system/config/metricbeat.yml.j2
@@ -8,6 +8,7 @@ metricbeat:
         - info
       period: 1s
       enabled: true
+      selectors: {{ redis_selectors }}
     {% endif %}
     {% if mysql %}
     - module: mysql:

--- a/metricbeat/tests/system/redis/test_info.py
+++ b/metricbeat/tests/system/redis/test_info.py
@@ -10,7 +10,7 @@ class Test(BaseTest):
 
     def test_base(self):
         """
-        Basic test with exiting Mockbeat normally
+        Basic test with exiting metricbeat with redis info metricset normally
         """
         self.render_config_template(
             redis=True,
@@ -21,6 +21,33 @@ class Test(BaseTest):
         self.wait_until(
             lambda: self.output_has(lines=1)
         )
+
+        exit_code = proc.kill_and_wait()
+        assert exit_code == 0
+
+    def test_selectors(self):
+        """
+        Test if selectors reduce the output as expected
+        """
+        self.render_config_template(
+            redis=True,
+            redis_host=os.getenv('REDIS_HOST'),
+            redis_selectors=["clients", "cpu"]
+        )
+
+        proc = self.start_beat()
+        self.wait_until(
+            lambda: self.output_has(lines=1)
+        )
+
+        output = self.read_output_json()
+        event = output[0]
+        redis_info = event["redis-info"]
+
+        assert len(redis_info) == 2
+        assert len(redis_info["clients"]) == 4
+        assert len(redis_info["cpu"]) == 4
+
 
         exit_code = proc.kill_and_wait()
         assert exit_code == 0


### PR DESCRIPTION
Selectors are a very basic filtering on a module level to define a whitelist of fields that should be included.
Most metricsets provide nested documents, so the selectors allow to include only a subset if needed.

* Selector as example implemented in redis
* System tests added for selectors
* Fetch JSON method in system tests added