### PR TITLE
Update TLS configuration options

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -17,6 +17,10 @@ https://github.com/elastic/beats/compare/v5.0.0-alpha5...master[Check the HEAD d
 - Replace `output.kafka.use_type` by `output.kafka.topic` accepting a format string. {pull}2188[2188]
 - If the path specified by the `-c` flag is not absolute and `-path.config` is not specified, it
   is considered relative to the current working directory. {pull}2245[2245]
+- rename `tls` configurations section to `ssl`. {pull}2330[2330]
+- rename `certificate_key` configuration to `key`. {pull}2330[2330]
+- replace `tls.insecure` with `ssl.verification_mode` setting. {pull}2330[2330]
+- replace `tls.min/max_version` with `ssl.supported_protocols` setting requiring full protocol name. {pull}2330[2330]
 
 *Metricbeat*
 - Change field type system.process.cpu.start_time from keyword to date. {issue}1565[1565]
@@ -77,6 +81,7 @@ https://github.com/elastic/beats/compare/v5.0.0-alpha5...master[Check the HEAD d
 - Re-write import_dashboards.sh in Golang. {pull}2155[2155]
 - Update to Go 1.7. {pull}2306[2306]
 - Log total non-zero internal metrics on shutdown. {pull}2349[2349]
+- Add support for encrypted private key files by introducing `ssl.key_passphrase` setting. {pull}2330[2330]
 
 *Metricbeat*
 

--- a/filebeat/docs/migration.asciidoc
+++ b/filebeat/docs/migration.asciidoc
@@ -208,25 +208,25 @@ output.logstash:
   # Network timeout in seconds.
   timeout: 15
 
-  # Optional TLS settings <2>
+  # Optional SSL settings <2>
   # List of root certificates for HTTPS server verifications
-  tls.certificate_authorities:
+  ssl.certificate_authorities:
     - ./logstash-forwarder.crt
 
-  # Certificate for TLS client authentication
-  tls.certificate: ./logstash-forwarder.crt
+  # Certificate for SSL client authentication
+  ssl.certificate: ./logstash-forwarder.crt
 
   # Client Certificate Key
-  tls.certificate_key: ./logstash-forwarder.key
+  ssl.key: ./logstash-forwarder.key
 -------------------------------------------------------------------------------------
 
 <1> When multiple hosts are defined, the default behavior in Filebeat is to
     pick a random host for new connections, similar to the Logstash Forwarder
     behavior. Filebeat can optionally do load balancing. For more details, see the
     <<loadbalance>> configuration option.
-<2> Note that if the `tls` settings are missing, then TLS is disabled. TLS is
-    automatically enabled when you add any of the `tls` options. For more information about
-    specific configuration options, see <<configuration-output-tls>>.
+<2> Note that if the `ssl` settings are missing, then SSL is disabled. SSL is
+    automatically enabled when you add any of the `ssl` options. For more information about
+    specific configuration options, see <<configuration-output-ssl>>.
 
 
 [[changed-configuration-options]]
@@ -442,10 +442,10 @@ Behind the scenes, Filebeat uses a sightly improved protocol for communicating
 with Logstash.
 
 [float]
-=== TLS Is Off by Default
+=== SSL Is Off by Default
 
-If you follow the section on migrating the configuration, you will have TLS
-enabled. However, you must be aware that if the `tls` section is missing from the
+If you follow the section on migrating the configuration, you will have SSL
+enabled. However, you must be aware that if the `ssl` section is missing from the
 configuration file, Filebeat uses an unencrypted connection to talk to Logstash.
 
 [float]

--- a/filebeat/docs/reference/configuration.asciidoc
+++ b/filebeat/docs/reference/configuration.asciidoc
@@ -19,7 +19,7 @@ configuration settings, you need to restart {beatname_uc} to pick up the changes
 * <<redis-output>>
 * <<file-output>>
 * <<console-output>>
-* <<configuration-output-tls>>
+* <<configuration-output-ssl>>
 * <<configuration-path>>
 * <<configuration-logging>>
 

--- a/filebeat/docs/securing-filebeat.asciidoc
+++ b/filebeat/docs/securing-filebeat.asciidoc
@@ -7,7 +7,7 @@
 The following topics describe how to secure communication between Filebeat and other products in the Elastic stack:
 
 * <<securing-communication-elasticsearch>>
-* <<configuring-tls-logstash>>
+* <<configuring-ssl-logstash>>
 
 --
 
@@ -15,6 +15,6 @@ The following topics describe how to secure communication between Filebeat and o
 == Securing Communication With Elasticsearch
 include::../../libbeat/docs/https.asciidoc[]
 
-[[configuring-tls-logstash]]
-== Securing Communication With Logstash by Using TLS
-include::../../libbeat/docs/shared-tls-logstash-config.asciidoc[]
+[[configuring-ssl-logstash]]
+== Securing Communication With Logstash by Using SSL
+include::../../libbeat/docs/shared-ssl-logstash-config.asciidoc[]

--- a/filebeat/filebeat.full.yml
+++ b/filebeat/filebeat.full.yml
@@ -373,34 +373,37 @@ output.elasticsearch:
   # Path to the Elasticsearch 2.x version of the template file.
   #template.versions.2x.path: "${path.config}/filebeat.template-es2x.json"
 
+  # Use SSL settings for HTTPS. Default is true.
+  #ssl.enabled: true
 
-  # TLS configuration. By default is off.
+  # Configure SSL verification mode. If `none` is configured, all server hosts
+  # and certificates will be accepted. In this mode, SSL based connections are
+  # susceptible to man-in-the-middle attacks. Use only for testing. Default is
+  # `full`.
+  #ssl.verification_mode: full
+
+  # List of supported/valid TLS versions. By default all TLS versions 1.0 up to
+  # 1.2 are enabled.
+  #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
+
+  # SSL configuration. By default is off.
   # List of root certificates for HTTPS server verifications
-  #tls.certificate_authorities: ["/etc/pki/root/ca.pem"]
+  #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
-  # Certificate for TLS client authentication
-  #tls.certificate: "/etc/pki/client/cert.pem"
+  # Certificate for SSL client authentication
+  #ssl.certificate: "/etc/pki/client/cert.pem"
 
   # Client Certificate Key
-  #tls.certificate_key: "/etc/pki/client/cert.key"
+  #ssl.key: "/etc/pki/client/cert.key"
 
-  # Controls whether the client verifies server certificates and host name.
-  # If insecure is set to true, all server host names and certificates will be
-  # accepted. In this mode TLS based connections are susceptible to
-  # man-in-the-middle attacks. Use only for testing.
-  #tls.insecure: true
+  # Optional passphrase for decrypting the Certificate Key.
+  #ssl.key_passphrase: ''
 
-  # Configure cipher suites to be used for TLS connections
-  #tls.cipher_suites: []
+  # Configure cipher suites to be used for SSL connections
+  #ssl.cipher_suites: []
 
   # Configure curve types for ECDHE based cipher suites
-  #tls.curve_types: []
-
-  # Configure minimum TLS version allowed for connection to logstash
-  #tls.min_version: 1.0
-
-  # Configure maximum TLS version allowed for connection to logstash
-  #tls.max_version: 1.2
+  #ssl.curve_types: []
 
 
 #----------------------------- Logstash output --------------------------------
@@ -434,27 +437,37 @@ output.elasticsearch:
   # Resolve names locally when using a proxy server. Defaults to false.
   #proxy_use_local_resolver: false
 
-  # Optional TLS configuration options. TLS is off by default.
-  # List of root certificates for HTTPS server verifications
-  #tls.certificate_authorities: ["/etc/pki/root/ca.pem"]
+  # Enable SSL support. SSL is automatically enabled, if any SSL setting is set.
+  #ssl.enabled: true
 
-  # Certificate for TLS client authentication
-  #tls.certificate: "/etc/pki/client/cert.pem"
+  # Configure SSL verification mode. If `none` is configured, all server hosts
+  # and certificates will be accepted. In this mode, SSL based connections are
+  # susceptible to man-in-the-middle attacks. Use only for testing. Default is
+  # `full`.
+  #ssl.verification_mode: full
+
+  # List of supported/valid TLS versions. By default all TLS versions 1.0 up to
+  # 1.2 are enabled.
+  #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
+
+  # Optional SSL configuration options. SSL is off by default.
+  # List of root certificates for HTTPS server verifications
+  #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
+
+  # Certificate for SSL client authentication
+  #ssl.certificate: "/etc/pki/client/cert.pem"
 
   # Client Certificate Key
-  #tls.certificate_key: "/etc/pki/client/cert.key"
+  #ssl.key: "/etc/pki/client/cert.key"
 
-  # Controls whether the client verifies server certificates and host name.
-  # If insecure is set to true, all server host names and certificates will be
-  # accepted. In this mode TLS based connections are susceptible to
-  # man-in-the-middle attacks. Use only for testing.
-  #tls.insecure: true
+  # Optional passphrase for decrypting the Certificate Key.
+  #ssl.key_passphrase: ''
 
-  # Configure cipher suites to be used for TLS connections
-  #tls.cipher_suites: []
+  # Configure cipher suites to be used for SSL connections
+  #ssl.cipher_suites: []
 
   # Configure curve types for ECDHE based cipher suites
-  #tls.curve_types: []
+  #ssl.curve_types: []
 
 #------------------------------- Kafka output ---------------------------------
 #output.kafka:
@@ -559,27 +572,37 @@ output.elasticsearch:
   # purposes.  The default is "beats".
   #client_id: beats
 
-  # Optional TLS configuration options. TLS is off by default.
-  # List of root certificates for HTTPS server verifications
-  #tls.certificate_authorities: ["/etc/pki/root/ca.pem"]
+  # Enable SSL support. SSL is automatically enabled, if any SSL setting is set.
+  #ssl.enabled: true
 
-  # Certificate for TLS client authentication
-  #tls.certificate: "/etc/pki/client/cert.pem"
+  # Optional SSL configuration options. SSL is off by default.
+  # List of root certificates for HTTPS server verifications
+  #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
+
+  # Configure SSL verification mode. If `none` is configured, all server hosts
+  # and certificates will be accepted. In this mode, SSL based connections are
+  # susceptible to man-in-the-middle attacks. Use only for testing. Default is
+  # `full`.
+  #ssl.verification_mode: full
+
+  # List of supported/valid TLS versions. By default all TLS versions 1.0 up to
+  # 1.2 are enabled.
+  #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
+
+  # Certificate for SSL client authentication
+  #ssl.certificate: "/etc/pki/client/cert.pem"
 
   # Client Certificate Key
-  #tls.certificate_key: "/etc/pki/client/cert.key"
+  #ssl.key: "/etc/pki/client/cert.key"
 
-  # Controls whether the client verifies server certificates and host name.
-  # If insecure is set to true, all server host names and certificates will be
-  # accepted. In this mode TLS based connections are susceptible to
-  # man-in-the-middle attacks. Use only for testing.
-  #tls.insecure: true
+  # Optional passphrase for decrypting the Certificate Key.
+  #ssl.key_passphrase: ''
 
-  # Configure cipher suites to be used for TLS connections
-  #tls.cipher_suites: []
+  # Configure cipher suites to be used for SSL connections
+  #ssl.cipher_suites: []
 
   # Configure curve types for ECDHE based cipher suites
-  #tls.curve_types: []
+  #ssl.curve_types: []
 
 #------------------------------- Redis output ---------------------------------
 #output.redis:
@@ -646,27 +669,38 @@ output.elasticsearch:
   # occurs on the proxy server.
   #proxy_use_local_resolver: false
 
-  # Optional TLS configuration options. TLS is off by default.
-  # List of root certificates for HTTPS server verifications
-  #tls.certificate_authorities: ["/etc/pki/root/ca.pem"]
+  # Enable SSL support. SSL is automatically enabled, if any SSL setting is set.
+  #ssl.enabled: true
 
-  # Certificate for TLS client authentication
-  #tls.certificate: "/etc/pki/client/cert.pem"
+  # Configure SSL verification mode. If `none` is configured, all server hosts
+  # and certificates will be accepted. In this mode, SSL based connections are
+  # susceptible to man-in-the-middle attacks. Use only for testing. Default is
+  # `full`.
+  #ssl.verification_mode: full
+
+  # List of supported/valid TLS versions. By default all TLS versions 1.0 up to
+  # 1.2 are enabled.
+  #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
+
+  # Optional SSL configuration options. SSL is off by default.
+  # List of root certificates for HTTPS server verifications
+  #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
+
+  # Certificate for SSL client authentication
+  #ssl.certificate: "/etc/pki/client/cert.pem"
 
   # Client Certificate Key
-  #tls.certificate_key: "/etc/pki/client/cert.key"
+  #ssl.key: "/etc/pki/client/cert.key"
 
-  # Controls whether the client verifies server certificates and host name.
-  # If insecure is set to true, all server host names and certificates will be
-  # accepted. In this mode TLS based connections are susceptible to
-  # man-in-the-middle attacks. Use only for testing.
-  #tls.insecure: true
+  # Optional passphrase for decrypting the Certificate Key.
+  #ssl.key_passphrase: ''
 
-  # Configure cipher suites to be used for TLS connections
-  #tls.cipher_suites: []
+  # Configure cipher suites to be used for SSL connections
+  #ssl.cipher_suites: []
 
   # Configure curve types for ECDHE based cipher suites
-  #tls.curve_types: []
+  #ssl.curve_types: []
+
 
 #------------------------------- File output ----------------------------------
 #output.file:

--- a/filebeat/filebeat.yml
+++ b/filebeat/filebeat.yml
@@ -92,15 +92,15 @@ output.elasticsearch:
   # The Logstash hosts
   #hosts: ["localhost:5044"]
 
-  # Optional TLS. By default is off.
+  # Optional SSL. By default is off.
   # List of root certificates for HTTPS server verifications
-  #tls.certificate_authorities: ["/etc/pki/root/ca.pem"]
+  #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
-  # Certificate for TLS client authentication
-  #tls.certificate: "/etc/pki/client/cert.pem"
+  # Certificate for SSL client authentication
+  #ssl.certificate: "/etc/pki/client/cert.pem"
 
   # Client Certificate Key
-  #tls.certificate_key: "/etc/pki/client/cert.key"
+  #ssl.key: "/etc/pki/client/cert.key"
 
 #================================ Logging =====================================
 

--- a/libbeat/_meta/config.full.yml
+++ b/libbeat/_meta/config.full.yml
@@ -144,34 +144,37 @@ output.elasticsearch:
   # Path to the Elasticsearch 2.x version of the template file.
   #template.versions.2x.path: "${path.config}/beatname.template-es2x.json"
 
+  # Use SSL settings for HTTPS. Default is true.
+  #ssl.enabled: true
 
-  # TLS configuration. By default is off.
+  # Configure SSL verification mode. If `none` is configured, all server hosts
+  # and certificates will be accepted. In this mode, SSL based connections are
+  # susceptible to man-in-the-middle attacks. Use only for testing. Default is
+  # `full`.
+  #ssl.verification_mode: full
+
+  # List of supported/valid TLS versions. By default all TLS versions 1.0 up to
+  # 1.2 are enabled.
+  #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
+
+  # SSL configuration. By default is off.
   # List of root certificates for HTTPS server verifications
-  #tls.certificate_authorities: ["/etc/pki/root/ca.pem"]
+  #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
-  # Certificate for TLS client authentication
-  #tls.certificate: "/etc/pki/client/cert.pem"
+  # Certificate for SSL client authentication
+  #ssl.certificate: "/etc/pki/client/cert.pem"
 
   # Client Certificate Key
-  #tls.certificate_key: "/etc/pki/client/cert.key"
+  #ssl.key: "/etc/pki/client/cert.key"
 
-  # Controls whether the client verifies server certificates and host name.
-  # If insecure is set to true, all server host names and certificates will be
-  # accepted. In this mode TLS based connections are susceptible to
-  # man-in-the-middle attacks. Use only for testing.
-  #tls.insecure: true
+  # Optional passphrase for decrypting the Certificate Key.
+  #ssl.key_passphrase: ''
 
-  # Configure cipher suites to be used for TLS connections
-  #tls.cipher_suites: []
+  # Configure cipher suites to be used for SSL connections
+  #ssl.cipher_suites: []
 
   # Configure curve types for ECDHE based cipher suites
-  #tls.curve_types: []
-
-  # Configure minimum TLS version allowed for connection to logstash
-  #tls.min_version: 1.0
-
-  # Configure maximum TLS version allowed for connection to logstash
-  #tls.max_version: 1.2
+  #ssl.curve_types: []
 
 
 #----------------------------- Logstash output --------------------------------
@@ -205,27 +208,37 @@ output.elasticsearch:
   # Resolve names locally when using a proxy server. Defaults to false.
   #proxy_use_local_resolver: false
 
-  # Optional TLS configuration options. TLS is off by default.
-  # List of root certificates for HTTPS server verifications
-  #tls.certificate_authorities: ["/etc/pki/root/ca.pem"]
+  # Enable SSL support. SSL is automatically enabled, if any SSL setting is set.
+  #ssl.enabled: true
 
-  # Certificate for TLS client authentication
-  #tls.certificate: "/etc/pki/client/cert.pem"
+  # Configure SSL verification mode. If `none` is configured, all server hosts
+  # and certificates will be accepted. In this mode, SSL based connections are
+  # susceptible to man-in-the-middle attacks. Use only for testing. Default is
+  # `full`.
+  #ssl.verification_mode: full
+
+  # List of supported/valid TLS versions. By default all TLS versions 1.0 up to
+  # 1.2 are enabled.
+  #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
+
+  # Optional SSL configuration options. SSL is off by default.
+  # List of root certificates for HTTPS server verifications
+  #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
+
+  # Certificate for SSL client authentication
+  #ssl.certificate: "/etc/pki/client/cert.pem"
 
   # Client Certificate Key
-  #tls.certificate_key: "/etc/pki/client/cert.key"
+  #ssl.key: "/etc/pki/client/cert.key"
 
-  # Controls whether the client verifies server certificates and host name.
-  # If insecure is set to true, all server host names and certificates will be
-  # accepted. In this mode TLS based connections are susceptible to
-  # man-in-the-middle attacks. Use only for testing.
-  #tls.insecure: true
+  # Optional passphrase for decrypting the Certificate Key.
+  #ssl.key_passphrase: ''
 
-  # Configure cipher suites to be used for TLS connections
-  #tls.cipher_suites: []
+  # Configure cipher suites to be used for SSL connections
+  #ssl.cipher_suites: []
 
   # Configure curve types for ECDHE based cipher suites
-  #tls.curve_types: []
+  #ssl.curve_types: []
 
 #------------------------------- Kafka output ---------------------------------
 #output.kafka:
@@ -330,27 +343,37 @@ output.elasticsearch:
   # purposes.  The default is "beats".
   #client_id: beats
 
-  # Optional TLS configuration options. TLS is off by default.
-  # List of root certificates for HTTPS server verifications
-  #tls.certificate_authorities: ["/etc/pki/root/ca.pem"]
+  # Enable SSL support. SSL is automatically enabled, if any SSL setting is set.
+  #ssl.enabled: true
 
-  # Certificate for TLS client authentication
-  #tls.certificate: "/etc/pki/client/cert.pem"
+  # Optional SSL configuration options. SSL is off by default.
+  # List of root certificates for HTTPS server verifications
+  #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
+
+  # Configure SSL verification mode. If `none` is configured, all server hosts
+  # and certificates will be accepted. In this mode, SSL based connections are
+  # susceptible to man-in-the-middle attacks. Use only for testing. Default is
+  # `full`.
+  #ssl.verification_mode: full
+
+  # List of supported/valid TLS versions. By default all TLS versions 1.0 up to
+  # 1.2 are enabled.
+  #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
+
+  # Certificate for SSL client authentication
+  #ssl.certificate: "/etc/pki/client/cert.pem"
 
   # Client Certificate Key
-  #tls.certificate_key: "/etc/pki/client/cert.key"
+  #ssl.key: "/etc/pki/client/cert.key"
 
-  # Controls whether the client verifies server certificates and host name.
-  # If insecure is set to true, all server host names and certificates will be
-  # accepted. In this mode TLS based connections are susceptible to
-  # man-in-the-middle attacks. Use only for testing.
-  #tls.insecure: true
+  # Optional passphrase for decrypting the Certificate Key.
+  #ssl.key_passphrase: ''
 
-  # Configure cipher suites to be used for TLS connections
-  #tls.cipher_suites: []
+  # Configure cipher suites to be used for SSL connections
+  #ssl.cipher_suites: []
 
   # Configure curve types for ECDHE based cipher suites
-  #tls.curve_types: []
+  #ssl.curve_types: []
 
 #------------------------------- Redis output ---------------------------------
 #output.redis:
@@ -417,27 +440,38 @@ output.elasticsearch:
   # occurs on the proxy server.
   #proxy_use_local_resolver: false
 
-  # Optional TLS configuration options. TLS is off by default.
-  # List of root certificates for HTTPS server verifications
-  #tls.certificate_authorities: ["/etc/pki/root/ca.pem"]
+  # Enable SSL support. SSL is automatically enabled, if any SSL setting is set.
+  #ssl.enabled: true
 
-  # Certificate for TLS client authentication
-  #tls.certificate: "/etc/pki/client/cert.pem"
+  # Configure SSL verification mode. If `none` is configured, all server hosts
+  # and certificates will be accepted. In this mode, SSL based connections are
+  # susceptible to man-in-the-middle attacks. Use only for testing. Default is
+  # `full`.
+  #ssl.verification_mode: full
+
+  # List of supported/valid TLS versions. By default all TLS versions 1.0 up to
+  # 1.2 are enabled.
+  #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
+
+  # Optional SSL configuration options. SSL is off by default.
+  # List of root certificates for HTTPS server verifications
+  #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
+
+  # Certificate for SSL client authentication
+  #ssl.certificate: "/etc/pki/client/cert.pem"
 
   # Client Certificate Key
-  #tls.certificate_key: "/etc/pki/client/cert.key"
+  #ssl.key: "/etc/pki/client/cert.key"
 
-  # Controls whether the client verifies server certificates and host name.
-  # If insecure is set to true, all server host names and certificates will be
-  # accepted. In this mode TLS based connections are susceptible to
-  # man-in-the-middle attacks. Use only for testing.
-  #tls.insecure: true
+  # Optional passphrase for decrypting the Certificate Key.
+  #ssl.key_passphrase: ''
 
-  # Configure cipher suites to be used for TLS connections
-  #tls.cipher_suites: []
+  # Configure cipher suites to be used for SSL connections
+  #ssl.cipher_suites: []
 
   # Configure curve types for ECDHE based cipher suites
-  #tls.curve_types: []
+  #ssl.curve_types: []
+
 
 #------------------------------- File output ----------------------------------
 #output.file:

--- a/libbeat/_meta/config.yml
+++ b/libbeat/_meta/config.yml
@@ -34,15 +34,15 @@ output.elasticsearch:
   # The Logstash hosts
   #hosts: ["localhost:5044"]
 
-  # Optional TLS. By default is off.
+  # Optional SSL. By default is off.
   # List of root certificates for HTTPS server verifications
-  #tls.certificate_authorities: ["/etc/pki/root/ca.pem"]
+  #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
-  # Certificate for TLS client authentication
-  #tls.certificate: "/etc/pki/client/cert.pem"
+  # Certificate for SSL client authentication
+  #ssl.certificate: "/etc/pki/client/cert.pem"
 
   # Client Certificate Key
-  #tls.certificate_key: "/etc/pki/client/cert.key"
+  #ssl.key: "/etc/pki/client/cert.key"
 
 #================================ Logging =====================================
 

--- a/libbeat/docs/gettingstarted.asciidoc
+++ b/libbeat/docs/gettingstarted.asciidoc
@@ -313,7 +313,7 @@ bin\logstash.bat -f logstash.conf
 ----------------------------------------------------------------------
 
 NOTE: The default configuration for Beats and Logstash uses plain TCP. For
-encryption you must explicitly enable TLS when you configure Beats and Logstash.
+encryption you must explicitly enable SSL when you configure Beats and Logstash.
 
 You can learn more about installing, configuring, and running Logstash
 https://www.elastic.co/guide/en/logstash/current/getting-started-with-logstash.html[here].

--- a/libbeat/docs/https.asciidoc
+++ b/libbeat/docs/https.asciidoc
@@ -49,18 +49,18 @@ output.elasticsearch:
   password: verysecret
   protocol: https
   hosts: ["elasticsearch.example.com:9200"]
-  tls.certificate_authorities: <1>
+  ssl.certificate_authorities: <1>
     - /etc/pki/my_root_ca.pem
     - /etc/pki/my_other_ca.pem
-  tls.certificate: "/etc/pki/client.pem" <2>
-  tls.certificate_key: "/etc/pki/key.pem" <3>
+  ssl.certificate: "/etc/pki/client.pem" <2>
+  ssl.key: "/etc/pki/key.pem" <3>
 ----------------------------------------------------------------------
 <1> The list of CA certificates to trust
-<2> The path to the certificate for TLS client authentication
+<2> The path to the certificate for SSL client authentication
 <3> The client certificate key
 
 NOTE: For any given connection, the SSL/TLS certificates must have a subject
-that matches the value specified for `hosts`, or the TLS handshake fails.
+that matches the value specified for `hosts`, or the SSL handshake fails.
 For example, if you specify `hosts: ["foobar:9200"]`, the certificate MUST
 include `foobar` in the subject (`CN=foobar`) or as a subject alternative name
 (SAN). Make sure the hostname resolves to the correct IP address. If no DNS is available, then

--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -37,16 +37,16 @@ output.elasticsearch:
   # [{beatname_lc}-]YYYY.MM.DD keys.
   index: "{beatname_lc}"
 
-  # Optional TLS configuration options. TLS is off by default.
+  # Optional SSL configuration options. SSL is off by default.
 
   # List of root certificates for HTTPS server verifications
-  tls.certificate_authorities: ["/etc/pki/root/ca.pem"]
+  ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
-  # Certificate for TLS client authentication
-  tls.certificate: "/etc/pki/client/cert.pem"
+  # Certificate for SSL client authentication
+  ssl.certificate: "/etc/pki/client/cert.pem"
 
   # Client Certificate Key
-  tls.certificatekey: "/etc/pki/client/cert.key"
+  ssl.key: "/etc/pki/client/cert.key"
 
 ------------------------------------------------------------------------------
 
@@ -285,13 +285,13 @@ false.
 
 This option is relevant for Packetbeat only.
 
-===== tls
+===== ssl
 
-Configuration options for TLS parameters like the certificate authority to use
+Configuration options for SSL parameters like the certificate authority to use
 for HTTPS-based connections. If the `tls` section is missing, the host CAs are used for HTTPS connections to
 Elasticsearch.
 
-See <<configuration-output-tls>> for more information.
+See <<configuration-output-ssl>> for more information.
 
 
 [[logstash-output]]
@@ -478,10 +478,10 @@ The index root name to write events to. The default is the Beat name.
 For example "{beatname_lc}" generates "[{beatname_lc}-]YYYY.MM.DD" indexes (for example,
 "{beatname_lc}-2015.04.26").
 
-===== tls
+===== ssl
 
-Configuration options for TLS parameters like the root CA for Logstash connections. See
-<<configuration-output-tls>> for more information. To use TLS, you must also configure the
+Configuration options for SSL parameters like the root CA for Logstash connections. See
+<<configuration-output-ssl>> for more information. To use SSL, you must also configure the
 https://www.elastic.co/guide/en/logstash/current/plugins-inputs-beats.html[Beats input plugin for Logstash] to use SSL/TLS.
 
 ===== timeout
@@ -630,10 +630,10 @@ Note: If set to 0, no ACKs are returned by Kafka. Messages might be lost silentl
 
 The number of seconds to wait for new events between two producer API calls.
 
-===== tls
+===== ssl
 
-Configuration options for TLS parameters like the root CA for Kibana connections. See
-<<configuration-output-tls>> for more information.
+Configuration options for SSL parameters like the root CA for Kafka connections. See
+<<configuration-output-ssl>> for more information.
 
 [[redis-output]]
 === Redis Output Configuration
@@ -778,11 +778,11 @@ Packetbeat) send each event directly to Redis. Beats that publish
 data in batches (such as Filebeat) send events in batches based on the spooler
 size.
 
-===== tls
+===== ssl
 
-Configuration options for TLS parameters like the root CA for Redis connections
+Configuration options for SSL parameters like the root CA for Redis connections
 guarded by SSL proxies (for example https://www.stunnel.org[stunnel]). See
-<<configuration-output-tls>> for more information.
+<<configuration-output-ssl>> for more information.
 
 ===== proxy_url
 
@@ -896,13 +896,13 @@ The maximum number of events to buffer internally during publishing. The default
 Specifying a larger batch size may add some latency and buffering during publishing. However, for Console output, this
 setting does not affect how events are published.
 
-Setting `bulk_max_size` to values less than or equal to 0 disables buffering in libbeat.
+Setting `bulk_max_size` to 0 disables buffering in libbeat.
 
-[[configuration-output-tls]]
+[[configuration-output-ssl]]
 
-=== TLS Configuration
+=== SSL Configuration
 
-You can specify TLS options for any output that supports TLS.
+You can specify SSL options for any output that supports SSL.
 
 Example configuration:
 
@@ -912,18 +912,26 @@ output.elasticsearch:
   hosts: ["192.168.1.42:9200"]
 
   # List of root certificates for HTTPS server verifications
-  tls.certificate_authorities: ["/etc/pki/root/ca.pem"]
+  ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
-  # Certificate for TLS client authentication
-  tls.certificate: "/etc/pki/client/cert.pem"
+  # Certificate for SSL client authentication
+  ssl.certificate: "/etc/pki/client/cert.pem"
 
   # Client Certificate Key
-  tls.certificate_key: "/etc/pki/client/cert.key"
+  ssl.key: "/etc/pki/client/cert.key"
 ------------------------------------------------------------------------------
 
-==== TLS Options
+==== SSL Options
 
-You can specify the following options in the `tls` section of the +{beatname_lc}.yml+ config file:
+You can specify the following options in the `ssl` section of the +{beatname_lc}.yml+ config file:
+
+===== enabled
+
+The `enabled` setting can be used to disable the ssl configuration by setting
+it to `false`. The default value is `true`.
+
+Note: SSL settings are disabled if either `enabled` is set to `false` or the
+`ssl` section is missing.
 
 ===== certificate_authorities
 
@@ -933,39 +941,41 @@ The list of root certificates for server verifications. If `certificate_authorit
 
 ===== certificate: "/etc/pki/client/cert.pem"
 
-The path to the certificate for TLS client authentication. If the certificate
+The path to the certificate for SSL client authentication. If the certificate
 is not specified, client authentication is not available. The connection
-might fail if the server requests client authentication. If the TLS server does not
+might fail if the server requests client authentication. If the SSL server does not
 require client authentication, the certificate will be loaded, but not requested or used
 by the server.
 
 When this option is configured, the <<certificate_key>> option is also required.
 
 [[certificate_key]]
-===== certificate_key: "/etc/pki/client/cert.key"
+===== key: "/etc/pki/client/cert.key"
 
 The client certificate key used for client authentication. This option is required if <<certificate>> is specified.
 
-===== min_version
+===== key_passphrase
 
-The minimum SSL/TLS version allowed for the encrypted connections. The value must be one of the following:
-`SSL-3.0` for SSL 3, `1.0` for TLS 1.0, `1.1` for TLS 1.1 and `1.2` for TLS 1.2.
+The passphrase used to decrypt an encrypted key stored in the configured `key` file.
 
-The default value is `1.0`.
+===== versions
 
-===== max_version
+List of allowed SSL/TLS versions. If SSL/TLS server decides for protocol versions
+not configured, the connection will be dropped during or after the handshake. The
+setting is a list of allowed protocol versions:
+`SSLv3`, `TLSv1` for TLS version 1.0, `TLSv1.0`, `TLSv1.1` and `TLSv1.2`.
 
-The maximum SSL/TLS version allowed for the encrypted connections. The value must be one of the following:
-`SSL-3.0` for SSL 3, `1.0` for TLS 1.0, `1.1` for TLS 1.1 and `1.2` for TLS 1.2.
+The default value is `[TLSv1.0, TLSv1.1, TLSv1.2]`.
 
-The default value is `1.2`.
+===== verification_mode
 
-===== insecure
+This option controls whether the client verifies server certificates and host
+names. The values `none` and `full` can be used. If `verification_mode` is set
+to `none`, all server host names and certificates are accepted. In this mode,
+TLS-based connections are susceptible to man-in-the-middle attacks. Use this
+option for testing only.
 
-This option controls whether the client verifies server certificates and host names.
-If insecure is set to true, all server host names and certificates are
-accepted. In this mode, TLS-based connections are susceptible to
-man-in-the-middle attacks. Use this option for testing only.
+The default is `full`.
 
 ===== cipher_suites
 
@@ -973,7 +983,25 @@ The list of cipher suites to use. The first entry has the highest priority.
 If this option is omitted, the Go crypto library's default
 suites are used (recommended).
 
-Here is a list of allowed cipher suites and their meanings.
+The following cipher suites are available:
+
+* RSA-RC4-128-SHA (disabled by default - RC4 not recommended)
+* RSA-3DES-CBC3-SHA
+* RSA-AES-128-CBC-SHA
+* RSA-AES-256-CBC-SHA
+* ECDHE-ECDSA-RC4-128-SHA (disabled by default - RC4 not recommended)
+* ECDHE-ECDSA-AES-128-CBC-SHA
+* ECDHE-ECDSA-AES-256-CBC-SHA
+* ECDHE-RSA-RC4-128-SHA (disabled by default- RC4 not recommended)
+* ECDHE-RSA-3DES-CBC3-SHA
+* ECDHE-RSA-AES-128-CBC-SHA
+* ECDHE-RSA-AES-256-CBC-SHA
+* ECDHE-RSA-AES-128-GCM-SHA256 (TLS 1.2 only)
+* ECDHE-ECDSA-AES-128-GCM-SHA256 (TLS 1.2 only)
+* ECDHE-RSA-AES-256-GCM-SHA384 (TLS 1.2 only)
+* ECDHE-ECDSA-AES-256-GCM-SHA384 (TLS 1.2 only)
+
+Here is a list of acronyms used in defining the cipher suites:
 
 * 3DES:
   Cipher suites using triple DES
@@ -1002,23 +1030,6 @@ Here is a list of allowed cipher suites and their meanings.
 * SHA, SHA256, SHA384:
   Cipher suites using SHA-1, SHA-256 or SHA-384.
 
-The following cipher suites are available:
-
-* RSA-RC4-128-SHA (disabled by default - RC4 not recommended)
-* RSA-3DES-CBC3-SHA
-* RSA-AES-128-CBC-SHA
-* RSA-AES-256-CBC-SHA
-* ECDHE-ECDSA-RC4-128-SHA (disabled by default - RC4 not recommended)
-* ECDHE-ECDSA-AES-128-CBC-SHA
-* ECDHE-ECDSA-AES-256-CBC-SHA
-* ECDHE-RSA-RC4-128-SHA (disabled by default- RC4 not recommended)
-* ECDHE-RSA-3DES-CBC3-SHA
-* ECDHE-RSA-AES-128-CBC-SHA
-* ECDHE-RSA-AES-256-CBC-SHA
-* ECDHE-RSA-AES-128-GCM-SHA256 (TLS 1.2 only)
-* ECDHE-ECDSA-AES-128-GCM-SHA256 (TLS 1.2 only)
-* ECDHE-RSA-AES-256-GCM-SHA384 (TLS 1.2 only)
-* ECDHE-ECDSA-AES-256-GCM-SHA384 (TLS 1.2 only)
 
 ===== curve_types
 

--- a/libbeat/docs/shared-faq.asciidoc
+++ b/libbeat/docs/shared-faq.asciidoc
@@ -69,7 +69,7 @@ telnet <hostname or IP> 5044
 
 * Verify that the certificate is valid and that the hostname and IP match.
 +
-TIP: For testing purposes only, you can set `insecure: true` to disable hostname checking.
+TIP: For testing purposes only, you can set `verification_mode: none` to disable hostname checking.
 
 * Use OpenSSL to test connectivity to the Logstash server and diagnose problems. See the https://www.openssl.org/docs/manmaster/apps/s_client.html[OpenSSL documentation] for more info.
 * Make sure that you have enabled SSL (set `ssl => true`) when configuring the https://www.elastic.co/guide/en/logstash/current/plugins-inputs-beats.html[Beats input plugin for Logstash].
@@ -102,13 +102,13 @@ server's certificate valid for both the hostname and the IP address.
 [[getsockopt-no-route-to-host]]
 ===== getsockopt: no route to host
 
-This is not a TLS problem. It's a networking problem. Make sure the two hosts can communicate.
+This is not a SSL problem. It's a networking problem. Make sure the two hosts can communicate.
 
 [float]
 [[getsockopt-connection-refused]]
 ===== getsockopt: connection refused
 
-This is not a TLS problem. Make sure that Logstash is running and that there is no firewall blocking the traffic.
+This is not a SSL problem. Make sure that Logstash is running and that there is no firewall blocking the traffic.
 
 [float]
 [[target-machine-refused-connection]]

--- a/libbeat/docs/shared-ssl-logstash-config.asciidoc
+++ b/libbeat/docs/shared-ssl-logstash-config.asciidoc
@@ -6,14 +6,14 @@
 //// Use the appropriate variables defined in the index.asciidoc file to
 //// resolve Beat names: beatname_uc and beatname_lc.
 //// Use the following include to pull this content into a doc file:
-//// include::../../libbeat/docs/shared-tls-logstash-config.asciidoc[]
+//// include::../../libbeat/docs/shared-ssl-logstash-config.asciidoc[]
 //////////////////////////////////////////////////////////////////////////
 
-You can use TLS mutual authentication to secure connections between {beatname_uc} and Logstash. This ensures that
+You can use SSL mutual authentication to secure connections between {beatname_uc} and Logstash. This ensures that
 {beatname_uc} sends encrypted data to trusted Logstash servers only, and that the Logstash server receives data from
 trusted {beatname_uc} clients only.
 
-To use TLS mutual authentication:
+To use SSL mutual authentication:
 
 . Create a certificate authority (CA) and use it to sign the certificates that you plan to use for
 {beatname_uc} and Logstash. Creating a correct SSL/TLS infrastructure is outside the scope of this
@@ -21,8 +21,8 @@ document. There are many online resources available that describe how to create 
 +
 NOTE: Certificates must be signed by your root CA. Intermediate CAs are currently not supported.
 
-. Configure {beatname_uc} to use TLS. In the +{beatname_lc}.yml+ config file, specify the following settings under
-`tls`: 
+. Configure {beatname_uc} to use SSL. In the +{beatname_lc}.yml+ config file, specify the following settings under
+`ssl`:
 +
 * `certificate_authorities`: Configures {beatname_uc} to trust any certificates signed by the specified CA. If
 `certificate_authorities` is empty or not set, the trusted certificate authorities of the host system are used.
@@ -31,7 +31,7 @@ Although  intermediate CAs are currently not supported, you may be able to work 
 certificates in the chain into one file. You can create the PEM file containing the CA chain by concatenating the root CA
 cert and the intermediate CA into a single file: `cat root-ca.crt intermediate-ca.crt > chain.crt`. Then set `certificate_authorities` to use this file: `certificate_authorities: ['chain.crt']`.
 
-* `certificate` and `certificate_key`: Specifies the certificate and key that {beatname_uc} uses to authenticate with 
+* `certificate` and `key`: Specifies the certificate and key that {beatname_uc} uses to authenticate with
 Logstash.
 +
 For example:
@@ -40,21 +40,21 @@ For example:
 ------------------------------------------------------------------------------
 output.logstash:
   hosts: ["logs.mycompany.com:5044"]
-  tls.certificate_authorities: ["/etc/ca.crt"]
-  tls.certificate: "/etc/client.crt"
-  tls.certificate_key: "/etc/client.key"
+  ssl.certificate_authorities: ["/etc/ca.crt"]
+  ssl.certificate: "/etc/client.crt"
+  ssl.key: "/etc/client.key"
 ------------------------------------------------------------------------------
 +
-For more information about these configuration options, see <<configuration-output-tls>>.
+For more information about these configuration options, see <<configuration-output-ssl>>.
 
-. Configure Logstash to use TLS. In the Logstash config file, specify the following settings for the https://www.elastic.co/guide/en/logstash/current/plugins-inputs-beats.html[Beats input plugin for Logstash]:
+. Configure Logstash to use SSL. In the Logstash config file, specify the following settings for the https://www.elastic.co/guide/en/logstash/current/plugins-inputs-beats.html[Beats input plugin for Logstash]:
 +
 * `ssl`: When set to true, enables Logstash to use SSL/TLS.
-* `ssl_certificate_authorities`: Configures Logstash to trust any certificates signed by the specified CA. 
-* `ssl_certificate` and `ssl_key`: Specify the certificate and key that Logstash uses to authenticate with the client. 
+* `ssl_certificate_authorities`: Configures Logstash to trust any certificates signed by the specified CA.
+* `ssl_certificate` and `ssl_key`: Specify the certificate and key that Logstash uses to authenticate with the client.
 * `ssl_verify_mode`: Specifies whether the Logstash server verifies the client certificate against the CA. You
 need to specify either `peer` or `force_peer` to make the server ask for the certificate and validate it. If you
-specify `force_peer`, and {beatname_uc} doesn't provide a certificate, the Logstash connection will be closed. 
+specify `force_peer`, and {beatname_uc} doesn't provide a certificate, the Logstash connection will be closed.
 +
 For example:
 +
@@ -76,7 +76,7 @@ For more information about these options, see the
 https://www.elastic.co/guide/en/logstash/current/plugins-inputs-beats.html[documentation] for the Beats input plugin.
 
 [float]
-[[testing-tls-logstash]]
+[[testing-ssl-logstash]]
 === Validating the Logstash Server's Certificate
 
 Before running {beatname_uc}, you should validate the Logstash server's certificate. You can use `curl` to validate the certificate even though the protocol used to communicate with Logstash is not based on HTTP. For example:
@@ -106,14 +106,14 @@ If the test is successful, you'll receive an empty response error:
 curl: (52) Empty reply from server
 ------------------------------------------------------------------------------
 
-The following example uses the IP address rather than the hostname to validate the certificate: 
+The following example uses the IP address rather than the hostname to validate the certificate:
 
 [source,shell]
 ------------------------------------------------------------------------------
 curl -v --cacert ca.crt https://192.168.99.100:5044
 ------------------------------------------------------------------------------
 
-Validation for this test fails because the certificate is not valid for the specified IP address. It's only valid for the `logs.mycompany.com`, the hostname that appears in the Subject field of the certificate.  
+Validation for this test fails because the certificate is not valid for the specified IP address. It's only valid for the `logs.mycompany.com`, the hostname that appears in the Subject field of the certificate.
 
 [source,shell]
 ------------------------------------------------------------------------------
@@ -131,8 +131,8 @@ See the <<ssl-client-fails,troubleshooting docs>> for info about resolving this 
 [float]
 === Testing the Beats to Logstash Connection
 
-If you have {beatname_uc} running as a service, first stop the service. Then test your setup by running {beatname_uc} in 
-the foreground so you can quickly see any errors that occur: 
+If you have {beatname_uc} running as a service, first stop the service. Then test your setup by running {beatname_uc} in
+the foreground so you can quickly see any errors that occur:
 
 ["source","sh",subs="attributes,callouts"]
 ------------------------------------------------------------------------------

--- a/libbeat/outputs/elasticsearch/config.go
+++ b/libbeat/outputs/elasticsearch/config.go
@@ -15,7 +15,7 @@ type elasticsearchConfig struct {
 	ProxyURL         string             `config:"proxy_url"`
 	LoadBalance      bool               `config:"loadbalance"`
 	CompressionLevel int                `config:"compression_level" validate:"min=0, max=9"`
-	TLS              *outputs.TLSConfig `config:"tls"`
+	TLS              *outputs.TLSConfig `config:"ssl"`
 	MaxRetries       int                `config:"max_retries"`
 	Timeout          time.Duration      `config:"timeout"`
 	SaveTopology     bool               `config:"save_topology"`

--- a/libbeat/outputs/elasticsearch/output.go
+++ b/libbeat/outputs/elasticsearch/output.go
@@ -1,7 +1,6 @@
 package elasticsearch
 
 import (
-	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -18,6 +17,7 @@ import (
 	"github.com/elastic/beats/libbeat/outputs/mode"
 	"github.com/elastic/beats/libbeat/outputs/mode/modeutil"
 	"github.com/elastic/beats/libbeat/outputs/outil"
+	"github.com/elastic/beats/libbeat/outputs/transport"
 	"github.com/elastic/beats/libbeat/paths"
 )
 
@@ -239,7 +239,7 @@ func (out *elasticsearchOutput) loadTemplate(config Template, client *Client) er
 }
 
 func makeClientFactory(
-	tls *tls.Config,
+	tls *transport.TLSConfig,
 	config *elasticsearchConfig,
 	out *elasticsearchOutput,
 ) func(string) (mode.ProtocolClient, error) {

--- a/libbeat/outputs/kafka/config.go
+++ b/libbeat/outputs/kafka/config.go
@@ -13,7 +13,7 @@ import (
 
 type kafkaConfig struct {
 	Hosts           []string                  `config:"hosts"               validate:"required"`
-	TLS             *outputs.TLSConfig        `config:"tls"`
+	TLS             *outputs.TLSConfig        `config:"ssl"`
 	Timeout         time.Duration             `config:"timeout"             validate:"min=1"`
 	Worker          int                       `config:"worker"              validate:"min=1"`
 	Metadata        metaConfig                `config:"metadata"`

--- a/libbeat/outputs/kafka/kafka.go
+++ b/libbeat/outputs/kafka/kafka.go
@@ -256,8 +256,10 @@ func newKafkaConfig(config *kafkaConfig) (*sarama.Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	k.Net.TLS.Enable = tls != nil
-	k.Net.TLS.Config = tls
+	if tls != nil {
+		k.Net.TLS.Enable = true
+		k.Net.TLS.Config = tls.BuildModuleConfig("")
+	}
 
 	if config.Username != "" {
 		k.Net.SASL.Enable = true

--- a/libbeat/outputs/logstash/config.go
+++ b/libbeat/outputs/logstash/config.go
@@ -16,7 +16,7 @@ type logstashConfig struct {
 	Pipelining       int                   `config:"pipelining"        validate:"min=0"`
 	CompressionLevel int                   `config:"compression_level" validate:"min=0, max=9"`
 	MaxRetries       int                   `config:"max_retries"       validate:"min=-1"`
-	TLS              *outputs.TLSConfig    `config:"tls"`
+	TLS              *outputs.TLSConfig    `config:"ssl"`
 	Proxy            transport.ProxyConfig `config:",inline"`
 }
 

--- a/libbeat/outputs/logstash/logstash_integration_test.go
+++ b/libbeat/outputs/logstash/logstash_integration_test.go
@@ -123,8 +123,8 @@ func newTestLogstashOutput(t *testing.T, test string, tls bool) *testOutputer {
 	}
 	if tls {
 		config["hosts"] = []string{getLogstashTLSHost()}
-		config["tls.insecure"] = false
-		config["tls.certificate_authorities"] = []string{
+		config["ssl.verification_mode"] = "full"
+		config["ssl.certificate_authorities"] = []string{
 			"../../../testing/environments/docker/logstash/pki/tls/certs/logstash.crt",
 		}
 	}

--- a/libbeat/outputs/logstash/logstash_test.go
+++ b/libbeat/outputs/logstash/logstash_test.go
@@ -117,7 +117,7 @@ func TestLogstashTLS(t *testing.T) {
 		"hosts":                       []string{server.Addr()},
 		"index":                       testLogstashIndex("logstash-conn-tls"),
 		"timeout":                     2,
-		"tls.certificate_authorities": []string{certName + ".pem"},
+		"ssl.certificate_authorities": []string{certName + ".pem"},
 	}
 	testConnectionType(t, server, testOutputerFactory(t, "", config))
 }
@@ -135,8 +135,8 @@ func TestLogstashInvalidTLSInsecure(t *testing.T) {
 		"index":                       testLogstashIndex("logstash-conn-tls-invalid"),
 		"timeout":                     2,
 		"max_retries":                 1,
-		"tls.insecure":                true,
-		"tls.certificate_authorities": []string{certName + ".pem"},
+		"ssl.verification_mode":       "none",
+		"ssl.certificate_authorities": []string{certName + ".pem"},
 	}
 	testConnectionType(t, server, testOutputerFactory(t, "", config))
 }

--- a/libbeat/outputs/redis/config.go
+++ b/libbeat/outputs/redis/config.go
@@ -18,7 +18,7 @@ type redisConfig struct {
 	LoadBalance bool                  `config:"loadbalance"`
 	Timeout     time.Duration         `config:"timeout"`
 	MaxRetries  int                   `config:"max_retries"`
-	TLS         *outputs.TLSConfig    `config:"tls"`
+	TLS         *outputs.TLSConfig    `config:"ssl"`
 	Proxy       transport.ProxyConfig `config:",inline"`
 
 	Db       int    `config:"db"`

--- a/libbeat/outputs/redis/redis_integration_test.go
+++ b/libbeat/outputs/redis/redis_integration_test.go
@@ -49,8 +49,8 @@ func TestTopologyInRedisTLS(t *testing.T) {
 		"db_topology":   db,
 		"timeout":       "5s",
 
-		"tls.insecure": false,
-		"tls.certificate_authorities": []string{
+		"ssl.verification_mode": "full",
+		"ssl.certificate_authorities": []string{
 			"../../../testing/environments/docker/sredis/pki/tls/certs/sredis.crt",
 		},
 	}
@@ -139,8 +139,8 @@ func TestPublishListTLS(t *testing.T) {
 		"datatype": "list",
 		"timeout":  "5s",
 
-		"tls.insecure": false,
-		"tls.certificate_authorities": []string{
+		"ssl.verification_mode": "full",
+		"ssl.certificate_authorities": []string{
 			"../../../testing/environments/docker/sredis/pki/tls/certs/sredis.crt",
 		},
 	}
@@ -210,8 +210,8 @@ func TestPublishChannelTLS(t *testing.T) {
 		"datatype": "channel",
 		"timeout":  "5s",
 
-		"tls.insecure": false,
-		"tls.certificate_authorities": []string{
+		"ssl.verification_mode": "full",
+		"ssl.certificate_authorities": []string{
 			"../../../testing/environments/docker/sredis/pki/tls/certs/sredis.crt",
 		},
 	}

--- a/libbeat/outputs/tls.go
+++ b/libbeat/outputs/tls.go
@@ -1,12 +1,17 @@
 package outputs
 
 import (
+	"bytes"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/pem"
 	"errors"
+	"fmt"
 	"io/ioutil"
 
 	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/outputs/transport"
+	"github.com/joeshaw/multierror"
 )
 
 var (
@@ -19,32 +24,58 @@ var (
 
 	// ErrKeyNoCertificate indicate a configuration error with missing certificate file
 	ErrKeyNoCertificate = errors.New("certificate file not configured")
-
-	// ErrInvalidTLSVersion indicates an unknown tls version string given.
-	ErrInvalidTLSVersion = errors.New("invalid TLS version string")
-
-	// ErrUnknownCipherSuite indicates an unknown tls cipher suite being used
-	ErrUnknownCipherSuite = errors.New("unknown cypher suite")
-
-	// ErrUnknownCurveID indicates an unknown curve id has been configured
-	ErrUnknownCurveID = errors.New("unknown curve id")
 )
 
 // TLSConfig defines config file options for TLS clients.
 type TLSConfig struct {
-	Certificate    string   `config:"certificate"`
-	CertificateKey string   `config:"certificate_key"`
-	CAs            []string `config:"certificate_authorities"`
-	Insecure       bool     `config:"insecure"`
-	CipherSuites   []string `config:"cipher_suites"`
-	MinVersion     string   `config:"min_version"`
-	MaxVersion     string   `config:"max_version"`
-	CurveTypes     []string `config:"curve_types"`
+	Enabled          *bool                         `config:"enabled"`
+	VerificationMode transport.TLSVerificationMode `config:"verification_mode"` // one of 'none', 'full'
+	Versions         []transport.TLSVersion        `config:"supported_protocols"`
+	CipherSuites     []tlsCipherSuite              `config:"cipher_suites"`
+	CAs              []string                      `config:"certificate_authorities"`
+	Certificate      CertificateConfig             `config:",inline"`
+	CurveTypes       []tlsCurveType                `config:"curve_types"`
+}
+
+type CertificateConfig struct {
+	Certificate string `config:"certificate"`
+	Key         string `config:"key"`
+	Passphrase  string `config:"key_passphrase"`
+}
+
+type tlsCipherSuite uint16
+
+type tlsCurveType tls.CurveID
+
+var tlsCipherSuites = map[string]tlsCipherSuite{
+	"ECDHE-ECDSA-AES-128-CBC-SHA":    tlsCipherSuite(tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA),
+	"ECDHE-ECDSA-AES-128-GCM-SHA256": tlsCipherSuite(tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256),
+	"ECDHE-ECDSA-AES-256-CBC-SHA":    tlsCipherSuite(tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA),
+	"ECDHE-ECDSA-AES-256-GCM-SHA384": tlsCipherSuite(tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384),
+	"ECDHE-ECDSA-RC4-128-SHA":        tlsCipherSuite(tls.TLS_ECDHE_ECDSA_WITH_RC4_128_SHA),
+	"ECDHE-RSA-3DES-CBC3-SHA":        tlsCipherSuite(tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA),
+	"ECDHE-RSA-AES-128-CBC-SHA":      tlsCipherSuite(tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA),
+	"ECDHE-RSA-AES-128-GCM-SHA256":   tlsCipherSuite(tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256),
+	"ECDHE-RSA-AES-256-CBC-SHA":      tlsCipherSuite(tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA),
+	"ECDHE-RSA-AES-256-GCM-SHA384":   tlsCipherSuite(tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384),
+	"ECDHE-RSA-RC4-128-SHA":          tlsCipherSuite(tls.TLS_ECDHE_RSA_WITH_RC4_128_SHA),
+	"RSA-3DES-CBC3-SHA":              tlsCipherSuite(tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA),
+	"RSA-AES-128-CBC-SHA":            tlsCipherSuite(tls.TLS_RSA_WITH_AES_128_CBC_SHA),
+	"RSA-AES-128-GCM-SHA256":         tlsCipherSuite(tls.TLS_RSA_WITH_AES_128_GCM_SHA256),
+	"RSA-AES-256-CBC-SHA":            tlsCipherSuite(tls.TLS_RSA_WITH_AES_256_CBC_SHA),
+	"RSA-AES-256-GCM-SHA384":         tlsCipherSuite(tls.TLS_RSA_WITH_AES_256_GCM_SHA384),
+	"RSA-RC4-128-SHA":                tlsCipherSuite(tls.TLS_RSA_WITH_RC4_128_SHA),
+}
+
+var tlsCurveTypes = map[string]tlsCurveType{
+	"P-256": tlsCurveType(tls.CurveP256),
+	"P-384": tlsCurveType(tls.CurveP384),
+	"P-521": tlsCurveType(tls.CurveP521),
 }
 
 func (c *TLSConfig) Validate() error {
-	hasCertificate := c.Certificate != ""
-	hasKey := c.CertificateKey != ""
+	hasCertificate := c.Certificate.Certificate != ""
+	hasKey := c.Certificate.Key != ""
 
 	switch {
 	case hasCertificate && !hasKey:
@@ -53,167 +84,218 @@ func (c *TLSConfig) Validate() error {
 		return ErrKeyNoCertificate
 	}
 
-	if _, err := parseTLSVersion(c.MinVersion); err != nil {
-		return err
-	}
-	if _, err := parseTLSVersion(c.MaxVersion); err != nil {
-		return err
-	}
-
-	if _, err := parseTLSCipherSuites(c.CipherSuites); err != nil {
-		return err
-	}
-
-	if _, err := parseCurveTypes(c.CurveTypes); err != nil {
-		return err
-	}
-
 	return nil
+}
+
+func (c *TLSConfig) IsEnabled() bool {
+	return c != nil && (c.Enabled == nil || *c.Enabled)
 }
 
 // LoadTLSConfig will load a certificate from config with all TLS based keys
 // defined. If Certificate and CertificateKey are configured, client authentication
 // will be configured. If no CAs are configured, the host CA will be used by go
 // built-in TLS support.
-func LoadTLSConfig(config *TLSConfig) (*tls.Config, error) {
-	if config == nil {
+func LoadTLSConfig(config *TLSConfig) (*transport.TLSConfig, error) {
+	if !config.IsEnabled() {
 		return nil, nil
 	}
 
+	fail := multierror.Errors{}
+	logFail := func(es ...error) {
+		for _, e := range es {
+			if e != nil {
+				fail = append(fail, e)
+			}
+		}
+	}
+
+	var cipherSuites []uint16
+	for _, suite := range config.CipherSuites {
+		cipherSuites = append(cipherSuites, uint16(suite))
+	}
+
+	var curves []tls.CurveID
+	for _, id := range config.CurveTypes {
+		curves = append(curves, tls.CurveID(id))
+	}
+
+	cert, err := loadCertificate(&config.Certificate)
+	logFail(err)
+
+	cas, errs := loadCertificateAuthorities(config.CAs)
+	logFail(errs...)
+
+	// fail, if any error occurred when loading certificate files
+	if err = fail.Err(); err != nil {
+		return nil, err
+	}
+
+	var certs []tls.Certificate
+	if cert != nil {
+		certs = []tls.Certificate{*cert}
+	}
+
+	// return config if no error occurred
+	return &transport.TLSConfig{
+		Versions:         config.Versions,
+		Verification:     config.VerificationMode,
+		Certificates:     certs,
+		RootCAs:          cas,
+		CipherSuites:     cipherSuites,
+		CurvePreferences: curves,
+	}, nil
+}
+
+func loadCertificate(config *CertificateConfig) (*tls.Certificate, error) {
 	certificate := config.Certificate
-	key := config.CertificateKey
-	rootCAs := config.CAs
+	key := config.Key
+
 	hasCertificate := certificate != ""
 	hasKey := key != ""
 
-	var certs []tls.Certificate
 	switch {
 	case hasCertificate && !hasKey:
 		return nil, ErrCertificateNoKey
 	case !hasCertificate && hasKey:
 		return nil, ErrKeyNoCertificate
-	case hasCertificate && hasKey:
-		cert, err := tls.LoadX509KeyPair(certificate, key)
+	case !hasCertificate && !hasKey:
+		return nil, nil
+	}
+
+	certPEM, err := readPEMFile(certificate, config.Passphrase)
+	if err != nil {
+		logp.Critical("Failed reading certificate file %v: %v", certificate, err)
+		return nil, fmt.Errorf("%v %v", err, certificate)
+	}
+
+	keyPEM, err := readPEMFile(key, config.Passphrase)
+	if err != nil {
+		logp.Critical("Failed reading key file %v: %v", key, err)
+		return nil, fmt.Errorf("%v %v", err, key)
+	}
+
+	cert, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		logp.Critical("Failed loading client certificate", err)
+		return nil, err
+	}
+
+	return &cert, nil
+}
+
+func readPEMFile(path, passphrase string) ([]byte, error) {
+	pass := []byte(passphrase)
+	var blocks []*pem.Block
+
+	content, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	for len(content) > 0 {
+		var block *pem.Block
+
+		block, content = pem.Decode(content)
+		if block == nil {
+			if len(blocks) == 0 {
+				return nil, errors.New("no pem file")
+			}
+			break
+		}
+
+		if x509.IsEncryptedPEMBlock(block) {
+			var buffer []byte
+			var err error
+			if len(pass) == 0 {
+				err = errors.New("No passphrase available")
+			} else {
+				// Note, decrypting pem might succeed even with wrong password, but
+				// only noise will be stored in buffer in this case.
+				buffer, err = x509.DecryptPEMBlock(block, pass)
+			}
+
+			if err != nil {
+				logp.Err("Dropping encrypted pem '%v' block read from %v. %v",
+					block.Type, path, err)
+				continue
+			}
+
+			// DEK-Info contains encryption info. Remove header to mark block as
+			// unencrypted.
+			delete(block.Headers, "DEK-Info")
+			block.Bytes = buffer
+		}
+		blocks = append(blocks, block)
+	}
+
+	if len(blocks) == 0 {
+		return nil, errors.New("no PEM blocks")
+	}
+
+	// re-encode available, decrypted blocks
+	buffer := bytes.NewBuffer(nil)
+	for _, block := range blocks {
+		err := pem.Encode(buffer, block)
 		if err != nil {
-			logp.Critical("Failed loading client certificate", err)
 			return nil, err
 		}
-		certs = []tls.Certificate{cert}
+	}
+	return buffer.Bytes(), nil
+}
+
+func loadCertificateAuthorities(CAs []string) (*x509.CertPool, []error) {
+	errors := []error{}
+
+	if len(CAs) == 0 {
+		return nil, nil
 	}
 
-	var roots *x509.CertPool
-	if len(rootCAs) > 0 {
-		roots = x509.NewCertPool()
-		for _, caFile := range rootCAs {
-			pemData, err := ioutil.ReadFile(caFile)
-			if err != nil {
-				logp.Critical("Failed reading CA certificate: %s", err)
-				return nil, err
-			}
+	roots := x509.NewCertPool()
+	for _, path := range CAs {
+		pemData, err := ioutil.ReadFile(path)
+		if err != nil {
+			logp.Critical("Failed reading CA certificate: %v", err)
+			errors = append(errors, fmt.Errorf("%v reading %v", err, path))
+			continue
+		}
 
-			if ok := roots.AppendCertsFromPEM(pemData); !ok {
-				return nil, ErrNotACertificate
-			}
+		if ok := roots.AppendCertsFromPEM(pemData); !ok {
+			logp.Critical("Failed reading CA certificate: %v", err)
+			errors = append(errors, fmt.Errorf("%v adding %v", ErrNotACertificate, path))
+			continue
 		}
 	}
 
-	minVersion, err := parseTLSVersion(config.MinVersion)
-	if err != nil {
-		return nil, err
-	}
-	if minVersion == 0 {
-		// require minimum TLS-1.0 if not configured
-		minVersion = tls.VersionTLS10
-	}
-
-	maxVersion, err := parseTLSVersion(config.MaxVersion)
-	if err != nil {
-		return nil, err
-	}
-
-	cipherSuites, err := parseTLSCipherSuites(config.CipherSuites)
-	if err != nil {
-		return nil, err
-	}
-
-	curveIDs, err := parseCurveTypes(config.CurveTypes)
-	if err != nil {
-		return nil, err
-	}
-
-	tlsConfig := tls.Config{
-		MinVersion:         minVersion,
-		MaxVersion:         maxVersion,
-		Certificates:       certs,
-		RootCAs:            roots,
-		InsecureSkipVerify: config.Insecure,
-		CipherSuites:       cipherSuites,
-		CurvePreferences:   curveIDs,
-	}
-	return &tlsConfig, nil
+	return roots, errors
 }
 
-func parseTLSVersion(s string) (uint16, error) {
-	versions := map[string]uint16{
-		"":        0,
-		"SSL-3.0": tls.VersionSSL30,
-		"1.0":     tls.VersionTLS10,
-		"1.1":     tls.VersionTLS11,
-		"1.2":     tls.VersionTLS12,
-	}
-
-	id, ok := versions[s]
+func (cs *tlsCipherSuite) Unpack(in interface{}) error {
+	s, ok := in.(string)
 	if !ok {
-		return 0, ErrInvalidTLSVersion
+		return fmt.Errorf("tls cipher suite must be an identifier")
 	}
-	return id, nil
+
+	suite, found := tlsCipherSuites[s]
+	if !found {
+		return fmt.Errorf("invalid tls cipher suite '%v'", s)
+	}
+
+	*cs = suite
+	return nil
 }
 
-func parseTLSCipherSuites(names []string) ([]uint16, error) {
-	suites := map[string]uint16{
-		"RSA-RC4-128-SHA":                tls.TLS_RSA_WITH_RC4_128_SHA,
-		"RSA-3DES-CBC3-SHA":              tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA,
-		"RSA-AES-128-CBC-SHA":            tls.TLS_RSA_WITH_AES_128_CBC_SHA,
-		"RSA-AES-256-CBC-SHA":            tls.TLS_RSA_WITH_AES_256_CBC_SHA,
-		"ECDHE-ECDSA-RC4-128-SHA":        tls.TLS_ECDHE_ECDSA_WITH_RC4_128_SHA,
-		"ECDHE-ECDSA-AES-128-CBC-SHA":    tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
-		"ECDHE-ECDSA-AES-256-CBC-SHA":    tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
-		"ECDHE-RSA-RC4-128-SHA":          tls.TLS_ECDHE_RSA_WITH_RC4_128_SHA,
-		"ECDHE-RSA-3DES-CBC3-SHA":        tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,
-		"ECDHE-RSA-AES-128-CBC-SHA":      tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
-		"ECDHE-RSA-AES-256-CBC-SHA":      tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
-		"ECDHE-RSA-AES-128-GCM-SHA256":   tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-		"ECDHE-ECDSA-AES-128-GCM-SHA256": tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-		"ECDHE-RSA-AES-256-GCM-SHA384":   tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-		"ECDHE-ECDSA-AES-256-GCM-SHA384": tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+func (ct *tlsCurveType) Unpack(in interface{}) error {
+	s, ok := in.(string)
+	if !ok {
+		return fmt.Errorf("tls curve type must be an identifier")
 	}
 
-	var list []uint16
-	for _, name := range names {
-		id, ok := suites[name]
-		if !ok {
-			return nil, ErrUnknownCipherSuite
-		}
-
-		list = append(list, id)
-	}
-	return list, nil
-}
-
-func parseCurveTypes(names []string) ([]tls.CurveID, error) {
-	curveIDs := map[string]tls.CurveID{
-		"P-256": tls.CurveP256,
-		"P-384": tls.CurveP384,
-		"P-521": tls.CurveP521,
+	t, found := tlsCurveTypes[s]
+	if !found {
+		return fmt.Errorf("invalid tls curve type '%v'", s)
 	}
 
-	var list []tls.CurveID
-	for _, name := range names {
-		id, ok := curveIDs[name]
-		if !ok {
-			return nil, ErrUnknownCurveID
-		}
-		list = append(list, id)
-	}
-	return list, nil
+	*ct = t
+	return nil
+
 }

--- a/libbeat/outputs/tls_test.go
+++ b/libbeat/outputs/tls_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/outputs/transport"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -25,71 +26,36 @@ func load(yamlStr string) (*TLSConfig, error) {
 	return &cfg, nil
 }
 
+func mustLoad(t *testing.T, yamlStr string) *TLSConfig {
+	cfg, err := load(yamlStr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return cfg
+}
+
 func TestEmptyTlsConfig(t *testing.T) {
 	cfg, err := load("")
 	assert.Nil(t, err)
 
-	assert.Equal(t, "", cfg.Certificate)
-	assert.Equal(t, "", cfg.CertificateKey)
-	assert.Len(t, cfg.CAs, 0)
-	assert.Equal(t, false, cfg.Insecure)
-	assert.Len(t, cfg.CipherSuites, 0)
-	assert.Equal(t, "", cfg.MinVersion)
-	assert.Equal(t, "", cfg.MaxVersion)
-	assert.Len(t, cfg.CurveTypes, 0)
+	assert.Equal(t, cfg, &TLSConfig{})
 }
 
 func TestLoadWithEmptyValues(t *testing.T) {
 	cfg, err := load(`
-    disabled:
+    enabled:
+    verification_mode:
     certificate:
-    certificate-key:
-    certificate-authorities:
-    insecure:
-    cipher-suites:
-    min-verion:
-    max-version:
-    curve-types:
-  `)
-
-	assert.Nil(t, err)
-
-	assert.Equal(t, "", cfg.Certificate)
-	assert.Equal(t, "", cfg.CertificateKey)
-	assert.Len(t, cfg.CAs, 0)
-	assert.Equal(t, false, cfg.Insecure)
-	assert.Len(t, cfg.CipherSuites, 0)
-	assert.Equal(t, "", cfg.MinVersion)
-	assert.Equal(t, "", cfg.MaxVersion)
-	assert.Len(t, cfg.CurveTypes, 0)
-}
-
-func TestValuesSet(t *testing.T) {
-	cfg, err := load(`
-    disabled: true
-    certificate: mycert.pem
-    certificate_key: mycert.key
-    certificate_authorities: ["ca1.pem", "ca2.pem"]
-    insecure: true
+    key:
+    key_passphrase:
+    certificate_authorities:
     cipher_suites:
-      - ECDHE-ECDSA-AES-256-CBC-SHA
-      - ECDHE-ECDSA-AES-256-GCM-SHA384
-    min_version: 1.1
-    max_version: 1.2
     curve_types:
-      - P-521
+    supported_protocols:
   `)
 
 	assert.Nil(t, err)
-
-	assert.Equal(t, "mycert.pem", cfg.Certificate)
-	assert.Equal(t, "mycert.key", cfg.CertificateKey)
-	assert.Len(t, cfg.CAs, 2)
-	assert.Equal(t, true, cfg.Insecure)
-	assert.Len(t, cfg.CipherSuites, 2)
-	assert.Equal(t, "1.1", cfg.MinVersion)
-	assert.Equal(t, "1.2", cfg.MaxVersion)
-	assert.Len(t, cfg.CurveTypes, 1)
+	assert.Equal(t, cfg, &TLSConfig{})
 }
 
 func TestNoLoadNilConfig(t *testing.T) {
@@ -98,12 +64,52 @@ func TestNoLoadNilConfig(t *testing.T) {
 	assert.Nil(t, cfg)
 }
 
-func TestApplyEmptyConfig(t *testing.T) {
-	cfg, err := LoadTLSConfig(&TLSConfig{})
+func TestNoLoadDisabledConfig(t *testing.T) {
+	enabled := false
+	cfg, err := LoadTLSConfig(&TLSConfig{Enabled: &enabled})
 	assert.Nil(t, err)
+	assert.Nil(t, cfg)
+}
 
+func TestValuesSet(t *testing.T) {
+	cfg, err := load(`
+    enabled: true
+    certificate_authorities: ["ca1.pem", "ca2.pem"]
+    certificate: mycert.pem
+    key: mycert.key
+    verification_mode: none
+    cipher_suites:
+      - ECDHE-ECDSA-AES-256-CBC-SHA
+      - ECDHE-ECDSA-AES-256-GCM-SHA384
+    supported_protocols: [TLSv1.1, TLSv1.2]
+    curve_types:
+      - P-521
+  `)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, "mycert.pem", cfg.Certificate.Certificate)
+	assert.Equal(t, "mycert.key", cfg.Certificate.Key)
+	assert.Len(t, cfg.CAs, 2)
+	assert.Equal(t, transport.VerifyNone, cfg.VerificationMode)
+	assert.Len(t, cfg.CipherSuites, 2)
+	assert.Equal(t,
+		[]transport.TLSVersion{transport.TLSVersion11, transport.TLSVersion12},
+		cfg.Versions)
+	assert.Len(t, cfg.CurveTypes, 1)
+}
+
+func TestApplyEmptyConfig(t *testing.T) {
+	tmp, err := LoadTLSConfig(&TLSConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := tmp.BuildModuleConfig("")
 	assert.Equal(t, int(tls.VersionTLS10), int(cfg.MinVersion))
-	assert.Equal(t, 0, int(cfg.MaxVersion))
+	assert.Equal(t, int(tls.VersionTLS12), int(cfg.MaxVersion))
 	assert.Len(t, cfg.Certificates, 0)
 	assert.Nil(t, cfg.RootCAs)
 	assert.Equal(t, false, cfg.InsecureSkipVerify)
@@ -112,21 +118,21 @@ func TestApplyEmptyConfig(t *testing.T) {
 }
 
 func TestApplyWithConfig(t *testing.T) {
-	cfg, err := LoadTLSConfig(&TLSConfig{
-		Certificate:    "logstash/ca_test.pem",
-		CertificateKey: "logstash/ca_test.key",
-		CAs:            []string{"logstash/ca_test.pem"},
-		Insecure:       true,
-		CipherSuites: []string{
-			"ECDHE-ECDSA-AES-256-CBC-SHA",
-			"ECDHE-ECDSA-AES-256-GCM-SHA384",
-		},
-		MinVersion: "1.0",
-		MaxVersion: "1.2",
-		CurveTypes: []string{"P-384"},
-	})
-	assert.Nil(t, err)
+	tmp, err := LoadTLSConfig(mustLoad(t, `
+    certificate: logstash/ca_test.pem
+    key: logstash/ca_test.key
+    certificate_authorities: [logstash/ca_test.pem]
+    verification_mode: none
+    cipher_suites:
+      - "ECDHE-ECDSA-AES-256-CBC-SHA"
+      - "ECDHE-ECDSA-AES-256-GCM-SHA384"
+    curve_types: [P-384]
+  `))
+	if err != nil {
+		t.Fatal(err)
+	}
 
+	cfg := tmp.BuildModuleConfig("")
 	assert.NotNil(t, cfg)
 	assert.Len(t, cfg.Certificates, 1)
 	assert.NotNil(t, cfg.RootCAs)
@@ -137,41 +143,50 @@ func TestApplyWithConfig(t *testing.T) {
 	assert.Len(t, cfg.CurvePreferences, 1)
 }
 
-func TestCertificateWithoutKeyFail(t *testing.T) {
-	_, err := LoadTLSConfig(&TLSConfig{
-		Certificate: "mycert.pem",
-	})
-	assert.NotNil(t, err)
-}
-
-func TestCertificateKeyWithoutCertFail(t *testing.T) {
-	_, err := LoadTLSConfig(&TLSConfig{
-		CertificateKey: "mycert.key",
-	})
-	assert.NotNil(t, err)
-}
-
-func TestUnknownCipherSuiteFail(t *testing.T) {
-	_, err := LoadTLSConfig(&TLSConfig{
-		CipherSuites: []string{
-			"Unknown cipher suite",
+func TestCertificateFails(t *testing.T) {
+	tests := []struct {
+		title string
+		yaml  string
+	}{
+		{
+			"certificate without key",
+			"certificate: mycert.pem",
 		},
-	})
-	assert.NotNil(t, err)
-}
-
-func TestUnknownVersionFail(t *testing.T) {
-	_, err := LoadTLSConfig(&TLSConfig{
-		MinVersion: "Unknown-Version",
-	})
-	assert.NotNil(t, err)
-}
-
-func TestUnknownCurveType(t *testing.T) {
-	_, err := LoadTLSConfig(&TLSConfig{
-		CurveTypes: []string{
-			"Unknown-Curve-Type",
+		{
+			"key without certificate",
+			"key: mycert.key",
 		},
-	})
-	assert.NotNil(t, err)
+		{
+			"unknown cipher suite",
+			"cipher_suites: ['unknown cipher suite']",
+		},
+		{
+			"unknown version",
+			"supported_protocols: [UnknwonTLSv1.1]",
+		},
+		{
+			"unknown curve type",
+			"curve_types: ['unknown curve type']",
+		},
+	}
+
+	for i, test := range tests {
+		t.Logf("run test (%v): %v", i, test.title)
+
+		config, err := common.NewConfigWithYAML([]byte(test.yaml), "")
+		if err != nil {
+			t.Error(err)
+			continue
+		}
+
+		// one must fail: validators on Unpack or transformation to *tls.Config
+		var tlscfg TLSConfig
+		if err = config.Unpack(&tlscfg); err != nil {
+			t.Log(err)
+			continue
+		}
+		_, err = LoadTLSConfig(&tlscfg)
+		t.Log(err)
+		assert.Error(t, err)
+	}
 }

--- a/libbeat/outputs/transport/client.go
+++ b/libbeat/outputs/transport/client.go
@@ -1,7 +1,6 @@
 package transport
 
 import (
-	"crypto/tls"
 	"fmt"
 	"net"
 	"sync"
@@ -19,7 +18,7 @@ type Client struct {
 
 type Config struct {
 	Proxy   *ProxyConfig
-	TLS     *tls.Config
+	TLS     *TLSConfig
 	Timeout time.Duration
 	Stats   *IOStats
 }
@@ -34,7 +33,10 @@ func MakeDialer(c *Config) (Dialer, error) {
 	if c.Stats != nil {
 		dialer = StatsDialer(dialer, c.Stats)
 	}
-	dialer = TLSDialer(c.TLS, c.Timeout, dialer)
+
+	if c.TLS != nil {
+		return TLSDialer(dialer, c.TLS, c.Timeout)
+	}
 	return dialer, nil
 }
 

--- a/libbeat/outputs/transport/tls.go
+++ b/libbeat/outputs/transport/tls.go
@@ -2,15 +2,79 @@ package transport
 
 import (
 	"crypto/tls"
+	"crypto/x509"
+	"errors"
 	"fmt"
 	"net"
+	"sync"
 	"time"
+
+	"github.com/elastic/beats/libbeat/logp"
 )
 
-func TLSDialer(tlscfg *tls.Config, timeout time.Duration, forward Dialer) Dialer {
-	if tlscfg == nil {
-		return forward
-	}
+type TLSConfig struct {
+	// List of allowed SSL/TLS protocol versions. Connections might be dropped
+	// after handshake succeeded, if TLS version in use is not listed.
+	Versions []TLSVersion
+
+	// Configure SSL/TLS verification mode used during handshake. By default
+	// VerifyFull will be used.
+	Verification TLSVerificationMode
+
+	// List of certificate chains to present to the other side of the
+	// connection.
+	Certificates []tls.Certificate
+
+	// Set of root certificate authorities use to verify server certificates.
+	// If RootCAs is nil, TLS might use the system its root CA set (not supported
+	// on MS Windows).
+	RootCAs *x509.CertPool
+
+	// List of supported cipher suites. If nil, a default list provided by the
+	// implementation will be used.
+	CipherSuites []uint16
+
+	// Types of elliptic curves that will be used in an ECDHE handshake. If empty,
+	// the implementation will choose a default.
+	CurvePreferences []tls.CurveID
+}
+
+type TLSVersion uint16
+
+const (
+	TLSVersionSSL30 TLSVersion = tls.VersionSSL30
+	TLSVersion10    TLSVersion = tls.VersionTLS10
+	TLSVersion11    TLSVersion = tls.VersionTLS11
+	TLSVersion12    TLSVersion = tls.VersionTLS12
+)
+
+type TLSVerificationMode uint8
+
+const (
+	VerifyFull TLSVerificationMode = iota
+	VerifyNone
+
+	// TODO: add VerifyCertificate support. Due to checks being run
+	//       during handshake being limited, verify certificates in
+	//       postVerifyTLSConnection
+	// VerifyCertificate
+)
+
+var tlsDefaultVersions = []TLSVersion{
+	TLSVersion10,
+	TLSVersion11,
+	TLSVersion12,
+}
+
+func TLSDialer(
+	forward Dialer,
+	config *TLSConfig,
+	timeout time.Duration,
+) (Dialer, error) {
+	var lastTLSConfig *tls.Config
+	var lastNetwork string
+	var lastAddress string
+	var m sync.Mutex
 
 	return DialerFunc(func(network, address string) (net.Conn, error) {
 		switch network {
@@ -19,27 +83,208 @@ func TLSDialer(tlscfg *tls.Config, timeout time.Duration, forward Dialer) Dialer
 			return nil, fmt.Errorf("unsupported network type %v", network)
 		}
 
-		socket, err := forward.Dial(network, address)
-		if err != nil {
-			return nil, err
-		}
-
 		host, _, err := net.SplitHostPort(address)
 		if err != nil {
 			return nil, err
 		}
 
-		tlscfg.ServerName = host
-		conn := tls.Client(socket, tlscfg)
+		var tlsConfig *tls.Config
+		m.Lock()
+		if network == lastNetwork && address == lastAddress {
+			tlsConfig = lastTLSConfig
+		}
+		if tlsConfig == nil {
+			tlsConfig = config.BuildModuleConfig(host)
+			lastNetwork = network
+			lastAddress = address
+			lastTLSConfig = tlsConfig
+		}
+		m.Unlock()
+
+		return tlsDialWith(forward, network, address, timeout, tlsConfig, config)
+	}), nil
+}
+
+func tlsDialWith(
+	dialer Dialer,
+	network, address string,
+	timeout time.Duration,
+	tlsConfig *tls.Config,
+	config *TLSConfig,
+) (net.Conn, error) {
+	socket, err := dialer.Dial(network, address)
+	if err != nil {
+		return nil, err
+	}
+
+	conn := tls.Client(socket, tlsConfig)
+
+	withTimeout := timeout > 0
+	if withTimeout {
 		if err := conn.SetDeadline(time.Now().Add(timeout)); err != nil {
 			_ = conn.Close()
 			return nil, err
 		}
-		if err := conn.Handshake(); err != nil {
-			_ = conn.Close()
-			return nil, err
-		}
+	}
 
-		return conn, nil
-	})
+	if err := conn.Handshake(); err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+
+	// remove timeout if handshake was subject to timeout:
+	if withTimeout {
+		conn.SetDeadline(time.Time{})
+	}
+
+	if err := postVerifyTLSConnection(conn, config); err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+
+	return conn, nil
+}
+
+func postVerifyTLSConnection(conn *tls.Conn, config *TLSConfig) error {
+	st := conn.ConnectionState()
+
+	if !st.HandshakeComplete {
+		return errors.New("incomplete handshake")
+	}
+
+	// no more checks if no extra configs available
+	if config == nil {
+		return nil
+	}
+
+	versions := config.Versions
+	if versions == nil {
+		versions = tlsDefaultVersions
+	}
+	versionOK := false
+	for _, version := range versions {
+		versionOK = versionOK || st.Version == uint16(version)
+	}
+	if !versionOK {
+		return fmt.Errorf("tls version %v not configured", TLSVersion(st.Version))
+	}
+
+	return nil
+}
+
+func (c *TLSConfig) BuildModuleConfig(host string) *tls.Config {
+	if c == nil {
+		// use default TLS settings, if config is empty.
+		return &tls.Config{ServerName: host}
+	}
+
+	versions := c.Versions
+	if len(versions) == 0 {
+		versions = tlsDefaultVersions
+	}
+
+	minVersion := uint16(0xffff)
+	maxVersion := uint16(0)
+	for _, version := range versions {
+		v := uint16(version)
+		if v < minVersion {
+			minVersion = v
+		}
+		if v > maxVersion {
+			maxVersion = v
+		}
+	}
+
+	insecure := c.Verification != VerifyFull
+	if insecure {
+		logp.Warn("SSL/TLS verifications disabled.")
+	}
+
+	return &tls.Config{
+		ServerName:         host,
+		MinVersion:         minVersion,
+		MaxVersion:         maxVersion,
+		Certificates:       c.Certificates,
+		RootCAs:            c.RootCAs,
+		InsecureSkipVerify: insecure,
+		CipherSuites:       c.CipherSuites,
+		CurvePreferences:   c.CurvePreferences,
+	}
+}
+
+var tlsProtocolVersions = map[string]TLSVersion{
+	"SSLv3":   TLSVersionSSL30,
+	"SSLv3.0": TLSVersionSSL30,
+	"TLSv1":   TLSVersion10,
+	"TLSv1.0": TLSVersion10,
+	"TLSv1.1": TLSVersion11,
+	"TLSv1.2": TLSVersion12,
+}
+
+func (v TLSVersion) String() string {
+	versions := map[TLSVersion]string{
+		TLSVersionSSL30: "SSLv3",
+		TLSVersion10:    "TLSv1.0",
+		TLSVersion11:    "TLSv1.1",
+		TLSVersion12:    "TLSv1.2",
+	}
+	if s, ok := versions[v]; ok {
+		return s
+	}
+	return "unknown"
+}
+
+func (v *TLSVersion) Unpack(in interface{}) error {
+	s, ok := in.(string)
+	if !ok {
+		return fmt.Errorf("tls version must be an identifier")
+	}
+
+	version, found := tlsProtocolVersions[s]
+	if !found {
+		return fmt.Errorf("invalid tls version '%v'", s)
+	}
+
+	*v = version
+	return nil
+}
+
+var tlsVerificationModes = map[string]TLSVerificationMode{
+	"":     VerifyFull,
+	"full": VerifyFull,
+	"none": VerifyNone,
+	// "certificate": verifyCertificate,
+}
+
+func (m TLSVerificationMode) String() string {
+	modes := map[TLSVerificationMode]string{
+		VerifyFull: "full",
+		// VerifyCertificate: "certificate",
+		VerifyNone: "none",
+	}
+
+	if s, ok := modes[m]; ok {
+		return s
+	}
+	return "unknown"
+}
+
+func (m *TLSVerificationMode) Unpack(in interface{}) error {
+	if in == nil {
+		*m = VerifyFull
+		return nil
+	}
+
+	s, ok := in.(string)
+	if !ok {
+		return fmt.Errorf("verification mode must be an identifier")
+	}
+
+	mode, found := tlsVerificationModes[s]
+	if !found {
+		return fmt.Errorf("unknown verification mode '%v'", s)
+	}
+
+	*m = mode
+	return nil
 }

--- a/libbeat/outputs/transport/transptest/testing.go
+++ b/libbeat/outputs/transport/transptest/testing.go
@@ -109,14 +109,16 @@ func NewMockServerTLS(t *testing.T, to time.Duration, cert string, proxy *transp
 	}
 
 	tlsConfig, err := outputs.LoadTLSConfig(&outputs.TLSConfig{
-		Certificate:    cert + ".pem",
-		CertificateKey: cert + ".key",
+		Certificate: outputs.CertificateConfig{
+			Certificate: cert + ".pem",
+			Key:         cert + ".key",
+		},
 	})
 	if err != nil {
 		t.Fatalf("failed to load certificate")
 	}
 
-	listener := tls.NewListener(tcpListener, tlsConfig)
+	listener := tls.NewListener(tcpListener, tlsConfig.BuildModuleConfig(""))
 
 	server := &MockServer{Listener: listener, Timeout: to}
 	server.Handshake = func(client net.Conn) {

--- a/metricbeat/docs/reference/configuration.asciidoc
+++ b/metricbeat/docs/reference/configuration.asciidoc
@@ -17,7 +17,7 @@ configuration settings, you need to restart {beatname_uc} to pick up the changes
 * <<redis-output>>
 * <<file-output>>
 * <<console-output>>
-* <<configuration-output-tls>>
+* <<configuration-output-ssl>>
 * <<configuration-path>>
 * <<configuration-logging>>
 

--- a/metricbeat/docs/securing-metricbeat.asciidoc
+++ b/metricbeat/docs/securing-metricbeat.asciidoc
@@ -8,7 +8,7 @@ The following topics describe how to secure communication between
 {beatname_uc} and other products in the Elastic stack:
 
 * <<securing-communication-elasticsearch>>
-* <<configuring-tls-logstash>>
+* <<configuring-ssl-logstash>>
 
 --
 
@@ -16,6 +16,6 @@ The following topics describe how to secure communication between
 == Securing Communication With Elasticsearch
 include::../../libbeat/docs/https.asciidoc[]
 
-[[configuring-tls-logstash]]
-== Securing Communication With Logstash by Using TLS
-include::../../libbeat/docs/shared-tls-logstash-config.asciidoc[]
+[[configuring-ssl-logstash]]
+== Securing Communication With Logstash by Using SSL
+include::../../libbeat/docs/shared-ssl-logstash-config.asciidoc[]

--- a/metricbeat/metricbeat.full.yml
+++ b/metricbeat/metricbeat.full.yml
@@ -328,34 +328,37 @@ output.elasticsearch:
   # Path to the Elasticsearch 2.x version of the template file.
   #template.versions.2x.path: "${path.config}/metricbeat.template-es2x.json"
 
+  # Use SSL settings for HTTPS. Default is true.
+  #ssl.enabled: true
 
-  # TLS configuration. By default is off.
+  # Configure SSL verification mode. If `none` is configured, all server hosts
+  # and certificates will be accepted. In this mode, SSL based connections are
+  # susceptible to man-in-the-middle attacks. Use only for testing. Default is
+  # `full`.
+  #ssl.verification_mode: full
+
+  # List of supported/valid TLS versions. By default all TLS versions 1.0 up to
+  # 1.2 are enabled.
+  #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
+
+  # SSL configuration. By default is off.
   # List of root certificates for HTTPS server verifications
-  #tls.certificate_authorities: ["/etc/pki/root/ca.pem"]
+  #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
-  # Certificate for TLS client authentication
-  #tls.certificate: "/etc/pki/client/cert.pem"
+  # Certificate for SSL client authentication
+  #ssl.certificate: "/etc/pki/client/cert.pem"
 
   # Client Certificate Key
-  #tls.certificate_key: "/etc/pki/client/cert.key"
+  #ssl.key: "/etc/pki/client/cert.key"
 
-  # Controls whether the client verifies server certificates and host name.
-  # If insecure is set to true, all server host names and certificates will be
-  # accepted. In this mode TLS based connections are susceptible to
-  # man-in-the-middle attacks. Use only for testing.
-  #tls.insecure: true
+  # Optional passphrase for decrypting the Certificate Key.
+  #ssl.key_passphrase: ''
 
-  # Configure cipher suites to be used for TLS connections
-  #tls.cipher_suites: []
+  # Configure cipher suites to be used for SSL connections
+  #ssl.cipher_suites: []
 
   # Configure curve types for ECDHE based cipher suites
-  #tls.curve_types: []
-
-  # Configure minimum TLS version allowed for connection to logstash
-  #tls.min_version: 1.0
-
-  # Configure maximum TLS version allowed for connection to logstash
-  #tls.max_version: 1.2
+  #ssl.curve_types: []
 
 
 #----------------------------- Logstash output --------------------------------
@@ -389,27 +392,37 @@ output.elasticsearch:
   # Resolve names locally when using a proxy server. Defaults to false.
   #proxy_use_local_resolver: false
 
-  # Optional TLS configuration options. TLS is off by default.
-  # List of root certificates for HTTPS server verifications
-  #tls.certificate_authorities: ["/etc/pki/root/ca.pem"]
+  # Enable SSL support. SSL is automatically enabled, if any SSL setting is set.
+  #ssl.enabled: true
 
-  # Certificate for TLS client authentication
-  #tls.certificate: "/etc/pki/client/cert.pem"
+  # Configure SSL verification mode. If `none` is configured, all server hosts
+  # and certificates will be accepted. In this mode, SSL based connections are
+  # susceptible to man-in-the-middle attacks. Use only for testing. Default is
+  # `full`.
+  #ssl.verification_mode: full
+
+  # List of supported/valid TLS versions. By default all TLS versions 1.0 up to
+  # 1.2 are enabled.
+  #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
+
+  # Optional SSL configuration options. SSL is off by default.
+  # List of root certificates for HTTPS server verifications
+  #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
+
+  # Certificate for SSL client authentication
+  #ssl.certificate: "/etc/pki/client/cert.pem"
 
   # Client Certificate Key
-  #tls.certificate_key: "/etc/pki/client/cert.key"
+  #ssl.key: "/etc/pki/client/cert.key"
 
-  # Controls whether the client verifies server certificates and host name.
-  # If insecure is set to true, all server host names and certificates will be
-  # accepted. In this mode TLS based connections are susceptible to
-  # man-in-the-middle attacks. Use only for testing.
-  #tls.insecure: true
+  # Optional passphrase for decrypting the Certificate Key.
+  #ssl.key_passphrase: ''
 
-  # Configure cipher suites to be used for TLS connections
-  #tls.cipher_suites: []
+  # Configure cipher suites to be used for SSL connections
+  #ssl.cipher_suites: []
 
   # Configure curve types for ECDHE based cipher suites
-  #tls.curve_types: []
+  #ssl.curve_types: []
 
 #------------------------------- Kafka output ---------------------------------
 #output.kafka:
@@ -514,27 +527,37 @@ output.elasticsearch:
   # purposes.  The default is "beats".
   #client_id: beats
 
-  # Optional TLS configuration options. TLS is off by default.
-  # List of root certificates for HTTPS server verifications
-  #tls.certificate_authorities: ["/etc/pki/root/ca.pem"]
+  # Enable SSL support. SSL is automatically enabled, if any SSL setting is set.
+  #ssl.enabled: true
 
-  # Certificate for TLS client authentication
-  #tls.certificate: "/etc/pki/client/cert.pem"
+  # Optional SSL configuration options. SSL is off by default.
+  # List of root certificates for HTTPS server verifications
+  #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
+
+  # Configure SSL verification mode. If `none` is configured, all server hosts
+  # and certificates will be accepted. In this mode, SSL based connections are
+  # susceptible to man-in-the-middle attacks. Use only for testing. Default is
+  # `full`.
+  #ssl.verification_mode: full
+
+  # List of supported/valid TLS versions. By default all TLS versions 1.0 up to
+  # 1.2 are enabled.
+  #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
+
+  # Certificate for SSL client authentication
+  #ssl.certificate: "/etc/pki/client/cert.pem"
 
   # Client Certificate Key
-  #tls.certificate_key: "/etc/pki/client/cert.key"
+  #ssl.key: "/etc/pki/client/cert.key"
 
-  # Controls whether the client verifies server certificates and host name.
-  # If insecure is set to true, all server host names and certificates will be
-  # accepted. In this mode TLS based connections are susceptible to
-  # man-in-the-middle attacks. Use only for testing.
-  #tls.insecure: true
+  # Optional passphrase for decrypting the Certificate Key.
+  #ssl.key_passphrase: ''
 
-  # Configure cipher suites to be used for TLS connections
-  #tls.cipher_suites: []
+  # Configure cipher suites to be used for SSL connections
+  #ssl.cipher_suites: []
 
   # Configure curve types for ECDHE based cipher suites
-  #tls.curve_types: []
+  #ssl.curve_types: []
 
 #------------------------------- Redis output ---------------------------------
 #output.redis:
@@ -601,27 +624,38 @@ output.elasticsearch:
   # occurs on the proxy server.
   #proxy_use_local_resolver: false
 
-  # Optional TLS configuration options. TLS is off by default.
-  # List of root certificates for HTTPS server verifications
-  #tls.certificate_authorities: ["/etc/pki/root/ca.pem"]
+  # Enable SSL support. SSL is automatically enabled, if any SSL setting is set.
+  #ssl.enabled: true
 
-  # Certificate for TLS client authentication
-  #tls.certificate: "/etc/pki/client/cert.pem"
+  # Configure SSL verification mode. If `none` is configured, all server hosts
+  # and certificates will be accepted. In this mode, SSL based connections are
+  # susceptible to man-in-the-middle attacks. Use only for testing. Default is
+  # `full`.
+  #ssl.verification_mode: full
+
+  # List of supported/valid TLS versions. By default all TLS versions 1.0 up to
+  # 1.2 are enabled.
+  #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
+
+  # Optional SSL configuration options. SSL is off by default.
+  # List of root certificates for HTTPS server verifications
+  #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
+
+  # Certificate for SSL client authentication
+  #ssl.certificate: "/etc/pki/client/cert.pem"
 
   # Client Certificate Key
-  #tls.certificate_key: "/etc/pki/client/cert.key"
+  #ssl.key: "/etc/pki/client/cert.key"
 
-  # Controls whether the client verifies server certificates and host name.
-  # If insecure is set to true, all server host names and certificates will be
-  # accepted. In this mode TLS based connections are susceptible to
-  # man-in-the-middle attacks. Use only for testing.
-  #tls.insecure: true
+  # Optional passphrase for decrypting the Certificate Key.
+  #ssl.key_passphrase: ''
 
-  # Configure cipher suites to be used for TLS connections
-  #tls.cipher_suites: []
+  # Configure cipher suites to be used for SSL connections
+  #ssl.cipher_suites: []
 
   # Configure curve types for ECDHE based cipher suites
-  #tls.curve_types: []
+  #ssl.curve_types: []
+
 
 #------------------------------- File output ----------------------------------
 #output.file:

--- a/metricbeat/metricbeat.yml
+++ b/metricbeat/metricbeat.yml
@@ -80,15 +80,15 @@ output.elasticsearch:
   # The Logstash hosts
   #hosts: ["localhost:5044"]
 
-  # Optional TLS. By default is off.
+  # Optional SSL. By default is off.
   # List of root certificates for HTTPS server verifications
-  #tls.certificate_authorities: ["/etc/pki/root/ca.pem"]
+  #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
-  # Certificate for TLS client authentication
-  #tls.certificate: "/etc/pki/client/cert.pem"
+  # Certificate for SSL client authentication
+  #ssl.certificate: "/etc/pki/client/cert.pem"
 
   # Client Certificate Key
-  #tls.certificate_key: "/etc/pki/client/cert.key"
+  #ssl.key: "/etc/pki/client/cert.key"
 
 #================================ Logging =====================================
 

--- a/packetbeat/docs/reference/configuration.asciidoc
+++ b/packetbeat/docs/reference/configuration.asciidoc
@@ -20,7 +20,7 @@ configuration settings, you need to restart {beatname_uc} to pick up the changes
 * <<redis-output>>
 * <<file-output>>
 * <<console-output>>
-* <<configuration-output-tls>>
+* <<configuration-output-ssl>>
 * <<configuration-path>>
 * <<configuration-logging>>
 * <<configuration-run-options>>

--- a/packetbeat/docs/securing-packetbeat.asciidoc
+++ b/packetbeat/docs/securing-packetbeat.asciidoc
@@ -7,7 +7,7 @@
 The following topics describe how to secure communication between Packetbeat and other products in the Elastic stack:
 
 * <<securing-communication-elasticsearch>>
-* <<configuring-tls-logstash>>
+* <<configuring-ssl-logstash>>
 
 --
 
@@ -15,6 +15,6 @@ The following topics describe how to secure communication between Packetbeat and
 == Securing Communication With Elasticsearch
 include::../../libbeat/docs/https.asciidoc[]
 
-[[configuring-tls-logstash]]
-== Securing Communication With Logstash by Using TLS
-include::../../libbeat/docs/shared-tls-logstash-config.asciidoc[]
+[[configuring-ssl-logstash]]
+== Securing Communication With Logstash by Using SSL
+include::../../libbeat/docs/shared-ssl-logstash-config.asciidoc[]

--- a/packetbeat/packetbeat.full.yml
+++ b/packetbeat/packetbeat.full.yml
@@ -594,34 +594,37 @@ output.elasticsearch:
   # Path to the Elasticsearch 2.x version of the template file.
   #template.versions.2x.path: "${path.config}/packetbeat.template-es2x.json"
 
+  # Use SSL settings for HTTPS. Default is true.
+  #ssl.enabled: true
 
-  # TLS configuration. By default is off.
+  # Configure SSL verification mode. If `none` is configured, all server hosts
+  # and certificates will be accepted. In this mode, SSL based connections are
+  # susceptible to man-in-the-middle attacks. Use only for testing. Default is
+  # `full`.
+  #ssl.verification_mode: full
+
+  # List of supported/valid TLS versions. By default all TLS versions 1.0 up to
+  # 1.2 are enabled.
+  #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
+
+  # SSL configuration. By default is off.
   # List of root certificates for HTTPS server verifications
-  #tls.certificate_authorities: ["/etc/pki/root/ca.pem"]
+  #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
-  # Certificate for TLS client authentication
-  #tls.certificate: "/etc/pki/client/cert.pem"
+  # Certificate for SSL client authentication
+  #ssl.certificate: "/etc/pki/client/cert.pem"
 
   # Client Certificate Key
-  #tls.certificate_key: "/etc/pki/client/cert.key"
+  #ssl.key: "/etc/pki/client/cert.key"
 
-  # Controls whether the client verifies server certificates and host name.
-  # If insecure is set to true, all server host names and certificates will be
-  # accepted. In this mode TLS based connections are susceptible to
-  # man-in-the-middle attacks. Use only for testing.
-  #tls.insecure: true
+  # Optional passphrase for decrypting the Certificate Key.
+  #ssl.key_passphrase: ''
 
-  # Configure cipher suites to be used for TLS connections
-  #tls.cipher_suites: []
+  # Configure cipher suites to be used for SSL connections
+  #ssl.cipher_suites: []
 
   # Configure curve types for ECDHE based cipher suites
-  #tls.curve_types: []
-
-  # Configure minimum TLS version allowed for connection to logstash
-  #tls.min_version: 1.0
-
-  # Configure maximum TLS version allowed for connection to logstash
-  #tls.max_version: 1.2
+  #ssl.curve_types: []
 
 
 #----------------------------- Logstash output --------------------------------
@@ -655,27 +658,37 @@ output.elasticsearch:
   # Resolve names locally when using a proxy server. Defaults to false.
   #proxy_use_local_resolver: false
 
-  # Optional TLS configuration options. TLS is off by default.
-  # List of root certificates for HTTPS server verifications
-  #tls.certificate_authorities: ["/etc/pki/root/ca.pem"]
+  # Enable SSL support. SSL is automatically enabled, if any SSL setting is set.
+  #ssl.enabled: true
 
-  # Certificate for TLS client authentication
-  #tls.certificate: "/etc/pki/client/cert.pem"
+  # Configure SSL verification mode. If `none` is configured, all server hosts
+  # and certificates will be accepted. In this mode, SSL based connections are
+  # susceptible to man-in-the-middle attacks. Use only for testing. Default is
+  # `full`.
+  #ssl.verification_mode: full
+
+  # List of supported/valid TLS versions. By default all TLS versions 1.0 up to
+  # 1.2 are enabled.
+  #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
+
+  # Optional SSL configuration options. SSL is off by default.
+  # List of root certificates for HTTPS server verifications
+  #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
+
+  # Certificate for SSL client authentication
+  #ssl.certificate: "/etc/pki/client/cert.pem"
 
   # Client Certificate Key
-  #tls.certificate_key: "/etc/pki/client/cert.key"
+  #ssl.key: "/etc/pki/client/cert.key"
 
-  # Controls whether the client verifies server certificates and host name.
-  # If insecure is set to true, all server host names and certificates will be
-  # accepted. In this mode TLS based connections are susceptible to
-  # man-in-the-middle attacks. Use only for testing.
-  #tls.insecure: true
+  # Optional passphrase for decrypting the Certificate Key.
+  #ssl.key_passphrase: ''
 
-  # Configure cipher suites to be used for TLS connections
-  #tls.cipher_suites: []
+  # Configure cipher suites to be used for SSL connections
+  #ssl.cipher_suites: []
 
   # Configure curve types for ECDHE based cipher suites
-  #tls.curve_types: []
+  #ssl.curve_types: []
 
 #------------------------------- Kafka output ---------------------------------
 #output.kafka:
@@ -780,27 +793,37 @@ output.elasticsearch:
   # purposes.  The default is "beats".
   #client_id: beats
 
-  # Optional TLS configuration options. TLS is off by default.
-  # List of root certificates for HTTPS server verifications
-  #tls.certificate_authorities: ["/etc/pki/root/ca.pem"]
+  # Enable SSL support. SSL is automatically enabled, if any SSL setting is set.
+  #ssl.enabled: true
 
-  # Certificate for TLS client authentication
-  #tls.certificate: "/etc/pki/client/cert.pem"
+  # Optional SSL configuration options. SSL is off by default.
+  # List of root certificates for HTTPS server verifications
+  #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
+
+  # Configure SSL verification mode. If `none` is configured, all server hosts
+  # and certificates will be accepted. In this mode, SSL based connections are
+  # susceptible to man-in-the-middle attacks. Use only for testing. Default is
+  # `full`.
+  #ssl.verification_mode: full
+
+  # List of supported/valid TLS versions. By default all TLS versions 1.0 up to
+  # 1.2 are enabled.
+  #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
+
+  # Certificate for SSL client authentication
+  #ssl.certificate: "/etc/pki/client/cert.pem"
 
   # Client Certificate Key
-  #tls.certificate_key: "/etc/pki/client/cert.key"
+  #ssl.key: "/etc/pki/client/cert.key"
 
-  # Controls whether the client verifies server certificates and host name.
-  # If insecure is set to true, all server host names and certificates will be
-  # accepted. In this mode TLS based connections are susceptible to
-  # man-in-the-middle attacks. Use only for testing.
-  #tls.insecure: true
+  # Optional passphrase for decrypting the Certificate Key.
+  #ssl.key_passphrase: ''
 
-  # Configure cipher suites to be used for TLS connections
-  #tls.cipher_suites: []
+  # Configure cipher suites to be used for SSL connections
+  #ssl.cipher_suites: []
 
   # Configure curve types for ECDHE based cipher suites
-  #tls.curve_types: []
+  #ssl.curve_types: []
 
 #------------------------------- Redis output ---------------------------------
 #output.redis:
@@ -867,27 +890,38 @@ output.elasticsearch:
   # occurs on the proxy server.
   #proxy_use_local_resolver: false
 
-  # Optional TLS configuration options. TLS is off by default.
-  # List of root certificates for HTTPS server verifications
-  #tls.certificate_authorities: ["/etc/pki/root/ca.pem"]
+  # Enable SSL support. SSL is automatically enabled, if any SSL setting is set.
+  #ssl.enabled: true
 
-  # Certificate for TLS client authentication
-  #tls.certificate: "/etc/pki/client/cert.pem"
+  # Configure SSL verification mode. If `none` is configured, all server hosts
+  # and certificates will be accepted. In this mode, SSL based connections are
+  # susceptible to man-in-the-middle attacks. Use only for testing. Default is
+  # `full`.
+  #ssl.verification_mode: full
+
+  # List of supported/valid TLS versions. By default all TLS versions 1.0 up to
+  # 1.2 are enabled.
+  #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
+
+  # Optional SSL configuration options. SSL is off by default.
+  # List of root certificates for HTTPS server verifications
+  #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
+
+  # Certificate for SSL client authentication
+  #ssl.certificate: "/etc/pki/client/cert.pem"
 
   # Client Certificate Key
-  #tls.certificate_key: "/etc/pki/client/cert.key"
+  #ssl.key: "/etc/pki/client/cert.key"
 
-  # Controls whether the client verifies server certificates and host name.
-  # If insecure is set to true, all server host names and certificates will be
-  # accepted. In this mode TLS based connections are susceptible to
-  # man-in-the-middle attacks. Use only for testing.
-  #tls.insecure: true
+  # Optional passphrase for decrypting the Certificate Key.
+  #ssl.key_passphrase: ''
 
-  # Configure cipher suites to be used for TLS connections
-  #tls.cipher_suites: []
+  # Configure cipher suites to be used for SSL connections
+  #ssl.cipher_suites: []
 
   # Configure curve types for ECDHE based cipher suites
-  #tls.curve_types: []
+  #ssl.curve_types: []
+
 
 #------------------------------- File output ----------------------------------
 #output.file:

--- a/packetbeat/packetbeat.yml
+++ b/packetbeat/packetbeat.yml
@@ -127,15 +127,15 @@ output.elasticsearch:
   # The Logstash hosts
   #hosts: ["localhost:5044"]
 
-  # Optional TLS. By default is off.
+  # Optional SSL. By default is off.
   # List of root certificates for HTTPS server verifications
-  #tls.certificate_authorities: ["/etc/pki/root/ca.pem"]
+  #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
-  # Certificate for TLS client authentication
-  #tls.certificate: "/etc/pki/client/cert.pem"
+  # Certificate for SSL client authentication
+  #ssl.certificate: "/etc/pki/client/cert.pem"
 
   # Client Certificate Key
-  #tls.certificate_key: "/etc/pki/client/cert.key"
+  #ssl.key: "/etc/pki/client/cert.key"
 
 #================================ Logging =====================================
 

--- a/winlogbeat/docs/reference/configuration.asciidoc
+++ b/winlogbeat/docs/reference/configuration.asciidoc
@@ -18,7 +18,7 @@ configuration settings, you need to restart {beatname_uc} to pick up the changes
 * <<redis-output>>
 * <<file-output>>
 * <<console-output>>
-* <<configuration-output-tls>>
+* <<configuration-output-ssl>>
 * <<configuration-path>>
 * <<configuration-logging>>
 

--- a/winlogbeat/docs/securing-winlogbeat.asciidoc
+++ b/winlogbeat/docs/securing-winlogbeat.asciidoc
@@ -7,7 +7,7 @@
 The following topics describe how to secure communication between Winlogbeat and other products in the Elastic stack:
 
 * <<securing-communication-elasticsearch>>
-* <<configuring-tls-logstash>>
+* <<configuring-ssl-logstash>>
 
 --
 
@@ -15,6 +15,6 @@ The following topics describe how to secure communication between Winlogbeat and
 == Securing Communication With Elasticsearch
 include::../../libbeat/docs/https.asciidoc[]
 
-[[configuring-tls-logstash]]
-== Securing Communication With Logstash by Using TLS
-include::../../libbeat/docs/shared-tls-logstash-config.asciidoc[]
+[[configuring-ssl-logstash]]
+== Securing Communication With Logstash by Using SSL
+include::../../libbeat/docs/shared-ssl-logstash-config.asciidoc[]

--- a/winlogbeat/winlogbeat.full.yml
+++ b/winlogbeat/winlogbeat.full.yml
@@ -179,34 +179,37 @@ output.elasticsearch:
   # Path to the Elasticsearch 2.x version of the template file.
   #template.versions.2x.path: "${path.config}/winlogbeat.template-es2x.json"
 
+  # Use SSL settings for HTTPS. Default is true.
+  #ssl.enabled: true
 
-  # TLS configuration. By default is off.
+  # Configure SSL verification mode. If `none` is configured, all server hosts
+  # and certificates will be accepted. In this mode, SSL based connections are
+  # susceptible to man-in-the-middle attacks. Use only for testing. Default is
+  # `full`.
+  #ssl.verification_mode: full
+
+  # List of supported/valid TLS versions. By default all TLS versions 1.0 up to
+  # 1.2 are enabled.
+  #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
+
+  # SSL configuration. By default is off.
   # List of root certificates for HTTPS server verifications
-  #tls.certificate_authorities: ["/etc/pki/root/ca.pem"]
+  #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
-  # Certificate for TLS client authentication
-  #tls.certificate: "/etc/pki/client/cert.pem"
+  # Certificate for SSL client authentication
+  #ssl.certificate: "/etc/pki/client/cert.pem"
 
   # Client Certificate Key
-  #tls.certificate_key: "/etc/pki/client/cert.key"
+  #ssl.key: "/etc/pki/client/cert.key"
 
-  # Controls whether the client verifies server certificates and host name.
-  # If insecure is set to true, all server host names and certificates will be
-  # accepted. In this mode TLS based connections are susceptible to
-  # man-in-the-middle attacks. Use only for testing.
-  #tls.insecure: true
+  # Optional passphrase for decrypting the Certificate Key.
+  #ssl.key_passphrase: ''
 
-  # Configure cipher suites to be used for TLS connections
-  #tls.cipher_suites: []
+  # Configure cipher suites to be used for SSL connections
+  #ssl.cipher_suites: []
 
   # Configure curve types for ECDHE based cipher suites
-  #tls.curve_types: []
-
-  # Configure minimum TLS version allowed for connection to logstash
-  #tls.min_version: 1.0
-
-  # Configure maximum TLS version allowed for connection to logstash
-  #tls.max_version: 1.2
+  #ssl.curve_types: []
 
 
 #----------------------------- Logstash output --------------------------------
@@ -240,27 +243,37 @@ output.elasticsearch:
   # Resolve names locally when using a proxy server. Defaults to false.
   #proxy_use_local_resolver: false
 
-  # Optional TLS configuration options. TLS is off by default.
-  # List of root certificates for HTTPS server verifications
-  #tls.certificate_authorities: ["/etc/pki/root/ca.pem"]
+  # Enable SSL support. SSL is automatically enabled, if any SSL setting is set.
+  #ssl.enabled: true
 
-  # Certificate for TLS client authentication
-  #tls.certificate: "/etc/pki/client/cert.pem"
+  # Configure SSL verification mode. If `none` is configured, all server hosts
+  # and certificates will be accepted. In this mode, SSL based connections are
+  # susceptible to man-in-the-middle attacks. Use only for testing. Default is
+  # `full`.
+  #ssl.verification_mode: full
+
+  # List of supported/valid TLS versions. By default all TLS versions 1.0 up to
+  # 1.2 are enabled.
+  #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
+
+  # Optional SSL configuration options. SSL is off by default.
+  # List of root certificates for HTTPS server verifications
+  #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
+
+  # Certificate for SSL client authentication
+  #ssl.certificate: "/etc/pki/client/cert.pem"
 
   # Client Certificate Key
-  #tls.certificate_key: "/etc/pki/client/cert.key"
+  #ssl.key: "/etc/pki/client/cert.key"
 
-  # Controls whether the client verifies server certificates and host name.
-  # If insecure is set to true, all server host names and certificates will be
-  # accepted. In this mode TLS based connections are susceptible to
-  # man-in-the-middle attacks. Use only for testing.
-  #tls.insecure: true
+  # Optional passphrase for decrypting the Certificate Key.
+  #ssl.key_passphrase: ''
 
-  # Configure cipher suites to be used for TLS connections
-  #tls.cipher_suites: []
+  # Configure cipher suites to be used for SSL connections
+  #ssl.cipher_suites: []
 
   # Configure curve types for ECDHE based cipher suites
-  #tls.curve_types: []
+  #ssl.curve_types: []
 
 #------------------------------- Kafka output ---------------------------------
 #output.kafka:
@@ -365,27 +378,37 @@ output.elasticsearch:
   # purposes.  The default is "beats".
   #client_id: beats
 
-  # Optional TLS configuration options. TLS is off by default.
-  # List of root certificates for HTTPS server verifications
-  #tls.certificate_authorities: ["/etc/pki/root/ca.pem"]
+  # Enable SSL support. SSL is automatically enabled, if any SSL setting is set.
+  #ssl.enabled: true
 
-  # Certificate for TLS client authentication
-  #tls.certificate: "/etc/pki/client/cert.pem"
+  # Optional SSL configuration options. SSL is off by default.
+  # List of root certificates for HTTPS server verifications
+  #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
+
+  # Configure SSL verification mode. If `none` is configured, all server hosts
+  # and certificates will be accepted. In this mode, SSL based connections are
+  # susceptible to man-in-the-middle attacks. Use only for testing. Default is
+  # `full`.
+  #ssl.verification_mode: full
+
+  # List of supported/valid TLS versions. By default all TLS versions 1.0 up to
+  # 1.2 are enabled.
+  #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
+
+  # Certificate for SSL client authentication
+  #ssl.certificate: "/etc/pki/client/cert.pem"
 
   # Client Certificate Key
-  #tls.certificate_key: "/etc/pki/client/cert.key"
+  #ssl.key: "/etc/pki/client/cert.key"
 
-  # Controls whether the client verifies server certificates and host name.
-  # If insecure is set to true, all server host names and certificates will be
-  # accepted. In this mode TLS based connections are susceptible to
-  # man-in-the-middle attacks. Use only for testing.
-  #tls.insecure: true
+  # Optional passphrase for decrypting the Certificate Key.
+  #ssl.key_passphrase: ''
 
-  # Configure cipher suites to be used for TLS connections
-  #tls.cipher_suites: []
+  # Configure cipher suites to be used for SSL connections
+  #ssl.cipher_suites: []
 
   # Configure curve types for ECDHE based cipher suites
-  #tls.curve_types: []
+  #ssl.curve_types: []
 
 #------------------------------- Redis output ---------------------------------
 #output.redis:
@@ -452,27 +475,38 @@ output.elasticsearch:
   # occurs on the proxy server.
   #proxy_use_local_resolver: false
 
-  # Optional TLS configuration options. TLS is off by default.
-  # List of root certificates for HTTPS server verifications
-  #tls.certificate_authorities: ["/etc/pki/root/ca.pem"]
+  # Enable SSL support. SSL is automatically enabled, if any SSL setting is set.
+  #ssl.enabled: true
 
-  # Certificate for TLS client authentication
-  #tls.certificate: "/etc/pki/client/cert.pem"
+  # Configure SSL verification mode. If `none` is configured, all server hosts
+  # and certificates will be accepted. In this mode, SSL based connections are
+  # susceptible to man-in-the-middle attacks. Use only for testing. Default is
+  # `full`.
+  #ssl.verification_mode: full
+
+  # List of supported/valid TLS versions. By default all TLS versions 1.0 up to
+  # 1.2 are enabled.
+  #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
+
+  # Optional SSL configuration options. SSL is off by default.
+  # List of root certificates for HTTPS server verifications
+  #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
+
+  # Certificate for SSL client authentication
+  #ssl.certificate: "/etc/pki/client/cert.pem"
 
   # Client Certificate Key
-  #tls.certificate_key: "/etc/pki/client/cert.key"
+  #ssl.key: "/etc/pki/client/cert.key"
 
-  # Controls whether the client verifies server certificates and host name.
-  # If insecure is set to true, all server host names and certificates will be
-  # accepted. In this mode TLS based connections are susceptible to
-  # man-in-the-middle attacks. Use only for testing.
-  #tls.insecure: true
+  # Optional passphrase for decrypting the Certificate Key.
+  #ssl.key_passphrase: ''
 
-  # Configure cipher suites to be used for TLS connections
-  #tls.cipher_suites: []
+  # Configure cipher suites to be used for SSL connections
+  #ssl.cipher_suites: []
 
   # Configure curve types for ECDHE based cipher suites
-  #tls.curve_types: []
+  #ssl.curve_types: []
+
 
 #------------------------------- File output ----------------------------------
 #output.file:

--- a/winlogbeat/winlogbeat.yml
+++ b/winlogbeat/winlogbeat.yml
@@ -58,15 +58,15 @@ output.elasticsearch:
   # The Logstash hosts
   #hosts: ["localhost:5044"]
 
-  # Optional TLS. By default is off.
+  # Optional SSL. By default is off.
   # List of root certificates for HTTPS server verifications
-  #tls.certificate_authorities: ["/etc/pki/root/ca.pem"]
+  #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
-  # Certificate for TLS client authentication
-  #tls.certificate: "/etc/pki/client/cert.pem"
+  # Certificate for SSL client authentication
+  #ssl.certificate: "/etc/pki/client/cert.pem"
 
   # Client Certificate Key
-  #tls.certificate_key: "/etc/pki/client/cert.key"
+  #ssl.key: "/etc/pki/client/cert.key"
 
 #================================ Logging =====================================
 


### PR DESCRIPTION
rename tls to SSL + adapt some fields:

- `insecure` has become `verification_mode`. `insecure: false` is replaced by mode `full` and `insecure: true` by mode `none`.
- renamed `certificate_key` to `key`
- introduced `key_passphrase`
- replaced `min_version` and `max_version` with `supported_protocols` using an array of ok versions. New versions strings: `SSLv3`, `SSLV3.0`, `TLSv1` (use TLSv1.0), `TLSv1.0`, `TLSv1.1` and `TLSv1.2`


Changes:
- rewrite TLS dialer and TLS configuration
- add support for encrypted key files
- use TLS dialer with elasticsearch output (some more manual tests with and without system certificates required)
- update unit/integration tests to use new settings
- update default configuration files to use new ssl settings
- update documentation (docs URL did also change from `tls` to `ssl`)
- update migration script