### PR TITLE
Always add conditionals to all processor actions

### DIFF
--- a/filebeat/tests/system/config/filebeat.yml.j2
+++ b/filebeat/tests/system/config/filebeat.yml.j2
@@ -108,31 +108,22 @@ geoip:
   ]
 {%- endif %}
 
-{%- if drop_fields or drop_event or include_fields %}
+{%- if processors %}
 
 #================================ Filters =====================================
+
 processors:
-
-    {%- if include_fields %}
-    - include_fields:
-        when:
-            {{include_fields.condition | default()}}
-        fields: {{include_fields.fields | default([])}}
-    {%- endif %}
-
-    {%- if drop_fields %}
-    - drop_fields:
-        when:
-            {{drop_fields.condition | default()}}
-        fields: {{drop_fields.fields | default([])}}
-    {%- endif %}
-
-
-    {%- if drop_event %}
-    - drop_event:
-        when:
-            {{ drop_event.condition | default()}}
-    {%- endif %}
+{%- for processor in processors %}
+{%- for name, settings in processor.iteritems() %}
+- {{name}}:
+  {%- if settings %}
+  {%- for k, v in settings.iteritems() %}
+    {{k}}:
+      {{v | default([])}}
+  {%- endfor %}
+  {%- endif %}
+{%- endfor %}
+{%- endfor %}
 
 {%- endif %}
 
@@ -152,4 +143,4 @@ output.file:
 #================================ Paths =====================================
 path:
   data: {{path_data}}
-{%endif%}
+{% endif %}

--- a/filebeat/tests/system/test_json.py
+++ b/filebeat/tests/system/test_json.py
@@ -263,9 +263,11 @@ class Test(BaseTest):
                 overwrite_keys=True,
                 add_error_key=True,
                 ),
-            drop_fields={
-                "fields": ["headers.request-id"],
-            },
+            processors=[{
+                "drop_fields": {
+                    "fields": ["headers.request-id"],
+                },
+            }]
         )
 
         os.mkdir(self.working_dir + "/log/")
@@ -303,9 +305,11 @@ class Test(BaseTest):
                 overwrite_keys=True,
                 add_error_key=True,
                 ),
-            drop_fields={
-                "fields": ["headers", "res"],
-            },
+            processors=[{
+                "drop_fields": {
+                    "fields": ["headers", "res"],
+                },
+            }]
         )
 
         os.mkdir(self.working_dir + "/log/")

--- a/filebeat/tests/system/test_processors.py
+++ b/filebeat/tests/system/test_processors.py
@@ -13,9 +13,11 @@ class Test(BaseTest):
         """
         self.render_config_template(
             path=os.path.abspath(self.working_dir) + "/test.log",
-            drop_fields={
-                "fields": ["beat"],
-            },
+            processors=[{
+                "drop_fields": {
+                    "fields": ["beat"],
+                },
+            }]
         )
         with open(self.working_dir + "/test.log", "w") as f:
             f.write("test message\n")
@@ -36,9 +38,11 @@ class Test(BaseTest):
         """
         self.render_config_template(
             path=os.path.abspath(self.working_dir) + "/test.log",
-            include_fields={
-                "fields": ["source", "offset", "message"],
-            },
+            processors=[{
+                "include_fields": {
+                    "fields": ["source", "offset", "message"],
+                },
+            }]
         )
         with open(self.working_dir + "/test.log", "w") as f:
             f.write("test message\n")
@@ -59,9 +63,11 @@ class Test(BaseTest):
         """
         self.render_config_template(
             path=os.path.abspath(self.working_dir) + "/test*.log",
-            drop_event={
-                "condition": "contains.source: test1",
-            },
+            processors=[{
+                "drop_event": {
+                    "when": "contains.source: test1",
+                },
+            }]
         )
         with open(self.working_dir + "/test1.log", "w") as f:
             f.write("test1 message\n")
@@ -86,9 +92,11 @@ class Test(BaseTest):
         """
         self.render_config_template(
             path=os.path.abspath(self.working_dir) + "/test*.log",
-            drop_event={
-                "condition": "not.contains.source: test",
-            },
+            processors=[{
+                "drop_event": {
+                    "when": "not.contains.source: test",
+                },
+            }]
         )
         with open(self.working_dir + "/test1.log", "w") as f:
             f.write("test1 message\n")

--- a/libbeat/processors/actions/checks.go
+++ b/libbeat/processors/actions/checks.go
@@ -1,0 +1,64 @@
+package actions
+
+import (
+	"fmt"
+
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/processors"
+)
+
+func configChecked(
+	constr processors.Constructor,
+	checks ...func(common.Config) error,
+) processors.Constructor {
+	validator := checkAll(checks...)
+	return func(c common.Config) (processors.Processor, error) {
+		err := validator(c)
+		if err != nil {
+			return nil, fmt.Errorf("%v in %v", err.Error(), c.Path())
+		}
+
+		return constr(c)
+	}
+}
+
+func checkAll(checks ...func(common.Config) error) func(common.Config) error {
+	return func(c common.Config) error {
+		for _, check := range checks {
+			if err := check(c); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
+
+func requireFields(fields ...string) func(common.Config) error {
+	return func(c common.Config) error {
+		for _, field := range fields {
+			if !c.HasField(field) {
+				return fmt.Errorf("missing %v option", field)
+			}
+		}
+		return nil
+	}
+}
+
+func allowedFields(fields ...string) func(common.Config) error {
+	return func(c common.Config) error {
+		for _, field := range c.GetFields() {
+			found := false
+			for _, allowed := range fields {
+				if field == allowed {
+					found = true
+					break
+				}
+			}
+
+			if !found {
+				return fmt.Errorf("unexpected %v option", field)
+			}
+		}
+		return nil
+	}
+}

--- a/libbeat/processors/actions/drop_event.go
+++ b/libbeat/processors/actions/drop_event.go
@@ -1,73 +1,26 @@
 package actions
 
 import (
-	"fmt"
-
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/processors"
 )
 
-type DropEvent struct {
-	Cond *processors.Condition
-}
-
-type DropEventConfig struct {
-	Cond *processors.ConditionConfig `config:"when"`
-}
+type dropEvent struct{}
 
 func init() {
-	if err := processors.RegisterPlugin("drop_event", newDropEvent); err != nil {
+	constructor := configChecked(newDropEvent, allowedFields("when"))
+	if err := processors.RegisterPlugin("drop_event", constructor); err != nil {
 		panic(err)
 	}
 }
 
 func newDropEvent(c common.Config) (processors.Processor, error) {
-
-	f := DropEvent{}
-
-	if err := f.CheckConfig(c); err != nil {
-		return nil, err
-	}
-
-	config := DropEventConfig{}
-
-	err := c.Unpack(&config)
-	if err != nil {
-		return nil, fmt.Errorf("fail to unpack the drop_event configuration: %s", err)
-	}
-
-	cond, err := processors.NewCondition(config.Cond)
-	if err != nil {
-		return nil, err
-	}
-	f.Cond = cond
-
-	return &f, nil
+	return dropEvent{}, nil
 }
 
-func (f *DropEvent) CheckConfig(c common.Config) error {
-
-	for _, field := range c.GetFields() {
-		if field != "when" {
-			return fmt.Errorf("unexpected %s option in the drop_event configuration", field)
-		}
-	}
-	return nil
-}
-
-func (f *DropEvent) Run(event common.MapStr) (common.MapStr, error) {
-
-	if f.Cond != nil && !f.Cond.Check(event) {
-		return event, nil
-	}
-
+func (f dropEvent) Run(event common.MapStr) (common.MapStr, error) {
 	// return event=nil to delete the entire event
 	return nil, nil
 }
 
-func (f DropEvent) String() string {
-	if f.Cond != nil {
-		return "drop_event, condition=" + f.Cond.String()
-	}
-	return "drop_event"
-}
+func (f dropEvent) String() string { return "drop_event" }

--- a/libbeat/processors/actions/drop_fields.go
+++ b/libbeat/processors/actions/drop_fields.go
@@ -8,33 +8,22 @@ import (
 	"github.com/elastic/beats/libbeat/processors"
 )
 
-type DropFields struct {
+type dropFields struct {
 	Fields []string
-	// condition
-	Cond *processors.Condition
-}
-
-type DropFieldsConfig struct {
-	Fields []string                    `config:"fields"`
-	Cond   *processors.ConditionConfig `config:"when"`
 }
 
 func init() {
-	if err := processors.RegisterPlugin("drop_fields", newDropFields); err != nil {
+	constructor := configChecked(newDropFields,
+		requireFields("fields"), allowedFields("fields", "when"))
+	if err := processors.RegisterPlugin("drop_fields", constructor); err != nil {
 		panic(err)
 	}
 }
 
 func newDropFields(c common.Config) (processors.Processor, error) {
-
-	f := DropFields{}
-
-	if err := f.CheckConfig(c); err != nil {
-		return nil, err
-	}
-
-	config := DropFieldsConfig{}
-
+	config := struct {
+		Fields []string `config:"fields"`
+	}{}
 	err := c.Unpack(&config)
 	if err != nil {
 		return nil, fmt.Errorf("fail to unpack the drop_fields configuration: %s", err)
@@ -48,42 +37,12 @@ func newDropFields(c common.Config) (processors.Processor, error) {
 			}
 		}
 	}
-	f.Fields = config.Fields
 
-	cond, err := processors.NewCondition(config.Cond)
-	if err != nil {
-		return nil, err
-	}
-	f.Cond = cond
-
-	return &f, nil
+	f := dropFields{Fields: config.Fields}
+	return f, nil
 }
 
-func (f *DropFields) CheckConfig(c common.Config) error {
-
-	complete := false
-
-	for _, field := range c.GetFields() {
-		if field != "fields" && field != "when" {
-			return fmt.Errorf("unexpected %s option in the drop_fields configuration", field)
-		}
-		if field == "fields" {
-			complete = true
-		}
-	}
-
-	if !complete {
-		return fmt.Errorf("missing fields option in the drop_fields configuration")
-	}
-	return nil
-}
-
-func (f *DropFields) Run(event common.MapStr) (common.MapStr, error) {
-
-	if f.Cond != nil && !f.Cond.Check(event) {
-		return event, nil
-	}
-
+func (f dropFields) Run(event common.MapStr) (common.MapStr, error) {
 	for _, field := range f.Fields {
 		err := event.Delete(field)
 		if err != nil {
@@ -94,11 +53,6 @@ func (f *DropFields) Run(event common.MapStr) (common.MapStr, error) {
 	return event, nil
 }
 
-func (f DropFields) String() string {
-
-	if f.Cond != nil {
-		return "drop_fields=" + strings.Join(f.Fields, ", ") + ", condition=" + f.Cond.String()
-	}
+func (f dropFields) String() string {
 	return "drop_fields=" + strings.Join(f.Fields, ", ")
-
 }

--- a/libbeat/processors/actions/include_fields.go
+++ b/libbeat/processors/actions/include_fields.go
@@ -5,37 +5,25 @@ import (
 	"strings"
 
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/processors"
 )
 
-type IncludeFields struct {
+type includeFields struct {
 	Fields []string
-	// condition
-	Cond *processors.Condition
-}
-
-type IncludeFieldsConfig struct {
-	Fields []string                    `config:"fields"`
-	Cond   *processors.ConditionConfig `config:"when"`
 }
 
 func init() {
-	if err := processors.RegisterPlugin("include_fields", newIncludeFields); err != nil {
+	constructor := configChecked(newIncludeFields,
+		requireFields("fields"), allowedFields("fields", "when"))
+	if err := processors.RegisterPlugin("include_fields", constructor); err != nil {
 		panic(err)
 	}
 }
 
 func newIncludeFields(c common.Config) (processors.Processor, error) {
-
-	f := IncludeFields{}
-
-	if err := f.CheckConfig(c); err != nil {
-		return nil, err
-	}
-
-	config := IncludeFieldsConfig{}
-
+	config := struct {
+		Fields []string `config:"fields"`
+	}{}
 	err := c.Unpack(&config)
 	if err != nil {
 		return nil, fmt.Errorf("fail to unpack the include_fields configuration: %s", err)
@@ -53,43 +41,12 @@ func newIncludeFields(c common.Config) (processors.Processor, error) {
 			config.Fields = append(config.Fields, readOnly)
 		}
 	}
-	f.Fields = config.Fields
 
-	cond, err := processors.NewCondition(config.Cond)
-	if err != nil {
-		return nil, err
-	}
-	f.Cond = cond
-
+	f := includeFields{Fields: config.Fields}
 	return &f, nil
 }
 
-func (f *IncludeFields) CheckConfig(c common.Config) error {
-
-	complete := false
-
-	logp.Info("include_fields: %v", c)
-	for _, field := range c.GetFields() {
-		if field != "fields" && field != "when" {
-			return fmt.Errorf("unexpected %s option in the include_fields configuration", field)
-		}
-		if field == "fields" {
-			complete = true
-		}
-	}
-
-	if !complete {
-		return fmt.Errorf("missing fields option in the include_fields configuration")
-	}
-	return nil
-}
-
-func (f *IncludeFields) Run(event common.MapStr) (common.MapStr, error) {
-
-	if f.Cond != nil && !f.Cond.Check(event) {
-		return event, nil
-	}
-
+func (f includeFields) Run(event common.MapStr) (common.MapStr, error) {
 	filtered := common.MapStr{}
 
 	for _, field := range f.Fields {
@@ -109,10 +66,6 @@ func (f *IncludeFields) Run(event common.MapStr) (common.MapStr, error) {
 	return filtered, nil
 }
 
-func (f IncludeFields) String() string {
-
-	if f.Cond != nil {
-		return "include_fields=" + strings.Join(f.Fields, ", ") + ", condition=" + f.Cond.String()
-	}
+func (f includeFields) String() string {
 	return "include_fields=" + strings.Join(f.Fields, ", ")
 }

--- a/libbeat/processors/processor_test.go
+++ b/libbeat/processors/processor_test.go
@@ -481,7 +481,9 @@ func TestBadCondition(t *testing.T) {
 
 		for name, actionYml := range action {
 			actionConfig, err := common.NewConfigFrom(actionYml)
-			assert.Nil(t, err)
+			if err != nil {
+				t.Fatal(err)
+			}
 
 			c[name] = *actionConfig
 		}
@@ -489,7 +491,7 @@ func TestBadCondition(t *testing.T) {
 	}
 
 	_, err := processors.New(config)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 
 }
 

--- a/libbeat/processors/registry.go
+++ b/libbeat/processors/registry.go
@@ -23,6 +23,6 @@ func RegisterPlugin(name string, constructor Constructor) error {
 	if _, exists := constructors[name]; exists {
 		return fmt.Errorf("plugin %s already registered", name)
 	}
-	constructors[name] = constructor
+	constructors[name] = NewConditional(constructor)
 	return nil
 }

--- a/metricbeat/tests/system/config/metricbeat.yml.j2
+++ b/metricbeat/tests/system/config/metricbeat.yml.j2
@@ -102,30 +102,22 @@ geoip:
   ]
 {%- endif %}
 
-{%- if drop_fields or drop_event or include_fields %}
+{%- if processors %}
 
-#================================ Processors =====================================
+#================================ Filters =====================================
+
 processors:
-
-  {%- if include_fields %}
-  - include_fields:
-      when:
-        {{include_fields.condition | default()}}
-      fields: {{include_fields.fields | default([])}}
+{%- for processor in processors %}
+{%- for name, settings in processor.iteritems() %}
+- {{name}}:
+  {%- if settings %}
+  {%- for k, v in settings.iteritems() %}
+    {{k}}:
+      {{v | default([])}}
+  {%- endfor %}
   {%- endif %}
-
-  {%- if drop_fields %}
-  - drop_fields:
-      when:
-        {{drop_fields.condition | default()}}
-      fields: {{drop_fields.fields | default([])}}
-  {%- endif %}
-
-  {%- if drop_event %}
-  - drop_event:
-      when:
-        {{ drop_event.condition | default()}}
-  {%- endif %}
+{%- endfor %}
+{%- endfor %}
 
 {%- endif %}
 

--- a/metricbeat/tests/system/test_processors.py
+++ b/metricbeat/tests/system/test_processors.py
@@ -14,10 +14,12 @@ class TestProcessors(metricbeat.BaseTest):
                 "metricsets": ["cpu"],
                 "period": "1s"
             }],
-            drop_fields={
-                "condition": "range.system.cpu.system.pct.lt: 0.1",
-                "fields": ["system.cpu.load"],
-            },
+            processors=[{
+                "drop_fields":{
+                    "when": "range.system.cpu.system.pct.lt: 0.1",
+                    "fields": ["system.cpu.load"],
+                },
+            }]
         )
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0)
@@ -52,10 +54,12 @@ class TestProcessors(metricbeat.BaseTest):
                 "metricsets": ["process"],
                 "period": "1s"
             }],
-            drop_fields={
-                "fields": ["system.process.memory"],
-                "condition": "range.system.process.cpu.total.pct.lt: 0.5",
-            },
+            processors=[{
+                "drop_fields":{
+                    "fields": ["system.process.memory"],
+                    "when": "range.system.process.cpu.total.pct.lt: 0.5",
+                },
+            }]
         )
         metricbeat = self.start_beat()
         self.wait_until(
@@ -84,9 +88,11 @@ class TestProcessors(metricbeat.BaseTest):
                 "metricsets": ["process"],
                 "period": "1s"
             }],
-            drop_event={
-                "condition": "range.system.process.cpu.total.pct.lt: 0.001",
-            },
+            processors=[{
+                "drop_event":{
+                    "when": "range.system.process.cpu.total.pct.lt: 0.001",
+                },
+            }]
         )
         metricbeat = self.start_beat()
         self.wait_until(
@@ -112,9 +118,11 @@ class TestProcessors(metricbeat.BaseTest):
                 "metricsets": ["process"],
                 "period": "1s"
             }],
-            drop_event={
-                "condition": "not.contains.system.process.cmdline: metricbeat.test",
-            },
+            processors=[{
+                "drop_event":{
+                    "when.not": "contains.system.process.cmdline: metricbeat.test",
+                },
+            }]
         )
         metricbeat = self.start_beat()
         self.wait_until(
@@ -139,7 +147,9 @@ class TestProcessors(metricbeat.BaseTest):
                 "metricsets": ["process"],
                 "period": "1s"
             }],
-            include_fields={"fields": ["system.process.cpu", "system.process.memory"]},
+            processors=[{
+                "include_fields":{"fields": ["system.process.cpu", "system.process.memory"]},
+            }]
         )
         metricbeat = self.start_beat()
         self.wait_until(
@@ -179,8 +189,11 @@ class TestProcessors(metricbeat.BaseTest):
                 "metricsets": ["process"],
                 "period": "1s"
             }],
-            include_fields={"fields": ["system.process"]},
-            drop_fields={"fields": ["system.process.memory"]},
+            processors=[{
+                "include_fields":{"fields": ["system.process"]},
+            }, {
+                "drop_fields": {"fields": ["system.process.memory"]},
+            }]
         )
         metricbeat = self.start_beat()
         self.wait_until(
@@ -218,8 +231,15 @@ class TestProcessors(metricbeat.BaseTest):
                 "metricsets": ["process"],
                 "period": "1s"
             }],
-            include_fields={"fields": ["system.process.memory.size", "proc.memory.rss.pct"]},
-            drop_fields={"fields": ["system.process.memory.size", "proc.memory.rss.pct"]},
+            processors=[{
+                "include_fields":{
+                    "fields": ["system.process.memory.size", "proc.memory.rss.pct"],
+                },
+            }, {
+                "drop_fields": {
+                    "fields": ["system.process.memory.size", "proc.memory.rss.pct"],
+                },
+            }]
         )
         metricbeat = self.start_beat()
         self.wait_until(

--- a/packetbeat/tests/system/config/packetbeat.yml.j2
+++ b/packetbeat/tests/system/config/packetbeat.yml.j2
@@ -174,31 +174,22 @@ geoip:
   ]
 {%- endif %}
 
-{%- if drop_fields or drop_event or include_fields %}
+{%- if processors %}
 
-#================================ Processors =====================================
+#================================ Filters =====================================
+
 processors:
-
-    {%- if include_fields %}
-    - include_fields:
-        when:
-            {{include_fields.condition | default()}}
-        fields: {{include_fields.fields | default([])}}
-    {%- endif %}
-
-    {%- if drop_fields %}
-    - drop_fields:
-        when:
-            {{drop_fields.condition | default()}}
-        fields: {{drop_fields.fields | default([])}}
-    {%- endif %}
-
-
-    {%- if drop_event %}
-    - drop_event:
-        when: 
-            {{ drop_event.condition | default()}}
-    {%- endif %}
+{%- for processor in processors %}
+{%- for name, settings in processor.iteritems() %}
+- {{name}}:
+  {%- if settings %}
+  {%- for k, v in settings.iteritems() %}
+    {{k}}:
+      {{v | default([])}}
+  {%- endfor %}
+  {%- endif %}
+{%- endfor %}
+{%- endfor %}
 
 {%- endif %}
 

--- a/packetbeat/tests/system/test_0060_processors.py
+++ b/packetbeat/tests/system/test_0060_processors.py
@@ -7,9 +7,11 @@ class Test(BaseTest):
 
         self.render_config_template(
             http_send_all_headers=True,
-            drop_fields={"fields": ["http.request_headers"]},
-            # export all fields
-            include_fields=None,
+            processors=[{
+                "drop_fields": {
+                    "fields": ["http.request_headers"]
+                },
+            }]
         )
 
         self.run_packetbeat(pcap="http_minitwit.pcap",
@@ -30,10 +32,12 @@ class Test(BaseTest):
 
         self.render_config_template(
             http_send_all_headers=True,
-            drop_fields={
-                "fields": ["http.request_headers", "http.response_headers"],
-                "condition": "equals.http.code: 200",
-            },
+            processors=[{
+                "drop_fields": {
+                    "fields": ["http.request_headers", "http.response_headers"],
+                    "when": "equals.http.code: 200",
+                },
+            }]
         )
 
         self.run_packetbeat(pcap="http_minitwit.pcap",
@@ -60,10 +64,12 @@ class Test(BaseTest):
         self.render_config_template(
             http_send_request=True,
             http_send_response=True,
-            include_fields={
-                "fields": ["http"],
-                "condition": "equals.http.code: 200",
-            },
+            processors=[{
+                "include_fields": {
+                    "fields": ["http"],
+                    "when": "equals.http.code: 200",
+                },
+            }]
         )
 
         self.run_packetbeat(pcap="http_minitwit.pcap",
@@ -92,10 +98,12 @@ class Test(BaseTest):
         self.render_config_template(
             http_send_request=True,
             http_send_response=True,
-            drop_fields={
-                "fields": ["request", "response"],
-                "condition": "range.http.code.lt: 300",
-            },
+            processors=[{
+                "drop_fields": {
+                    "fields": ["request", "response"],
+                    "when": "range.http.code.lt: 300",
+                },
+            }]
         )
 
         self.run_packetbeat(pcap="http_minitwit.pcap",
@@ -120,9 +128,11 @@ class Test(BaseTest):
     def test_drop_event_with_cond(self):
 
         self.render_config_template(
-            drop_event={
-                "condition": "range.http.code.lt: 300",
-            },
+            processors=[{
+                "drop_event": {
+                    "when": "range.http.code.lt: 300",
+                },
+            }]
         )
 
         self.run_packetbeat(pcap="http_minitwit.pcap",
@@ -138,11 +148,11 @@ class Test(BaseTest):
 
         self.render_config_template(
             http_send_all_headers=True,
-            drop_fields={
-                "fields": ["http.response_headers.transfer-encoding"]
-            },
-            # export all fields
-            include_fields=None,
+            processors=[{
+                "drop_fields": {
+                    "fields": ["http.response_headers.transfer-encoding"]
+                },
+            }]
         )
 
         self.run_packetbeat(pcap="http_minitwit.pcap",
@@ -167,11 +177,11 @@ class Test(BaseTest):
 
         self.render_config_template(
             http_send_all_headers=True,
-            drop_fields={
-                "fields": ["http.response_headers.transfer-encoding-test"]
-            },
-            # export all fields
-            include_fields=None,
+            processors=[{
+                "drop_fields": {
+                    "fields": ["http.response_headers.transfer-encoding-test"]
+                },
+            }]
         )
 
         self.run_packetbeat(pcap="http_minitwit.pcap",
@@ -196,9 +206,11 @@ class Test(BaseTest):
 
         self.render_config_template(
             http_send_all_headers=True,
-            drop_event={
-                "condition": "equals.status: OK",
-            },
+            processors=[{
+                "drop_event": {
+                    "when": "equals.status: OK",
+                },
+            }]
         )
 
         self.run_packetbeat(pcap="http_minitwit.pcap",
@@ -212,9 +224,11 @@ class Test(BaseTest):
         self.render_config_template(
             http_send_all_headers=True,
             # export all mandatory fields
-            include_fields={
-                "fields": [],
-            },
+            processors=[{
+                "include_fields": {
+                    "fields": [],
+                },
+            }]
         )
 
         self.run_packetbeat(pcap="http_minitwit.pcap",
@@ -228,14 +242,14 @@ class Test(BaseTest):
         assert "http.response_headers" not in objs[0]
 
     def test_drop_no_fields(self):
-
         self.render_config_template(
             http_send_all_headers=True,
-            drop_fields={
-                "fields": [],
-            },
-            # export all fields
-            include_fields=None,
+            processors=[{
+                "drop_fields": {
+                    "fields": [],
+                },
+                # export all fields
+            }]
         )
 
         self.run_packetbeat(pcap="http_minitwit.pcap",
@@ -250,16 +264,18 @@ class Test(BaseTest):
         assert objs[2]["status"] == "Error"
 
     def test_drop_and_include_fields_failed_cond(self):
-
         self.render_config_template(
             http_send_all_headers=True,
-            include_fields={
-                "fields": ["http"],
-            },
-            drop_fields={
-                "fields": ["http.request_headers", "http.response_headers"],
-                "condition": "equals.status: OK",
-            },
+            processors=[{
+                "include_fields": {
+                    "fields": ["http"],
+                },
+            }, {
+                "drop_fields": {
+                    "fields": ["http.request_headers", "http.response_headers"],
+                    "when": "equals.status: OK",
+                },
+            }]
         )
 
         self.run_packetbeat(pcap="http_minitwit.pcap",
@@ -281,13 +297,16 @@ class Test(BaseTest):
 
         self.render_config_template(
             http_send_all_headers=True,
-            include_fields={
-                "fields": ["http"],
-            },
-            drop_fields={
-                "fields": ["http.request_headers", "http.response_headers"],
-                "condition": "equals.http.code: 200",
-            },
+            processors=[{
+                "include_fields": {
+                    "fields": ["http"],
+                },
+            }, {
+                "drop_fields": {
+                    "fields": ["http.request_headers", "http.response_headers"],
+                    "when": "equals.http.code: 200",
+                },
+            }]
         )
 
         self.run_packetbeat(pcap="http_minitwit.pcap",
@@ -309,14 +328,16 @@ class Test(BaseTest):
 
         self.render_config_template(
             http_send_all_headers=True,
-            include_fields={
-                "fields": ["http"],
-                "condition": """
-                and:
-                    - equals.type: http
-                    - equals.http.code: 200
-                """
-            },
+            processors=[{
+                "include_fields": {
+                    "fields": ["http"],
+                    "when": """
+                    and:
+                      - equals.type: http
+                      - equals.http.code: 200
+                    """
+                },
+            }]
         )
 
         self.run_packetbeat(pcap="http_minitwit.pcap",
@@ -334,13 +355,15 @@ class Test(BaseTest):
 
         self.render_config_template(
             http_send_all_headers=True,
-            drop_event={
-                "condition": """
-                or:
-                    - equals.http.code: 404
-                    - equals.http.code: 200
-                """
-            },
+            processors=[{
+                "drop_event": {
+                    "when": """
+                      or:
+                        - equals.http.code: 404
+                        - equals.http.code: 200
+                    """
+                },
+            }]
         )
 
         self.run_packetbeat(pcap="http_minitwit.pcap",
@@ -356,9 +379,11 @@ class Test(BaseTest):
 
         self.render_config_template(
             http_send_all_headers=True,
-            drop_event={
-                "condition": "not.equals.http.code: 200",
-            },
+            processors=[{
+                "drop_event": {
+                    "when.not": "equals.http.code: 200",
+                },
+            }]
         )
 
         self.run_packetbeat(pcap="http_minitwit.pcap",


### PR DESCRIPTION
processor registry automatically adds conditional support to registered actions
by wrapping processor constructors with NewConditional.

With this PR every processor action being registered automatically gains support for the `when`-conditional clause without having to any any extra code. This simplifies existing processor actions code, by requiring actions to implement only the required actions instead of check, parsing, applying conditional configurations. Plus it ensures conditionals always work exactly the same for all available actions.