### PR TITLE
Reduce the polling interval in metricbeat sys tests

### DIFF
--- a/metricbeat/tests/system/test_filtering.py
+++ b/metricbeat/tests/system/test_filtering.py
@@ -12,7 +12,7 @@ class GlobalFiltering(metricbeat.BaseTest):
             modules=[{
                 "name": "system",
                 "metricsets": ["cpu"],
-                "period": "5s"
+                "period": "1s"
             }],
             drop_fields={
                 "condition": "range.system.cpu.system.pct.lt: 0.1",
@@ -50,7 +50,7 @@ class GlobalFiltering(metricbeat.BaseTest):
             modules=[{
                 "name": "system",
                 "metricsets": ["process"],
-                "period": "5s"
+                "period": "1s"
             }],
             drop_fields={
                 "fields": ["system.process.memory"],
@@ -82,7 +82,7 @@ class GlobalFiltering(metricbeat.BaseTest):
             modules=[{
                 "name": "system",
                 "metricsets": ["process"],
-                "period": "5s"
+                "period": "1s"
             }],
             drop_event={
                 "condition": "range.system.process.cpu.total.pct.lt: 0.001",
@@ -109,7 +109,7 @@ class GlobalFiltering(metricbeat.BaseTest):
             modules=[{
                 "name": "system",
                 "metricsets": ["process"],
-                "period": "5s"
+                "period": "1s"
             }],
             include_fields={"fields": ["system.process.cpu", "system.process.memory"]},
         )
@@ -149,7 +149,7 @@ class GlobalFiltering(metricbeat.BaseTest):
             modules=[{
                 "name": "system",
                 "metricsets": ["process"],
-                "period": "5s"
+                "period": "1s"
             }],
             include_fields={"fields": ["system.process"]},
             drop_fields={"fields": ["system.process.memory"]},
@@ -188,7 +188,7 @@ class GlobalFiltering(metricbeat.BaseTest):
             modules=[{
                 "name": "system",
                 "metricsets": ["process"],
-                "period": "5s"
+                "period": "1s"
             }],
             include_fields={"fields": ["system.process.memory.size", "proc.memory.rss.pct"]},
             drop_fields={"fields": ["system.process.memory.size", "proc.memory.rss.pct"]},


### PR DESCRIPTION
The theory goes that on the Jenkins slave, when doing % every 5s
there's no process that has significant CPU time. Reducing this to
1s should lower the chance of that happening and probably also speed
up the tests.