### PR TITLE
Fix mismatch between lists of supported protocols

### DIFF
--- a/packetbeat/docs/overview.asciidoc
+++ b/packetbeat/docs/overview.asciidoc
@@ -19,14 +19,7 @@ Packetbeat sniffs the traffic between your servers, parses the
 application-level protocols on the fly, and correlates the messages into transactions.
 Currently, Packetbeat supports the following protocols:
 
- * HTTP
- * MySQL
- * PostgreSQL
- * Redis
- * Thrift-RPC
- * MongoDB
- * DNS
- * Memcache
+include::shared-protocol-list.asciidoc[]
 
 Packetbeat can insert the correlated transactions directly into Elasticsearch
 or into a central queue created with Redis and Logstash. 

--- a/packetbeat/docs/reference/configuration/packetbeat-options.asciidoc
+++ b/packetbeat/docs/reference/configuration/packetbeat-options.asciidoc
@@ -218,16 +218,7 @@ common options like `ports`, `send_request`, `send_response`, and options that a
 
 Currently, Packetbeat supports the following protocols:
 
- - ICMP (v4 and v6)
- - DNS
- - HTTP
- - AMQP 0.9.1
- - Mysql
- - PostgreSQL
- - Redis
- - Thrift-RPC
- - MongoDB
- - Memcache
+include::../../shared-protocol-list.asciidoc[]
 
 Example configuration:
 

--- a/packetbeat/docs/shared-protocol-list.asciidoc
+++ b/packetbeat/docs/shared-protocol-list.asciidoc
@@ -1,0 +1,17 @@
+//////////////////////////////////////////////////////////////////////////
+//// This content is shared by multiple files.
+//// Use the following include to pull this content into a doc file:
+//// include::shared-protocol-list.asciidoc[]
+//////////////////////////////////////////////////////////////////////////
+
+ - ICMP (v4 and v6)
+ - DNS
+ - HTTP
+ - AMQP 0.9.1
+ - Mysql
+ - PostgreSQL
+ - Redis
+ - Thrift-RPC
+ - MongoDB
+ - Memcache
+ 


### PR DESCRIPTION
Using asciidoc include because it's too easy for these lists to get out of sync. 

This closes issue #979 