### PR TITLE
Update gosigar version

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -25,7 +25,7 @@ import:
   subpackages:
   - /difflib
 - package: github.com/elastic/gosigar
-  version: a6e5709f6a491f83588305c15151412c2e480fc2
+  version: 2716c1fe855ee5c88eae707195e0688374458c92
 - package: github.com/samuel/go-parser
   version: ca8abbf65d0e61dedf061f98bd3850f250e27539
 - package: github.com/samuel/go-thrift

--- a/metricbeat/docs/faq.asciidoc
+++ b/metricbeat/docs/faq.asciidoc
@@ -10,10 +10,12 @@ https://discuss.elastic.co/c/beats/metricbeat[Metricbeat discussion forum].
 
 The system metricsets rely a Linux comparability layer to retrieve metrics on
 FreeBSD. You need to mount the Linux procfs filesystem using the following
-commands.
+commands. You may want to add these filesystems to your `/etc/fstab` so they are
+mounted automatically.
 
 [source,sh]
 ----
+sudo mount -t procfs proc /proc
 sudo mkdir -p /compat/linux/proc
 sudo mount -t linprocfs /dev/null /compat/linux/proc
 ----

--- a/metricbeat/module/system/process/helper.go
+++ b/metricbeat/module/system/process/helper.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"runtime"
 	"strings"
 	"time"
 
@@ -99,6 +100,12 @@ func (proc *Process) getDetails(cmdline string) error {
 // data then  nil is returned with no error (/proc/[pid]/fd requires root
 // permissions). Any other errors that occur are returned.
 func getProcFDUsage(pid int) (*sigar.ProcFDUsage, error) {
+	// It's not possible to collect FD usage from other processes on FreeBSD
+	// due to linprocfs not exposing the information.
+	if runtime.GOOS == "freebsd" && pid != os.Getpid() {
+		return nil, nil
+	}
+
 	fd := sigar.ProcFDUsage{}
 	if err := fd.Get(pid); err != nil {
 		switch {

--- a/vendor/github.com/elastic/gosigar/README.md
+++ b/vendor/github.com/elastic/gosigar/README.md
@@ -38,6 +38,19 @@ The features vary by operating system.
 | Swap            |   X   |    X   |         |    X    |    X    |
 | Uptime          |   X   |    X   |         |    X    |    X    |
 
+## OS Specific Notes
+
+### FreeBSD
+
+Mount both `linprocfs` and `procfs` for compatability. Consider adding these
+mounts to your `/etc/fstab` file so they are mounted automatically at boot.
+
+```
+sudo mount -t procfs proc /proc
+sudo mkdir -p /compat/linux/proc
+sudo mount -t linprocfs /dev/null /compat/linux/proc
+```
+
 ## License
 
 Apache 2.0

--- a/vendor/github.com/elastic/gosigar/sigar_freebsd.go
+++ b/vendor/github.com/elastic/gosigar/sigar_freebsd.go
@@ -72,8 +72,8 @@ func (self *FDUsage) Get() error {
 }
 
 func (self *ProcFDUsage) Get(pid int) error {
-	err := readFile(procFileNameNative(pid, "rlimit"), func(line string) bool {
-		if strings.HasPrefix(line, "nofile ") {
+	err := readFile("/proc/"+strconv.Itoa(pid)+"/rlimit", func(line string) bool {
+		if strings.HasPrefix(line, "nofile") {
 			fields := strings.Fields(line)
 			if len(fields) == 3 {
 				self.SoftLimit, _ = strconv.ParseUint(fields[1], 10, 64)
@@ -86,11 +86,14 @@ func (self *ProcFDUsage) Get(pid int) error {
 	if err != nil {
 		return err
 	}
+
+	// linprocfs only provides this information for this process (self).
 	fds, err := ioutil.ReadDir(procFileName(pid, "fd"))
 	if err != nil {
 		return err
 	}
 	self.Open = uint64(len(fds))
+
 	return nil
 }
 
@@ -102,8 +105,4 @@ func parseCpuStat(self *Cpu, line string) error {
 	self.Sys, _ = strtoull(fields[3])
 	self.Idle, _ = strtoull(fields[4])
 	return nil
-}
-
-func procFileNameNative(pid int, name string) string {
-	return "/proc/" + strconv.Itoa(pid) + "/" + name
 }


### PR DESCRIPTION
This version removes the broken ProcFDUsage implementation from FreeBSD.

Closes #2312 