### PR TITLE
Don't include filtering in libbeat

### DIFF
--- a/libbeat/docs/index.asciidoc
+++ b/libbeat/docs/index.asciidoc
@@ -25,8 +25,6 @@ include::./visualizing-data.asciidoc[]
 
 include::./dashboards.asciidoc[]
 
-include::./filtering.asciidoc[]
-
 include::./newbeat.asciidoc[]
 
 include::./release.asciidoc[]


### PR DESCRIPTION
I think the intention was to include that in the Beats, but not in the libbeat index.asciidoc.
