### PR TITLE
Create a beats-dashboards package

### DIFF
--- a/dev-tools/packer/Makefile
+++ b/dev-tools/packer/Makefile
@@ -30,6 +30,11 @@ beat_abspath=${GOPATH}/src/${BEAT_DIR}
 	ARCH=386 BEAT=$(@D) BUILD_DIR=${BUILD_DIR} BEAT_DIR=$(beat_abspath) BUILDID=$(BUILDID) SNAPSHOT=$(SNAPSHOT) $(packer_absdir)/platforms/binary/build.sh
 	ARCH=amd64 BEAT=$(@D) BUILD_DIR=${BUILD_DIR} BEAT_DIR=$(beat_abspath) BUILDID=$(BUILDID) SNAPSHOT=$(SNAPSHOT) $(packer_absdir)/platforms/binary/build.sh
 
+.PHONY: package-dashboards
+package-dashboards:
+	echo Creating the Dashboards package
+	BUILDID=$(BUILDID) SNAPSHOT=$(SNAPSHOT) $(packer_absdir)/platforms/dashboards/build.sh
+
 .PHONY: deps
 deps:
 	go get -u github.com/tsg/gotpl

--- a/dev-tools/packer/platforms/README
+++ b/dev-tools/packer/platforms/README
@@ -1,0 +1,1 @@
+Pseudo-platform to build the dashboards in their own package.

--- a/dev-tools/packer/platforms/dashboards/build.sh
+++ b/dev-tools/packer/platforms/dashboards/build.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+set -e
+
+BASEDIR=$(dirname "$0")
+ARCHDIR=${BASEDIR}/../../
+
+runid=dashboards
+
+cat ${ARCHDIR}/version.yml > ${BUILD_DIR}/settings-$runid.yml
+gotpl ${BASEDIR}/run.sh.j2 < ${BUILD_DIR}/settings-$runid.yml > ${BUILD_DIR}/run-$runid.sh
+chmod +x ${BUILD_DIR}/run-$runid.sh
+
+docker run --rm -v ${BUILD_DIR}:/build \
+    -e BUILDID=$BUILDID -e SNAPSHOT=$SNAPSHOT -e RUNID=$runid \
+    tudorg/fpm /build/run-$runid.sh
+
+rm ${BUILD_DIR}/settings-$runid.yml ${BUILD_DIR}/run-$runid.sh

--- a/dev-tools/packer/platforms/dashboards/run.sh.j2
+++ b/dev-tools/packer/platforms/dashboards/run.sh.j2
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# this is executed in the docker fpm image
+set -e
+cd /build
+
+# add SNAPSHOT if it was requested
+VERSION={{.version}}
+if [ "$SNAPSHOT" = "yes" ]; then
+    VERSION="${VERSION}-SNAPSHOT"
+fi
+
+mkdir /beats-dashboards-${VERSION}
+cp -a dashboards/. /beats-dashboards-${VERSION}/
+echo "$BUILDID" > /beats-dashboards-${VERSION}/.build_hash.txt
+
+mkdir -p upload
+zip -r upload/beats-dashboards-${VERSION}.zip /beats-dashboards-${VERSION}
+echo "Created upload/beats-dashboards-${VERSION}.zip"
+
+cd upload
+sha1sum beats-dashboards-${VERSION}.zip > beats-dashboards-${VERSION}.zip.sha1.txt
+echo "Created upload/beats-dashboards-${VERSION}.zip.sha1.txt"


### PR DESCRIPTION
Contains the dashboards for each beat in a sub-directory, ready
to be used by the import Go program.

Implementation wise, this is done as a pseudo-platform so it can
use features like the common version and the build hash.