### PR TITLE
Bump versions in docs for 1.2.1

### DIFF
--- a/filebeat/docs/index.asciidoc
+++ b/filebeat/docs/index.asciidoc
@@ -1,6 +1,6 @@
 = Filebeat Reference
 :libbeat: http://www.elastic.co/guide/en/beats/libbeat/1.2
-:version: 1.2.0
+:version: 1.2.1
 :beatname_lc: filebeat
 :beatname_uc: Filebeat
 

--- a/packetbeat/docs/index.asciidoc
+++ b/packetbeat/docs/index.asciidoc
@@ -1,6 +1,6 @@
 = Packetbeat Reference
 :libbeat: http://www.elastic.co/guide/en/beats/libbeat/1.2
-:version: 1.2.0
+:version: 1.2.1
 :beatname_lc: packetbeat
 :beatname_uc: Packetbeat
 

--- a/topbeat/docs/index.asciidoc
+++ b/topbeat/docs/index.asciidoc
@@ -1,6 +1,6 @@
 = Topbeat Reference
 :libbeat: http://www.elastic.co/guide/en/beats/libbeat/1.2
-:version: 1.2.0
+:version: 1.2.1
 :beatname_lc: topbeat
 :beatname_uc: Topbeat
 

--- a/winlogbeat/docs/index.asciidoc
+++ b/winlogbeat/docs/index.asciidoc
@@ -1,6 +1,6 @@
 = Winlogbeat Reference
 :libbeat: http://www.elastic.co/guide/en/beats/libbeat/1.2
-:version: 1.2.0
+:version: 1.2.1
 :beatname_lc: winlogbeat
 :beatname_uc: Winlogbeat
 


### PR DESCRIPTION
We should only merge this one ~30 minutes before the release, otherwise it will link to the unreleased version in "current".