### PR TITLE
Fix for errno 1734 when calling EvtNext

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -48,6 +48,7 @@ https://github.com/elastic/beats/compare/v5.0.1...master[Check the HEAD diff]
 - Fix registry cleanup issue when files falling under ignore_older after restart. {issue}2818[2818]
 
 *Winlogbeat*
+- Fix for "The array bounds are invalid" error when reading large events. {issue}3076[3076]
 
 ==== Added
 

--- a/winlogbeat/eventlog/eventlogging.go
+++ b/winlogbeat/eventlog/eventlogging.go
@@ -195,6 +195,7 @@ func (l *eventLogging) Close() error {
 // by attempting to correct the error through closing and reopening the event
 // log.
 func (l *eventLogging) readRetryErrorHandler(err error) error {
+	incrementMetric(readErrors, err)
 	if errno, ok := err.(syscall.Errno); ok {
 		var reopen bool
 

--- a/winlogbeat/sys/wineventlog/syscall_windows.go
+++ b/winlogbeat/sys/wineventlog/syscall_windows.go
@@ -13,6 +13,7 @@ const (
 	ERROR_INSUFFICIENT_BUFFER             syscall.Errno = 122
 	ERROR_NO_MORE_ITEMS                   syscall.Errno = 259
 	ERROR_NONE_MAPPED                     syscall.Errno = 1332
+	RPC_S_INVALID_BOUND                   syscall.Errno = 1734
 	ERROR_INVALID_OPERATION               syscall.Errno = 4317
 	ERROR_EVT_MESSAGE_NOT_FOUND           syscall.Errno = 15027
 	ERROR_EVT_MESSAGE_ID_NOT_FOUND        syscall.Errno = 15028

--- a/winlogbeat/sys/wineventlog/wineventlog_windows.go
+++ b/winlogbeat/sys/wineventlog/wineventlog_windows.go
@@ -125,6 +125,10 @@ func Subscribe(
 // handles available to return. Close must be called on each returned EvtHandle
 // when finished with the handle.
 func EventHandles(subscription EvtHandle, maxHandles int) ([]EvtHandle, error) {
+	if maxHandles < 1 {
+		return nil, fmt.Errorf("maxHandles must be greater than 0")
+	}
+
 	eventHandles := make([]EvtHandle, maxHandles)
 	var numRead uint32
 


### PR DESCRIPTION
When reading a batch of large event log records the Windows function
EvtNext returns errno 1734 (0x6C6) which is RPC_S_INVALID_BOUND ("The
array bounds are invalid."). This seems to be a bug in Windows because
there is no documentation about this behavior.

This fix handles the error by resetting the event log subscription
handle (so events are not lost) and then retries the EvtNext call
with maxHandles/2.

Fixes #3076