### PR TITLE
Add a float tag to cgroup topic on system/process docs

### DIFF
--- a/metricbeat/module/system/process/_meta/docs.asciidoc
+++ b/metricbeat/module/system/process/_meta/docs.asciidoc
@@ -10,6 +10,7 @@ This metricset is available on:
 - Linux
 - Windows
 
+[float]
 === Control Group (cgroup) Metrics
 
 On Linux this metricset can collect metrics from any cgroups that the process


### PR DESCRIPTION
<img width="357" alt="cgroup-at-wrong-level" src="https://cloud.githubusercontent.com/assets/4565752/18312520/2f2ed272-74d8-11e6-998c-d2b7e0175643.png">
