### PR TITLE
Add tests for the filesystem, fsstats, and process MetricSets.

### DIFF
--- a/metricbeat/docs/fields.asciidoc
+++ b/metricbeat/docs/fields.asciidoc
@@ -608,9 +608,9 @@ The amount of CPU time spent in involuntary wait by the virtual CPU while the hy
 
 ==== system-filesystem.avail
 
-type: integer
+type: long
 
-The available disk space in bytes.
+The disk space available to an unprivileged user in bytes.
 
 
 ==== system-filesystem.device_name
@@ -629,28 +629,35 @@ The mounting point. For example: `/`
 
 ==== system-filesystem.files
 
-type: integer
+type: long
 
 The total number of file nodes in the file system.
 
 
+==== system-filesystem.free
+
+type: long
+
+The disk space available in bytes.
+
+
 ==== system-filesystem.free_files
 
-type: integer
+type: long
 
 The number of free file nodes in the file system.
 
 
 ==== system-filesystem.total
 
-type: integer
+type: long
 
 The total disk space in bytes.
 
 
 ==== system-filesystem.used
 
-type: integer
+type: long
 
 The used disk space in bytes.
 
@@ -664,46 +671,46 @@ The percentage of used disk space.
 
 === system-fsstats Fields
 
-`system-fsstats` contains local filesystem stats
+`system-fsstats` contains filesystem metrics aggregated from all mounted filesystems.
 
 
 
 ==== system-fsstats.count
 
-type: integer
+type: long
 
-Number of file systems found
+Number of file systems found.
 
 ==== system-fsstats.total_files
 
 type: long
 
-Number of total files
+Total number of files.
 
 === total_size Fields
 
-Nested file system docs
-
-
-==== system-fsstats.total_size.avail
-
-type: integer
-
-Total available space.
+Nested file system docs.
 
 
 ==== system-fsstats.total_size.free
 
-type: integer
+type: long
 
 Total free space.
 
 
 ==== system-fsstats.total_size.used
 
-type: integer
+type: long
 
 Total used space.
+
+
+==== system-fsstats.total_size.total
+
+type: long
+
+Total space (used plus free).
 
 
 === system-memory Fields
@@ -803,7 +810,7 @@ The percentage of used swap memory.
 
 === system-process Fields
 
-`system-process` contains process stats
+`system-process` contains process metadata, CPU metrics, and memory metrics.
 
 
 
@@ -857,7 +864,7 @@ CPU-specific statistics per process.
 
 ==== system-process.cpu.user
 
-type: integer
+type: long
 
 The amount of CPU time the process spent in user space.
 
@@ -871,14 +878,14 @@ The percentage of CPU time spent by the process since the last update. Its value
 
 ==== system-process.cpu.system
 
-type: integer
+type: long
 
 The amount of CPU time the process spent in kernel space.
 
 
 ==== system-process.cpu.total
 
-type: integer
+type: long
 
 The total CPU time spent by the process.
 
@@ -898,14 +905,14 @@ Memory-specific statistics per process.
 
 ==== system-process.mem.size
 
-type: integer
+type: long
 
 The total virtual memory the process has.
 
 
 ==== system-process.mem.rss
 
-type: integer
+type: long
 
 The Resident Set Size. The amount of memory the process occupied in main memory (RAM).
 
@@ -919,7 +926,7 @@ The percentage of memory the process occupied in main memory (RAM).
 
 ==== system-process.mem.share
 
-type: integer
+type: long
 
 The shared memory the process uses.
 

--- a/metricbeat/etc/fields.yml
+++ b/metricbeat/etc/fields.yml
@@ -423,9 +423,9 @@ system:
         `system-filesystem` contains local filesystem stats
       fields:
         - name: avail
-          type: integer
+          type: long
           description: >
-            The available disk space in bytes.
+            The disk space available to an unprivileged user in bytes.
         - name: device_name
           type: keyword
           description: >
@@ -435,19 +435,23 @@ system:
           description: >
             The mounting point. For example: `/`
         - name: files
-          type: integer
+          type: long
           description: >
             The total number of file nodes in the file system.
+        - name: free
+          type: long
+          description: >
+            The disk space available in bytes.
         - name: free_files
-          type: integer
+          type: long
           description: >
             The number of free file nodes in the file system.
         - name: total
-          type: integer
+          type: long
           description: >
             The total disk space in bytes.
         - name: used
-          type: integer
+          type: long
           description: >
             The used disk space in bytes.
         - name: used_p
@@ -459,30 +463,31 @@ system:
     - name: system-fsstats
       type: group
       description: >
-        `system-fsstats` contains local filesystem stats
+        `system-fsstats` contains filesystem metrics aggregated from all mounted
+        filesystems.
       fields:
         - name: count
-          type: integer
-          description: Number of file systems found
+          type: long
+          description: Number of file systems found.
         - name: total_files
           type: long
-          description: Number of total files
+          description: Total number of files.
         - name: total_size
           type: group
-          description: Nested file system docs
+          description: Nested file system docs.
           fields:
-            - name: avail
-              type: integer
-              description: >
-                Total available space.
             - name: free
-              type: integer
+              type: long
               description: >
                 Total free space.
             - name: used
-              type: integer
+              type: long
               description: >
                 Total used space.
+            - name: total
+              type: long
+              description: >
+                Total space (used plus free).
     - name: system-memory
       type: group
       description: >
@@ -557,7 +562,7 @@ system:
     - name: system-process
       type: group
       description: >
-        `system-process` contains process stats
+        `system-process` contains process metadata, CPU metrics, and memory metrics.
       fields:
         - name: name
           type: keyword
@@ -593,7 +598,7 @@ system:
           description: CPU-specific statistics per process.
           fields:
             - name: user
-              type: integer
+              type: long
               description: >
                 The amount of CPU time the process spent in user space.
             - name: total_p
@@ -602,11 +607,11 @@ system:
                 The percentage of CPU time spent by the process since the last update. Its value is similar with the
                 %CPU value of the process displayed by the top command on unix systems.
             - name: system
-              type: integer
+              type: long
               description: >
                 The amount of CPU time the process spent in kernel space.
             - name: total
-              type: integer
+              type: long
               description: >
                 The total CPU time spent by the process.
             - name: start_time
@@ -619,11 +624,11 @@ system:
           prefix: "[float]"
           fields:
             - name: size
-              type: integer
+              type: long
               description: >
                 The total virtual memory the process has.
             - name: rss
-              type: integer
+              type: long
               description: >
                 The Resident Set Size. The amount of memory the process occupied in main memory (RAM).
             - name: rss_p
@@ -631,7 +636,7 @@ system:
               description: >
                 The percentage of memory the process occupied in main memory (RAM).
             - name: share
-              type: integer
+              type: long
               description: >
                 The shared memory the process uses.
 zookeeper:

--- a/metricbeat/metricbeat.template.json
+++ b/metricbeat/metricbeat.template.json
@@ -278,27 +278,30 @@
         "system-filesystem": {
           "properties": {
             "avail": {
-              "type": "integer"
+              "type": "long"
             },
             "device_name": {
               "ignore_above": 1024,
               "type": "keyword"
             },
             "files": {
-              "type": "integer"
+              "type": "long"
+            },
+            "free": {
+              "type": "long"
             },
             "free_files": {
-              "type": "integer"
+              "type": "long"
             },
             "mount_point": {
               "ignore_above": 1024,
               "type": "keyword"
             },
             "total": {
-              "type": "integer"
+              "type": "long"
             },
             "used": {
-              "type": "integer"
+              "type": "long"
             },
             "used_p": {
               "type": "float"
@@ -308,21 +311,21 @@
         "system-fsstats": {
           "properties": {
             "count": {
-              "type": "integer"
+              "type": "long"
             },
             "total_files": {
               "type": "long"
             },
             "total_size": {
               "properties": {
-                "avail": {
-                  "type": "integer"
-                },
                 "free": {
-                  "type": "integer"
+                  "type": "long"
+                },
+                "total": {
+                  "type": "long"
                 },
                 "used": {
-                  "type": "integer"
+                  "type": "long"
                 }
               }
             }
@@ -386,32 +389,32 @@
                   "type": "keyword"
                 },
                 "system": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "total": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "total_p": {
                   "type": "float"
                 },
                 "user": {
-                  "type": "integer"
+                  "type": "long"
                 }
               }
             },
             "mem": {
               "properties": {
                 "rss": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "rss_p": {
                   "type": "float"
                 },
                 "share": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "size": {
-                  "type": "integer"
+                  "type": "long"
                 }
               }
             },

--- a/metricbeat/module/system/cpu/cpu.go
+++ b/metricbeat/module/system/cpu/cpu.go
@@ -27,7 +27,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 }
 
 // Fetch fetches CPU metrics from the OS.
-func (m *MetricSet) Fetch(host string) (event common.MapStr, err error) {
+func (m *MetricSet) Fetch(host string) (common.MapStr, error) {
 	cpuStat, err := system.GetCpuTimes()
 	if err != nil {
 		return nil, errors.Wrap(err, "cpu times")

--- a/metricbeat/module/system/filesystem/doc.go
+++ b/metricbeat/module/system/filesystem/doc.go
@@ -1,1 +1,30 @@
+/*
+Package filesystem provides a MetricSet implementation that fetches metrics
+for each of the mounted file systems.
+
+An example event looks as following:
+
+    {
+      "@timestamp": "2016-04-26T19:30:19.475Z",
+      "beat": {
+        "hostname": "ruflin",
+        "name": "ruflin"
+      },
+      "metricset": "filesystem",
+      "module": "system",
+      "rtt": 434,
+      "system-filesystem": {
+        "avail": 41159540736,
+        "device_name": "/dev/disk1",
+        "files": 60981246,
+        "free": 41421684736,
+        "free_files": 10048716,
+        "mount_point": "/",
+        "total": 249779191808,
+        "used": 208357507072,
+        "used_p": 0.83
+      },
+      "type": "metricsets"
+    }
+*/
 package filesystem

--- a/metricbeat/module/system/filesystem/fields.yml
+++ b/metricbeat/module/system/filesystem/fields.yml
@@ -4,9 +4,9 @@
     `system-filesystem` contains local filesystem stats
   fields:
     - name: avail
-      type: integer
+      type: long
       description: >
-        The available disk space in bytes.
+        The disk space available to an unprivileged user in bytes.
     - name: device_name
       type: keyword
       description: >
@@ -16,19 +16,23 @@
       description: >
         The mounting point. For example: `/`
     - name: files
-      type: integer
+      type: long
       description: >
         The total number of file nodes in the file system.
+    - name: free
+      type: long
+      description: >
+        The disk space available in bytes.
     - name: free_files
-      type: integer
+      type: long
       description: >
         The number of free file nodes in the file system.
     - name: total
-      type: integer
+      type: long
       description: >
         The total disk space in bytes.
     - name: used
-      type: integer
+      type: long
       description: >
         The used disk space in bytes.
     - name: used_p

--- a/metricbeat/module/system/fsstats/doc.go
+++ b/metricbeat/module/system/fsstats/doc.go
@@ -1,1 +1,27 @@
+/*
+Package fsstats provides a MetricSet for fetching aggregated filesystem stats.
+
+An example event looks as following:
+
+	{
+	  "@timestamp": "2016-05-03T15:11:04.610Z",
+	  "beat": {
+	    "hostname": "ruflin",
+	    "name": "ruflin"
+	  },
+	  "metricset": "fsstats",
+	  "module": "system",
+	  "rtt": 84,
+	  "system-fsstats": {
+	    "count": 4,
+	    "total_files": 60982450,
+	    "total_size": {
+	      "free": 32586960896,
+	      "total": 249779548160,
+	      "used": 217192587264
+	    }
+	  },
+	  "type": "metricsets"
+	}
+*/
 package fsstats

--- a/metricbeat/module/system/fsstats/fields.yml
+++ b/metricbeat/module/system/fsstats/fields.yml
@@ -1,27 +1,28 @@
 - name: system-fsstats
   type: group
   description: >
-    `system-fsstats` contains local filesystem stats
+    `system-fsstats` contains filesystem metrics aggregated from all mounted
+    filesystems.
   fields:
     - name: count
-      type: integer
-      description: Number of file systems found
+      type: long
+      description: Number of file systems found.
     - name: total_files
       type: long
-      description: Number of total files
+      description: Total number of files.
     - name: total_size
       type: group
-      description: Nested file system docs
+      description: Nested file system docs.
       fields:
-        - name: avail
-          type: integer
-          description: >
-            Total available space.
         - name: free
-          type: integer
+          type: long
           description: >
             Total free space.
         - name: used
-          type: integer
+          type: long
           description: >
             Total used space.
+        - name: total
+          type: long
+          description: >
+            Total space (used plus free).

--- a/metricbeat/module/system/memory/memory.go
+++ b/metricbeat/module/system/memory/memory.go
@@ -32,11 +32,13 @@ func (m *MetricSet) Fetch(host string) (event common.MapStr, err error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "memory")
 	}
+	system.AddMemPercentage(memStat)
 
 	swapStat, err := system.GetSwap()
 	if err != nil {
 		return nil, errors.Wrap(err, "swap")
 	}
+	system.AddSwapPercentage(swapStat)
 
 	return common.MapStr{
 		"mem":  system.GetMemoryEvent(memStat),

--- a/metricbeat/module/system/process/doc.go
+++ b/metricbeat/module/system/process/doc.go
@@ -1,1 +1,40 @@
+/*
+Package process collects metrics about the running processes using information
+from the operating system.
+
+An example event looks as following:
+
+    {
+      "@timestamp": "2016-04-26T19:24:19.108Z",
+      "beat": {
+        "hostname": "ruflin",
+        "name": "ruflin"
+      },
+      "metricset": "process",
+      "module": "system",
+      "rtt": 20982,
+      "system-process": {
+        "cmdline": ".\/metricbeat -e -d * -c metricbeat.dev.yml",
+        "cpu": {
+          "start_time": "21:24",
+          "system": 32,
+          "total": 79,
+          "total_p": 1.2791,
+          "user": 47
+        },
+        "mem": {
+          "rss": 11538432,
+          "rss_p": 0,
+          "share": 0,
+          "size": 587196518400
+        },
+        "name": "metricbeat",
+        "pid": 27769,
+        "ppid": 26608,
+        "state": "running",
+        "username": "ruflin"
+      },
+      "type": "metricsets"
+    }
+*/
 package process

--- a/metricbeat/module/system/process/fields.yml
+++ b/metricbeat/module/system/process/fields.yml
@@ -1,7 +1,7 @@
 - name: system-process
   type: group
   description: >
-    `system-process` contains process stats
+    `system-process` contains process metadata, CPU metrics, and memory metrics.
   fields:
     - name: name
       type: keyword
@@ -37,7 +37,7 @@
       description: CPU-specific statistics per process.
       fields:
         - name: user
-          type: integer
+          type: long
           description: >
             The amount of CPU time the process spent in user space.
         - name: total_p
@@ -46,11 +46,11 @@
             The percentage of CPU time spent by the process since the last update. Its value is similar with the
             %CPU value of the process displayed by the top command on unix systems.
         - name: system
-          type: integer
+          type: long
           description: >
             The amount of CPU time the process spent in kernel space.
         - name: total
-          type: integer
+          type: long
           description: >
             The total CPU time spent by the process.
         - name: start_time
@@ -63,11 +63,11 @@
       prefix: "[float]"
       fields:
         - name: size
-          type: integer
+          type: long
           description: >
             The total virtual memory the process has.
         - name: rss
-          type: integer
+          type: long
           description: >
             The Resident Set Size. The amount of memory the process occupied in main memory (RAM).
         - name: rss_p
@@ -75,6 +75,6 @@
           description: >
             The percentage of memory the process occupied in main memory (RAM).
         - name: share
-          type: integer
+          type: long
           description: >
             The shared memory the process uses.

--- a/metricbeat/module/system/process/process.go
+++ b/metricbeat/module/system/process/process.go
@@ -1,51 +1,13 @@
 // +build darwin linux windows
 
-/*
-
-An example event looks as following:
-
-
-    {
-      "@timestamp": "2016-04-26T19:24:19.108Z",
-      "beat": {
-        "hostname": "ruflin",
-        "name": "ruflin"
-      },
-      "metricset": "process",
-      "module": "system",
-      "rtt": 20982,
-      "system-process": {
-        "cmdline": ".\/metricbeat -e -d * -c metricbeat.dev.yml",
-        "cpu": {
-          "start_time": "21:24",
-          "system": 32,
-          "total": 79,
-          "total_p": 1.2791,
-          "user": 47
-        },
-        "mem": {
-          "rss": 11538432,
-          "rss_p": 0,
-          "share": 0,
-          "size": 587196518400
-        },
-        "name": "metricbeat",
-        "pid": 27769,
-        "ppid": 26608,
-        "state": "running",
-        "username": "ruflin"
-      },
-      "type": "metricsets"
-    }
-
-*/
-
 package process
 
 import (
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/topbeat/system"
+
+	"github.com/pkg/errors"
 )
 
 func init() {
@@ -54,25 +16,32 @@ func init() {
 	}
 }
 
+// MetricSet that fetches process metrics.
 type MetricSet struct {
 	mb.BaseMetricSet
 	stats *system.ProcStats
 }
 
-// New creates new instance of MetricSet
+// New creates and returns a new MetricSet.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-
 	m := &MetricSet{
 		BaseMetricSet: base,
-		stats:         &system.ProcStats{},
+		stats: &system.ProcStats{
+			ProcStats: true,
+			Procs:     []string{".*"}, // Collect all processes.
+		},
 	}
-
-	m.stats.Procs = []string{".*"} //all processes
-	m.stats.ProcStats = true
 	m.stats.InitProcStats()
 	return m, nil
 }
 
-func (m *MetricSet) Fetch(host string) (events []common.MapStr, err error) {
-	return m.stats.GetProcStats()
+// Fetch fetches metrics for all processes. It iterates over each PID and
+// collects process metadata, CPU metrics, and memory metrics.
+func (m *MetricSet) Fetch(host string) ([]common.MapStr, error) {
+	procs, err := m.stats.GetProcStats()
+	if err != nil {
+		return nil, errors.Wrap(err, "process stats")
+	}
+
+	return procs, err
 }

--- a/metricbeat/tests/system/test_system.py
+++ b/metricbeat/tests/system/test_system.py
@@ -6,7 +6,16 @@ import metricbeat
 SYSTEM_CPU_FIELDS = ["idle", "iowait", "irq", "nice", "softirq",
                      "steal", "system", "system_p", "user", "user_p"]
 
+SYSTEM_FILESYSTEM_FIELDS = ["avail", "device_name", "files", "free",
+                            "free_files", "mount_point", "total", "used",
+                            "used_p"]
+
+SYSTEM_FSSTATS_FIELDS = ["count", "total_files", "total_size"]
+
 SYSTEM_MEMORY_FIELDS = ["swap", "mem"]
+
+SYSTEM_PROCESS_FIELDS = ["cmdline", "cpu", "mem", "name", "pid", "ppid",
+                         "state", "username"]
 
 
 @unittest.skipUnless(re.match("(?i)win|linux|darwin|openbsd", sys.platform), "os")
@@ -31,12 +40,60 @@ class SystemTest(metricbeat.BaseTest):
         output = self.read_output_json()
         self.assertEqual(len(output), 1)
         evt = output[0]
+        self.assert_fields_are_documented(evt)
 
         cpu = evt["system-cpu"]
         self.assertItemsEqual(SYSTEM_CPU_FIELDS, cpu.keys())
 
-        # TODO: After fields.yml is updated this can be uncommented.
-        #self.assert_fields_are_documented(evt)
+    def test_filesystem(self):
+        """
+        Test system/filesystem output.
+        """
+        self.render_config_template(modules=[{
+            "name": "system",
+            "metricsets": ["filesystem"],
+            "period": "5s"
+        }])
+        proc = self.start_beat()
+        self.wait_until(lambda: self.output_lines() > 0)
+        proc.check_kill_and_wait()
+
+        # Ensure no errors or warnings exist in the log.
+        log = self.get_log()
+        self.assertNotRegexpMatches(log, "ERR|WARN")
+
+        output = self.read_output_json()
+        self.assertGreater(len(output), 0)
+
+        for evt in output:
+            self.assert_fields_are_documented(evt)
+            filesystem = evt["system-filesystem"]
+            self.assertItemsEqual(SYSTEM_FILESYSTEM_FIELDS, filesystem.keys())
+
+    def test_fsstats(self):
+        """
+        Test system/fsstats output.
+        """
+        self.render_config_template(modules=[{
+            "name": "system",
+            "metricsets": ["fsstats"],
+            "period": "5s"
+        }])
+        proc = self.start_beat()
+        self.wait_until(lambda: self.output_lines() > 0)
+        proc.check_kill_and_wait()
+
+        # Ensure no errors or warnings exist in the log.
+        log = self.get_log()
+        self.assertNotRegexpMatches(log, "ERR|WARN")
+
+        output = self.read_output_json()
+        self.assertEqual(len(output), 1)
+        evt = output[0]
+        self.assert_fields_are_documented(evt)
+
+        fsstats = evt["system-fsstats"]
+        self.assertItemsEqual(SYSTEM_FSSTATS_FIELDS, fsstats.keys())
 
     def test_memory(self):
         """
@@ -58,8 +115,46 @@ class SystemTest(metricbeat.BaseTest):
         output = self.read_output_json()
         self.assertEqual(len(output), 1)
         evt = output[0]
+        self.assert_fields_are_documented(evt)
 
         memory = evt["system-memory"]
         self.assertItemsEqual(SYSTEM_MEMORY_FIELDS, memory.keys())
 
-        self.assert_fields_are_documented(evt)
+        # Check that percentages are calculated.
+        mem = memory["mem"]
+        if mem["total"] != 0:
+            used_p = float(mem["used"]) / mem["total"]
+            self.assertAlmostEqual(mem["used_p"], used_p, places=4)
+
+            used_p = float(mem["actual_used"]) / mem["total"]
+            self.assertAlmostEqual(mem["actual_used_p"], used_p, places=4)
+
+        swap = memory["swap"]
+        if swap["total"] != 0:
+            used_p = float(swap["used"]) / swap["total"]
+            self.assertAlmostEqual(swap["used_p"], used_p, places=4)
+
+    def test_process(self):
+        """
+        Test system/process output.
+        """
+        self.render_config_template(modules=[{
+            "name": "system",
+            "metricsets": ["process"],
+            "period": "5s"
+        }])
+        proc = self.start_beat()
+        self.wait_until(lambda: self.output_lines() > 0)
+        proc.check_kill_and_wait()
+
+        # Ensure no errors or warnings exist in the log.
+        log = self.get_log()
+        self.assertNotRegexpMatches(log, "ERR|WARN")
+
+        output = self.read_output_json()
+        self.assertGreater(len(output), 0)
+
+        for evt in output:
+            self.assert_fields_are_documented(evt)
+            process = evt["system-process"]
+            self.assertItemsEqual(SYSTEM_PROCESS_FIELDS, process.keys())

--- a/topbeat/docs/fields.asciidoc
+++ b/topbeat/docs/fields.asciidoc
@@ -485,7 +485,7 @@ Contains details about the mounted disks, such as the total or used disk space, 
 
 type: long
 
-The available disk space in bytes.
+The disk space available to an unprivileged user in bytes.
 
 
 ==== fs.device_name
@@ -507,6 +507,13 @@ The mounting point. For example: `/`
 type: long
 
 The total number of file nodes in the file system.
+
+
+==== fs.free
+
+type: long
+
+The disk space available in bytes.
 
 
 ==== fs.free_files

--- a/topbeat/etc/fields.yml
+++ b/topbeat/etc/fields.yml
@@ -374,7 +374,7 @@ filesystem:
         - name: avail
           type: long
           description: >
-            The available disk space in bytes.
+            The disk space available to an unprivileged user in bytes.
 
         - name: device_name
           type: keyword
@@ -390,6 +390,11 @@ filesystem:
           type: long
           description: >
             The total number of file nodes in the file system.
+
+        - name: free
+          type: long
+          description: >
+            The disk space available in bytes.
 
         - name: free_files
           type: long

--- a/topbeat/system/cpu.go
+++ b/topbeat/system/cpu.go
@@ -78,7 +78,7 @@ func GetCpuPercentageList(last, current []CpuTimes) []CpuTimes {
 		calculate := func(field2 uint64, field1 uint64, all_delta uint64) float64 {
 
 			perc := 0.0
-			delta := field2 - field1
+			delta := int64(field2 - field1)
 			perc = float64(delta) / float64(all_delta)
 			return Round(perc, .5, 4)
 		}

--- a/topbeat/system/filesystem.go
+++ b/topbeat/system/filesystem.go
@@ -50,7 +50,7 @@ func AddFileSystemUsedPercentage(f *FileSystemStat) {
 	}
 
 	perc := float64(f.Used) / float64(f.Total)
-	f.UsedPercent = Round(perc, .5, 2)
+	f.UsedPercent = Round(perc, .5, 4)
 }
 
 func CollectFileSystemStats(fss []sigar.FileSystem) []common.MapStr {

--- a/topbeat/system/process.go
+++ b/topbeat/system/process.go
@@ -85,7 +85,7 @@ func GetProcMemPercentage(proc *Process, total_phymem uint64) float64 {
 
 	perc := (float64(proc.Mem.Resident) / float64(total_phymem))
 
-	return Round(perc, .5, 2)
+	return Round(perc, .5, 4)
 }
 
 func Pids() ([]int, error) {
@@ -148,9 +148,9 @@ func GetProcCpuPercentage(last *Process, current *Process) float64 {
 
 	if last != nil && current != nil {
 
-		delta_proc := current.Cpu.Total - last.Cpu.Total
-		delta_time := current.Ctime.Sub(last.Ctime).Nanoseconds() / 1e6 // in milliseconds
-		perc := float64(delta_proc) / float64(delta_time)
+		delta_proc := int64(current.Cpu.Total - last.Cpu.Total)
+		delta_time := float64(current.Ctime.Sub(last.Ctime).Nanoseconds()) / float64(1e6) // in milliseconds
+		perc := float64(delta_proc) / delta_time
 
 		return Round(perc, .5, 4)
 	}

--- a/topbeat/system/process_test.go
+++ b/topbeat/system/process_test.go
@@ -99,7 +99,7 @@ func TestProcMemPercentage(t *testing.T) {
 	procStats.ProcsMap[p.Pid] = &p
 
 	rssPercent := GetProcMemPercentage(&p, 10000)
-	assert.Equal(t, rssPercent, 0.14)
+	assert.Equal(t, rssPercent, 0.1416)
 }
 
 func TestProcCpuPercentage(t *testing.T) {

--- a/topbeat/system/system.go
+++ b/topbeat/system/system.go
@@ -88,10 +88,10 @@ func AddMemPercentage(m *MemStat) {
 	}
 
 	perc := float64(m.Mem.Used) / float64(m.Mem.Total)
-	m.UsedPercent = Round(perc, .5, 2)
+	m.UsedPercent = Round(perc, .5, 4)
 
 	actual_perc := float64(m.Mem.ActualUsed) / float64(m.Mem.Total)
-	m.ActualUsedPercent = Round(actual_perc, .5, 2)
+	m.ActualUsedPercent = Round(actual_perc, .5, 4)
 }
 
 func AddSwapPercentage(s *SwapStat) {
@@ -100,5 +100,5 @@ func AddSwapPercentage(s *SwapStat) {
 	}
 
 	perc := float64(s.Swap.Used) / float64(s.Swap.Total)
-	s.UsedPercent = Round(perc, .5, 2)
+	s.UsedPercent = Round(perc, .5, 4)
 }

--- a/topbeat/system/system_test.go
+++ b/topbeat/system/system_test.go
@@ -65,7 +65,7 @@ func TestMemPercentage(t *testing.T) {
 		},
 	}
 	AddMemPercentage(&m)
-	assert.Equal(t, m.UsedPercent, 0.71)
+	assert.Equal(t, m.UsedPercent, 0.7143)
 
 	m = MemStat{
 		Mem: gosigar.Mem{Total: 0},
@@ -84,7 +84,7 @@ func TestActualMemPercentage(t *testing.T) {
 		},
 	}
 	AddMemPercentage(&m)
-	assert.Equal(t, m.ActualUsedPercent, 0.71)
+	assert.Equal(t, m.ActualUsedPercent, 0.7143)
 
 	m = MemStat{
 		Mem: gosigar.Mem{

--- a/topbeat/topbeat.template.json
+++ b/topbeat/topbeat.template.json
@@ -113,6 +113,9 @@
             "files": {
               "type": "long"
             },
+            "free": {
+              "type": "long"
+            },
             "free_files": {
               "type": "long"
             },


### PR DESCRIPTION
And also:

- Fix issue where memory user_p and swap_p were not being calculated.
- Fix error where `proc.cpu.total_p` value could be NaN if the polling interval is less that 0.5 ms. When less than 0.5 ms, the time delta value was truncated to 0. Then 0 was being used as the denominator in the percentage calculation causing it to result in NaN. I changed the calculation to use a float64 for the time delta instead of an int64 so that the value is never truncated to 0.
- Fix golint warnings in the system module.
- Add missing fields to fields.yml (filesystem was missing `free`, and fsstats was missing `total_size.total`).
- Change data type in fields.yml for several fields marked as integer that are uint64 or int64 in Go.