### PR TITLE
Remove reference to the multiline examples

### DIFF
--- a/libbeat/docs/regexp.asciidoc
+++ b/libbeat/docs/regexp.asciidoc
@@ -18,7 +18,6 @@ coming[5.0.0-beta1]
 
 NOTE: We recommend that you wrap regular expressions in single quotation marks to work around YAML's string escaping rules. For example, `'^\[?[0-9][0-9]:?[0-9][0-9]|^[[:graph:]]+'`.
 
-For more regexp examples, see <<multiline-examples>>.
 
 [float]
 === Supported Patterns


### PR DESCRIPTION
Removing the multiline-examples reference from libbeat as the section is missing.

@dedemorton I had to remove the `multiline-examples` reference from regexp as the docs are failing. Please have a look, maybe you forgot to commit a file with the examples. Thanks!