### PR TITLE
Override default header for Dev Guide topics only (1.0.1)

### DIFF
--- a/libbeat/docs/index.asciidoc
+++ b/libbeat/docs/index.asciidoc
@@ -18,7 +18,11 @@ include::./command-line.asciidoc[]
 
 include::./https.asciidoc[]
 
+pass::[<?page_header <b>PLEASE NOTE:</b><br/>Always refer to the documentation in master for the latest information about contributing to Beats.?>]
+
 include::./newbeat.asciidoc[]
+
+pass::[<?page_header ?>]
 
 include::./repositories.asciidoc[]
 


### PR DESCRIPTION
We don't want the Dev Guide to show the default header, which says: "PLEASE NOTE: This page is for an older version of the software. Check out the latest version's documentation here." 

This PR overrides the header in the dev guide topics so that users don't inadvertently go to current only to discover that they really need to go to master. :-)