### PR TITLE
Fix high values of proc.cpu.user_p

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -30,6 +30,7 @@ https://github.com/elastic/beats/compare/v1.2.3...1.2[Check the HEAD diff]
 *Packetbeat*
 
 *Topbeat*
+- Fix high values of proc.cpu.user_p. {pull}1923[1923]
 
 *Filebeat*
 

--- a/topbeat/beat/topbeat.go
+++ b/topbeat/beat/topbeat.go
@@ -470,7 +470,7 @@ func (t *Topbeat) addProcCpuPercentage(proc *Process) {
 	oproc, ok := t.procsMap[proc.Pid]
 	if ok {
 
-		delta_proc := (proc.Cpu.User - oproc.Cpu.User) + (proc.Cpu.System - oproc.Cpu.System)
+		delta_proc := int64(proc.Cpu.User-oproc.Cpu.User) + int64(proc.Cpu.System-oproc.Cpu.System)
 		delta_time := proc.ctime.Sub(oproc.ctime).Nanoseconds() / 1e6 // in milliseconds
 		perc := float64(delta_proc) / float64(delta_time)
 


### PR DESCRIPTION
Apply the same fix from https://github.com/elastic/beats/pull/1128 to proc.cpu.user_p.