### PR TITLE
Backport: Initialize random number generator seed.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -27,6 +27,13 @@ https://github.com/elastic/beats/compare/v1.2.3...1.2[Check the HEAD diff]
 
 *Affecting all Beats*
 
+- Drain response buffers when pipelining is used by redis output. {pull}1353[1353]
+- Unterminated environment variable expressions in config files will now cause an error {pull}1389[1389]
+- Fix issue with the automatic template loading when Elasticsearch is not available on Beat start. {issue}1321[1321]
+- Fix bug affecting -cpuprofile, -memprofile, and -httpprof CLI flags {pull}1415[1415]
+- Fix race when multiple outputs access the same event with logstash output manipulating event {issue}1410[1410] {pull}1428[1428]
+- Seed random number generator using crypto.rand package. {pull}1503{1503]
+
 *Packetbeat*
 
 *Topbeat*

--- a/libbeat/beat/beat.go
+++ b/libbeat/beat/beat.go
@@ -1,10 +1,15 @@
 package beat
 
 import (
+	cryptRand "crypto/rand"
 	"flag"
 	"fmt"
+	"math"
+	"math/big"
+	"math/rand"
 	"os"
 	"runtime"
+	"time"
 
 	"github.com/elastic/beats/libbeat/cfgfile"
 	"github.com/elastic/beats/libbeat/logp"
@@ -51,6 +56,22 @@ var printVersion *bool
 
 func init() {
 	printVersion = flag.Bool("version", false, "Print version and exit")
+
+	// Initialize runtime random number generator seed using global, shared
+	// cryptographically strong pseudo random number generator.
+	//
+	// On linux Reader might use getrandom(2) or /udev/random. On windows systems
+	// CryptGenRandom is used.
+	n, err := cryptRand.Int(cryptRand.Reader, big.NewInt(math.MaxInt64))
+	var seed int64
+	if err != nil {
+		// fallback to current timestamp on error
+		seed = time.Now().UnixNano()
+	} else {
+		seed = n.Int64()
+	}
+
+	rand.Seed(seed)
 }
 
 // Initiates a new beat object


### PR DESCRIPTION
Initialize random number generator using cryptographic seed read from OS. Fixes
issues with random number generator always returning same sequence, e.g. when
using random endpoint connecting to logstash in failover mode.