### PR TITLE
Use snake_case in the settings for the JSON processor

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -14,6 +14,8 @@ https://github.com/elastic/beats/compare/v5.1.1...5.1[Check the HEAD diff]
 
 *Affecting all Beats*
 
+- Renamed the following settings of the decode_json_fields processor: maxDepth to max_depth and processArray to process_array. {pull}3111[3111]
+
 *Metricbeat*
 
 *Packetbeat*

--- a/libbeat/processors/actions/decode_json_fields.go
+++ b/libbeat/processors/actions/decode_json_fields.go
@@ -21,8 +21,8 @@ type decodeJSONFields struct {
 
 type config struct {
 	Fields       []string `config:"fields"`
-	MaxDepth     int      `config:"maxDepth" validate:"min=1"`
-	ProcessArray bool     `config:"processArray"`
+	MaxDepth     int      `config:"max_depth" validate:"min=1"`
+	ProcessArray bool     `config:"process_array"`
 }
 
 var (
@@ -38,7 +38,7 @@ func init() {
 	processors.RegisterPlugin("decode_json_fields",
 		configChecked(newDecodeJSONFields,
 			requireFields("fields"),
-			allowedFields("fields", "maxDepth", "processArray")))
+			allowedFields("fields", "max_depth", "process_array")))
 }
 
 func newDecodeJSONFields(c common.Config) (processors.Processor, error) {

--- a/libbeat/processors/actions/decode_json_fields_test.go
+++ b/libbeat/processors/actions/decode_json_fields_test.go
@@ -89,9 +89,9 @@ func TestValidJSONDepthTwo(t *testing.T) {
 	}
 
 	testConfig, _ = common.NewConfigFrom(map[string]interface{}{
-		"fields":       fields,
-		"processArray": false,
-		"maxDepth":     2,
+		"fields":        fields,
+		"process_array": false,
+		"max_depth":     2,
 	})
 
 	actual := getActualValue(t, testConfig, input)


### PR DESCRIPTION
This is to align them with the rest of our configuration files.