### PR TITLE
Do not remove folders and gitignore

### DIFF
--- a/dev-tools/cherrypick_pr
+++ b/dev-tools/cherrypick_pr
@@ -56,7 +56,7 @@ def main():
                                       "Continue? [y/n]: ") != "y":
             return 1
         check_call("git reset --hard", shell=True)
-        check_call("git clean -dfx", shell=True)
+        check_call("git clean -df", shell=True)
         check_call("git fetch", shell=True)
 
         check_call("git checkout {}".format(args.from_branch), shell=True)


### PR DESCRIPTION
The cherrypick script removed on every run all directories which were not under git including the ones which were under .gitignore. To prevent the removal of .idea folder or dev config files like `metricbeat.dev.yml` now only files which do not fall under .gitignore are cleaned by removing the -x param