### PR TITLE
Include cpu and memory only when supported by the OS.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ env:
     - TARGETS="-C packetbeat testsuite"
     - TARGETS="-C metricbeat testsuite"
     - TARGETS="-C libbeat crosscompile"
+    - TARGETS="-C metricbeat crosscompile"
     - TARGETS="-C winlogbeat crosscompile"
   global:
     # Cross-compile for amd64 only to speed up testing.
@@ -35,6 +36,8 @@ matrix:
       env: TARGETS="-C filebeat crosscompile"
     - os: osx
       env: TARGETS="-C libbeat crosscompile"
+    - os: osx
+      env: TARGETS="-C metricbeat crosscompile"
     - os: osx
       env: TARGETS="-C winlogbeat crosscompile"
     - os: osx

--- a/metricbeat/Makefile
+++ b/metricbeat/Makefile
@@ -5,6 +5,11 @@ SYSTEM_TESTS=true
 TEST_ENVIRONMENT?=true
 GOPACKAGES=$(shell go list ${BEAT_DIR}/${BEATNAME}/... | grep -v /vendor/)
 
+# Metricbeat can only be cross-compiled on platforms not requiring CGO which
+# are the same platforms where the system metrics (cpu, memory) are not
+# implemented.
+GOX_OS=solaris freebsd netbsd
+
 include ../libbeat/scripts/Makefile
 
 # Collects all module dashboards

--- a/metricbeat/include/list.go
+++ b/metricbeat/include/list.go
@@ -15,8 +15,6 @@ import (
 	_ "github.com/elastic/beats/metricbeat/module/mysql/status"
 	_ "github.com/elastic/beats/metricbeat/module/redis"
 	_ "github.com/elastic/beats/metricbeat/module/redis/info"
-
-	// System module and metricsets
 	_ "github.com/elastic/beats/metricbeat/module/system"
 	_ "github.com/elastic/beats/metricbeat/module/system/cpu"
 	_ "github.com/elastic/beats/metricbeat/module/system/memory"

--- a/metricbeat/module/system/cpu/cpu.go
+++ b/metricbeat/module/system/cpu/cpu.go
@@ -1,3 +1,5 @@
+// +build darwin linux openbsd windows
+
 package cpu
 
 import (

--- a/metricbeat/module/system/cpu/doc.go
+++ b/metricbeat/module/system/cpu/doc.go
@@ -1,0 +1,4 @@
+/*
+Package cpu collects CPU metrics from the host OS.
+*/
+package cpu

--- a/metricbeat/module/system/memory/doc.go
+++ b/metricbeat/module/system/memory/doc.go
@@ -1,0 +1,4 @@
+/*
+Package memory collects memory metrics from the host OS.
+*/
+package memory

--- a/metricbeat/module/system/memory/memory.go
+++ b/metricbeat/module/system/memory/memory.go
@@ -1,3 +1,5 @@
+// +build darwin linux openbsd windows
+
 package memory
 
 import (
@@ -5,7 +7,6 @@ import (
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
-	_ "github.com/elastic/beats/metricbeat/module/system"
 	"github.com/elastic/beats/topbeat/system"
 )
 

--- a/metricbeat/tests/system/test_system.py
+++ b/metricbeat/tests/system/test_system.py
@@ -1,7 +1,7 @@
-import os
+import re
+import sys
+import unittest
 import metricbeat
-from nose.plugins.attrib import attr
-
 
 SYSTEM_CPU_FIELDS = ["idle", "iowait", "irq", "nice", "softirq",
                      "steal", "system", "system_p", "user", "user_p"]
@@ -9,6 +9,7 @@ SYSTEM_CPU_FIELDS = ["idle", "iowait", "irq", "nice", "softirq",
 SYSTEM_MEMORY_FIELDS = ["swap", "mem"]
 
 
+@unittest.skipUnless(re.match("(?i)win|linux|darwin|openbsd", sys.platform), "os")
 class SystemTest(metricbeat.BaseTest):
     def test_cpu(self):
         """
@@ -63,5 +64,4 @@ class SystemTest(metricbeat.BaseTest):
         memory = evt["system-memory"]
         self.assertItemsEqual(SYSTEM_MEMORY_FIELDS, memory.keys())
 
-        # TODO: After fields.yml is updated this can be uncommented.
-        #self.assert_fields_are_documented(evt)
+        self.assert_fields_are_documented(evt)


### PR DESCRIPTION
The gosigar library support windows, linux, darwin, and openbsd which means you need CGO to build for these platforms. This disables cross-compiling for those platforms when running `make crosscompile`.

It also disables the cpu/memory system test unless it is running on an OS with these features.