### PR TITLE
Fix default Metricbeat config on Windows

### DIFF
--- a/metricbeat/Makefile
+++ b/metricbeat/Makefile
@@ -57,6 +57,11 @@ imports:
 # This is called by the beats packer before building starts
 .PHONY: before-build
 before-build:
+	# disable the system/load metricset on windows
+	sed -i.bk 's/- load/#- load/' $(PREFIX)/metricbeat-win.yml
+	rm $(PREFIX)/metricbeat-win.yml.bk
+	sed -i.bk 's/- load/#- load/' $(PREFIX)/metricbeat-win.full.yml
+	rm $(PREFIX)/metricbeat-win.full.yml.bk
 
 # Runs all collection steps and updates afterwards
 .PHONY: collect


### PR DESCRIPTION
The load metricset is not supported on Windows, and if it's enabled
in the configuration file, it makes Metricbeat exit immediately with
an error.

This change adjusted the configuration on Windows to exclude the load
metricset.

Fixes #2623.