### PR TITLE
Make sure the etc/kibana/index-pattern exists 

### DIFF
--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -240,6 +240,7 @@ update: python-env
 	cp ${ES_BEATS}/libbeat/docs/version.asciidoc docs/version.asciidoc
 
 	# Generate index-pattern
+	mkdir -p $(PWD)/etc/kibana/index-pattern
 	. ${PYTHON_ENV}/bin/activate && python ${ES_BEATS}/libbeat/scripts/generate_index_pattern.py --index ${BEATNAME}-* --libbeat ${ES_BEATS}/libbeat --beat $(PWD)
 
 

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -240,6 +240,7 @@ update: python-env
 	cp ${ES_BEATS}/libbeat/docs/version.asciidoc docs/version.asciidoc
 
 	# Generate index-pattern
+	-rm -f $(PWD)/etc/kibana/index-pattern/${BEATNAME}.json
 	mkdir -p $(PWD)/etc/kibana/index-pattern
 	. ${PYTHON_ENV}/bin/activate && python ${ES_BEATS}/libbeat/scripts/generate_index_pattern.py --index ${BEATNAME}-* --libbeat ${ES_BEATS}/libbeat --beat $(PWD)
 


### PR DESCRIPTION
This PR makes sure the etc/kibana/index-pattern directory exists before running `make update` that ganarates the index-pattern.