### PR TITLE
Export percentages for CPU usage 

### DIFF
--- a/metricbeat/module/system/cores/cores.go
+++ b/metricbeat/module/system/cores/cores.go
@@ -6,8 +6,6 @@ import (
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/topbeat/system"
-
-	"github.com/pkg/errors"
 )
 
 func init() {
@@ -36,20 +34,5 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // Fetch fetches CPU core metrics from the OS.
 func (m *MetricSet) Fetch() ([]common.MapStr, error) {
 
-	cpuCoreStat, err := system.GetCpuTimesList()
-	if err != nil {
-		return nil, errors.Wrap(err, "cpu core times")
-	}
-	m.cpu.AddCpuPercentageList(cpuCoreStat)
-
-	cores := []common.MapStr{}
-
-	for core, stat := range cpuCoreStat {
-		coreStat := system.GetCpuStatEvent(&stat)
-		coreStat["core"] = core
-		cores = append(cores, coreStat)
-
-	}
-
-	return cores, nil
+	return m.cpu.GetPerCoreStats()
 }

--- a/topbeat/beater/config.go
+++ b/topbeat/beater/config.go
@@ -16,10 +16,12 @@ type TopConfig struct {
 }
 
 type StatsEnableConfig struct {
-	System     bool `config:"system"`
-	Proc       bool `config:"process"`
-	Filesystem bool `config:"filesystem"`
-	CPUPerCore bool `config:"cpu_per_core"`
+	System          bool `config:"system"`
+	Proc            bool `config:"process"`
+	Filesystem      bool `config:"filesystem"`
+	CPUPerCore      bool `config:"cpu_per_core"`
+	CPUTicks        bool `config:"cpu_ticks"`
+	CPUTicksPerProc bool `config:"cpu_ticks_per_proc"`
 }
 
 var (
@@ -27,10 +29,12 @@ var (
 		Period: 10 * time.Second,
 		Procs:  []string{".*"}, //all processes
 		Stats: StatsEnableConfig{
-			System:     true,
-			Proc:       true,
-			Filesystem: true,
-			CPUPerCore: false,
+			System:          true,
+			Proc:            true,
+			Filesystem:      true,
+			CPUPerCore:      false,
+			CPUTicks:        false,
+			CPUTicksPerProc: false,
 		},
 	}
 )

--- a/topbeat/beater/topbeat.go
+++ b/topbeat/beater/topbeat.go
@@ -67,12 +67,12 @@ func (tb *Topbeat) Config(b *beat.Beat) error {
 	topbeatConfig := tb.TbConfig.Topbeat
 	tb.period = topbeatConfig.Period
 	tb.procStats.Procs = topbeatConfig.Procs
+	tb.procStats.CpuTicksPerProc = topbeatConfig.Stats.CPUTicksPerProc
 	tb.sysStats = topbeatConfig.Stats.System
 	tb.procStats.ProcStats = topbeatConfig.Stats.Proc
 	tb.fsStats = topbeatConfig.Stats.Filesystem
 	tb.cpu.CpuPerCore = topbeatConfig.Stats.CPUPerCore
 	tb.cpu.CpuTicks = topbeatConfig.Stats.CPUTicks
-	tb.cpu.CpuTicksPerProc = topbeatConfig.Stats.CPUTicksPerProc
 
 	logp.Debug("topbeat", "Init topbeat")
 	logp.Debug("topbeat", "Follow processes %q", tb.procStats.Procs)
@@ -80,9 +80,9 @@ func (tb *Topbeat) Config(b *beat.Beat) error {
 	logp.Debug("topbeat", "System statistics %t", tb.sysStats)
 	logp.Debug("topbeat", "Process statistics %t", tb.procStats.ProcStats)
 	logp.Debug("topbeat", "File system statistics %t", tb.fsStats)
-	logp.Debug("topbeat", "Add CPU info per core %t", tb.cpu.CpuPerCore)
-	logp.Debug("topbeat", "Add CPU ticks info %t", tb.cpu.CpuTicks)
-	logp.Debug("topbeat", "Add CPU ticks info per process %t", tb.cpu.CpuTicksPerProc)
+	logp.Debug("topbeat", "cpu_per_core=%t", tb.cpu.CpuPerCore)
+	logp.Debug("topbeat", "cpu_ticks=%t", tb.cpu.CpuTicks)
+	logp.Debug("topbeat", "cpu_ticks_per_proc=%t", tb.procStats.CpuTicksPerProc)
 
 	return nil
 }

--- a/topbeat/beater/topbeat.go
+++ b/topbeat/beater/topbeat.go
@@ -71,6 +71,8 @@ func (tb *Topbeat) Config(b *beat.Beat) error {
 	tb.procStats.ProcStats = topbeatConfig.Stats.Proc
 	tb.fsStats = topbeatConfig.Stats.Filesystem
 	tb.cpu.CpuPerCore = topbeatConfig.Stats.CPUPerCore
+	tb.cpu.CpuTicks = topbeatConfig.Stats.CPUTicks
+	tb.cpu.CpuTicksPerProc = topbeatConfig.Stats.CPUTicksPerProc
 
 	logp.Debug("topbeat", "Init topbeat")
 	logp.Debug("topbeat", "Follow processes %q", tb.procStats.Procs)
@@ -78,7 +80,9 @@ func (tb *Topbeat) Config(b *beat.Beat) error {
 	logp.Debug("topbeat", "System statistics %t", tb.sysStats)
 	logp.Debug("topbeat", "Process statistics %t", tb.procStats.ProcStats)
 	logp.Debug("topbeat", "File system statistics %t", tb.fsStats)
-	logp.Debug("topbeat", "Cpu usage per core %t", tb.cpu.CpuPerCore)
+	logp.Debug("topbeat", "Add CPU info per core %t", tb.cpu.CpuPerCore)
+	logp.Debug("topbeat", "Add CPU ticks info %t", tb.cpu.CpuTicks)
+	logp.Debug("topbeat", "Add CPU ticks info per process %t", tb.cpu.CpuTicksPerProc)
 
 	return nil
 }

--- a/topbeat/system/cpu.go
+++ b/topbeat/system/cpu.go
@@ -176,6 +176,13 @@ func (cpu *CPU) GetSystemStats() (common.MapStr, error) {
 		"swap":       GetSwapEvent(swapStat),
 	}
 
+	return event, nil
+}
+
+func (cpu *CPU) GetPerCoreStats() ([]common.MapStr, error) {
+
+	var result []common.MapStr
+
 	if cpu.CpuPerCore {
 
 		cpuCoreStat, err := GetCpuTimesList()
@@ -183,8 +190,8 @@ func (cpu *CPU) GetSystemStats() (common.MapStr, error) {
 			logp.Warn("Getting cpu core times: %v", err)
 			return nil, err
 		}
-		event["cpus"] = cpu.GetCpuStatForCores(cpuCoreStat)
+		cpuCoreStat["core"] = cpu.GetCpuStatForCores(cpuCoreStat)
 	}
 
-	return event, nil
+	return result, nil
 }

--- a/topbeat/system/cpu.go
+++ b/topbeat/system/cpu.go
@@ -13,12 +13,20 @@ type CPU struct {
 	CpuPerCore       bool
 	LastCpuTimes     *CpuTimes
 	LastCpuTimesList []CpuTimes
+	CpuTicks         bool
+	CpuTicksPerProc  bool
 }
 
 type CpuTimes struct {
 	sigar.Cpu
-	UserPercent   float64 `json:"user_p"`
-	SystemPercent float64 `json:"system_p"`
+	UserPercent    float64 `json:"user_p"`
+	SystemPercent  float64 `json:"system_p"`
+	IdlePercent    float64 `json:"idle_p"`
+	IOwaitPercent  float64 `json:"iowait_p"`
+	IrqPercent     float64 `json:"irq_p"`
+	NicePercent    float64 `json:"nice_p"`
+	SoftIrqPercent float64 `json:"softirq_p"`
+	StealPercent   float64 `json: "steal_p"`
 }
 
 func GetCpuTimes() (*CpuTimes, error) {
@@ -64,6 +72,12 @@ func GetCpuPercentage(last *CpuTimes, current *CpuTimes) *CpuTimes {
 
 		current.UserPercent = calculate(current.Cpu.User, last.Cpu.User)
 		current.SystemPercent = calculate(current.Cpu.Sys, last.Cpu.Sys)
+		current.IdlePercent = calculate(current.Cpu.Idle, last.Cpu.Idle)
+		current.IOwaitPercent = calculate(current.Cpu.Wait, last.Cpu.Wait)
+		current.IrqPercent = calculate(current.Cpu.Irq, last.Cpu.Irq)
+		current.NicePercent = calculate(current.Cpu.Nice, last.Cpu.Nice)
+		current.SoftIrqPercent = calculate(current.Cpu.SoftIrq, last.Cpu.SoftIrq)
+		current.StealPercent = calculate(current.Cpu.Stolen, last.Cpu.Stolen)
 	}
 
 	return current
@@ -85,6 +99,13 @@ func GetCpuPercentageList(last, current []CpuTimes) []CpuTimes {
 			all_delta := current[i].Cpu.Total() - last[i].Cpu.Total()
 			current[i].UserPercent = calculate(current[i].Cpu.User, last[i].Cpu.User, all_delta)
 			current[i].SystemPercent = calculate(current[i].Cpu.Sys, last[i].Cpu.Sys, all_delta)
+			current[i].IdlePercent = calculate(current[i].Cpu.Idle, last[i].Cpu.Idle, all_delta)
+			current[i].IOwaitPercent = calculate(current[i].Cpu.Wait, last[i].Cpu.Wait, all_delta)
+			current[i].IrqPercent = calculate(current[i].Cpu.Irq, last[i].Cpu.Irq, all_delta)
+			current[i].NicePercent = calculate(current[i].Cpu.Nice, last[i].Cpu.Nice, all_delta)
+			current[i].SoftIrqPercent = calculate(current[i].Cpu.SoftIrq, last[i].Cpu.SoftIrq, all_delta)
+			current[i].StealPercent = calculate(current[i].Cpu.Stolen, last[i].Cpu.Stolen, all_delta)
+
 		}
 
 	}
@@ -92,19 +113,33 @@ func GetCpuPercentageList(last, current []CpuTimes) []CpuTimes {
 	return current
 }
 
-func GetCpuStatEvent(cpuStat *CpuTimes) common.MapStr {
-	return common.MapStr{
-		"user":     cpuStat.User,
-		"system":   cpuStat.Sys,
-		"nice":     cpuStat.Nice,
-		"idle":     cpuStat.Idle,
-		"iowait":   cpuStat.Wait,
-		"irq":      cpuStat.Irq,
-		"softirq":  cpuStat.SoftIrq,
-		"steal":    cpuStat.Stolen,
-		"user_p":   cpuStat.UserPercent,
-		"system_p": cpuStat.SystemPercent,
+func (cpu *CPU) GetCpuStatEvent(cpuStat *CpuTimes) common.MapStr {
+	result := common.MapStr{
+		"user_p":    cpuStat.UserPercent,
+		"system_p":  cpuStat.SystemPercent,
+		"idle_p":    cpuStat.IdlePercent,
+		"iowait_p":  cpuStat.IOwaitPercent,
+		"irq_p":     cpuStat.IrqPercent,
+		"nice_p":    cpuStat.NicePercent,
+		"softirq_p": cpuStat.SoftIrqPercent,
+		"steal_p":   cpuStat.StealPercent,
 	}
+
+	if cpu.CpuTicks {
+		m := common.MapStr{
+			"user":    cpuStat.User,
+			"system":  cpuStat.Sys,
+			"nice":    cpuStat.Nice,
+			"idle":    cpuStat.Idle,
+			"iowait":  cpuStat.Wait,
+			"irq":     cpuStat.Irq,
+			"softirq": cpuStat.SoftIrq,
+			"steal":   cpuStat.Stolen,
+		}
+		return common.MapStrUnion(result, m)
+	}
+	return result
+
 }
 
 func (cpu *CPU) AddCpuPercentage(t2 *CpuTimes) {
@@ -147,7 +182,7 @@ func (cpu *CPU) GetSystemStats() (common.MapStr, error) {
 		"@timestamp": common.Time(time.Now()),
 		"type":       "system",
 		"load":       loadStat,
-		"cpu":        GetCpuStatEvent(cpuStat),
+		"cpu":        cpu.GetCpuStatEvent(cpuStat),
 		"mem":        GetMemoryEvent(memStat),
 		"swap":       GetSwapEvent(swapStat),
 	}
@@ -164,7 +199,7 @@ func (cpu *CPU) GetSystemStats() (common.MapStr, error) {
 		cpus := common.MapStr{}
 
 		for coreNumber, stat := range cpuCoreStat {
-			cpus["cpu"+strconv.Itoa(coreNumber)] = GetCpuStatEvent(&stat)
+			cpus["cpu"+strconv.Itoa(coreNumber)] = cpu.GetCpuStatEvent(&stat)
 		}
 		event["cpus"] = cpus
 	}

--- a/topbeat/system/cpu.go
+++ b/topbeat/system/cpu.go
@@ -14,7 +14,6 @@ type CPU struct {
 	LastCpuTimes     *sigar.Cpu
 	LastCpuTimesList []sigar.Cpu
 	CpuTicks         bool
-	CpuTicksPerProc  bool
 }
 
 func GetCpuTimes() (*sigar.Cpu, error) {
@@ -62,7 +61,7 @@ func calculateCpuPercentages(last, current *sigar.Cpu) common.MapStr {
 		all_delta := current.Total() - last.Total()
 
 		if all_delta == 0 {
-			// first run of the Beat
+			// first inquiry
 			return emptyMapStr
 		}
 

--- a/topbeat/system/cpu_test.go
+++ b/topbeat/system/cpu_test.go
@@ -5,7 +5,8 @@ package system
 import (
 	"testing"
 
-	"github.com/elastic/gosigar"
+	"github.com/elastic/beats/libbeat/logp"
+	sigar "github.com/elastic/gosigar"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -23,41 +24,39 @@ func TestGetCpuTimes(t *testing.T) {
 
 func TestCpuPercentage(t *testing.T) {
 
+	if testing.Verbose() {
+		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"*"})
+	}
 	cpu := CPU{}
 
-	cpu1 := CpuTimes{
-		Cpu: gosigar.Cpu{
-			User:    10855311,
-			Nice:    0,
-			Sys:     2021040,
-			Idle:    17657874,
-			Wait:    0,
-			Irq:     0,
-			SoftIrq: 0,
-			Stolen:  0,
-		},
+	cpu1 := sigar.Cpu{
+		User:    10855311,
+		Nice:    0,
+		Sys:     2021040,
+		Idle:    17657874,
+		Wait:    0,
+		Irq:     0,
+		SoftIrq: 0,
+		Stolen:  0,
 	}
 
-	cpu.AddCpuPercentage(&cpu1)
+	per := cpu.GetCpuStatEvent(&cpu1)
+	assert.Equal(t, per["user_p"], 0.0)
+	assert.Equal(t, per["system_p"], 0.0)
 
-	assert.Equal(t, cpu1.UserPercent, 0.0)
-	assert.Equal(t, cpu1.SystemPercent, 0.0)
-
-	cpu2 := CpuTimes{
-		Cpu: gosigar.Cpu{
-			User:    10855693,
-			Nice:    0,
-			Sys:     2021058,
-			Idle:    17657876,
-			Wait:    0,
-			Irq:     0,
-			SoftIrq: 0,
-			Stolen:  0,
-		},
+	cpu2 := sigar.Cpu{
+		User:    10855693,
+		Nice:    0,
+		Sys:     2021058,
+		Idle:    17657876,
+		Wait:    0,
+		Irq:     0,
+		SoftIrq: 0,
+		Stolen:  0,
 	}
 
-	cpu.AddCpuPercentage(&cpu2)
+	per = cpu.GetCpuStatEvent(&cpu2)
 
-	assert.Equal(t, cpu2.UserPercent, 0.9502)
-	assert.Equal(t, cpu2.SystemPercent, 0.0448)
+	assert.Equal(t, per["user_p"], 0.9502)
+	assert.Equal(t, per["system_p"], 0.0448)
 }

--- a/topbeat/system/cpu_test.go
+++ b/topbeat/system/cpu_test.go
@@ -36,9 +36,10 @@ func TestCpuPercentage(t *testing.T) {
 		Stolen:  0,
 	}
 
-	per := cpu.GetCpuStatEvent(&cpu1)
-	assert.Equal(t, per["user_p"], 0.0)
-	assert.Equal(t, per["system_p"], 0.0)
+	stats, err := cpu.GetCpuStats(&cpu1)
+	assert.Nil(t, err)
+	assert.Equal(t, stats["user_p"], 0.0)
+	assert.Equal(t, stats["system_p"], 0.0)
 
 	cpu2 := sigar.Cpu{
 		User:    10855693,
@@ -51,8 +52,8 @@ func TestCpuPercentage(t *testing.T) {
 		Stolen:  0,
 	}
 
-	per = cpu.GetCpuStatEvent(&cpu2)
-
-	assert.Equal(t, per["user_p"], 0.9502)
-	assert.Equal(t, per["system_p"], 0.0448)
+	stats, err = cpu.GetCpuStats(&cpu2)
+	assert.Nil(t, err)
+	assert.Equal(t, stats["user_p"], 0.9502)
+	assert.Equal(t, stats["system_p"], 0.0448)
 }

--- a/topbeat/system/cpu_test.go
+++ b/topbeat/system/cpu_test.go
@@ -5,7 +5,6 @@ package system
 import (
 	"testing"
 
-	"github.com/elastic/beats/libbeat/logp"
 	sigar "github.com/elastic/gosigar"
 	"github.com/stretchr/testify/assert"
 )
@@ -24,9 +23,6 @@ func TestGetCpuTimes(t *testing.T) {
 
 func TestCpuPercentage(t *testing.T) {
 
-	if testing.Verbose() {
-		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"*"})
-	}
 	cpu := CPU{}
 
 	cpu1 := sigar.Cpu{

--- a/topbeat/system/process.go
+++ b/topbeat/system/process.go
@@ -88,7 +88,7 @@ func GetProcMemPercentage(proc *Process, total_phymem uint64) float64 {
 			logp.Warn("Getting memory details: %v", err)
 			return 0
 		}
-		total_phymem = memStat.Mem.Total
+		total_phymem = memStat.Total
 	}
 
 	perc := (float64(proc.Mem.Resident) / float64(total_phymem))

--- a/topbeat/system/process.go
+++ b/topbeat/system/process.go
@@ -26,10 +26,11 @@ type Process struct {
 }
 
 type ProcStats struct {
-	ProcStats bool
-	Procs     []string
-	regexps   []*regexp.Regexp
-	ProcsMap  ProcsMap
+	ProcStats       bool
+	Procs           []string
+	regexps         []*regexp.Regexp
+	ProcsMap        ProcsMap
+	CpuTicksPerProc bool
 }
 
 // newProcess creates a new Process object based on the state information.
@@ -123,7 +124,7 @@ func getProcState(b byte) string {
 	return "unknown"
 }
 
-func GetProcessEvent(process *Process, last *Process) common.MapStr {
+func (procStats *ProcStats) GetProcessEvent(process *Process, last *Process) common.MapStr {
 	proc := common.MapStr{
 		"pid":      process.Pid,
 		"ppid":     process.Ppid,
@@ -136,17 +137,25 @@ func GetProcessEvent(process *Process, last *Process) common.MapStr {
 			"rss_p": GetProcMemPercentage(process, 0 /* read total mem usage */),
 			"share": process.Mem.Share,
 		},
-		"cpu": common.MapStr{
+	}
+
+	if process.CmdLine != "" {
+		proc["cmdline"] = process.CmdLine
+	}
+
+	if procStats.CpuTicksPerProc {
+		proc["cpu"] = common.MapStr{
 			"user":       process.Cpu.User,
 			"system":     process.Cpu.Sys,
 			"total":      process.Cpu.Total,
 			"total_p":    GetProcCpuPercentage(last, process),
 			"start_time": process.Cpu.FormatStartTime(),
-		},
-	}
-
-	if process.CmdLine != "" {
-		proc["cmdline"] = process.CmdLine
+		}
+	} else {
+		proc["cpu"] = common.MapStr{
+			"total_p":    GetProcCpuPercentage(last, process),
+			"start_time": process.Cpu.FormatStartTime(),
+		}
 	}
 
 	return proc
@@ -251,7 +260,7 @@ func (procStats *ProcStats) GetProcStats() ([]common.MapStr, error) {
 			newProcs[process.Pid] = process
 
 			last, _ := procStats.ProcsMap[process.Pid]
-			proc := GetProcessEvent(process, last)
+			proc := procStats.GetProcessEvent(process, last)
 
 			processes = append(processes, proc)
 		}

--- a/topbeat/system/system_test.go
+++ b/topbeat/system/system_test.go
@@ -6,7 +6,7 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/elastic/gosigar"
+	sigar "github.com/elastic/gosigar"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -57,40 +57,30 @@ func TestGetSwap(t *testing.T) {
 
 func TestMemPercentage(t *testing.T) {
 
-	m := MemStat{
-		Mem: gosigar.Mem{
-			Total: 7,
-			Used:  5,
-			Free:  2,
-		},
+	m := sigar.Mem{
+		Total: 7,
+		Used:  5,
+		Free:  2,
 	}
-	AddMemPercentage(&m)
-	assert.Equal(t, m.UsedPercent, 0.7143)
+	stats := GetMemoryEvent(&m)
+	assert.Equal(t, stats["used_p"], 0.7143)
 
-	m = MemStat{
-		Mem: gosigar.Mem{Total: 0},
-	}
-	AddMemPercentage(&m)
-	assert.Equal(t, m.UsedPercent, 0.0)
+	m = sigar.Mem{Total: 0}
+	stats = GetMemoryEvent(&m)
+	assert.Equal(t, stats["used_p"], 0.0)
 }
 
 func TestActualMemPercentage(t *testing.T) {
 
-	m := MemStat{
-		Mem: gosigar.Mem{
-			Total:      7,
-			ActualUsed: 5,
-			ActualFree: 2,
-		},
+	m := sigar.Mem{
+		Total:      7,
+		ActualUsed: 5,
+		ActualFree: 2,
 	}
-	AddMemPercentage(&m)
-	assert.Equal(t, m.ActualUsedPercent, 0.7143)
+	stats := GetMemoryEvent(&m)
+	assert.Equal(t, stats["actual_used_p"], 0.7143)
 
-	m = MemStat{
-		Mem: gosigar.Mem{
-			Total: 0,
-		},
-	}
-	AddMemPercentage(&m)
-	assert.Equal(t, m.ActualUsedPercent, 0.0)
+	m = sigar.Mem{Total: 0}
+	stats = GetMemoryEvent(&m)
+	assert.Equal(t, stats["actual_used_p"], 0.0)
 }

--- a/topbeat/tests/system/config/topbeat.yml.j2
+++ b/topbeat/tests/system/config/topbeat.yml.j2
@@ -14,10 +14,12 @@ topbeat:
 
   # Statistics to collect (all enabled by default)
   stats:
-    system: {{ "false" if system_stats == false else "true" }}
-    process: {{ "false" if process_stats == false else "true" }}
-    filesystem: {{ "false" if filesystem_stats == false else "true" }}
-    cpu_per_core: {{ "false" if cpu_per_core == false else "true" }}
+    system: {{ system_stats|default("true") }}
+    process: {{ process_stats|default("true") }}
+    filesystem: {{ filesystem_stats|default("true") }}
+    cpu_per_core: {{ cpu_per_core|default("false") }}
+    cpu_ticks: {{ cpu_ticks|default("false") }}
+    cpu_ticks_per_proc: {{ cpu_ticks_per_proc|default("false") }}
 
 ############################# Output ##########################################
 

--- a/topbeat/tests/system/test_cpu_per_core.py
+++ b/topbeat/tests/system/test_cpu_per_core.py
@@ -17,7 +17,39 @@ class Test(BaseTest):
             system_stats=True,
             process_stats=False,
             filesystem_stats=False,
-            cpu_per_core=True
+            cpu_per_core=True,
+        )
+        topbeat = self.start_beat()
+        self.wait_until(lambda: self.output_has(lines=1))
+        topbeat.check_kill_and_wait()
+
+        output = self.read_output()[0]
+
+        for key in [
+            "cpus.cpu0.user_p",
+            "cpus.cpu0.system_p",
+            "cpus.cpu0.nice_p",
+            "cpus.cpu0.idle_p",
+            "cpus.cpu0.iowait_p",
+            "cpus.cpu0.irq_p",
+            "cpus.cpu0.softirq_p",
+            "cpus.cpu0.steal_p",
+
+        ]:
+            assert type(output[key]) in [int, float]
+
+    @unittest.skipIf(sys.platform.startswith("win"), "CPU core stats require unix")
+    def test_cpu_per_core_with_more_details(self):
+        """
+        Checks that cpu usage per core statistics are exported
+        when the config option is enabled.
+        """
+        self.render_config_template(
+            system_stats=True,
+            process_stats=False,
+            filesystem_stats=False,
+            cpu_per_core=True,
+            cpu_ticks=True,
         )
         topbeat = self.start_beat()
         self.wait_until(lambda: self.output_has(lines=1))
@@ -31,11 +63,17 @@ class Test(BaseTest):
             "cpus.cpu0.user",
             "cpus.cpu0.system",
             "cpus.cpu0.nice",
+            "cpus.cpu0.nice_p",
             "cpus.cpu0.idle",
+            "cpus.cpu0.idle_p",
             "cpus.cpu0.iowait",
+            "cpus.cpu0.iowait_p",
             "cpus.cpu0.irq",
+            "cpus.cpu0.irq_p",
             "cpus.cpu0.softirq",
+            "cpus.cpu0.softirq_p",
             "cpus.cpu0.steal",
+            "cpus.cpu0.steal_p",
 
         ]:
             assert type(output[key]) in [int, float]

--- a/topbeat/tests/system/test_filtering.py
+++ b/topbeat/tests/system/test_filtering.py
@@ -29,10 +29,7 @@ class Test(BaseTest):
 
         for key in [
             "proc.cpu.start_time",
-            "proc.cpu.total",
             "proc.cpu.total_p",
-            "proc.cpu.user",
-            "proc.cpu.system",
             "proc.name",
             "proc.state",
             "proc.pid",
@@ -63,10 +60,7 @@ class Test(BaseTest):
 
         for key in [
             "proc.cpu.start_time",
-            "proc.cpu.total",
             "proc.cpu.total_p",
-            "proc.cpu.user",
-            "proc.cpu.system",
             "proc.mem.size",
             "proc.mem.rss",
             "proc.mem.rss_p"
@@ -104,10 +98,7 @@ class Test(BaseTest):
 
         for key in [
             "proc.cpu.start_time",
-            "proc.cpu.total",
             "proc.cpu.total_p",
-            "proc.cpu.user",
-            "proc.cpu.system",
             "proc.name",
             "proc.pid",
         ]:
@@ -145,10 +136,7 @@ class Test(BaseTest):
             "proc.mem.size",
             "proc.mem.rss",
             "proc.cpu.start_time",
-            "proc.cpu.total",
             "proc.cpu.total_p",
-            "proc.cpu.user",
-            "proc.cpu.system",
             "proc.name",
             "proc.pid",
             "proc.mem.rss_p"

--- a/topbeat/tests/system/test_procs.py
+++ b/topbeat/tests/system/test_procs.py
@@ -27,7 +27,6 @@ class Test(BaseTest):
 
         output = self.read_output()[0]
 
-        print output["proc.name"]
         assert re.match("(?i)topbeat.test(.exe)?", output["proc.name"])
         assert re.match("(?i).*topbeat.test(.exe)? -systemTest", output["proc.cmdline"])
         assert isinstance(output["proc.state"], basestring)
@@ -37,7 +36,6 @@ class Test(BaseTest):
         for key in [
             "proc.pid",
             "proc.ppid",
-            "proc.cpu.total_p",
             "proc.mem.size",
             "proc.mem.rss",
             "proc.mem.share",
@@ -48,7 +46,7 @@ class Test(BaseTest):
             "proc.cpu.total_p",
             "proc.mem.rss_p",
         ]:
-            assert type(output[key]) in [int, float]
+            assert type(output[key]) in float
 
     def test_cpu_ticks_per_proc_option(self):
         """

--- a/topbeat/tests/system/test_procs.py
+++ b/topbeat/tests/system/test_procs.py
@@ -40,13 +40,15 @@ class Test(BaseTest):
             "proc.mem.rss",
             "proc.mem.share",
         ]:
+            assert key in output
             assert type(output[key]) is int
 
         for key in [
             "proc.cpu.total_p",
             "proc.mem.rss_p",
         ]:
-            assert type(output[key]) in float
+            assert key in output
+            assert type(output[key]) in [float, int]
 
     def test_cpu_ticks_per_proc_option(self):
         """
@@ -64,7 +66,6 @@ class Test(BaseTest):
 
         output = self.read_output()[0]
 
-        print(output)
         for key in [
             "proc.pid",
             "proc.ppid",

--- a/topbeat/tests/system/test_procs.py
+++ b/topbeat/tests/system/test_procs.py
@@ -37,9 +37,7 @@ class Test(BaseTest):
         for key in [
             "proc.pid",
             "proc.ppid",
-            "proc.cpu.user",
-            "proc.cpu.system",
-            "proc.cpu.total",
+            "proc.cpu.total_p",
             "proc.mem.size",
             "proc.mem.rss",
             "proc.mem.share",
@@ -51,6 +49,37 @@ class Test(BaseTest):
             "proc.mem.rss_p",
         ]:
             assert type(output[key]) in [int, float]
+
+    def test_cpu_ticks_per_proc_option(self):
+        """
+        Checks the cpu_ticks_per_proc configuration option.
+        """
+        self.render_config_template(
+            system_stats=False,
+            process_stats=True,
+            filesystem_stats=False,
+            cpu_ticks_per_proc=True,
+        )
+        topbeat = self.start_beat()
+        self.wait_until(lambda: self.output_count(lambda x: x >= 1))
+        topbeat.check_kill_and_wait()
+
+        output = self.read_output()[0]
+
+        print(output)
+        for key in [
+            "proc.pid",
+            "proc.ppid",
+            "proc.cpu.total_p",
+            "proc.cpu.total",
+            "proc.cpu.user",
+            "proc.cpu.system",
+            "proc.cpu.start_time",
+            "proc.mem.size",
+            "proc.mem.rss",
+            "proc.mem.share",
+        ]:
+            assert key in output
 
     def check_username(self, observed, expected = None):
         if expected == None:

--- a/topbeat/tests/system/test_system.py
+++ b/topbeat/tests/system/test_system.py
@@ -17,7 +17,7 @@ class Test(BaseTest):
         self.render_config_template(
             system_stats=True,
             process_stats=False,
-            filesystem_stats=False
+            filesystem_stats=False,
         )
 
         topbeat = self.start_beat()
@@ -32,6 +32,81 @@ class Test(BaseTest):
         for key in [
             "cpu.user_p",
             "cpu.system_p",
+            "cpu.nice_p",
+            "cpu.idle_p",
+            "cpu.irq_p",
+            "cpu.softirq_p",
+            "cpu.steal_p",
+            "cpu.iowait_p",
+        ]:
+            assert key in output.keys()
+            assert type(output[key]) in [float, int]
+
+        for key in [
+            "mem.used_p",
+            "mem.actual_used_p",
+            "swap.used_p",
+        ]:
+            assert key in output.keys()
+            assert type(output[key]) in [float, int]
+
+        for key in [
+            "mem.total",
+            "mem.used",
+            "mem.free",
+            "mem.actual_used",
+            "mem.actual_free",
+            "swap.total",
+            "swap.used",
+            "swap.free",
+        ]:
+            assert key in output.keys()
+            assert type(output[key]) is int or type(output[key]) is long
+
+        print(output.keys())
+
+        for key in [
+            "cpu.user",
+            "cpu.nice",
+            "cpu.system",
+            "cpu.idle",
+            "cpu.iowait",
+            "cpu.irq",
+            "cpu.softirq",
+            "cpu.steal",
+        ]:
+            assert key not in output.keys()
+
+    def test_system_wide_with_cpu_ticks(self):
+        """
+        Checks that system wide stats are found in the output and
+        have the expected types.
+        """
+        self.render_config_template(
+            system_stats=True,
+            process_stats=False,
+            filesystem_stats=False,
+            cpu_ticks=True,
+        )
+
+        topbeat = self.start_beat()
+        self.wait_until(lambda: self.output_has(lines=1))
+        topbeat.check_kill_and_wait()
+        output = self.read_output()[0]
+
+        if os.name != "nt":
+            for key in ["load1", "load5", "load15"]:
+                assert type(output["load.{}".format(key)]) in [float, int]
+
+        for key in [
+            "cpu.user_p",
+            "cpu.system_p",
+            "cpu.nice_p",
+            "cpu.idle_p",
+            "cpu.iowait_p",
+            "cpu.softirq_p",
+            "cpu.irq_p",
+            "cpu.steal_p",
             "mem.used_p",
             "mem.actual_used_p",
             "swap.used_p",

--- a/topbeat/tests/system/test_system.py
+++ b/topbeat/tests/system/test_system.py
@@ -111,6 +111,7 @@ class Test(BaseTest):
             "mem.actual_used_p",
             "swap.used_p",
         ]:
+            assert key in output.keys()
             assert type(output[key]) in [float, int]
 
         for key in [
@@ -131,4 +132,5 @@ class Test(BaseTest):
             "swap.used",
             "swap.free",
         ]:
+            assert key in output.keys()
             assert type(output[key]) is int or type(output[key]) is long


### PR DESCRIPTION
WIP

With this PR, Topbeat exports CPU usage statistics in percentage instead of CPU ticks. The percentages are: 
- `cpu.iowait_p`, `cpu.idle_p`, `cpu.irq_p`, `cpu.nice_p`, `cpu.softirq_p`, `cpu.steal_p`, `cpu.system_p` and `cpu.user_p`.
- `proc.cpu.total_p`

If `cpu_per_core` is true, then Topbeat exports the CPU usage statistics in percentage for each core.

By default the CPU usage is exported only in percentage.

If the user is interested in exporting the CPU ticks (`cpu.iowait`, `cpu.idle`, `cpu.irq`, `cpu.nice`, `cpu.softirq`, `cpu.steal`), he/she needs to set the configuration option `cpu_ticks` to true.

If the user is interested in exporting the CPU ticks (`proc.cpu.user`, `proc.cpu.system`, `proc.cpu.total`), he/she needs to set the configuration option `cpu_ticks_per_proc` to true.

cc-ed: @tsg @simianhacker @ruflin @andrewkroh 