### PR TITLE
Remove ports data from docker/container metricset

### DIFF
--- a/metricbeat/module/docker/container/_meta/data.json
+++ b/metricbeat/module/docker/container/_meta/data.json
@@ -2,60 +2,23 @@
     "@timestamp": "2016-05-23T08:05:34.853Z",
     "docker": {
         "container": {
-            "command": "/entrypoint.sh /bin/sh -c 'logstash -f /logstash.conf --log.level=debug --config.debug'",
-            "created": "2016-10-05T13:33:37.000Z",
-            "id": "7e29f4a1b2c0dd13af7c725d8deb342a36ed170eac977c183da70ef266513202",
-            "image": "environments_logstash",
-            "labels": [
-                {
-                    "key": "com_docker_compose_config-hash",
-                    "value": "62a912f01b02c0673332badedfcb092977d8dba2ca1115448a2674218ae1af5a"
-                },
-                {
-                    "key": "com_docker_compose_container-number",
-                    "value": "1"
-                },
-                {
-                    "key": "com_docker_compose_oneoff",
-                    "value": "False"
-                },
-                {
-                    "key": "com_docker_compose_project",
-                    "value": "environments"
-                },
-                {
-                    "key": "com_docker_compose_service",
-                    "value": "logstash"
-                },
-                {
-                    "key": "com_docker_compose_version",
-                    "value": "1.8.1"
-                }
-            ],
-            "name": "logstash",
-            "ports": [
-                {
-                    "ip": "",
-                    "port": {
-                        "private": 5055,
-                        "public": 0
-                    },
-                    "type": "tcp"
-                },
-                {
-                    "ip": "",
-                    "port": {
-                        "private": 5044,
-                        "public": 0
-                    },
-                    "type": "tcp"
-                }
-            ],
+            "command": "bash",
+            "created": "2016-11-21T12:39:48.000Z",
+            "id": "4be260de8fc1212c9ff58789b8221e70c53f5af5d5a3915ff7de4b81b357d851",
+            "image": "environments_beat",
+            "labels": {
+                "com_docker_compose_container-number": "1",
+                "com_docker_compose_oneoff": "True",
+                "com_docker_compose_project": "environments",
+                "com_docker_compose_service": "beat",
+                "com_docker_compose_version": "1.9.0-rc4"
+            },
+            "name": "environments_beat_run_1",
             "size": {
                 "root_fs": 0,
                 "rw": 0
             },
-            "status": "Up 21 minutes"
+            "status": "Up 15 minutes"
         }
     },
     "metricset": {

--- a/metricbeat/module/docker/container/_meta/fields.yml
+++ b/metricbeat/module/docker/container/_meta/fields.yml
@@ -1,4 +1,3 @@
-# TODO: Currently ports and labels are not added to the template yet
 - name: container
   type: group
   description: >

--- a/metricbeat/module/docker/container/data.go
+++ b/metricbeat/module/docker/container/data.go
@@ -37,27 +37,5 @@ func eventMapping(cont *dc.APIContainers) common.MapStr {
 		event["labels"] = labels
 	}
 
-	ports := convertContainerPorts(cont.Ports)
-	if len(ports) > 0 {
-		event["ports"] = ports
-	}
-
 	return event
-}
-
-func convertContainerPorts(ports []dc.APIPort) []map[string]interface{} {
-	var outputPorts = []map[string]interface{}{}
-	for _, port := range ports {
-		outputPort := common.MapStr{
-			"ip": port.IP,
-			"port": common.MapStr{
-				"private": port.PrivatePort,
-				"public":  port.PublicPort,
-			},
-			"type": port.Type,
-		}
-		outputPorts = append(outputPorts, outputPort)
-	}
-
-	return outputPorts
 }

--- a/metricbeat/tests/system/test_docker.py
+++ b/metricbeat/tests/system/test_docker.py
@@ -29,7 +29,7 @@ class Test(metricbeat.BaseTest):
         output = self.read_output_json()
         evt = output[0]
 
-        evt = self.remove_labels_and_ports(evt)
+        evt = self.remove_labels(evt)
         self.assert_fields_are_documented(evt)
 
     @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
@@ -55,7 +55,7 @@ class Test(metricbeat.BaseTest):
         output = self.read_output_json()
         evt = output[0]
 
-        evt = self.remove_labels_and_ports(evt)
+        evt = self.remove_labels(evt)
 
         if 'per_cpu' in evt["docker"]["cpu"]["usage"]:
             del evt["docker"]["cpu"]["usage"]["per_cpu"]
@@ -85,7 +85,7 @@ class Test(metricbeat.BaseTest):
         output = self.read_output_json()
         evt = output[0]
 
-        evt = self.remove_labels_and_ports(evt)
+        evt = self.remove_labels(evt)
 
         self.assert_fields_are_documented(evt)
 
@@ -137,7 +137,7 @@ class Test(metricbeat.BaseTest):
         output = self.read_output_json()
         evt = output[0]
 
-        evt = self.remove_labels_and_ports(evt)
+        evt = self.remove_labels(evt)
         self.assert_fields_are_documented(evt)
 
     @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
@@ -163,14 +163,12 @@ class Test(metricbeat.BaseTest):
         output = self.read_output_json()
         evt = output[0]
 
-        evt = self.remove_labels_and_ports(evt)
+        evt = self.remove_labels(evt)
         self.assert_fields_are_documented(evt)
 
-    def remove_labels_and_ports(self, evt):
+    def remove_labels(self, evt):
 
         if 'labels' in evt["docker"]["container"]:
             del evt["docker"]["container"]["labels"]
-        if 'ports' in evt["docker"]["container"]:
-            del evt["docker"]["container"]["ports"]
 
         return evt


### PR DESCRIPTION
The current use case for ports is not clear. We will re-add ports if it gets requested. See discussion here: https://github.com/elastic/beats/issues/2629#issuecomment-261494953