### PR TITLE
Added test for closed stdin

### DIFF
--- a/libbeat/tests/system/beat/beat.py
+++ b/libbeat/tests/system/beat/beat.py
@@ -26,9 +26,9 @@ class Proc(object):
     def __init__(self, args, outputfile):
         self.args = args
         self.output = open(outputfile, "ab")
+        self.stdin_read, self.stdin_write = os.pipe()
 
     def start(self):
-        self.stdin_read, self.stdin_write = os.pipe()
 
         if sys.platform.startswith("win"):
             self.proc = subprocess.Popen(


### PR DESCRIPTION
Test for the condition in #2268. This bug was already fixed in master
but it's good to have a test for it.

The code needs to duplicate code from beat.py because it needs to close the pipe before starting the Beat, otherwise the bug wasn't triggered.