### PR TITLE
Make FAQs a single topic

### DIFF
--- a/filebeat/docs/faq.asciidoc
+++ b/filebeat/docs/faq.asciidoc
@@ -4,26 +4,17 @@
 This section contains frequently asked questions about Filebeat. Also check out the
 https://discuss.elastic.co/c/beats/filebeat[Filebeat discussion forum].
 
-* <<filebeat-network-volumes>>
-* <<filebeat-not-collecting-lines>>
-* <<filebeat-cpu>>
-* <<dashboard-fields-incorrect-filebeat>>
-* <<newline-character-required-eof>>
-* <<connection-problem>>
-* <<metadata-missing>>
-* <<diff-logstash-beats>>
-* <<ssl-client-fails>>
-
-
+[float]
 [[filebeat-network-volumes]]
-=== Why can't I read log files from network volumes?
+=== Can't read log files from network volumes?
 
 We do not recommend reading log files from network volumes. Whenever possible, install Filebeat on the host machine and
 send the log files directly from there. Reading files from network volumes (especially on Windows) can have unexpected side
 effects. For example, changed file identifiers may result in Filebeat reading a log file from scratch again.
 
+[float]
 [[filebeat-not-collecting-lines]]
-=== Why isn’t Filebeat collecting lines from my file?
+=== Filebeat isn't collecting lines from a file?
 
 Filebeat might be incorrectly configured or unable to send events to the output. To resolve the issue:
 
@@ -40,21 +31,24 @@ it's publishing events successfully:
 ./filebeat -c config.yml -e -d "*"
 ----------------------------------------------------------------------
 
+[float]
 [[filebeat-cpu]]
-=== Why is Filebeat using too much CPU?
+=== Filebeat is using too much CPU?
 
 Filebeat might be configured to scan for files too frequently. Check the setting for `scan_frequency` in the `filebeat.yml`
 config file. Setting `scan_frequency` to less than 1s may cause Filebeat to scan the disk in a tight loop.
 
 //=== Why is Filebeat keeping old files open?
 
+[float]
 [[dashboard-fields-incorrect-filebeat]]
-=== Why is the dashboard in Kibana breaking up my data fields incorrectly?
+=== Dashboard in Kibana is breaking up data fields incorrectly?
 
 The index template might not be loaded correctly. See <<filebeat-template>>.
 
+[float]
 [[newline-character-required-eof]]
-=== Why isn't Filebeat shipping the last line of my file?
+=== Filebeat isn't shipping the last line of a file?
 
 Filebeat uses a newline character to detect the end of an event. If lines are added incrementally to a file that's being
 harvested, a newline character is required after the last line, or Filebeat will not read the last line of

--- a/libbeat/docs/shared-faq.asciidoc
+++ b/libbeat/docs/shared-faq.asciidoc
@@ -9,27 +9,29 @@
 //// include::../../libbeat/docs/shared-faq.asciidoc[]
 //////////////////////////////////////////////////////////////////////////
 
+[float]
 [[connection-problem]]
-=== Why doesn't my connection to Logstash work?
+=== Logstash connection doesn't work?
 
-You may have configured Logstash or the Beat incorrectly. To resolve the issue: 
+You may have configured Logstash or {beatname_uc} incorrectly. To resolve the issue: 
 
 * Make sure that Logstash is running and you can connect to it. First, try to ping the Logstash host to verify that you can reach it
-from the host running the Beat. Then use either `nc` or `telnet` to make sure that the port is available. For example:
+from the host running {beatname_uc}. Then use either `nc` or `telnet` to make sure that the port is available. For example:
 +
 [source,shell]
 ----------------------------------------------------------------------
 ping <hostname or IP>
 telnet <hostname or IP> 5044
 ----------------------------------------------------------------------
-* Verify that the config file for your Beat specifies the correct port where Logstash is running.  
+* Verify that the config file for {beatname_uc} specifies the correct port where Logstash is running.  
 * Make sure that the Elasticsearch output is commented out in the config file and the Logstash output is uncommented. 
 * Confirm that the most recent Beats input plugin for Logstash is installed and configured. Note that Beats will not connect
 to the Lumberjack input plugin. See
 {libbeat}/logstash-installation.html#logstash-input-update[Updating the Beats Input Plugin for Logstash].
 
+[float]
 [[metadata-missing]]
-=== Why is @metadata missing in Logstash?
+=== @metadata is missing in Logstash?
 
 Logstash outputs remove `@metadata` fields automatically. Therefore, if Logstash instances are chained directly or via some message
 queue (for example, Redis or Kafka), the `@metadata` field will not be available in the final Logstash instance.
@@ -37,8 +39,9 @@ queue (for example, Redis or Kafka), the `@metadata` field will not be available
 TIP: To preserve `@metadata` fields, use the Logstash mutate filter with the rename setting to rename the fields to
 non-internal fields.
 
+[float]
 [[diff-logstash-beats]]
-=== What is the difference between Logstash and Beats?
+=== Difference between Logstash and Beats?
 
 Beats are lightweight data shippers that you install as agents on your servers to send specific types of operational
 data to Elasticsearch. Beats have a small footprint and use fewer system resources than Logstash.
@@ -49,13 +52,14 @@ and transforming data from a variety of sources.
 For more information, see the https://www.elastic.co/guide/en/logstash/current/introduction.html[Logstash Introduction] and
 the https://www.elastic.co/guide/en/beats/libbeat/current/beats-reference.html[Beats Overview].
 
+[float]
 [[ssl-client-fails]]
-=== Why does my SSL client fail to connect to Logstash?
+=== SSL client fails to connect to Logstash?
 
 The host running Logstash might be unreachable or the certificate may not be valid. To resolve your issue:
 
 * Make sure that Logstash is running and you can connect to it. First, try to ping the Logstash host to verify that you can reach it
-from the host running the Beat. Then use either `nc` or `telnet` to make sure that the port is available. For example:
+from the host running {beatname_uc}. Then use either `nc` or `telnet` to make sure that the port is available. For example:
 +
 [source,shell]
 ----------------------------------------------------------------------
@@ -69,15 +73,17 @@ TIP: For testing purposes only, you can set `insecure: true` to disable hostname
 
 * Make sure that you have enabled SSL (set `ssl => true`) when configuring the https://www.elastic.co/guide/en/logstash/current/plugins-inputs-beats.html[Beats input plugin for Logstash].
 
-==== Common Errors and Resolutions
+[float]
+==== Common SSL-Related Errors and Resolutions
 
 Here are some common errors and ways to fix them:
 
-* <<cannot-validate-certificate>>
-* <<getsockopt-no-route-to-host>>
-* <<getsockopt-connection-refused>>
-* <<target-machine-refused-connection>>
+* <<cannot-validate-certificate,x509: cannot validate certificate>>
+* <<getsockopt-no-route-to-host,getsockopt: no route to host>>
+* <<getsockopt-connection-refused,getsockopt: connection refused>>
+* <<target-machine-refused-connection,No connection could be made because the target machine actively refused it>>
 
+[float]
 [[cannot-validate-certificate]]
 ===== x509: cannot validate certificate for <IP address> because it doesn't contain any IP SANs
 
@@ -91,16 +97,19 @@ To resolve this problem, try one of these solutions:
 * Re-create the server certificate and add a SubjectAltName (SAN) for the IP address of the server. This make the
 server's certificate valid for both the hostname and the IP address.
 
+[float]
 [[getsockopt-no-route-to-host]]
 ===== getsockopt: no route to host
 
 This is not a TLS problem. It's a networking problem. Make sure the two hosts can communicate.
 
+[float]
 [[getsockopt-connection-refused]]
 ===== getsockopt: connection refused
 
 This is not a TLS problem. Make sure that Logstash is running and that there is no firewall blocking the traffic.
 
+[float]
 [[target-machine-refused-connection]]
 ===== No connection could be made because the target machine actively refused it
 

--- a/metricbeat/docs/faq.asciidoc
+++ b/metricbeat/docs/faq.asciidoc
@@ -4,14 +4,9 @@
 This section contains frequently asked questions about Metricbeat. Also check out the
 https://discuss.elastic.co/c/beats/metricbeat[Metricbeat discussion forum].
 
-* <<freebsd-no-such-file>>
-* <<connection-problem>>
-* <<metadata-missing>>
-* <<diff-logstash-beats>>
-* <<ssl-client-fails>>
-
+[float]
 [[freebsd-no-such-file]]
-=== How do I fix the `open /compat/linux/proc: no such file or directory` error on FreeBSD?
+=== Fix for `open /compat/linux/proc: no such file or directory` error on FreeBSD?
 
 The system metricsets rely a Linux comparability layer to retrieve metrics on
 FreeBSD. You need to mount the Linux procfs filesystem using the following

--- a/packetbeat/docs/faq.asciidoc
+++ b/packetbeat/docs/faq.asciidoc
@@ -4,18 +4,9 @@
 This section contains frequently asked questions about Packetbeat. Also check out the
 https://discuss.elastic.co/c/beats/packetbeat[Packetbeat discussion forum].
 
-* <<client-server-fields-empty>>
-* <<dashboard-fields-incorrect>>
-* <<packetbeat-mirror-ports>>
-* <<packetbeat-loopback-interface>>
-* <<packetbeat-missing-transactions>>
-* <<connection-problem>>
-* <<metadata-missing>>
-* <<diff-logstash-beats>>
-* <<ssl-client-fails>>
-
+[float]
 [[client-server-fields-empty]]
-=== Why are the client_server and server fields empty?
+=== Client_server and server fields are empty?
 
 The `client_server` and `server` fields are empty when Packetbeat is not configured
 to capture information about the network topology.
@@ -23,13 +14,15 @@ to capture information about the network topology.
 To capture information about the network topology, set the `save_topology` configuration option to true and make sure that
 you are sending the output to Elasticsearch.
 
+[float]
 [[dashboard-fields-incorrect]]
-=== Why is the dashboard in Kibana breaking up my data fields incorrectly?
+=== Dashboard in Kibana is breaking up data fields incorrectly?
 
 The index template might not be loaded correctly. See <<packetbeat-template>>.
 
+[float]
 [[packetbeat-mirror-ports]]
-=== Why doesn’t Packetbeat see any packets when using mirror ports?
+=== Packetbeat doesn't see any packets when using mirror ports?
 
 The interface needs to be set to promiscuous mode. Run the following command:
 
@@ -40,8 +33,9 @@ ip link set <device_name> promisc on
 
 For example: `ip link set enp5s0f1 promisc on`
 
+[float]
 [[packetbeat-loopback-interface]]
-=== Why can't Packetbeat capture traffic from the loopback interface on Windows?
+=== Packetbeat can't capture traffic from Windows loopback interface?
 
 Packetbeat is unable to capture traffic from the loopback device (127.0.0.1 traffic)
 because the Windows TCP/IP stack does not implement a network loopback interface, 
@@ -67,8 +61,9 @@ PS C:\Users\vagrant\Desktop\packetbeat-1.2.0-windows> .\packetbeat.exe -devices
 
 NOTE: Npcap is sponsored but not officially supported by the Nmap Project. 
 
+[float]
 [[packetbeat-missing-transactions]]
-=== Why is Packetbeat missing long running transactions?
+=== Packetbeat is missing long running transactions?
 
 Packetbeat has an internal timeout that it uses to time out transactions and TCP connections
 when no packets have been seen for a long time. 

--- a/winlogbeat/docs/faq.asciidoc
+++ b/winlogbeat/docs/faq.asciidoc
@@ -5,20 +5,15 @@ This section contains frequently asked questions about Winlogbeat. Also check
 out the https://discuss.elastic.co/c/beats/winlogbeat[Winlogbeat discussion
 forum].
 
-* <<dashboard-fields-incorrect>>
-* <<bogus-computer-name-fields>>
-* <<connection-problem>>
-* <<metadata-missing>>
-* <<diff-logstash-beats>>
-* <<ssl-client-fails>>
-
+[float]
 [[dashboard-fields-incorrect]]
-=== Why is the dashboard in Kibana breaking up my data fields incorrectly?
+=== Dashboard in Kibana is breaking up data fields incorrectly?
 
 The index template might not be loaded correctly. See <<winlogbeat-template>>.
 
+[float]
 [[bogus-computer-name-fields]]
-=== Why are there bogus computer_name fields reported in some events?
+=== Bogus computer_name fields are reported in some events?
 
 Prior to the hostname configuration stage, during OS installation any event log
 records generated may have a randomly assigned hostname.


### PR DESCRIPTION
- Added float tags to make all FAQ topics for a beat appear on the same page
- Shortened titles (they are easier to scan, but not proper questions...an OK compromise, IMHO)

I haven't tried to reorder the topics. Some of the topics are in a shared file, `shared-faq.asciidoc`. In order to put the topics in some kind of logical order (alphabetical or some logical grouping), I would need to put all the content (from all the beats) into `shared-faq.asciidoc` and use `ifdef` statements to include content conditionally. I try to avoid conditional stuff because it can be messy for other people to figure out. Right now, the list of questions is short enough that the order doesn't seem very important to me. WDYT?

I do like that I can remove the hand-built list and rely on the build to generate the list of topics for me. 

Here's an example page so you can see what the pages look like when they are build: https://filebeatfaqchanges.firebaseapp.com/faq.html