### PR TITLE
fix broken link to ingest docs

### DIFF
--- a/filebeat/docs/index.asciidoc
+++ b/filebeat/docs/index.asciidoc
@@ -7,7 +7,7 @@ include::./version.asciidoc[]
 :metricbeat: http://www.elastic.co/guide/en/beats/metricbeat/{doc-branch}
 :filebeat: http://www.elastic.co/guide/en/beats/filebeat/{doc-branch}
 :winlogbeat: http://www.elastic.co/guide/en/beats/winlogbeat/{doc-branch}
-:elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/{doc-branch}/
+:elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/master
 :version: {stack-version}
 :beatname_lc: filebeat
 :beatname_uc: Filebeat

--- a/libbeat/docs/shared-config-ingest.asciidoc
+++ b/libbeat/docs/shared-config-ingest.asciidoc
@@ -13,7 +13,7 @@
 == Configuring {beatname_uc} to Use Ingest Node
 
 When you use Elasticsearch for output, you can configure {beatname_uc} to use
-https://www.elastic.co/guide/en/elasticsearch/reference/master/ingest.html[ingest node] to pre-process documents
+{elasticsearch}/ingest.html[ingest node] to pre-process documents
 before the actual indexing takes place in Elasticsearch. Ingest node is a convenient processing option when you
 want to do some extra processing on your data, but you do not require the full power of Logstash. For
 example, you can create an ingest node pipeline in Elasticsearch that consists of one processor

--- a/metricbeat/docs/index.asciidoc
+++ b/metricbeat/docs/index.asciidoc
@@ -4,7 +4,7 @@ include::./version.asciidoc[]
 
 :libbeat: http://www.elastic.co/guide/en/beats/libbeat/{doc-branch}
 :filebeat: http://www.elastic.co/guide/en/beats/filebeat/{doc-branch}
-:elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/{doc-branch}/
+:elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/master
 :version: {stack-version}
 :beatname_lc: metricbeat
 :beatname_uc: Metricbeat

--- a/packetbeat/docs/index.asciidoc
+++ b/packetbeat/docs/index.asciidoc
@@ -7,7 +7,7 @@ include::./version.asciidoc[]
 :metricbeat: http://www.elastic.co/guide/en/beats/metricbeat/{doc-branch}
 :filebeat: http://www.elastic.co/guide/en/beats/filebeat/{doc-branch}
 :winlogbeat: http://www.elastic.co/guide/en/beats/winlogbeat/{doc-branch}
-:elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/{doc-branch}/
+:elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/master
 :version: {stack-version}
 :beatname_lc: packetbeat
 :beatname_uc: Packetbeat

--- a/winlogbeat/docs/index.asciidoc
+++ b/winlogbeat/docs/index.asciidoc
@@ -7,7 +7,7 @@ include::./version.asciidoc[]
 :metricbeat: http://www.elastic.co/guide/en/beats/metricbeat/{doc-branch}
 :filebeat: http://www.elastic.co/guide/en/beats/filebeat/{doc-branch}
 :winlogbeat: http://www.elastic.co/guide/en/beats/winlogbeat/{doc-branch}
-:elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/{doc-branch}/
+:elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/master
 :version: {stack-version}
 :beatname_lc: winlogbeat
 :beatname_uc: Winlogbeat


### PR DESCRIPTION
the elasticsearch docs are not being built in 5.0 yet. Because elasticsearch alpha4 builds in master, changing the variable to 5.0 broke the doc build.

I'll update the index.asciidoc files to use the correct variable once elasticsearch is building doc in a 5.0 branch.

The trailing slash is not needed, so I removed it.