### PR TITLE
Fix ES 2.x integration test

### DIFF
--- a/libbeat/outputs/elasticsearch/client_integration_test.go
+++ b/libbeat/outputs/elasticsearch/client_integration_test.go
@@ -35,18 +35,21 @@ func TestCheckTemplate(t *testing.T) {
 
 func TestLoadTemplate(t *testing.T) {
 
+	// Setup ES
+	client := GetTestingElasticsearch()
+	err := client.Connect(5 * time.Second)
+	assert.Nil(t, err)
+
 	// Load template
 	absPath, err := filepath.Abs("../../tests/files/")
 	assert.NotNil(t, absPath)
 	assert.Nil(t, err)
 
 	templatePath := absPath + "/template.json"
+	if strings.HasPrefix(client.Connection.version, "2.") {
+		templatePath = absPath + "/template-es2x.json"
+	}
 	content, err := readTemplate(templatePath)
-	assert.Nil(t, err)
-
-	// Setup ES
-	client := GetTestingElasticsearch()
-	err = client.Connect(5 * time.Second)
 	assert.Nil(t, err)
 
 	templateName := "testbeat"

--- a/libbeat/tests/files/template-es2x.json
+++ b/libbeat/tests/files/template-es2x.json
@@ -1,0 +1,43 @@
+{
+  "mappings": {
+    "_default_": {
+      "_all": {
+        "enabled": true,
+        "norms": {
+          "enabled": false
+        }
+      },
+      "dynamic_templates": [
+        {
+          "template1": {
+            "mapping": {
+              "doc_values": true,
+              "ignore_above": 1024,
+              "index": "not_analyzed",
+              "type": "{dynamic_type}"
+            },
+            "match": "*"
+          }
+        }
+      ],
+      "properties": {
+        "@timestamp": {
+          "type": "date"
+        },
+        "message": {
+          "type": "string",
+          "index": "analyzed"
+        },
+        "offset": {
+          "type": "long",
+          "doc_values": "true"
+        }
+      }
+    }
+  },
+  "settings": {
+    "index.refresh_interval": "5s"
+  },
+  "template": "mockbeat-*"
+}
+


### PR DESCRIPTION
There was a test that was loading a mock template, and this template
was assuming 5.x.