### PR TITLE
Change sha files format

### DIFF
--- a/dev-tools/packer/platforms/binary/run.sh.j2
+++ b/dev-tools/packer/platforms/binary/run.sh.j2
@@ -24,5 +24,5 @@ tar czvf upload/{{.beat_name}}-${VERSION}-linux-{{.bin_arch}}.tar.gz /{{.beat_na
 echo "Created upload/{{.beat_name}}-${VERSION}-linux-{{.bin_arch}}.tar.gz"
 
 cd upload
-sha1sum {{.beat_name}}-${VERSION}-linux-{{.bin_arch}}.tar.gz > {{.beat_name}}-${VERSION}-linux-{{.bin_arch}}.tar.gz.sha1.txt
-echo "Created upload/{{.beat_name}}-${VERSION}-linux-{{.bin_arch}}.tar.gz.sha1.txt"
+sha1sum {{.beat_name}}-${VERSION}-linux-{{.bin_arch}}.tar.gz | awk '{print $1;}' > {{.beat_name}}-${VERSION}-linux-{{.bin_arch}}.tar.gz.sha1
+echo "Created upload/{{.beat_name}}-${VERSION}-linux-{{.bin_arch}}.tar.gz.sha1"

--- a/dev-tools/packer/platforms/centos/run.sh.j2
+++ b/dev-tools/packer/platforms/centos/run.sh.j2
@@ -51,5 +51,5 @@ echo "Created upload/{{.beat_name}}-${VERSION}-{{.rpm_arch}}.rpm"
 
 # create sha1 file
 cd upload
-sha1sum {{.beat_name}}-${VERSION}-{{.rpm_arch}}.rpm > {{.beat_name}}-${VERSION}-{{.rpm_arch}}.rpm.sha1.txt
-echo "Created upload/{{.beat_name}}-${VERSION}-{{.rpm_arch}}.rpm.sha1.txt"
+sha1sum {{.beat_name}}-${VERSION}-{{.rpm_arch}}.rpm | awk '{print $1;}' > {{.beat_name}}-${VERSION}-{{.rpm_arch}}.rpm.sha1
+echo "Created upload/{{.beat_name}}-${VERSION}-{{.rpm_arch}}.rpm.sha1"

--- a/dev-tools/packer/platforms/darwin/run.sh.j2
+++ b/dev-tools/packer/platforms/darwin/run.sh.j2
@@ -24,5 +24,5 @@ tar czvf upload/{{.beat_name}}-${VERSION}-darwin-x86_64.tar.gz /{{.beat_name}}-$
 echo "Created upload/{{.beat_name}}-${VERSION}-darwin-x86_64.tar.gz"
 
 cd upload
-sha1sum {{.beat_name}}-${VERSION}-darwin-x86_64.tar.gz > {{.beat_name}}-${VERSION}-darwin-x86_64.tar.gz.sha1.txt
-echo "Created upload/{{.beat_name}}-${VERSION}-darwin-x86_64.tar.gz.sha1.txt"
+sha1sum {{.beat_name}}-${VERSION}-darwin-x86_64.tar.gz | awk '{print $1;}' > {{.beat_name}}-${VERSION}-darwin-x86_64.tar.gz.sha1
+echo "Created upload/{{.beat_name}}-${VERSION}-darwin-x86_64.tar.gz.sha1"

--- a/dev-tools/packer/platforms/dashboards/run.sh.j2
+++ b/dev-tools/packer/platforms/dashboards/run.sh.j2
@@ -19,5 +19,5 @@ zip -r upload/${BEATNAME:-beats}-dashboards-${VERSION}.zip /${BEATNAME:-beats}-d
 echo "Created upload/${BEATNAME:-beats}-dashboards-${VERSION}.zip"
 
 cd upload
-sha1sum ${BEATNAME:-beats}-dashboards-${VERSION}.zip > ${BEATNAME:-beats}-dashboards-${VERSION}.zip.sha1.txt
-echo "Created upload/${BEATNAME:-beats}-dashboards-${VERSION}.zip.sha1.txt"
+sha1sum ${BEATNAME:-beats}-dashboards-${VERSION}.zip | awk '{print $1;}' > ${BEATNAME:-beats}-dashboards-${VERSION}.zip.sha1
+echo "Created upload/${BEATNAME:-beats}-dashboards-${VERSION}.zip.sha1"

--- a/dev-tools/packer/platforms/debian/run.sh.j2
+++ b/dev-tools/packer/platforms/debian/run.sh.j2
@@ -46,5 +46,5 @@ echo "Created upload/{{.beat_name}}-${VERSION}-{{.deb_arch}}.deb"
 
 # create sha1 file
 cd upload
-sha1sum {{.beat_name}}-${VERSION}-{{.deb_arch}}.deb > {{.beat_name}}-${VERSION}-{{.deb_arch}}.deb.sha1.txt
-echo "Created upload/{{.beat_name}}-${VERSION}-{{.deb_arch}}.deb.sha1.txt"
+sha1sum {{.beat_name}}-${VERSION}-{{.deb_arch}}.deb | awk '{print $1;}' > {{.beat_name}}-${VERSION}-{{.deb_arch}}.deb.sha1
+echo "Created upload/{{.beat_name}}-${VERSION}-{{.deb_arch}}.deb.sha1"

--- a/dev-tools/packer/platforms/windows/run.sh.j2
+++ b/dev-tools/packer/platforms/windows/run.sh.j2
@@ -27,5 +27,5 @@ zip -r upload/{{.beat_name}}-${VERSION}-windows-{{.win_arch}}.zip /{{.beat_name}
 echo "Created upload/{{.beat_name}}-${VERSION}-windows-{{.win_arch}}.zip"
 
 cd upload
-sha1sum {{.beat_name}}-${VERSION}-windows-{{.win_arch}}.zip > {{.beat_name}}-${VERSION}-windows-{{.win_arch}}.zip.sha1.txt
-echo "Created upload/{{.beat_name}}-${VERSION}-windows-{{.win_arch}}.zip.sha1.txt"
+sha1sum {{.beat_name}}-${VERSION}-windows-{{.win_arch}}.zip | awk '{print $1;}' > {{.beat_name}}-${VERSION}-windows-{{.win_arch}}.zip.sha1
+echo "Created upload/{{.beat_name}}-${VERSION}-windows-{{.win_arch}}.zip.sha1"


### PR DESCRIPTION
The unified build process uses another format for the
SHA files, so aligning with that for easier testing. We'll
be able to remove our generation of sha1 files completely after we switch to using the unified build for snapshots as well.