### PR TITLE
Stop filebeat on error starting registrar

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -8,7 +8,7 @@
 // Template, add newest changes here
 
 === Beats version HEAD
-https://github.com/elastic/beats/compare/v5.0.0-rc1...5.0[Check the HEAD diff]
+https://github.com/elastic/beats/compare/v5.0.0...5.0[Check the HEAD diff]
 
 ==== Breaking changes
 
@@ -51,6 +51,7 @@ https://github.com/elastic/beats/compare/v5.0.0-rc1...5.0[Check the HEAD diff]
 *Topbeat*
 
 *Filebeat*
+- Stop Filebeat on registrar loading error.
 
 *Winlogbeat*
 

--- a/filebeat/beater/filebeat.go
+++ b/filebeat/beater/filebeat.go
@@ -91,6 +91,7 @@ func (fb *Filebeat) Run(b *beat.Beat) error {
 	err = registrar.Start()
 	if err != nil {
 		logp.Err("Could not start registrar: %v", err)
+		return err
 	}
 	// Stopping registrar will write last state
 	defer registrar.Stop()


### PR DESCRIPTION
Currently when there is an error during loading the state, filebeat 5.0 doesn't stop and just continues. The registrar loading in filebeat 5.x was already improved an additional validation was added. This PR only changes that if there is an error in loading states, filebeat is not started and a proper error is returned.

This PR does not need forward porting as in the master branch already a more enhanced error management is in place. 