### PR TITLE
Enable Prospector to Update state without Harvester

### DIFF
--- a/filebeat/harvester/harvester_test.go
+++ b/filebeat/harvester/harvester_test.go
@@ -14,9 +14,9 @@ import (
 func TestExampleTest(t *testing.T) {
 
 	h := Harvester{
-		Path:   "/var/log/",
+		path:   "/var/log/",
 		offset: 0,
 	}
 
-	assert.Equal(t, "/var/log/", h.Path)
+	assert.Equal(t, "/var/log/", h.path)
 }

--- a/filebeat/input/event.go
+++ b/filebeat/input/event.go
@@ -25,7 +25,13 @@ type FileEvent struct {
 	Fileinfo     os.FileInfo
 	JSONFields   common.MapStr
 	JSONConfig   *processor.JSONConfig
-	FileState    file.State
+	State        file.State
+}
+
+func NewEvent(state file.State) *FileEvent {
+	return &FileEvent{
+		State: state,
+	}
 }
 
 func (f *FileEvent) ToMapStr() common.MapStr {

--- a/filebeat/prospector/prospector.go
+++ b/filebeat/prospector/prospector.go
@@ -107,14 +107,14 @@ func (p *Prospector) Run() {
 			case event := <-p.harvesterChan:
 				// Add ttl if cleanOlder is enabled
 				if p.config.CleanOlder > 0 {
-					event.FileState.TTL = p.config.CleanOlder
+					event.State.TTL = p.config.CleanOlder
 				}
 				select {
 				case <-p.done:
 					logp.Info("Prospector channel stopped")
 					return
 				case p.spoolerChan <- event:
-					p.states.Update(event.FileState)
+					p.states.Update(event.State)
 				}
 			}
 		}

--- a/filebeat/registrar/registrar.go
+++ b/filebeat/registrar/registrar.go
@@ -199,7 +199,7 @@ func (r *Registrar) processEventStates(events []*FileEvent) {
 		if event.InputType == cfg.StdinInputType {
 			continue
 		}
-		r.states.Update(event.FileState)
+		r.states.Update(event.State)
 	}
 }
 


### PR DESCRIPTION
Until now it was always necessary to create a harvester to update the state. This now allows the prospector to update a state for example on detection of a file that was renamed but no updates area available, so no harvester has to be started.

Changes:
* Rename FileState to State in harvester
* Remove lastScan time as not needed anymore.
* Cleanup state, enabled prospector to update state directly
* Make sendUpdateState private
* Make state private in harvester
* Remove mutex as not needed anymore
* Rename spoolerChan to prospectorChan as events are sent to prospector first
* Make path variable private