### PR TITLE
Upgrade pip to fetch most recent dependencies 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,9 +73,17 @@ Packetbeat:
 Some of the Beats might have extra development requirements, in which case a
 CONTRIBUTING.md file is find in the Beat directory.
 
+## Testing
+
 You can run the whole testsuite with the following command:
 
-    # make testsuite
+    $ make testsuite
+
+Running the testsuite has the following requirements:
+
+* Python >=2.7.9
+* Docker >=1.10.0
+* Docker-compose >= 1.7.0
 
 ## Dependencies
 

--- a/libbeat/Dockerfile
+++ b/libbeat/Dockerfile
@@ -20,6 +20,9 @@ ENV PYTHON_ENV=/tmp/python-env
 
 RUN test -d ${PYTHON_ENV} || virtualenv ${PYTHON_ENV}
 COPY ./tests/system/requirements.txt /tmp/requirements.txt
+
+# Upgrade pip to make sure to have the most recent version
+RUN . ${PYTHON_ENV}/bin/activate && pip install -U pip
 RUN . ${PYTHON_ENV}/bin/activate && pip install -Ur /tmp/requirements.txt
 
 # Libbeat specific

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -155,6 +155,7 @@ benchmark-tests:
 .PHONY: python-env
 python-env: ${ES_BEATS}/libbeat/tests/system/requirements.txt
 	test -d ${PYTHON_ENV} || virtualenv ${PYTHON_ENV}
+	. ${PYTHON_ENV}/bin/activate && pip install --upgrade pip ; \
 	if [ -a ./tests/system/requirements.txt ] && [ ! ${ES_BEATS}/libbeat/tests/system/requirements.txt -ef ./tests/system/requirements.txt ] ; then \
 		. ${PYTHON_ENV}/bin/activate && pip install -Ur ${ES_BEATS}/libbeat/tests/system/requirements.txt -Ur ./tests/system/requirements.txt ; \
 	else \

--- a/libbeat/tests/system/requirements.txt
+++ b/libbeat/tests/system/requirements.txt
@@ -1,6 +1,5 @@
+pip
 nose
 jinja2
 PyYAML
 nose-timer
-pip
-


### PR DESCRIPTION
Pip must be upgraded to the most recent version before other packages are installed to make sure to fetch the most recent versions. For this, pip is not installed before all the other requirements.

* Requirement for python 2.7.9 was added. Reason see https://urllib3.readthedocs.org/en/latest/security.html#insecureplatformwarning
* Updated CONTRIBUTING.md with Docker versions