### PR TITLE
Make generate_index_pattern.py Python 3 compatible

### DIFF
--- a/libbeat/scripts/generate_index_pattern.py
+++ b/libbeat/scripts/generate_index_pattern.py
@@ -80,7 +80,7 @@ def fields_to_index_pattern(args, input):
 
 def get_index_pattern_name(index):
 
-    allow = string.letters + string.digits + "_"
+    allow = string.ascii_letters + string.digits + "_"
     return re.sub('[^%s]' % allow, '', index)
 
 
@@ -119,4 +119,4 @@ if __name__ == "__main__":
     with open(target_file, 'w') as f:
         f.write(output)
 
-    print "The index pattern was created under {}".format(target_file)
+    print ("The index pattern was created under {}".format(target_file))


### PR DESCRIPTION
Change `print` to use parenthesis and use `string.ascii_letters` instead of just `string.letters` to be compatible with Python 3.

This is a similar fix to #1778 .

Parenthesized form of `print` and `string.ascii_letters` is also valid in Python 2.

The change to use `ascii_letters` would also fix locale dependent field names (anything non-ASCII was actually valid in case the locale was set).