### PR TITLE
Count only the first filesystem with the same mounting point

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -39,6 +39,7 @@ https://github.com/elastic/beats/compare/v5.0.0-rc1...master[Check the HEAD diff
 - Fix high value of `system.memory.actual.free` and `system.memory.actual.used`. {issue}2653[2653]
 - Change several `OpenProcess` calls on Windows to request the lowest possible access provilege.  {issue}1897[1897]
 - Fix system.memory.actual.free high value on Windows. {issue}2653[2653]
+- Calculate the fsstat values per mounting point, and not filesystem. {pull}2777[2777]
 
 *Packetbeat*
 

--- a/metricbeat/docs/fields.asciidoc
+++ b/metricbeat/docs/fields.asciidoc
@@ -4522,7 +4522,7 @@ The percentage of used disk space.
 [float]
 == fsstat Fields
 
-`system.fsstat` contains filesystem metrics aggregated from all mounted filesystems.
+`system.fsstat` contains filesystem metrics aggregated from all mounted filesystems, similar with what `df -a` prints out.
 
 
 

--- a/metricbeat/etc/fields.yml
+++ b/metricbeat/etc/fields.yml
@@ -2778,7 +2778,7 @@
           type: group
           description: >
             `system.fsstat` contains filesystem metrics aggregated from all mounted
-            filesystems.
+            filesystems, similar with what `df -a` prints out.
           fields:
             - name: count
               type: long

--- a/metricbeat/module/system/fsstat/_meta/fields.yml
+++ b/metricbeat/module/system/fsstat/_meta/fields.yml
@@ -2,7 +2,7 @@
   type: group
   description: >
     `system.fsstat` contains filesystem metrics aggregated from all mounted
-    filesystems.
+    filesystems, similar with what `df -a` prints out.
   fields:
     - name: count
       type: long

--- a/metricbeat/module/system/fsstat/fsstat.go
+++ b/metricbeat/module/system/fsstat/fsstat.go
@@ -41,18 +41,28 @@ func (m *MetricSet) Fetch() (common.MapStr, error) {
 
 	// These values are optional and could also be calculated by Kibana
 	var totalFiles, totalSize, totalSizeFree, totalSizeUsed uint64
+	dict := map[string]bool{}
 
 	for _, fs := range fss {
-		fsStat, err := filesystem.GetFileSystemStat(fs)
+		stat, err := filesystem.GetFileSystemStat(fs)
 		if err != nil {
 			debugf("error fetching filesystem stats for '%s': %v", fs.DirName, err)
 			continue
 		}
+		logp.Debug("fsstat", "filesystem: %s total=%d, used=%d, free=%d", stat.Mount, stat.Total, stat.Used, stat.Free)
 
-		totalFiles += fsStat.Files
-		totalSize += fsStat.Total
-		totalSizeFree += fsStat.Free
-		totalSizeUsed += fsStat.Used
+		if _, ok := dict[stat.Mount]; ok {
+			// ignore filesystem with the same mounting point
+			continue
+		}
+
+		totalFiles += stat.Files
+		totalSize += stat.Total
+		totalSizeFree += stat.Free
+		totalSizeUsed += stat.Used
+
+		dict[stat.Mount] = true
+
 	}
 
 	return common.MapStr{
@@ -61,7 +71,7 @@ func (m *MetricSet) Fetch() (common.MapStr, error) {
 			"used":  totalSizeUsed,
 			"total": totalSize,
 		},
-		"count":       len(fss),
+		"count":       len(dict),
 		"total_files": totalFiles,
 	}, nil
 }


### PR DESCRIPTION
Trying to solve the issue #2079, by calculating the `fsstat` values per mounting point, and not per filesystem. If multiple filesystems point to the same mounting point, then only one would be counted.