### PR TITLE
Output IO counters

### DIFF
--- a/libbeat/outputs/elasticsearch/api_mock_test.go
+++ b/libbeat/outputs/elasticsearch/api_mock_test.go
@@ -50,7 +50,7 @@ func TestOneHostSuccessResp(t *testing.T) {
 
 	server := ElasticsearchMock(200, expectedResp)
 
-	client := NewClient(server.URL, "", nil, nil, "", "", nil, nil)
+	client := newTestClient(server.URL)
 
 	params := map[string]string{
 		"refresh": "true",
@@ -79,7 +79,7 @@ func TestOneHost500Resp(t *testing.T) {
 
 	server := ElasticsearchMock(http.StatusInternalServerError, []byte("Something wrong happened"))
 
-	client := NewClient(server.URL, "", nil, nil, "", "", nil, nil)
+	client := newTestClient(server.URL)
 	err := client.Connect(1 * time.Second)
 	if err != nil {
 		t.Fatalf("Failed to connect: %v", err)
@@ -114,7 +114,7 @@ func TestOneHost503Resp(t *testing.T) {
 
 	server := ElasticsearchMock(503, []byte("Something wrong happened"))
 
-	client := NewClient(server.URL, "", nil, nil, "", "", nil, nil)
+	client := newTestClient(server.URL)
 
 	params := map[string]string{
 		"refresh": "true",

--- a/libbeat/outputs/elasticsearch/api_test.go
+++ b/libbeat/outputs/elasticsearch/api_test.go
@@ -4,6 +4,7 @@ package elasticsearch
 import (
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -36,7 +37,7 @@ func GetTestingElasticsearch() *Client {
 	var address = "http://" + GetEsHost() + ":" + GetEsPort()
 	username := os.Getenv("ES_USER")
 	pass := os.Getenv("ES_PASS")
-	return NewClient(address, "", nil, nil, username, pass, nil, nil)
+	return newTestClientAuth(address, username, pass)
 }
 
 func GetValidQueryResult() QueryResult {
@@ -161,4 +162,12 @@ func TestReadSearchResult_invalid(t *testing.T) {
 	results, err := readSearchResult(json)
 	assert.Nil(t, results)
 	assert.Error(t, err)
+}
+
+func newTestClient(url string) *Client {
+	return newTestClientAuth(url, "", "")
+}
+
+func newTestClientAuth(url, user, pass string) *Client {
+	return NewClient(url, "", nil, nil, user, pass, nil, 60*time.Second, nil)
 }

--- a/libbeat/outputs/elasticsearch/bulkapi_mock_test.go
+++ b/libbeat/outputs/elasticsearch/bulkapi_mock_test.go
@@ -42,7 +42,7 @@ func TestOneHostSuccessResp_Bulk(t *testing.T) {
 
 	server := ElasticsearchMock(200, expectedResp)
 
-	client := NewClient(server.URL, "", nil, nil, "", "", nil, nil)
+	client := newTestClient(server.URL)
 
 	params := map[string]string{
 		"refresh": "true",
@@ -83,7 +83,7 @@ func TestOneHost500Resp_Bulk(t *testing.T) {
 
 	server := ElasticsearchMock(http.StatusInternalServerError, []byte("Something wrong happened"))
 
-	client := NewClient(server.URL, "", nil, nil, "", "", nil, nil)
+	client := newTestClient(server.URL)
 
 	params := map[string]string{
 		"refresh": "true",
@@ -125,7 +125,7 @@ func TestOneHost503Resp_Bulk(t *testing.T) {
 
 	server := ElasticsearchMock(503, []byte("Something wrong happened"))
 
-	client := NewClient(server.URL, "", nil, nil, "", "", nil, nil)
+	client := newTestClient(server.URL)
 
 	params := map[string]string{
 		"refresh": "true",

--- a/libbeat/outputs/elasticsearch/output.go
+++ b/libbeat/outputs/elasticsearch/output.go
@@ -216,7 +216,7 @@ func makeClientFactory(
 		client := NewClient(
 			esURL, config.Index, proxyURL, tls,
 			config.Username, config.Password,
-			params, onConnected)
+			params, config.Timeout, onConnected)
 		return client, nil
 	}
 }

--- a/libbeat/outputs/logstash/logstash.go
+++ b/libbeat/outputs/logstash/logstash.go
@@ -4,6 +4,7 @@ package logstash
 // registered with all output plugins
 
 import (
+	"expvar"
 	"time"
 
 	"github.com/urso/go-lumber/log"
@@ -18,6 +19,18 @@ import (
 )
 
 var debug = logp.MakeDebug("logstash")
+
+// Metrics that can retrieved through the expvar web interface.
+var (
+	ackedEvents            = expvar.NewInt("libbeatLogstashPublishedAndAckedEvents")
+	eventsNotAcked         = expvar.NewInt("libbeatLogstashPublishedButNotAckedEvents")
+	publishEventsCallCount = expvar.NewInt("libbeatLogstashPublishEventsCallCount")
+
+	statReadBytes   = expvar.NewInt("libbeatLogstashPublishReadBytes")
+	statWriteBytes  = expvar.NewInt("libbeatLogstashPublishWriteBytes")
+	statReadErrors  = expvar.NewInt("libbeatLogstashPublishReadErrors")
+	statWriteErrors = expvar.NewInt("libbeatLogstashPublishWriteErrors")
+)
 
 const (
 	defaultWaitRetry = 1 * time.Second
@@ -67,6 +80,12 @@ func (lj *logstash) init(cfg *common.Config) error {
 		Timeout: config.Timeout,
 		Proxy:   &config.Proxy,
 		TLS:     tls,
+		Stats: &transport.IOStats{
+			Read:        statReadBytes,
+			Write:       statWriteBytes,
+			ReadErrors:  statReadErrors,
+			WriteErrors: statWriteErrors,
+		},
 	}
 
 	logp.Info("Max Retries set to: %v", sendRetries)

--- a/libbeat/outputs/logstash/logstash_integration_test.go
+++ b/libbeat/outputs/logstash/logstash_integration_test.go
@@ -73,7 +73,8 @@ func esConnect(t *testing.T, index string) *esConnection {
 
 	username := os.Getenv("ES_USER")
 	password := os.Getenv("ES_PASS")
-	client := elasticsearch.NewClient(host, "", nil, nil, username, password, nil, nil)
+	client := elasticsearch.NewClient(host, "", nil, nil, username, password,
+		nil, 60*time.Second, nil)
 
 	// try to drop old index if left over from failed test
 	_, _, _ = client.Delete(index, "", "", nil) // ignore error

--- a/libbeat/outputs/logstash/sync.go
+++ b/libbeat/outputs/logstash/sync.go
@@ -1,7 +1,6 @@
 package logstash
 
 import (
-	"expvar"
 	"time"
 
 	"github.com/urso/go-lumber/client/v2"
@@ -9,13 +8,6 @@ import (
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/outputs/transport"
-)
-
-// Metrics that can retrieved through the expvar web interface.
-var (
-	ackedEvents            = expvar.NewInt("libbeatLogstashPublishedAndAckedEvents")
-	eventsNotAcked         = expvar.NewInt("libbeatLogstashPublishedButNotAckedEvents")
-	publishEventsCallCount = expvar.NewInt("libbeatLogstashPublishEventsCallCount")
 )
 
 const (

--- a/libbeat/outputs/redis/redis.go
+++ b/libbeat/outputs/redis/redis.go
@@ -2,6 +2,7 @@ package redis
 
 import (
 	"errors"
+	"expvar"
 	"fmt"
 	"time"
 
@@ -19,8 +20,14 @@ type redisOut struct {
 	topology
 }
 
+var debugf = logp.MakeDebug("redis")
+
+// Metrics that can retrieved through the expvar web interface.
 var (
-	debugf = logp.MakeDebug("redis")
+	statReadBytes   = expvar.NewInt("libbeatRedisPublishReadBytes")
+	statWriteBytes  = expvar.NewInt("libbeatRedisPublishWriteBytes")
+	statReadErrors  = expvar.NewInt("libbeatRedisPublishReadErrors")
+	statWriteErrors = expvar.NewInt("libbeatRedisPublishWriteErrors")
 )
 
 const (
@@ -76,6 +83,12 @@ func (r *redisOut) init(cfg *common.Config, expireTopo int) error {
 		Timeout: config.Timeout,
 		Proxy:   &config.Proxy,
 		TLS:     tls,
+		Stats: &transport.IOStats{
+			Read:        statReadBytes,
+			Write:       statWriteBytes,
+			ReadErrors:  statReadErrors,
+			WriteErrors: statWriteErrors,
+		},
 	}
 
 	// configure topology support

--- a/libbeat/outputs/transport/client.go
+++ b/libbeat/outputs/transport/client.go
@@ -21,6 +21,7 @@ type Config struct {
 	Proxy   *ProxyConfig
 	TLS     *tls.Config
 	Timeout time.Duration
+	Stats   *IOStats
 }
 
 func MakeDialer(c *Config) (Dialer, error) {
@@ -29,6 +30,9 @@ func MakeDialer(c *Config) (Dialer, error) {
 	dialer, err = ProxyDialer(c.Proxy, dialer)
 	if err != nil {
 		return nil, err
+	}
+	if c.Stats != nil {
+		dialer = StatsDialer(dialer, c.Stats)
 	}
 	dialer = TLSDialer(c.TLS, c.Timeout, dialer)
 	return dialer, nil

--- a/libbeat/outputs/transport/stats.go
+++ b/libbeat/outputs/transport/stats.go
@@ -1,0 +1,39 @@
+package transport
+
+import (
+	"expvar"
+	"net"
+)
+
+type IOStats struct {
+	Read, Write, ReadErrors, WriteErrors *expvar.Int
+}
+
+type statsConn struct {
+	net.Conn
+	stats *IOStats
+}
+
+func StatsDialer(d Dialer, s *IOStats) Dialer {
+	return ConnWrapper(d, func(c net.Conn) net.Conn {
+		return &statsConn{c, s}
+	})
+}
+
+func (s *statsConn) Read(b []byte) (int, error) {
+	n, err := s.Conn.Read(b)
+	if err != nil {
+		s.stats.ReadErrors.Add(1)
+	}
+	s.stats.Read.Add(int64(n))
+	return n, err
+}
+
+func (s *statsConn) Write(b []byte) (int, error) {
+	n, err := s.Conn.Write(b)
+	if err != nil {
+		s.stats.WriteErrors.Add(1)
+	}
+	s.stats.Write.Add(int64(n))
+	return n, err
+}

--- a/libbeat/outputs/transport/wrap.go
+++ b/libbeat/outputs/transport/wrap.go
@@ -1,0 +1,13 @@
+package transport
+
+import "net"
+
+func ConnWrapper(d Dialer, w func(net.Conn) net.Conn) Dialer {
+	return DialerFunc(func(network, addr string) (net.Conn, error) {
+		c, err := d.Dial(network, addr)
+		if err != nil {
+			return nil, err
+		}
+		return w(c), nil
+	})
+}


### PR DESCRIPTION
introduce counters (bytes send/received and errors) to elasticsearch, logstash
and redis outputs