### PR TITLE
Backport: Re-factor to fix high CPU usage on windows (#1562)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -31,6 +31,8 @@ https://github.com/elastic/beats/compare/v1.2.2...1.2[Check the HEAD diff]
 
 *Topbeat*
 
+- Fixed high CPU usage when using filtering under Windows. {pull}1562[1562]
+
 *Filebeat*
 
 *Winlogbeat*

--- a/topbeat/beat/sigar_test.go
+++ b/topbeat/beat/sigar_test.go
@@ -83,12 +83,13 @@ func TestGetProcess(t *testing.T) {
 
 	for _, pid := range pids {
 
-		process, err := GetProcess(pid, "")
-
+		process, err := newProcess(pid)
 		if err != nil {
 			continue
 		}
 		assert.NotNil(t, process)
+		err = process.getDetails("")
+		assert.NoError(t, err)
 
 		assert.True(t, (process.Pid > 0))
 		assert.True(t, (process.Ppid >= 0))
@@ -166,7 +167,11 @@ func BenchmarkGetProcess(b *testing.B) {
 			cmdline = p.CmdLine
 		}
 
-		process, err := GetProcess(pid, cmdline)
+		process, err := newProcess(pid)
+		if err != nil {
+			continue
+		}
+		err = process.getDetails(cmdline)
 		if err != nil {
 			continue
 		}

--- a/topbeat/beat/topbeat_test.go
+++ b/topbeat/beat/topbeat_test.go
@@ -12,13 +12,16 @@ func TestMatchProcs(t *testing.T) {
 	var beat = Topbeat{}
 
 	beat.procs = []string{".*"}
+	beat.initProcStats()
 	assert.True(t, beat.MatchProcess("topbeat"))
 
 	beat.procs = []string{"topbeat"}
+	beat.initProcStats()
 	assert.False(t, beat.MatchProcess("burn"))
 
 	// match no processes
 	beat.procs = []string{"$^"}
+	beat.initProcStats()
 	assert.False(t, beat.MatchProcess("burn"))
 }
 


### PR DESCRIPTION
* Re-factor to fix high CPU usage on windows

This decouples getting the basic state information from getting the more
detailed information.  The reason is that filtering only needs the name, but
the code was getting all details and then apply filtering. Getting the command
line is expensive on Windows, so that contributed to #1460.

What made it worse is that due to filtering, the command line cache was
invalidated on each run, which explains why topbeat was consuming more CPU when
filtering out processes than when not.

Fixes #1460.

This also pre-compiles the regexps, which brings some slight CPU usage improvements
and uncovers compilation errors earlier.