### PR TITLE
Add raw mysql fields to the mysql event

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -62,6 +62,7 @@ https://github.com/elastic/beats/compare/v5.0.0...master[Check the HEAD diff]
 - Add a sample Redis Kibana dashboard. {pull}2916[2916]
 - Add support for MongoDB 3.4 and WiredTiger metrics. {pull}2999[2999]
 - Add kafkka module with partition metricset. {pull}2969[2969]
+- Add raw config option for mysql/status metricset. {pull}3001[3001]
 
 *Packetbeat*
 

--- a/metricbeat/_meta/beat.full.yml
+++ b/metricbeat/_meta/beat.full.yml
@@ -131,6 +131,9 @@ metricbeat.modules:
   # Password of hosts. Empty by default
   #password: test
 
+  # By setting raw to true, all raw fields from the status metricset will be added to the event.
+  #raw: false
+
 #-------------------------------- Nginx Module -------------------------------
 #- module: nginx
   #metricsets: ["stubstatus"]

--- a/metricbeat/mb/mb.go
+++ b/metricbeat/mb/mb.go
@@ -103,6 +103,10 @@ func (b *BaseMetricSet) Host() string {
 // Configuration types
 
 // ModuleConfig is the base configuration data for all Modules.
+//
+// The Raw config option is used to enable raw fields in a metricset. This means
+// the metricset fetches not only the predefined fields but add alls raw data under
+// the raw namespace to the event.
 type ModuleConfig struct {
 	Hosts      []string                `config:"hosts"`
 	Period     time.Duration           `config:"period"     validate:"positive"`
@@ -111,6 +115,7 @@ type ModuleConfig struct {
 	MetricSets []string                `config:"metricsets" validate:"required"`
 	Enabled    bool                    `config:"enabled"`
 	Filters    processors.PluginConfig `config:"filters"`
+	Raw        bool                    `config:"raw"`
 
 	common.EventMetadata `config:",inline"` // Fields and tags to add to events.
 }

--- a/metricbeat/metricbeat.full.yml
+++ b/metricbeat/metricbeat.full.yml
@@ -131,6 +131,9 @@ metricbeat.modules:
   # Password of hosts. Empty by default
   #password: test
 
+  # By setting raw to true, all raw fields from the status metricset will be added to the event.
+  #raw: false
+
 #-------------------------------- Nginx Module -------------------------------
 #- module: nginx
   #metricsets: ["stubstatus"]

--- a/metricbeat/module/mysql/_meta/config.full.yml
+++ b/metricbeat/module/mysql/_meta/config.full.yml
@@ -12,3 +12,6 @@
 
   # Password of hosts. Empty by default
   #password: test
+
+  # By setting raw to true, all raw fields from the status metricset will be added to the event.
+  #raw: false

--- a/metricbeat/module/mysql/status/_meta/docs.asciidoc
+++ b/metricbeat/module/mysql/status/_meta/docs.asciidoc
@@ -3,3 +3,12 @@
 The MySQL `status` metricset collects data from MySQL by running a
 http://dev.mysql.com/doc/refman/5.7/en/show-status.html[`SHOW GLOBAL STATUS;`]
 SQL query. This query returns a large number of metrics.
+
+
+==== raw config option
+
+experimental[]
+
+The MySQL Status Metricset supports the `raw` config option. When enabled, in addition to the existing data structure, all fields available from the mysql service throgh `"SHOW /*!50002 GLOBAL */ STATUS;"` will be added to the event.
+
+These fields will be added under the namespace `mysql.status.raw`. The fields can vary from one MySQL instance to an other and no guarantees are provided for the  mapping of the fields as the mapping happens dynamically. This option is intended for enhance use cases.

--- a/metricbeat/module/mysql/status/data.go
+++ b/metricbeat/module/mysql/status/data.go
@@ -61,3 +61,16 @@ func eventMapping(status map[string]string) common.MapStr {
 	}
 	return schema.Apply(source)
 }
+
+func rawEventMapping(status map[string]string) common.MapStr {
+	source := common.MapStr{}
+	for key, val := range status {
+		// Only adds events which are not in the mapping
+		if schema.HasKey(key) {
+			continue
+		}
+
+		source[key] = val
+	}
+	return source
+}

--- a/metricbeat/module/mysql/status/status.go
+++ b/metricbeat/module/mysql/status/status.go
@@ -63,7 +63,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 }
 
 // Fetch fetches status messages from a mysql host.
-func (m *MetricSet) Fetch() (event common.MapStr, err error) {
+func (m *MetricSet) Fetch() (common.MapStr, error) {
 	if m.db == nil {
 		var err error
 		m.db, err = mysql.NewDB(m.dsn)
@@ -77,7 +77,12 @@ func (m *MetricSet) Fetch() (event common.MapStr, err error) {
 		return nil, err
 	}
 
-	return eventMapping(status), nil
+	event := eventMapping(status)
+
+	if m.Module().Config().Raw {
+		event["raw"] = rawEventMapping(status)
+	}
+	return event, nil
 }
 
 // loadStatus loads all status entries from the given database into an array.

--- a/metricbeat/schema/mapstriface/mapstriface.go
+++ b/metricbeat/schema/mapstriface/mapstriface.go
@@ -85,6 +85,14 @@ func (convMap ConvMap) Map(key string, event common.MapStr, data map[string]inte
 	event[key] = subEvent
 }
 
+func (convMap ConvMap) HasKey(key string) bool {
+	if convMap.Key == key {
+		return true
+	}
+
+	return convMap.Schema.HasKey(key)
+}
+
 func Dict(key string, s schema.Schema, opts ...DictSchemaOption) ConvMap {
 	return dictSetOptions(ConvMap{Key: key, Schema: s}, opts)
 }

--- a/metricbeat/schema/schema_test.go
+++ b/metricbeat/schema/schema_test.go
@@ -37,6 +37,25 @@ func TestSchema(t *testing.T) {
 	})
 }
 
+func TestHasKey(t *testing.T) {
+	schema := Schema{
+		"test": Conv{Key: "Test", Func: nop},
+		"test_obj": Object{
+			"test_a": Conv{Key: "TestA", Func: nop},
+			"test_b": Conv{Key: "TestB", Func: nop},
+		},
+	}
+
+	assert.True(t, schema.HasKey("Test"))
+	assert.True(t, schema.HasKey("TestA"))
+	assert.True(t, schema.HasKey("TestB"))
+	assert.False(t, schema.HasKey("test"))
+	assert.False(t, schema.HasKey("test_obj"))
+	assert.False(t, schema.HasKey("test_a"))
+	assert.False(t, schema.HasKey("test_b"))
+	assert.False(t, schema.HasKey("other"))
+}
+
 func test(key string, opts ...SchemaOption) Conv {
 	return SetOptions(Conv{Key: key, Func: nop}, opts)
 }


### PR DESCRIPTION
This will include all mysql stats into the event under `mysql.stats.raw`. All keys will change to lower case.

Discussions:
* What should be namespace for these fields? `raw`, `extended`
* Should we normalise the keys to lower case?
* Should we replace `_` by `.`?
  * This can cause namespace conflicts if `a_b` and `a_b_c` has a value (happens in mysql)
  * Also we could hit index.mapping.depth.limit (default 20)
* Should this be experimental and available for all metricsets?
* What are we doing about the dynamic filed limit? -> disable it? https://github.com/elastic/elasticsearch/issues/11443 (default 1000)

Potential improvements:
* Remove duplicates which are already part of the event

TODO:
* [ ] Update docs
* [ ] Update changelog