### PR TITLE
libbeat: output ES urls at INFO log level

### DIFF
--- a/libbeat/outputs/elasticsearch/client.go
+++ b/libbeat/outputs/elasticsearch/client.go
@@ -71,6 +71,8 @@ func NewClient(
 		proxy = http.ProxyURL(proxyURL)
 	}
 
+	logp.Info("Elasticsearch url: %s", esURL)
+
 	client := &Client{
 		Connection: Connection{
 			URL:      esURL,


### PR DESCRIPTION
I found quite useful to display the list of ES's urls in the log file for sanity check purpose.