### PR TITLE
Point to the upgrade docs from the docs for each beat

### DIFF
--- a/filebeat/docs/index.asciidoc
+++ b/filebeat/docs/index.asciidoc
@@ -22,6 +22,8 @@ include::./command-line.asciidoc[]
 
 include::../../libbeat/docs/shared-directory-layout.asciidoc[]
 
+include::./upgrading.asciidoc[]
+
 include::./how-filebeat-works.asciidoc[]
 
 include::./configuring-howto.asciidoc[]

--- a/filebeat/docs/upgrading.asciidoc
+++ b/filebeat/docs/upgrading.asciidoc
@@ -1,0 +1,7 @@
+[[upgrading-filebeat]]
+== Upgrading Filebeat
+
+For information about upgrading to a new version, see the following topics in the _Beats Platform Reference_:
+
+* {libbeat}/breaking-changes.html[Breaking Changes]
+* {libbeat}/upgrading.html[Upgrading]

--- a/metricbeat/docs/index.asciidoc
+++ b/metricbeat/docs/index.asciidoc
@@ -19,6 +19,8 @@ include::./command-line.asciidoc[]
 
 include::../../libbeat/docs/shared-directory-layout.asciidoc[]
 
+include::./upgrading.asciidoc[]
+
 include::./how-metricbeat-works.asciidoc[]
 
 include::./metricbeat-in-a-container.asciidoc[]

--- a/metricbeat/docs/upgrading.asciidoc
+++ b/metricbeat/docs/upgrading.asciidoc
@@ -1,0 +1,7 @@
+[[upgrading-metricbeat]]
+== Upgrading Metricbeat
+
+For information about upgrading to a new version, see the following topics in the _Beats Platform Reference_:
+
+* {libbeat}/breaking-changes.html[Breaking Changes]
+* {libbeat}/upgrading.html[Upgrading]

--- a/packetbeat/docs/index.asciidoc
+++ b/packetbeat/docs/index.asciidoc
@@ -22,6 +22,8 @@ include::./command-line.asciidoc[]
 
 include::../../libbeat/docs/shared-directory-layout.asciidoc[]
 
+include::./upgrading.asciidoc[]
+
 include::./configuring-howto.asciidoc[]
 
 include::./packetbeat-filtering.asciidoc[]

--- a/packetbeat/docs/upgrading.asciidoc
+++ b/packetbeat/docs/upgrading.asciidoc
@@ -1,0 +1,7 @@
+[[upgrading-packetbeat]]
+== Upgrading Packetbeat
+
+For information about upgrading to a new version, see the following topics in the _Beats Platform Reference_:
+
+* {libbeat}/breaking-changes.html[Breaking Changes]
+* {libbeat}/upgrading.html[Upgrading]

--- a/winlogbeat/docs/index.asciidoc
+++ b/winlogbeat/docs/index.asciidoc
@@ -22,6 +22,8 @@ include::./command-line.asciidoc[]
 
 include::../../libbeat/docs/shared-directory-layout.asciidoc[]
 
+include::./upgrading.asciidoc[]
+
 include::./configuring-howto.asciidoc[]
 
 include::./winlogbeat-filtering.asciidoc[]

--- a/winlogbeat/docs/upgrading.asciidoc
+++ b/winlogbeat/docs/upgrading.asciidoc
@@ -1,0 +1,7 @@
+[[upgrading-winlogbeat]]
+== Upgrading Winlogbeat
+
+For information about upgrading to a new version, see the following topics in the _Beats Platform Reference_:
+
+* {libbeat}/breaking-changes.html[Breaking Changes]
+* {libbeat}/upgrading.html[Upgrading]


### PR DESCRIPTION
I'm concerned that existing Beats users will not notice the upgrade instructions in the Platform Reference, so I've added short topics to the doc for each Beat to point to the Platform Reference. I thought about just adding links to the Getting Started, but wanted to raise visibility of the upgrade content by making the topic a main entry in the nav.

I didn't bother single sourcing the content because duplication seemed OK given that there's so little content here.