### PR TITLE
Backport: Fix corrupt Winlogbeat registry occurring on power failure (#2434)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -34,6 +34,7 @@ https://github.com/elastic/beats/compare/v1.3.1...1.3[Check the HEAD diff]
 *Filebeat*
 
 *Winlogbeat*
+- Fix corrupt registry file that occurs on power loss by disabling file write caching. {issue}2313[2313]
 
 ==== Added
 

--- a/winlogbeat/checkpoint/file_unix.go
+++ b/winlogbeat/checkpoint/file_unix.go
@@ -1,0 +1,9 @@
+// +build !windows
+
+package checkpoint
+
+import "os"
+
+func create(path string) (*os.File, error) {
+	return os.Create(path)
+}

--- a/winlogbeat/checkpoint/file_windows.go
+++ b/winlogbeat/checkpoint/file_windows.go
@@ -1,0 +1,37 @@
+package checkpoint
+
+import (
+	"os"
+	"syscall"
+)
+
+const (
+	_FILE_FLAG_WRITE_THROUGH = 0x80000000
+)
+
+func create(path string) (*os.File, error) {
+	return createWriteThroughFile(path)
+}
+
+// createWriteThroughFile creates a file whose write operations do not go
+// through any intermediary cache, they go directly to disk.
+func createWriteThroughFile(path string) (*os.File, error) {
+	if len(path) == 0 {
+		return nil, syscall.ERROR_FILE_NOT_FOUND
+	}
+	pathp, err := syscall.UTF16PtrFromString(path)
+	if err != nil {
+		return nil, err
+	}
+
+	h, err := syscall.CreateFile(
+		pathp, // Path
+		syscall.GENERIC_READ|syscall.GENERIC_WRITE,               // Access Mode
+		uint32(syscall.FILE_SHARE_READ|syscall.FILE_SHARE_WRITE), // Share Mode
+		nil, // Security Attributes
+		syscall.CREATE_ALWAYS,                                          // Create Mode
+		uint32(syscall.FILE_ATTRIBUTE_NORMAL|_FILE_FLAG_WRITE_THROUGH), // Flags and Attributes
+		0) // Template File
+
+	return os.NewFile(uintptr(h), path), err
+}


### PR DESCRIPTION
File writes are cached and not immediately flushed to disk. So if there is a power loss prior to flushing it seems that some corruption occurs. This adds the FILE_FLAG_WRITE_THROUGH flag to the CreateFile call to ensure that writes go directly to the disk.