### PR TITLE
Introducing named prospectors

### DIFF
--- a/filebeat/beater/filebeat.go
+++ b/filebeat/beater/filebeat.go
@@ -76,6 +76,11 @@ func (fb *Filebeat) Run(b *beat.Beat) error {
 		return err
 	}
 
+	for name, p := range config.NamedProspectors {
+		p.SetString("document_type", -1, name)
+		config.Prospectors = append(config.Prospectors, p)
+	}
+
 	crawler, err := crawler.New(newSpoolerOutlet(fb.done, spooler, wgEvents), config.Prospectors)
 	if err != nil {
 		logp.Err("Could not init crawler: %v", err)

--- a/filebeat/config/config.go
+++ b/filebeat/config/config.go
@@ -19,13 +19,14 @@ const (
 )
 
 type Config struct {
-	Prospectors     []*common.Config `config:"prospectors"`
-	SpoolSize       uint64           `config:"spool_size" validate:"min=1"`
-	PublishAsync    bool             `config:"publish_async"`
-	IdleTimeout     time.Duration    `config:"idle_timeout" validate:"nonzero,min=0s"`
-	RegistryFile    string           `config:"registry_file"`
-	ConfigDir       string           `config:"config_dir"`
-	ShutdownTimeout time.Duration    `config:"shutdown_timeout"`
+	Prospectors      []*common.Config          `config:"prospectors"`
+	NamedProspectors map[string]*common.Config `config:"prospectors"`
+	SpoolSize        uint64                    `config:"spool_size" validate:"min=1"`
+	PublishAsync     bool                      `config:"publish_async"`
+	IdleTimeout      time.Duration             `config:"idle_timeout" validate:"nonzero,min=0s"`
+	RegistryFile     string                    `config:"registry_file"`
+	ConfigDir        string                    `config:"config_dir"`
+	ShutdownTimeout  time.Duration             `config:"shutdown_timeout"`
 }
 
 var (

--- a/filebeat/tests/system/config/filebeat.yml.j2
+++ b/filebeat/tests/system/config/filebeat.yml.j2
@@ -70,6 +70,16 @@ filebeat.prospectors:
   {% endif %}
 {% endif %}
 
+{% if prospector_name %}
+filebeat.prospectors.{{ prospector_name}}:
+  {% if named_paths %}paths:
+    - {{ named_paths }}{% endif %}
+  scan_frequency: 0.1s
+  backoff: 0.1s
+  backoff_factor: 1
+  max_backoff: 0.1s
+{% endif %}
+
 filebeat.spool_size:
 filebeat.shutdown_timeout: {{ shutdown_timeout|default(0) }}
 filebeat.idle_timeout: 0.1s

--- a/filebeat/tests/system/test_prospectors_named.py
+++ b/filebeat/tests/system/test_prospectors_named.py
@@ -1,0 +1,67 @@
+from filebeat import BaseTest
+import os
+
+"""
+Tests for the named prospector functionality.
+"""
+
+
+class Test(BaseTest):
+
+    def test_named_prospector(self):
+        """
+        Test named prospector
+        """
+        self.render_config_template(
+            prospector_name="apache",
+            named_paths=os.path.abspath(self.working_dir) + "/log/apache.log",
+            prospectors=False,
+        )
+
+        os.mkdir(self.working_dir + "/log/")
+
+        apache = self.working_dir + "/log/apache.log"
+
+        with open(apache, 'w') as f:
+            f.write("Apache\n")
+
+        filebeat = self.start_beat()
+
+        self.wait_until(
+            lambda: self.output_has(lines=1), max_timeout=10)
+
+        filebeat.check_kill_and_wait()
+
+        content = self.read_output()
+
+        # Make sure type is set
+        assert content[0]["type"] == "apache"
+
+    def test_named_prospector_with_unnamed(self):
+        """
+        Test named prospector mixed with unnamed prospector
+        """
+        self.render_config_template(
+
+            path=os.path.abspath(self.working_dir) + "/log/test.log",
+            prospector_name="apache",
+            named_paths=os.path.abspath(self.working_dir) + "/log/apache.log",
+        )
+
+        os.mkdir(self.working_dir + "/log/")
+
+        testfile = self.working_dir + "/log/test.log"
+        apache = self.working_dir + "/log/apache.log"
+
+        with open(testfile, 'w') as f:
+            f.write("Hello world\n")
+
+        with open(apache, 'w') as f:
+            f.write("Apache\n")
+
+        filebeat = self.start_beat()
+
+        self.wait_until(
+            lambda: self.output_has(lines=2), max_timeout=10)
+
+        filebeat.check_kill_and_wait()


### PR DESCRIPTION
Named prospectors allow to define prospectors with a name instead of an array. The name of the prospector will automatically be set as `document_type` field. The config with named and unnamed prospectors looks as following:

```
filebeat.prospectors:
- paths:
    - test.log

filebeat.prospectors.apache:
  paths:
    - apache.log
```

It is not possible to mix named and unnamed directly. This change can make configurations more readable but has the downside, that named prospectors must be unique. In general it is recommended to only use named or unnamed and not mix them in one configuration file.