### PR TITLE
Streamline topbeat config loading

### DIFF
--- a/topbeat/beater/config.go
+++ b/topbeat/beater/config.go
@@ -1,17 +1,48 @@
 package beater
 
-type TopConfig struct {
-	Period *int64
-	Procs  *[]string
-	Stats  struct {
-		System     *bool `config:"system"`
-		Proc       *bool `config:"process"`
-		Filesystem *bool `config:"filesystem"`
-		CpuPerCore *bool `config:"cpu_per_core"`
-	}
-}
+import (
+	"errors"
+	"time"
+)
 
 type ConfigSettings struct {
-	Input   *TopConfig `config:"input"`
-	Topbeat *TopConfig `config:"topbeat"`
+	Topbeat TopConfig `config:"topbeat"`
+}
+
+type TopConfig struct {
+	Period time.Duration     `config:"period"  validate:"min=1ms"`
+	Procs  []string          `config:"procs"`
+	Stats  StatsEnableConfig `config:"stats"`
+}
+
+type StatsEnableConfig struct {
+	System     bool `config:"system"`
+	Proc       bool `config:"process"`
+	Filesystem bool `config:"filesystem"`
+	CPUPerCore bool `config:"cpu_per_core"`
+}
+
+var (
+	defaultConfig = TopConfig{
+		Period: 10 * time.Second,
+		Procs:  []string{".*"}, //all processes
+		Stats: StatsEnableConfig{
+			System:     true,
+			Proc:       true,
+			Filesystem: true,
+			CPUPerCore: false,
+		},
+	}
+)
+
+func (c *TopConfig) Validate() error {
+	return nil
+}
+
+func (c *StatsEnableConfig) Validate() error {
+	if !c.System && !c.Proc && !c.Filesystem {
+		return errors.New("Invalid statistics configuration (enable one of 'system', 'process' or 'filesystem')")
+	}
+
+	return nil
 }


### PR DESCRIPTION
Update topbeat config loading to match most ucfg changes. Also 'period' has become time.Duration and can be initialized as low as '1ms'.