### PR TITLE
Allow device ID to be equal to 0 on OpenBSD

### DIFF
--- a/filebeat/input/file/file_other_test.go
+++ b/filebeat/input/file/file_other_test.go
@@ -5,6 +5,7 @@ package file
 import (
 	"io/ioutil"
 	"os"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -20,7 +21,13 @@ func TestGetOSFileState(t *testing.T) {
 	state := GetOSState(fileinfo)
 
 	assert.True(t, state.Inode > 0)
-	assert.True(t, state.Device > 0)
+
+	if runtime.GOOS == "openbsd" {
+		// The first device on OpenBSD has an ID of 0 so allow this.
+		assert.True(t, state.Device >= 0, "Device %d", state.Device)
+	} else {
+		assert.True(t, state.Device > 0, "Device %d", state.Device)
+	}
 }
 
 func TestGetOSFileStateStat(t *testing.T) {
@@ -33,5 +40,11 @@ func TestGetOSFileStateStat(t *testing.T) {
 	state := GetOSState(fileinfo)
 
 	assert.True(t, state.Inode > 0)
-	assert.True(t, state.Device > 0)
+
+	if runtime.GOOS == "openbsd" {
+		// The first device on OpenBSD has an ID of 0 so allow this.
+		assert.True(t, state.Device >= 0, "Device %d", state.Device)
+	} else {
+		assert.True(t, state.Device > 0, "Device %d", state.Device)
+	}
 }

--- a/filebeat/tests/system/test_prospector.py
+++ b/filebeat/tests/system/test_prospector.py
@@ -251,7 +251,7 @@ class Test(BaseTest):
                 "Exiting"),
             max_timeout=10)
 
-        filebeat.check_kill_and_wait(exit_code=1)
+        filebeat.check_wait(exit_code=1)
 
     def test_no_paths_defined(self):
         """
@@ -274,7 +274,7 @@ class Test(BaseTest):
                 "Exiting"),
             max_timeout=10)
 
-        filebeat.check_kill_and_wait(exit_code=1)
+        filebeat.check_wait(exit_code=1)
 
 
     def test_files_added_late(self):


### PR DESCRIPTION
The OpenBSD build is failing on this test assertion.