### PR TITLE
Disable ES bootstrap checks in 5.0.0-alpha4 docker-compose

### DIFF
--- a/testing/environments/5.0.0-alpha4.yml
+++ b/testing/environments/5.0.0-alpha4.yml
@@ -4,7 +4,7 @@
 elasticsearch:
   build: ./docker/elasticsearch
   dockerfile: Dockerfile-5.0.0-alpha4
-  command: elasticsearch -Enetwork.host=0.0.0.0 -Ediscovery.zen.minimum_master_nodes=1
+  command: elasticsearch -Enetwork.host=0.0.0.0 -Ediscovery.zen.minimum_master_nodes=1 -Ebootstrap.ignore_system_bootstrap_checks=true
 
 logstash:
   build: ./docker/logstash


### PR DESCRIPTION
elasticsearch docker container in 5.0.0-alpha4 not starting in docker container due to bootstrap check finding some issues. Add flag to ignore these bootstrap checks (as done in other docker-compose files).