### PR TITLE
Make package-setup dependency of package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,6 @@ docs:
 
 .PHONY: package
 package: beats-dashboards
-	$(MAKE) -C libbeat package-setup
 	$(foreach var,$(BEATS),SNAPSHOT=$(SNAPSHOT) $(MAKE) -C $(var) package || exit 1;)
 
 	# build the dashboards package

--- a/libbeat/docs/newdashboards.asciidoc
+++ b/libbeat/docs/newdashboards.asciidoc
@@ -108,7 +108,7 @@ make
 -----------------------
 
 And then you can import the index pattern and the dashboards together with visualizations and searches for a single
-Beat, by passing the `-beat` option. 
+Beat, by passing the `-beat` option.
 
 For example, to import the Metricbeat dashboards together with visualizations,
 searches, and the Metricbeat index pattern:
@@ -118,7 +118,7 @@ searches, and the Metricbeat index pattern:
 beats/libbeat/dashboards/import_dashboards -beat metricbeat
 -----------------
 
-For this example, you must specify `-beat metricbeat`. If the `-beat` option is not 
+For this example, you must specify `-beat metricbeat`. If the `-beat` option is not
 specified, the script imports the dashboards of all Beats.
 
 NOTE: You can make use of the Makefile from the Beat GitHub repository to import the
@@ -342,7 +342,6 @@ repository:
 
 [source,shell]
 --------------
-make package-setup
 make package-dashboards
 --------------
 

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -377,9 +377,8 @@ package-setup:
 	$(MAKE) -C ${ES_BEATS}/dev-tools/packer deps images
 
 # Create binary packages for the beat.
-# This requires that `package-setup` was run before once.
 .PHONY: package
-package:
+package: package-setup
 
 	echo "Start building packages for ${BEATNAME}"
 
@@ -401,7 +400,7 @@ package:
 
 	echo "Finished packages for ${BEATNAME}"
 
-package-dashboards:
+package-dashboards: package-setup
 	mkdir -p ${BUILD_DIR}
 	cp -r etc/kibana ${BUILD_DIR}/dashboards
 	# build the dashboards package


### PR DESCRIPTION
* If `make package` is run for all beats, the setup part is run multiple times. This should not be an issue as the setup part should be fast after the first build.
* When building the dashboards, it is now also directly a dependency.