### PR TITLE
Clarify instructions for running configtest

### DIFF
--- a/filebeat/docs/getting-started.asciidoc
+++ b/filebeat/docs/getting-started.asciidoc
@@ -141,14 +141,18 @@ output.elasticsearch:
 +
 If you are sending output to Logstash, see <<config-filebeat-logstash>> instead.
 
-TIP: To test your configuration file, run Filebeat in the foreground with the following options specified:
-+./filebeat -configtest -e+.
+TIP: To test your configuration file, change to the directory where the Filebeat
+binary is installed, and run Filebeat in the foreground with the following
+options specified: +./filebeat -configtest -e+. Make sure your config files are
+in the path expected by Filebeat (see <<directory-layout>>). If you
+installed from DEB or RPM packages, run +./filebeat.sh -configtest -e+.
 
 See <<filebeat-configuration-details>> for more details about each configuration option.
 
 [[config-filebeat-logstash]]
 === Step 3: Configuring Filebeat to Use Logstash
 
+:allplatforms:
 include::../../libbeat/docs/shared-logstash-config.asciidoc[]
 
 [[filebeat-template]]

--- a/filebeat/docs/index.asciidoc
+++ b/filebeat/docs/index.asciidoc
@@ -38,6 +38,7 @@ include::../../libbeat/docs/shared-env-vars.asciidoc[]
 
 include::./multiple-prospectors.asciidoc[]
 
+:allplatforms:
 include::../../libbeat/docs/yaml.asciidoc[]
 
 include::../../libbeat/docs/regexp.asciidoc[]

--- a/libbeat/docs/config-file-format.asciidoc
+++ b/libbeat/docs/config-file-format.asciidoc
@@ -355,8 +355,9 @@ simply uncomment the line and change the values.
 [float]
 ==== Test Your Config File
 
-You can test your configuration file to verify that the structure is valid. Simply run
-your in the foreground with the `-configtest` flag specified. For example:
+You can test your configuration file to verify that the structure is valid.
+Simply change to the directory where the binary is installed, and run
+your Beat in the foreground with the `-configtest` flag specified. For example:
 
 ["source","yaml",subs="attributes,callouts"]
 ----------------------------------------------------------------------

--- a/libbeat/docs/shared-logstash-config.asciidoc
+++ b/libbeat/docs/shared-logstash-config.asciidoc
@@ -29,8 +29,23 @@ Beats connections.
 For this configuration, you must <<load-template-manually,load the index template into Elasticsearch manually>>
 because the options for auto loading the template are only available for the Elasticsearch output.
 
-TIP: To test your configuration file, run {beatname_uc} in the foreground with the following options specified:
-+./{beatname_lc} -configtest -e+.
+ifdef::allplatforms[]
+
+TIP: To test your configuration file, change to the directory where the {beatname_uc} 
+binary is installed, and run {beatname_uc} in the foreground with the following
+options specified: +./{beatname_lc} -configtest -e+. Make sure your config files are
+in the path expected by {beatname_uc} (see <<directory-layout>>). If you
+installed from DEB or RPM packages, run +./{beatname_lc}.sh -configtest -e+.
+
+endif::allplatforms[]
+
+ifdef::win[]
+
+TIP: To test your configuration file, change to the directory where the {beatname_uc} 
+binary is installed, and run {beatname_uc} in the foreground with the following
+options specified: +.\winlogbeat.exe -c .\winlogbeat.yml -configtest -e+.
+
+endif::win[]
 
 To use this configuration, you must also
 {libbeat}/logstash-installation.html#logstash-setup[set up Logstash] to receive events

--- a/libbeat/docs/yaml.asciidoc
+++ b/libbeat/docs/yaml.asciidoc
@@ -31,13 +31,27 @@ simply uncomment the line and change the setting.
 [float]
 === Test Your Config File
 
-You can test your configuration file to verify that the structure is valid. Simply run
+You can test your configuration file to verify that the structure is valid.
+Simply change to the directory where the binary is installed, and run
 {beatname_uc} in the foreground with the `-configtest` flag specified. For example: 
 
-["source","yaml",subs="attributes,callouts"]
+ifdef::allplatforms[]
+
+["source","shell",subs="attributes"]
 ----------------------------------------------------------------------
 {beatname_lc} -c {beatname_lc}.yml -configtest
 ----------------------------------------------------------------------
+
+endif::allplatforms[]
+
+ifdef::win[]
+
+["source","shell",subs="attributes"]
+----------------------------------------------------------------------
+.\winlogbeat.exe -c .\winlogbeat.yml -configtest -e
+----------------------------------------------------------------------
+
+endif::win[]
 
 You'll see a message if {beatname_uc} finds an error in the file.
 

--- a/metricbeat/docs/configuring-logstash.asciidoc
+++ b/metricbeat/docs/configuring-logstash.asciidoc
@@ -1,4 +1,5 @@
 [[config-metricbeat-logstash]]
 == Configuring Metricbeat to Use Logstash
 
+:allplatforms:
 include::../../libbeat/docs/shared-logstash-config.asciidoc[]

--- a/metricbeat/docs/index.asciidoc
+++ b/metricbeat/docs/index.asciidoc
@@ -35,6 +35,7 @@ include::./configuring-logstash.asciidoc[]
 
 include::../../libbeat/docs/shared-env-vars.asciidoc[]
 
+:allplatforms:
 include::../../libbeat/docs/yaml.asciidoc[]
 
 include::../../libbeat/docs/regexp.asciidoc[]

--- a/packetbeat/docs/configuring-logstash.asciidoc
+++ b/packetbeat/docs/configuring-logstash.asciidoc
@@ -1,4 +1,5 @@
 [[config-packetbeat-logstash]]
 == Configuring Packetbeat to Use Logstash
 
+:allplatforms:
 include::../../libbeat/docs/shared-logstash-config.asciidoc[]

--- a/packetbeat/docs/gettingstarted.asciidoc
+++ b/packetbeat/docs/gettingstarted.asciidoc
@@ -189,8 +189,11 @@ output.elasticsearch:
 +
 If you are sending output to Logstash, see <<config-packetbeat-logstash>> instead.
 
-TIP: To test your configuration file, run Packetbeat in the foreground with the following options specified:
-+sudo ./packetbeat -configtest -e+.
+TIP: To test your configuration file, change to the directory where the Packetbeat
+binary is installed, and run Packetbeat in the foreground with the following
+options specified: +sudo ./packetbeat -configtest -e+. Make sure your config files are
+in the path expected by Packetbeat (see <<directory-layout>>). If you
+installed from DEB or RPM packages, run +sudo ./packetbeat.sh -configtest -e+.
 
 [[packetbeat-template]]
 === Step 3: Loading the Index Template in Elasticsearch

--- a/packetbeat/docs/index.asciidoc
+++ b/packetbeat/docs/index.asciidoc
@@ -45,6 +45,7 @@ include::./thrift.asciidoc[]
 
 include::./maintaining-topology.asciidoc[]
 
+:allplatforms:
 include::../../libbeat/docs/yaml.asciidoc[]
 
 include::./fields.asciidoc[]

--- a/winlogbeat/docs/getting-started.asciidoc
+++ b/winlogbeat/docs/getting-started.asciidoc
@@ -121,6 +121,7 @@ PS C:\Program Files\Winlogbeat> .\winlogbeat.exe -c .\winlogbeat.yml -configtest
 [[config-winlogbeat-logstash]]
 === Step 3: Configuring Winlogbeat to Use Logstash
 
+:win:
 include::../../libbeat/docs/shared-logstash-config.asciidoc[]
 
 [[winlogbeat-template]]

--- a/winlogbeat/docs/index.asciidoc
+++ b/winlogbeat/docs/index.asciidoc
@@ -32,6 +32,7 @@ include::../../libbeat/docs/shared-config-ingest.asciidoc[]
 
 include::../../libbeat/docs/shared-env-vars.asciidoc[]
 
+:win:
 include::../../libbeat/docs/yaml.asciidoc[]
 
 include::./fields.asciidoc[]


### PR DESCRIPTION
Fixes issue reported in #2790 (clarified description for running configtest).

Also added some conditional coding because we were showing commands for winlogbeat that weren't right (source text is in shared files, hence the need to add conditional coding).
