### PR TITLE
Update snapshot build to 6.0.0-alpha1

### DIFF
--- a/metricbeat/module/beats/filebeat/_meta/Dockerfile
+++ b/metricbeat/module/beats/filebeat/_meta/Dockerfile
@@ -1,8 +1,11 @@
 FROM debian
 
+ENV VERSION 6.0.0-alpha1-SNAPSHOT
+ENV URL https://snapshots.elastic.co/downloads/beats/filebeat/filebeat-${VERSION}-amd64.deb
+
 RUN apt-get update && apt-get install -y wget
-RUN wget https://download.elastic.co/beats/filebeat/filebeat-5.0.0-alpha5-amd64.deb
-RUN dpkg -i filebeat-5.0.0-alpha5-amd64.deb
+RUN wget ${URL}
+RUN dpkg -i filebeat-${VERSION}-amd64.deb
 
 COPY filebeat.yml /etc/filebeat/filebeat.yml
 

--- a/testing/environments/docker/kibana/Dockerfile-snapshot
+++ b/testing/environments/docker/kibana/Dockerfile-snapshot
@@ -1,5 +1,9 @@
 FROM debian:jessie
 
+ENV VERSION 6.0.0-alpha1
+ENV FILENAME_VERSION 6.0.0-alpha1-SNAPSHOT-linux-x86_64
+ENV URL https://snapshots.elastic.co/downloads/kibana/kibana-${FILENAME_VERSION}.tar.gz
+
 # add our user and group first to make sure their IDs get assigned consistently
 RUN groupadd -r kibana && useradd -r -m -g kibana kibana
 
@@ -16,7 +20,7 @@ RUN arch="$(dpkg --print-architecture)" \
 	&& chmod +x /usr/local/bin/gosu
 
 RUN set -x \
-	&& curl -fSL "https://staging.elastic.co/5.0.0-beta1-5eb5cbdb/downloads/kibana/kibana-5.0.0-beta1-linux-x86_64.tar.gz" -o kibana.tar.gz \
+	&& curl -fSL "$URL?t=$(date +%F)" -o kibana.tar.gz \
 	&& mkdir -p /opt/kibana \
 	&& tar -xz --strip-components=1 -C /opt/kibana -f kibana.tar.gz \
 	&& chown -R kibana:kibana /opt/kibana \

--- a/testing/environments/docker/logstash/Dockerfile-snapshot
+++ b/testing/environments/docker/logstash/Dockerfile-snapshot
@@ -2,8 +2,8 @@ FROM java:8-jre
 
 ENV LS_VERSION 5
 
-ENV URL https://staging.elastic.co/5.0.0-beta1-5eb5cbdb/downloads/logstash/logstash-5.0.0-beta1.tar.gz
-ENV VERSION 5.0.0-beta1
+ENV VERSION 6.0.0-alpha1-SNAPSHOT
+ENV URL https://snapshots.elastic.co/downloads/logstash/logstash-${VERSION}.tar.gz
 ENV PATH $PATH:/opt/logstash-$VERSION/bin
 
 # As all snapshot builds have the same url, the image is cached. The date at then can be used to invalidate the image

--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -3,7 +3,7 @@
 elasticsearch:
   build: ./docker/elasticsearch
   dockerfile: Dockerfile-snapshot
-  command: elasticsearch -Enetwork.host=0.0.0.0 -Ediscovery.zen.minimum_master_nodes=1 -Ebootstrap.ignore_system_bootstrap_checks=true
+  command: elasticsearch -Ehttp.host=0.0.0.0
 
 logstash:
   build: ./docker/logstash


### PR DESCRIPTION
The current builds are broken because of LS beta1 link not working anymore.