### PR TITLE
Use half floats for most floating point numbers

### DIFF
--- a/libbeat/scripts/generate_template.py
+++ b/libbeat/scripts/generate_template.py
@@ -178,10 +178,14 @@ def fill_field_properties(args, field, defaults, path):
             }
 
     elif field["type"] in ["geo_point", "date", "long", "integer",
-                           "double", "float", "boolean"]:
+                           "double", "float", "half_float", "boolean"]:
         # Convert all integer fields to long
         if field["type"] == "integer":
             field["type"] = "long"
+
+        if args.es2x and field["type"] == "half_float":
+            # ES 2.x doesn't support half floats, so convert to floats
+            field["type"] = "float"
 
         properties[field["name"]] = {
             "type": field.get("type")

--- a/metricbeat/docs/fields.asciidoc
+++ b/metricbeat/docs/fields.asciidoc
@@ -71,7 +71,7 @@ Total number of kilobytes served.
 [float]
 === apache.status.requests_per_sec
 
-type: float
+type: half_float
 
 Requests per second.
 
@@ -87,7 +87,7 @@ Bytes per second.
 [float]
 === apache.status.bytes_per_request
 
-type: float
+type: half_float
 
 Bytes per request.
 
@@ -141,7 +141,7 @@ CPU stats.
 [float]
 === apache.status.cpu.load
 
-type: float
+type: half_float
 
 CPU Load.
 
@@ -149,7 +149,7 @@ CPU Load.
 [float]
 === apache.status.cpu.user
 
-type: float
+type: half_float
 
 CPU user load.
 
@@ -157,7 +157,7 @@ CPU user load.
 [float]
 === apache.status.cpu.system
 
-type: float
+type: half_float
 
 System cpu.
 
@@ -165,7 +165,7 @@ System cpu.
 [float]
 === apache.status.cpu.children_user
 
-type: float
+type: half_float
 
 CPU of children user.
 
@@ -173,7 +173,7 @@ CPU of children user.
 [float]
 === apache.status.cpu.children_system
 
-type: float
+type: half_float
 
 CPU of children system.
 
@@ -227,7 +227,7 @@ Load averages.
 [float]
 === apache.status.load.1
 
-type: float
+type: half_float
 
 Load average for the last minute.
 
@@ -235,7 +235,7 @@ Load average for the last minute.
 [float]
 === apache.status.load.5
 
-type: float
+type: half_float
 
 Load average for the last 5 minutes.
 
@@ -243,7 +243,7 @@ Load average for the last 5 minutes.
 [float]
 === apache.status.load.15
 
-type: float
+type: half_float
 
 Load average for the last 15 minutes.
 
@@ -1333,7 +1333,7 @@ Redis CPU stats
 [float]
 === redis.info.cpu.used.sys
 
-type: float
+type: half_float
 
 System CPU consumed by the Redis server.
 
@@ -1341,7 +1341,7 @@ System CPU consumed by the Redis server.
 [float]
 === redis.info.cpu.used.sys_children
 
-type: float
+type: half_float
 
 User CPU consumed by the Redis server.
 
@@ -1349,7 +1349,7 @@ User CPU consumed by the Redis server.
 [float]
 === redis.info.cpu.used.user
 
-type: float
+type: half_float
 
 System CPU consumed by the background processes.
 
@@ -1357,7 +1357,7 @@ System CPU consumed by the background processes.
 [float]
 === redis.info.cpu.used.user_children
 
-type: float
+type: half_float
 
 User CPU consumed by the background processes.
 
@@ -1899,7 +1899,7 @@ CPU Core number.
 [float]
 === system.core.user.pct
 
-type: float
+type: half_float
 
 The percentage of CPU time spent in user space. On multi-core systems, you can have percentages that are greater than 100%. For example, if 3 cores are at 60% use, then the `cpu.user_p` will be 180%.
 
@@ -1915,7 +1915,7 @@ The amount of CPU time spent in user space.
 [float]
 === system.core.system.pct
 
-type: float
+type: half_float
 
 The percentage of CPU time spent in kernel space.
 
@@ -1931,7 +1931,7 @@ The amount of CPU time spent in kernel space.
 [float]
 === system.core.nice.pct
 
-type: float
+type: half_float
 
 The percentage of CPU time spent on low-priority processes.
 
@@ -1947,7 +1947,7 @@ The amount of CPU time spent on low-priority processes.
 [float]
 === system.core.idle.pct
 
-type: float
+type: half_float
 
 The percentage of CPU time spent idle.
 
@@ -1963,7 +1963,7 @@ The amount of CPU time spent idle.
 [float]
 === system.core.iowait.pct
 
-type: float
+type: half_float
 
 The percentage of CPU time spent in wait (on disk).
 
@@ -1979,7 +1979,7 @@ The amount of CPU time spent in wait (on disk).
 [float]
 === system.core.irq.pct
 
-type: float
+type: half_float
 
 The percentage of CPU time spent servicing and handling hardware interrupts.
 
@@ -1995,7 +1995,7 @@ The amount of CPU time spent servicing and handling hardware interrupts.
 [float]
 === system.core.softirq.pct
 
-type: float
+type: half_float
 
 The percentage of CPU time spent servicing and handling software interrupts.
 
@@ -2011,7 +2011,7 @@ The amount of CPU time spent servicing and handling software interrupts.
 [float]
 === system.core.steal.pct
 
-type: float
+type: half_float
 
 The percentage of CPU time spent in involuntary wait by the virtual CPU while the hypervisor was servicing another processor. Available only on Unix.
 
@@ -2034,7 +2034,7 @@ The amount of CPU time spent in involuntary wait by the virtual CPU while the hy
 [float]
 === system.cpu.user.pct
 
-type: float
+type: half_float
 
 The percentage of CPU time spent in user space. On multi-core systems, you can have percentages that are greater than 100%. For example, if 3 cores are at 60% use, then the `cpu.user_p` will be 180%.
 
@@ -2042,7 +2042,7 @@ The percentage of CPU time spent in user space. On multi-core systems, you can h
 [float]
 === system.cpu.system.pct
 
-type: float
+type: half_float
 
 The percentage of CPU time spent in kernel space.
 
@@ -2050,7 +2050,7 @@ The percentage of CPU time spent in kernel space.
 [float]
 === system.cpu.nice.pct
 
-type: float
+type: half_float
 
 The percentage of CPU time spent on low-priority processes.
 
@@ -2058,7 +2058,7 @@ The percentage of CPU time spent on low-priority processes.
 [float]
 === system.cpu.idle.pct
 
-type: float
+type: half_float
 
 The percentage of CPU time spent idle.
 
@@ -2066,7 +2066,7 @@ The percentage of CPU time spent idle.
 [float]
 === system.cpu.iowait.pct
 
-type: float
+type: half_float
 
 The percentage of CPU time spent in wait (on disk).
 
@@ -2074,7 +2074,7 @@ The percentage of CPU time spent in wait (on disk).
 [float]
 === system.cpu.irq.pct
 
-type: float
+type: half_float
 
 The percentage of CPU time spent servicing and handling hardware interrupts.
 
@@ -2082,7 +2082,7 @@ The percentage of CPU time spent servicing and handling hardware interrupts.
 [float]
 === system.cpu.softirq.pct
 
-type: float
+type: half_float
 
 The percentage of CPU time spent servicing and handling software interrupts.
 
@@ -2090,7 +2090,7 @@ The percentage of CPU time spent servicing and handling software interrupts.
 [float]
 === system.cpu.steal.pct
 
-type: float
+type: half_float
 
 The percentage of CPU time spent in involuntary wait by the virtual CPU while the hypervisor was servicing another processor. Available only on Unix.
 
@@ -2169,7 +2169,7 @@ Load averages.
 [float]
 === system.cpu.load.1
 
-type: float
+type: half_float
 
 Load average for the last minute.
 
@@ -2177,7 +2177,7 @@ Load average for the last minute.
 [float]
 === system.cpu.load.5
 
-type: float
+type: half_float
 
 Load average for the last 5 minutes.
 
@@ -2185,7 +2185,7 @@ Load average for the last 5 minutes.
 [float]
 === system.cpu.load.15
 
-type: float
+type: half_float
 
 Load average for the last 15 minutes.
 
@@ -2345,7 +2345,7 @@ The used disk space in bytes.
 [float]
 === system.filesystem.used.pct
 
-type: float
+type: half_float
 
 The percentage of used disk space.
 
@@ -2435,7 +2435,7 @@ Available memory.
 [float]
 === system.memory.used.pct
 
-type: float
+type: half_float
 
 The percentage of used memory.
 
@@ -2466,7 +2466,7 @@ Actual available memory. This value is the "free" memory plus the memory used fo
 [float]
 === system.memory.actual.used.pct
 
-type: float
+type: half_float
 
 The percentage of actual used memory.
 
@@ -2504,7 +2504,7 @@ Available swap memory.
 [float]
 === system.memory.swap.used.pct
 
-type: float
+type: half_float
 
 The percentage of used swap memory.
 
@@ -2662,7 +2662,7 @@ The amount of CPU time the process spent in user space.
 [float]
 === system.process.cpu.total.pct
 
-type: float
+type: half_float
 
 The percentage of CPU time spent by the process since the last update. Its value is similar to the %CPU value of the process displayed by the top command on Unix systems.
 
@@ -2716,7 +2716,7 @@ The Resident Set Size. The amount of memory the process occupied in main memory 
 [float]
 === system.process.memory.rss.pct
 
-type: float
+type: half_float
 
 The percentage of memory the process occupied in main memory (RAM).
 

--- a/metricbeat/etc/fields.yml
+++ b/metricbeat/etc/fields.yml
@@ -57,7 +57,7 @@
               description: >
                 Total number of kilobytes served.
             - name: requests_per_sec
-              type: float
+              type: half_float
               description: >
                 Requests per second.
             - name: bytes_per_sec
@@ -65,7 +65,7 @@
               description: >
                 Bytes per second.
             - name: bytes_per_request
-              type: float
+              type: half_float
               description: >
                 Bytes per request.
             - name: workers.busy
@@ -95,23 +95,23 @@
                 CPU stats.
               fields:
                 - name: load
-                  type: float
+                  type: half_float
                   description: >
                     CPU Load.
                 - name: user
-                  type: float
+                  type: half_float
                   description: >
                     CPU user load.
                 - name: system
-                  type: float
+                  type: half_float
                   description: >
                     System cpu.
                 - name: children_user
-                  type: float
+                  type: half_float
                   description: >
                     CPU of children user.
                 - name: children_system
-                  type: float
+                  type: half_float
                   description: >
                     CPU of children system.
             - name: connections
@@ -141,15 +141,15 @@
                 Load averages.
               fields:
                 - name: "1"
-                  type: float
+                  type: half_float
                   description: >
                     Load average for the last minute.
                 - name: "5"
-                  type: float
+                  type: half_float
                   description: >
                     Load average for the last 5 minutes.
                 - name: "15"
-                  type: float
+                  type: half_float
                   description: >
                     Load average for the last 15 minutes.
             - name: scoreboard
@@ -779,22 +779,22 @@
                 Redis CPU stats
               fields:
                 - name: used.sys
-                  type: float
+                  type: half_float
                   description: >
                     System CPU consumed by the Redis server.
 
                 - name: used.sys_children
-                  type: float
+                  type: half_float
                   description: >
                     User CPU consumed by the Redis server.
 
                 - name: used.user
-                  type: float
+                  type: half_float
                   description: >
                     System CPU consumed by the background processes.
 
                 - name: used.user_children
-                  type: float
+                  type: half_float
                   description: >
                     User CPU consumed by the background processes.
 
@@ -1116,7 +1116,7 @@
                 CPU Core number.
 
             - name: user.pct
-              type: float
+              type: half_float
               description: >
                 The percentage of CPU time spent in user space. On multi-core systems, you can have percentages that are greater than 100%.
                 For example, if 3 cores are at 60% use, then the `cpu.user_p` will be 180%.
@@ -1127,7 +1127,7 @@
                The amount of CPU time spent in user space.
 
             - name: system.pct
-              type: float
+              type: half_float
               description: >
                 The percentage of CPU time spent in kernel space.
 
@@ -1137,7 +1137,7 @@
                 The amount of CPU time spent in kernel space.
 
             - name: nice.pct
-              type: float
+              type: half_float
               description: >
                 The percentage of CPU time spent on low-priority processes.
 
@@ -1147,7 +1147,7 @@
                 The amount of CPU time spent on low-priority processes.
 
             - name: idle.pct
-              type: float
+              type: half_float
               description: >
                 The percentage of CPU time spent idle.
 
@@ -1157,7 +1157,7 @@
                 The amount of CPU time spent idle.
 
             - name: iowait.pct
-              type: float
+              type: half_float
               description: >
                 The percentage of CPU time spent in wait (on disk).
 
@@ -1167,7 +1167,7 @@
                 The amount of CPU time spent in wait (on disk).
 
             - name: irq.pct
-              type: float
+              type: half_float
               description: >
                 The percentage of CPU time spent servicing and handling hardware interrupts.
 
@@ -1177,7 +1177,7 @@
                 The amount of CPU time spent servicing and handling hardware interrupts.
 
             - name: softirq.pct
-              type: float
+              type: half_float
               description: >
                 The percentage of CPU time spent servicing and handling software interrupts.
 
@@ -1187,7 +1187,7 @@
                 The amount of CPU time spent servicing and handling software interrupts.
 
             - name: steal.pct
-              type: float
+              type: half_float
               description: >
                 The percentage of CPU time spent in involuntary wait by the virtual CPU while the hypervisor
                 was servicing another processor.
@@ -1206,43 +1206,43 @@
             `cpu` contains local CPU stats.
           fields:
             - name: user.pct
-              type: float
+              type: half_float
               description: >
                 The percentage of CPU time spent in user space. On multi-core systems, you can have percentages that are greater than 100%.
                 For example, if 3 cores are at 60% use, then the `cpu.user_p` will be 180%.
 
             - name: system.pct
-              type: float
+              type: half_float
               description: >
                 The percentage of CPU time spent in kernel space.
 
             - name: nice.pct
-              type: float
+              type: half_float
               description: >
                 The percentage of CPU time spent on low-priority processes.
 
             - name: idle.pct
-              type: float
+              type: half_float
               description: >
                 The percentage of CPU time spent idle.
 
             - name: iowait.pct
-              type: float
+              type: half_float
               description: >
                 The percentage of CPU time spent in wait (on disk).
 
             - name: irq.pct
-              type: float
+              type: half_float
               description: >
                 The percentage of CPU time spent servicing and handling hardware interrupts.
 
             - name: softirq.pct
-              type: float
+              type: half_float
               description: >
                 The percentage of CPU time spent servicing and handling software interrupts.
 
             - name: steal.pct
-              type: float
+              type: half_float
               description: >
                 The percentage of CPU time spent in involuntary wait by the virtual CPU while the hypervisor
                 was servicing another processor.
@@ -1296,15 +1296,15 @@
                 Load averages.
               fields:
                 - name: "1"
-                  type: float
+                  type: half_float
                   description: >
                     Load average for the last minute.
                 - name: "5"
-                  type: float
+                  type: half_float
                   description: >
                     Load average for the last 5 minutes.
                 - name: "15"
-                  type: float
+                  type: half_float
                   description: >
                     Load average for the last 15 minutes.
         - name: diskio
@@ -1399,7 +1399,7 @@
               description: >
                 The used disk space in bytes.
             - name: used.pct
-              type: float
+              type: half_float
               description: >
                 The percentage of used disk space.
 
@@ -1453,7 +1453,7 @@
                 Available memory.
 
             - name: used.pct
-              type: float
+              type: half_float
               description: >
                 The percentage of used memory.
 
@@ -1475,7 +1475,7 @@
                     buffers. Available only on Unix.
 
                 - name: used.pct
-                  type: float
+                  type: half_float
                   description: >
                     The percentage of actual used memory.
 
@@ -1500,7 +1500,7 @@
                     Available swap memory.
 
                 - name: used.pct
-                  type: float
+                  type: half_float
                   description: >
                     The percentage of used swap memory.
         - name: network
@@ -1597,7 +1597,7 @@
                   description: >
                     The amount of CPU time the process spent in user space.
                 - name: total.pct
-                  type: float
+                  type: half_float
                   description: >
                     The percentage of CPU time spent by the process since the last update. Its value is similar to the
                     %CPU value of the process displayed by the top command on Unix systems.
@@ -1627,7 +1627,7 @@
                   description: >
                     The Resident Set Size. The amount of memory the process occupied in main memory (RAM).
                 - name: rss.pct
-                  type: float
+                  type: half_float
                   description: >
                     The percentage of memory the process occupied in main memory (RAM).
                 - name: share

--- a/metricbeat/metricbeat.template.json
+++ b/metricbeat/metricbeat.template.json
@@ -25,7 +25,7 @@
             "status": {
               "properties": {
                 "bytes_per_request": {
-                  "type": "float"
+                  "type": "half_float"
                 },
                 "bytes_per_sec": {
                   "type": "float"
@@ -53,19 +53,19 @@
                 "cpu": {
                   "properties": {
                     "children_system": {
-                      "type": "float"
+                      "type": "half_float"
                     },
                     "children_user": {
-                      "type": "float"
+                      "type": "half_float"
                     },
                     "load": {
-                      "type": "float"
+                      "type": "half_float"
                     },
                     "system": {
-                      "type": "float"
+                      "type": "half_float"
                     },
                     "user": {
-                      "type": "float"
+                      "type": "half_float"
                     }
                   }
                 },
@@ -76,18 +76,18 @@
                 "load": {
                   "properties": {
                     "1": {
-                      "type": "float"
+                      "type": "half_float"
                     },
                     "15": {
-                      "type": "float"
+                      "type": "half_float"
                     },
                     "5": {
-                      "type": "float"
+                      "type": "half_float"
                     }
                   }
                 },
                 "requests_per_sec": {
-                  "type": "float"
+                  "type": "half_float"
                 },
                 "scoreboard": {
                   "properties": {
@@ -651,16 +651,16 @@
                     "used": {
                       "properties": {
                         "sys": {
-                          "type": "float"
+                          "type": "half_float"
                         },
                         "sys_children": {
-                          "type": "float"
+                          "type": "half_float"
                         },
                         "user": {
-                          "type": "float"
+                          "type": "half_float"
                         },
                         "user_children": {
-                          "type": "float"
+                          "type": "half_float"
                         }
                       }
                     }
@@ -948,7 +948,7 @@
                 "idle": {
                   "properties": {
                     "pct": {
-                      "type": "float"
+                      "type": "half_float"
                     },
                     "ticks": {
                       "type": "long"
@@ -958,7 +958,7 @@
                 "iowait": {
                   "properties": {
                     "pct": {
-                      "type": "float"
+                      "type": "half_float"
                     },
                     "ticks": {
                       "type": "long"
@@ -968,7 +968,7 @@
                 "irq": {
                   "properties": {
                     "pct": {
-                      "type": "float"
+                      "type": "half_float"
                     },
                     "ticks": {
                       "type": "long"
@@ -978,7 +978,7 @@
                 "nice": {
                   "properties": {
                     "pct": {
-                      "type": "float"
+                      "type": "half_float"
                     },
                     "ticks": {
                       "type": "long"
@@ -988,7 +988,7 @@
                 "softirq": {
                   "properties": {
                     "pct": {
-                      "type": "float"
+                      "type": "half_float"
                     },
                     "ticks": {
                       "type": "long"
@@ -998,7 +998,7 @@
                 "steal": {
                   "properties": {
                     "pct": {
-                      "type": "float"
+                      "type": "half_float"
                     },
                     "ticks": {
                       "type": "long"
@@ -1008,7 +1008,7 @@
                 "system": {
                   "properties": {
                     "pct": {
-                      "type": "float"
+                      "type": "half_float"
                     },
                     "ticks": {
                       "type": "long"
@@ -1018,7 +1018,7 @@
                 "user": {
                   "properties": {
                     "pct": {
-                      "type": "float"
+                      "type": "half_float"
                     },
                     "ticks": {
                       "type": "long"
@@ -1032,7 +1032,7 @@
                 "idle": {
                   "properties": {
                     "pct": {
-                      "type": "float"
+                      "type": "half_float"
                     },
                     "ticks": {
                       "type": "long"
@@ -1042,7 +1042,7 @@
                 "iowait": {
                   "properties": {
                     "pct": {
-                      "type": "float"
+                      "type": "half_float"
                     },
                     "ticks": {
                       "type": "long"
@@ -1052,7 +1052,7 @@
                 "irq": {
                   "properties": {
                     "pct": {
-                      "type": "float"
+                      "type": "half_float"
                     },
                     "ticks": {
                       "type": "long"
@@ -1062,20 +1062,20 @@
                 "load": {
                   "properties": {
                     "1": {
-                      "type": "float"
+                      "type": "half_float"
                     },
                     "15": {
-                      "type": "float"
+                      "type": "half_float"
                     },
                     "5": {
-                      "type": "float"
+                      "type": "half_float"
                     }
                   }
                 },
                 "nice": {
                   "properties": {
                     "pct": {
-                      "type": "float"
+                      "type": "half_float"
                     },
                     "ticks": {
                       "type": "long"
@@ -1085,7 +1085,7 @@
                 "softirq": {
                   "properties": {
                     "pct": {
-                      "type": "float"
+                      "type": "half_float"
                     },
                     "ticks": {
                       "type": "long"
@@ -1095,7 +1095,7 @@
                 "steal": {
                   "properties": {
                     "pct": {
-                      "type": "float"
+                      "type": "half_float"
                     },
                     "ticks": {
                       "type": "long"
@@ -1105,7 +1105,7 @@
                 "system": {
                   "properties": {
                     "pct": {
-                      "type": "float"
+                      "type": "half_float"
                     },
                     "ticks": {
                       "type": "long"
@@ -1115,7 +1115,7 @@
                 "user": {
                   "properties": {
                     "pct": {
-                      "type": "float"
+                      "type": "half_float"
                     },
                     "ticks": {
                       "type": "long"
@@ -1200,7 +1200,7 @@
                       "type": "long"
                     },
                     "pct": {
-                      "type": "float"
+                      "type": "half_float"
                     }
                   }
                 }
@@ -1242,7 +1242,7 @@
                           "type": "long"
                         },
                         "pct": {
-                          "type": "float"
+                          "type": "half_float"
                         }
                       }
                     }
@@ -1265,7 +1265,7 @@
                           "type": "long"
                         },
                         "pct": {
-                          "type": "float"
+                          "type": "half_float"
                         }
                       }
                     }
@@ -1280,7 +1280,7 @@
                       "type": "long"
                     },
                     "pct": {
-                      "type": "float"
+                      "type": "half_float"
                     }
                   }
                 }
@@ -1344,7 +1344,7 @@
                     "total": {
                       "properties": {
                         "pct": {
-                          "type": "float"
+                          "type": "half_float"
                         },
                         "ticks": {
                           "type": "long"
@@ -1364,7 +1364,7 @@
                           "type": "long"
                         },
                         "pct": {
-                          "type": "float"
+                          "type": "half_float"
                         }
                       }
                     },

--- a/metricbeat/module/apache/status/_meta/fields.yml
+++ b/metricbeat/module/apache/status/_meta/fields.yml
@@ -16,7 +16,7 @@
       description: >
         Total number of kilobytes served.
     - name: requests_per_sec
-      type: float
+      type: half_float
       description: >
         Requests per second.
     - name: bytes_per_sec
@@ -24,7 +24,7 @@
       description: >
         Bytes per second.
     - name: bytes_per_request
-      type: float
+      type: half_float
       description: >
         Bytes per request.
     - name: workers.busy
@@ -54,23 +54,23 @@
         CPU stats.
       fields:
         - name: load
-          type: float
+          type: half_float
           description: >
             CPU Load.
         - name: user
-          type: float
+          type: half_float
           description: >
             CPU user load.
         - name: system
-          type: float
+          type: half_float
           description: >
             System cpu.
         - name: children_user
-          type: float
+          type: half_float
           description: >
             CPU of children user.
         - name: children_system
-          type: float
+          type: half_float
           description: >
             CPU of children system.
     - name: connections
@@ -100,15 +100,15 @@
         Load averages.
       fields:
         - name: "1"
-          type: float
+          type: half_float
           description: >
             Load average for the last minute.
         - name: "5"
-          type: float
+          type: half_float
           description: >
             Load average for the last 5 minutes.
         - name: "15"
-          type: float
+          type: half_float
           description: >
             Load average for the last 15 minutes.
     - name: scoreboard

--- a/metricbeat/module/redis/info/_meta/fields.yml
+++ b/metricbeat/module/redis/info/_meta/fields.yml
@@ -44,22 +44,22 @@
         Redis CPU stats
       fields:
         - name: used.sys
-          type: float
+          type: half_float
           description: >
             System CPU consumed by the Redis server.
 
         - name: used.sys_children
-          type: float
+          type: half_float
           description: >
             User CPU consumed by the Redis server.
 
         - name: used.user
-          type: float
+          type: half_float
           description: >
             System CPU consumed by the background processes.
 
         - name: used.user_children
-          type: float
+          type: half_float
           description: >
             User CPU consumed by the background processes.
 

--- a/metricbeat/module/system/core/_meta/fields.yml
+++ b/metricbeat/module/system/core/_meta/fields.yml
@@ -9,7 +9,7 @@
         CPU Core number.
 
     - name: user.pct
-      type: float
+      type: half_float
       description: >
         The percentage of CPU time spent in user space. On multi-core systems, you can have percentages that are greater than 100%.
         For example, if 3 cores are at 60% use, then the `cpu.user_p` will be 180%.
@@ -20,7 +20,7 @@
        The amount of CPU time spent in user space.
 
     - name: system.pct
-      type: float
+      type: half_float
       description: >
         The percentage of CPU time spent in kernel space.
 
@@ -30,7 +30,7 @@
         The amount of CPU time spent in kernel space.
 
     - name: nice.pct
-      type: float
+      type: half_float
       description: >
         The percentage of CPU time spent on low-priority processes.
 
@@ -40,7 +40,7 @@
         The amount of CPU time spent on low-priority processes.
 
     - name: idle.pct
-      type: float
+      type: half_float
       description: >
         The percentage of CPU time spent idle.
 
@@ -50,7 +50,7 @@
         The amount of CPU time spent idle.
 
     - name: iowait.pct
-      type: float
+      type: half_float
       description: >
         The percentage of CPU time spent in wait (on disk).
 
@@ -60,7 +60,7 @@
         The amount of CPU time spent in wait (on disk).
 
     - name: irq.pct
-      type: float
+      type: half_float
       description: >
         The percentage of CPU time spent servicing and handling hardware interrupts.
 
@@ -70,7 +70,7 @@
         The amount of CPU time spent servicing and handling hardware interrupts.
 
     - name: softirq.pct
-      type: float
+      type: half_float
       description: >
         The percentage of CPU time spent servicing and handling software interrupts.
 
@@ -80,7 +80,7 @@
         The amount of CPU time spent servicing and handling software interrupts.
 
     - name: steal.pct
-      type: float
+      type: half_float
       description: >
         The percentage of CPU time spent in involuntary wait by the virtual CPU while the hypervisor
         was servicing another processor.

--- a/metricbeat/module/system/cpu/_meta/fields.yml
+++ b/metricbeat/module/system/cpu/_meta/fields.yml
@@ -4,43 +4,43 @@
     `cpu` contains local CPU stats.
   fields:
     - name: user.pct
-      type: float
+      type: half_float
       description: >
         The percentage of CPU time spent in user space. On multi-core systems, you can have percentages that are greater than 100%.
         For example, if 3 cores are at 60% use, then the `cpu.user_p` will be 180%.
 
     - name: system.pct
-      type: float
+      type: half_float
       description: >
         The percentage of CPU time spent in kernel space.
 
     - name: nice.pct
-      type: float
+      type: half_float
       description: >
         The percentage of CPU time spent on low-priority processes.
 
     - name: idle.pct
-      type: float
+      type: half_float
       description: >
         The percentage of CPU time spent idle.
 
     - name: iowait.pct
-      type: float
+      type: half_float
       description: >
         The percentage of CPU time spent in wait (on disk).
 
     - name: irq.pct
-      type: float
+      type: half_float
       description: >
         The percentage of CPU time spent servicing and handling hardware interrupts.
 
     - name: softirq.pct
-      type: float
+      type: half_float
       description: >
         The percentage of CPU time spent servicing and handling software interrupts.
 
     - name: steal.pct
-      type: float
+      type: half_float
       description: >
         The percentage of CPU time spent in involuntary wait by the virtual CPU while the hypervisor
         was servicing another processor.
@@ -94,14 +94,14 @@
         Load averages.
       fields:
         - name: "1"
-          type: float
+          type: half_float
           description: >
             Load average for the last minute.
         - name: "5"
-          type: float
+          type: half_float
           description: >
             Load average for the last 5 minutes.
         - name: "15"
-          type: float
+          type: half_float
           description: >
             Load average for the last 15 minutes.

--- a/metricbeat/module/system/filesystem/_meta/fields.yml
+++ b/metricbeat/module/system/filesystem/_meta/fields.yml
@@ -36,7 +36,7 @@
       description: >
         The used disk space in bytes.
     - name: used.pct
-      type: float
+      type: half_float
       description: >
         The percentage of used disk space.
 

--- a/metricbeat/module/system/memory/_meta/fields.yml
+++ b/metricbeat/module/system/memory/_meta/fields.yml
@@ -19,7 +19,7 @@
         Available memory.
 
     - name: used.pct
-      type: float
+      type: half_float
       description: >
         The percentage of used memory.
 
@@ -41,7 +41,7 @@
             buffers. Available only on Unix.
 
         - name: used.pct
-          type: float
+          type: half_float
           description: >
             The percentage of actual used memory.
 
@@ -66,6 +66,6 @@
             Available swap memory.
 
         - name: used.pct
-          type: float
+          type: half_float
           description: >
             The percentage of used swap memory.

--- a/metricbeat/module/system/process/_meta/fields.yml
+++ b/metricbeat/module/system/process/_meta/fields.yml
@@ -41,7 +41,7 @@
           description: >
             The amount of CPU time the process spent in user space.
         - name: total.pct
-          type: float
+          type: half_float
           description: >
             The percentage of CPU time spent by the process since the last update. Its value is similar to the
             %CPU value of the process displayed by the top command on Unix systems.
@@ -71,7 +71,7 @@
           description: >
             The Resident Set Size. The amount of memory the process occupied in main memory (RAM).
         - name: rss.pct
-          type: float
+          type: half_float
           description: >
             The percentage of memory the process occupied in main memory (RAM).
         - name: share


### PR DESCRIPTION
Starting with 5.0.0-alpha4, Elasticsearch supports [half floats](https://github.com/elastic/elasticsearch/pull/18887).

[Half precision floating-point](https://en.wikipedia.org/wiki/Half-precision_floating-point_format) numbers
have good precision for small numbers, but the precision degrades fast for larger numbers.

This is switching to half floats all the fields that are percentages
(values between 0 and 1) and the fields that were floats but have naturally
small values only. After going through the list, most of our floating point
numbers fit in one of these categories. Only 3 float fields were left untouched.

The template generator automatically switches to "float" when generating the
ES 2.x template files.

This closes #1936.