### PR TITLE
improve modetest re-usability

### DIFF
--- a/libbeat/outputs/mode/modetest/event.go
+++ b/libbeat/outputs/mode/modetest/event.go
@@ -32,3 +32,31 @@ func Repeat(n int, evt []EventInfo) []EventInfo {
 	}
 	return events
 }
+
+func EventsList(in []EventInfo) [][]outputs.Data {
+	var out [][]outputs.Data
+	for _, pubEvents := range in {
+		if pubEvents.Single {
+			for _, event := range pubEvents.Data {
+				out = append(out, []outputs.Data{event})
+			}
+		} else {
+			out = append(out, pubEvents.Data)
+		}
+	}
+	return out
+}
+
+func FlatEventsList(in []EventInfo) []outputs.Data {
+	return FlattenEvents(EventsList(in))
+}
+
+func FlattenEvents(data [][]outputs.Data) []outputs.Data {
+	var out []outputs.Data
+	for _, inner := range data {
+		for _, d := range inner {
+			out = append(out, d)
+		}
+	}
+	return out
+}


### PR DESCRIPTION
Currently modetest only provides functionality for testing output independent output-publishing strategies (like single connection, single connection with failover or load-balanced output modes). This PR updates modetest helper function for being re-usable for publishing to actual output plugin implementations. This can simplify writing table-driven tests for output plugins.