### PR TITLE
Add shutdown timeout

### DIFF
--- a/filebeat/beater/signalwait.go
+++ b/filebeat/beater/signalwait.go
@@ -1,0 +1,48 @@
+package beater
+
+import "time"
+
+type signalWait struct {
+	count   int // number of potential 'alive' signals
+	signals chan struct{}
+}
+
+func newSignalWait() *signalWait {
+	return &signalWait{
+		signals: make(chan struct{}, 1),
+	}
+}
+
+func (s *signalWait) Wait() {
+	if s.count == 0 {
+		return
+	}
+
+	<-s.signals
+	s.count--
+}
+
+func (s *signalWait) Add(fn func()) {
+	s.count++
+	go func() {
+		fn()
+		var v struct{}
+		s.signals <- v
+	}()
+}
+
+func (s *signalWait) AddChan(c <-chan struct{}) {
+	s.Add(func() { <-c })
+}
+
+func (s *signalWait) AddTimer(t *time.Timer) {
+	s.Add(func() { <-t.C })
+}
+
+func (s *signalWait) AddTimeout(d time.Duration) {
+	s.AddTimer(time.NewTimer(d))
+}
+
+func (s *signalWait) Signal() {
+	s.Add(func() {})
+}

--- a/filebeat/config/config.go
+++ b/filebeat/config/config.go
@@ -19,19 +19,21 @@ const (
 )
 
 type Config struct {
-	Prospectors  []*common.Config `config:"prospectors"`
-	SpoolSize    uint64           `config:"spool_size" validate:"min=1"`
-	PublishAsync bool             `config:"publish_async"`
-	IdleTimeout  time.Duration    `config:"idle_timeout" validate:"nonzero,min=0s"`
-	RegistryFile string           `config:"registry_file"`
-	ConfigDir    string           `config:"config_dir"`
+	Prospectors     []*common.Config `config:"prospectors"`
+	SpoolSize       uint64           `config:"spool_size" validate:"min=1"`
+	PublishAsync    bool             `config:"publish_async"`
+	IdleTimeout     time.Duration    `config:"idle_timeout" validate:"nonzero,min=0s"`
+	RegistryFile    string           `config:"registry_file"`
+	ConfigDir       string           `config:"config_dir"`
+	ShutdownTimeout time.Duration    `config:"shutdown_timeout"`
 }
 
 var (
 	DefaultConfig = Config{
-		RegistryFile: "registry",
-		SpoolSize:    2048,
-		IdleTimeout:  5 * time.Second,
+		RegistryFile:    "registry",
+		SpoolSize:       2048,
+		IdleTimeout:     5 * time.Second,
+		ShutdownTimeout: 0,
 	}
 )
 

--- a/filebeat/etc/beat.full.yml
+++ b/filebeat/etc/beat.full.yml
@@ -231,3 +231,7 @@ filebeat.prospectors:
 # the prospector part is processed. All global options like spool_size are ignored.
 # The config_dir MUST point to a different directory then where the main filebeat config file is in.
 #filebeat.config_dir:
+
+# How long filebeat waits on shutdown for the publisher to finish.
+# Default is 0, not waiting.
+#filebeat.shutdown_timeout: 0

--- a/filebeat/filebeat.full.yml
+++ b/filebeat/filebeat.full.yml
@@ -232,6 +232,10 @@ filebeat.prospectors:
 # The config_dir MUST point to a different directory then where the main filebeat config file is in.
 #filebeat.config_dir:
 
+# How long filebeat waits on shutdown for the publisher to finish.
+# Default is 0, not waiting.
+#filebeat.shutdown_timeout: 0
+
 #================================ General =====================================
 
 # The name of the shipper that publishes the network data. It can be used to group


### PR DESCRIPTION
Introduce signalWait structure to filebeat waiting for stop signal after
fb.done was closed. If shutdown_timeout is configured, filebeat will either
stop after timeout or after all enqueued events have been successfully
published and written by registrar.

I hope the signalWait idea can be reused for implementing run-once mode as well.