### PR TITLE
Fix Metricbeat field names for redis aof

### DIFF
--- a/filebeat/filebeat.full.yml
+++ b/filebeat/filebeat.full.yml
@@ -273,8 +273,8 @@ filebeat.prospectors:
 
 #================================ Processors =====================================
 
-# Processors are used to reduce the number of fields in the exported event or to
-# enhance the event with external meta data. This section defines a list of processors
+# Processors are used to reduce the number of fields in the exported event or to 
+# enhance the event with external meta data. This section defines a list of processors 
 # that are applied one by one and the first one receives the initial event:
 #
 #   event -> filter1 -> event1 -> filter2 ->event2 ...
@@ -380,7 +380,7 @@ output.elasticsearch:
   #template.overwrite: false
 
   # If set to true, filebeat checks the Elasticsearch version at connect time, and if it
-  # is 2.x, it loads the file specified by the template.versions.2x.path setting. The
+  # is 2.x, it loads the file specified by the template.versions.2x.path setting. The 
   # default is true.
   #template.versions.2x.enabled: true
 

--- a/metricbeat/docs/fields.asciidoc
+++ b/metricbeat/docs/fields.asciidoc
@@ -1466,49 +1466,49 @@ type: integer
 None
 
 [float]
-=== redis.info.persistence.used.enabled
+=== redis.info.persistence.aof.enabled
 
 type: boolean
 
 None
 
 [float]
-=== redis.info.persistence.used.rewrite_in_progress
+=== redis.info.persistence.aof.rewrite_in_progress
 
 type: boolean
 
 None
 
 [float]
-=== redis.info.persistence.used.rewrite_scheduled
+=== redis.info.persistence.aof.rewrite_scheduled
 
 type: boolean
 
 None
 
 [float]
-=== redis.info.persistence.used.last_rewrite_time_sec
+=== redis.info.persistence.aof.last_rewrite_time_sec
 
 type: integer
 
 None
 
 [float]
-=== redis.info.persistence.used.current_rewrite_time_sec
+=== redis.info.persistence.aof.current_rewrite_time_sec
 
 type: integer
 
 None
 
 [float]
-=== redis.info.persistence.used.last_bgrewrite_status
+=== redis.info.persistence.aof.last_bgrewrite_status
 
 type: keyword
 
 None
 
 [float]
-=== redis.info.persistence.used.last_write_status
+=== redis.info.persistence.aof.last_write_status
 
 type: keyword
 

--- a/metricbeat/etc/fields.yml
+++ b/metricbeat/etc/fields.yml
@@ -861,31 +861,31 @@
                   type: integer
                   description:
 
-                - name: used.enabled
+                - name: aof.enabled
                   type: boolean
                   description:
 
-                - name: used.rewrite_in_progress
+                - name: aof.rewrite_in_progress
                   type: boolean
                   description:
 
-                - name: used.rewrite_scheduled
+                - name: aof.rewrite_scheduled
                   type: boolean
                   description:
 
-                - name: used.last_rewrite_time_sec
+                - name: aof.last_rewrite_time_sec
                   type: integer
                   description:
 
-                - name: used.current_rewrite_time_sec
+                - name: aof.current_rewrite_time_sec
                   type: integer
                   description:
 
-                - name: used.last_bgrewrite_status
+                - name: aof.last_bgrewrite_status
                   type: keyword
                   description:
 
-                - name: used.last_write_status
+                - name: aof.last_write_status
                   type: keyword
                   description:
 

--- a/metricbeat/metricbeat.template-es2x.json
+++ b/metricbeat/metricbeat.template-es2x.json
@@ -705,34 +705,7 @@
                 },
                 "persistence": {
                   "properties": {
-                    "loading": {
-                      "type": "boolean"
-                    },
-                    "rdb": {
-                      "properties": {
-                        "bgsave_in_progress": {
-                          "type": "boolean"
-                        },
-                        "changes_since_last_save": {
-                          "type": "long"
-                        },
-                        "current_bgsave_time_sec": {
-                          "type": "long"
-                        },
-                        "last_bgsave_status": {
-                          "ignore_above": 1024,
-                          "index": "not_analyzed",
-                          "type": "string"
-                        },
-                        "last_bgsave_time_sec": {
-                          "type": "long"
-                        },
-                        "last_save_time": {
-                          "type": "long"
-                        }
-                      }
-                    },
-                    "used": {
+                    "aof": {
                       "properties": {
                         "current_rewrite_time_sec": {
                           "type": "long"
@@ -758,6 +731,33 @@
                         },
                         "rewrite_scheduled": {
                           "type": "boolean"
+                        }
+                      }
+                    },
+                    "loading": {
+                      "type": "boolean"
+                    },
+                    "rdb": {
+                      "properties": {
+                        "bgsave_in_progress": {
+                          "type": "boolean"
+                        },
+                        "changes_since_last_save": {
+                          "type": "long"
+                        },
+                        "current_bgsave_time_sec": {
+                          "type": "long"
+                        },
+                        "last_bgsave_status": {
+                          "ignore_above": 1024,
+                          "index": "not_analyzed",
+                          "type": "string"
+                        },
+                        "last_bgsave_time_sec": {
+                          "type": "long"
+                        },
+                        "last_save_time": {
+                          "type": "long"
                         }
                       }
                     }

--- a/metricbeat/metricbeat.template.json
+++ b/metricbeat/metricbeat.template.json
@@ -692,33 +692,7 @@
                 },
                 "persistence": {
                   "properties": {
-                    "loading": {
-                      "type": "boolean"
-                    },
-                    "rdb": {
-                      "properties": {
-                        "bgsave_in_progress": {
-                          "type": "boolean"
-                        },
-                        "changes_since_last_save": {
-                          "type": "long"
-                        },
-                        "current_bgsave_time_sec": {
-                          "type": "long"
-                        },
-                        "last_bgsave_status": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "last_bgsave_time_sec": {
-                          "type": "long"
-                        },
-                        "last_save_time": {
-                          "type": "long"
-                        }
-                      }
-                    },
-                    "used": {
+                    "aof": {
                       "properties": {
                         "current_rewrite_time_sec": {
                           "type": "long"
@@ -742,6 +716,32 @@
                         },
                         "rewrite_scheduled": {
                           "type": "boolean"
+                        }
+                      }
+                    },
+                    "loading": {
+                      "type": "boolean"
+                    },
+                    "rdb": {
+                      "properties": {
+                        "bgsave_in_progress": {
+                          "type": "boolean"
+                        },
+                        "changes_since_last_save": {
+                          "type": "long"
+                        },
+                        "current_bgsave_time_sec": {
+                          "type": "long"
+                        },
+                        "last_bgsave_status": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "last_bgsave_time_sec": {
+                          "type": "long"
+                        },
+                        "last_save_time": {
+                          "type": "long"
                         }
                       }
                     }

--- a/metricbeat/module/redis/info/_meta/fields.yml
+++ b/metricbeat/module/redis/info/_meta/fields.yml
@@ -126,31 +126,31 @@
           type: integer
           description:
 
-        - name: used.enabled
+        - name: aof.enabled
           type: boolean
           description:
 
-        - name: used.rewrite_in_progress
+        - name: aof.rewrite_in_progress
           type: boolean
           description:
 
-        - name: used.rewrite_scheduled
+        - name: aof.rewrite_scheduled
           type: boolean
           description:
 
-        - name: used.last_rewrite_time_sec
+        - name: aof.last_rewrite_time_sec
           type: integer
           description:
 
-        - name: used.current_rewrite_time_sec
+        - name: aof.current_rewrite_time_sec
           type: integer
           description:
 
-        - name: used.last_bgrewrite_status
+        - name: aof.last_bgrewrite_status
           type: keyword
           description:
 
-        - name: used.last_write_status
+        - name: aof.last_write_status
           type: keyword
           description:
 

--- a/metricbeat/module/redis/info/data.go
+++ b/metricbeat/module/redis/info/data.go
@@ -44,7 +44,7 @@ var (
 				"last_bgsave_time_sec":    c.Int("rdb_last_bgsave_time_sec"),
 				"current_bgsave_time_sec": c.Int("rdb_current_bgsave_time_sec"),
 			},
-			"used": s.Object{
+			"aof": s.Object{
 				"enabled":                  c.Bool("aof_enabled"),
 				"rewrite_in_progress":      c.Bool("aof_rewrite_in_progress"),
 				"rewrite_scheduled":        c.Bool("aof_rewrite_scheduled"),


### PR DESCRIPTION
It was called `used`, probably due to a copy & paste error. Fixes #2027.