### PR TITLE
Do not update event in parallel

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -41,6 +41,7 @@ https://github.com/elastic/beats/compare/v5.0.0-alpha1...master[Check the HEAD d
 - Unterminated environment variable expressions in config files will now cause an error {pull}1389[1389]
 - Fix issue with the automatic template loading when Elasticsearch is not available on Beat start. {issue}1321[1321]
 - Fix bug affecting -cpuprofile, -memprofile, and -httpprof CLI flags {pull}1415[1415]
+- Fix race when multiple outputs access the same event with logstash output manipulating event {issue}1410[1410] {pull}1428[1428]
 
 *Packetbeat*
 

--- a/libbeat/outputs/logstash/client_test.go
+++ b/libbeat/outputs/logstash/client_test.go
@@ -40,7 +40,8 @@ type testDriverCommand struct {
 }
 
 func newLumberjackTestClient(conn *transport.Client) *client {
-	c, err := newLumberjackClient(conn, 3, testMaxWindowSize, 100*time.Millisecond)
+	c, err := newLumberjackClient(conn, 3,
+		testMaxWindowSize, 100*time.Millisecond, "test")
 	if err != nil {
 		panic(err)
 	}
@@ -95,7 +96,7 @@ func testSimpleEvent(t *testing.T, factory clientFactory) {
 	defer transp.Close()
 	defer sock.Close()
 
-	event := common.MapStr{"name": "me", "line": 10}
+	event := common.MapStr{"type": "test", "name": "me", "line": 10}
 	client.Publish([]common.MapStr{event})
 
 	// receive window message
@@ -135,6 +136,7 @@ func testStructuredEvent(t *testing.T, factory clientFactory) {
 	defer sock.Close()
 
 	event := common.MapStr{
+		"type": "test",
 		"name": "test",
 		"struct": common.MapStr{
 			"field1": 1,
@@ -189,6 +191,7 @@ func testCloseAfterWindowSize(t *testing.T, factory clientFactory) {
 	defer client.Stop()
 
 	client.Publish([]common.MapStr{common.MapStr{
+		"type":    "test",
 		"message": "hello world",
 	}})
 
@@ -213,7 +216,7 @@ func testMultiFailMaxTimeouts(t *testing.T, factory clientFactory) {
 	defer transp.Close()
 	defer client.Stop()
 
-	event := common.MapStr{"name": "me", "line": 10}
+	event := common.MapStr{"type": "test", "name": "me", "line": 10}
 
 	for i := 0; i < N; i++ {
 		await := server.Await()

--- a/libbeat/outputs/logstash/logstash_test.go
+++ b/libbeat/outputs/logstash/logstash_test.go
@@ -162,6 +162,7 @@ func TestLogstashTCP(t *testing.T) {
 	// create lumberjack output client
 	config := map[string]interface{}{
 		"hosts":   []string{server.Addr()},
+		"index":   testLogstashIndex("logstash-conn-tcp"),
 		"timeout": 2,
 	}
 	testConnectionType(t, server, testOutputerFactory(t, "", config))
@@ -177,6 +178,7 @@ func TestLogstashTLS(t *testing.T) {
 
 	config := map[string]interface{}{
 		"hosts":                       []string{server.Addr()},
+		"index":                       testLogstashIndex("logstash-conn-tls"),
 		"timeout":                     2,
 		"tls.certificate_authorities": []string{certName + ".pem"},
 	}
@@ -193,6 +195,7 @@ func TestLogstashInvalidTLSInsecure(t *testing.T) {
 
 	config := map[string]interface{}{
 		"hosts":                       []string{server.Addr()},
+		"index":                       testLogstashIndex("logstash-conn-tls-invalid"),
 		"timeout":                     2,
 		"max_retries":                 1,
 		"tls.insecure":                true,
@@ -290,6 +293,7 @@ func TestLogstashInvalidTLS(t *testing.T) {
 
 	config := map[string]interface{}{
 		"hosts":                       []string{server.Addr()},
+		"index":                       testLogstashIndex("logstash-tls-invalid"),
 		"timeout":                     1,
 		"max_retries":                 0,
 		"tls.certificate_authorities": []string{certName + ".pem"},

--- a/libbeat/outputs/logstash/sync.go
+++ b/libbeat/outputs/logstash/sync.go
@@ -46,8 +46,9 @@ func newLumberjackClient(
 	compressLevel int,
 	maxWindowSize int,
 	timeout time.Duration,
+	beat string,
 ) (*client, error) {
-	p, err := newClientProcol(conn, timeout, compressLevel)
+	p, err := newClientProcol(conn, timeout, compressLevel, beat)
 	if err != nil {
 		return nil, err
 	}

--- a/libbeat/outputs/logstash/sync_test.go
+++ b/libbeat/outputs/logstash/sync_test.go
@@ -56,7 +56,8 @@ func (s *clientServer) connectPair(compressLevel int) (*mockConn, *client, error
 	}
 
 	lc, err := newLumberjackClient(transp, compressLevel,
-		defaultConfig.BulkMaxSize, 100*time.Millisecond)
+		defaultConfig.BulkMaxSize, 100*time.Millisecond,
+		"test")
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
logstash output used to add metadata to an event. With potentially having
multiple outputs configured this is some bad practice. Instead the logstash
output plugin will add '@metadata' to the event when encoding and only if
'@metadata' is not already present in event

Resolves #1410