### PR TITLE
ProspectorStdin loops forever

### DIFF
--- a/filebeat/crawler/prospector_stdin.go
+++ b/filebeat/crawler/prospector_stdin.go
@@ -30,15 +30,16 @@ func NewProspectorStdin(p *Prospector) (*ProspectorStdin, error) {
 	return prospectorer, nil
 }
 
-func (p ProspectorStdin) Init() {
+func (p *ProspectorStdin) Init() {
 	p.started = false
 }
 
-func (p ProspectorStdin) Run() {
+func (p *ProspectorStdin) Run() {
 
 	// Make sure stdin harvester is only started once
 	if !p.started {
 		p.harvester.Start()
+		p.started = true
 	}
 
 	// Wait time during endless loop


### PR DESCRIPTION
Hi,

I came across this issue by compiling filebeat for OpenBSD (OpenBSD XXX 5.9 GENERIC.MP#1963 amd64).
Filebeats was increasing my load at a very fast pace when I used it as a stdin shipper.
Also I wasn't able to reproduce the bug on Linux Ubuntu (trusty) and I still don't know why.
So I started to investigate and I found that p.started is never set to true so the harverstor starts at every loop.

I also notice the missing pointer receiver on Init() I don't know if it's needed because in any case started is already at false. But since the logic is to modify the ProspectorStdin Object I also modified it.

Let me know what you think.