### PR TITLE
Validate wrong filebeat config combinations

### DIFF
--- a/filebeat/prospector/config.go
+++ b/filebeat/prospector/config.go
@@ -22,7 +22,7 @@ type prospectorConfig struct {
 	ExcludeFiles  []*regexp.Regexp `config:"exclude_files"`
 	IgnoreOlder   time.Duration    `config:"ignore_older"`
 	Paths         []string         `config:"paths"`
-	ScanFrequency time.Duration    `config:"scan_frequency"`
+	ScanFrequency time.Duration    `config:"scan_frequency" validate:"min=0,nonzero"`
 	InputType     string           `config:"input_type"`
 	CleanInactive time.Duration    `config:"clean_inactive" validate:"min=0"`
 	CleanRemoved  bool             `config:"clean_removed"`
@@ -33,5 +33,14 @@ func (config *prospectorConfig) Validate() error {
 	if config.InputType == cfg.LogInputType && len(config.Paths) == 0 {
 		return fmt.Errorf("No paths were defined for prospector")
 	}
+
+	if config.CleanInactive != 0 && config.IgnoreOlder == 0 {
+		return fmt.Errorf("ignore_older must be enabled when clean_older is used.")
+	}
+
+	if config.CleanInactive != 0 && config.CleanInactive <= config.IgnoreOlder+config.ScanFrequency {
+		return fmt.Errorf("clean_older must be > ignore_older + scan_frequency to make sure only files which are not monitored anymore are removed.")
+	}
+
 	return nil
 }

--- a/filebeat/prospector/config_test.go
+++ b/filebeat/prospector/config_test.go
@@ -1,0 +1,54 @@
+// +build !integration
+
+package prospector
+
+import (
+	"testing"
+
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCleanOlderError(t *testing.T) {
+
+	config := prospectorConfig{
+		CleanInactive: 10 * time.Hour,
+	}
+
+	err := config.Validate()
+	assert.Error(t, err)
+}
+
+func TestCleanOlderIgnoreOlderError(t *testing.T) {
+
+	config := prospectorConfig{
+		CleanInactive: 10 * time.Hour,
+		IgnoreOlder:   15 * time.Hour,
+	}
+
+	err := config.Validate()
+	assert.Error(t, err)
+}
+
+func TestCleanOlderIgnoreOlderErrorEqual(t *testing.T) {
+
+	config := prospectorConfig{
+		CleanInactive: 10 * time.Hour,
+		IgnoreOlder:   10 * time.Hour,
+	}
+
+	err := config.Validate()
+	assert.Error(t, err)
+}
+
+func TestCleanOlderIgnoreOlder(t *testing.T) {
+
+	config := prospectorConfig{
+		CleanInactive: 10*time.Hour + defaultConfig.ScanFrequency + 1*time.Second,
+		IgnoreOlder:   10 * time.Hour,
+	}
+
+	err := config.Validate()
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
* [x] Check ignore_older and close_older
* [x] Check close_removed and clean_removed combination
  * This will be indirectly solved by https://github.com/elastic/beats/pull/2075 as states can only be removed if reading is finished.
* [x] Check `clean_idle > ignore_older + scan_frequency`