### PR TITLE
Update annotations for alpha4

### DIFF
--- a/libbeat/docs/gettingstarted.asciidoc
+++ b/libbeat/docs/gettingstarted.asciidoc
@@ -109,17 +109,17 @@ On Windows, if you don't have cURL installed, simply point your browser to the U
 
 You should see a response similar to this:
 
-[source,shell]
+["source","sh",subs="attributes"]
 ----------------------------------------------------------------------
 {
   "name" : "Angela Del Toro",
   "cluster_name" : "elasticsearch",
   "version" : {
-    "number" : "2.2.0",
+    "number" : "{ES-version}",
     "build_hash" : "8ff36d139e16f8720f2947ef62c8167a888992fe",
     "build_timestamp" : "2016-01-27T13:32:39Z",
     "build_snapshot" : false,
-    "lucene_version" : "5.4.1"
+    "lucene_version" : "6.1.0"
   },
   "tagline" : "You Know, for Search"
 }

--- a/libbeat/docs/regexp.asciidoc
+++ b/libbeat/docs/regexp.asciidoc
@@ -12,7 +12,7 @@
 [[regexp-support]]
 == Regular Expression Support
 
-{beatname_uc} regular expression support is based on https://godoc.org/regexp/syntax[RE2]. coming[5.0.0-alpha3,Support is added for previously unsupported patterns]
+{beatname_uc} regular expression support is based on https://godoc.org/regexp/syntax[RE2]. added[5.0.0-alpha3,Support is added for previously unsupported patterns]
 
 NOTE: We recommend that you wrap regular expressions in single quotation marks to work around YAML's string escaping rules. For example, `'^\[?[0-9][0-9]:?[0-9][0-9]|^[[:graph:]]+'`.
 
@@ -122,7 +122,7 @@ The following patterns are supported:
 [float]
 === Unsupported Patterns
 
-deprecated[5.0.0-alpha3]
+deprecated[5.0.0-alpha3,The following patterns are supported starting in 5.0.0-alpha3]
 
 The following patterns are not supported.
 

--- a/metricbeat/docs/index-docinfo.xml
+++ b/metricbeat/docs/index-docinfo.xml
@@ -1,7 +1,7 @@
-<?page_header <b>PLEASE NOTE:</b> These docs are for a pre-GA version of Metricbeat, {version}.?>
+<?page_header <b>PLEASE NOTE:</b> These docs are for a pre-GA version of Metricbeat.?>
 
 <abstract>
     <simpara role="page_header">
-      These docs are for Metricbeat {version}, which has not yet reached GA.
+      These docs are for a pre-GA version of Metricbeat.
     </simpara>
 </abstract>


### PR DESCRIPTION
Some minor tweaks to fix version info and display annotations that make sense for alpha4.