### PR TITLE
fix regression: printing default config file path

### DIFF
--- a/libbeat/cfgfile/cfgfile.go
+++ b/libbeat/cfgfile/cfgfile.go
@@ -14,7 +14,7 @@ var (
 	// The default config cannot include the beat name as it is not initialized
 	// when this variable is created. See ChangeDefaultCfgfileFlag which should
 	// be called prior to flags.Parse().
-	configfiles = flagArgList("c", "beat.yml", "Configuration file")
+	configfiles = flagArgList("c", "beat.yml", "Configuration file `path`")
 	overwrites  = common.NewFlagConfig(nil, nil, "E", "Configuration overwrite")
 	testConfig  = flag.Bool("configtest", false, "Test configuration and exit.")
 )

--- a/libbeat/cfgfile/flags.go
+++ b/libbeat/cfgfile/flags.go
@@ -8,6 +8,7 @@ import (
 type argList struct {
 	list      []string
 	isDefault bool
+	f         *flag.Flag
 }
 
 func flagArgList(name string, def string, usage string) *argList {
@@ -16,10 +17,15 @@ func flagArgList(name string, def string, usage string) *argList {
 		isDefault: true,
 	}
 	flag.Var(l, name, usage)
+	l.f = flag.Lookup(name)
+	if l.f == nil {
+		panic("Failed to lookup registered flag")
+	}
 	return l
 }
 
 func (l *argList) SetDefault(v string) {
+	l.f.DefValue = v
 	l.list = []string{v}
 	l.isDefault = true
 }


### PR DESCRIPTION
Resolves: #2058

sample output:
```
Usage of ./filebeat:
  -E value
    	Configuration overwrite (default null)
  -N	Disable actual publishing for testing
  -c path
    	Configuration file path (default /Users/urso/.gvm/pkgsets/go1.6/global/src/github.com/elastic/beats/filebeat/filebeat.yml)
  -configtest
    	Test configuration and exit.
  -cpuprofile string
    	Write cpu profile to file
  -d string
    	Enable certain debug selectors
  -e	Log to stderr and disable syslog/file output
  -httpprof string
    	Start pprof http server
  -memprofile string
    	Write memory profile to this file
  -path.config string
    	Configuration path
  -path.data string
    	Data path
  -path.home string
    	Home path
  -path.logs string
    	Logs path
  -v	Log at INFO level
  -version
    	Print the version and exit
```