### PR TITLE
Marked ES as disconnected only of 5xx errors

### DIFF
--- a/libbeat/outputs/elasticsearch/client.go
+++ b/libbeat/outputs/elasticsearch/client.go
@@ -582,7 +582,9 @@ func (conn *Connection) execHTTPRequest(req *http.Request) (int, []byte, error) 
 
 	status := resp.StatusCode
 	if status >= 300 {
-		conn.connected = false
+		if status >= 500 {
+			conn.connected = false
+		}
 		return status, nil, fmt.Errorf("%v", resp.Status)
 	}
 


### PR DESCRIPTION
Old code was marking the connection as disconnected on any response code
larger than 300. This caused issues for the template loading code, that
expects a 404 when testing if the template is loaded.