### PR TITLE
Package the import_dashboards go program

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,7 @@ package: beats-dashboards
 	$(foreach var,$(BEATS),SNAPSHOT=$(SNAPSHOT) $(MAKE) -C $(var) package || exit 1;)
 
 	# build the dashboards package
+	mkdir -p build/upload/
 	BUILD_DIR=${shell pwd}/build SNAPSHOT=$(SNAPSHOT) $(MAKE) -C dev-tools/packer package-dashboards ${shell pwd}/build/upload/build_id.txt
 	mv build/upload build/dashboards-upload
 

--- a/dev-tools/packer/platforms/binary/run.sh.j2
+++ b/dev-tools/packer/platforms/binary/run.sh.j2
@@ -12,6 +12,7 @@ fi
 
 mkdir /{{.beat_name}}-${VERSION}-linux-{{.bin_arch}}
 cp -a homedir/. /{{.beat_name}}-${VERSION}-linux-{{.bin_arch}}/
+install -D -m 755 import_dashboards-linux-{{.arch}} /{{.beat_name}}-${VERSION}-linux-{{.bin_arch}}/scripts/import_dashboards
 cp {{.beat_name}}-linux-{{.arch}} /{{.beat_name}}-${VERSION}-linux-{{.bin_arch}}/{{.beat_name}}
 cp {{.beat_name}}-linux.yml /{{.beat_name}}-${VERSION}-linux-{{.bin_arch}}/{{.beat_name}}.yml
 cp {{.beat_name}}-linux.full.yml /{{.beat_name}}-${VERSION}-linux-{{.bin_arch}}/{{.beat_name}}.full.yml

--- a/dev-tools/packer/platforms/centos/run.sh.j2
+++ b/dev-tools/packer/platforms/centos/run.sh.j2
@@ -39,7 +39,9 @@ fpm --force -s dir -t rpm \
         {{.beat_name}}.template.json=/etc/{{.beat_name}}/{{.beat_name}}.template.json \
         {{.beat_name}}.template-es2x.json=/etc/{{.beat_name}}/{{.beat_name}}.template-es2x.json \
         ${RUNID}.service=/lib/systemd/system/{{.beat_name}}.service \
-        god-linux-{{.arch}}=/usr/share/{{.beat_name}}/bin/{{.beat_name}}-god
+        god-linux-{{.arch}}=/usr/share/{{.beat_name}}/bin/{{.beat_name}}-god \
+        import_dashboards-linux-{{.arch}}=/usr/share/{{.beat_name}}/scripts/import_dashboards
+
 
 
 # rename so that the filename respects semver rules

--- a/dev-tools/packer/platforms/darwin/run.sh.j2
+++ b/dev-tools/packer/platforms/darwin/run.sh.j2
@@ -12,6 +12,7 @@ fi
 
 mkdir /{{.beat_name}}-${VERSION}-darwin-x86_64
 cp -a homedir/. /{{.beat_name}}-${VERSION}-darwin-x86_64/
+install -D -m 755 import_dashboards-darwin-{{.arch}} /{{.beat_name}}-${VERSION}-darwin-x86_64/scripts/import_dashboards
 cp {{.beat_name}}-darwin-amd64 /{{.beat_name}}-${VERSION}-darwin-x86_64/{{.beat_name}}
 cp {{.beat_name}}-darwin.yml /{{.beat_name}}-${VERSION}-darwin-x86_64/{{.beat_name}}.yml
 cp {{.beat_name}}-darwin.full.yml /{{.beat_name}}-${VERSION}-darwin-x86_64/{{.beat_name}}.full.yml

--- a/dev-tools/packer/platforms/debian/run.sh.j2
+++ b/dev-tools/packer/platforms/debian/run.sh.j2
@@ -36,7 +36,8 @@ fpm --force -s dir -t deb \
         {{.beat_name}}.template.json=/etc/{{.beat_name}}/{{.beat_name}}.template.json \
         {{.beat_name}}.template-es2x.json=/etc/{{.beat_name}}/{{.beat_name}}.template-es2x.json \
         ${RUNID}.service=/lib/systemd/system/{{.beat_name}}.service \
-        god-linux-{{.arch}}=/usr/share/{{.beat_name}}/bin/{{.beat_name}}-god
+        god-linux-{{.arch}}=/usr/share/{{.beat_name}}/bin/{{.beat_name}}-god \
+        import_dashboards-linux-{{.arch}}=/usr/share/{{.beat_name}}/scripts/import_dashboards
 
 # move and rename to use the elastic conventions
 mkdir -p upload

--- a/dev-tools/packer/platforms/windows/run.sh.j2
+++ b/dev-tools/packer/platforms/windows/run.sh.j2
@@ -12,6 +12,7 @@ fi
 
 mkdir /{{.beat_name}}-${VERSION}-windows-{{.win_arch}}
 cp -a homedir/. /{{.beat_name}}-${VERSION}-windows-{{.win_arch}}/
+install -D -m 755 import_dashboards-windows-{{.arch}} /{{.beat_name}}-${VERSION}-windows-{{.win_arch}}/scripts/import_dashboards
 cp {{.beat_name}}-windows-{{.arch}}.exe /{{.beat_name}}-${VERSION}-windows-{{.win_arch}}/{{.beat_name}}.exe
 unix2dos {{.beat_name}}-win.yml
 cp {{.beat_name}}-win.yml /{{.beat_name}}-${VERSION}-windows-{{.win_arch}}/{{.beat_name}}.yml

--- a/dev-tools/packer/xgo-scripts/before_build.sh
+++ b/dev-tools/packer/xgo-scripts/before_build.sh
@@ -18,6 +18,26 @@ PREFIX=/build
 mkdir -p $PREFIX/homedir
 make install-home HOME_PREFIX=$PREFIX/homedir
 
+# Compile the import_dashboards binary for the requested targets.
+if [ -d $BEAT_PATH/../libbeat/ ]; then
+	# official Beats have libbeat in the top level folder
+	LIBBEAT_PATH=$BEAT_PATH/../libbeat/
+elif [ -d $BEAT_PATH/vendor/github.com/elastic/beats/libbeat/ ]; then
+	# community Beats have libbeat vendored
+	LIBBEAT_PATH=$BEAT_PATH/vendor/github.com/elastic/beats/libbeat/
+else
+	echo "Couldn't find the libbeat location"
+	exit 1
+fi
+
+for TARGET in $TARGETS; do
+	echo "Compiling import_dashboards for $TARGET"
+	XGOOS=`echo $TARGET | cut -d '/' -f 1`
+	XGOARCH=`echo $TARGET | cut -d '/' -f 2`
+
+	GOOS=$XGOOS GOARCH=$XGOARCH go build -o $PREFIX/import_dashboards-$XGOOS-$XGOARCH $LIBBEAT_PATH/dashboards/import_dashboards.go
+done
+
 if [ -n "BUILDID" ]; then
     echo "$BUILDID" > $PREFIX/homedir/.build_hash.txt
 fi

--- a/libbeat/dashboards/Makefile
+++ b/libbeat/dashboards/Makefile
@@ -1,0 +1,2 @@
+import_dasboards: import_dashboards.go
+	go build -o import_dashboards

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -316,10 +316,9 @@ env-logs:
 # Installs the files that need to get to the home path on installations
 HOME_PREFIX?=/tmp/${BEATNAME}
 .PHONY: install-home
-install-home: build-dashboards 
+install-home:
 	install -d -m 755 ${HOME_PREFIX}/scripts/
 	install -m 755 ${ES_BEATS}/libbeat/scripts/migrate_beat_config_1_x_to_5_0.py ${HOME_PREFIX}/scripts/
-	install -m 755 ${ES_BEATS}/libbeat/dashboards/import_dashboards ${HOME_PREFIX}/scripts/
 
 # Prepares for packaging. Builds binaries and creates homedir data
 .PHONY: prepare-package
@@ -369,11 +368,13 @@ prepare-package-cgo:
 		${BEAT_DIR}
 
 # Prepares images for packaging
+.PHONY: package-setup
 package-setup:
 	$(MAKE) -C ${ES_BEATS}/dev-tools/packer deps images
 
 # Create binary packages for the beat.
 # This requires that `package-setup` was run before once.
+.PHONY: package
 package:
 
 	echo "Start building packages for ${BEATNAME}"
@@ -395,6 +396,3 @@ package:
 	SNAPSHOT=${SNAPSHOT} BUILDID=${BUILDID} BEAT_DIR=${BEAT_DIR} BUILD_DIR=${BUILD_DIR} $(MAKE) -C ${ES_BEATS}/dev-tools/packer ${PACKAGES} ${BUILD_DIR}/upload/build_id.txt
 
 	echo "Finished packages for ${BEATNAME}"
-
-build-dashboards: ${ES_BEATS}/libbeat/dashboards/import_dashboards.go
-	go build -o ${ES_BEATS}/libbeat/dashboards/import_dashboards ${ES_BEATS}/libbeat/dashboards/import_dashboards.go


### PR DESCRIPTION
* The cross-compiling happens in the before-build script
* The correct binary gets included from the platform scripts
* Should work already for the community beats, but not yet tested
* Also moved the import_dashboards compile target in its own Makefile near the code (not used during packaging, though)