### PR TITLE
filebeat: Add failing tests for @timestamps in JSON with timezone specified

### DIFF
--- a/filebeat/tests/files/logs/json_timestamp.log
+++ b/filebeat/tests/files/logs/json_timestamp.log
@@ -1,3 +1,5 @@
-{"@timestamp":"2016-04-05T18:47:18.444Z","level":"INFO","logger":"iapi.logger","thread":"JobCourier4","appInfo":{"appname":"SessionManager","appid":"Pooler","host":"demohost.mydomain.com","ip":"192.168.128.113","pid":13982},"userFields":{"ApplicationId":"PROFAPP_001","RequestTrackingId":"RetrieveTBProfileToken-6066477"},"source":"DataAccess\/FetchActiveSessionToken.process","msg":"FetchActiveSessionToken process ended"}
-{"@timestamp":"invalid","level":"INFO","logger":"iapi.logger","thread":"JobCourier4","appInfo":{"appname":"SessionManager","appid":"Pooler","host":"demohost.mydomain.com","ip":"192.168.128.113","pid":13982},"userFields":{"ApplicationId":"PROFAPP_001","RequestTrackingId":"RetrieveTBProfileToken-6066477"},"source":"DataAccess\/FetchActiveSessionToken.process","msg":"FetchActiveSessionToken process ended"}
-{"@timestamp":{"hello": "test"},"level":"INFO","logger":"iapi.logger","thread":"JobCourier4","appInfo":{"appname":"SessionManager","appid":"Pooler","host":"demohost.mydomain.com","ip":"192.168.128.113","pid":13982},"userFields":{"ApplicationId":"PROFAPP_001","RequestTrackingId":"RetrieveTBProfileToken-6066477"},"source":"DataAccess\/FetchActiveSessionToken.process","msg":"FetchActiveSessionToken process ended"}
+{"@timestamp":"2016-04-05T18:47:18.444Z"}
+{"@timestamp":"invalid"}
+{"@timestamp":{"hello": "test"}}
+{"@timestamp":"2016-04-05T18:47:18.444+00:00"}
+{"@timestamp":"2016-04-05T18:47:18+00:00"}

--- a/filebeat/tests/system/test_json.py
+++ b/filebeat/tests/system/test_json.py
@@ -188,12 +188,12 @@ class Test(BaseTest):
 
         proc = self.start_beat()
         self.wait_until(
-            lambda: self.output_has(lines=3),
+            lambda: self.output_has(lines=5),
             max_timeout=10)
         proc.check_kill_and_wait()
 
         output = self.read_output()
-        assert len(output) == 3
+        assert len(output) == 5
         assert all(isinstance(o["@timestamp"], basestring) for o in output)
         assert all(isinstance(o["type"], basestring) for o in output)
         assert output[0]["@timestamp"] == "2016-04-05T18:47:18.444Z"
@@ -205,6 +205,11 @@ class Test(BaseTest):
         assert output[2]["json_error"] == \
             "@timestamp not overwritten (not string)"
 
+        assert output[3]["json_error"] is None, output[3]["json_error"]
+        assert output[3]["@timestamp"] == "2016-04-05T18:47:18.444+00:00", output[3]["@timestamp"]
+
+        assert output[4]["json_error"] is None, output[4]["json_error"]
+        assert output[4]["@timestamp"] == "2016-04-05T18:47:18+00:00", output[4]["@timestamp"]
     def test_type_in_message(self):
         """
         If overwrite_keys is true and type is in the message, we have to


### PR DESCRIPTION
filebeat is currently generating errors for timestamps with timezone specified as +00:00 ('Z' is allowed without suffix). Failing tests added.

This is the default @timestamp format used by kibana json log for example.

Seems to have been introduced here: https://github.com/elastic/beats/pull/1421/files#r60245935