### PR TITLE
Add link to regexp examples

### DIFF
--- a/filebeat/docs/index.asciidoc
+++ b/filebeat/docs/index.asciidoc
@@ -1,5 +1,9 @@
 = Filebeat Reference
 :libbeat: http://www.elastic.co/guide/en/beats/libbeat/master
+:packetbeat: http://www.elastic.co/guide/en/beats/packetbeat/master
+:topbeat: http://www.elastic.co/guide/en/beats/topbeat/master
+:filebeat: http://www.elastic.co/guide/en/beats/filebeat/master
+:winlogbeat: http://www.elastic.co/guide/en/beats/winlogbeat/master
 :elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/master/
 :version: 5.0.0-alpha2
 :beatname_lc: filebeat

--- a/libbeat/docs/regexp.asciidoc
+++ b/libbeat/docs/regexp.asciidoc
@@ -18,6 +18,8 @@ coming[5.0.0-beta1]
 
 NOTE: We recommend that you wrap regular expressions in single quotation marks to work around YAML's string escaping rules. For example, `'^\[?[0-9][0-9]:?[0-9][0-9]|^[[:graph:]]+'`.
 
+For more examples of supported regexp patterns, see {filebeat}/multiline-examples.html[Managing Multiline Messages].
+Although the examples pertain to Filebeat, the regexp patterns are applicable to other use cases.
 
 [float]
 === Supported Patterns

--- a/packetbeat/docs/index.asciidoc
+++ b/packetbeat/docs/index.asciidoc
@@ -1,5 +1,9 @@
 = Packetbeat Reference
 :libbeat: http://www.elastic.co/guide/en/beats/libbeat/master
+:packetbeat: http://www.elastic.co/guide/en/beats/packetbeat/master
+:topbeat: http://www.elastic.co/guide/en/beats/topbeat/master
+:filebeat: http://www.elastic.co/guide/en/beats/filebeat/master
+:winlogbeat: http://www.elastic.co/guide/en/beats/winlogbeat/master
 :elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/master/
 :version: 5.0.0-alpha2
 :beatname_lc: packetbeat

--- a/topbeat/docs/index.asciidoc
+++ b/topbeat/docs/index.asciidoc
@@ -1,5 +1,9 @@
 = Topbeat Reference
 :libbeat: http://www.elastic.co/guide/en/beats/libbeat/master
+:packetbeat: http://www.elastic.co/guide/en/beats/packetbeat/master
+:topbeat: http://www.elastic.co/guide/en/beats/topbeat/master
+:filebeat: http://www.elastic.co/guide/en/beats/filebeat/master
+:winlogbeat: http://www.elastic.co/guide/en/beats/winlogbeat/master
 :elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/master/
 :version: 5.0.0-alpha2
 :beatname_lc: topbeat

--- a/winlogbeat/docs/index.asciidoc
+++ b/winlogbeat/docs/index.asciidoc
@@ -1,5 +1,9 @@
 = Winlogbeat Reference
 :libbeat: http://www.elastic.co/guide/en/beats/libbeat/master
+:packetbeat: http://www.elastic.co/guide/en/beats/packetbeat/master
+:topbeat: http://www.elastic.co/guide/en/beats/topbeat/master
+:filebeat: http://www.elastic.co/guide/en/beats/filebeat/master
+:winlogbeat: http://www.elastic.co/guide/en/beats/winlogbeat/master
 :elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/master/
 :version: 5.0.0-alpha2
 :beatname_lc: winlogbeat


### PR DESCRIPTION
Added link to regexp examples plus variables to support linking between the docs for different Beats. 