### PR TITLE
Clarify how to set beat.name

### DIFF
--- a/filebeat/docs/fields.asciidoc
+++ b/filebeat/docs/fields.asciidoc
@@ -21,7 +21,7 @@ Contains common fields available in all event types.
 
 ==== beat.name
 
-The name of the Beat sending the log messages. If the shipper name is set in the configuration file, then that value is used. If it is not set, the hostname is used.
+The name of the Beat sending the log messages. If the shipper name is set in the configuration file, then that value is used. If it is not set, the hostname is used. To set the shipper name, use the `name` option in the `shipper` section of the configuration file.
 
 
 ==== beat.hostname

--- a/filebeat/etc/fields.yml
+++ b/filebeat/etc/fields.yml
@@ -16,7 +16,8 @@ env:
       description: >
         The name of the Beat sending the log messages. If the shipper name is set
         in the configuration file, then that value is used. If it is not set,
-        the hostname is used.
+        the hostname is used. To set the shipper name, use the `name` option in
+        the `shipper` section of the configuration file.
 
     - name: beat.hostname
       description: >


### PR DESCRIPTION
Fix for #2280 in the 1.2 branch. The topic about exported fields is not the right place to show the example config, so I didn't include it. However, when users refer to the docs about the shipper config, they'll see the example there.