### PR TITLE
Fix panic on fast file rotation

### DIFF
--- a/filebeat/prospector/prospector_log.go
+++ b/filebeat/prospector/prospector_log.go
@@ -112,7 +112,7 @@ func (p *ProspectorLog) getFiles() map[string]os.FileInfo {
 			// Fetch Lstat File info to detected also symlinks
 			fileInfo, err := os.Lstat(file)
 			if err != nil {
-				logp.Debug("prospector", "stat(%s) failed: %s", file, err)
+				logp.Debug("prospector", "lstat(%s) failed: %s", file, err)
 				continue
 			}
 
@@ -127,8 +127,12 @@ func (p *ProspectorLog) getFiles() map[string]os.FileInfo {
 				continue
 			}
 
-			// Fetch Stat file info which fetches the inode from the original and is used for comparison
+			// Fetch Stat file info which fetches the inode. In case of a symlink, the original inode is fetched
 			fileInfo, err = os.Stat(file)
+			if err != nil {
+				logp.Debug("prospector", "stat(%s) failed: %s", file, err)
+				continue
+			}
 
 			// If symlink is enabled, it is checked that original is not part of same prospector
 			// It original is harvested by other prospector, states will potentially overwrite each other


### PR DESCRIPTION
This bug was introduce with https://github.com/elastic/beats/pull/2478 . The check for the second Stat receiving was missing. In case of very fast rotating file it could be that exactly at the time of Stat request the file is not existing anymore and an error is returned. The error was not checked.