### PR TITLE
Use underscores in RPM version metadata

### DIFF
--- a/dev-tools/packer/README.md
+++ b/dev-tools/packer/README.md
@@ -62,8 +62,9 @@ We use a set of package name conventions across all the Elastic stack:
   use dashes even for Deb files.
 * The archs are called `x86` and `x64` except for deb/rpm where we keep the
   OS preferred names (i386/amd64, i686/x86_64).
-* For version strings like `5.0.0-alpha3` we keep them with a dash in the
-  filename but use `~` in the deb/rpm metadata.
+* For version strings like `5.0.0-alpha3` we use dashes in all filenames. The
+  only exception is the RPM metadata (not the filename) where we replace the
+  dash with an underscore (`5.0.0_alpha3`).
 * We omit the release number from the filenames. It's always `1` in the metadata.
 
 For example, here are the artifacts created for Filebeat:

--- a/dev-tools/packer/platforms/centos/run.sh.j2
+++ b/dev-tools/packer/platforms/centos/run.sh.j2
@@ -18,7 +18,7 @@ if [ "$SNAPSHOT" = "yes" ]; then
 fi
 
 # fpm replaces - with _ in the version
-RPM_VERSION=`echo ${VERSION} | sed 's/-/~/g'`
+RPM_VERSION=`echo ${VERSION} | sed 's/-/_/g'`
 
 # create rpm
 fpm --force -s dir -t rpm \

--- a/dev-tools/packer/platforms/debian/run.sh.j2
+++ b/dev-tools/packer/platforms/debian/run.sh.j2
@@ -17,12 +17,9 @@ if [ "$SNAPSHOT" = "yes" ]; then
     VERSION="${VERSION}-SNAPSHOT"
 fi
 
-# fpm replaces - with _ in the version
-DEB_VERSION=`echo ${VERSION} | sed 's/-/~/g'`
-
 # create deb
 fpm --force -s dir -t deb \
-        -n {{.beat_name}} -v ${DEB_VERSION} \
+        -n {{.beat_name}} -v ${VERSION} \
         --vendor "Elastic" \
         --license "ASL 2.0" \
         --architecture {{.deb_arch}} \
@@ -43,7 +40,7 @@ fpm --force -s dir -t deb \
 
 # move and rename to use the elastic conventions
 mkdir -p upload/{{.beat_name}}
-mv {{.beat_name}}_${DEB_VERSION}_{{.deb_arch}}.deb upload/{{.beat_name}}/{{.beat_name}}-${VERSION}-{{.deb_arch}}.deb
+mv {{.beat_name}}_${VERSION}_{{.deb_arch}}.deb upload/{{.beat_name}}/{{.beat_name}}-${VERSION}-{{.deb_arch}}.deb
 echo "Created upload/{{.beat_name}}/{{.beat_name}}-${VERSION}-{{.deb_arch}}.deb"
 
 # create sha1 file

--- a/dev-tools/packer/scripts/Makefile
+++ b/dev-tools/packer/scripts/Makefile
@@ -44,7 +44,7 @@ go-daemon-image:
 	docker build --rm=true -t tudorg/go-daemon $(packer_absdir)/docker/go-daemon/
 
 build/god-linux-386 build/god-linux-amd64:
-	docker run -v $(shell pwd)/build:/build tudorg/go-daemon
+	docker run --rm -v $(shell pwd)/build:/build tudorg/go-daemon
 
 build/upload:
 	mkdir -p build/upload


### PR DESCRIPTION
The ~ doesn't work with older RPM versions, so the new convention is that we
use - everywhere except for the RPM metadata which uses _. All filenames still
use dashes.