### PR TITLE
Add close_timeout option

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -94,6 +94,8 @@ https://github.com/elastic/beats/compare/v5.0.0-alpha5...master[Check the HEAD d
 *Topbeat*
 
 *Filebeat*
+- Introduce close_timeout harvester options {issue}1600[1600]
+
 
 - Add harvester_limit option {pull}2417[2417]
 

--- a/filebeat/docs/reference/configuration/filebeat-options.asciidoc
+++ b/filebeat/docs/reference/configuration/filebeat-options.asciidoc
@@ -233,6 +233,17 @@ WARNING: Only use this options if you understand that data loss is a potential s
 
 Close eof closes a file as soon as the end of a file is reached. This is useful in case your files are only written once and not updated from time to time. This case can happen in case you are writing every single log event to a new file.
 
+===== close_timeout
+
+WARNING: Only use this options if you understand the potential side affects with potential data loss. In addition it can happen that multiline events are not sent completely on timeout.
+
+Close timeout gives every harvester a predefined lifetime. Independent of the location of the reader, it will stop the reader after `close_timeout`. This option can be useful, if only a predefine time should be spent on older log files. Using this option in combination with `ignore_older` == `close_timeout` means the file is not picked up again in case it wasn't modified in between. This normally leads to data loss and not the complete file is sent.
+
+In case close_timeout is used in combination with multiline events, it can happen that the harvester will be stopped in the middle of a multiline event, means only parts of the event will be sent. In case the harvester is continued at a later stage again and the file still exists, only the second part of the event will be sent.
+
+Close timeout will not apply, in case your output is stuck and no further events can be sent. At least one event must be sent after close_timeout kicks in so the harvester can be closed afterwards.
+
+
 [[clean-options]]
 ===== clean_*
 

--- a/filebeat/docs/troubleshooting.asciidoc
+++ b/filebeat/docs/troubleshooting.asciidoc
@@ -22,8 +22,9 @@ There are 4 more configuration options which can be used to close file handlers,
 * close_renamed
 * close_removed
 * close_eof
+* close_timeout
 
-`close_renamed` and `close_removed` can be useful on Windows and issues related to file rotation, see <<windows-file-rotation>>. `close_eof` can be useful in environments with a large number of files with only very few entries. More details can be found in config options, see <<configuration-filebeat-options>>.
+`close_renamed` and `close_removed` can be useful on Windows and issues related to file rotation, see <<windows-file-rotation>>. `close_eof` can be useful in environments with a large number of files with only very few entries. `close_timeout` in environments where it is more important to close file handlers then to send all log lines. More details can be found in config options, see <<configuration-filebeat-options>>.
 
 Before using any of these variables, make sure to study the documentation on each.
 

--- a/filebeat/etc/beat.full.yml
+++ b/filebeat/etc/beat.full.yml
@@ -196,6 +196,11 @@ filebeat.prospectors:
   # Removes the state for file which cannot be found on disk anymore immediately
   #clean_removed: false
 
+  # Close timeout closes the harvester after the predefined time.
+  # This is independent if the harvester did finish reading the file or not.
+  # By default this option is disabled.
+  # Note: Potential data loss. Make sure to read and understand the docs for this option.
+  #close_timeout: 0
 
 #----------------------------- Stdin prospector -------------------------------
 # Configuration to use stdin input

--- a/filebeat/filebeat.full.yml
+++ b/filebeat/filebeat.full.yml
@@ -196,6 +196,11 @@ filebeat.prospectors:
   # Removes the state for file which cannot be found on disk anymore immediately
   #clean_removed: false
 
+  # Close timeout closes the harvester after the predefined time.
+  # This is independent if the harvester did finish reading the file or not.
+  # By default this option is disabled.
+  # Note: Potential data loss. Make sure to read and understand the docs for this option.
+  #close_timeout: 0
 
 #----------------------------- Stdin prospector -------------------------------
 # Configuration to use stdin input

--- a/filebeat/harvester/config.go
+++ b/filebeat/harvester/config.go
@@ -27,6 +27,7 @@ var (
 		CloseRemoved:    false,
 		CloseRenamed:    false,
 		CloseEOF:        false,
+		CloseTimeout:    0,
 		ForceCloseFiles: false,
 	}
 )
@@ -46,6 +47,7 @@ type harvesterConfig struct {
 	CloseRemoved         bool                    `config:"close_removed"`
 	CloseRenamed         bool                    `config:"close_renamed"`
 	CloseEOF             bool                    `config:"close_eof"`
+	CloseTimeout         time.Duration           `config:"close_timeout" validate:"min=0"`
 	ForceCloseFiles      bool                    `config:"force_close_files"`
 	ExcludeLines         []*regexp.Regexp        `config:"exclude_lines"`
 	IncludeLines         []*regexp.Regexp        `config:"include_lines"`

--- a/filebeat/harvester/harvester.go
+++ b/filebeat/harvester/harvester.go
@@ -38,9 +38,10 @@ type Harvester struct {
 	state           file.State
 	prospectorChan  chan *input.Event
 	file            source.FileSource /* the file being watched */
-	done            chan struct{}
+	fileReader      *LogFile
 	encodingFactory encoding.EncodingFactory
 	encoding        encoding.Encoding
+	done            chan struct{}
 }
 
 func NewHarvester(

--- a/filebeat/harvester/log_file.go
+++ b/filebeat/harvester/log_file.go
@@ -3,6 +3,7 @@ package harvester
 import (
 	"io"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/elastic/beats/filebeat/harvester/source"
@@ -17,12 +18,12 @@ type LogFile struct {
 	lastTimeRead time.Time
 	backoff      time.Duration
 	done         chan struct{}
+	singleClose  sync.Once
 }
 
 func NewLogFile(
 	fs source.FileSource,
 	config harvesterConfig,
-	done chan struct{},
 ) (*LogFile, error) {
 	var offset int64
 	if seeker, ok := fs.(io.Seeker); ok {
@@ -39,7 +40,7 @@ func NewLogFile(
 		config:       config,
 		lastTimeRead: time.Now(),
 		backoff:      config.Backoff,
-		done:         done,
+		done:         make(chan struct{}),
 	}, nil
 }
 
@@ -163,4 +164,12 @@ func (r *LogFile) wait() {
 			r.backoff = r.config.MaxBackoff
 		}
 	}
+}
+
+func (r *LogFile) Close() {
+	// Make sure reader is only closed once
+	r.singleClose.Do(func() {
+		close(r.done)
+		// Note: File reader is not closed here because that leads to race conditions
+	})
 }

--- a/filebeat/prospector/prospector.go
+++ b/filebeat/prospector/prospector.go
@@ -112,6 +112,7 @@ func (p *Prospector) Run() {
 				if p.config.CleanInactive > 0 {
 					event.State.TTL = p.config.CleanInactive
 				}
+
 				select {
 				case <-p.done:
 					logp.Info("Prospector channel stopped")

--- a/filebeat/tests/system/config/filebeat.yml.j2
+++ b/filebeat/tests/system/config/filebeat.yml.j2
@@ -22,6 +22,7 @@ filebeat.prospectors:
   close_removed: {{close_removed}}
   close_renamed: {{close_renamed}}
   close_eof: {{close_eof}}
+  close_timeout: {{close_timeout}}
   force_close_files: {{force_close_files}}
   clean_inactive: {{clean_inactive}}
   clean_removed: {{clean_removed}}


### PR DESCRIPTION
close_timeout will end the harvester after the predefined time. In case the output is blocked, close_timeout will only apply on the next event sent. This is identical with the close_* options.