### PR TITLE
Added short versions for the configuration files

### DIFF
--- a/filebeat/etc/beat.short.yml
+++ b/filebeat/etc/beat.short.yml
@@ -1,0 +1,58 @@
+###################### Filebeat Configuration Example #########################
+
+# This file is an example configuration file highlighting only the most common
+# options. The filebeat.full.yml file from the same directory contains all the
+# supported options with more comments. You can use it as a reference.
+#
+# You can find the full configuration reference here:
+# https://www.elastic.co/guide/en/beats/filebeat/index.html
+
+#=========================== Filebeat prospectors =============================
+
+filebeat.prospectors:
+
+# Each - is a prospector. Most options can be set at the prospector level, so
+# you can use different prospectors for various configurations.
+# Below are the prospector specific configurations.
+
+- input_type: log
+
+  # Paths that should be crawled and fetched. Glob based paths.
+  paths:
+    - /var/log/*.log
+    #- c:\programdata\elasticsearch\logs\*
+
+  # Exclude lines. A list of regular expressions to match. It drops the lines that are
+  # matching any regular expression from the list.
+  #exclude_lines: ["^DBG"]
+
+  # Include lines. A list of regular expressions to match. It exports the lines that are
+  # matching any regular expression from the list.
+  #include_lines: ["^ERR", "^WARN"]
+
+  # Exclude files. A list of regular expressions to match. Filebeat drops the files that
+  # are matching any regular expression from the list. By default, no files are dropped.
+  #exclude_files: [".gz$"]
+
+  # Optional additional fields. These field can be freely picked
+  # to add additional information to the crawled log files for filtering
+  #fields:
+  #  level: debug
+  #  review: 1
+
+  ### Multiline options
+
+  # Mutiline can be used for log messages spanning multiple lines. This is common
+  # for Java Stack Traces or C-Line Continuation
+
+  # The regexp Pattern that has to be matched. The example pattern matches all lines starting with [
+  #multiline.pattern: ^\[
+
+  # Defines if the pattern set under pattern should be negated or not. Default is false.
+  #multiline.negate: false
+
+  # Match can be set to "after" or "before". It is used to define if lines should be append to a pattern
+  # that was (not) matched before or after or as long as a pattern is not matched based on negate.
+  # Note: After is the equivalent to previous and before is the equivalent to to next in Logstash
+  #multiline.match: after
+

--- a/filebeat/etc/beat.yml
+++ b/filebeat/etc/beat.yml
@@ -1,10 +1,19 @@
-###################### Filebeat Configuration Example #########################
+##################$$$###### Filebeat Configuration ############################
+
+# This file is a full configuration example documenting all non-deprecated
+# options in comments. For a shorter configuration example, that contains only
+# the most common options, please see filebeat.short.yml in the same directory.
+#
+# You can find the full configuration reference here:
+# https://www.elastic.co/guide/en/beats/filebeat/index.html
 
 #=========================== Filebeat prospectors =============================
 
 # List of prospectors to fetch data.
 filebeat.prospectors:
-# Each - is a prospector. Below are the prospector specific configurations
+# Each - is a prospector. Most options can be set at the prospector level, so
+# you can use different prospectors for various configurations.
+# Below are the prospector specific configurations.
 
 # Type of the files. Based on this the way the file is read is decided.
 # The different types cannot be mixed in one prospector
@@ -32,25 +41,6 @@ filebeat.prospectors:
   #    hz-gb-2312, euc-kr, euc-jp, iso-2022-jp, shift-jis, ...
   #encoding: plain
 
-  # Decode JSON options. Enable this if your logs are structured in JSON.
-  # JSON key on which to apply the line filtering and multiline settings. This key
-  # must be top level and its value must be string, otherwise it is ignored. If
-  # no text key is defined, the line filtering and multiline features cannot be used.
-  #json.message_key:
-
-  # By default, the decoded JSON is placed under a "json" key in the output document.
-  # If you enable this setting, the keys are copied top level in the output document.
-  #json.keys_under_root: false
-
-  # If keys_under_root and this setting are enabled, then the values from the decoded
-  # JSON object overwrite the fields that Filebeat normally adds (type, source, offset, etc.)
-  # in case of conflicts.
-  #json.overwrite_keys: false
-
-  # If this setting is enabled, Filebeat adds a "json_error" key in case of JSON
-  # unmarshaling errors or when a text key is defined in the configuration but cannot
-  # be used.
-  #json.add_error_key: false
 
   # Exclude lines. A list of regular expressions to match. It drops the lines that are
   # matching any regular expression from the list. The include_lines is called before
@@ -106,9 +96,33 @@ filebeat.prospectors:
   # This is especially useful for multiline log messages which can get large.
   #max_bytes: 10485760
 
+  ### JSON configuration
+
+  # Decode JSON options. Enable this if your logs are structured in JSON.
+  # JSON key on which to apply the line filtering and multiline settings. This key
+  # must be top level and its value must be string, otherwise it is ignored. If
+  # no text key is defined, the line filtering and multiline features cannot be used.
+  #json.message_key:
+
+  # By default, the decoded JSON is placed under a "json" key in the output document.
+  # If you enable this setting, the keys are copied top level in the output document.
+  #json.keys_under_root: false
+
+  # If keys_under_root and this setting are enabled, then the values from the decoded
+  # JSON object overwrite the fields that Filebeat normally adds (type, source, offset, etc.)
+  # in case of conflicts.
+  #json.overwrite_keys: false
+
+  # If this setting is enabled, Filebeat adds a "json_error" key in case of JSON
+  # unmarshaling errors or when a text key is defined in the configuration but cannot
+  # be used.
+  #json.add_error_key: false
+
+  ### Multiline options
+
   # Mutiline can be used for log messages spanning multiple lines. This is common
   # for Java Stack Traces or C-Line Continuation
-  
+
   # The regexp Pattern that has to be matched. The example pattern matches all lines starting with [
   #multiline.pattern: ^\[
 

--- a/filebeat/filebeat.short.yml
+++ b/filebeat/filebeat.short.yml
@@ -1,0 +1,113 @@
+###################### Filebeat Configuration Example #########################
+
+# This file is an example configuration file highlighting only the most common
+# options. The filebeat.full.yml file from the same directory contains all the
+# supported options with more comments. You can use it as a reference.
+#
+# You can find the full configuration reference here:
+# https://www.elastic.co/guide/en/beats/filebeat/index.html
+
+#=========================== Filebeat prospectors =============================
+
+filebeat.prospectors:
+
+# Each - is a prospector. Most options can be set at the prospector level, so
+# you can use different prospectors for various configurations.
+# Below are the prospector specific configurations.
+
+- input_type: log
+
+  # Paths that should be crawled and fetched. Glob based paths.
+  paths:
+    - /var/log/*.log
+    #- c:\programdata\elasticsearch\logs\*
+
+  # Exclude lines. A list of regular expressions to match. It drops the lines that are
+  # matching any regular expression from the list.
+  #exclude_lines: ["^DBG"]
+
+  # Include lines. A list of regular expressions to match. It exports the lines that are
+  # matching any regular expression from the list.
+  #include_lines: ["^ERR", "^WARN"]
+
+  # Exclude files. A list of regular expressions to match. Filebeat drops the files that
+  # are matching any regular expression from the list. By default, no files are dropped.
+  #exclude_files: [".gz$"]
+
+  # Optional additional fields. These field can be freely picked
+  # to add additional information to the crawled log files for filtering
+  #fields:
+  #  level: debug
+  #  review: 1
+
+  ### Multiline options
+
+  # Mutiline can be used for log messages spanning multiple lines. This is common
+  # for Java Stack Traces or C-Line Continuation
+
+  # The regexp Pattern that has to be matched. The example pattern matches all lines starting with [
+  #multiline.pattern: ^\[
+
+  # Defines if the pattern set under pattern should be negated or not. Default is false.
+  #multiline.negate: false
+
+  # Match can be set to "after" or "before". It is used to define if lines should be append to a pattern
+  # that was (not) matched before or after or as long as a pattern is not matched based on negate.
+  # Note: After is the equivalent to previous and before is the equivalent to to next in Logstash
+  #multiline.match: after
+
+
+#================================ General =====================================
+
+# The name of the shipper that publishes the network data. It can be used to group
+# all the transactions sent by a single shipper in the web interface.
+#name:
+
+# The tags of the shipper are included in their own field with each
+# transaction published.
+#tags: ["service-X", "web-tier"]
+
+# Optional fields that you can specify to add additional information to the
+# output.
+#fields:
+#  env: staging
+
+#================================ Outputs =====================================
+
+# Configure what outputs to use when sending the data collected by the beat.
+# Multiple outputs may be used.
+
+#-------------------------- Elasticsearch output ------------------------------
+output.elasticsearch:
+  # Array of hosts to connect to.
+  hosts: ["localhost:9200"]
+
+  # Template name. By default the template name is filebeat.
+  template.name: "filebeat"
+
+  # Path to template file
+  template.path: "filebeat.template.json"
+
+  # Overwrite existing template
+  template.overwrite: false
+
+#----------------------------- Logstash output --------------------------------
+#output.logstash:
+  # The Logstash hosts
+  #hosts: ["localhost:5044"]
+
+  # Optional TLS. By default is off.
+  # List of root certificates for HTTPS server verifications
+  #tls.certificate_authorities: ["/etc/pki/root/ca.pem"]
+
+  # Certificate for TLS client authentication
+  #tls.certificate: "/etc/pki/client/cert.pem"
+
+  # Client Certificate Key
+  #tls.certificate_key: "/etc/pki/client/cert.key"
+
+#================================ Logging =====================================
+
+# Sets log level. The default log level is error.
+# Available log levels are: critical, error, warning, info, debug
+#logging.level: error

--- a/filebeat/filebeat.yml
+++ b/filebeat/filebeat.yml
@@ -1,10 +1,19 @@
-###################### Filebeat Configuration Example #########################
+##################$$$###### Filebeat Configuration ############################
+
+# This file is a full configuration example documenting all non-deprecated
+# options in comments. For a shorter configuration example, that contains only
+# the most common options, please see filebeat.short.yml in the same directory.
+#
+# You can find the full configuration reference here:
+# https://www.elastic.co/guide/en/beats/filebeat/index.html
 
 #=========================== Filebeat prospectors =============================
 
 # List of prospectors to fetch data.
 filebeat.prospectors:
-# Each - is a prospector. Below are the prospector specific configurations
+# Each - is a prospector. Most options can be set at the prospector level, so
+# you can use different prospectors for various configurations.
+# Below are the prospector specific configurations.
 
 # Type of the files. Based on this the way the file is read is decided.
 # The different types cannot be mixed in one prospector
@@ -32,25 +41,6 @@ filebeat.prospectors:
   #    hz-gb-2312, euc-kr, euc-jp, iso-2022-jp, shift-jis, ...
   #encoding: plain
 
-  # Decode JSON options. Enable this if your logs are structured in JSON.
-  # JSON key on which to apply the line filtering and multiline settings. This key
-  # must be top level and its value must be string, otherwise it is ignored. If
-  # no text key is defined, the line filtering and multiline features cannot be used.
-  #json.message_key:
-
-  # By default, the decoded JSON is placed under a "json" key in the output document.
-  # If you enable this setting, the keys are copied top level in the output document.
-  #json.keys_under_root: false
-
-  # If keys_under_root and this setting are enabled, then the values from the decoded
-  # JSON object overwrite the fields that Filebeat normally adds (type, source, offset, etc.)
-  # in case of conflicts.
-  #json.overwrite_keys: false
-
-  # If this setting is enabled, Filebeat adds a "json_error" key in case of JSON
-  # unmarshaling errors or when a text key is defined in the configuration but cannot
-  # be used.
-  #json.add_error_key: false
 
   # Exclude lines. A list of regular expressions to match. It drops the lines that are
   # matching any regular expression from the list. The include_lines is called before
@@ -106,9 +96,33 @@ filebeat.prospectors:
   # This is especially useful for multiline log messages which can get large.
   #max_bytes: 10485760
 
+  ### JSON configuration
+
+  # Decode JSON options. Enable this if your logs are structured in JSON.
+  # JSON key on which to apply the line filtering and multiline settings. This key
+  # must be top level and its value must be string, otherwise it is ignored. If
+  # no text key is defined, the line filtering and multiline features cannot be used.
+  #json.message_key:
+
+  # By default, the decoded JSON is placed under a "json" key in the output document.
+  # If you enable this setting, the keys are copied top level in the output document.
+  #json.keys_under_root: false
+
+  # If keys_under_root and this setting are enabled, then the values from the decoded
+  # JSON object overwrite the fields that Filebeat normally adds (type, source, offset, etc.)
+  # in case of conflicts.
+  #json.overwrite_keys: false
+
+  # If this setting is enabled, Filebeat adds a "json_error" key in case of JSON
+  # unmarshaling errors or when a text key is defined in the configuration but cannot
+  # be used.
+  #json.add_error_key: false
+
+  ### Multiline options
+
   # Mutiline can be used for log messages spanning multiple lines. This is common
   # for Java Stack Traces or C-Line Continuation
-  
+
   # The regexp Pattern that has to be matched. The example pattern matches all lines starting with [
   #multiline.pattern: ^\[
 
@@ -336,7 +350,6 @@ output.elasticsearch:
 
 
 #----------------------------- Logstash output --------------------------------
-### Logstash as output
 #output.logstash:
   # The Logstash hosts
   #hosts: ["localhost:5044"]
@@ -411,15 +424,14 @@ output.elasticsearch:
 # Under Windows systems, the log files are per default sent to the file output,
 # under all other system per default to syslog.
 
+# Sets log level. The default log level is error.
+# Available log levels are: critical, error, warning, info, debug
+#logging.level: error
 
-  # Enable debug output for selected components. To enable all selectors use ["*"]
-  # Other available selectors are beat, publish, service
-  # Multiple selectors can be chained.
-  #selectors: [ ]
-
-  # Sets log level. The default log level is error.
-  # Available log levels are: critical, error, warning, info, debug
-  #level: error
+# Enable debug output for selected components. To enable all selectors use ["*"]
+# Other available selectors are beat, publish, service
+# Multiple selectors can be chained.
+#logging.selectors: [ ]
 
 # Send all logging output to syslog. The default is false.
 #logging.to_syslog: true

--- a/libbeat/_beat/config.short.yml
+++ b/libbeat/_beat/config.short.yml
@@ -1,0 +1,55 @@
+
+#================================ General =====================================
+
+# The name of the shipper that publishes the network data. It can be used to group
+# all the transactions sent by a single shipper in the web interface.
+#name:
+
+# The tags of the shipper are included in their own field with each
+# transaction published.
+#tags: ["service-X", "web-tier"]
+
+# Optional fields that you can specify to add additional information to the
+# output.
+#fields:
+#  env: staging
+
+#================================ Outputs =====================================
+
+# Configure what outputs to use when sending the data collected by the beat.
+# Multiple outputs may be used.
+
+#-------------------------- Elasticsearch output ------------------------------
+output.elasticsearch:
+  # Array of hosts to connect to.
+  hosts: ["localhost:9200"]
+
+  # Template name. By default the template name is beatname.
+  template.name: "beatname"
+
+  # Path to template file
+  template.path: "beatname.template.json"
+
+  # Overwrite existing template
+  template.overwrite: false
+
+#----------------------------- Logstash output --------------------------------
+#output.logstash:
+  # The Logstash hosts
+  #hosts: ["localhost:5044"]
+
+  # Optional TLS. By default is off.
+  # List of root certificates for HTTPS server verifications
+  #tls.certificate_authorities: ["/etc/pki/root/ca.pem"]
+
+  # Certificate for TLS client authentication
+  #tls.certificate: "/etc/pki/client/cert.pem"
+
+  # Client Certificate Key
+  #tls.certificate_key: "/etc/pki/client/cert.key"
+
+#================================ Logging =====================================
+
+# Sets log level. The default log level is error.
+# Available log levels are: critical, error, warning, info, debug
+#logging.level: error

--- a/libbeat/_beat/config.yml
+++ b/libbeat/_beat/config.yml
@@ -147,7 +147,6 @@ output.elasticsearch:
 
 
 #----------------------------- Logstash output --------------------------------
-### Logstash as output
 #output.logstash:
   # The Logstash hosts
   #hosts: ["localhost:5044"]
@@ -222,15 +221,14 @@ output.elasticsearch:
 # Under Windows systems, the log files are per default sent to the file output,
 # under all other system per default to syslog.
 
+# Sets log level. The default log level is error.
+# Available log levels are: critical, error, warning, info, debug
+#logging.level: error
 
-  # Enable debug output for selected components. To enable all selectors use ["*"]
-  # Other available selectors are beat, publish, service
-  # Multiple selectors can be chained.
-  #selectors: [ ]
-
-  # Sets log level. The default log level is error.
-  # Available log levels are: critical, error, warning, info, debug
-  #level: error
+# Enable debug output for selected components. To enable all selectors use ["*"]
+# Other available selectors are beat, publish, service
+# Multiple selectors can be chained.
+#logging.selectors: [ ]
 
 # Send all logging output to syslog. The default is false.
 #logging.to_syslog: true

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -221,6 +221,8 @@ update: python-env
 	echo "Update config file"
 	rm -f etc/${BEATNAME}.yml
 	cat etc/beat.yml ${ES_BEATS}/libbeat/_beat/config.yml | sed -e "s/beatname/${BEATNAME}/g" > ${BEATNAME}.yml
+	rm -f etc/${BEATNAME}.short.yml
+	cat etc/beat.short.yml ${ES_BEATS}/libbeat/_beat/config.short.yml | sed -e "s/beatname/${BEATNAME}/g" > ${BEATNAME}.short.yml
 
 	# Update fields
 	echo "Update fields"

--- a/metricbeat/Makefile
+++ b/metricbeat/Makefile
@@ -38,6 +38,7 @@ docs:
 .PHONY: configs
 configs:
 	python ${ES_BEATS}/metricbeat/scripts/config_collector.py > etc/beat.yml
+	python ${ES_BEATS}/metricbeat/scripts/config_collector.py --short > etc/beat.short.yml
 
 # This is called by the beats packer before building starts
 .PHONY: before-build

--- a/metricbeat/etc/beat.short.yml
+++ b/metricbeat/etc/beat.short.yml
@@ -19,15 +19,6 @@ metricbeat.modules:
   # Apache hosts
   hosts: ["http://127.0.0.1/"]
 
-  # Path to server status. Default server-status
-  #server_status_path: "server-status"
-
-  # Username of hosts.  Empty by default
-  #username: test
-
-  # Password of hosts. Empty by default
-  #password: test123
-
 #------------------------------- Mysql Module ---------------------------------
 - module: mysql
   metricsets: ["status"]
@@ -38,12 +29,6 @@ metricbeat.modules:
   # The username and password can either be set in the DSN or for all hosts in username and password config option
   hosts: ["root@tcp(127.0.0.1:3306)/"]
 
-  # Username of hosts. Empty by default
-  #username: root
-
-  # Password of hosts. Empty by default
-  #password: test
-
 #------------------------------- Redis Module ---------------------------------
 - module: redis
   metricsets: ["info"]
@@ -53,43 +38,10 @@ metricbeat.modules:
   # Redis hosts
   hosts: ["127.0.0.1:6379"]
 
-  # Enabled defines if the module is enabled. Default: true
-  #enabled: true
-
-  # Timeout after which time a metricset should return an error
-  # Timeout is by default defined as period, as a fetch of a metricset
-  # should never take longer then period, as otherwise calls can pile up.
-  #timeout: 1s
-
-  # Optional fields to be added to each event
-  #fields:
-  #  datacenter: west
-
-  # Network type to be used for redis connection. Default: tcp
-  #network: tcp
-
-  # Max number of concurrent connections. Default: 10
-  #maxconn: 10
-
-  # Filters can be used to reduce the number of fields sent.
-  #filters:
-  #  - include_fields:
-  #      fields: ["stats"]
-
-  # Redis AUTH password. Empty by default.
-  #password: foobared
-
 #------------------------------ System Module ---------------------------------
 - module: system
   metricsets: ["cpu", "cores", "filesystem", "fsstats", "memory", "process"]
   enabled: true
   period: 2s
-
-#---------------------------- Zookeeper Module --------------------------------
-- module: zookeeper
-  metricsets: ["mntr"]
-  enabled: true
-  period: 5s
-  hosts: ["localhost:2181"]
 
 

--- a/metricbeat/metricbeat.short.yml
+++ b/metricbeat/metricbeat.short.yml
@@ -1,0 +1,102 @@
+########################## Metricbeat Configuration ###########################
+
+# This file is a full configuration example documenting all non-deprecated
+# options in comments. For a shorter configuration example, that contains only
+# the most common options, please see metricbeat.short.yml in the same directory.
+#
+# You can find the full configuration reference here:
+# https://www.elastic.co/guide/en/beats/metricbeat/index.html
+
+#==========================  Modules configuration ============================
+metricbeat.modules:
+
+#----------------------------- Apache Module ----------------------------------
+- module: apache
+  metricsets: ["status"]
+  enabled: true
+  period: 1s
+
+  # Apache hosts
+  hosts: ["http://127.0.0.1/"]
+
+#------------------------------- Mysql Module ---------------------------------
+- module: mysql
+  metricsets: ["status"]
+  enabled: true
+  period: 2s
+
+  # Host DSN should be defined as "tcp(127.0.0.1:3306)/"
+  # The username and password can either be set in the DSN or for all hosts in username and password config option
+  hosts: ["root@tcp(127.0.0.1:3306)/"]
+
+#------------------------------- Redis Module ---------------------------------
+- module: redis
+  metricsets: ["info"]
+  enabled: true
+  period: 1s
+
+  # Redis hosts
+  hosts: ["127.0.0.1:6379"]
+
+#------------------------------ System Module ---------------------------------
+- module: system
+  metricsets: ["cpu", "cores", "filesystem", "fsstats", "memory", "process"]
+  enabled: true
+  period: 2s
+
+
+
+#================================ General =====================================
+
+# The name of the shipper that publishes the network data. It can be used to group
+# all the transactions sent by a single shipper in the web interface.
+#name:
+
+# The tags of the shipper are included in their own field with each
+# transaction published.
+#tags: ["service-X", "web-tier"]
+
+# Optional fields that you can specify to add additional information to the
+# output.
+#fields:
+#  env: staging
+
+#================================ Outputs =====================================
+
+# Configure what outputs to use when sending the data collected by the beat.
+# Multiple outputs may be used.
+
+#-------------------------- Elasticsearch output ------------------------------
+output.elasticsearch:
+  # Array of hosts to connect to.
+  hosts: ["localhost:9200"]
+
+  # Template name. By default the template name is metricbeat.
+  template.name: "metricbeat"
+
+  # Path to template file
+  template.path: "metricbeat.template.json"
+
+  # Overwrite existing template
+  template.overwrite: false
+
+#----------------------------- Logstash output --------------------------------
+#output.logstash:
+  # The Logstash hosts
+  #hosts: ["localhost:5044"]
+
+  # Optional TLS. By default is off.
+  # List of root certificates for HTTPS server verifications
+  #tls.certificate_authorities: ["/etc/pki/root/ca.pem"]
+
+  # Certificate for TLS client authentication
+  #tls.certificate: "/etc/pki/client/cert.pem"
+
+  # Client Certificate Key
+  #tls.certificate_key: "/etc/pki/client/cert.key"
+
+#================================ Logging =====================================
+
+# Sets log level. The default log level is error.
+# Available log levels are: critical, error, warning, info, debug
+#logging.level: error

--- a/metricbeat/metricbeat.yml
+++ b/metricbeat/metricbeat.yml
@@ -1,4 +1,11 @@
-###################### Metricbeat Configuration Example #######################
+########################## Metricbeat Configuration ###########################
+
+# This file is a full configuration example documenting all non-deprecated
+# options in comments. For a shorter configuration example, that contains only
+# the most common options, please see metricbeat.short.yml in the same directory.
+#
+# You can find the full configuration reference here:
+# https://www.elastic.co/guide/en/beats/metricbeat/index.html
 
 #==========================  Modules configuration ============================
 metricbeat.modules:
@@ -235,7 +242,6 @@ output.elasticsearch:
 
 
 #----------------------------- Logstash output --------------------------------
-### Logstash as output
 #output.logstash:
   # The Logstash hosts
   #hosts: ["localhost:5044"]
@@ -310,15 +316,14 @@ output.elasticsearch:
 # Under Windows systems, the log files are per default sent to the file output,
 # under all other system per default to syslog.
 
+# Sets log level. The default log level is error.
+# Available log levels are: critical, error, warning, info, debug
+#logging.level: error
 
-  # Enable debug output for selected components. To enable all selectors use ["*"]
-  # Other available selectors are beat, publish, service
-  # Multiple selectors can be chained.
-  #selectors: [ ]
-
-  # Sets log level. The default log level is error.
-  # Available log levels are: critical, error, warning, info, debug
-  #level: error
+# Enable debug output for selected components. To enable all selectors use ["*"]
+# Other available selectors are beat, publish, service
+# Multiple selectors can be chained.
+#logging.selectors: [ ]
 
 # Send all logging output to syslog. The default is false.
 #logging.to_syslog: true

--- a/metricbeat/module/apache/_beat/config.short.yml
+++ b/metricbeat/module/apache/_beat/config.short.yml
@@ -1,0 +1,8 @@
+#----------------------------- Apache Module ----------------------------------
+- module: apache
+  metricsets: ["status"]
+  enabled: true
+  period: 1s
+
+  # Apache hosts
+  hosts: ["http://127.0.0.1/"]

--- a/metricbeat/module/mysql/_beat/config.short.yml
+++ b/metricbeat/module/mysql/_beat/config.short.yml
@@ -1,0 +1,9 @@
+#------------------------------- Mysql Module ---------------------------------
+- module: mysql
+  metricsets: ["status"]
+  enabled: true
+  period: 2s
+
+  # Host DSN should be defined as "tcp(127.0.0.1:3306)/"
+  # The username and password can either be set in the DSN or for all hosts in username and password config option
+  hosts: ["root@tcp(127.0.0.1:3306)/"]

--- a/metricbeat/module/redis/_beat/config.short.yml
+++ b/metricbeat/module/redis/_beat/config.short.yml
@@ -1,0 +1,8 @@
+#------------------------------- Redis Module ---------------------------------
+- module: redis
+  metricsets: ["info"]
+  enabled: true
+  period: 1s
+
+  # Redis hosts
+  hosts: ["127.0.0.1:6379"]

--- a/metricbeat/module/system/_beat/config.short.yml
+++ b/metricbeat/module/system/_beat/config.short.yml
@@ -1,0 +1,5 @@
+#------------------------------ System Module ---------------------------------
+- module: system
+  metricsets: ["cpu", "cores", "filesystem", "fsstats", "memory", "process"]
+  enabled: true
+  period: 2s

--- a/metricbeat/scripts/config_collector.py
+++ b/metricbeat/scripts/config_collector.py
@@ -1,8 +1,30 @@
 import os
+import argparse
 
 # Collects config for all modules
 
-header = """###################### Metricbeat Configuration Example #######################
+header = """########################## Metricbeat Configuration ###########################
+
+# This file is a full configuration example documenting all non-deprecated
+# options in comments. For a shorter configuration example, that contains only
+# the most common options, please see metricbeat.short.yml in the same directory.
+#
+# You can find the full configuration reference here:
+# https://www.elastic.co/guide/en/beats/metricbeat/index.html
+
+#==========================  Modules configuration ============================
+metricbeat.modules:
+
+"""
+
+header_short = """###################### Metricbeat Configuration Example #######################
+
+# This file is an example configuration file highlighting only the most common
+# options. The metricbeat.yml file from the same directory contains all the
+# supported options with more comments. You can use it as a reference.
+#
+# You can find the full configuration reference here:
+# https://www.elastic.co/guide/en/beats/metricbeat/index.html
 
 #==========================  Modules configuration ============================
 metricbeat.modules:
@@ -10,7 +32,7 @@ metricbeat.modules:
 """
 
 
-def collect():
+def collect(short=False):
 
     base_dir = "module"
     path = os.path.abspath("module")
@@ -21,7 +43,10 @@ def collect():
     # Iterate over all modules
     for module in os.listdir(base_dir):
 
-        module_configs = path + "/" + module + "/_beat/config.yml"
+        if short:
+            module_configs = path + "/" + module + "/_beat/config.short.yml"
+        else:
+            module_configs = path + "/" + module + "/_beat/config.yml"
 
         # Only check folders where fields.yml exists
         if not os.path.isfile(module_configs):
@@ -37,4 +62,9 @@ def collect():
     print config_yml
 
 if __name__ == "__main__":
-    collect()
+    parser = argparse.ArgumentParser(
+        description="Collects modules docs")
+    parser.add_argument("--short", action="store_true",
+                        help="Collect the short versions")
+    args = parser.parse_args()
+    collect(args.short)

--- a/packetbeat/etc/beat.short.yml
+++ b/packetbeat/etc/beat.short.yml
@@ -1,0 +1,89 @@
+#################### Packetbeat Configuration Example #########################
+
+# This file is an example configuration file highlighting only the most common
+# options. The packetbeat.yml file from the same directory contains all the
+# supported options with more comments. You can use it as a reference.
+#
+# You can find the full configuration reference here:
+# https://www.elastic.co/guide/en/beats/packetbeat/index.html
+
+#============================== Network device ================================
+
+# Select the network interface to sniff the data. You can use the "any"
+# keyword to sniff on all connected interfaces.
+packetbeat.interfaces.device: any
+
+#================================== Flows =====================================
+
+# Comment out all options to disable flows reporting.
+
+# Set network flow timeout. Flow is killed if no packet is received before being
+# timed out.
+packetbeat.flows.timeout: 30s
+
+# Configure reporting period. If set to -1, only killed flows will be reported
+packetbeat.flows.period: 10s
+
+#========================== Transaction protocols =============================
+
+packetbeat.protocols.icmp:
+  # Enable ICMPv4 and ICMPv6 monitoring. Default: false
+  enabled: true
+
+packetbeat.protocols.amqp:
+  # Configure the ports where to listen for AMQP traffic. You can disable
+  # the AMQP protocol by commenting out the list of ports.
+  ports: [5672]
+
+packetbeat.protocols.dns:
+  # Configure the ports where to listen for DNS traffic. You can disable
+  # the DNS protocol by commenting out the list of ports.
+  ports: [53]
+
+  # include_authorities controls whether or not the dns.authorities field
+  # (authority resource records) is added to messages.
+  include_authorities: true
+
+  # include_additionals controls whether or not the dns.additionals field
+  # (additional resource records) is added to messages.
+  include_additionals: true
+
+packetbeat.protocols.http:
+  # Configure the ports where to listen for HTTP traffic. You can disable
+  # the HTTP protocol by commenting out the list of ports.
+  ports: [80, 8080, 8000, 5000, 8002]
+
+packetbeat.protocols.memcache:
+  # Configure the ports where to listen for memcache traffic. You can disable
+  # the Memcache protocol by commenting out the list of ports.
+  ports: [11211]
+
+packetbeat.protocols.mysql:
+  # Configure the ports where to listen for MySQL traffic. You can disable
+  # the MySQL protocol by commenting out the list of ports.
+  ports: [3306]
+
+packetbeat.protocols.pgsql:
+  # Configure the ports where to listen for Pgsql traffic. You can disable
+  # the Pgsql protocol by commenting out the list of ports.
+  ports: [5432]
+
+packetbeat.protocols.redis:
+  # Configure the ports where to listen for Redis traffic. You can disable
+  # the Redis protocol by commenting out the list of ports.
+  ports: [6379]
+
+packetbeat.protocols.thrift:
+  # Configure the ports where to listen for Thrift-RPC traffic. You can disable
+  # the Thrift-RPC protocol by commenting out the list of ports.
+  ports: [9090]
+
+packetbeat.protocols.mongodb:
+  # Configure the ports where to listen for MongoDB traffic. You can disable
+  # the MongoDB protocol by commenting out the list of ports.
+  ports: [27017]
+
+packetbeat.protocols.nfs:
+  # Configure the ports where to listen for NFS traffic. You can disable
+  # the NFS protocol by commenting out the list of ports.
+  ports: [2049]

--- a/packetbeat/etc/beat.yml
+++ b/packetbeat/etc/beat.yml
@@ -1,16 +1,15 @@
 ###################### Packetbeat Configuration Example #######################
 
-# This file contains an overview of various configuration settings. Please consult
-# the docs at https://www.elastic.co/guide/en/beats/packetbeat/current/packetbeat-configuration.html
-# for more details.
+# This file is a full configuration example documenting all non-deprecated
+# options in comments. For a shorter configuration example, that contains only
+# the most common options, please see packetbeat.short.yml in the same directory.
+#
+# You can find the full configuration reference here:
+# https://www.elastic.co/guide/en/beats/packetbeat/index.html
 
-# The Packetbeat shipper works by sniffing the network traffic between your
-# application components. It inserts meta-data about each transaction into
-# Elasticsearch.
+#============================== Network device ================================
 
-#================================ Interfaces ==================================
-
-# Select the network interfaces to sniff the data. You can use the "any"
+# Select the network interface to sniff the data. You can use the "any"
 # keyword to sniff on all connected interfaces.
 packetbeat.interfaces.device: any
 

--- a/packetbeat/packetbeat.short.yml
+++ b/packetbeat/packetbeat.short.yml
@@ -1,0 +1,144 @@
+#################### Packetbeat Configuration Example #########################
+
+# This file is an example configuration file highlighting only the most common
+# options. The packetbeat.yml file from the same directory contains all the
+# supported options with more comments. You can use it as a reference.
+#
+# You can find the full configuration reference here:
+# https://www.elastic.co/guide/en/beats/packetbeat/index.html
+
+#============================== Network device ================================
+
+# Select the network interface to sniff the data. You can use the "any"
+# keyword to sniff on all connected interfaces.
+packetbeat.interfaces.device: any
+
+#================================== Flows =====================================
+
+# Comment out all options to disable flows reporting.
+
+# Set network flow timeout. Flow is killed if no packet is received before being
+# timed out.
+packetbeat.flows.timeout: 30s
+
+# Configure reporting period. If set to -1, only killed flows will be reported
+packetbeat.flows.period: 10s
+
+#========================== Transaction protocols =============================
+
+packetbeat.protocols.icmp:
+  # Enable ICMPv4 and ICMPv6 monitoring. Default: false
+  enabled: true
+
+packetbeat.protocols.amqp:
+  # Configure the ports where to listen for AMQP traffic. You can disable
+  # the AMQP protocol by commenting out the list of ports.
+  ports: [5672]
+
+packetbeat.protocols.dns:
+  # Configure the ports where to listen for DNS traffic. You can disable
+  # the DNS protocol by commenting out the list of ports.
+  ports: [53]
+
+  # include_authorities controls whether or not the dns.authorities field
+  # (authority resource records) is added to messages.
+  include_authorities: true
+
+  # include_additionals controls whether or not the dns.additionals field
+  # (additional resource records) is added to messages.
+  include_additionals: true
+
+packetbeat.protocols.http:
+  # Configure the ports where to listen for HTTP traffic. You can disable
+  # the HTTP protocol by commenting out the list of ports.
+  ports: [80, 8080, 8000, 5000, 8002]
+
+packetbeat.protocols.memcache:
+  # Configure the ports where to listen for memcache traffic. You can disable
+  # the Memcache protocol by commenting out the list of ports.
+  ports: [11211]
+
+packetbeat.protocols.mysql:
+  # Configure the ports where to listen for MySQL traffic. You can disable
+  # the MySQL protocol by commenting out the list of ports.
+  ports: [3306]
+
+packetbeat.protocols.pgsql:
+  # Configure the ports where to listen for Pgsql traffic. You can disable
+  # the Pgsql protocol by commenting out the list of ports.
+  ports: [5432]
+
+packetbeat.protocols.redis:
+  # Configure the ports where to listen for Redis traffic. You can disable
+  # the Redis protocol by commenting out the list of ports.
+  ports: [6379]
+
+packetbeat.protocols.thrift:
+  # Configure the ports where to listen for Thrift-RPC traffic. You can disable
+  # the Thrift-RPC protocol by commenting out the list of ports.
+  ports: [9090]
+
+packetbeat.protocols.mongodb:
+  # Configure the ports where to listen for MongoDB traffic. You can disable
+  # the MongoDB protocol by commenting out the list of ports.
+  ports: [27017]
+
+packetbeat.protocols.nfs:
+  # Configure the ports where to listen for NFS traffic. You can disable
+  # the NFS protocol by commenting out the list of ports.
+  ports: [2049]
+
+#================================ General =====================================
+
+# The name of the shipper that publishes the network data. It can be used to group
+# all the transactions sent by a single shipper in the web interface.
+#name:
+
+# The tags of the shipper are included in their own field with each
+# transaction published.
+#tags: ["service-X", "web-tier"]
+
+# Optional fields that you can specify to add additional information to the
+# output.
+#fields:
+#  env: staging
+
+#================================ Outputs =====================================
+
+# Configure what outputs to use when sending the data collected by the beat.
+# Multiple outputs may be used.
+
+#-------------------------- Elasticsearch output ------------------------------
+output.elasticsearch:
+  # Array of hosts to connect to.
+  hosts: ["localhost:9200"]
+
+  # Template name. By default the template name is packetbeat.
+  template.name: "packetbeat"
+
+  # Path to template file
+  template.path: "packetbeat.template.json"
+
+  # Overwrite existing template
+  template.overwrite: false
+
+#----------------------------- Logstash output --------------------------------
+#output.logstash:
+  # The Logstash hosts
+  #hosts: ["localhost:5044"]
+
+  # Optional TLS. By default is off.
+  # List of root certificates for HTTPS server verifications
+  #tls.certificate_authorities: ["/etc/pki/root/ca.pem"]
+
+  # Certificate for TLS client authentication
+  #tls.certificate: "/etc/pki/client/cert.pem"
+
+  # Client Certificate Key
+  #tls.certificate_key: "/etc/pki/client/cert.key"
+
+#================================ Logging =====================================
+
+# Sets log level. The default log level is error.
+# Available log levels are: critical, error, warning, info, debug
+#logging.level: error

--- a/packetbeat/packetbeat.yml
+++ b/packetbeat/packetbeat.yml
@@ -1,16 +1,15 @@
 ###################### Packetbeat Configuration Example #######################
 
-# This file contains an overview of various configuration settings. Please consult
-# the docs at https://www.elastic.co/guide/en/beats/packetbeat/current/packetbeat-configuration.html
-# for more details.
+# This file is a full configuration example documenting all non-deprecated
+# options in comments. For a shorter configuration example, that contains only
+# the most common options, please see packetbeat.short.yml in the same directory.
+#
+# You can find the full configuration reference here:
+# https://www.elastic.co/guide/en/beats/packetbeat/index.html
 
-# The Packetbeat shipper works by sniffing the network traffic between your
-# application components. It inserts meta-data about each transaction into
-# Elasticsearch.
+#============================== Network device ================================
 
-#================================ Interfaces ==================================
-
-# Select the network interfaces to sniff the data. You can use the "any"
+# Select the network interface to sniff the data. You can use the "any"
 # keyword to sniff on all connected interfaces.
 packetbeat.interfaces.device: any
 
@@ -324,7 +323,6 @@ output.elasticsearch:
 
 
 #----------------------------- Logstash output --------------------------------
-### Logstash as output
 #output.logstash:
   # The Logstash hosts
   #hosts: ["localhost:5044"]
@@ -399,15 +397,14 @@ output.elasticsearch:
 # Under Windows systems, the log files are per default sent to the file output,
 # under all other system per default to syslog.
 
+# Sets log level. The default log level is error.
+# Available log levels are: critical, error, warning, info, debug
+#logging.level: error
 
-  # Enable debug output for selected components. To enable all selectors use ["*"]
-  # Other available selectors are beat, publish, service
-  # Multiple selectors can be chained.
-  #selectors: [ ]
-
-  # Sets log level. The default log level is error.
-  # Available log levels are: critical, error, warning, info, debug
-  #level: error
+# Enable debug output for selected components. To enable all selectors use ["*"]
+# Other available selectors are beat, publish, service
+# Multiple selectors can be chained.
+#logging.selectors: [ ]
 
 # Send all logging output to syslog. The default is false.
 #logging.to_syslog: true

--- a/topbeat/etc/beat.short.yml
+++ b/topbeat/etc/beat.short.yml
@@ -1,8 +1,8 @@
-########################### Topbeat Configuration #############################
+###################### Topbeat Configuration Example ##########################
 
-# This file is a full configuration example documenting all non-deprecated
-# options in comments. For a shorter configuration example, that contains only
-# the most common options, please see topbeat.short.yml in the same directory.
+# This file is an example configuration file highlighting only the most common
+# options. The topbeat.yml file from the same directory contains all the
+# supported options with more comments. You can use it as a reference.
 #
 # You can find the full configuration reference here:
 # https://www.elastic.co/guide/en/beats/topbeat/index.html

--- a/topbeat/topbeat.short.yml
+++ b/topbeat/topbeat.short.yml
@@ -1,0 +1,86 @@
+###################### Topbeat Configuration Example ##########################
+
+# This file is an example configuration file highlighting only the most common
+# options. The topbeat.yml file from the same directory contains all the
+# supported options with more comments. You can use it as a reference.
+#
+# You can find the full configuration reference here:
+# https://www.elastic.co/guide/en/beats/topbeat/index.html
+
+#======================== Topbeat specific options ============================
+
+# In seconds, defines how often to read server statistics
+topbeat.period: 10
+
+# Regular expression to match the processes that are monitored
+# By default, all the processes are monitored
+topbeat.procs: [".*"]
+
+# Statistics to collect (all enabled by default)
+topbeat.stats:
+  # per system statistics, by default is true
+  system: true
+
+  # per process statistics, by default is true
+  process: true
+
+  # file system information, by default is true
+  filesystem: true
+
+  # cpu usage per core, by default is false
+  cpu_per_core: false
+
+#================================ General =====================================
+
+# The name of the shipper that publishes the network data. It can be used to group
+# all the transactions sent by a single shipper in the web interface.
+#name:
+
+# The tags of the shipper are included in their own field with each
+# transaction published.
+#tags: ["service-X", "web-tier"]
+
+# Optional fields that you can specify to add additional information to the
+# output.
+#fields:
+#  env: staging
+
+#================================ Outputs =====================================
+
+# Configure what outputs to use when sending the data collected by the beat.
+# Multiple outputs may be used.
+
+#-------------------------- Elasticsearch output ------------------------------
+output.elasticsearch:
+  # Array of hosts to connect to.
+  hosts: ["localhost:9200"]
+
+  # Template name. By default the template name is topbeat.
+  template.name: "topbeat"
+
+  # Path to template file
+  template.path: "topbeat.template.json"
+
+  # Overwrite existing template
+  template.overwrite: false
+
+#----------------------------- Logstash output --------------------------------
+#output.logstash:
+  # The Logstash hosts
+  #hosts: ["localhost:5044"]
+
+  # Optional TLS. By default is off.
+  # List of root certificates for HTTPS server verifications
+  #tls.certificate_authorities: ["/etc/pki/root/ca.pem"]
+
+  # Certificate for TLS client authentication
+  #tls.certificate: "/etc/pki/client/cert.pem"
+
+  # Client Certificate Key
+  #tls.certificate_key: "/etc/pki/client/cert.key"
+
+#================================ Logging =====================================
+
+# Sets log level. The default log level is error.
+# Available log levels are: critical, error, warning, info, debug
+#logging.level: error

--- a/topbeat/topbeat.yml
+++ b/topbeat/topbeat.yml
@@ -1,4 +1,11 @@
-###################### Topbeat Configuration Example ##########################
+########################### Topbeat Configuration #############################
+
+# This file is a full configuration example documenting all non-deprecated
+# options in comments. For a shorter configuration example, that contains only
+# the most common options, please see topbeat.short.yml in the same directory.
+#
+# You can find the full configuration reference here:
+# https://www.elastic.co/guide/en/beats/topbeat/index.html
 
 #======================== Topbeat specific options ============================
 
@@ -13,7 +20,7 @@ topbeat.procs: [".*"]
 topbeat.stats:
   # per system statistics, by default is true
   system: true
-    
+
   # per process statistics, by default is true
   process: true
 
@@ -22,7 +29,6 @@ topbeat.stats:
 
   # cpu usage per core, by default is false
   cpu_per_core: false
-
 
 #================================ General =====================================
 
@@ -172,7 +178,6 @@ output.elasticsearch:
 
 
 #----------------------------- Logstash output --------------------------------
-### Logstash as output
 #output.logstash:
   # The Logstash hosts
   #hosts: ["localhost:5044"]
@@ -247,15 +252,14 @@ output.elasticsearch:
 # Under Windows systems, the log files are per default sent to the file output,
 # under all other system per default to syslog.
 
+# Sets log level. The default log level is error.
+# Available log levels are: critical, error, warning, info, debug
+#logging.level: error
 
-  # Enable debug output for selected components. To enable all selectors use ["*"]
-  # Other available selectors are beat, publish, service
-  # Multiple selectors can be chained.
-  #selectors: [ ]
-
-  # Sets log level. The default log level is error.
-  # Available log levels are: critical, error, warning, info, debug
-  #level: error
+# Enable debug output for selected components. To enable all selectors use ["*"]
+# Other available selectors are beat, publish, service
+# Multiple selectors can be chained.
+#logging.selectors: [ ]
 
 # Send all logging output to syslog. The default is false.
 #logging.to_syslog: true

--- a/winlogbeat/etc/beat.short.yml
+++ b/winlogbeat/etc/beat.short.yml
@@ -1,0 +1,24 @@
+###################### Winlogbeat Configuration Example ##########################
+
+# This file is an example configuration file highlighting only the most common
+# options. The winlogbeat.yml file from the same directory contains all the
+# supported options with more comments. You can use it as a reference.
+#
+# You can find the full configuration reference here:
+# https://www.elastic.co/guide/en/beats/winlogbeat/index.html
+
+#======================= Winlogbeat specific options ==========================
+
+# event_logs specifies a list of event logs to monitor as well as any
+# accompanying options. The YAML data type of event_logs is a list of
+# dictionaries.
+#
+# The supported keys are name (required), tags, fields, fields_under_root,
+# ignore_older, level, event_id, provider, and include_xml. Please visit the
+# documentation for the complete details of each option.
+# https://go.es.io/WinlogbeatConfig
+winlogbeat.event_logs:
+  - name: Application
+    ignore_older: 72h
+  - name: Security
+  - name: System

--- a/winlogbeat/etc/beat.yml
+++ b/winlogbeat/etc/beat.yml
@@ -1,4 +1,13 @@
-###################### Winlogbeat Configuration Example #######################
+########################## Winlogbeat Configuration ###########################
+
+# This file is a full configuration example documenting all non-deprecated
+# options in comments. For a shorter configuration example, that contains only
+# the most common options, please see winlogbeat.short.yml in the same directory.
+#
+# You can find the full configuration reference here:
+# https://www.elastic.co/guide/en/beats/winlogbeat/index.html
+
+#======================= Winlogbeat specific options ==========================
 
 # The registry file is where Winlogbeat persists its state so that the beat
 # can resume after shutdown or an outage. The default is .winlogbeat.yml
@@ -24,5 +33,3 @@ winlogbeat.event_logs:
     ignore_older: 72h
   - name: Security
   - name: System
-
-

--- a/winlogbeat/winlogbeat.short.yml
+++ b/winlogbeat/winlogbeat.short.yml
@@ -1,0 +1,79 @@
+###################### Winlogbeat Configuration Example ##########################
+
+# This file is an example configuration file highlighting only the most common
+# options. The winlogbeat.yml file from the same directory contains all the
+# supported options with more comments. You can use it as a reference.
+#
+# You can find the full configuration reference here:
+# https://www.elastic.co/guide/en/beats/winlogbeat/index.html
+
+#======================= Winlogbeat specific options ==========================
+
+# event_logs specifies a list of event logs to monitor as well as any
+# accompanying options. The YAML data type of event_logs is a list of
+# dictionaries.
+#
+# The supported keys are name (required), tags, fields, fields_under_root,
+# ignore_older, level, event_id, provider, and include_xml. Please visit the
+# documentation for the complete details of each option.
+# https://go.es.io/WinlogbeatConfig
+winlogbeat.event_logs:
+  - name: Application
+    ignore_older: 72h
+  - name: Security
+  - name: System
+
+#================================ General =====================================
+
+# The name of the shipper that publishes the network data. It can be used to group
+# all the transactions sent by a single shipper in the web interface.
+#name:
+
+# The tags of the shipper are included in their own field with each
+# transaction published.
+#tags: ["service-X", "web-tier"]
+
+# Optional fields that you can specify to add additional information to the
+# output.
+#fields:
+#  env: staging
+
+#================================ Outputs =====================================
+
+# Configure what outputs to use when sending the data collected by the beat.
+# Multiple outputs may be used.
+
+#-------------------------- Elasticsearch output ------------------------------
+output.elasticsearch:
+  # Array of hosts to connect to.
+  hosts: ["localhost:9200"]
+
+  # Template name. By default the template name is winlogbeat.
+  template.name: "winlogbeat"
+
+  # Path to template file
+  template.path: "winlogbeat.template.json"
+
+  # Overwrite existing template
+  template.overwrite: false
+
+#----------------------------- Logstash output --------------------------------
+#output.logstash:
+  # The Logstash hosts
+  #hosts: ["localhost:5044"]
+
+  # Optional TLS. By default is off.
+  # List of root certificates for HTTPS server verifications
+  #tls.certificate_authorities: ["/etc/pki/root/ca.pem"]
+
+  # Certificate for TLS client authentication
+  #tls.certificate: "/etc/pki/client/cert.pem"
+
+  # Client Certificate Key
+  #tls.certificate_key: "/etc/pki/client/cert.key"
+
+#================================ Logging =====================================
+
+# Sets log level. The default log level is error.
+# Available log levels are: critical, error, warning, info, debug
+#logging.level: error

--- a/winlogbeat/winlogbeat.yml
+++ b/winlogbeat/winlogbeat.yml
@@ -1,4 +1,13 @@
-###################### Winlogbeat Configuration Example #######################
+########################## Winlogbeat Configuration ###########################
+
+# This file is a full configuration example documenting all non-deprecated
+# options in comments. For a shorter configuration example, that contains only
+# the most common options, please see winlogbeat.short.yml in the same directory.
+#
+# You can find the full configuration reference here:
+# https://www.elastic.co/guide/en/beats/winlogbeat/index.html
+
+#======================= Winlogbeat specific options ==========================
 
 # The registry file is where Winlogbeat persists its state so that the beat
 # can resume after shutdown or an outage. The default is .winlogbeat.yml
@@ -24,8 +33,6 @@ winlogbeat.event_logs:
     ignore_older: 72h
   - name: Security
   - name: System
-
-
 
 #================================ General =====================================
 
@@ -175,7 +182,6 @@ output.elasticsearch:
 
 
 #----------------------------- Logstash output --------------------------------
-### Logstash as output
 #output.logstash:
   # The Logstash hosts
   #hosts: ["localhost:5044"]
@@ -250,15 +256,14 @@ output.elasticsearch:
 # Under Windows systems, the log files are per default sent to the file output,
 # under all other system per default to syslog.
 
+# Sets log level. The default log level is error.
+# Available log levels are: critical, error, warning, info, debug
+#logging.level: error
 
-  # Enable debug output for selected components. To enable all selectors use ["*"]
-  # Other available selectors are beat, publish, service
-  # Multiple selectors can be chained.
-  #selectors: [ ]
-
-  # Sets log level. The default log level is error.
-  # Available log levels are: critical, error, warning, info, debug
-  #level: error
+# Enable debug output for selected components. To enable all selectors use ["*"]
+# Other available selectors are beat, publish, service
+# Multiple selectors can be chained.
+#logging.selectors: [ ]
 
 # Send all logging output to syslog. The default is false.
 #logging.to_syslog: true


### PR DESCRIPTION
For now, the short files are named like `beatname.short.yml` and I kept the
`beatname.yml` to be the full one.  The intention is to switch them around. The
short ones to become the default and the long ones to be something like
`beatname.full.yml` or similar.

But before doing that I wanted the others in the team to have a look. The
decision of what to include in the short version is fairly arbitrary, I just
did it based on what I thought makes most sense.

I kept the ES and LS outputs in the configuration file. I considered having
only ES for all the beats except Filebeat, but that would complicate the
generation part and I think it's nice to highlight that we support multiple
outputs.