### PR TITLE
Fix wrong link for dashboards (#2578)

### DIFF
--- a/libbeat/dashboards/import_dashboards.go
+++ b/libbeat/dashboards/import_dashboards.go
@@ -83,7 +83,7 @@ func DefineCommandLine() (*CommandLine, error) {
 	cl.flagSet.StringVar(&cl.opt.Dir, "dir", "", "Directory containing the subdirectories: dashboard, visualization, search, index-pattern. Example: etc/kibana/")
 	cl.flagSet.StringVar(&cl.opt.File, "file", "", "Zip archive file containing the Beats dashboards. The archive contains a directory for each Beat.")
 	cl.flagSet.StringVar(&cl.opt.Url, "url",
-		fmt.Sprintf("https://download.elastic.co/beats/dashboards/beats-dashboards-%s.zip", lbeat.GetDefaultVersion()),
+		fmt.Sprintf("https://download.elastic.co/beats/beats-dashboards/beats-dashboards-%s.zip", lbeat.GetDefaultVersion()),
 		"URL to the zip archive containing the Beats dashboards")
 	cl.flagSet.StringVar(&cl.opt.Beat, "beat", beat, "The Beat name, in case a zip archive is passed as input")
 	cl.flagSet.BoolVar(&cl.opt.OnlyDashboards, "only-dashboards", false, "Import only dashboards together with visualizations and searches. By default import both, dashboards and the index-pattern.")


### PR DESCRIPTION
Backport of #2578. Original description:

In https://github.com/elastic/beats/blob/master/libbeat/dashboards/import_dashboards.go#L86 we are downloading dashboards from `https://download.elastic.co/beats/dashboards/beats-dashboards-%s.zip`

But we are uploading dashboards to `https://download.elastic.co/beats/beats-dashboards/beats-dashboards-%s.zip`.

This commit fix it.

Closes #2575.