### PR TITLE
Fix mapping for Packetbeat flow metrics

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -35,6 +35,7 @@ https://github.com/elastic/beats/compare/v5.0.0-alpha5...master[Check the HEAD d
 *Metricbeat*
 
 *Packetbeat*
+- Fix mapping for some Packetbeat flow metrics that were not marked as being longs. {issue}2177[2177]
 
 *Topbeat*
 

--- a/packetbeat/docs/fields.asciidoc
+++ b/packetbeat/docs/fields.asciidoc
@@ -971,11 +971,15 @@ Object with source to destination flow measurements.
 [float]
 === source.stats.net_packets_total
 
+type: long
+
 Total number of packets
 
 
 [float]
 === source.stats.net_bytes_total
+
+type: long
 
 Total number of bytes
 
@@ -1073,11 +1077,15 @@ Object with destination to source flow measurements.
 [float]
 === dest.stats.net_packets_total
 
+type: long
+
 Total number of packets
 
 
 [float]
 === dest.stats.net_bytes_total
+
+type: long
 
 Total number of bytes
 

--- a/packetbeat/etc/fields.yml
+++ b/packetbeat/etc/fields.yml
@@ -198,10 +198,12 @@
             Object with source to destination flow measurements.
           fields:
             - name: net_packets_total
+              type: long
               description: >
                 Total number of packets
 
             - name: net_bytes_total
+              type: long
               description: >
                 Total number of bytes
 
@@ -274,10 +276,12 @@
             Object with destination to source flow measurements.
           fields:
             - name: net_packets_total
+              type: long
               description: >
                 Total number of packets
 
             - name: net_bytes_total
+              type: long
               description: >
                 Total number of bytes
     - name: icmp_id

--- a/packetbeat/packetbeat.template-es2x.json
+++ b/packetbeat/packetbeat.template-es2x.json
@@ -311,14 +311,10 @@
             "stats": {
               "properties": {
                 "net_bytes_total": {
-                  "ignore_above": 1024,
-                  "index": "not_analyzed",
-                  "type": "string"
+                  "type": "long"
                 },
                 "net_packets_total": {
-                  "ignore_above": 1024,
-                  "index": "not_analyzed",
-                  "type": "string"
+                  "type": "long"
                 }
               }
             }
@@ -1083,14 +1079,10 @@
             "stats": {
               "properties": {
                 "net_bytes_total": {
-                  "ignore_above": 1024,
-                  "index": "not_analyzed",
-                  "type": "string"
+                  "type": "long"
                 },
                 "net_packets_total": {
-                  "ignore_above": 1024,
-                  "index": "not_analyzed",
-                  "type": "string"
+                  "type": "long"
                 }
               }
             }

--- a/packetbeat/packetbeat.template.json
+++ b/packetbeat/packetbeat.template.json
@@ -274,12 +274,10 @@
             "stats": {
               "properties": {
                 "net_bytes_total": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "type": "long"
                 },
                 "net_packets_total": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "type": "long"
                 }
               }
             }
@@ -946,12 +944,10 @@
             "stats": {
               "properties": {
                 "net_bytes_total": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "type": "long"
                 },
                 "net_packets_total": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "type": "long"
                 }
               }
             }


### PR DESCRIPTION
The following fields were marked as not_analyzed strings and should be longs.

- source.stats.net_packets_total
- source.stats.net_bytes_total
- dest.stats.net_bytes_total
- dest.stats.net_packets_total

Issue #2177