### PR TITLE
Remove count field from the Packetbeat event

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -22,6 +22,7 @@ https://github.com/elastic/beats/compare/v1.1.2...master[Check the HEAD diff]
 - Rename output fields in the dns package. Former flag `recursion_allowed` becomes `recursion_available`. {pull}803[803]
   Former SOA field `ttl` becomes `minimum`. {pull}803[803]
 - The fully qualified domain names which are part of output fields values of the dns package now terminate with a dot. {pull}803[803]
+- Remove the count field from the exported event {pull}1210[1210]
 
 *Topbeat*
 - Rename proc.cpu.user_p with proc.cpu.total_p as includes CPU time spent in kernel space {pull}631[631]

--- a/packetbeat/docs/fields.asciidoc
+++ b/packetbeat/docs/fields.asciidoc
@@ -304,15 +304,6 @@ required: True
 The type of the transaction (for example, HTTP, MySQL, Redis, or RUM).
 
 
-==== count
-
-type: int
-
-required: True
-
-A count of the number of transactions that this event represents. This is generally the inverse of the sampling rate. For example, for a sample rate of 1/10, the count is 10. The count is used by the UIs to return estimated values.
-
-
 ==== direction
 
 required: True

--- a/packetbeat/etc/fields.yml
+++ b/packetbeat/etc/fields.yml
@@ -347,15 +347,6 @@ trans_event:
         The type of the transaction (for example, HTTP, MySQL, Redis, or RUM).
       required: true
 
-    - name: count
-      type: int
-      description: >
-        A count of the number of transactions that this event represents. This
-        is generally the inverse of the sampling rate. For example, for
-        a sample rate of 1/10, the count is 10. The count is used by the
-        UIs to return estimated values.
-      required: true
-
     - name: direction
       required: true
       description: >

--- a/packetbeat/flows/worker.go
+++ b/packetbeat/flows/worker.go
@@ -193,7 +193,6 @@ func createEvent(
 		"last_time":  common.Time(f.ts),
 		"type":       "flow",
 		"flow_id":    common.NetString(f.id.Serialize()),
-		"count":      1,
 		"final":      isOver,
 	}
 

--- a/packetbeat/protos/icmp/icmp.go
+++ b/packetbeat/protos/icmp/icmp.go
@@ -266,7 +266,6 @@ func (icmp *Icmp) publishTransaction(trans *icmpTransaction) {
 	// common fields - group "event"
 	event["@timestamp"] = common.Time(trans.Ts) // timestamp of the first packet
 	event["type"] = "icmp"                      // protocol name
-	event["count"] = 1                          // reserved for future sampling support
 	event["path"] = trans.Tuple.DstIp           // what is requested (dst ip)
 	if trans.HasError() {
 		event["status"] = common.ERROR_STATUS

--- a/packetbeat/publish/publish.go
+++ b/packetbeat/publish/publish.go
@@ -147,11 +147,6 @@ func validateEvent(event common.MapStr) error {
 		return errors.New("invalid '@timestamp' field from event")
 	}
 
-	err := event.EnsureCountField()
-	if err != nil {
-		return err
-	}
-
 	t, ok := event["type"]
 	if !ok {
 		return errors.New("missing 'type' field from event")
@@ -210,8 +205,6 @@ func normalizeTransAddr(pub *publisher.PublisherType, event common.MapStr) bool 
 		}
 
 	}
-
-	event.EnsureCountField()
 
 	if pub.GeoLite != nil {
 		realIP, exists := event["real_ip"]

--- a/packetbeat/tests/system/packetbeat.py
+++ b/packetbeat/tests/system/packetbeat.py
@@ -11,13 +11,10 @@ from beat.beat import TestCase
 from beat.beat import Proc
 
 TRANS_REQUIRED_FIELDS = ["@timestamp", "type", "status",
-                         "beat.name", "beat.hostname",
-                         "count"]
+                         "beat.name", "beat.hostname"]
 
 FLOWS_REQUIRED_FIELDS = ["@timestamp", "type",
-                         "beat.name", "beat.hostname",
-                         "count"]
-
+                         "beat.name", "beat.hostname"]
 
 
 class BaseTest(TestCase):

--- a/packetbeat/tests/system/test_0001_mysql_spaces.py
+++ b/packetbeat/tests/system/test_0001_mysql_spaces.py
@@ -17,23 +17,19 @@ class Test(BaseTest):
         assert objs[0]["method"] == "SET"
         assert objs[0]["path"] == ""
         assert objs[0]["status"] == "OK"
-        assert objs[0]["count"] == 1
 
         assert objs[2]["method"] == "DROP"
         assert objs[2]["mysql.iserror"] is False
         assert objs[2]["status"] == "OK"
-        assert objs[0]["count"] == 1
 
         assert objs[3]["method"] == "CREATE"
         assert objs[3]["mysql.iserror"] is False
         assert objs[3]["status"] == "OK"
-        assert objs[0]["count"] == 1
 
         assert objs[5]["method"] == "SELECT"
         assert objs[5]["path"] == "test.test"
         assert objs[5]["status"] == "OK"
         assert objs[5]["bytes_out"] == 118
-        assert objs[0]["count"] == 1
 
         assert all(["bytes_in" in o.keys() for o in objs])
         assert all(["bytes_out" in o.keys() for o in objs])

--- a/packetbeat/tests/system/test_0027_mysql_affected_rows.py
+++ b/packetbeat/tests/system/test_0027_mysql_affected_rows.py
@@ -18,4 +18,3 @@ class Test(BaseTest):
         assert objs[0]["method"] == "UPDATE"
         assert objs[0]["mysql.affected_rows"] == 316
         assert objs[0]["status"] == "OK"
-        assert objs[0]["count"] == 1

--- a/packetbeat/tests/system/test_0028_mysql_error.py
+++ b/packetbeat/tests/system/test_0028_mysql_error.py
@@ -19,4 +19,3 @@ class Test(BaseTest):
         assert objs[0]["status"] == "Error"
         assert objs[0]["mysql.error_code"] == 1046
         assert objs[0]["mysql.error_message"] == "3D000: No database selected"
-        assert objs[0]["count"] == 1

--- a/packetbeat/tests/system/test_0050_icmp.py
+++ b/packetbeat/tests/system/test_0050_icmp.py
@@ -68,7 +68,6 @@ class Test(BaseTest):
 
     def assert_common_fields(self, objs):
         assert all([o["type"] == "icmp" for o in objs])
-        assert all([o["count"] == 1 for o in objs])
         assert all([o["bytes_in"] == 4 for o in objs])
         assert all([o["bytes_out"] == 4 for o in objs])
         assert all([("port" in o) == False for o in objs])

--- a/packetbeat/tests/system/test_0051_amqp_publish.py
+++ b/packetbeat/tests/system/test_0051_amqp_publish.py
@@ -23,7 +23,6 @@ class Test(BaseTest):
         assert objs[0]["amqp.auto-delete"] == False
         assert objs[0]["amqp.exclusive"] == False
         assert objs[0]["amqp.no-wait"] == False
-        assert objs[0]["count"] == 1
 
         assert objs[1]["method"] == "basic.publish"
         assert objs[1]["status"] == "OK"
@@ -32,4 +31,3 @@ class Test(BaseTest):
         assert objs[1]["amqp.mandatory"] == False
         assert objs[1]["amqp.immediate"] == False
         assert objs[1]["amqp.content-type"] == "text/plain"
-        assert objs[1]["count"] == 1

--- a/packetbeat/tests/system/test_0052_amqp_emit_receive.py
+++ b/packetbeat/tests/system/test_0052_amqp_emit_receive.py
@@ -22,7 +22,6 @@ class Test(BaseTest):
         assert objs[0]["amqp.exchange-type"] == "fanout"
         assert objs[0]["amqp.passive"] == False
         assert objs[0]["amqp.no-wait"] == False
-        assert objs[0]["count"] == 1
 
         assert objs[1]["method"] == "queue.declare"
         assert objs[1]["status"] == "OK"
@@ -32,14 +31,12 @@ class Test(BaseTest):
         assert objs[1]["amqp.durable"] == False
         assert objs[1]["amqp.auto-delete"] == False
         assert objs[1]["amqp.passive"] == False
-        assert objs[1]["count"] == 1
 
         assert objs[2]["method"] == "queue.bind"
         assert objs[2]["status"] == "OK"
         assert objs[2]["amqp.queue"] != ""
         assert objs[2]["amqp.exchange"] == "logs"
         assert objs[2]["amqp.no-wait"] == False
-        assert objs[2]["count"] == 1
 
         assert objs[3]["method"] == "basic.consume"
         assert objs[3]["status"] == "OK"
@@ -48,7 +45,6 @@ class Test(BaseTest):
         assert objs[3]["amqp.no-wait"] == False
         assert objs[3]["amqp.no-local"] == False
         assert objs[3]["amqp.exclusive"] == False
-        assert objs[3]["count"] == 1
 
         assert objs[4]["method"] == "exchange.declare"
         assert objs[4]["status"] == "OK"
@@ -57,7 +53,6 @@ class Test(BaseTest):
         assert objs[4]["amqp.exchange-type"] == "fanout"
         assert objs[4]["amqp.passive"] == False
         assert objs[4]["amqp.no-wait"] == False
-        assert objs[4]["count"] == 1
 
         assert objs[5]["method"] == "basic.publish"
         assert objs[5]["status"] == "OK"
@@ -65,7 +60,6 @@ class Test(BaseTest):
         assert objs[5]["amqp.exchange"] == "logs"
         assert objs[5]["amqp.immediate"] == False
         assert objs[5]["amqp.mandatory"] == False
-        assert objs[5]["count"] == 1
 
         assert objs[6]["method"] == "basic.deliver"
         assert objs[6]["status"] == "OK"
@@ -73,4 +67,3 @@ class Test(BaseTest):
         assert objs[6]["amqp.delivery-tag"] == 1
         assert objs[6]["amqp.exchange"] == "logs"
         assert objs[6]["amqp.redelivered"] == False
-        assert objs[6]["count"] == 1

--- a/packetbeat/tests/system/test_0053_amqp_channel_error.py
+++ b/packetbeat/tests/system/test_0053_amqp_channel_error.py
@@ -21,7 +21,6 @@ class Test(BaseTest):
         assert objs[0]["amqp.exchange-type"] == "fanout"
         assert objs[0]["amqp.passive"] == False
         assert objs[0]["amqp.no-wait"] == True
-        assert objs[0]["count"] == 1
 
         assert objs[1]["method"] == "queue.declare"
         assert objs[1]["status"] == "OK"
@@ -31,7 +30,6 @@ class Test(BaseTest):
         assert objs[1]["amqp.durable"] == False
         assert objs[1]["amqp.auto-delete"] == False
         assert objs[1]["amqp.passive"] == False
-        assert objs[1]["count"] == 1
 
         assert objs[2]["method"] == "channel.close"
         assert objs[2]["status"] == "Error"
@@ -39,4 +37,3 @@ class Test(BaseTest):
         assert objs[2]["amqp.reply-text"] == "NOT_FOUND - no exchange 'plop' in vhost '/'"
         assert objs[2]["amqp.class-id"] == 50
         assert objs[2]["amqp.method-id"] == 20
-        assert objs[2]["count"] == 1


### PR DESCRIPTION
Similar with the other Beats, removing the count field from the Packetbeat event.
This change requires an update of the Packetbeat dashboards as they rely on count.