### PR TITLE
Override default header for Dev Guide topics only (master)

### DIFF
--- a/libbeat/docs/index.asciidoc
+++ b/libbeat/docs/index.asciidoc
@@ -28,10 +28,14 @@ include::./visualizing-data.asciidoc[]
 
 include::./dashboards.asciidoc[]
 
+pass::[<?page_header <b>PLEASE NOTE:</b><br/>Always refer to the documentation in master for the latest information about contributing to Beats.?>]
+
 include::./newbeat.asciidoc[]
 
 include::./event-conventions.asciidoc[]
 
 include::./newdashboards.asciidoc[]
+
+pass::[<?page_header ?>]
 
 include::./release.asciidoc[]


### PR DESCRIPTION
We don't want the Dev Guide to show the default header, which says: "This page is for an as yet unreleased version of the software. Check out the latest version's documentation here. 

This PR overrides the header in the dev guide topics so that users aren't confused when they go to master and see the above message.