### PR TITLE
Fix loadbalancer deadlock on too many retries being queued up

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -31,6 +31,7 @@ https://github.com/elastic/beats/compare/v5.0.0-alpha3...master[Check the HEAD d
 
 *Affecting all Beats*
 - Reset backoff factor on partial ACK. {issue}1803[1803]
+- Fix beats load balancer deadlock if max_retries: -1 or publish_async is enabled in filebeat. {issue}1829[1829]
 
 *Metricbeat*
 

--- a/libbeat/outputs/mode/lb/context.go
+++ b/libbeat/outputs/mode/lb/context.go
@@ -120,6 +120,15 @@ func (ctx *context) forwardEvent(ch chan eventsMessage, msg eventsMessage) bool 
 
 func (ctx *context) receive() (eventsMessage, bool) {
 	var msg eventsMessage
+
+	select {
+	case msg = <-ctx.retries: // receive message from other failed worker
+		debugf("events from retries queue")
+		return msg, true
+	default:
+		break
+	}
+
 	select {
 	case <-ctx.done:
 		return msg, false

--- a/libbeat/outputs/mode/lb/context_test.go
+++ b/libbeat/outputs/mode/lb/context_test.go
@@ -1,0 +1,68 @@
+package lb
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInfRetryNoDeadlock(t *testing.T) {
+	N := 100       // Number of events to be send
+	Fails := 1000  // Number of fails per event
+	NumWorker := 2 // Number of concurrent workers pushing events into retry queue
+
+	ctx := makeContext(1, -1, 0)
+
+	// atomic success counter incremented whenever one event didn't fail
+	// Test finishes if i==N
+	i := int32(0)
+
+	var closer sync.Once
+	worker := func(wg *sync.WaitGroup) {
+		defer wg.Done()
+
+		// close queue once done, so other workers waiting for new messages will be
+		// released
+		defer closer.Do(func() {
+			ctx.Close()
+		})
+
+		for int(atomic.LoadInt32(&i)) < N {
+			msg, open := ctx.receive()
+			if !open {
+				break
+			}
+
+			fails := msg.event["fails"].(int)
+			if fails < Fails {
+				msg.event["fails"] = fails + 1
+				ctx.pushFailed(msg)
+				continue
+			}
+
+			atomic.AddInt32(&i, 1)
+		}
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(NumWorker)
+	for w := 0; w < NumWorker; w++ {
+		go worker(&wg)
+	}
+
+	// push up to N events to workers. If workers deadlock, pushEvents will block.
+	for i := 0; i < N; i++ {
+		msg := eventsMessage{
+			worker: -1,
+			event:  common.MapStr{"fails": int(0)},
+		}
+		ok := ctx.pushEvents(msg, true)
+		assert.True(t, ok)
+	}
+
+	// wait for all workers to terminate before test timeout
+	wg.Wait()
+}


### PR DESCRIPTION
New test is able to reproduce deadlock quite often given `Fails` variable is big enough (deadlock more or less triggered by random). Has not been captured by available unit tests, due to available tests not producing enough events and errors.

Resolves #1829 