### PR TITLE
Backport: Fix the custom BPF filter option (#2671)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -35,6 +35,8 @@ https://github.com/elastic/beats/compare/v5.0.0-beta1...master[Check the HEAD di
 
 *Packetbeat*
 
+- Fix the `bpf_filter` setting. {issue}2660[2660]
+
 *Topbeat*
 
 *Filebeat*


### PR DESCRIPTION
Backport of #2671. Original message:

* Fix the custom BPF filter option

Set the `sniffer.filter` before `setFromConfig` is called. Changed the
factory prototype so it doesn't pass around `filter` and instead just
done it directly via Init.

Fixes #2660.

* Simplified code by removing the factory maker