### PR TITLE
Convert integer fields to long

### DIFF
--- a/libbeat/scripts/generate_template.py
+++ b/libbeat/scripts/generate_template.py
@@ -179,6 +179,10 @@ def fill_field_properties(args, field, defaults, path):
 
     elif field["type"] in ["geo_point", "date", "long", "integer",
                            "double", "float", "boolean"]:
+        # Convert all integer fields to long
+        if field["type"] == "integer":
+            field["type"] = "long"
+
         properties[field["name"]] = {
             "type": field.get("type")
         }

--- a/metricbeat/metricbeat.template-es2x.json
+++ b/metricbeat/metricbeat.template-es2x.json
@@ -38,18 +38,18 @@
                     "async": {
                       "properties": {
                         "closing": {
-                          "type": "integer"
+                          "type": "long"
                         },
                         "keep_alive": {
-                          "type": "integer"
+                          "type": "long"
                         },
                         "writing": {
-                          "type": "integer"
+                          "type": "long"
                         }
                       }
                     },
                     "total": {
-                      "type": "integer"
+                      "type": "long"
                     }
                   }
                 },
@@ -96,66 +96,66 @@
                 "scoreboard": {
                   "properties": {
                     "closing_connection": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "dns_lookup": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "gracefully_finishing": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "idle_cleanup": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "keepalive": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "logging": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "open_slot": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "reading_request": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "sending_reply": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "starting_up": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "total": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "waiting_for_connection": {
-                      "type": "integer"
+                      "type": "long"
                     }
                   }
                 },
                 "total_accesses": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "total_kbytes": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "uptime": {
                   "properties": {
                     "server_uptime": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "uptime": {
-                      "type": "integer"
+                      "type": "long"
                     }
                   }
                 },
                 "workers": {
                   "properties": {
                     "busy": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "idle": {
-                      "type": "integer"
+                      "type": "long"
                     }
                   }
                 }
@@ -206,10 +206,10 @@
                 "aborted": {
                   "properties": {
                     "clients": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "connects": {
-                      "type": "integer"
+                      "type": "long"
                     }
                   }
                 },
@@ -218,10 +218,10 @@
                     "cache": {
                       "properties": {
                         "disk_use": {
-                          "type": "integer"
+                          "type": "long"
                         },
                         "use": {
-                          "type": "integer"
+                          "type": "long"
                         }
                       }
                     }
@@ -230,28 +230,28 @@
                 "bytes": {
                   "properties": {
                     "received": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "sent": {
-                      "type": "integer"
+                      "type": "long"
                     }
                   }
                 },
                 "connections": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "created": {
                   "properties": {
                     "tmp": {
                       "properties": {
                         "disk_tables": {
-                          "type": "integer"
+                          "type": "long"
                         },
                         "files": {
-                          "type": "integer"
+                          "type": "long"
                         },
                         "tables": {
-                          "type": "integer"
+                          "type": "long"
                         }
                       }
                     }
@@ -260,37 +260,37 @@
                 "delayed": {
                   "properties": {
                     "errors": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "insert_threads": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "writes": {
-                      "type": "integer"
+                      "type": "long"
                     }
                   }
                 },
                 "flush_commands": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "max_used_connections": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "open": {
                   "properties": {
                     "files": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "streams": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "tables": {
-                      "type": "integer"
+                      "type": "long"
                     }
                   }
                 },
                 "opened_tables": {
-                  "type": "integer"
+                  "type": "long"
                 }
               }
             }
@@ -301,19 +301,19 @@
             "stubstatus": {
               "properties": {
                 "accepts": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "active": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "current": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "dropped": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "handled": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "hostname": {
                   "ignore_above": 1024,
@@ -321,16 +321,16 @@
                   "type": "string"
                 },
                 "reading": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "requests": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "waiting": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "writing": {
-                  "type": "integer"
+                  "type": "long"
                 }
               }
             }
@@ -343,16 +343,16 @@
                 "clients": {
                   "properties": {
                     "biggest_input_buf": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "blocked": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "connected": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "longest_output_list": {
-                      "type": "integer"
+                      "type": "long"
                     }
                   }
                 },
@@ -393,16 +393,16 @@
                     "used": {
                       "properties": {
                         "lua": {
-                          "type": "integer"
+                          "type": "long"
                         },
                         "peak": {
-                          "type": "integer"
+                          "type": "long"
                         },
                         "rss": {
-                          "type": "integer"
+                          "type": "long"
                         },
                         "value": {
-                          "type": "integer"
+                          "type": "long"
                         }
                       }
                     }
@@ -419,10 +419,10 @@
                           "type": "boolean"
                         },
                         "changes_since_last_save": {
-                          "type": "integer"
+                          "type": "long"
                         },
                         "current_bgsave_time_sec": {
-                          "type": "integer"
+                          "type": "long"
                         },
                         "last_bgsave_status": {
                           "ignore_above": 1024,
@@ -430,17 +430,17 @@
                           "type": "string"
                         },
                         "last_bgsave_time_sec": {
-                          "type": "integer"
+                          "type": "long"
                         },
                         "last_save_time": {
-                          "type": "integer"
+                          "type": "long"
                         }
                       }
                     },
                     "used": {
                       "properties": {
                         "current_rewrite_time_sec": {
-                          "type": "integer"
+                          "type": "long"
                         },
                         "enabled": {
                           "type": "boolean"
@@ -451,7 +451,7 @@
                           "type": "string"
                         },
                         "last_rewrite_time_sec": {
-                          "type": "integer"
+                          "type": "long"
                         },
                         "last_write_status": {
                           "ignore_above": 1024,
@@ -473,24 +473,24 @@
                     "backlog": {
                       "properties": {
                         "active": {
-                          "type": "integer"
+                          "type": "long"
                         },
                         "first_byte_offset": {
-                          "type": "integer"
+                          "type": "long"
                         },
                         "histlen": {
-                          "type": "integer"
+                          "type": "long"
                         },
                         "size": {
-                          "type": "integer"
+                          "type": "long"
                         }
                       }
                     },
                     "connected_slaves": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "master_offset": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "role": {
                       "ignore_above": 1024,
@@ -532,10 +532,10 @@
                       "type": "string"
                     },
                     "hz": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "lru_clock": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "mode": {
                       "ignore_above": 1024,
@@ -553,7 +553,7 @@
                       "type": "string"
                     },
                     "process_id": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "run_id": {
                       "ignore_above": 1024,
@@ -561,10 +561,10 @@
                       "type": "string"
                     },
                     "tcp_port": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "uptime": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "version": {
                       "ignore_above": 1024,
@@ -578,10 +578,10 @@
                     "connections": {
                       "properties": {
                         "received": {
-                          "type": "integer"
+                          "type": "long"
                         },
                         "rejected": {
-                          "type": "integer"
+                          "type": "long"
                         }
                       }
                     },
@@ -589,7 +589,7 @@
                       "type": "float"
                     },
                     "instantaneous_ops_per_sec": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "instantaneous_output_kbps": {
                       "type": "float"
@@ -597,56 +597,56 @@
                     "keys": {
                       "properties": {
                         "evicted": {
-                          "type": "integer"
+                          "type": "long"
                         },
                         "expired": {
-                          "type": "integer"
+                          "type": "long"
                         }
                       }
                     },
                     "keyspace": {
                       "properties": {
                         "hits": {
-                          "type": "integer"
+                          "type": "long"
                         },
                         "misses": {
-                          "type": "integer"
+                          "type": "long"
                         }
                       }
                     },
                     "latest_fork_usec": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "migrate_cached_sockets": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "pubsub_channels": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "pubsub_patterns": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "sync": {
                       "properties": {
                         "full": {
-                          "type": "integer"
+                          "type": "long"
                         },
                         "partial_err": {
-                          "type": "integer"
+                          "type": "long"
                         },
                         "partial_ok": {
-                          "type": "integer"
+                          "type": "long"
                         }
                       }
                     },
                     "total_commands_processed": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "total_net_input_bytes": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "total_net_output_bytes": {
-                      "type": "integer"
+                      "type": "long"
                     }
                   }
                 }
@@ -677,7 +677,7 @@
             "core": {
               "properties": {
                 "id": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "idle": {
                   "properties": {
@@ -1123,10 +1123,10 @@
                   "type": "string"
                 },
                 "pid": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "ppid": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "state": {
                   "ignore_above": 1024,
@@ -1160,10 +1160,10 @@
                   "type": "long"
                 },
                 "ephemerals_count": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "followers": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "hostname": {
                   "ignore_above": 1024,
@@ -1173,32 +1173,32 @@
                 "latency": {
                   "properties": {
                     "avg": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "max": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "min": {
-                      "type": "integer"
+                      "type": "long"
                     }
                   }
                 },
                 "max_file_descriptor_count": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "num_alive_connections": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "open_file_descriptor_count": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "outstanding_requests": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "packets": {
                   "properties": {
                     "received": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "sent": {
                       "type": "long"
@@ -1206,7 +1206,7 @@
                   }
                 },
                 "pending_syncs": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "server_state": {
                   "ignore_above": 1024,
@@ -1214,7 +1214,7 @@
                   "type": "string"
                 },
                 "synced_followers": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "version": {
                   "ignore_above": 1024,
@@ -1222,10 +1222,10 @@
                   "type": "string"
                 },
                 "watch_count": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "znode_count": {
-                  "type": "integer"
+                  "type": "long"
                 }
               }
             }

--- a/metricbeat/metricbeat.template.json
+++ b/metricbeat/metricbeat.template.json
@@ -35,18 +35,18 @@
                     "async": {
                       "properties": {
                         "closing": {
-                          "type": "integer"
+                          "type": "long"
                         },
                         "keep_alive": {
-                          "type": "integer"
+                          "type": "long"
                         },
                         "writing": {
-                          "type": "integer"
+                          "type": "long"
                         }
                       }
                     },
                     "total": {
-                      "type": "integer"
+                      "type": "long"
                     }
                   }
                 },
@@ -92,66 +92,66 @@
                 "scoreboard": {
                   "properties": {
                     "closing_connection": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "dns_lookup": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "gracefully_finishing": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "idle_cleanup": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "keepalive": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "logging": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "open_slot": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "reading_request": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "sending_reply": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "starting_up": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "total": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "waiting_for_connection": {
-                      "type": "integer"
+                      "type": "long"
                     }
                   }
                 },
                 "total_accesses": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "total_kbytes": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "uptime": {
                   "properties": {
                     "server_uptime": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "uptime": {
-                      "type": "integer"
+                      "type": "long"
                     }
                   }
                 },
                 "workers": {
                   "properties": {
                     "busy": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "idle": {
-                      "type": "integer"
+                      "type": "long"
                     }
                   }
                 }
@@ -197,10 +197,10 @@
                 "aborted": {
                   "properties": {
                     "clients": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "connects": {
-                      "type": "integer"
+                      "type": "long"
                     }
                   }
                 },
@@ -209,10 +209,10 @@
                     "cache": {
                       "properties": {
                         "disk_use": {
-                          "type": "integer"
+                          "type": "long"
                         },
                         "use": {
-                          "type": "integer"
+                          "type": "long"
                         }
                       }
                     }
@@ -221,28 +221,28 @@
                 "bytes": {
                   "properties": {
                     "received": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "sent": {
-                      "type": "integer"
+                      "type": "long"
                     }
                   }
                 },
                 "connections": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "created": {
                   "properties": {
                     "tmp": {
                       "properties": {
                         "disk_tables": {
-                          "type": "integer"
+                          "type": "long"
                         },
                         "files": {
-                          "type": "integer"
+                          "type": "long"
                         },
                         "tables": {
-                          "type": "integer"
+                          "type": "long"
                         }
                       }
                     }
@@ -251,37 +251,37 @@
                 "delayed": {
                   "properties": {
                     "errors": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "insert_threads": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "writes": {
-                      "type": "integer"
+                      "type": "long"
                     }
                   }
                 },
                 "flush_commands": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "max_used_connections": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "open": {
                   "properties": {
                     "files": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "streams": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "tables": {
-                      "type": "integer"
+                      "type": "long"
                     }
                   }
                 },
                 "opened_tables": {
-                  "type": "integer"
+                  "type": "long"
                 }
               }
             }
@@ -292,35 +292,35 @@
             "stubstatus": {
               "properties": {
                 "accepts": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "active": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "current": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "dropped": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "handled": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "hostname": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
                 "reading": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "requests": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "waiting": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "writing": {
-                  "type": "integer"
+                  "type": "long"
                 }
               }
             }
@@ -333,16 +333,16 @@
                 "clients": {
                   "properties": {
                     "biggest_input_buf": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "blocked": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "connected": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "longest_output_list": {
-                      "type": "integer"
+                      "type": "long"
                     }
                   }
                 },
@@ -382,16 +382,16 @@
                     "used": {
                       "properties": {
                         "lua": {
-                          "type": "integer"
+                          "type": "long"
                         },
                         "peak": {
-                          "type": "integer"
+                          "type": "long"
                         },
                         "rss": {
-                          "type": "integer"
+                          "type": "long"
                         },
                         "value": {
-                          "type": "integer"
+                          "type": "long"
                         }
                       }
                     }
@@ -408,27 +408,27 @@
                           "type": "boolean"
                         },
                         "changes_since_last_save": {
-                          "type": "integer"
+                          "type": "long"
                         },
                         "current_bgsave_time_sec": {
-                          "type": "integer"
+                          "type": "long"
                         },
                         "last_bgsave_status": {
                           "ignore_above": 1024,
                           "type": "keyword"
                         },
                         "last_bgsave_time_sec": {
-                          "type": "integer"
+                          "type": "long"
                         },
                         "last_save_time": {
-                          "type": "integer"
+                          "type": "long"
                         }
                       }
                     },
                     "used": {
                       "properties": {
                         "current_rewrite_time_sec": {
-                          "type": "integer"
+                          "type": "long"
                         },
                         "enabled": {
                           "type": "boolean"
@@ -438,7 +438,7 @@
                           "type": "keyword"
                         },
                         "last_rewrite_time_sec": {
-                          "type": "integer"
+                          "type": "long"
                         },
                         "last_write_status": {
                           "ignore_above": 1024,
@@ -459,24 +459,24 @@
                     "backlog": {
                       "properties": {
                         "active": {
-                          "type": "integer"
+                          "type": "long"
                         },
                         "first_byte_offset": {
-                          "type": "integer"
+                          "type": "long"
                         },
                         "histlen": {
-                          "type": "integer"
+                          "type": "long"
                         },
                         "size": {
-                          "type": "integer"
+                          "type": "long"
                         }
                       }
                     },
                     "connected_slaves": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "master_offset": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "role": {
                       "ignore_above": 1024,
@@ -511,10 +511,10 @@
                       "type": "keyword"
                     },
                     "hz": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "lru_clock": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "mode": {
                       "ignore_above": 1024,
@@ -529,17 +529,17 @@
                       "type": "keyword"
                     },
                     "process_id": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "run_id": {
                       "ignore_above": 1024,
                       "type": "keyword"
                     },
                     "tcp_port": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "uptime": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "version": {
                       "ignore_above": 1024,
@@ -552,10 +552,10 @@
                     "connections": {
                       "properties": {
                         "received": {
-                          "type": "integer"
+                          "type": "long"
                         },
                         "rejected": {
-                          "type": "integer"
+                          "type": "long"
                         }
                       }
                     },
@@ -563,7 +563,7 @@
                       "type": "float"
                     },
                     "instantaneous_ops_per_sec": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "instantaneous_output_kbps": {
                       "type": "float"
@@ -571,56 +571,56 @@
                     "keys": {
                       "properties": {
                         "evicted": {
-                          "type": "integer"
+                          "type": "long"
                         },
                         "expired": {
-                          "type": "integer"
+                          "type": "long"
                         }
                       }
                     },
                     "keyspace": {
                       "properties": {
                         "hits": {
-                          "type": "integer"
+                          "type": "long"
                         },
                         "misses": {
-                          "type": "integer"
+                          "type": "long"
                         }
                       }
                     },
                     "latest_fork_usec": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "migrate_cached_sockets": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "pubsub_channels": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "pubsub_patterns": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "sync": {
                       "properties": {
                         "full": {
-                          "type": "integer"
+                          "type": "long"
                         },
                         "partial_err": {
-                          "type": "integer"
+                          "type": "long"
                         },
                         "partial_ok": {
-                          "type": "integer"
+                          "type": "long"
                         }
                       }
                     },
                     "total_commands_processed": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "total_net_input_bytes": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "total_net_output_bytes": {
-                      "type": "integer"
+                      "type": "long"
                     }
                   }
                 }
@@ -650,7 +650,7 @@
             "core": {
               "properties": {
                 "id": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "idle": {
                   "properties": {
@@ -1088,10 +1088,10 @@
                   "type": "keyword"
                 },
                 "pid": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "ppid": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "state": {
                   "ignore_above": 1024,
@@ -1121,10 +1121,10 @@
                   "type": "long"
                 },
                 "ephemerals_count": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "followers": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "hostname": {
                   "ignore_above": 1024,
@@ -1133,32 +1133,32 @@
                 "latency": {
                   "properties": {
                     "avg": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "max": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "min": {
-                      "type": "integer"
+                      "type": "long"
                     }
                   }
                 },
                 "max_file_descriptor_count": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "num_alive_connections": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "open_file_descriptor_count": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "outstanding_requests": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "packets": {
                   "properties": {
                     "received": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "sent": {
                       "type": "long"
@@ -1166,24 +1166,24 @@
                   }
                 },
                 "pending_syncs": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "server_state": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
                 "synced_followers": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "version": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
                 "watch_count": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "znode_count": {
-                  "type": "integer"
+                  "type": "long"
                 }
               }
             }

--- a/packetbeat/packetbeat.template-es2x.json
+++ b/packetbeat/packetbeat.template-es2x.json
@@ -67,10 +67,10 @@
               "type": "boolean"
             },
             "class-id": {
-              "type": "integer"
+              "type": "long"
             },
             "consumer-count": {
-              "type": "integer"
+              "type": "long"
             },
             "consumer-tag": {
               "ignore_above": 1024,
@@ -98,7 +98,7 @@
               "type": "string"
             },
             "delivery-tag": {
-              "type": "integer"
+              "type": "long"
             },
             "durable": {
               "type": "boolean"
@@ -134,7 +134,7 @@
               "type": "boolean"
             },
             "message-count": {
-              "type": "integer"
+              "type": "long"
             },
             "message-id": {
               "ignore_above": 1024,
@@ -142,7 +142,7 @@
               "type": "string"
             },
             "method-id": {
-              "type": "integer"
+              "type": "long"
             },
             "multiple": {
               "type": "boolean"
@@ -160,7 +160,7 @@
               "type": "boolean"
             },
             "priority": {
-              "type": "integer"
+              "type": "long"
             },
             "queue": {
               "ignore_above": 1024,
@@ -171,7 +171,7 @@
               "type": "boolean"
             },
             "reply-code": {
-              "type": "integer"
+              "type": "long"
             },
             "reply-text": {
               "ignore_above": 1024,
@@ -349,7 +349,7 @@
                   "type": "string"
                 },
                 "ttl": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "type": {
                   "ignore_above": 1024,
@@ -359,7 +359,7 @@
               }
             },
             "additionals_count": {
-              "type": "integer"
+              "type": "long"
             },
             "answers": {
               "properties": {
@@ -379,7 +379,7 @@
                   "type": "string"
                 },
                 "ttl": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "type": {
                   "ignore_above": 1024,
@@ -389,7 +389,7 @@
               }
             },
             "answers_count": {
-              "type": "integer"
+              "type": "long"
             },
             "authorities": {
               "properties": {
@@ -411,7 +411,7 @@
               }
             },
             "authorities_count": {
-              "type": "integer"
+              "type": "long"
             },
             "flags": {
               "properties": {
@@ -436,7 +436,7 @@
               }
             },
             "id": {
-              "type": "integer"
+              "type": "long"
             },
             "op_code": {
               "ignore_above": 1024,
@@ -454,7 +454,7 @@
                   "type": "string"
                 },
                 "udp_size": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "version": {
                   "ignore_above": 1024,
@@ -532,7 +532,7 @@
             "request": {
               "properties": {
                 "code": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "message": {
                   "ignore_above": 1024,
@@ -540,14 +540,14 @@
                   "type": "string"
                 },
                 "type": {
-                  "type": "integer"
+                  "type": "long"
                 }
               }
             },
             "response": {
               "properties": {
                 "code": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "message": {
                   "ignore_above": 1024,
@@ -555,7 +555,7 @@
                   "type": "string"
                 },
                 "type": {
-                  "type": "integer"
+                  "type": "long"
                 }
               }
             },
@@ -608,22 +608,22 @@
                   "type": "string"
                 },
                 "count_values": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "delta": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "dest_class": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "exptime": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "flags": {
                   "type": "long"
                 },
                 "initial": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "line": {
                   "ignore_above": 1024,
@@ -634,7 +634,7 @@
                   "type": "boolean"
                 },
                 "opaque": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "opcode": {
                   "ignore_above": 1024,
@@ -642,7 +642,7 @@
                   "type": "string"
                 },
                 "opcode_value": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "quiet": {
                   "type": "boolean"
@@ -656,7 +656,7 @@
                   "type": "long"
                 },
                 "source_class": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "type": {
                   "ignore_above": 1024,
@@ -664,10 +664,10 @@
                   "type": "string"
                 },
                 "vbucket": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "verbosity": {
-                  "type": "integer"
+                  "type": "long"
                 }
               }
             },
@@ -685,7 +685,7 @@
                   "type": "string"
                 },
                 "count_values": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "error_msg": {
                   "ignore_above": 1024,
@@ -696,7 +696,7 @@
                   "type": "long"
                 },
                 "opaque": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "opcode": {
                   "ignore_above": 1024,
@@ -704,7 +704,7 @@
                   "type": "string"
                 },
                 "opcode_value": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "status": {
                   "ignore_above": 1024,
@@ -712,7 +712,7 @@
                   "type": "string"
                 },
                 "status_code": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "type": {
                   "ignore_above": 1024,
@@ -754,13 +754,13 @@
               "type": "string"
             },
             "numberReturned": {
-              "type": "integer"
+              "type": "long"
             },
             "numberToReturn": {
-              "type": "integer"
+              "type": "long"
             },
             "numberToSkip": {
-              "type": "integer"
+              "type": "long"
             },
             "query": {
               "ignore_above": 1024,
@@ -792,10 +792,10 @@
         "mysql": {
           "properties": {
             "affected_rows": {
-              "type": "integer"
+              "type": "long"
             },
             "error_code": {
-              "type": "integer"
+              "type": "long"
             },
             "error_message": {
               "ignore_above": 1024,
@@ -830,7 +830,7 @@
         "nfs": {
           "properties": {
             "minor_version": {
-              "type": "integer"
+              "type": "long"
             },
             "opcode": {
               "ignore_above": 1024,
@@ -848,7 +848,7 @@
               "type": "string"
             },
             "version": {
-              "type": "integer"
+              "type": "long"
             }
           }
         },
@@ -877,7 +877,7 @@
         "pgsql": {
           "properties": {
             "error_code": {
-              "type": "integer"
+              "type": "long"
             },
             "error_message": {
               "ignore_above": 1024,
@@ -978,12 +978,12 @@
               "type": "string"
             },
             "call_size": {
-              "type": "integer"
+              "type": "long"
             },
             "cred": {
               "properties": {
                 "gid": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "gids": {
                   "ignore_above": 1024,
@@ -996,15 +996,15 @@
                   "type": "string"
                 },
                 "stamp": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "uid": {
-                  "type": "integer"
+                  "type": "long"
                 }
               }
             },
             "reply_size": {
-              "type": "integer"
+              "type": "long"
             },
             "status": {
               "ignore_above": 1024,

--- a/packetbeat/packetbeat.template.json
+++ b/packetbeat/packetbeat.template.json
@@ -60,10 +60,10 @@
               "type": "boolean"
             },
             "class-id": {
-              "type": "integer"
+              "type": "long"
             },
             "consumer-count": {
-              "type": "integer"
+              "type": "long"
             },
             "consumer-tag": {
               "ignore_above": 1024,
@@ -86,7 +86,7 @@
               "type": "keyword"
             },
             "delivery-tag": {
-              "type": "integer"
+              "type": "long"
             },
             "durable": {
               "type": "boolean"
@@ -119,14 +119,14 @@
               "type": "boolean"
             },
             "message-count": {
-              "type": "integer"
+              "type": "long"
             },
             "message-id": {
               "ignore_above": 1024,
               "type": "keyword"
             },
             "method-id": {
-              "type": "integer"
+              "type": "long"
             },
             "multiple": {
               "type": "boolean"
@@ -144,7 +144,7 @@
               "type": "boolean"
             },
             "priority": {
-              "type": "integer"
+              "type": "long"
             },
             "queue": {
               "ignore_above": 1024,
@@ -154,7 +154,7 @@
               "type": "boolean"
             },
             "reply-code": {
-              "type": "integer"
+              "type": "long"
             },
             "reply-text": {
               "ignore_above": 1024,
@@ -306,7 +306,7 @@
                   "type": "keyword"
                 },
                 "ttl": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "type": {
                   "ignore_above": 1024,
@@ -315,7 +315,7 @@
               }
             },
             "additionals_count": {
-              "type": "integer"
+              "type": "long"
             },
             "answers": {
               "properties": {
@@ -332,7 +332,7 @@
                   "type": "keyword"
                 },
                 "ttl": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "type": {
                   "ignore_above": 1024,
@@ -341,7 +341,7 @@
               }
             },
             "answers_count": {
-              "type": "integer"
+              "type": "long"
             },
             "authorities": {
               "properties": {
@@ -360,7 +360,7 @@
               }
             },
             "authorities_count": {
-              "type": "integer"
+              "type": "long"
             },
             "flags": {
               "properties": {
@@ -385,7 +385,7 @@
               }
             },
             "id": {
-              "type": "integer"
+              "type": "long"
             },
             "op_code": {
               "ignore_above": 1024,
@@ -401,7 +401,7 @@
                   "type": "keyword"
                 },
                 "udp_size": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "version": {
                   "ignore_above": 1024,
@@ -469,28 +469,28 @@
             "request": {
               "properties": {
                 "code": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "message": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
                 "type": {
-                  "type": "integer"
+                  "type": "long"
                 }
               }
             },
             "response": {
               "properties": {
                 "code": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "message": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
                 "type": {
-                  "type": "integer"
+                  "type": "long"
                 }
               }
             },
@@ -537,22 +537,22 @@
                   "type": "keyword"
                 },
                 "count_values": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "delta": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "dest_class": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "exptime": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "flags": {
                   "type": "long"
                 },
                 "initial": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "line": {
                   "ignore_above": 1024,
@@ -562,14 +562,14 @@
                   "type": "boolean"
                 },
                 "opaque": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "opcode": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
                 "opcode_value": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "quiet": {
                   "type": "boolean"
@@ -582,17 +582,17 @@
                   "type": "long"
                 },
                 "source_class": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "type": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
                 "vbucket": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "verbosity": {
-                  "type": "integer"
+                  "type": "long"
                 }
               }
             },
@@ -609,7 +609,7 @@
                   "type": "keyword"
                 },
                 "count_values": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "error_msg": {
                   "ignore_above": 1024,
@@ -619,21 +619,21 @@
                   "type": "long"
                 },
                 "opaque": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "opcode": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
                 "opcode_value": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "status": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
                 "status_code": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "type": {
                   "ignore_above": 1024,
@@ -669,13 +669,13 @@
               "type": "keyword"
             },
             "numberReturned": {
-              "type": "integer"
+              "type": "long"
             },
             "numberToReturn": {
-              "type": "integer"
+              "type": "long"
             },
             "numberToSkip": {
-              "type": "integer"
+              "type": "long"
             },
             "query": {
               "ignore_above": 1024,
@@ -702,10 +702,10 @@
         "mysql": {
           "properties": {
             "affected_rows": {
-              "type": "integer"
+              "type": "long"
             },
             "error_code": {
-              "type": "integer"
+              "type": "long"
             },
             "error_message": {
               "ignore_above": 1024,
@@ -735,7 +735,7 @@
         "nfs": {
           "properties": {
             "minor_version": {
-              "type": "integer"
+              "type": "long"
             },
             "opcode": {
               "ignore_above": 1024,
@@ -750,7 +750,7 @@
               "type": "keyword"
             },
             "version": {
-              "type": "integer"
+              "type": "long"
             }
           }
         },
@@ -773,7 +773,7 @@
         "pgsql": {
           "properties": {
             "error_code": {
-              "type": "integer"
+              "type": "long"
             },
             "error_message": {
               "ignore_above": 1024,
@@ -854,12 +854,12 @@
               "type": "keyword"
             },
             "call_size": {
-              "type": "integer"
+              "type": "long"
             },
             "cred": {
               "properties": {
                 "gid": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "gids": {
                   "ignore_above": 1024,
@@ -870,15 +870,15 @@
                   "type": "keyword"
                 },
                 "stamp": {
-                  "type": "integer"
+                  "type": "long"
                 },
                 "uid": {
-                  "type": "integer"
+                  "type": "long"
                 }
               }
             },
             "reply_size": {
-              "type": "integer"
+              "type": "long"
             },
             "status": {
               "ignore_above": 1024,

--- a/topbeat/topbeat.template-es2x.json
+++ b/topbeat/topbeat.template-es2x.json
@@ -125,7 +125,7 @@
           }
         },
         "id": {
-          "type": "integer"
+          "type": "long"
         },
         "idle": {
           "type": "long"
@@ -233,10 +233,10 @@
               "type": "string"
             },
             "pid": {
-              "type": "integer"
+              "type": "long"
             },
             "ppid": {
-              "type": "integer"
+              "type": "long"
             },
             "state": {
               "ignore_above": 1024,

--- a/topbeat/topbeat.template.json
+++ b/topbeat/topbeat.template.json
@@ -118,7 +118,7 @@
           }
         },
         "id": {
-          "type": "integer"
+          "type": "long"
         },
         "idle": {
           "type": "long"
@@ -223,10 +223,10 @@
               "type": "keyword"
             },
             "pid": {
-              "type": "integer"
+              "type": "long"
             },
             "ppid": {
-              "type": "integer"
+              "type": "long"
             },
             "state": {
               "ignore_above": 1024,

--- a/winlogbeat/winlogbeat.template-es2x.json
+++ b/winlogbeat/winlogbeat.template-es2x.json
@@ -170,7 +170,7 @@
           }
         },
         "version": {
-          "type": "integer"
+          "type": "long"
         },
         "xml": {
           "index": "analyzed",

--- a/winlogbeat/winlogbeat.template.json
+++ b/winlogbeat/winlogbeat.template.json
@@ -142,7 +142,7 @@
           }
         },
         "version": {
-          "type": "integer"
+          "type": "long"
         },
         "xml": {
           "norms": false,


### PR DESCRIPTION
Automatically convert all fields which were defined as integer to long to prevent potential overflow issues with integer. This should not have an affect on storage need.