### PR TITLE
Document PFRING as unsupported

### DIFF
--- a/packetbeat/docs/capturing.asciidoc
+++ b/packetbeat/docs/capturing.asciidoc
@@ -20,32 +20,34 @@ Currently Packetbeat has several options for traffic capturing:
 
  * `pcap`, which uses the libpcap library and works on most platforms, but
    it's not the fastest option.
- * `af_packet`, which uses memory mapped sniffing. This option is faster than libpcap 
+ * `af_packet`, which uses memory mapped sniffing. This option is faster than libpcap
     and doesn't require a kernel module, but it's Linux-specific.
  * `pf_ring`, which makes use of an ntop.org
-   http://www.ntop.org/products/pf_ring/[project]. This setting provides the best 
-   sniffing speed, but it requires a kernel module, and it's Linux-specific.
+   http://www.ntop.org/products/pf_ring/[project]. This setting provides the best
+   sniffing speed, but it requires recompilation and a kernel module, and it's
+   Linux-specific.
 
-The `pf_ring` option is a good configuration to use when you have
-dedicated servers for Packetbeat. It provides sniffing speeds in the order of
-Gigabits per second using only standard hardware.
+The `pf_ring` option provides sniffing speeds in the order of Gigabits per
+second using only standard hardware, but it requires you to recompile Packetbeat
+against the ntop libraries and is therefore currently not officially supported
+by Elastic.
 
 The `af_packet` option, also known as "memory-mapped sniffing," makes use of a
 Linux-specific
 http://lxr.free-electrons.com/source/Documentation/networking/packet_mmap.txt[feature].
-This could be the optimal sniffing mode for both the dedicated server and 
+This could be the optimal sniffing mode for both the dedicated server and
 when Packetbeat is deployed on an existing application server.
 
 The way it works is that both the kernel and the user space program map the
 same memory zone, and a simple circular buffer is organized in this memory zone.
 The kernel writes packets into the circular buffer, and the user space program
 reads from it. The poll system call is used for getting a notification for the
-first packet available, but the remaining available packets can be simply read 
+first packet available, but the remaining available packets can be simply read
 via memory access.
 
-This option is not quite as fast as `pf_ring` (it works to up to 200k packets per second
-before dropping packets), but it requires no kernel modules, and it's still a
-significant improvement over libpcap.
+This option is not quite as fast as `pf_ring` (it works to up to 200k packets
+per second before dropping packets), but it requires no recompilation and no
+kernel modules, and it's still a significant improvement over libpcap.
 
 The `af_packet` sniffer can be further tuned to use more memory in exchange for
 better performance. The larger the size of the circular buffer, the fewer

--- a/packetbeat/docs/reference/configuration/packetbeat-options.asciidoc
+++ b/packetbeat/docs/reference/configuration/packetbeat-options.asciidoc
@@ -94,6 +94,9 @@ Packetbeat supports three sniffer types:
    http://www.ntop.org/products/pf_ring/[project]. This setting provides the best
    sniffing speed, but it requires a kernel module, and it's Linux-specific.
 
+NOTE: The `pf_ring` option requires re-compilation of Packetbeat and is not
+      officially supported by Elastic at this moment.
+
 The default sniffer type is `pcap`.
 
 Here is an example configuration that specifies
@@ -105,9 +108,9 @@ packetbeat.interfaces.device: eth0
 packetbeat.interfaces.type: af_packet
 ------------------------------------------------------------------------------
 
-On Linux, if you are trying to optimize the CPU usage of Packetbeat,
-we recommend trying the `af_packet` and `pf_ring` options. Read <<capturing-options>>
-for more details.
+On Linux, if you are trying to optimize the CPU usage of Packetbeat, we
+recommend trying the `af_packet` option. Read <<capturing-options>> for more
+details.
 
 If you use the `af_packet` sniffer, you can tune its behaviour by specifying the
 following options:


### PR DESCRIPTION
We don't regularly test it, so it cannot be supported. Modified the docs
to clarify that and direct people more towards the af_packet option.