### PR TITLE
Fix corrupt Winlogbeat registry occurring on power failure

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -57,6 +57,7 @@ https://github.com/elastic/beats/compare/v5.0.0-alpha5...master[Check the HEAD d
 - Fix processor failure in Filebeat when using regex, contain, or equals with the message field. {issue}2178[2178]
 
 *Winlogbeat*
+- Fix corrupt registry file that occurs on power loss by disabling file write caching. {issue}2313[2313]
 
 ==== Added
 

--- a/winlogbeat/checkpoint/file_unix.go
+++ b/winlogbeat/checkpoint/file_unix.go
@@ -1,0 +1,9 @@
+// +build !windows
+
+package checkpoint
+
+import "os"
+
+func create(path string) (*os.File, error) {
+	return os.Create(path)
+}

--- a/winlogbeat/checkpoint/file_windows.go
+++ b/winlogbeat/checkpoint/file_windows.go
@@ -1,0 +1,37 @@
+package checkpoint
+
+import (
+	"os"
+	"syscall"
+)
+
+const (
+	_FILE_FLAG_WRITE_THROUGH = 0x80000000
+)
+
+func create(path string) (*os.File, error) {
+	return createWriteThroughFile(path)
+}
+
+// createWriteThroughFile creates a file whose write operations do not go
+// through any intermediary cache, they go directly to disk.
+func createWriteThroughFile(path string) (*os.File, error) {
+	if len(path) == 0 {
+		return nil, syscall.ERROR_FILE_NOT_FOUND
+	}
+	pathp, err := syscall.UTF16PtrFromString(path)
+	if err != nil {
+		return nil, err
+	}
+
+	h, err := syscall.CreateFile(
+		pathp, // Path
+		syscall.GENERIC_READ|syscall.GENERIC_WRITE,               // Access Mode
+		uint32(syscall.FILE_SHARE_READ|syscall.FILE_SHARE_WRITE), // Share Mode
+		nil, // Security Attributes
+		syscall.CREATE_ALWAYS,                                          // Create Mode
+		uint32(syscall.FILE_ATTRIBUTE_NORMAL|_FILE_FLAG_WRITE_THROUGH), // Flags and Attributes
+		0) // Template File
+
+	return os.NewFile(uintptr(h), path), err
+}


### PR DESCRIPTION
File writes are cached and not immediately flushed to disk. So if there is a power loss prior to flushing it seems that some corruption occurs. This adds the FILE_FLAG_WRITE_THROUGH flag to the CreateFile call to ensure that writes go directly to the disk on Windows.