### PR TITLE
Backport #2765: Document system.memory.actual.free on Windows

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -34,6 +34,9 @@ https://github.com/elastic/beats/compare/v5.0.0-rc1...5.0[Check the HEAD diff]
 *Metricbeat*
 
 - Fix high CPU usage on macOS when encountering processes with long command lines. {issue}2747[2747]
+- Fix high value of `system.memory.actual.free` and `system.memory.actual.used`. {issue}2653[2653]
+- Change several `OpenProcess` calls on Windows to request the lowest possible access provilege.  {issue}1897[1897]
+- Fix system.memory.actual.free high value on Windows. {issue}2653[2653]
 
 *Packetbeat*
 

--- a/metricbeat/docs/fields.asciidoc
+++ b/metricbeat/docs/fields.asciidoc
@@ -3998,7 +3998,7 @@ type: long
 
 format: bytes
 
-Actual free memory in bytes. It is calculated based on the OS. On Linux it consists of the free memory plus caches and buffers. On OSX it is a sum of free memory and the inactive memory. On Windows, it is the  amount of unreserved and uncommitted memory currently in the user-mode portion of the virtual address space of the calling process.
+Actual free memory in bytes. It is calculated based on the OS. On Linux it consists of the free memory plus caches and buffers. On OSX it is a sum of free memory and the inactive memory. On Windows, it is equal to `system.memory.free`.
 
 
 [float]

--- a/metricbeat/etc/fields.yml
+++ b/metricbeat/etc/fields.yml
@@ -2488,9 +2488,8 @@
                   format: bytes
                   description: >
                     Actual free memory in bytes. It is calculated based on the OS. On Linux it consists of the free memory
-                    plus caches and buffers. On OSX it is a sum of free memory and the inactive memory. On Windows, it is the 
-                    amount of unreserved and uncommitted memory currently in the user-mode portion of the virtual address space
-                    of the calling process.
+                    plus caches and buffers. On OSX it is a sum of free memory and the inactive memory. On Windows, it is equal
+                    to `system.memory.free`.
 
                 - name: used.pct
                   type: scaled_float

--- a/metricbeat/module/system/memory/_meta/fields.yml
+++ b/metricbeat/module/system/memory/_meta/fields.yml
@@ -46,9 +46,8 @@
           format: bytes
           description: >
             Actual free memory in bytes. It is calculated based on the OS. On Linux it consists of the free memory
-            plus caches and buffers. On OSX it is a sum of free memory and the inactive memory. On Windows, it is the 
-            amount of unreserved and uncommitted memory currently in the user-mode portion of the virtual address space
-            of the calling process.
+            plus caches and buffers. On OSX it is a sum of free memory and the inactive memory. On Windows, it is equal
+            to `system.memory.free`.
 
         - name: used.pct
           type: scaled_float


### PR DESCRIPTION
Backport #2765 