### PR TITLE
Implements workaround for dashboard loading

### DIFF
--- a/dev-tools/import_dashboards.sh
+++ b/dev-tools/import_dashboards.sh
@@ -8,7 +8,7 @@
 
 # The default value of the variable. Initialize your own variables here
 ELASTICSEARCH=http://localhost:9200
-CURL=curl
+CURL="curl -H Expect:"
 KIBANA_INDEX=".kibana"
 DIR=.
 BEAT_CONFIG=".beatconfig"


### PR DESCRIPTION
Workaround for #2208. Elasticsearch alpha5 doesn't like the "Expect: 100-continue"
header that is added by curl. We should remove this workaround after the next
release is out.