### PR TITLE
Update to Go 1.7.1 (#2533)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,7 +6,7 @@ os: Windows Server 2012 R2
 
 # Environment variables
 environment:
-  GOROOT: c:\go1.7
+  GOROOT: c:\go1.7.1
   GOPATH: c:\gopath
   PYWIN_DL: https://beats-files.s3.amazonaws.com/deps/pywin32-220.win32-py2.7.exe
   matrix:
@@ -22,13 +22,13 @@ clone_folder: c:\gopath\src\github.com\elastic\beats
 cache:
 - C:\ProgramData\chocolatey\bin -> .appveyor.yml
 - C:\ProgramData\chocolatey\lib -> .appveyor.yml
-- C:\go1.7 -> .appveyor.yml
+- C:\go1.7.1 -> .appveyor.yml
 - C:\tools\mingw64 -> .appveyor.yml
 - C:\pywin_inst.exe -> .appveyor.yml
 
 # Scripts that run after cloning repository
 install:
-  - ps: c:\gopath\src\github.com\elastic\beats\libbeat\scripts\install-go.ps1 -version 1.7
+  - ps: c:\gopath\src\github.com\elastic\beats\libbeat\scripts\install-go.ps1 -version 1.7.1
   - set PATH=%GOROOT%\bin;%PATH%
   # AppVeyor installed mingw is 32-bit only.
   - ps: >-

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
 language: go
 
 go:
-  - 1.7
+  - 1.7.1
 
 # Make sure project can also be built on travis for clones of the repo
 go_import_path: github.com/elastic/beats

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ Beats](https://github.com/elastic/beats/blob/master/libbeat/docs/communitybeats.
 
 The Beats are Go programs, so install the latest version of
 [golang](http://golang.org/) if you don't have it already. The current Go version
-used for development is Golang 1.7.
+used for development is Golang 1.7.1.
 
 The location where you clone is important. Please clone under the source
 directory of your `GOPATH`. If you don't have `GOPATH` already set, you can

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.7
+FROM golang:1.7.1
 MAINTAINER Nicolas Ruflin <ruflin@elastic.co>
 
 RUN set -x && \

--- a/dev-tools/packer/docker/xgo-image-deb6/beats-builder/Dockerfile
+++ b/dev-tools/packer/docker/xgo-image-deb6/beats-builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM tudorg/xgo-deb6-1.7
+FROM tudorg/xgo-deb6-1.7.1
 
 MAINTAINER Tudor Golubenco <tudor@elastic.co>
 

--- a/dev-tools/packer/docker/xgo-image-deb6/build.sh
+++ b/dev-tools/packer/docker/xgo-image-deb6/build.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 docker build --rm=true -t tudorg/xgo-deb6-base base/ && \
-    docker build --rm=true -t tudorg/xgo-deb6-1.7 go-1.7/ &&
+    docker build --rm=true -t tudorg/xgo-deb6-1.7.1 go-1.7.1/ &&
     docker build --rm=true -t tudorg/beats-builder-deb6 beats-builder

--- a/dev-tools/packer/docker/xgo-image-deb6/go-1.7.1/Dockerfile
+++ b/dev-tools/packer/docker/xgo-image-deb6/go-1.7.1/Dockerfile
@@ -1,15 +1,15 @@
-# Go cross compiler (xgo): Go 1.7 layer
+# Go cross compiler (xgo): Go 1.7.1 layer
 # Copyright (c) 2014 Péter Szilágyi. All rights reserved.
 #
 # Released under the MIT license.
 
-FROM tudorg/xgo-base
+FROM tudorg/xgo-deb6-base
 
 MAINTAINER Tudor Golubenco <tudor@elastic.co>
 
 # Configure the root Go distribution and bootstrap based on it
 RUN \
-  export ROOT_DIST="https://storage.googleapis.com/golang/go1.7.linux-amd64.tar.gz" && \
-  export ROOT_DIST_SHA1="a744e29da97fc3aadad1ee0d7d89b0d899645e50" && \
+  export ROOT_DIST="https://storage.googleapis.com/golang/go1.7.1.linux-amd64.tar.gz" && \
+  export ROOT_DIST_SHA1="919ab01305ada0078a9fdf8a12bb56fb0b8a1444" && \
   \
   $BOOTSTRAP_PURE

--- a/dev-tools/packer/docker/xgo-image/beats-builder/Dockerfile
+++ b/dev-tools/packer/docker/xgo-image/beats-builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM tudorg/xgo-1.7
+FROM tudorg/xgo-1.7.1
 
 MAINTAINER Tudor Golubenco <tudor@elastic.co>
 

--- a/dev-tools/packer/docker/xgo-image/build.sh
+++ b/dev-tools/packer/docker/xgo-image/build.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 docker build --rm=true -t tudorg/xgo-base base/ && \
-    docker build --rm=true -t tudorg/xgo-1.7 go-1.7/ &&
+    docker build --rm=true -t tudorg/xgo-1.7.1 go-1.7.1/ &&
     docker build --rm=true -t tudorg/beats-builder beats-builder

--- a/dev-tools/packer/docker/xgo-image/go-1.7.1/Dockerfile
+++ b/dev-tools/packer/docker/xgo-image/go-1.7.1/Dockerfile
@@ -1,15 +1,15 @@
-# Go cross compiler (xgo): Go 1.7 layer
+# Go cross compiler (xgo): Go 1.7.1 layer
 # Copyright (c) 2014 Péter Szilágyi. All rights reserved.
 #
 # Released under the MIT license.
 
-FROM tudorg/xgo-deb6-base
+FROM tudorg/xgo-base
 
 MAINTAINER Tudor Golubenco <tudor@elastic.co>
 
 # Configure the root Go distribution and bootstrap based on it
 RUN \
-  export ROOT_DIST="https://storage.googleapis.com/golang/go1.7.linux-amd64.tar.gz" && \
-  export ROOT_DIST_SHA1="a744e29da97fc3aadad1ee0d7d89b0d899645e50" && \
+  export ROOT_DIST="https://storage.googleapis.com/golang/go1.7.1.linux-amd64.tar.gz" && \
+  export ROOT_DIST_SHA1="919ab01305ada0078a9fdf8a12bb56fb0b8a1444" && \
   \
   $BOOTSTRAP_PURE

--- a/generate/beat/README.asciidoc
+++ b/generate/beat/README.asciidoc
@@ -6,7 +6,7 @@ The Beat generator enables you to create your own Beat in a few steps.
 [float]
 === Requirements
 
-To create your own Beat, you must have Golang 1.7 or later installed, and the `$GOPATH`
+To create your own Beat, you must have Golang 1.7.1 or later installed, and the `$GOPATH`
 must be set up correctly. In addition, the following tools are quired:
 
 * https://www.python.org/downloads/[python]

--- a/generate/metricbeat/metricset/README.asciidoc
+++ b/generate/metricbeat/metricset/README.asciidoc
@@ -7,7 +7,7 @@ own metricsets.
 [float]
 === Requirements
 
-To create your own Beat, you must have Golang 1.7 or later installed, and the `$GOPATH`
+To create your own Beat, you must have Golang 1.7.1 or later installed, and the `$GOPATH`
 must be set up correctly. In addition, the following tools are quired:
 
 * https://www.python.org/downloads/[python]

--- a/libbeat/Dockerfile
+++ b/libbeat/Dockerfile
@@ -1,5 +1,5 @@
 # Beats dockerfile used for testing
-FROM golang:1.7
+FROM golang:1.7.1
 MAINTAINER Nicolas Ruflin <ruflin@elastic.co>
 
 RUN set -x && \

--- a/metricbeat/Dockerfile
+++ b/metricbeat/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.7
+FROM golang:1.7.1
 MAINTAINER Nicolas Ruflin <ruflin@elastic.co>
 
 RUN set -x && \

--- a/packetbeat/Dockerfile
+++ b/packetbeat/Dockerfile
@@ -1,5 +1,5 @@
 # Beats dockerfile used for testing
-FROM golang:1.7
+FROM golang:1.7.1
 MAINTAINER Nicolas Ruflin <ruflin@elastic.co>
 
 RUN set -x && \


### PR DESCRIPTION
Backport of #2533.

This updates packaging, docker files for tests, travis and appveyor configs.