### PR TITLE
Fix make import-dashboards command

### DIFF
--- a/dev-tools/export_dashboards.py
+++ b/dev-tools/export_dashboards.py
@@ -76,10 +76,6 @@ def ExportIndex(es, index, kibana_index, output_directory):
         doc_type="index-pattern",
         id=index)
 
-    # Fixes windows problem with files with * inside
-    # Removes it from index pattern
-    doc['_id'] = doc['_id'][:-2]
-
     # save index-pattern
     SaveJson("index-pattern", doc, output_directory)
 
@@ -119,7 +115,7 @@ def main():
     args = parser.parse_args()
 
     if args.index is None:
-        args.index = args.beat.lower() + "-*"
+        args.index = args.beat.lower()
 
     print("Export {} dashboards to {} directory".format(args.beat, args.dir))
     print("Elasticsearch URL: {}".format(args.url))

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -275,8 +275,9 @@ export-dashboards: python-env
 	. ${PYTHON_ENV}/bin/activate && python ${ES_BEATS}/dev-tools/export_dashboards.py --url ${ES_URL} --dir $(shell pwd)/etc/kibana --beat ${BEATNAME}
 
 .PHONY: import-dashboards
-import-dashboards: build-dashboards
-	${ES_BEATS}/libbeat/dashboards/import_dashboards -es ${ES_URL} -dir $(shell pwd)/etc/kibana
+import-dashboards:
+	$(MAKE) -C ${ES_BEATS}/libbeat/dashboards import_dasboards
+	${ES_BEATS}/libbeat/dashboards/import_dashboards -es ${ES_URL} -dir ${PWD}/etc/kibana
 
 ### CONTAINER ENVIRONMENT ####
 


### PR DESCRIPTION
* Make sure binary is built before executing command
* Update export-dashboard script: Special treatment for windows is not needed anymore as the index pattern id does not contain -* anymore.