### PR TITLE
Rename / restructure input / output setup in filebeat

### DIFF
--- a/filebeat/crawler/crawler.go
+++ b/filebeat/crawler/crawler.go
@@ -13,18 +13,18 @@ import (
 type Crawler struct {
 	prospectors       []*prospector.Prospector
 	prospectorConfigs []*common.Config
-	out               prospector.Outlet
+	output            prospector.Output
 	wg                sync.WaitGroup
 }
 
-func New(out prospector.Outlet, prospectorConfigs []*common.Config) (*Crawler, error) {
+func New(output prospector.Output, prospectorConfigs []*common.Config) (*Crawler, error) {
 
 	if len(prospectorConfigs) == 0 {
 		return nil, fmt.Errorf("No prospectors defined. You must have at least one prospector defined in the config file.")
 	}
 
 	return &Crawler{
-		out:               out,
+		output:            output,
 		prospectorConfigs: prospectorConfigs,
 	}, nil
 }
@@ -36,7 +36,7 @@ func (c *Crawler) Start(states file.States, once bool) error {
 	// Prospect the globs/paths given on the command line and launch harvesters
 	for _, prospectorConfig := range c.prospectorConfigs {
 
-		prospector, err := prospector.NewProspector(prospectorConfig, states, c.out)
+		prospector, err := prospector.NewProspector(prospectorConfig, states, c.output)
 		if err != nil {
 			return fmt.Errorf("Error in initing prospector: %s", err)
 		}

--- a/filebeat/prospector/prospector_log_other_test.go
+++ b/filebeat/prospector/prospector_log_other_test.go
@@ -132,7 +132,7 @@ func TestInit(t *testing.T) {
 		p := ProspectorLog{
 			Prospector: &Prospector{
 				states: &file.States{},
-				outlet: TestOutlet{},
+				output: TestOutput{},
 			},
 			config: prospectorConfig{
 				Paths: test.paths,
@@ -148,6 +148,6 @@ func TestInit(t *testing.T) {
 }
 
 // TestOutlet is an empty outlet for testing
-type TestOutlet struct{}
+type TestOutput struct{}
 
-func (o TestOutlet) OnEvent(event *input.Event) bool { return true }
+func (o TestOutput) Send(event *input.Event) bool { return true }

--- a/filebeat/publisher/publisher.go
+++ b/filebeat/publisher/publisher.go
@@ -19,23 +19,22 @@ type LogPublisher interface {
 	Stop()
 }
 
-// SuccessLogger is used to report successfully published events.
-type SuccessLogger interface {
-
+// Output is used to report successfully published events.
+type Output interface {
 	// Published will be run after events have been acknowledged by the outputs.
-	Published(events []*input.Event) bool
+	Send(events []*input.Event) bool
 }
 
 func New(
 	async bool,
-	in chan []*input.Event,
-	out SuccessLogger,
+	input chan []*input.Event,
+	output Output,
 	pub publisher.Publisher,
 ) LogPublisher {
 	if async {
-		return newAsyncLogPublisher(in, out, pub)
+		return newAsyncLogPublisher(input, output, pub)
 	}
-	return newSyncLogPublisher(in, out, pub)
+	return newSyncLogPublisher(input, output, pub)
 }
 
 var (

--- a/filebeat/publisher/publisher_test.go
+++ b/filebeat/publisher/publisher_test.go
@@ -19,7 +19,7 @@ type collectLogger struct {
 	events [][]*input.Event
 }
 
-func (l *collectLogger) Published(events []*input.Event) bool {
+func (l *collectLogger) Send(events []*input.Event) bool {
 	l.wg.Done()
 	l.events = append(l.events, events)
 	return true

--- a/filebeat/publisher/sync.go
+++ b/filebeat/publisher/sync.go
@@ -12,22 +12,21 @@ type syncLogPublisher struct {
 	pub    publisher.Publisher
 	client publisher.Client
 	in     chan []*input.Event
-	out    SuccessLogger
-
-	done chan struct{}
-	wg   sync.WaitGroup
+	output Output
+	done   chan struct{}
+	wg     sync.WaitGroup
 }
 
 func newSyncLogPublisher(
 	in chan []*input.Event,
-	out SuccessLogger,
+	output Output,
 	pub publisher.Publisher,
 ) *syncLogPublisher {
 	return &syncLogPublisher{
-		in:   in,
-		out:  out,
-		pub:  pub,
-		done: make(chan struct{}),
+		in:     in,
+		output: output,
+		pub:    pub,
+		done:   make(chan struct{}),
 	}
 }
 
@@ -69,7 +68,7 @@ func (p *syncLogPublisher) Publish() error {
 	eventsSent.Add(int64(len(events)))
 
 	// Tell the logger that we've successfully sent these events
-	ok = p.out.Published(events)
+	ok = p.output.Send(events)
 	if !ok {
 		// stop publisher if successfully send events can not be logged anymore.
 		return sigPublisherStop


### PR DESCRIPTION
Naming convention:
- Everything using a channel to send data is called input / output with a Send method
- If only confirmation of events happens, it is called a Logger with a log method

More cleanup is needed in future PRs.

This replaces https://github.com/elastic/beats/pull/2511
