### PR TITLE
fix a potential bug : massive cpu metrics for docker module

### DIFF
--- a/metricbeat/module/docker/cpu/helper.go
+++ b/metricbeat/module/docker/cpu/helper.go
@@ -83,24 +83,24 @@ func (c *CPUService) PerCpuUsage(stats *dc.Stats) common.MapStr {
 	if cap(getNewCpu(stats).PerCpuUsage) == cap(getOLdCpu(stats).PerCpuUsage) {
 		output = common.MapStr{}
 		for index := range getNewCpu(stats).PerCpuUsage {
-			output[strconv.Itoa(index)] = c.calculateLoad(getNewCpu(stats).PerCpuUsage[index] - getOLdCpu(stats).PerCpuUsage[index])
+			output[strconv.Itoa(index)] = c.calculateLoad(int64(getNewCpu(stats).PerCpuUsage[index] - getOLdCpu(stats).PerCpuUsage[index]))
 		}
 	}
 	return output
 }
 
 func (c *CPUService) TotalUsage(stats *dc.Stats) float64 {
-	return c.calculateLoad(getNewCpu(stats).TotalUsage - getOLdCpu(stats).TotalUsage)
+	return c.calculateLoad(int64(getNewCpu(stats).TotalUsage - getOLdCpu(stats).TotalUsage))
 }
 
 func (c *CPUService) UsageInKernelmode(stats *dc.Stats) float64 {
-	return c.calculateLoad(getNewCpu(stats).UsageInKernelmode - getOLdCpu(stats).UsageInKernelmode)
+	return c.calculateLoad(int64(getNewCpu(stats).UsageInKernelmode - getOLdCpu(stats).UsageInKernelmode))
 }
 
 func (c *CPUService) UsageInUsermode(stats *dc.Stats) float64 {
-	return c.calculateLoad(getNewCpu(stats).UsageInUsermode - getOLdCpu(stats).UsageInUsermode)
+	return c.calculateLoad(int64(getNewCpu(stats).UsageInUsermode - getOLdCpu(stats).UsageInUsermode))
 }
 
-func (c *CPUService) calculateLoad(value uint64) float64 {
+func (c *CPUService) calculateLoad(value int64) float64 {
 	return float64(value) / float64(1000000000)
 }


### PR DESCRIPTION
 Negative values caused by the use of unsigned integers were transformed in huge positives value