### PR TITLE
Generic event conversion of pointers, arrays, slices

### DIFF
--- a/filebeat/tests/system/test_json.py
+++ b/filebeat/tests/system/test_json.py
@@ -289,7 +289,9 @@ class Test(BaseTest):
 
         assert "headers.content-type" in o
         assert "headers.request-id" not in o
-        assert o["res"] is None
+
+        # We drop null values during the generic event conversion.
+        assert "res" not in o
 
     def test_with_generic_filtering_remove_headers(self):
         """

--- a/libbeat/common/event.go
+++ b/libbeat/common/event.go
@@ -1,92 +1,223 @@
 package common
 
 import (
+	"encoding"
 	"encoding/json"
+	"fmt"
 	"reflect"
-	"time"
+	"strconv"
+	"strings"
 
 	"github.com/elastic/beats/libbeat/logp"
+
+	"github.com/pkg/errors"
 )
 
-func MarshallUnmarshall(v interface{}) (MapStr, error) {
-	// decode and encode JSON
-	marshaled, err := json.Marshal(v)
-	if err != nil {
-		logp.Warn("marshal err: %v", err)
-		return nil, err
-	}
-	var v1 MapStr
-	err = json.Unmarshal(marshaled, &v1)
-	if err != nil {
-		logp.Warn("unmarshal err: %v", err)
-		return nil, err
-	}
+const eventDebugSelector = "event"
 
-	return v1, nil
+var eventDebugf = logp.MakeDebug(eventDebugSelector)
+
+var textMarshalerType = reflect.TypeOf((*encoding.TextMarshaler)(nil)).Elem()
+
+// ConvertToGenericEvent normalizes the types contained in the given MapStr.
+//
+// Nil values in maps are dropped during the conversion. Any unsupported types
+// that are found in the MapStr are dropped and warnings are logged.
+func ConvertToGenericEvent(m MapStr) MapStr {
+	event, errs := normalizeMap("", m)
+	if len(errs) > 0 {
+		logp.Warn("Unsuccessful conversion to generic event: %v errors: %v, "+
+			"event=%#v", len(errs), errs, m)
+	}
+	return event
 }
 
-func ConvertToGenericEvent(v MapStr) MapStr {
+// normalizeMap normalizes each element contained in the given map. If an error
+// occurs during normalization, processing of m will continue, and all errors
+// are returned at the end.
+func normalizeMap(baseKey string, m MapStr) (MapStr, []error) {
+	var errs []error
 
-	for key, value := range v {
+	out := make(MapStr, len(m))
+	for key, value := range m {
+		fullKey := joinKeys(baseKey, key)
+		v, err := normalizeValue(fullKey, value)
+		if len(err) > 0 {
+			errs = append(errs, err...)
+		}
 
-		if value == nil {
-			// leave nil values alone
+		// Drop nil values from maps.
+		if v == nil {
+			if logp.IsDebug(eventDebugSelector) {
+				eventDebugf("Dropped nil value from event where key=%v", fullKey)
+			}
 			continue
 		}
 
-		switch value.(type) {
-		case Time, *Time:
-			continue
-		case time.Location, *time.Location:
-			continue
-		case MapStr:
-			v[key] = ConvertToGenericEvent(value.(MapStr))
-			continue
-		case *MapStr:
-			v[key] = ConvertToGenericEvent(*value.(*MapStr))
-			continue
+		out[key] = v
+	}
+
+	return out, errs
+}
+
+// normalizeMapStrSlice normalizes each individual MapStr.
+func normalizeMapStrSlice(baseKey string, maps []MapStr) ([]MapStr, []error) {
+	var errs []error
+
+	out := make([]MapStr, 0, len(maps))
+	for i, m := range maps {
+		normalizedMap, err := normalizeMap(joinKeys(baseKey, strconv.Itoa(i)), m)
+		if len(err) > 0 {
+			errs = append(errs, err...)
+		}
+		out = append(out, normalizedMap)
+	}
+
+	return out, errs
+}
+
+// normalizeMapStringSlice normalizes each individual map[string]interface{} and
+// returns a []MapStr.
+func normalizeMapStringSlice(baseKey string, maps []map[string]interface{}) ([]MapStr, []error) {
+	var errs []error
+
+	out := make([]MapStr, 0, len(maps))
+	for i, m := range maps {
+		normalizedMap, err := normalizeMap(joinKeys(baseKey, strconv.Itoa(i)), m)
+		if len(err) > 0 {
+			errs = append(errs, err...)
+		}
+		out = append(out, normalizedMap)
+	}
+
+	return out, errs
+}
+
+// normalizeSlice normalizes each element of the slice and returns a []interface{}.
+func normalizeSlice(baseKey string, v reflect.Value) (interface{}, []error) {
+	var errs []error
+	var sliceValues []interface{}
+
+	n := v.Len()
+	for i := 0; i < n; i++ {
+		sliceValue, err := normalizeValue(joinKeys(baseKey, strconv.Itoa(i)), v.Index(i).Interface())
+		if len(err) > 0 {
+			errs = append(errs, err...)
+		}
+
+		sliceValues = append(sliceValues, sliceValue)
+	}
+
+	return sliceValues, errs
+}
+
+func normalizeValue(key string, value interface{}) (interface{}, []error) {
+	// Dereference pointers.
+	value = followPointer(value)
+
+	if value == nil {
+		return nil, nil
+	}
+
+	switch value.(type) {
+	case encoding.TextMarshaler:
+		text, err := value.(encoding.TextMarshaler).MarshalText()
+		if err != nil {
+			return nil, []error{errors.Wrapf(err, "key=%v: error converting %T to string", key, value)}
+		}
+		return string(text), nil
+	case bool, []bool:
+	case int, int8, int16, int32, int64:
+	case []int, []int8, []int16, []int32, []int64:
+	case uint, uint8, uint16, uint32, uint64:
+	case []uint, []uint8, []uint16, []uint32, []uint64:
+	case float32, float64:
+	case []float32, []float64:
+	case complex64, complex128:
+	case []complex64, []complex128:
+	case string, []string:
+	case Time, []Time:
+	case MapStr:
+		return normalizeMap(key, value.(MapStr))
+	case []MapStr:
+		return normalizeMapStrSlice(key, value.([]MapStr))
+	case map[string]interface{}:
+		return normalizeMap(key, value.(map[string]interface{}))
+	case []map[string]interface{}:
+		return normalizeMapStringSlice(key, value.([]map[string]interface{}))
+	default:
+		v := reflect.ValueOf(value)
+
+		switch v.Type().Kind() {
+		case reflect.Bool:
+			return v.Bool(), nil
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			return v.Int(), nil
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			return v.Uint(), nil
+		case reflect.Float32, reflect.Float64:
+			return v.Float(), nil
+		case reflect.Complex64, reflect.Complex128:
+			return v.Complex(), nil
+		case reflect.String:
+			return v.String(), nil
+		case reflect.Array, reflect.Slice:
+			return normalizeSlice(key, v)
+		case reflect.Map, reflect.Struct:
+			var m MapStr
+			err := marshalUnmarshal(value, &m)
+			if err != nil {
+				return m, []error{errors.Wrapf(err, "key=%v: error converting %T to MapStr", key, value)}
+			}
+			return m, nil
 		default:
-
-			typ := reflect.TypeOf(value)
-
-			if typ.Kind() == reflect.Ptr {
-				typ = typ.Elem()
-			}
-
-			switch typ.Kind() {
-			case reflect.Bool:
-			case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-			case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-			case reflect.Uintptr:
-			case reflect.Float32, reflect.Float64:
-			case reflect.Complex64, reflect.Complex128:
-			case reflect.String:
-			case reflect.UnsafePointer:
-			case reflect.Array, reflect.Slice:
-			//case reflect.Chan:
-			//case reflect.Func:
-			//case reflect.Interface:
-			case reflect.Map:
-				anothermap, err := MarshallUnmarshall(value)
-				if err != nil {
-					logp.Warn("fail to marshall & unmarshall map (%v): key=%v value=%#v",
-						key, value)
-					continue
-				}
-				v[key] = anothermap
-
-			case reflect.Struct:
-				anothermap, err := MarshallUnmarshall(value)
-				if err != nil {
-					logp.Warn("fail to marshall & unmarshall struct %v", key)
-					continue
-				}
-				v[key] = anothermap
-			default:
-				logp.Warn("unknown type %v", typ)
-				continue
-			}
+			// Drop Uintptr, UnsafePointer, Chan, Func, Interface, and any other
+			// types not specifically handled above.
+			return nil, []error{fmt.Errorf("key=%v: error unsupported type=%T value=%#v", key, value, value)}
 		}
 	}
-	return v
+
+	return value, nil
+}
+
+// marshalUnmarshal converts an interface to a MapStr by marshalling to JSON
+// then unmarshalling the JSON object into a MapStr.
+func marshalUnmarshal(in interface{}, out interface{}) error {
+	// Decode and encode as JSON to normalized the types.
+	marshaled, err := json.Marshal(in)
+	if err != nil {
+		return errors.Wrap(err, "error marshalling to JSON")
+	}
+	err = json.Unmarshal(marshaled, out)
+	if err != nil {
+		return errors.Wrap(err, "error unmarshalling from JSON")
+	}
+
+	return nil
+}
+
+// followPointer accepts an interface{} and if the interface is a pointer then
+// the value that v points to is returned. If v is not a pointer then v is
+// returned.
+func followPointer(v interface{}) interface{} {
+	if v == nil || reflect.TypeOf(v).Kind() != reflect.Ptr {
+		return v
+	}
+
+	val := reflect.ValueOf(v)
+	if val.IsNil() {
+		return nil
+	}
+
+	return val.Elem().Interface()
+}
+
+// joinKeys concatenates the keys into a single string with each key separated
+// by a dot.
+func joinKeys(keys ...string) string {
+	// Strip leading empty string.
+	if len(keys) > 0 && keys[0] == "" {
+		keys = keys[1:]
+	}
+	return strings.Join(keys, ".")
 }

--- a/libbeat/common/event.go
+++ b/libbeat/common/event.go
@@ -112,8 +112,6 @@ func normalizeSlice(baseKey string, v reflect.Value) (interface{}, []error) {
 }
 
 func normalizeValue(key string, value interface{}) (interface{}, []error) {
-	// Dereference pointers.
-	value = followPointer(value)
 
 	if value == nil {
 		return nil, nil
@@ -149,6 +147,9 @@ func normalizeValue(key string, value interface{}) (interface{}, []error) {
 		v := reflect.ValueOf(value)
 
 		switch v.Type().Kind() {
+		case reflect.Ptr:
+			// Dereference pointers.
+			return normalizeValue(key, followPointer(value))
 		case reflect.Bool:
 			return v.Bool(), nil
 		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:

--- a/libbeat/common/event_test.go
+++ b/libbeat/common/event_test.go
@@ -224,7 +224,7 @@ func TestNormalizeValue(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		out, err := normalizeValue("", test.in)
+		out, err := normalizeValue(test.in)
 		if err != nil {
 			t.Error(err)
 			continue
@@ -242,7 +242,7 @@ func TestNormalizeMapError(t *testing.T) {
 	}
 
 	for i, in := range badInputs {
-		_, errs := normalizeMap("bad.type", in)
+		_, errs := normalizeMap(in, "bad.type")
 		if assert.Len(t, errs, 1) {
 			t.Log(errs[0])
 			assert.Contains(t, errs[0].Error(), "key=bad.type", "Test case %v", i)

--- a/libbeat/common/event_test.go
+++ b/libbeat/common/event_test.go
@@ -18,7 +18,7 @@ func TestConvertNestedMapStr(t *testing.T) {
 	type String string
 
 	tests := []io{
-		io{
+		{
 			Input: MapStr{
 				"key": MapStr{
 					"key1": "value1",
@@ -30,7 +30,7 @@ func TestConvertNestedMapStr(t *testing.T) {
 				},
 			},
 		},
-		io{
+		{
 			Input: MapStr{
 				"key": MapStr{
 					"key1": String("value1"),
@@ -38,11 +38,11 @@ func TestConvertNestedMapStr(t *testing.T) {
 			},
 			Output: MapStr{
 				"key": MapStr{
-					"key1": String("value1"),
+					"key1": "value1",
 				},
 			},
 		},
-		io{
+		{
 			Input: MapStr{
 				"key": MapStr{
 					"key1": []string{"value1", "value2"},
@@ -54,7 +54,7 @@ func TestConvertNestedMapStr(t *testing.T) {
 				},
 			},
 		},
-		io{
+		{
 			Input: MapStr{
 				"key": MapStr{
 					"key1": []String{"value1", "value2"},
@@ -62,11 +62,11 @@ func TestConvertNestedMapStr(t *testing.T) {
 			},
 			Output: MapStr{
 				"key": MapStr{
-					"key1": []String{"value1", "value2"},
+					"key1": []interface{}{"value1", "value2"},
 				},
 			},
 		},
-		io{
+		{
 			Input: MapStr{
 				"@timestamp": MustParseTime("2015-03-01T12:34:56.123Z"),
 			},
@@ -74,18 +74,46 @@ func TestConvertNestedMapStr(t *testing.T) {
 				"@timestamp": MustParseTime("2015-03-01T12:34:56.123Z"),
 			},
 		},
-		io{
+		{
 			Input: MapStr{
-				"env": nil,
+				"env":  nil,
+				"key2": uintptr(88),
+				"key3": func() { t.Log("hello") },
+			},
+			Output: MapStr{},
+		},
+		{
+			Input: MapStr{
+				"key": []MapStr{
+					{"keyX": []String{"value1", "value2"}},
+				},
 			},
 			Output: MapStr{
-				"env": nil,
+				"key": []MapStr{
+					{"keyX": []interface{}{"value1", "value2"}},
+				},
 			},
+		},
+		{
+			Input: MapStr{
+				"key": []interface{}{
+					MapStr{"key1": []string{"value1", "value2"}},
+				},
+			},
+			Output: MapStr{
+				"key": []interface{}{
+					MapStr{"key1": []string{"value1", "value2"}},
+				},
+			},
+		},
+		{
+			MapStr{"k": map[string]int{"hits": 1}},
+			MapStr{"k": MapStr{"hits": float64(1)}},
 		},
 	}
 
-	for _, test := range tests {
-		assert.EqualValues(t, test.Output, ConvertToGenericEvent(test.Input))
+	for i, test := range tests {
+		assert.Equal(t, test.Output, ConvertToGenericEvent(test.Input), "Test case %d", i)
 	}
 
 }
@@ -104,7 +132,7 @@ func TestConvertNestedStruct(t *testing.T) {
 	}
 
 	tests := []io{
-		io{
+		{
 			Input: MapStr{
 				"key": MapStr{
 					"key1": TestStruct{
@@ -122,10 +150,149 @@ func TestConvertNestedStruct(t *testing.T) {
 				},
 			},
 		},
+		{
+			Input: MapStr{
+				"key": []interface{}{
+					TestStruct{
+						A: "hello",
+						B: 5,
+					},
+				},
+			},
+			Output: MapStr{
+				"key": []interface{}{
+					MapStr{
+						"A": "hello",
+						"B": float64(5),
+					},
+				},
+			},
+		},
 	}
 
-	for _, test := range tests {
-		assert.EqualValues(t, test.Output, ConvertToGenericEvent(test.Input))
+	for i, test := range tests {
+		assert.EqualValues(t, test.Output, ConvertToGenericEvent(test.Input), "Test case %v", i)
+	}
+}
+
+func TestNormalizeValue(t *testing.T) {
+	logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"*"})
+
+	var nilStringPtr *string
+	someString := "foo"
+
+	type mybool bool
+	type myint int32
+	type myuint uint8
+
+	var tests = []struct {
+		in  interface{}
+		out interface{}
+	}{
+		{nil, nil},
+		{&someString, someString},   // Pointers are dereferenced.
+		{nilStringPtr, nil},         // Nil pointers are dropped.
+		{NetString("test"), "test"}, // It honors the TextMarshaler contract.
+		{true, true},
+		{int8(8), int8(8)},
+		{uint8(8), uint8(8)},
+		{"hello", "hello"},
+		{map[string]interface{}{"foo": "bar"}, MapStr{"foo": "bar"}},
+
+		// Other map types are converted using marshalUnmarshal which will lose
+		// type information for arrays which become []interface{} and numbers
+		// which all become float64.
+		{map[string]string{"foo": "bar"}, MapStr{"foo": "bar"}},
+		{map[string][]string{"list": {"foo", "bar"}}, MapStr{"list": []interface{}{"foo", "bar"}}},
+
+		{[]string{"foo", "bar"}, []string{"foo", "bar"}},
+		{[]bool{true, false}, []bool{true, false}},
+		{[]string{"foo", "bar"}, []string{"foo", "bar"}},
+		{[]int{10, 11}, []int{10, 11}},
+		{[]MapStr{{"foo": "bar"}}, []MapStr{{"foo": "bar"}}},
+		{[]map[string]interface{}{{"foo": "bar"}}, []MapStr{{"foo": "bar"}}},
+
+		// Wrapper types are converted to primitives using reflection.
+		{mybool(true), true},
+		{myint(32), int64(32)},
+		{myuint(8), uint64(8)},
+
+		// Slices of wrapper types are converted to an []interface{} of primitives.
+		{[]mybool{true, false}, []interface{}{true, false}},
+		{[]myint{32}, []interface{}{int64(32)}},
+		{[]myuint{8}, []interface{}{uint64(8)}},
 	}
 
+	for i, test := range tests {
+		out, err := normalizeValue("", test.in)
+		if err != nil {
+			t.Error(err)
+			continue
+		}
+
+		assert.Equal(t, test.out, out, "Test case %v", i)
+	}
+}
+
+func TestNormalizeMapError(t *testing.T) {
+	badInputs := []MapStr{
+		{"func": func() {}},
+		{"chan": make(chan struct{})},
+		{"uintptr": uintptr(123)},
+	}
+
+	for i, in := range badInputs {
+		_, errs := normalizeMap("bad.type", in)
+		if assert.Len(t, errs, 1) {
+			t.Log(errs[0])
+			assert.Contains(t, errs[0].Error(), "key=bad.type", "Test case %v", i)
+		}
+	}
+}
+
+func TestJoinKeys(t *testing.T) {
+	assert.Equal(t, "", joinKeys(""))
+	assert.Equal(t, "co", joinKeys("co"))
+	assert.Equal(t, "co.elastic", joinKeys("", "co", "elastic"))
+	assert.Equal(t, "co.elastic", joinKeys("co", "elastic"))
+}
+
+func TestMarshalUnmarshalMap(t *testing.T) {
+	tests := []struct {
+		in  MapStr
+		out MapStr
+	}{
+		{MapStr{"names": []string{"a", "b"}}, MapStr{"names": []interface{}{"a", "b"}}},
+	}
+
+	for i, test := range tests {
+		var out MapStr
+		err := marshalUnmarshal(test.in, &out)
+		if err != nil {
+			t.Error(err)
+			continue
+		}
+
+		assert.Equal(t, test.out, out, "Test case %v", i)
+	}
+}
+
+func TestMarshalUnmarshalArray(t *testing.T) {
+	tests := []struct {
+		in  interface{}
+		out interface{}
+	}{
+		{[]string{"a", "b"}, []interface{}{"a", "b"}},
+	}
+
+	for i, test := range tests {
+		var out interface{}
+		err := marshalUnmarshal(test.in, &out)
+		if err != nil {
+			t.Error(err)
+			continue
+		}
+
+		assert.Equal(t, test.out, out, "Test case %v", i)
+	}
 }

--- a/libbeat/common/event_test.go
+++ b/libbeat/common/event_test.go
@@ -296,3 +296,47 @@ func TestMarshalUnmarshalArray(t *testing.T) {
 		assert.Equal(t, test.out, out, "Test case %v", i)
 	}
 }
+
+// Uses TextMarshaler interface.
+func BenchmarkConvertToGenericEventNetString(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		ConvertToGenericEvent(MapStr{"key": NetString("hola")})
+	}
+}
+
+// Uses reflection.
+func BenchmarkConvertToGenericEventMapStringString(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		ConvertToGenericEvent(MapStr{"key": map[string]string{"greeting": "hola"}})
+	}
+}
+
+// Uses recursion to step into the nested MapStr.
+func BenchmarkConvertToGenericEventMapStr(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		ConvertToGenericEvent(MapStr{"key": map[string]interface{}{"greeting": "hola"}})
+	}
+}
+
+// No reflection required.
+func BenchmarkConvertToGenericEventStringSlice(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		ConvertToGenericEvent(MapStr{"key": []string{"foo", "bar"}})
+	}
+}
+
+// Uses reflection to convert the string array.
+func BenchmarkConvertToGenericEventCustomStringSlice(b *testing.B) {
+	type myString string
+	for i := 0; i < b.N; i++ {
+		ConvertToGenericEvent(MapStr{"key": []myString{"foo", "bar"}})
+	}
+}
+
+// Pointers require reflection to generically dereference.
+func BenchmarkConvertToGenericEventStringPointer(b *testing.B) {
+	val := "foo"
+	for i := 0; i < b.N; i++ {
+		ConvertToGenericEvent(MapStr{"key": &val})
+	}
+}

--- a/libbeat/processors/condition.go
+++ b/libbeat/processors/condition.go
@@ -281,10 +281,6 @@ outer:
 			if !strings.Contains(value.(string), equalValue) {
 				return false
 			}
-		case *string:
-			if !strings.Contains(*value.(*string), equalValue) {
-				return false
-			}
 		case []string:
 			for _, s := range value.([]string) {
 				if strings.Contains(s, equalValue) {

--- a/libbeat/processors/config.go
+++ b/libbeat/processors/config.go
@@ -126,8 +126,6 @@ func extractString(unk interface{}) (string, error) {
 	switch s := unk.(type) {
 	case string:
 		return s, nil
-	case *string:
-		return *s, nil
 	default:
 		return "", fmt.Errorf("unknown type %T passed to extractString", unk)
 	}

--- a/libbeat/processors/config_test.go
+++ b/libbeat/processors/config_test.go
@@ -14,10 +14,4 @@ func TestExtractString(t *testing.T) {
 		t.Fatal(err)
 	}
 	assert.Equal(t, input, v)
-
-	v, err = extractString(&input)
-	if err != nil {
-		t.Fatal(err)
-	}
-	assert.Equal(t, input, v)
 }

--- a/packetbeat/protos/memcache/memcache.go
+++ b/packetbeat/protos/memcache/memcache.go
@@ -449,9 +449,8 @@ func (mc memcacheString) String() string {
 	return string(mc.raw)
 }
 
-func (mc memcacheString) MarshalJSON() ([]byte, error) {
-	s := string(mc.raw)
-	return json.Marshal(s)
+func (mc memcacheString) MarshalText() ([]byte, error) {
+	return mc.raw, nil
 }
 
 func (mc memcacheData) String() string {


### PR DESCRIPTION
Changes
- Dereference any pointers in the event.
- Apply generic event conversion to arrays and slices in the event.
- Drop nil values from MapStr. This does not apply to arrays, structs, or map types converted via JSON marshal/unmarshal.
- Drop keys containing values of unknown types (previously it only logged a warning).
- Provide a detailed warning when the generic event conversion is unsuccessful. A message is logged contained the map key that failed, the cause, and the event (for context).
- Due to the enhancement to normalize types in arrays, a change was required in Packetbeat's memcache proto.
- Changed a test case in Filebeat to not expect a null value.