### PR TITLE
Fix formatting of list

### DIFF
--- a/libbeat/docs/newdashboards.asciidoc
+++ b/libbeat/docs/newdashboards.asciidoc
@@ -59,7 +59,7 @@ Elasticsearch running on localhost for a single Beat (eg. Metricbeat):
 ----------------------------------------------------------------------
 
 - from the official zip archive available under http://artifacts.elastic.co/:
-
++
 [source,shell]
 ----------------------------------------------------------------------
 ./scripts/import_dashboards


### PR DESCRIPTION
Adds a missing plus sign to fix list formatting. The formatting is correct in master, so the plus must have been dropped during the merge or something.