### PR TITLE
Update and fix minor issues with scripts

### DIFF
--- a/dev-tools/export_dashboards.py
+++ b/dev-tools/export_dashboards.py
@@ -16,7 +16,7 @@ def ExportDashboards(es, beat, kibana_index, output_directory):
     for doc in res['hits']['hits']:
 
         if not reg_exp.match(doc["_source"]["title"]):
-            print "Ignore dashboard", doc["_source"]["title"]
+            print("Ignore dashboard", doc["_source"]["title"])
             continue
 
         # save dashboard

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -238,8 +238,8 @@ update: python-env
 ES_URL?=http://localhost:9200
 
 .PHONY: export-dashboards
-export-dashboards:
-	python ${ES_BEATS}/dev-tools//export_dashboards.py --url ${ES_URL} --dir $(shell pwd)/etc/kibana --beat ${BEATNAME}
+export-dashboards: python-env
+	. ${PYTHON_ENV}/bin/activate && python ${ES_BEATS}/dev-tools/export_dashboards.py --url ${ES_URL} --dir $(shell pwd)/etc/kibana --beat ${BEATNAME}
 
 .PHONY: import-dashboards
 import-dashboards:

--- a/libbeat/tests/system/requirements.txt
+++ b/libbeat/tests/system/requirements.txt
@@ -4,3 +4,4 @@ jinja2
 PyYAML
 nose-timer
 redis
+elasticsearch


### PR DESCRIPTION
I have found following changes very useful while playing with exporting of dashboards:
- update requirements for python env (elasticsearch)
- fix typo and add python env for export-dashboards target in makefile
- fix 'print' call in export_dashboards script