### PR TITLE
Fix gotestcover executable in make.bat for winlogbeat

### DIFF
--- a/winlogbeat/make.bat
+++ b/winlogbeat/make.bat
@@ -14,7 +14,8 @@ if %errorlevel% neq 0 exit /b %errorlevel%
 
 echo Testing
 mkdir build\coverage
-gotestcover -race -coverprofile=build/coverage/integration.cov github.com/elastic/beats/winlogbeat/...
+set gotestcover="%GOPATH/src/github.com/elastic/beats/vendor/github.com/pierrre/gotestcover/gotestcover.go"
+go run %gotestcover% -race -coverprofile=build/coverage/integration.cov github.com/elastic/beats/winlogbeat/...
 if %errorlevel% neq 0 exit /b %errorlevel%
 
 echo System Testing


### PR DESCRIPTION
On windows if you call `make.bat` you get an error for tests that `gotestcover` i not a valid command. So you have define the path and then call it with `go run`. What i also noticed is that you have install many python extensions that are not installed by default.
```
pip install pyyaml
pip install jinja2
pip install pypiwin32
pip install nose
```
So maybe you should make a note in the readme for winlogbeat.