### PR TITLE
Update changelog with gzip compression support in the ES output

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -57,7 +57,7 @@ https://github.com/elastic/beats/compare/v5.0.0-alpha3...master[Check the HEAD d
 
 *Affecting all Beats*
 - Improve error message if compiling regular expression from config files fails. {pull}1900[1900]
-
+- Compression support in the Elasticsearch output. {pull}1835[1835]
 
 *Metricbeat*
 


### PR DESCRIPTION
Update changelog with the changes from #1835 