### PR TITLE
Add link to repos back into GS guides

### DIFF
--- a/filebeat/docs/getting-started.asciidoc
+++ b/filebeat/docs/getting-started.asciidoc
@@ -30,7 +30,11 @@ mac>> for OS X, and <<win, win>> for Windows).
 
 [NOTE]
 ==================================================
-See our https://www.elastic.co/downloads/beats/filebeat[download page] for other installation options, such as 32-bit images.
+If you use Apt or Yum, you can {libbeat}/setup-repositories.html[install Filebeat from our repositories] to update to
+the newest version more easily.
+
+See our https://www.elastic.co/downloads/beats/filebeat[download page] for other installation options, such as 32-bit
+images.
 
 ==================================================
 

--- a/metricbeat/docs/gettingstarted.asciidoc
+++ b/metricbeat/docs/gettingstarted.asciidoc
@@ -40,6 +40,10 @@ mac>> for OS X, and <<win, win>> for Windows).
 
 [NOTE]
 ==================================================
+If you use Apt or Yum, you can
+{libbeat}/setup-repositories.html[install Metricbeat from our repositories] to
+update to the newest version more easily.
+
 See our https://www.elastic.co/downloads/beats/metricbeat[download page] for
 other installation options, such as 32-bit images.
 ==================================================

--- a/packetbeat/docs/gettingstarted.asciidoc
+++ b/packetbeat/docs/gettingstarted.asciidoc
@@ -31,7 +31,11 @@ Redhat/Centos/Fedora, <<mac, mac>> for OS X, and <<win, win>> for Windows).
 
 [NOTE]
 ==================================================
-See our https://www.elastic.co/downloads/beats/packetbeat[download page] for other installation options, such as 32-bit images.
+If you use Apt or Yum, you can {libbeat}/setup-repositories.html[install Packetbeat from our repositories] to update to
+the newest version more easily.
+
+See our https://www.elastic.co/downloads/beats/packetbeat[download page] for other installation options, such as 32-bit
+images.
 ==================================================
 
 [[deb]]


### PR DESCRIPTION
We removed these links during the 5.0 pre-release cycle because we removed the topic about the repos temporarily. Now that we've added it back in, we should add the links, too.