### PR TITLE
Backport: Rewrite elasticsearch connection URL (#3058)

### DIFF
--- a/libbeat/outputs/elasticsearch/client.go
+++ b/libbeat/outputs/elasticsearch/client.go
@@ -142,6 +142,19 @@ func NewClient(
 		}
 	}
 
+	u, err := url.Parse(s.URL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse elasticsearch URL: %v", err)
+	}
+	if u.User != nil {
+		s.Username = u.User.Username()
+		s.Password, _ = u.User.Password()
+		u.User = nil
+
+		// Re-write URL without credentials.
+		s.URL = u.String()
+	}
+
 	client := &Client{
 		Connection: Connection{
 			URL:      s.URL,


### PR DESCRIPTION
Backport of #3058 to 5.1.

(cherry picked from commit 270736980e7ebd591da9835546deaf18e3a87709)