### PR TITLE
Faster make target

### DIFF
--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -29,6 +29,7 @@ ARCH?=$(shell uname -m)
 export PATH := ./bin:$(PATH)
 GOFILES = $(shell find . -type f -name '*.go')
 GOFILES_NOVENDOR = $(shell find . -type f -name '*.go' -not -path "*/vendor/*")
+GOFILES_ALL = $(GOFILES) $(shell find $(ES_BEATS) -type f -name '*.go')
 SHELL=bash
 ES_HOST?="elasticsearch"
 PWD=$(shell pwd)
@@ -68,13 +69,11 @@ endif
 ### BUILDING ###
 
 # Builds beat
-.PHONY: ${BEATNAME}
-${BEATNAME}: $(GOFILES)
+${BEATNAME}: $(GOFILES_ALL)
 	go build
 
 # Create test coverage binary
-.PHONY: ${BEATNAME}.test
-${BEATNAME}.test: $(GOFILES)
+${BEATNAME}.test: $(GOFILES_ALL)
 	go test $(RACE) -c -coverpkg ${GOPACKAGES_COMMA_SEP}
 
 # Cross-compile beat for the OS'es specified in GOX_OS variable.


### PR DESCRIPTION
This change makes the build target be executed only if any of the go
files have changed. It looks for go files in the current directory +
everything under ES_BEATS (including vendor folder). This means it should
be fine for community beats as well, as long as they vendor their deps (I
think the default now).

The difference is significant, for example for metricbeat:

before:

```
> time make
go build
        7.14 real        16.77 user         3.07 sys
```

after:

```
> time make
make: `metricbeat' is up to date.
        0.89 real         0.79 user         0.09 sys
```