### PR TITLE
Fix state removal and sending empty lines

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -52,6 +52,8 @@ https://github.com/elastic/beats/compare/v5.0.0-alpha4...master[Check the HEAD d
 - Fix potential data loss between filebeat restarts, reporting unpublished lines as published. {issue}2041[2041]
 - Fix open file handler issue {issue}2028[2028] {pull}2020[2020]
 - Fix filtering of JSON events when using integers in conditions {issue}2038[2038]
+- Fix sending of empty lines {issue}2105[2105]
+- Fix potential issue that state was not removed with clean_removed {issue}2105[2105]
 
 *Winlogbeat*
 - Fix potential data loss between winlogbeat restarts, reporting unpublished lines as published. {issue}2041[2041]

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -52,8 +52,6 @@ https://github.com/elastic/beats/compare/v5.0.0-alpha4...master[Check the HEAD d
 - Fix potential data loss between filebeat restarts, reporting unpublished lines as published. {issue}2041[2041]
 - Fix open file handler issue {issue}2028[2028] {pull}2020[2020]
 - Fix filtering of JSON events when using integers in conditions {issue}2038[2038]
-- Fix sending of empty lines {issue}2105[2105]
-- Fix potential issue that state was not removed with clean_removed {issue}2105[2105]
 
 *Winlogbeat*
 - Fix potential data loss between winlogbeat restarts, reporting unpublished lines as published. {issue}2041[2041]

--- a/filebeat/harvester/reader/reader.go
+++ b/filebeat/harvester/reader/reader.go
@@ -22,3 +22,20 @@ type Message struct {
 type Reader interface {
 	Next() (Message, error)
 }
+
+// IsEmpty returns true in case the message is empty
+// A message with only newline character is counted as an empty message
+func (m *Message) IsEmpty() bool {
+	// If no Bytes were read, event is empty
+	// For empty line Bytes is at least 1 because of the newline char
+	if m.Bytes == 0 {
+		return true
+	}
+
+	// Content length can be 0 because of JSON events. Content and Fields must be empty.
+	if len(m.Content) == 0 && len(m.Fields) == 0 {
+		return true
+	}
+
+	return false
+}


### PR DESCRIPTION
# State Removal

With a very low scan_frequency it could potentially happen, that a state of a finished harvester was overwritten by the prospector which lead to the problem, that the state was never set to Finished. This is now fixed in that the prospector only sends a state when the state is set to Finished.

# Sending empty lines

Empty lines were still sent as the byte check was set to 0 and with the newline char it was always at least 1. The tests passed because filebeat was shutdown before the last line was written. Tests were now improved to tests both cases.

Example failed build: http://build-eu-00.elastic.co/job/Beats-PR/2577/