### PR TITLE
Elasticsearch output support for gzip compressed content-encoding

### DIFF
--- a/filebeat/filebeat.full.yml
+++ b/filebeat/filebeat.full.yml
@@ -286,6 +286,9 @@ output.elasticsearch:
   # IPv6 addresses should always be defined as: https://[2001:db8::1]:9200
   hosts: ["localhost:9200"]
 
+  # Set gzip compression level.
+  #compression_level: 0
+
   # Optional protocol and basic auth credentials.
   #protocol: "https"
   #username: "admin"

--- a/libbeat/_beat/config.full.yml
+++ b/libbeat/_beat/config.full.yml
@@ -83,6 +83,9 @@ output.elasticsearch:
   # IPv6 addresses should always be defined as: https://[2001:db8::1]:9200
   hosts: ["localhost:9200"]
 
+  # Set gzip compression level.
+  #compression_level: 0
+
   # Optional protocol and basic auth credentials.
   #protocol: "https"
   #username: "admin"

--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -120,6 +120,13 @@ output.elasticsearch:
 In the previous example, the Elasticsearch nodes are available at `https://10.45.3.2:9220/elasticsearch` and
 `https://10.45.3.1:9230/elasticsearch`.
 
+===== compression_level
+
+The gzip compression level. Setting this value to 0 disables compression.
+The compression level must be in the range of 1 (best speed) to 9 (best compression).
+
+The default value is 0.
+
 ===== worker
 
 The number of workers per configured host publishing events to Elasticsearch. This
@@ -363,7 +370,7 @@ is used as the default port number.
 
 ===== compression_level
 
-The gzip compression level. Setting this value to values less than or equal to 0 disables compression.
+The gzip compression level. Setting this value to 0 disables compression.
 The compression level must be in the range of 1 (best speed) to 9 (best compression).
 
 The default value is 3.

--- a/libbeat/outputs/elasticsearch/api_test.go
+++ b/libbeat/outputs/elasticsearch/api_test.go
@@ -169,5 +169,9 @@ func newTestClient(url string) *Client {
 }
 
 func newTestClientAuth(url, user, pass string) *Client {
-	return NewClient(url, "", nil, nil, user, pass, nil, 60*time.Second, nil)
+	client, err := NewClient(url, "", nil, nil, user, pass, nil, 60*time.Second, 3, nil)
+	if err != nil {
+		panic(err)
+	}
+	return client
 }

--- a/libbeat/outputs/elasticsearch/bulkapi_integration_test.go
+++ b/libbeat/outputs/elasticsearch/bulkapi_integration_test.go
@@ -102,6 +102,7 @@ func TestBulkMoreOperations(t *testing.T) {
 		{
 			"field1": "value1",
 		},
+
 		{
 			"delete": map[string]interface{}{
 				"_index": index,
@@ -109,6 +110,7 @@ func TestBulkMoreOperations(t *testing.T) {
 				"_id":    "2",
 			},
 		},
+
 		{
 			"create": map[string]interface{}{
 				"_index": index,
@@ -119,6 +121,7 @@ func TestBulkMoreOperations(t *testing.T) {
 		{
 			"field1": "value3",
 		},
+
 		{
 			"update": map[string]interface{}{
 				"_id":    "1",

--- a/libbeat/outputs/elasticsearch/client_integration_test.go
+++ b/libbeat/outputs/elasticsearch/client_integration_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"bytes"
-	"io/ioutil"
 	"path/filepath"
 
 	"github.com/elastic/beats/libbeat/common"
@@ -42,8 +40,7 @@ func TestLoadTemplate(t *testing.T) {
 	assert.Nil(t, err)
 
 	templatePath := absPath + "/template.json"
-	content, err := ioutil.ReadFile(templatePath)
-	reader := bytes.NewReader(content)
+	content, err := readTemplate(templatePath)
 	assert.Nil(t, err)
 
 	// Setup ES
@@ -54,7 +51,7 @@ func TestLoadTemplate(t *testing.T) {
 	templateName := "testbeat"
 
 	// Load template
-	err = client.LoadTemplate(templateName, reader)
+	err = client.LoadTemplate(templateName, content)
 	assert.Nil(t, err)
 
 	// Make sure template was loaded
@@ -71,7 +68,9 @@ func TestLoadTemplate(t *testing.T) {
 func TestLoadInvalidTemplate(t *testing.T) {
 
 	// Invalid Template
-	reader := bytes.NewReader([]byte("{json:invalid}"))
+	template := map[string]interface{}{
+		"json": "invalid",
+	}
 
 	// Setup ES
 	client := GetTestingElasticsearch()
@@ -81,7 +80,7 @@ func TestLoadInvalidTemplate(t *testing.T) {
 	templateName := "invalidtemplate"
 
 	// Try to load invalid template
-	err = client.LoadTemplate(templateName, reader)
+	err = client.LoadTemplate(templateName, template)
 	assert.Error(t, err)
 
 	// Make sure template was not loaded
@@ -106,8 +105,7 @@ func TestLoadBeatsTemplate(t *testing.T) {
 		assert.Nil(t, err)
 
 		templatePath := absPath + "/" + beat + ".template.json"
-		content, err := ioutil.ReadFile(templatePath)
-		reader := bytes.NewReader(content)
+		content, err := readTemplate(templatePath)
 		assert.Nil(t, err)
 
 		// Setup ES
@@ -118,7 +116,7 @@ func TestLoadBeatsTemplate(t *testing.T) {
 		templateName := beat
 
 		// Load template
-		err = client.LoadTemplate(templateName, reader)
+		err = client.LoadTemplate(templateName, content)
 		assert.Nil(t, err)
 
 		// Make sure template was loaded

--- a/libbeat/outputs/elasticsearch/config.go
+++ b/libbeat/outputs/elasticsearch/config.go
@@ -7,19 +7,20 @@ import (
 )
 
 type elasticsearchConfig struct {
-	Protocol     string             `config:"protocol"`
-	Path         string             `config:"path"`
-	Params       map[string]string  `config:"parameters"`
-	Username     string             `config:"username"`
-	Password     string             `config:"password"`
-	ProxyURL     string             `config:"proxy_url"`
-	Index        string             `config:"index"`
-	LoadBalance  bool               `config:"loadbalance"`
-	TLS          *outputs.TLSConfig `config:"tls"`
-	MaxRetries   int                `config:"max_retries"`
-	Timeout      time.Duration      `config:"timeout"`
-	SaveTopology bool               `config:"save_topology"`
-	Template     Template           `config:"template"`
+	Protocol         string             `config:"protocol"`
+	Path             string             `config:"path"`
+	Params           map[string]string  `config:"parameters"`
+	Username         string             `config:"username"`
+	Password         string             `config:"password"`
+	ProxyURL         string             `config:"proxy_url"`
+	Index            string             `config:"index"`
+	LoadBalance      bool               `config:"loadbalance"`
+	CompressionLevel int                `config:"compression_level" validate:"min=0, max=9"`
+	TLS              *outputs.TLSConfig `config:"tls"`
+	MaxRetries       int                `config:"max_retries"`
+	Timeout          time.Duration      `config:"timeout"`
+	SaveTopology     bool               `config:"save_topology"`
+	Template         Template           `config:"template"`
 }
 
 type Template struct {
@@ -34,16 +35,17 @@ const (
 
 var (
 	defaultConfig = elasticsearchConfig{
-		Protocol:    "",
-		Path:        "",
-		ProxyURL:    "",
-		Params:      nil,
-		Username:    "",
-		Password:    "",
-		Timeout:     90 * time.Second,
-		MaxRetries:  3,
-		TLS:         nil,
-		LoadBalance: true,
+		Protocol:         "",
+		Path:             "",
+		ProxyURL:         "",
+		Params:           nil,
+		Username:         "",
+		Password:         "",
+		Timeout:          90 * time.Second,
+		MaxRetries:       3,
+		CompressionLevel: 0,
+		TLS:              nil,
+		LoadBalance:      true,
 	}
 )
 

--- a/libbeat/outputs/elasticsearch/enc.go
+++ b/libbeat/outputs/elasticsearch/enc.go
@@ -1,0 +1,137 @@
+package elasticsearch
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"io"
+	"net/http"
+)
+
+type bodyEncoder interface {
+	bulkBodyEncoder
+	Reader() io.Reader
+	Marshal(doc interface{}) error
+}
+
+type bulkBodyEncoder interface {
+	bulkWriter
+
+	AddHeader(*http.Header)
+	Reset()
+}
+
+type bulkWriter interface {
+	Add(meta, obj interface{}) error
+	AddRaw(raw interface{}) error
+}
+
+type jsonEncoder struct {
+	buf *bytes.Buffer
+}
+
+type gzipEncoder struct {
+	buf  *bytes.Buffer
+	gzip *gzip.Writer
+}
+
+func newJSONEncoder(buf *bytes.Buffer) *jsonEncoder {
+	if buf == nil {
+		buf = bytes.NewBuffer(nil)
+	}
+	return &jsonEncoder{buf}
+}
+
+func (b *jsonEncoder) Reset() {
+	b.buf.Reset()
+}
+
+func (b *jsonEncoder) AddHeader(header *http.Header) {
+	header.Add("Content-Type", "application/json; charset=UTF-8")
+}
+
+func (b *jsonEncoder) Reader() io.Reader {
+	return b.buf
+}
+
+func (b *jsonEncoder) Marshal(obj interface{}) error {
+	b.Reset()
+	enc := json.NewEncoder(b.buf)
+	return enc.Encode(obj)
+}
+
+func (b *jsonEncoder) AddRaw(raw interface{}) error {
+	enc := json.NewEncoder(b.buf)
+	return enc.Encode(raw)
+}
+
+func (b *jsonEncoder) Add(meta, obj interface{}) error {
+	enc := json.NewEncoder(b.buf)
+	pos := b.buf.Len()
+
+	if err := enc.Encode(meta); err != nil {
+		b.buf.Truncate(pos)
+		return err
+	}
+	if err := enc.Encode(obj); err != nil {
+		b.buf.Truncate(pos)
+		return err
+	}
+	return nil
+}
+
+func newGzipEncoder(level int, buf *bytes.Buffer) (*gzipEncoder, error) {
+	if buf == nil {
+		buf = bytes.NewBuffer(nil)
+	}
+	w, err := gzip.NewWriterLevel(buf, level)
+	if err != nil {
+		return nil, err
+	}
+
+	return &gzipEncoder{buf, w}, nil
+}
+
+func (b *gzipEncoder) Reset() {
+	b.buf.Reset()
+	b.gzip.Reset(b.buf)
+}
+
+func (b *gzipEncoder) Reader() io.Reader {
+	b.gzip.Close()
+	return b.buf
+}
+
+func (b *gzipEncoder) AddHeader(header *http.Header) {
+	header.Add("Content-Type", "application/json; charset=UTF-8")
+	header.Add("Content-Encoding", "gzip")
+}
+
+func (b *gzipEncoder) Marshal(obj interface{}) error {
+	b.Reset()
+	enc := json.NewEncoder(b.gzip)
+	err := enc.Encode(obj)
+	return err
+}
+
+func (b *gzipEncoder) AddRaw(raw interface{}) error {
+	enc := json.NewEncoder(b.gzip)
+	return enc.Encode(raw)
+}
+
+func (b *gzipEncoder) Add(meta, obj interface{}) error {
+	enc := json.NewEncoder(b.gzip)
+	pos := b.buf.Len()
+
+	if err := enc.Encode(meta); err != nil {
+		b.buf.Truncate(pos)
+		return err
+	}
+	if err := enc.Encode(obj); err != nil {
+		b.buf.Truncate(pos)
+		return err
+	}
+
+	b.gzip.Flush()
+	return nil
+}

--- a/libbeat/outputs/elasticsearch/output.go
+++ b/libbeat/outputs/elasticsearch/output.go
@@ -1,12 +1,12 @@
 package elasticsearch
 
 import (
-	"bytes"
 	"crypto/tls"
+	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/url"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -25,8 +25,8 @@ type elasticsearchOutput struct {
 	mode  mode.ConnectionMode
 	topology
 
-	templateContents []byte
-	templateMutex    sync.Mutex
+	template      map[string]interface{}
+	templateMutex sync.Mutex
 }
 
 func init() {
@@ -34,7 +34,7 @@ func init() {
 }
 
 var (
-	debug = logp.MakeDebug("elasticsearch")
+	debugf = logp.MakeDebug("elasticsearch")
 )
 
 var (
@@ -140,13 +140,31 @@ func (out *elasticsearchOutput) readTemplate(config Template) error {
 
 		logp.Info("Loading template enabled. Reading template file: %v", templatePath)
 
-		var err error
-		out.templateContents, err = ioutil.ReadFile(templatePath)
+		template, err := readTemplate(templatePath)
 		if err != nil {
 			return fmt.Errorf("Error loading template %s: %v", templatePath, err)
 		}
+
+		out.template = template
 	}
 	return nil
+}
+
+func readTemplate(filename string) (map[string]interface{}, error) {
+	f, err := os.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	var template map[string]interface{}
+	dec := json.NewDecoder(f)
+	err = dec.Decode(&template)
+	if err != nil {
+		return nil, err
+	}
+
+	return template, nil
 }
 
 // loadTemplate checks if the index mapping template should be loaded
@@ -166,8 +184,7 @@ func (out *elasticsearchOutput) loadTemplate(config Template, client *Client) er
 			logp.Info("Existing template will be overwritten, as overwrite is enabled.")
 		}
 
-		reader := bytes.NewReader(out.templateContents)
-		err := client.LoadTemplate(config.Name, reader)
+		err := client.LoadTemplate(config.Name, out.template)
 		if err != nil {
 			return fmt.Errorf("Could not load template: %v", err)
 		}
@@ -207,17 +224,18 @@ func makeClientFactory(
 
 		// define a callback to be called on connection
 		var onConnected connectCallback
-		if len(out.templateContents) > 0 {
+		if out.template != nil {
 			onConnected = func(client *Client) error {
 				return out.loadTemplate(config.Template, client)
 			}
 		}
 
-		client := NewClient(
+		return NewClient(
 			esURL, config.Index, proxyURL, tls,
 			config.Username, config.Password,
-			params, config.Timeout, onConnected)
-		return client, nil
+			params, config.Timeout,
+			config.CompressionLevel,
+			onConnected)
 	}
 }
 

--- a/libbeat/outputs/elasticsearch/output_test.go
+++ b/libbeat/outputs/elasticsearch/output_test.go
@@ -108,7 +108,7 @@ func TestOneEvent(t *testing.T) {
 	r["response"] = "value1"
 
 	index := fmt.Sprintf("%s-%d.%02d.%02d", output.index, ts.Year(), ts.Month(), ts.Day())
-	logp.Debug("output_elasticsearch", "index = %s", index)
+	debugf("index = %s", index)
 
 	client := output.randomClient()
 	client.CreateIndex(index, common.MapStr{
@@ -148,7 +148,7 @@ func TestOneEvent(t *testing.T) {
 		t.Errorf("Failed to query elasticsearch for index(%s): %s", index, err)
 		return
 	}
-	logp.Debug("output_elasticsearch", "resp = %s", resp)
+	debugf("resp = %s", resp)
 	if resp.Hits.Total != 1 {
 		t.Errorf("Wrong number of results: %d", resp.Hits.Total)
 	}

--- a/libbeat/outputs/elasticsearch/topology.go
+++ b/libbeat/outputs/elasticsearch/topology.go
@@ -79,8 +79,7 @@ func (t *topology) GetNameByIP(ip string) string {
 // Each shipper publishes a list of IPs together with its name to Elasticsearch
 func (t *topology) PublishIPs(name string, localAddrs []string) error {
 	if !t.ttlEnabled {
-		logp.Debug("output_elasticsearch",
-			"Not publishing IPs because TTL was not yet confirmed to be enabled")
+		debugf("Not publishing IPs because TTL was not yet confirmed to be enabled")
 		return nil
 	}
 
@@ -89,8 +88,7 @@ func (t *topology) PublishIPs(name string, localAddrs []string) error {
 		return ErrNotConnected
 	}
 
-	logp.Debug("output_elasticsearch",
-		"Publish IPs %s with expiration time %d", localAddrs, t.TopologyExpire)
+	debugf("Publish IPs %s with expiration time %d", localAddrs, t.TopologyExpire)
 
 	params := map[string]string{
 		"ttl":     fmt.Sprintf("%dms", t.TopologyExpire),
@@ -161,6 +159,6 @@ func loadTopolgyMap(client *Client) (map[string]string, error) {
 		}
 	}
 
-	logp.Debug("output_elasticsearch", "Topology map %s", topology)
+	debugf("Topology map %s", topology)
 	return topology, nil
 }

--- a/libbeat/outputs/logstash/logstash_integration_test.go
+++ b/libbeat/outputs/logstash/logstash_integration_test.go
@@ -73,13 +73,16 @@ func esConnect(t *testing.T, index string) *esConnection {
 
 	username := os.Getenv("ES_USER")
 	password := os.Getenv("ES_PASS")
-	client := elasticsearch.NewClient(host, "", nil, nil, username, password,
-		nil, 60*time.Second, nil)
+	client, err := elasticsearch.NewClient(host, "", nil, nil, username, password,
+		nil, 60*time.Second, 0, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// try to drop old index if left over from failed test
 	_, _, _ = client.Delete(index, "", "", nil) // ignore error
 
-	_, _, err := client.CreateIndex(index, common.MapStr{
+	_, _, err = client.CreateIndex(index, common.MapStr{
 		"settings": common.MapStr{
 			"number_of_shards":   1,
 			"number_of_replicas": 0,

--- a/metricbeat/metricbeat.full.yml
+++ b/metricbeat/metricbeat.full.yml
@@ -217,6 +217,9 @@ output.elasticsearch:
   # IPv6 addresses should always be defined as: https://[2001:db8::1]:9200
   hosts: ["localhost:9200"]
 
+  # Set gzip compression level.
+  #compression_level: 0
+
   # Optional protocol and basic auth credentials.
   #protocol: "https"
   #username: "admin"

--- a/packetbeat/packetbeat.full.yml
+++ b/packetbeat/packetbeat.full.yml
@@ -467,6 +467,9 @@ output.elasticsearch:
   # IPv6 addresses should always be defined as: https://[2001:db8::1]:9200
   hosts: ["localhost:9200"]
 
+  # Set gzip compression level.
+  #compression_level: 0
+
   # Optional protocol and basic auth credentials.
   #protocol: "https"
   #username: "admin"

--- a/topbeat/topbeat.full.yml
+++ b/topbeat/topbeat.full.yml
@@ -114,6 +114,9 @@ output.elasticsearch:
   # IPv6 addresses should always be defined as: https://[2001:db8::1]:9200
   hosts: ["localhost:9200"]
 
+  # Set gzip compression level.
+  #compression_level: 0
+
   # Optional protocol and basic auth credentials.
   #protocol: "https"
   #username: "admin"

--- a/winlogbeat/winlogbeat.full.yml
+++ b/winlogbeat/winlogbeat.full.yml
@@ -118,6 +118,9 @@ output.elasticsearch:
   # IPv6 addresses should always be defined as: https://[2001:db8::1]:9200
   hosts: ["localhost:9200"]
 
+  # Set gzip compression level.
+  #compression_level: 0
+
   # Optional protocol and basic auth credentials.
   #protocol: "https"
   #username: "admin"


### PR DESCRIPTION
Add support and new configuration option to elasticsearch output to enable gzip based  compression of JSON payload in POST requests.

Requires #1834 plus rebase after merging #1834