### PR TITLE
libbeat: fix logging section in the _beat/config.yml file

### DIFF
--- a/libbeat/_beat/config.yml
+++ b/libbeat/_beat/config.yml
@@ -221,7 +221,7 @@ output.elasticsearch:
 # There are three options for the log output: syslog, file, stderr.
 # Under Windows systems, the log files are per default sent to the file output,
 # under all other system per default to syslog.
-
+logging:
 
   # Enable debug output for selected components. To enable all selectors use ["*"]
   # Other available selectors are beat, publish, service
@@ -232,23 +232,22 @@ output.elasticsearch:
   # Available log levels are: critical, error, warning, info, debug
   #level: error
 
-# Send all logging output to syslog. The default is false.
-#logging.to_syslog: true
+  # Send all logging output to syslog. The default is false.
+  #to_syslog: true
 
-# Logging to rotating files files. Set logging.to_files to false to disable logging to
-# files.
-logging.to_files: true
-logging.files:
+  # Logging to rotating files files. Set to_files to false to disable logging to
+  # files.
+  to_files: true
   # Configure the path where the logs are written. The default is the logs directory
   # under the home path (the binary location).
-  #path: /var/log/mybeat
+  #files.path: /var/log/mybeat
 
   # The name of the files where the logs are written to.
-  #name: mybeat
+  #files.name: mybeat
 
   # Configure log file size limit. If limit is reached, log file will be
   # automatically rotated
-  #rotateeverybytes: 10485760 # = 10MB
+  #files.rotateeverybytes: 10485760 # = 10MB
 
   # Number of rotated log files to keep. Oldest files will be deleted first.
-  #keepfiles: 7
+  #files.keepfiles: 7


### PR DESCRIPTION
I did the same structure as the other configuration sections.
"logging" is the top section.
The configuration fields within the logging section use the dot notation: files.path, files.name, etc.