### PR TITLE
Per beat package dashboard target

### DIFF
--- a/dev-tools/packer/platforms/dashboards/build.sh
+++ b/dev-tools/packer/platforms/dashboards/build.sh
@@ -12,7 +12,7 @@ gotpl ${BASEDIR}/run.sh.j2 < ${BUILD_DIR}/settings-$runid.yml > ${BUILD_DIR}/run
 chmod +x ${BUILD_DIR}/run-$runid.sh
 
 docker run --rm -v ${BUILD_DIR}:/build \
-    -e BUILDID=$BUILDID -e SNAPSHOT=$SNAPSHOT -e RUNID=$runid \
+    -e BUILDID=$BUILDID -e SNAPSHOT=$SNAPSHOT -e RUNID=$runid -e BEATNAME=$BEATNAME \
     tudorg/fpm /build/run-$runid.sh
 
 rm ${BUILD_DIR}/settings-$runid.yml ${BUILD_DIR}/run-$runid.sh

--- a/dev-tools/packer/platforms/dashboards/run.sh.j2
+++ b/dev-tools/packer/platforms/dashboards/run.sh.j2
@@ -10,14 +10,14 @@ if [ "$SNAPSHOT" = "yes" ]; then
     VERSION="${VERSION}-SNAPSHOT"
 fi
 
-mkdir /beats-dashboards-${VERSION}
-cp -a dashboards/. /beats-dashboards-${VERSION}/
-echo "$BUILDID" > /beats-dashboards-${VERSION}/.build_hash.txt
+mkdir /${BEATNAME:-beats}-dashboards-${VERSION}
+cp -a dashboards/. /${BEATNAME:-beats}-dashboards-${VERSION}/
+echo "$BUILDID" > /${BEATNAME:-beats}-dashboards-${VERSION}/.build_hash.txt
 
 mkdir -p upload
-zip -r upload/beats-dashboards-${VERSION}.zip /beats-dashboards-${VERSION}
-echo "Created upload/beats-dashboards-${VERSION}.zip"
+zip -r upload/${BEATNAME:-beats}-dashboards-${VERSION}.zip /${BEATNAME:-beats}-dashboards-${VERSION}
+echo "Created upload/${BEATNAME:-beats}-dashboards-${VERSION}.zip"
 
 cd upload
-sha1sum beats-dashboards-${VERSION}.zip > beats-dashboards-${VERSION}.zip.sha1.txt
-echo "Created upload/beats-dashboards-${VERSION}.zip.sha1.txt"
+sha1sum ${BEATNAME:-beats}-dashboards-${VERSION}.zip > ${BEATNAME:-beats}-dashboards-${VERSION}.zip.sha1.txt
+echo "Created upload/${BEATNAME:-beats}-dashboards-${VERSION}.zip.sha1.txt"

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -396,3 +396,9 @@ package:
 	SNAPSHOT=${SNAPSHOT} BUILDID=${BUILDID} BEAT_DIR=${BEAT_DIR} BUILD_DIR=${BUILD_DIR} $(MAKE) -C ${ES_BEATS}/dev-tools/packer ${PACKAGES} ${BUILD_DIR}/upload/build_id.txt
 
 	echo "Finished packages for ${BEATNAME}"
+
+package-dashboards:
+	mkdir -p ${BUILD_DIR}
+	cp -r etc/kibana ${BUILD_DIR}/dashboards
+	# build the dashboards package
+	BEATNAME=${BEATNAME} BUILD_DIR=${BUILD_DIR} SNAPSHOT=$(SNAPSHOT) $(MAKE) -C ${ES_BEATS}/dev-tools/packer package-dashboards ${shell pwd}/build/upload/build_id.txt


### PR DESCRIPTION
This can be used by the community beats, but also by us if we
ever want to create a package containing the dashboards from a
single Beat.

Part of #2299.

The resulting archives are called, e.g. `filebeat-dashboards-5.0.0.zip`