### PR TITLE
Update filehandler tests to most recent snapshot builds

### DIFF
--- a/filebeat/tests/open-file-handlers/Dockerfile-filebeat
+++ b/filebeat/tests/open-file-handlers/Dockerfile-filebeat
@@ -1,10 +1,10 @@
 FROM debian
 
 RUN apt-get update && apt-get install -y wget
-RUN wget https://beats-nightlies.s3.amazonaws.com/filebeat/filebeat-5.0.0-alpha6-SNAPSHOT-linux-x86_64.tar.gz -O filebeat.tar.gz
+RUN wget https://beats-nightlies.s3.amazonaws.com/filebeat/filebeat-6.0.0-alpha1-SNAPSHOT-linux-x86_64.tar.gz -O filebeat.tar.gz
 RUN mkdir filebeat
 RUN tar xvfz filebeat.tar.gz -C filebeat --strip-components=1
-RUN wget https://beats-nightlies.s3.amazonaws.com/metricbeat/metricbeat-5.0.0-alpha6-SNAPSHOT-amd64.deb -O metricbeat.deb
+RUN wget https://beats-nightlies.s3.amazonaws.com/metricbeat/metricbeat-6.0.0-alpha1-SNAPSHOT-amd64.deb -O metricbeat.deb
 RUN dpkg --force-overwrite -i metricbeat.deb
 
 COPY filebeat.yml /filebeat/filebeat.yml

--- a/filebeat/tests/open-file-handlers/docker-compose.yml
+++ b/filebeat/tests/open-file-handlers/docker-compose.yml
@@ -8,6 +8,8 @@ filebeat:
     - ES_HOST=${ES_HOST}
     - ES_USER=${ES_USER}
     - ES_PASSWORD=${ES_PASSWORD}
+  ports:
+    - 6060:6060
 
 # This host name is fixed because of the certificate
 logs:


### PR DESCRIPTION
Expose port 6060 to also allow local tools to use for debugging.