### PR TITLE
Introduce docker cache invalidation through build-args

### DIFF
--- a/testing/environments/docker/elasticsearch/Dockerfile-snapshot
+++ b/testing/environments/docker/elasticsearch/Dockerfile-snapshot
@@ -6,6 +6,9 @@ ENV VERSION 6.0.0-alpha1
 ENV FILENAME_VERSION 6.0.0-alpha1-SNAPSHOT
 ENV URL https://snapshots.elastic.co/downloads/elasticsearch/elasticsearch-${FILENAME_VERSION}.tar.gz
 
+# Cache variable can be set during building to invalidate the build cache with `--build-arg CACHE=$(date +%s) .`
+ARG CACHE=1
+
 ENV ESHOME /opt/elasticsearch-${FILENAME_VERSION}
 
 # grab gosu for easy step-down from root
@@ -22,7 +25,7 @@ RUN groupadd -r elasticsearch && useradd -r -m -g elasticsearch elasticsearch
 
 RUN set -x && \
 	cd /opt && \
-	wget -qO elasticsearch.tar.gz "$URL?t=$(date +%F)" && \
+	wget -qO elasticsearch.tar.gz "$URL?${CACHE}" && \
 	tar xzvf elasticsearch.tar.gz && \
 	chown -R elasticsearch:elasticsearch ${ESHOME}
 

--- a/testing/environments/docker/kibana/Dockerfile-snapshot
+++ b/testing/environments/docker/kibana/Dockerfile-snapshot
@@ -4,6 +4,9 @@ ENV VERSION 6.0.0-alpha1
 ENV FILENAME_VERSION 6.0.0-alpha1-SNAPSHOT-linux-x86_64
 ENV URL https://snapshots.elastic.co/downloads/kibana/kibana-${FILENAME_VERSION}.tar.gz
 
+# Cache variable can be set during building to invalidate the build cache with `--build-arg CACHE=$(date +%s) .`
+ARG CACHE=1
+
 # add our user and group first to make sure their IDs get assigned consistently
 RUN groupadd -r kibana && useradd -r -m -g kibana kibana
 
@@ -20,7 +23,7 @@ RUN arch="$(dpkg --print-architecture)" \
 	&& chmod +x /usr/local/bin/gosu
 
 RUN set -x \
-	&& curl -fSL "$URL?t=$(date +%F)" -o kibana.tar.gz \
+	&& curl -fSL "$URL?${CACHE}" -o kibana.tar.gz \
 	&& mkdir -p /opt/kibana \
 	&& tar -xz --strip-components=1 -C /opt/kibana -f kibana.tar.gz \
 	&& chown -R kibana:kibana /opt/kibana \

--- a/testing/environments/docker/logstash/Dockerfile-snapshot
+++ b/testing/environments/docker/logstash/Dockerfile-snapshot
@@ -6,11 +6,14 @@ ENV VERSION 6.0.0-alpha1-SNAPSHOT
 ENV URL https://snapshots.elastic.co/downloads/logstash/logstash-${VERSION}.tar.gz
 ENV PATH $PATH:/opt/logstash-$VERSION/bin
 
+# Cache variable can be set during building to invalidate the build cache with `--build-arg CACHE=$(date +%s) .`
+ARG CACHE=1
+
 # As all snapshot builds have the same url, the image is cached. The date at then can be used to invalidate the image
 RUN set -x && \
     cd /opt && \
-    wget -q $URL && \
-    tar xzf logstash-$VERSION.tar.gz
+    wget -qO logstash.tar.gz $URL?${CACHE} && \
+    tar xzf logstash.tar.gz
 
 
 COPY logstash.conf.2.tmpl /logstash.conf.2.tmpl

--- a/testing/environments/docker/metricbeat/Dockerfile-5.0.0-cgroups
+++ b/testing/environments/docker/metricbeat/Dockerfile-5.0.0-cgroups
@@ -3,7 +3,10 @@ MAINTAINER Monica Sarbu <monica@elastic.co>
 
 ENV METRICBEAT_FILE=metricbeat-6.0.0-alpha1-SNAPSHOT-linux-x86_64
 
-ADD https://beats-nightlies.s3.amazonaws.com/metricbeat/$METRICBEAT_FILE.tar.gz /$METRICBEAT_FILE.tar.gz
+# Cache variable can be set during building to invalidate the build cache with `--build-arg CACHE=$(date +%s) .`
+ARG CACHE=1
+
+ADD https://beats-nightlies.s3.amazonaws.com/metricbeat/$METRICBEAT_FILE.tar.gz?${CACHE} /$METRICBEAT_FILE.tar.gz
 
 RUN tar -xzvf $METRICBEAT_FILE.tar.gz && \
     ln -s $METRICBEAT_FILE metricbeat


### PR DESCRIPTION
To invalide the cache for the images, use --build-arg CACHE=...

The idea is to implement this invalidation directly in the docker-compose.yml, but this requires `version: 2` of the files. This will be done at a later stage. Current behaviour is as before. For invalidation cache variable can be incremented or --no-cache can be used.