### PR TITLE
Backport #2559 to 5.0 - Remove println from Packetbeat http header code

### DIFF
--- a/packetbeat/protos/http/http.go
+++ b/packetbeat/protos/http/http.go
@@ -551,7 +551,6 @@ func (http *HTTP) collectHeaders(m *message) interface{} {
 			}
 		}
 	}
-	fmt.Println("Headers: ", hdrs)
 	return hdrs
 }
 


### PR DESCRIPTION
Closes #2558