### PR TITLE
Implement BasicAuth for apache module

### DIFF
--- a/metricbeat/etc/beat.yml
+++ b/metricbeat/etc/beat.yml
@@ -13,6 +13,12 @@ metricbeat:
       # Path to server status. Default server-status
       #server_status_path: "server-status"
 
+      # Username of hosts.  Empty by default
+      #username: test
+
+      # Password of hosts. Empty by default
+      #password: test123
+
     # Redis Module
     - module: redis
       metricsets: ["info"]

--- a/metricbeat/metricbeat.yml
+++ b/metricbeat/metricbeat.yml
@@ -13,6 +13,12 @@ metricbeat:
       # Path to server status. Default server-status
       #server_status_path: "server-status"
 
+      # Username of hosts.  Empty by default
+      #username: test
+
+      # Password of hosts. Empty by default
+      #password: test123
+
     # Redis Module
     - module: redis
       metricsets: ["info"]


### PR DESCRIPTION
This implements basic authentication for apache server-status page when secured by username and password. 
It is part of the implementation of #1196. 
@ruflin this is PR and part of the work I mentioned in my morning's email