### PR TITLE
Update links to x-pack security docs

### DIFF
--- a/libbeat/docs/https.asciidoc
+++ b/libbeat/docs/https.asciidoc
@@ -27,13 +27,14 @@ output.elasticsearch:
 <4> The IP and port of the Elasticsearch nodes.
 
 Elasticsearch doesn't have built-in basic authentication, but you can achieve it
-either by using a web proxy or by using {security}. For more information, see {securitydoc}/xpack-security.html[{security}].
+either by using a web proxy or by using X-Pack to secure Elasticsearch. For more
+information, see the X-Pack documentation about 
+{securitydoc}/xpack-security.html[securing Elasticsearch], including the topic
+about {securitydoc}/beats.html[Beats and security].
 
 {beatname_uc} verifies the validity of the server certificates and only accepts trusted
 certificates. Creating a correct SSL/TLS infrastructure is outside the scope of
 this document.
-
-//TODO: Need to replace the link before adding this back into the doc: "but a good guide to follow is the https://www.elastic.co/guide/en/shield/current/certificate-authority.html[Setting Up a Certificate Authority] topic in the {security}" documentation. Also add it back to shared-ssl-logstash-config, if possible.
 
 By default {beatname_uc} uses the list of trusted certificate authorities from the
 operating system where {beatname_uc} is running. You can configure {beatname_uc} to use a specific list of


### PR DESCRIPTION
Note that we can't link to https://www.elastic.co/guide/en/shield/current/certificate-authority.html anymore because the topic has been removed from the doc. 