### PR TITLE
Add to the readme how to create and enable the env

### DIFF
--- a/dev-tools/README.md
+++ b/dev-tools/README.md
@@ -1,5 +1,8 @@
-The following scripts are used by the unified release process:
+Available scripts
+-----------------
 
+
+The following scripts are used by the unified release process:
 
 | File                 | Description |
 |----------------------|-------------|
@@ -26,4 +29,23 @@ Import / export the dashboards of a single Beat:
 | import_dashboards.ps1 | Powershell script to import the Beat dashboards from a local directory in Elasticsearch |
 | export_dashboards.py  | Python script to export the Beat dashboards from Elasticsearch to a local directory|
 
+Running export_dashboards.py in environment
+----------------------------------------------
 
+If you are running the python script for the first time, you need to create the
+environment by running the following commands in the `beats/dev-tools`
+directory:
+
+```
+virtualenv env
+. env/bin/activate
+pip install -r requirements.txt
+```
+
+This creates the environment that contains all the python packages required to
+run the `export_dashboards.py` script. Thus, for the next runs you just need
+to enable the enviroment:
+
+```
+. env/bin/activate
+```

--- a/dev-tools/requirements.txt
+++ b/dev-tools/requirements.txt
@@ -1,0 +1,1 @@
+elasticsearch


### PR DESCRIPTION
Add to the `dev-tools/README` how to create and enable the environment that contains all the python packages required to run the `export_dashboards.py` script. 
The same info is also available in the docs, but it's sometime more handy to be closer to script in the readme file.