### PR TITLE
Improve stop-environment command

### DIFF
--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -261,8 +261,7 @@ start-environment: stop-environment
 .PHONY: stop-environment
 stop-environment:
 	-${DOCKER_COMPOSE} stop
-	-${DOCKER_COMPOSE} rm -f
-	-docker ps -a  | grep ${BEATNAME} | grep Exited | awk '{print $$1}' | xargs docker rm
+	-${DOCKER_COMPOSE} rm -f -v -a
 
 .PHONY: write-environment
 write-environment:


### PR DESCRIPTION
The stop-environment command now also removes volumes from contains and potential contaiiners which were only run once. This should eliminiate the tangling volume issue on Jenkins.