### PR TITLE
Fix debug statement in elasticsearch/output.go

### DIFF
--- a/libbeat/outputs/elasticsearch/output.go
+++ b/libbeat/outputs/elasticsearch/output.go
@@ -156,7 +156,7 @@ func (out *elasticsearchOutput) loadTemplate(config Template, client *Client) er
 	out.templateMutex.Lock()
 	defer out.templateMutex.Unlock()
 
-	logp.Info("Trying to load template for client: %s", client)
+	logp.Info("Trying to load template for client: %s", client.Connection.URL)
 
 	// Check if template already exist or should be overwritten
 	exists := client.CheckTemplate(config.Name)


### PR DESCRIPTION
BEFORE:
2016/05/23 07:44:22.310808 output.go:159: INFO Trying to load template for client: &{{http://elasticsearch:9200   %!s(*http.Client=&{0xc8200ca300 <nil> <nil> 90000000000}) %!s(bool=true) %!s(func() error=0x624c90)} infinibandbeat map[] {{ <nil> %!s(bool=false) %!s(int=0) %!s(int=0) %!s(int=0)}  %!s(elasticsearch.state=0) }}

AFTER:
2016/05/23 07:44:22.310808 output.go:159: INFO Trying to load template for client: http://elasticsearch:9200