### PR TITLE
add cloudtrailbeat to community beats list

### DIFF
--- a/libbeat/docs/communitybeats.asciidoc
+++ b/libbeat/docs/communitybeats.asciidoc
@@ -6,6 +6,7 @@ out some of them here:
 
 [horizontal]
 https://github.com/radoondas/apachebeat[apachebeat]:: Reads status from Apache HTTPD server-status.
+https://github.com/aidan-/cloudtrailbeat[cloudtrailbeat]:: Read events from Amazon Web Services' https://aws.amazon.com/cloudtrail/[CloudTrail]
 https://github.com/Ingensi/dockerbeat[dockerbeat]:: Reads Docker container
 statistics and indexes them in Elasticsearch.
 https://github.com/radoondas/elasticbeat[elasticbeat]:: Reads status from an Elasticsearch cluster and indexes them in Elasticsearch.


### PR DESCRIPTION
CloudTrailBeat is a beat that processes AWS CloudTrail events.