### PR TITLE
Introduce the condition in the processor with the when keyword

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -14,6 +14,7 @@ https://github.com/elastic/beats/compare/v5.0.0-alpha3...master[Check the HEAD d
 
 *Affecting all Beats*
 - Rename the `filters` section to `processors`. {pull}1944[1944]
+- Introduce the condition with `when` in the processor configuration. {pull}1949[1949]
 
 *Metricbeat*
 

--- a/filebeat/filebeat.full.yml
+++ b/filebeat/filebeat.full.yml
@@ -283,8 +283,9 @@ filebeat.prospectors:
 #
 #processors:
 #- drop_event:
-#    equals:
-#       http.code: 200
+#    when:
+#       equals:
+#           http.code: 200
 #
 
 #================================ Outputs =====================================

--- a/filebeat/tests/system/config/filebeat.yml.j2
+++ b/filebeat/tests/system/config/filebeat.yml.j2
@@ -114,20 +114,23 @@ processors:
 
     {%- if include_fields %}
     - include_fields:
-        {{include_fields.condition | default()}}
+        when:
+            {{include_fields.condition | default()}}
         fields: {{include_fields.fields | default([])}}
     {%- endif %}
 
     {%- if drop_fields %}
     - drop_fields:
-        {{drop_fields.condition | default()}}
+        when:
+            {{drop_fields.condition | default()}}
         fields: {{drop_fields.fields | default([])}}
     {%- endif %}
 
 
     {%- if drop_event %}
     - drop_event:
-        {{ drop_event.condition | default()}}
+        when:
+            {{ drop_event.condition | default()}}
     {%- endif %}
 
 {%- endif %}

--- a/libbeat/_meta/config.full.yml
+++ b/libbeat/_meta/config.full.yml
@@ -45,20 +45,21 @@
 # default is the number of logical CPUs available in the system.
 #max_procs:
 
-#================================ Filters =====================================
+#================================ Processors =====================================
 
-# This section defines a list of filtering rules that are applied one by one
-# starting with the exported event:
+# Processors are used to reduce the number of fields in the exported event or to 
+# enhance the event with external meta data. This section defines a list of processors 
+# that are applied one by one and the first one receives the initial event:
 #
 #   event -> filter1 -> event1 -> filter2 ->event2 ...
 #
-# Supported actions: drop_fields, drop_event, include_fields
+# Supported processors: drop_fields, drop_event, include_fields
 #
-# For example, the following filter configuration uses multiple actions to keep
+# For example, you can use the following processors to keep
 # the fields that contain CPU load percentages, but remove the fields that
 # contain CPU ticks values:
 #
-#filters:
+#processors:
 #- include_fields:
 #    fields: ["cpu"]
 #- drop_fields:
@@ -66,10 +67,11 @@
 #
 # The following example drops the events that have the HTTP response code 200:
 #
-#filters:
+#processors:
 #- drop_event:
-#    equals:
-#       http.code: 200
+#    when:
+#       equals:
+#           http.code: 200
 #
 
 #================================ Outputs =====================================

--- a/libbeat/docs/filteringconfig.asciidoc
+++ b/libbeat/docs/filteringconfig.asciidoc
@@ -28,7 +28,7 @@ event -> processor 1 -> event1 -> processor 2 -> event2 ...
 See <<exported-fields>> for the full list of possible fields.
 
 Each processor receives a condition and optionally a set of arguments. The action is executed only if the condition
-is fulfilled. If not condition is passed then the action is always executed.
+is fulfilled. If no condition is passed then the action is always executed.
 
 [source,yaml]
 ------

--- a/libbeat/docs/filteringconfig.asciidoc
+++ b/libbeat/docs/filteringconfig.asciidoc
@@ -28,16 +28,18 @@ event -> processor 1 -> event1 -> processor 2 -> event2 ...
 See <<exported-fields>> for the full list of possible fields.
 
 Each processor receives a condition and optionally a set of arguments. The action is executed only if the condition
-is fulfilled.
+is fulfilled. If not condition is passed then the action is always executed.
 
 [source,yaml]
 ------
 processors:
  - action1:
-     condition1
+     when:
+        condition1
      [arguments]
  - action2:
-     condition2
+     when:
+        condition2
 	 [arguments]
 ...
 
@@ -160,7 +162,8 @@ optional and if it's missing then the defined fields are always exported. The `@
 -------
 processors:
  - include_fields:
-     [condition]
+     when:
+        condition
      fields: ["field1", "field2", ...]
 -------
 
@@ -182,7 +185,8 @@ even if they show up in the `drop_fields` list.
 -----------------------------------------------------
 processors:
  - drop_fields:
-     [condition]
+     when:
+        condition
      fields: ["field1", "field2", ...]
 -----------------------------------------------------
 
@@ -199,6 +203,7 @@ without one all the events are dropped.
 ------
 processors:
  - drop_event:
-     condition
+     when:
+        condition
 ------
 

--- a/libbeat/processors/actions/drop_event.go
+++ b/libbeat/processors/actions/drop_event.go
@@ -12,7 +12,7 @@ type DropEvent struct {
 }
 
 type DropEventConfig struct {
-	processors.ConditionConfig `config:",inline"`
+	Cond *processors.ConditionConfig `config:"when"`
 }
 
 func init() {
@@ -36,7 +36,7 @@ func newDropEvent(c common.Config) (processors.Processor, error) {
 		return nil, fmt.Errorf("fail to unpack the drop_event configuration: %s", err)
 	}
 
-	cond, err := processors.NewCondition(config.ConditionConfig)
+	cond, err := processors.NewCondition(config.Cond)
 	if err != nil {
 		return nil, err
 	}
@@ -48,7 +48,7 @@ func newDropEvent(c common.Config) (processors.Processor, error) {
 func (f *DropEvent) CheckConfig(c common.Config) error {
 
 	for _, field := range c.GetFields() {
-		if !processors.AvailableCondition(field) {
+		if field != "when" {
 			return fmt.Errorf("unexpected %s option in the drop_event configuration", field)
 		}
 	}

--- a/libbeat/processors/actions/drop_fields.go
+++ b/libbeat/processors/actions/drop_fields.go
@@ -15,8 +15,8 @@ type DropFields struct {
 }
 
 type DropFieldsConfig struct {
-	Fields                     []string `config:"fields"`
-	processors.ConditionConfig `config:",inline"`
+	Fields []string                    `config:"fields"`
+	Cond   *processors.ConditionConfig `config:"when"`
 }
 
 func init() {
@@ -50,7 +50,7 @@ func newDropFields(c common.Config) (processors.Processor, error) {
 	}
 	f.Fields = config.Fields
 
-	cond, err := processors.NewCondition(config.ConditionConfig)
+	cond, err := processors.NewCondition(config.Cond)
 	if err != nil {
 		return nil, err
 	}
@@ -64,10 +64,8 @@ func (f *DropFields) CheckConfig(c common.Config) error {
 	complete := false
 
 	for _, field := range c.GetFields() {
-		if !processors.AvailableCondition(field) {
-			if field != "fields" {
-				return fmt.Errorf("unexpected %s option in the drop_fields configuration", field)
-			}
+		if field != "fields" && field != "when" {
+			return fmt.Errorf("unexpected %s option in the drop_fields configuration", field)
 		}
 		if field == "fields" {
 			complete = true

--- a/libbeat/processors/condition.go
+++ b/libbeat/processors/condition.go
@@ -30,19 +30,14 @@ type Condition struct {
 	rangexp  map[string]RangeValue
 }
 
-func AvailableCondition(name string) bool {
-
-	switch name {
-	case "equals", "contains", "range", "regexp":
-		return true
-	default:
-		return false
-	}
-}
-
-func NewCondition(config ConditionConfig) (*Condition, error) {
+func NewCondition(config *ConditionConfig) (*Condition, error) {
 
 	c := Condition{}
+
+	if config == nil {
+		// empty condition
+		return nil, nil
+	}
 
 	if config.Equals != nil {
 		if err := c.setEquals(config.Equals); err != nil {
@@ -61,8 +56,7 @@ func NewCondition(config ConditionConfig) (*Condition, error) {
 			return nil, err
 		}
 	} else {
-		// empty condition
-		return nil, nil
+		return nil, fmt.Errorf("missing condition")
 	}
 
 	return &c, nil

--- a/libbeat/processors/condition_test.go
+++ b/libbeat/processors/condition_test.go
@@ -40,7 +40,7 @@ func TestBadCondition(t *testing.T) {
 	}
 
 	for _, config := range configs {
-		_, err := NewCondition(config)
+		_, err := NewCondition(&config)
 		assert.NotNil(t, err)
 	}
 }
@@ -50,7 +50,7 @@ func GetConditions(t *testing.T, configs []ConditionConfig) []Condition {
 
 	for _, config := range configs {
 
-		cond, err := NewCondition(config)
+		cond, err := NewCondition(&config)
 		assert.Nil(t, err)
 		conds = append(conds, *cond)
 	}

--- a/libbeat/processors/processor.go
+++ b/libbeat/processors/processor.go
@@ -14,7 +14,7 @@ type Processors struct {
 
 func New(config PluginConfig) (*Processors, error) {
 
-	processors := Processors{}
+	procs := Processors{}
 
 	for _, processor := range config {
 
@@ -35,24 +35,24 @@ func New(config PluginConfig) (*Processors, error) {
 				return nil, err
 			}
 
-			processors.addProcessor(plugin)
+			procs.addProcessor(plugin)
 		}
 	}
 
-	logp.Debug("processors", "Processors: %v", processors)
-	return &processors, nil
+	logp.Debug("processors", "Processors: %v", procs)
+	return &procs, nil
 }
 
-func (processors *Processors) addProcessor(p Processor) {
+func (procs *Processors) addProcessor(p Processor) {
 
-	processors.list = append(processors.list, p)
+	procs.list = append(procs.list, p)
 }
 
 // Applies a sequence of processing rules and returns the filtered event
-func (processors *Processors) Run(event common.MapStr) common.MapStr {
+func (procs *Processors) Run(event common.MapStr) common.MapStr {
 
 	// Check if processors are set, just return event if not
-	if len(processors.list) == 0 {
+	if len(procs.list) == 0 {
 		return event
 	}
 
@@ -60,7 +60,7 @@ func (processors *Processors) Run(event common.MapStr) common.MapStr {
 	filtered := event.Clone()
 	var err error
 
-	for _, p := range processors.list {
+	for _, p := range procs.list {
 		filtered, err = p.Run(filtered)
 		if err != nil {
 			logp.Debug("filter", "fail to apply processor %s: %s", p, err)
@@ -74,10 +74,10 @@ func (processors *Processors) Run(event common.MapStr) common.MapStr {
 	return filtered
 }
 
-func (processors Processors) String() string {
+func (procs Processors) String() string {
 	s := []string{}
 
-	for _, p := range processors.list {
+	for _, p := range procs.list {
 
 		s = append(s, p.String())
 	}

--- a/libbeat/processors/processor_test.go
+++ b/libbeat/processors/processor_test.go
@@ -43,8 +43,10 @@ func TestBadConfig(t *testing.T) {
 	yml := []map[string]interface{}{
 		map[string]interface{}{
 			"include_fields": map[string]interface{}{
-				"contains": map[string]string{
-					"proc.name": "test",
+				"when": map[string]interface{}{
+					"contains": map[string]string{
+						"proc.name": "test",
+					},
 				},
 				"fields": []string{"proc.cpu.total_p", "proc.mem", "dd"},
 			},
@@ -82,8 +84,10 @@ func TestIncludeFields(t *testing.T) {
 	yml := []map[string]interface{}{
 		map[string]interface{}{
 			"include_fields": map[string]interface{}{
-				"contains": map[string]string{
-					"proc.name": "test",
+				"when": map[string]interface{}{
+					"contains": map[string]string{
+						"proc.name": "test",
+					},
 				},
 				"fields": []string{"proc.cpu.total_p", "proc.mem", "dd"},
 			},
@@ -148,8 +152,10 @@ func TestIncludeFields1(t *testing.T) {
 	yml := []map[string]interface{}{
 		map[string]interface{}{
 			"include_fields": map[string]interface{}{
-				"regexp": map[string]string{
-					"proc.cmdline": "launchd",
+				"when": map[string]interface{}{
+					"regexp": map[string]string{
+						"proc.cmdline": "launchd",
+					},
 				},
 				"fields": []string{"proc.cpu.total_add"},
 			},
@@ -199,8 +205,10 @@ func TestDropFields(t *testing.T) {
 	yml := []map[string]interface{}{
 		map[string]interface{}{
 			"drop_fields": map[string]interface{}{
-				"equals": map[string]string{
-					"beat.hostname": "mar",
+				"when": map[string]interface{}{
+					"equals": map[string]string{
+						"beat.hostname": "mar",
+					},
 				},
 				"fields": []string{"proc.cpu.start_time", "mem", "proc.cmdline", "beat", "dd"},
 			},
@@ -262,8 +270,10 @@ func TestMultipleIncludeFields(t *testing.T) {
 	yml := []map[string]interface{}{
 		map[string]interface{}{
 			"include_fields": map[string]interface{}{
-				"contains": map[string]string{
-					"beat.name": "my-shipper",
+				"when": map[string]interface{}{
+					"contains": map[string]string{
+						"beat.name": "my-shipper",
+					},
 				},
 				"fields": []string{"proc"},
 			},
@@ -357,9 +367,11 @@ func TestDropEvent(t *testing.T) {
 	yml := []map[string]interface{}{
 		map[string]interface{}{
 			"drop_event": map[string]interface{}{
-				"range": map[string]interface{}{
-					"proc.cpu.total_p": map[string]float64{
-						"lt": 0.5,
+				"when": map[string]interface{}{
+					"range": map[string]interface{}{
+						"proc.cpu.total_p": map[string]float64{
+							"lt": 0.5,
+						},
 					},
 				},
 			},
@@ -453,8 +465,10 @@ func TestBadCondition(t *testing.T) {
 	yml := []map[string]interface{}{
 		map[string]interface{}{
 			"drop_event": map[string]interface{}{
-				"equal": map[string]string{
-					"type": "process",
+				"when": map[string]interface{}{
+					"equal": map[string]string{
+						"type": "process",
+					},
 				},
 			},
 		},
@@ -488,9 +502,49 @@ func TestMissingFields(t *testing.T) {
 	yml := []map[string]interface{}{
 		map[string]interface{}{
 			"include_fields": map[string]interface{}{
-				"equals": map[string]string{
-					"type": "process",
+				"when": map[string]interface{}{
+					"equals": map[string]string{
+						"type": "process",
+					},
 				},
+			},
+		},
+	}
+
+	config := processors.PluginConfig{}
+
+	for _, action := range yml {
+		c := map[string]common.Config{}
+
+		for name, actionYml := range action {
+			actionConfig, err := common.NewConfigFrom(actionYml)
+			assert.Nil(t, err)
+
+			c[name] = *actionConfig
+		}
+		config = append(config, c)
+	}
+
+	_, err := processors.New(config)
+	assert.NotNil(t, err)
+
+}
+
+func TestBadConditionConfig(t *testing.T) {
+
+	if testing.Verbose() {
+		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"*"})
+	}
+
+	yml := []map[string]interface{}{
+		map[string]interface{}{
+			"include_fields": map[string]interface{}{
+				"when": map[string]interface{}{
+					"fake": map[string]string{
+						"type": "process",
+					},
+				},
+				"fields": []string{"proc.cpu.start_time", "proc.cpu.total_p", "proc.mem.rss_p", "proc.cmdline"},
 			},
 		},
 	}

--- a/metricbeat/metricbeat.full.yml
+++ b/metricbeat/metricbeat.full.yml
@@ -190,20 +190,21 @@ metricbeat.modules:
 # default is the number of logical CPUs available in the system.
 #max_procs:
 
-#================================ Filters =====================================
+#================================ Processors =====================================
 
-# This section defines a list of filtering rules that are applied one by one
-# starting with the exported event:
+# Processors are used to reduce the number of fields in the exported event or to 
+# enhance the event with external meta data. This section defines a list of processors 
+# that are applied one by one and the first one receives the initial event:
 #
 #   event -> filter1 -> event1 -> filter2 ->event2 ...
 #
-# Supported actions: drop_fields, drop_event, include_fields
+# Supported processors: drop_fields, drop_event, include_fields
 #
-# For example, the following filter configuration uses multiple actions to keep
+# For example, you can use the following processors to keep
 # the fields that contain CPU load percentages, but remove the fields that
 # contain CPU ticks values:
 #
-#filters:
+#processors:
 #- include_fields:
 #    fields: ["cpu"]
 #- drop_fields:
@@ -211,11 +212,11 @@ metricbeat.modules:
 #
 # The following example drops the events that have the HTTP response code 200:
 #
-#filters:
+#processors:
 #- drop_event:
-#   when:
-#     equals:
-#       http.code: 200
+#    when:
+#       equals:
+#           http.code: 200
 #
 
 #================================ Outputs =====================================

--- a/metricbeat/metricbeat.full.yml
+++ b/metricbeat/metricbeat.full.yml
@@ -213,7 +213,8 @@ metricbeat.modules:
 #
 #filters:
 #- drop_event:
-#    equals:
+#   when:
+#     equals:
 #       http.code: 200
 #
 

--- a/metricbeat/tests/system/config/metricbeat.yml.j2
+++ b/metricbeat/tests/system/config/metricbeat.yml.j2
@@ -109,19 +109,22 @@ processors:
 
   {%- if include_fields %}
   - include_fields:
-      {{include_fields.condition | default()}}
+      when:
+        {{include_fields.condition | default()}}
       fields: {{include_fields.fields | default([])}}
   {%- endif %}
 
   {%- if drop_fields %}
   - drop_fields:
-      {{drop_fields.condition | default()}}
+      when:
+        {{drop_fields.condition | default()}}
       fields: {{drop_fields.fields | default([])}}
   {%- endif %}
 
   {%- if drop_event %}
   - drop_event:
-      {{ drop_event.condition | default()}}
+      when:
+        {{ drop_event.condition | default()}}
   {%- endif %}
 
 {%- endif %}

--- a/packetbeat/packetbeat.full.yml
+++ b/packetbeat/packetbeat.full.yml
@@ -453,8 +453,9 @@ packetbeat.protocols.nfs:
 #
 #processors:
 #- drop_event:
-#    equals:
-#       http.code: 200
+#    when:
+#       equals:
+#           http.code: 200
 #
 
 #================================ Outputs =====================================

--- a/packetbeat/tests/system/config/packetbeat.yml.j2
+++ b/packetbeat/tests/system/config/packetbeat.yml.j2
@@ -181,20 +181,23 @@ processors:
 
     {%- if include_fields %}
     - include_fields:
-        {{include_fields.condition | default()}}
+        when:
+            {{include_fields.condition | default()}}
         fields: {{include_fields.fields | default([])}}
     {%- endif %}
 
     {%- if drop_fields %}
     - drop_fields:
-        {{drop_fields.condition | default()}}
+        when:
+            {{drop_fields.condition | default()}}
         fields: {{drop_fields.fields | default([])}}
     {%- endif %}
 
 
     {%- if drop_event %}
     - drop_event:
-        {{ drop_event.condition | default()}}
+        when: 
+            {{ drop_event.condition | default()}}
     {%- endif %}
 
 {%- endif %}

--- a/winlogbeat/winlogbeat.full.yml
+++ b/winlogbeat/winlogbeat.full.yml
@@ -88,13 +88,13 @@ winlogbeat.event_logs:
 #
 #   event -> filter1 -> event1 -> filter2 ->event2 ...
 #
-# Supported actions: drop_fields, drop_event, include_fields
+# Supported processors: drop_fields, drop_event, include_fields
 #
-# For example, the following filter configuration uses multiple actions to keep
+# For example, you can use the following processors to keep
 # the fields that contain CPU load percentages, but remove the fields that
 # contain CPU ticks values:
 #
-#filters:
+#processors:
 #- include_fields:
 #    fields: ["cpu"]
 #- drop_fields:
@@ -102,10 +102,11 @@ winlogbeat.event_logs:
 #
 # The following example drops the events that have the HTTP response code 200:
 #
-#filters:
+#processors:
 #- drop_event:
-#    equals:
-#       http.code: 200
+#    when:
+#       equals:
+#           http.code: 200
 #
 
 #================================ Outputs =====================================


### PR DESCRIPTION
By renaming `filters` with `processors` ( #1944), more and more arguments will be available under `processors`, so introducing the condition with `when` makes it easier to be spotted. 

Before:
<pre>
processors:
 - include_fields:
     equals:
       proc.pid: 3455
     fields: ["proc.cpu", "proc.mem"]
</pre>

After:
<pre>
processors:
 - include_fields:
     when:    
        equals:
           proc.pid: 3455
     fields: ["proc.cpu", "proc.mem"]
</pre>
