### PR TITLE
Closing changelog for GA

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -29,31 +29,19 @@ https://github.com/elastic/beats/compare/v5.0.0-rc1...5.0[Check the HEAD diff]
 
 *Affecting all Beats*
 
-- Fix kafka output re-trying batches with too large events. {issue}2735[2735]
-- Fix kafka output protocol error if `version: 0.10` is configured. {issue}2651[2651]
-- Fix kafka output connection closed by broker on SASL/PLAIN. {issue}2717[2717]
-
 *Metricbeat*
-
-- Fix high CPU usage on macOS when encountering processes with long command lines. {issue}2747[2747]
-- Fix high value of `system.memory.actual.free` and `system.memory.actual.used`. {issue}2653[2653]
-- Change several `OpenProcess` calls on Windows to request the lowest possible access provilege.  {issue}1897[1897]
-- Fix system.memory.actual.free high value on Windows. {issue}2653[2653]
 
 *Packetbeat*
 
 *Topbeat*
 
 *Filebeat*
-- Fix issue when clean_removed and clean_inactive were used together that states were not directly removed from the registry.
-- Fix issue where upgrading a 1.x registry file resulted in duplicate state entries. {pull}2792[2792]
 
 *Winlogbeat*
 
 ==== Added
 
 *Affecting all Beats*
-- Add beat.version fields to all events.
 
 *Metricbeat*
 
@@ -80,6 +68,38 @@ https://github.com/elastic/beats/compare/v5.0.0-rc1...5.0[Check the HEAD diff]
 *Winlogbeat*
 
 ////////////////////////////////////////////////////////////
+
+[[release-notes-5.0.0-ga]]
+=== Beats version 5.0.0-GA
+https://github.com/elastic/beats/compare/v5.0.0-rc1...v5.0.0[View commits]
+
+The list below covers the changes between 5.0.0-rc1 and 5.0.0 GA only.
+
+==== Bugfixes
+
+*Affecting all Beats*
+
+- Fix kafka output re-trying batches with too large events. {issue}2735[2735]
+- Fix kafka output protocol error if `version: 0.10` is configured. {issue}2651[2651]
+- Fix kafka output connection closed by broker on SASL/PLAIN. {issue}2717[2717]
+
+*Metricbeat*
+
+- Fix high CPU usage on macOS when encountering processes with long command lines. {issue}2747[2747]
+- Fix high value of `system.memory.actual.free` and `system.memory.actual.used`. {issue}2653[2653]
+- Change several `OpenProcess` calls on Windows to request the lowest possible access provilege.  {issue}1897[1897]
+- Fix system.memory.actual.free high value on Windows. {issue}2653[2653]
+
+*Filebeat*
+
+- Fix issue when clean_removed and clean_inactive were used together that states were not directly removed from the registry.
+- Fix issue where upgrading a 1.x registry file resulted in duplicate state entries. {pull}2792[2792]
+
+==== Added
+
+*Affecting all Beats*
+
+- Add beat.version fields to all events.
 
 [[release-notes-5.0.0-rc1]]
 === Beats version 5.0.0-rc1
@@ -410,30 +430,6 @@ https://github.com/elastic/beats/compare/v5.0.0-alpha2...v5.0.0-alpha3[View comm
 
 - The support for doing GeoIP lookups is deprecated and will be removed in version 6.0. {pull}1601[1601]
 
-[[release-notes-1.2.3]]
-=== Beats version 1.2.3
-https://github.com/elastic/beats/compare/v1.2.2...v1.2.3[View commits]
-
-==== Bugfixes
-
-*Topbeat*
-
-- Fix high CPU usage when using filtering under Windows. {pull}1598[1598]
-
-*Filebeat*
-
-- Fix rotation issue with ignore_older. {issue}1528[1528]
-
-*Winlogbeat*
-
-- Fix panic when reading messages larger than 32K characters on Windows XP and 2003. {pull}1498[1498]
-
-==== Added
-
-*Filebeat*
-
-- Prevent file opening for files which reached ignore_older. {pull}1649[1649]
-
 
 [[release-notes-5.0.0-alpha2]]
 === Beats version 5.0.0-alpha2
@@ -507,43 +503,6 @@ https://github.com/elastic/beats/compare/v5.0.0-alpha1...v5.0.0-alpha2[View comm
 
 - Updated elastic/gosigar version so Topbeat can compile on OpenBSD. {pull}1403[1403]
 
-[[release-notes-1.2.2]]
-=== Beats version 1.2.2
-https://github.com/elastic/beats/compare/v1.2.0...v1.2.2[View commits]
-
-==== Bugfixes
-
-*Affecting all Beats*
-
-- Fix race when multiple outputs access the same event with Logstash output manipulating event. {issue}1410[1410]
-- Fix go-daemon (supervisor used in init scripts) hanging when executed over SSH. {issue}1394[1394]
-
-*Filebeat*
-
-- Improvements in registrar dealing with file rotation. {issue}1281[1281]
-
-
-[[release-notes-1.2.1]]
-=== Beats version 1.2.1
-https://github.com/elastic/beats/compare/v1.2.0...v1.2.1[View commits]
-
-==== Breaking changes
-
-*Affecting all Beats*
-
-- Require braces for environment variable expansion in config files {pull}1304[1304]
-- Removed deprecation warning for the Redis output. {pull}1282[1282]
-
-*Topbeat*
-
-- Fixed name of the setting `stats.proc` to `stats.process` in the default configuration file. {pull}1343[1343]
-- Fix issue with cpu.system_p being greater than 1 on Windows {pull}1128[1128]
-
-==== Added
-
-*Topbeat*
-
-- Add username to processes {pull}845[845]
 
 [[release-notes-5.0.0-alpha1]]
 === Beats version 5.0.0-alpha1
@@ -653,6 +612,69 @@ https://github.com/elastic/beats/compare/v1.2.0...v5.0.0-alpha1[View commits]
 * When running the Beats as a service on Windows, you need to manually load the Elasticsearch mapping
   template. {issue}1315[1315]
 * The ES template automatic load doesn't work if Elasticsearch is not available when the Beat is starting. {issue}1321[1321]
+
+[[release-notes-1.2.3]]
+=== Beats version 1.2.3
+https://github.com/elastic/beats/compare/v1.2.2...v1.2.3[View commits]
+
+==== Bugfixes
+
+*Topbeat*
+
+- Fix high CPU usage when using filtering under Windows. {pull}1598[1598]
+
+*Filebeat*
+
+- Fix rotation issue with ignore_older. {issue}1528[1528]
+
+*Winlogbeat*
+
+- Fix panic when reading messages larger than 32K characters on Windows XP and 2003. {pull}1498[1498]
+
+==== Added
+
+*Filebeat*
+
+- Prevent file opening for files which reached ignore_older. {pull}1649[1649]
+
+
+[[release-notes-1.2.2]]
+=== Beats version 1.2.2
+https://github.com/elastic/beats/compare/v1.2.0...v1.2.2[View commits]
+
+==== Bugfixes
+
+*Affecting all Beats*
+
+- Fix race when multiple outputs access the same event with Logstash output manipulating event. {issue}1410[1410]
+- Fix go-daemon (supervisor used in init scripts) hanging when executed over SSH. {issue}1394[1394]
+
+*Filebeat*
+
+- Improvements in registrar dealing with file rotation. {issue}1281[1281]
+
+
+[[release-notes-1.2.1]]
+=== Beats version 1.2.1
+https://github.com/elastic/beats/compare/v1.2.0...v1.2.1[View commits]
+
+==== Breaking changes
+
+*Affecting all Beats*
+
+- Require braces for environment variable expansion in config files {pull}1304[1304]
+- Removed deprecation warning for the Redis output. {pull}1282[1282]
+
+*Topbeat*
+
+- Fixed name of the setting `stats.proc` to `stats.process` in the default configuration file. {pull}1343[1343]
+- Fix issue with cpu.system_p being greater than 1 on Windows {pull}1128[1128]
+
+==== Added
+
+*Topbeat*
+
+- Add username to processes {pull}845[845]
 
 
 [[release-notes-1.2.0]]

--- a/libbeat/docs/release.asciidoc
+++ b/libbeat/docs/release.asciidoc
@@ -6,16 +6,17 @@
 --
 This section summarizes the changes in each release.
 
+* <<release-notes-5.0.0-ga>>
 * <<release-notes-5.0.0-rc1>>
 * <<release-notes-5.0.0-beta1>>
 * <<release-notes-5.0.0-alpha5>>
 * <<release-notes-5.0.0-alpha4>>
 * <<release-notes-5.0.0-alpha3>>
-* <<release-notes-1.2.3>>
 * <<release-notes-5.0.0-alpha2>>
+* <<release-notes-5.0.0-alpha1>>
+* <<release-notes-1.2.3>>
 * <<release-notes-1.2.2>>
 * <<release-notes-1.2.1>>
-* <<release-notes-5.0.0-alpha1>>
 * <<release-notes-1.2.0>>
 * <<release-notes-1.1.2>>
 * <<release-notes-1.1.1>>


### PR DESCRIPTION
I also plan to add a consolidated page with the combined release notes
from all the pre-releases.

This also sorts the entries so all 1.x releases are shown after the 5.x
releases (drops the calendaristic order).