### PR TITLE
Add system uptime MetricSet

### DIFF
--- a/metricbeat/docs/fields.asciidoc
+++ b/metricbeat/docs/fields.asciidoc
@@ -2729,6 +2729,21 @@ type: long
 The shared memory the process uses.
 
 
+[float]
+== uptime Fields
+
+`uptime` contains the operating system uptime metric.
+
+
+
+[float]
+=== system.uptime.uptime_ms
+
+type: long
+
+The OS uptime in milliseconds.
+
+
 [[exported-fields-zookeeper]]
 == ZooKeeper Fields
 

--- a/metricbeat/docs/modules/system.asciidoc
+++ b/metricbeat/docs/modules/system.asciidoc
@@ -107,6 +107,8 @@ The following metricsets are available:
 
 * <<metricbeat-metricset-system-process,process>>
 
+* <<metricbeat-metricset-system-uptime,uptime>>
+
 include::system/core.asciidoc[]
 
 include::system/cpu.asciidoc[]
@@ -122,4 +124,6 @@ include::system/memory.asciidoc[]
 include::system/network.asciidoc[]
 
 include::system/process.asciidoc[]
+
+include::system/uptime.asciidoc[]
 

--- a/metricbeat/etc/fields.yml
+++ b/metricbeat/etc/fields.yml
@@ -1634,6 +1634,15 @@
                   type: long
                   description: >
                     The shared memory the process uses.
+        - name: uptime
+          type: group
+          description: >
+            `uptime` contains the operating system uptime metric.
+          fields:
+            - name: uptime_ms
+              type: long
+              description: >
+                The OS uptime in milliseconds.
 - key: zookeeper
   title: "ZooKeeper"
   description: >

--- a/metricbeat/include/list.go
+++ b/metricbeat/include/list.go
@@ -28,6 +28,7 @@ import (
 	_ "github.com/elastic/beats/metricbeat/module/system/memory"
 	_ "github.com/elastic/beats/metricbeat/module/system/network"
 	_ "github.com/elastic/beats/metricbeat/module/system/process"
+	_ "github.com/elastic/beats/metricbeat/module/system/uptime"
 	_ "github.com/elastic/beats/metricbeat/module/zookeeper"
 	_ "github.com/elastic/beats/metricbeat/module/zookeeper/mntr"
 )

--- a/metricbeat/metricbeat.template-es2x.json
+++ b/metricbeat/metricbeat.template-es2x.json
@@ -1434,6 +1434,13 @@
                   "type": "string"
                 }
               }
+            },
+            "uptime": {
+              "properties": {
+                "uptime_ms": {
+                  "type": "long"
+                }
+              }
             }
           }
         },

--- a/metricbeat/metricbeat.template.json
+++ b/metricbeat/metricbeat.template.json
@@ -1395,6 +1395,13 @@
                   "type": "keyword"
                 }
               }
+            },
+            "uptime": {
+              "properties": {
+                "uptime_ms": {
+                  "type": "long"
+                }
+              }
             }
           }
         },

--- a/metricbeat/module/system/uptime/_meta/data.json
+++ b/metricbeat/module/system/uptime/_meta/data.json
@@ -1,0 +1,18 @@
+{
+    "@timestamp": "2016-06-29T19:25:08.155Z",
+    "beat": {
+        "hostname": "host.example.com",
+        "name": "host.example.com"
+    },
+    "metricset": {
+        "module": "system",
+        "name": "uptime",
+        "rtt": 33
+    },
+    "system": {
+        "uptime": {
+            "uptime_ms": 789306155
+        }
+    },
+    "type": "metricsets"
+}

--- a/metricbeat/module/system/uptime/_meta/docs.asciidoc
+++ b/metricbeat/module/system/uptime/_meta/docs.asciidoc
@@ -1,0 +1,9 @@
+=== System Uptime Metricset
+
+The System `uptime` metricset provides the uptime of the host operating system.
+
+This metricset is available on:
+
+- Darwin
+- Linux
+- OpenBSD

--- a/metricbeat/module/system/uptime/_meta/fields.yml
+++ b/metricbeat/module/system/uptime/_meta/fields.yml
@@ -1,0 +1,9 @@
+- name: uptime
+  type: group
+  description: >
+    `uptime` contains the operating system uptime metric.
+  fields:
+    - name: uptime_ms
+      type: long
+      description: >
+        The OS uptime in milliseconds.

--- a/metricbeat/module/system/uptime/doc.go
+++ b/metricbeat/module/system/uptime/doc.go
@@ -1,0 +1,4 @@
+/*
+Package uptime fetch uptime information from the host operating system.
+*/
+package uptime

--- a/metricbeat/module/system/uptime/uptime.go
+++ b/metricbeat/module/system/uptime/uptime.go
@@ -1,0 +1,39 @@
+// +build darwin linux openbsd
+
+package uptime
+
+import (
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/metricbeat/mb"
+
+	sigar "github.com/elastic/gosigar"
+	"github.com/pkg/errors"
+)
+
+func init() {
+	if err := mb.Registry.AddMetricSet("system", "uptime", New); err != nil {
+		panic(err)
+	}
+}
+
+// MetricSet for fetching an OS uptime metric.
+type MetricSet struct {
+	mb.BaseMetricSet
+}
+
+// New is a mb.MetricSetFactory that returns a new MetricSet.
+func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
+	return &MetricSet{base}, nil
+}
+
+// Fetch fetches the uptime metric from the OS.
+func (m *MetricSet) Fetch() (common.MapStr, error) {
+	uptime := sigar.Uptime{}
+	if err := uptime.Get(); err != nil {
+		return nil, errors.Wrap(err, "error fetching uptime")
+	}
+
+	return common.MapStr{
+		"uptime_ms": int64(uptime.Length * 1000),
+	}, nil
+}


### PR DESCRIPTION
This MetricSet reports the OS uptime in milliseconds. It is currently implemented for Linux, Darwin, and OpenBSD. It's not implemented on Windows yet.

Commentary
- I chose milliseconds for the units (abbreviated as ms).
- `uptime` is in its own metricset. Should it be included in some other metricset?