### PR TITLE
Fix high values of proc.cpu.user_p

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -8,7 +8,7 @@
 // Template, add newest changes here
 
 === Beats version HEAD
-https://github.com/elastic/beats/compare/v1.2.3...1.3[Check the HEAD diff]
+https://github.com/elastic/beats/compare/v1.3.0...1.3[Check the HEAD diff]
 
 ==== Breaking changes
 
@@ -87,6 +87,7 @@ https://github.com/elastic/beats/compare/v1.2.2...v1.2.3[View commits]
 *Topbeat*
 
 - Fix high CPU usage when using filtering under Windows. {pull}1598[1598]
+- Fix high values of proc.cpu.user_p. {pull}1928[1928]
 
 *Filebeat*
 

--- a/topbeat/beat/topbeat.go
+++ b/topbeat/beat/topbeat.go
@@ -470,7 +470,7 @@ func (t *Topbeat) addProcCpuPercentage(proc *Process) {
 	oproc, ok := t.procsMap[proc.Pid]
 	if ok {
 
-		delta_proc := (proc.Cpu.User - oproc.Cpu.User) + (proc.Cpu.System - oproc.Cpu.System)
+		delta_proc := int64(proc.Cpu.User-oproc.Cpu.User) + int64(proc.Cpu.System-oproc.Cpu.System)
 		delta_time := proc.ctime.Sub(oproc.ctime).Nanoseconds() / 1e6 // in milliseconds
 		perc := float64(delta_proc) / float64(delta_time)
 


### PR DESCRIPTION
Apply the same fix from #1128 to proc.cpu.user_p. This is fixed already in 5.0.