### PR TITLE
Add some format string support to libbeat

### DIFF
--- a/libbeat/common/fmtstr/formatevents.go
+++ b/libbeat/common/fmtstr/formatevents.go
@@ -1,0 +1,276 @@
+package fmtstr
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/logp"
+)
+
+// EventFormatString implements format string support on events
+// of type common.MapStr.
+//
+// The concrete event expansion requires the field name enclosed by brackets.
+// For example: '%{[field.name]}'. Field names can be separated by points or
+// multiple braces. This format `%{[field.name]}` is equivalent to `%{[field][name]}`.
+//
+// Default values are given defined by the colon operator. For example:
+// `%{[field.name]:default value}`.
+type EventFormatString struct {
+	formatter StringFormatter
+	ctx       *eventEvalContext
+	fields    []fieldInfo
+}
+
+type eventFieldEvaler struct {
+	ctx   *eventEvalContext
+	index int
+}
+
+type defaultEventFieldEvaler struct {
+	ctx          *eventEvalContext
+	index        int
+	defaultValue string
+}
+
+type eventFieldCompiler struct {
+	ctx   *eventEvalContext
+	keys  map[string]keyInfo
+	index int
+}
+
+type fieldInfo struct {
+	path     string
+	required bool
+}
+
+type keyInfo struct {
+	index    int
+	required bool
+}
+
+type eventEvalContext struct {
+	keys []string
+}
+
+var (
+	errMissingKeys   = errors.New("missing keys")
+	errConvertString = errors.New("can not convert to string")
+)
+
+// CompileEvent compiles an event format string into an runnable
+// EventFormatString. Returns error if parsing or compilation fails.
+func CompileEvent(in string) (*EventFormatString, error) {
+	ctx := &eventEvalContext{}
+	efComp := &eventFieldCompiler{
+		ctx:   ctx,
+		keys:  map[string]keyInfo{},
+		index: 0,
+	}
+
+	sf, err := Compile(in, efComp.compileEventField)
+	if err != nil {
+		return nil, err
+	}
+
+	keys := make([]fieldInfo, len(efComp.keys))
+	for path, info := range efComp.keys {
+		keys[info.index] = fieldInfo{
+			path:     path,
+			required: info.required,
+		}
+	}
+
+	ctx.keys = make([]string, len(keys))
+	efs := &EventFormatString{
+		formatter: sf,
+		ctx:       ctx,
+		fields:    keys,
+	}
+	return efs, nil
+}
+
+// NumFields returns number of unique event fields used by the format string.
+func (fs *EventFormatString) NumFields() int {
+	return len(fs.fields)
+}
+
+// Fields returns list of unique event fields required by the format string.
+func (fs *EventFormatString) Fields() []string {
+	var fields []string
+
+	for _, fi := range fs.fields {
+		if fi.required {
+			fields = append(fields, fi.path)
+		}
+	}
+	return fields
+}
+
+// Run executes the format string returning a new expanded string or an error
+// if execution or event field expansion fails.
+func (fs *EventFormatString) Run(event common.MapStr) (string, error) {
+	if err := fs.collectFields(event); err != nil {
+		return "", err
+	}
+	return fs.formatter.Run()
+}
+
+// Eval executes the format string, writing the resulting string into the provided output buffer. Returns error if execution or event field expansion fails.
+func (fs *EventFormatString) Eval(out *bytes.Buffer, event common.MapStr) error {
+	if err := fs.collectFields(event); err != nil {
+		return err
+	}
+	return fs.formatter.Eval(out)
+}
+
+// collectFields tries to extract and convert all required fields into an array
+// of strings.
+func (fs *EventFormatString) collectFields(event common.MapStr) error {
+	for i, fi := range fs.fields {
+		s, err := fieldString(event, fi.path)
+		if err != nil {
+			if fi.required {
+				return err
+			}
+
+			s = ""
+		}
+		fs.ctx.keys[i] = s
+	}
+
+	return nil
+}
+
+func (e *eventFieldCompiler) compileEventField(
+	field string,
+	ops []VariableOp,
+) (FormatEvaler, error) {
+	if len(ops) > 1 {
+		return nil, errors.New("Too many format modifiers given")
+	}
+
+	defaultValue := ""
+	if len(ops) == 1 {
+		op := ops[0]
+		if op.op != ":" {
+			return nil, fmt.Errorf("unsupported format operator: %v", op.op)
+		}
+		defaultValue = op.param
+	}
+
+	path, err := parseEventPath(field)
+	if err != nil {
+		return nil, err
+	}
+
+	info, found := e.keys[path]
+	if !found {
+		info = keyInfo{
+			required: len(ops) == 0,
+			index:    e.index,
+		}
+		e.index++
+		e.keys[path] = info
+	} else if !info.required && len(ops) == 0 {
+		info.required = true
+		e.keys[path] = info
+	}
+
+	idx := info.index
+
+	if len(ops) == 0 {
+		return &eventFieldEvaler{e.ctx, idx}, nil
+	}
+
+	return &defaultEventFieldEvaler{e.ctx, idx, defaultValue}, nil
+}
+
+func (e *eventFieldEvaler) Eval(out *bytes.Buffer) error {
+	type stringer interface {
+		String() string
+	}
+
+	s := e.ctx.keys[e.index]
+	_, err := out.WriteString(s)
+	return err
+}
+
+func (e *defaultEventFieldEvaler) Eval(out *bytes.Buffer) error {
+	type stringer interface {
+		String() string
+	}
+
+	s := e.ctx.keys[e.index]
+	if s == "" {
+		s = e.defaultValue
+	}
+	_, err := out.WriteString(s)
+	return err
+}
+
+func parseEventPath(field string) (string, error) {
+	field = strings.Trim(field, " \n\r\t")
+	var fields []string
+
+	for len(field) > 0 {
+		if field[0] != '[' {
+			return "", errors.New("expected field extractor start with '['")
+		}
+
+		idx := strings.IndexByte(field, ']')
+		if idx < 0 {
+			return "", errors.New("missing closing ']'")
+		}
+
+		path := field[1:idx]
+		if path == "" {
+			return "", errors.New("empty fields selector '[]'")
+		}
+
+		fields = append(fields, path)
+		field = field[idx+1:]
+	}
+
+	path := strings.Join(fields, ".")
+	return path, nil
+}
+
+// TODO: move to libbeat/common?
+func fieldString(event common.MapStr, field string) (string, error) {
+	type stringer interface {
+		String() string
+	}
+
+	v, err := event.GetValue(field)
+	if err != nil {
+		return "", err
+	}
+
+	switch s := v.(type) {
+	case string:
+		return s, nil
+	case []byte:
+		return string(s), nil
+	case stringer:
+		return s.String(), nil
+	case int8, int16, int32, int64, int:
+		i := reflect.ValueOf(s).Int()
+		return strconv.FormatInt(i, 10), nil
+	case uint8, uint16, uint32, uint64, uint:
+		u := reflect.ValueOf(s).Uint()
+		return strconv.FormatUint(u, 10), nil
+	case float32:
+		return strconv.FormatFloat(float64(s), 'g', -1, 32), nil
+	case float64:
+		return strconv.FormatFloat(s, 'g', -1, 64), nil
+	default:
+		logp.Warn("Can not convert key '%v' value to string", v)
+		return "", errConvertString
+	}
+}

--- a/libbeat/common/fmtstr/formatevents_test.go
+++ b/libbeat/common/fmtstr/formatevents_test.go
@@ -1,0 +1,156 @@
+package fmtstr
+
+import (
+	"testing"
+
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEventFormatString(t *testing.T) {
+	tests := []struct {
+		title    string
+		format   string
+		event    common.MapStr
+		expected string
+		fields   []string
+	}{
+		{
+			"no fields configured",
+			"format string",
+			nil,
+			"format string",
+			nil,
+		},
+		{
+			"expand event field",
+			"%{[key]}",
+			common.MapStr{"key": "value"},
+			"value",
+			[]string{"key"},
+		},
+		{
+			"expand with default",
+			"%{[key]:default}",
+			common.MapStr{},
+			"default",
+			nil,
+		},
+		{
+			"expand nested event field",
+			"%{[nested.key]}",
+			common.MapStr{"nested": common.MapStr{"key": "value"}},
+			"value",
+			[]string{"nested.key"},
+		},
+		{
+			"expand nested event field (alt. syntax)",
+			"%{[nested][key]}",
+			common.MapStr{"nested": common.MapStr{"key": "value"}},
+			"value",
+			[]string{"nested.key"},
+		},
+		{
+			"multiple event fields",
+			"%{[key1]} - %{[key2]}",
+			common.MapStr{"key1": "v1", "key2": "v2"},
+			"v1 - v2",
+			[]string{"key1", "key2"},
+		},
+		{
+			"same fields",
+			"%{[key]} - %{[key]}",
+			common.MapStr{"key": "value"},
+			"value - value",
+			[]string{"key"},
+		},
+		{
+			"same fields with default (first)",
+			"%{[key]:default} - %{[key]}",
+			common.MapStr{"key": "value"},
+			"value - value",
+			[]string{"key"},
+		},
+		{
+			"same fields with default (second)",
+			"%{[key]} - %{[key]:default}",
+			common.MapStr{"key": "value"},
+			"value - value",
+			[]string{"key"},
+		},
+	}
+
+	for i, test := range tests {
+		t.Logf("test(%v): %v", i, test.title)
+
+		fs, err := CompileEvent(test.format)
+		if err != nil {
+			t.Error(err)
+			continue
+		}
+
+		actual, err := fs.Run(test.event)
+
+		assert.NoError(t, err)
+		assert.Equal(t, test.expected, actual)
+		assert.Equal(t, test.fields, fs.Fields())
+	}
+}
+
+func TestEventFormatStringErrors(t *testing.T) {
+	tests := []struct {
+		title          string
+		format         string
+		expectCompiles bool
+		event          common.MapStr
+	}{
+		{
+			"empty field",
+			"%{[]}",
+			false, nil,
+		},
+		{
+			"field not closed",
+			"%{[field}",
+			false, nil,
+		},
+		{
+			"no field accessor",
+			"%{field}",
+			false, nil,
+		},
+		{
+			"unknown operator",
+			"%{[field]:?fail}",
+			false, nil,
+		},
+		{
+			"too many operators",
+			"%{[field]:a:b}",
+			false, nil,
+		},
+		{
+			"missing required field",
+			"%{[key]}",
+			true,
+			common.MapStr{},
+		},
+	}
+
+	for i, test := range tests {
+		t.Logf("run (%v): %v", i, test.title)
+
+		fs, err := CompileEvent(test.format)
+		if !test.expectCompiles {
+			assert.Error(t, err)
+			continue
+		}
+		if err != nil {
+			t.Error(err)
+			continue
+		}
+
+		_, err = fs.Run(test.event)
+		assert.Error(t, err)
+	}
+}

--- a/libbeat/common/fmtstr/formatstring.go
+++ b/libbeat/common/fmtstr/formatstring.go
@@ -1,0 +1,415 @@
+package fmtstr
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// FormatEvaler evaluates some format.
+type FormatEvaler interface {
+	// Eval will execute the format and writes the results into
+	// the provided output buffer. Returns error on failure.
+	Eval(out *bytes.Buffer) error
+}
+
+// StringFormatter interface extends FormatEvaler adding support for querying
+// formatter meta data.
+type StringFormatter interface {
+	FormatEvaler
+
+	// Run execute the formatter returning the generated string.
+	Run() (string, error)
+
+	// IsConst returns true, if execution of formatter will always return the
+	// same constant string.
+	IsConst() bool
+}
+
+// VariableOp defines one expansion variable, including operator and parameter.
+// variable operations are always introduced by a collon ':'.
+// For example the format string %{x:p1:?p2} has 2 variable operations
+// (":", "p1") and (":?", "p2"). It's up to concrete format string implementation
+// to compile and interpret variable ops.
+type VariableOp struct {
+	op    string
+	param string
+}
+
+type constStringFormatter struct {
+	s string
+}
+
+type execStringFormatter struct {
+	buf     *bytes.Buffer
+	evalers []FormatEvaler
+}
+
+type formatElement interface {
+	compile(ctx *compileCtx) (FormatEvaler, error)
+}
+
+type compileCtx struct {
+	compileVariable VariableCompiler
+}
+
+// VariableCompiler is used to compile a variable expansion into
+// an FormatEvaler to be used with the format-string.
+type VariableCompiler func(string, []VariableOp) (FormatEvaler, error)
+
+// StringElement implements StringFormatter always returning a constant string.
+type StringElement struct {
+	s string
+}
+
+type variableElement struct {
+	field string
+	ops   []VariableOp
+}
+
+type token struct {
+	typ tokenType
+	val string
+}
+
+type tokenType uint16
+
+type lexer chan token
+
+const (
+	tokErr tokenType = iota + 1
+	tokString
+	tokOpen
+	tokClose
+	tokOperator
+)
+
+var (
+	openToken  = token{tokOpen, "%{"}
+	closeToken = token{tokClose, "}"}
+)
+
+var (
+	errNestedVar          = errors.New("format string variables can not be nested")
+	errUnexpectedOperator = errors.New("unexpected formatter operator")
+	errMissingClose       = errors.New("missing closing '}'")
+	errEmptyFormat        = errors.New("empty format expansion")
+	errParamsOpsMismatch  = errors.New("more parameters then ops parsed")
+)
+
+// Compile compiles an input format string into a StringFormatter. The variable
+// compiler `vc` is invoked for every variable expansion found in the input format
+// string. Returns error on parse failure or if variable compiler fails.
+//
+// Variable expansion are enclosed in expansion braces `%{<expansion>}`.
+// The `<expansion>` can contain additional parameters separated by ops
+// introduced by collons ':'. For example the format string `%{value:v1:?v2}`
+// will be parsed into variable expansion on `value` with variable ops
+// `[(":", "v1"), (":?", "v2")]`. It's up to the variable compiler to interpret
+// content and variable ops.
+//
+// The back-slash character `\` acts as escape character.
+func Compile(in string, vc VariableCompiler) (StringFormatter, error) {
+	ctx := &compileCtx{vc}
+	return compile(ctx, in)
+}
+
+func compile(ctx *compileCtx, in string) (StringFormatter, error) {
+	lexer := makeLexer(in)
+	defer lexer.Finish()
+
+	// parse format string
+	elements, err := parse(lexer)
+	if err != nil {
+		return nil, err
+	}
+
+	// compile elements into evaluators
+	evalers := make([]FormatEvaler, len(elements))
+	for i := range elements {
+		evalers[i], err = elements[i].compile(ctx)
+		if err != nil {
+			return nil, err
+		}
+	}
+	evalers = optimize(evalers)
+
+	// try to create constant formatter for constant string
+	if len(evalers) == 1 {
+		if se, ok := evalers[0].(StringElement); ok {
+			return constStringFormatter{se.s}, nil
+		}
+	}
+
+	// create executable string formatter
+	fmt := execStringFormatter{
+		evalers: evalers,
+		buf:     bytes.NewBuffer(nil),
+	}
+	return fmt, nil
+}
+
+// optimize optimizes the sequence of evaluators by combining consecutive
+// StringElement instances into one StringElement
+func optimize(in []FormatEvaler) []FormatEvaler {
+	out := in[:0]
+
+	var active StringElement
+	isActive := false
+
+	for _, evaler := range in {
+		se, isString := evaler.(StringElement)
+		if !isString {
+			if isActive {
+				out = append(out, active)
+				isActive = false
+			}
+			out = append(out, evaler)
+			continue
+		}
+
+		if !isActive {
+			active = se
+			isActive = true
+			continue
+		}
+		active.s += se.s
+	}
+
+	if isActive {
+		out = append(out, active)
+	}
+
+	return out
+}
+
+func (f constStringFormatter) Eval(out *bytes.Buffer) error {
+	_, err := out.WriteString(f.s)
+	return err
+}
+
+func (f constStringFormatter) Run() (string, error) {
+	return f.s, nil
+}
+
+func (f constStringFormatter) IsConst() bool {
+	return true
+}
+
+func (f execStringFormatter) Eval(out *bytes.Buffer) error {
+	for _, evaler := range f.evalers {
+		if err := evaler.Eval(out); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (f execStringFormatter) Run() (string, error) {
+	f.buf.Reset()
+	if err := f.Eval(f.buf); err != nil {
+		return "", err
+	}
+	return f.buf.String(), nil
+}
+
+func (f execStringFormatter) IsConst() bool {
+	return false
+}
+
+func (e StringElement) compile(ctx *compileCtx) (FormatEvaler, error) {
+	return e, nil
+}
+
+// Eval write the string elements constant string value into
+// output buffer.
+func (e StringElement) Eval(out *bytes.Buffer) error {
+	_, err := out.WriteString(e.s)
+	return err
+}
+
+func makeVariableElement(f string, ops, params []string) (variableElement, error) {
+	if len(params) > len(ops) {
+		return variableElement{}, errParamsOpsMismatch
+	}
+
+	out := make([]VariableOp, len(ops))
+	for i := range params {
+		out[i] = VariableOp{op: ops[i], param: params[i]}
+	}
+	if len(ops) > len(params) {
+		i := len(ops) - 1
+		out[i] = VariableOp{op: ops[i]}
+	}
+
+	return variableElement{field: f, ops: out}, nil
+}
+
+func (e variableElement) compile(ctx *compileCtx) (FormatEvaler, error) {
+	return ctx.compileVariable(e.field, e.ops)
+}
+
+func parse(lex lexer) ([]formatElement, error) {
+	var elems []formatElement
+
+	for token := range lex.Tokens() {
+		switch token.typ {
+		case tokErr:
+			return nil, errors.New(token.val)
+
+		case tokString:
+			elems = append(elems, StringElement{token.val})
+
+		case tokOpen:
+			elem, err := parseVariable(lex)
+			if err != nil {
+				return nil, err
+			}
+			elems = append(elems, elem)
+
+		case tokClose, tokOperator:
+			// should not happen, but let's return error just in case
+			return nil, fmt.Errorf("Token '%v'(%v) not allowed", token.val, token.typ)
+		}
+	}
+
+	return elems, nil
+}
+
+func parseVariable(lex lexer) (formatElement, error) {
+	var strings []string
+	var ops []string
+
+	for token := range lex.Tokens() {
+		switch token.typ {
+		case tokErr:
+			return nil, errors.New(token.val)
+
+		case tokOpen:
+			return nil, errNestedVar
+
+		case tokClose:
+			if len(strings) == 0 {
+				return nil, errEmptyFormat
+			}
+			return makeVariableElement(strings[0], ops, strings[1:])
+
+		case tokString:
+			if len(strings) != len(ops) {
+				return nil, fmt.Errorf("Unexpected string token %v, expected operator", token.val)
+			}
+			strings = append(strings, token.val)
+
+		case tokOperator:
+			if len(strings) == 0 {
+				return nil, errUnexpectedOperator
+			}
+			ops = append(ops, token.val)
+			if len(ops) > len(strings) {
+				return nil, fmt.Errorf("Consecutive operator tokens '%v'", token.val)
+			}
+
+		default:
+			return nil, fmt.Errorf("Unexpected token '%v' (%v)", token.val, token.typ)
+		}
+	}
+
+	return nil, errMissingClose
+}
+
+func makeLexer(in string) lexer {
+	lex := make(chan token, 1)
+
+	go func() {
+		off := 0
+		content := in
+
+		defer func() {
+			if len(content) > 0 {
+				lex <- token{tokString, content}
+			}
+			close(lex)
+		}()
+
+		strToken := func(s string) {
+			if s != "" {
+				lex <- token{tokString, s}
+			}
+		}
+
+		opToken := func(op string) token {
+			return token{tokOperator, op}
+		}
+
+		varcount := 0
+		for len(content) > 0 {
+			idx := -1
+			if varcount == 0 {
+				idx = strings.IndexAny(content[off:], `%\`)
+			} else {
+				idx = strings.IndexAny(content[off:], `%:}\`)
+			}
+
+			if idx == -1 {
+				return
+			}
+
+			idx += off
+			off = idx + 1
+
+			switch content[idx] {
+			case '\\': // escape next character
+				content = content[:idx] + content[off:]
+				continue
+
+			case ':':
+				if len(content) <= off { // found ':' at end of string
+					return
+				}
+
+				strToken(content[:idx])
+				op := ":"
+				if strings.ContainsRune("!@#&*=+<>?", rune(content[off])) {
+					off++
+					op = content[idx : off+1]
+				}
+				lex <- opToken(op)
+
+			case '}':
+				strToken(content[:idx])
+				lex <- closeToken
+				varcount--
+
+			case '%':
+				if len(content) <= off { // found '%' at end of string
+					return
+				}
+
+				if content[off] != '{' {
+					continue // no variable expression
+				}
+
+				strToken(content[:idx])
+				lex <- openToken
+				off++
+				varcount++
+			}
+
+			content = content[off:]
+			off = 0
+		}
+
+	}()
+
+	return lex
+}
+
+func (l lexer) Tokens() <-chan token {
+	return (chan token)(l)
+}
+
+func (l lexer) Finish() {
+	for range l.Tokens() {
+	}
+}

--- a/libbeat/common/fmtstr/formatstring_test.go
+++ b/libbeat/common/fmtstr/formatstring_test.go
@@ -1,0 +1,153 @@
+package fmtstr
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFormatString(t *testing.T) {
+
+	tests := []struct {
+		title       string
+		pattern     string
+		dyn, lookup map[string]string
+		expected    string
+	}{
+		{
+			"no interpolations",
+			"no interpolations",
+			nil, nil,
+			"no interpolations",
+		},
+		{
+			"simple lookup standalone",
+			"%{k}",
+			nil, map[string]string{"k": "v"},
+			"v",
+		},
+		{
+			"simple lookup start of string",
+			"%{k} test",
+			nil, map[string]string{"k": "v"},
+			"v test",
+		},
+		{
+			"simple lookup end of string",
+			"test %{k}",
+			nil, map[string]string{"k": "v"},
+			"test v",
+		},
+		{
+			"simple lookup middle of string",
+			"pre %{k} post",
+			nil, map[string]string{"k": "v"},
+			"pre v post",
+		},
+		{
+			"compile lookup default",
+			"%{unknown:default}",
+			nil, nil,
+			"default",
+		},
+		{
+			"just with % symbol",
+			"just with % symbol",
+			nil, nil,
+			"just with % symbol",
+		},
+		{
+			"with escaped % symbol",
+			`\%{abc}`,
+			nil, nil,
+			"%{abc}",
+		},
+		{
+			"with dynamic evaluation",
+			"my dynamic %{key}",
+			map[string]string{"key": "value"}, nil,
+			"my dynamic value",
+		},
+		{
+			"test mixed",
+			"pre %{c} abc %{d} def %{c} post",
+			map[string]string{"d": "dynamic"},
+			map[string]string{"c": "const"},
+			"pre const abc dynamic def const post",
+		},
+	}
+
+	for i, test := range tests {
+		// stringElement wraps StringElement in order to disable
+		// optimization and enforce evaluation of formatter.
+		type stringElement struct {
+			StringElement
+		}
+
+		t.Logf("run (%v): '%v'", i, test.title)
+
+		// compile format string with test key lookup
+		sf, err := Compile(test.pattern,
+			func(key string, ops []VariableOp) (FormatEvaler, error) {
+				if test.lookup != nil {
+					if v, found := test.lookup[key]; found {
+						return StringElement{v}, nil
+					}
+				}
+
+				if test.dyn != nil {
+					if v, found := test.dyn[key]; found {
+						return stringElement{StringElement{v}}, nil
+					}
+				}
+
+				if len(ops) == 0 {
+					return nil, errors.New("no default operator")
+				}
+
+				op := ops[0]
+				if op.op != ":" {
+					return nil, fmt.Errorf("invalid op: '%v'", op.op)
+				}
+
+				return StringElement{ops[0].param}, nil
+			},
+		)
+
+		// validate compile ok
+		if err != nil {
+			t.Error(err)
+			continue
+		}
+
+		// run string formatter
+		actual, err := sf.Run()
+
+		// test validation
+		if test.dyn == nil {
+			assert.True(t, sf.IsConst())
+		} else {
+			assert.False(t, sf.IsConst())
+		}
+		assert.Equal(t, test.expected, actual)
+	}
+}
+
+func TestFormatStringErrors(t *testing.T) {
+	tests := []struct {
+		title  string
+		format string
+	}{
+		{"missing close", "%{key"},
+		{"nesting not allowed", "%{key %{nested}}"},
+	}
+
+	for i, test := range tests {
+		t.Logf("run (%v): %v", i, test.title)
+
+		_, err := Compile(test.format, nil)
+		assert.Error(t, err)
+	}
+}


### PR DESCRIPTION
This PR adds some customizable format-string support to libbeat. This feature is not used anywhere yet, but lays some ground-work for features/improvements requiring format-string support dynamically constructing strings right from events.

**EventFormatString** implements format string support on events
of type common.MapStr.

The concrete event expansion requires the field name enclosed by brackets.
For example: '%{[field.name]}'. Field names can be separated by points or
multiple braces. This format `%{[field.name]}` is equivalent to `%{[field][name]}`.

Default values are given by the colon operator. For example:
`%{[field.name]:default value}`.

**EventFormatString** is build on top of generic **StringFormatter** Compile function.

Compile compiles an input format string into a StringFormatter. The variable
compiler `vc` is invoked for every variable expansion found in the input format
string.

Variable expansion are enclosed in expansion braces `%{<expansion>}`.
The `<expansion>` can contain additional parameters separated by ops
introduced by collons ':'. For example the format string `%{value:v1:?v2}`
will be parsed into variable expansion on `value` with variable ops
`[(":", "v1"), (":?", "v2")]`. It's up to the variable compiler to interpret
content and variable ops.

The back-slash character `\` acts as escape character so the sequence '%{' will be written to the resulting string is `\` is used.