### PR TITLE
Update naming conventions with micro and nano seconds

### DIFF
--- a/libbeat/docs/event-conventions.asciidoc
+++ b/libbeat/docs/event-conventions.asciidoc
@@ -37,4 +37,7 @@ List of standardised words and units across all Beats:
 * ms: millisecond, millis
 * mb: megabytes
 * msg: message
+* nanos: nanoseconds
+* norm: normalized
+* us: microseconds
 

--- a/metricbeat/module/doc.go
+++ b/metricbeat/module/doc.go
@@ -37,7 +37,9 @@ List of standardised words and units across all metricsets. On the left are the 
 * ms: millisecond, millis
 * mb: megabytes
 * msg: message
+* nanos: nanoseconds
 * norm: normalized
+* us: microseconds
 
 */
 package module


### PR DESCRIPTION
@andrewkroh I'm somehow tempted to go with ns for nanoseconds but ns could also stand for namespace and other things. WDYT?