### PR TITLE
Backport: Remove pre-GA note from Metricbeat docs 

### DIFF
--- a/metricbeat/docs/page_header.html
+++ b/metricbeat/docs/page_header.html
@@ -1,1 +1,0 @@
-<b>PLEASE NOTE:</b> These docs are for a pre-GA version of Metricbeat.


### PR DESCRIPTION
Backport #2861 