### PR TITLE
Backport: HAProxy docs updated (#2929)

### DIFF
--- a/metricbeat/docs/modules/apache.asciidoc
+++ b/metricbeat/docs/modules/apache.asciidoc
@@ -11,7 +11,7 @@ HTTPD] servers.
 [float]
 === Compatibility
 
-The Apache metricsets were tested with Apache 2.4.20 and are expected to work with all version
+The Apache metricsets were tested with Apache 2.4.20 and are expected to work with all versions
 >= 2.2.31 and >= 2.4.16.
 
 

--- a/metricbeat/docs/modules/haproxy.asciidoc
+++ b/metricbeat/docs/modules/haproxy.asciidoc
@@ -3,15 +3,20 @@ This file is generated! See scripts/docs_collector.py
 ////
 
 [[metricbeat-module-haproxy]]
-== haproxy Module
+== HAProxy Module
 
-This is the haproxy Module.  To enable stats collection from HAProxy, you must enable the stats socket via TCP.  
+This is the haproxy Module.  To enable stats collection from HAProxy, you must enable the stats socket via TCP.
 For example, placing the following statement under the `global` or `default` section of the haproxy config:
 
 `stats socket 127.0.0.1:14567`
 
 will enable stats reporting via any local IP on port 14567.  Please note that you should probably use an internal private IP
 or secure this with a firewall rule so that only designated hosts can access this data.
+
+[float]
+=== Compatibility
+
+The HAProxy metricsets were tested with HAProxy 1.6 and are expected to work with all 1.6 versions.
 
 
 [float]

--- a/metricbeat/module/apache/_meta/docs.asciidoc
+++ b/metricbeat/module/apache/_meta/docs.asciidoc
@@ -6,7 +6,7 @@ HTTPD] servers.
 [float]
 === Compatibility
 
-The Apache metricsets were tested with Apache 2.4.20 and are expected to work with all version
+The Apache metricsets were tested with Apache 2.4.20 and are expected to work with all versions
 >= 2.2.31 and >= 2.4.16.
 
 

--- a/metricbeat/module/haproxy/_meta/docs.asciidoc
+++ b/metricbeat/module/haproxy/_meta/docs.asciidoc
@@ -1,9 +1,14 @@
-== haproxy Module
+== HAProxy Module
 
-This is the haproxy Module.  To enable stats collection from HAProxy, you must enable the stats socket via TCP.  
+This is the haproxy Module.  To enable stats collection from HAProxy, you must enable the stats socket via TCP.
 For example, placing the following statement under the `global` or `default` section of the haproxy config:
 
 `stats socket 127.0.0.1:14567`
 
 will enable stats reporting via any local IP on port 14567.  Please note that you should probably use an internal private IP
 or secure this with a firewall rule so that only designated hosts can access this data.
+
+[float]
+=== Compatibility
+
+The HAProxy metricsets were tested with HAProxy 1.6 and are expected to work with all 1.6 versions.

--- a/metricbeat/module/haproxy/info/_meta/docs.asciidoc
+++ b/metricbeat/module/haproxy/info/_meta/docs.asciidoc
@@ -1,3 +1,3 @@
-=== haproxy stat MetricSet
+=== HAProxy info MetricSet
 
-This is the info metricset of the module haproxy.
+This is the info metricset of the haproxy module.

--- a/metricbeat/module/haproxy/stat/_meta/docs.asciidoc
+++ b/metricbeat/module/haproxy/stat/_meta/docs.asciidoc
@@ -1,6 +1,6 @@
-=== haproxy stat MetricSet
+=== HAProxy stat MetricSet
 
-This is the info metricset of the module haproxy.
+This is the stat metricset of the haproxy module.
 
 
 [float]
@@ -12,7 +12,7 @@ http://www.haproxy.org/download/1.6/doc/management.txt
 
 The following documentation bellow is an extract from the URL above, more specifically from section "9.1. CSV format"
 
-[source,ruby]
+[source,log]
 ----
 In brackets after each field name are the types which may have a value for
 that field. The types are L (Listeners), F (Frontends), B (Backends), and


### PR DESCRIPTION
* Fix duplicated info name
* Change ruby to log docs
* Document supported versions

See https://github.com/elastic/beats/issues/2485
(cherry picked from commit 2d776fa3da706d84e3c29b7c2788c33271fa3dbb)