### PR TITLE
Move state creation to harvester

### DIFF
--- a/filebeat/harvester/log.go
+++ b/filebeat/harvester/log.go
@@ -107,7 +107,7 @@ func (h *Harvester) Harvest() {
 // By default the offset is set to 0, means no bytes read. This can be used to report the status
 // of a harvester
 func (h *Harvester) createEvent() *input.FileEvent {
-	return &input.FileEvent{
+	event := &input.FileEvent{
 		EventMetadata: h.Config.EventMetadata,
 		Source:        h.Path,
 		InputType:     h.Config.InputType,
@@ -117,6 +117,15 @@ func (h *Harvester) createEvent() *input.FileEvent {
 		Fileinfo:      &h.Stat.Fileinfo,
 		JSONConfig:    h.Config.JSON,
 	}
+
+	if h.Config.InputType != config.StdinInputType {
+		event.FileState = input.FileState{
+			Source:      h.Path,
+			Offset:      h.getOffset(),
+			FileStateOS: *input.GetOSFileState(&h.Stat.Fileinfo),
+		}
+	}
+	return event
 }
 
 // sendEvent sends event to the spooler channel

--- a/filebeat/input/event.go
+++ b/filebeat/input/event.go
@@ -24,18 +24,7 @@ type FileEvent struct {
 	JSONFields   common.MapStr
 	JSONConfig   *config.JSONConfig
 	Stat         *FileStat
-}
-
-// GetState builds and returns the FileState object based on the Event info.
-func (f *FileEvent) GetState() *FileState {
-
-	state := &FileState{
-		Source:      f.Source,
-		Offset:      f.Offset,
-		FileStateOS: *GetOSFileState(f.Fileinfo),
-	}
-
-	return state
+	FileState    FileState
 }
 
 // mergeJSONFields writes the JSON fields in the event map,

--- a/filebeat/tests/system/test_registrar.py
+++ b/filebeat/tests/system/test_registrar.py
@@ -313,6 +313,9 @@ class Test(BaseTest):
             lambda: self.output_has(lines=1),
             max_timeout=10)
 
+        # Wait a momemt to make sure registry is completely written
+        time.sleep(1)
+
         data = self.get_registry()
         assert os.stat(testfile).st_ino == data[os.path.abspath(testfile)]["FileStateOS"]["inode"]
 
@@ -325,6 +328,9 @@ class Test(BaseTest):
         self.wait_until(
             lambda: self.output_has(lines=2),
             max_timeout=10)
+
+        # Wait a momemt to make sure registry is completely written
+        time.sleep(1)
 
         data = self.get_registry()
 


### PR DESCRIPTION
The Registrar should only persist the state but should not have to fetch information from the file itself before writing the state. First this is not the responsibility of the registrar to have knowledge about the different harvester implementation, second the information of a file could already have changed when the registrar writes. With this PR the file state is decoupled from the Registrar.

Currently there is duplicated information in FileEvent. This will be cleaned up in a second step to keep the changes as minimal as possible per PR.

Related to #1022