### PR TITLE
Add default logs directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /.idea
 /build
 /*/data
+/*/logs
 
 # Files
 .DS_Store


### PR DESCRIPTION
This has the side affect a a logs package (same as data package) cannot be used in any of our beats.