### PR TITLE
Added deprecation notice for symlinks

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -28,16 +28,10 @@ https://github.com/elastic/beats/compare/v1.3.0...1.3[Check the HEAD diff]
 *Affecting all Beats*
 
 *Packetbeat*
-- Add missing nil-check to memcached GapInStream handler. {issue}1162[1162]
-- Fix NFSv4 Operation returning the first found first-class operation available in compound requests. {pull}1821[1821]
-- Fix TCP overlapping segments not being handled correctly. {pull}1917[1917]
 
 *Topbeat*
 
 *Filebeat*
-
-- Fix open file handler issue {issue}2028[2028]
-- Fix panic when the stdin reader encounters EOF. {pull}2268{2268]
 
 *Winlogbeat*
 
@@ -71,6 +65,12 @@ https://github.com/elastic/beats/compare/v1.3.0...1.3[Check the HEAD diff]
 === Beats version 1.3.0
 https://github.com/elastic/beats/compare/v1.2.3...v1.3.0[View commits]
 
+==== Deprecated
+
+*Filebeat*
+
+- Undocumented support for following symlinks is deprecated and will be removed in version 5.0. {pull}1767[1767]
+
 ==== Bugfixes
 
 *Affecting all Beats*
@@ -84,6 +84,8 @@ https://github.com/elastic/beats/compare/v1.2.3...v1.3.0[View commits]
 *Packetbeat*
 
 - Add missing nil-check to memcached GapInStream handler. {issue}1162[1162]
+- Fix NFSv4 Operation returning the first found first-class operation available in compound requests. {pull}1821[1821]
+- Fix TCP overlapping segments not being handled correctly. {pull}1917[1917]
 
 [[release-notes-1.2.3]]
 === Beats version 1.2.3
@@ -99,6 +101,8 @@ https://github.com/elastic/beats/compare/v1.2.2...v1.2.3[View commits]
 *Filebeat*
 
 - Fix rotation issue with ignore_older. {issue}1528[1528]
+- Fix open file handler issue {issue}2028[2028]
+- Fix panic when the stdin reader encounters EOF. {pull}2268{2268]
 
 *Winlogbeat*
 


### PR DESCRIPTION
Also moved more changelog items into 1.3, as we'll be doing another
respin for sure.