### PR TITLE
Fix map concurrent bug

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -63,6 +63,14 @@ https://github.com/elastic/beats/compare/v1.3.0...1.3[Check the HEAD diff]
 
 ////////////////////////////////////////////////////////////
 
+[[release-notes-1.3.1]]
+=== Beats version 1.3.1
+https://github.com/elastic/beats/compare/v1.3.0...v1.3.1[View commits]
+
+*Filebeat*
+
+- Fix a concurrent bug on filebeat startup with a large number of prospectors defined. {pull}2509[2509]
+
 [[release-notes-1.3.0]]
 === Beats version 1.3.0
 https://github.com/elastic/beats/compare/v1.2.3...v1.3.0[View commits]

--- a/filebeat/crawler/crawler.go
+++ b/filebeat/crawler/crawler.go
@@ -67,7 +67,7 @@ func (crawler *Crawler) Start(files []config.ProspectorConfig, eventChan chan *i
 			}
 			continue
 		}
-		crawler.Registrar.state[event.Source] = event
+		crawler.Registrar.setState(event)
 		logp.Debug("prospector", "Registrar will re-save state for %s", event.Source)
 
 		if !crawler.running {


### PR DESCRIPTION
crawler.Registrar.state may be accessed both in function `(*Prospector).scan` and pulling the events from the `crawler.Registrar.Persist`, which leads to `fatal error: concurrent map read and map write`