### PR TITLE
Fix rotation issue - 1.3

### DIFF
--- a/filebeat/beat/publish.go
+++ b/filebeat/beat/publish.go
@@ -97,7 +97,10 @@ func (p *syncLogPublisher) Start() {
 
 			pubEvents := make([]common.MapStr, 0, len(events))
 			for _, event := range events {
-				pubEvents = append(pubEvents, event.ToMapStr())
+				// Only publish events with content
+				if event.Bytes > 0 {
+					pubEvents = append(pubEvents, event.ToMapStr())
+				}
 			}
 
 			p.client.PublishEvents(pubEvents, publisher.Sync, publisher.Guaranteed)

--- a/filebeat/crawler/prospector.go
+++ b/filebeat/crawler/prospector.go
@@ -392,8 +392,8 @@ func (p *Prospector) checkNewFile(newinfo *harvester.FileStat, file string, outp
 				time.Since(newinfo.Fileinfo.ModTime()),
 				file)
 			h.SetOffset(newinfo.Fileinfo.Size())
+			p.registrar.Persist <- h.GetState()
 		}
-		p.registrar.Persist <- h.GetState()
 	} else if previousFile, err := p.getPreviousFile(file, newinfo.Fileinfo); err == nil {
 		// This file was simply renamed (known inode+dev) - link the same harvester channel as the old file
 		logp.Debug("prospector", "File rename was detected, not a new file: %s -> %s", previousFile, file)
@@ -414,7 +414,6 @@ func (p *Prospector) checkNewFile(newinfo *harvester.FileStat, file string, outp
 		// Launch the harvester
 		h.SetOffset(oldState.offset)
 		h.Start()
-		p.registrar.Persist <- h.GetState()
 	}
 }
 
@@ -457,7 +456,6 @@ func (p *Prospector) checkExistingFile(newinfo *harvester.FileStat, newFile *inp
 
 			// Start a new harvester on the path
 			h.Start()
-			p.registrar.Persist <- h.GetState()
 		}
 
 		// Keep the old file in missingFiles so we don't rescan it if it was renamed and we've not yet reached the new filename
@@ -472,7 +470,6 @@ func (p *Prospector) checkExistingFile(newinfo *harvester.FileStat, newFile *inp
 		// The offset to continue from will be stored in the harvester channel - so take that to use and also clear the channel
 		h.SetOffset(<-newinfo.Return)
 		h.Start()
-		p.registrar.Persist <- h.GetState()
 	} else {
 		logp.Debug("prospector", "Not harvesting, file didn't change: %s", file)
 	}

--- a/filebeat/crawler/prospector.go
+++ b/filebeat/crawler/prospector.go
@@ -302,6 +302,9 @@ func (p *Prospector) scan(path string, output chan *input.FileEvent) {
 
 		// Call crawler if there if there exists a state for the given file
 		foundState, resuming := p.registrar.fetchState(file, newInfo.Fileinfo)
+
+		// Checks if the state is the state in the file info. Keeps fetching the state until it matches.
+		// It can happen on heavy file rotation that state and fileinfo do not correlate
 		for foundState != nil && !foundState.FileStateOS.IsSame(input.GetOSFileState(&newInfo.Fileinfo)) {
 			logp.Debug("prospector", "Refetching state")
 			foundState, resuming = p.registrar.fetchState(file, newInfo.Fileinfo)

--- a/filebeat/crawler/registrar.go
+++ b/filebeat/crawler/registrar.go
@@ -164,7 +164,7 @@ func (r *Registrar) writeRegistry() error {
 	return SafeFileRotate(r.registryFile, tempfile)
 }
 
-func (r *Registrar) fetchState(filePath string, fileInfo os.FileInfo) (int64, bool) {
+func (r *Registrar) fetchState(filePath string, fileInfo os.FileInfo) (*input.FileState, bool) {
 
 	// Check if there is a state for this file
 	lastState, isFound := r.GetFileState(filePath)
@@ -175,7 +175,7 @@ func (r *Registrar) fetchState(filePath string, fileInfo os.FileInfo) (int64, bo
 		logp.Debug("registar", "Same file as before found. Fetch the state.")
 		// We're resuming - throw the last state back downstream so we resave it
 		// And return the offset - also force harvest in case the file is old and we're about to skip it
-		return lastState.Offset, true
+		return lastState, true
 	}
 
 	if previous, err := r.getPreviousFile(filePath, fileInfo); err == nil {
@@ -185,7 +185,7 @@ func (r *Registrar) fetchState(filePath string, fileInfo os.FileInfo) (int64, bo
 		logp.Info("Detected rename of a previously harvested file: %s -> %s", previous, filePath)
 
 		lastState, _ := r.GetFileState(previous)
-		return lastState.Offset, true
+		return lastState, true
 	}
 
 	if isFound {
@@ -193,7 +193,7 @@ func (r *Registrar) fetchState(filePath string, fileInfo os.FileInfo) (int64, bo
 	}
 
 	// New file so just start from an automatic position
-	return 0, false
+	return nil, false
 }
 
 // getPreviousFile checks in the registrar if there is the newFile already exist with a different name

--- a/filebeat/harvester/harvester.go
+++ b/filebeat/harvester/harvester.go
@@ -91,6 +91,8 @@ func NewFileStat(fi os.FileInfo, lastIteration uint32) *FileStat {
 	return fs
 }
 
+// Finished returns true if harvesting is finished
+// fs.Return contains the last offset to continue reading.
 func (fs *FileStat) Finished() bool {
 	return len(fs.Return) != 0
 }

--- a/filebeat/harvester/log.go
+++ b/filebeat/harvester/log.go
@@ -140,6 +140,16 @@ func (h *Harvester) Harvest() {
 		return
 	}
 
+	event := &input.FileEvent{
+		Source:    h.Path,
+		InputType: h.Config.InputType,
+		Offset:    h.GetOffset(),
+		Fileinfo:  &info,
+		Bytes:     0,
+	}
+
+	h.SpoolerChan <- event
+
 	for {
 		// Partial lines return error and are only read on completion
 		ts, text, bytesRead, err := readLine(reader)

--- a/filebeat/harvester/log.go
+++ b/filebeat/harvester/log.go
@@ -87,14 +87,16 @@ func createLineReader(
 // Log harvester reads files line by line and sends events to the defined output
 func (h *Harvester) Harvest() {
 	defer func() {
-		// On completion, push offset so we can continue where we left off if we relaunch on the same file
-		if h.Stat != nil {
-			h.Stat.Return <- h.GetOffset()
-		}
 
 		// Make sure file is closed as soon as harvester exits
 		// If file was never properly opened, it can't be closed
 		if h.file != nil {
+			// On completion, push offset so we can continue where we left off if we relaunch on the same file
+			if h.Stat != nil {
+				// On completion, push offset so we can continue where we left off if we relaunch on the same file
+				h.Stat.Return <- h.GetOffset()
+			}
+
 			h.file.Close()
 			logp.Debug("harvester", "Closing file: %s", h.Path)
 		}
@@ -240,6 +242,21 @@ func (h *Harvester) openFile() (encoding.Encoding, error) {
 			file.Close()
 		}
 	}()
+
+	// Check we are not following a rabbit hole (symlinks, etc.)
+	if !input.IsRegularFile(file) {
+		return nil, errors.New("Given file is not a regular file.")
+	}
+
+	info, err := file.Stat()
+	if err != nil {
+		logp.Err("Failed getting stats for file %s: %s", h.Path, err)
+		return nil, err
+	}
+	// Compares the stat of the opened file to the state given by the prospector. Abort if not match.
+	if !os.SameFile(h.Stat.Fileinfo, info) {
+		return nil, errors.New("File info is not identical with opened file. Aborting harvesting and retrying file later again.")
+	}
 
 	// Check we are not following a rabbit hole (symlinks, etc.)
 	if !input.IsRegularFile(file) {

--- a/filebeat/harvester/log.go
+++ b/filebeat/harvester/log.go
@@ -88,14 +88,15 @@ func createLineReader(
 func (h *Harvester) Harvest() {
 	defer func() {
 
+		// On completion, push offset so we can continue where we left off if we relaunch on the same file
+		if h.Stat != nil {
+			// On completion, push offset so we can continue where we left off if we relaunch on the same file
+			h.Stat.Return <- h.GetOffset()
+		}
+
 		// Make sure file is closed as soon as harvester exits
 		// If file was never properly opened, it can't be closed
 		if h.file != nil {
-			// On completion, push offset so we can continue where we left off if we relaunch on the same file
-			if h.Stat != nil {
-				// On completion, push offset so we can continue where we left off if we relaunch on the same file
-				h.Stat.Return <- h.GetOffset()
-			}
 
 			h.file.Close()
 			logp.Debug("harvester", "Closing file: %s", h.Path)

--- a/filebeat/tests/system/config/filebeat.yml.j2
+++ b/filebeat/tests/system/config/filebeat.yml.j2
@@ -118,7 +118,7 @@ output:
     enabled: true
     path: {{ output_file_path|default(fb.working_dir + "/output") }}
     filename: "{{ output_file_filename|default("filebeat") }}"
-    rotate_every_kb: 1000
+    rotate_every_kb: {{ rotate_every_kb | default(1000) }}
     #number_of_files: 7
 
 # vim: set ft=jinja:

--- a/filebeat/tests/system/test_crawler.py
+++ b/filebeat/tests/system/test_crawler.py
@@ -35,7 +35,7 @@ class Test(TestCase):
 
         self.wait_until(
             lambda: self.log_contains(
-                "Processing 80 events"),
+                "publish 80 events"),
             max_timeout=15)
 
         # TODO: Find better solution when filebeat did crawl the file
@@ -180,7 +180,7 @@ class Test(TestCase):
 
         self.wait_until(
             lambda: self.log_contains(
-                "Processing 5 events"),
+                "publish 5 events"),
             max_timeout=15)
 
         # Rename the file (no new file created)
@@ -200,7 +200,7 @@ class Test(TestCase):
         # expecting 6 more events
         self.wait_until(
             lambda: self.log_contains(
-                "Processing 6 events"),
+                "publish 6 events"),
             max_timeout=20)
 
         filebeat.kill_and_wait()
@@ -235,7 +235,7 @@ class Test(TestCase):
         # Let it read the file
         self.wait_until(
             lambda: self.log_contains(
-                "Processing 5 events"),
+                "publish 5 events"),
             max_timeout=15)
         os.remove(testfile)
 
@@ -250,10 +250,11 @@ class Test(TestCase):
 
         file.close()
 
+        time.sleep(5)
         # Let it read the file
         self.wait_until(
             lambda: self.log_contains(
-                "Processing 6 events"),
+                "publish 6 events"),
             max_timeout=15)
 
         filebeat.kill_and_wait()
@@ -411,7 +412,7 @@ class Test(TestCase):
 
         self.wait_until(
             lambda: self.log_contains(
-                "Processing 1 events"),
+                "publish 1 events"),
             max_timeout=15)
 
         with open(testfile, 'a') as f:
@@ -421,7 +422,7 @@ class Test(TestCase):
 
         self.wait_until(
             lambda: self.log_contains(
-                "Processing 2 events"),
+                "publish 2 events"),
             max_timeout=15)
 
         filebeat.kill_and_wait()
@@ -496,7 +497,7 @@ class Test(TestCase):
 
             self.wait_until(
                 lambda: self.log_contains(
-                    "Processing 1 events"),
+                    "publish 1 events"),
                 max_timeout=15)
 
             # now write another line
@@ -506,7 +507,7 @@ class Test(TestCase):
 
             self.wait_until(
                 lambda: self.log_contains(
-                    "Processing 2 events"),
+                    "publish 2 events"),
                 max_timeout=15)
 
         filebeat.kill_and_wait()
@@ -587,7 +588,7 @@ class Test(TestCase):
 
             self.wait_until(
                 lambda: self.log_contains(
-                    "Processing 1 events"),
+                    "publish 1 events"),
                 max_timeout=15)
 
         # Append utf-8 chars to check if it keeps reading
@@ -599,7 +600,7 @@ class Test(TestCase):
 
             self.wait_until(
                 lambda: self.log_contains(
-                    "Processing 2 events"),
+                    "publish 2 events"),
                 max_timeout=15)
 
         filebeat.kill_and_wait()

--- a/filebeat/tests/system/test_load.py
+++ b/filebeat/tests/system/test_load.py
@@ -41,7 +41,8 @@ class Test(TestCase):
         self.render_config_template(
             path=os.path.abspath(self.working_dir) + "/log/*",
             rotate_every_kb=(total_lines * (line_length +1)),    # With filepath, each line can be up to 1KB is assumed
-            scan_frequency="1s",
+            scan_frequency="0.1s",
+            close_older="1s",
         )
 
         # Start filebeat

--- a/filebeat/tests/system/test_load.py
+++ b/filebeat/tests/system/test_load.py
@@ -41,7 +41,7 @@ class Test(TestCase):
         self.render_config_template(
             path=os.path.abspath(self.working_dir) + "/log/*",
             rotate_every_kb=(total_lines * (line_length +1)),    # With filepath, each line can be up to 1KB is assumed
-            scan_frequency="1s",
+            scan_frequency="0.1s",
         )
 
         # Start filebeat

--- a/filebeat/tests/system/test_load.py
+++ b/filebeat/tests/system/test_load.py
@@ -41,7 +41,7 @@ class Test(TestCase):
         self.render_config_template(
             path=os.path.abspath(self.working_dir) + "/log/*",
             rotate_every_kb=(total_lines * (line_length +1)),    # With filepath, each line can be up to 1KB is assumed
-            scan_frequency="0.1s",
+            scan_frequency="1s",
         )
 
         # Start filebeat

--- a/filebeat/tests/system/test_load.py
+++ b/filebeat/tests/system/test_load.py
@@ -1,0 +1,99 @@
+from filebeat import TestCase
+import os
+import logging
+import logging.handlers
+import json
+from nose.plugins.skip import Skip, SkipTest
+import time
+
+"""
+Test filebeat under different load scenarios
+"""
+
+
+class Test(TestCase):
+    def test_no_missing_events(self):
+        """
+        Test that filebeat does not loose any events under heavy file rotation and load
+        """
+
+        if os.name == "nt":
+            # This test is currently skipped on windows because very fast file
+            # rotation cannot happen when harvester has file handler still open.
+            raise SkipTest
+
+        log_file = self.working_dir + "/log/test.log"
+        os.mkdir(self.working_dir + "/log/")
+
+        logger = logging.getLogger('beats-logger')
+        total_lines = 1000
+        lines_per_file = 10
+        # Each line should have the same length + line ending
+        # Some spare capacity is added to make sure all events are presisted
+        line_length = len(str(total_lines)) + 1
+
+        # Setup python log handler
+        handler = logging.handlers.RotatingFileHandler(
+            log_file, maxBytes=line_length * lines_per_file + 1,
+            backupCount=total_lines / lines_per_file + 1)
+        logger.addHandler(handler)
+
+        self.render_config_template(
+            path=os.path.abspath(self.working_dir) + "/log/*",
+            rotate_every_kb=(total_lines * (line_length +1)),    # With filepath, each line can be up to 1KB is assumed
+            scan_frequency="0.1s",
+        )
+
+        # Start filebeat
+        filebeat = self.start_filebeat()
+
+        # wait until filebeat is fully running
+        self.wait_until(
+            lambda: self.log_contains("All prospectors initialised"),
+            max_timeout=15)
+
+        # Start logging and rotating
+        for i in range(total_lines):
+            # Make sure each line has the same length
+            line = format(i, str(line_length - 1))
+            logger.debug("%d", i)
+
+        # wait until all lines are read
+        self.wait_until(
+            lambda: self.output_has(lines=total_lines),
+            max_timeout=35)
+
+        filebeat.kill_and_wait()
+
+        entry_list = []
+
+        with open(self.working_dir + "/output/filebeat") as f:
+            for line in f:
+                content = json.loads(line)
+                v = int(content["message"])
+                entry_list.append(v)
+
+        ### This lines can be uncomemnted for debugging ###
+        # Prints out the missing entries
+        #for i in range(total_lines):
+        #    if i not in entry_list:
+        #        print i
+        # Stats about the files read
+        #unique_entries = len(set(entry_list))
+        #print "Total lines: " + str(total_lines)
+        #print "Total unique entries: " + str(unique_entries)
+        #print "Total entries: " + str(len(entry_list))
+        #print "Registry entries: " + str(len(data))
+
+        # Check that file exist
+        data = self.get_dot_filebeat()
+
+        paths = os.listdir(self.working_dir + "/log/")
+        assert len(paths) == len(data)
+
+        for i in range(total_lines):
+            assert i in entry_list
+
+        # Compares unique entries
+        assert len(set(entry_list)) == total_lines
+        assert len(entry_list) == total_lines

--- a/filebeat/tests/system/test_prospector.py
+++ b/filebeat/tests/system/test_prospector.py
@@ -66,7 +66,7 @@ class Test(TestCase):
 
         self.wait_until(
             lambda: self.log_contains(
-                "Processing 5 events"),
+                "publish 5 events"),
             max_timeout=10)
 
         proc.kill_and_wait()

--- a/filebeat/tests/system/test_registrar.py
+++ b/filebeat/tests/system/test_registrar.py
@@ -39,7 +39,7 @@ class Test(TestCase):
 
         self.wait_until(
                 lambda: self.log_contains(
-                        "Processing 5 events"),
+                        "publish 5 events"),
                 max_timeout=15)
 
         # Make sure states written appears one more time
@@ -116,7 +116,7 @@ class Test(TestCase):
 
         self.wait_until(
                 lambda: self.log_contains(
-                        "Processing 10 events"),
+                        "publish 10 events"),
                 max_timeout=15)
         # wait until the registry file exist. Needed to avoid a race between
         # the logging and actual writing the file. Seems to happen on Windows.
@@ -148,7 +148,7 @@ class Test(TestCase):
         filebeat = self.start_filebeat()
         self.wait_until(
                 lambda: self.log_contains(
-                        "Processing 1 events"),
+                        "publish 1 events"),
                 max_timeout=15)
         # wait until the registry file exist. Needed to avoid a race between
         # the logging and actual writing the file. Seems to happen on Windows.
@@ -422,7 +422,7 @@ class Test(TestCase):
 
         self.wait_until(
                 lambda: self.log_contains_count(
-                        "Registry file updated. 2 states written.") >= 4,
+                        "Registry file updated. 2 states written.") >= 3,
                 max_timeout=15)
 
         time.sleep(1)


### PR DESCRIPTION
This PR fixes the issue that sometimes on fast file rotation it could happen, that the same file was read twice. This does now no happen anymore. There is one downside to this change and that is on very low scan_frequency it can happen that some file are never read. I'm still investigating if there is an option to prevent this. The main problem here seems to be that states are stored based on the file name, means if there are 2 states with the same filename during one scan, they overwrite each other. This is fixed in 5.0 by removing the filepath as key for the state.