### PR TITLE
Leave only the system module enabled in Metricbeat

### DIFF
--- a/metricbeat/docs/fields.asciidoc
+++ b/metricbeat/docs/fields.asciidoc
@@ -1173,6 +1173,7 @@ type: integer
 
 None
 
+[float]
 === keyspace Fields
 
 `keyspace` contains the information about the keyspaces returned by the `INFO` command.

--- a/metricbeat/docs/modules/apache.asciidoc
+++ b/metricbeat/docs/modules/apache.asciidoc
@@ -22,7 +22,7 @@ metricbeat.modules:
 - module: apache
   metricsets: ["status"]
   enabled: true
-  period: 1s
+  period: 10s
 
   # Apache hosts
   hosts: ["http://127.0.0.1/"]

--- a/metricbeat/docs/modules/mysql.asciidoc
+++ b/metricbeat/docs/modules/mysql.asciidoc
@@ -32,7 +32,7 @@ metricbeat.modules:
 - module: mysql
   metricsets: ["status"]
   enabled: true
-  period: 2s
+  period: 10s
 
   # Host DSN should be defined as "tcp(127.0.0.1:3306)/"
   # The username and password can either be set in the DSN or for all hosts in username and password config option

--- a/metricbeat/docs/modules/nginx.asciidoc
+++ b/metricbeat/docs/modules/nginx.asciidoc
@@ -25,7 +25,6 @@ metricbeat.modules:
 
   # Nginx hosts
   hosts: ["http://127.0.0.1/"]
-
 ----
 
 [float]

--- a/metricbeat/docs/modules/nginx.asciidoc
+++ b/metricbeat/docs/modules/nginx.asciidoc
@@ -21,7 +21,7 @@ metricbeat.modules:
 - module: nginx
   metricsets: ["stubstatus"]
   enabled: true
-  period: 1s
+  period: 10s
 
   # Nginx hosts
   hosts: ["http://127.0.0.1/"]

--- a/metricbeat/docs/modules/redis.asciidoc
+++ b/metricbeat/docs/modules/redis.asciidoc
@@ -34,7 +34,7 @@ metricbeat.modules:
 - module: redis
   metricsets: ["info"]
   enabled: true
-  period: 1s
+  period: 10s
 
   # Redis hosts
   hosts: ["127.0.0.1:6379"]

--- a/metricbeat/docs/modules/system.asciidoc
+++ b/metricbeat/docs/modules/system.asciidoc
@@ -56,11 +56,31 @@ here (add link). Below is an example of a configuration option:
 ----
 metricbeat.modules:
 - module: system
-  metricsets: ["cpu", "core", "filesystem", "fsstat", "memory", "process"]
+  metricsets:
+    # CPU stats
+    - cpu
+
+    # Per CPU core stats
+    #- core
+
+    # IO stats
+    #- disk
+
+    # Per filesystem stats
+    - filesystem
+
+    # File system summary stats
+    #- fsstat
+
+    # Memory stats
+    - memory
+
+    # Per process stats
+    - process
   enabled: true
-  period: 2s
+  period: 10s
   processes: ['.*']
-  
+
   # if true, exports the CPU usage in ticks, together with the percentage values
   cpu_ticks: false
 ----

--- a/metricbeat/docs/modules/zookeeper.asciidoc
+++ b/metricbeat/docs/modules/zookeeper.asciidoc
@@ -17,11 +17,11 @@ here (add link). Below is an example of a configuration option:
 [source,yaml]
 ----
 metricbeat.modules:
-- module: zookeeper
-  metricsets: ["mntr"]
-  enabled: true
-  period: 5s
-  hosts: ["localhost:2181"]
+#- module: zookeeper
+  #metricsets: ["mntr"]
+  #enabled: true
+  #period: 5s
+  #hosts: ["localhost:2181"]
 ----
 
 [float]

--- a/metricbeat/docs/modules/zookeeper.asciidoc
+++ b/metricbeat/docs/modules/zookeeper.asciidoc
@@ -20,7 +20,7 @@ metricbeat.modules:
 #- module: zookeeper
   #metricsets: ["mntr"]
   #enabled: true
-  #period: 5s
+  #period: 10s
   #hosts: ["localhost:2181"]
 ----
 

--- a/metricbeat/etc/beat.full.yml
+++ b/metricbeat/etc/beat.full.yml
@@ -10,14 +10,44 @@
 #==========================  Modules configuration ============================
 metricbeat.modules:
 
-#------------------------------- Apache Module -------------------------------
-- module: apache
-  metricsets: ["status"]
+#---------------------------- System Status Module ---------------------------
+- module: system
+  metricsets:
+    # CPU stats
+    - cpu
+
+    # Per CPU core stats
+    #- core
+
+    # IO stats
+    #- disk
+
+    # Per filesystem stats
+    - filesystem
+
+    # File system summary stats
+    #- fsstat
+
+    # Memory stats
+    - memory
+
+    # Per process stats
+    - process
   enabled: true
-  period: 1s
+  period: 10s
+  processes: ['.*']
+
+  # if true, exports the CPU usage in ticks, together with the percentage values
+  cpu_ticks: false
+
+#------------------------------- Apache Module -------------------------------
+#- module: apache
+  #metricsets: ["status"]
+  #enabled: true
+  #period: 1s
 
   # Apache hosts
-  hosts: ["http://127.0.0.1/"]
+  #hosts: ["http://127.0.0.1/"]
 
   # Path to server status. Default server-status
   #server_status_path: "server-status"
@@ -29,14 +59,14 @@ metricbeat.modules:
   #password: test123
 
 #---------------------------- MySQL Status Module ----------------------------
-- module: mysql
-  metricsets: ["status"]
-  enabled: true
-  period: 2s
+#- module: mysql
+  #metricsets: ["status"]
+  #enabled: true
+  #period: 2s
 
   # Host DSN should be defined as "tcp(127.0.0.1:3306)/"
   # The username and password can either be set in the DSN or for all hosts in username and password config option
-  hosts: ["root@tcp(127.0.0.1:3306)/"]
+  #hosts: ["root@tcp(127.0.0.1:3306)/"]
 
   # Username of hosts. Empty by default
   #username: root
@@ -45,25 +75,25 @@ metricbeat.modules:
   #password: test
 
 #---------------------------- Nginx Status Module ----------------------------
-- module: nginx
-  metricsets: ["stubstatus"]
-  enabled: true
-  period: 1s
+#- module: nginx
+  #metricsets: ["stubstatus"]
+  #enabled: true
+  #period: 1s
 
   # Nginx hosts
-  hosts: ["http://127.0.0.1/"]
+  #hosts: ["http://127.0.0.1/"]
 
   # Path to server status. Default server-status
   #server_status_path: "server-status"
 
 #---------------------------- Redis Status Module ----------------------------
-- module: redis
-  metricsets: ["info"]
-  enabled: true
-  period: 1s
+#- module: redis
+  #metricsets: ["info", "keyspace"]
+  #enabled: true
+  #period: 1s
 
   # Redis hosts
-  hosts: ["127.0.0.1:6379"]
+  #hosts: ["127.0.0.1:6379"]
 
   # Enabled defines if the module is enabled. Default: true
   #enabled: true
@@ -91,21 +121,11 @@ metricbeat.modules:
   # Redis AUTH password. Empty by default.
   #password: foobared
 
-#---------------------------- System Status Module ---------------------------
-- module: system
-  metricsets: ["cpu", "core", "filesystem", "fsstat", "memory", "process"]
-  enabled: true
-  period: 2s
-  processes: ['.*']
-  
-  # if true, exports the CPU usage in ticks, together with the percentage values
-  cpu_ticks: false
-
 #-------------------------- Zookeeper Status Module --------------------------
-- module: zookeeper
-  metricsets: ["mntr"]
-  enabled: true
-  period: 5s
-  hosts: ["localhost:2181"]
+#- module: zookeeper
+  #metricsets: ["mntr"]
+  #enabled: true
+  #period: 5s
+  #hosts: ["localhost:2181"]
 
 

--- a/metricbeat/etc/beat.full.yml
+++ b/metricbeat/etc/beat.full.yml
@@ -44,7 +44,7 @@ metricbeat.modules:
 #- module: apache
   #metricsets: ["status"]
   #enabled: true
-  #period: 1s
+  #period: 10s
 
   # Apache hosts
   #hosts: ["http://127.0.0.1/"]
@@ -62,7 +62,7 @@ metricbeat.modules:
 #- module: mysql
   #metricsets: ["status"]
   #enabled: true
-  #period: 2s
+  #period: 10s
 
   # Host DSN should be defined as "tcp(127.0.0.1:3306)/"
   # The username and password can either be set in the DSN or for all hosts in username and password config option
@@ -78,7 +78,7 @@ metricbeat.modules:
 #- module: nginx
   #metricsets: ["stubstatus"]
   #enabled: true
-  #period: 1s
+  #period: 10s
 
   # Nginx hosts
   #hosts: ["http://127.0.0.1/"]
@@ -90,7 +90,7 @@ metricbeat.modules:
 #- module: redis
   #metricsets: ["info", "keyspace"]
   #enabled: true
-  #period: 1s
+  #period: 10s
 
   # Redis hosts
   #hosts: ["127.0.0.1:6379"]
@@ -125,7 +125,7 @@ metricbeat.modules:
 #- module: zookeeper
   #metricsets: ["mntr"]
   #enabled: true
-  #period: 5s
+  #period: 10s
   #hosts: ["localhost:2181"]
 
 

--- a/metricbeat/etc/beat.yml
+++ b/metricbeat/etc/beat.yml
@@ -10,51 +10,33 @@
 #==========================  Modules configuration ============================
 metricbeat.modules:
 
-#------------------------------- Apache Module -------------------------------
-- module: apache
-  metricsets: ["status"]
-  enabled: true
-  period: 1s
-
-  # Apache hosts
-  hosts: ["http://127.0.0.1/"]
-
-#---------------------------- MySQL Status Module ----------------------------
-- module: mysql
-  metricsets: ["status"]
-  enabled: true
-  period: 2s
-
-  # Host DSN should be defined as "tcp(127.0.0.1:3306)/"
-  # The username and password can either be set in the DSN or for all hosts in username and password config option
-  hosts: ["root@tcp(127.0.0.1:3306)/"]
-
-#---------------------------- Nginx Status Module ----------------------------
-- module: nginx
-  metricsets: ["stubstatus"]
-  enabled: true
-  period: 1s
-
-  # Nginx hosts
-  hosts: ["http://127.0.0.1/"]
-
-
-#---------------------------- Redis Status Module ----------------------------
-- module: redis
-  metricsets: ["info"]
-  enabled: true
-  period: 1s
-
-  # Redis hosts
-  hosts: ["127.0.0.1:6379"]
-
 #---------------------------- System Status Module ---------------------------
 - module: system
-  metricsets: ["cpu", "core", "filesystem", "fsstat", "memory", "process"]
+  metricsets:
+    # CPU stats
+    - cpu
+
+    # Per CPU core stats
+    #- core
+
+    # IO stats
+    #- disk
+
+    # Per filesystem stats
+    - filesystem
+
+    # File system summary stats
+    #- fsstat
+
+    # Memory stats
+    - memory
+
+    # Per process stats
+    - process
   enabled: true
-  period: 2s
+  period: 10s
   processes: ['.*']
-  
+
   # if true, exports the CPU usage in ticks, together with the percentage values
   cpu_ticks: false
 

--- a/metricbeat/etc/fields.yml
+++ b/metricbeat/etc/fields.yml
@@ -32,6 +32,7 @@
   title: "Apache"
   description: >
     Apache HTTPD server metric sets collected from the apache web server.
+  short_config: false
   fields:
     - name: apache
       type: group
@@ -208,6 +209,7 @@
   title: "MySQL Status"
   description: >
     MySQL server status metrics collected from MySQL
+  short_config: false
   fields:
     - name: mysql
       type: group
@@ -329,6 +331,7 @@
   title: "Nginx Status"
   description: >
     Nginx server status metrics collected from various modules.
+  short_config: false
   fields:
     - name: nginx
       type: group
@@ -384,6 +387,7 @@
   title: "Redis Status"
   description: >
     Redis metrics collected from the Redis
+  short_config: false
   fields:
     - name: redis
       type: group

--- a/metricbeat/metricbeat.full.yml
+++ b/metricbeat/metricbeat.full.yml
@@ -10,14 +10,44 @@
 #==========================  Modules configuration ============================
 metricbeat.modules:
 
-#------------------------------- Apache Module -------------------------------
-- module: apache
-  metricsets: ["status"]
+#---------------------------- System Status Module ---------------------------
+- module: system
+  metricsets:
+    # CPU stats
+    - cpu
+
+    # Per CPU core stats
+    #- core
+
+    # IO stats
+    #- disk
+
+    # Per filesystem stats
+    - filesystem
+
+    # File system summary stats
+    #- fsstat
+
+    # Memory stats
+    - memory
+
+    # Per process stats
+    - process
   enabled: true
-  period: 1s
+  period: 10s
+  processes: ['.*']
+
+  # if true, exports the CPU usage in ticks, together with the percentage values
+  cpu_ticks: false
+
+#------------------------------- Apache Module -------------------------------
+#- module: apache
+  #metricsets: ["status"]
+  #enabled: true
+  #period: 1s
 
   # Apache hosts
-  hosts: ["http://127.0.0.1/"]
+  #hosts: ["http://127.0.0.1/"]
 
   # Path to server status. Default server-status
   #server_status_path: "server-status"
@@ -29,14 +59,14 @@ metricbeat.modules:
   #password: test123
 
 #---------------------------- MySQL Status Module ----------------------------
-- module: mysql
-  metricsets: ["status"]
-  enabled: true
-  period: 2s
+#- module: mysql
+  #metricsets: ["status"]
+  #enabled: true
+  #period: 2s
 
   # Host DSN should be defined as "tcp(127.0.0.1:3306)/"
   # The username and password can either be set in the DSN or for all hosts in username and password config option
-  hosts: ["root@tcp(127.0.0.1:3306)/"]
+  #hosts: ["root@tcp(127.0.0.1:3306)/"]
 
   # Username of hosts. Empty by default
   #username: root
@@ -45,25 +75,25 @@ metricbeat.modules:
   #password: test
 
 #---------------------------- Nginx Status Module ----------------------------
-- module: nginx
-  metricsets: ["stubstatus"]
-  enabled: true
-  period: 1s
+#- module: nginx
+  #metricsets: ["stubstatus"]
+  #enabled: true
+  #period: 1s
 
   # Nginx hosts
-  hosts: ["http://127.0.0.1/"]
+  #hosts: ["http://127.0.0.1/"]
 
   # Path to server status. Default server-status
   #server_status_path: "server-status"
 
 #---------------------------- Redis Status Module ----------------------------
-- module: redis
-  metricsets: ["info"]
-  enabled: true
-  period: 1s
+#- module: redis
+  #metricsets: ["info", "keyspace"]
+  #enabled: true
+  #period: 1s
 
   # Redis hosts
-  hosts: ["127.0.0.1:6379"]
+  #hosts: ["127.0.0.1:6379"]
 
   # Enabled defines if the module is enabled. Default: true
   #enabled: true
@@ -91,22 +121,12 @@ metricbeat.modules:
   # Redis AUTH password. Empty by default.
   #password: foobared
 
-#---------------------------- System Status Module ---------------------------
-- module: system
-  metricsets: ["cpu", "core", "filesystem", "fsstat", "memory", "process"]
-  enabled: true
-  period: 2s
-  processes: ['.*']
-  
-  # if true, exports the CPU usage in ticks, together with the percentage values
-  cpu_ticks: false
-
 #-------------------------- Zookeeper Status Module --------------------------
-- module: zookeeper
-  metricsets: ["mntr"]
-  enabled: true
-  period: 5s
-  hosts: ["localhost:2181"]
+#- module: zookeeper
+  #metricsets: ["mntr"]
+  #enabled: true
+  #period: 5s
+  #hosts: ["localhost:2181"]
 
 
 

--- a/metricbeat/metricbeat.full.yml
+++ b/metricbeat/metricbeat.full.yml
@@ -44,7 +44,7 @@ metricbeat.modules:
 #- module: apache
   #metricsets: ["status"]
   #enabled: true
-  #period: 1s
+  #period: 10s
 
   # Apache hosts
   #hosts: ["http://127.0.0.1/"]
@@ -62,7 +62,7 @@ metricbeat.modules:
 #- module: mysql
   #metricsets: ["status"]
   #enabled: true
-  #period: 2s
+  #period: 10s
 
   # Host DSN should be defined as "tcp(127.0.0.1:3306)/"
   # The username and password can either be set in the DSN or for all hosts in username and password config option
@@ -78,7 +78,7 @@ metricbeat.modules:
 #- module: nginx
   #metricsets: ["stubstatus"]
   #enabled: true
-  #period: 1s
+  #period: 10s
 
   # Nginx hosts
   #hosts: ["http://127.0.0.1/"]
@@ -90,7 +90,7 @@ metricbeat.modules:
 #- module: redis
   #metricsets: ["info", "keyspace"]
   #enabled: true
-  #period: 1s
+  #period: 10s
 
   # Redis hosts
   #hosts: ["127.0.0.1:6379"]
@@ -125,7 +125,7 @@ metricbeat.modules:
 #- module: zookeeper
   #metricsets: ["mntr"]
   #enabled: true
-  #period: 5s
+  #period: 10s
   #hosts: ["localhost:2181"]
 
 

--- a/metricbeat/metricbeat.yml
+++ b/metricbeat/metricbeat.yml
@@ -10,51 +10,33 @@
 #==========================  Modules configuration ============================
 metricbeat.modules:
 
-#------------------------------- Apache Module -------------------------------
-- module: apache
-  metricsets: ["status"]
-  enabled: true
-  period: 1s
-
-  # Apache hosts
-  hosts: ["http://127.0.0.1/"]
-
-#---------------------------- MySQL Status Module ----------------------------
-- module: mysql
-  metricsets: ["status"]
-  enabled: true
-  period: 2s
-
-  # Host DSN should be defined as "tcp(127.0.0.1:3306)/"
-  # The username and password can either be set in the DSN or for all hosts in username and password config option
-  hosts: ["root@tcp(127.0.0.1:3306)/"]
-
-#---------------------------- Nginx Status Module ----------------------------
-- module: nginx
-  metricsets: ["stubstatus"]
-  enabled: true
-  period: 1s
-
-  # Nginx hosts
-  hosts: ["http://127.0.0.1/"]
-
-
-#---------------------------- Redis Status Module ----------------------------
-- module: redis
-  metricsets: ["info"]
-  enabled: true
-  period: 1s
-
-  # Redis hosts
-  hosts: ["127.0.0.1:6379"]
-
 #---------------------------- System Status Module ---------------------------
 - module: system
-  metricsets: ["cpu", "core", "filesystem", "fsstat", "memory", "process"]
+  metricsets:
+    # CPU stats
+    - cpu
+
+    # Per CPU core stats
+    #- core
+
+    # IO stats
+    #- disk
+
+    # Per filesystem stats
+    - filesystem
+
+    # File system summary stats
+    #- fsstat
+
+    # Memory stats
+    - memory
+
+    # Per process stats
+    - process
   enabled: true
-  period: 2s
+  period: 10s
   processes: ['.*']
-  
+
   # if true, exports the CPU usage in ticks, together with the percentage values
   cpu_ticks: false
 

--- a/metricbeat/module/apache/_beat/config.full.yml
+++ b/metricbeat/module/apache/_beat/config.full.yml
@@ -1,7 +1,7 @@
 #- module: apache
   #metricsets: ["status"]
   #enabled: true
-  #period: 1s
+  #period: 10s
 
   # Apache hosts
   #hosts: ["http://127.0.0.1/"]

--- a/metricbeat/module/apache/_beat/config.full.yml
+++ b/metricbeat/module/apache/_beat/config.full.yml
@@ -1,10 +1,10 @@
-- module: apache
-  metricsets: ["status"]
-  enabled: true
-  period: 1s
+#- module: apache
+  #metricsets: ["status"]
+  #enabled: true
+  #period: 1s
 
   # Apache hosts
-  hosts: ["http://127.0.0.1/"]
+  #hosts: ["http://127.0.0.1/"]
 
   # Path to server status. Default server-status
   #server_status_path: "server-status"

--- a/metricbeat/module/apache/_beat/config.yml
+++ b/metricbeat/module/apache/_beat/config.yml
@@ -1,7 +1,7 @@
 - module: apache
   metricsets: ["status"]
   enabled: true
-  period: 1s
+  period: 10s
 
   # Apache hosts
   hosts: ["http://127.0.0.1/"]

--- a/metricbeat/module/apache/_beat/fields.yml
+++ b/metricbeat/module/apache/_beat/fields.yml
@@ -2,6 +2,7 @@
   title: "Apache"
   description: >
     Apache HTTPD server metric sets collected from the apache web server.
+  short_config: false
   fields:
     - name: apache
       type: group

--- a/metricbeat/module/mysql/_beat/config.full.yml
+++ b/metricbeat/module/mysql/_beat/config.full.yml
@@ -1,11 +1,11 @@
-- module: mysql
-  metricsets: ["status"]
-  enabled: true
-  period: 2s
+#- module: mysql
+  #metricsets: ["status"]
+  #enabled: true
+  #period: 2s
 
   # Host DSN should be defined as "tcp(127.0.0.1:3306)/"
   # The username and password can either be set in the DSN or for all hosts in username and password config option
-  hosts: ["root@tcp(127.0.0.1:3306)/"]
+  #hosts: ["root@tcp(127.0.0.1:3306)/"]
 
   # Username of hosts. Empty by default
   #username: root

--- a/metricbeat/module/mysql/_beat/config.full.yml
+++ b/metricbeat/module/mysql/_beat/config.full.yml
@@ -1,7 +1,7 @@
 #- module: mysql
   #metricsets: ["status"]
   #enabled: true
-  #period: 2s
+  #period: 10s
 
   # Host DSN should be defined as "tcp(127.0.0.1:3306)/"
   # The username and password can either be set in the DSN or for all hosts in username and password config option

--- a/metricbeat/module/mysql/_beat/config.yml
+++ b/metricbeat/module/mysql/_beat/config.yml
@@ -1,7 +1,7 @@
 - module: mysql
   metricsets: ["status"]
   enabled: true
-  period: 2s
+  period: 10s
 
   # Host DSN should be defined as "tcp(127.0.0.1:3306)/"
   # The username and password can either be set in the DSN or for all hosts in username and password config option

--- a/metricbeat/module/mysql/_beat/fields.yml
+++ b/metricbeat/module/mysql/_beat/fields.yml
@@ -2,6 +2,7 @@
   title: "MySQL Status"
   description: >
     MySQL server status metrics collected from MySQL
+  short_config: false
   fields:
     - name: mysql
       type: group

--- a/metricbeat/module/nginx/_beat/config.full.yml
+++ b/metricbeat/module/nginx/_beat/config.full.yml
@@ -1,10 +1,10 @@
-- module: nginx
-  metricsets: ["stubstatus"]
-  enabled: true
-  period: 1s
+#- module: nginx
+  #metricsets: ["stubstatus"]
+  #enabled: true
+  #period: 1s
 
   # Nginx hosts
-  hosts: ["http://127.0.0.1/"]
+  #hosts: ["http://127.0.0.1/"]
 
   # Path to server status. Default server-status
   #server_status_path: "server-status"

--- a/metricbeat/module/nginx/_beat/config.full.yml
+++ b/metricbeat/module/nginx/_beat/config.full.yml
@@ -1,7 +1,7 @@
 #- module: nginx
   #metricsets: ["stubstatus"]
   #enabled: true
-  #period: 1s
+  #period: 10s
 
   # Nginx hosts
   #hosts: ["http://127.0.0.1/"]

--- a/metricbeat/module/nginx/_beat/config.yml
+++ b/metricbeat/module/nginx/_beat/config.yml
@@ -1,7 +1,7 @@
 - module: nginx
   metricsets: ["stubstatus"]
   enabled: true
-  period: 1s
+  period: 10s
 
   # Nginx hosts
   hosts: ["http://127.0.0.1/"]

--- a/metricbeat/module/nginx/_beat/config.yml
+++ b/metricbeat/module/nginx/_beat/config.yml
@@ -5,4 +5,3 @@
 
   # Nginx hosts
   hosts: ["http://127.0.0.1/"]
-

--- a/metricbeat/module/nginx/_beat/fields.yml
+++ b/metricbeat/module/nginx/_beat/fields.yml
@@ -2,6 +2,7 @@
   title: "Nginx Status"
   description: >
     Nginx server status metrics collected from various modules.
+  short_config: false
   fields:
     - name: nginx
       type: group

--- a/metricbeat/module/redis/_beat/config.full.yml
+++ b/metricbeat/module/redis/_beat/config.full.yml
@@ -1,10 +1,10 @@
-- module: redis
-  metricsets: ["info", "keyspace"]
-  enabled: true
-  period: 1s
+#- module: redis
+  #metricsets: ["info", "keyspace"]
+  #enabled: true
+  #period: 1s
 
   # Redis hosts
-  hosts: ["127.0.0.1:6379"]
+  #hosts: ["127.0.0.1:6379"]
 
   # Enabled defines if the module is enabled. Default: true
   #enabled: true

--- a/metricbeat/module/redis/_beat/config.full.yml
+++ b/metricbeat/module/redis/_beat/config.full.yml
@@ -1,7 +1,7 @@
 #- module: redis
   #metricsets: ["info", "keyspace"]
   #enabled: true
-  #period: 1s
+  #period: 10s
 
   # Redis hosts
   #hosts: ["127.0.0.1:6379"]

--- a/metricbeat/module/redis/_beat/config.yml
+++ b/metricbeat/module/redis/_beat/config.yml
@@ -1,7 +1,7 @@
 - module: redis
   metricsets: ["info"]
   enabled: true
-  period: 1s
+  period: 10s
 
   # Redis hosts
   hosts: ["127.0.0.1:6379"]

--- a/metricbeat/module/redis/_beat/fields.yml
+++ b/metricbeat/module/redis/_beat/fields.yml
@@ -2,6 +2,7 @@
   title: "Redis Status"
   description: >
     Redis metrics collected from the Redis
+  short_config: false
   fields:
     - name: redis
       type: group

--- a/metricbeat/module/system/_beat/config.yml
+++ b/metricbeat/module/system/_beat/config.yml
@@ -1,8 +1,28 @@
 - module: system
-  metricsets: ["cpu", "core", "filesystem", "fsstat", "memory", "process"]
+  metricsets:
+    # CPU stats
+    - cpu
+
+    # Per CPU core stats
+    #- core
+
+    # IO stats
+    #- disk
+
+    # Per filesystem stats
+    - filesystem
+
+    # File system summary stats
+    #- fsstat
+
+    # Memory stats
+    - memory
+
+    # Per process stats
+    - process
   enabled: true
-  period: 2s
+  period: 10s
   processes: ['.*']
-  
+
   # if true, exports the CPU usage in ticks, together with the percentage values
   cpu_ticks: false

--- a/metricbeat/module/zookeeper/_beat/config.yml
+++ b/metricbeat/module/zookeeper/_beat/config.yml
@@ -1,5 +1,5 @@
-- module: zookeeper
-  metricsets: ["mntr"]
-  enabled: true
-  period: 5s
-  hosts: ["localhost:2181"]
+#- module: zookeeper
+  #metricsets: ["mntr"]
+  #enabled: true
+  #period: 5s
+  #hosts: ["localhost:2181"]

--- a/metricbeat/module/zookeeper/_beat/config.yml
+++ b/metricbeat/module/zookeeper/_beat/config.yml
@@ -1,5 +1,5 @@
 #- module: zookeeper
   #metricsets: ["mntr"]
   #enabled: true
-  #period: 5s
+  #period: 10s
   #hosts: ["localhost:2181"]

--- a/metricbeat/scripts/config_collector.py
+++ b/metricbeat/scripts/config_collector.py
@@ -45,8 +45,14 @@ def collect(beat_path, full=False):
     else:
         config_yml = header_short
 
-    # Iterate over all modules
+    # Read the modules list but put "system" first
+    modules = ["system"]
     for module in os.listdir(base_dir):
+        if module != "system":
+            modules.append(module)
+
+    # Iterate over all modules
+    for module in modules:
 
         beat_path = path + "/" + module + "/_beat"
 


### PR DESCRIPTION
So that Metricbeat (default) == Topbeat

Also changed the default interval to 10s. The other modules are
left commented out in the full config and removed completely from the short configs.