### PR TITLE
Switch squeeze image to use archive

### DIFF
--- a/dev-tools/packer/docker/xgo-image-deb6/base/sources.list
+++ b/dev-tools/packer/docker/xgo-image-deb6/base/sources.list
@@ -1,3 +1,2 @@
-deb http://snapshot.debian.org/archive/debian/20160229T214851Z squeeze main
-deb http://snapshot.debian.org/archive/debian/20160229T214851Z squeeze-updates main
-deb http://snapshot.debian.org/archive/debian/20160229T214851Z squeeze-lts main
+deb http://archive.debian.org/debian/ squeeze main contrib
+deb http://archive.debian.org/debian/ squeeze-lts main


### PR DESCRIPTION
It was set to use snapshots as a temporary (heh) workaround for the
time when squeeze got removed from the main repos but wasn't yet added
to the archive.