### PR TITLE
Edit topics about creating new dashboards

### DIFF
--- a/libbeat/docs/newdashboards.asciidoc
+++ b/libbeat/docs/newdashboards.asciidoc
@@ -42,7 +42,7 @@ There are a couple of common use cases for importing dashboards:
 [[import-single-beat]]
 ==== Import Dashboards and/or the Index Pattern for a Single Beat
 
-Using the `import_dashboards` script, you can import the dashboards and the index pattern to
+Using the `import_dashboards` script from the Beat package, you can import the dashboards and the index pattern to
 Elasticsearch running on localhost for a single Beat (eg. Metricbeat):
 
 - from a local directory:
@@ -56,14 +56,14 @@ Elasticsearch running on localhost for a single Beat (eg. Metricbeat):
 +
 [source,shell]
 ----------------------------------------------------------------------
-./scripts/import_dashboards -beat metricbeat -file metricbeat-dashboards-1.1.zip
+./scripts/import_dashboards -file metricbeat-dashboards-1.1.zip
 ----------------------------------------------------------------------
 
 - from the official zip archive available under http://download.elastic.co/:
 +
 [source,shell]
 ----------------------------------------------------------------------
-./scripts/import_dashboards -beat metricbeat
+./scripts/import_dashboards
 ----------------------------------------------------------------------
 +
 See <<dashboards-archive-structure>> for more details about the structure of dashboard archives.
@@ -72,7 +72,7 @@ See <<dashboards-archive-structure>> for more details about the structure of das
 +
 [source,shell]
 -----------------------
-./scripts/import_dashboards -beat metricbeat -url https://github.com/monicasarbu/metricbeat-dashboards/archive/v1.1.zip
+./scripts/import_dashboards -url https://github.com/monicasarbu/metricbeat-dashboards/archive/v1.1.zip
 -----------------------
 
 If you don't specify the location of the archive, then by default it's set to the official zip archive containing the index pattern and the dashboards of the official Beats.
@@ -80,14 +80,14 @@ If you don't specify the location of the archive, then by default it's set to th
 To import only the index-pattern for a single Beat (eg. Metricbeat) use:
 [source,shell]
 -----------------------
-./scripts/import_dashboards -only-index -beat metricbeat
+./scripts/import_dashboards -only-index
 -----------------------
 
 To import only the dashboards together with visualizations and searches for a single Beat (eg. Metricbeat) use:
 
 [source,shell]
 -----------------------
-./scripts/import_dashboards -only-dashboards -beat metricbeat
+./scripts/import_dashboards -only-dashboards
 -----------------------
 
 
@@ -118,8 +118,8 @@ searches, and the Metricbeat index pattern:
 beats/libbeat/dashboards/import_dashboards -beat metricbeat
 -----------------
 
-If the `-beat` option is not specified, the script imports the dashboards of all
-Beats by default.
+For this example, you must specify `-beat metricbeat`. If the `-beat` option is not 
+specified, the script imports the dashboards of all Beats.
 
 NOTE: You can make use of the Makefile from the Beat GitHub repository to import the
 dashboards. If Elasticsearch is running on localhost, then you can run the following command from the Beat repository:
@@ -219,7 +219,7 @@ are available in a separate directory for each Beat, having the name of the Beat
 
 
 [[build-dashboards]]
-=== Building Your Own Dashboards
+=== Building Your Own Beat Dashboards
 
 For visualizing the dashboards of a Beat in Kibana you need to have configured:
 
@@ -334,7 +334,7 @@ output/
 --------------
 
 [[archive-dashboards]]
-=== Archiving Your Kibana Dashboards
+=== Archiving Your Beat Dashboards
 
 The Kibana dashboards for the Elastic Beats are saved under the `etc/kibana` directory. To create a zip archive with the
 dashboards, including visualizations and searches and the index pattern, you can run the following command in the Beat

--- a/libbeat/docs/newdashboards.asciidoc
+++ b/libbeat/docs/newdashboards.asciidoc
@@ -1,12 +1,12 @@
 [[new-dashboards]]
 == Developer Guide: Creating New Kibana Dashboards for a Beat
 
+NOTE: Starting with 5.0.0-beta1, the Kibana dashboards are not released as part of the Beat package. They are released in a separate
+package called `beats-dashboards`.
+
 When contributing to Beats development, you may want to add new dashboards or modify existing ones. To make this easier,
 we've created an `import_dashboards` script that you can use to <<import-dashboards,import the dashboards>> from an
 existing Beat into Kibana, where you can modify the dashboards or use them as a starting point to create new dashboards.
-
-Starting with 5.0.0-beta1, the Kibana dashboards are not released as part of the Beat package, they are released in a separate
-package, `beats-dashboards`.
 
 Kibana saves the dashboards, along with all the dependencies such as visualizations, searches, and index patterns, in
 a special index in Elasticsearch. By default the index is `.kibana`, but you can specify a different index.
@@ -32,57 +32,166 @@ The following topics provide more detail about importing and working with Beats 
 
 You can use the `import_dashboards` script to import all the dashboards and the index pattern for a Beat, including the dependencies such as visualizations and searches.
 The `import_dashboards` script is available under
-https://github.com/elastic/beats/tree/master/libbeat/dashboards[beats/libbeat/dashboards], and it's copied in each Beat package under the `scripts` directory.
+https://github.com/elastic/beats/tree/master/libbeat/dashboards[beats/libbeat/dashboards]. It's also available in each Beat package under the `scripts` directory.
 
+There are a couple of common use cases for importing dashboards:
+
+* Users who are getting started with Beats may want to <<import-single-beat,import dashboards and/or the index pattern for a single Beat>>.
+* Community Beats developers may want to <<import-dashboards-for-development,import dashboards for development>> to use as a starting point for new dashboards.
+
+[[import-single-beat]]
+==== Import Dashboards and/or the Index Pattern for a Single Beat
 
 Using the `import_dashboards` script, you can import the dashboards and the index pattern to
 Elasticsearch running on localhost for a single Beat (eg. Metricbeat):
 
 - from a local directory:
-
++
 [source,shell]
 ----------------------------------------------------------------------
-$ ./scripts/import_dashboards -dir kibana/metricbeat
+./scripts/import_dashboards -dir kibana/metricbeat
 ----------------------------------------------------------------------
 
 - from a local zip archive:
-
++
 [source,shell]
 ----------------------------------------------------------------------
-$ ./scripts/import_dashboards -beat metricbeat -file metricbeat-dashboards-1.1.zip
+./scripts/import_dashboards -beat metricbeat -file metricbeat-dashboards-1.1.zip
 ----------------------------------------------------------------------
 
 - from the official zip archive available under http://download.elastic.co/:
-
++
 [source,shell]
 ----------------------------------------------------------------------
-$ ./scripts/import_dashboards -beat metricbeat
+./scripts/import_dashboards -beat metricbeat
 ----------------------------------------------------------------------
++
+See <<dashboards-archive-structure>> for more details about the structure of dashboard archives.
 
 - from a zip archive available online:
-
++
 [source,shell]
 -----------------------
-$ scripts/import_dashboards -beat metricbeat -url https://github.com/monicasarbu/metricbeat-dashboards/archive/v1.1.zip
+./scripts/import_dashboards -beat metricbeat -url https://github.com/monicasarbu/metricbeat-dashboards/archive/v1.1.zip
 -----------------------
 
+If you don't specify the location of the archive, then by default it's set to the official zip archive containing the index pattern and the dashboards of the official Beats.
 
 To import only the index-pattern for a single Beat (eg. Metricbeat) use:
 [source,shell]
 -----------------------
-./import_dashboards -only-index -beat metricbeat
+./scripts/import_dashboards -only-index -beat metricbeat
 -----------------------
 
 To import only the dashboards together with visualizations and searches for a single Beat (eg. Metricbeat) use:
 
 [source,shell]
 -----------------------
-./import_dashboards -only-dashboards -beat metricbeat
+./scripts/import_dashboards -only-dashboards -beat metricbeat
 -----------------------
 
 
-NOTE:: When running the `import_dashboards` from the Beat package, the `-beat` option is set automatically to the Beat
+NOTE: When running the `import_dashboards` script from within the Beat package, the `-beat` option is set automatically to the Beat
 name.
+
+See <<import-dashboard-options>> for a description of other import options.
+
+[[import-dashboards-for-development]]
+==== Import Dashboards for Development
+
+For development or community Beats, it's easier to run the `import_dashboards` script from the https://github.com/elastic/beats/tree/master/libbeat/dashboards[beats/libbeat/dashboards] directory. In this case, you need to first compile the script:
+
+[source,shell]
+-----------------------
+cd beats/libbeat/dashboards
+make
+-----------------------
+
+And then you can import the index pattern and the dashboards together with visualizations and searches for a single
+Beat, by passing the `-beat` option. 
+
+For example, to import the Metricbeat dashboards together with visualizations,
+searches, and the Metricbeat index pattern:
+
+[source,shell]
+-----------------
+beats/libbeat/dashboards/import_dashboards -beat metricbeat
+-----------------
+
+If the `-beat` option is not specified, the script imports the dashboards of all
+Beats by default.
+
+NOTE: You can make use of the Makefile from the Beat GitHub repository to import the
+dashboards. If Elasticsearch is running on localhost, then you can run the following command from the Beat repository:
+
+[source,shell]
+--------------------------------
+make import-dashboards
+--------------------------------
+
+If Elasticsearch is running on a different host, then you can use the `ES_URL` variable:
+
+[source,shell]
+-------------------------------
+ES_URL="http://192.168.3.206:9200" make import-dashboards
+-------------------------------
+
+[[import-dashboard-options]]
+==== Command Line Options
+
+The `import_dashboards` script accepts the following command-line options. To see all the available options, read the descriptions below or run:
+
+["source","sh",subs="attributes"]
+----------------------------------------------------------------------
+./import_dashboards -h
+----------------------------------------------------------------------
+
+*`-beat <beatname>`*::
+The Beat name. The Beat name is required when importing from a zip archive. When using `import_dashboards` from the Beat package, this option is set automatically with the name of
+the Beat. When running the script from source, the default value is "", so you need to set this option in order to install the index pattern and
+the dashboards for a single Beat. Otherwise the script imports the index pattern and the dashboards for all Beats.
+
+*`-dir <local_dir>`*::
+Local directory that contains the subdirectories: dashboard, visualization, search, and index-pattern. The default value is the current directory.
+
+*`-es <elasticsearch_url>`*::
+The Elasticsearch URL. The default value is http://localhost:9200.
+
+*`-file <local_archive>`*::
+Local zip archive with the dashboards. The archive can contain Kibana dashboards for a single Beat or for multiple Beats.
+
+*`-i <elasticsearch_index>`*::
+You should only use this option if you want to change the index pattern name that's used by default. For example, if the
+default is `metricbeat-*`, you can change it to `custombeat-*`.
+
+*`-k <kibana_index>`*::
+The Elasticsearch index pattern where Kibana saves its configuration. The default value is `.kibana`.
+
+*`-only-dashboards`*::
+If specified, then only the dashboards, along with their visualizations and searches, are imported. The index pattern is
+not imported. By default, this is false.
+
+*`-only-index`*::
+If specified, then only the index pattern is imported. The dashboards, along with their visualizations and searches, are not imported. By default, this is false.
+
+*`-pass <password>`*::
+The password for authenticating the connection to Elasticsearch by using Basic Authentication. By default no username and password are used.
+
+*`-snapshot`*::
+Using `-snapshot` will import the snapshot dashboards build for the current version. This is mainly useful when running a snapshot Beat build for testing purpose.
++
+NOTE: When using `-snapshot`, `-url` will be ignored.
+
+*`-url <zip_url>`*::
+Zip archive with the dashboards, available online. The archive can contain Kibana dashboards for a single Beat or for
+multiple Beats.
+
+*`-user <username>`*::
+The username for authenticating the connection to Elasticsearch by using Basic Authentication. By default no username and password are used.
+
+
+[[dashboards-archive-structure]]
+==== Structure of the Dashboards Archive
 
 The zip archive contains dashboards for at least one Beat. The index pattern, dashboards, visualizations and searches
 are available in a separate directory for each Beat, having the name of the Beat. For example the official zip archive (beats-dashboards-{stack-version}) has the following structure:
@@ -109,105 +218,12 @@ are available in a separate directory for each Beat, having the name of the Beat
 ------------------------
 
 
-If you don't specify the `-url` option, then by default it's set to the official zip archive containing the index
-pattern and the dashboards of the official Beats.
-
-
-For development or community Beats it's easier to run the `import_dashboards` script from the https://github.com/elastic/beats/tree/master/libbeat/dashboards[beats/libbeat/dashboards] directory. In this case, you need to first compile the script:
-
-[source,shell]
------------------------
-$ cd beats/libbeat/dashboards
-$ make
------------------------
-
-And then you can import the index pattern and the dashboards together with visualizations and searches for a single
-Beat, by passing the `-beat` option. If the `-beat` option is not specified, by default it imports the dashboards of all
-Beats.
-
-For example, to import the Metricbeat dashboards together with visualizations,
-searches and the Metricbeat index pattern:
-
-[source,shell]
------------------
-$ beats/libbeat/dashboards/import_dashboards -beat metricbeat
------------------
-
-
-NOTE: You can make use of the Makefile from the Beat GitHub repository to import the
-dashboards. If Elasticsearch is running on localhost, then you can run the following command from the Beat repository:
-
-[source,shell]
---------------------------------
-$ make import-dashboards
---------------------------------
-
-If Elasticsearch is running on a different host, then you can use the environment `ES_URL`:
-
-[source,shell]
--------------------------------
-$ ES_URL="http://192.168.3.206:9200" make import-dashboards
--------------------------------
-
-To see all the available options, check the options below or run:
-
-["source","sh",subs="attributes"]
-----------------------------------------------------------------------
-./import_dashboards -h
-----------------------------------------------------------------------
-
-
-==== es
-The Elasticsearch URL. The default value is http://localhost:9200.
-
-==== user
-The username for authenticating the connection to Elasticsearch by using Basic Authentication. By default no username and password are used.
-
-
-==== pass
-The password for authenticating the connection to Elasticsearch by using Basic Authentication. By default no username and password are used.
-
-==== k
-The Elasticsearch index pattern where Kibana saves its configuration. The default value is `.kibana`.
-
-==== i
-You should only use this option if you want to change the index pattern name that's used by default. For example, if the
-default is `metricbeat-*`, you can change it to `custombeat-*`.
-
-==== only-dashboards
-If specified, then only the dashboards, along with their visualizations and searches, are imported. The index pattern is
-not imported. By default is false.
-
-==== only-index
-If specified, then only the index pattern is imported. The dashboards, along with their visualizations and searches, are not imported. By default is false.
-
-==== dir
-Local directory that contains the subdirectories: dashboard, visualization, search and index-pattern. The default value is the current directory.
-
-==== file
-Local zip archive with the dashboards. The archive can contain Kibana dashboards for a single Beat or for multiple Beats.
-
-==== url
-Zip archive with the dashboards, available online. The archive can contain Kibana dashboards for a single Beat or for
-multiple Beats.
-
-==== beat
-The Beat name, and it's required when importing from a zip archive. When using the `import_dashboards` from the Beat package, this option is set automatically with the name of
-the Beat. When running the script from source, the default value is "", so you need to set this option in order to install the index pattern and
-the dashboards for a single Beat. Otherwise it imports the index pattern and the dashboards for all Beats.
-
-==== snapshot
-
-Using `-snapshot` will import the snapshot dashboards build for the current version. This is mainly useful when running a snapshot beat build for testing purpose.
-
-NOTE: When using `-snapshot`, `-url` will be ignored.
-
 [[build-dashboards]]
-=== Building your Own Dashboards
+=== Building Your Own Dashboards
 
 For visualizing the dashboards of a Beat in Kibana you need to have configured:
 
-* the Beat index pattern, that specifies how Kibana should display the Beat fields
+* the Beat index pattern, which specifies how Kibana should display the Beat fields
 * the Beat dashboards, including the dependencies such as visualizations and searches
 
 For the Elastic Beats, the index pattern is available in the GitHub repository of each Beat under
@@ -224,13 +240,13 @@ $ scripts/import_dashboards -only-index
 ---------------
 
 After creating your own dashboards in Kibana, you can <<export-dashboards,export the Kibana dashboards>> to a local
-directory, and then <<archive-dashboards,archive the dashboards>> in order to be able to share it with the community.
+directory, and then <<archive-dashboards,archive the dashboards>> in order to be able to share the dashboards with the community.
 
 [[generate-index-pattern]]
 === Generating the Beat Index Pattern
 
-You need to generate again a new index pattern for your Beat, in case you change the fields exported by the Beat. Otherwise
-you can just use the index pattern available under `etc/kibana/index-pattern` directory or in the `beats-dashboards`
+If you change the fields exported by the Beat, you need to generate a new index pattern for your Beat. Otherwise
+you can just use the index pattern available under the `etc/kibana/index-pattern` directory or in the `beats-dashboards`
 archive for the Elastic Beats.
 
 The Beat index pattern is generated from the `etc/fields.yml`, where all the fields for a Beat are defined. For each field, besides the `type`, you can configure the
@@ -241,7 +257,7 @@ To generate the index pattern from the `etc/fields.yml`, you need to run the fol
 
 [source,shell]
 ---------------
-$ make update
+make update
 ---------------
 
 [[export-dashboards]]
@@ -258,14 +274,14 @@ from your Elasticsearch. If Elasticsearch is running on localhost, then you just
 
 [source,shell]
 -----------------------------
-$ make export-dashboards
+make export-dashboards
 -----------------------------
 
-If the Elasticsearch is running on a different host, then you can use the `ES_URL` variable:
+If Elasticsearch is running on a different host, then you can use the `ES_URL` variable:
 
 [source,shell]
 ----------------------------
-$ ES_URL="http://192.168.3.206:9200" make export-dashboards
+ES_URL="http://192.168.3.206:9200" make export-dashboards
 ----------------------------
 
 
@@ -287,37 +303,23 @@ For example, to export all Kibana dashboards that start with the **Packetbeat** 
 python ../dev-tools/export_dashboards.py --regex Packetbeat*
 ----------------------------------------------------------------------
 
-The command has the following options:
+To see all the available options, read the descriptions below or run:
 
 [source,shell]
 ----------------------------------------------------------------------
-$ python ../dev-tools/export_dashboards.py -h
-usage: export_dashboards.py [-h] [--url URL] --regex REGEX [--kibana KIBANA]
-                            [--dir DIR]
-
-Export the Kibana dashboards together with all used visualizations, searches
-and index pattern
-
-optional arguments:
-  -h, --help       show this help message and exit
-  --url URL        Elasticsearch URL. By default: http://localhost:9200
-  --regex REGEX    Regular expression to match all the dashboards to be
-                   exported. For example: metricbeat*
-  --kibana KIBANA  Elasticsearch index where to store the Kibana settings. By
-                   default: .kibana
-  --dir DIR        Output directory. By default: output
+python ../dev-tools/export_dashboards.py -h
 ----------------------------------------------------------------------
 
-==== url
+*`--url <elasticsearch_url>`*::
 The Elasticsearch URL. The default value is http://localhost:9200.
 
-==== regex
+*`--regex <regular_expression>`*::
 Regular expression to match all the Kibana dashboards to be exported. This argument is required.
 
-==== kibana
+*`--kibana <kibana_index>`*::
 The Elasticsearch index pattern where Kibana saves its configuration. The default value is `.kibana`.
 
-==== dir
+*`--dir <output_dir>`*::
 The output directory where the dashboards and all dependencies will be saved. The default value is `output`.
 
 The output directory has the following structure:
@@ -332,7 +334,7 @@ output/
 --------------
 
 [[archive-dashboards]]
-=== Archiving your Own Kibana Dashboards
+=== Archiving Your Kibana Dashboards
 
 The Kibana dashboards for the Elastic Beats are saved under the `etc/kibana` directory. To create a zip archive with the
 dashboards, including visualizations and searches and the index pattern, you can run the following command in the Beat
@@ -340,8 +342,8 @@ repository:
 
 [source,shell]
 --------------
-$ make package-setup
-$ make package-dashboards
+make package-setup
+make package-dashboards
 --------------
 
 The Makefile is part of libbeat, which means that community Beats contributors can use the commands shown here to
@@ -355,7 +357,7 @@ Share the Kibana dashboards archive with the community, so other users can use y
 
 
 [[share-beat-dashboards]]
-=== Share your own Beat Dashboards
+=== Sharing Your Beat Dashboards
 
 When you're done with your own Beat dashboards, how about letting everyone know? You can create a topic on the https://discuss.elastic.co/c/beats[Beats
-forum], and provide the link to the zip archive together with a small description.
+forum], and provide the link to the zip archive together with a short description.


### PR DESCRIPTION
Summary of changes:
- Formatted CLI options and changed the order to match how they appear when you run `-h` (makes it a lot easier to see when we've left something out).
- Divided topic about importing dashboards into sections to make it easier for non-developers to figure out what is relevant to them. Why? Because point end users to this section for more info about importing dashboards, I want them to be able to find the stuff that's relevant to them quickly.
- Did some light edits for consistency. In command examples, removed `$` because we've gotten feedback from developers saying that it makes copy/paste harder when we include `$` in our examples.
