### PR TITLE
Fixing the broken link to 'CONTRIBUTING.md' file

### DIFF
--- a/filebeat/README.md
+++ b/filebeat/README.md
@@ -29,7 +29,7 @@ If you are sure you found a bug or have a feature request, open an issue on
 ## Contributions
 
 We love contributions from our community! Please read the
-[CONTRIBUTING.md](CONTRIBUTING.md) file.
+[CONTRIBUTING.md](../CONTRIBUTING.md) file.
 
 ## Nightlies
 


### PR DESCRIPTION
Fixing the broken 'CONTRIBUTING.md' link from the README.md