### PR TITLE
Add lookup.exec processor

### DIFF
--- a/libbeat/beat/beat.go
+++ b/libbeat/beat/beat.go
@@ -47,10 +47,13 @@ import (
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/paths"
 	"github.com/elastic/beats/libbeat/processors"
-	_ "github.com/elastic/beats/libbeat/processors/actions"
 	"github.com/elastic/beats/libbeat/publisher"
 	svc "github.com/elastic/beats/libbeat/service"
 	"github.com/satori/go.uuid"
+
+	// load modules
+	_ "github.com/elastic/beats/libbeat/processors/actions"
+	_ "github.com/elastic/beats/libbeat/processors/actions/lookup/exec"
 )
 
 // Beater is the interface that must be implemented by every Beat. A Beater

--- a/libbeat/processors/actions/lookup/exec/config.go
+++ b/libbeat/processors/actions/lookup/exec/config.go
@@ -1,0 +1,41 @@
+package exec
+
+import (
+	"time"
+
+	"github.com/elastic/beats/libbeat/common/fmtstr"
+	"github.com/elastic/beats/libbeat/processors/actions/lookup/lutool"
+)
+
+type execLookupConfig struct {
+	Key    []string           `config:"key"`
+	Cache  lutool.CacheConfig `config:"inline"`
+	Runner execRunnerConfig   `config:",inline"`
+}
+
+type execRunnerConfig struct {
+	Run        *fmtstr.EventFormatString `config:"run"          validate:"required"`
+	Timeout    time.Duration             `config:"timeout"      validate:"min=0"`
+	User       string                    `config:"user"`
+	Chroot     string                    `config:"chroot"`
+	WorkingDir string                    `config:"working_directory"`
+	Env        []string                  `config:"env"`
+
+	// XXX: Querying group information support is lacking in golang runtime.
+	//      Do support `group` config for now.
+	// Group      string        `config:"group"`
+}
+
+var (
+	defaultConfig = execLookupConfig{
+		Key:   nil,
+		Cache: lutool.DefaultCacheConfig,
+		Runner: execRunnerConfig{
+			Timeout:    60 * time.Second,
+			User:       "",
+			Chroot:     "",
+			WorkingDir: "",
+			Env:        nil,
+		},
+	}
+)

--- a/libbeat/processors/actions/lookup/exec/exec.go
+++ b/libbeat/processors/actions/lookup/exec/exec.go
@@ -1,0 +1,215 @@
+package exec
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os/exec"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+	"unicode"
+
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/fmtstr"
+	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/processors"
+	"github.com/elastic/beats/libbeat/processors/actions/lookup/lutool"
+)
+
+type execRunner struct {
+	formatter   *fmtstr.EventFormatString
+	config      execRunnerConfig
+	credentials *syscall.Credential
+}
+
+func init() {
+	processors.RegisterPlugin("lookup.exec", newExecLookupProcessor)
+}
+
+func newExecLookupProcessor(cfg common.Config) (processors.Processor, error) {
+	config := defaultConfig
+	if err := cfg.Unpack(&config); err != nil {
+		return nil, err
+	}
+
+	runner, err := newExecRunner(config.Runner)
+	if err != nil {
+		return nil, err
+	}
+
+	keys := config.Key
+	if len(keys) == 0 {
+		keys = runner.Keys()
+	}
+
+	keyer, err := lutool.MakeKeyBuilder(keys)
+	if err != nil {
+		return nil, err
+	}
+
+	return lutool.NewCachedLookupTool(
+		"lookup.exec",
+		config.Cache,
+		keyer,
+		runner,
+	)
+}
+
+func newExecRunner(config execRunnerConfig) (*execRunner, error) {
+	fs := config.Run
+	if fs.NumFields() == 0 {
+		logp.Err("Exec runner without event arguments")
+		return nil, errors.New("no arguments")
+	}
+
+	credential, err := loadCredentials(config.User)
+	if err != nil {
+		return nil, err
+	}
+
+	runner := &execRunner{
+		formatter:   fs,
+		credentials: credential,
+		config:      config,
+	}
+	return runner, nil
+}
+
+func (r *execRunner) Keys() []string {
+	return r.formatter.Fields()
+}
+
+func (r *execRunner) Exec(event common.MapStr) (common.MapStr, error) {
+	// XXX: if lookup.keys has been configured and keys can extract the field values,
+	//       but extracting arguments from event fails (e.g. due to missing fields in
+	//       arguments not used by key), No meta-data will be cached + execRunner will
+	//       not be re-executed.
+
+	command, err := r.formatter.Run(event)
+	if err != nil {
+		return nil, err
+	}
+
+	args, err := parseCommand(command)
+	if err != nil {
+		logp.Err("Failed to parse command '%v'", command)
+		return nil, err
+	}
+
+	// TODO: add support for event being pushed on stdin instead of passing arguments
+	cmd := exec.Command(args[0], args[1:]...)
+	cmd.Dir = r.config.WorkingDir
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Chroot:     r.config.Chroot,
+		Credential: r.credentials,
+	}
+	cmd.Env = r.config.Env
+
+	// read and capture output
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return nil, err
+	}
+
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+
+	var timer *time.Timer
+	if r.config.Timeout > 0 {
+		timer = time.AfterFunc(r.config.Timeout, func() {
+			// TODO: kill enough or send SIGKILL on unix based systems?
+			// XXX: this might not kill spawned child processes running in background.
+			cmd.Process.Kill()
+		})
+	}
+
+	var fields map[string]interface{}
+	var decodeErr error
+	var wg sync.WaitGroup
+	stderrBuf := bytes.NewBuffer(nil)
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		decodeErr = json.NewDecoder(stdout).Decode(&fields)
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		limit := int64(2048)
+		n, err := io.CopyN(stderrBuf, stderr, limit)
+		if limit == n && err != nil {
+			io.Copy(ioutil.Discard, stderr)
+		}
+	}()
+
+	err = cmd.Wait()
+	if timer != nil {
+		timer.Stop()
+	}
+	wg.Wait()
+	if err != nil {
+		// something bad happened, let's try to generate some error message
+		if stderrBuf.Len() == 0 {
+			return nil, err
+		}
+
+		return nil, fmt.Errorf("%v with stderr '%v'", err.Error(), stderrBuf.String())
+	}
+
+	// check decoder failed:
+	if decodeErr != nil {
+		return nil, decodeErr
+	}
+
+	return common.MapStr(fields), nil
+}
+
+func parseCommand(in string) ([]string, error) {
+	trim := func(s string) string { return strings.TrimFunc(s, unicode.IsSpace) }
+
+	raw := trim(in)
+	if len(raw) == 0 {
+		return nil, fmt.Errorf("Empty command given")
+	}
+
+	var args []string
+	for len(raw) > 0 {
+		idx := strings.IndexFunc(raw, func(r rune) bool {
+			return r == '"' || unicode.IsSpace(r)
+		})
+		if idx < 0 {
+			args = append(args, trim(raw))
+			break
+		}
+
+		switch raw[idx] {
+		case '"':
+			if str := trim(raw[:idx]); str != "" {
+				args = append(args, str)
+			}
+			raw = raw[idx+1:]
+			idx = strings.IndexRune(raw, '"')
+			if idx < 0 {
+				return nil, fmt.Errorf("Failed parsing '%v' due to missing '\"'", in)
+			}
+			args = append(args, raw[:idx])
+			raw = trim(raw[idx+1:])
+		default:
+			args = append(args, trim(raw[:idx]))
+			raw = trim(raw[idx+1:])
+		}
+	}
+	return args, nil
+}

--- a/libbeat/processors/actions/lookup/exec/exec_test.go
+++ b/libbeat/processors/actions/lookup/exec/exec_test.go
@@ -1,0 +1,404 @@
+package exec
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/fmtstr"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExecInitFail(t *testing.T) {
+	tests := []struct {
+		title  string
+		config execRunnerConfig
+	}{
+		{
+			"no keys in format string",
+			execRunnerConfig{
+				Run: fmtstr.MustCompileEvent("test"),
+			},
+		},
+		{
+			"invalid username",
+			execRunnerConfig{
+				Run:  fmtstr.MustCompileEvent("test %{[key]}"),
+				User: "non_existent_system_user_test",
+			},
+		},
+	}
+
+	for i, test := range tests {
+		t.Logf("run (%v): %v", i, test.title)
+
+		_, err := newExecRunner(test.config)
+		assert.Error(t, err)
+	}
+}
+
+func TestExec(t *testing.T) {
+	mustHaveExec(t)
+
+	tests := []struct {
+		title    string
+		command  string
+		keys     []string
+		event    common.MapStr
+		expected common.MapStr
+	}{
+		{
+			"run plain",
+			`fields f1 %{[a]} %{[f2]} b`,
+			[]string{"a", "f2"},
+			common.MapStr{"a": "test", "f2": "ft"},
+			common.MapStr{"f1": "test", "ft": "b"},
+		},
+		{
+			"run with quoted string",
+			`fields f1 "pre %{[a]} post" %{[f2]} "another field"`,
+			[]string{"a", "f2"},
+			common.MapStr{"a": "test", "f2": "ft"},
+			common.MapStr{
+				"f1": "pre test post",
+				"ft": "another field",
+			},
+		},
+	}
+
+	for i, test := range tests {
+		t.Logf("run (%v): %v", i, test.title)
+
+		config := defaultConfig.Runner
+		config.Run = fmtstr.MustCompileEvent(
+			fmt.Sprintf("%s -test.run TestHelper -- %s", os.Args[0], test.command))
+		config.Env = []string{
+			"WANT_HELPER_PROCESS=1",
+		}
+		runner, err := newExecRunner(config)
+		if err != nil {
+			t.Error(err)
+			continue
+		}
+
+		actual, err := runner.Exec(test.event)
+		if err != nil {
+			t.Error(err)
+			continue
+		}
+
+		assert.Equal(t, test.keys, runner.Keys())
+		assert.Equal(t, test.expected, actual)
+	}
+}
+
+func TestExecErr(t *testing.T) {
+	tests := []struct {
+		title   string
+		command string
+		workdir string
+		event   common.MapStr
+	}{
+		{
+			"test invalid command",
+			`"invalid nonexistent shell tool" "%{[arg]}"`,
+			"",
+			common.MapStr{"arg": "arg"},
+		},
+		{
+			"configure invalid work directory",
+			os.Args[0] + " -test.run TestHelper -- echo %{[arg]}",
+			"invalid nonexistent work directory",
+			common.MapStr{"arg": "arg"},
+		},
+	}
+
+	for i, test := range tests {
+		t.Logf("run (%v): %v", i, test.title)
+
+		config := defaultConfig.Runner
+		config.Run = fmtstr.MustCompileEvent(test.command)
+		config.WorkingDir = test.workdir
+		config.Env = []string{
+			"WANT_HELPER_PROCESS=1",
+		}
+
+		runner, err := newExecRunner(config)
+		if err != nil {
+			t.Error(err)
+			continue
+		}
+
+		_, err = runner.Exec(test.event)
+		assert.Error(t, err)
+		t.Logf("process exited with: %v", err)
+	}
+}
+
+func TestExecScriptErr(t *testing.T) {
+	mustHaveExec(t)
+
+	tests := []struct {
+		title   string
+		command string
+		timeout time.Duration
+		event   common.MapStr
+		error   string
+	}{
+		{
+			"do not run if argument key is missing",
+			"%{[cmd]}",
+			0,
+			common.MapStr{"key": "wrong"},
+			"",
+		},
+		{
+			"process exits with error",
+			"%{[cmd]} %{[code]}",
+			0,
+			common.MapStr{"cmd": "exit", "code": 10},
+			"exit status 10",
+		},
+		{
+			"process exists without output",
+			"exit %{[code]}",
+			0,
+			common.MapStr{"code": 0},
+			"EOF",
+		},
+		{
+			"fail due to invalid json being printed",
+			"echo %{[key]}",
+			0,
+			common.MapStr{"key": "value"},
+			"",
+		},
+		{
+			"fail with message to stderr",
+			"echoerr %{[key]}",
+			0,
+			common.MapStr{"key": "errormessage"},
+			"exit status 1 with stderr 'errormessage'",
+		},
+		{
+			"timeout fail",
+			"sleep %{[duration]}",
+			100 * time.Millisecond,
+			common.MapStr{"duration": "10s"},
+			"signal: killed",
+		},
+	}
+
+	for i, test := range tests {
+		t.Logf("run (%v): %v", i, test.title)
+
+		config := defaultConfig.Runner
+		config.Run = fmtstr.MustCompileEvent(
+			fmt.Sprintf("%s -test.run TestHelper -- %s", os.Args[0], test.command))
+		config.Env = []string{
+			"WANT_HELPER_PROCESS=1",
+		}
+		if test.timeout > 0 {
+			config.Timeout = test.timeout
+		}
+
+		runner, err := newExecRunner(config)
+		if err != nil {
+			t.Error(err)
+			continue
+		}
+
+		_, err = runner.Exec(test.event)
+		if test.error != "" {
+			assert.EqualError(t, err, test.error)
+		} else {
+			assert.Error(t, err)
+		}
+
+		t.Logf("process exited with: %v", err)
+	}
+}
+
+func TestParseCommand(t *testing.T) {
+	tests := []struct {
+		title    string
+		command  string
+		expected []string
+	}{
+		{
+			"empty command fails",
+			"",
+			nil,
+		},
+		{
+			"non-closed escape fails",
+			`abc "def`,
+			nil,
+		},
+		{
+			"parse with arguments",
+			"command arg1 arg2 arg3",
+			[]string{"command", "arg1", "arg2", "arg3"},
+		},
+		{
+			"parse escaped all args",
+			`command "a 1" "a 2" "a 3"`,
+			[]string{"command", "a 1", "a 2", "a 3"},
+		},
+		{
+			"parse escaped first arg",
+			`command "a 1" a2 a3`,
+			[]string{"command", "a 1", "a2", "a3"},
+		},
+		{
+			"parse escaped last arg",
+			`command a1 a2 "a 3"`,
+			[]string{"command", "a1", "a2", "a 3"},
+		},
+		{
+			"parse escaped middle arg",
+			`command a1 "a 2" a3`,
+			[]string{"command", "a1", "a 2", "a3"},
+		},
+	}
+
+	for i, test := range tests {
+		t.Logf("run (%v): %v", i, test.title)
+
+		cmd, err := parseCommand(test.command)
+		if test.expected == nil {
+			assert.Error(t, err)
+			continue
+		}
+		if err != nil {
+			t.Error(err)
+			continue
+		}
+
+		assert.Equal(t, test.expected, cmd)
+	}
+}
+
+// TestHelper isn't a real test. It's used as a helper process
+func TestHelper(*testing.T) {
+	if os.Getenv("WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+	defer os.Exit(0)
+
+	args := os.Args
+	for len(args) > 0 {
+		if args[0] == "--" {
+			args = args[1:]
+			break
+		}
+		args = args[1:]
+	}
+	if len(args) == 0 {
+		fmt.Fprintf(os.Stderr, "No command\n")
+		os.Exit(2)
+	}
+	cmd, args := args[0], args[1:]
+	switch cmd {
+	case "fields":
+		kv := [2][]string{}
+		i := 0
+		for _, arg := range args {
+			kv[i] = append(kv[i], arg)
+			i = 1 - i
+		}
+
+		L := len(kv[0])
+		if len(kv[1]) < L {
+			L = len(kv[1])
+		}
+
+		event := common.MapStr{}
+		for i := range kv[0] {
+			event[kv[0][i]] = kv[1][i]
+		}
+
+		dat, err := json.Marshal(event)
+		if err != nil {
+			fmt.Fprint(os.Stderr, err)
+			os.Exit(1)
+		}
+		fmt.Println(string(dat))
+
+	case "echo":
+		iargs := []interface{}{}
+		for _, s := range args {
+			iargs = append(iargs, s)
+		}
+		fmt.Println(iargs...)
+
+	case "echoerr":
+		iargs := []interface{}{}
+		for _, s := range args {
+			iargs = append(iargs, s)
+		}
+		fmt.Fprint(os.Stderr, iargs...)
+		os.Exit(1)
+
+	case "exit":
+		n, _ := strconv.Atoi(args[0])
+		os.Exit(n)
+
+	case "sleep":
+		d, err := time.ParseDuration(args[0])
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		time.Sleep(d)
+
+	case "cat":
+		if len(args) == 0 {
+			io.Copy(os.Stdout, os.Stdin)
+			return
+		}
+		exit := 0
+		for _, fn := range args {
+			f, err := os.Open(fn)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+				exit = 2
+			} else {
+				defer f.Close()
+				io.Copy(os.Stdout, f)
+			}
+		}
+		os.Exit(exit)
+
+	default:
+		fmt.Fprintf(os.Stderr, "Unknown command %q\n", cmd)
+		os.Exit(2)
+	}
+}
+
+func mustHaveExec(t *testing.T) {
+	if !hasExec() {
+		t.Skipf("skipping test: cannot exec subprocess on %s/%s", runtime.GOOS, runtime.GOARCH)
+	}
+}
+
+// HasExec reports whether the current system can start new processes
+// using os.StartProcess or (more commonly) exec.Command.
+func hasExec() bool {
+	switch runtime.GOOS {
+	case "nacl":
+		return false
+	case "darwin":
+		if strings.HasPrefix(runtime.GOARCH, "arm") {
+			return false
+		}
+	}
+	return true
+}

--- a/libbeat/processors/actions/lookup/exec/exec_unix.go
+++ b/libbeat/processors/actions/lookup/exec/exec_unix.go
@@ -9,6 +9,18 @@ import (
 	"syscall"
 )
 
+func newProcAttributes(config execRunnerConfig) (*syscall.SysProcAttr, error) {
+	creds, err := loadCredentials(config.User)
+	if err != nil {
+		return nil, err
+	}
+
+	return &syscall.SysProcAttr{
+		Chroot:     config.Chroot,
+		Credential: creds,
+	}, nil
+}
+
 func loadCredentials(username string) (*syscall.Credential, error) {
 	if username == "" {
 		return nil, nil

--- a/libbeat/processors/actions/lookup/exec/exec_unix.go
+++ b/libbeat/processors/actions/lookup/exec/exec_unix.go
@@ -1,0 +1,33 @@
+// +build darwin dragonfly freebsd linux nacl netbsd openbsd solaris
+
+package exec
+
+import (
+	"fmt"
+	"os/user"
+	"strconv"
+	"syscall"
+)
+
+func loadCredentials(username string) (*syscall.Credential, error) {
+	if username == "" {
+		return nil, nil
+	}
+
+	u, err := user.Lookup(username)
+	if err != nil {
+		return nil, err
+	}
+
+	uid, err := strconv.Atoi(u.Uid)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse uid %v", uid)
+	}
+
+	gid, err := strconv.Atoi(u.Gid)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse gid %v", uid)
+	}
+
+	return &syscall.Credential{Uid: uint32(uid), Gid: uint32(gid)}, nil
+}

--- a/libbeat/processors/actions/lookup/exec/exec_windows.go
+++ b/libbeat/processors/actions/lookup/exec/exec_windows.go
@@ -1,18 +1,29 @@
 package exec
 
 import (
+	"errors"
 	"fmt"
 	"syscall"
 
 	"github.com/elastic/beats/libbeat/logp"
 )
 
-func loadCredentials(username string) (*syscall.Credential, error) {
-	if username == "" {
-		return nil, nil
+func newProcAttributes(config execRunnerConfig) (*syscall.SysProcAttr, error) {
+	if user := config.User; user != "" {
+		err := fmt.Errorf(
+			"runnning commands as user ('%v') not supported on this platform.",
+			user)
+		logp.Err("Reading exec config failed: %v", err)
+		return nil, err
 	}
 
-	err := fmt.Errorf("runnning commands as user ('%v') not supported on this platform.", username)
-	logp.Err("Loading credential failed: %v", err)
-	return nil, err
+	if config.Chroot != "" {
+		err := errors.New("Chroot not supported on this platform")
+		logp.Err("Reading exec config failed: %v", err)
+		return nil, err
+	}
+
+	return &syscall.SysProcAttr{
+		HideWindow: true,
+	}, nil
 }

--- a/libbeat/processors/actions/lookup/exec/exec_windows.go
+++ b/libbeat/processors/actions/lookup/exec/exec_windows.go
@@ -1,0 +1,18 @@
+package exec
+
+import (
+	"fmt"
+	"syscall"
+
+	"github.com/elastic/beats/libbeat/logp"
+)
+
+func loadCredentials(username string) (*syscall.Credential, error) {
+	if username == "" {
+		return nil, nil
+	}
+
+	err := fmt.Errorf("runnning commands as user ('%v') not supported on this platform.", username)
+	logp.Err("Loading credential failed: %v", err)
+	return nil, err
+}

--- a/libbeat/processors/actions/lookup/lookup.go
+++ b/libbeat/processors/actions/lookup/lookup.go
@@ -1,0 +1,4 @@
+// lookup meta package.
+// See lutool for common functionality used by different lookup processor
+// implementations.
+package lookup

--- a/libbeat/processors/actions/lookup/lutool/cache.go
+++ b/libbeat/processors/actions/lookup/lutool/cache.go
@@ -1,0 +1,231 @@
+package lutool
+
+import (
+	"errors"
+	"hash/fnv"
+	"sync"
+	"time"
+
+	"github.com/elastic/beats/libbeat/common"
+)
+
+// Table using fine-grained locking to reduce congestion.
+type cache struct {
+	mutex   sync.Mutex
+	bins    map[uint64]*bin
+	janitor *janitor
+}
+
+// janitor removes expired and unused entries from cache.
+//
+// Collect and remove old entries in 3 steps:
+// 1. create snapshot of bins table using table mutex.
+//    After creating snapshot, table can be accessed concurrently
+// 2. Search and remove expired entries for each single bin. Bin will be locked, but
+//    Other bins can be used concurrently.
+// 3. Probe and remove empty bins from table.
+type janitor struct {
+	ticks chan time.Time
+	cache *cache
+}
+
+type bin struct {
+	mutex   sync.Mutex
+	entries []*binEntry
+}
+
+type binEntry struct {
+	ts    time.Time
+	exec  execOnce
+	key   Key
+	value binValue
+}
+
+type binValue interface {
+	error() error
+	lastRun() time.Time
+	backoff() time.Duration
+	value() common.MapStr
+}
+
+type binError struct {
+	ts time.Time
+	d  time.Duration
+	e  error
+}
+
+type binLookupValue common.MapStr
+
+var errConvertString = errors.New("can not convert to string")
+
+func newCache(tick, timeout time.Duration) *cache {
+	t := &cache{
+		mutex: sync.Mutex{},
+		bins:  map[uint64]*bin{},
+	}
+
+	if timeout > 0 {
+		// TODO: how to stop the go-routine? No processor shutdown logic
+		j := newJanitor(t)
+		go j.run(tick, timeout)
+		t.janitor = j
+	}
+
+	return t
+}
+
+func (t *cache) Close() {
+	t.janitor.stop()
+}
+
+func (t *cache) getEntry(ts time.Time, k Key) (*binEntry, error) {
+	e, err := t.doGetEntry(k)
+	t.janitor.signalTS(ts)
+	return e, err
+}
+
+func (t *cache) doGetEntry(k Key) (*binEntry, error) {
+	hash := fnv.New64()
+	if err := k.Hash(hash); err != nil {
+		return nil, err
+	}
+
+	bin := t.getBin(hash.Sum64())
+	defer bin.mutex.Unlock()
+
+	for _, entry := range bin.entries {
+		if entry.key.Equals(&k) {
+			entry.ts = time.Now()
+			return entry, nil
+		}
+	}
+
+	debugf("Create new table entry for key: %v", k)
+	entry := &binEntry{ts: time.Now(), key: k}
+	bin.entries = append(bin.entries, entry)
+	return entry, nil
+}
+
+func (t *cache) getBin(hash uint64) *bin {
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+
+	b := t.bins[hash]
+	if b == nil {
+		b = &bin{}
+		t.bins[hash] = b
+	}
+	b.mutex.Lock()
+	return b
+}
+
+func newJanitor(c *cache) *janitor {
+	return &janitor{
+		cache: c,
+		ticks: make(chan time.Time, 1),
+	}
+}
+
+func (j *janitor) stop() {
+	close(j.ticks)
+}
+
+func (j *janitor) signalTS(ts time.Time) {
+	// try to push current timestamp
+	select {
+	case j.ticks <- ts:
+	default:
+	}
+}
+
+func (j *janitor) run(tick, timeout time.Duration) {
+	last := time.Time{}
+	for ts := range j.ticks {
+		if ts.Before(last) {
+			continue
+		}
+		if ts.Sub(last) < tick {
+			continue
+		}
+
+		j.collect(ts, timeout)
+		last = ts
+	}
+}
+
+func (j *janitor) collect(ts time.Time, timeout time.Duration) {
+	debugf("collect old entries from table")
+	hashes, bins := j.makeSnapshot()
+	dropped := hashes[:0] // reuse 'hashes' slice to collect hashes to be dropped
+	for i := range bins {
+		drop := j.collectBin(ts, timeout, bins[i])
+		if drop {
+			dropped = append(dropped, hashes[i])
+		}
+	}
+
+	// try to drop bins without any entries
+	for _, hash := range dropped {
+		j.collectEmptyBin(hash)
+	}
+}
+
+func (j *janitor) makeSnapshot() ([]uint64, []*bin) {
+	t := j.cache
+
+	// take snapshot of main table
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+
+	hashes := make([]uint64, 0, len(t.bins))
+	bins := make([]*bin, 0, len(t.bins))
+	for hash, bin := range t.bins {
+		hashes = append(hashes, hash)
+		bins = append(bins, bin)
+	}
+	return hashes, bins
+}
+
+func (j *janitor) collectBin(now time.Time, timeout time.Duration, b *bin) bool {
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+
+	entries := b.entries[:0]
+	for _, entry := range b.entries {
+		if now.Sub(entry.ts) > timeout {
+			debugf("delete entry for key: ", entry.key)
+			continue
+		}
+
+		entries = append(entries, entry)
+	}
+	b.entries = entries
+	return len(entries) == 0
+}
+
+func (j *janitor) collectEmptyBin(hash uint64) {
+	t := j.cache
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+
+	// Safe to get and drop bin here, as bin can only be acquired when table
+	// mutex is locked and before updating entries, the bins mutex is locked using
+	// hand-over-hand locking. In case bin is locked, it will be updated, before
+	// cleanup gets lock to check if bin has been invalidated.
+	b := t.bins[hash]
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+	if len(b.entries) == 0 {
+		delete(t.bins, hash)
+	}
+}
+
+func (e binError) error() error           { return e.e }
+func (e binError) lastRun() time.Time     { return e.ts }
+func (e binError) backoff() time.Duration { return e.d }
+func (e binError) value() common.MapStr   { return nil }
+
+func (v binLookupValue) error() error           { return nil }
+func (v binLookupValue) lastRun() time.Time     { return time.Time{} }
+func (v binLookupValue) backoff() time.Duration { return 0 }
+func (v binLookupValue) value() common.MapStr   { return common.MapStr(v) }

--- a/libbeat/processors/actions/lookup/lutool/key.go
+++ b/libbeat/processors/actions/lookup/lutool/key.go
@@ -1,0 +1,59 @@
+package lutool
+
+import (
+	"hash"
+
+	"github.com/elastic/beats/libbeat/common"
+)
+
+type Key struct {
+	keys []string
+}
+
+type KeyBuilder interface {
+	ExtractKey(common.MapStr) (Key, bool)
+}
+
+type KeyBuilderFunc func(common.MapStr) (Key, bool)
+
+func (k *Key) Equals(o *Key) bool {
+	if len(k.keys) != len(k.keys) {
+		return false
+	}
+
+	for i := range k.keys {
+		if k.keys[i] != o.keys[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func (k *Key) Hash(h hash.Hash64) error {
+	for i, s := range k.keys {
+		var err error
+
+		_, err = h.Write([]byte{byte(i), byte(i >> 8)})
+		if err != nil {
+			return err
+		}
+
+		_, err = h.Write([]byte(s))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func MakeKeyBuilder(fields []string) (KeyBuilder, error) {
+	fn, err := makeFieldsCollector(fields)
+	if err != nil {
+		return nil, err
+	}
+
+	return KeyBuilderFunc(func(event common.MapStr) (Key, bool) {
+		values, ok := fn(event)
+		return Key{values}, ok
+	}), nil
+}

--- a/libbeat/processors/actions/lookup/lutool/key_test.go
+++ b/libbeat/processors/actions/lookup/lutool/key_test.go
@@ -1,0 +1,81 @@
+package lutool
+
+import (
+	"hash/fnv"
+	"testing"
+
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestKey(t *testing.T) {
+	tests := []struct {
+		title  string
+		keys   []string
+		e1, e2 common.MapStr
+		equals bool
+	}{
+		{
+			"same compound key",
+			[]string{"a", "b"},
+			common.MapStr{"a": 1, "b": 2, "c": true},
+			common.MapStr{"a": 1, "b": 2, "c": false},
+			true,
+		},
+		{
+			"different compound key",
+			[]string{"a", "b"},
+			common.MapStr{"a": 1, "b": 2, "c": true},
+			common.MapStr{"a": 2, "b": 1, "c": false},
+			false,
+		},
+		{
+			"different but similar keys",
+			[]string{"a", "b"},
+			common.MapStr{"a": "abc", "b": "d"},
+			common.MapStr{"a": "ab", "b": "cd"},
+			false,
+		},
+	}
+
+	for i, test := range tests {
+		t.Logf("run (%v): %v", i, test.title)
+
+		kb, err := MakeKeyBuilder(test.keys)
+		if err != nil {
+			t.Error(err)
+			continue
+		}
+
+		k1, b1 := kb.ExtractKey(test.e1)
+		k2, b2 := kb.ExtractKey(test.e2)
+		if !b1 || !b2 {
+			assert.True(t, b1)
+			assert.True(t, b2)
+			continue
+		}
+
+		hash := fnv.New64()
+		err = k1.Hash(hash)
+		assert.NoError(t, err)
+		h1 := hash.Sum64()
+
+		hash.Reset()
+		err = k2.Hash(hash)
+		assert.NoError(t, err)
+		h2 := hash.Sum64()
+
+		t.Log(h1)
+		t.Log(h2)
+
+		if test.equals {
+			assert.Equal(t, h1, h2)
+			assert.True(t, k1.Equals(&k2))
+			assert.True(t, k2.Equals(&k1))
+		} else {
+			assert.NotEqual(t, h1, h2)
+			assert.False(t, k1.Equals(&k2))
+			assert.False(t, k2.Equals(&k1))
+		}
+	}
+}

--- a/libbeat/processors/actions/lookup/lutool/lutool.go
+++ b/libbeat/processors/actions/lookup/lutool/lutool.go
@@ -1,0 +1,118 @@
+package lutool
+
+import (
+	"time"
+
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/processors"
+)
+
+type Runner interface {
+	Exec(common.MapStr) (common.MapStr, error)
+}
+
+type cachedLookup struct {
+	FieldsUnderRoot bool
+	name            string
+	cache           *cache
+	runner          *runner
+	keyBuilder      KeyBuilder
+}
+
+type CacheConfig struct {
+	Backoff         BackoffConfig `config:"backoff"`
+	GCInterval      time.Duration `config:"gc_interval"       validate:"min=0s"`
+	ExpireUnused    time.Duration `config:"expire_unused"     validate:"min=1s"`
+	FieldsUnderRoot bool          `config:"fields_under_root"`
+}
+
+var debugf = logp.MakeDebug("lookup")
+
+var DefaultCacheConfig = CacheConfig{
+	Backoff: BackoffConfig{
+		Duration: 1 * time.Second,
+		Factor:   2.0,
+		Max:      60 * time.Second,
+	},
+	GCInterval:      10 * time.Second,
+	ExpireUnused:    60 * time.Second,
+	FieldsUnderRoot: false,
+}
+
+func NewCachedLookupTool(
+	name string,
+	config CacheConfig,
+	keyBuilder KeyBuilder,
+	backend Runner,
+) (processors.Processor, error) {
+	runner, err := newRunner(config.Backoff, backend)
+	if err != nil {
+		return nil, err
+	}
+
+	module := &cachedLookup{
+		name:            name,
+		FieldsUnderRoot: config.FieldsUnderRoot,
+		cache:           newCache(config.GCInterval, config.ExpireUnused),
+		runner:          runner,
+		keyBuilder:      keyBuilder,
+	}
+	return module, nil
+}
+
+func (l *cachedLookup) Run(event common.MapStr) (common.MapStr, error) {
+	var ts time.Time
+	timestamp, found := event["@timestamp"]
+	if found {
+		if commonTS, ok := timestamp.(common.Time); ok {
+			ts = time.Time(commonTS)
+		} else {
+			ts = time.Now()
+		}
+	} else {
+		ts = time.Now()
+	}
+
+	key, ok := l.keyBuilder.ExtractKey(event)
+	if !ok { // if key is not extractable from event, do not touch the event
+		return event, nil
+	}
+
+	entry, err := l.cache.getEntry(ts, key)
+	if err != nil {
+		return event, err
+	}
+
+	err = entry.exec.Do(func() error { return l.runner.do(entry, event) })
+	if err != nil {
+		l.annotateError(event, err)
+		return event, nil
+	}
+
+	fields := entry.value.value()
+	return l.mergeFields(event, fields), nil
+}
+
+func (l *cachedLookup) String() string {
+	return l.name
+}
+
+func (l *cachedLookup) annotateError(event common.MapStr, err error) common.MapStr {
+	// TODO: where/how do we want to store errors in events?
+	return event
+}
+
+func (l *cachedLookup) mergeFields(event, fields common.MapStr) common.MapStr {
+	debugf("merging fields")
+	err := common.MergeFields(event, fields, l.FieldsUnderRoot)
+	if err != nil {
+		logp.Warn("Merging lookup fields failed with: ", err)
+		return l.annotateError(event, err)
+	}
+	return event
+}
+
+func (fn KeyBuilderFunc) ExtractKey(event common.MapStr) (Key, bool) {
+	return fn(event)
+}

--- a/libbeat/processors/actions/lookup/lutool/lutool_test.go
+++ b/libbeat/processors/actions/lookup/lutool/lutool_test.go
@@ -1,0 +1,320 @@
+package lutool
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/logp"
+	"github.com/stretchr/testify/assert"
+)
+
+type funcRunner func(common.MapStr) (common.MapStr, error)
+
+type testRunner struct {
+	Runner
+	count int
+}
+
+type testAction func(t *testing.T, cache *cachedLookup, runner *testRunner) error
+
+func enableLogging(selectors []string) {
+	if testing.Verbose() {
+		logp.LogInit(logp.LOG_DEBUG, "", false, true, selectors)
+	}
+}
+
+func TestCacheLookupInitError(t *testing.T) {
+	enableLogging([]string{"*"})
+
+	tests := []struct {
+		title string
+		keys  []string
+	}{{
+		"Fail no keys",
+		nil,
+	}}
+
+	for i, test := range tests {
+		t.Logf("run (%v): %v", i, test.title)
+
+		exec := false
+		_, err := testWithCache(t, test.keys, makeCacheConfig(10),
+			func(c *cachedLookup, runner *testRunner) {
+				exec = true
+			},
+		)
+		assert.Error(t, err)
+		assert.False(t, exec)
+	}
+}
+
+func TestCachedLookup(t *testing.T) {
+	type myint int
+
+	fields1 := common.MapStr{"field": 1}
+	fields2 := common.MapStr{"field": 2}
+	fields3 := common.MapStr{"field": 3}
+	errUPS := errors.New("ups")
+
+	tests := []struct {
+		title         string
+		keys          []string
+		expire        time.Duration
+		actions       []testAction
+		expectedCalls int
+	}{
+		{
+			"lookup same key twice + success + no expire",
+			[]string{"key"},
+			100 * time.Second, // do not expire
+			[]testAction{
+				actSetRunner(fieldsRunner(fields1)),
+				actSend(
+					common.MapStr{"key": "1", "b": true},
+					common.MapStr{"key": "1", "b": true, "fields": fields1}),
+				actSend(
+					common.MapStr{"key": "1", "b": false},
+					common.MapStr{"key": "1", "b": false, "fields": fields1}),
+			},
+			1,
+		},
+		{
+			"lookup multiple keys twice + success + no expire",
+			[]string{"key"},
+			100 * time.Second, // do not expire
+			[]testAction{
+				actSetRunner(fieldsRunner(fields1)),
+				actSend(
+					common.MapStr{"key": "1", "b": true},
+					common.MapStr{"key": "1", "b": true, "fields": fields1}),
+				actSetRunner(fieldsRunner(fields2)),
+				actSend(
+					common.MapStr{"key": "2", "b": true},
+					common.MapStr{"key": "2", "b": true, "fields": fields2}),
+				actSetRunner(fieldsRunner(fields3)),
+				actSend(
+					common.MapStr{"key": "1", "b": false},
+					common.MapStr{"key": "1", "b": false, "fields": fields1}),
+				actSend(
+					common.MapStr{"key": "2", "b": false},
+					common.MapStr{"key": "2", "b": false, "fields": fields2}),
+			},
+			2,
+		},
+		{
+			"lookup with error + then success",
+			[]string{"key"},
+			100 * time.Second, // do not expire
+			[]testAction{
+				actSetRunner(errRunner(errUPS)),
+				actSendUnmodified(common.MapStr{"key": "1"}),
+
+				actWait(50 * time.Millisecond),
+				actSendUnmodified(common.MapStr{"key": "1"}),
+
+				actWait(50 * time.Millisecond),
+				actSetRunner(fieldsRunner(fields1)),
+				actSend(
+					common.MapStr{"key": "1", "b": true},
+					common.MapStr{"key": "1", "b": true, "fields": fields1}),
+			},
+			3,
+		},
+		{
+			"do not update event if key fields not available",
+			[]string{"key"},
+			100 * time.Second, // do not expire
+			[]testAction{
+				actSetRunner(fieldsRunner(fields1)),
+				actSendUnmodified(common.MapStr{"mykey": "1"}),
+			},
+			0,
+		},
+		{
+			"load expired event",
+			[]string{"key"},
+			10 * time.Millisecond, // expire very fast
+			[]testAction{
+				actSetRunner(fieldsRunner(fields1)),
+				actSend(
+					common.MapStr{"key": "1", "b": true},
+					common.MapStr{"key": "1", "b": true, "fields": fields1}),
+				actSetRunner(fieldsRunner(fields2)),
+
+				// send another event enforcing janitor to cleanup cache
+				actWait(100 * time.Millisecond),
+				actSend(
+					common.MapStr{"key": "2"},
+					common.MapStr{"key": "2", "fields": fields2}),
+
+				// give janitor a chance to drop 'key: 1' and send new event
+				actWait(50 * time.Millisecond),
+				actSend(
+					common.MapStr{"key": "1", "b": false},
+					common.MapStr{"key": "1", "b": false, "fields": fields2}),
+			},
+			3,
+		},
+		{
+			"do not modify event if key is not convertible to string",
+			[]string{"key"},
+			100 * time.Second, // do not expire
+			[]testAction{
+				actSetRunner(fieldsRunner(fields1)),
+				actSendUnmodified(common.MapStr{"key": myint(2)}),
+			},
+			0,
+		},
+		{
+			"runner only executed after backoff",
+			[]string{"key"},
+			100 * time.Second, // do not expire
+			[]testAction{
+				actSetRunner(errRunner(errUPS)),
+				actSendUnmodified(common.MapStr{"key": "1", "b": false}),
+
+				actSetRunner(fieldsRunner(fields1)),
+				actRepeat(4, []testAction{
+					actSendUnmodified(common.MapStr{"key": "1", "b": false}),
+				}),
+
+				actWait(50 * time.Millisecond),
+				actSend(
+					common.MapStr{"key": "1", "b": false},
+					common.MapStr{"key": "1", "b": false, "fields": fields1}),
+			},
+			2,
+		},
+	}
+
+	for i, test := range tests {
+		t.Logf("run (%v): %v", i, test.title)
+		n, err := testWithCache(t, test.keys, makeCacheConfig(test.expire),
+			func(c *cachedLookup, runner *testRunner) {
+				for _, action := range test.actions {
+					if err := action(t, c, runner); err != nil {
+						t.Error(err)
+						break
+					}
+				}
+			},
+		)
+
+		assert.NoError(t, err)
+		if test.expectedCalls >= 0 {
+			assert.Equal(t, test.expectedCalls, n)
+		}
+	}
+}
+
+func makeCacheConfig(expire time.Duration) CacheConfig {
+	return CacheConfig{
+		Backoff: BackoffConfig{
+			Duration: 10 * time.Millisecond,
+			Factor:   2.0,
+			Max:      50 * time.Millisecond,
+		},
+		GCInterval:      10 * time.Millisecond,
+		ExpireUnused:    expire,
+		FieldsUnderRoot: false,
+	}
+}
+
+func testWithCache(
+	t *testing.T,
+	keys []string,
+	cg CacheConfig,
+	fn func(c *cachedLookup, runner *testRunner),
+) (int, error) {
+	kb, err := MakeKeyBuilder(keys)
+	if len(keys) == 0 {
+		assert.Error(t, err)
+		return 0, err
+	}
+	if err != nil {
+		t.Error(err)
+		return 0, err
+	}
+
+	runner := &testRunner{}
+	lookup, err := NewCachedLookupTool("test", cg, kb, runner)
+	if err != nil {
+		return 0, err
+	}
+
+	cache := lookup.(*cachedLookup)
+	defer cache.cache.Close()
+
+	fn(cache, runner)
+	return runner.count, nil
+}
+
+func (fn funcRunner) Exec(evt common.MapStr) (common.MapStr, error) {
+	return fn(evt)
+}
+
+func errRunner(err error) funcRunner {
+	return func(_ common.MapStr) (common.MapStr, error) {
+		return nil, err
+	}
+}
+
+func fieldsRunner(fields common.MapStr) funcRunner {
+	return func(_ common.MapStr) (common.MapStr, error) {
+		return fields.Clone(), nil
+	}
+}
+
+func (r *testRunner) Exec(evt common.MapStr) (common.MapStr, error) {
+	r.count++
+	return r.Runner.Exec(evt)
+}
+
+func actSetRunner(r Runner) testAction {
+	return func(t *testing.T, cache *cachedLookup, runner *testRunner) error {
+		runner.Runner = r
+		return nil
+	}
+}
+
+func actSend(event, expected common.MapStr) testAction {
+	return func(t *testing.T, cache *cachedLookup, runner *testRunner) error {
+		ret, err := cache.Run(event.Clone())
+		assert.NoError(t, err)
+		if err != nil {
+			return err
+		}
+
+		b := assert.Equal(t, expected, ret)
+		if !b {
+			return errors.New("test fail")
+		}
+		return nil
+	}
+}
+
+func actSendUnmodified(event common.MapStr) testAction {
+	return actSend(event, event)
+}
+
+func actWait(d time.Duration) testAction {
+	return func(t *testing.T, cache *cachedLookup, runner *testRunner) error {
+		time.Sleep(d)
+		return nil
+	}
+}
+
+func actRepeat(N int, actions []testAction) testAction {
+	return func(t *testing.T, cache *cachedLookup, runner *testRunner) error {
+		for i := 0; i < N; i++ {
+			for _, act := range actions {
+				if err := act(t, cache, runner); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	}
+}

--- a/libbeat/processors/actions/lookup/lutool/once.go
+++ b/libbeat/processors/actions/lookup/lutool/once.go
@@ -1,0 +1,30 @@
+package lutool
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+type execOnce struct {
+	m    sync.Mutex
+	done uint32
+}
+
+func (e *execOnce) Do(fn func() error) error {
+	if atomic.LoadUint32(&e.done) == 1 {
+		return nil
+	}
+
+	// Slow path. Run fn and store result only if fn did not error.
+	e.m.Lock()
+	defer e.m.Unlock()
+	if e.done == 0 {
+		err := fn()
+		if err != nil {
+			return err
+		}
+		atomic.StoreUint32(&e.done, 1)
+	}
+
+	return nil
+}

--- a/libbeat/processors/actions/lookup/lutool/once_test.go
+++ b/libbeat/processors/actions/lookup/lutool/once_test.go
@@ -1,0 +1,85 @@
+package lutool
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExecOnce(t *testing.T) {
+	err := errors.New("test")
+
+	tests := []struct {
+		title  string
+		errors []error
+		Worker int
+		NRun   int
+		NCalls int
+		NOK    int
+		NFails int
+	}{
+		{
+			"all success",
+			nil,
+			3,
+			5, 1, 15, 0,
+		},
+		{
+			"some fails",
+			[]error{err, err},
+			3,
+			5, 3, 13, 2,
+		},
+	}
+
+	for i, test := range tests {
+		t.Logf("test (%v): %v", i, test.title)
+
+		var exec execOnce
+
+		calls := int32(0)
+		oks := int32(0)
+		fails := int32(0)
+
+		errors := test.errors
+
+		worker := func() {
+			for i := 0; i < test.NRun; i++ {
+				err := exec.Do(func() error {
+					calls++
+
+					if len(errors) > 0 {
+						err := errors[0]
+						errors = errors[1:]
+						return err
+					}
+					return nil
+				})
+
+				if err != nil {
+					atomic.AddInt32(&fails, 1)
+				} else {
+					atomic.AddInt32(&oks, 1)
+				}
+			}
+		}
+
+		var wg sync.WaitGroup
+		for i := 0; i < test.Worker; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				worker()
+			}()
+		}
+
+		wg.Wait()
+
+		assert.Equal(t, test.NCalls, int(calls))
+		assert.Equal(t, test.NOK, int(oks))
+		assert.Equal(t, test.NFails, int(fails))
+	}
+}

--- a/libbeat/processors/actions/lookup/lutool/runner.go
+++ b/libbeat/processors/actions/lookup/lutool/runner.go
@@ -1,0 +1,79 @@
+package lutool
+
+import (
+	"time"
+
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/logp"
+)
+
+type runner struct {
+	backoff BackoffConfig
+	module  Runner
+}
+
+type BackoffConfig struct {
+	Duration time.Duration `config:"duration" validate:"min=0"`
+	Factor   float64       `config:"factor"   validate:"min=1.0"`
+	Max      time.Duration `config:"max"      validate:"min=0"`
+}
+
+func newRunner(backoff BackoffConfig, backend Runner) (*runner, error) {
+	return &runner{backoff, backend}, nil
+}
+
+func (r *runner) do(e *binEntry, event common.MapStr) error {
+	debugf("Execute lookup for key: ", e.key)
+
+	backoff, err := r.checkBackoff(e)
+	if err != nil {
+		return err
+	}
+
+	value, err := r.module.Exec(event)
+	if err != nil {
+		logp.Err("Lookup runner returned error: ", err)
+		e.value = binError{time.Now(), backoff, err}
+		return err
+	}
+
+	debugf("Lookup returned fields: ", value)
+	e.value = binLookupValue(value)
+	return nil
+}
+
+// backoff checks if entry is to be run or last error must be returned.
+// Returns the last used backoff duration for storing with failed event and
+// last known error if command shall not be run yet. Error being nil is returned
+// if command shall be executed.
+func (r *runner) checkBackoff(e *binEntry) (time.Duration, error) {
+	backoff := r.backoff.Duration
+	if backoff == 0 { // check backoff being enabled
+		return 0, nil
+	}
+
+	// do not backoff, if entry is new
+	v := e.value
+	if v == nil {
+		return 0, nil
+	}
+	err := v.error()
+	if err == nil {
+		return 0, nil
+	}
+
+	// increment backoff up to max
+	f := r.backoff.Factor
+	backoff = v.backoff() + time.Duration(f*float64(backoff))
+	if backoff > r.backoff.Max {
+		backoff = r.backoff.Max
+	}
+
+	dur := time.Now().Sub(v.lastRun())
+	if dur < backoff {
+		return v.backoff(), err
+	}
+
+	// run command with updated backoff on next fail
+	return backoff, nil
+}

--- a/libbeat/processors/actions/lookup/lutool/util.go
+++ b/libbeat/processors/actions/lookup/lutool/util.go
@@ -1,0 +1,82 @@
+package lutool
+
+import (
+	"errors"
+	"reflect"
+	"strconv"
+
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/logp"
+)
+
+func makeFieldsCollector(fields []string) (func(common.MapStr) ([]string, bool), error) {
+	type stringer interface {
+		String() string
+	}
+
+	b := func(event common.MapStr) ([]string, bool) {
+		keys := make([]string, len(fields))
+		return collectFieldsInto(keys, fields, event)
+	}
+
+	if len(fields) == 0 {
+		return nil, errors.New("No keys configured")
+	}
+	return b, nil
+}
+
+func collectFieldsInto(
+	to []string,
+	fields []string,
+	event common.MapStr,
+) ([]string, bool) {
+
+	if len(to) != len(fields) {
+		return nil, false
+	}
+
+	for i, f := range fields {
+		s, err := fieldString(event, f)
+		if err != nil {
+			return nil, false
+		}
+
+		to[i] = s
+	}
+
+	return to, true
+}
+
+// TODO: move to libbeat/common and remove duplicate code
+func fieldString(event common.MapStr, field string) (string, error) {
+	type stringer interface {
+		String() string
+	}
+
+	v, err := event.GetValue(field)
+	if err != nil {
+		return "", err
+	}
+
+	switch s := v.(type) {
+	case string:
+		return s, nil
+	case []byte:
+		return string(s), nil
+	case stringer:
+		return s.String(), nil
+	case int8, int16, int32, int64, int:
+		i := reflect.ValueOf(s).Int()
+		return strconv.FormatInt(i, 16), nil
+	case uint8, uint16, uint32, uint64, uint:
+		u := reflect.ValueOf(s).Uint()
+		return strconv.FormatUint(u, 16), nil
+	case float32:
+		return strconv.FormatFloat(float64(s), 'g', -1, 32), nil
+	case float64:
+		return strconv.FormatFloat(s, 'g', -1, 64), nil
+	default:
+		logp.Warn("Can not convert key '%v' value to string", v)
+		return "", errConvertString
+	}
+}


### PR DESCRIPTION
experimental lookup processor.

```
$ go test -cover ./...
?   	github.com/elastic/beats/libbeat/processors/actions/lookup	[no test files]
ok  	github.com/elastic/beats/libbeat/processors/actions/lookup/exec	0.179s	coverage: 76.1% of statements
ok  	github.com/elastic/beats/libbeat/processors/actions/lookup/lutool	0.328s	coverage: 86.8% of statements
```