### PR TITLE
Remove trailing slash from apache/nginx configs

### DIFF
--- a/metricbeat/docs/modules/apache.asciidoc
+++ b/metricbeat/docs/modules/apache.asciidoc
@@ -30,7 +30,7 @@ metricbeat.modules:
   period: 10s
 
   # Apache hosts
-  hosts: ["http://127.0.0.1/"]
+  hosts: ["http://127.0.0.1"]
 ----
 
 [float]

--- a/metricbeat/docs/modules/nginx.asciidoc
+++ b/metricbeat/docs/modules/nginx.asciidoc
@@ -30,7 +30,7 @@ metricbeat.modules:
   period: 10s
 
   # Nginx hosts
-  hosts: ["http://127.0.0.1/"]
+  hosts: ["http://127.0.0.1"]
 ----
 
 [float]

--- a/metricbeat/etc/beat.full.yml
+++ b/metricbeat/etc/beat.full.yml
@@ -50,7 +50,7 @@ metricbeat.modules:
   #period: 10s
 
   # Apache hosts
-  #hosts: ["http://127.0.0.1/"]
+  #hosts: ["http://127.0.0.1"]
 
   # Path to server status. Default server-status
   #server_status_path: "server-status"
@@ -84,7 +84,7 @@ metricbeat.modules:
   #period: 10s
 
   # Nginx hosts
-  #hosts: ["http://127.0.0.1/"]
+  #hosts: ["http://127.0.0.1"]
 
   # Path to server status. Default server-status
   #server_status_path: "server-status"

--- a/metricbeat/metricbeat.full.yml
+++ b/metricbeat/metricbeat.full.yml
@@ -50,7 +50,7 @@ metricbeat.modules:
   #period: 10s
 
   # Apache hosts
-  #hosts: ["http://127.0.0.1/"]
+  #hosts: ["http://127.0.0.1"]
 
   # Path to server status. Default server-status
   #server_status_path: "server-status"
@@ -84,7 +84,7 @@ metricbeat.modules:
   #period: 10s
 
   # Nginx hosts
-  #hosts: ["http://127.0.0.1/"]
+  #hosts: ["http://127.0.0.1"]
 
   # Path to server status. Default server-status
   #server_status_path: "server-status"

--- a/metricbeat/module/apache/_beat/config.full.yml
+++ b/metricbeat/module/apache/_beat/config.full.yml
@@ -4,7 +4,7 @@
   #period: 10s
 
   # Apache hosts
-  #hosts: ["http://127.0.0.1/"]
+  #hosts: ["http://127.0.0.1"]
 
   # Path to server status. Default server-status
   #server_status_path: "server-status"

--- a/metricbeat/module/apache/_beat/config.yml
+++ b/metricbeat/module/apache/_beat/config.yml
@@ -4,4 +4,4 @@
   period: 10s
 
   # Apache hosts
-  hosts: ["http://127.0.0.1/"]
+  hosts: ["http://127.0.0.1"]

--- a/metricbeat/module/nginx/_beat/config.full.yml
+++ b/metricbeat/module/nginx/_beat/config.full.yml
@@ -4,7 +4,7 @@
   #period: 10s
 
   # Nginx hosts
-  #hosts: ["http://127.0.0.1/"]
+  #hosts: ["http://127.0.0.1"]
 
   # Path to server status. Default server-status
   #server_status_path: "server-status"

--- a/metricbeat/module/nginx/_beat/config.yml
+++ b/metricbeat/module/nginx/_beat/config.yml
@@ -4,4 +4,4 @@
   period: 10s
 
   # Nginx hosts
-  hosts: ["http://127.0.0.1/"]
+  hosts: ["http://127.0.0.1"]


### PR DESCRIPTION
The issue with the trailing slash is that the code considers that
a "path", so the real path is ignored when configured.

Fixes #1779.