### PR TITLE
Test with most recent 2.4.0 builds

### DIFF
--- a/testing/environments/docker/elasticsearch/Dockerfile-2.4.0
+++ b/testing/environments/docker/elasticsearch/Dockerfile-2.4.0
@@ -15,7 +15,7 @@ RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 46095ACC85485
 ENV ELASTICSEARCH_MAJOR 2.4
 ENV ELASTICSEARCH_VERSION 2.4.0
 
-RUN wget https://download.elasticsearch.org/elasticsearch/staging/2.4.0-7a922b6/org/elasticsearch/distribution/deb/elasticsearch/2.4.0/elasticsearch-2.4.0.deb
+RUN wget https://download.elasticsearch.org/elasticsearch/staging/2.4.0-ce9f0c7/org/elasticsearch/distribution/deb/elasticsearch/2.4.0/elasticsearch-2.4.0.deb
 
 #RUN wget https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/${ELASTICSEARCH_VERSION}/elasticsearch-${ELASTICSEARCH_VERSION}.deb
 

--- a/testing/environments/docker/kibana/Dockerfile-4.6.0
+++ b/testing/environments/docker/kibana/Dockerfile-4.6.0
@@ -18,7 +18,7 @@ RUN arch="$(dpkg --print-architecture)" \
 ENV KIBANA_VERSION 4.6.0
 
 RUN set -x \
-	&& curl -fSL "https://download.elastic.co/kibana/staging/4.6.0-6b8ddde/kibana/kibana-4.6.0-linux-x86_64.tar.gz" -o kibana.tar.gz \
+	&& curl -fSL "https://download.elastic.co/kibana/staging/4.6.0-f898fba/kibana/kibana-4.6.0-linux-x86_64.tar.gz" -o kibana.tar.gz \
 	&& mkdir -p /opt/kibana \
 	&& tar -xz --strip-components=1 -C /opt/kibana -f kibana.tar.gz \
 	&& chown -R kibana:kibana /opt/kibana \

--- a/testing/environments/docker/logstash/Dockerfile-2.4.0
+++ b/testing/environments/docker/logstash/Dockerfile-2.4.0
@@ -2,7 +2,7 @@ FROM java:8-jre
 
 ENV LS_VERSION 2
 
-ENV DEB_URL https://download.elastic.co/logstash/logstash/packages/debian/logstash-2.4.0.snapshot3_all.deb
+ENV DEB_URL https://download.elastic.co/logstash/logstash/packages/debian/logstash-2.4.0.snapshot4_all.deb
 
 ENV PATH $PATH:/opt/logstash/bin:/opt/logstash/vendor/jruby/bin
 


### PR DESCRIPTION
Needs retesting after https://github.com/elastic/beats/pull/2414 is merged.

Command to be run is `TESTING_ENVIRONMENT=latest make testsuite`