### PR TITLE
Remove count field from filebeat event

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -29,6 +29,7 @@ https://github.com/elastic/beats/compare/v1.1.2...master[Check the HEAD diff]
 *Filebeat*
 - Default config for ignore_older is now infinite instead of 24h, means ignore_older is disabled by default. Use close_older to only close file handlers.
 - Scalar values in used in the `fields` configuration setting are no longer automatically converted to strings. {pull}1092[1092]
+- Count field was removed from event as not used in filebeat {issue}778[778]
 
 *Winlogbeat*
 

--- a/filebeat/input/file.go
+++ b/filebeat/input/file.go
@@ -64,7 +64,6 @@ func (f *FileEvent) ToMapStr() common.MapStr {
 		"message":               f.Text,
 		"type":                  f.DocumentType,
 		"input_type":            f.InputType,
-		"count":                 1,
 	}
 
 	return event

--- a/libbeat/tests/system/beat/beat.py
+++ b/libbeat/tests/system/beat/beat.py
@@ -215,8 +215,7 @@ class TestCase(unittest.TestCase):
                 jsons.append(self.flatten_object(json.loads(line),
                                                  []))
         self.all_have_fields(jsons, ["@timestamp", "type",
-                                     "beat.name", "beat.hostname",
-                                     "count"])
+                                     "beat.name", "beat.hostname"])
         return jsons
 
     def copy_files(self, files, source_dir="files/"):


### PR DESCRIPTION
This closes https://github.com/elastic/beats/issues/778

Remove count as required field from system tests checks