### PR TITLE
Add namespace to runoptions example

### DIFF
--- a/packetbeat/docs/reference/configuration/runconfig.asciidoc
+++ b/packetbeat/docs/reference/configuration/runconfig.asciidoc
@@ -15,8 +15,9 @@ Example configuration for the `runoptions` section of the +{beatname_lc}.yml+ co
 
 [source,yaml]
 ------------------------------------------------------------------------------
-runoptions:
+packetbeat.runoptions:
   uid=501
   gid=501
 ------------------------------------------------------------------------------
 
+The `runoptions` configuration is supported on Linux only.


### PR DESCRIPTION
For #2281, adds namespace to runoptions example and clarifies that the config is supported on Linux only.