### PR TITLE
Remove dashboards.asciidoc from libbeat TOC

### DIFF
--- a/libbeat/docs/index.asciidoc
+++ b/libbeat/docs/index.asciidoc
@@ -29,10 +29,6 @@ include::./upgrading.asciidoc[]
 
 include::./config-file-format.asciidoc[]
 
-// include::./visualizing-data.asciidoc[]
-
-include::./dashboards.asciidoc[]
-
 pass::[<?page_header Always refer to the documentation in master for the latest information about contributing to Beats.?>]
 
 include::./newbeat.asciidoc[]


### PR DESCRIPTION
Whoops...looks like I commented out some entries in the toc when I should have deleted them. One of the topics inadvertently got added back in by [this commit](https://github.com/elastic/beats/commit/c5bdb0c900aeed7458264b0a1af9b6c36dc17979). So now the content appears where it doesn't belong (under YAML Tips and Gotchas _doh_). Don't worry...the content is still available elsewhere. :-)