### PR TITLE
Add template option to reference docs

### DIFF
--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -177,6 +177,35 @@ The index root name to write events to. The default is the Beat name.
 For example "{beatname_lc}" generates "[{beatname_lc}-]YYYY.MM.DD" indexes (for example,
 "{beatname_lc}-2015.04.26").
 
+===== template
+
+The http://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates.html[index
+template] to use for setting mappings in Elasticsearch. By default, template loading is
+disabled. If you leave this option disabled, you must load the template by running the
+load script that is provided with {beatname_uc}. 
+
+If you enable the `template` config option, you can adjust the following settings to load your
+own template or overwrite an existing one:
+
+*`name`*:: The name of the template. The default is +{beatname_lc}+.
+
+*`path`*:: The path to the template file.
+
+*`overwrite`*:: A boolean that specifies whether to overwrite the existing template. The default
+is false.
+
+For example:
+
+["source","yaml",subs="attributes,callouts"]
+----------------------------------------------------------------------
+output:
+  elasticsearch:
+    hosts: ["localhost:9200"]
+      name: "{beatname_lc}"
+      path: "{beatname_lc}.template.json"
+      overwrite: false
+----------------------------------------------------------------------
+
 ===== max_retries
 
 The number of times to retry publishing an event after a publishing failure.


### PR DESCRIPTION
This PR adds content about the template option to the reference docs. It resolves the second item listed in #862. Content for the getting started was added in PRs #1142 and #1151 . So these additions close the doc changes for #862 