### PR TITLE
Fix panic if logging directory cannot be generated

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -50,6 +50,7 @@ https://github.com/elastic/beats/compare/v5.0.0-alpha5...master[Check the HEAD d
 - Fix array value support in -E CLI flag. {pull}2521[2521]
 - Fix merging array values if -c CLI flag is used multiple times. {pull}2521[2521]
 - Fix beats failing to start due to invalid duplicate key error in configuration file. {pull}2521[2521]
+- Fix panic on non writable logging directory.
 
 *Metricbeat*
 - Fix module filters to work properly with drop_event filter. {issue}2249[2249]

--- a/libbeat/logp/log.go
+++ b/libbeat/logp/log.go
@@ -162,10 +162,7 @@ func SetToSyslog(toSyslog bool, prefix string) {
 }
 
 func SetToFile(toFile bool, rotator *FileRotator) error {
-	_log.toFile = toFile
-	if _log.toFile {
-		_log.rotator = rotator
-
+	if toFile {
 		err := rotator.CreateDirectory()
 		if err != nil {
 			return err
@@ -174,6 +171,12 @@ func SetToFile(toFile bool, rotator *FileRotator) error {
 		if err != nil {
 			return err
 		}
+
+		// Only assign rotator on no errors
+		_log.rotator = rotator
 	}
+
+	_log.toFile = toFile
+
 	return nil
 }


### PR DESCRIPTION
* Assigns log rotator only after successful creation. Otherwise panic can happen during shutdown if directory cannot be generated as it tries to log.

Closes https://github.com/elastic/beats/issues/2490