### PR TITLE
New community Beat for monitoring Logstash

### DIFF
--- a/libbeat/docs/communitybeats.asciidoc
+++ b/libbeat/docs/communitybeats.asciidoc
@@ -19,6 +19,7 @@ Logstash or Elasticsearch. Supports all HTTP methods and proxies.
 https://github.com/jasperla/hwsensorsbeat[hwsensorsbeat]:: Reads sensors information from OpenBSD.
 https://github.com/radoondas/jmxproxybeat[jmxproxybeat]:: Reads Tomcat JMX metrics exposed over 'JMX Proxy Servlet' to HTTP.
 https://github.com/eskibars/lmsensorsbeat[lmsensorsbeat]:: Collects data from lm-sensors (such as CPU temperatures, fan speeds, and voltages from i2c and smbus)
+https://github.com/consulthys/logstashbeat[logstashbeat]:: Collects data from Logstash monitoring API (v5 onwards) and indexes them in Elasticsearch
 https://github.com/adibendahan/mysqlbeat[mysqlbeat]:: Run any query on MySQL and send results to Elasticsearch.
 https://github.com/PhaedrusTheGreek/nagioscheckbeat[nagioscheckbeat]:: For Nagios checks and performance data.
 https://github.com/mrkschan/nginxbeat[nginxbeat]:: Reads status from Nginx.


### PR DESCRIPTION
Since Logstash 5 now provides a [monitoring API](https://www.elastic.co/guide/en/logstash/5.0/stats-info-api.html), I've created a new community beat called `logstashbeat` that will gather stats (`events`, `jvm` and `process`) from a running Logstash instance and ship them to Elasticsearch.

`process` stat:
```
{
  "@timestamp": "2016-06-09T10:56:27.534Z",
  "beat": {
    "hostname": "iMac.local",
    "name": "iMac.local"
  },
  "counter": 3,
  "process": {
    "cpu": {
      "percent": 0,
      "total_in_millis": 44377821000
    },
    "max_file_descriptors": 10240,
    "mem": {
      "total_virtual_in_bytes": 5193240576
    },
    "open_file_descriptors": 59,
    "peak_open_file_descriptors": 64
  },
  "type": "process"
}
```

`events` stat:
```
{
  "@timestamp": "2016-06-09T10:56:27.534Z",
  "beat": {
    "hostname": "iMac.local",
    "name": "iMac.local"
  },
  "counter": 3,
  "events": {
    "filtered": 10,
    "in": 10,
    "out": 10
  },
  "type": "process"
}
```

`jvm` stat:
```
{
  "@timestamp": "2016-06-09T10:56:27.534Z",
  "beat": {
    "hostname": "iMac.local",
    "name": "iMac.local"
  },
  "counter": 3,
  "jvm": {
    "threads": {
      "count": 21,
      "peak_count": 23
    }
  },
  "type": "process"
}
```