### PR TITLE
Add Elasticsearch alpha2 to the testing environment

### DIFF
--- a/testing/environments/docker/elasticsearch/Dockerfile-5.0.0-alpha2
+++ b/testing/environments/docker/elasticsearch/Dockerfile-5.0.0-alpha2
@@ -1,0 +1,51 @@
+FROM java:8-jre
+
+# grab gosu for easy step-down from root
+RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
+RUN arch="$(dpkg --print-architecture)" \
+	&& set -x \
+	&& curl -o /usr/local/bin/gosu -fSL "https://github.com/tianon/gosu/releases/download/1.3/gosu-$arch" \
+	&& curl -o /usr/local/bin/gosu.asc -fSL "https://github.com/tianon/gosu/releases/download/1.3/gosu-$arch.asc" \
+	&& gpg --verify /usr/local/bin/gosu.asc \
+	&& rm /usr/local/bin/gosu.asc \
+	&& chmod +x /usr/local/bin/gosu
+
+RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 46095ACC8548582C1A2699A9D27D666CD88E42B4
+
+ENV ELASTICSEARCH_MAJOR 5.0
+ENV ELASTICSEARCH_VERSION 5.0.0-alpha2
+
+RUN wget http://download.elastic.co/elasticsearch/staging/5.0.0-alpha2-e3126df/org/elasticsearch/distribution/deb/elasticsearch/5.0.0-alpha2/elasticsearch-5.0.0-alpha2.deb
+
+RUN dpkg -i elasticsearch-5.0.0-alpha2.deb
+
+ENV PATH /usr/share/elasticsearch/bin:$PATH
+
+RUN set -ex \
+	&& for path in \
+		/usr/share/elasticsearch/data \
+		/usr/share/elasticsearch/logs \
+		/usr/share/elasticsearch/config \
+		/usr/share/elasticsearch/config/scripts \
+	; do \
+		mkdir -p "$path"; \
+		chown -R elasticsearch:elasticsearch "$path"; \
+	done
+
+COPY config /usr/share/elasticsearch/config
+
+VOLUME /usr/share/elasticsearch/data
+
+# Shield currently not enabled
+#RUN elasticsearch-plugin install -Des.plugins.staging=true -b xpack
+
+COPY docker-entrypoint.sh /
+
+ENV ES_JAVA_OPTS "-Xms512m -Xmx512m"
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+
+EXPOSE 9200 9300
+
+CMD ["elasticsearch"]
+


### PR DESCRIPTION
To make use of it, you currently have to:

    docker-machine ssh default
    sudo sysctl -w vm.max_map_count=262144

I also committed the change `snapshot.yml` to test if this breaks on Travis (I expect it to). So please don't merge it unless tests show green.
