### PR TITLE
Add tests for file truncation

### DIFF
--- a/filebeat/harvester/log.go
+++ b/filebeat/harvester/log.go
@@ -260,7 +260,7 @@ func (h *Harvester) close() {
 	if h.file != nil {
 
 		h.file.Close()
-		logp.Debug("harvester", "Stopping harvester, closing file: %s", h.state.Source)
+		logp.Debug("harvester", "Closing file: %s", h.state.Source)
 		harvesterOpenFiles.Add(-1)
 
 		// On completion, push offset so we can continue where we left off if we relaunch on the same file

--- a/filebeat/harvester/log_file.go
+++ b/filebeat/harvester/log_file.go
@@ -117,7 +117,7 @@ func (r *LogFile) errorChecks(err error) error {
 	// check if file was truncated
 	if info.Size() < r.offset {
 		logp.Debug("harvester",
-			"File was truncated as offset (%s) > size (%s): %s", r.offset, info.Size(), r.fs.Name())
+			"File was truncated as offset (%d) > size (%d): %s", r.offset, info.Size(), r.fs.Name())
 		return ErrFileTruncate
 	}
 

--- a/filebeat/tests/system/test_prospector.py
+++ b/filebeat/tests/system/test_prospector.py
@@ -239,7 +239,7 @@ class Test(BaseTest):
         # wait for file to be closed due to close_inactive
         self.wait_until(
             lambda: self.log_contains(
-                "Stopping harvester, closing file: {}\n".format(os.path.abspath(testfile))),
+                "Closing file: {}\n".format(os.path.abspath(testfile))),
             max_timeout=10)
 
         # wait a bit longer (on 1.0.1 this would cause the harvester
@@ -373,7 +373,7 @@ class Test(BaseTest):
         # wait for file to be closed due to close_inactive
         self.wait_until(
                 lambda: self.log_contains(
-                        "Stopping harvester, closing file: {}\n".format(os.path.abspath(testfile))),
+                        "Closing file: {}\n".format(os.path.abspath(testfile))),
                 max_timeout=10)
 
         # write second line
@@ -427,7 +427,7 @@ class Test(BaseTest):
         # wait for file to be closed due to close_inactive
         self.wait_until(
                 lambda: self.log_contains(
-                        "Stopping harvester, closing file: {}\n".format(os.path.abspath(testfile))),
+                        "Closing file: {}\n".format(os.path.abspath(testfile))),
                 max_timeout=10)
 
         filebeat.check_kill_and_wait()
@@ -475,7 +475,7 @@ class Test(BaseTest):
         self.wait_until(
                 lambda: self.log_contains(
                     # Still checking for old file name as filename does not change in harvester
-                    "Stopping harvester, closing file: "),
+                    "Closing file: "),
                 max_timeout=10)
 
         filebeat.check_kill_and_wait()
@@ -535,7 +535,7 @@ class Test(BaseTest):
         self.wait_until(
                 lambda: self.log_contains_count(
                         # Checking if two files were closed
-                        "Stopping harvester, closing file: ") == 2,
+                        "Closing file: ") == 2,
                 max_timeout=10)
 
         filebeat.check_kill_and_wait()


### PR DESCRIPTION
Test truncation of file when harvester is running and stopped. In case harvester is stopped, detection happens on the prospector side.