### PR TITLE
Updated docs with new repositories

### DIFF
--- a/libbeat/docs/index.asciidoc
+++ b/libbeat/docs/index.asciidoc
@@ -27,7 +27,7 @@ include::./config-file-format.asciidoc[]
 
 // include::./visualizing-data.asciidoc[]
 
-//include::./dashboards.asciidoc[]
+include::./dashboards.asciidoc[]
 
 pass::[<?page_header <b>PLEASE NOTE:</b><br/>Always refer to the documentation in master for the latest information about contributing to Beats.?>]
 

--- a/libbeat/docs/repositories.asciidoc
+++ b/libbeat/docs/repositories.asciidoc
@@ -20,20 +20,26 @@ To add the Beats repository for APT:
 +
 [source,sh]
 --------------------------------------------------
-curl https://packages.elasticsearch.org/GPG-KEY-elasticsearch | sudo apt-key add -
+wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | sudo apt-key add -
 --------------------------------------------------
 
-. Save the repository definition to  +/etc/apt/sources.list.d/beats.list+:
+. You may need to install the `apt-transport-https` package on Debian before proceeding:
++
+[source,sh]
+--------------------------------------------------
+sudo apt-get install apt-transport-https
+--------------------------------------------------
+
+. Save the repository definition to  +/etc/apt/sources.list.d/elastic-5.x.list+:
 +
 ["source","sh",subs="attributes,callouts"]
 --------------------------------------------------
-echo "deb https://packages.elastic.co/beats/apt stable main" |  sudo tee -a /etc/apt/sources.list.d/beats.list
-
+echo "deb https://artifacts.elastic.co/packages/5.x-prerelease/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-5.x.list
 --------------------------------------------------
 +
 [WARNING]
 ==================================================
-To add the Beats repository, make sure that you use the `echo` method  shown
+To add the Elastic repository, make sure that you use the `echo` method  shown
 in the example. Do not use `add-apt-repository` because it will add a `deb-src`
 entry, but we do not provide a source package.
 
@@ -72,17 +78,19 @@ To add the Beats repository for YUM:
 sudo rpm --import https://packages.elastic.co/GPG-KEY-elasticsearch
 --------------------------------------------------
 
-. Create a file with a `.repo` extension (for example, `beats.repo`) in
+. Create a file with a `.repo` extension (for example, `elastic.repo`) in
 your `/etc/yum.repos.d/` directory and add the following lines:
 +
 ["source","sh",subs="attributes,callouts"]
 --------------------------------------------------
-[beats]
-name=Elastic Beats Repository
-baseurl=https://packages.elastic.co/beats/yum/el/$basearch
-enabled=1
-gpgkey=https://packages.elastic.co/GPG-KEY-elasticsearch
+[elastic-5.x]
+name=Elastic repository for 5.x packages
+baseurl=https://artifacts.elastic.co/packages/5.x-prerelease/yum
 gpgcheck=1
+gpgkey=https://artifacts.elastic.co/GPG-KEY-elasticsearch
+enabled=1
+autorefresh=1
+type=rpm-md
 --------------------------------------------------
 +
 Your repository is ready to use. For example, you can install Filebeat by


### PR DESCRIPTION
Added back the repos docs as we have freshly unified apt/yum repositories. The URLs and such come from the Elasticsearch docs, as we'll be sharing the same repos: https://www.elastic.co/guide/en/elasticsearch/reference/5.0/deb.html