### PR TITLE
Fix redis metricset dots issue with ES 2.x

### DIFF
--- a/metricbeat/docs/fields.asciidoc
+++ b/metricbeat/docs/fields.asciidoc
@@ -3632,6 +3632,12 @@ type: boolean
 None
 
 [float]
+== rdb Fields
+
+None
+
+
+[float]
 === redis.info.persistence.rdb.last_save.changes_since
 
 type: long
@@ -3672,6 +3678,12 @@ None
 type: long
 
 None
+
+[float]
+== aof Fields
+
+None
+
 
 [float]
 === redis.info.persistence.aof.enabled

--- a/metricbeat/etc/fields.yml
+++ b/metricbeat/etc/fields.yml
@@ -2257,57 +2257,65 @@
                   type: boolean
                   description:
 
-                - name: rdb.last_save.changes_since
-                  type: long
+                - name: rdb
+                  type: group
                   description:
+                  fields:
+                    - name: last_save.changes_since
+                      type: long
+                      description:
 
-                - name: rdb.bgsave.in_progress
-                  type: boolean
-                  description:
+                    - name: bgsave.in_progress
+                      type: boolean
+                      description:
 
-                - name: rdb.last_save.time
-                  type: long
-                  description:
+                    - name: last_save.time
+                      type: long
+                      description:
 
-                - name: rdb.bgsave.last_status
-                  type: keyword
-                  description:
+                    - name: bgsave.last_status
+                      type: keyword
+                      description:
 
-                - name: rdb.bgsave.last_time.sec
-                  type: long
-                  description:
+                    - name: bgsave.last_time.sec
+                      type: long
+                      description:
 
-                - name: rdb.bgsave.current_time.sec
-                  type: long
-                  description:
+                    - name: bgsave.current_time.sec
+                      type: long
+                      description:
 
-                - name: aof.enabled
-                  type: boolean
+                - name: aof
+                  type: group
                   description:
+                  fields:
+                    - name: enabled
+                      type: boolean
+                      description:
 
-                - name: aof.rewrite.in_progress
-                  type: boolean
-                  description:
+                    - name: rewrite.in_progress
+                      type: boolean
+                      description:
 
-                - name: aof.rewrite.scheduled
-                  type: boolean
-                  description:
+                    - name: rewrite.scheduled
+                      type: boolean
+                      description:
 
-                - name: aof.rewrite.last_time.sec
-                  type: long
-                  description:
+                    - name: rewrite.last_time.sec
+                      type: long
+                      description:
 
-                - name: aof.rewrite.current_time.sec
-                  type: long
-                  description:
+                    - name: rewrite.current_time.sec
+                      type: long
+                      description:
 
-                - name: aof.bgrewrite.last_status
-                  type: keyword
-                  description:
+                    - name: bgrewrite.last_status
+                      type: keyword
+                      description:
 
-                - name: aof.write.last_status
-                  type: keyword
-                  description:
+                    - name: write.last_status
+                      type: keyword
+                      description:
 
             - name: replication
               type: group

--- a/metricbeat/module/redis/info/_meta/data.json
+++ b/metricbeat/module/redis/info/_meta/data.json
@@ -23,43 +23,57 @@
             },
             "cpu": {
                 "used": {
-                    "sys": 49.19,
+                    "sys": 0.33,
                     "sys_children": 0,
-                    "user": 55.02,
-                    "user_children": 0.01
+                    "user": 0.39,
+                    "user_children": 0
                 }
             },
             "memory": {
                 "allocator": "jemalloc-4.0.3",
                 "used": {
                     "lua": 37888,
-                    "peak": 15216072,
-                    "rss": 7077888,
-                    "value": 4687616
+                    "peak": 883992,
+                    "rss": 4030464,
+                    "value": 883032
                 }
             },
             "persistence": {
                 "aof": {
-                    "bgrewrite.last_status": "ok",
+                    "bgrewrite": {
+                        "last_status": "ok"
+                    },
                     "enabled": false,
                     "rewrite": {
-                        "current_time.sec": -1,
+                        "current_time": {
+                            "sec": -1
+                        },
                         "in_progress": false,
-                        "last_time.sec": -1,
+                        "last_time": {
+                            "sec": -1
+                        },
                         "scheduled": false
                     },
-                    "write.last_status": "ok"
+                    "write": {
+                        "last_status": "ok"
+                    }
                 },
                 "loading": false,
                 "rdb": {
                     "bgsave": {
-                        "current_time.sec": -1,
+                        "current_time": {
+                            "sec": -1
+                        },
                         "in_progress": false,
                         "last_status": "ok",
-                        "last_time.sec": -1
+                        "last_time": {
+                            "sec": -1
+                        }
                     },
-                    "last_save.changes_since": 200224,
-                    "last_save.time": 1472827193
+                    "last_save": {
+                        "changes_since": 2,
+                        "time": 1475698251
+                    }
                 }
             },
             "replication": {
@@ -75,51 +89,61 @@
             },
             "server": {
                 "arch_bits": "64",
-                "build_id": "f449541256e7d446",
+                "build_id": "5575d747b4b3b12c",
                 "config_file": "",
                 "gcc_version": "4.9.2",
                 "git_dirty": "0",
                 "git_sha1": "00000000",
                 "hz": 10,
-                "lru_clock": 13529407,
+                "lru_clock": 16080842,
                 "mode": "standalone",
                 "multiplexing_api": "epoll",
-                "os": "Linux 4.4.19-moby x86_64",
+                "os": "Linux 4.4.22-moby x86_64",
                 "process_id": 1,
-                "run_id": "12aa47bb284cef56c793646b291167131a999ebe",
+                "run_id": "d37e5ebfe0ae6c4972dbe9f0174a1637bb8247f6",
                 "tcp_port": 6379,
-                "uptime": 320006,
-                "version": "3.2.0"
+                "uptime": 383,
+                "version": "3.2.4"
             },
             "stats": {
-                "commands_processed": 200540,
+                "commands_processed": 70,
                 "connections": {
-                    "received": 87,
+                    "received": 17,
                     "rejected": 0
                 },
                 "instantaneous": {
-                    "input_kbps": 0,
-                    "ops_per_sec": 0,
-                    "output_kbps": 0
+                    "input_kbps": 0.07,
+                    "ops_per_sec": 2,
+                    "output_kbps": 0.07
                 },
                 "keys": {
                     "evicted": 0,
-                    "expired": 3
+                    "expired": 0
                 },
                 "keyspace": {
-                    "hits": 33,
+                    "hits": 0,
                     "misses": 0
                 },
                 "latest_fork_usec": 0,
                 "migrate_cached_sockets": 0,
-                "net.input.bytes": 17576095,
-                "net.output.bytes": 1915928,
-                "pubsub.channels": 0,
-                "pubsub.patterns": 0,
+                "net": {
+                    "input": {
+                        "bytes": 1949
+                    },
+                    "output": {
+                        "bytes": 4956554
+                    }
+                },
+                "pubsub": {
+                    "channels": 0,
+                    "patterns": 0
+                },
                 "sync": {
                     "full": 0,
-                    "partial.err": 0,
-                    "partial.ok": 0
+                    "partial": {
+                        "err": 0,
+                        "ok": 0
+                    }
                 }
             }
         }

--- a/metricbeat/module/redis/info/_meta/fields.yml
+++ b/metricbeat/module/redis/info/_meta/fields.yml
@@ -102,57 +102,65 @@
           type: boolean
           description:
 
-        - name: rdb.last_save.changes_since
-          type: long
+        - name: rdb
+          type: group
           description:
+          fields:
+            - name: last_save.changes_since
+              type: long
+              description:
 
-        - name: rdb.bgsave.in_progress
-          type: boolean
-          description:
+            - name: bgsave.in_progress
+              type: boolean
+              description:
 
-        - name: rdb.last_save.time
-          type: long
-          description:
+            - name: last_save.time
+              type: long
+              description:
 
-        - name: rdb.bgsave.last_status
-          type: keyword
-          description:
+            - name: bgsave.last_status
+              type: keyword
+              description:
 
-        - name: rdb.bgsave.last_time.sec
-          type: long
-          description:
+            - name: bgsave.last_time.sec
+              type: long
+              description:
 
-        - name: rdb.bgsave.current_time.sec
-          type: long
-          description:
+            - name: bgsave.current_time.sec
+              type: long
+              description:
 
-        - name: aof.enabled
-          type: boolean
+        - name: aof
+          type: group
           description:
+          fields:
+            - name: enabled
+              type: boolean
+              description:
 
-        - name: aof.rewrite.in_progress
-          type: boolean
-          description:
+            - name: rewrite.in_progress
+              type: boolean
+              description:
 
-        - name: aof.rewrite.scheduled
-          type: boolean
-          description:
+            - name: rewrite.scheduled
+              type: boolean
+              description:
 
-        - name: aof.rewrite.last_time.sec
-          type: long
-          description:
+            - name: rewrite.last_time.sec
+              type: long
+              description:
 
-        - name: aof.rewrite.current_time.sec
-          type: long
-          description:
+            - name: rewrite.current_time.sec
+              type: long
+              description:
 
-        - name: aof.bgrewrite.last_status
-          type: keyword
-          description:
+            - name: bgrewrite.last_status
+              type: keyword
+              description:
 
-        - name: aof.write.last_status
-          type: keyword
-          description:
+            - name: write.last_status
+              type: keyword
+              description:
 
     - name: replication
       type: group

--- a/metricbeat/module/redis/info/data.go
+++ b/metricbeat/module/redis/info/data.go
@@ -37,25 +37,39 @@ var (
 		"persistence": s.Object{
 			"loading": c.Bool("loading"),
 			"rdb": s.Object{
-				"last_save.changes_since": c.Int("rdb_changes_since_last_save"),
-				"last_save.time":          c.Int("rdb_last_save_time"),
+				"last_save": s.Object{
+					"changes_since": c.Int("rdb_changes_since_last_save"),
+					"time":          c.Int("rdb_last_save_time"),
+				},
 				"bgsave": s.Object{
-					"last_status":      c.Str("rdb_last_bgsave_status"),
-					"in_progress":      c.Bool("rdb_bgsave_in_progress"),
-					"last_time.sec":    c.Int("rdb_last_bgsave_time_sec"),
-					"current_time.sec": c.Int("rdb_current_bgsave_time_sec"),
+					"last_status": c.Str("rdb_last_bgsave_status"),
+					"in_progress": c.Bool("rdb_bgsave_in_progress"),
+					"last_time": s.Object{
+						"sec": c.Int("rdb_last_bgsave_time_sec"),
+					},
+					"current_time": s.Object{
+						"sec": c.Int("rdb_current_bgsave_time_sec"),
+					},
 				},
 			},
 			"aof": s.Object{
 				"enabled": c.Bool("aof_enabled"),
 				"rewrite": s.Object{
-					"in_progress":      c.Bool("aof_rewrite_in_progress"),
-					"scheduled":        c.Bool("aof_rewrite_scheduled"),
-					"last_time.sec":    c.Int("aof_last_rewrite_time_sec"),
-					"current_time.sec": c.Int("aof_current_rewrite_time_sec"),
+					"in_progress": c.Bool("aof_rewrite_in_progress"),
+					"scheduled":   c.Bool("aof_rewrite_scheduled"),
+					"last_time": s.Object{
+						"sec": c.Int("aof_last_rewrite_time_sec"),
+					},
+					"current_time": s.Object{
+						"sec": c.Int("aof_current_rewrite_time_sec"),
+					},
 				},
-				"bgrewrite.last_status": c.Str("aof_last_bgrewrite_status"),
-				"write.last_status":     c.Str("aof_last_write_status"),
+				"bgrewrite": s.Object{
+					"last_status": c.Str("aof_last_bgrewrite_status"),
+				},
+				"write": s.Object{
+					"last_status": c.Str("aof_last_write_status"),
+				},
 			},
 		},
 		"replication": s.Object{
@@ -93,17 +107,25 @@ var (
 				"rejected": c.Int("rejected_connections"),
 			},
 			"commands_processed": c.Int("total_commands_processed"),
-			"net.input.bytes":    c.Int("total_net_input_bytes"),
-			"net.output.bytes":   c.Int("total_net_output_bytes"),
+			"net": s.Object{
+				"input": s.Object{
+					"bytes": c.Int("total_net_input_bytes"),
+				},
+				"output": s.Object{
+					"bytes": c.Int("total_net_output_bytes"),
+				},
+			},
 			"instantaneous": s.Object{
 				"ops_per_sec": c.Int("instantaneous_ops_per_sec"),
 				"input_kbps":  c.Float("instantaneous_input_kbps"),
 				"output_kbps": c.Float("instantaneous_output_kbps"),
 			},
 			"sync": s.Object{
-				"full":        c.Int("sync_full"),
-				"partial.ok":  c.Int("sync_partial_ok"),
-				"partial.err": c.Int("sync_partial_err"),
+				"full": c.Int("sync_full"),
+				"partial": s.Object{
+					"ok":  c.Int("sync_partial_ok"),
+					"err": c.Int("sync_partial_err"),
+				},
 			},
 			"keys": s.Object{
 				"expired": c.Int("expired_keys"),
@@ -113,8 +135,10 @@ var (
 				"hits":   c.Int("keyspace_hits"),
 				"misses": c.Int("keyspace_misses"),
 			},
-			"pubsub.channels":        c.Int("pubsub_channels"),
-			"pubsub.patterns":        c.Int("pubsub_patterns"),
+			"pubsub": s.Object{
+				"channels": c.Int("pubsub_channels"),
+				"patterns": c.Int("pubsub_patterns"),
+			},
 			"latest_fork_usec":       c.Int("latest_fork_usec"),
 			"migrate_cached_sockets": c.Int("migrate_cached_sockets"),
 		},

--- a/metricbeat/module/redis/keyspace/_meta/data.json
+++ b/metricbeat/module/redis/keyspace/_meta/data.json
@@ -15,7 +15,7 @@
             "avg_ttl": 0,
             "expires": 0,
             "id": "db0",
-            "keys": 3
+            "keys": 1
         }
     },
     "type": "metricsets"


### PR DESCRIPTION
Not all 2.x elasticsearch releases support dots on field names. In the redis metricsets some dots instead of json objects were used as the outcome in elasticsearch 5.x is the same. All dots were removed and nested objects were created to make it compatible with elasticsearch 2.x.

Closes https://github.com/elastic/beats/issues/2694