### PR TITLE
Add Timeout config option for metricseter to exit

### DIFF
--- a/metricbeat/etc/beat.yml
+++ b/metricbeat/etc/beat.yml
@@ -13,7 +13,14 @@ metricbeat:
       metricsets: ["info"]
       period: 1s
       hosts: ["127.0.0.1:6379"]
-      enabled: true
+
+      # Enabled defines if the module is enabled. Default: true
+      #enabled: true
+
+      # Timeout after which time a metricset should return an error
+      # Timeout is by default defined as period, as a fetch of a metricset
+      # should never take longer then period, as otherwise calls can pile up.
+      #timeout: 1s
 
       # Selectors to only fetch a subset of metrics (whitelisting)
       # If no selectors are set, all metrics are sent.

--- a/metricbeat/helper/interfacer.go
+++ b/metricbeat/helper/interfacer.go
@@ -1,13 +1,33 @@
+/**
+
+= MetricSeter
+
+== Timeout
+Each metricseter must implement on his side to make sure the timeout is followed.
+Otherwise it can lead to the issue that multiple calls for one metricset happen in parallel and pile up.
+
+*/
+
 package helper
 
 import (
 	"github.com/elastic/beats/libbeat/common"
 )
 
+/*
+
+Implementation Background of Fetch
+
+The initial idea was to use a Cancel function, but it was not implemented as it would add complexity by requiring
+an identifier for each fetch call and it would have to be decide, which fetch call must be canceled.
+
+*/
+
 // Base configuration for each module/metricsets combination
 type ModuleConfig struct {
 	Hosts      []string `config:"hosts"`
 	Period     string   `config:"period"`
+	Timeout    string   `config:"timeout"`
 	Module     string   `config:"module"`
 	MetricSets []string `config:"metricsets"`
 	Enabled    bool     `config:"enabled"`
@@ -27,6 +47,7 @@ type MetricSeter interface {
 	// Fetch is called for each host. In case where host does not exist, it can be transferred
 	// differently in the setup to have a different meaning. An example here is for filesystem
 	// of topbeat, where each host could be a filesystem.
+	// Fetch is called on the predefined interval and does not take delays into account.
 	Fetch(ms *MetricSet, host string) (common.MapStr, error)
 }
 

--- a/metricbeat/helper/metricset.go
+++ b/metricbeat/helper/metricset.go
@@ -48,12 +48,11 @@ func (m *MetricSet) Setup() error {
 func (m *MetricSet) Fetch() error {
 
 	for _, host := range m.Config.Hosts {
-		// TODO Improve fetching in go routing -> how are go routines stopped if they take too long? - @ruflin,20160314
-		m.Module.wg.Add(1)
+
 		go func(h string) {
-			defer m.Module.wg.Done()
 
 			starttime := time.Now()
+			// Fetch method must make sure to return error after Timeout reached
 			event, err := m.MetricSeter.Fetch(m, h)
 			elapsed := time.Since(starttime)
 

--- a/metricbeat/metricbeat.yml
+++ b/metricbeat/metricbeat.yml
@@ -13,7 +13,14 @@ metricbeat:
       metricsets: ["info"]
       period: 1s
       hosts: ["127.0.0.1:6379"]
-      enabled: true
+
+      # Enabled defines if the module is enabled. Default: true
+      #enabled: true
+
+      # Timeout after which time a metricset should return an error
+      # Timeout is by default defined as period, as a fetch of a metricset
+      # should never take longer then period, as otherwise calls can pile up.
+      #timeout: 1s
 
       # Selectors to only fetch a subset of metrics (whitelisting)
       # If no selectors are set, all metrics are sent.

--- a/metricbeat/module/redis/info/info.go
+++ b/metricbeat/module/redis/info/info.go
@@ -46,7 +46,8 @@ func (m *MetricSeter) Setup(ms *helper.MetricSet) error {
 
 		// Set up redis pool
 		redisPool := rd.NewPool(func() (rd.Conn, error) {
-			c, err := rd.Dial(config.Network, host)
+			// Sets timeout to exit request if is longer then Timeout
+			c, err := rd.Dial(config.Network, host, rd.DialReadTimeout(ms.Module.Timeout))
 
 			if err != nil {
 				logp.Err("Failed to create Redis connection pool: %v", err)


### PR DESCRIPTION
The fetch on each metricseter is called based on the predefined ticker without taking delays of fetching into account. This can lead to the issue, that one metricset adds more requests before the last one was ended. The timeout variable was introduced. This allows to configure when the metricseter should exist. By default it is set to period, but it can also be selected larger or smaller then period based on the specific needs.

* Add timeout config option which is by default set to period
* Implement timeout for redis and mysql