### PR TITLE
Remove note that the Metricbeat docs are for pre-GA version

### DIFF
--- a/metricbeat/docs/page_header.html
+++ b/metricbeat/docs/page_header.html
@@ -1,1 +1,0 @@
-<b>PLEASE NOTE:</b> These docs are for a pre-GA version of Metricbeat.


### PR DESCRIPTION
Remove the note from the Metricbeat documentation.