### PR TITLE
Add IP address to -devices command output

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -86,6 +86,7 @@ https://github.com/elastic/beats/compare/v5.0.0-alpha5...master[Check the HEAD d
 
  - Add cassandra protocol analyzer to packetbeat. {pull}1959[1959]
  - Match connections with IPv6 addresses to processes {pull}2254[2254]
+ - Add IP address to -devices command output {pull}2327[2327]
 
 *Topbeat*
 

--- a/packetbeat/beater/devices.go
+++ b/packetbeat/beater/devices.go
@@ -18,7 +18,7 @@ func init() {
 			return nil
 		}
 
-		devs, err := sniffer.ListDeviceNames(true)
+		devs, err := sniffer.ListDeviceNames(true, true)
 		if err != nil {
 			return fmt.Errorf("Error getting devices list: %v\n", err)
 		}

--- a/packetbeat/sniffer/sniffer.go
+++ b/packetbeat/sniffer/sniffer.go
@@ -133,7 +133,7 @@ func (sniffer *SnifferSetup) setFromConfig(config *config.InterfacesConfig) erro
 	}
 
 	if index, err := strconv.Atoi(sniffer.config.Device); err == nil { // Device is numeric
-		devices, err := ListDeviceNames(false)
+		devices, err := ListDeviceNames(false, false)
 		if err != nil {
 			return fmt.Errorf("Error getting devices list: %v", err)
 		}

--- a/packetbeat/sniffer/sniffer.go
+++ b/packetbeat/sniffer/sniffer.go
@@ -74,8 +74,9 @@ func deviceNameFromIndex(index int, devices []string) (string, error) {
 
 // ListDevicesNames returns the list of adapters available for sniffing on
 // this computer. If the withDescription parameter is set to true, a human
-// readable version of the adapter name is added.
-func ListDeviceNames(withDescription bool) ([]string, error) {
+// readable version of the adapter name is added. If the withIP parameter
+// is set to true, IP address of the adatper is added.
+func ListDeviceNames(withDescription bool, withIP bool) ([]string, error) {
 	devices, err := pcap.FindAllDevs()
 	if err != nil {
 		return []string{}, err
@@ -83,15 +84,34 @@ func ListDeviceNames(withDescription bool) ([]string, error) {
 
 	ret := []string{}
 	for _, dev := range devices {
+		result := dev.Name
+		
 		if withDescription {
 			desc := "No description available"
 			if len(dev.Description) > 0 {
 				desc = dev.Description
 			}
-			ret = append(ret, fmt.Sprintf("%s (%s)", dev.Name, desc))
-		} else {
-			ret = append(ret, dev.Name)
+			result += fmt.Sprintf(" (%s)", desc)
 		}
+		
+		if withIP {
+			ips := "Not assigned ip address"
+			if len(dev.Addresses) > 0 {
+				ips = ""
+				
+				for index, address := range []pcap.InterfaceAddress(dev.Addresses) {
+					if index > 0 {
+						// add a space between the IP address.
+						ips += " "
+					}
+					
+					ips += fmt.Sprintf("%s", address.IP.String())
+				}
+			}
+			result += fmt.Sprintf(" (%s)", ips)
+
+		}
+		ret = append(ret, result)
 	}
 	return ret, nil
 }

--- a/packetbeat/sniffer/sniffer.go
+++ b/packetbeat/sniffer/sniffer.go
@@ -84,34 +84,34 @@ func ListDeviceNames(withDescription bool, withIP bool) ([]string, error) {
 
 	ret := []string{}
 	for _, dev := range devices {
-		result := dev.Name
-		
+		r := dev.Name
+
 		if withDescription {
 			desc := "No description available"
 			if len(dev.Description) > 0 {
 				desc = dev.Description
 			}
-			result += fmt.Sprintf(" (%s)", desc)
+			r += fmt.Sprintf(" (%s)", desc)
 		}
-		
+
 		if withIP {
 			ips := "Not assigned ip address"
 			if len(dev.Addresses) > 0 {
 				ips = ""
-				
-				for index, address := range []pcap.InterfaceAddress(dev.Addresses) {
-					if index > 0 {
-						// add a space between the IP address.
+
+				for i, address := range []pcap.InterfaceAddress(dev.Addresses) {
+					// Add a space between the IP address.
+					if i > 0 {
 						ips += " "
 					}
-					
+
 					ips += fmt.Sprintf("%s", address.IP.String())
 				}
 			}
-			result += fmt.Sprintf(" (%s)", ips)
+			r += fmt.Sprintf(" (%s)", ips)
 
 		}
-		ret = append(ret, result)
+		ret = append(ret, r)
 	}
 	return ret, nil
 }


### PR DESCRIPTION
On Windows, device description is a device driver name.
It is confusing when there are multiple same devices.

![image](https://cloud.githubusercontent.com/assets/1870623/17832953/c5cb7234-674b-11e6-9ebe-2f8d3545c5df.png)

So, I added a IP address to -devices command output.
It is helpful to set up a sniffer interface.

![image](https://cloud.githubusercontent.com/assets/1870623/17832991/1ce3c034-674d-11e6-830a-98db404f3ed1.png)
