### PR TITLE
Add missing calls to service.BeforeRun() and service.Cleanup()

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -38,6 +38,7 @@ https://github.com/elastic/beats/compare/v5.0.0-alpha1...master[Check the HEAD d
 - Drain response buffers when pipelining is used by redis output. {pull}1353[1353]
 - Unterminated environment variable expressions in config files will now cause an error {pull}1389[1389]
 - Fix issue with the automatic template loading when Elasticsearch is not available on Beat start. {issue}1321[1321]
+- Fix bug affecting -cpuprofile, -memprofile, and -httpprof CLI flags {pull}1415[1415]
 
 *Packetbeat*
 

--- a/libbeat/beat/beat.go
+++ b/libbeat/beat/beat.go
@@ -262,6 +262,7 @@ func (bc *instance) run() error {
 // reaches the setup stage.
 func (bc *instance) cleanup() error {
 	logp.Info("%s cleanup", bc.data.Name)
+	defer svc.Cleanup()
 	return bc.beater.Cleanup(bc.data)
 }
 
@@ -291,6 +292,7 @@ func (bc *instance) launch(exit bool) error {
 		return err
 	}
 
+	svc.BeforeRun()
 	svc.HandleSignals(bc.beater.Stop)
 	err = bc.run()
 	return err


### PR DESCRIPTION
They were dropped during the refactor in #1249.

In a separate PR I'll work on adding a test case to prevent future regressions.