### PR TITLE
Add banner indicating that guide for creating new beat is out of date

### DIFF
--- a/libbeat/docs/index.asciidoc
+++ b/libbeat/docs/index.asciidoc
@@ -24,7 +24,11 @@ include::./visualizing-data.asciidoc[]
 
 include::./dashboards.asciidoc[]
 
+pass::[<?page_header <b>PLEASE NOTE:</b><br/>We are working on updating this section. Some content might be out of date. While you're waiting for updates, you might want to try out the Beat generator at https://github.com/elastic/beat-generator.?>]
+
 include::./newbeat.asciidoc[]
+
+pass::[<?page_header ?>]
 
 include::./newdashboards.asciidoc[]
 


### PR DESCRIPTION
This change adds a banner to the page to indicate that the content is out of date. I've also included the URL for the beat generator because I think it would be useful for developers. I hope it's OK to mention the Beat generator in the docs. Let me know if it's not.

The second pass block clears the header so that it doesn't appear on subsequent sections.

@monicasarbu Here's the change we talked about.