### PR TITLE
Filebeat: added chunk-splitting in addition to newline splitting to filebeats.

### DIFF
--- a/filebeat/config/config.go
+++ b/filebeat/config/config.go
@@ -63,6 +63,7 @@ type HarvesterConfig struct {
 	DocumentType       string `config:"document_type"`
 	Encoding           string `config:"encoding"`
 	InputType          string `config:"input_type"`
+	ChunkSize          int    `config:"chunk_size"`
 	TailFiles          bool   `config:"tail_files"`
 	Backoff            string `config:"backoff"`
 	BackoffDuration    time.Duration

--- a/filebeat/crawler/prospector.go
+++ b/filebeat/crawler/prospector.go
@@ -173,6 +173,8 @@ func (p *Prospector) setupHarvesterConfig() error {
 	}
 	logp.Info("input_type set to: %v", config.InputType)
 
+	logp.Info("chunk_size set to: %v", config.ChunkSize)
+
 	config.BackoffDuration, err = getConfigDuration(config.Backoff, cfg.DefaultBackoff, "backoff")
 	if err != nil {
 		return err

--- a/filebeat/etc/beat.yml
+++ b/filebeat/etc/beat.yml
@@ -52,6 +52,9 @@ filebeat:
         # be used.
         #add_error_key: false
 
+      # If chunk_size is set, the input is read in chunks of given byte-length instead of lines
+      #chunk_size: 200 
+
       # Exclude lines. A list of regular expressions to match. It drops the lines that are
       # matching any regular expression from the list. The include_lines is called before
       # exclude_lines. By default, no lines are dropped.
@@ -191,4 +194,3 @@ filebeat:
   # the prospector part is processed. All global options like spool_size are ignored.
   # The config_dir MUST point to a different directory then where the main filebeat config file is in.
   #config_dir:
-

--- a/filebeat/filebeat.yml
+++ b/filebeat/filebeat.yml
@@ -53,7 +53,7 @@ filebeat:
         #add_error_key: false
 
       # If chunk_size is set, the input is read in chunks of given byte-length instead of lines
-      # chunk_size: 200
+      #chunk_size: 200 
 
       # Exclude lines. A list of regular expressions to match. It drops the lines that are
       # matching any regular expression from the list. The include_lines is called before
@@ -194,7 +194,6 @@ filebeat:
   # the prospector part is processed. All global options like spool_size are ignored.
   # The config_dir MUST point to a different directory then where the main filebeat config file is in.
   #config_dir:
-
 ###############################################################################
 ############################# Libbeat Config ##################################
 # Base config file used by all other beats for using libbeat features
@@ -468,3 +467,5 @@ logging:
   # Sets log level. The default log level is error.
   # Available log levels are: critical, error, warning, info, debug
   #level: error
+
+

--- a/filebeat/filebeat.yml
+++ b/filebeat/filebeat.yml
@@ -52,6 +52,9 @@ filebeat:
         # be used.
         #add_error_key: false
 
+      # If chunk_size is set, the input is read in chunks of given byte-length instead of lines
+      # chunk_size: 200
+
       # Exclude lines. A list of regular expressions to match. It drops the lines that are
       # matching any regular expression from the list. The include_lines is called before
       # exclude_lines. By default, no lines are dropped.
@@ -465,5 +468,3 @@ logging:
   # Sets log level. The default log level is error.
   # Available log levels are: critical, error, warning, info, debug
   #level: error
-
-

--- a/filebeat/harvester/encoding/reader.go
+++ b/filebeat/harvester/encoding/reader.go
@@ -171,3 +171,105 @@ func (l *LineReader) decode(end int) (int, error) {
 	l.byteCount += start
 	return start, err
 }
+
+type ChunkReader struct {
+	rawInput   io.Reader
+	codec      encoding.Encoding
+	bufferSize int
+	chunkSize int
+
+	buffer  *streambuf.Buffer
+	rawBuffer *streambuf.Buffer
+	byteCount int // number of bytes decoded from input buffer into output buffer
+	decoder   transform.Transformer
+}
+
+// chunkReader reads chunks given a defined byte size from underlying reader,
+// decoding the input stream using the configured codec.
+func NewChunkReader(
+	input io.Reader,
+	codec encoding.Encoding,
+	chunkSize int,
+	bufferSize int,
+) (*ChunkReader, error) {
+	l := &ChunkReader{}
+
+	if err := l.init(input, codec, chunkSize, bufferSize); err != nil {
+		return nil, err
+	}
+	return l, nil
+}
+
+func (l *ChunkReader) init(
+	input io.Reader,
+	codec encoding.Encoding,
+	chunkSize int,
+	bufferSize int,
+) error {
+	l.rawInput = input
+	l.codec = codec
+	l.chunkSize = chunkSize
+	l.bufferSize = bufferSize
+
+	l.decoder = l.codec.NewDecoder()
+	l.buffer = streambuf.New(nil)
+	l.rawBuffer = streambuf.New(nil)
+	return nil
+}
+
+func (l *ChunkReader) Next() ([]byte, int, error) {
+	for l.rawBuffer.Len() < l.chunkSize {
+		n := 0
+		buf := make([]byte, l.bufferSize)
+		n, err := l.rawInput.Read(buf)
+		l.rawBuffer.Append(buf[:n])
+		if n == 0 {
+			if err != nil {
+				return nil, 0, err
+			}
+			return nil, 0, streambuf.ErrNoMoreBytes
+		}
+	}
+
+	// output chunk from the rawBuffer and reset the buffer
+	bytes, err := l.rawBuffer.Collect(l.chunkSize);
+	l.rawBuffer.Reset()
+	if err != nil {
+		// This should never happen as otherwise we have a broken state
+		panic(err)
+	}
+	// Decode data using provided codec
+	decodedBytes, _ := l.decode(bytes)
+	return decodedBytes, l.chunkSize, nil
+}
+
+// Decode data using given codec
+func (l *ChunkReader) decode(input []byte) ([]byte, error) {
+	var err error
+	buffer := make([]byte, 1024)
+	decoded := 0
+
+	for decoded < l.chunkSize {
+		var nDst, nSrc int
+
+		nDst, nSrc, err = l.decoder.Transform(buffer, input[decoded:], false)
+		decoded += nSrc
+
+		l.buffer.Write(buffer[:nDst])
+
+		if err != nil {
+			if err == transform.ErrShortDst { // continue transforming
+				continue
+			}
+			if err == transform.ErrShortSrc {
+				err = nil;
+				break;
+			}
+			break
+		}
+	}
+	resdata := l.buffer.Bytes()
+	l.buffer.Collect(l.buffer.Len())
+	l.buffer.Reset();
+	return resdata, err
+}

--- a/filebeat/harvester/encoding/reader.go
+++ b/filebeat/harvester/encoding/reader.go
@@ -176,9 +176,9 @@ type ChunkReader struct {
 	rawInput   io.Reader
 	codec      encoding.Encoding
 	bufferSize int
-	chunkSize int
+	chunkSize  int
 
-	buffer  *streambuf.Buffer
+	buffer    *streambuf.Buffer
 	rawBuffer *streambuf.Buffer
 	byteCount int // number of bytes decoded from input buffer into output buffer
 	decoder   transform.Transformer
@@ -232,7 +232,7 @@ func (l *ChunkReader) Next() ([]byte, int, error) {
 	}
 
 	// output chunk from the rawBuffer and reset the buffer
-	bytes, err := l.rawBuffer.Collect(l.chunkSize);
+	bytes, err := l.rawBuffer.Collect(l.chunkSize)
 	l.rawBuffer.Reset()
 	if err != nil {
 		// This should never happen as otherwise we have a broken state
@@ -262,14 +262,14 @@ func (l *ChunkReader) decode(input []byte) ([]byte, error) {
 				continue
 			}
 			if err == transform.ErrShortSrc {
-				err = nil;
-				break;
+				err = nil
+				break
 			}
 			break
 		}
 	}
 	resdata := l.buffer.Bytes()
 	l.buffer.Collect(l.buffer.Len())
-	l.buffer.Reset();
+	l.buffer.Reset()
 	return resdata, err
 }

--- a/filebeat/harvester/log.go
+++ b/filebeat/harvester/log.go
@@ -38,7 +38,7 @@ func createLineReader(
 	if chunkSize <= 0 {
 		p, err = processor.NewLineSource(fileReader, codec, bufferSize)
 	} else {
-		p, err = processor.NewChunkSource(fileReader, codec, chunkSize, bufferSize);
+		p, err = processor.NewChunkSource(fileReader, codec, chunkSize, bufferSize)
 	}
 	if err != nil {
 		return nil, err

--- a/filebeat/harvester/log.go
+++ b/filebeat/harvester/log.go
@@ -22,6 +22,7 @@ func createLineReader(
 	codec encoding.Encoding,
 	bufferSize int,
 	maxBytes int,
+	chunkSize int,
 	readerConfig logFileReaderConfig,
 	jsonConfig *config.JSONConfig,
 	mlrConfig *config.MultilineConfig,
@@ -34,7 +35,11 @@ func createLineReader(
 		return nil, err
 	}
 
-	p, err = processor.NewLineSource(fileReader, codec, bufferSize)
+	if chunkSize <= 0 {
+		p, err = processor.NewLineSource(fileReader, codec, bufferSize)
+	} else {
+		p, err = processor.NewChunkSource(fileReader, codec, chunkSize, bufferSize);
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +108,7 @@ func (h *Harvester) Harvest() {
 	}
 
 	reader, err := createLineReader(
-		h.file, enc, config.BufferSize, config.MaxBytes, readerConfig,
+		h.file, enc, config.BufferSize, config.MaxBytes, config.ChunkSize, readerConfig,
 		config.JSON, config.Multiline)
 	if err != nil {
 		logp.Err("Stop Harvesting. Unexpected encoding line reader error: %s", err)

--- a/filebeat/harvester/log_test.go
+++ b/filebeat/harvester/log_test.go
@@ -64,7 +64,7 @@ func TestReadLine(t *testing.T) {
 		maxBackoffDuration: 1 * time.Second,
 		backoffFactor:      2,
 	}
-	reader, _ := createLineReader(fileSource{readFile}, codec, 100, 1000, readConfig, nil, nil)
+	reader, _ := createLineReader(fileSource{readFile}, codec, 100, 1000, 0, readConfig, nil, nil)
 
 	// Read third line
 	_, text, bytesread, _, err := readLine(reader)

--- a/filebeat/harvester/processor/processor.go
+++ b/filebeat/harvester/processor/processor.go
@@ -39,6 +39,12 @@ type LineSource struct {
 	reader *encoding.LineReader
 }
 
+// LineSource produces lines by reading lines from an io.Reader
+// through a decoder converting the reader it's encoding to utf-8.
+type ChunkSource struct {
+	reader *encoding.ChunkReader
+}
+
 // StripNewline processor removes the last trailing newline characters from
 // read lines.
 type StripNewline struct {
@@ -70,6 +76,23 @@ func NewLineSource(
 
 // Next reads the next line from it's initial io.Reader
 func (p LineSource) Next() (Line, error) {
+	c, sz, err := p.reader.Next()
+	return Line{Ts: time.Now(), Content: c, Bytes: sz}, err
+}
+
+func NewChunkSource(
+	in io.Reader,
+	codec encoding.Encoding,
+	chunkSize int,
+	bufferSize int,
+) (ChunkSource, error) {
+	r, err := encoding.NewChunkReader(in, codec, chunkSize, bufferSize)
+	return ChunkSource{r}, err
+}
+
+// NewChunkSource creates a new ChunkSource from input reader by applying
+// the given codec
+func (p ChunkSource) Next() (Line, error) {
 	c, sz, err := p.reader.Next()
 	return Line{Ts: time.Now(), Content: c, Bytes: sz}, err
 }


### PR DESCRIPTION
There are some logs (notably SAP audit logs) that are not line-oriented, but rather chunk oriented (i.e. each text record is exactly 200 bytes). I am not sure if it fits within the filebeats framework, but it seems to work correctly. 
