### PR TITLE
Improve prospector state handling

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -61,8 +61,9 @@ https://github.com/elastic/beats/compare/v5.0.0...master[Check the HEAD diff]
 *Topbeat*
 
 *Filebeat*
-
 - Add command line option -once to run filebeat only once and then close. {pull}2456[2456]
+- Only load matching states into prospector to improve state handling {pull}2840[2840]
+- Reset all states ttl on startup to make sure it is overwritten by new config {pull}2840[2840]
 
 *Winlogbeat*
 

--- a/filebeat/input/file/state.go
+++ b/filebeat/input/file/state.go
@@ -27,7 +27,7 @@ func NewState(fileInfo os.FileInfo, path string) State {
 		Finished:    false,
 		FileStateOS: GetOSState(fileInfo),
 		Timestamp:   time.Now(),
-		TTL:         -1 * time.Second, // By default, state does have an infinite ttl
+		TTL:         -1, // By default, state does have an infinite ttl
 	}
 }
 
@@ -102,11 +102,11 @@ func (s *States) Cleanup() int {
 
 	for _, state := range s.states {
 
-		ttl := state.TTL
+		expired := (state.TTL > 0 && currentTime.Sub(state.Timestamp) > state.TTL)
 
-		if ttl == 0 || (ttl > 0 && currentTime.Sub(state.Timestamp) > ttl) {
+		if state.TTL == 0 || expired {
 			if state.Finished {
-				logp.Debug("state", "State removed for %v because of older: %v", state.Source, ttl)
+				logp.Debug("state", "State removed for %v because of older: %v", state.Source, state.TTL)
 				continue // drop state
 			} else {
 				logp.Err("State for %s should have been dropped, but couldn't as state is not finished.", state.Source)

--- a/filebeat/prospector/prospector.go
+++ b/filebeat/prospector/prospector.go
@@ -34,7 +34,7 @@ type Prospector struct {
 }
 
 type Prospectorer interface {
-	Init()
+	Init(states []file.State) error
 	Run()
 }
 
@@ -49,8 +49,8 @@ func NewProspector(cfg *common.Config, states file.States, outlet Outlet) (*Pros
 		outlet:        outlet,
 		harvesterChan: make(chan *input.Event),
 		done:          make(chan struct{}),
-		states:        states.Copy(),
 		wg:            sync.WaitGroup{},
+		states:        &file.States{},
 		channelWg:     sync.WaitGroup{},
 	}
 
@@ -61,7 +61,7 @@ func NewProspector(cfg *common.Config, states file.States, outlet Outlet) (*Pros
 		return nil, err
 	}
 
-	err := prospector.Init()
+	err := prospector.Init(states.GetStates())
 	if err != nil {
 		return nil, err
 	}
@@ -72,7 +72,7 @@ func NewProspector(cfg *common.Config, states file.States, outlet Outlet) (*Pros
 }
 
 // Init sets up default config for prospector
-func (p *Prospector) Init() error {
+func (p *Prospector) Init(states []file.State) error {
 
 	var prospectorer Prospectorer
 	var err error
@@ -90,7 +90,10 @@ func (p *Prospector) Init() error {
 		return err
 	}
 
-	prospectorer.Init()
+	err = prospectorer.Init(states)
+	if err != nil {
+		return err
+	}
 	p.prospectorer = prospectorer
 
 	// Create empty harvester to check if configs are fine

--- a/filebeat/prospector/prospector_log_other_test.go
+++ b/filebeat/prospector/prospector_log_other_test.go
@@ -1,0 +1,151 @@
+// +build !windows
+
+package prospector
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/elastic/beats/filebeat/input"
+	"github.com/elastic/beats/filebeat/input/file"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var matchTests = []struct {
+	file         string
+	paths        []string
+	excludeFiles []*regexp.Regexp
+	result       bool
+}{
+	{
+		"test/test.log",
+		[]string{"test/*"},
+		nil,
+		true,
+	},
+	{
+		"notest/test.log",
+		[]string{"test/*"},
+		nil,
+		false,
+	},
+	{
+		"test/test.log",
+		[]string{"test/*.log"},
+		nil,
+		true,
+	},
+	{
+		"test/test.log",
+		[]string{"test/*.nolog"},
+		nil,
+		false,
+	},
+	{
+		"test/test.log",
+		[]string{"test/*"},
+		[]*regexp.Regexp{regexp.MustCompile("test.log")},
+		false,
+	},
+	{
+		"test/test.log",
+		[]string{"test/*"},
+		[]*regexp.Regexp{regexp.MustCompile("test2.log")},
+		true,
+	},
+}
+
+func TestMatchFile(t *testing.T) {
+
+	for _, test := range matchTests {
+
+		p := ProspectorLog{
+			config: prospectorConfig{
+				Paths:        test.paths,
+				ExcludeFiles: test.excludeFiles,
+			},
+		}
+
+		assert.Equal(t, test.result, p.matchesFile(test.file))
+	}
+}
+
+var initStateTests = []struct {
+	states []file.State // list of states
+	paths  []string     // prospector glob
+	count  int          // expected states in prospector
+}{
+	{
+		[]file.State{
+			file.State{Source: "test"},
+		},
+		[]string{"test"},
+		1,
+	},
+	{
+		[]file.State{
+			file.State{Source: "notest"},
+		},
+		[]string{"test"},
+		0,
+	},
+	{
+		[]file.State{
+			file.State{Source: "test1.log", FileStateOS: file.StateOS{Inode: 1}},
+			file.State{Source: "test2.log", FileStateOS: file.StateOS{Inode: 2}},
+		},
+		[]string{"*.log"},
+		2,
+	},
+	{
+		[]file.State{
+			file.State{Source: "test1.log", FileStateOS: file.StateOS{Inode: 1}},
+			file.State{Source: "test2.log", FileStateOS: file.StateOS{Inode: 2}},
+		},
+		[]string{"test1.log"},
+		1,
+	},
+	{
+		[]file.State{
+			file.State{Source: "test1.log", FileStateOS: file.StateOS{Inode: 1}},
+			file.State{Source: "test2.log", FileStateOS: file.StateOS{Inode: 2}},
+		},
+		[]string{"test.log"},
+		0,
+	},
+	{
+		[]file.State{
+			file.State{Source: "test1.log", FileStateOS: file.StateOS{Inode: 1}},
+			file.State{Source: "test2.log", FileStateOS: file.StateOS{Inode: 1}},
+		},
+		[]string{"*.log"},
+		1, // Expecting only 1 state because of some inode (this is only a theoretical case)
+	},
+}
+
+// TestInit checks that the correct states are in a prospector after the init phase
+// This means only the ones that match the glob and not exclude files
+func TestInit(t *testing.T) {
+
+	for _, test := range initStateTests {
+		p := ProspectorLog{
+			Prospector: &Prospector{
+				states: &file.States{},
+				outlet: TestOutlet{},
+			},
+			config: prospectorConfig{
+				Paths: test.paths,
+			},
+		}
+		err := p.Init(test.states)
+		assert.NoError(t, err)
+		assert.Equal(t, test.count, p.Prospector.states.Count())
+	}
+
+}
+
+// TestOutlet is an empty outlet for testing
+type TestOutlet struct{}
+
+func (o TestOutlet) OnEvent(event *input.Event) bool { return true }

--- a/filebeat/prospector/prospector_log_windows_test.go
+++ b/filebeat/prospector/prospector_log_windows_test.go
@@ -1,0 +1,47 @@
+// +build windows
+
+package prospector
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var matchTestsWindows = []struct {
+	file         string
+	paths        []string
+	excludeFiles []*regexp.Regexp
+	result       bool
+}{
+	{
+		"C:\\\\hello\\test\\test.log",      // Path are always in windows format
+		[]string{"C:\\\\hello/test/*.log"}, // Globs can also be with forward slashes
+		nil,
+		true,
+	},
+	{
+		"C:\\\\hello\\test\\test.log",       // Path are always in windows format
+		[]string{"C:\\\\hello\\test/*.log"}, // Globs can also be mixed
+		nil,
+		true,
+	},
+}
+
+// TestMatchFileWindows test if match works correctly on windows
+// Separate test are needed on windows because of automated path conversion
+func TestMatchFileWindows(t *testing.T) {
+
+	for _, test := range matchTestsWindows {
+
+		p := ProspectorLog{
+			config: prospectorConfig{
+				Paths:        test.paths,
+				ExcludeFiles: test.excludeFiles,
+			},
+		}
+
+		assert.Equal(t, test.result, p.matchesFile(test.file))
+	}
+}

--- a/filebeat/prospector/prospector_stdin.go
+++ b/filebeat/prospector/prospector_stdin.go
@@ -29,8 +29,9 @@ func NewProspectorStdin(p *Prospector) (*ProspectorStdin, error) {
 	return prospectorer, nil
 }
 
-func (p *ProspectorStdin) Init() {
+func (p *ProspectorStdin) Init(states []file.State) error {
 	p.started = false
+	return nil
 }
 
 func (p *ProspectorStdin) Run() {

--- a/filebeat/prospector/prospector_test.go
+++ b/filebeat/prospector/prospector_test.go
@@ -6,6 +6,8 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/elastic/beats/filebeat/input/file"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -15,7 +17,7 @@ func TestProspectorInitInputTypeLogError(t *testing.T) {
 		config: prospectorConfig{},
 	}
 
-	err := prospector.Init()
+	err := prospector.Init([]file.State{})
 	// Error should be returned because no path is set
 	assert.Error(t, err)
 }

--- a/filebeat/registrar/registrar.go
+++ b/filebeat/registrar/registrar.go
@@ -118,9 +118,12 @@ func (r *Registrar) loadStates() error {
 		return fmt.Errorf("Error decoding states: %s", err)
 	}
 
-	// Set all states to finished on restart
+	// Set all states to finished and disable TTL on restart
+	// For all states covered by a prospector, TTL will be overwritten with the prospector value
 	for key, state := range states {
 		state.Finished = true
+		// Set ttl to -2 to easily spot which states are not managed by a prospector
+		state.TTL = -2
 		states[key] = state
 	}
 
@@ -248,7 +251,7 @@ func (r *Registrar) Run() {
 		statesCleanup.Add(int64(cleanedStates))
 
 		logp.Debug("registrar",
-			"Registrar states cleaned up. Before: %d , After: %d",
+			"Registrar states cleaned up. Before: %d, After: %d",
 			beforeCount, beforeCount-cleanedStates)
 
 		if err := r.writeRegistry(); err != nil {

--- a/filebeat/tests/system/test_harvester.py
+++ b/filebeat/tests/system/test_harvester.py
@@ -482,7 +482,7 @@ class Test(BaseTest):
                 content = message + '\n'
                 file.write(content)
 
-            filebeat = self.start_beat()
+            filebeat = self.start_beat(output=config[0] + ".log")
 
             self.wait_until(
                 lambda: self.output_has(lines=1, output_file="output/" + config[0]),

--- a/libbeat/scripts/install-go.ps1
+++ b/libbeat/scripts/install-go.ps1
@@ -1,10 +1,10 @@
 # Installs golang on Windows.
 #
 # # Run script:
-# .\install-go.ps1 -version 1.5.3 
+# .\install-go.ps1 -version 1.7.3
 #
 # # Download and run script:
-# $env:GOVERSION = '1.5.3'
+# $env:GOVERSION = '1.7.3'
 # iex ((new-object net.webclient).DownloadString('SCRIPT_URL_HERE'))
 Param(
     [String]$version,
@@ -20,7 +20,7 @@ Download and install Golang on Windows. It sets the GOROOT environment
 variable and adds GOROOT\bin to the PATH environment variable.
 
 Usage:
-  $SCRIPT -version 1.5.3
+  $SCRIPT -version 1.7.3
 Options:
   -h | -help
     Print the help menu.


### PR DESCRIPTION
Previously each prospector was holding old states initially loaded by the registry file. This was changed to that each prospector only loads the states with a path that matches the glob pattern. This reduces the number of states handled by each prospector and reduces overlap.

One consequence of this is that in case a log file "moves" from one prospector to an other through renaming during the runtime of filebeat, no state will be found. But this behaviour is not expected and would lead to other issues already now. The expectation is that a file stays inside the prospector over its full lifetime.

In case of a filebeat restart including a config change, it can happen that some states are not managed anymore by a prospector. These "obsolete" states will stay in the registrar until a further config change when a glob pattern would again include these states. As an example:

Filebeat is started with the following config.

```
filebeat.prospectors:
- paths: ['*.log']
  clean_removed: true
```

There is a log file `a.log` and `b.log`. Both files are harvested and states for `a.log` and `b.log` are persisted. Then filebeat is stopped and the config file is modified to.

```
filebeat.prospectors:
- paths: ['a.log']
  clean_removed: true
```

Filebeat is started again. The prospector will now only handle the state for `a.log`. In case `b.log` is removed from disk, the state for `b.log` will stay in the registry file.

In case the config file was with `clean_inactive: 5min`, all TTL are reset on restart to `-2` by the registry and `-1` the prospector or the new `clean_inactive` value. Using `-2` in the registrar can be useful in the future to detect which states are not managed anymore by any prospector. As all TTL are reset on restart, persisting of the TTL is not required anymore but can become useful for cleanup so the information is kept in the registry file.

Further changes:
- Add tests for matchFile method
- Add tests for prospector state init filtering
- states are passed to `Prospector.Init` on startup instead of setting it directly in the object
- `Prospector.Init` and `Prospectorer.Init` now return an error and filebeat exits on startup problems
- Remove lastClean as not needed anymore
- Have one log file for each bom file test
- Update to new vagrant box with Golang 1.7.3
