### PR TITLE
Change titles in config reference topics

### DIFF
--- a/filebeat/docs/reference/configuration.asciidoc
+++ b/filebeat/docs/reference/configuration.asciidoc
@@ -22,7 +22,6 @@ configuration settings, you need to restart Filebeat to pick up the changes.
 * <<configuration-output-tls>>
 * <<configuration-path>>
 * <<configuration-logging>>
-* <<configuration-run-options>>
 
 include::configuration/filebeat-options.asciidoc[]
 

--- a/filebeat/docs/reference/configuration.asciidoc
+++ b/filebeat/docs/reference/configuration.asciidoc
@@ -10,13 +10,16 @@ The configuration options are described in the following sections. After changin
 configuration settings, you need to restart Filebeat to pick up the changes.
 
 * <<configuration-filebeat-options>>
+* <<configuration-global-options>>
+* <<configuration-shipper>>
+* <<configuration-filter>>
 * <<elasticsearch-output>>
 * <<logstash-output>>
-* <<redis-output>>
 * <<kafka-output>>
+* <<redis-output>>
 * <<file-output>>
 * <<console-output>>
-* <<configuration-shipper>>
+* <<configuration-output-tls>>
 * <<configuration-path>>
 * <<configuration-logging>>
 * <<configuration-run-options>>

--- a/filebeat/docs/reference/configuration.asciidoc
+++ b/filebeat/docs/reference/configuration.asciidoc
@@ -11,7 +11,7 @@ configuration settings, you need to restart Filebeat to pick up the changes.
 
 * <<configuration-filebeat-options>>
 * <<configuration-global-options>>
-* <<configuration-shipper>>
+* <<configuration-general>>
 * <<configuration-filter>>
 * <<elasticsearch-output>>
 * <<logstash-output>>

--- a/filebeat/docs/reference/configuration/filebeat-options.asciidoc
+++ b/filebeat/docs/reference/configuration/filebeat-options.asciidoc
@@ -1,5 +1,5 @@
 [[configuration-filebeat-options]]
-=== Filebeat
+=== Filebeat Prospectors Configuration
 
 The `filebeat` section specifies a list of `prospectors` that Filebeat
 uses to locate and process log files. Each prospector item begins with a dash (-)
@@ -44,6 +44,18 @@ The value that you specify here is used as the `input_type` for each event publi
 
 A list of glob-based paths that should be crawled and fetched. Filebeat starts a harvester for
 each file that it finds under the specified paths. You can specify one path per line. Each line begins with a dash (-).
+
+===== encoding
+
+The file encoding to use for reading files that contain international characters.
+See the encoding names http://www.w3.org/TR/encoding/[recommended by the W3C for use in HTML5].
+
+Here are some sample encodings from W3C recommendation:
+
+    * plain, latin1, utf-8, utf-16be-bom, utf-16be, utf-16le, big5, gb18030, gbk, hz-gb-2312,
+    * euc-kr, euc-jp, iso-2022-jp, shift-jis, and so on
+
+The `plain` encoding is special, because it does not validate or transform any input.
 
 [[exclude-lines]]
 ===== exclude_lines
@@ -329,6 +341,13 @@ You can force Filebeat to close the file as soon as the file name changes by set
 `force_close_files` option to true. The default is false. Turning on this option can lead to loss of data on
 rotated files in case not all lines were read from the rotated file.
 
+[[configuration-global-options]]
+=== Filebeat Global Configuration
+
+You can specify configuration options that control Filebeat behavior at a global level.
+
+==== Options
+
 ===== spool_size
 
 The event count spool threshold. This setting forces a network flush if the number of events in the spooler exceeds
@@ -342,7 +361,7 @@ filebeat.spool_size: 2048
 
 ===== publish_async
 
-If enabled, the publisher pipeline in filebeat operates in async mode preparing
+If enabled, the publisher pipeline in Filebeat operates in async mode preparing
 a new batch of lines while waiting for ACK. This option can improve load-balancing
 throughput at the cost of increased memory usage. The default value is false.
 
@@ -386,27 +405,14 @@ If the specified path is not absolute, it is considered relative to the configur
 filebeat.config_dir: path/to/configs
 -------------------------------------------------------------------------------------
 
-===== encoding
+include::../../../../libbeat/docs/shipperconfig.asciidoc[]
 
-The file encoding to use for reading files that contain international characters.
-See the encoding names http://www.w3.org/TR/encoding/[recommended by the W3C for use in HTML5].
-
-Here are some sample encodings from W3C recommendation:
-
-    * plain, latin1, utf-8, utf-16be-bom, utf-16be, utf-16le, big5, gb18030, gbk, hz-gb-2312,
-    * euc-kr, euc-jp, iso-2022-jp, shift-jis, and so on
-
-The `plain` encoding is special, because it does not validate or transform any input.
+include::../../../../libbeat/docs/filteringconfig.asciidoc[]
 
 include::../../../../libbeat/docs/outputconfig.asciidoc[]
-
-include::../../../../libbeat/docs/shipperconfig.asciidoc[]
 
 include::../../../../libbeat/docs/shared-path-config.asciidoc[]
 
 include::../../../../libbeat/docs/loggingconfig.asciidoc[]
 
 include::../../../../libbeat/docs/runconfig.asciidoc[]
-
-include::../../../../libbeat/docs/filteringconfig.asciidoc[]
-

--- a/filebeat/docs/reference/configuration/filebeat-options.asciidoc
+++ b/filebeat/docs/reference/configuration/filebeat-options.asciidoc
@@ -414,5 +414,3 @@ include::../../../../libbeat/docs/outputconfig.asciidoc[]
 include::../../../../libbeat/docs/shared-path-config.asciidoc[]
 
 include::../../../../libbeat/docs/loggingconfig.asciidoc[]
-
-include::../../../../libbeat/docs/runconfig.asciidoc[]

--- a/filebeat/docs/reference/configuration/filebeat-options.asciidoc
+++ b/filebeat/docs/reference/configuration/filebeat-options.asciidoc
@@ -122,7 +122,7 @@ See <<regexp-support>> for a list of supported regexp patterns.
 A list of tags that the Beat includes in the `tags` field of each published
 event. Tags make it easy to select specific events in Kibana or apply
 conditional filtering in Logstash. These tags will be appended to the list of
-tags specified in the `shipper` configuration.
+tags specified in the general configuration.
 
 Example:
 
@@ -142,7 +142,7 @@ data. Fields can be scalar values, arrays, dictionaries, or any nested
 combination of these. By default, the fields that you specify here will be
 grouped under a `fields` sub-dictionary in the output document. To store the
 custom fields as top-level fields, set the `fields_under_root` option to true.
-If a duplicate field is declared in the `shipper` configuration, then its value
+If a duplicate field is declared in the general configuration, then its value
 will be overwritten by the value declared here.
 
 [source,yaml]
@@ -405,7 +405,7 @@ If the specified path is not absolute, it is considered relative to the configur
 filebeat.config_dir: path/to/configs
 -------------------------------------------------------------------------------------
 
-include::../../../../libbeat/docs/shipperconfig.asciidoc[]
+include::../../../../libbeat/docs/generalconfig.asciidoc[]
 
 include::../../../../libbeat/docs/filteringconfig.asciidoc[]
 

--- a/libbeat/docs/filteringconfig.asciidoc
+++ b/libbeat/docs/filteringconfig.asciidoc
@@ -11,7 +11,7 @@
 //////////////////////////////////////////////////////////////////////////
 
 [[configuration-filter]]
-=== Filter
+=== Filters Configuration
 
 You can set a list of filter actions in the `filters` section of the {beatname_uc} config file to reduce the number of fields that are
 exported by the Beat. 

--- a/libbeat/docs/generalconfig.asciidoc
+++ b/libbeat/docs/generalconfig.asciidoc
@@ -6,11 +6,11 @@
 //// Use the appropriate variables defined in the index.asciidoc file to
 //// resolve Beat names: beatname_uc and beatname_lc.
 //// Use the following include to pull this content into a doc file:
-//// include::../../libbeat/docs/shipperconfig.asciidoc[]
+//// include::../../libbeat/docs/generalconfig.asciidoc[]
 //// Make sure this content appears below a level 2 heading.
 //////////////////////////////////////////////////////////////////////////
 
-[[configuration-shipper]]
+[[configuration-general]]
 === General Configuration
 
 The general section contains configuration options for the Beat and some

--- a/libbeat/docs/installing-beats.asciidoc
+++ b/libbeat/docs/installing-beats.asciidoc
@@ -2,7 +2,7 @@
 ////////////////////////////////////////////////////////////////////
 ///// The content about individual configuration options has been
 ///// moved to the following files:
-///// shipperconfig.asciidoc for Shipper options
+///// generalconfig.asciidoc for General options
 ///// outputconfig.asciidoc for Output options
 ///// loggingconfig.asciidoc for Logging options
 ///// runconfig.asciidoc for Run Configuration options
@@ -10,7 +10,7 @@
 ///// include the content in the guide for your Beat by using the
 ///// following asciidoc include statements:
 ///// include::../../libbeat/docs/outputconfig.asciidoc[]
-///// include::../../libbeat/docs/shipperconfig.asciidoc[]
+///// include::../../libbeat/docs/generalconfig.asciidoc[]
 ///// include::../../libbeat/docs/loggingconfig.asciidoc[]
 ///// include::../../libbeat/docs/runconfig.asciidoc[]
 ////////////////////////////////////////////////////////////////////

--- a/libbeat/docs/loggingconfig.asciidoc
+++ b/libbeat/docs/loggingconfig.asciidoc
@@ -11,7 +11,7 @@
 //////////////////////////////////////////////////////////////////////////
 
 [[configuration-logging]]
-=== Logging (Optional)
+=== Logging Configuration (Optional)
 
 The `logging` section contains options for configuring the Beats logging output.
 The logging system can write logs to syslog or rotate log files. If logging is

--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -11,7 +11,7 @@
 //////////////////////////////////////////////////////////////////////////
 
 [[elasticsearch-output]]
-=== Elasticsearch Output
+=== Elasticsearch Output Configuration
 
 When you specify Elasticsearch for the output, the Beat sends the transactions directly to Elasticsearch by using the Elasticsearch HTTP API.
 
@@ -272,7 +272,7 @@ See <<configuration-output-tls>> for more information.
 
 
 [[logstash-output]]
-=== Logstash Output
+=== Logstash Output Configuration
 
 The Logstash output sends the events directly to Logstash by using the lumberjack
 protocol, which runs over TCP. To use this option, you must
@@ -486,8 +486,93 @@ Beats that publish single events (such as Packetbeat) send each event directly t
 Elasticsearch. Beats that publish data in batches (such as Filebeat) send events in batches based on the
 spooler size.
 
+[[kafka-output]]
+=== Kafka Output Configuration
+
+The Kafka output sends the events to Apache Kafka.
+
+==== Kafka Output Options
+
+You can specify the following options in the `kafka` section:
+
+===== hosts
+
+The list of Kafka broker addresses from where to fetch the cluster metadata.
+The cluster metadata contain the actual Kafka brokers events are published to.
+
+===== topic
+
+The Kafka topic used for produced events. If `use_type` is set to true, the topic will not be used.
+
+===== use_type
+
+Set Kafka topic by event type. If `use_type` is false, the `topic` option must be configured. The default is false.
+
+===== client_id
+
+The configurable ClientID used for logging, debugging, and auditing purposes. The default is "beats".
+
+===== worker
+
+The number of concurrent load-balanced Kafka output workers.
+
+===== max_retries
+
+The number of times to retry publishing an event after a publishing failure.
+After the specified number of retries, the events are typically dropped.
+Some Beats, such as Filebeat, ignore the `max_retries` setting and retry until all
+events are published.
+
+Set `max_retries` to a value less than 0 to retry until all events are published. 
+
+The default is 3.
+
+===== bulk_max_size
+
+The maximum number of events to bulk in a single Kafka request. The default is 2048.
+
+===== timeout
+
+The number of seconds to wait for responses from the Kafka brokers before timing
+out. The default is 30 (seconds).
+
+===== broker_timeout
+
+The maximum duration a broker will wait for number of required ACKs. The default is 10s.
+
+===== channel_buffer_size
+
+Per Kafka broker number of messages buffered in output pipeline. The default is 256.
+
+===== keep_alive
+
+The keep-alive period for an active network connection. If 0s, keep-alives are disabled. The default is 0 seconds.
+
+===== compression
+
+Sets the output compression codec. Must be one of `none`, `snappy` and `gzip`. The default is `gzip`.
+
+===== max_message_bytes
+
+The maximum permitted size of JSON-encoded messages. Bigger messages will be dropped. The default value is 1000000 (bytes). This value should be equal to or less than the broker's `message.max.bytes`.
+
+===== required_acks
+
+The ACK reliability level required from broker. 0=no response, 1=wait for local commit, -1=wait for all replicas to commit. The default is 1.
+
+Note: If set to 0, no ACKs are returned by Kafka. Messages might be lost silently on error.
+
+===== flush_interval
+
+The number of seconds to wait for new events between two producer API calls.
+
+===== tls
+
+Configuration options for TLS parameters like the root CA for Kibana connections. See
+<<configuration-output-tls>> for more information.
+
 [[redis-output]]
-=== Redis Output
+=== Redis Output Configuration
 
 The Redis output inserts the events into a Redis list or a Redis channel.
 This output plugin is compatible with
@@ -634,94 +719,8 @@ client. You can change this behavior by setting the
 This option determines whether Redis hostnames are resolved locally when using a proxy.
 The default value is false, which means that name resolution occurs on the proxy server.
 
-
-[[kafka-output]]
-=== Kafka Output
-
-The Kafka output sends the events to Apache Kafka.
-
-==== Kafka Output Options
-
-You can specify the following options in the `kafka` section:
-
-===== hosts
-
-The list of Kafka broker addresses from where to fetch the cluster metadata.
-The cluster metadata contain the actual Kafka brokers events are published to.
-
-===== topic
-
-The Kafka topic used for produced events. If `use_type` is set to true, the topic will not be used.
-
-===== use_type
-
-Set Kafka topic by event type. If `use_type` is false, the `topic` option must be configured. The default is false.
-
-===== client_id
-
-The configurable ClientID used for logging, debugging, and auditing purposes. The default is "beats".
-
-===== worker
-
-The number of concurrent load-balanced Kafka output workers.
-
-===== max_retries
-
-The number of times to retry publishing an event after a publishing failure.
-After the specified number of retries, the events are typically dropped.
-Some Beats, such as Filebeat, ignore the `max_retries` setting and retry until all
-events are published.
-
-Set `max_retries` to a value less than 0 to retry until all events are published. 
-
-The default is 3.
-
-===== bulk_max_size
-
-The maximum number of events to bulk in a single Kafka request. The default is 2048.
-
-===== timeout
-
-The number of seconds to wait for responses from the Kafka brokers before timing
-out. The default is 30 (seconds).
-
-===== broker_timeout
-
-The maximum duration a broker will wait for number of required ACKs. The default is 10s.
-
-===== channel_buffer_size
-
-Per Kafka broker number of messages buffered in output pipeline. The default is 256.
-
-===== keep_alive
-
-The keep-alive period for an active network connection. If 0s, keep-alives are disabled. The default is 0 seconds.
-
-===== compression
-
-Sets the output compression codec. Must be one of `none`, `snappy` and `gzip`. The default is `gzip`.
-
-===== max_message_bytes
-
-The maximum permitted size of JSON-encoded messages. Bigger messages will be dropped. The default value is 1000000 (bytes). This value should be equal to or less than the broker's `message.max.bytes`.
-
-===== required_acks
-
-The ACK reliability level required from broker. 0=no response, 1=wait for local commit, -1=wait for all replicas to commit. The default is 1.
-
-Note: If set to 0, no ACKs are returned by Kafka. Messages might be lost silently on error.
-
-===== flush_interval
-
-The number of seconds to wait for new events between two producer API calls.
-
-===== tls
-
-Configuration options for TLS parameters like the root CA for Kibana connections. See
-<<configuration-output-tls>> for more information.
-
 [[file-output]]
-=== File Output
+=== File Output Configuration
 
 The File output dumps the transactions into a file where each transaction is in a JSON format.
 Currently, this output is used for testing, but it can be used as input for
@@ -774,7 +773,7 @@ oldest file is deleted, and the rest of the files are shifted from last to first
 is 7 files.
 
 [[console-output]]
-=== Console Output
+=== Console Output Configuration
 
 The Console output writes events in JSON format to stdout.
 
@@ -803,7 +802,7 @@ Setting `bulk_max_size` to values less than or equal to 0 disables buffering in 
 
 [[configuration-output-tls]]
 
-=== TLS Options
+=== TLS Configuration
 
 You can specify TLS options for any output that supports TLS. 
 

--- a/libbeat/docs/runconfig.asciidoc
+++ b/libbeat/docs/runconfig.asciidoc
@@ -11,7 +11,7 @@
 //////////////////////////////////////////////////////////////////////////
 
 [[configuration-run-options]]
-=== Run Options (Optional)
+=== Run Options Configuration (Optional)
 
 The Beat can drop privileges after creating the sniffing socket.
 Root access is required for opening the socket, but everything else requires no

--- a/libbeat/docs/shared-path-config.asciidoc
+++ b/libbeat/docs/shared-path-config.asciidoc
@@ -11,7 +11,7 @@
 //////////////////////////////////////////////////////////////////////////
 
 [[configuration-path]]
-=== Path
+=== Paths Configuration
 
 The `path` section contains configuration options that define where the Beat
 looks for its files. For example, all Beats look for the Elasticsearch

--- a/libbeat/docs/shipperconfig.asciidoc
+++ b/libbeat/docs/shipperconfig.asciidoc
@@ -11,9 +11,9 @@
 //////////////////////////////////////////////////////////////////////////
 
 [[configuration-shipper]]
-=== Top level configuration options
+=== General Configuration
 
-The top level section contains configuration options for the Beat and some
+The general section contains configuration options for the Beat and some
 general settings that control its behaviour.
 
 Here is an example configuration:
@@ -46,7 +46,7 @@ topology_expire: 15
 
 ------------------------------------------------------------------------------
 
-==== Top Level Options
+==== General Options
 
 You can specify the following options:
 

--- a/metricbeat/docs/reference/configuration.asciidoc
+++ b/metricbeat/docs/reference/configuration.asciidoc
@@ -9,7 +9,7 @@ The configuration options are described in the following sections. After changin
 configuration settings, you need to restart {beatname_uc} to pick up the changes.
 
 * <<configuration-metricbeat>>
-* <<configuration-shipper>>
+* <<configuration-general>>
 * <<configuration-filter>>
 * <<elasticsearch-output>>
 * <<logstash-output>>

--- a/metricbeat/docs/reference/configuration.asciidoc
+++ b/metricbeat/docs/reference/configuration.asciidoc
@@ -20,6 +20,5 @@ configuration settings, you need to restart {beatname_uc} to pick up the changes
 * <<configuration-output-tls>>
 * <<configuration-path>>
 * <<configuration-logging>>
-* <<configuration-run-options>>
 
 include::configuration/metricbeat-options.asciidoc[]

--- a/metricbeat/docs/reference/configuration.asciidoc
+++ b/metricbeat/docs/reference/configuration.asciidoc
@@ -9,13 +9,15 @@ The configuration options are described in the following sections. After changin
 configuration settings, you need to restart {beatname_uc} to pick up the changes.
 
 * <<configuration-metricbeat>>
+* <<configuration-shipper>>
+* <<configuration-filter>>
 * <<elasticsearch-output>>
 * <<logstash-output>>
-* <<redis-output>>
 * <<kafka-output>>
+* <<redis-output>>
 * <<file-output>>
 * <<console-output>>
-* <<configuration-shipper>>
+* <<configuration-output-tls>>
 * <<configuration-path>>
 * <<configuration-logging>>
 * <<configuration-run-options>>

--- a/metricbeat/docs/reference/configuration/metricbeat-options.asciidoc
+++ b/metricbeat/docs/reference/configuration/metricbeat-options.asciidoc
@@ -75,7 +75,7 @@ List of tags
 
 Dict of fields
 
-include::../../../../libbeat/docs/shipperconfig.asciidoc[]
+include::../../../../libbeat/docs/generalconfig.asciidoc[]
 
 include::../../../../libbeat/docs/filteringconfig.asciidoc[]
 

--- a/metricbeat/docs/reference/configuration/metricbeat-options.asciidoc
+++ b/metricbeat/docs/reference/configuration/metricbeat-options.asciidoc
@@ -1,5 +1,5 @@
 [[configuration-metricbeat]]
-=== Metricbeat
+=== Modules Configuration
 
 The `metricbeat.modules` section contains an array with the enabled modules.
 Please see the <<metricbeat-modules>> section for details about the available
@@ -75,16 +75,14 @@ List of tags
 
 Dict of fields
 
+include::../../../../libbeat/docs/shipperconfig.asciidoc[]
 
+include::../../../../libbeat/docs/filteringconfig.asciidoc[]
 
 include::../../../../libbeat/docs/outputconfig.asciidoc[]
-
-include::../../../../libbeat/docs/shipperconfig.asciidoc[]
 
 include::../../../../libbeat/docs/shared-path-config.asciidoc[]
 
 include::../../../../libbeat/docs/loggingconfig.asciidoc[]
 
 include::../../../../libbeat/docs/runconfig.asciidoc[]
-
-include::../../../../libbeat/docs/filteringconfig.asciidoc[]

--- a/metricbeat/docs/reference/configuration/metricbeat-options.asciidoc
+++ b/metricbeat/docs/reference/configuration/metricbeat-options.asciidoc
@@ -84,5 +84,3 @@ include::../../../../libbeat/docs/outputconfig.asciidoc[]
 include::../../../../libbeat/docs/shared-path-config.asciidoc[]
 
 include::../../../../libbeat/docs/loggingconfig.asciidoc[]
-
-include::../../../../libbeat/docs/runconfig.asciidoc[]

--- a/packetbeat/docs/reference/configuration.asciidoc
+++ b/packetbeat/docs/reference/configuration.asciidoc
@@ -12,17 +12,18 @@ configuration settings, you need to restart Packetbeat to pick up the changes.
 * <<configuration-flows>>
 * <<configuration-protocols>>
 * <<configuration-processes>>
+* <<configuration-shipper>>
+* <<configuration-filter>>
 * <<elasticsearch-output>>
 * <<logstash-output>>
-* <<redis-output>>
 * <<kafka-output>>
+* <<redis-output>>
 * <<file-output>>
 * <<console-output>>
-* <<configuration-shipper>>
+* <<configuration-output-tls>>
 * <<configuration-path>>
 * <<configuration-logging>>
 * <<configuration-run-options>>
-* <<configuration-filter>>
 
 NOTE: Packetbeat maintains a real-time topology map of all the servers in your network.
 See <<maintaining-topology>> for more details.

--- a/packetbeat/docs/reference/configuration.asciidoc
+++ b/packetbeat/docs/reference/configuration.asciidoc
@@ -12,7 +12,7 @@ configuration settings, you need to restart Packetbeat to pick up the changes.
 * <<configuration-flows>>
 * <<configuration-protocols>>
 * <<configuration-processes>>
-* <<configuration-shipper>>
+* <<configuration-general>>
 * <<configuration-filter>>
 * <<elasticsearch-output>>
 * <<logstash-output>>

--- a/packetbeat/docs/reference/configuration/packetbeat-options.asciidoc
+++ b/packetbeat/docs/reference/configuration/packetbeat-options.asciidoc
@@ -720,7 +720,7 @@ periodically afterwards, it scans the process table for
 processes that match the values specified for this option. The match is done against the
 process' command line as read from `/proc/<pid>/cmdline`.
 
-include::../../../../libbeat/docs/shipperconfig.asciidoc[]
+include::../../../../libbeat/docs/generalconfig.asciidoc[]
 
 include::../../../../libbeat/docs/filteringconfig.asciidoc[]
 

--- a/packetbeat/docs/reference/configuration/packetbeat-options.asciidoc
+++ b/packetbeat/docs/reference/configuration/packetbeat-options.asciidoc
@@ -1,5 +1,5 @@
 [[configuration-interfaces]]
-=== Interfaces
+=== Network Device Configuration
 
 The `interfaces` section configures the sniffer. Here is an example configuration:
 
@@ -171,7 +171,7 @@ ports defined in the `protocols` section.
 
 
 [[configuration-flows]]
-=== Flows
+=== Flows Configuration
 
 The `flows` section contains configuration options for bidirectional network
 flows. If section is missing from configuration file, network flows are
@@ -202,7 +202,7 @@ disabled, flows are still reported once being timed out. The default value is
 
 
 [[configuration-protocols]]
-=== Protocols
+=== Transaction Protocols Configuration
 
 The `protocols` section contains configuration options for each supported protocol, including
 common options like `ports`, `send_request`, `send_response`, and options that are protocol-specific.
@@ -622,7 +622,7 @@ to a relatively high value. The default is 500.
 
 
 [[configuration-mongodb]]
-==== MongoDB Configuration
+==== MongoDB Configuration Options
 
 The following settings are specific to the MongoDB protocol. Here is a sample
 configuration section:
@@ -660,7 +660,7 @@ Note that limiting documents in this way means that they are no longer correctly
 formatted JSON objects.
 
 [[configuration-processes]]
-=== Processes (Optional)
+=== Monitored Processes Configuration (Optional)
 
 This section is optional, but configuring the processes enables Packetbeat
 to show you not only the servers that the traffic is flowing between, but
@@ -720,9 +720,11 @@ periodically afterwards, it scans the process table for
 processes that match the values specified for this option. The match is done against the
 process' command line as read from `/proc/<pid>/cmdline`.
 
-include::../../../../libbeat/docs/outputconfig.asciidoc[]
-
 include::../../../../libbeat/docs/shipperconfig.asciidoc[]
+
+include::../../../../libbeat/docs/filteringconfig.asciidoc[]
+
+include::../../../../libbeat/docs/outputconfig.asciidoc[]
 
 include::../../../../libbeat/docs/shared-path-config.asciidoc[]
 
@@ -730,4 +732,3 @@ include::../../../../libbeat/docs/loggingconfig.asciidoc[]
 
 include::../../../../libbeat/docs/runconfig.asciidoc[]
 
-include::../../../../libbeat/docs/filteringconfig.asciidoc[]

--- a/topbeat/docs/reference/configuration.asciidoc
+++ b/topbeat/docs/reference/configuration.asciidoc
@@ -16,7 +16,7 @@ configuration settings, you need to restart Topbeat to pick up the changes.
 * <<kafka-output>>
 * <<file-output>>
 * <<console-output>>
-* <<configuration-shipper>>
+* <<configuration-general>>
 * <<configuration-path>>
 * <<configuration-logging>>
 * <<configuration-run-options>>

--- a/winlogbeat/docs/reference/configuration.asciidoc
+++ b/winlogbeat/docs/reference/configuration.asciidoc
@@ -10,13 +10,15 @@ The configuration options are described in the following sections. After changin
 configuration settings, you need to restart Winlogbeat to pick up the changes.
 
 * <<configuration-winlogbeat-options>>
+* <<configuration-shipper>>
+* <<configuration-filter>>
 * <<elasticsearch-output>>
 * <<logstash-output>>
-* <<redis-output>>
 * <<kafka-output>>
+* <<redis-output>>
 * <<file-output>>
 * <<console-output>>
-* <<configuration-shipper>>
+* <<configuration-output-tls>>
 * <<configuration-path>>
 * <<configuration-logging>>
 * <<configuration-run-options>>

--- a/winlogbeat/docs/reference/configuration.asciidoc
+++ b/winlogbeat/docs/reference/configuration.asciidoc
@@ -10,7 +10,7 @@ The configuration options are described in the following sections. After changin
 configuration settings, you need to restart Winlogbeat to pick up the changes.
 
 * <<configuration-winlogbeat-options>>
-* <<configuration-shipper>>
+* <<configuration-general>>
 * <<configuration-filter>>
 * <<elasticsearch-output>>
 * <<logstash-output>>

--- a/winlogbeat/docs/reference/configuration.asciidoc
+++ b/winlogbeat/docs/reference/configuration.asciidoc
@@ -21,7 +21,6 @@ configuration settings, you need to restart Winlogbeat to pick up the changes.
 * <<configuration-output-tls>>
 * <<configuration-path>>
 * <<configuration-logging>>
-* <<configuration-run-options>>
 
 include::configuration/winlogbeat-options.asciidoc[]
 

--- a/winlogbeat/docs/reference/configuration/winlogbeat-options.asciidoc
+++ b/winlogbeat/docs/reference/configuration/winlogbeat-options.asciidoc
@@ -2,7 +2,7 @@
   supporting the Windows Event Log API (Microsoft Windows Vista and newer).
 
 [[configuration-winlogbeat-options]]
-=== Winlogbeat
+=== Winlogbeat Configuration
 
 The `winlogbeat` section specifies all options that are specific to Winlogbeat.
 Most importantly, it contains the list of event logs to monitor.
@@ -290,14 +290,14 @@ The metrics are served as a JSON document. The metrics include:
 - total number of successfully published events
 - uptime
 
-include::../../../../libbeat/docs/outputconfig.asciidoc[]
-
 include::../../../../libbeat/docs/shipperconfig.asciidoc[]
+
+include::../../../../libbeat/docs/filteringconfig.asciidoc[]
+
+include::../../../../libbeat/docs/outputconfig.asciidoc[]
 
 include::../../../../libbeat/docs/shared-path-config.asciidoc[]
 
 include::../../../../libbeat/docs/loggingconfig.asciidoc[]
 
 include::../../../../libbeat/docs/runconfig.asciidoc[]
-
-include::../../../../libbeat/docs/filteringconfig.asciidoc[]

--- a/winlogbeat/docs/reference/configuration/winlogbeat-options.asciidoc
+++ b/winlogbeat/docs/reference/configuration/winlogbeat-options.asciidoc
@@ -228,7 +228,7 @@ winlogbeat.event_logs:
 A list of tags that the Beat includes in the `tags` field of each published
 event. Tags make it easy to select specific events in Kibana or apply
 conditional filtering in Logstash. These tags will be appended to the list of
-tags specified in the `shipper` configuration.
+tags specified in the general configuration.
 
 Example:
 
@@ -248,7 +248,7 @@ data. Fields can be scalar values, arrays, dictionaries, or any nested
 combination of these. By default, the fields that you specify here will be
 grouped under a `fields` sub-dictionary in the output document. To store the
 custom fields as top-level fields, set the `fields_under_root` option to true.
-If a duplicate field is declared in the `shipper` configuration, then its value
+If a duplicate field is declared in the general configuration, then its value
 will be overwritten by the value declared here.
 
 [source,yaml]
@@ -290,7 +290,7 @@ The metrics are served as a JSON document. The metrics include:
 - total number of successfully published events
 - uptime
 
-include::../../../../libbeat/docs/shipperconfig.asciidoc[]
+include::../../../../libbeat/docs/generalconfig.asciidoc[]
 
 include::../../../../libbeat/docs/filteringconfig.asciidoc[]
 

--- a/winlogbeat/docs/reference/configuration/winlogbeat-options.asciidoc
+++ b/winlogbeat/docs/reference/configuration/winlogbeat-options.asciidoc
@@ -299,5 +299,3 @@ include::../../../../libbeat/docs/outputconfig.asciidoc[]
 include::../../../../libbeat/docs/shared-path-config.asciidoc[]
 
 include::../../../../libbeat/docs/loggingconfig.asciidoc[]
-
-include::../../../../libbeat/docs/runconfig.asciidoc[]


### PR DESCRIPTION
This PR resolves issue #1792 

Section titles are renamed to match the section comments in the long version of each config file (hopefully making it easier for users to find what they're looking for in the reference docs).

Some content has been moved around to better match the organization of the config files.