### PR TITLE
Import metricbeat modules

### DIFF
--- a/metricbeat/Makefile
+++ b/metricbeat/Makefile
@@ -48,3 +48,18 @@ before-build:
 # Runs all collection steps and updates afterwards
 .PHONY: collect
 collect: kibana fields docs configs update
+
+# Import a module from a metricbeat repository
+import:
+
+	mkdir -p build/modules/$(shell basename https://github.com/ruflin/countbeat)
+
+	# Clone remote repo
+	git clone https://github.com/ruflin/countbeat build/modules/$(shell basename https://github.com/ruflin/countbeat)
+
+	# Copy modules to metricbeat
+	cp -r build/modules/$(shell basename https://github.com/ruflin/countbeat)/module/* module/
+
+	# Collect new dependencies
+	make collect
+


### PR DESCRIPTION
This is only for discussion and not something that should be implemented in the short run. It is more about discussing the concept.

This allows someone with a fork of metricbeat, to import additional modules. It is important that these repositories are a pure module implementation and not a metricbeat fork, as otherwise modules would be overwritten. The command to import a module would look like:

```
make import-module https://github.com/ruflin/countbeat
```

This would add the count module.

@urso The same could be done for outputs. The advantage of the option below over the pure import is that it also adds templates, configs etc. Except for the config, this is not really needed for outputs. For the outputs it could be as following:

```
make add-output https://github.com/ruflin/mysqloutputbeat
```

This would add an import link to a file where the outputs are listed. Potentially it could also fetch the config and append it to the existing config. This would work better if configs would also be local to the outputs as we have it in metricbeat modules.

### Community Edition

In case there would be a community edit of metricbeat with unsupported modules, this community edition would have additional modules inside only and only link to metricbeat. So it would not be a fork but still could provide all the docs and configs for the modules. Not sure about the community edition, more showing the possibilities of this.