### PR TITLE
Update tsg/gopacket to HEAD as of 8c16bb8

### DIFF
--- a/vendor/github.com/tsg/gopacket/layers/pflog.go
+++ b/vendor/github.com/tsg/gopacket/layers/pflog.go
@@ -8,7 +8,6 @@ package layers
 
 import (
 	"encoding/binary"
-	"errors"
 
 	"github.com/tsg/gopacket"
 )
@@ -52,12 +51,8 @@ func (pf *PFLog) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error 
 	pf.RuleUID = binary.BigEndian.Uint32(data[52:56])
 	pf.RulePID = int32(binary.BigEndian.Uint32(data[56:60]))
 	pf.Direction = PFDirection(data[60])
-	if pf.Length%4 != 1 {
-		return errors.New("PFLog header length should be 3 less than multiple of 4")
-	}
-	actualLength := int(pf.Length) + 3
-	pf.Contents = data[:actualLength]
-	pf.Payload = data[actualLength:]
+	pf.Contents = data[:pf.Length]
+	pf.Payload = data[pf.Length:]
 	return nil
 }
 

--- a/vendor/github.com/tsg/gopacket/pcap/pcap.go
+++ b/vendor/github.com/tsg/gopacket/pcap/pcap.go
@@ -10,6 +10,7 @@ package pcap
 /*
 #cgo linux LDFLAGS: -lpcap
 #cgo freebsd LDFLAGS: -lpcap
+#cgo openbsd LDFLAGS: -lpcap
 #cgo darwin LDFLAGS: -lpcap
 #cgo solaris LDFLAGS: -lpcap
 #cgo windows CFLAGS: -I C:/WpdPack/Include
@@ -83,6 +84,10 @@ int pcap_set_rfmon(pcap_t *p, int rfmon) {
 #elif __GLIBC__
 #define gopacket_time_secs_t __time_t
 #define gopacket_time_usecs_t __suseconds_t
+#elif __OpenBSD__
+// time_t is 64-bit, however bpf_timeval uses 32 bit fields
+#define gopacket_time_secs_t u_int32_t
+#define gopacket_time_usecs_t u_int32_t
 #else
 #define gopacket_time_secs_t time_t
 #define gopacket_time_usecs_t suseconds_t


### PR DESCRIPTION
This includes two new commits:

- https://github.com/tsg/gopacket/commit/23b7ce90d4f105ae8cfbf3bd5d3615937e34d160
- https://github.com/tsg/gopacket/commit/5db802b492c9ead2d7d7b449762383139e1dc9ff

The first one adds support for OpenBSD to gopacket, and by extension packetbeat. The latter removes an unneeded check of PFLog packets. While this code is currently unused in Packetbeat, it will allow at some point to decode pflog packets.