### PR TITLE
Add support for double fields

### DIFF
--- a/libbeat/scripts/generate_template.py
+++ b/libbeat/scripts/generate_template.py
@@ -137,6 +137,11 @@ def fill_field_properties(field, defaults):
             "type": "float",
             "doc_values": "true"
         }
+    elif field.get("type") == "double":
+        properties[field["name"]] = {
+            "type": "double",
+            "doc_values": "true"
+        }
     elif field.get("type") == "integer":
         properties[field["name"]] = {
             "type": "integer",


### PR DESCRIPTION
When we generate elasticsearch template we don't treat `double` fields.