### PR TITLE
Fix non existing registrar reading

### DIFF
--- a/filebeat/tests/system/test_registrar.py
+++ b/filebeat/tests/system/test_registrar.py
@@ -831,6 +831,10 @@ class Test(BaseTest):
             lambda: self.log_contains("Registry file updated"),
             max_timeout=15)
 
+        if os.name == "nt":
+            # On windows registry recration can take a bit longer
+            time.sleep(1)
+
         data = self.get_registry()
         assert len(data) == 2
 


### PR DESCRIPTION
Under windows the registry file is renamed to .old first and then the new one is created. In the tests it can happen that the registry file is read exactly when the original is missing. This PR fixes the test

An example of such a failure can be found here: https://ci.appveyor.com/project/elastic-beats/beats/build/5404/job/ogqkpvsf8a0xcwg4