### PR TITLE
Improve Moduler interface

### DIFF
--- a/metricbeat/helper/interfacer.go
+++ b/metricbeat/helper/interfacer.go
@@ -1,8 +1,6 @@
 package helper
 
 import (
-	"github.com/urso/ucfg"
-
 	"github.com/elastic/beats/libbeat/common"
 )
 
@@ -34,5 +32,5 @@ type MetricSeter interface {
 // Interface for each module
 type Moduler interface {
 	// Raw ucfg config is passed. This allows each module to extract its own local config variables
-	Setup(cfg *ucfg.Config) error
+	Setup(m *Module) error
 }

--- a/metricbeat/helper/metricset.go
+++ b/metricbeat/helper/metricset.go
@@ -55,10 +55,16 @@ func (m *MetricSet) Fetch() error {
 			event, err := m.MetricSeter.Fetch(m, h)
 
 			if err != nil {
+				// Most of the time, event is nil in case of error (not required)
+				if event == nil {
+					event = common.MapStr{}
+				}
 				event["error"] = err
 			}
 			event = m.createEvent(event)
+
 			m.Module.Publish <- event
+
 		}(host)
 	}
 	return nil

--- a/metricbeat/helper/module.go
+++ b/metricbeat/helper/module.go
@@ -57,10 +57,9 @@ func NewModule(cfg *ucfg.Config, moduler func() Moduler) (*Module, error) {
 		cfg:        cfg,
 		moduler:    moduler(),
 		metricSets: map[string]*MetricSet{},
-		// TODO: What should be size of channel?
-		Publish: make(chan common.MapStr),
-		wg:      sync.WaitGroup{},
-		done:    make(chan struct{}),
+		Publish:    make(chan common.MapStr), // TODO: What should be size of channel? @ruflin,20160316
+		wg:         sync.WaitGroup{},
+		done:       make(chan struct{}),
 	}, nil
 }
 
@@ -75,7 +74,7 @@ func (m *Module) Start(b *beat.Beat) error {
 	}
 
 	logp.Info("Setup moduler: %s", m.name)
-	err := m.moduler.Setup(m.cfg)
+	err := m.moduler.Setup(m)
 	if err != nil {
 		return fmt.Errorf("Error setting up module: %s. Not starting metricsets for this module.", err)
 	}

--- a/metricbeat/helper/module_test.go
+++ b/metricbeat/helper/module_test.go
@@ -33,7 +33,7 @@ func TestNewModule(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, module)
 
-	err = module.moduler.Setup(config)
+	err = module.moduler.Setup(module)
 	assert.NoError(t, err)
 }
 
@@ -49,7 +49,7 @@ func TestNewModulerDifferentInstance(t *testing.T) {
 	module2, err := NewModule(config, NewMockModuler)
 	assert.NoError(t, err)
 
-	module1.moduler.Setup(config)
+	module1.moduler.Setup(module1)
 	assert.False(t, reflect.DeepEqual(module1.moduler, module2.moduler))
 	assert.True(t, reflect.DeepEqual(module1.moduler, module1.moduler))
 }
@@ -63,7 +63,7 @@ type MockModuler struct {
 	counter int
 }
 
-func (m *MockModuler) Setup(cfg *ucfg.Config) error {
+func (m *MockModuler) Setup(mo *Module) error {
 	m.counter += 1
 	return nil
 }

--- a/metricbeat/module/apache/apache.go
+++ b/metricbeat/module/apache/apache.go
@@ -3,8 +3,6 @@ package apache
 import (
 	"os"
 
-	"github.com/urso/ucfg"
-
 	"github.com/elastic/beats/metricbeat/helper"
 )
 
@@ -19,7 +17,7 @@ func New() helper.Moduler {
 
 type Moduler struct{}
 
-func (r Moduler) Setup(cfg *ucfg.Config) error {
+func (m *Moduler) Setup(mo *helper.Module) error {
 	return nil
 }
 

--- a/metricbeat/module/mysql/mysql.go
+++ b/metricbeat/module/mysql/mysql.go
@@ -7,7 +7,6 @@ import (
 	"github.com/elastic/beats/metricbeat/helper"
 
 	_ "github.com/go-sql-driver/mysql"
-	"github.com/urso/ucfg"
 )
 
 func init() {
@@ -21,8 +20,7 @@ func New() helper.Moduler {
 
 type Moduler struct{}
 
-func (b Moduler) Setup(cfg *ucfg.Config) error {
-	// TODO: Ping available servers to check if available
+func (m *Moduler) Setup(mo *helper.Module) error {
 	return nil
 }
 

--- a/metricbeat/module/redis/redis.go
+++ b/metricbeat/module/redis/redis.go
@@ -4,7 +4,6 @@ import (
 	"os"
 
 	"github.com/garyburd/redigo/redis"
-	"github.com/urso/ucfg"
 
 	"github.com/elastic/beats/libbeat/logp"
 
@@ -22,7 +21,7 @@ func New() helper.Moduler {
 
 type Moduler struct{}
 
-func (r Moduler) Setup(cfg *ucfg.Config) error {
+func (m *Moduler) Setup(mo *helper.Module) error {
 	return nil
 }
 


### PR DESCRIPTION
* Make interface a pointer to make sure only one instance exists per Module
* Pass module to setup instead of config to give broader access to module. Removes also ucfg dependency.