### PR TITLE
Added https user/pass to the default template

### DIFF
--- a/filebeat/filebeat.full.yml
+++ b/filebeat/filebeat.full.yml
@@ -313,8 +313,8 @@ output.elasticsearch:
 
   # Optional protocol and basic auth credentials.
   #protocol: "https"
-  #username: "admin"
-  #password: "s3cr3t"
+  #username: "elastic"
+  #password: "changeme"
 
   # Dictionary of HTTP parameters to pass within the url with index operations.
   #parameters:

--- a/filebeat/filebeat.yml
+++ b/filebeat/filebeat.yml
@@ -82,6 +82,11 @@ output.elasticsearch:
   # Array of hosts to connect to.
   hosts: ["localhost:9200"]
 
+  # Optional protocol and basic auth credentials.
+  #protocol: "https"
+  #username: "elastic"
+  #password: "changeme"
+
 #----------------------------- Logstash output --------------------------------
 #output.logstash:
   # The Logstash hosts

--- a/libbeat/_meta/config.full.yml
+++ b/libbeat/_meta/config.full.yml
@@ -95,8 +95,8 @@ output.elasticsearch:
 
   # Optional protocol and basic auth credentials.
   #protocol: "https"
-  #username: "admin"
-  #password: "s3cr3t"
+  #username: "elastic"
+  #password: "changeme"
 
   # Dictionary of HTTP parameters to pass within the url with index operations.
   #parameters:

--- a/libbeat/_meta/config.yml
+++ b/libbeat/_meta/config.yml
@@ -24,6 +24,11 @@ output.elasticsearch:
   # Array of hosts to connect to.
   hosts: ["localhost:9200"]
 
+  # Optional protocol and basic auth credentials.
+  #protocol: "https"
+  #username: "elastic"
+  #password: "changeme"
+
 #----------------------------- Logstash output --------------------------------
 #output.logstash:
   # The Logstash hosts

--- a/metricbeat/metricbeat.full.yml
+++ b/metricbeat/metricbeat.full.yml
@@ -240,8 +240,8 @@ output.elasticsearch:
 
   # Optional protocol and basic auth credentials.
   #protocol: "https"
-  #username: "admin"
-  #password: "s3cr3t"
+  #username: "elastic"
+  #password: "changeme"
 
   # Dictionary of HTTP parameters to pass within the url with index operations.
   #parameters:

--- a/metricbeat/metricbeat.yml
+++ b/metricbeat/metricbeat.yml
@@ -70,6 +70,11 @@ output.elasticsearch:
   # Array of hosts to connect to.
   hosts: ["localhost:9200"]
 
+  # Optional protocol and basic auth credentials.
+  #protocol: "https"
+  #username: "elastic"
+  #password: "changeme"
+
 #----------------------------- Logstash output --------------------------------
 #output.logstash:
   # The Logstash hosts

--- a/packetbeat/packetbeat.full.yml
+++ b/packetbeat/packetbeat.full.yml
@@ -479,8 +479,8 @@ output.elasticsearch:
 
   # Optional protocol and basic auth credentials.
   #protocol: "https"
-  #username: "admin"
-  #password: "s3cr3t"
+  #username: "elastic"
+  #password: "changeme"
 
   # Dictionary of HTTP parameters to pass within the url with index operations.
   #parameters:

--- a/packetbeat/packetbeat.yml
+++ b/packetbeat/packetbeat.yml
@@ -113,6 +113,11 @@ output.elasticsearch:
   # Array of hosts to connect to.
   hosts: ["localhost:9200"]
 
+  # Optional protocol and basic auth credentials.
+  #protocol: "https"
+  #username: "elastic"
+  #password: "changeme"
+
 #----------------------------- Logstash output --------------------------------
 #output.logstash:
   # The Logstash hosts

--- a/winlogbeat/winlogbeat.full.yml
+++ b/winlogbeat/winlogbeat.full.yml
@@ -130,8 +130,8 @@ output.elasticsearch:
 
   # Optional protocol and basic auth credentials.
   #protocol: "https"
-  #username: "admin"
-  #password: "s3cr3t"
+  #username: "elastic"
+  #password: "changeme"
 
   # Dictionary of HTTP parameters to pass within the url with index operations.
   #parameters:

--- a/winlogbeat/winlogbeat.yml
+++ b/winlogbeat/winlogbeat.yml
@@ -48,6 +48,11 @@ output.elasticsearch:
   # Array of hosts to connect to.
   hosts: ["localhost:9200"]
 
+  # Optional protocol and basic auth credentials.
+  #protocol: "https"
+  #username: "elastic"
+  #password: "changeme"
+
 #----------------------------- Logstash output --------------------------------
 #output.logstash:
   # The Logstash hosts


### PR DESCRIPTION
Since we removed the template stuff from the default config, we can add
the user/pass instead so it's easy to enabled https. It also updates the
sample user/pass used, to match the default in Shield, closing #1735.

Depends on #1993.