### PR TITLE
configurable heartbeat defaults values

### DIFF
--- a/heartbeat/_meta/beat.yml
+++ b/heartbeat/_meta/beat.yml
@@ -182,6 +182,23 @@ heartbeat.monitors:
     # Required response contents.
     #body:
 
+# Configure monitors default settings shared by all monitors.
+heartbeat.defaults.monitors:
+  # Enable/Disable monitor
+  #enabled: true
+
+  # Configure default task scheduler
+  #schedule: '@every 30s'
+
+  # Configure IP protocol types to ping on if hostnames are configured.
+  # Ping all resolvable IPs if `mode` is `all`, or only one IP if `mode` is `any`.
+  #ipv4: true
+  #ipv6: true
+  #mode: all
+
+  # Total running time per ping test.
+  #timeout: 16s
+
 heartbeat.scheduler:
   # Limit number of concurrent tasks executed by heartbeat. The task limit if
   # disabled if set to 0. The default is 0.

--- a/heartbeat/beater/heartbeat.go
+++ b/heartbeat/beater/heartbeat.go
@@ -38,9 +38,14 @@ func New(b *beat.Beat, cfg *common.Config) (beat.Beater, error) {
 		return nil, err
 	}
 
+	var defaults *common.Config
+	if config.Defaults != nil {
+		defaults = config.Defaults["monitors"]
+	}
+
 	client := b.Publisher.Connect()
 	sched := scheduler.NewWithLocation(limit, location)
-	manager, err := newMonitorManager(client, sched, monitors.Registry, config.Monitors)
+	manager, err := newMonitorManager(client, sched, monitors.Registry, defaults, config.Monitors)
 	if err != nil {
 		return nil, err
 	}

--- a/heartbeat/config/config.go
+++ b/heartbeat/config/config.go
@@ -7,8 +7,9 @@ import "github.com/elastic/beats/libbeat/common"
 
 type Config struct {
 	// Modules is a list of module specific configuration data.
-	Monitors  []*common.Config `config:"monitors"         validate:"required"`
-	Scheduler Scheduler        `config:"scheduler"`
+	Monitors  []*common.Config          `config:"monitors"         validate:"required"`
+	Scheduler Scheduler                 `config:"scheduler"`
+	Defaults  map[string]*common.Config `config:"defaults"`
 }
 
 type Scheduler struct {

--- a/heartbeat/heartbeat.full.yml
+++ b/heartbeat/heartbeat.full.yml
@@ -182,6 +182,23 @@ heartbeat.monitors:
     # Required response contents.
     #body:
 
+# Configure monitors default settings shared by all monitors.
+heartbeat.defaults.monitors:
+  # Enable/Disable monitor
+  #enabled: true
+
+  # Configure default task scheduler
+  #schedule: '@every 30s'
+
+  # Configure IP protocol types to ping on if hostnames are configured.
+  # Ping all resolvable IPs if `mode` is `all`, or only one IP if `mode` is `any`.
+  #ipv4: true
+  #ipv6: true
+  #mode: all
+
+  # Total running time per ping test.
+  #timeout: 16s
+
 heartbeat.scheduler:
   # Limit number of concurrent tasks executed by heartbeat. The task limit if
   # disabled if set to 0. The default is 0.

--- a/heartbeat/heartbeat.yml
+++ b/heartbeat/heartbeat.yml
@@ -182,6 +182,23 @@ heartbeat.monitors:
     # Required response contents.
     #body:
 
+# Configure monitors default settings shared by all monitors.
+heartbeat.defaults.monitors:
+  # Enable/Disable monitor
+  #enabled: true
+
+  # Configure default task scheduler
+  #schedule: '@every 30s'
+
+  # Configure IP protocol types to ping on if hostnames are configured.
+  # Ping all resolvable IPs if `mode` is `all`, or only one IP if `mode` is `any`.
+  #ipv4: true
+  #ipv6: true
+  #mode: all
+
+  # Total running time per ping test.
+  #timeout: 16s
+
 heartbeat.scheduler:
   # Limit number of concurrent tasks executed by heartbeat. The task limit if
   # disabled if set to 0. The default is 0.


### PR DESCRIPTION
Introduce configurable heartbeat default settings for monitors. Add default values to `heartbeat.defaults.monitors` section. This helps with sharing common settings like DNS-client or service discovery settings.