### PR TITLE
Move one level up the sections in the configuration file

### DIFF
--- a/filebeat/etc/beat.yml
+++ b/filebeat/etc/beat.yml
@@ -168,7 +168,7 @@ filebeat.prospectors:
 
 ######################### Filebeat general configuration #############################
 
-filebeat:
+#filebeat:
   
   # Event count spool threshold - forces network flush if exceeded
   #spool_size: 2048

--- a/filebeat/etc/beat.yml
+++ b/filebeat/etc/beat.yml
@@ -1,176 +1,175 @@
 ################### Filebeat Configuration Example #########################
 
-############################# Filebeat ######################################
-filebeat:
-  # List of prospectors to fetch data.
-  prospectors:
-    # Each - is a prospector. Below are the prospector specific configurations
+######################### Filebeat prospectors #############################
 
-      # Type of the files. Based on this the way the file is read is decided.
-      # The different types cannot be mixed in one prospector
-      #
-      # Possible options are:
-      # * log: Reads every line of the log file (default)
-      # * stdin: Reads the standard in
-    - input_type: log
+# List of prospectors to fetch data.
+filebeat.prospectors:
+  # Each - is a prospector. Below are the prospector specific configurations
 
-      # Paths that should be crawled and fetched. Glob based paths.
-      # To fetch all ".log" files from a specific level of subdirectories
-      # /var/log/*/*.log can be used.
-      # For each file found under this path, a harvester is started.
-      # Make sure not file is defined twice as this can lead to unexpected behaviour.
-      paths:
-        - /var/log/*.log
-        #- c:\programdata\elasticsearch\logs\*
-
-      # Configure the file encoding for reading files with international characters
-      # following the W3C recommendation for HTML5 (http://www.w3.org/TR/encoding).
-      # Some sample encodings:
-      #   plain, utf-8, utf-16be-bom, utf-16be, utf-16le, big5, gb18030, gbk,
-      #    hz-gb-2312, euc-kr, euc-jp, iso-2022-jp, shift-jis, ...
-      #encoding: plain
-
-
-      # Decode JSON options. Enable this if your logs are structured in JSON.
-      #json:
-        # JSON key on which to apply the line filtering and multiline settings. This key
-        # must be top level and its value must be string, otherwise it is ignored. If
-        # no text key is defined, the line filtering and multiline features cannot be used.
-        #message_key:
-
-        # By default, the decoded JSON is placed under a "json" key in the output document.
-        # If you enable this setting, the keys are copied top level in the output document.
-        #keys_under_root: false
-
-        # If keys_under_root and this setting are enabled, then the values from the decoded
-        # JSON object overwrite the fields that Filebeat normally adds (type, source, offset, etc.)
-        # in case of conflicts.
-        #overwrite_keys: false
-
-        # If this setting is enabled, Filebeat adds a "json_error" key in case of JSON
-        # unmarshaling errors or when a text key is defined in the configuration but cannot
-        # be used.
-        #add_error_key: false
-
-      # Exclude lines. A list of regular expressions to match. It drops the lines that are
-      # matching any regular expression from the list. The include_lines is called before
-      # exclude_lines. By default, no lines are dropped.
-      #exclude_lines: ["^DBG"]
-
-      # Include lines. A list of regular expressions to match. It exports the lines that are
-      # matching any regular expression from the list. The include_lines is called before
-      # exclude_lines. By default, all the lines are exported.
-      #include_lines: ["^ERR", "^WARN"]
-
-      # Exclude files. A list of regular expressions to match. Filebeat drops the files that
-      # are matching any regular expression from the list. By default, no files are dropped.
-      #exclude_files: [".gz$"]
-
-      # Optional additional fields. These field can be freely picked
-      # to add additional information to the crawled log files for filtering
-      #fields:
-      #  level: debug
-      #  review: 1
-
-      # Set to true to store the additional fields as top level fields instead
-      # of under the "fields" sub-dictionary. In case of name conflicts with the
-      # fields added by Filebeat itself, the custom fields overwrite the default
-      # fields.
-      #fields_under_root: false
-
-      # Ignore files which were modified more then the defined timespan in the past.
-      # ignore_older is disabled by default, so no files are ignored by setting it to 0.
-      # Time strings like 2h (2 hours), 5m (5 minutes) can be used.
-      #ignore_older: 0
-
-      # Close older closes the file handler for which were not modified
-      # for longer then close_older
-      # Time strings like 2h (2 hours), 5m (5 minutes) can be used.
-      #close_older: 1h
-
-      # Type to be published in the 'type' field. For Elasticsearch output,
-      # the type defines the document type these entries should be stored
-      # in. Default: log
-      #document_type: log
-
-      # Scan frequency in seconds.
-      # How often these files should be checked for changes. In case it is set
-      # to 0s, it is done as often as possible. Default: 10s
-      #scan_frequency: 10s
-
-      # Defines the buffer size every harvester uses when fetching the file
-      #harvester_buffer_size: 16384
-
-      # Maximum number of bytes a single log event can have
-      # All bytes after max_bytes are discarded and not sent. The default is 10MB.
-      # This is especially useful for multiline log messages which can get large.
-      #max_bytes: 10485760
-
-      # Mutiline can be used for log messages spanning multiple lines. This is common
-      # for Java Stack Traces or C-Line Continuation
-      #multiline:
-
-        # The regexp Pattern that has to be matched. The example pattern matches all lines starting with [
-        #pattern: ^\[
-
-        # Defines if the pattern set under pattern should be negated or not. Default is false.
-        #negate: false
-
-        # Match can be set to "after" or "before". It is used to define if lines should be append to a pattern
-        # that was (not) matched before or after or as long as a pattern is not matched based on negate.
-        # Note: After is the equivalent to previous and before is the equivalent to to next in Logstash
-        #match: after
-
-        # The maximum number of lines that are combined to one event.
-        # In case there are more the max_lines the additional lines are discarded.
-        # Default is 500
-        #max_lines: 500
-
-        # After the defined timeout, an multiline event is sent even if no new pattern was found to start a new event
-        # Default is 5s.
-        #timeout: 5s
-
-      # Setting tail_files to true means filebeat starts reading new files at the end
-      # instead of the beginning. If this is used in combination with log rotation
-      # this can mean that the first entries of a new file are skipped.
-      #tail_files: false
-
-      # Backoff values define how aggressively filebeat crawls new files for updates
-      # The default values can be used in most cases. Backoff defines how long it is waited
-      # to check a file again after EOF is reached. Default is 1s which means the file
-      # is checked every second if new lines were added. This leads to a near real time crawling.
-      # Every time a new line appears, backoff is reset to the initial value.
-      #backoff: 1s
-
-      # Max backoff defines what the maximum backoff time is. After having backed off multiple times
-      # from checking the files, the waiting time will never exceed max_backoff independent of the
-      # backoff factor. Having it set to 10s means in the worst case a new line can be added to a log
-      # file after having backed off multiple times, it takes a maximum of 10s to read the new line
-      #max_backoff: 10s
-
-      # The backoff factor defines how fast the algorithm backs off. The bigger the backoff factor,
-      # the faster the max_backoff value is reached. If this value is set to 1, no backoff will happen.
-      # The backoff value will be multiplied each time with the backoff_factor until max_backoff is reached
-      #backoff_factor: 2
-
-      # This option closes a file, as soon as the file name changes.
-      # This config option is recommended on windows only. Filebeat keeps the files it's reading open. This can cause
-      # issues when the file is removed, as the file will not be fully removed until also Filebeat closes
-      # the reading. Filebeat closes the file handler after ignore_older. During this time no new file with the
-      # same name can be created. Turning this feature on the other hand can lead to loss of data
-      # on rotate files. It can happen that after file rotation the beginning of the new
-      # file is skipped, as the reading starts at the end. We recommend to leave this option on false
-      # but lower the ignore_older value to release files faster.
-      #force_close_files: false
-
-    # Additional stdin prospector
-
-      # Configuration to use stdin input
-    #- input_type: stdin
-
-
-  # General filebeat configuration options
+  # Type of the files. Based on this the way the file is read is decided.
+  # The different types cannot be mixed in one prospector
   #
+  # Possible options are:
+  # * log: Reads every line of the log file (default)
+  # * stdin: Reads the standard in
+  - input_type: log
+
+    # Paths that should be crawled and fetched. Glob based paths.
+    # To fetch all ".log" files from a specific level of subdirectories
+    # /var/log/*/*.log can be used.
+    # For each file found under this path, a harvester is started.
+    # Make sure not file is defined twice as this can lead to unexpected behaviour.
+    paths:
+      - /var/log/*.log
+      #- c:\programdata\elasticsearch\logs\*
+
+    # Configure the file encoding for reading files with international characters
+    # following the W3C recommendation for HTML5 (http://www.w3.org/TR/encoding).
+    # Some sample encodings:
+    #   plain, utf-8, utf-16be-bom, utf-16be, utf-16le, big5, gb18030, gbk,
+    #    hz-gb-2312, euc-kr, euc-jp, iso-2022-jp, shift-jis, ...
+    #encoding: plain
+
+    # Decode JSON options. Enable this if your logs are structured in JSON.
+    # JSON key on which to apply the line filtering and multiline settings. This key
+    # must be top level and its value must be string, otherwise it is ignored. If
+    # no text key is defined, the line filtering and multiline features cannot be used.
+    #json.message_key:
+
+    # By default, the decoded JSON is placed under a "json" key in the output document.
+    # If you enable this setting, the keys are copied top level in the output document.
+    #json.keys_under_root: false
+
+    # If keys_under_root and this setting are enabled, then the values from the decoded
+    # JSON object overwrite the fields that Filebeat normally adds (type, source, offset, etc.)
+    # in case of conflicts.
+    #json.overwrite_keys: false
+
+    # If this setting is enabled, Filebeat adds a "json_error" key in case of JSON
+    # unmarshaling errors or when a text key is defined in the configuration but cannot
+    # be used.
+    #json.add_error_key: false
+
+    # Exclude lines. A list of regular expressions to match. It drops the lines that are
+    # matching any regular expression from the list. The include_lines is called before
+    # exclude_lines. By default, no lines are dropped.
+    #exclude_lines: ["^DBG"]
+
+    # Include lines. A list of regular expressions to match. It exports the lines that are
+    # matching any regular expression from the list. The include_lines is called before
+    # exclude_lines. By default, all the lines are exported.
+    #include_lines: ["^ERR", "^WARN"]
+
+    # Exclude files. A list of regular expressions to match. Filebeat drops the files that
+    # are matching any regular expression from the list. By default, no files are dropped.
+    #exclude_files: [".gz$"]
+
+    # Optional additional fields. These field can be freely picked
+    # to add additional information to the crawled log files for filtering
+    #fields:
+    #  level: debug
+    #  review: 1
+
+    # Set to true to store the additional fields as top level fields instead
+    # of under the "fields" sub-dictionary. In case of name conflicts with the
+    # fields added by Filebeat itself, the custom fields overwrite the default
+    # fields.
+    #fields_under_root: false
+
+    # Ignore files which were modified more then the defined timespan in the past.
+    # ignore_older is disabled by default, so no files are ignored by setting it to 0.
+    # Time strings like 2h (2 hours), 5m (5 minutes) can be used.
+    #ignore_older: 0
+
+    # Close older closes the file handler for which were not modified
+    # for longer then close_older
+    # Time strings like 2h (2 hours), 5m (5 minutes) can be used.
+    #close_older: 1h
+
+    # Type to be published in the 'type' field. For Elasticsearch output,
+    # the type defines the document type these entries should be stored
+    # in. Default: log
+    #document_type: log
+
+    # Scan frequency in seconds.
+    # How often these files should be checked for changes. In case it is set
+    # to 0s, it is done as often as possible. Default: 10s
+    #scan_frequency: 10s
+
+    # Defines the buffer size every harvester uses when fetching the file
+    #harvester_buffer_size: 16384
+
+    # Maximum number of bytes a single log event can have
+    # All bytes after max_bytes are discarded and not sent. The default is 10MB.
+    # This is especially useful for multiline log messages which can get large.
+    #max_bytes: 10485760
+
+    # Mutiline can be used for log messages spanning multiple lines. This is common
+    # for Java Stack Traces or C-Line Continuation
+    
+    # The regexp Pattern that has to be matched. The example pattern matches all lines starting with [
+    #multiline.pattern: ^\[
+
+    # Defines if the pattern set under pattern should be negated or not. Default is false.
+    #multiline.negate: false
+
+    # Match can be set to "after" or "before". It is used to define if lines should be append to a pattern
+    # that was (not) matched before or after or as long as a pattern is not matched based on negate.
+    # Note: After is the equivalent to previous and before is the equivalent to to next in Logstash
+    #multiline.match: after
+
+    # The maximum number of lines that are combined to one event.
+    # In case there are more the max_lines the additional lines are discarded.
+    # Default is 500
+    #multiline.max_lines: 500
+
+    # After the defined timeout, an multiline event is sent even if no new pattern was found to start a new event
+    # Default is 5s.
+    #multiline.timeout: 5s
+
+    # Setting tail_files to true means filebeat starts reading new files at the end
+    # instead of the beginning. If this is used in combination with log rotation
+    # this can mean that the first entries of a new file are skipped.
+    #tail_files: false
+
+    # Backoff values define how aggressively filebeat crawls new files for updates
+    # The default values can be used in most cases. Backoff defines how long it is waited
+    # to check a file again after EOF is reached. Default is 1s which means the file
+    # is checked every second if new lines were added. This leads to a near real time crawling.
+    # Every time a new line appears, backoff is reset to the initial value.
+    #backoff: 1s
+
+    # Max backoff defines what the maximum backoff time is. After having backed off multiple times
+    # from checking the files, the waiting time will never exceed max_backoff independent of the
+    # backoff factor. Having it set to 10s means in the worst case a new line can be added to a log
+    # file after having backed off multiple times, it takes a maximum of 10s to read the new line
+    #max_backoff: 10s
+
+    # The backoff factor defines how fast the algorithm backs off. The bigger the backoff factor,
+    # the faster the max_backoff value is reached. If this value is set to 1, no backoff will happen.
+    # The backoff value will be multiplied each time with the backoff_factor until max_backoff is reached
+    #backoff_factor: 2
+
+    # This option closes a file, as soon as the file name changes.
+    # This config option is recommended on windows only. Filebeat keeps the files it's reading open. This can cause
+    # issues when the file is removed, as the file will not be fully removed until also Filebeat closes
+    # the reading. Filebeat closes the file handler after ignore_older. During this time no new file with the
+    # same name can be created. Turning this feature on the other hand can lead to loss of data
+    # on rotate files. It can happen that after file rotation the beginning of the new
+    # file is skipped, as the reading starts at the end. We recommend to leave this option on false
+    # but lower the ignore_older value to release files faster.
+    #force_close_files: false
+
+  # Additional stdin prospector
+
+  # Configuration to use stdin input
+  #- input_type: stdin
+
+
+######################### Filebeat general configuration #############################
+
+filebeat:
+  
   # Event count spool threshold - forces network flush if exceeded
   #spool_size: 2048
 

--- a/filebeat/filebeat.yml
+++ b/filebeat/filebeat.yml
@@ -168,7 +168,7 @@ filebeat.prospectors:
 
 ######################### Filebeat general configuration #############################
 
-filebeat:
+#filebeat:
   
   # Event count spool threshold - forces network flush if exceeded
   #spool_size: 2048

--- a/filebeat/filebeat.yml
+++ b/filebeat/filebeat.yml
@@ -1,176 +1,175 @@
 ################### Filebeat Configuration Example #########################
 
-############################# Filebeat ######################################
-filebeat:
-  # List of prospectors to fetch data.
-  prospectors:
-    # Each - is a prospector. Below are the prospector specific configurations
+######################### Filebeat prospectors #############################
 
-      # Type of the files. Based on this the way the file is read is decided.
-      # The different types cannot be mixed in one prospector
-      #
-      # Possible options are:
-      # * log: Reads every line of the log file (default)
-      # * stdin: Reads the standard in
-    - input_type: log
+# List of prospectors to fetch data.
+filebeat.prospectors:
+  # Each - is a prospector. Below are the prospector specific configurations
 
-      # Paths that should be crawled and fetched. Glob based paths.
-      # To fetch all ".log" files from a specific level of subdirectories
-      # /var/log/*/*.log can be used.
-      # For each file found under this path, a harvester is started.
-      # Make sure not file is defined twice as this can lead to unexpected behaviour.
-      paths:
-        - /var/log/*.log
-        #- c:\programdata\elasticsearch\logs\*
-
-      # Configure the file encoding for reading files with international characters
-      # following the W3C recommendation for HTML5 (http://www.w3.org/TR/encoding).
-      # Some sample encodings:
-      #   plain, utf-8, utf-16be-bom, utf-16be, utf-16le, big5, gb18030, gbk,
-      #    hz-gb-2312, euc-kr, euc-jp, iso-2022-jp, shift-jis, ...
-      #encoding: plain
-
-
-      # Decode JSON options. Enable this if your logs are structured in JSON.
-      #json:
-        # JSON key on which to apply the line filtering and multiline settings. This key
-        # must be top level and its value must be string, otherwise it is ignored. If
-        # no text key is defined, the line filtering and multiline features cannot be used.
-        #message_key:
-
-        # By default, the decoded JSON is placed under a "json" key in the output document.
-        # If you enable this setting, the keys are copied top level in the output document.
-        #keys_under_root: false
-
-        # If keys_under_root and this setting are enabled, then the values from the decoded
-        # JSON object overwrite the fields that Filebeat normally adds (type, source, offset, etc.)
-        # in case of conflicts.
-        #overwrite_keys: false
-
-        # If this setting is enabled, Filebeat adds a "json_error" key in case of JSON
-        # unmarshaling errors or when a text key is defined in the configuration but cannot
-        # be used.
-        #add_error_key: false
-
-      # Exclude lines. A list of regular expressions to match. It drops the lines that are
-      # matching any regular expression from the list. The include_lines is called before
-      # exclude_lines. By default, no lines are dropped.
-      #exclude_lines: ["^DBG"]
-
-      # Include lines. A list of regular expressions to match. It exports the lines that are
-      # matching any regular expression from the list. The include_lines is called before
-      # exclude_lines. By default, all the lines are exported.
-      #include_lines: ["^ERR", "^WARN"]
-
-      # Exclude files. A list of regular expressions to match. Filebeat drops the files that
-      # are matching any regular expression from the list. By default, no files are dropped.
-      #exclude_files: [".gz$"]
-
-      # Optional additional fields. These field can be freely picked
-      # to add additional information to the crawled log files for filtering
-      #fields:
-      #  level: debug
-      #  review: 1
-
-      # Set to true to store the additional fields as top level fields instead
-      # of under the "fields" sub-dictionary. In case of name conflicts with the
-      # fields added by Filebeat itself, the custom fields overwrite the default
-      # fields.
-      #fields_under_root: false
-
-      # Ignore files which were modified more then the defined timespan in the past.
-      # ignore_older is disabled by default, so no files are ignored by setting it to 0.
-      # Time strings like 2h (2 hours), 5m (5 minutes) can be used.
-      #ignore_older: 0
-
-      # Close older closes the file handler for which were not modified
-      # for longer then close_older
-      # Time strings like 2h (2 hours), 5m (5 minutes) can be used.
-      #close_older: 1h
-
-      # Type to be published in the 'type' field. For Elasticsearch output,
-      # the type defines the document type these entries should be stored
-      # in. Default: log
-      #document_type: log
-
-      # Scan frequency in seconds.
-      # How often these files should be checked for changes. In case it is set
-      # to 0s, it is done as often as possible. Default: 10s
-      #scan_frequency: 10s
-
-      # Defines the buffer size every harvester uses when fetching the file
-      #harvester_buffer_size: 16384
-
-      # Maximum number of bytes a single log event can have
-      # All bytes after max_bytes are discarded and not sent. The default is 10MB.
-      # This is especially useful for multiline log messages which can get large.
-      #max_bytes: 10485760
-
-      # Mutiline can be used for log messages spanning multiple lines. This is common
-      # for Java Stack Traces or C-Line Continuation
-      #multiline:
-
-        # The regexp Pattern that has to be matched. The example pattern matches all lines starting with [
-        #pattern: ^\[
-
-        # Defines if the pattern set under pattern should be negated or not. Default is false.
-        #negate: false
-
-        # Match can be set to "after" or "before". It is used to define if lines should be append to a pattern
-        # that was (not) matched before or after or as long as a pattern is not matched based on negate.
-        # Note: After is the equivalent to previous and before is the equivalent to to next in Logstash
-        #match: after
-
-        # The maximum number of lines that are combined to one event.
-        # In case there are more the max_lines the additional lines are discarded.
-        # Default is 500
-        #max_lines: 500
-
-        # After the defined timeout, an multiline event is sent even if no new pattern was found to start a new event
-        # Default is 5s.
-        #timeout: 5s
-
-      # Setting tail_files to true means filebeat starts reading new files at the end
-      # instead of the beginning. If this is used in combination with log rotation
-      # this can mean that the first entries of a new file are skipped.
-      #tail_files: false
-
-      # Backoff values define how aggressively filebeat crawls new files for updates
-      # The default values can be used in most cases. Backoff defines how long it is waited
-      # to check a file again after EOF is reached. Default is 1s which means the file
-      # is checked every second if new lines were added. This leads to a near real time crawling.
-      # Every time a new line appears, backoff is reset to the initial value.
-      #backoff: 1s
-
-      # Max backoff defines what the maximum backoff time is. After having backed off multiple times
-      # from checking the files, the waiting time will never exceed max_backoff independent of the
-      # backoff factor. Having it set to 10s means in the worst case a new line can be added to a log
-      # file after having backed off multiple times, it takes a maximum of 10s to read the new line
-      #max_backoff: 10s
-
-      # The backoff factor defines how fast the algorithm backs off. The bigger the backoff factor,
-      # the faster the max_backoff value is reached. If this value is set to 1, no backoff will happen.
-      # The backoff value will be multiplied each time with the backoff_factor until max_backoff is reached
-      #backoff_factor: 2
-
-      # This option closes a file, as soon as the file name changes.
-      # This config option is recommended on windows only. Filebeat keeps the files it's reading open. This can cause
-      # issues when the file is removed, as the file will not be fully removed until also Filebeat closes
-      # the reading. Filebeat closes the file handler after ignore_older. During this time no new file with the
-      # same name can be created. Turning this feature on the other hand can lead to loss of data
-      # on rotate files. It can happen that after file rotation the beginning of the new
-      # file is skipped, as the reading starts at the end. We recommend to leave this option on false
-      # but lower the ignore_older value to release files faster.
-      #force_close_files: false
-
-    # Additional stdin prospector
-
-      # Configuration to use stdin input
-    #- input_type: stdin
-
-
-  # General filebeat configuration options
+  # Type of the files. Based on this the way the file is read is decided.
+  # The different types cannot be mixed in one prospector
   #
+  # Possible options are:
+  # * log: Reads every line of the log file (default)
+  # * stdin: Reads the standard in
+  - input_type: log
+
+    # Paths that should be crawled and fetched. Glob based paths.
+    # To fetch all ".log" files from a specific level of subdirectories
+    # /var/log/*/*.log can be used.
+    # For each file found under this path, a harvester is started.
+    # Make sure not file is defined twice as this can lead to unexpected behaviour.
+    paths:
+      - /var/log/*.log
+      #- c:\programdata\elasticsearch\logs\*
+
+    # Configure the file encoding for reading files with international characters
+    # following the W3C recommendation for HTML5 (http://www.w3.org/TR/encoding).
+    # Some sample encodings:
+    #   plain, utf-8, utf-16be-bom, utf-16be, utf-16le, big5, gb18030, gbk,
+    #    hz-gb-2312, euc-kr, euc-jp, iso-2022-jp, shift-jis, ...
+    #encoding: plain
+
+    # Decode JSON options. Enable this if your logs are structured in JSON.
+    # JSON key on which to apply the line filtering and multiline settings. This key
+    # must be top level and its value must be string, otherwise it is ignored. If
+    # no text key is defined, the line filtering and multiline features cannot be used.
+    #json.message_key:
+
+    # By default, the decoded JSON is placed under a "json" key in the output document.
+    # If you enable this setting, the keys are copied top level in the output document.
+    #json.keys_under_root: false
+
+    # If keys_under_root and this setting are enabled, then the values from the decoded
+    # JSON object overwrite the fields that Filebeat normally adds (type, source, offset, etc.)
+    # in case of conflicts.
+    #json.overwrite_keys: false
+
+    # If this setting is enabled, Filebeat adds a "json_error" key in case of JSON
+    # unmarshaling errors or when a text key is defined in the configuration but cannot
+    # be used.
+    #json.add_error_key: false
+
+    # Exclude lines. A list of regular expressions to match. It drops the lines that are
+    # matching any regular expression from the list. The include_lines is called before
+    # exclude_lines. By default, no lines are dropped.
+    #exclude_lines: ["^DBG"]
+
+    # Include lines. A list of regular expressions to match. It exports the lines that are
+    # matching any regular expression from the list. The include_lines is called before
+    # exclude_lines. By default, all the lines are exported.
+    #include_lines: ["^ERR", "^WARN"]
+
+    # Exclude files. A list of regular expressions to match. Filebeat drops the files that
+    # are matching any regular expression from the list. By default, no files are dropped.
+    #exclude_files: [".gz$"]
+
+    # Optional additional fields. These field can be freely picked
+    # to add additional information to the crawled log files for filtering
+    #fields:
+    #  level: debug
+    #  review: 1
+
+    # Set to true to store the additional fields as top level fields instead
+    # of under the "fields" sub-dictionary. In case of name conflicts with the
+    # fields added by Filebeat itself, the custom fields overwrite the default
+    # fields.
+    #fields_under_root: false
+
+    # Ignore files which were modified more then the defined timespan in the past.
+    # ignore_older is disabled by default, so no files are ignored by setting it to 0.
+    # Time strings like 2h (2 hours), 5m (5 minutes) can be used.
+    #ignore_older: 0
+
+    # Close older closes the file handler for which were not modified
+    # for longer then close_older
+    # Time strings like 2h (2 hours), 5m (5 minutes) can be used.
+    #close_older: 1h
+
+    # Type to be published in the 'type' field. For Elasticsearch output,
+    # the type defines the document type these entries should be stored
+    # in. Default: log
+    #document_type: log
+
+    # Scan frequency in seconds.
+    # How often these files should be checked for changes. In case it is set
+    # to 0s, it is done as often as possible. Default: 10s
+    #scan_frequency: 10s
+
+    # Defines the buffer size every harvester uses when fetching the file
+    #harvester_buffer_size: 16384
+
+    # Maximum number of bytes a single log event can have
+    # All bytes after max_bytes are discarded and not sent. The default is 10MB.
+    # This is especially useful for multiline log messages which can get large.
+    #max_bytes: 10485760
+
+    # Mutiline can be used for log messages spanning multiple lines. This is common
+    # for Java Stack Traces or C-Line Continuation
+    
+    # The regexp Pattern that has to be matched. The example pattern matches all lines starting with [
+    #multiline.pattern: ^\[
+
+    # Defines if the pattern set under pattern should be negated or not. Default is false.
+    #multiline.negate: false
+
+    # Match can be set to "after" or "before". It is used to define if lines should be append to a pattern
+    # that was (not) matched before or after or as long as a pattern is not matched based on negate.
+    # Note: After is the equivalent to previous and before is the equivalent to to next in Logstash
+    #multiline.match: after
+
+    # The maximum number of lines that are combined to one event.
+    # In case there are more the max_lines the additional lines are discarded.
+    # Default is 500
+    #multiline.max_lines: 500
+
+    # After the defined timeout, an multiline event is sent even if no new pattern was found to start a new event
+    # Default is 5s.
+    #multiline.timeout: 5s
+
+    # Setting tail_files to true means filebeat starts reading new files at the end
+    # instead of the beginning. If this is used in combination with log rotation
+    # this can mean that the first entries of a new file are skipped.
+    #tail_files: false
+
+    # Backoff values define how aggressively filebeat crawls new files for updates
+    # The default values can be used in most cases. Backoff defines how long it is waited
+    # to check a file again after EOF is reached. Default is 1s which means the file
+    # is checked every second if new lines were added. This leads to a near real time crawling.
+    # Every time a new line appears, backoff is reset to the initial value.
+    #backoff: 1s
+
+    # Max backoff defines what the maximum backoff time is. After having backed off multiple times
+    # from checking the files, the waiting time will never exceed max_backoff independent of the
+    # backoff factor. Having it set to 10s means in the worst case a new line can be added to a log
+    # file after having backed off multiple times, it takes a maximum of 10s to read the new line
+    #max_backoff: 10s
+
+    # The backoff factor defines how fast the algorithm backs off. The bigger the backoff factor,
+    # the faster the max_backoff value is reached. If this value is set to 1, no backoff will happen.
+    # The backoff value will be multiplied each time with the backoff_factor until max_backoff is reached
+    #backoff_factor: 2
+
+    # This option closes a file, as soon as the file name changes.
+    # This config option is recommended on windows only. Filebeat keeps the files it's reading open. This can cause
+    # issues when the file is removed, as the file will not be fully removed until also Filebeat closes
+    # the reading. Filebeat closes the file handler after ignore_older. During this time no new file with the
+    # same name can be created. Turning this feature on the other hand can lead to loss of data
+    # on rotate files. It can happen that after file rotation the beginning of the new
+    # file is skipped, as the reading starts at the end. We recommend to leave this option on false
+    # but lower the ignore_older value to release files faster.
+    #force_close_files: false
+
+  # Additional stdin prospector
+
+  # Configuration to use stdin input
+  #- input_type: stdin
+
+
+######################### Filebeat general configuration #############################
+
+filebeat:
+  
   # Event count spool threshold - forces network flush if exceeded
   #spool_size: 2048
 
@@ -199,178 +198,174 @@ filebeat:
 
 # Configure what outputs to use when sending the data collected by the beat.
 # Multiple outputs may be used.
-output:
 
-  ### Elasticsearch as output
-  elasticsearch:
-    # Array of hosts to connect to.
-    # Scheme and port can be left out and will be set to the default (http and 9200)
-    # In case you specify and additional path, the scheme is required: http://localhost:9200/path
-    # IPv6 addresses should always be defined as: https://[2001:db8::1]:9200
-    hosts: ["localhost:9200"]
+### Elasticsearch as output
+output.elasticsearch:
+  # Array of hosts to connect to.
+  # Scheme and port can be left out and will be set to the default (http and 9200)
+  # In case you specify and additional path, the scheme is required: http://localhost:9200/path
+  # IPv6 addresses should always be defined as: https://[2001:db8::1]:9200
+  hosts: ["localhost:9200"]
 
-    # Optional protocol and basic auth credentials.
-    #protocol: "https"
-    #username: "admin"
-    #password: "s3cr3t"
+  # Optional protocol and basic auth credentials.
+  #protocol: "https"
+  #username: "admin"
+  #password: "s3cr3t"
 
-    # Dictionary of HTTP parameters to pass within the url with index operations.
-    #parameters:
-      #param1: value1
-      #param2: value2
+  # Dictionary of HTTP parameters to pass within the url with index operations.
+  #parameters:
+    #param1: value1
+    #param2: value2
 
-    # Number of workers per Elasticsearch host.
-    #worker: 1
+  # Number of workers per Elasticsearch host.
+  #worker: 1
 
-    # Optional index name. The default is "filebeat" and generates
-    # [filebeat-]YYYY.MM.DD keys.
-    #index: "filebeat"
+  # Optional index name. The default is "filebeat" and generates
+  # [filebeat-]YYYY.MM.DD keys.
+  #index: "filebeat"
 
-    # A template is used to set the mapping in Elasticsearch
-    # By default template loading is enabled and the template is loaded.
-    # These settings can be adjusted to load your own template or overwrite existing ones
-    template:
+  # Optional HTTP Path
+  #path: "/elasticsearch"
 
-      # Template name. By default the template name is filebeat.
-      name: "filebeat"
+  # Proxy server url
+  #proxy_url: http://proxy:3128
 
-      # Path to template file
-      path: "filebeat.template.json"
+  # The number of times a particular Elasticsearch index operation is attempted. If
+  # the indexing operation doesn't succeed after this many retries, the events are
+  # dropped. The default is 3.
+  #max_retries: 3
 
-      # Overwrite existing template
-      overwrite: false
+  # The maximum number of events to bulk in a single Elasticsearch bulk API index request.
+  # The default is 50.
+  #bulk_max_size: 50
 
-    # Optional HTTP Path
-    #path: "/elasticsearch"
+  # Configure http request timeout before failing an request to Elasticsearch.
+  #timeout: 90
 
-    # Proxy server url
-    #proxy_url: http://proxy:3128
+  # The number of seconds to wait for new events between two bulk API index requests.
+  # If `bulk_max_size` is reached before this interval expires, addition bulk index
+  # requests are made.
+  #flush_interval: 1
 
-    # The number of times a particular Elasticsearch index operation is attempted. If
-    # the indexing operation doesn't succeed after this many retries, the events are
-    # dropped. The default is 3.
-    #max_retries: 3
+  # Boolean that sets if the topology is kept in Elasticsearch. The default is
+  # false. This option makes sense only for Packetbeat.
+  #save_topology: false
 
-    # The maximum number of events to bulk in a single Elasticsearch bulk API index request.
-    # The default is 50.
-    #bulk_max_size: 50
+  # The time to live in seconds for the topology information that is stored in
+  # Elasticsearch. The default is 15 seconds.
+  #topology_expire: 15
 
-    # Configure http request timeout before failing an request to Elasticsearch.
-    #timeout: 90
+  # A template is used to set the mapping in Elasticsearch
+  # By default template loading is enabled and the template is loaded.
+  # These settings can be adjusted to load your own template or overwrite existing ones
 
-    # The number of seconds to wait for new events between two bulk API index requests.
-    # If `bulk_max_size` is reached before this interval expires, addition bulk index
-    # requests are made.
-    #flush_interval: 1
+  # Template name. By default the template name is filebeat.
+  template.name:"filebeat"
 
-    # Boolean that sets if the topology is kept in Elasticsearch. The default is
-    # false. This option makes sense only for Packetbeat.
-    #save_topology: false
+  # Path to template file
+  template.path: "filebeat.template.json"
 
-    # The time to live in seconds for the topology information that is stored in
-    # Elasticsearch. The default is 15 seconds.
-    #topology_expire: 15
+  # Overwrite existing template
+  template.overwrite: false
 
-    # tls configuration. By default is off.
-    #tls:
-      # List of root certificates for HTTPS server verifications
-      #certificate_authorities: ["/etc/pki/root/ca.pem"]
+  # TLS configuration. By default is off.
+  # List of root certificates for HTTPS server verifications
+  #tls.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
-      # Certificate for TLS client authentication
-      #certificate: "/etc/pki/client/cert.pem"
+  # Certificate for TLS client authentication
+  #tls.certificate: "/etc/pki/client/cert.pem"
 
-      # Client Certificate Key
-      #certificate_key: "/etc/pki/client/cert.key"
+  # Client Certificate Key
+  #tls.certificate_key: "/etc/pki/client/cert.key"
 
-      # Controls whether the client verifies server certificates and host name.
-      # If insecure is set to true, all server host names and certificates will be
-      # accepted. In this mode TLS based connections are susceptible to
-      # man-in-the-middle attacks. Use only for testing.
-      #insecure: true
+  # Controls whether the client verifies server certificates and host name.
+  # If insecure is set to true, all server host names and certificates will be
+  # accepted. In this mode TLS based connections are susceptible to
+  # man-in-the-middle attacks. Use only for testing.
+  #tls.insecure: true
 
-      # Configure cipher suites to be used for TLS connections
-      #cipher_suites: []
+  # Configure cipher suites to be used for TLS connections
+  #tls.cipher_suites: []
 
-      # Configure curve types for ECDHE based cipher suites
-      #curve_types: []
+  # Configure curve types for ECDHE based cipher suites
+  #tls.curve_types: []
 
-      # Configure minimum TLS version allowed for connection to logstash
-      #min_version: 1.0
+  # Configure minimum TLS version allowed for connection to logstash
+  #tls.min_version: 1.0
 
-      # Configure maximum TLS version allowed for connection to logstash
-      #max_version: 1.2
+  # Configure maximum TLS version allowed for connection to logstash
+  #tls.max_version: 1.2
 
 
-  ### Logstash as output
-  #logstash:
-    # The Logstash hosts
-    #hosts: ["localhost:5044"]
+### Logstash as output
+#output.logstash:
+  # The Logstash hosts
+  #hosts: ["localhost:5044"]
 
-    # Number of workers per Logstash host.
-    #worker: 1
+  # Number of workers per Logstash host.
+  #worker: 1
 
-    # Set gzip compression level.
-    #compression_level: 3
+  # Set gzip compression level.
+  #compression_level: 3
 
-    # Optional load balance the events between the Logstash hosts
-    #loadbalance: true
+  # Optional load balance the events between the Logstash hosts
+  #loadbalance: true
 
-    # Optional index name. The default index name is set to name of the beat
-    # in all lowercase.
-    #index: filebeat
+  # Optional index name. The default index name is set to name of the beat
+  # in all lowercase.
+  #index: filebeat
 
-    # SOCKS5 proxy server URL
-    #proxy_url: socks5://user:password@socks5-server:2233
+  # SOCKS5 proxy server URL
+  #proxy_url: socks5://user:password@socks5-server:2233
 
-    # Resolve names locally when using a proxy server. Defaults to false.
-    #proxy_use_local_resolver: false
+  # Resolve names locally when using a proxy server. Defaults to false.
+  #proxy_use_local_resolver: false
 
-    # Optional TLS. By default is off.
-    #tls:
-      # List of root certificates for HTTPS server verifications
-      #certificate_authorities: ["/etc/pki/root/ca.pem"]
+  # Optional TLS. By default is off.
+  # List of root certificates for HTTPS server verifications
+  #tls.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
-      # Certificate for TLS client authentication
-      #certificate: "/etc/pki/client/cert.pem"
+  # Certificate for TLS client authentication
+  #tls.certificate: "/etc/pki/client/cert.pem"
 
-      # Client Certificate Key
-      #certificate_key: "/etc/pki/client/cert.key"
+  # Client Certificate Key
+  #tls.certificate_key: "/etc/pki/client/cert.key"
 
-      # Controls whether the client verifies server certificates and host name.
-      # If insecure is set to true, all server host names and certificates will be
-      # accepted. In this mode TLS based connections are susceptible to
-      # man-in-the-middle attacks. Use only for testing.
-      #insecure: true
+  # Controls whether the client verifies server certificates and host name.
+  # If insecure is set to true, all server host names and certificates will be
+  # accepted. In this mode TLS based connections are susceptible to
+  # man-in-the-middle attacks. Use only for testing.
+  #tls.insecure: true
 
-      # Configure cipher suites to be used for TLS connections
-      #cipher_suites: []
+  # Configure cipher suites to be used for TLS connections
+  #tls.cipher_suites: []
 
-      # Configure curve types for ECDHE based cipher suites
-      #curve_types: []
-
-
-  ### File as output
-  #file:
-    # Path to the directory where to save the generated files. The option is mandatory.
-    #path: "/tmp/filebeat"
-
-    # Name of the generated files. The default is `filebeat` and it generates files: `filebeat`, `filebeat.1`, `filebeat.2`, etc.
-    #filename: filebeat
-
-    # Maximum size in kilobytes of each file. When this size is reached, the files are
-    # rotated. The default value is 10240 kB.
-    #rotate_every_kb: 10000
-
-    # Maximum number of files under path. When this number of files is reached, the
-    # oldest file is deleted and the rest are shifted from last to first. The default
-    # is 7 files.
-    #number_of_files: 7
+  # Configure curve types for ECDHE based cipher suites
+  #tls.curve_types: []
 
 
-  ### Console output
-  # console:
-    # Pretty print json event
-    #pretty: false
+### File as output
+#output.file:
+  # Path to the directory where to save the generated files. The option is mandatory.
+  #path: "/tmp/filebeat"
+
+  # Name of the generated files. The default is `filebeat` and it generates files: `filebeat`, `filebeat.1`, `filebeat.2`, etc.
+  #filename: filebeat
+
+  # Maximum size in kilobytes of each file. When this size is reached, the files are
+  # rotated. The default value is 10240 kB.
+  #rotate_every_kb: 10000
+
+  # Maximum number of files under path. When this number of files is reached, the
+  # oldest file is deleted and the rest are shifted from last to first. The default
+  # is 7 files.
+  #number_of_files: 7
+
+
+### Console output
+#output.console:
+  # Pretty print json event
+  #pretty: false
 
 
 ############################# General #########################################
@@ -417,7 +412,6 @@ output:
 # default is the number of logical CPUs available in the system.
 #max_procs:
 
-
 ############################# Logging #########################################
 
 # There are three options for the log output: syslog, file, stderr.
@@ -434,19 +428,18 @@ logging:
   #to_files: false
 
   # To enable logging to files, to_files option has to be set to true
-  files:
-    # The directory where the log files will written to.
-    #path: /var/log/mybeat
+  # The directory where the log files will written to.
+  #files.path: /var/log/mybeat
 
-    # The name of the files where the logs are written to.
-    #name: mybeat
+  # The name of the files where the logs are written to.
+  #files.name: mybeat
 
-    # Configure log file size limit. If limit is reached, log file will be
-    # automatically rotated
-    rotateeverybytes: 10485760 # = 10MB
+  # Configure log file size limit. If limit is reached, log file will be
+  # automatically rotated
+  files.rotateeverybytes: 10485760 # = 10MB
 
-    # Number of rotated log files to keep. Oldest files will be deleted first.
-    #keepfiles: 7
+  # Number of rotated log files to keep. Oldest files will be deleted first.
+  #files.keepfiles: 7
 
   # Enable debug output for selected components. To enable all selectors use ["*"]
   # Other available selectors are beat, publish, service
@@ -456,5 +449,3 @@ logging:
   # Sets log level. The default log level is error.
   # Available log levels are: critical, error, warning, info, debug
   #level: error
-
-

--- a/filebeat/filebeat.yml
+++ b/filebeat/filebeat.yml
@@ -260,7 +260,7 @@ output.elasticsearch:
   # These settings can be adjusted to load your own template or overwrite existing ones
 
   # Template name. By default the template name is filebeat.
-  template.name:"filebeat"
+  template.name: "filebeat"
 
   # Path to template file
   template.path: "filebeat.template.json"
@@ -417,7 +417,7 @@ output.elasticsearch:
 # There are three options for the log output: syslog, file, stderr.
 # Under Windows systems, the log files are per default sent to the file output,
 # under all other system per default to syslog.
-logging:
+#logging:
 
   # Send all logging output to syslog. On Windows default is false, otherwise
   # default is true.

--- a/filebeat/filebeat.yml
+++ b/filebeat/filebeat.yml
@@ -427,20 +427,6 @@ logging:
   # limit is reached.
   #to_files: false
 
-  # To enable logging to files, to_files option has to be set to true
-  # The directory where the log files will written to.
-  #files.path: /var/log/mybeat
-
-  # The name of the files where the logs are written to.
-  #files.name: mybeat
-
-  # Configure log file size limit. If limit is reached, log file will be
-  # automatically rotated
-  files.rotateeverybytes: 10485760 # = 10MB
-
-  # Number of rotated log files to keep. Oldest files will be deleted first.
-  #files.keepfiles: 7
-
   # Enable debug output for selected components. To enable all selectors use ["*"]
   # Other available selectors are beat, publish, service
   # Multiple selectors can be chained.
@@ -449,3 +435,19 @@ logging:
   # Sets log level. The default log level is error.
   # Available log levels are: critical, error, warning, info, debug
   #level: error
+
+
+# To enable logging to files, to_files option has to be set to true
+# The directory where the log files will written to.
+logging.files:
+  #path: /var/log/mybeat
+
+  # The name of the files where the logs are written to.
+  #name: mybeat
+
+  # Configure log file size limit. If limit is reached, log file will be
+  # automatically rotated
+  rotateeverybytes: 10485760 # = 10MB
+
+  # Number of rotated log files to keep. Oldest files will be deleted first.
+  #keepfiles: 7

--- a/libbeat/etc/libbeat.yml
+++ b/libbeat/etc/libbeat.yml
@@ -68,7 +68,7 @@ output.elasticsearch:
   # These settings can be adjusted to load your own template or overwrite existing ones
 
   # Template name. By default the template name is beatname.
-  template.name:"beatname"
+  template.name: "beatname"
 
   # Path to template file
   template.path: "beatname.template.json"
@@ -225,7 +225,7 @@ output.elasticsearch:
 # There are three options for the log output: syslog, file, stderr.
 # Under Windows systems, the log files are per default sent to the file output,
 # under all other system per default to syslog.
-logging:
+#logging:
 
   # Send all logging output to syslog. On Windows default is false, otherwise
   # default is true.

--- a/libbeat/etc/libbeat.yml
+++ b/libbeat/etc/libbeat.yml
@@ -235,20 +235,6 @@ logging:
   # limit is reached.
   #to_files: false
 
-  # To enable logging to files, to_files option has to be set to true
-  # The directory where the log files will written to.
-  #files.path: /var/log/mybeat
-
-  # The name of the files where the logs are written to.
-  #files.name: mybeat
-
-  # Configure log file size limit. If limit is reached, log file will be
-  # automatically rotated
-  files.rotateeverybytes: 10485760 # = 10MB
-
-  # Number of rotated log files to keep. Oldest files will be deleted first.
-  #files.keepfiles: 7
-
   # Enable debug output for selected components. To enable all selectors use ["*"]
   # Other available selectors are beat, publish, service
   # Multiple selectors can be chained.
@@ -257,3 +243,19 @@ logging:
   # Sets log level. The default log level is error.
   # Available log levels are: critical, error, warning, info, debug
   #level: error
+
+
+# To enable logging to files, to_files option has to be set to true
+# The directory where the log files will written to.
+logging.files:
+  #path: /var/log/mybeat
+
+  # The name of the files where the logs are written to.
+  #name: mybeat
+
+  # Configure log file size limit. If limit is reached, log file will be
+  # automatically rotated
+  rotateeverybytes: 10485760 # = 10MB
+
+  # Number of rotated log files to keep. Oldest files will be deleted first.
+  #keepfiles: 7

--- a/libbeat/etc/libbeat.yml
+++ b/libbeat/etc/libbeat.yml
@@ -6,178 +6,174 @@
 
 # Configure what outputs to use when sending the data collected by the beat.
 # Multiple outputs may be used.
-output:
 
-  ### Elasticsearch as output
-  elasticsearch:
-    # Array of hosts to connect to.
-    # Scheme and port can be left out and will be set to the default (http and 9200)
-    # In case you specify and additional path, the scheme is required: http://localhost:9200/path
-    # IPv6 addresses should always be defined as: https://[2001:db8::1]:9200
-    hosts: ["localhost:9200"]
+### Elasticsearch as output
+output.elasticsearch:
+  # Array of hosts to connect to.
+  # Scheme and port can be left out and will be set to the default (http and 9200)
+  # In case you specify and additional path, the scheme is required: http://localhost:9200/path
+  # IPv6 addresses should always be defined as: https://[2001:db8::1]:9200
+  hosts: ["localhost:9200"]
 
-    # Optional protocol and basic auth credentials.
-    #protocol: "https"
-    #username: "admin"
-    #password: "s3cr3t"
+  # Optional protocol and basic auth credentials.
+  #protocol: "https"
+  #username: "admin"
+  #password: "s3cr3t"
 
-    # Dictionary of HTTP parameters to pass within the url with index operations.
-    #parameters:
-      #param1: value1
-      #param2: value2
+  # Dictionary of HTTP parameters to pass within the url with index operations.
+  #parameters:
+    #param1: value1
+    #param2: value2
 
-    # Number of workers per Elasticsearch host.
-    #worker: 1
+  # Number of workers per Elasticsearch host.
+  #worker: 1
 
-    # Optional index name. The default is "beatname" and generates
-    # [beatname-]YYYY.MM.DD keys.
-    #index: "beatname"
+  # Optional index name. The default is "beatname" and generates
+  # [beatname-]YYYY.MM.DD keys.
+  #index: "beatname"
 
-    # A template is used to set the mapping in Elasticsearch
-    # By default template loading is enabled and the template is loaded.
-    # These settings can be adjusted to load your own template or overwrite existing ones
-    template:
+  # Optional HTTP Path
+  #path: "/elasticsearch"
 
-      # Template name. By default the template name is beatname.
-      name: "beatname"
+  # Proxy server url
+  #proxy_url: http://proxy:3128
 
-      # Path to template file
-      path: "beatname.template.json"
+  # The number of times a particular Elasticsearch index operation is attempted. If
+  # the indexing operation doesn't succeed after this many retries, the events are
+  # dropped. The default is 3.
+  #max_retries: 3
 
-      # Overwrite existing template
-      overwrite: false
+  # The maximum number of events to bulk in a single Elasticsearch bulk API index request.
+  # The default is 50.
+  #bulk_max_size: 50
 
-    # Optional HTTP Path
-    #path: "/elasticsearch"
+  # Configure http request timeout before failing an request to Elasticsearch.
+  #timeout: 90
 
-    # Proxy server url
-    #proxy_url: http://proxy:3128
+  # The number of seconds to wait for new events between two bulk API index requests.
+  # If `bulk_max_size` is reached before this interval expires, addition bulk index
+  # requests are made.
+  #flush_interval: 1
 
-    # The number of times a particular Elasticsearch index operation is attempted. If
-    # the indexing operation doesn't succeed after this many retries, the events are
-    # dropped. The default is 3.
-    #max_retries: 3
+  # Boolean that sets if the topology is kept in Elasticsearch. The default is
+  # false. This option makes sense only for Packetbeat.
+  #save_topology: false
 
-    # The maximum number of events to bulk in a single Elasticsearch bulk API index request.
-    # The default is 50.
-    #bulk_max_size: 50
+  # The time to live in seconds for the topology information that is stored in
+  # Elasticsearch. The default is 15 seconds.
+  #topology_expire: 15
 
-    # Configure http request timeout before failing an request to Elasticsearch.
-    #timeout: 90
+  # A template is used to set the mapping in Elasticsearch
+  # By default template loading is enabled and the template is loaded.
+  # These settings can be adjusted to load your own template or overwrite existing ones
 
-    # The number of seconds to wait for new events between two bulk API index requests.
-    # If `bulk_max_size` is reached before this interval expires, addition bulk index
-    # requests are made.
-    #flush_interval: 1
+  # Template name. By default the template name is beatname.
+  template.name:"beatname"
 
-    # Boolean that sets if the topology is kept in Elasticsearch. The default is
-    # false. This option makes sense only for Packetbeat.
-    #save_topology: false
+  # Path to template file
+  template.path: "beatname.template.json"
 
-    # The time to live in seconds for the topology information that is stored in
-    # Elasticsearch. The default is 15 seconds.
-    #topology_expire: 15
+  # Overwrite existing template
+  template.overwrite: false
 
-    # tls configuration. By default is off.
-    #tls:
-      # List of root certificates for HTTPS server verifications
-      #certificate_authorities: ["/etc/pki/root/ca.pem"]
+  # TLS configuration. By default is off.
+  # List of root certificates for HTTPS server verifications
+  #tls.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
-      # Certificate for TLS client authentication
-      #certificate: "/etc/pki/client/cert.pem"
+  # Certificate for TLS client authentication
+  #tls.certificate: "/etc/pki/client/cert.pem"
 
-      # Client Certificate Key
-      #certificate_key: "/etc/pki/client/cert.key"
+  # Client Certificate Key
+  #tls.certificate_key: "/etc/pki/client/cert.key"
 
-      # Controls whether the client verifies server certificates and host name.
-      # If insecure is set to true, all server host names and certificates will be
-      # accepted. In this mode TLS based connections are susceptible to
-      # man-in-the-middle attacks. Use only for testing.
-      #insecure: true
+  # Controls whether the client verifies server certificates and host name.
+  # If insecure is set to true, all server host names and certificates will be
+  # accepted. In this mode TLS based connections are susceptible to
+  # man-in-the-middle attacks. Use only for testing.
+  #tls.insecure: true
 
-      # Configure cipher suites to be used for TLS connections
-      #cipher_suites: []
+  # Configure cipher suites to be used for TLS connections
+  #tls.cipher_suites: []
 
-      # Configure curve types for ECDHE based cipher suites
-      #curve_types: []
+  # Configure curve types for ECDHE based cipher suites
+  #tls.curve_types: []
 
-      # Configure minimum TLS version allowed for connection to logstash
-      #min_version: 1.0
+  # Configure minimum TLS version allowed for connection to logstash
+  #tls.min_version: 1.0
 
-      # Configure maximum TLS version allowed for connection to logstash
-      #max_version: 1.2
+  # Configure maximum TLS version allowed for connection to logstash
+  #tls.max_version: 1.2
 
 
-  ### Logstash as output
-  #logstash:
-    # The Logstash hosts
-    #hosts: ["localhost:5044"]
+### Logstash as output
+#output.logstash:
+  # The Logstash hosts
+  #hosts: ["localhost:5044"]
 
-    # Number of workers per Logstash host.
-    #worker: 1
+  # Number of workers per Logstash host.
+  #worker: 1
 
-    # Set gzip compression level.
-    #compression_level: 3
+  # Set gzip compression level.
+  #compression_level: 3
 
-    # Optional load balance the events between the Logstash hosts
-    #loadbalance: true
+  # Optional load balance the events between the Logstash hosts
+  #loadbalance: true
 
-    # Optional index name. The default index name is set to name of the beat
-    # in all lowercase.
-    #index: beatname
+  # Optional index name. The default index name is set to name of the beat
+  # in all lowercase.
+  #index: beatname
 
-    # SOCKS5 proxy server URL
-    #proxy_url: socks5://user:password@socks5-server:2233
+  # SOCKS5 proxy server URL
+  #proxy_url: socks5://user:password@socks5-server:2233
 
-    # Resolve names locally when using a proxy server. Defaults to false.
-    #proxy_use_local_resolver: false
+  # Resolve names locally when using a proxy server. Defaults to false.
+  #proxy_use_local_resolver: false
 
-    # Optional TLS. By default is off.
-    #tls:
-      # List of root certificates for HTTPS server verifications
-      #certificate_authorities: ["/etc/pki/root/ca.pem"]
+  # Optional TLS. By default is off.
+  # List of root certificates for HTTPS server verifications
+  #tls.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
-      # Certificate for TLS client authentication
-      #certificate: "/etc/pki/client/cert.pem"
+  # Certificate for TLS client authentication
+  #tls.certificate: "/etc/pki/client/cert.pem"
 
-      # Client Certificate Key
-      #certificate_key: "/etc/pki/client/cert.key"
+  # Client Certificate Key
+  #tls.certificate_key: "/etc/pki/client/cert.key"
 
-      # Controls whether the client verifies server certificates and host name.
-      # If insecure is set to true, all server host names and certificates will be
-      # accepted. In this mode TLS based connections are susceptible to
-      # man-in-the-middle attacks. Use only for testing.
-      #insecure: true
+  # Controls whether the client verifies server certificates and host name.
+  # If insecure is set to true, all server host names and certificates will be
+  # accepted. In this mode TLS based connections are susceptible to
+  # man-in-the-middle attacks. Use only for testing.
+  #tls.insecure: true
 
-      # Configure cipher suites to be used for TLS connections
-      #cipher_suites: []
+  # Configure cipher suites to be used for TLS connections
+  #tls.cipher_suites: []
 
-      # Configure curve types for ECDHE based cipher suites
-      #curve_types: []
-
-
-  ### File as output
-  #file:
-    # Path to the directory where to save the generated files. The option is mandatory.
-    #path: "/tmp/beatname"
-
-    # Name of the generated files. The default is `beatname` and it generates files: `beatname`, `beatname.1`, `beatname.2`, etc.
-    #filename: beatname
-
-    # Maximum size in kilobytes of each file. When this size is reached, the files are
-    # rotated. The default value is 10240 kB.
-    #rotate_every_kb: 10000
-
-    # Maximum number of files under path. When this number of files is reached, the
-    # oldest file is deleted and the rest are shifted from last to first. The default
-    # is 7 files.
-    #number_of_files: 7
+  # Configure curve types for ECDHE based cipher suites
+  #tls.curve_types: []
 
 
-  ### Console output
-  # console:
-    # Pretty print json event
-    #pretty: false
+### File as output
+#output.file:
+  # Path to the directory where to save the generated files. The option is mandatory.
+  #path: "/tmp/beatname"
+
+  # Name of the generated files. The default is `beatname` and it generates files: `beatname`, `beatname.1`, `beatname.2`, etc.
+  #filename: beatname
+
+  # Maximum size in kilobytes of each file. When this size is reached, the files are
+  # rotated. The default value is 10240 kB.
+  #rotate_every_kb: 10000
+
+  # Maximum number of files under path. When this number of files is reached, the
+  # oldest file is deleted and the rest are shifted from last to first. The default
+  # is 7 files.
+  #number_of_files: 7
+
+
+### Console output
+#output.console:
+  # Pretty print json event
+  #pretty: false
 
 
 ############################# General #########################################
@@ -224,7 +220,6 @@ output:
 # default is the number of logical CPUs available in the system.
 #max_procs:
 
-
 ############################# Logging #########################################
 
 # There are three options for the log output: syslog, file, stderr.
@@ -241,19 +236,18 @@ logging:
   #to_files: false
 
   # To enable logging to files, to_files option has to be set to true
-  files:
-    # The directory where the log files will written to.
-    #path: /var/log/mybeat
+  # The directory where the log files will written to.
+  #files.path: /var/log/mybeat
 
-    # The name of the files where the logs are written to.
-    #name: mybeat
+  # The name of the files where the logs are written to.
+  #files.name: mybeat
 
-    # Configure log file size limit. If limit is reached, log file will be
-    # automatically rotated
-    rotateeverybytes: 10485760 # = 10MB
+  # Configure log file size limit. If limit is reached, log file will be
+  # automatically rotated
+  files.rotateeverybytes: 10485760 # = 10MB
 
-    # Number of rotated log files to keep. Oldest files will be deleted first.
-    #keepfiles: 7
+  # Number of rotated log files to keep. Oldest files will be deleted first.
+  #files.keepfiles: 7
 
   # Enable debug output for selected components. To enable all selectors use ["*"]
   # Other available selectors are beat, publish, service
@@ -263,5 +257,3 @@ logging:
   # Sets log level. The default log level is error.
   # Available log levels are: critical, error, warning, info, debug
   #level: error
-
-

--- a/metricbeat/metricbeat.yml
+++ b/metricbeat/metricbeat.yml
@@ -153,7 +153,7 @@ output.elasticsearch:
   # These settings can be adjusted to load your own template or overwrite existing ones
 
   # Template name. By default the template name is metricbeat.
-  template.name:"metricbeat"
+  template.name: "metricbeat"
 
   # Path to template file
   template.path: "metricbeat.template.json"
@@ -310,7 +310,7 @@ output.elasticsearch:
 # There are three options for the log output: syslog, file, stderr.
 # Under Windows systems, the log files are per default sent to the file output,
 # under all other system per default to syslog.
-logging:
+#logging:
 
   # Send all logging output to syslog. On Windows default is false, otherwise
   # default is true.

--- a/metricbeat/metricbeat.yml
+++ b/metricbeat/metricbeat.yml
@@ -91,178 +91,174 @@ metricbeat.modules:
 
 # Configure what outputs to use when sending the data collected by the beat.
 # Multiple outputs may be used.
-output:
 
-  ### Elasticsearch as output
-  elasticsearch:
-    # Array of hosts to connect to.
-    # Scheme and port can be left out and will be set to the default (http and 9200)
-    # In case you specify and additional path, the scheme is required: http://localhost:9200/path
-    # IPv6 addresses should always be defined as: https://[2001:db8::1]:9200
-    hosts: ["localhost:9200"]
+### Elasticsearch as output
+output.elasticsearch:
+  # Array of hosts to connect to.
+  # Scheme and port can be left out and will be set to the default (http and 9200)
+  # In case you specify and additional path, the scheme is required: http://localhost:9200/path
+  # IPv6 addresses should always be defined as: https://[2001:db8::1]:9200
+  hosts: ["localhost:9200"]
 
-    # Optional protocol and basic auth credentials.
-    #protocol: "https"
-    #username: "admin"
-    #password: "s3cr3t"
+  # Optional protocol and basic auth credentials.
+  #protocol: "https"
+  #username: "admin"
+  #password: "s3cr3t"
 
-    # Dictionary of HTTP parameters to pass within the url with index operations.
-    #parameters:
-      #param1: value1
-      #param2: value2
+  # Dictionary of HTTP parameters to pass within the url with index operations.
+  #parameters:
+    #param1: value1
+    #param2: value2
 
-    # Number of workers per Elasticsearch host.
-    #worker: 1
+  # Number of workers per Elasticsearch host.
+  #worker: 1
 
-    # Optional index name. The default is "metricbeat" and generates
-    # [metricbeat-]YYYY.MM.DD keys.
-    #index: "metricbeat"
+  # Optional index name. The default is "metricbeat" and generates
+  # [metricbeat-]YYYY.MM.DD keys.
+  #index: "metricbeat"
 
-    # A template is used to set the mapping in Elasticsearch
-    # By default template loading is enabled and the template is loaded.
-    # These settings can be adjusted to load your own template or overwrite existing ones
-    template:
+  # Optional HTTP Path
+  #path: "/elasticsearch"
 
-      # Template name. By default the template name is metricbeat.
-      name: "metricbeat"
+  # Proxy server url
+  #proxy_url: http://proxy:3128
 
-      # Path to template file
-      path: "metricbeat.template.json"
+  # The number of times a particular Elasticsearch index operation is attempted. If
+  # the indexing operation doesn't succeed after this many retries, the events are
+  # dropped. The default is 3.
+  #max_retries: 3
 
-      # Overwrite existing template
-      overwrite: false
+  # The maximum number of events to bulk in a single Elasticsearch bulk API index request.
+  # The default is 50.
+  #bulk_max_size: 50
 
-    # Optional HTTP Path
-    #path: "/elasticsearch"
+  # Configure http request timeout before failing an request to Elasticsearch.
+  #timeout: 90
 
-    # Proxy server url
-    #proxy_url: http://proxy:3128
+  # The number of seconds to wait for new events between two bulk API index requests.
+  # If `bulk_max_size` is reached before this interval expires, addition bulk index
+  # requests are made.
+  #flush_interval: 1
 
-    # The number of times a particular Elasticsearch index operation is attempted. If
-    # the indexing operation doesn't succeed after this many retries, the events are
-    # dropped. The default is 3.
-    #max_retries: 3
+  # Boolean that sets if the topology is kept in Elasticsearch. The default is
+  # false. This option makes sense only for Packetbeat.
+  #save_topology: false
 
-    # The maximum number of events to bulk in a single Elasticsearch bulk API index request.
-    # The default is 50.
-    #bulk_max_size: 50
+  # The time to live in seconds for the topology information that is stored in
+  # Elasticsearch. The default is 15 seconds.
+  #topology_expire: 15
 
-    # Configure http request timeout before failing an request to Elasticsearch.
-    #timeout: 90
+  # A template is used to set the mapping in Elasticsearch
+  # By default template loading is enabled and the template is loaded.
+  # These settings can be adjusted to load your own template or overwrite existing ones
 
-    # The number of seconds to wait for new events between two bulk API index requests.
-    # If `bulk_max_size` is reached before this interval expires, addition bulk index
-    # requests are made.
-    #flush_interval: 1
+  # Template name. By default the template name is metricbeat.
+  template.name:"metricbeat"
 
-    # Boolean that sets if the topology is kept in Elasticsearch. The default is
-    # false. This option makes sense only for Packetbeat.
-    #save_topology: false
+  # Path to template file
+  template.path: "metricbeat.template.json"
 
-    # The time to live in seconds for the topology information that is stored in
-    # Elasticsearch. The default is 15 seconds.
-    #topology_expire: 15
+  # Overwrite existing template
+  template.overwrite: false
 
-    # tls configuration. By default is off.
-    #tls:
-      # List of root certificates for HTTPS server verifications
-      #certificate_authorities: ["/etc/pki/root/ca.pem"]
+  # TLS configuration. By default is off.
+  # List of root certificates for HTTPS server verifications
+  #tls.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
-      # Certificate for TLS client authentication
-      #certificate: "/etc/pki/client/cert.pem"
+  # Certificate for TLS client authentication
+  #tls.certificate: "/etc/pki/client/cert.pem"
 
-      # Client Certificate Key
-      #certificate_key: "/etc/pki/client/cert.key"
+  # Client Certificate Key
+  #tls.certificate_key: "/etc/pki/client/cert.key"
 
-      # Controls whether the client verifies server certificates and host name.
-      # If insecure is set to true, all server host names and certificates will be
-      # accepted. In this mode TLS based connections are susceptible to
-      # man-in-the-middle attacks. Use only for testing.
-      #insecure: true
+  # Controls whether the client verifies server certificates and host name.
+  # If insecure is set to true, all server host names and certificates will be
+  # accepted. In this mode TLS based connections are susceptible to
+  # man-in-the-middle attacks. Use only for testing.
+  #tls.insecure: true
 
-      # Configure cipher suites to be used for TLS connections
-      #cipher_suites: []
+  # Configure cipher suites to be used for TLS connections
+  #tls.cipher_suites: []
 
-      # Configure curve types for ECDHE based cipher suites
-      #curve_types: []
+  # Configure curve types for ECDHE based cipher suites
+  #tls.curve_types: []
 
-      # Configure minimum TLS version allowed for connection to logstash
-      #min_version: 1.0
+  # Configure minimum TLS version allowed for connection to logstash
+  #tls.min_version: 1.0
 
-      # Configure maximum TLS version allowed for connection to logstash
-      #max_version: 1.2
+  # Configure maximum TLS version allowed for connection to logstash
+  #tls.max_version: 1.2
 
 
-  ### Logstash as output
-  #logstash:
-    # The Logstash hosts
-    #hosts: ["localhost:5044"]
+### Logstash as output
+#output.logstash:
+  # The Logstash hosts
+  #hosts: ["localhost:5044"]
 
-    # Number of workers per Logstash host.
-    #worker: 1
+  # Number of workers per Logstash host.
+  #worker: 1
 
-    # Set gzip compression level.
-    #compression_level: 3
+  # Set gzip compression level.
+  #compression_level: 3
 
-    # Optional load balance the events between the Logstash hosts
-    #loadbalance: true
+  # Optional load balance the events between the Logstash hosts
+  #loadbalance: true
 
-    # Optional index name. The default index name is set to name of the beat
-    # in all lowercase.
-    #index: metricbeat
+  # Optional index name. The default index name is set to name of the beat
+  # in all lowercase.
+  #index: metricbeat
 
-    # SOCKS5 proxy server URL
-    #proxy_url: socks5://user:password@socks5-server:2233
+  # SOCKS5 proxy server URL
+  #proxy_url: socks5://user:password@socks5-server:2233
 
-    # Resolve names locally when using a proxy server. Defaults to false.
-    #proxy_use_local_resolver: false
+  # Resolve names locally when using a proxy server. Defaults to false.
+  #proxy_use_local_resolver: false
 
-    # Optional TLS. By default is off.
-    #tls:
-      # List of root certificates for HTTPS server verifications
-      #certificate_authorities: ["/etc/pki/root/ca.pem"]
+  # Optional TLS. By default is off.
+  # List of root certificates for HTTPS server verifications
+  #tls.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
-      # Certificate for TLS client authentication
-      #certificate: "/etc/pki/client/cert.pem"
+  # Certificate for TLS client authentication
+  #tls.certificate: "/etc/pki/client/cert.pem"
 
-      # Client Certificate Key
-      #certificate_key: "/etc/pki/client/cert.key"
+  # Client Certificate Key
+  #tls.certificate_key: "/etc/pki/client/cert.key"
 
-      # Controls whether the client verifies server certificates and host name.
-      # If insecure is set to true, all server host names and certificates will be
-      # accepted. In this mode TLS based connections are susceptible to
-      # man-in-the-middle attacks. Use only for testing.
-      #insecure: true
+  # Controls whether the client verifies server certificates and host name.
+  # If insecure is set to true, all server host names and certificates will be
+  # accepted. In this mode TLS based connections are susceptible to
+  # man-in-the-middle attacks. Use only for testing.
+  #tls.insecure: true
 
-      # Configure cipher suites to be used for TLS connections
-      #cipher_suites: []
+  # Configure cipher suites to be used for TLS connections
+  #tls.cipher_suites: []
 
-      # Configure curve types for ECDHE based cipher suites
-      #curve_types: []
-
-
-  ### File as output
-  #file:
-    # Path to the directory where to save the generated files. The option is mandatory.
-    #path: "/tmp/metricbeat"
-
-    # Name of the generated files. The default is `metricbeat` and it generates files: `metricbeat`, `metricbeat.1`, `metricbeat.2`, etc.
-    #filename: metricbeat
-
-    # Maximum size in kilobytes of each file. When this size is reached, the files are
-    # rotated. The default value is 10240 kB.
-    #rotate_every_kb: 10000
-
-    # Maximum number of files under path. When this number of files is reached, the
-    # oldest file is deleted and the rest are shifted from last to first. The default
-    # is 7 files.
-    #number_of_files: 7
+  # Configure curve types for ECDHE based cipher suites
+  #tls.curve_types: []
 
 
-  ### Console output
-  # console:
-    # Pretty print json event
-    #pretty: false
+### File as output
+#output.file:
+  # Path to the directory where to save the generated files. The option is mandatory.
+  #path: "/tmp/metricbeat"
+
+  # Name of the generated files. The default is `metricbeat` and it generates files: `metricbeat`, `metricbeat.1`, `metricbeat.2`, etc.
+  #filename: metricbeat
+
+  # Maximum size in kilobytes of each file. When this size is reached, the files are
+  # rotated. The default value is 10240 kB.
+  #rotate_every_kb: 10000
+
+  # Maximum number of files under path. When this number of files is reached, the
+  # oldest file is deleted and the rest are shifted from last to first. The default
+  # is 7 files.
+  #number_of_files: 7
+
+
+### Console output
+#output.console:
+  # Pretty print json event
+  #pretty: false
 
 
 ############################# General #########################################
@@ -309,7 +305,6 @@ output:
 # default is the number of logical CPUs available in the system.
 #max_procs:
 
-
 ############################# Logging #########################################
 
 # There are three options for the log output: syslog, file, stderr.
@@ -325,21 +320,6 @@ logging:
   # limit is reached.
   #to_files: false
 
-  # To enable logging to files, to_files option has to be set to true
-  files:
-    # The directory where the log files will written to.
-    #path: /var/log/mybeat
-
-    # The name of the files where the logs are written to.
-    #name: mybeat
-
-    # Configure log file size limit. If limit is reached, log file will be
-    # automatically rotated
-    rotateeverybytes: 10485760 # = 10MB
-
-    # Number of rotated log files to keep. Oldest files will be deleted first.
-    #keepfiles: 7
-
   # Enable debug output for selected components. To enable all selectors use ["*"]
   # Other available selectors are beat, publish, service
   # Multiple selectors can be chained.
@@ -350,3 +330,17 @@ logging:
   #level: error
 
 
+# To enable logging to files, to_files option has to be set to true
+# The directory where the log files will written to.
+logging.files:
+  #path: /var/log/mybeat
+
+  # The name of the files where the logs are written to.
+  #name: mybeat
+
+  # Configure log file size limit. If limit is reached, log file will be
+  # automatically rotated
+  rotateeverybytes: 10485760 # = 10MB
+
+  # Number of rotated log files to keep. Oldest files will be deleted first.
+  #keepfiles: 7

--- a/packetbeat/etc/beat.yml
+++ b/packetbeat/etc/beat.yml
@@ -8,12 +8,15 @@
 # application components. It inserts meta-data about each transaction into
 # Elasticsearch.
 
-############################# Sniffer #########################################
+############################# Interfaces #########################################
 
 # Select the network interfaces to sniff the data. You can use the "any"
 # keyword to sniff on all connected interfaces.
 packetbeat.interfaces:
   device: any
+
+
+############################# Flows ##############################################
 
 packetbeat.flows:
   # Set network flow timeout. Flow is killed if no packet is received before being
@@ -23,135 +26,136 @@ packetbeat.flows:
   # Configure reporting period. If set to -1, only killed flows will be reported
   #period: 10s
 
-############################# Protocols #######################################
-packetbeat.protocols:
-  icmp:
-    # Enable ICMPv4 and ICMPv6 monitoring. Default: false
-    enabled: true
 
-  amqp:
-    # Configure the ports where to listen for AMQP traffic. You can disable
-    # the AMQP protocol by commenting out the list of ports.
-    ports: [5672]
-    # Truncate messages that are published and avoid huge messages being
-    # indexed.
-    # Default: 1000
-    #max_body_length: 1000
+########################### Transaction protocols ################################
 
-    # Hide the header fields in header frames.
-    # Default: false
-    #parse_headers: false
+packetbeat.protocols.icmp:
+  # Enable ICMPv4 and ICMPv6 monitoring. Default: false
+  enabled: true
 
-    # Hide the additional arguments of method frames.
-    # Default: false
-    #parse_arguments: false
+packetbeat.protocols.amqp:
+  # Configure the ports where to listen for AMQP traffic. You can disable
+  # the AMQP protocol by commenting out the list of ports.
+  ports: [5672]
+  # Truncate messages that are published and avoid huge messages being
+  # indexed.
+  # Default: 1000
+  #max_body_length: 1000
 
-    # Hide all methods relative to connection negociation between server and
-    # client.
-    # Default: true
-    #hide_connection_information: true
+  # Hide the header fields in header frames.
+  # Default: false
+  #parse_headers: false
 
-  dns:
-    # Configure the ports where to listen for DNS traffic. You can disable
-    # the DNS protocol by commenting out the list of ports.
-    ports: [53]
+  # Hide the additional arguments of method frames.
+  # Default: false
+  #parse_arguments: false
 
-    # include_authorities controls whether or not the dns.authorities field
-    # (authority resource records) is added to messages.
-    # Default: false
-    include_authorities: true
-    # include_additionals controls whether or not the dns.additionals field
-    # (additional resource records) is added to messages.
-    # Default: false
-    include_additionals: true
+  # Hide all methods relative to connection negociation between server and
+  # client.
+  # Default: true
+  #hide_connection_information: true
 
-    # send_request and send_response control whether or not the stringified DNS
-    # request and response message are added to the result.
-    # Nearly all data about the request/response is available in the dns.*
-    # fields, but this can be useful if you need visibility specifically
-    # into the request or the response.
-    # Default: false
-    # send_request:  true
-    # send_response: true
+packetbeat.protocols.dns:
+  # Configure the ports where to listen for DNS traffic. You can disable
+  # the DNS protocol by commenting out the list of ports.
+  ports: [53]
 
-  http:
-    # Configure the ports where to listen for HTTP traffic. You can disable
-    # the HTTP protocol by commenting out the list of ports.
-    ports: [80, 8080, 8000, 5000, 8002]
+  # include_authorities controls whether or not the dns.authorities field
+  # (authority resource records) is added to messages.
+  # Default: false
+  include_authorities: true
+  # include_additionals controls whether or not the dns.additionals field
+  # (additional resource records) is added to messages.
+  # Default: false
+  include_additionals: true
 
-    # Uncomment the following to hide certain parameters in URL or forms attached
-    # to HTTP requests. The names of the parameters are case insensitive.
-    # The value of the parameters will be replaced with the 'xxxxx' string.
-    # This is generally useful for avoiding storing user passwords or other
-    # sensitive information.
-    # Only query parameters and top level form parameters are replaced.
-    # hide_keywords: ['pass', 'password', 'passwd']
+  # send_request and send_response control whether or not the stringified DNS
+  # request and response message are added to the result.
+  # Nearly all data about the request/response is available in the dns.*
+  # fields, but this can be useful if you need visibility specifically
+  # into the request or the response.
+  # Default: false
+  # send_request:  true
+  # send_response: true
 
-  memcache:
-    # Configure the ports where to listen for memcache traffic. You can disable
-    # the Memcache protocol by commenting out the list of ports.
-    ports: [11211]
+packetbeat.protocols.http:
+  # Configure the ports where to listen for HTTP traffic. You can disable
+  # the HTTP protocol by commenting out the list of ports.
+  ports: [80, 8080, 8000, 5000, 8002]
 
-    # Uncomment the parseunknown option to force the memcache text protocol parser
-    # to accept unknown commands.
-    # Note: All unknown commands MUST not contain any data parts!
-    # Default: false
-    # parseunknown: true
+  # Uncomment the following to hide certain parameters in URL or forms attached
+  # to HTTP requests. The names of the parameters are case insensitive.
+  # The value of the parameters will be replaced with the 'xxxxx' string.
+  # This is generally useful for avoiding storing user passwords or other
+  # sensitive information.
+  # Only query parameters and top level form parameters are replaced.
+  # hide_keywords: ['pass', 'password', 'passwd']
 
-    # Update the maxvalue option to store the values - base64 encoded - in the
-    # json output.
-    # possible values:
-    #    maxvalue: -1  # store all values (text based protocol multi-get)
-    #    maxvalue: 0   # store no values at all
-    #    maxvalue: N   # store up to N values
-    # Default: 0
-    # maxvalues: -1
+packetbeat.protocols.memcache:
+  # Configure the ports where to listen for memcache traffic. You can disable
+  # the Memcache protocol by commenting out the list of ports.
+  ports: [11211]
 
-    # Use maxbytespervalue to limit the number of bytes to be copied per value element.
-    # Note: Values will be base64 encoded, so actual size in json document
-    #       will be 4 times maxbytespervalue.
-    # Default: unlimited
-    # maxbytespervalue: 100
+  # Uncomment the parseunknown option to force the memcache text protocol parser
+  # to accept unknown commands.
+  # Note: All unknown commands MUST not contain any data parts!
+  # Default: false
+  # parseunknown: true
 
-    # UDP transaction timeout in milliseconds.
-    # Note: Quiet messages in UDP binary protocol will get response only in error case.
-    #       The memcached analyzer will wait for udptransactiontimeout milliseconds
-    #       before publishing quiet messages. Non quiet messages or quiet requests with
-    #       error response will not have to wait for the timeout.
-    # Default: 200
-    # udptransactiontimeout: 1000
+  # Update the maxvalue option to store the values - base64 encoded - in the
+  # json output.
+  # possible values:
+  #    maxvalue: -1  # store all values (text based protocol multi-get)
+  #    maxvalue: 0   # store no values at all
+  #    maxvalue: N   # store up to N values
+  # Default: 0
+  # maxvalues: -1
 
-  mysql:
-    # Configure the ports where to listen for MySQL traffic. You can disable
-    # the MySQL protocol by commenting out the list of ports.
-    ports: [3306]
+  # Use maxbytespervalue to limit the number of bytes to be copied per value element.
+  # Note: Values will be base64 encoded, so actual size in json document
+  #       will be 4 times maxbytespervalue.
+  # Default: unlimited
+  # maxbytespervalue: 100
 
-  pgsql:
-    # Configure the ports where to listen for Pgsql traffic. You can disable
-    # the Pgsql protocol by commenting out the list of ports.
-    ports: [5432]
+  # UDP transaction timeout in milliseconds.
+  # Note: Quiet messages in UDP binary protocol will get response only in error case.
+  #       The memcached analyzer will wait for udptransactiontimeout milliseconds
+  #       before publishing quiet messages. Non quiet messages or quiet requests with
+  #       error response will not have to wait for the timeout.
+  # Default: 200
+  # udptransactiontimeout: 1000
 
-  redis:
-    # Configure the ports where to listen for Redis traffic. You can disable
-    # the Redis protocol by commenting out the list of ports.
-    ports: [6379]
+packetbeat.protocols.mysql:
+  # Configure the ports where to listen for MySQL traffic. You can disable
+  # the MySQL protocol by commenting out the list of ports.
+  ports: [3306]
 
-  thrift:
-    # Configure the ports where to listen for Thrift-RPC traffic. You can disable
-    # the Thrift-RPC protocol by commenting out the list of ports.
-    ports: [9090]
+packetbeat.protocols.pgsql:
+  # Configure the ports where to listen for Pgsql traffic. You can disable
+  # the Pgsql protocol by commenting out the list of ports.
+  ports: [5432]
 
-  mongodb:
-    # Configure the ports where to listen for MongoDB traffic. You can disable
-    # the MongoDB protocol by commenting out the list of ports.
-    ports: [27017]
+packetbeat.protocols.redis:
+  # Configure the ports where to listen for Redis traffic. You can disable
+  # the Redis protocol by commenting out the list of ports.
+  ports: [6379]
 
-  nfs:
-    # Configure the ports where to listen for NFS traffic. You can disable
-    # the NFS protocol by commenting out the list of ports.
-    ports: [2049]
+packetbeat.protocols.thrift:
+  # Configure the ports where to listen for Thrift-RPC traffic. You can disable
+  # the Thrift-RPC protocol by commenting out the list of ports.
+  ports: [9090]
 
-############################# Processes #######################################
+packetbeat.protocols.mongodb:
+  # Configure the ports where to listen for MongoDB traffic. You can disable
+  # the MongoDB protocol by commenting out the list of ports.
+  ports: [27017]
+
+packetbeat.protocols.nfs:
+  # Configure the ports where to listen for NFS traffic. You can disable
+  # the NFS protocol by commenting out the list of ports.
+  ports: [2049]
+
+########################## Monitored processes ################################
 
 # Configure the processes to be monitored and how to find them. If a process is
 # monitored then Packetbeat attempts to use it's name to fill in the `proc` and

--- a/packetbeat/packetbeat.yml
+++ b/packetbeat/packetbeat.yml
@@ -8,12 +8,15 @@
 # application components. It inserts meta-data about each transaction into
 # Elasticsearch.
 
-############################# Sniffer #########################################
+############################# Interfaces #########################################
 
 # Select the network interfaces to sniff the data. You can use the "any"
 # keyword to sniff on all connected interfaces.
 packetbeat.interfaces:
   device: any
+
+
+############################# Flows ##############################################
 
 packetbeat.flows:
   # Set network flow timeout. Flow is killed if no packet is received before being
@@ -23,135 +26,136 @@ packetbeat.flows:
   # Configure reporting period. If set to -1, only killed flows will be reported
   #period: 10s
 
-############################# Protocols #######################################
-packetbeat.protocols:
-  icmp:
-    # Enable ICMPv4 and ICMPv6 monitoring. Default: false
-    enabled: true
 
-  amqp:
-    # Configure the ports where to listen for AMQP traffic. You can disable
-    # the AMQP protocol by commenting out the list of ports.
-    ports: [5672]
-    # Truncate messages that are published and avoid huge messages being
-    # indexed.
-    # Default: 1000
-    #max_body_length: 1000
+########################### Transaction protocols ################################
 
-    # Hide the header fields in header frames.
-    # Default: false
-    #parse_headers: false
+packetbeat.protocols.icmp:
+  # Enable ICMPv4 and ICMPv6 monitoring. Default: false
+  enabled: true
 
-    # Hide the additional arguments of method frames.
-    # Default: false
-    #parse_arguments: false
+packetbeat.protocols.amqp:
+  # Configure the ports where to listen for AMQP traffic. You can disable
+  # the AMQP protocol by commenting out the list of ports.
+  ports: [5672]
+  # Truncate messages that are published and avoid huge messages being
+  # indexed.
+  # Default: 1000
+  #max_body_length: 1000
 
-    # Hide all methods relative to connection negociation between server and
-    # client.
-    # Default: true
-    #hide_connection_information: true
+  # Hide the header fields in header frames.
+  # Default: false
+  #parse_headers: false
 
-  dns:
-    # Configure the ports where to listen for DNS traffic. You can disable
-    # the DNS protocol by commenting out the list of ports.
-    ports: [53]
+  # Hide the additional arguments of method frames.
+  # Default: false
+  #parse_arguments: false
 
-    # include_authorities controls whether or not the dns.authorities field
-    # (authority resource records) is added to messages.
-    # Default: false
-    include_authorities: true
-    # include_additionals controls whether or not the dns.additionals field
-    # (additional resource records) is added to messages.
-    # Default: false
-    include_additionals: true
+  # Hide all methods relative to connection negociation between server and
+  # client.
+  # Default: true
+  #hide_connection_information: true
 
-    # send_request and send_response control whether or not the stringified DNS
-    # request and response message are added to the result.
-    # Nearly all data about the request/response is available in the dns.*
-    # fields, but this can be useful if you need visibility specifically
-    # into the request or the response.
-    # Default: false
-    # send_request:  true
-    # send_response: true
+packetbeat.protocols.dns:
+  # Configure the ports where to listen for DNS traffic. You can disable
+  # the DNS protocol by commenting out the list of ports.
+  ports: [53]
 
-  http:
-    # Configure the ports where to listen for HTTP traffic. You can disable
-    # the HTTP protocol by commenting out the list of ports.
-    ports: [80, 8080, 8000, 5000, 8002]
+  # include_authorities controls whether or not the dns.authorities field
+  # (authority resource records) is added to messages.
+  # Default: false
+  include_authorities: true
+  # include_additionals controls whether or not the dns.additionals field
+  # (additional resource records) is added to messages.
+  # Default: false
+  include_additionals: true
 
-    # Uncomment the following to hide certain parameters in URL or forms attached
-    # to HTTP requests. The names of the parameters are case insensitive.
-    # The value of the parameters will be replaced with the 'xxxxx' string.
-    # This is generally useful for avoiding storing user passwords or other
-    # sensitive information.
-    # Only query parameters and top level form parameters are replaced.
-    # hide_keywords: ['pass', 'password', 'passwd']
+  # send_request and send_response control whether or not the stringified DNS
+  # request and response message are added to the result.
+  # Nearly all data about the request/response is available in the dns.*
+  # fields, but this can be useful if you need visibility specifically
+  # into the request or the response.
+  # Default: false
+  # send_request:  true
+  # send_response: true
 
-  memcache:
-    # Configure the ports where to listen for memcache traffic. You can disable
-    # the Memcache protocol by commenting out the list of ports.
-    ports: [11211]
+packetbeat.protocols.http:
+  # Configure the ports where to listen for HTTP traffic. You can disable
+  # the HTTP protocol by commenting out the list of ports.
+  ports: [80, 8080, 8000, 5000, 8002]
 
-    # Uncomment the parseunknown option to force the memcache text protocol parser
-    # to accept unknown commands.
-    # Note: All unknown commands MUST not contain any data parts!
-    # Default: false
-    # parseunknown: true
+  # Uncomment the following to hide certain parameters in URL or forms attached
+  # to HTTP requests. The names of the parameters are case insensitive.
+  # The value of the parameters will be replaced with the 'xxxxx' string.
+  # This is generally useful for avoiding storing user passwords or other
+  # sensitive information.
+  # Only query parameters and top level form parameters are replaced.
+  # hide_keywords: ['pass', 'password', 'passwd']
 
-    # Update the maxvalue option to store the values - base64 encoded - in the
-    # json output.
-    # possible values:
-    #    maxvalue: -1  # store all values (text based protocol multi-get)
-    #    maxvalue: 0   # store no values at all
-    #    maxvalue: N   # store up to N values
-    # Default: 0
-    # maxvalues: -1
+packetbeat.protocols.memcache:
+  # Configure the ports where to listen for memcache traffic. You can disable
+  # the Memcache protocol by commenting out the list of ports.
+  ports: [11211]
 
-    # Use maxbytespervalue to limit the number of bytes to be copied per value element.
-    # Note: Values will be base64 encoded, so actual size in json document
-    #       will be 4 times maxbytespervalue.
-    # Default: unlimited
-    # maxbytespervalue: 100
+  # Uncomment the parseunknown option to force the memcache text protocol parser
+  # to accept unknown commands.
+  # Note: All unknown commands MUST not contain any data parts!
+  # Default: false
+  # parseunknown: true
 
-    # UDP transaction timeout in milliseconds.
-    # Note: Quiet messages in UDP binary protocol will get response only in error case.
-    #       The memcached analyzer will wait for udptransactiontimeout milliseconds
-    #       before publishing quiet messages. Non quiet messages or quiet requests with
-    #       error response will not have to wait for the timeout.
-    # Default: 200
-    # udptransactiontimeout: 1000
+  # Update the maxvalue option to store the values - base64 encoded - in the
+  # json output.
+  # possible values:
+  #    maxvalue: -1  # store all values (text based protocol multi-get)
+  #    maxvalue: 0   # store no values at all
+  #    maxvalue: N   # store up to N values
+  # Default: 0
+  # maxvalues: -1
 
-  mysql:
-    # Configure the ports where to listen for MySQL traffic. You can disable
-    # the MySQL protocol by commenting out the list of ports.
-    ports: [3306]
+  # Use maxbytespervalue to limit the number of bytes to be copied per value element.
+  # Note: Values will be base64 encoded, so actual size in json document
+  #       will be 4 times maxbytespervalue.
+  # Default: unlimited
+  # maxbytespervalue: 100
 
-  pgsql:
-    # Configure the ports where to listen for Pgsql traffic. You can disable
-    # the Pgsql protocol by commenting out the list of ports.
-    ports: [5432]
+  # UDP transaction timeout in milliseconds.
+  # Note: Quiet messages in UDP binary protocol will get response only in error case.
+  #       The memcached analyzer will wait for udptransactiontimeout milliseconds
+  #       before publishing quiet messages. Non quiet messages or quiet requests with
+  #       error response will not have to wait for the timeout.
+  # Default: 200
+  # udptransactiontimeout: 1000
 
-  redis:
-    # Configure the ports where to listen for Redis traffic. You can disable
-    # the Redis protocol by commenting out the list of ports.
-    ports: [6379]
+packetbeat.protocols.mysql:
+  # Configure the ports where to listen for MySQL traffic. You can disable
+  # the MySQL protocol by commenting out the list of ports.
+  ports: [3306]
 
-  thrift:
-    # Configure the ports where to listen for Thrift-RPC traffic. You can disable
-    # the Thrift-RPC protocol by commenting out the list of ports.
-    ports: [9090]
+packetbeat.protocols.pgsql:
+  # Configure the ports where to listen for Pgsql traffic. You can disable
+  # the Pgsql protocol by commenting out the list of ports.
+  ports: [5432]
 
-  mongodb:
-    # Configure the ports where to listen for MongoDB traffic. You can disable
-    # the MongoDB protocol by commenting out the list of ports.
-    ports: [27017]
+packetbeat.protocols.redis:
+  # Configure the ports where to listen for Redis traffic. You can disable
+  # the Redis protocol by commenting out the list of ports.
+  ports: [6379]
 
-  nfs:
-    # Configure the ports where to listen for NFS traffic. You can disable
-    # the NFS protocol by commenting out the list of ports.
-    ports: [2049]
+packetbeat.protocols.thrift:
+  # Configure the ports where to listen for Thrift-RPC traffic. You can disable
+  # the Thrift-RPC protocol by commenting out the list of ports.
+  ports: [9090]
 
-############################# Processes #######################################
+packetbeat.protocols.mongodb:
+  # Configure the ports where to listen for MongoDB traffic. You can disable
+  # the MongoDB protocol by commenting out the list of ports.
+  ports: [27017]
+
+packetbeat.protocols.nfs:
+  # Configure the ports where to listen for NFS traffic. You can disable
+  # the NFS protocol by commenting out the list of ports.
+  ports: [2049]
+
+########################## Monitored processes ################################
 
 # Configure the processes to be monitored and how to find them. If a process is
 # monitored then Packetbeat attempts to use it's name to fill in the `proc` and
@@ -183,178 +187,174 @@ packetbeat.protocols:
 
 # Configure what outputs to use when sending the data collected by the beat.
 # Multiple outputs may be used.
-output:
 
-  ### Elasticsearch as output
-  elasticsearch:
-    # Array of hosts to connect to.
-    # Scheme and port can be left out and will be set to the default (http and 9200)
-    # In case you specify and additional path, the scheme is required: http://localhost:9200/path
-    # IPv6 addresses should always be defined as: https://[2001:db8::1]:9200
-    hosts: ["localhost:9200"]
+### Elasticsearch as output
+output.elasticsearch:
+  # Array of hosts to connect to.
+  # Scheme and port can be left out and will be set to the default (http and 9200)
+  # In case you specify and additional path, the scheme is required: http://localhost:9200/path
+  # IPv6 addresses should always be defined as: https://[2001:db8::1]:9200
+  hosts: ["localhost:9200"]
 
-    # Optional protocol and basic auth credentials.
-    #protocol: "https"
-    #username: "admin"
-    #password: "s3cr3t"
+  # Optional protocol and basic auth credentials.
+  #protocol: "https"
+  #username: "admin"
+  #password: "s3cr3t"
 
-    # Dictionary of HTTP parameters to pass within the url with index operations.
-    #parameters:
-      #param1: value1
-      #param2: value2
+  # Dictionary of HTTP parameters to pass within the url with index operations.
+  #parameters:
+    #param1: value1
+    #param2: value2
 
-    # Number of workers per Elasticsearch host.
-    #worker: 1
+  # Number of workers per Elasticsearch host.
+  #worker: 1
 
-    # Optional index name. The default is "packetbeat" and generates
-    # [packetbeat-]YYYY.MM.DD keys.
-    #index: "packetbeat"
+  # Optional index name. The default is "packetbeat" and generates
+  # [packetbeat-]YYYY.MM.DD keys.
+  #index: "packetbeat"
 
-    # A template is used to set the mapping in Elasticsearch
-    # By default template loading is enabled and the template is loaded.
-    # These settings can be adjusted to load your own template or overwrite existing ones
-    template:
+  # Optional HTTP Path
+  #path: "/elasticsearch"
 
-      # Template name. By default the template name is packetbeat.
-      name: "packetbeat"
+  # Proxy server url
+  #proxy_url: http://proxy:3128
 
-      # Path to template file
-      path: "packetbeat.template.json"
+  # The number of times a particular Elasticsearch index operation is attempted. If
+  # the indexing operation doesn't succeed after this many retries, the events are
+  # dropped. The default is 3.
+  #max_retries: 3
 
-      # Overwrite existing template
-      overwrite: false
+  # The maximum number of events to bulk in a single Elasticsearch bulk API index request.
+  # The default is 50.
+  #bulk_max_size: 50
 
-    # Optional HTTP Path
-    #path: "/elasticsearch"
+  # Configure http request timeout before failing an request to Elasticsearch.
+  #timeout: 90
 
-    # Proxy server url
-    #proxy_url: http://proxy:3128
+  # The number of seconds to wait for new events between two bulk API index requests.
+  # If `bulk_max_size` is reached before this interval expires, addition bulk index
+  # requests are made.
+  #flush_interval: 1
 
-    # The number of times a particular Elasticsearch index operation is attempted. If
-    # the indexing operation doesn't succeed after this many retries, the events are
-    # dropped. The default is 3.
-    #max_retries: 3
+  # Boolean that sets if the topology is kept in Elasticsearch. The default is
+  # false. This option makes sense only for Packetbeat.
+  #save_topology: false
 
-    # The maximum number of events to bulk in a single Elasticsearch bulk API index request.
-    # The default is 50.
-    #bulk_max_size: 50
+  # The time to live in seconds for the topology information that is stored in
+  # Elasticsearch. The default is 15 seconds.
+  #topology_expire: 15
 
-    # Configure http request timeout before failing an request to Elasticsearch.
-    #timeout: 90
+  # A template is used to set the mapping in Elasticsearch
+  # By default template loading is enabled and the template is loaded.
+  # These settings can be adjusted to load your own template or overwrite existing ones
 
-    # The number of seconds to wait for new events between two bulk API index requests.
-    # If `bulk_max_size` is reached before this interval expires, addition bulk index
-    # requests are made.
-    #flush_interval: 1
+  # Template name. By default the template name is packetbeat.
+  template.name:"packetbeat"
 
-    # Boolean that sets if the topology is kept in Elasticsearch. The default is
-    # false. This option makes sense only for Packetbeat.
-    #save_topology: false
+  # Path to template file
+  template.path: "packetbeat.template.json"
 
-    # The time to live in seconds for the topology information that is stored in
-    # Elasticsearch. The default is 15 seconds.
-    #topology_expire: 15
+  # Overwrite existing template
+  template.overwrite: false
 
-    # tls configuration. By default is off.
-    #tls:
-      # List of root certificates for HTTPS server verifications
-      #certificate_authorities: ["/etc/pki/root/ca.pem"]
+  # TLS configuration. By default is off.
+  # List of root certificates for HTTPS server verifications
+  #tls.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
-      # Certificate for TLS client authentication
-      #certificate: "/etc/pki/client/cert.pem"
+  # Certificate for TLS client authentication
+  #tls.certificate: "/etc/pki/client/cert.pem"
 
-      # Client Certificate Key
-      #certificate_key: "/etc/pki/client/cert.key"
+  # Client Certificate Key
+  #tls.certificate_key: "/etc/pki/client/cert.key"
 
-      # Controls whether the client verifies server certificates and host name.
-      # If insecure is set to true, all server host names and certificates will be
-      # accepted. In this mode TLS based connections are susceptible to
-      # man-in-the-middle attacks. Use only for testing.
-      #insecure: true
+  # Controls whether the client verifies server certificates and host name.
+  # If insecure is set to true, all server host names and certificates will be
+  # accepted. In this mode TLS based connections are susceptible to
+  # man-in-the-middle attacks. Use only for testing.
+  #tls.insecure: true
 
-      # Configure cipher suites to be used for TLS connections
-      #cipher_suites: []
+  # Configure cipher suites to be used for TLS connections
+  #tls.cipher_suites: []
 
-      # Configure curve types for ECDHE based cipher suites
-      #curve_types: []
+  # Configure curve types for ECDHE based cipher suites
+  #tls.curve_types: []
 
-      # Configure minimum TLS version allowed for connection to logstash
-      #min_version: 1.0
+  # Configure minimum TLS version allowed for connection to logstash
+  #tls.min_version: 1.0
 
-      # Configure maximum TLS version allowed for connection to logstash
-      #max_version: 1.2
+  # Configure maximum TLS version allowed for connection to logstash
+  #tls.max_version: 1.2
 
 
-  ### Logstash as output
-  #logstash:
-    # The Logstash hosts
-    #hosts: ["localhost:5044"]
+### Logstash as output
+#output.logstash:
+  # The Logstash hosts
+  #hosts: ["localhost:5044"]
 
-    # Number of workers per Logstash host.
-    #worker: 1
+  # Number of workers per Logstash host.
+  #worker: 1
 
-    # Set gzip compression level.
-    #compression_level: 3
+  # Set gzip compression level.
+  #compression_level: 3
 
-    # Optional load balance the events between the Logstash hosts
-    #loadbalance: true
+  # Optional load balance the events between the Logstash hosts
+  #loadbalance: true
 
-    # Optional index name. The default index name is set to name of the beat
-    # in all lowercase.
-    #index: packetbeat
+  # Optional index name. The default index name is set to name of the beat
+  # in all lowercase.
+  #index: packetbeat
 
-    # SOCKS5 proxy server URL
-    #proxy_url: socks5://user:password@socks5-server:2233
+  # SOCKS5 proxy server URL
+  #proxy_url: socks5://user:password@socks5-server:2233
 
-    # Resolve names locally when using a proxy server. Defaults to false.
-    #proxy_use_local_resolver: false
+  # Resolve names locally when using a proxy server. Defaults to false.
+  #proxy_use_local_resolver: false
 
-    # Optional TLS. By default is off.
-    #tls:
-      # List of root certificates for HTTPS server verifications
-      #certificate_authorities: ["/etc/pki/root/ca.pem"]
+  # Optional TLS. By default is off.
+  # List of root certificates for HTTPS server verifications
+  #tls.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
-      # Certificate for TLS client authentication
-      #certificate: "/etc/pki/client/cert.pem"
+  # Certificate for TLS client authentication
+  #tls.certificate: "/etc/pki/client/cert.pem"
 
-      # Client Certificate Key
-      #certificate_key: "/etc/pki/client/cert.key"
+  # Client Certificate Key
+  #tls.certificate_key: "/etc/pki/client/cert.key"
 
-      # Controls whether the client verifies server certificates and host name.
-      # If insecure is set to true, all server host names and certificates will be
-      # accepted. In this mode TLS based connections are susceptible to
-      # man-in-the-middle attacks. Use only for testing.
-      #insecure: true
+  # Controls whether the client verifies server certificates and host name.
+  # If insecure is set to true, all server host names and certificates will be
+  # accepted. In this mode TLS based connections are susceptible to
+  # man-in-the-middle attacks. Use only for testing.
+  #tls.insecure: true
 
-      # Configure cipher suites to be used for TLS connections
-      #cipher_suites: []
+  # Configure cipher suites to be used for TLS connections
+  #tls.cipher_suites: []
 
-      # Configure curve types for ECDHE based cipher suites
-      #curve_types: []
-
-
-  ### File as output
-  #file:
-    # Path to the directory where to save the generated files. The option is mandatory.
-    #path: "/tmp/packetbeat"
-
-    # Name of the generated files. The default is `packetbeat` and it generates files: `packetbeat`, `packetbeat.1`, `packetbeat.2`, etc.
-    #filename: packetbeat
-
-    # Maximum size in kilobytes of each file. When this size is reached, the files are
-    # rotated. The default value is 10240 kB.
-    #rotate_every_kb: 10000
-
-    # Maximum number of files under path. When this number of files is reached, the
-    # oldest file is deleted and the rest are shifted from last to first. The default
-    # is 7 files.
-    #number_of_files: 7
+  # Configure curve types for ECDHE based cipher suites
+  #tls.curve_types: []
 
 
-  ### Console output
-  # console:
-    # Pretty print json event
-    #pretty: false
+### File as output
+#output.file:
+  # Path to the directory where to save the generated files. The option is mandatory.
+  #path: "/tmp/packetbeat"
+
+  # Name of the generated files. The default is `packetbeat` and it generates files: `packetbeat`, `packetbeat.1`, `packetbeat.2`, etc.
+  #filename: packetbeat
+
+  # Maximum size in kilobytes of each file. When this size is reached, the files are
+  # rotated. The default value is 10240 kB.
+  #rotate_every_kb: 10000
+
+  # Maximum number of files under path. When this number of files is reached, the
+  # oldest file is deleted and the rest are shifted from last to first. The default
+  # is 7 files.
+  #number_of_files: 7
+
+
+### Console output
+#output.console:
+  # Pretty print json event
+  #pretty: false
 
 
 ############################# General #########################################
@@ -401,7 +401,6 @@ output:
 # default is the number of logical CPUs available in the system.
 #max_procs:
 
-
 ############################# Logging #########################################
 
 # There are three options for the log output: syslog, file, stderr.
@@ -418,19 +417,18 @@ logging:
   #to_files: false
 
   # To enable logging to files, to_files option has to be set to true
-  files:
-    # The directory where the log files will written to.
-    #path: /var/log/mybeat
+  # The directory where the log files will written to.
+  #files.path: /var/log/mybeat
 
-    # The name of the files where the logs are written to.
-    #name: mybeat
+  # The name of the files where the logs are written to.
+  #files.name: mybeat
 
-    # Configure log file size limit. If limit is reached, log file will be
-    # automatically rotated
-    rotateeverybytes: 10485760 # = 10MB
+  # Configure log file size limit. If limit is reached, log file will be
+  # automatically rotated
+  files.rotateeverybytes: 10485760 # = 10MB
 
-    # Number of rotated log files to keep. Oldest files will be deleted first.
-    #keepfiles: 7
+  # Number of rotated log files to keep. Oldest files will be deleted first.
+  #files.keepfiles: 7
 
   # Enable debug output for selected components. To enable all selectors use ["*"]
   # Other available selectors are beat, publish, service
@@ -440,5 +438,3 @@ logging:
   # Sets log level. The default log level is error.
   # Available log levels are: critical, error, warning, info, debug
   #level: error
-
-

--- a/packetbeat/packetbeat.yml
+++ b/packetbeat/packetbeat.yml
@@ -416,20 +416,6 @@ logging:
   # limit is reached.
   #to_files: false
 
-  # To enable logging to files, to_files option has to be set to true
-  # The directory where the log files will written to.
-  #files.path: /var/log/mybeat
-
-  # The name of the files where the logs are written to.
-  #files.name: mybeat
-
-  # Configure log file size limit. If limit is reached, log file will be
-  # automatically rotated
-  files.rotateeverybytes: 10485760 # = 10MB
-
-  # Number of rotated log files to keep. Oldest files will be deleted first.
-  #files.keepfiles: 7
-
   # Enable debug output for selected components. To enable all selectors use ["*"]
   # Other available selectors are beat, publish, service
   # Multiple selectors can be chained.
@@ -438,3 +424,19 @@ logging:
   # Sets log level. The default log level is error.
   # Available log levels are: critical, error, warning, info, debug
   #level: error
+
+
+# To enable logging to files, to_files option has to be set to true
+# The directory where the log files will written to.
+logging.files:
+  #path: /var/log/mybeat
+
+  # The name of the files where the logs are written to.
+  #name: mybeat
+
+  # Configure log file size limit. If limit is reached, log file will be
+  # automatically rotated
+  rotateeverybytes: 10485760 # = 10MB
+
+  # Number of rotated log files to keep. Oldest files will be deleted first.
+  #keepfiles: 7

--- a/packetbeat/packetbeat.yml
+++ b/packetbeat/packetbeat.yml
@@ -249,7 +249,7 @@ output.elasticsearch:
   # These settings can be adjusted to load your own template or overwrite existing ones
 
   # Template name. By default the template name is packetbeat.
-  template.name:"packetbeat"
+  template.name: "packetbeat"
 
   # Path to template file
   template.path: "packetbeat.template.json"
@@ -406,7 +406,7 @@ output.elasticsearch:
 # There are three options for the log output: syslog, file, stderr.
 # Under Windows systems, the log files are per default sent to the file output,
 # under all other system per default to syslog.
-logging:
+#logging:
 
   # Send all logging output to syslog. On Windows default is false, otherwise
   # default is true.

--- a/topbeat/etc/beat.yml
+++ b/topbeat/etc/beat.yml
@@ -2,26 +2,25 @@
 
 ##################### Topbeat general configuration #######################
 
-topbeat:
-  # In seconds, defines how often to read server statistics
-  period: 10
+# In seconds, defines how often to read server statistics
+topbeat.period: 10
 
-  # Regular expression to match the processes that are monitored
-  # By default, all the processes are monitored
-  procs: [".*"]
+# Regular expression to match the processes that are monitored
+# By default, all the processes are monitored
+topbeat.procs: [".*"]
 
-  # Statistics to collect (all enabled by default)
-  
+# Statistics to collect (all enabled by default)
+topbeat.stats:
   # per system statistics, by default is true
-  stats.system: true
+  system: true
     
   # per process statistics, by default is true
-  stats.process: true
+  process: true
 
   # file system information, by default is true
-  stats.filesystem: true
+  filesystem: true
 
   # cpu usage per core, by default is false
-  stats.cpu_per_core: false
+  cpu_per_core: false
 
 

--- a/topbeat/etc/beat.yml
+++ b/topbeat/etc/beat.yml
@@ -1,6 +1,7 @@
 ################### Topbeat Configuration Example #########################
 
-############################# Topbeat ############################################
+##################### Topbeat general configuration #######################
+
 topbeat:
   # In seconds, defines how often to read server statistics
   period: 10
@@ -10,17 +11,17 @@ topbeat:
   procs: [".*"]
 
   # Statistics to collect (all enabled by default)
-  stats:
-    # per system statistics, by default is true
-    system: true
+  
+  # per system statistics, by default is true
+  stats.system: true
+    
+  # per process statistics, by default is true
+  stats.process: true
 
-    # per process statistics, by default is true
-    process: true
+  # file system information, by default is true
+  stats.filesystem: true
 
-    # file system information, by default is true
-    filesystem: true
-
-    # cpu usage per core, by default is false
-    cpu_per_core: false
+  # cpu usage per core, by default is false
+  stats.cpu_per_core: false
 
 

--- a/topbeat/topbeat.yml
+++ b/topbeat/topbeat.yml
@@ -94,7 +94,7 @@ output.elasticsearch:
   # These settings can be adjusted to load your own template or overwrite existing ones
 
   # Template name. By default the template name is topbeat.
-  template.name:"topbeat"
+  template.name: "topbeat"
 
   # Path to template file
   template.path: "topbeat.template.json"
@@ -251,7 +251,7 @@ output.elasticsearch:
 # There are three options for the log output: syslog, file, stderr.
 # Under Windows systems, the log files are per default sent to the file output,
 # under all other system per default to syslog.
-logging:
+#logging:
 
   # Send all logging output to syslog. On Windows default is false, otherwise
   # default is true.
@@ -269,6 +269,7 @@ logging:
   # Sets log level. The default log level is error.
   # Available log levels are: critical, error, warning, info, debug
   #level: error
+
 
 # To enable logging to files, to_files option has to be set to true
 # The directory where the log files will written to.

--- a/topbeat/topbeat.yml
+++ b/topbeat/topbeat.yml
@@ -1,6 +1,7 @@
 ################### Topbeat Configuration Example #########################
 
-############################# Topbeat ############################################
+##################### Topbeat general configuration #######################
+
 topbeat:
   # In seconds, defines how often to read server statistics
   period: 10
@@ -10,18 +11,18 @@ topbeat:
   procs: [".*"]
 
   # Statistics to collect (all enabled by default)
-  stats:
-    # per system statistics, by default is true
-    system: true
+  
+  # per system statistics, by default is true
+  stats.system: true
+    
+  # per process statistics, by default is true
+  stats.process: true
 
-    # per process statistics, by default is true
-    process: true
+  # file system information, by default is true
+  stats.filesystem: true
 
-    # file system information, by default is true
-    filesystem: true
-
-    # cpu usage per core, by default is false
-    cpu_per_core: false
+  # cpu usage per core, by default is false
+  stats.cpu_per_core: false
 
 
 ###############################################################################
@@ -32,178 +33,174 @@ topbeat:
 
 # Configure what outputs to use when sending the data collected by the beat.
 # Multiple outputs may be used.
-output:
 
-  ### Elasticsearch as output
-  elasticsearch:
-    # Array of hosts to connect to.
-    # Scheme and port can be left out and will be set to the default (http and 9200)
-    # In case you specify and additional path, the scheme is required: http://localhost:9200/path
-    # IPv6 addresses should always be defined as: https://[2001:db8::1]:9200
-    hosts: ["localhost:9200"]
+### Elasticsearch as output
+output.elasticsearch:
+  # Array of hosts to connect to.
+  # Scheme and port can be left out and will be set to the default (http and 9200)
+  # In case you specify and additional path, the scheme is required: http://localhost:9200/path
+  # IPv6 addresses should always be defined as: https://[2001:db8::1]:9200
+  hosts: ["localhost:9200"]
 
-    # Optional protocol and basic auth credentials.
-    #protocol: "https"
-    #username: "admin"
-    #password: "s3cr3t"
+  # Optional protocol and basic auth credentials.
+  #protocol: "https"
+  #username: "admin"
+  #password: "s3cr3t"
 
-    # Dictionary of HTTP parameters to pass within the url with index operations.
-    #parameters:
-      #param1: value1
-      #param2: value2
+  # Dictionary of HTTP parameters to pass within the url with index operations.
+  #parameters:
+    #param1: value1
+    #param2: value2
 
-    # Number of workers per Elasticsearch host.
-    #worker: 1
+  # Number of workers per Elasticsearch host.
+  #worker: 1
 
-    # Optional index name. The default is "topbeat" and generates
-    # [topbeat-]YYYY.MM.DD keys.
-    #index: "topbeat"
+  # Optional index name. The default is "topbeat" and generates
+  # [topbeat-]YYYY.MM.DD keys.
+  #index: "topbeat"
 
-    # A template is used to set the mapping in Elasticsearch
-    # By default template loading is enabled and the template is loaded.
-    # These settings can be adjusted to load your own template or overwrite existing ones
-    template:
+  # Optional HTTP Path
+  #path: "/elasticsearch"
 
-      # Template name. By default the template name is topbeat.
-      name: "topbeat"
+  # Proxy server url
+  #proxy_url: http://proxy:3128
 
-      # Path to template file
-      path: "topbeat.template.json"
+  # The number of times a particular Elasticsearch index operation is attempted. If
+  # the indexing operation doesn't succeed after this many retries, the events are
+  # dropped. The default is 3.
+  #max_retries: 3
 
-      # Overwrite existing template
-      overwrite: false
+  # The maximum number of events to bulk in a single Elasticsearch bulk API index request.
+  # The default is 50.
+  #bulk_max_size: 50
 
-    # Optional HTTP Path
-    #path: "/elasticsearch"
+  # Configure http request timeout before failing an request to Elasticsearch.
+  #timeout: 90
 
-    # Proxy server url
-    #proxy_url: http://proxy:3128
+  # The number of seconds to wait for new events between two bulk API index requests.
+  # If `bulk_max_size` is reached before this interval expires, addition bulk index
+  # requests are made.
+  #flush_interval: 1
 
-    # The number of times a particular Elasticsearch index operation is attempted. If
-    # the indexing operation doesn't succeed after this many retries, the events are
-    # dropped. The default is 3.
-    #max_retries: 3
+  # Boolean that sets if the topology is kept in Elasticsearch. The default is
+  # false. This option makes sense only for Packetbeat.
+  #save_topology: false
 
-    # The maximum number of events to bulk in a single Elasticsearch bulk API index request.
-    # The default is 50.
-    #bulk_max_size: 50
+  # The time to live in seconds for the topology information that is stored in
+  # Elasticsearch. The default is 15 seconds.
+  #topology_expire: 15
 
-    # Configure http request timeout before failing an request to Elasticsearch.
-    #timeout: 90
+  # A template is used to set the mapping in Elasticsearch
+  # By default template loading is enabled and the template is loaded.
+  # These settings can be adjusted to load your own template or overwrite existing ones
 
-    # The number of seconds to wait for new events between two bulk API index requests.
-    # If `bulk_max_size` is reached before this interval expires, addition bulk index
-    # requests are made.
-    #flush_interval: 1
+  # Template name. By default the template name is topbeat.
+  template.name:"topbeat"
 
-    # Boolean that sets if the topology is kept in Elasticsearch. The default is
-    # false. This option makes sense only for Packetbeat.
-    #save_topology: false
+  # Path to template file
+  template.path: "topbeat.template.json"
 
-    # The time to live in seconds for the topology information that is stored in
-    # Elasticsearch. The default is 15 seconds.
-    #topology_expire: 15
+  # Overwrite existing template
+  template.overwrite: false
 
-    # tls configuration. By default is off.
-    #tls:
-      # List of root certificates for HTTPS server verifications
-      #certificate_authorities: ["/etc/pki/root/ca.pem"]
+  # TLS configuration. By default is off.
+  # List of root certificates for HTTPS server verifications
+  #tls.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
-      # Certificate for TLS client authentication
-      #certificate: "/etc/pki/client/cert.pem"
+  # Certificate for TLS client authentication
+  #tls.certificate: "/etc/pki/client/cert.pem"
 
-      # Client Certificate Key
-      #certificate_key: "/etc/pki/client/cert.key"
+  # Client Certificate Key
+  #tls.certificate_key: "/etc/pki/client/cert.key"
 
-      # Controls whether the client verifies server certificates and host name.
-      # If insecure is set to true, all server host names and certificates will be
-      # accepted. In this mode TLS based connections are susceptible to
-      # man-in-the-middle attacks. Use only for testing.
-      #insecure: true
+  # Controls whether the client verifies server certificates and host name.
+  # If insecure is set to true, all server host names and certificates will be
+  # accepted. In this mode TLS based connections are susceptible to
+  # man-in-the-middle attacks. Use only for testing.
+  #tls.insecure: true
 
-      # Configure cipher suites to be used for TLS connections
-      #cipher_suites: []
+  # Configure cipher suites to be used for TLS connections
+  #tls.cipher_suites: []
 
-      # Configure curve types for ECDHE based cipher suites
-      #curve_types: []
+  # Configure curve types for ECDHE based cipher suites
+  #tls.curve_types: []
 
-      # Configure minimum TLS version allowed for connection to logstash
-      #min_version: 1.0
+  # Configure minimum TLS version allowed for connection to logstash
+  #tls.min_version: 1.0
 
-      # Configure maximum TLS version allowed for connection to logstash
-      #max_version: 1.2
+  # Configure maximum TLS version allowed for connection to logstash
+  #tls.max_version: 1.2
 
 
-  ### Logstash as output
-  #logstash:
-    # The Logstash hosts
-    #hosts: ["localhost:5044"]
+### Logstash as output
+#output.logstash:
+  # The Logstash hosts
+  #hosts: ["localhost:5044"]
 
-    # Number of workers per Logstash host.
-    #worker: 1
+  # Number of workers per Logstash host.
+  #worker: 1
 
-    # Set gzip compression level.
-    #compression_level: 3
+  # Set gzip compression level.
+  #compression_level: 3
 
-    # Optional load balance the events between the Logstash hosts
-    #loadbalance: true
+  # Optional load balance the events between the Logstash hosts
+  #loadbalance: true
 
-    # Optional index name. The default index name is set to name of the beat
-    # in all lowercase.
-    #index: topbeat
+  # Optional index name. The default index name is set to name of the beat
+  # in all lowercase.
+  #index: topbeat
 
-    # SOCKS5 proxy server URL
-    #proxy_url: socks5://user:password@socks5-server:2233
+  # SOCKS5 proxy server URL
+  #proxy_url: socks5://user:password@socks5-server:2233
 
-    # Resolve names locally when using a proxy server. Defaults to false.
-    #proxy_use_local_resolver: false
+  # Resolve names locally when using a proxy server. Defaults to false.
+  #proxy_use_local_resolver: false
 
-    # Optional TLS. By default is off.
-    #tls:
-      # List of root certificates for HTTPS server verifications
-      #certificate_authorities: ["/etc/pki/root/ca.pem"]
+  # Optional TLS. By default is off.
+  # List of root certificates for HTTPS server verifications
+  #tls.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
-      # Certificate for TLS client authentication
-      #certificate: "/etc/pki/client/cert.pem"
+  # Certificate for TLS client authentication
+  #tls.certificate: "/etc/pki/client/cert.pem"
 
-      # Client Certificate Key
-      #certificate_key: "/etc/pki/client/cert.key"
+  # Client Certificate Key
+  #tls.certificate_key: "/etc/pki/client/cert.key"
 
-      # Controls whether the client verifies server certificates and host name.
-      # If insecure is set to true, all server host names and certificates will be
-      # accepted. In this mode TLS based connections are susceptible to
-      # man-in-the-middle attacks. Use only for testing.
-      #insecure: true
+  # Controls whether the client verifies server certificates and host name.
+  # If insecure is set to true, all server host names and certificates will be
+  # accepted. In this mode TLS based connections are susceptible to
+  # man-in-the-middle attacks. Use only for testing.
+  #tls.insecure: true
 
-      # Configure cipher suites to be used for TLS connections
-      #cipher_suites: []
+  # Configure cipher suites to be used for TLS connections
+  #tls.cipher_suites: []
 
-      # Configure curve types for ECDHE based cipher suites
-      #curve_types: []
-
-
-  ### File as output
-  #file:
-    # Path to the directory where to save the generated files. The option is mandatory.
-    #path: "/tmp/topbeat"
-
-    # Name of the generated files. The default is `topbeat` and it generates files: `topbeat`, `topbeat.1`, `topbeat.2`, etc.
-    #filename: topbeat
-
-    # Maximum size in kilobytes of each file. When this size is reached, the files are
-    # rotated. The default value is 10240 kB.
-    #rotate_every_kb: 10000
-
-    # Maximum number of files under path. When this number of files is reached, the
-    # oldest file is deleted and the rest are shifted from last to first. The default
-    # is 7 files.
-    #number_of_files: 7
+  # Configure curve types for ECDHE based cipher suites
+  #tls.curve_types: []
 
 
-  ### Console output
-  # console:
-    # Pretty print json event
-    #pretty: false
+### File as output
+#output.file:
+  # Path to the directory where to save the generated files. The option is mandatory.
+  #path: "/tmp/topbeat"
+
+  # Name of the generated files. The default is `topbeat` and it generates files: `topbeat`, `topbeat.1`, `topbeat.2`, etc.
+  #filename: topbeat
+
+  # Maximum size in kilobytes of each file. When this size is reached, the files are
+  # rotated. The default value is 10240 kB.
+  #rotate_every_kb: 10000
+
+  # Maximum number of files under path. When this number of files is reached, the
+  # oldest file is deleted and the rest are shifted from last to first. The default
+  # is 7 files.
+  #number_of_files: 7
+
+
+### Console output
+#output.console:
+  # Pretty print json event
+  #pretty: false
 
 
 ############################# General #########################################
@@ -250,7 +247,6 @@ output:
 # default is the number of logical CPUs available in the system.
 #max_procs:
 
-
 ############################# Logging #########################################
 
 # There are three options for the log output: syslog, file, stderr.
@@ -267,19 +263,18 @@ logging:
   #to_files: false
 
   # To enable logging to files, to_files option has to be set to true
-  files:
-    # The directory where the log files will written to.
-    #path: /var/log/mybeat
+  # The directory where the log files will written to.
+  #files.path: /var/log/mybeat
 
-    # The name of the files where the logs are written to.
-    #name: mybeat
+  # The name of the files where the logs are written to.
+  #files.name: mybeat
 
-    # Configure log file size limit. If limit is reached, log file will be
-    # automatically rotated
-    rotateeverybytes: 10485760 # = 10MB
+  # Configure log file size limit. If limit is reached, log file will be
+  # automatically rotated
+  files.rotateeverybytes: 10485760 # = 10MB
 
-    # Number of rotated log files to keep. Oldest files will be deleted first.
-    #keepfiles: 7
+  # Number of rotated log files to keep. Oldest files will be deleted first.
+  #files.keepfiles: 7
 
   # Enable debug output for selected components. To enable all selectors use ["*"]
   # Other available selectors are beat, publish, service
@@ -289,5 +284,3 @@ logging:
   # Sets log level. The default log level is error.
   # Available log levels are: critical, error, warning, info, debug
   #level: error
-
-

--- a/topbeat/topbeat.yml
+++ b/topbeat/topbeat.yml
@@ -2,27 +2,26 @@
 
 ##################### Topbeat general configuration #######################
 
-topbeat:
-  # In seconds, defines how often to read server statistics
-  period: 10
+# In seconds, defines how often to read server statistics
+topbeat.period: 10
 
-  # Regular expression to match the processes that are monitored
-  # By default, all the processes are monitored
-  procs: [".*"]
+# Regular expression to match the processes that are monitored
+# By default, all the processes are monitored
+topbeat.procs: [".*"]
 
-  # Statistics to collect (all enabled by default)
-  
+# Statistics to collect (all enabled by default)
+topbeat.stats:
   # per system statistics, by default is true
-  stats.system: true
+  system: true
     
   # per process statistics, by default is true
-  stats.process: true
+  process: true
 
   # file system information, by default is true
-  stats.filesystem: true
+  filesystem: true
 
   # cpu usage per core, by default is false
-  stats.cpu_per_core: false
+  cpu_per_core: false
 
 
 ###############################################################################
@@ -262,20 +261,6 @@ logging:
   # limit is reached.
   #to_files: false
 
-  # To enable logging to files, to_files option has to be set to true
-  # The directory where the log files will written to.
-  #files.path: /var/log/mybeat
-
-  # The name of the files where the logs are written to.
-  #files.name: mybeat
-
-  # Configure log file size limit. If limit is reached, log file will be
-  # automatically rotated
-  files.rotateeverybytes: 10485760 # = 10MB
-
-  # Number of rotated log files to keep. Oldest files will be deleted first.
-  #files.keepfiles: 7
-
   # Enable debug output for selected components. To enable all selectors use ["*"]
   # Other available selectors are beat, publish, service
   # Multiple selectors can be chained.
@@ -284,3 +269,18 @@ logging:
   # Sets log level. The default log level is error.
   # Available log levels are: critical, error, warning, info, debug
   #level: error
+
+# To enable logging to files, to_files option has to be set to true
+# The directory where the log files will written to.
+logging.files:
+  #path: /var/log/mybeat
+
+  # The name of the files where the logs are written to.
+  #name: mybeat
+
+  # Configure log file size limit. If limit is reached, log file will be
+  # automatically rotated
+  rotateeverybytes: 10485760 # = 10MB
+
+  # Number of rotated log files to keep. Oldest files will be deleted first.
+  #keepfiles: 7

--- a/winlogbeat/etc/beat.yml
+++ b/winlogbeat/etc/beat.yml
@@ -8,23 +8,24 @@ winlogbeat:
   # in the directory in which it was started.
   #registry_file: .winlogbeat.yml
 
-  # event_logs specifies a list of event logs to monitor as well as any
-  # accompanying options. The YAML data type of event_logs is a list of
-  # dictionaries.
-  #
-  # The supported keys are name (required), tags, fields, fields_under_root,
-  # ignore_older, level, event_id, provider, and include_xml. Please visit the
-  # documentation for the complete details of each option.
-  # https://go.es.io/WinlogbeatConfig
-  event_logs:
-    - name: Application
-      ignore_older: 72h
-    - name: Security
-    - name: System
-
   # Diagnostic metrics that can retrieved through a web interface if a
   # bindaddress value (host:port) is specified. The web address will be
   # http://<bindaddress>/debug/vars
   #metrics:
   #  bindaddress: 'localhost:8123'
+
+# event_logs specifies a list of event logs to monitor as well as any
+# accompanying options. The YAML data type of event_logs is a list of
+# dictionaries.
+#
+# The supported keys are name (required), tags, fields, fields_under_root,
+# ignore_older, level, event_id, provider, and include_xml. Please visit the
+# documentation for the complete details of each option.
+# https://go.es.io/WinlogbeatConfig
+winlogbeat.event_logs:
+  - name: Application
+    ignore_older: 72h
+  - name: Security
+  - name: System
+
 

--- a/winlogbeat/etc/beat.yml
+++ b/winlogbeat/etc/beat.yml
@@ -1,5 +1,7 @@
-###############################################################################
-############################# Winlogbeat ######################################
+################### Winlogbeat Configuration Example #########################
+
+##################### Winlogbeat general configuration ######################
+
 winlogbeat:
   # The registry file is where Winlogbeat persists its state so that the beat
   # can resume after shutdown or an outage. The default is .winlogbeat.yml

--- a/winlogbeat/winlogbeat.yml
+++ b/winlogbeat/winlogbeat.yml
@@ -2,7 +2,7 @@
 
 ##################### Winlogbeat general configuration ######################
 
-winlogbeat:
+#winlogbeat:
   # The registry file is where Winlogbeat persists its state so that the beat
   # can resume after shutdown or an outage. The default is .winlogbeat.yml
   # in the directory in which it was started.

--- a/winlogbeat/winlogbeat.yml
+++ b/winlogbeat/winlogbeat.yml
@@ -99,7 +99,7 @@ output.elasticsearch:
   # These settings can be adjusted to load your own template or overwrite existing ones
 
   # Template name. By default the template name is winlogbeat.
-  template.name:"winlogbeat"
+  template.name: "winlogbeat"
 
   # Path to template file
   template.path: "winlogbeat.template.json"
@@ -256,7 +256,7 @@ output.elasticsearch:
 # There are three options for the log output: syslog, file, stderr.
 # Under Windows systems, the log files are per default sent to the file output,
 # under all other system per default to syslog.
-logging:
+#logging:
 
   # Send all logging output to syslog. On Windows default is false, otherwise
   # default is true.

--- a/winlogbeat/winlogbeat.yml
+++ b/winlogbeat/winlogbeat.yml
@@ -8,25 +8,26 @@ winlogbeat:
   # in the directory in which it was started.
   #registry_file: .winlogbeat.yml
 
-  # event_logs specifies a list of event logs to monitor as well as any
-  # accompanying options. The YAML data type of event_logs is a list of
-  # dictionaries.
-  #
-  # The supported keys are name (required), tags, fields, fields_under_root,
-  # ignore_older, level, event_id, provider, and include_xml. Please visit the
-  # documentation for the complete details of each option.
-  # https://go.es.io/WinlogbeatConfig
-  event_logs:
-    - name: Application
-      ignore_older: 72h
-    - name: Security
-    - name: System
-
   # Diagnostic metrics that can retrieved through a web interface if a
   # bindaddress value (host:port) is specified. The web address will be
   # http://<bindaddress>/debug/vars
   #metrics:
   #  bindaddress: 'localhost:8123'
+
+# event_logs specifies a list of event logs to monitor as well as any
+# accompanying options. The YAML data type of event_logs is a list of
+# dictionaries.
+#
+# The supported keys are name (required), tags, fields, fields_under_root,
+# ignore_older, level, event_id, provider, and include_xml. Please visit the
+# documentation for the complete details of each option.
+# https://go.es.io/WinlogbeatConfig
+winlogbeat.event_logs:
+  - name: Application
+    ignore_older: 72h
+  - name: Security
+  - name: System
+
 
 ###############################################################################
 ############################# Libbeat Config ##################################
@@ -265,20 +266,6 @@ logging:
   # limit is reached.
   #to_files: false
 
-  # To enable logging to files, to_files option has to be set to true
-  # The directory where the log files will written to.
-  #files.path: /var/log/mybeat
-
-  # The name of the files where the logs are written to.
-  #files.name: mybeat
-
-  # Configure log file size limit. If limit is reached, log file will be
-  # automatically rotated
-  files.rotateeverybytes: 10485760 # = 10MB
-
-  # Number of rotated log files to keep. Oldest files will be deleted first.
-  #files.keepfiles: 7
-
   # Enable debug output for selected components. To enable all selectors use ["*"]
   # Other available selectors are beat, publish, service
   # Multiple selectors can be chained.
@@ -287,3 +274,19 @@ logging:
   # Sets log level. The default log level is error.
   # Available log levels are: critical, error, warning, info, debug
   #level: error
+
+
+# To enable logging to files, to_files option has to be set to true
+# The directory where the log files will written to.
+logging.files:
+  #path: /var/log/mybeat
+
+  # The name of the files where the logs are written to.
+  #name: mybeat
+
+  # Configure log file size limit. If limit is reached, log file will be
+  # automatically rotated
+  rotateeverybytes: 10485760 # = 10MB
+
+  # Number of rotated log files to keep. Oldest files will be deleted first.
+  #keepfiles: 7

--- a/winlogbeat/winlogbeat.yml
+++ b/winlogbeat/winlogbeat.yml
@@ -1,5 +1,7 @@
-###############################################################################
-############################# Winlogbeat ######################################
+################### Winlogbeat Configuration Example #########################
+
+##################### Winlogbeat general configuration ######################
+
 winlogbeat:
   # The registry file is where Winlogbeat persists its state so that the beat
   # can resume after shutdown or an outage. The default is .winlogbeat.yml
@@ -34,178 +36,174 @@ winlogbeat:
 
 # Configure what outputs to use when sending the data collected by the beat.
 # Multiple outputs may be used.
-output:
 
-  ### Elasticsearch as output
-  elasticsearch:
-    # Array of hosts to connect to.
-    # Scheme and port can be left out and will be set to the default (http and 9200)
-    # In case you specify and additional path, the scheme is required: http://localhost:9200/path
-    # IPv6 addresses should always be defined as: https://[2001:db8::1]:9200
-    hosts: ["localhost:9200"]
+### Elasticsearch as output
+output.elasticsearch:
+  # Array of hosts to connect to.
+  # Scheme and port can be left out and will be set to the default (http and 9200)
+  # In case you specify and additional path, the scheme is required: http://localhost:9200/path
+  # IPv6 addresses should always be defined as: https://[2001:db8::1]:9200
+  hosts: ["localhost:9200"]
 
-    # Optional protocol and basic auth credentials.
-    #protocol: "https"
-    #username: "admin"
-    #password: "s3cr3t"
+  # Optional protocol and basic auth credentials.
+  #protocol: "https"
+  #username: "admin"
+  #password: "s3cr3t"
 
-    # Dictionary of HTTP parameters to pass within the url with index operations.
-    #parameters:
-      #param1: value1
-      #param2: value2
+  # Dictionary of HTTP parameters to pass within the url with index operations.
+  #parameters:
+    #param1: value1
+    #param2: value2
 
-    # Number of workers per Elasticsearch host.
-    #worker: 1
+  # Number of workers per Elasticsearch host.
+  #worker: 1
 
-    # Optional index name. The default is "winlogbeat" and generates
-    # [winlogbeat-]YYYY.MM.DD keys.
-    #index: "winlogbeat"
+  # Optional index name. The default is "winlogbeat" and generates
+  # [winlogbeat-]YYYY.MM.DD keys.
+  #index: "winlogbeat"
 
-    # A template is used to set the mapping in Elasticsearch
-    # By default template loading is enabled and the template is loaded.
-    # These settings can be adjusted to load your own template or overwrite existing ones
-    template:
+  # Optional HTTP Path
+  #path: "/elasticsearch"
 
-      # Template name. By default the template name is winlogbeat.
-      name: "winlogbeat"
+  # Proxy server url
+  #proxy_url: http://proxy:3128
 
-      # Path to template file
-      path: "winlogbeat.template.json"
+  # The number of times a particular Elasticsearch index operation is attempted. If
+  # the indexing operation doesn't succeed after this many retries, the events are
+  # dropped. The default is 3.
+  #max_retries: 3
 
-      # Overwrite existing template
-      overwrite: false
+  # The maximum number of events to bulk in a single Elasticsearch bulk API index request.
+  # The default is 50.
+  #bulk_max_size: 50
 
-    # Optional HTTP Path
-    #path: "/elasticsearch"
+  # Configure http request timeout before failing an request to Elasticsearch.
+  #timeout: 90
 
-    # Proxy server url
-    #proxy_url: http://proxy:3128
+  # The number of seconds to wait for new events between two bulk API index requests.
+  # If `bulk_max_size` is reached before this interval expires, addition bulk index
+  # requests are made.
+  #flush_interval: 1
 
-    # The number of times a particular Elasticsearch index operation is attempted. If
-    # the indexing operation doesn't succeed after this many retries, the events are
-    # dropped. The default is 3.
-    #max_retries: 3
+  # Boolean that sets if the topology is kept in Elasticsearch. The default is
+  # false. This option makes sense only for Packetbeat.
+  #save_topology: false
 
-    # The maximum number of events to bulk in a single Elasticsearch bulk API index request.
-    # The default is 50.
-    #bulk_max_size: 50
+  # The time to live in seconds for the topology information that is stored in
+  # Elasticsearch. The default is 15 seconds.
+  #topology_expire: 15
 
-    # Configure http request timeout before failing an request to Elasticsearch.
-    #timeout: 90
+  # A template is used to set the mapping in Elasticsearch
+  # By default template loading is enabled and the template is loaded.
+  # These settings can be adjusted to load your own template or overwrite existing ones
 
-    # The number of seconds to wait for new events between two bulk API index requests.
-    # If `bulk_max_size` is reached before this interval expires, addition bulk index
-    # requests are made.
-    #flush_interval: 1
+  # Template name. By default the template name is winlogbeat.
+  template.name:"winlogbeat"
 
-    # Boolean that sets if the topology is kept in Elasticsearch. The default is
-    # false. This option makes sense only for Packetbeat.
-    #save_topology: false
+  # Path to template file
+  template.path: "winlogbeat.template.json"
 
-    # The time to live in seconds for the topology information that is stored in
-    # Elasticsearch. The default is 15 seconds.
-    #topology_expire: 15
+  # Overwrite existing template
+  template.overwrite: false
 
-    # tls configuration. By default is off.
-    #tls:
-      # List of root certificates for HTTPS server verifications
-      #certificate_authorities: ["/etc/pki/root/ca.pem"]
+  # TLS configuration. By default is off.
+  # List of root certificates for HTTPS server verifications
+  #tls.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
-      # Certificate for TLS client authentication
-      #certificate: "/etc/pki/client/cert.pem"
+  # Certificate for TLS client authentication
+  #tls.certificate: "/etc/pki/client/cert.pem"
 
-      # Client Certificate Key
-      #certificate_key: "/etc/pki/client/cert.key"
+  # Client Certificate Key
+  #tls.certificate_key: "/etc/pki/client/cert.key"
 
-      # Controls whether the client verifies server certificates and host name.
-      # If insecure is set to true, all server host names and certificates will be
-      # accepted. In this mode TLS based connections are susceptible to
-      # man-in-the-middle attacks. Use only for testing.
-      #insecure: true
+  # Controls whether the client verifies server certificates and host name.
+  # If insecure is set to true, all server host names and certificates will be
+  # accepted. In this mode TLS based connections are susceptible to
+  # man-in-the-middle attacks. Use only for testing.
+  #tls.insecure: true
 
-      # Configure cipher suites to be used for TLS connections
-      #cipher_suites: []
+  # Configure cipher suites to be used for TLS connections
+  #tls.cipher_suites: []
 
-      # Configure curve types for ECDHE based cipher suites
-      #curve_types: []
+  # Configure curve types for ECDHE based cipher suites
+  #tls.curve_types: []
 
-      # Configure minimum TLS version allowed for connection to logstash
-      #min_version: 1.0
+  # Configure minimum TLS version allowed for connection to logstash
+  #tls.min_version: 1.0
 
-      # Configure maximum TLS version allowed for connection to logstash
-      #max_version: 1.2
+  # Configure maximum TLS version allowed for connection to logstash
+  #tls.max_version: 1.2
 
 
-  ### Logstash as output
-  #logstash:
-    # The Logstash hosts
-    #hosts: ["localhost:5044"]
+### Logstash as output
+#output.logstash:
+  # The Logstash hosts
+  #hosts: ["localhost:5044"]
 
-    # Number of workers per Logstash host.
-    #worker: 1
+  # Number of workers per Logstash host.
+  #worker: 1
 
-    # Set gzip compression level.
-    #compression_level: 3
+  # Set gzip compression level.
+  #compression_level: 3
 
-    # Optional load balance the events between the Logstash hosts
-    #loadbalance: true
+  # Optional load balance the events between the Logstash hosts
+  #loadbalance: true
 
-    # Optional index name. The default index name is set to name of the beat
-    # in all lowercase.
-    #index: winlogbeat
+  # Optional index name. The default index name is set to name of the beat
+  # in all lowercase.
+  #index: winlogbeat
 
-    # SOCKS5 proxy server URL
-    #proxy_url: socks5://user:password@socks5-server:2233
+  # SOCKS5 proxy server URL
+  #proxy_url: socks5://user:password@socks5-server:2233
 
-    # Resolve names locally when using a proxy server. Defaults to false.
-    #proxy_use_local_resolver: false
+  # Resolve names locally when using a proxy server. Defaults to false.
+  #proxy_use_local_resolver: false
 
-    # Optional TLS. By default is off.
-    #tls:
-      # List of root certificates for HTTPS server verifications
-      #certificate_authorities: ["/etc/pki/root/ca.pem"]
+  # Optional TLS. By default is off.
+  # List of root certificates for HTTPS server verifications
+  #tls.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
-      # Certificate for TLS client authentication
-      #certificate: "/etc/pki/client/cert.pem"
+  # Certificate for TLS client authentication
+  #tls.certificate: "/etc/pki/client/cert.pem"
 
-      # Client Certificate Key
-      #certificate_key: "/etc/pki/client/cert.key"
+  # Client Certificate Key
+  #tls.certificate_key: "/etc/pki/client/cert.key"
 
-      # Controls whether the client verifies server certificates and host name.
-      # If insecure is set to true, all server host names and certificates will be
-      # accepted. In this mode TLS based connections are susceptible to
-      # man-in-the-middle attacks. Use only for testing.
-      #insecure: true
+  # Controls whether the client verifies server certificates and host name.
+  # If insecure is set to true, all server host names and certificates will be
+  # accepted. In this mode TLS based connections are susceptible to
+  # man-in-the-middle attacks. Use only for testing.
+  #tls.insecure: true
 
-      # Configure cipher suites to be used for TLS connections
-      #cipher_suites: []
+  # Configure cipher suites to be used for TLS connections
+  #tls.cipher_suites: []
 
-      # Configure curve types for ECDHE based cipher suites
-      #curve_types: []
-
-
-  ### File as output
-  #file:
-    # Path to the directory where to save the generated files. The option is mandatory.
-    #path: "/tmp/winlogbeat"
-
-    # Name of the generated files. The default is `winlogbeat` and it generates files: `winlogbeat`, `winlogbeat.1`, `winlogbeat.2`, etc.
-    #filename: winlogbeat
-
-    # Maximum size in kilobytes of each file. When this size is reached, the files are
-    # rotated. The default value is 10240 kB.
-    #rotate_every_kb: 10000
-
-    # Maximum number of files under path. When this number of files is reached, the
-    # oldest file is deleted and the rest are shifted from last to first. The default
-    # is 7 files.
-    #number_of_files: 7
+  # Configure curve types for ECDHE based cipher suites
+  #tls.curve_types: []
 
 
-  ### Console output
-  # console:
-    # Pretty print json event
-    #pretty: false
+### File as output
+#output.file:
+  # Path to the directory where to save the generated files. The option is mandatory.
+  #path: "/tmp/winlogbeat"
+
+  # Name of the generated files. The default is `winlogbeat` and it generates files: `winlogbeat`, `winlogbeat.1`, `winlogbeat.2`, etc.
+  #filename: winlogbeat
+
+  # Maximum size in kilobytes of each file. When this size is reached, the files are
+  # rotated. The default value is 10240 kB.
+  #rotate_every_kb: 10000
+
+  # Maximum number of files under path. When this number of files is reached, the
+  # oldest file is deleted and the rest are shifted from last to first. The default
+  # is 7 files.
+  #number_of_files: 7
+
+
+### Console output
+#output.console:
+  # Pretty print json event
+  #pretty: false
 
 
 ############################# General #########################################
@@ -252,7 +250,6 @@ output:
 # default is the number of logical CPUs available in the system.
 #max_procs:
 
-
 ############################# Logging #########################################
 
 # There are three options for the log output: syslog, file, stderr.
@@ -269,19 +266,18 @@ logging:
   #to_files: false
 
   # To enable logging to files, to_files option has to be set to true
-  files:
-    # The directory where the log files will written to.
-    #path: /var/log/mybeat
+  # The directory where the log files will written to.
+  #files.path: /var/log/mybeat
 
-    # The name of the files where the logs are written to.
-    #name: mybeat
+  # The name of the files where the logs are written to.
+  #files.name: mybeat
 
-    # Configure log file size limit. If limit is reached, log file will be
-    # automatically rotated
-    rotateeverybytes: 10485760 # = 10MB
+  # Configure log file size limit. If limit is reached, log file will be
+  # automatically rotated
+  files.rotateeverybytes: 10485760 # = 10MB
 
-    # Number of rotated log files to keep. Oldest files will be deleted first.
-    #keepfiles: 7
+  # Number of rotated log files to keep. Oldest files will be deleted first.
+  #files.keepfiles: 7
 
   # Enable debug output for selected components. To enable all selectors use ["*"]
   # Other available selectors are beat, publish, service
@@ -291,5 +287,3 @@ logging:
   # Sets log level. The default log level is error.
   # Available log levels are: critical, error, warning, info, debug
   #level: error
-
-


### PR DESCRIPTION
Based on the changed done in #1490, I am proposing the following structure of the configuration file where I move all the sections one level up all. 

Implements part of https://github.com/elastic/beats/issues/1417.

The changes should affect the following configuration files:

- [x] libbeat.yml
- [x] packetbeat.yml
- [x] topbeat.yml
- [x] filebeat.yml
- [x] winlogbeat.yml
 