### PR TITLE
Fix async flush_interval value

### DIFF
--- a/libbeat/mock/mockbeat.go
+++ b/libbeat/mock/mockbeat.go
@@ -1,7 +1,10 @@
 package mock
 
 import (
+	"time"
+
 	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/common"
 )
 
 ///*** Mock Beat Setup ***///
@@ -32,6 +35,11 @@ func (mb *Mockbeat) Setup(b *beat.Beat) error {
 
 func (mb *Mockbeat) Run(b *beat.Beat) error {
 	// Wait until mockbeat is done
+	b.Events.PublishEvent(common.MapStr{
+		"@timestamp": common.Time(time.Now()),
+		"type":       "mock",
+		"message":    "Mockbeat is alive!",
+	})
 	<-mb.done
 	return nil
 }

--- a/libbeat/publisher/async.go
+++ b/libbeat/publisher/async.go
@@ -1,8 +1,6 @@
 package publisher
 
 import (
-	"time"
-
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/outputs"
@@ -65,7 +63,7 @@ func (p *asyncPublisher) send(m message) {
 func asyncOutputer(ws *common.WorkerSignal, hwm, bulkHWM int, worker *outputWorker) worker {
 	config := worker.config
 
-	flushInterval := config.FlushInterval * time.Second
+	flushInterval := config.FlushInterval
 	maxBulkSize := config.BulkMaxSize
 	logp.Info("Flush Interval set to: %v", flushInterval)
 	logp.Info("Max Bulk Size set to: %v", maxBulkSize)

--- a/libbeat/tests/system/config/mockbeat.yml.j2
+++ b/libbeat/tests/system/config/mockbeat.yml.j2
@@ -36,6 +36,12 @@ shipper:
 # Configure what outputs to use when sending the data collected by packetbeat.
 # Multiple outputs may be enabled.
 output:
+  {% if console -%}
+  console:
+    {% for k, v in console.items() -%}
+    {{ k }}: {{ v }}
+    {% endfor -%}
+  {%- endif %}
 
   # Elasticsearch as output
   # Options:

--- a/libbeat/tests/system/test_base.py
+++ b/libbeat/tests/system/test_base.py
@@ -6,7 +6,6 @@ import subprocess
 
 
 class Test(BaseTest):
-
     def test_base(self):
         """
         Basic test with exiting Mockbeat normally
@@ -15,7 +14,7 @@ class Test(BaseTest):
         )
 
         proc = self.start_beat()
-        self.wait_until( lambda: self.log_contains("Setup Beat"))
+        self.wait_until(lambda: self.log_contains("Setup Beat"))
         proc.check_kill_and_wait()
 
     def test_no_config(self):
@@ -48,8 +47,8 @@ class Test(BaseTest):
         shutil.copy("../../etc/libbeat.yml",
                     os.path.join(self.working_dir, "libbeat.yml"))
 
-        exit_code = self.run_beat(
-                config="libbeat.yml", extra_args=["-configtest"])
+        exit_code = self.run_beat(config="libbeat.yml",
+                                  extra_args=["-configtest"])
 
         assert exit_code == 0
         assert self.log_contains("Config OK") is True
@@ -72,7 +71,7 @@ class Test(BaseTest):
         assert self.log_contains("error loading config file") is False
 
         with open(os.path.join(self.working_dir, "mockbeat.log"), "wb") \
-                as outputfile:
+            as outputfile:
             proc = subprocess.Popen(args,
                                     stdout=outputfile,
                                     stderr=subprocess.STDOUT)
@@ -82,3 +81,33 @@ class Test(BaseTest):
         assert self.log_contains("mockbeat") is True
         assert self.log_contains("version") is True
         assert self.log_contains("9.9.9") is True
+
+    def test_console_output_timed_flush(self):
+        """
+        outputs/console - timed flush
+        """
+        self.render_config_template(
+            console={"pretty": "false"}
+        )
+
+        proc = self.start_beat(logging_args=["-e"])
+        self.wait_until(lambda: self.log_contains("Mockbeat is alive"),
+                        max_timeout=2)
+        proc.check_kill_and_wait()
+
+    def test_console_output_size_flush(self):
+        """
+        outputs/console - size based flush
+        """
+        self.render_config_template(
+            console={
+                "pretty": "false",
+                "bulk_max_size": 1,
+                "flush_interval": "1h"
+            }
+        )
+
+        proc = self.start_beat(logging_args=["-e"])
+        self.wait_until(lambda: self.log_contains("Mockbeat is alive"),
+                        max_timeout=2)
+        proc.check_kill_and_wait()

--- a/topbeat/tests/system/test_procs.py
+++ b/topbeat/tests/system/test_procs.py
@@ -29,7 +29,7 @@ class Test(BaseTest):
 
         print output["proc.name"]
         assert re.match("(?i)topbeat.test(.exe)?", output["proc.name"])
-        assert re.match("(?i).*topbeat.test(.exe)? -e -c", output["proc.cmdline"])
+        assert re.match("(?i).*topbeat.test(.exe)? -systemTest", output["proc.cmdline"])
         assert isinstance(output["proc.state"], basestring)
         assert isinstance(output["proc.cpu.start_time"], basestring)
         self.check_username(output["proc.username"])


### PR DESCRIPTION
The async `flush_interval` wasn't being initialized correctly so time based flushing was not occurring as expected affecting the console output. I added test cases for the console output (timed flush and size based flushing).

Previously in the log we had:

`async.go:79: DBG  create bulk processing worker (interval=277777h46m40s, bulk size=2048)`

and now:

`async.go:77: DBG  create bulk processing worker (interval=1s, bulk size=2048)`