### PR TITLE
Remove ERR migration log entry on startup

### DIFF
--- a/filebeat/registrar/registrar.go
+++ b/filebeat/registrar/registrar.go
@@ -142,7 +142,17 @@ func (r *Registrar) loadAndConvertOldState(f *os.File) bool {
 		return false
 	}
 
+	// Check if already new state format
 	decoder := json.NewDecoder(f)
+	newState := []file.State{}
+	err = decoder.Decode(&newState)
+	// No error means registry is already in new format
+	if err == nil {
+		return false
+	}
+
+	// Reset file offset
+	f.Seek(0, 0)
 	oldStates := map[string]file.State{}
 	err = decoder.Decode(&oldStates)
 	if err != nil {


### PR DESCRIPTION
An ERR message was written to the log file in case the state file was already in the new format. Now it is first checked if the file is already in the new format and it is only tried to conver the file if this is not the case.