### PR TITLE
Backport: Fix for errno 1734 when calling EvtNext (#3112)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -60,6 +60,7 @@ https://github.com/elastic/beats/compare/v5.1.1...5.1[Check the HEAD diff]
 *Filebeat*
 
 *Winlogbeat*
+- Fix for "The array bounds are invalid" error when reading large events. {issue}3076[3076]
 
 ////////////////////////////////////////////////////////////
 

--- a/winlogbeat/eventlog/bench_test.go
+++ b/winlogbeat/eventlog/bench_test.go
@@ -1,0 +1,137 @@
+// +build windows
+
+package eventlog
+
+import (
+	"flag"
+	"math/rand"
+	"os/exec"
+	"strconv"
+	"testing"
+	"time"
+
+	elog "github.com/andrewkroh/sys/windows/svc/eventlog"
+	"github.com/dustin/go-humanize"
+)
+
+// Benchmark tests with customized output. (`go test -v -benchtime 10s -benchtest .`)
+
+var (
+	benchTest    = flag.Bool("benchtest", false, "Run benchmarks for the eventlog package")
+	injectAmount = flag.Int("inject", 50000, "Number of events to inject before running benchmarks")
+)
+
+// TestBenchmarkBatchReadSize tests the performance of different
+// batch_read_size values.
+func TestBenchmarkBatchReadSize(t *testing.T) {
+	if !*benchTest {
+		t.Skip("-benchtest not enabled")
+	}
+
+	log, err := initLog(providerName, sourceName, eventCreateMsgFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		err := uninstallLog(providerName, sourceName, log)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	// Increase the log size so that it can hold these large events.
+	output, err := exec.Command("wevtutil.exe", "sl", "/ms:1073741824", providerName).CombinedOutput()
+	if err != nil {
+		t.Fatal(err, string(output))
+	}
+
+	// Publish test messages:
+	for i := 0; i < *injectAmount; i++ {
+		err = log.Report(elog.Info, uint32(rng.Int63()%1000), []string{strconv.Itoa(i) + " " + randString(256)})
+		if err != nil {
+			t.Fatal("ReportEvent error", err)
+		}
+	}
+
+	setup := func(t testing.TB, batchReadSize int) (EventLog, func()) {
+		eventlog, err := newWinEventLog(map[string]interface{}{"name": providerName, "batch_read_size": batchReadSize})
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = eventlog.Open(0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return eventlog, func() {
+			err := eventlog.Close()
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	benchTest := func(batchSize int) {
+		var err error
+		result := testing.Benchmark(func(b *testing.B) {
+			eventlog, tearDown := setup(b, batchSize)
+			defer tearDown()
+			b.ResetTimer()
+
+			// Each iteration reads one batch.
+			for i := 0; i < b.N; i++ {
+				_, err = eventlog.Read()
+				if err != nil {
+					return
+				}
+			}
+		})
+
+		if err != nil {
+			t.Fatal(err)
+			return
+		}
+
+		t.Logf("batch_size=%v, total_events=%v, batch_time=%v, events_per_sec=%v, bytes_alloced_per_event=%v, total_allocs=%v",
+			batchSize,
+			result.N*batchSize,
+			time.Duration(result.NsPerOp()),
+			float64(batchSize)/time.Duration(result.NsPerOp()).Seconds(),
+			humanize.Bytes(result.MemBytes/(uint64(result.N)*uint64(batchSize))),
+			result.MemAllocs)
+	}
+
+	benchTest(10)
+	benchTest(100)
+	benchTest(500)
+	benchTest(1000)
+}
+
+// Utility Functions
+
+var rng = rand.NewSource(time.Now().UnixNano())
+
+const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+const (
+	letterIdxBits = 6                    // 6 bits to represent a letter index
+	letterIdxMask = 1<<letterIdxBits - 1 // All 1-bits, as many as letterIdxBits
+	letterIdxMax  = 63 / letterIdxBits   // # of letter indices fitting in 63 bits
+)
+
+// https://stackoverflow.com/questions/22892120/how-to-generate-a-random-string-of-a-fixed-length-in-golang
+func randString(n int) string {
+	b := make([]byte, n)
+	// A src.Int63() generates 63 random bits, enough for letterIdxMax characters!
+	for i, cache, remain := n-1, rng.Int63(), letterIdxMax; i >= 0; {
+		if remain == 0 {
+			cache, remain = rng.Int63(), letterIdxMax
+		}
+		if idx := int(cache & letterIdxMask); idx < len(letterBytes) {
+			b[i] = letterBytes[idx]
+			i--
+		}
+		cache >>= letterIdxBits
+		remain--
+	}
+
+	return string(b)
+}

--- a/winlogbeat/eventlog/eventlogging.go
+++ b/winlogbeat/eventlog/eventlogging.go
@@ -195,6 +195,7 @@ func (l *eventLogging) Close() error {
 // by attempting to correct the error through closing and reopening the event
 // log.
 func (l *eventLogging) readRetryErrorHandler(err error) error {
+	incrementMetric(readErrors, err)
 	if errno, ok := err.(syscall.Errno); ok {
 		var reopen bool
 

--- a/winlogbeat/sys/wineventlog/syscall_windows.go
+++ b/winlogbeat/sys/wineventlog/syscall_windows.go
@@ -13,6 +13,7 @@ const (
 	ERROR_INSUFFICIENT_BUFFER             syscall.Errno = 122
 	ERROR_NO_MORE_ITEMS                   syscall.Errno = 259
 	ERROR_NONE_MAPPED                     syscall.Errno = 1332
+	RPC_S_INVALID_BOUND                   syscall.Errno = 1734
 	ERROR_INVALID_OPERATION               syscall.Errno = 4317
 	ERROR_EVT_MESSAGE_NOT_FOUND           syscall.Errno = 15027
 	ERROR_EVT_MESSAGE_ID_NOT_FOUND        syscall.Errno = 15028

--- a/winlogbeat/sys/wineventlog/wineventlog_windows.go
+++ b/winlogbeat/sys/wineventlog/wineventlog_windows.go
@@ -125,6 +125,10 @@ func Subscribe(
 // handles available to return. Close must be called on each returned EvtHandle
 // when finished with the handle.
 func EventHandles(subscription EvtHandle, maxHandles int) ([]EvtHandle, error) {
+	if maxHandles < 1 {
+		return nil, fmt.Errorf("maxHandles must be greater than 0")
+	}
+
 	eventHandles := make([]EvtHandle, maxHandles)
 	var numRead uint32
 


### PR DESCRIPTION
Backport #3112 to 5.1 branch

> When reading a batch of large event log records the Windows function
EvtNext returns errno 1734 (0x6C6) which is RPC_S_INVALID_BOUND ("The
array bounds are invalid."). This seems to be a bug in Windows because
there is no documentation about this behavior.
>
>This fix handles the error by resetting the event log subscription
handle (so events are not lost) and then retries the EvtNext call
with maxHandles/2.
>
>Fixes #3076

(cherry picked from commit 226eb10ce03042c3259e8055b18ddc8193fde519)