### PR TITLE
Allow filebeat to only run once

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -116,6 +116,7 @@ https://github.com/elastic/beats/compare/v5.0.0-alpha5...master[Check the HEAD d
 *Filebeat*
 - Introduce close_timeout harvester options {issue}1926[1926]
 - Strip BOM from first message in case of BOM files {issue}2351[2351]
+- Add command line option -once to run filebeat only once and then close {pull}2456[2456]
 
 
 - Add harvester_limit option {pull}2417[2417]

--- a/filebeat/beater/filebeat.go
+++ b/filebeat/beater/filebeat.go
@@ -155,6 +155,8 @@ func (fb *Filebeat) Run(b *beat.Beat) error {
 			logp.Info("Shutdown output timer started. Waiting for max %v.", timeout)
 			waitEvents.Add(withLog(waitDuration(timeout),
 				"Continue shutdown: Time out waiting for events being published."))
+		} else {
+			waitEvents.AddChan(fb.done)
 		}
 	}
 

--- a/filebeat/beater/filebeat.go
+++ b/filebeat/beater/filebeat.go
@@ -1,6 +1,7 @@
 package beater
 
 import (
+	"flag"
 	"fmt"
 	"sync"
 
@@ -15,11 +16,12 @@ import (
 	"github.com/elastic/beats/filebeat/spooler"
 )
 
+var once = flag.Bool("once", false, "Run filebeat only once until all harvesters reach EOF")
+
 // Filebeat is a beater object. Contains all objects needed to run the beat
 type Filebeat struct {
-	config  *cfg.Config
-	sigWait *signalWait
-	done    chan struct{}
+	config *cfg.Config
+	done   chan struct{}
 }
 
 // New creates a new Filebeat pointer instance.
@@ -33,9 +35,8 @@ func New(b *beat.Beat, rawConfig *common.Config) (beat.Beater, error) {
 	}
 
 	fb := &Filebeat{
-		done:    make(chan struct{}),
-		sigWait: newSignalWait(),
-		config:  &config,
+		done:   make(chan struct{}),
+		config: &config,
 	}
 	return fb, nil
 }
@@ -45,13 +46,12 @@ func (fb *Filebeat) Run(b *beat.Beat) error {
 	var err error
 	config := fb.config
 
-	var wgEvents *sync.WaitGroup // count active events for waiting on shutdown
-	var finishedLogger publisher.SuccessLogger
+	waitFinished := newSignalWait()
+	waitEvents := newSignalWait()
 
-	if fb.config.ShutdownTimeout > 0 {
-		wgEvents = &sync.WaitGroup{}
-		finishedLogger = newFinishedLogger(wgEvents)
-	}
+	// count active events for waiting on shutdown
+	wgEvents := &sync.WaitGroup{}
+	finishedLogger := newFinishedLogger(wgEvents)
 
 	// Setup registrar to persist state
 	registrar, err := registrar.New(config.RegistryFile, finishedLogger)
@@ -60,13 +60,14 @@ func (fb *Filebeat) Run(b *beat.Beat) error {
 		return err
 	}
 
-	// Channel from harvesters to spooler
-	successLogger := newRegistrarLogger(registrar)
+	// Make sure all events that were published in
+	registrarChannel := newRegistrarLogger(registrar)
+
+	// Channel from spooler to harvester
 	publisherChan := newPublisherChannel()
 
 	// Publishes event to output
-	publisher := publisher.New(config.PublishAsync,
-		publisherChan.ch, successLogger, b.Publisher)
+	publisher := publisher.New(config.PublishAsync, publisherChan.ch, registrarChannel, b.Publisher)
 
 	// Init and Start spooler: Harvesters dump events into the spooler.
 	spooler, err := spooler.New(config, publisherChan)
@@ -75,9 +76,7 @@ func (fb *Filebeat) Run(b *beat.Beat) error {
 		return err
 	}
 
-	crawler, err := crawler.New(
-		newSpoolerOutlet(fb.done, spooler, wgEvents),
-		config.Prospectors)
+	crawler, err := crawler.New(newSpoolerOutlet(fb.done, spooler, wgEvents), config.Prospectors)
 	if err != nil {
 		logp.Err("Could not init crawler: %v", err)
 		return err
@@ -98,30 +97,45 @@ func (fb *Filebeat) Run(b *beat.Beat) error {
 	// Start publisher
 	publisher.Start()
 	// Stopping publisher (might potentially drop items)
-	defer publisher.Stop()
-	defer successLogger.Close()
+	defer func() {
+		// Closes first the registrar logger to make sure not more events arrive at the registrar
+		// registrarChannel must be closed first to potentially unblock (pretty unlikely) the publisher
+		registrarChannel.Close()
+		publisher.Stop()
+	}()
 
 	// Starting spooler
 	spooler.Start()
 
 	// Stopping spooler will flush items
 	defer func() {
-		// With harvesters being stopped, optionally wait for all enqueued events being
-		// published and written by registrar before continuing shutdown.
-		fb.sigWait.Wait()
+		// Wait for all events to be processed or timeout
+		waitEvents.Wait()
 
-		// continue shutdown
+		// Closes publisher so no further events can be sent
 		publisherChan.Close()
+		// Stopping spooler
 		spooler.Stop()
 	}()
 
-	err = crawler.Start(registrar.GetStates())
+	err = crawler.Start(registrar.GetStates(), *once)
 	if err != nil {
 		return err
 	}
-	// Blocks progressing. As soon as channel is closed, all defer statements come into play
 
-	<-fb.done
+	// If run once, add crawler completion check as alternative to done signal
+	if *once {
+		runOnce := func() {
+			logp.Info("Running filebeat once. Waiting for completion ...")
+			crawler.WaitForCompletion()
+			logp.Info("All data collection completed. Shutting down.")
+		}
+		waitFinished.Add(runOnce)
+	}
+
+	// Add done channel to wait for shutdown signal
+	waitFinished.AddChan(fb.done)
+	waitFinished.Wait()
 
 	// Stop crawler -> stop prospectors -> stop harvesters
 	// Note: waiting for crawlers to stop here in order to install wgEvents.Wait
@@ -130,14 +144,18 @@ func (fb *Filebeat) Run(b *beat.Beat) error {
 	crawler.Stop()
 
 	timeout := fb.config.ShutdownTimeout
-	if timeout > 0 {
-		logp.Info("Shutdown output timer started. Waiting for max %v.", timeout)
-
-		// Wait for either timeout or all events having been ACKed by outputs.
-		fb.sigWait.Add(withLog(wgEvents.Wait,
+	// Checks if on shutdown it should wait for all events to be published
+	waitPublished := fb.config.ShutdownTimeout > 0 || *once
+	if waitPublished {
+		// Wait for registrar to finish writing registry
+		waitEvents.Add(withLog(wgEvents.Wait,
 			"Continue shutdown: All enqueued events being published."))
-		fb.sigWait.Add(withLog(waitDuration(timeout),
-			"Continue shutdown: Time out waiting for events being published."))
+		// Wait for either timeout or all events having been ACKed by outputs.
+		if fb.config.ShutdownTimeout > 0 {
+			logp.Info("Shutdown output timer started. Waiting for max %v.", timeout)
+			waitEvents.Add(withLog(waitDuration(timeout),
+				"Continue shutdown: Time out waiting for events being published."))
+		}
 	}
 
 	return nil

--- a/filebeat/crawler/crawler.go
+++ b/filebeat/crawler/crawler.go
@@ -29,7 +29,7 @@ func New(out prospector.Outlet, prospectorConfigs []*common.Config) (*Crawler, e
 	}, nil
 }
 
-func (c *Crawler) Start(states file.States) error {
+func (c *Crawler) Start(states file.States, once bool) error {
 
 	logp.Info("Loading Prospectors: %v", len(c.prospectorConfigs))
 
@@ -54,7 +54,7 @@ func (c *Crawler) Start(states file.States) error {
 				logp.Debug("crawler", "Prospector %v stopped", id)
 			}()
 			logp.Debug("crawler", "Starting prospector %v", id)
-			prospector.Run()
+			prospector.Run(once)
 		}(i, p)
 	}
 
@@ -76,6 +76,10 @@ func (c *Crawler) Stop() {
 		c.wg.Add(1)
 		go stopProspector(p)
 	}
-	c.wg.Wait()
+	c.WaitForCompletion()
 	logp.Info("Crawler stopped")
+}
+
+func (c *Crawler) WaitForCompletion() {
+	c.wg.Wait()
 }

--- a/filebeat/tests/system/test_shutdown.py
+++ b/filebeat/tests/system/test_shutdown.py
@@ -10,25 +10,12 @@ Tests that Filebeat shuts down cleanly.
 
 class Test(BaseTest):
 
-    def setUp(self):
-        super(Test, self).setUp()
-
-        # Uncompress the nasa log file.
-        nasa_log = '../files/logs/nasa-50k.log'
-        if not os.path.isfile(nasa_log):
-            with gzip.open('../files/logs/nasa-50k.log.gz', 'rb') as infile:
-                with open(nasa_log, 'w') as outfile:
-                    for line in infile:
-                        outfile.write(line)
-        os.mkdir(self.working_dir + "/log/")
-        self.copy_files(["logs/nasa-50k.log"],
-                        source_dir="../files",
-                        target_dir="log")
-
     def test_shutdown(self):
         """
         Test starting and stopping Filebeat under load.
         """
+
+        self.nasa_logs()
 
         self.render_config_template(
             path=os.path.abspath(self.working_dir) + "/log/*",
@@ -43,18 +30,31 @@ class Test(BaseTest):
         """
         Test stopping filebeat under load and wait for publisher queue to be emptied.
         """
+
+        self.nasa_logs()
+
         self.render_config_template(
             path=os.path.abspath(self.working_dir) + "/log/*",
             ignore_older="1h",
             shutdown_timeout="10s",
         )
-        proc = self.start_beat(logging_args=["-e", "-v"])
-        time.sleep(.5)
-        proc.check_kill_and_wait()
+        filebeat = self.start_beat()
+
+        # Wait until first flush
+        self.wait_until(
+            lambda: self.log_contains("Flushing spooler because spooler full"),
+            max_timeout=15)
+
+        filebeat.check_kill_and_wait()
 
         log = self.get_log()
-        assert "Shutdown output timer started." in log
-        assert "Continue shutdown: All enqueued events being published." in log
+        self.wait_until(
+            lambda: self.log_contains("Shutdown output timer started."),
+            max_timeout=15)
+
+        self.wait_until(
+            lambda: self.log_contains("Continue shutdown: All enqueued events being published."),
+            max_timeout=15)
 
         # validate registry entry offset matches last published event
         registry = self.get_registry()
@@ -66,19 +66,82 @@ class Test(BaseTest):
         """
         Test stopping filebeat under load and wait for publisher queue to be emptied.
         """
+
+        self.nasa_logs()
+
         self.render_config_template(
             logstash={"host": "does.not.exist:12345"},
             path=os.path.abspath(self.working_dir) + "/log/*",
             ignore_older="1h",
             shutdown_timeout="1s",
         )
-        proc = self.start_beat(logging_args=["-e", "-v"])
-        time.sleep(.5)
-        proc.check_kill_and_wait()
+        filebeat = self.start_beat()
 
-        log = self.get_log()
-        assert "Shutdown output timer started." in log
-        assert "Continue shutdown: Time out waiting for events being published." in log
+        # Wait until it tries the first time to publish
+        self.wait_until(
+            lambda: self.log_contains("ERR Connecting error publishing events"),
+            max_timeout=15)
+
+        filebeat.check_kill_and_wait()
+
+        self.wait_until(
+            lambda: self.log_contains("Shutdown output timer started."),
+            max_timeout=15)
+
+        self.wait_until(
+            lambda: self.log_contains("Continue shutdown: Time out waiting for events being published."),
+            max_timeout=15)
 
         # check registry being really empty
         assert self.get_registry() == []
+
+    def test_once(self):
+        """
+        Test filebeat running with the once flag.
+        """
+
+        self.render_config_template(
+            path=os.path.abspath(self.working_dir) + "/log/test.log",
+            close_eof="true",
+            scan_frequency="1s"
+        )
+
+        os.mkdir(self.working_dir + "/log/")
+
+        testfile = self.working_dir + "/log/test.log"
+        file = open(testfile, 'w')
+
+        iterations = 100
+        for n in range(0, iterations):
+            file.write("entry " + str(n+1))
+            file.write("\n")
+
+        file.close()
+
+        filebeat = self.start_beat(extra_args=["-once"])
+
+        # Make sure all lines are read
+        self.wait_until(lambda: self.output_has(lines=iterations), max_timeout=10)
+
+        # Waits for filebeat to stop
+        self.wait_until(
+            lambda: self.log_contains("filebeat stopped."),
+            max_timeout=15)
+
+        # Checks that registry was written
+        data = self.get_registry()
+        assert len(data) == 1
+
+    def nasa_logs(self):
+
+        # Uncompress the nasa log file.
+        nasa_log = '../files/logs/nasa-50k.log'
+        if not os.path.isfile(nasa_log):
+            with gzip.open('../files/logs/nasa-50k.log.gz', 'rb') as infile:
+                with open(nasa_log, 'w') as outfile:
+                    for line in infile:
+                        outfile.write(line)
+        os.mkdir(self.working_dir + "/log/")
+        self.copy_files(["logs/nasa-50k.log"],
+                        source_dir="../files",
+                        target_dir="log")


### PR DESCRIPTION
When the `-once` flag is used, filebeat starts all configured harvesters and prospectors and runs each prospector until the harvesters are closed. It is recommended to use the flag in combination with `close_eof` so harvester directly close when the end of the file is reached. By default harvesters are closed after `close_inactive`.

Closes https://github.com/elastic/beats/issues/880