### PR TITLE
Document supported versions for outputs

### DIFF
--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -54,6 +54,10 @@ output.elasticsearch:
 
 ------------------------------------------------------------------------------
 
+==== Compatibility
+
+This output works with all compatible versions of Elasticsearch. See "Supported Beats Versions" in the https://www.elastic.co/support/matrix#show_compatibility[Elastic Support Matrix].
+
 ==== Elasticsearch Output Options
 
 You can specify the following options in the `elasticsearch` section of the +{beatname_lc}.yml+ config file:
@@ -341,6 +345,10 @@ output.logstash:
   index: {beatname_lc}
 ------------------------------------------------------------------------------
 
+==== Compatibility
+
+This output works with all compatible versions of Logstash. See "Supported Beats Versions" in the https://www.elastic.co/support/matrix#show_compatibility[Elastic Support Matrix].
+
 ==== Logstash Output Options
 
 You can specify the following options in the `logstash` section of the
@@ -479,6 +487,10 @@ spooler size.
 
 The Kafka output sends the events to Apache Kafka.
 
+==== Compatibility
+
+This output works with Kafka 0.8, 0.9, and 0.10.
+
 ==== Kafka Output Options
 
 You can specify the following options in the `kafka` section of the +{beatname_lc}.yml+ config file:
@@ -610,6 +622,10 @@ output.redis:
   db: 0
   timeout: 5
 ------------------------------------------------------------------------------
+
+==== Compatibility
+
+This output works with Redis 3.2.0.
 
 ==== Redis Output Options
 


### PR DESCRIPTION
Adds version info as described in https://github.com/elastic/beats/issues/1450

Decided to add a separate section to be consistent with the Metricbeat docs. I'm not sure a compatibility statement warrants a separate section, but it might be nice to have a section where we can add more detail if we decide to support some versions conditionally. The downside is that users might need to scroll down (or click the "compatibility" link) to see supported versions. Does this concern anyone? The other option is to just put a note at the top of the topic right after the heading.