### PR TITLE
Add info about testing the config file

### DIFF
--- a/filebeat/docs/getting-started.asciidoc
+++ b/filebeat/docs/getting-started.asciidoc
@@ -152,6 +152,9 @@ output:
 +
 If you are sending output to Logstash, see <<config-filebeat-logstash>> instead.
 
+TIP: To test your configuration file, run Filebeat in the foreground with the following options specified:
++./filebeat -configtest -e+.
+
 See <<filebeat-configuration-details>> for more details about each configuration option.
 
 [[config-filebeat-logstash]]

--- a/libbeat/docs/shared-logstash-config.asciidoc
+++ b/libbeat/docs/shared-logstash-config.asciidoc
@@ -29,6 +29,10 @@ output:
 In this configuration, `hosts` specifies the Logstash server and the port (`5044`)
 where Logstash is configured to listen for incoming Beats connections.
 
+TIP: To test your configuration file, run {beatname_uc} in the foreground with the following options specified:
++./{beatname_lc} -configtest -e+.
+
 To use this configuration, you must also
 {libbeat}/logstash-installation.html#logstash-setup[set up Logstash] to receive events
 from Beats.
+

--- a/packetbeat/docs/gettingstarted.asciidoc
+++ b/packetbeat/docs/gettingstarted.asciidoc
@@ -186,6 +186,9 @@ output:
 +
 If you are sending output to Logstash, see <<config-packetbeat-logstash>> instead.
 
+TIP: To test your configuration file, run Packetbeat in the foreground with the following options specified:
++sudo ./packetbeat -configtest -e+.
+
 [[packetbeat-template]]
 === Step 3: Loading the Index Template in Elasticsearch
 

--- a/topbeat/docs/gettingstarted.asciidoc
+++ b/topbeat/docs/gettingstarted.asciidoc
@@ -131,6 +131,9 @@ output:
 +
 If you are sending output to Logstash, see <<config-topbeat-logstash>> instead.
 
+TIP: To test your configuration file, run Topbeat in the foreground with the following options specified:
++./topbeat -configtest -e+.
+
 [[topbeat-template]]
 === Step 3: Loading the Index Template in Elasticsearch
 


### PR DESCRIPTION
Winlogbeat is not included here because the docs already have this info.

This closes issue #982 