### PR TITLE
Updated package names

### DIFF
--- a/dev-tools/packer/README.md
+++ b/dev-tools/packer/README.md
@@ -52,31 +52,44 @@ a future.
 
 Building all Beats for all platforms:
 
-     make clean && make -j2
+     make clean && make
 
-Which currently produces the following:
+## Naming conventions
 
-        topbeat-1.0.0-nightly.150813173034-darwin.tgz
-        topbeat-1.0.0-nightly.150813173034-darwin.tgz.sha1
-        topbeat_1.0.0-nightly.150813173034_i386.deb
-        topbeat_1.0.0-nightly.150813173034_i386.deb.sha1
-        topbeat-1.0.0-nightly.150813173034-windows.zip
-        topbeat-1.0.0-nightly.150813173034-windows.zip.sha1
-        topbeat-1.0.0-nightly.150813173034-i686.rpm
-        topbeat-1.0.0-nightly.150813173034-i686.rpm
-        topbeat_1.0.0-nightly.150813173034_amd64.deb
-        topbeat_1.0.0-nightly.150813173034_amd64.deb.sha1
-        topbeat-1.0.0-nightly.150813173034-x86_64.rpm
-        topbeat-1.0.0-nightly.150813173034-x86_64.rpm
-        packetbeat-1.0.0-nightly.150813173058-windows.zip
-        packetbeat-1.0.0-nightly.150813173058-windows.zip.sha1
-        packetbeat-1.0.0-nightly.150813173058-darwin.tgz
-        packetbeat-1.0.0-nightly.150813173058-darwin.tgz.sha1
-        packetbeat_1.0.0-nightly.150813173058_i386.deb
-        packetbeat_1.0.0-nightly.150813173058_i386.deb.sha1
-        packetbeat-1.0.0-nightly.150813173058-i686.rpm
-        packetbeat-1.0.0-nightly.150813173058-i686.rpm
-        packetbeat_1.0.0-nightly.150813173058_amd64.deb
-        packetbeat_1.0.0-nightly.150813173058_amd64.deb.sha1
-        packetbeat-1.0.0-nightly.150813173058-x86_64.rpm
-        packetbeat-1.0.0-nightly.150813173058-x86_64.rpm
+We use a set of package name conventions across all the Elastic stack:
+
+* The general form is `name-version-os-arch.ext`. Note that this means we
+  use dashes even for Deb files.
+* The archs are called `x86` and `x64` except for deb/rpm where we keep the
+  OS preferred names (i386/amd64, i686/x86_64).
+* For version strings like `5.0.0-alpha3` we keep them with a dash in the
+  filename but use `~` in the deb/rpm metadata.
+* We omit the release number from the filenames. It's always `1` in the metadata.
+
+For example, here are the artifacts created for Filebeat:
+
+```
+filebeat-5.0.0-amd64.deb
+filebeat-5.0.0-darwin-x86.tar.gz
+filebeat-5.0.0-i386.deb
+filebeat-5.0.0-i686.rpm
+filebeat-5.0.0-linux-x64.tar.gz
+filebeat-5.0.0-linux-x86.tar.gz
+filebeat-5.0.0-windows-x64.zip
+filebeat-5.0.0-windows-x86.zip
+filebeat-5.0.0-x86_64.rpm
+```
+
+And the SNAPSHOT versions:
+
+```
+filebeat-5.0.0-SNAPSHOT-amd64.deb
+filebeat-5.0.0-SNAPSHOT-i386.deb
+filebeat-5.0.0-SNAPSHOT-i686.rpm
+filebeat-5.0.0-SNAPSHOT-x86_64.rpm
+filebeat-5.0.0-SNAPSHOT-darwin-x86.tar.gz
+filebeat-5.0.0-SNAPSHOT-linux-x64.tar.gz
+filebeat-5.0.0-SNAPSHOT-linux-x86.tar.gz
+filebeat-5.0.0-SNAPSHOT-windows-x64.zip
+filebeat-5.0.0-SNAPSHOT-windows-x86.zip
+```

--- a/dev-tools/packer/archs/386.yml
+++ b/dev-tools/packer/archs/386.yml
@@ -1,5 +1,5 @@
 arch: '386'
 deb_arch: i386
 rpm_arch: i686
-bin_arch: i686
-win_arch: 32
+bin_arch: x86
+win_arch: x86

--- a/dev-tools/packer/archs/amd64.yml
+++ b/dev-tools/packer/archs/amd64.yml
@@ -1,5 +1,5 @@
 arch: amd64
 deb_arch: amd64
 rpm_arch: x86_64
-bin_arch: x86_64
-win_arch: 64
+bin_arch: x64
+win_arch: x64

--- a/dev-tools/packer/platforms/binary/run.sh.j2
+++ b/dev-tools/packer/platforms/binary/run.sh.j2
@@ -10,17 +10,17 @@ if [ "$SNAPSHOT" = "yes" ]; then
     VERSION="${VERSION}-SNAPSHOT"
 fi
 
-mkdir /{{.beat_name}}-${VERSION}-{{.bin_arch}}
-cp -a homedirs/{{.beat_name}}/. /{{.beat_name}}-${VERSION}-{{.bin_arch}}/
-cp {{.beat_name}}-linux-{{.arch}} /{{.beat_name}}-${VERSION}-{{.bin_arch}}/{{.beat_name}}
-cp {{.beat_name}}-binary.yml /{{.beat_name}}-${VERSION}-{{.bin_arch}}/{{.beat_name}}.yml
-cp {{.beat_name}}.template.json /{{.beat_name}}-${VERSION}-{{.bin_arch}}/
-cp {{.beat_name}}.template-es2x.json /{{.beat_name}}-${VERSION}-{{.bin_arch}}/
+mkdir /{{.beat_name}}-${VERSION}-linux-{{.bin_arch}}
+cp -a homedirs/{{.beat_name}}/. /{{.beat_name}}-${VERSION}-linux-{{.bin_arch}}/
+cp {{.beat_name}}-linux-{{.arch}} /{{.beat_name}}-${VERSION}-linux-{{.bin_arch}}/{{.beat_name}}
+cp {{.beat_name}}-binary.yml /{{.beat_name}}-${VERSION}-linux-{{.bin_arch}}/{{.beat_name}}.yml
+cp {{.beat_name}}.template.json /{{.beat_name}}-${VERSION}-linux-{{.bin_arch}}/
+cp {{.beat_name}}.template-es2x.json /{{.beat_name}}-${VERSION}-linux-{{.bin_arch}}/
 
 mkdir -p upload/{{.beat_name}}
-tar czvf upload/{{.beat_name}}/{{.beat_name}}-${VERSION}-{{.bin_arch}}.tar.gz /{{.beat_name}}-${VERSION}-{{.bin_arch}}
-echo "Created upload/{{.beat_name}}/{{.beat_name}}-${VERSION}-{{.bin_arch}}.tar.gz"
+tar czvf upload/{{.beat_name}}/{{.beat_name}}-${VERSION}-linux-{{.bin_arch}}.tar.gz /{{.beat_name}}-${VERSION}-linux-{{.bin_arch}}
+echo "Created upload/{{.beat_name}}/{{.beat_name}}-${VERSION}-linux-{{.bin_arch}}.tar.gz"
 
 cd upload/{{.beat_name}}
-sha1sum {{.beat_name}}-${VERSION}-{{.bin_arch}}.tar.gz > {{.beat_name}}-${VERSION}-{{.bin_arch}}.tar.gz.sha1.txt
-echo "Created upload/{{.beat_name}}/{{.beat_name}}-${VERSION}-{{.bin_arch}}.tar.gz.sha1.txt"
+sha1sum {{.beat_name}}-${VERSION}-linux-{{.bin_arch}}.tar.gz > {{.beat_name}}-${VERSION}-linux-{{.bin_arch}}.tar.gz.sha1.txt
+echo "Created upload/{{.beat_name}}/{{.beat_name}}-${VERSION}-linux-{{.bin_arch}}.tar.gz.sha1.txt"

--- a/dev-tools/packer/platforms/centos/run.sh.j2
+++ b/dev-tools/packer/platforms/centos/run.sh.j2
@@ -17,8 +17,8 @@ if [ "$SNAPSHOT" = "yes" ]; then
     VERSION="${VERSION}-SNAPSHOT"
 fi
 
-# replace - with ~ to allow the GA versions to be installed over alpahs/betas/snapshots
-RPM_VERSION=`echo ${VERSION} | sed 's/-/~/'`
+# fpm replaces - with _ in the version
+RPM_VERSION=`echo ${VERSION} | sed 's/-/~/g'`
 
 # create rpm
 fpm --force -s dir -t rpm \

--- a/dev-tools/packer/platforms/darwin/run.sh.j2
+++ b/dev-tools/packer/platforms/darwin/run.sh.j2
@@ -10,17 +10,17 @@ if [ "$SNAPSHOT" = "yes" ]; then
     VERSION="${VERSION}-SNAPSHOT"
 fi
 
-mkdir /{{.beat_name}}-${VERSION}-darwin
-cp -a homedirs/{{.beat_name}}/. /{{.beat_name}}-${VERSION}-darwin/
-cp {{.beat_name}}-darwin-amd64 /{{.beat_name}}-${VERSION}-darwin/{{.beat_name}}
-cp {{.beat_name}}-darwin.yml /{{.beat_name}}-${VERSION}-darwin/{{.beat_name}}.yml
-cp {{.beat_name}}.template.json /{{.beat_name}}-${VERSION}-darwin/
-cp {{.beat_name}}.template-es2x.json /{{.beat_name}}-${VERSION}-darwin/
+mkdir /{{.beat_name}}-${VERSION}-darwin-x86
+cp -a homedirs/{{.beat_name}}/. /{{.beat_name}}-${VERSION}-darwin-x86/
+cp {{.beat_name}}-darwin-amd64 /{{.beat_name}}-${VERSION}-darwin-x86/{{.beat_name}}
+cp {{.beat_name}}-darwin.yml /{{.beat_name}}-${VERSION}-darwin-x86/{{.beat_name}}.yml
+cp {{.beat_name}}.template.json /{{.beat_name}}-${VERSION}-darwin-x86/
+cp {{.beat_name}}.template-es2x.json /{{.beat_name}}-${VERSION}-darwin-x86/
 
 mkdir -p upload/{{.beat_name}}
-tar czvf upload/{{.beat_name}}/{{.beat_name}}-${VERSION}-darwin.tgz /{{.beat_name}}-${VERSION}-darwin
-echo "Created upload/{{.beat_name}}/{{.beat_name}}-${VERSION}-darwin.tgz"
+tar czvf upload/{{.beat_name}}/{{.beat_name}}-${VERSION}-darwin-x86.tar.gz /{{.beat_name}}-${VERSION}-darwin-x86
+echo "Created upload/{{.beat_name}}/{{.beat_name}}-${VERSION}-darwin-x86.tar.gz"
 
 cd upload/{{.beat_name}}
-sha1sum {{.beat_name}}-${VERSION}-darwin.tgz > {{.beat_name}}-${VERSION}-darwin.tgz.sha1.txt
-echo "Created upload/{{.beat_name}}/{{.beat_name}}-${VERSION}-darwin.tgz.sha1.txt"
+sha1sum {{.beat_name}}-${VERSION}-darwin-x86.tar.gz > {{.beat_name}}-${VERSION}-darwin-x86.tar.gz.sha1.txt
+echo "Created upload/{{.beat_name}}/{{.beat_name}}-${VERSION}-darwin-x86.tar.gz.sha1.txt"

--- a/dev-tools/packer/platforms/debian/run.sh.j2
+++ b/dev-tools/packer/platforms/debian/run.sh.j2
@@ -17,8 +17,8 @@ if [ "$SNAPSHOT" = "yes" ]; then
     VERSION="${VERSION}-SNAPSHOT"
 fi
 
-# replace - with ~ to allow the GA versions to be installed over alpahs/betas/snapshots
-DEB_VERSION=`echo ${VERSION} | sed 's/-/~/'`
+# fpm replaces - with _ in the version
+DEB_VERSION=`echo ${VERSION} | sed 's/-/~/g'`
 
 # create deb
 fpm --force -s dir -t deb \
@@ -40,12 +40,12 @@ fpm --force -s dir -t deb \
         ${RUNID}.service=/lib/systemd/system/{{.beat_name}}.service \
         god-linux-{{.arch}}=/usr/share/{{.beat_name}}/bin/{{.beat_name}}-god
 
-# move and rename so that the filename respects semver rules
+# move and rename to use the elastic conventions
 mkdir -p upload/{{.beat_name}}
-mv {{.beat_name}}_${DEB_VERSION}_{{.deb_arch}}.deb upload/{{.beat_name}}/{{.beat_name}}_${VERSION}_{{.deb_arch}}.deb
-echo "Created upload/{{.beat_name}}/{{.beat_name}}_${VERSION}_{{.deb_arch}}.deb"
+mv {{.beat_name}}_${DEB_VERSION}_{{.deb_arch}}.deb upload/{{.beat_name}}/{{.beat_name}}-${VERSION}-{{.deb_arch}}.deb
+echo "Created upload/{{.beat_name}}/{{.beat_name}}-${VERSION}-{{.deb_arch}}.deb"
 
 # create sha1 file
 cd upload/{{.beat_name}}
-sha1sum {{.beat_name}}_${VERSION}_{{.deb_arch}}.deb > {{.beat_name}}_${VERSION}_{{.deb_arch}}.deb.sha1.txt
-echo "Created upload//{{.beat_name}}/{{.beat_name}}_${VERSION}_{{.deb_arch}}.deb.sha1.txt"
+sha1sum {{.beat_name}}-${VERSION}-{{.deb_arch}}.deb > {{.beat_name}}-${VERSION}-{{.deb_arch}}.deb.sha1.txt
+echo "Created upload//{{.beat_name}}/{{.beat_name}}-${VERSION}-{{.deb_arch}}.deb.sha1.txt"


### PR DESCRIPTION
To match the conventions agreed with the other Elastic projects. Summary of the
changes:

* archs are called x86 and x64 except for deb/rpm where we keep the OS
  preferred ways
* Use the ~ from the rpm/deb metadata, but - in the file names
* include `linux` in linux name  and `x86` in darwin name
* added these conventions to the README file

 Here are the resulting filenames:

```
filebeat-5.0.0-amd64.deb
filebeat-5.0.0-i386.deb

filebeat-5.0.0-i686.rpm
filebeat-5.0.0-x86_64.rpm

filebeat-5.0.0-linux-x64.tar.gz
filebeat-5.0.0-linux-x86.tar.gz

filebeat-5.0.0-windows-x64.zip
filebeat-5.0.0-windows-x86.zip

filebeat-5.0.0-darwin-x86.tar.gz
```
and the "snapshot" versions:

```
filebeat-5.0.0-SNAPSHOT-amd64.deb
filebeat-5.0.0-SNAPSHOT-i386.deb

filebeat-5.0.0-SNAPSHOT-i686.rpm
filebeat-5.0.0-SNAPSHOT-x86_64.rpm

filebeat-5.0.0-SNAPSHOT-linux-x64.tar.gz
filebeat-5.0.0-SNAPSHOT-linux-x86.tar.gz

filebeat-5.0.0-SNAPSHOT-windows-x64.zip
filebeat-5.0.0-SNAPSHOT-windows-x86.zip

filebeat-5.0.0-SNAPSHOT-darwin-x86.tar.gz
```