### PR TITLE
Update testing environment to beta1 IRC

### DIFF
--- a/testing/environments/docker/elasticsearch/Dockerfile-snapshot
+++ b/testing/environments/docker/elasticsearch/Dockerfile-snapshot
@@ -5,7 +5,7 @@ ENV ELASTICSEARCH_VERSION master
 
 
 COPY setup.sh /
-RUN bash setup.sh http://staging.elastic.co/5.0.0-beta1-e9e2b09c/download/elasticsearch/elasticsearch-5.0.0-beta1.deb
+RUN bash setup.sh https://staging.elastic.co/5.0.0-beta1-e9e2b09c/download/elasticsearch/elasticsearch-5.0.0-beta1.deb
 
 ENV PATH /usr/share/elasticsearch/bin:$PATH
 

--- a/testing/environments/docker/elasticsearch/Dockerfile-snapshot
+++ b/testing/environments/docker/elasticsearch/Dockerfile-snapshot
@@ -5,7 +5,7 @@ ENV ELASTICSEARCH_VERSION master
 
 
 COPY setup.sh /
-RUN bash setup.sh http://staging.elastic.co/5.0.0-beta1-2b315be2/download/elasticsearch/elasticsearch-5.0.0-beta1.deb
+RUN bash setup.sh http://staging.elastic.co/5.0.0-beta1-e9e2b09c/download/elasticsearch/elasticsearch-5.0.0-beta1.deb
 
 ENV PATH /usr/share/elasticsearch/bin:$PATH
 

--- a/testing/environments/docker/elasticsearch/Dockerfile-snapshot
+++ b/testing/environments/docker/elasticsearch/Dockerfile-snapshot
@@ -5,7 +5,7 @@ ENV ELASTICSEARCH_VERSION master
 
 
 COPY setup.sh /
-RUN bash setup.sh https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/5.0.0-alpha5/elasticsearch-5.0.0-alpha5.deb
+RUN bash setup.sh http://staging.elastic.co/5.0.0-beta1-2b315be2/download/elasticsearch/elasticsearch-5.0.0-beta1.deb
 
 ENV PATH /usr/share/elasticsearch/bin:$PATH
 

--- a/testing/environments/docker/elasticsearch/setup.sh
+++ b/testing/environments/docker/elasticsearch/setup.sh
@@ -17,6 +17,9 @@ wget $1 -O elasticsearch.deb
 
 dpkg -i elasticsearch.deb
 
+# this is more convenient when running without the init script
+cp -r /etc/elasticsearch/ /usr/share/elasticsearch/config
+
 set -ex \
 	&& for path in \
 		/usr/share/elasticsearch/data \

--- a/testing/environments/docker/kibana/Dockerfile-snapshot
+++ b/testing/environments/docker/kibana/Dockerfile-snapshot
@@ -16,7 +16,7 @@ RUN arch="$(dpkg --print-architecture)" \
 	&& chmod +x /usr/local/bin/gosu
 
 RUN set -x \
-	&& curl -fSL "https://download.elastic.co/kibana/kibana-snapshot/kibana-5.0.0-alpha6-SNAPSHOT-linux-x86_64.tar.gz?20160908" -o kibana.tar.gz \
+	&& curl -fSL "http://staging.elastic.co/5.0.0-beta1-2b315be2/download/kibana/kibana-5.0.0-beta1-linux-x86_64.tar.gz" -o kibana.tar.gz \
 	&& mkdir -p /opt/kibana \
 	&& tar -xz --strip-components=1 -C /opt/kibana -f kibana.tar.gz \
 	&& chown -R kibana:kibana /opt/kibana \

--- a/testing/environments/docker/kibana/Dockerfile-snapshot
+++ b/testing/environments/docker/kibana/Dockerfile-snapshot
@@ -16,7 +16,7 @@ RUN arch="$(dpkg --print-architecture)" \
 	&& chmod +x /usr/local/bin/gosu
 
 RUN set -x \
-	&& curl -fSL "http://staging.elastic.co/5.0.0-beta1-2b315be2/download/kibana/kibana-5.0.0-beta1-linux-x86_64.tar.gz" -o kibana.tar.gz \
+	&& curl -fSL "https://staging.elastic.co/5.0.0-beta1-e9e2b09c/download/kibana/kibana-5.0.0-beta1-linux-x86_64.tar.gz" -o kibana.tar.gz \
 	&& mkdir -p /opt/kibana \
 	&& tar -xz --strip-components=1 -C /opt/kibana -f kibana.tar.gz \
 	&& chown -R kibana:kibana /opt/kibana \

--- a/testing/environments/docker/logstash/Dockerfile-snapshot
+++ b/testing/environments/docker/logstash/Dockerfile-snapshot
@@ -2,17 +2,15 @@ FROM java:8-jre
 
 ENV LS_VERSION 5
 
-
-COPY setup.sh /
-
-ENV URL http://staging.elastic.co/5.0.0-beta1-2b315be2/download/logstash/logstash-5.0.0-beta1.tar.gz
+ENV URL https://staging.elastic.co/5.0.0-beta1-e9e2b09c/download/logstash/logstash-5.0.0-beta1.tar.gz
 ENV VERSION 5.0.0-beta1
 ENV PATH $PATH:/opt/logstash-$VERSION/bin
 
-RUN echo $PATH
-
 # As all snapshot builds have the same url, the image is cached. The date at then can be used to invalidate the image
-RUN bash setup.sh
+RUN set -x && \
+    cd /opt && \
+    wget -q $URL && \
+    tar xzf logstash-$VERSION.tar.gz
 
 
 COPY logstash.conf.2.tmpl /logstash.conf.2.tmpl

--- a/testing/environments/docker/logstash/Dockerfile-snapshot
+++ b/testing/environments/docker/logstash/Dockerfile-snapshot
@@ -2,12 +2,17 @@ FROM java:8-jre
 
 ENV LS_VERSION 5
 
-ENV PATH $PATH:/usr/share/logstash/bin
 
 COPY setup.sh /
 
+ENV URL http://staging.elastic.co/5.0.0-beta1-2b315be2/download/logstash/logstash-5.0.0-beta1.tar.gz
+ENV VERSION 5.0.0-beta1
+ENV PATH $PATH:/opt/logstash-$VERSION/bin
+
+RUN echo $PATH
+
 # As all snapshot builds have the same url, the image is cached. The date at then can be used to invalidate the image
-RUN bash setup.sh https://s3-eu-west-1.amazonaws.com/build-eu.elasticsearch.org/logstash/master/nightly/JDK8/logstash-latest-SNAPSHOT.deb?20160826
+RUN bash setup.sh
 
 
 COPY logstash.conf.2.tmpl /logstash.conf.2.tmpl
@@ -19,4 +24,4 @@ ENTRYPOINT ["/entrypoint.sh"]
 
 EXPOSE 5044 5055
 
-CMD logstash --path.settings=/etc/logstash -f /logstash.conf --log.level=debug --config.debug
+CMD logstash -f /logstash.conf --log.level=debug --config.debug

--- a/testing/environments/docker/logstash/setup.sh
+++ b/testing/environments/docker/logstash/setup.sh
@@ -1,18 +1,9 @@
 #!/usr/bin/env bash
 
-# setup logstash dependencies
-set -x && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends logrotate && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
 # download & install logstash
 set -x && \
-    mkdir -p /var/tmp && \
-    wget -qO /var/tmp/logstash.deb $1 && \
-    dpkg -i /var/tmp/logstash.deb && \
+    cd /opt && \
+    wget -q $URL && \
+    tar xzf logstash-$VERSION.tar.gz
 
-
-export PATH=$PATH:/usr/share/logstash/bin
-logstash-plugin install logstash-input-beats
+#logstash-plugin install logstash-input-beats

--- a/testing/environments/docker/logstash/setup.sh
+++ b/testing/environments/docker/logstash/setup.sh
@@ -1,9 +1,18 @@
 #!/usr/bin/env bash
 
+# setup logstash dependencies
+set -x && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends logrotate && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
 # download & install logstash
 set -x && \
-    cd /opt && \
-    wget -q $URL && \
-    tar xzf logstash-$VERSION.tar.gz
+    mkdir -p /var/tmp && \
+    wget -qO /var/tmp/logstash.deb $1 && \
+    dpkg -i /var/tmp/logstash.deb && \
 
-#logstash-plugin install logstash-input-beats
+
+export PATH=$PATH:/usr/share/logstash/bin
+logstash-plugin install logstash-input-beats


### PR DESCRIPTION
- Changed the logstash dockerfile to use the tar.gz which is much
  simpler.
- Unfortunately it still doesn't work, I posted:
  https://github.com/logstash-plugins/logstash-input-beats/issues/129
- For elasticsearch I did a hack for now, but we should consider moving
  to the tar.gz as well