### PR TITLE
Update regex support to be based on regexp.Compile

### DIFF
--- a/filebeat/crawler/prospector.go
+++ b/filebeat/crawler/prospector.go
@@ -140,10 +140,6 @@ func (p *Prospector) setupProspectorConfig() error {
 	if err != nil {
 		return err
 	}
-	config.ExcludeFilesRegexp, err = harvester.InitRegexps(config.ExcludeFiles)
-	if err != nil {
-		return err
-	}
 
 	if config.Harvester.InputType == cfg.LogInputType && len(config.Paths) == 0 {
 		return fmt.Errorf("No paths were defined for prospector")

--- a/filebeat/crawler/prospector_log.go
+++ b/filebeat/crawler/prospector_log.go
@@ -292,13 +292,6 @@ func (p *ProspectorLog) getPreviousFile(file string, info os.FileInfo) (string, 
 }
 
 func (p *ProspectorLog) isFileExcluded(file string) bool {
-
-	if len(p.config.ExcludeFilesRegexp) > 0 {
-
-		if harvester.MatchAnyRegexps(p.config.ExcludeFilesRegexp, file) {
-			return true
-		}
-	}
-
-	return false
+	patterns := p.config.ExcludeFiles
+	return len(patterns) > 0 && harvester.MatchAnyRegexps(patterns, file)
 }

--- a/filebeat/crawler/prospector_test.go
+++ b/filebeat/crawler/prospector_test.go
@@ -3,6 +3,7 @@
 package crawler
 
 import (
+	"regexp"
 	"testing"
 	"time"
 
@@ -215,7 +216,7 @@ func TestProspectorInitInputTypeWrong(t *testing.T) {
 func TestProspectorFileExclude(t *testing.T) {
 
 	prospectorConfig := config.ProspectorConfig{
-		ExcludeFiles: []string{"\\.gz$"},
+		ExcludeFiles: []*regexp.Regexp{regexp.MustCompile(`\.gz$`)},
 		Harvester: config.HarvesterConfig{
 			BufferSize: 0,
 		},

--- a/filebeat/harvester/harvester.go
+++ b/filebeat/harvester/harvester.go
@@ -40,8 +40,6 @@ func NewHarvester(
 	stat *input.FileStat,
 	spooler chan *input.FileEvent,
 ) (*Harvester, error) {
-
-	var err error
 	encoding, ok := encoding.FindEncoding(cfg.Encoding)
 	if !ok || encoding == nil {
 		return nil, fmt.Errorf("unknown encoding('%v')", cfg.Encoding)
@@ -54,14 +52,8 @@ func NewHarvester(
 		SpoolerChan: spooler,
 		encoding:    encoding,
 	}
-	h.ExcludeLinesRegexp, err = InitRegexps(cfg.ExcludeLines)
-	if err != nil {
-		return h, err
-	}
-	h.IncludeLinesRegexp, err = InitRegexps(cfg.IncludeLines)
-	if err != nil {
-		return h, err
-	}
+	h.ExcludeLinesRegexp = cfg.ExcludeLines
+	h.IncludeLinesRegexp = cfg.IncludeLines
 	return h, nil
 }
 

--- a/filebeat/harvester/processor/multiline_test.go
+++ b/filebeat/harvester/processor/multiline_test.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"errors"
 	"os"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -26,7 +27,7 @@ func (p bufferSource) Continuable() bool          { return false }
 func TestMultilineAfterOK(t *testing.T) {
 	testMultilineOK(t,
 		config.MultilineConfig{
-			Pattern: "^[ \t] +", // next line is indented by spaces
+			Pattern: regexp.MustCompile(`^[ \t] +`), // next line is indented by spaces
 			Match:   "after",
 		},
 		"line1\n  line1.1\n  line1.2\n",
@@ -37,7 +38,7 @@ func TestMultilineAfterOK(t *testing.T) {
 func TestMultilineBeforeOK(t *testing.T) {
 	testMultilineOK(t,
 		config.MultilineConfig{
-			Pattern: "\\\\$", // previous line ends with \
+			Pattern: regexp.MustCompile(`\\$`), // previous line ends with \
 			Match:   "before",
 		},
 		"line1 \\\nline1.1 \\\nline1.2\n",
@@ -48,7 +49,7 @@ func TestMultilineBeforeOK(t *testing.T) {
 func TestMultilineAfterNegateOK(t *testing.T) {
 	testMultilineOK(t,
 		config.MultilineConfig{
-			Pattern: "^-", // first line starts with '-' at beginning of line
+			Pattern: regexp.MustCompile(`^-`), // first line starts with '-' at beginning of line
 			Negate:  true,
 			Match:   "after",
 		},
@@ -60,7 +61,7 @@ func TestMultilineAfterNegateOK(t *testing.T) {
 func TestMultilineBeforeNegateOK(t *testing.T) {
 	testMultilineOK(t,
 		config.MultilineConfig{
-			Pattern: ";$", // last line ends with ';'
+			Pattern: regexp.MustCompile(`;$`), // last line ends with ';'
 			Negate:  true,
 			Match:   "before",
 		},

--- a/filebeat/harvester/util.go
+++ b/filebeat/harvester/util.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/elastic/beats/filebeat/harvester/processor"
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/logp"
 )
 
 // readLine reads a full line into buffer and returns it.
@@ -21,23 +20,6 @@ func readLine(reader processor.LineProcessor) (time.Time, string, int, common.Ma
 	}
 
 	return time.Time{}, "", 0, nil, err
-}
-
-// InitRegexps initializes a list of compiled regular expressions.
-func InitRegexps(exprs []string) ([]*regexp.Regexp, error) {
-
-	result := []*regexp.Regexp{}
-
-	for _, exp := range exprs {
-
-		rexp, err := regexp.CompilePOSIX(exp)
-		if err != nil {
-			logp.Err("Fail to compile the regexp %s: %s", exp, err)
-			return nil, err
-		}
-		result = append(result, rexp)
-	}
-	return result, nil
 }
 
 // MatchAnyRegexps checks if the text matches any of the regular expressions

--- a/filebeat/harvester/util_test.go
+++ b/filebeat/harvester/util_test.go
@@ -3,10 +3,28 @@
 package harvester
 
 import (
+	"regexp"
 	"testing"
 
+	"github.com/elastic/beats/libbeat/logp"
 	"github.com/stretchr/testify/assert"
 )
+
+// InitRegexps initializes a list of compiled regular expressions.
+func InitRegexps(exprs []string) ([]*regexp.Regexp, error) {
+
+	result := []*regexp.Regexp{}
+
+	for _, exp := range exprs {
+		rexp, err := regexp.Compile(exp)
+		if err != nil {
+			logp.Err("Fail to compile the regexp %s: %s", exp, err)
+			return nil, err
+		}
+		result = append(result, rexp)
+	}
+	return result, nil
+}
 
 func TestMatchAnyRegexps(t *testing.T) {
 

--- a/filebeat/tests/system/test_json.py
+++ b/filebeat/tests/system/test_json.py
@@ -157,7 +157,7 @@ class Test(BaseTest):
             json=dict(
                 keys_under_root=True),
             multiline=True,
-            pattern="^["
+            pattern="^\\["
         )
 
         proc = self.start_beat()


### PR DESCRIPTION
This changes the regexp dialect by using regexp.Compile instead of
regexp.CompilePosix.

For details of impact see:
https://github.com/elastic/beats/issues/740#issuecomment-173569093

In case of errors or for improved error messages see #1575. 
