### PR TITLE
Fix invalid event_id on Windows XP and Windows 2003

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -36,6 +36,7 @@ https://github.com/elastic/beats/compare/v1.1.2...master[Check the HEAD diff]
 *Filebeat*
 
 *Winlogbeat*
+- Fix invalid `event_id` on Windows XP and Windows 2003 {pull}1227[1227]
 
 
 ==== Added

--- a/winlogbeat/eventlog/eventlogging_test.go
+++ b/winlogbeat/eventlog/eventlogging_test.go
@@ -341,10 +341,9 @@ func TestReadMultiParameterMsg(t *testing.T) {
 	// <EventID Qualifiers="16384">7036</EventID>
 	// 1073748860 = 16384 << 16 + 7036
 	// https://msdn.microsoft.com/en-us/library/windows/desktop/aa385206(v=vs.85).aspx
-	var eventID uint32 = 1073748860
 	template := "The %s service entered the %s state."
 	msgs := []string{"Windows Update", "running"}
-	err = log.Report(elog.Info, eventID, msgs)
+	err = log.Report(elog.Info, uint32(1073748860), msgs)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -374,7 +373,7 @@ func TestReadMultiParameterMsg(t *testing.T) {
 	if len(records) != 1 {
 		t.FailNow()
 	}
-	assert.Equal(t, eventID, records[0].EventID)
+	assert.Equal(t, uint32(7036), records[0].EventID)
 	assert.Equal(t, fmt.Sprintf(template, msgs[0], msgs[1]),
 		strings.TrimRight(records[0].Message, "\r\n"))
 }
@@ -447,7 +446,7 @@ func TestReadNoParameterMsg(t *testing.T) {
 	if len(records) != 1 {
 		t.FailNow()
 	}
-	assert.Equal(t, eventID, records[0].EventID)
+	assert.Equal(t, uint32(6006), records[0].EventID)
 	assert.Equal(t, template,
 		strings.TrimRight(records[0].Message, "\r\n"))
 }

--- a/winlogbeat/sys/eventlogging/eventlogging_windows.go
+++ b/winlogbeat/sys/eventlogging/eventlogging_windows.go
@@ -16,6 +16,14 @@ import (
 	"golang.org/x/sys/windows/registry"
 )
 
+// The value of EventID element contains the low-order 16 bits of the event
+// identifier and the Qualifier attribute contains the high-order 16 bits of the
+// event identifier.
+const (
+	eventIDLowerMask uint32 = 0xFFFF
+	eventIDUpperMask uint32 = 0xFFFF0000
+)
+
 // IsAvailable returns true if the Event Logging API is supported by this
 // operating system. If not supported then false is returned with the
 // accompanying error.
@@ -104,7 +112,7 @@ func RenderEvents(
 			RecordID:      record.recordNumber,
 			TimeGenerated: unixTime(record.timeGenerated),
 			TimeWritten:   unixTime(record.timeWritten),
-			EventID:       record.eventID,
+			EventID:       record.eventID & eventIDLowerMask,
 			Level:         EventType(record.eventType).String(),
 			SourceName:    record.sourceName,
 			Computer:      record.computerName,


### PR DESCRIPTION
Backport a change that fixes the event ID on earlier versions of Windows.

https://discuss.elastic.co/t/winlogbeat-reports-wrong-event-id-on-windows-server-2003/44982/3