### PR TITLE
Fix one more flaky windows filebeat test

### DIFF
--- a/filebeat/tests/system/test_registrar.py
+++ b/filebeat/tests/system/test_registrar.py
@@ -763,6 +763,10 @@ class Test(BaseTest):
             lambda: self.log_contains("Registry file updated"),
             max_timeout=15)
 
+        if os.name == "nt":
+            # On windows registry recreation can take a bit longer
+            time.sleep(1)
+
         data = self.get_registry()
         assert len(data) == 2
 


### PR DESCRIPTION
Test is flaky because it can happen that registry is directly read during renaming

See https://ci.appveyor.com/project/elastic-beats/beats/build/5561/job/yepf9ippxtmvquk2