### PR TITLE
Show download link to dashboards

### DIFF
--- a/libbeat/docs/index.asciidoc
+++ b/libbeat/docs/index.asciidoc
@@ -12,6 +12,7 @@ include::./version.asciidoc[]
 :ES-version: {stack-version}
 :LS-version: {stack-version}
 :Kibana-version: {stack-version}
+:dashboards: https://artifacts.elastic.co/downloads/beats/beats-dashboards/beats-dashboards-{stack-version}.zip
 
 include::./overview.asciidoc[]
 

--- a/libbeat/docs/newdashboards.asciidoc
+++ b/libbeat/docs/newdashboards.asciidoc
@@ -59,7 +59,7 @@ Elasticsearch running on localhost for a single Beat (eg. Metricbeat):
 ./scripts/import_dashboards -file metricbeat-dashboards-1.1.zip
 ----------------------------------------------------------------------
 
-- from the official zip archive available under http://artifacts.elastic.co/:
+- from the official zip archive available at {dashboards}:
 +
 [source,shell]
 ----------------------------------------------------------------------


### PR DESCRIPTION
Documenting the download URL for the official beats dashboards to fix issue #3037 

I'm using a variable so we'll remember to update the docs if the URL changes.
