### PR TITLE
Add gotestcover to vendor directory

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -38,7 +38,7 @@ install:
       }
   - set PATH=C:\tools\mingw64\bin;%GOROOT%\bin;%PATH%
   - set PATH=%GOPATH%\bin;%PATH%
-  - go get github.com/pierrre/gotestcover
+  - go install github.com/elastic/beats/vendor/github.com/pierrre/gotestcover
   - go version
   - go env
   # Download the PyWin32 installer if it is not cached.

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,14 +6,6 @@ RUN set -x && \
     apt-get install -y netcat && \
     apt-get clean
 
-
-## Install go package dependencies
-RUN set -x \
-  go get \
-	github.com/pierrre/gotestcover \
-	github.com/tsg/goautotest \
-	golang.org/x/tools/cmd/vet
-
 COPY libbeat/scripts/docker-entrypoint.sh /entrypoint.sh
 
 RUN mkdir -p /etc/pki/tls/certs

--- a/libbeat/Dockerfile
+++ b/libbeat/Dockerfile
@@ -7,13 +7,6 @@ RUN set -x && \
     apt-get install -y netcat python-virtualenv python-pip && \
     apt-get clean
 
-## Install go package dependencies
-RUN set -x \
-  go get \
-	github.com/pierrre/gotestcover \
-	github.com/tsg/goautotest \
-	golang.org/x/tools/cmd/vet
-
 ENV PYTHON_ENV=/tmp/python-env
 
 RUN test -d ${PYTHON_ENV} || virtualenv ${PYTHON_ENV}

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -114,7 +114,7 @@ ci:
 prepare-tests:
 	mkdir -p ${COVERAGE_DIR}
 	# gotestcover is needed to fetch coverage for multiple packages
-	go get github.com/pierrre/gotestcover
+	go install github.com/elastic/beats/vendor/github.com/pierrre/gotestcover
 
 # Runs the unit tests with coverage
 # Race is not enabled for unit tests because tests run much slower.

--- a/metricbeat/Dockerfile
+++ b/metricbeat/Dockerfile
@@ -6,14 +6,6 @@ RUN set -x && \
     apt-get install -y netcat python-virtualenv python-pip && \
     apt-get clean
 
-
-## Install go package dependencies
-RUN set -x \
-  go get \
-	github.com/pierrre/gotestcover \
-	github.com/tsg/goautotest \
-	golang.org/x/tools/cmd/vet
-
 # Setup work environment
 ENV METRICBEAT_PATH /go/src/github.com/elastic/beats/metricbeat
 

--- a/packetbeat/Dockerfile
+++ b/packetbeat/Dockerfile
@@ -7,15 +7,7 @@ RUN set -x && \
     apt-get install -y netcat python-virtualenv python-pip && \
     apt-get clean
 
-## Install go package dependencies
-RUN set -x \
-  go get \
-	github.com/pierrre/gotestcover \
-	github.com/tsg/goautotest \
-	golang.org/x/tools/cmd/vet
-
 ENV PYTHON_ENV=/tmp/python-env
-
 
 RUN test -d ${PYTHON_ENV} || virtualenv ${PYTHON_ENV}
 RUN . ${PYTHON_ENV}/bin/activate && pip install nose jinja2 PyYAML nose-timer

--- a/vendor/github.com/pierrre/gotestcover/LICENSE
+++ b/vendor/github.com/pierrre/gotestcover/LICENSE
@@ -1,0 +1,7 @@
+Copyright (C) 2015 Pierre Durand
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/pierrre/gotestcover/Makefile
+++ b/vendor/github.com/pierrre/gotestcover/Makefile
@@ -1,0 +1,19 @@
+#/bin/bash
+
+setup:
+	go get -u -v github.com/golang/lint/golint
+	go get -v -t ./...
+
+check:
+	gofmt -d .
+	go tool vet .
+	golint
+
+coverage:
+	gotestcover -coverprofile=coverage.txt github.com/pierrre/gotestcover
+	go tool cover -html=coverage.txt -o=coverage.html
+	
+clean:
+	-rm coverage.txt
+	-rm coverage.html
+	gofmt -w .

--- a/vendor/github.com/pierrre/gotestcover/README.md
+++ b/vendor/github.com/pierrre/gotestcover/README.md
@@ -1,0 +1,29 @@
+# Go test cover with multiple packages support
+
+## Deprecated
+Just use this script instead:
+```
+echo 'mode: atomic' > coverage.txt && go list ./... | xargs -n1 -I{} sh -c 'go test -covermode=atomic -coverprofile=coverage.tmp {} && tail -n +2 coverage.tmp >> coverage.txt' && rm coverage.tmp
+```
+It's easier to customize, gives you better control, and doesn't require to download a third-party tool.
+
+The repository will remain, but I will not update it anymore.
+If you want to add new features, create a new fork.
+
+## Features
+- Coverage profile with multiple packages (`go test` doesn't support that)
+
+## Install
+`go get github.com/pierrre/gotestcover`
+
+## Usage
+```sh
+gotestcover -coverprofile=cover.out mypackage
+go tool cover -html=cover.out -o=cover.html
+```
+
+Run on multiple package with:
+- `package1 package2`
+- `package/...`
+
+Some `go test / build` flags are available.

--- a/vendor/github.com/pierrre/gotestcover/gotestcover.go
+++ b/vendor/github.com/pierrre/gotestcover/gotestcover.go
@@ -1,0 +1,282 @@
+// Package gotestcover provides multiple packages support for Go test cover.
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"sync"
+)
+
+var (
+	// go build
+	flagA    bool
+	flagX    bool
+	flagRace bool
+	flagTags string
+
+	// go test
+	flagV            bool
+	flagCount        int
+	flagCPU          string
+	flagParallel     string
+	flagRun          string
+	flagShort        bool
+	flagTimeout      string
+	flagCoverMode    string
+	flagCoverProfile string
+
+	// custom
+	flagParallelPackages = runtime.GOMAXPROCS(0)
+
+	// GAE/Go
+	flagGoogleAppEngine bool
+)
+
+func main() {
+	err := run()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	err := parseFlags()
+	if err != nil {
+		return err
+	}
+	pkgArgs, flagArgs := parseArgs()
+	pkgs, err := resolvePackages(pkgArgs)
+	if err != nil {
+		return err
+	}
+	cov, failed := runAllPackageTests(pkgs, flagArgs, func(out string) {
+		fmt.Print(out)
+	})
+	err = writeCoverProfile(cov)
+	if err != nil {
+		return err
+	}
+	if failed {
+		return fmt.Errorf("test failed")
+	}
+	return nil
+}
+
+func parseFlags() error {
+	flag.BoolVar(&flagA, "a", flagA, "see 'go build' help")
+	flag.BoolVar(&flagX, "x", flagX, "see 'go build' help")
+	flag.BoolVar(&flagRace, "race", flagRace, "see 'go build' help")
+	flag.StringVar(&flagTags, "tags", flagTags, "see 'go build' help")
+
+	flag.BoolVar(&flagV, "v", flagV, "see 'go test' help")
+	flag.IntVar(&flagCount, "count", flagCount, "see 'go test' help")
+	flag.StringVar(&flagCPU, "cpu", flagCPU, "see 'go test' help")
+	flag.StringVar(&flagParallel, "parallel", flagParallel, "see 'go test' help")
+	flag.StringVar(&flagRun, "run", flagRun, "see 'go test' help")
+	flag.BoolVar(&flagShort, "short", flagShort, "see 'go test' help")
+	flag.StringVar(&flagTimeout, "timeout", flagTimeout, "see 'go test' help")
+	flag.StringVar(&flagCoverMode, "covermode", flagCoverMode, "see 'go test' help")
+	flag.StringVar(&flagCoverProfile, "coverprofile", flagCoverProfile, "see 'go test' help")
+
+	flag.IntVar(&flagParallelPackages, "parallelpackages", flagParallelPackages, "Number of package test run in parallel")
+
+	flag.BoolVar(&flagGoogleAppEngine, "gae", flagGoogleAppEngine, "Bool of Command exec in GAE/Go")
+
+	flag.Parse()
+	if flagCoverProfile == "" {
+		return fmt.Errorf("flag coverprofile must be set")
+	}
+	if flagParallelPackages < 1 {
+		return fmt.Errorf("flag parallelpackages must be greater than or equal to 1")
+	}
+	return nil
+}
+
+func parseArgs() (pkgArgs, flagArgs []string) {
+	args := flag.Args()
+	for i, a := range args {
+		if strings.HasPrefix(a, "-") {
+			return args[:i], args[i:]
+		}
+	}
+	return args, nil
+}
+
+func resolvePackages(pkgArgs []string) ([]string, error) {
+	cmdArgs := []string{"list"}
+	cmdArgs = append(cmdArgs, pkgArgs...)
+	cmdOut, err := runGoCommand(cmdArgs...)
+	if err != nil {
+		return nil, err
+	}
+	var pkgs []string
+	sc := bufio.NewScanner(bytes.NewReader(cmdOut))
+	for sc.Scan() {
+		pkgs = append(pkgs, sc.Text())
+	}
+	return pkgs, nil
+}
+
+func runAllPackageTests(pkgs []string, flgs []string, pf func(string)) ([]byte, bool) {
+	pkgch := make(chan string)
+	type res struct {
+		out string
+		cov []byte
+		err error
+	}
+	resch := make(chan res)
+	wg := new(sync.WaitGroup)
+	wg.Add(flagParallelPackages)
+	go func() {
+		for _, pkg := range pkgs {
+			pkgch <- pkg
+		}
+		close(pkgch)
+		wg.Wait()
+		close(resch)
+	}()
+	for i := 0; i < flagParallelPackages; i++ {
+		go func() {
+			for p := range pkgch {
+				out, cov, err := runPackageTests(p, flgs)
+				resch <- res{
+					out: out,
+					cov: cov,
+					err: err,
+				}
+			}
+			wg.Done()
+		}()
+	}
+	failed := false
+	var cov []byte
+	for r := range resch {
+		if r.err == nil {
+			pf(r.out)
+			cov = append(cov, r.cov...)
+		} else {
+			pf(r.err.Error())
+			failed = true
+		}
+	}
+	return cov, failed
+}
+
+func runPackageTests(pkg string, flgs []string) (out string, cov []byte, err error) {
+	coverFile, err := ioutil.TempFile("", "gotestcover-")
+	if err != nil {
+		return "", nil, err
+	}
+	defer os.Remove(coverFile.Name())
+	defer coverFile.Close()
+	var args []string
+	args = append(args, "test")
+
+	if flagA {
+		args = append(args, "-a")
+	}
+	if flagX {
+		args = append(args, "-x")
+	}
+	if flagRace {
+		args = append(args, "-race")
+	}
+	if flagTags != "" {
+		args = append(args, "-tags", flagTags)
+	}
+
+	if flagV {
+		args = append(args, "-v")
+	}
+	if flagCount != 0 {
+		args = append(args, "-count", fmt.Sprint(flagCount))
+	}
+	if flagCPU != "" {
+		args = append(args, "-cpu", flagCPU)
+	}
+	if flagParallel != "" {
+		args = append(args, "-parallel", flagParallel)
+	}
+	if flagRun != "" {
+		args = append(args, "-run", flagRun)
+	}
+	if flagShort {
+		args = append(args, "-short")
+	}
+	if flagTimeout != "" {
+		args = append(args, "-timeout", flagTimeout)
+	}
+	args = append(args, "-cover")
+	if flagCoverMode != "" {
+		args = append(args, "-covermode", flagCoverMode)
+	}
+	args = append(args, "-coverprofile", coverFile.Name())
+
+	args = append(args, pkg)
+
+	args = append(args, flgs...)
+
+	cmdOut, err := runGoCommand(args...)
+	if err != nil {
+		return "", nil, err
+	}
+	cov, err = ioutil.ReadAll(coverFile)
+	if err != nil {
+		return "", nil, err
+	}
+	cov = removeFirstLine(cov)
+	return string(cmdOut), cov, nil
+}
+
+func writeCoverProfile(cov []byte) error {
+	if len(cov) == 0 {
+		return nil
+	}
+	buf := new(bytes.Buffer)
+	mode := flagCoverMode
+	if mode == "" {
+		if flagRace {
+			mode = "atomic"
+		} else {
+			mode = "set"
+		}
+	}
+	fmt.Fprintf(buf, "mode: %s\n", mode)
+	buf.Write(cov)
+	return ioutil.WriteFile(flagCoverProfile, buf.Bytes(), os.FileMode(0644))
+}
+
+func runGoCommand(args ...string) ([]byte, error) {
+	goCmd := "go"
+	if flagGoogleAppEngine {
+		goCmd = "goapp"
+	}
+	cmd := exec.Command(goCmd, args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("command %s: %s\n%s", cmd.Args, err, out)
+	}
+	return out, nil
+}
+
+func removeFirstLine(b []byte) []byte {
+	out := new(bytes.Buffer)
+	sc := bufio.NewScanner(bytes.NewReader(b))
+	firstLine := true
+	for sc.Scan() {
+		if firstLine {
+			firstLine = false
+			continue
+		}
+		fmt.Fprintf(out, "%s\n", sc.Bytes())
+	}
+	return out.Bytes()
+}

--- a/winlogbeat/make.bat
+++ b/winlogbeat/make.bat
@@ -5,7 +5,7 @@ REM Batch script to build and test on Windows. You can use this in conjunction
 REM with the Vagrant machine.
 REM
 
-go get github.com/pierrre/gotestcover
+go install github.com/elastic/beats/vendor/github.com/pierrre/gotestcover
 if %errorlevel% neq 0 exit /b %errorlevel%
 
 echo Building


### PR DESCRIPTION
gotestcover is currently deprecated but does exactly what we need, so no need to replace it.

Add gotestcover to the vendor directory removes the need to fetch gotestcover during the building process. This means one less component with external dependencies during the build process.

Remove go vet and autotest from build process as not needed anymore

This PR replaces https://github.com/elastic/beats/pull/2013