### PR TITLE
Fix: HTTP Request headers with split_cookies enabled

### DIFF
--- a/packetbeat/protos/http/http.go
+++ b/packetbeat/protos/http/http.go
@@ -542,10 +542,8 @@ func (http *httpPlugin) collectHeaders(m *message) interface{} {
 			if strings.ToLower(name) == "content-length" {
 				continue
 			}
-			if http.splitCookie {
-				if name == cookie {
-					hdrs[name] = splitCookiesHeader(string(value))
-				}
+			if http.splitCookie && name == cookie {
+				hdrs[name] = splitCookiesHeader(string(value))
 			} else {
 				hdrs[name] = value
 			}


### PR DESCRIPTION
When split_cookies is enabled the request headers are missing. Just "cookie" header is shown. 
Before fix, split_cookies disabled:

```
"request" : {
	"headers" : {
		"accept" : "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
		"accept-encoding" : "gzip, deflate",
		"accept-language" : "es-ES,es;q=0.8,en-US;q=0.5,en;q=0.3",
		"cache-control" : "no-cache",
		"connection" : "keep-alive",
		"content-length" : 0,
		"cookie" : {
			"_ga" : "GA1.2.1508934816.1463591013",
		},
		"host" : "myhost.host.es",
		"pragma" : "no-cache",
		"user-agent" : "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:30.0) Gecko/20100101 Firefox/30.0"
	},
	"params" : ""
},
```

Split Cookies enabled

```
"request" : {
	"headers" : {
		"content-length" : 0,
		"cookie" : {
			"_ga" : "GA1.2.1508934816.1463591013"
		}
	},
	"params" : ""
},
```