### PR TITLE
Add script to generate MetricSet

### DIFF
--- a/filebeat/tests/system/test_crawler.py
+++ b/filebeat/tests/system/test_crawler.py
@@ -6,6 +6,7 @@ import codecs
 import os
 import time
 from nose.plugins.skip import Skip, SkipTest
+import shutil
 
 # Additional tests to be added:
 # * Check what happens when file renamed -> no recrawling should happen
@@ -270,14 +271,18 @@ class Test(BaseTest):
         """
 
         self.render_config_template(
-            path=os.path.abspath(self.working_dir) + "/log/*",
+            path=os.path.abspath(self.working_dir) + "/log/*.log",
             force_close_files="true",
             scan_frequency="0.1s"
         )
         os.mkdir(self.working_dir + "/log/")
 
         testfile = self.working_dir + "/log/test.log"
+        testfilenew = self.working_dir + "/log/hiddenfile"
         file = open(testfile, 'w')
+
+        # Creates testfile now, to prevent inode reuse
+        open(testfilenew, 'a').close()
 
         iterations1 = 5
         for n in range(0, iterations1):
@@ -299,7 +304,8 @@ class Test(BaseTest):
                 "Force close file"),
             max_timeout=15)
 
-        # Create new file with same name to see if it is picked up
+        # Move file to old file name
+        shutil.move(testfilenew, testfile)
         file = open(testfile, 'w')
 
         iterations2 = 6

--- a/metricbeat/Makefile
+++ b/metricbeat/Makefile
@@ -53,3 +53,8 @@ before-build:
 # Runs all collection steps and updates afterwards
 .PHONY: collect
 collect: kibana fields docs configs update imports
+
+# Creates a new metricset. Requires the params MODULE and METRICSET
+.PHONY: create-metricset
+create-metricset:
+	python ${ES_BEATS}/metricbeat/scripts/create_metricset.py $(MODULE) $(METRICSET)

--- a/metricbeat/docs/developer-guide/create-metricset.asciidoc
+++ b/metricbeat/docs/developer-guide/create-metricset.asciidoc
@@ -34,33 +34,7 @@ Each metricseter consists 3 parts:
 
 [source,go]
 ----
-package {metricset-name}
-
-import (
-	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/metricbeat/mb"
-)
-
-func init() {
-	if err := helper.Registry.AddMetricSeter("{module-name}", "{metricset-name}", New); err != nil {
-        panic(err)
-	}
-}
-
-// MetricSet for fetching metrics.
-type MetricSet struct {
-	mb.BaseMetricSet
-}
-
-// New is a mb.MetricSetFactory that returns a cpu.MetricSet.
-func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	return &MetricSet{base}, nil
-}
-
-func (m *MetricSet) Fetch() (common.MapStr, error) {
-	event := common.MapStr{"hello": "world"}
-	return event, nil
-}
+include::../../scripts/module/metricset/metricset.go.tmpl[]
 ----
 
 This adds a working metricset do your module which reports the event

--- a/metricbeat/docs/developer-guide/index.asciidoc
+++ b/metricbeat/docs/developer-guide/index.asciidoc
@@ -62,8 +62,6 @@ on what should be documented, check the existing documented modules.
 TODO: Add details on how to create dashboards
 
 
-
-
 include::./create-metricset.asciidoc[]
 
 include::./testing.asciidoc[]

--- a/metricbeat/scripts/create_metricset.py
+++ b/metricbeat/scripts/create_metricset.py
@@ -1,0 +1,91 @@
+import os
+import argparse
+
+# Creates a new metricset with all the necessary file
+# In case the module does not exist, also the module is created
+
+
+def generate_metricset(base_path, module, metricset):
+
+    generate_module(base_path, module)
+    metricset_path = base_path + "/module/" + module + "/" + metricset
+    meta_path = metricset_path + "/_beat"
+
+    if os.path.isdir(metricset_path):
+        print "MericSet already exists. Skipping creating metricset " + metricset + ".\n"
+        return
+
+    os.makedirs(meta_path)
+
+    templates = base_path + "/scripts/module/metricset/"
+
+
+    content = load_file(templates + "metricset.go.tmpl", module, metricset)
+    with open(metricset_path + "/metricset.go", "w") as f:
+        f.write(content)
+
+    content = load_file(templates + "fields.yml", module, metricset)
+    with open(meta_path + "/fields.yml", "w") as f:
+        f.write(content)
+
+    content = load_file(templates + "docs.asciidoc", module, metricset)
+    with open(meta_path + "/docs.asciidoc", "w") as f:
+        f.write(content)
+
+    content = load_file(templates + "data.json", module, metricset)
+    with open(meta_path + "/data.json", "w") as f:
+        f.write(content)
+
+    print "Metricset " + metricset + " created.\n"
+
+
+def generate_module(base_path, module):
+
+    module_path = base_path + "/module/" + module
+    meta_path = module_path + "/_beat"
+
+    if os.path.isdir(module_path):
+        print "Module already exists. Skipping creating module " + module + ".\n"
+        return
+
+    os.makedirs(meta_path)
+
+    templates = base_path + "/scripts/module/"
+
+    content = load_file(templates + "fields.yml", module, "")
+    with open(meta_path + "/fields.yml", "w") as f:
+        f.write(content)
+
+    content = load_file(templates + "docs.asciidoc", module, "")
+    with open(meta_path + "/docs.asciidoc", "w") as f:
+        f.write(content)
+
+    content = load_file(templates + "config.yml", module, "")
+    with open(meta_path + "/config.yml", "w") as f:
+        f.write(content)
+
+    content = load_file(templates + "doc.go.tmpl", module, "")
+    with open(module_path + "/doc.go", "w") as f:
+        f.write(content)
+
+    print "Module " + module + " created.\n"
+
+
+def load_file(file, module, metricset):
+    content = ""
+    with open(file) as f:
+        content = f.read()
+
+    return content.replace("{module}", module).replace("{metricset}", metricset)
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(
+        description="Creates a metricset")
+    parser.add_argument("module", help="Module name")
+    parser.add_argument("metricset", help="Metricset name")
+
+    args = parser.parse_args()
+
+    path = os.path.abspath("./")
+    generate_metricset(path, args.module.lower(), args.metricset.lower())

--- a/metricbeat/scripts/module/config.yml
+++ b/metricbeat/scripts/module/config.yml
@@ -1,0 +1,6 @@
+- module: {module}
+  metricsets: ["{metricset}"]
+  enabled: true
+  period: 1s
+  hosts: ["localhost"]
+

--- a/metricbeat/scripts/module/doc.go.tmpl
+++ b/metricbeat/scripts/module/doc.go.tmpl
@@ -1,0 +1,4 @@
+/*
+Package {module} is a Metricbeat module that contains MetricSets.
+*/
+package {module}

--- a/metricbeat/scripts/module/docs.asciidoc
+++ b/metricbeat/scripts/module/docs.asciidoc
@@ -1,0 +1,4 @@
+== {module} Module
+
+This is the {module} Module.
+

--- a/metricbeat/scripts/module/fields.yml
+++ b/metricbeat/scripts/module/fields.yml
@@ -1,0 +1,9 @@
+- key: {module}
+  title: "{module}"
+  description: >
+    {module} Module
+  fields:
+    - name: {module}
+      type: group
+      description: >
+      fields:

--- a/metricbeat/scripts/module/metricset/data.json
+++ b/metricbeat/scripts/module/metricset/data.json
@@ -1,0 +1,19 @@
+{
+    "@timestamp":"2016-05-23T08:05:34.853Z",
+    "beat":{
+        "hostname":"beathost",
+        "name":"beathost"
+    },
+    "metricset":{
+        "host":"localhost",
+        "module":"mysql",
+        "name":"status",
+        "rtt":44269
+    },
+    "{module}":{
+        "{metricset}":{
+            "example": "{metricset}"
+        }
+    },
+    "type":"metricsets"
+}

--- a/metricbeat/scripts/module/metricset/docs.asciidoc
+++ b/metricbeat/scripts/module/metricset/docs.asciidoc
@@ -1,0 +1,3 @@
+=== {module} {metricset} MetricSet
+
+This is the {metricset} Metricset of the module {module}.

--- a/metricbeat/scripts/module/metricset/fields.yml
+++ b/metricbeat/scripts/module/metricset/fields.yml
@@ -1,0 +1,9 @@
+- name: {metricset}
+  type: group
+  description: >
+    {metricset}
+  fields:
+    - name: example
+      type: keyword
+      description: >
+        Example field

--- a/metricbeat/scripts/module/metricset/metricset.go.tmpl
+++ b/metricbeat/scripts/module/metricset/metricset.go.tmpl
@@ -1,0 +1,37 @@
+package {metricset}
+
+import (
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/metricbeat/mb"
+)
+
+func init() {
+	if err := mb.Registry.AddMetricSet("{module}", "{metricset}", New); err != nil {
+		panic(err)
+	}
+}
+
+type MetricSet struct {
+	mb.BaseMetricSet
+}
+
+func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
+
+	config := struct{}{}
+
+	if err := base.Module().UnpackConfig(&config); err != nil {
+		return nil, err
+	}
+
+	return &MetricSet{
+		BaseMetricSet: base,
+	}, nil
+}
+
+func (m *MetricSet) Fetch() (common.MapStr, error) {
+
+	event := common.MapStr{
+		"example": "{metricset} example",
+	}
+	return event, nil
+}


### PR DESCRIPTION
Adding a MetricSet requires a create several files with a predefined file structure for automation. To simplify the task of creating a MetricSet and make sure the correct structure is used, this task is now automated with a script. The script can be called with `make create-metricset MODULE=modulename METRICSET=metricsetname`. This generates all files including template, config and docs. After `make imports` must be called to update the import list and `make collect` to aggregate all the new data. The MetricSet can directly be compiled and run with the default content.

This script can also be used in the metricbeat-generator, means someone creating multiple metricsets has also the tooling available. In addition, this simplifies the metricbeat-generator as most of the templates which change frequently are in the beats repository.

As the templates used for the generation are the same as shown in the developer guide, it would be nice to also import these templates to make sure the docs are always up-to-date.