### PR TITLE
Honor "enabled: false" in Metricbeat module configuration

### DIFF
--- a/metricbeat/mb/mb_test.go
+++ b/metricbeat/mb/mb_test.go
@@ -11,6 +11,14 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+type testMetricSet struct {
+	BaseMetricSet
+}
+
+func (m *testMetricSet) Fetch(host string) (common.MapStr, error) {
+	return nil, nil
+}
+
 func TestModuleConfig(t *testing.T) {
 	tests := []struct {
 		in  map[string]interface{}
@@ -63,4 +71,54 @@ func TestModuleConfigDefaults(t *testing.T) {
 	assert.Equal(t, time.Second, mc.Period)
 	assert.Equal(t, time.Duration(0), mc.Timeout)
 	assert.Empty(t, mc.Hosts)
+}
+
+// TestNewModulesWithEmptyModulesConfig verifies that an error is returned if
+// the modules configuration list is empty.
+func TestNewModulesWithEmptyModulesConfig(t *testing.T) {
+	r := newTestRegistry(t)
+	_, err := NewModules(nil, r)
+	assert.Equal(t, ErrEmptyConfig, err)
+}
+
+// TestNewModulesWithAllDisabled verifies that an error is returned if all
+// modules defined in the config are disabled.
+func TestNewModulesWithAllDisabled(t *testing.T) {
+	r := newTestRegistry(t)
+
+	c := newConfig(t, map[string]interface{}{
+		"module":     moduleName,
+		"metricsets": []string{metricSetName},
+		"enabled":    false,
+	})
+
+	_, err := NewModules(c, r)
+	assert.Equal(t, ErrAllModulesDisabled, err)
+}
+
+func newTestRegistry(t testing.TB) *Register {
+	r := NewRegister()
+
+	if err := r.AddModule(moduleName, DefaultModuleFactory); err != nil {
+		t.Fatal(err)
+	}
+
+	factory := func(base BaseMetricSet) (MetricSet, error) {
+		return &testMetricSet{base}, nil
+	}
+
+	if err := r.AddMetricSet(moduleName, metricSetName, factory); err != nil {
+		t.Fatal(err)
+	}
+
+	return r
+}
+
+func newConfig(t testing.TB, moduleConfig map[string]interface{}) []*common.Config {
+	config, err := common.NewConfigFrom(moduleConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return []*common.Config{config}
 }

--- a/metricbeat/tests/system/test_base.py
+++ b/metricbeat/tests/system/test_base.py
@@ -7,7 +7,11 @@ class Test(BaseTest):
         """
         Metricbeat starts and stops without error.
         """
-        self.render_config_template()
+        self.render_config_template(modules=[{
+            "name": "system",
+            "metricsets": ["cpu"],
+            "period": "5s"
+        }])
         proc = self.start_beat()
         self.wait_until(lambda: self.log_contains("start running"))
         proc.check_kill_and_wait()


### PR DESCRIPTION
- Config validation fails if no modules are configured.
- Config validation fails if all modules are disabled.