### PR TITLE
Merge defaults for publisher queue_size and bulk_queue_size

### DIFF
--- a/filebeat/filebeat.full.yml
+++ b/filebeat/filebeat.full.yml
@@ -260,6 +260,10 @@ filebeat.prospectors:
 # Internal queue size for single events in processing pipeline
 #queue_size: 1000
 
+# The internal queue size for bulk events in the processing pipeline.
+# Do not modify this value.
+#bulk_queue_size: 0
+
 # Sets the maximum number of CPUs that can be executing simultaneously. The
 # default is the number of logical CPUs available in the system.
 #max_procs:

--- a/libbeat/_meta/config.full.yml
+++ b/libbeat/_meta/config.full.yml
@@ -36,6 +36,10 @@
 # Internal queue size for single events in processing pipeline
 #queue_size: 1000
 
+# The internal queue size for bulk events in the processing pipeline.
+# Do not modify this value.
+#bulk_queue_size: 0
+
 # Sets the maximum number of CPUs that can be executing simultaneously. The
 # default is the number of logical CPUs available in the system.
 #max_procs:

--- a/libbeat/publisher/common_test.go
+++ b/libbeat/publisher/common_test.go
@@ -160,12 +160,12 @@ func newTestPublisher(bulkSize int, response OutputResponse) *testPublisher {
 	ow := &outputWorker{}
 	ow.config.BulkMaxSize = bulkSize
 	ow.handler = mh
-	ow.messageWorker.init(&pub.wsOutput, defaultChanSize, defaultBulkChanSize, mh)
+	ow.messageWorker.init(&pub.wsOutput, DefaultQueueSize, DefaultBulkQueueSize, mh)
 
 	pub.Output = []*outputWorker{ow}
 
-	pub.pipelines.sync = newSyncPipeline(pub, defaultChanSize, defaultBulkChanSize)
-	pub.pipelines.async = newAsyncPipeline(pub, defaultChanSize, defaultBulkChanSize, &pub.wsPublisher)
+	pub.pipelines.sync = newSyncPipeline(pub, DefaultQueueSize, DefaultBulkQueueSize)
+	pub.pipelines.async = newAsyncPipeline(pub, DefaultQueueSize, DefaultBulkQueueSize, &pub.wsPublisher)
 
 	return &testPublisher{
 		pub:              pub,

--- a/libbeat/publisher/publish.go
+++ b/libbeat/publisher/publish.go
@@ -101,8 +101,8 @@ type Topology struct {
 }
 
 const (
-	defaultChanSize     = 1000
-	defaultBulkChanSize = 0
+	DefaultQueueSize     = 1000
+	DefaultBulkQueueSize = 0
 )
 
 func init() {
@@ -208,15 +208,7 @@ func (publisher *BeatPublisher) init(
 		logp.Info("Dry run mode. All output types except the file based one are disabled.")
 	}
 
-	hwm := defaultChanSize
-	if shipper.QueueSize != nil && *shipper.QueueSize > 0 {
-		hwm = *shipper.QueueSize
-	}
-
-	bulkHWM := defaultBulkChanSize
-	if shipper.BulkQueueSize != nil && *shipper.BulkQueueSize >= 0 {
-		bulkHWM = *shipper.BulkQueueSize
-	}
+	shipper.InitShipperConfig()
 
 	publisher.geoLite = common.LoadGeoIPData(shipper.Geoip)
 
@@ -242,8 +234,8 @@ func (publisher *BeatPublisher) init(
 					config,
 					output,
 					&publisher.wsOutput,
-					hwm,
-					bulkHWM))
+					*shipper.QueueSize,
+					*shipper.BulkQueueSize))
 
 			if ok, _ := config.Bool("save_topology", 0); !ok {
 				continue
@@ -321,8 +313,8 @@ func (publisher *BeatPublisher) init(
 		go publisher.UpdateTopologyPeriodically()
 	}
 
-	publisher.pipelines.async = newAsyncPipeline(publisher, hwm, bulkHWM, &publisher.wsPublisher)
-	publisher.pipelines.sync = newSyncPipeline(publisher, hwm, bulkHWM)
+	publisher.pipelines.async = newAsyncPipeline(publisher, *shipper.QueueSize, *shipper.BulkQueueSize, &publisher.wsPublisher)
+	publisher.pipelines.sync = newSyncPipeline(publisher, *shipper.QueueSize, *shipper.BulkQueueSize)
 	return nil
 }
 
@@ -333,4 +325,18 @@ func (publisher *BeatPublisher) Stop() {
 
 	publisher.wsPublisher.stop()
 	publisher.wsOutput.stop()
+}
+
+func (config *ShipperConfig) InitShipperConfig() {
+
+	// TODO: replace by ucfg
+	if config.QueueSize == nil || *config.QueueSize <= 0 {
+		queueSize := DefaultQueueSize
+		config.QueueSize = &queueSize
+	}
+
+	if config.BulkQueueSize == nil || *config.BulkQueueSize < 0 {
+		bulkQueueSize := DefaultBulkQueueSize
+		config.BulkQueueSize = &bulkQueueSize
+	}
 }

--- a/metricbeat/metricbeat.full.yml
+++ b/metricbeat/metricbeat.full.yml
@@ -220,6 +220,10 @@ metricbeat.modules:
 # Internal queue size for single events in processing pipeline
 #queue_size: 1000
 
+# The internal queue size for bulk events in the processing pipeline.
+# Do not modify this value.
+#bulk_queue_size: 0
+
 # Sets the maximum number of CPUs that can be executing simultaneously. The
 # default is the number of logical CPUs available in the system.
 #max_procs:

--- a/packetbeat/packetbeat.full.yml
+++ b/packetbeat/packetbeat.full.yml
@@ -486,6 +486,10 @@ packetbeat.protocols.nfs:
 # Internal queue size for single events in processing pipeline
 #queue_size: 1000
 
+# The internal queue size for bulk events in the processing pipeline.
+# Do not modify this value.
+#bulk_queue_size: 0
+
 # Sets the maximum number of CPUs that can be executing simultaneously. The
 # default is the number of logical CPUs available in the system.
 #max_procs:

--- a/winlogbeat/winlogbeat.full.yml
+++ b/winlogbeat/winlogbeat.full.yml
@@ -71,6 +71,10 @@ winlogbeat.event_logs:
 # Internal queue size for single events in processing pipeline
 #queue_size: 1000
 
+# The internal queue size for bulk events in the processing pipeline.
+# Do not modify this value.
+#bulk_queue_size: 0
+
 # Sets the maximum number of CPUs that can be executing simultaneously. The
 # default is the number of logical CPUs available in the system.
 #max_procs:


### PR DESCRIPTION
There was a default in packetbeat and libbeat publisher for the default queueSize. The two are now merged and the default from libbeat was taken.

* Add bulk_queue_size to config as it was missing
* Rely on constants from libbeat