### PR TITLE
Removed topbeat username from 1.2 changelog

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -92,7 +92,6 @@ https://github.com/elastic/beats/compare/v1.1.2...v1.2.0[View commits]
 *Topbeat*
 
 - Add the command line used to start processes {issue}533[533]
-- Add username to processes {pull}845[845]
 
 *Filebeat*
 

--- a/topbeat/docs/fields.asciidoc
+++ b/topbeat/docs/fields.asciidoc
@@ -379,14 +379,6 @@ type: string
 
 The full command-line used to start the process, including the arguments separated by space.
 
-
-==== proc.username
-
-type: string
-
-The username of the user that created the process. If the username can not be determined then the the field will contain the user's numeric identifier (UID). On Windows, this field includes the user's domain and is formatted as `domain\username`.
-
-
 [float]
 === cpu Fields
 

--- a/topbeat/etc/fields.yml
+++ b/topbeat/etc/fields.yml
@@ -330,15 +330,6 @@ process:
             The full command-line used to start the process, including the
             arguments separated by space.
 
-        - name: username
-          path: proc.username
-          type: string
-          description: >
-            The username of the user that created the process. If the username
-            can not be determined then the the field will contain the user's
-            numeric identifier (UID). On Windows, this field includes the user's
-            domain and is formatted as `domain\username`.
-
         - name: cpu
           type: group
           description: CPU-specific statistics per process.


### PR DESCRIPTION
Looks like the PRs were not (fully) backported. In my tests, the username
doesn't show up on Linux and OS X, and looking at the code I think it doesn't
work on any of the platforms.