### PR TITLE
Update to most recent stable releases for testing

### DIFF
--- a/libbeat/outputs/elasticsearch/api_integration_test.go
+++ b/libbeat/outputs/elasticsearch/api_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/elastic/beats/libbeat/logp"
@@ -76,6 +77,10 @@ func TestIngest(t *testing.T) {
 	}
 
 	client := GetTestingElasticsearch()
+	if strings.HasPrefix(client.Connection.version, "2.") {
+		t.Skip("Skipping tests as pipeline not available in 2.x releases")
+	}
+
 	_, _, err := client.DeletePipeline(pipeline, nil)
 
 	_, resp, err := client.CreatePipeline(pipeline, nil, pipelineBody)

--- a/libbeat/outputs/elasticsearch/api_test.go
+++ b/libbeat/outputs/elasticsearch/api_test.go
@@ -38,7 +38,11 @@ func GetTestingElasticsearch() *Client {
 	var address = "http://" + GetEsHost() + ":" + GetEsPort()
 	username := os.Getenv("ES_USER")
 	pass := os.Getenv("ES_PASS")
-	return newTestClientAuth(address, username, pass)
+	client := newTestClientAuth(address, username, pass)
+
+	// Load version number
+	client.Connect(3 * time.Second)
+	return client
 }
 
 func GetValidQueryResult() QueryResult {

--- a/testing/environments/docker/elasticsearch/Dockerfile-2.4.0
+++ b/testing/environments/docker/elasticsearch/Dockerfile-2.4.0
@@ -12,10 +12,12 @@ RUN arch="$(dpkg --print-architecture)" \
 
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 46095ACC8548582C1A2699A9D27D666CD88E42B4
 
-ENV ELASTICSEARCH_MAJOR 2.3
-ENV ELASTICSEARCH_VERSION 2.3.5
+ENV ELASTICSEARCH_MAJOR 2.4
+ENV ELASTICSEARCH_VERSION 2.4.0
 
-RUN wget https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/${ELASTICSEARCH_VERSION}/elasticsearch-${ELASTICSEARCH_VERSION}.deb
+RUN wget https://download.elasticsearch.org/elasticsearch/staging/2.4.0-7a922b6/org/elasticsearch/distribution/deb/elasticsearch/2.4.0/elasticsearch-2.4.0.deb
+
+#RUN wget https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/${ELASTICSEARCH_VERSION}/elasticsearch-${ELASTICSEARCH_VERSION}.deb
 
 RUN dpkg -i elasticsearch-${ELASTICSEARCH_VERSION}.deb
 
@@ -37,8 +39,6 @@ COPY config /usr/share/elasticsearch/config
 VOLUME /usr/share/elasticsearch/data
 
 COPY docker-entrypoint.sh /
-
-ENTRYPOINT ["/docker-entrypoint.sh"]
 
 EXPOSE 9200 9300
 

--- a/testing/environments/docker/elasticsearch/config/elasticsearch.yml
+++ b/testing/environments/docker/elasticsearch/config/elasticsearch.yml
@@ -1,0 +1,1 @@
+http.compression: true

--- a/testing/environments/docker/kibana/Dockerfile-4.6.0
+++ b/testing/environments/docker/kibana/Dockerfile-4.6.0
@@ -15,10 +15,10 @@ RUN arch="$(dpkg --print-architecture)" \
 	&& rm /usr/local/bin/gosu.asc \
 	&& chmod +x /usr/local/bin/gosu
 
-ENV KIBANA_VERSION 4.5.4
+ENV KIBANA_VERSION 4.6.0
 
 RUN set -x \
-	&& curl -fSL "https://download.elastic.co/kibana/kibana/kibana-${KIBANA_VERSION}-linux-x64.tar.gz" -o kibana.tar.gz \
+	&& curl -fSL "https://download.elastic.co/kibana/staging/4.6.0-6b8ddde/kibana/kibana-4.6.0-linux-x86_64.tar.gz" -o kibana.tar.gz \
 	&& mkdir -p /opt/kibana \
 	&& tar -xz --strip-components=1 -C /opt/kibana -f kibana.tar.gz \
 	&& chown -R kibana:kibana /opt/kibana \
@@ -30,6 +30,7 @@ COPY ./docker-entrypoint.sh /
 
 RUN gosu kibana kibana plugin --install elastic/sense
 RUN gosu kibana kibana plugin --install kibana/timelion
+RUN gosu kibana kibana plugin --install kibana/reporting/2.4.0-SNAPSHOT
 
 EXPOSE 5601
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/testing/environments/docker/logstash/Dockerfile-2.4.0
+++ b/testing/environments/docker/logstash/Dockerfile-2.4.0
@@ -2,7 +2,7 @@ FROM java:8-jre
 
 ENV LS_VERSION 2
 
-ENV DEB_URL https://download.elastic.co/logstash/logstash/packages/debian/logstash_2.3.4-1_all.deb
+ENV DEB_URL https://download.elastic.co/logstash/logstash/packages/debian/logstash-2.4.0.snapshot3_all.deb
 
 ENV PATH $PATH:/opt/logstash/bin:/opt/logstash/vendor/jruby/bin
 

--- a/testing/environments/latest.yml
+++ b/testing/environments/latest.yml
@@ -3,13 +3,13 @@
 
 elasticsearch:
   build: docker/elasticsearch
-  dockerfile: Dockerfile-2.3.0
+  dockerfile: Dockerfile-2.4.0
   command: elasticsearch -Des.network.host=0.0.0.0
 
 logstash:
   build: docker/logstash
-  dockerfile: Dockerfile-2.3.0
+  dockerfile: Dockerfile-2.4.0
 
 kibana:
   build: docker/kibana/
-  dockerfile: Dockerfile-4.5.0
+  dockerfile: Dockerfile-4.6.0


### PR DESCRIPTION
* Run tests by using `TESTING_ENVIRONMENT=latest make integration-tests-environment`
* Fix tests to also work with elasticsearch 2.x