### PR TITLE
Use dots for expvar names

### DIFF
--- a/libbeat/outputs/elasticsearch/client.go
+++ b/libbeat/outputs/elasticsearch/client.go
@@ -50,14 +50,14 @@ type Connection struct {
 
 // Metrics that can retrieved through the expvar web interface.
 var (
-	ackedEvents            = expvar.NewInt("libbeatEsPublishedAndAckedEvents")
-	eventsNotAcked         = expvar.NewInt("libbeatEsPublishedButNotAckedEvents")
-	publishEventsCallCount = expvar.NewInt("libbeatEsPublishEventsCallCount")
+	ackedEvents            = expvar.NewInt("libbeat.es.published_and_acked_events")
+	eventsNotAcked         = expvar.NewInt("libbeat.es.published_but_not_acked_events")
+	publishEventsCallCount = expvar.NewInt("libbeat.es.call_count.PublishEvents")
 
-	statReadBytes   = expvar.NewInt("libbeatEsPublishReadBytes")
-	statWriteBytes  = expvar.NewInt("libbeatEsPublishWriteBytes")
-	statReadErrors  = expvar.NewInt("libbeatEsPublishReadErrors")
-	statWriteErrors = expvar.NewInt("libbeatEsPublishWriteErrors")
+	statReadBytes   = expvar.NewInt("libbeat.es.publish.read_bytes")
+	statWriteBytes  = expvar.NewInt("libbeat.es.publish.write_bytes")
+	statReadErrors  = expvar.NewInt("libbeat.es.publish.read_errors")
+	statWriteErrors = expvar.NewInt("libbeat.es.publish.write_errors")
 )
 
 var (

--- a/libbeat/outputs/kafka/client.go
+++ b/libbeat/outputs/kafka/client.go
@@ -35,9 +35,9 @@ type msgRef struct {
 }
 
 var (
-	ackedEvents            = expvar.NewInt("libbeatKafkaPublishedAndAckedEvents")
-	eventsNotAcked         = expvar.NewInt("libbeatKafkaPublishedButNotAckedEvents")
-	publishEventsCallCount = expvar.NewInt("libbeatKafkaPublishEventsCallCount")
+	ackedEvents            = expvar.NewInt("libbeat.kafka.published_and_acked_events")
+	eventsNotAcked         = expvar.NewInt("libbeat.kafka.published_but_not_acked_events")
+	publishEventsCallCount = expvar.NewInt("libbeat.kafka.call_count.PublishEvents")
 )
 
 func newKafkaClient(hosts []string, topic string, useType bool, cfg *sarama.Config) (*client, error) {

--- a/libbeat/outputs/logstash/logstash.go
+++ b/libbeat/outputs/logstash/logstash.go
@@ -22,14 +22,14 @@ var debug = logp.MakeDebug("logstash")
 
 // Metrics that can retrieved through the expvar web interface.
 var (
-	ackedEvents            = expvar.NewInt("libbeatLogstashPublishedAndAckedEvents")
-	eventsNotAcked         = expvar.NewInt("libbeatLogstashPublishedButNotAckedEvents")
-	publishEventsCallCount = expvar.NewInt("libbeatLogstashPublishEventsCallCount")
+	ackedEvents            = expvar.NewInt("libbeat.logstash.published_and_acked_events")
+	eventsNotAcked         = expvar.NewInt("libbeat.logstash.published_but_not_acked_events")
+	publishEventsCallCount = expvar.NewInt("libbeat.logstash.call_count.PublishEvents")
 
-	statReadBytes   = expvar.NewInt("libbeatLogstashPublishReadBytes")
-	statWriteBytes  = expvar.NewInt("libbeatLogstashPublishWriteBytes")
-	statReadErrors  = expvar.NewInt("libbeatLogstashPublishReadErrors")
-	statWriteErrors = expvar.NewInt("libbeatLogstashPublishWriteErrors")
+	statReadBytes   = expvar.NewInt("libbeat.logstash.publish.read_bytes")
+	statWriteBytes  = expvar.NewInt("libbeat.logstash.publish.write_bytes")
+	statReadErrors  = expvar.NewInt("libbeat.logstash.publish.read_errors")
+	statWriteErrors = expvar.NewInt("libbeat.logstash.publish.write_errors")
 )
 
 const (

--- a/libbeat/outputs/mode/mode.go
+++ b/libbeat/outputs/mode/mode.go
@@ -15,7 +15,7 @@ import (
 
 // Metrics that can retrieved through the expvar web interface.
 var (
-	messagesDropped = expvar.NewInt("libbeatMessagesDropped")
+	messagesDropped = expvar.NewInt("libbeat.outputs.messages_dropped")
 )
 
 // ErrNoHostsConfigured indicates missing host or hosts configuration

--- a/libbeat/outputs/redis/redis.go
+++ b/libbeat/outputs/redis/redis.go
@@ -24,10 +24,10 @@ var debugf = logp.MakeDebug("redis")
 
 // Metrics that can retrieved through the expvar web interface.
 var (
-	statReadBytes   = expvar.NewInt("libbeatRedisPublishReadBytes")
-	statWriteBytes  = expvar.NewInt("libbeatRedisPublishWriteBytes")
-	statReadErrors  = expvar.NewInt("libbeatRedisPublishReadErrors")
-	statWriteErrors = expvar.NewInt("libbeatRedisPublishWriteErrors")
+	statReadBytes   = expvar.NewInt("libbeat.redis.publish.read_bytes")
+	statWriteBytes  = expvar.NewInt("libbeat.redis.publish.write_bytes")
+	statReadErrors  = expvar.NewInt("libbeat.redis.publish.read_errors")
+	statWriteErrors = expvar.NewInt("libbeat.redis.publish.write_errors")
 )
 
 const (

--- a/libbeat/publisher/client.go
+++ b/libbeat/publisher/client.go
@@ -12,7 +12,7 @@ import (
 
 // Metrics that can retrieved through the expvar web interface.
 var (
-	publishedEvents = expvar.NewInt("libbeatPublishedEvents")
+	publishedEvents = expvar.NewInt("libbeat.publisher.published_events")
 )
 
 var (

--- a/libbeat/publisher/worker.go
+++ b/libbeat/publisher/worker.go
@@ -10,7 +10,7 @@ import (
 
 // Metrics that can retrieved through the expvar web interface.
 var (
-	messagesInWorkerQueues = expvar.NewInt("libbeatMessagesInWorkerQueues")
+	messagesInWorkerQueues = expvar.NewInt("libbeat.publisher.messages_in_worker_queues")
 )
 
 type worker interface {

--- a/packetbeat/protos/amqp/amqp.go
+++ b/packetbeat/protos/amqp/amqp.go
@@ -35,8 +35,8 @@ type Amqp struct {
 }
 
 var (
-	unmatchedRequests  = expvar.NewInt("amqpUnmatchedRequests")
-	unmatchedResponses = expvar.NewInt("amqpUnmatchedResponses")
+	unmatchedRequests  = expvar.NewInt("amqp.unmatched_requests")
+	unmatchedResponses = expvar.NewInt("amqp.unmatched_responses")
 )
 
 func init() {

--- a/packetbeat/protos/dns/dns.go
+++ b/packetbeat/protos/dns/dns.go
@@ -43,8 +43,8 @@ const (
 type Transport uint8
 
 var (
-	unmatchedRequests  = expvar.NewInt("dnsUnmatchedRequests")
-	unmatchedResponses = expvar.NewInt("dnsUnmatchedResponses")
+	unmatchedRequests  = expvar.NewInt("dns.unmatched_requests")
+	unmatchedResponses = expvar.NewInt("dns.unmatched_responses")
 )
 
 const (

--- a/packetbeat/protos/http/http.go
+++ b/packetbeat/protos/http/http.go
@@ -33,7 +33,7 @@ const (
 )
 
 var (
-	unmatchedResponses = expvar.NewInt("httpUnmatchedResponses")
+	unmatchedResponses = expvar.NewInt("http.unmatched_responses")
 )
 
 type stream struct {

--- a/packetbeat/protos/icmp/icmp.go
+++ b/packetbeat/protos/icmp/icmp.go
@@ -51,9 +51,9 @@ const (
 )
 
 var (
-	unmatchedRequests  = expvar.NewInt("icmpUnmatchedRequests")
-	unmatchedResponses = expvar.NewInt("icmpUnmatchedResponses")
-	duplicateRequests  = expvar.NewInt("icmpDuplicateRequests")
+	unmatchedRequests  = expvar.NewInt("icmp.unmatched_requests")
+	unmatchedResponses = expvar.NewInt("icmp.unmatched_responses")
+	duplicateRequests  = expvar.NewInt("icmp.duplicate_requests")
 )
 
 func New(testMode bool, results publish.Transactions, cfg *common.Config) (*Icmp, error) {

--- a/packetbeat/protos/memcache/memcache.go
+++ b/packetbeat/protos/memcache/memcache.go
@@ -101,9 +101,9 @@ type memcacheStat struct {
 var debug = logp.MakeDebug("memcache")
 
 var (
-	unmatchedRequests      = expvar.NewInt("memcacheUnmatchedRequests")
-	unmatchedResponses     = expvar.NewInt("memcacheUnmatchedResponses")
-	unfinishedTransactions = expvar.NewInt("memcacheUnfinishedTransaction")
+	unmatchedRequests      = expvar.NewInt("memcache.unmatched_requests")
+	unmatchedResponses     = expvar.NewInt("memcache.unmatched_responses")
+	unfinishedTransactions = expvar.NewInt("memcache.unfinished_transactions")
 )
 
 func init() {

--- a/packetbeat/protos/mongodb/mongodb.go
+++ b/packetbeat/protos/mongodb/mongodb.go
@@ -37,7 +37,7 @@ type transactionKey struct {
 }
 
 var (
-	unmatchedRequests = expvar.NewInt("mongodbUnmatchedRequests")
+	unmatchedRequests = expvar.NewInt("mongodb.unmatched_requests")
 )
 
 func init() {

--- a/packetbeat/protos/mysql/mysql.go
+++ b/packetbeat/protos/mysql/mysql.go
@@ -24,8 +24,8 @@ const (
 const MAX_PAYLOAD_SIZE = 100 * 1024
 
 var (
-	unmatchedRequests  = expvar.NewInt("mysqlUnmatchedRequests")
-	unmatchedResponses = expvar.NewInt("mysqlUnmatchedResponses")
+	unmatchedRequests  = expvar.NewInt("mysql.unmatched_requests")
+	unmatchedResponses = expvar.NewInt("mysql.unmatched_responses")
 )
 
 type MysqlMessage struct {

--- a/packetbeat/protos/nfs/request_handler.go
+++ b/packetbeat/protos/nfs/request_handler.go
@@ -22,7 +22,7 @@ var ACCEPT_STATUS = [...]string{
 }
 
 var (
-	unmatchedRequests = expvar.NewInt("nfsUnmatchedRequests")
+	unmatchedRequests = expvar.NewInt("nfs.unmatched_requests")
 )
 
 // called by Cache, when re reply seen within expected time window

--- a/packetbeat/protos/pgsql/pgsql.go
+++ b/packetbeat/protos/pgsql/pgsql.go
@@ -99,7 +99,7 @@ var (
 )
 
 var (
-	unmatchedResponses = expvar.NewInt("pgsqlUnmatchedResponses")
+	unmatchedResponses = expvar.NewInt("pgsql.unmatched_responses")
 )
 
 type Pgsql struct {

--- a/packetbeat/protos/redis/redis.go
+++ b/packetbeat/protos/redis/redis.go
@@ -49,7 +49,7 @@ var (
 )
 
 var (
-	unmatchedResponses = expvar.NewInt("redisUnmatchedResponses")
+	unmatchedResponses = expvar.NewInt("redis.unmatched_responses")
 )
 
 func init() {

--- a/packetbeat/protos/tcp/tcp.go
+++ b/packetbeat/protos/tcp/tcp.go
@@ -33,7 +33,7 @@ type Processor interface {
 }
 
 var (
-	droppedBecauseOfGaps = expvar.NewInt("tcpDroppedBecauseOfGaps")
+	droppedBecauseOfGaps = expvar.NewInt("tcp.dropped_because_of_gaps")
 )
 
 type seqCompare int

--- a/packetbeat/protos/thrift/thrift.go
+++ b/packetbeat/protos/thrift/thrift.go
@@ -159,8 +159,8 @@ type Thrift struct {
 }
 
 var (
-	unmatchedRequests  = expvar.NewInt("thriftUnmatchedRequests")
-	unmatchedResponses = expvar.NewInt("thriftUnmatchedResponses")
+	unmatchedRequests  = expvar.NewInt("thrift.unmatched_requests")
+	unmatchedResponses = expvar.NewInt("thrift.unmatched_responses")
 )
 
 func init() {

--- a/winlogbeat/beater/winlogbeat.go
+++ b/winlogbeat/beater/winlogbeat.go
@@ -25,8 +25,8 @@ import (
 // Metrics that can retrieved through the expvar web interface. Metrics must be
 // enable through configuration in order for the web service to be started.
 var (
-	publishedEvents = expvar.NewMap("publishedEvents")
-	ignoredEvents   = expvar.NewMap("ignoredEvents")
+	publishedEvents = expvar.NewMap("published_events")
+	ignoredEvents   = expvar.NewMap("ignored_events")
 )
 
 func init() {

--- a/winlogbeat/eventlog/cache.go
+++ b/winlogbeat/eventlog/cache.go
@@ -14,7 +14,7 @@ import (
 
 // Stats for the message file caches.
 var (
-	cacheStats = expvar.NewMap("msgFileCacheStats")
+	cacheStats = expvar.NewMap("msg_file_cache")
 )
 
 // Constants that control the cache behavior.

--- a/winlogbeat/eventlog/eventlog.go
+++ b/winlogbeat/eventlog/eventlog.go
@@ -25,7 +25,7 @@ var (
 
 // dropReasons contains counters for the number of dropped events for each
 // reason.
-var dropReasons = expvar.NewMap("dropReasons")
+var dropReasons = expvar.NewMap("drop_reasons")
 
 // EventLog is an interface to a Windows Event Log.
 type EventLog interface {


### PR DESCRIPTION
Part of #1931, this applies the metricbeat conventions to the names
of the expvars. Most of the counters are still top level integers.