### PR TITLE
Stop following symlinks.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -22,6 +22,8 @@ https://github.com/elastic/beats/compare/v5.0.0-alpha3...master[Check the HEAD d
 
 *Filebeat*
 
+- Stop following symlink. Symlinks are now ignored: {pull}1686[1686]
+
 *Winlogbeat*
 
 
@@ -79,7 +81,7 @@ https://github.com/elastic/beats/compare/v5.0.0alpha2...v5.0.0-alpha3[View commi
 *Affecting all Beats*
 
 - All configuration settings under `shipper:` are moved to be top level configuration settings. I.e.
-  `shipper.name:` becomes `name:` in the configuration file. #1570
+  `shipper.name:` becomes `name:` in the configuration file. {pull}1570[1570]
 
 *Packetbeat*
 

--- a/filebeat/crawler/prospector_log.go
+++ b/filebeat/crawler/prospector_log.go
@@ -78,12 +78,12 @@ func (p *ProspectorLog) getFiles() map[string]os.FileInfo {
 				continue
 			}
 
-			// Stat the file, following any symlinks.
 			fileinfo, err := os.Lstat(file)
 			if err != nil {
 				logp.Debug("prospector", "stat(%s) failed: %s", file, err)
 				continue
 			}
+			// Check if file is symlink
 			if fileinfo.Mode()&os.ModeSymlink != 0 {
 				logp.Debug("prospector", "File %s skipped as it is a symlink.", file)
 				continue

--- a/filebeat/crawler/prospector_log.go
+++ b/filebeat/crawler/prospector_log.go
@@ -79,9 +79,13 @@ func (p *ProspectorLog) getFiles() map[string]os.FileInfo {
 			}
 
 			// Stat the file, following any symlinks.
-			fileinfo, err := os.Stat(file)
+			fileinfo, err := os.Lstat(file)
 			if err != nil {
 				logp.Debug("prospector", "stat(%s) failed: %s", file, err)
+				continue
+			}
+			if fileinfo.Mode()&os.ModeSymlink != 0 {
+				logp.Debug("prospector", "File %s skipped as it is a symlink.", file)
 				continue
 			}
 

--- a/filebeat/tests/system/test_prospector.py
+++ b/filebeat/tests/system/test_prospector.py
@@ -531,7 +531,11 @@ class Test(BaseTest):
         with open(testfile, 'a') as file:
             file.write("Hello world\n")
 
-        os.symlink(testfile, symlink_file)
+        if os.name == "nt":
+            import win32file
+            win32file.CreateSymbolicLink(testfile, symlink_file, 1)
+        else:
+            os.symlink(testfile, symlink_file)
 
         filebeat = self.start_beat()
 

--- a/filebeat/tests/system/test_prospector.py
+++ b/filebeat/tests/system/test_prospector.py
@@ -533,7 +533,7 @@ class Test(BaseTest):
 
         if os.name == "nt":
             import win32file
-            win32file.CreateSymbolicLink(testfile, symlink_file, 1)
+            win32file.CreateSymbolicLink(symlink_file, testfile, 1)
         else:
             os.symlink(testfile, symlink_file)
 

--- a/filebeat/tests/system/test_prospector.py
+++ b/filebeat/tests/system/test_prospector.py
@@ -533,7 +533,7 @@ class Test(BaseTest):
 
         if os.name == "nt":
             import win32file
-            win32file.CreateSymbolicLink(symlink_file, testfile, 1)
+            win32file.CreateSymbolicLink(symlink_file, testfile, 0)
         else:
             os.symlink(testfile, symlink_file)
 

--- a/filebeat/tests/system/test_prospector.py
+++ b/filebeat/tests/system/test_prospector.py
@@ -514,3 +514,41 @@ class Test(BaseTest):
                 max_timeout=10)
 
         filebeat.check_kill_and_wait()
+
+    def test_skip_symlinks(self):
+        """
+        Test that symlinks are skipped
+        """
+        self.render_config_template(
+            path=os.path.abspath(self.working_dir) + "/log/*",
+        )
+
+        os.mkdir(self.working_dir + "/log/")
+        testfile = self.working_dir + "/log/test-2016.log"
+        symlink_file = self.working_dir + "/log/test.log"
+
+        # write first line
+        with open(testfile, 'a') as file:
+            file.write("Hello world\n")
+
+        os.symlink(testfile, symlink_file)
+
+        filebeat = self.start_beat()
+
+        # wait for file to be skipped
+        self.wait_until(
+            lambda: self.log_contains("skipped as it is a symlink"),
+            max_timeout=10)
+
+        # wait for log to be read
+        self.wait_until(
+            lambda: self.output_has(lines=1),
+            max_timeout=15)
+
+        time.sleep(5)
+        filebeat.check_kill_and_wait()
+
+        data = self.read_output()
+
+        # Make sure there is only one entry, means it didn't follow the symlink
+        assert len(data) == 1


### PR DESCRIPTION
Previously symlinks were followed. This had the consequence if a symlink and the file itself existed, the file was read twice. Now symlinks are not followed anymore.

This closes #1686