### PR TITLE
Add close_removed and close_renamed, deprecate force_close_files

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -22,6 +22,9 @@ https://github.com/elastic/beats/compare/v5.0.0-alpha3...master[Check the HEAD d
 
 *Filebeat*
 
+- Stop following symlink. Symlinks are now ignored: {pull}1686[1686]
+- Deprecate force_close_files option and replace it with close_removed and close_renamed {issue}1600[1600]
+
 *Winlogbeat*
 
 
@@ -50,6 +53,8 @@ https://github.com/elastic/beats/compare/v5.0.0-alpha3...master[Check the HEAD d
 *Topbeat*
 
 *Filebeat*
+- Introdce close_removed and close_renamed harvester options {issue}1600[1600]
+
 
 *Winlogbeat*
 

--- a/filebeat/etc/beat.full.yml
+++ b/filebeat/etc/beat.full.yml
@@ -166,22 +166,22 @@ filebeat.prospectors:
   # The backoff value will be multiplied each time with the backoff_factor until max_backoff is reached
   #backoff_factor: 2
 
-  # This option closes a file, as soon as the file name changes.
-  # This config option is recommended on windows only. Filebeat keeps the files it's reading open. This can cause
-  # issues when the file is removed, as the file will not be fully removed until also Filebeat closes
-  # the reading. Filebeat closes the file handler after ignore_older. During this time no new file with the
-  # same name can be created. Turning this feature on the other hand can lead to loss of data
-  # on rotate files. It can happen that after file rotation the beginning of the new
-  # file is skipped, as the reading starts at the end. We recommend to leave this option on false
-  # but lower the ignore_older value to release files faster.
-  #force_close_files: false
+  # Close renamed ensures a file handler is closed when the file is renamed or rotated.
+  # Note: Potential data loss if renamed file is not picked up by prospector.
+  #close_renamed: false
+
+  # When enabling this option, a file handler is closed immidiately in case a file can't be found
+  # any more. In case the file shows up again later, harvesting will continue at the last known position
+  # after scan_frequency.
+  # Note: Potential data loss if file reading was not finished when file was removed.
+  #close_removed: false
 
 #----------------------------- Stdin prospector -------------------------------
 # Configuration to use stdin input
 #- input_type: stdin
 
 #========================= Filebeat global options ============================
-  
+
 # Event count spool threshold - forces network flush if exceeded
 #filebeat.spool_size: 2048
 

--- a/filebeat/filebeat.full.yml
+++ b/filebeat/filebeat.full.yml
@@ -166,14 +166,14 @@ filebeat.prospectors:
   # The backoff value will be multiplied each time with the backoff_factor until max_backoff is reached
   #backoff_factor: 2
 
-  # Close renamed means a file handler is close when a file is renamed / rotated. In case the harvester was
-  # not finished reading the roated file, the file will be picked up again after scan_frequency in case it
-  # also matches the prospector patterns.
+  # Close renamed ensures a file handler is closed when the file is renamed or rotated.
+  # Note: Potential data loss if renamed file is not picked up by prospector.
   #close_renamed: false
 
   # When enabling this option, a file handler is closed immidiately in case a file can't be found
-  # any more. In case the file shows up again later, harvesting will continue at the last position
-  # after scan_frequency
+  # any more. In case the file shows up again later, harvesting will continue at the last known position
+  # after scan_frequency.
+  # Note: Potential data loss if file reading was not finished when file was removed.
   #close_removed: false
 
 #----------------------------- Stdin prospector -------------------------------

--- a/filebeat/filebeat.full.yml
+++ b/filebeat/filebeat.full.yml
@@ -166,22 +166,22 @@ filebeat.prospectors:
   # The backoff value will be multiplied each time with the backoff_factor until max_backoff is reached
   #backoff_factor: 2
 
-  # This option closes a file, as soon as the file name changes.
-  # This config option is recommended on windows only. Filebeat keeps the files it's reading open. This can cause
-  # issues when the file is removed, as the file will not be fully removed until also Filebeat closes
-  # the reading. Filebeat closes the file handler after ignore_older. During this time no new file with the
-  # same name can be created. Turning this feature on the other hand can lead to loss of data
-  # on rotate files. It can happen that after file rotation the beginning of the new
-  # file is skipped, as the reading starts at the end. We recommend to leave this option on false
-  # but lower the ignore_older value to release files faster.
-  #force_close_files: false
+  # Close renamed means a file handler is close when a file is renamed / rotated. In case the harvester was
+  # not finished reading the roated file, the file will be picked up again after scan_frequency in case it
+  # also matches the prospector patterns.
+  #close_renamed: false
+
+  # When enabling this option, a file handler is closed immidiately in case a file can't be found
+  # any more. In case the file shows up again later, harvesting will continue at the last position
+  # after scan_frequency
+  #close_removed: false
 
 #----------------------------- Stdin prospector -------------------------------
 # Configuration to use stdin input
 #- input_type: stdin
 
 #========================= Filebeat global options ============================
-  
+
 # Event count spool threshold - forces network flush if exceeded
 #filebeat.spool_size: 2048
 

--- a/filebeat/harvester/config_test.go
+++ b/filebeat/harvester/config_test.go
@@ -1,0 +1,22 @@
+package harvester
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestForceCloseFiles(t *testing.T) {
+
+	config := defaultConfig
+	assert.False(t, config.ForceCloseFiles)
+	assert.False(t, config.CloseRemoved)
+	assert.False(t, config.CloseRenamed)
+
+	config.ForceCloseFiles = true
+	config.Validate()
+
+	assert.True(t, config.ForceCloseFiles)
+	assert.True(t, config.CloseRemoved)
+	assert.True(t, config.CloseRenamed)
+}

--- a/filebeat/harvester/reader/log.go
+++ b/filebeat/harvester/reader/log.go
@@ -117,6 +117,7 @@ func (r *logFileReader) Read(buf []byte) (int, error) {
 		}
 
 		if r.config.CloseRenamed {
+			// Check if the file can still be found under the same path
 			if !file.IsSameFile(r.fs.Name(), info) {
 				return n, ErrRenamed
 			}

--- a/filebeat/tests/system/config/filebeat.yml.j2
+++ b/filebeat/tests/system/config/filebeat.yml.j2
@@ -19,7 +19,8 @@ filebeat.prospectors:
   backoff: 0.1s
   backoff_factor: 1
   max_backoff: 0.1s
-  force_close_files: {{force_close_files}}
+  close_removed: {{close_removed}}
+  close_renamed: {{close_renamed}}
 
   {% if fields %}
   fields:

--- a/filebeat/tests/system/test_harvester.py
+++ b/filebeat/tests/system/test_harvester.py
@@ -1,0 +1,106 @@
+from filebeat import BaseTest
+import os
+import socket
+
+"""
+Test Harvesters
+"""
+
+
+class Test(BaseTest):
+
+    def test_close_renamed(self):
+        """
+        Checks that a file is closed when its renamed / rotated
+        """
+
+        self.render_config_template(
+            path=os.path.abspath(self.working_dir) + "/log/test.log",
+            close_renamed="true",
+            scan_frequency="0.1s"
+        )
+        os.mkdir(self.working_dir + "/log/")
+
+        testfile1 = self.working_dir + "/log/test.log"
+        testfile2 = self.working_dir + "/log/test.log.rotated"
+        file = open(testfile1, 'w')
+
+        iterations1 = 5
+        for n in range(0, iterations1):
+            file.write("rotation file")
+            file.write("\n")
+
+        file.close()
+
+        filebeat = self.start_beat()
+
+        # Let it read the file
+        self.wait_until(
+            lambda: self.output_has(lines=iterations1), max_timeout=10)
+
+        os.rename(testfile1, testfile2)
+
+        file = open(testfile1, 'w', 0)
+        file.write("Hello World\n")
+        file.close()
+
+        # Wait until error shows up
+        self.wait_until(
+            lambda: self.log_contains(
+                "Closing because close_renamed is enabled"),
+            max_timeout=15)
+
+        # Let it read the file
+        self.wait_until(
+            lambda: self.output_has(lines=iterations1 + 1), max_timeout=10)
+
+        filebeat.check_kill_and_wait()
+
+        data = self.get_registry()
+
+        # Make sure new file was picked up. As it has the same file name,
+        # one entry for the new and one for the old should exist
+        assert len(data) == 2
+
+
+    def test_close_removed(self):
+        """
+        Checks that a file is closed if removed
+        """
+        self.render_config_template(
+            path=os.path.abspath(self.working_dir) + "/log/test.log",
+            close_removed="true",
+            scan_frequency="0.1s"
+        )
+        os.mkdir(self.working_dir + "/log/")
+
+        testfile1 = self.working_dir + "/log/test.log"
+        file = open(testfile1, 'w')
+
+        iterations1 = 5
+        for n in range(0, iterations1):
+            file.write("rotation file")
+            file.write("\n")
+
+        file.close()
+
+        filebeat = self.start_beat()
+
+        # Let it read the file
+        self.wait_until(
+            lambda: self.output_has(lines=iterations1), max_timeout=10)
+
+        os.remove(testfile1)
+
+        # Wait until error shows up on windows
+        self.wait_until(
+            lambda: self.log_contains(
+                "Closing because close_removed is enabled"),
+            max_timeout=15)
+
+        filebeat.check_kill_and_wait()
+
+        data = self.get_registry()
+
+        # Make sure the state for the file was persisted
+        assert len(data) == 1


### PR DESCRIPTION
force_close_files is replaced by the two option close_removed and close_renamed. Force_close_files is deprecated. In case it is enabled, it sets close_removed and close_renamed to true.

This is part of https://github.com/elastic/beats/issues/1600