### PR TITLE
Rewrite of doc for generic filtering

### DIFF
--- a/filebeat/docs/filebeat-filtering.asciidoc
+++ b/filebeat/docs/filebeat-filtering.asciidoc
@@ -1,0 +1,42 @@
+[[filtering-data]]
+=== Filtering the Exported Data
+
+When your use case requires only a subset of the data exported by Filebeat, you can <<filebeat-filtering-overview,use Filebeat config options to filter the data>>, or you can <<generic-filtering-overview-filebeat,use the generic filtering provided by libbeat>>.
+
+[[filebeat-filtering-overview]]
+==== Filebeat Config Options for Filtering
+
+You can specify configuration options in the `filebeat` section of the config file to define regular expressions that
+match the lines you want to include and/or exclude from the output. The supported options are <<include-lines,`include_lines`>>, <<exclude-lines,`exclude_lines`>>, and <<exclude-files,`exclude_files`>>. 
+
+For example, you can use the `include_lines` option to export any lines that start with "ERR" or "WARN":
+
+[source,yaml]
+-------------------------------------------------------------------------------------
+filebeat:
+  prospectors:
+    - paths:
+        - /var/log/myapp/*.log
+      include_lines: ["^ERR", "^WARN"]
+-------------------------------------------------------------------------------------
+
+The disadvantage of this approach is that you need to implement a configuration option for each filtering criteria that you need.
+
+See <<configuration-filebeat-options,Filebeat configuration options>> for more information about each option.
+
+[[generic-filtering-overview-filebeat]]
+==== Generic Filtering
+
+include::../../libbeat/docs/filtering.asciidoc[]
+
+For example, the following filter configuration exports fewer fields (in this case, `message` and `source`) along
+with the mandatory fields.
+
+[source, yaml]
+-----------------------------------------------------
+filter:
+ - include_fields:
+     fields: ["message", "source"]
+-----------------------------------------------------
+
+See <<configuration-filter,filter configuration options>> for more information.

--- a/filebeat/docs/index.asciidoc
+++ b/filebeat/docs/index.asciidoc
@@ -12,6 +12,8 @@ include::./command-line.asciidoc[]
 
 include::./configuring-howto.asciidoc[]
 
+include::./filebeat-filtering.asciidoc[]
+
 include::../../libbeat/docs/shared-env-vars.asciidoc[]
 
 include::../../libbeat/docs/https.asciidoc[]

--- a/filebeat/docs/reference/configuration/filebeat-options.asciidoc
+++ b/filebeat/docs/reference/configuration/filebeat-options.asciidoc
@@ -58,7 +58,11 @@ The following example configures Filebeat to drop any lines that start with "DBG
 
 [source,yaml]
 -------------------------------------------------------------------------------------
-exclude_lines: ["^DBG"]
+filebeat:
+  prospectors:
+    - paths:
+        - /var/log/myapp/*.log
+      exclude_lines: ["^DBG"]
 -------------------------------------------------------------------------------------
 
 [[include-lines]]
@@ -72,7 +76,11 @@ The following example configures Filebeat to export any lines that start with "E
 
 [source,yaml]
 -------------------------------------------------------------------------------------
-include_lines: ["^ERR", "^WARN"]
+filebeat:
+  prospectors:
+    - paths:
+        - /var/log/myapp/*.log
+      include_lines: ["^ERR", "^WARN"]
 -------------------------------------------------------------------------------------
 
 NOTE: If both `include_lines` and `exclude_lines` are defined, Filebeat executes `include_lines` first and then executes `exclude_lines`. So, for example, to export all Apache log lines except the debugging messages (DBGs), you can use:
@@ -83,6 +91,7 @@ NOTE: If both `include_lines` and `exclude_lines` are defined, Filebeat executes
  exclude_lines: ["^DBG"]
 -------------------------------------------------------------------------------------
 
+[[exclude-files]]
 ===== exclude_files
 
 A list of regular expressions to match the files that you want Filebeat to ignore. By default no files are excluded.
@@ -425,4 +434,6 @@ include::../../../../libbeat/docs/shipperconfig.asciidoc[]
 include::../../../../libbeat/docs/loggingconfig.asciidoc[]
 
 include::../../../../libbeat/docs/runconfig.asciidoc[]
+
+include::../../../../libbeat/docs/filteringconfig.asciidoc[]
 

--- a/libbeat/docs/filtering.asciidoc
+++ b/libbeat/docs/filtering.asciidoc
@@ -1,67 +1,17 @@
-[[filtering-data]]
-== Reduce the exported fields
+//////////////////////////////////////////////////////////////////////////
+//// This content is shared by all Elastic Beats. Make sure you keep the
+//// descriptions here generic enough to work for all Beats that include
+//// this file. When using cross references, make sure that the cross
+//// references resolve correctly for any files that include this one.
+//// Use the appropriate variables defined in the index.asciidoc file to
+//// resolve Beat names: beatname_uc and beatname_lc.
+//// Use the following include to pull this content into a doc file:
+//// include::../../libbeat/docs/filtering.asciidoc[]
+//////////////////////////////////////////////////////////////////////////
 
-With the evolution of the Beats, the number of fields that are exported increases. In most of the use cases, you are
-interested only in a subset of data that are exported by the Beats, so there are two options. 
+Generic filtering is available to all Beats through libbeat. With generic filtering, you can reduce the number of
+fields that are exported by the Beat by defining a list of filter actions that are applied to each event before it's
+sent to the defined output. The filter actions are executed in the order that they are defined in the config file.
 
-One option is to use specific configuration options implemented by each Beat to filter the data. For example, in Filebeat you
-can configure the `include_lines` option to specify via regular expressions what log lines to export. The disadvantage 
-of this approach is that you need to implement a configuration option for each filtering criteria that you need.
-
-The second option is to use a more generic way of filtering that is implemented in libbeat and it's available to all Beats. The generic
-filtering is defined by a list of filtering criteria that are applied in sequence to the event before sending it to the defined output.
-
-
-This section describes how to reduce the exported fields of a Beat by using the generic filtering feature of libbeat.
-The `filter` section contains a list of actions, executed in the defined order. The supported actions are:
-
-* <<include_fields, include_fields>>
-* <<drop_fields, drop_fields>>
-
-There is a list of mandatory fields like `@timestamp` and `type` that cannot be removed as they are required by the
-outputs.
-
-[[include_fields]]
-=== Include fields
-
-The include fields action defines the list of fields to be exported. As field you can also define full nested maps. For
-example, Topbeat can export only the load, memory, swap and the percentage value of the cpu usage in user space with the
-following filter configuration:
-
-[source, yaml]
------------------------------------------------------
-filter:
- - include_fields:
-     fields: ["load, "mem", "swap", "cpu.user_p"]
------------------------------------------------------
-
-By default, all fields are exported and `include_fields` is undefined. 
-
-Note:: In case the include fields is equal with the empty list, then only the mandatory fields are exported.
-
-[[drop_fields]]
-=== Drop fields
-
-The drop fields action defines the list of fields to be dropped. Similar with the <<include_fields>> action, you can
-also define full nested maps as fields. For example, Topbeat can drop all swap information by configuring:
-
-[source, yaml]
------------------------------------------------------
-filter:
- - drop_fields:
-     fields: ["swap"]
------------------------------------------------------
-
-
-An example of using multiple actions might the following where only the CPU load percentages are kept and the CPU ticks
-values are removed:
-
-[source, yaml]
------------------------------------------------------
-filter:
- - include_fields:
-     fields: [“cpu”]
- - drop_fields:
-     fields: [“cpu.user”, “cpu.system”]
------------------------------------------------------
-
+The supported actions are <<include-fields,`include_fields`>> and <<drop-fields,`drop_fields`>>. You set these actions in the `filter` section of
+the {beatname_uc} config file. 

--- a/libbeat/docs/filteringconfig.asciidoc
+++ b/libbeat/docs/filteringconfig.asciidoc
@@ -1,0 +1,67 @@
+//////////////////////////////////////////////////////////////////////////
+//// This content is shared by all Elastic Beats. Make sure you keep the
+//// descriptions here generic enough to work for all Beats that include
+//// this file. When using cross references, make sure that the cross
+//// references resolve correctly for any files that include this one.
+//// Use the appropriate variables defined in the index.asciidoc file to
+//// resolve Beat names: beatname_uc and beatname_lc.
+//// Use the following include to pull this content into a doc file:
+//// include::../../libbeat/docs/filteringconfig.asciidoc[]
+//// Make sure this content appears below a level 2 heading.
+//////////////////////////////////////////////////////////////////////////
+
+[[configuration-filter]]
+=== Filter
+
+You can set options in the `filter` section of the {beatname_uc} config file to reduce the number of fields that are 
+exported by the Beat. See <<exported-fields>> for the full list of possible fields.
+
+The filter actions that you specify are applied to each event before it's sent to the defined output. You can define
+multiple filter actions. The filter actions are executed in the order that they're defined in the config file.
+
+==== Filter Options
+
+You can specify the following options under the `filter` section:
+
+[[include-fields]]
+===== include_fields
+
+The `include_fields` action specifies the list of fields to export. For each field, you can specify a simple field
+name, or a nested map. For example, if you specify `dns.question.name`, the Beat exports only the `name` field
+because it's a simple field. If you specify `dns.question`, the Beat exports all the fields nested under
+`dns.question`. 
+
+Example configuration:
+
+[source, yaml]
+-----------------------------------------------------
+filter:
+ - include_fields:
+     fields: ["field_A", "field_B", "field_C"]
+-----------------------------------------------------
+
+If `include_fields` is not specified, all fields are exported by default. 
+
+See <<filtering-data>> for specific {beatname_uc} examples.
+
+NOTE: If you specify an empty list for `include_fields`, only the required fields, `@timestamp` and `type`, are
+exported. 
+
+[[drop-fields]]
+===== drop_fields
+
+The `drop_fields` action defines a list of fields to drop. For each field, you can specify a simple field name, or a
+nested map. For example, if you specify `dns.question.name`, the Beat drops only the `name` field because it's a
+simple field. If you specify `dns.question`, the Beat drops all the fields nested under `dns.question`. Some fields,
+such as `@timestamp` and `type`, are mandatory and cannot be removed because they are required by the outputs. 
+
+Example configuration:
+
+[source, yaml]
+-----------------------------------------------------
+filter:
+ - drop_fields:
+     fields: ["field_A"]
+-----------------------------------------------------
+
+See <<filtering-data>> for specific {beatname_uc} examples.

--- a/packetbeat/docs/index.asciidoc
+++ b/packetbeat/docs/index.asciidoc
@@ -12,6 +12,8 @@ include::./command-line.asciidoc[]
 
 include::./configuring-howto.asciidoc[]
 
+include::./packetbeat-filtering.asciidoc[]
+
 include::../../libbeat/docs/shared-env-vars.asciidoc[]
 
 include::../../libbeat/docs/https.asciidoc[]

--- a/packetbeat/docs/packetbeat-filtering.asciidoc
+++ b/packetbeat/docs/packetbeat-filtering.asciidoc
@@ -1,0 +1,44 @@
+[[filtering-data]]
+=== Filtering the Exported Data
+
+include::../../libbeat/docs/filtering.asciidoc[]
+
+For example, the following filter configuration includes a subset of the Packetbeat DNS fields so that only the
+requests and their response codes are reported:
+
+[source, yaml]
+-----------------------------------------------------
+filter:
+  - include_fields:
+      fields: 
+        - bytes_in
+        - bytes_out
+        - ip
+        - client_ip
+        - dns.question.name
+        - dns.question.etld_plus_one
+        - dns.response_code
+-----------------------------------------------------
+
+The filtered event would look something like this:
+
+[source,shell]
+-----------------------------------------------------
+{
+  "@timestamp": "2016-03-28T14:48:21.732Z",
+  "bytes_in": 32,
+  "bytes_out": 48,
+  "client_ip": "192.168.10.111",
+  "dns": {
+    "question": {
+      "etld_plus_one": "google.com.",
+      "name": "www.google.com."
+    },
+    "response_code": "NOERROR"
+  },
+  "ip": "8.8.8.8",
+  "type": "dns"
+}
+-----------------------------------------------------
+
+See <<configuration-filter,filter configuration options>> for more information.

--- a/packetbeat/docs/reference/configuration.asciidoc
+++ b/packetbeat/docs/reference/configuration.asciidoc
@@ -21,6 +21,7 @@ configuration settings, you need to restart Packetbeat to pick up the changes.
 * <<configuration-shipper>>
 * <<configuration-logging>>
 * <<configuration-run-options>>
+* <<configuration-filter>>
 
 NOTE: Packetbeat maintains a real-time topology map of all the servers in your network.
 See <<maintaining-topology>> for more details.

--- a/packetbeat/docs/reference/configuration/packetbeat-options.asciidoc
+++ b/packetbeat/docs/reference/configuration/packetbeat-options.asciidoc
@@ -704,3 +704,5 @@ include::../../../../libbeat/docs/loggingconfig.asciidoc[]
 
 include::../../../../libbeat/docs/runconfig.asciidoc[]
 
+include::../../../../libbeat/docs/filteringconfig.asciidoc[]
+

--- a/topbeat/docs/index.asciidoc
+++ b/topbeat/docs/index.asciidoc
@@ -12,6 +12,8 @@ include::./command-line.asciidoc[]
 
 include::./configuring-howto.asciidoc[]
 
+include::./topbeat-filtering.asciidoc[]
+
 include::../../libbeat/docs/shared-env-vars.asciidoc[]
 
 include::../../libbeat/docs/https.asciidoc[]

--- a/topbeat/docs/reference/configuration/topbeat-options.asciidoc
+++ b/topbeat/docs/reference/configuration/topbeat-options.asciidoc
@@ -39,6 +39,7 @@ You can specify the following options in the `topbeat` section:
 
 How often, in seconds, to read system-wide and per-process statistics from your servers. The default is 10.
 
+[[procs-option]]
 ===== procs
 
 A list of regular expressions to match all the processes that need to be monitored. By
@@ -87,4 +88,7 @@ include::../../../../libbeat/docs/shipperconfig.asciidoc[]
 include::../../../../libbeat/docs/loggingconfig.asciidoc[]
 
 include::../../../../libbeat/docs/runconfig.asciidoc[]
+
+include::../../../../libbeat/docs/filteringconfig.asciidoc[]
+
 

--- a/topbeat/docs/topbeat-filtering.asciidoc
+++ b/topbeat/docs/topbeat-filtering.asciidoc
@@ -1,0 +1,55 @@
+[[filtering-data]]
+=== Filtering the Exported Data
+
+When your use case requires only a subset of the data exported by Topbeat, you can <<topbeat-filtering-overview,use Topbeat config options to filter the data>>, or you can <<generic-filtering-overview-topbeat,use the generic filtering provided by libbeat>>.
+
+[[topbeat-filtering-overview]]
+==== Topbeat Config Options for Filtering
+
+You can specify the <<procs-option,`procs`>> option in the `input` section of the config file to specify a list of
+regular expressions to match the processes that you want to monitor. 
+
+By default, all processes are monitored:
+
+[source,yaml]
+-------------------------------------------------------------------------------------
+procs: [".*"]
+-------------------------------------------------------------------------------------
+
+[[generic-filtering-overview-topbeat]]
+==== Generic Filtering
+
+include::../../libbeat/docs/filtering.asciidoc[]
+
+
+For example, the following filter configuration reduces the exported fields to include only `load`, `memory`,
+`swap`, and `cpu.user_p`, the percentage of CPU time spent in user space:
+
+[source, yaml]
+-----------------------------------------------------
+filter:
+ - include_fields:
+     fields: ["load", "mem", "swap", "cpu.user_p"]
+-----------------------------------------------------
+
+The following filter configuration drops all the swap information:
+
+[source, yaml]
+-----------------------------------------------------
+filter:
+ - drop_fields:
+     fields: ["swap"]
+-----------------------------------------------------
+
+The following filter configuration uses multiple actions to keep the fields that contain CPU load percentages, but remove the fields that contain CPU ticks values:
+
+[source, yaml]
+-----------------------------------------------------
+filter:
+ - include_fields:
+     fields: ["cpu"]
+ - drop_fields:
+     fields: ["cpu.user", "cpu.system"]
+-----------------------------------------------------
+
+See <<configuration-filter,filter configuration options>> for more information.

--- a/winlogbeat/docs/index.asciidoc
+++ b/winlogbeat/docs/index.asciidoc
@@ -12,6 +12,8 @@ include::./command-line.asciidoc[]
 
 include::./configuring-howto.asciidoc[]
 
+include::./winlogbeat-filtering.asciidoc[]
+
 include::../../libbeat/docs/shared-env-vars.asciidoc[]
 
 include::../../libbeat/docs/https.asciidoc[]

--- a/winlogbeat/docs/reference/configuration/winlogbeat-options.asciidoc
+++ b/winlogbeat/docs/reference/configuration/winlogbeat-options.asciidoc
@@ -310,3 +310,5 @@ include::../../../../libbeat/docs/shipperconfig.asciidoc[]
 include::../../../../libbeat/docs/loggingconfig.asciidoc[]
 
 include::../../../../libbeat/docs/runconfig.asciidoc[]
+
+include::../../../../libbeat/docs/filteringconfig.asciidoc[]

--- a/winlogbeat/docs/winlogbeat-filtering.asciidoc
+++ b/winlogbeat/docs/winlogbeat-filtering.asciidoc
@@ -1,0 +1,15 @@
+[[filtering-data]]
+=== Filtering the Exported Data
+
+include::../../libbeat/docs/filtering.asciidoc[]
+
+For example, the following filter configuration drops a few fields that are rarely used (`provider_guid`, `process_id`, `thread_id`, and `version`) and one nested field, `event_data.ErrorSourceTable`:
+
+[source, yaml]
+-----------------------------------------------------
+filter:
+  - drop_fields:
+      fields: [provider_guid, process_id, thread_id, version, event_data.ErrorSourceTable]
+-----------------------------------------------------
+
+See <<configuration-filter,filter configuration options>> for more information.


### PR DESCRIPTION
@monicasarbu Here's a rewrite of the content that you submitted in #1199 (with all the changes that I suggested during my review). So that you can get a better sense of how the content is structured, I've uploaded the built doc (just Topbeat since the structure is the same for all Beats): the topic about the different ways to configure filtering is [here](https://topbeatfilteringreview.firebaseapp.com/filtering-data.html) and the reference topic about the config options is [here](url).

A couple of outstanding issues:

* I kept the examples in the reference doc generic since the descriptions are shared across the docs for all Beats. 
* I want to add specific examples for Packetbeat, Winlogbeat, and Filebeat (similar to what we do for Topbeat). Can you help me with that? 
* I wasn't sure where to put the filter section in the ref docs so I just tacked it on to the end for now.
