### PR TITLE
Log event publishing errors as Err (was Info)

### DIFF
--- a/libbeat/outputs/mode/lb/async_worker.go
+++ b/libbeat/outputs/mode/lb/async_worker.go
@@ -84,7 +84,7 @@ func (w *asyncWorker) connect() bool {
 			return false
 		}
 
-		logp.Info("Connect failed with: %v", err)
+		logp.Err("Connect failed with: %v", err)
 
 		cont := w.backoff.Wait()
 		if !cont {

--- a/libbeat/outputs/mode/lb/sync_worker.go
+++ b/libbeat/outputs/mode/lb/sync_worker.go
@@ -84,7 +84,7 @@ func (w *syncWorker) connect() bool {
 			return false
 		}
 
-		logp.Info("Connect failed with: %v", err)
+		logp.Err("Connect failed with: %v", err)
 
 		cont := w.backoff.Wait()
 		if !cont {

--- a/libbeat/outputs/mode/single/single.go
+++ b/libbeat/outputs/mode/single/single.go
@@ -137,7 +137,7 @@ func (s *Mode) publish(
 		resetFail := false
 
 		if err := s.connect(); err != nil {
-			logp.Info("Connecting error publishing events (retrying): %s", err)
+			logp.Err("Connecting error publishing events (retrying): %s", err)
 			goto sendFail
 		}
 


### PR DESCRIPTION
Hi folks!

Today I ran into an issue regarding the classification of log messages. Our logging fell over and we saw no errors in the Filebeat logs. After further investigation we found that this error was being logged as INFO:

    2016/08/08 10:56:03.814969 single.go:130: INFO Connecting error publishing events (retrying): Head http://confidential-hostname:9200: dial tcp: lookup confidential-hostname on 10.251.0.2:53: no such host

This feels wrong as any event publishing error seems to be a real error. This PR ensures these errors are logged as errors.

____

We also found the following which I have not modified in this PR as I am not sure if it is intentional behaviour:

    2016/08/08 10:56:20.807266 log.go:80: INFO Read line error: No more bytes

This appears to be an issue in `filebeat/harvester/log.go`, lines 67-85. A number of these logging calls appear to be real error cases which I would argue should be logged as such. If this is the case, I'm happy to update this PR to modify that behaviour too.