### PR TITLE
Provide basic log parsing capability in filebeat

### DIFF
--- a/filebeat/harvester/config.go
+++ b/filebeat/harvester/config.go
@@ -54,6 +54,8 @@ type harvesterConfig struct {
 	MaxBytes             int                     `config:"max_bytes" validate:"min=0,nonzero"`
 	Multiline            *reader.MultilineConfig `config:"multiline"`
 	JSON                 *reader.JSONConfig      `config:"json"`
+        ParsingRegex         string                  `config:"parsingRegex"`
+        DateFormat           string                  `config:"dateFormat"`
 }
 
 func (config *harvesterConfig) Validate() error {

--- a/filebeat/harvester/config.go
+++ b/filebeat/harvester/config.go
@@ -54,8 +54,8 @@ type harvesterConfig struct {
 	MaxBytes             int                     `config:"max_bytes" validate:"min=0,nonzero"`
 	Multiline            *reader.MultilineConfig `config:"multiline"`
 	JSON                 *reader.JSONConfig      `config:"json"`
-        ParsingRegex         string                  `config:"parsingRegex"`
-        DateFormat           string                  `config:"dateFormat"`
+	ParsingRegex         string                  `config:"parsingRegex"`
+	DateFormat           string                  `config:"dateFormat"`
 }
 
 func (config *harvesterConfig) Validate() error {

--- a/filebeat/harvester/log.go
+++ b/filebeat/harvester/log.go
@@ -137,8 +137,8 @@ func (h *Harvester) Harvest(r reader.Reader) {
 			event.InputType = h.config.InputType
 			event.DocumentType = h.config.DocumentType
 			event.JSONConfig = h.config.JSON
-                        event.AnnotationRegex =  h.config.ParsingRegex
-                        event.DateFormat = h.config.DateFormat
+			event.AnnotationRegex = h.config.ParsingRegex
+			event.DateFormat = h.config.DateFormat
 		}
 
 		// Always send event to update state, also if lines was skipped

--- a/filebeat/harvester/log.go
+++ b/filebeat/harvester/log.go
@@ -137,6 +137,8 @@ func (h *Harvester) Harvest(r reader.Reader) {
 			event.InputType = h.config.InputType
 			event.DocumentType = h.config.DocumentType
 			event.JSONConfig = h.config.JSON
+                        event.AnnotationRegex =  h.config.ParsingRegex
+                        event.DateFormat = h.config.DateFormat
 		}
 
 		// Always send event to update state, also if lines was skipped

--- a/filebeat/input/event.go
+++ b/filebeat/input/event.go
@@ -2,10 +2,10 @@ package input
 
 import (
 	"fmt"
+	"regexp"
+	"strconv"
+	s "strings"
 	"time"
-         "regexp"
-        "strconv"
-        s "strings"
 
 	"github.com/elastic/beats/filebeat/harvester/reader"
 	"github.com/elastic/beats/filebeat/input/file"
@@ -16,16 +16,16 @@ import (
 // Event is sent to the output and must contain all relevant information
 type Event struct {
 	common.EventMetadata
-	ReadTime     time.Time
-	InputType    string
-	DocumentType string
-	Bytes        int
-	Text         *string
-	JSONFields   common.MapStr
-	JSONConfig   *reader.JSONConfig
-	State        file.State
-        AnnotationRegex string
-        DateFormat      string
+	ReadTime        time.Time
+	InputType       string
+	DocumentType    string
+	Bytes           int
+	Text            *string
+	JSONFields      common.MapStr
+	JSONConfig      *reader.JSONConfig
+	State           file.State
+	AnnotationRegex string
+	DateFormat      string
 }
 
 func NewEvent(state file.State) *Event {
@@ -50,79 +50,78 @@ func (f *Event) ToMapStr() common.MapStr {
 		event["message"] = *f.Text
 	}
 
-        
-        logp.Debug("event","ToMapStr-->DocumentType=%s",f.DocumentType)
-	logp.Debug("event","ToMapStr-->regex=%s",f.AnnotationRegex)
-        
-        if f.AnnotationRegex != "" {
-            logp.Debug("event", "ToMapStr-->apply regular expression on text")
-        
-           //move compiling part to once per propsector v/s once for every event
-           var myExp = regexp.MustCompile(f.AnnotationRegex)
-           match := myExp.FindStringSubmatch(*f.Text)
+	logp.Debug("event", "ToMapStr-->DocumentType=%s", f.DocumentType)
+	logp.Debug("event", "ToMapStr-->regex=%s", f.AnnotationRegex)
 
-           if (match != nil){
-  
-               //for every named match from regular expression 
-               for i, name := range myExp.SubexpNames() {
-                  if i != 0 {
-                     if(match[i] != ""){
-                     if(s.HasSuffix(name,"_int")) {
-                         i,err := strconv.Atoi(match[i])
-                         if (err == nil) {
-                           event[s.TrimSuffix(name,"_int")]=i
-                         } else {
-                           logp.Err("event","Err converting %d to int",match[i])
-                         }
-                     } else if(s.HasSuffix(name,"_date")){
-                         logp.Debug("event","dateFormat : %s",f.DateFormat)
-                        
-                         //input format should come from yml file
-                         //const inputTime = "02/Jan/2006:15:04:05 -0700"
-                         //check if dateFormat field exists, if yes then consume it 
-                               
-                         if(f.DateFormat != "") {
-                                //convert : to . so millisecond can be taken 
-                                 str1 := s.Replace(f.DateFormat, ":", ".", 3)
-                                 logp.Debug("event","input timeformat  %s",str1)
-                                 inputTime := s.Replace(match[i],":",".",3)
-                                 logp.Debug("event","input time  %s",inputTime)
-                                 t, err := time.Parse(str1, inputTime)
-                                 if err != nil {
-                                    logp.Err("event","Err converting date %s",inputTime)
-                                 } else {
-                                    event[s.TrimSuffix(name,"_date")]=t.Format("2006-01-02T15:04:05.000-0700")
-                                    logp.Debug("event","after conversion %s",event[s.TrimSuffix(name,"_date")])
-                                 }
-                          } 
-                     } else if(s.HasSuffix(name,"_long")){
+	if f.AnnotationRegex != "" {
+		logp.Debug("event", "ToMapStr-->apply regular expression on text")
 
-                        num,err := strconv.ParseInt(match[i],10,64)
-                        if (err == nil) {
-                           event[s.TrimSuffix(name,"_long")]=num
-                        }else {
-                           logp.Err("file.go","Err converting %s to long",match[i])
-                        }
-                     } else if(s.HasSuffix(name,"_float")){
-                        num,err := strconv.ParseFloat(match[i],64)
-                        if (err == nil) {
-                           event[s.TrimSuffix(name,"_float")]=num
-                        }else {
-                           logp.Err("event","Err converting %s to float",match[i])
-                        }
-                     } else {
-                       event[name]=match[i]
-                     }
-                     logp.Debug("event","%s=%s", name, match[i])
-                    }//end of match[i] != ""
-                  } // end of if i !=0
-               } // enf of forloop 
-               
-          } else {
-            logp.Err("no match for regular expression:%s=",f.AnnotationRegex)
-            logp.Err("text being matched : %s=",*f.Text)
-          }
-        }
+		//move compiling part to once per propsector v/s once for every event
+		var myExp = regexp.MustCompile(f.AnnotationRegex)
+		match := myExp.FindStringSubmatch(*f.Text)
+
+		if match != nil {
+
+			//for every named match from regular expression
+			for i, name := range myExp.SubexpNames() {
+				if i != 0 {
+					if match[i] != "" {
+						if s.HasSuffix(name, "_int") {
+							i, err := strconv.Atoi(match[i])
+							if err == nil {
+								event[s.TrimSuffix(name, "_int")] = i
+							} else {
+								logp.Err("event", "Err converting %d to int", match[i])
+							}
+						} else if s.HasSuffix(name, "_date") {
+							logp.Debug("event", "dateFormat : %s", f.DateFormat)
+
+							//input format should come from yml file
+							//const inputTime = "02/Jan/2006:15:04:05 -0700"
+							//check if dateFormat field exists, if yes then consume it
+
+							if f.DateFormat != "" {
+								//convert : to . so millisecond can be taken
+								str1 := s.Replace(f.DateFormat, ":", ".", 3)
+								logp.Debug("event", "input timeformat  %s", str1)
+								inputTime := s.Replace(match[i], ":", ".", 3)
+								logp.Debug("event", "input time  %s", inputTime)
+								t, err := time.Parse(str1, inputTime)
+								if err != nil {
+									logp.Err("event", "Err converting date %s", inputTime)
+								} else {
+									event[s.TrimSuffix(name, "_date")] = t.Format("2006-01-02T15:04:05.000-0700")
+									logp.Debug("event", "after conversion %s", event[s.TrimSuffix(name, "_date")])
+								}
+							}
+						} else if s.HasSuffix(name, "_long") {
+
+							num, err := strconv.ParseInt(match[i], 10, 64)
+							if err == nil {
+								event[s.TrimSuffix(name, "_long")] = num
+							} else {
+								logp.Err("file.go", "Err converting %s to long", match[i])
+							}
+						} else if s.HasSuffix(name, "_float") {
+							num, err := strconv.ParseFloat(match[i], 64)
+							if err == nil {
+								event[s.TrimSuffix(name, "_float")] = num
+							} else {
+								logp.Err("event", "Err converting %s to float", match[i])
+							}
+						} else {
+							event[name] = match[i]
+						}
+						logp.Debug("event", "%s=%s", name, match[i])
+					} //end of match[i] != ""
+				} // end of if i !=0
+			} // enf of forloop
+
+		} else {
+			logp.Err("no match for regular expression:%s=", f.AnnotationRegex)
+			logp.Err("text being matched : %s=", *f.Text)
+		}
+	}
 
 	return event
 }
@@ -138,7 +137,6 @@ func (e *Event) HasData() bool {
 // If MessageKey is defined, the Text value from the event always
 // takes precedence.
 func mergeJSONFields(f *Event, event common.MapStr) {
-
 
 	// The message key might have been modified by multiline
 	if len(f.JSONConfig.MessageKey) > 0 && f.Text != nil {


### PR DESCRIPTION
The ability to provide basic log parsing capability in filebeat was discussed under https://github.com/elastic/beats/issues/2644

**The submitted code provides three functionalities**
a) parse the log record using the regex (named regex) present in yml file per prospector

>   `parsingRegex: (?P<was_requestHost>\S+)\s\S+\s\S+\s\[(?P<was_datetime_date>.+)\]\s"(?P<was_requestMethod>\S+)\s(?P<was_uriPath>\S+)(?:\?)?(?P<was_queryString>\S+)?\s(?P<was_requestProtocol>\S+)\s(?P<was_responseCode_int>\S+)\s(?P<was_bytesReceived_long>\S+)\s(?P<was_elapsedTime_long>\S+)?`

b) based on the suffix of field names (_int,_float, _long), convert values of those fields to correct datatype

c) convert fields having _date suffix from format specified under dateFormat (YML config) to  ISO-8601  format (1994-11-05T08:15:30-05:00). 

**Example YML section for WebSphere Application Server's SystemOut.log is as follows**

`parsingRegex: \[(?P<was_datetime_date>.+)\]\s(?P<was_threadId>[\w|\d]+)\s(?P<module>\w+)?\s+?(?P<loglevel>\w{1})\s+(?:(?P<was_className>\w+\.[\w|\.]+)\s(?P<was_methodName>\S+)\s)?(?:(?P<was_messageId>\S+):\s)?(?:.+:\s(?P<was_exceptionName>\w+\.[\w|\.]+Exception))?`

 `dateFormat : "1/02/06 15:04:05:000 GMT-07:00"`

**Example Systemout.log file to test is as follows**

[4/16/16 11:28:41:090 GMT+05:30] 00000028 SystemOut     O inside connect...
[4/16/16 11:28:41:090 GMT+05:30] 00000028 SystemOut     O getting connnection..
[4/16/16 11:28:41:091 GMT+05:30] 00000028 SystemOut     O Connection Successful 
[4/16/16 11:28:41:091 GMT+05:30] 00000028 SystemOut     O forwarding to logonfail
[4/16/16 11:28:41:091 GMT+05:30] 00000028 SystemOut     O requestURL--->/app1/RequestPendingViewAction.do
[4/16/16 11:28:52:815 GMT+05:30] 00000028 SystemOut     O LoginAction processed
[4/16/16 11:28:52:815 GMT+05:30] 00000028 SystemOut     O Email ID : usr@abc.com
[4/16/16 11:28:54:726 GMT+05:30] 00000028 SystemOut     O Authenticate Status : Success
[4/16/16 11:28:54:726 GMT+05:30] 00000028 SystemOut     O empid--->usr@abc.com
[4/16/16 11:28:59:086 GMT+05:30] 00000028 SystemOut     O Url---->/app1/RequestPendingViewAction.do
