### PR TITLE
Add load test for open files

### DIFF
--- a/filebeat/tests/system/test_load.py
+++ b/filebeat/tests/system/test_load.py
@@ -3,12 +3,15 @@ import os
 import logging
 import logging.handlers
 import json
+import unittest
 from nose.plugins.skip import Skip, SkipTest
 from nose.plugins.attrib import attr
 
 """
 Test filebeat under different load scenarios
 """
+
+LOAD_TESTS = os.environ.get('LOAD_TESTS', False)
 
 
 class Test(BaseTest):
@@ -98,6 +101,7 @@ class Test(BaseTest):
         assert len(entry_list) == total_lines
 
 
+    @unittest.skipUnless(LOAD_TESTS, "load test")
     @attr('load')
     def test_large_number_of_files(self):
         """

--- a/filebeat/tests/system/test_load.py
+++ b/filebeat/tests/system/test_load.py
@@ -4,7 +4,7 @@ import logging
 import logging.handlers
 import json
 from nose.plugins.skip import Skip, SkipTest
-import time
+from nose.plugins.attrib import attr
 
 """
 Test filebeat under different load scenarios
@@ -98,11 +98,46 @@ class Test(BaseTest):
         assert len(entry_list) == total_lines
 
 
-    def test_no_open_files_left(self):
+    @attr('load')
+    def test_large_number_of_files(self):
         """
-        Test that filebeat not keep any files open
+        Tests the number of files filebeat can open on startup
         """
 
-        # This is not implemented yet, here as a reminder
-        raise SkipTest
+        number_of_files = 1000
+        lines_per_file = 3
+
+        # Create content for each file
+        content = ""
+        for n in range(lines_per_file):
+            content += "Line " + str(n+1) + "\n"
+
+        os.mkdir(self.working_dir + "/log/")
+        testfile = self.working_dir + "/log/test"
+
+        for n in range(number_of_files):
+            with open(testfile + "-" + str(n+1), 'w') as f:
+                f.write(content)
+
+
+        self.render_config_template(
+            path=os.path.abspath(self.working_dir) + "/log/*",
+            rotate_every_kb=number_of_files * lines_per_file * 12 * 2,
+            scan_frequency="40s",
+            #close_inactive="5s",
+            #close_eof=True,
+        )
+        filebeat = self.start_beat()
+
+        total_lines = number_of_files * lines_per_file
+        # wait until all lines are read
+        self.wait_until(
+            lambda: self.output_has(lines=total_lines),
+            max_timeout=120)
+
+        filebeat.check_kill_and_wait()
+
+        data = self.get_registry()
+        assert len(data) == number_of_files
+
 

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -132,7 +132,6 @@ prepare-tests:
 unit-tests: prepare-tests
 	$(GOPATH)/bin/gotestcover $(RACE) -coverprofile=${COVERAGE_DIR}/unit.cov  ${GOPACKAGES}
 
-
 # Runs the unit tests without coverage reports.
 .PHONY: unit
 unit:
@@ -151,18 +150,18 @@ integration-tests-environment: prepare-tests build-image
 # Runs the system tests
 .PHONY: system-tests
 system-tests: ${BEATNAME}.test prepare-tests python-env
-	. ${PYTHON_ENV}/bin/activate; nosetests -w tests/system --process-timeout=$(TIMEOUT) -a '!load' --with-timer
+	. ${PYTHON_ENV}/bin/activate; INTEGRATION_TESTS=1 nosetests -w tests/system --process-timeout=$(TIMEOUT) --with-timer
 	python ${ES_BEATS}/dev-tools/aggregate_coverage.py -o ${COVERAGE_DIR}/system.cov ./build/system-tests/run
 
 # Runs the system tests
 .PHONY: system-tests-environment
 system-tests-environment: prepare-tests build-image
-	${DOCKER_COMPOSE} run beat make system-tests;
+	${DOCKER_COMPOSE} run beat make system-tests
 
 # Runs system tests without coverage reports and in parallel
 .PHONY: fast-system-tests
 fast-system-tests: ${BEATNAME}.test python-env
-	. ${PYTHON_ENV}/bin/activate; nosetests -w tests/system --processes=$(PROCESSES) --process-timeout=$(TIMEOUT) -a '!integration' -a '!load'
+	. ${PYTHON_ENV}/bin/activate; nosetests -w tests/system --processes=$(PROCESSES) --process-timeout=$(TIMEOUT)
 
 # Run benchmark tests
 .PHONY: benchmark-tests
@@ -173,7 +172,7 @@ benchmark-tests:
 # Run load tests
 .PHONY: load-tests
 load-tests:
-	. ${PYTHON_ENV}/bin/activate; nosetests -w tests/system --processes=$(PROCESSES) --process-timeout=$(TIMEOUT) -a 'load'
+	. ${PYTHON_ENV}/bin/activate; LOAD_TESTS=1  nosetests -w tests/system --processes=$(PROCESSES) --process-timeout=$(TIMEOUT) -a 'load'
 
 # Sets up the virtual python environment
 .PHONY: python-env

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -151,7 +151,7 @@ integration-tests-environment: prepare-tests build-image
 # Runs the system tests
 .PHONY: system-tests
 system-tests: ${BEATNAME}.test prepare-tests python-env
-	. ${PYTHON_ENV}/bin/activate; nosetests -w tests/system --process-timeout=$(TIMEOUT) --with-timer
+	. ${PYTHON_ENV}/bin/activate; nosetests -w tests/system --process-timeout=$(TIMEOUT) -a '!load' --with-timer
 	python ${ES_BEATS}/dev-tools/aggregate_coverage.py -o ${COVERAGE_DIR}/system.cov ./build/system-tests/run
 
 # Runs the system tests
@@ -162,13 +162,18 @@ system-tests-environment: prepare-tests build-image
 # Runs system tests without coverage reports and in parallel
 .PHONY: fast-system-tests
 fast-system-tests: ${BEATNAME}.test python-env
-	. ${PYTHON_ENV}/bin/activate; nosetests -w tests/system --processes=$(PROCESSES) --process-timeout=$(TIMEOUT) -a '!integration'
+	. ${PYTHON_ENV}/bin/activate; nosetests -w tests/system --processes=$(PROCESSES) --process-timeout=$(TIMEOUT) -a '!integration' -a '!load'
 
 # Run benchmark tests
 .PHONY: benchmark-tests
 benchmark-tests:
 	# No benchmark tests exist so far
 	#go test -bench=. ${GOPACKAGES}
+
+# Run load tests
+.PHONY: load-tests
+load-tests:
+	. ${PYTHON_ENV}/bin/activate; nosetests -w tests/system --processes=$(PROCESSES) --process-timeout=$(TIMEOUT) -a 'load'
 
 # Sets up the virtual python environment
 .PHONY: python-env
@@ -270,7 +275,7 @@ docs-preview:
 ### KIBANA FILES HANDLING ###
 ES_URL?=http://localhost:9200
 
-.PHONY: export-dashboards 
+.PHONY: export-dashboards
 export-dashboards: python-env update
 	. ${PYTHON_ENV}/bin/activate && python ${ES_BEATS}/dev-tools/export_dashboards.py --url ${ES_URL} --dir $(shell pwd)/etc/kibana --regex ${BEATNAME}-*
 

--- a/libbeat/tests/system/beat/beat.py
+++ b/libbeat/tests/system/beat/beat.py
@@ -14,6 +14,7 @@ from datetime import datetime, timedelta
 BEAT_REQUIRED_FIELDS = ["@timestamp", "type",
                         "beat.name", "beat.hostname"]
 
+INTEGRATION_TESTS = os.environ.get('INTEGRATION_TESTS', False)
 
 class Proc(object):
     """

--- a/libbeat/tests/system/test_dashboard.py
+++ b/libbeat/tests/system/test_dashboard.py
@@ -3,9 +3,13 @@ from nose.plugins.attrib import attr
 
 import os
 import subprocess
+import unittest
 
+INTEGRATION_TESTS = os.environ.get('INTEGRATION_TESTS', False)
 
 class Test(BaseTest):
+
+    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     @attr('integration')
     def test_load_dashboard(self):
         """

--- a/metricbeat/tests/system/metricbeat.py
+++ b/metricbeat/tests/system/metricbeat.py
@@ -1,4 +1,5 @@
 import sys
+import os
 
 sys.path.append('../../../libbeat/tests/system')
 from beat.beat import TestCase
@@ -6,6 +7,7 @@ from beat.beat import TestCase
 COMMON_FIELDS = ["@timestamp", "beat", "metricset.name", "metricset.host",
                  "metricset.module", "metricset.rtt", "type"]
 
+INTEGRATION_TESTS = os.environ.get('INTEGRATION_TESTS', False)
 
 class BaseTest(TestCase):
     @classmethod

--- a/metricbeat/tests/system/test_apache.py
+++ b/metricbeat/tests/system/test_apache.py
@@ -1,5 +1,6 @@
 import os
 import metricbeat
+import unittest
 from nose.plugins.attrib import attr
 import urllib2
 import time
@@ -16,6 +17,7 @@ CPU_FIELDS = ["load", "user", "system", "children_user",
 
 
 class ApacheStatusTest(metricbeat.BaseTest):
+    @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
     @attr('integration')
     def test_output(self):
         """

--- a/metricbeat/tests/system/test_mongodb.py
+++ b/metricbeat/tests/system/test_mongodb.py
@@ -1,11 +1,14 @@
 import os
 import metricbeat
+import unittest
 from nose.plugins.attrib import attr
 
 MONGODB_FIELDS = metricbeat.COMMON_FIELDS + ["mongodb"]
 
 
 class Test(metricbeat.BaseTest):
+
+    @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
     @attr('integration')
     def test_status(self):
         """

--- a/metricbeat/tests/system/test_mysql.py
+++ b/metricbeat/tests/system/test_mysql.py
@@ -1,5 +1,6 @@
 import os
 import metricbeat
+import unittest
 from nose.plugins.attrib import attr
 
 MYSQL_FIELDS = metricbeat.COMMON_FIELDS + ["mysql"]
@@ -9,6 +10,8 @@ MYSQL_STATUS_FIELDS = ["clients", "cluster", "cpu", "keyspace", "memory",
 
 
 class Test(metricbeat.BaseTest):
+
+    @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
     @attr('integration')
     def test_status(self):
         """

--- a/metricbeat/tests/system/test_postgresql.py
+++ b/metricbeat/tests/system/test_postgresql.py
@@ -1,5 +1,6 @@
 import os
 import metricbeat
+import unittest
 from nose.plugins.attrib import attr
 
 
@@ -19,6 +20,7 @@ class Test(metricbeat.BaseTest):
     def get_hosts(self):
         return [os.getenv("POSTGRESQL_DSN")]
 
+    @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
     @attr('integration')
     def test_activity(self):
         """
@@ -42,6 +44,7 @@ class Test(metricbeat.BaseTest):
             assert "oid" in evt["postgresql"]["activity"]["database"]
             assert "state" in evt["postgresql"]["activity"]
 
+    @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
     @attr('integration')
     def test_database(self):
         """
@@ -68,6 +71,7 @@ class Test(metricbeat.BaseTest):
             assert "conflicts" in evt["postgresql"]["database"]
             assert "deadlocks" in evt["postgresql"]["database"]
 
+    @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
     @attr('integration')
     def test_bgwriter(self):
         """

--- a/metricbeat/tests/system/test_redis.py
+++ b/metricbeat/tests/system/test_redis.py
@@ -1,6 +1,7 @@
 import os
 import metricbeat
 import redis
+import unittest
 from nose.plugins.attrib import attr
 
 REDIS_FIELDS = metricbeat.COMMON_FIELDS + ["redis"]
@@ -18,6 +19,7 @@ CLIENTS_FIELDS = ["blocked", "biggest_input_buf",
 
 
 class Test(metricbeat.BaseTest):
+    @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
     @attr('integration')
     def test_info(self):
         """
@@ -48,6 +50,7 @@ class Test(metricbeat.BaseTest):
         self.assertItemsEqual(self.de_dot(CPU_FIELDS), redis_info["cpu"].keys())
         self.assert_fields_are_documented(evt)
 
+    @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
     @attr('integration')
     def test_keysace(self):
         """
@@ -81,6 +84,7 @@ class Test(metricbeat.BaseTest):
         self.assertItemsEqual(self.de_dot(REDIS_KEYSPACE_FIELDS), redis_info.keys())
         self.assert_fields_are_documented(evt)
 
+    @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
     @attr('integration')
     def test_filters(self):
         """

--- a/metricbeat/tests/system/test_zookeeper.py
+++ b/metricbeat/tests/system/test_zookeeper.py
@@ -1,5 +1,6 @@
 import os
 import metricbeat
+import unittest
 from nose.plugins.attrib import attr
 
 ZK_FIELDS = metricbeat.COMMON_FIELDS + ["zookeeper"]
@@ -11,6 +12,7 @@ MNTR_FIELDS = ["version", "latency.avg", "latency.max",
                "approximate_data_size", "num_alive_connections"]
 
 class ZooKeeperMntrTest(metricbeat.BaseTest):
+    @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
     @attr('integration')
     def test_output(self):
         """


### PR DESCRIPTION
This test creates x files to be read by filebeat on startup. The close_* config options were disabled to keep the file handlers open to hit some potential limits.

`make load-tests` was introduced as load tests are not run as part of the full test suite as they could be slow and long running.