### PR TITLE
Remove ERR migration log entry on startup

### DIFF
--- a/filebeat/registrar/registrar.go
+++ b/filebeat/registrar/registrar.go
@@ -124,10 +124,19 @@ func (r *Registrar) loadAndConvertOldState(f *os.File) bool {
 	// Make sure file reader is reset afterwards
 	defer f.Seek(0, 0)
 
+	// Check if already new state format
 	decoder := json.NewDecoder(f)
-	oldStates := map[string]file.State{}
-	err := decoder.Decode(&oldStates)
+	newState := []file.State{}
+	err := decoder.Decode(&newState)
+	// No error means registry is already in new format
+	if err == nil {
+		return false
+	}
 
+	// Reset file offset
+	f.Seek(0, 0)
+	oldStates := map[string]file.State{}
+	err = decoder.Decode(&oldStates)
 	if err != nil {
 		logp.Debug("registrar", "Error decoding old state: %+v", err)
 		return false


### PR DESCRIPTION
An ERR message was written to the log file in case the state file was already in the new format. Now it is first checked if the file is already in the new format and it is only tried to conver the file if this is not the case.

(cherry picked from commit 4b2c905ff1520fb6873abac1af3a0908e0dfcee1)

Backport of https://github.com/elastic/beats/pull/2831