### PR TITLE
Fix warning message print

### DIFF
--- a/libbeat/outputs/elasticsearch/client.go
+++ b/libbeat/outputs/elasticsearch/client.go
@@ -13,7 +13,7 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/dustin/go-humanize"
+	humanize "github.com/dustin/go-humanize"
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
@@ -264,11 +264,11 @@ func bulkCollectPublishFails(
 
 		if status < 500 && status != 429 {
 			// hard failure, don't collect
-			logp.Warn("Can not index event (status=%v): %v", status, msg)
+			logp.Warn("Can not index event (status=%v): %s", status, msg)
 			continue
 		}
 
-		logp.Info("Bulk item insert failed (i=%v, status=%v): %v", i, status, msg)
+		logp.Info("Bulk item insert failed (i=%v, status=%v): %s", i, status, msg)
 		failed = append(failed, events[i])
 	}
 


### PR DESCRIPTION
It was printing with `%v` a `[]byte`, which resulted in showing the
bytes representation to the user, instead of the actual message.

The change in the humanize import is to convince `goimports` to
not mess with the line.