### PR TITLE
Added beatname.sh in /usr/bin

### DIFF
--- a/dev-tools/packer/platforms/centos/beatname.sh.j2
+++ b/dev-tools/packer/platforms/centos/beatname.sh.j2
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Script to run {.beat_name} in foreground with the same path settings that
+# the init script / systemd unit file would do.
+
+/usr/share/{{.beat_name}}/bin/{{.beat_name}} -e \
+  -c /etc/{{.beat_name}}/{{.beat_name}}.yml \
+  -path.home /usr/share/{{.beat_name}} \
+  -path.config /etc/{{.beat_name}} \
+  -path.data /var/lib/{{.beat_name}} \
+  $@

--- a/dev-tools/packer/platforms/centos/build.sh
+++ b/dev-tools/packer/platforms/centos/build.sh
@@ -10,9 +10,11 @@ runid=centos-$BEAT-$ARCH
 
 cat beats/$BEAT.yml ${ARCHDIR}/archs/$ARCH.yml version.yml > build/settings-$runid.yml
 gotpl ${BASEDIR}/run.sh.j2 < build/settings-$runid.yml > build/run-$runid.sh
+chmod +x build/run-$runid.sh
 gotpl ${BASEDIR}/init.j2 < build/settings-$runid.yml > build/$runid.init
 gotpl ${BASEDIR}/systemd.j2 < build/settings-$runid.yml > build/$runid.service
-chmod +x build/run-$runid.sh
+gotpl ${BASEDIR}/beatname.sh.j2 < build/settings-$runid.yml > build/beatname-$runid.sh
+chmod +x build/beatname-$runid.sh
 
 docker run --rm -v `pwd`/build:/build \
     -e BUILDID=$BUILDID -e SNAPSHOT=$SNAPSHOT -e RUNID=$runid \

--- a/dev-tools/packer/platforms/centos/run.sh.j2
+++ b/dev-tools/packer/platforms/centos/run.sh.j2
@@ -8,7 +8,8 @@ cd /build
 cp ${RUNID}.init /tmp/{{.beat_name}}.init
 
 # create script to reload systemd config
-echo "#!/bin/bash\nsystemctl daemon-reload 2> /dev/null || true" > /tmp/systemd-daemon-reload.sh
+echo "#!/bin/bash" > /tmp/systemd-daemon-reload.sh
+echo "systemctl daemon-reload 2> /dev/null || true" >> /tmp/systemd-daemon-reload.sh
 
 # add SNAPSHOT if it was requested
 VERSION="{{.version}}"

--- a/dev-tools/packer/platforms/centos/run.sh.j2
+++ b/dev-tools/packer/platforms/centos/run.sh.j2
@@ -32,6 +32,7 @@ fpm --force -s dir -t rpm \
         --after-install /tmp/systemd-daemon-reload.sh \
         --config-files /etc/{{.beat_name}}/{{.beat_name}}.yml \
         homedirs/{{.beat_name}}=/usr/share/ \
+        beatname-${RUNID}.sh=/usr/bin/{{.beat_name}}.sh \
         {{.beat_name}}-linux-{{.arch}}=/usr/share/{{.beat_name}}/bin/{{.beat_name}} \
         {{.beat_name}}-linux.yml=/etc/{{.beat_name}}/{{.beat_name}}.yml \
         {{.beat_name}}.template.json=/etc/{{.beat_name}}/{{.beat_name}}.template.json \

--- a/dev-tools/packer/platforms/debian/beatname.sh.j2
+++ b/dev-tools/packer/platforms/debian/beatname.sh.j2
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Script to run {.beat_name} in foreground with the same path settings that
+# the init script / systemd unit file would do.
+
+/usr/share/{{.beat_name}}/bin/{{.beat_name}} -e \
+  -c /etc/{{.beat_name}}/{{.beat_name}}.yml \
+  -path.home /usr/share/{{.beat_name}} \
+  -path.config /etc/{{.beat_name}} \
+  -path.data /var/lib/{{.beat_name}} \
+  $@

--- a/dev-tools/packer/platforms/debian/build.sh
+++ b/dev-tools/packer/platforms/debian/build.sh
@@ -10,9 +10,11 @@ runid=debian-$BEAT-$ARCH
 
 cat beats/$BEAT.yml ${ARCHDIR}/archs/$ARCH.yml version.yml > build/settings-$runid.yml
 gotpl ${BASEDIR}/run.sh.j2 < build/settings-$runid.yml > build/run-$runid.sh
+chmod +x build/run-$runid.sh
 gotpl ${BASEDIR}/init.j2 < build/settings-$runid.yml > build/$runid.init
 gotpl ${BASEDIR}/systemd.j2 < build/settings-$runid.yml > build/$runid.service
-chmod +x build/run-$runid.sh
+gotpl ${BASEDIR}/beatname.sh.j2 < build/settings-$runid.yml > build/beatname-$runid.sh
+chmod +x build/beatname-$runid.sh
 
 docker run --rm -v `pwd`/build:/build \
     -e BUILDID=$BUILDID -e SNAPSHOT=$SNAPSHOT -e RUNID=$runid \

--- a/dev-tools/packer/platforms/debian/run.sh.j2
+++ b/dev-tools/packer/platforms/debian/run.sh.j2
@@ -8,7 +8,8 @@ cd /build
 cp ${RUNID}.init /tmp/{{.beat_name}}.init
 
 # create script to reload systemd config
-echo "#!/bin/bash\nsystemctl daemon-reload 2> /dev/null || true" > /tmp/systemd-daemon-reload.sh
+echo "#!/bin/bash" > /tmp/systemd-daemon-reload.sh
+echo "systemctl daemon-reload 2> /dev/null || true" >> /tmp/systemd-daemon-reload.sh
 
 # add SNAPSHOT if it was requested
 VERSION="{{.version}}"

--- a/dev-tools/packer/platforms/debian/run.sh.j2
+++ b/dev-tools/packer/platforms/debian/run.sh.j2
@@ -32,11 +32,12 @@ fpm --force -s dir -t deb \
         --after-install /tmp/systemd-daemon-reload.sh \
         --config-files /etc/{{.beat_name}}/{{.beat_name}}.yml \
         homedirs/{{.beat_name}}=/usr/share/ \
+        beatname-${RUNID}.sh=/usr/bin/{{.beat_name}}.sh \
         {{.beat_name}}-linux-{{.arch}}=/usr/share/{{.beat_name}}/bin/{{.beat_name}} \
         {{.beat_name}}-linux.yml=/etc/{{.beat_name}}/{{.beat_name}}.yml \
         {{.beat_name}}.template.json=/etc/{{.beat_name}}/{{.beat_name}}.template.json \
         ${RUNID}.service=/lib/systemd/system/{{.beat_name}}.service \
-		god-linux-{{.arch}}=/usr/share/{{.beat_name}}/bin/{{.beat_name}}-god
+        god-linux-{{.arch}}=/usr/share/{{.beat_name}}/bin/{{.beat_name}}-god
 
 # move and rename so that the filename respects semver rules
 mkdir -p upload/{{.beat_name}}


### PR DESCRIPTION
For Deb and Rpm installations. This makes it easy to run the Beat
in foreground, while still being executed with the write paths.
Part of #1371.

This sits on top op #1444, please have a look at that one first.