### PR TITLE
Backport: Misc doc changes (#2983)

### DIFF
--- a/filebeat/docs/getting-started.asciidoc
+++ b/filebeat/docs/getting-started.asciidoc
@@ -214,3 +214,5 @@ After you've created the index pattern, you can select the `filebeat-*` index pa
 Filebeat data.
 
 image:./images/filebeat-discover-tab.png[]
+
+TIP: If you don't see `filebeat-*` in the list of available index patterns, try refreshing the page in your browser.

--- a/filebeat/docs/load-balancing.asciidoc
+++ b/filebeat/docs/load-balancing.asciidoc
@@ -24,7 +24,7 @@ Filebeat can send events in a few different modes:
 By default, when you configure Filebeat to send events to multiple hosts
 (`loadbalance: true`), Filebeat will send the events to one host after
 another. This mode requires the least memory and CPU usage. This is not
-true load balancing in the sense that Filebeat does account for the load
+true load balancing in the sense that Filebeat doesn't account for the load
 being processed by each host.
 +
 The load balancer also supports multiple workers per host. The default is
@@ -51,8 +51,12 @@ In this example, there are 4 workers participating in load balancing.
 * **Send events to `N` hosts in lock-step:**
 +
 You can configure Filebeat to send events to `N` hosts in lock-step by setting
-`spool_size = N * bulk_max_size`. This mode requires more memory and CPU usage
-than the previous mode.
+`spool_size = N * bulk_max_size`. In lock-step mode, the batch collected by the
+spooler is split up into smaller batches of size `bulk_max_size`. These smaller
+batches are load balanced between available connections. Filebeat waits for all
+sub-batches to be published before it retrieves another batch from the spooler. 
++
+This mode requires more memory and CPU usage than the previous mode.
 +
 Example:
 +

--- a/filebeat/docs/reference/configuration/filebeat-options.asciidoc
+++ b/filebeat/docs/reference/configuration/filebeat-options.asciidoc
@@ -367,7 +367,8 @@ See <<multiline-examples>> for more configuration examples.
 
 You specify the following settings under `multiline` to control how Filebeat combines the lines in the message:
 
-*`pattern`*:: Specifies the regular expression pattern to match. See <<regexp-support>> for a list of supported regexp patterns.
+*`pattern`*:: Specifies the regular expression pattern to match. Note that the regexp patterns supported by Filebeat differ
+somewhat from the patterns supported by Logstash. See <<regexp-support>> for a list of supported regexp patterns.
 
 *`negate`*:: Defines whether the pattern is negated. The default is `false`.
 

--- a/libbeat/docs/gettingstarted.asciidoc
+++ b/libbeat/docs/gettingstarted.asciidoc
@@ -378,7 +378,8 @@ https://www.elastic.co/downloads/kibana[Kibana downloads page].
 
 ==== Launching the Kibana Web Interface
 
-To launch the Kibana web interface, point your browser to port 5601. For example, `http://127.0.0.1:5601`.
+To launch the Kibana web interface, point your browser to port 5601. For example,
+http://127.0.0.1:5601[http://127.0.0.1:5601].
 
 You can learn more about Kibana in the
 http://www.elastic.co/guide/en/kibana/current/index.html[Kibana User Guide].


### PR DESCRIPTION
* Mention that the regexp support in Filbeat differs from LS
* Add tip about refreshing browser to see filebeat index pattern
* Provide active link to open kibana on localhost (for convenience)
* Explain what we mean by lock-step in the Filebeat docs about load balancing