### PR TITLE
Enhancements in system module

### DIFF
--- a/metricbeat/beater/event.go
+++ b/metricbeat/beater/event.go
@@ -8,10 +8,6 @@ import (
 	"github.com/elastic/beats/libbeat/processors"
 )
 
-const (
-	defaultType = "metricsets"
-)
-
 // eventBuilder is used for building MetricSet events. MetricSets generate a
 // data in the form of a common.MapStr. This builder transforms that data into
 // a complete event and applies any Module-level filtering.
@@ -38,7 +34,7 @@ func (b eventBuilder) build() (common.MapStr, error) {
 
 	// Get and remove meta fields from the event created by the MetricSet.
 	indexName := getIndex(event, "")
-	typeName := getType(event, defaultType)
+	typeName := getType(event, b.moduleName+"."+b.metricSetName)
 	timestamp := getTimestamp(event, common.Time(b.startTime))
 
 	// Apply filters.
@@ -51,9 +47,7 @@ func (b eventBuilder) build() (common.MapStr, error) {
 		"type":       typeName,
 
 		common.EventMetadataKey: b.metadata,
-		b.moduleName: common.MapStr{
-			b.metricSetName: event,
-		},
+		b.moduleName:            event,
 		"metricset": common.MapStr{
 			"module": b.moduleName,
 			"name":   b.metricSetName,

--- a/metricbeat/beater/event_test.go
+++ b/metricbeat/beater/event_test.go
@@ -45,7 +45,7 @@ func TestEventBuilder(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assert.Equal(t, defaultType, event["type"])
+	assert.Equal(t, moduleName+"."+metricSetName, event["type"])
 	assert.Equal(t, common.Time(startTime), event["@timestamp"])
 
 	metricset := event["metricset"].(common.MapStr)
@@ -53,7 +53,7 @@ func TestEventBuilder(t *testing.T) {
 	assert.Equal(t, metricSetName, metricset["name"])
 	assert.Equal(t, int64(500000), metricset["rtt"])
 	assert.Equal(t, host, metricset["host"])
-	assert.Equal(t, common.MapStr{}, event[moduleName].(common.MapStr)[metricSetName])
+	assert.Equal(t, common.MapStr{}, event[moduleName])
 	assert.Nil(t, event["error"])
 }
 

--- a/metricbeat/beater/example_test.go
+++ b/metricbeat/beater/example_test.go
@@ -77,7 +77,7 @@ func ExampleModuleWrapper() {
 	//     "name": "status",
 	//     "rtt": 111
 	//   },
-	//   "type": "metricsets"
+	//   "type": "fake.status"
 	// }
 }
 

--- a/metricbeat/beater/module_test.go
+++ b/metricbeat/beater/module_test.go
@@ -32,7 +32,7 @@ type fakeMetricSet struct {
 
 func (ms *fakeMetricSet) Fetch() (common.MapStr, error) {
 	t, _ := time.Parse(time.RFC3339, "2016-05-10T23:27:58.485Z")
-	return common.MapStr{"@timestamp": common.Time(t), "metric": 1}, nil
+	return common.MapStr{"@timestamp": common.Time(t), metricSetName: common.MapStr{"metric": 1}}, nil
 }
 
 func newFakeMetricSet(base mb.BaseMetricSet) (mb.MetricSet, error) {

--- a/metricbeat/docs/fields.asciidoc
+++ b/metricbeat/docs/fields.asciidoc
@@ -2167,7 +2167,7 @@ Load averages.
 
 
 [float]
-=== system.cpu.load.1
+=== system.load.1
 
 type: half_float
 
@@ -2175,7 +2175,7 @@ Load average for the last minute.
 
 
 [float]
-=== system.cpu.load.5
+=== system.load.5
 
 type: half_float
 
@@ -2183,7 +2183,7 @@ Load average for the last 5 minutes.
 
 
 [float]
-=== system.cpu.load.15
+=== system.load.15
 
 type: half_float
 
@@ -2279,7 +2279,7 @@ The total number of of milliseconds spent doing I/Os.
 
 
 [float]
-=== system.filesystem.avail
+=== system.filesystem.available
 
 type: long
 
@@ -2404,8 +2404,7 @@ Total space (used plus free).
 [float]
 == memory Fields
 
-`memory` contains local memory stats.
-
+This group contains statistics related to the virtual memory usage on the system.
 
 
 [float]
@@ -2425,14 +2424,6 @@ Used memory.
 
 
 [float]
-=== system.memory.free
-
-type: long
-
-Available memory.
-
-
-[float]
 === system.memory.used.pct
 
 type: half_float
@@ -2441,34 +2432,59 @@ The percentage of used memory.
 
 
 [float]
-== actual Fields
-
-Actual memory fields.
-
-
-
-[float]
-=== system.memory.actual.used.bytes
+=== system.memory.free
 
 type: long
 
-Actual used memory. This value is the "used" memory minus the memory used for disk caches and buffers. Available only on Unix.
+Free memory. For a human readable value use Available.
 
 
 [float]
-=== system.memory.actual.free
+=== system.memory.available
 
 type: long
 
-Actual available memory. This value is the "free" memory plus the memory used for disk caches and buffers. Available only on Unix.
+Available memory is what it matters. It is calculated based on the OS. On Linux it is a sum of free memory and caches and buffers. On OSX consists of free and inactive memory.
 
 
 [float]
-=== system.memory.actual.used.pct
+=== system.memory.active
 
-type: half_float
+type: long
 
-The percentage of actual used memory.
+Specific for OSX/BSD systems. 
+
+
+[float]
+=== system.memory.inactive
+
+type: long
+
+Specific for OSX/BSD systems. 
+
+
+[float]
+=== system.memory.wired
+
+type: long
+
+Specific for OSX/BSD systems. 
+
+
+[float]
+=== system.memory.buffers
+
+type: long
+
+Specific for Linux systems. 
+
+
+[float]
+=== system.memory.cached
+
+type: long
+
+Specific for Linux systems. 
 
 
 [float]
@@ -2478,7 +2494,7 @@ This group contains statistics related to the swap memory usage on the system.
 
 
 [float]
-=== system.memory.swap.total
+=== system.swap.total
 
 type: long
 
@@ -2486,7 +2502,7 @@ Total swap memory.
 
 
 [float]
-=== system.memory.swap.used.bytes
+=== system.swap.used.bytes
 
 type: long
 
@@ -2494,19 +2510,35 @@ Used swap memory.
 
 
 [float]
-=== system.memory.swap.free
-
-type: long
-
-Available swap memory.
-
-
-[float]
-=== system.memory.swap.used.pct
+=== system.swap.used.pct
 
 type: half_float
 
 The percentage of used swap memory.
+
+
+[float]
+=== system.swap.free
+
+type: long
+
+Free swap memory.
+
+
+[float]
+=== system.swap.in
+
+type: long
+
+Swaps-in 
+
+
+[float]
+=== system.swap.out
+
+type: long
+
+Swaps-out 
 
 
 [float]

--- a/metricbeat/etc/fields.yml
+++ b/metricbeat/etc/fields.yml
@@ -1290,23 +1290,23 @@
                 was servicing another processor.
                 Available only on Unix.
 
-            - name: load
-              type: group
+        - name: load
+          type: group
+          description: >
+            Load averages.
+          fields:
+            - name: "1"
+              type: half_float
               description: >
-                Load averages.
-              fields:
-                - name: "1"
-                  type: half_float
-                  description: >
-                    Load average for the last minute.
-                - name: "5"
-                  type: half_float
-                  description: >
-                    Load average for the last 5 minutes.
-                - name: "15"
-                  type: half_float
-                  description: >
-                    Load average for the last 15 minutes.
+                Load average for the last minute.
+            - name: "5"
+              type: half_float
+              description: >
+                Load average for the last 5 minutes.
+            - name: "15"
+              type: half_float
+              description: >
+                Load average for the last 15 minutes.
         - name: diskio
           type: group
           description: >
@@ -1366,7 +1366,7 @@
           description: >
             `filesystem` contains local filesystem stats.
           fields:
-            - name: avail
+            - name: available
               type: long
               description: >
                 The disk space available to an unprivileged user in bytes.
@@ -1434,8 +1434,7 @@
                     Total space (used plus free).
         - name: memory
           type: group
-          description: >
-            `memory` contains local memory stats.
+          description: This group contains statistics related to the virtual memory usage on the system.
           fields:
             - name: total
               type: long
@@ -1447,62 +1446,82 @@
               description: >
                 Used memory.
 
-            - name: free
-              type: long
-              description: >
-                Available memory.
-
             - name: used.pct
               type: half_float
               description: >
                 The percentage of used memory.
 
-            - name: actual
-              type: group
+            - name: free
+              type: long
               description: >
-                Actual memory fields.
-              fields:
-                - name: used.bytes
-                  type: long
-                  description: >
-                    Actual used memory. This value is the "used" memory minus the memory used for disk caches and buffers.
-                    Available only on Unix.
+                Free memory. For a human readable value use Available.
 
-                - name: free
-                  type: long
-                  description: >
-                    Actual available memory. This value is the "free" memory plus the memory used for disk caches and
-                    buffers. Available only on Unix.
+            - name: available
+              type: long
+              description: >
+                Available memory is what it matters. It is calculated based on the OS. On Linux it is a sum of free memory
+                and caches and buffers. On OSX consists of free and inactive memory.
 
-                - name: used.pct
-                  type: half_float
-                  description: >
-                    The percentage of actual used memory.
+            - name: active
+              type: long
+              description: >
+                Specific for OSX/BSD systems. 
 
-            - name: swap
-              type: group
-              prefix: "[float]"
-              description: This group contains statistics related to the swap memory usage on the system.
-              fields:
-                - name: total
-                  type: long
-                  description: >
-                    Total swap memory.
+            - name: inactive
+              type: long
+              description: >
+                Specific for OSX/BSD systems. 
 
-                - name: used.bytes
-                  type: long
-                  description: >
-                    Used swap memory.
+            - name: wired
+              type: long
+              description: >
+                Specific for OSX/BSD systems. 
 
-                - name: free
-                  type: long
-                  description: >
-                    Available swap memory.
+            - name: buffers
+              type: long
+              description: >
+                Specific for Linux systems. 
 
-                - name: used.pct
-                  type: half_float
-                  description: >
-                    The percentage of used swap memory.
+            - name: cached
+              type: long
+              description: >
+                Specific for Linux systems. 
+
+
+        - name: swap
+          type: group
+          description: This group contains statistics related to the swap memory usage on the system.
+          fields:
+            - name: total
+              type: long
+              description: >
+                Total swap memory.
+
+            - name: used.bytes
+              type: long
+              description: >
+                Used swap memory.
+
+            - name: used.pct
+              type: half_float
+              description: >
+                The percentage of used swap memory.
+
+            - name: free
+              type: long
+              description: >
+                Free swap memory.
+
+            - name: in
+              type: long
+              description: >
+                Swaps-in 
+
+            - name: out
+              type: long
+              description: >
+                Swaps-out 
+
         - name: network
           type: group
           description: >

--- a/metricbeat/metricbeat.template-es2x.json
+++ b/metricbeat/metricbeat.template-es2x.json
@@ -1088,19 +1088,6 @@
                     }
                   }
                 },
-                "load": {
-                  "properties": {
-                    "1": {
-                      "type": "float"
-                    },
-                    "15": {
-                      "type": "float"
-                    },
-                    "5": {
-                      "type": "float"
-                    }
-                  }
-                },
                 "nice": {
                   "properties": {
                     "pct": {
@@ -1202,7 +1189,7 @@
             },
             "filesystem": {
               "properties": {
-                "avail": {
+                "available": {
                   "type": "long"
                 },
                 "device_name": {
@@ -1262,47 +1249,38 @@
                 }
               }
             },
+            "load": {
+              "properties": {
+                "1": {
+                  "type": "float"
+                },
+                "15": {
+                  "type": "float"
+                },
+                "5": {
+                  "type": "float"
+                }
+              }
+            },
             "memory": {
               "properties": {
-                "actual": {
-                  "properties": {
-                    "free": {
-                      "type": "long"
-                    },
-                    "used": {
-                      "properties": {
-                        "bytes": {
-                          "type": "long"
-                        },
-                        "pct": {
-                          "type": "float"
-                        }
-                      }
-                    }
-                  }
+                "active": {
+                  "type": "long"
+                },
+                "available": {
+                  "type": "long"
+                },
+                "buffers": {
+                  "type": "long"
+                },
+                "cached": {
+                  "type": "long"
                 },
                 "free": {
                   "type": "long"
                 },
-                "swap": {
-                  "properties": {
-                    "free": {
-                      "type": "long"
-                    },
-                    "total": {
-                      "type": "long"
-                    },
-                    "used": {
-                      "properties": {
-                        "bytes": {
-                          "type": "long"
-                        },
-                        "pct": {
-                          "type": "float"
-                        }
-                      }
-                    }
-                  }
+                "inactive": {
+                  "type": "long"
                 },
                 "total": {
                   "type": "long"
@@ -1316,6 +1294,9 @@
                       "type": "float"
                     }
                   }
+                },
+                "wired": {
+                  "type": "long"
                 }
               }
             },
@@ -1432,6 +1413,32 @@
                   "ignore_above": 1024,
                   "index": "not_analyzed",
                   "type": "string"
+                }
+              }
+            },
+            "swap": {
+              "properties": {
+                "free": {
+                  "type": "long"
+                },
+                "in": {
+                  "type": "long"
+                },
+                "out": {
+                  "type": "long"
+                },
+                "total": {
+                  "type": "long"
+                },
+                "used": {
+                  "properties": {
+                    "bytes": {
+                      "type": "long"
+                    },
+                    "pct": {
+                      "type": "float"
+                    }
+                  }
                 }
               }
             }

--- a/metricbeat/metricbeat.template.json
+++ b/metricbeat/metricbeat.template.json
@@ -1059,19 +1059,6 @@
                     }
                   }
                 },
-                "load": {
-                  "properties": {
-                    "1": {
-                      "type": "half_float"
-                    },
-                    "15": {
-                      "type": "half_float"
-                    },
-                    "5": {
-                      "type": "half_float"
-                    }
-                  }
-                },
                 "nice": {
                   "properties": {
                     "pct": {
@@ -1171,7 +1158,7 @@
             },
             "filesystem": {
               "properties": {
-                "avail": {
+                "available": {
                   "type": "long"
                 },
                 "device_name": {
@@ -1229,47 +1216,38 @@
                 }
               }
             },
+            "load": {
+              "properties": {
+                "1": {
+                  "type": "half_float"
+                },
+                "15": {
+                  "type": "half_float"
+                },
+                "5": {
+                  "type": "half_float"
+                }
+              }
+            },
             "memory": {
               "properties": {
-                "actual": {
-                  "properties": {
-                    "free": {
-                      "type": "long"
-                    },
-                    "used": {
-                      "properties": {
-                        "bytes": {
-                          "type": "long"
-                        },
-                        "pct": {
-                          "type": "half_float"
-                        }
-                      }
-                    }
-                  }
+                "active": {
+                  "type": "long"
+                },
+                "available": {
+                  "type": "long"
+                },
+                "buffers": {
+                  "type": "long"
+                },
+                "cached": {
+                  "type": "long"
                 },
                 "free": {
                   "type": "long"
                 },
-                "swap": {
-                  "properties": {
-                    "free": {
-                      "type": "long"
-                    },
-                    "total": {
-                      "type": "long"
-                    },
-                    "used": {
-                      "properties": {
-                        "bytes": {
-                          "type": "long"
-                        },
-                        "pct": {
-                          "type": "half_float"
-                        }
-                      }
-                    }
-                  }
+                "inactive": {
+                  "type": "long"
                 },
                 "total": {
                   "type": "long"
@@ -1283,6 +1261,9 @@
                       "type": "half_float"
                     }
                   }
+                },
+                "wired": {
+                  "type": "long"
                 }
               }
             },
@@ -1393,6 +1374,32 @@
                 "username": {
                   "ignore_above": 1024,
                   "type": "keyword"
+                }
+              }
+            },
+            "swap": {
+              "properties": {
+                "free": {
+                  "type": "long"
+                },
+                "in": {
+                  "type": "long"
+                },
+                "out": {
+                  "type": "long"
+                },
+                "total": {
+                  "type": "long"
+                },
+                "used": {
+                  "properties": {
+                    "bytes": {
+                      "type": "long"
+                    },
+                    "pct": {
+                      "type": "half_float"
+                    }
+                  }
                 }
               }
             }

--- a/metricbeat/module/system/core/core.go
+++ b/metricbeat/module/system/core/core.go
@@ -54,7 +54,7 @@ func (m *MetricSet) Fetch() ([]common.MapStr, error) {
 
 	m.cpu.AddCpuPercentageList(cpuCoreStat)
 
-	cores := []common.MapStr{}
+	events := []common.MapStr{}
 
 	for core, stat := range cpuCoreStat {
 
@@ -97,8 +97,11 @@ func (m *MetricSet) Fetch() ([]common.MapStr, error) {
 		}
 
 		coreStat["id"] = core
-		cores = append(cores, coreStat)
+		event := common.MapStr{
+			"core": coreStat,
+		}
+		events = append(events, event)
 	}
 
-	return cores, nil
+	return events, nil
 }

--- a/metricbeat/module/system/cpu/_meta/fields.yml
+++ b/metricbeat/module/system/cpu/_meta/fields.yml
@@ -88,20 +88,20 @@
         was servicing another processor.
         Available only on Unix.
 
-    - name: load
-      type: group
+- name: load
+  type: group
+  description: >
+    Load averages.
+  fields:
+    - name: "1"
+      type: half_float
       description: >
-        Load averages.
-      fields:
-        - name: "1"
-          type: half_float
-          description: >
-            Load average for the last minute.
-        - name: "5"
-          type: half_float
-          description: >
-            Load average for the last 5 minutes.
-        - name: "15"
-          type: half_float
-          description: >
-            Load average for the last 15 minutes.
+        Load average for the last minute.
+    - name: "5"
+      type: half_float
+      description: >
+        Load average for the last 5 minutes.
+    - name: "15"
+      type: half_float
+      description: >
+        Load average for the last 15 minutes.

--- a/metricbeat/module/system/cpu/cpu.go
+++ b/metricbeat/module/system/cpu/cpu.go
@@ -94,11 +94,14 @@ func (m *MetricSet) Fetch() (common.MapStr, error) {
 		cpuStat["steal"].(common.MapStr)["ticks"] = stat.Stolen
 	}
 
-	cpuStat["load"] = common.MapStr{
-		"1":  loadStat.Load1,
-		"5":  loadStat.Load5,
-		"15": loadStat.Load15,
+	event := common.MapStr{
+		"load": common.MapStr{
+			"1":  loadStat.Load1,
+			"5":  loadStat.Load5,
+			"15": loadStat.Load15,
+		},
+		"cpu": cpuStat,
 	}
 
-	return cpuStat, nil
+	return event, nil
 }

--- a/metricbeat/module/system/diskio/diskio.go
+++ b/metricbeat/module/system/diskio/diskio.go
@@ -35,7 +35,7 @@ func (m *MetricSet) Fetch() ([]common.MapStr, error) {
 
 	events := make([]common.MapStr, 0, len(stats))
 	for _, counters := range stats {
-		event := common.MapStr{
+		diskio := common.MapStr{
 			"name": counters.Name,
 			"read": common.MapStr{
 				"count": counters.ReadCount,
@@ -51,11 +51,15 @@ func (m *MetricSet) Fetch() ([]common.MapStr, error) {
 				"time": counters.IoTime,
 			},
 		}
+		if counters.SerialNumber != "" {
+			diskio["serial_number"] = counters.SerialNumber
+		}
+
+		event := common.MapStr{
+			"diskio": diskio,
+		}
 		events = append(events, event)
 
-		if counters.SerialNumber != "" {
-			event["serial_number"] = counters.SerialNumber
-		}
 	}
 
 	return events, nil

--- a/metricbeat/module/system/filesystem/_meta/fields.yml
+++ b/metricbeat/module/system/filesystem/_meta/fields.yml
@@ -3,7 +3,7 @@
   description: >
     `filesystem` contains local filesystem stats.
   fields:
-    - name: avail
+    - name: available
       type: long
       description: >
         The disk space available to an unprivileged user in bytes.

--- a/metricbeat/module/system/filesystem/filesystem.go
+++ b/metricbeat/module/system/filesystem/filesystem.go
@@ -38,7 +38,7 @@ func (m *MetricSet) Fetch() ([]common.MapStr, error) {
 		return nil, errors.Wrap(err, "filesystem list")
 	}
 
-	filesSystems := make([]common.MapStr, 0, len(fss))
+	events := make([]common.MapStr, 0, len(fss))
 	for _, fs := range fss {
 		fsStat, err := GetFileSystemStat(fs)
 		if err != nil {
@@ -46,8 +46,12 @@ func (m *MetricSet) Fetch() ([]common.MapStr, error) {
 			continue
 		}
 		AddFileSystemUsedPercentage(fsStat)
-		filesSystems = append(filesSystems, GetFilesystemEvent(fsStat))
+
+		event := common.MapStr{
+			"filesystem": GetFilesystemEvent(fsStat),
+		}
+		events = append(events, event)
 	}
 
-	return filesSystems, nil
+	return events, nil
 }

--- a/metricbeat/module/system/filesystem/helper.go
+++ b/metricbeat/module/system/filesystem/helper.go
@@ -82,7 +82,7 @@ func GetFilesystemEvent(fsStat *FileSystemStat) common.MapStr {
 		"mount_point": fsStat.Mount,
 		"total":       fsStat.Total,
 		"free":        fsStat.Free,
-		"avail":       fsStat.Avail,
+		"available":   fsStat.Avail,
 		"files":       fsStat.Files,
 		"free_files":  fsStat.FreeFiles,
 		"used": common.MapStr{

--- a/metricbeat/module/system/fsstat/fsstat.go
+++ b/metricbeat/module/system/fsstat/fsstat.go
@@ -56,12 +56,13 @@ func (m *MetricSet) Fetch() (common.MapStr, error) {
 	}
 
 	return common.MapStr{
-		"total_size": common.MapStr{
-			"free":  totalSizeFree,
-			"used":  totalSizeUsed,
-			"total": totalSize,
-		},
-		"count":       len(fss),
-		"total_files": totalFiles,
-	}, nil
+		"fsstat": common.MapStr{
+			"total_size": common.MapStr{
+				"free":  totalSizeFree,
+				"used":  totalSizeUsed,
+				"total": totalSize,
+			},
+			"count":       len(fss),
+			"total_files": totalFiles,
+		}}, nil
 }

--- a/metricbeat/module/system/memory/_meta/fields.yml
+++ b/metricbeat/module/system/memory/_meta/fields.yml
@@ -1,7 +1,6 @@
 - name: memory
   type: group
-  description: >
-    `memory` contains local memory stats.
+  description: This group contains statistics related to the virtual memory usage on the system.
   fields:
     - name: total
       type: long
@@ -13,59 +12,79 @@
       description: >
         Used memory.
 
-    - name: free
-      type: long
-      description: >
-        Available memory.
-
     - name: used.pct
       type: half_float
       description: >
         The percentage of used memory.
 
-    - name: actual
-      type: group
+    - name: free
+      type: long
       description: >
-        Actual memory fields.
-      fields:
-        - name: used.bytes
-          type: long
-          description: >
-            Actual used memory. This value is the "used" memory minus the memory used for disk caches and buffers.
-            Available only on Unix.
+        Free memory. For a human readable value use Available.
 
-        - name: free
-          type: long
-          description: >
-            Actual available memory. This value is the "free" memory plus the memory used for disk caches and
-            buffers. Available only on Unix.
+    - name: available
+      type: long
+      description: >
+        Available memory is what it matters. It is calculated based on the OS. On Linux it is a sum of free memory
+        and caches and buffers. On OSX consists of free and inactive memory.
 
-        - name: used.pct
-          type: half_float
-          description: >
-            The percentage of actual used memory.
+    - name: active
+      type: long
+      description: >
+        Specific for OSX/BSD systems. 
 
-    - name: swap
-      type: group
-      prefix: "[float]"
-      description: This group contains statistics related to the swap memory usage on the system.
-      fields:
-        - name: total
-          type: long
-          description: >
-            Total swap memory.
+    - name: inactive
+      type: long
+      description: >
+        Specific for OSX/BSD systems. 
 
-        - name: used.bytes
-          type: long
-          description: >
-            Used swap memory.
+    - name: wired
+      type: long
+      description: >
+        Specific for OSX/BSD systems. 
 
-        - name: free
-          type: long
-          description: >
-            Available swap memory.
+    - name: buffers
+      type: long
+      description: >
+        Specific for Linux systems. 
 
-        - name: used.pct
-          type: half_float
-          description: >
-            The percentage of used swap memory.
+    - name: cached
+      type: long
+      description: >
+        Specific for Linux systems. 
+
+
+- name: swap
+  type: group
+  description: This group contains statistics related to the swap memory usage on the system.
+  fields:
+    - name: total
+      type: long
+      description: >
+        Total swap memory.
+
+    - name: used.bytes
+      type: long
+      description: >
+        Used swap memory.
+
+    - name: used.pct
+      type: half_float
+      description: >
+        The percentage of used swap memory.
+
+    - name: free
+      type: long
+      description: >
+        Free swap memory.
+
+    - name: in
+      type: long
+      description: >
+        Swaps-in 
+
+    - name: out
+      type: long
+      description: >
+        Swaps-out 
+

--- a/metricbeat/module/system/memory/memory.go
+++ b/metricbeat/module/system/memory/memory.go
@@ -7,6 +7,8 @@ package memory
 import (
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/metricbeat/mb"
+	"github.com/elastic/beats/metricbeat/module/system"
+	"github.com/shirou/gopsutil/mem"
 
 	"github.com/pkg/errors"
 )
@@ -28,44 +30,60 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 }
 
 // Fetch fetches memory metrics from the OS.
-func (m *MetricSet) Fetch() (event common.MapStr, err error) {
-	memStat, err := GetMemory()
+func (m *MetricSet) Fetch() (common.MapStr, error) {
+
+	memStat, err := mem.VirtualMemory()
 	if err != nil {
 		return nil, errors.Wrap(err, "memory")
 	}
-	AddMemPercentage(memStat)
 
-	swapStat, err := GetSwap()
+	swapStat, err := mem.SwapMemory()
 	if err != nil {
 		return nil, errors.Wrap(err, "swap")
 	}
-	AddSwapPercentage(swapStat)
 
 	memory := common.MapStr{
 		"total": memStat.Total,
 		"used": common.MapStr{
 			"bytes": memStat.Used,
-			"pct":   memStat.UsedPercent,
+			"pct":   system.Round(memStat.UsedPercent/100, .5, 4),
 		},
-		"free": memStat.Free,
-		"actual": common.MapStr{
-			"free": memStat.ActualFree,
-			"used": common.MapStr{
-				"pct":   memStat.ActualUsedPercent,
-				"bytes": memStat.ActualUsed,
-			},
-		},
+		"free":      memStat.Free,
+		"available": memStat.Available,
+	}
+	// OSX /BSD specific
+	if memStat.Active != 0 {
+		memory["active"] = memStat.Active
+	}
+	if memStat.Inactive != 0 {
+		memory["inactive"] = memStat.Inactive
+	}
+	if memStat.Wired != 0 {
+		memory["wired"] = memStat.Wired
+	}
+
+	// Linux specific
+	if memStat.Buffers != 0 {
+		memory["buffers"] = memStat.Buffers
+	}
+	if memStat.Cached != 0 {
+		memory["cached"] = memStat.Cached
 	}
 
 	swap := common.MapStr{
 		"total": swapStat.Total,
 		"used": common.MapStr{
 			"bytes": swapStat.Used,
-			"pct":   swapStat.UsedPercent,
+			"pct":   system.Round(swapStat.UsedPercent/100, .5, 4),
 		},
 		"free": swapStat.Free,
+		"in":   swapStat.Sin,
+		"out":  swapStat.Sout,
 	}
 
-	memory["swap"] = swap
-	return memory, nil
+	event := common.MapStr{
+		"memory": memory,
+		"swap":   swap,
+	}
+	return event, nil
 }

--- a/metricbeat/module/system/network/network.go
+++ b/metricbeat/module/system/network/network.go
@@ -82,18 +82,20 @@ func (m *MetricSet) Fetch() ([]common.MapStr, error) {
 
 func ioCountersToMapStr(counters net.IOCountersStat) common.MapStr {
 	return common.MapStr{
-		"name": counters.Name,
-		"in": common.MapStr{
-			"errors":  counters.Errin,
-			"dropped": counters.Dropin,
-			"bytes":   counters.BytesRecv,
-			"packets": counters.PacketsRecv,
-		},
-		"out": common.MapStr{
-			"errors":  counters.Errout,
-			"dropped": counters.Dropout,
-			"packets": counters.PacketsSent,
-			"bytes":   counters.BytesSent,
+		"network": common.MapStr{
+			"name": counters.Name,
+			"in": common.MapStr{
+				"errors":  counters.Errin,
+				"dropped": counters.Dropin,
+				"bytes":   counters.BytesRecv,
+				"packets": counters.PacketsRecv,
+			},
+			"out": common.MapStr{
+				"errors":  counters.Errout,
+				"dropped": counters.Dropout,
+				"packets": counters.PacketsSent,
+				"bytes":   counters.BytesSent,
+			},
 		},
 	}
 }

--- a/metricbeat/module/system/process/helper.go
+++ b/metricbeat/module/system/process/helper.go
@@ -168,7 +168,9 @@ func (procStats *ProcStats) GetProcessEvent(process *Process, last *Process) com
 		}
 	}
 
-	return proc
+	return common.MapStr{
+		"process": proc,
+	}
 }
 
 func GetProcCpuPercentage(last *Process, current *Process) float64 {

--- a/metricbeat/tests/system/metricbeat.py
+++ b/metricbeat/tests/system/metricbeat.py
@@ -47,3 +47,8 @@ class BaseTest(TestCase):
                 fields[key] = self.de_dot(fields[key])
 
         return fields
+
+    def assertOptionalItemsEqual(self, items, fields):
+        for field in fields:
+            if field not in items:
+                raise Exception("Field '{}' not expected".format(field))


### PR DESCRIPTION
This PR is a proposal and includes couple of changes:
- set `type` to `<module>.<metricset>` to be easier to define searches in Kibana
- allow the metricset to define what groups of fields is adding instead of placing all metrics under the `system.<meticSet>. For example: for `system.memory`, `mem` and `swap` information are added (move one level up the swap information).
- use gopsutil (instead of gosigar) to get memory statistics and export more information like `memory.available` instead of `actual`, for OSX/BSD (`memory.active`, `memory.inactive`, `memory.wired`), for Linux (`memory.buffers`, `memory.cached`). In addition `swap.in` and `swap.out` are exported.


This PR comes with a few breaking changes:
- `system.cpu.load` -> `system.load`
- `system.memory.swap` -> `system.swap`
- `filesystem.avail` -> `filesystem.available`
- `type: metricsets` -> `type: <module>.<metricSet>`

Things that need to be updated:
- [ ] docs
- [ ] update the `Fetch()` function of the other modules (except system) to export the group of fields as they are added to event. For example an event returned by `Fetch` should contain `memory`: { "total": x, ...} instead of {"total": x, ...}

Here is an example of the JSON object exported by the new version:
```
{
  "@timestamp": "2016-07-19T22:17:44.304Z",
  "beat": {
    "hostname": "mar.local",
    "name": "mar.local"
  },
  "metricset": {
    "module": "system",
    "name": "memory",
    "rtt": 6427
  },
  "system": {
    "memory": {
      "active": 5930377216,
      "available": 5852270592,
      "free": 359858176,
      "inactive": 5492412416,
      "total": 17179869184,
      "used": {
        "bytes": 11327598592,
        "pct": 0.6594
      },
      "wired": 3681193984
    },
    "swap": {
      "free": 559750,
      "in": 0,
      "out": 0,
      "total": 6144000,
      "used": {
        "bytes": 5584250,
        "pct": 0.9089
      }
    }
  },
  "type": "system.memory"
}
```

