### PR TITLE
Fix data loss on filebeat/winlogbeat shutdown

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -34,6 +34,7 @@ https://github.com/elastic/beats/compare/v5.0.0-alpha4...master[Check the HEAD d
 ==== Bugfixes
 
 *Affecting all Beats*
+- Fix sync publisher PublishEvents return value if client is closed concurrently. {pull}2046[2046]
 
 *Metricbeat*
 
@@ -44,8 +45,10 @@ https://github.com/elastic/beats/compare/v5.0.0-alpha4...master[Check the HEAD d
 *Topbeat*
 
 *Filebeat*
+- Fix potential data loss between filebeat restarts, reporting unpublished lines as published. {issue}2041[2041]
 
 *Winlogbeat*
+- Fix potential data loss between winlogbeat restarts, reporting unpublished lines as published. {issue}2041[2041]
 
 ==== Added
 

--- a/filebeat/publish/publish.go
+++ b/filebeat/publish/publish.go
@@ -116,7 +116,13 @@ func (p *syncLogPublisher) Start() {
 				}
 			}
 
-			p.client.PublishEvents(pubEvents, publisher.Sync, publisher.Guaranteed)
+			ok := p.client.PublishEvents(pubEvents, publisher.Sync, publisher.Guaranteed)
+			if !ok {
+				// PublishEvents will only returns false, if p.client has been closed.
+				logp.Debug("publish", "Shutting down publisher")
+				return
+			}
+
 			logp.Debug("publish", "Events sent: %d", len(events))
 			eventsSent.Add(int64(len(events)))
 

--- a/libbeat/publisher/sync.go
+++ b/libbeat/publisher/sync.go
@@ -34,7 +34,7 @@ func (p *syncPipeline) publish(m message) bool {
 	// ignore any signal and drop events no matter if send or not.
 	select {
 	case <-client.canceler.Done():
-		return true
+		return false // return false, indicating events potentially not being send
 	case sig := <-sync.C:
 		sig.Apply(signal)
 		return sig == op.SignalCompleted


### PR DESCRIPTION
filebeat/winlogbeat in master branch might loose data between restarts, due to non-published events still being forwarded to registry as success on shutdown.

syncPublisher needs to check (publisher.Client).PublishEvents return code and
stop if `false` is returned. Only in case of client.Close() is run while
sending, `false` will be returned.