### PR TITLE
Backport logstash concurrent event modification fix for #1410

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ https://github.com/elastic/beats/compare/v1.2.1...1.2[Check the HEAD diff]
 ==== Bugfixes
 
 *Affecting all Beats*
+- Fix race when multiple outputs access the same event with logstash output manipulating event {issue}1410[1410]
 
 *Packetbeat*
 

--- a/libbeat/outputs/logstash/client_test.go
+++ b/libbeat/outputs/logstash/client_test.go
@@ -65,7 +65,7 @@ type mockTransport struct {
 }
 
 func newLumberjackTestClient(conn TransportClient) *lumberjackClient {
-	c, err := newLumberjackClient(conn, 3, testMaxWindowSize, 5*time.Second)
+	c, err := newLumberjackClient(conn, 3, testMaxWindowSize, 5*time.Second, "test")
 	if err != nil {
 		panic(err)
 	}
@@ -325,7 +325,7 @@ func TestSimpleEvent(t *testing.T) {
 	transp := newMockTransport()
 	client := newClientTestDriver(newLumberjackTestClient(transp))
 
-	event := common.MapStr{"name": "me", "line": 10}
+	event := common.MapStr{"type": "test", "name": "me", "line": 10}
 	client.Publish([]common.MapStr{event})
 
 	// receive window message
@@ -357,6 +357,7 @@ func TestStructuredEvent(t *testing.T) {
 	transp := newMockTransport()
 	client := newClientTestDriver(newLumberjackTestClient(transp))
 	event := common.MapStr{
+		"type": "test",
 		"name": "test",
 		"struct": common.MapStr{
 			"field1": 1,
@@ -432,7 +433,7 @@ func testGrowWindowSize(t *testing.T,
 	initial, maxOK, windowSize, batchSize, expected int,
 ) {
 	enableLogging([]string{"logstash"})
-	c, _ := newLumberjackClient(nil, 3, windowSize, 1*time.Second)
+	c, _ := newLumberjackClient(nil, 3, windowSize, 1*time.Second, "test")
 	c.windowSize = initial
 	c.maxOkWindowSize = maxOK
 	for i := 0; i < 100; i++ {
@@ -447,7 +448,7 @@ func TestShrinkWindowSizeNeverZero(t *testing.T) {
 	enableLogging([]string{"logstash"})
 
 	windowSize := 124
-	c, _ := newLumberjackClient(nil, 3, windowSize, 1*time.Second)
+	c, _ := newLumberjackClient(nil, 3, windowSize, 1*time.Second, "test")
 	c.windowSize = windowSize
 	for i := 0; i < 100; i++ {
 		c.shrinkWindow()


### PR DESCRIPTION
logstash output used to add metadata to an event. With potentially having
multiple outputs configured this is some bad practice. Instead the logstash
output plugin will add '@metadata' to the event when encoding and only if
'@metadata' is not already present in event