### PR TITLE
Replace filters with processors

### DIFF
--- a/metricbeat/docs/modules/system.asciidoc
+++ b/metricbeat/docs/modules/system.asciidoc
@@ -15,7 +15,7 @@ The System module has these additional config options:
 
 *`processes`*:: When the `process` metricset is enabled, you can use the `processes` option to define a list of
 regexp expressions to filter the processes that are reported. For more complex filtering, you should use the
-`filters` configuration option.
+<<configuration-processors, processors>> configuration option.
 +
 The following example config returns metrics for all processes:
 +

--- a/metricbeat/module/system/_meta/docs.asciidoc
+++ b/metricbeat/module/system/_meta/docs.asciidoc
@@ -10,7 +10,7 @@ The System module has these additional config options:
 
 *`processes`*:: When the `process` metricset is enabled, you can use the `processes` option to define a list of
 regexp expressions to filter the processes that are reported. For more complex filtering, you should use the
-`filters` configuration option.
+<<configuration-processors, processors>> configuration option.
 +
 The following example config returns metrics for all processes:
 +


### PR DESCRIPTION
Replace `filters` with `processors` in the documentation. 