### PR TITLE
Copy beats directory over to vendor dir for generators

### DIFF
--- a/generate/beat/Makefile
+++ b/generate/beat/Makefile
@@ -18,13 +18,15 @@ test: python-env
 
 	# Makes sure to use current version of beats for testing
 	mkdir -p ${BUILD_DIR}/src/github.com/elastic/beats/
-	cp -r ${PWD}/../../libbeat ${PWD}/../../vendor ${BUILD_DIR}/src/github.com/elastic/beats/
+	rsync -a --exclude=generate ${PWD}/../../* ${BUILD_DIR}/src/github.com/elastic/beats/
 
 	. ${PYTHON_ENV}/bin/activate; \
 	export GOPATH=${PWD}/build ; \
 	export PATH=${PATH}:${PWD}/build/bin; \
 	cd ${BEAT_PATH} ; \
+	make copy-vendor ; \
 	make check ; \
+	make update ; \
 	make ; \
 	make unit
 

--- a/generate/beat/{{cookiecutter.beat}}/Makefile
+++ b/generate/beat/{{cookiecutter.beat}}/Makefile
@@ -2,7 +2,7 @@ BEATNAME={{cookiecutter.beat}}
 BEAT_DIR={{cookiecutter.beat_path}}
 SYSTEM_TESTS=false
 TEST_ENVIRONMENT=false
-ES_BEATS?=${GOPATH}/src/github.com/elastic/beats
+ES_BEATS?=./vendor/github.com/elastic/beats
 GOPACKAGES=$(shell glide novendor)
 PREFIX?=.
 
@@ -11,8 +11,15 @@ PREFIX?=.
 
 # Initial beat setup
 .PHONY: setup
-setup:
+setup: copy-vendor
 	make update
+
+# Copy beats into vendor directory
+.PHONY: copy-vendor
+copy-vendor:
+	mkdir -p vendor/github.com/elastic/
+	cp -R ${GOPATH}/src/github.com/elastic/beats vendor/github.com/elastic/
+	rm -rf vendor/github.com/elastic/beats/.git
 
 .PHONY: git-init
 git-init:

--- a/generate/beat/{{cookiecutter.beat}}/beater/{{cookiecutter.beat}}.go
+++ b/generate/beat/{{cookiecutter.beat}}/beater/{{cookiecutter.beat}}.go
@@ -13,9 +13,9 @@ import (
 )
 
 type {{cookiecutter.beat|capitalize}} struct {
-	done       chan struct{}
-	config     config.Config
-	client     publisher.Client
+	done   chan struct{}
+	config config.Config
+	client publisher.Client
 }
 
 // Creates beater

--- a/generate/metricbeat/metricset/Makefile
+++ b/generate/metricbeat/metricset/Makefile
@@ -18,15 +18,15 @@ test: python-env
 
 	# Makes sure to use current version of beats for testing
 	mkdir -p ${BUILD_DIR}/src/github.com/elastic/beats/
-	cp -r ${PWD}/../../../metricbeat ${PWD}/../../../libbeat ${PWD}/../../../vendor ${BUILD_DIR}/src/github.com/elastic/beats/
+	rsync -a --exclude=generate ${PWD}/../../../* ${BUILD_DIR}/src/github.com/elastic/beats/
 
 	. ${PYTHON_ENV}/bin/activate; \
 	export GOPATH=${PWD}/build ; \
 	export PATH=${PATH}:${PWD}/build/bin; \
 	cd ${BEAT_PATH}; \
+	make copy-vendor; \
 	MODULE=elastic METRICSET=test make create-metricset ; \
 	make imports collect check ; \
-	make ; \
 	make unit
 
 # Tests the build process for the beat

--- a/generate/metricbeat/metricset/{{cookiecutter.beat}}/Makefile
+++ b/generate/metricbeat/metricset/{{cookiecutter.beat}}/Makefile
@@ -2,7 +2,7 @@ BEATNAME={{cookiecutter.beat}}
 BEAT_DIR={{cookiecutter.beat_path}}
 SYSTEM_TESTS=false
 TEST_ENVIRONMENT=false
-ES_BEATS?=${GOPATH}/src/github.com/elastic/beats
+ES_BEATS?=./vendor/github.com/elastic/beats
 GOPACKAGES=$(shell glide novendor)
 PREFIX?=.
 
@@ -11,9 +11,16 @@ PREFIX?=.
 
 # Initial beat setup
 .PHONY: setup
-setup:
+setup: copy-vendor
 	make create-metricset
 	make collect
+
+# Copy beats into vendor directory
+.PHONY: copy-vendor
+copy-vendor:
+	mkdir -p vendor/github.com/elastic/
+	cp -R ${GOPATH}/src/github.com/elastic/beats vendor/github.com/elastic/
+	rm -rf vendor/github.com/elastic/beats/.git
 
 .PHONY: update-deps
 update-deps:


### PR DESCRIPTION
* Automatically copy over beats directory to vendor on setup. The git directory is removed.
* Make ES_BEATS depend on the vendor directory. This makes packaging possible
* Fix fmt check

Existing community beats generated with the previous version can run the following command to get the same result:

```
mkdir -p vendor/github.com/elastic/
cp -R ${GOPATH}/src/github.com/elastic/beats vendor/github.com/elastic/
```

Afterwards the line with `ES_BEATS` has to be changed to:

```
ES_BEATS?=./vendor/github.com/elastic/beats
```

These changes to not change how a beat is generated.

Vendoring / Versioning note:

It is up to the user to do decide which tool should be used for vendoring. That is the reason no glide file for example is added. Also the versioning is up to the user. We currently recommend to check in the vendor directory as it makes sure other developers can directly start working on the project. It is also a requirement to make packaging work out of the box.