### PR TITLE
Snapshot expvar maps for periodic logging

### DIFF
--- a/libbeat/logp/logp_test.go
+++ b/libbeat/logp/logp_test.go
@@ -19,6 +19,21 @@ func TestSnapshotExpvars(t *testing.T) {
 	assert.Equal(t, vals["test"], int64(42))
 }
 
+func TestSnapshotExpvarsMap(t *testing.T) {
+	test := expvar.NewMap("testMap")
+	test.Add("hello", 42)
+
+	map2 := new(expvar.Map).Init()
+	map2.Add("test", 5)
+	test.Set("map2", map2)
+
+	vals := map[string]int64{}
+	snapshotExpvars(vals)
+
+	assert.Equal(t, vals["testMap.hello"], int64(42))
+	assert.Equal(t, vals["testMap.map2.test"], int64(5))
+}
+
 func TestBuildMetricsOutput(t *testing.T) {
 	test := expvar.NewInt("testLog")
 	test.Add(1)


### PR DESCRIPTION
Part of #1931, this adds logic to descend into maps. This is useful especially
to support the metricbeat fetches stats. Locking should be safe as the expvar.Map
Do function takes a read lock on the map.

Note that expvars of type Func are still not included, which is why
the memstats are not logged.