### PR TITLE
beatname.sh.j2: fix

### DIFF
--- a/dev-tools/packer/platforms/centos/beatname.sh.j2
+++ b/dev-tools/packer/platforms/centos/beatname.sh.j2
@@ -7,5 +7,5 @@
   -path.home /usr/share/{{.beat_name}} \
   -path.config /etc/{{.beat_name}} \
   -path.data /var/lib/{{.beat_name}} \
-  -path.log /var/log/{{.beat_name}} \
+  -path.logs /var/log/{{.beat_name}} \
   $@

--- a/dev-tools/packer/platforms/debian/beatname.sh.j2
+++ b/dev-tools/packer/platforms/debian/beatname.sh.j2
@@ -7,5 +7,5 @@
   -path.home /usr/share/{{.beat_name}} \
   -path.config /etc/{{.beat_name}} \
   -path.data /var/lib/{{.beat_name}} \
-  -path.log /var/log/{{.beat_name}} \
+  -path.logs /var/log/{{.beat_name}} \
   $@


### PR DESCRIPTION
Fix "flag provided but not defined: -path.log" when using the init script