### PR TITLE
Fix go vet

### DIFF
--- a/libbeat/publisher/output.go
+++ b/libbeat/publisher/output.go
@@ -72,7 +72,7 @@ func (o *outputWorker) onMessage(m message) {
 
 func (o *outputWorker) onEvent(ctx *Context, event common.MapStr) {
 	debug("output worker: publish single event")
-	o.out.PublishEvent(ctx.Signal, outputs.Options{ctx.Guaranteed}, event)
+	o.out.PublishEvent(ctx.Signal, outputs.Options{Guaranteed: ctx.Guaranteed}, event)
 }
 
 func (o *outputWorker) onBulk(ctx *Context, events []common.MapStr) {
@@ -106,7 +106,7 @@ func (o *outputWorker) sendBulk(
 ) {
 	debug("output worker: publish %v events", len(events))
 
-	opts := outputs.Options{ctx.Guaranteed}
+	opts := outputs.Options{Guaranteed: ctx.Guaranteed}
 	err := o.out.BulkPublish(ctx.Signal, opts, events)
 	if err != nil {
 		logp.Info("Error bulk publishing events: %s", err)


### PR DESCRIPTION
It seems that composite literal with unkeyed fields are not A-OK.

This is what I was getting;

```
make check
make -C libbeat check || exit 1; make -C packetbeat check || exit 1; make -C topbeat check || exit 1; make -C filebeat check || exit 1; make -C winlogbeat check || exit 1;
go vet ./...
publisher/output.go:55: github.com/elastic/beats/libbeat/outputs.Options composite literal uses unkeyed fields
publisher/output.go:89: github.com/elastic/beats/libbeat/outputs.Options composite literal uses unkeyed fields
exit status 1
make[1]: *** [check] Error 1
make: *** [check] Error 1
```