### PR TITLE
packetbeat: nfs: set rpc machinename to ip address if not set

### DIFF
--- a/packetbeat/protos/nfs/request_handler.go
+++ b/packetbeat/protos/nfs/request_handler.go
@@ -76,7 +76,11 @@ func (rpc *Rpc) handleCall(xid string, xdr *Xdr, ts time.Time, tcptuple *common.
 		cred := common.MapStr{}
 		credXdr := Xdr{data: auth_opaque, offset: 0}
 		cred["stamp"] = credXdr.getUInt()
-		cred["machinename"] = credXdr.getString()
+		machine := credXdr.getString()
+		if machine == "" {
+			machine = src.Ip
+		}
+		cred["machinename"] = machine
 		cred["uid"] = credXdr.getUInt()
 		cred["gid"] = credXdr.getUInt()
 		cred["gids"] = credXdr.getUIntVector()


### PR DESCRIPTION
Some nfs client do not set machinename. As a result, visualizations
based on it will show empty value.

Set nfs client's ip address as machinename if not provided.

Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>