### PR TITLE
Backport: Set strings to be keywords by default (#2688)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -14,6 +14,8 @@ https://github.com/elastic/beats/compare/v5.0.0-beta1...master[Check the HEAD di
 
 *Affecting all Beats*
 
+- A dynamic mapping rule is added to the default Elasticsearch template to treat strings as keywords by default. {pull}2688[2688]
+
 *Metricbeat*
 
 *Packetbeat*

--- a/filebeat/filebeat.template-es2x.json
+++ b/filebeat/filebeat.template-es2x.json
@@ -11,14 +11,13 @@
       },
       "dynamic_templates": [
         {
-          "fields": {
+          "strings_as_keyword": {
             "mapping": {
               "ignore_above": 1024,
               "index": "not_analyzed",
               "type": "string"
             },
-            "match_mapping_type": "string",
-            "path_match": "fields.*"
+            "match_mapping_type": "string"
           }
         }
       ],

--- a/filebeat/filebeat.template.json
+++ b/filebeat/filebeat.template.json
@@ -9,13 +9,12 @@
       },
       "dynamic_templates": [
         {
-          "fields": {
+          "strings_as_keyword": {
             "mapping": {
               "ignore_above": 1024,
               "type": "keyword"
             },
-            "match_mapping_type": "string",
-            "path_match": "fields.*"
+            "match_mapping_type": "string"
           }
         }
       ],

--- a/metricbeat/metricbeat.template-es2x.json
+++ b/metricbeat/metricbeat.template-es2x.json
@@ -11,14 +11,13 @@
       },
       "dynamic_templates": [
         {
-          "fields": {
+          "strings_as_keyword": {
             "mapping": {
               "ignore_above": 1024,
               "index": "not_analyzed",
               "type": "string"
             },
-            "match_mapping_type": "string",
-            "path_match": "fields.*"
+            "match_mapping_type": "string"
           }
         }
       ],

--- a/metricbeat/metricbeat.template.json
+++ b/metricbeat/metricbeat.template.json
@@ -9,13 +9,12 @@
       },
       "dynamic_templates": [
         {
-          "fields": {
+          "strings_as_keyword": {
             "mapping": {
               "ignore_above": 1024,
               "type": "keyword"
             },
-            "match_mapping_type": "string",
-            "path_match": "fields.*"
+            "match_mapping_type": "string"
           }
         }
       ],

--- a/packetbeat/packetbeat.template-es2x.json
+++ b/packetbeat/packetbeat.template-es2x.json
@@ -11,58 +11,13 @@
       },
       "dynamic_templates": [
         {
-          "fields": {
+          "strings_as_keyword": {
             "mapping": {
               "ignore_above": 1024,
               "index": "not_analyzed",
               "type": "string"
             },
-            "match_mapping_type": "string",
-            "path_match": "fields.*"
-          }
-        },
-        {
-          "amqp.headers": {
-            "mapping": {
-              "ignore_above": 1024,
-              "index": "not_analyzed",
-              "type": "string"
-            },
-            "match_mapping_type": "string",
-            "path_match": "amqp.headers.*"
-          }
-        },
-        {
-          "cassandra.response.supported": {
-            "mapping": {
-              "ignore_above": 1024,
-              "index": "not_analyzed",
-              "type": "string"
-            },
-            "match_mapping_type": "string",
-            "path_match": "cassandra.response.supported.*"
-          }
-        },
-        {
-          "http.request.headers": {
-            "mapping": {
-              "ignore_above": 1024,
-              "index": "not_analyzed",
-              "type": "string"
-            },
-            "match_mapping_type": "string",
-            "path_match": "http.request.headers.*"
-          }
-        },
-        {
-          "http.response.headers": {
-            "mapping": {
-              "ignore_above": 1024,
-              "index": "not_analyzed",
-              "type": "string"
-            },
-            "match_mapping_type": "string",
-            "path_match": "http.response.headers.*"
+            "match_mapping_type": "string"
           }
         }
       ],

--- a/packetbeat/packetbeat.template.json
+++ b/packetbeat/packetbeat.template.json
@@ -9,53 +9,12 @@
       },
       "dynamic_templates": [
         {
-          "fields": {
+          "strings_as_keyword": {
             "mapping": {
               "ignore_above": 1024,
               "type": "keyword"
             },
-            "match_mapping_type": "string",
-            "path_match": "fields.*"
-          }
-        },
-        {
-          "amqp.headers": {
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "match_mapping_type": "string",
-            "path_match": "amqp.headers.*"
-          }
-        },
-        {
-          "cassandra.response.supported": {
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "match_mapping_type": "string",
-            "path_match": "cassandra.response.supported.*"
-          }
-        },
-        {
-          "http.request.headers": {
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "match_mapping_type": "string",
-            "path_match": "http.request.headers.*"
-          }
-        },
-        {
-          "http.response.headers": {
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "match_mapping_type": "string",
-            "path_match": "http.response.headers.*"
+            "match_mapping_type": "string"
           }
         }
       ],

--- a/winlogbeat/winlogbeat.template-es2x.json
+++ b/winlogbeat/winlogbeat.template-es2x.json
@@ -11,36 +11,13 @@
       },
       "dynamic_templates": [
         {
-          "fields": {
+          "strings_as_keyword": {
             "mapping": {
               "ignore_above": 1024,
               "index": "not_analyzed",
               "type": "string"
             },
-            "match_mapping_type": "string",
-            "path_match": "fields.*"
-          }
-        },
-        {
-          "event_data": {
-            "mapping": {
-              "ignore_above": 1024,
-              "index": "not_analyzed",
-              "type": "string"
-            },
-            "match_mapping_type": "string",
-            "path_match": "event_data.*"
-          }
-        },
-        {
-          "user_data": {
-            "mapping": {
-              "ignore_above": 1024,
-              "index": "not_analyzed",
-              "type": "string"
-            },
-            "match_mapping_type": "string",
-            "path_match": "user_data.*"
+            "match_mapping_type": "string"
           }
         }
       ],

--- a/winlogbeat/winlogbeat.template.json
+++ b/winlogbeat/winlogbeat.template.json
@@ -9,33 +9,12 @@
       },
       "dynamic_templates": [
         {
-          "fields": {
+          "strings_as_keyword": {
             "mapping": {
               "ignore_above": 1024,
               "type": "keyword"
             },
-            "match_mapping_type": "string",
-            "path_match": "fields.*"
-          }
-        },
-        {
-          "event_data": {
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "match_mapping_type": "string",
-            "path_match": "event_data.*"
-          }
-        },
-        {
-          "user_data": {
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "match_mapping_type": "string",
-            "path_match": "user_data.*"
+            "match_mapping_type": "string"
           }
         }
       ],


### PR DESCRIPTION
Backport of #2688. Original message:


This adds a dynamic mapping to all our template files to set strings to be
keywords by default.

Previously we were using the default of `text` and only switching to `keyword`
when configured in `fields.yml`. This reverses the logic and sets mappings to
`text` only when requested in `fields.yml`.

The goal is to make upgrading the mapping template less painful. In the Beats
we have so far, unexpected fields are better of as keywords.