### PR TITLE
Fix logging error for ignore_older

### DIFF
--- a/filebeat/prospector/prospector_log.go
+++ b/filebeat/prospector/prospector_log.go
@@ -164,7 +164,9 @@ func (p *ProspectorLog) scan() {
 		// Ignores all files which fall under ignore_older
 		if p.isIgnoreOlder(newState) {
 			logp.Debug("prospector", "Ignore file because ignore_older reached: %s", newState.Source)
-			if lastState.IsEmpty() && lastState.Finished == false {
+
+			// If last state is empty, it means state was removed or never created -> can be ignored
+			if !lastState.IsEmpty() && !lastState.Finished {
 				logp.Err("File is falling under ignore_older before harvesting is finished. Adjust your close_* settings: %s", newState.Source)
 			}
 			continue


### PR DESCRIPTION
Errors were logged for files falling under ignore_older before file was closed. These errors should not have been logged. The check to log the message was wrong. There were no affects besides logging.

See https://discuss.elastic.co/t/about-clean-removed-in-filebeat-5-0-0-alpha5/59949