### PR TITLE
Add state for ignore_older files

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -72,6 +72,7 @@ https://github.com/elastic/beats/compare/v5.0.0...master[Check the HEAD diff]
 - Add command line option -once to run filebeat only once and then close. {pull}2456[2456]
 - Only load matching states into prospector to improve state handling {pull}2840[2840]
 - Reset all states ttl on startup to make sure it is overwritten by new config {pull}2840[2840]
+- Persist all states for files which fall under ignore_older to have consistent behaviour {pull}2859[2859]
 
 *Winlogbeat*
 

--- a/filebeat/docs/reference/configuration/filebeat-options.asciidoc
+++ b/filebeat/docs/reference/configuration/filebeat-options.asciidoc
@@ -175,7 +175,7 @@ The files affected by this setting fall into two categories:
 * Files that were never harvested
 * Files that were harvested but weren't updated for longer than `ignore_older`
 
-When a file that has never been harvested is updated, the reading starts from the beginning of the file because no state has been persisted. For a file that has been harvested previously, the state still exists, so when the file is updated, reading continues at the last position.
+When a file that has never been harvested is updated, the reading starts from the beginning as the state of the file was created with the offset 0. For a file that has been harvested previously, reading continues at the last position.
 
 The `ignore_older` setting relies on the modification time of the file to determine if a file is ignored. If the modification time of the file is not updated when lines are written to a file (which can happen on Windows), the `ignore_older` setting may cause Filebeat to ignore files even though content was added at a later time.
 
@@ -527,14 +527,14 @@ before Filebeat shuts down.
 
 By default, this option is disabled, and Filebeat does not wait for the
 publisher to finish sending events before shutting down. This means that any
-events sent to the output, but not acknowledged before Filebeat shuts down, 
+events sent to the output, but not acknowledged before Filebeat shuts down,
 are sent again when you restart Filebeat. For more details about how this
 works, see <<at-least-once-delivery>>.
 
 You can configure the `shutdown_timeout` option to specify the maximum amount
 of time that Filebeat waits for the publisher to finish sending events before
 shutting down. If all events are acknowledged before `shutdown_timeout` is
-reached, Filebeat will shut down. 
+reached, Filebeat will shut down.
 
 There is no recommended setting for this option because determining the correct
 value for `shutdown_timeout` depends heavily on the environment in which

--- a/filebeat/prospector/prospector_log_test.go
+++ b/filebeat/prospector/prospector_log_test.go
@@ -1,0 +1,64 @@
+// +build !integration
+
+package prospector
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/elastic/beats/filebeat/input/file"
+	"github.com/stretchr/testify/assert"
+)
+
+var cleanInactiveTests = []struct {
+	cleanInactive time.Duration
+	fileTime      time.Time
+	result        bool
+}{
+	{
+		cleanInactive: 0,
+		fileTime:      time.Now(),
+		result:        false,
+	},
+	{
+		cleanInactive: 1 * time.Second,
+		fileTime:      time.Now().Add(-5 * time.Second),
+		result:        true,
+	},
+	{
+		cleanInactive: 10 * time.Second,
+		fileTime:      time.Now().Add(-5 * time.Second),
+		result:        false,
+	},
+}
+
+func TestIsCleanInactive(t *testing.T) {
+
+	for _, test := range cleanInactiveTests {
+
+		prospector := ProspectorLog{
+			config: prospectorConfig{
+				CleanInactive: test.cleanInactive,
+			},
+		}
+		state := file.State{
+			Fileinfo: TestFileInfo{
+				time: test.fileTime,
+			},
+		}
+
+		assert.Equal(t, test.result, prospector.isCleanInactive(state))
+	}
+}
+
+type TestFileInfo struct {
+	time time.Time
+}
+
+func (t TestFileInfo) Name() string       { return "" }
+func (t TestFileInfo) Size() int64        { return 0 }
+func (t TestFileInfo) Mode() os.FileMode  { return 0 }
+func (t TestFileInfo) ModTime() time.Time { return t.time }
+func (t TestFileInfo) IsDir() bool        { return false }
+func (t TestFileInfo) Sys() interface{}   { return nil }

--- a/filebeat/tests/system/test_harvester.py
+++ b/filebeat/tests/system/test_harvester.py
@@ -413,10 +413,9 @@ class Test(BaseTest):
         data = self.get_registry()
         assert len(data) == 1
 
-        # Check that not all but some lines were read
-        assert self.output_lines() < 1000
+        # Check that not all but some lines were read. It can happen sometimes that filebeat finishes reading ...
+        assert self.output_lines() <= 1000
         assert self.output_lines() > 0
-
 
     def test_bom_utf8(self):
         """


### PR DESCRIPTION
Previously if a file was falling under ignore_older on startup and no previous state was found, also no state was persisted. This was important in 1.x releases to prevent the registry file to contain too many files as no cleanup was possible. With the new clean_\* options the registry file can now be cleaned up. For consistency all files that fall under ignore_older should have a state, even if they are not crawled before.

This change is also required to move tail_files under the prospector (https://github.com/elastic/beats/issues/2613). Otherwise files which fall under `ignore_older` the state could not be set to the end of the file.
