### PR TITLE
Reduce filebeat verbosity at INFO level

### DIFF
--- a/filebeat/prospector/prospector.go
+++ b/filebeat/prospector/prospector.go
@@ -129,7 +129,7 @@ func (p *Prospector) Run() {
 			logp.Info("Prospector ticker stopped")
 			return
 		case <-time.After(p.config.ScanFrequency):
-			logp.Info("Run prospector")
+			logp.Debug("prospector", "Run prospector")
 			p.prospectorer.Run()
 		}
 	}

--- a/filebeat/publish/publish.go
+++ b/filebeat/publish/publish.go
@@ -1,6 +1,7 @@
 package publish
 
 import (
+	"expvar"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -61,6 +62,10 @@ const (
 	batchCanceled
 )
 
+var (
+	eventsSent = expvar.NewInt("publish.events")
+)
+
 func New(
 	async bool,
 	in, out chan []*input.FileEvent,
@@ -108,7 +113,8 @@ func (p *syncLogPublisher) Start() {
 			}
 
 			p.client.PublishEvents(pubEvents, publisher.Sync, publisher.Guaranteed)
-			logp.Info("Events sent: %d", len(events))
+			logp.Debug("publish", "Events sent: %d", len(events))
+			eventsSent.Add(int64(len(events)))
 
 			// Tell the registrar that we've successfully sent these events
 			select {


### PR DESCRIPTION
Part of #1931. Replaces two of the "periodic" Infos with Debugs + expvars.