### PR TITLE
Kafka output drop invalid messages

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -29,6 +29,8 @@ https://github.com/elastic/beats/compare/v5.0.0-rc1...master[Check the HEAD diff
 
 *Affecting all Beats*
 
+- Fix kafka output re-trying batches with too large events. {issue}2735[2735]
+
 *Metricbeat*
 
 *Packetbeat*

--- a/libbeat/outputs/kafka/message.go
+++ b/libbeat/outputs/kafka/message.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/Shopify/sarama"
-	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/outputs"
 )
 
@@ -20,7 +19,7 @@ type message struct {
 	hash      uint32
 	partition int32
 
-	event common.MapStr
+	data outputs.Data
 }
 
 var kafkaMessageKey interface{} = int(0)

--- a/libbeat/outputs/kafka/partition.go
+++ b/libbeat/outputs/kafka/partition.go
@@ -223,7 +223,7 @@ func makeFieldsHashPartitioner(fields []string, dropFail bool) partitioner {
 
 			var err error
 			for _, field := range fields {
-				err = hashFieldValue(hasher, msg.event, field)
+				err = hashFieldValue(hasher, msg.data.Event, field)
 				if err != nil {
 					break
 				}

--- a/libbeat/outputs/kafka/partition_test.go
+++ b/libbeat/outputs/kafka/partition_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Shopify/sarama"
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/outputs"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -219,7 +220,7 @@ func partTestSimple(N int, makeKey bool) partTestScenario {
 			}
 
 			msg := &message{partition: -1}
-			msg.event = event
+			msg.data = outputs.Data{event, nil}
 			msg.topic = "test"
 			if makeKey {
 				msg.key = randASCIIBytes(10)
@@ -272,7 +273,7 @@ func partTestHashInvariant(N int) partTestScenario {
 			}
 
 			msg := &message{partition: -1}
-			msg.event = event
+			msg.data = outputs.Data{event, nil}
 			msg.topic = "test"
 			msg.key = randASCIIBytes(10)
 			msg.value = jsonEvent


### PR DESCRIPTION
- Fix too big messages not being dropped, but forcing continuous resends
- If publishing subset of batches fails, only attempt to resend failed events instead of complete batch