### PR TITLE
Add Host information to each metricset event

### DIFF
--- a/metricbeat/helper/metricset.go
+++ b/metricbeat/helper/metricset.go
@@ -57,7 +57,7 @@ func (m *MetricSet) Fetch() error {
 			event, err := m.MetricSeter.Fetch(m, h)
 			elapsed := time.Since(starttime)
 
-			event = m.createEvent(event, elapsed, err)
+			event = m.createEvent(event, h, elapsed, err)
 
 			m.Module.Publish <- event
 
@@ -66,7 +66,7 @@ func (m *MetricSet) Fetch() error {
 	return nil
 }
 
-func (m *MetricSet) createEvent(event common.MapStr, rtt time.Duration, eventErr error) common.MapStr {
+func (m *MetricSet) createEvent(event common.MapStr, host string, rtt time.Duration, eventErr error) common.MapStr {
 
 	// Most of the time, event is nil in case of error (not required)
 	if event == nil {
@@ -106,6 +106,12 @@ func (m *MetricSet) createEvent(event common.MapStr, rtt time.Duration, eventErr
 		}
 	}
 
+	// Adds host name to event. In case credentials are passed through hostname, these are contained in this string
+	if host != "" {
+		event["metricset-host"] = host
+	}
+
+	// Adds error to event in case error happened
 	if eventErr != nil {
 		event["error"] = eventErr.Error()
 	}

--- a/metricbeat/helper/metricset_test.go
+++ b/metricbeat/helper/metricset_test.go
@@ -3,7 +3,9 @@
 package helper
 
 import (
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -92,6 +94,50 @@ func TestApplySelectorTwoNested(t *testing.T) {
 			"hd": "not available",
 		},
 	}, newEvent)
+}
+
+func TestCreateEvent(t *testing.T) {
+	module := &Module{}
+	metricSet, _ := NewMetricSet("mockmetricset1", NewMockMetricSeter, module)
+
+	event := common.MapStr{}
+	host := "localhost"
+	rtt, _ := time.ParseDuration("1s")
+	event = metricSet.createEvent(event, host, rtt, nil)
+
+	assert.Equal(t, host, event["metricset-host"])
+
+	_, ok := event["error"]
+	assert.False(t, ok)
+	assert.Equal(t, rtt.Nanoseconds()/1000, event["rtt"])
+}
+
+func TestCreateEventError(t *testing.T) {
+	module := &Module{}
+	metricSet, _ := NewMetricSet("mockmetricset1", NewMockMetricSeter, module)
+
+	event := common.MapStr{}
+	host := "localhost"
+	rtt, _ := time.ParseDuration("1s")
+
+	eventErr := fmt.Errorf("hello world")
+	event = metricSet.createEvent(event, host, rtt, eventErr)
+
+	assert.Equal(t, host, event["metricset-host"])
+	assert.Equal(t, eventErr.Error(), event["error"])
+}
+
+func TestCreateEventNoHost(t *testing.T) {
+	module := &Module{}
+	metricSet, _ := NewMetricSet("mockmetricset1", NewMockMetricSeter, module)
+
+	event := common.MapStr{}
+	rtt, _ := time.ParseDuration("1s")
+
+	event = metricSet.createEvent(event, "", rtt, nil)
+
+	_, ok := event["metricset-host"]
+	assert.False(t, ok)
 }
 
 /*** Mock tests objects ***/

--- a/metricbeat/module/redis/info/info.go
+++ b/metricbeat/module/redis/info/info.go
@@ -31,7 +31,6 @@ func (m *MetricSeter) Setup(ms *helper.MetricSet) error {
 
 	// Additional configuration options
 	config := struct {
-		// TODO: Introduce default value for network
 		Network string `config:"network"`
 		MaxConn int    `config:"maxconn"`
 	}{


### PR DESCRIPTION
This host information is required so on the elasticsearch side it can be identified which has was called in case multiple hosts are defined.