### PR TITLE
Refactoring of FileState loading for Prospector

### DIFF
--- a/filebeat/harvester/log.go
+++ b/filebeat/harvester/log.go
@@ -224,6 +224,7 @@ func (h *Harvester) updateOffset(increment int64) {
 }
 
 func (h *Harvester) UpdateState() {
+	logp.Debug("Update state: %s, offset: %v", h.Path, h.offset)
 	h.sendEvent(h.createEvent())
 }
 


### PR DESCRIPTION
Previously the file state was loaded from disk every time a new file was found. The state from the registry file is now only loaded once during startup and from the one the prospector internal in memory state is used. This is more efficient and prevents race conditions.

This can have one side affect. In case a shared file system is not available during a restart and becomes available later, all files are read from the start again as the state for these files was not loaded. Only the state for files which are found during startup (rotated or not) are loaded.

This is related to #1022

Changes:
* Registry only loaded once during startup
* File Stats are only read once and reuse during one scan
* No state for empty files is written
* Additional tests to confirm changes were added


More cleanup and variable renaming is needed in a next step, as parts in registrar and prospector can now be simplified.