### PR TITLE
Fix flaky filebeat test clean_inactive

### DIFF
--- a/filebeat/tests/system/test_registrar.py
+++ b/filebeat/tests/system/test_registrar.py
@@ -733,6 +733,11 @@ class Test(BaseTest):
             lambda: self.output_has(lines=2),
             max_timeout=10)
 
+        # Wait until registry file is created
+        self.wait_until(
+            lambda: self.log_contains("Registry file updated"),
+            max_timeout=15)
+
         data = self.get_registry()
         assert len(data) == 2
 


### PR DESCRIPTION
Sometimes the test failed because the registry file was not written yet. This change introduces a check to guarantee that the registry file was already written when requested.