### PR TITLE
Backport: Remove metadata prefix from config as not needed (#3095)

### DIFF
--- a/metricbeat/_meta/beat.full.yml
+++ b/metricbeat/_meta/beat.full.yml
@@ -95,9 +95,8 @@ metricbeat.modules:
   #hosts: ["localhost:9092"]
 
   #client_id: metricbeat
-
-  #metadata.retries: 3
-  #metadata.backoff: 250ms
+  #retries: 3
+  #backoff: 250ms
 
   # List of Topics to query metadata for. If empty, all topics will be queried.
   #topics: []

--- a/metricbeat/docs/modules/kafka.asciidoc
+++ b/metricbeat/docs/modules/kafka.asciidoc
@@ -25,9 +25,8 @@ metricbeat.modules:
   #hosts: ["localhost:9092"]
 
   #client_id: metricbeat
-
-  #metadata.retries: 3
-  #metadata.backoff: 250ms
+  #retries: 3
+  #backoff: 250ms
 
   # List of Topics to query metadata for. If empty, all topics will be queried.
   #topics: []

--- a/metricbeat/metricbeat.full.yml
+++ b/metricbeat/metricbeat.full.yml
@@ -95,9 +95,8 @@ metricbeat.modules:
   #hosts: ["localhost:9092"]
 
   #client_id: metricbeat
-
-  #metadata.retries: 3
-  #metadata.backoff: 250ms
+  #retries: 3
+  #backoff: 250ms
 
   # List of Topics to query metadata for. If empty, all topics will be queried.
   #topics: []

--- a/metricbeat/module/kafka/_meta/config.yml
+++ b/metricbeat/module/kafka/_meta/config.yml
@@ -5,9 +5,8 @@
   #hosts: ["localhost:9092"]
 
   #client_id: metricbeat
-
-  #metadata.retries: 3
-  #metadata.backoff: 250ms
+  #retries: 3
+  #backoff: 250ms
 
   # List of Topics to query metadata for. If empty, all topics will be queried.
   #topics: []

--- a/metricbeat/module/kafka/partition/config.go
+++ b/metricbeat/module/kafka/partition/config.go
@@ -8,7 +8,8 @@ import (
 )
 
 type connConfig struct {
-	Metadata metaConfig         `config:"metadata"`
+	Retries  int                `config:"retries" validate:"min=0"`
+	Backoff  time.Duration      `config:"backoff" validate:"min=0"`
 	TLS      *outputs.TLSConfig `config:"ssl"`
 	Username string             `config:"username"`
 	Password string             `config:"password"`
@@ -17,15 +18,11 @@ type connConfig struct {
 }
 
 type metaConfig struct {
-	Retries int           `config:"retries" validate:"min=0"`
-	Backoff time.Duration `config:"backoff" validate:"min=0"`
 }
 
 var defaultConfig = connConfig{
-	Metadata: metaConfig{
-		Retries: 3,
-		Backoff: 250 * time.Millisecond,
-	},
+	Retries:  3,
+	Backoff:  250 * time.Millisecond,
 	TLS:      nil,
 	Username: "",
 	Password: "",

--- a/metricbeat/module/kafka/partition/partition.go
+++ b/metricbeat/module/kafka/partition/partition.go
@@ -52,8 +52,8 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	cfg.Net.DialTimeout = base.Module().Config().Timeout
 	cfg.Net.ReadTimeout = base.Module().Config().Timeout
 	cfg.ClientID = config.ClientID
-	cfg.Metadata.Retry.Max = config.Metadata.Retries
-	cfg.Metadata.Retry.Backoff = config.Metadata.Backoff
+	cfg.Metadata.Retry.Max = config.Retries
+	cfg.Metadata.Retry.Backoff = config.Backoff
 	if tls != nil {
 		cfg.Net.TLS.Enable = true
 		cfg.Net.TLS.Config = tls.BuildModuleConfig("")


### PR DESCRIPTION
(cherry picked from commit bc9fdbf79a1f04adf45b9d9bde36c4d172ec011a)