### PR TITLE
Bump version to 5.1.1

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -8,7 +8,7 @@
 // Template, add newest changes here
 
 === Beats version HEAD
-https://github.com/elastic/beats/compare/v5.1.0...5.1[Check the HEAD diff]
+https://github.com/elastic/beats/compare/v5.1.1...5.1[Check the HEAD diff]
 
 ==== Breaking changes
 
@@ -61,9 +61,9 @@ https://github.com/elastic/beats/compare/v5.1.0...5.1[Check the HEAD diff]
 
 ////////////////////////////////////////////////////////////
 
-[[release-notes-5.1.0]]
-=== Beats version 5.1.0
-https://github.com/elastic/beats/compare/v5.0.2...v5.1.0[View commits]
+[[release-notes-5.1.1]]
+=== Beats version 5.1.1
+https://github.com/elastic/beats/compare/v5.0.2...v5.1.1[View commits]
 
 ==== Breaking changes
 

--- a/dev-tools/packer/version.yml
+++ b/dev-tools/packer/version.yml
@@ -1,1 +1,1 @@
-version: "5.1.0"
+version: "5.1.1"

--- a/filebeat/filebeat.template-es2x.json
+++ b/filebeat/filebeat.template-es2x.json
@@ -7,7 +7,7 @@
         }
       },
       "_meta": {
-        "version": "5.1.0"
+        "version": "5.1.1"
       },
       "dynamic_templates": [
         {

--- a/filebeat/filebeat.template.json
+++ b/filebeat/filebeat.template.json
@@ -5,7 +5,7 @@
         "norms": false
       },
       "_meta": {
-        "version": "5.1.0"
+        "version": "5.1.1"
       },
       "dynamic_templates": [
         {

--- a/heartbeat/heartbeat.template-es2x.json
+++ b/heartbeat/heartbeat.template-es2x.json
@@ -7,7 +7,7 @@
         }
       },
       "_meta": {
-        "version": "5.1.0"
+        "version": "5.1.1"
       },
       "dynamic_templates": [
         {

--- a/heartbeat/heartbeat.template.json
+++ b/heartbeat/heartbeat.template.json
@@ -5,7 +5,7 @@
         "norms": false
       },
       "_meta": {
-        "version": "5.1.0"
+        "version": "5.1.1"
       },
       "dynamic_templates": [
         {

--- a/libbeat/beat/version.go
+++ b/libbeat/beat/version.go
@@ -1,3 +1,3 @@
 package beat
 
-const defaultBeatVersion = "5.1.0"
+const defaultBeatVersion = "5.1.1"

--- a/metricbeat/metricbeat.template-es2x.json
+++ b/metricbeat/metricbeat.template-es2x.json
@@ -7,7 +7,7 @@
         }
       },
       "_meta": {
-        "version": "5.1.0"
+        "version": "5.1.1"
       },
       "dynamic_templates": [
         {

--- a/metricbeat/metricbeat.template.json
+++ b/metricbeat/metricbeat.template.json
@@ -5,7 +5,7 @@
         "norms": false
       },
       "_meta": {
-        "version": "5.1.0"
+        "version": "5.1.1"
       },
       "dynamic_templates": [
         {

--- a/packetbeat/packetbeat.template-es2x.json
+++ b/packetbeat/packetbeat.template-es2x.json
@@ -7,7 +7,7 @@
         }
       },
       "_meta": {
-        "version": "5.1.0"
+        "version": "5.1.1"
       },
       "dynamic_templates": [
         {

--- a/packetbeat/packetbeat.template.json
+++ b/packetbeat/packetbeat.template.json
@@ -5,7 +5,7 @@
         "norms": false
       },
       "_meta": {
-        "version": "5.1.0"
+        "version": "5.1.1"
       },
       "dynamic_templates": [
         {

--- a/winlogbeat/winlogbeat.template-es2x.json
+++ b/winlogbeat/winlogbeat.template-es2x.json
@@ -7,7 +7,7 @@
         }
       },
       "_meta": {
-        "version": "5.1.0"
+        "version": "5.1.1"
       },
       "dynamic_templates": [
         {

--- a/winlogbeat/winlogbeat.template.json
+++ b/winlogbeat/winlogbeat.template.json
@@ -5,7 +5,7 @@
         "norms": false
       },
       "_meta": {
-        "version": "5.1.0"
+        "version": "5.1.1"
       },
       "dynamic_templates": [
         {


### PR DESCRIPTION
5.1.0 was accidentally published to the apt/yum repos, so in order
to avoid any problems for people that have it installed, we're going
to release 5.1.1.