### PR TITLE
Improve packer 

### DIFF
--- a/dev-tools/packer/Makefile
+++ b/dev-tools/packer/Makefile
@@ -18,6 +18,7 @@ packetbeat topbeat filebeat metricbeat winlogbeat: build/upload
 		-e PACK=$@ \
 		-e BEFORE_BUILD=before_build.sh \
 		-e SOURCE=/source \
+		-e TARGETS="windows/amd64 windows/386 darwin/amd64" \
 		-e BUILDID=${BUILDID} \
 		tudorg/beats-builder \
 		github.com/elastic/beats
@@ -29,6 +30,7 @@ packetbeat topbeat filebeat metricbeat winlogbeat: build/upload
 		-e PACK=$@ \
 		-e BEFORE_BUILD=before_build.sh \
 		-e SOURCE=/source \
+		-e TARGETS="linux/amd64 linux/386" \
 		-e BUILDID=${BUILDID} \
 		tudorg/beats-builder-deb6 \
 		github.com/elastic/beats

--- a/dev-tools/packer/docker/xgo-image-deb6/base/build.sh
+++ b/dev-tools/packer/docker/xgo-image-deb6/base/build.sh
@@ -14,6 +14,9 @@
 #   OUT         - Optional output prefix to override the package name
 #   FLAG_V      - Optional verbosity flag to set on the Go builder
 #   FLAG_RACE   - Optional race flag to set on the Go builder
+#   TARGETS        - Comma separated list of build targets to compile for
+
+
 
 # Download the canonical import path (may fail, don't allow failures beyond)
 
@@ -68,12 +71,19 @@ fi
 
 # Download all the C dependencies
 echo "Fetching dependencies..."
-mkdir -p /deps
+BUILD_DEPS=/build_deps.sh
+DEPS_FOLDER=/deps
+LIST_DEPS=""
+mkdir -p $DEPS_FOLDER
 DEPS=($DEPS) && for dep in "${DEPS[@]}"; do
-  echo Downloading $dep
-  if [ "${dep##*.}" == "tar" ]; then wget -q $dep -O - | tar -C /deps -x; fi
-  if [ "${dep##*.}" == "gz" ]; then wget -q $dep -O - | tar -C /deps -xz; fi
-  if [ "${dep##*.}" == "bz2" ]; then wget -q $dep -O - | tar -C /deps -xj; fi
+  dep_filename=${dep##*/}
+  echo "Downloading $dep to $DEPS_FOLDER/$dep_filename"
+  wget -q $dep --directory-prefix=$DEPS_FOLDER
+  dep_name=$(tar --list --no-recursion --file=$DEPS_FOLDER/$dep_filename  --exclude="*/*" | sed 's/\///g')
+  LIST_DEPS="${LIST_DEPS} ${dep_name}"
+  if [ "${dep_filename##*.}" == "tar" ]; then tar -xf  $DEPS_FOLDER/$dep_filename --directory $DEPS_FOLDER/  ; fi
+  if [ "${dep_filename##*.}" == "gz"  ]; then tar -xzf $DEPS_FOLDER/$dep_filename --directory $DEPS_FOLDER/  ; fi
+  if [ "${dep_filename##*.}" == "bz2" ]; then tar -xj  $DEPS_FOLDER/$dep_filename --directory $DEPS_FOLDER/  ; fi
 done
 
 # Configure some global build parameters
@@ -93,45 +103,80 @@ if [ -n $BEFORE_BUILD ]; then
 	/scripts/$BEFORE_BUILD ${1}
 fi
 
-# Build for each platform individually
-echo "Compiling $PACK for linux/amd64..."
-HOST=x86_64-linux PREFIX=/usr/local $BUILD_DEPS /deps
-GOOS=linux GOARCH=amd64 CGO_ENABLED=1 go get -d ./$PACK
-sh -c "GOOS=linux GOARCH=amd64 CGO_ENABLED=1 go build $V $R $LDARGS -o $NAME-linux-amd64$R ./$PACK"
 
-echo "Compiling $PACK for linux/386..."
-HOST=i686-linux PREFIX=/usr/local $BUILD_DEPS /deps
-GOOS=linux GOARCH=386 CGO_ENABLED=1 go get -d ./$PACK
-sh -c "GOOS=linux GOARCH=386 CGO_ENABLED=1 go build $V $LDARGS -o $NAME-linux-386 ./$PACK"
+# If no build targets were specified, inject a catch all wildcard
+if [ "$TARGETS" == "" ]; then
+  TARGETS="./."
+fi
 
-#echo "Compiling $PACK for linux/arm..."
-#CC=arm-linux-gnueabi-gcc HOST=arm-linux PREFIX=/usr/local/arm $BUILD_DEPS /deps
-#CC=arm-linux-gnueabi-gcc GOOS=linux GOARCH=arm CGO_ENABLED=1 GOARM=5 go get -d ./$PACK
-#CC=arm-linux-gnueabi-gcc GOOS=linux GOARCH=arm CGO_ENABLED=1 GOARM=5 go build $V -o $NAME-linux-arm ./$PACK
 
-#echo "Compiling $PACK for windows/amd64..."
-#CC=x86_64-w64-mingw32-gcc HOST=x86_64-w64-mingw32 PREFIX=/usr/x86_64-w64-mingw32 $BUILD_DEPS /deps
-#CC=x86_64-w64-mingw32-gcc GOOS=windows GOARCH=amd64 CGO_ENABLED=1 go get -d ./$PACK
-#CC=x86_64-w64-mingw32-gcc GOOS=windows GOARCH=amd64 CGO_ENABLED=1 go build  $V $R -o $NAME-windows-amd64$R.exe ./$PACK
+built_targets=0
+for TARGET in $TARGETS; do
+	# Split the target into platform and architecture
+	XGOOS=`echo $TARGET | cut -d '/' -f 1`
+	XGOARCH=`echo $TARGET | cut -d '/' -f 2`
 
-#echo "Compiling $PACK for windows/386..."
-#CC=i686-w64-mingw32-gcc HOST=i686-w64-mingw32 PREFIX=/usr/i686-w64-mingw32 $BUILD_DEPS /deps
-#CC=i686-w64-mingw32-gcc GOOS=windows GOARCH=386 CGO_ENABLED=1 go get -d ./$PACK
-#CC=i686-w64-mingw32-gcc GOOS=windows GOARCH=386 CGO_ENABLED=1 go build $V -o $NAME-windows-386.exe ./$PACK
+	# Check and build for Linux targets
+	if ([ $XGOOS == "." ] || [ $XGOOS == "linux" ]) && ([ $XGOARCH == "." ] || [ $XGOARCH == "amd64" ]); then
+		echo "Compiling $PACK for linux/amd64..."
+		HOST=x86_64-linux PREFIX=/usr/local $BUILD_DEPS /deps $LIST_DEPS
+		GOOS=linux GOARCH=amd64 CGO_ENABLED=1 go get -d ./$PACK
+		sh -c "GOOS=linux GOARCH=amd64 CGO_ENABLED=1 go build $V $R $LDARGS -o $NAME-linux-amd64$R ./$PACK"
+		built_targets=$((built_targets+1))
+	fi
+	if ([ $XGOOS == "." ] || [ $XGOOS == "linux" ]) && ([ $XGOARCH == "." ] || [ $XGOARCH == "386" ]); then
+		echo "Compiling $PACK for linux/386..."
+		HOST=i686-linux PREFIX=/usr/local $BUILD_DEPS /deps $LIST_DEPS
+		GOOS=linux GOARCH=386 CGO_ENABLED=1 go get -d ./$PACK
+		sh -c "GOOS=linux GOARCH=386 CGO_ENABLED=1 go build $V $R $LDARGS -o $NAME-linux-386$R ./$PACK"
+		built_targets=$((built_targets+1))
+	fi	
+	if ([ $XGOOS == "." ] || [ $XGOOS == "linux" ]) && ([ $XGOARCH == "." ] || [ $XGOARCH == "arm" ]); then
+		echo "Compiling $PACK for linux/arm..."
+		CC=arm-linux-gnueabi-gcc HOST=arm-linux PREFIX=/usr/local/arm $BUILD_DEPS /deps $LIST_DEPS
+		CC=arm-linux-gnueabi-gcc GOOS=linux GOARCH=arm CGO_ENABLED=1 GOARM=5 go get -d ./$PACK
+		CC=arm-linux-gnueabi-gcc GOOS=linux GOARCH=arm CGO_ENABLED=1 GOARM=5 go build $V -o $NAME-linux-arm ./$PACK
+		built_targets=$((built_targets+1))
+	fi
+	
+	# Check and build for Windows targets
+	if ([ $XGOOS == "." ] || [ $XGOOS == "windows" ]) && ([ $XGOARCH == "." ] || [ $XGOARCH == "amd64" ]); then
+		echo "Compiling $PACK for windows/amd64..."
+		CC=x86_64-w64-mingw32-gcc HOST=x86_64-w64-mingw32 PREFIX=/usr/x86_64-w64-mingw32 $BUILD_DEPS /deps $LIST_DEPS
+		CC=x86_64-w64-mingw32-gcc GOOS=windows GOARCH=amd64 CGO_ENABLED=1 go get -d ./$PACK
+		CC=x86_64-w64-mingw32-gcc GOOS=windows GOARCH=amd64 CGO_ENABLED=1 go build  $V $R -o $NAME-windows-amd64$R.exe ./$PACK
+		built_targets=$((built_targets+1))
+	fi
+	
+	if ([ $XGOOS == "." ] || [ $XGOOS == "windows" ]) && ([ $XGOARCH == "." ] || [ $XGOARCH == "386" ]); then
+		echo "Compiling $PACK for windows/386..."
+		CC=i686-w64-mingw32-gcc HOST=i686-w64-mingw32 PREFIX=/usr/i686-w64-mingw32 $BUILD_DEPS /deps $LIST_DEPS
+		CC=i686-w64-mingw32-gcc GOOS=windows GOARCH=386 CGO_ENABLED=1 go get -d ./$PACK
+		CC=i686-w64-mingw32-gcc GOOS=windows GOARCH=386 CGO_ENABLED=1 go build $V -o $NAME-windows-386.exe ./$PACK
+		built_targets=$((built_targets+1))
+	fi
+	
+	# Check and build for OSX targets
+	if ([ $XGOOS == "." ] || [ $XGOOS == "darwin" ]) && ([ $XGOARCH == "." ] || [ $XGOARCH == "amd64" ]); then
+		echo "Compiling $PACK for darwin/amd64..."
+		CC=o64-clang HOST=x86_64-apple-darwin10 PREFIX=/usr/local $BUILD_DEPS /deps $LIST_DEPS
+		CC=o64-clang GOOS=darwin GOARCH=amd64 CGO_ENABLED=1 go get -d ./$PACK
+		CC=o64-clang GOOS=darwin GOARCH=amd64 CGO_ENABLED=1 go build -ldflags=-s $V $R -o $NAME-darwin-amd64$R ./$PACK
+		built_targets=$((built_targets+1))
+	fi
+	if ([ $XGOOS == "." ] || [ $XGOOS == "darwin" ]) && ([ $XGOARCH == "." ] || [ $XGOARCH == "386" ]); then
+		echo "Compiling for darwin/386..."
+		CC=o32-clang HOST=i386-apple-darwin10 PREFIX=/usr/local $BUILD_DEPS /deps $LIST_DEPS
+		CC=o32-clang GOOS=darwin GOARCH=386 CGO_ENABLED=1 go get -d ./$PACK
+		CC=o32-clang GOOS=darwin GOARCH=386 CGO_ENABLED=1 go build $V -o $NAME-darwin-386 ./$PACK
+		built_targets=$((built_targets+1))
+	fi
+done
 
-#echo "Compiling $PACK for darwin/amd64..."
-#CC=o64-clang HOST=x86_64-apple-darwin10 PREFIX=/usr/local $BUILD_DEPS /deps
-#CC=o64-clang GOOS=darwin GOARCH=amd64 CGO_ENABLED=1 go get -d ./$PACK
-#CC=o64-clang GOOS=darwin GOARCH=amd64 CGO_ENABLED=1 go build $V $R -o $NAME-darwin-amd64$R ./$PACK
 
-#echo "Compiling $PACK for darwin/386..."
-#CC=o32-clang HOST=i386-apple-darwin10 PREFIX=/usr/local $BUILD_DEPS /deps
-#CC=o32-clang GOOS=darwin GOARCH=386 CGO_ENABLED=1 go get -d ./$PACK
-#CC=o32-clang GOOS=darwin GOARCH=386 CGO_ENABLED=1 go build $V -o $NAME-darwin-386 ./$PACK
-
-# The binary files are the 2 last created files
-echo "Moving binaries to host..."
-ls -t | head -n 2
-cp `ls -t | head -n 2` /build
+# The binary files are the last created files
+echo "Moving $built_targets $PACK binaries to host folder..."
+ls -t | head -n $built_targets 
+cp `ls -t | head -n $built_targets ` /build
 
 echo "Build process completed"

--- a/dev-tools/packer/docker/xgo-image-deb6/base/build.sh
+++ b/dev-tools/packer/docker/xgo-image-deb6/base/build.sh
@@ -17,15 +17,16 @@
 
 # Download the canonical import path (may fail, don't allow failures beyond)
 
+SRC_FOLDER=$SOURCE
+DST_FOLDER=$GOPATH/src/$1
+
 if [ $1 = "github.com/elastic/beats" ]; then
-        SRC_FOLDER=$SOURCE
-        DST_FOLDER=$GOPATH/src/$1
         WORKING_DIRECTORY=$GOPATH/src/$1
 else
-        SRC_FOLDER=$SOURCE
-        DST_FOLDER=$GOPATH/src/$1
         WORKING_DIRECTORY=$GOPATH/src/`dirname $1`
 fi
+
+echo "Working directory=$WORKING_DIRECTORY"
 
 if [ "$SOURCE" != "" ]; then
         mkdir -p ${DST_FOLDER}
@@ -93,40 +94,44 @@ if [ -n $BEFORE_BUILD ]; then
 fi
 
 # Build for each platform individually
-echo "Compiling for linux/amd64..."
+echo "Compiling $PACK for linux/amd64..."
 HOST=x86_64-linux PREFIX=/usr/local $BUILD_DEPS /deps
 GOOS=linux GOARCH=amd64 CGO_ENABLED=1 go get -d ./$PACK
 sh -c "GOOS=linux GOARCH=amd64 CGO_ENABLED=1 go build $V $R $LDARGS -o $NAME-linux-amd64$R ./$PACK"
 
-echo "Compiling for linux/386..."
+echo "Compiling $PACK for linux/386..."
 HOST=i686-linux PREFIX=/usr/local $BUILD_DEPS /deps
 GOOS=linux GOARCH=386 CGO_ENABLED=1 go get -d ./$PACK
 sh -c "GOOS=linux GOARCH=386 CGO_ENABLED=1 go build $V $LDARGS -o $NAME-linux-386 ./$PACK"
 
-#echo "Compiling for linux/arm..."
+#echo "Compiling $PACK for linux/arm..."
 #CC=arm-linux-gnueabi-gcc HOST=arm-linux PREFIX=/usr/local/arm $BUILD_DEPS /deps
 #CC=arm-linux-gnueabi-gcc GOOS=linux GOARCH=arm CGO_ENABLED=1 GOARM=5 go get -d ./$PACK
 #CC=arm-linux-gnueabi-gcc GOOS=linux GOARCH=arm CGO_ENABLED=1 GOARM=5 go build $V -o $NAME-linux-arm ./$PACK
 
-#echo "Compiling for windows/amd64..."
+#echo "Compiling $PACK for windows/amd64..."
 #CC=x86_64-w64-mingw32-gcc HOST=x86_64-w64-mingw32 PREFIX=/usr/x86_64-w64-mingw32 $BUILD_DEPS /deps
 #CC=x86_64-w64-mingw32-gcc GOOS=windows GOARCH=amd64 CGO_ENABLED=1 go get -d ./$PACK
 #CC=x86_64-w64-mingw32-gcc GOOS=windows GOARCH=amd64 CGO_ENABLED=1 go build  $V $R -o $NAME-windows-amd64$R.exe ./$PACK
 
-#echo "Compiling for windows/386..."
+#echo "Compiling $PACK for windows/386..."
 #CC=i686-w64-mingw32-gcc HOST=i686-w64-mingw32 PREFIX=/usr/i686-w64-mingw32 $BUILD_DEPS /deps
 #CC=i686-w64-mingw32-gcc GOOS=windows GOARCH=386 CGO_ENABLED=1 go get -d ./$PACK
 #CC=i686-w64-mingw32-gcc GOOS=windows GOARCH=386 CGO_ENABLED=1 go build $V -o $NAME-windows-386.exe ./$PACK
 
-#echo "Compiling for darwin/amd64..."
+#echo "Compiling $PACK for darwin/amd64..."
 #CC=o64-clang HOST=x86_64-apple-darwin10 PREFIX=/usr/local $BUILD_DEPS /deps
 #CC=o64-clang GOOS=darwin GOARCH=amd64 CGO_ENABLED=1 go get -d ./$PACK
 #CC=o64-clang GOOS=darwin GOARCH=amd64 CGO_ENABLED=1 go build $V $R -o $NAME-darwin-amd64$R ./$PACK
 
-#echo "Compiling for darwin/386..."
+#echo "Compiling $PACK for darwin/386..."
 #CC=o32-clang HOST=i386-apple-darwin10 PREFIX=/usr/local $BUILD_DEPS /deps
 #CC=o32-clang GOOS=darwin GOARCH=386 CGO_ENABLED=1 go get -d ./$PACK
 #CC=o32-clang GOOS=darwin GOARCH=386 CGO_ENABLED=1 go build $V -o $NAME-darwin-386 ./$PACK
 
+# The binary files are the 2 last created files
 echo "Moving binaries to host..."
+ls -t | head -n 2
 cp `ls -t | head -n 2` /build
+
+echo "Build process completed"

--- a/dev-tools/packer/docker/xgo-image-deb6/base/build.sh
+++ b/dev-tools/packer/docker/xgo-image-deb6/base/build.sh
@@ -120,55 +120,77 @@ for TARGET in $TARGETS; do
 	if ([ $XGOOS == "." ] || [ $XGOOS == "linux" ]) && ([ $XGOARCH == "." ] || [ $XGOARCH == "amd64" ]); then
 		echo "Compiling $PACK for linux/amd64..."
 		HOST=x86_64-linux PREFIX=/usr/local $BUILD_DEPS /deps $LIST_DEPS
+		export PKG_CONFIG_PATH=/usr/aarch64-linux-gnu/lib/pkgconfig
+
 		GOOS=linux GOARCH=amd64 CGO_ENABLED=1 go get -d ./$PACK
 		sh -c "GOOS=linux GOARCH=amd64 CGO_ENABLED=1 go build $V $R $LDARGS -o $NAME-linux-amd64$R ./$PACK"
 		built_targets=$((built_targets+1))
 	fi
 	if ([ $XGOOS == "." ] || [ $XGOOS == "linux" ]) && ([ $XGOARCH == "." ] || [ $XGOARCH == "386" ]); then
 		echo "Compiling $PACK for linux/386..."
-		HOST=i686-linux PREFIX=/usr/local $BUILD_DEPS /deps $LIST_DEPS
+		CFLAGS=-m32 CXXFLAGS=-m32 LDFLAGS=-m32 HOST=i686-linux PREFIX=/usr/local $BUILD_DEPS /deps $LIST_DEPS
 		GOOS=linux GOARCH=386 CGO_ENABLED=1 go get -d ./$PACK
 		sh -c "GOOS=linux GOARCH=386 CGO_ENABLED=1 go build $V $R $LDARGS -o $NAME-linux-386$R ./$PACK"
 		built_targets=$((built_targets+1))
 	fi	
 	if ([ $XGOOS == "." ] || [ $XGOOS == "linux" ]) && ([ $XGOARCH == "." ] || [ $XGOARCH == "arm" ]); then
 		echo "Compiling $PACK for linux/arm..."
-		CC=arm-linux-gnueabi-gcc HOST=arm-linux PREFIX=/usr/local/arm $BUILD_DEPS /deps $LIST_DEPS
-		CC=arm-linux-gnueabi-gcc GOOS=linux GOARCH=arm CGO_ENABLED=1 GOARM=5 go get -d ./$PACK
-		CC=arm-linux-gnueabi-gcc GOOS=linux GOARCH=arm CGO_ENABLED=1 GOARM=5 go build $V -o $NAME-linux-arm ./$PACK
+		CC=arm-linux-gnueabi-gcc CXX=rm-linux-gnueabi-g++ HOST=arm-linux PREFIX=/usr/local/arm $BUILD_DEPS /deps $LIST_DEPS
+
+		CC=arm-linux-gnueabi-gcc CXX=rm-linux-gnueabi-g++ GOOS=linux GOARCH=arm CGO_ENABLED=1 GOARM=5 go get -d ./$PACK
+		CC=arm-linux-gnueabi-gcc CXX=rm-linux-gnueabi-g++ GOOS=linux GOARCH=arm CGO_ENABLED=1 GOARM=5 go build $V -o $NAME-linux-arm ./$PACK
 		built_targets=$((built_targets+1))
 	fi
-	
+
 	# Check and build for Windows targets
-	if ([ $XGOOS == "." ] || [ $XGOOS == "windows" ]) && ([ $XGOARCH == "." ] || [ $XGOARCH == "amd64" ]); then
-		echo "Compiling $PACK for windows/amd64..."
-		CC=x86_64-w64-mingw32-gcc HOST=x86_64-w64-mingw32 PREFIX=/usr/x86_64-w64-mingw32 $BUILD_DEPS /deps $LIST_DEPS
-		CC=x86_64-w64-mingw32-gcc GOOS=windows GOARCH=amd64 CGO_ENABLED=1 go get -d ./$PACK
-		CC=x86_64-w64-mingw32-gcc GOOS=windows GOARCH=amd64 CGO_ENABLED=1 go build  $V $R -o $NAME-windows-amd64$R.exe ./$PACK
-		built_targets=$((built_targets+1))
-	fi
-	
-	if ([ $XGOOS == "." ] || [ $XGOOS == "windows" ]) && ([ $XGOARCH == "." ] || [ $XGOARCH == "386" ]); then
-		echo "Compiling $PACK for windows/386..."
-		CC=i686-w64-mingw32-gcc HOST=i686-w64-mingw32 PREFIX=/usr/i686-w64-mingw32 $BUILD_DEPS /deps $LIST_DEPS
-		CC=i686-w64-mingw32-gcc GOOS=windows GOARCH=386 CGO_ENABLED=1 go get -d ./$PACK
-		CC=i686-w64-mingw32-gcc GOOS=windows GOARCH=386 CGO_ENABLED=1 go build $V -o $NAME-windows-386.exe ./$PACK
-		built_targets=$((built_targets+1))
+	if [ $XGOOS == "." ] || [[ $XGOOS == windows* ]]; then
+		# Split the platform version and configure the Windows NT version
+		PLATFORM=`echo $XGOOS | cut -d '-' -f 2`
+		if [ "$PLATFORM" == "" ] || [ "$PLATFORM" == "." ] || [ "$PLATFORM" == "windows" ]; then
+		  PLATFORM=4.0 # Windows NT
+		fi
+
+	    MAJOR=`echo $PLATFORM | cut -d '.' -f 1`
+		if [ "${PLATFORM/.}" != "$PLATFORM" ] ; then
+		  MINOR=`echo $PLATFORM | cut -d '.' -f 2`
+		fi
+		CGO_NTDEF="-D_WIN32_WINNT=0x`printf "%02d" $MAJOR``printf "%02d" $MINOR`"
+
+		# Build the requested windows binaries
+		if [ $XGOARCH == "." ] || [ $XGOARCH == "amd64" ]; then
+			echo "Compiling for windows-$PLATFORM/amd64..."
+			CC=x86_64-w64-mingw32-gcc CXX=x86_64-w64-mingw32-g++ CFLAGS="$CGO_NTDEF" CXXFLAGS="$CGO_NTDEF" HOST=x86_64-w64-mingw32 PREFIX=/usr/x86_64-w64-mingw32 $BUILD_DEPS /deps $LIST_DEPS
+			export PKG_CONFIG_PATH=/usr/x86_64-w64-mingw32/lib/pkgconfig
+
+			CC=x86_64-w64-mingw32-gcc CXX=x86_64-w64-mingw32-g++ GOOS=windows GOARCH=amd64 CGO_ENABLED=1 CGO_CFLAGS="$CGO_NTDEF" CGO_CXXFLAGS="$CGO_NTDEF" go get -d ./$PACK
+			CC=x86_64-w64-mingw32-gcc CXX=x86_64-w64-mingw32-g++ GOOS=windows GOARCH=amd64 CGO_ENABLED=1 CGO_CFLAGS="$CGO_NTDEF" CGO_CXXFLAGS="$CGO_NTDEF" go build  $V $R -o $NAME-windows-amd64$R.exe ./$PACK
+			built_targets=$((built_targets+1))
+		fi
+
+		if [ $XGOARCH == "." ] || [ $XGOARCH == "386" ]; then
+			echo "Compiling for windows-$PLATFORM/386..."
+			CC=i686-w64-mingw32-gcc CXX=i686-w64-mingw32-g++ CFLAGS="$CGO_NTDEF" CXXFLAGS="$CGO_NTDEF" HOST=i686-w64-mingw32 PREFIX=/usr/i686-w64-mingw32 $BUILD_DEPS /deps $LIST_DEPS
+			export PKG_CONFIG_PATH=/usr/i686-w64-mingw32/lib/pkgconfig
+
+			CC=i686-w64-mingw32-gcc CXX=i686-w64-mingw32-g++ GOOS=windows GOARCH=386 CGO_ENABLED=1 CGO_CFLAGS="$CGO_NTDEF" CGO_CXXFLAGS="$CGO_NTDEF" go get -d ./$PACK
+			CC=i686-w64-mingw32-gcc CXX=i686-w64-mingw32-g++ GOOS=windows GOARCH=386 CGO_ENABLED=1 CGO_CFLAGS="$CGO_NTDEF" CGO_CXXFLAGS="$CGO_NTDEF" go build $V -o $NAME-windows-386.exe ./$PACK
+			built_targets=$((built_targets+1))
+		fi
 	fi
 	
 	# Check and build for OSX targets
 	if ([ $XGOOS == "." ] || [ $XGOOS == "darwin" ]) && ([ $XGOARCH == "." ] || [ $XGOARCH == "amd64" ]); then
 		echo "Compiling $PACK for darwin/amd64..."
-		CC=o64-clang HOST=x86_64-apple-darwin10 PREFIX=/usr/local $BUILD_DEPS /deps $LIST_DEPS
-		CC=o64-clang GOOS=darwin GOARCH=amd64 CGO_ENABLED=1 go get -d ./$PACK
-		CC=o64-clang GOOS=darwin GOARCH=amd64 CGO_ENABLED=1 go build -ldflags=-s $V $R -o $NAME-darwin-amd64$R ./$PACK
+		CC=o64-clang CXX=o64-clang++ HOST=x86_64-apple-darwin10 PREFIX=/usr/local $BUILD_DEPS /deps $LIST_DEPS
+		CC=o64-clang CXX=o64-clang++ GOOS=darwin GOARCH=amd64 CGO_ENABLED=1 go get -d ./$PACK
+		CC=o64-clang CXX=o64-clang++ GOOS=darwin GOARCH=amd64 CGO_ENABLED=1 go build -ldflags=-s $V $R -o $NAME-darwin-amd64$R ./$PACK
 		built_targets=$((built_targets+1))
 	fi
 	if ([ $XGOOS == "." ] || [ $XGOOS == "darwin" ]) && ([ $XGOARCH == "." ] || [ $XGOARCH == "386" ]); then
 		echo "Compiling for darwin/386..."
-		CC=o32-clang HOST=i386-apple-darwin10 PREFIX=/usr/local $BUILD_DEPS /deps $LIST_DEPS
-		CC=o32-clang GOOS=darwin GOARCH=386 CGO_ENABLED=1 go get -d ./$PACK
-		CC=o32-clang GOOS=darwin GOARCH=386 CGO_ENABLED=1 go build $V -o $NAME-darwin-386 ./$PACK
+		CC=o32-clang CXX=o32-clang++ HOST=i386-apple-darwin10 PREFIX=/usr/local $BUILD_DEPS /deps $LIST_DEPS
+		CC=o32-clang CXX=o32-clang++ GOOS=darwin GOARCH=386 CGO_ENABLED=1 go get -d ./$PACK
+		CC=o32-clang CXX=o32-clang++ GOOS=darwin GOARCH=386 CGO_ENABLED=1 go build $V -o $NAME-darwin-386 ./$PACK
 		built_targets=$((built_targets+1))
 	fi
 done

--- a/dev-tools/packer/docker/xgo-image-deb6/base/build_deps.sh
+++ b/dev-tools/packer/docker/xgo-image-deb6/base/build_deps.sh
@@ -1,23 +1,32 @@
 #!/bin/bash
 #
-# Contains the a dependency builder to iterate over all installed dependencies
+# Contains the dependency builder to iterate over all installed dependencies
 # and cross compile them to the requested target platform.
 # 
-# Usage: build_deps.sh <dependency folder>
+# Usage: build_deps.sh dependency_root_folder dependency1 dependency_2 ...
 #
 # Needed environment variables:
 #   CC     - C cross compiler to use for the build
 #   HOST   - Target platform to build (used to find the needed tool-chains)
 #   PREFIX - File-system path where to install the built binaries
+#   STATIC - true if the libraries are statically linked to the go application
 set -e
 
-# Remove any previous build leftovers, and copy a fresh working set (clean doesn't work for cross compiling)
-rm -rf /deps-build && cp -r $1 /deps-build
+DEP_ROOT_FOLDER=$1
 
-# Build all the dependencies (no order for now)
-for dep in `ls /deps-build`; do
+# Remove any previous build leftovers, and copy a fresh working set (clean doesn't work for cross compiling)
+rm -rf /deps-build && cp -r $DEP_ROOT_FOLDER /deps-build
+
+args=("$@")
+
+if [ "$STATIC" == "true" ]; then DISABLE_SHARED=-disable-shared; fi
+
+# Build all the dependencies
+for ((i=1; i<${#args[@]}; i++)); do
+	dep=${args[i]}
 	echo "Configuring dependency $dep for $HOST..."
-	(cd /deps-build/$dep && ./configure --disable-shared --host=$HOST --prefix=$PREFIX --silent)
+	if [ -f "/deps-build/$dep/autogen.sh" ]; then (cd /deps-build/$dep && ./autogen.sh); fi
+	(cd /deps-build/$dep && ./configure $DISABLE_SHARED --host=$HOST --prefix=$PREFIX --silent)
 
 	echo "Building dependency $dep for $HOST..."
 	(cd /deps-build/$dep && make --silent -j install)

--- a/dev-tools/packer/docker/xgo-image/base/Dockerfile
+++ b/dev-tools/packer/docker/xgo-image/base/Dockerfile
@@ -24,7 +24,7 @@ RUN \
   apt-get install -y automake autogen build-essential ca-certificates           \
     gcc-arm-linux-gnueabi g++-arm-linux-gnueabi libc6-dev-armel-cross           \
     gcc-multilib  g++-multilib mingw-w64 clang llvm-dev                         \
-    libtool libxml2-dev uuid-dev libssl-dev swig openjdk-8-jdk pkg-config patch \
+    libtool libxml2-dev uuid-dev libssl-dev swig pkg-config patch               \
     make xz-utils cpio wget zip unzip p7zip git mercurial bzr texinfo help2man  \
     binutils-multiarch rsync                                                    \
     --no-install-recommends

--- a/dev-tools/packer/docker/xgo-image/base/Dockerfile
+++ b/dev-tools/packer/docker/xgo-image/base/Dockerfile
@@ -21,10 +21,13 @@ RUN chmod +x $FETCH
 # Make sure apt-get is up to date and dependent packages are installed
 RUN \
   apt-get update && \
-  apt-get install -y automake autogen build-essential ca-certificates \
-    gcc-arm-linux-gnueabi libc6-dev-armel-cross gcc-multilib gcc-mingw-w64 \
-    clang llvm-dev  libtool libxml2-dev uuid-dev libssl-dev pkg-config \
-    patch make xz-utils cpio wget unzip git mercurial bzr rsync --no-install-recommends
+  apt-get install -y automake autogen build-essential ca-certificates           \
+    gcc-arm-linux-gnueabi g++-arm-linux-gnueabi libc6-dev-armel-cross           \
+    gcc-multilib  g++-multilib mingw-w64 clang llvm-dev                         \
+    libtool libxml2-dev uuid-dev libssl-dev swig openjdk-8-jdk pkg-config patch \
+    make xz-utils cpio wget zip unzip p7zip git mercurial bzr texinfo help2man  \
+    binutils-multiarch rsync                                                    \
+    --no-install-recommends
 
 # Configure the container for OSX cross compilation
 ENV OSX_SDK_PATH https://github.com/trevd/android_platform_build2/raw/master/osxsdks10.6.tar.gz

--- a/dev-tools/packer/docker/xgo-image/base/build.sh
+++ b/dev-tools/packer/docker/xgo-image/base/build.sh
@@ -14,6 +14,9 @@
 #   OUT         - Optional output prefix to override the package name
 #   FLAG_V      - Optional verbosity flag to set on the Go builder
 #   FLAG_RACE   - Optional race flag to set on the Go builder
+#   TARGETS        - Comma separated list of build targets to compile for
+
+
 
 # Download the canonical import path (may fail, don't allow failures beyond)
 
@@ -68,12 +71,19 @@ fi
 
 # Download all the C dependencies
 echo "Fetching dependencies..."
-mkdir -p /deps
+BUILD_DEPS=/build_deps.sh
+DEPS_FOLDER=/deps
+LIST_DEPS=""
+mkdir -p $DEPS_FOLDER
 DEPS=($DEPS) && for dep in "${DEPS[@]}"; do
-  echo Downloading $dep
-  if [ "${dep##*.}" == "tar" ]; then wget -q $dep -O - | tar -C /deps -x; fi
-  if [ "${dep##*.}" == "gz" ]; then wget -q $dep -O - | tar -C /deps -xz; fi
-  if [ "${dep##*.}" == "bz2" ]; then wget -q $dep -O - | tar -C /deps -xj; fi
+  dep_filename=${dep##*/}
+  echo "Downloading $dep to $DEPS_FOLDER/$dep_filename"
+  wget -q $dep --directory-prefix=$DEPS_FOLDER
+  dep_name=$(tar --list --no-recursion --file=$DEPS_FOLDER/$dep_filename  --exclude="*/*" | sed 's/\///g')
+  LIST_DEPS="${LIST_DEPS} ${dep_name}"
+  if [ "${dep_filename##*.}" == "tar" ]; then tar -xf  $DEPS_FOLDER/$dep_filename --directory $DEPS_FOLDER/  ; fi
+  if [ "${dep_filename##*.}" == "gz"  ]; then tar -xzf $DEPS_FOLDER/$dep_filename --directory $DEPS_FOLDER/  ; fi
+  if [ "${dep_filename##*.}" == "bz2" ]; then tar -xj  $DEPS_FOLDER/$dep_filename --directory $DEPS_FOLDER/  ; fi
 done
 
 # Configure some global build parameters
@@ -93,45 +103,80 @@ if [ -n $BEFORE_BUILD ]; then
 	/scripts/$BEFORE_BUILD ${1}
 fi
 
-# Build for each platform individually
-#echo "Compiling $PACK for linux/amd64..."
-#HOST=x86_64-linux PREFIX=/usr/local $BUILD_DEPS /deps
-#GOOS=linux GOARCH=amd64 CGO_ENABLED=1 go get -d ./$PACK
-#sh -c "GOOS=linux GOARCH=amd64 CGO_ENABLED=1 go build $V $R $LDARGS -o $NAME-linux-amd64$R ./$PACK"
 
-#echo "Compiling $PACK for linux/386..."
-#HOST=i686-linux PREFIX=/usr/local $BUILD_DEPS /deps
-#GOOS=linux GOARCH=386 CGO_ENABLED=1 go get -d ./$PACK
-#sh -c "GOOS=linux GOARCH=386 CGO_ENABLED=1 go build $V $LDARGS -o $NAME-linux-386 ./$PACK"
+# If no build targets were specified, inject a catch all wildcard
+if [ "$TARGETS" == "" ]; then
+  TARGETS="./."
+fi
 
-#echo "Compiling $PACK for linux/arm..."
-#CC=arm-linux-gnueabi-gcc HOST=arm-linux PREFIX=/usr/local/arm $BUILD_DEPS /deps
-#CC=arm-linux-gnueabi-gcc GOOS=linux GOARCH=arm CGO_ENABLED=1 GOARM=5 go get -d ./$PACK
-#CC=arm-linux-gnueabi-gcc GOOS=linux GOARCH=arm CGO_ENABLED=1 GOARM=5 go build $V -o $NAME-linux-arm ./$PACK
 
-echo "Compiling $PACK for windows/amd64..."
-CC=x86_64-w64-mingw32-gcc HOST=x86_64-w64-mingw32 PREFIX=/usr/x86_64-w64-mingw32 $BUILD_DEPS /deps
-CC=x86_64-w64-mingw32-gcc GOOS=windows GOARCH=amd64 CGO_ENABLED=1 go get -d ./$PACK
-CC=x86_64-w64-mingw32-gcc GOOS=windows GOARCH=amd64 CGO_ENABLED=1 go build  $V $R -o $NAME-windows-amd64$R.exe ./$PACK
+built_targets=0
+for TARGET in $TARGETS; do
+	# Split the target into platform and architecture
+	XGOOS=`echo $TARGET | cut -d '/' -f 1`
+	XGOARCH=`echo $TARGET | cut -d '/' -f 2`
 
-echo "Compiling $PACK for windows/386..."
-CC=i686-w64-mingw32-gcc HOST=i686-w64-mingw32 PREFIX=/usr/i686-w64-mingw32 $BUILD_DEPS /deps
-CC=i686-w64-mingw32-gcc GOOS=windows GOARCH=386 CGO_ENABLED=1 go get -d ./$PACK
-CC=i686-w64-mingw32-gcc GOOS=windows GOARCH=386 CGO_ENABLED=1 go build $V -o $NAME-windows-386.exe ./$PACK
-$PACKz
-echo "Compiling $PACK for darwin/amd64..."
-CC=o64-clang HOST=x86_64-apple-darwin10 PREFIX=/usr/local $BUILD_DEPS /deps
-CC=o64-clang GOOS=darwin GOARCH=amd64 CGO_ENABLED=1 go get -d ./$PACK
-CC=o64-clang GOOS=darwin GOARCH=amd64 CGO_ENABLED=1 go build -ldflags=-s $V $R -o $NAME-darwin-amd64$R ./$PACK
+	# Check and build for Linux targets
+	if ([ $XGOOS == "." ] || [ $XGOOS == "linux" ]) && ([ $XGOARCH == "." ] || [ $XGOARCH == "amd64" ]); then
+		echo "Compiling $PACK for linux/amd64..."
+		HOST=x86_64-linux PREFIX=/usr/local $BUILD_DEPS /deps $LIST_DEPS
+		GOOS=linux GOARCH=amd64 CGO_ENABLED=1 go get -d ./$PACK
+		sh -c "GOOS=linux GOARCH=amd64 CGO_ENABLED=1 go build $V $R $LDARGS -o $NAME-linux-amd64$R ./$PACK"
+		built_targets=$((built_targets+1))
+	fi
+	if ([ $XGOOS == "." ] || [ $XGOOS == "linux" ]) && ([ $XGOARCH == "." ] || [ $XGOARCH == "386" ]); then
+		echo "Compiling $PACK for linux/386..."
+		HOST=i686-linux PREFIX=/usr/local $BUILD_DEPS /deps $LIST_DEPS
+		GOOS=linux GOARCH=386 CGO_ENABLED=1 go get -d ./$PACK
+		sh -c "GOOS=linux GOARCH=386 CGO_ENABLED=1 go build $V $R $LDARGS -o $NAME-linux-386$R ./$PACK"
+		built_targets=$((built_targets+1))
+	fi	
+	if ([ $XGOOS == "." ] || [ $XGOOS == "linux" ]) && ([ $XGOARCH == "." ] || [ $XGOARCH == "arm" ]); then
+		echo "Compiling $PACK for linux/arm..."
+		CC=arm-linux-gnueabi-gcc HOST=arm-linux PREFIX=/usr/local/arm $BUILD_DEPS /deps $LIST_DEPS
+		CC=arm-linux-gnueabi-gcc GOOS=linux GOARCH=arm CGO_ENABLED=1 GOARM=5 go get -d ./$PACK
+		CC=arm-linux-gnueabi-gcc GOOS=linux GOARCH=arm CGO_ENABLED=1 GOARM=5 go build $V -o $NAME-linux-arm ./$PACK
+		built_targets=$((built_targets+1))
+	fi
+	
+	# Check and build for Windows targets
+	if ([ $XGOOS == "." ] || [ $XGOOS == "windows" ]) && ([ $XGOARCH == "." ] || [ $XGOARCH == "amd64" ]); then
+		echo "Compiling $PACK for windows/amd64..."
+		CC=x86_64-w64-mingw32-gcc HOST=x86_64-w64-mingw32 PREFIX=/usr/x86_64-w64-mingw32 $BUILD_DEPS /deps $LIST_DEPS
+		CC=x86_64-w64-mingw32-gcc GOOS=windows GOARCH=amd64 CGO_ENABLED=1 go get -d ./$PACK
+		CC=x86_64-w64-mingw32-gcc GOOS=windows GOARCH=amd64 CGO_ENABLED=1 go build  $V $R -o $NAME-windows-amd64$R.exe ./$PACK
+		built_targets=$((built_targets+1))
+	fi
+	
+	if ([ $XGOOS == "." ] || [ $XGOOS == "windows" ]) && ([ $XGOARCH == "." ] || [ $XGOARCH == "386" ]); then
+		echo "Compiling $PACK for windows/386..."
+		CC=i686-w64-mingw32-gcc HOST=i686-w64-mingw32 PREFIX=/usr/i686-w64-mingw32 $BUILD_DEPS /deps $LIST_DEPS
+		CC=i686-w64-mingw32-gcc GOOS=windows GOARCH=386 CGO_ENABLED=1 go get -d ./$PACK
+		CC=i686-w64-mingw32-gcc GOOS=windows GOARCH=386 CGO_ENABLED=1 go build $V -o $NAME-windows-386.exe ./$PACK
+		built_targets=$((built_targets+1))
+	fi
+	
+	# Check and build for OSX targets
+	if ([ $XGOOS == "." ] || [ $XGOOS == "darwin" ]) && ([ $XGOARCH == "." ] || [ $XGOARCH == "amd64" ]); then
+		echo "Compiling $PACK for darwin/amd64..."
+		CC=o64-clang HOST=x86_64-apple-darwin10 PREFIX=/usr/local $BUILD_DEPS /deps $LIST_DEPS
+		CC=o64-clang GOOS=darwin GOARCH=amd64 CGO_ENABLED=1 go get -d ./$PACK
+		CC=o64-clang GOOS=darwin GOARCH=amd64 CGO_ENABLED=1 go build -ldflags=-s $V $R -o $NAME-darwin-amd64$R ./$PACK
+		built_targets=$((built_targets+1))
+	fi
+	if ([ $XGOOS == "." ] || [ $XGOOS == "darwin" ]) && ([ $XGOARCH == "." ] || [ $XGOARCH == "386" ]); then
+		echo "Compiling for darwin/386..."
+		CC=o32-clang HOST=i386-apple-darwin10 PREFIX=/usr/local $BUILD_DEPS /deps $LIST_DEPS
+		CC=o32-clang GOOS=darwin GOARCH=386 CGO_ENABLED=1 go get -d ./$PACK
+		CC=o32-clang GOOS=darwin GOARCH=386 CGO_ENABLED=1 go build $V -o $NAME-darwin-386 ./$PACK
+		built_targets=$((built_targets+1))
+	fi
+done
 
-#echo "Compiling for darwin/386..."
-#CC=o32-clang HOST=i386-apple-darwin10 PREFIX=/usr/local $BUILD_DEPS /deps
-#CC=o32-clang GOOS=darwin GOARCH=386 CGO_ENABLED=1 go get -d ./$PACK
-#CC=o32-clang GOOS=darwin GOARCH=386 CGO_ENABLED=1 go build $V -o $NAME-darwin-386 ./$PACK
 
-# The binary files are the 3 last created files
-echo "Moving $PACK binaries to host folder..."
-ls -t | head -n 3
-cp `ls -t | head -n 3` /build
+# The binary files are the last created files
+echo "Moving $built_targets $PACK binaries to host folder..."
+ls -t | head -n $built_targets 
+cp `ls -t | head -n $built_targets ` /build
 
 echo "Build process completed"

--- a/dev-tools/packer/docker/xgo-image/base/build.sh
+++ b/dev-tools/packer/docker/xgo-image/base/build.sh
@@ -126,7 +126,7 @@ for TARGET in $TARGETS; do
 	fi
 	if ([ $XGOOS == "." ] || [ $XGOOS == "linux" ]) && ([ $XGOARCH == "." ] || [ $XGOARCH == "386" ]); then
 		echo "Compiling $PACK for linux/386..."
-		HOST=i686-linux PREFIX=/usr/local $BUILD_DEPS /deps $LIST_DEPS
+		CFLAGS=-m32 CXXFLAGS=-m32 LDFLAGS=-m32 HOST=i686-linux PREFIX=/usr/local $BUILD_DEPS /deps $LIST_DEPS
 		GOOS=linux GOARCH=386 CGO_ENABLED=1 go get -d ./$PACK
 		sh -c "GOOS=linux GOARCH=386 CGO_ENABLED=1 go build $V $R $LDARGS -o $NAME-linux-386$R ./$PACK"
 		built_targets=$((built_targets+1))

--- a/dev-tools/packer/docker/xgo-image/base/build.sh
+++ b/dev-tools/packer/docker/xgo-image/base/build.sh
@@ -26,6 +26,8 @@ else
         WORKING_DIRECTORY=$GOPATH/src/`dirname $1`
 fi
 
+echo "Working directory=$WORKING_DIRECTORY"
+
 if [ "$SOURCE" != "" ]; then
         mkdir -p ${DST_FOLDER}
         echo "Copying main source folder ${SRC_FOLDER} to folder ${DST_FOLDER}"
@@ -87,37 +89,37 @@ if [ "$STATIC" == "true" ]; then LDARGS=--ldflags\ \'-extldflags\ \"-static\"\';
 
 if [ -n $BEFORE_BUILD ]; then
 	chmod +x /scripts/$BEFORE_BUILD
-	echo "Execute /scripts/$BEFORE_BUILD $1"
-	/scripts/$BEFORE_BUILD $1
+	echo "Execute /scripts/$BEFORE_BUILD ${1}"
+	/scripts/$BEFORE_BUILD ${1}
 fi
 
 # Build for each platform individually
-#echo "Compiling for linux/amd64..."
+#echo "Compiling $PACK for linux/amd64..."
 #HOST=x86_64-linux PREFIX=/usr/local $BUILD_DEPS /deps
 #GOOS=linux GOARCH=amd64 CGO_ENABLED=1 go get -d ./$PACK
 #sh -c "GOOS=linux GOARCH=amd64 CGO_ENABLED=1 go build $V $R $LDARGS -o $NAME-linux-amd64$R ./$PACK"
 
-#echo "Compiling for linux/386..."
+#echo "Compiling $PACK for linux/386..."
 #HOST=i686-linux PREFIX=/usr/local $BUILD_DEPS /deps
 #GOOS=linux GOARCH=386 CGO_ENABLED=1 go get -d ./$PACK
 #sh -c "GOOS=linux GOARCH=386 CGO_ENABLED=1 go build $V $LDARGS -o $NAME-linux-386 ./$PACK"
 
-#echo "Compiling for linux/arm..."
+#echo "Compiling $PACK for linux/arm..."
 #CC=arm-linux-gnueabi-gcc HOST=arm-linux PREFIX=/usr/local/arm $BUILD_DEPS /deps
 #CC=arm-linux-gnueabi-gcc GOOS=linux GOARCH=arm CGO_ENABLED=1 GOARM=5 go get -d ./$PACK
 #CC=arm-linux-gnueabi-gcc GOOS=linux GOARCH=arm CGO_ENABLED=1 GOARM=5 go build $V -o $NAME-linux-arm ./$PACK
 
-echo "Compiling for windows/amd64..."
+echo "Compiling $PACK for windows/amd64..."
 CC=x86_64-w64-mingw32-gcc HOST=x86_64-w64-mingw32 PREFIX=/usr/x86_64-w64-mingw32 $BUILD_DEPS /deps
 CC=x86_64-w64-mingw32-gcc GOOS=windows GOARCH=amd64 CGO_ENABLED=1 go get -d ./$PACK
 CC=x86_64-w64-mingw32-gcc GOOS=windows GOARCH=amd64 CGO_ENABLED=1 go build  $V $R -o $NAME-windows-amd64$R.exe ./$PACK
 
-echo "Compiling for windows/386..."
+echo "Compiling $PACK for windows/386..."
 CC=i686-w64-mingw32-gcc HOST=i686-w64-mingw32 PREFIX=/usr/i686-w64-mingw32 $BUILD_DEPS /deps
 CC=i686-w64-mingw32-gcc GOOS=windows GOARCH=386 CGO_ENABLED=1 go get -d ./$PACK
 CC=i686-w64-mingw32-gcc GOOS=windows GOARCH=386 CGO_ENABLED=1 go build $V -o $NAME-windows-386.exe ./$PACK
-
-echo "Compiling for darwin/amd64..."
+$PACKz
+echo "Compiling $PACK for darwin/amd64..."
 CC=o64-clang HOST=x86_64-apple-darwin10 PREFIX=/usr/local $BUILD_DEPS /deps
 CC=o64-clang GOOS=darwin GOARCH=amd64 CGO_ENABLED=1 go get -d ./$PACK
 CC=o64-clang GOOS=darwin GOARCH=amd64 CGO_ENABLED=1 go build -ldflags=-s $V $R -o $NAME-darwin-amd64$R ./$PACK
@@ -127,5 +129,9 @@ CC=o64-clang GOOS=darwin GOARCH=amd64 CGO_ENABLED=1 go build -ldflags=-s $V $R -
 #CC=o32-clang GOOS=darwin GOARCH=386 CGO_ENABLED=1 go get -d ./$PACK
 #CC=o32-clang GOOS=darwin GOARCH=386 CGO_ENABLED=1 go build $V -o $NAME-darwin-386 ./$PACK
 
-echo "Moving binaries to host..."
+# The binary files are the 3 last created files
+echo "Moving $PACK binaries to host folder..."
+ls -t | head -n 3
 cp `ls -t | head -n 3` /build
+
+echo "Build process completed"

--- a/dev-tools/packer/docker/xgo-image/base/build_deps.sh
+++ b/dev-tools/packer/docker/xgo-image/base/build_deps.sh
@@ -1,23 +1,32 @@
 #!/bin/bash
 #
-# Contains the a dependency builder to iterate over all installed dependencies
+# Contains the dependency builder to iterate over all installed dependencies
 # and cross compile them to the requested target platform.
 # 
-# Usage: build_deps.sh <dependency folder>
+# Usage: build_deps.sh dependency_root_folder dependency1 dependency_2 ...
 #
 # Needed environment variables:
 #   CC     - C cross compiler to use for the build
 #   HOST   - Target platform to build (used to find the needed tool-chains)
 #   PREFIX - File-system path where to install the built binaries
+#   STATIC - true if the libraries are statically linked to the go application
 set -e
 
-# Remove any previous build leftovers, and copy a fresh working set (clean doesn't work for cross compiling)
-rm -rf /deps-build && cp -r $1 /deps-build
+DEP_ROOT_FOLDER=$1
 
-# Build all the dependencies (no order for now)
-for dep in `ls /deps-build`; do
+# Remove any previous build leftovers, and copy a fresh working set (clean doesn't work for cross compiling)
+rm -rf /deps-build && cp -r $DEP_ROOT_FOLDER /deps-build
+
+args=("$@")
+
+if [ "$STATIC" == "true" ]; then DISABLE_SHARED=-disable-shared; fi
+
+# Build all the dependencies
+for ((i=1; i<${#args[@]}; i++)); do
+	dep=${args[i]}
 	echo "Configuring dependency $dep for $HOST..."
-	(cd /deps-build/$dep && ./configure --disable-shared --host=$HOST --prefix=$PREFIX --silent)
+	if [ -f "/deps-build/$dep/autogen.sh" ]; then (cd /deps-build/$dep && ./autogen.sh); fi
+	(cd /deps-build/$dep && ./configure $DISABLE_SHARED --host=$HOST --prefix=$PREFIX --silent)
 
 	echo "Building dependency $dep for $HOST..."
 	(cd /deps-build/$dep && make --silent -j install)

--- a/dev-tools/packer/scripts/Makefile
+++ b/dev-tools/packer/scripts/Makefile
@@ -74,6 +74,7 @@ release-upload:
 run-interactive:
 	docker run -t -i -v $(shell pwd)/build:/build \
 		-v $(shell pwd)/xgo-scripts/:/scripts \
+		-v $(shell pwd)/../..:/source \
 		--entrypoint=bash tudorg/beats-builder-deb6
 
 .PHONY: images

--- a/dev-tools/packer/scripts/Makefile
+++ b/dev-tools/packer/scripts/Makefile
@@ -6,23 +6,23 @@ packer_absdir=$(shell dirname ${makefile_abspath})
 
 
 %/deb: % build/god-linux-386 build/god-linux-amd64 fpm-image
-	-ARCH=386 BEAT=$(@D) BUILDID=$(BUILDID) SNAPSHOT=$(SNAPSHOT) $(packer_absdir)/platforms/debian/build.sh
-	-ARCH=amd64 BEAT=$(@D) BUILDID=$(BUILDID) SNAPSHOT=$(SNAPSHOT) $(packer_absdir)/platforms/debian/build.sh
+	ARCH=386 BEAT=$(@D) BUILDID=$(BUILDID) SNAPSHOT=$(SNAPSHOT) $(packer_absdir)/platforms/debian/build.sh
+	ARCH=amd64 BEAT=$(@D) BUILDID=$(BUILDID) SNAPSHOT=$(SNAPSHOT) $(packer_absdir)/platforms/debian/build.sh
 
 %/rpm: % build/god-linux-386 build/god-linux-amd64 fpm-image
-	-ARCH=386 BEAT=$(@D) BUILDID=$(BUILDID) SNAPSHOT=$(SNAPSHOT) $(packer_absdir)/platforms/centos/build.sh
-	-ARCH=amd64 BEAT=$(@D) BUILDID=$(BUILDID) SNAPSHOT=$(SNAPSHOT) $(packer_absdir)/platforms/centos/build.sh
+	ARCH=386 BEAT=$(@D) BUILDID=$(BUILDID) SNAPSHOT=$(SNAPSHOT) $(packer_absdir)/platforms/centos/build.sh
+	ARCH=amd64 BEAT=$(@D) BUILDID=$(BUILDID) SNAPSHOT=$(SNAPSHOT) $(packer_absdir)/platforms/centos/build.sh
 
 %/darwin: %
-	-ARCH=amd64 BEAT=$(@D) BUILDID=$(BUILDID) SNAPSHOT=$(SNAPSHOT) $(packer_absdir)/platforms/darwin/build.sh
+	ARCH=amd64 BEAT=$(@D) BUILDID=$(BUILDID) SNAPSHOT=$(SNAPSHOT) $(packer_absdir)/platforms/darwin/build.sh
 
 %/win: %
-	-ARCH=386 BEAT=$(@D) BUILDID=$(BUILDID) SNAPSHOT=$(SNAPSHOT) $(packer_absdir)/platforms/windows/build.sh
-	-ARCH=amd64 BEAT=$(@D) BUILDID=$(BUILDID) SNAPSHOT=$(SNAPSHOT) $(packer_absdir)/platforms/windows/build.sh
+	ARCH=386 BEAT=$(@D) BUILDID=$(BUILDID) SNAPSHOT=$(SNAPSHOT) $(packer_absdir)/platforms/windows/build.sh
+	ARCH=amd64 BEAT=$(@D) BUILDID=$(BUILDID) SNAPSHOT=$(SNAPSHOT) $(packer_absdir)/platforms/windows/build.sh
 
 %/bin: %
-	-ARCH=386 BEAT=$(@D) BUILDID=$(BUILDID) SNAPSHOT=$(SNAPSHOT) $(packer_absdir)/platforms/binary/build.sh
-	-ARCH=amd64 BEAT=$(@D) BUILDID=$(BUILDID) SNAPSHOT=$(SNAPSHOT) $(packer_absdir)/platforms/binary/build.sh
+	ARCH=386 BEAT=$(@D) BUILDID=$(BUILDID) SNAPSHOT=$(SNAPSHOT) $(packer_absdir)/platforms/binary/build.sh
+	ARCH=amd64 BEAT=$(@D) BUILDID=$(BUILDID) SNAPSHOT=$(SNAPSHOT) $(packer_absdir)/platforms/binary/build.sh
 
 .PHONY: deps
 deps:

--- a/dev-tools/packer/scripts/Makefile
+++ b/dev-tools/packer/scripts/Makefile
@@ -6,23 +6,23 @@ packer_absdir=$(shell dirname ${makefile_abspath})
 
 
 %/deb: % build/god-linux-386 build/god-linux-amd64 fpm-image
-	ARCH=386 BEAT=$(@D) BUILDID=$(BUILDID) SNAPSHOT=$(SNAPSHOT) $(packer_absdir)/platforms/debian/build.sh
-	ARCH=amd64 BEAT=$(@D) BUILDID=$(BUILDID) SNAPSHOT=$(SNAPSHOT) $(packer_absdir)/platforms/debian/build.sh
+	-ARCH=386 BEAT=$(@D) BUILDID=$(BUILDID) SNAPSHOT=$(SNAPSHOT) $(packer_absdir)/platforms/debian/build.sh
+	-ARCH=amd64 BEAT=$(@D) BUILDID=$(BUILDID) SNAPSHOT=$(SNAPSHOT) $(packer_absdir)/platforms/debian/build.sh
 
 %/rpm: % build/god-linux-386 build/god-linux-amd64 fpm-image
-	ARCH=386 BEAT=$(@D) BUILDID=$(BUILDID) SNAPSHOT=$(SNAPSHOT) $(packer_absdir)/platforms/centos/build.sh
-	ARCH=amd64 BEAT=$(@D) BUILDID=$(BUILDID) SNAPSHOT=$(SNAPSHOT) $(packer_absdir)/platforms/centos/build.sh
+	-ARCH=386 BEAT=$(@D) BUILDID=$(BUILDID) SNAPSHOT=$(SNAPSHOT) $(packer_absdir)/platforms/centos/build.sh
+	-ARCH=amd64 BEAT=$(@D) BUILDID=$(BUILDID) SNAPSHOT=$(SNAPSHOT) $(packer_absdir)/platforms/centos/build.sh
 
 %/darwin: %
-	ARCH=amd64 BEAT=$(@D) BUILDID=$(BUILDID) SNAPSHOT=$(SNAPSHOT) $(packer_absdir)/platforms/darwin/build.sh
+	-ARCH=amd64 BEAT=$(@D) BUILDID=$(BUILDID) SNAPSHOT=$(SNAPSHOT) $(packer_absdir)/platforms/darwin/build.sh
 
 %/win: %
-	ARCH=386 BEAT=$(@D) BUILDID=$(BUILDID) SNAPSHOT=$(SNAPSHOT) $(packer_absdir)/platforms/windows/build.sh
-	ARCH=amd64 BEAT=$(@D) BUILDID=$(BUILDID) SNAPSHOT=$(SNAPSHOT) $(packer_absdir)/platforms/windows/build.sh
+	-ARCH=386 BEAT=$(@D) BUILDID=$(BUILDID) SNAPSHOT=$(SNAPSHOT) $(packer_absdir)/platforms/windows/build.sh
+	-ARCH=amd64 BEAT=$(@D) BUILDID=$(BUILDID) SNAPSHOT=$(SNAPSHOT) $(packer_absdir)/platforms/windows/build.sh
 
 %/bin: %
-	ARCH=386 BEAT=$(@D) BUILDID=$(BUILDID) SNAPSHOT=$(SNAPSHOT) $(packer_absdir)/platforms/binary/build.sh
-	ARCH=amd64 BEAT=$(@D) BUILDID=$(BUILDID) SNAPSHOT=$(SNAPSHOT) $(packer_absdir)/platforms/binary/build.sh
+	-ARCH=386 BEAT=$(@D) BUILDID=$(BUILDID) SNAPSHOT=$(SNAPSHOT) $(packer_absdir)/platforms/binary/build.sh
+	-ARCH=amd64 BEAT=$(@D) BUILDID=$(BUILDID) SNAPSHOT=$(SNAPSHOT) $(packer_absdir)/platforms/binary/build.sh
 
 .PHONY: deps
 deps:
@@ -70,12 +70,19 @@ package-upload:
 release-upload:
 	aws s3 cp --recursive --acl public-read build/upload s3://download.elasticsearch.org/beats/
 
-.PHONY: run-interactive
-run-interactive:
+.PHONY: run-interactive-builder-deb6
+run-interactive-builder-deb6:
 	docker run -t -i -v $(shell pwd)/build:/build \
 		-v $(shell pwd)/xgo-scripts/:/scripts \
 		-v $(shell pwd)/../..:/source \
 		--entrypoint=bash tudorg/beats-builder-deb6
+
+.PHONY: run-interactive-builder
+run-interactive-builder:
+	docker run -t -i -v $(shell pwd)/build:/build \
+		-v $(packer_absdir)/xgo-scripts/:/scripts \
+		-v $(shell pwd)/../..:/source \
+		--entrypoint=bash tudorg/beats-builder
 
 .PHONY: images
 images: xgo-image fpm-image go-daemon-image


### PR DESCRIPTION
Improvements.

1. install dependencies in the order given by `DEPS`
2. select which targets to build through `TARGETS` environment variable. (code from https://github.com/karalabe/xgo)
3. when building a dependency, `autogen.sh` is called when the file exists
4. when building a dependency, honors the `STATIC` environment variable to produce a static or shared library

Example:
myexample needs `libsodium`, `zeromq` and `czmq` shared libraries

```
	docker run --rm \
		-v $(abspath build):/build \
		-v $(abspath $(ES_BEATS)/dev-tools/packer/xgo-scripts):/scripts \
		-v $(abspath ../..):/source \
		-e PACK=myexample \
		-e DEPS=https://download.libsodium.org/libsodium/releases/libsodium-1.0.9.tar.gz\ http://download.zeromq.org/zeromq-4.1.4.tar.gz\ https://github.com/zeromq/czmq/archive/v3.0.2.tar.gz  \
		-e BEFORE_BUILD=before_build.sh \
		-e SOURCE=/source \
		-e TARGETS="linux/amd64" \
		-e BUILDID=${BUILDID} \
		tudorg/beats-builder \
		github.com/example/myexample

```



Note:
1. `xgo-image-deb6/base/build.sh` and `xgo-image/base/build.sh` are identical
2. `xgo-image-deb6/base/build_deps.sh` and `xgo-image/base/build_deps.sh` are identical
some cleaning can be done at a later stage