### PR TITLE
Use pure Go compilation for community beats

### DIFF
--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -318,4 +318,4 @@ create-packer:
 package: create-packer
 	cd dev-tools/packer; \
 	export ES_BEATS=${ES_BEATS} ; \
-	make deps images ${BEATNAME}
+	make deps images all

--- a/libbeat/scripts/dev-tools/packer/Makefile
+++ b/libbeat/scripts/dev-tools/packer/Makefile
@@ -15,20 +15,11 @@ include $(ES_BEATS)/dev-tools/packer/scripts/Makefile
 		-v $(abspath build):/build \
 		-v $(abspath $(ES_BEATS)/dev-tools/packer/xgo-scripts):/scripts \
 		-v $(abspath ../..):/source \
+		-e PUREGO="yes" \
 		-e PACK=$@ \
 		-e BEFORE_BUILD=before_build.sh \
 		-e SOURCE=/source \
+		-e TARGETS="linux/amd64 linux/386 windows/amd64 windows/386 darwin/amd64" \
 		-e BUILDID=${BUILDID} \
 		tudorg/beats-builder \
-		{beat_path}
-	# linux builds on debian 6
-	docker run --rm \
-		-v $(abspath build):/build \
-		-v $(abspath $(ES_BEATS)/dev-tools/packer/xgo-scripts):/scripts \
-		-v $(abspath ../..):/source \
-		-e PACK=$@ \
-		-e BEFORE_BUILD=before_build.sh \
-		-e SOURCE=/source \
-		-e BUILDID=${BUILDID} \
-		tudorg/beats-builder-deb6 \
 		{beat_path}


### PR DESCRIPTION
Part of #2128. Most community Beats don't require Cgo, and if Cgo is
required things will probably not work out of the box anyway (extra
libraries will probably be needed).

Also `make package` call `make all` in the `dev-tools/packer` so that
the packages are built, not only the binaries.