### PR TITLE
Prospector and Harvester Cleanups

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -47,6 +47,8 @@ https://github.com/elastic/beats/compare/v5.0.0-alpha4...master[Check the HEAD d
 *Filebeat*
 - Fix potential data loss between filebeat restarts, reporting unpublished lines as published. {issue}2041[2041]
 
+- Fix open file handler issue {issue}2028[2028] {pull}2020[2020]
+
 *Winlogbeat*
 - Fix potential data loss between winlogbeat restarts, reporting unpublished lines as published. {issue}2041[2041]
 

--- a/filebeat/harvester/harvester.go
+++ b/filebeat/harvester/harvester.go
@@ -15,7 +15,6 @@ package harvester
 
 import (
 	"fmt"
-	"regexp"
 
 	"github.com/elastic/beats/filebeat/config"
 	"github.com/elastic/beats/filebeat/harvester/encoding"
@@ -26,34 +25,26 @@ import (
 )
 
 type Harvester struct {
-	path               string /* the file path to harvest */
-	config             harvesterConfig
-	offset             int64
-	state              file.State
-	prospectorChan     chan *input.FileEvent
-	file               source.FileSource /* the file being watched */
-	ExcludeLinesRegexp []*regexp.Regexp
-	IncludeLinesRegexp []*regexp.Regexp
-	done               chan struct{}
-	encodingFactory    encoding.EncodingFactory
-	encoding           encoding.Encoding
+	config          harvesterConfig
+	state           file.State
+	prospectorChan  chan *input.FileEvent
+	file            source.FileSource /* the file being watched */
+	done            chan struct{}
+	encodingFactory encoding.EncodingFactory
+	encoding        encoding.Encoding
 }
 
 func NewHarvester(
 	cfg *common.Config,
-	path string,
 	state file.State,
 	prospectorChan chan *input.FileEvent,
-	offset int64,
 	done chan struct{},
 ) (*Harvester, error) {
 
 	h := &Harvester{
-		path:           path,
 		config:         defaultConfig,
 		state:          state,
 		prospectorChan: prospectorChan,
-		offset:         offset,
 		done:           done,
 	}
 

--- a/filebeat/harvester/harvester_test.go
+++ b/filebeat/harvester/harvester_test.go
@@ -1,22 +1,3 @@
 // +build !integration
 
 package harvester
-
-import (
-	"testing"
-
-	"github.com/stretchr/testify/assert"
-)
-
-// Most harvester tests need real files to tes that can be modified. These tests are implemented with
-// system tests
-
-func TestExampleTest(t *testing.T) {
-
-	h := Harvester{
-		path:   "/var/log/",
-		offset: 0,
-	}
-
-	assert.Equal(t, "/var/log/", h.path)
-}

--- a/filebeat/harvester/log.go
+++ b/filebeat/harvester/log.go
@@ -2,11 +2,11 @@ package harvester
 
 import (
 	"errors"
+	"expvar"
+	"io"
 	"os"
 
 	"golang.org/x/text/transform"
-
-	"io"
 
 	"github.com/elastic/beats/filebeat/config"
 	"github.com/elastic/beats/filebeat/harvester/processor"
@@ -17,8 +17,20 @@ import (
 	"github.com/elastic/beats/libbeat/logp"
 )
 
+var (
+	harvesterStarted   = expvar.NewInt("filebeat.harvester.started")
+	harvesterClosed    = expvar.NewInt("filebeat.harvester.closed")
+	harvesterRunning   = expvar.NewInt("filebeat.harvester.running")
+	harvesterOpenFiles = expvar.NewInt("filebeat.harvester.open_files")
+	filesTruncated     = expvar.NewInt("filebeat.harvester.files.truncated")
+)
+
 // Log harvester reads files line by line and sends events to the defined output
 func (h *Harvester) Harvest() {
+
+	harvesterStarted.Add(1)
+	harvesterRunning.Add(1)
+	defer harvesterRunning.Add(-1)
 
 	// Makes sure file is properly closed when the harvester is stopped
 	defer h.close()
@@ -31,7 +43,7 @@ func (h *Harvester) Harvest() {
 		return
 	}
 
-	logp.Info("Harvester started for file: %s", h.path)
+	logp.Info("Harvester started for file: %s", h.state.Source)
 
 	processor, err := h.newLineProcessor()
 	if err != nil {
@@ -40,6 +52,7 @@ func (h *Harvester) Harvest() {
 	}
 
 	// Always report the state before starting a harvester
+	// This is useful in case the file was renamed
 	if !h.sendStateUpdate() {
 		return
 	}
@@ -56,14 +69,15 @@ func (h *Harvester) Harvest() {
 		if err != nil {
 			switch err {
 			case reader.ErrFileTruncate:
-				logp.Info("File was truncated. Begin reading file from offset 0: %s", h.path)
-				h.SetOffset(0)
+				logp.Info("File was truncated. Begin reading file from offset 0: %s", h.state.Source)
+				h.state.Offset = 0
+				filesTruncated.Add(1)
 			case reader.ErrRemoved:
-				logp.Info("File was removed: %s. Closing because close_removed is enabled.", h.path)
+				logp.Info("File was removed: %s. Closing because close_removed is enabled.", h.state.Source)
 			case reader.ErrRenamed:
-				logp.Info("File was renamed: %s. Closing because close_renamed is enabled.", h.path)
+				logp.Info("File was renamed: %s. Closing because close_renamed is enabled.", h.state.Source)
 			case io.EOF:
-				logp.Info("End of file reached: %s. Closing because close_eof is enabled.", h.path)
+				logp.Info("End of file reached: %s. Closing because close_eof is enabled.", h.state.Source)
 			default:
 				logp.Info("Read line error: %s", err)
 			}
@@ -71,7 +85,7 @@ func (h *Harvester) Harvest() {
 		}
 
 		// Update offset if complete line has been processed
-		h.updateOffset(int64(bytesRead))
+		h.state.Offset += int64(bytesRead)
 
 		event := h.createEvent()
 
@@ -94,12 +108,13 @@ func (h *Harvester) Harvest() {
 // By default the offset is set to 0, means no bytes read. This can be used to report the status
 // of a harvester
 func (h *Harvester) createEvent() *input.FileEvent {
+
 	event := &input.FileEvent{
 		EventMetadata: h.config.EventMetadata,
-		Source:        h.path,
+		Source:        h.state.Source,
 		InputType:     h.config.InputType,
 		DocumentType:  h.config.DocumentType,
-		Offset:        h.getOffset(),
+		Offset:        h.state.Offset,
 		Bytes:         0,
 		Fileinfo:      h.state.Fileinfo,
 		JSONConfig:    h.config.JSON,
@@ -148,12 +163,27 @@ func (h *Harvester) shouldExportLine(line string) bool {
 // the file system is scanned
 func (h *Harvester) openFile() error {
 
-	f, err := file.ReadOpen(h.path)
+	f, err := file.ReadOpen(h.state.Source)
 	if err != nil {
-		logp.Err("Failed opening %s: %s", h.path, err)
+		logp.Err("Failed opening %s: %s", h.state.Source, err)
 		return err
 	}
 
+	harvesterOpenFiles.Add(1)
+
+	// Makes sure file handler is also closed on errors
+	err = h.validateFile(f)
+	if err != nil {
+		f.Close()
+		harvesterOpenFiles.Add(-1)
+		return err
+	}
+
+	h.file = source.File{f}
+	return nil
+}
+
+func (h *Harvester) validateFile(f *os.File) error {
 	// Check we are not following a rabbit hole (symlinks, etc.)
 	if !file.IsRegular(f) {
 		return errors.New("Given file is not a regular file.")
@@ -161,7 +191,7 @@ func (h *Harvester) openFile() error {
 
 	info, err := f.Stat()
 	if err != nil {
-		logp.Err("Failed getting stats for file %s: %s", h.path, err)
+		logp.Err("Failed getting stats for file %s: %s", h.state.Source, err)
 		return err
 	}
 	// Compares the stat of the opened file to the state given by the prospector. Abort if not match.
@@ -180,58 +210,42 @@ func (h *Harvester) openFile() error {
 		return err
 	}
 
-	// update file offset
-	err = h.initFileOffset(f)
+	// get file offset. Only update offset if no error
+	offset, err := h.initFileOffset(f)
 	if err != nil {
 		return err
 	}
 
-	// yay, open file
-	h.file = source.File{f}
+	logp.Debug("harvester", "Setting offset for file: %s. Offset: %d ", h.state.Source, offset)
+	h.state.Offset = offset
+
 	return nil
 }
 
-func (h *Harvester) initFileOffset(file *os.File) error {
-	offset, err := file.Seek(0, os.SEEK_CUR)
+func (h *Harvester) initFileOffset(file *os.File) (int64, error) {
 
-	if h.getOffset() > 0 {
-		// continue from last known offset
-		logp.Debug("harvester",
-			"harvest: %q position:%d (offset snapshot:%d)", h.path, h.getOffset(), offset)
-		_, err = file.Seek(h.getOffset(), os.SEEK_SET)
-	} else if h.config.TailFiles {
-		// tail file if file is new and tail_files config is set
-		logp.Debug("harvester", "harvest: (tailing) %q (offset snapshot:%d)", h.path, offset)
-
-		offset, err = file.Seek(0, os.SEEK_END)
-		h.SetOffset(offset)
-
-	} else {
-		// get offset from file in case of encoding factory was
-		// required to read some data.
-		logp.Debug("harvester", "harvest: %q (offset snapshot:%d)", h.path, offset)
-		h.SetOffset(offset)
+	// continue from last known offset
+	if h.state.Offset > 0 {
+		logp.Debug("harvester", "Set previous offset for file: %s. Offset: %d ", h.state.Source, h.state.Offset)
+		return file.Seek(h.state.Offset, os.SEEK_SET)
 	}
 
-	return err
-}
+	// tail file if file is new and tail_files config is set
+	if h.config.TailFiles {
+		logp.Debug("harvester", "Setting offset for tailing file: %s.", h.state.Source)
+		return file.Seek(0, os.SEEK_END)
+	}
 
-func (h *Harvester) SetOffset(offset int64) {
-	h.offset = offset
-}
-
-func (h *Harvester) getOffset() int64 {
-	return h.offset
-}
-
-func (h *Harvester) updateOffset(increment int64) {
-	h.offset += increment
+	// get offset from file in case of encoding factory was required to read some data.
+	logp.Debug("harvester", "Setting offset for file based on seek: %s", h.state.Source)
+	return file.Seek(0, os.SEEK_CUR)
 }
 
 // sendStateUpdate send an empty event with the current state to update the registry
 func (h *Harvester) sendStateUpdate() bool {
-	logp.Debug("harvester", "Update state: %s, offset: %v", h.path, h.offset)
-	return h.sendEvent(h.createEvent())
+	logp.Debug("harvester", "Update state: %s, offset: %v", h.state.Source, h.state.Offset)
+	event := input.NewEvent(h.getState())
+	return h.sendEvent(event)
 }
 
 func (h *Harvester) getState() file.State {
@@ -240,34 +254,33 @@ func (h *Harvester) getState() file.State {
 		return file.State{}
 	}
 
-	h.refreshState()
-	return h.state
-}
-
-// refreshState refreshes the values in State with the values from the harvester itself
-func (h *Harvester) refreshState() {
-	h.state.Source = h.path
-	h.state.Offset = h.getOffset()
+	// refreshes the values in State with the values from the harvester itself
 	h.state.FileStateOS = file.GetOSState(h.state.Fileinfo)
+	return h.state
 }
 
 func (h *Harvester) close() {
 	// Mark harvester as finished
 	h.state.Finished = true
 
-	// On completion, push offset so we can continue where we left off if we relaunch on the same file
-	h.sendStateUpdate()
-
-	logp.Debug("harvester", "Stopping harvester for file: %s", h.path)
+	logp.Debug("harvester", "Stopping harvester for file: %s", h.state.Source)
 
 	// Make sure file is closed as soon as harvester exits
 	// If file was never opened, it can't be closed
 	if h.file != nil {
+
+		// On completion, push offset so we can continue where we left off if we relaunch on the same file
+		// Only send offset if file object was created successfully
+		h.sendStateUpdate()
+
 		h.file.Close()
-		logp.Debug("harvester", "Stopping harvester, closing file: %s", h.path)
+		logp.Debug("harvester", "Stopping harvester, closing file: %s", h.state.Source)
+		harvesterOpenFiles.Add(-1)
 	} else {
-		logp.Warn("Stopping harvester, NOT closing file as file info not available: %s", h.path)
+		logp.Warn("Stopping harvester, NOT closing file as file info not available: %s", h.state.Source)
 	}
+
+	harvesterClosed.Add(1)
 }
 
 func (h *Harvester) newLogFileReaderConfig() reader.LogFileReaderConfig {

--- a/filebeat/input/file/state.go
+++ b/filebeat/input/file/state.go
@@ -31,6 +31,11 @@ func NewState(fileInfo os.FileInfo, path string) State {
 	}
 }
 
+// IsEmpty returns true if the state is empty
+func (s *State) IsEmpty() bool {
+	return *s == State{}
+}
+
 // States handles list of FileState
 type States struct {
 	states []State
@@ -60,11 +65,12 @@ func (s *States) Update(newState State) {
 	}
 }
 
-func (s *States) FindPrevious(newState State) (int, State) {
+func (s *States) FindPrevious(newState State) State {
 	// TODO: This currently blocks writing updates every time state is fetched. Should be improved for performance
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
-	return s.findPrevious(newState)
+	_, state := s.findPrevious(newState)
+	return state
 }
 
 // findPreviousState returns the previous state fo the file

--- a/filebeat/prospector/prospector.go
+++ b/filebeat/prospector/prospector.go
@@ -146,10 +146,8 @@ func (p *Prospector) createHarvester(state file.State) (*harvester.Harvester, er
 
 	h, err := harvester.NewHarvester(
 		p.cfg,
-		state.Source,
 		state,
 		p.harvesterChan,
-		state.Offset,
 		p.done,
 	)
 

--- a/filebeat/registrar/registrar.go
+++ b/filebeat/registrar/registrar.go
@@ -27,6 +27,7 @@ type Registrar struct {
 
 var (
 	statesUpdated = expvar.NewInt("registrar.state_updates")
+	statesTotal   = expvar.NewInt("registar.states.total")
 )
 
 func New(registryFile string) (*Registrar, error) {
@@ -185,11 +186,13 @@ func (r *Registrar) Run() {
 			r.processEventStates(events)
 		}
 
+		beforeCount := r.states.Count()
 		r.states.Cleanup()
-		logp.Debug("registrar", "Registrar states cleaned up.")
+		logp.Debug("registrar", "Registrar states cleaned up. Before: %d , After: %d", beforeCount, r.states.Count())
 		if err := r.writeRegistry(); err != nil {
 			logp.Err("Writing of registry returned error: %v. Continuing...", err)
 		}
+
 	}
 }
 
@@ -241,6 +244,7 @@ func (r *Registrar) writeRegistry() error {
 
 	logp.Debug("registrar", "Registry file updated. %d states written.", len(states))
 	statesUpdated.Add(int64(len(states)))
+	statesTotal.Set(int64(len(states)))
 
 	return file.SafeFileRotate(r.registryFile, tempfile)
 }

--- a/filebeat/tests/system/test_registrar.py
+++ b/filebeat/tests/system/test_registrar.py
@@ -804,7 +804,7 @@ class Test(BaseTest):
         # Wait until states are removed from prospectors
         self.wait_until(
             lambda: self.log_contains(
-                "Cleanup state for file as file removed"),
+                "Remove state for file as file removed"),
             max_timeout=15)
 
         # Add one more line to make sure registry is written

--- a/metricbeat/Makefile
+++ b/metricbeat/Makefile
@@ -64,5 +64,5 @@ create-metricset:
 
 # Generates the data.json example documents
 .PHONY: generate-json
-generate-json:
+generate-json: build-image
 	 ${DOCKER_COMPOSE} run beat go test -tags=integration github.com/elastic/beats/metricbeat/module/... -data


### PR DESCRIPTION
See elastic#1913

* Make sure ignore_older is not only applied to new files but also existing files
* Improve logging in prospector
* Add expvar to prospector and harvester
* Cleanup offset handling
* Add truncation handling to prospector
* Handle all offsets as part of the state
* Remove path from harvester and use state.Source instead
* Remove obsolete exclude / include options
* Remove unnecessary getOffset()
* Fix potential file handler leak. Close file handler in case of errors.
* Implement cleaner file handler closing
* Cleanup initOffset handling