### PR TITLE
Add banner to indicate that doc about adding protocols is out-of-date

### DIFF
--- a/libbeat/docs/index.asciidoc
+++ b/libbeat/docs/index.asciidoc
@@ -33,7 +33,7 @@ include::./config-file-format.asciidoc[]
 
 include::./dashboards.asciidoc[]
 
-pass::[<?page_header <b>PLEASE NOTE:</b><br/>Always refer to the documentation in master for the latest information about contributing to Beats.?>]
+pass::[<?page_header Always refer to the documentation in master for the latest information about contributing to Beats.?>]
 
 include::./newbeat.asciidoc[]
 

--- a/packetbeat/docs/index.asciidoc
+++ b/packetbeat/docs/index.asciidoc
@@ -60,4 +60,9 @@ include::./troubleshooting.asciidoc[]
 
 include::./faq.asciidoc[]
 
+pass::[<?page_header We are working on updating this section. Some content might be out of date. While you're waiting for updates, you might want to try out the TCP protocol generator at https://github.com/elastic/beats/tree/master/generate/packetbeat/tcp-protocol. ?>]
+
 include::./new_protocol.asciidoc[]
+
+pass::[<?page_header ?>]
+


### PR DESCRIPTION
@urso should probably confirm that we want to point to the protocol generator. Seems like a pointer is better than no guidance.