### PR TITLE
Export embedded struct using in config reflection

### DIFF
--- a/winlogbeat/eventlog/eventlogging.go
+++ b/winlogbeat/eventlog/eventlogging.go
@@ -23,7 +23,7 @@ const (
 var eventLoggingConfigKeys = append(commonConfigKeys, "ignore_older")
 
 type eventLoggingConfig struct {
-	configCommon `config:",inline"`
+	ConfigCommon `config:",inline"`
 	IgnoreOlder  time.Duration          `config:"ignore_older"`
 	Raw          map[string]interface{} `config:",inline"`
 }

--- a/winlogbeat/eventlog/factory.go
+++ b/winlogbeat/eventlog/factory.go
@@ -11,8 +11,10 @@ import (
 
 var commonConfigKeys = []string{"api", "name", "fields", "fields_under_root", "tags"}
 
-// Config is the configuration data used to instantiate a new EventLog.
-type configCommon struct {
+// ConfigCommon is the common configuration data used to instantiate a new
+// EventLog. Each implementation is free to support additional configuration
+// options.
+type ConfigCommon struct {
 	API                  string             `config:"api"`  // Name of the API to use. Optional.
 	Name                 string             `config:"name"` // Name of the event log or channel.
 	common.EventMetadata `config:",inline"` // Fields and tags to add to each event.
@@ -102,7 +104,7 @@ func New(options map[string]interface{}) (EventLog, error) {
 		return nil, fmt.Errorf("No event log API is available on this system")
 	}
 
-	var config configCommon
+	var config ConfigCommon
 	if err := readConfig(options, &config, nil); err != nil {
 		return nil, err
 	}

--- a/winlogbeat/eventlog/wineventlog.go
+++ b/winlogbeat/eventlog/wineventlog.go
@@ -32,7 +32,7 @@ var winEventLogConfigKeys = append(commonConfigKeys, "ignore_older", "include_xm
 	"event_id", "level", "provider")
 
 type winEventLogConfig struct {
-	configCommon `config:",inline"`
+	ConfigCommon `config:",inline"`
 	IncludeXML   bool                   `config:"include_xml"`
 	SimpleQuery  query                  `config:",inline"`
 	Raw          map[string]interface{} `config:",inline"`


### PR DESCRIPTION
This change is required due the upgrade to Go 1.6 where the behavior of the reflect package was changed to not allow `Set` on unexported embedded structs.