### PR TITLE
Required doc cleanup for beta1

### DIFF
--- a/filebeat/docs/filebeat-filtering.asciidoc
+++ b/filebeat/docs/filebeat-filtering.asciidoc
@@ -33,18 +33,6 @@ include::../../libbeat/docs/processors.asciidoc[]
 
 For example, the following configuration drops all the DEBUG messages.
 
-deprecated[5.0.0-alpha4,The `filters` section is being renamed to `processors` in 5.0.0-alpha5. Therefore the following configuration is deprecated]
-
-[source,yaml]
------------------------------------------------------
-filters:
- - drop_event:
-    regexp:
-      message: "^DBG:"
------------------------------------------------------
-
-added[5.0.0-alpha5,Begin using the following configuration starting with 5.0.0-alpha5]
-
 [source,yaml]
 -----------------------------------------------------
 processors:
@@ -55,18 +43,6 @@ processors:
 -----------------------------------------------------
 
 To drop all the log messages coming from a certain log file:
-
-deprecated[5.0.0-alpha4,The `filters` section is being renamed to `processors` in 5.0.0-alpha5. Therefore the following configuration is deprecated]
-
-[source,yaml]
-----------------
-filters:
- - drop_event:
-     contains:
-        source: "test"
-----------------
-
-added[5.0.0-alpha5,Begin using the following configuration starting with 5.0.0-alpha5]
 
 [source,yaml]
 ----------------

--- a/filebeat/docs/index.asciidoc
+++ b/filebeat/docs/index.asciidoc
@@ -8,7 +8,7 @@ include::./version.asciidoc[]
 :filebeat: http://www.elastic.co/guide/en/beats/filebeat/{doc-branch}
 :winlogbeat: http://www.elastic.co/guide/en/beats/winlogbeat/{doc-branch}
 :elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/{doc-branch}
-:securitydoc: https://www.elastic.co/guide/en/shield/current
+:securitydoc: https://www.elastic.co/guide/en/x-pack/5.0
 :version: {stack-version}
 :beatname_lc: filebeat
 :beatname_uc: Filebeat

--- a/libbeat/docs/dashboards.asciidoc
+++ b/libbeat/docs/dashboards.asciidoc
@@ -112,18 +112,6 @@ If Kibana shows a `No default index pattern` warning, you must select or create
 an index pattern to continue. To resolve the issue, select one of the
 predefined index patterns and set it as the default.
 
-[NOTE]
-.Known Issue in 5.0.0-alpha4
-====
-There is a known issue in the 5.0.0-alpha4 release of Kibana that affects
-the loading process of our sample dashboards. It only affects brand new
-installations of Kibana 5.0.0-alpha4 that don’t yet have any indices defined. 
-To resolve this error, see the "Known issue and workaround" section
-https://www.elastic.co/blog/beats-5-0-0-alpha4-released[here].
-
-This issue is resolved in 5.0.0-alpha5.
-====
-
 image:./images/kibana-created-indexes.png[Kibana configured indexes]
 
 To open the loaded dashboards, go to the *Dashboard* page and click *Open*.

--- a/libbeat/docs/https.asciidoc
+++ b/libbeat/docs/https.asciidoc
@@ -33,7 +33,7 @@ either by using a web proxy or by using {security}. For more information, see {s
 certificates. Creating a correct SSL/TLS infrastructure is outside the scope of
 this document.
 
-//TO DO: Need to replace the link before adding this back into the doc: "but a good guide to follow is the https://www.elastic.co/guide/en/shield/current/certificate-authority.html[Setting Up a Certificate Authority] topic in the {security}" documentation. Also add it back to shared-ssl-logstash-config, if possible.
+//TODO: Need to replace the link before adding this back into the doc: "but a good guide to follow is the https://www.elastic.co/guide/en/shield/current/certificate-authority.html[Setting Up a Certificate Authority] topic in the {security}" documentation. Also add it back to shared-ssl-logstash-config, if possible.
 
 By default {beatname_uc} uses the list of trusted certificate authorities from the
 operating system where {beatname_uc} is running. You can configure {beatname_uc} to use a specific list of

--- a/libbeat/docs/https.asciidoc
+++ b/libbeat/docs/https.asciidoc
@@ -27,14 +27,13 @@ output.elasticsearch:
 <4> The IP and port of the Elasticsearch nodes.
 
 Elasticsearch doesn't have built-in basic authentication, but you can achieve it
-either by using a web proxy or by using
-https://www.elastic.co/products/shield[{security}].
+either by using a web proxy or by using {security}. For more information, see {securitydoc}/xpack-security.html[{security}].
 
 {beatname_uc} verifies the validity of the server certificates and only accepts trusted
 certificates. Creating a correct SSL/TLS infrastructure is outside the scope of
-this document, but a good guide to follow is the
-https://www.elastic.co/guide/en/shield/current/certificate-authority.html[Setting Up a Certificate Authority]
-topic in the {security} documentation.
+this document.
+
+//TO DO: Need to replace the link before adding this back into the doc: "but a good guide to follow is the https://www.elastic.co/guide/en/shield/current/certificate-authority.html[Setting Up a Certificate Authority] topic in the {security}" documentation. Also add it back to shared-ssl-logstash-config, if possible.
 
 By default {beatname_uc} uses the list of trusted certificate authorities from the
 operating system where {beatname_uc} is running. You can configure {beatname_uc} to use a specific list of

--- a/libbeat/docs/index.asciidoc
+++ b/libbeat/docs/index.asciidoc
@@ -7,7 +7,7 @@ include::./version.asciidoc[]
 :metricbeat: http://www.elastic.co/guide/en/beats/metricbeat/{doc-branch}
 :filebeat: http://www.elastic.co/guide/en/beats/filebeat/{doc-branch}
 :winlogbeat: http://www.elastic.co/guide/en/beats/winlogbeat/{doc-branch}
-:securitydoc: https://www.elastic.co/guide/en/shield/current
+:securitydoc: https://www.elastic.co/guide/en/x-pack/5.0
 :security: X-Pack Security
 :ES-version: {stack-version}
 :LS-version: {stack-version}

--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -652,7 +652,7 @@ The Redis port to use if `hosts` does not contain a port number. The default is 
 
 ===== index
 
-deprecated[5.0.0},The `index` setting is renamed to `key`]
+deprecated[5.0.0,The `index` setting is renamed to `key`]
 
 The name of the Redis list or channel the events are published to. The default is
 "{beatname_lc}".

--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -652,7 +652,7 @@ The Redis port to use if `hosts` does not contain a port number. The default is 
 
 ===== index
 
-deprecated[5.0.0-alpha5,The `index` setting is renamed to `key.]
+deprecated[5.0.0},The `index` setting is renamed to `key`]
 
 The name of the Redis list or channel the events are published to. The default is
 "{beatname_lc}".

--- a/libbeat/docs/processors-config.asciidoc
+++ b/libbeat/docs/processors-config.asciidoc
@@ -11,31 +11,13 @@
 //////////////////////////////////////////////////////////////////////////
 
 [[configuration-processors]]
-=== Processors Configuration (was Filters)
-
-//TODO: Remove was Filters from the above title and remove extra sections that show the alpha4 configuration
+=== Processors Configuration
 
 include::../../libbeat/docs/processors.asciidoc[]
 
 Each processor has associated an action with a set of parameters and optionally a condition. If the condition is
 present, then the action is executed only if the condition
 is fulfilled. If no condition is passed then the action is always executed.
-
-deprecated[5.0.0-alpha4,The `filters` configuration option is being renamed to `processors` in 5.0.0-alpha5. Therefore the following configuration is deprecated]
-
-[source,yaml]
-------
-filters:
- - <action>:
-     <condition>
-     <parameters>
- - <action>:
-     <condition>
-     <parameters>
-...
-------
-
-added[5.0.0-alpha5,Begin using the following configuration starting with 5.0.0-alpha5]
 
 [source,yaml]
 ------
@@ -155,8 +137,6 @@ range:
 ------
 
 
-added[5.0.0-alpha5, You can combine multiple conditions with the `or`, `and` or `not` operators]
-
 [[condition-or]]
 ===== OR
 
@@ -262,18 +242,6 @@ The `include_fields` action specifies what fields to export if a certain conditi
 optional and if it's missing then the defined fields are always exported. The `@timestamp` and
 `type` fields are always exported, even if they are not defined in the `include_fields` list.
 
-deprecated[5.0.0-alpha4,The `filters` section is being renamed to `processors` in 5.0.0-alpha5. Therefore the following configuration is deprecated]
-
-[source,yaml]
--------
-filters:
- - include_fields:
-     [condition]
-     fields: ["field1", "field2", ...]
--------
-
-added[5.0.0-alpha5,Begin using the following configuration starting with 5.0.0-alpha5]
-
 [source,yaml]
 -------
 processors:
@@ -297,18 +265,6 @@ The `drop_fields` action specifies what fields to drop if a certain condition is
 and if it's missing then the defined fields are always dropped. The `@timestamp` and `type` fields cannot be dropped,
 even if they show up in the `drop_fields` list.
 
-deprecated[5.0.0-alpha4,The `filters` section is being renamed to `processors` in 5.0.0-alpha5. Therefore the following configuration is deprecated]
-
-[source,yaml]
------------------------------------------------------
-filters:
- - drop_fields:
-     [condition]
-     fields: ["field1", "field2", ...]
------------------------------------------------------
-
-added[5.0.0-alpha5,Begin using the following configuration starting with 5.0.0-alpha5]
-
 [source,yaml]
 -----------------------------------------------------
 processors:
@@ -326,17 +282,6 @@ NOTE: If you define an empty list of fields under `drop_fields`, then no fields 
 
 The `drop_event` action drops the entire event if the associated condition is fulfilled. The condition is mandatory, as
 without one all the events are dropped.
-
-deprecated[5.0.0-alpha4,The `filters` section is being renamed to `processors` in 5.0.0-alpha5. Therefore the following configuration is deprecated]
-
-[source,yaml]
-------
-filters:
- - drop_event:
-     condition
-------
-
-added[5.0.0-alpha5,Begin using the following configuration starting with 5.0.0-alpha5]
 
 [source,yaml]
 ------

--- a/libbeat/docs/processors.asciidoc
+++ b/libbeat/docs/processors.asciidoc
@@ -9,8 +9,6 @@
 //// include::../../libbeat/docs/filtering.asciidoc[]
 //////////////////////////////////////////////////////////////////////////
 
-added[5.0.0-alpha5,Filters are being renamed to "processors" to better reflect the capabilities they provide. If you are using 5.0.0-alpha4 or earlier, these are still called "filters" even though the documentation refers to "processors"]
-
 You can define processors in your configuration to process events before they are sent to the configured output.
 The libbeat library provides processors for reducing the number of exported fields, and processors for
 enhancing events with additional metadata. Each processor receives an event, applies a defined action to the event,

--- a/libbeat/docs/regexp.asciidoc
+++ b/libbeat/docs/regexp.asciidoc
@@ -12,15 +12,13 @@
 [[regexp-support]]
 == Regular Expression Support
 
-{beatname_uc} regular expression support is based on https://godoc.org/regexp/syntax[RE2]. added[5.0.0-alpha3,Support is added for previously unsupported patterns]
+{beatname_uc} regular expression support is based on https://godoc.org/regexp/syntax[RE2]. 
 
 NOTE: We recommend that you wrap regular expressions in single quotation marks to work around YAML's string escaping rules. For example, `'^\[?[0-9][0-9]:?[0-9][0-9]|^[[:graph:]]+'`.
 
 For more examples of supported regexp patterns, see {filebeat}/multiline-examples.html[Managing Multiline Messages].
 Although the examples pertain to Filebeat, the regexp patterns are applicable to other use cases.
 
-[float]
-=== Supported Patterns
 The following patterns are supported:
 
 * <<single-characters, Single Characters>>
@@ -115,51 +113,6 @@ The following patterns are supported:
 |`\S`             |not whitespace (same as `[^\t\n\f\r ]`)
 |`\w`             |word characters (same as `[0-9A-Za-z_]`)
 |`\W`             |not word characters (same as `[^0-9A-Za-z_]`)
-|=======================
-
-
-[[unsupported-regexp-patterns]]
-[float]
-=== Unsupported Patterns
-
-deprecated[5.0.0-alpha3,The following patterns are supported starting in 5.0.0-alpha3]
-
-The following patterns are not supported.
-
-[options="header"]
-|=======================
-|Pattern           |Description
-|*Unsupported Single Characters* 1+|  
-|`\d`              |Perl character class
-|`\D`              |negated Perl character class
-|`\pN`             |Unicode character class (one-letter name)
-|`\p{Greek}`       |Unicode character class
-|`\PN`             |negated Unicode character class (one-letter name)
-|`\P{Greek}`       |negated Unicode character class
-|*Unsupported Grouping*      1+|
-|`(?P<name>re)`    |named & numbered capturing group (submatch)
-|`(?:re)`          |non-capturing group
-|`(?i)abc`         |set flags within current group, non-capturing
-|`(?i:re)`         |set flags during re, non-capturing
-|`(?i)PaTTeRN`     |case-insensitive (default false)
-|`(?m)multiline`   |multi-line mode: `^` and `$` match begin/end line in addition to begin/end text (default false)
-|`(?s)pattern.`    |let `.` match `\n` (default false)
-|`(?U)x*abc`      |ungreedy: swap meaning of `x*` and `x*?`, `x+` and `x+?`, etc (default false)
-|*Unsupported Empty Strings* 1+|
-|`\A`              |at beginning of text
-|`\b`              |at ASCII word boundary (`\w` on one side and `\W`, `\A`, or `\z` on the other)
-|`\B`              |not at ASCII word boundary
-|`\z`              |at end of text
-|*Unsupported Escape Sequences* 1+|
-|`\C`              |match a single byte even in UTF-8 mode
-|`\Q...\E`         |literal text `...` even if `...` has punctuation
-|*Unsupported Perl Character Classes*  1+|
-|`\d`              |digits (same as `[0-9]`)
-|`\D`              |not digits (same as `[^0-9]`)
-|`\s`              |whitespace (same as `[\t\n\f\r ]`)
-|`\S`              |not whitespace (same as `[^\t\n\f\r ]`)
-|`\w`              |word characters (same as `[0-9A-Za-z_]`)
-|`\W`              |not word characters (same as `[^0-9A-Za-z_]`)
 |=======================
 
 

--- a/libbeat/docs/shared-config-ingest.asciidoc
+++ b/libbeat/docs/shared-config-ingest.asciidoc
@@ -13,7 +13,7 @@
 == Configuring {beatname_uc} to Use Ingest Node
 
 When you use Elasticsearch for output, you can configure {beatname_uc} to use
-https://www.elastic.co/guide/en/elasticsearch/reference/master/ingest.html[ingest node] to pre-process documents
+{elasticsearch}/ingest.html[ingest node] to pre-process documents
 before the actual indexing takes place in Elasticsearch. Ingest node is a convenient processing option when you
 want to do some extra processing on your data, but you do not require the full power of Logstash. For
 example, you can create an ingest node pipeline in Elasticsearch that consists of one processor

--- a/libbeat/docs/shared-ssl-logstash-config.asciidoc
+++ b/libbeat/docs/shared-ssl-logstash-config.asciidoc
@@ -17,7 +17,7 @@ To use SSL mutual authentication:
 
 . Create a certificate authority (CA) and use it to sign the certificates that you plan to use for
 {beatname_uc} and Logstash. Creating a correct SSL/TLS infrastructure is outside the scope of this
-document. There are many online resources available that describe how to create certificates, including the section in the {security} documentation about {securitydoc}/certificate-authority.html[setting up a certificate authority].
+document. There are many online resources available that describe how to create certificates.
 
 . Configure {beatname_uc} to use SSL. In the +{beatname_lc}.yml+ config file, specify the following settings under
 `ssl`:

--- a/metricbeat/docs/index.asciidoc
+++ b/metricbeat/docs/index.asciidoc
@@ -5,7 +5,7 @@ include::./version.asciidoc[]
 :libbeat: http://www.elastic.co/guide/en/beats/libbeat/{doc-branch}
 :filebeat: http://www.elastic.co/guide/en/beats/filebeat/{doc-branch}
 :elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/{doc-branch}
-:securitydoc: https://www.elastic.co/guide/en/shield/current
+:securitydoc: https://www.elastic.co/guide/en/x-pack/5.0
 :version: {stack-version}
 :beatname_lc: metricbeat
 :beatname_uc: Metricbeat

--- a/metricbeat/docs/metricbeat-filtering.asciidoc
+++ b/metricbeat/docs/metricbeat-filtering.asciidoc
@@ -40,17 +40,6 @@ include::../../libbeat/docs/processors.asciidoc[]
 For example, the following filters configuration reduces the exported fields by
 dropping the `beat.name` and `beat.hostname` fields under `beat`, from all documents.
 
-deprecated[5.0.0-alpha4,The `filters` section is being renamed to `processors` in 5.0.0-alpha5. Therefore the following configuration is deprecated]
-
-[source, yaml]
-----
-filters:
- - drop_fields:
-    fields: ['beat']
-----
-
-added[5.0.0-alpha5,Begin using the following configuration starting with 5.0.0-alpha5]
-
 [source, yaml]
 ----
 processors:

--- a/packetbeat/docs/index.asciidoc
+++ b/packetbeat/docs/index.asciidoc
@@ -8,7 +8,7 @@ include::./version.asciidoc[]
 :filebeat: http://www.elastic.co/guide/en/beats/filebeat/{doc-branch}
 :winlogbeat: http://www.elastic.co/guide/en/beats/winlogbeat/{doc-branch}
 :elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/{doc-branch}
-:securitydoc: https://www.elastic.co/guide/en/shield/current
+:securitydoc: https://www.elastic.co/guide/en/x-pack/5.0
 :version: {stack-version}
 :beatname_lc: packetbeat
 :beatname_uc: Packetbeat

--- a/packetbeat/docs/packetbeat-filtering.asciidoc
+++ b/packetbeat/docs/packetbeat-filtering.asciidoc
@@ -43,18 +43,6 @@ The filtered event would look something like this:
 
 If you would like to drop all the successful transactions, you can use the following configuration:
 
-deprecated[5.0.0-alpha4,The `filters` section is being renamed to `processors` in 5.0.0-alpha5. Therefore the following configuration is deprecated]
-
-[source,yaml]
-------------
-filters:
- - drop_event:
-     equals:
-       http.response.code: 200
------------
-
-added[5.0.0-alpha5,Begin using the following configuration starting with 5.0.0-alpha5]
-
 [source,yaml]
 ------------
 processors:
@@ -66,19 +54,6 @@ processors:
 
 
 If you don't want to export raw data for the successful transactions:
-
-deprecated[5.0.0-alpha4,The `filters` section is being renamed to `processors` in 5.0.0-alpha5. Therefore the following configuration is deprecated]
-
-[source,yaml]
-------------
-filters:
- - drop_fields:
-     equals:
-       http.response.code: 200
-     fields: ["request", "response"]
-------------
-
-added[5.0.0-alpha5,Begin using the following configuration starting with 5.0.0-alpha5]
 
 [source,yaml]
 ------------

--- a/winlogbeat/docs/index.asciidoc
+++ b/winlogbeat/docs/index.asciidoc
@@ -8,7 +8,7 @@ include::./version.asciidoc[]
 :filebeat: http://www.elastic.co/guide/en/beats/filebeat/{doc-branch}
 :winlogbeat: http://www.elastic.co/guide/en/beats/winlogbeat/{doc-branch}
 :elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/{doc-branch}
-:securitydoc: https://www.elastic.co/guide/en/shield/current
+:securitydoc: https://www.elastic.co/guide/en/x-pack/5.0
 :version: {stack-version}
 :beatname_lc: winlogbeat
 :beatname_uc: Winlogbeat

--- a/winlogbeat/docs/winlogbeat-filtering.asciidoc
+++ b/winlogbeat/docs/winlogbeat-filtering.asciidoc
@@ -5,17 +5,6 @@ include::../../libbeat/docs/processors.asciidoc[]
 
 For example, the following filter configuration drops a few fields that are rarely used (`provider_guid`, `process_id`, `thread_id`, and `version`) and one nested field, `event_data.ErrorSourceTable`:
 
-deprecated[5.0.0-alpha4,The `filters` section is being renamed to `processors` in 5.0.0-alpha5. Therefore the following configuration is deprecated]
-
-[source, yaml]
------------------------------------------------------
-filters:
-  - drop_fields:
-      fields: [provider_guid, process_id, thread_id, version, event_data.ErrorSourceTable]
------------------------------------------------------
-
-added[5.0.0-alpha5,Begin using the following configuration starting with 5.0.0-alpha5]
-
 [source, yaml]
 -----------------------------------------------------
 processors:


### PR DESCRIPTION
This PR resolves the required cleanup for beta1 tracked in #2482 

- Removed alpha notes that describe changes between alpha 4 and alpha 5. Kept deprecated items that (I think) we want to flag for GA.
- Changed links to point to x-pack docs. Note that I used "current" because X-Pack does not build docs in master.
- Had to take out the link to security doc about creating a CA because that doc no longer seems to exist