### PR TITLE
Check OS before running a Metricbeat system test

### DIFF
--- a/metricbeat/tests/system/test_base.py
+++ b/metricbeat/tests/system/test_base.py
@@ -1,8 +1,11 @@
 import re
+import sys
+import unittest
 from metricbeat import BaseTest
 
 
 class Test(BaseTest):
+    @unittest.skipUnless(re.match("(?i)win|linux|darwin|openbsd", sys.platform), "os")
     def test_start_stop(self):
         """
         Metricbeat starts and stops without error.
@@ -21,7 +24,7 @@ class Test(BaseTest):
         self.assertNotRegexpMatches(log, "ERR|WARN")
 
         # Ensure all Beater stages are used.
-        self.assertRegexpMatches(log, re.compile(".*".join([
+        self.assertRegexpMatches(log, re.compile("(?i).*".join([
             "Setup Beat: metricbeat",
             "metricbeat start running",
             "metricbeat cleanup"


### PR DESCRIPTION
Check OS before running system test because it depends on an OS specific MetricSet.