### PR TITLE
New template generation logic

### DIFF
--- a/filebeat/docs/fields.asciidoc
+++ b/filebeat/docs/fields.asciidoc
@@ -19,6 +19,9 @@ Contains common fields available in all event types.
 
 
 
+=== beat Fields
+
+
 ==== beat.name
 
 The name of the Beat sending the log messages. If the shipper name is set in the configuration file, then that value is used. If it is not set, the hostname is used.
@@ -93,8 +96,6 @@ The content of the line read from the log file.
 ==== fields
 
 type: dict
-
-required: False
 
 Contains user configurable fields.
 

--- a/filebeat/etc/fields.yml
+++ b/filebeat/etc/fields.yml
@@ -1,27 +1,26 @@
-version: 1.0
-
 defaults:
   type: keyword
   required: false
   index: true
-  doc_values: true
-  ignore_above: 1024
 
 env:
   type: group
   description: >
     Contains common fields available in all event types.
   fields:
-    - name: beat.name
-      description: >
-        The name of the Beat sending the log messages. If the shipper name is set
-        in the configuration file, then that value is used. If it is not set,
-        the hostname is used.
+    - type: group
+      name: beat
+      fields:
+      - name: name
+        description: >
+          The name of the Beat sending the log messages. If the shipper name is set
+          in the configuration file, then that value is used. If it is not set,
+          the hostname is used.
 
-    - name: beat.hostname
-      description: >
-        The hostname as returned by the operating system on which the Beat is
-        running.
+      - name: hostname
+        description: >
+          The hostname as returned by the operating system on which the Beat is
+          running.
 
     - name: "@timestamp"
       type: date
@@ -62,7 +61,6 @@ log:
 
     - name: message
       type: text
-      doc_values: true
       ignore_above: 0
       required: true
       description: >
@@ -70,7 +68,7 @@ log:
 
     - name: fields
       type: dict
-      required: false
+      dict-type: keyword
       description: >
         Contains user configurable fields.
 

--- a/filebeat/filebeat.template.json
+++ b/filebeat/filebeat.template.json
@@ -6,14 +6,14 @@
       },
       "dynamic_templates": [
         {
-          "template1": {
+          "fields": {
             "mapping": {
-              "doc_values": true,
               "ignore_above": 1024,
               "index": true,
               "type": "keyword"
             },
-            "match_mapping_type": "string"
+            "match_mapping_type": "string",
+            "path_match": "fields.*"
           }
         }
       ],
@@ -21,16 +21,41 @@
         "@timestamp": {
           "type": "date"
         },
+        "beat": {
+          "properties": {
+            "hostname": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "input_type": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
         "message": {
           "norms": false,
           "type": "text"
         },
         "offset": {
           "type": "long"
+        },
+        "source": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "type": {
+          "ignore_above": 1024,
+          "type": "keyword"
         }
       }
     }
   },
+  "order": 0,
   "settings": {
     "index.refresh_interval": "5s"
   },

--- a/libbeat/scripts/generate_template.py
+++ b/libbeat/scripts/generate_template.py
@@ -6,7 +6,7 @@ the etc/fields.yml file.
 
 Example usage:
 
-   python generate_template.py etc/fields.yml topbeat.template.json
+   python generate_template.py filebeat/ filebeat
 """
 
 import sys
@@ -35,14 +35,21 @@ def fields_to_es_template(input, output, index):
 
     # Each template needs defaults
     if "defaults" not in docs.keys():
-        print "No defaults are defined. Each template needs at least defaults defined."
+        print("No defaults are defined. Each template needs at" +
+              " least defaults defined.")
         return
 
     defaults = docs["defaults"]
 
+    # de-dot
+    for doc, section in docs.items():
+        if doc != "defaults":
+            docs[doc] = dedot(section)
+
     # skeleton
     template = {
         "template": index,
+        "order": 0,
         "settings": {
             "index.refresh_interval": "5s"
         },
@@ -51,95 +58,148 @@ def fields_to_es_template(input, output, index):
                 "_all": {
                     "norms": False
                 },
-                "properties": {},
-                "dynamic_templates": [{
-                    "template1": {
-                        "match_mapping_type": "string",
-                        "mapping": {
-                            "type": "keyword",
-                            "index": defaults["index"],
-                            "doc_values": defaults["doc_values"],
-                            "ignore_above": defaults["ignore_above"]
-                        }
-                    }
-                }]
+                "properties": {}
             }
         }
     }
 
     properties = {}
+    dynamic_templates = []
     for doc, section in docs.items():
-        if doc not in ["version", "defaults"]:
-            prop = fill_section_properties(section, defaults)
+        if doc != "defaults":
+            prop, dynamic = fill_section_properties(section, defaults, "")
             properties.update(prop)
+            dynamic_templates.extend(dynamic)
 
     template["mappings"]["_default_"]["properties"] = properties
+    if len(dynamic_templates) > 0:
+        template["mappings"]["_default_"]["dynamic_templates"] = \
+            dynamic_templates
 
     json.dump(template, output,
               indent=2, separators=(',', ': '),
               sort_keys=True)
 
 
-def fill_section_properties(section, defaults):
+def dedot(group):
+    """
+    Walk the tree and transform keys like "beat.name" and "beat.hostname" into
+      - name: "beat"
+        type: group
+        fields:
+        - name: name
+            ...
+        - name: hostname
+            ...
+    """
+    fields = []
+    dedotted = {}
+    for field in group["fields"]:
+        if "." in field["name"]:
+            # dedot
+            newkey, rest = field["name"].split(".", 1)
+            field["name"] = rest    # move one level down
+            if newkey not in dedotted:
+                dedotted[newkey] = {
+                    "name": newkey,
+                    "type": "group",
+                    "fields": []
+                }
+            if field.get("type") == "group":
+                dedotted[newkey]["fields"].append(dedotted(field))
+            else:
+                dedotted[newkey]["fields"].append(field)
+        elif field.get("type") == "group":
+            # call recursively
+            fields.append(dedot(field))
+        else:
+            fields.append(field)
+    for _, field in dedotted.items():
+        fields.append(field)
+    group["fields"] = fields
+    return group
+
+
+def fill_section_properties(section, defaults, path):
     """
     Traverse the sections tree and fill in the properties
     map.
     """
     properties = {}
+    dynamic_templates = []
 
     for field in section["fields"]:
-        prop = fill_field_properties(field, defaults)
+        prop, dynamic = fill_field_properties(field, defaults, path)
         properties.update(prop)
+        dynamic_templates.extend(dynamic)
 
-    return properties
+    return properties, dynamic_templates
 
 
-def fill_field_properties(field, defaults):
+def fill_field_properties(field, defaults, path):
     """
     Add data about a particular field in the properties
     map.
     """
     properties = {}
+    dynamic_templates = []
 
     for key in defaults.keys():
         if key not in field:
             field[key] = defaults[key]
 
     # TODO: Make this more dyanmic
-    if field.get("type") == "text":
+    if field["type"] == "text":
         properties[field["name"]] = {
             "type": field["type"],
             "norms": False
         }
 
-    elif field.get("type")  == "keyword":
-        mapping = {
-        }
-        if field.get("doc_values") != defaults.get("doc_values"):
-             mapping["doc_values"] = field.get("doc_values")
-        if field.get("ignore_above") != defaults.get("ignore_above"):
-             mapping["ignore_above"] = field.get("ignore_above")
-        if len(mapping) > 0:
-            # only add the field if the mapping is different from the defaults
-            mapping["type"] = "keyword"
-            properties[field["name"]] = mapping
-
-    elif field.get("type") in ["geo_point", "date", "long", "integer", "double", "float"]:
+    elif field["type"] in ["geo_point", "date", "long", "integer",
+                           "double", "float", "keyword"]:
         properties[field["name"]] = {
             "type": field.get("type")
         }
+        if field["type"] == "keyword":
+            properties[field["name"]]["ignore_above"] = \
+                defaults.get("ignore_above", 1024)
+
+    elif field["type"] == "dict":
+        if field.get("dict-type") == "keyword":
+            # add a dynamic template to set all members of
+            # the dict as keywords
+            if len(path) > 0:
+                name = path + "." + field["name"]
+            else:
+                name = field["name"]
+
+            dynamic_templates.append({
+                name: {
+                    "mapping": {
+                        "index": True,
+                        "type": "keyword",
+                        "ignore_above": 1024
+                    },
+                    "match_mapping_type": "string",
+                    "path_match": name + ".*"
+                }
+            })
 
     elif field.get("type") == "group":
-        prop = fill_section_properties(field, defaults)
+        if len(path) > 0:
+            path = path + "." + field["name"]
+        else:
+            path = field["name"]
+        prop, dynamic = fill_section_properties(field, defaults, path)
 
         # Only add properties if they have a content
         if len(prop) is not 0:
             properties[field.get("name")] = {"properties": {}}
             properties[field.get("name")]["properties"] = prop
 
-    # Otherwise let dynamic mappings do the job
+        dynamic_templates.extend(dynamic)
 
-    return properties
+    return properties, dynamic_templates
 
 
 if __name__ == "__main__":

--- a/metricbeat/docs/fields.asciidoc
+++ b/metricbeat/docs/fields.asciidoc
@@ -78,6 +78,18 @@ required: True
 The document type. Always set to "metricsets".
 
 
+==== tags
+
+Arbitrary tags that can be set per Beat and per transaction type.
+
+
+==== fields
+
+type: dict
+
+Contains user configurable fields.
+
+
 [[exported-fields-apache]]
 === Apache Status Fields
 

--- a/metricbeat/etc/fields.yml
+++ b/metricbeat/etc/fields.yml
@@ -1,5 +1,3 @@
-version: 1.0
-
 defaults:
   type: keyword
   required: false

--- a/metricbeat/etc/fields.yml
+++ b/metricbeat/etc/fields.yml
@@ -61,6 +61,18 @@ common:
       example: metricsets
       description: >
         The document type. Always set to "metricsets".
+
+    - name: tags
+      description: >
+        Arbitrary tags that can be set per Beat and per transaction
+        type.
+
+    - name: fields
+      type: dict
+      dict-type: keyword
+      description: >
+        Contains user configurable fields.
+
 apache:
   type: group
   description: >

--- a/metricbeat/metricbeat.template.json
+++ b/metricbeat/metricbeat.template.json
@@ -4,19 +4,6 @@
       "_all": {
         "norms": false
       },
-      "dynamic_templates": [
-        {
-          "template1": {
-            "mapping": {
-              "doc_values": true,
-              "ignore_above": 1024,
-              "index": true,
-              "type": "keyword"
-            },
-            "match_mapping_type": "string"
-          }
-        }
-      ],
       "properties": {
         "@timestamp": {
           "type": "date"
@@ -144,6 +131,30 @@
             }
           }
         },
+        "beat": {
+          "properties": {
+            "hostname": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "metricset": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "metricset-host": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "module": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
         "mysql-status": {
           "properties": {
             "aborted": {
@@ -227,10 +238,15 @@
               }
             }
           }
+        },
+        "type": {
+          "ignore_above": 1024,
+          "type": "keyword"
         }
       }
     }
   },
+  "order": 0,
   "settings": {
     "index.refresh_interval": "5s"
   },

--- a/metricbeat/metricbeat.template.json
+++ b/metricbeat/metricbeat.template.json
@@ -4,6 +4,19 @@
       "_all": {
         "norms": false
       },
+      "dynamic_templates": [
+        {
+          "fields": {
+            "mapping": {
+              "ignore_above": 1024,
+              "index": true,
+              "type": "keyword"
+            },
+            "match_mapping_type": "string",
+            "path_match": "fields.*"
+          }
+        }
+      ],
       "properties": {
         "@timestamp": {
           "type": "date"
@@ -238,6 +251,10 @@
               }
             }
           }
+        },
+        "tags": {
+          "ignore_above": 1024,
+          "type": "keyword"
         },
         "type": {
           "ignore_above": 1024,

--- a/packetbeat/docs/fields.asciidoc
+++ b/packetbeat/docs/fields.asciidoc
@@ -21,8 +21,7 @@ grouped in the following categories:
 * <<exported-fields-redis>>
 * <<exported-fields-mongodb>>
 * <<exported-fields-trans_measurements>>
-* <<exported-fields-trans_env>>
-* <<exported-fields-flows_env>>
+* <<exported-fields-env>>
 * <<exported-fields-raw>>
 * <<exported-fields-nfs>>
 
@@ -1645,10 +1644,10 @@ type: int
 In RUM (real-user-monitoring), the total time it takes for the DOM to be loaded. In terms of the W3 Navigation Timing API, this is the difference between `domContentLoadedEnd` and `domContentLoadedStart`.
 
 
-[[exported-fields-trans_env]]
-=== Environmental (Transactions) Fields
+[[exported-fields-env]]
+=== Environmental Fields
 
-These fields contain data about the environment in which the transaction was captured.
+These fields contain data about the environment in which the transaction or flow was captured.
 
 
 
@@ -1759,28 +1758,6 @@ Arbitrary tags that can be set per Beat and per transaction type.
 type: dict
 
 Contains user configurable fields.
-
-
-[[exported-fields-flows_env]]
-=== Environmental (Flows) Fields
-
-These fields contain data about the environment in which the flow data was captured.
-
-
-
-==== beat.name
-
-Name of the Beat sending the events. If the shipper name is set in the configuration file, then that value is used. If it is not set, the hostname is used.
-
-
-==== beat.hostname
-
-The hostname as returned by the operating system on which the Beat is running.
-
-
-==== tags
-
-Arbitrary tags that can be set per Beat and per transaction type.
 
 
 [[exported-fields-raw]]

--- a/packetbeat/docs/fields.asciidoc
+++ b/packetbeat/docs/fields.asciidoc
@@ -830,7 +830,9 @@ type: bool
 Acknowledge multiple messages.
 
 
-==== amqp.arguments.*
+==== amqp.arguments
+
+type: dict
 
 Optional additional arguments passed to some methods. Can be of various types.
 
@@ -865,7 +867,9 @@ type: keyword
 MIME content encoding.
 
 
-==== amqp.headers.*
+==== amqp.headers
+
+type: dict
 
 Message header field table.
 
@@ -1748,6 +1752,13 @@ The software release of the service serving the transaction. This can be the com
 ==== tags
 
 Arbitrary tags that can be set per Beat and per transaction type.
+
+
+==== fields
+
+type: dict
+
+Contains user configurable fields.
 
 
 [[exported-fields-flows_env]]

--- a/packetbeat/etc/fields.yml
+++ b/packetbeat/etc/fields.yml
@@ -1,10 +1,7 @@
-version: 1.0
-
 defaults:
   type: keyword
   required: false
   index: true
-  doc_values: true
   ignore_above: 1024
 
 flows_env:
@@ -45,6 +42,7 @@ trans_env:
       description: >
         The hostname as returned by the operating system on which the Beat is
         running.
+
 
     - name: server
       description: >
@@ -124,6 +122,12 @@ trans_env:
       description: >
         Arbitrary tags that can be set per Beat and per transaction
         type.
+
+    - name: fields
+      type: dict
+      dict-type: keyword
+      description: >
+        Contains user configurable fields.
 
 flows_event:
   type: group
@@ -783,7 +787,8 @@ trans_event:
           description: >
             Acknowledge multiple messages.
 
-        - name: arguments.*
+        - name: arguments
+          type: dict
           description: >
             Optional additional arguments passed to some methods. Can be of
             various types.
@@ -809,7 +814,9 @@ trans_event:
           description: >
             MIME content encoding.
 
-        - name: headers.*
+        - name: headers
+          type: dict
+          dict-type: keyword
           description: >
             Message header field table.
 
@@ -877,6 +884,7 @@ trans_event:
 
         - name: request_headers
           type: dict
+          dict-type: keyword
           description: >
             A map containing the captured header fields from the request.
             Which headers to capture is configurable. If headers with the same
@@ -885,6 +893,7 @@ trans_event:
 
         - name: response_headers
           type: dict
+          dict-type: keyword
           description: >
             A map containing the captured header fields from the response.
             Which headers to capture is configurable. If headers with the

--- a/packetbeat/etc/fields.yml
+++ b/packetbeat/etc/fields.yml
@@ -4,33 +4,11 @@ defaults:
   index: true
   ignore_above: 1024
 
-flows_env:
-  type: group
-  description: >
-    These fields contain data about the environment in which the flow data was
-    captured.
-  fields:
-    - name: beat.name
-      description: >
-        Name of the Beat sending the events. If the shipper name is set
-        in the configuration file, then that value is used. If it is not set,
-        the hostname is used.
-
-    - name: beat.hostname
-      description: >
-        The hostname as returned by the operating system on which the Beat is
-        running.
-
-    - name: tags
-      description: >
-        Arbitrary tags that can be set per Beat and per transaction
-        type.
-
-trans_env:
+env:
   type: group
   description: >
       These fields contain data about the environment in which the
-      transaction was captured.
+      transaction or flow was captured.
   fields:
     - name: beat.name
       description: >
@@ -1477,7 +1455,6 @@ sections:
   - ["redis", "Redis"]
   - ["mongodb", "MongoDb"]
   - ["trans_measurements", "Measurements (Transactions)"]
-  - ["trans_env", "Environmental (Transactions)"]
-  - ["flows_env", "Environmental (Flows)"]
+  - ["env", "Environmental"]
   - ["raw", "Raw"]
   - ["nfs", "NFS"]

--- a/packetbeat/packetbeat.template.json
+++ b/packetbeat/packetbeat.template.json
@@ -6,14 +6,47 @@
       },
       "dynamic_templates": [
         {
-          "template1": {
+          "fields": {
             "mapping": {
-              "doc_values": true,
               "ignore_above": 1024,
               "index": true,
               "type": "keyword"
             },
-            "match_mapping_type": "string"
+            "match_mapping_type": "string",
+            "path_match": "fields.*"
+          }
+        },
+        {
+          "amqp.headers": {
+            "mapping": {
+              "ignore_above": 1024,
+              "index": true,
+              "type": "keyword"
+            },
+            "match_mapping_type": "string",
+            "path_match": "amqp.headers.*"
+          }
+        },
+        {
+          "http.request_headers": {
+            "mapping": {
+              "ignore_above": 1024,
+              "index": true,
+              "type": "keyword"
+            },
+            "match_mapping_type": "string",
+            "path_match": "http.request_headers.*"
+          }
+        },
+        {
+          "http.response_headers": {
+            "mapping": {
+              "ignore_above": 1024,
+              "index": true,
+              "type": "keyword"
+            },
+            "match_mapping_type": "string",
+            "path_match": "http.response_headers.*"
           }
         }
       ],
@@ -21,62 +54,687 @@
         "@timestamp": {
           "type": "date"
         },
+        "amqp": {
+          "properties": {
+            "app-id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "consumer-tag": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "content-encoding": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "content-type": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "correlation-id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "exchange": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "exchange-type": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "expiration": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "message-id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "queue": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "reply-text": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "reply-to": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "timestamp": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "type": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "user-id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "beat": {
+          "properties": {
+            "hostname": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "client_ip": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
         "client_location": {
           "type": "geo_point"
         },
+        "client_port": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "client_proc": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "client_server": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "client_service": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "connection_id": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
         "dest": {
           "properties": {
+            "ip": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "ip_location": {
               "type": "geo_point"
+            },
+            "ipv6": {
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "ipv6_location": {
               "type": "geo_point"
             },
+            "mac": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "outer_ip": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "outer_ip_location": {
               "type": "geo_point"
             },
+            "outer_ipv6": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "outer_ipv6_location": {
               "type": "geo_point"
+            },
+            "port": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "stats": {
+              "properties": {
+                "net_bytes_total": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "net_packets_total": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
             }
           }
         },
+        "direction": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "dns": {
+          "properties": {
+            "additionals": {
+              "properties": {
+                "class": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "data": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "answers": {
+              "properties": {
+                "class": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "data": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "authorities": {
+              "properties": {
+                "class": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "op_code": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "opt": {
+              "properties": {
+                "ext_rcode": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "version": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "question": {
+              "properties": {
+                "class": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "etld_plus_one": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "response_code": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "final": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "flow_id": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "http": {
+          "properties": {
+            "code": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "phrase": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "icmp": {
+          "properties": {
+            "request": {
+              "properties": {
+                "message": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "response": {
+              "properties": {
+                "message": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "version": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "icmp_id": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "ip": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
         "last_time": {
           "type": "date"
+        },
+        "memcache": {
+          "properties": {
+            "protocol_type": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "request": {
+              "properties": {
+                "automove": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "command": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "line": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "opcode": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "raw_args": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "response": {
+              "properties": {
+                "command": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "error_msg": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "opcode": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "status": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "version": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            }
+          }
+        },
+        "method": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "mongodb": {
+          "properties": {
+            "cursorId": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "error": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "fullCollectionName": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "query": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "returnFieldsSelector": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "selector": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "startingFrom": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "update": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "mysql": {
+          "properties": {
+            "error_message": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "insert_id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "num_fields": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "num_rows": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "query": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "nfs": {
+          "properties": {
+            "opcode": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "status": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "tag": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "notes": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "outer_vlan": {
+          "ignore_above": 1024,
+          "type": "keyword"
         },
         "params": {
           "norms": false,
           "type": "text"
         },
+        "path": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "pgsql": {
+          "properties": {
+            "error_message": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "error_severity": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "num_fields": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "num_rows": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "query": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "port": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "proc": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "query": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "real_ip": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "redis": {
+          "properties": {
+            "error": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "return_value": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "release": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
         "request": {
           "norms": false,
           "type": "text"
+        },
+        "resource": {
+          "ignore_above": 1024,
+          "type": "keyword"
         },
         "response": {
           "norms": false,
           "type": "text"
         },
+        "rpc": {
+          "properties": {
+            "auth_flavor": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "cred": {
+              "properties": {
+                "gids": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "machinename": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "status": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "time_str": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "xid": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "server": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "service": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
         "source": {
           "properties": {
+            "ip": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "ip_location": {
               "type": "geo_point"
+            },
+            "ipv6": {
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "ipv6_location": {
               "type": "geo_point"
             },
+            "mac": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "outer_ip": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "outer_ip_location": {
               "type": "geo_point"
             },
+            "outer_ipv6": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "outer_ipv6_location": {
               "type": "geo_point"
+            },
+            "port": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "stats": {
+              "properties": {
+                "net_bytes_total": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "net_packets_total": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
             }
           }
         },
         "start_time": {
           "type": "date"
+        },
+        "status": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "tags": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "thrift": {
+          "properties": {
+            "exceptions": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "params": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "return_value": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "service": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "transport": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "type": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "vlan": {
+          "ignore_above": 1024,
+          "type": "keyword"
         }
       }
     }
   },
+  "order": 0,
   "settings": {
     "index.refresh_interval": "5s"
   },

--- a/topbeat/docs/fields.asciidoc
+++ b/topbeat/docs/fields.asciidoc
@@ -51,6 +51,18 @@ Name of the Beat sending the events. If the shipper name is set in the configura
 The hostname as returned by the operating system on which the Beat is running.
 
 
+==== tags
+
+Arbitrary tags that can be set per Beat and per transaction type.
+
+
+==== fields
+
+type: dict
+
+Contains user configurable fields.
+
+
 [[exported-fields-system]]
 === System-Wide Statistics Fields
 

--- a/topbeat/etc/fields.yml
+++ b/topbeat/etc/fields.yml
@@ -1,10 +1,7 @@
-version: 1.0
-
 defaults:
   type: keyword
   required: false
   index: true
-  doc_values: true
   ignore_above: 1024
 
 env:
@@ -36,6 +33,17 @@ env:
       description: >
         The hostname as returned by the operating system on which the Beat is
         running.
+
+    - name: tags
+      description: >
+        Arbitrary tags that can be set per Beat and per transaction
+        type.
+
+    - name: fields
+      type: dict
+      dict-type: keyword
+      description: >
+        Contains user configurable fields.
 
 system:
   type: group

--- a/topbeat/topbeat.template.json
+++ b/topbeat/topbeat.template.json
@@ -6,20 +6,32 @@
       },
       "dynamic_templates": [
         {
-          "template1": {
+          "fields": {
             "mapping": {
-              "doc_values": true,
               "ignore_above": 1024,
               "index": true,
               "type": "keyword"
             },
-            "match_mapping_type": "string"
+            "match_mapping_type": "string",
+            "path_match": "fields.*"
           }
         }
       ],
       "properties": {
         "@timestamp": {
           "type": "date"
+        },
+        "beat": {
+          "properties": {
+            "hostname": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
         },
         "cpu": {
           "properties": {
@@ -47,6 +59,14 @@
         },
         "fs": {
           "properties": {
+            "device_name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "mount_point": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "used_p": {
               "type": "float"
             }
@@ -77,8 +97,16 @@
         },
         "proc": {
           "properties": {
+            "cmdline": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "cpu": {
               "properties": {
+                "start_time": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "total_p": {
                   "type": "float"
                 }
@@ -90,6 +118,18 @@
                   "type": "float"
                 }
               }
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "state": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "username": {
+              "ignore_above": 1024,
+              "type": "keyword"
             }
           }
         },
@@ -99,10 +139,19 @@
               "type": "float"
             }
           }
+        },
+        "tags": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "type": {
+          "ignore_above": 1024,
+          "type": "keyword"
         }
       }
     }
   },
+  "order": 0,
   "settings": {
     "index.refresh_interval": "5s"
   },

--- a/winlogbeat/docs/fields.asciidoc
+++ b/winlogbeat/docs/fields.asciidoc
@@ -50,6 +50,18 @@ The event log API type used to read the record. The possible values are "wineven
 The Event Logging API was designed for Windows Server 2003, Windows XP, or Windows 2000 operating systems. In Windows Vista, the event logging infrastructure was redesigned. On Windows Vista or later operating systems, the Windows Event Log API is used. Winlogbeat automatically detects which API to use for reading event logs.
 
 
+==== tags
+
+Arbitrary tags that can be set per Beat and per transaction type.
+
+
+==== fields
+
+type: dict
+
+Contains user configurable fields.
+
+
 [[exported-fields-eventlog]]
 === Event Log Record Fields
 

--- a/winlogbeat/docs/fields.asciidoc
+++ b/winlogbeat/docs/fields.asciidoc
@@ -77,7 +77,7 @@ The name of the computer that generated the record. When using Windows event for
 
 ==== event_data
 
-type: dictionary
+type: dict
 
 required: False
 
@@ -95,7 +95,7 @@ The event identifier. The value is specific to the source of the event.
 
 ==== keywords
 
-type: keyword[]
+type: keyword
 
 required: False
 
@@ -212,7 +212,7 @@ The thread_id identifies the thread that generated the event.
 
 ==== user_data
 
-type: dictionary
+type: dict
 
 required: False
 

--- a/winlogbeat/etc/fields.yml
+++ b/winlogbeat/etc/fields.yml
@@ -42,6 +42,17 @@ common:
         systems, the Windows Event Log API is used. Winlogbeat automatically
         detects which API to use for reading event logs.
 
+    - name: tags
+      description: >
+        Arbitrary tags that can be set per Beat and per transaction
+        type.
+
+    - name: fields
+      type: dict
+      dict-type: keyword
+      description: >
+        Contains user configurable fields.
+
 eventlog:
   type: group
   description: >

--- a/winlogbeat/etc/fields.yml
+++ b/winlogbeat/etc/fields.yml
@@ -1,5 +1,3 @@
-version: 1.0
-
 defaults:
   type: keyword
   required: false
@@ -65,7 +63,8 @@ eventlog:
         event forwarding, this name can differ from the `beat.hostname`.
 
     - name: event_data
-      type: dictionary
+      type: dict
+      dict-type: keyword
       required: false
       description: >
         The event specific data. This field is mutually exclusive with
@@ -78,7 +77,7 @@ eventlog:
         The event identifier. The value is specific to the source of the event.
 
     - name: keywords
-      type: keyword[]
+      type: keyword
       required: false
       description: >
         The keywords are used to classify an event.
@@ -173,7 +172,8 @@ eventlog:
         The thread_id identifies the thread that generated the event.
 
     - name: user_data
-      type: dictionary
+      type: dict
+      dict-type: keyword
       required: false
       description: >
         The event specific data. This field is mutually exclusive with

--- a/winlogbeat/winlogbeat.template.json
+++ b/winlogbeat/winlogbeat.template.json
@@ -6,6 +6,17 @@
       },
       "dynamic_templates": [
         {
+          "fields": {
+            "mapping": {
+              "ignore_above": 1024,
+              "index": true,
+              "type": "keyword"
+            },
+            "match_mapping_type": "string",
+            "path_match": "fields.*"
+          }
+        },
+        {
           "event_data": {
             "mapping": {
               "ignore_above": 1024,
@@ -95,6 +106,10 @@
           "type": "keyword"
         },
         "source_name": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "tags": {
           "ignore_above": 1024,
           "type": "keyword"
         },

--- a/winlogbeat/winlogbeat.template.json
+++ b/winlogbeat/winlogbeat.template.json
@@ -6,14 +6,25 @@
       },
       "dynamic_templates": [
         {
-          "template1": {
+          "event_data": {
             "mapping": {
-              "doc_values": true,
               "ignore_above": 1024,
               "index": true,
               "type": "keyword"
             },
-            "match_mapping_type": "string"
+            "match_mapping_type": "string",
+            "path_match": "event_data.*"
+          }
+        },
+        {
+          "user_data": {
+            "mapping": {
+              "ignore_above": 1024,
+              "index": true,
+              "type": "keyword"
+            },
+            "match_mapping_type": "string",
+            "path_match": "user_data.*"
           }
         }
       ],
@@ -21,22 +32,107 @@
         "@timestamp": {
           "type": "date"
         },
+        "activity_id": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "beat": {
+          "properties": {
+            "hostname": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "computer_name": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
         "event_id": {
           "type": "long"
+        },
+        "keywords": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "level": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "log_name": {
+          "ignore_above": 1024,
+          "type": "keyword"
         },
         "message": {
           "norms": false,
           "type": "text"
         },
+        "message_error": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "opcode": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
         "process_id": {
           "type": "long"
         },
+        "provider_guid": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "record_number": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "related_activity_id": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "source_name": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "task": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
         "thread_id": {
           "type": "long"
+        },
+        "type": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "user": {
+          "properties": {
+            "domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "identifier": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "type": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
         }
       }
     }
   },
+  "order": 0,
   "settings": {
     "index.refresh_interval": "5s"
   },


### PR DESCRIPTION
* Put all fields in the template, even the ones with default settings.
* No longer set a catch all default to type "keyword". ES will fallback to a
  a multifield (name and name.keyword). This can be more useful in the case
  of the JSON output, for example.
* The template generation script now removes the dots from field names (replaces them
  with dictionaries). I took this approach, rather then modifying `fields.yml` to not
  interfere with the documentation.
* If `dict-type: keyword` is used, a dynamic mapping is added to match on the path and
  set the type to keyword.
* Added the custom `fields` to all etc/fields.yml, using the `dict-type: keyword` features
* Removed version as it was not used
* Fixed invalid fields definitions (e.g. `amqp.headers.*`, `type: keyword[]`)

This implements #1427.