### PR TITLE
packetbeat: nfs: fix stream initialization

### DIFF
--- a/packetbeat/protos/nfs/rpc.go
+++ b/packetbeat/protos/nfs/rpc.go
@@ -235,6 +235,7 @@ func (rpc *Rpc) handleRpcFragment(
 func newStream(pkt *protos.Packet, tcptuple *common.TcpTuple) *RpcStream {
 	return &RpcStream{
 		tcpTuple: tcptuple,
+		rawData:  pkt.Payload,
 	}
 }
 


### PR DESCRIPTION
when a new stream is created, packet data was lost.

depends on (PR)#1485