### PR TITLE
The '-c' flag can be used multiple times

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -8,7 +8,7 @@
 // Template, add newest changes here
 
 === Beats version HEAD
-https://github.com/elastic/beats/compare/v5.0.0-alpha3...master[Check the HEAD diff]
+https://github.com/elastic/beats/compare/v5.0.0-alpha4...master[Check the HEAD diff]
 
 ==== Breaking changes
 
@@ -50,6 +50,7 @@ https://github.com/elastic/beats/compare/v5.0.0-alpha3...master[Check the HEAD d
 
 - Periodically log internal metrics. {pull}1955[1955]
 - Add enable-setting to all output modules. {pull}1987[1987]
+- Command line flag -c can be used multiple times. {pull}1985[1985]
 
 *Metricbeat*
 

--- a/libbeat/cfgfile/cfgfile.go
+++ b/libbeat/cfgfile/cfgfile.go
@@ -14,18 +14,13 @@ var (
 	// The default config cannot include the beat name as it is not initialized
 	// when this variable is created. See ChangeDefaultCfgfileFlag which should
 	// be called prior to flags.Parse().
-	configfile = flag.String("c", "beat.yml", "Configuration file")
-	testConfig = flag.Bool("configtest", false, "Test configuration and exit.")
+	configfiles = flagArgList("c", "beat.yml", "Configuration file")
+	testConfig  = flag.Bool("configtest", false, "Test configuration and exit.")
 )
 
 // ChangeDefaultCfgfileFlag replaces the value and default value for the `-c`
 // flag so that it reflects the beat name.
 func ChangeDefaultCfgfileFlag(beatName string) error {
-	cliflag := flag.Lookup("c")
-	if cliflag == nil {
-		return fmt.Errorf("Flag -c not found")
-	}
-
 	path, err := filepath.Abs(filepath.Dir(os.Args[0]))
 	if err != nil {
 		return fmt.Errorf("Failed to set default config file location because "+
@@ -33,9 +28,9 @@ func ChangeDefaultCfgfileFlag(beatName string) error {
 			os.Args[0], err)
 	}
 
-	cliflag.DefValue = filepath.Join(path, beatName+".yml")
-
-	return cliflag.Value.Set(cliflag.DefValue)
+	path = filepath.Join(path, beatName+".yml")
+	configfiles.SetDefault(path)
+	return nil
 }
 
 // Deprecated: Please use Load().
@@ -57,7 +52,7 @@ func Read(out interface{}, path string) error {
 // line flag.
 func Load(path string) (*common.Config, error) {
 	if path == "" {
-		path = *configfile
+		return common.LoadFiles(configfiles.list...)
 	}
 	return common.LoadFile(path)
 }

--- a/libbeat/cfgfile/flags.go
+++ b/libbeat/cfgfile/flags.go
@@ -1,0 +1,43 @@
+package cfgfile
+
+import (
+	"flag"
+	"strings"
+)
+
+type argList struct {
+	list      []string
+	isDefault bool
+}
+
+func flagArgList(name string, def string, usage string) *argList {
+	l := &argList{
+		list:      []string{def},
+		isDefault: true,
+	}
+	flag.Var(l, name, usage)
+	return l
+}
+
+func (l *argList) SetDefault(v string) {
+	l.list = []string{v}
+	l.isDefault = true
+}
+
+func (l *argList) String() string {
+	return strings.Join(l.list, ", ")
+}
+
+func (l *argList) Set(v string) error {
+	if l.isDefault {
+		l.list = []string{v}
+	} else {
+		l.list = append(l.list, v)
+	}
+	l.isDefault = false
+	return nil
+}
+
+func (l *argList) Get() interface{} {
+	return l.list
+}

--- a/libbeat/common/config.go
+++ b/libbeat/common/config.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"github.com/elastic/go-ucfg"
+	"github.com/elastic/go-ucfg/cfgutil"
 	"github.com/elastic/go-ucfg/yaml"
 )
 
@@ -36,6 +37,17 @@ func NewConfigWithYAML(in []byte, source string) (*Config, error) {
 func LoadFile(path string) (*Config, error) {
 	c, err := yaml.NewConfigWithFile(path, configOpts...)
 	return fromConfig(c), err
+}
+
+func LoadFiles(paths ...string) (*Config, error) {
+	merger := cfgutil.NewCollector(nil, configOpts...)
+	for _, path := range paths {
+		err := merger.Add(yaml.NewConfigWithFile(path, configOpts...))
+		if err != nil {
+			return nil, err
+		}
+	}
+	return fromConfig(merger.Config()), nil
 }
 
 func (c *Config) Merge(from interface{}) error {


### PR DESCRIPTION
Change '-c' flag to load and merge all config files given on command line via
'-c' flag.