### PR TITLE
Cherry-pick to 5.0: Add username/pass options for PostgreSQL

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -48,6 +48,8 @@ https://github.com/elastic/beats/compare/v5.0.0...5.0[Check the HEAD diff]
 
 *Metricbeat*
 
+- Add username and password config options to the PostgreSQL module. {pull}2889[2890]
+
 *Packetbeat*
 
 *Topbeat*

--- a/metricbeat/docker-compose.yml
+++ b/metricbeat/docker-compose.yml
@@ -21,9 +21,10 @@ beat:
     - MYSQL_DSN=root:test@tcp(mysql:3306)/
     - MYSQL_HOST=mysql
     - MYSQL_PORT=3306
-    - POSTGRESQL_DSN=postgres://postgres@postgresql:5432?sslmode=disable
+    - POSTGRESQL_DSN=postgres://postgresql:5432?sslmode=disable
     - POSTGRESQL_HOST=postgresql
     - POSTGRESQL_PORT=5432
+    - POSTGRESQL_USERNAME=postgres
     - ZOOKEEPER_HOST=zookeeper
     - ZOOKEEPER_PORT=2181
     - HAPROXY_HOST=haproxy

--- a/metricbeat/docs/modules/postgresql.asciidoc
+++ b/metricbeat/docs/modules/postgresql.asciidoc
@@ -3,10 +3,56 @@ This file is generated! See scripts/docs_collector.py
 ////
 
 [[metricbeat-module-postgresql]]
-== postgresql Module
+== PostgreSQL Module
 
-This is the postgresql Module.
+This module periodically fetches metrics from
+https://www.postgresql.org/[PostgreSQL] servers.
 
+[float]
+=== Module-Specific Configuration Notes
+
+When configuring the `hosts` option, you must use Postgres URLs of the following
+format:
+
+-----------------------------------
+[postgres://][user:pass@]host[:port][?options]
+-----------------------------------
+
+The URL can be as simple as:
+
+[source,yaml]
+----------------------------------------------------------------------
+- module: postgresql
+  hosts: ["postgres://localhost"]
+----------------------------------------------------------------------
+
+Or more complex like:
+
+[source,yaml]
+----------------------------------------------------------------------
+- module: postgresql
+  hosts: ["postgres://localhost:40001?sslmode=disable", "postgres://otherhost:40001"]
+----------------------------------------------------------------------
+
+WARNING: In case you use username and password in the hosts array, this
+information will be sent with each event as part of the `metricset.host` field.
+To prevent sending username and password the config options `username` and
+`password` can be used.
+
+[source,yaml]
+----
+- module: postgresql
+  metricsets: ["status"]
+  hosts: ["postgres://localhost:5432"]
+  username: root
+  password: test
+----
+
+[float]
+=== Compatibility
+
+This module was tested with PostgreSQL 9.5.3 and is expected to work with all
+versions >= 9.
 
 
 [float]
@@ -33,10 +79,20 @@ metricbeat.modules:
   #period: 10s
 
   # The host must be passed as PostgreSQL DSN. Example:
-  # postgres://pqgotest:password@localhost:5432?sslmode=disable
+  # postgres://localhost:5432?sslmode=disable
   # The available parameters are documented here:
   # https://godoc.org/github.com/lib/pq#hdr-Connection_String_Parameters
-  #hosts: ["postgres://postgres@localhost:5432"]
+  #
+  # Warning: specifying the user/password in the hosts array is possible
+  # but it will result in the password being present in the output documents.
+  # We recommend using the username and password options instead.
+  #hosts: ["postgres://localhost:5432"]
+
+  # Username to use when connecting to PostgreSQL. Empty by default.
+  #username: user
+
+  # Password to use when connecting to PostgreSQL. Empty by default.
+  #password: pass
 
 ----
 

--- a/metricbeat/etc/beat.full.yml
+++ b/metricbeat/etc/beat.full.yml
@@ -129,10 +129,20 @@ metricbeat.modules:
   #period: 10s
 
   # The host must be passed as PostgreSQL DSN. Example:
-  # postgres://pqgotest:password@localhost:5432?sslmode=disable
+  # postgres://localhost:5432?sslmode=disable
   # The available parameters are documented here:
   # https://godoc.org/github.com/lib/pq#hdr-Connection_String_Parameters
-  #hosts: ["postgres://postgres@localhost:5432"]
+  #
+  # Warning: specifying the user/password in the hosts array is possible
+  # but it will result in the password being present in the output documents.
+  # We recommend using the username and password options instead.
+  #hosts: ["postgres://localhost:5432"]
+
+  # Username to use when connecting to PostgreSQL. Empty by default.
+  #username: user
+
+  # Password to use when connecting to PostgreSQL. Empty by default.
+  #password: pass
 
 
 #-------------------------------- Redis Module -------------------------------

--- a/metricbeat/metricbeat.full.yml
+++ b/metricbeat/metricbeat.full.yml
@@ -129,10 +129,20 @@ metricbeat.modules:
   #period: 10s
 
   # The host must be passed as PostgreSQL DSN. Example:
-  # postgres://pqgotest:password@localhost:5432?sslmode=disable
+  # postgres://localhost:5432?sslmode=disable
   # The available parameters are documented here:
   # https://godoc.org/github.com/lib/pq#hdr-Connection_String_Parameters
-  #hosts: ["postgres://postgres@localhost:5432"]
+  #
+  # Warning: specifying the user/password in the hosts array is possible
+  # but it will result in the password being present in the output documents.
+  # We recommend using the username and password options instead.
+  #hosts: ["postgres://localhost:5432"]
+
+  # Username to use when connecting to PostgreSQL. Empty by default.
+  #username: user
+
+  # Password to use when connecting to PostgreSQL. Empty by default.
+  #password: pass
 
 
 #-------------------------------- Redis Module -------------------------------

--- a/metricbeat/module/postgresql/_meta/config.yml
+++ b/metricbeat/module/postgresql/_meta/config.yml
@@ -13,8 +13,18 @@
   #period: 10s
 
   # The host must be passed as PostgreSQL DSN. Example:
-  # postgres://pqgotest:password@localhost:5432?sslmode=disable
+  # postgres://localhost:5432?sslmode=disable
   # The available parameters are documented here:
   # https://godoc.org/github.com/lib/pq#hdr-Connection_String_Parameters
-  #hosts: ["postgres://postgres@localhost:5432"]
+  #
+  # Warning: specifying the user/password in the hosts array is possible
+  # but it will result in the password being present in the output documents.
+  # We recommend using the username and password options instead.
+  #hosts: ["postgres://localhost:5432"]
+
+  # Username to use when connecting to PostgreSQL. Empty by default.
+  #username: user
+
+  # Password to use when connecting to PostgreSQL. Empty by default.
+  #password: pass
 

--- a/metricbeat/module/postgresql/_meta/docs.asciidoc
+++ b/metricbeat/module/postgresql/_meta/docs.asciidoc
@@ -1,4 +1,50 @@
-== postgresql Module
+== PostgreSQL Module
 
-This is the postgresql Module.
+This module periodically fetches metrics from
+https://www.postgresql.org/[PostgreSQL] servers.
 
+[float]
+=== Module-Specific Configuration Notes
+
+When configuring the `hosts` option, you must use Postgres URLs of the following
+format:
+
+-----------------------------------
+[postgres://][user:pass@]host[:port][?options]
+-----------------------------------
+
+The URL can be as simple as:
+
+[source,yaml]
+----------------------------------------------------------------------
+- module: postgresql
+  hosts: ["postgres://localhost"]
+----------------------------------------------------------------------
+
+Or more complex like:
+
+[source,yaml]
+----------------------------------------------------------------------
+- module: postgresql
+  hosts: ["postgres://localhost:40001?sslmode=disable", "postgres://otherhost:40001"]
+----------------------------------------------------------------------
+
+WARNING: In case you use username and password in the hosts array, this
+information will be sent with each event as part of the `metricset.host` field.
+To prevent sending username and password the config options `username` and
+`password` can be used.
+
+[source,yaml]
+----
+- module: postgresql
+  metricsets: ["status"]
+  hosts: ["postgres://localhost:5432"]
+  username: root
+  password: test
+----
+
+[float]
+=== Compatibility
+
+This module was tested with PostgreSQL 9.5.3 and is expected to work with all
+versions >= 9.

--- a/metricbeat/module/postgresql/activity/activity_integration_test.go
+++ b/metricbeat/module/postgresql/activity/activity_integration_test.go
@@ -52,5 +52,7 @@ func getConfig() map[string]interface{} {
 		"module":     "postgresql",
 		"metricsets": []string{"activity"},
 		"hosts":      []string{postgresql.GetEnvDSN()},
+		"username":   postgresql.GetEnvUsername(),
+		"password":   postgresql.GetEnvPassword(),
 	}
 }

--- a/metricbeat/module/postgresql/bgwriter/bgwriter_integration_test.go
+++ b/metricbeat/module/postgresql/bgwriter/bgwriter_integration_test.go
@@ -54,5 +54,7 @@ func getConfig() map[string]interface{} {
 		"module":     "postgresql",
 		"metricsets": []string{"bgwriter"},
 		"hosts":      []string{postgresql.GetEnvDSN()},
+		"username":   postgresql.GetEnvUsername(),
+		"password":   postgresql.GetEnvPassword(),
 	}
 }

--- a/metricbeat/module/postgresql/database/database.go
+++ b/metricbeat/module/postgresql/database/database.go
@@ -22,26 +22,41 @@ func init() {
 // MetricSet type defines all fields of the MetricSet
 type MetricSet struct {
 	mb.BaseMetricSet
+	connectionString string
 }
 
 // New create a new instance of the MetricSet
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 
-	config := struct{}{}
+	config := struct {
+		Hosts    []string `config:"hosts"    validate:"nonzero,required"`
+		Username string   `config:"username"`
+		Password string   `config:"password"`
+	}{
+		Username: "",
+		Password: "",
+	}
 
 	if err := base.Module().UnpackConfig(&config); err != nil {
 		return nil, err
 	}
 
+	url, err := postgresql.ParseURL(base.Host(), config.Username, config.Password,
+		base.Module().Config().Timeout)
+	if err != nil {
+		return nil, err
+	}
+
 	return &MetricSet{
-		BaseMetricSet: base,
+		BaseMetricSet:    base,
+		connectionString: url,
 	}, nil
 }
 
 // Fetch methods implements the data gathering and data conversion to the right format
 func (m *MetricSet) Fetch() ([]common.MapStr, error) {
 
-	db, err := sql.Open("postgres", m.Host())
+	db, err := sql.Open("postgres", m.connectionString)
 	if err != nil {
 		return nil, err
 	}

--- a/metricbeat/module/postgresql/database/database_integration_test.go
+++ b/metricbeat/module/postgresql/database/database_integration_test.go
@@ -54,5 +54,7 @@ func getConfig() map[string]interface{} {
 		"module":     "postgresql",
 		"metricsets": []string{"database"},
 		"hosts":      []string{postgresql.GetEnvDSN()},
+		"username":   postgresql.GetEnvUsername(),
+		"password":   postgresql.GetEnvPassword(),
 	}
 }

--- a/metricbeat/module/postgresql/postgresql.go
+++ b/metricbeat/module/postgresql/postgresql.go
@@ -5,6 +5,13 @@ package postgresql
 
 import (
 	"database/sql"
+	"fmt"
+	"net"
+	nurl "net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
 
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/pkg/errors"
@@ -44,4 +51,65 @@ func QueryStats(db *sql.DB, query string) ([]map[string]interface{}, error) {
 		results = append(results, result)
 	}
 	return results, nil
+}
+
+// ParseURL parses the given URL and overrides the values of username, password and timeout
+// if given. Returns a connection string in the form of `user=pass` ready to be passed to the
+// sql.Open call.
+// Code adapted from the pg driver: https://github.com/lib/pq/blob/master/url.go#L32
+func ParseURL(url, username, password string, timeout time.Duration) (string, error) {
+	u, err := nurl.Parse(url)
+	if err != nil {
+		return "", err
+	}
+
+	if u.Scheme != "postgres" && u.Scheme != "postgresql" {
+		return "", fmt.Errorf("invalid connection protocol: %s", u.Scheme)
+	}
+
+	var kvs []string
+	escaper := strings.NewReplacer(` `, `\ `, `'`, `\'`, `\`, `\\`)
+	accrue := func(k, v string) {
+		if v != "" {
+			kvs = append(kvs, k+"="+escaper.Replace(v))
+		}
+	}
+
+	if len(username) > 0 {
+		accrue("user", username)
+		accrue("password", password)
+	} else {
+		if u.User != nil {
+			v := u.User.Username()
+			accrue("user", v)
+
+			v, _ = u.User.Password()
+			accrue("password", v)
+		}
+	}
+
+	if host, port, err := net.SplitHostPort(u.Host); err != nil {
+		accrue("host", u.Host)
+	} else {
+		accrue("host", host)
+		accrue("port", port)
+	}
+
+	if u.Path != "" {
+		accrue("dbname", u.Path[1:])
+	}
+
+	q := u.Query()
+	for k := range q {
+		if k == "connect_timeout" && timeout != 0 {
+			continue
+		}
+		accrue(k, q.Get(k))
+	}
+	if timeout != 0 {
+		accrue("connect_timeout", strconv.Itoa(int(timeout.Seconds())))
+	}
+
+	sort.Strings(kvs) // Makes testing easier (not a performance concern)
+	return strings.Join(kvs, " "), nil
 }

--- a/metricbeat/module/postgresql/postgresql_test.go
+++ b/metricbeat/module/postgresql/postgresql_test.go
@@ -1,0 +1,74 @@
+package postgresql
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseUrl(t *testing.T) {
+	tests := []struct {
+		Name     string
+		URL      string
+		Username string
+		Password string
+		Timeout  time.Duration
+		Expected string
+	}{
+		{
+			Name:     "simple test",
+			URL:      "postgres://host1:5432",
+			Expected: "host=host1 port=5432",
+		},
+		{
+			Name:     "no port",
+			URL:      "postgres://host1",
+			Expected: "host=host1",
+		},
+		{
+			Name:     "user/pass in URL",
+			URL:      "postgres://user:pass@host1:5432",
+			Expected: "host=host1 password=pass port=5432 user=user",
+		},
+		{
+			Name:     "user/pass in params",
+			URL:      "postgres://host1:5432",
+			Username: "user",
+			Password: "secret",
+			Expected: "host=host1 password=secret port=5432 user=user",
+		},
+		{
+			Name:     "user/pass override",
+			URL:      "postgres://user1:pass@host1:5432",
+			Username: "user",
+			Password: "secret",
+			Expected: "host=host1 password=secret port=5432 user=user",
+		},
+		{
+			Name:     "timeout no override",
+			URL:      "postgres://host1:5432?connect_timeout=2",
+			Expected: "connect_timeout=2 host=host1 port=5432",
+		},
+		{
+			Name:     "timeout from param",
+			URL:      "postgres://host1:5432",
+			Timeout:  3 * time.Second,
+			Expected: "connect_timeout=3 host=host1 port=5432",
+		},
+		{
+			Name:     "user/pass override, and timeout override",
+			URL:      "postgres://user1:pass@host1:5432?connect_timeout=2",
+			Username: "user",
+			Password: "secret",
+			Timeout:  3 * time.Second,
+			Expected: "connect_timeout=3 host=host1 password=secret port=5432 user=user",
+		},
+	}
+
+	for _, test := range tests {
+		url, err := ParseURL(test.URL, test.Username, test.Password, test.Timeout)
+		assert.NoError(t, err, test.Name)
+		assert.Equal(t, test.Expected, url, test.Name)
+	}
+}

--- a/metricbeat/module/postgresql/testing.go
+++ b/metricbeat/module/postgresql/testing.go
@@ -5,3 +5,11 @@ import "os"
 func GetEnvDSN() string {
 	return os.Getenv("POSTGRESQL_DSN")
 }
+
+func GetEnvUsername() string {
+	return os.Getenv("POSTGRESQL_USERNAME")
+}
+
+func GetEnvPassword() string {
+	return os.Getenv("POSTGRESQL_PASSWORD")
+}

--- a/metricbeat/tests/system/config/metricbeat.yml.j2
+++ b/metricbeat/tests/system/config/metricbeat.yml.j2
@@ -14,6 +14,14 @@ metricbeat.modules:
     {% endfor %}
   {% endif -%}
 
+  {% if m.username -%}
+  username: {{ m.username }}
+  {% endif -%}
+
+  {% if m.password -%}
+  password: {{ m.password }}
+  {% endif -%}
+
   {% if m.metricsets -%}
   metricsets:
     {% for ms in m.metricsets -%}

--- a/metricbeat/tests/system/test_postgresql.py
+++ b/metricbeat/tests/system/test_postgresql.py
@@ -18,7 +18,8 @@ class Test(metricbeat.BaseTest):
             self.assert_fields_are_documented(evt)
 
     def get_hosts(self):
-        return [os.getenv("POSTGRESQL_DSN")]
+        return [os.getenv("POSTGRESQL_DSN")], os.getenv("POSTGRESQL_USERNAME"), \
+            os.getenv("POSTGRESQL_PASSWORD")
 
     @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
     @attr('integration')
@@ -26,10 +27,13 @@ class Test(metricbeat.BaseTest):
         """
         PostgreSQL module outputs an event.
         """
+        hosts, username, password = self.get_hosts()
         self.render_config_template(modules=[{
             "name": "postgresql",
             "metricsets": ["activity"],
-            "hosts": self.get_hosts(),
+            "hosts": hosts,
+            "username": username,
+            "password": password,
             "period": "5s"
         }])
         proc = self.start_beat()
@@ -50,10 +54,13 @@ class Test(metricbeat.BaseTest):
         """
         PostgreSQL module outputs an event.
         """
+        hosts, username, password = self.get_hosts()
         self.render_config_template(modules=[{
             "name": "postgresql",
             "metricsets": ["database"],
-            "hosts": self.get_hosts(),
+            "hosts": hosts,
+            "username": username,
+            "password": password,
             "period": "5s"
         }])
         proc = self.start_beat()
@@ -77,10 +84,13 @@ class Test(metricbeat.BaseTest):
         """
         PostgreSQL module outputs an event.
         """
+        hosts, username, password = self.get_hosts()
         self.render_config_template(modules=[{
             "name": "postgresql",
             "metricsets": ["bgwriter"],
-            "hosts": self.get_hosts(),
+            "hosts": hosts,
+            "username": username,
+            "password": password,
             "period": "5s"
         }])
         proc = self.start_beat()


### PR DESCRIPTION
Cherry-pick of PR #2890 to 5.0 branch. Original message: 
Similar to #2889 but for PostgreSQL. Also adds docs to the Postgres module,
which were missing, and adjusted the integration tests to use the username
option instead of the full URL.