### PR TITLE
Updated the release notes to mark the Topbeat replacement

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -85,18 +85,13 @@ https://github.com/elastic/beats/compare/v5.0.0alpha2...v5.0.0-alpha3[View commi
 
 *Topbeat*
 
-- Export CPU stats per core in type=core documents instead of type=system documents. {pull}1705[1705]
-- Export CPU usage in percentage and optionally the values in ticks if `cpu_ticks` option is enabled. {pull}1705[1705]
+- Topbeat is replaced by Metricbeat.
 
 *Filebeat*
 
 - The state for files which fall under ignore_older is not stored anymore. This has the consequence, that if a file which fell under ignore_older is updated, the whole file will be crawled.
 
 ==== Bugfixes
-
-*Topbeat*
-
-- Fixed high CPU usage when using filtering under Windows. {pull}1562[1562]
 
 *Winlogbeat*
 
@@ -110,7 +105,7 @@ https://github.com/elastic/beats/compare/v5.0.0alpha2...v5.0.0-alpha3[View commi
 
 *Metricbeat*
 
-- First public release, containing the following modules: apache, mysql, nginx, redis, system and zookeeper
+- First public release, containing the following modules: apache, mysql, nginx, redis, system, and zookeeper.
 
 *Filebeat*
 


### PR DESCRIPTION
Some of the fixes that went into Topbeat are benefiting Metricbeat,
but with Metricbeat being new, it had no bugs before :)