### PR TITLE
Remove -e from the beatname.sh

### DIFF
--- a/dev-tools/packer/platforms/centos/beatname.sh.j2
+++ b/dev-tools/packer/platforms/centos/beatname.sh.j2
@@ -3,8 +3,7 @@
 # Script to run {.beat_name} in foreground with the same path settings that
 # the init script / systemd unit file would do.
 
-/usr/share/{{.beat_name}}/bin/{{.beat_name}} -e \
-  -c /etc/{{.beat_name}}/{{.beat_name}}.yml \
+/usr/share/{{.beat_name}}/bin/{{.beat_name}} \
   -path.home /usr/share/{{.beat_name}} \
   -path.config /etc/{{.beat_name}} \
   -path.data /var/lib/{{.beat_name}} \

--- a/dev-tools/packer/platforms/debian/beatname.sh.j2
+++ b/dev-tools/packer/platforms/debian/beatname.sh.j2
@@ -3,7 +3,7 @@
 # Script to run {{.beat_name}} in foreground with the same path settings that
 # the init script / systemd unit file would do.
 
-/usr/share/{{.beat_name}}/bin/{{.beat_name}} -e \
+/usr/share/{{.beat_name}}/bin/{{.beat_name}} \
   -path.home /usr/share/{{.beat_name}} \
   -path.config /etc/{{.beat_name}} \
   -path.data /var/lib/{{.beat_name}} \


### PR DESCRIPTION
This makes it behave more similar with the init/system.d scripts, which helps troubleshoot some situations (e.g. logging). Related to #2321.

Also removes a -c flag forgotten.