### PR TITLE
Send float fields as float values to Elasticsearch

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -28,6 +28,8 @@ https://github.com/elastic/beats/compare/v5.0.0-beta1...master[Check the HEAD di
 ==== Bugfixes
 
 *Affecting all Beats*
+- Make sure Beats sent always float values when they are defined as float by sending 5.00000 instead of 5.
+  {pull}2627[2627]
 
 *Metricbeat*
 

--- a/libbeat/common/event.go
+++ b/libbeat/common/event.go
@@ -19,6 +19,8 @@ var eventDebugf = logp.MakeDebug(eventDebugSelector)
 
 var textMarshalerType = reflect.TypeOf((*encoding.TextMarshaler)(nil)).Elem()
 
+type Float float64
+
 // ConvertToGenericEvent normalizes the types contained in the given MapStr.
 //
 // Nil values in maps are dropped during the conversion. Any unsupported types
@@ -130,6 +132,7 @@ func normalizeValue(value interface{}, keys ...string) (interface{}, []error) {
 	case uint, uint8, uint16, uint32, uint64:
 	case []uint, []uint8, []uint16, []uint32, []uint64:
 	case float32, float64:
+		return Float(value.(float64)), nil
 	case []float32, []float64:
 	case complex64, complex128:
 	case []complex64, []complex128:
@@ -156,7 +159,7 @@ func normalizeValue(value interface{}, keys ...string) (interface{}, []error) {
 		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
 			return v.Uint(), nil
 		case reflect.Float32, reflect.Float64:
-			return v.Float(), nil
+			return Float(v.Float()), nil
 		case reflect.Complex64, reflect.Complex128:
 			return v.Complex(), nil
 		case reflect.String:
@@ -220,4 +223,9 @@ func joinKeys(keys ...string) string {
 		keys = keys[1:]
 	}
 	return strings.Join(keys, ".")
+}
+
+// Defines the marshal of the Float type
+func (f Float) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf("%.6f", f)), nil
 }

--- a/libbeat/common/event_test.go
+++ b/libbeat/common/event_test.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/elastic/beats/libbeat/logp"
@@ -295,6 +296,23 @@ func TestMarshalUnmarshalArray(t *testing.T) {
 
 		assert.Equal(t, test.out, out, "Test case %v", i)
 	}
+}
+
+func TestMarshalFloatValues(t *testing.T) {
+
+	assert := assert.New(t)
+
+	var f float64
+
+	f = 5
+
+	a := MapStr{
+		"f": Float(f),
+	}
+
+	b, err := json.Marshal(a)
+	assert.Nil(err)
+	assert.Equal(string(b), "{\"f\":5.000000}")
 }
 
 // Uses TextMarshaler interface.

--- a/libbeat/processors/condition.go
+++ b/libbeat/processors/condition.go
@@ -369,7 +369,7 @@ func (c *Condition) checkRange(event common.MapStr) bool {
 				return false
 			}
 
-		case float64, float32:
+		case float64, float32, common.Float:
 			floatValue := reflect.ValueOf(value).Float()
 
 			if !checkValue(floatValue, rangeValue) {
@@ -377,7 +377,7 @@ func (c *Condition) checkRange(event common.MapStr) bool {
 			}
 
 		default:
-			logp.Warn("unexpected type %T in range condition as it accepts only strings. ", value)
+			logp.Warn("unexpected type %T in range condition. ", value)
 			return false
 		}
 

--- a/metricbeat/tests/system/test_processors.py
+++ b/metricbeat/tests/system/test_processors.py
@@ -134,7 +134,7 @@ class TestProcessors(metricbeat.BaseTest):
         output = self.read_output(
             required_fields=["@timestamp", "type"],
         )
-        assert len(output) == 1
+        assert len(output) >= 1
 
 
     def test_include_fields(self):


### PR DESCRIPTION
This PR tries to remove the necessity to define the mapping before inserting the data into Elasticsearch, by making sure that float fields are always sent as float values even if they are not flows. For example `5` will be sent as `5.00000`, so Elasticsearch defines it as `float`.

With this change, it's not needed to load the template in advance, before inserting the data into Elasticsearch.

NOTE: This also affects processors.