### PR TITLE
Adjust prospector log to use reference

### DIFF
--- a/filebeat/crawler/prospector_log.go
+++ b/filebeat/crawler/prospector_log.go
@@ -36,12 +36,12 @@ func NewProspectorLog(p *Prospector) (*ProspectorLog, error) {
 	return prospectorer, nil
 }
 
-func (p ProspectorLog) Init() {
+func (p *ProspectorLog) Init() {
 	logp.Debug("prospector", "exclude_files: %s", p.config.ExcludeFiles)
 	p.scan()
 }
 
-func (p ProspectorLog) Run() {
+func (p *ProspectorLog) Run() {
 
 	logp.Debug("prospector", "Start next scan")
 	p.scan()
@@ -61,7 +61,7 @@ func (p ProspectorLog) Run() {
 }
 
 // Scan starts a scanGlob for each provided path/glob
-func (p ProspectorLog) scan() {
+func (p *ProspectorLog) scan() {
 
 	newlastscan := time.Now()
 
@@ -74,7 +74,7 @@ func (p ProspectorLog) scan() {
 
 // Scans the specific path which can be a glob (/**/**/*.log)
 // For all found files it is checked if a harvester should be started
-func (p ProspectorLog) scanGlob(glob string) {
+func (p *ProspectorLog) scanGlob(glob string) {
 
 	logp.Debug("prospector", "scan path %s", glob)
 
@@ -145,7 +145,7 @@ func (p ProspectorLog) scanGlob(glob string) {
 
 // Check if harvester for new file has to be started
 // For a new file the following options exist:
-func (p ProspectorLog) checkNewFile(h *harvester.Harvester) {
+func (p *ProspectorLog) checkNewFile(h *harvester.Harvester) {
 
 	logp.Debug("prospector", "Start harvesting unknown file: %s", h.Path)
 
@@ -179,7 +179,7 @@ func (p ProspectorLog) checkNewFile(h *harvester.Harvester) {
 
 // checkOldFile returns true if the given file is currently not harvested
 // and the last time was modified before ignore_older
-func (p ProspectorLog) checkOldFile(h *harvester.Harvester) bool {
+func (p *ProspectorLog) checkOldFile(h *harvester.Harvester) bool {
 
 	// Resuming never needed if ignore_older disabled
 	if p.config.IgnoreOlderDuration == 0 {
@@ -208,7 +208,7 @@ func (p ProspectorLog) checkOldFile(h *harvester.Harvester) bool {
 // * The new file is not the same as the old file, means file was renamed
 // ** New file is actually really a new file, start a new harvester
 // ** Renamed file has a state, continue there
-func (p ProspectorLog) checkExistingFile(h *harvester.Harvester, newFile *input.File, oldFile *input.File) {
+func (p *ProspectorLog) checkExistingFile(h *harvester.Harvester, newFile *input.File, oldFile *input.File) {
 
 	logp.Debug("prospector", "Update existing file for harvesting: %s", h.Path)
 
@@ -247,7 +247,7 @@ func (p ProspectorLog) checkExistingFile(h *harvester.Harvester, newFile *input.
 // Continue reading on an existing file.
 // The given file was renamed from another file we know -> The same harvester channel is linked as the old file
 // The file param is only used for logging
-func (p ProspectorLog) continueExistingFile(h *harvester.Harvester, previousFile string) {
+func (p *ProspectorLog) continueExistingFile(h *harvester.Harvester, previousFile string) {
 	logp.Debug("prospector", "Launching harvester on renamed file. File rename was detected: %s -> %s", previousFile, h.Path)
 
 	lastinfo := p.prospectorList[previousFile]
@@ -255,7 +255,7 @@ func (p ProspectorLog) continueExistingFile(h *harvester.Harvester, previousFile
 }
 
 // Start / resume harvester with a predefined offset
-func (p ProspectorLog) resumeHarvesting(h *harvester.Harvester, offset int64) {
+func (p *ProspectorLog) resumeHarvesting(h *harvester.Harvester, offset int64) {
 
 	logp.Debug("prospector", "Start / resuming harvester of file: %s", h.Path)
 	h.Offset = offset
@@ -265,7 +265,7 @@ func (p ProspectorLog) resumeHarvesting(h *harvester.Harvester, offset int64) {
 // Check if the given file was renamed. If file is known but with different path,
 // the previous file path will be returned. If no file is found, an error
 // will be returned.
-func (p ProspectorLog) getPreviousFile(file string, info os.FileInfo) (string, error) {
+func (p *ProspectorLog) getPreviousFile(file string, info os.FileInfo) (string, error) {
 
 	for path, pFileStat := range p.prospectorList {
 		if path == file {
@@ -288,7 +288,7 @@ func (p ProspectorLog) getPreviousFile(file string, info os.FileInfo) (string, e
 	return "", fmt.Errorf("No previous file found")
 }
 
-func (p ProspectorLog) isFileExcluded(file string) bool {
+func (p *ProspectorLog) isFileExcluded(file string) bool {
 
 	if len(p.config.ExcludeFilesRegexp) > 0 {
 

--- a/packetbeat/protos/nfs/nfs.go
+++ b/packetbeat/protos/nfs/nfs.go
@@ -1,8 +1,9 @@
 package nfs
 
 import (
-	"github.com/elastic/beats/libbeat/common"
 	"time"
+
+	"github.com/elastic/beats/libbeat/common"
 )
 
 type Nfs struct {

--- a/packetbeat/protos/nfs/rpc_message.go
+++ b/packetbeat/protos/nfs/rpc_message.go
@@ -2,9 +2,10 @@ package nfs
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/packetbeat/publish"
-	"time"
 )
 
 const (

--- a/packetbeat/protos/nfs/xdr_test.go
+++ b/packetbeat/protos/nfs/xdr_test.go
@@ -1,8 +1,9 @@
 package nfs
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 var test_msg = []byte{


### PR DESCRIPTION
There were not errors reported for this yet, but as also state is modified the reference should be used.

See also https://github.com/elastic/beats/pull/1274