### PR TITLE
Default docs update for filbeat

### DIFF
--- a/filebeat/docs/overview.asciidoc
+++ b/filebeat/docs/overview.asciidoc
@@ -1,10 +1,8 @@
 [[filebeat-overview]]
 == Overview
 
-Filebeat is a log data shipper initially based on the https://github.com/elastic/logstash-forwarder[Logstash-Forwarder]
-source code. Installed as an agent on your servers, Filebeat monitors the log directories or specific log files, tails the files,
-and forwards them either to https://www.elastic.co/products/logstash[Logstash] for parsing or directly to
-https://www.elastic.co/products/elasticsearch[Elasticsearch] for indexing.
+Filebeat is a log data shipper. Installed as an agent on your servers, Filebeat monitors the log directories or specific log files, tails the files,
+and forwards them either to https://www.elastic.co/products/elasticsearch[Elasticsearch] or https://www.elastic.co/products/logstash[Logstash] for indexing.
 
 Here's how Filebeat works: When you start Filebeat, it starts one or more prospectors that look in the paths you've specified for log files. For each log file that the prospector locates, Filebeat starts a harvester. Each harvester reads a single log file for new content and sends the new log data to the spooler, which aggregates the events and sends the aggregated data to the output that you've configured for Filebeat.
 

--- a/filebeat/docs/reference/configuration/filebeat-options.asciidoc
+++ b/filebeat/docs/reference/configuration/filebeat-options.asciidoc
@@ -233,7 +233,7 @@ WINDOWS:  If your Windows log rotation system shows errors because it can't rota
 
 WARNING: Only use this option if you understand that data loss is a potential side effect.
 
-When this option is enabled, Filebeat closes a file as soon as the end of a file is reached. This is useful when your files are only written once and not updated from time to time. For example, this happens when you are writing every single log event to a new file.
+When this option is enabled, Filebeat closes a file as soon as the end of a file is reached. This is useful when your files are only written once and not updated from time to time. For example, this happens when you are writing every single log event to a new file. This option is disabled by default.
 
 [[close-timeout]]
 ===== close_timeout
@@ -245,6 +245,8 @@ When this option is enabled, Filebeat gives every harvester a predefined lifetim
 When you use `close_timeout` for logs that contain multiline events, the harvester might stop in the middle of a multiline event, which means that only parts of the event will be sent. If the harvester is started again and the file still exists, only the second part of the event will be sent.
 
 The `close_timeout` setting won't apply if your output is stalled and no further events can be sent. At least one event must be sent after `close_timeout` elapses so the harvester can be closed after sending the event.
+
+This option is set to 0 by default which means it is disabled.
 
 
 [[clean-options]]


### PR DESCRIPTION
* Default docs for close_eof and close_timeout added
* Remove note for logstash-forward based code
* Updated output docs as elasticsearch can now also be used for parsing (ingest)