### PR TITLE
Fix packaging issue with old git version on debian 6

### DIFF
--- a/dev-tools/packer/xgo-scripts/before_build.sh
+++ b/dev-tools/packer/xgo-scripts/before_build.sh
@@ -42,11 +42,16 @@ if [ -n "BUILDID" ]; then
     echo "$BUILDID" > $PREFIX/homedir/.build_hash.txt
 fi
 
-# Generate and copy README.md into homedir
-go get -u github.com/tsg/gotpl
+# Install gotpl. Clone and copy needed as go-yaml is behind a proxy which doesn't work
+# with git 1.7
+git clone https://github.com/tsg/gotpl.git /go/src/github.com/tsg/gotpl
+mkdir -p /go/src/gopkg.in/yaml.v2
+cp -r /go/src/github.com/elastic/beats/vendor/gopkg.in/yaml.v2 /go/src/gopkg.in/
+go install github.com/tsg/gotpl
+
 # Append doc versions to package.yml
 cat ${LIBBEAT_PATH}/docs/version.asciidoc >> ${PREFIX}/package.yml
-# Make varialbe naming of doc-branch compatible with gotpl
+# Make variable naming of doc-branch compatible with gotpl. Generate and copy README.md into homedir
 sed -i -e 's/:doc-branch/doc_branch/g' ${PREFIX}/package.yml
 /go/bin/gotpl ${LIBBEAT_PATH}/../dev-tools/packer/readme.md.j2 < ${PREFIX}/package.yml > ${PREFIX}/homedir/README.md
 


### PR DESCRIPTION
Git 1.7 on debian cannot handle packages which are behind a proxy. As go-yaml is fetched through a proxy this will make the build hang. As a work around gotpl is cloned manually and go-yaml is copied from the already vendored directory.