### PR TITLE
Parse PrepareId from Prepare statement Response

### DIFF
--- a/packetbeat/protos/cassandra/internal/gocql/frame.go
+++ b/packetbeat/protos/cassandra/internal/gocql/frame.go
@@ -443,7 +443,14 @@ func (f *Framer) parseResultPrepared() map[string]interface{} {
 
 	result := make(map[string]interface{})
 
-	result["prepared_id"] = string((f.decoder).ReadShortBytes())
+        uuid,err := UUIDFromBytes((f.decoder).ReadShortBytes())
+
+	if(err != nil){
+		logp.Err("Error in parsing UUID")
+	}
+	
+	result["prepared_id"] =  uuid.String()
+	
 	result["req_meta"] = f.parseResultMetadata(true)
 
 	if f.proto < protoVersion2 {

--- a/packetbeat/protos/cassandra/internal/gocql/frame.go
+++ b/packetbeat/protos/cassandra/internal/gocql/frame.go
@@ -443,13 +443,13 @@ func (f *Framer) parseResultPrepared() map[string]interface{} {
 
 	result := make(map[string]interface{})
 
-        uuid,err := UUIDFromBytes((f.decoder).ReadShortBytes())
+        uuid, err := UUIDFromBytes((f.decoder).ReadShortBytes())
 
 	if err != nil {
 		logp.Err("Error in parsing UUID")
 	}
 	
-	result["prepared_id"] =  uuid.String()
+	result["prepared_id"] = uuid.String()
 	
 	result["req_meta"] = f.parseResultMetadata(true)
 

--- a/packetbeat/protos/cassandra/internal/gocql/frame.go
+++ b/packetbeat/protos/cassandra/internal/gocql/frame.go
@@ -443,14 +443,14 @@ func (f *Framer) parseResultPrepared() map[string]interface{} {
 
 	result := make(map[string]interface{})
 
-        uuid, err := UUIDFromBytes((f.decoder).ReadShortBytes())
+	uuid, err := UUIDFromBytes((f.decoder).ReadShortBytes())
 
 	if err != nil {
 		logp.Err("Error in parsing UUID")
 	}
-	
+
 	result["prepared_id"] = uuid.String()
-	
+
 	result["req_meta"] = f.parseResultMetadata(true)
 
 	if f.proto < protoVersion2 {

--- a/packetbeat/protos/cassandra/internal/gocql/frame.go
+++ b/packetbeat/protos/cassandra/internal/gocql/frame.go
@@ -445,7 +445,7 @@ func (f *Framer) parseResultPrepared() map[string]interface{} {
 
         uuid,err := UUIDFromBytes((f.decoder).ReadShortBytes())
 
-	if(err != nil){
+	if err != nil {
 		logp.Err("Error in parsing UUID")
 	}
 	


### PR DESCRIPTION
Cassandra response for prepare statement contains prepareid of type UUID. Currently this is parsed as string. Added code fix to parse UUID and convert the same to string