### PR TITLE
Remove optional labels from config topic headings

### DIFF
--- a/libbeat/docs/loggingconfig.asciidoc
+++ b/libbeat/docs/loggingconfig.asciidoc
@@ -11,7 +11,7 @@
 //////////////////////////////////////////////////////////////////////////
 
 [[configuration-logging]]
-=== Logging Configuration (Optional)
+=== Logging Configuration
 
 The `logging` section of the +{beatname_lc}.yml+ config file contains options
 for configuring the Beats logging output. The logging system can write logs to

--- a/packetbeat/docs/reference/configuration/packetbeat-options.asciidoc
+++ b/packetbeat/docs/reference/configuration/packetbeat-options.asciidoc
@@ -660,7 +660,7 @@ Note that limiting documents in this way means that they are no longer correctly
 formatted JSON objects.
 
 [[configuration-processes]]
-=== Monitored Processes Configuration (Optional)
+=== Monitored Processes Configuration
 
 This section of the +{beatname_lc}.yml+ config file is optional, but configuring
 the processes enables Packetbeat to show you not only the servers that the

--- a/packetbeat/docs/reference/configuration/runconfig.asciidoc
+++ b/packetbeat/docs/reference/configuration/runconfig.asciidoc
@@ -1,5 +1,5 @@
 [[configuration-run-options]]
-=== Run Options Configuration (Optional)
+=== Run Options Configuration
 
 The Beat can drop privileges after creating the sniffing socket.
 Root access is required for opening the socket, but everything else requires no


### PR DESCRIPTION
Removed "(Optional)" after config reference section titles because it makes it seem like other sections (which aren't marked optional) are required, which is not true. 