### PR TITLE
Updating Metricbeat filtering docs

### DIFF
--- a/metricbeat/docs/metricbeat-filtering.asciidoc
+++ b/metricbeat/docs/metricbeat-filtering.asciidoc
@@ -18,8 +18,6 @@ and `type` so they can only be used to filter fields from the module.
 The following example reduces the exported fields of the Redis module to
 include only the `redis.info.memory` fields.
 
-deprecated[5.0.0-alpha4,The `filters` section is being renamed to `processors` in 5.0.0-alpha5. Therefore the following configuration is deprecated]
-
 [source,yaml]
 ----
 metricbeat.modules:
@@ -30,22 +28,7 @@ metricbeat.modules:
   enabled: true
   filters:
     - include_fields:
-       fields: ['redis.info.memory']
-----
-
-added[5.0.0-alpha5,Begin using the following configuration starting with 5.0.0-alpha5]
-
-[source,yaml]
-----
-metricbeat.modules:
-- module: redis
-  metricsets: ["info"]
-  period: 1s
-  hosts: ["127.0.0.1:6379"]
-  enabled: true
-  processors:
-    - include_fields:
-       fields: ['redis.info.memory']
+       fields: ['memory']
 ----
 
 [float]

--- a/metricbeat/docs/reference/configuration/metricbeat-options.asciidoc
+++ b/metricbeat/docs/reference/configuration/metricbeat-options.asciidoc
@@ -12,7 +12,6 @@ metricbeat.modules:
   metricsets: ["status"]
   enabled: true
   period: 1s
-  filters:
   hosts: ["http://127.0.0.1/"]
 
 #---------------------------- MySQL Status Module ----------------------------

--- a/metricbeat/tests/system/test_system.py
+++ b/metricbeat/tests/system/test_system.py
@@ -32,7 +32,7 @@ SYSTEM_MEMORY_FIELDS = ["swap", "actual.free", "free", "total", "used.bytes", "u
                         "actual.used.pct"]
 
 SYSTEM_NETWORK_FIELDS = ["name", "out.bytes", "in.bytes", "out.packets",
-                         "in.packets", "in.error", "out.error", "in.dropeed", "out.dropped"]
+                         "in.packets", "in.error", "out.error", "in.dropped", "out.dropped"]
 
 # cmdline is also part of the system process fields, but it may not be present
 # for some kernel level processes. fd is also part of the system process, but


### PR DESCRIPTION
Within the module config, filters is still valid (it wasn't renamed to processors in this location).

The fields are referenced without the `module.metricset` qualifier (e.g. use `memory` instead of `redis.info.memory`).

Closes #2249