### PR TITLE
Refactor fields handling with readers

### DIFF
--- a/filebeat/harvester/log.go
+++ b/filebeat/harvester/log.go
@@ -132,8 +132,8 @@ func (h *Harvester) Harvest(r reader.Reader) {
 			event.ReadTime = message.Ts
 			event.Bytes = message.Bytes
 			event.Text = &text
-			event.JSONFields = message.Fields
 			event.EventMetadata = h.config.EventMetadata
+			event.Data = message.Fields
 			event.InputType = h.config.InputType
 			event.DocumentType = h.config.DocumentType
 			event.JSONConfig = h.config.JSON

--- a/filebeat/harvester/reader/json.go
+++ b/filebeat/harvester/reader/json.go
@@ -121,7 +121,7 @@ func (r *JSON) Next() (Message, error) {
 		return message, err
 	}
 
-	var fields = common.MapStr{}
+	var fields common.MapStr
 	message.Content, fields = r.decodeJSON(message.Content)
 	message.AddFields(common.MapStr{"json": fields})
 	return message, nil

--- a/filebeat/harvester/reader/json.go
+++ b/filebeat/harvester/reader/json.go
@@ -120,6 +120,9 @@ func (r *JSON) Next() (Message, error) {
 	if err != nil {
 		return message, err
 	}
-	message.Content, message.Fields = r.decodeJSON(message.Content)
+
+	var fields = common.MapStr{}
+	message.Content, fields = r.decodeJSON(message.Content)
+	message.AddFields(common.MapStr{"json": fields})
 	return message, nil
 }

--- a/filebeat/harvester/reader/message.go
+++ b/filebeat/harvester/reader/message.go
@@ -31,3 +31,14 @@ func (m *Message) IsEmpty() bool {
 
 	return false
 }
+
+func (msg *Message) AddFields(fields common.MapStr) {
+	if fields == nil {
+		return
+	}
+
+	if msg.Fields == nil {
+		msg.Fields = common.MapStr{}
+	}
+	msg.Fields.Update(fields)
+}

--- a/filebeat/harvester/reader/multiline.go
+++ b/filebeat/harvester/reader/multiline.go
@@ -211,7 +211,7 @@ func (mlr *Multiline) load(m Message) {
 	mlr.addLine(m)
 	// Timestamp of first message is taken as overall timestamp
 	mlr.message.Ts = m.Ts
-	mlr.message.Fields = m.Fields
+	mlr.message.AddFields(m.Fields)
 }
 
 // clearBuffer resets the reader buffer variables
@@ -265,6 +265,7 @@ func (mlr *Multiline) addLine(m Message) {
 
 	mlr.last = m.Content
 	mlr.message.Bytes += m.Bytes
+	mlr.message.AddFields(m.Fields)
 }
 
 // resetState sets state of the reader to readFirst

--- a/filebeat/input/event.go
+++ b/filebeat/input/event.go
@@ -20,7 +20,7 @@ type Event struct {
 	Text         *string
 	JSONConfig   *reader.JSONConfig
 	State        file.State
-	Data         common.MapStr
+	Data         common.MapStr // Use in readers to add data to the event
 }
 
 func NewEvent(state file.State) *Event {

--- a/filebeat/input/event.go
+++ b/filebeat/input/event.go
@@ -18,9 +18,9 @@ type Event struct {
 	DocumentType string
 	Bytes        int
 	Text         *string
-	JSONFields   common.MapStr
 	JSONConfig   *reader.JSONConfig
 	State        file.State
+	Data         common.MapStr
 }
 
 func NewEvent(state file.State) *Event {
@@ -39,8 +39,19 @@ func (e *Event) ToMapStr() common.MapStr {
 		"input_type":            e.InputType,
 	}
 
-	if e.JSONConfig != nil && len(e.JSONFields) > 0 {
-		mergeJSONFields(e, event)
+	// Add data fields which are added by the readers
+	for key, value := range e.Data {
+		event[key] = value
+	}
+
+	// Check if json fields exist
+	var jsonFields common.MapStr
+	if fields, ok := event["json"]; ok {
+		jsonFields = fields.(common.MapStr)
+	}
+
+	if e.JSONConfig != nil && len(jsonFields) > 0 {
+		mergeJSONFields(e, event, jsonFields)
 	} else if e.Text != nil {
 		event["message"] = *e.Text
 	}
@@ -58,15 +69,18 @@ func (e *Event) HasData() bool {
 // respecting the KeysUnderRoot and OverwriteKeys configuration options.
 // If MessageKey is defined, the Text value from the event always
 // takes precedence.
-func mergeJSONFields(e *Event, event common.MapStr) {
+func mergeJSONFields(e *Event, event common.MapStr, jsonFields common.MapStr) {
 
 	// The message key might have been modified by multiline
 	if len(e.JSONConfig.MessageKey) > 0 && e.Text != nil {
-		e.JSONFields[e.JSONConfig.MessageKey] = *e.Text
+		jsonFields[e.JSONConfig.MessageKey] = *e.Text
 	}
 
 	if e.JSONConfig.KeysUnderRoot {
-		for k, v := range e.JSONFields {
+		// Delete existing json key
+		delete(event, "json")
+
+		for k, v := range jsonFields {
 			if e.JSONConfig.OverwriteKeys {
 				if k == "@timestamp" {
 					vstr, ok := v.(string)
@@ -104,7 +118,5 @@ func mergeJSONFields(e *Event, event common.MapStr) {
 				event[k] = v
 			}
 		}
-	} else {
-		event["json"] = e.JSONFields
 	}
 }

--- a/filebeat/input/event_test.go
+++ b/filebeat/input/event_test.go
@@ -33,7 +33,7 @@ func TestEventToMapStrJSON(t *testing.T) {
 			Event: Event{
 				DocumentType: "test_type",
 				Text:         &text,
-				JSONFields:   common.MapStr{"type": "test", "text": "hello"},
+				Data:         common.MapStr{"json": common.MapStr{"type": "test", "text": "hello"}},
 				JSONConfig:   &reader.JSONConfig{KeysUnderRoot: true},
 			},
 			ExpectedItems: common.MapStr{
@@ -46,7 +46,7 @@ func TestEventToMapStrJSON(t *testing.T) {
 			Event: Event{
 				DocumentType: "test_type",
 				Text:         &text,
-				JSONFields:   common.MapStr{"type": "test", "text": "hello"},
+				Data:         common.MapStr{"json": common.MapStr{"type": "test", "text": "hello"}},
 				JSONConfig:   &reader.JSONConfig{KeysUnderRoot: true, OverwriteKeys: true},
 			},
 			ExpectedItems: common.MapStr{
@@ -59,7 +59,7 @@ func TestEventToMapStrJSON(t *testing.T) {
 			Event: Event{
 				DocumentType: "test_type",
 				Text:         &text,
-				JSONFields:   common.MapStr{"type": "test", "text": "hello"},
+				Data:         common.MapStr{"json": common.MapStr{"type": "test", "text": "hello"}},
 				JSONConfig:   &reader.JSONConfig{},
 			},
 			ExpectedItems: common.MapStr{
@@ -72,7 +72,7 @@ func TestEventToMapStrJSON(t *testing.T) {
 			Event: Event{
 				DocumentType: "test_type",
 				Text:         &text,
-				JSONFields:   common.MapStr{"type": "test", "text": "hi"},
+				Data:         common.MapStr{"json": common.MapStr{"type": "test", "text": "hi"}},
 				JSONConfig:   &reader.JSONConfig{MessageKey: "text"},
 			},
 			ExpectedItems: common.MapStr{
@@ -87,7 +87,7 @@ func TestEventToMapStrJSON(t *testing.T) {
 				ReadTime:     now,
 				DocumentType: "test_type",
 				Text:         &text,
-				JSONFields:   common.MapStr{"type": "test", "@timestamp": "2016-04-05T18:47:18.444Z"},
+				Data:         common.MapStr{"json": common.MapStr{"type": "test", "@timestamp": "2016-04-05T18:47:18.444Z"}},
 				JSONConfig:   &reader.JSONConfig{KeysUnderRoot: true, OverwriteKeys: true},
 			},
 			ExpectedItems: common.MapStr{
@@ -102,7 +102,7 @@ func TestEventToMapStrJSON(t *testing.T) {
 				ReadTime:     now,
 				DocumentType: "test_type",
 				Text:         &text,
-				JSONFields:   common.MapStr{"type": "test", "@timestamp": "2016-04-05T18:47:18.44XX4Z"},
+				Data:         common.MapStr{"json": common.MapStr{"type": "test", "@timestamp": "2016-04-05T18:47:18.44XX4Z"}},
 				JSONConfig:   &reader.JSONConfig{KeysUnderRoot: true, OverwriteKeys: true},
 			},
 			ExpectedItems: common.MapStr{
@@ -118,7 +118,7 @@ func TestEventToMapStrJSON(t *testing.T) {
 				ReadTime:     now,
 				DocumentType: "test_type",
 				Text:         &text,
-				JSONFields:   common.MapStr{"type": "test", "@timestamp": 42},
+				Data:         common.MapStr{"json": common.MapStr{"type": "test", "@timestamp": 42}},
 				JSONConfig:   &reader.JSONConfig{KeysUnderRoot: true, OverwriteKeys: true},
 			},
 			ExpectedItems: common.MapStr{
@@ -132,7 +132,7 @@ func TestEventToMapStrJSON(t *testing.T) {
 			Event: Event{
 				DocumentType: "test_type",
 				Text:         &text,
-				JSONFields:   common.MapStr{"type": 42},
+				Data:         common.MapStr{"json": common.MapStr{"type": 42}},
 				JSONConfig:   &reader.JSONConfig{KeysUnderRoot: true, OverwriteKeys: true},
 			},
 			ExpectedItems: common.MapStr{
@@ -145,7 +145,7 @@ func TestEventToMapStrJSON(t *testing.T) {
 			Event: Event{
 				DocumentType: "test_type",
 				Text:         &text,
-				JSONFields:   common.MapStr{"type": ""},
+				Data:         common.MapStr{"json": common.MapStr{"type": ""}},
 				JSONConfig:   &reader.JSONConfig{KeysUnderRoot: true, OverwriteKeys: true},
 			},
 			ExpectedItems: common.MapStr{
@@ -158,7 +158,7 @@ func TestEventToMapStrJSON(t *testing.T) {
 			Event: Event{
 				DocumentType: "test_type",
 				Text:         &text,
-				JSONFields:   common.MapStr{"type": "_type"},
+				Data:         common.MapStr{"json": common.MapStr{"type": "_type"}},
 				JSONConfig:   &reader.JSONConfig{KeysUnderRoot: true, OverwriteKeys: true},
 			},
 			ExpectedItems: common.MapStr{

--- a/libbeat/common/mapstr.go
+++ b/libbeat/common/mapstr.go
@@ -148,7 +148,7 @@ func MapStrUnion(dict1 MapStr, dict2 MapStr) MapStr {
 // An error is returned if underRoot is true and the value of ms.fields is not a
 // MapStr.
 func MergeFields(ms, fields MapStr, underRoot bool) error {
-	if ms == nil || fields == nil {
+	if ms == nil || len(fields) == 0 {
 		return nil
 	}
 


### PR DESCRIPTION
Each reader can add fields to the message object. The reader itself should always add data under its own namespace to prevent conflicts. All these fields are then added to the Data object. This will allow each reader in the future to add its own data if needed.

The JSON reader was simplified in the way that data by default is written under the `json` namespace. Now no special fields have to be passed for JSON and the processing can still happen on the event level.

No functional changes were made in this PR.

This PR was extracted from https://github.com/elastic/beats/pull/2279