### PR TITLE
Update Elasticsearch alpha1 to RC2 in tests

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -87,15 +87,12 @@ https://github.com/elastic/beats/compare/v1.2.0...master[Check the HEAD diff]
 - Add support for NFS v3 and v4. {pull}1231[1231]
 
 *Topbeat*
-- Group all cpu usage per core statistics and export them optionally if cpu_per_core is configured {pull}496[496]
 
 *Filebeat*
-- Add multiline support for combining multiple related lines into one event. {issue}461[461]
 - Add experimental option to enable filebeat publisher pipeline to operate asynchonrously {pull}782[782]
 - Add the ability to set a list of tags for each prospector {pull}1092[1092]
 - Add JSON decoding support {pull}1143[1143]
 
-*Filebeat*
 
 *Winlogbeat*
 - Add caching of event metadata handles and the system render context for the wineventlog API {pull}888[888]
@@ -103,7 +100,7 @@ https://github.com/elastic/beats/compare/v1.2.0...master[Check the HEAD diff]
 - Add the ability to set tags, fields, and fields_under_root as options for each event log {pull}1092[1092]
 - Add additional data to the events published by Winlogbeat. The new fields are `activity_id`,
 `event_data`, `keywords`, `opcode`, `process_id`, `provider_guid`, `related_activity_id`,
-`task`, `thread_id`, `user_data`. and `version`. {issue}1053[1053]
+`task`, `thread_id`, `user_data`, and `version`. {issue}1053[1053]
 - Add `event_id`, `level`, and `provider` configuration options for filtering events {pull}1218[1218]
 - Add `include_xml` configuration option for including the raw XML with the event {pull}1218[1218]
 
@@ -226,7 +223,6 @@ https://github.com/elastic/beats/compare/v1.0.1...v1.1.0[View commits]
 
 *Topbeat*
 
-- Group all cpu usage per core statistics and export them optionally if cpu_per_core is configured {pull}496[496]
 - Group all CPU usage per core statistics and export them optionally if cpu_per_core is configured {pull}496[496]
 
 *Filebeat*

--- a/libbeat/docker-compose.yml
+++ b/libbeat/docker-compose.yml
@@ -27,7 +27,7 @@ beat:
 elasticsearch:
   build: ../testing/environments/docker/elasticsearch
   dockerfile: Dockerfile-5.0.0-alpha1
-  command: elasticsearch -Ees.network.host=0.0.0.0
+  command: elasticsearch -Ees.network.host=0.0.0.0 -Ees.discovery.zen.minimum_master_nodes=1
 redis:
   image: redis:3.0.7
 # This host name is fixed because of the certificate

--- a/metricbeat/docker-compose.yml
+++ b/metricbeat/docker-compose.yml
@@ -21,7 +21,7 @@ beat:
   entrypoint: /go/src/github.com/elastic/beats/metricbeat/docker-entrypoint.sh
 elasticsearch:
   image: elasticsearch:2.2.0
-  command: elasticsearch -Des.network.host=0.0.0.0
+  command: elasticsearch -Des.network.host=0.0.0.0 -Ees.discovery.zen.minimum_master_nodes=1
 
 # Modules
 apache:

--- a/testing/environments/docker/elasticsearch/Dockerfile-5.0.0-alpha1
+++ b/testing/environments/docker/elasticsearch/Dockerfile-5.0.0-alpha1
@@ -15,7 +15,7 @@ RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 46095ACC85485
 ENV ELASTICSEARCH_MAJOR 5.0
 ENV ELASTICSEARCH_VERSION 5.0.0-alpha1
 
-RUN wget http://download.elastic.co/elasticsearch/staging/5.0.0-alpha1-bf98a44/org/elasticsearch/distribution/deb/elasticsearch/5.0.0-alpha1/elasticsearch-5.0.0-alpha1.deb
+RUN wget http://download.elastic.co/elasticsearch/staging/5.0.0-alpha1-7d4ed5b/org/elasticsearch/distribution/deb/elasticsearch/5.0.0-alpha1/elasticsearch-5.0.0-alpha1.deb
 
 RUN dpkg -i elasticsearch-5.0.0-alpha1.deb
 

--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -3,7 +3,7 @@
 elasticsearch:
   build: ./docker/elasticsearch
   dockerfile: Dockerfile-5.0.0-alpha1
-  command: elasticsearch -Ees.network.host=0.0.0.0
+  command: elasticsearch -Ees.network.host=0.0.0.0 -Ees.discovery.zen.minimum_master_nodes=1
 
 logstash:
   build: ./docker/logstash


### PR DESCRIPTION
Should fix the failing libbeat tests. Also, small cleanups in the
CHANGELOG, removing duplicate lines.