### PR TITLE
Fix Metricbeat to work with drop_event filter

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -37,6 +37,7 @@ https://github.com/elastic/beats/compare/v5.0.0-alpha5...master[Check the HEAD d
 - Fix Elasticsearch structured error response parsing error. {issue}2229[2229]
 
 *Metricbeat*
+- Fix module filters to work properly with drop_event filter. {issue}2249[2249]
 
 *Packetbeat*
 - Fix mapping for some Packetbeat flow metrics that were not marked as being longs. {issue}2177[2177]

--- a/metricbeat/beater/event.go
+++ b/metricbeat/beater/event.go
@@ -43,7 +43,9 @@ func (b eventBuilder) build() (common.MapStr, error) {
 
 	// Apply filters.
 	if b.filters != nil {
-		event = b.filters.Run(event)
+		if event = b.filters.Run(event); event == nil {
+			return nil, nil
+		}
 	}
 
 	event = common.MapStr{


### PR DESCRIPTION
The drop_event filter causes the MetricSet data to be nil, but the event was still being sent. This PR causes the event to actually be dropped.