### PR TITLE
Fix 'print' and 'file' for python 3.5 scripts in libbeat

### DIFF
--- a/libbeat/scripts/generate_fields_docs.py
+++ b/libbeat/scripts/generate_fields_docs.py
@@ -76,7 +76,7 @@ grouped in the following categories:
 
     # fields file is empty
     if docs is None:
-        print "fields.yml file is empty. fields.asciidoc cannot be generated."
+        print("fields.yml file is empty. fields.asciidoc cannot be generated.")
         return
 
     # Create sections from available fields
@@ -111,11 +111,11 @@ if __name__ == "__main__":
     es_beats = args.es_beats
 
     # Read fields.yml
-    with file(beat_path + "/etc/fields.yml") as f:
+    with open(beat_path + "/etc/fields.yml") as f:
         fields = f.read()
 
     # Prepends beat fields from libbeat
-    with file(es_beats + "/libbeat/_beat/fields.yml") as f:
+    with open(es_beats + "/libbeat/_beat/fields.yml") as f:
         fields = f.read() + fields
 
     output = open(beat_path + "/docs/fields.asciidoc", 'w')

--- a/libbeat/scripts/generate_template.py
+++ b/libbeat/scripts/generate_template.py
@@ -26,7 +26,7 @@ def fields_to_es_template(args, input, output, index):
 
     # No fields defined, can't generate template
     if docs is None:
-        print "fields.yml is empty. Cannot generate template."
+        print("fields.yml is empty. Cannot generate template.")
         return
 
     # Each template needs defaults
@@ -272,7 +272,7 @@ if __name__ == "__main__":
         fields = f.read()
 
         # Prepend beat fields from libbeat
-        with file(args.es_beats + "/libbeat/_beat/fields.yml") as f:
+        with open(args.es_beats + "/libbeat/_beat/fields.yml") as f:
             fields = f.read() + fields
 
         with open(target, 'w') as output:


### PR DESCRIPTION
This PR fixes (in my case) issues with python scripts. I was unable to run 'make update' unless I fixed scripts the way as in commit. Environment created in my beat was with python3.5.
Is this a valid fix?