### PR TITLE
Fix doc build by removing broken x-ref

### DIFF
--- a/libbeat/docs/shared-command-line.asciidoc
+++ b/libbeat/docs/shared-command-line.asciidoc
@@ -40,16 +40,16 @@ Write memory profile data to the specified output file. This option is useful fo
 troubleshooting the Beat.
 
 *`-path.config`*::
-Set the default location for configuration (e.g. the Elasticsearch template). See the <<directory-layout>> section for details.
+Set the default location for configuration (e.g. the Elasticsearch template).
 
 *`-path.data`*::
-Set the default location for data files. See the <<directory-layout>> section for details.
+Set the default location for data files.
 
 *`-path.home`*::
-Set the default location for miscellaneous files. See the <<directory-layout>> section for details.
+Set the default location for miscellaneous files.
 
 *`-path.logs`*::
-Set the default location for log files. See the <<directory-layout>> section for details.
+Set the default location for log files.
 
 *`-v`*::
 Enable verbose output to show INFO-level messages.


### PR DESCRIPTION
Unfortunately I have to remove the links from the command line docs to the directory layout, because the directory layout is included in the Beats docs but not the libbeat one, while the command line docs are also included in libbeat.

CC @dedemorton 