### PR TITLE
Update to ucfg v0.1.1

### DIFF
--- a/filebeat/beater/spooler_test.go
+++ b/filebeat/beater/spooler_test.go
@@ -6,14 +6,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/urso/ucfg/yaml"
-
 	cfg "github.com/elastic/beats/filebeat/config"
+	"github.com/elastic/beats/libbeat/common"
 	"github.com/stretchr/testify/assert"
 )
 
 func load(t *testing.T, in string) cfg.FilebeatConfig {
-	yaml, err := yaml.NewConfig([]byte(in))
+	yaml, err := common.NewConfigWithYAML([]byte(in), "")
 	if err != nil {
 		t.Fatalf("Failed to parse config input: %v", err)
 	}

--- a/glide.yaml
+++ b/glide.yaml
@@ -58,6 +58,6 @@ import:
 - package: github.com/dustin/go-humanize
   version: 8929fe90cee4b2cb9deb468b51fb34eba64d1bf0
 - package: github.com/urso/ucfg
-  version: 60c5618c1d445e97c3c52d738dbc887d68af76a5
+  version: v0.1.1
 - package: github.com/armon/go-socks5
   version: 3a873e99f5400ad7706e464e905ffcc94b3ff247

--- a/libbeat/beat/beat.go
+++ b/libbeat/beat/beat.go
@@ -28,14 +28,13 @@ import (
 	"runtime"
 	"sync"
 
-	"github.com/satori/go.uuid"
-	"github.com/urso/ucfg"
-
 	"github.com/elastic/beats/libbeat/cfgfile"
+	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/filter"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/publisher"
 	"github.com/elastic/beats/libbeat/service"
+	"github.com/satori/go.uuid"
 )
 
 // Beater interface that every beat must use
@@ -82,7 +81,7 @@ const (
 
 // BeatConfig struct contains the basic configuration of every beat
 type BeatConfig struct {
-	Output  map[string]*ucfg.Config
+	Output  map[string]*common.Config
 	Logging logp.Logging
 	Shipper publisher.ShipperConfig
 	Filter  []filter.FilterConfig

--- a/libbeat/cfgfile/cfgfile.go
+++ b/libbeat/cfgfile/cfgfile.go
@@ -8,9 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/urso/ucfg"
-	"github.com/urso/ucfg/yaml"
-
+	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 )
 
@@ -57,12 +55,12 @@ func Read(out interface{}, path string) error {
 	}
 	filecontent = expandEnv(filecontent)
 
-	config, err := yaml.NewConfig(filecontent, ucfg.PathSep("."))
+	config, err := common.NewConfigWithYAML(filecontent, path)
 	if err != nil {
 		return fmt.Errorf("YAML config parsing failed on %s: %v. Exiting.", path, err)
 	}
 
-	err = config.Unpack(out, ucfg.PathSep("."))
+	err = config.Unpack(out)
 	if err != nil {
 		return fmt.Errorf("Failed to apply config %s: %v. Exiting. ", path, err)
 	}

--- a/libbeat/common/config.go
+++ b/libbeat/common/config.go
@@ -1,0 +1,100 @@
+package common
+
+import (
+	"github.com/urso/ucfg"
+	"github.com/urso/ucfg/yaml"
+)
+
+type Config ucfg.Config
+
+func NewConfig() *Config {
+	return fromConfig(ucfg.New())
+}
+
+func NewConfigFrom(from interface{}) (*Config, error) {
+	c, err := ucfg.NewFrom(from, ucfg.PathSep("."))
+	return fromConfig(c), err
+}
+
+func NewConfigWithYAML(in []byte, source string) (*Config, error) {
+	c, err := yaml.NewConfig(in, ucfg.PathSep("."), ucfg.MetaData(ucfg.Meta{source}))
+	return fromConfig(c), err
+}
+
+func LoadFile(path string) (*Config, error) {
+	c, err := yaml.NewConfigWithFile(path, ucfg.PathSep("."))
+	return fromConfig(c), err
+}
+
+func (c *Config) Merge(from interface{}) error {
+	return c.access().Merge(from, ucfg.PathSep("."))
+}
+
+func (c *Config) Unpack(to interface{}) error {
+	return c.access().Unpack(to, ucfg.PathSep("."))
+}
+
+func (c *Config) Path() string {
+	return c.access().Path(".")
+}
+
+func (c *Config) PathOf(field string) string {
+	return c.access().PathOf(field, ".")
+}
+
+func (c *Config) HasField(name string) bool {
+	return c.access().HasField(name)
+}
+
+func (c *Config) CountField(name string) (int, error) {
+	return c.access().CountField(name)
+}
+
+func (c *Config) Bool(name string, idx int) (bool, error) {
+	return c.access().Bool(name, idx, ucfg.PathSep("."))
+}
+
+func (c *Config) String(name string, idx int) (string, error) {
+	return c.access().String(name, idx, ucfg.PathSep("."))
+}
+
+func (c *Config) Int(name string, idx int) (int64, error) {
+	return c.access().Int(name, idx, ucfg.PathSep("."))
+}
+
+func (c *Config) Float(name string, idx int) (float64, error) {
+	return c.access().Float(name, idx, ucfg.PathSep("."))
+}
+
+func (c *Config) Child(name string, idx int) (*Config, error) {
+	sub, err := c.access().Child(name, idx, ucfg.PathSep("."))
+	return fromConfig(sub), err
+}
+
+func (c *Config) SetBool(name string, idx int, value bool) error {
+	return c.access().SetBool(name, idx, value, ucfg.PathSep("."))
+}
+
+func (c *Config) SetInt(name string, idx int, value int64) error {
+	return c.access().SetInt(name, idx, value, ucfg.PathSep("."))
+}
+
+func (c *Config) SetFloat(name string, idx int, value float64) error {
+	return c.access().SetFloat(name, idx, value, ucfg.PathSep("."))
+}
+
+func (c *Config) SetString(name string, idx int, value string) error {
+	return c.access().SetString(name, idx, value, ucfg.PathSep("."))
+}
+
+func (c *Config) SetChild(name string, idx int, value *Config) error {
+	return c.access().SetChild(name, idx, value.access(), ucfg.PathSep("."))
+}
+
+func fromConfig(in *ucfg.Config) *Config {
+	return (*Config)(in)
+}
+
+func (c *Config) access() *ucfg.Config {
+	return (*ucfg.Config)(c)
+}

--- a/libbeat/outputs/console/console.go
+++ b/libbeat/outputs/console/console.go
@@ -4,8 +4,6 @@ import (
 	"encoding/json"
 	"os"
 
-	"github.com/urso/ucfg"
-
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/outputs"
@@ -19,7 +17,7 @@ type console struct {
 	config config
 }
 
-func New(config *ucfg.Config, _ int) (outputs.Outputer, error) {
+func New(config *common.Config, _ int) (outputs.Outputer, error) {
 	c := &console{config: defaultConfig}
 	err := config.Unpack(&c.config)
 	if err != nil {

--- a/libbeat/outputs/elasticsearch/config.go
+++ b/libbeat/outputs/elasticsearch/config.go
@@ -1,6 +1,10 @@
 package elasticsearch
 
-import "github.com/elastic/beats/libbeat/outputs"
+import (
+	"time"
+
+	"github.com/elastic/beats/libbeat/outputs"
+)
 
 type elasticsearchConfig struct {
 	Protocol     string             `config:"protocol"`
@@ -13,7 +17,7 @@ type elasticsearchConfig struct {
 	LoadBalance  bool               `config:"loadbalance"`
 	TLS          *outputs.TLSConfig `config:"tls"`
 	MaxRetries   int                `config:"max_retries"`
-	Timeout      int                `config:"timeout"`
+	Timeout      time.Duration      `config:"timeout"`
 	SaveTopology bool               `config:"save_topology"`
 	Template     Template           `config:"template"`
 }
@@ -36,7 +40,7 @@ var (
 		Params:      nil,
 		Username:    "",
 		Password:    "",
-		Timeout:     90,
+		Timeout:     90 * time.Second,
 		MaxRetries:  3,
 		TLS:         nil,
 		LoadBalance: true,

--- a/libbeat/outputs/elasticsearch/output.go
+++ b/libbeat/outputs/elasticsearch/output.go
@@ -9,8 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/urso/ucfg"
-
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/outputs"
@@ -43,7 +41,7 @@ var (
 )
 
 // NewOutput instantiates a new output plugin instance publishing to elasticsearch.
-func New(cfg *ucfg.Config, topologyExpire int) (outputs.Outputer, error) {
+func New(cfg *common.Config, topologyExpire int) (outputs.Outputer, error) {
 	if !cfg.HasField("bulk_max_size") {
 		cfg.SetInt("bulk_max_size", 0, defaultBulkSize)
 	}
@@ -57,7 +55,7 @@ func New(cfg *ucfg.Config, topologyExpire int) (outputs.Outputer, error) {
 }
 
 func (out *elasticsearchOutput) init(
-	cfg *ucfg.Config,
+	cfg *common.Config,
 	topologyExpire int,
 ) error {
 	config := defaultConfig
@@ -75,8 +73,6 @@ func (out *elasticsearchOutput) init(
 		return err
 	}
 
-	timeout := time.Duration(config.Timeout) * time.Second
-
 	maxRetries := config.MaxRetries
 	maxAttempts := maxRetries + 1 // maximum number of send attempts (-1 = infinite)
 	if maxRetries < 0 {
@@ -89,7 +85,7 @@ func (out *elasticsearchOutput) init(
 	out.clients = clients
 	loadBalance := config.LoadBalance
 	m, err := mode.NewConnectionMode(clients, !loadBalance,
-		maxAttempts, waitRetry, timeout, maxWaitRetry)
+		maxAttempts, waitRetry, config.Timeout, maxWaitRetry)
 	if err != nil {
 		return err
 	}

--- a/libbeat/outputs/elasticsearch/output_test.go
+++ b/libbeat/outputs/elasticsearch/output_test.go
@@ -9,8 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/urso/ucfg"
-
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/outputs"
@@ -27,7 +25,7 @@ func createElasticsearchConnection(flushInterval int, bulkSize int) elasticsearc
 		logp.Err("Invalid port. Cannot be converted to in: %s", GetEsPort())
 	}
 
-	config, _ := ucfg.NewFrom(map[string]interface{}{
+	config, _ := common.NewConfigFrom(map[string]interface{}{
 		"save_topology":  true,
 		"hosts":          []string{GetEsHost()},
 		"port":           esPort,

--- a/libbeat/outputs/fileout/file.go
+++ b/libbeat/outputs/fileout/file.go
@@ -3,8 +3,6 @@ package fileout
 import (
 	"encoding/json"
 
-	"github.com/urso/ucfg"
-
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/outputs"
@@ -18,7 +16,7 @@ type fileOutput struct {
 	rotator logp.FileRotator
 }
 
-func New(cfg *ucfg.Config, _ int) (outputs.Outputer, error) {
+func New(cfg *common.Config, _ int) (outputs.Outputer, error) {
 	config := defaultConfig
 	if err := cfg.Unpack(&config); err != nil {
 		return nil, err
@@ -41,6 +39,7 @@ func (out *fileOutput) init(config config) error {
 	if out.rotator.Name == "" {
 		out.rotator.Name = config.Index
 	}
+	logp.Info("File output path set to: %v", out.rotator.Path)
 	logp.Info("File output base filename set to: %v", out.rotator.Name)
 
 	rotateeverybytes := uint64(config.RotateEveryKb) * 1024

--- a/libbeat/outputs/kafka/config.go
+++ b/libbeat/outputs/kafka/config.go
@@ -9,7 +9,7 @@ import (
 type kafkaConfig struct {
 	Hosts           []string           `config:"hosts"`
 	TLS             *outputs.TLSConfig `config:"tls"`
-	Timeout         int                `config:"timeout"`
+	Timeout         time.Duration      `config:"timeout"`
 	Worker          int                `config:"worker"`
 	UseType         bool               `config:"use_type"`
 	Topic           string             `config:"topic"`
@@ -24,7 +24,7 @@ type kafkaConfig struct {
 
 var (
 	defaultConfig = kafkaConfig{
-		Timeout:     30,
+		Timeout:     30 * time.Second,
 		Worker:      1,
 		Compression: "gzip",
 		ClientID:    "beats",

--- a/libbeat/outputs/kafka/kafka.go
+++ b/libbeat/outputs/kafka/kafka.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/Shopify/sarama"
-	"github.com/urso/ucfg"
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
@@ -41,7 +40,7 @@ var (
 	}
 )
 
-func New(cfg *ucfg.Config, topologyExpire int) (outputs.Outputer, error) {
+func New(cfg *common.Config, topologyExpire int) (outputs.Outputer, error) {
 	output := &kafka{}
 	err := output.init(cfg)
 	if err != nil {
@@ -50,7 +49,7 @@ func New(cfg *ucfg.Config, topologyExpire int) (outputs.Outputer, error) {
 	return output, nil
 }
 
-func (k *kafka) init(cfg *ucfg.Config) error {
+func (k *kafka) init(cfg *common.Config) error {
 	debugf("initialize kafka output")
 
 	config := defaultConfig
@@ -134,7 +133,7 @@ func newKafkaConfig(config *kafkaConfig) (*sarama.Config, int, error) {
 	modeRetries := 1
 
 	// configure network level properties
-	timeout := time.Duration(config.Timeout) * time.Second
+	timeout := config.Timeout
 	k.Net.DialTimeout = timeout
 	k.Net.ReadTimeout = timeout
 	k.Net.WriteTimeout = timeout

--- a/libbeat/outputs/kafka/kafka_integration_test.go
+++ b/libbeat/outputs/kafka/kafka_integration_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/outputs"
 	"github.com/stretchr/testify/assert"
-	"github.com/urso/ucfg"
 )
 
 const (
@@ -61,7 +60,7 @@ func newTestKafkaOutput(t *testing.T, topic string, useType bool) outputs.Output
 		"use_type":       useType,
 	}
 
-	cfg, err := ucfg.NewFrom(config, ucfg.PathSep("."))
+	cfg, err := common.NewConfigFrom(config)
 	assert.NoError(t, err)
 	output, err := New(cfg, 0)
 	assert.NoError(t, err)

--- a/libbeat/outputs/logstash/config.go
+++ b/libbeat/outputs/logstash/config.go
@@ -3,6 +3,7 @@ package logstash
 import (
 	"fmt"
 	"net/url"
+	"time"
 
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/outputs"
@@ -15,7 +16,7 @@ type logstashConfig struct {
 	Port             int                `config:"port"`
 	LoadBalance      bool               `config:"loadbalance"`
 	BulkMaxSize      int                `config:"bulk_max_size"`
-	Timeout          int                `config:"timeout"`
+	Timeout          time.Duration      `config:"timeout"`
 	CompressionLevel int                `config:"compression_level"`
 	MaxRetries       int                `config:"max_retries"`
 	TLS              *outputs.TLSConfig `config:"tls"`
@@ -28,7 +29,7 @@ var (
 		LoadBalance:      false,
 		BulkMaxSize:      2048,
 		CompressionLevel: 3,
-		Timeout:          30,
+		Timeout:          30 * time.Second,
 		MaxRetries:       3,
 	}
 )

--- a/libbeat/outputs/logstash/logstash_integration_test.go
+++ b/libbeat/outputs/logstash/logstash_integration_test.go
@@ -9,8 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/urso/ucfg"
-
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/outputs"
 	"github.com/elastic/beats/libbeat/outputs/elasticsearch"
@@ -137,7 +135,7 @@ func newTestElasticsearchOutput(t *testing.T, test string) *testOutputer {
 
 	flushInterval := 0
 	bulkSize := 0
-	config, _ := ucfg.NewFrom(map[string]interface{}{
+	config, _ := common.NewConfigFrom(map[string]interface{}{
 		"hosts":          []string{getElasticsearchHost()},
 		"index":          index,
 		"flush_interval": &flushInterval,

--- a/libbeat/outputs/logstash/logstash_test.go
+++ b/libbeat/outputs/logstash/logstash_test.go
@@ -18,7 +18,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/urso/ucfg"
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/streambuf"
@@ -113,7 +112,7 @@ func newTestLumberjackOutput(
 		t.Fatalf("No logstash output plugin found")
 	}
 
-	cfg, _ := ucfg.NewFrom(config, ucfg.PathSep("."))
+	cfg, _ := common.NewConfigFrom(config)
 	output, err := plugin(cfg, 0)
 	if err != nil {
 		t.Fatalf("init logstash output plugin failed: %v", err)

--- a/libbeat/outputs/mode/mode.go
+++ b/libbeat/outputs/mode/mode.go
@@ -7,8 +7,6 @@ import (
 	"expvar"
 	"time"
 
-	"github.com/urso/ucfg"
-
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/outputs"
@@ -126,7 +124,7 @@ func NewAsyncConnectionMode(
 // MakeClients will create a list from of ProtocolClient instances from
 // outputer configuration host list and client factory function.
 func MakeClients(
-	config *ucfg.Config,
+	config *common.Config,
 	newClient func(string) (ProtocolClient, error),
 ) ([]ProtocolClient, error) {
 	hosts, err := ReadHostList(config)
@@ -153,7 +151,7 @@ func MakeClients(
 }
 
 func MakeAsyncClients(
-	config *ucfg.Config,
+	config *common.Config,
 	newClient func(string) (AsyncProtocolClient, error),
 ) ([]AsyncProtocolClient, error) {
 	hosts, err := ReadHostList(config)
@@ -179,7 +177,7 @@ func MakeAsyncClients(
 	return clients, nil
 }
 
-func ReadHostList(cfg *ucfg.Config) ([]string, error) {
+func ReadHostList(cfg *common.Config) ([]string, error) {
 	config := struct {
 		Host   string   `config:"host"`
 		Hosts  []string `config:"hosts"`

--- a/libbeat/outputs/mode/mode_test.go
+++ b/libbeat/outputs/mode/mode_test.go
@@ -8,8 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/urso/ucfg"
-
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/outputs"
@@ -312,7 +310,7 @@ func signals(s ...bool) []bool {
 func makeTestClients(c map[string]interface{},
 	newClient func(string) (ProtocolClient, error),
 ) ([]ProtocolClient, error) {
-	cfg, err := ucfg.NewFrom(c, ucfg.PathSep("."))
+	cfg, err := common.NewConfigFrom(c)
 	if err != nil {
 		return nil, err
 	}

--- a/libbeat/outputs/outputs.go
+++ b/libbeat/outputs/outputs.go
@@ -1,8 +1,6 @@
 package outputs
 
 import (
-	"github.com/urso/ucfg"
-
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 )
@@ -34,7 +32,7 @@ type BulkOutputer interface {
 }
 
 // Create and initialize the output plugin
-type OutputBuilder func(config *ucfg.Config, topologyExpire int) (Outputer, error)
+type OutputBuilder func(config *common.Config, topologyExpire int) (Outputer, error)
 
 // Functions to be exported by a output plugin
 type OutputInterface interface {
@@ -44,7 +42,7 @@ type OutputInterface interface {
 
 type OutputPlugin struct {
 	Name   string
-	Config *ucfg.Config
+	Config *common.Config
 	Output Outputer
 }
 
@@ -64,7 +62,7 @@ func FindOutputPlugin(name string) OutputBuilder {
 
 func InitOutputs(
 	beatName string,
-	configs map[string]*ucfg.Config,
+	configs map[string]*common.Config,
 	topologyExpire int,
 ) ([]OutputPlugin, error) {
 	var plugins []OutputPlugin = nil

--- a/libbeat/outputs/redis/config.go
+++ b/libbeat/outputs/redis/config.go
@@ -1,21 +1,23 @@
 package redis
 
+import "time"
+
 type redisConfig struct {
-	Host              string `config:"host"`
-	Port              int    `config:"port"`
-	Password          string `config:"password"`
-	Db                int    `config:"db"`
-	DbTopology        int    `config:"db_topology"`
-	Timeout           int    `config:"timeout"`
-	Index             string `config:"index"`
-	ReconnectInterval int    `config:"reconnect_interval"`
-	DataType          string `config:"datatype"`
+	Host              string        `config:"host"`
+	Port              int           `config:"port"`
+	Password          string        `config:"password"`
+	Db                int           `config:"db"`
+	DbTopology        int           `config:"db_topology"`
+	Timeout           time.Duration `config:"timeout"`
+	Index             string        `config:"index"`
+	ReconnectInterval int           `config:"reconnect_interval"`
+	DataType          string        `config:"datatype"`
 }
 
 var (
 	defaultConfig = redisConfig{
 		DbTopology:        1,
-		Timeout:           5,
+		Timeout:           5 * time.Second,
 		ReconnectInterval: 1,
 	}
 )

--- a/libbeat/outputs/redis/redis.go
+++ b/libbeat/outputs/redis/redis.go
@@ -13,8 +13,6 @@ import (
 
 	"github.com/garyburd/redigo/redis"
 
-	"github.com/urso/ucfg"
-
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/outputs"
@@ -54,7 +52,7 @@ func init() {
 	outputs.RegisterOutputPlugin("redis", New)
 }
 
-func New(cfg *ucfg.Config, topologyExpire int) (outputs.Outputer, error) {
+func New(cfg *common.Config, topologyExpire int) (outputs.Outputer, error) {
 	config := defaultConfig
 	if err := cfg.Unpack(&config); err != nil {
 		return nil, err
@@ -77,10 +75,7 @@ func (out *redisOutput) Init(config *redisConfig, topology_expire int) error {
 	out.Db = config.Db
 	out.DbTopology = config.DbTopology
 
-	out.Timeout = 5 * time.Second
-	if config.Timeout > 0 {
-		out.Timeout = time.Duration(config.Timeout) * time.Second
-	}
+	out.Timeout = config.Timeout
 
 	out.ReconnectInterval = time.Duration(1) * time.Second
 	if config.ReconnectInterval >= 0 {

--- a/libbeat/outputs/tls_test.go
+++ b/libbeat/outputs/tls_test.go
@@ -6,8 +6,7 @@ import (
 	"crypto/tls"
 	"testing"
 
-	"github.com/urso/ucfg/yaml"
-
+	"github.com/elastic/beats/libbeat/common"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -15,7 +14,7 @@ import (
 
 func load(yamlStr string) (*TLSConfig, error) {
 	var cfg TLSConfig
-	config, err := yaml.NewConfig([]byte(yamlStr))
+	config, err := common.NewConfigWithYAML([]byte(yamlStr), "")
 	if err != nil {
 		return nil, err
 	}

--- a/libbeat/publisher/async.go
+++ b/libbeat/publisher/async.go
@@ -65,7 +65,7 @@ func (p *asyncPublisher) send(m message) {
 func asyncOutputer(ws *common.WorkerSignal, hwm, bulkHWM int, worker *outputWorker) worker {
 	config := worker.config
 
-	flushInterval := time.Duration(config.FlushInterval) * time.Second
+	flushInterval := config.FlushInterval * time.Second
 	maxBulkSize := config.BulkMaxSize
 	logp.Info("Flush Interval set to: %v", flushInterval)
 	logp.Info("Max Bulk Size set to: %v", maxBulkSize)

--- a/libbeat/publisher/output.go
+++ b/libbeat/publisher/output.go
@@ -2,8 +2,7 @@ package publisher
 
 import (
 	"errors"
-
-	"github.com/urso/ucfg"
+	"time"
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
@@ -18,13 +17,13 @@ type outputWorker struct {
 }
 
 type outputConfig struct {
-	BulkMaxSize   int `config:"bulk_max_size"`
-	FlushInterval int `config:"flush_interval"`
+	BulkMaxSize   int           `config:"bulk_max_size"`
+	FlushInterval time.Duration `config:"flush_interval"`
 }
 
 var (
 	defaultConfig = outputConfig{
-		FlushInterval: 1,
+		FlushInterval: 1 * time.Second,
 		BulkMaxSize:   2048,
 	}
 )
@@ -34,7 +33,7 @@ var (
 )
 
 func newOutputWorker(
-	cfg *ucfg.Config,
+	cfg *common.Config,
 	out outputs.Outputer,
 	ws *common.WorkerSignal,
 	hwm int,

--- a/libbeat/publisher/output_test.go
+++ b/libbeat/publisher/output_test.go
@@ -5,8 +5,6 @@ package publisher
 import (
 	"testing"
 
-	"github.com/urso/ucfg"
-
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/outputs"
 	"github.com/stretchr/testify/assert"
@@ -36,7 +34,7 @@ func (t *testOutputer) PublishEvent(trans outputs.Signaler, opts outputs.Options
 func TestOutputWorker(t *testing.T) {
 	outputer := &testOutputer{events: make(chan common.MapStr, 10)}
 	ow := newOutputWorker(
-		ucfg.New(),
+		common.NewConfig(),
 		outputer,
 		common.NewWorkerSignal(),
 		1, 0)

--- a/libbeat/publisher/publish.go
+++ b/libbeat/publisher/publish.go
@@ -6,13 +6,11 @@ import (
 	"os"
 	"time"
 
-	"github.com/nranchev/go-libGeoIP"
-	"github.com/urso/ucfg"
-
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/filter"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/outputs"
+	"github.com/nranchev/go-libGeoIP"
 
 	// load supported output plugins
 	_ "github.com/elastic/beats/libbeat/outputs/console"
@@ -78,12 +76,12 @@ type PublisherType struct {
 }
 
 type ShipperConfig struct {
-	common.EventMetadata  `config:",inline"` // Fields and tags to add to each event.
-	Name                  string
-	Refresh_topology_freq int
-	Ignore_outgoing       bool
-	Topology_expire       int
-	Geoip                 common.Geoip
+	common.EventMetadata `config:",inline"` // Fields and tags to add to each event.
+	Name                 string
+	RefreshTopologyFreq  time.Duration `config:"refresh_topology_freq"`
+	Ignore_outgoing      bool          `config:"ignore_outgoing"`
+	Topology_expire      int           `config:"topology_expire"`
+	Geoip                common.Geoip  `config:"geoip"`
 
 	// internal publisher queue sizes
 	QueueSize     *int `config:"queue_size"`
@@ -178,7 +176,7 @@ func (publisher *PublisherType) RegisterFilter(filters *filter.FilterList) error
 // Create new PublisherType
 func New(
 	beatName string,
-	configs map[string]*ucfg.Config,
+	configs map[string]*common.Config,
 	shipper ShipperConfig,
 ) (*PublisherType, error) {
 
@@ -192,7 +190,7 @@ func New(
 
 func (publisher *PublisherType) init(
 	beatName string,
-	configs map[string]*ucfg.Config,
+	configs map[string]*common.Config,
 	shipper ShipperConfig,
 ) error {
 	var err error
@@ -299,8 +297,8 @@ func (publisher *PublisherType) init(
 
 	if !publisher.disabled && publisher.TopologyOutput != nil {
 		RefreshTopologyFreq := 10 * time.Second
-		if shipper.Refresh_topology_freq != 0 {
-			RefreshTopologyFreq = time.Duration(shipper.Refresh_topology_freq) * time.Second
+		if shipper.RefreshTopologyFreq != 0 {
+			RefreshTopologyFreq = shipper.RefreshTopologyFreq
 		}
 		publisher.RefreshTopologyTimer = time.Tick(RefreshTopologyFreq)
 		logp.Info("Topology map refreshed every %s", RefreshTopologyFreq)

--- a/metricbeat/beater/config.go
+++ b/metricbeat/beater/config.go
@@ -1,13 +1,11 @@
 package beater
 
-import (
-	"github.com/urso/ucfg"
-)
+import "github.com/elastic/beats/libbeat/common"
 
 type Config struct {
 	Metricbeat MetricbeatConfig
 }
 
 type MetricbeatConfig struct {
-	Modules []*ucfg.Config
+	Modules []*common.Config
 }

--- a/metricbeat/helper/interfacer.go
+++ b/metricbeat/helper/interfacer.go
@@ -53,6 +53,6 @@ type MetricSeter interface {
 
 // Interface for each module
 type Moduler interface {
-	// Raw ucfg config is passed. This allows each module to extract its own local config variables
+	// Raw *common.Config config is passed. This allows each module to extract its own local config variables
 	Setup(m *Module) error
 }

--- a/metricbeat/helper/module.go
+++ b/metricbeat/helper/module.go
@@ -10,8 +10,6 @@ import (
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
-
-	"github.com/urso/ucfg"
 )
 
 // Module specifics. This must be defined by each module
@@ -27,7 +25,7 @@ type Module struct {
 	Timeout time.Duration
 
 	// Raw config object to be unpacked by moduler
-	cfg *ucfg.Config
+	cfg *common.Config
 
 	// List of all metricsets in this module. Use to keep track of metricsets
 	metricSets map[string]*MetricSet
@@ -41,7 +39,7 @@ type Module struct {
 }
 
 // NewModule creates a new module
-func NewModule(cfg *ucfg.Config, moduler func() Moduler) (*Module, error) {
+func NewModule(cfg *common.Config, moduler func() Moduler) (*Module, error) {
 
 	// Module config defaults
 	config := ModuleConfig{

--- a/metricbeat/helper/module_test.go
+++ b/metricbeat/helper/module_test.go
@@ -6,9 +6,9 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/elastic/beats/libbeat/common"
 
-	"github.com/urso/ucfg"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetMetricSetsList(t *testing.T) {
@@ -27,7 +27,7 @@ func TestGetMetricSetsList(t *testing.T) {
 
 func TestNewModule(t *testing.T) {
 
-	config, _ := ucfg.NewFrom(ModuleConfig{
+	config, _ := common.NewConfigFrom(ModuleConfig{
 		Module: "test",
 	})
 
@@ -42,7 +42,7 @@ func TestNewModule(t *testing.T) {
 // Check that the moduler inside each module is a different instance
 func TestNewModulerDifferentInstance(t *testing.T) {
 
-	config, _ := ucfg.NewFrom(ModuleConfig{
+	config, _ := common.NewConfigFrom(ModuleConfig{
 		Module: "test",
 	})
 

--- a/metricbeat/helper/register.go
+++ b/metricbeat/helper/register.go
@@ -3,8 +3,7 @@ package helper
 import (
 	"fmt"
 
-	"github.com/urso/ucfg"
-
+	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 )
 
@@ -50,13 +49,13 @@ func (r *Register) AddMetricSeter(module string, name string, new func() MetricS
 }
 
 // GetModule returns a new module instance for the given moduler name
-func (r *Register) GetModule(ucfg *ucfg.Config) (*Module, error) {
+func (r *Register) GetModule(cfg *common.Config) (*Module, error) {
 
 	// Unpack config to load module name
 	config := struct {
 		Module string `config:"module"`
 	}{}
-	if err := ucfg.Unpack(&config); err != nil {
+	if err := cfg.Unpack(&config); err != nil {
 		return nil, err
 	}
 
@@ -65,7 +64,7 @@ func (r *Register) GetModule(ucfg *ucfg.Config) (*Module, error) {
 		return nil, fmt.Errorf("Module %s does not exist", config.Module)
 	}
 
-	return NewModule(ucfg, moduler)
+	return NewModule(cfg, moduler)
 }
 
 // GetMetricSet returns a new metricset instance for the given metricset name combined with the module name

--- a/metricbeat/helper/register_test.go
+++ b/metricbeat/helper/register_test.go
@@ -5,14 +5,13 @@ package helper
 import (
 	"testing"
 
+	"github.com/elastic/beats/libbeat/common"
 	"github.com/stretchr/testify/assert"
-
-	"github.com/urso/ucfg"
 )
 
 func TestGetModuleInvalid(t *testing.T) {
 
-	config, _ := ucfg.NewFrom(ModuleConfig{
+	config, _ := common.NewConfigFrom(ModuleConfig{
 		Module: "test",
 	})
 

--- a/metricbeat/module/apache/status/status_test.go
+++ b/metricbeat/module/apache/status/status_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/urso/ucfg"
 
+	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/metricbeat/helper"
 	"github.com/elastic/beats/metricbeat/module/apache"
 )
@@ -42,8 +42,8 @@ type ApacheModuleConfig struct {
 	Module string   `config:"module"`
 }
 
-func getApacheModuleConfig() (*ucfg.Config, error) {
-	return ucfg.NewFrom(ApacheModuleConfig{
+func getApacheModuleConfig() (*common.Config, error) {
+	return common.NewConfigFrom(ApacheModuleConfig{
 		Module: "apache",
 		Hosts:  []string{apache.GetApacheEnvHost()},
 	})

--- a/metricbeat/module/redis/info/info_test.go
+++ b/metricbeat/module/redis/info/info_test.go
@@ -7,7 +7,6 @@ import (
 
 	rd "github.com/garyburd/redigo/redis"
 	"github.com/stretchr/testify/assert"
-	"github.com/urso/ucfg"
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/metricbeat/helper"
@@ -71,8 +70,8 @@ func TestKeyspace(t *testing.T) {
 	assert.True(t, (keyCount > 0))
 }
 
-func getRedisModuleConfig() (*ucfg.Config, error) {
-	return ucfg.NewFrom(RedisModuleConfig{
+func getRedisModuleConfig() (*common.Config, error) {
+	return common.NewConfigFrom(RedisModuleConfig{
 		Module: "redis",
 		Hosts:  []string{redis.GetRedisEnvHost() + ":" + redis.GetRedisEnvPort()},
 	})

--- a/packetbeat/config/config.go
+++ b/packetbeat/config/config.go
@@ -1,17 +1,19 @@
 package config
 
 import (
+	"time"
+
+	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/droppriv"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/publisher"
 	"github.com/elastic/beats/packetbeat/procs"
-	"github.com/urso/ucfg"
 )
 
 type Config struct {
 	Interfaces InterfacesConfig
 	Flows      *Flows
-	Protocols  map[string]*ucfg.Config
+	Protocols  map[string]*common.Config
 	Shipper    publisher.ShipperConfig
 	Procs      procs.ProcsConfig
 	RunOptions droppriv.RunOptions
@@ -38,10 +40,10 @@ type Flows struct {
 }
 
 type ProtocolCommon struct {
-	Ports              []int `config:"ports"`
-	SendRequest        bool  `config:"send_request"`
-	SendResponse       bool  `config:"send_response"`
-	TransactionTimeout int   `config:"transaction_timeout"`
+	Ports              []int         `config:"ports"`
+	SendRequest        bool          `config:"send_request"`
+	SendResponse       bool          `config:"send_response"`
+	TransactionTimeout time.Duration `config:"transaction_timeout"`
 }
 
 // Config Singleton

--- a/packetbeat/procs/procs.go
+++ b/packetbeat/procs/procs.go
@@ -60,10 +60,10 @@ type ProcessesWatcher struct {
 }
 
 type ProcsConfig struct {
-	Enabled            bool
-	Max_proc_read_freq int
-	Monitored          []ProcConfig
-	Refresh_pids_freq  int
+	Enabled            bool          `config:"enabled"`
+	Max_proc_read_freq time.Duration `config:"max_proc_read_freq"`
+	Monitored          []ProcConfig  `config:"monitored"`
+	Refresh_pids_freq  time.Duration `config:"refresh_pids_freq"`
 }
 
 type ProcConfig struct {
@@ -87,20 +87,20 @@ func (proc *ProcessesWatcher) Init(config ProcsConfig) error {
 		} else {
 			logp.Info("Process matching enabled")
 		}
+	} else {
+		logp.Info("Process matching disabled")
 	}
 
 	if config.Max_proc_read_freq == 0 {
 		proc.MaxReadFreq = 10 * time.Millisecond
 	} else {
-		proc.MaxReadFreq = time.Duration(config.Max_proc_read_freq) *
-			time.Millisecond
+		proc.MaxReadFreq = config.Max_proc_read_freq
 	}
 
 	if config.Refresh_pids_freq == 0 {
 		proc.RefreshPidsFreq = 1 * time.Second
 	} else {
-		proc.RefreshPidsFreq = time.Duration(config.Refresh_pids_freq) *
-			time.Millisecond
+		proc.RefreshPidsFreq = config.Refresh_pids_freq
 	}
 
 	// Read the local IP addresses

--- a/packetbeat/protos/amqp/amqp.go
+++ b/packetbeat/protos/amqp/amqp.go
@@ -10,7 +10,6 @@ import (
 	"github.com/elastic/beats/packetbeat/protos"
 	"github.com/elastic/beats/packetbeat/protos/tcp"
 	"github.com/elastic/beats/packetbeat/publish"
-	"github.com/urso/ucfg"
 )
 
 var (
@@ -41,7 +40,7 @@ func init() {
 func New(
 	testMode bool,
 	results publish.Transactions,
-	cfg *ucfg.Config,
+	cfg *common.Config,
 ) (protos.Plugin, error) {
 	p := &Amqp{}
 	config := defaultConfig
@@ -144,7 +143,7 @@ func (amqp *Amqp) setFromConfig(config *amqpConfig) {
 	amqp.ParseHeaders = config.ParseHeaders
 	amqp.ParseArguments = config.ParseArguments
 	amqp.HideConnectionInformation = config.HideConnectionInformation
-	amqp.transactionTimeout = time.Duration(config.TransactionTimeout) * time.Second
+	amqp.transactionTimeout = config.TransactionTimeout
 }
 
 func (amqp *Amqp) addConnectionMethods() {

--- a/packetbeat/protos/amqp/config.go
+++ b/packetbeat/protos/amqp/config.go
@@ -16,7 +16,7 @@ type amqpConfig struct {
 var (
 	defaultConfig = amqpConfig{
 		ProtocolCommon: config.ProtocolCommon{
-			TransactionTimeout: protos.DefaultTransactionTimeout,
+			TransactionTimeout: protos.DefaultTransactionExpiration,
 		},
 		ParseHeaders:              true,
 		ParseArguments:            true,

--- a/packetbeat/protos/dns/config.go
+++ b/packetbeat/protos/dns/config.go
@@ -14,7 +14,7 @@ type dnsConfig struct {
 var (
 	defaultConfig = dnsConfig{
 		ProtocolCommon: config.ProtocolCommon{
-			TransactionTimeout: protos.DefaultTransactionTimeout,
+			TransactionTimeout: protos.DefaultTransactionExpiration,
 		},
 	}
 )

--- a/packetbeat/protos/dns/dns.go
+++ b/packetbeat/protos/dns/dns.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
-	"github.com/urso/ucfg"
 
 	"github.com/elastic/beats/packetbeat/protos"
 	"github.com/elastic/beats/packetbeat/publish"
@@ -192,7 +191,7 @@ func init() {
 func New(
 	testMode bool,
 	results publish.Transactions,
-	cfg *ucfg.Config,
+	cfg *common.Config,
 ) (protos.Plugin, error) {
 	p := &Dns{}
 	config := defaultConfig
@@ -234,7 +233,7 @@ func (dns *Dns) setFromConfig(config *dnsConfig) error {
 	dns.Send_response = config.SendResponse
 	dns.Include_authorities = config.Include_authorities
 	dns.Include_additionals = config.Include_additionals
-	dns.transactionTimeout = time.Duration(config.TransactionTimeout) * time.Second
+	dns.transactionTimeout = config.TransactionTimeout
 	return nil
 }
 

--- a/packetbeat/protos/dns/dns_test.go
+++ b/packetbeat/protos/dns/dns_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/elastic/beats/packetbeat/protos"
 	"github.com/elastic/beats/packetbeat/publish"
-	"github.com/urso/ucfg"
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
@@ -64,7 +63,7 @@ func newDns(verbose bool) *Dns {
 	}
 
 	results := &publish.ChanTransactions{make(chan common.MapStr, 100)}
-	cfg, _ := ucfg.NewFrom(map[string]interface{}{
+	cfg, _ := common.NewConfigFrom(map[string]interface{}{
 		"ports":               []int{ServerPort},
 		"include_authorities": true,
 		"include_additionals": true,

--- a/packetbeat/protos/http/config.go
+++ b/packetbeat/protos/http/config.go
@@ -19,7 +19,7 @@ type httpConfig struct {
 var (
 	defaultConfig = httpConfig{
 		ProtocolCommon: config.ProtocolCommon{
-			TransactionTimeout: protos.DefaultTransactionTimeout,
+			TransactionTimeout: protos.DefaultTransactionExpiration,
 		},
 	}
 )

--- a/packetbeat/protos/http/http.go
+++ b/packetbeat/protos/http/http.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
-	"github.com/urso/ucfg"
 
 	"github.com/elastic/beats/packetbeat/procs"
 	"github.com/elastic/beats/packetbeat/protos"
@@ -84,7 +83,7 @@ func init() {
 func New(
 	testMode bool,
 	results publish.Transactions,
-	cfg *ucfg.Config,
+	cfg *common.Config,
 ) (protos.Plugin, error) {
 	p := &HTTP{}
 	config := defaultConfig
@@ -118,7 +117,7 @@ func (http *HTTP) setFromConfig(config *httpConfig) {
 	http.RedactAuthorization = config.Redact_authorization
 	http.SplitCookie = config.Split_cookie
 	http.parserConfig.RealIPHeader = strings.ToLower(config.Real_ip_header)
-	http.transactionTimeout = time.Duration(config.TransactionTimeout) * time.Second
+	http.transactionTimeout = config.TransactionTimeout
 	http.IncludeBodyFor = config.Include_body_for
 
 	if config.Send_all_headers {

--- a/packetbeat/protos/http/http_test.go
+++ b/packetbeat/protos/http/http_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/elastic/beats/packetbeat/protos"
 	"github.com/elastic/beats/packetbeat/publish"
 	"github.com/stretchr/testify/assert"
-	"github.com/urso/ucfg"
 )
 
 type testParser struct {
@@ -52,7 +51,7 @@ func (tp *testParser) parse() (*message, bool, bool) {
 
 func httpModForTests() *HTTP {
 	results := &publish.ChanTransactions{Channel: make(chan common.MapStr, 10)}
-	http, err := New(false, results, ucfg.New())
+	http, err := New(false, results, common.NewConfig())
 	if err != nil {
 		panic(err)
 	}

--- a/packetbeat/protos/icmp/config.go
+++ b/packetbeat/protos/icmp/config.go
@@ -1,15 +1,19 @@
 package icmp
 
-import "github.com/elastic/beats/packetbeat/protos"
+import (
+	"time"
+
+	"github.com/elastic/beats/packetbeat/protos"
+)
 
 type icmpConfig struct {
-	SendRequest        bool `config:"send_request"`
-	SendResponse       bool `config:"send_response"`
-	TransactionTimeout int  `config:"transaction_timeout"`
+	SendRequest        bool          `config:"send_request"`
+	SendResponse       bool          `config:"send_response"`
+	TransactionTimeout time.Duration `config:"transaction_timeout"`
 }
 
 var (
 	defaultConfig = icmpConfig{
-		TransactionTimeout: protos.DefaultTransactionTimeout,
+		TransactionTimeout: protos.DefaultTransactionExpiration,
 	}
 )

--- a/packetbeat/protos/icmp/icmp.go
+++ b/packetbeat/protos/icmp/icmp.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
-	"github.com/urso/ucfg"
 
 	"github.com/elastic/beats/packetbeat/flows"
 	"github.com/elastic/beats/packetbeat/protos"
@@ -50,7 +49,7 @@ const (
 	orphanedResponseMsg = "Response was received without an associated request."
 )
 
-func New(testMode bool, results publish.Transactions, cfg *ucfg.Config) (*Icmp, error) {
+func New(testMode bool, results publish.Transactions, cfg *common.Config) (*Icmp, error) {
 	p := &Icmp{}
 	config := defaultConfig
 	if !testMode {
@@ -95,7 +94,7 @@ func (icmp *Icmp) init(results publish.Transactions, config *icmpConfig) error {
 func (icmp *Icmp) setFromConfig(config *icmpConfig) {
 	icmp.sendRequest = config.SendRequest
 	icmp.sendResponse = config.SendResponse
-	icmp.transactionTimeout = time.Duration(config.TransactionTimeout) * time.Second
+	icmp.transactionTimeout = config.TransactionTimeout
 }
 
 func (icmp *Icmp) ProcessICMPv4(

--- a/packetbeat/protos/icmp/icmp_test.go
+++ b/packetbeat/protos/icmp/icmp_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
-	"github.com/urso/ucfg"
 
 	"github.com/elastic/beats/packetbeat/protos"
 	"github.com/elastic/beats/packetbeat/publish"
@@ -47,7 +46,7 @@ func BenchmarkIcmpProcessICMPv4(b *testing.B) {
 	}
 
 	results := &publish.ChanTransactions{make(chan common.MapStr, 10)}
-	icmp, err := New(true, results, ucfg.New())
+	icmp, err := New(true, results, common.NewConfig())
 	if err != nil {
 		b.Error("Failed to create ICMP processor")
 		return

--- a/packetbeat/protos/memcache/config.go
+++ b/packetbeat/protos/memcache/config.go
@@ -1,6 +1,8 @@
 package memcache
 
 import (
+	"time"
+
 	"github.com/elastic/beats/packetbeat/config"
 	"github.com/elastic/beats/packetbeat/protos"
 )
@@ -9,7 +11,7 @@ type memcacheConfig struct {
 	config.ProtocolCommon `config:",inline"`
 	MaxValues             int
 	MaxBytesPerValue      int
-	UdpTransactionTimeout int
+	UdpTransactionTimeout time.Duration
 	ParseUnknown          bool
 }
 
@@ -17,8 +19,8 @@ var (
 	defaultConfig = memcacheConfig{
 		ProtocolCommon: config.ProtocolCommon{
 			Ports:              []int{11211},
-			TransactionTimeout: protos.DefaultTransactionTimeout,
+			TransactionTimeout: protos.DefaultTransactionExpiration,
 		},
-		UdpTransactionTimeout: protos.DefaultTransactionTimeout,
+		UdpTransactionTimeout: protos.DefaultTransactionExpiration,
 	}
 )

--- a/packetbeat/protos/memcache/memcache.go
+++ b/packetbeat/protos/memcache/memcache.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
-	"github.com/urso/ucfg"
 
 	"github.com/elastic/beats/packetbeat/protos"
 	"github.com/elastic/beats/packetbeat/protos/applayer"
@@ -107,7 +106,7 @@ func init() {
 func New(
 	testMode bool,
 	results publish.Transactions,
-	cfg *ucfg.Config,
+	cfg *common.Config,
 ) (protos.Plugin, error) {
 	p := &Memcache{}
 	config := defaultConfig
@@ -151,12 +150,8 @@ func (mc *Memcache) setFromConfig(config *memcacheConfig) error {
 
 	mc.config.parseUnkown = config.ParseUnknown
 
-	mc.udpConfig.transTimeout = computeTransTimeout(
-		&config.UdpTransactionTimeout,
-		protos.DefaultTransactionExpiration)
-	mc.tcpConfig.tcpTransTimeout = computeTransTimeout(
-		&config.TransactionTimeout,
-		protos.DefaultTransactionExpiration)
+	mc.udpConfig.transTimeout = config.UdpTransactionTimeout
+	mc.tcpConfig.tcpTransTimeout = config.TransactionTimeout
 
 	debug("transaction timeout: %v", config.TransactionTimeout)
 	debug("udp transaction timeout: %v", config.UdpTransactionTimeout)
@@ -462,11 +457,4 @@ func (mc memcacheData) MarshalJSON() ([]byte, error) {
 
 func (mc memcacheData) IsSet() bool {
 	return mc.data != nil
-}
-
-func computeTransTimeout(to *int, defaultTo time.Duration) time.Duration {
-	if to == nil || *to <= 0 {
-		return defaultTo
-	}
-	return time.Duration(*to) * time.Millisecond
 }

--- a/packetbeat/protos/mongodb/config.go
+++ b/packetbeat/protos/mongodb/config.go
@@ -14,7 +14,7 @@ type mongodbConfig struct {
 var (
 	defaultConfig = mongodbConfig{
 		ProtocolCommon: config.ProtocolCommon{
-			TransactionTimeout: protos.DefaultTransactionTimeout,
+			TransactionTimeout: protos.DefaultTransactionExpiration,
 		},
 		MaxDocLength: 5000,
 		MaxDocs:      10,

--- a/packetbeat/protos/mongodb/mongodb.go
+++ b/packetbeat/protos/mongodb/mongodb.go
@@ -11,7 +11,6 @@ import (
 	"github.com/elastic/beats/packetbeat/protos"
 	"github.com/elastic/beats/packetbeat/protos/tcp"
 	"github.com/elastic/beats/packetbeat/publish"
-	"github.com/urso/ucfg"
 )
 
 var debugf = logp.MakeDebug("mongodb")
@@ -43,7 +42,7 @@ func init() {
 func New(
 	testMode bool,
 	results publish.Transactions,
-	cfg *ucfg.Config,
+	cfg *common.Config,
 ) (protos.Plugin, error) {
 	p := &Mongodb{}
 	config := defaultConfig
@@ -82,7 +81,7 @@ func (mongodb *Mongodb) setFromConfig(config *mongodbConfig) {
 	mongodb.SendResponse = config.SendResponse
 	mongodb.MaxDocs = config.MaxDocs
 	mongodb.MaxDocLength = config.MaxDocLength
-	mongodb.transactionTimeout = time.Duration(config.TransactionTimeout) * time.Second
+	mongodb.transactionTimeout = config.TransactionTimeout
 }
 
 func (mongodb *Mongodb) GetPorts() []int {

--- a/packetbeat/protos/mysql/config.go
+++ b/packetbeat/protos/mysql/config.go
@@ -14,7 +14,7 @@ type mysqlConfig struct {
 var (
 	defaultConfig = mysqlConfig{
 		ProtocolCommon: config.ProtocolCommon{
-			TransactionTimeout: protos.DefaultTransactionTimeout,
+			TransactionTimeout: protos.DefaultTransactionExpiration,
 		},
 		MaxRowLength: 1024,
 		MaxRows:      10,

--- a/packetbeat/protos/mysql/mysql.go
+++ b/packetbeat/protos/mysql/mysql.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
-	"github.com/urso/ucfg"
 
 	"github.com/elastic/beats/packetbeat/procs"
 	"github.com/elastic/beats/packetbeat/protos"
@@ -137,7 +136,7 @@ func init() {
 func New(
 	testMode bool,
 	results publish.Transactions,
-	cfg *ucfg.Config,
+	cfg *common.Config,
 ) (protos.Plugin, error) {
 	p := &Mysql{}
 	config := defaultConfig
@@ -172,7 +171,7 @@ func (mysql *Mysql) setFromConfig(config *mysqlConfig) {
 	mysql.maxStoreRows = config.MaxRows
 	mysql.Send_request = config.SendRequest
 	mysql.Send_response = config.SendResponse
-	mysql.transactionTimeout = time.Duration(config.TransactionTimeout) * time.Second
+	mysql.transactionTimeout = config.TransactionTimeout
 }
 
 func (mysql *Mysql) getTransaction(k common.HashableTcpTuple) *MysqlTransaction {

--- a/packetbeat/protos/pgsql/config.go
+++ b/packetbeat/protos/pgsql/config.go
@@ -14,7 +14,7 @@ type pgsqlConfig struct {
 var (
 	defaultConfig = pgsqlConfig{
 		ProtocolCommon: config.ProtocolCommon{
-			TransactionTimeout: protos.DefaultTransactionTimeout,
+			TransactionTimeout: protos.DefaultTransactionExpiration,
 		},
 		MaxRowLength: 1024,
 		MaxRows:      10,

--- a/packetbeat/protos/pgsql/pgsql.go
+++ b/packetbeat/protos/pgsql/pgsql.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
-	"github.com/urso/ucfg"
 
 	"github.com/elastic/beats/packetbeat/procs"
 	"github.com/elastic/beats/packetbeat/protos"
@@ -124,7 +123,7 @@ func init() {
 func New(
 	testMode bool,
 	results publish.Transactions,
-	cfg *ucfg.Config,
+	cfg *common.Config,
 ) (protos.Plugin, error) {
 	p := &Pgsql{}
 	config := defaultConfig
@@ -159,7 +158,7 @@ func (pgsql *Pgsql) setFromConfig(config *pgsqlConfig) {
 	pgsql.maxStoreRows = config.MaxRows
 	pgsql.Send_request = config.SendRequest
 	pgsql.Send_response = config.SendResponse
-	pgsql.transactionTimeout = time.Duration(config.TransactionTimeout) * time.Second
+	pgsql.transactionTimeout = config.TransactionTimeout
 }
 
 func (pgsql *Pgsql) getTransaction(k common.HashableTcpTuple) []*PgsqlTransaction {

--- a/packetbeat/protos/protos.go
+++ b/packetbeat/protos/protos.go
@@ -10,13 +10,11 @@ import (
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/packetbeat/publish"
-	"github.com/urso/ucfg"
 )
 
 const (
 	DefaultTransactionHashSize                 = 2 ^ 16
 	DefaultTransactionExpiration time.Duration = 10 * time.Second
-	DefaultTransactionTimeout                  = 10
 )
 
 // ProtocolData interface to represent an upper
@@ -85,7 +83,7 @@ var Protos = ProtocolsStruct{
 func (protocols ProtocolsStruct) Init(
 	testMode bool,
 	results publish.Transactions,
-	configs map[string]*ucfg.Config,
+	configs map[string]*common.Config,
 ) error {
 	for proto := range protocolSyms {
 		logp.Info("registered protocol plugin: %v", proto)

--- a/packetbeat/protos/redis/config.go
+++ b/packetbeat/protos/redis/config.go
@@ -12,7 +12,7 @@ type redisConfig struct {
 var (
 	defaultConfig = redisConfig{
 		ProtocolCommon: config.ProtocolCommon{
-			TransactionTimeout: protos.DefaultTransactionTimeout,
+			TransactionTimeout: protos.DefaultTransactionExpiration,
 		},
 	}
 )

--- a/packetbeat/protos/redis/redis.go
+++ b/packetbeat/protos/redis/redis.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
-	"github.com/urso/ucfg"
 
 	"github.com/elastic/beats/packetbeat/procs"
 	"github.com/elastic/beats/packetbeat/protos"
@@ -55,7 +54,7 @@ func init() {
 func New(
 	testMode bool,
 	results publish.Transactions,
-	cfg *ucfg.Config,
+	cfg *common.Config,
 ) (protos.Plugin, error) {
 	p := &Redis{}
 	config := defaultConfig
@@ -84,7 +83,7 @@ func (redis *Redis) setFromConfig(config *redisConfig) {
 	redis.Ports = config.Ports
 	redis.SendRequest = config.SendRequest
 	redis.SendResponse = config.SendResponse
-	redis.transactionTimeout = time.Duration(config.TransactionTimeout) * time.Second
+	redis.transactionTimeout = config.TransactionTimeout
 }
 
 func (redis *Redis) GetPorts() []int {

--- a/packetbeat/protos/registry.go
+++ b/packetbeat/protos/registry.go
@@ -5,13 +5,12 @@ import (
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/packetbeat/publish"
-	"github.com/urso/ucfg"
 )
 
 type ProtocolPlugin func(
 	testMode bool,
 	results publish.Transactions,
-	cfg *ucfg.Config,
+	cfg *common.Config,
 ) (Plugin, error)
 
 // Functions to be exported by a protocol plugin

--- a/packetbeat/protos/tcp/tcp_test.go
+++ b/packetbeat/protos/tcp/tcp_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/packetbeat/protos"
 	"github.com/elastic/beats/packetbeat/publish"
-	"github.com/urso/ucfg"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/tsg/gopacket/layers"
@@ -30,7 +29,7 @@ var (
 )
 
 func init() {
-	new := func(_ bool, _ publish.Transactions, _ *ucfg.Config) (protos.Plugin, error) {
+	new := func(_ bool, _ publish.Transactions, _ *common.Config) (protos.Plugin, error) {
 		return &TestProtocol{}, nil
 	}
 

--- a/packetbeat/protos/thrift/config.go
+++ b/packetbeat/protos/thrift/config.go
@@ -20,7 +20,7 @@ type thriftConfig struct {
 var (
 	defaultConfig = thriftConfig{
 		ProtocolCommon: config.ProtocolCommon{
-			TransactionTimeout: protos.DefaultTransactionTimeout,
+			TransactionTimeout: protos.DefaultTransactionExpiration,
 		},
 		StringMaxSize:          200,
 		CollectionMaxSize:      15,

--- a/packetbeat/protos/thrift/thrift.go
+++ b/packetbeat/protos/thrift/thrift.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
-	"github.com/urso/ucfg"
 
 	"github.com/elastic/beats/packetbeat/procs"
 	"github.com/elastic/beats/packetbeat/protos"
@@ -165,7 +164,7 @@ func init() {
 func New(
 	testMode bool,
 	results publish.Transactions,
-	cfg *ucfg.Config,
+	cfg *common.Config,
 ) (protos.Plugin, error) {
 	p := &Thrift{}
 	config := defaultConfig

--- a/packetbeat/tests/system/config/packetbeat.yml.j2
+++ b/packetbeat/tests/system/config/packetbeat.yml.j2
@@ -105,7 +105,7 @@ protocols:
 {% if memcache_send_response %}    send_response: true{%- endif %}
 {% if memcache_parse_unknown %}    parseunknown: true{%- endif %}
 {% if memcache_max_values %}    maxvalues: {{ memcache_max_values }}{%- endif %}
-{% if memcache_udp_transaction_timeout %}    udptransactiontimeout: {{ memcache_udp_transaction_timeout}}{%- endif %}
+{% if memcache_udp_transaction_timeout %}    udptransactiontimeout: {{ memcache_udp_transaction_timeout}}ms {%- endif %}
 
   mysql:
     ports: [{{ mysql_ports|default([3306])|join(", ") }}]

--- a/vendor/github.com/urso/ucfg/.travis.yml
+++ b/vendor/github.com/urso/ucfg/.travis.yml
@@ -2,4 +2,5 @@ language: go
 
 go:
   - 1.5.3
+  - 1.6
   - tip

--- a/vendor/github.com/urso/ucfg/CHANGELOG.md
+++ b/vendor/github.com/urso/ucfg/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+This project adheres to [Semantic Versioning](http://semver.org/).
+
+## [0.1.1]
+
+### Fixed
+- Fixed unpacking *regexp.Regexp
+- Fixed unpacking empty config as *Config object
+
+## [0.1.0]
+
+### Added
+- add support for unpacking *regexp.Regexp via regexp.Compile
+- Parse time.Duration from int/float values in seconds
+- Improve error messages
+- Add options and PathSep support to low level option setters/getters
+- Added support for _rebranding_ `*ucfg.Config` via `type MyConfig ucfg.Config` using
+  casts between pointer types in Unpack and Merge.
+- Introduced CHANGELOG.md for documenting changes to ucfg.
+
+
+[Unreleased]: https://github.com/urso/ucfg/compare/v0.1.0...HEAD
+[0.1.1]: https://github.com/urso/ucfg/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/urso/ucfg/compare/v0.0.0...v0.1.0

--- a/vendor/github.com/urso/ucfg/common_test.go
+++ b/vendor/github.com/urso/ucfg/common_test.go
@@ -1,3 +1,46 @@
 package ucfg
 
 type node map[string]interface{}
+
+// C rebrands Config
+type C Config
+
+func newC() *C {
+	return fromConfig(New())
+}
+
+func newCFrom(from interface{}) *C {
+	c, err := NewFrom(from)
+	if err != nil {
+		panic(err)
+	}
+	return fromConfig(c)
+}
+
+func fromConfig(in *Config) *C {
+	return (*C)(in)
+}
+
+func (c *C) asConfig() *Config {
+	return (*Config)(c)
+}
+
+func (c *C) SetBool(name string, idx int, value bool) {
+	c.asConfig().SetBool(name, idx, value)
+}
+
+func (c *C) SetInt(name string, idx int, value int64) {
+	c.asConfig().SetInt(name, idx, value)
+}
+
+func (c *C) SetFloat(name string, idx int, value float64) {
+	c.asConfig().SetFloat(name, idx, value)
+}
+
+func (c *C) SetString(name string, idx int, value string) {
+	c.asConfig().SetString(name, idx, value)
+}
+
+func (c *C) SetChild(name string, idx int, value *C) {
+	c.asConfig().SetChild(name, idx, (*Config)(value))
+}

--- a/vendor/github.com/urso/ucfg/error.go
+++ b/vendor/github.com/urso/ucfg/error.go
@@ -1,0 +1,261 @@
+package ucfg
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"runtime/debug"
+)
+
+type Error interface {
+	error
+	Reason() error
+
+	// error class, one of ErrConfig, ErrImplementation, ErrUnknown
+	Class() error
+
+	Message() string
+
+	// [optional] path of config element error occured for
+	Path() string
+
+	// [optional] stack trace
+	Trace() string
+}
+
+type baseError struct {
+	reason  error
+	class   error
+	message string
+}
+
+type criticalError struct {
+	baseError
+	trace string
+}
+
+type pathError struct {
+	baseError
+	meta *Meta
+	path string
+}
+
+// error Reasons
+var (
+	ErrMissing = errors.New("missing field")
+
+	ErrTypeNoArray = errors.New("field is no array")
+
+	ErrTypeMismatch = errors.New("type mismatch")
+
+	ErrKeyTypeNotString = errors.New("key must be a string")
+
+	ErrIndexOutOfRange = errors.New("out of range index")
+
+	ErrPointerRequired = errors.New("pointer required for unpacking configurations")
+
+	ErrArraySizeMistach = errors.New("Array size mismatch")
+
+	ErrExpectedObject = errors.New("expected object")
+
+	ErrNilConfig = errors.New("config is nil")
+
+	ErrNilValue = errors.New("nil value is invalid")
+
+	ErrTODO = errors.New("TODO - implement me")
+
+	ErrDuplicateKeey = errors.New("duplicate key")
+)
+
+// error classes
+var (
+	ErrConfig         = errors.New("Configuration error")
+	ErrImplementation = errors.New("Implementation error")
+	ErrUnknown        = errors.New("Unspecified")
+)
+
+func (e baseError) Message() string { return e.Error() }
+func (e baseError) Reason() error   { return e.reason }
+func (e baseError) Class() error    { return e.class }
+func (e baseError) Trace() string   { return "" }
+func (e baseError) Path() string    { return "" }
+
+func (e baseError) Error() string {
+	if e.message == "" {
+		return e.reason.Error()
+	}
+	return e.message
+}
+
+func (e criticalError) Error() string {
+	return fmt.Sprintf("%s\nTrace:%v\n", e.baseError, e.trace)
+}
+
+func raiseErr(reason error, message string) Error {
+	return baseError{
+		reason:  reason,
+		message: message,
+		class:   ErrConfig,
+	}
+}
+
+func raiseImplErr(reason error) Error {
+	return baseError{
+		reason: reason,
+		class:  ErrImplementation,
+	}
+}
+
+func raiseCritical(reason error, message string) Error {
+	if message == "" {
+		message = reason.Error()
+	}
+	if message != "" {
+		message = fmt.Sprintf("(assert) %v", message)
+	}
+	return criticalError{
+		baseError{reason, ErrImplementation, message},
+		string(debug.Stack()),
+	}
+}
+
+func raisePathErr(reason error, meta *Meta, message, path string) Error {
+	// fmt.Printf("path err, reason='%v', meta=%v, message='%v', path='%v'\n", reason, meta, message, path)
+	message = messagePath(reason, meta, message, path)
+	// fmt.Printf("  -> report message: %v\n", message)
+
+	return pathError{
+		baseError{reason, ErrConfig, message},
+		meta,
+		path,
+	}
+}
+
+func messageMeta(message string, meta *Meta) string {
+	if meta == nil || meta.Source == "" {
+		return message
+	}
+	return fmt.Sprintf("%v (source:'%v')", message, meta.Source)
+}
+
+func messagePath(reason error, meta *Meta, message, path string) string {
+	if path == "" {
+		path = "config"
+	} else {
+		path = fmt.Sprintf("'%v'", path)
+	}
+
+	if message == "" {
+		message = reason.Error()
+	}
+
+	message = fmt.Sprintf("%v accessing %v", message, path)
+	return messageMeta(message, meta)
+}
+
+func raiseDuplicateKey(cfg *Config, name string) Error {
+	return raisePathErr(ErrDuplicateKeey, cfg.metadata, "", cfg.PathOf(name, "."))
+}
+
+func raiseMissing(c *Config, field string) Error {
+	// error reading field from config, as missing in c
+	return raisePathErr(ErrMissing, c.metadata, "", c.PathOf(field, "."))
+}
+
+func raiseMissingArr(arr *cfgArray, idx int) Error {
+	message := fmt.Sprintf("no value in array at %v", idx)
+	return raisePathErr(ErrMissing, arr.meta(), message, arr.ctx.path("."))
+}
+
+func raiseIndexOutOfBounds(value value, idx int) Error {
+	reason := ErrIndexOutOfRange
+	ctx := value.Context()
+	message := fmt.Sprintf("index '%v' out of range (length=%v)", idx, value.Len())
+	return raisePathErr(reason, value.meta(), message, ctx.path("."))
+}
+
+func raiseInvalidTopLevelType(v interface{}) Error {
+	// most likely developers fault
+	t := chaseTypePointers(chaseValue(reflect.ValueOf(v)).Type())
+	message := fmt.Sprintf("can not use go type '%v' for merging/unpacking configurations", t)
+	return raiseCritical(ErrTypeMismatch, message)
+}
+
+func raiseKeyInvalidTypeUnpack(t reflect.Type, from *Config) Error {
+	// most likely developers fault
+	ctx := from.ctx
+	reason := ErrKeyTypeNotString
+	message := fmt.Sprintf("string key required when unpacking into '%v'", t)
+	return raiseCritical(reason, messagePath(reason, from.metadata, message, ctx.path(".")))
+}
+
+func raiseKeyInvalidTypeMerge(cfg *Config, t reflect.Type) Error {
+	ctx := cfg.ctx
+	reason := ErrKeyTypeNotString
+	message := fmt.Sprintf("string key required when merging into '%v'", t)
+	return raiseCritical(reason, messagePath(reason, cfg.metadata, message, ctx.path(".")))
+}
+
+func raiseSquashNeedsObject(cfg *Config, opts options, f string, t reflect.Type) Error {
+	reason := ErrTypeMismatch
+	message := fmt.Sprintf("require map or struct when squash merging '%v' (%v)", f, t)
+
+	return raiseCritical(reason, messagePath(reason, opts.meta, message, cfg.Path(".")))
+}
+
+func raiseInlineNeedsObject(cfg *Config, f string, t reflect.Type) Error {
+	reason := ErrTypeMismatch
+	message := fmt.Sprintf("require map or struct when inling '%v' (%v)", f, t)
+	return raiseCritical(reason,
+		messagePath(reason, cfg.metadata, message, cfg.Path(".")))
+}
+
+func raiseUnsupportedInputType(ctx context, opts options, v reflect.Value) Error {
+	reason := ErrTypeMismatch
+	message := fmt.Sprintf("unspported input type (%v) with value '%#v'",
+		v.Type(), v)
+
+	return raiseCritical(reason, messagePath(reason, opts.meta, message, ctx.path(".")))
+}
+
+func raiseNil(reason error) Error {
+	// programmers error (passed unexpected nil pointer)
+	return raiseCritical(reason, "")
+}
+
+func raisePointerRequired(v reflect.Value) Error {
+	// developer did not pass pointer, unpack target is not settable
+	return raiseCritical(ErrPointerRequired, "")
+}
+
+func raiseToTypeNotSupported(v value, t reflect.Type) Error {
+	reason := ErrTypeMismatch
+	message := fmt.Sprintf("value of type '%v' not convertible into unsupported go type '%v'", v.typeName(), t)
+	ctx := v.Context()
+
+	return raiseCritical(reason, messagePath(reason, v.meta(), message, ctx.path(".")))
+}
+
+func raiseArraySize(to reflect.Type, arr *cfgArray) Error {
+	reason := ErrArraySizeMistach
+	message := fmt.Sprintf("array of length %v does not meet required length %v",
+		arr.Len(), to.Len())
+
+	return raisePathErr(reason, arr.meta(), message, arr.ctx.path("."))
+}
+
+func raiseConversion(v value, err error, to string) Error {
+	ctx := v.Context()
+	path := ctx.path(".")
+	message := fmt.Sprintf("can not convert '%v' into '%v'", v.typeName(), to)
+	return raisePathErr(err, v.meta(), message, path)
+}
+
+func raiseExpectedObject(v value) Error {
+	ctx := v.Context()
+	path := ctx.path(".")
+	message := fmt.Sprintf("required 'object', but found '%v' in field '%v'",
+		v.typeName(), path)
+
+	return raiseErr(ErrExpectedObject, messageMeta(message, v.meta()))
+}

--- a/vendor/github.com/urso/ucfg/error_test.go
+++ b/vendor/github.com/urso/ucfg/error_test.go
@@ -1,0 +1,171 @@
+package ucfg
+
+import (
+	"flag"
+	"io/ioutil"
+	"path"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var updateFlag = flag.Bool("update", false, "Update the golden files.")
+
+func TestErrorMessages(t *testing.T) {
+	goldenPath := path.Join("testdata", "error", "message")
+
+	c := New()
+	cMeta := New()
+	cNested := New()
+	cNestedMeta := New()
+
+	testMeta := &Meta{"test.source"}
+	cMeta.metadata = testMeta
+	cNestedMeta.metadata = testMeta
+
+	testNestedCtx := context{field: "nested"}
+	cNested.ctx = testNestedCtx
+	cNestedMeta.ctx = testNestedCtx
+
+	arr := &cfgArray{arr: make([]value, 3)}
+	arrNested := &cfgArray{cfgPrimitive{ctx: testNestedCtx}, make([]value, 3)}
+	arrMeta := &cfgArray{cfgPrimitive{metadata: testMeta}, make([]value, 3)}
+	arrNestedMeta := &cfgArray{
+		cfgPrimitive{metadata: testMeta, ctx: testNestedCtx},
+		make([]value, 3)}
+
+	tests := map[string]Error{
+		"duplicate_wo_meta":        raiseDuplicateKey(c, "test"),
+		"duplicate_w_meta":         raiseDuplicateKey(cMeta, "test"),
+		"duplicate_nested_wo_meta": raiseDuplicateKey(cNested, "test"),
+		"duplicate_nested_w_meta":  raiseDuplicateKey(cNestedMeta, "test"),
+
+		"missing_wo_meta":        raiseMissing(c, "field"),
+		"missing_w_meta":         raiseMissing(cMeta, "field"),
+		"missing_nested_wo_meta": raiseMissing(cNested, "field"),
+		"missing_nested_w_meta":  raiseMissing(cNestedMeta, "field"),
+
+		"arr_missing_wo_meta":        raiseMissingArr(arr, 5),
+		"arr_missing_w_meta":         raiseMissingArr(arrMeta, 5),
+		"arr_missing_nested_wo_meta": raiseMissingArr(arrNested, 5),
+		"arr_missing_nested_w_meta":  raiseMissingArr(arrNestedMeta, 5),
+
+		"arr_oob_wo_meta":        raiseIndexOutOfBounds(arr, 5),
+		"arr_oob_w_meta":         raiseIndexOutOfBounds(arrMeta, 5),
+		"arr_oob_nested_wo_meta": raiseIndexOutOfBounds(arrNested, 5),
+		"arr_oob_nested_w_meta":  raiseIndexOutOfBounds(arrNestedMeta, 5),
+
+		"invalid_type_top_level": raiseInvalidTopLevelType(""),
+
+		"invalid_type_unpack_wo_meta": raiseKeyInvalidTypeUnpack(
+			reflect.TypeOf(map[int]interface{}{}), c),
+		"invalid_type_unpack_w_meta": raiseKeyInvalidTypeUnpack(
+			reflect.TypeOf(map[int]interface{}{}), cMeta),
+		"invalid_type_unpack_nested_wo_meta": raiseKeyInvalidTypeUnpack(
+			reflect.TypeOf(map[int]interface{}{}), cNested),
+		"invalid_type_unpack_nested_w_meta": raiseKeyInvalidTypeUnpack(
+			reflect.TypeOf(map[int]interface{}{}), cNestedMeta),
+
+		"invalid_type_merge_wo_meta": raiseKeyInvalidTypeMerge(
+			c, reflect.TypeOf(map[int]interface{}{})),
+		"invalid_type_merge_w_meta": raiseKeyInvalidTypeMerge(
+			cMeta, reflect.TypeOf(map[int]interface{}{})),
+		"invalid_type_merge_nested_wo_meta": raiseKeyInvalidTypeMerge(
+			cNested, reflect.TypeOf(map[int]interface{}{})),
+		"invalid_type_merge_nested_w_meta": raiseKeyInvalidTypeMerge(
+			cNestedMeta, reflect.TypeOf(map[int]interface{}{})),
+
+		"squash_wo_meta": raiseSquashNeedsObject(
+			c, options{}, "ABC", reflect.TypeOf("")),
+		"squash_w_meta": raiseSquashNeedsObject(
+			c, options{meta: testMeta}, "ABC", reflect.TypeOf("")),
+		"squash_nested_wo_meta": raiseSquashNeedsObject(
+			cNested, options{}, "ABC", reflect.TypeOf("")),
+		"squash_nested_w_meta": raiseSquashNeedsObject(
+			cNested, options{meta: testMeta}, "ABC", reflect.TypeOf("")),
+
+		"inline_wo_meta": raiseInlineNeedsObject(
+			c, "ABC", reflect.TypeOf("")),
+		"inline_w_meta": raiseInlineNeedsObject(
+			cMeta, "ABC", reflect.TypeOf("")),
+		"inline_nested_wo_meta": raiseInlineNeedsObject(
+			cNested, "ABC", reflect.TypeOf("")),
+		"inline_nested_w_meta": raiseInlineNeedsObject(
+			cNestedMeta, "ABC", reflect.TypeOf("")),
+
+		"unsupported_input_type_wo_meta": raiseUnsupportedInputType(
+			context{}, options{}, reflect.ValueOf(1)),
+		"unsupported_input_type_w_meta": raiseUnsupportedInputType(
+			context{}, options{meta: testMeta}, reflect.ValueOf(1)),
+		"unsupported_input_type_nested_wo_meta": raiseUnsupportedInputType(
+			testNestedCtx, options{}, reflect.ValueOf(1)),
+		"unsupported_input_type_nested_w_meta": raiseUnsupportedInputType(
+			testNestedCtx, options{meta: testMeta}, reflect.ValueOf(1)),
+
+		"nil_value_error":  raiseNil(ErrNilValue),
+		"nil_config_error": raiseNil(ErrNilConfig),
+
+		"pointer_required": raisePointerRequired(reflect.ValueOf(1)),
+
+		"to_type_not_supported_wo_meta": raiseToTypeNotSupported(
+			newInt(context{}, nil, 1), reflect.TypeOf(struct{}{})),
+		"to_type_not_supported_w_meta": raiseToTypeNotSupported(
+			newInt(context{}, testMeta, 1), reflect.TypeOf(struct{}{})),
+		"to_type_not_supported_nested_wo_meta": raiseToTypeNotSupported(
+			newInt(testNestedCtx, nil, 1), reflect.TypeOf(struct{}{})),
+		"to_type_not_supported_nested_w_meta": raiseToTypeNotSupported(
+			newInt(testNestedCtx, testMeta, 1), reflect.TypeOf(struct{}{})),
+
+		"array_size_wo_meta": raiseArraySize(reflect.TypeOf([10]int{}), arr),
+		"array_size_w_meta": raiseArraySize(
+			reflect.TypeOf([10]int{}), arrMeta),
+		"array_size_nested_wo_meta": raiseArraySize(
+			reflect.TypeOf([10]int{}), arrNested),
+		"array_size_nested_w_meta": raiseArraySize(
+			reflect.TypeOf([10]int{}), arrNestedMeta),
+
+		"conversion_wo_meta": raiseConversion(
+			newInt(context{}, nil, 1), ErrTypeMismatch, "bool"),
+		"conversion_w_meta": raiseConversion(
+			newInt(context{}, testMeta, 1), ErrTypeMismatch, "bool"),
+		"conversion_nested_wo_meta": raiseConversion(
+			newInt(testNestedCtx, nil, 1), ErrTypeMismatch, "bool"),
+		"conversion_nested_w_meta": raiseConversion(
+			newInt(testNestedCtx, testMeta, 1), ErrTypeMismatch, "bool"),
+
+		"expected_object_wo_meta": raiseExpectedObject(
+			newInt(context{}, nil, 1)),
+		"expected_object_w_meta": raiseExpectedObject(
+			newInt(context{}, testMeta, 1)),
+		"expected_object_nested_wo_meta": raiseExpectedObject(
+			newInt(testNestedCtx, nil, 1)),
+		"expected_object_nested_w_meta": raiseExpectedObject(
+			newInt(testNestedCtx, testMeta, 1)),
+	}
+
+	for name, result := range tests {
+		t.Logf("Test error message for: %v", name)
+
+		message := result.Message()
+		goldenFile := path.Join(goldenPath, name+".golden")
+
+		if updateFlag != nil && *updateFlag {
+			t.Logf("writing golden file: %v", goldenFile)
+			t.Logf("%v", message)
+			t.Log("")
+			err := ioutil.WriteFile(goldenFile, []byte(message), 0666)
+			if err != nil {
+				t.Fatalf("Failed to write golden file ('%v'): %v", goldenFile, err)
+			}
+		}
+
+		tmp, err := ioutil.ReadFile(goldenFile)
+		if err != nil {
+			t.Fatalf("Failed to read golden file ('%v'): %v", goldenFile, err)
+		}
+
+		golden := string(tmp)
+		assert.Equal(t, golden, message)
+	}
+}

--- a/vendor/github.com/urso/ucfg/getset.go
+++ b/vendor/github.com/urso/ucfg/getset.go
@@ -1,105 +1,148 @@
 package ucfg
 
+import "fmt"
+
 // ******************************************************************************
 // Low level getters and setters (do we actually need this?)
 // ******************************************************************************
 
+func convertErr(v value, err error, to string) Error {
+	if err == nil {
+		return nil
+	}
+	return raiseConversion(v, err, to)
+}
+
 // number of elements for this field. If config value is a list, returns number
 // of elements in list
 func (c *Config) CountField(name string) (int, error) {
-	if v, ok := c.fields[name]; ok {
+	if v, ok := c.fields.fields[name]; ok {
 		return v.Len(), nil
 	}
-	return -1, raise(ErrMissing)
+	return -1, raiseMissing(c, name)
 }
 
-func (c *Config) Bool(name string, idx int) (bool, error) {
-	v, err := c.getField(name, idx)
+func (c *Config) Bool(name string, idx int, opts ...Option) (bool, error) {
+	v, err := c.getField(name, idx, opts)
 	if err != nil {
 		return false, err
 	}
-	return v.toBool()
+	b, fail := v.toBool()
+	return b, convertErr(v, fail, "bool")
 }
 
-func (c *Config) String(name string, idx int) (string, error) {
-	v, err := c.getField(name, idx)
+func (c *Config) String(name string, idx int, opts ...Option) (string, error) {
+	v, err := c.getField(name, idx, opts)
 	if err != nil {
 		return "", err
 	}
-	return v.toString()
+	s, fail := v.toString()
+	return s, convertErr(v, fail, "string")
 }
 
-func (c *Config) Int(name string, idx int) (int64, error) {
-	v, err := c.getField(name, idx)
+func (c *Config) Int(name string, idx int, opts ...Option) (int64, error) {
+	v, err := c.getField(name, idx, opts)
 	if err != nil {
 		return 0, err
 	}
-	return v.toInt()
+	i, fail := v.toInt()
+	return i, convertErr(v, fail, "int")
 }
 
-func (c *Config) Float(name string, idx int) (float64, error) {
-	v, err := c.getField(name, idx)
+func (c *Config) Float(name string, idx int, opts ...Option) (float64, error) {
+	v, err := c.getField(name, idx, opts)
 	if err != nil {
 		return 0, err
 	}
-	return v.toFloat()
+	f, fail := v.toFloat()
+	return f, convertErr(v, fail, "float")
 }
 
-func (c *Config) Child(name string, idx int) (*Config, error) {
-	v, err := c.getField(name, idx)
+func (c *Config) Child(name string, idx int, opts ...Option) (*Config, error) {
+	v, err := c.getField(name, idx, opts)
 	if err != nil {
 		return nil, err
 	}
-	return v.toConfig()
+	c, fail := v.toConfig()
+	return c, convertErr(v, fail, "object")
 }
 
-func (c *Config) SetBool(name string, idx int, value bool) {
-	c.setField(name, idx, &cfgBool{b: value})
+func (c *Config) SetBool(name string, idx int, value bool, opts ...Option) error {
+	return c.setField(name, idx, &cfgBool{b: value}, opts)
 }
 
-func (c *Config) SetInt(name string, idx int, value int64) {
-	c.setField(name, idx, &cfgInt{i: value})
+func (c *Config) SetInt(name string, idx int, value int64, opts ...Option) error {
+	return c.setField(name, idx, &cfgInt{i: value}, opts)
 }
 
-func (c *Config) SetFloat(name string, idx int, value float64) {
-	c.setField(name, idx, &cfgFloat{f: value})
+func (c *Config) SetFloat(name string, idx int, value float64, opts ...Option) error {
+	return c.setField(name, idx, &cfgFloat{f: value}, opts)
 }
 
-func (c *Config) SetString(name string, idx int, value string) {
-	c.setField(name, idx, &cfgString{s: value})
+func (c *Config) SetString(name string, idx int, value string, opts ...Option) error {
+	return c.setField(name, idx, &cfgString{s: value}, opts)
 }
 
-func (c *Config) SetChild(name string, idx int, value *Config) {
-	c.setField(name, idx, cfgSub{c: value})
+func (c *Config) SetChild(name string, idx int, value *Config, opts ...Option) error {
+	return c.setField(name, idx, cfgSub{c: value}, opts)
 }
 
-func (c *Config) getField(name string, idx int) (value, error) {
-	v, ok := c.fields[name]
-	if !ok {
-		return nil, raise(ErrMissing)
+func (c *Config) getField(name string, idx int, options []Option) (value, Error) {
+	opts := makeOptions(options)
+
+	cfg, field, err := reifyCfgPath(c, opts, name)
+	if err != nil {
+		return nil, err
 	}
 
-	if idx >= v.Len() {
-		return nil, raise(ErrIndexOutOfRange)
+	v, ok := cfg.fields.fields[field]
+	if !ok {
+		return nil, raiseMissing(cfg, field)
 	}
 
 	if arr, ok := v.(*cfgArray); ok {
+		if idx >= arr.Len() {
+			return nil, raiseIndexOutOfBounds(v, idx)
+		}
+
 		v = arr.arr[idx]
 		if v == nil {
-			return nil, raise(ErrMissing)
+			return nil, raiseMissingArr(arr, idx)
 		}
 		return arr.arr[idx], nil
 	}
+
+	if idx > 0 {
+		return nil, raiseIndexOutOfBounds(v, idx)
+	}
+
 	return v, nil
 }
 
-func (c *Config) setField(name string, idx int, v value) {
-	old, ok := c.fields[name]
+func (c *Config) setField(name string, idx int, v value, options []Option) Error {
+	opts := makeOptions(options)
+	ctx := context{
+		parent: cfgSub{c},
+		field:  name,
+	}
+	orig := v
+
+	cfg, field, err := normalizeCfgPath(c, opts, name)
+	if err != nil {
+		return err
+	}
+
+	old, ok := cfg.fields.fields[field]
 	if !ok {
 		if idx > 0 {
-			slice := &cfgArray{arr: make([]value, idx+1)}
+			slice := &cfgArray{
+				cfgPrimitive: cfgPrimitive{ctx: ctx},
+				arr:          make([]value, idx+1),
+			}
 			slice.arr[idx] = v
 			v = slice
+		} else {
+			idx = -1
 		}
 	} else if slice, ok := old.(*cfgArray); ok {
 		for idx >= len(slice.arr) {
@@ -108,11 +151,28 @@ func (c *Config) setField(name string, idx int, v value) {
 		slice.arr[idx] = v
 		v = slice
 	} else if idx > 0 {
-		slice := &cfgArray{arr: make([]value, idx+1)}
+		slice := &cfgArray{
+			cfgPrimitive: cfgPrimitive{ctx: ctx},
+			arr:          make([]value, idx+1),
+		}
 		slice.arr[0] = old
 		slice.arr[idx] = v
 		v = slice
+	} else {
+		idx = -1
 	}
 
-	c.fields[name] = v
+	if idx >= 0 {
+		ctx.parent = v
+		ctx.field = fmt.Sprintf("%v", idx)
+	}
+	orig.SetContext(ctx)
+
+	if opts.meta != nil {
+		v.setMeta(opts.meta)
+	}
+
+	cfg.fields.fields[field] = v
+
+	return nil
 }

--- a/vendor/github.com/urso/ucfg/getset_test.go
+++ b/vendor/github.com/urso/ucfg/getset_test.go
@@ -20,6 +20,9 @@ func TestSetGetPrimitives(t *testing.T) {
 	assert.True(t, c.HasField("str"))
 	assert.Len(t, c.GetFields(), 4)
 
+	path := c.Path(".")
+	assert.Equal(t, "", path)
+
 	cnt, err := c.CountField("bool")
 	assert.NoError(t, err)
 	assert.Equal(t, 1, cnt)
@@ -67,15 +70,45 @@ func TestSetGetChild(t *testing.T) {
 	i, err := child.Int("test", 0)
 	assert.Nil(t, err)
 	assert.Equal(t, 42, int(i))
+
+	assert.Equal(t, "", c.Path("."))
+	assert.Equal(t, "child", child.Path("."))
+	assert.Equal(t, c, child.Parent())
+}
+
+func TestSetGetChildPath(t *testing.T) {
+	c := New()
+
+	err := c.SetInt("sub.test", 0, 42, PathSep("."))
+	assert.NoError(t, err)
+
+	sub, err := c.Child("sub", 0)
+	assert.Nil(t, err)
+
+	i, err := sub.Int("test", 0)
+	assert.Nil(t, err)
+	assert.Equal(t, 42, int(i))
+
+	i, err = c.Int("sub.test", 0, PathSep("."))
+	assert.Nil(t, err)
+	assert.Equal(t, 42, int(i))
+
+	assert.Equal(t, "", c.Path("."))
+	assert.Equal(t, "sub", sub.Path("."))
+	assert.Equal(t, c, sub.Parent())
 }
 
 func TestSetGetArray(t *testing.T) {
 	c := New()
 
+	child := New()
+	child.SetInt("test", 0, 42)
+
 	c.SetBool("a", 0, true)
 	c.SetInt("a", 1, 42)
 	c.SetFloat("a", 2, 3.14)
 	c.SetString("a", 3, "string")
+	c.SetChild("a", 4, child)
 
 	b, err := c.Bool("a", 0)
 	assert.NoError(t, err)
@@ -92,4 +125,10 @@ func TestSetGetArray(t *testing.T) {
 	s, err := c.String("a", 3)
 	assert.NoError(t, err)
 	assert.Equal(t, "string", s)
+
+	child, err = c.Child("a", 4)
+	assert.Nil(t, err)
+	assert.Equal(t, "", c.Path("."))
+	assert.Equal(t, "a.4", child.Path("."))
+	assert.Equal(t, c, child.Parent())
 }

--- a/vendor/github.com/urso/ucfg/json/json.go
+++ b/vendor/github.com/urso/ucfg/json/json.go
@@ -20,5 +20,7 @@ func NewConfigWithFile(name string, opts ...ucfg.Option) (*ucfg.Config, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	opts = append([]ucfg.Option{ucfg.MetaData(ucfg.Meta{name})}, opts...)
 	return NewConfig(input, opts...)
 }

--- a/vendor/github.com/urso/ucfg/merge.go
+++ b/vendor/github.com/urso/ucfg/merge.go
@@ -1,6 +1,7 @@
 package ucfg
 
 import (
+	"fmt"
 	"reflect"
 	"strings"
 )
@@ -11,31 +12,35 @@ func (c *Config) Merge(from interface{}, options ...Option) error {
 	if err != nil {
 		return err
 	}
-	return mergeConfig(c.fields, other.fields)
+	return mergeConfig(c, other)
 }
 
-func mergeConfig(to, from map[string]value) error {
-	for k, v := range from {
-		old, ok := to[k]
+func mergeConfig(to, from *Config) Error {
+	for k, v := range from.fields.fields {
+		ctx := context{
+			parent: cfgSub{to},
+			field:  k,
+		}
+
+		old, ok := to.fields.fields[k]
 		if !ok {
-			to[k] = v
+			to.fields.fields[k] = v.cpy(ctx)
 			continue
 		}
 
 		subOld, err := old.toConfig()
 		if err != nil {
-			to[k] = v
+			to.fields.fields[k] = v.cpy(ctx)
 			continue
 		}
 
 		subFrom, err := v.toConfig()
 		if err != nil {
-			to[k] = v
+			to.fields.fields[k] = v.cpy(ctx)
 			continue
 		}
 
-		err = mergeConfig(subOld.fields, subFrom.fields)
-		if err != nil {
+		if err := mergeConfig(subOld, subFrom); err != nil {
 			return err
 		}
 	}
@@ -44,7 +49,7 @@ func mergeConfig(to, from map[string]value) error {
 
 // convert from into normalized *Config checking for errors
 // before merging generated(normalized) config with current config
-func normalize(opts options, from interface{}) (*Config, error) {
+func normalize(opts options, from interface{}) (*Config, Error) {
 	vFrom := chaseValue(reflect.ValueOf(from))
 
 	switch vFrom.Type() {
@@ -53,18 +58,25 @@ func normalize(opts options, from interface{}) (*Config, error) {
 	case tConfigMap:
 		return normalizeMap(opts, vFrom)
 	default:
+		// try to convert vFrom into Config (rebranding)
+		if v, ok := tryTConfig(vFrom); ok {
+			return v.Addr().Interface().(*Config), nil
+		}
+
+		// normalize given map/struct value
 		switch vFrom.Kind() {
 		case reflect.Struct:
 			return normalizeStruct(opts, vFrom)
 		case reflect.Map:
 			return normalizeMap(opts, vFrom)
 		}
+
 	}
 
-	return nil, raise(ErrTypeMismatch)
+	return nil, raiseInvalidTopLevelType(from)
 }
 
-func normalizeCfgPath(cfg *Config, opts options, field string) (*Config, string, error) {
+func normalizeCfgPath(cfg *Config, opts options, field string) (*Config, string, Error) {
 	if opts.pathSep == "" {
 		return cfg, field, nil
 	}
@@ -74,11 +86,11 @@ func normalizeCfgPath(cfg *Config, opts options, field string) (*Config, string,
 		field = path[0]
 		path = path[1:]
 
-		sub, exists := cfg.fields[field]
+		sub, exists := cfg.fields.fields[field]
 		if exists {
 			vSub, ok := sub.(cfgSub)
 			if !ok {
-				return nil, field, raise(ErrExpectedObject)
+				return nil, field, raiseExpectedObject(sub)
 			}
 
 			cfg = vSub.c
@@ -86,7 +98,13 @@ func normalizeCfgPath(cfg *Config, opts options, field string) (*Config, string,
 		}
 
 		next := New()
-		cfg.fields[field] = cfgSub{next}
+		next.metadata = opts.meta
+		v := cfgSub{next}
+		v.SetContext(context{
+			parent: cfgSub{cfg},
+			field:  field,
+		})
+		cfg.fields.fields[field] = v
 		cfg = next
 	}
 	field = path[0]
@@ -94,24 +112,25 @@ func normalizeCfgPath(cfg *Config, opts options, field string) (*Config, string,
 	return cfg, field, nil
 }
 
-func normalizeMap(opts options, from reflect.Value) (*Config, error) {
+func normalizeMap(opts options, from reflect.Value) (*Config, Error) {
 	cfg := New()
+	cfg.metadata = opts.meta
 	if err := normalizeMapInto(cfg, opts, from); err != nil {
 		return nil, err
 	}
 	return cfg, nil
 }
 
-func normalizeMapInto(cfg *Config, opts options, from reflect.Value) error {
+func normalizeMapInto(cfg *Config, opts options, from reflect.Value) Error {
 	k := from.Type().Key().Kind()
 	if k != reflect.String && k != reflect.Interface {
-		return raise(ErrTypeMismatch)
+		return raiseKeyInvalidTypeMerge(cfg, from.Type())
 	}
 
 	for _, k := range from.MapKeys() {
 		k = chaseValueInterfaces(k)
 		if k.Kind() != reflect.String {
-			return raise(ErrKeyTypeNotString)
+			return raiseKeyInvalidTypeMerge(cfg, from.Type())
 		}
 
 		err := normalizeSetField(cfg, opts, k.String(), from.MapIndex(k))
@@ -122,20 +141,21 @@ func normalizeMapInto(cfg *Config, opts options, from reflect.Value) error {
 	return nil
 }
 
-func normalizeStruct(opts options, from reflect.Value) (*Config, error) {
+func normalizeStruct(opts options, from reflect.Value) (*Config, Error) {
 	cfg := New()
+	cfg.metadata = opts.meta
 	if err := normalizeStructInto(cfg, opts, from); err != nil {
 		return nil, err
 	}
 	return cfg, nil
 }
 
-func normalizeStructInto(cfg *Config, opts options, from reflect.Value) error {
+func normalizeStructInto(cfg *Config, opts options, from reflect.Value) Error {
 	v := chaseValue(from)
 	numField := v.NumField()
 
 	for i := 0; i < numField; i++ {
-		var err error
+		var err Error
 		stField := v.Type().Field(i)
 		name, tagOpts := parseTags(stField.Tag.Get(opts.tag))
 
@@ -147,7 +167,7 @@ func normalizeStructInto(cfg *Config, opts options, from reflect.Value) error {
 			case reflect.Map:
 				err = normalizeMapInto(cfg, opts, vField)
 			default:
-				return raise(ErrTypeMismatch)
+				return raiseSquashNeedsObject(cfg, opts, stField.Name, vField.Type())
 			}
 		} else {
 			name = fieldName(name, stField.Name)
@@ -161,89 +181,104 @@ func normalizeStructInto(cfg *Config, opts options, from reflect.Value) error {
 	return nil
 }
 
-func normalizeSetField(cfg *Config, opts options, name string, v reflect.Value) error {
+func normalizeSetField(cfg *Config, opts options, name string, v reflect.Value) Error {
 	to, name, err := normalizeCfgPath(cfg, opts, name)
 	if err != nil {
 		return err
 	}
 	if to.HasField(name) {
-		return errDuplicateKey(name)
+		return raiseDuplicateKey(to, name)
 	}
 
-	val, err := normalizeValue(opts, v)
+	ctx := context{
+		parent: cfgSub{cfg},
+		field:  name,
+	}
+	val, err := normalizeValue(opts, ctx, v)
 	if err != nil {
 		return err
 	}
 
-	to.fields[name] = val
+	to.fields.fields[name] = val
 	return nil
 }
 
-func normalizeStructValue(opts options, from reflect.Value) (value, error) {
+func normalizeStructValue(opts options, ctx context, from reflect.Value) (value, Error) {
 	sub, err := normalizeStruct(opts, from)
 	if err != nil {
 		return nil, err
 	}
-	return cfgSub{sub}, nil
+	v := cfgSub{sub}
+	v.SetContext(ctx)
+	return v, nil
 }
 
-func normalizeMapValue(opts options, from reflect.Value) (value, error) {
+func normalizeMapValue(opts options, ctx context, from reflect.Value) (value, Error) {
 	sub, err := normalizeMap(opts, from)
 	if err != nil {
 		return nil, err
 	}
-	return cfgSub{sub}, nil
+	v := cfgSub{sub}
+	v.SetContext(ctx)
+	return v, nil
 }
 
-func normalizeArray(opts options, v reflect.Value) (value, error) {
+func normalizeArray(opts options, ctx context, v reflect.Value) (value, Error) {
 	l := v.Len()
 	out := make([]value, 0, l)
+
+	arr := &cfgArray{cfgPrimitive{ctx, opts.meta}, nil}
+
 	for i := 0; i < l; i++ {
-		tmp, err := normalizeValue(opts, v.Index(i))
+		ctx := context{
+			parent: arr,
+			field:  fmt.Sprintf("%v", i),
+		}
+		tmp, err := normalizeValue(opts, ctx, v.Index(i))
 		if err != nil {
 			return nil, err
 		}
 		out = append(out, tmp)
 	}
-	return &cfgArray{arr: out}, nil
+
+	arr.arr = out
+	return arr, nil
 }
 
-func normalizeValue(opts options, v reflect.Value) (value, error) {
+func normalizeValue(opts options, ctx context, v reflect.Value) (value, Error) {
 	v = chaseValue(v)
 
 	// handle primitives
 	switch v.Kind() {
 	case reflect.Bool:
-		return &cfgBool{b: v.Bool()}, nil
+		return newBool(ctx, opts.meta, v.Bool()), nil
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		return &cfgInt{i: v.Int()}, nil
+		return newInt(ctx, opts.meta, v.Int()), nil
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		return &cfgInt{i: int64(v.Uint())}, nil
+		return newInt(ctx, opts.meta, int64(v.Uint())), nil
 	case reflect.Float32, reflect.Float64:
-		return &cfgFloat{f: v.Float()}, nil
+		return newFloat(ctx, opts.meta, v.Float()), nil
 	case reflect.String:
-		return &cfgString{s: v.String()}, nil
+		return newString(ctx, opts.meta, v.String()), nil
 	case reflect.Array, reflect.Slice:
-		return normalizeArray(opts, v)
+		return normalizeArray(opts, ctx, v)
 	case reflect.Map:
-		return normalizeMapValue(opts, v)
+		return normalizeMapValue(opts, ctx, v)
 	case reflect.Struct:
-		if v.Type().ConvertibleTo(tConfig) {
-			var c *Config
-			if !v.CanAddr() {
-				vTmp := reflect.New(tConfig)
-				vTmp.Elem().Set(v)
-				c = vTmp.Interface().(*Config)
-			} else {
-				c = v.Addr().Interface().(*Config)
+		if v, ok := tryTConfig(v); ok {
+			c := v.Addr().Interface().(*Config)
+			ret := cfgSub{c}
+			if ret.Context().parent != ctx.parent {
+				ret.SetContext(ctx)
 			}
-			return cfgSub{c}, nil
+			return ret, nil
 		}
-		return normalizeStructValue(opts, v)
+
+		return normalizeStructValue(opts, ctx, v)
 	default:
 		if v.IsNil() {
-			return cfgNil{}, nil
+			return &cfgNil{cfgPrimitive{ctx, opts.meta}}, nil
 		}
-		return nil, raise(ErrTypeMismatch)
+		return nil, raiseUnsupportedInputType(ctx, opts, v)
 	}
 }

--- a/vendor/github.com/urso/ucfg/opts.go
+++ b/vendor/github.com/urso/ucfg/opts.go
@@ -1,0 +1,38 @@
+package ucfg
+
+type Option func(*options)
+
+type options struct {
+	tag     string
+	pathSep string
+	meta    *Meta
+}
+
+func StructTag(tag string) Option {
+	return func(o *options) {
+		o.tag = tag
+	}
+}
+
+func PathSep(sep string) Option {
+	return func(o *options) {
+		o.pathSep = sep
+	}
+}
+
+func MetaData(meta Meta) Option {
+	return func(o *options) {
+		o.meta = &meta
+	}
+}
+
+func makeOptions(opts []Option) options {
+	o := options{
+		tag:     "config",
+		pathSep: "", // no separator by default
+	}
+	for _, opt := range opts {
+		opt(&o)
+	}
+	return o
+}

--- a/vendor/github.com/urso/ucfg/reify_test.go
+++ b/vendor/github.com/urso/ucfg/reify_test.go
@@ -93,8 +93,11 @@ func TestUnpackNested(t *testing.T) {
 	tests := []interface{}{
 		New(),
 
+		newC(),
+
 		map[string]interface{}{},
 		map[string]*Config{},
+		map[string]*C{},
 		map[string]map[string]bool{},
 		map[string]map[string]interface{}{},
 		map[string]interface{}{
@@ -108,14 +111,26 @@ func TestUnpackNested(t *testing.T) {
 		map[string]*Config{
 			"c": nil,
 		},
+		map[string]*C{
+			"c": nil,
+		},
 		map[string]interface{}{
 			"c": New(),
+		},
+		map[string]interface{}{
+			"c": newC(),
 		},
 		map[string]interface{}{
 			"c": genSub("b"),
 		},
 		map[string]interface{}{
 			"c": genSub("d"),
+		},
+		map[string]interface{}{
+			"c": fromConfig(genSub("b")),
+		},
+		map[string]interface{}{
+			"c": fromConfig(genSub("d")),
 		},
 		map[string]*struct{ B bool }{},
 		map[string]*struct{ B bool }{"c": nil},
@@ -125,6 +140,7 @@ func TestUnpackNested(t *testing.T) {
 		node{"c": node{}},
 		node{"c": node{"b": false}},
 		node{"c": genSub("d")},
+		node{"c": fromConfig(genSub("d"))},
 
 		&struct{ C *Config }{},
 		&struct{ C *Config }{sub},
@@ -134,6 +150,10 @@ func TestUnpackNested(t *testing.T) {
 		&struct{ C struct{ B bool } }{},
 		&struct{ C *struct{ B bool } }{&struct{ B bool }{}},
 		&struct{ C *struct{ B bool } }{},
+
+		&struct{ C *C }{},
+		&struct{ C *C }{fromConfig(sub)},
+		&struct{ C *C }{fromConfig(genSub("d"))},
 	}
 
 	for i, out := range tests {

--- a/vendor/github.com/urso/ucfg/testdata/error/message/arr_missing_nested_w_meta.golden
+++ b/vendor/github.com/urso/ucfg/testdata/error/message/arr_missing_nested_w_meta.golden
@@ -1,0 +1,1 @@
+no value in array at 5 accessing 'nested' (source:'test.source')

--- a/vendor/github.com/urso/ucfg/testdata/error/message/arr_missing_nested_wo_meta.golden
+++ b/vendor/github.com/urso/ucfg/testdata/error/message/arr_missing_nested_wo_meta.golden
@@ -1,0 +1,1 @@
+no value in array at 5 accessing 'nested'

--- a/vendor/github.com/urso/ucfg/testdata/error/message/arr_missing_w_meta.golden
+++ b/vendor/github.com/urso/ucfg/testdata/error/message/arr_missing_w_meta.golden
@@ -1,0 +1,1 @@
+no value in array at 5 accessing config (source:'test.source')

--- a/vendor/github.com/urso/ucfg/testdata/error/message/arr_missing_wo_meta.golden
+++ b/vendor/github.com/urso/ucfg/testdata/error/message/arr_missing_wo_meta.golden
@@ -1,0 +1,1 @@
+no value in array at 5 accessing config

--- a/vendor/github.com/urso/ucfg/testdata/error/message/arr_oob_nested_w_meta.golden
+++ b/vendor/github.com/urso/ucfg/testdata/error/message/arr_oob_nested_w_meta.golden
@@ -1,0 +1,1 @@
+index '5' out of range (length=3) accessing 'nested' (source:'test.source')

--- a/vendor/github.com/urso/ucfg/testdata/error/message/arr_oob_nested_wo_meta.golden
+++ b/vendor/github.com/urso/ucfg/testdata/error/message/arr_oob_nested_wo_meta.golden
@@ -1,0 +1,1 @@
+index '5' out of range (length=3) accessing 'nested'

--- a/vendor/github.com/urso/ucfg/testdata/error/message/arr_oob_w_meta.golden
+++ b/vendor/github.com/urso/ucfg/testdata/error/message/arr_oob_w_meta.golden
@@ -1,0 +1,1 @@
+index '5' out of range (length=3) accessing config (source:'test.source')

--- a/vendor/github.com/urso/ucfg/testdata/error/message/arr_oob_wo_meta.golden
+++ b/vendor/github.com/urso/ucfg/testdata/error/message/arr_oob_wo_meta.golden
@@ -1,0 +1,1 @@
+index '5' out of range (length=3) accessing config

--- a/vendor/github.com/urso/ucfg/testdata/error/message/array_size_nested_w_meta.golden
+++ b/vendor/github.com/urso/ucfg/testdata/error/message/array_size_nested_w_meta.golden
@@ -1,0 +1,1 @@
+array of length 3 does not meet required length 10 accessing 'nested' (source:'test.source')

--- a/vendor/github.com/urso/ucfg/testdata/error/message/array_size_nested_wo_meta.golden
+++ b/vendor/github.com/urso/ucfg/testdata/error/message/array_size_nested_wo_meta.golden
@@ -1,0 +1,1 @@
+array of length 3 does not meet required length 10 accessing 'nested'

--- a/vendor/github.com/urso/ucfg/testdata/error/message/array_size_w_meta.golden
+++ b/vendor/github.com/urso/ucfg/testdata/error/message/array_size_w_meta.golden
@@ -1,0 +1,1 @@
+array of length 3 does not meet required length 10 accessing config (source:'test.source')

--- a/vendor/github.com/urso/ucfg/testdata/error/message/array_size_wo_meta.golden
+++ b/vendor/github.com/urso/ucfg/testdata/error/message/array_size_wo_meta.golden
@@ -1,0 +1,1 @@
+array of length 3 does not meet required length 10 accessing config

--- a/vendor/github.com/urso/ucfg/testdata/error/message/conversion_nested_w_meta.golden
+++ b/vendor/github.com/urso/ucfg/testdata/error/message/conversion_nested_w_meta.golden
@@ -1,0 +1,1 @@
+can not convert 'int' into 'bool' accessing 'nested' (source:'test.source')

--- a/vendor/github.com/urso/ucfg/testdata/error/message/conversion_nested_wo_meta.golden
+++ b/vendor/github.com/urso/ucfg/testdata/error/message/conversion_nested_wo_meta.golden
@@ -1,0 +1,1 @@
+can not convert 'int' into 'bool' accessing 'nested'

--- a/vendor/github.com/urso/ucfg/testdata/error/message/conversion_w_meta.golden
+++ b/vendor/github.com/urso/ucfg/testdata/error/message/conversion_w_meta.golden
@@ -1,0 +1,1 @@
+can not convert 'int' into 'bool' accessing config (source:'test.source')

--- a/vendor/github.com/urso/ucfg/testdata/error/message/conversion_wo_meta.golden
+++ b/vendor/github.com/urso/ucfg/testdata/error/message/conversion_wo_meta.golden
@@ -1,0 +1,1 @@
+can not convert 'int' into 'bool' accessing config

--- a/vendor/github.com/urso/ucfg/testdata/error/message/duplicate_nested_w_meta.golden
+++ b/vendor/github.com/urso/ucfg/testdata/error/message/duplicate_nested_w_meta.golden
@@ -1,0 +1,1 @@
+duplicate key accessing 'nested.test' (source:'test.source')

--- a/vendor/github.com/urso/ucfg/testdata/error/message/duplicate_nested_wo_meta.golden
+++ b/vendor/github.com/urso/ucfg/testdata/error/message/duplicate_nested_wo_meta.golden
@@ -1,0 +1,1 @@
+duplicate key accessing 'nested.test'

--- a/vendor/github.com/urso/ucfg/testdata/error/message/duplicate_w_meta.golden
+++ b/vendor/github.com/urso/ucfg/testdata/error/message/duplicate_w_meta.golden
@@ -1,0 +1,1 @@
+duplicate key accessing 'test' (source:'test.source')

--- a/vendor/github.com/urso/ucfg/testdata/error/message/duplicate_wo_meta.golden
+++ b/vendor/github.com/urso/ucfg/testdata/error/message/duplicate_wo_meta.golden
@@ -1,0 +1,1 @@
+duplicate key accessing 'test'

--- a/vendor/github.com/urso/ucfg/testdata/error/message/expected_object_nested_w_meta.golden
+++ b/vendor/github.com/urso/ucfg/testdata/error/message/expected_object_nested_w_meta.golden
@@ -1,0 +1,1 @@
+required 'object', but found 'int' in field 'nested' (source:'test.source')

--- a/vendor/github.com/urso/ucfg/testdata/error/message/expected_object_nested_wo_meta.golden
+++ b/vendor/github.com/urso/ucfg/testdata/error/message/expected_object_nested_wo_meta.golden
@@ -1,0 +1,1 @@
+required 'object', but found 'int' in field 'nested'

--- a/vendor/github.com/urso/ucfg/testdata/error/message/expected_object_w_meta.golden
+++ b/vendor/github.com/urso/ucfg/testdata/error/message/expected_object_w_meta.golden
@@ -1,0 +1,1 @@
+required 'object', but found 'int' in field '' (source:'test.source')

--- a/vendor/github.com/urso/ucfg/testdata/error/message/expected_object_wo_meta.golden
+++ b/vendor/github.com/urso/ucfg/testdata/error/message/expected_object_wo_meta.golden
@@ -1,0 +1,1 @@
+required 'object', but found 'int' in field ''

--- a/vendor/github.com/urso/ucfg/testdata/error/message/inline_nested_w_meta.golden
+++ b/vendor/github.com/urso/ucfg/testdata/error/message/inline_nested_w_meta.golden
@@ -1,0 +1,1 @@
+(assert) require map or struct when inling 'ABC' (string) accessing 'nested' (source:'test.source')

--- a/vendor/github.com/urso/ucfg/testdata/error/message/inline_nested_wo_meta.golden
+++ b/vendor/github.com/urso/ucfg/testdata/error/message/inline_nested_wo_meta.golden
@@ -1,0 +1,1 @@
+(assert) require map or struct when inling 'ABC' (string) accessing 'nested'

--- a/vendor/github.com/urso/ucfg/testdata/error/message/inline_w_meta.golden
+++ b/vendor/github.com/urso/ucfg/testdata/error/message/inline_w_meta.golden
@@ -1,0 +1,1 @@
+(assert) require map or struct when inling 'ABC' (string) accessing config (source:'test.source')

--- a/vendor/github.com/urso/ucfg/testdata/error/message/inline_wo_meta.golden
+++ b/vendor/github.com/urso/ucfg/testdata/error/message/inline_wo_meta.golden
@@ -1,0 +1,1 @@
+(assert) require map or struct when inling 'ABC' (string) accessing config

--- a/vendor/github.com/urso/ucfg/testdata/error/message/invalid_type_merge_nested_w_meta.golden
+++ b/vendor/github.com/urso/ucfg/testdata/error/message/invalid_type_merge_nested_w_meta.golden
@@ -1,0 +1,1 @@
+(assert) string key required when merging into 'map[int]interface {}' accessing 'nested' (source:'test.source')

--- a/vendor/github.com/urso/ucfg/testdata/error/message/invalid_type_merge_nested_wo_meta.golden
+++ b/vendor/github.com/urso/ucfg/testdata/error/message/invalid_type_merge_nested_wo_meta.golden
@@ -1,0 +1,1 @@
+(assert) string key required when merging into 'map[int]interface {}' accessing 'nested'

--- a/vendor/github.com/urso/ucfg/testdata/error/message/invalid_type_merge_w_meta.golden
+++ b/vendor/github.com/urso/ucfg/testdata/error/message/invalid_type_merge_w_meta.golden
@@ -1,0 +1,1 @@
+(assert) string key required when merging into 'map[int]interface {}' accessing config (source:'test.source')

--- a/vendor/github.com/urso/ucfg/testdata/error/message/invalid_type_merge_wo_meta.golden
+++ b/vendor/github.com/urso/ucfg/testdata/error/message/invalid_type_merge_wo_meta.golden
@@ -1,0 +1,1 @@
+(assert) string key required when merging into 'map[int]interface {}' accessing config

--- a/vendor/github.com/urso/ucfg/testdata/error/message/invalid_type_top_level.golden
+++ b/vendor/github.com/urso/ucfg/testdata/error/message/invalid_type_top_level.golden
@@ -1,0 +1,1 @@
+(assert) can not use go type 'string' for merging/unpacking configurations

--- a/vendor/github.com/urso/ucfg/testdata/error/message/invalid_type_unpack_nested_w_meta.golden
+++ b/vendor/github.com/urso/ucfg/testdata/error/message/invalid_type_unpack_nested_w_meta.golden
@@ -1,0 +1,1 @@
+(assert) string key required when unpacking into 'map[int]interface {}' accessing 'nested' (source:'test.source')

--- a/vendor/github.com/urso/ucfg/testdata/error/message/invalid_type_unpack_nested_wo_meta.golden
+++ b/vendor/github.com/urso/ucfg/testdata/error/message/invalid_type_unpack_nested_wo_meta.golden
@@ -1,0 +1,1 @@
+(assert) string key required when unpacking into 'map[int]interface {}' accessing 'nested'

--- a/vendor/github.com/urso/ucfg/testdata/error/message/invalid_type_unpack_w_meta.golden
+++ b/vendor/github.com/urso/ucfg/testdata/error/message/invalid_type_unpack_w_meta.golden
@@ -1,0 +1,1 @@
+(assert) string key required when unpacking into 'map[int]interface {}' accessing config (source:'test.source')

--- a/vendor/github.com/urso/ucfg/testdata/error/message/invalid_type_unpack_wo_meta.golden
+++ b/vendor/github.com/urso/ucfg/testdata/error/message/invalid_type_unpack_wo_meta.golden
@@ -1,0 +1,1 @@
+(assert) string key required when unpacking into 'map[int]interface {}' accessing config

--- a/vendor/github.com/urso/ucfg/testdata/error/message/missing_nested_w_meta.golden
+++ b/vendor/github.com/urso/ucfg/testdata/error/message/missing_nested_w_meta.golden
@@ -1,0 +1,1 @@
+missing field accessing 'nested.field' (source:'test.source')

--- a/vendor/github.com/urso/ucfg/testdata/error/message/missing_nested_wo_meta.golden
+++ b/vendor/github.com/urso/ucfg/testdata/error/message/missing_nested_wo_meta.golden
@@ -1,0 +1,1 @@
+missing field accessing 'nested.field'

--- a/vendor/github.com/urso/ucfg/testdata/error/message/missing_w_meta.golden
+++ b/vendor/github.com/urso/ucfg/testdata/error/message/missing_w_meta.golden
@@ -1,0 +1,1 @@
+missing field accessing 'field' (source:'test.source')

--- a/vendor/github.com/urso/ucfg/testdata/error/message/missing_wo_meta.golden
+++ b/vendor/github.com/urso/ucfg/testdata/error/message/missing_wo_meta.golden
@@ -1,0 +1,1 @@
+missing field accessing 'field'

--- a/vendor/github.com/urso/ucfg/testdata/error/message/nil_config_error.golden
+++ b/vendor/github.com/urso/ucfg/testdata/error/message/nil_config_error.golden
@@ -1,0 +1,1 @@
+(assert) config is nil

--- a/vendor/github.com/urso/ucfg/testdata/error/message/nil_value_error.golden
+++ b/vendor/github.com/urso/ucfg/testdata/error/message/nil_value_error.golden
@@ -1,0 +1,1 @@
+(assert) nil value is invalid

--- a/vendor/github.com/urso/ucfg/testdata/error/message/pointer_required.golden
+++ b/vendor/github.com/urso/ucfg/testdata/error/message/pointer_required.golden
@@ -1,0 +1,1 @@
+(assert) pointer required for unpacking configurations

--- a/vendor/github.com/urso/ucfg/testdata/error/message/squash_nested_w_meta.golden
+++ b/vendor/github.com/urso/ucfg/testdata/error/message/squash_nested_w_meta.golden
@@ -1,0 +1,1 @@
+(assert) require map or struct when squash merging 'ABC' (string) accessing 'nested' (source:'test.source')

--- a/vendor/github.com/urso/ucfg/testdata/error/message/squash_nested_wo_meta.golden
+++ b/vendor/github.com/urso/ucfg/testdata/error/message/squash_nested_wo_meta.golden
@@ -1,0 +1,1 @@
+(assert) require map or struct when squash merging 'ABC' (string) accessing 'nested'

--- a/vendor/github.com/urso/ucfg/testdata/error/message/squash_w_meta.golden
+++ b/vendor/github.com/urso/ucfg/testdata/error/message/squash_w_meta.golden
@@ -1,0 +1,1 @@
+(assert) require map or struct when squash merging 'ABC' (string) accessing config (source:'test.source')

--- a/vendor/github.com/urso/ucfg/testdata/error/message/squash_wo_meta.golden
+++ b/vendor/github.com/urso/ucfg/testdata/error/message/squash_wo_meta.golden
@@ -1,0 +1,1 @@
+(assert) require map or struct when squash merging 'ABC' (string) accessing config

--- a/vendor/github.com/urso/ucfg/testdata/error/message/to_type_not_supported_nested_w_meta.golden
+++ b/vendor/github.com/urso/ucfg/testdata/error/message/to_type_not_supported_nested_w_meta.golden
@@ -1,0 +1,1 @@
+(assert) value of type 'int' not convertible into unsupported go type 'struct {}' accessing 'nested' (source:'test.source')

--- a/vendor/github.com/urso/ucfg/testdata/error/message/to_type_not_supported_nested_wo_meta.golden
+++ b/vendor/github.com/urso/ucfg/testdata/error/message/to_type_not_supported_nested_wo_meta.golden
@@ -1,0 +1,1 @@
+(assert) value of type 'int' not convertible into unsupported go type 'struct {}' accessing 'nested'

--- a/vendor/github.com/urso/ucfg/testdata/error/message/to_type_not_supported_w_meta.golden
+++ b/vendor/github.com/urso/ucfg/testdata/error/message/to_type_not_supported_w_meta.golden
@@ -1,0 +1,1 @@
+(assert) value of type 'int' not convertible into unsupported go type 'struct {}' accessing config (source:'test.source')

--- a/vendor/github.com/urso/ucfg/testdata/error/message/to_type_not_supported_wo_meta.golden
+++ b/vendor/github.com/urso/ucfg/testdata/error/message/to_type_not_supported_wo_meta.golden
@@ -1,0 +1,1 @@
+(assert) value of type 'int' not convertible into unsupported go type 'struct {}' accessing config

--- a/vendor/github.com/urso/ucfg/testdata/error/message/unsupported_input_type_nested_w_meta.golden
+++ b/vendor/github.com/urso/ucfg/testdata/error/message/unsupported_input_type_nested_w_meta.golden
@@ -1,0 +1,1 @@
+(assert) unspported input type (int) with value '1' accessing 'nested' (source:'test.source')

--- a/vendor/github.com/urso/ucfg/testdata/error/message/unsupported_input_type_nested_wo_meta.golden
+++ b/vendor/github.com/urso/ucfg/testdata/error/message/unsupported_input_type_nested_wo_meta.golden
@@ -1,0 +1,1 @@
+(assert) unspported input type (int) with value '1' accessing 'nested'

--- a/vendor/github.com/urso/ucfg/testdata/error/message/unsupported_input_type_w_meta.golden
+++ b/vendor/github.com/urso/ucfg/testdata/error/message/unsupported_input_type_w_meta.golden
@@ -1,0 +1,1 @@
+(assert) unspported input type (int) with value '1' accessing config (source:'test.source')

--- a/vendor/github.com/urso/ucfg/testdata/error/message/unsupported_input_type_wo_meta.golden
+++ b/vendor/github.com/urso/ucfg/testdata/error/message/unsupported_input_type_wo_meta.golden
@@ -1,0 +1,1 @@
+(assert) unspported input type (int) with value '1' accessing config

--- a/vendor/github.com/urso/ucfg/types.go
+++ b/vendor/github.com/urso/ucfg/types.go
@@ -6,17 +6,32 @@ import (
 )
 
 type value interface {
+	cpy(c context) value
+
+	Context() context
+	SetContext(c context)
+
+	meta() *Meta
+	setMeta(m *Meta)
+
 	Len() int
 
 	reflect() reflect.Value
 	typ() reflect.Type
 	reify() interface{}
 
+	typeName() string
+
 	toBool() (bool, error)
 	toString() (string, error)
 	toInt() (int64, error)
 	toFloat() (float64, error)
 	toConfig() (*Config, error)
+}
+
+type context struct {
+	parent value
+	field  string
 }
 
 type cfgArray struct {
@@ -50,18 +65,73 @@ type cfgSub struct {
 
 type cfgNil struct{ cfgPrimitive }
 
-type cfgPrimitive struct{}
+type cfgPrimitive struct {
+	ctx      context
+	metadata *Meta
+}
 
+func (c *context) empty() bool {
+	return c.parent == nil
+}
+
+func (c *context) path(sep string) string {
+	if c.field == "" {
+		return ""
+	}
+
+	if c.parent != nil {
+		p := c.parent.Context()
+		if parent := p.path(sep); parent != "" {
+			return fmt.Sprintf("%v%v%v", parent, sep, c.field)
+		}
+	}
+
+	return c.field
+}
+
+func (c *context) pathOf(field, sep string) string {
+	if p := c.path(sep); p != "" {
+		return fmt.Sprintf("%v%v%v", p, sep, field)
+	}
+	return field
+}
+
+func newBool(ctx context, m *Meta, b bool) *cfgBool {
+	return &cfgBool{cfgPrimitive{ctx, m}, b}
+}
+
+func newInt(ctx context, m *Meta, i int64) *cfgInt {
+	return &cfgInt{cfgPrimitive{ctx, m}, i}
+}
+
+func newFloat(ctx context, m *Meta, f float64) *cfgFloat {
+	return &cfgFloat{cfgPrimitive{ctx, m}, f}
+}
+
+func newString(ctx context, m *Meta, s string) *cfgString {
+	return &cfgString{cfgPrimitive{ctx, m}, s}
+}
+
+func (p *cfgPrimitive) Context() context        { return p.ctx }
+func (p *cfgPrimitive) SetContext(c context)    { p.ctx = c }
+func (p *cfgPrimitive) meta() *Meta             { return p.metadata }
+func (p *cfgPrimitive) setMeta(m *Meta)         { p.metadata = m }
 func (cfgPrimitive) Len() int                   { return 1 }
-func (cfgPrimitive) toBool() (bool, error)      { return false, raise(ErrTypeMismatch) }
-func (cfgPrimitive) toString() (string, error)  { return "", raise(ErrTypeMismatch) }
-func (cfgPrimitive) toInt() (int64, error)      { return 0, raise(ErrTypeMismatch) }
-func (cfgPrimitive) toFloat() (float64, error)  { return 0, raise(ErrTypeMismatch) }
-func (cfgPrimitive) toConfig() (*Config, error) { return nil, raise(ErrTypeMismatch) }
+func (cfgPrimitive) toBool() (bool, error)      { return false, ErrTypeMismatch }
+func (cfgPrimitive) toString() (string, error)  { return "", ErrTypeMismatch }
+func (cfgPrimitive) toInt() (int64, error)      { return 0, ErrTypeMismatch }
+func (cfgPrimitive) toFloat() (float64, error)  { return 0, ErrTypeMismatch }
+func (cfgPrimitive) toConfig() (*Config, error) { return nil, ErrTypeMismatch }
 
+func (cfgArray) typeName() string          { return "array" }
 func (c *cfgArray) Len() int               { return len(c.arr) }
 func (c *cfgArray) reflect() reflect.Value { return reflect.ValueOf(c.arr) }
 func (cfgArray) typ() reflect.Type         { return tInterfaceArray }
+
+func (c *cfgArray) cpy(ctx context) value {
+	return &cfgArray{cfgPrimitive{ctx, c.meta()}, c.arr}
+}
+
 func (c *cfgArray) reify() interface{} {
 	r := make([]interface{}, len(c.arr))
 	for i, v := range c.arr {
@@ -70,61 +140,93 @@ func (c *cfgArray) reify() interface{} {
 	return r
 }
 
-func (cfgNil) Len() int                   { return 0 }
-func (cfgNil) toString() (string, error)  { return "null", nil }
-func (cfgNil) toInt() (int64, error)      { return 0, raise(ErrTypeMismatch) }
-func (cfgNil) toFloat() (float64, error)  { return 0, raise(ErrTypeMismatch) }
-func (cfgNil) toConfig() (*Config, error) { return New(), nil }
-func (cfgNil) reflect() reflect.Value     { return reflect.ValueOf(nil) }
-func (cfgNil) reify() interface{}         { return nil }
-func (cfgNil) typ() reflect.Type          { return reflect.PtrTo(tConfig) }
+func (c *cfgNil) cpy(ctx context) value   { return &cfgNil{cfgPrimitive{ctx, c.metadata}} }
+func (*cfgNil) Len() int                  { return 0 }
+func (*cfgNil) typeName() string          { return "any" }
+func (*cfgNil) toString() (string, error) { return "null", nil }
+func (*cfgNil) toInt() (int64, error)     { return 0, ErrTypeMismatch }
+func (*cfgNil) toFloat() (float64, error) { return 0, ErrTypeMismatch }
+func (*cfgNil) reify() interface{}        { return nil }
+func (*cfgNil) typ() reflect.Type         { return reflect.PtrTo(tConfig) }
+func (c *cfgNil) meta() *Meta             { return c.metadata }
+func (c *cfgNil) setMeta(m *Meta)         { c.metadata = m }
 
+func (c *cfgNil) reflect() reflect.Value {
+	cfg, _ := c.toConfig()
+	return reflect.ValueOf(cfg)
+}
+
+func (c *cfgNil) toConfig() (*Config, error) {
+	n := New()
+	n.ctx = c.ctx
+	return n, nil
+}
+
+func (c *cfgBool) cpy(ctx context) value     { return newBool(ctx, c.meta(), c.b) }
+func (*cfgBool) typeName() string            { return "bool" }
 func (c *cfgBool) toBool() (bool, error)     { return c.b, nil }
 func (c *cfgBool) reflect() reflect.Value    { return reflect.ValueOf(c.b) }
 func (c *cfgBool) reify() interface{}        { return c.b }
 func (c *cfgBool) toString() (string, error) { return fmt.Sprintf("%t", c.b), nil }
 func (c *cfgBool) typ() reflect.Type         { return tBool }
 
+func (c *cfgInt) cpy(ctx context) value     { return newInt(ctx, c.meta(), c.i) }
+func (*cfgInt) typeName() string            { return "int" }
 func (c *cfgInt) toInt() (int64, error)     { return c.i, nil }
 func (c *cfgInt) reflect() reflect.Value    { return reflect.ValueOf(c.i) }
 func (c *cfgInt) reify() interface{}        { return c.i }
 func (c *cfgInt) toString() (string, error) { return fmt.Sprintf("%d", c.i), nil }
 func (c *cfgInt) typ() reflect.Type         { return tInt64 }
 
+func (c *cfgFloat) cpy(ctx context) value     { return newFloat(ctx, c.meta(), c.f) }
+func (*cfgFloat) typeName() string            { return "float" }
 func (c *cfgFloat) toFloat() (float64, error) { return c.f, nil }
 func (c *cfgFloat) reflect() reflect.Value    { return reflect.ValueOf(c.f) }
 func (c *cfgFloat) reify() interface{}        { return c.f }
 func (c *cfgFloat) toString() (string, error) { return fmt.Sprintf("%v", c.f), nil }
 func (c *cfgFloat) typ() reflect.Type         { return tFloat64 }
 
+func (c *cfgString) cpy(ctx context) value     { return newString(ctx, c.meta(), c.s) }
+func (*cfgString) typeName() string            { return "string" }
 func (c *cfgString) toString() (string, error) { return c.s, nil }
 func (c *cfgString) reflect() reflect.Value    { return reflect.ValueOf(c.s) }
 func (c *cfgString) reify() interface{}        { return c.s }
 func (c *cfgString) typ() reflect.Type         { return tString }
 
 func (cfgSub) Len() int                     { return 1 }
-func (cfgSub) toBool() (bool, error)        { return false, raise(ErrTypeMismatch) }
-func (cfgSub) toString() (string, error)    { return "", raise(ErrTypeMismatch) }
-func (cfgSub) toInt() (int64, error)        { return 0, raise(ErrTypeMismatch) }
-func (cfgSub) toFloat() (float64, error)    { return 0, raise(ErrTypeMismatch) }
+func (cfgSub) typeName() string             { return "object" }
+func (c cfgSub) Context() context           { return c.c.ctx }
+func (cfgSub) toBool() (bool, error)        { return false, ErrTypeMismatch }
+func (cfgSub) toString() (string, error)    { return "", ErrTypeMismatch }
+func (cfgSub) toInt() (int64, error)        { return 0, ErrTypeMismatch }
+func (cfgSub) toFloat() (float64, error)    { return 0, ErrTypeMismatch }
 func (c cfgSub) toConfig() (*Config, error) { return c.c, nil }
 func (cfgSub) typ() reflect.Type            { return reflect.PtrTo(tConfig) }
 func (c cfgSub) reflect() reflect.Value     { return reflect.ValueOf(c.c) }
+func (c cfgSub) meta() *Meta                { return c.c.metadata }
+func (c cfgSub) setMeta(m *Meta)            { c.c.metadata = m }
+
+func (c cfgSub) cpy(ctx context) value {
+	return cfgSub{
+		c: &Config{ctx: ctx, fields: c.c.fields, metadata: c.c.metadata},
+	}
+}
+
+func (c cfgSub) SetContext(ctx context) {
+	if c.c.ctx.empty() {
+		c.c.ctx = ctx
+	} else {
+		c.c = &Config{
+			ctx:    ctx,
+			fields: c.c.fields,
+		}
+	}
+}
+
 func (c cfgSub) reify() interface{} {
 	m := make(map[string]interface{})
-	for k, v := range c.c.fields {
+	for k, v := range c.c.fields.fields {
 		m[k] = v.reify()
 	}
 	return m
 }
-
-type cfgKind uint8
-
-const (
-	kindBool cfgKind = iota
-	kindString
-	kindInt
-	kindFloat
-	kindConfig
-	kindArray
-)

--- a/vendor/github.com/urso/ucfg/yaml/yaml.go
+++ b/vendor/github.com/urso/ucfg/yaml/yaml.go
@@ -20,5 +20,7 @@ func NewConfigWithFile(name string, opts ...ucfg.Option) (*ucfg.Config, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	opts = append([]ucfg.Option{ucfg.MetaData(ucfg.Meta{name})}, opts...)
 	return NewConfig(input, opts...)
 }


### PR DESCRIPTION
Upgrading ucfg from v0.0.0 to v0.1.1, see [changelog](https://github.com/urso/ucfg/blob/master/CHANGELOG.md)

Fix vendoring problem by shadowing *ucfg.Config via *common.Config.

Use time.Duration parsing support in ucfg for some duration types in libbeat and packetbeat. time.Duration parsing will treat raw number (int, float) as seconds and string will be parsed by time.ParseDuration -> change if backwards compatible to code places using 'int' for durations in seconds.

Note: Can not make use of regexp parsing support in ucfg, due to ucfg using regexp.Compile but beats using regexp.CompilePOSIX (which unfortunately works a little differently, potentially breaking backwards compatibility, see: http://play.golang.org/p/soMR8CXcwy)

Note: In general with ucfg when unpacking, the object to unpack into should have default values already be initialized instead of using pointers and do post-unpacking checks.

prefer:

```
    config := struct { number int }{ number: 5}
    err := cfg.Unpack(&config)
```

over 

```
    config := struct { number *int }
    err := cfg.Unpack(&config)
    ...
    var number int
    if config.number != nil {
        number = *config.number
    } else {
        number = 5
    }
```