### PR TITLE
Set version to 5.0.0-alpha3

### DIFF
--- a/dev-tools/packer/version.yml
+++ b/dev-tools/packer/version.yml
@@ -1,2 +1,1 @@
-
 version: "5.0.0-alpha3"

--- a/dev-tools/packer/version.yml
+++ b/dev-tools/packer/version.yml
@@ -1,1 +1,2 @@
-version: "5.0.0"
+
+version: "5.0.0-alpha3"

--- a/dev-tools/set_version
+++ b/dev-tools/set_version
@@ -7,8 +7,7 @@ template_go = '''package beat
 const defaultBeatVersion = "{}"
 '''
 
-template_packer = '''
-version: "{version}"
+template_packer = '''version: "{version}"
 '''
 
 

--- a/libbeat/beat/version.go
+++ b/libbeat/beat/version.go
@@ -1,3 +1,3 @@
 package beat
 
-const defaultBeatVersion = "5.0.0-SNAPSHOT"
+const defaultBeatVersion = "5.0.0-alpha3"


### PR DESCRIPTION
To be closer to what we plan for the unified release process, I'm setting the
version in advance. The artifacts will be named 5.0.0-alpha3-SNAPSHOT during
testing but the version in code is 5.0.0-alpha3. At the time of the release, we
rename the artifacts to remove SNAPSHOT, without having to rebuild.