### PR TITLE
Create a MetricSet per host.

### DIFF
--- a/metricbeat/beater/event.go
+++ b/metricbeat/beater/event.go
@@ -127,7 +127,6 @@ func getTimestamp(event common.MapStr, timestamp common.Time) common.Time {
 // createEvent creates a new event from the fetched MetricSet data.
 func createEvent(
 	msw *metricSetWrapper,
-	host string,
 	event common.MapStr,
 	fetchErr error,
 	start time.Time,
@@ -136,7 +135,7 @@ func createEvent(
 	return eventBuilder{
 		moduleName:    msw.Module().Name(),
 		metricSetName: msw.Name(),
-		host:          host,
+		host:          msw.Host(),
 		startTime:     start,
 		fetchDuration: elapsed,
 		event:         event,

--- a/metricbeat/mb/example_metricset_test.go
+++ b/metricbeat/mb/example_metricset_test.go
@@ -38,7 +38,7 @@ func NewMetricSet(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	}, nil
 }
 
-func (ms *MetricSet) Fetch(host string) (common.MapStr, error) {
+func (ms *MetricSet) Fetch() (common.MapStr, error) {
 	// Fetch data from host and return the data.
 	return common.MapStr{
 		"someParam":  "value",

--- a/metricbeat/mb/mb.go
+++ b/metricbeat/mb/mb.go
@@ -50,19 +50,22 @@ func (m *BaseModule) UnpackConfig(to interface{}) error {
 type MetricSet interface {
 	Name() string   // Name returns the name of the MetricSet.
 	Module() Module // Module returns the parent Module for the MetricSet.
+	Host() string   // Host returns a hostname or other module specific value
+	// that identifies a specific host or service instance from which to collect
+	// metrics.
 }
 
 // EventFetcher is a MetricSet that returns a single event when collecting data.
 type EventFetcher interface {
 	MetricSet
-	Fetch(host string) (common.MapStr, error)
+	Fetch() (common.MapStr, error)
 }
 
 // EventsFetcher is a MetricSet that returns a multiple events when collecting
 // data.
 type EventsFetcher interface {
 	MetricSet
-	Fetch(host string) ([]common.MapStr, error)
+	Fetch() ([]common.MapStr, error)
 }
 
 // BaseMetricSet implements the MetricSet interface.
@@ -73,6 +76,7 @@ type EventsFetcher interface {
 type BaseMetricSet struct {
 	name   string
 	module Module
+	host   string
 }
 
 // Name returns the name of the MetricSet. It should not include the name of
@@ -84,6 +88,12 @@ func (b *BaseMetricSet) Name() string {
 // Module returns the parent Module for the MetricSet.
 func (b *BaseMetricSet) Module() Module {
 	return b.module
+}
+
+// Host returns the hostname or other module specific value that identifies a
+// specific host or service instance from which to collect metrics.
+func (b *BaseMetricSet) Host() string {
+	return b.host
 }
 
 // Configuration types

--- a/metricbeat/mb/mb_test.go
+++ b/metricbeat/mb/mb_test.go
@@ -96,6 +96,21 @@ func TestNewModulesWithAllDisabled(t *testing.T) {
 	assert.Equal(t, ErrAllModulesDisabled, err)
 }
 
+// TestNewModulesDuplicateHosts verifies that an error is returned by
+// NewModules if any module configuration contains duplicate hosts.
+func TestNewModulesDuplicateHosts(t *testing.T) {
+	r := newTestRegistry(t)
+
+	c := newConfig(t, map[string]interface{}{
+		"module":     moduleName,
+		"metricsets": []string{metricSetName},
+		"hosts":      []string{"a", "b", "a"},
+	})
+
+	_, err := NewModules(c, r)
+	assert.Error(t, err)
+}
+
 func newTestRegistry(t testing.TB) *Register {
 	r := NewRegister()
 

--- a/metricbeat/mb/testing/modules.go
+++ b/metricbeat/mb/testing/modules.go
@@ -16,7 +16,7 @@ that Metricbeat does it and with the same validations.
 
 	func TestFetch(t *testing.T) {
 		f := mbtest.NewEventFetcher(t, getConfig())
-		event, err := f.Fetch(f.Module().Config().Hosts[0])
+		event, err := f.Fetch()
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/metricbeat/module/apache/status/status_integration_test.go
+++ b/metricbeat/module/apache/status/status_integration_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestFetch(t *testing.T) {
 	f := mbtest.NewEventFetcher(t, getConfig())
-	event, err := f.Fetch(f.Module().Config().Hosts[0])
+	event, err := f.Fetch()
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}

--- a/metricbeat/module/mysql/status/status_integration_test.go
+++ b/metricbeat/module/mysql/status/status_integration_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestFetch(t *testing.T) {
 	f := mbtest.NewEventFetcher(t, getConfig())
-	event, err := f.Fetch(f.Module().Config().Hosts[0])
+	event, err := f.Fetch()
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}

--- a/metricbeat/module/redis/info/info_integration_test.go
+++ b/metricbeat/module/redis/info/info_integration_test.go
@@ -22,7 +22,7 @@ var redisHost = redis.GetRedisEnvHost() + ":" + redis.GetRedisEnvPort()
 
 func TestFetch(t *testing.T) {
 	f := mbtest.NewEventFetcher(t, getConfig(""))
-	event, err := f.Fetch(f.Module().Config().Hosts[0])
+	event, err := f.Fetch()
 	if err != nil {
 		t.Fatal("fetch", err)
 	}
@@ -45,7 +45,7 @@ func TestKeyspace(t *testing.T) {
 
 	// Fetch metrics
 	f := mbtest.NewEventFetcher(t, getConfig(""))
-	event, err := f.Fetch(f.Module().Config().Hosts[0])
+	event, err := f.Fetch()
 	if err != nil {
 		t.Fatal("fetch", err)
 	}
@@ -65,21 +65,21 @@ func TestPasswords(t *testing.T) {
 
 	// Test Fetch metrics with missing password
 	f := mbtest.NewEventFetcher(t, getConfig(""))
-	_, err = f.Fetch(f.Module().Config().Hosts[0])
+	_, err = f.Fetch()
 	if assert.Error(t, err, "missing password") {
 		assert.Contains(t, err, "NOAUTH Authentication required.")
 	}
 
 	// Config redis and metricset with an invalid password
 	f = mbtest.NewEventFetcher(t, getConfig("blah"))
-	_, err = f.Fetch(f.Module().Config().Hosts[0])
+	_, err = f.Fetch()
 	if assert.Error(t, err, "invalid password") {
 		assert.Contains(t, err, "ERR invalid password")
 	}
 
 	// Config redis and metricset with a valid password
 	f = mbtest.NewEventFetcher(t, getConfig(password))
-	_, err = f.Fetch(f.Module().Config().Hosts[0])
+	_, err = f.Fetch()
 	assert.NoError(t, err, "valid password")
 }
 

--- a/metricbeat/module/system/cpu/cpu.go
+++ b/metricbeat/module/system/cpu/cpu.go
@@ -27,7 +27,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 }
 
 // Fetch fetches CPU metrics from the OS.
-func (m *MetricSet) Fetch(host string) (common.MapStr, error) {
+func (m *MetricSet) Fetch() (common.MapStr, error) {
 	cpuStat, err := system.GetCpuTimes()
 	if err != nil {
 		return nil, errors.Wrap(err, "cpu times")

--- a/metricbeat/module/system/filesystem/filesystem.go
+++ b/metricbeat/module/system/filesystem/filesystem.go
@@ -33,7 +33,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 
 // Fetch fetches filesystem metrics for all mounted filesystems and returns
 // an event for each mount point.
-func (m *MetricSet) Fetch(host string) ([]common.MapStr, error) {
+func (m *MetricSet) Fetch() ([]common.MapStr, error) {
 	fss, err := system.GetFileSystemList()
 	if err != nil {
 		return nil, errors.Wrap(err, "filesystem list")

--- a/metricbeat/module/system/fsstats/fsstats.go
+++ b/metricbeat/module/system/fsstats/fsstats.go
@@ -33,7 +33,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 
 // Fetch fetches filesystem metrics for all mounted filesystems and returns
 // a single event containing aggregated data.
-func (m *MetricSet) Fetch(host string) (common.MapStr, error) {
+func (m *MetricSet) Fetch() (common.MapStr, error) {
 	fss, err := system.GetFileSystemList()
 	if err != nil {
 		return nil, errors.Wrap(err, "filesystem list")

--- a/metricbeat/module/system/memory/memory.go
+++ b/metricbeat/module/system/memory/memory.go
@@ -27,7 +27,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 }
 
 // Fetch fetches memory metrics from the OS.
-func (m *MetricSet) Fetch(host string) (event common.MapStr, err error) {
+func (m *MetricSet) Fetch() (event common.MapStr, err error) {
 	memStat, err := system.GetMemory()
 	if err != nil {
 		return nil, errors.Wrap(err, "memory")

--- a/metricbeat/module/system/process/process.go
+++ b/metricbeat/module/system/process/process.go
@@ -40,7 +40,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 
 // Fetch fetches metrics for all processes. It iterates over each PID and
 // collects process metadata, CPU metrics, and memory metrics.
-func (m *MetricSet) Fetch(host string) ([]common.MapStr, error) {
+func (m *MetricSet) Fetch() ([]common.MapStr, error) {
 	procs, err := m.stats.GetProcStats()
 	if err != nil {
 		return nil, errors.Wrap(err, "process stats")

--- a/metricbeat/module/zookeeper/mntr/mntr.go
+++ b/metricbeat/module/zookeeper/mntr/mntr.go
@@ -54,8 +54,8 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 
 // Fetch fetches metrics from ZooKeeper by making a tcp connection to the
 // command port and sending the "mntr" command and parsing the output.
-func (m *MetricSet) Fetch(host string) (common.MapStr, error) {
-	outputReader, err := zookeeper.RunCommand("mntr", host, m.Module().Config().Timeout)
+func (m *MetricSet) Fetch() (common.MapStr, error) {
+	outputReader, err := zookeeper.RunCommand("mntr", m.Host(), m.Module().Config().Timeout)
 	if err != nil {
 		return nil, errors.Wrap(err, "mntr command failed")
 	}

--- a/metricbeat/module/zookeeper/mntr/mntr_integration_test.go
+++ b/metricbeat/module/zookeeper/mntr/mntr_integration_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestFetch(t *testing.T) {
 	f := mbtest.NewEventFetcher(t, getConfig())
-	event, err := f.Fetch(f.Module().Config().Hosts[0])
+	event, err := f.Fetch()
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}


### PR DESCRIPTION
This change ensures a single MetricSet instance is used per host. Creating a MetricSet per host simplifies MetricSet implementations because the MetricSet does not need to concern itself with multiple hosts. Previously a single MetricSet instance was reused for fetching data from multiple hosts. Its Fetch() method was invoked by various goroutines so any mutable state had to be made concurrency-safe which added a source of complexity. Now since a MetricSet is used by only one host, it's Fetch() method is only invoked by a single goroutine so no synchronization is required to protect data members.

Added validation to ensure that the same host was not defined more than once in the hosts configuration.

Fixed an issue where if multiple instances of the same module type were used, that only the expvar metrics from the last one would be exported.