### PR TITLE
Prepare the 1.3.0 release

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,13 +26,8 @@ https://github.com/elastic/beats/compare/v1.2.3...1.3[Check the HEAD diff]
 ==== Bugfixes
 
 *Affecting all Beats*
-- Fix beats load balancer deadlock if max_retries: -1 or publish_async is enabled in filebeat. {issue}1829[1829]
-- Fix output modes backoff counter reset. {issue}1803[1803] {pull}1814[1814] {pull}1818[1818]
-- Set logstash output default bulk_max_size to 2048. {issue}1662[1662]
-- Seed random number generator using crypto.rand package. {pull}1503{1503]
 
 *Packetbeat*
-- Add missing nil-check to memcached GapInStream handler. {issue}1162[1162]
 
 *Topbeat*
 
@@ -65,6 +60,23 @@ https://github.com/elastic/beats/compare/v1.2.3...1.3[Check the HEAD diff]
 *Winlogbeat*
 
 ////////////////////////////////////////////////////////////
+
+[[release-notes-1.3.0]]
+=== Beats version 1.3.0
+https://github.com/elastic/beats/compare/v1.2.3...v1.3.0[View commits]
+
+==== Bugfixes
+
+*Affecting all Beats*
+
+- Fix beats load balancer deadlock if `max_retries: -1` or `publish_async` is enabled in filebeat. {issue}1829[1829]
+- Fix output modes backoff counter reset. {issue}1803[1803] {pull}1814[1814] {pull}1818[1818]
+- Set logstash output default bulk_max_size to 2048. {issue}1662[1662]
+- Seed random number generator using crypto.rand package. {pull}1503[1503]
+
+*Packetbeat*
+
+- Add missing nil-check to memcached GapInStream handler. {issue}1162[1162]
 
 [[release-notes-1.2.3]]
 === Beats version 1.2.3

--- a/filebeat/docs/index.asciidoc
+++ b/filebeat/docs/index.asciidoc
@@ -1,6 +1,6 @@
 = Filebeat Reference
-:libbeat: http://www.elastic.co/guide/en/beats/libbeat/1.2
-:version: 1.2.3
+:libbeat: http://www.elastic.co/guide/en/beats/libbeat/1.3
+:version: 1.3.0
 :beatname_lc: filebeat
 :beatname_uc: Filebeat
 

--- a/filebeat/main.go
+++ b/filebeat/main.go
@@ -5,7 +5,7 @@ import (
 	"github.com/elastic/beats/libbeat/beat"
 )
 
-var Version = "1.2.3"
+var Version = "1.3.0"
 var Name = "filebeat"
 
 // The basic model of execution:

--- a/libbeat/docs/index.asciidoc
+++ b/libbeat/docs/index.asciidoc
@@ -1,13 +1,13 @@
 [[beats-reference]]
 = Beats Platform Reference
-:packetbeat: http://www.elastic.co/guide/en/beats/packetbeat/1.2
-:topbeat: http://www.elastic.co/guide/en/beats/topbeat/1.2
-:filebeat: http://www.elastic.co/guide/en/beats/filebeat/1.2
-:winlogbeat: http://www.elastic.co/guide/en/beats/winlogbeat/1.2
-:ES-version: 2.3.3
-:LS-version: 2.3.2
-:Kibana-version: 4.5.1
-:Dashboards-version: 1.2.3
+:packetbeat: http://www.elastic.co/guide/en/beats/packetbeat/1.3
+:topbeat: http://www.elastic.co/guide/en/beats/topbeat/1.3
+:filebeat: http://www.elastic.co/guide/en/beats/filebeat/1.3
+:winlogbeat: http://www.elastic.co/guide/en/beats/winlogbeat/1.3
+:ES-version: 2.4.0
+:LS-version: 2.4.0
+:Kibana-version: 4.6.0
+:Dashboards-version: 1.3.0
 
 
 include::./overview.asciidoc[]

--- a/libbeat/docs/release.asciidoc
+++ b/libbeat/docs/release.asciidoc
@@ -6,6 +6,7 @@
 --
 This section summarizes the changes in each release.
 
+* <<release-notes-1.3.0>>
 * <<release-notes-1.2.3>>
 * <<release-notes-1.2.2>>
 * <<release-notes-1.2.1>>

--- a/packetbeat/docs/index.asciidoc
+++ b/packetbeat/docs/index.asciidoc
@@ -1,6 +1,6 @@
 = Packetbeat Reference
-:libbeat: http://www.elastic.co/guide/en/beats/libbeat/1.2
-:version: 1.2.3
+:libbeat: http://www.elastic.co/guide/en/beats/libbeat/1.3
+:version: 1.3.0
 :beatname_lc: packetbeat
 :beatname_uc: Packetbeat
 

--- a/packetbeat/main.go
+++ b/packetbeat/main.go
@@ -7,7 +7,7 @@ import (
 )
 
 // You can overwrite these, e.g.: go build -ldflags "-X main.Version 1.0.0-beta3"
-var Version = "1.2.3"
+var Version = "1.3.0"
 var Name = "packetbeat"
 
 // Setups and Runs Packetbeat

--- a/topbeat/docs/index.asciidoc
+++ b/topbeat/docs/index.asciidoc
@@ -1,6 +1,6 @@
 = Topbeat Reference
-:libbeat: http://www.elastic.co/guide/en/beats/libbeat/1.2
-:version: 1.2.3
+:libbeat: http://www.elastic.co/guide/en/beats/libbeat/1.3
+:version: 1.3.0
 :beatname_lc: topbeat
 :beatname_uc: Topbeat
 

--- a/topbeat/main.go
+++ b/topbeat/main.go
@@ -7,7 +7,7 @@ import (
 )
 
 // You can overwrite these, e.g.: go build -ldflags "-X main.Version 1.0.0-beta3"
-var Version = "1.2.3"
+var Version = "1.3.0"
 var Name = "topbeat"
 
 func main() {

--- a/winlogbeat/docs/index.asciidoc
+++ b/winlogbeat/docs/index.asciidoc
@@ -1,6 +1,6 @@
 = Winlogbeat Reference
-:libbeat: http://www.elastic.co/guide/en/beats/libbeat/1.2
-:version: 1.2.3
+:libbeat: http://www.elastic.co/guide/en/beats/libbeat/1.3
+:version: 1.3.0
 :beatname_lc: winlogbeat
 :beatname_uc: Winlogbeat
 

--- a/winlogbeat/main.go
+++ b/winlogbeat/main.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Version of Winlogbeat.
-var Version = "1.2.3"
+var Version = "1.3.0"
 
 // Name of this beat.
 var Name = "winlogbeat"


### PR DESCRIPTION
* Close the changelog
* Bump versions in code
* Bump versions in docs