### PR TITLE
Update to kibana to most recent snapshot

### DIFF
--- a/testing/environments/docker/kibana/Dockerfile-snapshot
+++ b/testing/environments/docker/kibana/Dockerfile-snapshot
@@ -16,7 +16,7 @@ RUN arch="$(dpkg --print-architecture)" \
 	&& chmod +x /usr/local/bin/gosu
 
 RUN set -x \
-	&& curl -fSL "https://download.elastic.co/kibana/kibana-snapshot/kibana-5.0.0-alpha6-SNAPSHOT-linux-x86_64.tar.gz?20160811" -o kibana.tar.gz \
+	&& curl -fSL "https://download.elastic.co/kibana/kibana-snapshot/kibana-5.0.0-alpha6-SNAPSHOT-linux-x86_64.tar.gz?20160908" -o kibana.tar.gz \
 	&& mkdir -p /opt/kibana \
 	&& tar -xz --strip-components=1 -C /opt/kibana -f kibana.tar.gz \
 	&& chown -R kibana:kibana /opt/kibana \
@@ -25,10 +25,6 @@ RUN set -x \
 ENV PATH /opt/kibana/bin:$PATH
 
 COPY ./docker-entrypoint.sh /
-
-#RUN gosu kibana kibana-plugin install timelion
-# This is a temporary fix as currently no alpha6 snapshot for timelion exists
-RUN gosu kibana kibana-plugin install https://download.elastic.co/kibana/timelion/timelion-5.0.0-beta1.zip
 
 EXPOSE 5601
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/testing/environments/docker/kibana/docker-entrypoint.sh
+++ b/testing/environments/docker/kibana/docker-entrypoint.sh
@@ -12,6 +12,7 @@ if [ "$1" = 'kibana' ]; then
 	if [ "$ELASTICSEARCH_URL" -o "$ELASTICSEARCH_PORT_9200_TCP" ]; then
 		: ${ELASTICSEARCH_URL:='http://elasticsearch:9200'}
 		sed -ri "s!^(\#\s*)?(elasticsearch\.url:).*!\2 '$ELASTICSEARCH_URL'!" /opt/kibana/config/kibana.yml
+		sed -ri "s!^(\#\s*)?(server\.host:).*!\2 '0.0.0.0'!" /opt/kibana/config/kibana.yml
 	else
 		echo >&2 'warning: missing ELASTICSEARCH_PORT_9200_TCP or ELASTICSEARCH_URL'
 		echo >&2 '  Did you forget to --link some-elasticsearch:elasticsearch'


### PR DESCRIPTION
* Timelion is now part of master, not need to install it anymore
* Default host is now localhost, 0.0.0.0 for dev needs config file: https://github.com/elastic/kibana/pull/8013