### PR TITLE
Prevent filebeat from starting on error with registry file

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -93,6 +93,7 @@ https://github.com/elastic/beats/compare/v5.0.0-alpha5...master[Check the HEAD d
 - Log total non-zero internal metrics on shutdown. {pull}2349[2349]
 - Add support for encrypted private key files by introducing `ssl.key_passphrase` setting. {pull}2330[2330]
 - Add experimental symlink support with `symlinks` config {pull}2478[2478]
+- Improve validation of registry file on startup.
 
 *Metricbeat*
 

--- a/filebeat/beater/filebeat.go
+++ b/filebeat/beater/filebeat.go
@@ -90,7 +90,7 @@ func (fb *Filebeat) Run(b *beat.Beat) error {
 	// Start the registrar
 	err = registrar.Start()
 	if err != nil {
-		logp.Err("Could not start registrar: %v", err)
+		return fmt.Errorf("Could not start registrar: %v", err)
 	}
 	// Stopping registrar will write last state
 	defer registrar.Stop()

--- a/filebeat/docs/reference/configuration/filebeat-options.asciidoc
+++ b/filebeat/docs/reference/configuration/filebeat-options.asciidoc
@@ -489,6 +489,8 @@ data path. See the <<directory-layout>> section for details. The default is `reg
 filebeat.registry_file: registry
 -------------------------------------------------------------------------------------
 
+It is not possible to use a symlink as registry file.
+
 
 ===== config_dir
 

--- a/filebeat/registrar/registrar.go
+++ b/filebeat/registrar/registrar.go
@@ -59,8 +59,32 @@ func (r *Registrar) Init() error {
 	registryPath := filepath.Dir(r.registryFile)
 	err := os.MkdirAll(registryPath, 0755)
 	if err != nil {
-		return fmt.Errorf("Failed to created registry file dir %s: %v",
-			registryPath, err)
+		return fmt.Errorf("Failed to created registry file dir %s: %v", registryPath, err)
+	}
+
+	// Check if files exists
+	fileInfo, err := os.Lstat(r.registryFile)
+	if os.IsNotExist(err) {
+		logp.Info("No registry file found under: %s. Creating a new registry file.", r.registryFile)
+		// No registry exists yet, write empty state to check if registry can be written
+		err = r.writeRegistry()
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	// Check if regular file, no dir, no symlink
+	if !fileInfo.Mode().IsRegular() {
+		// Special error message for directory
+		if fileInfo.IsDir() {
+			return fmt.Errorf("Registry file path must be a file. %s is a directory.", r.registryFile)
+		} else {
+			return fmt.Errorf("Registry file path is not a regular file: %s", r.registryFile)
+		}
 	}
 
 	logp.Info("Registry file set to: %s", r.registryFile)
@@ -76,18 +100,6 @@ func (r *Registrar) GetStates() file.States {
 // loadStates fetches the previous reading state from the configure RegistryFile file
 // The default file is `registry` in the data path.
 func (r *Registrar) loadStates() error {
-
-	// Check if files exists
-	_, err := os.Stat(r.registryFile)
-	if err != nil && !os.IsNotExist(err) {
-		return err
-	}
-
-	// Error means no file found
-	if err != nil {
-		logp.Info("No registry file found under: %s. Creating a new registry file.", r.registryFile)
-		return nil
-	}
 
 	f, err := os.Open(r.registryFile)
 	if err != nil {
@@ -108,8 +120,7 @@ func (r *Registrar) loadStates() error {
 	states := []file.State{}
 	err = decoder.Decode(&states)
 	if err != nil {
-		logp.Err("Error decoding states: %s", err)
-		return err
+		return fmt.Errorf("Error decoding states: %s", err)
 	}
 
 	r.states.SetStates(states)
@@ -164,8 +175,7 @@ func (r *Registrar) Start() error {
 	// Load the previous log file locations now, for use in prospector
 	err := r.loadStates()
 	if err != nil {
-		logp.Err("Error loading state: %v", err)
-		return err
+		return fmt.Errorf("Error loading state: %v", err)
 	}
 
 	r.wg.Add(1)
@@ -259,9 +269,11 @@ func (r *Registrar) writeRegistry() error {
 	// Directly close file because of windows
 	f.Close()
 
+	err = file.SafeFileRotate(r.registryFile, tempfile)
+
 	logp.Debug("registrar", "Registry file updated. %d states written.", len(states))
 	registryWrites.Add(1)
 	statesCurrent.Set(int64(len(states)))
 
-	return file.SafeFileRotate(r.registryFile, tempfile)
+	return err
 }

--- a/filebeat/registrar/registrar.go
+++ b/filebeat/registrar/registrar.go
@@ -67,11 +67,7 @@ func (r *Registrar) Init() error {
 	if os.IsNotExist(err) {
 		logp.Info("No registry file found under: %s. Creating a new registry file.", r.registryFile)
 		// No registry exists yet, write empty state to check if registry can be written
-		err = r.writeRegistry()
-		if err != nil {
-			return err
-		}
-		return nil
+		return r.writeRegistry()
 	}
 	if err != nil {
 		return err
@@ -262,6 +258,7 @@ func (r *Registrar) writeRegistry() error {
 	encoder := json.NewEncoder(f)
 	err = encoder.Encode(states)
 	if err != nil {
+		f.Close()
 		logp.Err("Error when encoding the states: %s", err)
 		return err
 	}

--- a/filebeat/tests/system/test_prospector.py
+++ b/filebeat/tests/system/test_prospector.py
@@ -622,7 +622,7 @@ class Test(BaseTest):
 
         # wait for registry to be written
         self.wait_until(
-            lambda: self.log_contains("Registry file updated"),
+            lambda: self.log_contains_count("Registry file updated") > 1,
             max_timeout=10)
 
         # Make sure not all events were written so far

--- a/filebeat/tests/system/test_publisher.py
+++ b/filebeat/tests/system/test_publisher.py
@@ -48,8 +48,8 @@ class Test(BaseTest):
 
         # Wait until registry file is written
         self.wait_until(
-            lambda: self.log_contains(
-                "Registry file updated."),
+            lambda: self.log_contains_count(
+                "Registry file updated.") > 1,
             max_timeout=15)
 
         filebeat.check_kill_and_wait()


### PR DESCRIPTION
Filebeat was starting also if there were problems with the registry file. The problems could have been:

* Registry file is a directory
* Registry file is not writable
* Invalid state in registry file
* Registry file is a symlink

All this cases are now checked and in case one of the checks fails, filebeat is stopped and a descriptive error is returned.

Symlinks are not allowed as filebeat must be able to write to the file and on windows also does some renaming magic which causes issues.

Closes https://github.com/elastic/beats/issues/1742