### PR TITLE
Remove help output from command line documentation

### DIFF
--- a/filebeat/docs/command-line.asciidoc
+++ b/filebeat/docs/command-line.asciidoc
@@ -10,26 +10,7 @@ use these options, you need to start Filebeat in the foreground.
 To start Filebeat, you must use the `-c config/path` option to specify the path to the
 configuration file.
 
-[source,shell]
-----------------------------------------------------------------------------
-$ ./filebeat -h
-Usage of ./filebeat:
-  -N  Disable actual publishing for testing
-  -c string
-      Configuration file (default "/etc/filebeat/filebeat.yml")
-  -configtest
-      Test configuration and exit.
-  -cpuprofile string
-      Write cpu profile to file
-  -d string
-      Enable certain debug selectors
-  -e  Log to stderr and disable syslog/file output
-  -memprofile string
-      Write memory profile to this file
-  -v  Log at INFO level
-  -version
-      Print version and exit
------------------------------------------------------------------------------
+TIP: Run `./filebeat -h` to see the full list of options from the command line.
 
 include::../../libbeat/docs/shared-command-line.asciidoc[]
 

--- a/packetbeat/docs/command-line.asciidoc
+++ b/packetbeat/docs/command-line.asciidoc
@@ -2,40 +2,9 @@
 === Command Line Options
 
 The following command line options are available for Packetbeat. To use these options,
-you need to start Packetbeat in the foreground.
+you need to start Packetbeat in the foreground. 
 
-[source,shell]
-------------------------------------------------------------------------
-$ ./packetbeat -h
-Usage of ./packetbeat:
-  -I string
-      file
-  -N  Disable actual publishing for testing
-  -O  Read packets one at a time (press Enter)
-  -c string
-      Configuration file (default "/etc/packetbeat/packetbeat.yml")
-  -configtest
-      Test configuration and exit.
-  -cpuprofile string
-      Write cpu profile to file
-  -d string
-      Enable certain debug selectors
-  -devices
-      Print the list of devices and exit
-  -dump string
-      Write all captured packets to this libpcap file
-  -e  Log to stderr and disable syslog/file output
-  -l int
-      Loop file. 0 - loop forever (default 1)
-  -memprofile string
-      Write memory profile to this file
-  -t  Read packets as fast as possible, without sleeping
-  -v  Log at INFO level
-  -version
-      Print version and exit
-  -waitstop int
-      Additional seconds to wait before shutting down
-----------------------------------------------------------------------------
+TIP: Run `./packetbeat -h` to see the full list of options from the command line.
 
 ==== Packet-Beat Specific Options
 These command line options are specific to Packetbeat:

--- a/topbeat/docs/command-line.asciidoc
+++ b/topbeat/docs/command-line.asciidoc
@@ -4,27 +4,7 @@
 The following command line options from libbeat are also available for Topbeat.
 To use these options, you need to start Topbeat in the foreground.
 
-[source,shell]
----------------------------------------------------------
-
-$ ./topbeat -h
-Usage of ./topbeat:
-  -N  Disable actual publishing for testing
-  -c string
-      Configuration file (default "/etc/topbeat/topbeat.yml")
-  -configtest
-      Test configuration and exit.
-  -cpuprofile string
-      Write cpu profile to file
-  -d string
-      Enable certain debug selectors
-  -e  Log to stderr and disable syslog/file output
-  -memprofile string
-      Write memory profile to this file
-  -v  Log at INFO level
-  -version
-      Print version and exit
----------------------------------------------------------
+TIP: Run `./topbeat -h` to see the full list of options from the command line.
 
 include::../../libbeat/docs/shared-command-line.asciidoc[]
 

--- a/winlogbeat/docs/command-line.asciidoc
+++ b/winlogbeat/docs/command-line.asciidoc
@@ -8,27 +8,6 @@ configuration file.
 The following command line options from libbeat are also available for
 Winlogbeat.
 
-[source,shell]
---------------------------------------------------------------------------------
-$ winlogbeat -h
-Usage of ./winlogbeat:
-  -N	Disable actual publishing for testing
-  -c string
-    	Configuration file (defaults to winlogbeat.yml in the same dir as winlogbeat.exe)
-  -configtest
-    	Test configuration and exit.
-  -cpuprofile string
-    	Write cpu profile to file
-  -d string
-    	Enable certain debug selectors
-  -e	Log to stderr and disable syslog/file output
-  -httpprof string
-    	Start pprof http server
-  -memprofile string
-    	Write memory profile to this file
-  -v	Log at INFO level
-  -version
-    	Print version and exit
---------------------------------------------------------------------------------
+TIP: Run `winlogbeat -h` to see the full list of options from the command line.
 
 include::../../libbeat/docs/shared-command-line.asciidoc[]


### PR DESCRIPTION
We've been showing the output from the -h option in the documentation, but the content gets out of date too easily when we add new options and forget to update the example output. There's really no reason to provide this output since we describe the options. So I've removed the output and added a tip instead that reminds users to use the -h flag to see the options from the command line.