### PR TITLE
Remove deprecated 'host' option

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -17,6 +17,7 @@ https://github.com/elastic/beats/compare/v5.0.0-alpha1...master[Check the HEAD d
 - Add scripts for managing the dashboards of a single Beat {pull}1359[1359]
 - On DEB/RPM installations, the binary files are now found under `/usr/share/{{beat_name}}/bin`, not in `/usr/bin`. {pull}1385[1385]
 - The logs are written by default to self rotating files, instead of syslog. {pull}1371[1371]
+- Remove deprecated `host` option from elasticsearch, logstash and redis outputs. {pull}1474[1474]
 
 *Packetbeat*
 

--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -131,13 +131,9 @@ The number of workers per configured host publishing events to Elasticsearch. Th
 is best used with load balancing mode enabled. Example: If you have 2 hosts and
 3 workers, in total 6 workers are started (3 for each host).
 
-===== host (DEPRECATED)
+===== port
 
-The host of the Elasticsearch server. This option is deprecated because it is replaced by <<hosts-option>>.
-
-===== port (DEPRECATED)
-
-The port of the Elasticsearch server. This option is deprecated because it is replaced by <<hosts-option>>.
+The default port of the Elasticsearch server if the port number is missing in <<hosts-option>> URL. The default port number is 9200.
 
 ===== username
 

--- a/libbeat/outputs/mode/mode.go
+++ b/libbeat/outputs/mode/mode.go
@@ -182,7 +182,6 @@ func MakeAsyncClients(
 
 func ReadHostList(cfg *common.Config) ([]string, error) {
 	config := struct {
-		Host   string   `config:"host"`
 		Hosts  []string `config:"hosts"`
 		Worker int      `config:"worker"`
 	}{
@@ -194,14 +193,7 @@ func ReadHostList(cfg *common.Config) ([]string, error) {
 		return nil, err
 	}
 
-	// TODO: remove config.Host
-	var lst []string
-	if len(config.Hosts) > 0 {
-		lst = config.Hosts
-	} else if config.Host != "" {
-		lst = []string{config.Host}
-	}
-
+	lst := config.Hosts
 	if len(lst) == 0 || config.Worker <= 1 {
 		return lst, nil
 	}


### PR DESCRIPTION
remove support for deprecated `host` option in elasticsearch, logstash, kafka
and redis output.