### PR TITLE
Send field as message

### DIFF
--- a/libbeat/outputs/kafka/client.go
+++ b/libbeat/outputs/kafka/client.go
@@ -14,10 +14,11 @@ import (
 )
 
 type client struct {
-	hosts   []string
-	topic   string
-	useType bool
-	config  sarama.Config
+	hosts         []string
+	topic         string
+	useType       bool
+	config        sarama.Config
+	sendFieldOnly string
 
 	producer sarama.AsyncProducer
 
@@ -40,12 +41,13 @@ var (
 	publishEventsCallCount = expvar.NewInt("libbeatKafkaPublishEventsCallCount")
 )
 
-func newKafkaClient(hosts []string, topic string, useType bool, cfg *sarama.Config) (*client, error) {
+func newKafkaClient(hosts []string, topic string, useType bool, sendFieldOnly string, cfg *sarama.Config) (*client, error) {
 	c := &client{
-		hosts:   hosts,
-		useType: useType,
-		topic:   topic,
-		config:  *cfg,
+		hosts:         hosts,
+		useType:       useType,
+		topic:         topic,
+		config:        *cfg,
+		sendFieldOnly: sendFieldOnly,
 	}
 	return c, nil
 }
@@ -115,15 +117,40 @@ func (c *client) AsyncPublishEvents(
 	for _, event := range events {
 		topic := c.topic
 		if c.useType {
-			topic = event["type"].(string)
+			topic = (event["type"].(string))
 		}
 
-		jsonEvent, err := json.Marshal(event)
-		if err != nil {
-			ref.done()
-			continue
-		}
+		var jsonEvent []byte
 
+		if c.sendFieldOnly != "" {
+			debugf("Only sending field %s to kafka", c.sendFieldOnly)
+			value := event[c.sendFieldOnly]
+
+			if value == nil {
+				logp.Warn("Field %s does not found in event", value)
+				continue
+			}
+
+			switch value.(type) {
+			case string:
+				jsonEvent = []byte(value.(string))
+			case *string:
+				jsonEvent = []byte(*value.(*string))
+			default:
+				logp.Warn("Unexpected type %T for sending to Kafka. Only string is supported.", value)
+				continue
+			}
+
+		} else {
+			event, err := json.Marshal(event)
+			if err != nil {
+				ref.done()
+				continue
+			}
+
+			jsonEvent = event
+		}
+		debugf("Message to send: %s", jsonEvent)
 		msg := &sarama.ProducerMessage{
 			Metadata: ref,
 			Topic:    topic,

--- a/libbeat/outputs/kafka/config.go
+++ b/libbeat/outputs/kafka/config.go
@@ -24,6 +24,7 @@ type kafkaConfig struct {
 	MaxRetries      int                `config:"max_retries"         validate:"min=-1,nonzero"`
 	ClientID        string             `config:"client_id"`
 	ChanBufferSize  int                `config:"channel_buffer_size" validate:"min=1"`
+	SendFieldOnly   string             `config:"send_field_only"`
 }
 
 var (
@@ -42,6 +43,7 @@ var (
 		MaxRetries:      3,
 		ClientID:        "beats",
 		ChanBufferSize:  256,
+		SendFieldOnly:   "",
 	}
 )
 

--- a/libbeat/outputs/kafka/kafka.go
+++ b/libbeat/outputs/kafka/kafka.go
@@ -98,8 +98,12 @@ func (k *kafka) initMode(guaranteed bool) (mode.ConnectionMode, error) {
 	hosts := k.config.Hosts
 	topic := k.config.Topic
 	useType := k.config.UseType
+	sendMessageOnly := k.config.SendFieldOnly
+
+	logp.Info("SendmessageOnly is: %v", sendMessageOnly)
+
 	for i := 0; i < worker; i++ {
-		client, err := newKafkaClient(hosts, topic, useType, libCfg)
+		client, err := newKafkaClient(hosts, topic, useType, sendMessageOnly, libCfg)
 		if err != nil {
 			logp.Err("Failed to create kafka client: %v", err)
 			return nil, err

--- a/libbeat/outputs/kafka/kafka_integration_test.go
+++ b/libbeat/outputs/kafka/kafka_integration_test.go
@@ -47,7 +47,7 @@ func newTestKafkaClient(t *testing.T, topic string) *client {
 	hosts := []string{getTestKafkaHost()}
 	t.Logf("host: %v", hosts)
 
-	client, err := newKafkaClient(hosts, topic, false, nil)
+	client, err := newKafkaClient(hosts, topic, false, "", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -55,13 +55,14 @@ func newTestKafkaClient(t *testing.T, topic string) *client {
 	return client
 }
 
-func newTestKafkaOutput(t *testing.T, topic string, useType bool) outputs.Outputer {
+func newTestKafkaOutput(t *testing.T, topic string, useType bool, sendFieldOnly string) outputs.Outputer {
 
 	config := map[string]interface{}{
-		"hosts":    []string{getTestKafkaHost()},
-		"timeout":  "1s",
-		"topic":    topic,
-		"use_type": useType,
+		"hosts":           []string{getTestKafkaHost()},
+		"timeout":         "1s",
+		"topic":           topic,
+		"use_type":        useType,
+		"send_field_only": sendFieldOnly,
 	}
 
 	cfg, err := common.NewConfigFrom(config)
@@ -128,7 +129,7 @@ func TestOneMessageToKafka(t *testing.T) {
 	id := strconv.Itoa(rand.New(rand.NewSource(int64(time.Now().Nanosecond()))).Int())
 	topic := fmt.Sprintf("test-libbeat-%s", id)
 
-	kafka := newTestKafkaOutput(t, topic, false)
+	kafka := newTestKafkaOutput(t, topic, false, "")
 	event := common.MapStr{
 		"@timestamp": common.Time(time.Now()),
 		"host":       "test-host",
@@ -158,7 +159,7 @@ func TestUseType(t *testing.T) {
 	id := strconv.Itoa(rand.New(rand.NewSource(int64(time.Now().Nanosecond()))).Int())
 	logType := fmt.Sprintf("log-type-%s", id)
 
-	kafka := newTestKafkaOutput(t, "", true)
+	kafka := newTestKafkaOutput(t, "", true, "")
 	event := common.MapStr{
 		"@timestamp": common.Time(time.Now()),
 		"host":       "test-host",
@@ -174,5 +175,67 @@ func TestUseType(t *testing.T) {
 		msg := messages[0]
 		logp.Debug("kafka", "%s: %s", msg.Key, msg.Value)
 		assert.Contains(t, string(msg.Value), id)
+	}
+}
+
+func TestSendStringFieldAsMessageToKafka(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping in short mode. Requires Kafka")
+	}
+	if testing.Verbose() {
+		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"kafka"})
+	}
+
+	id := strconv.Itoa(rand.New(rand.NewSource(int64(time.Now().Nanosecond()))).Int())
+	message := "test message"
+	topic := fmt.Sprintf("test-libbeat-%s", id)
+
+	kafka := newTestKafkaOutput(t, topic, false, "message")
+	event := common.MapStr{
+		"@timestamp": common.Time(time.Now()),
+		"host":       "test-host",
+		"type":       "log",
+		"message":    message,
+	}
+	if err := kafka.PublishEvent(nil, testOptions, event); err != nil {
+		t.Fatal(err)
+	}
+
+	messages := testReadFromKafkaTopic(t, topic, 1, 5*time.Second)
+	if assert.Len(t, messages, 1) {
+		msg := messages[0]
+		logp.Debug("kafka", "%s: %s", msg.Key, msg.Value)
+		assert.Equal(t, message, string(msg.Value))
+	}
+}
+
+func TestSendStringPointerFieldAsMessageToKafka(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping in short mode. Requires Kafka")
+	}
+	if testing.Verbose() {
+		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"kafka"})
+	}
+
+	id := strconv.Itoa(rand.New(rand.NewSource(int64(time.Now().Nanosecond()))).Int())
+	message := "test message"
+	topic := fmt.Sprintf("test-libbeat-%s", id)
+
+	kafka := newTestKafkaOutput(t, topic, false, "message")
+	event := common.MapStr{
+		"@timestamp": common.Time(time.Now()),
+		"host":       "test-host",
+		"type":       "log",
+		"message":    &message,
+	}
+	if err := kafka.PublishEvent(nil, testOptions, event); err != nil {
+		t.Fatal(err)
+	}
+
+	messages := testReadFromKafkaTopic(t, topic, 1, 5*time.Second)
+	if assert.Len(t, messages, 1) {
+		msg := messages[0]
+		logp.Debug("kafka", "%s: %s", msg.Key, msg.Value)
+		assert.Equal(t, message, string(msg.Value))
 	}
 }


### PR DESCRIPTION
Being able to specify a field to kafka output which will be sent as it is to kafka.
I found it a bit tricky to send loglines as it is to kafka from filbeat so I created this change where you can specify which field you want to send to kafka.

Feel free to reject if you don't find it useful. It is useful for us.
