### PR TITLE
Cleanup harvester stopping goroutine

### DIFF
--- a/filebeat/harvester/harvester.go
+++ b/filebeat/harvester/harvester.go
@@ -41,7 +41,6 @@ type Harvester struct {
 	fileReader      *LogFile
 	encodingFactory encoding.EncodingFactory
 	encoding        encoding.Encoding
-	harvesterDone   chan struct{}
 	done            chan struct{}
 }
 
@@ -56,7 +55,6 @@ func NewHarvester(
 		config:         defaultConfig,
 		state:          state,
 		prospectorChan: prospectorChan,
-		harvesterDone:  make(chan struct{}),
 		done:           done,
 	}
 

--- a/filebeat/harvester/log.go
+++ b/filebeat/harvester/log.go
@@ -57,6 +57,27 @@ func (h *Harvester) Harvest(r reader.Reader) {
 	// Makes sure file is properly closed when the harvester is stopped
 	defer h.close()
 
+	// Channel to stop internal harvester routines
+	harvestDone := make(chan struct{})
+	defer close(harvestDone)
+
+	// Closes reader after timeout or when done channel is closed
+	// This routine is also responsible to properly stop the reader
+	go func() {
+		var closeTimeout <-chan time.Time
+		if h.config.CloseTimeout > 0 {
+			closeTimeout = time.After(h.config.CloseTimeout)
+		}
+
+		select {
+		case <-closeTimeout:
+			logp.Info("Closing harvester because close_timeout was reached: %s", h.state.Source)
+		case <-h.done:
+		case <-harvestDone:
+		}
+		h.fileReader.Close()
+	}()
+
 	logp.Info("Harvester started for file: %s", h.state.Source)
 
 	for {
@@ -258,8 +279,6 @@ func (h *Harvester) getState() file.State {
 }
 
 func (h *Harvester) close() {
-	// stops all go routines inside the harvester
-	close(h.harvesterDone)
 
 	// Mark harvester as finished
 	h.state.Finished = true
@@ -310,23 +329,6 @@ func (h *Harvester) newLogFileReader() (reader.Reader, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	// Closes reader after timeout or when done channel is closed
-	// This routine is also responsible to properly stop the reader
-	go func() {
-		var closeTimeout <-chan time.Time
-		if h.config.CloseTimeout > 0 {
-			closeTimeout = time.After(h.config.CloseTimeout)
-		}
-
-		select {
-		case <-closeTimeout:
-			logp.Info("Closing harvester because close_timeout was reached: %s", h.state.Source)
-		case <-h.done:
-		case <-h.harvesterDone:
-		}
-		h.fileReader.Close()
-	}()
 
 	r, err = reader.NewEncode(h.fileReader, h.encoding, h.config.BufferSize)
 	if err != nil {

--- a/filebeat/harvester/log.go
+++ b/filebeat/harvester/log.go
@@ -70,9 +70,12 @@ func (h *Harvester) Harvest(r reader.Reader) {
 		}
 
 		select {
+		// Applies when timeout is reached
 		case <-closeTimeout:
 			logp.Info("Closing harvester because close_timeout was reached: %s", h.state.Source)
+		// Required for shutdown when hanging inside reader
 		case <-h.done:
+		// Required when reader loop returns and reader finished
 		case <-harvestDone:
 		}
 		h.fileReader.Close()

--- a/filebeat/harvester/log_file.go
+++ b/filebeat/harvester/log_file.go
@@ -3,7 +3,6 @@ package harvester
 import (
 	"io"
 	"os"
-	"sync"
 	"time"
 
 	"github.com/elastic/beats/filebeat/harvester/source"
@@ -18,7 +17,6 @@ type LogFile struct {
 	lastTimeRead time.Time
 	backoff      time.Duration
 	done         chan struct{}
-	singleClose  sync.Once
 }
 
 func NewLogFile(
@@ -167,9 +165,6 @@ func (r *LogFile) wait() {
 }
 
 func (r *LogFile) Close() {
-	// Make sure reader is only closed once
-	r.singleClose.Do(func() {
-		close(r.done)
-		// Note: File reader is not closed here because that leads to race conditions
-	})
+	close(r.done)
+	// Note: File reader is not closed here because that leads to race conditions
 }

--- a/filebeat/tests/system/test_harvester.py
+++ b/filebeat/tests/system/test_harvester.py
@@ -260,7 +260,7 @@ class Test(BaseTest):
         # Wait until state is written
         self.wait_until(
             lambda: self.log_contains(
-                "1 states written."),
+                "Registrar states cleaned up"),
             max_timeout=15)
 
         filebeat.check_kill_and_wait()


### PR DESCRIPTION
* Move close_timeout go routine to Harvest method to only be started when Harvester starts
* Remove once lock for reader as only one location to close channel now