### PR TITLE
Improves Docker Labels handling and output

### DIFF
--- a/metricbeat/module/docker/container/data.go
+++ b/metricbeat/module/docker/container/data.go
@@ -32,7 +32,7 @@ func eventMapping(cont *dc.APIContainers) common.MapStr {
 		"status": cont.Status,
 	}
 
-	labels := docker.BuildLabelArray(cont.Labels)
+	labels := docker.ConvertContainerLabels(cont.Labels)
 	if len(labels) > 0 {
 		event["labels"] = labels
 	}

--- a/metricbeat/module/docker/container/data.go
+++ b/metricbeat/module/docker/container/data.go
@@ -32,7 +32,7 @@ func eventMapping(cont *dc.APIContainers) common.MapStr {
 		"status": cont.Status,
 	}
 
-	labels := docker.ConvertContainerLabels(cont.Labels)
+	labels := docker.DeDotLabels(cont.Labels)
 	if len(labels) > 0 {
 		event["labels"] = labels
 	}

--- a/metricbeat/module/docker/cpu/cpu_test.go
+++ b/metricbeat/module/docker/cpu/cpu_test.go
@@ -169,7 +169,7 @@ func TestCPUService_GetCpuStats(t *testing.T) {
 				"id":     containerID,
 				"name":   "name1",
 				"socket": docker.GetSocket(),
-				"labels": docker.ConvertContainerLabels(labels),
+				"labels": docker.DeDotLabels(labels),
 			},
 		},
 		"usage": common.MapStr{

--- a/metricbeat/module/docker/cpu/cpu_test.go
+++ b/metricbeat/module/docker/cpu/cpu_test.go
@@ -169,7 +169,7 @@ func TestCPUService_GetCpuStats(t *testing.T) {
 				"id":     containerID,
 				"name":   "name1",
 				"socket": docker.GetSocket(),
-				"labels": docker.BuildLabelArray(labels),
+				"labels": docker.ConvertContainerLabels(labels),
 			},
 		},
 		"usage": common.MapStr{

--- a/metricbeat/module/docker/helper.go
+++ b/metricbeat/module/docker/helper.go
@@ -34,7 +34,7 @@ func NewContainer(container *docker.APIContainers) *Container {
 	return &Container{
 		Id:     container.ID,
 		Name:   ExtractContainerName(container.Names),
-		Labels: ConvertContainerLabels(container.Labels),
+		Labels: DeDotLabels(container.Labels),
 	}
 }
 
@@ -51,7 +51,9 @@ func ExtractContainerName(names []string) string {
 	return strings.Trim(output, "/")
 }
 
-func ConvertContainerLabels(labels map[string]string) common.MapStr {
+// DeDotLabels returns a new common.MapStr containing a copy of the labels
+// where the dots in each label name have been changed to an underscore.
+func DeDotLabels(labels map[string]string) common.MapStr {
 
 	outputLabels := common.MapStr{}
 

--- a/metricbeat/module/docker/helper.go
+++ b/metricbeat/module/docker/helper.go
@@ -34,7 +34,7 @@ func NewContainer(container *docker.APIContainers) *Container {
 	return &Container{
 		Id:     container.ID,
 		Name:   ExtractContainerName(container.Names),
-		Labels: BuildLabelArray(container.Labels),
+		Labels: ConvertContainerLabels(container.Labels),
 	}
 }
 
@@ -51,7 +51,7 @@ func ExtractContainerName(names []string) string {
 	return strings.Trim(output, "/")
 }
 
-func BuildLabelArray(labels map[string]string) common.MapStr {
+func ConvertContainerLabels(labels map[string]string) common.MapStr {
 
 	outputLabels := common.MapStr{}
 

--- a/metricbeat/module/docker/helper.go
+++ b/metricbeat/module/docker/helper.go
@@ -1,7 +1,6 @@
 package docker
 
 import (
-	"sort"
 	"strings"
 
 	"github.com/elastic/beats/libbeat/common"
@@ -12,7 +11,7 @@ import (
 type Container struct {
 	Id     string
 	Name   string
-	Labels []common.MapStr
+	Labels common.MapStr
 	Socket *string
 }
 
@@ -52,24 +51,15 @@ func ExtractContainerName(names []string) string {
 	return strings.Trim(output, "/")
 }
 
-func BuildLabelArray(labels map[string]string) []common.MapStr {
+func BuildLabelArray(labels map[string]string) common.MapStr {
 
-	outputLabels := make([]common.MapStr, len(labels))
-	i := 0
-	var keys []string
-	for key := range labels {
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
-	for _, k := range keys {
-		// Replace all . in the labels by _
-		// TODO: WHY?
+	outputLabels := common.MapStr{}
+
+	for k, v := range labels {
+		// This is necessary, so ES does not interpret '.' fields as new nested JSONs, and also makes this compatible with ES 2.4
 		label := strings.Replace(k, ".", "_", -1)
-		outputLabels[i] = common.MapStr{
-			"key":   label,
-			"value": labels[k],
-		}
-		i++
+		outputLabels.Put(label, v)
 	}
+
 	return outputLabels
 }

--- a/metricbeat/module/docker/memory/memory_test.go
+++ b/metricbeat/module/docker/memory/memory_test.go
@@ -46,7 +46,7 @@ func TestMemoryService_GetMemoryStats(t *testing.T) {
 				"id":     containerID,
 				"name":   "name1",
 				"socket": docker.GetSocket(),
-				"labels": docker.BuildLabelArray(labels),
+				"labels": docker.ConvertContainerLabels(labels),
 			},
 		},
 		"fail": common.MapStr{

--- a/metricbeat/module/docker/memory/memory_test.go
+++ b/metricbeat/module/docker/memory/memory_test.go
@@ -46,7 +46,7 @@ func TestMemoryService_GetMemoryStats(t *testing.T) {
 				"id":     containerID,
 				"name":   "name1",
 				"socket": docker.GetSocket(),
-				"labels": docker.ConvertContainerLabels(labels),
+				"labels": docker.DeDotLabels(labels),
 			},
 		},
 		"fail": common.MapStr{


### PR DESCRIPTION
This PR improves Docker Label handling, by not turning it as an array of JSONs, but instead a set of different fields on a map string.

This is useful specially if you're building dashboards with Kibana and wants to filter based on container labels.

This is one of the items of issue #2629 

Hope it helps :smile: 