### PR TITLE
Use longs everywhere where integer might overflow.

### DIFF
--- a/metricbeat/docs/fields.asciidoc
+++ b/metricbeat/docs/fields.asciidoc
@@ -112,14 +112,14 @@ Apache hostname
 
 ==== apache-status.totalAccesses
 
-type: integer
+type: long
 
 Total number of access requests
 
 
 ==== apache-status.totalKBytes
 
-type: integer
+type: long
 
 Total number of kilobytes served
 
@@ -399,14 +399,14 @@ Number of client connections (excluding connections from slaves)
 
 ==== redis-info.clients.client_longest_output_list
 
-type: integer
+type: long
 
 Longest output list among current client connections.
 
 
 ==== redis-info.clients.client_biggest_input_buf
 
-type: integer
+type: long
 
 Biggest input buffer among current client connections
 
@@ -506,14 +506,14 @@ Bytes stats
 
 ==== mysql-status.bytes.Bytes_received
 
-type: integer
+type: long
 
 The number of bytes received from all clients.
 
 
 ==== mysql-status.bytes.Bytes_sent
 
-type: integer
+type: long
 
 The number of bytes sent to all clients.
 
@@ -533,7 +533,7 @@ System status metrics, like CPU and memory usage, that are collected from the op
 
 ==== system-cpu.user
 
-type: integer
+type: long
 
 The amount of CPU time spent in user space.
 
@@ -547,14 +547,14 @@ The percentage of CPU time spent in user space. On multi-core systems, you can h
 
 ==== system-cpu.nice
 
-type: integer
+type: long
 
 The amount of CPU time spent on low-priority processes.
 
 
 ==== system-cpu.system
 
-type: integer
+type: long
 
 The amount of CPU time spent in kernel space.
 
@@ -568,34 +568,34 @@ The percentage of CPU time spent in kernel space.
 
 ==== system-cpu.idle
 
-type: integer
+type: long
 
 The amount of CPU time spent idle.
 
 
 ==== system-cpu.iowait
 
-type: integer
+type: long
 
 The amount of CPU time spent in wait (on disk).
 
 
 ==== system-cpu.irq
 
-type: integer
+type: long
 
 The amount of CPU time spent servicing and handling hardware interrupts.
 
 
 ==== system-cpu.softirq
 
-type: integer
+type: long
 
 The amount of CPU time spent servicing and handling software interrupts.
 
 ==== system-cpu.steal
 
-type: integer
+type: long
 
 The amount of CPU time spent in involuntary wait by the virtual CPU while the hypervisor was servicing another processor. Available only on Unix.
 
@@ -614,21 +614,21 @@ This group contains statistics related to the memory usage on the system.
 
 ==== system-memory.mem.total
 
-type: integer
+type: long
 
 Total memory.
 
 
 ==== system-memory.mem.used
 
-type: integer
+type: long
 
 Used memory.
 
 
 ==== system-memory.mem.free
 
-type: integer
+type: long
 
 Available memory.
 
@@ -642,14 +642,14 @@ The percentage of used memory.
 
 ==== system-memory.mem.actual_used
 
-type: integer
+type: long
 
 Actual used memory. This value is the "used" memory minus the memory used for disk caches and buffers. Available only on Unix.
 
 
 ==== system-memory.mem.actual_free
 
-type: integer
+type: long
 
 Actual available memory. This value is the "free" memory plus the memory used for disk caches and buffers. Available only on Unix.
 
@@ -669,21 +669,21 @@ This group contains statistics related to the swap memory usage on the system.
 
 ==== system-memory.swap.total
 
-type: integer
+type: long
 
 Total swap memory.
 
 
 ==== system-memory.swap.used
 
-type: integer
+type: long
 
 Used swap memory.
 
 
 ==== system-memory.swap.free
 
-type: integer
+type: long
 
 Available swap memory.
 

--- a/metricbeat/etc/fields.yml
+++ b/metricbeat/etc/fields.yml
@@ -88,11 +88,11 @@ apache:
           description: >
             Apache hostname
         - name: totalAccesses
-          type: integer
+          type: long
           description: >
             Total number of access requests
         - name: totalKBytes
-          type: integer
+          type: long
           description: >
             Total number of kilobytes served
         - name: reqPerSec
@@ -276,12 +276,12 @@ mysql:
             Bytes stats
           fields:
             - name: Bytes_received
-              type: integer
+              type: long
               description: >
                 The number of bytes received from all clients.
 
             - name: Bytes_sent
-              type: integer
+              type: long
               description: >
                 The number of bytes sent to all clients.
 redis:
@@ -306,12 +306,12 @@ redis:
                 Number of client connections (excluding connections from slaves)
 
             - name: client_longest_output_list
-              type: integer
+              type: long
               description: >
                 Longest output list among current client connections.
 
             - name: client_biggest_input_buf
-              type: integer
+              type: long
               description: >
                 Biggest input buffer among current client connections
 
@@ -365,7 +365,7 @@ system:
         `system-cpu` contains local cpu stats.
       fields:
         - name: user
-          type: integer
+          type: long
           description: >
            The amount of CPU time spent in user space.
 
@@ -376,12 +376,12 @@ system:
             For example, if 3 cores are at 60% use, then the `cpu.user_p` will be 180%.
 
         - name: nice
-          type: integer
+          type: long
           description: >
             The amount of CPU time spent on low-priority processes.
 
         - name: system
-          type: integer
+          type: long
           description: >
             The amount of CPU time spent in kernel space.
 
@@ -391,27 +391,27 @@ system:
             The percentage of CPU time spent in kernel space.
 
         - name: idle
-          type: integer
+          type: long
           description: >
             The amount of CPU time spent idle.
 
         - name: iowait
-          type: integer
+          type: long
           description: >
             The amount of CPU time spent in wait (on disk).
 
         - name: irq
-          type: integer
+          type: long
           description: >
             The amount of CPU time spent servicing and handling hardware interrupts.
 
         - name: softirq
-          type: integer
+          type: long
           description:
             The amount of CPU time spent servicing and handling software interrupts.
 
         - name: steal
-          type: integer
+          type: long
           description: >
             The amount of CPU time spent in involuntary wait by the virtual CPU while the hypervisor
             was servicing another processor.
@@ -428,17 +428,17 @@ system:
           description: This group contains statistics related to the memory usage on the system.
           fields:
             - name: total
-              type: integer
+              type: long
               description: >
                 Total memory.
 
             - name: used
-              type: integer
+              type: long
               description: >
                 Used memory.
 
             - name: free
-              type: integer
+              type: long
               description: >
                 Available memory.
 
@@ -448,13 +448,13 @@ system:
                 The percentage of used memory.
 
             - name: actual_used
-              type: integer
+              type: long
               description: >
                 Actual used memory. This value is the "used" memory minus the memory used for disk caches and buffers.
                 Available only on Unix.
 
             - name: actual_free
-              type: integer
+              type: long
               description: >
                 Actual available memory. This value is the "free" memory plus the memory used for disk caches and
                 buffers. Available only on Unix.
@@ -470,17 +470,17 @@ system:
           description: This group contains statistics related to the swap memory usage on the system.
           fields:
             - name: total
-              type: integer
+              type: long
               description: >
                 Total swap memory.
 
             - name: used
-              type: integer
+              type: long
               description: >
                 Used swap memory.
 
             - name: free
-              type: integer
+              type: long
               description: >
                 Available swap memory.
 

--- a/metricbeat/metricbeat.template-es2x.json
+++ b/metricbeat/metricbeat.template-es2x.json
@@ -134,10 +134,10 @@
               }
             },
             "totalAccesses": {
-              "type": "integer"
+              "type": "long"
             },
             "totalKBytes": {
-              "type": "integer"
+              "type": "long"
             },
             "uptime": {
               "properties": {
@@ -195,10 +195,10 @@
             "bytes": {
               "properties": {
                 "Bytes_received": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "Bytes_sent": {
-                  "type": "integer"
+                  "type": "long"
                 }
               }
             }
@@ -212,10 +212,10 @@
                   "type": "integer"
                 },
                 "client_biggest_input_buf": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "client_longest_output_list": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "connected_clients": {
                   "type": "integer"
@@ -253,31 +253,31 @@
         "system-cpu": {
           "properties": {
             "idle": {
-              "type": "integer"
+              "type": "long"
             },
             "iowait": {
-              "type": "integer"
+              "type": "long"
             },
             "irq": {
-              "type": "integer"
+              "type": "long"
             },
             "nice": {
-              "type": "integer"
+              "type": "long"
             },
             "softirq": {
-              "type": "integer"
+              "type": "long"
             },
             "steal": {
-              "type": "integer"
+              "type": "long"
             },
             "system": {
-              "type": "integer"
+              "type": "long"
             },
             "system_p": {
               "type": "float"
             },
             "user": {
-              "type": "integer"
+              "type": "long"
             },
             "user_p": {
               "type": "float"
@@ -289,22 +289,22 @@
             "mem": {
               "properties": {
                 "actual_free": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "actual_used": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "actual_used_p": {
                   "type": "float"
                 },
                 "free": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "total": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "used": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "used_p": {
                   "type": "float"
@@ -314,13 +314,13 @@
             "swap": {
               "properties": {
                 "free": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "total": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "used": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "used_p": {
                   "type": "float"

--- a/metricbeat/metricbeat.template.json
+++ b/metricbeat/metricbeat.template.json
@@ -130,10 +130,10 @@
               }
             },
             "totalAccesses": {
-              "type": "integer"
+              "type": "long"
             },
             "totalKBytes": {
-              "type": "integer"
+              "type": "long"
             },
             "uptime": {
               "properties": {
@@ -186,10 +186,10 @@
             "bytes": {
               "properties": {
                 "Bytes_received": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "Bytes_sent": {
-                  "type": "integer"
+                  "type": "long"
                 }
               }
             }
@@ -203,10 +203,10 @@
                   "type": "integer"
                 },
                 "client_biggest_input_buf": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "client_longest_output_list": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "connected_clients": {
                   "type": "integer"
@@ -244,31 +244,31 @@
         "system-cpu": {
           "properties": {
             "idle": {
-              "type": "integer"
+              "type": "long"
             },
             "iowait": {
-              "type": "integer"
+              "type": "long"
             },
             "irq": {
-              "type": "integer"
+              "type": "long"
             },
             "nice": {
-              "type": "integer"
+              "type": "long"
             },
             "softirq": {
-              "type": "integer"
+              "type": "long"
             },
             "steal": {
-              "type": "integer"
+              "type": "long"
             },
             "system": {
-              "type": "integer"
+              "type": "long"
             },
             "system_p": {
               "type": "float"
             },
             "user": {
-              "type": "integer"
+              "type": "long"
             },
             "user_p": {
               "type": "float"
@@ -280,22 +280,22 @@
             "mem": {
               "properties": {
                 "actual_free": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "actual_used": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "actual_used_p": {
                   "type": "float"
                 },
                 "free": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "total": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "used": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "used_p": {
                   "type": "float"
@@ -305,13 +305,13 @@
             "swap": {
               "properties": {
                 "free": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "total": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "used": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "used_p": {
                   "type": "float"

--- a/packetbeat/docs/fields.asciidoc
+++ b/packetbeat/docs/fields.asciidoc
@@ -979,7 +979,7 @@ A map containing the captured header fields from the response. Which headers to 
 
 ==== http.content_length
 
-type: integer
+type: long
 
 The value of the Content-Length header if present.
 
@@ -1146,14 +1146,14 @@ The list of base64 encoded values sent with the response (if present).
 
 ==== memcache.request.bytes
 
-type: integer
+type: long
 
 The byte count of the values being transfered.
 
 
 ==== memcache.response.bytes
 
-type: integer
+type: long
 
 The byte count of the values being transfered.
 
@@ -1209,14 +1209,14 @@ The automove mode in the 'slab automove' command expressed as a string. This val
 
 ==== memcache.request.flags
 
-type: integer
+type: long
 
 The memcache command flags sent in the request (if present).
 
 
 ==== memcache.response.flags
 
-type: integer
+type: long
 
 The memcache message flags sent in the response (if present).
 
@@ -1230,14 +1230,14 @@ The data expiry time in seconds sent with the memcache command (if present). If 
 
 ==== memcache.request.sleep_us
 
-type: integer
+type: long
 
 The sleep setting in microseconds for the 'lru_crawler sleep' command.
 
 
 ==== memcache.response.value
 
-type: integer
+type: long
 
 The counter value returned by a counter operation.
 
@@ -1258,14 +1258,14 @@ Set to true if the binary protocol message is to be treated as a quiet message.
 
 ==== memcache.request.cas_unique
 
-type: integer
+type: long
 
 The CAS (compare-and-swap) identifier if present.
 
 
 ==== memcache.response.cas_unique
 
-type: integer
+type: long
 
 The CAS (compare-and-swap) identifier to be used with CAS-based updates (if present).
 
@@ -1515,7 +1515,7 @@ RPC message reply status.
 
 ==== rpc.time
 
-type: integer
+type: long
 
 RPC message processing time.
 
@@ -1593,55 +1593,55 @@ These fields contain measurements related to the transaction.
 
 ==== responsetime
 
-type: integer
+type: long
 
 The wall clock time it took to complete the transaction. The precision is in milliseconds.
 
 
 ==== cpu_time
 
-type: integer
+type: long
 
 The CPU time it took to complete the transaction.
 
 ==== bytes_in
 
-type: integer
+type: long
 
 The number of bytes of the request. Note that this size is the application layer message length, without the length of the IP or TCP headers.
 
 
 ==== bytes_out
 
-type: integer
+type: long
 
 The number of bytes of the response. Note that this size is the application layer message length, without the length of the IP or TCP headers.
 
 
 ==== dnstime
 
-type: integer
+type: long
 
 The time it takes to query the name server for a given request. This is typically used for RUM (real-user-monitoring) but can also have values for server-to-server communication when DNS is used for service discovery. The precision is in microseconds.
 
 
 ==== connecttime
 
-type: integer
+type: long
 
 The time it takes for the TCP connection to be established for the given transaction. The precision is in microseconds.
 
 
 ==== loadtime
 
-type: integer
+type: long
 
 The time it takes for the content to be loaded. This is typically used for RUM (real-user-monitoring) but it can make sense in other cases as well. The precision is in microseconds.
 
 
 ==== domloadtime
 
-type: integer
+type: long
 
 In RUM (real-user-monitoring), the total time it takes for the DOM to be loaded. In terms of the W3 Navigation Timing API, this is the difference between `domContentLoadedEnd` and `domContentLoadedStart`.
 

--- a/packetbeat/etc/fields.yml
+++ b/packetbeat/etc/fields.yml
@@ -879,7 +879,7 @@ trans_event:
             by commas.
 
         - name: content_length
-          type: integer
+          type: long
           description: >
             The value of the Content-Length header if present.
 
@@ -1016,12 +1016,12 @@ trans_event:
             The list of base64 encoded values sent with the response (if present).
 
         - name: request.bytes
-          type: integer
+          type: long
           description: >
             The byte count of the values being transfered.
 
         - name: response.bytes
-          type: integer
+          type: long
           description: >
             The byte count of the values being transfered.
 
@@ -1063,12 +1063,12 @@ trans_event:
               the value is unknown.
 
         - name: request.flags
-          type: integer
+          type: long
           description: >
             The memcache command flags sent in the request (if present).
 
         - name: response.flags
-          type: integer
+          type: long
           description: >
             The memcache message flags sent in the response (if present).
 
@@ -1080,12 +1080,12 @@ trans_event:
             is an absolute Unix time in seconds (32-bit).
 
         - name: request.sleep_us
-          type: integer
+          type: long
           description: >
             The sleep setting in microseconds for the 'lru_crawler sleep' command.
 
         - name: response.value
-          type: integer
+          type: long
           description: >
             The counter value returned by a counter operation.
 
@@ -1101,12 +1101,12 @@ trans_event:
             Set to true if the binary protocol message is to be treated as a quiet message.
 
         - name: request.cas_unique
-          type: integer
+          type: long
           description: >
             The CAS (compare-and-swap) identifier if present.
 
         - name: response.cas_unique
-          type: integer
+          type: long
           description: >
             The CAS (compare-and-swap) identifier to be used with CAS-based updates
             (if present).
@@ -1314,7 +1314,7 @@ trans_event:
           description: RPC message reply status.
 
         - name: time
-          type: integer
+          type: long
           description: RPC message processing time.
 
         - name: time_str
@@ -1390,28 +1390,28 @@ trans_measurements:
       description: >
         The wall clock time it took to complete the transaction.
         The precision is in milliseconds.
-      type: integer
+      type: long
 
     - name: cpu_time
       description: The CPU time it took to complete the transaction.
-      type: integer
+      type: long
 
     - name: bytes_in
       description: >
         The number of bytes of the request. Note that this size is
         the application layer message length, without the length of the IP or
         TCP headers.
-      type: integer
+      type: long
 
     - name: bytes_out
       description: >
         The number of bytes of the response. Note that this size is
         the application layer message length, without the length of the IP or
         TCP headers.
-      type: integer
+      type: long
 
     - name: dnstime
-      type: integer
+      type: long
       description: >
         The time it takes to query the name server for a given request.
         This is typically used for RUM (real-user-monitoring) but can
@@ -1420,14 +1420,14 @@ trans_measurements:
         The precision is in microseconds.
 
     - name: connecttime
-      type: integer
+      type: long
       description: >
         The time it takes for the TCP connection to be established for
         the given transaction.
         The precision is in microseconds.
 
     - name: loadtime
-      type: integer
+      type: long
       description: >
         The time it takes for the content to be loaded. This is typically
         used for RUM (real-user-monitoring) but it can make sense in other
@@ -1435,7 +1435,7 @@ trans_measurements:
         The precision is in microseconds.
 
     - name: domloadtime
-      type: integer
+      type: long
       description: >
         In RUM (real-user-monitoring), the total time it takes for the
         DOM to be loaded. In terms of the W3 Navigation Timing API, this is

--- a/packetbeat/packetbeat.template-es2x.json
+++ b/packetbeat/packetbeat.template-es2x.json
@@ -216,10 +216,10 @@
           }
         },
         "bytes_in": {
-          "type": "integer"
+          "type": "long"
         },
         "bytes_out": {
-          "type": "integer"
+          "type": "long"
         },
         "client_ip": {
           "ignore_above": 1024,
@@ -255,10 +255,10 @@
           "type": "string"
         },
         "connecttime": {
-          "type": "integer"
+          "type": "long"
         },
         "cpu_time": {
-          "type": "integer"
+          "type": "long"
         },
         "dest": {
           "properties": {
@@ -491,10 +491,10 @@
           }
         },
         "dnstime": {
-          "type": "integer"
+          "type": "long"
         },
         "domloadtime": {
-          "type": "integer"
+          "type": "long"
         },
         "final": {
           "ignore_above": 1024,
@@ -514,7 +514,7 @@
               "type": "string"
             },
             "content_length": {
-              "type": "integer"
+              "type": "long"
             },
             "phrase": {
               "ignore_above": 1024,
@@ -576,7 +576,7 @@
           "type": "date"
         },
         "loadtime": {
-          "type": "integer"
+          "type": "long"
         },
         "memcache": {
           "properties": {
@@ -593,10 +593,10 @@
                   "type": "string"
                 },
                 "bytes": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "cas_unique": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "command": {
                   "ignore_above": 1024,
@@ -616,7 +616,7 @@
                   "type": "integer"
                 },
                 "flags": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "initial": {
                   "type": "integer"
@@ -649,7 +649,7 @@
                   "type": "string"
                 },
                 "sleep_us": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "source_class": {
                   "type": "integer"
@@ -670,10 +670,10 @@
             "response": {
               "properties": {
                 "bytes": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "cas_unique": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "command": {
                   "ignore_above": 1024,
@@ -689,7 +689,7 @@
                   "type": "string"
                 },
                 "flags": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "opaque": {
                   "type": "integer"
@@ -716,7 +716,7 @@
                   "type": "string"
                 },
                 "value": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "version": {
                   "ignore_above": 1024,
@@ -964,7 +964,7 @@
           "type": "string"
         },
         "responsetime": {
-          "type": "integer"
+          "type": "long"
         },
         "rpc": {
           "properties": {
@@ -1008,7 +1008,7 @@
               "type": "string"
             },
             "time": {
-              "type": "integer"
+              "type": "long"
             },
             "time_str": {
               "ignore_above": 1024,

--- a/packetbeat/packetbeat.template.json
+++ b/packetbeat/packetbeat.template.json
@@ -193,10 +193,10 @@
           }
         },
         "bytes_in": {
-          "type": "integer"
+          "type": "long"
         },
         "bytes_out": {
-          "type": "integer"
+          "type": "long"
         },
         "client_ip": {
           "ignore_above": 1024,
@@ -226,10 +226,10 @@
           "type": "keyword"
         },
         "connecttime": {
-          "type": "integer"
+          "type": "long"
         },
         "cpu_time": {
-          "type": "integer"
+          "type": "long"
         },
         "dest": {
           "properties": {
@@ -434,10 +434,10 @@
           }
         },
         "dnstime": {
-          "type": "integer"
+          "type": "long"
         },
         "domloadtime": {
-          "type": "integer"
+          "type": "long"
         },
         "final": {
           "ignore_above": 1024,
@@ -454,7 +454,7 @@
               "type": "keyword"
             },
             "content_length": {
-              "type": "integer"
+              "type": "long"
             },
             "phrase": {
               "ignore_above": 1024,
@@ -510,7 +510,7 @@
           "type": "date"
         },
         "loadtime": {
-          "type": "integer"
+          "type": "long"
         },
         "memcache": {
           "properties": {
@@ -525,10 +525,10 @@
                   "type": "keyword"
                 },
                 "bytes": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "cas_unique": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "command": {
                   "ignore_above": 1024,
@@ -547,7 +547,7 @@
                   "type": "integer"
                 },
                 "flags": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "initial": {
                   "type": "integer"
@@ -577,7 +577,7 @@
                   "type": "keyword"
                 },
                 "sleep_us": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "source_class": {
                   "type": "integer"
@@ -597,10 +597,10 @@
             "response": {
               "properties": {
                 "bytes": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "cas_unique": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "command": {
                   "ignore_above": 1024,
@@ -614,7 +614,7 @@
                   "type": "keyword"
                 },
                 "flags": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "opaque": {
                   "type": "integer"
@@ -638,7 +638,7 @@
                   "type": "keyword"
                 },
                 "value": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "version": {
                   "ignore_above": 1024,
@@ -843,7 +843,7 @@
           "type": "text"
         },
         "responsetime": {
-          "type": "integer"
+          "type": "long"
         },
         "rpc": {
           "properties": {
@@ -883,7 +883,7 @@
               "type": "keyword"
             },
             "time": {
-              "type": "integer"
+              "type": "long"
             },
             "time_str": {
               "ignore_above": 1024,

--- a/topbeat/docs/fields.asciidoc
+++ b/topbeat/docs/fields.asciidoc
@@ -106,7 +106,7 @@ This group contains statistics related to CPU usage.
 
 ==== cpu.user
 
-type: integer
+type: long
 
 The amount of CPU time spent in user space.
 
@@ -120,14 +120,14 @@ The percentage of CPU time spent in user space. On multi-core systems, you can h
 
 ==== cpu.nice
 
-type: integer
+type: long
 
 The amount of CPU time spent on low-priority processes.
 
 
 ==== cpu.system
 
-type: integer
+type: long
 
 The amount of CPU time spent in kernel space.
 
@@ -141,34 +141,34 @@ The percentage of CPU time spent in kernel space.
 
 ==== cpu.idle
 
-type: integer
+type: long
 
 The amount of CPU time spent idle.
 
 
 ==== cpu.iowait
 
-type: integer
+type: long
 
 The amount of CPU time spent in wait (on disk).
 
 
 ==== cpu.irq
 
-type: integer
+type: long
 
 The amount of CPU time spent servicing and handling hardware interrupts.
 
 
 ==== cpu.softirq
 
-type: integer
+type: long
 
 The amount of CPU time spent servicing and handling software interrupts.
 
 ==== cpu.steal
 
-type: integer
+type: long
 
 The amount of CPU time spent in involuntary wait by the virtual CPU while the hypervisor was servicing another processor. Available only on Unix.
 
@@ -187,7 +187,7 @@ This group contains CPU usage statistics of the core X, where 0<X<N and N is the
 
 ==== cpus.cpuX.user
 
-type: integer
+type: long
 
 The amount of CPU time spent in user space on core X.
 
@@ -201,14 +201,14 @@ The percentage of CPU time spent in user space on core X.
 
 ==== cpus.cpuX.nice
 
-type: integer
+type: long
 
 The amount of CPU time spent on low-priority processes on core X.
 
 
 ==== cpus.cpuX.system
 
-type: integer
+type: long
 
 The amount of CPU time spent in kernel space on core X.
 
@@ -222,27 +222,27 @@ The percentage of CPU time spent in kernel space on core X.
 
 ==== cpus.cpuX.idle
 
-type: integer
+type: long
 
 The amount of CPU time spent idle on core X.
 
 
 ==== cpus.cpuX.iowait
 
-type: integer
+type: long
 
 The amount of CPU time spent in wait (on disk) on core X.
 
 
 ==== cpus.cpuX.softirq
 
-type: integer
+type: long
 
 The amount of CPU time spent servicing and handling software interrupts on core X.
 
 ==== cpus.cpuX.steal
 
-type: integer
+type: long
 
 The amount of CPU time spent in involuntary wait by the virtual CPU while the hypervisor was servicing another processor on core X. Available only on Unix.
 
@@ -255,21 +255,21 @@ This group contains statistics related to the memory usage on the system.
 
 ==== mem.total
 
-type: integer
+type: long
 
 Total memory.
 
 
 ==== mem.used
 
-type: integer
+type: long
 
 Used memory.
 
 
 ==== mem.free
 
-type: integer
+type: long
 
 Available memory.
 
@@ -283,14 +283,14 @@ The percentage of used memory.
 
 ==== mem.actual_used
 
-type: integer
+type: long
 
 Actual used memory. This value is the "used" memory minus the memory used for disk caches and buffers. Available only on Unix.
 
 
 ==== mem.actual_free
 
-type: integer
+type: long
 
 Actual available memory. This value is the "free" memory plus the memory used for disk caches and buffers. Available only on Unix.
 
@@ -310,21 +310,21 @@ This group contains statistics related to the swap memory usage on the system.
 
 ==== swap.total
 
-type: integer
+type: long
 
 Total swap memory.
 
 
 ==== swap.used
 
-type: integer
+type: long
 
 Used swap memory.
 
 
 ==== swap.free
 
-type: integer
+type: long
 
 Available swap memory.
 
@@ -400,7 +400,7 @@ CPU-specific statistics per process.
 
 ==== proc.cpu.user
 
-type: integer
+type: long
 
 The amount of CPU time the process spent in user space.
 
@@ -414,14 +414,14 @@ The percentage of CPU time spent by the process since the last update. Its value
 
 ==== proc.cpu.system
 
-type: integer
+type: long
 
 The amount of CPU time the process spent in kernel space.
 
 
 ==== proc.cpu.total
 
-type: integer
+type: long
 
 The total CPU time spent by the process.
 
@@ -441,14 +441,14 @@ Memory-specific statistics per process.
 
 ==== proc.mem.size
 
-type: integer
+type: long
 
 The total virtual memory the process has.
 
 
 ==== proc.mem.rss
 
-type: integer
+type: long
 
 The Resident Set Size. The amount of memory the process occupied in main memory (RAM).
 
@@ -462,7 +462,7 @@ The percentage of memory the process occupied in main memory (RAM).
 
 ==== proc.mem.share
 
-type: integer
+type: long
 
 The shared memory the process uses.
 
@@ -483,7 +483,7 @@ Contains details about the mounted disks, such as the total or used disk space, 
 
 ==== fs.avail
 
-type: integer
+type: long
 
 The available disk space in bytes.
 
@@ -504,28 +504,28 @@ The mounting point. For example: `/`
 
 ==== fs.files
 
-type: integer
+type: long
 
 The total number of file nodes in the file system.
 
 
 ==== fs.free_files
 
-type: integer
+type: long
 
 The number of free file nodes in the file system.
 
 
 ==== fs.total
 
-type: integer
+type: long
 
 The total disk space in bytes.
 
 
 ==== fs.used
 
-type: integer
+type: long
 
 The used disk space in bytes.
 

--- a/topbeat/etc/fields.yml
+++ b/topbeat/etc/fields.yml
@@ -78,7 +78,7 @@ system:
       description: This group contains statistics related to CPU usage.
       fields:
         - name: user
-          type: integer
+          type: long
           description: >
            The amount of CPU time spent in user space.
 
@@ -89,12 +89,12 @@ system:
             For example, if 3 cores are at 60% use, then the `cpu.user_p` will be 180%.
 
         - name: nice
-          type: integer
+          type: long
           description: >
             The amount of CPU time spent on low-priority processes.
 
         - name: system
-          type: integer
+          type: long
           description: >
             The amount of CPU time spent in kernel space.
 
@@ -104,27 +104,27 @@ system:
             The percentage of CPU time spent in kernel space.
 
         - name: idle
-          type: integer
+          type: long
           description: >
             The amount of CPU time spent idle.
 
         - name: iowait
-          type: integer
+          type: long
           description: >
             The amount of CPU time spent in wait (on disk).
 
         - name: irq
-          type: integer
+          type: long
           description: >
             The amount of CPU time spent servicing and handling hardware interrupts.
 
         - name: softirq
-          type: integer
+          type: long
           description:
             The amount of CPU time spent servicing and handling software interrupts.
 
         - name: steal
-          type: integer
+          type: long
           description: >
             The amount of CPU time spent in involuntary wait by the virtual CPU while the hypervisor
             was servicing another processor.
@@ -142,7 +142,7 @@ system:
           fields:
 
           - name: user
-            type: integer
+            type: long
             description: >
              The amount of CPU time spent in user space on core X.
 
@@ -152,12 +152,12 @@ system:
               The percentage of CPU time spent in user space on core X.
 
           - name: nice
-            type: integer
+            type: long
             description: >
               The amount of CPU time spent on low-priority processes on core X.
 
           - name: system
-            type: integer
+            type: long
             description: >
               The amount of CPU time spent in kernel space on core X.
 
@@ -167,22 +167,22 @@ system:
               The percentage of CPU time spent in kernel space on core X.
 
           - name: idle
-            type: integer
+            type: long
             description: >
               The amount of CPU time spent idle on core X.
 
           - name: iowait
-            type: integer
+            type: long
             description: >
               The amount of CPU time spent in wait (on disk) on core X.
 
           - name: softirq
-            type: integer
+            type: long
             description:
               The amount of CPU time spent servicing and handling software interrupts on core X.
 
           - name: steal
-            type: integer
+            type: long
             description: >
               The amount of CPU time spent in involuntary wait by the virtual CPU while the hypervisor
               was servicing another processor on core X.
@@ -196,17 +196,17 @@ system:
       description: This group contains statistics related to the memory usage on the system.
       fields:
         - name: total
-          type: integer
+          type: long
           description: >
             Total memory.
 
         - name: used
-          type: integer
+          type: long
           description: >
             Used memory.
 
         - name: free
-          type: integer
+          type: long
           description: >
             Available memory.
 
@@ -216,13 +216,13 @@ system:
             The percentage of used memory.
 
         - name: actual_used
-          type: integer
+          type: long
           description: >
             Actual used memory. This value is the "used" memory minus the memory used for disk caches and buffers.
             Available only on Unix.
 
         - name: actual_free
-          type: integer
+          type: long
           description: >
             Actual available memory. This value is the "free" memory plus the memory used for disk caches and
             buffers. Available only on Unix.
@@ -238,17 +238,17 @@ system:
       description: This group contains statistics related to the swap memory usage on the system.
       fields:
         - name: total
-          type: integer
+          type: long
           description: >
             Total swap memory.
 
         - name: used
-          type: integer
+          type: long
           description: >
             Used swap memory.
 
         - name: free
-          type: integer
+          type: long
           description: >
             Available swap memory.
 
@@ -309,7 +309,7 @@ process:
           description: CPU-specific statistics per process.
           fields:
             - name: user
-              type: integer
+              type: long
               description: >
                 The amount of CPU time the process spent in user space.
 
@@ -320,12 +320,12 @@ process:
                 %CPU value of the process displayed by the top command on unix systems.
 
             - name: system
-              type: integer
+              type: long
               description: >
                 The amount of CPU time the process spent in kernel space.
 
             - name: total
-              type: integer
+              type: long
               description: >
                 The total CPU time spent by the process.
 
@@ -340,12 +340,12 @@ process:
           prefix: "[float]"
           fields:
             - name: size
-              type: integer
+              type: long
               description: >
                 The total virtual memory the process has.
 
             - name: rss
-              type: integer
+              type: long
               description: >
                 The Resident Set Size. The amount of memory the process occupied in main memory (RAM).
 
@@ -355,7 +355,7 @@ process:
                 The percentage of memory the process occupied in main memory (RAM).
 
             - name: share
-              type: integer
+              type: long
               description: >
                 The shared memory the process uses.
 
@@ -372,7 +372,7 @@ filesystem:
         the device name and the mounting place.
       fields:
         - name: avail
-          type: integer
+          type: long
           description: >
             The available disk space in bytes.
 
@@ -387,22 +387,22 @@ filesystem:
             The mounting point. For example: `/`
 
         - name: files
-          type: integer
+          type: long
           description: >
             The total number of file nodes in the file system.
 
         - name: free_files
-          type: integer
+          type: long
           description: >
             The number of free file nodes in the file system.
 
         - name: total
-          type: integer
+          type: long
           description: >
             The total disk space in bytes.
 
         - name: used
-          type: integer
+          type: long
           description: >
             The used disk space in bytes.
 

--- a/topbeat/topbeat.template-es2x.json
+++ b/topbeat/topbeat.template-es2x.json
@@ -40,31 +40,31 @@
         "cpu": {
           "properties": {
             "idle": {
-              "type": "integer"
+              "type": "long"
             },
             "iowait": {
-              "type": "integer"
+              "type": "long"
             },
             "irq": {
-              "type": "integer"
+              "type": "long"
             },
             "nice": {
-              "type": "integer"
+              "type": "long"
             },
             "softirq": {
-              "type": "integer"
+              "type": "long"
             },
             "steal": {
-              "type": "integer"
+              "type": "long"
             },
             "system": {
-              "type": "integer"
+              "type": "long"
             },
             "system_p": {
               "type": "float"
             },
             "user": {
-              "type": "integer"
+              "type": "long"
             },
             "user_p": {
               "type": "float"
@@ -76,28 +76,28 @@
             "cpuX": {
               "properties": {
                 "idle": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "iowait": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "nice": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "softirq": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "steal": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "system": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "system_p": {
                   "type": "float"
                 },
                 "user": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "user_p": {
                   "type": "float"
@@ -109,7 +109,7 @@
         "fs": {
           "properties": {
             "avail": {
-              "type": "integer"
+              "type": "long"
             },
             "device_name": {
               "ignore_above": 1024,
@@ -117,10 +117,10 @@
               "type": "string"
             },
             "files": {
-              "type": "integer"
+              "type": "long"
             },
             "free_files": {
-              "type": "integer"
+              "type": "long"
             },
             "mount_point": {
               "ignore_above": 1024,
@@ -128,10 +128,10 @@
               "type": "string"
             },
             "total": {
-              "type": "integer"
+              "type": "long"
             },
             "used": {
-              "type": "integer"
+              "type": "long"
             },
             "used_p": {
               "type": "float"
@@ -154,22 +154,22 @@
         "mem": {
           "properties": {
             "actual_free": {
-              "type": "integer"
+              "type": "long"
             },
             "actual_used": {
-              "type": "integer"
+              "type": "long"
             },
             "actual_used_p": {
               "type": "float"
             },
             "free": {
-              "type": "integer"
+              "type": "long"
             },
             "total": {
-              "type": "integer"
+              "type": "long"
             },
             "used": {
-              "type": "integer"
+              "type": "long"
             },
             "used_p": {
               "type": "float"
@@ -191,32 +191,32 @@
                   "type": "string"
                 },
                 "system": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "total": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "total_p": {
                   "type": "float"
                 },
                 "user": {
-                  "type": "integer"
+                  "type": "long"
                 }
               }
             },
             "mem": {
               "properties": {
                 "rss": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "rss_p": {
                   "type": "float"
                 },
                 "share": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "size": {
-                  "type": "integer"
+                  "type": "long"
                 }
               }
             },
@@ -246,13 +246,13 @@
         "swap": {
           "properties": {
             "free": {
-              "type": "integer"
+              "type": "long"
             },
             "total": {
-              "type": "integer"
+              "type": "long"
             },
             "used": {
-              "type": "integer"
+              "type": "long"
             },
             "used_p": {
               "type": "float"

--- a/topbeat/topbeat.template.json
+++ b/topbeat/topbeat.template.json
@@ -35,31 +35,31 @@
         "cpu": {
           "properties": {
             "idle": {
-              "type": "integer"
+              "type": "long"
             },
             "iowait": {
-              "type": "integer"
+              "type": "long"
             },
             "irq": {
-              "type": "integer"
+              "type": "long"
             },
             "nice": {
-              "type": "integer"
+              "type": "long"
             },
             "softirq": {
-              "type": "integer"
+              "type": "long"
             },
             "steal": {
-              "type": "integer"
+              "type": "long"
             },
             "system": {
-              "type": "integer"
+              "type": "long"
             },
             "system_p": {
               "type": "float"
             },
             "user": {
-              "type": "integer"
+              "type": "long"
             },
             "user_p": {
               "type": "float"
@@ -71,28 +71,28 @@
             "cpuX": {
               "properties": {
                 "idle": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "iowait": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "nice": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "softirq": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "steal": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "system": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "system_p": {
                   "type": "float"
                 },
                 "user": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "user_p": {
                   "type": "float"
@@ -104,27 +104,27 @@
         "fs": {
           "properties": {
             "avail": {
-              "type": "integer"
+              "type": "long"
             },
             "device_name": {
               "ignore_above": 1024,
               "type": "keyword"
             },
             "files": {
-              "type": "integer"
+              "type": "long"
             },
             "free_files": {
-              "type": "integer"
+              "type": "long"
             },
             "mount_point": {
               "ignore_above": 1024,
               "type": "keyword"
             },
             "total": {
-              "type": "integer"
+              "type": "long"
             },
             "used": {
-              "type": "integer"
+              "type": "long"
             },
             "used_p": {
               "type": "float"
@@ -147,22 +147,22 @@
         "mem": {
           "properties": {
             "actual_free": {
-              "type": "integer"
+              "type": "long"
             },
             "actual_used": {
-              "type": "integer"
+              "type": "long"
             },
             "actual_used_p": {
               "type": "float"
             },
             "free": {
-              "type": "integer"
+              "type": "long"
             },
             "total": {
-              "type": "integer"
+              "type": "long"
             },
             "used": {
-              "type": "integer"
+              "type": "long"
             },
             "used_p": {
               "type": "float"
@@ -182,32 +182,32 @@
                   "type": "keyword"
                 },
                 "system": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "total": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "total_p": {
                   "type": "float"
                 },
                 "user": {
-                  "type": "integer"
+                  "type": "long"
                 }
               }
             },
             "mem": {
               "properties": {
                 "rss": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "rss_p": {
                   "type": "float"
                 },
                 "share": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "size": {
-                  "type": "integer"
+                  "type": "long"
                 }
               }
             },
@@ -234,13 +234,13 @@
         "swap": {
           "properties": {
             "free": {
-              "type": "integer"
+              "type": "long"
             },
             "total": {
-              "type": "integer"
+              "type": "long"
             },
             "used": {
-              "type": "integer"
+              "type": "long"
             },
             "used_p": {
               "type": "float"


### PR DESCRIPTION
On integer overflow, Elasticsearch errors on index, so we have to make sure
that doesn't happen normally. I switched from `integer` to `long` everywhere
where I thought there might be a chance of overflow. Would be good for
reviewers to do another search for `integer` to check that I didn't miss any.

Fixes #1509.