### PR TITLE
Add condition to filters

### DIFF
--- a/libbeat/common/mapstr.go
+++ b/libbeat/common/mapstr.go
@@ -154,6 +154,29 @@ func (m MapStr) HasKey(key string) (bool, error) {
 	return true, nil
 }
 
+func (m MapStr) GetValue(key string) (interface{}, error) {
+
+	keyParts := strings.Split(key, ".")
+	keyPartsLen := len(keyParts)
+
+	mapp := m
+	for i := 0; i < keyPartsLen; i++ {
+		keyPart := keyParts[i]
+
+		if _, ok := mapp[keyPart]; ok {
+			if i < keyPartsLen-1 {
+				mapp, ok = mapp[keyPart].(MapStr)
+				if !ok {
+					return nil, fmt.Errorf("Unknown type of %s key", keyPart)
+				}
+			}
+		} else {
+			return nil, fmt.Errorf("Missing %s key", keyPart)
+		}
+	}
+	return mapp[keyParts[keyPartsLen-1]], nil
+}
+
 func (m MapStr) StringToPrint() string {
 	json, err := json.MarshalIndent(m, "", "  ")
 	if err != nil {

--- a/libbeat/filter/condition.go
+++ b/libbeat/filter/condition.go
@@ -217,25 +217,25 @@ func (c *Condition) CheckRange(event common.MapStr) bool {
 			}
 
 		case uint, uint8, uint16, uint32, uint64:
-			float_value := reflect.ValueOf(value).Uint()
+			uint_value := reflect.ValueOf(value).Uint()
 
 			if rangeValue.Gte != nil {
-				if float_value < uint64(*rangeValue.Gte) {
+				if uint_value < uint64(*rangeValue.Gte) {
 					return false
 				}
 			}
 			if rangeValue.Gt != nil {
-				if float_value <= uint64(*rangeValue.Gt) {
+				if uint_value <= uint64(*rangeValue.Gt) {
 					return false
 				}
 			}
 			if rangeValue.Lte != nil {
-				if float_value > uint64(*rangeValue.Lte) {
+				if uint_value > uint64(*rangeValue.Lte) {
 					return false
 				}
 			}
 			if rangeValue.Lt != nil {
-				if float_value >= uint64(*rangeValue.Lt) {
+				if uint_value >= uint64(*rangeValue.Lt) {
 					return false
 				}
 			}

--- a/libbeat/filter/condition.go
+++ b/libbeat/filter/condition.go
@@ -1,0 +1,304 @@
+package filter
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/logp"
+)
+
+type EqualsValue struct {
+	Int int
+	Str string
+}
+
+type Condition struct {
+	Equals   map[string]EqualsValue
+	Contains map[string]string
+	Regexp   map[string]*regexp.Regexp
+	Range    map[string]RangeValue
+}
+
+func NewCondition(config ConditionConfig) (*Condition, error) {
+
+	c := Condition{}
+	c.Equals = map[string]EqualsValue{}
+	c.Contains = map[string]string{}
+	c.Regexp = map[string]*regexp.Regexp{}
+	c.Range = map[string]RangeValue{}
+
+	if err := c.AddEquals(config.Equals); err != nil {
+		return nil, err
+	}
+	if err := c.AddContains(config.Contains); err != nil {
+		return nil, err
+	}
+	if err := c.AddRegexp(config.Regexp); err != nil {
+		return nil, err
+	}
+	if err := c.AddRange(config.Range); err != nil {
+		return nil, err
+	}
+
+	return &c, nil
+}
+
+func (c *Condition) AddEquals(equals map[string]string) error {
+
+	for field, value := range equals {
+
+		i, err := strconv.Atoi(value)
+		if err == nil {
+			c.Equals[field] = EqualsValue{Int: i}
+		} else {
+			c.Equals[field] = EqualsValue{Str: value}
+		}
+	}
+	return nil
+}
+
+func (c *Condition) AddContains(contains map[string]string) error {
+
+	c.Contains = contains
+	return nil
+}
+
+func (c *Condition) AddRegexp(r map[string]string) error {
+
+	for field, value := range r {
+		reg, err := regexp.CompilePOSIX(value)
+		if err != nil {
+			return err
+		}
+		c.Regexp[field] = reg
+	}
+	return nil
+}
+
+func (c *Condition) AddRange(config map[string]RangeValue) error {
+
+	for field, rangeValue := range config {
+		c.Range[field] = rangeValue
+	}
+	return nil
+}
+
+func (c *Condition) Check(event common.MapStr) bool {
+
+	if !c.CheckEquals(event) {
+		return false
+	}
+	if !c.CheckContains(event) {
+		return false
+	}
+	if !c.CheckRegexp(event) {
+		return false
+	}
+	if !c.CheckRange(event) {
+		return false
+	}
+
+	return true
+}
+
+func (c *Condition) CheckEquals(event common.MapStr) bool {
+
+	for field, equalValue := range c.Equals {
+
+		value, err := event.GetValue(field)
+		if err != nil {
+			logp.Err("unavailable field %s: %v", field, err)
+			return false
+		}
+
+		switch value.(type) {
+		case uint8, uint16, uint32, uint64, int8, int16, int32, int64, int, uint:
+			return value == equalValue.Int
+		case string:
+			return value == equalValue.Str
+		default:
+			logp.Err("unexpected type %T in equals condition as it accepts only integers and strings. ", value)
+			return false
+		}
+
+	}
+
+	return true
+
+}
+
+func (c *Condition) CheckContains(event common.MapStr) bool {
+
+	for field, equalValue := range c.Contains {
+
+		value, err := event.GetValue(field)
+		if err != nil {
+			logp.Err("unavailable field %s: %v", field, err)
+			return false
+		}
+
+		switch value.(type) {
+		case string:
+			return strings.Contains(value.(string), equalValue)
+		default:
+			logp.Err("unexpected type %T in contains condition as it accepts only strings. ", value)
+			return false
+		}
+
+	}
+
+	return true
+
+}
+
+func (c *Condition) CheckRegexp(event common.MapStr) bool {
+
+	for field, equalValue := range c.Regexp {
+
+		value, err := event.GetValue(field)
+		if err != nil {
+			logp.Err("unavailable field %s: %v", field, err)
+			return false
+		}
+
+		switch value.(type) {
+		case string:
+			if !equalValue.MatchString(value.(string)) {
+				return false
+			}
+		default:
+			logp.Err("unexpected type %T in regexp condition as it accepts only strings. ", value)
+			return false
+		}
+
+	}
+
+	return true
+
+}
+
+func (c *Condition) CheckRange(event common.MapStr) bool {
+
+	for field, rangeValue := range c.Range {
+
+		value, err := event.GetValue(field)
+		if err != nil {
+			logp.Err("unavailable field %s: %v", field, err)
+			return false
+		}
+
+		switch value.(type) {
+		case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
+			int_value := value.(int)
+
+			if rangeValue.Gte != nil {
+				if int_value < int(*rangeValue.Gte) {
+					return false
+				}
+			}
+			if rangeValue.Gt != nil {
+				if int_value <= int(*rangeValue.Gt) {
+					return false
+				}
+			}
+			if rangeValue.Lte != nil {
+				if int_value > int(*rangeValue.Lte) {
+					return false
+				}
+			}
+			if rangeValue.Lt != nil {
+				if int_value >= int(*rangeValue.Lt) {
+					return false
+				}
+			}
+		case float64, float32:
+			float_value := value.(float64)
+
+			if rangeValue.Gte != nil {
+				if float_value < *rangeValue.Gte {
+					return false
+				}
+			}
+			if rangeValue.Gt != nil {
+				if float_value <= *rangeValue.Gt {
+					return false
+				}
+			}
+			if rangeValue.Lte != nil {
+				if float_value > *rangeValue.Lte {
+					return false
+				}
+			}
+			if rangeValue.Lt != nil {
+				if float_value >= *rangeValue.Lt {
+					return false
+				}
+			}
+
+		default:
+			logp.Err("unexpected type %T in range condition as it accepts only strings. ", value)
+			return false
+		}
+
+	}
+	return true
+}
+
+func (c *Condition) String() string {
+
+	s := ""
+
+	if len(c.Equals) > 0 {
+		s = s + fmt.Sprintf("equals: %v", c.Equals)
+	}
+	if len(c.Contains) > 0 {
+		s = s + fmt.Sprintf("contains: %v", c.Contains)
+	}
+	if len(c.Regexp) > 0 {
+		s = s + fmt.Sprintf("regexp: %v", c.Regexp)
+	}
+	if len(c.Range) > 0 {
+		s = s + fmt.Sprintf("range: %v", c.Range)
+	}
+	return s
+}
+
+func (r RangeValue) String() string {
+
+	s := ""
+	if r.Gte != nil {
+		s = s + fmt.Sprintf(">= %v", *r.Gte)
+	}
+
+	if r.Gt != nil {
+		if len(s) > 0 {
+			s = s + " and "
+		}
+		s = s + fmt.Sprintf("> %v", *r.Gt)
+	}
+
+	if r.Lte != nil {
+		if len(s) > 0 {
+			s = s + " and "
+		}
+		s = s + fmt.Sprintf("<= %v", *r.Lte)
+	}
+	if r.Lt != nil {
+		if len(s) > 0 {
+			s = s + " and "
+		}
+		s = s + fmt.Sprintf("< %v", *r.Lt)
+	}
+	return s
+}
+
+func (e EqualsValue) String() string {
+
+	if len(e.Str) > 0 {
+		return e.Str
+	}
+	return strconv.Itoa(e.Int)
+}

--- a/libbeat/filter/condition.go
+++ b/libbeat/filter/condition.go
@@ -111,7 +111,6 @@ func (c *Condition) CheckEquals(event common.MapStr) bool {
 
 		value, err := event.GetValue(field)
 		if err != nil {
-			logp.Warn("unavailable field %s: %v", field, err)
 			return false
 		}
 
@@ -137,7 +136,6 @@ func (c *Condition) CheckContains(event common.MapStr) bool {
 
 		value, err := event.GetValue(field)
 		if err != nil {
-			logp.Warn("unavailable field %s: %v", field, err)
 			return false
 		}
 
@@ -161,7 +159,6 @@ func (c *Condition) CheckRegexp(event common.MapStr) bool {
 
 		value, err := event.GetValue(field)
 		if err != nil {
-			logp.Warn("unavailable field %s: %v", field, err)
 			return false
 		}
 
@@ -187,7 +184,6 @@ func (c *Condition) CheckRange(event common.MapStr) bool {
 
 		value, err := event.GetValue(field)
 		if err != nil {
-			logp.Warn("unavailable field %s: %v", field, err)
 			return false
 		}
 

--- a/libbeat/filter/condition.go
+++ b/libbeat/filter/condition.go
@@ -111,7 +111,7 @@ func (c *Condition) CheckEquals(event common.MapStr) bool {
 
 		value, err := event.GetValue(field)
 		if err != nil {
-			logp.Err("unavailable field %s: %v", field, err)
+			logp.Warn("unavailable field %s: %v", field, err)
 			return false
 		}
 
@@ -121,7 +121,7 @@ func (c *Condition) CheckEquals(event common.MapStr) bool {
 		case string:
 			return value == equalValue.Str
 		default:
-			logp.Err("unexpected type %T in equals condition as it accepts only integers and strings. ", value)
+			logp.Warn("unexpected type %T in equals condition as it accepts only integers and strings. ", value)
 			return false
 		}
 
@@ -137,7 +137,7 @@ func (c *Condition) CheckContains(event common.MapStr) bool {
 
 		value, err := event.GetValue(field)
 		if err != nil {
-			logp.Err("unavailable field %s: %v", field, err)
+			logp.Warn("unavailable field %s: %v", field, err)
 			return false
 		}
 
@@ -145,7 +145,7 @@ func (c *Condition) CheckContains(event common.MapStr) bool {
 		case string:
 			return strings.Contains(value.(string), equalValue)
 		default:
-			logp.Err("unexpected type %T in contains condition as it accepts only strings. ", value)
+			logp.Warn("unexpected type %T in contains condition as it accepts only strings. ", value)
 			return false
 		}
 
@@ -161,7 +161,7 @@ func (c *Condition) CheckRegexp(event common.MapStr) bool {
 
 		value, err := event.GetValue(field)
 		if err != nil {
-			logp.Err("unavailable field %s: %v", field, err)
+			logp.Warn("unavailable field %s: %v", field, err)
 			return false
 		}
 
@@ -171,7 +171,7 @@ func (c *Condition) CheckRegexp(event common.MapStr) bool {
 				return false
 			}
 		default:
-			logp.Err("unexpected type %T in regexp condition as it accepts only strings. ", value)
+			logp.Warn("unexpected type %T in regexp condition as it accepts only strings. ", value)
 			return false
 		}
 
@@ -187,7 +187,7 @@ func (c *Condition) CheckRange(event common.MapStr) bool {
 
 		value, err := event.GetValue(field)
 		if err != nil {
-			logp.Err("unavailable field %s: %v", field, err)
+			logp.Warn("unavailable field %s: %v", field, err)
 			return false
 		}
 
@@ -265,7 +265,7 @@ func (c *Condition) CheckRange(event common.MapStr) bool {
 			}
 
 		default:
-			logp.Err("unexpected type %T in range condition as it accepts only strings. ", value)
+			logp.Warn("unexpected type %T in range condition as it accepts only strings. ", value)
 			return false
 		}
 

--- a/libbeat/filter/condition.go
+++ b/libbeat/filter/condition.go
@@ -111,6 +111,7 @@ func (c *Condition) CheckEquals(event common.MapStr) bool {
 
 		value, err := event.GetValue(field)
 		if err != nil {
+			logp.Debug("filter", "unavailable field %s: %v", field, err)
 			return false
 		}
 
@@ -136,6 +137,7 @@ func (c *Condition) CheckContains(event common.MapStr) bool {
 
 		value, err := event.GetValue(field)
 		if err != nil {
+			logp.Debug("filter", "unavailable field %s: %v", field, err)
 			return false
 		}
 
@@ -159,6 +161,7 @@ func (c *Condition) CheckRegexp(event common.MapStr) bool {
 
 		value, err := event.GetValue(field)
 		if err != nil {
+			logp.Debug("filter", "unavailable field %s: %v", field, err)
 			return false
 		}
 
@@ -184,6 +187,7 @@ func (c *Condition) CheckRange(event common.MapStr) bool {
 
 		value, err := event.GetValue(field)
 		if err != nil {
+			logp.Debug("filter", "unavailable field %s: %v", field, err)
 			return false
 		}
 

--- a/libbeat/filter/condition.go
+++ b/libbeat/filter/condition.go
@@ -2,6 +2,7 @@ package filter
 
 import (
 	"fmt"
+	"reflect"
 	"regexp"
 	"strconv"
 	"strings"
@@ -191,31 +192,56 @@ func (c *Condition) CheckRange(event common.MapStr) bool {
 		}
 
 		switch value.(type) {
-		case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
-			int_value := value.(int)
+		case int, int8, int16, int32, int64:
+			int_value := reflect.ValueOf(value).Int()
 
 			if rangeValue.Gte != nil {
-				if int_value < int(*rangeValue.Gte) {
+				if int_value < int64(*rangeValue.Gte) {
 					return false
 				}
 			}
 			if rangeValue.Gt != nil {
-				if int_value <= int(*rangeValue.Gt) {
+				if int_value <= int64(*rangeValue.Gt) {
 					return false
 				}
 			}
 			if rangeValue.Lte != nil {
-				if int_value > int(*rangeValue.Lte) {
+				if int_value > int64(*rangeValue.Lte) {
 					return false
 				}
 			}
 			if rangeValue.Lt != nil {
-				if int_value >= int(*rangeValue.Lt) {
+				if int_value >= int64(*rangeValue.Lt) {
 					return false
 				}
 			}
+
+		case uint, uint8, uint16, uint32, uint64:
+			float_value := reflect.ValueOf(value).Uint()
+
+			if rangeValue.Gte != nil {
+				if float_value < uint64(*rangeValue.Gte) {
+					return false
+				}
+			}
+			if rangeValue.Gt != nil {
+				if float_value <= uint64(*rangeValue.Gt) {
+					return false
+				}
+			}
+			if rangeValue.Lte != nil {
+				if float_value > uint64(*rangeValue.Lte) {
+					return false
+				}
+			}
+			if rangeValue.Lt != nil {
+				if float_value >= uint64(*rangeValue.Lt) {
+					return false
+				}
+			}
+
 		case float64, float32:
-			float_value := value.(float64)
+			float_value := reflect.ValueOf(value).Float()
 
 			if rangeValue.Gte != nil {
 				if float_value < *rangeValue.Gte {

--- a/libbeat/filter/condition.go
+++ b/libbeat/filter/condition.go
@@ -11,11 +11,6 @@ import (
 	"github.com/elastic/beats/libbeat/logp"
 )
 
-type EqualsValue struct {
-	Int int
-	Str string
-}
-
 type Condition struct {
 	Equals   map[string]EqualsValue
 	Contains map[string]string

--- a/libbeat/filter/condition_test.go
+++ b/libbeat/filter/condition_test.go
@@ -1,0 +1,280 @@
+package filter
+
+import (
+	"testing"
+
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/logp"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEqualsCondition(t *testing.T) {
+
+	if testing.Verbose() {
+		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"*"})
+	}
+
+	config1 := ConditionConfig{
+		Equals: map[string]string{
+			"type": "process",
+		},
+	}
+	cond1, err := NewCondition(config1)
+	assert.True(t, err == nil)
+
+	config2 := ConditionConfig{
+		Equals: map[string]string{
+			"proc.pid": "305",
+		},
+	}
+	cond2, err := NewCondition(config2)
+	assert.True(t, err == nil)
+
+	config3 := ConditionConfig{
+		Equals: map[string]string{
+			"proc.pid": "0.08",
+		},
+	}
+	cond3, err := NewCondition(config3)
+	assert.True(t, err == nil)
+
+	config4 := ConditionConfig{
+		Equals: map[string]string{
+			"proc.cpu.total_p": "0.08",
+		},
+	}
+	cond4, err := NewCondition(config4)
+	assert.True(t, err == nil)
+
+	event := common.MapStr{
+		"@timestamp": "2016-04-14T20:41:06.258Z",
+		"proc": common.MapStr{
+			"cmdline": "/usr/libexec/secd",
+			"cpu": common.MapStr{
+				"start_time": "Apr10",
+				"system":     1988,
+				"total":      6029,
+				"total_p":    0.08,
+				"user":       4041,
+			},
+			"name":     "secd",
+			"pid":      305,
+			"ppid":     1,
+			"state":    "running",
+			"username": "monica",
+		},
+		"type": "process",
+	}
+
+	assert.True(t, cond1.Check(event))
+	assert.True(t, cond2.Check(event))
+	assert.False(t, cond3.Check(event))
+	assert.False(t, cond4.Check(event))
+}
+
+func TestContainsCondition(t *testing.T) {
+
+	if testing.Verbose() {
+		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"*"})
+	}
+
+	config1 := ConditionConfig{
+		Contains: map[string]string{
+			"proc.name": "sec",
+		},
+	}
+	cond1, err := NewCondition(config1)
+	assert.True(t, err == nil)
+
+	config2 := ConditionConfig{
+		Contains: map[string]string{
+			"proc.name": "secddd",
+		},
+	}
+	cond2, err := NewCondition(config2)
+	assert.True(t, err == nil)
+
+	event := common.MapStr{
+		"@timestamp": "2016-04-14T20:41:06.258Z",
+		"proc": common.MapStr{
+			"cmdline": "/usr/libexec/secd",
+			"cpu": common.MapStr{
+				"start_time": "Apr10",
+				"system":     1988,
+				"total":      6029,
+				"total_p":    0.08,
+				"user":       4041,
+			},
+			"name":     "secd",
+			"pid":      305,
+			"ppid":     1,
+			"state":    "running",
+			"username": "monica",
+		},
+		"type": "process",
+	}
+
+	assert.True(t, cond1.Check(event))
+	assert.False(t, cond2.Check(event))
+}
+
+func TestRegexpCondition(t *testing.T) {
+
+	if testing.Verbose() {
+		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"*"})
+	}
+
+	// first simple condition
+	config1 := ConditionConfig{
+		Regexp: map[string]string{
+			"source": "apache2/error.*",
+		},
+	}
+	cond1, err := NewCondition(config1)
+	assert.True(t, err == nil)
+
+	// second simple condition
+	config2 := ConditionConfig{
+		Regexp: map[string]string{
+			"source": "apache2/access.*",
+		},
+	}
+	cond2, err := NewCondition(config2)
+	assert.True(t, err == nil)
+
+	// third complex condition
+	config3 := ConditionConfig{
+		Regexp: map[string]string{
+			"source":  "apache2/error.*",
+			"message": "[client 1.2.3.4]",
+		},
+	}
+	cond3, err := NewCondition(config3)
+	assert.True(t, err == nil)
+
+	event := common.MapStr{
+		"@timestamp": "2016-04-14T20:41:06.258Z",
+		"message":    `[Fri Dec 16 01:46:23 2005] [error] [client 1.2.3.4] Directory index forbidden by rule: /home/test/`,
+		"source":     "/var/log/apache2/error.log",
+		"type":       "log",
+		"input_type": "log",
+		"offset":     30,
+	}
+
+	event1 := common.MapStr{
+		"@timestamp": "2016-04-14T20:41:06.258Z",
+		"message":    `127.0.0.1 - - [28/Jul/2006:10:27:32 -0300] "GET /hidden/ HTTP/1.0" 404 7218`,
+		"source":     "/var/log/apache2/access.log",
+		"type":       "log",
+		"input_type": "log",
+		"offset":     30,
+	}
+
+	assert.True(t, cond1.Check(event))
+	assert.False(t, cond2.Check(event))
+	assert.True(t, cond3.Check(event))
+
+	assert.False(t, cond1.Check(event1))
+	assert.True(t, cond2.Check(event1))
+}
+
+func TestRangeCondition(t *testing.T) {
+
+	if testing.Verbose() {
+		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"*"})
+	}
+
+	// first condition
+	var v400 float64 = 400
+	var v500 float64 = 500
+	config1 := ConditionConfig{
+		Range: map[string]RangeValue{
+			"http.code": RangeValue{Gte: &v400, Lt: &v500},
+		},
+	}
+	cond1, err := NewCondition(config1)
+	assert.True(t, err == nil)
+
+	// second condition
+	var v2800 float64 = 28000
+	config2 := ConditionConfig{
+		Range: map[string]RangeValue{
+			"bytes_out": RangeValue{Gte: &v2800},
+		},
+	}
+	cond2, err := NewCondition(config2)
+	assert.True(t, err == nil)
+
+	// complex condition
+	var v30 float64 = 30
+	config3 := ConditionConfig{
+		Range: map[string]RangeValue{
+			"bytes_out":    RangeValue{Gte: &v2800},
+			"responsetime": RangeValue{Gt: &v30},
+		},
+	}
+	cond3, err := NewCondition(config3)
+	assert.True(t, err == nil)
+
+	// float condition
+	var v05 float64 = 0.5
+	config4 := ConditionConfig{
+		Range: map[string]RangeValue{
+			"proc.cpu.total_p": RangeValue{Gte: &v05},
+		},
+	}
+	cond4, err := NewCondition(config4)
+	assert.True(t, err == nil)
+
+	event := common.MapStr{
+		"@timestamp":    "2015-06-11T09:51:23.642Z",
+		"bytes_in":      126,
+		"bytes_out":     28033,
+		"client_ip":     "127.0.0.1",
+		"client_port":   42840,
+		"client_proc":   "",
+		"client_server": "mar.local",
+		"http": common.MapStr{
+			"code":           404,
+			"content_length": 76985,
+			"phrase":         "Not found",
+		},
+		"ip":           "127.0.0.1",
+		"method":       "GET",
+		"params":       "",
+		"path":         "/jszip.min.js",
+		"port":         8000,
+		"proc":         "",
+		"query":        "GET /jszip.min.js",
+		"responsetime": 30,
+		"server":       "mar.local",
+		"status":       "OK",
+		"type":         "http",
+	}
+
+	event1 := common.MapStr{
+		"@timestamp": "2016-04-20T07:46:44.633Z",
+		"proc": common.MapStr{
+			"cmdline": "/System/Library/Frameworks/CoreServices.framework/Frameworks/Metadata.framework/Versions/A/Support/mdworker -s mdworker -c MDSImporterWorker -m com.apple.mdworker.single",
+			"cpu": common.MapStr{
+				"start_time": "09:19",
+				"system":     22,
+				"total":      66,
+				"total_p":    0.6,
+				"user":       44,
+			},
+			"name":     "mdworker",
+			"pid":      44978,
+			"ppid":     1,
+			"state":    "running",
+			"username": "test",
+		},
+		"type": "process",
+	}
+
+	assert.True(t, cond1.Check(event))
+	assert.True(t, cond2.Check(event))
+	assert.False(t, cond3.Check(event))
+	assert.True(t, cond4.Check(event1))
+	assert.False(t, cond4.Check(event))
+}

--- a/libbeat/filter/config.go
+++ b/libbeat/filter/config.go
@@ -1,11 +1,27 @@
 package filter
 
+type ConditionConfig struct {
+	Equals   map[string]string     `config:"equals"`
+	Contains map[string]string     `config:"contains"`
+	Regexp   map[string]string     `config:"regexp"`
+	Range    map[string]RangeValue `config:"range"`
+}
+
+type RangeValue struct {
+	Gte *float64 `config:"gte"`
+	Gt  *float64 `config:"gt"`
+	Lte *float64 `config:"lte"`
+	Lt  *float64 `config:"lt"`
+}
+
 type DropFieldsConfig struct {
-	Fields []string `config:"fields"`
+	Fields          []string `config:"fields"`
+	ConditionConfig `config:",inline"`
 }
 
 type IncludeFieldsConfig struct {
-	Fields []string `config:"fields"`
+	Fields          []string `config:"fields"`
+	ConditionConfig `config:",inline"`
 }
 
 type FilterConfig struct {

--- a/libbeat/filter/config.go
+++ b/libbeat/filter/config.go
@@ -14,6 +14,11 @@ type RangeValue struct {
 	Lt  *float64 `config:"lt"`
 }
 
+type EqualsValue struct {
+	Int int
+	Str string
+}
+
 type DropFieldsConfig struct {
 	Fields          []string `config:"fields"`
 	ConditionConfig `config:",inline"`

--- a/libbeat/filter/filter_test.go
+++ b/libbeat/filter/filter_test.go
@@ -16,7 +16,15 @@ func TestIncludeFields(t *testing.T) {
 
 	Filters := FilterList{}
 
-	Filters.Register(NewIncludeFields([]string{"proc.cpu.total_p", "proc.mem", "dd"}))
+	rule, err := NewIncludeFields(IncludeFieldsConfig{
+		Fields: []string{"proc.cpu.total_p", "proc.mem", "dd"},
+		ConditionConfig: ConditionConfig{Contains: map[string]string{
+			"proc.name": "test",
+		}},
+	})
+	assert.True(t, err == nil)
+
+	Filters.Register(rule)
 
 	event := common.MapStr{
 		"@timestamp": "2016-01-24T18:35:19.308Z",
@@ -24,7 +32,6 @@ func TestIncludeFields(t *testing.T) {
 			"hostname": "mar",
 			"name":     "my-shipper-1",
 		},
-		"count": 1,
 		"proc": common.MapStr{
 			"cpu": common.MapStr{
 				"start_time": "Jan14",
@@ -33,6 +40,7 @@ func TestIncludeFields(t *testing.T) {
 				"total_p":    0,
 				"user":       53363,
 			},
+			"name":    "test-1",
 			"cmdline": "/sbin/launchd",
 			"mem": common.MapStr{
 				"rss":   11194368,
@@ -73,7 +81,15 @@ func TestIncludeFields1(t *testing.T) {
 
 	Filters := FilterList{}
 
-	Filters.Register(NewIncludeFields([]string{"proc.cpu.total_ddd"}))
+	rule, err := NewIncludeFields(IncludeFieldsConfig{
+		Fields: []string{"proc.cpu.total_ddd"},
+		ConditionConfig: ConditionConfig{Regexp: map[string]string{
+			"proc.cmdline": "launchd",
+		}},
+	})
+	assert.True(t, err == nil)
+
+	Filters.Register(rule)
 
 	event := common.MapStr{
 		"@timestamp": "2016-01-24T18:35:19.308Z",
@@ -81,7 +97,6 @@ func TestIncludeFields1(t *testing.T) {
 			"hostname": "mar",
 			"name":     "my-shipper-1",
 		},
-		"count": 1,
 
 		"proc": common.MapStr{
 			"cpu": common.MapStr{
@@ -116,7 +131,15 @@ func TestDropFields(t *testing.T) {
 
 	Filters := FilterList{}
 
-	Filters.Register(NewDropFields([]string{"proc.cpu.start_time", "mem", "proc.cmdline", "beat", "dd"}))
+	rule, err := NewDropFields(DropFieldsConfig{
+		Fields: []string{"proc.cpu.start_time", "mem", "proc.cmdline", "beat", "dd"},
+		ConditionConfig: ConditionConfig{Equals: map[string]string{
+			"beat.hostname": "mar",
+		}},
+	})
+	assert.True(t, err == nil)
+
+	Filters.Register(rule)
 
 	event := common.MapStr{
 		"@timestamp": "2016-01-24T18:35:19.308Z",
@@ -124,7 +147,6 @@ func TestDropFields(t *testing.T) {
 			"hostname": "mar",
 			"name":     "my-shipper-1",
 		},
-		"count": 1,
 
 		"proc": common.MapStr{
 			"cpu": common.MapStr{
@@ -149,7 +171,6 @@ func TestDropFields(t *testing.T) {
 
 	expectedEvent := common.MapStr{
 		"@timestamp": "2016-01-24T18:35:19.308Z",
-		"count":      1,
 		"proc": common.MapStr{
 			"cpu": common.MapStr{
 				"system":  26027,
@@ -171,9 +192,23 @@ func TestMultipleIncludeFields(t *testing.T) {
 	}
 	Filters := FilterList{}
 
-	Filters.Register(NewIncludeFields([]string{"proc"}))
-	Filters.Register(NewIncludeFields([]string{"proc.cpu.start_time", "proc.cpu.total_p",
-		"proc.mem.rss_p", "proc.cmdline"}))
+	rule, err := NewIncludeFields(IncludeFieldsConfig{
+		Fields: []string{"proc"},
+		ConditionConfig: ConditionConfig{Contains: map[string]string{
+			"beat.name": "my-shipper",
+		}},
+	})
+	assert.True(t, err == nil)
+
+	Filters.Register(rule)
+
+	rule, err = NewIncludeFields(IncludeFieldsConfig{
+		Fields: []string{"proc.cpu.start_time", "proc.cpu.total_p",
+			"proc.mem.rss_p", "proc.cmdline"},
+	})
+	assert.True(t, err == nil)
+
+	Filters.Register(rule)
 
 	event1 := common.MapStr{
 		"@timestamp": "2016-01-24T18:35:19.308Z",
@@ -181,7 +216,6 @@ func TestMultipleIncludeFields(t *testing.T) {
 			"hostname": "mar",
 			"name":     "my-shipper-1",
 		},
-		"count": 1,
 
 		"proc": common.MapStr{
 			"cpu": common.MapStr{
@@ -208,7 +242,6 @@ func TestMultipleIncludeFields(t *testing.T) {
 			"hostname": "mar",
 			"name":     "my-shipper-1",
 		},
-		"count": 1,
 		"fs": common.MapStr{
 			"device_name": "devfs",
 			"total":       198656,


### PR DESCRIPTION
This implements a task from the meta issue: https://github.com/elastic/beats/issues/1447

This PR adds `equals`, `contains`, `regexp` and `range` conditions.

Please note that in the current implementation you cannot pass fields that contain `.`. The fix will come in a different PR.
