### PR TITLE
Start a new harvester when file was truncated

### DIFF
--- a/filebeat/harvester/log.go
+++ b/filebeat/harvester/log.go
@@ -2,7 +2,6 @@ package harvester
 
 import (
 	"errors"
-	"io"
 	"os"
 
 	"golang.org/x/text/transform"
@@ -64,17 +63,9 @@ func (h *Harvester) Harvest() {
 		ts, text, bytesRead, jsonFields, err := readLine(reader)
 		if err != nil {
 			if err == errFileTruncate {
-				seeker, ok := h.file.(io.Seeker)
-				if !ok {
-					logp.Err("can not seek source")
-					return
-				}
-
 				logp.Info("File was truncated. Begin reading file from offset 0: %s", h.Path)
-
 				h.SetOffset(0)
-				seeker.Seek(h.getOffset(), os.SEEK_SET)
-				continue
+				return
 			}
 
 			logp.Info("Read line error: %s", err)


### PR DESCRIPTION
Currently file truncation was handeld by the reader. In case of truncation, the same harvester stayed open and the reader just continued reading from the beginning. This is the most efficient way to make sure the truncated file is immidiately read.

From a logical point of view, truncation of a file is very similar to creating a new file. Instead of letting the reader just continue, the harvester is closed and a completely new harvester is started with a new reader. This means the reader only needs to detect a truncation, but doesnt' have to decide what happens.

The consequence of this change is that it can take up to `scan_frequency` to read the truncated file, but that is the same behaviour as for a new file. In addition the file handler will be closed when the old harvester is stopped.