### PR TITLE
Add doc for json_decode_fields processor

### DIFF
--- a/filebeat/docs/filebeat-filtering.asciidoc
+++ b/filebeat/docs/filebeat-filtering.asciidoc
@@ -2,20 +2,31 @@
 == Filtering and Enhancing the Exported Data
 
 Your use case might require only a subset of the data exported by Filebeat, or
-you might need to add metadata. Filebeat provides a couple of options for
-filtering and enhancing exported data. You can:
+you might need to enhance the exported data (for example, by adding metadata).
+Filebeat provides a couple of options for filtering and enhancing exported
+data. You can:
 
-* <<filebeat-filtering-overview,Use simple filtering based on pattern matching>>
-* <<defining-processors,Define processors for more complex processing requirements>>
+* <<filebeat-filtering-overview,Define filters at the prospector level>> to
+configure each prospector to include or exclude specific lines or files.
+* <<defining-processors,Define processors>> to configure global processing
+across all data exported by Filebeat.
 
 [float]
 [[filebeat-filtering-overview]]
-=== Filtering Based on Pattern Matching
+=== Filtering at the Prospector Level
 
-You can specify configuration options in the `filebeat` section of the config file to define regular expressions that
-match the lines you want to include and/or exclude from the output. The supported options are <<include-lines,`include_lines`>>, <<exclude-lines,`exclude_lines`>>, and <<exclude-files,`exclude_files`>>.
+You can specify filtering options at the prospector level to configure which
+lines or files are included or excluded in the output. This allows you to
+specify different filtering criteria for each prospector.
 
-For example, you can use the `include_lines` option to export any lines that start with "ERR" or "WARN":
+You configure prospector-level filtering in the `filebeat.prospectors` section
+of the config file by specifying regular expressions that match the lines you
+want to include and/or exclude from the output. The supported options are
+<<include-lines,`include_lines`>>, <<exclude-lines,`exclude_lines`>>, and
+<<exclude-files,`exclude_files`>>.
+
+For example, you can use the `include_lines` option to export any lines that
+start with "ERR" or "WARN":
 
 [source,yaml]
 -------------------------------------------------------------------------------------
@@ -26,9 +37,11 @@ filebeat.prospectors:
   include_lines: ["^ERR", "^WARN"]
 -------------------------------------------------------------------------------------
 
-The disadvantage of this approach is that you need to implement a configuration option for each filtering criteria that you need.
+The disadvantage of this approach is that you need to implement a
+configuration option for each filtering criteria that you need.
 
-See <<configuration-filebeat-options,Filebeat configuration options>> for more information about each option.
+See <<configuration-filebeat-options,Filebeat configuration options>> for more
+information about each option.
 
 [float]
 [[defining-processors]]
@@ -85,7 +98,7 @@ filebeat.prospectors:
 
 processors:
   - decode_json_fields:
-      fields: ["inner"]
+      fields: ['inner']
 
 output.console.pretty: true
 -----------------------------------------------------

--- a/filebeat/docs/filebeat-filtering.asciidoc
+++ b/filebeat/docs/filebeat-filtering.asciidoc
@@ -1,11 +1,16 @@
 [[filtering-and-enhancing-data]]
 == Filtering and Enhancing the Exported Data
 
-When your use case requires only a subset of the data exported by Filebeat or you need to add metadata, you can <<filebeat-filtering-overview,use Filebeat config options to filter the data>>, or you can  <<defining-processors,define processors>>.
+Your use case might require only a subset of the data exported by Filebeat, or
+you might need to add metadata. Filebeat provides a couple of options for
+filtering and enhancing exported data. You can:
+
+* <<filebeat-filtering-overview,Use simple filtering based on pattern matching>>
+* <<defining-processors,Define processors for more complex processing requirements>>
 
 [float]
 [[filebeat-filtering-overview]]
-=== Filebeat Config Options for Filtering
+=== Filtering Based on Pattern Matching
 
 You can specify configuration options in the `filebeat` section of the config file to define regular expressions that
 match the lines you want to include and/or exclude from the output. The supported options are <<include-lines,`include_lines`>>, <<exclude-lines,`exclude_lines`>>, and <<exclude-files,`exclude_files`>>.
@@ -31,7 +36,11 @@ See <<configuration-filebeat-options,Filebeat configuration options>> for more i
 
 include::../../libbeat/docs/processors.asciidoc[]
 
-For example, the following configuration drops all the DEBUG messages.
+[float]
+[[drop-event-example]]
+==== Drop Event Example
+
+The following configuration drops all the DEBUG messages.
 
 [source,yaml]
 -----------------------------------------------------
@@ -52,5 +61,55 @@ processors:
         contains:
            source: "test"
 ----------------
+
+[float]
+[[decode-json-example]]
+==== Decode JSON Example
+
+In the following example, the fields exported by Filebeat include a
+field, `inner`, whose value is a JSON object encoded as a string:
+
+[source,json]
+-----------------------------------------------------
+{ "outer": "value", "inner": "{\"data\": \"value\"}" }
+-----------------------------------------------------
+
+The following configuration decodes the inner JSON object:
+
+[source,yaml]
+-----------------------------------------------------
+filebeat.prospectors:
+- paths:
+    - input.json
+  json.keys_under_root: true
+
+processors:
+  - decode_json_fields:
+      fields: ["inner"]
+
+output.console.pretty: true
+-----------------------------------------------------
+
+The resulting output looks something like this:
+
+["source","json",subs="attributes"]
+-----------------------------------------------------
+{
+  "@timestamp": "2016-12-06T17:38:11.541Z",
+  "beat": {
+    "hostname": "macbook13.local",
+    "name": "macbook13.local",
+    "version": "{version}"
+  },
+  "inner": {
+    "data": "value"
+  },
+  "input_type": "log",
+  "offset": 55,
+  "outer": "value",
+  "source": "input.json",
+  "type": "log"
+}
+-----------------------------------------------------
 
 See <<configuration-processors>> for more information.

--- a/filebeat/docs/filebeat-filtering.asciidoc
+++ b/filebeat/docs/filebeat-filtering.asciidoc
@@ -110,8 +110,8 @@ The resulting output looks something like this:
 {
   "@timestamp": "2016-12-06T17:38:11.541Z",
   "beat": {
-    "hostname": "macbook13.local",
-    "name": "macbook13.local",
+    "hostname": "host.example.com",
+    "name": "host.example.com",
     "version": "{version}"
   },
   "inner": {

--- a/libbeat/docs/processors-config.asciidoc
+++ b/libbeat/docs/processors-config.asciidoc
@@ -233,7 +233,7 @@ The supported actions are:
  * <<drop-fields,`drop_fields`>>
  * <<drop-event,`drop_event`>>
  * <<add-cloud-metadata,`add_cloud_metadata`>>
- * <<json-decode-fields,`json_decode_fields`>>
+ * <<decode-json-fields,`decode_json_fields`>>
 
 See <<exported-fields>> for the full list of possible fields.
 
@@ -373,21 +373,23 @@ _GCE_
 }
 --------------------------------------------------------------------------------
 
-[[json-decode-fields]]
-===== json_decode_fields
+[[decode-json-fields]]
+===== decode_json_fields
 
-The `json_decode_fields` action decodes fields containing JSON strings and replaces the strings with valid JSON objects.
+experimental[]
+
+The `decode_json_fields` action decodes fields containing JSON strings and replaces the strings with valid JSON objects.
 
 [source,yaml]
 -----------------------------------------------------
 processors:
- - json_decode_fields:
+ - decode_json_fields:
      fields: ["field1", "field2", ...]
      processArray: false 
      maxDepth: 1
 -----------------------------------------------------
 
-The `json_decode_fields` action has the following configuration settings:
+The `decode_json_fields` action has the following configuration settings:
 
 `fields`:: The fields containing JSON strings to decode.
 `processArray`:: (Optional) A boolean that specifies whether to process arrays. The default is false.

--- a/libbeat/docs/processors-config.asciidoc
+++ b/libbeat/docs/processors-config.asciidoc
@@ -376,8 +376,6 @@ _GCE_
 [[decode-json-fields]]
 ===== decode_json_fields
 
-experimental[]
-
 The `decode_json_fields` action decodes fields containing JSON strings and replaces the strings with valid JSON objects.
 
 [source,yaml]
@@ -385,12 +383,12 @@ The `decode_json_fields` action decodes fields containing JSON strings and repla
 processors:
  - decode_json_fields:
      fields: ["field1", "field2", ...]
-     processArray: false 
-     maxDepth: 1
+     process_array: false 
+     max_depth: 1
 -----------------------------------------------------
 
 The `decode_json_fields` action has the following configuration settings:
 
 `fields`:: The fields containing JSON strings to decode.
-`processArray`:: (Optional) A boolean that specifies whether to process arrays. The default is false.
-`maxDepth`:: (Optional) The maximum parsing depth. The default is 1.
+`process_array`:: (Optional) A boolean that specifies whether to process arrays. The default is false.
+`max_dept`:: (Optional) The maximum parsing depth. The default is 1.

--- a/libbeat/docs/processors-config.asciidoc
+++ b/libbeat/docs/processors-config.asciidoc
@@ -233,6 +233,7 @@ The supported actions are:
  * <<drop-fields,`drop_fields`>>
  * <<drop-event,`drop_event`>>
  * <<add-cloud-metadata,`add_cloud_metadata`>>
+ * <<json-decode-fields,`json_decode_fields`>>
 
 See <<exported-fields>> for the full list of possible fields.
 
@@ -371,3 +372,23 @@ _GCE_
   }
 }
 --------------------------------------------------------------------------------
+
+[[json-decode-fields]]
+===== json_decode_fields
+
+The `json_decode_fields` action decodes fields containing JSON strings and replaces the strings with valid JSON objects.
+
+[source,yaml]
+-----------------------------------------------------
+processors:
+ - json_decode_fields:
+     fields: ["field1", "field2", ...]
+     processArray: false 
+     maxDepth: 1
+-----------------------------------------------------
+
+The `json_decode_fields` action has the following configuration settings:
+
+`fields`:: The fields containing JSON strings to decode.
+`processArray`:: (Optional) A boolean that specifies whether to process arrays. The default is false.
+`maxDepth`:: (Optional) The maximum parsing depth. The default is 1.

--- a/libbeat/docs/processors-config.asciidoc
+++ b/libbeat/docs/processors-config.asciidoc
@@ -391,4 +391,4 @@ The `decode_json_fields` action has the following configuration settings:
 
 `fields`:: The fields containing JSON strings to decode.
 `process_array`:: (Optional) A boolean that specifies whether to process arrays. The default is false.
-`max_dept`:: (Optional) The maximum parsing depth. The default is 1.
+`max_depth`:: (Optional) The maximum parsing depth. The default is 1.

--- a/libbeat/docs/processors.asciidoc
+++ b/libbeat/docs/processors.asciidoc
@@ -9,15 +9,18 @@
 //// include::../../libbeat/docs/filtering.asciidoc[]
 //////////////////////////////////////////////////////////////////////////
 
-You can define processors in your configuration to process events before they are sent to the configured output.
-The libbeat library provides processors for reducing the number of exported fields, and processors for
-enhancing events with additional metadata. Each processor receives an event, applies a defined action to the event,
-and returns the event. If you define a list of processors, they are executed in the order they are defined in the
-configuration file.
+You can define processors in your configuration to process events before they
+are sent to the configured output.The libbeat library provides processors for:
+
+* reducing the number of exported fields
+* enhancing events with additional metadata
+* performing additional processing and decoding
+
+Each processor receives an event, applies a defined action to the event, and
+returns the event. If you define a list of processors, they are executed in the
+order they are defined in the {beatname_uc} configuration file.
 
 [source,yaml]
 -------
 event -> processor 1 -> event1 -> processor 2 -> event2 ...
 -------
-
-The processors are defined in the {beatname_uc} configuration file.


### PR DESCRIPTION
I'm eager to get this processor documented, so I created a first draft of content for the Beats docs. I think this needs more detail. It's meant to be a starting point. I don't read Go very well, so I might have gotten some of the details wrong.

@suraj-soni I thought it might be easier for you to review this (rather than create the docs yourself) because our doc structure a little eccentric due to single sourcing some of the config content. 

In addition to adding more detail to the descriptions (if you think it's needed), it would be nice to have a real example that shows the message string, the config that you would use to decode it, and the JSON object that would result. Can someone help me with this?

This PR fixes issue #2923 