### PR TITLE
Add beat version number to elasticsearch template

### DIFF
--- a/dev-tools/set_version
+++ b/dev-tools/set_version
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import os
 import argparse
+from subprocess import check_call
 
 template_go = '''package beat
 
@@ -27,6 +28,11 @@ def main():
         f.write(template_packer.format(
             version=version,
         ))
+
+    # Updates all files with the new templates
+    os.chdir(dir + "/../")
+    print("Update build files")
+    check_call("make update", shell=True)
 
 if __name__ == "__main__":
     main()

--- a/filebeat/filebeat.template-es2x.json
+++ b/filebeat/filebeat.template-es2x.json
@@ -6,6 +6,9 @@
           "enabled": false
         }
       },
+      "_meta": {
+        "version": "5.0.0-alpha6"
+      },
       "dynamic_templates": [
         {
           "fields": {

--- a/filebeat/filebeat.template.json
+++ b/filebeat/filebeat.template.json
@@ -4,6 +4,9 @@
       "_all": {
         "norms": false
       },
+      "_meta": {
+        "version": "5.0.0-alpha6"
+      },
       "dynamic_templates": [
         {
           "fields": {

--- a/libbeat/scripts/generate_template.py
+++ b/libbeat/scripts/generate_template.py
@@ -14,7 +14,7 @@ import json
 import argparse
 
 
-def fields_to_es_template(args, input, output, index):
+def fields_to_es_template(args, input, output, index, version):
     """
     Reads the YAML file from input and generates the JSON for
     the ES template in output. input and output are both file
@@ -52,7 +52,10 @@ def fields_to_es_template(args, input, output, index):
                 "_all": {
                     "norms": False
                 },
-                "properties": {}
+                "properties": {},
+                "_meta": {
+                    "version": version,
+                }
             }
         }
     }
@@ -288,5 +291,8 @@ if __name__ == "__main__":
         with open(args.es_beats + "/libbeat/_meta/fields.yml") as f:
             fields = f.read() + fields
 
+        with open(args.es_beats + "/dev-tools/packer/version.yml") as file:
+            version_data = yaml.load(file)
+
         with open(target, 'w') as output:
-            fields_to_es_template(args, fields, output, args.beatname + "-*")
+            fields_to_es_template(args, fields, output, args.beatname + "-*", version_data['version'])

--- a/metricbeat/metricbeat.template-es2x.json
+++ b/metricbeat/metricbeat.template-es2x.json
@@ -6,6 +6,9 @@
           "enabled": false
         }
       },
+      "_meta": {
+        "version": "5.0.0-alpha6"
+      },
       "dynamic_templates": [
         {
           "fields": {

--- a/metricbeat/metricbeat.template.json
+++ b/metricbeat/metricbeat.template.json
@@ -4,6 +4,9 @@
       "_all": {
         "norms": false
       },
+      "_meta": {
+        "version": "5.0.0-alpha6"
+      },
       "dynamic_templates": [
         {
           "fields": {

--- a/packetbeat/packetbeat.template-es2x.json
+++ b/packetbeat/packetbeat.template-es2x.json
@@ -6,6 +6,9 @@
           "enabled": false
         }
       },
+      "_meta": {
+        "version": "5.0.0-alpha6"
+      },
       "dynamic_templates": [
         {
           "fields": {

--- a/packetbeat/packetbeat.template.json
+++ b/packetbeat/packetbeat.template.json
@@ -4,6 +4,9 @@
       "_all": {
         "norms": false
       },
+      "_meta": {
+        "version": "5.0.0-alpha6"
+      },
       "dynamic_templates": [
         {
           "fields": {

--- a/winlogbeat/winlogbeat.template-es2x.json
+++ b/winlogbeat/winlogbeat.template-es2x.json
@@ -6,6 +6,9 @@
           "enabled": false
         }
       },
+      "_meta": {
+        "version": "5.0.0-alpha6"
+      },
       "dynamic_templates": [
         {
           "fields": {

--- a/winlogbeat/winlogbeat.template.json
+++ b/winlogbeat/winlogbeat.template.json
@@ -4,6 +4,9 @@
       "_all": {
         "norms": false
       },
+      "_meta": {
+        "version": "5.0.0-alpha6"
+      },
       "dynamic_templates": [
         {
           "fields": {


### PR DESCRIPTION
This can help during debugging which template is loaded in elasticsearch. Also in case a template must be overwritten in the future for upgrading, this could be done based on the version.