### PR TITLE
Backport: cherrypick_pr: display a deep link to the GH PR (#2816)

### DIFF
--- a/dev-tools/cherrypick_pr
+++ b/dev-tools/cherrypick_pr
@@ -67,7 +67,7 @@ def main():
 
         call("git branch -D {} > /dev/null".format(tmp_branch), shell=True)
         check_call("git checkout -b {}".format(tmp_branch), shell=True)
-        if call("git cherry-pick {}".format(" ".join(args.commit_hashes)),
+        if call("git cherry-pick -x {}".format(" ".join(args.commit_hashes)),
                 shell=True) != 0:
             print("Looks like you have cherry-pick errors.")
             print("Fix them, then run: ")
@@ -91,8 +91,9 @@ def main():
          shell=True)
     check_call("git push --set-upstream {} {}"
                .format(remote, tmp_branch), shell=True)
-    print("Done. Go to Github and open the PR. Branch name is: {}"
-          .format(tmp_branch))
+    print("Done. Open PR by following this URL: \n\t" +
+          "https://github.com/elastic/beats/compare/{}...{}:{}?expand=1"
+          .format(args.to_branch, remote, tmp_branch))
 
 if __name__ == "__main__":
     sys.exit(main())


### PR DESCRIPTION
Backport of #2816 to 5.0 (it's convenient to have the same script in both branches):

This displays at end a link that, if followed, sends you to the
pre-filled PR form which you can customize and publish. This skips
the selection of the target branch, which can be slow on GitHub.

Also added the -x flag to the cherry-pick command which adds a note
that the commit was cherry picked.
(cherry picked from commit 07303aeb667b99403f8bb58e5f5917ef81565060)