### PR TITLE
Introduce dot notation for metricset namespace

### DIFF
--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -147,6 +147,11 @@ system-tests: buildbeat.test prepare-tests python-env
 	. ${PYTHON_ENV}/bin/activate; nosetests -w tests/system --process-timeout=$(TIMEOUT) --with-timer
 	python ${ES_BEATS}/dev-tools/aggregate_coverage.py -o ${COVERAGE_DIR}/system.cov ./build/system-tests/run
 
+# Runs the system tests
+.PHONY: system-tests-environment
+system-tests-environment:
+	${DOCKER_COMPOSE} run beat make system-tests;
+
 # Runs system tests without coverage reports and in parallel
 .PHONY: fast-system-tests
 fast-system-tests: buildbeat.test python-env

--- a/metricbeat/beater/event.go
+++ b/metricbeat/beater/event.go
@@ -1,7 +1,6 @@
 package beater
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/elastic/beats/libbeat/common"
@@ -42,9 +41,6 @@ func (b eventBuilder) build() (common.MapStr, error) {
 	typeName := getType(event, defaultType)
 	timestamp := getTimestamp(event, common.Time(b.startTime))
 
-	// Each metricset has a unique event field name to prevent type conflicts.
-	eventFieldName := fmt.Sprintf("%s-%s", b.moduleName, b.metricSetName)
-
 	// Apply filters.
 	if b.filters != nil {
 		event = b.filters.Filter(event)
@@ -57,7 +53,9 @@ func (b eventBuilder) build() (common.MapStr, error) {
 		"metricset":  b.metricSetName,
 		"rtt":        b.fetchDuration.Nanoseconds() / int64(time.Microsecond),
 		common.EventMetadataKey: b.metadata,
-		eventFieldName:          event,
+		b.moduleName: common.MapStr{
+			b.metricSetName: event,
+		},
 	}
 
 	// Overwrite default index if set.

--- a/metricbeat/beater/event_test.go
+++ b/metricbeat/beater/event_test.go
@@ -12,12 +12,11 @@ import (
 )
 
 const (
-	moduleName     = "mymodule"
-	metricSetName  = "mymetricset"
-	eventFieldName = moduleName + "-" + metricSetName
-	host           = "localhost"
-	elapsed        = time.Duration(500 * time.Millisecond)
-	tag            = "alpha"
+	moduleName    = "mymodule"
+	metricSetName = "mymetricset"
+	host          = "localhost"
+	elapsed       = time.Duration(500 * time.Millisecond)
+	tag           = "alpha"
 )
 
 var (
@@ -52,7 +51,7 @@ func TestEventBuilder(t *testing.T) {
 	assert.Equal(t, common.Time(startTime), event["@timestamp"])
 	assert.Equal(t, int64(500000), event["rtt"])
 	assert.Equal(t, host, event["metricset-host"])
-	assert.Equal(t, common.MapStr{}, event[eventFieldName])
+	assert.Equal(t, common.MapStr{}, event[moduleName].(common.MapStr)[metricSetName])
 	assert.Nil(t, event["error"])
 }
 

--- a/metricbeat/beater/example_test.go
+++ b/metricbeat/beater/example_test.go
@@ -67,8 +67,10 @@ func ExampleModuleWrapper() {
 	//     "FieldsUnderRoot": false,
 	//     "Tags": null
 	//   },
-	//   "fake-status": {
-	//     "metric": 1
+	//   "fake": {
+	//     "status": {
+	//       "metric": 1
+	//     }
 	//   },
 	//   "metricset": "status",
 	//   "module": "fake",

--- a/metricbeat/docker-compose.yml
+++ b/metricbeat/docker-compose.yml
@@ -6,7 +6,7 @@ beat:
     - redis
     - zookeeper
   environment:
-    - APACHE_HOST=http://apache/
+    - APACHE_HOST=apache
     - APACHE_PORT=80
     - REDIS_HOST=redis
     - REDIS_PORT=6379

--- a/metricbeat/docs/fields.asciidoc
+++ b/metricbeat/docs/fields.asciidoc
@@ -24,62 +24,68 @@ Apache HTTPD server metrics collected from the mod_status module.
 
 
 
-=== apache-status Fields
+=== apache Fields
 
-`apache-status` contains the metrics that were scraped from the status page.
+apache contains the metrics that were scraped from apache.
 
 
 
-==== apache-status.hostname
+=== status Fields
+
+`status` contains the metrics that were scraped from the apache status page.
+
+
+
+==== apache.status.hostname
 
 type: keyword
 
 Apache hostname.
 
 
-==== apache-status.totalAccesses
+==== apache.status.totalAccesses
 
 type: integer
 
 Total number of access requests.
 
 
-==== apache-status.totalKBytes
+==== apache.status.totalKBytes
 
 type: integer
 
 Total number of kilobytes served.
 
 
-==== apache-status.reqPerSec
+==== apache.status.reqPerSec
 
 type: float
 
 Requests per second.
 
 
-==== apache-status.bytesPerSec
+==== apache.status.bytesPerSec
 
 type: float
 
 Bytes per second.
 
 
-==== apache-status.bytesPerReq
+==== apache.status.bytesPerReq
 
 type: float
 
 Bytes per request.
 
 
-==== apache-status.busyWorkers
+==== apache.status.busyWorkers
 
 type: integer
 
 Number of busy workers.
 
 
-==== apache-status.idleWorkers
+==== apache.status.idleWorkers
 
 type: integer
 
@@ -92,14 +98,14 @@ Uptime stats.
 
 
 
-==== apache-status.uptime.serverUptimeSeconds
+==== apache.status.uptime.serverUptimeSeconds
 
 type: integer
 
 Server uptime in seconds.
 
 
-==== apache-status.uptime.uptime
+==== apache.status.uptime.uptime
 
 type: integer
 
@@ -112,35 +118,35 @@ CPU stats.
 
 
 
-==== apache-status.cpu.cpuLoad
+==== apache.status.cpu.cpuLoad
 
 type: float
 
 CPU Load.
 
 
-==== apache-status.cpu.cpuUser
+==== apache.status.cpu.cpuUser
 
 type: float
 
 CPU user load.
 
 
-==== apache-status.cpu.cpuSystem
+==== apache.status.cpu.cpuSystem
 
 type: float
 
 System cpu.
 
 
-==== apache-status.cpu.cpuChildrenUser
+==== apache.status.cpu.cpuChildrenUser
 
 type: float
 
 CPU of children user.
 
 
-==== apache-status.cpu.cpuChildrenSystem
+==== apache.status.cpu.cpuChildrenSystem
 
 type: float
 
@@ -153,28 +159,28 @@ Connection stats.
 
 
 
-==== apache-status.connections.connsTotal
+==== apache.status.connections.connsTotal
 
 type: integer
 
 Total connections.
 
 
-==== apache-status.connections.connsAsyncWriting
+==== apache.status.connections.connsAsyncWriting
 
 type: integer
 
 Async connection writing.
 
 
-==== apache-status.connections.connsAsyncKeepAlive
+==== apache.status.connections.connsAsyncKeepAlive
 
 type: integer
 
 Async keeped alive connections.
 
 
-==== apache-status.connections.connsAsyncClosing
+==== apache.status.connections.connsAsyncClosing
 
 type: integer
 
@@ -187,21 +193,21 @@ Load averages.
 
 
 
-==== apache-status.load.load1
+==== apache.status.load.load1
 
 type: float
 
 Load average for the last minute.
 
 
-==== apache-status.load.load5
+==== apache.status.load.load5
 
 type: float
 
 Load average for the last 5 minutes.
 
 
-==== apache-status.load.load15
+==== apache.status.load.load15
 
 type: float
 
@@ -214,84 +220,84 @@ Scoreboard metrics.
 
 
 
-==== apache-status.scoreboard.startingUp
+==== apache.status.scoreboard.startingUp
 
 type: integer
 
 Starting up.
 
 
-==== apache-status.scoreboard.readingRequest
+==== apache.status.scoreboard.readingRequest
 
 type: integer
 
 Reading requests.
 
 
-==== apache-status.scoreboard.sendingReply
+==== apache.status.scoreboard.sendingReply
 
 type: integer
 
 Sending Reply.
 
 
-==== apache-status.scoreboard.keepalive
+==== apache.status.scoreboard.keepalive
 
 type: integer
 
 Keep alive.
 
 
-==== apache-status.scoreboard.dnsLookup
+==== apache.status.scoreboard.dnsLookup
 
 type: integer
 
 Dns Lookups.
 
 
-==== apache-status.scoreboard.closingConnection
+==== apache.status.scoreboard.closingConnection
 
 type: integer
 
 Closing connections.
 
 
-==== apache-status.scoreboard.logging
+==== apache.status.scoreboard.logging
 
 type: integer
 
 Logging
 
 
-==== apache-status.scoreboard.gracefullyFinishing
+==== apache.status.scoreboard.gracefullyFinishing
 
 type: integer
 
 Gracefully finishing.
 
 
-==== apache-status.scoreboard.idleCleanup
+==== apache.status.scoreboard.idleCleanup
 
 type: integer
 
 Idle cleanups
 
 
-==== apache-status.scoreboard.openSlot
+==== apache.status.scoreboard.openSlot
 
 type: integer
 
 Open slots.
 
 
-==== apache-status.scoreboard.waitingForConnection
+==== apache.status.scoreboard.waitingForConnection
 
 type: integer
 
 Waiting for connections.
 
 
-==== apache-status.scoreboard.total
+==== apache.status.scoreboard.total
 
 type: integer
 
@@ -383,13 +389,19 @@ The document type. Always set to "metricsets".
 [[exported-fields-mysql]]
 === MySQL Status Fields
 
-MySQL server status metrics collected from a `SHOW GLOBAL STATUS` SQL query.
+MySQL server status metrics collected from MySQL
 
 
 
-=== mysql-status Fields
+=== mysql Fields
 
-`mysql-status` contains the metrics that were obtained the status SQL query.
+mysql contains the metrics that were obtained from MySQL query.
+
+
+
+=== status Fields
+
+`status` contains the metrics that were obtained by the status SQL query.
 
 
 
@@ -399,14 +411,14 @@ Aborted status fields
 
 
 
-==== mysql-status.aborted.Aborted_clients
+==== mysql.status.aborted.Aborted_clients
 
 type: integer
 
 The number of connections that were aborted because the client died without closing the connection properly.
 
 
-==== mysql-status.aborted.Aborted_connects
+==== mysql.status.aborted.Aborted_connects
 
 type: integer
 
@@ -419,14 +431,14 @@ Bytes stats
 
 
 
-==== mysql-status.bytes.Bytes_received
+==== mysql.status.bytes.Bytes_received
 
 type: integer
 
 The number of bytes received from all clients.
 
 
-==== mysql-status.bytes.Bytes_sent
+==== mysql.status.bytes.Bytes_sent
 
 type: integer
 
@@ -434,15 +446,21 @@ The number of bytes sent to all clients.
 
 
 [[exported-fields-redis]]
-=== Redis Info Fields
+=== Redis Fields
 
-Redis metrics collected from the Redis `INFO` command.
+Redis metrics collected from the Redis
 
 
 
-=== redis-info Fields
+=== redis Fields
 
-`redis-info` contains the information and statistics returned by the `INFO` command.
+`redis` contains the information and statistics from Redis
+
+
+
+=== info Fields
+
+`info` contains the information and statistics returned by the `INFO` command.
 
 
 
@@ -452,28 +470,28 @@ Redis client stats
 
 
 
-==== redis-info.clients.connected_clients
+==== redis.info.clients.connected_clients
 
 type: integer
 
 Number of client connections (excluding connections from slaves)
 
 
-==== redis-info.clients.client_longest_output_list
+==== redis.info.clients.client_longest_output_list
 
 type: integer
 
 Longest output list among current client connections.
 
 
-==== redis-info.clients.client_biggest_input_buf
+==== redis.info.clients.client_biggest_input_buf
 
 type: integer
 
 Biggest input buffer among current client connections
 
 
-==== redis-info.clients.blocked_clients
+==== redis.info.clients.blocked_clients
 
 type: integer
 
@@ -486,7 +504,7 @@ Redis cluster information
 
 
 
-==== redis-info.cluster.cluster_enabled
+==== redis.info.cluster.cluster_enabled
 
 type: boolean
 
@@ -499,28 +517,28 @@ Redis CPU stats
 
 
 
-==== redis-info.cpu.used_cpu_sys
+==== redis.info.cpu.used_cpu_sys
 
 type: float
 
 System CPU consumed by the Redis server
 
 
-==== redis-info.cpu.used_cpu_sys_children
+==== redis.info.cpu.used_cpu_sys_children
 
 type: float
 
 User CPU consumed by the Redis server
 
 
-==== redis-info.cpu.used_cpu_user
+==== redis.info.cpu.used_cpu_user
 
 type: float
 
 System CPU consumed by the background processes
 
 
-==== redis-info.cpu.used_cpu_user_children
+==== redis.info.cpu.used_cpu_user_children
 
 type: float
 
@@ -534,157 +552,163 @@ System status metrics, like CPU and memory usage, that are collected from the op
 
 
 
-=== system-cores Fields
+=== system Fields
+
+`system` contains local system metrics
+
+
+
+=== cores Fields
 
 `system-cores` contains local cpu core stats.
 
 
 
-==== system-cores.core
+==== system.cores.core
 
 type: integer
 
 CPU Core number.
 
 
-==== system-cores.user
+==== system.cores.user
 
 type: integer
 
 The amount of CPU time spent in user space.
 
 
-==== system-cores.user_p
+==== system.cores.user_p
 
 type: float
 
 The percentage of CPU time spent in user space. On multi-core systems, you can have percentages that are greater than 100%. For example, if 3 cores are at 60% use, then the `cpu.user_p` will be 180%.
 
 
-==== system-cores.nice
+==== system.cores.nice
 
 type: integer
 
 The amount of CPU time spent on low-priority processes.
 
 
-==== system-cores.system
+==== system.cores.system
 
 type: integer
 
 The amount of CPU time spent in kernel space.
 
 
-==== system-cores.system_p
+==== system.cores.system_p
 
 type: float
 
 The percentage of CPU time spent in kernel space.
 
 
-==== system-cores.idle
+==== system.cores.idle
 
 type: integer
 
 The amount of CPU time spent idle.
 
 
-==== system-cores.iowait
+==== system.cores.iowait
 
 type: integer
 
 The amount of CPU time spent in wait (on disk).
 
 
-==== system-cores.irq
+==== system.cores.irq
 
 type: integer
 
 The amount of CPU time spent servicing and handling hardware interrupts.
 
 
-==== system-cores.softirq
+==== system.cores.softirq
 
 type: integer
 
 The amount of CPU time spent servicing and handling software interrupts.
 
-==== system-cores.steal
+==== system.cores.steal
 
 type: integer
 
 The amount of CPU time spent in involuntary wait by the virtual CPU while the hypervisor was servicing another processor. Available only on Unix.
 
 
-=== system-cpu Fields
+=== cpu Fields
 
-`system-cpu` contains local cpu stats.
+`cpu` contains local cpu stats.
 
 
 
-==== system-cpu.user
+==== system.cpu.user
 
 type: integer
 
 The amount of CPU time spent in user space.
 
 
-==== system-cpu.user_p
+==== system.cpu.user_p
 
 type: float
 
 The percentage of CPU time spent in user space. On multi-core systems, you can have percentages that are greater than 100%. For example, if 3 cores are at 60% use, then the `cpu.user_p` will be 180%.
 
 
-==== system-cpu.nice
+==== system.cpu.nice
 
 type: integer
 
 The amount of CPU time spent on low-priority processes.
 
 
-==== system-cpu.system
+==== system.cpu.system
 
 type: integer
 
 The amount of CPU time spent in kernel space.
 
 
-==== system-cpu.system_p
+==== system.cpu.system_p
 
 type: float
 
 The percentage of CPU time spent in kernel space.
 
 
-==== system-cpu.idle
+==== system.cpu.idle
 
 type: integer
 
 The amount of CPU time spent idle.
 
 
-==== system-cpu.iowait
+==== system.cpu.iowait
 
 type: integer
 
 The amount of CPU time spent in wait (on disk).
 
 
-==== system-cpu.irq
+==== system.cpu.irq
 
 type: integer
 
 The amount of CPU time spent servicing and handling hardware interrupts.
 
 
-==== system-cpu.softirq
+==== system.cpu.softirq
 
 type: integer
 
 The amount of CPU time spent servicing and handling software interrupts.
 
-==== system-cpu.steal
+==== system.cpu.steal
 
 type: integer
 
@@ -697,34 +721,34 @@ Load averages.
 
 
 
-==== system-cpu.load.load1
+==== system.cpu.load.load1
 
 type: float
 
 Load average for the last minute.
 
 
-==== system-cpu.load.load5
+==== system.cpu.load.load5
 
 type: float
 
 Load average for the last 5 minutes.
 
 
-==== system-cpu.load.load15
+==== system.cpu.load.load15
 
 type: float
 
 Load average for the last 15 minutes.
 
 
-=== system-disk Fields
+=== disk Fields
 
-`system-disk` contains disk IO metrics collected from the operating system.
+`disk` contains disk IO metrics collected from the operating system.
 
 
 
-==== system-disk.name
+==== system.disk.name
 
 type: keyword
 
@@ -733,144 +757,144 @@ example: sda1
 The disk name.
 
 
-==== system-disk.serial_number
+==== system.disk.serial_number
 
 type: keyword
 
 The disk's serial number. This may not be provided by all operating systems.
 
 
-==== system-disk.read_count
+==== system.disk.read_count
 
 type: long
 
 This is the total number of reads completed successfully.
 
 
-==== system-disk.write_count
+==== system.disk.write_count
 
 type: long
 
 This is the total number of writes completed successfully.
 
 
-==== system-disk.read_bytes
+==== system.disk.read_bytes
 
 type: long
 
 This is the total number of bytes read successfully. On Linux this is the number of sectors read multiplied by an assumed sector size of 512.
 
 
-==== system-disk.write_bytes
+==== system.disk.write_bytes
 
 type: long
 
 This is the total number of bytes written successfully. On Linux this is the number of sectors written multiplied by an assumed sector size of 512.
 
 
-==== system-disk.read_time
+==== system.disk.read_time
 
 type: long
 
 This is the total number of milliseconds spent by all reads.
 
 
-==== system-disk.write_time
+==== system.disk.write_time
 
 type: long
 
 This is the total number of milliseconds spent by all writes.
 
 
-==== system-disk.io_time
+==== system.disk.io_time
 
 type: long
 
 This is the total number of of milliseconds spent doing I/Os.
 
 
-=== system-filesystem Fields
+=== filesystem Fields
 
-`system-filesystem` contains local filesystem stats
+`filesystem` contains local filesystem stats
 
 
 
-==== system-filesystem.avail
+==== system.filesystem.avail
 
 type: long
 
 The disk space available to an unprivileged user in bytes.
 
 
-==== system-filesystem.device_name
+==== system.filesystem.device_name
 
 type: keyword
 
 The disk name. For example: `/dev/disk1`
 
 
-==== system-filesystem.mount_point
+==== system.filesystem.mount_point
 
 type: keyword
 
 The mounting point. For example: `/`
 
 
-==== system-filesystem.files
+==== system.filesystem.files
 
 type: long
 
 The total number of file nodes in the file system.
 
 
-==== system-filesystem.free
+==== system.filesystem.free
 
 type: long
 
 The disk space available in bytes.
 
 
-==== system-filesystem.free_files
+==== system.filesystem.free_files
 
 type: long
 
 The number of free file nodes in the file system.
 
 
-==== system-filesystem.total
+==== system.filesystem.total
 
 type: long
 
 The total disk space in bytes.
 
 
-==== system-filesystem.used
+==== system.filesystem.used
 
 type: long
 
 The used disk space in bytes.
 
 
-==== system-filesystem.used_p
+==== system.filesystem.used_p
 
 type: float
 
 The percentage of used disk space.
 
 
-=== system-fsstats Fields
+=== fsstats Fields
 
 `system-fsstats` contains filesystem metrics aggregated from all mounted filesystems.
 
 
 
-==== system-fsstats.count
+==== system.fsstats.count
 
 type: long
 
 Number of file systems found.
 
-==== system-fsstats.total_files
+==== system.fsstats.total_files
 
 type: long
 
@@ -881,30 +905,30 @@ Total number of files.
 Nested file system docs.
 
 
-==== system-fsstats.total_size.free
+==== system.fsstats.total_size.free
 
 type: long
 
 Total free space.
 
 
-==== system-fsstats.total_size.used
+==== system.fsstats.total_size.used
 
 type: long
 
 Total used space.
 
 
-==== system-fsstats.total_size.total
+==== system.fsstats.total_size.total
 
 type: long
 
 Total space (used plus free).
 
 
-=== system-memory Fields
+=== memory Fields
 
-`system-memory` contains local memory stats.
+`memory` contains local memory stats.
 
 
 
@@ -914,49 +938,49 @@ Total space (used plus free).
 This group contains statistics related to the memory usage on the system.
 
 
-==== system-memory.mem.total
+==== system.memory.mem.total
 
 type: long
 
 Total memory.
 
 
-==== system-memory.mem.used
+==== system.memory.mem.used
 
 type: long
 
 Used memory.
 
 
-==== system-memory.mem.free
+==== system.memory.mem.free
 
 type: long
 
 Available memory.
 
 
-==== system-memory.mem.used_p
+==== system.memory.mem.used_p
 
 type: float
 
 The percentage of used memory.
 
 
-==== system-memory.mem.actual_used
+==== system.memory.mem.actual_used
 
 type: long
 
 Actual used memory. This value is the "used" memory minus the memory used for disk caches and buffers. Available only on Unix.
 
 
-==== system-memory.mem.actual_free
+==== system.memory.mem.actual_free
 
 type: long
 
 Actual available memory. This value is the "free" memory plus the memory used for disk caches and buffers. Available only on Unix.
 
 
-==== system-memory.mem.actual_used_p
+==== system.memory.mem.actual_used_p
 
 type: float
 
@@ -969,76 +993,76 @@ The percentage of actual used memory.
 This group contains statistics related to the swap memory usage on the system.
 
 
-==== system-memory.swap.total
+==== system.memory.swap.total
 
 type: long
 
 Total swap memory.
 
 
-==== system-memory.swap.used
+==== system.memory.swap.used
 
 type: long
 
 Used swap memory.
 
 
-==== system-memory.swap.free
+==== system.memory.swap.free
 
 type: long
 
 Available swap memory.
 
 
-==== system-memory.swap.used_p
+==== system.memory.swap.used_p
 
 type: float
 
 The percentage of used swap memory.
 
 
-=== system-process Fields
+=== process Fields
 
-`system-process` contains process metadata, CPU metrics, and memory metrics.
+`process` contains process metadata, CPU metrics, and memory metrics.
 
 
 
-==== system-process.name
+==== system.process.name
 
 type: keyword
 
 The process name.
 
 
-==== system-process.state
+==== system.process.state
 
 type: keyword
 
 The process state. For example: "running"
 
 
-==== system-process.pid
+==== system.process.pid
 
 type: integer
 
 The process pid.
 
 
-==== system-process.ppid
+==== system.process.ppid
 
 type: integer
 
 The process parent pid.
 
 
-==== system-process.cmdline
+==== system.process.cmdline
 
 type: keyword
 
 The full command-line used to start the process, including the arguments separated by space.
 
 
-==== system-process.username
+==== system.process.username
 
 type: keyword
 
@@ -1051,35 +1075,35 @@ The username of the user that created the process. If the username can not be de
 CPU-specific statistics per process.
 
 
-==== system-process.cpu.user
+==== system.process.cpu.user
 
 type: long
 
 The amount of CPU time the process spent in user space.
 
 
-==== system-process.cpu.total_p
+==== system.process.cpu.total_p
 
 type: float
 
 The percentage of CPU time spent by the process since the last update. Its value is similar with the %CPU value of the process displayed by the top command on unix systems.
 
 
-==== system-process.cpu.system
+==== system.process.cpu.system
 
 type: long
 
 The amount of CPU time the process spent in kernel space.
 
 
-==== system-process.cpu.total
+==== system.process.cpu.total
 
 type: long
 
 The total CPU time spent by the process.
 
 
-==== system-process.cpu.start_time
+==== system.process.cpu.start_time
 
 type: keyword
 
@@ -1092,28 +1116,28 @@ The time when the process was started. Example: "17:45".
 Memory-specific statistics per process.
 
 
-==== system-process.mem.size
+==== system.process.mem.size
 
 type: long
 
 The total virtual memory the process has.
 
 
-==== system-process.mem.rss
+==== system.process.mem.rss
 
 type: long
 
 The Resident Set Size. The amount of memory the process occupied in main memory (RAM).
 
 
-==== system-process.mem.rss_p
+==== system.process.mem.rss_p
 
 type: float
 
 The percentage of memory the process occupied in main memory (RAM).
 
 
-==== system-process.mem.share
+==== system.process.mem.share
 
 type: long
 
@@ -1127,139 +1151,145 @@ ZooKeeper metrics collected by the four-letter monitoring commands.
 
 
 
-=== zookeeper-mntr Fields
+=== zookeeper Fields
 
-`zookeeper-mntr` contains the metrics reported by the four-letter `mntr` command.
+`zookeeper` contains the metrics reported by zookeeper command.
 
 
 
-==== zookeeper-mntr.hostname
+=== mntr Fields
+
+`mntr` contains the metrics reported by the four-letter `mntr` command.
+
+
+
+==== zookeeper.mntr.hostname
 
 type: keyword
 
 Zookeeper hostname.
 
 
-==== zookeeper-mntr.zk_approximate_data_size
+==== zookeeper.mntr.zk_approximate_data_size
 
 type: long
 
 Approximate size of zookeeper data.
 
 
-==== zookeeper-mntr.zk_avg_latency
+==== zookeeper.mntr.zk_avg_latency
 
 type: integer
 
 Average latency between ensemble hosts in milliseconds.
 
 
-==== zookeeper-mntr.zk_ephemerals_count
+==== zookeeper.mntr.zk_ephemerals_count
 
 type: integer
 
 Number of ephemeral znodes.
 
 
-==== zookeeper-mntr.zk_followers
+==== zookeeper.mntr.zk_followers
 
 type: integer
 
 Number of followers seen by the current host.
 
 
-==== zookeeper-mntr.zk_max_file_descriptor_count
+==== zookeeper.mntr.zk_max_file_descriptor_count
 
 type: integer
 
 Maximum number of file descriptors allowed for the zookeeper process.
 
 
-==== zookeeper-mntr.zk_max_latency
+==== zookeeper.mntr.zk_max_latency
 
 type: integer
 
 Maximum latency in milliseconds.
 
 
-==== zookeeper-mntr.zk_min_latency
+==== zookeeper.mntr.zk_min_latency
 
 type: integer
 
 Minimum latency in milliseconds.
 
 
-==== zookeeper-mntr.zk_num_alive_connections
+==== zookeeper.mntr.zk_num_alive_connections
 
 type: integer
 
 Number of connections to zookeeper that are currently alive.
 
 
-==== zookeeper-mntr.zk_open_file_descriptor_count
+==== zookeeper.mntr.zk_open_file_descriptor_count
 
 type: integer
 
 Number of file descriptors open by the zookeeper process.
 
 
-==== zookeeper-mntr.zk_outstanding_requests
+==== zookeeper.mntr.zk_outstanding_requests
 
 type: integer
 
 Number of outstanding requests that need to be processed by the cluster.
 
 
-==== zookeeper-mntr.zk_packets_received
+==== zookeeper.mntr.zk_packets_received
 
 type: integer
 
 Number zookeeper network packets received.
 
 
-==== zookeeper-mntr.zk_packets_sent
+==== zookeeper.mntr.zk_packets_sent
 
 type: long
 
 Number zookeeper network packets sent.
 
 
-==== zookeeper-mntr.zk_pending_syncs
+==== zookeeper.mntr.zk_pending_syncs
 
 type: integer
 
 Number of pending syncs to carry out to zookeeper ensemble followers.
 
 
-==== zookeeper-mntr.zk_server_state
+==== zookeeper.mntr.zk_server_state
 
 type: keyword
 
 Role in the zookeeper ensemble.
 
 
-==== zookeeper-mntr.zk_synced_followers
+==== zookeeper.mntr.zk_synced_followers
 
 type: integer
 
 Number of synced followers reported when a node server_state is leader.
 
 
-==== zookeeper-mntr.zk_version
+==== zookeeper.mntr.zk_version
 
 type: keyword
 
 Zookeeper version and build string reported.
 
 
-==== zookeeper-mntr.zk_watch_count
+==== zookeeper.mntr.zk_watch_count
 
 type: integer
 
 Number of watches currently set on the local zookeeper process.
 
 
-==== zookeeper-mntr.zk_znode_count
+==== zookeeper.mntr.zk_znode_count
 
 type: integer
 

--- a/metricbeat/etc/fields.yml
+++ b/metricbeat/etc/fields.yml
@@ -33,791 +33,811 @@
   description: >
     Apache HTTPD server metrics collected from the mod_status module.
   fields:
-
-    - name: apache-status
+    - name: apache
       type: group
       description: >
-        `apache-status` contains the metrics that were scraped from the status
-        page.
+        apache contains the metrics that were scraped from apache.
       fields:
-        - name: hostname
-          type: keyword
-          description: >
-            Apache hostname.
-        - name: totalAccesses
-          type: integer
-          description: >
-            Total number of access requests.
-        - name: totalKBytes
-          type: integer
-          description: >
-            Total number of kilobytes served.
-        - name: reqPerSec
-          type: float
-          description: >
-            Requests per second.
-        - name: bytesPerSec
-          type: float
-          description: >
-            Bytes per second.
-        - name: bytesPerReq
-          type: float
-          description: >
-            Bytes per request.
-        - name: busyWorkers
-          type: integer
-          description: >
-            Number of busy workers.
-        - name: idleWorkers
-          type: integer
-          description: >
-            Number of idle workers.
-        - name: uptime
+        - name: status
           type: group
           description: >
-            Uptime stats.
+            `status` contains the metrics that were scraped from the apache status page.
           fields:
-            - name: serverUptimeSeconds
+            - name: hostname
+              type: keyword
+              description: >
+                Apache hostname.
+            - name: totalAccesses
               type: integer
               description: >
-                Server uptime in seconds.
+                Total number of access requests.
+            - name: totalKBytes
+              type: integer
+              description: >
+                Total number of kilobytes served.
+            - name: reqPerSec
+              type: float
+              description: >
+                Requests per second.
+            - name: bytesPerSec
+              type: float
+              description: >
+                Bytes per second.
+            - name: bytesPerReq
+              type: float
+              description: >
+                Bytes per request.
+            - name: busyWorkers
+              type: integer
+              description: >
+                Number of busy workers.
+            - name: idleWorkers
+              type: integer
+              description: >
+                Number of idle workers.
             - name: uptime
-              type: integer
+              type: group
               description: >
-                Server uptime.
-        - name: cpu
-          type: group
-          description: >
-            CPU stats.
-          fields:
-            - name: cpuLoad
-              type: float
+                Uptime stats.
+              fields:
+                - name: serverUptimeSeconds
+                  type: integer
+                  description: >
+                    Server uptime in seconds.
+                - name: uptime
+                  type: integer
+                  description: >
+                    Server uptime.
+            - name: cpu
+              type: group
               description: >
-                CPU Load.
-            - name: cpuUser
-              type: float
+                CPU stats.
+              fields:
+                - name: cpuLoad
+                  type: float
+                  description: >
+                    CPU Load.
+                - name: cpuUser
+                  type: float
+                  description: >
+                    CPU user load.
+                - name: cpuSystem
+                  type: float
+                  description: >
+                    System cpu.
+                - name: cpuChildrenUser
+                  type: float
+                  description: >
+                    CPU of children user.
+                - name: cpuChildrenSystem
+                  type: float
+                  description: >
+                    CPU of children system.
+            - name: connections
+              type: group
               description: >
-                CPU user load.
-            - name: cpuSystem
-              type: float
+                Connection stats.
+              fields:
+                - name: connsTotal
+                  type: integer
+                  description: >
+                    Total connections.
+                - name: connsAsyncWriting
+                  type: integer
+                  description: >
+                    Async connection writing.
+                - name: connsAsyncKeepAlive
+                  type: integer
+                  description: >
+                    Async keeped alive connections.
+                - name: connsAsyncClosing
+                  type: integer
+                  description: >
+                    Async closed connections.
+            - name: load
+              type: group
               description: >
-                System cpu.
-            - name: cpuChildrenUser
-              type: float
+                Load averages.
+              fields:
+                - name: load1
+                  type: float
+                  description: >
+                    Load average for the last minute.
+                - name: load5
+                  type: float
+                  description: >
+                    Load average for the last 5 minutes.
+                - name: load15
+                  type: float
+                  description: >
+                    Load average for the last 15 minutes.
+            - name: scoreboard
+              type: group
               description: >
-                CPU of children user.
-            - name: cpuChildrenSystem
-              type: float
-              description: >
-                CPU of children system.
-        - name: connections
-          type: group
-          description: >
-            Connection stats.
-          fields:
-            - name: connsTotal
-              type: integer
-              description: >
-                Total connections.
-            - name: connsAsyncWriting
-              type: integer
-              description: >
-                Async connection writing.
-            - name: connsAsyncKeepAlive
-              type: integer
-              description: >
-                Async keeped alive connections.
-            - name: connsAsyncClosing
-              type: integer
-              description: >
-                Async closed connections.
-        - name: load
-          type: group
-          description: >
-            Load averages.
-          fields:
-            - name: load1
-              type: float
-              description: >
-                Load average for the last minute.
-            - name: load5
-              type: float
-              description: >
-                Load average for the last 5 minutes.
-            - name: load15
-              type: float
-              description: >
-                Load average for the last 15 minutes.
-        - name: scoreboard
-          type: group
-          description: >
-            Scoreboard metrics.
-          fields:
-            - name: startingUp
-              type: integer
-              description: >
-                Starting up.
-            - name: readingRequest
-              type: integer
-              description: >
-                Reading requests.
-            - name: sendingReply
-              type: integer
-              description: >
-                Sending Reply.
-            - name: keepalive
-              type: integer
-              description: >
-                Keep alive.
-            - name: dnsLookup
-              type: integer
-              description: >
-                Dns Lookups.
-            - name: closingConnection
-              type: integer
-              description: >
-                Closing connections.
-            - name: logging
-              type: integer
-              description: >
-                Logging
-            - name: gracefullyFinishing
-              type: integer
-              description: >
-                Gracefully finishing.
-            - name: idleCleanup
-              type: integer
-              description: >
-                Idle cleanups
-            - name: openSlot
-              type: integer
-              description: >
-                Open slots.
-            - name: waitingForConnection
-              type: integer
-              description: >
-                Waiting for connections.
-            - name: total
-              type: integer
-              description: >
-                Total.
+                Scoreboard metrics.
+              fields:
+                - name: startingUp
+                  type: integer
+                  description: >
+                    Starting up.
+                - name: readingRequest
+                  type: integer
+                  description: >
+                    Reading requests.
+                - name: sendingReply
+                  type: integer
+                  description: >
+                    Sending Reply.
+                - name: keepalive
+                  type: integer
+                  description: >
+                    Keep alive.
+                - name: dnsLookup
+                  type: integer
+                  description: >
+                    Dns Lookups.
+                - name: closingConnection
+                  type: integer
+                  description: >
+                    Closing connections.
+                - name: logging
+                  type: integer
+                  description: >
+                    Logging
+                - name: gracefullyFinishing
+                  type: integer
+                  description: >
+                    Gracefully finishing.
+                - name: idleCleanup
+                  type: integer
+                  description: >
+                    Idle cleanups
+                - name: openSlot
+                  type: integer
+                  description: >
+                    Open slots.
+                - name: waitingForConnection
+                  type: integer
+                  description: >
+                    Waiting for connections.
+                - name: total
+                  type: integer
+                  description: >
+                    Total.
 - key: mysql
   title: "MySQL Status"
   description: >
-    MySQL server status metrics collected from a `SHOW GLOBAL STATUS` SQL query.
+    MySQL server status metrics collected from MySQL
   fields:
-
-    - name: mysql-status
+    - name: mysql
       type: group
       description: >
-        `mysql-status` contains the metrics that were obtained the status SQL
+        mysql contains the metrics that were obtained from MySQL
         query.
       fields:
-        - name: aborted
+        - name: status
           type: group
           description: >
-            Aborted status fields
+            `status` contains the metrics that were obtained by the status SQL query.
           fields:
-            - name: Aborted_clients
-              type: integer
+            - name: aborted
+              type: group
               description: >
-                The number of connections that were aborted because the client died without closing the connection properly.
+                Aborted status fields
+              fields:
+                - name: Aborted_clients
+                  type: integer
+                  description: >
+                    The number of connections that were aborted because the client died without closing the connection properly.
 
-            - name: Aborted_connects
-              type: integer
-              description: >
-                The number of failed attempts to connect to the MySQL server.
+                - name: Aborted_connects
+                  type: integer
+                  description: >
+                    The number of failed attempts to connect to the MySQL server.
 
-        - name: bytes
-          type: group
-          description: >
-            Bytes stats
-          fields:
-            - name: Bytes_received
-              type: integer
+            - name: bytes
+              type: group
               description: >
-                The number of bytes received from all clients.
+                Bytes stats
+              fields:
+                - name: Bytes_received
+                  type: integer
+                  description: >
+                    The number of bytes received from all clients.
 
-            - name: Bytes_sent
-              type: integer
-              description: >
-                The number of bytes sent to all clients.
+                - name: Bytes_sent
+                  type: integer
+                  description: >
+                    The number of bytes sent to all clients.
 - key: redis
-  title: "Redis Info"
+  title: "Redis"
   description: >
-    Redis metrics collected from the Redis `INFO` command.
+    Redis metrics collected from the Redis
   fields:
-    - name: redis-info
+    - name: redis
       type: group
       description: >
-        `redis-info` contains the information and statistics returned by the
-        `INFO` command.
+        `redis` contains the information and statistics from Redis
       fields:
-        - name: clients
+        - name: info
           type: group
           description: >
-            Redis client stats
+            `info` contains the information and statistics returned by the `INFO` command.
           fields:
-            - name: connected_clients
-              type: integer
+            - name: clients
+              type: group
               description: >
-                Number of client connections (excluding connections from slaves)
+                Redis client stats
+              fields:
+                - name: connected_clients
+                  type: integer
+                  description: >
+                    Number of client connections (excluding connections from slaves)
 
-            - name: client_longest_output_list
-              type: integer
-              description: >
-                Longest output list among current client connections.
+                - name: client_longest_output_list
+                  type: integer
+                  description: >
+                    Longest output list among current client connections.
 
-            - name: client_biggest_input_buf
-              type: integer
-              description: >
-                Biggest input buffer among current client connections
+                - name: client_biggest_input_buf
+                  type: integer
+                  description: >
+                    Biggest input buffer among current client connections
 
-            - name: blocked_clients
-              type: integer
-              description: >
-                Number of clients pending on a blocking call (BLPOP, BRPOP, BRPOPLPUSH)
+                - name: blocked_clients
+                  type: integer
+                  description: >
+                    Number of clients pending on a blocking call (BLPOP, BRPOP, BRPOPLPUSH)
 
-        - name: cluster
-          type: group
-          description: >
-            Redis cluster information
-          fields:
-            - name: cluster_enabled
-              type: boolean
+            - name: cluster
+              type: group
               description: >
-                Indicate Redis cluster is enabled
+                Redis cluster information
+              fields:
+                - name: cluster_enabled
+                  type: boolean
+                  description: >
+                    Indicate Redis cluster is enabled
 
-        - name: cpu
-          type: group
-          description: >
-            Redis CPU stats
-          fields:
-            - name: used_cpu_sys
-              type: float
+            - name: cpu
+              type: group
               description: >
-                System CPU consumed by the Redis server
+                Redis CPU stats
+              fields:
+                - name: used_cpu_sys
+                  type: float
+                  description: >
+                    System CPU consumed by the Redis server
 
-            - name: used_cpu_sys_children
-              type: float
-              description: >
-                User CPU consumed by the Redis server
+                - name: used_cpu_sys_children
+                  type: float
+                  description: >
+                    User CPU consumed by the Redis server
 
-            - name: used_cpu_user
-              type: float
-              description: >
-                System CPU consumed by the background processes
+                - name: used_cpu_user
+                  type: float
+                  description: >
+                    System CPU consumed by the background processes
 
-            - name: used_cpu_user_children
-              type: float
-              description: >
-                User CPU consumed by the background processes
+                - name: used_cpu_user_children
+                  type: float
+                  description: >
+                    User CPU consumed by the background processes
 - key: system
   title: System Status
   description: >
     System status metrics, like CPU and memory usage, that are collected from the operating system.
   fields:
-
-    - name: system-cores
+    - name: system
       type: group
       description: >
-        `system-cores` contains local cpu core stats.
+        `system` contains local system metrics
       fields:
-        - name: core
-          type: integer
-          description: >
-            CPU Core number.
-
-        - name: user
-          type: integer
-          description: >
-           The amount of CPU time spent in user space.
-
-        - name: user_p
-          type: float
-          description: >
-            The percentage of CPU time spent in user space. On multi-core systems, you can have percentages that are greater than 100%.
-            For example, if 3 cores are at 60% use, then the `cpu.user_p` will be 180%.
-
-        - name: nice
-          type: integer
-          description: >
-            The amount of CPU time spent on low-priority processes.
-
-        - name: system
-          type: integer
-          description: >
-            The amount of CPU time spent in kernel space.
-
-        - name: system_p
-          type: float
-          description: >
-            The percentage of CPU time spent in kernel space.
-
-        - name: idle
-          type: integer
-          description: >
-            The amount of CPU time spent idle.
-
-        - name: iowait
-          type: integer
-          description: >
-            The amount of CPU time spent in wait (on disk).
-
-        - name: irq
-          type: integer
-          description: >
-            The amount of CPU time spent servicing and handling hardware interrupts.
-
-        - name: softirq
-          type: integer
-          description:
-            The amount of CPU time spent servicing and handling software interrupts.
-
-        - name: steal
-          type: integer
-          description: >
-            The amount of CPU time spent in involuntary wait by the virtual CPU while the hypervisor
-            was servicing another processor.
-            Available only on Unix.
-
-    - name: system-cpu
-      type: group
-      description: >
-        `system-cpu` contains local cpu stats.
-      fields:
-        - name: user
-          type: integer
-          description: >
-           The amount of CPU time spent in user space.
-
-        - name: user_p
-          type: float
-          description: >
-            The percentage of CPU time spent in user space. On multi-core systems, you can have percentages that are greater than 100%.
-            For example, if 3 cores are at 60% use, then the `cpu.user_p` will be 180%.
-
-        - name: nice
-          type: integer
-          description: >
-            The amount of CPU time spent on low-priority processes.
-
-        - name: system
-          type: integer
-          description: >
-            The amount of CPU time spent in kernel space.
-
-        - name: system_p
-          type: float
-          description: >
-            The percentage of CPU time spent in kernel space.
-
-        - name: idle
-          type: integer
-          description: >
-            The amount of CPU time spent idle.
-
-        - name: iowait
-          type: integer
-          description: >
-            The amount of CPU time spent in wait (on disk).
-
-        - name: irq
-          type: integer
-          description: >
-            The amount of CPU time spent servicing and handling hardware interrupts.
-
-        - name: softirq
-          type: integer
-          description:
-            The amount of CPU time spent servicing and handling software interrupts.
-
-        - name: steal
-          type: integer
-          description: >
-            The amount of CPU time spent in involuntary wait by the virtual CPU while the hypervisor
-            was servicing another processor.
-            Available only on Unix.
-
-        - name: load
+        - name: cores
           type: group
           description: >
-            Load averages.
+            `system-cores` contains local cpu core stats.
           fields:
-            - name: load1
+            - name: core
+              type: integer
+              description: >
+                CPU Core number.
+
+            - name: user
+              type: integer
+              description: >
+               The amount of CPU time spent in user space.
+
+            - name: user_p
               type: float
               description: >
-                Load average for the last minute.
-            - name: load5
+                The percentage of CPU time spent in user space. On multi-core systems, you can have percentages that are greater than 100%.
+                For example, if 3 cores are at 60% use, then the `cpu.user_p` will be 180%.
+
+            - name: nice
+              type: integer
+              description: >
+                The amount of CPU time spent on low-priority processes.
+
+            - name: system
+              type: integer
+              description: >
+                The amount of CPU time spent in kernel space.
+
+            - name: system_p
               type: float
               description: >
-                Load average for the last 5 minutes.
-            - name: load15
-              type: float
+                The percentage of CPU time spent in kernel space.
+
+            - name: idle
+              type: integer
               description: >
-                Load average for the last 15 minutes.
-    - name: system-disk
-      type: group
-      description: >
-        `system-disk` contains disk IO metrics collected from the operating system.
-      fields:
-        - name: name
-          type: keyword
-          example: sda1
-          description: >
-            The disk name.
+                The amount of CPU time spent idle.
 
-        - name: serial_number
-          type: keyword
-          description: >
-            The disk's serial number. This may not be provided by all operating
-            systems.
-
-        - name: read_count
-          type: long
-          description: >
-            This is the total number of reads completed successfully.
-
-        - name: write_count
-          type: long
-          description: >
-            This is the total number of writes completed successfully.
-
-        - name: read_bytes
-          type: long
-          description: >
-            This is the total number of bytes read successfully. On Linux this is
-            the number of sectors read multiplied by an assumed sector size of 512.
-
-        - name: write_bytes
-          type: long
-          description: >
-            This is the total number of bytes written successfully. On Linux this is
-            the number of sectors written multiplied by an assumed sector size of
-            512.
-
-        - name: read_time
-          type: long
-          description: >
-            This is the total number of milliseconds spent by all reads.
-
-        - name: write_time
-          type: long
-          description: >
-            This is the total number of milliseconds spent by all writes.
-
-        - name: io_time
-          type: long
-          description: >
-            This is the total number of of milliseconds spent doing I/Os.
-    - name: system-filesystem
-      type: group
-      description: >
-        `system-filesystem` contains local filesystem stats
-      fields:
-        - name: avail
-          type: long
-          description: >
-            The disk space available to an unprivileged user in bytes.
-        - name: device_name
-          type: keyword
-          description: >
-            The disk name. For example: `/dev/disk1`
-        - name: mount_point
-          type: keyword
-          description: >
-            The mounting point. For example: `/`
-        - name: files
-          type: long
-          description: >
-            The total number of file nodes in the file system.
-        - name: free
-          type: long
-          description: >
-            The disk space available in bytes.
-        - name: free_files
-          type: long
-          description: >
-            The number of free file nodes in the file system.
-        - name: total
-          type: long
-          description: >
-            The total disk space in bytes.
-        - name: used
-          type: long
-          description: >
-            The used disk space in bytes.
-        - name: used_p
-          type: float
-          description: >
-            The percentage of used disk space.
-
-
-    - name: system-fsstats
-      type: group
-      description: >
-        `system-fsstats` contains filesystem metrics aggregated from all mounted
-        filesystems.
-      fields:
-        - name: count
-          type: long
-          description: Number of file systems found.
-        - name: total_files
-          type: long
-          description: Total number of files.
-        - name: total_size
-          type: group
-          description: Nested file system docs.
-          fields:
-            - name: free
-              type: long
+            - name: iowait
+              type: integer
               description: >
-                Total free space.
-            - name: used
-              type: long
-              description: >
-                Total used space.
-            - name: total
-              type: long
-              description: >
-                Total space (used plus free).
-    - name: system-memory
-      type: group
-      description: >
-        `system-memory` contains local memory stats.
-      fields:
-        - name: mem
-          type: group
-          prefix: "[float]"
-          description: This group contains statistics related to the memory usage on the system.
-          fields:
-            - name: total
-              type: long
-              description: >
-                Total memory.
+                The amount of CPU time spent in wait (on disk).
 
-            - name: used
-              type: long
+            - name: irq
+              type: integer
               description: >
-                Used memory.
+                The amount of CPU time spent servicing and handling hardware interrupts.
 
-            - name: free
-              type: long
-              description: >
-                Available memory.
+            - name: softirq
+              type: integer
+              description:
+                The amount of CPU time spent servicing and handling software interrupts.
 
-            - name: used_p
-              type: float
+            - name: steal
+              type: integer
               description: >
-                The percentage of used memory.
-
-            - name: actual_used
-              type: long
-              description: >
-                Actual used memory. This value is the "used" memory minus the memory used for disk caches and buffers.
+                The amount of CPU time spent in involuntary wait by the virtual CPU while the hypervisor
+                was servicing another processor.
                 Available only on Unix.
 
-            - name: actual_free
-              type: long
+        - name: cpu
+          type: group
+          description: >
+            `cpu` contains local cpu stats.
+          fields:
+            - name: user
+              type: integer
               description: >
-                Actual available memory. This value is the "free" memory plus the memory used for disk caches and
-                buffers. Available only on Unix.
+               The amount of CPU time spent in user space.
 
-            - name: actual_used_p
+            - name: user_p
               type: float
               description: >
-                The percentage of actual used memory.
+                The percentage of CPU time spent in user space. On multi-core systems, you can have percentages that are greater than 100%.
+                For example, if 3 cores are at 60% use, then the `cpu.user_p` will be 180%.
 
-        - name: swap
+            - name: nice
+              type: integer
+              description: >
+                The amount of CPU time spent on low-priority processes.
+
+            - name: system
+              type: integer
+              description: >
+                The amount of CPU time spent in kernel space.
+
+            - name: system_p
+              type: float
+              description: >
+                The percentage of CPU time spent in kernel space.
+
+            - name: idle
+              type: integer
+              description: >
+                The amount of CPU time spent idle.
+
+            - name: iowait
+              type: integer
+              description: >
+                The amount of CPU time spent in wait (on disk).
+
+            - name: irq
+              type: integer
+              description: >
+                The amount of CPU time spent servicing and handling hardware interrupts.
+
+            - name: softirq
+              type: integer
+              description:
+                The amount of CPU time spent servicing and handling software interrupts.
+
+            - name: steal
+              type: integer
+              description: >
+                The amount of CPU time spent in involuntary wait by the virtual CPU while the hypervisor
+                was servicing another processor.
+                Available only on Unix.
+
+            - name: load
+              type: group
+              description: >
+                Load averages.
+              fields:
+                - name: load1
+                  type: float
+                  description: >
+                    Load average for the last minute.
+                - name: load5
+                  type: float
+                  description: >
+                    Load average for the last 5 minutes.
+                - name: load15
+                  type: float
+                  description: >
+                    Load average for the last 15 minutes.
+        - name: disk
           type: group
-          prefix: "[float]"
-          description: This group contains statistics related to the swap memory usage on the system.
+          description: >
+            `disk` contains disk IO metrics collected from the operating system.
           fields:
-            - name: total
+            - name: name
+              type: keyword
+              example: sda1
+              description: >
+                The disk name.
+
+            - name: serial_number
+              type: keyword
+              description: >
+                The disk's serial number. This may not be provided by all operating
+                systems.
+
+            - name: read_count
               type: long
               description: >
-                Total swap memory.
+                This is the total number of reads completed successfully.
 
-            - name: used
+            - name: write_count
               type: long
               description: >
-                Used swap memory.
+                This is the total number of writes completed successfully.
 
+            - name: read_bytes
+              type: long
+              description: >
+                This is the total number of bytes read successfully. On Linux this is
+                the number of sectors read multiplied by an assumed sector size of 512.
+
+            - name: write_bytes
+              type: long
+              description: >
+                This is the total number of bytes written successfully. On Linux this is
+                the number of sectors written multiplied by an assumed sector size of
+                512.
+
+            - name: read_time
+              type: long
+              description: >
+                This is the total number of milliseconds spent by all reads.
+
+            - name: write_time
+              type: long
+              description: >
+                This is the total number of milliseconds spent by all writes.
+
+            - name: io_time
+              type: long
+              description: >
+                This is the total number of of milliseconds spent doing I/Os.
+        - name: filesystem
+          type: group
+          description: >
+            `filesystem` contains local filesystem stats
+          fields:
+            - name: avail
+              type: long
+              description: >
+                The disk space available to an unprivileged user in bytes.
+            - name: device_name
+              type: keyword
+              description: >
+                The disk name. For example: `/dev/disk1`
+            - name: mount_point
+              type: keyword
+              description: >
+                The mounting point. For example: `/`
+            - name: files
+              type: long
+              description: >
+                The total number of file nodes in the file system.
             - name: free
               type: long
               description: >
-                Available swap memory.
-
-            - name: used_p
-              type: float
-              description: >
-                The percentage of used swap memory.
-    - name: system-process
-      type: group
-      description: >
-        `system-process` contains process metadata, CPU metrics, and memory metrics.
-      fields:
-        - name: name
-          type: keyword
-          description: >
-            The process name.
-        - name: state
-          type: keyword
-          description: >
-            The process state. For example: "running"
-        - name: pid
-          type: integer
-          description: >
-            The process pid.
-        - name: ppid
-          type: integer
-          description: >
-            The process parent pid.
-        - name: cmdline
-          type: keyword
-          description: >
-            The full command-line used to start the process, including the
-            arguments separated by space.
-        - name: username
-          type: keyword
-          description: >
-            The username of the user that created the process. If the username
-            can not be determined then the the field will contain the user's
-            numeric identifier (UID). On Windows, this field includes the user's
-            domain and is formatted as `domain\username`.
-        - name: cpu
-          type: group
-          prefix: "[float]"
-          description: CPU-specific statistics per process.
-          fields:
-            - name: user
+                The disk space available in bytes.
+            - name: free_files
               type: long
               description: >
-                The amount of CPU time the process spent in user space.
-            - name: total_p
-              type: float
-              description: >
-                The percentage of CPU time spent by the process since the last update. Its value is similar with the
-                %CPU value of the process displayed by the top command on unix systems.
-            - name: system
-              type: long
-              description: >
-                The amount of CPU time the process spent in kernel space.
+                The number of free file nodes in the file system.
             - name: total
               type: long
               description: >
-                The total CPU time spent by the process.
-            - name: start_time
-              type: keyword
-              description: >
-                The time when the process was started. Example: "17:45".
-        - name: mem
-          type: group
-          description: Memory-specific statistics per process.
-          prefix: "[float]"
-          fields:
-            - name: size
+                The total disk space in bytes.
+            - name: used
               type: long
               description: >
-                The total virtual memory the process has.
-            - name: rss
-              type: long
-              description: >
-                The Resident Set Size. The amount of memory the process occupied in main memory (RAM).
-            - name: rss_p
+                The used disk space in bytes.
+            - name: used_p
               type: float
               description: >
-                The percentage of memory the process occupied in main memory (RAM).
-            - name: share
+                The percentage of used disk space.
+
+
+        - name: fsstats
+          type: group
+          description: >
+            `system-fsstats` contains filesystem metrics aggregated from all mounted
+            filesystems.
+          fields:
+            - name: count
               type: long
+              description: Number of file systems found.
+            - name: total_files
+              type: long
+              description: Total number of files.
+            - name: total_size
+              type: group
+              description: Nested file system docs.
+              fields:
+                - name: free
+                  type: long
+                  description: >
+                    Total free space.
+                - name: used
+                  type: long
+                  description: >
+                    Total used space.
+                - name: total
+                  type: long
+                  description: >
+                    Total space (used plus free).
+        - name: memory
+          type: group
+          description: >
+            `memory` contains local memory stats.
+          fields:
+            - name: mem
+              type: group
+              prefix: "[float]"
+              description: This group contains statistics related to the memory usage on the system.
+              fields:
+                - name: total
+                  type: long
+                  description: >
+                    Total memory.
+
+                - name: used
+                  type: long
+                  description: >
+                    Used memory.
+
+                - name: free
+                  type: long
+                  description: >
+                    Available memory.
+
+                - name: used_p
+                  type: float
+                  description: >
+                    The percentage of used memory.
+
+                - name: actual_used
+                  type: long
+                  description: >
+                    Actual used memory. This value is the "used" memory minus the memory used for disk caches and buffers.
+                    Available only on Unix.
+
+                - name: actual_free
+                  type: long
+                  description: >
+                    Actual available memory. This value is the "free" memory plus the memory used for disk caches and
+                    buffers. Available only on Unix.
+
+                - name: actual_used_p
+                  type: float
+                  description: >
+                    The percentage of actual used memory.
+
+            - name: swap
+              type: group
+              prefix: "[float]"
+              description: This group contains statistics related to the swap memory usage on the system.
+              fields:
+                - name: total
+                  type: long
+                  description: >
+                    Total swap memory.
+
+                - name: used
+                  type: long
+                  description: >
+                    Used swap memory.
+
+                - name: free
+                  type: long
+                  description: >
+                    Available swap memory.
+
+                - name: used_p
+                  type: float
+                  description: >
+                    The percentage of used swap memory.
+        - name: process
+          type: group
+          description: >
+            `process` contains process metadata, CPU metrics, and memory metrics.
+          fields:
+            - name: name
+              type: keyword
               description: >
-                The shared memory the process uses.
+                The process name.
+            - name: state
+              type: keyword
+              description: >
+                The process state. For example: "running"
+            - name: pid
+              type: integer
+              description: >
+                The process pid.
+            - name: ppid
+              type: integer
+              description: >
+                The process parent pid.
+            - name: cmdline
+              type: keyword
+              description: >
+                The full command-line used to start the process, including the
+                arguments separated by space.
+            - name: username
+              type: keyword
+              description: >
+                The username of the user that created the process. If the username
+                can not be determined then the the field will contain the user's
+                numeric identifier (UID). On Windows, this field includes the user's
+                domain and is formatted as `domain\username`.
+            - name: cpu
+              type: group
+              prefix: "[float]"
+              description: CPU-specific statistics per process.
+              fields:
+                - name: user
+                  type: long
+                  description: >
+                    The amount of CPU time the process spent in user space.
+                - name: total_p
+                  type: float
+                  description: >
+                    The percentage of CPU time spent by the process since the last update. Its value is similar with the
+                    %CPU value of the process displayed by the top command on unix systems.
+                - name: system
+                  type: long
+                  description: >
+                    The amount of CPU time the process spent in kernel space.
+                - name: total
+                  type: long
+                  description: >
+                    The total CPU time spent by the process.
+                - name: start_time
+                  type: keyword
+                  description: >
+                    The time when the process was started. Example: "17:45".
+            - name: mem
+              type: group
+              description: Memory-specific statistics per process.
+              prefix: "[float]"
+              fields:
+                - name: size
+                  type: long
+                  description: >
+                    The total virtual memory the process has.
+                - name: rss
+                  type: long
+                  description: >
+                    The Resident Set Size. The amount of memory the process occupied in main memory (RAM).
+                - name: rss_p
+                  type: float
+                  description: >
+                    The percentage of memory the process occupied in main memory (RAM).
+                - name: share
+                  type: long
+                  description: >
+                    The shared memory the process uses.
 - key: zookeeper
   title: "Zookeeper Status"
   description: >
     ZooKeeper metrics collected by the four-letter monitoring commands.
   fields:
-
-    - name: zookeeper-mntr
+    - name: zookeeper
       type: group
       description: >
-        `zookeeper-mntr` contains the metrics reported by the four-letter `mntr`
+        `zookeeper` contains the metrics reported by zookeeper
         command.
       fields:
-        - name: hostname
-          type: keyword
+        - name: mntr
+          type: group
           description: >
-            Zookeeper hostname.
-        - name: zk_approximate_data_size
-          type: long
-          description: >
-            Approximate size of zookeeper data.
-        - name: zk_avg_latency
-          type: integer
-          description: >
-            Average latency between ensemble hosts in milliseconds.
-        - name: zk_ephemerals_count
-          type: integer
-          description: >
-            Number of ephemeral znodes.
-        - name: zk_followers
-          type: integer
-          description: >
-            Number of followers seen by the current host.
-        - name: zk_max_file_descriptor_count
-          type: integer
-          description: >
-            Maximum number of file descriptors allowed for the zookeeper process.
-        - name: zk_max_latency
-          type: integer
-          description: >
-            Maximum latency in milliseconds.
-        - name: zk_min_latency
-          type: integer
-          description: >
-            Minimum latency in milliseconds.
-        - name: zk_num_alive_connections
-          type: integer
-          description: >
-            Number of connections to zookeeper that are currently alive.
-        - name: zk_open_file_descriptor_count
-          type: integer
-          description: >
-            Number of file descriptors open by the zookeeper process.
-        - name: zk_outstanding_requests
-          type: integer
-          description: >
-            Number of outstanding requests that need to be processed by the cluster.
-        - name: zk_packets_received
-          type: integer
-          description: >
-            Number zookeeper network packets received.
-        - name: zk_packets_sent
-          type: long
-          description: >
-            Number zookeeper network packets sent.
-        - name: zk_pending_syncs
-          type: integer
-          description: >
-            Number of pending syncs to carry out to zookeeper ensemble followers.
-        - name: zk_server_state
-          type: keyword
-          description: >
-            Role in the zookeeper ensemble.
-        - name: zk_synced_followers
-          type: integer
-          description: >
-            Number of synced followers reported when a node server_state is leader.
-        - name: zk_version
-          type: keyword
-          description: >
-            Zookeeper version and build string reported.
-        - name: zk_watch_count
-          type: integer
-          description: >
-            Number of watches currently set on the local zookeeper process.
-        - name: zk_znode_count
-          type: integer
-          description: >
-            Number of znodes reported by the local zookeeper process.
+            `mntr` contains the metrics reported by the four-letter `mntr`
+            command.
+          fields:
+            - name: hostname
+              type: keyword
+              description: >
+                Zookeeper hostname.
+            - name: zk_approximate_data_size
+              type: long
+              description: >
+                Approximate size of zookeeper data.
+            - name: zk_avg_latency
+              type: integer
+              description: >
+                Average latency between ensemble hosts in milliseconds.
+            - name: zk_ephemerals_count
+              type: integer
+              description: >
+                Number of ephemeral znodes.
+            - name: zk_followers
+              type: integer
+              description: >
+                Number of followers seen by the current host.
+            - name: zk_max_file_descriptor_count
+              type: integer
+              description: >
+                Maximum number of file descriptors allowed for the zookeeper process.
+            - name: zk_max_latency
+              type: integer
+              description: >
+                Maximum latency in milliseconds.
+            - name: zk_min_latency
+              type: integer
+              description: >
+                Minimum latency in milliseconds.
+            - name: zk_num_alive_connections
+              type: integer
+              description: >
+                Number of connections to zookeeper that are currently alive.
+            - name: zk_open_file_descriptor_count
+              type: integer
+              description: >
+                Number of file descriptors open by the zookeeper process.
+            - name: zk_outstanding_requests
+              type: integer
+              description: >
+                Number of outstanding requests that need to be processed by the cluster.
+            - name: zk_packets_received
+              type: integer
+              description: >
+                Number zookeeper network packets received.
+            - name: zk_packets_sent
+              type: long
+              description: >
+                Number zookeeper network packets sent.
+            - name: zk_pending_syncs
+              type: integer
+              description: >
+                Number of pending syncs to carry out to zookeeper ensemble followers.
+            - name: zk_server_state
+              type: keyword
+              description: >
+                Role in the zookeeper ensemble.
+            - name: zk_synced_followers
+              type: integer
+              description: >
+                Number of synced followers reported when a node server_state is leader.
+            - name: zk_version
+              type: keyword
+              description: >
+                Zookeeper version and build string reported.
+            - name: zk_watch_count
+              type: integer
+              description: >
+                Number of watches currently set on the local zookeeper process.
+            - name: zk_znode_count
+              type: integer
+              description: >
+                Number of znodes reported by the local zookeeper process.
 

--- a/metricbeat/metricbeat.template-es2x.json
+++ b/metricbeat/metricbeat.template-es2x.json
@@ -23,129 +23,133 @@
         "@timestamp": {
           "type": "date"
         },
-        "apache-status": {
+        "apache": {
           "properties": {
-            "busyWorkers": {
-              "type": "integer"
-            },
-            "bytesPerReq": {
-              "type": "float"
-            },
-            "bytesPerSec": {
-              "type": "float"
-            },
-            "connections": {
+            "status": {
               "properties": {
-                "connsAsyncClosing": {
+                "busyWorkers": {
                   "type": "integer"
                 },
-                "connsAsyncKeepAlive": {
-                  "type": "integer"
-                },
-                "connsAsyncWriting": {
-                  "type": "integer"
-                },
-                "connsTotal": {
-                  "type": "integer"
-                }
-              }
-            },
-            "cpu": {
-              "properties": {
-                "cpuChildrenSystem": {
+                "bytesPerReq": {
                   "type": "float"
                 },
-                "cpuChildrenUser": {
+                "bytesPerSec": {
                   "type": "float"
                 },
-                "cpuLoad": {
+                "connections": {
+                  "properties": {
+                    "connsAsyncClosing": {
+                      "type": "integer"
+                    },
+                    "connsAsyncKeepAlive": {
+                      "type": "integer"
+                    },
+                    "connsAsyncWriting": {
+                      "type": "integer"
+                    },
+                    "connsTotal": {
+                      "type": "integer"
+                    }
+                  }
+                },
+                "cpu": {
+                  "properties": {
+                    "cpuChildrenSystem": {
+                      "type": "float"
+                    },
+                    "cpuChildrenUser": {
+                      "type": "float"
+                    },
+                    "cpuLoad": {
+                      "type": "float"
+                    },
+                    "cpuSystem": {
+                      "type": "float"
+                    },
+                    "cpuUser": {
+                      "type": "float"
+                    }
+                  }
+                },
+                "hostname": {
+                  "ignore_above": 1024,
+                  "index": "not_analyzed",
+                  "type": "string"
+                },
+                "idleWorkers": {
+                  "type": "integer"
+                },
+                "load": {
+                  "properties": {
+                    "load1": {
+                      "type": "float"
+                    },
+                    "load15": {
+                      "type": "float"
+                    },
+                    "load5": {
+                      "type": "float"
+                    }
+                  }
+                },
+                "reqPerSec": {
                   "type": "float"
                 },
-                "cpuSystem": {
-                  "type": "float"
+                "scoreboard": {
+                  "properties": {
+                    "closingConnection": {
+                      "type": "integer"
+                    },
+                    "dnsLookup": {
+                      "type": "integer"
+                    },
+                    "gracefullyFinishing": {
+                      "type": "integer"
+                    },
+                    "idleCleanup": {
+                      "type": "integer"
+                    },
+                    "keepalive": {
+                      "type": "integer"
+                    },
+                    "logging": {
+                      "type": "integer"
+                    },
+                    "openSlot": {
+                      "type": "integer"
+                    },
+                    "readingRequest": {
+                      "type": "integer"
+                    },
+                    "sendingReply": {
+                      "type": "integer"
+                    },
+                    "startingUp": {
+                      "type": "integer"
+                    },
+                    "total": {
+                      "type": "integer"
+                    },
+                    "waitingForConnection": {
+                      "type": "integer"
+                    }
+                  }
                 },
-                "cpuUser": {
-                  "type": "float"
-                }
-              }
-            },
-            "hostname": {
-              "ignore_above": 1024,
-              "index": "not_analyzed",
-              "type": "string"
-            },
-            "idleWorkers": {
-              "type": "integer"
-            },
-            "load": {
-              "properties": {
-                "load1": {
-                  "type": "float"
-                },
-                "load15": {
-                  "type": "float"
-                },
-                "load5": {
-                  "type": "float"
-                }
-              }
-            },
-            "reqPerSec": {
-              "type": "float"
-            },
-            "scoreboard": {
-              "properties": {
-                "closingConnection": {
+                "totalAccesses": {
                   "type": "integer"
                 },
-                "dnsLookup": {
-                  "type": "integer"
-                },
-                "gracefullyFinishing": {
-                  "type": "integer"
-                },
-                "idleCleanup": {
-                  "type": "integer"
-                },
-                "keepalive": {
-                  "type": "integer"
-                },
-                "logging": {
-                  "type": "integer"
-                },
-                "openSlot": {
-                  "type": "integer"
-                },
-                "readingRequest": {
-                  "type": "integer"
-                },
-                "sendingReply": {
-                  "type": "integer"
-                },
-                "startingUp": {
-                  "type": "integer"
-                },
-                "total": {
-                  "type": "integer"
-                },
-                "waitingForConnection": {
-                  "type": "integer"
-                }
-              }
-            },
-            "totalAccesses": {
-              "type": "integer"
-            },
-            "totalKBytes": {
-              "type": "integer"
-            },
-            "uptime": {
-              "properties": {
-                "serverUptimeSeconds": {
+                "totalKBytes": {
                   "type": "integer"
                 },
                 "uptime": {
-                  "type": "integer"
+                  "properties": {
+                    "serverUptimeSeconds": {
+                      "type": "integer"
+                    },
+                    "uptime": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             }
@@ -180,68 +184,76 @@
           "index": "not_analyzed",
           "type": "string"
         },
-        "mysql-status": {
+        "mysql": {
           "properties": {
-            "aborted": {
+            "status": {
               "properties": {
-                "Aborted_clients": {
-                  "type": "integer"
+                "aborted": {
+                  "properties": {
+                    "Aborted_clients": {
+                      "type": "integer"
+                    },
+                    "Aborted_connects": {
+                      "type": "integer"
+                    }
+                  }
                 },
-                "Aborted_connects": {
-                  "type": "integer"
-                }
-              }
-            },
-            "bytes": {
-              "properties": {
-                "Bytes_received": {
-                  "type": "integer"
-                },
-                "Bytes_sent": {
-                  "type": "integer"
+                "bytes": {
+                  "properties": {
+                    "Bytes_received": {
+                      "type": "integer"
+                    },
+                    "Bytes_sent": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             }
           }
         },
-        "redis-info": {
+        "redis": {
           "properties": {
-            "clients": {
+            "info": {
               "properties": {
-                "blocked_clients": {
-                  "type": "integer"
+                "clients": {
+                  "properties": {
+                    "blocked_clients": {
+                      "type": "integer"
+                    },
+                    "client_biggest_input_buf": {
+                      "type": "integer"
+                    },
+                    "client_longest_output_list": {
+                      "type": "integer"
+                    },
+                    "connected_clients": {
+                      "type": "integer"
+                    }
+                  }
                 },
-                "client_biggest_input_buf": {
-                  "type": "integer"
+                "cluster": {
+                  "properties": {
+                    "cluster_enabled": {
+                      "type": "boolean"
+                    }
+                  }
                 },
-                "client_longest_output_list": {
-                  "type": "integer"
-                },
-                "connected_clients": {
-                  "type": "integer"
-                }
-              }
-            },
-            "cluster": {
-              "properties": {
-                "cluster_enabled": {
-                  "type": "boolean"
-                }
-              }
-            },
-            "cpu": {
-              "properties": {
-                "used_cpu_sys": {
-                  "type": "float"
-                },
-                "used_cpu_sys_children": {
-                  "type": "float"
-                },
-                "used_cpu_user": {
-                  "type": "float"
-                },
-                "used_cpu_user_children": {
-                  "type": "float"
+                "cpu": {
+                  "properties": {
+                    "used_cpu_sys": {
+                      "type": "float"
+                    },
+                    "used_cpu_sys_children": {
+                      "type": "float"
+                    },
+                    "used_cpu_user": {
+                      "type": "float"
+                    },
+                    "used_cpu_user_children": {
+                      "type": "float"
+                    }
+                  }
                 }
               }
             }
@@ -250,292 +262,296 @@
         "rtt": {
           "type": "long"
         },
-        "system-cores": {
+        "system": {
           "properties": {
-            "core": {
-              "type": "integer"
-            },
-            "idle": {
-              "type": "integer"
-            },
-            "iowait": {
-              "type": "integer"
-            },
-            "irq": {
-              "type": "integer"
-            },
-            "nice": {
-              "type": "integer"
-            },
-            "softirq": {
-              "type": "integer"
-            },
-            "steal": {
-              "type": "integer"
-            },
-            "system": {
-              "type": "integer"
-            },
-            "system_p": {
-              "type": "float"
-            },
-            "user": {
-              "type": "integer"
-            },
-            "user_p": {
-              "type": "float"
-            }
-          }
-        },
-        "system-cpu": {
-          "properties": {
-            "idle": {
-              "type": "integer"
-            },
-            "iowait": {
-              "type": "integer"
-            },
-            "irq": {
-              "type": "integer"
-            },
-            "load": {
+            "cores": {
               "properties": {
-                "load1": {
+                "core": {
+                  "type": "integer"
+                },
+                "idle": {
+                  "type": "integer"
+                },
+                "iowait": {
+                  "type": "integer"
+                },
+                "irq": {
+                  "type": "integer"
+                },
+                "nice": {
+                  "type": "integer"
+                },
+                "softirq": {
+                  "type": "integer"
+                },
+                "steal": {
+                  "type": "integer"
+                },
+                "system": {
+                  "type": "integer"
+                },
+                "system_p": {
                   "type": "float"
                 },
-                "load15": {
-                  "type": "float"
+                "user": {
+                  "type": "integer"
                 },
-                "load5": {
+                "user_p": {
                   "type": "float"
                 }
               }
-            },
-            "nice": {
-              "type": "integer"
-            },
-            "softirq": {
-              "type": "integer"
-            },
-            "steal": {
-              "type": "integer"
-            },
-            "system": {
-              "type": "integer"
-            },
-            "system_p": {
-              "type": "float"
-            },
-            "user": {
-              "type": "integer"
-            },
-            "user_p": {
-              "type": "float"
-            }
-          }
-        },
-        "system-disk": {
-          "properties": {
-            "io_time": {
-              "type": "long"
-            },
-            "name": {
-              "ignore_above": 1024,
-              "index": "not_analyzed",
-              "type": "string"
-            },
-            "read_bytes": {
-              "type": "long"
-            },
-            "read_count": {
-              "type": "long"
-            },
-            "read_time": {
-              "type": "long"
-            },
-            "serial_number": {
-              "ignore_above": 1024,
-              "index": "not_analyzed",
-              "type": "string"
-            },
-            "write_bytes": {
-              "type": "long"
-            },
-            "write_count": {
-              "type": "long"
-            },
-            "write_time": {
-              "type": "long"
-            }
-          }
-        },
-        "system-filesystem": {
-          "properties": {
-            "avail": {
-              "type": "long"
-            },
-            "device_name": {
-              "ignore_above": 1024,
-              "index": "not_analyzed",
-              "type": "string"
-            },
-            "files": {
-              "type": "long"
-            },
-            "free": {
-              "type": "long"
-            },
-            "free_files": {
-              "type": "long"
-            },
-            "mount_point": {
-              "ignore_above": 1024,
-              "index": "not_analyzed",
-              "type": "string"
-            },
-            "total": {
-              "type": "long"
-            },
-            "used": {
-              "type": "long"
-            },
-            "used_p": {
-              "type": "float"
-            }
-          }
-        },
-        "system-fsstats": {
-          "properties": {
-            "count": {
-              "type": "long"
-            },
-            "total_files": {
-              "type": "long"
-            },
-            "total_size": {
-              "properties": {
-                "free": {
-                  "type": "long"
-                },
-                "total": {
-                  "type": "long"
-                },
-                "used": {
-                  "type": "long"
-                }
-              }
-            }
-          }
-        },
-        "system-memory": {
-          "properties": {
-            "mem": {
-              "properties": {
-                "actual_free": {
-                  "type": "long"
-                },
-                "actual_used": {
-                  "type": "long"
-                },
-                "actual_used_p": {
-                  "type": "float"
-                },
-                "free": {
-                  "type": "long"
-                },
-                "total": {
-                  "type": "long"
-                },
-                "used": {
-                  "type": "long"
-                },
-                "used_p": {
-                  "type": "float"
-                }
-              }
-            },
-            "swap": {
-              "properties": {
-                "free": {
-                  "type": "long"
-                },
-                "total": {
-                  "type": "long"
-                },
-                "used": {
-                  "type": "long"
-                },
-                "used_p": {
-                  "type": "float"
-                }
-              }
-            }
-          }
-        },
-        "system-process": {
-          "properties": {
-            "cmdline": {
-              "ignore_above": 1024,
-              "index": "not_analyzed",
-              "type": "string"
             },
             "cpu": {
               "properties": {
-                "start_time": {
+                "idle": {
+                  "type": "integer"
+                },
+                "iowait": {
+                  "type": "integer"
+                },
+                "irq": {
+                  "type": "integer"
+                },
+                "load": {
+                  "properties": {
+                    "load1": {
+                      "type": "float"
+                    },
+                    "load15": {
+                      "type": "float"
+                    },
+                    "load5": {
+                      "type": "float"
+                    }
+                  }
+                },
+                "nice": {
+                  "type": "integer"
+                },
+                "softirq": {
+                  "type": "integer"
+                },
+                "steal": {
+                  "type": "integer"
+                },
+                "system": {
+                  "type": "integer"
+                },
+                "system_p": {
+                  "type": "float"
+                },
+                "user": {
+                  "type": "integer"
+                },
+                "user_p": {
+                  "type": "float"
+                }
+              }
+            },
+            "disk": {
+              "properties": {
+                "io_time": {
+                  "type": "long"
+                },
+                "name": {
                   "ignore_above": 1024,
                   "index": "not_analyzed",
                   "type": "string"
                 },
-                "system": {
+                "read_bytes": {
                   "type": "long"
+                },
+                "read_count": {
+                  "type": "long"
+                },
+                "read_time": {
+                  "type": "long"
+                },
+                "serial_number": {
+                  "ignore_above": 1024,
+                  "index": "not_analyzed",
+                  "type": "string"
+                },
+                "write_bytes": {
+                  "type": "long"
+                },
+                "write_count": {
+                  "type": "long"
+                },
+                "write_time": {
+                  "type": "long"
+                }
+              }
+            },
+            "filesystem": {
+              "properties": {
+                "avail": {
+                  "type": "long"
+                },
+                "device_name": {
+                  "ignore_above": 1024,
+                  "index": "not_analyzed",
+                  "type": "string"
+                },
+                "files": {
+                  "type": "long"
+                },
+                "free": {
+                  "type": "long"
+                },
+                "free_files": {
+                  "type": "long"
+                },
+                "mount_point": {
+                  "ignore_above": 1024,
+                  "index": "not_analyzed",
+                  "type": "string"
                 },
                 "total": {
                   "type": "long"
                 },
-                "total_p": {
-                  "type": "float"
-                },
-                "user": {
+                "used": {
                   "type": "long"
+                },
+                "used_p": {
+                  "type": "float"
                 }
               }
             },
-            "mem": {
+            "fsstats": {
               "properties": {
-                "rss": {
+                "count": {
                   "type": "long"
                 },
-                "rss_p": {
-                  "type": "float"
-                },
-                "share": {
+                "total_files": {
                   "type": "long"
                 },
-                "size": {
-                  "type": "long"
+                "total_size": {
+                  "properties": {
+                    "free": {
+                      "type": "long"
+                    },
+                    "total": {
+                      "type": "long"
+                    },
+                    "used": {
+                      "type": "long"
+                    }
+                  }
                 }
               }
             },
-            "name": {
-              "ignore_above": 1024,
-              "index": "not_analyzed",
-              "type": "string"
+            "memory": {
+              "properties": {
+                "mem": {
+                  "properties": {
+                    "actual_free": {
+                      "type": "long"
+                    },
+                    "actual_used": {
+                      "type": "long"
+                    },
+                    "actual_used_p": {
+                      "type": "float"
+                    },
+                    "free": {
+                      "type": "long"
+                    },
+                    "total": {
+                      "type": "long"
+                    },
+                    "used": {
+                      "type": "long"
+                    },
+                    "used_p": {
+                      "type": "float"
+                    }
+                  }
+                },
+                "swap": {
+                  "properties": {
+                    "free": {
+                      "type": "long"
+                    },
+                    "total": {
+                      "type": "long"
+                    },
+                    "used": {
+                      "type": "long"
+                    },
+                    "used_p": {
+                      "type": "float"
+                    }
+                  }
+                }
+              }
             },
-            "pid": {
-              "type": "integer"
-            },
-            "ppid": {
-              "type": "integer"
-            },
-            "state": {
-              "ignore_above": 1024,
-              "index": "not_analyzed",
-              "type": "string"
-            },
-            "username": {
-              "ignore_above": 1024,
-              "index": "not_analyzed",
-              "type": "string"
+            "process": {
+              "properties": {
+                "cmdline": {
+                  "ignore_above": 1024,
+                  "index": "not_analyzed",
+                  "type": "string"
+                },
+                "cpu": {
+                  "properties": {
+                    "start_time": {
+                      "ignore_above": 1024,
+                      "index": "not_analyzed",
+                      "type": "string"
+                    },
+                    "system": {
+                      "type": "long"
+                    },
+                    "total": {
+                      "type": "long"
+                    },
+                    "total_p": {
+                      "type": "float"
+                    },
+                    "user": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "mem": {
+                  "properties": {
+                    "rss": {
+                      "type": "long"
+                    },
+                    "rss_p": {
+                      "type": "float"
+                    },
+                    "share": {
+                      "type": "long"
+                    },
+                    "size": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "index": "not_analyzed",
+                  "type": "string"
+                },
+                "pid": {
+                  "type": "integer"
+                },
+                "ppid": {
+                  "type": "integer"
+                },
+                "state": {
+                  "ignore_above": 1024,
+                  "index": "not_analyzed",
+                  "type": "string"
+                },
+                "username": {
+                  "ignore_above": 1024,
+                  "index": "not_analyzed",
+                  "type": "string"
+                }
+              }
             }
           }
         },
@@ -549,70 +565,74 @@
           "index": "not_analyzed",
           "type": "string"
         },
-        "zookeeper-mntr": {
+        "zookeeper": {
           "properties": {
-            "hostname": {
-              "ignore_above": 1024,
-              "index": "not_analyzed",
-              "type": "string"
-            },
-            "zk_approximate_data_size": {
-              "type": "long"
-            },
-            "zk_avg_latency": {
-              "type": "integer"
-            },
-            "zk_ephemerals_count": {
-              "type": "integer"
-            },
-            "zk_followers": {
-              "type": "integer"
-            },
-            "zk_max_file_descriptor_count": {
-              "type": "integer"
-            },
-            "zk_max_latency": {
-              "type": "integer"
-            },
-            "zk_min_latency": {
-              "type": "integer"
-            },
-            "zk_num_alive_connections": {
-              "type": "integer"
-            },
-            "zk_open_file_descriptor_count": {
-              "type": "integer"
-            },
-            "zk_outstanding_requests": {
-              "type": "integer"
-            },
-            "zk_packets_received": {
-              "type": "integer"
-            },
-            "zk_packets_sent": {
-              "type": "long"
-            },
-            "zk_pending_syncs": {
-              "type": "integer"
-            },
-            "zk_server_state": {
-              "ignore_above": 1024,
-              "index": "not_analyzed",
-              "type": "string"
-            },
-            "zk_synced_followers": {
-              "type": "integer"
-            },
-            "zk_version": {
-              "ignore_above": 1024,
-              "index": "not_analyzed",
-              "type": "string"
-            },
-            "zk_watch_count": {
-              "type": "integer"
-            },
-            "zk_znode_count": {
-              "type": "integer"
+            "mntr": {
+              "properties": {
+                "hostname": {
+                  "ignore_above": 1024,
+                  "index": "not_analyzed",
+                  "type": "string"
+                },
+                "zk_approximate_data_size": {
+                  "type": "long"
+                },
+                "zk_avg_latency": {
+                  "type": "integer"
+                },
+                "zk_ephemerals_count": {
+                  "type": "integer"
+                },
+                "zk_followers": {
+                  "type": "integer"
+                },
+                "zk_max_file_descriptor_count": {
+                  "type": "integer"
+                },
+                "zk_max_latency": {
+                  "type": "integer"
+                },
+                "zk_min_latency": {
+                  "type": "integer"
+                },
+                "zk_num_alive_connections": {
+                  "type": "integer"
+                },
+                "zk_open_file_descriptor_count": {
+                  "type": "integer"
+                },
+                "zk_outstanding_requests": {
+                  "type": "integer"
+                },
+                "zk_packets_received": {
+                  "type": "integer"
+                },
+                "zk_packets_sent": {
+                  "type": "long"
+                },
+                "zk_pending_syncs": {
+                  "type": "integer"
+                },
+                "zk_server_state": {
+                  "ignore_above": 1024,
+                  "index": "not_analyzed",
+                  "type": "string"
+                },
+                "zk_synced_followers": {
+                  "type": "integer"
+                },
+                "zk_version": {
+                  "ignore_above": 1024,
+                  "index": "not_analyzed",
+                  "type": "string"
+                },
+                "zk_watch_count": {
+                  "type": "integer"
+                },
+                "zk_znode_count": {
+                  "type": "integer"
+                }
+              }
             }
           }
         }

--- a/metricbeat/metricbeat.template.json
+++ b/metricbeat/metricbeat.template.json
@@ -20,128 +20,132 @@
         "@timestamp": {
           "type": "date"
         },
-        "apache-status": {
+        "apache": {
           "properties": {
-            "busyWorkers": {
-              "type": "integer"
-            },
-            "bytesPerReq": {
-              "type": "float"
-            },
-            "bytesPerSec": {
-              "type": "float"
-            },
-            "connections": {
+            "status": {
               "properties": {
-                "connsAsyncClosing": {
+                "busyWorkers": {
                   "type": "integer"
                 },
-                "connsAsyncKeepAlive": {
-                  "type": "integer"
-                },
-                "connsAsyncWriting": {
-                  "type": "integer"
-                },
-                "connsTotal": {
-                  "type": "integer"
-                }
-              }
-            },
-            "cpu": {
-              "properties": {
-                "cpuChildrenSystem": {
+                "bytesPerReq": {
                   "type": "float"
                 },
-                "cpuChildrenUser": {
+                "bytesPerSec": {
                   "type": "float"
                 },
-                "cpuLoad": {
+                "connections": {
+                  "properties": {
+                    "connsAsyncClosing": {
+                      "type": "integer"
+                    },
+                    "connsAsyncKeepAlive": {
+                      "type": "integer"
+                    },
+                    "connsAsyncWriting": {
+                      "type": "integer"
+                    },
+                    "connsTotal": {
+                      "type": "integer"
+                    }
+                  }
+                },
+                "cpu": {
+                  "properties": {
+                    "cpuChildrenSystem": {
+                      "type": "float"
+                    },
+                    "cpuChildrenUser": {
+                      "type": "float"
+                    },
+                    "cpuLoad": {
+                      "type": "float"
+                    },
+                    "cpuSystem": {
+                      "type": "float"
+                    },
+                    "cpuUser": {
+                      "type": "float"
+                    }
+                  }
+                },
+                "hostname": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "idleWorkers": {
+                  "type": "integer"
+                },
+                "load": {
+                  "properties": {
+                    "load1": {
+                      "type": "float"
+                    },
+                    "load15": {
+                      "type": "float"
+                    },
+                    "load5": {
+                      "type": "float"
+                    }
+                  }
+                },
+                "reqPerSec": {
                   "type": "float"
                 },
-                "cpuSystem": {
-                  "type": "float"
+                "scoreboard": {
+                  "properties": {
+                    "closingConnection": {
+                      "type": "integer"
+                    },
+                    "dnsLookup": {
+                      "type": "integer"
+                    },
+                    "gracefullyFinishing": {
+                      "type": "integer"
+                    },
+                    "idleCleanup": {
+                      "type": "integer"
+                    },
+                    "keepalive": {
+                      "type": "integer"
+                    },
+                    "logging": {
+                      "type": "integer"
+                    },
+                    "openSlot": {
+                      "type": "integer"
+                    },
+                    "readingRequest": {
+                      "type": "integer"
+                    },
+                    "sendingReply": {
+                      "type": "integer"
+                    },
+                    "startingUp": {
+                      "type": "integer"
+                    },
+                    "total": {
+                      "type": "integer"
+                    },
+                    "waitingForConnection": {
+                      "type": "integer"
+                    }
+                  }
                 },
-                "cpuUser": {
-                  "type": "float"
-                }
-              }
-            },
-            "hostname": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "idleWorkers": {
-              "type": "integer"
-            },
-            "load": {
-              "properties": {
-                "load1": {
-                  "type": "float"
-                },
-                "load15": {
-                  "type": "float"
-                },
-                "load5": {
-                  "type": "float"
-                }
-              }
-            },
-            "reqPerSec": {
-              "type": "float"
-            },
-            "scoreboard": {
-              "properties": {
-                "closingConnection": {
+                "totalAccesses": {
                   "type": "integer"
                 },
-                "dnsLookup": {
-                  "type": "integer"
-                },
-                "gracefullyFinishing": {
-                  "type": "integer"
-                },
-                "idleCleanup": {
-                  "type": "integer"
-                },
-                "keepalive": {
-                  "type": "integer"
-                },
-                "logging": {
-                  "type": "integer"
-                },
-                "openSlot": {
-                  "type": "integer"
-                },
-                "readingRequest": {
-                  "type": "integer"
-                },
-                "sendingReply": {
-                  "type": "integer"
-                },
-                "startingUp": {
-                  "type": "integer"
-                },
-                "total": {
-                  "type": "integer"
-                },
-                "waitingForConnection": {
-                  "type": "integer"
-                }
-              }
-            },
-            "totalAccesses": {
-              "type": "integer"
-            },
-            "totalKBytes": {
-              "type": "integer"
-            },
-            "uptime": {
-              "properties": {
-                "serverUptimeSeconds": {
+                "totalKBytes": {
                   "type": "integer"
                 },
                 "uptime": {
-                  "type": "integer"
+                  "properties": {
+                    "serverUptimeSeconds": {
+                      "type": "integer"
+                    },
+                    "uptime": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             }
@@ -171,68 +175,76 @@
           "ignore_above": 1024,
           "type": "keyword"
         },
-        "mysql-status": {
+        "mysql": {
           "properties": {
-            "aborted": {
+            "status": {
               "properties": {
-                "Aborted_clients": {
-                  "type": "integer"
+                "aborted": {
+                  "properties": {
+                    "Aborted_clients": {
+                      "type": "integer"
+                    },
+                    "Aborted_connects": {
+                      "type": "integer"
+                    }
+                  }
                 },
-                "Aborted_connects": {
-                  "type": "integer"
-                }
-              }
-            },
-            "bytes": {
-              "properties": {
-                "Bytes_received": {
-                  "type": "integer"
-                },
-                "Bytes_sent": {
-                  "type": "integer"
+                "bytes": {
+                  "properties": {
+                    "Bytes_received": {
+                      "type": "integer"
+                    },
+                    "Bytes_sent": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             }
           }
         },
-        "redis-info": {
+        "redis": {
           "properties": {
-            "clients": {
+            "info": {
               "properties": {
-                "blocked_clients": {
-                  "type": "integer"
+                "clients": {
+                  "properties": {
+                    "blocked_clients": {
+                      "type": "integer"
+                    },
+                    "client_biggest_input_buf": {
+                      "type": "integer"
+                    },
+                    "client_longest_output_list": {
+                      "type": "integer"
+                    },
+                    "connected_clients": {
+                      "type": "integer"
+                    }
+                  }
                 },
-                "client_biggest_input_buf": {
-                  "type": "integer"
+                "cluster": {
+                  "properties": {
+                    "cluster_enabled": {
+                      "type": "boolean"
+                    }
+                  }
                 },
-                "client_longest_output_list": {
-                  "type": "integer"
-                },
-                "connected_clients": {
-                  "type": "integer"
-                }
-              }
-            },
-            "cluster": {
-              "properties": {
-                "cluster_enabled": {
-                  "type": "boolean"
-                }
-              }
-            },
-            "cpu": {
-              "properties": {
-                "used_cpu_sys": {
-                  "type": "float"
-                },
-                "used_cpu_sys_children": {
-                  "type": "float"
-                },
-                "used_cpu_user": {
-                  "type": "float"
-                },
-                "used_cpu_user_children": {
-                  "type": "float"
+                "cpu": {
+                  "properties": {
+                    "used_cpu_sys": {
+                      "type": "float"
+                    },
+                    "used_cpu_sys_children": {
+                      "type": "float"
+                    },
+                    "used_cpu_user": {
+                      "type": "float"
+                    },
+                    "used_cpu_user_children": {
+                      "type": "float"
+                    }
+                  }
                 }
               }
             }
@@ -241,283 +253,287 @@
         "rtt": {
           "type": "long"
         },
-        "system-cores": {
+        "system": {
           "properties": {
-            "core": {
-              "type": "integer"
-            },
-            "idle": {
-              "type": "integer"
-            },
-            "iowait": {
-              "type": "integer"
-            },
-            "irq": {
-              "type": "integer"
-            },
-            "nice": {
-              "type": "integer"
-            },
-            "softirq": {
-              "type": "integer"
-            },
-            "steal": {
-              "type": "integer"
-            },
-            "system": {
-              "type": "integer"
-            },
-            "system_p": {
-              "type": "float"
-            },
-            "user": {
-              "type": "integer"
-            },
-            "user_p": {
-              "type": "float"
-            }
-          }
-        },
-        "system-cpu": {
-          "properties": {
-            "idle": {
-              "type": "integer"
-            },
-            "iowait": {
-              "type": "integer"
-            },
-            "irq": {
-              "type": "integer"
-            },
-            "load": {
+            "cores": {
               "properties": {
-                "load1": {
-                  "type": "float"
+                "core": {
+                  "type": "integer"
                 },
-                "load15": {
-                  "type": "float"
+                "idle": {
+                  "type": "integer"
                 },
-                "load5": {
-                  "type": "float"
-                }
-              }
-            },
-            "nice": {
-              "type": "integer"
-            },
-            "softirq": {
-              "type": "integer"
-            },
-            "steal": {
-              "type": "integer"
-            },
-            "system": {
-              "type": "integer"
-            },
-            "system_p": {
-              "type": "float"
-            },
-            "user": {
-              "type": "integer"
-            },
-            "user_p": {
-              "type": "float"
-            }
-          }
-        },
-        "system-disk": {
-          "properties": {
-            "io_time": {
-              "type": "long"
-            },
-            "name": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "read_bytes": {
-              "type": "long"
-            },
-            "read_count": {
-              "type": "long"
-            },
-            "read_time": {
-              "type": "long"
-            },
-            "serial_number": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "write_bytes": {
-              "type": "long"
-            },
-            "write_count": {
-              "type": "long"
-            },
-            "write_time": {
-              "type": "long"
-            }
-          }
-        },
-        "system-filesystem": {
-          "properties": {
-            "avail": {
-              "type": "long"
-            },
-            "device_name": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "files": {
-              "type": "long"
-            },
-            "free": {
-              "type": "long"
-            },
-            "free_files": {
-              "type": "long"
-            },
-            "mount_point": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "total": {
-              "type": "long"
-            },
-            "used": {
-              "type": "long"
-            },
-            "used_p": {
-              "type": "float"
-            }
-          }
-        },
-        "system-fsstats": {
-          "properties": {
-            "count": {
-              "type": "long"
-            },
-            "total_files": {
-              "type": "long"
-            },
-            "total_size": {
-              "properties": {
-                "free": {
-                  "type": "long"
+                "iowait": {
+                  "type": "integer"
                 },
-                "total": {
-                  "type": "long"
+                "irq": {
+                  "type": "integer"
                 },
-                "used": {
-                  "type": "long"
-                }
-              }
-            }
-          }
-        },
-        "system-memory": {
-          "properties": {
-            "mem": {
-              "properties": {
-                "actual_free": {
-                  "type": "long"
+                "nice": {
+                  "type": "integer"
                 },
-                "actual_used": {
-                  "type": "long"
+                "softirq": {
+                  "type": "integer"
                 },
-                "actual_used_p": {
-                  "type": "float"
-                },
-                "free": {
-                  "type": "long"
-                },
-                "total": {
-                  "type": "long"
-                },
-                "used": {
-                  "type": "long"
-                },
-                "used_p": {
-                  "type": "float"
-                }
-              }
-            },
-            "swap": {
-              "properties": {
-                "free": {
-                  "type": "long"
-                },
-                "total": {
-                  "type": "long"
-                },
-                "used": {
-                  "type": "long"
-                },
-                "used_p": {
-                  "type": "float"
-                }
-              }
-            }
-          }
-        },
-        "system-process": {
-          "properties": {
-            "cmdline": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "cpu": {
-              "properties": {
-                "start_time": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                "steal": {
+                  "type": "integer"
                 },
                 "system": {
-                  "type": "long"
+                  "type": "integer"
                 },
-                "total": {
-                  "type": "long"
-                },
-                "total_p": {
+                "system_p": {
                   "type": "float"
                 },
                 "user": {
-                  "type": "long"
+                  "type": "integer"
+                },
+                "user_p": {
+                  "type": "float"
                 }
               }
             },
-            "mem": {
+            "cpu": {
               "properties": {
-                "rss": {
-                  "type": "long"
+                "idle": {
+                  "type": "integer"
                 },
-                "rss_p": {
+                "iowait": {
+                  "type": "integer"
+                },
+                "irq": {
+                  "type": "integer"
+                },
+                "load": {
+                  "properties": {
+                    "load1": {
+                      "type": "float"
+                    },
+                    "load15": {
+                      "type": "float"
+                    },
+                    "load5": {
+                      "type": "float"
+                    }
+                  }
+                },
+                "nice": {
+                  "type": "integer"
+                },
+                "softirq": {
+                  "type": "integer"
+                },
+                "steal": {
+                  "type": "integer"
+                },
+                "system": {
+                  "type": "integer"
+                },
+                "system_p": {
                   "type": "float"
                 },
-                "share": {
+                "user": {
+                  "type": "integer"
+                },
+                "user_p": {
+                  "type": "float"
+                }
+              }
+            },
+            "disk": {
+              "properties": {
+                "io_time": {
                   "type": "long"
                 },
-                "size": {
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "read_bytes": {
+                  "type": "long"
+                },
+                "read_count": {
+                  "type": "long"
+                },
+                "read_time": {
+                  "type": "long"
+                },
+                "serial_number": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "write_bytes": {
+                  "type": "long"
+                },
+                "write_count": {
+                  "type": "long"
+                },
+                "write_time": {
                   "type": "long"
                 }
               }
             },
-            "name": {
-              "ignore_above": 1024,
-              "type": "keyword"
+            "filesystem": {
+              "properties": {
+                "avail": {
+                  "type": "long"
+                },
+                "device_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "files": {
+                  "type": "long"
+                },
+                "free": {
+                  "type": "long"
+                },
+                "free_files": {
+                  "type": "long"
+                },
+                "mount_point": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "total": {
+                  "type": "long"
+                },
+                "used": {
+                  "type": "long"
+                },
+                "used_p": {
+                  "type": "float"
+                }
+              }
             },
-            "pid": {
-              "type": "integer"
+            "fsstats": {
+              "properties": {
+                "count": {
+                  "type": "long"
+                },
+                "total_files": {
+                  "type": "long"
+                },
+                "total_size": {
+                  "properties": {
+                    "free": {
+                      "type": "long"
+                    },
+                    "total": {
+                      "type": "long"
+                    },
+                    "used": {
+                      "type": "long"
+                    }
+                  }
+                }
+              }
             },
-            "ppid": {
-              "type": "integer"
+            "memory": {
+              "properties": {
+                "mem": {
+                  "properties": {
+                    "actual_free": {
+                      "type": "long"
+                    },
+                    "actual_used": {
+                      "type": "long"
+                    },
+                    "actual_used_p": {
+                      "type": "float"
+                    },
+                    "free": {
+                      "type": "long"
+                    },
+                    "total": {
+                      "type": "long"
+                    },
+                    "used": {
+                      "type": "long"
+                    },
+                    "used_p": {
+                      "type": "float"
+                    }
+                  }
+                },
+                "swap": {
+                  "properties": {
+                    "free": {
+                      "type": "long"
+                    },
+                    "total": {
+                      "type": "long"
+                    },
+                    "used": {
+                      "type": "long"
+                    },
+                    "used_p": {
+                      "type": "float"
+                    }
+                  }
+                }
+              }
             },
-            "state": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "username": {
-              "ignore_above": 1024,
-              "type": "keyword"
+            "process": {
+              "properties": {
+                "cmdline": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "cpu": {
+                  "properties": {
+                    "start_time": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "system": {
+                      "type": "long"
+                    },
+                    "total": {
+                      "type": "long"
+                    },
+                    "total_p": {
+                      "type": "float"
+                    },
+                    "user": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "mem": {
+                  "properties": {
+                    "rss": {
+                      "type": "long"
+                    },
+                    "rss_p": {
+                      "type": "float"
+                    },
+                    "share": {
+                      "type": "long"
+                    },
+                    "size": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "pid": {
+                  "type": "integer"
+                },
+                "ppid": {
+                  "type": "integer"
+                },
+                "state": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "username": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
             }
           }
         },
@@ -529,67 +545,71 @@
           "ignore_above": 1024,
           "type": "keyword"
         },
-        "zookeeper-mntr": {
+        "zookeeper": {
           "properties": {
-            "hostname": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "zk_approximate_data_size": {
-              "type": "long"
-            },
-            "zk_avg_latency": {
-              "type": "integer"
-            },
-            "zk_ephemerals_count": {
-              "type": "integer"
-            },
-            "zk_followers": {
-              "type": "integer"
-            },
-            "zk_max_file_descriptor_count": {
-              "type": "integer"
-            },
-            "zk_max_latency": {
-              "type": "integer"
-            },
-            "zk_min_latency": {
-              "type": "integer"
-            },
-            "zk_num_alive_connections": {
-              "type": "integer"
-            },
-            "zk_open_file_descriptor_count": {
-              "type": "integer"
-            },
-            "zk_outstanding_requests": {
-              "type": "integer"
-            },
-            "zk_packets_received": {
-              "type": "integer"
-            },
-            "zk_packets_sent": {
-              "type": "long"
-            },
-            "zk_pending_syncs": {
-              "type": "integer"
-            },
-            "zk_server_state": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "zk_synced_followers": {
-              "type": "integer"
-            },
-            "zk_version": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "zk_watch_count": {
-              "type": "integer"
-            },
-            "zk_znode_count": {
-              "type": "integer"
+            "mntr": {
+              "properties": {
+                "hostname": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "zk_approximate_data_size": {
+                  "type": "long"
+                },
+                "zk_avg_latency": {
+                  "type": "integer"
+                },
+                "zk_ephemerals_count": {
+                  "type": "integer"
+                },
+                "zk_followers": {
+                  "type": "integer"
+                },
+                "zk_max_file_descriptor_count": {
+                  "type": "integer"
+                },
+                "zk_max_latency": {
+                  "type": "integer"
+                },
+                "zk_min_latency": {
+                  "type": "integer"
+                },
+                "zk_num_alive_connections": {
+                  "type": "integer"
+                },
+                "zk_open_file_descriptor_count": {
+                  "type": "integer"
+                },
+                "zk_outstanding_requests": {
+                  "type": "integer"
+                },
+                "zk_packets_received": {
+                  "type": "integer"
+                },
+                "zk_packets_sent": {
+                  "type": "long"
+                },
+                "zk_pending_syncs": {
+                  "type": "integer"
+                },
+                "zk_server_state": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "zk_synced_followers": {
+                  "type": "integer"
+                },
+                "zk_version": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "zk_watch_count": {
+                  "type": "integer"
+                },
+                "zk_znode_count": {
+                  "type": "integer"
+                }
+              }
             }
           }
         }

--- a/metricbeat/module/apache/_beat/fields.yml
+++ b/metricbeat/module/apache/_beat/fields.yml
@@ -3,4 +3,8 @@
   description: >
     Apache HTTPD server metrics collected from the mod_status module.
   fields:
-
+    - name: apache
+      type: group
+      description: >
+        apache contains the metrics that were scraped from apache.
+      fields:

--- a/metricbeat/module/apache/status/_beat/fields.yml
+++ b/metricbeat/module/apache/status/_beat/fields.yml
@@ -1,8 +1,7 @@
-- name: apache-status
+- name: status
   type: group
   description: >
-    `apache-status` contains the metrics that were scraped from the status
-    page.
+    `status` contains the metrics that were scraped from the apache status page.
   fields:
     - name: hostname
       type: keyword

--- a/metricbeat/module/mysql/_beat/fields.yml
+++ b/metricbeat/module/mysql/_beat/fields.yml
@@ -1,6 +1,11 @@
 - key: mysql
   title: "MySQL Status"
   description: >
-    MySQL server status metrics collected from a `SHOW GLOBAL STATUS` SQL query.
+    MySQL server status metrics collected from MySQL
   fields:
-
+    - name: mysql
+      type: group
+      description: >
+        mysql contains the metrics that were obtained from MySQL
+        query.
+      fields:

--- a/metricbeat/module/mysql/status/_beat/fields.yml
+++ b/metricbeat/module/mysql/status/_beat/fields.yml
@@ -1,8 +1,7 @@
-- name: mysql-status
+- name: status
   type: group
   description: >
-    `mysql-status` contains the metrics that were obtained the status SQL
-    query.
+    `status` contains the metrics that were obtained by the status SQL query.
   fields:
     - name: aborted
       type: group

--- a/metricbeat/module/redis/_beat/fields.yml
+++ b/metricbeat/module/redis/_beat/fields.yml
@@ -1,5 +1,10 @@
 - key: redis
-  title: "Redis Info"
+  title: "Redis"
   description: >
-    Redis metrics collected from the Redis `INFO` command.
+    Redis metrics collected from the Redis
   fields:
+    - name: redis
+      type: group
+      description: >
+        `redis` contains the information and statistics from Redis
+      fields:

--- a/metricbeat/module/redis/info/_beat/fields.yml
+++ b/metricbeat/module/redis/info/_beat/fields.yml
@@ -1,8 +1,7 @@
-- name: redis-info
+- name: info
   type: group
   description: >
-    `redis-info` contains the information and statistics returned by the
-    `INFO` command.
+    `info` contains the information and statistics returned by the `INFO` command.
   fields:
     - name: clients
       type: group

--- a/metricbeat/module/system/_beat/fields.yml
+++ b/metricbeat/module/system/_beat/fields.yml
@@ -3,4 +3,8 @@
   description: >
     System status metrics, like CPU and memory usage, that are collected from the operating system.
   fields:
-
+    - name: system
+      type: group
+      description: >
+        `system` contains local system metrics
+      fields:

--- a/metricbeat/module/system/cores/_beat/fields.yml
+++ b/metricbeat/module/system/cores/_beat/fields.yml
@@ -1,4 +1,4 @@
-- name: system-cores
+- name: cores
   type: group
   description: >
     `system-cores` contains local cpu core stats.

--- a/metricbeat/module/system/cpu/_beat/fields.yml
+++ b/metricbeat/module/system/cpu/_beat/fields.yml
@@ -1,7 +1,7 @@
-- name: system-cpu
+- name: cpu
   type: group
   description: >
-    `system-cpu` contains local cpu stats.
+    `cpu` contains local cpu stats.
   fields:
     - name: user
       type: integer

--- a/metricbeat/module/system/disk/_beat/fields.yml
+++ b/metricbeat/module/system/disk/_beat/fields.yml
@@ -1,7 +1,7 @@
-- name: system-disk
+- name: disk
   type: group
   description: >
-    `system-disk` contains disk IO metrics collected from the operating system.
+    `disk` contains disk IO metrics collected from the operating system.
   fields:
     - name: name
       type: keyword

--- a/metricbeat/module/system/filesystem/_beat/fields.yml
+++ b/metricbeat/module/system/filesystem/_beat/fields.yml
@@ -1,7 +1,7 @@
-- name: system-filesystem
+- name: filesystem
   type: group
   description: >
-    `system-filesystem` contains local filesystem stats
+    `filesystem` contains local filesystem stats
   fields:
     - name: avail
       type: long

--- a/metricbeat/module/system/fsstats/_beat/fields.yml
+++ b/metricbeat/module/system/fsstats/_beat/fields.yml
@@ -1,4 +1,4 @@
-- name: system-fsstats
+- name: fsstats
   type: group
   description: >
     `system-fsstats` contains filesystem metrics aggregated from all mounted

--- a/metricbeat/module/system/memory/_beat/fields.yml
+++ b/metricbeat/module/system/memory/_beat/fields.yml
@@ -1,7 +1,7 @@
-- name: system-memory
+- name: memory
   type: group
   description: >
-    `system-memory` contains local memory stats.
+    `memory` contains local memory stats.
   fields:
     - name: mem
       type: group

--- a/metricbeat/module/system/process/_beat/fields.yml
+++ b/metricbeat/module/system/process/_beat/fields.yml
@@ -1,7 +1,7 @@
-- name: system-process
+- name: process
   type: group
   description: >
-    `system-process` contains process metadata, CPU metrics, and memory metrics.
+    `process` contains process metadata, CPU metrics, and memory metrics.
   fields:
     - name: name
       type: keyword

--- a/metricbeat/module/zookeeper/_beat/fields.yml
+++ b/metricbeat/module/zookeeper/_beat/fields.yml
@@ -3,4 +3,9 @@
   description: >
     ZooKeeper metrics collected by the four-letter monitoring commands.
   fields:
-
+    - name: zookeeper
+      type: group
+      description: >
+        `zookeeper` contains the metrics reported by zookeeper
+        command.
+      fields:

--- a/metricbeat/module/zookeeper/mntr/_beat/fields.yml
+++ b/metricbeat/module/zookeeper/mntr/_beat/fields.yml
@@ -1,7 +1,7 @@
-- name: zookeeper-mntr
+- name: mntr
   type: group
   description: >
-    `zookeeper-mntr` contains the metrics reported by the four-letter `mntr`
+    `mntr` contains the metrics reported by the four-letter `mntr`
     command.
   fields:
     - name: hostname

--- a/metricbeat/scripts/fields_collector.py
+++ b/metricbeat/scripts/fields_collector.py
@@ -40,7 +40,7 @@ def collect():
                 # Add 4 spaces for indentation in front of each line
                 for line in f:
                     if len(line.strip()) > 0:
-                        fields_yml += "    " + line
+                        fields_yml += "    " + "    " + line
                     else:
                         fields_yml += line
 

--- a/metricbeat/tests/system/test_apache.py
+++ b/metricbeat/tests/system/test_apache.py
@@ -2,7 +2,7 @@ import os
 import metricbeat
 from nose.plugins.attrib import attr
 
-APACHE_FIELDS = metricbeat.COMMON_FIELDS + ["apache-status"]
+APACHE_FIELDS = metricbeat.COMMON_FIELDS + ["apache"]
 
 APACHE_STATUS_FIELDS = ["hostname", "totalAccesses", "totalKBytes",
                         "reqPerSec", "bytesPerSec", "bytesPerReq",
@@ -39,7 +39,7 @@ class ApacheStatusTest(metricbeat.BaseTest):
 
         # Verify the required fields are present.
         self.assertItemsEqual(APACHE_FIELDS, evt.keys())
-        apache_status = evt["apache-status"]
+        apache_status = evt["apache"]["status"]
         self.assertItemsEqual(APACHE_STATUS_FIELDS, apache_status.keys())
         self.assertItemsEqual(CPU_FIELDS, apache_status["cpu"].keys())
         # There are more fields that could be checked.

--- a/metricbeat/tests/system/test_redis.py
+++ b/metricbeat/tests/system/test_redis.py
@@ -2,7 +2,7 @@ import os
 import metricbeat
 from nose.plugins.attrib import attr
 
-REDIS_FIELDS = metricbeat.COMMON_FIELDS + ["redis-info"]
+REDIS_FIELDS = metricbeat.COMMON_FIELDS + ["redis"]
 
 REDIS_INFO_FIELDS = ["clients", "cluster", "cpu", "keyspace", "memory",
                      "persistence", "replication", "server", "stats"]
@@ -39,7 +39,7 @@ class RedisInfoTest(metricbeat.BaseTest):
         evt = output[0]
 
         self.assertItemsEqual(REDIS_FIELDS, evt.keys())
-        redis_info = evt["redis-info"]
+        redis_info = evt["redis"]["info"]
         self.assertItemsEqual(REDIS_INFO_FIELDS, redis_info.keys())
         self.assertItemsEqual(CLIENTS_FIELDS, redis_info["clients"].keys())
         self.assertItemsEqual(CPU_FIELDS, redis_info["cpu"].keys())
@@ -75,7 +75,7 @@ class RedisInfoTest(metricbeat.BaseTest):
         evt = output[0]
 
         self.assertItemsEqual(REDIS_FIELDS, evt.keys())
-        redis_info = evt["redis-info"]
+        redis_info = evt["redis"]["info"]
         self.assertItemsEqual(fields, redis_info.keys())
         self.assertItemsEqual(CLIENTS_FIELDS, redis_info["clients"].keys())
         self.assertItemsEqual(CPU_FIELDS, redis_info["cpu"].keys())

--- a/metricbeat/tests/system/test_system.py
+++ b/metricbeat/tests/system/test_system.py
@@ -48,7 +48,7 @@ class SystemTest(metricbeat.BaseTest):
         evt = output[0]
         self.assert_fields_are_documented(evt)
 
-        cpu = evt["system-cpu"]
+        cpu = evt["system"]["cpu"]
         self.assertItemsEqual(SYSTEM_CPU_FIELDS, cpu.keys())
 
     def test_cores(self):
@@ -73,7 +73,7 @@ class SystemTest(metricbeat.BaseTest):
 
         for evt in output:
             self.assert_fields_are_documented(evt)
-            cores = evt["system-cores"]
+            cores = evt["system"]["cores"]
             self.assertItemsEqual(SYSTEM_CORES, cores.keys())
 
     @unittest.skipUnless(re.match("(?i)win|linux|freebsd", sys.platform), "os")
@@ -99,7 +99,7 @@ class SystemTest(metricbeat.BaseTest):
 
         for evt in output:
             self.assert_fields_are_documented(evt)
-            disk = evt["system-disk"]
+            disk = evt["system"]["disk"]
             self.assertItemsEqual(SYSTEM_DISK_FIELDS, disk.keys())
 
     def test_filesystem(self):
@@ -124,7 +124,7 @@ class SystemTest(metricbeat.BaseTest):
 
         for evt in output:
             self.assert_fields_are_documented(evt)
-            filesystem = evt["system-filesystem"]
+            filesystem = evt["system"]["filesystem"]
             self.assertItemsEqual(SYSTEM_FILESYSTEM_FIELDS, filesystem.keys())
 
     def test_fsstats(self):
@@ -149,7 +149,7 @@ class SystemTest(metricbeat.BaseTest):
         evt = output[0]
         self.assert_fields_are_documented(evt)
 
-        fsstats = evt["system-fsstats"]
+        fsstats = evt["system"]["fsstats"]
         self.assertItemsEqual(SYSTEM_FSSTATS_FIELDS, fsstats.keys())
 
     def test_memory(self):
@@ -174,7 +174,7 @@ class SystemTest(metricbeat.BaseTest):
         evt = output[0]
         self.assert_fields_are_documented(evt)
 
-        memory = evt["system-memory"]
+        memory = evt["system"]["memory"]
         self.assertItemsEqual(SYSTEM_MEMORY_FIELDS, memory.keys())
 
         # Check that percentages are calculated.
@@ -213,5 +213,5 @@ class SystemTest(metricbeat.BaseTest):
 
         for evt in output:
             self.assert_fields_are_documented(evt)
-            process = evt["system-process"]
+            process = evt["system"]["process"]
             self.assertItemsEqual(SYSTEM_PROCESS_FIELDS, process.keys())

--- a/metricbeat/tests/system/test_zookeeper.py
+++ b/metricbeat/tests/system/test_zookeeper.py
@@ -2,7 +2,7 @@ import os
 import metricbeat
 from nose.plugins.attrib import attr
 
-ZK_FIELDS = metricbeat.COMMON_FIELDS + ["zookeeper-mntr"]
+ZK_FIELDS = metricbeat.COMMON_FIELDS + ["zookeeper"]
 
 MNTR_FIELDS = ["zk_version", "zk_avg_latency", "zk_max_latency",
                "zk_min_latency", "zk_packets_received", "zk_packets_sent",
@@ -40,7 +40,7 @@ class ZooKeeperMntrTest(metricbeat.BaseTest):
         evt = output[0]
 
         self.assertItemsEqual(ZK_FIELDS, evt.keys())
-        zk_mntr = evt["zookeeper-mntr"]
+        zk_mntr = evt["zookeeper"]["mntr"]
         self.assertItemsEqual(MNTR_FIELDS, zk_mntr.keys())
 
         self.assert_fields_are_documented(evt)


### PR DESCRIPTION
Before the namespace for each metricset was "moduleName-metricSetName". This was not changed to "moduleName.metricSetName", the dot being a sub document. This notation is more in line with the other beats and is nicer to be used.

* Tests were updated to check for new structure
* Apache available for system tests fixed
* Environment system tests command introduced

This PR depends on https://github.com/elastic/beats/pull/1636