### PR TITLE
Winlogbeat - fix large message panic for WinXP/2003

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -57,6 +57,8 @@ https://github.com/elastic/beats/compare/v5.0.0-alpha1...master[Check the HEAD d
 
 *Winlogbeat*
 
+- Fix panic when reading messages larger than 32K characters on Windows XP and 2003. {pull}1498[1498]
+
 ==== Added
 
 *Affecting all Beats*


### PR DESCRIPTION
Fix panic when reading messages larger than 32K characters on XP and 2003.

Winlogbeat was passing the size of the buffer to Windows using number of bytes, but Windows was expecting number of TCHAR's. This made Windows return that the number of TCHARs read was greater than the number that the buffer could hold. Winlogbeat used the return value to read from the buffer which caused a 'runtime error: slice bounds out of range' panic.

The buffer length issue has been corrected by dividing by sizeof(TCHAR) which is 2. In addition a check has been added to verify that the return value from Windows is sane before using it to slice the buffer.

Reported here: https://discuss.elastic.co/t/report-a-bug-of-winlogbeat-5-0-0-alpha1-windows-32/47550