### PR TITLE
Fix the custom BPF filter option

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -35,6 +35,8 @@ https://github.com/elastic/beats/compare/v5.0.0-beta1...master[Check the HEAD di
 
 *Packetbeat*
 
+- Fix the `bpf_filter` setting. {issue}2660[2660]
+
 *Topbeat*
 
 *Filebeat*

--- a/packetbeat/beater/packetbeat.go
+++ b/packetbeat/beater/packetbeat.go
@@ -198,52 +198,50 @@ func (pb *Packetbeat) setupSniffer() error {
 	}
 
 	pb.Sniff = &sniffer.SnifferSetup{}
-	return pb.Sniff.Init(false, filter, pb.makeWorkerFactory(), &config.Interfaces)
+	return pb.Sniff.Init(false, filter, pb.createWorker, &config.Interfaces)
 }
 
-func (pb *Packetbeat) makeWorkerFactory() sniffer.WorkerFactory {
-	return func(dl layers.LinkType) (sniffer.Worker, error) {
-		var f *flows.Flows
-		var err error
-		config := &pb.Config
+func (pb *Packetbeat) createWorker(dl layers.LinkType) (sniffer.Worker, error) {
+	var f *flows.Flows
+	var err error
+	config := &pb.Config
 
-		if config.Flows.IsEnabled() {
-			f, err = flows.NewFlows(pb.Pub, config.Flows)
-			if err != nil {
-				return nil, err
-			}
-		}
-
-		var icmp4 icmp.ICMPv4Processor
-		var icmp6 icmp.ICMPv6Processor
-		if cfg := config.Protocols["icmp"]; cfg.Enabled() {
-			icmp, err := icmp.New(false, pb.Pub, cfg)
-			if err != nil {
-				return nil, err
-			}
-
-			icmp4 = icmp
-			icmp6 = icmp
-		}
-
-		tcp, err := tcp.NewTcp(&protos.Protos)
+	if config.Flows.IsEnabled() {
+		f, err = flows.NewFlows(pb.Pub, config.Flows)
 		if err != nil {
 			return nil, err
 		}
-
-		udp, err := udp.NewUdp(&protos.Protos)
-		if err != nil {
-			return nil, err
-		}
-
-		worker, err := decoder.NewDecoder(f, dl, icmp4, icmp6, tcp, udp)
-		if err != nil {
-			return nil, err
-		}
-
-		if f != nil {
-			pb.services = append(pb.services, f)
-		}
-		return worker, nil
 	}
+
+	var icmp4 icmp.ICMPv4Processor
+	var icmp6 icmp.ICMPv6Processor
+	if cfg := config.Protocols["icmp"]; cfg.Enabled() {
+		icmp, err := icmp.New(false, pb.Pub, cfg)
+		if err != nil {
+			return nil, err
+		}
+
+		icmp4 = icmp
+		icmp6 = icmp
+	}
+
+	tcp, err := tcp.NewTcp(&protos.Protos)
+	if err != nil {
+		return nil, err
+	}
+
+	udp, err := udp.NewUdp(&protos.Protos)
+	if err != nil {
+		return nil, err
+	}
+
+	worker, err := decoder.NewDecoder(f, dl, icmp4, icmp6, tcp, udp)
+	if err != nil {
+		return nil, err
+	}
+
+	if f != nil {
+		pb.services = append(pb.services, f)
+	}
+	return worker, nil
 }


### PR DESCRIPTION
Set the `sniffer.filter` before `setFromConfig` is called. Changed the
factory prototype so it doesn't pass around `filter` and instead just
done it directly via Init.

Fixes #2660.