### PR TITLE
Migration to new state structure

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -55,6 +55,7 @@ https://github.com/elastic/beats/compare/v5.0.0-alpha2...master[Check the HEAD d
 *Topbeat*
 
 *Filebeat*
+- The registry format was changed to an array instead of dict. The migration to the new format will happen automatically at the first startup. {pull}1703[1703]
 
 *Winlogbeat*
 

--- a/filebeat/beater/filebeat.go
+++ b/filebeat/beater/filebeat.go
@@ -71,7 +71,11 @@ func (fb *Filebeat) Run(b *beat.Beat) error {
 	}
 
 	// Load the previous log file locations now, for use in prospector
-	fb.registrar.LoadState()
+	err = fb.registrar.LoadState()
+	if err != nil {
+		logp.Err("Error loading state: %v", err)
+		return err
+	}
 
 	// Init and Start spooler: Harvesters dump events into the spooler.
 	fb.spooler = NewSpooler(fb.FbConfig.Filebeat, fb.publisherChan)

--- a/filebeat/crawler/crawler.go
+++ b/filebeat/crawler/crawler.go
@@ -36,10 +36,13 @@ func (c *Crawler) Start(prospectorConfigs []*common.Config, eventChan chan *inpu
 
 	logp.Info("Loading Prospectors: %v", len(prospectorConfigs))
 
+	// Get existing states
+	states := *c.Registrar.state
+
 	// Prospect the globs/paths given on the command line and launch harvesters
 	for _, prospectorConfig := range prospectorConfigs {
 
-		prospector, err := NewProspector(prospectorConfig, c.Registrar, eventChan)
+		prospector, err := NewProspector(prospectorConfig, states, eventChan)
 		if err != nil {
 			return fmt.Errorf("Error in initing prospector: %s", err)
 		}
@@ -60,10 +63,9 @@ func (c *Crawler) Start(prospectorConfigs []*common.Config, eventChan chan *inpu
 			logp.Debug("crawler", "Starting prospector %v", id)
 			prospector.Run()
 		}(i, p)
-
 	}
 
-	logp.Info("All prospectors are initialised and running with %d states to persist", len(c.Registrar.getState()))
+	logp.Info("All prospectors are initialised and running with %d states to persist", c.Registrar.state.Count())
 
 	return nil
 }

--- a/filebeat/crawler/prospector.go
+++ b/filebeat/crawler/prospector.go
@@ -33,7 +33,7 @@ func NewProspector(cfg *common.Config, states input.States, spoolerChan chan *in
 		spoolerChan:   spoolerChan,
 		harvesterChan: make(chan *input.FileEvent),
 		done:          make(chan struct{}),
-		states:        &states,
+		states:        states.Copy(),
 		wg:            sync.WaitGroup{},
 	}
 

--- a/filebeat/crawler/prospector_test.go
+++ b/filebeat/crawler/prospector_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestProspectorDefaultConfigs(t *testing.T) {
 
-	prospector, err := NewProspector(common.NewConfig(), nil, nil)
+	prospector, err := NewProspector(common.NewConfig(), *input.NewStates(), nil)
 	assert.NoError(t, err)
 
 	// Default values expected

--- a/filebeat/input/state.go
+++ b/filebeat/input/state.go
@@ -125,3 +125,10 @@ func (s *States) SetStates(states []FileState) {
 	defer s.mutex.Unlock()
 	s.states = states
 }
+
+// Copy create a new copy of the states object
+func (s *States) Copy() *States {
+	states := NewStates()
+	states.states = s.GetStates()
+	return states
+}

--- a/filebeat/input/state.go
+++ b/filebeat/input/state.go
@@ -15,6 +15,7 @@ type FileState struct {
 	Finished    bool        `json:"-"` // harvester state
 	Fileinfo    os.FileInfo `json:"-"` // the file info
 	FileStateOS FileStateOS
+	LastSeen    time.Time `json:"last_seen"`
 }
 
 // NewFileState creates a new file state
@@ -24,6 +25,7 @@ func NewFileState(fileInfo os.FileInfo, path string) FileState {
 		Source:      path,
 		Finished:    false,
 		FileStateOS: GetOSFileState(fileInfo),
+		LastSeen:    time.Now(),
 	}
 }
 
@@ -45,6 +47,7 @@ func (s *States) Update(newState FileState) {
 	defer s.mutex.Unlock()
 
 	index, oldState := s.findPrevious(newState)
+	newState.LastSeen = time.Now()
 
 	if index >= 0 {
 		s.states[index] = newState
@@ -84,10 +87,9 @@ func (s *States) Cleanup(older time.Duration) {
 	defer s.mutex.Unlock()
 
 	for i, state := range s.states {
-		// File is older then ignore_older -> remove state
-		modTime := state.Fileinfo.ModTime()
 
-		if time.Since(modTime) > older {
+		// File wasn't seen for longer then older -> remove state
+		if time.Since(state.LastSeen) > older {
 			logp.Debug("prospector", "State removed for %s because of older: %s", state.Source)
 			s.states = append(s.states[:i], s.states[i+1:]...)
 		}
@@ -100,4 +102,26 @@ func (s *States) Count() int {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 	return len(s.states)
+}
+
+// Returns a copy of the file states
+func (s *States) GetStates() []FileState {
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	copy := make([]FileState, len(s.states))
+
+	for i := range s.states {
+		copy[i] = s.states[i]
+	}
+
+	return copy
+}
+
+// SetStates overwrites all internal states with the given states array
+func (s *States) SetStates(states []FileState) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	s.states = states
 }

--- a/filebeat/input/state.go
+++ b/filebeat/input/state.go
@@ -106,17 +106,13 @@ func (s *States) Count() int {
 
 // Returns a copy of the file states
 func (s *States) GetStates() []FileState {
-
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
-	copy := make([]FileState, len(s.states))
+	newStates := make([]FileState, len(s.states))
+	copy(newStates, s.states)
 
-	for i := range s.states {
-		copy[i] = s.states[i]
-	}
-
-	return copy
+	return newStates
 }
 
 // SetStates overwrites all internal states with the given states array

--- a/filebeat/tests/system/filebeat.py
+++ b/filebeat/tests/system/filebeat.py
@@ -21,3 +21,26 @@ class BaseTest(TestCase):
 
         with open(dotFilebeat) as file:
             return json.load(file)
+
+    def get_registry_entry_by_path(self, path):
+        """
+        Fetches the registry file and checks if an entry for the given path exists
+        If the path exists, the state for the given path is returned
+        If a path exists multiple times (which is possible because of file rotation)
+        the most recent version is returned
+        """
+        registry = self.get_registry()
+
+        tmp_entry = None
+
+        # Checks all entries and returns the most recent one
+        for entry in registry:
+            if entry["source"] == path:
+                if tmp_entry == None:
+                    tmp_entry = entry
+                else:
+                    if tmp_entry["last_seen"] < entry["last_seen"]:
+                        tmp_entry = entry
+
+        return tmp_entry
+

--- a/filebeat/tests/system/test_crawler.py
+++ b/filebeat/tests/system/test_crawler.py
@@ -318,8 +318,8 @@ class Test(BaseTest):
         data = self.get_registry()
 
         # Make sure new file was picked up. As it has the same file name,
-        # only one entry exists
-        assert len(data) == 1
+        # one entry for the new file and one for the old should exist
+        assert len(data) == 2
 
         # Make sure output has 11 entries, the new file was started
         # from scratch
@@ -376,8 +376,8 @@ class Test(BaseTest):
         data = self.get_registry()
 
         # Make sure new file was picked up. As it has the same file name,
-        # only one entry exists
-        assert len(data) == 1
+        # one entry for the new and one for the old should exist
+        assert len(data) == 2
 
         # Make sure output has 11 entries, the new file was started
         # from scratch


### PR DESCRIPTION
The previous state list was dependent on a file path. This had the potential to lead to overwrite and conflicts on file rotation. As the file path is also stored inside the state object this information was duplicated. Now a pure array is stored in the registry which makes the format more flexibel and brings it close to the format used by Logstash.

Changes:
* Not storing an index with paths as this leaded to duplicates
* Introduction of last_seen to differentiate between entries with same bath which show up multiple times. This introduces also the base to clean up the registry file. Currently it is only used in the prospector, no registry yet.
* Registry can now contain multiple entries for a path
* Refactor registrar to use the same state array as prospector does
* Introduce migration check to migrate from old to new state. Make it backward compatible by checking for old structure on startup
* Decouple registrar from prospector
* Update tests to follow new model