### PR TITLE
Only cleanup state if harvester finished

### DIFF
--- a/filebeat/input/file/state.go
+++ b/filebeat/input/file/state.go
@@ -98,11 +98,18 @@ func (s *States) Cleanup() {
 	states := s.states[:0]
 
 	for _, state := range s.states {
+
 		ttl := state.TTL
+
 		if ttl == 0 || (ttl > 0 && currentTime.Sub(state.Timestamp) > ttl) {
-			logp.Debug("state", "State removed for %v because of older: %v", state.Source, ttl)
-			continue // drop state
+			if state.Finished {
+				logp.Debug("state", "State removed for %v because of older: %v", state.Source, ttl)
+				continue // drop state
+			} else {
+				logp.Err("State for %s should have been dropped, but couldn't as state is not finished.", state.Source)
+			}
 		}
+
 		states = append(states, state) // in-place copy old state
 	}
 	s.states = states


### PR DESCRIPTION
Currently it was possible, that a state was cleaned up also if a harvester was not finished yet. Now a state will not be cleaned up as long as a harvester is still running.