### PR TITLE
Add scripts to import the Kibana dashboards of a single Beat

### DIFF
--- a/libbeat/scripts/kibana_import.ps1
+++ b/libbeat/scripts/kibana_import.ps1
@@ -1,0 +1,132 @@
+param(
+  [String] $l, [String] $url, 
+  [String] $u, [String] $user, 
+  [String] $i, [String] $index,
+  [String] $d, [String] $dir,
+  [switch] $h = $false, [switch] $help = $false
+)
+
+# The default value of the variable. Initialize your own variables here
+$ELASTICSEARCH="http://localhost:9200"
+$CURL="Invoke-RestMethod"
+$KIBANA_INDEX=".kibana"
+$SCRIPT=$MyInvocation.MyCommand.Name
+$KIBANA_DIR=
+
+# Verify that Invoke-RestMethod is present. It was added in PS 3.
+if (!(Get-Command $CURL -errorAction SilentlyContinue))
+{
+  Write-Error "$CURL cmdlet was not found. You may need to upgrade your PowerShell version."
+  exit 1
+}
+
+function print_usage() {
+  echo @"
+
+Load the dashboards, visualizations and index patterns into the given
+Elasticsearch instance.
+
+Usage:
+  $SCRIPT -url $ELASTICSEARCH -user admin -index $KIBANA_INDEX
+Options:
+  -h | -help
+    Print the help menu.
+  -d | -dir
+    Local directory where the dashboards, visualizations, searches and index pattern are saved.
+  -l | -url
+    Elasticseacrh URL. By default is $ELASTICSEARCH.
+  -u | -user
+    Username and password for authenticating to Elasticsearch using Basic
+    Authentication. The username and password should be separated by a
+    colon (i.e. "user:secret"). By default no username and password are
+    used.
+  -i | -index
+    Kibana index pattern where to save the dashboards, visualizations,
+    index patterns. By default is $KIBANA_INDEX.
+
+"@
+}
+
+if ($help -or $h) {
+  print_usage
+  exit 0
+}
+if ($args -ne "") {
+  Write-Error "Error: Unknown option $args"
+  print_usage
+  exit 1
+}
+
+if ($l -ne "" ) {
+  $ELASTICSEARCH=$l
+}
+if ($url -ne "") {
+  $ELASTICSEARCH=$url
+}
+if ($ELASTICSEARCH -eq "") {
+  Write-Error "Error: Missing Elasticsearch URL"
+  print_usage
+  exit 1
+}
+
+if ($u -ne "" ){
+  $user = $u
+}
+if ($user -ne "") {
+  $base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(("{0}" -f $user)))
+  $headers=@{Authorization=("Basic $base64AuthInfo")}
+}
+
+if ($d -ne "" ){
+  $KIBANA_DIR = $d
+}
+if ($dir -ne "" ){
+  $KIBANA_DIR = $dir
+}
+if ($KIBANA_DIR -eq "") {
+  Write-Error "Error: Missing local directory containing the Kibana dashboards, visualizations, searches and index
+  patterns"
+  print_usage
+  exit 1
+}
+
+if ($i -ne "") {
+  $KIBANA_INDEX=$i
+}
+if ($index -ne "") {
+  $KIBANA_INDEX=$index
+}
+if ($KIBANA_INDEX -eq "") {
+  Write-Error "Error: Missing Kibana index pattern"
+  print_usage
+  exit 1
+}
+
+echo "Import dashboards from $KIBANA_DIR to $ELASTICSEARCH in $KIBANA_INDEX"  
+
+ForEach ($file in Get-ChildItem "$KIBANA_DIR/search/" -Filter *.json) {
+  $name = [io.path]::GetFileNameWithoutExtension($file.Name)
+  echo "Import search $($name):"
+  &$CURL -Headers $headers -Uri "$ELASTICSEARCH/$KIBANA_INDEX/search/$name" -Method PUT -Body $(Get-Content "$KIBANA_DIR/search/$file")
+}
+
+ForEach ($file in Get-ChildItem "$KIBANA_DIR/visualization/" -Filter *.json) {
+  $name = [io.path]::GetFileNameWithoutExtension($file.Name)
+  echo "Import visualization $($name):"
+  &$CURL -Headers $headers -Uri "$ELASTICSEARCH/$KIBANA_INDEX/visualization/$name" -Method PUT -Body $(Get-Content
+  "$KIBANA_DIR/visualization/$file")
+}
+
+ForEach ($file in Get-ChildItem "$KIBANA_DIR/dashboard/" -Filter *.json) {
+  $name = [io.path]::GetFileNameWithoutExtension($file.Name)
+  echo "Import dashboard $($name):"
+  &$CURL -Headers $headers -Uri "$ELASTICSEARCH/$KIBANA_INDEX/dashboard/$name" -Method PUT -Body $(Get-Content "$KIBANA_DIR/dashboard/$file")
+}
+
+ForEach ($file in Get-ChildItem "$KIBANA_DIR/index-pattern/" -Filter *.json) {
+  $json = Get-Content "$KIBANA_DIR/index-pattern/$file" -Raw | ConvertFrom-Json
+  $name = $json.title
+  echo "Import index-pattern $($name):"
+  &$CURL -Headers $headers -Uri "$ELASTICSEARCH/$KIBANA_INDEX/index-pattern/$name" -Method PUT -Body $(Get-Content
+  "$KIBANA_DIR/index-pattern/$file")
+}

--- a/libbeat/scripts/kibana_import.sh
+++ b/libbeat/scripts/kibana_import.sh
@@ -1,0 +1,143 @@
+#!/bin/bash
+
+# Usage examples:
+# env KIBANA_INDEX='.kibana_env1' ./kibana_import.sh
+# ./kibana_import.sh -dir etc/kibana -url http://test.com:9200
+# ./kibana_import.sh -dir etc/kibana -url http://test.com:9200 -user admin:secret
+# ./kibana_import.sh -dir etc/kibana -url http://test.com:9200 -index .kibana-test
+
+# The default value of the variable. Initialize your own variables here
+ELASTICSEARCH=http://localhost:9200
+CURL=curl
+KIBANA_INDEX=".kibana"
+DIR=
+
+print_usage() {
+  echo "
+  
+Load the dashboards, visualizations and index patterns into the given
+Elasticsearch instance.
+
+Usage:
+  $(basename "$0") -url ${ELASTICSEARCH} -user admin:secret -index ${KIBANA_INDEX}
+
+Options:
+  -h | -help
+    Print the help menu.
+  -d | -dir
+    Local directory where the dashboards, visualizations, searches and index pattern are saved.
+  -l | -url
+    Elasticseacrh URL. By default is ${ELASTICSEARCH}.
+  -u | -user
+    Username and password for authenticating to Elasticsearch using Basic
+    Authentication. The username and password should be separated by a
+    colon (i.e. "admin:secret"). By default no username and password are
+    used.
+  -i | -index
+    Kibana index pattern where to save the dashboards, visualizations,
+    index patterns. By default is ${KIBANA_INDEX}.
+
+" >&2
+}
+
+while [ "$1" != "" ]; do
+case $1 in
+    -d | -dir )
+        DIR=$2
+        if [ "$DIR" = "" ]; then
+            echo "Error: Missing directory"
+            print_usage
+            exit 1
+        fi
+        ;;
+
+    -l | -url )
+        ELASTICSEARCH=$2
+        if [ "$ELASTICSEARCH" = "" ]; then
+            echo "Error: Missing Elasticsearch URL"
+            print_usage
+            exit 1
+        fi
+        ;;
+
+    -u | -user )
+        USER=$2
+        if [ "$USER" = "" ]; then
+            echo "Error: Missing username"
+            print_usage
+            exit 1
+        fi
+        CURL="curl --user ${USER}"
+        ;;
+
+    -i | -index )
+        KIBANA_INDEX=$2
+        if [ "$KIBANA_INDEX" = "" ]; then
+            echo "Error: Missing Kibana index pattern"
+            print_usage
+            exit 1
+        fi
+        ;;
+
+    -h | -help )
+        print_usage
+        exit 0
+        ;;
+
+     *)
+        echo "Error: Unknown option $2"
+        print_usage
+        exit 1
+        ;;
+
+esac
+shift 2
+done
+
+if [ "$DIR" = "" ]; then
+    echo "Error: Missing directory. Please specify the local directory containing the dashboards, visualizations,
+         searches and index patterns."
+    print_usage
+    exit 1
+fi
+
+echo "Import dashboards,visualizations, searches and index pattern from ${DIR} to ${ELASTICSEARCH} in ${KIBANA_INDEX}"
+
+for file in ${DIR}/search/*.json
+do
+    NAME=`basename ${file} .json`
+    echo "Import search ${NAME}:"
+    ${CURL} -XPUT ${ELASTICSEARCH}/${KIBANA_INDEX}/search/${NAME} \
+        -d @${file} || exit 1
+    echo
+done
+
+for file in ${DIR}/visualization/*.json
+do
+    NAME=`basename ${file} .json`
+    echo "Import visualization ${NAME}:"
+    ${CURL} -XPUT ${ELASTICSEARCH}/${KIBANA_INDEX}/visualization/${NAME} \
+        -d @${file} || exit 1
+    echo
+done
+
+for file in ${DIR}/dashboard/*.json
+do
+    NAME=`basename ${file} .json`
+    echo "Import dashboard ${NAME}:"
+    ${CURL} -XPUT ${ELASTICSEARCH}/${KIBANA_INDEX}/dashboard/${NAME} \
+        -d @${file} || exit 1
+    echo
+done
+
+for file in ${DIR}/index-pattern/*.json
+do
+    NAME=`awk '$1 == "\"title\":" {gsub(/[",]/, "", $2); print $2}' ${file}`
+    echo "Import index pattern ${NAME}:"
+
+    ${CURL} -XPUT ${ELASTICSEARCH}/${KIBANA_INDEX}/index-pattern/${NAME} \
+        -d @${file} || exit 1
+    echo
+done
+
+


### PR DESCRIPTION
Add a bash script for Unix systems and a powershell script for Windows systems to import all the dashboards (including the dependencies) to Elasticsearch.

I added another parameter to the script to pass the local directory containing the dashboards, visualizations, searches and index pattern.