### PR TITLE
Require unique names for modules and metricsets

### DIFF
--- a/metricbeat/beater/metricbeat.go
+++ b/metricbeat/beater/metricbeat.go
@@ -30,8 +30,8 @@ import (
 	"fmt"
 
 	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/metricbeat/helper"
-	"github.com/elastic/beats/metricbeat/include"
 )
 
 type Metricbeat struct {
@@ -45,14 +45,14 @@ func New() *Metricbeat {
 }
 
 func (mb *Metricbeat) Config(b *beat.Beat) error {
+	// List all registered modules and metricsets.
+	logp.Info("%s", helper.Registry.String())
+
 	mb.config = &Config{}
 	err := b.RawConfig.Unpack(mb.config)
 	if err != nil {
 		return fmt.Errorf("error reading configuration file. %v", err)
 	}
-
-	// List all registered modules and metricsets
-	include.ListAll()
 
 	return nil
 }

--- a/metricbeat/docs/developer-guide/create-metricset.asciidoc
+++ b/metricbeat/docs/developer-guide/create-metricset.asciidoc
@@ -43,7 +43,9 @@ import (
 )
 
 func init() {
-	helper.Registry.AddMetricSeter("{module-name}", "{metricset-name}", New)
+	if err := helper.Registry.AddMetricSeter("{module-name}", "{metricset-name}", New); err != nil {
+        panic(err)
+	}
 }
 
 // New creates new instance of MetricSeter
@@ -90,7 +92,9 @@ registry with the given module and makes sure it is run later as expected.
 [source,go]
 ----
 func init() {
-	helper.Registry.AddMetricSeter("{module-name}", "{metricset-name}", New)
+	if err := helper.Registry.AddMetricSeter("{module-name}", "{metricset-name}", New); err != nil {
+        panic(err)
+	}
 }
 ----
 

--- a/metricbeat/docs/developer-guide/index.asciidoc
+++ b/metricbeat/docs/developer-guide/index.asciidoc
@@ -137,7 +137,9 @@ import (
 )
 
 func init() {
-	helper.Registry.AddModuler("{module-name}", New)
+	if err := helper.Registry.AddModuler("{module-name}", New); err != nil {
+        panic(err)
+	}
 }
 
 // New creates new instance of Moduler
@@ -167,7 +169,9 @@ import (
 )
 
 func init() {
-	helper.Registry.AddMetricSeter("{module-name}", "{metricset-name}", New)
+	if err := helper.Registry.AddMetricSeter("{module-name}", "{metricset-name}", New); err != nil {
+        panic(err)
+	}
 }
 
 // New creates new instance of MetricSeter
@@ -299,7 +303,9 @@ import (
 )
 
 func init() {
-	helper.Registry.AddModuler("{module-name}", New)
+	if err := helper.Registry.AddModuler("{module-name}", New); err != nil {
+        panic(err)
+	}
 }
 
 // New creates new instance of Moduler

--- a/metricbeat/helper/register_test.go
+++ b/metricbeat/helper/register_test.go
@@ -9,16 +9,138 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetModuleInvalid(t *testing.T) {
+const (
+	moduleName    = "mymodule"
+	metricSetName = "mymetricset"
+)
+
+func TestAddModulerEmptyName(t *testing.T) {
+	registry := &Register{}
+	err := registry.AddModuler("", func() Moduler { return nil })
+	if assert.Error(t, err) {
+		assert.Equal(t, "module name is required", err.Error())
+	}
+}
+
+func TestAddModulerNilFactory(t *testing.T) {
+	registry := &Register{}
+	err := registry.AddModuler(moduleName, nil)
+	if assert.Error(t, err) {
+		assert.Equal(t, "module 'mymodule' cannot be registered with a nil factory", err.Error())
+	}
+}
+
+func TestAddModulerDuplicateName(t *testing.T) {
+	registry := &Register{}
+	err := registry.AddModuler(moduleName, func() Moduler { return nil })
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = registry.AddModuler(moduleName, func() Moduler { return nil })
+	if assert.Error(t, err) {
+		assert.Equal(t, "module 'mymodule' is already registered", err.Error())
+	}
+}
+
+func TestAddModuler(t *testing.T) {
+	registry := &Register{}
+	err := registry.AddModuler(moduleName, func() Moduler { return nil })
+	if err != nil {
+		t.Fatal(err)
+	}
+	factory, found := registry.Modulers[moduleName]
+	assert.True(t, found, "module not found")
+	assert.NotNil(t, factory, "factory fuction is nil")
+}
+
+func TestAddMetricSeterEmptyModuleName(t *testing.T) {
+	registry := &Register{}
+	err := registry.AddMetricSeter("", metricSetName, func() MetricSeter { return nil })
+	if assert.Error(t, err) {
+		assert.Equal(t, "module name is required", err.Error())
+	}
+}
+
+func TestAddMetricSeterEmptyName(t *testing.T) {
+	registry := &Register{}
+	err := registry.AddMetricSeter(moduleName, "", func() MetricSeter { return nil })
+	if assert.Error(t, err) {
+		assert.Equal(t, "metricset name is required", err.Error())
+	}
+}
+
+func TestAddMetricSeterNilFactory(t *testing.T) {
+	registry := &Register{}
+	err := registry.AddMetricSeter(moduleName, metricSetName, nil)
+	if assert.Error(t, err) {
+		assert.Equal(t, "metricset 'mymodule/mymetricset' cannot be registered with a nil factory", err.Error())
+	}
+}
+
+func TestAddMetricSeterDuplicateName(t *testing.T) {
+	registry := &Register{}
+	factory := func() MetricSeter { return nil }
+	err := registry.AddMetricSeter(moduleName, metricSetName, factory)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = registry.AddMetricSeter(moduleName, metricSetName, factory)
+	if assert.Error(t, err) {
+		assert.Equal(t, "metricset 'mymodule/mymetricset' is already registered", err.Error())
+	}
+}
+
+func TestAddMetricSeter(t *testing.T) {
+	registry := &Register{}
+	factory := func() MetricSeter { return nil }
+	err := registry.AddMetricSeter(moduleName, metricSetName, factory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f, found := registry.MetricSeters[moduleName][metricSetName]
+	assert.True(t, found, "metricset not found")
+	assert.NotNil(t, f, "factory fuction is nil")
+}
+
+func TestGetModule(t *testing.T) {
+	registry := Register{
+		Modulers: make(map[string]func() Moduler),
+	}
+	registry.Modulers[moduleName] = func() Moduler { return nil }
 
 	config, _ := common.NewConfigFrom(ModuleConfig{
-		Module: "test",
+		Module: moduleName,
+	})
+	module, err := registry.GetModule(config)
+	if assert.NoError(t, err) {
+		assert.NotNil(t, module)
+	}
+}
+
+func TestGetModuleInvalid(t *testing.T) {
+	config, _ := common.NewConfigFrom(ModuleConfig{
+		Module: moduleName,
 	})
 
 	registry := Register{}
-
 	module, err := registry.GetModule(config)
+	if assert.Error(t, err) {
+		assert.Nil(t, module)
+	}
+}
 
-	assert.Nil(t, module)
-	assert.Error(t, err)
+func TestGetMetricSet(t *testing.T) {
+	registry := &Register{}
+	factory := func() MetricSeter { return nil }
+	err := registry.AddMetricSeter(moduleName, metricSetName, factory)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ms, err := registry.GetMetricSet(&Module{name: moduleName}, metricSetName)
+	if assert.NoError(t, err) {
+		assert.NotNil(t, ms)
+	}
 }

--- a/metricbeat/include/list.go
+++ b/metricbeat/include/list.go
@@ -1,33 +1,18 @@
 /*
-
-This file is included in the main file to load all metricsets.
-
-In case only a subset of metricsets should be included, they can be specified manually in the main.go file.
-
+Package include imports all Module and MetricSet packages so that they register
+their factories with the global registry. This package can be imported in the
+main package to automatically register all of the standard supported Metricbeat
+modules.
 */
 package include
 
-// Make sure all active plugins are loaded
-// TODO: create a script to automatically generate this list
 import (
-	"github.com/elastic/beats/libbeat/logp"
-	"github.com/elastic/beats/metricbeat/helper"
-
-	// List of all metrics to make sure they are registered
-	// Every new metric must be added here
+	// Every module and metricset must be added here so that they can register
+	// themselves.
+	_ "github.com/elastic/beats/metricbeat/module/apache"
 	_ "github.com/elastic/beats/metricbeat/module/apache/status"
+	_ "github.com/elastic/beats/metricbeat/module/mysql"
 	_ "github.com/elastic/beats/metricbeat/module/mysql/status"
-
-	// Redis module and metrics
 	_ "github.com/elastic/beats/metricbeat/module/redis"
 	_ "github.com/elastic/beats/metricbeat/module/redis/info"
 )
-
-func ListAll() {
-	logp.Debug("beat", "Registered Modules and Metrics")
-	for module := range helper.Registry.Modulers {
-		for metricset := range helper.Registry.MetricSeters[module] {
-			logp.Debug("metricbeat", "Registred: Module: %v, MetricSet: %v", module, metricset)
-		}
-	}
-}

--- a/metricbeat/module/apache/apache.go
+++ b/metricbeat/module/apache/apache.go
@@ -5,7 +5,9 @@ import (
 )
 
 func init() {
-	helper.Registry.AddModuler("apache", New)
+	if err := helper.Registry.AddModuler("apache", New); err != nil {
+		panic(err)
+	}
 }
 
 // New creates new instance of Moduler

--- a/metricbeat/module/apache/status/status.go
+++ b/metricbeat/module/apache/status/status.go
@@ -32,7 +32,9 @@ var (
 )
 
 func init() {
-	helper.Registry.AddMetricSeter("apache", "status", New)
+	if err := helper.Registry.AddMetricSeter("apache", "status", New); err != nil {
+		panic(err)
+	}
 }
 
 // New creates new instance of MetricSeter

--- a/metricbeat/module/mysql/mysql.go
+++ b/metricbeat/module/mysql/mysql.go
@@ -9,7 +9,9 @@ import (
 )
 
 func init() {
-	helper.Registry.AddModuler("mysql", New)
+	if err := helper.Registry.AddModuler("mysql", New); err != nil {
+		panic(err)
+	}
 }
 
 // New creates new instance of Moduler

--- a/metricbeat/module/mysql/status/status.go
+++ b/metricbeat/module/mysql/status/status.go
@@ -21,7 +21,9 @@ import (
 )
 
 func init() {
-	helper.Registry.AddMetricSeter("mysql", "status", New)
+	if err := helper.Registry.AddMetricSeter("mysql", "status", New); err != nil {
+		panic(err)
+	}
 }
 
 // New creates new instance of MetricSeter

--- a/metricbeat/module/redis/info/info.go
+++ b/metricbeat/module/redis/info/info.go
@@ -17,7 +17,9 @@ var (
 )
 
 func init() {
-	helper.Registry.AddMetricSeter("redis", "info", New)
+	if err := helper.Registry.AddMetricSeter("redis", "info", New); err != nil {
+		panic(err)
+	}
 }
 
 // New creates new instance of MetricSeter

--- a/metricbeat/module/redis/redis.go
+++ b/metricbeat/module/redis/redis.go
@@ -9,7 +9,9 @@ import (
 )
 
 func init() {
-	helper.Registry.AddModuler("redis", New)
+	if err := helper.Registry.AddModuler("redis", New); err != nil {
+		panic(err)
+	}
 }
 
 // New creates new instance of Moduler


### PR DESCRIPTION
- AddModuler and AddMetricSeter now validate their inputs and return an error if there is any problem with the registration parameters.
- GetModule and GetMetricSet retrieve data from method receiver instead of the singleton Register instance.
- Adding a String() method to Register. Removed include.ListAll().
- Add all modules and metricsets to include/list.go.