### PR TITLE
Use the new Elasticsearch snapshots in our tests

### DIFF
--- a/testing/environments/docker/elasticsearch/Dockerfile-snapshot
+++ b/testing/environments/docker/elasticsearch/Dockerfile-snapshot
@@ -1,17 +1,36 @@
 FROM java:8-jre
 
-ENV ELASTICSEARCH_MAJOR 5.0
+ENV ELASTICSEARCH_MAJOR 6.0
 ENV ELASTICSEARCH_VERSION master
+ENV VERSION 6.0.0-alpha1
+ENV FILENAME_VERSION 6.0.0-alpha1-SNAPSHOT
+ENV URL https://snapshots.elastic.co/downloads/elasticsearch/elasticsearch-${FILENAME_VERSION}.tar.gz
 
+ENV ESHOME /opt/elasticsearch-${FILENAME_VERSION}
 
-COPY setup.sh /
-RUN bash setup.sh https://staging.elastic.co/5.0.0-beta1-5eb5cbdb/downloads/elasticsearch/elasticsearch-5.0.0-beta1.deb
+# grab gosu for easy step-down from root
+RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
+RUN arch="$(dpkg --print-architecture)" \
+	&& set -x \
+	&& curl -o /usr/local/bin/gosu -fSL "https://github.com/tianon/gosu/releases/download/1.3/gosu-$arch" \
+	&& curl -o /usr/local/bin/gosu.asc -fSL "https://github.com/tianon/gosu/releases/download/1.3/gosu-$arch.asc" \
+	&& gpg --verify /usr/local/bin/gosu.asc \
+	&& rm /usr/local/bin/gosu.asc \
+	&& chmod +x /usr/local/bin/gosu
 
-ENV PATH /usr/share/elasticsearch/bin:$PATH
+RUN groupadd -r elasticsearch && useradd -r -m -g elasticsearch elasticsearch
 
-COPY config /usr/share/elasticsearch/config
+RUN set -x && \
+	cd /opt && \
+	wget -q $URL && \
+	tar xzvf elasticsearch-${FILENAME_VERSION}.tar.gz && \
+	chown -R elasticsearch:elasticsearch ${ESHOME}
 
-VOLUME /usr/share/elasticsearch/data
+ENV PATH ${ESHOME}/bin:$PATH
+
+#COPY config /opt/elasticsearch-$VERSION/config
+
+VOLUME ${ESHOME}/data
 
 ENV ES_JAVA_OPTS="-Xms512m -Xmx512m"
 

--- a/testing/environments/docker/elasticsearch/Dockerfile-snapshot
+++ b/testing/environments/docker/elasticsearch/Dockerfile-snapshot
@@ -22,13 +22,11 @@ RUN groupadd -r elasticsearch && useradd -r -m -g elasticsearch elasticsearch
 
 RUN set -x && \
 	cd /opt && \
-	wget -q $URL && \
-	tar xzvf elasticsearch-${FILENAME_VERSION}.tar.gz && \
+	wget -qO elasticsearch.tar.gz "$URL?t=$(date +%F)" && \
+	tar xzvf elasticsearch.tar.gz && \
 	chown -R elasticsearch:elasticsearch ${ESHOME}
 
 ENV PATH ${ESHOME}/bin:$PATH
-
-#COPY config /opt/elasticsearch-$VERSION/config
 
 VOLUME ${ESHOME}/data
 

--- a/testing/environments/docker/elasticsearch/docker-entrypoint.sh
+++ b/testing/environments/docker/elasticsearch/docker-entrypoint.sh
@@ -10,7 +10,7 @@ fi
 # Drop root privileges if we are running elasticsearch
 if [ "$1" = 'elasticsearch' ]; then
 	# Change the ownership of /usr/share/elasticsearch/data to elasticsearch
-	chown -R elasticsearch:elasticsearch /usr/share/elasticsearch/data
+	chown -R elasticsearch:elasticsearch ${ESHOME-/usr/share/elasticsearch}/data
 	exec gosu elasticsearch "$@"
 fi
 


### PR DESCRIPTION
This change makes our tests use the real - built from master -
snapshots. We can easily switch to use other branches in our release
branches.

This also simplifies our docker files by using the tar.gz instead of
the deb.

Note that the current snapshots is a few days old due to failures in
the UBP.