### PR TITLE
Update to Go 1.6.2 from 1.6

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,7 +6,7 @@ os: Windows Server 2012 R2
 
 # Environment variables
 environment:
-  GOROOT: c:\go1.6
+  GOROOT: c:\go1.6.2
   GOPATH: c:\gopath
   PYWIN_DL: https://downloads.sourceforge.net/project/pywin32/pywin32/Build%20219/pywin32-219.win32-py2.7.exe
   matrix:
@@ -24,13 +24,13 @@ clone_folder: c:\gopath\src\github.com\elastic\beats
 cache:
 - C:\ProgramData\chocolatey\bin -> .appveyor.yml
 - C:\ProgramData\chocolatey\lib -> .appveyor.yml
-- C:\go1.6 -> .appveyor.yml
+- C:\go1.6.2 -> .appveyor.yml
 - C:\tools\mingw64 -> .appveyor.yml
 - C:\pywin_inst.exe -> .appveyor.yml
 
 # Scripts that run after cloning repository
 install:
-  - ps: c:\gopath\src\github.com\elastic\beats\libbeat\scripts\install-go.ps1 -version 1.6
+  - ps: c:\gopath\src\github.com\elastic\beats\libbeat\scripts\install-go.ps1 -version 1.6.2
   - set PATH=%GOROOT%\bin;%PATH%
   # AppVeyor installed mingw is 32-bit only.
   - ps: >-

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
 language: go
 
 go:
-  - 1.6
+  - 1.6.2
 
 os:
   - linux

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -63,6 +63,7 @@ https://github.com/elastic/beats/compare/v5.0.0-alpha1...master[Check the HEAD d
 - Added ability to escape `${x}` in config files to avoid environment variable expansion {pull}1389[1389]
 - Configuration options and CLI flags for setting the home, data and config paths. {pull}1373[1373]
 - Configuration options and CLI flags for setting the default logs path. {pull}1437[1437]
+- Update to Go 1.6.2 {pull}1447[1447]
 
 *Packetbeat*
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ Beats](https://github.com/elastic/beats/blob/master/libbeat/docs/communitybeats.
 
 The Beats are Go programs, so install the latest version of
 [golang](http://golang.org/) if you don't have it already. The current Go version
-used for development is Golang 1.6.
+used for development is Golang 1.6.2.
 
 The Beats are Go programs, so install the latest version of
 [golang](http://golang.org/) if you don't have it already.

--- a/dev-tools/packer/docker/xgo-image-deb6/go-1.6/Dockerfile
+++ b/dev-tools/packer/docker/xgo-image-deb6/go-1.6/Dockerfile
@@ -9,7 +9,7 @@ MAINTAINER Tudor Golubenco <tudor@elastic.co>
 
 # Configure the root Go distribution and bootstrap based on it
 RUN \
-  export ROOT_DIST="https://storage.googleapis.com/golang/go1.6.linux-amd64.tar.gz" && \
-  export ROOT_DIST_SHA1="01a6a28dbe31a53103b600979bbbbd63a8104456" && \
+  export ROOT_DIST="https://storage.googleapis.com/golang/go1.6.2.linux-amd64.tar.gz" && \
+  export ROOT_DIST_SHA1="b8318b09de06076d5397e6ec18ebef3b45cd315d" && \
   \
   $BOOTSTRAP_PURE

--- a/dev-tools/packer/docker/xgo-image/go-1.6/Dockerfile
+++ b/dev-tools/packer/docker/xgo-image/go-1.6/Dockerfile
@@ -9,7 +9,7 @@ MAINTAINER Tudor Golubenco <tudor@elastic.co>
 
 # Configure the root Go distribution and bootstrap based on it
 RUN \
-  export ROOT_DIST="https://storage.googleapis.com/golang/go1.6.linux-amd64.tar.gz" && \
-  export ROOT_DIST_SHA1="01a6a28dbe31a53103b600979bbbbd63a8104456" && \
+  export ROOT_DIST="https://storage.googleapis.com/golang/go1.6.2.linux-amd64.tar.gz" && \
+  export ROOT_DIST_SHA1="b8318b09de06076d5397e6ec18ebef3b45cd315d" && \
   \
   $BOOTSTRAP_PURE


### PR DESCRIPTION
The `golang:1.6.2` docker image isn't available yet so I will have to update the Dockerfiles files after the image is published.