### PR TITLE
Replaced `stat.proc` to `stat.process` in the default config file for Topbeat

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -32,6 +32,8 @@ https://github.com/elastic/beats/compare/v1.2.0...master[Check the HEAD diff]
 
 *Topbeat*
 
+- Fixed name of the setting `stats.proc` to `stats.process` in the default configuration file. {pull}1343[1343]
+
 *Filebeat*
 
 *Winlogbeat*

--- a/topbeat/etc/beat.yml
+++ b/topbeat/etc/beat.yml
@@ -15,7 +15,7 @@ input:
     system: true
 
     # per process statistics, by default is true
-    proc: true
+    process: true
 
     # file system information, by default is true
     filesystem: true

--- a/topbeat/etc/topbeat.yml
+++ b/topbeat/etc/topbeat.yml
@@ -15,7 +15,7 @@ input:
     system: true
 
     # per process statistics, by default is true
-    proc: true
+    process: true
 
     # file system information, by default is true
     filesystem: true


### PR DESCRIPTION
Fixes #1323.