### PR TITLE
Change the error to a debug message

### DIFF
--- a/libbeat/filter/filter.go
+++ b/libbeat/filter/filter.go
@@ -72,7 +72,7 @@ func (filters *FilterList) Filter(event common.MapStr) common.MapStr {
 	for _, filter := range filters.filters {
 		filtered, err = filter.Filter(filtered)
 		if err != nil {
-			logp.Err("fail to apply filtering rule %s: %s", filter, err)
+			logp.Debug("filter", "fail to apply filtering rule %s: %s", filter, err)
 		}
 	}
 


### PR DESCRIPTION
Change the error message with a debug message in case the field that needs to be dropped is missing.
Requested by issue #1246 