### PR TITLE
Fix redis.datatype typo in config file

### DIFF
--- a/filebeat/filebeat.full.yml
+++ b/filebeat/filebeat.full.yml
@@ -642,7 +642,7 @@ output.elasticsearch:
   # The Redis data type to use for publishing events. If the data type is list,
   # the Redis RPUSH command is used. If the data type is channel, the Redis
   # PUBLISH command is used. The default value is list.
-  #datetype: list
+  #datatype: list
 
   # The number of workers to use for each host configured to publish events to
   # Redis. Use this setting along with the loadbalance option. For example, if

--- a/libbeat/_meta/config.full.yml
+++ b/libbeat/_meta/config.full.yml
@@ -406,7 +406,7 @@ output.elasticsearch:
   # The Redis data type to use for publishing events. If the data type is list,
   # the Redis RPUSH command is used. If the data type is channel, the Redis
   # PUBLISH command is used. The default value is list.
-  #datetype: list
+  #datatype: list
 
   # The number of workers to use for each host configured to publish events to
   # Redis. Use this setting along with the loadbalance option. For example, if

--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -813,8 +813,10 @@ The Redis database number where the events are published. The default is 0.
 
 ===== datatype
 
-The Redis data type to use for publishing events. If the data type is `list`, the
-Redis RPUSH command is used. If the data type is `channel`, the Redis `PUBLISH` command is used.
+The Redis data type to use for publishing events.If the data type is `list`, the
+Redis RPUSH command is used and all events are added to the list with the key defined under `key`.
+If the data type `channel` is used, the Redis `PUBLISH` command is used and means that all events
+are pushed to the pub/sub mechanism of Redis. The name of the channel is the one defined under `key`.
 The default value is `list`.
 
 ===== host_topology

--- a/metricbeat/metricbeat.full.yml
+++ b/metricbeat/metricbeat.full.yml
@@ -597,7 +597,7 @@ output.elasticsearch:
   # The Redis data type to use for publishing events. If the data type is list,
   # the Redis RPUSH command is used. If the data type is channel, the Redis
   # PUBLISH command is used. The default value is list.
-  #datetype: list
+  #datatype: list
 
   # The number of workers to use for each host configured to publish events to
   # Redis. Use this setting along with the loadbalance option. For example, if

--- a/packetbeat/packetbeat.full.yml
+++ b/packetbeat/packetbeat.full.yml
@@ -860,7 +860,7 @@ output.elasticsearch:
   # The Redis data type to use for publishing events. If the data type is list,
   # the Redis RPUSH command is used. If the data type is channel, the Redis
   # PUBLISH command is used. The default value is list.
-  #datetype: list
+  #datatype: list
 
   # The number of workers to use for each host configured to publish events to
   # Redis. Use this setting along with the loadbalance option. For example, if

--- a/winlogbeat/winlogbeat.full.yml
+++ b/winlogbeat/winlogbeat.full.yml
@@ -441,7 +441,7 @@ output.elasticsearch:
   # The Redis data type to use for publishing events. If the data type is list,
   # the Redis RPUSH command is used. If the data type is channel, the Redis
   # PUBLISH command is used. The default value is list.
-  #datetype: list
+  #datatype: list
 
   # The number of workers to use for each host configured to publish events to
   # Redis. Use this setting along with the loadbalance option. For example, if


### PR DESCRIPTION
* In the config file, it was redis.datetype instead of datatype
* Improve documentation