### PR TITLE
Add generation script for packer files

### DIFF
--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -288,3 +288,7 @@ install-home:
 	fi
 	install -d -m 755 ${HOME_PREFIX}/scripts/
 	install -m 755 ${ES_BEATS}/libbeat/scripts/migrate_beat_config_1_x_to_5_0.py ${HOME_PREFIX}/scripts/
+
+.PHONY: create-packer
+create-packer:
+	python ${ES_BEATS}/libbeat/scripts/create_packer.py --es_beats=${ES_BEATS} --beat_path=${BEAT_DIR} --beat=${BEATNAME}

--- a/libbeat/scripts/create_packer.py
+++ b/libbeat/scripts/create_packer.py
@@ -1,0 +1,71 @@
+import os
+import argparse
+
+# Creates a new metricset with all the necessary file
+# In case the module does not exist, also the module is created
+
+
+def generate_packer(es_beats, abs_path, beat, beat_path, version):
+
+    # create dev-tools/packer
+    packer_path = abs_path + "/dev-tools/packer"
+
+    print packer_path
+
+    if os.path.isdir(packer_path):
+        print "Dev tools already exists. Stopping..."
+        return
+
+    # create all directories needed
+    os.makedirs(packer_path + "/beats")
+
+    templates = es_beats + "/libbeat/scripts/dev-tools/packer"
+
+    content = load_file(templates + "/version.yml", beat, beat_path, version)
+    with open(packer_path + "/version.yml", "w") as f:
+        f.write(content)
+
+
+    content = load_file(templates + "/Makefile", beat, beat_path, version)
+    with open(packer_path + "/Makefile", "w") as f:
+        f.write(content)
+
+
+    content = load_file(templates + "/config.yml", beat, beat_path, version)
+    with open(packer_path + "/beats/" + beat + ".yml", "w") as f:
+        f.write(content)
+
+    print "Packer directories created"
+
+
+def load_file(file, beat, beat_path, version):
+    content = ""
+    with open(file) as f:
+        content = f.read()
+
+    return content.replace("{beat}", beat).replace("{beat_path}", beat_path).replace("{version}", version)
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(description="Creates the beats packer structure")
+    parser.add_argument("--beat", help="Beat name", default="test")
+    parser.add_argument("--beat_path", help="Beat path", default="./")
+    parser.add_argument("--es_beats", help="Beat path", default="../")
+    parser.add_argument("--version", help="Beat version", default="0.1.0")
+
+    args = parser.parse_args()
+
+    # Fetches GOPATH and current execution directory. It is expected to run this script from the Makefile.
+    gopath = os.environ['GOPATH']
+    # Normalise go path
+    gopath = os.path.abspath(gopath)
+    abs_path = os.path.abspath("./")
+
+    # Removes the gopath + /src/ from the directory name to fetch the path
+    beat_path = abs_path[len(gopath)+5:]
+
+    print beat_path
+    print abs_path
+
+    es_beats = os.path.abspath(args.es_beats)
+    generate_packer(es_beats, abs_path, args.beat, beat_path, args.version)

--- a/libbeat/scripts/create_packer.py
+++ b/libbeat/scripts/create_packer.py
@@ -1,9 +1,7 @@
 import os
 import argparse
 
-# Creates a new metricset with all the necessary file
-# In case the module does not exist, also the module is created
-
+# Adds dev-tools/packer directory with the necessary files to a beat
 
 def generate_packer(es_beats, abs_path, beat, beat_path, version):
 

--- a/libbeat/scripts/dev-tools/README.md
+++ b/libbeat/scripts/dev-tools/README.md
@@ -1,0 +1,1 @@
+These are the template files for dev-tools which are used by `make packer`.

--- a/libbeat/scripts/dev-tools/packer/Makefile
+++ b/libbeat/scripts/dev-tools/packer/Makefile
@@ -1,0 +1,34 @@
+BUILDID=$(shell git rev-parse HEAD)
+
+.PHONY: all
+all: {beat}/deb {beat}/rpm {beat}/darwin {beat}/win {beat}/bin \
+	build/upload/build_id.txt
+
+ES_BEATS=../../vendor/github.com/elastic/beats
+include $(ES_BEATS)/dev-tools/packer/scripts/Makefile
+
+
+.PHONY: {beat}
+{beat}: build/upload
+	# cross compile on ubuntu
+	docker run --rm \
+		-v $(abspath build):/build \
+		-v $(abspath $(ES_BEATS)/dev-tools/packer/xgo-scripts):/scripts \
+		-v $(abspath ../..):/source \
+		-e PACK=$@ \
+		-e BEFORE_BUILD=before_build.sh \
+		-e SOURCE=/source \
+		-e BUILDID=${BUILDID} \
+		tudorg/beats-builder \
+		{beat_path}//{beat}
+	# linux builds on debian 6
+	docker run --rm \
+		-v $(abspath build):/build \
+		-v $(abspath $(ES_BEATS)/dev-tools/packer/xgo-scripts):/scripts \
+		-v $(abspath ../..):/source \
+		-e PACK=$@ \
+		-e BEFORE_BUILD=before_build.sh \
+		-e SOURCE=/source \
+		-e BUILDID=${BUILDID} \
+		tudorg/beats-builder-deb6 \
+		{beat_path}//{beat}

--- a/libbeat/scripts/dev-tools/packer/config.yml
+++ b/libbeat/scripts/dev-tools/packer/config.yml
@@ -1,0 +1,4 @@
+beat_name: {beat}
+beat_url: 'https://{beat_path}'
+beat_repo: '{beat_path}'
+beat_description: Sends {beat} metrics to Logstash or directly to Elasticsearch.

--- a/libbeat/scripts/dev-tools/packer/version.yml
+++ b/libbeat/scripts/dev-tools/packer/version.yml
@@ -1,0 +1,1 @@
+version: "{version}"


### PR DESCRIPTION
These script can be used in all community beats to generate the dev-tools folder with the docker files. This allows to also use these scripts in the generator in a second step. This simplifies getting started with a beat (less files) but still offers all the possibilities. In addition, it allows us to update / improve these files over time and external beats can fetch the updates again through overwriting if needed.

Dev-tools folder will be removed from the templates after this PR and https://github.com/elastic/beats/pull/1799 are merged.