### PR TITLE
Introduce ufcg for prospector

### DIFF
--- a/filebeat/config/config.go
+++ b/filebeat/config/config.go
@@ -1,11 +1,9 @@
 package config
 
 import (
-	"fmt"
 	"log"
 	"os"
 	"path/filepath"
-	"regexp"
 	"time"
 
 	"github.com/elastic/beats/libbeat/cfgfile"
@@ -17,9 +15,7 @@ import (
 // Defaults for config variables which are not set
 const (
 	DefaultRegistryFile                      = "registry"
-	DefaultIgnoreOlderDuration time.Duration = 0
-	DefaultCloseOlderDuration  time.Duration = 1 * time.Hour
-	DefaultScanFrequency       time.Duration = 10 * time.Second
+	DefaultCloseOlder          time.Duration = 1 * time.Hour
 	DefaultSpoolSize           uint64        = 2048
 	DefaultIdleTimeout         time.Duration = 5 * time.Second
 	DefaultHarvesterBufferSize int           = 16 << 10 // 16384
@@ -38,61 +34,12 @@ type Config struct {
 }
 
 type FilebeatConfig struct {
-	Prospectors  []ProspectorConfig
-	SpoolSize    uint64        `config:"spool_size"`
-	PublishAsync bool          `config:"publish_async"`
-	IdleTimeout  time.Duration `config:"idle_timeout"`
-	RegistryFile string        `config:"registry_file"`
-	ConfigDir    string        `config:"config_dir"`
-}
-
-type ProspectorConfig struct {
-	ExcludeFiles          []*regexp.Regexp `config:"exclude_files"`
-	Harvester             HarvesterConfig  `config:",inline"`
-	Input                 string
-	IgnoreOlder           string `config:"ignore_older"`
-	IgnoreOlderDuration   time.Duration
-	Paths                 []string
-	ScanFrequency         string `config:"scan_frequency"`
-	ScanFrequencyDuration time.Duration
-}
-
-type HarvesterConfig struct {
-	common.EventMetadata `config:",inline"` // Fields and tags to add to events.
-
-	BufferSize         int    `config:"harvester_buffer_size"`
-	DocumentType       string `config:"document_type"`
-	Encoding           string `config:"encoding"`
-	InputType          string `config:"input_type"`
-	TailFiles          bool   `config:"tail_files"`
-	Backoff            string `config:"backoff"`
-	BackoffDuration    time.Duration
-	BackoffFactor      int    `config:"backoff_factor"`
-	MaxBackoff         string `config:"max_backoff"`
-	MaxBackoffDuration time.Duration
-	CloseOlder         string `config:"close_older"`
-	CloseOlderDuration time.Duration
-	ForceCloseFiles    bool             `config:"force_close_files"`
-	ExcludeLines       []*regexp.Regexp `config:"exclude_lines"`
-	IncludeLines       []*regexp.Regexp `config:"include_lines"`
-	MaxBytes           int              `config:"max_bytes"`
-	Multiline          *MultilineConfig `config:"multiline"`
-	JSON               *JSONConfig      `config:"json"`
-}
-
-type JSONConfig struct {
-	MessageKey    string `config:"message_key"`
-	KeysUnderRoot bool   `config:"keys_under_root"`
-	OverwriteKeys bool   `config:"overwrite_keys"`
-	AddErrorKey   bool   `config:"add_error_key"`
-}
-
-type MultilineConfig struct {
-	Negate   bool           `config:"negate"`
-	Match    string         `config:"match"       validate:"required"`
-	MaxLines *int           `config:"max_lines"`
-	Pattern  *regexp.Regexp `config:"pattern"`
-	Timeout  *time.Duration `config:"timeout"     validate:"positive"`
+	Prospectors  []*common.Config `config:"prospectors"`
+	SpoolSize    uint64           `config:"spool_size"`
+	PublishAsync bool             `config:"publish_async"`
+	IdleTimeout  time.Duration    `config:"idle_timeout"`
+	RegistryFile string           `config:"registry_file"`
+	ConfigDir    string           `config:"config_dir"`
 }
 
 const (
@@ -104,13 +51,6 @@ const (
 var ValidInputType = map[string]struct{}{
 	StdinInputType: {},
 	LogInputType:   {},
-}
-
-func (c *MultilineConfig) Validate() error {
-	if c.Match != "after" && c.Match != "before" {
-		return fmt.Errorf("unknown matcher type: %s", c.Match)
-	}
-	return nil
 }
 
 // getConfigFiles returns list of config files.

--- a/filebeat/config/config_test.go
+++ b/filebeat/config/config_test.go
@@ -10,41 +10,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestReadConfig(t *testing.T) {
-	absPath, err := filepath.Abs("../tests/files/")
-
-	assert.NotNil(t, absPath)
-	assert.Nil(t, err)
-
-	config := &Config{}
-
-	err = cfgfile.Read(config, absPath+"/config.yml")
-
-	assert.Nil(t, err)
-
-	assert.Equal(t, uint64(DefaultSpoolSize), config.Filebeat.SpoolSize)
-	assert.Equal(t, "/prospectorConfigs/", config.Filebeat.ConfigDir)
-
-	prospectors := config.Filebeat.Prospectors
-
-	// Check if multiple paths were read in
-	assert.Equal(t, 3, len(prospectors))
-
-	// Check if full array can be read. Assumed that are ordered same as in config file
-	assert.Equal(t, 2, len(prospectors[0].Paths))
-	assert.Equal(t, "/var/log/s*.log", prospectors[0].Paths[1])
-	assert.Equal(t, "log", prospectors[0].Input)
-	assert.Equal(t, 3, len(prospectors[0].Harvester.Fields))
-	assert.Equal(t, uint64(1), prospectors[0].Harvester.Fields["review"])
-	assert.Equal(t, "0", prospectors[0].IgnoreOlder)
-	assert.Equal(t, "1h", prospectors[0].Harvester.CloseOlder)
-	assert.Equal(t, "10s", prospectors[0].ScanFrequency)
-
-	assert.Equal(t, "stdin", prospectors[2].Input)
-	assert.Equal(t, 0, len(prospectors[2].Paths))
-	assert.Equal(t, "", prospectors[1].ScanFrequency)
-}
-
 func TestReadConfig2(t *testing.T) {
 	// Tests with different params from config file
 	absPath, err := filepath.Abs("../tests/files/")

--- a/filebeat/crawler/config.go
+++ b/filebeat/crawler/config.go
@@ -1,0 +1,30 @@
+package crawler
+
+import (
+	"regexp"
+	"time"
+
+	"github.com/elastic/beats/filebeat/harvester"
+)
+
+const (
+	DefaultIgnoreOlder   time.Duration = 0
+	DefaultScanFrequency time.Duration = 10 * time.Second
+)
+
+var (
+	defaultConfig = prospectorConfig{
+		IgnoreOlder:   DefaultIgnoreOlder,
+		ScanFrequency: DefaultScanFrequency,
+	}
+)
+
+type prospectorConfig struct {
+	ExcludeFiles  []*regexp.Regexp          `config:"exclude_files"`
+	Harvester     harvester.HarvesterConfig `config:",inline"`
+	IgnoreOlder   time.Duration             `config:"ignore_older"`
+	Paths         []string                  `config:"paths"`
+	ScanFrequency time.Duration             `config:"scan_frequency"`
+}
+
+func (p *prospectorConfig) Validate() error { return nil }

--- a/filebeat/crawler/crawler.go
+++ b/filebeat/crawler/crawler.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/elastic/beats/filebeat/config"
 	"github.com/elastic/beats/filebeat/input"
+	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 )
 
@@ -28,7 +28,7 @@ type Crawler struct {
 	wg          sync.WaitGroup
 }
 
-func (c *Crawler) Start(prospectorConfigs []config.ProspectorConfig, eventChan chan *input.FileEvent) error {
+func (c *Crawler) Start(prospectorConfigs []*common.Config, eventChan chan *input.FileEvent) error {
 
 	if len(prospectorConfigs) == 0 {
 		return fmt.Errorf("No prospectors defined. You must have at least one prospector defined in the config file.")
@@ -38,8 +38,6 @@ func (c *Crawler) Start(prospectorConfigs []config.ProspectorConfig, eventChan c
 
 	// Prospect the globs/paths given on the command line and launch harvesters
 	for _, prospectorConfig := range prospectorConfigs {
-
-		logp.Debug("prospector", "File Configs: %v", prospectorConfig.Paths)
 
 		prospector, err := NewProspector(prospectorConfig, c.Registrar, eventChan)
 		if err != nil {

--- a/filebeat/crawler/crawler_test.go
+++ b/filebeat/crawler/crawler_test.go
@@ -5,15 +5,15 @@ package crawler
 import (
 	"testing"
 
-	"github.com/elastic/beats/filebeat/config"
 	"github.com/elastic/beats/filebeat/input"
+	"github.com/elastic/beats/libbeat/common"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestCrawlerStartError(t *testing.T) {
 	crawler := Crawler{}
 	channel := make(chan *input.FileEvent, 1)
-	prospectorConfigs := []config.ProspectorConfig{}
+	prospectorConfigs := []*common.Config{}
 
 	error := crawler.Start(prospectorConfigs, channel)
 

--- a/filebeat/crawler/prospector_log.go
+++ b/filebeat/crawler/prospector_log.go
@@ -5,7 +5,6 @@ import (
 	"path/filepath"
 	"time"
 
-	cfg "github.com/elastic/beats/filebeat/config"
 	"github.com/elastic/beats/filebeat/harvester"
 	"github.com/elastic/beats/filebeat/input"
 	"github.com/elastic/beats/libbeat/logp"
@@ -14,14 +13,14 @@ import (
 type ProspectorLog struct {
 	Prospector *Prospector
 	lastscan   time.Time
-	config     cfg.ProspectorConfig
+	config     prospectorConfig
 }
 
 func NewProspectorLog(p *Prospector) (*ProspectorLog, error) {
 
 	prospectorer := &ProspectorLog{
 		Prospector: p,
-		config:     p.ProspectorConfig,
+		config:     p.config,
 	}
 
 	return prospectorer, nil

--- a/filebeat/crawler/prospector_test.go
+++ b/filebeat/crawler/prospector_test.go
@@ -5,173 +5,58 @@ package crawler
 import (
 	"regexp"
 	"testing"
-	"time"
 
 	"github.com/elastic/beats/filebeat/config"
+	"github.com/elastic/beats/filebeat/harvester"
+	"github.com/elastic/beats/libbeat/common"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestProspectorInit(t *testing.T) {
+func TestProspectorDefaultConfigs(t *testing.T) {
 
-	prospectorConfig := config.ProspectorConfig{
-		ScanFrequency: "15s",
-		IgnoreOlder:   "100m",
-		Harvester: config.HarvesterConfig{
-			BufferSize: 100,
-			TailFiles:  true,
-		},
-	}
-
-	prospector := Prospector{
-		ProspectorConfig: prospectorConfig,
-	}
-
-	assert.NotNil(t, prospector)
-
-	prospector.Init()
-
-	// Predefined values expected
-	assert.Equal(t, 100*time.Minute, prospector.ProspectorConfig.IgnoreOlderDuration)
-	assert.Equal(t, 15*time.Second, prospector.ProspectorConfig.ScanFrequencyDuration)
-	assert.Equal(t, 100, prospector.ProspectorConfig.Harvester.BufferSize)
-	assert.Equal(t, true, prospector.ProspectorConfig.Harvester.TailFiles)
-}
-
-func TestProspectorInitEmpty(t *testing.T) {
-
-	prospectorConfig := config.ProspectorConfig{
-		ScanFrequency: "",
-		IgnoreOlder:   "",
-		Harvester: config.HarvesterConfig{
-			BufferSize: 0,
-		},
-	}
-
-	prospector := Prospector{
-		ProspectorConfig: prospectorConfig,
-	}
-
-	prospector.Init()
+	prospector, err := NewProspector(common.NewConfig(), nil, nil)
+	assert.NoError(t, err)
 
 	// Default values expected
-	assert.Equal(t, config.DefaultIgnoreOlderDuration, prospector.ProspectorConfig.IgnoreOlderDuration)
-	assert.Equal(t, config.DefaultScanFrequency, prospector.ProspectorConfig.ScanFrequencyDuration)
-}
-
-func TestProspectorInitNotSet(t *testing.T) {
-
-	prospectorConfig := config.ProspectorConfig{}
-
-	prospector := Prospector{
-		ProspectorConfig: prospectorConfig,
-	}
-
-	prospector.Init()
-
-	// Default values expected
-	assert.Equal(t, config.DefaultIgnoreOlderDuration, prospector.ProspectorConfig.IgnoreOlderDuration)
-	assert.Equal(t, config.DefaultScanFrequency, prospector.ProspectorConfig.ScanFrequencyDuration)
-	assert.Equal(t, config.DefaultHarvesterBufferSize, prospector.ProspectorConfig.Harvester.BufferSize)
-	assert.Equal(t, config.DefaultTailFiles, prospector.ProspectorConfig.Harvester.TailFiles)
-	assert.Equal(t, config.DefaultBackoff, prospector.ProspectorConfig.Harvester.BackoffDuration)
-	assert.Equal(t, config.DefaultBackoffFactor, prospector.ProspectorConfig.Harvester.BackoffFactor)
-	assert.Equal(t, config.DefaultMaxBackoff, prospector.ProspectorConfig.Harvester.MaxBackoffDuration)
-	assert.Equal(t, config.DefaultForceCloseFiles, prospector.ProspectorConfig.Harvester.ForceCloseFiles)
-	assert.Equal(t, config.DefaultMaxBytes, prospector.ProspectorConfig.Harvester.MaxBytes)
-}
-
-func TestProspectorInitScanFrequency0(t *testing.T) {
-
-	prospectorConfig := config.ProspectorConfig{
-		ScanFrequency: "0s",
-	}
-
-	prospector := Prospector{
-		ProspectorConfig: prospectorConfig,
-	}
-
-	prospector.Init()
-
-	var zero time.Duration = 0
-	// 0 expected
-	assert.Equal(t, zero, prospector.ProspectorConfig.ScanFrequencyDuration)
-}
-
-func TestProspectorInitCloseOlder0(t *testing.T) {
-
-	prospectorConfig := config.ProspectorConfig{
-		Harvester: config.HarvesterConfig{
-			CloseOlder: "0",
-		},
-	}
-
-	prospector := Prospector{
-		ProspectorConfig: prospectorConfig,
-	}
-
-	prospector.Init()
-
-	var zero time.Duration = 0
-	// 0 expected
-	assert.Equal(t, zero, prospector.ProspectorConfig.Harvester.CloseOlderDuration)
-}
-
-func TestProspectorInitInvalidScanFrequency(t *testing.T) {
-
-	prospectorConfig := config.ProspectorConfig{
-		ScanFrequency: "abc",
-	}
-
-	prospector := Prospector{
-		ProspectorConfig: prospectorConfig,
-	}
-
-	err := prospector.Init()
-	assert.NotNil(t, err)
-}
-
-func TestProspectorInitInvalidIgnoreOlder(t *testing.T) {
-
-	prospectorConfig := config.ProspectorConfig{
-		IgnoreOlder: "abc",
-	}
-
-	prospector := Prospector{
-		ProspectorConfig: prospectorConfig,
-	}
-
-	err := prospector.Init()
-	assert.NotNil(t, err)
+	assert.Equal(t, DefaultIgnoreOlder, prospector.config.IgnoreOlder)
+	assert.Equal(t, DefaultScanFrequency, prospector.config.ScanFrequency)
+	assert.Equal(t, config.DefaultHarvesterBufferSize, prospector.config.Harvester.BufferSize)
+	assert.Equal(t, config.DefaultTailFiles, prospector.config.Harvester.TailFiles)
+	assert.Equal(t, config.DefaultBackoff, prospector.config.Harvester.BackoffDuration)
+	assert.Equal(t, config.DefaultBackoffFactor, prospector.config.Harvester.BackoffFactor)
+	assert.Equal(t, config.DefaultMaxBackoff, prospector.config.Harvester.MaxBackoffDuration)
+	assert.Equal(t, config.DefaultForceCloseFiles, prospector.config.Harvester.ForceCloseFiles)
+	assert.Equal(t, config.DefaultMaxBytes, prospector.config.Harvester.MaxBytes)
 }
 
 func TestProspectorInitInputTypeLog(t *testing.T) {
 
-	prospectorConfig := config.ProspectorConfig{
+	prospectorConfig := prospectorConfig{
 		Paths: []string{"testpath1", "testpath2"},
-		Harvester: config.HarvesterConfig{
+		Harvester: harvester.HarvesterConfig{
 			InputType: "log",
 		},
 	}
 
 	prospector := Prospector{
-		ProspectorConfig: prospectorConfig,
+		config: prospectorConfig,
 	}
 
 	err := prospector.Init()
 	assert.Nil(t, err)
-	assert.Equal(t, "log", prospector.ProspectorConfig.Harvester.InputType)
+	assert.Equal(t, "log", prospector.config.Harvester.InputType)
 }
 
 func TestProspectorInitInputTypeLogError(t *testing.T) {
 
-	prospectorConfig := config.ProspectorConfig{
-		Harvester: config.HarvesterConfig{
+	prospectorConfig := prospectorConfig{
+		Harvester: harvester.HarvesterConfig{
 			InputType: "log",
 		},
 	}
 
 	prospector := Prospector{
-		ProspectorConfig: prospectorConfig,
+		config: prospectorConfig,
 	}
 
 	err := prospector.Init()
@@ -181,49 +66,49 @@ func TestProspectorInitInputTypeLogError(t *testing.T) {
 
 func TestProspectorInitInputTypeStdin(t *testing.T) {
 
-	prospectorConfig := config.ProspectorConfig{
-		Harvester: config.HarvesterConfig{
+	prospectorConfig := prospectorConfig{
+		Harvester: harvester.HarvesterConfig{
 			InputType: "stdin",
 		},
 	}
 
 	prospector := Prospector{
-		ProspectorConfig: prospectorConfig,
+		config: prospectorConfig,
 	}
 
 	err := prospector.Init()
 	assert.Nil(t, err)
-	assert.Equal(t, "stdin", prospector.ProspectorConfig.Harvester.InputType)
+	assert.Equal(t, "stdin", prospector.config.Harvester.InputType)
 }
 
 func TestProspectorInitInputTypeWrong(t *testing.T) {
 
-	prospectorConfig := config.ProspectorConfig{
-		Harvester: config.HarvesterConfig{
+	prospectorConfig := prospectorConfig{
+		Harvester: harvester.HarvesterConfig{
 			InputType: "wrong-type",
 		},
 	}
 
 	prospector := Prospector{
-		ProspectorConfig: prospectorConfig,
+		config: prospectorConfig,
 	}
 
 	err := prospector.Init()
 	assert.Nil(t, err)
-	assert.Equal(t, "log", prospector.ProspectorConfig.Harvester.InputType)
+	assert.Equal(t, "log", prospector.config.Harvester.InputType)
 }
 
 func TestProspectorFileExclude(t *testing.T) {
 
-	prospectorConfig := config.ProspectorConfig{
+	prospectorConfig := prospectorConfig{
 		ExcludeFiles: []*regexp.Regexp{regexp.MustCompile(`\.gz$`)},
-		Harvester: config.HarvesterConfig{
+		Harvester: harvester.HarvesterConfig{
 			BufferSize: 0,
 		},
 	}
 
 	prospector := Prospector{
-		ProspectorConfig: prospectorConfig,
+		config: prospectorConfig,
 	}
 
 	prospector.Init()

--- a/filebeat/harvester/harvester.go
+++ b/filebeat/harvester/harvester.go
@@ -18,14 +18,17 @@ import (
 	"regexp"
 	"sync"
 
+	"time"
+
 	"github.com/elastic/beats/filebeat/config"
 	"github.com/elastic/beats/filebeat/harvester/encoding"
 	"github.com/elastic/beats/filebeat/input"
+	"github.com/elastic/beats/libbeat/common"
 )
 
 type Harvester struct {
 	Path               string /* the file path to harvest */
-	Config             *config.HarvesterConfig
+	Config             *HarvesterConfig
 	offset             int64
 	State              input.FileState
 	stateMutex         sync.Mutex
@@ -37,8 +40,31 @@ type Harvester struct {
 	done               chan struct{}
 }
 
+type HarvesterConfig struct {
+	common.EventMetadata `config:",inline"` // Fields and tags to add to events.
+
+	BufferSize         int    `config:"harvester_buffer_size"`
+	DocumentType       string `config:"document_type"`
+	Encoding           string `config:"encoding"`
+	InputType          string `config:"input_type"`
+	TailFiles          bool   `config:"tail_files"`
+	Backoff            string `config:"backoff"`
+	BackoffDuration    time.Duration
+	BackoffFactor      int    `config:"backoff_factor"`
+	MaxBackoff         string `config:"max_backoff"`
+	MaxBackoffDuration time.Duration
+	CloseOlder         string `config:"close_older"`
+	CloseOlderDuration time.Duration
+	ForceCloseFiles    bool                   `config:"force_close_files"`
+	ExcludeLines       []*regexp.Regexp       `config:"exclude_lines"`
+	IncludeLines       []*regexp.Regexp       `config:"include_lines"`
+	MaxBytes           int                    `config:"max_bytes"`
+	Multiline          *input.MultilineConfig `config:"multiline"`
+	JSON               *input.JSONConfig      `config:"json"`
+}
+
 func NewHarvester(
-	cfg *config.HarvesterConfig,
+	cfg *HarvesterConfig,
 	path string,
 	state input.FileState,
 	spooler chan *input.FileEvent,

--- a/filebeat/harvester/linereader.go
+++ b/filebeat/harvester/linereader.go
@@ -3,8 +3,8 @@ package harvester
 import (
 	"golang.org/x/text/encoding"
 
-	"github.com/elastic/beats/filebeat/config"
 	"github.com/elastic/beats/filebeat/harvester/processor"
+	"github.com/elastic/beats/filebeat/input"
 )
 
 func createLineReader(
@@ -13,8 +13,8 @@ func createLineReader(
 	bufferSize int,
 	maxBytes int,
 	readerConfig logFileReaderConfig,
-	jsonConfig *config.JSONConfig,
-	mlrConfig *config.MultilineConfig,
+	jsonConfig *input.JSONConfig,
+	mlrConfig *input.MultilineConfig,
 	done chan struct{},
 ) (processor.LineProcessor, error) {
 	var p processor.LineProcessor

--- a/filebeat/harvester/processor/multiline.go
+++ b/filebeat/harvester/processor/multiline.go
@@ -6,7 +6,7 @@ import (
 	"regexp"
 	"time"
 
-	"github.com/elastic/beats/filebeat/config"
+	"github.com/elastic/beats/filebeat/input"
 	"github.com/elastic/beats/libbeat/common"
 )
 
@@ -61,7 +61,7 @@ func NewMultiline(
 	r LineProcessor,
 	separator string,
 	maxBytes int,
-	config *config.MultilineConfig,
+	config *input.MultilineConfig,
 ) (*MultiLine, error) {
 	types := map[string]func(*regexp.Regexp) (matcher, error){
 		"before": beforeMatcher,

--- a/filebeat/harvester/processor/multiline_test.go
+++ b/filebeat/harvester/processor/multiline_test.go
@@ -11,8 +11,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/elastic/beats/filebeat/config"
 	"github.com/elastic/beats/filebeat/harvester/encoding"
+	"github.com/elastic/beats/filebeat/input"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -26,7 +26,7 @@ func (p bufferSource) Continuable() bool          { return false }
 
 func TestMultilineAfterOK(t *testing.T) {
 	testMultilineOK(t,
-		config.MultilineConfig{
+		input.MultilineConfig{
 			Pattern: regexp.MustCompile(`^[ \t] +`), // next line is indented by spaces
 			Match:   "after",
 		},
@@ -37,7 +37,7 @@ func TestMultilineAfterOK(t *testing.T) {
 
 func TestMultilineBeforeOK(t *testing.T) {
 	testMultilineOK(t,
-		config.MultilineConfig{
+		input.MultilineConfig{
 			Pattern: regexp.MustCompile(`\\$`), // previous line ends with \
 			Match:   "before",
 		},
@@ -48,7 +48,7 @@ func TestMultilineBeforeOK(t *testing.T) {
 
 func TestMultilineAfterNegateOK(t *testing.T) {
 	testMultilineOK(t,
-		config.MultilineConfig{
+		input.MultilineConfig{
 			Pattern: regexp.MustCompile(`^-`), // first line starts with '-' at beginning of line
 			Negate:  true,
 			Match:   "after",
@@ -60,7 +60,7 @@ func TestMultilineAfterNegateOK(t *testing.T) {
 
 func TestMultilineBeforeNegateOK(t *testing.T) {
 	testMultilineOK(t,
-		config.MultilineConfig{
+		input.MultilineConfig{
 			Pattern: regexp.MustCompile(`;$`), // last line ends with ';'
 			Negate:  true,
 			Match:   "before",
@@ -70,7 +70,7 @@ func TestMultilineBeforeNegateOK(t *testing.T) {
 	)
 }
 
-func testMultilineOK(t *testing.T, cfg config.MultilineConfig, expected ...string) {
+func testMultilineOK(t *testing.T, cfg input.MultilineConfig, expected ...string) {
 	_, buf := createLineBuffer(expected...)
 	reader := createMultilineTestReader(t, buf, cfg)
 
@@ -96,7 +96,7 @@ func testMultilineOK(t *testing.T, cfg config.MultilineConfig, expected ...strin
 	}
 }
 
-func createMultilineTestReader(t *testing.T, in *bytes.Buffer, cfg config.MultilineConfig) LineProcessor {
+func createMultilineTestReader(t *testing.T, in *bytes.Buffer, cfg input.MultilineConfig) LineProcessor {
 	encFactory, ok := encoding.FindEncoding("plain")
 	if !ok {
 		t.Fatalf("unable to find 'plain' encoding")

--- a/filebeat/harvester/processor/processor.go
+++ b/filebeat/harvester/processor/processor.go
@@ -6,8 +6,8 @@ import (
 	"io"
 	"time"
 
-	"github.com/elastic/beats/filebeat/config"
 	"github.com/elastic/beats/filebeat/harvester/encoding"
+	"github.com/elastic/beats/filebeat/input"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 )
@@ -54,7 +54,7 @@ type LimitProcessor struct {
 
 type JSONProcessor struct {
 	reader LineProcessor
-	cfg    *config.JSONConfig
+	cfg    *input.JSONConfig
 }
 
 // NewLineSource creates a new LineSource from input reader by applying
@@ -106,7 +106,7 @@ func (p *LimitProcessor) Next() (Line, error) {
 }
 
 // NewJSONProcessor creates a new processor that can decode JSON.
-func NewJSONProcessor(in LineProcessor, cfg *config.JSONConfig) *JSONProcessor {
+func NewJSONProcessor(in LineProcessor, cfg *input.JSONConfig) *JSONProcessor {
 	return &JSONProcessor{reader: in, cfg: cfg}
 }
 

--- a/filebeat/harvester/processor/processor_test.go
+++ b/filebeat/harvester/processor/processor_test.go
@@ -5,7 +5,7 @@ package processor
 import (
 	"testing"
 
-	"github.com/elastic/beats/filebeat/config"
+	"github.com/elastic/beats/filebeat/input"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/stretchr/testify/assert"
 )
@@ -46,7 +46,7 @@ func TestLineEndingChars(t *testing.T) {
 func TestDecodeJSON(t *testing.T) {
 	type io struct {
 		Text         string
-		Config       config.JSONConfig
+		Config       input.JSONConfig
 		ExpectedText string
 		ExpectedMap  common.MapStr
 	}
@@ -54,60 +54,60 @@ func TestDecodeJSON(t *testing.T) {
 	var tests = []io{
 		{
 			Text:         `{"message": "test", "value": 1}`,
-			Config:       config.JSONConfig{MessageKey: "message"},
+			Config:       input.JSONConfig{MessageKey: "message"},
 			ExpectedText: "test",
 			ExpectedMap:  common.MapStr{"message": "test", "value": float64(1)},
 		},
 		{
 			Text:         `{"message": "test", "value": 1}`,
-			Config:       config.JSONConfig{MessageKey: "message1"},
+			Config:       input.JSONConfig{MessageKey: "message1"},
 			ExpectedText: "",
 			ExpectedMap:  common.MapStr{"message": "test", "value": float64(1)},
 		},
 		{
 			Text:         `{"message": "test", "value": 1}`,
-			Config:       config.JSONConfig{MessageKey: "value"},
+			Config:       input.JSONConfig{MessageKey: "value"},
 			ExpectedText: "",
 			ExpectedMap:  common.MapStr{"message": "test", "value": float64(1)},
 		},
 		{
 			Text:         `{"message": "test", "value": "1"}`,
-			Config:       config.JSONConfig{MessageKey: "value"},
+			Config:       input.JSONConfig{MessageKey: "value"},
 			ExpectedText: "1",
 			ExpectedMap:  common.MapStr{"message": "test", "value": "1"},
 		},
 		{
 			// in case of JSON decoding errors, the text is passed as is
 			Text:         `{"message": "test", "value": "`,
-			Config:       config.JSONConfig{MessageKey: "value"},
+			Config:       input.JSONConfig{MessageKey: "value"},
 			ExpectedText: `{"message": "test", "value": "`,
 			ExpectedMap:  nil,
 		},
 		{
 			// Add key error helps debugging this
 			Text:         `{"message": "test", "value": "`,
-			Config:       config.JSONConfig{MessageKey: "value", AddErrorKey: true},
+			Config:       input.JSONConfig{MessageKey: "value", AddErrorKey: true},
 			ExpectedText: `{"message": "test", "value": "`,
 			ExpectedMap:  common.MapStr{"json_error": "Error decoding JSON: unexpected end of JSON input"},
 		},
 		{
 			// If the text key is not found, put an error
 			Text:         `{"message": "test", "value": "1"}`,
-			Config:       config.JSONConfig{MessageKey: "hello", AddErrorKey: true},
+			Config:       input.JSONConfig{MessageKey: "hello", AddErrorKey: true},
 			ExpectedText: ``,
 			ExpectedMap:  common.MapStr{"message": "test", "value": "1", "json_error": "Key 'hello' not found"},
 		},
 		{
 			// If the text key is found, but not a string, put an error
 			Text:         `{"message": "test", "value": 1}`,
-			Config:       config.JSONConfig{MessageKey: "value", AddErrorKey: true},
+			Config:       input.JSONConfig{MessageKey: "value", AddErrorKey: true},
 			ExpectedText: ``,
 			ExpectedMap:  common.MapStr{"message": "test", "value": float64(1), "json_error": "Value of key 'value' is not a string"},
 		},
 		{
 			// Without a text key, simple return the json and an empty text
 			Text:         `{"message": "test", "value": 1}`,
-			Config:       config.JSONConfig{AddErrorKey: true},
+			Config:       input.JSONConfig{AddErrorKey: true},
 			ExpectedText: ``,
 			ExpectedMap:  common.MapStr{"message": "test", "value": float64(1)},
 		},

--- a/filebeat/input/event.go
+++ b/filebeat/input/event.go
@@ -3,9 +3,9 @@ package input
 import (
 	"fmt"
 	"os"
+	"regexp"
 	"time"
 
-	"github.com/elastic/beats/filebeat/config"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 )
@@ -22,8 +22,30 @@ type FileEvent struct {
 	Text         *string
 	Fileinfo     os.FileInfo
 	JSONFields   common.MapStr
-	JSONConfig   *config.JSONConfig
+	JSONConfig   *JSONConfig
 	FileState    FileState
+}
+
+type JSONConfig struct {
+	MessageKey    string `config:"message_key"`
+	KeysUnderRoot bool   `config:"keys_under_root"`
+	OverwriteKeys bool   `config:"overwrite_keys"`
+	AddErrorKey   bool   `config:"add_error_key"`
+}
+
+type MultilineConfig struct {
+	Negate   bool           `config:"negate"`
+	Match    string         `config:"match"       validate:"required"`
+	MaxLines *int           `config:"max_lines"`
+	Pattern  *regexp.Regexp `config:"pattern"`
+	Timeout  *time.Duration `config:"timeout"     validate:"positive"`
+}
+
+func (c *MultilineConfig) Validate() error {
+	if c.Match != "after" && c.Match != "before" {
+		return fmt.Errorf("unknown matcher type: %s", c.Match)
+	}
+	return nil
 }
 
 // mergeJSONFields writes the JSON fields in the event map,

--- a/filebeat/input/file_test.go
+++ b/filebeat/input/file_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/elastic/beats/filebeat/config"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/stretchr/testify/assert"
 )
@@ -134,7 +133,7 @@ func TestFileEventToMapStrJSON(t *testing.T) {
 				DocumentType: "test_type",
 				Text:         &text,
 				JSONFields:   common.MapStr{"type": "test", "text": "hello"},
-				JSONConfig:   &config.JSONConfig{KeysUnderRoot: true},
+				JSONConfig:   &JSONConfig{KeysUnderRoot: true},
 			},
 			ExpectedItems: common.MapStr{
 				"type": "test_type",
@@ -147,7 +146,7 @@ func TestFileEventToMapStrJSON(t *testing.T) {
 				DocumentType: "test_type",
 				Text:         &text,
 				JSONFields:   common.MapStr{"type": "test", "text": "hello"},
-				JSONConfig:   &config.JSONConfig{KeysUnderRoot: true, OverwriteKeys: true},
+				JSONConfig:   &JSONConfig{KeysUnderRoot: true, OverwriteKeys: true},
 			},
 			ExpectedItems: common.MapStr{
 				"type": "test",
@@ -160,7 +159,7 @@ func TestFileEventToMapStrJSON(t *testing.T) {
 				DocumentType: "test_type",
 				Text:         &text,
 				JSONFields:   common.MapStr{"type": "test", "text": "hello"},
-				JSONConfig:   &config.JSONConfig{},
+				JSONConfig:   &JSONConfig{},
 			},
 			ExpectedItems: common.MapStr{
 				"json": common.MapStr{"type": "test", "text": "hello"},
@@ -173,7 +172,7 @@ func TestFileEventToMapStrJSON(t *testing.T) {
 				DocumentType: "test_type",
 				Text:         &text,
 				JSONFields:   common.MapStr{"type": "test", "text": "hi"},
-				JSONConfig:   &config.JSONConfig{MessageKey: "text"},
+				JSONConfig:   &JSONConfig{MessageKey: "text"},
 			},
 			ExpectedItems: common.MapStr{
 				"json": common.MapStr{"type": "test", "text": "hello"},
@@ -188,7 +187,7 @@ func TestFileEventToMapStrJSON(t *testing.T) {
 				DocumentType: "test_type",
 				Text:         &text,
 				JSONFields:   common.MapStr{"type": "test", "@timestamp": "2016-04-05T18:47:18.444Z"},
-				JSONConfig:   &config.JSONConfig{KeysUnderRoot: true, OverwriteKeys: true},
+				JSONConfig:   &JSONConfig{KeysUnderRoot: true, OverwriteKeys: true},
 			},
 			ExpectedItems: common.MapStr{
 				"@timestamp": common.MustParseTime("2016-04-05T18:47:18.444Z"),
@@ -203,7 +202,7 @@ func TestFileEventToMapStrJSON(t *testing.T) {
 				DocumentType: "test_type",
 				Text:         &text,
 				JSONFields:   common.MapStr{"type": "test", "@timestamp": "2016-04-05T18:47:18.44XX4Z"},
-				JSONConfig:   &config.JSONConfig{KeysUnderRoot: true, OverwriteKeys: true},
+				JSONConfig:   &JSONConfig{KeysUnderRoot: true, OverwriteKeys: true},
 			},
 			ExpectedItems: common.MapStr{
 				"@timestamp": common.Time(now),
@@ -219,7 +218,7 @@ func TestFileEventToMapStrJSON(t *testing.T) {
 				DocumentType: "test_type",
 				Text:         &text,
 				JSONFields:   common.MapStr{"type": "test", "@timestamp": 42},
-				JSONConfig:   &config.JSONConfig{KeysUnderRoot: true, OverwriteKeys: true},
+				JSONConfig:   &JSONConfig{KeysUnderRoot: true, OverwriteKeys: true},
 			},
 			ExpectedItems: common.MapStr{
 				"@timestamp": common.Time(now),
@@ -233,7 +232,7 @@ func TestFileEventToMapStrJSON(t *testing.T) {
 				DocumentType: "test_type",
 				Text:         &text,
 				JSONFields:   common.MapStr{"type": 42},
-				JSONConfig:   &config.JSONConfig{KeysUnderRoot: true, OverwriteKeys: true},
+				JSONConfig:   &JSONConfig{KeysUnderRoot: true, OverwriteKeys: true},
 			},
 			ExpectedItems: common.MapStr{
 				"type":       "test_type",
@@ -246,7 +245,7 @@ func TestFileEventToMapStrJSON(t *testing.T) {
 				DocumentType: "test_type",
 				Text:         &text,
 				JSONFields:   common.MapStr{"type": ""},
-				JSONConfig:   &config.JSONConfig{KeysUnderRoot: true, OverwriteKeys: true},
+				JSONConfig:   &JSONConfig{KeysUnderRoot: true, OverwriteKeys: true},
 			},
 			ExpectedItems: common.MapStr{
 				"type":       "test_type",
@@ -259,7 +258,7 @@ func TestFileEventToMapStrJSON(t *testing.T) {
 				DocumentType: "test_type",
 				Text:         &text,
 				JSONFields:   common.MapStr{"type": "_type"},
-				JSONConfig:   &config.JSONConfig{KeysUnderRoot: true, OverwriteKeys: true},
+				JSONConfig:   &JSONConfig{KeysUnderRoot: true, OverwriteKeys: true},
 			},
 			ExpectedItems: common.MapStr{
 				"type":       "test_type",

--- a/filebeat/tests/system/config/filebeat.yml.j2
+++ b/filebeat/tests/system/config/filebeat.yml.j2
@@ -11,8 +11,8 @@ filebeat:
         - {{ path }}{% endif %}
       # Type of the files. Annotated in every documented
       scan_frequency: {{scan_frequency | default("0.1s") }}
-      ignore_older: "{{ignoreOlder}}"
-      close_older: "{{closeOlder}}"
+      ignore_older: {{ignoreOlder}}
+      close_older: {{closeOlder}}
       harvester_buffer_size:
       encoding: {{encoding | default("utf-8") }}
       tail_files: {{tailFiles}}


### PR DESCRIPTION
In a first step, ucfg was introduced to unpack prospector configs. In next steps the config files also for the prospector types and harvester types will be split up.

* Obsolete tests were removed