### PR TITLE
Update to go-ucfg v0.3.3

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -75,7 +75,7 @@ import:
 - package: github.com/dustin/go-humanize
   version: 499693e27ee0d14ffab67c31ad065fdb3d34ea75
 - package: github.com/elastic/go-ucfg
-  version: v0.3.2
+  version: v0.3.3
 - package: github.com/armon/go-socks5
   version: 3a873e99f5400ad7706e464e905ffcc94b3ff247
 - package: github.com/pkg/errors

--- a/vendor/github.com/elastic/go-ucfg/CHANGELOG.md
+++ b/vendor/github.com/elastic/go-ucfg/CHANGELOG.md
@@ -14,6 +14,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+## [0.3.3]
+
+### Fixed
+- Fix (*FlagValue).String panic with go 1.7 #54
+
 ## [0.3.2]
 
 ### Changed
@@ -90,7 +95,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Introduced CHANGELOG.md for documenting changes to ucfg.
 
 
-[Unreleased]: https://github.com/elastic/go-ucfg/compare/v0.3.2...HEAD
+[Unreleased]: https://github.com/elastic/go-ucfg/compare/v0.3.3...HEAD
+[0.3.3]: https://github.com/elastic/go-ucfg/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/elastic/go-ucfg/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/elastic/go-ucfg/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/elastic/go-ucfg/compare/v0.2.1...v0.3.0

--- a/vendor/github.com/elastic/go-ucfg/README.md
+++ b/vendor/github.com/elastic/go-ucfg/README.md
@@ -11,7 +11,7 @@ Card](https://goreportcard.com/badge/github.com/elastic/go-ucfg)](https://gorepo
 
 ## API Documentation
 
-The full API Documentat can be found [here](https://godoc.org/github.com/elastic/go-ucfg).
+The full API Documentation can be found [here](https://godoc.org/github.com/elastic/go-ucfg).
 
 ## Examples
 

--- a/vendor/github.com/elastic/go-ucfg/flag/util.go
+++ b/vendor/github.com/elastic/go-ucfg/flag/util.go
@@ -32,6 +32,10 @@ func (v *FlagValue) Error() error {
 }
 
 func (v *FlagValue) String() string {
+	if v.collector == nil {
+		return ""
+	}
+	
 	return toString(v.Config(), v.collector.GetOptions(), v.onError)
 }
 


### PR DESCRIPTION
fixes panic on `-h` command line flag with go1.7 