### PR TITLE
Upgrade elasticsearch templates so that they are compliant with the upcoming elasticsearch 5.0.

### DIFF
--- a/filebeat/etc/fields.yml
+++ b/filebeat/etc/fields.yml
@@ -1,9 +1,9 @@
 version: 1.0
 
 defaults:
-  type: string
+  type: keyword
   required: false
-  index: not_analyzed
+  index: true
   doc_values: true
   ignore_above: 1024
 
@@ -48,7 +48,7 @@ log:
     Contains log file lines.
   fields:
     - name: source
-      type: string
+      type: keyword
       required: true
       description: >
         The file from which the line was read. This field contains the full path to the file.
@@ -61,8 +61,7 @@ log:
         The file offset the reported line starts at.
 
     - name: message
-      type: string
-      index: analyzed
+      type: text
       doc_values: true
       ignore_above: 0
       required: true

--- a/filebeat/etc/filebeat.template.json
+++ b/filebeat/etc/filebeat.template.json
@@ -2,10 +2,7 @@
   "mappings": {
     "_default_": {
       "_all": {
-        "enabled": true,
-        "norms": {
-          "enabled": false
-        }
+        "norms": false
       },
       "dynamic_templates": [
         {
@@ -13,10 +10,10 @@
             "mapping": {
               "doc_values": true,
               "ignore_above": 1024,
-              "index": "not_analyzed",
-              "type": "{dynamic_type}"
+              "index": true,
+              "type": "keyword"
             },
-            "match": "*"
+            "match_mapping_type": "string"
           }
         }
       ],
@@ -25,14 +22,10 @@
           "type": "date"
         },
         "message": {
-          "index": "analyzed",
-          "norms": {
-            "enabled": false
-          },
-          "type": "string"
+          "norms": false,
+          "type": "text"
         },
         "offset": {
-          "doc_values": "true",
           "type": "long"
         }
       }

--- a/metricbeat/etc/fields.yml
+++ b/metricbeat/etc/fields.yml
@@ -1,9 +1,9 @@
 version: 1.0
 
 defaults:
-  type: string
+  type: keyword
   required: false
-  index: not_analyzed
+  index: true
   doc_values: true
   ignore_above: 1024
 

--- a/metricbeat/etc/metricbeat.template.json
+++ b/metricbeat/etc/metricbeat.template.json
@@ -2,10 +2,7 @@
   "mappings": {
     "_default_": {
       "_all": {
-        "enabled": true,
-        "norms": {
-          "enabled": false
-        }
+        "norms": false
       },
       "dynamic_templates": [
         {
@@ -13,10 +10,10 @@
             "mapping": {
               "doc_values": true,
               "ignore_above": 1024,
-              "index": "not_analyzed",
-              "type": "{dynamic_type}"
+              "index": true,
+              "type": "keyword"
             },
-            "match": "*"
+            "match_mapping_type": "string"
           }
         }
       ],
@@ -29,11 +26,9 @@
             "aborted": {
               "properties": {
                 "Aborted_clients": {
-                  "doc_values": "true",
                   "type": "integer"
                 },
                 "Aborted_connects": {
-                  "doc_values": "true",
                   "type": "integer"
                 }
               }
@@ -41,11 +36,9 @@
             "bytes": {
               "properties": {
                 "Bytes_received": {
-                  "doc_values": "true",
                   "type": "integer"
                 },
                 "Bytes_sent": {
-                  "doc_values": "true",
                   "type": "integer"
                 }
               }
@@ -57,19 +50,15 @@
             "clients": {
               "properties": {
                 "blocked_clients": {
-                  "doc_values": "true",
                   "type": "integer"
                 },
                 "client_biggest_input_buf": {
-                  "doc_values": "true",
                   "type": "integer"
                 },
                 "client_longest_output_list": {
-                  "doc_values": "true",
                   "type": "integer"
                 },
                 "connected_clients": {
-                  "doc_values": "true",
                   "type": "integer"
                 }
               }
@@ -77,19 +66,15 @@
             "cpu": {
               "properties": {
                 "used_cpu_sys": {
-                  "doc_values": "true",
                   "type": "float"
                 },
                 "used_cpu_sys_children": {
-                  "doc_values": "true",
                   "type": "float"
                 },
                 "used_cpu_user": {
-                  "doc_values": "true",
                   "type": "float"
                 },
                 "used_cpu_user_children": {
-                  "doc_values": "true",
                   "type": "float"
                 }
               }
@@ -97,7 +82,6 @@
           }
         },
         "rtt": {
-          "doc_values": "true",
           "type": "long"
         }
       }

--- a/packetbeat/etc/fields.yml
+++ b/packetbeat/etc/fields.yml
@@ -1,9 +1,9 @@
 version: 1.0
 
 defaults:
-  type: string
+  type: keyword
   required: false
-  index: not_analyzed
+  index: true
   doc_values: true
   ignore_above: 1024
 
@@ -398,17 +398,15 @@ trans_event:
         is the key.
 
     - name: query
-      type: string
+      type: keyword
       ignore_above: 0
-      index: not_analyzed
-      doc_values: true
       description: >
         The query in a human readable format. For HTTP, it will typically be
         something like `GET /users/_search?name=test`. For MySQL, it is
         something like `SELECT id from users where name=test`.
 
     - name: params
-      index: analyzed
+      type: text
       description: >
         The request parameters. For HTTP, these are the POST or GET parameters.
         For Thrift-RPC, these are the parameters from the request.
@@ -429,7 +427,7 @@ trans_event:
             - 6
 
         - name: request.message
-          type: string
+          type: keyword
           description: A human readable form of the request.
 
         - name: request.type
@@ -441,7 +439,7 @@ trans_event:
           description: The request code.
 
         - name: response.message
-          type: string
+          type: keyword
           description: A human readable form of the response.
 
         - name: response.type
@@ -653,7 +651,7 @@ trans_event:
           example: 404
 
         - name: reply-text
-          type: string
+          type: keyword
           description: >
             Text explaining the error.
 
@@ -668,12 +666,12 @@ trans_event:
             Failing method ID.
 
         - name: exchange
-          type: string
+          type: keyword
           description: >
             Name of the exchange.
 
         - name: exchange-type
-          type: string
+          type: keyword
           description: >
             Exchange type.
           example: fanout
@@ -750,7 +748,7 @@ trans_event:
             Delete only if empty.
 
         - name: queue
-          type: string
+          type: keyword
           description: >
             The queue name identifies the queue within the vhost.
 
@@ -781,13 +779,13 @@ trans_event:
             Request immediate delivery.
 
         - name: content-type
-          type: string
+          type: keyword
           description: >
             MIME content type.
           example: text/plain
 
         - name: content-encoding
-          type: string
+          type: keyword
           description: >
             MIME content encoding.
 
@@ -806,42 +804,42 @@ trans_event:
             Message priority, 0 to 9.
 
         - name: correlation-id
-          type: string
+          type: keyword
           description: >
             Application correlation identifier.
 
         - name: reply-to
-          type: string
+          type: keyword
           description: >
             Address to reply to.
 
         - name: expiration
-          type: string
+          type: keyword
           description: >
             Message expiration specification.
 
         - name: message-id
-          type: string
+          type: keyword
           description: >
             Application message identifier.
 
         - name: timestamp
-          type: string
+          type: keyword
           description: >
             Message timestamp.
 
         - name: type
-          type: string
+          type: keyword
           description: >
             Message type name.
 
         - name: user-id
-          type: string
+          type: keyword
           description: >
             Creating user id.
 
         - name: app-id
-          type: string
+          type: keyword
           description: >
             Creating application id.
 
@@ -883,19 +881,19 @@ trans_event:
       description: Memcached-specific event fields
       fields:
         - name: protocol_type
-          type: string
+          type: keyword
           description: >
             The memcache protocol implementation. The value can be "binary"
             for binary-based, "text" for text-based, or "unknown" for an unknown
             memcache protocol type.
 
         - name: request.line
-          type: string
+          type: keyword
           description: >
             The raw command line for unknown commands ONLY.
 
         - name: request.command
-          type: string
+          type: keyword
           description: >
             The memcache command being requested in the memcache text protocol.
             For example "set" or "get".
@@ -903,20 +901,20 @@ trans_event:
             commands.
 
         - name: response.command
-          type: string
+          type: keyword
           description: >
             Either the text based protocol response message type
             or the name of the originating request if binary protocol is used.
 
         - name: request.type
-          type: string
+          type: keyword
           description: >
             The memcache command classification. This value can be "UNKNOWN", "Load",
             "Store", "Delete", "Counter", "Info", "SlabCtrl", "LRUCrawler",
             "Stats", "Success", "Fail", or "Auth".
 
         - name: response.type
-          type: string
+          type: keyword
           description: >
             The memcache command classification. This value can be "UNKNOWN", "Load",
             "Store", "Delete", "Counter", "Info", "SlabCtrl", "LRUCrawler",
@@ -926,17 +924,17 @@ trans_event:
             `memcache.response.status` for binary protocol).
 
         - name: response.error_msg
-          type: string
+          type: keyword
           description: >
             The optional error message in the memcache response (text based protocol only).
 
         - name: request.opcode
-          type: string
+          type: keyword
           description: >
             The binary protocol message opcode name.
 
         - name: response.opcode
-          type: string
+          type: keyword
           description: >
             The binary protocol message opcode name.
 
@@ -968,7 +966,7 @@ trans_event:
             The vbucket index sent in the binary message.
 
         - name: response.status
-          type: string
+          type: keyword
           description: >
             The textual representation of the response error code
             (binary protocol only).
@@ -1036,7 +1034,7 @@ trans_event:
             The value of the memcache "verbosity" command.
 
         - name: request.raw_args
-          type: string
+          type: keyword
           description: >
             The text protocol raw arguments for the "stats ..." and "lru crawl ..." commands.
 
@@ -1051,7 +1049,7 @@ trans_event:
             The destination class id in 'slab reassign' command.
 
         - name: request.automove
-          type: string
+          type: keyword
           description: >
               The automove mode in the 'slab automove' command expressed as a string.
               This value can be "standby"(=0), "slow"(=1), "aggressive"(=2), or the raw value if
@@ -1113,7 +1111,7 @@ trans_event:
             fields "name" and "value".
 
         - name: response.version
-          type: string
+          type: keyword
           description: >
             The returned memcache version string.
 
@@ -1295,14 +1293,14 @@ raw:
   description: These fields contain the raw transaction data.
   fields:
     - name: request
-      index: analyzed
+      type: text
       description: >
         For text protocols, this is the request as seen on the wire
         (application layer only). For binary protocols this is our
         representation of the request.
 
     - name: response
-      index: analyzed
+      type: text
       description: >
         For text protocols, this is the response as seen on the wire
         (application layer only). For binary protocols this is our

--- a/packetbeat/etc/packetbeat.template.json
+++ b/packetbeat/etc/packetbeat.template.json
@@ -2,10 +2,7 @@
   "mappings": {
     "_default_": {
       "_all": {
-        "enabled": true,
-        "norms": {
-          "enabled": false
-        }
+        "norms": false
       },
       "dynamic_templates": [
         {
@@ -13,10 +10,10 @@
             "mapping": {
               "doc_values": true,
               "ignore_above": 1024,
-              "index": "not_analyzed",
-              "type": "{dynamic_type}"
+              "index": true,
+              "type": "keyword"
             },
-            "match": "*"
+            "match_mapping_type": "string"
           }
         }
       ],
@@ -55,30 +52,20 @@
           "type": "geo_point"
         },
         "params": {
-          "index": "analyzed",
-          "norms": {
-            "enabled": false
-          },
-          "type": "string"
+          "norms": false,
+          "type": "text"
         },
         "query": {
-          "doc_values": true,
-          "index": "not_analyzed",
-          "type": "string"
+          "ignore_above": 0,
+          "type": "keyword"
         },
         "request": {
-          "index": "analyzed",
-          "norms": {
-            "enabled": false
-          },
-          "type": "string"
+          "norms": false,
+          "type": "text"
         },
         "response": {
-          "index": "analyzed",
-          "norms": {
-            "enabled": false
-          },
-          "type": "string"
+          "norms": false,
+          "type": "text"
         },
         "start_time": {
           "type": "date"

--- a/topbeat/etc/fields.yml
+++ b/topbeat/etc/fields.yml
@@ -1,9 +1,9 @@
 version: 1.0
 
 defaults:
-  type: string
+  type: keyword
   required: false
-  index: not_analyzed
+  index: true
   doc_values: true
   ignore_above: 1024
 
@@ -262,12 +262,12 @@ process:
         pid, and ppid.
       fields:
         - name: name
-          type: string
+          type: keyword
           description: >
             The process name.
 
         - name: state
-          type: string
+          type: keyword
           description: >
             The process state. For example: "running"
 
@@ -282,13 +282,13 @@ process:
             The process parent pid.
 
         - name: cmdline
-          type: string
+          type: keyword
           description: >
             The full command-line used to start the process, including the
             arguments separated by space.
 
         - name: username
-          type: string
+          type: keyword
           description: >
             The username of the user that created the process. If the username
             can not be determined then the the field will contain the user's
@@ -322,7 +322,7 @@ process:
                 The total CPU time spent by the process.
 
             - name: start_time
-              type: string
+              type: keyword
               description: >
                 The time when the process was started. Example: "17:45".
 
@@ -369,12 +369,12 @@ filesystem:
             The available disk space in bytes.
 
         - name: device_name
-          type: string
+          type: keyword
           description: >
             The disk name. For example: `/dev/disk1`
 
         - name: mount_point
-          type: string
+          type: keyword
           description: >
             The mounting point. For example: `/`
 

--- a/topbeat/etc/topbeat.template.json
+++ b/topbeat/etc/topbeat.template.json
@@ -2,10 +2,7 @@
   "mappings": {
     "_default_": {
       "_all": {
-        "enabled": true,
-        "norms": {
-          "enabled": false
-        }
+        "norms": false
       },
       "dynamic_templates": [
         {
@@ -13,10 +10,10 @@
             "mapping": {
               "doc_values": true,
               "ignore_above": 1024,
-              "index": "not_analyzed",
-              "type": "{dynamic_type}"
+              "index": true,
+              "type": "keyword"
             },
-            "match": "*"
+            "match_mapping_type": "string"
           }
         }
       ],
@@ -27,11 +24,9 @@
         "cpu": {
           "properties": {
             "system_p": {
-              "doc_values": "true",
               "type": "float"
             },
             "user_p": {
-              "doc_values": "true",
               "type": "float"
             }
           }
@@ -41,11 +36,9 @@
             "cpuX": {
               "properties": {
                 "system_p": {
-                  "doc_values": "true",
                   "type": "float"
                 },
                 "user_p": {
-                  "doc_values": "true",
                   "type": "float"
                 }
               }
@@ -55,7 +48,6 @@
         "fs": {
           "properties": {
             "used_p": {
-              "doc_values": "true",
               "type": "float"
             }
           }
@@ -63,15 +55,12 @@
         "load": {
           "properties": {
             "load1": {
-              "doc_values": "true",
               "type": "float"
             },
             "load15": {
-              "doc_values": "true",
               "type": "float"
             },
             "load5": {
-              "doc_values": "true",
               "type": "float"
             }
           }
@@ -79,11 +68,9 @@
         "mem": {
           "properties": {
             "actual_used_p": {
-              "doc_values": "true",
               "type": "float"
             },
             "used_p": {
-              "doc_values": "true",
               "type": "float"
             }
           }
@@ -93,7 +80,6 @@
             "cpu": {
               "properties": {
                 "total_p": {
-                  "doc_values": "true",
                   "type": "float"
                 }
               }
@@ -101,7 +87,6 @@
             "mem": {
               "properties": {
                 "rss_p": {
-                  "doc_values": "true",
                   "type": "float"
                 }
               }
@@ -111,7 +96,6 @@
         "swap": {
           "properties": {
             "used_p": {
-              "doc_values": "true",
               "type": "float"
             }
           }

--- a/winlogbeat/etc/fields.yml
+++ b/winlogbeat/etc/fields.yml
@@ -1,9 +1,9 @@
 version: 1.0
 
 defaults:
-  type: string
+  type: keyword
   required: false
-  index: not_analyzed
+  index: true
   doc_values: true
   ignore_above: 1024
 
@@ -57,7 +57,7 @@ eventlog:
     Contains data from a Windows event log record.
   fields:
     - name: activity_id
-      type: string
+      type: keyword
       required: false
       description: >
         A globally unique identifier that identifies the current activity. The
@@ -65,7 +65,7 @@ eventlog:
         activity.
 
     - name: computer_name
-      type: string
+      type: keyword
       required: true
       description: >
         The name of the computer that generated the record. When using Windows
@@ -85,20 +85,20 @@ eventlog:
         The event identifier. The value is specific to the source of the event.
 
     - name: keywords
-      type: string[]
+      type: keyword[]
       required: false
       description: >
         The keywords are used to classify an event.
 
     - name: log_name
-      type: string
+      type: keyword
       required: true
       description: >
         The name of the event log from which this record was read. This value is
         one of the names from the `event_logs` collection in the configuration.
 
     - name: level
-      type: string
+      type: keyword
       required: false
       description: >
         The level of the event. There are five levels of events that can be
@@ -106,23 +106,20 @@ eventlog:
         Failure.
 
     - name: message
-      type: string
-      index: analyzed
-      doc_values: true
-      ignore_above: 0
+      type: text
       required: false
       description: >
         The message from the event log record.
 
     - name: message_error
-      type: string
+      type: keyword
       required: false
       description: >
         The error that occurred while reading and formatting the message from
         the log.
 
     - name: record_number
-      type: string
+      type: keyword
       required: true
       description: >
         The record number of the event log record. The first record written
@@ -132,7 +129,7 @@ eventlog:
         the next record number will be 0.
 
     - name: related_activity_id
-      type: string
+      type: keyword
       required: false
       description: >
         A globally unique identifier that identifies the activity to which
@@ -140,7 +137,7 @@ eventlog:
         identifier as their `activity_id` identifier.
 
     - name: opcode
-      type: string
+      type: keyword
       required: false
       description: >
         The opcode defined in the event. Task and opcode are typically used to
@@ -148,7 +145,7 @@ eventlog:
         logged.
 
     - name: provider_guid
-      type: string
+      type: keyword
       required: false
       description: >
         A globally unique identifier that identifies the provider that logged
@@ -161,14 +158,14 @@ eventlog:
         The process_id identifies the process that generated the event.
 
     - name: source_name
-      type: string
+      type: keyword
       required: true
       description: >
         The source of the event log record (the application or service that
         logged the record).
 
     - name: task
-      type: string
+      type: keyword
       required: false
       description: >
         The task defined in the event. Task and opcode are typically used to
@@ -190,7 +187,7 @@ eventlog:
         `event_data`.
 
     - name: user.identifier
-      type: string
+      type: keyword
       required: false
       example: S-1-5-21-3541430928-2051711210-1391384369-1001
       description: >
@@ -204,19 +201,19 @@ eventlog:
         clues as to what the problem may be.
 
     - name: user.name
-      type: string
+      type: keyword
       required: false
       description: >
         The name of the account associated with this event.
 
     - name: user.domain
-      type: string
+      type: keyword
       required: false
       description: >
         The domain that the account associated with this event is a member of.
 
     - name: user.type
-      type: string
+      type: keyword
       required: false
       description: >
         The type of account associated with this event.

--- a/winlogbeat/etc/winlogbeat.template.json
+++ b/winlogbeat/etc/winlogbeat.template.json
@@ -2,10 +2,7 @@
   "mappings": {
     "_default_": {
       "_all": {
-        "enabled": true,
-        "norms": {
-          "enabled": false
-        }
+        "norms": false
       },
       "dynamic_templates": [
         {
@@ -13,10 +10,10 @@
             "mapping": {
               "doc_values": true,
               "ignore_above": 1024,
-              "index": "not_analyzed",
-              "type": "{dynamic_type}"
+              "index": true,
+              "type": "keyword"
             },
-            "match": "*"
+            "match_mapping_type": "string"
           }
         }
       ],
@@ -25,22 +22,16 @@
           "type": "date"
         },
         "event_id": {
-          "doc_values": "true",
           "type": "long"
         },
         "message": {
-          "index": "analyzed",
-          "norms": {
-            "enabled": false
-          },
-          "type": "string"
+          "norms": false,
+          "type": "text"
         },
         "process_id": {
-          "doc_values": "true",
           "type": "long"
         },
         "thread_id": {
-          "doc_values": "true",
           "type": "long"
         }
       }


### PR DESCRIPTION
Elasticsearch 5.0 has refactored mappings as described in
elastic/elasticsearch#12394. Most notably the string field has been replaced
by the `text` and `keyword` fields.