### PR TITLE
Add note so users know to update mappings for geoip

### DIFF
--- a/packetbeat/docs/packetbeat-geoip.asciidoc
+++ b/packetbeat/docs/packetbeat-geoip.asciidoc
@@ -61,7 +61,33 @@ when it encounters an event that doesn't have a `client_ip` field.
 +
 See 
 {plugindoc}/using-ingest-geoip.html[Using the Geoip Processor in a Pipeline]
-for more options. 
+for more options.
++
+[NOTE]
+===============================
+The index template that ships with Packetbeat 5.0 does not specify a
+mapping for the `client_geoip.location` field. To make sure the geoIP data gets
+indexed correctly, you need to add the following lines to the Packetbeat index
+template, `packetbeat.template.json`. Add these lines immediately before the
+entry for `client_ip`:
+
+[source,json]
+        "client_geoip": {
+          "properties": {
+            "location": {
+              "type": "geo_point"
+            }
+          }
+        },
+
+If you've already loaded the index template, make sure you load it again (see
+<<packetbeat-template,Loading the Index Template in Elasticsearch>>).
+
+You must update the mappings before you send the geoIP data to ingest node
+for the first time, or the location data will be incorrectly indexed as separate
+float values instead of a `geo point`.
+
+===============================
 
 3. In the Packetbeat config file, configure the Elasticsearch output to use the
 pipeline. Specify the pipeline ID in the `pipeline` option under
@@ -74,7 +100,7 @@ output.elasticsearch:
   pipeline: geoip-info
 -------------------------------------------------------------------------------
 
-4. Run Packbeat, passing in the configuration file that you updated earlier.
+4. Run Packetbeat, passing in the configuration file that you updated earlier.
 +
 [source,shell]
 -------------------------------------------------------------------------------


### PR DESCRIPTION
The index template in 5.1 will contain the correct mappings. Until then, users need to update the index template manually.