### PR TITLE
Remove redundant logging in Metricbeat

### DIFF
--- a/metricbeat/mb/builders.go
+++ b/metricbeat/mb/builders.go
@@ -137,7 +137,8 @@ func initMetricSets(r *Register, modules []Module) (map[Module][]MetricSet, erro
 		if hostParser != nil {
 			bms.hostData, err = hostParser(bms.Module(), bms.host)
 			if err != nil {
-				errs = append(errs, err)
+				errs = append(errs, errors.Wrapf(err, "host parsing failed for %v-%v",
+					bms.Module().Name(), bms.Name()))
 				continue
 			}
 			bms.host = bms.hostData.Host

--- a/metricbeat/module/apache/status/status.go
+++ b/metricbeat/module/apache/status/status.go
@@ -50,7 +50,6 @@ type MetricSet struct {
 
 // New creates new instance of MetricSet.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	debugf("apache-status URL=%s", base.HostData().SanitizedURI)
 	return &MetricSet{
 		BaseMetricSet: base,
 		client:        &http.Client{Timeout: base.Module().Config().Timeout},
@@ -60,7 +59,10 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // Fetch makes an HTTP request to fetch status metrics from the mod_status
 // endpoint.
 func (m *MetricSet) Fetch() (common.MapStr, error) {
-	req, err := http.NewRequest("GET", m.HostData().URI, nil)
+	req, err := http.NewRequest("GET", m.HostData().SanitizedURI, nil)
+	if m.HostData().User != "" || m.HostData().Password != "" {
+		req.SetBasicAuth(m.HostData().User, m.HostData().Password)
+	}
 	resp, err := m.client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("error making http request: %v", err)

--- a/metricbeat/module/haproxy/info/info.go
+++ b/metricbeat/module/haproxy/info/info.go
@@ -38,7 +38,9 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 
 // Fetch fetches info stats from the haproxy service.
 func (m *MetricSet) Fetch() (common.MapStr, error) {
-	hapc, err := haproxy.NewHaproxyClient(m.HostData().URI)
+	// haproxy doesn't accept a username or password so ignore them if they
+	// are in the URL.
+	hapc, err := haproxy.NewHaproxyClient(m.HostData().SanitizedURI)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed creating haproxy client")
 	}

--- a/metricbeat/module/haproxy/stat/stat.go
+++ b/metricbeat/module/haproxy/stat/stat.go
@@ -38,7 +38,9 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 
 // Fetch methods returns a list of stats metrics.
 func (m *MetricSet) Fetch() ([]common.MapStr, error) {
-	hapc, err := haproxy.NewHaproxyClient(m.HostData().URI)
+	// haproxy doesn't accept a username or password so ignore them if they
+	// are in the URL.
+	hapc, err := haproxy.NewHaproxyClient(m.HostData().SanitizedURI)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed creating haproxy client")
 	}
@@ -49,5 +51,4 @@ func (m *MetricSet) Fetch() ([]common.MapStr, error) {
 	}
 
 	return eventMapping(res), nil
-
 }

--- a/metricbeat/module/mongodb/mongodb.go
+++ b/metricbeat/module/mongodb/mongodb.go
@@ -12,7 +12,7 @@ import (
 )
 
 func init() {
-	// Register the ModuleFactory function for the "mysql" module.
+	// Register the ModuleFactory function for the "mongodb" module.
 	if err := mb.Registry.AddModule("mongodb", NewModule); err != nil {
 		panic(err)
 	}

--- a/metricbeat/module/mongodb/status/status.go
+++ b/metricbeat/module/mongodb/status/status.go
@@ -37,7 +37,6 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	}
 	dialInfo.Timeout = base.Module().Config().Timeout
 
-	debugf("mongodb-status url=%v", base.HostData().SanitizedURI)
 	return &MetricSet{
 		BaseMetricSet: base,
 		dialInfo:      dialInfo,

--- a/metricbeat/module/mysql/status/status.go
+++ b/metricbeat/module/mysql/status/status.go
@@ -35,7 +35,6 @@ type MetricSet struct {
 
 // New creates and returns a new MetricSet instance.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	debugf("mysql-status dsn=%v", base.HostData().SanitizedURI)
 	return &MetricSet{BaseMetricSet: base}, nil
 }
 

--- a/metricbeat/module/nginx/stubstatus/stubstatus.go
+++ b/metricbeat/module/nginx/stubstatus/stubstatus.go
@@ -45,7 +45,6 @@ type MetricSet struct {
 
 // New creates new instance of MetricSet
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	debugf("nginx-stubstatus URL=%s", base.HostData().SanitizedURI)
 	return &MetricSet{
 		BaseMetricSet: base,
 		client:        &http.Client{Timeout: base.Module().Config().Timeout},
@@ -54,7 +53,10 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 
 // Fetch makes an HTTP request to fetch status metrics from the stubstatus endpoint.
 func (m *MetricSet) Fetch() (common.MapStr, error) {
-	req, err := http.NewRequest("GET", m.HostData().URI, nil)
+	req, err := http.NewRequest("GET", m.HostData().SanitizedURI, nil)
+	if m.HostData().User != "" || m.HostData().Password != "" {
+		req.SetBasicAuth(m.HostData().User, m.HostData().Password)
+	}
 	resp, err := m.client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("error making http request: %v", err)


### PR DESCRIPTION
The individual MetricSets don’t need to log the host information on initialization because the Metricbeat core does this when it initializes the MetricSets.