### PR TITLE
Multiline reader normalizing multiline character

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -104,6 +104,7 @@ https://github.com/elastic/beats/compare/v5.0.0alpha1...v5.0.0-alpha2[View commi
 - Fix issue with JSON decoding where `@timestamp` or `type` keys with the wrong type could cause Filebeat
   to crash. {issue}1378[1378]
 - Fix issue with JSON decoding where values having `null` as values could crash Filebeat. {issue}1466[1466]
+- Multiline reader normalizing newline to use `\n`. {pull}1552[1552]
 
 *Winlogbeat*
 

--- a/filebeat/harvester/linereader.go
+++ b/filebeat/harvester/linereader.go
@@ -33,15 +33,13 @@ func createLineReader(
 		p = processor.NewJSONProcessor(p, jsonConfig)
 	}
 
+	p = processor.NewStripNewline(p)
 	if mlrConfig != nil {
-		p, err = processor.NewMultiline(p, maxBytes, mlrConfig)
+		p, err = processor.NewMultiline(p, "\n", maxBytes, mlrConfig)
 		if err != nil {
 			return nil, err
 		}
-
-		return processor.NewStripNewline(p), nil
 	}
 
-	p = processor.NewStripNewline(p)
 	return processor.NewLimitProcessor(p, maxBytes), nil
 }

--- a/filebeat/harvester/processor/multiline_test.go
+++ b/filebeat/harvester/processor/multiline_test.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"errors"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -89,7 +90,7 @@ func testMultilineOK(t *testing.T, cfg config.MultilineConfig, expected ...strin
 		var tsZero time.Time
 
 		assert.NotEqual(t, tsZero, line.Ts)
-		assert.Equal(t, expected[i], string(line.Content))
+		assert.Equal(t, strings.TrimRight(expected[i], "\r\n "), string(line.Content))
 		assert.Equal(t, len(expected[i]), int(line.Bytes))
 	}
 }
@@ -111,7 +112,7 @@ func createMultilineTestReader(t *testing.T, in *bytes.Buffer, cfg config.Multil
 		t.Fatalf("Failed to initialize line reader: %v", err)
 	}
 
-	reader, err = NewMultiline(reader, 1<<20, &cfg)
+	reader, err = NewMultiline(NewStripNewline(reader), "\n", 1<<20, &cfg)
 	if err != nil {
 		t.Fatalf("failed to initializ reader: %v", err)
 	}


### PR DESCRIPTION
Multiline reader assumes newline characters already removed. The StripNewLine reader will be applied right before the multiline reader.