### PR TITLE
Add line number counter for multiline

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -824,6 +824,11 @@ https://github.com/elastic/beats/compare/v5.2.0...v5.2.1[View commits]
 *Packetbeat*
 
 - Fix error in the NFS sample dashboard. {pull}3548[3548]
+- Add enabled config option to prospectors. {pull}3157[3157]
+- Add target option for decoded_json_field. {pull}3169[3169]
+- Add the `pipeline` config option at the prospector level, for configuring the Ingest Node pipeline ID. {pull}3433[3433]
+- Update regular expressions used for matching file names or lines (multiline, include/exclude functionality) to new matchers improving performance of simple string matches. {pull}3469[3469]
+- Add multiline line number to filebeat event {pull}2279[2279]
 
 *Winlogbeat*
 

--- a/filebeat/_meta/fields.common.yml
+++ b/filebeat/_meta/fields.common.yml
@@ -41,3 +41,8 @@
     - name: fileset.name
       description: >
         The Filebeat fileset that generated this event.
+
+    - name: multiline.lines
+      type: long
+      description: >
+        This is set in case of a multiline event and contains the number of lines that the multiline event consists of.

--- a/filebeat/docs/fields.asciidoc
+++ b/filebeat/docs/fields.asciidoc
@@ -959,6 +959,14 @@ The Filebeat module that generated this event.
 The Filebeat fileset that generated this event.
 
 
+[float]
+=== `multiline.lines`
+
+type: long
+
+This is set in case of a multiline event and contains the number of lines that the multiline event consists of.
+
+
 [[exported-fields-mysql]]
 == MySQL fields
 

--- a/filebeat/harvester/reader/multiline.go
+++ b/filebeat/harvester/reader/multiline.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/match"
 	"github.com/elastic/beats/libbeat/logp"
 )
@@ -248,6 +249,12 @@ func (mlr *Multiline) clear() {
 
 // finalize writes the existing content into the returned message and resets all reader variables.
 func (mlr *Multiline) finalize() Message {
+
+	mlr.message.AddFields(common.MapStr{
+		"multiline": common.MapStr{
+			"lines": mlr.numLines,
+		},
+	})
 	// Copy message from existing content
 	msg := mlr.message
 	mlr.clear()


### PR DESCRIPTION
This allows to indicate if an event was multiline or not. The number of lines will be put under the multiline namespace and looks as following:

```
{
  ...
  "message": "[2015] hello world\n  First Line\n  Second Line",
  "multiline": {
    "lines": 3
  },
  ...
}
```

See elastic#957
