### PR TITLE
libbeat/scripts/Makefile: fix install-home rule

### DIFF
--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -281,8 +281,8 @@ install-home:
 	mkdir -p ${HOME_PREFIX}/kibana
 	if [ -d "etc/kibana" ]; then \
 		cp -a etc/kibana/. ${HOME_PREFIX}/kibana/; \
-		install -m 755  ../dev-tools/import_dashboards.sh ${HOME_PREFIX}/kibana/; \
-		install -m 755 ../dev-tools/import_dashboards.ps1 ${HOME_PREFIX}/kibana/; \
+		install -m 755 ${ES_BEATS}/dev-tools/import_dashboards.sh ${HOME_PREFIX}/kibana/; \
+		install -m 755 ${ES_BEATS}/dev-tools/import_dashboards.ps1 ${HOME_PREFIX}/kibana/; \
 	fi
 	install -d -m 755 ${HOME_PREFIX}/scripts/
-	install -m 755 ../libbeat/scripts/migrate_beat_config_1_x_to_5_0.py ${HOME_PREFIX}/scripts/
+	install -m 755 ${ES_BEATS}/libbeat/scripts/migrate_beat_config_1_x_to_5_0.py ${HOME_PREFIX}/scripts/


### PR DESCRIPTION
some libbeat paths were hard-coded with relative paths.
It was not possible to use this Makefile rule in a community beat.