### PR TITLE
minor cleanups

### DIFF
--- a/filebeat/harvester/reader/json_test.go
+++ b/filebeat/harvester/reader/json_test.go
@@ -8,14 +8,12 @@ import (
 )
 
 func TestUnmarshal(t *testing.T) {
-	type io struct {
+	tests := []struct {
 		Name   string
 		Input  string
 		Output map[string]interface{}
-	}
-
-	tests := []io{
-		io{
+	}{
+		{
 			Name:  "Top level int, float, string, bool",
 			Input: `{"a": 3, "b": 2.0, "c": "hello", "d": true}`,
 			Output: map[string]interface{}{
@@ -25,7 +23,7 @@ func TestUnmarshal(t *testing.T) {
 				"d": true,
 			},
 		},
-		io{
+		{
 			Name:  "Nested objects with ints",
 			Input: `{"a": 3, "b": {"c": {"d": 5}}}`,
 			Output: map[string]interface{}{
@@ -37,7 +35,7 @@ func TestUnmarshal(t *testing.T) {
 				},
 			},
 		},
-		io{
+		{
 			Name:  "Array of floats",
 			Input: `{"a": 3, "b": {"c": [4.0, 4.1, 4.2]}}`,
 			Output: map[string]interface{}{
@@ -49,7 +47,7 @@ func TestUnmarshal(t *testing.T) {
 				},
 			},
 		},
-		io{
+		{
 			Name:  "Array of mixed ints and floats",
 			Input: `{"a": 3, "b": {"c": [4, 4.1, 4.2]}}`,
 			Output: map[string]interface{}{
@@ -61,7 +59,7 @@ func TestUnmarshal(t *testing.T) {
 				},
 			},
 		},
-		io{
+		{
 			Name:  "Negative values",
 			Input: `{"a": -3, "b": -1.0}`,
 			Output: map[string]interface{}{
@@ -81,14 +79,12 @@ func TestUnmarshal(t *testing.T) {
 }
 
 func TestDecodeJSON(t *testing.T) {
-	type io struct {
+	var tests = []struct {
 		Text         string
 		Config       JSONConfig
 		ExpectedText string
 		ExpectedMap  common.MapStr
-	}
-
-	var tests = []io{
+	}{
 		{
 			Text:         `{"message": "test", "value": 1}`,
 			Config:       JSONConfig{MessageKey: "message"},

--- a/filebeat/input/file/file_windows.go
+++ b/filebeat/input/file/file_windows.go
@@ -30,7 +30,7 @@ func GetOSState(info os.FileInfo) StateOS {
 	// Get the three fields required to uniquely identify file und windows
 	// More details can be found here: https://msdn.microsoft.com/en-us/library/aa363788(v=vs.85).aspx
 	// Uint should already return uint64, but making sure this is the case
-	// The required fiels can be found here: https://github.com/golang/go/blob/master/src/os/types_windows.go#L78
+	// The required fields can be found here: https://github.com/golang/go/blob/master/src/os/types_windows.go#L78
 	fileState := StateOS{
 		IdxHi: uint64(fileStat.FieldByName("idxhi").Uint()),
 		IdxLo: uint64(fileStat.FieldByName("idxlo").Uint()),

--- a/filebeat/prospector/prospector.go
+++ b/filebeat/prospector/prospector.go
@@ -218,7 +218,7 @@ func (p *Prospector) startHarvester(state file.State, offset int64) error {
 		return fmt.Errorf("Error setting up harvester: %s", err)
 	}
 
-	// State is directly updated and not through channel to make state update immidiate
+	// State is directly updated and not through channel to make state update immediate
 	// State is only updated after setup is completed successfully
 	err = p.updateState(input.NewEvent(state))
 	if err != nil {

--- a/filebeat/publisher/publisher_test.go
+++ b/filebeat/publisher/publisher_test.go
@@ -72,7 +72,7 @@ func TestPublisherModes(t *testing.T) {
 		}
 
 		var msgs []pubtest.PublishMessage
-		for _ = range test.order {
+		for range test.order {
 			m := <-client.Channel
 			msgs = append(msgs, m)
 		}

--- a/filebeat/registrar/registrar_test.go
+++ b/filebeat/registrar/registrar_test.go
@@ -20,27 +20,27 @@ func TestConvertOldStates(t *testing.T) {
 		{
 			Name: "Simple test with three files",
 			Input: map[string]file.State{
-				"test":  file.State{Source: "test", FileStateOS: file.StateOS{Inode: 5}},
-				"test1": file.State{Source: "test1", FileStateOS: file.StateOS{Inode: 3}},
-				"test2": file.State{Source: "test2", FileStateOS: file.StateOS{Inode: 2}},
+				"test":  {Source: "test", FileStateOS: file.StateOS{Inode: 5}},
+				"test1": {Source: "test1", FileStateOS: file.StateOS{Inode: 3}},
+				"test2": {Source: "test2", FileStateOS: file.StateOS{Inode: 2}},
 			},
 			Output: []string{"test", "test1", "test2"},
 		},
 		{
 			Name: "De-duplicate inodes. Bigger offset wins (1)",
 			Input: map[string]file.State{
-				"test":  file.State{Source: "test", FileStateOS: file.StateOS{Inode: 2}},
-				"test1": file.State{Source: "test1", FileStateOS: file.StateOS{Inode: 3}},
-				"test2": file.State{Source: "test2", FileStateOS: file.StateOS{Inode: 2}, Offset: 2},
+				"test":  {Source: "test", FileStateOS: file.StateOS{Inode: 2}},
+				"test1": {Source: "test1", FileStateOS: file.StateOS{Inode: 3}},
+				"test2": {Source: "test2", FileStateOS: file.StateOS{Inode: 2}, Offset: 2},
 			},
 			Output: []string{"test1", "test2"},
 		},
 		{
 			Name: "De-duplicate inodes. Bigger offset wins (2)",
 			Input: map[string]file.State{
-				"test":  file.State{Source: "test", FileStateOS: file.StateOS{Inode: 2}, Offset: 2},
-				"test1": file.State{Source: "test1", FileStateOS: file.StateOS{Inode: 3}},
-				"test2": file.State{Source: "test2", FileStateOS: file.StateOS{Inode: 2}, Offset: 0},
+				"test":  {Source: "test", FileStateOS: file.StateOS{Inode: 2}, Offset: 2},
+				"test1": {Source: "test1", FileStateOS: file.StateOS{Inode: 3}},
+				"test2": {Source: "test2", FileStateOS: file.StateOS{Inode: 2}, Offset: 0},
 			},
 			Output: []string{"test", "test1"},
 		},
@@ -54,6 +54,5 @@ func TestConvertOldStates(t *testing.T) {
 		}
 		sort.Strings(resultSources)
 		assert.Equal(t, test.Output, resultSources, test.Name)
-
 	}
 }

--- a/heartbeat/monitors/active/tcp/check.go
+++ b/heartbeat/monitors/active/tcp/check.go
@@ -91,7 +91,7 @@ func sendBuffer(conn net.Conn, buf []byte) error {
 }
 
 func recvBuffer(conn net.Conn, buf []byte) error {
-	if len(buf) > 0 {
+	for len(buf) > 0 {
 		n, err := conn.Read(buf)
 		if err != nil {
 			return err

--- a/libbeat/common/bytes.go
+++ b/libbeat/common/bytes.go
@@ -8,21 +8,21 @@ import (
 
 // Byte order utilities
 
-func Bytes_Ntohs(b []byte) uint16 {
+func BytesNtohs(b []byte) uint16 {
 	return uint16(b[0])<<8 | uint16(b[1])
 }
 
-func Bytes_Ntohl(b []byte) uint32 {
+func BytesNtohl(b []byte) uint32 {
 	return uint32(b[0])<<24 | uint32(b[1])<<16 |
 		uint32(b[2])<<8 | uint32(b[3])
 }
 
-func Bytes_Htohl(b []byte) uint32 {
+func BytesHtohl(b []byte) uint32 {
 	return uint32(b[3])<<24 | uint32(b[2])<<16 |
 		uint32(b[1])<<8 | uint32(b[0])
 }
 
-func Bytes_Ntohll(b []byte) uint64 {
+func BytesNtohll(b []byte) uint64 {
 	return uint64(b[0])<<56 | uint64(b[1])<<48 |
 		uint64(b[2])<<40 | uint64(b[3])<<32 |
 		uint64(b[4])<<24 | uint64(b[5])<<16 |
@@ -30,7 +30,7 @@ func Bytes_Ntohll(b []byte) uint64 {
 }
 
 // Ipv4_Ntoa transforms an IP4 address in it's dotted notation
-func Ipv4_Ntoa(ip uint32) string {
+func IPv4Ntoa(ip uint32) string {
 	return fmt.Sprintf("%d.%d.%d.%d",
 		byte(ip>>24), byte(ip>>16),
 		byte(ip>>8), byte(ip))

--- a/libbeat/common/bytes_test.go
+++ b/libbeat/common/bytes_test.go
@@ -35,7 +35,7 @@ func TestBytes_Ntohs(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		assert.Equal(t, test.Output, Bytes_Ntohs(test.Input))
+		assert.Equal(t, test.Output, BytesNtohs(test.Input))
 	}
 }
 
@@ -69,7 +69,7 @@ func TestBytes_Ntohl(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		assert.Equal(t, test.Output, Bytes_Ntohl(test.Input))
+		assert.Equal(t, test.Output, BytesNtohl(test.Input))
 	}
 }
 
@@ -103,7 +103,7 @@ func TestBytes_Htohl(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		assert.Equal(t, test.Output, Bytes_Htohl(test.Input))
+		assert.Equal(t, test.Output, BytesHtohl(test.Input))
 	}
 }
 
@@ -153,7 +153,7 @@ func TestBytes_Ntohll(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		assert.Equal(t, test.Output, Bytes_Ntohll(test.Input))
+		assert.Equal(t, test.Output, BytesNtohll(test.Input))
 	}
 }
 
@@ -179,7 +179,7 @@ func TestIpv4_Ntoa(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		assert.Equal(t, test.Output, Ipv4_Ntoa(test.Input))
+		assert.Equal(t, test.Output, IPv4Ntoa(test.Input))
 	}
 }
 

--- a/libbeat/common/droppriv/droppriv_unix.go
+++ b/libbeat/common/droppriv/droppriv_unix.go
@@ -11,29 +11,29 @@ import (
 )
 
 type RunOptions struct {
-	Uid *int
-	Gid *int
+	UID *int
+	GID *int
 }
 
 func DropPrivileges(config RunOptions) error {
 	var err error
 
-	if config.Uid == nil {
+	if config.UID == nil {
 		// not found, no dropping privileges but no err
 		return nil
 	}
 
-	if config.Gid == nil {
+	if config.GID == nil {
 		return errors.New("GID must be specified for dropping privileges")
 	}
 
-	logp.Info("Switching to user: %d.%d", config.Uid, config.Gid)
+	logp.Info("Switching to user: %d.%d", config.UID, config.GID)
 
-	if err = syscall.Setgid(*config.Gid); err != nil {
+	if err = syscall.Setgid(*config.GID); err != nil {
 		return fmt.Errorf("setgid: %s", err.Error())
 	}
 
-	if err = syscall.Setuid(*config.Uid); err != nil {
+	if err = syscall.Setuid(*config.UID); err != nil {
 		return fmt.Errorf("setuid: %s", err.Error())
 	}
 

--- a/libbeat/common/dtfmt/doc.go
+++ b/libbeat/common/dtfmt/doc.go
@@ -1,4 +1,4 @@
-// dtfmt package provides time formatter support with pattern syntax mostly
+// Package dtfmt provides time formatter support with pattern syntax mostly
 // similar to joda DateTimeFormat. The pattern syntax supported is a subset
 // (mostly compatible) with joda DateTimeFormat.
 //

--- a/libbeat/common/endpoint.go
+++ b/libbeat/common/endpoint.go
@@ -2,7 +2,7 @@ package common
 
 // Endpoint represents an endpoint in the communication.
 type Endpoint struct {
-	Ip      string
+	IP      string
 	Port    uint16
 	Name    string
 	Cmdline string

--- a/libbeat/common/fmtstr/formatstring_test.go
+++ b/libbeat/common/fmtstr/formatstring_test.go
@@ -124,6 +124,10 @@ func TestFormatString(t *testing.T) {
 
 		// run string formatter
 		actual, err := sf.Run(nil)
+		if err != nil {
+			t.Error(err)
+			continue
+		}
 
 		// test validation
 		if test.dyn == nil {

--- a/libbeat/common/geolite.go
+++ b/libbeat/common/geolite.go
@@ -23,9 +23,9 @@ func LoadGeoIPData(config Geoip) *libgeo.GeoIP {
 	if len(geoipPaths) == 0 {
 		// disabled
 		return nil
-	} else {
-		logp.Warn("GeoIP lookup support is deprecated and will be removed in version 6.0.")
 	}
+
+	logp.Warn("GeoIP lookup support is deprecated and will be removed in version 6.0.")
 
 	// look for the first existing path
 	var geoipPath string

--- a/libbeat/common/net.go
+++ b/libbeat/common/net.go
@@ -5,9 +5,9 @@ import (
 	"net"
 )
 
-// LocalIpAddrs finds the IP addresses of the hosts on which
+// LocalIPAddrs finds the IP addresses of the hosts on which
 // the shipper currently runs on.
-func LocalIpAddrs() ([]net.IP, error) {
+func LocalIPAddrs() ([]net.IP, error) {
 	var localIPAddrs = []net.IP{}
 	ipaddrs, err := net.InterfaceAddrs()
 	if err != nil {
@@ -21,18 +21,18 @@ func LocalIpAddrs() ([]net.IP, error) {
 	return localIPAddrs, nil
 }
 
-// LocalIpAddrsAsStrings finds the IP addresses of the hosts on which
+// LocalIPAddrsAsStrings finds the IP addresses of the hosts on which
 // the shipper currently runs on and returns them as an array of
 // strings.
-func LocalIpAddrsAsStrings(include_loopbacks bool) ([]string, error) {
+func LocalIPAddrsAsStrings(includeLoopbacks bool) ([]string, error) {
 	var localIPAddrsStrings = []string{}
 	var err error
-	ipaddrs, err := LocalIpAddrs()
+	ipaddrs, err := LocalIPAddrs()
 	if err != nil {
 		return []string{}, err
 	}
 	for _, ipaddr := range ipaddrs {
-		if include_loopbacks || !ipaddr.IsLoopback() {
+		if includeLoopbacks || !ipaddr.IsLoopback() {
 			localIPAddrsStrings = append(localIPAddrsStrings, ipaddr.String())
 		}
 	}
@@ -41,10 +41,10 @@ func LocalIpAddrsAsStrings(include_loopbacks bool) ([]string, error) {
 
 // IsLoopback check if a particular IP notation corresponds
 // to a loopback interface.
-func IsLoopback(ip_str string) (bool, error) {
-	ip := net.ParseIP(ip_str)
+func IsLoopback(ipStr string) (bool, error) {
+	ip := net.ParseIP(ipStr)
 	if ip == nil {
-		return false, fmt.Errorf("Wrong IP format %s", ip_str)
+		return false, fmt.Errorf("Wrong IP format %s", ipStr)
 	}
 	return ip.IsLoopback(), nil
 }

--- a/libbeat/common/streambuf/ascii.go
+++ b/libbeat/common/streambuf/ascii.go
@@ -45,7 +45,7 @@ func (b *Buffer) UntilCRLF() ([]byte, error) {
 	return nil, b.bufferEndError()
 }
 
-// Ignore symbol will advance the read pointer until the first symbol not
+// IgnoreSymbol will advance the read pointer until the first symbol not
 // matching s is found.
 func (b *Buffer) IgnoreSymbol(s uint8) error {
 	if b.err != nil {
@@ -107,15 +107,15 @@ func (b *Buffer) UntilSymbol(s uint8, errOnEnd bool) ([]byte, error) {
 	if errOnEnd {
 		b.offset += len(data)
 		return nil, b.bufferEndError()
-	} else {
-		data := b.data[b.mark:]
-		b.Advance(len(data))
-		return data, nil
 	}
+
+	data = b.data[b.mark:]
+	b.Advance(len(data))
+	return data, nil
 }
 
-// AsciiUint will parse unsigned number from Buffer.
-func (b *Buffer) AsciiUint(errOnEnd bool) (uint64, error) {
+// UintASCII will parse unsigned number from Buffer.
+func (b *Buffer) UintASCII(errOnEnd bool) (uint64, error) {
 	if b.err != nil {
 		return 0, b.err
 	}
@@ -137,8 +137,8 @@ func (b *Buffer) AsciiUint(errOnEnd bool) (uint64, error) {
 	return value, nil
 }
 
-// AsciiInt will parse (optionally) signed number from Buffer.
-func (b *Buffer) AsciiInt(errOnEnd bool) (int64, error) {
+// IntASCII will parse (optionally) signed number from Buffer.
+func (b *Buffer) IntASCII(errOnEnd bool) (int64, error) {
 	if b.err != nil {
 		return 0, b.err
 	}
@@ -180,14 +180,13 @@ func (b *Buffer) AsciiInt(errOnEnd bool) (int64, error) {
 	b.Advance(end - b.mark)
 	if signed {
 		return -int64(value), nil
-	} else {
-		return int64(value), nil
 	}
+	return int64(value), nil
 }
 
-// AsciiMatch checks the Buffer it's next byte sequence matched prefix. The
+// MatchASCII checks the Buffer it's next byte sequence matched prefix. The
 // read pointer is not advanced by AsciiPrefix.
-func (b *Buffer) AsciiMatch(prefix []byte) (bool, error) {
+func (b *Buffer) MatchASCII(prefix []byte) (bool, error) {
 	if b.err != nil {
 		return false, b.err
 	}
@@ -213,9 +212,8 @@ func (b *Buffer) asciiFindNumberEnd(start int, errOnEnd bool) (int, error) {
 	if end < 0 {
 		if errOnEnd {
 			return -1, b.bufferEndError()
-		} else {
-			end = len(b.data)
 		}
+		end = len(b.data)
 	}
 
 	return end, nil

--- a/libbeat/common/streambuf/ascii_test.go
+++ b/libbeat/common/streambuf/ascii_test.go
@@ -145,7 +145,7 @@ func Test_UntilSymbolOrEnd(t *testing.T) {
 
 func Test_AsciiUintOK(t *testing.T) {
 	b := New([]byte("123 "))
-	v, err := b.AsciiUint(false)
+	v, err := b.UintASCII(false)
 	b.checkInvariants(t)
 	assert.Nil(t, err)
 	assert.Equal(t, uint64(123), v)
@@ -154,29 +154,29 @@ func Test_AsciiUintOK(t *testing.T) {
 func Test_AsciiUintFailed(t *testing.T) {
 	b := New([]byte("123 "))
 	b.SetError(ErrTest)
-	_, err := b.AsciiUint(false)
+	_, err := b.UintASCII(false)
 	assert.Equal(t, ErrTest, err)
 }
 
 func Test_AsciiUintNotDigit(t *testing.T) {
 	b := New([]byte("test"))
-	_, err := b.AsciiUint(false)
+	_, err := b.UintASCII(false)
 	assert.Equal(t, ErrExpectedDigit, err)
 }
 
 func Test_AsciiUintEmpty(t *testing.T) {
 	b := New([]byte(""))
-	_, err := b.AsciiUint(false)
+	_, err := b.UintASCII(false)
 	assert.Equal(t, ErrNoMoreBytes, err)
 }
 
 func Test_AsciiUintCont(t *testing.T) {
 	b := New([]byte("12"))
-	_, err := b.AsciiUint(true)
+	_, err := b.UintASCII(true)
 	assert.Equal(t, ErrNoMoreBytes, err)
 
 	b.Append([]byte("34 "))
-	v, err := b.AsciiUint(true)
+	v, err := b.UintASCII(true)
 	b.checkInvariants(t)
 	assert.Nil(t, err)
 	assert.Equal(t, uint64(1234), v)
@@ -184,7 +184,7 @@ func Test_AsciiUintCont(t *testing.T) {
 
 func Test_AsciiUintOrEndOK(t *testing.T) {
 	b := New([]byte("12"))
-	v, err := b.AsciiUint(false)
+	v, err := b.UintASCII(false)
 	b.checkInvariants(t)
 	assert.Nil(t, err)
 	assert.Equal(t, uint64(12), v)
@@ -192,7 +192,7 @@ func Test_AsciiUintOrEndOK(t *testing.T) {
 
 func Test_AsciiIntOK(t *testing.T) {
 	b := New([]byte("123 "))
-	v, err := b.AsciiInt(false)
+	v, err := b.IntASCII(false)
 	b.checkInvariants(t)
 	assert.Nil(t, err)
 	assert.Equal(t, int64(123), v)
@@ -200,7 +200,7 @@ func Test_AsciiIntOK(t *testing.T) {
 
 func Test_AsciiIntPosOK(t *testing.T) {
 	b := New([]byte("+123 "))
-	v, err := b.AsciiInt(false)
+	v, err := b.IntASCII(false)
 	b.checkInvariants(t)
 	assert.Nil(t, err)
 	assert.Equal(t, int64(123), v)
@@ -208,7 +208,7 @@ func Test_AsciiIntPosOK(t *testing.T) {
 
 func Test_AsciiIntNegOK(t *testing.T) {
 	b := New([]byte("-123 "))
-	v, err := b.AsciiInt(false)
+	v, err := b.IntASCII(false)
 	b.checkInvariants(t)
 	assert.Nil(t, err)
 	assert.Equal(t, int64(-123), v)
@@ -217,29 +217,29 @@ func Test_AsciiIntNegOK(t *testing.T) {
 func Test_AsciiIntFailed(t *testing.T) {
 	b := New([]byte("123 "))
 	b.SetError(ErrTest)
-	_, err := b.AsciiInt(false)
+	_, err := b.IntASCII(false)
 	assert.Equal(t, ErrTest, err)
 }
 
 func Test_AsciiIntNotDigit(t *testing.T) {
 	b := New([]byte("test"))
-	_, err := b.AsciiInt(false)
+	_, err := b.IntASCII(false)
 	assert.Equal(t, ErrExpectedDigit, err)
 }
 
 func Test_AsciiIntEmpty(t *testing.T) {
 	b := New([]byte(""))
-	_, err := b.AsciiInt(false)
+	_, err := b.IntASCII(false)
 	assert.Equal(t, ErrNoMoreBytes, err)
 }
 
 func Test_AsciiIntCont(t *testing.T) {
 	b := New([]byte("12"))
-	_, err := b.AsciiInt(true)
+	_, err := b.IntASCII(true)
 	assert.Equal(t, ErrNoMoreBytes, err)
 
 	b.Append([]byte("34 "))
-	v, err := b.AsciiInt(true)
+	v, err := b.IntASCII(true)
 	b.checkInvariants(t)
 	assert.Nil(t, err)
 	assert.Equal(t, int64(1234), v)
@@ -247,7 +247,7 @@ func Test_AsciiIntCont(t *testing.T) {
 
 func Test_AsciiIntOrEndOK(t *testing.T) {
 	b := New([]byte("12"))
-	v, err := b.AsciiInt(false)
+	v, err := b.IntASCII(false)
 	b.checkInvariants(t)
 	assert.Nil(t, err)
 	assert.Equal(t, int64(12), v)
@@ -255,7 +255,7 @@ func Test_AsciiIntOrEndOK(t *testing.T) {
 
 func Test_AsciiMatchOK(t *testing.T) {
 	b := New([]byte("match test"))
-	r, err := b.AsciiMatch([]byte("match"))
+	r, err := b.MatchASCII([]byte("match"))
 	b.checkInvariants(t)
 	assert.Nil(t, err)
 	assert.True(t, r)
@@ -264,7 +264,7 @@ func Test_AsciiMatchOK(t *testing.T) {
 
 func Test_AsciiMatchNo(t *testing.T) {
 	b := New([]byte("match test"))
-	r, err := b.AsciiMatch([]byte("batch"))
+	r, err := b.MatchASCII([]byte("batch"))
 	b.checkInvariants(t)
 	assert.Nil(t, err)
 	assert.False(t, r)
@@ -274,11 +274,11 @@ func Test_AsciiMatchNo(t *testing.T) {
 func Test_AsciiMatchCont(t *testing.T) {
 	b := New([]byte("mat"))
 
-	_, err := b.AsciiMatch([]byte("match"))
+	_, err := b.MatchASCII([]byte("match"))
 	assert.Equal(t, ErrNoMoreBytes, err)
 
 	b.Append([]byte("ch test"))
-	r, err := b.AsciiMatch([]byte("match"))
+	r, err := b.MatchASCII([]byte("match"))
 	b.checkInvariants(t)
 	assert.Nil(t, err)
 	assert.True(t, r)
@@ -288,6 +288,6 @@ func Test_AsciiMatchCont(t *testing.T) {
 func Test_AsciiMatchFailed(t *testing.T) {
 	b := New([]byte("match test"))
 	b.SetError(ErrTest)
-	_, err := b.AsciiMatch([]byte("match"))
+	_, err := b.MatchASCII([]byte("match"))
 	assert.Equal(t, ErrTest, err)
 }

--- a/libbeat/common/streambuf/io_test.go
+++ b/libbeat/common/streambuf/io_test.go
@@ -140,6 +140,7 @@ func Test_ReadBufSmaller(t *testing.T) {
 	assert.Equal(t, []byte{6, 7, 8}, tmp[:n])
 
 	n, err = b.Read(tmp)
+	assert.Equal(t, 0, n)
 	assert.Equal(t, io.EOF, err)
 }
 
@@ -154,6 +155,7 @@ func Test_ReadBufBigger(t *testing.T) {
 	assert.Equal(t, []byte{1, 2, 3, 4, 5, 6, 7, 8}, tmp[:n])
 
 	n, err = b.Read(tmp)
+	assert.Equal(t, 0, n)
 	assert.Equal(t, io.EOF, err)
 }
 

--- a/libbeat/common/streambuf/net.go
+++ b/libbeat/common/streambuf/net.go
@@ -55,7 +55,7 @@ func (b *Buffer) ReadNetUint16() (uint16, error) {
 	if err := b.Advance(2); err != nil {
 		return 0, err
 	}
-	value := common.Bytes_Ntohs(tmp)
+	value := common.BytesNtohs(tmp)
 	return value, nil
 }
 
@@ -73,7 +73,7 @@ func (b *Buffer) ReadNetUint16At(index int) (uint16, error) {
 	if !b.Avail(2 + index) {
 		return 0, b.bufferEndError()
 	}
-	return common.Bytes_Ntohs(b.data[index+b.mark:]), nil
+	return common.BytesNtohs(b.data[index+b.mark:]), nil
 
 }
 
@@ -98,7 +98,7 @@ func (b *Buffer) ReadNetUint32() (uint32, error) {
 	if err := b.Advance(4); err != nil {
 		return 0, err
 	}
-	value := common.Bytes_Ntohl(tmp)
+	value := common.BytesNtohl(tmp)
 	return value, nil
 }
 
@@ -116,7 +116,7 @@ func (b *Buffer) ReadNetUint32At(index int) (uint32, error) {
 	if !b.Avail(4 + index) {
 		return 0, b.bufferEndError()
 	}
-	return common.Bytes_Ntohl(b.data[index+b.mark:]), nil
+	return common.BytesNtohl(b.data[index+b.mark:]), nil
 
 }
 
@@ -143,7 +143,7 @@ func (b *Buffer) ReadNetUint64() (uint64, error) {
 	if err := b.Advance(8); err != nil {
 		return 0, err
 	}
-	value := common.Bytes_Ntohll(tmp)
+	value := common.BytesNtohll(tmp)
 	return value, nil
 }
 
@@ -161,7 +161,7 @@ func (b *Buffer) ReadNetUint64At(index int) (uint64, error) {
 	if !b.Avail(8 + index) {
 		return 0, b.bufferEndError()
 	}
-	return common.Bytes_Ntohll(b.data[index+b.mark:]), nil
+	return common.BytesNtohll(b.data[index+b.mark:]), nil
 
 }
 

--- a/libbeat/common/streambuf/streambuf.go
+++ b/libbeat/common/streambuf/streambuf.go
@@ -1,4 +1,4 @@
-// The streambuf module provides helpers for buffering multiple packet payloads
+// Package streambuf provides helpers for buffering multiple packet payloads
 // and some general parsing functions. All parsing functions are re-entrant,
 // that is if a parse function fails due do not having buffered enough bytes yet
 // (error value ErrNoMoreBytes) the parser can be called again after appending more
@@ -221,7 +221,7 @@ func (b *Buffer) Failed() bool {
 	return failed
 }
 
-// Returns the error value of the last failed operation.
+// Err returns the error value of the last failed operation.
 func (b *Buffer) Err() error {
 	return b.err
 }
@@ -268,14 +268,14 @@ func (b *Buffer) Consume(n int) ([]byte, error) {
 		return nil, ErrOutOfRange
 	}
 
-	new_mark := b.mark - n
-	if new_mark < 0 {
+	newMark := b.mark - n
+	if newMark < 0 {
 		return nil, ErrOutOfRange
 	}
 
 	old := b.data[:n]
 	b.data = b.data[n:]
-	b.mark = new_mark
+	b.mark = newMark
 	b.offset -= n
 	b.available = len(b.data) - b.mark
 	return old, nil
@@ -309,9 +309,8 @@ func (b *Buffer) Bytes() []byte {
 func (b *Buffer) bufferEndError() error {
 	if b.fixed {
 		return b.SetError(ErrUnexpectedEOB)
-	} else {
-		return b.SetError(ErrNoMoreBytes)
 	}
+	return b.SetError(ErrNoMoreBytes)
 }
 
 // SetError marks a buffer as failed. Append and parse operations will fail with
@@ -338,7 +337,7 @@ func (b *Buffer) Collect(count int) ([]byte, error) {
 	return data, nil
 }
 
-// CollectWithDelimiter collects count bytes and checks delim will immediately
+// CollectWithSuffix collects count bytes and checks delim will immediately
 // follow the byte sequence. Returns count bytes without delim.
 // If delim is not matched ErrExpectedByteSequenceMismatch will be raised.
 func (b *Buffer) CollectWithSuffix(count int, delim []byte) ([]byte, error) {

--- a/libbeat/common/tuples.go
+++ b/libbeat/common/tuples.go
@@ -11,121 +11,121 @@ import (
 // We're introducing the HashableIpPortTuple and the HashableTcpTuple
 // types which are internally simple byte arrays.
 
-const MaxIpPortTupleRawSize = 16 + 16 + 2 + 2
+const MaxIPPortTupleRawSize = 16 + 16 + 2 + 2
 
-type HashableIpPortTuple [MaxIpPortTupleRawSize]byte
+type HashableIPPortTuple [MaxIPPortTupleRawSize]byte
 
-type IpPortTuple struct {
-	Ip_length          int
-	Src_ip, Dst_ip     net.IP
-	Src_port, Dst_port uint16
+type IPPortTuple struct {
+	IPLength         int
+	SrcIP, DstIP     net.IP
+	SrcPort, DstPort uint16
 
-	raw    HashableIpPortTuple // Src_ip:Src_port:Dst_ip:Dst_port
-	revRaw HashableIpPortTuple // Dst_ip:Dst_port:Src_ip:Src_port
+	raw    HashableIPPortTuple // Src_ip:Src_port:Dst_ip:Dst_port
+	revRaw HashableIPPortTuple // Dst_ip:Dst_port:Src_ip:Src_port
 }
 
-func NewIpPortTuple(ip_length int, src_ip net.IP, src_port uint16,
-	dst_ip net.IP, dst_port uint16) IpPortTuple {
+func NewIPPortTuple(ipLength int, srcIP net.IP, srcPort uint16,
+	dstIP net.IP, dstPort uint16) IPPortTuple {
 
-	tuple := IpPortTuple{
-		Ip_length: ip_length,
-		Src_ip:    src_ip,
-		Dst_ip:    dst_ip,
-		Src_port:  src_port,
-		Dst_port:  dst_port,
+	tuple := IPPortTuple{
+		IPLength: ipLength,
+		SrcIP:    srcIP,
+		DstIP:    dstIP,
+		SrcPort:  srcPort,
+		DstPort:  dstPort,
 	}
 	tuple.ComputeHashebles()
 
 	return tuple
 }
 
-func (t *IpPortTuple) ComputeHashebles() {
-	copy(t.raw[0:16], t.Src_ip)
-	copy(t.raw[16:18], []byte{byte(t.Src_port >> 8), byte(t.Src_port)})
-	copy(t.raw[18:34], t.Dst_ip)
-	copy(t.raw[34:36], []byte{byte(t.Dst_port >> 8), byte(t.Dst_port)})
+func (t *IPPortTuple) ComputeHashebles() {
+	copy(t.raw[0:16], t.SrcIP)
+	copy(t.raw[16:18], []byte{byte(t.SrcPort >> 8), byte(t.SrcPort)})
+	copy(t.raw[18:34], t.DstIP)
+	copy(t.raw[34:36], []byte{byte(t.DstPort >> 8), byte(t.DstPort)})
 
-	copy(t.revRaw[0:16], t.Dst_ip)
-	copy(t.revRaw[16:18], []byte{byte(t.Dst_port >> 8), byte(t.Dst_port)})
-	copy(t.revRaw[18:34], t.Src_ip)
-	copy(t.revRaw[34:36], []byte{byte(t.Src_port >> 8), byte(t.Src_port)})
+	copy(t.revRaw[0:16], t.DstIP)
+	copy(t.revRaw[16:18], []byte{byte(t.DstPort >> 8), byte(t.DstPort)})
+	copy(t.revRaw[18:34], t.SrcIP)
+	copy(t.revRaw[34:36], []byte{byte(t.SrcPort >> 8), byte(t.SrcPort)})
 }
 
-func (t *IpPortTuple) String() string {
+func (t *IPPortTuple) String() string {
 	return fmt.Sprintf("IpPortTuple src[%s:%d] dst[%s:%d]",
-		t.Src_ip.String(),
-		t.Src_port,
-		t.Dst_ip.String(),
-		t.Dst_port)
+		t.SrcIP.String(),
+		t.SrcPort,
+		t.DstIP.String(),
+		t.DstPort)
 }
 
 // Hashable returns a hashable value that uniquely identifies
 // the IP-port tuple.
-func (t *IpPortTuple) Hashable() HashableIpPortTuple {
+func (t *IPPortTuple) Hashable() HashableIPPortTuple {
 	return t.raw
 }
 
 // Hashable returns a hashable value that uniquely identifies
 // the IP-port tuple after swapping the source and destination.
-func (t *IpPortTuple) RevHashable() HashableIpPortTuple {
+func (t *IPPortTuple) RevHashable() HashableIPPortTuple {
 	return t.revRaw
 }
 
-const MaxTcpTupleRawSize = 16 + 16 + 2 + 2 + 4
+const MaxTCPTupleRawSize = 16 + 16 + 2 + 2 + 4
 
-type HashableTcpTuple [MaxTcpTupleRawSize]byte
+type HashableTCPTuple [MaxTCPTupleRawSize]byte
 
-type TcpTuple struct {
-	Ip_length          int
-	Src_ip, Dst_ip     net.IP
-	Src_port, Dst_port uint16
-	Stream_id          uint32
+type TCPTuple struct {
+	IPLength         int
+	SrcIP, DstIP     net.IP
+	SrcPort, DstPort uint16
+	StreamID         uint32
 
-	raw HashableTcpTuple // Src_ip:Src_port:Dst_ip:Dst_port:stream_id
+	raw HashableTCPTuple // Src_ip:Src_port:Dst_ip:Dst_port:stream_id
 }
 
-func TcpTupleFromIpPort(t *IpPortTuple, tcp_id uint32) TcpTuple {
-	tuple := TcpTuple{
-		Ip_length: t.Ip_length,
-		Src_ip:    t.Src_ip,
-		Dst_ip:    t.Dst_ip,
-		Src_port:  t.Src_port,
-		Dst_port:  t.Dst_port,
-		Stream_id: tcp_id,
+func TCPTupleFromIPPort(t *IPPortTuple, streamID uint32) TCPTuple {
+	tuple := TCPTuple{
+		IPLength: t.IPLength,
+		SrcIP:    t.SrcIP,
+		DstIP:    t.DstIP,
+		SrcPort:  t.SrcPort,
+		DstPort:  t.DstPort,
+		StreamID: streamID,
 	}
 	tuple.ComputeHashebles()
 
 	return tuple
 }
 
-func (t *TcpTuple) ComputeHashebles() {
-	copy(t.raw[0:16], t.Src_ip)
-	copy(t.raw[16:18], []byte{byte(t.Src_port >> 8), byte(t.Src_port)})
-	copy(t.raw[18:34], t.Dst_ip)
-	copy(t.raw[34:36], []byte{byte(t.Dst_port >> 8), byte(t.Dst_port)})
-	copy(t.raw[36:40], []byte{byte(t.Stream_id >> 24), byte(t.Stream_id >> 16),
-		byte(t.Stream_id >> 8), byte(t.Stream_id)})
+func (t *TCPTuple) ComputeHashebles() {
+	copy(t.raw[0:16], t.SrcIP)
+	copy(t.raw[16:18], []byte{byte(t.SrcPort >> 8), byte(t.SrcPort)})
+	copy(t.raw[18:34], t.DstIP)
+	copy(t.raw[34:36], []byte{byte(t.DstPort >> 8), byte(t.DstPort)})
+	copy(t.raw[36:40], []byte{byte(t.StreamID >> 24), byte(t.StreamID >> 16),
+		byte(t.StreamID >> 8), byte(t.StreamID)})
 }
 
-func (t TcpTuple) String() string {
+func (t TCPTuple) String() string {
 	return fmt.Sprintf("TcpTuple src[%s:%d] dst[%s:%d] stream_id[%d]",
-		t.Src_ip.String(),
-		t.Src_port,
-		t.Dst_ip.String(),
-		t.Dst_port,
-		t.Stream_id)
+		t.SrcIP.String(),
+		t.SrcPort,
+		t.DstIP.String(),
+		t.DstPort,
+		t.StreamID)
 }
 
 // Returns a pointer to the equivalent IpPortTuple.
-func (t TcpTuple) IpPort() *IpPortTuple {
-	ipport := NewIpPortTuple(t.Ip_length, t.Src_ip, t.Src_port,
-		t.Dst_ip, t.Dst_port)
+func (t TCPTuple) IPPort() *IPPortTuple {
+	ipport := NewIPPortTuple(t.IPLength, t.SrcIP, t.SrcPort,
+		t.DstIP, t.DstPort)
 	return &ipport
 }
 
 // Hashable() returns a hashable value that uniquely identifies
 // the TCP tuple.
-func (t *TcpTuple) Hashable() HashableTcpTuple {
+func (t *TCPTuple) Hashable() HashableTCPTuple {
 	return t.raw
 }
 

--- a/libbeat/common/tuples_test.go
+++ b/libbeat/common/tuples_test.go
@@ -12,12 +12,12 @@ import (
 func TestTuples_tuples_ipv4(t *testing.T) {
 	assert := assert.New(t)
 
-	var tuple IpPortTuple
+	var tuple IPPortTuple
 
 	// from net/ip.go
 	var v4InV6Prefix = []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff}
 
-	tuple = NewIpPortTuple(4, net.IPv4(192, 168, 0, 1), 9200, net.IPv4(192, 168, 0, 2), 9201)
+	tuple = NewIPPortTuple(4, net.IPv4(192, 168, 0, 1), 9200, net.IPv4(192, 168, 0, 2), 9201)
 
 	assert.Equal(v4InV6Prefix, tuple.raw[0:12], "prefix_src")
 	assert.Equal([]byte{192, 168, 0, 1}, tuple.raw[12:16], "src_ip")
@@ -37,17 +37,17 @@ func TestTuples_tuples_ipv4(t *testing.T) {
 	assert.Equal([]byte{0x23, 0xf0}, tuple.revRaw[34:36], "rev src_port")
 	assert.Equal(36, len(tuple.revRaw))
 
-	tcp_tuple := TcpTupleFromIpPort(&tuple, 1)
-	assert.Equal(tuple.raw[:], tcp_tuple.raw[0:36], "Wrong TCP tuple hashable")
-	assert.Equal([]byte{0, 0, 0, 1}, tcp_tuple.raw[36:40], "stream_id")
+	tcpTuple := TCPTupleFromIPPort(&tuple, 1)
+	assert.Equal(tuple.raw[:], tcpTuple.raw[0:36], "Wrong TCP tuple hashable")
+	assert.Equal([]byte{0, 0, 0, 1}, tcpTuple.raw[36:40], "stream_id")
 }
 
 func TestTuples_tuples_ipv6(t *testing.T) {
 	assert := assert.New(t)
 
-	var tuple IpPortTuple
+	var tuple IPPortTuple
 
-	tuple = NewIpPortTuple(16, net.ParseIP("2001:db8::1"),
+	tuple = NewIPPortTuple(16, net.ParseIP("2001:db8::1"),
 		9200, net.ParseIP("2001:db8::123:12:1"), 9201)
 
 	ip1 := []byte{0x20, 0x1, 0xd, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x1}
@@ -67,7 +67,7 @@ func TestTuples_tuples_ipv6(t *testing.T) {
 	assert.Equal([]byte{0x23, 0xf0}, tuple.revRaw[34:36], "rev src_port")
 	assert.Equal(36, len(tuple.revRaw))
 
-	tcp_tuple := TcpTupleFromIpPort(&tuple, 1)
-	assert.Equal(tuple.raw[:], tcp_tuple.raw[0:36], "Wrong TCP tuple hashable")
-	assert.Equal([]byte{0, 0, 0, 1}, tcp_tuple.raw[36:40], "stream_id")
+	tcpTuple := TCPTupleFromIPPort(&tuple, 1)
+	assert.Equal(tuple.raw[:], tcpTuple.raw[0:36], "Wrong TCP tuple hashable")
+	assert.Equal([]byte{0, 0, 0, 1}, tcpTuple.raw[36:40], "stream_id")
 }

--- a/libbeat/logp/file_rotator_test.go
+++ b/libbeat/logp/file_rotator_test.go
@@ -84,19 +84,19 @@ func Test_Rotator(t *testing.T) {
 		return
 	}
 
-	file_0, err := ioutil.ReadFile(rotator.FilePath(0))
-	if err != nil || bytes.Equal(file_0, []byte("4")) {
-		t.Errorf("Wrong contents of file 0: %s, expected: %s", string(file_0), "4")
+	file0, err := ioutil.ReadFile(rotator.FilePath(0))
+	if err != nil || bytes.Equal(file0, []byte("4")) {
+		t.Errorf("Wrong contents of file 0: %s, expected: %s", string(file0), "4")
 	}
 
-	file_1, err := ioutil.ReadFile(rotator.FilePath(1))
-	if err != nil || bytes.Equal(file_1, []byte("3")) {
-		t.Errorf("Wrong contents of file 1: %s", string(file_1))
+	file1, err := ioutil.ReadFile(rotator.FilePath(1))
+	if err != nil || bytes.Equal(file1, []byte("3")) {
+		t.Errorf("Wrong contents of file 1: %s", string(file1))
 	}
 
-	file_2, err := ioutil.ReadFile(rotator.FilePath(2))
-	if err != nil || bytes.Equal(file_2, []byte("2")) {
-		t.Errorf("Wrong contents of file 2: %s", string(file_2))
+	file2, err := ioutil.ReadFile(rotator.FilePath(2))
+	if err != nil || bytes.Equal(file2, []byte("2")) {
+		t.Errorf("Wrong contents of file 2: %s", string(file2))
 	}
 
 	if rotator.FileExists(3) {

--- a/libbeat/outputs/elasticsearch/client.go
+++ b/libbeat/outputs/elasticsearch/client.go
@@ -563,7 +563,7 @@ func (client *Client) PublishEvent(data outputs.Data) error {
 func (client *Client) LoadTemplate(templateName string, template map[string]interface{}) error {
 
 	path := "/_template/" + templateName
-	err := client.LoadJson(path, template)
+	err := client.LoadJSON(path, template)
 	if err != nil {
 		return fmt.Errorf("couldn't load template: %v", err)
 	}
@@ -571,7 +571,7 @@ func (client *Client) LoadTemplate(templateName string, template map[string]inte
 	return nil
 }
 
-func (client *Client) LoadJson(path string, json map[string]interface{}) error {
+func (client *Client) LoadJSON(path string, json map[string]interface{}) error {
 	status, _, err := client.request("PUT", path, "", nil, json)
 	if err != nil {
 		return fmt.Errorf("couldn't load json. Error: %s", err)

--- a/libbeat/outputs/elasticsearch/client_integration_test.go
+++ b/libbeat/outputs/elasticsearch/client_integration_test.go
@@ -29,7 +29,7 @@ func TestCheckTemplate(t *testing.T) {
 	err := client.Connect(5 * time.Second)
 	assert.Nil(t, err)
 
-	// Check for non existant template
+	// Check for non existent template
 	assert.False(t, client.CheckTemplate("libbeat-notexists"))
 }
 

--- a/libbeat/outputs/elasticsearch/json_read.go
+++ b/libbeat/outputs/elasticsearch/json_read.go
@@ -202,7 +202,7 @@ func (r *jsonReader) nextInt() (int, error) {
 	}
 
 	tmp := streambuf.NewFixed(raw)
-	i, err := tmp.AsciiInt(false)
+	i, err := tmp.IntASCII(false)
 	return int(i), err
 }
 
@@ -428,7 +428,7 @@ func (r *jsonReader) stepFalse() (entity, []byte, error) {
 }
 
 func stepSymbol(r *jsonReader, e entity, symb []byte, fail error) (entity, []byte, error) {
-	ok, err := r.AsciiMatch(symb)
+	ok, err := r.MatchASCII(symb)
 	if err != nil {
 		return failEntity, nil, err
 	}

--- a/libbeat/outputs/elasticsearch/output.go
+++ b/libbeat/outputs/elasticsearch/output.go
@@ -205,7 +205,7 @@ func readTemplate(filename string) (map[string]interface{}, error) {
 }
 
 // loadTemplate checks if the index mapping template should be loaded
-// In case the template is not already loaded or overwritting is enabled, the
+// In case the template is not already loaded or overwriting is enabled, the
 // template is written to index
 func (out *elasticsearchOutput) loadTemplate(config Template, client *Client) error {
 	out.templateMutex.Lock()

--- a/libbeat/outputs/elasticsearch/output_test.go
+++ b/libbeat/outputs/elasticsearch/output_test.go
@@ -16,7 +16,7 @@ import (
 
 var testOptions = outputs.Options{}
 
-func createElasticsearchConnection(flushInterval int, bulkSize int) elasticsearchOutput {
+func createElasticsearchConnection(flushInterval int, bulkSize int) *elasticsearchOutput {
 	index := fmt.Sprintf("packetbeat-int-test-%d", os.Getpid())
 
 	esPort, err := strconv.Atoi(GetEsPort())
@@ -39,7 +39,7 @@ func createElasticsearchConnection(flushInterval int, bulkSize int) elasticsearc
 		"template.enabled": false,
 	})
 
-	var output elasticsearchOutput
+	output := &elasticsearchOutput{beatName: "test"}
 	output.init(config, 10)
 	return output
 }
@@ -231,7 +231,7 @@ func TestEvents(t *testing.T) {
 	}
 }
 
-func testBulkWithParams(t *testing.T, output elasticsearchOutput) {
+func testBulkWithParams(t *testing.T, output *elasticsearchOutput) {
 	ts := time.Now()
 	index, _ := output.index.Select(common.MapStr{
 		"@timestamp": common.Time(ts),
@@ -302,12 +302,7 @@ func TestBulkEvents(t *testing.T) {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"topology", "output_elasticsearch", "elasticsearch"})
 	}
 
-	output := createElasticsearchConnection(50, 2)
-	testBulkWithParams(t, output)
-
-	output = createElasticsearchConnection(50, 1000)
-	testBulkWithParams(t, output)
-
-	output = createElasticsearchConnection(50, 5)
-	testBulkWithParams(t, output)
+	testBulkWithParams(t, createElasticsearchConnection(50, 2))
+	testBulkWithParams(t, createElasticsearchConnection(50, 1000))
+	testBulkWithParams(t, createElasticsearchConnection(50, 5))
 }

--- a/libbeat/outputs/logstash/sync.go
+++ b/libbeat/outputs/logstash/sync.go
@@ -66,21 +66,21 @@ func (c *client) PublishEvent(data outputs.Data) error {
 
 // PublishEvents sends all events to logstash. On error a slice with all events
 // not published or confirmed to be processed by logstash will be returned.
-func (l *client) PublishEvents(
+func (c *client) PublishEvents(
 	data []outputs.Data,
 ) ([]outputs.Data, error) {
 	publishEventsCallCount.Add(1)
 	totalNumberOfEvents := len(data)
 	for len(data) > 0 {
-		n, err := l.publishWindowed(data)
+		n, err := c.publishWindowed(data)
 
 		debug("%v events out of %v events sent to logstash. Continue sending",
 			n, len(data))
 
 		data = data[n:]
 		if err != nil {
-			l.win.shrinkWindow()
-			_ = l.Close()
+			c.win.shrinkWindow()
+			_ = c.Close()
 
 			logp.Err("Failed to publish events caused by: %v", err)
 

--- a/libbeat/outputs/mode/mode.go
+++ b/libbeat/outputs/mode/mode.go
@@ -64,7 +64,7 @@ type ProtocolClient interface {
 	PublishEvent(data outputs.Data) error
 }
 
-// AsyncProtocolClient interface is a output plugin specfic client implementation
+// AsyncProtocolClient interface is a output plugin specific client implementation
 // for asynchronous encoding and publishing events.
 type AsyncProtocolClient interface {
 	Connectable

--- a/libbeat/outputs/outputs.go
+++ b/libbeat/outputs/outputs.go
@@ -85,7 +85,7 @@ func InitOutputs(
 	configs map[string]*common.Config,
 	topologyExpire int,
 ) ([]OutputPlugin, error) {
-	var plugins []OutputPlugin = nil
+	var plugins []OutputPlugin
 	for name, plugin := range outputsPlugins {
 		config, exists := configs[name]
 		if !exists {

--- a/libbeat/outputs/redis/config_test.go
+++ b/libbeat/outputs/redis/config_test.go
@@ -7,21 +7,19 @@ import (
 )
 
 func TestValidate(t *testing.T) {
-	type io struct {
+	tests := []struct {
 		Name  string
 		Input redisConfig
 		Valid bool
-	}
+	}{
+		{"No config", redisConfig{Key: "", Index: ""}, true},
+		{"Only key", redisConfig{Key: "test", Index: ""}, true},
+		{"Only index", redisConfig{Key: "", Index: "test"}, true},
+		{"Both", redisConfig{Key: "test", Index: "test"}, false},
 
-	tests := []io{
-		io{"No config", redisConfig{Key: "", Index: ""}, true},
-		io{"Only key", redisConfig{Key: "test", Index: ""}, true},
-		io{"Only index", redisConfig{Key: "", Index: "test"}, true},
-		io{"Both", redisConfig{Key: "test", Index: "test"}, false},
-
-		io{"Invalid Datatype", redisConfig{Key: "test", DataType: "something"}, false},
-		io{"List Datatype", redisConfig{Key: "test", DataType: "list"}, true},
-		io{"Channel Datatype", redisConfig{Key: "test", DataType: "channel"}, true},
+		{"Invalid Datatype", redisConfig{Key: "test", DataType: "something"}, false},
+		{"List Datatype", redisConfig{Key: "test", DataType: "list"}, true},
+		{"Channel Datatype", redisConfig{Key: "test", DataType: "channel"}, true},
 	}
 
 	for _, test := range tests {

--- a/libbeat/paths/paths.go
+++ b/libbeat/paths/paths.go
@@ -1,4 +1,4 @@
-// Package libbeat.paths provides a common way to handle paths
+// Package paths provides a common way to handle paths
 // configuration for all Beats.
 //
 // Currently the following paths are defined:

--- a/libbeat/processors/actions/add_cloud_metadata_test.go
+++ b/libbeat/processors/actions/add_cloud_metadata_test.go
@@ -216,6 +216,10 @@ func TestRetrieveAWSMetadata(t *testing.T) {
 	}
 
 	actual, err := p.Run(common.MapStr{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	expected := common.MapStr{
 		"meta": common.MapStr{
 			"cloud": common.MapStr{
@@ -246,6 +250,10 @@ func TestRetrieveDigitalOceanMetadata(t *testing.T) {
 	}
 
 	actual, err := p.Run(common.MapStr{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	expected := common.MapStr{
 		"meta": common.MapStr{
 			"cloud": common.MapStr{
@@ -274,6 +282,10 @@ func TestRetrieveGCEMetadata(t *testing.T) {
 	}
 
 	actual, err := p.Run(common.MapStr{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	expected := common.MapStr{
 		"meta": common.MapStr{
 			"cloud": common.MapStr{

--- a/libbeat/processors/condition.go
+++ b/libbeat/processors/condition.go
@@ -77,16 +77,16 @@ func NewCondition(config *ConditionConfig) (*Condition, error) {
 			return nil, err
 		}
 	} else if len(config.OR) > 0 {
-		for _, cond_config := range config.OR {
-			cond, err := NewCondition(&cond_config)
+		for _, condConfig := range config.OR {
+			cond, err := NewCondition(&condConfig)
 			if err != nil {
 				return nil, err
 			}
 			c.or = append(c.or, *cond)
 		}
 	} else if len(config.AND) > 0 {
-		for _, cond_config := range config.AND {
-			cond, err := NewCondition(&cond_config)
+		for _, condConfig := range config.AND {
+			cond, err := NewCondition(&condConfig)
 			if err != nil {
 				return nil, err
 			}

--- a/libbeat/processors/condition_test.go
+++ b/libbeat/processors/condition_test.go
@@ -27,24 +27,24 @@ func TestBadCondition(t *testing.T) {
 	}
 
 	configs := []ConditionConfig{
-		ConditionConfig{
+		{
 			Equals: &ConditionFields{fields: map[string]interface{}{
 				"proc.pid": 0.08,
 			}},
 		},
 
-		ConditionConfig{
+		{
 			Range: &ConditionFields{fields: map[string]interface{}{
 				"gtr": 0.3,
 			}},
 		},
 
-		ConditionConfig{
+		{
 			Range: &ConditionFields{fields: map[string]interface{}{
 				"gt": "fdfdd",
 			}},
 		},
-		ConditionConfig{
+		{
 			Regexp: &ConditionFields{fields: map[string]interface{}{
 				"proc.name": "58gdhsga-=kw++w00",
 			}},
@@ -78,20 +78,20 @@ func TestEqualsCondition(t *testing.T) {
 	}
 
 	configs := []ConditionConfig{
-		ConditionConfig{
+		{
 			Equals: &ConditionFields{fields: map[string]interface{}{
 				"type": "process",
 			}},
 		},
 
-		ConditionConfig{
+		{
 			Equals: &ConditionFields{fields: map[string]interface{}{
 				"type":     "process",
 				"proc.pid": 305,
 			}},
 		},
 
-		ConditionConfig{
+		{
 			Range: &ConditionFields{fields: map[string]interface{}{
 				"proc.cpu.total_p.gt": 0.5,
 			}},
@@ -132,21 +132,21 @@ func TestContainsCondition(t *testing.T) {
 	}
 
 	configs := []ConditionConfig{
-		ConditionConfig{
+		{
 			Contains: &ConditionFields{fields: map[string]interface{}{
 				"proc.name":     "sec",
 				"proc.username": "monica",
 			}},
 		},
 
-		ConditionConfig{
+		{
 			Contains: &ConditionFields{fields: map[string]interface{}{
 				"type":      "process",
 				"proc.name": "secddd",
 			}},
 		},
 
-		ConditionConfig{
+		{
 			Contains: &ConditionFields{fields: map[string]interface{}{
 				"proc.keywords": "bar",
 			}},
@@ -188,19 +188,19 @@ func TestRegexpCondition(t *testing.T) {
 	}
 
 	configs := []ConditionConfig{
-		ConditionConfig{
+		{
 			Regexp: &ConditionFields{fields: map[string]interface{}{
 				"source": "apache2/error.*",
 			}},
 		},
 
-		ConditionConfig{
+		{
 			Regexp: &ConditionFields{fields: map[string]interface{}{
 				"source": "apache2/access.*",
 			}},
 		},
 
-		ConditionConfig{
+		{
 			Regexp: &ConditionFields{fields: map[string]interface{}{
 				"source":  "apache2/error.*",
 				"message": "[client 1.2.3.4]",
@@ -243,27 +243,27 @@ func TestRangeCondition(t *testing.T) {
 	}
 
 	configs := []ConditionConfig{
-		ConditionConfig{
+		{
 			Range: &ConditionFields{fields: map[string]interface{}{
 				"http.code.gte": 400,
 				"http.code.lt":  500,
 			}},
 		},
 
-		ConditionConfig{
+		{
 			Range: &ConditionFields{fields: map[string]interface{}{
 				"bytes_out.gte": 2800,
 			}},
 		},
 
-		ConditionConfig{
+		{
 			Range: &ConditionFields{fields: map[string]interface{}{
 				"bytes_out.gte":   2800,
 				"responsetime.gt": 30,
 			}},
 		},
 
-		ConditionConfig{
+		{
 			Range: &ConditionFields{fields: map[string]interface{}{
 				"proc.cpu.total_p.gte": 0.5,
 			}},
@@ -330,15 +330,15 @@ func TestORCondition(t *testing.T) {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"*"})
 	}
 	configs := []ConditionConfig{
-		ConditionConfig{
+		{
 			OR: []ConditionConfig{
-				ConditionConfig{
+				{
 					Range: &ConditionFields{fields: map[string]interface{}{
 						"http.code.gte": 400,
 						"http.code.lt":  500,
 					}},
 				},
-				ConditionConfig{
+				{
 					Range: &ConditionFields{fields: map[string]interface{}{
 						"http.code.gte": 200,
 						"http.code.lt":  300,
@@ -388,14 +388,14 @@ func TestANDCondition(t *testing.T) {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"*"})
 	}
 	configs := []ConditionConfig{
-		ConditionConfig{
+		{
 			AND: []ConditionConfig{
-				ConditionConfig{
+				{
 					Equals: &ConditionFields{fields: map[string]interface{}{
 						"client_server": "mar.local",
 					}},
 				},
-				ConditionConfig{
+				{
 					Range: &ConditionFields{fields: map[string]interface{}{
 						"http.code.gte": 400,
 						"http.code.lt":  500,
@@ -445,7 +445,7 @@ func TestNOTCondition(t *testing.T) {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"*"})
 	}
 	configs := []ConditionConfig{
-		ConditionConfig{
+		{
 			NOT: &ConditionConfig{
 				Equals: &ConditionFields{fields: map[string]interface{}{
 					"method": "GET",
@@ -494,22 +494,22 @@ func TestCombinedCondition(t *testing.T) {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"*"})
 	}
 	configs := []ConditionConfig{
-		ConditionConfig{
+		{
 			OR: []ConditionConfig{
-				ConditionConfig{
+				{
 					Range: &ConditionFields{fields: map[string]interface{}{
 						"http.code.gte": 100,
 						"http.code.lt":  300,
 					}},
 				},
-				ConditionConfig{
+				{
 					AND: []ConditionConfig{
-						ConditionConfig{
+						{
 							Equals: &ConditionFields{fields: map[string]interface{}{
 								"status": 200,
 							}},
 						},
-						ConditionConfig{
+						{
 							Equals: &ConditionFields{fields: map[string]interface{}{
 								"type": "http",
 							}},

--- a/libbeat/processors/config.go
+++ b/libbeat/processors/config.go
@@ -44,7 +44,7 @@ func (f *ConditionFields) Unpack(to interface{}) error {
 				expand(fmt.Sprintf("%v.%v", key, k), val)
 			}
 		case []interface{}:
-			for i, _ := range v {
+			for i := range v {
 				expand(fmt.Sprintf("%v.%v", key, i), v[i])
 			}
 		default:

--- a/libbeat/processors/processor.go
+++ b/libbeat/processors/processor.go
@@ -19,7 +19,7 @@ func New(config PluginConfig) (*Processors, error) {
 	for _, processor := range config {
 
 		if len(processor) != 1 {
-			return nil, fmt.Errorf("each processor needs to have exactly one action, but found %d actions.",
+			return nil, fmt.Errorf("each processor needs to have exactly one action, but found %d actions",
 				len(processor))
 		}
 

--- a/libbeat/processors/processor_test.go
+++ b/libbeat/processors/processor_test.go
@@ -41,7 +41,7 @@ func TestBadConfig(t *testing.T) {
 	}
 
 	yml := []map[string]interface{}{
-		map[string]interface{}{
+		{
 			"include_fields": map[string]interface{}{
 				"when": map[string]interface{}{
 					"contains": map[string]string{
@@ -82,7 +82,7 @@ func TestIncludeFields(t *testing.T) {
 	}
 
 	yml := []map[string]interface{}{
-		map[string]interface{}{
+		{
 			"include_fields": map[string]interface{}{
 				"when": map[string]interface{}{
 					"contains": map[string]string{
@@ -150,7 +150,7 @@ func TestIncludeFields1(t *testing.T) {
 	}
 
 	yml := []map[string]interface{}{
-		map[string]interface{}{
+		{
 			"include_fields": map[string]interface{}{
 				"when": map[string]interface{}{
 					"regexp": map[string]string{
@@ -203,7 +203,7 @@ func TestIncludeFields1(t *testing.T) {
 func TestDropFields(t *testing.T) {
 
 	yml := []map[string]interface{}{
-		map[string]interface{}{
+		{
 			"drop_fields": map[string]interface{}{
 				"when": map[string]interface{}{
 					"equals": map[string]string{
@@ -268,7 +268,7 @@ func TestMultipleIncludeFields(t *testing.T) {
 	}
 
 	yml := []map[string]interface{}{
-		map[string]interface{}{
+		{
 			"include_fields": map[string]interface{}{
 				"when": map[string]interface{}{
 					"contains": map[string]string{
@@ -278,7 +278,7 @@ func TestMultipleIncludeFields(t *testing.T) {
 				"fields": []string{"proc"},
 			},
 		},
-		map[string]interface{}{
+		{
 			"include_fields": map[string]interface{}{
 				"fields": []string{"proc.cpu.start_time", "proc.cpu.total_p", "proc.mem.rss_p", "proc.cmdline"},
 			},
@@ -365,7 +365,7 @@ func TestDropEvent(t *testing.T) {
 	}
 
 	yml := []map[string]interface{}{
-		map[string]interface{}{
+		{
 			"drop_event": map[string]interface{}{
 				"when": map[string]interface{}{
 					"range": map[string]interface{}{
@@ -418,7 +418,7 @@ func TestEmptyCondition(t *testing.T) {
 	}
 
 	yml := []map[string]interface{}{
-		map[string]interface{}{
+		{
 			"drop_event": map[string]interface{}{},
 		},
 	}
@@ -463,7 +463,7 @@ func TestBadCondition(t *testing.T) {
 	}
 
 	yml := []map[string]interface{}{
-		map[string]interface{}{
+		{
 			"drop_event": map[string]interface{}{
 				"when": map[string]interface{}{
 					"equal": map[string]string{
@@ -502,7 +502,7 @@ func TestMissingFields(t *testing.T) {
 	}
 
 	yml := []map[string]interface{}{
-		map[string]interface{}{
+		{
 			"include_fields": map[string]interface{}{
 				"when": map[string]interface{}{
 					"equals": map[string]string{
@@ -539,7 +539,7 @@ func TestBadConditionConfig(t *testing.T) {
 	}
 
 	yml := []map[string]interface{}{
-		map[string]interface{}{
+		{
 			"include_fields": map[string]interface{}{
 				"when": map[string]interface{}{
 					"fake": map[string]string{
@@ -573,7 +573,7 @@ func TestBadConditionConfig(t *testing.T) {
 func TestDropMissingFields(t *testing.T) {
 
 	yml := []map[string]interface{}{
-		map[string]interface{}{
+		{
 			"drop_fields": map[string]interface{}{
 				"fields": []string{"foo.bar", "proc.cpu", "proc.sss", "beat", "mem"},
 			},

--- a/libbeat/publisher/publish.go
+++ b/libbeat/publisher/publish.go
@@ -55,7 +55,7 @@ type BeatPublisher struct {
 	hostname       string // Host name as returned by the operation system
 	name           string // The shipperName if configured, the hostname otherwise
 	version        string
-	IpAddrs        []string
+	IPAddrs        []string
 	disabled       bool
 	Index          string
 	Output         []*outputWorker
@@ -87,7 +87,7 @@ type ShipperConfig struct {
 	common.EventMetadata `config:",inline"` // Fields and tags to add to each event.
 	Name                 string             `config:"name"`
 	RefreshTopologyFreq  time.Duration      `config:"refresh_topology_freq"`
-	Topology_expire      int                `config:"topology_expire"`
+	TopologyExpire       int                `config:"topology_expire"`
 	Geoip                common.Geoip       `config:"geoip"`
 
 	// internal publisher queue sizes
@@ -98,7 +98,7 @@ type ShipperConfig struct {
 
 type Topology struct {
 	Name string `json:"name"`
-	Ip   string `json:"ip"`
+	IP   string `json:"ip"`
 }
 
 const (
@@ -111,7 +111,7 @@ func init() {
 }
 
 func (publisher *BeatPublisher) IsPublisherIP(ip string) bool {
-	for _, myip := range publisher.IpAddrs {
+	for _, myip := range publisher.IPAddrs {
 		if myip == ip {
 			return true
 		}
@@ -160,7 +160,7 @@ func (publisher *BeatPublisher) PublishTopology(params ...string) error {
 
 	localAddrs := params
 	if len(params) == 0 {
-		addrs, err := common.LocalIpAddrsAsStrings(false)
+		addrs, err := common.LocalIPAddrsAsStrings(false)
 		if err != nil {
 			logp.Err("Getting local IP addresses fails with: %s", err)
 			return err
@@ -220,7 +220,7 @@ func (publisher *BeatPublisher) init(
 	publisher.wsOutput.Init()
 
 	if !publisher.disabled {
-		plugins, err := outputs.InitOutputs(beatName, configs, shipper.Topology_expire)
+		plugins, err := outputs.InitOutputs(beatName, configs, shipper.TopologyExpire)
 		if err != nil {
 			return err
 		}
@@ -293,7 +293,7 @@ func (publisher *BeatPublisher) init(
 	publisher.globalEventMetadata = shipper.EventMetadata
 
 	//Store the publisher's IP addresses
-	publisher.IpAddrs, err = common.LocalIpAddrsAsStrings(false)
+	publisher.IPAddrs, err = common.LocalIPAddrsAsStrings(false)
 	if err != nil {
 		logp.Err("Failed to get local IP addresses: %s", err)
 		return err

--- a/metricbeat/module/doc.go
+++ b/metricbeat/module/doc.go
@@ -31,7 +31,7 @@ List of standardised words and units across all metricsets. On the left are the 
 * day: days, d
 * max: maximumg
 * min: minimum
-* pct: precentage
+* pct: percentage
 * request: req
 * sec: seconds, second, s
 * ms: millisecond, millis

--- a/metricbeat/module/postgresql/postgresql.go
+++ b/metricbeat/module/postgresql/postgresql.go
@@ -23,7 +23,7 @@ func QueryStats(db *sql.DB, query string) ([]map[string]interface{}, error) {
 	}
 	vals := make([][]byte, len(columns))
 	valPointers := make([]interface{}, len(columns))
-	for i, _ := range vals {
+	for i := range vals {
 		valPointers[i] = &vals[i]
 	}
 

--- a/metricbeat/module/redis/keyspace/keyspace_integration_test.go
+++ b/metricbeat/module/redis/keyspace/keyspace_integration_test.go
@@ -59,6 +59,9 @@ func addEntry(t *testing.T) {
 	}
 	defer c.Close()
 	_, err = c.Do("SET", "foo", "bar")
+	if err != nil {
+		t.Fatal("SET", err)
+	}
 }
 
 func getConfig() map[string]interface{} {

--- a/metricbeat/module/system/cpu/cpu_test.go
+++ b/metricbeat/module/system/cpu/cpu_test.go
@@ -12,7 +12,7 @@ import (
 func TestData(t *testing.T) {
 	f := mbtest.NewEventFetcher(t, getConfig())
 
-	// Do a first fetch to have precentages
+	// Do a first fetch to have percentages
 	f.Fetch()
 	time.Sleep(1 * time.Second)
 

--- a/metricbeat/module/system/diskio/diskio_test.go
+++ b/metricbeat/module/system/diskio/diskio_test.go
@@ -14,7 +14,7 @@ import (
 func TestData(t *testing.T) {
 	f := mbtest.NewEventsFetcher(t, getConfig())
 
-	// Do a first fetch to have precentages
+	// Do a first fetch to have percentages
 	f.Fetch()
 	time.Sleep(1 * time.Second)
 

--- a/metricbeat/module/system/filesystem/filesystem_test.go
+++ b/metricbeat/module/system/filesystem/filesystem_test.go
@@ -13,7 +13,7 @@ import (
 func TestData(t *testing.T) {
 	f := mbtest.NewEventsFetcher(t, getConfig())
 
-	// Do a first fetch to have precentages
+	// Do a first fetch to have percentages
 	f.Fetch()
 	time.Sleep(1 * time.Second)
 

--- a/metricbeat/module/system/fsstat/fsstat_test.go
+++ b/metricbeat/module/system/fsstat/fsstat_test.go
@@ -13,7 +13,7 @@ import (
 func TestData(t *testing.T) {
 	f := mbtest.NewEventFetcher(t, getConfig())
 
-	// Do a first fetch to have precentages
+	// Do a first fetch to have percentages
 	f.Fetch()
 	time.Sleep(1 * time.Second)
 

--- a/packetbeat/beater/packetbeat.go
+++ b/packetbeat/beater/packetbeat.go
@@ -123,7 +123,7 @@ func (pb *Packetbeat) init(b *beat.Beat) error {
 
 func (pb *Packetbeat) Run(b *beat.Beat) error {
 	defer func() {
-		if service.WithMemProfile() {
+		if service.ProfileEnabled() {
 			logp.Debug("main", "Waiting for streams and transactions to expire...")
 			time.Sleep(time.Duration(float64(protos.DefaultTransactionExpiration) * 1.2))
 			logp.Debug("main", "Streams and transactions should all be expired now.")

--- a/packetbeat/decoder/decoder.go
+++ b/packetbeat/decoder/decoder.go
@@ -221,9 +221,9 @@ func (d *DecoderStruct) process(
 			d.flowID.AddIPv4(ip4.SrcIP, ip4.DstIP)
 		}
 
-		packet.Tuple.Src_ip = ip4.SrcIP
-		packet.Tuple.Dst_ip = ip4.DstIP
-		packet.Tuple.Ip_length = 4
+		packet.Tuple.SrcIP = ip4.SrcIP
+		packet.Tuple.DstIP = ip4.DstIP
+		packet.Tuple.IPLength = 4
 
 	case layers.LayerTypeIPv6:
 		debugf("IPv6 packet")
@@ -234,9 +234,9 @@ func (d *DecoderStruct) process(
 			d.flowID.AddIPv6(ip6.SrcIP, ip6.DstIP)
 		}
 
-		packet.Tuple.Src_ip = ip6.SrcIP
-		packet.Tuple.Dst_ip = ip6.DstIP
-		packet.Tuple.Ip_length = 16
+		packet.Tuple.SrcIP = ip6.SrcIP
+		packet.Tuple.DstIP = ip6.DstIP
+		packet.Tuple.IPLength = 16
 
 	case layers.LayerTypeICMPv4:
 		debugf("ICMPv4 packet")
@@ -287,8 +287,8 @@ func (d *DecoderStruct) onUDP(packet *protos.Packet) {
 		d.flowID.AddUDP(src, dst)
 	}
 
-	packet.Tuple.Src_port = src
-	packet.Tuple.Dst_port = dst
+	packet.Tuple.SrcPort = src
+	packet.Tuple.DstPort = dst
 	packet.Payload = d.udp.Payload
 	packet.Tuple.ComputeHashebles()
 
@@ -304,8 +304,8 @@ func (d *DecoderStruct) onTCP(packet *protos.Packet) {
 		id.AddTCP(src, dst)
 	}
 
-	packet.Tuple.Src_port = src
-	packet.Tuple.Dst_port = dst
+	packet.Tuple.SrcPort = src
+	packet.Tuple.DstPort = dst
 	packet.Payload = d.tcp.Payload
 
 	if id == nil && len(packet.Payload) == 0 && !d.tcp.FIN {

--- a/packetbeat/decoder/decoder_test.go
+++ b/packetbeat/decoder/decoder_test.go
@@ -77,10 +77,10 @@ func TestDecodePacketData_ipv4Tcp(t *testing.T) {
 	d.OnPacket(p.Data(), &p.Metadata().CaptureInfo)
 
 	assert.NotNil(t, tcp.pkt, "TCP packet not received")
-	assert.Equal(t, "172.16.16.164", tcp.pkt.Tuple.Src_ip.String())
-	assert.Equal(t, uint16(1108), tcp.pkt.Tuple.Src_port)
-	assert.Equal(t, "172.16.16.139", tcp.pkt.Tuple.Dst_ip.String())
-	assert.Equal(t, uint16(53), tcp.pkt.Tuple.Dst_port)
+	assert.Equal(t, "172.16.16.164", tcp.pkt.Tuple.SrcIP.String())
+	assert.Equal(t, uint16(1108), tcp.pkt.Tuple.SrcPort)
+	assert.Equal(t, "172.16.16.139", tcp.pkt.Tuple.DstIP.String())
+	assert.Equal(t, uint16(53), tcp.pkt.Tuple.DstPort)
 	assert.NotEqual(t, -1, strings.Index(string(p.Data()), string(tcp.pkt.Payload)))
 }
 
@@ -103,10 +103,10 @@ func TestDecodePacketData_ipv4Udp(t *testing.T) {
 	d.OnPacket(p.Data(), &p.Metadata().CaptureInfo)
 
 	assert.NotNil(t, udp.pkt, "UDP packet not received")
-	assert.Equal(t, "192.168.170.8", udp.pkt.Tuple.Src_ip.String())
-	assert.Equal(t, uint16(32795), udp.pkt.Tuple.Src_port)
-	assert.Equal(t, "192.168.170.20", udp.pkt.Tuple.Dst_ip.String())
-	assert.Equal(t, uint16(53), udp.pkt.Tuple.Dst_port)
+	assert.Equal(t, "192.168.170.8", udp.pkt.Tuple.SrcIP.String())
+	assert.Equal(t, uint16(32795), udp.pkt.Tuple.SrcPort)
+	assert.Equal(t, "192.168.170.20", udp.pkt.Tuple.DstIP.String())
+	assert.Equal(t, uint16(53), udp.pkt.Tuple.DstPort)
 	assert.NotEqual(t, -1, strings.Index(string(p.Data()), string(udp.pkt.Payload)))
 }
 
@@ -144,10 +144,10 @@ func TestDecodePacketData_ipv6Tcp(t *testing.T) {
 	d.OnPacket(p.Data(), &p.Metadata().CaptureInfo)
 
 	assert.NotNil(t, tcp.pkt, "TCP packet not received")
-	assert.Equal(t, "2001:6f8:102d:0:2d0:9ff:fee3:e8de", tcp.pkt.Tuple.Src_ip.String())
-	assert.Equal(t, uint16(59201), tcp.pkt.Tuple.Src_port)
-	assert.Equal(t, "2001:6f8:900:7c0::2", tcp.pkt.Tuple.Dst_ip.String())
-	assert.Equal(t, uint16(80), tcp.pkt.Tuple.Dst_port)
+	assert.Equal(t, "2001:6f8:102d:0:2d0:9ff:fee3:e8de", tcp.pkt.Tuple.SrcIP.String())
+	assert.Equal(t, uint16(59201), tcp.pkt.Tuple.SrcPort)
+	assert.Equal(t, "2001:6f8:900:7c0::2", tcp.pkt.Tuple.DstIP.String())
+	assert.Equal(t, uint16(80), tcp.pkt.Tuple.DstPort)
 	assert.NotEqual(t, -1, strings.Index(string(p.Data()), string(tcp.pkt.Payload)))
 }
 
@@ -175,10 +175,10 @@ func TestDecodePacketData_ipv6Udp(t *testing.T) {
 	d.OnPacket(p.Data(), &p.Metadata().CaptureInfo)
 
 	assert.NotNil(t, udp.pkt, "UDP packet not received")
-	assert.Equal(t, "3ffe:507:0:1:200:86ff:fe05:80da", udp.pkt.Tuple.Src_ip.String())
-	assert.Equal(t, uint16(2415), udp.pkt.Tuple.Src_port)
-	assert.Equal(t, "3ffe:501:4819::42", udp.pkt.Tuple.Dst_ip.String())
-	assert.Equal(t, uint16(53), udp.pkt.Tuple.Dst_port)
+	assert.Equal(t, "3ffe:507:0:1:200:86ff:fe05:80da", udp.pkt.Tuple.SrcIP.String())
+	assert.Equal(t, uint16(2415), udp.pkt.Tuple.SrcPort)
+	assert.Equal(t, "3ffe:501:4819::42", udp.pkt.Tuple.DstIP.String())
+	assert.Equal(t, uint16(53), udp.pkt.Tuple.DstPort)
 	assert.NotEqual(t, -1, strings.Index(string(p.Data()), string(udp.pkt.Payload)))
 }
 

--- a/packetbeat/procs/procs.go
+++ b/packetbeat/procs/procs.go
@@ -105,7 +105,7 @@ func (proc *ProcessesWatcher) Init(config ProcsConfig) error {
 
 	// Read the local IP addresses
 	var err error
-	proc.LocalAddrs, err = common.LocalIpAddrs()
+	proc.LocalAddrs, err = common.LocalIPAddrs()
 	if err != nil {
 		logp.Err("Error getting local IP addresses: %s", err)
 		proc.LocalAddrs = []net.IP{}
@@ -194,26 +194,26 @@ func FindPidsByCmdlineGrep(prefix string, process string) ([]int, error) {
 	return pids, nil
 }
 
-func (proc *ProcessesWatcher) FindProcessesTuple(tuple *common.IpPortTuple) (proc_tuple *common.CmdlineTuple) {
+func (proc *ProcessesWatcher) FindProcessesTuple(tuple *common.IPPortTuple) (proc_tuple *common.CmdlineTuple) {
 	proc_tuple = &common.CmdlineTuple{}
 
 	if !proc.ReadFromProc {
 		return
 	}
 
-	if proc.IsLocalIp(tuple.Src_ip) {
-		logp.Debug("procs", "Looking for port %d", tuple.Src_port)
-		proc_tuple.Src = []byte(proc.FindProc(tuple.Src_port))
+	if proc.IsLocalIp(tuple.SrcIP) {
+		logp.Debug("procs", "Looking for port %d", tuple.SrcPort)
+		proc_tuple.Src = []byte(proc.FindProc(tuple.SrcPort))
 		if len(proc_tuple.Src) > 0 {
-			logp.Debug("procs", "Found device %s for port %d", proc_tuple.Src, tuple.Src_port)
+			logp.Debug("procs", "Found device %s for port %d", proc_tuple.Src, tuple.SrcPort)
 		}
 	}
 
-	if proc.IsLocalIp(tuple.Dst_ip) {
-		logp.Debug("procs", "Looking for port %d", tuple.Dst_port)
-		proc_tuple.Dst = []byte(proc.FindProc(tuple.Dst_port))
+	if proc.IsLocalIp(tuple.DstIP) {
+		logp.Debug("procs", "Looking for port %d", tuple.DstPort)
+		proc_tuple.Dst = []byte(proc.FindProc(tuple.DstPort))
 		if len(proc_tuple.Dst) > 0 {
-			logp.Debug("procs", "Found device %s for port %d", proc_tuple.Dst, tuple.Dst_port)
+			logp.Debug("procs", "Found device %s for port %d", proc_tuple.Dst, tuple.DstPort)
 		}
 	}
 

--- a/packetbeat/protos/amqp/amqp.go
+++ b/packetbeat/protos/amqp/amqp.go
@@ -171,7 +171,7 @@ func (amqp *Amqp) ConnectionTimeout() time.Duration {
 	return amqp.transactionTimeout
 }
 
-func (amqp *Amqp) Parse(pkt *protos.Packet, tcptuple *common.TcpTuple,
+func (amqp *Amqp) Parse(pkt *protos.Packet, tcptuple *common.TCPTuple,
 	dir uint8, private protos.ProtocolData) protos.ProtocolData {
 
 	defer logp.Recover("ParseAmqp exception")
@@ -224,13 +224,13 @@ func (amqp *Amqp) Parse(pkt *protos.Packet, tcptuple *common.TcpTuple,
 	return priv
 }
 
-func (amqp *Amqp) GapInStream(tcptuple *common.TcpTuple, dir uint8,
+func (amqp *Amqp) GapInStream(tcptuple *common.TCPTuple, dir uint8,
 	nbytes int, private protos.ProtocolData) (priv protos.ProtocolData, drop bool) {
 	detailedf("GapInStream called")
 	return private, true
 }
 
-func (amqp *Amqp) ReceivedFin(tcptuple *common.TcpTuple, dir uint8,
+func (amqp *Amqp) ReceivedFin(tcptuple *common.TCPTuple, dir uint8,
 	private protos.ProtocolData) protos.ProtocolData {
 	return private
 }
@@ -254,13 +254,13 @@ func (amqp *Amqp) handleAmqpRequest(msg *AmqpMessage) {
 	trans.Ts = trans.ts.UnixNano() / 1000
 	trans.JsTs = msg.Ts
 	trans.Src = common.Endpoint{
-		Ip:   msg.TcpTuple.Src_ip.String(),
-		Port: msg.TcpTuple.Src_port,
+		IP:   msg.TcpTuple.SrcIP.String(),
+		Port: msg.TcpTuple.SrcPort,
 		Proc: string(msg.CmdlineTuple.Src),
 	}
 	trans.Dst = common.Endpoint{
-		Ip:   msg.TcpTuple.Dst_ip.String(),
-		Port: msg.TcpTuple.Dst_port,
+		IP:   msg.TcpTuple.DstIP.String(),
+		Port: msg.TcpTuple.DstPort,
 		Proc: string(msg.CmdlineTuple.Dst),
 	}
 	if msg.Direction == tcp.TcpDirectionReverse {
@@ -360,13 +360,13 @@ func (amqp *Amqp) handlePublishing(client *AmqpMessage) {
 	trans.Ts = client.Ts.UnixNano() / 1000
 	trans.JsTs = client.Ts
 	trans.Src = common.Endpoint{
-		Ip:   client.TcpTuple.Src_ip.String(),
-		Port: client.TcpTuple.Src_port,
+		IP:   client.TcpTuple.SrcIP.String(),
+		Port: client.TcpTuple.SrcPort,
 		Proc: string(client.CmdlineTuple.Src),
 	}
 	trans.Dst = common.Endpoint{
-		Ip:   client.TcpTuple.Dst_ip.String(),
-		Port: client.TcpTuple.Dst_port,
+		IP:   client.TcpTuple.DstIP.String(),
+		Port: client.TcpTuple.DstPort,
 		Proc: string(client.CmdlineTuple.Dst),
 	}
 
@@ -407,13 +407,13 @@ func (amqp *Amqp) handleDelivering(server *AmqpMessage) {
 	trans.Ts = server.Ts.UnixNano() / 1000
 	trans.JsTs = server.Ts
 	trans.Src = common.Endpoint{
-		Ip:   server.TcpTuple.Src_ip.String(),
-		Port: server.TcpTuple.Src_port,
+		IP:   server.TcpTuple.SrcIP.String(),
+		Port: server.TcpTuple.SrcPort,
 		Proc: string(server.CmdlineTuple.Src),
 	}
 	trans.Dst = common.Endpoint{
-		Ip:   server.TcpTuple.Dst_ip.String(),
-		Port: server.TcpTuple.Dst_port,
+		IP:   server.TcpTuple.DstIP.String(),
+		Port: server.TcpTuple.DstPort,
 		Proc: string(server.CmdlineTuple.Dst),
 	}
 
@@ -546,7 +546,7 @@ func isStringable(m *AmqpMessage) bool {
 	return stringable
 }
 
-func (amqp *Amqp) getTransaction(k common.HashableTcpTuple) *AmqpTransaction {
+func (amqp *Amqp) getTransaction(k common.HashableTCPTuple) *AmqpTransaction {
 	v := amqp.transactions.Get(k)
 	if v != nil {
 		return v.(*AmqpTransaction)

--- a/packetbeat/protos/amqp/amqp.go
+++ b/packetbeat/protos/amqp/amqp.go
@@ -79,15 +79,15 @@ func (amqp *Amqp) init(results publish.Transactions, config *amqpConfig) error {
 
 func (amqp *Amqp) initMethodMap() {
 	amqp.MethodMap = map[codeClass]map[codeMethod]AmqpMethod{
-		connectionCode: map[codeMethod]AmqpMethod{
+		connectionCode: {
 			connectionClose:   connectionCloseMethod,
 			connectionCloseOk: okMethod,
 		},
-		channelCode: map[codeMethod]AmqpMethod{
+		channelCode: {
 			channelClose:   channelCloseMethod,
 			channelCloseOk: okMethod,
 		},
-		exchangeCode: map[codeMethod]AmqpMethod{
+		exchangeCode: {
 			exchangeDeclare:   exchangeDeclareMethod,
 			exchangeDeclareOk: okMethod,
 			exchangeDelete:    exchangeDeleteMethod,
@@ -97,7 +97,7 @@ func (amqp *Amqp) initMethodMap() {
 			exchangeUnbind:    exchangeUnbindMethod,
 			exchangeUnbindOk:  okMethod,
 		},
-		queueCode: map[codeMethod]AmqpMethod{
+		queueCode: {
 			queueDeclare:   queueDeclareMethod,
 			queueDeclareOk: queueDeclareOkMethod,
 			queueBind:      queueBindMethod,
@@ -109,7 +109,7 @@ func (amqp *Amqp) initMethodMap() {
 			queueDelete:    queueDeleteMethod,
 			queueDeleteOk:  queueDeleteOkMethod,
 		},
-		basicCode: map[codeMethod]AmqpMethod{
+		basicCode: {
 			basicConsume:   basicConsumeMethod,
 			basicConsumeOk: basicConsumeOkMethod,
 			basicCancel:    basicCancelMethod,
@@ -126,7 +126,7 @@ func (amqp *Amqp) initMethodMap() {
 			basicRecoverOk: okMethod,
 			basicNack:      basicNackMethod,
 		},
-		txCode: map[codeMethod]AmqpMethod{
+		txCode: {
 			txSelect:     txSelectMethod,
 			txSelectOk:   okMethod,
 			txCommit:     txCommitMethod,
@@ -251,7 +251,7 @@ func (amqp *Amqp) handleAmqpRequest(msg *AmqpMessage) {
 	}
 
 	trans.ts = msg.Ts
-	trans.Ts = int64(trans.ts.UnixNano() / 1000)
+	trans.Ts = trans.ts.UnixNano() / 1000
 	trans.JsTs = msg.Ts
 	trans.Src = common.Endpoint{
 		Ip:   msg.TcpTuple.Src_ip.String(),
@@ -357,7 +357,7 @@ func (amqp *Amqp) handlePublishing(client *AmqpMessage) {
 	}
 
 	trans.ts = client.Ts
-	trans.Ts = int64(client.Ts.UnixNano() / 1000)
+	trans.Ts = client.Ts.UnixNano() / 1000
 	trans.JsTs = client.Ts
 	trans.Src = common.Endpoint{
 		Ip:   client.TcpTuple.Src_ip.String(),
@@ -404,7 +404,7 @@ func (amqp *Amqp) handleDelivering(server *AmqpMessage) {
 	}
 
 	trans.ts = server.Ts
-	trans.Ts = int64(server.Ts.UnixNano() / 1000)
+	trans.Ts = server.Ts.UnixNano() / 1000
 	trans.JsTs = server.Ts
 	trans.Src = common.Endpoint{
 		Ip:   server.TcpTuple.Src_ip.String(),

--- a/packetbeat/protos/amqp/amqp_methods.go
+++ b/packetbeat/protos/amqp/amqp_methods.go
@@ -584,7 +584,7 @@ func basicReturnMethod(m *AmqpMessage, args []byte) (bool, bool) {
 		logp.Warn("Error getting name of exchange in basic return")
 		return false, false
 	}
-	routingKey, nextOffset, err := getShortString(args, nextOffset+1, uint32(args[nextOffset]))
+	routingKey, _, err := getShortString(args, nextOffset+1, uint32(args[nextOffset]))
 	if err {
 		logp.Warn("Error getting name of routing key in basic return")
 		return false, false

--- a/packetbeat/protos/amqp/amqp_methods.go
+++ b/packetbeat/protos/amqp/amqp_methods.go
@@ -2,10 +2,11 @@ package amqp
 
 import (
 	"encoding/binary"
-	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/logp"
 	"strconv"
 	"strings"
+
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/logp"
 )
 
 func connectionStartMethod(m *AmqpMessage, args []byte) (bool, bool) {
@@ -81,7 +82,7 @@ func connectionStartOkMethod(m *AmqpMessage, args []byte) (bool, bool) {
 func connectionTuneMethod(m *AmqpMessage, args []byte) (bool, bool) {
 	m.IsRequest = true
 	m.Method = "connection.tune"
-	//parameters are not parsed here, they are further negociated by the server
+	//parameters are not parsed here, they are further negotiated by the server
 	//in the connection.tune-ok method
 	return true, true
 }

--- a/packetbeat/protos/amqp/amqp_parser.go
+++ b/packetbeat/protos/amqp/amqp_parser.go
@@ -312,14 +312,14 @@ func getMessageProperties(s *AmqpStream, data []byte) bool {
 	return false
 }
 
-func (amqp *Amqp) handleAmqp(m *AmqpMessage, tcptuple *common.TcpTuple, dir uint8) {
+func (amqp *Amqp) handleAmqp(m *AmqpMessage, tcptuple *common.TCPTuple, dir uint8) {
 	if amqp.mustHideCloseMethod(m) {
 		return
 	}
 	debugf("A message is ready to be handled")
 	m.TcpTuple = *tcptuple
 	m.Direction = dir
-	m.CmdlineTuple = procs.ProcWatcher.FindProcessesTuple(tcptuple.IpPort())
+	m.CmdlineTuple = procs.ProcWatcher.FindProcessesTuple(tcptuple.IPPort())
 
 	if m.Method == "basic.publish" {
 		amqp.handlePublishing(m)

--- a/packetbeat/protos/amqp/amqp_parser.go
+++ b/packetbeat/protos/amqp/amqp_parser.go
@@ -2,10 +2,11 @@ package amqp
 
 import (
 	"encoding/binary"
+	"time"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/packetbeat/procs"
-	"time"
 )
 
 func (amqp *Amqp) amqpMessageParser(s *AmqpStream) (ok bool, complete bool) {
@@ -301,13 +302,12 @@ func getMessageProperties(s *AmqpStream, data []byte) bool {
 	}
 
 	if hasProperty(prop2, appIdProp) {
-		appId, next, err := getShortString(data, offset+1, uint32(data[offset]))
+		appId, _, err := getShortString(data, offset+1, uint32(data[offset]))
 		if err {
 			logp.Warn("Failed to get app-id in header frame")
 			return true
 		}
 		m.Fields["app-id"] = appId
-		offset = next
 	}
 	return false
 }

--- a/packetbeat/protos/amqp/amqp_structs.go
+++ b/packetbeat/protos/amqp/amqp_structs.go
@@ -174,7 +174,7 @@ type AmqpFrame struct {
 
 type AmqpMessage struct {
 	Ts             time.Time
-	TcpTuple       common.TcpTuple
+	TcpTuple       common.TCPTuple
 	CmdlineTuple   *common.CmdlineTuple
 	Method         string
 	IsRequest      bool
@@ -193,7 +193,7 @@ type AmqpMessage struct {
 
 // represent a stream of data to be parsed
 type AmqpStream struct {
-	tcptuple *common.TcpTuple
+	tcptuple *common.TCPTuple
 
 	data        []byte
 	parseOffset int
@@ -204,7 +204,7 @@ type AmqpStream struct {
 // contains the result of parsing
 type AmqpTransaction struct {
 	Type  string
-	tuple common.TcpTuple
+	tuple common.TCPTuple
 	Src   common.Endpoint
 	Dst   common.Endpoint
 	Ts    int64

--- a/packetbeat/protos/amqp/amqp_test.go
+++ b/packetbeat/protos/amqp/amqp_test.go
@@ -20,11 +20,11 @@ func AmqpModForTests() *Amqp {
 	return &amqp
 }
 
-func testTcpTuple() *common.TcpTuple {
-	t := &common.TcpTuple{
-		Ip_length: 4,
-		Src_ip:    net.IPv4(192, 168, 0, 1), Dst_ip: net.IPv4(192, 168, 0, 2),
-		Src_port: 6512, Dst_port: 3306,
+func testTcpTuple() *common.TCPTuple {
+	t := &common.TCPTuple{
+		IPLength: 4,
+		SrcIP:    net.IPv4(192, 168, 0, 1), DstIP: net.IPv4(192, 168, 0, 2),
+		SrcPort: 6512, DstPort: 3306,
 	}
 	t.ComputeHashebles()
 	return t

--- a/packetbeat/protos/amqp/amqp_test.go
+++ b/packetbeat/protos/amqp/amqp_test.go
@@ -291,7 +291,7 @@ func TestAmqp_ExchangeUnbindTransaction(t *testing.T) {
 	private := protos.ProtocolData(new(amqpPrivateData))
 	private = amqp.Parse(&req, tcptuple, 0, private)
 	req = protos.Packet{Payload: data2}
-	private = amqp.Parse(&req, tcptuple, 1, private)
+	amqp.Parse(&req, tcptuple, 1, private)
 
 	trans := expectTransaction(t, amqp)
 	assert.Equal(t, "exchange.unbind", trans["method"])
@@ -339,7 +339,7 @@ func TestAmqp_PublishMessage(t *testing.T) {
 	private = amqp.Parse(&req, tcptuple, 0, private)
 	req = protos.Packet{Payload: data3}
 	//body frame
-	private = amqp.Parse(&req, tcptuple, 0, private)
+	amqp.Parse(&req, tcptuple, 0, private)
 
 	trans := expectTransaction(t, amqp)
 
@@ -390,7 +390,7 @@ func TestAmqp_DeliverMessage(t *testing.T) {
 	private = amqp.Parse(&req, tcptuple, 0, private)
 	req = protos.Packet{Payload: data3}
 	//body frame
-	private = amqp.Parse(&req, tcptuple, 0, private)
+	amqp.Parse(&req, tcptuple, 0, private)
 
 	trans := expectTransaction(t, amqp)
 
@@ -521,7 +521,7 @@ func TestAmqp_NoWaitQueueDeleteMethod(t *testing.T) {
 	req := protos.Packet{Payload: data}
 	private := protos.ProtocolData(new(amqpPrivateData))
 
-	private = amqp.Parse(&req, tcptuple, 0, private)
+	amqp.Parse(&req, tcptuple, 0, private)
 
 	trans := expectTransaction(t, amqp)
 
@@ -555,7 +555,7 @@ func TestAmqp_RejectMessage(t *testing.T) {
 	private := protos.ProtocolData(new(amqpPrivateData))
 
 	//method frame
-	private = amqp.Parse(&req, tcptuple, 0, private)
+	amqp.Parse(&req, tcptuple, 0, private)
 
 	trans := expectTransaction(t, amqp)
 
@@ -590,7 +590,7 @@ func TestAmqp_GetEmptyMethod(t *testing.T) {
 	private := protos.ProtocolData(new(amqpPrivateData))
 	private = amqp.Parse(&req, tcptuple, 0, private)
 	req = protos.Packet{Payload: data2}
-	private = amqp.Parse(&req, tcptuple, 1, private)
+	amqp.Parse(&req, tcptuple, 1, private)
 
 	trans := expectTransaction(t, amqp)
 	assert.Equal(t, "basic.get-empty", trans["method"])
@@ -623,7 +623,7 @@ func TestAmqp_GetMethod(t *testing.T) {
 	private := protos.ProtocolData(new(amqpPrivateData))
 	private = amqp.Parse(&req, tcptuple, 0, private)
 	req = protos.Packet{Payload: data2}
-	private = amqp.Parse(&req, tcptuple, 1, private)
+	amqp.Parse(&req, tcptuple, 1, private)
 
 	trans := expectTransaction(t, amqp)
 	assert.Equal(t, "basic.get", trans["method"])
@@ -684,7 +684,7 @@ func TestAmqp_MaxBodyLength(t *testing.T) {
 	private = protos.ProtocolData(new(amqpPrivateData))
 
 	//method frame
-	private = amqp.Parse(&req, tcptuple, 0, private)
+	amqp.Parse(&req, tcptuple, 0, private)
 
 	trans = expectTransaction(t, amqp)
 
@@ -748,7 +748,7 @@ func TestAmqp_HideArguments(t *testing.T) {
 	tcptuple = testTcpTuple()
 	req = protos.Packet{Payload: data}
 	private = protos.ProtocolData(new(amqpPrivateData))
-	private = amqp.Parse(&req, tcptuple, 0, private)
+	amqp.Parse(&req, tcptuple, 0, private)
 	trans = expectTransaction(t, amqp)
 	assert.Equal(t, "basic.publish", trans["method"])
 	assert.Equal(t, "amqp", trans["type"])
@@ -786,7 +786,7 @@ func TestAmqp_RecoverMethod(t *testing.T) {
 	private := protos.ProtocolData(new(amqpPrivateData))
 	private = amqp.Parse(&req, tcptuple, 0, private)
 	req = protos.Packet{Payload: data2}
-	private = amqp.Parse(&req, tcptuple, 1, private)
+	amqp.Parse(&req, tcptuple, 1, private)
 
 	trans := expectTransaction(t, amqp)
 	assert.Equal(t, "basic.recover", trans["method"])
@@ -1112,7 +1112,7 @@ func TestAmqp_ChannelCloseErrorMethod(t *testing.T) {
 	private := protos.ProtocolData(new(amqpPrivateData))
 	private = amqp.Parse(&req, tcptuple, 0, private)
 	req = protos.Packet{Payload: data2}
-	private = amqp.Parse(&req, tcptuple, 1, private)
+	amqp.Parse(&req, tcptuple, 1, private)
 
 	trans := expectTransaction(t, amqp)
 	assert.Equal(t, "channel.close", trans["method"])
@@ -1140,7 +1140,7 @@ func TestAmqp_ConnectionCloseNoError(t *testing.T) {
 	private := protos.ProtocolData(new(amqpPrivateData))
 	private = amqp.Parse(&req, tcptuple, 0, private)
 	req = protos.Packet{Payload: data2}
-	private = amqp.Parse(&req, tcptuple, 1, private)
+	amqp.Parse(&req, tcptuple, 1, private)
 
 	trans := expectTransaction(t, amqp)
 	assert.Equal(t, "connection.close", trans["method"])
@@ -1175,7 +1175,7 @@ func TestAmqp_MultipleBodyFrames(t *testing.T) {
 	private := protos.ProtocolData(new(amqpPrivateData))
 	private = amqp.Parse(&req, tcptuple, 0, private)
 	req = protos.Packet{Payload: data2}
-	private = amqp.Parse(&req, tcptuple, 0, private)
+	amqp.Parse(&req, tcptuple, 0, private)
 	trans := expectTransaction(t, amqp)
 	assert.Equal(t, "basic.publish", trans["method"])
 	assert.Equal(t, "***hello I like to publish big messages***", trans["request"])

--- a/packetbeat/protos/applayer/applayer.go
+++ b/packetbeat/protos/applayer/applayer.go
@@ -14,7 +14,7 @@ import (
 type NetDirection uint8
 
 const (
-	// Message due to a reponse by server
+	// Message due to a response by server
 	NetReverseDirection NetDirection = 0
 
 	// Message was send by client

--- a/packetbeat/protos/applayer/applayer.go
+++ b/packetbeat/protos/applayer/applayer.go
@@ -59,7 +59,7 @@ type Transaction struct {
 	Type string
 
 	// Transaction source and destination IPs and Ports.
-	Tuple common.IpPortTuple
+	Tuple common.IPPortTuple
 
 	// Transport layer type
 	Transport Transport
@@ -102,7 +102,7 @@ type TransactionTimestamp struct {
 // are required to initialize a Transaction (see (*Transaction).InitWithMsg).
 type Message struct {
 	Ts           time.Time
-	Tuple        common.IpPortTuple
+	Tuple        common.IPPortTuple
 	Transport    Transport
 	CmdlineTuple *common.CmdlineTuple
 	Direction    NetDirection
@@ -160,7 +160,7 @@ func (stream *Stream) Write(data []byte) (int, error) {
 // BytesOut are initialized to zero and must be filled by application code.
 func (t *Transaction) Init(
 	typ string,
-	tuple common.IpPortTuple,
+	tuple common.IPPortTuple,
 	transport Transport,
 	direction NetDirection,
 	time time.Time,
@@ -175,13 +175,13 @@ func (t *Transaction) Init(
 	t.Ts.Ts = time
 	t.Ts.Millis = int64(time.UnixNano() / 1000)
 	t.Src = common.Endpoint{
-		Ip:   tuple.Src_ip.String(),
-		Port: tuple.Src_port,
+		IP:   tuple.SrcIP.String(),
+		Port: tuple.SrcPort,
 		Proc: string(cmdline.Src),
 	}
 	t.Dst = common.Endpoint{
-		Ip:   tuple.Dst_ip.String(),
-		Port: tuple.Dst_port,
+		IP:   tuple.DstIP.String(),
+		Port: tuple.DstPort,
 		Proc: string(cmdline.Dst),
 	}
 	t.Notes = notes

--- a/packetbeat/protos/cassandra/cassandra.go
+++ b/packetbeat/protos/cassandra/cassandra.go
@@ -124,7 +124,7 @@ func (cassandra *cassandra) GetPorts() []int {
 // state shall be dropped (e.g. parser not in sync with tcp stream)
 func (cassandra *cassandra) Parse(
 	pkt *protos.Packet,
-	tcptuple *common.TcpTuple, dir uint8,
+	tcptuple *common.TCPTuple, dir uint8,
 	private protos.ProtocolData,
 ) protos.ProtocolData {
 	defer logp.Recover("Parse cassandra exception")
@@ -134,7 +134,7 @@ func (cassandra *cassandra) Parse(
 	if st == nil {
 		st = &stream{}
 		st.parser.init(&cassandra.parserConfig, func(msg *message) error {
-			return conn.trans.onMessage(tcptuple.IpPort(), dir, msg)
+			return conn.trans.onMessage(tcptuple.IPPort(), dir, msg)
 		})
 		conn.streams[dir] = st
 	}
@@ -149,14 +149,14 @@ func (cassandra *cassandra) Parse(
 
 // ReceivedFin handles TCP-FIN packet.
 func (cassandra *cassandra) ReceivedFin(
-	tcptuple *common.TcpTuple, dir uint8,
+	tcptuple *common.TCPTuple, dir uint8,
 	private protos.ProtocolData,
 ) protos.ProtocolData {
 	return private
 }
 
 // GapInStream handles lost packets in tcp-stream.
-func (cassandra *cassandra) GapInStream(tcptuple *common.TcpTuple, dir uint8,
+func (cassandra *cassandra) GapInStream(tcptuple *common.TCPTuple, dir uint8,
 	nbytes int,
 	private protos.ProtocolData,
 ) (protos.ProtocolData, bool) {

--- a/packetbeat/protos/cassandra/pub.go
+++ b/packetbeat/protos/cassandra/pub.go
@@ -52,8 +52,8 @@ func (pub *transPub) createEvent(requ, resp *message) common.MapStr {
 		responseTime := int32(resp.Ts.Sub(requ.Ts).Nanoseconds() / 1e6)
 
 		src := &common.Endpoint{
-			Ip:   requ.Tuple.Src_ip.String(),
-			Port: requ.Tuple.Src_port,
+			IP:   requ.Tuple.SrcIP.String(),
+			Port: requ.Tuple.SrcPort,
 			Proc: string(requ.CmdlineTuple.Src),
 		}
 
@@ -81,8 +81,8 @@ func (pub *transPub) createEvent(requ, resp *message) common.MapStr {
 		}
 
 		dst := &common.Endpoint{
-			Ip:   requ.Tuple.Dst_ip.String(),
-			Port: requ.Tuple.Dst_port,
+			IP:   requ.Tuple.DstIP.String(),
+			Port: requ.Tuple.DstPort,
 			Proc: string(requ.CmdlineTuple.Dst),
 		}
 		event["dst"] = dst
@@ -93,8 +93,8 @@ func (pub *transPub) createEvent(requ, resp *message) common.MapStr {
 		event["@timestamp"] = common.Time(resp.Ts)
 
 		dst := &common.Endpoint{
-			Ip:   resp.Tuple.Dst_ip.String(),
-			Port: resp.Tuple.Dst_port,
+			IP:   resp.Tuple.DstIP.String(),
+			Port: resp.Tuple.DstPort,
 			Proc: string(resp.CmdlineTuple.Dst),
 		}
 		event["dst"] = dst

--- a/packetbeat/protos/cassandra/trans.go
+++ b/packetbeat/protos/cassandra/trans.go
@@ -35,7 +35,7 @@ func (trans *transactions) init(c *transactionConfig, cb transactionHandler) {
 }
 
 func (trans *transactions) onMessage(
-	tuple *common.IpPortTuple,
+	tuple *common.IPPortTuple,
 	dir uint8,
 	msg *message,
 ) error {
@@ -62,7 +62,7 @@ func (trans *transactions) onMessage(
 // onRequest handles request messages, merging with incomplete requests
 // and adding non-merged requests into the correlation list.
 func (trans *transactions) onRequest(
-	tuple *common.IpPortTuple,
+	tuple *common.IPPortTuple,
 	dir uint8,
 	msg *message,
 ) error {
@@ -87,7 +87,7 @@ func (trans *transactions) onRequest(
 // onRequest handles response messages, merging with incomplete requests
 // and adding non-merged responses into the correlation list.
 func (trans *transactions) onResponse(
-	tuple *common.IpPortTuple,
+	tuple *common.IPPortTuple,
 	dir uint8,
 	msg *message,
 ) error {

--- a/packetbeat/protos/dns/dns.go
+++ b/packetbeat/protos/dns/dns.go
@@ -771,7 +771,7 @@ func dnsToString(dns *mkdns.Msg) string {
 }
 
 // decodeDnsData decodes a byte array into a DNS struct. If an error occurs
-// then the returnd dns pointer will be nil. This method recovers from panics
+// then the returned dns pointer will be nil. This method recovers from panics
 // and is concurrency-safe.
 // We do not handle Unpack ErrTruncated for now. See https://github.com/miekg/dns/pull/281
 func decodeDnsData(transport Transport, rawData []byte) (dns *mkdns.Msg, err error) {

--- a/packetbeat/protos/dns/dns.go
+++ b/packetbeat/protos/dns/dns.go
@@ -69,7 +69,7 @@ type HashableDnsTuple [MaxDnsTupleRawSize]byte
 // DnsMessage contains a single DNS message.
 type DnsMessage struct {
 	Ts           time.Time          // Time when the message was received.
-	Tuple        common.IpPortTuple // Source and destination addresses of packet.
+	Tuple        common.IPPortTuple // Source and destination addresses of packet.
 	CmdlineTuple *common.CmdlineTuple
 	Data         *mkdns.Msg // Parsed DNS packet data.
 	Length       int        // Length of the DNS message in bytes (without DecodeOffset).
@@ -88,13 +88,13 @@ type DnsTuple struct {
 	revRaw HashableDnsTuple // Dst_ip:Dst_port:Src_ip:Src_port:Transport:Id
 }
 
-func DnsTupleFromIpPort(t *common.IpPortTuple, trans Transport, id uint16) DnsTuple {
+func DnsTupleFromIpPort(t *common.IPPortTuple, trans Transport, id uint16) DnsTuple {
 	tuple := DnsTuple{
-		Ip_length: t.Ip_length,
-		Src_ip:    t.Src_ip,
-		Dst_ip:    t.Dst_ip,
-		Src_port:  t.Src_port,
-		Dst_port:  t.Dst_port,
+		Ip_length: t.IPLength,
+		Src_ip:    t.SrcIP,
+		Dst_ip:    t.DstIP,
+		Src_port:  t.SrcPort,
+		Dst_port:  t.DstPort,
 		Transport: trans,
 		Id:        id,
 	}
@@ -256,12 +256,12 @@ func newTransaction(ts time.Time, tuple DnsTuple, cmd common.CmdlineTuple) *DnsT
 		tuple:     tuple,
 	}
 	trans.Src = common.Endpoint{
-		Ip:   tuple.Src_ip.String(),
+		IP:   tuple.Src_ip.String(),
 		Port: tuple.Src_port,
 		Proc: string(cmd.Src),
 	}
 	trans.Dst = common.Endpoint{
-		Ip:   tuple.Dst_ip.String(),
+		IP:   tuple.Dst_ip.String(),
 		Port: tuple.Dst_port,
 		Proc: string(cmd.Dst),
 	}

--- a/packetbeat/protos/dns/dns.go
+++ b/packetbeat/protos/dns/dns.go
@@ -564,7 +564,7 @@ func rrToString(rr mkdns.RR) string {
 	data, ok := mapStr["data"]
 	delete(mapStr, "data")
 
-	for k, _ := range mapStr {
+	for k := range mapStr {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)

--- a/packetbeat/protos/dns/dns_tcp.go
+++ b/packetbeat/protos/dns/dns_tcp.go
@@ -22,7 +22,7 @@ const DecodeOffset = 2
 // DnsStream contains DNS data from one side of a TCP transmission. A pair
 // of DnsStream's are used to represent the full conversation.
 type DnsStream struct {
-	tcpTuple    *common.TcpTuple
+	tcpTuple    *common.TCPTuple
 	rawData     []byte
 	parseOffset int
 	message     *DnsMessage
@@ -37,7 +37,7 @@ type dnsConnectionData struct {
 	prevRequest *DnsMessage
 }
 
-func (dns *Dns) Parse(pkt *protos.Packet, tcpTuple *common.TcpTuple, dir uint8, private protos.ProtocolData) protos.ProtocolData {
+func (dns *Dns) Parse(pkt *protos.Packet, tcpTuple *common.TCPTuple, dir uint8, private protos.ProtocolData) protos.ProtocolData {
 	defer logp.Recover("Dns ParseTcp")
 
 	debugf("Parsing packet addressed with %s of length %d.",
@@ -71,7 +71,7 @@ func ensureDnsConnection(private protos.ProtocolData) *dnsConnectionData {
 	return conn
 }
 
-func (dns *Dns) doParse(conn *dnsConnectionData, pkt *protos.Packet, tcpTuple *common.TcpTuple, dir uint8) *dnsConnectionData {
+func (dns *Dns) doParse(conn *dnsConnectionData, pkt *protos.Packet, tcpTuple *common.TCPTuple, dir uint8) *dnsConnectionData {
 	stream := conn.Data[dir]
 	payload := pkt.Payload
 
@@ -117,7 +117,7 @@ func (dns *Dns) doParse(conn *dnsConnectionData, pkt *protos.Packet, tcpTuple *c
 	return conn
 }
 
-func newStream(pkt *protos.Packet, tcpTuple *common.TcpTuple) *DnsStream {
+func newStream(pkt *protos.Packet, tcpTuple *common.TCPTuple) *DnsStream {
 	return &DnsStream{
 		tcpTuple: tcpTuple,
 		rawData:  pkt.Payload,
@@ -125,15 +125,15 @@ func newStream(pkt *protos.Packet, tcpTuple *common.TcpTuple) *DnsStream {
 	}
 }
 
-func (dns *Dns) messageComplete(conn *dnsConnectionData, tcpTuple *common.TcpTuple, dir uint8, decodedData *mkdns.Msg) {
+func (dns *Dns) messageComplete(conn *dnsConnectionData, tcpTuple *common.TCPTuple, dir uint8, decodedData *mkdns.Msg) {
 	dns.handleDns(conn, tcpTuple, decodedData, dir)
 }
 
-func (dns *Dns) handleDns(conn *dnsConnectionData, tcpTuple *common.TcpTuple, decodedData *mkdns.Msg, dir uint8) {
+func (dns *Dns) handleDns(conn *dnsConnectionData, tcpTuple *common.TCPTuple, decodedData *mkdns.Msg, dir uint8) {
 	message := conn.Data[dir].message
 	dnsTuple := DnsTupleFromIpPort(&message.Tuple, TransportTcp, decodedData.Id)
 
-	message.CmdlineTuple = procs.ProcWatcher.FindProcessesTuple(tcpTuple.IpPort())
+	message.CmdlineTuple = procs.ProcWatcher.FindProcessesTuple(tcpTuple.IPPort())
 	message.Data = decodedData
 	message.Length += DecodeOffset
 
@@ -152,7 +152,7 @@ func (stream *DnsStream) PrepareForNewMessage() {
 	stream.parseOffset = 0
 }
 
-func (dns *Dns) ReceivedFin(tcpTuple *common.TcpTuple, dir uint8, private protos.ProtocolData) protos.ProtocolData {
+func (dns *Dns) ReceivedFin(tcpTuple *common.TCPTuple, dir uint8, private protos.ProtocolData) protos.ProtocolData {
 	if private == nil {
 		return nil
 	}
@@ -183,7 +183,7 @@ func (dns *Dns) ReceivedFin(tcpTuple *common.TcpTuple, dir uint8, private protos
 	return conn
 }
 
-func (dns *Dns) GapInStream(tcpTuple *common.TcpTuple, dir uint8, nbytes int, private protos.ProtocolData) (priv protos.ProtocolData, drop bool) {
+func (dns *Dns) GapInStream(tcpTuple *common.TCPTuple, dir uint8, nbytes int, private protos.ProtocolData) (priv protos.ProtocolData, drop bool) {
 	if private == nil {
 		return private, true
 	}

--- a/packetbeat/protos/dns/dns_tcp_test.go
+++ b/packetbeat/protos/dns/dns_tcp_test.go
@@ -397,7 +397,7 @@ func TestParseTcp_errorDuplicateRequestsOnePacket(t *testing.T) {
 	assert.Equal(t, 1, dns.transactions.Size(), "There should be one transaction.")
 
 	packet = newPacket(forward, q.request[offset:])
-	private = dns.Parse(packet, tcptuple, tcp.TcpDirectionOriginal, private)
+	dns.Parse(packet, tcptuple, tcp.TcpDirectionOriginal, private)
 	assert.Equal(t, 1, dns.transactions.Size(), "There should be one transaction.")
 
 	m := expectResult(t, dns)

--- a/packetbeat/protos/dns/dns_tcp_test.go
+++ b/packetbeat/protos/dns/dns_tcp_test.go
@@ -175,11 +175,11 @@ var (
 	}
 )
 
-func testTcpTuple() *common.TcpTuple {
-	t := &common.TcpTuple{
-		Ip_length: 4,
-		Src_ip:    net.IPv4(192, 168, 0, 1), Dst_ip: net.IPv4(192, 168, 0, 2),
-		Src_port: ClientPort, Dst_port: ServerPort,
+func testTcpTuple() *common.TCPTuple {
+	t := &common.TCPTuple{
+		IPLength: 4,
+		SrcIP:    net.IPv4(192, 168, 0, 1), DstIP: net.IPv4(192, 168, 0, 2),
+		SrcPort: ClientPort, DstPort: ServerPort,
 	}
 	t.ComputeHashebles()
 	return t
@@ -636,7 +636,7 @@ func BenchmarkParallelTcpParse(b *testing.B) {
 		for pb.Next() {
 			q := messagesTcp[rand.Intn(numMessages)]
 			var packet *protos.Packet
-			var tcptuple *common.TcpTuple
+			var tcptuple *common.TCPTuple
 			var private protos.ProtocolData
 
 			if rand.Intn(2) == 0 {

--- a/packetbeat/protos/dns/dns_test.go
+++ b/packetbeat/protos/dns/dns_test.go
@@ -47,10 +47,10 @@ type DnsTestMessage struct {
 
 // Request and response addresses.
 var (
-	forward = common.NewIpPortTuple(4,
+	forward = common.NewIPPortTuple(4,
 		net.ParseIP(ServerIp), ServerPort,
 		net.ParseIP(ClientIp), ClientPort)
-	reverse = common.NewIpPortTuple(4,
+	reverse = common.NewIPPortTuple(4,
 		net.ParseIP(ClientIp), ClientPort,
 		net.ParseIP(ServerIp), ServerPort)
 )
@@ -78,7 +78,7 @@ func newDns(verbose bool) *Dns {
 	return dns.(*Dns)
 }
 
-func newPacket(t common.IpPortTuple, payload []byte) *protos.Packet {
+func newPacket(t common.IPPortTuple, payload []byte) *protos.Packet {
 	return &protos.Packet{
 		Ts:      time.Now(),
 		Tuple:   t,
@@ -252,12 +252,12 @@ func assertFlags(t testing.TB, m common.MapStr, flags []string) {
 
 // Assert that the given Endpoint matches the IP and port in the given
 // IpPortTuple.
-func assertAddress(t testing.TB, expected common.IpPortTuple, endpoint interface{}) {
+func assertAddress(t testing.TB, expected common.IPPortTuple, endpoint interface{}) {
 	e, ok := endpoint.(*common.Endpoint)
 	if !ok {
 		t.Errorf("Expected a common.Endpoint but got %v", endpoint)
 	}
 
-	assert.Equal(t, expected.Src_ip.String(), e.Ip)
-	assert.Equal(t, expected.Src_port, e.Port)
+	assert.Equal(t, expected.SrcIP.String(), e.IP)
+	assert.Equal(t, expected.SrcPort, e.Port)
 }

--- a/packetbeat/protos/http/http.go
+++ b/packetbeat/protos/http/http.go
@@ -37,7 +37,7 @@ var (
 )
 
 type stream struct {
-	tcptuple *common.TcpTuple
+	tcptuple *common.TCPTuple
 
 	data []byte
 
@@ -198,7 +198,7 @@ func (st *stream) PrepareForNewMessage() {
 // of a message.
 func (http *HTTP) messageComplete(
 	conn *httpConnectionData,
-	tcptuple *common.TcpTuple,
+	tcptuple *common.TCPTuple,
 	dir uint8,
 	st *stream,
 ) {
@@ -215,7 +215,7 @@ func (http *HTTP) ConnectionTimeout() time.Duration {
 // Parse function is used to process TCP payloads.
 func (http *HTTP) Parse(
 	pkt *protos.Packet,
-	tcptuple *common.TcpTuple,
+	tcptuple *common.TCPTuple,
 	dir uint8,
 	private protos.ProtocolData,
 ) protos.ProtocolData {
@@ -259,7 +259,7 @@ func getHTTPConnection(private protos.ProtocolData) *httpConnectionData {
 func (http *HTTP) doParse(
 	conn *httpConnectionData,
 	pkt *protos.Packet,
-	tcptuple *common.TcpTuple,
+	tcptuple *common.TCPTuple,
 	dir uint8,
 ) *httpConnectionData {
 
@@ -314,7 +314,7 @@ func (http *HTTP) doParse(
 	return conn
 }
 
-func newStream(pkt *protos.Packet, tcptuple *common.TcpTuple) *stream {
+func newStream(pkt *protos.Packet, tcptuple *common.TCPTuple) *stream {
 	return &stream{
 		tcptuple: tcptuple,
 		data:     pkt.Payload,
@@ -323,7 +323,7 @@ func newStream(pkt *protos.Packet, tcptuple *common.TcpTuple) *stream {
 }
 
 // ReceivedFin will be called when TCP transaction is terminating.
-func (http *HTTP) ReceivedFin(tcptuple *common.TcpTuple, dir uint8,
+func (http *HTTP) ReceivedFin(tcptuple *common.TCPTuple, dir uint8,
 	private protos.ProtocolData) protos.ProtocolData {
 
 	debugf("Received FIN")
@@ -352,7 +352,7 @@ func (http *HTTP) ReceivedFin(tcptuple *common.TcpTuple, dir uint8,
 
 // GapInStream is called when a gap of nbytes bytes is found in the stream (due
 // to packet loss).
-func (http *HTTP) GapInStream(tcptuple *common.TcpTuple, dir uint8,
+func (http *HTTP) GapInStream(tcptuple *common.TCPTuple, dir uint8,
 	nbytes int, private protos.ProtocolData) (priv protos.ProtocolData, drop bool) {
 
 	defer logp.Recover("GapInStream(http) exception")
@@ -390,13 +390,13 @@ func (http *HTTP) GapInStream(tcptuple *common.TcpTuple, dir uint8,
 func (http *HTTP) handleHTTP(
 	conn *httpConnectionData,
 	m *message,
-	tcptuple *common.TcpTuple,
+	tcptuple *common.TCPTuple,
 	dir uint8,
 ) {
 
 	m.TCPTuple = *tcptuple
 	m.Direction = dir
-	m.CmdlineTuple = procs.ProcWatcher.FindProcessesTuple(tcptuple.IpPort())
+	m.CmdlineTuple = procs.ProcWatcher.FindProcessesTuple(tcptuple.IPPort())
 	http.hideHeaders(m)
 
 	if m.IsRequest {
@@ -452,13 +452,13 @@ func (http *HTTP) newTransaction(requ, resp *message) common.MapStr {
 	}
 
 	src := common.Endpoint{
-		Ip:   requ.TCPTuple.Src_ip.String(),
-		Port: requ.TCPTuple.Src_port,
+		IP:   requ.TCPTuple.SrcIP.String(),
+		Port: requ.TCPTuple.SrcPort,
 		Proc: string(requ.CmdlineTuple.Src),
 	}
 	dst := common.Endpoint{
-		Ip:   requ.TCPTuple.Dst_ip.String(),
-		Port: requ.TCPTuple.Dst_port,
+		IP:   requ.TCPTuple.DstIP.String(),
+		Port: requ.TCPTuple.DstPort,
 		Proc: string(requ.CmdlineTuple.Dst),
 	}
 	if requ.Direction == tcp.TcpDirectionReverse {

--- a/packetbeat/protos/http/http_parser.go
+++ b/packetbeat/protos/http/http_parser.go
@@ -22,7 +22,7 @@ type message struct {
 	chunkedBody      []byte
 
 	IsRequest    bool
-	TCPTuple     common.TcpTuple
+	TCPTuple     common.TCPTuple
 	CmdlineTuple *common.CmdlineTuple
 	Direction    uint8
 
@@ -533,7 +533,7 @@ func trimRight(buf []byte) []byte {
 
 func parseInt(line []byte) (int, error) {
 	buf := streambuf.NewFixed(line)
-	i, err := buf.AsciiInt(false)
+	i, err := buf.IntASCII(false)
 	return int(i), err
 	// TODO: is it an error if 'buf.Len() != 0 {}' ?
 }

--- a/packetbeat/protos/http/http_test.go
+++ b/packetbeat/protos/http/http_test.go
@@ -1048,11 +1048,11 @@ func Test_gap_in_body_http1dot0(t *testing.T) {
 
 }
 
-func testCreateTCPTuple() *common.TcpTuple {
-	t := &common.TcpTuple{
-		Ip_length: 4,
-		Src_ip:    net.IPv4(192, 168, 0, 1), Dst_ip: net.IPv4(192, 168, 0, 2),
-		Src_port: 6512, Dst_port: 80,
+func testCreateTCPTuple() *common.TCPTuple {
+	t := &common.TCPTuple{
+		IPLength: 4,
+		SrcIP:    net.IPv4(192, 168, 0, 1), DstIP: net.IPv4(192, 168, 0, 2),
+		SrcPort: 6512, DstPort: 80,
 	}
 	t.ComputeHashebles()
 	return t

--- a/packetbeat/protos/http/http_test.go
+++ b/packetbeat/protos/http/http_test.go
@@ -1107,7 +1107,7 @@ func Test_gap_in_body_http1dot0_fin(t *testing.T) {
 	private, drop := http.GapInStream(tcptuple, 1, 10, private)
 	assert.Equal(t, false, drop)
 
-	private = http.ReceivedFin(tcptuple, 1, private)
+	http.ReceivedFin(tcptuple, 1, private)
 
 	trans := expectTransaction(t, http)
 	assert.NotNil(t, trans)
@@ -1284,7 +1284,7 @@ func BenchmarkHttpSimpleTransaction(b *testing.B) {
 		private = http.ReceivedFin(tcptuple, 0, private)
 
 		private = http.Parse(&resp, tcptuple, 1, private)
-		private = http.ReceivedFin(tcptuple, 1, private)
+		http.ReceivedFin(tcptuple, 1, private)
 
 		select {
 		case <-client.Channel:

--- a/packetbeat/protos/icmp/icmp.go
+++ b/packetbeat/protos/icmp/icmp.go
@@ -75,7 +75,7 @@ func (icmp *Icmp) init(results publish.Transactions, config *icmpConfig) error {
 	icmp.setFromConfig(config)
 
 	var err error
-	icmp.localIps, err = common.LocalIpAddrs()
+	icmp.localIps, err = common.LocalIPAddrs()
 	if err != nil {
 		logp.Err("icmp", "Error getting local IP addresses: %s", err)
 		icmp.localIps = []net.IP{}
@@ -115,8 +115,8 @@ func (icmp *Icmp) ProcessICMPv4(
 
 	tuple := &icmpTuple{
 		IcmpVersion: 4,
-		SrcIp:       pkt.Tuple.Src_ip,
-		DstIp:       pkt.Tuple.Dst_ip,
+		SrcIp:       pkt.Tuple.SrcIP,
+		DstIp:       pkt.Tuple.DstIP,
 		Id:          id,
 		Seq:         seq,
 	}
@@ -150,8 +150,8 @@ func (icmp *Icmp) ProcessICMPv6(
 	id, seq := extractTrackingData(6, typ, &icmp6.BaseLayer)
 	tuple := &icmpTuple{
 		IcmpVersion: 6,
-		SrcIp:       pkt.Tuple.Src_ip,
-		DstIp:       pkt.Tuple.Dst_ip,
+		SrcIp:       pkt.Tuple.SrcIP,
+		DstIp:       pkt.Tuple.DstIP,
 		Id:          id,
 		Seq:         seq,
 	}

--- a/packetbeat/protos/memcache/memcache.go
+++ b/packetbeat/protos/memcache/memcache.go
@@ -138,7 +138,7 @@ func (mc *Memcache) init(results publish.Transactions, config *memcacheConfig) e
 		return err
 	}
 
-	mc.udpConnections = make(map[common.HashableIpPortTuple]*udpConnection)
+	mc.udpConnections = make(map[common.HashableIPPortTuple]*udpConnection)
 	mc.results = results
 	return nil
 }

--- a/packetbeat/protos/memcache/plugin_tcp.go
+++ b/packetbeat/protos/memcache/plugin_tcp.go
@@ -79,7 +79,7 @@ func (mc *Memcache) ConnectionTimeout() time.Duration {
 // Parse is called from TCP layer when payload data is available for parsing.
 func (mc *Memcache) Parse(
 	pkt *protos.Packet,
-	tcptuple *common.TcpTuple,
+	tcptuple *common.TCPTuple,
 	dir uint8,
 	private protos.ProtocolData,
 ) protos.ProtocolData {
@@ -95,7 +95,7 @@ func (mc *Memcache) Parse(
 	return tcpConn
 }
 
-func (mc *Memcache) newStream(tcptuple *common.TcpTuple) *stream {
+func (mc *Memcache) newStream(tcptuple *common.TCPTuple) *stream {
 	s := &stream{}
 	s.parser.init(&mc.config)
 	s.Stream.Init(tcp.TCP_MAX_DATA_IN_STREAM)
@@ -105,7 +105,7 @@ func (mc *Memcache) newStream(tcptuple *common.TcpTuple) *stream {
 func (mc *Memcache) memcacheParseTCP(
 	tcpConn *tcpConnectionData,
 	pkt *protos.Packet,
-	tcptuple *common.TcpTuple,
+	tcptuple *common.TCPTuple,
 	dir uint8,
 ) *tcpConnectionData {
 	// assume we are in sync
@@ -151,7 +151,7 @@ func (mc *Memcache) memcacheParseTCP(
 		}
 		stream.reset()
 
-		tuple := tcptuple.IpPort()
+		tuple := tcptuple.IPPort()
 		err = mc.onTCPMessage(conn, tuple, dir, msg)
 		if err != nil {
 			logp.Warn("error processing memcache message: %s", err)
@@ -168,7 +168,7 @@ func (mc *Memcache) memcacheParseTCP(
 
 func (mc *Memcache) onTCPMessage(
 	conn *connection,
-	tuple *common.IpPortTuple,
+	tuple *common.IPPortTuple,
 	dir uint8,
 	msg *message,
 ) error {
@@ -185,7 +185,7 @@ func (mc *Memcache) onTCPMessage(
 
 func (mc *Memcache) onTCPRequest(
 	conn *connection,
-	tuple *common.IpPortTuple,
+	tuple *common.IPPortTuple,
 	dir uint8,
 	msg *message,
 ) error {
@@ -213,7 +213,7 @@ func (mc *Memcache) onTCPRequest(
 
 func (mc *Memcache) onTCPResponse(
 	conn *connection,
-	tuple *common.IpPortTuple,
+	tuple *common.IPPortTuple,
 	dir uint8,
 	msg *message,
 ) error {
@@ -321,7 +321,7 @@ func (mc *Memcache) onTCPTrans(requ, resp *message) error {
 // GapInStream is called by TCP layer when a packets are missing from the tcp
 // stream.
 func (mc *Memcache) GapInStream(
-	tcptuple *common.TcpTuple,
+	tcptuple *common.TCPTuple,
 	dir uint8, nbytes int,
 	private protos.ProtocolData,
 ) (priv protos.ProtocolData, drop bool) {
@@ -385,7 +385,7 @@ func (mc *Memcache) GapInStream(
 
 // ReceivedFin is called by tcp layer when the FIN flag is seen in the TCP stream.
 func (mc *Memcache) ReceivedFin(
-	tcptuple *common.TcpTuple,
+	tcptuple *common.TCPTuple,
 	dir uint8,
 	private protos.ProtocolData,
 ) protos.ProtocolData {

--- a/packetbeat/protos/memcache/plugin_tcp.go
+++ b/packetbeat/protos/memcache/plugin_tcp.go
@@ -89,7 +89,7 @@ func (mc *Memcache) Parse(
 	debug("memcache connection %p", tcpConn)
 	tcpConn = mc.memcacheParseTCP(tcpConn, pkt, tcptuple, dir)
 	if tcpConn == nil {
-		// explicitely return nil if tcpConn equals nil so ProtocolData really is nil
+		// explicitly return nil if tcpConn equals nil so ProtocolData really is nil
 		return nil
 	}
 	return tcpConn

--- a/packetbeat/protos/memcache/plugin_udp.go
+++ b/packetbeat/protos/memcache/plugin_udp.go
@@ -17,7 +17,7 @@ import (
 
 type udpMemcache struct {
 	udpConfig      udpConfig
-	udpConnections map[common.HashableIpPortTuple]*udpConnection
+	udpConnections map[common.HashableIPPortTuple]*udpConnection
 	udpExpTrans    udpExpTransList
 }
 
@@ -32,7 +32,7 @@ type mcUdpHeader struct {
 }
 
 type udpConnection struct {
-	tuple        common.IpPortTuple
+	tuple        common.IPPortTuple
 	transactions map[uint16]*udpTransaction
 	memcache     *Memcache
 }
@@ -136,7 +136,7 @@ func (mc *Memcache) ParseUdp(pkt *protos.Packet) {
 }
 
 func (mc *Memcache) getUdpConnection(
-	tuple *common.IpPortTuple,
+	tuple *common.IPPortTuple,
 ) (*udpConnection, applayer.NetDirection) {
 	connection := mc.udpConnections[tuple.Hashable()]
 	if connection != nil {
@@ -154,7 +154,7 @@ func (mc *Memcache) getUdpConnection(
 
 func (mc *Memcache) onUdpMessage(
 	trans *udpTransaction,
-	tuple *common.IpPortTuple,
+	tuple *common.IPPortTuple,
 	dir applayer.NetDirection,
 	msg *message,
 ) (bool, error) {
@@ -198,7 +198,7 @@ func (mc *Memcache) onUdpTrans(udp *udpTransaction) error {
 	return mc.finishTransaction(trans)
 }
 
-func newUdpConnection(mc *Memcache, tuple *common.IpPortTuple) *udpConnection {
+func newUdpConnection(mc *Memcache, tuple *common.IPPortTuple) *udpConnection {
 	c := &udpConnection{
 		tuple:        *tuple,
 		memcache:     mc,

--- a/packetbeat/protos/memcache/text.go
+++ b/packetbeat/protos/memcache/text.go
@@ -478,7 +478,7 @@ func parseUnknown(parser *parser, buf *streambuf.Buffer) parseResult {
 func parseCounterResponse(parser *parser, buf *streambuf.Buffer) parseResult {
 	msg := parser.message
 	tmp := streambuf.NewFixed(msg.rawCommand)
-	msg.value, _ = tmp.AsciiUint(false)
+	msg.value, _ = tmp.UintASCII(false)
 	if tmp.Failed() {
 		err := tmp.Err()
 		debug("counter response invalid: %v", err)
@@ -610,7 +610,7 @@ func withUintArg(
 ) error {
 	msg := parser.message
 	parseNextArg(buf)
-	value, err := buf.AsciiUint(false)
+	value, err := buf.UintASCII(false)
 	if err == nil {
 		fn(msg, uint32(value))
 	}
@@ -623,7 +623,7 @@ func withUint64Arg(
 	fn func(msg *message, v uint64),
 ) error {
 	parseNextArg(buf)
-	value, err := buf.AsciiUint(false)
+	value, err := buf.UintASCII(false)
 	if err == nil {
 		fn(parser.message, value)
 	}
@@ -648,7 +648,7 @@ func withInt64Arg(
 	fn func(msg *message, v int64),
 ) error {
 	parseNextArg(buf)
-	value, err := buf.AsciiInt(false)
+	value, err := buf.IntASCII(false)
 	if err == nil {
 		fn(parser.message, value)
 	}

--- a/packetbeat/protos/mongodb/mongodb.go
+++ b/packetbeat/protos/mongodb/mongodb.go
@@ -32,7 +32,7 @@ type Mongodb struct {
 }
 
 type transactionKey struct {
-	tcp common.HashableTcpTuple
+	tcp common.HashableTCPTuple
 	id  int
 }
 
@@ -99,7 +99,7 @@ func (mongodb *Mongodb) ConnectionTimeout() time.Duration {
 
 func (mongodb *Mongodb) Parse(
 	pkt *protos.Packet,
-	tcptuple *common.TcpTuple,
+	tcptuple *common.TCPTuple,
 	dir uint8,
 	private protos.ProtocolData,
 ) protos.ProtocolData {
@@ -135,7 +135,7 @@ func ensureMongodbConnection(private protos.ProtocolData) *mongodbConnectionData
 func (mongodb *Mongodb) doParse(
 	conn *mongodbConnectionData,
 	pkt *protos.Packet,
-	tcptuple *common.TcpTuple,
+	tcptuple *common.TCPTuple,
 	dir uint8,
 ) *mongodbConnectionData {
 	st := conn.Streams[dir]
@@ -182,7 +182,7 @@ func (mongodb *Mongodb) doParse(
 	return conn
 }
 
-func newStream(pkt *protos.Packet, tcptuple *common.TcpTuple) *stream {
+func newStream(pkt *protos.Packet, tcptuple *common.TCPTuple) *stream {
 	s := &stream{
 		tcptuple: tcptuple,
 		data:     pkt.Payload,
@@ -194,13 +194,13 @@ func newStream(pkt *protos.Packet, tcptuple *common.TcpTuple) *stream {
 func (mongodb *Mongodb) handleMongodb(
 	conn *mongodbConnectionData,
 	m *mongodbMessage,
-	tcptuple *common.TcpTuple,
+	tcptuple *common.TCPTuple,
 	dir uint8,
 ) {
 
 	m.TcpTuple = *tcptuple
 	m.Direction = dir
-	m.CmdlineTuple = procs.ProcWatcher.FindProcessesTuple(tcptuple.IpPort())
+	m.CmdlineTuple = procs.ProcWatcher.FindProcessesTuple(tcptuple.IPPort())
 
 	if m.IsResponse {
 		debugf("MongoDB response message")
@@ -274,13 +274,13 @@ func newTransaction(requ, resp *mongodbMessage) *transaction {
 		trans.Ts = int64(trans.ts.UnixNano() / 1000) // transactions have microseconds resolution
 		trans.JsTs = requ.Ts
 		trans.Src = common.Endpoint{
-			Ip:   requ.TcpTuple.Src_ip.String(),
-			Port: requ.TcpTuple.Src_port,
+			IP:   requ.TcpTuple.SrcIP.String(),
+			Port: requ.TcpTuple.SrcPort,
 			Proc: string(requ.CmdlineTuple.Src),
 		}
 		trans.Dst = common.Endpoint{
-			Ip:   requ.TcpTuple.Dst_ip.String(),
-			Port: requ.TcpTuple.Dst_port,
+			IP:   requ.TcpTuple.DstIP.String(),
+			Port: requ.TcpTuple.DstPort,
 			Proc: string(requ.CmdlineTuple.Dst),
 		}
 		if requ.Direction == tcp.TcpDirectionReverse {
@@ -313,12 +313,12 @@ func newTransaction(requ, resp *mongodbMessage) *transaction {
 	return trans
 }
 
-func (mongodb *Mongodb) GapInStream(tcptuple *common.TcpTuple, dir uint8,
+func (mongodb *Mongodb) GapInStream(tcptuple *common.TCPTuple, dir uint8,
 	nbytes int, private protos.ProtocolData) (priv protos.ProtocolData, drop bool) {
 	return private, true
 }
 
-func (mongodb *Mongodb) ReceivedFin(tcptuple *common.TcpTuple, dir uint8,
+func (mongodb *Mongodb) ReceivedFin(tcptuple *common.TCPTuple, dir uint8,
 	private protos.ProtocolData) protos.ProtocolData {
 	return private
 }

--- a/packetbeat/protos/mongodb/mongodb_parser.go
+++ b/packetbeat/protos/mongodb/mongodb_parser.go
@@ -31,9 +31,11 @@ func mongodbMessageParser(s *stream) (bool, bool) {
 	// fill up the header common to all messages
 	// see http://docs.mongodb.org/meta-driver/latest/legacy/mongodb-wire-protocol/#standard-message-header
 	s.message.messageLength = length
-	s.message.requestId, err = d.readInt32()
-	s.message.responseTo, err = d.readInt32()
-	code, err := d.readInt32()
+
+	s.message.requestId, _ = d.readInt32()
+	s.message.responseTo, _ = d.readInt32()
+	code, _ := d.readInt32()
+
 	opCode := opCode(code)
 
 	if !validOpcode(opCode) {

--- a/packetbeat/protos/mongodb/mongodb_structs.go
+++ b/packetbeat/protos/mongodb/mongodb_structs.go
@@ -10,7 +10,7 @@ import (
 type mongodbMessage struct {
 	Ts time.Time
 
-	TcpTuple     common.TcpTuple
+	TcpTuple     common.TCPTuple
 	CmdlineTuple *common.CmdlineTuple
 	Direction    uint8
 
@@ -40,7 +40,7 @@ type mongodbMessage struct {
 
 // Represent a stream being parsed that contains a mongodb message
 type stream struct {
-	tcptuple *common.TcpTuple
+	tcptuple *common.TCPTuple
 
 	data    []byte
 	message *mongodbMessage
@@ -62,7 +62,7 @@ type mongodbConnectionData struct {
 // These transactions are the end product of this parser
 type transaction struct {
 	Type         string
-	tuple        common.TcpTuple
+	tuple        common.TCPTuple
 	cmdline      *common.CmdlineTuple
 	Src          common.Endpoint
 	Dst          common.Endpoint

--- a/packetbeat/protos/mongodb/mongodb_test.go
+++ b/packetbeat/protos/mongodb/mongodb_test.go
@@ -25,11 +25,11 @@ func MongodbModForTests() *Mongodb {
 }
 
 // Helper function that returns an example TcpTuple
-func testTcpTuple() *common.TcpTuple {
-	t := &common.TcpTuple{
-		Ip_length: 4,
-		Src_ip:    net.IPv4(192, 168, 0, 1), Dst_ip: net.IPv4(192, 168, 0, 2),
-		Src_port: 6512, Dst_port: 27017,
+func testTcpTuple() *common.TCPTuple {
+	t := &common.TCPTuple{
+		IPLength: 4,
+		SrcIP:    net.IPv4(192, 168, 0, 1), DstIP: net.IPv4(192, 168, 0, 2),
+		SrcPort: 6512, DstPort: 27017,
 	}
 	t.ComputeHashebles()
 	return t

--- a/packetbeat/protos/mongodb/mongodb_test.go
+++ b/packetbeat/protos/mongodb/mongodb_test.go
@@ -106,7 +106,7 @@ func TestSimpleFindLimit1(t *testing.T) {
 	private := protos.ProtocolData(new(mongodbConnectionData))
 
 	private = mongodb.Parse(&req, tcptuple, 0, private)
-	private = mongodb.Parse(&resp, tcptuple, 1, private)
+	mongodb.Parse(&resp, tcptuple, 1, private)
 	trans := expectTransaction(t, mongodb)
 
 	assert.Equal(t, "OK", trans["status"])
@@ -188,7 +188,7 @@ func TestSimpleFindLimit1_split(t *testing.T) {
 	private = mongodb.Parse(&resp2, tcptuple, 1, private)
 
 	resp3 := protos.Packet{Payload: resp_data3}
-	private = mongodb.Parse(&resp3, tcptuple, 1, private)
+	mongodb.Parse(&resp3, tcptuple, 1, private)
 
 	trans := expectTransaction(t, mongodb)
 

--- a/packetbeat/protos/mysql/mysql.go
+++ b/packetbeat/protos/mysql/mysql.go
@@ -292,7 +292,7 @@ func mysqlMessageParser(s *MysqlStream) (bool, bool) {
 					m.AffectedRows = affectedRows
 
 					// last insert id
-					insertId, off, complete, err := read_linteger(s.data, off)
+					insertId, _, complete, err := read_linteger(s.data, off)
 					if !complete {
 						return true, false
 					}
@@ -356,7 +356,7 @@ func mysqlMessageParser(s *MysqlStream) (bool, bool) {
 						logp.Debug("mysql", "Error on read_lstring: %s", err)
 						return false, false
 					}
-					table /* table */, off, complete, err := read_lstring(s.data, off)
+					table /* table */, _ /*off*/, complete, err := read_lstring(s.data, off)
 					if !complete {
 						return true, false
 					}
@@ -757,7 +757,7 @@ func (mysql *Mysql) parseMysqlResponse(data []byte) ([]string, [][]string) {
 				logp.Debug("mysql", "Reading field: %v %v", err, complete)
 				return fields, rows
 			}
-			_ /* org name */, off, complete, err = read_lstring(data, off)
+			_ /* org name */, _ /*off*/, complete, err = read_lstring(data, off)
 			if err != nil || !complete {
 				logp.Debug("mysql", "Reading field: %v %v", err, complete)
 				return fields, rows

--- a/packetbeat/protos/mysql/mysql.go
+++ b/packetbeat/protos/mysql/mysql.go
@@ -54,7 +54,7 @@ type MysqlMessage struct {
 
 	Direction    uint8
 	IsTruncated  bool
-	TcpTuple     common.TcpTuple
+	TcpTuple     common.TCPTuple
 	CmdlineTuple *common.CmdlineTuple
 	Raw          []byte
 	Notes        []string
@@ -62,7 +62,7 @@ type MysqlMessage struct {
 
 type MysqlTransaction struct {
 	Type         string
-	tuple        common.TcpTuple
+	tuple        common.TCPTuple
 	Src          common.Endpoint
 	Dst          common.Endpoint
 	ResponseTime int32
@@ -83,7 +83,7 @@ type MysqlTransaction struct {
 }
 
 type MysqlStream struct {
-	tcptuple *common.TcpTuple
+	tcptuple *common.TCPTuple
 
 	data []byte
 
@@ -131,7 +131,7 @@ type Mysql struct {
 	results publish.Transactions
 
 	// function pointer for mocking
-	handleMysql func(mysql *Mysql, m *MysqlMessage, tcp *common.TcpTuple,
+	handleMysql func(mysql *Mysql, m *MysqlMessage, tcp *common.TCPTuple,
 		dir uint8, raw_msg []byte)
 }
 
@@ -180,7 +180,7 @@ func (mysql *Mysql) setFromConfig(config *mysqlConfig) {
 	mysql.transactionTimeout = config.TransactionTimeout
 }
 
-func (mysql *Mysql) getTransaction(k common.HashableTcpTuple) *MysqlTransaction {
+func (mysql *Mysql) getTransaction(k common.HashableTCPTuple) *MysqlTransaction {
 	v := mysql.transactions.Get(k)
 	if v != nil {
 		return v.(*MysqlTransaction)
@@ -462,7 +462,7 @@ type mysqlPrivateData struct {
 }
 
 // Called when the parser has identified a full message.
-func (mysql *Mysql) messageComplete(tcptuple *common.TcpTuple, dir uint8, stream *MysqlStream) {
+func (mysql *Mysql) messageComplete(tcptuple *common.TCPTuple, dir uint8, stream *MysqlStream) {
 	// all ok, ship it
 	msg := stream.data[stream.message.start:stream.message.end]
 
@@ -478,7 +478,7 @@ func (mysql *Mysql) ConnectionTimeout() time.Duration {
 	return mysql.transactionTimeout
 }
 
-func (mysql *Mysql) Parse(pkt *protos.Packet, tcptuple *common.TcpTuple,
+func (mysql *Mysql) Parse(pkt *protos.Packet, tcptuple *common.TCPTuple,
 	dir uint8, private protos.ProtocolData) protos.ProtocolData {
 
 	defer logp.Recover("ParseMysql exception")
@@ -534,7 +534,7 @@ func (mysql *Mysql) Parse(pkt *protos.Packet, tcptuple *common.TcpTuple,
 	return priv
 }
 
-func (mysql *Mysql) GapInStream(tcptuple *common.TcpTuple, dir uint8,
+func (mysql *Mysql) GapInStream(tcptuple *common.TCPTuple, dir uint8,
 	nbytes int, private protos.ProtocolData) (priv protos.ProtocolData, drop bool) {
 
 	defer logp.Recover("GapInStream(mysql) exception")
@@ -563,7 +563,7 @@ func (mysql *Mysql) GapInStream(tcptuple *common.TcpTuple, dir uint8,
 	return private, true
 }
 
-func (mysql *Mysql) ReceivedFin(tcptuple *common.TcpTuple, dir uint8,
+func (mysql *Mysql) ReceivedFin(tcptuple *common.TCPTuple, dir uint8,
 	private protos.ProtocolData) protos.ProtocolData {
 
 	// TODO: check if we have data pending and either drop it to free
@@ -571,12 +571,12 @@ func (mysql *Mysql) ReceivedFin(tcptuple *common.TcpTuple, dir uint8,
 	return private
 }
 
-func handleMysql(mysql *Mysql, m *MysqlMessage, tcptuple *common.TcpTuple,
+func handleMysql(mysql *Mysql, m *MysqlMessage, tcptuple *common.TCPTuple,
 	dir uint8, raw_msg []byte) {
 
 	m.TcpTuple = *tcptuple
 	m.Direction = dir
-	m.CmdlineTuple = procs.ProcWatcher.FindProcessesTuple(tcptuple.IpPort())
+	m.CmdlineTuple = procs.ProcWatcher.FindProcessesTuple(tcptuple.IPPort())
 	m.Raw = raw_msg
 
 	if m.IsRequest {
@@ -603,13 +603,13 @@ func (mysql *Mysql) receivedMysqlRequest(msg *MysqlMessage) {
 	trans.Ts = int64(trans.ts.UnixNano() / 1000) // transactions have microseconds resolution
 	trans.JsTs = msg.Ts
 	trans.Src = common.Endpoint{
-		Ip:   msg.TcpTuple.Src_ip.String(),
-		Port: msg.TcpTuple.Src_port,
+		IP:   msg.TcpTuple.SrcIP.String(),
+		Port: msg.TcpTuple.SrcPort,
 		Proc: string(msg.CmdlineTuple.Src),
 	}
 	trans.Dst = common.Endpoint{
-		Ip:   msg.TcpTuple.Dst_ip.String(),
-		Port: msg.TcpTuple.Dst_port,
+		IP:   msg.TcpTuple.DstIP.String(),
+		Port: msg.TcpTuple.DstPort,
 		Proc: string(msg.CmdlineTuple.Dst),
 	}
 	if msg.Direction == tcp.TcpDirectionReverse {

--- a/packetbeat/protos/mysql/mysql_test.go
+++ b/packetbeat/protos/mysql/mysql_test.go
@@ -330,12 +330,12 @@ func TestParseMySQL_simpleUpdateResponse(t *testing.T) {
 		Payload: data,
 		Ts:      ts,
 	}
-	var tuple common.TcpTuple
+	var tuple common.TCPTuple
 	var private mysqlPrivateData
 
 	var count_handleMysql = 0
 
-	mysql.handleMysql = func(mysql *Mysql, m *MysqlMessage, tcp *common.TcpTuple,
+	mysql.handleMysql = func(mysql *Mysql, m *MysqlMessage, tcp *common.TCPTuple,
 		dir uint8, raw_msg []byte) {
 
 		count_handleMysql += 1
@@ -373,12 +373,12 @@ func TestParseMySQL_threeResponses(t *testing.T) {
 		Payload: data,
 		Ts:      ts,
 	}
-	var tuple common.TcpTuple
+	var tuple common.TCPTuple
 	var private mysqlPrivateData
 
 	var count_handleMysql = 0
 
-	mysql.handleMysql = func(mysql *Mysql, m *MysqlMessage, tcptuple *common.TcpTuple,
+	mysql.handleMysql = func(mysql *Mysql, m *MysqlMessage, tcptuple *common.TCPTuple,
 		dir uint8, raw_msg []byte) {
 
 		count_handleMysql += 1
@@ -417,12 +417,12 @@ func TestParseMySQL_splitResponse(t *testing.T) {
 		Payload: data,
 		Ts:      ts,
 	}
-	var tuple common.TcpTuple
+	var tuple common.TCPTuple
 	var private mysqlPrivateData
 
 	var count_handleMysql = 0
 
-	mysql.handleMysql = func(mysql *Mysql, m *MysqlMessage, tcptuple *common.TcpTuple,
+	mysql.handleMysql = func(mysql *Mysql, m *MysqlMessage, tcptuple *common.TCPTuple,
 		dir uint8, raw_msg []byte) {
 
 		count_handleMysql += 1
@@ -458,11 +458,11 @@ func TestParseMySQL_splitResponse(t *testing.T) {
 	}
 }
 
-func testTcpTuple() *common.TcpTuple {
-	t := &common.TcpTuple{
-		Ip_length: 4,
-		Src_ip:    net.IPv4(192, 168, 0, 1), Dst_ip: net.IPv4(192, 168, 0, 2),
-		Src_port: 6512, Dst_port: 3306,
+func testTcpTuple() *common.TCPTuple {
+	t := &common.TCPTuple{
+		IPLength: 4,
+		SrcIP:    net.IPv4(192, 168, 0, 1), DstIP: net.IPv4(192, 168, 0, 2),
+		SrcPort: 6512, DstPort: 3306,
 	}
 	t.ComputeHashebles()
 	return t

--- a/packetbeat/protos/mysql/mysql_test.go
+++ b/packetbeat/protos/mysql/mysql_test.go
@@ -443,6 +443,9 @@ func TestParseMySQL_splitResponse(t *testing.T) {
 			"2a00000a013309416e6f6e796d6f75730454657374047465737413323031332d30372d32322031383a33323a3130" +
 			"2a00000b013409416e6f6e796d6f75730474657374047465737413323031332d30372d32322031383a34343a3137" +
 			"0500000cfe00002100")
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	pkt = protos.Packet{
 		Payload: data,
@@ -522,7 +525,7 @@ func Test_gap_in_response(t *testing.T) {
 
 	logp.Debug("mysql", "Now sending gap..")
 
-	private, drop := mysql.GapInStream(tcptuple, 1, 10, private)
+	_, drop := mysql.GapInStream(tcptuple, 1, 10, private)
 	assert.Equal(t, true, drop)
 
 	trans := expectTransaction(t, mysql)

--- a/packetbeat/protos/nfs/rpc.go
+++ b/packetbeat/protos/nfs/rpc.go
@@ -31,7 +31,7 @@ const (
 )
 
 type RpcStream struct {
-	tcpTuple *common.TcpTuple
+	tcpTuple *common.TCPTuple
 	rawData  []byte
 }
 
@@ -105,7 +105,7 @@ func (rpc *Rpc) GetPorts() []int {
 // Called when TCP payload data is available for parsing.
 func (rpc *Rpc) Parse(
 	pkt *protos.Packet,
-	tcptuple *common.TcpTuple,
+	tcptuple *common.TCPTuple,
 	dir uint8,
 	private protos.ProtocolData,
 ) protos.ProtocolData {
@@ -122,7 +122,7 @@ func (rpc *Rpc) Parse(
 }
 
 // Called when the FIN flag is seen in the TCP stream.
-func (rpc *Rpc) ReceivedFin(tcptuple *common.TcpTuple, dir uint8,
+func (rpc *Rpc) ReceivedFin(tcptuple *common.TCPTuple, dir uint8,
 	private protos.ProtocolData) protos.ProtocolData {
 
 	defer logp.Recover("ReceivedFinRpc exception")
@@ -133,7 +133,7 @@ func (rpc *Rpc) ReceivedFin(tcptuple *common.TcpTuple, dir uint8,
 
 // Called when a packets are missing from the tcp
 // stream.
-func (rpc *Rpc) GapInStream(tcptuple *common.TcpTuple, dir uint8,
+func (rpc *Rpc) GapInStream(tcptuple *common.TCPTuple, dir uint8,
 	nbytes int, private protos.ProtocolData) (priv protos.ProtocolData, drop bool) {
 
 	defer logp.Recover("GapInRpcStream exception")
@@ -179,7 +179,7 @@ func getRpcConnection(private protos.ProtocolData) *rpcConnectionData {
 func (rpc *Rpc) handleRpcFragment(
 	conn *rpcConnectionData,
 	pkt *protos.Packet,
-	tcptuple *common.TcpTuple,
+	tcptuple *common.TCPTuple,
 	dir uint8,
 ) *rpcConnectionData {
 
@@ -229,7 +229,7 @@ func (rpc *Rpc) handleRpcFragment(
 	return conn
 }
 
-func (rpc *Rpc) handleRpcPacket(xdr *Xdr, ts time.Time, tcptuple *common.TcpTuple, dir uint8) {
+func (rpc *Rpc) handleRpcPacket(xdr *Xdr, ts time.Time, tcptuple *common.TCPTuple, dir uint8) {
 
 	xid := fmt.Sprintf("%.8x", xdr.getUInt())
 
@@ -245,7 +245,7 @@ func (rpc *Rpc) handleRpcPacket(xdr *Xdr, ts time.Time, tcptuple *common.TcpTupl
 	}
 }
 
-func newStream(pkt *protos.Packet, tcptuple *common.TcpTuple) *RpcStream {
+func newStream(pkt *protos.Packet, tcptuple *common.TCPTuple) *RpcStream {
 	return &RpcStream{
 		tcpTuple: tcptuple,
 		rawData:  pkt.Payload,

--- a/packetbeat/protos/pgsql/parse.go
+++ b/packetbeat/protos/pgsql/parse.go
@@ -379,7 +379,7 @@ func pgsqlFieldsParser(s *PgsqlStream, buf []byte) error {
 		off += 4
 
 		// read format (int16)
-		format := common.Bytes_Ntohs(buf[off : off+2])
+		format := common.BytesNtohs(buf[off : off+2])
 		off += 2
 		fieldsFormat = append(fieldsFormat, byte(format))
 
@@ -649,7 +649,7 @@ func isSpecialPgsqlCommand(data []byte) (bool, int, int) {
 	length := readLength(data[0:])
 
 	// read command identifier
-	code := int(common.Bytes_Ntohl(data[4:]))
+	code := int(common.BytesNtohl(data[4:]))
 
 	if length == 16 && code == 80877102 {
 		// Cancel Request
@@ -670,11 +670,11 @@ func isSpecialPgsqlCommand(data []byte) (bool, int, int) {
 // length field in pgsql counts total length of length field + payload, not
 // including the message identifier. => Always check buffer size >= length + 1
 func readLength(b []byte) int {
-	return int(common.Bytes_Ntohl(b))
+	return int(common.BytesNtohl(b))
 }
 
 func readCount(b []byte) int {
-	return int(common.Bytes_Ntohs(b))
+	return int(common.BytesNtohs(b))
 }
 
 func pgsqlString(b []byte, sz int) (string, error) {

--- a/packetbeat/protos/pgsql/pgsql_test.go
+++ b/packetbeat/protos/pgsql/pgsql_test.go
@@ -201,11 +201,11 @@ func TestPgsqlParser_threeResponses(t *testing.T) {
 		Payload: data,
 		Ts:      ts,
 	}
-	var tuple common.TcpTuple
+	var tuple common.TCPTuple
 	var private pgsqlPrivateData
 	var count_handlePgsql = 0
 
-	pgsql.handlePgsql = func(pgsql *Pgsql, m *PgsqlMessage, tcptuple *common.TcpTuple,
+	pgsql.handlePgsql = func(pgsql *Pgsql, m *PgsqlMessage, tcptuple *common.TCPTuple,
 		dir uint8, raw_msg []byte) {
 
 		count_handlePgsql += 1
@@ -291,11 +291,11 @@ func TestPgsqlParser_invalidMessage(t *testing.T) {
 	}
 }
 
-func testTcpTuple() *common.TcpTuple {
-	t := &common.TcpTuple{
-		Ip_length: 4,
-		Src_ip:    net.IPv4(192, 168, 0, 1), Dst_ip: net.IPv4(192, 168, 0, 2),
-		Src_port: 6512, Dst_port: 5432,
+func testTcpTuple() *common.TCPTuple {
+	t := &common.TCPTuple{
+		IPLength: 4,
+		SrcIP:    net.IPv4(192, 168, 0, 1), DstIP: net.IPv4(192, 168, 0, 2),
+		SrcPort: 6512, DstPort: 5432,
 	}
 	t.ComputeHashebles()
 	return t

--- a/packetbeat/protos/pgsql/pgsql_test.go
+++ b/packetbeat/protos/pgsql/pgsql_test.go
@@ -353,7 +353,7 @@ func Test_gap_in_response(t *testing.T) {
 
 	logp.Debug("pgsql", "Now sending gap..")
 
-	private, drop := pgsql.GapInStream(tcptuple, 1, 10, private)
+	_, drop := pgsql.GapInStream(tcptuple, 1, 10, private)
 	assert.Equal(t, true, drop)
 
 	trans := expectTransaction(t, pgsql)

--- a/packetbeat/protos/protos.go
+++ b/packetbeat/protos/protos.go
@@ -24,7 +24,7 @@ type ProtocolData interface{}
 
 type Packet struct {
 	Ts      time.Time
-	Tuple   common.IpPortTuple
+	Tuple   common.IPPortTuple
 	Payload []byte
 }
 

--- a/packetbeat/protos/protos_test.go
+++ b/packetbeat/protos/protos_test.go
@@ -26,17 +26,17 @@ func (proto *TcpProtocol) GetPorts() []int {
 	return proto.Ports
 }
 
-func (proto *TcpProtocol) Parse(pkt *Packet, tcptuple *common.TcpTuple,
+func (proto *TcpProtocol) Parse(pkt *Packet, tcptuple *common.TCPTuple,
 	dir uint8, private ProtocolData) ProtocolData {
 	return private
 }
 
-func (proto *TcpProtocol) ReceivedFin(tcptuple *common.TcpTuple, dir uint8,
+func (proto *TcpProtocol) ReceivedFin(tcptuple *common.TCPTuple, dir uint8,
 	private ProtocolData) ProtocolData {
 	return private
 }
 
-func (proto *TcpProtocol) GapInStream(tcptuple *common.TcpTuple, dir uint8,
+func (proto *TcpProtocol) GapInStream(tcptuple *common.TCPTuple, dir uint8,
 	nbytes int, private ProtocolData) (priv ProtocolData, drop bool) {
 	return private, true
 }
@@ -67,17 +67,17 @@ func (proto *TcpUdpProtocol) GetPorts() []int {
 	return proto.Ports
 }
 
-func (proto *TcpUdpProtocol) Parse(pkt *Packet, tcptuple *common.TcpTuple,
+func (proto *TcpUdpProtocol) Parse(pkt *Packet, tcptuple *common.TCPTuple,
 	dir uint8, private ProtocolData) ProtocolData {
 	return private
 }
 
-func (proto *TcpUdpProtocol) ReceivedFin(tcptuple *common.TcpTuple, dir uint8,
+func (proto *TcpUdpProtocol) ReceivedFin(tcptuple *common.TCPTuple, dir uint8,
 	private ProtocolData) ProtocolData {
 	return private
 }
 
-func (proto *TcpUdpProtocol) GapInStream(tcptuple *common.TcpTuple, dir uint8,
+func (proto *TcpUdpProtocol) GapInStream(tcptuple *common.TCPTuple, dir uint8,
 	nbytes int, private ProtocolData) (priv ProtocolData, drop bool) {
 	return private, true
 }

--- a/packetbeat/protos/redis/redis.go
+++ b/packetbeat/protos/redis/redis.go
@@ -18,7 +18,7 @@ import (
 type stream struct {
 	applayer.Stream
 	parser   parser
-	tcptuple *common.TcpTuple
+	tcptuple *common.TCPTuple
 }
 
 type redisConnectionData struct {
@@ -107,7 +107,7 @@ func (redis *Redis) ConnectionTimeout() time.Duration {
 
 func (redis *Redis) Parse(
 	pkt *protos.Packet,
-	tcptuple *common.TcpTuple,
+	tcptuple *common.TCPTuple,
 	dir uint8,
 	private protos.ProtocolData,
 ) protos.ProtocolData {
@@ -142,7 +142,7 @@ func ensureRedisConnection(private protos.ProtocolData) *redisConnectionData {
 func (redis *Redis) doParse(
 	conn *redisConnectionData,
 	pkt *protos.Packet,
-	tcptuple *common.TcpTuple,
+	tcptuple *common.TCPTuple,
 	dir uint8,
 ) *redisConnectionData {
 
@@ -203,7 +203,7 @@ func (redis *Redis) doParse(
 	return conn
 }
 
-func newStream(ts time.Time, tcptuple *common.TcpTuple) *stream {
+func newStream(ts time.Time, tcptuple *common.TCPTuple) *stream {
 	s := &stream{
 		tcptuple: tcptuple,
 	}
@@ -219,12 +219,12 @@ func newMessage(ts time.Time) *redisMessage {
 func (redis *Redis) handleRedis(
 	conn *redisConnectionData,
 	m *redisMessage,
-	tcptuple *common.TcpTuple,
+	tcptuple *common.TCPTuple,
 	dir uint8,
 ) {
 	m.TcpTuple = *tcptuple
 	m.Direction = dir
-	m.CmdlineTuple = procs.ProcWatcher.FindProcessesTuple(tcptuple.IpPort())
+	m.CmdlineTuple = procs.ProcWatcher.FindProcessesTuple(tcptuple.IPPort())
 
 	if m.IsRequest {
 		conn.requests.append(m) // wait for response
@@ -275,13 +275,13 @@ func (redis *Redis) newTransaction(requ, resp *redisMessage) common.MapStr {
 	}
 
 	src := &common.Endpoint{
-		Ip:   requ.TcpTuple.Src_ip.String(),
-		Port: requ.TcpTuple.Src_port,
+		IP:   requ.TcpTuple.SrcIP.String(),
+		Port: requ.TcpTuple.SrcPort,
 		Proc: string(requ.CmdlineTuple.Src),
 	}
 	dst := &common.Endpoint{
-		Ip:   requ.TcpTuple.Dst_ip.String(),
-		Port: requ.TcpTuple.Dst_port,
+		IP:   requ.TcpTuple.DstIP.String(),
+		Port: requ.TcpTuple.DstPort,
 		Proc: string(requ.CmdlineTuple.Dst),
 	}
 	if requ.Direction == tcp.TcpDirectionReverse {
@@ -315,7 +315,7 @@ func (redis *Redis) newTransaction(requ, resp *redisMessage) common.MapStr {
 	return event
 }
 
-func (redis *Redis) GapInStream(tcptuple *common.TcpTuple, dir uint8,
+func (redis *Redis) GapInStream(tcptuple *common.TCPTuple, dir uint8,
 	nbytes int, private protos.ProtocolData) (priv protos.ProtocolData, drop bool) {
 
 	// tsg: being packet loss tolerant is probably not very useful for Redis,
@@ -324,7 +324,7 @@ func (redis *Redis) GapInStream(tcptuple *common.TcpTuple, dir uint8,
 	return private, true
 }
 
-func (redis *Redis) ReceivedFin(tcptuple *common.TcpTuple, dir uint8,
+func (redis *Redis) ReceivedFin(tcptuple *common.TCPTuple, dir uint8,
 	private protos.ProtocolData) protos.ProtocolData {
 
 	// TODO: check if we have pending data that we can send up the stack

--- a/packetbeat/protos/redis/redis_parse.go
+++ b/packetbeat/protos/redis/redis_parse.go
@@ -17,7 +17,7 @@ type parser struct {
 type redisMessage struct {
 	Ts time.Time
 
-	TcpTuple     common.TcpTuple
+	TcpTuple     common.TCPTuple
 	CmdlineTuple *common.CmdlineTuple
 	Direction    uint8
 
@@ -439,7 +439,7 @@ func (p *parser) parseArray(depth int, buf *streambuf.Buffer) (common.NetString,
 
 func parseInt(line []byte) (int64, error) {
 	buf := streambuf.NewFixed(line)
-	return buf.AsciiInt(false)
+	return buf.IntASCII(false)
 	// TODO: is it an error if 'buf.Len() != 0 {}' ?
 }
 

--- a/packetbeat/protos/registry.go
+++ b/packetbeat/protos/registry.go
@@ -23,16 +23,16 @@ type TcpPlugin interface {
 	Plugin
 
 	// Called when TCP payload data is available for parsing.
-	Parse(pkt *Packet, tcptuple *common.TcpTuple,
+	Parse(pkt *Packet, tcptuple *common.TCPTuple,
 		dir uint8, private ProtocolData) ProtocolData
 
 	// Called when the FIN flag is seen in the TCP stream.
-	ReceivedFin(tcptuple *common.TcpTuple, dir uint8,
+	ReceivedFin(tcptuple *common.TCPTuple, dir uint8,
 		private ProtocolData) ProtocolData
 
 	// Called when a packets are missing from the tcp
 	// stream.
-	GapInStream(tcptuple *common.TcpTuple, dir uint8, nbytes int,
+	GapInStream(tcptuple *common.TCPTuple, dir uint8, nbytes int,
 		private ProtocolData) (priv ProtocolData, drop bool)
 
 	// ConnectionTimeout returns the per stream connection timeout.

--- a/packetbeat/protos/tcp/tcp.go
+++ b/packetbeat/protos/tcp/tcp.go
@@ -54,13 +54,13 @@ func (tcp *Tcp) getId() uint32 {
 	return tcp.id
 }
 
-func (tcp *Tcp) decideProtocol(tuple *common.IpPortTuple) protos.Protocol {
-	protocol, exists := tcp.portMap[tuple.Src_port]
+func (tcp *Tcp) decideProtocol(tuple *common.IPPortTuple) protos.Protocol {
+	protocol, exists := tcp.portMap[tuple.SrcPort]
 	if exists {
 		return protocol
 	}
 
-	protocol, exists = tcp.portMap[tuple.Dst_port]
+	protocol, exists = tcp.portMap[tuple.DstPort]
 	if exists {
 		return protocol
 	}
@@ -68,7 +68,7 @@ func (tcp *Tcp) decideProtocol(tuple *common.IpPortTuple) protos.Protocol {
 	return protos.UnknownProtocol
 }
 
-func (tcp *Tcp) findStream(k common.HashableIpPortTuple) *TcpConnection {
+func (tcp *Tcp) findStream(k common.HashableIPPortTuple) *TcpConnection {
 	v := tcp.streams.Get(k)
 	if v != nil {
 		return v.(*TcpConnection)
@@ -78,9 +78,9 @@ func (tcp *Tcp) findStream(k common.HashableIpPortTuple) *TcpConnection {
 
 type TcpConnection struct {
 	id       uint32
-	tuple    *common.IpPortTuple
+	tuple    *common.IPPortTuple
 	protocol protos.Protocol
-	tcptuple common.TcpTuple
+	tcptuple common.TCPTuple
 	tcp      *Tcp
 
 	lastSeq [2]uint32
@@ -232,8 +232,8 @@ func (tcp *Tcp) getStream(pkt *protos.Packet) (stream TcpStream, created bool) {
 	if isDebug {
 		t := pkt.Tuple
 		debugf("Connection src[%s:%d] dst[%s:%d] doesn't exist, creating new",
-			t.Src_ip.String(), t.Src_port,
-			t.Dst_ip.String(), t.Dst_port)
+			t.SrcIP.String(), t.SrcPort,
+			t.DstIP.String(), t.DstPort)
 	}
 
 	conn := &TcpConnection{
@@ -241,7 +241,7 @@ func (tcp *Tcp) getStream(pkt *protos.Packet) (stream TcpStream, created bool) {
 		tuple:    &pkt.Tuple,
 		protocol: protocol,
 		tcp:      tcp}
-	conn.tcptuple = common.TcpTupleFromIpPort(conn.tuple, conn.id)
+	conn.tcptuple = common.TCPTupleFromIPPort(conn.tuple, conn.id)
 	tcp.streams.PutWithTimeout(pkt.Tuple.Hashable(), conn, timeout)
 	return TcpStream{conn: conn, dir: TcpDirectionOriginal}, true
 }

--- a/packetbeat/protos/tcp/tcp_test.go
+++ b/packetbeat/protos/tcp/tcp_test.go
@@ -45,20 +45,20 @@ type TestProtocol struct {
 	Ports []int
 
 	init  func(testMode bool, results publish.Transactions) error
-	parse func(*protos.Packet, *common.TcpTuple, uint8, protos.ProtocolData) protos.ProtocolData
-	onFin func(*common.TcpTuple, uint8, protos.ProtocolData) protos.ProtocolData
-	gap   func(*common.TcpTuple, uint8, int, protos.ProtocolData) (protos.ProtocolData, bool)
+	parse func(*protos.Packet, *common.TCPTuple, uint8, protos.ProtocolData) protos.ProtocolData
+	onFin func(*common.TCPTuple, uint8, protos.ProtocolData) protos.ProtocolData
+	gap   func(*common.TCPTuple, uint8, int, protos.ProtocolData) (protos.ProtocolData, bool)
 }
 
 var _ protos.Plugin = &TestProtocol{
 	init: func(m bool, r publish.Transactions) error { return nil },
-	parse: func(p *protos.Packet, t *common.TcpTuple, d uint8, priv protos.ProtocolData) protos.ProtocolData {
+	parse: func(p *protos.Packet, t *common.TCPTuple, d uint8, priv protos.ProtocolData) protos.ProtocolData {
 		return priv
 	},
-	onFin: func(t *common.TcpTuple, d uint8, p protos.ProtocolData) protos.ProtocolData {
+	onFin: func(t *common.TCPTuple, d uint8, p protos.ProtocolData) protos.ProtocolData {
 		return p
 	},
-	gap: func(t *common.TcpTuple, d uint8, b int, p protos.ProtocolData) (protos.ProtocolData, bool) {
+	gap: func(t *common.TCPTuple, d uint8, b int, p protos.ProtocolData) (protos.ProtocolData, bool) {
 		return p, true
 	},
 }
@@ -71,17 +71,17 @@ func (proto TestProtocol) GetPorts() []int {
 	return proto.Ports
 }
 
-func (proto TestProtocol) Parse(pkt *protos.Packet, tcptuple *common.TcpTuple,
+func (proto TestProtocol) Parse(pkt *protos.Packet, tcptuple *common.TCPTuple,
 	dir uint8, private protos.ProtocolData) protos.ProtocolData {
 	return proto.parse(pkt, tcptuple, dir, private)
 }
 
-func (proto TestProtocol) ReceivedFin(tcptuple *common.TcpTuple, dir uint8,
+func (proto TestProtocol) ReceivedFin(tcptuple *common.TCPTuple, dir uint8,
 	private protos.ProtocolData) protos.ProtocolData {
 	return proto.onFin(tcptuple, dir, private)
 }
 
-func (proto TestProtocol) GapInStream(tcptuple *common.TcpTuple, dir uint8,
+func (proto TestProtocol) GapInStream(tcptuple *common.TCPTuple, dir uint8,
 	nbytes int, private protos.ProtocolData) (priv protos.ProtocolData, drop bool) {
 	return proto.gap(tcptuple, dir, nbytes, private)
 }
@@ -286,7 +286,7 @@ func TestTCSeqPayload(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		addr := common.NewIpPortTuple(4,
+		addr := common.NewIPPortTuple(4,
 			net.ParseIP(ServerIp), ServerPort,
 			net.ParseIP(ClientIp), uint16(rand.Intn(65535)))
 
@@ -324,7 +324,7 @@ func BenchmarkParallelProcess(b *testing.B) {
 		for pb.Next() {
 			pkt := &protos.Packet{
 				Ts: time.Now(),
-				Tuple: common.NewIpPortTuple(4,
+				Tuple: common.NewIPPortTuple(4,
 					net.ParseIP(ServerIp), ServerPort,
 					net.ParseIP(ClientIp), uint16(rand.Intn(65535))),
 				Payload: []byte{1, 2, 3, 4},
@@ -337,9 +337,9 @@ func BenchmarkParallelProcess(b *testing.B) {
 func makeCountGaps(
 	counter *int,
 	bytes *int,
-) func(*common.TcpTuple, uint8, int, protos.ProtocolData) (protos.ProtocolData, bool) {
+) func(*common.TCPTuple, uint8, int, protos.ProtocolData) (protos.ProtocolData, bool) {
 	return func(
-		t *common.TcpTuple,
+		t *common.TCPTuple,
 		d uint8,
 		n int,
 		p protos.ProtocolData,
@@ -358,10 +358,10 @@ func makeCountGaps(
 func makeCollectPayload(
 	state *[]byte,
 	resetOnNil bool,
-) func(*protos.Packet, *common.TcpTuple, uint8, protos.ProtocolData) protos.ProtocolData {
+) func(*protos.Packet, *common.TCPTuple, uint8, protos.ProtocolData) protos.ProtocolData {
 	return func(
 		p *protos.Packet,
-		t *common.TcpTuple,
+		t *common.TCPTuple,
 		d uint8,
 		priv protos.ProtocolData,
 	) protos.ProtocolData {

--- a/packetbeat/protos/thrift/thrift_test.go
+++ b/packetbeat/protos/thrift/thrift_test.go
@@ -1072,8 +1072,7 @@ func TestThrift_GapInStream_response(t *testing.T) {
 	private := protos.ProtocolData(new(thriftPrivateData))
 	private = thrift.Parse(req, tcptuple, 0, private)
 	private = thrift.Parse(repl, tcptuple, 1, private)
-	private, drop := thrift.GapInStream(tcptuple, 1, 5, private)
-
+	_, drop := thrift.GapInStream(tcptuple, 1, 5, private)
 	if drop == false {
 		t.Error("GapInStream returned drop=false")
 	}
@@ -1124,8 +1123,7 @@ func TestThrift_GapInStream_request(t *testing.T) {
 	private = thrift.Parse(req, tcptuple, 0, private)
 	private, drop := thrift.GapInStream(tcptuple, 0, 5, private)
 
-	private = thrift.Parse(repl, tcptuple, 1, private)
-
+	thrift.Parse(repl, tcptuple, 1, private)
 	if drop == false {
 		t.Error("GapInStream returned drop=false")
 	}

--- a/packetbeat/protos/thrift/thrift_test.go
+++ b/packetbeat/protos/thrift/thrift_test.go
@@ -584,11 +584,11 @@ func expectThriftTransaction(t *testing.T, thrift *Thrift) *ThriftTransaction {
 	return nil
 }
 
-func testTcpTuple() *common.TcpTuple {
-	t := &common.TcpTuple{
-		Ip_length: 4,
-		Src_ip:    net.IPv4(192, 168, 0, 1), Dst_ip: net.IPv4(192, 168, 0, 2),
-		Src_port: 9200, Dst_port: 9201,
+func testTcpTuple() *common.TCPTuple {
+	t := &common.TCPTuple{
+		IPLength: 4,
+		SrcIP:    net.IPv4(192, 168, 0, 1), DstIP: net.IPv4(192, 168, 0, 2),
+		SrcPort: 9200, DstPort: 9201,
 	}
 	t.ComputeHashebles()
 	return t

--- a/packetbeat/protos/udp/udp.go
+++ b/packetbeat/protos/udp/udp.go
@@ -22,13 +22,13 @@ type Processor interface {
 // decideProtocol determines the protocol based on the source and destination
 // ports. If the protocol cannot be determined then protos.UnknownProtocol
 // is returned.
-func (udp *Udp) decideProtocol(tuple *common.IpPortTuple) protos.Protocol {
-	protocol, exists := udp.portMap[tuple.Src_port]
+func (udp *Udp) decideProtocol(tuple *common.IPPortTuple) protos.Protocol {
+	protocol, exists := udp.portMap[tuple.SrcPort]
 	if exists {
 		return protocol
 	}
 
-	protocol, exists = udp.portMap[tuple.Dst_port]
+	protocol, exists = udp.portMap[tuple.DstPort]
 	if exists {
 		return protocol
 	}

--- a/packetbeat/protos/udp/udp_test.go
+++ b/packetbeat/protos/udp/udp_test.go
@@ -193,7 +193,7 @@ func Test_buildPortsMap_portOverlapError(t *testing.T) {
 // packet's source port.
 func Test_decideProtocol_bySrcPort(t *testing.T) {
 	test := testSetup(t)
-	tuple := common.NewIpPortTuple(4,
+	tuple := common.NewIPPortTuple(4,
 		net.ParseIP("192.168.0.1"), PORT,
 		net.ParseIP("10.0.0.1"), 34898)
 	assert.Equal(t, PROTO, test.udp.decideProtocol(&tuple))
@@ -203,7 +203,7 @@ func Test_decideProtocol_bySrcPort(t *testing.T) {
 // packet's destination port.
 func Test_decideProtocol_byDstPort(t *testing.T) {
 	test := testSetup(t)
-	tuple := common.NewIpPortTuple(4,
+	tuple := common.NewIPPortTuple(4,
 		net.ParseIP("10.0.0.1"), 34898,
 		net.ParseIP("192.168.0.1"), PORT)
 	assert.Equal(t, PROTO, test.udp.decideProtocol(&tuple))
@@ -213,7 +213,7 @@ func Test_decideProtocol_byDstPort(t *testing.T) {
 // which it does not have a plugin.
 func TestProcess_unknownProtocol(t *testing.T) {
 	test := testSetup(t)
-	tuple := common.NewIpPortTuple(4,
+	tuple := common.NewIPPortTuple(4,
 		net.ParseIP("10.0.0.1"), 34898,
 		net.ParseIP("192.168.0.1"), PORT+1)
 	assert.Equal(t, protos.UnknownProtocol, test.udp.decideProtocol(&tuple))
@@ -222,7 +222,7 @@ func TestProcess_unknownProtocol(t *testing.T) {
 // Verify that Process ignores empty packets.
 func TestProcess_emptyPayload(t *testing.T) {
 	test := testSetup(t)
-	tuple := common.NewIpPortTuple(4,
+	tuple := common.NewIPPortTuple(4,
 		net.ParseIP("192.168.0.1"), PORT,
 		net.ParseIP("10.0.0.1"), 34898)
 	emptyPkt := &protos.Packet{Ts: time.Now(), Tuple: tuple, Payload: []byte{}}
@@ -234,7 +234,7 @@ func TestProcess_emptyPayload(t *testing.T) {
 // ProcessUdp on it.
 func TestProcess_nonEmptyPayload(t *testing.T) {
 	test := testSetup(t)
-	tuple := common.NewIpPortTuple(4,
+	tuple := common.NewIPPortTuple(4,
 		net.ParseIP("192.168.0.1"), PORT,
 		net.ParseIP("10.0.0.1"), 34898)
 	payload := []byte{1}

--- a/packetbeat/publish/publish.go
+++ b/packetbeat/publish/publish.go
@@ -195,7 +195,7 @@ func (p *PacketbeatPublisher) normalizeTransAddr(event common.MapStr) bool {
 	debugf("has src: %v", ok)
 	if ok {
 		// check if it's outgoing transaction (as client)
-		isOutgoing := p.topo.IsPublisherIP(src.Ip)
+		isOutgoing := p.topo.IsPublisherIP(src.IP)
 		if isOutgoing {
 			if p.ignoreOutgoing {
 				// duplicated transaction -> ignore it
@@ -207,8 +207,8 @@ func (p *PacketbeatPublisher) normalizeTransAddr(event common.MapStr) bool {
 			event["direction"] = "out"
 		}
 
-		srcServer = p.topo.GetServerName(src.Ip)
-		event["client_ip"] = src.Ip
+		srcServer = p.topo.GetServerName(src.IP)
+		event["client_ip"] = src.IP
 		event["client_port"] = src.Port
 		event["client_proc"] = src.Proc
 		event["client_server"] = srcServer
@@ -218,15 +218,15 @@ func (p *PacketbeatPublisher) normalizeTransAddr(event common.MapStr) bool {
 	dst, ok := event["dst"].(*common.Endpoint)
 	debugf("has dst: %v", ok)
 	if ok {
-		dstServer = p.topo.GetServerName(dst.Ip)
-		event["ip"] = dst.Ip
+		dstServer = p.topo.GetServerName(dst.IP)
+		event["ip"] = dst.IP
 		event["port"] = dst.Port
 		event["proc"] = dst.Proc
 		event["server"] = dstServer
 		delete(event, "dst")
 
 		//check if it's incoming transaction (as server)
-		if p.topo.IsPublisherIP(dst.Ip) {
+		if p.topo.IsPublisherIP(dst.IP) {
 			// incoming transaction
 			event["direction"] = "in"
 		}
@@ -243,7 +243,7 @@ func (p *PacketbeatPublisher) normalizeTransAddr(event common.MapStr) bool {
 			}
 		} else {
 			if len(srcServer) == 0 && src != nil { // only for external IP addresses
-				loc := p.geoLite.GetLocationByIP(src.Ip)
+				loc := p.geoLite.GetLocationByIP(src.IP)
 				if loc != nil && loc.Latitude != 0 && loc.Longitude != 0 {
 					loc := fmt.Sprintf("%f, %f", loc.Latitude, loc.Longitude)
 					event["client_location"] = loc

--- a/packetbeat/publish/publish_test.go
+++ b/packetbeat/publish/publish_test.go
@@ -67,14 +67,14 @@ func TestDirectionOut(t *testing.T) {
 
 	event := common.MapStr{
 		"src": &common.Endpoint{
-			Ip:      "192.145.2.4",
+			IP:      "192.145.2.4",
 			Port:    3267,
 			Name:    "server1",
 			Cmdline: "proc1 start",
 			Proc:    "proc1",
 		},
 		"dst": &common.Endpoint{
-			Ip:      "192.145.2.5",
+			IP:      "192.145.2.5",
 			Port:    32232,
 			Name:    "server2",
 			Cmdline: "proc2 start",
@@ -93,14 +93,14 @@ func TestDirectionIn(t *testing.T) {
 
 	event := common.MapStr{
 		"src": &common.Endpoint{
-			Ip:      "192.145.2.4",
+			IP:      "192.145.2.4",
 			Port:    3267,
 			Name:    "server1",
 			Cmdline: "proc1 start",
 			Proc:    "proc1",
 		},
 		"dst": &common.Endpoint{
-			Ip:      "192.145.2.5",
+			IP:      "192.145.2.5",
 			Port:    32232,
 			Name:    "server2",
 			Cmdline: "proc2 start",
@@ -115,7 +115,7 @@ func TestDirectionIn(t *testing.T) {
 
 func newTestPublisher(ips []string) *publisher.BeatPublisher {
 	p := &publisher.BeatPublisher{}
-	p.IpAddrs = ips
+	p.IPAddrs = ips
 	return p
 }
 
@@ -125,14 +125,14 @@ func TestNoDirection(t *testing.T) {
 
 	event := common.MapStr{
 		"src": &common.Endpoint{
-			Ip:      "192.145.2.4",
+			IP:      "192.145.2.4",
 			Port:    3267,
 			Name:    "server1",
 			Cmdline: "proc1 start",
 			Proc:    "proc1",
 		},
 		"dst": &common.Endpoint{
-			Ip:      "192.145.2.5",
+			IP:      "192.145.2.5",
 			Port:    32232,
 			Name:    "server2",
 			Cmdline: "proc2 start",

--- a/winlogbeat/eventlog/wineventlog.go
+++ b/winlogbeat/eventlog/wineventlog.go
@@ -245,7 +245,7 @@ func newWinEventLog(options map[string]interface{}) (EventLog, error) {
 			return mf
 		}
 
-		mf.Handles = []sys.FileHandle{sys.FileHandle{Handle: uintptr(h)}}
+		mf.Handles = []sys.FileHandle{{Handle: uintptr(h)}}
 		return mf
 	}
 

--- a/winlogbeat/sys/event_test.go
+++ b/winlogbeat/sys/event_test.go
@@ -85,9 +85,9 @@ func TestXML(t *testing.T) {
 				User:            SID{Identifier: "S-1-5-21-3541430928-2051711210-1391384369-1001"},
 				EventData: EventData{
 					Pairs: []KeyValue{
-						KeyValue{"param1", "winlogbeat"},
-						KeyValue{"param2", "running"},
-						KeyValue{"Binary", "770069006E006C006F00670062006500610074002F0034000000"},
+						{"param1", "winlogbeat"},
+						{"param2", "running"},
+						{"Binary", "770069006E006C006F00670062006500610074002F0034000000"},
 					},
 				},
 				UserData: UserData{
@@ -96,8 +96,8 @@ func TestXML(t *testing.T) {
 						Space: "Event_NS",
 					},
 					Pairs: []KeyValue{
-						KeyValue{"ServerName", `\\VAGRANT-2012-R2`},
-						KeyValue{"UserName", "vagrant"},
+						{"ServerName", `\\VAGRANT-2012-R2`},
+						{"UserName", "vagrant"},
 					},
 				},
 				Message:                 "Creating WSMan shell on server with ResourceUri: %1",
@@ -126,7 +126,7 @@ func TestXML(t *testing.T) {
 						Space: "http://manifests.microsoft.com/win/2006/windows/WMI",
 					},
 					Pairs: []KeyValue{
-						KeyValue{"Id", "{00000000-0000-0000-0000-000000000000}"},
+						{"Id", "{00000000-0000-0000-0000-000000000000}"},
 					},
 				},
 			},


### PR DESCRIPTION
Some minor code cleanups to make linters a little more happy (thanks goes to `gofmt -s` and `gorename`).

Includes:
- renames in libbeat to use camel case
- fix some spelling errors in comments
- modernize/simplify some code via `gofmt -s`
- check all ineffective assignments not being potential bugs (thus time no potential bugs have been found)
- ensure mutex-values are not accidentally copied