### PR TITLE
Introduce Filters for metricbeat modules

### DIFF
--- a/libbeat/filter/filter.go
+++ b/libbeat/filter/filter.go
@@ -65,6 +65,11 @@ func (filters *FilterList) Get(index int) FilterRule {
 // Applies a sequence of filtering rules and returns the filtered event
 func (filters *FilterList) Filter(event common.MapStr) common.MapStr {
 
+	// Check if filters are set, just return event if not
+	if len(filters.filters) == 0 {
+		return event
+	}
+
 	// clone the event at first, before starting filtering
 	filtered := event.Clone()
 	var err error

--- a/metricbeat/etc/beat.yml
+++ b/metricbeat/etc/beat.yml
@@ -33,11 +33,6 @@ metricbeat:
       # should never take longer then period, as otherwise calls can pile up.
       #timeout: 1s
 
-      # Selectors to only fetch a subset of metrics (whitelisting)
-      # If no selectors are set, all metrics are sent.
-      # Use filters for a more fine grained filtering.
-      #selectors: []
-
       # Optional fields to be added to each event
       #fields:
       #  datacenter: west
@@ -48,7 +43,10 @@ metricbeat:
       # Max number of concurrent connections. Default: 10
       #maxconn: 10
 
-      #filter: ...
+      # Filters can be used to reduce the number of fields sent.
+      #filters:
+      #  - include_fields:
+      #      fields: ["stats"]
 
       # Redis AUTH password. Empty by default.
       #password: foobared

--- a/metricbeat/helper/interfacer.go
+++ b/metricbeat/helper/interfacer.go
@@ -12,6 +12,7 @@ package helper
 
 import (
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/filter"
 )
 
 /*
@@ -25,13 +26,13 @@ an identifier for each fetch call and it would have to be decide, which fetch ca
 
 // Base configuration for each module/metricsets combination
 type ModuleConfig struct {
-	Hosts      []string `config:"hosts"`
-	Period     string   `config:"period"`
-	Timeout    string   `config:"timeout"`
-	Module     string   `config:"module"`
-	MetricSets []string `config:"metricsets"`
-	Enabled    bool     `config:"enabled"`
-	Selectors  []string `config:"selectors"`
+	Hosts      []string              `config:"hosts"`
+	Period     string                `config:"period"`
+	Timeout    string                `config:"timeout"`
+	Module     string                `config:"module"`
+	MetricSets []string              `config:"metricsets"`
+	Enabled    bool                  `config:"enabled"`
+	Filters    []filter.FilterConfig `config:"filters"`
 
 	common.EventMetadata `config:",inline"` // Fields and tags to add to events.
 }

--- a/metricbeat/helper/metricset.go
+++ b/metricbeat/helper/metricset.go
@@ -125,7 +125,10 @@ func (m *MetricSet) createEvent(event common.MapStr, host string, rtt time.Durat
 	// Each metricset has a unique eventfieldname to prevent type conflicts
 	eventFieldName := m.Module.name + "-" + m.Name
 
-	event = applySelector(event, m.Config.Selectors)
+	// Makes sure filters are set and applies them
+	if m.Module.filters != nil {
+		event = m.Module.filters.Filter(event)
+	}
 
 	event = common.MapStr{
 		"type":                  typeName,
@@ -155,27 +158,6 @@ func (m *MetricSet) createEvent(event common.MapStr, host string, rtt time.Durat
 	}
 
 	return event
-}
-
-func applySelector(event common.MapStr, selectors []string) common.MapStr {
-
-	// No selectors set means return full events
-	if len(selectors) == 0 {
-		return event
-	}
-
-	newEvent := common.MapStr{}
-	logp.Debug("metricset", "Applying selectors: %v", selectors)
-
-	for _, selector := range selectors {
-
-		if value, ok := event[selector]; ok {
-			newEvent[selector] = value
-		}
-
-	}
-
-	return newEvent
 }
 
 // incrementFetcher increments the number of open fetcher

--- a/metricbeat/helper/metricset_test.go
+++ b/metricbeat/helper/metricset_test.go
@@ -42,60 +42,6 @@ func TestMetricSetTwoInstances(t *testing.T) {
 	assert.Equal(t, 1, event["counter"])
 }
 
-func TestApplySelectorEmpty(t *testing.T) {
-	event := common.MapStr{
-		"hello": "world",
-	}
-
-	newEvent := applySelector(event, []string{})
-
-	assert.Equal(t, event, newEvent)
-}
-
-func TestApplySelectorOne(t *testing.T) {
-	event := common.MapStr{
-		"hello": "world",
-		"test":  "value",
-	}
-
-	newEvent := applySelector(event, []string{"hello"})
-
-	assert.Equal(t, common.MapStr{"hello": "world"}, newEvent)
-}
-
-func TestApplySelectorNotExistant(t *testing.T) {
-	event := common.MapStr{
-		"hello": "world",
-		"test":  "value",
-		"cpu":   100,
-	}
-
-	newEvent := applySelector(event, []string{"hello", "notexistant"})
-
-	assert.Equal(t, common.MapStr{"hello": "world"}, newEvent)
-}
-
-func TestApplySelectorTwoNested(t *testing.T) {
-	event := common.MapStr{
-		"cpu": common.MapStr{
-			"p0": 100,
-		},
-		"test": "value",
-		"disk": common.MapStr{
-			"hd": "not available",
-		},
-	}
-
-	newEvent := applySelector(event, []string{"test", "disk"})
-
-	assert.Equal(t, common.MapStr{
-		"test": "value",
-		"disk": common.MapStr{
-			"hd": "not available",
-		},
-	}, newEvent)
-}
-
 func TestCreateEvent(t *testing.T) {
 	module := &Module{}
 	metricSet, _ := NewMetricSet("mockmetricset1", NewMockMetricSeter, module)

--- a/metricbeat/metricbeat.yml
+++ b/metricbeat/metricbeat.yml
@@ -33,11 +33,6 @@ metricbeat:
       # should never take longer then period, as otherwise calls can pile up.
       #timeout: 1s
 
-      # Selectors to only fetch a subset of metrics (whitelisting)
-      # If no selectors are set, all metrics are sent.
-      # Use filters for a more fine grained filtering.
-      #selectors: []
-
       # Optional fields to be added to each event
       #fields:
       #  datacenter: west
@@ -48,7 +43,10 @@ metricbeat:
       # Max number of concurrent connections. Default: 10
       #maxconn: 10
 
-      #filter: ...
+      # Filters can be used to reduce the number of fields sent.
+      #filters:
+      #  - include_fields:
+      #      fields: ["stats"]
 
       # Redis AUTH password. Empty by default.
       #password: foobared

--- a/metricbeat/tests/system/config/metricbeat.yml.j2
+++ b/metricbeat/tests/system/config/metricbeat.yml.j2
@@ -8,7 +8,11 @@ metricbeat:
         - info
       period: 2s
       enabled: true
-      selectors: {{ redis_selectors }}
+      {% if redis_include_fields %}
+      filters:
+        - include_fields:
+            fields: {{ redis_include_fields }}
+      {% endif %}
     {% endif %}
     {% if mysql %}
     - module: mysql:

--- a/metricbeat/tests/system/test_redis.py
+++ b/metricbeat/tests/system/test_redis.py
@@ -48,15 +48,15 @@ class RedisInfoTest(metricbeat.BaseTest):
         #self.assert_fields_are_documented(evt)
 
     @attr('integration')
-    def test_selectors(self):
+    def test_filters(self):
         """
-        Redis selectors filter the event.
+        Test filters for Redis info event.
         """
-        selectors = ["clients", "cpu"]
+        fields = ["clients", "cpu"]
         self.render_config_template(
             redis=True,
             redis_host=os.getenv('REDIS_HOST'),
-            redis_selectors=selectors
+            redis_include_fields=fields
         )
         proc = self.start_beat()
         self.wait_until(
@@ -74,6 +74,6 @@ class RedisInfoTest(metricbeat.BaseTest):
 
         self.assertItemsEqual(REDIS_FIELDS, evt.keys())
         redis_info = evt["redis-info"]
-        self.assertItemsEqual(selectors, redis_info.keys())
+        self.assertItemsEqual(fields, redis_info.keys())
         self.assertItemsEqual(CLIENTS_FIELDS, redis_info["clients"].keys())
         self.assertItemsEqual(CPU_FIELDS, redis_info["cpu"].keys())


### PR DESCRIPTION
Replace selectors through filters as selectors are now not needed anymore. The following to examples are identical:

Before
```
selectors: ["stats"]
```

After
```
filters:
  - include_fields:
      fields: ["stats"]
```