### PR TITLE
Use scaled_floats for percentages in ES mapping

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -45,6 +45,8 @@ https://github.com/elastic/beats/compare/v5.0.0-alpha5...master[Check the HEAD d
 
 *Metricbeat*
 
+- Use the new scaled_float Elasticsearch type for the percentage values. {pull}2156[2156]
+
 *Packetbeat*
 
 *Topbeat*

--- a/libbeat/scripts/generate_template.py
+++ b/libbeat/scripts/generate_template.py
@@ -178,18 +178,23 @@ def fill_field_properties(args, field, defaults, path):
             }
 
     elif field["type"] in ["geo_point", "date", "long", "integer",
-                           "double", "float", "half_float", "boolean"]:
+                           "double", "float", "half_float", "scaled_float",
+                           "boolean"]:
         # Convert all integer fields to long
         if field["type"] == "integer":
             field["type"] = "long"
 
-        if args.es2x and field["type"] == "half_float":
-            # ES 2.x doesn't support half floats, so convert to floats
+        if args.es2x and field["type"] in ["half_float", "scaled_float"]:
+            # ES 2.x doesn't support half or scaled floats, so convert to float
             field["type"] = "float"
 
         properties[field["name"]] = {
             "type": field.get("type")
         }
+
+        if field["type"] == "scaled_float":
+            properties[field["name"]]["scaling_factor"] = \
+                field.get("scaling_factor", 1000)
 
     elif field["type"] in ["dict", "list"]:
         if field.get("dict-type") == "keyword":

--- a/metricbeat/docs/fields.asciidoc
+++ b/metricbeat/docs/fields.asciidoc
@@ -141,7 +141,7 @@ CPU stats.
 [float]
 === apache.status.cpu.load
 
-type: half_float
+type: scaled_float
 
 CPU Load.
 
@@ -149,7 +149,7 @@ CPU Load.
 [float]
 === apache.status.cpu.user
 
-type: half_float
+type: scaled_float
 
 CPU user load.
 
@@ -157,7 +157,7 @@ CPU user load.
 [float]
 === apache.status.cpu.system
 
-type: half_float
+type: scaled_float
 
 System cpu.
 
@@ -165,7 +165,7 @@ System cpu.
 [float]
 === apache.status.cpu.children_user
 
-type: half_float
+type: scaled_float
 
 CPU of children user.
 
@@ -173,7 +173,7 @@ CPU of children user.
 [float]
 === apache.status.cpu.children_system
 
-type: half_float
+type: scaled_float
 
 CPU of children system.
 
@@ -1899,7 +1899,7 @@ CPU Core number.
 [float]
 === system.core.user.pct
 
-type: half_float
+type: scaled_float
 
 The percentage of CPU time spent in user space. On multi-core systems, you can have percentages that are greater than 100%. For example, if 3 cores are at 60% use, then the `cpu.user_p` will be 180%.
 
@@ -1915,7 +1915,7 @@ The amount of CPU time spent in user space.
 [float]
 === system.core.system.pct
 
-type: half_float
+type: scaled_float
 
 The percentage of CPU time spent in kernel space.
 
@@ -1931,7 +1931,7 @@ The amount of CPU time spent in kernel space.
 [float]
 === system.core.nice.pct
 
-type: half_float
+type: scaled_float
 
 The percentage of CPU time spent on low-priority processes.
 
@@ -1947,7 +1947,7 @@ The amount of CPU time spent on low-priority processes.
 [float]
 === system.core.idle.pct
 
-type: half_float
+type: scaled_float
 
 The percentage of CPU time spent idle.
 
@@ -1963,7 +1963,7 @@ The amount of CPU time spent idle.
 [float]
 === system.core.iowait.pct
 
-type: half_float
+type: scaled_float
 
 The percentage of CPU time spent in wait (on disk).
 
@@ -1979,7 +1979,7 @@ The amount of CPU time spent in wait (on disk).
 [float]
 === system.core.irq.pct
 
-type: half_float
+type: scaled_float
 
 The percentage of CPU time spent servicing and handling hardware interrupts.
 
@@ -1995,7 +1995,7 @@ The amount of CPU time spent servicing and handling hardware interrupts.
 [float]
 === system.core.softirq.pct
 
-type: half_float
+type: scaled_float
 
 The percentage of CPU time spent servicing and handling software interrupts.
 
@@ -2011,7 +2011,7 @@ The amount of CPU time spent servicing and handling software interrupts.
 [float]
 === system.core.steal.pct
 
-type: half_float
+type: scaled_float
 
 The percentage of CPU time spent in involuntary wait by the virtual CPU while the hypervisor was servicing another processor. Available only on Unix.
 
@@ -2034,7 +2034,7 @@ The amount of CPU time spent in involuntary wait by the virtual CPU while the hy
 [float]
 === system.cpu.user.pct
 
-type: half_float
+type: scaled_float
 
 The percentage of CPU time spent in user space. On multi-core systems, you can have percentages that are greater than 100%. For example, if 3 cores are at 60% use, then the `cpu.user_p` will be 180%.
 
@@ -2042,7 +2042,7 @@ The percentage of CPU time spent in user space. On multi-core systems, you can h
 [float]
 === system.cpu.system.pct
 
-type: half_float
+type: scaled_float
 
 The percentage of CPU time spent in kernel space.
 
@@ -2050,7 +2050,7 @@ The percentage of CPU time spent in kernel space.
 [float]
 === system.cpu.nice.pct
 
-type: half_float
+type: scaled_float
 
 The percentage of CPU time spent on low-priority processes.
 
@@ -2058,7 +2058,7 @@ The percentage of CPU time spent on low-priority processes.
 [float]
 === system.cpu.idle.pct
 
-type: half_float
+type: scaled_float
 
 The percentage of CPU time spent idle.
 
@@ -2066,7 +2066,7 @@ The percentage of CPU time spent idle.
 [float]
 === system.cpu.iowait.pct
 
-type: half_float
+type: scaled_float
 
 The percentage of CPU time spent in wait (on disk).
 
@@ -2074,7 +2074,7 @@ The percentage of CPU time spent in wait (on disk).
 [float]
 === system.cpu.irq.pct
 
-type: half_float
+type: scaled_float
 
 The percentage of CPU time spent servicing and handling hardware interrupts.
 
@@ -2082,7 +2082,7 @@ The percentage of CPU time spent servicing and handling hardware interrupts.
 [float]
 === system.cpu.softirq.pct
 
-type: half_float
+type: scaled_float
 
 The percentage of CPU time spent servicing and handling software interrupts.
 
@@ -2090,7 +2090,7 @@ The percentage of CPU time spent servicing and handling software interrupts.
 [float]
 === system.cpu.steal.pct
 
-type: half_float
+type: scaled_float
 
 The percentage of CPU time spent in involuntary wait by the virtual CPU while the hypervisor was servicing another processor. Available only on Unix.
 
@@ -2314,7 +2314,7 @@ The used disk space in bytes.
 [float]
 === system.filesystem.used.pct
 
-type: half_float
+type: scaled_float
 
 The percentage of used disk space.
 
@@ -2380,7 +2380,7 @@ Load averages.
 [float]
 === system.load.1
 
-type: half_float
+type: scaled_float
 
 Load average for the last minute.
 
@@ -2388,7 +2388,7 @@ Load average for the last minute.
 [float]
 === system.load.5
 
-type: half_float
+type: scaled_float
 
 Load average for the last 5 minutes.
 
@@ -2396,7 +2396,7 @@ Load average for the last 5 minutes.
 [float]
 === system.load.15
 
-type: half_float
+type: scaled_float
 
 Load average for the last 15 minutes.
 
@@ -2404,7 +2404,7 @@ Load average for the last 15 minutes.
 [float]
 === system.load.norm.1
 
-type: half_float
+type: scaled_float
 
 Load divided by the number of cores for the last minute.
 
@@ -2412,7 +2412,7 @@ Load divided by the number of cores for the last minute.
 [float]
 === system.load.norm.5
 
-type: half_float
+type: scaled_float
 
 Load divided by the number of cores for the last 5 minutes.
 
@@ -2420,7 +2420,7 @@ Load divided by the number of cores for the last 5 minutes.
 [float]
 === system.load.norm.15
 
-type: half_float
+type: scaled_float
 
 Load divided by the number of cores for the last 15 minutes.
 
@@ -2459,7 +2459,7 @@ The total amount of free memory in bytes. This value does not include memory con
 [float]
 === system.memory.used.pct
 
-type: half_float
+type: scaled_float
 
 The percentage of used memory.
 
@@ -2490,7 +2490,7 @@ Actual free memory in bytes. It is calculated based on the OS. On Linux it consi
 [float]
 === system.memory.actual.used.pct
 
-type: half_float
+type: scaled_float
 
 The percentage of actual used memory.
 
@@ -2528,7 +2528,7 @@ Available swap memory.
 [float]
 === system.memory.swap.used.pct
 
-type: half_float
+type: scaled_float
 
 The percentage of used swap memory.
 
@@ -2694,7 +2694,7 @@ The amount of CPU time the process spent in user space.
 [float]
 === system.process.cpu.total.pct
 
-type: half_float
+type: scaled_float
 
 The percentage of CPU time spent by the process since the last update. Its value is similar to the %CPU value of the process displayed by the top command on Unix systems.
 
@@ -2748,7 +2748,7 @@ The Resident Set Size. The amount of memory the process occupied in main memory 
 [float]
 === system.process.memory.rss.pct
 
-type: half_float
+type: scaled_float
 
 The percentage of memory the process occupied in main memory (RAM).
 

--- a/metricbeat/etc/fields.yml
+++ b/metricbeat/etc/fields.yml
@@ -95,23 +95,23 @@
                 CPU stats.
               fields:
                 - name: load
-                  type: half_float
+                  type: scaled_float
                   description: >
                     CPU Load.
                 - name: user
-                  type: half_float
+                  type: scaled_float
                   description: >
                     CPU user load.
                 - name: system
-                  type: half_float
+                  type: scaled_float
                   description: >
                     System cpu.
                 - name: children_user
-                  type: half_float
+                  type: scaled_float
                   description: >
                     CPU of children user.
                 - name: children_system
-                  type: half_float
+                  type: scaled_float
                   description: >
                     CPU of children system.
             - name: connections
@@ -1116,7 +1116,7 @@
                 CPU Core number.
 
             - name: user.pct
-              type: half_float
+              type: scaled_float
               description: >
                 The percentage of CPU time spent in user space. On multi-core systems, you can have percentages that are greater than 100%.
                 For example, if 3 cores are at 60% use, then the `cpu.user_p` will be 180%.
@@ -1127,7 +1127,7 @@
                The amount of CPU time spent in user space.
 
             - name: system.pct
-              type: half_float
+              type: scaled_float
               description: >
                 The percentage of CPU time spent in kernel space.
 
@@ -1137,7 +1137,7 @@
                 The amount of CPU time spent in kernel space.
 
             - name: nice.pct
-              type: half_float
+              type: scaled_float
               description: >
                 The percentage of CPU time spent on low-priority processes.
 
@@ -1147,7 +1147,7 @@
                 The amount of CPU time spent on low-priority processes.
 
             - name: idle.pct
-              type: half_float
+              type: scaled_float
               description: >
                 The percentage of CPU time spent idle.
 
@@ -1157,7 +1157,7 @@
                 The amount of CPU time spent idle.
 
             - name: iowait.pct
-              type: half_float
+              type: scaled_float
               description: >
                 The percentage of CPU time spent in wait (on disk).
 
@@ -1167,7 +1167,7 @@
                 The amount of CPU time spent in wait (on disk).
 
             - name: irq.pct
-              type: half_float
+              type: scaled_float
               description: >
                 The percentage of CPU time spent servicing and handling hardware interrupts.
 
@@ -1177,7 +1177,7 @@
                 The amount of CPU time spent servicing and handling hardware interrupts.
 
             - name: softirq.pct
-              type: half_float
+              type: scaled_float
               description: >
                 The percentage of CPU time spent servicing and handling software interrupts.
 
@@ -1187,7 +1187,7 @@
                 The amount of CPU time spent servicing and handling software interrupts.
 
             - name: steal.pct
-              type: half_float
+              type: scaled_float
               description: >
                 The percentage of CPU time spent in involuntary wait by the virtual CPU while the hypervisor
                 was servicing another processor.
@@ -1206,43 +1206,43 @@
             `cpu` contains local CPU stats.
           fields:
             - name: user.pct
-              type: half_float
+              type: scaled_float
               description: >
                 The percentage of CPU time spent in user space. On multi-core systems, you can have percentages that are greater than 100%.
                 For example, if 3 cores are at 60% use, then the `cpu.user_p` will be 180%.
 
             - name: system.pct
-              type: half_float
+              type: scaled_float
               description: >
                 The percentage of CPU time spent in kernel space.
 
             - name: nice.pct
-              type: half_float
+              type: scaled_float
               description: >
                 The percentage of CPU time spent on low-priority processes.
 
             - name: idle.pct
-              type: half_float
+              type: scaled_float
               description: >
                 The percentage of CPU time spent idle.
 
             - name: iowait.pct
-              type: half_float
+              type: scaled_float
               description: >
                 The percentage of CPU time spent in wait (on disk).
 
             - name: irq.pct
-              type: half_float
+              type: scaled_float
               description: >
                 The percentage of CPU time spent servicing and handling hardware interrupts.
 
             - name: softirq.pct
-              type: half_float
+              type: scaled_float
               description: >
                 The percentage of CPU time spent servicing and handling software interrupts.
 
             - name: steal.pct
-              type: half_float
+              type: scaled_float
               description: >
                 The percentage of CPU time spent in involuntary wait by the virtual CPU while the hypervisor
                 was servicing another processor.
@@ -1381,7 +1381,7 @@
               description: >
                 The used disk space in bytes.
             - name: used.pct
-              type: half_float
+              type: scaled_float
               description: >
                 The percentage of used disk space.
 
@@ -1420,30 +1420,36 @@
             Load averages.
           fields:
             - name: "1"
-              type: half_float
+              type: scaled_float
+              scaling_factor: 100
               description: >
                 Load average for the last minute.
             - name: "5"
-              type: half_float
+              type: scaled_float
+              scaling_factor: 100
               description: >
                 Load average for the last 5 minutes.
             - name: "15"
-              type: half_float
+              type: scaled_float
+              scaling_factor: 100
               description: >
                 Load average for the last 15 minutes.
 
             - name: "norm.1"
-              type: half_float
+              type: scaled_float
+              scaling_factor: 100
               description: >
                 Load divided by the number of cores for the last minute.
 
             - name: "norm.5"
-              type: half_float
+              type: scaled_float
+              scaling_factor: 100
               description: >
                 Load divided by the number of cores for the last 5 minutes.
 
             - name: "norm.15"
-              type: half_float
+              type: scaled_float
+              scaling_factor: 100
               description: >
                 Load divided by the number of cores for the last 15 minutes.
         - name: memory
@@ -1468,7 +1474,7 @@
                 buffers (see system.memory.actual.free).
 
             - name: used.pct
-              type: half_float
+              type: scaled_float
               description: >
                 The percentage of used memory.
 
@@ -1493,7 +1499,7 @@
                     of the calling process.
 
                 - name: used.pct
-                  type: half_float
+                  type: scaled_float
                   description: >
                     The percentage of actual used memory.
 
@@ -1518,7 +1524,7 @@
                     Available swap memory.
 
                 - name: used.pct
-                  type: half_float
+                  type: scaled_float
                   description: >
                     The percentage of used swap memory.
         - name: network
@@ -1619,7 +1625,7 @@
                   description: >
                     The amount of CPU time the process spent in user space.
                 - name: total.pct
-                  type: half_float
+                  type: scaled_float
                   description: >
                     The percentage of CPU time spent by the process since the last update. Its value is similar to the
                     %CPU value of the process displayed by the top command on Unix systems.
@@ -1649,7 +1655,7 @@
                   description: >
                     The Resident Set Size. The amount of memory the process occupied in main memory (RAM).
                 - name: rss.pct
-                  type: half_float
+                  type: scaled_float
                   description: >
                     The percentage of memory the process occupied in main memory (RAM).
                 - name: share

--- a/metricbeat/metricbeat.template.json
+++ b/metricbeat/metricbeat.template.json
@@ -53,19 +53,24 @@
                 "cpu": {
                   "properties": {
                     "children_system": {
-                      "type": "half_float"
+                      "scaling_factor": 1000,
+                      "type": "scaled_float"
                     },
                     "children_user": {
-                      "type": "half_float"
+                      "scaling_factor": 1000,
+                      "type": "scaled_float"
                     },
                     "load": {
-                      "type": "half_float"
+                      "scaling_factor": 1000,
+                      "type": "scaled_float"
                     },
                     "system": {
-                      "type": "half_float"
+                      "scaling_factor": 1000,
+                      "type": "scaled_float"
                     },
                     "user": {
-                      "type": "half_float"
+                      "scaling_factor": 1000,
+                      "type": "scaled_float"
                     }
                   }
                 },
@@ -948,7 +953,8 @@
                 "idle": {
                   "properties": {
                     "pct": {
-                      "type": "half_float"
+                      "scaling_factor": 1000,
+                      "type": "scaled_float"
                     },
                     "ticks": {
                       "type": "long"
@@ -958,7 +964,8 @@
                 "iowait": {
                   "properties": {
                     "pct": {
-                      "type": "half_float"
+                      "scaling_factor": 1000,
+                      "type": "scaled_float"
                     },
                     "ticks": {
                       "type": "long"
@@ -968,7 +975,8 @@
                 "irq": {
                   "properties": {
                     "pct": {
-                      "type": "half_float"
+                      "scaling_factor": 1000,
+                      "type": "scaled_float"
                     },
                     "ticks": {
                       "type": "long"
@@ -978,7 +986,8 @@
                 "nice": {
                   "properties": {
                     "pct": {
-                      "type": "half_float"
+                      "scaling_factor": 1000,
+                      "type": "scaled_float"
                     },
                     "ticks": {
                       "type": "long"
@@ -988,7 +997,8 @@
                 "softirq": {
                   "properties": {
                     "pct": {
-                      "type": "half_float"
+                      "scaling_factor": 1000,
+                      "type": "scaled_float"
                     },
                     "ticks": {
                       "type": "long"
@@ -998,7 +1008,8 @@
                 "steal": {
                   "properties": {
                     "pct": {
-                      "type": "half_float"
+                      "scaling_factor": 1000,
+                      "type": "scaled_float"
                     },
                     "ticks": {
                       "type": "long"
@@ -1008,7 +1019,8 @@
                 "system": {
                   "properties": {
                     "pct": {
-                      "type": "half_float"
+                      "scaling_factor": 1000,
+                      "type": "scaled_float"
                     },
                     "ticks": {
                       "type": "long"
@@ -1018,7 +1030,8 @@
                 "user": {
                   "properties": {
                     "pct": {
-                      "type": "half_float"
+                      "scaling_factor": 1000,
+                      "type": "scaled_float"
                     },
                     "ticks": {
                       "type": "long"
@@ -1032,7 +1045,8 @@
                 "idle": {
                   "properties": {
                     "pct": {
-                      "type": "half_float"
+                      "scaling_factor": 1000,
+                      "type": "scaled_float"
                     },
                     "ticks": {
                       "type": "long"
@@ -1042,7 +1056,8 @@
                 "iowait": {
                   "properties": {
                     "pct": {
-                      "type": "half_float"
+                      "scaling_factor": 1000,
+                      "type": "scaled_float"
                     },
                     "ticks": {
                       "type": "long"
@@ -1052,7 +1067,8 @@
                 "irq": {
                   "properties": {
                     "pct": {
-                      "type": "half_float"
+                      "scaling_factor": 1000,
+                      "type": "scaled_float"
                     },
                     "ticks": {
                       "type": "long"
@@ -1062,7 +1078,8 @@
                 "nice": {
                   "properties": {
                     "pct": {
-                      "type": "half_float"
+                      "scaling_factor": 1000,
+                      "type": "scaled_float"
                     },
                     "ticks": {
                       "type": "long"
@@ -1072,7 +1089,8 @@
                 "softirq": {
                   "properties": {
                     "pct": {
-                      "type": "half_float"
+                      "scaling_factor": 1000,
+                      "type": "scaled_float"
                     },
                     "ticks": {
                       "type": "long"
@@ -1082,7 +1100,8 @@
                 "steal": {
                   "properties": {
                     "pct": {
-                      "type": "half_float"
+                      "scaling_factor": 1000,
+                      "type": "scaled_float"
                     },
                     "ticks": {
                       "type": "long"
@@ -1092,7 +1111,8 @@
                 "system": {
                   "properties": {
                     "pct": {
-                      "type": "half_float"
+                      "scaling_factor": 1000,
+                      "type": "scaled_float"
                     },
                     "ticks": {
                       "type": "long"
@@ -1102,7 +1122,8 @@
                 "user": {
                   "properties": {
                     "pct": {
-                      "type": "half_float"
+                      "scaling_factor": 1000,
+                      "type": "scaled_float"
                     },
                     "ticks": {
                       "type": "long"
@@ -1187,7 +1208,8 @@
                       "type": "long"
                     },
                     "pct": {
-                      "type": "half_float"
+                      "scaling_factor": 1000,
+                      "type": "scaled_float"
                     }
                   }
                 }
@@ -1219,24 +1241,30 @@
             "load": {
               "properties": {
                 "1": {
-                  "type": "half_float"
+                  "scaling_factor": 100,
+                  "type": "scaled_float"
                 },
                 "15": {
-                  "type": "half_float"
+                  "scaling_factor": 100,
+                  "type": "scaled_float"
                 },
                 "5": {
-                  "type": "half_float"
+                  "scaling_factor": 100,
+                  "type": "scaled_float"
                 },
                 "norm": {
                   "properties": {
                     "1": {
-                      "type": "half_float"
+                      "scaling_factor": 100,
+                      "type": "scaled_float"
                     },
                     "15": {
-                      "type": "half_float"
+                      "scaling_factor": 100,
+                      "type": "scaled_float"
                     },
                     "5": {
-                      "type": "half_float"
+                      "scaling_factor": 100,
+                      "type": "scaled_float"
                     }
                   }
                 }
@@ -1255,7 +1283,8 @@
                           "type": "long"
                         },
                         "pct": {
-                          "type": "half_float"
+                          "scaling_factor": 1000,
+                          "type": "scaled_float"
                         }
                       }
                     }
@@ -1278,7 +1307,8 @@
                           "type": "long"
                         },
                         "pct": {
-                          "type": "half_float"
+                          "scaling_factor": 1000,
+                          "type": "scaled_float"
                         }
                       }
                     }
@@ -1293,7 +1323,8 @@
                       "type": "long"
                     },
                     "pct": {
-                      "type": "half_float"
+                      "scaling_factor": 1000,
+                      "type": "scaled_float"
                     }
                   }
                 }
@@ -1357,7 +1388,8 @@
                     "total": {
                       "properties": {
                         "pct": {
-                          "type": "half_float"
+                          "scaling_factor": 1000,
+                          "type": "scaled_float"
                         },
                         "ticks": {
                           "type": "long"
@@ -1377,7 +1409,8 @@
                           "type": "long"
                         },
                         "pct": {
-                          "type": "half_float"
+                          "scaling_factor": 1000,
+                          "type": "scaled_float"
                         }
                       }
                     },

--- a/metricbeat/module/apache/status/_meta/fields.yml
+++ b/metricbeat/module/apache/status/_meta/fields.yml
@@ -54,23 +54,23 @@
         CPU stats.
       fields:
         - name: load
-          type: half_float
+          type: scaled_float
           description: >
             CPU Load.
         - name: user
-          type: half_float
+          type: scaled_float
           description: >
             CPU user load.
         - name: system
-          type: half_float
+          type: scaled_float
           description: >
             System cpu.
         - name: children_user
-          type: half_float
+          type: scaled_float
           description: >
             CPU of children user.
         - name: children_system
-          type: half_float
+          type: scaled_float
           description: >
             CPU of children system.
     - name: connections

--- a/metricbeat/module/system/core/_meta/fields.yml
+++ b/metricbeat/module/system/core/_meta/fields.yml
@@ -9,7 +9,7 @@
         CPU Core number.
 
     - name: user.pct
-      type: half_float
+      type: scaled_float
       description: >
         The percentage of CPU time spent in user space. On multi-core systems, you can have percentages that are greater than 100%.
         For example, if 3 cores are at 60% use, then the `cpu.user_p` will be 180%.
@@ -20,7 +20,7 @@
        The amount of CPU time spent in user space.
 
     - name: system.pct
-      type: half_float
+      type: scaled_float
       description: >
         The percentage of CPU time spent in kernel space.
 
@@ -30,7 +30,7 @@
         The amount of CPU time spent in kernel space.
 
     - name: nice.pct
-      type: half_float
+      type: scaled_float
       description: >
         The percentage of CPU time spent on low-priority processes.
 
@@ -40,7 +40,7 @@
         The amount of CPU time spent on low-priority processes.
 
     - name: idle.pct
-      type: half_float
+      type: scaled_float
       description: >
         The percentage of CPU time spent idle.
 
@@ -50,7 +50,7 @@
         The amount of CPU time spent idle.
 
     - name: iowait.pct
-      type: half_float
+      type: scaled_float
       description: >
         The percentage of CPU time spent in wait (on disk).
 
@@ -60,7 +60,7 @@
         The amount of CPU time spent in wait (on disk).
 
     - name: irq.pct
-      type: half_float
+      type: scaled_float
       description: >
         The percentage of CPU time spent servicing and handling hardware interrupts.
 
@@ -70,7 +70,7 @@
         The amount of CPU time spent servicing and handling hardware interrupts.
 
     - name: softirq.pct
-      type: half_float
+      type: scaled_float
       description: >
         The percentage of CPU time spent servicing and handling software interrupts.
 
@@ -80,7 +80,7 @@
         The amount of CPU time spent servicing and handling software interrupts.
 
     - name: steal.pct
-      type: half_float
+      type: scaled_float
       description: >
         The percentage of CPU time spent in involuntary wait by the virtual CPU while the hypervisor
         was servicing another processor.

--- a/metricbeat/module/system/cpu/_meta/fields.yml
+++ b/metricbeat/module/system/cpu/_meta/fields.yml
@@ -4,43 +4,43 @@
     `cpu` contains local CPU stats.
   fields:
     - name: user.pct
-      type: half_float
+      type: scaled_float
       description: >
         The percentage of CPU time spent in user space. On multi-core systems, you can have percentages that are greater than 100%.
         For example, if 3 cores are at 60% use, then the `cpu.user_p` will be 180%.
 
     - name: system.pct
-      type: half_float
+      type: scaled_float
       description: >
         The percentage of CPU time spent in kernel space.
 
     - name: nice.pct
-      type: half_float
+      type: scaled_float
       description: >
         The percentage of CPU time spent on low-priority processes.
 
     - name: idle.pct
-      type: half_float
+      type: scaled_float
       description: >
         The percentage of CPU time spent idle.
 
     - name: iowait.pct
-      type: half_float
+      type: scaled_float
       description: >
         The percentage of CPU time spent in wait (on disk).
 
     - name: irq.pct
-      type: half_float
+      type: scaled_float
       description: >
         The percentage of CPU time spent servicing and handling hardware interrupts.
 
     - name: softirq.pct
-      type: half_float
+      type: scaled_float
       description: >
         The percentage of CPU time spent servicing and handling software interrupts.
 
     - name: steal.pct
-      type: half_float
+      type: scaled_float
       description: >
         The percentage of CPU time spent in involuntary wait by the virtual CPU while the hypervisor
         was servicing another processor.

--- a/metricbeat/module/system/filesystem/_meta/fields.yml
+++ b/metricbeat/module/system/filesystem/_meta/fields.yml
@@ -36,7 +36,7 @@
       description: >
         The used disk space in bytes.
     - name: used.pct
-      type: half_float
+      type: scaled_float
       description: >
         The percentage of used disk space.
 

--- a/metricbeat/module/system/load/_meta/fields.yml
+++ b/metricbeat/module/system/load/_meta/fields.yml
@@ -4,29 +4,35 @@
     Load averages.
   fields:
     - name: "1"
-      type: half_float
+      type: scaled_float
+      scaling_factor: 100
       description: >
         Load average for the last minute.
     - name: "5"
-      type: half_float
+      type: scaled_float
+      scaling_factor: 100
       description: >
         Load average for the last 5 minutes.
     - name: "15"
-      type: half_float
+      type: scaled_float
+      scaling_factor: 100
       description: >
         Load average for the last 15 minutes.
 
     - name: "norm.1"
-      type: half_float
+      type: scaled_float
+      scaling_factor: 100
       description: >
         Load divided by the number of cores for the last minute.
 
     - name: "norm.5"
-      type: half_float
+      type: scaled_float
+      scaling_factor: 100
       description: >
         Load divided by the number of cores for the last 5 minutes.
 
     - name: "norm.15"
-      type: half_float
+      type: scaled_float
+      scaling_factor: 100
       description: >
         Load divided by the number of cores for the last 15 minutes.

--- a/metricbeat/module/system/memory/_meta/fields.yml
+++ b/metricbeat/module/system/memory/_meta/fields.yml
@@ -20,7 +20,7 @@
         buffers (see system.memory.actual.free).
 
     - name: used.pct
-      type: half_float
+      type: scaled_float
       description: >
         The percentage of used memory.
 
@@ -45,7 +45,7 @@
             of the calling process.
 
         - name: used.pct
-          type: half_float
+          type: scaled_float
           description: >
             The percentage of actual used memory.
 
@@ -70,6 +70,6 @@
             Available swap memory.
 
         - name: used.pct
-          type: half_float
+          type: scaled_float
           description: >
             The percentage of used swap memory.

--- a/metricbeat/module/system/process/_meta/fields.yml
+++ b/metricbeat/module/system/process/_meta/fields.yml
@@ -45,7 +45,7 @@
           description: >
             The amount of CPU time the process spent in user space.
         - name: total.pct
-          type: half_float
+          type: scaled_float
           description: >
             The percentage of CPU time spent by the process since the last update. Its value is similar to the
             %CPU value of the process displayed by the top command on Unix systems.
@@ -75,7 +75,7 @@
           description: >
             The Resident Set Size. The amount of memory the process occupied in main memory (RAM).
         - name: rss.pct
-          type: half_float
+          type: scaled_float
           description: >
             The percentage of memory the process occupied in main memory (RAM).
         - name: share


### PR DESCRIPTION
Elasticsearch has recently added scaled_float as an option for storing floating
point numbers. The scaled floats are stored internally as longs, which means
they can take advantage of the integer compression in Lucene. See
https://github.com/elastic/elasticsearch/pull/19264 for details.

The PR moves all percentages to scaled floats. In our `fields.yml` we assume a
default scaling factor of 1000, which should work well for our percentages
(values between 0 and 1). This scaling factor can also be set to a different
value in `fields.yml`.