### PR TITLE
Fix force_close_files docs

### DIFF
--- a/filebeat/docs/reference/configuration/filebeat-options.asciidoc
+++ b/filebeat/docs/reference/configuration/filebeat-options.asciidoc
@@ -281,7 +281,7 @@ lines. The `backoff` value will be multiplied each time with the `backoff_factor
 
 ===== force_close_files
 
-By default, Filebeat keeps the files that it’s reading open until the timespan specified by `ignore_older` has elapsed.
+By default, Filebeat keeps the files that it’s reading open until the timespan specified by `close_older` has elapsed.
 This behaviour can cause issues when a file is removed. On Windows, the file cannot be fully removed until Filebeat closes
 the file. In addition no new file with the same name can be created during this time.
 


### PR DESCRIPTION
The docs were referring to the `ignore_older` option, but that was split
in `ignore_older` and `close_older`, with `close_older` being the relevant
one here.