### PR TITLE
Added proc.username to fields.yml

### DIFF
--- a/topbeat/docs/fields.asciidoc
+++ b/topbeat/docs/fields.asciidoc
@@ -352,6 +352,13 @@ type: string
 The process name.
 
 
+==== proc.username
+
+type: string
+
+The user name of the process owner. Added in 1.2.1.
+
+
 ==== proc.state
 
 type: string

--- a/topbeat/etc/fields.yml
+++ b/topbeat/etc/fields.yml
@@ -305,6 +305,12 @@ process:
           description: >
             The process name.
 
+        - name: username
+          path: proc.username
+          type: string
+          description: >
+            The user name of the process owner.
+
         - name: state
           path: proc.state
           type: string


### PR DESCRIPTION
In the fields.asciidoc, I manually added a note that the field is only
present starting with 1.2.1.