### PR TITLE
Remove IsConnected from ProtocolClient interface

### DIFF
--- a/libbeat/outputs/elasticsearch/client_integration_test.go
+++ b/libbeat/outputs/elasticsearch/client_integration_test.go
@@ -17,9 +17,7 @@ func TestClientConnect(t *testing.T) {
 
 	client := GetTestingElasticsearch()
 	err := client.Connect(5 * time.Second)
-
-	assert.Nil(t, err)
-	assert.True(t, client.IsConnected())
+	assert.NoError(t, err)
 }
 
 func TestCheckTemplate(t *testing.T) {

--- a/libbeat/outputs/logstash/client_test.go
+++ b/libbeat/outputs/logstash/client_test.go
@@ -186,10 +186,6 @@ func testMultiFailMaxTimeouts(t *testing.T, factory clientFactory) {
 
 		// read batch + never ACK in order to enforce timeout
 		server.Receive()
-
-		// close client
-		for transp.IsConnected() {
-		}
 	}
 
 	client.Stop()

--- a/libbeat/outputs/mode/lb/async_worker.go
+++ b/libbeat/outputs/mode/lb/async_worker.go
@@ -61,11 +61,6 @@ func newAsyncWorker(
 
 func (w *asyncWorker) run() {
 	client := w.client
-	defer func() {
-		if client.IsConnected() {
-			_ = client.Close()
-		}
-	}()
 
 	debugf("load balancer: start client loop")
 	defer debugf("load balancer: stop client loop")
@@ -74,9 +69,10 @@ func (w *asyncWorker) run() {
 	for !done {
 		if done = w.connect(); !done {
 			done = w.sendLoop()
+
+			debugf("close client (done=%v)", done)
+			client.Close()
 		}
-		debugf("close client (done=%v)", done)
-		client.Close()
 	}
 }
 

--- a/libbeat/outputs/mode/lb/sync_worker.go
+++ b/libbeat/outputs/mode/lb/sync_worker.go
@@ -61,11 +61,6 @@ func newSyncWorker(
 
 func (w *syncWorker) run() {
 	client := w.client
-	defer func() {
-		if client.IsConnected() {
-			_ = client.Close()
-		}
-	}()
 
 	debugf("load balancer: start client loop")
 	defer debugf("load balancer: stop client loop")
@@ -74,9 +69,10 @@ func (w *syncWorker) run() {
 	for !done {
 		if done = w.connect(); !done {
 			done = w.sendLoop()
+
+			debugf("close client (done=%v)", done)
+			client.Close()
 		}
-		debugf("close client (done=%v)", done)
-		client.Close()
 	}
 }
 

--- a/libbeat/outputs/mode/mode.go
+++ b/libbeat/outputs/mode/mode.go
@@ -45,12 +45,6 @@ type Connectable interface {
 
 	// Close closes the established connection.
 	Close() error
-
-	// IsConnected indicates the clients connection state. If connection has
-	// been lost while publishing events, IsConnected must return false. As long as
-	// IsConnected returns false, an output plugin might try to re-establish the
-	// connection by calling Connect.
-	IsConnected() bool
 }
 
 // ProtocolClient interface is a output plugin specific client implementation
@@ -61,8 +55,7 @@ type ProtocolClient interface {
 	Connectable
 
 	// PublishEvents sends events to the clients sink. On failure or timeout err
-	// must be set. If connection has been lost, IsConnected must return false
-	// in future calls.
+	// must be set.
 	// PublishEvents is free to publish only a subset of given events, even in
 	// error case. On return nextEvents contains all events not yet published.
 	PublishEvents(events []common.MapStr) (nextEvents []common.MapStr, err error)

--- a/libbeat/outputs/mode/mode_test.go
+++ b/libbeat/outputs/mode/mode_test.go
@@ -18,7 +18,6 @@ type mockClient struct {
 	publish      func([]common.MapStr) ([]common.MapStr, error)
 	asyncPublish func(func([]common.MapStr, error), []common.MapStr) error
 	close        func() error
-	connected    bool
 	connect      func(time.Duration) error
 }
 
@@ -34,10 +33,6 @@ func (c *mockClient) Connect(timeout time.Duration) error {
 
 func (c *mockClient) Close() error {
 	return c.close()
-}
-
-func (c *mockClient) IsConnected() bool {
-	return c.connected
 }
 
 func (c *mockClient) PublishEvents(events []common.MapStr) ([]common.MapStr, error) {

--- a/libbeat/outputs/mode/modetest/modetest.go
+++ b/libbeat/outputs/mode/modetest/modetest.go
@@ -47,10 +47,6 @@ func NewMockClient(template *MockClient) *MockClient {
 	return mc
 }
 
-func (c *MockClient) IsConnected() bool {
-	return c.Connected
-}
-
 func (c *MockClient) Connect(timeout time.Duration) error {
 	err := c.CBConnect(timeout)
 	c.Connected = err == nil

--- a/libbeat/outputs/mode/modeutil/failover_client.go
+++ b/libbeat/outputs/mode/modeutil/failover_client.go
@@ -49,10 +49,6 @@ func (f *failOverClient) Connect(to time.Duration) error {
 	return connect(f, to)
 }
 
-func (f *failOverClient) IsConnected() bool {
-	return f.active >= 0 && f.conns[f.active].IsConnected()
-}
-
 func (f *failOverClient) Close() error {
 	return closeActive(f)
 }
@@ -87,10 +83,6 @@ func (f *asyncFailOverClient) Activate(i int)             { f.active = i }
 
 func (f *asyncFailOverClient) Connect(to time.Duration) error {
 	return connect(f, to)
-}
-
-func (f *asyncFailOverClient) IsConnected() bool {
-	return f.active >= 0 && f.conns[f.active].IsConnected()
 }
 
 func (f *asyncFailOverClient) Close() error {
@@ -143,10 +135,6 @@ func connect(lst clientList, to time.Duration) error {
 
 	conn := lst.Get(next)
 	lst.Activate(next)
-	if conn.IsConnected() {
-		return nil
-	}
-
 	return conn.Connect(to)
 }
 

--- a/libbeat/outputs/mode/modeutil/modeutil_test.go
+++ b/libbeat/outputs/mode/modeutil/modeutil_test.go
@@ -14,7 +14,6 @@ type dummyClient struct{}
 
 func (dummyClient) Connect(timeout time.Duration) error { return nil }
 func (dummyClient) Close() error                        { return nil }
-func (dummyClient) IsConnected() bool                   { return false }
 func (dummyClient) PublishEvents(events []common.MapStr) (nextEvents []common.MapStr, err error) {
 	return nil, nil
 }

--- a/libbeat/outputs/mode/single/single.go
+++ b/libbeat/outputs/mode/single/single.go
@@ -15,7 +15,8 @@ import (
 // not available, the output plugin blocks until the connection is either available
 // again or the connection mode is closed by Close.
 type Mode struct {
-	conn mode.ProtocolClient
+	conn        mode.ProtocolClient
+	isConnected bool
 
 	closed bool // mode closed flag to break publisher loop
 
@@ -52,16 +53,25 @@ func New(
 }
 
 func (s *Mode) connect() error {
-	if s.conn.IsConnected() {
+	if s.isConnected {
 		return nil
 	}
-	return s.conn.Connect(s.timeout)
+
+	err := s.conn.Connect(s.timeout)
+	s.isConnected = err == nil
+	return err
 }
 
 // Close closes the underlying connection.
 func (s *Mode) Close() error {
 	s.closed = true
-	return s.conn.Close()
+	return s.closeClient()
+}
+
+func (s *Mode) closeClient() error {
+	err := s.conn.Close()
+	s.isConnected = false
+	return err
 }
 
 // PublishEvents tries to publish the events with retries if connection becomes
@@ -133,6 +143,7 @@ func (s *Mode) publish(
 
 		ok, resetFail = send()
 		if !ok {
+			s.closeClient()
 			goto sendFail
 		}
 


### PR DESCRIPTION
- Always close connections on failure and enforce reconnect.
- IsConnected flag gone from elasticsearch output (no more error if template already loaded).

Closes: #1997 