### PR TITLE
add parsing of Packetbeat DNS answers into fields

### DIFF
--- a/packetbeat/protos/dns/dns.go
+++ b/packetbeat/protos/dns/dns.go
@@ -476,7 +476,9 @@ func addDnsToMapStr(m common.MapStr, dns *mkdns.Msg, authority bool, additional 
 
 	m["authorities_count"] = len(dns.Ns)
 	if authority && len(dns.Ns) > 0 {
-		m["authorities"] = rrsToMapStrs(dns.Ns)
+        authorities := ansToMapStrs(dns.Ns)
+        authorities["raw"] = rrsToMapStrs(dns.Ns)
+		m["authorities"] = authorities
 	}
 
 	if rrOPT != nil {
@@ -489,7 +491,9 @@ func addDnsToMapStr(m common.MapStr, dns *mkdns.Msg, authority bool, additional 
 		// We do not want OPT RR to appear in the 'additional' section,
 		// that's why rrsMapStrs could be empty even though len(dns.Extra) > 0
 		if len(rrsMapStrs) > 0 {
-			m["additionals"] = rrsMapStrs
+            additionals := ansToMapStrs(dns.Extra)
+            additionals["raw"] = rrsMapStrs
+			m["additionals"] = additionals
 		}
 	}
 

--- a/packetbeat/protos/dns/dns.go
+++ b/packetbeat/protos/dns/dns.go
@@ -469,7 +469,10 @@ func addDnsToMapStr(m common.MapStr, dns *mkdns.Msg, authority bool, additional 
 
 	m["answers_count"] = len(dns.Answer)
 	if len(dns.Answer) > 0 {
-		m["answers"] = ansToMapStrs(dns.Answer)
+		//m["answers"] = ansToMapStrs(dns.Answer)
+        ans := ansToMapStrs(dns.Answer)
+        ans["raw"] = rrsToMapStrs(dns.Answer)
+		m["answers"] = ans
 	}
 
 	m["authorities_count"] = len(dns.Ns)
@@ -551,20 +554,40 @@ func rrsToMapStrs(records []mkdns.RR) []common.MapStr {
 	return mapStrArray
 }
 
+func AppendStrIfMissing(slice []string, i string) []string {
+    for _, ele := range slice {
+        if ele == i {
+            return slice
+        }
+    }
+    return append(slice, i)
+}
+
+func AppendIntIfMissing(slice []int, i int) []int {
+    for _, ele := range slice {
+        if ele == i {
+            return slice
+        }
+    }
+    return append(slice, i)
+}
+
 // ansToMapStrs extracts answers from an array of RR's and returns MapStr.
+// TODO adapt unit tests for this
 func ansToMapStrs(answers []mkdns.RR) common.MapStr {
         answer_class := []string{}
         answer_data := []string{}
         answer_name := []string{}
-        answer_ttl := []string{}
+        answer_ttl := []int{}
         answer_type := []string{}
 
         for _, a := range rrsToMapStrs(answers) {
-            answer_class = append(answer_class, fmt.Sprint(a["class"]))
-            answer_data = append(answer_data, fmt.Sprint(a["data"]))
-            answer_name = append(answer_name, fmt.Sprint(a["name"]))
-            answer_ttl = append(answer_ttl, fmt.Sprint(a["ttl"]))
-            answer_type = append(answer_type, fmt.Sprint(a["type"]))
+            answer_class = AppendStrIfMissing(answer_class, fmt.Sprint(a["class"]))
+            answer_data = AppendStrIfMissing(answer_data, fmt.Sprint(a["data"]))
+            answer_name = AppendStrIfMissing(answer_name, fmt.Sprint(a["name"]))
+            i, _ := strconv.Atoi(fmt.Sprint(a["ttl"]))
+            answer_ttl = AppendIntIfMissing(answer_ttl, i)
+            answer_type = AppendStrIfMissing(answer_type, fmt.Sprint(a["type"]))
         }
         ansMapStr := common.MapStr{}
         ansMapStr["class"] = answer_class

--- a/packetbeat/protos/dns/dns.go
+++ b/packetbeat/protos/dns/dns.go
@@ -469,7 +469,7 @@ func addDnsToMapStr(m common.MapStr, dns *mkdns.Msg, authority bool, additional 
 
 	m["answers_count"] = len(dns.Answer)
 	if len(dns.Answer) > 0 {
-		m["answers"] = rrsToMapStrs(dns.Answer)
+		m["answers"] = ansToMapStrs(dns.Answer)
 	}
 
 	m["authorities_count"] = len(dns.Ns)
@@ -550,6 +550,30 @@ func rrsToMapStrs(records []mkdns.RR) []common.MapStr {
 	}
 	return mapStrArray
 }
+
+// ansToMapStrs extracts answers from an array of RR's and returns MapStr.
+func ansToMapStrs(answers []mkdns.RR) common.MapStr {
+        answer_class := []string{}
+        answer_data := []string{}
+        answer_name := []string{}
+        answer_ttl := []string{}
+        answer_type := []string{}
+
+        for _, a := range rrsToMapStrs(answers) {
+            answer_class = append(answer_class, fmt.Sprint(a["class"]))
+            answer_data = append(answer_data, fmt.Sprint(a["data"]))
+            answer_name = append(answer_name, fmt.Sprint(a["name"]))
+            answer_ttl = append(answer_ttl, fmt.Sprint(a["ttl"]))
+            answer_type = append(answer_type, fmt.Sprint(a["type"]))
+        }
+        ansMapStr := common.MapStr{}
+        ansMapStr["class"] = answer_class
+        ansMapStr["data"] = answer_data
+        ansMapStr["name"] = answer_name
+        ansMapStr["ttl"] = answer_ttl
+        ansMapStr["type"] = answer_type
+        return ansMapStr
+    }
 
 // Convert all RDATA fields of a RR to a single string
 // fields are ordered alphabetically with 'data' as the last element

--- a/packetbeat/protos/dns/dns.go
+++ b/packetbeat/protos/dns/dns.go
@@ -469,7 +469,6 @@ func addDnsToMapStr(m common.MapStr, dns *mkdns.Msg, authority bool, additional 
 
 	m["answers_count"] = len(dns.Answer)
 	if len(dns.Answer) > 0 {
-		//m["answers"] = ansToMapStrs(dns.Answer)
         ans := ansToMapStrs(dns.Answer)
         ans["raw"] = rrsToMapStrs(dns.Answer)
 		m["answers"] = ans


### PR DESCRIPTION
Add parsing of Packetbeat DNS answers into fields.
Before this change the DNS answers were added to the Elasticsearch
indexes as a list of arrays. Arrays are not working well with Kibana.
After this change these individual fields are parsed:
- dns.answers.class
- dns.answers.data
- dns.answers.name
- dns.answers.ttl
- dns.answers.type

As the DNS answers can contain multiple records (even of different type)
the actual result values are put into a list.
These lists should be treated as Multivalue Fields in the index.

Before

```
"answers": [
  {
    "class": "IN",
    "data": "193.99.144.80",
    "name": "heise.de.",
    "ttl": "1143",
    "type": "A"
  }
]
```

After

```
"answers": {
  "class": [
    "IN"
  ],
  "data": [
    "193.99.144.80"
  ],
  "name": [
    "heise.de."
  ],
  "ttl": [
    "1143"
  ],
  "type": [
    "A"
  ]
}
```
