### PR TITLE
Remove link that points to github repo for dashboards

### DIFF
--- a/packetbeat/docs/gettingstarted.asciidoc
+++ b/packetbeat/docs/gettingstarted.asciidoc
@@ -250,16 +250,13 @@ instance. The command should return data about the HTTP transaction you just cre
 === Step 5: Loading Sample Kibana Dashboards
 
 To make it easier for you to get application performance insights
-from packet data, we have created a few sample dashboards. The
-dashboards are maintained in this
-https://github.com/elastic/beats-dashboards[GitHub repository], which also
-includes instructions for loading the dashboards.
+from packet data, we have created a sample Packetbeat dashboard. This dashboard is provided as
+an example. We recommend that you
+http://www.elastic.co/guide/en/kibana/current/dashboard.html[customize] it
+to meet your needs.
 
-For more information about loading and viewing the dashboards, see {libbeat}/visualizing-data.html[Visualizing Your Data in Kibana].
-
+For more information about loading and viewing the Beats dashboards, see
+{libbeat}/visualizing-data.html[Visualizing Your Data in Kibana].
 
 image:./images/packetbeat-statistics.png[Packetbeat statistics]
 
-These dashboards are provided as examples. We recommend that you
-http://www.elastic.co/guide/en/kibana/current/dashboard.html[customize] them
-to meet your needs.

--- a/topbeat/docs/gettingstarted.asciidoc
+++ b/topbeat/docs/gettingstarted.asciidoc
@@ -191,17 +191,15 @@ On Windows, if you don't have cURL installed, simply point your browser to the U
 === Step 5: Loading Sample Kibana Dashboards
 
 To make it easier for you to start monitoring your servers in Kibana,
-we have created a few sample dashboards. The dashboards are maintained in this
-https://github.com/elastic/beats-dashboards[GitHub repository], which also
-includes instructions for loading the dashboards.
+we have created a sample Topbeat dashboard. This dashboard is provided as
+an example. We recommend that you
+http://www.elastic.co/guide/en/kibana/current/dashboard.html[customize] it
+to meet your needs.
 
-For more information about loading and viewing the dashboards, see {libbeat}/visualizing-data.html[Visualizing Your Data in Kibana].
+For more information about loading and viewing the Beats dashboards, see
+{libbeat}/visualizing-data.html[Visualizing Your Data in Kibana].
 
 image:./images/topbeat-dashboard.png[Topbeat statistics]
-
-These dashboards are provided as examples. We recommend that you
-http://www.elastic.co/guide/en/kibana/current/dashboard.html[customize] them
-to meet your needs.
 
 ==== Example of a System-Wide Overview
 

--- a/winlogbeat/docs/getting-started.asciidoc
+++ b/winlogbeat/docs/getting-started.asciidoc
@@ -155,14 +155,12 @@ PS C:\Program Files\Winlogbeat> Stop-Service winlogbeat
 === Step 6: Loading Sample Kibana Dashboards
 
 To make it easier for you to start monitoring your servers in Kibana,
-we have created a few sample dashboards. The dashboards are maintained in this
-https://github.com/elastic/beats-dashboards[GitHub repository], which also
-includes instructions for loading the dashboards.
+we have created a sample Winlogbeat dashboard. This dashboard is provided as
+an example. We recommend that you
+http://www.elastic.co/guide/en/kibana/current/dashboard.html[customize] it
+to meet your needs.
 
-For more information about loading and viewing the dashboards, see {libbeat}/visualizing-data.html[Visualizing Your Data in Kibana].
+For more information about loading and viewing the Beats dashboards, see
+{libbeat}/visualizing-data.html[Visualizing Your Data in Kibana].
 
 image:./images/winlogbeat-dashboard.png[Winlogbeat statistics]
-
-These dashboards are provided as examples. We recommend that you
-http://www.elastic.co/guide/en/kibana/current/dashboard.html[customize] them
-to meet your needs.


### PR DESCRIPTION
Removed the link that points to GitHub because the dashboards from the master branch in the beats-dashboards repo will not work in 1.2. Instead, the topic contains a link that points to the instructions for downloading the package that contains the dashboards.

Note that the same changes were added to the 5.0 docs through a different PR. I didn't cherry pick the commit because it contained other stuff that I didn't want in 1.2.