### PR TITLE
Fix metricbeat service times-out at startup

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -38,6 +38,7 @@ https://github.com/elastic/beats/compare/v5.0.1...master[Check the HEAD diff]
 *Metricbeat*
 
 - Calculate the fsstat values per mounting point, and not filesystem. {pull}2777[2777]
+- Fix service times-out at startup. {pull}3056[3056]
 
 *Packetbeat*
 

--- a/metricbeat/module/system/process/helper.go
+++ b/metricbeat/module/system/process/helper.go
@@ -260,25 +260,6 @@ func (procStats *ProcStats) InitProcStats() error {
 		procStats.regexps = append(procStats.regexps, reg)
 	}
 
-	pids, err := Pids()
-	if err != nil {
-		logp.Warn("Getting the initial list of pids: %v", err)
-	}
-
-	for _, pid := range pids {
-		process, err := newProcess(pid)
-		if err != nil {
-			logp.Debug("metricbeat", "Skip process pid=%d: %v", pid, err)
-			continue
-		}
-		err = process.getDetails("")
-		if err != nil {
-			logp.Err("Error getting process details pid=%d: %v", pid, err)
-			continue
-		}
-		procStats.ProcsMap[process.Pid] = process
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
Fixes #3018

This PR remove the inital collecting of processes at service start up. Instead waiting for the first fetch after the service is started.