### PR TITLE
Unify doc version handling

### DIFF
--- a/filebeat/docs/index.asciidoc
+++ b/filebeat/docs/index.asciidoc
@@ -2,12 +2,12 @@
 
 include::./version.asciidoc[]
 
-:libbeat: http://www.elastic.co/guide/en/beats/libbeat/master
-:packetbeat: http://www.elastic.co/guide/en/beats/packetbeat/master
-:metricbeat: http://www.elastic.co/guide/en/beats/metricbeat/master
-:filebeat: http://www.elastic.co/guide/en/beats/filebeat/master
-:winlogbeat: http://www.elastic.co/guide/en/beats/winlogbeat/master
-:elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/master/
+:libbeat: http://www.elastic.co/guide/en/beats/libbeat/{doc-branch}
+:packetbeat: http://www.elastic.co/guide/en/beats/packetbeat/{doc-branch}
+:metricbeat: http://www.elastic.co/guide/en/beats/metricbeat/{doc-branch}
+:filebeat: http://www.elastic.co/guide/en/beats/filebeat/{doc-branch}
+:winlogbeat: http://www.elastic.co/guide/en/beats/winlogbeat/{doc-branch}
+:elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/{doc-branch}/
 :version: {stack-version}
 :beatname_lc: filebeat
 :beatname_uc: Filebeat

--- a/filebeat/docs/index.asciidoc
+++ b/filebeat/docs/index.asciidoc
@@ -1,11 +1,14 @@
 = Filebeat Reference
+
+include::./version.asciidoc[]
+
 :libbeat: http://www.elastic.co/guide/en/beats/libbeat/master
 :packetbeat: http://www.elastic.co/guide/en/beats/packetbeat/master
 :metricbeat: http://www.elastic.co/guide/en/beats/metricbeat/master
 :filebeat: http://www.elastic.co/guide/en/beats/filebeat/master
 :winlogbeat: http://www.elastic.co/guide/en/beats/winlogbeat/master
 :elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/master/
-:version: 5.0.0-alpha3
+:version: {stack-version}
 :beatname_lc: filebeat
 :beatname_uc: Filebeat
 :security: X-Pack Security

--- a/filebeat/docs/version.asciidoc
+++ b/filebeat/docs/version.asciidoc
@@ -1,0 +1,1 @@
+:stack-version: 5.0.0-alpha3

--- a/filebeat/docs/version.asciidoc
+++ b/filebeat/docs/version.asciidoc
@@ -1,1 +1,2 @@
 :stack-version: 5.0.0-alpha3
+:doc-branch: master

--- a/libbeat/docs/index.asciidoc
+++ b/libbeat/docs/index.asciidoc
@@ -1,14 +1,16 @@
 [[beats-reference]]
 = Beats Platform Reference
+
+include::./version.asciidoc[]
+
 :packetbeat: http://www.elastic.co/guide/en/beats/packetbeat/master
 :metricbeat: http://www.elastic.co/guide/en/beats/metricbeat/master
 :filebeat: http://www.elastic.co/guide/en/beats/filebeat/master
 :winlogbeat: http://www.elastic.co/guide/en/beats/winlogbeat/master
 :security: X-Pack Security
-:ES-version: 5.0.0-alpha3
-:LS-version: 5.0.0-alpha3
-:Kibana-version: 5.0.0-alpha3
-:Dashboards-version: 5.0.0-alpha3
+:ES-version: {stack-version}
+:LS-version: {stack-version}
+:Kibana-version: {stack-version}
 
 include::./overview.asciidoc[]
 

--- a/libbeat/docs/index.asciidoc
+++ b/libbeat/docs/index.asciidoc
@@ -3,10 +3,10 @@
 
 include::./version.asciidoc[]
 
-:packetbeat: http://www.elastic.co/guide/en/beats/packetbeat/master
-:metricbeat: http://www.elastic.co/guide/en/beats/metricbeat/master
-:filebeat: http://www.elastic.co/guide/en/beats/filebeat/master
-:winlogbeat: http://www.elastic.co/guide/en/beats/winlogbeat/master
+:packetbeat: http://www.elastic.co/guide/en/beats/packetbeat/{doc-branch}
+:metricbeat: http://www.elastic.co/guide/en/beats/metricbeat/{doc-branch}
+:filebeat: http://www.elastic.co/guide/en/beats/filebeat/{doc-branch}
+:winlogbeat: http://www.elastic.co/guide/en/beats/winlogbeat/{doc-branch}
 :security: X-Pack Security
 :ES-version: {stack-version}
 :LS-version: {stack-version}

--- a/libbeat/docs/version.asciidoc
+++ b/libbeat/docs/version.asciidoc
@@ -1,0 +1,1 @@
+:stack-version: 5.0.0-alpha3

--- a/libbeat/docs/version.asciidoc
+++ b/libbeat/docs/version.asciidoc
@@ -1,1 +1,2 @@
 :stack-version: 5.0.0-alpha3
+:doc-branch: master

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -230,6 +230,9 @@ update: python-env
 	. ${PYTHON_ENV}/bin/activate && python ${ES_BEATS}/libbeat/scripts/generate_template.py $(PWD) ${BEATNAME} ${ES_BEATS}
 	. ${PYTHON_ENV}/bin/activate && python ${ES_BEATS}/libbeat/scripts/generate_template.py --es2x $(PWD) ${BEATNAME} ${ES_BEATS}
 
+	# Update docs version
+	cp ${ES_BEATS}/libbeat/docs/version.asciidoc docs/version.asciidoc
+
 # Builds the documents for the beat
 .PHONY: docs
 docs:

--- a/metricbeat/docs/index.asciidoc
+++ b/metricbeat/docs/index.asciidoc
@@ -1,8 +1,11 @@
 = Metricbeat Reference
+
+include::./version.asciidoc[]
+
 :libbeat: http://www.elastic.co/guide/en/beats/libbeat/master
 :filebeat: http://www.elastic.co/guide/en/beats/filebeat/master
 :elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/master/
-:version: 5.0.0-alpha3
+:version: {stack-version}
 :beatname_lc: metricbeat
 :beatname_uc: Metricbeat
 :security: X-Pack Security

--- a/metricbeat/docs/index.asciidoc
+++ b/metricbeat/docs/index.asciidoc
@@ -2,9 +2,9 @@
 
 include::./version.asciidoc[]
 
-:libbeat: http://www.elastic.co/guide/en/beats/libbeat/master
-:filebeat: http://www.elastic.co/guide/en/beats/filebeat/master
-:elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/master/
+:libbeat: http://www.elastic.co/guide/en/beats/libbeat/{doc-branch}
+:filebeat: http://www.elastic.co/guide/en/beats/filebeat/{doc-branch}
+:elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/{doc-branch}/
 :version: {stack-version}
 :beatname_lc: metricbeat
 :beatname_uc: Metricbeat

--- a/metricbeat/docs/version.asciidoc
+++ b/metricbeat/docs/version.asciidoc
@@ -1,0 +1,1 @@
+:stack-version: 5.0.0-alpha3

--- a/metricbeat/docs/version.asciidoc
+++ b/metricbeat/docs/version.asciidoc
@@ -1,1 +1,2 @@
 :stack-version: 5.0.0-alpha3
+:doc-branch: master

--- a/packetbeat/docs/index.asciidoc
+++ b/packetbeat/docs/index.asciidoc
@@ -2,12 +2,12 @@
 
 include::./version.asciidoc[]
 
-:libbeat: http://www.elastic.co/guide/en/beats/libbeat/master
-:packetbeat: http://www.elastic.co/guide/en/beats/packetbeat/master
-:metricbeat: http://www.elastic.co/guide/en/beats/metricbeat/master
-:filebeat: http://www.elastic.co/guide/en/beats/filebeat/master
-:winlogbeat: http://www.elastic.co/guide/en/beats/winlogbeat/master
-:elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/master/
+:libbeat: http://www.elastic.co/guide/en/beats/libbeat/{doc-branch}
+:packetbeat: http://www.elastic.co/guide/en/beats/packetbeat/{doc-branch}
+:metricbeat: http://www.elastic.co/guide/en/beats/metricbeat/{doc-branch}
+:filebeat: http://www.elastic.co/guide/en/beats/filebeat/{doc-branch}
+:winlogbeat: http://www.elastic.co/guide/en/beats/winlogbeat/{doc-branch}
+:elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/{doc-branch}/
 :version: {stack-version}
 :beatname_lc: packetbeat
 :beatname_uc: Packetbeat

--- a/packetbeat/docs/index.asciidoc
+++ b/packetbeat/docs/index.asciidoc
@@ -1,11 +1,14 @@
 = Packetbeat Reference
+
+include::./version.asciidoc[]
+
 :libbeat: http://www.elastic.co/guide/en/beats/libbeat/master
 :packetbeat: http://www.elastic.co/guide/en/beats/packetbeat/master
 :metricbeat: http://www.elastic.co/guide/en/beats/metricbeat/master
 :filebeat: http://www.elastic.co/guide/en/beats/filebeat/master
 :winlogbeat: http://www.elastic.co/guide/en/beats/winlogbeat/master
 :elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/master/
-:version: 5.0.0-alpha3
+:version: {stack-version}
 :beatname_lc: packetbeat
 :beatname_uc: Packetbeat
 :security: X-Pack Security

--- a/packetbeat/docs/version.asciidoc
+++ b/packetbeat/docs/version.asciidoc
@@ -1,0 +1,1 @@
+:stack-version: 5.0.0-alpha3

--- a/packetbeat/docs/version.asciidoc
+++ b/packetbeat/docs/version.asciidoc
@@ -1,1 +1,2 @@
 :stack-version: 5.0.0-alpha3
+:doc-branch: master

--- a/winlogbeat/docs/index.asciidoc
+++ b/winlogbeat/docs/index.asciidoc
@@ -2,12 +2,12 @@
 
 include::./version.asciidoc[]
 
-:libbeat: http://www.elastic.co/guide/en/beats/libbeat/master
-:packetbeat: http://www.elastic.co/guide/en/beats/packetbeat/master
-:metricbeat: http://www.elastic.co/guide/en/beats/metricbeat/master
-:filebeat: http://www.elastic.co/guide/en/beats/filebeat/master
-:winlogbeat: http://www.elastic.co/guide/en/beats/winlogbeat/master
-:elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/master/
+:libbeat: http://www.elastic.co/guide/en/beats/libbeat/{doc-branch}
+:packetbeat: http://www.elastic.co/guide/en/beats/packetbeat/{doc-branch}
+:metricbeat: http://www.elastic.co/guide/en/beats/metricbeat/{doc-branch}
+:filebeat: http://www.elastic.co/guide/en/beats/filebeat/{doc-branch}
+:winlogbeat: http://www.elastic.co/guide/en/beats/winlogbeat/{doc-branch}
+:elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/{doc-branch}/
 :version: {stack-version}
 :beatname_lc: winlogbeat
 :beatname_uc: Winlogbeat

--- a/winlogbeat/docs/index.asciidoc
+++ b/winlogbeat/docs/index.asciidoc
@@ -1,11 +1,14 @@
 = Winlogbeat Reference
+
+include::./version.asciidoc[]
+
 :libbeat: http://www.elastic.co/guide/en/beats/libbeat/master
 :packetbeat: http://www.elastic.co/guide/en/beats/packetbeat/master
 :metricbeat: http://www.elastic.co/guide/en/beats/metricbeat/master
 :filebeat: http://www.elastic.co/guide/en/beats/filebeat/master
 :winlogbeat: http://www.elastic.co/guide/en/beats/winlogbeat/master
 :elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/master/
-:version: 5.0.0-alpha3
+:version: {stack-version}
 :beatname_lc: winlogbeat
 :beatname_uc: Winlogbeat
 :security: X-Pack Security

--- a/winlogbeat/docs/version.asciidoc
+++ b/winlogbeat/docs/version.asciidoc
@@ -1,0 +1,1 @@
+:stack-version: 5.0.0-alpha3

--- a/winlogbeat/docs/version.asciidoc
+++ b/winlogbeat/docs/version.asciidoc
@@ -1,1 +1,2 @@
 :stack-version: 5.0.0-alpha3
+:doc-branch: master


### PR DESCRIPTION
The new file `libbeat/docs/version.asciidoc` contains a single line with the
`stack-version` variable. All other version variables reference this one. This
makes it easy to automate version changing.

`make update` is needed to copy the file to the individual Beats. It would have
been possible to include directly the file from libbeat, but that would have had
a big disadvantage: the docs only get rebuild on file changes in the "book", so
changing the version in libbeat wouldn't trigger a docs rebuild on the public
website.

Also, it's kind of nice to have to run `make update` shortly before each release,
that makes it sure we won't forget.