### PR TITLE
Enhance kafka broker matching

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -51,6 +51,7 @@ https://github.com/elastic/beats/compare/v5.1.1...master[Check the HEAD diff]
 - Added new flags to import_dashboards (-cacert, -cert, -key, -insecure). {pull}3139[3139] {pull}3163[3163]
 
 *Metricbeat*
+- Kafka module broker matching enhancements. {pull}3129[3129]
 
 
 *Packetbeat*


### PR DESCRIPTION
Enhance bootstrap broker matching:
- configurable `advertised` address for matching
- compare broker addresses to hostname
- compare machines interfaces ips to all known broker ips