### PR TITLE
Improve close_inactive error

### DIFF
--- a/filebeat/harvester/log.go
+++ b/filebeat/harvester/log.go
@@ -78,8 +78,10 @@ func (h *Harvester) Harvest() {
 				logp.Info("Reader was closed: %s. Closing.", h.state.Source)
 			case io.EOF:
 				logp.Info("End of file reached: %s. Closing because close_eof is enabled.", h.state.Source)
+			case ErrInactive:
+				logp.Info("File is inactive: %s. Closing because close_inactive of %v reached.", h.state.Source, h.config.CloseInactive)
 			default:
-				logp.Info("Read line error: %s", err)
+				logp.Err("Read line error: %s; File: ", err, h.state.Source)
 			}
 			return
 		}


### PR DESCRIPTION
Currently the close inactive error is not handled separately which shows errors in the log file which are not self explanatory. This is changed by handling the close_inactive error separately.

Default error was change to Log an error as this should not happen.