### PR TITLE
Winlogbeat - fix large message panic for Windows Vista and newer

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -59,6 +59,8 @@ https://github.com/elastic/beats/compare/v5.0.0-alpha1...master[Check the HEAD d
 *Winlogbeat*
 
 - Fix panic when reading messages larger than 32K characters on Windows XP and 2003. {pull}1498[1498]
+- Fix panic that occurs when reading a large events on Windows Vista and newer. {pull}1499[1499]
+
 
 ==== Added
 


### PR DESCRIPTION
Fix panic that occurs when reading a large events on Windows Vista and newer.

This occurs in an error recovery path so in order for the panic to occur, first there had to have been an error rendering the event as XML with the event message string. When that error occurs Winlogbeat tries to render the event as XML, but without the message string. If the XML was larger than half the buffer size a panic would occur.

The cause was invalid handling of the "BufferUsed [out]" parameter value. The value specifies the number of bytes in this case and it was treated as if it where the number of characters. This is opposite of the behavior of FormatMessage() used in earlier versions of Windows which returns the number of characters rather than bytes.

Reported here: https://discuss.elastic.co/t/report-a-bug-of-winlogbeat-5-0-0-alpha1-windows-32/47550/4