### PR TITLE
Fixed Kafka host description

### DIFF
--- a/filebeat/filebeat.full.yml
+++ b/filebeat/filebeat.full.yml
@@ -324,7 +324,7 @@ output.elasticsearch:
   # The number of seconds to wait for new events between two bulk API index requests.
   # If `bulk_max_size` is reached before this interval expires, addition bulk index
   # requests are made.
-  #flush_interval: 1
+  #flush_interval: 1s
 
   # Boolean that sets if the topology is kept in Elasticsearch. The default is
   # false. This option makes sense only for Packetbeat.
@@ -400,7 +400,7 @@ output.elasticsearch:
   # Resolve names locally when using a proxy server. Defaults to false.
   #proxy_use_local_resolver: false
 
-  # Optional TLS. By default is off.
+  # Optional TLS configuration options. TLS is off by default.
   # List of root certificates for HTTPS server verifications
   #tls.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
@@ -424,7 +424,9 @@ output.elasticsearch:
 
 #------------------------------- Kafka output ---------------------------------
 #output.kafka:
-  # The list of Kafka broker addresses to connect to.
+  # The list of Kafka broker addresses from where to fetch the cluster metadata.
+  # The cluster metadata contain the actual Kafka brokers events are published
+  # to.
   #hosts: ["localhost:9092"]
 
   # The Kafka topic used for produced events. If use_type is set to true, the
@@ -457,8 +459,7 @@ output.elasticsearch:
   # default is 10s.
   #broker_timeout: 10s
 
-  # Per Kafka broker number of messages buffered in output pipeline. The default
-  # is 256.
+  # The number of messages buffered for each Kafka broker. The default is 256.
   #channel_buffer_size: 256
 
   # The keep-alive period for an active network connection. If 0s, keep-alives
@@ -466,8 +467,8 @@ output.elasticsearch:
   #keep_alive: 0
 
   # Sets the output compression codec. Must be one of none, snappy and gzip. The
-  # default is snappy.
-  #compression: snappy
+  # default is gzip.
+  #compression: gzip
 
   # The maximum permitted size of JSON-encoded messages. Bigger messages will be
   # dropped. The default value is 1000000 (bytes). This value should be equal to
@@ -478,16 +479,16 @@ output.elasticsearch:
   # local commit, -1=wait for all replicas to commit. The default is 1.  Note:
   # If set to 0, no ACKs are returned by Kafka. Messages might be lost silently
   # on error.
-  #required_acks: 0
+  #required_acks: 1
 
   # The number of seconds to wait for new events between two producer API calls.
-  #flush_interval: 1
+  #flush_interval: 1s
 
   # The configurable ClientID used for logging, debugging, and auditing
   # purposes.  The default is "beats".
   #client_id: beats
 
-  # Optional TLS. By default is off.
+  # Optional TLS configuration options. TLS is off by default.
   # List of root certificates for HTTPS server verifications
   #tls.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
@@ -583,7 +584,7 @@ output.elasticsearch:
   # occurs on the proxy server.
   #proxy_use_local_resolver: false
 
-  # Optional TLS. By default is off.
+  # Optional TLS configuration options. TLS is off by default.
   # List of root certificates for HTTPS server verifications
   #tls.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
@@ -615,8 +616,9 @@ output.elasticsearch:
   # files: `filebeat`, `filebeat.1`, `filebeat.2`, etc.
   #filename: filebeat
 
-  # Maximum size in kilobytes of each file. When this size is reached, the files
-  # are rotated. The default value is 10240 kB.
+  # Maximum size in kilobytes of each file. When this size is reached, and on
+  # every filebeat restart, the files are rotated. The default value is 10240
+  # kB.
   #rotate_every_kb: 10000
 
   # Maximum number of files under path. When this number of files is reached,

--- a/libbeat/_beat/config.full.yml
+++ b/libbeat/_beat/config.full.yml
@@ -221,8 +221,9 @@ output.elasticsearch:
 
 #------------------------------- Kafka output ---------------------------------
 #output.kafka:
-  # The list of Kafka broker addresses from where to fetch the cluster
-  # metadata.
+  # The list of Kafka broker addresses from where to fetch the cluster metadata.
+  # The cluster metadata contain the actual Kafka brokers events are published
+  # to.
   #hosts: ["localhost:9092"]
 
   # The Kafka topic used for produced events. If use_type is set to true, the

--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -633,6 +633,7 @@ You can specify the following options in the `kafka` section:
 ===== hosts
 
 The list of Kafka broker addresses from where to fetch the cluster metadata.
+The cluster metadata contain the actual Kafka brokers events are published to.
 
 ===== topic
 

--- a/metricbeat/metricbeat.full.yml
+++ b/metricbeat/metricbeat.full.yml
@@ -229,7 +229,7 @@ output.elasticsearch:
   # The number of seconds to wait for new events between two bulk API index requests.
   # If `bulk_max_size` is reached before this interval expires, addition bulk index
   # requests are made.
-  #flush_interval: 1
+  #flush_interval: 1s
 
   # Boolean that sets if the topology is kept in Elasticsearch. The default is
   # false. This option makes sense only for Packetbeat.
@@ -305,7 +305,7 @@ output.elasticsearch:
   # Resolve names locally when using a proxy server. Defaults to false.
   #proxy_use_local_resolver: false
 
-  # Optional TLS. By default is off.
+  # Optional TLS configuration options. TLS is off by default.
   # List of root certificates for HTTPS server verifications
   #tls.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
@@ -329,7 +329,9 @@ output.elasticsearch:
 
 #------------------------------- Kafka output ---------------------------------
 #output.kafka:
-  # The list of Kafka broker addresses to connect to.
+  # The list of Kafka broker addresses from where to fetch the cluster metadata.
+  # The cluster metadata contain the actual Kafka brokers events are published
+  # to.
   #hosts: ["localhost:9092"]
 
   # The Kafka topic used for produced events. If use_type is set to true, the
@@ -362,8 +364,7 @@ output.elasticsearch:
   # default is 10s.
   #broker_timeout: 10s
 
-  # Per Kafka broker number of messages buffered in output pipeline. The default
-  # is 256.
+  # The number of messages buffered for each Kafka broker. The default is 256.
   #channel_buffer_size: 256
 
   # The keep-alive period for an active network connection. If 0s, keep-alives
@@ -371,8 +372,8 @@ output.elasticsearch:
   #keep_alive: 0
 
   # Sets the output compression codec. Must be one of none, snappy and gzip. The
-  # default is snappy.
-  #compression: snappy
+  # default is gzip.
+  #compression: gzip
 
   # The maximum permitted size of JSON-encoded messages. Bigger messages will be
   # dropped. The default value is 1000000 (bytes). This value should be equal to
@@ -383,16 +384,16 @@ output.elasticsearch:
   # local commit, -1=wait for all replicas to commit. The default is 1.  Note:
   # If set to 0, no ACKs are returned by Kafka. Messages might be lost silently
   # on error.
-  #required_acks: 0
+  #required_acks: 1
 
   # The number of seconds to wait for new events between two producer API calls.
-  #flush_interval: 1
+  #flush_interval: 1s
 
   # The configurable ClientID used for logging, debugging, and auditing
   # purposes.  The default is "beats".
   #client_id: beats
 
-  # Optional TLS. By default is off.
+  # Optional TLS configuration options. TLS is off by default.
   # List of root certificates for HTTPS server verifications
   #tls.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
@@ -488,7 +489,7 @@ output.elasticsearch:
   # occurs on the proxy server.
   #proxy_use_local_resolver: false
 
-  # Optional TLS. By default is off.
+  # Optional TLS configuration options. TLS is off by default.
   # List of root certificates for HTTPS server verifications
   #tls.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
@@ -520,8 +521,9 @@ output.elasticsearch:
   # files: `metricbeat`, `metricbeat.1`, `metricbeat.2`, etc.
   #filename: metricbeat
 
-  # Maximum size in kilobytes of each file. When this size is reached, the files
-  # are rotated. The default value is 10240 kB.
+  # Maximum size in kilobytes of each file. When this size is reached, and on
+  # every metricbeat restart, the files are rotated. The default value is 10240
+  # kB.
   #rotate_every_kb: 10000
 
   # Maximum number of files under path. When this number of files is reached,

--- a/packetbeat/packetbeat.full.yml
+++ b/packetbeat/packetbeat.full.yml
@@ -505,7 +505,7 @@ output.elasticsearch:
   # The number of seconds to wait for new events between two bulk API index requests.
   # If `bulk_max_size` is reached before this interval expires, addition bulk index
   # requests are made.
-  #flush_interval: 1
+  #flush_interval: 1s
 
   # Boolean that sets if the topology is kept in Elasticsearch. The default is
   # false. This option makes sense only for Packetbeat.
@@ -581,7 +581,7 @@ output.elasticsearch:
   # Resolve names locally when using a proxy server. Defaults to false.
   #proxy_use_local_resolver: false
 
-  # Optional TLS. By default is off.
+  # Optional TLS configuration options. TLS is off by default.
   # List of root certificates for HTTPS server verifications
   #tls.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
@@ -605,7 +605,9 @@ output.elasticsearch:
 
 #------------------------------- Kafka output ---------------------------------
 #output.kafka:
-  # The list of Kafka broker addresses to connect to.
+  # The list of Kafka broker addresses from where to fetch the cluster metadata.
+  # The cluster metadata contain the actual Kafka brokers events are published
+  # to.
   #hosts: ["localhost:9092"]
 
   # The Kafka topic used for produced events. If use_type is set to true, the
@@ -638,8 +640,7 @@ output.elasticsearch:
   # default is 10s.
   #broker_timeout: 10s
 
-  # Per Kafka broker number of messages buffered in output pipeline. The default
-  # is 256.
+  # The number of messages buffered for each Kafka broker. The default is 256.
   #channel_buffer_size: 256
 
   # The keep-alive period for an active network connection. If 0s, keep-alives
@@ -647,8 +648,8 @@ output.elasticsearch:
   #keep_alive: 0
 
   # Sets the output compression codec. Must be one of none, snappy and gzip. The
-  # default is snappy.
-  #compression: snappy
+  # default is gzip.
+  #compression: gzip
 
   # The maximum permitted size of JSON-encoded messages. Bigger messages will be
   # dropped. The default value is 1000000 (bytes). This value should be equal to
@@ -659,16 +660,16 @@ output.elasticsearch:
   # local commit, -1=wait for all replicas to commit. The default is 1.  Note:
   # If set to 0, no ACKs are returned by Kafka. Messages might be lost silently
   # on error.
-  #required_acks: 0
+  #required_acks: 1
 
   # The number of seconds to wait for new events between two producer API calls.
-  #flush_interval: 1
+  #flush_interval: 1s
 
   # The configurable ClientID used for logging, debugging, and auditing
   # purposes.  The default is "beats".
   #client_id: beats
 
-  # Optional TLS. By default is off.
+  # Optional TLS configuration options. TLS is off by default.
   # List of root certificates for HTTPS server verifications
   #tls.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
@@ -764,7 +765,7 @@ output.elasticsearch:
   # occurs on the proxy server.
   #proxy_use_local_resolver: false
 
-  # Optional TLS. By default is off.
+  # Optional TLS configuration options. TLS is off by default.
   # List of root certificates for HTTPS server verifications
   #tls.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
@@ -796,8 +797,9 @@ output.elasticsearch:
   # files: `packetbeat`, `packetbeat.1`, `packetbeat.2`, etc.
   #filename: packetbeat
 
-  # Maximum size in kilobytes of each file. When this size is reached, the files
-  # are rotated. The default value is 10240 kB.
+  # Maximum size in kilobytes of each file. When this size is reached, and on
+  # every packetbeat restart, the files are rotated. The default value is 10240
+  # kB.
   #rotate_every_kb: 10000
 
   # Maximum number of files under path. When this number of files is reached,

--- a/topbeat/topbeat.full.yml
+++ b/topbeat/topbeat.full.yml
@@ -152,7 +152,7 @@ output.elasticsearch:
   # The number of seconds to wait for new events between two bulk API index requests.
   # If `bulk_max_size` is reached before this interval expires, addition bulk index
   # requests are made.
-  #flush_interval: 1
+  #flush_interval: 1s
 
   # Boolean that sets if the topology is kept in Elasticsearch. The default is
   # false. This option makes sense only for Packetbeat.
@@ -228,7 +228,7 @@ output.elasticsearch:
   # Resolve names locally when using a proxy server. Defaults to false.
   #proxy_use_local_resolver: false
 
-  # Optional TLS. By default is off.
+  # Optional TLS configuration options. TLS is off by default.
   # List of root certificates for HTTPS server verifications
   #tls.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
@@ -252,7 +252,9 @@ output.elasticsearch:
 
 #------------------------------- Kafka output ---------------------------------
 #output.kafka:
-  # The list of Kafka broker addresses to connect to.
+  # The list of Kafka broker addresses from where to fetch the cluster metadata.
+  # The cluster metadata contain the actual Kafka brokers events are published
+  # to.
   #hosts: ["localhost:9092"]
 
   # The Kafka topic used for produced events. If use_type is set to true, the
@@ -285,8 +287,7 @@ output.elasticsearch:
   # default is 10s.
   #broker_timeout: 10s
 
-  # Per Kafka broker number of messages buffered in output pipeline. The default
-  # is 256.
+  # The number of messages buffered for each Kafka broker. The default is 256.
   #channel_buffer_size: 256
 
   # The keep-alive period for an active network connection. If 0s, keep-alives
@@ -294,8 +295,8 @@ output.elasticsearch:
   #keep_alive: 0
 
   # Sets the output compression codec. Must be one of none, snappy and gzip. The
-  # default is snappy.
-  #compression: snappy
+  # default is gzip.
+  #compression: gzip
 
   # The maximum permitted size of JSON-encoded messages. Bigger messages will be
   # dropped. The default value is 1000000 (bytes). This value should be equal to
@@ -306,16 +307,16 @@ output.elasticsearch:
   # local commit, -1=wait for all replicas to commit. The default is 1.  Note:
   # If set to 0, no ACKs are returned by Kafka. Messages might be lost silently
   # on error.
-  #required_acks: 0
+  #required_acks: 1
 
   # The number of seconds to wait for new events between two producer API calls.
-  #flush_interval: 1
+  #flush_interval: 1s
 
   # The configurable ClientID used for logging, debugging, and auditing
   # purposes.  The default is "beats".
   #client_id: beats
 
-  # Optional TLS. By default is off.
+  # Optional TLS configuration options. TLS is off by default.
   # List of root certificates for HTTPS server verifications
   #tls.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
@@ -411,7 +412,7 @@ output.elasticsearch:
   # occurs on the proxy server.
   #proxy_use_local_resolver: false
 
-  # Optional TLS. By default is off.
+  # Optional TLS configuration options. TLS is off by default.
   # List of root certificates for HTTPS server verifications
   #tls.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
@@ -443,8 +444,9 @@ output.elasticsearch:
   # files: `topbeat`, `topbeat.1`, `topbeat.2`, etc.
   #filename: topbeat
 
-  # Maximum size in kilobytes of each file. When this size is reached, the files
-  # are rotated. The default value is 10240 kB.
+  # Maximum size in kilobytes of each file. When this size is reached, and on
+  # every topbeat restart, the files are rotated. The default value is 10240
+  # kB.
   #rotate_every_kb: 10000
 
   # Maximum number of files under path. When this number of files is reached,

--- a/winlogbeat/winlogbeat.full.yml
+++ b/winlogbeat/winlogbeat.full.yml
@@ -156,7 +156,7 @@ output.elasticsearch:
   # The number of seconds to wait for new events between two bulk API index requests.
   # If `bulk_max_size` is reached before this interval expires, addition bulk index
   # requests are made.
-  #flush_interval: 1
+  #flush_interval: 1s
 
   # Boolean that sets if the topology is kept in Elasticsearch. The default is
   # false. This option makes sense only for Packetbeat.
@@ -232,7 +232,7 @@ output.elasticsearch:
   # Resolve names locally when using a proxy server. Defaults to false.
   #proxy_use_local_resolver: false
 
-  # Optional TLS. By default is off.
+  # Optional TLS configuration options. TLS is off by default.
   # List of root certificates for HTTPS server verifications
   #tls.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
@@ -256,7 +256,9 @@ output.elasticsearch:
 
 #------------------------------- Kafka output ---------------------------------
 #output.kafka:
-  # The list of Kafka broker addresses to connect to.
+  # The list of Kafka broker addresses from where to fetch the cluster metadata.
+  # The cluster metadata contain the actual Kafka brokers events are published
+  # to.
   #hosts: ["localhost:9092"]
 
   # The Kafka topic used for produced events. If use_type is set to true, the
@@ -289,8 +291,7 @@ output.elasticsearch:
   # default is 10s.
   #broker_timeout: 10s
 
-  # Per Kafka broker number of messages buffered in output pipeline. The default
-  # is 256.
+  # The number of messages buffered for each Kafka broker. The default is 256.
   #channel_buffer_size: 256
 
   # The keep-alive period for an active network connection. If 0s, keep-alives
@@ -298,8 +299,8 @@ output.elasticsearch:
   #keep_alive: 0
 
   # Sets the output compression codec. Must be one of none, snappy and gzip. The
-  # default is snappy.
-  #compression: snappy
+  # default is gzip.
+  #compression: gzip
 
   # The maximum permitted size of JSON-encoded messages. Bigger messages will be
   # dropped. The default value is 1000000 (bytes). This value should be equal to
@@ -310,16 +311,16 @@ output.elasticsearch:
   # local commit, -1=wait for all replicas to commit. The default is 1.  Note:
   # If set to 0, no ACKs are returned by Kafka. Messages might be lost silently
   # on error.
-  #required_acks: 0
+  #required_acks: 1
 
   # The number of seconds to wait for new events between two producer API calls.
-  #flush_interval: 1
+  #flush_interval: 1s
 
   # The configurable ClientID used for logging, debugging, and auditing
   # purposes.  The default is "beats".
   #client_id: beats
 
-  # Optional TLS. By default is off.
+  # Optional TLS configuration options. TLS is off by default.
   # List of root certificates for HTTPS server verifications
   #tls.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
@@ -415,7 +416,7 @@ output.elasticsearch:
   # occurs on the proxy server.
   #proxy_use_local_resolver: false
 
-  # Optional TLS. By default is off.
+  # Optional TLS configuration options. TLS is off by default.
   # List of root certificates for HTTPS server verifications
   #tls.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
@@ -447,8 +448,9 @@ output.elasticsearch:
   # files: `winlogbeat`, `winlogbeat.1`, `winlogbeat.2`, etc.
   #filename: winlogbeat
 
-  # Maximum size in kilobytes of each file. When this size is reached, the files
-  # are rotated. The default value is 10240 kB.
+  # Maximum size in kilobytes of each file. When this size is reached, and on
+  # every winlogbeat restart, the files are rotated. The default value is 10240
+  # kB.
   #rotate_every_kb: 10000
 
   # Maximum number of files under path. When this number of files is reached,


### PR DESCRIPTION
Follow up from #1690. This also calls `make collect` and `make update`
again to make sure all files are up to date.