### PR TITLE
Make sure we run package-setup before package-dashboards

### DIFF
--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -397,7 +397,7 @@ package:
 
 	echo "Finished packages for ${BEATNAME}"
 
-package-dashboards:
+package-dashboards: package-setup
 	mkdir -p ${BUILD_DIR}
 	cp -r etc/kibana ${BUILD_DIR}/dashboards
 	# build the dashboards package


### PR DESCRIPTION
Make package-dashboards depend on package-setup, so we install all the dependencies before.

cc-ed @tsg 