### PR TITLE
Don't check stdout on windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@
 /build
 /*/data
 /*/logs
-/**/.vscode
 
 # Files
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /build
 /*/data
 /*/logs
+/**/.vscode
 
 # Files
 .DS_Store

--- a/libbeat/outputs/console/console.go
+++ b/libbeat/outputs/console/console.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"runtime"
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/op"
@@ -28,8 +29,10 @@ func New(_ string, config *common.Config, _ int) (outputs.Outputer, error) {
 	}
 
 	// check stdout actually being available
-	if _, err = c.out.Stat(); err != nil {
-		return nil, fmt.Errorf("console output initialization failed with: %v", err)
+	if runtime.GOOS != "windows" {
+		if _, err = c.out.Stat(); err != nil {
+			return nil, fmt.Errorf("console output initialization failed with: %v", err)
+		}
 	}
 
 	return c, nil

--- a/libbeat/outputs/console/console.go
+++ b/libbeat/outputs/console/console.go
@@ -2,6 +2,7 @@ package console
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"runtime"
@@ -10,6 +11,7 @@ import (
 	"github.com/elastic/beats/libbeat/common/op"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/outputs"
+	"github.com/mattn/go-isatty"
 )
 
 func init() {
@@ -22,6 +24,13 @@ type console struct {
 }
 
 func New(_ string, config *common.Config, _ int) (outputs.Outputer, error) {
+	if runtime.GOOS == "windows" {
+		if !isatty.IsTerminal(os.Stdout.Fd()) {
+			logp.Info("It seems you're not running from a console. Please use another output.")
+			return nil, errors.New("It seems you're not running from a console. Please use another output.")
+		}
+	}
+
 	c := &console{config: defaultConfig, out: os.Stdout}
 	err := config.Unpack(&c.config)
 	if err != nil {

--- a/libbeat/outputs/console/console.go
+++ b/libbeat/outputs/console/console.go
@@ -2,7 +2,6 @@ package console
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 	"runtime"
@@ -11,7 +10,6 @@ import (
 	"github.com/elastic/beats/libbeat/common/op"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/outputs"
-	"github.com/mattn/go-isatty"
 )
 
 func init() {
@@ -24,13 +22,6 @@ type console struct {
 }
 
 func New(_ string, config *common.Config, _ int) (outputs.Outputer, error) {
-	if runtime.GOOS == "windows" {
-		if !isatty.IsTerminal(os.Stdout.Fd()) {
-			logp.Info("It seems you're not running from a console. Please use another output.")
-			return nil, errors.New("It seems you're not running from a console. Please use another output.")
-		}
-	}
-
 	c := &console{config: defaultConfig, out: os.Stdout}
 	err := config.Unpack(&c.config)
 	if err != nil {


### PR DESCRIPTION
fixes #2756 

The only way we can ignore this error, is not to call `Stat()` on windows. Or we use something like this 
```
if runtime.GOOS == "windows" {
		if !isatty.IsTerminal(os.Stdout.Fd()) {
			return nil, fmt.Errorf("console output initialization failed")
		}
	} else {
		if _, err = c.out.Stat(); err != nil {
			return nil, fmt.Errorf("console output initialization failed with: %v", err)
		}
	}
```
But this depends on external library [isatty](https://github.com/mattn/go-isatty)