### PR TITLE
Remove close_timeout from docs and config

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -136,7 +136,7 @@ https://github.com/elastic/beats/compare/v5.0.0-alpha4...v5.0.0-alpha5[View comm
 
 - Introduce `close_removed` and `close_renamed` harvester options. {issue}1600[1600]
 - Introduce `close_eof` harvester option. {issue}1600[1600]
-- Add `clean_removed` config option. {issue}1600[1600]
+- Add `clean_removed` and `clean_inactive` config option. {issue}1600[1600]
 
 ==== Deprecated
 

--- a/filebeat/docs/reference/configuration/filebeat-options.asciidoc
+++ b/filebeat/docs/reference/configuration/filebeat-options.asciidoc
@@ -93,9 +93,9 @@ filebeat.prospectors:
   include_lines: ["^ERR", "^WARN"]
 -------------------------------------------------------------------------------------
 
-NOTE: If both `include_lines` and `exclude_lines` are defined, Filebeat executes `include_lines` first and then executes `exclude_lines`. 
+NOTE: If both `include_lines` and `exclude_lines` are defined, Filebeat executes `include_lines` first and then executes `exclude_lines`.
 The order in which the two options are defined doesn't matter. The `include_lines` option will always be executed
-before the `exclude_lines` option, even if `exclude_lines` appears before `include_lines` in the config file. 
+before the `exclude_lines` option, even if `exclude_lines` appears before `include_lines` in the config file.
 
 The following example exports all Apache log lines except the debugging messages (DBGs):
 
@@ -234,11 +234,6 @@ WARNING: Only use this options if you understand the potential side affects with
 
 Close eof closes a file as soon as the end of a file is reached. This is useful in case your files are only written once and not updated from time to time. This case can happen in case you are writing every single log event to a new file.
 
-===== close_timeout
-
-WARNING: Only use this options if you understand the potential side affects with potential data loss.
-
-Close timeout gives every harvester a predefined lifetime. Independent of the location of the reader, it will stop the reader after `close_timeout`. This option can be useful, if only a predefine time should be spent on older log files. Using this option in combination with `ignore_older` == `close_timeout` means the file is not picked up again in case it wasn't modified in between. This normally leads to data loss and not the complete file is sent.
 
 [[clean-options]]
 ===== clean_*

--- a/filebeat/docs/troubleshooting.asciidoc
+++ b/filebeat/docs/troubleshooting.asciidoc
@@ -22,7 +22,6 @@ There are 4 more configuration options which can be used to close file handlers,
 * close_renamed
 * close_removed
 * close_eof
-* close_timeout
 
 `close_renamed` and `close_removed` can be useful on Windows and issues related to file rotation, see <<windows-file-rotation>>. `close_eof` can be useful in environments with a large number of files with only very few entries. `close_timeout` in environments where it is more important to close file handlers then to send all log lines. More details can be found in config options, see <<configuration-filebeat-options>>.
 

--- a/filebeat/etc/beat.full.yml
+++ b/filebeat/etc/beat.full.yml
@@ -183,12 +183,6 @@ filebeat.prospectors:
   # Note: Potential data loss. Make sure to read and understand the docs for this option.
   #close_eof: false
 
-  # Close timeout closes the harvester after the predefined time.
-  # This is independent if the harvester did finish reading the file or not.
-  # By default this option is disabled.
-  # Note: Potential data loss. Make sure to read and understand the docs for this option.
-  #close_timeout: 0
-
   ### State options
 
   # Files for the modification data is older then clean_inactive the state from the registry is removed

--- a/filebeat/filebeat.full.yml
+++ b/filebeat/filebeat.full.yml
@@ -183,12 +183,6 @@ filebeat.prospectors:
   # Note: Potential data loss. Make sure to read and understand the docs for this option.
   #close_eof: false
 
-  # Close timeout closes the harvester after the predefined time.
-  # This is independent if the harvester did finish reading the file or not.
-  # By default this option is disabled.
-  # Note: Potential data loss. Make sure to read and understand the docs for this option.
-  #close_timeout: 0
-
   ### State options
 
   # Files for the modification data is older then clean_inactive the state from the registry is removed


### PR DESCRIPTION
close_timeout is not implemented yet so it had to be removed from the docs and config file.
Missing clean_inactive added to changelog