### PR TITLE
Make it clear that 'any' only works on Linux

### DIFF
--- a/packetbeat/etc/beat.yml
+++ b/packetbeat/etc/beat.yml
@@ -9,8 +9,8 @@
 
 #============================== Network device ================================
 
-# Select the network interface to sniff the data. You can use the "any"
-# keyword to sniff on all connected interfaces.
+# Select the network interface to sniff the data. On Linux, you can use the
+# "any" keyword to sniff on all connected interfaces.
 packetbeat.interfaces.device: any
 
 #================================== Flows =====================================

--- a/packetbeat/packetbeat.yml
+++ b/packetbeat/packetbeat.yml
@@ -9,8 +9,8 @@
 
 #============================== Network device ================================
 
-# Select the network interface to sniff the data. You can use the "any"
-# keyword to sniff on all connected interfaces.
+# Select the network interface to sniff the data. On Linux, you can use the
+# "any" keyword to sniff on all connected interfaces.
 packetbeat.interfaces.device: any
 
 #================================== Flows =====================================


### PR DESCRIPTION
The previous wording in the default config make it look like 'any'
would work on OS X & Windows, but it doesn't.