### PR TITLE
Backport: Metricbeat - Fix system.process.start_time on Windows (#2848)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -31,6 +31,8 @@ https://github.com/elastic/beats/compare/v5.0.0-rc1...5.0[Check the HEAD diff]
 
 *Metricbeat*
 
+- Fix `system.process.start_time` on Windows. {pull}2848[2848]
+
 *Packetbeat*
 
 *Topbeat*

--- a/glide.yaml
+++ b/glide.yaml
@@ -25,7 +25,7 @@ import:
   subpackages:
   - /difflib
 - package: github.com/elastic/gosigar
-  version: 15322f7ed81bc3cfedb66b6716fd272ce042e9db
+  version: fcde510856e0041789e6669ec042386b560109bf
 - package: github.com/samuel/go-parser
   version: ca8abbf65d0e61dedf061f98bd3850f250e27539
 - package: github.com/samuel/go-thrift

--- a/vendor/github.com/elastic/gosigar/CHANGELOG.md
+++ b/vendor/github.com/elastic/gosigar/CHANGELOG.md
@@ -15,3 +15,4 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Fix value of `Mem.ActualFree` and `Mem.ActualUsed` on Windows. #49
+- Fix `ProcTime.StartTime` on Windows to report value in milliseconds since Unix epoch. #51

--- a/vendor/github.com/elastic/gosigar/sigar_windows.go
+++ b/vendor/github.com/elastic/gosigar/sigar_windows.go
@@ -476,13 +476,14 @@ func (self *ProcTime) Get(pid int) error {
 		return fmt.Errorf("GetProcessTimes fails with %v", err)
 	}
 
-	// convert to millis
-	self.StartTime = uint64(FiletimeToDuration(&CPU.CreationTime).Nanoseconds() / 1e6)
+	// Windows epoch times are expressed as time elapsed since midnight on
+	// January 1, 1601 at Greenwich, England. This converts the Filetime to
+	// unix epoch in milliseconds.
+	self.StartTime = uint64(CPU.CreationTime.Nanoseconds() / 1e6)
 
+	// Convert to millis.
 	self.User = uint64(FiletimeToDuration(&CPU.UserTime).Nanoseconds() / 1e6)
-
 	self.Sys = uint64(FiletimeToDuration(&CPU.KernelTime).Nanoseconds() / 1e6)
-
 	self.Total = self.User + self.Sys
 
 	return nil


### PR DESCRIPTION
Cherrypick of #2848 to 5.0:

The process creation time needed converted from Windows epoch to unix epoch.

(cherry picked from commit e866c944eb03e6c14f4911a571658bab59685a5c)