### PR TITLE
Removed (alpha) from the Metricbeat docs title

### DIFF
--- a/metricbeat/docs/index.asciidoc
+++ b/metricbeat/docs/index.asciidoc
@@ -1,4 +1,4 @@
-= Metricbeat Reference (alpha)
+= Metricbeat Reference
 :libbeat: http://www.elastic.co/guide/en/beats/libbeat/master
 :elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/master/
 :version: 5.0.0-alpha3


### PR DESCRIPTION
This partially reverts #1726. After all, the text on the index page
comes from conf.yaml, and the notice is enough on the main Metricbeat
docs page.