### PR TITLE
Add freebsd build tags for Metricbeat system metricsets

### DIFF
--- a/metricbeat/Makefile
+++ b/metricbeat/Makefile
@@ -10,7 +10,7 @@ ES_BEATS?=..
 # Metricbeat can only be cross-compiled on platforms not requiring CGO which
 # are the same platforms where the system metrics (cpu, memory) are not
 # implemented.
-GOX_OS=solaris freebsd netbsd
+GOX_OS=solaris netbsd
 GOX_FLAGS='-arch=amd64'
 
 include ${ES_BEATS}/libbeat/scripts/Makefile

--- a/metricbeat/docs/faq.asciidoc
+++ b/metricbeat/docs/faq.asciidoc
@@ -4,4 +4,16 @@
 This section contains frequently asked questions about Metricbeat. Also check out the
 https://discuss.elastic.co/c/beats/metricbeat[Metricbeat discussion forum].
 
+=== How do I fix the `open /compat/linux/proc: no such file or directory` error on FreeBSD?
+
+The system metricsets rely a Linux comparability layer to retrieve metrics on
+FreeBSD. You need to mount the Linux procfs filesystem using the following
+commands.
+
+[source,sh]
+----
+sudo mkdir -p /compat/linux/proc
+sudo mount -t linprocfs /dev/null /compat/linux/proc
+----
+
 include::../../libbeat/docs/shared-faq.asciidoc[]

--- a/metricbeat/module/system/common/process_test.go
+++ b/metricbeat/module/system/common/process_test.go
@@ -1,4 +1,5 @@
 // +build !integration
+// +build darwin freebsd linux windows
 
 package common
 

--- a/metricbeat/module/system/core/_meta/docs.asciidoc
+++ b/metricbeat/module/system/core/_meta/docs.asciidoc
@@ -1,3 +1,10 @@
 === System Core Metricset
 
 The System `core` metricset provides load statistics for each CPU core.
+
+This metricset is available on:
+
+- Darwin
+- FreeBSD
+- Linux
+- OpenBSD

--- a/metricbeat/module/system/core/core.go
+++ b/metricbeat/module/system/core/core.go
@@ -1,4 +1,4 @@
-// +build darwin linux openbsd windows
+// +build darwin freebsd linux openbsd
 
 package core
 

--- a/metricbeat/module/system/core/core_test.go
+++ b/metricbeat/module/system/core/core_test.go
@@ -1,3 +1,6 @@
+// +build !integration
+// +build darwin freebsd linux openbsd
+
 package core
 
 import (

--- a/metricbeat/module/system/cpu/_meta/docs.asciidoc
+++ b/metricbeat/module/system/cpu/_meta/docs.asciidoc
@@ -1,3 +1,11 @@
 === System CPU Metricset
 
 The System `cpu` metricset provides CPU statistics.
+
+This metricset is available on:
+
+- Darwin
+- FreeBSD
+- Linux
+- OpenBSD
+- Windows

--- a/metricbeat/module/system/cpu/cpu.go
+++ b/metricbeat/module/system/cpu/cpu.go
@@ -1,4 +1,4 @@
-// +build darwin linux openbsd windows
+// +build darwin freebsd linux openbsd windows
 
 package cpu
 

--- a/metricbeat/module/system/cpu/cpu_test.go
+++ b/metricbeat/module/system/cpu/cpu_test.go
@@ -1,3 +1,6 @@
+// +build !integration
+// +build darwin freebsd linux openbsd windows
+
 package cpu
 
 import (

--- a/metricbeat/module/system/filesystem/_meta/docs.asciidoc
+++ b/metricbeat/module/system/filesystem/_meta/docs.asciidoc
@@ -1,3 +1,12 @@
 === System Filesystem Metricset
 
-The System `filesystem` metricset provides file system statistics. For each file system, one document is provided.
+The System `filesystem` metricset provides file system statistics. For each file
+system, one document is provided.
+
+This metricset is available on:
+
+- Darwin
+- FreeBSD
+- Linux
+- OpenBSD
+- Windows

--- a/metricbeat/module/system/filesystem/filesystem.go
+++ b/metricbeat/module/system/filesystem/filesystem.go
@@ -1,4 +1,4 @@
-// +build darwin linux openbsd windows
+// +build darwin freebsd linux openbsd windows
 
 package filesystem
 

--- a/metricbeat/module/system/filesystem/filesystem_test.go
+++ b/metricbeat/module/system/filesystem/filesystem_test.go
@@ -1,3 +1,6 @@
+// +build !integration
+// +build darwin freebsd linux openbsd windows
+
 package filesystem
 
 import (

--- a/metricbeat/module/system/fsstat/_meta/docs.asciidoc
+++ b/metricbeat/module/system/fsstat/_meta/docs.asciidoc
@@ -1,3 +1,11 @@
 === System Fsstat Metricset
 
 The System `fsstats` metricset provides overall file system statistics.
+
+This metricset is available on:
+
+- Darwin
+- FreeBSD
+- Linux
+- OpenBSD
+- Windows

--- a/metricbeat/module/system/fsstat/fsstat.go
+++ b/metricbeat/module/system/fsstat/fsstat.go
@@ -1,4 +1,4 @@
-// +build darwin linux openbsd windows
+// +build darwin freebsd linux openbsd windows
 
 package fsstat
 

--- a/metricbeat/module/system/fsstat/fsstat_test.go
+++ b/metricbeat/module/system/fsstat/fsstat_test.go
@@ -1,3 +1,6 @@
+// +build !integration
+// +build darwin freebsd linux openbsd windows
+
 package fsstat
 
 import (

--- a/metricbeat/module/system/memory/_meta/docs.asciidoc
+++ b/metricbeat/module/system/memory/_meta/docs.asciidoc
@@ -1,3 +1,11 @@
 === System Memory Metricset
 
 The System `memory` metricset provides memory statistics.
+
+This metricset is available on:
+
+- Darwin
+- FreeBSD
+- Linux
+- OpenBSD
+- Windows

--- a/metricbeat/module/system/memory/memory.go
+++ b/metricbeat/module/system/memory/memory.go
@@ -1,4 +1,4 @@
-// +build darwin linux openbsd windows
+// +build darwin freebsd linux openbsd windows
 
 package memory
 

--- a/metricbeat/module/system/memory/memory_test.go
+++ b/metricbeat/module/system/memory/memory_test.go
@@ -1,3 +1,6 @@
+// +build !integration
+// +build darwin freebsd linux openbsd windows
+
 package memory
 
 import (

--- a/metricbeat/module/system/network/network_test.go
+++ b/metricbeat/module/system/network/network_test.go
@@ -1,3 +1,6 @@
+// +build !integration
+// +build darwin freebsd linux windows
+
 package network
 
 import (

--- a/metricbeat/module/system/process/_meta/docs.asciidoc
+++ b/metricbeat/module/system/process/_meta/docs.asciidoc
@@ -1,3 +1,11 @@
 === System Process Metricset
 
-The System `process` metricset provides process statistics. One document is provided for each process.
+The System `process` metricset provides process statistics. One document is
+provided for each process.
+
+This metricset is available on:
+
+- Darwin
+- FreeBSD
+- Linux
+- Windows

--- a/metricbeat/module/system/process/process.go
+++ b/metricbeat/module/system/process/process.go
@@ -1,4 +1,4 @@
-// +build darwin linux windows
+// +build darwin freebsd linux windows
 
 package process
 

--- a/metricbeat/module/system/process/process_test.go
+++ b/metricbeat/module/system/process/process_test.go
@@ -1,3 +1,6 @@
+// +build !integration
+// +build darwin freebsd linux windows
+
 package process
 
 import (
@@ -11,7 +14,7 @@ import (
 func TestData(t *testing.T) {
 	f := mbtest.NewEventsFetcher(t, getConfig())
 
-	// Do a first fetch to have precentages
+	// Do a first fetch to have percentages
 	f.Fetch()
 	time.Sleep(1 * time.Second)
 

--- a/metricbeat/tests/system/test_base.py
+++ b/metricbeat/tests/system/test_base.py
@@ -5,7 +5,7 @@ from metricbeat import BaseTest
 
 
 class Test(BaseTest):
-    @unittest.skipUnless(re.match("(?i)win|linux|darwin|openbsd", sys.platform), "os")
+    @unittest.skipUnless(re.match("(?i)win|linux|darwin|freebsd|openbsd", sys.platform), "os")
     def test_start_stop(self):
         """
         Metricbeat starts and stops without error.

--- a/metricbeat/tests/system/test_filtering.py
+++ b/metricbeat/tests/system/test_filtering.py
@@ -3,7 +3,7 @@ import sys
 import metricbeat
 import unittest
 
-@unittest.skipUnless(re.match("(?i)win|linux|darwin|openbsd", sys.platform), "os")
+@unittest.skipUnless(re.match("(?i)win|linux|darwin|freebsd", sys.platform), "os")
 class GlobalFiltering(metricbeat.BaseTest):
 
     def test_drop_fields(self):


### PR DESCRIPTION
The MetricSets made available on FreeBSD by this change are core, cpu, filesystem, fsstat, memory, and process.

- Enable python system tests on FreeBSD.
- Remove cmdline from the required fields list in the python system tests for system/process events because cmdline may not be included for certain kernel level processes.
- Disable python filtering tests on OpenBSD because system/process is not implemented.
- Add build tags for the Golang tests in the system module.