### PR TITLE
Document batch_read_size is experimental in Winlogbeat

### DIFF
--- a/winlogbeat/docs/reference/configuration/winlogbeat-options.asciidoc
+++ b/winlogbeat/docs/reference/configuration/winlogbeat-options.asciidoc
@@ -55,8 +55,11 @@ winlogbeat.event_logs:
 
 ===== event_logs.batch_read_size
 
+experimental[]
+
 The maximum number of event log records to read from the Windows API in a single
-batch. The default batch size is 100. *{vista_and_newer}*
+batch. The default batch size is 100. Most Windows versions return an error if
+the value is larger than 1024. *{vista_and_newer}*
 
 Winlogbeat starts a goroutine (a lightweight thread) to read from each
 individual event log. The goroutine reads a batch of event log records using the


### PR DESCRIPTION
The feature is new for 5.1 and should be marked as experimental.