### PR TITLE
Log errors when harvester could not be started

### DIFF
--- a/filebeat/prospector/prospector.go
+++ b/filebeat/prospector/prospector.go
@@ -154,12 +154,12 @@ func (p *Prospector) createHarvester(state file.State) (*harvester.Harvester, er
 	return h, err
 }
 
-func (p *Prospector) startHarvester(state file.State, offset int64) (*harvester.Harvester, error) {
+func (p *Prospector) startHarvester(state file.State, offset int64) error {
 	state.Offset = offset
 	// Create harvester with state
 	h, err := p.createHarvester(state)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	p.wg.Add(1)
@@ -169,5 +169,5 @@ func (p *Prospector) startHarvester(state file.State, offset int64) (*harvester.
 		h.Harvest()
 	}()
 
-	return h, nil
+	return nil
 }


### PR DESCRIPTION
So far no errors were logged when a harvester could not be strated. This should be a very rare case in general but it is good to have log messages in case it happens.

This is a small improvement based on https://github.com/elastic/beats/issues/1913