### PR TITLE
Limit Metricbeat crosscompile to amd64

### DIFF
--- a/metricbeat/Makefile
+++ b/metricbeat/Makefile
@@ -10,6 +10,7 @@ ES_BEATS?=..
 # are the same platforms where the system metrics (cpu, memory) are not
 # implemented.
 GOX_OS=solaris freebsd netbsd
+GOX_FLAGS='-arch=amd64'
 
 include ${ES_BEATS}/libbeat/scripts/Makefile
 

--- a/metricbeat/module/system/disk/_beat/docs.asciidoc
+++ b/metricbeat/module/system/disk/_beat/docs.asciidoc
@@ -2,3 +2,9 @@
 
 The System Disk MetricSet provides disk IO metrics collected from the operating
 system. One event is created for each disk mounted on the system.
+
+This MetricSet is available on:
+
+- Linux
+- Windows
+- FreeBSD (amd64)


### PR DESCRIPTION
Other arches are possible but they are not very useful in the context of solaris, freebsd, and netbsd.

system/disk is not implemented on freebsd/arm and freebsd/386 appears to have bug where it is missing a variable `sizeOfDevstat`.