### PR TITLE
Add overview links to dashboard container topic

### DIFF
--- a/libbeat/docs/visualizing-data.asciidoc
+++ b/libbeat/docs/visualizing-data.asciidoc
@@ -3,3 +3,9 @@
 
 This section describes how to load the sample Beats dashboards. After loading
 the dashboards in Kibana, you can modify them to meet your needs. 
+
+This section includes the following topics:
+
+* <<load-kibana-dashboards>>
+* <<dashboard-load-options>>
+* <<view-kibana-dashboards>>


### PR DESCRIPTION
This PR doesn't solve #1943, but it will at least help users understand that the topic about Loading Beats dashboards is a sub-topic under Visualizing Data in Kibana.

It's true that you can see the nested structure of the topics in the TOC, but this isn't obvious, especially to new users.