### PR TITLE
Update download paths and increment product versions for alpha2

### DIFF
--- a/filebeat/docs/index.asciidoc
+++ b/filebeat/docs/index.asciidoc
@@ -1,7 +1,7 @@
 = Filebeat Reference
 :libbeat: http://www.elastic.co/guide/en/beats/libbeat/master
 :elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/master/
-:version: 5.0.0-alpha1
+:version: 5.0.0-alpha2
 :beatname_lc: filebeat
 :beatname_uc: Filebeat
 :security: X-Pack Security

--- a/libbeat/docs/gettingstarted.asciidoc
+++ b/libbeat/docs/gettingstarted.asciidoc
@@ -1,5 +1,5 @@
 [[getting-started]]
-== Getting Started with Beats and the Elastic Stack
+== Getting Started with Beats and the Elastic Stack 
 
 Looking for an "ELK tutorial" that shows how to set up the Elastic stack for Beats? You've
 come to the right place. The topics in this section describe how to install and configure
@@ -42,8 +42,8 @@ mac>> for OS X, and <<win, win>> for Windows):
 ["source","sh",subs="attributes,callouts"]
 ----------------------------------------------------------------------
 sudo apt-get install openjdk-7-jre
-curl -L -O https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/5.0.0-alpha1/elasticsearch-5.0.0-alpha1.deb
-sudo dpkg -i elasticsearch-5.0.0-alpha1.deb
+curl -L -O https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/{ES-version}/elasticsearch-{ES-version}.deb
+sudo dpkg -i elasticsearch-{ES-version}.deb
 sudo /etc/init.d/elasticsearch start
 ----------------------------------------------------------------------
 
@@ -52,8 +52,8 @@ sudo /etc/init.d/elasticsearch start
 ["source","sh",subs="attributes,callouts"]
 ----------------------------------------------------------------------
 sudo yum install java-1.7.0-openjdk
-curl -L -O https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/rpm/elasticsearch/5.0.0-alpha1/elasticsearch-5.0.0-alpha1.rpm
-sudo rpm -i elasticsearch-5.0.0-alpha1.rpm
+curl -L -O https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/rpm/elasticsearch/{ES-version}/elasticsearch-{ES-version}.rpm
+sudo rpm -i elasticsearch-{ES-version}.rpm
 sudo service elasticsearch start
 ----------------------------------------------------------------------
 
@@ -62,9 +62,9 @@ sudo service elasticsearch start
 ["source","sh",subs="attributes,callouts"]
 ----------------------------------------------------------------------
 # install Java, e.g. from: https://www.java.com/en/download/manual.jsp
-curl -L -O https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/zip/elasticsearch/5.0.0-alpha1/elasticsearch-5.0.0-alpha1.zip
-unzip elasticsearch-5.0.0-alpha1.zip
-cd elasticsearch-5.0.0-alpha1
+curl -L -O https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/zip/elasticsearch/{ES-version}/elasticsearch-{ES-version}.zip
+unzip elasticsearch-{ES-version}.zip
+cd elasticsearch-{ES-version}
 ./bin/elasticsearch
 ----------------------------------------------------------------------
 
@@ -151,8 +151,8 @@ with your system:
 ["source","sh",subs="attributes,callouts"]
 ----------------------------------------------------------------------
 sudo apt-get install openjdk-7-jre
-curl -L -O https://download.elastic.co/logstash/logstash/packages/debian/logstash_5.0.0~alpha1-1_all.deb
-sudo dpkg -i logstash_5.0.0~alpha1-1_all.deb
+curl -L -O https://download.elastic.co/logstash/logstash/packages/debian/logstash-{LS-version}_all.deb
+sudo dpkg -i logstash-{LS-version}_all.deb
 ----------------------------------------------------------------------
 
 *rpm:*
@@ -160,8 +160,8 @@ sudo dpkg -i logstash_5.0.0~alpha1-1_all.deb
 ["source","sh",subs="attributes,callouts"]
 ----------------------------------------------------------------------
 sudo yum install java-1.7.0-openjdk
-curl -L -O https://download.elastic.co/logstash/logstash/packages/centos/logstash-5.0.0~alpha1-1.noarch.rpm
-sudo rpm -i logstash-5.0.0~alpha1-1.noarch.rpm
+curl -L -O https://download.elastic.co/logstash/logstash/packages/centos/logstash-{LS-version}.noarch.rpm
+sudo rpm -i logstash-{LS-version}.noarch.rpm
 ----------------------------------------------------------------------
 
 *mac:*

--- a/libbeat/docs/index.asciidoc
+++ b/libbeat/docs/index.asciidoc
@@ -5,10 +5,10 @@
 :filebeat: http://www.elastic.co/guide/en/beats/filebeat/master
 :winlogbeat: http://www.elastic.co/guide/en/beats/winlogbeat/master
 :security: X-Pack Security
-:ES-version: 5.0.0-alpha1
-:LS-version: 5.0.0-alpha1
-:Kibana-version: 5.0.0-alpha1
-:Dashboards-version: 5.0.0-alpha1
+:ES-version: 5.0.0-alpha2
+:LS-version: 5.0.0-alpha2
+:Kibana-version: 5.0.0-alpha2
+:Dashboards-version: 5.0.0-alpha2
 
 include::./overview.asciidoc[]
 

--- a/packetbeat/docs/index.asciidoc
+++ b/packetbeat/docs/index.asciidoc
@@ -1,7 +1,7 @@
 = Packetbeat Reference
 :libbeat: http://www.elastic.co/guide/en/beats/libbeat/master
 :elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/master/
-:version: 5.0.0-alpha1
+:version: 5.0.0-alpha2
 :beatname_lc: packetbeat
 :beatname_uc: Packetbeat
 :security: X-Pack Security

--- a/topbeat/docs/index.asciidoc
+++ b/topbeat/docs/index.asciidoc
@@ -1,7 +1,7 @@
 = Topbeat Reference
 :libbeat: http://www.elastic.co/guide/en/beats/libbeat/master
 :elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/master/
-:version: 5.0.0-alpha1
+:version: 5.0.0-alpha2
 :beatname_lc: topbeat
 :beatname_uc: Topbeat
 :security: X-Pack Security

--- a/winlogbeat/docs/index.asciidoc
+++ b/winlogbeat/docs/index.asciidoc
@@ -1,7 +1,7 @@
 = Winlogbeat Reference
 :libbeat: http://www.elastic.co/guide/en/beats/libbeat/master
 :elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/master/
-:version: 5.0.0-alpha1
+:version: 5.0.0-alpha2
 :beatname_lc: winlogbeat
 :beatname_uc: Winlogbeat
 :security: X-Pack Security


### PR DESCRIPTION
This needs to be merged tomorrow morning (morning of alpha2 release):
* Increments version variables for libbeat, packetbeat, topbeat, filebeat, and winlogbeat.
* Adds variables back into asciidoc for Platform Ref GS (where we had to remove them in alpha1)
