### PR TITLE
Backport: Remove fixed container names as not needed (#3122)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ BUILD_DIR=build
 COVERAGE_DIR=${BUILD_DIR}/coverage
 BEATS=packetbeat filebeat winlogbeat metricbeat heartbeat
 PROJECTS=libbeat ${BEATS}
+PROJECTS_ENV=libbeat metricbeat
 SNAPSHOT?=yes
 
 # Runs complete testsuites (unit, system, integration) for all beats with coverage and race detection.
@@ -11,6 +12,9 @@ SNAPSHOT?=yes
 testsuite:
 	$(foreach var,$(PROJECTS),$(MAKE) -C $(var) testsuite || exit 1;)
 	#$(MAKE) -C generate test
+
+stop-environments:
+	$(foreach var,$(PROJECTS_ENV),$(MAKE) -C $(var) stop-environment || exit 0;)
 
 # Runs unit and system tests without coverage and race detection.
 .PHONY: test

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -43,7 +43,8 @@ TEST_ENVIRONMENT?=false
 SYSTEM_TESTS?=false
 GOX_OS?=linux darwin windows solaris freebsd netbsd openbsd
 TESTING_ENVIRONMENT?=snapshot
-DOCKER_COMPOSE?=docker-compose -f ${PWD}/../testing/environments/base.yml -f ${PWD}/../testing/environments/${TESTING_ENVIRONMENT}.yml -f docker-compose.yml
+DOCKER_COMPOSE_PROJECT_NAME?=${BEATNAME}_${TESTING_ENVIRONMENT}
+DOCKER_COMPOSE?=docker-compose -p ${DOCKER_COMPOSE_PROJECT_NAME} -f ${PWD}/../testing/environments/base.yml -f ${PWD}/../testing/environments/${TESTING_ENVIRONMENT}.yml -f docker-compose.yml
 DOCKER_CACHE?=1 # If set to 0, all docker images are created without cache
 GOPACKAGES_COMMA_SEP=$(subst $(space),$(comma),$(strip ${GOPACKAGES}))
 PYTHON_ENV?=${BUILD_DIR}/python-env
@@ -304,7 +305,7 @@ start-environment: stop-environment
 .PHONY: stop-environment
 stop-environment:
 	-${DOCKER_COMPOSE} stop
-	-${DOCKER_COMPOSE} rm -f -v -a
+	-${DOCKER_COMPOSE} rm -f -v
 
 .PHONY: write-environment
 write-environment:

--- a/testing/environments/base.yml
+++ b/testing/environments/base.yml
@@ -8,17 +8,14 @@ services:
       - logstash
     environment:
       - LS_HOST=logstash
-    container_name: beat
 
   elasticsearch:
     image: elasticsearch:latest
-    container_name: elasticsearch
 
   logstash:
     image: logstash:latest
     links:
       - elasticsearch
-    container_name: logstash
     environment:
       - ES_HOST=elasticsearch
 
@@ -28,4 +25,3 @@ services:
       - elasticsearch
     environment:
       - ELASTICSEARCH_URL=http://elasticsearch:9200/
-    container_name: kibana


### PR DESCRIPTION
Add beat name to project namespace

* This makes sure different beats environment do not affect each other for example when Kafka is used
* It also allows to run the testsuites of all the beats in parallel

Introduce `stop-environment` command to stop all containers
(cherry picked from commit 46baa433ce8afb81fa2eaf7e8cdcb39367845268)

This needs backport as the Jenkins job for 5.1 and master are the same. This makes sure builds keep working.