### PR TITLE
Cleanup Line Reader

### DIFF
--- a/filebeat/harvester/log.go
+++ b/filebeat/harvester/log.go
@@ -275,12 +275,12 @@ func (h *Harvester) close() {
 //
 // It creates a chain of readers which looks as following:
 //
-//   limit -> (multiline -> timeout) -> strip_newline -> json -> encode -> log_file
+//   limit -> (multiline -> timeout) -> strip_newline -> json -> encode -> line -> log_file
 //
 // Each reader on the left, contains the reader on the right and calls `Next()` to fetch more data.
 // At the base of all readers the the log_file reader. That means in the data is flowing in the opposite direction:
 //
-//   log_file -> encode -> json -> strip_newlin -> (timeout -> multiline) -> limit
+//   log_file -> line -> encode -> json -> strip_newline -> (timeout -> multiline) -> limit
 //
 // log_file implements io.Reader interface and encode reader is an adapter for io.Reader to
 // reader.Reader also handling file encodings. All other readers implement reader.Reader
@@ -317,3 +317,9 @@ func (h *Harvester) newLogFileReader() (reader.Reader, error) {
 
 	return reader.NewLimit(r, h.config.MaxBytes), nil
 }
+
+/*
+
+TODO: introduce new structure: log_file —[raw bytes]—> (line —[utf8 bytes]—> encode) —[message]—> …`
+
+*/

--- a/filebeat/harvester/reader/encode.go
+++ b/filebeat/harvester/reader/encode.go
@@ -16,17 +16,19 @@ type Encode struct {
 // NewEncode creates a new Encode reader from input reader by applying
 // the given codec.
 func NewEncode(
-	in io.Reader,
+	reader io.Reader,
 	codec encoding.Encoding,
 	bufferSize int,
 ) (Encode, error) {
-	r, err := NewLine(in, codec, bufferSize)
+	r, err := NewLine(reader, codec, bufferSize)
 	return Encode{r}, err
 }
 
 // Next reads the next line from it's initial io.Reader
+// This converts a io.Reader to a reader.reader
 func (p Encode) Next() (Message, error) {
 	c, sz, err := p.reader.Next()
+	// Creating message object
 	return Message{
 		Ts:      time.Now(),
 		Content: c,

--- a/filebeat/tests/system/test_registrar.py
+++ b/filebeat/tests/system/test_registrar.py
@@ -801,6 +801,11 @@ class Test(BaseTest):
             lambda: self.output_has(lines=2),
             max_timeout=10)
 
+        # Wait until registry file is created
+        self.wait_until(
+            lambda: self.log_contains("Registry file updated"),
+            max_timeout=15)
+
         data = self.get_registry()
         assert len(data) == 2
 


### PR DESCRIPTION
* Simplify advance loop
* Move newline check and error return to the end of the loop
* Directly return on reading errors
* Add more docs
* Fix flaky filebeat test