### PR TITLE
Remove optional from config topic headings

### DIFF
--- a/libbeat/docs/loggingconfig.asciidoc
+++ b/libbeat/docs/loggingconfig.asciidoc
@@ -11,7 +11,7 @@
 //////////////////////////////////////////////////////////////////////////
 
 [[configuration-logging]]
-=== Logging (Optional)
+=== Logging
 
 The `logging` section contains options for configuring the Beats logging output.
 The logging system can write logs to syslog or rotate log files. If logging is

--- a/libbeat/docs/runconfig.asciidoc
+++ b/libbeat/docs/runconfig.asciidoc
@@ -11,7 +11,7 @@
 //////////////////////////////////////////////////////////////////////////
 
 [[configuration-run-options]]
-=== Run Options (Optional)
+=== Run Options
 
 The Beat can drop privileges after creating the sniffing socket.
 Root access is required for opening the socket, but everything else requires no

--- a/packetbeat/docs/reference/configuration/packetbeat-options.asciidoc
+++ b/packetbeat/docs/reference/configuration/packetbeat-options.asciidoc
@@ -596,9 +596,9 @@ Note that limiting documents in this way means that they are no longer correctly
 formatted JSON objects.
 
 [[configuration-processes]]
-=== Processes (Optional)
+=== Processes
 
-This section is optional, but configuring the processes enables Packetbeat
+Configuring the processes enables Packetbeat
 to show you not only the servers that the traffic is flowing between, but
 also the processes. Packetbeat can even show you the traffic between two
 processes running on the same host, which is particularly useful when you


### PR DESCRIPTION
Removed "(Optional)" after config reference section titles because it makes it seem like other sections (which aren't marked optional) are required, which is not true. 