### PR TITLE
Improve short config behaviour

### DIFF
--- a/metricbeat/etc/beat.short.yml
+++ b/metricbeat/etc/beat.short.yml
@@ -29,6 +29,16 @@ metricbeat.modules:
   # The username and password can either be set in the DSN or for all hosts in username and password config option
   hosts: ["root@tcp(127.0.0.1:3306)/"]
 
+#---------------------------- Nginx Status Module ----------------------------
+- module: nginx
+  metricsets: ["stubstatus"]
+  enabled: true
+  period: 1s
+
+  # Nginx hosts
+  hosts: ["http://127.0.0.1/"]
+
+
 #---------------------------- Redis Status Module ----------------------------
 - module: redis
   metricsets: ["info"]

--- a/metricbeat/etc/fields.yml
+++ b/metricbeat/etc/fields.yml
@@ -806,6 +806,7 @@
   title: "Zookeeper Status"
   description: >
     ZooKeeper metrics collected by the four-letter monitoring commands.
+  short_config: false
   fields:
     - name: zookeeper
       type: group

--- a/metricbeat/metricbeat.short.yml
+++ b/metricbeat/metricbeat.short.yml
@@ -29,6 +29,16 @@ metricbeat.modules:
   # The username and password can either be set in the DSN or for all hosts in username and password config option
   hosts: ["root@tcp(127.0.0.1:3306)/"]
 
+#---------------------------- Nginx Status Module ----------------------------
+- module: nginx
+  metricsets: ["stubstatus"]
+  enabled: true
+  period: 1s
+
+  # Nginx hosts
+  hosts: ["http://127.0.0.1/"]
+
+
 #---------------------------- Redis Status Module ----------------------------
 - module: redis
   metricsets: ["info"]

--- a/metricbeat/module/nginx/_beat/config.short.yml
+++ b/metricbeat/module/nginx/_beat/config.short.yml
@@ -1,0 +1,8 @@
+- module: nginx
+  metricsets: ["stubstatus"]
+  enabled: true
+  period: 1s
+
+  # Nginx hosts
+  hosts: ["http://127.0.0.1/"]
+

--- a/metricbeat/module/system/_beat/config.short.yml
+++ b/metricbeat/module/system/_beat/config.short.yml
@@ -1,4 +1,0 @@
-- module: system
-  metricsets: ["cpu", "cores", "filesystem", "fsstats", "memory", "process"]
-  enabled: true
-  period: 2s

--- a/metricbeat/module/zookeeper/_beat/fields.yml
+++ b/metricbeat/module/zookeeper/_beat/fields.yml
@@ -2,6 +2,7 @@
   title: "Zookeeper Status"
   description: >
     ZooKeeper metrics collected by the four-letter monitoring commands.
+  short_config: false
   fields:
     - name: zookeeper
       type: group

--- a/metricbeat/scripts/config_collector.py
+++ b/metricbeat/scripts/config_collector.py
@@ -45,19 +45,34 @@ def collect(beat_path, short=False):
     for module in os.listdir(base_dir):
 
         beat_path = path + "/" + module + "/_beat"
+
+        module_configs = beat_path + "/config.yml"
+
+        # By default, short config is read if short is set
+        short_config = True
+
+        # Check if short config exists
         if short:
-            module_configs = beat_path + "/config.short.yml"
-        else:
-            module_configs = beat_path + "/config.yml"
+            short_module_config = beat_path + "/config.short.yml"
+            if os.path.isfile(short_module_config):
+                module_configs = short_module_config
 
         # Only check folders where config exists
         if not os.path.isfile(module_configs):
             continue
 
+
         # Load title from fields.yml
         with open(beat_path + "/fields.yml") as f:
             fields = yaml.load(f.read())
             title = fields[0]["title"]
+
+            # Check if short config was disabled in fields.yml
+            if short and "short_config" in fields[0]:
+                short_config = fields[0]["short_config"]
+
+        if short and short_config == False:
+            continue
 
         config_yml += get_title_line(title)
 


### PR DESCRIPTION
The following rules apply to create a short config:

* If config.short.yml exists, this file is taken for the short config
* If file does not exist, the standard config file is taken.
* If short config for a module should be disabled, short_config has to be set to false in fields.yml

The reason behind this change as by default, a module config should also be in the short config. So if Metricbeat is used as library for community beats, by default the short config also has content inside.

The change that was made is:

* Remove config.short.yml from system module as it was identical with the long config
* Disable short config for zookeeper is normally not used to play around
* Add nginx short config