### PR TITLE
[WIP] Experimental config

### DIFF
--- a/metricbeat/beater/config.go
+++ b/metricbeat/beater/config.go
@@ -5,5 +5,6 @@ import "github.com/elastic/beats/libbeat/common"
 // Config is the root of the Metricbeat configuration hierarchy.
 type Config struct {
 	// Modules is a list of module specific configuration data.
-	Modules []*common.Config `config:"modules" validate:"required"`
+	Modules      []*common.Config `config:"modules" validate:"required"`
+	Experimental bool             `config:"experimental"`
 }

--- a/metricbeat/mb/registry.go
+++ b/metricbeat/mb/registry.go
@@ -38,6 +38,8 @@ type Register struct {
 	modules map[string]ModuleFactory
 	// A map of module name to nested map of MetricSet name to MetricSetFactory.
 	metricSets map[string]map[string]MetricSetFactory
+
+	experimentalMetricSets map[string]bool
 }
 
 // NewRegister creates and returns a new Register.
@@ -45,6 +47,7 @@ func NewRegister() *Register {
 	return &Register{
 		modules:    make(map[string]ModuleFactory, initialSize),
 		metricSets: make(map[string]map[string]MetricSetFactory, initialSize),
+		experimentalMetricSets: map[string]bool{},
 	}
 }
 
@@ -99,6 +102,16 @@ func (r *Register) AddMetricSet(module string, name string, factory MetricSetFac
 
 	r.metricSets[module][name] = factory
 	logp.Info("MetricSet registered: %s/%s", module, name)
+	return nil
+}
+
+func (r *Register) AddExperimentalMetricSet(module string, name string, factory MetricSetFactory) error {
+	err := r.AddMetricSet(module,name,factory)
+	if err != nil {
+		return err
+	}
+
+	r.experimentalMetricSets[module + " - " + name] = true
 	return nil
 }
 

--- a/metricbeat/module/system/process/process.go
+++ b/metricbeat/module/system/process/process.go
@@ -15,6 +15,7 @@ import (
 )
 
 var debugf = logp.MakeDebug("system-process")
+var Experimental = true
 
 func init() {
 	if err := mb.Registry.AddMetricSet("system", "process", New); err != nil {

--- a/metricbeat/module/zookeeper/mntr/mntr.go
+++ b/metricbeat/module/zookeeper/mntr/mntr.go
@@ -35,7 +35,7 @@ import (
 )
 
 func init() {
-	if err := mb.Registry.AddMetricSet("zookeeper", "mntr", New); err != nil {
+	if err := mb.Registry.AddExperimentalMetricSet("zookeeper", "mntr", New); err != nil {
 		panic(err)
 	}
 }


### PR DESCRIPTION
Over time we will add additional MetricSets without having a major release. Adding a MetricSet does not necessarly directly mean its data structure is already final. Still we would like to get the community to test it. One option is to have this MetricSets only in master and the nightly build must be used to test it. For most users this is a big hurdle. My suggestion is to introduce an "experimental" config option.

`metricbeat.experimental` can be enabled in the config to also use experimental metricsets. This will allow users to test new Metricsets which are already shipped with the binary but not available by default. Also on our doc pages we would state that these are experimental. In case a Metricset is enabled but is experimental and experimental was not enabled, an error message is printed.

This will allow us to add MetricSets with each new minor release without it being already stable.

Below is a first code draft on how the experimental could look like in a MetricSet. A function `AddExperimentalMetricSet` was introduced. This code is not complete yet and only to show / discuss the idea.