### PR TITLE
Use new version for templates

### DIFF
--- a/filebeat/filebeat.template-es2x.json
+++ b/filebeat/filebeat.template-es2x.json
@@ -6,9 +6,6 @@
           "enabled": false
         }
       },
-      "_meta": {
-        "version": "6.0.0-alpha1"
-      },
       "dynamic_templates": [
         {
           "fields": {
@@ -77,5 +74,6 @@
   "settings": {
     "index.refresh_interval": "5s"
   },
-  "template": "filebeat-*"
+  "template": "filebeat-*",
+  "version": "6.0.0-alpha1"
 }

--- a/filebeat/filebeat.template.json
+++ b/filebeat/filebeat.template.json
@@ -4,9 +4,6 @@
       "_all": {
         "norms": false
       },
-      "_meta": {
-        "version": "6.0.0-alpha1"
-      },
       "dynamic_templates": [
         {
           "fields": {
@@ -65,5 +62,6 @@
   "settings": {
     "index.refresh_interval": "5s"
   },
-  "template": "filebeat-*"
+  "template": "filebeat-*",
+  "version": "6.0.0-alpha1"
 }

--- a/libbeat/scripts/generate_template.py
+++ b/libbeat/scripts/generate_template.py
@@ -47,15 +47,13 @@ def fields_to_es_template(args, input, output, index, version):
         "settings": {
             "index.refresh_interval": "5s"
         },
+        "version": version,
         "mappings": {
             "_default_": {
                 "_all": {
                     "norms": False
                 },
-                "properties": {},
-                "_meta": {
-                    "version": version,
-                }
+                "properties": {}
             }
         }
     }

--- a/metricbeat/metricbeat.template-es2x.json
+++ b/metricbeat/metricbeat.template-es2x.json
@@ -6,9 +6,6 @@
           "enabled": false
         }
       },
-      "_meta": {
-        "version": "6.0.0-alpha1"
-      },
       "dynamic_templates": [
         {
           "fields": {
@@ -2797,5 +2794,6 @@
   "settings": {
     "index.refresh_interval": "5s"
   },
-  "template": "metricbeat-*"
+  "template": "metricbeat-*",
+  "version": "6.0.0-alpha1"
 }

--- a/metricbeat/metricbeat.template.json
+++ b/metricbeat/metricbeat.template.json
@@ -4,9 +4,6 @@
       "_all": {
         "norms": false
       },
-      "_meta": {
-        "version": "6.0.0-alpha1"
-      },
       "dynamic_templates": [
         {
           "fields": {
@@ -2775,5 +2772,6 @@
   "settings": {
     "index.refresh_interval": "5s"
   },
-  "template": "metricbeat-*"
+  "template": "metricbeat-*",
+  "version": "6.0.0-alpha1"
 }

--- a/packetbeat/packetbeat.template-es2x.json
+++ b/packetbeat/packetbeat.template-es2x.json
@@ -6,9 +6,6 @@
           "enabled": false
         }
       },
-      "_meta": {
-        "version": "6.0.0-alpha1"
-      },
       "dynamic_templates": [
         {
           "fields": {
@@ -1557,5 +1554,6 @@
   "settings": {
     "index.refresh_interval": "5s"
   },
-  "template": "packetbeat-*"
+  "template": "packetbeat-*",
+  "version": "6.0.0-alpha1"
 }

--- a/packetbeat/packetbeat.template.json
+++ b/packetbeat/packetbeat.template.json
@@ -4,9 +4,6 @@
       "_all": {
         "norms": false
       },
-      "_meta": {
-        "version": "6.0.0-alpha1"
-      },
       "dynamic_templates": [
         {
           "fields": {
@@ -1356,5 +1353,6 @@
   "settings": {
     "index.refresh_interval": "5s"
   },
-  "template": "packetbeat-*"
+  "template": "packetbeat-*",
+  "version": "6.0.0-alpha1"
 }

--- a/winlogbeat/winlogbeat.template-es2x.json
+++ b/winlogbeat/winlogbeat.template-es2x.json
@@ -6,9 +6,6 @@
           "enabled": false
         }
       },
-      "_meta": {
-        "version": "6.0.0-alpha1"
-      },
       "dynamic_templates": [
         {
           "fields": {
@@ -189,5 +186,6 @@
   "settings": {
     "index.refresh_interval": "5s"
   },
-  "template": "winlogbeat-*"
+  "template": "winlogbeat-*",
+  "version": "6.0.0-alpha1"
 }

--- a/winlogbeat/winlogbeat.template.json
+++ b/winlogbeat/winlogbeat.template.json
@@ -4,9 +4,6 @@
       "_all": {
         "norms": false
       },
-      "_meta": {
-        "version": "6.0.0-alpha1"
-      },
       "dynamic_templates": [
         {
           "fields": {
@@ -158,5 +155,6 @@
   "settings": {
     "index.refresh_interval": "5s"
   },
-  "template": "winlogbeat-*"
+  "template": "winlogbeat-*",
+  "version": "6.0.0-alpha1"
 }


### PR DESCRIPTION
- [ ] Test that shows up in mapping most recent elasticsearch versions
- [ ] Use _meta version for 2.x
- [ ] Test on 2.x

Closes https://github.com/elastic/beats/issues/2556
