### PR TITLE
Fix processor actions that incorrectly always return an error

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -33,6 +33,7 @@ https://github.com/elastic/beats/compare/v5.0.1...master[Check the HEAD diff]
 ==== Bugfixes
 
 *Affecting all Beats*
+- Fix empty benign errors logged by processor actions. {pull}3046[3046]
 
 *Metricbeat*
 

--- a/libbeat/processors/actions/decode_json_fields.go
+++ b/libbeat/processors/actions/decode_json_fields.go
@@ -84,7 +84,10 @@ func (f decodeJSONFields) Run(event common.MapStr) (common.MapStr, error) {
 		}
 	}
 
-	return event, fmt.Errorf(strings.Join(errs, ", "))
+	if len(errs) > 0 {
+		return event, fmt.Errorf(strings.Join(errs, ", "))
+	}
+	return event, nil
 }
 
 func unmarshal(maxDepth int, text []byte, fields *interface{}, processArray bool) error {

--- a/libbeat/processors/actions/drop_fields.go
+++ b/libbeat/processors/actions/drop_fields.go
@@ -42,7 +42,7 @@ func newDropFields(c common.Config) (processors.Processor, error) {
 }
 
 func (f dropFields) Run(event common.MapStr) (common.MapStr, error) {
-	errors := []string{}
+	var errors []string
 
 	for _, field := range f.Fields {
 		err := event.Delete(field)
@@ -51,7 +51,11 @@ func (f dropFields) Run(event common.MapStr) (common.MapStr, error) {
 		}
 
 	}
-	return event, fmt.Errorf(strings.Join(errors, ", "))
+
+	if len(errors) > 0 {
+		return event, fmt.Errorf(strings.Join(errors, ", "))
+	}
+	return event, nil
 }
 
 func (f dropFields) String() string {

--- a/libbeat/processors/actions/include_fields.go
+++ b/libbeat/processors/actions/include_fields.go
@@ -48,7 +48,7 @@ func newIncludeFields(c common.Config) (processors.Processor, error) {
 
 func (f includeFields) Run(event common.MapStr) (common.MapStr, error) {
 	filtered := common.MapStr{}
-	errs := []string{}
+	var errs []string
 
 	for _, field := range f.Fields {
 		err := event.CopyFieldsTo(filtered, field)
@@ -58,7 +58,10 @@ func (f includeFields) Run(event common.MapStr) (common.MapStr, error) {
 		}
 	}
 
-	return filtered, fmt.Errorf(strings.Join(errs, ", "))
+	if len(errs) > 0 {
+		return filtered, fmt.Errorf(strings.Join(errs, ", "))
+	}
+	return filtered, nil
 }
 
 func (f includeFields) String() string {

--- a/libbeat/processors/processor.go
+++ b/libbeat/processors/processor.go
@@ -75,10 +75,8 @@ func (procs *Processors) Run(event common.MapStr) common.MapStr {
 }
 
 func (procs Processors) String() string {
-	s := []string{}
-
+	var s []string
 	for _, p := range procs.list {
-
 		s = append(s, p.String())
 	}
 	return strings.Join(s, ", ")


### PR DESCRIPTION
Even when no error occurs during the action, a new empty error was being returned causing an error to be logged.