### PR TITLE
Fix go routine leak which lead to memory leak

### DIFF
--- a/filebeat/harvester/harvester.go
+++ b/filebeat/harvester/harvester.go
@@ -41,6 +41,7 @@ type Harvester struct {
 	fileReader      *LogFile
 	encodingFactory encoding.EncodingFactory
 	encoding        encoding.Encoding
+	harvesterDone   chan struct{}
 	done            chan struct{}
 }
 
@@ -55,6 +56,7 @@ func NewHarvester(
 		config:         defaultConfig,
 		state:          state,
 		prospectorChan: prospectorChan,
+		harvesterDone:  make(chan struct{}),
 		done:           done,
 	}
 


### PR DESCRIPTION
The internal goroutine used to stop fileReader and for close_timeout was not stoppped when a harvester was finished which lead to a memory leak and leak of go routines. The goroutine is now properly stopped and resources are freed