### PR TITLE
Harvester Cleanup and FileEvent

### DIFF
--- a/filebeat/beater/filebeat.go
+++ b/filebeat/beater/filebeat.go
@@ -51,7 +51,7 @@ func (fb *Filebeat) Run(b *beat.Beat) error {
 	}
 
 	// Channel from harvesters to spooler
-	publisherChan := make(chan []*input.FileEvent, 1)
+	publisherChan := make(chan []*input.Event, 1)
 
 	// Publishes event to output
 	publisher := publish.New(config.PublishAsync,

--- a/filebeat/harvester/harvester.go
+++ b/filebeat/harvester/harvester.go
@@ -27,7 +27,7 @@ import (
 type Harvester struct {
 	config          harvesterConfig
 	state           file.State
-	prospectorChan  chan *input.FileEvent
+	prospectorChan  chan *input.Event
 	file            source.FileSource /* the file being watched */
 	done            chan struct{}
 	encodingFactory encoding.EncodingFactory
@@ -37,7 +37,7 @@ type Harvester struct {
 func NewHarvester(
 	cfg *common.Config,
 	state file.State,
-	prospectorChan chan *input.FileEvent,
+	prospectorChan chan *input.Event,
 	done chan struct{},
 ) (*Harvester, error) {
 

--- a/filebeat/harvester/log_test.go
+++ b/filebeat/harvester/log_test.go
@@ -77,7 +77,7 @@ func TestReadLine(t *testing.T) {
 	h.encoding, err = h.encodingFactory(readFile)
 	assert.NoError(t, err)
 
-	r, err := h.newLineReader()
+	r, err := h.newLogFileReader()
 	assert.NoError(t, err)
 
 	// Read third line

--- a/filebeat/input/event.go
+++ b/filebeat/input/event.go
@@ -2,7 +2,6 @@ package input
 
 import (
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/elastic/beats/filebeat/harvester/reader"
@@ -11,34 +10,31 @@ import (
 	"github.com/elastic/beats/libbeat/logp"
 )
 
-// FileEvent is sent to the output and must contain all relevant information
-type FileEvent struct {
+// Event is sent to the output and must contain all relevant information
+type Event struct {
 	common.EventMetadata
 	ReadTime     time.Time
-	Source       string
 	InputType    string
 	DocumentType string
-	Offset       int64
 	Bytes        int
 	Text         *string
-	Fileinfo     os.FileInfo
 	JSONFields   common.MapStr
 	JSONConfig   *reader.JSONConfig
 	State        file.State
 }
 
-func NewEvent(state file.State) *FileEvent {
-	return &FileEvent{
+func NewEvent(state file.State) *Event {
+	return &Event{
 		State: state,
 	}
 }
 
-func (f *FileEvent) ToMapStr() common.MapStr {
+func (f *Event) ToMapStr() common.MapStr {
 	event := common.MapStr{
 		common.EventMetadataKey: f.EventMetadata,
 		"@timestamp":            common.Time(f.ReadTime),
-		"source":                f.Source,
-		"offset":                f.Offset, // Offset here is the offset before the starting char.
+		"source":                f.State.Source,
+		"offset":                f.State.Offset, // Offset here is the offset before the starting char.
 		"type":                  f.DocumentType,
 		"input_type":            f.InputType,
 	}
@@ -56,7 +52,7 @@ func (f *FileEvent) ToMapStr() common.MapStr {
 // respecting the KeysUnderRoot and OverwriteKeys configuration options.
 // If MessageKey is defined, the Text value from the event always
 // takes precedence.
-func mergeJSONFields(f *FileEvent, event common.MapStr) {
+func mergeJSONFields(f *Event, event common.MapStr) {
 
 	// The message key might have been modified by multiline
 	if len(f.JSONConfig.MessageKey) > 0 && f.Text != nil {

--- a/filebeat/input/event_test.go
+++ b/filebeat/input/event_test.go
@@ -9,17 +9,17 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestFileEventToMapStr(t *testing.T) {
+func TestEventToMapStr(t *testing.T) {
 	// Test 'fields' is not present when it is nil.
-	event := FileEvent{}
+	event := Event{}
 	mapStr := event.ToMapStr()
 	_, found := mapStr["fields"]
 	assert.False(t, found)
 }
 
-func TestFileEventToMapStrJSON(t *testing.T) {
+func TestEventToMapStrJSON(t *testing.T) {
 	type io struct {
-		Event         FileEvent
+		Event         Event
 		ExpectedItems common.MapStr
 	}
 
@@ -30,7 +30,7 @@ func TestFileEventToMapStrJSON(t *testing.T) {
 	tests := []io{
 		{
 			// by default, don't overwrite keys
-			Event: FileEvent{
+			Event: Event{
 				DocumentType: "test_type",
 				Text:         &text,
 				JSONFields:   common.MapStr{"type": "test", "text": "hello"},
@@ -43,7 +43,7 @@ func TestFileEventToMapStrJSON(t *testing.T) {
 		},
 		{
 			// overwrite keys if asked
-			Event: FileEvent{
+			Event: Event{
 				DocumentType: "test_type",
 				Text:         &text,
 				JSONFields:   common.MapStr{"type": "test", "text": "hello"},
@@ -56,7 +56,7 @@ func TestFileEventToMapStrJSON(t *testing.T) {
 		},
 		{
 			// without keys_under_root, put everything in a json key
-			Event: FileEvent{
+			Event: Event{
 				DocumentType: "test_type",
 				Text:         &text,
 				JSONFields:   common.MapStr{"type": "test", "text": "hello"},
@@ -69,7 +69,7 @@ func TestFileEventToMapStrJSON(t *testing.T) {
 		},
 		{
 			// when MessageKey is defined, the Text overwrites the value of that key
-			Event: FileEvent{
+			Event: Event{
 				DocumentType: "test_type",
 				Text:         &text,
 				JSONFields:   common.MapStr{"type": "test", "text": "hi"},
@@ -83,7 +83,7 @@ func TestFileEventToMapStrJSON(t *testing.T) {
 		{
 			// when @timestamp is in JSON and overwrite_keys is true, parse it
 			// in a common.Time
-			Event: FileEvent{
+			Event: Event{
 				ReadTime:     now,
 				DocumentType: "test_type",
 				Text:         &text,
@@ -98,7 +98,7 @@ func TestFileEventToMapStrJSON(t *testing.T) {
 		{
 			// when the parsing on @timestamp fails, leave the existing value and add an error key
 			// in a common.Time
-			Event: FileEvent{
+			Event: Event{
 				ReadTime:     now,
 				DocumentType: "test_type",
 				Text:         &text,
@@ -114,7 +114,7 @@ func TestFileEventToMapStrJSON(t *testing.T) {
 		{
 			// when the @timestamp has the wrong type, leave the existing value and add an error key
 			// in a common.Time
-			Event: FileEvent{
+			Event: Event{
 				ReadTime:     now,
 				DocumentType: "test_type",
 				Text:         &text,
@@ -129,7 +129,7 @@ func TestFileEventToMapStrJSON(t *testing.T) {
 		},
 		{
 			// if overwrite_keys is true, but the `type` key in json is not a string, ignore it
-			Event: FileEvent{
+			Event: Event{
 				DocumentType: "test_type",
 				Text:         &text,
 				JSONFields:   common.MapStr{"type": 42},
@@ -142,7 +142,7 @@ func TestFileEventToMapStrJSON(t *testing.T) {
 		},
 		{
 			// if overwrite_keys is true, but the `type` key in json is empty, ignore it
-			Event: FileEvent{
+			Event: Event{
 				DocumentType: "test_type",
 				Text:         &text,
 				JSONFields:   common.MapStr{"type": ""},
@@ -155,7 +155,7 @@ func TestFileEventToMapStrJSON(t *testing.T) {
 		},
 		{
 			// if overwrite_keys is true, but the `type` key in json starts with _, ignore it
-			Event: FileEvent{
+			Event: Event{
 				DocumentType: "test_type",
 				Text:         &text,
 				JSONFields:   common.MapStr{"type": "_type"},

--- a/filebeat/prospector/prospector.go
+++ b/filebeat/prospector/prospector.go
@@ -17,8 +17,8 @@ type Prospector struct {
 	cfg           *common.Config // Raw config
 	config        prospectorConfig
 	prospectorer  Prospectorer
-	spoolerChan   chan *input.FileEvent
-	harvesterChan chan *input.FileEvent
+	spoolerChan   chan *input.Event
+	harvesterChan chan *input.Event
 	done          chan struct{}
 	states        *file.States
 	wg            sync.WaitGroup
@@ -29,12 +29,12 @@ type Prospectorer interface {
 	Run()
 }
 
-func NewProspector(cfg *common.Config, states file.States, spoolerChan chan *input.FileEvent) (*Prospector, error) {
+func NewProspector(cfg *common.Config, states file.States, spoolerChan chan *input.Event) (*Prospector, error) {
 	prospector := &Prospector{
 		cfg:           cfg,
 		config:        defaultConfig,
 		spoolerChan:   spoolerChan,
-		harvesterChan: make(chan *input.FileEvent),
+		harvesterChan: make(chan *input.Event),
 		done:          make(chan struct{}),
 		states:        states.Copy(),
 		wg:            sync.WaitGroup{},

--- a/filebeat/publish/publish.go
+++ b/filebeat/publish/publish.go
@@ -20,7 +20,7 @@ type LogPublisher interface {
 type syncLogPublisher struct {
 	pub     publisher.Publisher
 	client  publisher.Client
-	in, out chan []*input.FileEvent
+	in, out chan []*input.Event
 
 	done chan struct{}
 	wg   sync.WaitGroup
@@ -29,7 +29,7 @@ type syncLogPublisher struct {
 type asyncLogPublisher struct {
 	pub     publisher.Publisher
 	client  publisher.Client
-	in, out chan []*input.FileEvent
+	in, out chan []*input.Event
 
 	// list of in-flight batches
 	active   batchList
@@ -44,7 +44,7 @@ type asyncLogPublisher struct {
 type eventsBatch struct {
 	next   *eventsBatch
 	flag   int32
-	events []*input.FileEvent
+	events []*input.Event
 }
 
 type batchList struct {
@@ -70,7 +70,7 @@ var (
 
 func New(
 	async bool,
-	in, out chan []*input.FileEvent,
+	in, out chan []*input.Event,
 	pub publisher.Publisher,
 ) LogPublisher {
 	if async {
@@ -80,7 +80,7 @@ func New(
 }
 
 func newSyncLogPublisher(
-	in, out chan []*input.FileEvent,
+	in, out chan []*input.Event,
 	pub publisher.Publisher,
 ) *syncLogPublisher {
 	return &syncLogPublisher{
@@ -101,7 +101,7 @@ func (p *syncLogPublisher) Start() {
 		logp.Info("Start sending events to output")
 
 		for {
-			var events []*input.FileEvent
+			var events []*input.Event
 			select {
 			case <-p.done:
 				return
@@ -143,7 +143,7 @@ func (p *syncLogPublisher) Stop() {
 }
 
 func newAsyncLogPublisher(
-	in, out chan []*input.FileEvent,
+	in, out chan []*input.Event,
 	pub publisher.Publisher,
 ) *asyncLogPublisher {
 	return &asyncLogPublisher{

--- a/filebeat/publish/publish_test.go
+++ b/filebeat/publish/publish_test.go
@@ -13,16 +13,14 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func makeEvents(name string, n int) []*input.FileEvent {
-	var events []*input.FileEvent
+func makeEvents(name string, n int) []*input.Event {
+	var events []*input.Event
 	for i := 0; i < n; i++ {
-		event := &input.FileEvent{
+		event := &input.Event{
 			ReadTime:     time.Now(),
 			InputType:    "log",
 			DocumentType: "log",
 			Bytes:        100,
-			Offset:       int64(i),
-			Source:       name,
 		}
 		events = append(events, event)
 	}
@@ -43,14 +41,14 @@ func TestPublisherModes(t *testing.T) {
 	for i, test := range tests {
 		t.Logf("run publisher test (%v): %v", i, test.title)
 
-		pubChan := make(chan []*input.FileEvent, len(test.order)+1)
-		regChan := make(chan []*input.FileEvent, len(test.order)+1)
+		pubChan := make(chan []*input.Event, len(test.order)+1)
+		regChan := make(chan []*input.Event, len(test.order)+1)
 		client := pubtest.NewChanClient(0)
 
 		pub := New(test.async, pubChan, regChan, pubtest.PublisherWithClient(client))
 		pub.Start()
 
-		var events [][]*input.FileEvent
+		var events [][]*input.Event
 		for i := range test.order {
 			tmp := makeEvents(fmt.Sprintf("msg: %v", i), 1)
 			pubChan <- tmp
@@ -67,7 +65,7 @@ func TestPublisherModes(t *testing.T) {
 			op.SigCompleted(msgs[i-1].Context.Signal)
 		}
 
-		var regEvents [][]*input.FileEvent
+		var regEvents [][]*input.Event
 		for _ = range test.order {
 			regEvents = append(regEvents, <-regChan)
 		}

--- a/filebeat/registrar/registrar.go
+++ b/filebeat/registrar/registrar.go
@@ -18,7 +18,7 @@ import (
 )
 
 type Registrar struct {
-	Channel      chan []*FileEvent
+	Channel      chan []*Event
 	done         chan struct{}
 	registryFile string       // Path to the Registry File
 	states       *file.States // Map with all file paths inside and the corresponding state
@@ -36,7 +36,7 @@ func New(registryFile string) (*Registrar, error) {
 		registryFile: registryFile,
 		done:         make(chan struct{}),
 		states:       file.NewStates(),
-		Channel:      make(chan []*FileEvent, 1),
+		Channel:      make(chan []*Event, 1),
 		wg:           sync.WaitGroup{},
 	}
 	err := r.Init()
@@ -197,7 +197,7 @@ func (r *Registrar) Run() {
 }
 
 // processEventStates gets the states from the events and writes them to the registrar state
-func (r *Registrar) processEventStates(events []*FileEvent) {
+func (r *Registrar) processEventStates(events []*Event) {
 	logp.Debug("registrar", "Processing %d events", len(events))
 
 	// Take the last event found for each file source


### PR DESCRIPTION
* Rename FileEvent to Event
* Remove double information between FileEvent and State (Source, Fileinfo)
* Remove readLine function as not needed anymore