### PR TITLE
Make format string thread safe

### DIFF
--- a/libbeat/common/fmtstr/formatstring_test.go
+++ b/libbeat/common/fmtstr/formatstring_test.go
@@ -123,7 +123,7 @@ func TestFormatString(t *testing.T) {
 		}
 
 		// run string formatter
-		actual, err := sf.Run()
+		actual, err := sf.Run(nil)
 
 		// test validation
 		if test.dyn == nil {


### PR DESCRIPTION
Do not store evaluation context in formatter, but allocate context via
shared sync.Pool.