### PR TITLE
Dockerfile for Metricbeat to test cgroups

### DIFF
--- a/testing/environments/5.0.0-cgroups.yml
+++ b/testing/environments/5.0.0-cgroups.yml
@@ -13,3 +13,13 @@ logstash:
 kibana:
   build: ./docker/kibana
   dockerfile: Dockerfile-5.0.0-alpha5
+
+metricbeat:
+  build: ./docker/metricbeat
+  dockerfile: Dockerfile-5.0.0-cgroups
+  links:
+    - elasticsearch
+  volumes:
+    - "/proc:/hostfs/proc:ro"
+    - "/sys/fs/cgroup:/hostfs/sys/fs/cgroup"
+  command: -system.hostfs=/hostfs -E output.elasticsearch.hosts=elasticsearch -E metricbeat.modules.0.cgroups=true

--- a/testing/environments/Makefile
+++ b/testing/environments/Makefile
@@ -10,6 +10,11 @@ stop:
 	${BASE_COMMAND} stop
 	${BASE_COMMAND} rm -f
 
+
+up:
+	${BASE_COMMAND} build
+	${BASE_COMMAND} up
+
 # Be careful using this command, as it will remove all containers and volumes of your docker-machine
 clean:
 	docker stop $(shell docker ps -a -q)

--- a/testing/environments/docker/metricbeat/Dockerfile-5.0.0-cgroups
+++ b/testing/environments/docker/metricbeat/Dockerfile-5.0.0-cgroups
@@ -1,0 +1,12 @@
+FROM ubuntu:14.04
+MAINTAINER Monica Sarbu <monica@elastic.co>
+
+ENV METRICBEAT_FILE=metricbeat-6.0.0-alpha1-SNAPSHOT-linux-x86_64
+
+ADD https://beats-nightlies.s3.amazonaws.com/metricbeat/$METRICBEAT_FILE.tar.gz /$METRICBEAT_FILE.tar.gz
+
+RUN tar -xzvf $METRICBEAT_FILE.tar.gz && \
+    ln -s $METRICBEAT_FILE metricbeat
+
+EXPOSE 8080
+ENTRYPOINT ["/metricbeat/metricbeat", "-httpprof", "0.0.0.0:8080", "-c", "/metricbeat/metricbeat.yml", "-e", "-v"]

--- a/testing/environments/docker/metricbeat/config/metricbeat.cgroups.yml
+++ b/testing/environments/docker/metricbeat/config/metricbeat.cgroups.yml
@@ -1,0 +1,103 @@
+###################### Metricbeat Configuration Example #######################
+
+# This file is an example configuration file highlighting only the most common
+# options. The metricbeat.full.yml file from the same directory contains all the
+# supported options with more comments. You can use it as a reference.
+#
+# You can find the full configuration reference here:
+# https://www.elastic.co/guide/en/beats/metricbeat/index.html
+
+#==========================  Modules configuration ============================
+metricbeat.modules:
+
+#------------------------------- System Module -------------------------------
+- module: system
+  metricsets:
+    # CPU stats
+    - cpu
+
+    # System Load stats
+    - load
+
+    # Per CPU core stats
+    #- core
+
+    # IO stats
+    #- diskio
+
+    # Per filesystem stats
+    - filesystem
+
+    # File system summary stats
+    #- fsstat
+
+    # Memory stats
+    - memory
+
+    # Network stats
+    - network
+
+    # Per process stats
+    - process
+  enabled: true
+  period: 10s
+  processes: ['.*']
+  cgroups: true
+
+
+
+#================================ General =====================================
+
+# The name of the shipper that publishes the network data. It can be used to group
+# all the transactions sent by a single shipper in the web interface.
+#name:
+
+# The tags of the shipper are included in their own field with each
+# transaction published.
+#tags: ["service-X", "web-tier"]
+
+# Optional fields that you can specify to add additional information to the
+# output.
+#fields:
+#  env: staging
+
+#================================ Outputs =====================================
+
+# Configure what outputs to use when sending the data collected by the beat.
+# Multiple outputs may be used.
+
+#-------------------------- Elasticsearch output ------------------------------
+output.elasticsearch:
+  # Array of hosts to connect to.
+  hosts: ["localhost:9200"]
+
+  # Optional protocol and basic auth credentials.
+  #protocol: "https"
+  #username: "elastic"
+  #password: "changeme"
+
+#----------------------------- Logstash output --------------------------------
+#output.logstash:
+  # The Logstash hosts
+  #hosts: ["localhost:5044"]
+
+  # Optional SSL. By default is off.
+  # List of root certificates for HTTPS server verifications
+  #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
+
+  # Certificate for SSL client authentication
+  #ssl.certificate: "/etc/pki/client/cert.pem"
+
+  # Client Certificate Key
+  #ssl.key: "/etc/pki/client/cert.key"
+
+#================================ Logging =====================================
+
+# Sets log level. The default log level is info.
+# Available log levels are: critical, error, warning, info, debug
+#logging.level: debug
+
+# At debug level, you can selectively enable logging only for some components.
+# To enable all selectors use ["*"]. Examples of other selectors are "beat",
+# "publish", "service".
+#logging.selectors: ["*"]

--- a/testing/environments/ports.yml
+++ b/testing/environments/ports.yml
@@ -12,6 +12,8 @@ kibana:
   ports:
     - "5601:5601"
 
+# The link is available here in order to avoid fetching and building it for each CI build on travis and jenkins which
+# makes the builds a lot slower.
 beat:
   links:
     - kibana


### PR DESCRIPTION
Add a Dockerfile for Metricbeat to test cgroups functionality. 

You need to run the following commands to start a container with Kibana, one with Elasticsearch and one with Metricbeat:
```
$ make up ENV=5.0.0-cgroups.yml 
```

To stop all the containers, you can use:
```
$ make stop ENV=5.0.0-cgroups.yml
```