### PR TITLE
Report event log records when a rendering error occurs

### DIFF
--- a/winlogbeat/eventlog/eventlog.go
+++ b/winlogbeat/eventlog/eventlog.go
@@ -1,6 +1,7 @@
 package eventlog
 
 import (
+	"expvar"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -21,6 +22,10 @@ var (
 	debugf  = logp.MakeDebug(debugSelector)
 	detailf = logp.MakeDebug(detailSelector)
 )
+
+// dropReasons contains counters for the number of dropped events for each
+// reason.
+var dropReasons = expvar.NewMap("dropReasons")
 
 // EventLog is an interface to a Windows Event Log.
 type EventLog interface {

--- a/winlogbeat/eventlog/wineventlog.go
+++ b/winlogbeat/eventlog/wineventlog.go
@@ -4,6 +4,8 @@ package eventlog
 
 import (
 	"fmt"
+	"strconv"
+	"syscall"
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
@@ -102,35 +104,19 @@ func (l *winEventLog) Read() ([]Record, error) {
 			l.renderBuf = make([]byte, bufErr.RequiredSize)
 			x, err = win.RenderEvent(h, 0, l.renderBuf, l.cache.get)
 		}
-		if err != nil {
+		if err != nil && x == "" {
 			logp.Err("%s Dropping event with rendering error. %v", l.logPrefix, err)
+			reportDrop(err)
 			continue
 		}
 
-		e, err := sys.UnmarshalEventXML([]byte(x))
+		r, err := l.buildRecordFromXML(x, err)
 		if err != nil {
-			logp.Err("%s Dropping event. Failed to unmarshal XML='%s'. %v",
-				l.logPrefix, x, err)
+			logp.Err("%s Dropping event. %v", l.logPrefix, err)
+			reportDrop("unmarshal")
 			continue
 		}
-
-		err = sys.PopulateAccount(&e.User)
-		if err != nil {
-			debugf("%s SID %s account lookup failed. %v", l.logPrefix,
-				e.User.Identifier, err)
-		}
-
-		// TODO: Enrich the event with RenderErr when there is a RenderErrorCode.
-
-		if logp.IsDebug(detailSelector) {
-			detailf("%s XML=%s Event=%+v", l.logPrefix, x, e)
-		}
-
-		records = append(records, Record{
-			API:           winEventLogAPIName,
-			EventMetadata: l.eventMetadata,
-			Event:         e,
-		})
+		records = append(records, r)
 	}
 
 	debugf("%s Read() is returning %d records", l.logPrefix, len(records))
@@ -140,6 +126,53 @@ func (l *winEventLog) Read() ([]Record, error) {
 func (l *winEventLog) Close() error {
 	debugf("%s Closing handle", l.logPrefix)
 	return win.Close(l.subscription)
+}
+
+func (l *winEventLog) buildRecordFromXML(x string, recoveredErr error) (Record, error) {
+	e, err := sys.UnmarshalEventXML([]byte(x))
+	if err != nil {
+		return Record{}, fmt.Errorf("Failed to unmarshal XML='%s'. %v", x, err)
+	}
+
+	err = sys.PopulateAccount(&e.User)
+	if err != nil {
+		debugf("%s SID %s account lookup failed. %v", l.logPrefix,
+			e.User.Identifier, err)
+	}
+
+	if e.RenderErrorCode != 0 {
+		// Convert the render error code to an error message that can be
+		// included in the "message_error" field.
+		e.RenderErr = syscall.Errno(e.RenderErrorCode).Error()
+	} else if recoveredErr != nil {
+		e.RenderErr = recoveredErr.Error()
+	}
+
+	if logp.IsDebug(detailSelector) {
+		detailf("%s XML=%s Event=%+v", l.logPrefix, x, e)
+	}
+
+	r := Record{
+		API:           winEventLogAPIName,
+		EventMetadata: l.eventMetadata,
+		Event:         e,
+	}
+
+	return r, nil
+}
+
+// reportDrop reports a dropped event log record and the reason as an expvar
+// metric. The reason should be a windows syscall.Errno or a string. Any other
+// types will be reported under the "other" key.
+func reportDrop(reason interface{}) {
+	switch t := reason.(type) {
+	default:
+		dropReasons.Add("other", 1)
+	case string:
+		dropReasons.Add(t, 1)
+	case syscall.Errno:
+		dropReasons.Add(strconv.Itoa(int(t)), 1)
+	}
 }
 
 // newWinEventLog creates and returns a new EventLog for reading event logs

--- a/winlogbeat/sys/eventlogging/eventlogging_windows.go
+++ b/winlogbeat/sys/eventlogging/eventlogging_windows.go
@@ -114,8 +114,8 @@ func RenderEvents(
 			return nil, 0, err
 		}
 
-		var qualifier uint16 = uint16((record.eventID & eventIDUpperMask) >> 16)
-		var eventID uint32 = record.eventID & eventIDLowerMask
+		var qualifier = uint16((record.eventID & eventIDUpperMask) >> 16)
+		var eventID = record.eventID & eventIDLowerMask
 		event := sys.Event{
 			Provider:        sys.Provider{Name: record.sourceName},
 			EventIdentifier: sys.EventIdentifier{ID: eventID, Qualifiers: qualifier},


### PR DESCRIPTION
This change improves the error handling. When an error occurs it will try to render the event without the message string (aka RenderingInfo). Then both the event data and the original error are reported in the published event.

This completes the change from #1153.