### PR TITLE
Add async logstash output mode supporting pipelining

### DIFF
--- a/filebeat/filebeat.full.yml
+++ b/filebeat/filebeat.full.yml
@@ -390,6 +390,10 @@ output.elasticsearch:
   # Optional load balance the events between the Logstash hosts
   #loadbalance: true
 
+  # Number of batches to be send asynchronously to logstash while processing
+  # new batches.
+  #pipelining: 0
+
   # Optional index name. The default index name is set to name of the beat
   # in all lowercase.
   #index: filebeat

--- a/libbeat/_beat/config.full.yml
+++ b/libbeat/_beat/config.full.yml
@@ -187,6 +187,10 @@ output.elasticsearch:
   # Optional load balance the events between the Logstash hosts
   #loadbalance: true
 
+  # Number of batches to be send asynchronously to logstash while processing
+  # new batches.
+  #pipelining: 0
+
   # Optional index name. The default index name is set to name of the beat
   # in all lowercase.
   #index: beatname

--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -394,6 +394,13 @@ output.logstash:
   index: {beatname_lc}
 ------------------------------------------------------------------------------
 
+===== pipelining
+
+Configures number of batches to be send asynchronously to logstash while waiting
+for ACK from logstash. Output only becomes blocking once number of `pipelining`
+batches have been written. Pipelining is disabled if a values of 0 is
+configured. The default value is 0.
+
 [[port]]
 ===== port
 

--- a/libbeat/outputs/logstash/async.go
+++ b/libbeat/outputs/logstash/async.go
@@ -1,0 +1,193 @@
+package logstash
+
+import (
+	"sync/atomic"
+	"time"
+
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/outputs/transport"
+	"github.com/urso/go-lumber/client/v2"
+)
+
+type asyncClient struct {
+	*transport.Client
+	client *v2.AsyncClient
+	win    window
+
+	connect func() error
+}
+
+type msgRef struct {
+	count     int32
+	batch     []common.MapStr
+	err       error
+	cb        func([]common.MapStr, error)
+	win       *window
+	batchSize int
+}
+
+func newAsyncLumberjackClient(
+	conn *transport.Client,
+	queueSize int,
+	compressLevel int,
+	maxWindowSize int,
+	timeout time.Duration,
+	beat string,
+) (*asyncClient, error) {
+	c := &asyncClient{}
+	c.Client = conn
+	c.win.init(defaultStartMaxWindowSize, maxWindowSize)
+
+	enc, err := makeLogstashEventEncoder(beat)
+	if err != nil {
+		return nil, err
+	}
+
+	c.connect = func() error {
+		err := c.Client.Connect()
+		if err == nil {
+			c.client, err = v2.NewAsyncClientWithConn(c.Client,
+				queueSize,
+				v2.JSONEncoder(enc),
+				v2.Timeout(timeout),
+				v2.CompressionLevel(compressLevel))
+		}
+		return err
+	}
+	return c, nil
+}
+
+func (c *asyncClient) Connect(timeout time.Duration) error {
+	logp.Debug("logstash", "connect")
+	return c.connect()
+}
+
+func (c *asyncClient) Close() error {
+	logp.Debug("logstash", "close connection")
+	if c.client != nil {
+		err := c.client.Close()
+		c.client = nil
+		return err
+	}
+	return c.Client.Close()
+}
+
+func (c *asyncClient) AsyncPublishEvent(
+	cb func(error),
+	event common.MapStr,
+) error {
+	data := []interface{}{event}
+	return c.client.Send(func(seq uint32, err error) { cb(err) }, data)
+}
+
+func (c *asyncClient) AsyncPublishEvents(
+	cb func([]common.MapStr, error),
+	events []common.MapStr,
+) error {
+	publishEventsCallCount.Add(1)
+
+	if len(events) == 0 {
+		debug("send nil")
+		cb(nil, nil)
+		return nil
+	}
+
+	ref := &msgRef{
+		count:     1,
+		batch:     events,
+		batchSize: len(events),
+		win:       &c.win,
+		cb:        cb,
+		err:       nil,
+	}
+
+	for len(events) > 0 {
+		n, err := c.publishWindowed(ref, events)
+
+		debug("%v events out of %v events sent to logstash. Continue sending",
+			n, len(events))
+
+		events = events[n:]
+		if err != nil {
+			c.win.shrinkWindow()
+			_ = c.Close()
+
+			logp.Err("Failed to publish events caused by: %v", err)
+			eventsNotAcked.Add(int64(len(events)))
+			return err
+		}
+	}
+	ref.dec()
+
+	return nil
+}
+
+func (c *asyncClient) publishWindowed(
+	ref *msgRef,
+	events []common.MapStr,
+) (int, error) {
+	batchSize := len(events)
+	windowSize := c.win.get()
+	debug("Try to publish %v events to logstash with window size %v",
+		batchSize, windowSize)
+
+	// prepare message payload
+	if batchSize > windowSize {
+		events = events[:windowSize]
+	}
+
+	err := c.sendEvents(ref, events)
+	if err != nil {
+		return 0, err
+	}
+
+	return len(events), nil
+}
+
+func (c *asyncClient) sendEvents(ref *msgRef, events []common.MapStr) error {
+	window := make([]interface{}, len(events))
+	for i, event := range events {
+		window[i] = event
+	}
+	atomic.AddInt32(&ref.count, 1)
+	return c.client.Send(ref.callback, window)
+}
+
+func (r *msgRef) callback(seq uint32, err error) {
+	if err != nil {
+		r.fail(seq, err)
+	} else {
+		r.done(seq)
+	}
+}
+
+func (r *msgRef) done(n uint32) {
+	ackedEvents.Add(int64(n))
+	r.batch = r.batch[n:]
+	r.dec()
+}
+
+func (r *msgRef) fail(n uint32, err error) {
+	ackedEvents.Add(int64(n))
+	r.err = err
+	r.batch = r.batch[n:]
+	r.dec()
+}
+
+func (r *msgRef) dec() {
+	i := atomic.AddInt32(&r.count, -1)
+	if i > 0 {
+		return
+	}
+
+	err := r.err
+	if err != nil {
+		eventsNotAcked.Add(int64(len(r.batch)))
+		r.win.shrinkWindow()
+		r.cb(r.batch, err)
+	} else {
+		r.win.tryGrowWindow(r.batchSize)
+		r.cb(nil, nil)
+	}
+}

--- a/libbeat/outputs/logstash/async_test.go
+++ b/libbeat/outputs/logstash/async_test.go
@@ -1,0 +1,123 @@
+// +build !integration
+
+package logstash
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/outputs/mode"
+	"github.com/elastic/beats/libbeat/outputs/transport"
+)
+
+type testAsyncDriver struct {
+	client  mode.AsyncProtocolClient
+	ch      chan testDriverCommand
+	returns []testClientReturn
+	wg      sync.WaitGroup
+}
+
+func TestAsyncSendZero(t *testing.T) {
+	testSendZero(t, makeAsyncTestClient)
+}
+
+func TestAsyncSimpleEvent(t *testing.T) {
+	testSimpleEvent(t, makeAsyncTestClient)
+}
+
+func TestAsyncStructuredEvent(t *testing.T) {
+	testStructuredEvent(t, makeAsyncTestClient)
+}
+
+func TestAsyncMultiFailMaxTimeouts(t *testing.T) {
+	testMultiFailMaxTimeouts(t, makeAsyncTestClient)
+}
+
+func makeAsyncTestClient(conn *transport.Client) testClientDriver {
+	return newAsyncTestDriver(newAsyncTestClient(conn))
+}
+
+func newAsyncTestClient(conn *transport.Client) *asyncClient {
+	c, err := newAsyncLumberjackClient(conn,
+		1, 3, testMaxWindowSize, 100*time.Millisecond, "testbeat")
+	if err != nil {
+		panic(err)
+	}
+	c.Connect(100 * time.Millisecond)
+	return c
+}
+
+func newAsyncTestDriver(client mode.AsyncProtocolClient) *testAsyncDriver {
+	driver := &testAsyncDriver{
+		client:  client,
+		ch:      make(chan testDriverCommand, 1),
+		returns: nil,
+	}
+
+	resp := make(chan testClientReturn, 1)
+
+	driver.wg.Add(1)
+	go func() {
+		defer driver.wg.Done()
+
+		for {
+			cmd, ok := <-driver.ch
+			if !ok {
+				return
+			}
+
+			switch cmd.code {
+			case driverCmdQuit:
+				return
+			case driverCmdConnect:
+				driver.client.Connect(1 * time.Second)
+			case driverCmdClose:
+				driver.client.Close()
+			case driverCmdPublish:
+				cb := func(events []common.MapStr, err error) {
+					n := len(cmd.events) - len(events)
+					ret := testClientReturn{n, err}
+					resp <- ret
+				}
+
+				err := driver.client.AsyncPublishEvents(cb, cmd.events)
+				if err != nil {
+					driver.returns = append(driver.returns, testClientReturn{0, err})
+				} else {
+					r := <-resp
+					driver.returns = append(driver.returns, r)
+				}
+			}
+		}
+	}()
+
+	return driver
+}
+
+func (t *testAsyncDriver) Close() {
+	t.ch <- testDriverCommand{code: driverCmdClose}
+}
+
+func (t *testAsyncDriver) Connect() {
+	t.ch <- testDriverCommand{code: driverCmdConnect}
+}
+
+func (t *testAsyncDriver) Stop() {
+	if t.ch != nil {
+		t.ch <- testDriverCommand{code: driverCmdQuit}
+		t.wg.Wait()
+		close(t.ch)
+		t.client.Close()
+		t.ch = nil
+	}
+}
+
+func (t *testAsyncDriver) Publish(events []common.MapStr) {
+	t.ch <- testDriverCommand{code: driverCmdPublish, events: events}
+}
+
+func (t *testAsyncDriver) Returns() []testClientReturn {
+	return t.returns
+}

--- a/libbeat/outputs/logstash/client_test.go
+++ b/libbeat/outputs/logstash/client_test.go
@@ -19,9 +19,13 @@ import (
 const (
 	driverCmdQuit = iota
 	driverCmdPublish
+	driverCmdConnect
+	driverCmdClose
 )
 
 type testClientDriver interface {
+	Connect()
+	Close()
 	Stop()
 	Publish(events []common.MapStr)
 	Returns() []testClientReturn
@@ -174,10 +178,7 @@ func testMultiFailMaxTimeouts(t *testing.T, factory clientFactory) {
 	event := common.MapStr{"type": "test", "name": "me", "line": 10}
 
 	for i := 0; i < N; i++ {
-		err = transp.Connect()
-		if err != nil {
-			t.Fatalf("Transport client Failed to connect: %v", err)
-		}
+		client.Connect()
 
 		// publish event. With client returning on timeout, we have to send
 		// messages again
@@ -186,7 +187,7 @@ func testMultiFailMaxTimeouts(t *testing.T, factory clientFactory) {
 		// read batch + never ACK in order to enforce timeout
 		server.Receive()
 
-		// wait for client being disconnected
+		// close client
 		for transp.IsConnected() {
 		}
 	}

--- a/libbeat/outputs/logstash/config.go
+++ b/libbeat/outputs/logstash/config.go
@@ -13,6 +13,7 @@ type logstashConfig struct {
 	LoadBalance      bool                  `config:"loadbalance"`
 	BulkMaxSize      int                   `config:"bulk_max_size"`
 	Timeout          time.Duration         `config:"timeout"`
+	Pipelining       int                   `config:"pipelining"        validate:"min=0"`
 	CompressionLevel int                   `config:"compression_level" validate:"min=0, max=9"`
 	MaxRetries       int                   `config:"max_retries"       validate:"min=-1"`
 	TLS              *outputs.TLSConfig    `config:"tls"`

--- a/libbeat/outputs/logstash/sync_test.go
+++ b/libbeat/outputs/logstash/sync_test.go
@@ -68,6 +68,10 @@ func newClientTestDriver(client mode.ProtocolClient) *testSyncDriver {
 			switch cmd.code {
 			case driverCmdQuit:
 				return
+			case driverCmdConnect:
+				driver.client.Connect(1 * time.Second)
+			case driverCmdClose:
+				driver.client.Close()
 			case driverCmdPublish:
 				events, err := driver.client.PublishEvents(cmd.events)
 				n := len(cmd.events) - len(events)
@@ -87,6 +91,14 @@ func (t *testSyncDriver) Stop() {
 		t.client.Close()
 		t.ch = nil
 	}
+}
+
+func (t *testSyncDriver) Connect() {
+	t.ch <- testDriverCommand{code: driverCmdConnect}
+}
+
+func (t *testSyncDriver) Close() {
+	t.ch <- testDriverCommand{code: driverCmdClose}
 }
 
 func (t *testSyncDriver) Publish(events []common.MapStr) {

--- a/libbeat/outputs/logstash/window.go
+++ b/libbeat/outputs/logstash/window.go
@@ -26,7 +26,7 @@ func (w *window) get() int {
 // (window size grows exponentially)
 // TODO: use duration until ACK to estimate an ok max window size value
 func (w *window) tryGrowWindow(batchSize int) {
-	windowSize := int(w.windowSize)
+	windowSize := w.get()
 
 	if windowSize <= batchSize {
 		if w.maxOkWindowSize < windowSize {
@@ -62,7 +62,7 @@ func (w *window) tryGrowWindow(batchSize int) {
 }
 
 func (w *window) shrinkWindow() {
-	windowSize := int(w.windowSize)
+	windowSize := w.get()
 	orig := windowSize
 
 	windowSize = windowSize / 2

--- a/metricbeat/metricbeat.full.yml
+++ b/metricbeat/metricbeat.full.yml
@@ -298,6 +298,10 @@ output.elasticsearch:
   # Optional load balance the events between the Logstash hosts
   #loadbalance: true
 
+  # Number of batches to be send asynchronously to logstash while processing
+  # new batches.
+  #pipelining: 0
+
   # Optional index name. The default index name is set to name of the beat
   # in all lowercase.
   #index: metricbeat

--- a/packetbeat/packetbeat.full.yml
+++ b/packetbeat/packetbeat.full.yml
@@ -571,6 +571,10 @@ output.elasticsearch:
   # Optional load balance the events between the Logstash hosts
   #loadbalance: true
 
+  # Number of batches to be send asynchronously to logstash while processing
+  # new batches.
+  #pipelining: 0
+
   # Optional index name. The default index name is set to name of the beat
   # in all lowercase.
   #index: packetbeat

--- a/topbeat/topbeat.full.yml
+++ b/topbeat/topbeat.full.yml
@@ -218,6 +218,10 @@ output.elasticsearch:
   # Optional load balance the events between the Logstash hosts
   #loadbalance: true
 
+  # Number of batches to be send asynchronously to logstash while processing
+  # new batches.
+  #pipelining: 0
+
   # Optional index name. The default index name is set to name of the beat
   # in all lowercase.
   #index: topbeat

--- a/winlogbeat/winlogbeat.full.yml
+++ b/winlogbeat/winlogbeat.full.yml
@@ -222,6 +222,10 @@ output.elasticsearch:
   # Optional load balance the events between the Logstash hosts
   #loadbalance: true
 
+  # Number of batches to be send asynchronously to logstash while processing
+  # new batches.
+  #pipelining: 0
+
   # Optional index name. The default index name is set to name of the beat
   # in all lowercase.
   #index: winlogbeat


### PR DESCRIPTION
Requires async client support from go-lumber introduced in #1678 