### PR TITLE
Pass `--always-copy` to virtualenv

### DIFF
--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -179,7 +179,7 @@ load-tests:
 # Sets up the virtual python environment
 .PHONY: python-env
 python-env: ${ES_BEATS}/libbeat/tests/system/requirements.txt
-	@test -d ${PYTHON_ENV} || virtualenv ${PYTHON_ENV}
+	@test -d ${PYTHON_ENV} || virtualenv --always-copy ${PYTHON_ENV}
 	@. ${PYTHON_ENV}/bin/activate && pip install -q --upgrade pip ; \
 	if [ -a ./tests/system/requirements.txt ] && [ ! ${ES_BEATS}/libbeat/tests/system/requirements.txt -ef ./tests/system/requirements.txt ] ; then \
 		. ${PYTHON_ENV}/bin/activate && pip install -qUr ${ES_BEATS}/libbeat/tests/system/requirements.txt -Ur ./tests/system/requirements.txt ; \


### PR DESCRIPTION
virtualenv creates symlinks so `make setup` fails when ran on a network mounted
fs. `--always-copy` forces virtualenv to copy files to the destination dir rather than symlinking.