### PR TITLE
Backport: Parse elasticsearch URL before logging it (#3075)

### DIFF
--- a/libbeat/outputs/elasticsearch/client.go
+++ b/libbeat/outputs/elasticsearch/client.go
@@ -104,11 +104,23 @@ func NewClient(
 		pipeline = nil
 	}
 
+	u, err := url.Parse(s.URL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse elasticsearch URL: %v", err)
+	}
+	if u.User != nil {
+		s.Username = u.User.Username()
+		s.Password, _ = u.User.Password()
+		u.User = nil
+
+		// Re-write URL without credentials.
+		s.URL = u.String()
+	}
+
 	logp.Info("Elasticsearch url: %s", s.URL)
 
 	// TODO: add socks5 proxy support
 	var dialer, tlsDialer transport.Dialer
-	var err error
 
 	dialer = transport.NetDialer(s.Timeout)
 	tlsDialer, err = transport.TLSDialer(dialer, s.TLS, s.Timeout)
@@ -140,19 +152,6 @@ func NewClient(
 		if err != nil {
 			return nil, err
 		}
-	}
-
-	u, err := url.Parse(s.URL)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse elasticsearch URL: %v", err)
-	}
-	if u.User != nil {
-		s.Username = u.User.Username()
-		s.Password, _ = u.User.Password()
-		u.User = nil
-
-		// Re-write URL without credentials.
-		s.URL = u.String()
 	}
 
 	client := &Client{


### PR DESCRIPTION
Backport #3075 to 5.1

(cherry picked from commit 4d2f01a7b423b9ad13d8ac1b4a9a02ade932a661)