### PR TITLE
Change error message from 'no host...' to 'no hosts...'

### DIFF
--- a/libbeat/outputs/mode/mode.go
+++ b/libbeat/outputs/mode/mode.go
@@ -18,7 +18,7 @@ var (
 )
 
 // ErrNoHostsConfigured indicates missing host or hosts configuration
-var ErrNoHostsConfigured = errors.New("no host configuration found")
+var ErrNoHostsConfigured = errors.New("no hosts configuration found")
 
 // ConnectionMode takes care of connecting to hosts
 // and potentially doing load balancing and/or failover


### PR DESCRIPTION
In config file user define 'hosts' not 'host', so this error message is confusing 