### PR TITLE
Test beats templates with elasticsearch

### DIFF
--- a/libbeat/outputs/elasticsearch/client_integration_test.go
+++ b/libbeat/outputs/elasticsearch/client_integration_test.go
@@ -85,3 +85,47 @@ func TestLoadInvalidTemplate(t *testing.T) {
 	// Make sure template was not loaded
 	assert.False(t, client.CheckTemplate(templateName))
 }
+
+// Tests loading the templates for each beat
+func TestLoadBeatsTemplate(t *testing.T) {
+
+	beats := []string{
+		"topbeat",
+		"filebeat",
+		"packetbeat",
+		"metricbeat",
+		"winlogbeat",
+	}
+
+	for _, beat := range beats {
+		// Load template
+		absPath, err := filepath.Abs("../../../" + beat + "/etc/")
+		assert.NotNil(t, absPath)
+		assert.Nil(t, err)
+
+		templatePath := absPath + "/" + beat + ".template.json"
+		content, err := ioutil.ReadFile(templatePath)
+		reader := bytes.NewReader(content)
+		assert.Nil(t, err)
+
+		// Setup ES
+		client := GetTestingElasticsearch()
+		err = client.Connect(5 * time.Second)
+		assert.Nil(t, err)
+
+		templateName := beat
+
+		// Load template
+		err = client.LoadTemplate(templateName, reader)
+		assert.Nil(t, err)
+
+		// Make sure template was loaded
+		assert.True(t, client.CheckTemplate(templateName))
+
+		// Delete template again to clean up
+		client.request("DELETE", "/_template/"+templateName, nil, nil)
+
+		// Make sure it was removed
+		assert.False(t, client.CheckTemplate(templateName))
+	}
+}


### PR DESCRIPTION
Closes #1222

In a second step, a good way should be found to also insert valid documents from each beat into es and make sure no errors are returned. For this, each beat should generate the standard json documents. These could be used for the docs and for these tests here.