### PR TITLE
Remove docs mentions of the apt/yum repos

### DIFF
--- a/filebeat/docs/getting-started.asciidoc
+++ b/filebeat/docs/getting-started.asciidoc
@@ -20,8 +20,6 @@ mac>> for OS X, and <<win, win>> for Windows).
 
 [NOTE]
 ==================================================
-If you use Apt or Yum, you can {libbeat}/setup-repositories.html[install Filebeat from our repositories] to update to the newest version more easily.
-
 See our https://www.elastic.co/downloads/beats/filebeat[download page] for other installation options, such as 32-bit images.
 ==================================================
 

--- a/libbeat/docs/index.asciidoc
+++ b/libbeat/docs/index.asciidoc
@@ -20,7 +20,7 @@ include::./gettingstarted.asciidoc[]
 
 include::./installing-beats.asciidoc[]
 
-include::./repositories.asciidoc[]
+//include::./repositories.asciidoc[]
 
 include::./config-file-format.asciidoc[]
 

--- a/metricbeat/docs/gettingstarted.asciidoc
+++ b/metricbeat/docs/gettingstarted.asciidoc
@@ -35,10 +35,6 @@ mac>> for OS X, and <<win, win>> for Windows).
 
 [NOTE]
 ==================================================
-If you use Apt or Yum, you can
-{libbeat}/setup-repositories.html[install Metricbeat from our repositories] to
-update to the newest version more easily.
-
 See our https://www.elastic.co/downloads/beats/metricbeat[download page] for
 other installation options, such as 32-bit images.
 ==================================================

--- a/packetbeat/docs/gettingstarted.asciidoc
+++ b/packetbeat/docs/gettingstarted.asciidoc
@@ -23,8 +23,6 @@ Redhat/Centos/Fedora, <<mac, mac>> for OS X, and <<win, win>> for Windows).
 
 [NOTE]
 ==================================================
-If you use Apt or Yum, you can {libbeat}/setup-repositories.html[install Packetbeat from our repositories] to update to the newest version more easily.
-
 See our https://www.elastic.co/downloads/beats/packetbeat[download page] for other installation options, such as 32-bit images.
 ==================================================
 


### PR DESCRIPTION
We don't have the repos for the alphas, so remove for now the
mentions about them. Closes #2454.

The docs should be added back after beta1, but the instructions
will likely change a little, so they need updating anyhow.