### PR TITLE
Fix changelog for 5.0.1/5.0.0

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -87,11 +87,6 @@ https://github.com/elastic/beats/compare/v5.0.0...v5.0.1[View commits]
 
 - Fix 'index out of bounds' bug in Packetbeat DNS protocol plugin. {issue}2872[2872]
 
-*Filebeat*
-
-- Fix registry cleanup issue when files falling under ignore_older after restart. {issue}2818[2818]
-
-
 ==== Added
 
 *Metricbeat*
@@ -174,6 +169,8 @@ https://github.com/elastic/beats/compare/v5.0.0-beta1...v5.0.0-rc1[View commits]
 *Filebeat*
 
 - Fix input buffer on encoding problem. {pull}2416[2416]
+- Fix registry cleanup issue when files falling under ignore_older after restart. {issue}2818[2818]
+
 
 ==== Deprecated
 

--- a/libbeat/docs/release-notes/5.0.0.asciidoc
+++ b/libbeat/docs/release-notes/5.0.0.asciidoc
@@ -105,6 +105,7 @@ The list below covers changes between 1.x to 5.0.0 releases.
 - Fix input buffer on encoding problem. {pull}2416[2416]
 - Fix issue when `clean_removed` and `clean_inactive` were used together that states were not directly removed from the registry.
 - Fix issue where upgrading a 1.x registry file resulted in duplicate state entries. {pull}2792[2792]
+- Fix registry cleanup issue when files falling under ignore_older after restart. {issue}2818[2818]
 
 
 *Packetbeat*


### PR DESCRIPTION
The #2818 fix actually got in 5.0.0, so move the changelog entry around.