### PR TITLE
Use 5.0.0-rc1 build in testing

### DIFF
--- a/testing/environments/docker/elasticsearch/Dockerfile-snapshot
+++ b/testing/environments/docker/elasticsearch/Dockerfile-snapshot
@@ -1,17 +1,34 @@
 FROM java:8-jre
 
 ENV ELASTICSEARCH_MAJOR 5.0
-ENV ELASTICSEARCH_VERSION master
+ENV ELASTICSEARCH_VERSION 5.0
+ENV VERSION 5.0.0-rc1
+ENV FILENAME_VERSION 5.0.0-rc1
+ENV URL http://staging.elastic.co/5.0.0-rc1-ace3a21c/downloads/elasticsearch/elasticsearch-5.0.0-rc1.tar.gz
 
+ENV ESHOME /opt/elasticsearch-${FILENAME_VERSION}
 
-COPY setup.sh /
-RUN bash setup.sh https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/5.0.0-alpha5/elasticsearch-5.0.0-alpha5.deb
+# grab gosu for easy step-down from root
+RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
+RUN arch="$(dpkg --print-architecture)" \
+	&& set -x \
+	&& curl -o /usr/local/bin/gosu -fSL "https://github.com/tianon/gosu/releases/download/1.3/gosu-$arch" \
+	&& curl -o /usr/local/bin/gosu.asc -fSL "https://github.com/tianon/gosu/releases/download/1.3/gosu-$arch.asc" \
+	&& gpg --verify /usr/local/bin/gosu.asc \
+	&& rm /usr/local/bin/gosu.asc \
+	&& chmod +x /usr/local/bin/gosu
 
-ENV PATH /usr/share/elasticsearch/bin:$PATH
+RUN groupadd -r elasticsearch && useradd -r -m -g elasticsearch elasticsearch
 
-COPY config /usr/share/elasticsearch/config
+RUN set -x && \
+	cd /opt && \
+	wget -qO elasticsearch.tar.gz "$URL?t=$(date +%F)" && \
+	tar xzvf elasticsearch.tar.gz && \
+	chown -R elasticsearch:elasticsearch ${ESHOME}
 
-VOLUME /usr/share/elasticsearch/data
+ENV PATH ${ESHOME}/bin:$PATH
+
+VOLUME ${ESHOME}/data
 
 ENV ES_JAVA_OPTS="-Xms512m -Xmx512m"
 

--- a/testing/environments/docker/elasticsearch/docker-entrypoint.sh
+++ b/testing/environments/docker/elasticsearch/docker-entrypoint.sh
@@ -10,7 +10,7 @@ fi
 # Drop root privileges if we are running elasticsearch
 if [ "$1" = 'elasticsearch' ]; then
 	# Change the ownership of /usr/share/elasticsearch/data to elasticsearch
-	chown -R elasticsearch:elasticsearch /usr/share/elasticsearch/data
+	chown -R elasticsearch:elasticsearch ${ESHOME-/usr/share/elasticsearch}/data
 	exec gosu elasticsearch "$@"
 fi
 

--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -3,7 +3,7 @@
 elasticsearch:
   build: ./docker/elasticsearch
   dockerfile: Dockerfile-snapshot
-  command: elasticsearch -Enetwork.host=0.0.0.0 -Ediscovery.zen.minimum_master_nodes=1 -Ebootstrap.ignore_system_bootstrap_checks=true
+  command: elasticsearch -Ehttp.host=0.0.0.0
 
 logstash:
   build: ./docker/logstash


### PR DESCRIPTION
This is mostly a backport of #2676, but using the 5.0 URLs.