### PR TITLE
revert versions because alpha5 is not yet released

### DIFF
--- a/filebeat/docs/version.asciidoc
+++ b/filebeat/docs/version.asciidoc
@@ -1,2 +1,2 @@
-:stack-version: 5.0.0-alpha5
-:doc-branch: master
+:stack-version: 5.0.0-alpha4
+:doc-branch: 5.0

--- a/libbeat/docs/version.asciidoc
+++ b/libbeat/docs/version.asciidoc
@@ -1,2 +1,2 @@
-:stack-version: 5.0.0-alpha5
-:doc-branch: master
+:stack-version: 5.0.0-alpha4
+:doc-branch: 5.0

--- a/metricbeat/docs/version.asciidoc
+++ b/metricbeat/docs/version.asciidoc
@@ -1,2 +1,2 @@
-:stack-version: 5.0.0-alpha5
-:doc-branch: master
+:stack-version: 5.0.0-alpha4
+:doc-branch: 5.0

--- a/packetbeat/docs/version.asciidoc
+++ b/packetbeat/docs/version.asciidoc
@@ -1,2 +1,2 @@
-:stack-version: 5.0.0-alpha5
-:doc-branch: master
+:stack-version: 5.0.0-alpha4
+:doc-branch: 5.0

--- a/winlogbeat/docs/version.asciidoc
+++ b/winlogbeat/docs/version.asciidoc
@@ -1,2 +1,2 @@
-:stack-version: 5.0.0-alpha5
-:doc-branch: master
+:stack-version: 5.0.0-alpha4
+:doc-branch: 5.0


### PR DESCRIPTION
We need to revert the version back to alpha4 until alpha5 is released.