### PR TITLE
Fixed double dir in Kibana

### DIFF
--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -259,9 +259,9 @@ write-environment:
 HOME_PREFIX?=/tmp/${BEATNAME}
 .PHONY: install-home
 install-home:
-	mkdir -p ${HOME_PREFIX}
+	mkdir -p ${HOME_PREFIX}/kibana
 	if [ -d "etc/kibana" ]; then \
-		cp -r etc/kibana ${HOME_PREFIX}/kibana; \
+		cp -a etc/kibana/. ${HOME_PREFIX}/kibana/; \
 		install -m 755  ../dev-tools/import_dashboards.sh ${HOME_PREFIX}/kibana/; \
 		install -m 755 ../dev-tools/import_dashboards.ps1 ${HOME_PREFIX}/kibana/; \
 	fi


### PR DESCRIPTION
Was happening because if the kibana folder was already existing, the copy
was done in it. Fixes #1529.