### PR TITLE
Build a 32-bit and 64-bit binary for all Beats on Windows

### DIFF
--- a/dev-tools/packer/archs/386.yml
+++ b/dev-tools/packer/archs/386.yml
@@ -2,3 +2,4 @@ arch: '386'
 deb_arch: i386
 rpm_arch: i686
 bin_arch: i686
+win_arch: 32

--- a/dev-tools/packer/archs/amd64.yml
+++ b/dev-tools/packer/archs/amd64.yml
@@ -2,3 +2,4 @@ arch: amd64
 deb_arch: amd64
 rpm_arch: x86_64
 bin_arch: x86_64
+win_arch: 64

--- a/dev-tools/packer/platforms/windows/run.sh.j2
+++ b/dev-tools/packer/platforms/windows/run.sh.j2
@@ -5,7 +5,7 @@ set -e
 cd /build
 
 mkdir /{{.beat_name}}-{{.version}}-windows
-cp {{.beat_name}}-windows-386.exe /{{.beat_name}}-{{.version}}-windows/{{.beat_name}}.exe
+cp {{.beat_name}}-windows-{{.arch}}.exe /{{.beat_name}}-{{.version}}-windows/{{.beat_name}}.exe
 unix2dos {{.beat_name}}-win.yml
 cp {{.beat_name}}-win.yml /{{.beat_name}}-{{.version}}-windows/{{.beat_name}}.yml
 cp {{.beat_name}}.template.json /{{.beat_name}}-{{.version}}-windows/
@@ -13,9 +13,9 @@ cp install-service-{{.beat_name}}.ps1 /{{.beat_name}}-{{.version}}-windows/
 cp uninstall-service-{{.beat_name}}.ps1 /{{.beat_name}}-{{.version}}-windows/
 
 mkdir -p upload/{{.beat_name}}
-zip -r upload/{{.beat_name}}/{{.beat_name}}-{{.version}}-windows.zip /{{.beat_name}}-{{.version}}-windows
+zip -r upload/{{.beat_name}}/{{.beat_name}}-{{.version}}-windows-{{.win_arch}}.zip /{{.beat_name}}-{{.version}}-windows
 echo "Created upload/{{.beat_name}}/{{.beat_name}}-{{.version}}-windows.zip"
 
 cd upload/{{.beat_name}}
-sha1sum {{.beat_name}}-{{.version}}-windows.zip > {{.beat_name}}-{{.version}}-windows.zip.sha1.txt
-echo "Created upload/{{.beat_name}}/{{.beat_name}}-{{.version}}-windows.zip.sha1.txt"
+sha1sum {{.beat_name}}-{{.version}}-windows-{{.win_arch}}.zip > {{.beat_name}}-{{.version}}-windows-{{.win_arch}}.zip.sha1.txt
+echo "Created upload/{{.beat_name}}/{{.beat_name}}-{{.version}}-windows-{{.win_arch}}.zip.sha1.txt"

--- a/dev-tools/packer/scripts/Makefile
+++ b/dev-tools/packer/scripts/Makefile
@@ -17,6 +17,7 @@ packer_absdir=$(shell dirname ${makefile_abspath})
 	ARCH=amd64 BEAT=$(@D) BUILDID=$(BUILDID) $(packer_absdir)/platforms/darwin/build.sh
 
 %/win: %
+	ARCH=386 BEAT=$(@D) BUILDID=$(BUILDID) $(packer_absdir)/platforms/windows/build.sh
 	ARCH=amd64 BEAT=$(@D) BUILDID=$(BUILDID) $(packer_absdir)/platforms/windows/build.sh
 
 %/bin: %


### PR DESCRIPTION
This adds a 64-bit version of Topbeat for Windows. Potential solution for #986.

@tsg This changes the zip file name for Windows to include the architecture. I assume we would have to update the Windows links on the Download pages. Correct?