### PR TITLE
Look for the .winlogbeat.yml in the data path

### DIFF
--- a/dev-tools/packer/platforms/windows/install-service.ps1.j2
+++ b/dev-tools/packer/platforms/windows/install-service.ps1.j2
@@ -11,4 +11,4 @@ $workdir = Split-Path $MyInvocation.MyCommand.Path
 # create new service
 New-Service -name {{.beat_name}} `
   -displayName {{.beat_name}} `
-  -binaryPathName "`"$workdir\\{{.beat_name}}.exe`" -c `"$workdir\\{{.beat_name}}.yml`""
+  -binaryPathName "`"$workdir\\{{.beat_name}}.exe`" -c `"$workdir\\{{.beat_name}}.yml`" -path.home `"$workdir`" -path.data `"C:\\ProgramData\\{{.beat_name}}`""

--- a/winlogbeat/Makefile
+++ b/winlogbeat/Makefile
@@ -13,7 +13,6 @@ gen:
 .PHONY: before-build
 before-build:
 	# Windows
-	sed -i 's|#\{0,1\}\(registry_file:\).*|\1 C:/ProgramData/winlogbeat/.winlogbeat.yml|' $(PREFIX)/$(BEATNAME)-win.yml
 	sed -i 's|#\{0,1\}\(to_files:\).*|\1 true|' $(PREFIX)/$(BEATNAME)-win.yml
 	sed -i 's|#\{0,1\}\(level:\).*|\1 info|' $(PREFIX)/$(BEATNAME)-win.yml
 	sed -i '/log files/{n;s|#\{0,1\}path:.*|path: C:/ProgramData/winlogbeat/Logs|}' $(PREFIX)/$(BEATNAME)-win.yml

--- a/winlogbeat/beater/winlogbeat.go
+++ b/winlogbeat/beater/winlogbeat.go
@@ -5,13 +5,13 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"path/filepath"
 	"sync"
 	"time"
 
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/paths"
 	"github.com/elastic/beats/libbeat/publisher"
 	"github.com/elastic/beats/winlogbeat/checkpoint"
 	"github.com/elastic/beats/winlogbeat/config"
@@ -72,12 +72,7 @@ func (eb *Winlogbeat) Config(b *beat.Beat) error {
 	if eb.config.Winlogbeat.RegistryFile == "" {
 		eb.config.Winlogbeat.RegistryFile = config.DefaultRegistryFile
 	}
-	eb.config.Winlogbeat.RegistryFile, err = filepath.Abs(
-		eb.config.Winlogbeat.RegistryFile)
-	if err != nil {
-		return fmt.Errorf("Error getting absolute path of registry file %s. %v",
-			eb.config.Winlogbeat.RegistryFile, err)
-	}
+	eb.config.Winlogbeat.RegistryFile = paths.Resolve(paths.Data, eb.config.Winlogbeat.RegistryFile)
 	logp.Info("State will be read from and persisted to %s",
 		eb.config.Winlogbeat.RegistryFile)
 


### PR DESCRIPTION
Also set data path to `c:\ProgramData\Beatname` when running as a service.

I didn't rename `.winlogbeat.yml` to avoid breaking compatibility. @andrewkroh do you prefer keeping like it is or renaming it to `registry` to be consistent with Filebeat?