### PR TITLE
Deprecate Topology Map

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -104,6 +104,7 @@ https://github.com/elastic/beats/compare/v5.0.0-alpha5...master[Check the HEAD d
 ==== Deprecated
 
 *Affecting all Beats*
+- Topology map is deperecated. This applies to the settings: refresh_topology_freq, topology_expire, save_topology, host_topology, password_topology, db_topology
 
 *Packetbeat*
 

--- a/filebeat/filebeat.full.yml
+++ b/filebeat/filebeat.full.yml
@@ -246,11 +246,11 @@ filebeat.prospectors:
 # sub-dictionary. Default is false.
 #fields_under_root: false
 
-# How often (in seconds) shippers are publishing their IPs to the topology map.
+# DEPRECATED: How often (in seconds) shippers are publishing their IPs to the topology map.
 # The default is 10 seconds.
 #refresh_topology_freq: 10
 
-# Expiration time (in seconds) of the IPs published by a shipper to the topology map.
+# DEPRECATED: Expiration time (in seconds) of the IPs published by a shipper to the topology map.
 # All the IPs will be deleted afterwards. Note, that the value must be higher than
 # refresh_topology_freq. This setting is used only by the Redis output. The other
 # outputs don't support expiring entries.
@@ -355,7 +355,7 @@ output.elasticsearch:
   # requests are made.
   #flush_interval: 1s
 
-  # Boolean that sets if the topology is kept in Elasticsearch. The default is
+  # DEPRECATED: Boolean that sets if the topology is kept in Elasticsearch. The default is
   # false. This option makes sense only for Packetbeat.
   #save_topology: false
 
@@ -620,15 +620,15 @@ output.elasticsearch:
   # PUBLISH command is used. The default value is list.
   #datetype: list
 
-  # The Redis host to connect to when using topology map support. Topology map
+  # DEPRECATED: The Redis host to connect to when using topology map support. Topology map
   # support is disabled if this option is not set.
   #host_topology:
 
-  # The password to use for authenticating with the Redis topology server. The
+  # DEPRECATED: The password to use for authenticating with the Redis topology server. The
   # default is no authentication.
   #password_topology:
 
-  # The Redis database number where the topology information is stored. The
+  # DEPRECATED: The Redis database number where the topology information is stored. The
   # default is 1.
   #db_topology: 1
 

--- a/filebeat/filebeat.full.yml
+++ b/filebeat/filebeat.full.yml
@@ -246,17 +246,6 @@ filebeat.prospectors:
 # sub-dictionary. Default is false.
 #fields_under_root: false
 
-# DEPRECATED: How often (in seconds) shippers are publishing their IPs to the topology map.
-# The default is 10 seconds.
-#refresh_topology_freq: 10
-
-# DEPRECATED: Expiration time (in seconds) of the IPs published by a shipper to the topology map.
-# All the IPs will be deleted afterwards. Note, that the value must be higher than
-# refresh_topology_freq. This setting is used only by the Redis output. The other
-# outputs don't support expiring entries.
-# The default is 15 seconds.
-#topology_expire: 15
-
 # Internal queue size for single events in processing pipeline
 #queue_size: 1000
 
@@ -354,10 +343,6 @@ output.elasticsearch:
   # If `bulk_max_size` is reached before this interval expires, addition bulk index
   # requests are made.
   #flush_interval: 1s
-
-  # DEPRECATED: Boolean that sets if the topology is kept in Elasticsearch. The default is
-  # false. This option makes sense only for Packetbeat.
-  #save_topology: false
 
   # A template is used to set the mapping in Elasticsearch
   # By default template loading is enabled and the template is loaded.
@@ -619,18 +604,6 @@ output.elasticsearch:
   # the Redis RPUSH command is used. If the data type is channel, the Redis
   # PUBLISH command is used. The default value is list.
   #datetype: list
-
-  # DEPRECATED: The Redis host to connect to when using topology map support. Topology map
-  # support is disabled if this option is not set.
-  #host_topology:
-
-  # DEPRECATED: The password to use for authenticating with the Redis topology server. The
-  # default is no authentication.
-  #password_topology:
-
-  # DEPRECATED: The Redis database number where the topology information is stored. The
-  # default is 1.
-  #db_topology: 1
 
   # The number of workers to use for each host configured to publish events to
   # Redis. Use this setting along with the loadbalance option. For example, if

--- a/libbeat/_meta/config.full.yml
+++ b/libbeat/_meta/config.full.yml
@@ -22,17 +22,6 @@
 # sub-dictionary. Default is false.
 #fields_under_root: false
 
-# DEPRECATED: How often (in seconds) shippers are publishing their IPs to the topology map.
-# The default is 10 seconds.
-#refresh_topology_freq: 10
-
-# DEPRECATED: Expiration time (in seconds) of the IPs published by a shipper to the topology map.
-# All the IPs will be deleted afterwards. Note, that the value must be higher than
-# refresh_topology_freq. This setting is used only by the Redis output. The other
-# outputs don't support expiring entries.
-# The default is 15 seconds.
-#topology_expire: 15
-
 # Internal queue size for single events in processing pipeline
 #queue_size: 1000
 
@@ -130,10 +119,6 @@ output.elasticsearch:
   # If `bulk_max_size` is reached before this interval expires, addition bulk index
   # requests are made.
   #flush_interval: 1s
-
-  # DEPRECATED: Boolean that sets if the topology is kept in Elasticsearch. The default is
-  # false. This option makes sense only for Packetbeat.
-  #save_topology: false
 
   # A template is used to set the mapping in Elasticsearch
   # By default template loading is enabled and the template is loaded.
@@ -395,18 +380,6 @@ output.elasticsearch:
   # the Redis RPUSH command is used. If the data type is channel, the Redis
   # PUBLISH command is used. The default value is list.
   #datetype: list
-
-  # DEPRECATED: The Redis host to connect to when using topology map support. Topology map
-  # support is disabled if this option is not set.
-  #host_topology:
-
-  # DEPRECATED: The password to use for authenticating with the Redis topology server. The
-  # default is no authentication.
-  #password_topology:
-
-  # DEPRECATED: The Redis database number where the topology information is stored. The
-  # default is 1.
-  #db_topology: 1
 
   # The number of workers to use for each host configured to publish events to
   # Redis. Use this setting along with the loadbalance option. For example, if

--- a/libbeat/_meta/config.full.yml
+++ b/libbeat/_meta/config.full.yml
@@ -22,11 +22,11 @@
 # sub-dictionary. Default is false.
 #fields_under_root: false
 
-# How often (in seconds) shippers are publishing their IPs to the topology map.
+# DEPRECATED: How often (in seconds) shippers are publishing their IPs to the topology map.
 # The default is 10 seconds.
 #refresh_topology_freq: 10
 
-# Expiration time (in seconds) of the IPs published by a shipper to the topology map.
+# DEPRECATED: Expiration time (in seconds) of the IPs published by a shipper to the topology map.
 # All the IPs will be deleted afterwards. Note, that the value must be higher than
 # refresh_topology_freq. This setting is used only by the Redis output. The other
 # outputs don't support expiring entries.
@@ -131,7 +131,7 @@ output.elasticsearch:
   # requests are made.
   #flush_interval: 1s
 
-  # Boolean that sets if the topology is kept in Elasticsearch. The default is
+  # DEPRECATED: Boolean that sets if the topology is kept in Elasticsearch. The default is
   # false. This option makes sense only for Packetbeat.
   #save_topology: false
 
@@ -396,15 +396,15 @@ output.elasticsearch:
   # PUBLISH command is used. The default value is list.
   #datetype: list
 
-  # The Redis host to connect to when using topology map support. Topology map
+  # DEPRECATED: The Redis host to connect to when using topology map support. Topology map
   # support is disabled if this option is not set.
   #host_topology:
 
-  # The password to use for authenticating with the Redis topology server. The
+  # DEPRECATED: The password to use for authenticating with the Redis topology server. The
   # default is no authentication.
   #password_topology:
 
-  # The Redis database number where the topology information is stored. The
+  # DEPRECATED: The Redis database number where the topology information is stored. The
   # default is 1.
   #db_topology: 1
 

--- a/libbeat/docs/generalconfig.asciidoc
+++ b/libbeat/docs/generalconfig.asciidoc
@@ -99,13 +99,17 @@ fields:
 
 ===== refresh_topology_freq
 
-DEPRECATED: The refresh interval of the topology map in
+deprecated[5.0.0]
+
+The refresh interval of the topology map in
 seconds. In other words, this setting specifies how often each Beat publishes its
 IP addresses to the topology map. The default is 10 seconds.
 
 ===== topology_expire
 
-DEPRECATED: The expiration time for the topology in seconds. This is useful in case a Beat
+deprecated[5.0.0]
+
+The expiration time for the topology in seconds. This is useful in case a Beat
 stops publishing its IP addresses. The IP addresses are removed automatically
 from the topology map after expiration.
 

--- a/libbeat/docs/generalconfig.asciidoc
+++ b/libbeat/docs/generalconfig.asciidoc
@@ -30,15 +30,6 @@ Here is an example configuration:
 # logical properties.
 tags: ["service-X", "web-tier"]
 
-# How often (in seconds) shippers are publishing their IPs to the topology map.
-# The default is 10 seconds.
-refresh_topology_freq: 10
-
-# Expiration time (in seconds) of the IPs published by a shipper to the topology map.
-# All the IPs will be deleted afterwards. Note, that the value must be higher than
-# refresh_topology_freq. The default is 15 seconds.
-topology_expire: 15
-
 ------------------------------------------------------------------------------
 
 ==== General Options
@@ -50,19 +41,6 @@ You can specify the following options:
 The name of the Beat. If this option is empty, the `hostname` of the server is
 used. The name is included as the `beat.name` field in each published transaction. You can
 use the name to group all transactions sent by a single Beat.
-
-At startup, each Beat can publish its IP, port, and name to Elasticsearch. This information
-is stored in Elasticsearch as a network topology map that maps the IP and port
-of each Beat to the name that you specify here.
-
-When a Beat receives a new request and response (called a transaction), the Beat can query
-Elasticsearch to see if the network topology includes the IP and port of the source
-and destination servers. If this information is available, the `client_server` field in the
-output is set to the name of the Beat running on the source server, and the `server` field is set to the
-name of the Beat running on the destination server.
-
-To use the topology map in Elasticsearch, you must enable Elasticsearch as output and set the
-`save_topology` option to true.
 
 Example:
 
@@ -121,13 +99,13 @@ fields:
 
 ===== refresh_topology_freq
 
-The refresh interval of the topology map in
+DEPRECATED: The refresh interval of the topology map in
 seconds. In other words, this setting specifies how often each Beat publishes its
 IP addresses to the topology map. The default is 10 seconds.
 
 ===== topology_expire
 
-The expiration time for the topology in seconds. This is useful in case a Beat
+DEPRECATED: The expiration time for the topology in seconds. This is useful in case a Beat
 stops publishing its IP addresses. The IP addresses are removed automatically
 from the topology map after expiration.
 

--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -77,11 +77,6 @@ output.elasticsearch:
   # Optional http or https. Default is http
   protocol: "https"
 
-  # DEPRECATED: Comment this option if you don't want to store the topology in
-  # Elasticsearch. The default is false.
-  # This option makes sense only for Packetbeat
-  #save_topology: false
-
   # HTTP basic auth
   username: "admin"
   password: "s3cr3t"
@@ -283,7 +278,9 @@ requests are made.
 [[save_topology]]
 ===== save_topology
 
-DEPRECATED: A Boolean that specifies whether the topology is kept in Elasticsearch. The default is
+deprecated[5.0.0]
+
+A Boolean that specifies whether the topology is kept in Elasticsearch. The default is
 false.
 
 This option is relevant for Packetbeat only.
@@ -720,15 +717,21 @@ The default value is `list`.
 
 ===== host_topology
 
-DEPRECATED: The Redis host to connect to when using topology map support. Topology map support is disabled if this option is not set.
+deprecated[5.0.0]
+
+The Redis host to connect to when using topology map support. Topology map support is disabled if this option is not set.
 
 ===== password_topology
 
-DEPRECATED: The password to use for authenticating with the Redis topology server. The default is no authentication.
+deprecated[5.0.0]
+
+The password to use for authenticating with the Redis topology server. The default is no authentication.
 
 ===== db_topology
 
-DEPRECATED: The Redis database number where the topology information is stored. The default is 1.
+deprecated[5.0.0]
+
+The Redis database number where the topology information is stored. The default is 1.
 
 ===== worker
 

--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -77,10 +77,10 @@ output.elasticsearch:
   # Optional http or https. Default is http
   protocol: "https"
 
-  # Comment this option if you don't want to store the topology in
+  # DEPRECATED: Comment this option if you don't want to store the topology in
   # Elasticsearch. The default is false.
   # This option makes sense only for Packetbeat
-  # save_topology: false
+  #save_topology: false
 
   # HTTP basic auth
   username: "admin"
@@ -248,7 +248,7 @@ After the specified number of retries, the events are typically dropped.
 Some Beats, such as Filebeat, ignore the `max_retries` setting and retry until all
 events are published.
 
-Set `max_retries` to a value less than 0 to retry until all events are published. 
+Set `max_retries` to a value less than 0 to retry until all events are published.
 
 The default is 3.
 
@@ -260,7 +260,7 @@ If the Beat sends single events, the events are collected into batches. If the B
 a large batch of events (larger than the value specified by `bulk_max_size`), the batch is
 split.
 
-Specifying a larger batch size can improve performance by lowering the overhead of sending events. 
+Specifying a larger batch size can improve performance by lowering the overhead of sending events.
 However big batch sizes can also increase processing times, which might result in
 API errors, killed connections, timed-out publishing requests, and, ultimately, lower
 throughput.
@@ -283,7 +283,7 @@ requests are made.
 [[save_topology]]
 ===== save_topology
 
-A Boolean that specifies whether the topology is kept in Elasticsearch. The default is
+DEPRECATED: A Boolean that specifies whether the topology is kept in Elasticsearch. The default is
 false.
 
 This option is relevant for Packetbeat only.
@@ -484,7 +484,7 @@ For example "{beatname_lc}" generates "[{beatname_lc}-]YYYY.MM.DD" indexes (for 
 ===== tls
 
 Configuration options for TLS parameters like the root CA for Logstash connections. See
-<<configuration-output-tls>> for more information. To use TLS, you must also configure the 
+<<configuration-output-tls>> for more information. To use TLS, you must also configure the
 https://www.elastic.co/guide/en/logstash/current/plugins-inputs-beats.html[Beats input plugin for Logstash] to use SSL/TLS.
 
 ===== timeout
@@ -498,7 +498,7 @@ After the specified number of retries, the events are typically dropped.
 Some Beats, such as Filebeat, ignore the `max_retries` setting and retry until all
 events are published.
 
-Set `max_retries` to a value less than 0 to retry until all events are published. 
+Set `max_retries` to a value less than 0 to retry until all events are published.
 
 The default is 3.
 
@@ -510,7 +510,7 @@ If the Beat sends single events, the events are collected into batches. If the B
 a large batch of events (larger than the value specified by `bulk_max_size`), the batch is
 split.
 
-Specifying a larger batch size can improve performance by lowering the overhead of sending events. 
+Specifying a larger batch size can improve performance by lowering the overhead of sending events.
 However big batch sizes can also increase processing times, which might result in
 API errors, killed connections, timed-out publishing requests, and, ultimately, lower
 throughput.
@@ -590,7 +590,7 @@ After the specified number of retries, the events are typically dropped.
 Some Beats, such as Filebeat, ignore the `max_retries` setting and retry until all
 events are published.
 
-Set `max_retries` to a value less than 0 to retry until all events are published. 
+Set `max_retries` to a value less than 0 to retry until all events are published.
 
 The default is 3.
 
@@ -720,15 +720,15 @@ The default value is `list`.
 
 ===== host_topology
 
-The Redis host to connect to when using topology map support. Topology map support is disabled if this option is not set.
+DEPRECATED: The Redis host to connect to when using topology map support. Topology map support is disabled if this option is not set.
 
 ===== password_topology
 
-The password to use for authenticating with the Redis topology server. The default is no authentication.
+DEPRECATED: The password to use for authenticating with the Redis topology server. The default is no authentication.
 
 ===== db_topology
 
-The Redis database number where the topology information is stored. The default is 1.
+DEPRECATED: The Redis database number where the topology information is stored. The default is 1.
 
 ===== worker
 
@@ -752,7 +752,7 @@ After the specified number of retries, the events are typically dropped.
 Some Beats, such as Filebeat, ignore the `max_retries` setting and retry until all
 events are published.
 
-Set `max_retries` to a value less than 0 to retry until all events are published. 
+Set `max_retries` to a value less than 0 to retry until all events are published.
 
 The default is 3.
 
@@ -890,16 +890,16 @@ The default value is true.
 
 The maximum number of events to buffer internally during publishing. The default is 2048.
 
-Specifying a larger batch size may add some latency and buffering during publishing. However, for Console output, this 
+Specifying a larger batch size may add some latency and buffering during publishing. However, for Console output, this
 setting does not affect how events are published.
 
-Setting `bulk_max_size` to values less than or equal to 0 disables buffering in libbeat. 
+Setting `bulk_max_size` to values less than or equal to 0 disables buffering in libbeat.
 
 [[configuration-output-tls]]
 
 === TLS Configuration
 
-You can specify TLS options for any output that supports TLS. 
+You can specify TLS options for any output that supports TLS.
 
 Example configuration:
 

--- a/libbeat/publisher/publish.go
+++ b/libbeat/publisher/publish.go
@@ -133,6 +133,7 @@ func (publisher *BeatPublisher) GetServerName(ip string) string {
 
 	// find the shipper with the desired IP
 	if publisher.TopologyOutput != nil {
+		logp.Warn("Topology settings are deprecated.")
 		return publisher.TopologyOutput.GetNameByIP(ip)
 	}
 

--- a/libbeat/tests/system/config/mockbeat.yml.j2
+++ b/libbeat/tests/system/config/mockbeat.yml.j2
@@ -39,20 +39,16 @@ output:
   # Elasticsearch as output
   # Options:
   # host, port: where Elasticsearch is listening on
-  # save_topology: specify if the topology is saved in Elasticsearch
   #elasticsearch:
   #  host: localhost
   #  port: 9200
-  #  save_topology: true
 
   # Redis as output
   # Options:
   # host, port: where Redis is listening on
-  # save_topology: specify if the topology is saved in Redis
   #redis:
   #  host: localhost
   #  port: 6379
-  #  save_topology: true
 
   # File as output
   # Options

--- a/metricbeat/metricbeat.full.yml
+++ b/metricbeat/metricbeat.full.yml
@@ -206,11 +206,11 @@ metricbeat.modules:
 # sub-dictionary. Default is false.
 #fields_under_root: false
 
-# How often (in seconds) shippers are publishing their IPs to the topology map.
+# DEPRECATED: How often (in seconds) shippers are publishing their IPs to the topology map.
 # The default is 10 seconds.
 #refresh_topology_freq: 10
 
-# Expiration time (in seconds) of the IPs published by a shipper to the topology map.
+# DEPRECATED: Expiration time (in seconds) of the IPs published by a shipper to the topology map.
 # All the IPs will be deleted afterwards. Note, that the value must be higher than
 # refresh_topology_freq. This setting is used only by the Redis output. The other
 # outputs don't support expiring entries.
@@ -315,7 +315,7 @@ output.elasticsearch:
   # requests are made.
   #flush_interval: 1s
 
-  # Boolean that sets if the topology is kept in Elasticsearch. The default is
+  # DEPRECATED: Boolean that sets if the topology is kept in Elasticsearch. The default is
   # false. This option makes sense only for Packetbeat.
   #save_topology: false
 
@@ -580,15 +580,15 @@ output.elasticsearch:
   # PUBLISH command is used. The default value is list.
   #datetype: list
 
-  # The Redis host to connect to when using topology map support. Topology map
+  # DEPRECATED: The Redis host to connect to when using topology map support. Topology map
   # support is disabled if this option is not set.
   #host_topology:
 
-  # The password to use for authenticating with the Redis topology server. The
+  # DEPRECATED: The password to use for authenticating with the Redis topology server. The
   # default is no authentication.
   #password_topology:
 
-  # The Redis database number where the topology information is stored. The
+  # DEPRECATED: The Redis database number where the topology information is stored. The
   # default is 1.
   #db_topology: 1
 

--- a/metricbeat/metricbeat.full.yml
+++ b/metricbeat/metricbeat.full.yml
@@ -206,17 +206,6 @@ metricbeat.modules:
 # sub-dictionary. Default is false.
 #fields_under_root: false
 
-# DEPRECATED: How often (in seconds) shippers are publishing their IPs to the topology map.
-# The default is 10 seconds.
-#refresh_topology_freq: 10
-
-# DEPRECATED: Expiration time (in seconds) of the IPs published by a shipper to the topology map.
-# All the IPs will be deleted afterwards. Note, that the value must be higher than
-# refresh_topology_freq. This setting is used only by the Redis output. The other
-# outputs don't support expiring entries.
-# The default is 15 seconds.
-#topology_expire: 15
-
 # Internal queue size for single events in processing pipeline
 #queue_size: 1000
 
@@ -314,10 +303,6 @@ output.elasticsearch:
   # If `bulk_max_size` is reached before this interval expires, addition bulk index
   # requests are made.
   #flush_interval: 1s
-
-  # DEPRECATED: Boolean that sets if the topology is kept in Elasticsearch. The default is
-  # false. This option makes sense only for Packetbeat.
-  #save_topology: false
 
   # A template is used to set the mapping in Elasticsearch
   # By default template loading is enabled and the template is loaded.
@@ -579,18 +564,6 @@ output.elasticsearch:
   # the Redis RPUSH command is used. If the data type is channel, the Redis
   # PUBLISH command is used. The default value is list.
   #datetype: list
-
-  # DEPRECATED: The Redis host to connect to when using topology map support. Topology map
-  # support is disabled if this option is not set.
-  #host_topology:
-
-  # DEPRECATED: The password to use for authenticating with the Redis topology server. The
-  # default is no authentication.
-  #password_topology:
-
-  # DEPRECATED: The Redis database number where the topology information is stored. The
-  # default is 1.
-  #db_topology: 1
 
   # The number of workers to use for each host configured to publish events to
   # Redis. Use this setting along with the loadbalance option. For example, if

--- a/packetbeat/docs/maintaining-topology.asciidoc
+++ b/packetbeat/docs/maintaining-topology.asciidoc
@@ -1,6 +1,8 @@
 [[maintaining-topology]]
 == Maintaining the Real-Time State of the Network Topology
 
+DEPRECATED
+
 One important feature of Packetbeat is that it knows the name of the source and
 destination servers for each transaction. It does this without needing to maintain
 a central configuration. Instead, each Beat notes the hostname of the server
@@ -8,7 +10,7 @@ where the Beat runs, and maps the hostname to the list of IP addresses of that s
 
 Packetbeat stores the topology information in an Elasticsearch index, so to save
 the network topology, you need to use Elasticsearch as output and set the
-`save_topology` configuration option to true. 
+`save_topology` configuration option to true.
 
 For example:
 

--- a/packetbeat/docs/maintaining-topology.asciidoc
+++ b/packetbeat/docs/maintaining-topology.asciidoc
@@ -1,7 +1,7 @@
 [[maintaining-topology]]
 == Maintaining the Real-Time State of the Network Topology
 
-DEPRECATED
+deprecated[5.0.0]
 
 One important feature of Packetbeat is that it knows the name of the source and
 destination servers for each transaction. It does this without needing to maintain

--- a/packetbeat/packetbeat.full.yml
+++ b/packetbeat/packetbeat.full.yml
@@ -472,11 +472,11 @@ packetbeat.protocols.nfs:
 # sub-dictionary. Default is false.
 #fields_under_root: false
 
-# How often (in seconds) shippers are publishing their IPs to the topology map.
+# DEPRECATED: How often (in seconds) shippers are publishing their IPs to the topology map.
 # The default is 10 seconds.
 #refresh_topology_freq: 10
 
-# Expiration time (in seconds) of the IPs published by a shipper to the topology map.
+# DEPRECATED: Expiration time (in seconds) of the IPs published by a shipper to the topology map.
 # All the IPs will be deleted afterwards. Note, that the value must be higher than
 # refresh_topology_freq. This setting is used only by the Redis output. The other
 # outputs don't support expiring entries.
@@ -581,7 +581,7 @@ output.elasticsearch:
   # requests are made.
   #flush_interval: 1s
 
-  # Boolean that sets if the topology is kept in Elasticsearch. The default is
+  # DEPRECATED: Boolean that sets if the topology is kept in Elasticsearch. The default is
   # false. This option makes sense only for Packetbeat.
   #save_topology: false
 
@@ -846,15 +846,15 @@ output.elasticsearch:
   # PUBLISH command is used. The default value is list.
   #datetype: list
 
-  # The Redis host to connect to when using topology map support. Topology map
+  # DEPRECATED: The Redis host to connect to when using topology map support. Topology map
   # support is disabled if this option is not set.
   #host_topology:
 
-  # The password to use for authenticating with the Redis topology server. The
+  # DEPRECATED: The password to use for authenticating with the Redis topology server. The
   # default is no authentication.
   #password_topology:
 
-  # The Redis database number where the topology information is stored. The
+  # DEPRECATED: The Redis database number where the topology information is stored. The
   # default is 1.
   #db_topology: 1
 

--- a/packetbeat/packetbeat.full.yml
+++ b/packetbeat/packetbeat.full.yml
@@ -472,17 +472,6 @@ packetbeat.protocols.nfs:
 # sub-dictionary. Default is false.
 #fields_under_root: false
 
-# DEPRECATED: How often (in seconds) shippers are publishing their IPs to the topology map.
-# The default is 10 seconds.
-#refresh_topology_freq: 10
-
-# DEPRECATED: Expiration time (in seconds) of the IPs published by a shipper to the topology map.
-# All the IPs will be deleted afterwards. Note, that the value must be higher than
-# refresh_topology_freq. This setting is used only by the Redis output. The other
-# outputs don't support expiring entries.
-# The default is 15 seconds.
-#topology_expire: 15
-
 # Internal queue size for single events in processing pipeline
 #queue_size: 1000
 
@@ -580,10 +569,6 @@ output.elasticsearch:
   # If `bulk_max_size` is reached before this interval expires, addition bulk index
   # requests are made.
   #flush_interval: 1s
-
-  # DEPRECATED: Boolean that sets if the topology is kept in Elasticsearch. The default is
-  # false. This option makes sense only for Packetbeat.
-  #save_topology: false
 
   # A template is used to set the mapping in Elasticsearch
   # By default template loading is enabled and the template is loaded.
@@ -845,18 +830,6 @@ output.elasticsearch:
   # the Redis RPUSH command is used. If the data type is channel, the Redis
   # PUBLISH command is used. The default value is list.
   #datetype: list
-
-  # DEPRECATED: The Redis host to connect to when using topology map support. Topology map
-  # support is disabled if this option is not set.
-  #host_topology:
-
-  # DEPRECATED: The password to use for authenticating with the Redis topology server. The
-  # default is no authentication.
-  #password_topology:
-
-  # DEPRECATED: The Redis database number where the topology information is stored. The
-  # default is 1.
-  #db_topology: 1
 
   # The number of workers to use for each host configured to publish events to
   # Redis. Use this setting along with the loadbalance option. For example, if

--- a/winlogbeat/winlogbeat.full.yml
+++ b/winlogbeat/winlogbeat.full.yml
@@ -57,17 +57,6 @@ winlogbeat.event_logs:
 # sub-dictionary. Default is false.
 #fields_under_root: false
 
-# DEPRECATED: How often (in seconds) shippers are publishing their IPs to the topology map.
-# The default is 10 seconds.
-#refresh_topology_freq: 10
-
-# DEPRECATED: Expiration time (in seconds) of the IPs published by a shipper to the topology map.
-# All the IPs will be deleted afterwards. Note, that the value must be higher than
-# refresh_topology_freq. This setting is used only by the Redis output. The other
-# outputs don't support expiring entries.
-# The default is 15 seconds.
-#topology_expire: 15
-
 # Internal queue size for single events in processing pipeline
 #queue_size: 1000
 
@@ -165,10 +154,6 @@ output.elasticsearch:
   # If `bulk_max_size` is reached before this interval expires, addition bulk index
   # requests are made.
   #flush_interval: 1s
-
-  # DEPRECATED: Boolean that sets if the topology is kept in Elasticsearch. The default is
-  # false. This option makes sense only for Packetbeat.
-  #save_topology: false
 
   # A template is used to set the mapping in Elasticsearch
   # By default template loading is enabled and the template is loaded.
@@ -430,18 +415,6 @@ output.elasticsearch:
   # the Redis RPUSH command is used. If the data type is channel, the Redis
   # PUBLISH command is used. The default value is list.
   #datetype: list
-
-  # DEPRECATED: The Redis host to connect to when using topology map support. Topology map
-  # support is disabled if this option is not set.
-  #host_topology:
-
-  # DEPRECATED: The password to use for authenticating with the Redis topology server. The
-  # default is no authentication.
-  #password_topology:
-
-  # DEPRECATED: The Redis database number where the topology information is stored. The
-  # default is 1.
-  #db_topology: 1
 
   # The number of workers to use for each host configured to publish events to
   # Redis. Use this setting along with the loadbalance option. For example, if

--- a/winlogbeat/winlogbeat.full.yml
+++ b/winlogbeat/winlogbeat.full.yml
@@ -57,11 +57,11 @@ winlogbeat.event_logs:
 # sub-dictionary. Default is false.
 #fields_under_root: false
 
-# How often (in seconds) shippers are publishing their IPs to the topology map.
+# DEPRECATED: How often (in seconds) shippers are publishing their IPs to the topology map.
 # The default is 10 seconds.
 #refresh_topology_freq: 10
 
-# Expiration time (in seconds) of the IPs published by a shipper to the topology map.
+# DEPRECATED: Expiration time (in seconds) of the IPs published by a shipper to the topology map.
 # All the IPs will be deleted afterwards. Note, that the value must be higher than
 # refresh_topology_freq. This setting is used only by the Redis output. The other
 # outputs don't support expiring entries.
@@ -166,7 +166,7 @@ output.elasticsearch:
   # requests are made.
   #flush_interval: 1s
 
-  # Boolean that sets if the topology is kept in Elasticsearch. The default is
+  # DEPRECATED: Boolean that sets if the topology is kept in Elasticsearch. The default is
   # false. This option makes sense only for Packetbeat.
   #save_topology: false
 
@@ -431,15 +431,15 @@ output.elasticsearch:
   # PUBLISH command is used. The default value is list.
   #datetype: list
 
-  # The Redis host to connect to when using topology map support. Topology map
+  # DEPRECATED: The Redis host to connect to when using topology map support. Topology map
   # support is disabled if this option is not set.
   #host_topology:
 
-  # The password to use for authenticating with the Redis topology server. The
+  # DEPRECATED: The password to use for authenticating with the Redis topology server. The
   # default is no authentication.
   #password_topology:
 
-  # The Redis database number where the topology information is stored. The
+  # DEPRECATED: The Redis database number where the topology information is stored. The
   # default is 1.
   #db_topology: 1
 


### PR DESCRIPTION
The current implementation of Topology map will be deprecated as it is focused on Packetbeat. It is intented to potentially readd something similar to topology map in the future which applies to all beats.