### PR TITLE
Add additional GOOS/GOARCH combos to make crosscompile

### DIFF
--- a/filebeat/Makefile
+++ b/filebeat/Makefile
@@ -4,6 +4,7 @@ BEATNAME?=filebeat
 BEAT_DESCRIPTION?=Filebeat sends log files to Logstash or directly to Elasticsearch.
 SYSTEM_TESTS=true
 TEST_ENVIRONMENT=false
+GOX_FLAGS='-arch=amd64 386 arm ppc64 ppc64le'
 
 include ../libbeat/scripts/Makefile
 

--- a/metricbeat/Makefile
+++ b/metricbeat/Makefile
@@ -12,11 +12,9 @@ TARGETS?="windows/amd64 windows/386 darwin/amd64"
 TARGETS_OLD?="linux/amd64 linux/386"
 CGO=true
 
-# Metricbeat can only be cross-compiled on platforms not requiring CGO which
-# are the same platforms where the system metrics (cpu, memory) are not
-# implemented.
-GOX_OS=solaris netbsd
-GOX_FLAGS='-arch=amd64'
+# Metricbeat can only be cross-compiled on platforms not requiring CGO.
+GOX_OS=solaris netbsd linux windows
+GOX_FLAGS='-arch=amd64 386 arm ppc64 ppc64le'
 
 
 include ${ES_BEATS}/libbeat/scripts/Makefile


### PR DESCRIPTION
This doesn't change packaging. It just adds additional GOOS/GOARCH combinations to the `make crosscompile` target. For Filebeat it adds ppc64/ppc64le. And for Metricbeat it adds linux/windows and arm/386/ppc64/ppc64le.