### PR TITLE
Backport: Fix 'index out of range' bug in Packetbeat DNS protocol plugin (#2875)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -35,6 +35,8 @@ https://github.com/elastic/beats/compare/v5.0.0...5.0[Check the HEAD diff]
 
 *Packetbeat*
 
+- Fix 'index out of bounds' bug in Packetbeat DNS protocol plugin. {issue}2872[2872]
+
 *Topbeat*
 
 *Filebeat*

--- a/packetbeat/protos/dns/dns.go
+++ b/packetbeat/protos/dns/dns.go
@@ -529,26 +529,23 @@ func optToMapStr(rrOPT *mkdns.OPT) common.MapStr {
 	return optMapStr
 }
 
-// rrsToMapStr converts an array of RR's to an array of MapStr's.
+// rrsToMapStr converts an slice of RR's to an slice of MapStr's.
 func rrsToMapStrs(records []mkdns.RR) []common.MapStr {
-	mapStrArray := make([]common.MapStr, len(records))
-	for i, rr := range records {
+	mapStrSlice := make([]common.MapStr, 0, len(records))
+	for _, rr := range records {
 		rrHeader := rr.Header()
 
 		mapStr := rrToMapStr(rr)
 		if len(mapStr) == 0 { // OPT pseudo-RR returns an empty MapStr
-			resizeStrArray := make([]common.MapStr, len(mapStrArray)-1)
-			copy(resizeStrArray, mapStrArray)
-			mapStrArray = resizeStrArray
 			continue
 		}
 		mapStr["name"] = rrHeader.Name
 		mapStr["type"] = dnsTypeToString(rrHeader.Rrtype)
 		mapStr["class"] = dnsClassToString(rrHeader.Class)
 		mapStr["ttl"] = strconv.FormatInt(int64(rrHeader.Ttl), 10)
-		mapStrArray[i] = mapStr
+		mapStrSlice = append(mapStrSlice, mapStr)
 	}
-	return mapStrArray
+	return mapStrSlice
 }
 
 // Convert all RDATA fields of a RR to a single string


### PR DESCRIPTION
Backport of #2875 to 5.0

> When converting resource records into MapStrs the code can run into an index out of range exception when processing OPT psuedo resource records. The code reduces the size of a slice by creating a new, smaller slice and copies the existing data to the smaller slice. But the code did not account for the fact that the length of the slice was smaller when indexing.
>
>Fixes #2872

Cherry picked from: cbde106b7a915ffd781a933397786473d3c1e429, 7c2fe0933a49dafbeaa518fb551dd07deb54f978