### PR TITLE
Output without the json wrapper

### DIFF
--- a/libbeat/outputs/console/config.go
+++ b/libbeat/outputs/console/config.go
@@ -1,11 +1,15 @@
 package console
 
+import "github.com/elastic/beats/libbeat/common/fmtstr"
+
 type config struct {
-	Pretty bool `config:"pretty"`
+	Pretty bool                      `config:"pretty"`
+	Format *fmtstr.EventFormatString `config:"format"`
 }
 
 var (
 	defaultConfig = config{
 		Pretty: false,
+		Format: nil,
 	}
 )

--- a/libbeat/outputs/console/config.go
+++ b/libbeat/outputs/console/config.go
@@ -1,15 +1,10 @@
 package console
 
-import "github.com/elastic/beats/libbeat/common/fmtstr"
-
-type config struct {
-	Pretty bool                      `config:"pretty"`
-	Format *fmtstr.EventFormatString `config:"format"`
-}
-
-var (
-	defaultConfig = config{
-		Pretty: false,
-		Format: nil,
-	}
+import (
+	"github.com/elastic/beats/libbeat/outputs"
 )
+
+type Config struct {
+	Pretty       bool                 `config:"pretty"`
+	WriterConfig outputs.WriterConfig `config:"writer"`
+}

--- a/libbeat/outputs/console/console.go
+++ b/libbeat/outputs/console/console.go
@@ -6,10 +6,10 @@ import (
 	"os"
 
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/fmtstr"
 	"github.com/elastic/beats/libbeat/common/op"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/outputs"
-    "github.com/elastic/beats/libbeat/common/fmtstr"
 )
 
 func init() {
@@ -53,26 +53,26 @@ func (c *console) PublishEvent(
 	var serializedEvent []byte
 	var err error
 
-    if c.config.Format != nil {
-        formattedEvent, err := c.config.Format.Run(data.Event)
-        if err != nil {
-            logp.Err("Fail to format event (%v): %#v", err, data.Event)
-            op.SigCompleted(s)
-            return err
-        }
-        serializedEvent = []byte(formattedEvent)
-    }else {
-        if c.config.Pretty {
-            serializedEvent, err = json.MarshalIndent(data.Event, "", "  ")
-        } else {
-            serializedEvent, err = json.Marshal(data.Event)
-        }
-        if err != nil {
-            logp.Err("Fail to convert the event to JSON (%v): %#v", err, data.Event)
-            op.SigCompleted(s)
-            return err
-        }
-    }
+	if c.config.Format != nil {
+		formattedEvent, err := c.config.Format.Run(data.Event)
+		if err != nil {
+			logp.Err("Fail to format event (%v): %#v", err, data.Event)
+			op.SigCompleted(s)
+			return err
+		}
+		serializedEvent = []byte(formattedEvent)
+	} else {
+		if c.config.Pretty {
+			serializedEvent, err = json.MarshalIndent(data.Event, "", "  ")
+		} else {
+			serializedEvent, err = json.Marshal(data.Event)
+		}
+		if err != nil {
+			logp.Err("Fail to convert the event to JSON (%v): %#v", err, data.Event)
+			op.SigCompleted(s)
+			return err
+		}
+	}
 
 	if err = c.writeBuffer(serializedEvent); err != nil {
 		goto fail

--- a/libbeat/outputs/console/console_test.go
+++ b/libbeat/outputs/console/console_test.go
@@ -9,9 +9,9 @@ import (
 	"testing"
 
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/fmtstr"
 	"github.com/elastic/beats/libbeat/outputs"
 	"github.com/stretchr/testify/assert"
-    "github.com/elastic/beats/libbeat/common/fmtstr"
 )
 
 // capture stdout and return captured string
@@ -71,10 +71,10 @@ func TestConsoleOneEventIndented(t *testing.T) {
 }
 
 func TestConsoleOneEventFormatted(t *testing.T) {
-    lines, err := run(false, fmtstr.MustCompileEvent("%{[event]}"), event("event", "myevent"))
-    assert.Nil(t, err)
-    expected := "myevent\n"
-    assert.Equal(t, expected, lines)
+	lines, err := run(false, fmtstr.MustCompileEvent("%{[event]}"), event("event", "myevent"))
+	assert.Nil(t, err)
+	expected := "myevent\n"
+	assert.Equal(t, expected, lines)
 }
 
 func TestConsoleMultipleEvents(t *testing.T) {

--- a/libbeat/outputs/fileout/config.go
+++ b/libbeat/outputs/fileout/config.go
@@ -3,20 +3,23 @@ package fileout
 import (
 	"fmt"
 
+	"github.com/elastic/beats/libbeat/common/fmtstr"
 	"github.com/elastic/beats/libbeat/logp"
 )
 
 type config struct {
-	Path          string `config:"path"`
-	Filename      string `config:"filename"`
-	RotateEveryKb int    `config:"rotate_every_kb" validate:"min=1"`
-	NumberOfFiles int    `config:"number_of_files"`
+	Path          string                    `config:"path"`
+	Filename      string                    `config:"filename"`
+	RotateEveryKb int                       `config:"rotate_every_kb" validate:"min=1"`
+	NumberOfFiles int                       `config:"number_of_files"`
+	Format        *fmtstr.EventFormatString `config:"format"`
 }
 
 var (
 	defaultConfig = config{
 		NumberOfFiles: 7,
 		RotateEveryKb: 10 * 1024,
+		Format:        nil,
 	}
 )
 

--- a/libbeat/outputs/fileout/config.go
+++ b/libbeat/outputs/fileout/config.go
@@ -3,23 +3,23 @@ package fileout
 import (
 	"fmt"
 
-	"github.com/elastic/beats/libbeat/common/fmtstr"
 	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/outputs"
 )
 
 type config struct {
-	Path          string                    `config:"path"`
-	Filename      string                    `config:"filename"`
-	RotateEveryKb int                       `config:"rotate_every_kb" validate:"min=1"`
-	NumberOfFiles int                       `config:"number_of_files"`
-	Format        *fmtstr.EventFormatString `config:"format"`
+	Path          string               `config:"path"`
+	Filename      string               `config:"filename"`
+	RotateEveryKb int                  `config:"rotate_every_kb" validate:"min=1"`
+	NumberOfFiles int                  `config:"number_of_files"`
+	WriterConfig  outputs.WriterConfig `config:"writer"`
 }
 
 var (
 	defaultConfig = config{
 		NumberOfFiles: 7,
 		RotateEveryKb: 10 * 1024,
-		Format:        nil,
+		WriterConfig:  outputs.WriterConfig{Type: outputs.JsonWriterType, Pretty: false},
 	}
 )
 

--- a/libbeat/outputs/fileout/file.go
+++ b/libbeat/outputs/fileout/file.go
@@ -4,10 +4,10 @@ import (
 	"encoding/json"
 
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/fmtstr"
 	"github.com/elastic/beats/libbeat/common/op"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/outputs"
-    "github.com/elastic/beats/libbeat/common/fmtstr"
 )
 
 func init() {
@@ -17,7 +17,7 @@ func init() {
 type fileOutput struct {
 	beatName string
 	rotator  logp.FileRotator
-    format        *fmtstr.EventFormatString
+	format   *fmtstr.EventFormatString
 }
 
 // New instantiates a new file output instance.
@@ -45,8 +45,8 @@ func (out *fileOutput) init(config config) error {
 		out.rotator.Name = out.beatName
 	}
 
-    out.format = config.Format
-    logp.Info("File output path set to: %v", out.rotator.Path)
+	out.format = config.Format
+	logp.Info("File output path set to: %v", out.rotator.Path)
 	logp.Info("File output base filename set to: %v", out.rotator.Name)
 
 	rotateeverybytes := uint64(config.RotateEveryKb) * 1024
@@ -80,28 +80,28 @@ func (out *fileOutput) PublishEvent(
 	opts outputs.Options,
 	data outputs.Data,
 ) error {
-    var serializedEvent []byte
-    var err error
+	var serializedEvent []byte
+	var err error
 
-    if out.format != nil {
-        formattedEvent, err := out.format.Run(data.Event)
-        if err != nil {
-            logp.Err("Fail to format event (%v): %#v", err, data.Event)
-            op.SigCompleted(sig)
-            return err
-        }
-        serializedEvent = []byte(formattedEvent)
+	if out.format != nil {
+		formattedEvent, err := out.format.Run(data.Event)
+		if err != nil {
+			logp.Err("Fail to format event (%v): %#v", err, data.Event)
+			op.SigCompleted(sig)
+			return err
+		}
+		serializedEvent = []byte(formattedEvent)
 
-    }else {
-        serializedEvent, err = json.Marshal(data.Event)
-        if err != nil {
-            // mark as success so event is not sent again.
-            op.SigCompleted(sig)
+	} else {
+		serializedEvent, err = json.Marshal(data.Event)
+		if err != nil {
+			// mark as success so event is not sent again.
+			op.SigCompleted(sig)
 
-            logp.Err("Fail to json encode event(%v): %#v", err, data.Event)
-            return err
-        }
-    }
+			logp.Err("Fail to json encode event(%v): %#v", err, data.Event)
+			return err
+		}
+	}
 
 	err = out.rotator.WriteLine(serializedEvent)
 	if err != nil {

--- a/libbeat/outputs/kafka/client.go
+++ b/libbeat/outputs/kafka/client.go
@@ -149,21 +149,21 @@ func (c *client) getEventMessage(data *outputs.Data) (*message, error) {
 	}
 	msg.topic = topic
 
-    var serializedEvent []byte
+	var serializedEvent []byte
 
-    if c.format != nil {
-        formattedEvent, err := c.format.Run(event)
-        if err != nil {
-            return nil, fmt.Errorf("Fail to format event (%v): %#v", err, event)
-        }
-        serializedEvent = []byte(formattedEvent)
-    }else {
-        jsonEvent, err := json.Marshal(event)
-        if err != nil {
-            return nil, fmt.Errorf("json encoding failed with %v", err)
-        }
-        serializedEvent = jsonEvent
-    }
+	if c.format != nil {
+		formattedEvent, err := c.format.Run(event)
+		if err != nil {
+			return nil, fmt.Errorf("Fail to format event (%v): %#v", err, event)
+		}
+		serializedEvent = []byte(formattedEvent)
+	} else {
+		jsonEvent, err := json.Marshal(event)
+		if err != nil {
+			return nil, fmt.Errorf("json encoding failed with %v", err)
+		}
+		serializedEvent = jsonEvent
+	}
 
 	msg.value = serializedEvent
 

--- a/libbeat/outputs/kafka/client.go
+++ b/libbeat/outputs/kafka/client.go
@@ -1,7 +1,6 @@
 package kafka
 
 import (
-	"encoding/json"
 	"expvar"
 	"fmt"
 	"sync"
@@ -21,7 +20,7 @@ type client struct {
 	hosts  []string
 	topic  outil.Selector
 	key    *fmtstr.EventFormatString
-	format *fmtstr.EventFormatString
+	writer outputs.Writer
 	config sarama.Config
 
 	producer sarama.AsyncProducer
@@ -48,14 +47,14 @@ func newKafkaClient(
 	hosts []string,
 	key *fmtstr.EventFormatString,
 	topic outil.Selector,
-	format *fmtstr.EventFormatString,
+	writer outputs.Writer,
 	cfg *sarama.Config,
 ) (*client, error) {
 	c := &client{
 		hosts:  hosts,
 		topic:  topic,
 		key:    key,
-		format: format,
+		writer: writer,
 		config: *cfg,
 	}
 	return c, nil
@@ -149,20 +148,9 @@ func (c *client) getEventMessage(data *outputs.Data) (*message, error) {
 	}
 	msg.topic = topic
 
-	var serializedEvent []byte
-
-	if c.format != nil {
-		formattedEvent, err := c.format.Run(event)
-		if err != nil {
-			return nil, fmt.Errorf("Fail to format event (%v): %#v", err, event)
-		}
-		serializedEvent = []byte(formattedEvent)
-	} else {
-		jsonEvent, err := json.Marshal(event)
-		if err != nil {
-			return nil, fmt.Errorf("json encoding failed with %v", err)
-		}
-		serializedEvent = jsonEvent
+	serializedEvent, err := c.writer.Write(event)
+	if err != nil {
+		return nil, err
 	}
 
 	msg.value = serializedEvent

--- a/libbeat/outputs/kafka/config.go
+++ b/libbeat/outputs/kafka/config.go
@@ -30,6 +30,7 @@ type kafkaConfig struct {
 	ChanBufferSize  int                       `config:"channel_buffer_size" validate:"min=1"`
 	Username        string                    `config:"username"`
 	Password        string                    `config:"password"`
+	Format          *fmtstr.EventFormatString `config:"format"`
 }
 
 type metaConfig struct {

--- a/libbeat/outputs/kafka/config.go
+++ b/libbeat/outputs/kafka/config.go
@@ -30,7 +30,7 @@ type kafkaConfig struct {
 	ChanBufferSize  int                       `config:"channel_buffer_size" validate:"min=1"`
 	Username        string                    `config:"username"`
 	Password        string                    `config:"password"`
-	Format          *fmtstr.EventFormatString `config:"format"`
+	WriterConfig    outputs.WriterConfig      `config:"writer"`
 }
 
 type metaConfig struct {

--- a/libbeat/outputs/kafka/kafka.go
+++ b/libbeat/outputs/kafka/kafka.go
@@ -160,7 +160,7 @@ func (k *kafka) initMode(guaranteed bool) (mode.ConnectionMode, error) {
 	hosts := k.config.Hosts
 	topic := k.topic
 	for i := 0; i < worker; i++ {
-		client, err := newKafkaClient(hosts, k.config.Key, topic, libCfg)
+		client, err := newKafkaClient(hosts, k.config.Key, topic, k.config.Format, libCfg)
 		if err != nil {
 			logp.Err("Failed to create kafka client: %v", err)
 			return nil, err

--- a/libbeat/outputs/kafka/kafka.go
+++ b/libbeat/outputs/kafka/kafka.go
@@ -159,8 +159,11 @@ func (k *kafka) initMode(guaranteed bool) (mode.ConnectionMode, error) {
 	var clients []mode.AsyncProtocolClient
 	hosts := k.config.Hosts
 	topic := k.topic
+
+	writer := outputs.CreateWriter(k.config.WriterConfig)
+
 	for i := 0; i < worker; i++ {
-		client, err := newKafkaClient(hosts, k.config.Key, topic, k.config.Format, libCfg)
+		client, err := newKafkaClient(hosts, k.config.Key, topic, writer, libCfg)
 		if err != nil {
 			logp.Err("Failed to create kafka client: %v", err)
 			return nil, err

--- a/libbeat/outputs/kafka/kafka_integration_test.go
+++ b/libbeat/outputs/kafka/kafka_integration_test.go
@@ -13,12 +13,11 @@ import (
 
 	"github.com/Shopify/sarama"
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/fmtstr"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/outputs"
 	"github.com/elastic/beats/libbeat/outputs/mode/modetest"
 	"github.com/stretchr/testify/assert"
-    "github.com/elastic/beats/libbeat/common/fmtstr"
-
 )
 
 const (
@@ -67,20 +66,20 @@ func TestKafkaPublish(t *testing.T) {
 				"message":    id,
 			}),
 		},
-        {
-            "publish single event with formating to test topic",
-            map[string]interface{}{
-                "format": "%{[message]}",
-            },
-            testTopic,
-            single(common.MapStr{
-                "@timestamp": common.Time(time.Now()),
-                "host":       "test-host",
-                "type":       "log",
-                "message":    id,
-            }),
-        },
-        {
+		{
+			"publish single event with formating to test topic",
+			map[string]interface{}{
+				"format": "%{[message]}",
+			},
+			testTopic,
+			single(common.MapStr{
+				"@timestamp": common.Time(time.Now()),
+				"host":       "test-host",
+				"type":       "log",
+				"message":    id,
+			}),
+		},
+		{
 			"batch publish to test topic",
 			nil,
 			testTopic,
@@ -215,24 +214,24 @@ func TestKafkaPublish(t *testing.T) {
 			}
 
 			for i, d := range expected {
-                if test.config["format"] != nil {
-                    fmtString := fmtstr.MustCompileEvent(test.config["format"].(string))
-                    expectedMessage, _ := fmtString.Run(d.Event)
-                    assert.Equal(t, string(expectedMessage), string(stored[i].Value))
-                }else {
+				if test.config["format"] != nil {
+					fmtString := fmtstr.MustCompileEvent(test.config["format"].(string))
+					expectedMessage, _ := fmtString.Run(d.Event)
+					assert.Equal(t, string(expectedMessage), string(stored[i].Value))
+				} else {
 
-                    var decoded map[string]interface{}
-                    err := json.Unmarshal(stored[i].Value, &decoded)
-                    if err != nil {
-                        t.Errorf("can not json decode event value: %v", stored[i].Value)
-                        return
-                    }
-                    event := d.Event
+					var decoded map[string]interface{}
+					err := json.Unmarshal(stored[i].Value, &decoded)
+					if err != nil {
+						t.Errorf("can not json decode event value: %v", stored[i].Value)
+						return
+					}
+					event := d.Event
 
-                    assert.Equal(t, decoded["type"], event["type"])
-                    assert.Equal(t, decoded["message"], event["message"])
+					assert.Equal(t, decoded["type"], event["type"])
+					assert.Equal(t, decoded["message"], event["message"])
 
-                }
+				}
 			}
 		}()
 	}

--- a/libbeat/outputs/kafka/kafka_integration_test.go
+++ b/libbeat/outputs/kafka/kafka_integration_test.go
@@ -17,6 +17,8 @@ import (
 	"github.com/elastic/beats/libbeat/outputs"
 	"github.com/elastic/beats/libbeat/outputs/mode/modetest"
 	"github.com/stretchr/testify/assert"
+    "github.com/elastic/beats/libbeat/common/fmtstr"
+
 )
 
 const (
@@ -65,7 +67,20 @@ func TestKafkaPublish(t *testing.T) {
 				"message":    id,
 			}),
 		},
-		{
+        {
+            "publish single event with formating to test topic",
+            map[string]interface{}{
+                "format": "%{[message]}",
+            },
+            testTopic,
+            single(common.MapStr{
+                "@timestamp": common.Time(time.Now()),
+                "host":       "test-host",
+                "type":       "log",
+                "message":    id,
+            }),
+        },
+        {
 			"batch publish to test topic",
 			nil,
 			testTopic,
@@ -200,16 +215,24 @@ func TestKafkaPublish(t *testing.T) {
 			}
 
 			for i, d := range expected {
-				var decoded map[string]interface{}
-				err := json.Unmarshal(stored[i].Value, &decoded)
-				if err != nil {
-					t.Errorf("can not json decode event value: %v", stored[i].Value)
-					return
-				}
-				event := d.Event
+                if test.config["format"] != nil {
+                    fmtString := fmtstr.MustCompileEvent(test.config["format"].(string))
+                    expectedMessage, _ := fmtString.Run(d.Event)
+                    assert.Equal(t, string(expectedMessage), string(stored[i].Value))
+                }else {
 
-				assert.Equal(t, decoded["type"], event["type"])
-				assert.Equal(t, decoded["message"], event["message"])
+                    var decoded map[string]interface{}
+                    err := json.Unmarshal(stored[i].Value, &decoded)
+                    if err != nil {
+                        t.Errorf("can not json decode event value: %v", stored[i].Value)
+                        return
+                    }
+                    event := d.Event
+
+                    assert.Equal(t, decoded["type"], event["type"])
+                    assert.Equal(t, decoded["message"], event["message"])
+
+                }
 			}
 		}()
 	}

--- a/libbeat/outputs/kafka/kafka_integration_test.go
+++ b/libbeat/outputs/kafka/kafka_integration_test.go
@@ -69,7 +69,8 @@ func TestKafkaPublish(t *testing.T) {
 		{
 			"publish single event with formating to test topic",
 			map[string]interface{}{
-				"format": "%{[message]}",
+				"writer.type":   "FormatStringWriter",
+				"writer.format": "%{[message]}",
 			},
 			testTopic,
 			single(common.MapStr{
@@ -214,8 +215,8 @@ func TestKafkaPublish(t *testing.T) {
 			}
 
 			for i, d := range expected {
-				if test.config["format"] != nil {
-					fmtString := fmtstr.MustCompileEvent(test.config["format"].(string))
+				if test.config["writer.type"] == "FormatStringWriter" {
+					fmtString := fmtstr.MustCompileEvent(test.config["writer.format"].(string))
 					expectedMessage, _ := fmtString.Run(d.Event)
 					assert.Equal(t, string(expectedMessage), string(stored[i].Value))
 				} else {

--- a/libbeat/outputs/outputs.go
+++ b/libbeat/outputs/outputs.go
@@ -136,3 +136,13 @@ func (b *bulkOutputAdapter) BulkPublish(
 func (d *Data) AddValue(key, value interface{}) {
 	d.Values = d.Values.Append(key, value)
 }
+
+type EventEncoder interface {
+	// Encode event
+	Encode(event common.MapStr, options interface{}) ([]byte, error)
+}
+
+type EventFormatter interface {
+	// Format event
+	Format(event common.MapStr, format string) ([]byte, error)
+}

--- a/libbeat/outputs/redis/client.go
+++ b/libbeat/outputs/redis/client.go
@@ -112,7 +112,7 @@ func makePublish(
 	conn redis.Conn,
 	key outil.Selector,
 	dt redisDataType,
-    format *fmtstr.EventFormatString,
+	format *fmtstr.EventFormatString,
 ) (publishFn, error) {
 	if dt == redisChannelType {
 		return makePublishPUBLISH(conn, format)
@@ -167,7 +167,7 @@ func makePublishRPUSH(conn redis.Conn, key outil.Selector, format *fmtstr.EventF
 	return publishEventsPipeline(conn, "RPUSH", format), nil
 }
 
-func makePublishPUBLISH(conn redis.Conn, format *fmtstr.EventFormatString ) (publishFn, error) {
+func makePublishPUBLISH(conn redis.Conn, format *fmtstr.EventFormatString) (publishFn, error) {
 	return publishEventsPipeline(conn, "PUBLISH", format), nil
 }
 
@@ -194,7 +194,7 @@ func publishEventsBulk(conn redis.Conn, key outil.Selector, command string, form
 	}
 }
 
-func publishEventsPipeline(conn redis.Conn, command string, format *fmtstr.EventFormatString ) publishFn {
+func publishEventsPipeline(conn redis.Conn, command string, format *fmtstr.EventFormatString) publishFn {
 	return func(key outil.Selector, data []outputs.Data) ([]outputs.Data, error) {
 		var okEvents []outputs.Data
 		serialized := make([]interface{}, 0, len(data))
@@ -249,28 +249,28 @@ func serializeEvents(
 	to []interface{},
 	i int,
 	data []outputs.Data,
-    format *fmtstr.EventFormatString,
+	format *fmtstr.EventFormatString,
 ) ([]outputs.Data, []interface{}) {
-    var serializedEvent []byte
-    var err error
+	var serializedEvent []byte
+	var err error
 
 	succeeded := data
 	for _, d := range data {
-        if (format != nil){
-            formattedEvent, err := format.Run(d.Event)
-            if err != nil {
-                logp.Err("Fail to format event (%v): %#v", err, formattedEvent)
-                goto failLoop
-            }
-            serializedEvent = []byte(formattedEvent)
-        }else {
-            serializedEvent, err = json.Marshal(d.Event)
-            if err != nil {
-                logp.Err("Failed to convert the event to JSON (%v): %#v", err, d.Event)
-                goto failLoop
-            }
+		if format != nil {
+			formattedEvent, err := format.Run(d.Event)
+			if err != nil {
+				logp.Err("Fail to format event (%v): %#v", err, formattedEvent)
+				goto failLoop
+			}
+			serializedEvent = []byte(formattedEvent)
+		} else {
+			serializedEvent, err = json.Marshal(d.Event)
+			if err != nil {
+				logp.Err("Failed to convert the event to JSON (%v): %#v", err, d.Event)
+				goto failLoop
+			}
 
-        }
+		}
 		to = append(to, serializedEvent)
 		i++
 	}

--- a/libbeat/outputs/redis/config.go
+++ b/libbeat/outputs/redis/config.go
@@ -8,6 +8,7 @@ import (
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/outputs"
 	"github.com/elastic/beats/libbeat/outputs/transport"
+    "github.com/elastic/beats/libbeat/common/fmtstr"
 )
 
 type redisConfig struct {
@@ -27,6 +28,7 @@ type redisConfig struct {
 	HostTopology     string `config:"host_topology"`
 	PasswordTopology string `config:"password_topology"`
 	DbTopology       int    `config:"db_topology"`
+    Format          *fmtstr.EventFormatString `config:"format"`
 }
 
 var (

--- a/libbeat/outputs/redis/config.go
+++ b/libbeat/outputs/redis/config.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/elastic/beats/libbeat/common/fmtstr"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/outputs"
 	"github.com/elastic/beats/libbeat/outputs/transport"
-    "github.com/elastic/beats/libbeat/common/fmtstr"
 )
 
 type redisConfig struct {
@@ -25,10 +25,10 @@ type redisConfig struct {
 	Db       int    `config:"db"`
 	DataType string `config:"datatype"`
 
-	HostTopology     string `config:"host_topology"`
-	PasswordTopology string `config:"password_topology"`
-	DbTopology       int    `config:"db_topology"`
-    Format          *fmtstr.EventFormatString `config:"format"`
+	HostTopology     string                    `config:"host_topology"`
+	PasswordTopology string                    `config:"password_topology"`
+	DbTopology       int                       `config:"db_topology"`
+	Format           *fmtstr.EventFormatString `config:"format"`
 }
 
 var (

--- a/libbeat/outputs/redis/config.go
+++ b/libbeat/outputs/redis/config.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/elastic/beats/libbeat/common/fmtstr"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/outputs"
 	"github.com/elastic/beats/libbeat/outputs/transport"
@@ -25,10 +24,10 @@ type redisConfig struct {
 	Db       int    `config:"db"`
 	DataType string `config:"datatype"`
 
-	HostTopology     string                    `config:"host_topology"`
-	PasswordTopology string                    `config:"password_topology"`
-	DbTopology       int                       `config:"db_topology"`
-	Format           *fmtstr.EventFormatString `config:"format"`
+	HostTopology     string               `config:"host_topology"`
+	PasswordTopology string               `config:"password_topology"`
+	DbTopology       int                  `config:"db_topology"`
+	WriterConfig     outputs.WriterConfig `config:"writer"`
 }
 
 var (

--- a/libbeat/outputs/redis/redis.go
+++ b/libbeat/outputs/redis/redis.go
@@ -124,7 +124,7 @@ func (r *redisOut) init(cfg *common.Config, expireTopo int) error {
 		if err != nil {
 			return nil, err
 		}
-		return newClient(t, config.Password, config.Db, key, dataType), nil
+		return newClient(t, config.Password, config.Db, key, dataType, config.Format), nil
 	})
 	if err != nil {
 		return err

--- a/libbeat/outputs/redis/redis.go
+++ b/libbeat/outputs/redis/redis.go
@@ -120,11 +120,15 @@ func (r *redisOut) init(cfg *common.Config, expireTopo int) error {
 
 	// configure publisher clients
 	clients, err := modeutil.MakeClients(cfg, func(host string) (mode.ProtocolClient, error) {
+
 		t, err := transport.NewClient(transp, "tcp", host, config.Port)
 		if err != nil {
 			return nil, err
 		}
-		return newClient(t, config.Password, config.Db, key, dataType, config.Format), nil
+
+		writer := outputs.CreateWriter(config.WriterConfig)
+
+		return newClient(t, config.Password, config.Db, key, dataType, writer), nil
 	})
 	if err != nil {
 		return err

--- a/libbeat/outputs/redis/redis_integration_test.go
+++ b/libbeat/outputs/redis/redis_integration_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/elastic/beats/libbeat/outputs"
 	"github.com/garyburd/redigo/redis"
 	"github.com/stretchr/testify/assert"
+    "github.com/elastic/beats/libbeat/common/fmtstr"
 )
 
 const (
@@ -219,6 +220,21 @@ func TestPublishChannelTLS(t *testing.T) {
 	testPublishChannel(t, redisConfig)
 }
 
+func TestPublishChannelTCPWithFormatting(t *testing.T) {
+    db := 0
+    key := "test_pubchan_tcp"
+    redisConfig := map[string]interface{}{
+        "hosts":    []string{getRedisAddr()},
+        "key":      key,
+        "db":       db,
+        "datatype": "channel",
+        "timeout":  "5s",
+        "format": "%{[message]} bla",
+    }
+
+    testPublishChannel(t, redisConfig)
+}
+
 func testPublishChannel(t *testing.T, cfg map[string]interface{}) {
 	batches := 100
 	batchSize := 1000
@@ -282,9 +298,17 @@ func testPublishChannel(t *testing.T, cfg map[string]interface{}) {
 	assert.Equal(t, total, len(messages))
 	for i, raw := range messages {
 		evt := struct{ Message int }{}
-		err = json.Unmarshal(raw, &evt)
-		assert.NoError(t, err)
-		assert.Equal(t, i+1, evt.Message)
+        if cfg["format"] != nil {
+            fmtString := fmtstr.MustCompileEvent(cfg["format"].(string))
+            expectedMessage, _ := fmtString.Run(createEvent(i+1))
+
+            assert.NoError(t, err)
+            assert.Equal(t, string(expectedMessage), string(raw))
+        }else {
+            err = json.Unmarshal(raw, &evt)
+            assert.NoError(t, err)
+            assert.Equal(t, i+1, evt.Message)
+        }
 	}
 }
 
@@ -339,7 +363,7 @@ func sendTestEvents(out *redisOut, batches, N int) error {
 	for b := 0; b < batches; b++ {
 		batch := make([]outputs.Data, N)
 		for n := range batch {
-			batch[n] = outputs.Data{Event: common.MapStr{"message": i}}
+			batch[n] = outputs.Data{Event: createEvent(i)}
 			i++
 		}
 
@@ -350,4 +374,8 @@ func sendTestEvents(out *redisOut, batches, N int) error {
 	}
 
 	return nil
+}
+
+func createEvent(message int) common.MapStr{
+    return common.MapStr{"message": message}
 }

--- a/libbeat/outputs/redis/redis_integration_test.go
+++ b/libbeat/outputs/redis/redis_integration_test.go
@@ -10,10 +10,10 @@ import (
 	"testing"
 
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/fmtstr"
 	"github.com/elastic/beats/libbeat/outputs"
 	"github.com/garyburd/redigo/redis"
 	"github.com/stretchr/testify/assert"
-    "github.com/elastic/beats/libbeat/common/fmtstr"
 )
 
 const (
@@ -221,18 +221,18 @@ func TestPublishChannelTLS(t *testing.T) {
 }
 
 func TestPublishChannelTCPWithFormatting(t *testing.T) {
-    db := 0
-    key := "test_pubchan_tcp"
-    redisConfig := map[string]interface{}{
-        "hosts":    []string{getRedisAddr()},
-        "key":      key,
-        "db":       db,
-        "datatype": "channel",
-        "timeout":  "5s",
-        "format": "%{[message]} bla",
-    }
+	db := 0
+	key := "test_pubchan_tcp"
+	redisConfig := map[string]interface{}{
+		"hosts":    []string{getRedisAddr()},
+		"key":      key,
+		"db":       db,
+		"datatype": "channel",
+		"timeout":  "5s",
+		"format":   "%{[message]} bla",
+	}
 
-    testPublishChannel(t, redisConfig)
+	testPublishChannel(t, redisConfig)
 }
 
 func testPublishChannel(t *testing.T, cfg map[string]interface{}) {
@@ -298,17 +298,17 @@ func testPublishChannel(t *testing.T, cfg map[string]interface{}) {
 	assert.Equal(t, total, len(messages))
 	for i, raw := range messages {
 		evt := struct{ Message int }{}
-        if cfg["format"] != nil {
-            fmtString := fmtstr.MustCompileEvent(cfg["format"].(string))
-            expectedMessage, _ := fmtString.Run(createEvent(i+1))
+		if cfg["format"] != nil {
+			fmtString := fmtstr.MustCompileEvent(cfg["format"].(string))
+			expectedMessage, _ := fmtString.Run(createEvent(i + 1))
 
-            assert.NoError(t, err)
-            assert.Equal(t, string(expectedMessage), string(raw))
-        }else {
-            err = json.Unmarshal(raw, &evt)
-            assert.NoError(t, err)
-            assert.Equal(t, i+1, evt.Message)
-        }
+			assert.NoError(t, err)
+			assert.Equal(t, string(expectedMessage), string(raw))
+		} else {
+			err = json.Unmarshal(raw, &evt)
+			assert.NoError(t, err)
+			assert.Equal(t, i+1, evt.Message)
+		}
 	}
 }
 
@@ -376,6 +376,6 @@ func sendTestEvents(out *redisOut, batches, N int) error {
 	return nil
 }
 
-func createEvent(message int) common.MapStr{
-    return common.MapStr{"message": message}
+func createEvent(message int) common.MapStr {
+	return common.MapStr{"message": message}
 }

--- a/libbeat/outputs/redis/redis_integration_test.go
+++ b/libbeat/outputs/redis/redis_integration_test.go
@@ -224,12 +224,13 @@ func TestPublishChannelTCPWithFormatting(t *testing.T) {
 	db := 0
 	key := "test_pubchan_tcp"
 	redisConfig := map[string]interface{}{
-		"hosts":    []string{getRedisAddr()},
-		"key":      key,
-		"db":       db,
-		"datatype": "channel",
-		"timeout":  "5s",
-		"format":   "%{[message]} bla",
+		"hosts":         []string{getRedisAddr()},
+		"key":           key,
+		"db":            db,
+		"datatype":      "channel",
+		"timeout":       "5s",
+		"writer.type":   "FormatStringWriter",
+		"writer.format": "%{[message]}",
 	}
 
 	testPublishChannel(t, redisConfig)
@@ -298,8 +299,8 @@ func testPublishChannel(t *testing.T, cfg map[string]interface{}) {
 	assert.Equal(t, total, len(messages))
 	for i, raw := range messages {
 		evt := struct{ Message int }{}
-		if cfg["format"] != nil {
-			fmtString := fmtstr.MustCompileEvent(cfg["format"].(string))
+		if cfg["writer.type"] == "FormatStringWriter" {
+			fmtString := fmtstr.MustCompileEvent(cfg["writer.format"].(string))
 			expectedMessage, _ := fmtString.Run(createEvent(i + 1))
 
 			assert.NoError(t, err)

--- a/libbeat/outputs/writers.go
+++ b/libbeat/outputs/writers.go
@@ -1,0 +1,112 @@
+package outputs
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/fmtstr"
+	"github.com/elastic/beats/libbeat/logp"
+)
+
+type Writer interface {
+	Write(Event common.MapStr) ([]byte, error)
+}
+type writerType string
+
+func (t *writerType) Unpack(in interface{}) error {
+	s, ok := in.(string)
+	if !ok {
+		return fmt.Errorf("writer type must be an identifier")
+	}
+
+	writerType, found := writerTypes[s]
+	if !found {
+		return fmt.Errorf("invalid writer type '%v'", s)
+	}
+
+	*t = writerType
+	return nil
+}
+
+const (
+	FormatStringWriterType writerType = "FormatStringWriter"
+	JsonWriterType         writerType = "JsonWriter"
+)
+
+var (
+	writerTypes = map[string]writerType{
+		"":                   JsonWriterType,
+		"JsonWriter":         JsonWriterType,
+		"FormatStringWriter": FormatStringWriterType,
+	}
+)
+
+// TLSConfig defines config file options for TLS clients.
+type WriterConfig struct {
+	Type   writerType                `config:"type"`
+	Pretty bool                      `config:"pretty"`
+	Format *fmtstr.EventFormatString `config:"format"`
+}
+
+type JsonWriter struct {
+	Writer,
+	Pretty bool
+}
+
+func CreateWriter(config WriterConfig) Writer {
+	switch config.Type {
+	case "FormatStringWriter":
+		return NewFormatStringWriter(config.Format)
+	case "JsonWriter":
+	default:
+		return NewJsonWriter(config.Pretty)
+	}
+	return NewJsonWriter(config.Pretty)
+}
+
+func NewJsonWriter(pretty bool) *JsonWriter {
+	jsonWriter := new(JsonWriter)
+	jsonWriter.Pretty = pretty
+	return jsonWriter
+}
+
+func (j *JsonWriter) Write(event common.MapStr) ([]byte, error) {
+	var err error
+	var serializedEvent []byte
+
+	if j.Pretty {
+		serializedEvent, err = json.MarshalIndent(event, "", "  ")
+	} else {
+		serializedEvent, err = json.Marshal(event)
+	}
+	if err != nil {
+		logp.Err("Fail to convert the event to JSON (%v): %#v", err, event)
+	}
+
+	return serializedEvent, err
+}
+
+type FormatStringWriter struct {
+	Writer,
+	Format *fmtstr.EventFormatString
+}
+
+func NewFormatStringWriter(format *fmtstr.EventFormatString) *FormatStringWriter {
+	formattedWriter := new(FormatStringWriter)
+	if format == nil {
+		format = fmtstr.MustCompileEvent("%{[message]}")
+	}
+	formattedWriter.Format = format
+	return formattedWriter
+}
+
+func (w *FormatStringWriter) Write(event common.MapStr) ([]byte, error) {
+
+	serializedEvent, err := w.Format.RunBytes(event)
+	if err != nil {
+		logp.Err("Fail to format event (%v): %#v", err, event)
+		return serializedEvent, err
+	}
+
+	return serializedEvent, err
+}

--- a/libbeat/outputs/writers_test.go
+++ b/libbeat/outputs/writers_test.go
@@ -1,0 +1,72 @@
+package outputs
+
+import (
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/fmtstr"
+	"testing"
+)
+
+func event(k, v string) common.MapStr {
+	return common.MapStr{k: v}
+}
+
+func TestFormatStringWriter(t *testing.T) {
+	format := fmtstr.MustCompileEvent("test %{[msg]}")
+	expectedValue := "test message"
+
+	formatStringWriter := NewFormatStringWriter(format)
+	output, err := formatStringWriter.Write(event("msg", "message"))
+
+	if err != nil {
+		t.Errorf("Error during event write %v", err)
+	} else {
+		if string(output) != expectedValue {
+			t.Errorf("Expected value (%s) does not equal with output %s", expectedValue, output)
+		}
+	}
+}
+
+func TestJsonWriter(t *testing.T) {
+	expectedValue := "{\"msg\":\"message\"}"
+
+	formatStringWriter := NewJsonWriter(false)
+	output, err := formatStringWriter.Write(event("msg", "message"))
+
+	if err != nil {
+		t.Errorf("Error during event write %v", err)
+	} else {
+		if string(output) != expectedValue {
+			t.Errorf("Expected value (%s) does not equal with output (%s)", expectedValue, output)
+		}
+	}
+}
+
+func TestJsonWriterPrettyPrint(t *testing.T) {
+	expectedValue := "{\n  \"msg\": \"message\"\n}"
+
+	formatStringWriter := NewJsonWriter(true)
+	output, err := formatStringWriter.Write(event("msg", "message"))
+
+	if err != nil {
+		t.Errorf("Error during event write %v", err)
+	} else {
+		if string(output) != expectedValue {
+			t.Errorf("Expected value (%s) does not equal with output (%s)", expectedValue, output)
+		}
+	}
+}
+
+func TestCreatWriterDefaultsToJsonWriterWithoutPrettyprint(t *testing.T) {
+	expectedValue := "{\"msg\":\"message\"}"
+
+	formatStringWriter := CreateWriter(WriterConfig{})
+	output, err := formatStringWriter.Write(event("msg", "message"))
+
+	if err != nil {
+		t.Errorf("Error during event write %v", err)
+	} else {
+		if string(output) != expectedValue {
+			t.Errorf("Expected value (%s) does not equal with output (%s)", expectedValue, output)
+		}
+	}
+}


### PR DESCRIPTION
Initial implemenation of #2000 issue to be able specify format for the outputs (console, file, kafka, redis).

For example:

```
output.kafka:
  format: "%{[@timestamp]} %{[message]}"

```

I had an earlier implemetation which I had issues so I redid it to follow the common template format.