### PR TITLE
Clearly mark Metricbeat as alpha in docs

### DIFF
--- a/metricbeat/docs/index-docinfo.xml
+++ b/metricbeat/docs/index-docinfo.xml
@@ -1,0 +1,7 @@
+<?page_header <b>PLEASE NOTE:</b> These docs are for a pre-GA version of Metricbeat, {version}.?>
+
+<abstract>
+    <simpara role="page_header">
+      These docs are for Metricbeat {version}, which has not yet reached GA.
+    </simpara>
+</abstract>

--- a/metricbeat/docs/index.asciidoc
+++ b/metricbeat/docs/index.asciidoc
@@ -1,7 +1,7 @@
-= Metricbeat Reference
+= Metricbeat Reference (alpha)
 :libbeat: http://www.elastic.co/guide/en/beats/libbeat/master
 :elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/master/
-:version: 5.0.0-alpha1
+:version: 5.0.0-alpha3
 :beatname_lc: metricbeat
 :beatname_uc: Metricbeat
 :security: X-Pack Security


### PR DESCRIPTION
* Add (alpha) in the title, so that shows up on the main index page
* Add a notice that the docs are for a non-GA version. This is done
  via a temporary `index-docinfo.xml` file at Clint's suggestion.
* Set version to alpha3 already (the version bump for the other
  products will come later)

CC @dedemorton and @ruflin. I think with these changes we can push Metricbeat to the live website. What do you say?