### PR TITLE
Increment versions for elastic stack products listed in the 1.1 getting started

### DIFF
--- a/libbeat/docs/index.asciidoc
+++ b/libbeat/docs/index.asciidoc
@@ -4,10 +4,10 @@
 :topbeat: http://www.elastic.co/guide/en/beats/topbeat/1.1
 :filebeat: http://www.elastic.co/guide/en/beats/filebeat/1.1
 :winlogbeat: http://www.elastic.co/guide/en/beats/winlogbeat/1.1
-:ES-version: 2.2.0
-:LS-version: 2.2.2
-:Kibana-version: 4.4.1
-:Dashboards-version: 1.1.1
+:ES-version: 2.2.2
+:LS-version: 2.2.4
+:Kibana-version: 4.4.2
+:Dashboards-version: 1.1.2
 
 
 include::./overview.asciidoc[]


### PR DESCRIPTION
Updating versions in the 1.1 docs to match the latest releases. 