### PR TITLE
Fixes TOC link in the Packetbeat doc

### DIFF
--- a/packetbeat/docs/index.asciidoc
+++ b/packetbeat/docs/index.asciidoc
@@ -45,7 +45,7 @@ include::./securing-packetbeat.asciidoc[]
 
 include::./visualizing-data-packetbeat.asciidoc[]
 
-include::../../libbeat/docs/processors.asciidoc[]
+include::./filtering.asciidoc[]
 
 include::./troubleshooting.asciidoc[]
 


### PR DESCRIPTION
The link in the TOC should point to filtering.asciidoc (this topic talks about Kibana filtering) not the shared topic about processors. 