### PR TITLE
Fix json system test

### DIFF
--- a/filebeat/tests/system/test_json.py
+++ b/filebeat/tests/system/test_json.py
@@ -157,6 +157,7 @@ class Test(BaseTest):
             json=dict(
                 keys_under_root=True),
             multiline=True,
+            match="after",
             pattern="^\\["
         )
 


### PR DESCRIPTION
Tests did fail because match was empty and this was not accepted anymore by ucfg.