### PR TITLE
Fix postinst script

### DIFF
--- a/dev-tools/packer/platforms/centos/run.sh.j2
+++ b/dev-tools/packer/platforms/centos/run.sh.j2
@@ -8,7 +8,8 @@ cd /build
 cp ${RUNID}.init /tmp/{{.beat_name}}.init
 
 # create script to reload systemd config
-echo "#!/bin/bash\nsystemctl daemon-reload 2> /dev/null || true" > /tmp/systemd-daemon-reload.sh
+echo "#!/bin/bash" > /tmp/systemd-daemon-reload.sh
+echo "systemctl daemon-reload 2> /dev/null || true" >> /tmp/systemd-daemon-reload.sh
 
 # add SNAPSHOT if it was requested
 VERSION="{{.version}}"

--- a/dev-tools/packer/platforms/debian/run.sh.j2
+++ b/dev-tools/packer/platforms/debian/run.sh.j2
@@ -8,7 +8,8 @@ cd /build
 cp ${RUNID}.init /tmp/{{.beat_name}}.init
 
 # create script to reload systemd config
-echo "#!/bin/bash\nsystemctl daemon-reload 2> /dev/null || true" > /tmp/systemd-daemon-reload.sh
+echo "#!/bin/bash" > /tmp/systemd-daemon-reload.sh
+echo "systemctl daemon-reload 2> /dev/null || true" >> /tmp/systemd-daemon-reload.sh
 
 # add SNAPSHOT if it was requested
 VERSION="{{.version}}"


### PR DESCRIPTION
Not quite sure why that stopped working, I guess when I switched from `/bin/sh` to `/bin/bash`. This should fix (part of) the beats tester errors.