### PR TITLE
Add Jmxproxybeat to community beats

### DIFF
--- a/libbeat/docs/communitybeats.asciidoc
+++ b/libbeat/docs/communitybeats.asciidoc
@@ -16,6 +16,7 @@ https://github.com/FStelzer/flowbeat[flowbeat]:: Collects, parses, and indexes h
 https://github.com/YaSuenag/hsbeat[hsbeat]:: Reads all performance counters in Java HotSpot VM.
 https://github.com/christiangalsterer/httpbeat[httpbeat]:: Polls multiple HTTP(S) endpoints and sends the data to
 Logstash or Elasticsearch. Supports all HTTP methods and proxies.
+https://github.com/radoondas/jmxproxybeat[jmxproxybeat]:: Reads Tomcat JMX metrics exposed over 'JMX Proxy Servlet' to HTTP.
 https://github.com/eskibars/lmsensorsbeat[lmsensorsbeat]:: Collects data from lm-sensors (such as CPU temperatures, fan speeds, and voltages from i2c and smbus)
 https://github.com/PhaedrusTheGreek/nagioscheckbeat[nagioscheckbeat]:: For Nagios checks and performance data.
 https://github.com/mrkschan/nginxbeat[nginxbeat]:: Reads status from Nginx.


### PR DESCRIPTION
This PR adds new little beat for JMX metrics from Tomcat exposed via JMX Proxy Servlet to HTTP listener. 