### PR TITLE
Use x86_64 instead of x64 in tar ball names

### DIFF
--- a/dev-tools/packer/README.md
+++ b/dev-tools/packer/README.md
@@ -71,13 +71,13 @@ For example, here are the artifacts created for Filebeat:
 
 ```
 filebeat-5.0.0-amd64.deb
-filebeat-5.0.0-darwin-x64.tar.gz
+filebeat-5.0.0-darwin-x86_64.tar.gz
 filebeat-5.0.0-i386.deb
 filebeat-5.0.0-i686.rpm
-filebeat-5.0.0-linux-x64.tar.gz
 filebeat-5.0.0-linux-x86.tar.gz
-filebeat-5.0.0-windows-x64.zip
+filebeat-5.0.0-linux-x86_64.tar.gz
 filebeat-5.0.0-windows-x86.zip
+filebeat-5.0.0-windows-x86_64.zip
 filebeat-5.0.0-x86_64.rpm
 ```
 
@@ -85,12 +85,12 @@ And the SNAPSHOT versions:
 
 ```
 filebeat-5.0.0-SNAPSHOT-amd64.deb
+filebeat-5.0.0-SNAPSHOT-darwin-x86_64.tar.gz
 filebeat-5.0.0-SNAPSHOT-i386.deb
 filebeat-5.0.0-SNAPSHOT-i686.rpm
-filebeat-5.0.0-SNAPSHOT-x86_64.rpm
-filebeat-5.0.0-SNAPSHOT-darwin-x64.tar.gz
-filebeat-5.0.0-SNAPSHOT-linux-x64.tar.gz
 filebeat-5.0.0-SNAPSHOT-linux-x86.tar.gz
-filebeat-5.0.0-SNAPSHOT-windows-x64.zip
+filebeat-5.0.0-SNAPSHOT-linux-x86_64.tar.gz
 filebeat-5.0.0-SNAPSHOT-windows-x86.zip
+filebeat-5.0.0-SNAPSHOT-windows-x86_64.zip
+filebeat-5.0.0-SNAPSHOT-x86_64.rpm
 ```

--- a/dev-tools/packer/archs/amd64.yml
+++ b/dev-tools/packer/archs/amd64.yml
@@ -1,5 +1,5 @@
 arch: amd64
 deb_arch: amd64
 rpm_arch: x86_64
-bin_arch: x64
-win_arch: x64
+bin_arch: x86_64
+win_arch: x86_64

--- a/dev-tools/packer/platforms/darwin/run.sh.j2
+++ b/dev-tools/packer/platforms/darwin/run.sh.j2
@@ -10,18 +10,18 @@ if [ "$SNAPSHOT" = "yes" ]; then
     VERSION="${VERSION}-SNAPSHOT"
 fi
 
-mkdir /{{.beat_name}}-${VERSION}-darwin-x64
-cp -a homedirs/{{.beat_name}}/. /{{.beat_name}}-${VERSION}-darwin-x64/
-cp {{.beat_name}}-darwin-amd64 /{{.beat_name}}-${VERSION}-darwin-x64/{{.beat_name}}
-cp {{.beat_name}}-darwin.yml /{{.beat_name}}-${VERSION}-darwin-x64/{{.beat_name}}.yml
-cp {{.beat_name}}-darwin.full.yml /{{.beat_name}}-${VERSION}-darwin-x64/{{.beat_name}}.full.yml
-cp {{.beat_name}}.template.json /{{.beat_name}}-${VERSION}-darwin-x64/
-cp {{.beat_name}}.template-es2x.json /{{.beat_name}}-${VERSION}-darwin-x64/
+mkdir /{{.beat_name}}-${VERSION}-darwin-x86_64
+cp -a homedirs/{{.beat_name}}/. /{{.beat_name}}-${VERSION}-darwin-x86_64/
+cp {{.beat_name}}-darwin-amd64 /{{.beat_name}}-${VERSION}-darwin-x86_64/{{.beat_name}}
+cp {{.beat_name}}-darwin.yml /{{.beat_name}}-${VERSION}-darwin-x86_64/{{.beat_name}}.yml
+cp {{.beat_name}}-darwin.full.yml /{{.beat_name}}-${VERSION}-darwin-x86_64/{{.beat_name}}.full.yml
+cp {{.beat_name}}.template.json /{{.beat_name}}-${VERSION}-darwin-x86_64/
+cp {{.beat_name}}.template-es2x.json /{{.beat_name}}-${VERSION}-darwin-x86_64/
 
 mkdir -p upload/{{.beat_name}}
-tar czvf upload/{{.beat_name}}/{{.beat_name}}-${VERSION}-darwin-x64.tar.gz /{{.beat_name}}-${VERSION}-darwin-x64
-echo "Created upload/{{.beat_name}}/{{.beat_name}}-${VERSION}-darwin-x64.tar.gz"
+tar czvf upload/{{.beat_name}}/{{.beat_name}}-${VERSION}-darwin-x86_64.tar.gz /{{.beat_name}}-${VERSION}-darwin-x86_64
+echo "Created upload/{{.beat_name}}/{{.beat_name}}-${VERSION}-darwin-x86_64.tar.gz"
 
 cd upload/{{.beat_name}}
-sha1sum {{.beat_name}}-${VERSION}-darwin-x64.tar.gz > {{.beat_name}}-${VERSION}-darwin-x64.tar.gz.sha1.txt
-echo "Created upload/{{.beat_name}}/{{.beat_name}}-${VERSION}-darwin-x64.tar.gz.sha1.txt"
+sha1sum {{.beat_name}}-${VERSION}-darwin-x86_64.tar.gz > {{.beat_name}}-${VERSION}-darwin-x86_64.tar.gz.sha1.txt
+echo "Created upload/{{.beat_name}}/{{.beat_name}}-${VERSION}-darwin-x86_64.tar.gz.sha1.txt"


### PR DESCRIPTION
* Fixes #1808.
* x86_64 is more common in config management tools, so it is easier
  to work with.
* The DEB/RPM still use their recommended arch names.