### PR TITLE
Add event to json encoding error/warn ouput

### DIFF
--- a/libbeat/common/event.go
+++ b/libbeat/common/event.go
@@ -64,7 +64,8 @@ func ConvertToGenericEvent(v MapStr) MapStr {
 			case reflect.Map:
 				anothermap, err := MarshallUnmarshall(value)
 				if err != nil {
-					logp.Warn("fail to marschall & unmarshall map %v", key)
+					logp.Warn("fail to marschall & unmarshall map (%v): key=%v value=%#v",
+						key, value)
 					continue
 				}
 				v[key] = anothermap

--- a/libbeat/outputs/console/console.go
+++ b/libbeat/outputs/console/console.go
@@ -62,7 +62,7 @@ func (c *console) PublishEvent(
 		jsonEvent, err = json.Marshal(event)
 	}
 	if err != nil {
-		logp.Err("Fail to convert the event to JSON: %s", err)
+		logp.Err("Fail to convert the event to JSON (%v): %#v", err, event)
 		outputs.SignalCompleted(s)
 		return err
 	}

--- a/libbeat/outputs/elasticsearch/api.go
+++ b/libbeat/outputs/elasticsearch/api.go
@@ -1,6 +1,10 @@
 package elasticsearch
 
-import "encoding/json"
+import (
+	"encoding/json"
+
+	"github.com/elastic/beats/libbeat/logp"
+)
 
 type QueryResult struct {
 	Ok      bool            `json:"ok"`
@@ -35,6 +39,7 @@ type CountResults struct {
 func (r QueryResult) String() string {
 	out, err := json.Marshal(r)
 	if err != nil {
+		logp.Warn("failed to marshal QueryResult (%v): %#v", err, r)
 		return "ERROR"
 	}
 	return string(out)

--- a/libbeat/outputs/elasticsearch/client.go
+++ b/libbeat/outputs/elasticsearch/client.go
@@ -463,6 +463,7 @@ func (conn *Connection) request(
 		var err error
 		obj, err = json.Marshal(body)
 		if err != nil {
+			logp.Warn("Failed to json encode body (%v): %#v", err, body)
 			return 0, nil, ErrJSONEncodeFailed
 		}
 	}

--- a/libbeat/outputs/fileout/file.go
+++ b/libbeat/outputs/fileout/file.go
@@ -78,7 +78,7 @@ func (out *fileOutput) PublishEvent(
 		// mark as success so event is not sent again.
 		outputs.SignalCompleted(trans)
 
-		logp.Err("Fail to convert the event to JSON: %s", err)
+		logp.Err("Fail to json encode event(%v): %#v", err, event)
 		return err
 	}
 

--- a/libbeat/outputs/logstash/protocol.go
+++ b/libbeat/outputs/logstash/protocol.go
@@ -265,7 +265,7 @@ func (p *protocol) serializeDataFrame(
 
 	jsonEvent, err := json.Marshal(event)
 	if err != nil {
-		debug("Fail to convert the event to JSON: %s", err)
+		debug("Fail to json encode event (%v): %#v", err, event)
 		return err
 	}
 

--- a/libbeat/outputs/redis/redis.go
+++ b/libbeat/outputs/redis/redis.go
@@ -275,7 +275,7 @@ func (out *redisOutput) doBulkPublish(events []common.MapStr) error {
 		event := events[0]
 		jsonEvent, err := json.Marshal(event)
 		if err != nil {
-			logp.Err("Fail to convert the event to JSON: %s", err)
+			logp.Err("Fail to json encode event (%v): %#v", err, event)
 			return err
 		}
 
@@ -287,7 +287,7 @@ func (out *redisOutput) doBulkPublish(events []common.MapStr) error {
 	for _, event := range events {
 		jsonEvent, err := json.Marshal(event)
 		if err != nil {
-			logp.Err("Fail to convert the event to JSON: %s", err)
+			logp.Err("Fail to json encode event (%v): %#v", err, event)
 			continue
 		}
 		err = out.Conn.Send(command, out.Index, string(jsonEvent))


### PR DESCRIPTION
have original event/data included (including type information) when json.Marshal fails, to improve chances to debug error.