### PR TITLE
Update Vagrant box to OpenBSD 5.9-current so that Packetbeat will build

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -95,9 +95,9 @@ Vagrant.configure(2) do |config|
     freebsd.vm.provision "shell", inline: $unixProvision, privileged: false
   end
 
-  # OpenBSD 5.9
+  # OpenBSD 5.9-current
   config.vm.define "openbsd", primary: true do |openbsd|
-    openbsd.vm.box = "https://s3.amazonaws.com/beats-files/vagrant/beats-openbsd-5.9-virtualbox-2016-04-14_0019.box"
+    openbsd.vm.box = "https://s3.amazonaws.com/beats-files/vagrant/beats-openbsd-5.9-current-virtualbox-2016-04-22_0422.box"
     openbsd.vm.network :forwarded_port, guest: 22,   host: 2225,  id: "ssh", auto_correct: true
 
     config.vm.synced_folder ".", "/vagrant", type: "rsync", disabled: true


### PR DESCRIPTION
I updated the OpenBSD box to be based on https://atlas.hashicorp.com/jasperla/boxes/openbsd-current. from @jasperla (thanks).

I setup a [Jenkins job for OpenBSD](http://build-eu-00.elastic.co/view/Beats/job/beats-openbsd/4/console) to run our tests. Summary:

- Packetbeat's NFS system tests fail with:

```
2016/04/22 04:48:05.905525 beat.go:313: CRIT Exiting: Initializing sniffer failed: Error creating sniffer: bad dump file format
Exiting: Initializing sniffer failed: Error creating sniffer: bad dump file format
```

- Filebeat unit tests fail with:

```
--- FAIL: TestGetOSFileState (0.00s)
	assertions.go:203: 
                        
	Error Trace:	file_other_test.go:23
		
	Error:		Should be true
		
--- FAIL: TestGetOSFileStateStat (0.00s)
	assertions.go:203: 
                        
	Error Trace:	file_other_test.go:36
		
	Error:		Should be true
		
FAIL
```

- Topbeat unit tests fail, but this is expected since we haven't implemented process information in gosigar:

```
--- FAIL: TestPids (0.00s)
	assertions.go:203: 
                        
	Error Trace:	process_test.go:16
		
	Error:		Expected value not to be nil.
		
	assertions.go:203: 
                        
	Error Trace:	process_test.go:20
		
	Error:		Should be true
		
FAIL
```
