### PR TITLE
Improve error message when user sets any on Windows and OS X

### DIFF
--- a/packetbeat/sniffer/sniffer.go
+++ b/packetbeat/sniffer/sniffer.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"runtime"
 	"strconv"
 	"syscall"
 	"time"
@@ -270,6 +271,15 @@ func (sniffer *SnifferSetup) Init(test_mode bool, filter string, factory WorkerF
 		err = sniffer.setFromConfig(interfaces)
 		if err != nil {
 			return fmt.Errorf("Error creating sniffer: %v", err)
+		}
+	}
+
+	if len(interfaces.File) == 0 {
+		if interfaces.Device == "any" {
+			// OS X or Windows
+			if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
+				return fmt.Errorf("any interface is not supported on %s", runtime.GOOS)
+			}
 		}
 	}
 


### PR DESCRIPTION
Trying to fix https://github.com/elastic/beats/issues/1823
Check if the interface is `any`, and throw an error when the system is OS X or Windows.