### PR TITLE
Fix Filebeat rotation issue

### DIFF
--- a/filebeat/input/file/file_windows.go
+++ b/filebeat/input/file/file_windows.go
@@ -81,7 +81,7 @@ func ReadOpen(path string) (*os.File, error) {
 	// This is mostly the code from syscall_windows::Open. Only difference is passing the Delete flag
 	// TODO: Open pull request to Golang so also Delete flag can be set
 	if len(path) == 0 {
-		return nil, fmt.Errorf("File '%s' not found. Error: %v", syscall.ERROR_FILE_NOT_FOUND)
+		return nil, fmt.Errorf("File '%s' not found. Error: %v", path, syscall.ERROR_FILE_NOT_FOUND)
 	}
 
 	pathp, err := syscall.UTF16PtrFromString(path)

--- a/filebeat/tests/system/config/filebeat.yml.j2
+++ b/filebeat/tests/system/config/filebeat.yml.j2
@@ -144,7 +144,7 @@ processors:
 output.file:
   path: {{ output_file_path|default(beat.working_dir + "/output") }}
   filename: "{{ output_file_filename|default("filebeat") }}"
-  rotate_every_kb: 1000
+  rotate_every_kb: {{ rotate_every_kb | default(1000) }}
   #number_of_files: 7
 
 {% if path_data %}

--- a/filebeat/tests/system/test_load.py
+++ b/filebeat/tests/system/test_load.py
@@ -1,0 +1,108 @@
+from filebeat import BaseTest
+import os
+import logging
+import logging.handlers
+import json
+from nose.plugins.skip import Skip, SkipTest
+import time
+
+"""
+Test filebeat under different load scenarios
+"""
+
+
+class Test(BaseTest):
+    def test_no_missing_events(self):
+        """
+        Test that filebeat does not loose any events under heavy file rotation and load
+        """
+
+        if os.name == "nt":
+            # This test is currently skipped on windows because very fast file
+            # rotation cannot happen when harvester has file handler still open.
+            raise SkipTest
+
+        log_file = self.working_dir + "/log/test.log"
+        os.mkdir(self.working_dir + "/log/")
+
+        logger = logging.getLogger('beats-logger')
+        total_lines = 1000
+        lines_per_file = 10
+        # Each line should have the same length + line ending
+        # Some spare capacity is added to make sure all events are presisted
+        line_length = len(str(total_lines)) + 1
+
+        # Setup python log handler
+        handler = logging.handlers.RotatingFileHandler(
+            log_file, maxBytes=line_length * lines_per_file + 1,
+            backupCount=total_lines / lines_per_file + 1)
+        logger.addHandler(handler)
+
+        self.render_config_template(
+            path=os.path.abspath(self.working_dir) + "/log/*",
+            rotate_every_kb=(total_lines * (line_length +1)),    # With filepath, each line can be up to 1KB is assumed
+        )
+
+        # Start filebeat
+        filebeat = self.start_beat()
+
+        # wait until filebeat is fully running
+        self.wait_until(
+            lambda: self.log_contains("All prospectors are initialised and running"),
+            max_timeout=15)
+
+        # Start logging and rotating
+        for i in range(total_lines):
+            # Make sure each line has the same length
+            line = format(i, str(line_length - 1))
+            logger.debug("%d", i)
+
+        # wait until all lines are read
+        self.wait_until(
+            lambda: self.output_has(lines=total_lines),
+            max_timeout=15)
+
+        filebeat.check_kill_and_wait()
+
+        entry_list = []
+
+        with open(self.working_dir + "/output/filebeat") as f:
+            for line in f:
+                content = json.loads(line)
+                v = int(content["message"])
+                entry_list.append(v)
+
+        ### This lines can be uncomemnted for debugging ###
+        # Prints out the missing entries
+        #for i in range(total_lines):
+        #    if i not in entry_list:
+        #        print i
+        # Stats about the files read
+        #unique_entries = len(set(entry_list))
+        #print "Total lines: " + str(total_lines)
+        #print "Total unique entries: " + str(unique_entries)
+        #print "Total entries: " + str(len(entry_list))
+        #print "Registry entries: " + str(len(data))
+
+        # Check that file exist
+        data = self.get_registry()
+
+        paths = os.listdir(self.working_dir + "/log/")
+        assert len(paths) == len(data)
+
+        for i in range(total_lines):
+            assert i in entry_list
+
+        # Compares unique entries
+        assert len(set(entry_list)) == total_lines
+        assert len(entry_list) == total_lines
+
+
+    def test_no_open_files_left(self):
+        """
+        Test that filebeat not keep any files open
+        """
+
+        # This is not implemented yet, here as a reminder
+        raise SkipTest
+


### PR DESCRIPTION
In case a file was renamed after the state was read but before the file was opened by the harvester it could happen that the wrong file was opened. This lead to the issue, that the wrong file was read including reporting the wrong state for a file. In general this was rather unlikely to happen, but can happen when scan_frequency is very low and number of files rotated is very high.

This issue is fixed with the harvester now compares again the file after opening with the state given from the prospector. In case the state is not identical with the file, the harvester aborts. This means that the file will only be picked up again after scan_frequency but potential errors are prevented.

Closes https://github.com/elastic/beats/issues/1956