### PR TITLE
Filbeat harvester copy

### DIFF
--- a/filebeat/harvester/harvester.go
+++ b/filebeat/harvester/harvester.go
@@ -36,14 +36,12 @@ type Harvester struct {
 
 func NewHarvester(
 	cfg *common.Config,
-	state file.State,
 	prospectorChan chan *input.Event,
 	done chan struct{},
 ) (*Harvester, error) {
 
 	h := &Harvester{
 		config:         defaultConfig,
-		state:          state,
 		prospectorChan: prospectorChan,
 		done:           done,
 	}

--- a/filebeat/harvester/harvester.go
+++ b/filebeat/harvester/harvester.go
@@ -71,3 +71,8 @@ func (h *Harvester) open() error {
 		return fmt.Errorf("Invalid input type")
 	}
 }
+
+func (h *Harvester) Copy() *Harvester {
+	copy := *h
+	return &copy
+}

--- a/filebeat/harvester/log.go
+++ b/filebeat/harvester/log.go
@@ -25,7 +25,7 @@ var (
 )
 
 // Log harvester reads files line by line and sends events to the defined output
-func (h *Harvester) Harvest() {
+func (h *Harvester) Harvest(state file.State) {
 
 	harvesterStarted.Add(1)
 	harvesterRunning.Add(1)
@@ -34,6 +34,7 @@ func (h *Harvester) Harvest() {
 	// Makes sure file is properly closed when the harvester is stopped
 	defer h.close()
 
+	h.state = state
 	h.state.Finished = false
 
 	err := h.open()

--- a/filebeat/prospector/prospector.go
+++ b/filebeat/prospector/prospector.go
@@ -156,7 +156,9 @@ func (p *Prospector) createHarvester() (*harvester.Harvester, error) {
 
 func (p *Prospector) startHarvester(state file.State, offset int64) (*harvester.Harvester, error) {
 	state.Offset = offset
-	h := *p.harvester
+
+	// Create a copy of the harvester
+	h := p.harvester.Copy()
 
 	p.wg.Add(1)
 	go func() {
@@ -165,5 +167,5 @@ func (p *Prospector) startHarvester(state file.State, offset int64) (*harvester.
 		h.Harvest(state)
 	}()
 
-	return &h, nil
+	return h, nil
 }

--- a/filebeat/prospector/prospector_stdin.go
+++ b/filebeat/prospector/prospector_stdin.go
@@ -20,7 +20,7 @@ func NewProspectorStdin(p *Prospector) (*ProspectorStdin, error) {
 
 	var err error
 
-	prospectorer.harvester, err = p.createHarvester(file.State{Source: "-"})
+	prospectorer.harvester, err = p.createHarvester()
 	if err != nil {
 		return nil, fmt.Errorf("Error initializing stdin harvester: %v", err)
 	}
@@ -36,7 +36,7 @@ func (p *ProspectorStdin) Run() {
 
 	// Make sure stdin harvester is only started once
 	if !p.started {
-		go p.harvester.Harvest()
+		go p.harvester.Harvest(file.State{Source: "-"})
 		p.started = true
 	}
 }


### PR DESCRIPTION
Instead of creating a harvester every time a harvester is started, the prospector has only one harvester which is copied and then started. The advantage is that config unpacking and encoding factory are called only once. 

The idea is that also readers will process their own config in the future and should be setup as part of the "New" method to make sure this also happens only once.