### PR TITLE
Fix panic when hitting EOF on stdin input

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -37,6 +37,7 @@ https://github.com/elastic/beats/compare/v1.3.0...1.3[Check the HEAD diff]
 *Filebeat*
 
 - Fix open file handler issue {issue}2028[2028]
+- Fix panic when the stdin reader encounters EOF. {pull}2268{2268]
 
 *Winlogbeat*
 

--- a/filebeat/harvester/log.go
+++ b/filebeat/harvester/log.go
@@ -88,7 +88,9 @@ func createLineReader(
 func (h *Harvester) Harvest() {
 	defer func() {
 		// On completion, push offset so we can continue where we left off if we relaunch on the same file
-		h.Stat.Return <- h.GetOffset()
+		if h.Stat != nil {
+			h.Stat.Return <- h.GetOffset()
+		}
 
 		// Make sure file is closed as soon as harvester exits
 		// If file was never properly opened, it can't be closed

--- a/filebeat/tests/system/filebeat.py
+++ b/filebeat/tests/system/filebeat.py
@@ -19,10 +19,9 @@ class Proc(object):
     def __init__(self, args, outputfile):
         self.args = args
         self.output = open(outputfile, "wb")
+        self.stdin_read, self.stdin_write = os.pipe()
 
     def start(self):
-
-        self.stdin_read, self.stdin_write = os.pipe()
 
         self.proc = subprocess.Popen(
             self.args,


### PR DESCRIPTION
The stdin harverster type has no state, so do a nil check before
trying to update it.