### PR TITLE
Move logstash config out of getting started for Topbeat and Packetbeat

### DIFF
--- a/packetbeat/docs/configuring-logstash.asciidoc
+++ b/packetbeat/docs/configuring-logstash.asciidoc
@@ -1,0 +1,4 @@
+[[config-packetbeat-logstash]]
+=== Configuring Packetbeat to Use Logstash
+
+include::../../libbeat/docs/shared-logstash-config.asciidoc[]

--- a/packetbeat/docs/gettingstarted.asciidoc
+++ b/packetbeat/docs/gettingstarted.asciidoc
@@ -184,20 +184,15 @@ output:
      hosts: ["192.168.1.42:9200"]
 ----------------------------------------------------------------------
 +
-If you are sending output to Logstash, see <<config-filebeat-logstash>> instead.
-
-[[config-filebeat-logstash]]
-=== Step 3 (Optional): Configuring Packetbeat to Use Logstash
-
-include::../../libbeat/docs/shared-logstash-config.asciidoc[]
+If you are sending output to Logstash, see <<config-packetbeat-logstash>> instead.
 
 [[packetbeat-template]]
-=== Step 4: Loading the Index Template in Elasticsearch
+=== Step 3: Loading the Index Template in Elasticsearch
 
 :allplatforms:
 include::../../libbeat/docs/shared-template-load.asciidoc[]
 
-=== Step 5: Starting Packetbeat
+=== Step 4: Starting Packetbeat
 
 Run Packetbeat by issuing the following command:
 
@@ -252,7 +247,7 @@ curl -XGET 'http://localhost:9200/packetbeat-*/_search?pretty'
 Make sure that you replace `localhost:9200` with the address of your Elasticsearch
 instance. The command should return data about the HTTP transaction you just created.
 
-=== Step 6: Loading Sample Kibana Dashboards
+=== Step 5: Loading Sample Kibana Dashboards
 
 To make it easier for you to get application performance insights
 from packet data, we have created a few sample dashboards. The

--- a/packetbeat/docs/index.asciidoc
+++ b/packetbeat/docs/index.asciidoc
@@ -12,6 +12,8 @@ include::./command-line.asciidoc[]
 
 include::./configuring-howto.asciidoc[]
 
+include::./configuring-logstash.asciidoc[]
+
 include::../../libbeat/docs/shared-env-vars.asciidoc[]
 
 include::../../libbeat/docs/https.asciidoc[]

--- a/topbeat/docs/configuring-logstash.asciidoc
+++ b/topbeat/docs/configuring-logstash.asciidoc
@@ -1,0 +1,4 @@
+[[config-topbeat-logstash]]
+=== Configuring Topbeat to Use Logstash
+
+include::../../libbeat/docs/shared-logstash-config.asciidoc[]

--- a/topbeat/docs/gettingstarted.asciidoc
+++ b/topbeat/docs/gettingstarted.asciidoc
@@ -129,20 +129,15 @@ output:
      hosts: ["192.168.1.42:9200"]
 ----------------------------------------------------------------------
 +
-If you are sending output to Logstash, see <<config-filebeat-logstash>> instead.
-
-[[config-filebeat-logstash]]
-=== Step 3 (Optional): Configuring Topbeat to Use Logstash
-
-include::../../libbeat/docs/shared-logstash-config.asciidoc[]
+If you are sending output to Logstash, see <<config-topbeat-logstash>> instead.
 
 [[topbeat-template]]
-=== Step 4: Loading the Index Template in Elasticsearch
+=== Step 3: Loading the Index Template in Elasticsearch
 
 :allplatforms:
 include::../../libbeat/docs/shared-template-load.asciidoc[]
 
-=== Step 5: Starting Topbeat
+=== Step 4: Starting Topbeat
 
 Run Topbeat by issuing the following command:
 
@@ -193,7 +188,7 @@ instance.
 
 On Windows, if you don't have cURL installed, simply point your browser to the URL.
 
-=== Step 6: Loading Sample Kibana Dashboards
+=== Step 5: Loading Sample Kibana Dashboards
 
 To make it easier for you to start monitoring your servers in Kibana,
 we have created a few sample dashboards. The dashboards are maintained in this

--- a/topbeat/docs/index.asciidoc
+++ b/topbeat/docs/index.asciidoc
@@ -12,6 +12,8 @@ include::./command-line.asciidoc[]
 
 include::./configuring-howto.asciidoc[]
 
+include::./configuring-logstash.asciidoc[]
+
 include::../../libbeat/docs/shared-env-vars.asciidoc[]
 
 include::../../libbeat/docs/https.asciidoc[]

--- a/winlogbeat/docs/getting-started.asciidoc
+++ b/winlogbeat/docs/getting-started.asciidoc
@@ -103,7 +103,7 @@ output:
       - localhost:9200
 ----------------------------------------------------------------------
 +
-If you are sending output to Logstash, see <<config-filebeat-logstash>> instead.
+If you are sending output to Logstash, see <<config-winlogbeat-logstash>> instead.
 
 . After you save your configuration file, test it with the following command.
 +
@@ -112,7 +112,7 @@ If you are sending output to Logstash, see <<config-filebeat-logstash>> instead.
 PS C:\Program Files\Winlogbeat> .\winlogbeat.exe -c .\winlogbeat.yml -configtest -e
 ----------------------------------------------------------------------
 
-[[config-filebeat-logstash]]
+[[config-winlogbeat-logstash]]
 === Step 3: Configuring Winlogbeat to Use Logstash
 
 include::../../libbeat/docs/shared-logstash-config.asciidoc[]


### PR DESCRIPTION
Moved sections about configuring Logstash out of the Getting Started doc for Topbeat and Packetbeat because using Topbeat or Packetbeat with Logstash is not a common use case.

@monicasarbu  For the other Beats, I would like to continue flagging the Logstash config as "optional" because it truly will be optional when ingest node comes out, right? If we really want to make the step required, then we should remove all config details about specifying Elasticsearch as output, and we should probably not have a separate topic about configuring Logstash (it should replace the part where we talk about configuring Elasticsearch for output). I hesitate to move stuff around when I know that ingest node is coming. WDYT?