### PR TITLE
Configurable Elasticsearch index pattern

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -13,6 +13,7 @@ https://github.com/elastic/beats/compare/v5.0.0-alpha5...master[Check the HEAD d
 ==== Breaking changes
 
 *Affecting all Beats*
+- Change Elasticsearch output index configuration to be based on format strings. If index has been configured, no date will be appended anymore to the index name. {pull}2119[2119]
 
 *Metricbeat*
 

--- a/filebeat/filebeat.full.yml
+++ b/filebeat/filebeat.full.yml
@@ -440,7 +440,7 @@ output.elasticsearch:
 
   # Optional index name. The default index name is set to name of the beat
   # in all lowercase.
-  #index: filebeat
+  #index: 'filebeat-%{+yyyy.MM.dd}'
 
   # SOCKS5 proxy server URL
   #proxy_url: socks5://user:password@socks5-server:2233

--- a/libbeat/_meta/config.full.yml
+++ b/libbeat/_meta/config.full.yml
@@ -214,7 +214,7 @@ output.elasticsearch:
 
   # Optional index name. The default index name is set to name of the beat
   # in all lowercase.
-  #index: beatname
+  #index: 'beatname-%{+yyyy.MM.dd}'
 
   # SOCKS5 proxy server URL
   #proxy_url: socks5://user:password@socks5-server:2233

--- a/libbeat/outputs/elasticsearch/api_test.go
+++ b/libbeat/outputs/elasticsearch/api_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/elastic/beats/libbeat/outputs/outil"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -169,7 +170,8 @@ func newTestClient(url string) *Client {
 }
 
 func newTestClientAuth(url, user, pass string) *Client {
-	client, err := NewClient(url, "", nil, nil, user, pass, nil, 60*time.Second, 3, nil)
+	index := outil.MakeSelector()
+	client, err := NewClient(url, index, nil, nil, user, pass, nil, 60*time.Second, 3, nil)
 	if err != nil {
 		panic(err)
 	}

--- a/libbeat/outputs/elasticsearch/client_test.go
+++ b/libbeat/outputs/elasticsearch/client_test.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/fmtstr"
+	"github.com/elastic/beats/libbeat/outputs/outil"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -128,7 +130,11 @@ func TestGetIndexStandard(t *testing.T) {
 		"field":      1,
 	}
 
-	index := getIndex(event, "beatname")
+	pattern := "beatname-%{+yyyy.MM.dd}"
+	fmtstr := fmtstr.MustCompileEvent(pattern)
+	indexSel := outil.MakeSelector(outil.FmtSelectorExpr(fmtstr, ""))
+
+	index := getIndex(event, indexSel)
 	assert.Equal(t, index, "beatname-"+extension)
 }
 
@@ -145,7 +151,12 @@ func TestGetIndexOverwrite(t *testing.T) {
 			"index": "dynamicindex",
 		},
 	}
-	index := getIndex(event, "beatname")
+
+	pattern := "beatname-%%{+yyyy.MM.dd}"
+	fmtstr := fmtstr.MustCompileEvent(pattern)
+	indexSel := outil.MakeSelector(outil.FmtSelectorExpr(fmtstr, ""))
+
+	index := getIndex(event, indexSel)
 	assert.Equal(t, index, "dynamicindex-"+extension)
 }
 

--- a/libbeat/outputs/elasticsearch/config.go
+++ b/libbeat/outputs/elasticsearch/config.go
@@ -13,7 +13,6 @@ type elasticsearchConfig struct {
 	Username         string             `config:"username"`
 	Password         string             `config:"password"`
 	ProxyURL         string             `config:"proxy_url"`
-	Index            string             `config:"index"`
 	LoadBalance      bool               `config:"loadbalance"`
 	CompressionLevel int                `config:"compression_level" validate:"min=0, max=9"`
 	TLS              *outputs.TLSConfig `config:"tls"`

--- a/libbeat/outputs/elasticsearch/output.go
+++ b/libbeat/outputs/elasticsearch/output.go
@@ -17,11 +17,12 @@ import (
 	"github.com/elastic/beats/libbeat/outputs"
 	"github.com/elastic/beats/libbeat/outputs/mode"
 	"github.com/elastic/beats/libbeat/outputs/mode/modeutil"
+	"github.com/elastic/beats/libbeat/outputs/outil"
 	"github.com/elastic/beats/libbeat/paths"
 )
 
 type elasticsearchOutput struct {
-	index    string
+	index    outil.Selector
 	beatName string
 	mode     mode.ConnectionMode
 	topology
@@ -57,7 +58,8 @@ func New(beatName string, cfg *common.Config, topologyExpire int) (outputs.Outpu
 	}
 
 	if !cfg.HasField("index") {
-		cfg.SetString("index", -1, beatName)
+		pattern := fmt.Sprintf("%v-%%{+yyyy.MM.dd}", beatName)
+		cfg.SetString("index", -1, pattern)
 	}
 
 	output := &elasticsearchOutput{beatName: beatName}
@@ -77,6 +79,16 @@ func (out *elasticsearchOutput) init(
 		return err
 	}
 
+	index, err := outil.BuildSelectorFromConfig(cfg, outil.Settings{
+		Key:              "index",
+		MultiKey:         "indices",
+		EnableSingleOnly: true,
+		FailEmpty:        true,
+	})
+	if err != nil {
+		return err
+	}
+
 	tlsConfig, err := outputs.LoadTLSConfig(config.TLS)
 	if err != nil {
 		return err
@@ -87,6 +99,7 @@ func (out *elasticsearchOutput) init(
 		return err
 	}
 
+	out.index = index
 	clients, err := modeutil.MakeClients(cfg, makeClientFactory(tlsConfig, &config, out))
 	if err != nil {
 		return err
@@ -110,7 +123,6 @@ func (out *elasticsearchOutput) init(
 	}
 
 	out.mode = m
-	out.index = config.Index
 
 	return nil
 }
@@ -241,7 +253,7 @@ func makeClientFactory(
 		}
 
 		return NewClient(
-			esURL, config.Index, proxyURL, tls,
+			esURL, out.index, proxyURL, tls,
 			config.Username, config.Password,
 			params, config.Timeout,
 			config.CompressionLevel,

--- a/metricbeat/metricbeat.full.yml
+++ b/metricbeat/metricbeat.full.yml
@@ -362,7 +362,7 @@ output.elasticsearch:
 
   # Optional index name. The default index name is set to name of the beat
   # in all lowercase.
-  #index: metricbeat
+  #index: 'metricbeat-%{+yyyy.MM.dd}'
 
   # SOCKS5 proxy server URL
   #proxy_url: socks5://user:password@socks5-server:2233

--- a/packetbeat/packetbeat.full.yml
+++ b/packetbeat/packetbeat.full.yml
@@ -632,7 +632,7 @@ output.elasticsearch:
 
   # Optional index name. The default index name is set to name of the beat
   # in all lowercase.
-  #index: packetbeat
+  #index: 'packetbeat-%{+yyyy.MM.dd}'
 
   # SOCKS5 proxy server URL
   #proxy_url: socks5://user:password@socks5-server:2233

--- a/winlogbeat/winlogbeat.full.yml
+++ b/winlogbeat/winlogbeat.full.yml
@@ -249,7 +249,7 @@ output.elasticsearch:
 
   # Optional index name. The default index name is set to name of the beat
   # in all lowercase.
-  #index: winlogbeat
+  #index: 'winlogbeat-%{+yyyy.MM.dd}'
 
   # SOCKS5 proxy server URL
   #proxy_url: socks5://user:password@socks5-server:2233


### PR DESCRIPTION
Part of #2074 
Depends on #2118 

Implement index selector based on selector support provided by #2087 and new format string support.

Default index pattern changes to `beatname-%{+yyyy.MM.dd}`.

More advanced index selection via selector:

```
output.elasticsearch.indices:
- rule1
- rule2
```

If `output.elasticsearch.indices` doesn't match, default case in `output.elasticsearch.index` is used (which is always set to default value on init).

Rules are similar to #2064 with supported keywords: `index`, `default`, `mapping`, `when`.