### PR TITLE
Add batch_read_size config to Winlogbeat

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -56,9 +56,11 @@ https://github.com/elastic/beats/compare/v5.0.0-beta1...master[Check the HEAD di
 
 *Filebeat*
 
-- Add command line option -once to run filebeat only once and then close {pull}2456[2456]
+- Add command line option -once to run filebeat only once and then close. {pull}2456[2456]
 
 *Winlogbeat*
+
+- Add `event_logs.batch_read_size` configuration option. {pull}2641[2641]
 
 ==== Deprecated
 

--- a/winlogbeat/docs/reference/configuration/winlogbeat-options.asciidoc
+++ b/winlogbeat/docs/reference/configuration/winlogbeat-options.asciidoc
@@ -53,6 +53,17 @@ winlogbeat.event_logs:
   - name: Application
 --------------------------------------------------------------------------------
 
+===== event_logs.batch_read_size
+
+The maximum number of event log records to read from the Windows API in a single
+batch. The default batch size is 100. *{vista_and_newer}*
+
+Winlogbeat starts a goroutine (a lightweight thread) to read from each
+individual event log. The goroutine reads a batch of event log records using the
+Windows API, applies any processors to the events, publishes them to the
+configured outputs, and waits for an acknowledgement from the outputs before
+reading additional event log records.
+
 [[configuration-winlogbeat-options-event_logs-name]]
 ===== event_logs.name
 

--- a/winlogbeat/eventlog/wineventlog.go
+++ b/winlogbeat/eventlog/wineventlog.go
@@ -17,9 +17,6 @@ import (
 )
 
 const (
-	// defaultBatchReadSize is the maximum number of event Read will return.
-	defaultBatchReadSize = 100
-
 	// renderBufferSize is the size in bytes of the buffer used to render events.
 	renderBufferSize = 1 << 14
 
@@ -33,11 +30,16 @@ var winEventLogConfigKeys = append(commonConfigKeys, "batch_read_size",
 
 type winEventLogConfig struct {
 	ConfigCommon  `config:",inline"`
-	BatchReadSize int                    `config:"batch_read_size"`
+	BatchReadSize int                    `config:"batch_read_size"` // Maximum number of events that Read will return.
 	IncludeXML    bool                   `config:"include_xml"`
 	Forwarded     *bool                  `config:"forwarded"`
 	SimpleQuery   query                  `config:",inline"`
 	Raw           map[string]interface{} `config:",inline"`
+}
+
+// defaultWinEventLogConfig is the default configuration for new wineventlog readers.
+var defaultWinEventLogConfig = winEventLogConfig{
+	BatchReadSize: 100,
 }
 
 // query contains parameters used to customize the event log data that is
@@ -219,7 +221,7 @@ func reportDrop(reason interface{}) {
 // newWinEventLog creates and returns a new EventLog for reading event logs
 // using the Windows Event Log.
 func newWinEventLog(options map[string]interface{}) (EventLog, error) {
-	c := winEventLogConfig{BatchReadSize: defaultBatchReadSize}
+	c := defaultWinEventLogConfig
 	if err := readConfig(options, &c, winEventLogConfigKeys); err != nil {
 		return nil, err
 	}

--- a/winlogbeat/eventlog/wineventlog_test.go
+++ b/winlogbeat/eventlog/wineventlog_test.go
@@ -1,0 +1,54 @@
+// +build windows
+
+package eventlog
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWinEventLogBatchReadSize(t *testing.T) {
+	configureLogp()
+	log, err := initLog(providerName, sourceName, eventCreateMsgFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		err := uninstallLog(providerName, sourceName, log)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	// Publish test messages:
+	for k, m := range messages {
+		err = log.Report(m.eventType, k, []string{m.message})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	batchReadSize := 2
+	eventlog, err := newWinEventLog(map[string]interface{}{"name": providerName, "batch_read_size": batchReadSize})
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = eventlog.Open(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		err := eventlog.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	records, err := eventlog.Read()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Len(t, records, batchReadSize)
+}


### PR DESCRIPTION
This configuration option allows users to control the number of event log records that are read, processed, and published in its event loop.