### PR TITLE
Added logic to parse prepare id from Prepare response

### DIFF
--- a/packetbeat/protos/cassandra/internal/gocql/frame.go
+++ b/packetbeat/protos/cassandra/internal/gocql/frame.go
@@ -443,7 +443,13 @@ func (f *Framer) parseResultPrepared() map[string]interface{} {
 
 	result := make(map[string]interface{})
 
-	result["prepared_id"] = string((f.decoder).ReadShortBytes())
+	uuid,err := UUIDFromBytes((f.decoder).ReadShortBytes())
+
+	if(err != nil){
+		logp.Err("Error in parsing UUID")
+	}
+	
+	result["prepared_id"] =  uuid.String()
 	result["req_meta"] = f.parseResultMetadata(true)
 
 	if f.proto < protoVersion2 {


### PR DESCRIPTION
Prepare statement response from Cassandra contains prepareId of type UUID. Currently this is parsed as string. Fix has been added to convert UUID to string.