### PR TITLE
Documentation: Clearer example for include_lines and exclude_lines.

### DIFF
--- a/filebeat/docs/reference/configuration/filebeat-options.asciidoc
+++ b/filebeat/docs/reference/configuration/filebeat-options.asciidoc
@@ -80,8 +80,8 @@ NOTE: If both `include_lines` and `exclude_lines` are defined, Filebeat executes
 
 [source,yaml]
 -------------------------------------------------------------------------------------
- include_lines: ["apache"]
  exclude_lines: ["^DBG"]
+ include_lines: ["apache"]
 -------------------------------------------------------------------------------------
 
 See <<regexp-support>> for a list of supported regexp patterns.


### PR DESCRIPTION
The note about include_lines and exclude_lines tells about the *order of execution* of these options. So to make clear that it's not about their *order of occurrence* in the file I switched the two options.