### PR TITLE
Initialize random number generator seed.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -47,6 +47,7 @@ https://github.com/elastic/beats/compare/v5.0.0-alpha1...master[Check the HEAD d
 - Fix issue with the automatic template loading when Elasticsearch is not available on Beat start. {issue}1321[1321]
 - Fix bug affecting -cpuprofile, -memprofile, and -httpprof CLI flags {pull}1415[1415]
 - Fix race when multiple outputs access the same event with logstash output manipulating event {issue}1410[1410] {pull}1428[1428]
+- Seed random number generator using crypto.rand package. {pull}1503{1503]
 
 *Packetbeat*
 

--- a/libbeat/beat/beat.go
+++ b/libbeat/beat/beat.go
@@ -30,10 +30,15 @@ Recommendations
 package beat
 
 import (
+	cryptRand "crypto/rand"
 	"flag"
 	"fmt"
+	"math"
+	"math/big"
+	"math/rand"
 	"os"
 	"runtime"
+	"time"
 
 	"github.com/elastic/beats/libbeat/cfgfile"
 	"github.com/elastic/beats/libbeat/common"
@@ -120,6 +125,24 @@ func Run(name, version string, bt Beater) error {
 type instance struct {
 	data   *Beat
 	beater Beater
+}
+
+func init() {
+	// Initialize runtime random number generator seed using global, shared
+	// cryptographically strong pseudo random number generator.
+	//
+	// On linux Reader might use getrandom(2) or /udev/random. On windows systems
+	// CryptGenRandom is used.
+	n, err := cryptRand.Int(cryptRand.Reader, big.NewInt(math.MaxInt64))
+	var seed int64
+	if err != nil {
+		// fallback to current timestamp on error
+		seed = time.Now().UnixNano()
+	} else {
+		seed = n.Int64()
+	}
+
+	rand.Seed(seed)
 }
 
 // newInstance creates and initializes a new Beat instance.


### PR DESCRIPTION
Initialize random number generator using cryptographic seed read from OS. Fixes
issues with random number generator always returning same sequence, e.g. when
using random endpoint connecting to logstash in failover mode.