### PR TITLE
Fix ES and Kafka Integration Test Panics

### DIFF
--- a/libbeat/outputs/elasticsearch/bulkapi_integration_test.go
+++ b/libbeat/outputs/elasticsearch/bulkapi_integration_test.go
@@ -41,7 +41,7 @@ func TestBulk(t *testing.T) {
 	}
 	_, err := client.Bulk(index, "type1", params, body)
 	if err != nil {
-		t.Errorf("Bulk() returned error: %s", err)
+		t.Fatalf("Bulk() returned error: %s", err)
 	}
 
 	params = map[string]string{
@@ -49,7 +49,7 @@ func TestBulk(t *testing.T) {
 	}
 	_, result, err := client.SearchURI(index, "type1", params)
 	if err != nil {
-		t.Errorf("SearchUri() returns an error: %s", err)
+		t.Fatalf("SearchUri() returns an error: %s", err)
 	}
 	if result.Hits.Total != 1 {
 		t.Errorf("Wrong number of search results: %d", result.Hits.Total)
@@ -76,7 +76,7 @@ func TestEmptyBulk(t *testing.T) {
 	}
 	resp, err := client.Bulk(index, "type1", params, body)
 	if err != nil {
-		t.Errorf("Bulk() returned error: %s", err)
+		t.Fatalf("Bulk() returned error: %s", err)
 	}
 	if resp != nil {
 		t.Errorf("Unexpected response: %s", resp)
@@ -143,8 +143,7 @@ func TestBulkMoreOperations(t *testing.T) {
 	}
 	resp, err := client.Bulk(index, "type1", params, body)
 	if err != nil {
-		t.Errorf("Bulk() returned error: %s [%s]", err, resp)
-		return
+		t.Fatalf("Bulk() returned error: %s [%s]", err, resp)
 	}
 
 	params = map[string]string{
@@ -152,7 +151,7 @@ func TestBulkMoreOperations(t *testing.T) {
 	}
 	_, result, err := client.SearchURI(index, "type1", params)
 	if err != nil {
-		t.Errorf("SearchUri() returns an error: %s", err)
+		t.Fatalf("SearchUri() returns an error: %s", err)
 	}
 	if result.Hits.Total != 1 {
 		t.Errorf("Wrong number of search results: %d", result.Hits.Total)
@@ -163,7 +162,7 @@ func TestBulkMoreOperations(t *testing.T) {
 	}
 	_, result, err = client.SearchURI(index, "type1", params)
 	if err != nil {
-		t.Errorf("SearchUri() returns an error: %s", err)
+		t.Fatalf("SearchUri() returns an error: %s", err)
 	}
 	if result.Hits.Total != 1 {
 		t.Errorf("Wrong number of search results: %d", result.Hits.Total)


### PR DESCRIPTION
- Change tests to use `testing.Fatalf` instead of `testing.Errorf` when an error occurs that cannot be recovered.
- Added a unique ID to Kafka test topics and messages so that they can be re-run using the same server and to guarantee the message published is the message that is consumed.