### PR TITLE
Temporary hack for the Kibana index pattern

### DIFF
--- a/dev-tools/import_dashboards.ps1
+++ b/dev-tools/import_dashboards.ps1
@@ -145,4 +145,9 @@ If (Test-Path "$KIBANA_DIR/index-pattern") {
       echo "Import index-pattern $($name):"
       &$CURL -Headers $headers -Uri "$ELASTICSEARCH/$KIBANA_INDEX/index-pattern/$name" -Method PUT -Body $(Get-Content "$KIBANA_DIR/index-pattern/$file")
     }
+
+    # Temporary hack to set the index pattern as the default one.
+    # Workaround for: https://github.com/elastic/kibana/issues/7563
+    &$CURL -Headers $headers -Uri "$ELASTICSEARCH/$KIBANA_INDEX/config/5.0.0-alpha4/_update" -Method POST -Body "{`"doc`":{`"defaultIndex`":`"$name`"}, `"doc_as_upsert`" : true}"
+
 }

--- a/dev-tools/import_dashboards.sh
+++ b/dev-tools/import_dashboards.sh
@@ -178,6 +178,12 @@ if [ -d "${DIR}/index-pattern" ]; then
             -d @${file} || exit 1
         echo
     done
+
+    # Temporary hack to set the index pattern as the default one.
+    # Workaround for: https://github.com/elastic/kibana/issues/7563
+    ${CURL} -XPOST ${ELASTICSEARCH}/${KIBANA_INDEX}/config/5.0.0-alpha4/_update \
+        -d "{\"doc\":{\"defaultIndex\":\"${NAME}\"}, \"doc_as_upsert\" : true}"
+
 fi
 
 


### PR DESCRIPTION
This is an attempt at a workaround for elastic/kibana#7563. The PR
adds code to our load scripts to set the default index to be
`<name-of-the-beat>-*` after loading the index patterns. This makes it work well out of the box but
comes with two disadvantages:

1. it's hardcoded for alpha4
2. we used to not touch the default index. It might be unexpected for
 existing users that we now change it.