### PR TITLE
Fix logstash default bulk max size

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -27,6 +27,7 @@ https://github.com/elastic/beats/compare/v1.2.3...1.3[Check the HEAD diff]
 
 *Affecting all Beats*
 - Fix output modes backoff counter reset. {issue}1803[1803] {pull}1814[1814] {pull}1818[1818]
+- Set logstash output default bulk_max_size to 2048. {issue}1662[1662]
 
 *Packetbeat*
 

--- a/filebeat/etc/filebeat.yml
+++ b/filebeat/etc/filebeat.yml
@@ -282,6 +282,10 @@ output:
     # Number of workers per Logstash host.
     #worker: 1
 
+    # The maximum number of events to bulk into a single batch window. The
+    # default is 2048.
+    #bulk_max_size: 2048
+
     # Set gzip compression level.
     #compression_level: 3
 

--- a/libbeat/etc/libbeat.yml
+++ b/libbeat/etc/libbeat.yml
@@ -111,6 +111,10 @@ output:
     # Number of workers per Logstash host.
     #worker: 1
 
+    # The maximum number of events to bulk into a single batch window. The
+    # default is 2048.
+    #bulk_max_size: 2048
+
     # Set gzip compression level.
     #compression_level: 3
 

--- a/libbeat/outputs/logstash/logstash.go
+++ b/libbeat/outputs/logstash/logstash.go
@@ -44,7 +44,7 @@ const (
 	logstashDefaultTimeout   = 30 * time.Second
 	logstasDefaultMaxTimeout = 90 * time.Second
 	defaultSendRetries       = 3
-	defaultMaxWindowSize     = 1024
+	defaultMaxWindowSize     = 2048
 	defaultCompressionLevel  = 3
 )
 

--- a/packetbeat/etc/packetbeat.yml
+++ b/packetbeat/etc/packetbeat.yml
@@ -250,6 +250,10 @@ output:
     # Number of workers per Logstash host.
     #worker: 1
 
+    # The maximum number of events to bulk into a single batch window. The
+    # default is 2048.
+    #bulk_max_size: 2048
+
     # Set gzip compression level.
     #compression_level: 3
 

--- a/topbeat/etc/topbeat.yml
+++ b/topbeat/etc/topbeat.yml
@@ -137,6 +137,10 @@ output:
     # Number of workers per Logstash host.
     #worker: 1
 
+    # The maximum number of events to bulk into a single batch window. The
+    # default is 2048.
+    #bulk_max_size: 2048
+
     # Set gzip compression level.
     #compression_level: 3
 

--- a/winlogbeat/etc/winlogbeat.yml
+++ b/winlogbeat/etc/winlogbeat.yml
@@ -136,6 +136,10 @@ output:
     # Number of workers per Logstash host.
     #worker: 1
 
+    # The maximum number of events to bulk into a single batch window. The
+    # default is 2048.
+    #bulk_max_size: 2048
+
     # Set gzip compression level.
     #compression_level: 3
 


### PR DESCRIPTION
Resolves #1662 