### PR TITLE
Remove count from the Topbeat event

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -25,6 +25,7 @@ https://github.com/elastic/beats/compare/v1.1.2...master[Check the HEAD diff]
 
 *Topbeat*
 - Rename proc.cpu.user_p with proc.cpu.total_p as includes CPU time spent in kernel space {pull}631[631]
+- Remove count field from the exported fields {pull}1207[1207]
 
 *Filebeat*
 - Default config for ignore_older is now infinite instead of 24h, means ignore_older is disabled by default. Use close_older to only close file handlers.

--- a/topbeat/docs/fields.asciidoc
+++ b/topbeat/docs/fields.asciidoc
@@ -41,15 +41,6 @@ required: True
 Set to "system" to indicate that the statistics are system-wide.
 
 
-==== count
-
-type: int
-
-required: True
-
-The number of transactions that this event represents. This is generally the inverse of the sampling rate. For example, for a sample rate of 1/10, the count is 10. The count is used by the UIs to return estimated values. Reserved for future usage.
-
-
 ==== beat.name
 
 Name of the Beat sending the events. If the shipper name is set in the configuration file, then that value is used. If it is not set, the hostname is used.

--- a/topbeat/etc/fields.yml
+++ b/topbeat/etc/fields.yml
@@ -26,15 +26,6 @@ env:
         Set to "system" to indicate that the statistics are system-wide.
       required: true
 
-    - name: count
-      type: int
-      description: >
-        The number of transactions that this event represents. This
-        is generally the inverse of the sampling rate. For example, for
-        a sample rate of 1/10, the count is 10. The count is used by the
-        UIs to return estimated values. Reserved for future usage.
-      required: true
-
     - name: beat.name
       description: >
         Name of the Beat sending the events. If the shipper name is set

--- a/topbeat/system/cpu.go
+++ b/topbeat/system/cpu.go
@@ -1,11 +1,12 @@
 package system
 
 import (
+	"strconv"
+	"time"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	sigar "github.com/elastic/gosigar"
-	"strconv"
-	"time"
 )
 
 type CPU struct {
@@ -147,7 +148,6 @@ func (cpu *CPU) GetSystemStats() (common.MapStr, error) {
 	event := common.MapStr{
 		"@timestamp": common.Time(time.Now()),
 		"type":       "system",
-		"count":      1,
 		"load":       loadStat,
 		"cpu":        GetCpuStatEvent(cpuStat),
 		"mem":        GetMemoryEvent(memStat),

--- a/topbeat/system/filesystem.go
+++ b/topbeat/system/filesystem.go
@@ -66,7 +66,6 @@ func CollectFileSystemStats(fss []sigar.FileSystem) []common.MapStr {
 		event := common.MapStr{
 			"@timestamp": common.Time(time.Now()),
 			"type":       "filesystem",
-			"count":      1,
 			"fs":         GetFilesystemEvent(fsStat),
 		}
 		events = append(events, event)

--- a/topbeat/system/process.go
+++ b/topbeat/system/process.go
@@ -230,7 +230,6 @@ func (procStats *ProcStats) GetProcStats() ([]common.MapStr, error) {
 			event := common.MapStr{
 				"@timestamp": common.Time(time.Now()),
 				"type":       "process",
-				"count":      1,
 				"proc":       proc,
 			}
 


### PR DESCRIPTION
Remove the count field from the Topbeat event as it was also removed by Filebeat in https://github.com/elastic/beats/pull/1166