### PR TITLE
Add 'Origin: Elastic' to the APT repo metadata

### DIFF
--- a/dev-tools/packer/docker/deb-rpm-s3/deb-rpm-s3.sh
+++ b/dev-tools/packer/docker/deb-rpm-s3/deb-rpm-s3.sh
@@ -27,6 +27,7 @@ bucket="packages.elasticsearch.org"
 prefix="beats"
 dir="/beats-packer/build/upload"
 gpg_key="/beats-packer/docker/deb-rpm-s3/elasticsearch.asc"
+origin=Elastic
 
 docker run -it --rm \
   --env="PASS=$PASS" \
@@ -38,6 +39,7 @@ docker run -it --rm \
   --aws-access-key="$AWS_ACCESS_KEY" \
   --aws-secret-key="$AWS_SECRET_KEY" \
   --gpg-key="$gpg_key" \
+  --origin="$origin" \
   --verbose \
   "$@"
 

--- a/dev-tools/packer/docker/deb-rpm-s3/deb-s3.expect
+++ b/dev-tools/packer/docker/deb-rpm-s3/deb-s3.expect
@@ -9,6 +9,7 @@ spawn deb-s3 upload \
         --bucket "$env(BUCKET)" \
         --prefix "$env(PREFIX)/apt" \
         --arch $env(arch) \
+        -o "$env(ORIGIN)" \
         {*}$argv
 expect {
   "Enter passphrase: " {

--- a/dev-tools/packer/docker/deb-rpm-s3/publish-package-repositories.sh
+++ b/dev-tools/packer/docker/deb-rpm-s3/publish-package-repositories.sh
@@ -36,6 +36,8 @@ cat << EOF
 
     -g=GPG_KEY | --gpg-key=GPG_KEY   Optional. Path to GPG key file to import.
 
+    -o=ORIGIN | --origin=ORIGIN      Optional. Origin to use in APT repo metadata.
+
     -v | --verbose                   Optional. Enable verbose logging to stderr.
     
     -h | --help                      Optional. Print this usage information.
@@ -85,6 +87,10 @@ parseArgs() {
       usage
       exit 1
       ;;
+    -o=*|--origin=*)
+      ORIGIN="${i#*=}"
+      shift
+      ;;
     -p=*|--prefix=*)
       PREFIX="${i#*=}"
       shift
@@ -132,6 +138,7 @@ parseArgs() {
   fi
 
   export BUCKET
+  export ORIGIN 
   export PREFIX
   export AWS_ACCESS_KEY
   export AWS_SECRET_KEY


### PR DESCRIPTION
https://wiki.debian.org/RepositoryFormat#Origin

https://discuss.elastic.co/t/missing-origin-field-on-filebeat-packetbeat-deb-packages/44541/3

I tested it to make sure it publishes with `Origin: Elastic` in the Release file.