### PR TITLE
Update testing environment

### DIFF
--- a/testing/environments/alpha2.yml
+++ b/testing/environments/alpha2.yml
@@ -1,15 +1,16 @@
 # This should test the environment with the latest snapshots
 # This is based on base.yml
+
 elasticsearch:
   build: ./docker/elasticsearch
-  dockerfile: Dockerfile-snapshot
+  dockerfile: Dockerfile-5.0.0-alpha1    # still using alpha1 because alpha2 doesn't work fine in docker
   command: elasticsearch -Ees.network.host=0.0.0.0 -Ees.discovery.zen.minimum_master_nodes=1
 
 logstash:
   build: ./docker/logstash
-  dockerfile: Dockerfile-snapshot
+  dockerfile: Dockerfile-5.0.0-alpha2
 
 kibana:
   build: ./docker/kibana
-  dockerfile: Dockerfile-snapshot
+  dockerfile: Dockerfile-5.0.0-alpha2
 

--- a/testing/environments/docker/elasticsearch/Dockerfile-5.0.0-alpha1
+++ b/testing/environments/docker/elasticsearch/Dockerfile-5.0.0-alpha1
@@ -15,7 +15,7 @@ RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 46095ACC85485
 ENV ELASTICSEARCH_MAJOR 5.0
 ENV ELASTICSEARCH_VERSION 5.0.0-alpha1
 
-RUN wget http://download.elastic.co/elasticsearch/staging/5.0.0-alpha1-7d4ed5b/org/elasticsearch/distribution/deb/elasticsearch/5.0.0-alpha1/elasticsearch-5.0.0-alpha1.deb
+RUN wget https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/5.0.0-alpha1/elasticsearch-5.0.0-alpha1.deb
 
 RUN dpkg -i elasticsearch-5.0.0-alpha1.deb
 

--- a/testing/environments/docker/kibana/Dockerfile-5.0.0-alpha2
+++ b/testing/environments/docker/kibana/Dockerfile-5.0.0-alpha2
@@ -17,7 +17,7 @@ RUN arch="$(dpkg --print-architecture)" \
 
 RUN set -x \
 
-	&& curl -fSL "https://download.elastic.co/kibana/kibana/kibana-5.0.0-alpha1-linux-x64.tar.gz" -o kibana.tar.gz \
+	&& curl -fSL "https://download.elastic.co/kibana/kibana/kibana-5.0.0-alpha2-linux-x64.tar.gz" -o kibana.tar.gz \
 	&& mkdir -p /opt/kibana \
 	&& tar -xz --strip-components=1 -C /opt/kibana -f kibana.tar.gz \
 	&& chown -R kibana:kibana /opt/kibana \
@@ -27,8 +27,7 @@ ENV PATH /opt/kibana/bin:$PATH
 
 COPY ./docker-entrypoint.sh /
 
-# There is no compatible Sense plugin for Kibana 5.0-alpha1.
-RUN gosu kibana kibana-plugin install https://download.elasticsearch.org/kibana/timelion/timelion-5.0.0-0.1.259.zip
+RUN gosu kibana kibana-plugin install https://download.elasticsearch.org/elastic/timelion/timelion-5.0.0-0.1.276.zip
 
 EXPOSE 5601
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/testing/environments/docker/logstash/Dockerfile-5.0.0-alpha2
+++ b/testing/environments/docker/logstash/Dockerfile-5.0.0-alpha2
@@ -3,7 +3,7 @@ FROM java:8-jre
 ENV LS_VERSION 5
 
 # As all snapshot builds have the same url, the image is cached. The date at then can be used to invalidate the image
-ENV DEB_URL https://download.elastic.co/logstash/logstash/packages/debian/logstash_5.0.0~alpha1-1_all.deb
+ENV DEB_URL https://download.elastic.co/logstash/logstash/packages/debian/logstash-5.0.0-alpha2_all.deb
 
 ENV PATH $PATH:/opt/logstash/bin:/opt/logstash/vendor/jruby/bin
 


### PR DESCRIPTION
Added an `alpha2.yml` env, using the alpha2 versions of LS and Kibana, but still
alpha1 for Elasticsearch, due to the docker issue.

The snapshot.yml also still uses alpha1 for ES until I figure out where to get the
ES snapshots from. That can be done in a future PR.