### PR TITLE
Use dotted notation in the ingest node docs

### DIFF
--- a/libbeat/docs/shared-config-ingest.asciidoc
+++ b/libbeat/docs/shared-config-ingest.asciidoc
@@ -27,7 +27,7 @@ After defining the pipeline in Elasticsearch, you simply configure your Beat to 
 ------------------------------------------------------------------------------
 output.elasticsearch:
   hosts: ["localhost:9200"]
-  parameters: {pipeline: my_pipeline_id}
+  parameters.pipeline: my_pipeline_id
 ------------------------------------------------------------------------------
 
 For example, let's say that you've defined the following pipeline in a file named `pipeline.json`:
@@ -50,7 +50,7 @@ To add the pipeline in Elasticsearch, you would run:
 
 [source,shell]
 ------------------------------------------------------------------------------
-curl -XPUT 'http://192.168.99.100:9200/_ingest/pipeline/test-pipeline' -d@pipeline.json
+curl -XPUT 'http://localhost:9200/_ingest/pipeline/test-pipeline' -d@pipeline.json
 ------------------------------------------------------------------------------
 
 Then in the +{beatname_lc}.yml+ file, you would specify:
@@ -59,7 +59,7 @@ Then in the +{beatname_lc}.yml+ file, you would specify:
 ------------------------------------------------------------------------------
 output.elasticsearch:
   hosts: ["localhost:9200"]
-  parameters: {pipeline: "test-pipeline"}
+  parameters.pipeline: "test-pipeline"
 ------------------------------------------------------------------------------
 
 When you run {beatname_uc}, the value of `beat.name` is converted to lowercase before indexing.


### PR DESCRIPTION
Minor edit for our ingest node guide. Now that dots are supported, we
can avoid the curlies and still keep it in one line.

Also switched the example to use localhost instead of the docker machine IP,
which is less likely to be used by the users.