### PR TITLE
Change close_inactive default to 5m

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -21,6 +21,7 @@ https://github.com/elastic/beats/compare/v5.0.0-alpha5...master[Check the HEAD d
 *Topbeat*
 
 *Filebeat*
+- Set close_inactive default to 5 minutes (was 1 hour before)
 
 *Winlogbeat*
 
@@ -136,7 +137,7 @@ https://github.com/elastic/beats/compare/v5.0.0-alpha4...v5.0.0-alpha5[View comm
 
 - Introduce `close_removed` and `close_renamed` harvester options. {issue}1600[1600]
 - Introduce `close_eof` harvester option. {issue}1600[1600]
-- Add `clean_removed` config option. {issue}1600[1600]
+- Add `clean_removed` and `clean_inactive` config option. {issue}1600[1600]
 
 ==== Deprecated
 

--- a/filebeat/docs/reference/configuration/filebeat-options.asciidoc
+++ b/filebeat/docs/reference/configuration/filebeat-options.asciidoc
@@ -93,9 +93,9 @@ filebeat.prospectors:
   include_lines: ["^ERR", "^WARN"]
 -------------------------------------------------------------------------------------
 
-NOTE: If both `include_lines` and `exclude_lines` are defined, Filebeat executes `include_lines` first and then executes `exclude_lines`. 
+NOTE: If both `include_lines` and `exclude_lines` are defined, Filebeat executes `include_lines` first and then executes `exclude_lines`.
 The order in which the two options are defined doesn't matter. The `include_lines` option will always be executed
-before the `exclude_lines` option, even if `exclude_lines` appears before `include_lines` in the config file. 
+before the `exclude_lines` option, even if `exclude_lines` appears before `include_lines` in the config file.
 
 The following example exports all Apache log lines except the debugging messages (DBGs):
 
@@ -207,7 +207,7 @@ Setting `close_inactive` to a lower value means file handles are closed faster b
 
 The timestamp for closing a file does not depend on the modification time of the file but an internal timestamp that is update when the file was last harvested. If `close_inactive` is set to 5 minutes, the countdown for the 5 minutes starts the last time the harvester read a line from the file.
 
-You can use time strings like 2h (2 hours) and 5m (5 minutes). The default is 1h.
+You can use time strings like 2h (2 hours) and 5m (5 minutes). The default is 5m.
 
 
 ===== close_renamed

--- a/filebeat/etc/beat.full.yml
+++ b/filebeat/etc/beat.full.yml
@@ -166,7 +166,7 @@ filebeat.prospectors:
   # Close inactive closes the file handler after the predefined period.
   # The period starts when the last line of the file was, not the file ModTime.
   # Time strings like 2h (2 hours), 5m (5 minutes) can be used.
-  #close_inactive: 1h
+  #close_inactive: 5m
 
   # Close renamed closes a file handler when the file is renamed or rotated.
   # Note: Potential data loss. Make sure to read and understand the docs for this option.

--- a/filebeat/filebeat.full.yml
+++ b/filebeat/filebeat.full.yml
@@ -166,7 +166,7 @@ filebeat.prospectors:
   # Close inactive closes the file handler after the predefined period.
   # The period starts when the last line of the file was, not the file ModTime.
   # Time strings like 2h (2 hours), 5m (5 minutes) can be used.
-  #close_inactive: 1h
+  #close_inactive: 5m
 
   # Close renamed closes a file handler when the file is renamed or rotated.
   # Note: Potential data loss. Make sure to read and understand the docs for this option.
@@ -273,8 +273,8 @@ filebeat.prospectors:
 
 #================================ Processors =====================================
 
-# Processors are used to reduce the number of fields in the exported event or to 
-# enhance the event with external meta data. This section defines a list of processors 
+# Processors are used to reduce the number of fields in the exported event or to
+# enhance the event with external meta data. This section defines a list of processors
 # that are applied one by one and the first one receives the initial event:
 #
 #   event -> filter1 -> event1 -> filter2 ->event2 ...
@@ -380,7 +380,7 @@ output.elasticsearch:
   #template.overwrite: false
 
   # If set to true, filebeat checks the Elasticsearch version at connect time, and if it
-  # is 2.x, it loads the file specified by the template.versions.2x.path setting. The 
+  # is 2.x, it loads the file specified by the template.versions.2x.path setting. The
   # default is true.
   #template.versions.2x.enabled: true
 

--- a/filebeat/harvester/config.go
+++ b/filebeat/harvester/config.go
@@ -22,7 +22,7 @@ var (
 		Backoff:         1 * time.Second,
 		BackoffFactor:   2,
 		MaxBackoff:      10 * time.Second,
-		CloseInactive:   1 * time.Hour,
+		CloseInactive:   5 * time.Minute,
 		MaxBytes:        10 * humanize.MiByte,
 		CloseRemoved:    false,
 		CloseRenamed:    false,

--- a/filebeat/tests/files/config.yml
+++ b/filebeat/tests/files/config.yml
@@ -13,7 +13,7 @@ filebeat:
         review: 1
         type: log
       ignore_older: 0
-      close_inactive: 1h
+      close_inactive: 5m
       scan_frequency: 10s
       harvester_buffer_size: 5000
       tail_files: false

--- a/filebeat/tests/load/filebeat.yml
+++ b/filebeat/tests/load/filebeat.yml
@@ -8,7 +8,7 @@ filebeat:
       #  level: debug
       #  review: 1
       ignore_older: 0
-      close_inactive: 1h
+      close_inactive: 5m
       scan_frequency: 0s
       harvester_buffer_size: 1000000
 


### PR DESCRIPTION
The close_inactive default was set to one hour. Having scan_frequency as default set to 10s a lower value as 5 minutes is reasonable for less active files.

There were many issues in the past with open files. This will close inactive files faster by default now.