### PR TITLE
Fix wrong state update

### DIFF
--- a/filebeat/prospector/prospector_log.go
+++ b/filebeat/prospector/prospector_log.go
@@ -208,8 +208,8 @@ func (p *ProspectorLog) harvestExistingFile(newState file.State, oldState file.S
 		if oldState.Finished {
 			logp.Debug("prospector", "Updating state for renamed file: %s -> %s, Current offset: %v", oldState.Source, newState.Source, oldState.Offset)
 			// Update state because of file rotation
-			newState.Offset = oldState.Offset
-			event := input.NewEvent(newState)
+			oldState.Source = newState.Source
+			event := input.NewEvent(oldState)
 			p.Prospector.harvesterChan <- event
 
 			filesRenamed.Add(1)


### PR DESCRIPTION
As for renamed files the newState instead of the oldState was sent. As the newState was not finished, this prevented the states to be removed from the registry file