### PR TITLE
docs: Fix broken Kibana doc link in faq

### DIFF
--- a/libbeat/docs/faq-refresh-index.asciidoc
+++ b/libbeat/docs/faq-refresh-index.asciidoc
@@ -11,7 +11,7 @@ http.response.headers = {
         "content-type": "application/json"
 }
 ----------------------------------------------------------------------
-To fix this you need to https://www.elastic.co/guide/en/kibana/5.0/settings.html#reload-fields[reload the index pattern] in Kibana under the Management->Index Patterns, and the index-pattern will be
+To fix this you need to https://www.elastic.co/guide/en/kibana/5.0/index-patterns.html#reload-fields[reload the index pattern] in Kibana under the Management->Index Patterns, and the index-pattern will be
 updated with a field for each key available in the dictionary:
 
 [source,shell]


### PR DESCRIPTION
The Kibana docs overhaul for 5.0+ changed the link to the index pattern
field refresh instructions.