### PR TITLE
Remove alpha and beta-specific notes

### DIFF
--- a/libbeat/docs/dashboards.asciidoc
+++ b/libbeat/docs/dashboards.asciidoc
@@ -14,17 +14,6 @@
 [[load-kibana-dashboards]]
 ==== Importing the Dashboards
 
-[NOTE]
-.Known Doc Issue in 5.0.0-alpha5
-====
-The instructions in this section describe how to use a script that's not available in the {beatname_uc} 5.0.0-alpha5
-download package. If you are importing dashboards for 5.0.0-alpha5, you need to run one of the
-import scripts in the `kibana` directory: `import_dashboards.sh` or `import_dashboards.ps1`.
-Use the `-help` command to see the list of options for running the script. For example: 
-`./import_dashboards.sh -help`.
-
-====
-
 {beatname_uc} comes packaged with the `scripts/import_dashboards` script that you can use to import the example dashboards,
 visualizations, and searches for {beatname_uc}. The script also creates an index pattern,
 +{beatname_lc}-*+, for {beatname_uc}. 

--- a/libbeat/docs/newdashboards.asciidoc
+++ b/libbeat/docs/newdashboards.asciidoc
@@ -1,7 +1,7 @@
 [[new-dashboards]]
 == Developer Guide: Creating New Kibana Dashboards for a Beat
 
-NOTE: Starting with 5.0.0-beta1, the Kibana dashboards are not released as part of the Beat package. They are released in a separate
+NOTE: Starting with Beats 5.0.0, the Kibana dashboards are not released as part of the Beat package. They are released in a separate
 package called `beats-dashboards`.
 
 When contributing to Beats development, you may want to add new dashboards or modify existing ones. To make this easier,


### PR DESCRIPTION
As we move towards the release candidate, special alpha and beta-specific notes no longer make sense. At this point, we should only provide notes that are relevant to the GA release.