### PR TITLE
Rename shipper config to beat

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -17,6 +17,7 @@ https://github.com/elastic/beats/compare/v1.1.2...master[Check the HEAD diff]
 - Some publisher options refactoring in libbeat {pull}684[684]
 - Run function to start a beat no returns an error instead of directly exiting. {pull}771[771]
 - Move event preprocessor applying GeoIP to packetbeat {pull}772[772]
+- shipper.* config was renamed to beat.* config. shipper is still available but deprecated.
 
 *Packetbeat*
 - Rename output fields in the dns package. Former flag `recursion_allowed` becomes `recursion_available`. {pull}803[803]

--- a/filebeat/docs/fields.asciidoc
+++ b/filebeat/docs/fields.asciidoc
@@ -21,7 +21,7 @@ Contains common fields available in all event types.
 
 ==== beat.name
 
-The name of the Beat sending the log messages. If the shipper name is set in the configuration file, then that value is used. If it is not set, the hostname is used.
+The name of the Beat sending the log messages. If the beat name is set in the configuration file, then that value is used. If it is not set, the hostname is used.
 
 
 ==== beat.hostname

--- a/filebeat/docs/reference/configuration.asciidoc
+++ b/filebeat/docs/reference/configuration.asciidoc
@@ -16,7 +16,7 @@ configuration settings, you need to restart Filebeat to pick up the changes.
 * <<kafka-output>>
 * <<file-output>>
 * <<console-output>>
-* <<configuration-shipper>>
+* <<configuration-beat>>
 * <<configuration-logging>>
 * <<configuration-run-options>>
 

--- a/filebeat/docs/reference/configuration/filebeat-options.asciidoc
+++ b/filebeat/docs/reference/configuration/filebeat-options.asciidoc
@@ -99,7 +99,7 @@ The following example configures Filebeat to ignore all the files that have a `g
 A list of tags that the Beat includes in the `tags` field of each published
 event. Tags make it easy to select specific events in Kibana or apply
 conditional filtering in Logstash. These tags will be appended to the list of
-tags specified in the `shipper` configuration.
+tags specified in the `beat` configuration.
 
 Example:
 
@@ -120,7 +120,7 @@ data. Fields can be scalar values, arrays, dictionaries, or any nested
 combination of these. By default, the fields that you specify here will be
 grouped under a `fields` sub-dictionary in the output document. To store the
 custom fields as top-level fields, set the `fields_under_root` option to true.
-If a duplicate field is declared in the `shipper` configuration, then its value
+If a duplicate field is declared in the `beat` configuration, then its value
 will be overwritten by the value declared here.
 
 [source,yaml]
@@ -386,7 +386,7 @@ The `plain` encoding is special, because it does not validate or transform any i
 
 include::../../../../libbeat/docs/outputconfig.asciidoc[]
 
-include::../../../../libbeat/docs/shipperconfig.asciidoc[]
+include::../../../../libbeat/docs/beatconfig.asciidoc[]
 
 include::../../../../libbeat/docs/loggingconfig.asciidoc[]
 

--- a/filebeat/etc/fields.yml
+++ b/filebeat/etc/fields.yml
@@ -14,7 +14,7 @@ env:
   fields:
     - name: beat.name
       description: >
-        The name of the Beat sending the log messages. If the shipper name is set
+        The name of the Beat sending the log messages. If the beat name is set
         in the configuration file, then that value is used. If it is not set,
         the hostname is used.
 

--- a/filebeat/filebeat.yml
+++ b/filebeat/filebeat.yml
@@ -352,15 +352,15 @@ output:
     #pretty: false
 
 
-############################# Shipper #########################################
+############################# Beat #########################################
 
-shipper:
-  # The name of the shipper that publishes the network data. It can be used to group
-  # all the transactions sent by a single shipper in the web interface.
+beat:
+  # The name of the beat that publishes the network data. It can be used to group
+  # all the transactions sent by a single beat in the web interface.
   # If this options is not defined, the hostname is used.
   #name:
 
-  # The tags of the shipper are included in their own field with each
+  # The tags of the beat are included in their own field with each
   # transaction published. Tags make it easy to group servers by different
   # logical properties.
   #tags: ["service-X", "web-tier"]
@@ -377,15 +377,15 @@ shipper:
   #fields_under_root: false
 
   # Uncomment the following if you want to ignore transactions created
-  # by the server on which the shipper is installed. This option is useful
-  # to remove duplicates if shippers are installed on multiple servers.
+  # by the server on which the beat is installed. This option is useful
+  # to remove duplicates if beat are installed on multiple servers.
   #ignore_outgoing: true
 
-  # How often (in seconds) shippers are publishing their IPs to the topology map.
+  # How often (in seconds) beat are publishing their IPs to the topology map.
   # The default is 10 seconds.
   #refresh_topology_freq: 10
 
-  # Expiration time (in seconds) of the IPs published by a shipper to the topology map.
+  # Expiration time (in seconds) of the IPs published by a beat to the topology map.
   # All the IPs will be deleted afterwards. Note, that the value must be higher than
   # refresh_topology_freq. The default is 15 seconds.
   #topology_expire: 15

--- a/filebeat/tests/system/config/filebeat.yml.j2
+++ b/filebeat/tests/system/config/filebeat.yml.j2
@@ -58,15 +58,15 @@ filebeat:
   registry_file: {{ beat.working_dir + '/' }}{{ registryFile|default(".filebeat")}}
 
 
-############################# Shipper ############################################
-shipper:
+############################# Beat ############################################
+beat:
 
- # The name of the shipper that publishes the network data. It can be used to group
- # all the transactions sent by a single shipper in the web interface.
+ # The name of the beat that publishes the data. It can be used to group
+ # all the transactions sent by a single beat in the web interface.
  # If this options is not defined, the hostname is used.
- name: {{shipperName}}
+ name: {{beatName}}
 
- # The tags of the shipper are included in their own field with each
+ # The tags of the beat are included in their own field with each
  # transaction published. Tags make it easy to group servers by different
  # logical properties.
  tags: [
@@ -79,8 +79,8 @@ shipper:
 
 
  # Uncomment the following if you want to ignore transactions created
- # by the server on which the shipper is installed. This option is useful
- # to remove duplicates if shippers are installed on multiple servers.
+ # by the server on which the beat is installed. This option is useful
+ # to remove duplicates if beat are installed on multiple servers.
  # ignore_outgoing: true
 
 

--- a/filebeat/tests/system/test_fields.py
+++ b/filebeat/tests/system/test_fields.py
@@ -62,12 +62,12 @@ class Test(BaseTest):
 
     def test_beat_fields(self):
         """
-        Checks that it's possible to set a custom shipper name. Also
+        Checks that it's possible to set a custom beat name. Also
         tests that beat.hostname  has values.
         """
         self.render_config_template(
             path=os.path.abspath(self.working_dir) + "/test.log",
-            shipperName="testShipperName"
+            beatName="testBeatName"
         )
 
         with open(self.working_dir + "/test.log", "w") as f:
@@ -79,6 +79,6 @@ class Test(BaseTest):
 
         output = self.read_output()
         doc = output[0]
-        assert doc["beat.name"] == "testShipperName"
+        assert doc["beat.name"] == "testBeatName"
         assert doc["beat.hostname"] == socket.gethostname()
         assert "fields" not in doc

--- a/libbeat/common/geolite.go
+++ b/libbeat/common/geolite.go
@@ -21,7 +21,7 @@ func LoadGeoIPData(config Geoip) *libgeo.GeoIP {
 		geoipPaths = *config.Paths
 	}
 	if len(geoipPaths) == 0 {
-		logp.Info("GeoIP disabled: No paths were set under shipper.geoip.paths")
+		logp.Info("GeoIP disabled: No paths were set under beat.geoip.paths")
 		// disabled
 		return nil
 	}

--- a/libbeat/common/net.go
+++ b/libbeat/common/net.go
@@ -6,7 +6,7 @@ import (
 )
 
 // LocalIpAddrs finds the IP addresses of the hosts on which
-// the shipper currently runs on.
+// the beat currently runs on.
 func LocalIpAddrs() ([]net.IP, error) {
 	var localIPAddrs = []net.IP{}
 	ipaddrs, err := net.InterfaceAddrs()
@@ -22,7 +22,7 @@ func LocalIpAddrs() ([]net.IP, error) {
 }
 
 // LocalIpAddrsAsStrings finds the IP addresses of the hosts on which
-// the shipper currently runs on and returns them as an array of
+// the beat currently runs on and returns them as an array of
 // strings.
 func LocalIpAddrsAsStrings(include_loopbacks bool) ([]string, error) {
 	var localIPAddrsStrings = []string{}

--- a/libbeat/docs/beatconfig.asciidoc
+++ b/libbeat/docs/beatconfig.asciidoc
@@ -6,41 +6,41 @@
 //// Use the appropriate variables defined in the index.asciidoc file to
 //// resolve Beat names: beatname_uc and beatname_lc.
 //// Use the following include to pull this content into a doc file:
-//// include::../../libbeat/docs/shipperconfig.asciidoc[]
+//// include::../../libbeat/docs/beatconfig.asciidoc[]
 //// Make sure this content appears below a level 2 heading.
 //////////////////////////////////////////////////////////////////////////
 
-[[configuration-shipper]]
-=== Shipper
+[[configuration-beat]]
+=== Beat
 
-The `shipper` section contains configuration options for the Beat and some
+The `beat` section contains configuration options for the Beat and some
 general settings that control its behaviour.
 
 Here is an example configuration:
 
 [source,yaml]
 ------------------------------------------------------------------------------
-shipper:
-  # The name of the shipper that publishes the network data. It can be used to group
-  # all the transactions sent by a single shipper in the web interface.
+beat:
+  # The name of the beat that publishes the network data. It can be used to group
+  # all the transactions sent by a single beat in the web interface.
   # If this options is not defined, the hostname is used.
   #name:
 
-  # The tags of the shipper are included in their own field with each
+  # The tags of the beat are included in their own field with each
   # transaction published. Tags make it easy to group servers by different
   # logical properties.
   tags: ["service-X", "web-tier"]
 
   # Uncomment the following if you want to ignore transactions created
-  # by the server on which the shipper is installed. This option is useful
-  # to remove duplicates if shippers are installed on multiple servers.
+  # by the server on which the beat is installed. This option is useful
+  # to remove duplicates if beat are installed on multiple servers.
   ignore_outgoing: true
 
-  # How often (in seconds) shippers are publishing their IPs to the topology map.
+  # How often (in seconds) beat are publishing their IPs to the topology map.
   # The default is 10 seconds.
   refresh_topology_freq: 10
 
-  # Expiration time (in seconds) of the IPs published by a shipper to the topology map.
+  # Expiration time (in seconds) of the IPs published by a beat to the topology map.
   # All the IPs will be deleted afterwards. Note, that the value must be higher than
   # refresh_topology_freq. The default is 15 seconds.
   topology_expire: 15
@@ -54,14 +54,14 @@ shipper:
 
 ------------------------------------------------------------------------------
 
-==== Shipper Options
+==== Beat Options
 
-You can specify the following options under the `shipper` section:
+You can specify the following options under the `beat` section:
 
 ===== name
 
 The name of the Beat. If this option is empty, the `hostname` of the server is
-used. The name is included as the `shipper` field in each published transaction. You can
+used. The name is included as the `beat` field in each published transaction. You can
 use the name to group all transactions sent by a single Beat.
 
 At startup, each Beat can publish its IP, port, and name to Elasticsearch. This information
@@ -81,8 +81,8 @@ Example:
 
 [source,yaml]
 ------------------------------------------------------------------------------
-shipper:
-  name: "my-shipper"
+beat:
+  name: "my-beat"
 ------------------------------------------------------------------------------
 
 ===== tags
@@ -97,7 +97,7 @@ Example:
 
 [source,yaml]
 --------------------------------------------------------------------------------
-shipper:
+beat:
   tags: ["my-service", "hardware", "test"]
 --------------------------------------------------------------------------------
 
@@ -114,7 +114,7 @@ Example:
 
 [source,yaml]
 ------------------------------------------------------------------------------
-shipper:
+beat:
   fields: {project: "myproject", instance-id: "574734885120952459"}
 ------------------------------------------------------------------------------
 
@@ -129,7 +129,7 @@ Example:
 
 [source,yaml]
 ------------------------------------------------------------------------------
-shipper:
+beat:
   fields_under_root: true
   fields:
     instance_id: i-10a64379

--- a/libbeat/docs/installing-beats.asciidoc
+++ b/libbeat/docs/installing-beats.asciidoc
@@ -2,7 +2,7 @@
 ////////////////////////////////////////////////////////////////////
 ///// The content about individual configuration options has been
 ///// moved to the following files:
-///// shipperconfig.asciidoc for Shipper options
+///// beatconfig.asciidoc for Beat options
 ///// outputconfig.asciidoc for Output options
 ///// loggingconfig.asciidoc for Logging options
 ///// runconfig.asciidoc for Run Configuration options
@@ -10,7 +10,7 @@
 ///// include the content in the guide for your Beat by using the
 ///// following asciidoc include statements:
 ///// include::../../libbeat/docs/outputconfig.asciidoc[]
-///// include::../../libbeat/docs/shipperconfig.asciidoc[]
+///// include::../../libbeat/docs/beatconfig.asciidoc[]
 ///// include::../../libbeat/docs/loggingconfig.asciidoc[]
 ///// include::../../libbeat/docs/runconfig.asciidoc[]
 ////////////////////////////////////////////////////////////////////

--- a/libbeat/etc/libbeat.yml
+++ b/libbeat/etc/libbeat.yml
@@ -180,15 +180,15 @@ output:
     #pretty: false
 
 
-############################# Shipper #########################################
+############################# Beat #########################################
 
-shipper:
-  # The name of the shipper that publishes the network data. It can be used to group
-  # all the transactions sent by a single shipper in the web interface.
+beat:
+  # The name of the beat that publishes the network data. It can be used to group
+  # all the transactions sent by a single beat in the web interface.
   # If this options is not defined, the hostname is used.
   #name:
 
-  # The tags of the shipper are included in their own field with each
+  # The tags of the beat are included in their own field with each
   # transaction published. Tags make it easy to group servers by different
   # logical properties.
   #tags: ["service-X", "web-tier"]
@@ -205,15 +205,15 @@ shipper:
   #fields_under_root: false
 
   # Uncomment the following if you want to ignore transactions created
-  # by the server on which the shipper is installed. This option is useful
-  # to remove duplicates if shippers are installed on multiple servers.
+  # by the server on which the beat is installed. This option is useful
+  # to remove duplicates if beat are installed on multiple servers.
   #ignore_outgoing: true
 
-  # How often (in seconds) shippers are publishing their IPs to the topology map.
+  # How often (in seconds) beat are publishing their IPs to the topology map.
   # The default is 10 seconds.
   #refresh_topology_freq: 10
 
-  # Expiration time (in seconds) of the IPs published by a shipper to the topology map.
+  # Expiration time (in seconds) of the IPs published by a beat to the topology map.
   # All the IPs will be deleted afterwards. Note, that the value must be higher than
   # refresh_topology_freq. The default is 15 seconds.
   #topology_expire: 15

--- a/libbeat/outputs/elasticsearch/topology.go
+++ b/libbeat/outputs/elasticsearch/topology.go
@@ -64,7 +64,7 @@ func (t *topology) EnableTTL() error {
 	return nil
 }
 
-// Get the name of a shipper by its IP address from the local topology map
+// Get the name of a beat by its IP address from the local topology map
 func (t *topology) GetNameByIP(ip string) string {
 	topologyMap, ok := t.TopologyMap.Load().(map[string]string)
 	if ok {
@@ -76,7 +76,7 @@ func (t *topology) GetNameByIP(ip string) string {
 	return ""
 }
 
-// Each shipper publishes a list of IPs together with its name to Elasticsearch
+// Each beat publishes a list of IPs together with its name to Elasticsearch
 func (t *topology) PublishIPs(name string, localAddrs []string) error {
 	if !t.ttlEnabled {
 		logp.Debug("output_elasticsearch",
@@ -120,7 +120,7 @@ func (t *topology) PublishIPs(name string, localAddrs []string) error {
 
 // Update the local topology map
 func loadTopolgyMap(client *Client) (map[string]string, error) {
-	// get all shippers IPs from Elasticsearch
+	// get all beats IPs from Elasticsearch
 
 	index := ".packetbeat-topology"
 	docType := "server-ip"

--- a/libbeat/outputs/redis/redis.go
+++ b/libbeat/outputs/redis/redis.go
@@ -219,7 +219,7 @@ func (out *redisOutput) UpdateLocalTopologyMap(conn redis.Conn) {
 	topologyMapTmp := make(map[string]string)
 	hostnames, err := redis.Strings(conn.Do("KEYS", "*"))
 	if err != nil {
-		logp.Err("Fail to get the all shippers from the topology map %s", err)
+		logp.Err("Fail to get the all beats from the topology map %s", err)
 		return
 	}
 	for _, hostname := range hostnames {

--- a/libbeat/publisher/client.go
+++ b/libbeat/publisher/client.go
@@ -29,7 +29,7 @@ var (
 //  }
 //
 // Event publishers can add fields and tags to an event. The fields will take
-// precedence over the global fields defined in the shipper configuration.
+// precedence over the global fields defined in the beat configuration.
 //
 //  event := common.MapStr{
 //      // Add custom fields to the root of the event.
@@ -143,7 +143,7 @@ func (c *client) annotateEvent(event common.MapStr) {
 	}
 	event["beat"] = beatMeta
 
-	// Add the global tags and fields defined under shipper.
+	// Add the global tags and fields defined under beat.
 	common.AddTags(event, c.globalEventMetadata.Tags)
 	common.MergeFields(event, c.globalEventMetadata.Fields, c.globalEventMetadata.FieldsUnderRoot)
 

--- a/libbeat/publisher/publish_test.go
+++ b/libbeat/publisher/publish_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	shipperName   = "testShipper"
+	beatName      = "testBeat"
 	hostOnNetwork = "someHost"
 )
 
@@ -46,8 +46,8 @@ func TestPrintPublishEvent(t *testing.T) {
 
 // Test GetServerName.
 func TestPublisherTypeGetServerName(t *testing.T) {
-	pt := &PublisherType{name: shipperName}
-	assert.Equal(t, shipperName, pt.GetServerName("127.0.0.1"))
+	pt := &PublisherType{name: beatName}
+	assert.Equal(t, beatName, pt.GetServerName("127.0.0.1"))
 
 	// Unknown hosts return empty string.
 	assert.Equal(t, "", pt.GetServerName("172.0.0.1"))
@@ -67,7 +67,7 @@ func TestPublisherTypeUpdateTopologyPeriodically(t *testing.T) {
 		publishLocalAddrs: make(chan []string, 1),
 	}
 	pt := &PublisherType{
-		name:                 shipperName,
+		name:                 beatName,
 		RefreshTopologyTimer: c,
 		TopologyOutput:       topo,
 	}
@@ -78,6 +78,6 @@ func TestPublisherTypeUpdateTopologyPeriodically(t *testing.T) {
 	pt.UpdateTopologyPeriodically()
 
 	// Validate that PublishTopology was invoked.
-	assert.Equal(t, shipperName, <-topo.publishName)
+	assert.Equal(t, beatName, <-topo.publishName)
 	assert.True(t, len(<-topo.publishLocalAddrs) > 0)
 }

--- a/libbeat/tests/files/beat-shipper.yml
+++ b/libbeat/tests/files/beat-shipper.yml
@@ -1,0 +1,14 @@
+# This is an invalid config and an error should be returned
+beat:
+  name: "beatName"
+
+# Deprecated shipper config
+shipper:
+  name: "shipperName"
+
+
+output:
+  elasticsearch:
+    enabled: true
+    port: 9200
+    host: localhost

--- a/libbeat/tests/files/shipper.yml
+++ b/libbeat/tests/files/shipper.yml
@@ -1,8 +1,9 @@
+# Deprecated shipper config
+shipper:
+  name: "shipperName"
+
 output:
   elasticsearch:
     enabled: true
     port: 9200
     host: localhost
-
-beat:
-  name: "beatName"

--- a/libbeat/tests/system/config/mockbeat.yml.j2
+++ b/libbeat/tests/system/config/mockbeat.yml.j2
@@ -4,15 +4,15 @@ mockbeat:
 
 
 
-############################# Shipper ############################################
-shipper:
+############################# Beat ############################################
+beat:
 
- # The name of the shipper that publishes the network data. It can be used to group
- # all the transactions sent by a single shipper in the web interface.
+ # The name of the beat that publishes the network data. It can be used to group
+ # all the transactions sent by a single beat in the web interface.
  # If this options is not defined, the hostname is used.
  name:
 
- # The tags of the shipper are included in their own field with each
+ # The tags of the beat are included in their own field with each
  # transaction published. Tags make it easy to group servers by different
  # logical properties.
  tags: [
@@ -22,12 +22,6 @@ shipper:
             {%- if not loop.last %}, {% endif -%}
         {%- endfor -%}
     {%- endif -%}]
-
-
- # Uncomment the following if you want to ignore transactions created
- # by the server on which the shipper is installed. This option is useful
- # to remove duplicates if shippers are installed on multiple servers.
- # ignore_outgoing: true
 
 
 

--- a/metricbeat/metricbeat.yml
+++ b/metricbeat/metricbeat.yml
@@ -212,15 +212,15 @@ output:
     #pretty: false
 
 
-############################# Shipper #########################################
+############################# Beat #########################################
 
-shipper:
-  # The name of the shipper that publishes the network data. It can be used to group
-  # all the transactions sent by a single shipper in the web interface.
+beat:
+  # The name of the beat that publishes the network data. It can be used to group
+  # all the transactions sent by a single beat in the web interface.
   # If this options is not defined, the hostname is used.
   #name:
 
-  # The tags of the shipper are included in their own field with each
+  # The tags of the beat are included in their own field with each
   # transaction published. Tags make it easy to group servers by different
   # logical properties.
   #tags: ["service-X", "web-tier"]
@@ -237,15 +237,15 @@ shipper:
   #fields_under_root: false
 
   # Uncomment the following if you want to ignore transactions created
-  # by the server on which the shipper is installed. This option is useful
-  # to remove duplicates if shippers are installed on multiple servers.
+  # by the server on which the beat is installed. This option is useful
+  # to remove duplicates if beat are installed on multiple servers.
   #ignore_outgoing: true
 
-  # How often (in seconds) shippers are publishing their IPs to the topology map.
+  # How often (in seconds) beat are publishing their IPs to the topology map.
   # The default is 10 seconds.
   #refresh_topology_freq: 10
 
-  # Expiration time (in seconds) of the IPs published by a shipper to the topology map.
+  # Expiration time (in seconds) of the IPs published by a beat to the topology map.
   # All the IPs will be deleted afterwards. Note, that the value must be higher than
   # refresh_topology_freq. The default is 15 seconds.
   #topology_expire: 15

--- a/packetbeat/beater/packetbeat.go
+++ b/packetbeat/beater/packetbeat.go
@@ -139,12 +139,12 @@ func (pb *Packetbeat) Setup(b *beat.Beat) error {
 	}
 
 	queueSize := defaultQueueSize
-	if pb.PbConfig.Shipper.QueueSize != nil {
-		queueSize = *pb.PbConfig.Shipper.QueueSize
+	if pb.PbConfig.Beat.QueueSize != nil {
+		queueSize = *pb.PbConfig.Beat.QueueSize
 	}
 	bulkQueueSize := defaultBulkQueueSize
-	if pb.PbConfig.Shipper.BulkQueueSize != nil {
-		bulkQueueSize = *pb.PbConfig.Shipper.BulkQueueSize
+	if pb.PbConfig.Beat.BulkQueueSize != nil {
+		bulkQueueSize = *pb.PbConfig.Beat.BulkQueueSize
 	}
 	pb.Pub = publish.NewPublisher(b.Publisher, queueSize, bulkQueueSize)
 	pb.Pub.Start()

--- a/packetbeat/config/config.go
+++ b/packetbeat/config/config.go
@@ -12,7 +12,7 @@ type Config struct {
 	Interfaces InterfacesConfig
 	Flows      *Flows
 	Protocols  map[string]*ucfg.Config
-	Shipper    publisher.ShipperConfig
+	Beat       publisher.BeatConfig
 	Procs      procs.ProcsConfig
 	RunOptions droppriv.RunOptions
 	Logging    logp.Logging

--- a/packetbeat/docs/fields.asciidoc
+++ b/packetbeat/docs/fields.asciidoc
@@ -1524,7 +1524,7 @@ These fields contain data about the environment in which the transaction was cap
 
 ==== beat.name
 
-Name of the Beat sending the events. If the shipper name is set in the configuration file, then that value is used. If it is not set, the hostname is used.
+Name of the Beat sending the events. If the beat name is set in the configuration file, then that value is used. If it is not set, the hostname is used.
 
 
 ==== beat.hostname
@@ -1633,7 +1633,7 @@ These fields contain data about the environment in which the flow data was captu
 
 ==== beat.name
 
-Name of the Beat sending the events. If the shipper name is set in the configuration file, then that value is used. If it is not set, the hostname is used.
+Name of the Beat sending the events. If the beat name is set in the configuration file, then that value is used. If it is not set, the hostname is used.
 
 
 ==== beat.hostname

--- a/packetbeat/docs/reference/configuration.asciidoc
+++ b/packetbeat/docs/reference/configuration.asciidoc
@@ -18,7 +18,7 @@ configuration settings, you need to restart Packetbeat to pick up the changes.
 * <<kafka-output>>
 * <<file-output>>
 * <<console-output>>
-* <<configuration-shipper>>
+* <<configuration-beat>>
 * <<configuration-logging>>
 * <<configuration-run-options>>
 

--- a/packetbeat/docs/reference/configuration/packetbeat-options.asciidoc
+++ b/packetbeat/docs/reference/configuration/packetbeat-options.asciidoc
@@ -514,7 +514,7 @@ quiet requests with an error response are published immediately.
 
 ==== MySQL and PgSQL Configuration Options
 
-You can specify the following options in the `mysql` or `pgsql` sections: 
+You can specify the following options in the `mysql` or `pgsql` sections:
 
 ===== max_rows
 
@@ -698,7 +698,7 @@ process' command line as read from `/proc/<pid>/cmdline`.
 
 include::../../../../libbeat/docs/outputconfig.asciidoc[]
 
-include::../../../../libbeat/docs/shipperconfig.asciidoc[]
+include::../../../../libbeat/docs/beatconfig.asciidoc[]
 
 include::../../../../libbeat/docs/loggingconfig.asciidoc[]
 

--- a/packetbeat/etc/fields.yml
+++ b/packetbeat/etc/fields.yml
@@ -15,7 +15,7 @@ flows_env:
   fields:
     - name: beat.name
       description: >
-        Name of the Beat sending the events. If the shipper name is set
+        Name of the Beat sending the events. If the beat name is set
         in the configuration file, then that value is used. If it is not set,
         the hostname is used.
 
@@ -37,7 +37,7 @@ trans_env:
   fields:
     - name: beat.name
       description: >
-        Name of the Beat sending the events. If the shipper name is set
+        Name of the Beat sending the events. If the beat name is set
         in the configuration file, then that value is used. If it is not set,
         the hostname is used.
 

--- a/packetbeat/packetbeat.yml
+++ b/packetbeat/packetbeat.yml
@@ -352,15 +352,15 @@ output:
     #pretty: false
 
 
-############################# Shipper #########################################
+############################# Beat #########################################
 
-shipper:
-  # The name of the shipper that publishes the network data. It can be used to group
-  # all the transactions sent by a single shipper in the web interface.
+beat:
+  # The name of the beat that publishes the network data. It can be used to group
+  # all the transactions sent by a single beat in the web interface.
   # If this options is not defined, the hostname is used.
   #name:
 
-  # The tags of the shipper are included in their own field with each
+  # The tags of the beat are included in their own field with each
   # transaction published. Tags make it easy to group servers by different
   # logical properties.
   #tags: ["service-X", "web-tier"]
@@ -377,15 +377,15 @@ shipper:
   #fields_under_root: false
 
   # Uncomment the following if you want to ignore transactions created
-  # by the server on which the shipper is installed. This option is useful
-  # to remove duplicates if shippers are installed on multiple servers.
+  # by the server on which the beat is installed. This option is useful
+  # to remove duplicates if beat are installed on multiple servers.
   #ignore_outgoing: true
 
-  # How often (in seconds) shippers are publishing their IPs to the topology map.
+  # How often (in seconds) beat are publishing their IPs to the topology map.
   # The default is 10 seconds.
   #refresh_topology_freq: 10
 
-  # Expiration time (in seconds) of the IPs published by a shipper to the topology map.
+  # Expiration time (in seconds) of the IPs published by a beat to the topology map.
   # All the IPs will be deleted afterwards. Note, that the value must be higher than
   # refresh_topology_freq. The default is 15 seconds.
   #topology_expire: 15

--- a/packetbeat/tests/system/config/packetbeat.yml.j2
+++ b/packetbeat/tests/system/config/packetbeat.yml.j2
@@ -1,11 +1,11 @@
-############################# Shipper #########################################
-shipper:
-  # The name of the shipper that publishes the network data. It can be used to group
-  # all the transactions sent by a single shipper in the web interface.
+############################# Beat #########################################
+beat:
+  # The name of the beat that publishes the network data. It can be used to group
+  # all the transactions sent by a single beat in the web interface.
   # If this options is not defined, the hostname is used.
   name:
 
-  # The tags of the shipper are included in their own field with each
+  # The tags of the beat are included in their own field with each
   # transaction published. Tags make it easy to group servers by different
   # logical properties.
   tags: [
@@ -18,8 +18,8 @@ shipper:
   ]
 
   # Uncomment the following if you want to ignore transactions created
-  # by the server on which the shipper is installed. This option is useful
-  # to remove duplicates if shippers are installed on multiple servers.
+  # by the server on which the beat is installed. This option is useful
+  # to remove duplicates if beats are installed on multiple servers.
   # ignore_outgoing: true
 
 {% if geoip_paths is not none %}

--- a/topbeat/docs/fields.asciidoc
+++ b/topbeat/docs/fields.asciidoc
@@ -52,7 +52,7 @@ The number of transactions that this event represents. This is generally the inv
 
 ==== beat.name
 
-Name of the Beat sending the events. If the shipper name is set in the configuration file, then that value is used. If it is not set, the hostname is used.
+Name of the Beat sending the events. If the beat name is set in the configuration file, then that value is used. If it is not set, the hostname is used.
 
 
 ==== beat.hostname

--- a/topbeat/docs/reference/configuration.asciidoc
+++ b/topbeat/docs/reference/configuration.asciidoc
@@ -16,7 +16,7 @@ configuration settings, you need to restart Topbeat to pick up the changes.
 * <<kafka-output>>
 * <<file-output>>
 * <<console-output>>
-* <<configuration-shipper>>
+* <<configuration-beat>>
 * <<configuration-logging>>
 * <<configuration-run-options>>
 

--- a/topbeat/docs/reference/configuration/topbeat-options.asciidoc
+++ b/topbeat/docs/reference/configuration/topbeat-options.asciidoc
@@ -55,8 +55,8 @@ parent pid, state, pid, CPU usage, and memory usage.
 * `filesystem` to export file system statistics, including details about the
 mounted disks, such as the total and used disk space, and details about each
 disk, such as the device name and the mounting place.
-* `cpu_per_core` to export the CPU usage per core. By default, this setting is false. It makes sense only if 
-`system: true` is specified. 
+* `cpu_per_core` to export the CPU usage per core. By default, this setting is false. It makes sense only if
+`system: true` is specified.
 The details are grouped under `cpus`. The Beat exports details for each core of the server. For example:
 +
 [source,json]
@@ -82,7 +82,7 @@ For more information about the exported fields, see <<exported-fields-system>>.
 
 include::../../../../libbeat/docs/outputconfig.asciidoc[]
 
-include::../../../../libbeat/docs/shipperconfig.asciidoc[]
+include::../../../../libbeat/docs/beatconfig.asciidoc[]
 
 include::../../../../libbeat/docs/loggingconfig.asciidoc[]
 

--- a/topbeat/etc/fields.yml
+++ b/topbeat/etc/fields.yml
@@ -37,7 +37,7 @@ env:
 
     - name: beat.name
       description: >
-        Name of the Beat sending the events. If the shipper name is set
+        Name of the Beat sending the events. If the beat name is set
         in the configuration file, then that value is used. If it is not set,
         the hostname is used.
 

--- a/topbeat/tests/system/config/topbeat.yml.j2
+++ b/topbeat/tests/system/config/topbeat.yml.j2
@@ -49,22 +49,22 @@ output:
 
 
 
-############################# Shipper #########################################
+############################# Beat #########################################
 
-shipper:
-  # The name of the shipper that publishes the network data. It can be used to group
-  # all the transactions sent by a single shipper in the web interface.
+beat:
+  # The name of the beat that publishes the network data. It can be used to group
+  # all the transactions sent by a single beat in the web interface.
   # If this options is not defined, the hostname is used.
   #name:
 
-  # The tags of the shipper are included in their own field with each
+  # The tags of the beat are included in their own field with each
   # transaction published. Tags make it easy to group servers by different
   # logical properties.
   #tags: ["service-X", "web-tier"]
 
   # Uncomment the following if you want to ignore transactions created
-  # by the server on which the shipper is installed. This option is useful
-  # to remove duplicates if shippers are installed on multiple servers.
+  # by the server on which the beat is installed. This option is useful
+  # to remove duplicates if beats are installed on multiple servers.
   #ignore_outgoing: true
 
 

--- a/topbeat/topbeat.yml
+++ b/topbeat/topbeat.yml
@@ -206,15 +206,15 @@ output:
     #pretty: false
 
 
-############################# Shipper #########################################
+############################# Beat #########################################
 
-shipper:
-  # The name of the shipper that publishes the network data. It can be used to group
-  # all the transactions sent by a single shipper in the web interface.
+beat:
+  # The name of the beat that publishes the network data. It can be used to group
+  # all the transactions sent by a single beat in the web interface.
   # If this options is not defined, the hostname is used.
   #name:
 
-  # The tags of the shipper are included in their own field with each
+  # The tags of the beat are included in their own field with each
   # transaction published. Tags make it easy to group servers by different
   # logical properties.
   #tags: ["service-X", "web-tier"]
@@ -231,15 +231,15 @@ shipper:
   #fields_under_root: false
 
   # Uncomment the following if you want to ignore transactions created
-  # by the server on which the shipper is installed. This option is useful
-  # to remove duplicates if shippers are installed on multiple servers.
+  # by the server on which the beat is installed. This option is useful
+  # to remove duplicates if beat are installed on multiple servers.
   #ignore_outgoing: true
 
-  # How often (in seconds) shippers are publishing their IPs to the topology map.
+  # How often (in seconds) beat are publishing their IPs to the topology map.
   # The default is 10 seconds.
   #refresh_topology_freq: 10
 
-  # Expiration time (in seconds) of the IPs published by a shipper to the topology map.
+  # Expiration time (in seconds) of the IPs published by a beat to the topology map.
   # All the IPs will be deleted afterwards. Note, that the value must be higher than
   # refresh_topology_freq. The default is 15 seconds.
   #topology_expire: 15

--- a/winlogbeat/config/config.go
+++ b/winlogbeat/config/config.go
@@ -36,7 +36,7 @@ type Settings struct {
 // Validate validates the Settings data and returns an error describing
 // all problems or nil if there are none.
 func (s Settings) Validate() error {
-	validKeys := []string{"winlogbeat", "output", "shipper", "logging"}
+	validKeys := []string{"winlogbeat", "output", "beat", "shipper", "logging"}
 	sort.Strings(validKeys)
 
 	// Check for invalid top-level keys.

--- a/winlogbeat/config/config_test.go
+++ b/winlogbeat/config/config_test.go
@@ -42,7 +42,7 @@ func TestConfigValidate(t *testing.T) {
 				map[string]interface{}{"other": "value"},
 			},
 			"1 error: Invalid top-level key 'other' found. Valid keys are " +
-				"logging, output, shipper, winlogbeat",
+				"beat, logging, output, shipper, winlogbeat",
 		},
 		{
 			WinlogbeatConfig{},

--- a/winlogbeat/docs/fields.asciidoc
+++ b/winlogbeat/docs/fields.asciidoc
@@ -21,7 +21,7 @@ Contains common fields available in all event types.
 
 ==== beat.name
 
-The name of the Beat sending the log messages. If the shipper name is set in the configuration file, then that value is used. If it is not set, the hostname is used.
+The name of the Beat sending the log messages. If the beat name is set in the configuration file, then that value is used. If it is not set, the hostname is used.
 
 
 ==== beat.hostname

--- a/winlogbeat/docs/reference/configuration.asciidoc
+++ b/winlogbeat/docs/reference/configuration.asciidoc
@@ -16,7 +16,7 @@ configuration settings, you need to restart Winlogbeat to pick up the changes.
 * <<kafka-output>>
 * <<file-output>>
 * <<console-output>>
-* <<configuration-shipper>>
+* <<configuration-beat>>
 * <<configuration-logging>>
 * <<configuration-run-options>>
 

--- a/winlogbeat/docs/reference/configuration/winlogbeat-options.asciidoc
+++ b/winlogbeat/docs/reference/configuration/winlogbeat-options.asciidoc
@@ -129,7 +129,7 @@ winlogbeat:
 A list of tags that the Beat includes in the `tags` field of each published
 event. Tags make it easy to select specific events in Kibana or apply
 conditional filtering in Logstash. These tags will be appended to the list of
-tags specified in the `shipper` configuration.
+tags specified in the `beat` configuration.
 
 Example:
 
@@ -150,7 +150,7 @@ data. Fields can be scalar values, arrays, dictionaries, or any nested
 combination of these. By default, the fields that you specify here will be
 grouped under a `fields` sub-dictionary in the output document. To store the
 custom fields as top-level fields, set the `fields_under_root` option to true.
-If a duplicate field is declared in the `shipper` configuration, then its value
+If a duplicate field is declared in the `beat` configuration, then its value
 will be overwritten by the value declared here.
 
 [source,yaml]
@@ -197,7 +197,7 @@ The metrics are served as a JSON document. The metrics include:
 
 include::../../../../libbeat/docs/outputconfig.asciidoc[]
 
-include::../../../../libbeat/docs/shipperconfig.asciidoc[]
+include::../../../../libbeat/docs/beatconfig.asciidoc[]
 
 include::../../../../libbeat/docs/loggingconfig.asciidoc[]
 

--- a/winlogbeat/etc/fields.yml
+++ b/winlogbeat/etc/fields.yml
@@ -14,7 +14,7 @@ common:
   fields:
     - name: beat.name
       description: >
-        The name of the Beat sending the log messages. If the shipper name is
+        The name of the Beat sending the log messages. If the beat name is
         set in the configuration file, then that value is used. If it is not
         set, the hostname is used.
 

--- a/winlogbeat/tests/system/config/winlogbeat.yml.j2
+++ b/winlogbeat/tests/system/config/winlogbeat.yml.j2
@@ -45,11 +45,11 @@ output:
     {% endif %}
     rotate_every_kb: 1000
 
-############################# Shipper #########################################
+############################# Beat #########################################
 
-shipper:
-  {%- if shipper_name %}
-  name: {{ shipper_name }}
+beat:
+  {%- if beat_name %}
+  name: {{ beat_name }}
   {% endif %}
 
   {%- if tags %}

--- a/winlogbeat/winlogbeat.yml
+++ b/winlogbeat/winlogbeat.yml
@@ -205,15 +205,15 @@ output:
     #pretty: false
 
 
-############################# Shipper #########################################
+############################# Beat #########################################
 
-shipper:
-  # The name of the shipper that publishes the network data. It can be used to group
-  # all the transactions sent by a single shipper in the web interface.
+beat:
+  # The name of the beat that publishes the network data. It can be used to group
+  # all the transactions sent by a single beat in the web interface.
   # If this options is not defined, the hostname is used.
   #name:
 
-  # The tags of the shipper are included in their own field with each
+  # The tags of the beat are included in their own field with each
   # transaction published. Tags make it easy to group servers by different
   # logical properties.
   #tags: ["service-X", "web-tier"]
@@ -230,15 +230,15 @@ shipper:
   #fields_under_root: false
 
   # Uncomment the following if you want to ignore transactions created
-  # by the server on which the shipper is installed. This option is useful
-  # to remove duplicates if shippers are installed on multiple servers.
+  # by the server on which the beat is installed. This option is useful
+  # to remove duplicates if beat are installed on multiple servers.
   #ignore_outgoing: true
 
-  # How often (in seconds) shippers are publishing their IPs to the topology map.
+  # How often (in seconds) beat are publishing their IPs to the topology map.
   # The default is 10 seconds.
   #refresh_topology_freq: 10
 
-  # Expiration time (in seconds) of the IPs published by a shipper to the topology map.
+  # Expiration time (in seconds) of the IPs published by a beat to the topology map.
   # All the IPs will be deleted afterwards. Note, that the value must be higher than
   # refresh_topology_freq. The default is 15 seconds.
   #topology_expire: 15


### PR DESCRIPTION
This change is backward compatible, as shipper is still accepted but a warning will be printed out that shipper is deprecated. In case beat and shipper are set, an error is returned.

* Docs were updated with new name
* CHANEGLOG updated with change message