### PR TITLE
add description field for chkconfig add command

### DIFF
--- a/dev-tools/packer/platforms/centos/init.j2
+++ b/dev-tools/packer/platforms/centos/init.j2
@@ -3,6 +3,7 @@
 # {{.beat_name}}          {{.beat_name}} shipper
 #
 # chkconfig: 2345 98 02
+# description: Starts and stops a single {{.beat_name}} instance on this system
 #
 
 ### BEGIN INIT INFO


### PR DESCRIPTION
I found the luck of description field of /etc/init.d/filebeat.
After this commit, we can "chkconfig --add filebeat".
The description field's sentence is copied from /etc/init.d/elasticsearch.