### PR TITLE
Improve Filebeat organisiation and Cleanup

### DIFF
--- a/filebeat/beater/filebeat.go
+++ b/filebeat/beater/filebeat.go
@@ -9,18 +9,15 @@ import (
 	cfg "github.com/elastic/beats/filebeat/config"
 	"github.com/elastic/beats/filebeat/crawler"
 	"github.com/elastic/beats/filebeat/input"
+	"github.com/elastic/beats/filebeat/publish"
+	"github.com/elastic/beats/filebeat/registrar"
+	"github.com/elastic/beats/filebeat/spooler"
 )
 
 // Filebeat is a beater object. Contains all objects needed to run the beat
 type Filebeat struct {
-	FbConfig *cfg.Config
-	// Channel from harvesters to spooler
-	publisherChan chan []*input.FileEvent
-	spooler       *Spooler
-	registrar     *crawler.Registrar
-	crawler       *crawler.Crawler
-	pub           logPublisher
-	done          chan struct{}
+	config *cfg.Config
+	done   chan struct{}
 }
 
 // New creates a new Filebeat pointer instance.
@@ -32,14 +29,13 @@ func New() *Filebeat {
 func (fb *Filebeat) Config(b *beat.Beat) error {
 
 	// Load Base config
-	err := b.RawConfig.Unpack(&fb.FbConfig)
-
+	err := b.RawConfig.Unpack(&fb.config)
 	if err != nil {
 		return fmt.Errorf("Error reading config file: %v", err)
 	}
 
 	// Check if optional config_dir is set to fetch additional prospector config files
-	fb.FbConfig.FetchConfigs()
+	fb.config.FetchConfigs()
 
 	return nil
 }
@@ -47,7 +43,6 @@ func (fb *Filebeat) Config(b *beat.Beat) error {
 // Setup applies the minimum required setup to a new Filebeat instance for use.
 func (fb *Filebeat) Setup(b *beat.Beat) error {
 	fb.done = make(chan struct{})
-
 	return nil
 }
 
@@ -55,50 +50,65 @@ func (fb *Filebeat) Setup(b *beat.Beat) error {
 func (fb *Filebeat) Run(b *beat.Beat) error {
 
 	var err error
-
-	// Init channels
-	fb.publisherChan = make(chan []*input.FileEvent, 1)
+	config := fb.config.Filebeat
 
 	// Setup registrar to persist state
-	fb.registrar, err = crawler.NewRegistrar(fb.FbConfig.Filebeat.RegistryFile)
+	registrar, err := registrar.New(config.RegistryFile)
 	if err != nil {
 		logp.Err("Could not init registrar: %v", err)
 		return err
 	}
 
-	fb.crawler = &crawler.Crawler{
-		Registrar: fb.registrar,
-	}
+	// Channel from harvesters to spooler
+	publisherChan := make(chan []*input.FileEvent, 1)
 
-	// Load the previous log file locations now, for use in prospector
-	err = fb.registrar.LoadState()
-	if err != nil {
-		logp.Err("Error loading state: %v", err)
-		return err
-	}
+	// Publishes event to output
+	publisher := publish.New(config.PublishAsync,
+		publisherChan, registrar.Channel, b.Publisher.Connect())
 
 	// Init and Start spooler: Harvesters dump events into the spooler.
-	fb.spooler = NewSpooler(fb.FbConfig.Filebeat, fb.publisherChan)
-
+	spooler, err := spooler.New(config, publisherChan)
 	if err != nil {
 		logp.Err("Could not init spooler: %v", err)
 		return err
 	}
 
-	fb.registrar.Start()
-	fb.spooler.Start()
-
-	err = fb.crawler.Start(fb.FbConfig.Filebeat.Prospectors, fb.spooler.Channel)
+	crawler, err := crawler.New(spooler, config.Prospectors)
 	if err != nil {
+		logp.Err("Could not init crawler: %v", err)
 		return err
 	}
 
-	// Publishes event to output
-	fb.pub = newPublisher(fb.FbConfig.Filebeat.PublishAsync,
-		fb.publisherChan, fb.registrar.Channel, b.Publisher.Connect())
-	fb.pub.Start()
+	// The order of starting and stopping is important. Stopping is inverted to the starting order.
+	// The current order is: registrar, publisher, spooler, crawler
+	// That means, crawler is stopped first.
 
-	// Blocks progressing
+	// Start the registrar
+	err = registrar.Start()
+	if err != nil {
+		logp.Err("Could not start registrar: %v", err)
+	}
+	// Stopping registrar will write last state
+	defer registrar.Stop()
+
+	// Start publisher
+	publisher.Start()
+	// Stopping publisher (might potentially drop items)
+	defer publisher.Stop()
+
+	// Starting spooler
+	spooler.Start()
+	// Stopping spooler will flush items
+	defer spooler.Stop()
+
+	err = crawler.Start(registrar.GetStates())
+	if err != nil {
+		return err
+	}
+	// Stop crawler -> stop prospectors -> stop harvesters
+	defer crawler.Stop()
+
+	// Blocks progressing. As soon as channel is closed, all defer statements come into play
 	<-fb.done
 
 	return nil
@@ -113,18 +123,6 @@ func (fb *Filebeat) Cleanup(b *beat.Beat) error {
 func (fb *Filebeat) Stop() {
 
 	logp.Info("Stopping filebeat")
-
-	// Stop crawler -> stop prospectors -> stop harvesters
-	fb.crawler.Stop()
-
-	// Stopping spooler will flush items
-	fb.spooler.Stop()
-
-	// stopping publisher (might potentially drop items)
-	fb.pub.Stop()
-
-	// Stopping registrar will write last state
-	fb.registrar.Stop()
 
 	// Stop Filebeat
 	close(fb.done)

--- a/filebeat/beater/filebeat_test.go
+++ b/filebeat/beater/filebeat_test.go
@@ -1,3 +1,0 @@
-// +build !integration
-
-package beater

--- a/filebeat/crawler/crawler_test.go
+++ b/filebeat/crawler/crawler_test.go
@@ -5,17 +5,14 @@ package crawler
 import (
 	"testing"
 
-	"github.com/elastic/beats/filebeat/input"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCrawlerStartError(t *testing.T) {
-	crawler := Crawler{}
-	channel := make(chan *input.FileEvent, 1)
+func TestNewCrawlerNoProspectorsError(t *testing.T) {
 	prospectorConfigs := []*common.Config{}
 
-	error := crawler.Start(prospectorConfigs, channel)
+	_, error := New(nil, prospectorConfigs)
 
 	assert.Error(t, error)
 }

--- a/filebeat/harvester/log.go
+++ b/filebeat/harvester/log.go
@@ -63,7 +63,7 @@ func (h *Harvester) Harvest() {
 		ts, text, bytesRead, jsonFields, err := readLine(reader)
 		if err != nil {
 			if err == errFileTruncate {
-				logp.Info("File was truncated. Begin reading file from offset 0: %s", h.Path)
+				logp.Warn("File was truncated. Begin reading file from offset 0: %s", h.Path)
 				h.SetOffset(0)
 				return
 			}

--- a/filebeat/prospector/prospector.go
+++ b/filebeat/prospector/prospector.go
@@ -130,11 +130,10 @@ func (p *Prospector) Run() {
 	}
 }
 
-func (p *Prospector) Stop(wg *sync.WaitGroup) {
+func (p *Prospector) Stop() {
 	logp.Info("Stopping Prospector")
 	close(p.done)
 	p.wg.Wait()
-	wg.Done()
 }
 
 // createHarvester creates a new harvester instance from the given state
@@ -168,21 +167,4 @@ func (p *Prospector) startHarvester(state input.FileState, offset int64) (*harve
 	}()
 
 	return h, nil
-}
-
-// isIgnoreOlder checks if the given state reached ignore_older
-func (p *Prospector) isIgnoreOlder(state input.FileState) bool {
-
-	// ignore_older is disable
-	if p.config.IgnoreOlder == 0 {
-		return false
-	}
-
-	modTime := state.Fileinfo.ModTime()
-
-	if time.Since(modTime) > p.config.IgnoreOlder {
-		return true
-	}
-
-	return false
 }

--- a/filebeat/prospector/prospector_log.go
+++ b/filebeat/prospector/prospector_log.go
@@ -132,7 +132,7 @@ func (p *ProspectorLog) scan() {
 // harvestNewFile harvest a new file
 func (p *ProspectorLog) harvestNewFile(state input.FileState) {
 
-	if !p.Prospector.isIgnoreOlder(state) {
+	if !p.isIgnoreOlder(state) {
 		logp.Debug("prospector", "Start harvester for new file: %s", state.Source)
 		p.Prospector.startHarvester(state, 0)
 	} else {
@@ -175,4 +175,21 @@ func (p *ProspectorLog) harvestExistingFile(newState input.FileState, oldState i
 func (p *ProspectorLog) isFileExcluded(file string) bool {
 	patterns := p.config.ExcludeFiles
 	return len(patterns) > 0 && harvester.MatchAnyRegexps(patterns, file)
+}
+
+// isIgnoreOlder checks if the given state reached ignore_older
+func (p *ProspectorLog) isIgnoreOlder(state input.FileState) bool {
+
+	// ignore_older is disable
+	if p.config.IgnoreOlder == 0 {
+		return false
+	}
+
+	modTime := state.Fileinfo.ModTime()
+
+	if time.Since(modTime) > p.config.IgnoreOlder {
+		return true
+	}
+
+	return false
 }

--- a/filebeat/prospector/prospector_stdin.go
+++ b/filebeat/prospector/prospector_stdin.go
@@ -8,16 +8,15 @@ import (
 )
 
 type ProspectorStdin struct {
-	Prospector *Prospector
-	harvester  *harvester.Harvester
-	started    bool
+	harvester *harvester.Harvester
+	started   bool
 }
 
+// NewProspectorStdin creates a new stdin prospector
+// This prospector contains one harvester which is reading from stdin
 func NewProspectorStdin(p *Prospector) (*ProspectorStdin, error) {
 
-	prospectorer := &ProspectorStdin{
-		Prospector: p,
-	}
+	prospectorer := &ProspectorStdin{}
 
 	var err error
 

--- a/filebeat/publish/publish.go
+++ b/filebeat/publish/publish.go
@@ -1,4 +1,4 @@
-package beater
+package publish
 
 import (
 	"sync"
@@ -11,7 +11,7 @@ import (
 	"github.com/elastic/beats/libbeat/publisher"
 )
 
-type logPublisher interface {
+type LogPublisher interface {
 	Start()
 	Stop()
 }
@@ -61,11 +61,11 @@ const (
 	batchCanceled
 )
 
-func newPublisher(
+func New(
 	async bool,
 	in, out chan []*input.FileEvent,
 	client publisher.Client,
-) logPublisher {
+) LogPublisher {
 	if async {
 		return newAsyncLogPublisher(in, out, client)
 	}

--- a/filebeat/publish/publish_test.go
+++ b/filebeat/publish/publish_test.go
@@ -1,6 +1,6 @@
 // +build !integration
 
-package beater
+package publish
 
 import (
 	"fmt"
@@ -47,7 +47,7 @@ func TestPublisherModes(t *testing.T) {
 		regChan := make(chan []*input.FileEvent, len(test.order)+1)
 		client := pubtest.NewChanClient(0)
 
-		pub := newPublisher(test.async, pubChan, regChan, client)
+		pub := New(test.async, pubChan, regChan, client)
 		pub.Start()
 
 		var events [][]*input.FileEvent

--- a/filebeat/spooler/spooler.go
+++ b/filebeat/spooler/spooler.go
@@ -1,4 +1,4 @@
-package beater
+package spooler
 
 import (
 	"sync"
@@ -29,12 +29,12 @@ type Spooler struct {
 	wg            sync.WaitGroup            // WaitGroup used to control the shutdown.
 }
 
-// NewSpooler creates and returns a new Spooler. The returned Spooler must be
+// New creates and returns a new Spooler. The returned Spooler must be
 // started by calling Start before it can be used.
-func NewSpooler(
+func New(
 	config cfg.FilebeatConfig,
 	publisher chan<- []*input.FileEvent,
-) *Spooler {
+) (*Spooler, error) {
 	spoolSize := config.SpoolSize
 	if spoolSize <= 0 {
 		spoolSize = cfg.DefaultSpoolSize
@@ -55,7 +55,7 @@ func NewSpooler(
 		nextFlushTime: time.Now().Add(idleTimeout),
 		publisher:     publisher,
 		spool:         make([]*input.FileEvent, 0, spoolSize),
-	}
+	}, nil
 }
 
 // Start starts the Spooler. Stop must be called to stop the Spooler.

--- a/filebeat/spooler/spooler_test.go
+++ b/filebeat/spooler/spooler_test.go
@@ -1,6 +1,6 @@
 // +build !integration
 
-package beater
+package spooler
 
 import (
 	"testing"
@@ -30,8 +30,9 @@ func TestNewSpoolerDefaultConfig(t *testing.T) {
 	config := load(t, "")
 
 	// Read from empty yaml config
-	spooler := NewSpooler(config, nil)
+	spooler, err := New(config, nil)
 
+	assert.NoError(t, err)
 	assert.Equal(t, cfg.DefaultSpoolSize, spooler.spoolSize)
 	assert.Equal(t, cfg.DefaultIdleTimeout, spooler.idleTimeout)
 }
@@ -39,14 +40,16 @@ func TestNewSpoolerDefaultConfig(t *testing.T) {
 func TestNewSpoolerSpoolSize(t *testing.T) {
 	spoolSize := uint64(19)
 	config := cfg.FilebeatConfig{SpoolSize: spoolSize}
-	spooler := NewSpooler(config, nil)
+	spooler, err := New(config, nil)
 
+	assert.NoError(t, err)
 	assert.Equal(t, spoolSize, spooler.spoolSize)
 }
 
 func TestNewSpoolerIdleTimeout(t *testing.T) {
 	config := load(t, "idle_timeout: 10s")
-	spooler := NewSpooler(config, nil)
+	spooler, err := New(config, nil)
 
+	assert.NoError(t, err)
 	assert.Equal(t, time.Duration(10*time.Second), spooler.idleTimeout)
 }


### PR DESCRIPTION
The overall goal is to decouple all the modules to make them better reusable and extendable.
In addition the current organisation was not very intuitive.

* Move registrar to its own package
* Improve startup handling of filebeat
* Rename state to states in registrar as this is more accurate
* Add warn message for truncated files. See https://github.com/elastic/beats/pull/1882/files#r67523587
* Move ignore older to ProspectorLog as only used there
* Remove Prospector reference from ProspectorStdin
* Remove empty filebeat test file
* Cleanup New function naming
* Implement defer statements to stop running services
* Clean up crawler / prospector stopping