### PR TITLE
Cleanup harvester stopping goroutine (#2599)

### DIFF
--- a/filebeat/harvester/harvester.go
+++ b/filebeat/harvester/harvester.go
@@ -41,7 +41,6 @@ type Harvester struct {
 	fileReader      *LogFile
 	encodingFactory encoding.EncodingFactory
 	encoding        encoding.Encoding
-	harvesterDone   chan struct{}
 	done            chan struct{}
 }
 
@@ -56,7 +55,6 @@ func NewHarvester(
 		config:         defaultConfig,
 		state:          state,
 		prospectorChan: prospectorChan,
-		harvesterDone:  make(chan struct{}),
 		done:           done,
 	}
 

--- a/filebeat/harvester/log_file.go
+++ b/filebeat/harvester/log_file.go
@@ -3,7 +3,6 @@ package harvester
 import (
 	"io"
 	"os"
-	"sync"
 	"time"
 
 	"github.com/elastic/beats/filebeat/harvester/source"
@@ -18,7 +17,6 @@ type LogFile struct {
 	lastTimeRead time.Time
 	backoff      time.Duration
 	done         chan struct{}
-	singleClose  sync.Once
 }
 
 func NewLogFile(
@@ -167,9 +165,6 @@ func (r *LogFile) wait() {
 }
 
 func (r *LogFile) Close() {
-	// Make sure reader is only closed once
-	r.singleClose.Do(func() {
-		close(r.done)
-		// Note: File reader is not closed here because that leads to race conditions
-	})
+	close(r.done)
+	// Note: File reader is not closed here because that leads to race conditions
 }

--- a/filebeat/tests/system/test_harvester.py
+++ b/filebeat/tests/system/test_harvester.py
@@ -259,7 +259,7 @@ class Test(BaseTest):
         # Wait until state is written
         self.wait_until(
             lambda: self.log_contains(
-                "1 states written."),
+                "Registrar states cleaned up"),
             max_timeout=15)
 
         filebeat.check_kill_and_wait()


### PR DESCRIPTION
* Cleanup harvester stopping goroutine
* Move close_timeout go routine to Harvest method to only be started when Harvester starts
* Remove once lock for reader as only one location to close channel now
* Fix flaky test