### PR TITLE
Add a note to refresh the index pattern before visualizing the data

### DIFF
--- a/libbeat/docs/faq-refresh-index.asciidoc
+++ b/libbeat/docs/faq-refresh-index.asciidoc
@@ -1,0 +1,23 @@
+[float]
+[[refresh-index-pattern]]
+=== Fields show up as nested JSON in Kibana
+
+In case the Beat exports a field of type dictionary, and the keys are not known in advance, the Discovery page from Kibana will display it as a nested JSON object:
+
+[source,shell]
+----------------------------------------------------------------------
+http.response.headers = {
+        "content-length": 12,
+        "content-type": "application/json"
+}
+----------------------------------------------------------------------
+To fix this you need to https://www.elastic.co/guide/en/kibana/5.0/settings.html#reload-fields[reload the index pattern] in Kibana under the Management->Index Patterns, and the index-pattern will be
+updated with a field for each key available in the dictionary:
+
+[source,shell]
+----------------------------------------------------------------------
+http.response.headers.content-length = 12
+http.response.headers.content-type = "application/json"
+----------------------------------------------------------------------
+
+

--- a/packetbeat/docs/faq.asciidoc
+++ b/packetbeat/docs/faq.asciidoc
@@ -72,3 +72,4 @@ response messages are not sent.
 
 include::../../libbeat/docs/faq-limit-bandwidth.asciidoc[]
 include::../../libbeat/docs/shared-faq.asciidoc[]
+include::../../libbeat/docs/faq-refresh-index.asciidoc[]


### PR DESCRIPTION
Packetbeat uses a few fields in the event of type `dict`. The problem appears as the Beat doesn't always know the keys that a dictionary field might contain, so it's not able to define them in advance.

Let's consider as an example `http.request.headers`, that has the type `dict`. After importing the index-pattern in Kibana, the Discovery page in Kibana looks like:

![screen shot 2016-10-06 at 10 08 32 pm](https://cloud.githubusercontent.com/assets/11757159/19192443/8eba69d2-8ca6-11e6-80eb-6995bac8f17b.png)

After you refresh the `packetbeat-*` index pattern, then all the keys are updated and the Discovery page looks like:

![screen shot 2016-10-07 at 3 58 06 pm](https://cloud.githubusercontent.com/assets/11757159/19192543/dd074e66-8ca6-11e6-8aea-03a9b8cb82c4.png)

where a field is created in the `packetbeat-*` index pattern for each key available in the dictionary.

cc-ed @dedemorton 
