### PR TITLE
Set negate to true in multiline option.

### DIFF
--- a/filebeat/docs/multiline.asciidoc
+++ b/filebeat/docs/multiline.asciidoc
@@ -100,11 +100,11 @@ To consolidate these lines into a single event in Filebeat, use the following mu
 -------------------------------------------------------------------------------------
 multiline:
   pattern: '\\$'
-  negate: false
+  negate: true
   match: after
 -------------------------------------------------------------------------------------
 
-This configuration merges any line that ends with the `\` character with the line that follows.
+This configuration merges any line that ends with the `\` character with the line that follows. The `negate: true` setting means that the pattern matches the lines that aren't a continuation line but the start of a new multiline event.
 
 ===== Timestamps
 


### PR DESCRIPTION
According to the [multiline doc] (https://www.elastic.co/guide/en/beats/filebeat/current/configuration-filebeat-options.html#multiline), "negate: true" means that the pattern should match the lines that are NOT a continuation but the start of a new multiline event. This is the case here like in the following example (Timestamps).