### PR TITLE
Re-factor to fix high CPU usage on windows

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -31,6 +31,8 @@ https://github.com/elastic/beats/compare/v5.0.0-alpha2...master[Check the HEAD d
 
 *Topbeat*
 
+- Fixed high CPU usage when using filtering under Windows. {pull}1562[1562]
+
 *Filebeat*
 
 *Winlogbeat*

--- a/metricbeat/module/system/process/process.go
+++ b/metricbeat/module/system/process/process.go
@@ -31,7 +31,10 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 			Procs:     []string{".*"}, // Collect all processes.
 		},
 	}
-	m.stats.InitProcStats()
+	err := m.stats.InitProcStats()
+	if err != nil {
+		return nil, err
+	}
 	return m, nil
 }
 

--- a/topbeat/beater/topbeat.go
+++ b/topbeat/beater/topbeat.go
@@ -115,7 +115,10 @@ func (t *Topbeat) Setup(b *beat.Beat) error {
 func (t *Topbeat) Run(b *beat.Beat) error {
 	var err error
 
-	t.procStats.InitProcStats()
+	err = t.procStats.InitProcStats()
+	if err != nil {
+		return err
+	}
 
 	ticker := time.NewTicker(t.period)
 	defer ticker.Stop()

--- a/topbeat/system/process.go
+++ b/topbeat/system/process.go
@@ -28,31 +28,16 @@ type Process struct {
 type ProcStats struct {
 	ProcStats bool
 	Procs     []string
+	regexps   []*regexp.Regexp
 	ProcsMap  ProcsMap
 }
 
-func GetProcess(pid int, cmdline string) (*Process, error) {
+// newProcess creates a new Process object based on the state information.
+func newProcess(pid int) (*Process, error) {
+
 	state := sigar.ProcState{}
 	if err := state.Get(pid); err != nil {
 		return nil, fmt.Errorf("error getting process state for pid=%d: %v", pid, err)
-	}
-
-	mem := sigar.ProcMem{}
-	if err := mem.Get(pid); err != nil {
-		return nil, fmt.Errorf("error getting process mem for pid=%d: %v", pid, err)
-	}
-
-	cpu := sigar.ProcTime{}
-	if err := cpu.Get(pid); err != nil {
-		return nil, fmt.Errorf("error getting process cpu time for pid=%d: %v", pid, err)
-	}
-
-	if cmdline == "" {
-		args := sigar.ProcArgs{}
-		if err := args.Get(pid); err != nil {
-			return nil, fmt.Errorf("error getting process arguments for pid=%d: %v", pid, err)
-		}
-		cmdline = strings.Join(args.List, " ")
 	}
 
 	proc := Process{
@@ -61,13 +46,36 @@ func GetProcess(pid int, cmdline string) (*Process, error) {
 		Name:     state.Name,
 		State:    getProcState(byte(state.State)),
 		Username: state.Username,
-		CmdLine:  cmdline,
-		Mem:      mem,
-		Cpu:      cpu,
 		Ctime:    time.Now(),
 	}
 
 	return &proc, nil
+}
+
+// getDetails fills in CPU, memory, and command line details for the process
+func (proc *Process) getDetails(cmdline string) error {
+
+	proc.Mem = sigar.ProcMem{}
+	if err := proc.Mem.Get(proc.Pid); err != nil {
+		return fmt.Errorf("error getting process mem for pid=%d: %v", proc.Pid, err)
+	}
+
+	proc.Cpu = sigar.ProcTime{}
+	if err := proc.Cpu.Get(proc.Pid); err != nil {
+		return fmt.Errorf("error getting process cpu time for pid=%d: %v", proc.Pid, err)
+	}
+
+	if cmdline == "" {
+		args := sigar.ProcArgs{}
+		if err := args.Get(proc.Pid); err != nil {
+			return fmt.Errorf("error getting process arguments for pid=%d: %v", proc.Pid, err)
+		}
+		proc.CmdLine = strings.Join(args.List, " ")
+	} else {
+		proc.CmdLine = cmdline
+	}
+
+	return nil
 }
 
 func GetProcMemPercentage(proc *Process, total_phymem uint64) float64 {
@@ -159,21 +167,29 @@ func GetProcCpuPercentage(last *Process, current *Process) float64 {
 
 func (procStats *ProcStats) MatchProcess(name string) bool {
 
-	for _, reg := range procStats.Procs {
-		matched, _ := regexp.MatchString(reg, name)
-		if matched {
+	for _, reg := range procStats.regexps {
+		if reg.MatchString(name) {
 			return true
 		}
 	}
 	return false
 }
 
-func (procStats *ProcStats) InitProcStats() {
+func (procStats *ProcStats) InitProcStats() error {
 
 	procStats.ProcsMap = make(ProcsMap)
 
 	if len(procStats.Procs) == 0 {
-		return
+		return nil
+	}
+
+	procStats.regexps = []*regexp.Regexp{}
+	for _, pattern := range procStats.Procs {
+		reg, err := regexp.Compile(pattern)
+		if err != nil {
+			return fmt.Errorf("Failed to compile regexp [%s]: %v", pattern, err)
+		}
+		procStats.regexps = append(procStats.regexps, reg)
 	}
 
 	pids, err := Pids()
@@ -182,13 +198,20 @@ func (procStats *ProcStats) InitProcStats() {
 	}
 
 	for _, pid := range pids {
-		process, err := GetProcess(pid, "")
+		process, err := newProcess(pid)
 		if err != nil {
 			logp.Debug("topbeat", "Skip process pid=%d: %v", pid, err)
 			continue
 		}
+		err = process.getDetails("")
+		if err != nil {
+			logp.Err("Error getting process details pid=%d: %v", pid, err)
+			continue
+		}
 		procStats.ProcsMap[process.Pid] = process
 	}
+
+	return nil
 }
 
 func (procStats *ProcStats) GetProcStats() ([]common.MapStr, error) {
@@ -212,20 +235,22 @@ func (procStats *ProcStats) GetProcStats() ([]common.MapStr, error) {
 			cmdline = previousProc.CmdLine
 		}
 
-		process, err := GetProcess(pid, cmdline)
+		process, err := newProcess(pid)
 		if err != nil {
 			logp.Debug("topbeat", "Skip process pid=%d: %v", pid, err)
 			continue
 		}
 
 		if procStats.MatchProcess(process.Name) {
+			err = process.getDetails(cmdline)
+			if err != nil {
+				logp.Err("Error getting process details. pid=%d: %v", process.Pid, err)
+				continue
+			}
 
 			newProcs[process.Pid] = process
 
-			last, ok := procStats.ProcsMap[process.Pid]
-			if ok {
-				procStats.ProcsMap[process.Pid] = process
-			}
+			last, _ := procStats.ProcsMap[process.Pid]
 			proc := GetProcessEvent(process, last)
 
 			processes = append(processes, proc)

--- a/topbeat/system/process_test.go
+++ b/topbeat/system/process_test.go
@@ -27,11 +27,12 @@ func TestGetProcess(t *testing.T) {
 
 	for _, pid := range pids {
 
-		process, err := GetProcess(pid, "")
-
+		process, err := newProcess(pid)
 		if err != nil {
 			continue
 		}
+		err = process.getDetails("")
+		assert.NoError(t, err)
 		assert.NotNil(t, process)
 
 		assert.True(t, (process.Pid > 0))
@@ -73,13 +74,20 @@ func TestMatchProcs(t *testing.T) {
 	var procStats = ProcStats{}
 
 	procStats.Procs = []string{".*"}
+	err := procStats.InitProcStats()
+	assert.NoError(t, err)
+
 	assert.True(t, procStats.MatchProcess("topbeat"))
 
 	procStats.Procs = []string{"topbeat"}
+	err = procStats.InitProcStats()
+	assert.NoError(t, err)
 	assert.False(t, procStats.MatchProcess("burn"))
 
 	// match no processes
 	procStats.Procs = []string{"$^"}
+	err = procStats.InitProcStats()
+	assert.NoError(t, err)
 	assert.False(t, procStats.MatchProcess("burn"))
 }
 
@@ -154,10 +162,12 @@ func BenchmarkGetProcess(b *testing.B) {
 			cmdline = p.CmdLine
 		}
 
-		process, err := GetProcess(pid, cmdline)
+		process, err := newProcess(pid)
 		if err != nil {
 			continue
 		}
+		err = process.getDetails(cmdline)
+		assert.NoError(b, err)
 
 		procs[pid] = process
 	}


### PR DESCRIPTION
This decouples getting the basic state information from getting the more
detailed information.  The reason is that filtering only needs the name, but
the code was getting all details and then apply filtering. Getting the command
line is expensive on Windows, so that contributed to #1460.

What made it worse is that due to filtering, the command line cache was
invalidated on each run, which explains why topbeat was consuming more CPU when
filtering out processes than when not.

Fixes #1460.

This also pre-compiles the regexps, which brings some slight CPU usage improvements
and uncovers compilation errors earlier.