### PR TITLE
Adjustments to full config file

### DIFF
--- a/filebeat/_meta/beat.full.yml
+++ b/filebeat/_meta/beat.full.yml
@@ -39,18 +39,19 @@ filebeat.prospectors:
   # Some sample encodings:
   #   plain, utf-8, utf-16be-bom, utf-16be, utf-16le, big5, gb18030, gbk,
   #    hz-gb-2312, euc-kr, euc-jp, iso-2022-jp, shift-jis, ...
-  #encoding: plain
-
+  encoding: plain
 
   # Exclude lines. A list of regular expressions to match. It drops the lines that are
   # matching any regular expression from the list. The include_lines is called before
   # exclude_lines. By default, no lines are dropped.
-  #exclude_lines: ["^DBG"]
+  # Example: ["^DBG"]
+  exclude_lines: []
 
   # Include lines. A list of regular expressions to match. It exports the lines that are
   # matching any regular expression from the list. The include_lines is called before
   # exclude_lines. By default, all the lines are exported.
-  #include_lines: ["^ERR", "^WARN"]
+  # Example: ["^ERR", "^WARN"]
+  include_lines: []
 
   # Exclude files. A list of regular expressions to match. Filebeat drops the files that
   # are matching any regular expression from the list. By default, no files are dropped.
@@ -58,38 +59,38 @@ filebeat.prospectors:
 
   # Optional additional fields. These field can be freely picked
   # to add additional information to the crawled log files for filtering
-  #fields:
-  #  level: debug
-  #  review: 1
+  fields:
+    #level: debug
+    #review: 1
 
   # Set to true to store the additional fields as top level fields instead
   # of under the "fields" sub-dictionary. In case of name conflicts with the
   # fields added by Filebeat itself, the custom fields overwrite the default
   # fields.
-  #fields_under_root: false
+  fields_under_root: false
 
   # Ignore files which were modified more then the defined timespan in the past.
   # ignore_older is disabled by default, so no files are ignored by setting it to 0.
   # Time strings like 2h (2 hours), 5m (5 minutes) can be used.
-  #ignore_older: 0
+  ignore_older: 0
 
   # Type to be published in the 'type' field. For Elasticsearch output,
   # the type defines the document type these entries should be stored
   # in. Default: log
-  #document_type: log
+  document_type: log
 
   # How often the prospector checks for new files in the paths that are specified
   # for harvesting. Specify 1s to scan the directory as frequently as possible
   # without causing Filebeat to scan too frequently. Default: 10s.
-  #scan_frequency: 10s
+  scan_frequency: 10s
 
   # Defines the buffer size every harvester uses when fetching the file
-  #harvester_buffer_size: 16384
+  harvester_buffer_size: 16384
 
   # Maximum number of bytes a single log event can have
   # All bytes after max_bytes are discarded and not sent. The default is 10MB.
   # This is especially useful for multiline log messages which can get large.
-  #max_bytes: 10485760
+  max_bytes: 10485760
 
   ### JSON configuration
 
@@ -141,69 +142,69 @@ filebeat.prospectors:
   # Setting tail_files to true means filebeat starts reading new files at the end
   # instead of the beginning. If this is used in combination with log rotation
   # this can mean that the first entries of a new file are skipped.
-  #tail_files: false
+  tail_files: false
 
   # Experimental: If symlinks is enabled, symlinks are opened and harvested. The harvester is openening the
   # original for harvesting but will report the symlink name as source.
-  #symlinks: false
+  symlinks: false
 
   # Backoff values define how aggressively filebeat crawls new files for updates
   # The default values can be used in most cases. Backoff defines how long it is waited
   # to check a file again after EOF is reached. Default is 1s which means the file
   # is checked every second if new lines were added. This leads to a near real time crawling.
   # Every time a new line appears, backoff is reset to the initial value.
-  #backoff: 1s
+  backoff: 1s
 
   # Max backoff defines what the maximum backoff time is. After having backed off multiple times
   # from checking the files, the waiting time will never exceed max_backoff independent of the
   # backoff factor. Having it set to 10s means in the worst case a new line can be added to a log
   # file after having backed off multiple times, it takes a maximum of 10s to read the new line
-  #max_backoff: 10s
+  max_backoff: 10s
 
   # The backoff factor defines how fast the algorithm backs off. The bigger the backoff factor,
   # the faster the max_backoff value is reached. If this value is set to 1, no backoff will happen.
   # The backoff value will be multiplied each time with the backoff_factor until max_backoff is reached
-  #backoff_factor: 2
+  backoff_factor: 2
 
   # Experimental: Max number of harvesters that are started in parallel.
   # Default is 0 which means unlimited
-  #harvester_limit: 0
+  harvester_limit: 0
 
   ### Harvester closing options
 
   # Close inactive closes the file handler after the predefined period.
   # The period starts when the last line of the file was, not the file ModTime.
   # Time strings like 2h (2 hours), 5m (5 minutes) can be used.
-  #close_inactive: 5m
+  close_inactive: 5m
 
   # Close renamed closes a file handler when the file is renamed or rotated.
   # Note: Potential data loss. Make sure to read and understand the docs for this option.
-  #close_renamed: false
+  close_renamed: false
 
   # When enabling this option, a file handler is closed immediately in case a file can't be found
   # any more. In case the file shows up again later, harvesting will continue at the last known position
   # after scan_frequency.
-  #close_removed: true
+  close_removed: true
 
   # Closes the file handler as soon as the harvesters reaches the end of the file.
   # By default this option is disabled.
   # Note: Potential data loss. Make sure to read and understand the docs for this option.
-  #close_eof: false
+  close_eof: false
 
   ### State options
 
   # Files for the modification data is older then clean_inactive the state from the registry is removed
   # By default this is disabled.
-  #clean_inactive: 0
+  clean_inactive: 0
 
   # Removes the state for file which cannot be found on disk anymore immediately
-  #clean_removed: true
+  clean_removed: true
 
   # Close timeout closes the harvester after the predefined time.
   # This is independent if the harvester did finish reading the file or not.
   # By default this option is disabled.
   # Note: Potential data loss. Make sure to read and understand the docs for this option.
-  #close_timeout: 0
+  close_timeout: 0
 
 #----------------------------- Stdin prospector -------------------------------
 # Configuration to use stdin input
@@ -212,25 +213,25 @@ filebeat.prospectors:
 #========================= Filebeat global options ============================
 
 # Event count spool threshold - forces network flush if exceeded
-#filebeat.spool_size: 2048
+filebeat.spool_size: 2048
 
 # Enable async publisher pipeline in filebeat (Experimental!)
-#filebeat.publish_async: false
+filebeat.publish_async: false
 
 # Defines how often the spooler is flushed. After idle_timeout the spooler is
 # Flush even though spool_size is not reached.
-#filebeat.idle_timeout: 5s
+filebeat.idle_timeout: 5s
 
 # Name of the registry file. If a relative path is used, it is considered relative to the
 # data path.
-#filebeat.registry_file: ${path.data}/registry
+filebeat.registry_file: ${path.data}/registry
 
 #
 # These config files must have the full filebeat config part inside, but only
 # the prospector part is processed. All global options like spool_size are ignored.
 # The config_dir MUST point to a different directory then where the main filebeat config file is in.
-#filebeat.config_dir:
+filebeat.config_dir: ${path.config}
 
 # How long filebeat waits on shutdown for the publisher to finish.
 # Default is 0, not waiting.
-#filebeat.shutdown_timeout: 0
+filebeat.shutdown_timeout: 0

--- a/filebeat/filebeat.full.yml
+++ b/filebeat/filebeat.full.yml
@@ -39,18 +39,19 @@ filebeat.prospectors:
   # Some sample encodings:
   #   plain, utf-8, utf-16be-bom, utf-16be, utf-16le, big5, gb18030, gbk,
   #    hz-gb-2312, euc-kr, euc-jp, iso-2022-jp, shift-jis, ...
-  #encoding: plain
-
+  encoding: plain
 
   # Exclude lines. A list of regular expressions to match. It drops the lines that are
   # matching any regular expression from the list. The include_lines is called before
   # exclude_lines. By default, no lines are dropped.
-  #exclude_lines: ["^DBG"]
+  # Example: ["^DBG"]
+  exclude_lines: []
 
   # Include lines. A list of regular expressions to match. It exports the lines that are
   # matching any regular expression from the list. The include_lines is called before
   # exclude_lines. By default, all the lines are exported.
-  #include_lines: ["^ERR", "^WARN"]
+  # Example: ["^ERR", "^WARN"]
+  include_lines: []
 
   # Exclude files. A list of regular expressions to match. Filebeat drops the files that
   # are matching any regular expression from the list. By default, no files are dropped.
@@ -58,38 +59,38 @@ filebeat.prospectors:
 
   # Optional additional fields. These field can be freely picked
   # to add additional information to the crawled log files for filtering
-  #fields:
-  #  level: debug
-  #  review: 1
+  fields:
+    #level: debug
+    #review: 1
 
   # Set to true to store the additional fields as top level fields instead
   # of under the "fields" sub-dictionary. In case of name conflicts with the
   # fields added by Filebeat itself, the custom fields overwrite the default
   # fields.
-  #fields_under_root: false
+  fields_under_root: false
 
   # Ignore files which were modified more then the defined timespan in the past.
   # ignore_older is disabled by default, so no files are ignored by setting it to 0.
   # Time strings like 2h (2 hours), 5m (5 minutes) can be used.
-  #ignore_older: 0
+  ignore_older: 0
 
   # Type to be published in the 'type' field. For Elasticsearch output,
   # the type defines the document type these entries should be stored
   # in. Default: log
-  #document_type: log
+  document_type: log
 
   # How often the prospector checks for new files in the paths that are specified
   # for harvesting. Specify 1s to scan the directory as frequently as possible
   # without causing Filebeat to scan too frequently. Default: 10s.
-  #scan_frequency: 10s
+  scan_frequency: 10s
 
   # Defines the buffer size every harvester uses when fetching the file
-  #harvester_buffer_size: 16384
+  harvester_buffer_size: 16384
 
   # Maximum number of bytes a single log event can have
   # All bytes after max_bytes are discarded and not sent. The default is 10MB.
   # This is especially useful for multiline log messages which can get large.
-  #max_bytes: 10485760
+  max_bytes: 10485760
 
   ### JSON configuration
 
@@ -141,69 +142,69 @@ filebeat.prospectors:
   # Setting tail_files to true means filebeat starts reading new files at the end
   # instead of the beginning. If this is used in combination with log rotation
   # this can mean that the first entries of a new file are skipped.
-  #tail_files: false
+  tail_files: false
 
   # Experimental: If symlinks is enabled, symlinks are opened and harvested. The harvester is openening the
   # original for harvesting but will report the symlink name as source.
-  #symlinks: false
+  symlinks: false
 
   # Backoff values define how aggressively filebeat crawls new files for updates
   # The default values can be used in most cases. Backoff defines how long it is waited
   # to check a file again after EOF is reached. Default is 1s which means the file
   # is checked every second if new lines were added. This leads to a near real time crawling.
   # Every time a new line appears, backoff is reset to the initial value.
-  #backoff: 1s
+  backoff: 1s
 
   # Max backoff defines what the maximum backoff time is. After having backed off multiple times
   # from checking the files, the waiting time will never exceed max_backoff independent of the
   # backoff factor. Having it set to 10s means in the worst case a new line can be added to a log
   # file after having backed off multiple times, it takes a maximum of 10s to read the new line
-  #max_backoff: 10s
+  max_backoff: 10s
 
   # The backoff factor defines how fast the algorithm backs off. The bigger the backoff factor,
   # the faster the max_backoff value is reached. If this value is set to 1, no backoff will happen.
   # The backoff value will be multiplied each time with the backoff_factor until max_backoff is reached
-  #backoff_factor: 2
+  backoff_factor: 2
 
   # Experimental: Max number of harvesters that are started in parallel.
   # Default is 0 which means unlimited
-  #harvester_limit: 0
+  harvester_limit: 0
 
   ### Harvester closing options
 
   # Close inactive closes the file handler after the predefined period.
   # The period starts when the last line of the file was, not the file ModTime.
   # Time strings like 2h (2 hours), 5m (5 minutes) can be used.
-  #close_inactive: 5m
+  close_inactive: 5m
 
   # Close renamed closes a file handler when the file is renamed or rotated.
   # Note: Potential data loss. Make sure to read and understand the docs for this option.
-  #close_renamed: false
+  close_renamed: false
 
   # When enabling this option, a file handler is closed immediately in case a file can't be found
   # any more. In case the file shows up again later, harvesting will continue at the last known position
   # after scan_frequency.
-  #close_removed: true
+  close_removed: true
 
   # Closes the file handler as soon as the harvesters reaches the end of the file.
   # By default this option is disabled.
   # Note: Potential data loss. Make sure to read and understand the docs for this option.
-  #close_eof: false
+  close_eof: false
 
   ### State options
 
   # Files for the modification data is older then clean_inactive the state from the registry is removed
   # By default this is disabled.
-  #clean_inactive: 0
+  clean_inactive: 0
 
   # Removes the state for file which cannot be found on disk anymore immediately
-  #clean_removed: true
+  clean_removed: true
 
   # Close timeout closes the harvester after the predefined time.
   # This is independent if the harvester did finish reading the file or not.
   # By default this option is disabled.
   # Note: Potential data loss. Make sure to read and understand the docs for this option.
-  #close_timeout: 0
+  close_timeout: 0
 
 #----------------------------- Stdin prospector -------------------------------
 # Configuration to use stdin input
@@ -212,35 +213,35 @@ filebeat.prospectors:
 #========================= Filebeat global options ============================
 
 # Event count spool threshold - forces network flush if exceeded
-#filebeat.spool_size: 2048
+filebeat.spool_size: 2048
 
 # Enable async publisher pipeline in filebeat (Experimental!)
-#filebeat.publish_async: false
+filebeat.publish_async: false
 
 # Defines how often the spooler is flushed. After idle_timeout the spooler is
 # Flush even though spool_size is not reached.
-#filebeat.idle_timeout: 5s
+filebeat.idle_timeout: 5s
 
 # Name of the registry file. If a relative path is used, it is considered relative to the
 # data path.
-#filebeat.registry_file: ${path.data}/registry
+filebeat.registry_file: ${path.data}/registry
 
 #
 # These config files must have the full filebeat config part inside, but only
 # the prospector part is processed. All global options like spool_size are ignored.
 # The config_dir MUST point to a different directory then where the main filebeat config file is in.
-#filebeat.config_dir:
+filebeat.config_dir: ${path.config}
 
 # How long filebeat waits on shutdown for the publisher to finish.
 # Default is 0, not waiting.
-#filebeat.shutdown_timeout: 0
+filebeat.shutdown_timeout: 0
 
 #================================ General ======================================
 
 # The name of the shipper that publishes the network data. It can be used to group
 # all the transactions sent by a single shipper in the web interface.
 # If this options is not defined, the hostname is used.
-#name:
+name:
 
 # The tags of the shipper are included in their own field with each
 # transaction published. Tags make it easy to group servers by different
@@ -256,14 +257,14 @@ filebeat.prospectors:
 # If this option is set to true, the custom fields are stored as top-level
 # fields in the output document instead of being grouped under a fields
 # sub-dictionary. Default is false.
-#fields_under_root: false
+fields_under_root: false
 
 # Internal queue size for single events in processing pipeline
-#queue_size: 1000
+queue_size: 1000
 
 # The internal queue size for bulk events in the processing pipeline.
 # Do not modify this value.
-#bulk_queue_size: 0
+bulk_queue_size: 0
 
 # Sets the maximum number of CPUs that can be executing simultaneously. The
 # default is the number of logical CPUs available in the system.
@@ -314,7 +315,7 @@ filebeat.prospectors:
 #-------------------------- Elasticsearch output -------------------------------
 output.elasticsearch:
   # Boolean flag to enable or disable the output module.
-  #enabled: true
+  enabled: true
 
   # Array of hosts to connect to.
   # Scheme and port can be left out and will be set to the default (http and 9200)
@@ -323,7 +324,7 @@ output.elasticsearch:
   hosts: ["localhost:9200"]
 
   # Set gzip compression level.
-  #compression_level: 0
+  compression_level: 0
 
   # Optional protocol and basic auth credentials.
   #protocol: "https"
@@ -336,422 +337,422 @@ output.elasticsearch:
     #param2: value2
 
   # Number of workers per Elasticsearch host.
-  #worker: 1
+  worker: 1
 
   # Optional index name. The default is "filebeat" plus date
   # and generates [filebeat-]YYYY.MM.DD keys.
-  #index: "filebeat-%{+yyyy.MM.dd}"
+  index: "filebeat-%{+yyyy.MM.dd}"
 
   # Optional ingest node pipeline. By default no pipeline will be used.
-  #pipeline: ""
+  pipeline: ""
 
-  # Optional HTTP Path
-  #path: "/elasticsearch"
+  # Optional HTTP Path. Example: /elasticsearch
+  path:
 
-  # Proxy server url
-  #proxy_url: http://proxy:3128
+  # Proxy server url. Example: http://proxy:3128
+  proxy_url:
 
   # The number of times a particular Elasticsearch index operation is attempted. If
   # the indexing operation doesn't succeed after this many retries, the events are
   # dropped. The default is 3.
-  #max_retries: 3
+  max_retries: 3
 
   # The maximum number of events to bulk in a single Elasticsearch bulk API index request.
   # The default is 50.
-  #bulk_max_size: 50
+  bulk_max_size: 50
 
   # Configure http request timeout before failing an request to Elasticsearch.
-  #timeout: 90
+  timeout: 90
 
   # The number of seconds to wait for new events between two bulk API index requests.
   # If `bulk_max_size` is reached before this interval expires, addition bulk index
   # requests are made.
-  #flush_interval: 1s
+  flush_interval: 1s
 
   # A template is used to set the mapping in Elasticsearch
   # By default template loading is enabled and the template is loaded.
   # These settings can be adjusted to load your own template or overwrite existing ones.
 
   # Set to false to disable template loading.
-  #template.enabled: true
+  template.enabled: true
 
   # Template name. By default the template name is filebeat.
-  #template.name: "filebeat"
+  template.name: "filebeat"
 
   # Path to template file
-  #template.path: "${path.config}/filebeat.template.json"
+  template.path: "${path.config}/filebeat.template.json"
 
   # Overwrite existing template
-  #template.overwrite: false
+  #emplate.overwrite: false
 
   # If set to true, filebeat checks the Elasticsearch version at connect time, and if it
   # is 2.x, it loads the file specified by the template.versions.2x.path setting. The
   # default is true.
-  #template.versions.2x.enabled: true
+  template.versions.2x.enabled: true
 
   # Path to the Elasticsearch 2.x version of the template file.
-  #template.versions.2x.path: "${path.config}/filebeat.template-es2x.json"
+  template.versions.2x.path: "${path.config}/filebeat.template-es2x.json"
 
   # Use SSL settings for HTTPS. Default is true.
-  #ssl.enabled: true
+  ssl.enabled: false
 
   # Configure SSL verification mode. If `none` is configured, all server hosts
   # and certificates will be accepted. In this mode, SSL based connections are
   # susceptible to man-in-the-middle attacks. Use only for testing. Default is
   # `full`.
-  #ssl.verification_mode: full
+  ssl.verification_mode: full
 
   # List of supported/valid TLS versions. By default all TLS versions 1.0 up to
   # 1.2 are enabled.
-  #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
+  ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
 
-  # SSL configuration. By default is off.
+  # SSL configuration. By default is off. TODO
   # List of root certificates for HTTPS server verifications
-  #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
+  ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
   # Certificate for SSL client authentication
-  #ssl.certificate: "/etc/pki/client/cert.pem"
+  ssl.certificate: "/etc/pki/client/cert.pem"
 
   # Client Certificate Key
-  #ssl.key: "/etc/pki/client/cert.key"
+  ssl.key: "/etc/pki/client/cert.key"
 
   # Optional passphrase for decrypting the Certificate Key.
-  #ssl.key_passphrase: ''
+  ssl.key_passphrase: ''
 
   # Configure cipher suites to be used for SSL connections
-  #ssl.cipher_suites: []
+  ssl.cipher_suites: []
 
   # Configure curve types for ECDHE based cipher suites
-  #ssl.curve_types: []
+  ssl.curve_types: []
 
 
 #----------------------------- Logstash output ---------------------------------
-#output.logstash:
+output.logstash:
   # Boolean flag to enable or disable the output module.
-  #enabled: true
+  enabled: false
 
   # The Logstash hosts
-  #hosts: ["localhost:5044"]
+  hosts: ["localhost:5044"]
 
   # Number of workers per Logstash host.
-  #worker: 1
+  worker: 1
 
   # Set gzip compression level.
-  #compression_level: 3
+  compression_level: 3
 
   # Optional load balance the events between the Logstash hosts
-  #loadbalance: true
+  loadbalance: true
 
   # Number of batches to be send asynchronously to logstash while processing
   # new batches.
-  #pipelining: 0
+  pipelining: 0
 
   # Optional index name. The default index name is set to name of the beat
   # in all lowercase.
-  #index: 'filebeat'
+  index: 'filebeat'
 
   # SOCKS5 proxy server URL
-  #proxy_url: socks5://user:password@socks5-server:2233
+  proxy_url: socks5://user:password@socks5-server:2233
 
   # Resolve names locally when using a proxy server. Defaults to false.
-  #proxy_use_local_resolver: false
+  proxy_use_local_resolver: false
 
   # Enable SSL support. SSL is automatically enabled, if any SSL setting is set.
-  #ssl.enabled: true
+  ssl.enabled: false
 
   # Configure SSL verification mode. If `none` is configured, all server hosts
   # and certificates will be accepted. In this mode, SSL based connections are
   # susceptible to man-in-the-middle attacks. Use only for testing. Default is
   # `full`.
-  #ssl.verification_mode: full
+  ssl.verification_mode: full
 
   # List of supported/valid TLS versions. By default all TLS versions 1.0 up to
   # 1.2 are enabled.
-  #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
+  ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
 
   # Optional SSL configuration options. SSL is off by default.
   # List of root certificates for HTTPS server verifications
-  #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
+  ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
   # Certificate for SSL client authentication
-  #ssl.certificate: "/etc/pki/client/cert.pem"
+  ssl.certificate: "/etc/pki/client/cert.pem"
 
   # Client Certificate Key
-  #ssl.key: "/etc/pki/client/cert.key"
+  ssl.key: "/etc/pki/client/cert.key"
 
   # Optional passphrase for decrypting the Certificate Key.
-  #ssl.key_passphrase: ''
+  ssl.key_passphrase: ''
 
   # Configure cipher suites to be used for SSL connections
-  #ssl.cipher_suites: []
+  ssl.cipher_suites: []
 
   # Configure curve types for ECDHE based cipher suites
-  #ssl.curve_types: []
+  ssl.curve_types: []
 
 #------------------------------- Kafka output ----------------------------------
-#output.kafka:
+output.kafka:
   # Boolean flag to enable or disable the output module.
-  #enabled: true
+  enabled: false
 
   # The list of Kafka broker addresses from where to fetch the cluster metadata.
   # The cluster metadata contain the actual Kafka brokers events are published
   # to.
-  #hosts: ["localhost:9092"]
+  hosts: ["localhost:9092"]
 
   # The Kafka topic used for produced events. The setting can be a format string
   # using any event field. To set the topic from document type use `%{[type]}`.
-  #topic: beats
+  topic: beats
 
   # The Kafka event key setting. Use format string to create unique event key.
   # By default no event key will be generated.
-  #key: ''
+  key: ''
 
   # The Kafka event partitioning strategy. Default hashing strategy is `hash`
   # using the `output.kafka.key` setting or randomly distributes events if
   # `output.kafka.key` is not configured.
-  #partition.hash:
+  partition.hash:
     # If enabled, events will only be published to partitions with reachable
     # leaders. Default is false.
-    #reachable_only: false
+    reachable_only: false
 
     # Configure alternative event field names used to compute the hash value.
     # If empty `output.kafka.key` setting will be used.
     # Default value is empty list.
-    #hash: []
+    hash: []
 
   # Authentication details. Password is required if username is set.
-  #username: ''
-  #password: ''
+  username: ''
+  password: ''
 
   # Kafka version filebeat is assumed to run against. Defaults to the oldest
   # supported stable version (currently version 0.8.2.0)
-  #version: 0.8.2
+  version: 0.8.2
 
   # Metadata update configuration. Metadata do contain leader information
   # deciding which broker to use when publishing.
-  #metadata:
+  metadata:
     # Max metadata request retry attempts when cluster is in middle of leader
     # election. Defaults to 3 retries.
-    #retry.max: 3
+    retry.max: 3
 
     # Waiting time between retries during leader elections. Default is 250ms.
-    #retry.backoff: 250ms
+    retry.backoff: 250ms
 
     # Refresh metadata interval. Defaults to every 10 minutes.
-    #refresh_frequency: 10m
+    refresh_frequency: 10m
 
   # The number of concurrent load-balanced Kafka output workers.
-  #worker: 1
+  worker: 1
 
   # The number of times to retry publishing an event after a publishing failure.
   # After the specified number of retries, the events are typically dropped.
   # Some Beats, such as Filebeat, ignore the max_retries setting and retry until
   # all events are published.  Set max_retries to a value less than 0 to retry
   # until all events are published. The default is 3.
-  #max_retries: 3
+  max_retries: 3
 
   # The maximum number of events to bulk in a single Kafka request. The default
   # is 2048.
-  #bulk_max_size: 2048
+  bulk_max_size: 2048
 
   # The number of seconds to wait for responses from the Kafka brokers before
   # timing out. The default is 30s.
-  #timeout: 30s
+  timeout: 30s
 
   # The maximum duration a broker will wait for number of required ACKs. The
   # default is 10s.
-  #broker_timeout: 10s
+  broker_timeout: 10s
 
   # The number of messages buffered for each Kafka broker. The default is 256.
-  #channel_buffer_size: 256
+  channel_buffer_size: 256
 
   # The keep-alive period for an active network connection. If 0s, keep-alives
   # are disabled. The default is 0 seconds.
-  #keep_alive: 0
+  keep_alive: 0
 
   # Sets the output compression codec. Must be one of none, snappy and gzip. The
   # default is gzip.
-  #compression: gzip
+  compression: gzip
 
   # The maximum permitted size of JSON-encoded messages. Bigger messages will be
   # dropped. The default value is 1000000 (bytes). This value should be equal to
   # or less than the broker's message.max.bytes.
-  #max_message_bytes: 1000000
+  max_message_bytes: 1000000
 
   # The ACK reliability level required from broker. 0=no response, 1=wait for
   # local commit, -1=wait for all replicas to commit. The default is 1.  Note:
   # If set to 0, no ACKs are returned by Kafka. Messages might be lost silently
   # on error.
-  #required_acks: 1
+  required_acks: 1
 
   # The number of seconds to wait for new events between two producer API calls.
-  #flush_interval: 1s
+  flush_interval: 1s
 
   # The configurable ClientID used for logging, debugging, and auditing
   # purposes.  The default is "beats".
-  #client_id: beats
+  client_id: beats
 
   # Enable SSL support. SSL is automatically enabled, if any SSL setting is set.
-  #ssl.enabled: true
+  ssl.enabled: false
 
   # Optional SSL configuration options. SSL is off by default.
   # List of root certificates for HTTPS server verifications
-  #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
+  ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
   # Configure SSL verification mode. If `none` is configured, all server hosts
   # and certificates will be accepted. In this mode, SSL based connections are
   # susceptible to man-in-the-middle attacks. Use only for testing. Default is
   # `full`.
-  #ssl.verification_mode: full
+  ssl.verification_mode: full
 
   # List of supported/valid TLS versions. By default all TLS versions 1.0 up to
   # 1.2 are enabled.
-  #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
+  ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
 
   # Certificate for SSL client authentication
-  #ssl.certificate: "/etc/pki/client/cert.pem"
+  ssl.certificate: "/etc/pki/client/cert.pem"
 
   # Client Certificate Key
-  #ssl.key: "/etc/pki/client/cert.key"
+  ssl.key: "/etc/pki/client/cert.key"
 
   # Optional passphrase for decrypting the Certificate Key.
-  #ssl.key_passphrase: ''
+  ssl.key_passphrase: ''
 
   # Configure cipher suites to be used for SSL connections
-  #ssl.cipher_suites: []
+  ssl.cipher_suites: []
 
   # Configure curve types for ECDHE based cipher suites
-  #ssl.curve_types: []
+  ssl.curve_types: []
 
 #------------------------------- Redis output ----------------------------------
-#output.redis:
+output.redis:
   # Boolean flag to enable or disable the output module.
-  #enabled: true
+  enabled: false
 
   # The list of Redis servers to connect to. If load balancing is enabled, the
   # events are distributed to the servers in the list. If one server becomes
   # unreachable, the events are distributed to the reachable servers only.
-  #hosts: ["localhost:6379"]
+  hosts: ["localhost:6379"]
 
   # The Redis port to use if hosts does not contain a port number. The default
   # is 6379.
-  #port: 6379
+  port: 6379
 
   # The name of the Redis list or channel the events are published to. The
   # default is filebeat.
-  #key: filebeat
+  key: filebeat
 
   # The password to authenticate with. The default is no authentication.
-  #password:
+  password:
 
   # The Redis database number where the events are published. The default is 0.
-  #db: 0
+  db: 0
 
   # The Redis data type to use for publishing events. If the data type is list,
   # the Redis RPUSH command is used. If the data type is channel, the Redis
   # PUBLISH command is used. The default value is list.
-  #datatype: list
+  datatype: list
 
   # The number of workers to use for each host configured to publish events to
   # Redis. Use this setting along with the loadbalance option. For example, if
   # you have 2 hosts and 3 workers, in total 6 workers are started (3 for each
   # host).
-  #worker: 1
+  worker: 1
 
   # If set to true and multiple hosts or workers are configured, the output
   # plugin load balances published events onto all Redis hosts. If set to false,
   # the output plugin sends all events to only one host (determined at random)
   # and will switch to another host if the currently selected one becomes
   # unreachable. The default value is true.
-  #loadbalance: true
+  loadbalance: true
 
   # The Redis connection timeout in seconds. The default is 5 seconds.
-  #timeout: 5s
+  timeout: 5s
 
   # The number of times to retry publishing an event after a publishing failure.
   # After the specified number of retries, the events are typically dropped.
   # Some Beats, such as Filebeat, ignore the max_retries setting and retry until
   # all events are published. Set max_retries to a value less than 0 to retry
   # until all events are published. The default is 3.
-  #max_retries: 3
+  max_retries: 3
 
   # The maximum number of events to bulk in a single Redis request or pipeline.
   # The default is 2048.
-  #bulk_max_size: 2048
+  bulk_max_size: 2048
 
   # The URL of the SOCKS5 proxy to use when connecting to the Redis servers. The
   # value must be a URL with a scheme of socks5://.
-  #proxy_url:
+  proxy_url:
 
   # This option determines whether Redis hostnames are resolved locally when
   # using a proxy. The default value is false, which means that name resolution
   # occurs on the proxy server.
-  #proxy_use_local_resolver: false
+  proxy_use_local_resolver: false
 
   # Enable SSL support. SSL is automatically enabled, if any SSL setting is set.
-  #ssl.enabled: true
+  ssl.enabled: false
 
   # Configure SSL verification mode. If `none` is configured, all server hosts
   # and certificates will be accepted. In this mode, SSL based connections are
   # susceptible to man-in-the-middle attacks. Use only for testing. Default is
   # `full`.
-  #ssl.verification_mode: full
+  ssl.verification_mode: full
 
   # List of supported/valid TLS versions. By default all TLS versions 1.0 up to
   # 1.2 are enabled.
-  #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
+  ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
 
   # Optional SSL configuration options. SSL is off by default.
   # List of root certificates for HTTPS server verifications
-  #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
+  ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
   # Certificate for SSL client authentication
-  #ssl.certificate: "/etc/pki/client/cert.pem"
+  ssl.certificate: "/etc/pki/client/cert.pem"
 
   # Client Certificate Key
-  #ssl.key: "/etc/pki/client/cert.key"
+  ssl.key: "/etc/pki/client/cert.key"
 
   # Optional passphrase for decrypting the Certificate Key.
-  #ssl.key_passphrase: ''
+  ssl.key_passphrase: ''
 
   # Configure cipher suites to be used for SSL connections
-  #ssl.cipher_suites: []
+  ssl.cipher_suites: []
 
   # Configure curve types for ECDHE based cipher suites
-  #ssl.curve_types: []
+  ssl.curve_types: []
 
 
 #------------------------------- File output -----------------------------------
-#output.file:
+output.file:
   # Boolean flag to enable or disable the output module.
-  #enabled: true
+  enabled: false
 
   # Path to the directory where to save the generated files. The option is
   # mandatory.
-  #path: "/tmp/filebeat"
+  path: "/tmp/filebeat"
 
   # Name of the generated files. The default is `filebeat` and it generates
   # files: `filebeat`, `filebeat.1`, `filebeat.2`, etc.
-  #filename: filebeat
+  filename: filebeat
 
   # Maximum size in kilobytes of each file. When this size is reached, and on
   # every filebeat restart, the files are rotated. The default value is 10240
   # kB.
-  #rotate_every_kb: 10000
+  rotate_every_kb: 10000
 
   # Maximum number of files under path. When this number of files is reached,
   # the oldest file is deleted and the rest are shifted from last to first. The
   # default is 7 files.
-  #number_of_files: 7
+  number_of_files: 7
 
 
 #----------------------------- Console output ---------------------------------
-#output.console:
+output.console:
   # Boolean flag to enable or disable the output module.
-  #enabled: true
+  enabled: false
 
   # Pretty print json event
-  #pretty: false
+  pretty: false
 
 #================================= Paths ======================================
 
@@ -760,24 +761,24 @@ output.elasticsearch:
 # distribution (for example, the sample dashboards).
 # If not set by a CLI flag or in the configuration file, the default for the
 # home path is the location of the binary.
-#path.home:
+path.home:
 
 # The configuration path for the filebeat installation. This is the default
 # base path for configuration files, including the main YAML configuration file
 # and the Elasticsearch template file. If not set by a CLI flag or in the
 # configuration file, the default for the configuration path is the home path.
-#path.config: ${path.home}
+path.config: ${path.home}
 
 # The data path for the filebeat installation. This is the default base path
 # for all the files in which filebeat needs to store its data. If not set by a
 # CLI flag or in the configuration file, the default for the data path is a data
 # subdirectory inside the home path.
-#path.data: ${path.home}/data
+path.data: ${path.home}/data
 
 # The logs path for a filebeat installation. This is the default location for
 # the Beat's log files. If not set by a CLI flag or in the configuration file,
 # the default for the logs path is a logs subdirectory inside the home path.
-#path.logs: ${path.home}/logs
+path.logs: ${path.home}/logs
 
 #================================ Logging ======================================
 # There are three options for the log output: syslog, file, stderr.
@@ -786,24 +787,24 @@ output.elasticsearch:
 
 # Sets log level. The default log level is info.
 # Available log levels are: critical, error, warning, info, debug
-#logging.level: info
+logging.level: info
 
 # Enable debug output for selected components. To enable all selectors use ["*"]
 # Other available selectors are "beat", "publish", "service"
 # Multiple selectors can be chained.
-#logging.selectors: [ ]
+logging.selectors: [ ]
 
 # Send all logging output to syslog. The default is false.
-#logging.to_syslog: true
+logging.to_syslog: false
 
 # If enabled, filebeat periodically logs its internal metrics that have changed
 # in the last period. For each metric that changed, the delta from the value at
 # the beginning of the period is logged. Also, the total values for
 # all non-zero internal metrics are logged on shutdown. The default is true.
-#logging.metrics.enabled: true
+logging.metrics.enabled: true
 
 # The period after which to log the internal metrics. The default is 30s.
-#logging.metrics.period: 30s
+logging.metrics.period: 30s
 
 # Logging to rotating files files. Set logging.to_files to false to disable logging to
 # files.
@@ -811,15 +812,15 @@ logging.to_files: true
 logging.files:
   # Configure the path where the logs are written. The default is the logs directory
   # under the home path (the binary location).
-  #path: /var/log/filebeat
+  path: /var/log/filebeat
 
   # The name of the files where the logs are written to.
-  #name: filebeat
+  name: filebeat
 
   # Configure log file size limit. If limit is reached, log file will be
   # automatically rotated
-  #rotateeverybytes: 10485760 # = 10MB
+  rotateeverybytes: 10485760 # = 10MB
 
   # Number of rotated log files to keep. Oldest files will be deleted first.
-  #keepfiles: 7
+  keepfiles: 7
 

--- a/heartbeat/heartbeat.full.yml
+++ b/heartbeat/heartbeat.full.yml
@@ -195,7 +195,7 @@ heartbeat.scheduler:
 # The name of the shipper that publishes the network data. It can be used to group
 # all the transactions sent by a single shipper in the web interface.
 # If this options is not defined, the hostname is used.
-#name:
+name:
 
 # The tags of the shipper are included in their own field with each
 # transaction published. Tags make it easy to group servers by different
@@ -211,14 +211,14 @@ heartbeat.scheduler:
 # If this option is set to true, the custom fields are stored as top-level
 # fields in the output document instead of being grouped under a fields
 # sub-dictionary. Default is false.
-#fields_under_root: false
+fields_under_root: false
 
 # Internal queue size for single events in processing pipeline
-#queue_size: 1000
+queue_size: 1000
 
 # The internal queue size for bulk events in the processing pipeline.
 # Do not modify this value.
-#bulk_queue_size: 0
+bulk_queue_size: 0
 
 # Sets the maximum number of CPUs that can be executing simultaneously. The
 # default is the number of logical CPUs available in the system.
@@ -269,7 +269,7 @@ heartbeat.scheduler:
 #-------------------------- Elasticsearch output -------------------------------
 output.elasticsearch:
   # Boolean flag to enable or disable the output module.
-  #enabled: true
+  enabled: true
 
   # Array of hosts to connect to.
   # Scheme and port can be left out and will be set to the default (http and 9200)
@@ -278,7 +278,7 @@ output.elasticsearch:
   hosts: ["localhost:9200"]
 
   # Set gzip compression level.
-  #compression_level: 0
+  compression_level: 0
 
   # Optional protocol and basic auth credentials.
   #protocol: "https"
@@ -291,422 +291,422 @@ output.elasticsearch:
     #param2: value2
 
   # Number of workers per Elasticsearch host.
-  #worker: 1
+  worker: 1
 
   # Optional index name. The default is "heartbeat" plus date
   # and generates [heartbeat-]YYYY.MM.DD keys.
-  #index: "heartbeat-%{+yyyy.MM.dd}"
+  index: "heartbeat-%{+yyyy.MM.dd}"
 
   # Optional ingest node pipeline. By default no pipeline will be used.
-  #pipeline: ""
+  pipeline: ""
 
-  # Optional HTTP Path
-  #path: "/elasticsearch"
+  # Optional HTTP Path. Example: /elasticsearch
+  path:
 
-  # Proxy server url
-  #proxy_url: http://proxy:3128
+  # Proxy server url. Example: http://proxy:3128
+  proxy_url:
 
   # The number of times a particular Elasticsearch index operation is attempted. If
   # the indexing operation doesn't succeed after this many retries, the events are
   # dropped. The default is 3.
-  #max_retries: 3
+  max_retries: 3
 
   # The maximum number of events to bulk in a single Elasticsearch bulk API index request.
   # The default is 50.
-  #bulk_max_size: 50
+  bulk_max_size: 50
 
   # Configure http request timeout before failing an request to Elasticsearch.
-  #timeout: 90
+  timeout: 90
 
   # The number of seconds to wait for new events between two bulk API index requests.
   # If `bulk_max_size` is reached before this interval expires, addition bulk index
   # requests are made.
-  #flush_interval: 1s
+  flush_interval: 1s
 
   # A template is used to set the mapping in Elasticsearch
   # By default template loading is enabled and the template is loaded.
   # These settings can be adjusted to load your own template or overwrite existing ones.
 
   # Set to false to disable template loading.
-  #template.enabled: true
+  template.enabled: true
 
   # Template name. By default the template name is heartbeat.
-  #template.name: "heartbeat"
+  template.name: "heartbeat"
 
   # Path to template file
-  #template.path: "${path.config}/heartbeat.template.json"
+  template.path: "${path.config}/heartbeat.template.json"
 
   # Overwrite existing template
-  #template.overwrite: false
+  #emplate.overwrite: false
 
   # If set to true, heartbeat checks the Elasticsearch version at connect time, and if it
   # is 2.x, it loads the file specified by the template.versions.2x.path setting. The
   # default is true.
-  #template.versions.2x.enabled: true
+  template.versions.2x.enabled: true
 
   # Path to the Elasticsearch 2.x version of the template file.
-  #template.versions.2x.path: "${path.config}/heartbeat.template-es2x.json"
+  template.versions.2x.path: "${path.config}/heartbeat.template-es2x.json"
 
   # Use SSL settings for HTTPS. Default is true.
-  #ssl.enabled: true
+  ssl.enabled: false
 
   # Configure SSL verification mode. If `none` is configured, all server hosts
   # and certificates will be accepted. In this mode, SSL based connections are
   # susceptible to man-in-the-middle attacks. Use only for testing. Default is
   # `full`.
-  #ssl.verification_mode: full
+  ssl.verification_mode: full
 
   # List of supported/valid TLS versions. By default all TLS versions 1.0 up to
   # 1.2 are enabled.
-  #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
+  ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
 
-  # SSL configuration. By default is off.
+  # SSL configuration. By default is off. TODO
   # List of root certificates for HTTPS server verifications
-  #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
+  ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
   # Certificate for SSL client authentication
-  #ssl.certificate: "/etc/pki/client/cert.pem"
+  ssl.certificate: "/etc/pki/client/cert.pem"
 
   # Client Certificate Key
-  #ssl.key: "/etc/pki/client/cert.key"
+  ssl.key: "/etc/pki/client/cert.key"
 
   # Optional passphrase for decrypting the Certificate Key.
-  #ssl.key_passphrase: ''
+  ssl.key_passphrase: ''
 
   # Configure cipher suites to be used for SSL connections
-  #ssl.cipher_suites: []
+  ssl.cipher_suites: []
 
   # Configure curve types for ECDHE based cipher suites
-  #ssl.curve_types: []
+  ssl.curve_types: []
 
 
 #----------------------------- Logstash output ---------------------------------
-#output.logstash:
+output.logstash:
   # Boolean flag to enable or disable the output module.
-  #enabled: true
+  enabled: false
 
   # The Logstash hosts
-  #hosts: ["localhost:5044"]
+  hosts: ["localhost:5044"]
 
   # Number of workers per Logstash host.
-  #worker: 1
+  worker: 1
 
   # Set gzip compression level.
-  #compression_level: 3
+  compression_level: 3
 
   # Optional load balance the events between the Logstash hosts
-  #loadbalance: true
+  loadbalance: true
 
   # Number of batches to be send asynchronously to logstash while processing
   # new batches.
-  #pipelining: 0
+  pipelining: 0
 
   # Optional index name. The default index name is set to name of the beat
   # in all lowercase.
-  #index: 'heartbeat'
+  index: 'heartbeat'
 
   # SOCKS5 proxy server URL
-  #proxy_url: socks5://user:password@socks5-server:2233
+  proxy_url: socks5://user:password@socks5-server:2233
 
   # Resolve names locally when using a proxy server. Defaults to false.
-  #proxy_use_local_resolver: false
+  proxy_use_local_resolver: false
 
   # Enable SSL support. SSL is automatically enabled, if any SSL setting is set.
-  #ssl.enabled: true
+  ssl.enabled: false
 
   # Configure SSL verification mode. If `none` is configured, all server hosts
   # and certificates will be accepted. In this mode, SSL based connections are
   # susceptible to man-in-the-middle attacks. Use only for testing. Default is
   # `full`.
-  #ssl.verification_mode: full
+  ssl.verification_mode: full
 
   # List of supported/valid TLS versions. By default all TLS versions 1.0 up to
   # 1.2 are enabled.
-  #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
+  ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
 
   # Optional SSL configuration options. SSL is off by default.
   # List of root certificates for HTTPS server verifications
-  #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
+  ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
   # Certificate for SSL client authentication
-  #ssl.certificate: "/etc/pki/client/cert.pem"
+  ssl.certificate: "/etc/pki/client/cert.pem"
 
   # Client Certificate Key
-  #ssl.key: "/etc/pki/client/cert.key"
+  ssl.key: "/etc/pki/client/cert.key"
 
   # Optional passphrase for decrypting the Certificate Key.
-  #ssl.key_passphrase: ''
+  ssl.key_passphrase: ''
 
   # Configure cipher suites to be used for SSL connections
-  #ssl.cipher_suites: []
+  ssl.cipher_suites: []
 
   # Configure curve types for ECDHE based cipher suites
-  #ssl.curve_types: []
+  ssl.curve_types: []
 
 #------------------------------- Kafka output ----------------------------------
-#output.kafka:
+output.kafka:
   # Boolean flag to enable or disable the output module.
-  #enabled: true
+  enabled: false
 
   # The list of Kafka broker addresses from where to fetch the cluster metadata.
   # The cluster metadata contain the actual Kafka brokers events are published
   # to.
-  #hosts: ["localhost:9092"]
+  hosts: ["localhost:9092"]
 
   # The Kafka topic used for produced events. The setting can be a format string
   # using any event field. To set the topic from document type use `%{[type]}`.
-  #topic: beats
+  topic: beats
 
   # The Kafka event key setting. Use format string to create unique event key.
   # By default no event key will be generated.
-  #key: ''
+  key: ''
 
   # The Kafka event partitioning strategy. Default hashing strategy is `hash`
   # using the `output.kafka.key` setting or randomly distributes events if
   # `output.kafka.key` is not configured.
-  #partition.hash:
+  partition.hash:
     # If enabled, events will only be published to partitions with reachable
     # leaders. Default is false.
-    #reachable_only: false
+    reachable_only: false
 
     # Configure alternative event field names used to compute the hash value.
     # If empty `output.kafka.key` setting will be used.
     # Default value is empty list.
-    #hash: []
+    hash: []
 
   # Authentication details. Password is required if username is set.
-  #username: ''
-  #password: ''
+  username: ''
+  password: ''
 
   # Kafka version heartbeat is assumed to run against. Defaults to the oldest
   # supported stable version (currently version 0.8.2.0)
-  #version: 0.8.2
+  version: 0.8.2
 
   # Metadata update configuration. Metadata do contain leader information
   # deciding which broker to use when publishing.
-  #metadata:
+  metadata:
     # Max metadata request retry attempts when cluster is in middle of leader
     # election. Defaults to 3 retries.
-    #retry.max: 3
+    retry.max: 3
 
     # Waiting time between retries during leader elections. Default is 250ms.
-    #retry.backoff: 250ms
+    retry.backoff: 250ms
 
     # Refresh metadata interval. Defaults to every 10 minutes.
-    #refresh_frequency: 10m
+    refresh_frequency: 10m
 
   # The number of concurrent load-balanced Kafka output workers.
-  #worker: 1
+  worker: 1
 
   # The number of times to retry publishing an event after a publishing failure.
   # After the specified number of retries, the events are typically dropped.
   # Some Beats, such as Filebeat, ignore the max_retries setting and retry until
   # all events are published.  Set max_retries to a value less than 0 to retry
   # until all events are published. The default is 3.
-  #max_retries: 3
+  max_retries: 3
 
   # The maximum number of events to bulk in a single Kafka request. The default
   # is 2048.
-  #bulk_max_size: 2048
+  bulk_max_size: 2048
 
   # The number of seconds to wait for responses from the Kafka brokers before
   # timing out. The default is 30s.
-  #timeout: 30s
+  timeout: 30s
 
   # The maximum duration a broker will wait for number of required ACKs. The
   # default is 10s.
-  #broker_timeout: 10s
+  broker_timeout: 10s
 
   # The number of messages buffered for each Kafka broker. The default is 256.
-  #channel_buffer_size: 256
+  channel_buffer_size: 256
 
   # The keep-alive period for an active network connection. If 0s, keep-alives
   # are disabled. The default is 0 seconds.
-  #keep_alive: 0
+  keep_alive: 0
 
   # Sets the output compression codec. Must be one of none, snappy and gzip. The
   # default is gzip.
-  #compression: gzip
+  compression: gzip
 
   # The maximum permitted size of JSON-encoded messages. Bigger messages will be
   # dropped. The default value is 1000000 (bytes). This value should be equal to
   # or less than the broker's message.max.bytes.
-  #max_message_bytes: 1000000
+  max_message_bytes: 1000000
 
   # The ACK reliability level required from broker. 0=no response, 1=wait for
   # local commit, -1=wait for all replicas to commit. The default is 1.  Note:
   # If set to 0, no ACKs are returned by Kafka. Messages might be lost silently
   # on error.
-  #required_acks: 1
+  required_acks: 1
 
   # The number of seconds to wait for new events between two producer API calls.
-  #flush_interval: 1s
+  flush_interval: 1s
 
   # The configurable ClientID used for logging, debugging, and auditing
   # purposes.  The default is "beats".
-  #client_id: beats
+  client_id: beats
 
   # Enable SSL support. SSL is automatically enabled, if any SSL setting is set.
-  #ssl.enabled: true
+  ssl.enabled: false
 
   # Optional SSL configuration options. SSL is off by default.
   # List of root certificates for HTTPS server verifications
-  #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
+  ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
   # Configure SSL verification mode. If `none` is configured, all server hosts
   # and certificates will be accepted. In this mode, SSL based connections are
   # susceptible to man-in-the-middle attacks. Use only for testing. Default is
   # `full`.
-  #ssl.verification_mode: full
+  ssl.verification_mode: full
 
   # List of supported/valid TLS versions. By default all TLS versions 1.0 up to
   # 1.2 are enabled.
-  #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
+  ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
 
   # Certificate for SSL client authentication
-  #ssl.certificate: "/etc/pki/client/cert.pem"
+  ssl.certificate: "/etc/pki/client/cert.pem"
 
   # Client Certificate Key
-  #ssl.key: "/etc/pki/client/cert.key"
+  ssl.key: "/etc/pki/client/cert.key"
 
   # Optional passphrase for decrypting the Certificate Key.
-  #ssl.key_passphrase: ''
+  ssl.key_passphrase: ''
 
   # Configure cipher suites to be used for SSL connections
-  #ssl.cipher_suites: []
+  ssl.cipher_suites: []
 
   # Configure curve types for ECDHE based cipher suites
-  #ssl.curve_types: []
+  ssl.curve_types: []
 
 #------------------------------- Redis output ----------------------------------
-#output.redis:
+output.redis:
   # Boolean flag to enable or disable the output module.
-  #enabled: true
+  enabled: false
 
   # The list of Redis servers to connect to. If load balancing is enabled, the
   # events are distributed to the servers in the list. If one server becomes
   # unreachable, the events are distributed to the reachable servers only.
-  #hosts: ["localhost:6379"]
+  hosts: ["localhost:6379"]
 
   # The Redis port to use if hosts does not contain a port number. The default
   # is 6379.
-  #port: 6379
+  port: 6379
 
   # The name of the Redis list or channel the events are published to. The
   # default is heartbeat.
-  #key: heartbeat
+  key: heartbeat
 
   # The password to authenticate with. The default is no authentication.
-  #password:
+  password:
 
   # The Redis database number where the events are published. The default is 0.
-  #db: 0
+  db: 0
 
   # The Redis data type to use for publishing events. If the data type is list,
   # the Redis RPUSH command is used. If the data type is channel, the Redis
   # PUBLISH command is used. The default value is list.
-  #datatype: list
+  datatype: list
 
   # The number of workers to use for each host configured to publish events to
   # Redis. Use this setting along with the loadbalance option. For example, if
   # you have 2 hosts and 3 workers, in total 6 workers are started (3 for each
   # host).
-  #worker: 1
+  worker: 1
 
   # If set to true and multiple hosts or workers are configured, the output
   # plugin load balances published events onto all Redis hosts. If set to false,
   # the output plugin sends all events to only one host (determined at random)
   # and will switch to another host if the currently selected one becomes
   # unreachable. The default value is true.
-  #loadbalance: true
+  loadbalance: true
 
   # The Redis connection timeout in seconds. The default is 5 seconds.
-  #timeout: 5s
+  timeout: 5s
 
   # The number of times to retry publishing an event after a publishing failure.
   # After the specified number of retries, the events are typically dropped.
   # Some Beats, such as Filebeat, ignore the max_retries setting and retry until
   # all events are published. Set max_retries to a value less than 0 to retry
   # until all events are published. The default is 3.
-  #max_retries: 3
+  max_retries: 3
 
   # The maximum number of events to bulk in a single Redis request or pipeline.
   # The default is 2048.
-  #bulk_max_size: 2048
+  bulk_max_size: 2048
 
   # The URL of the SOCKS5 proxy to use when connecting to the Redis servers. The
   # value must be a URL with a scheme of socks5://.
-  #proxy_url:
+  proxy_url:
 
   # This option determines whether Redis hostnames are resolved locally when
   # using a proxy. The default value is false, which means that name resolution
   # occurs on the proxy server.
-  #proxy_use_local_resolver: false
+  proxy_use_local_resolver: false
 
   # Enable SSL support. SSL is automatically enabled, if any SSL setting is set.
-  #ssl.enabled: true
+  ssl.enabled: false
 
   # Configure SSL verification mode. If `none` is configured, all server hosts
   # and certificates will be accepted. In this mode, SSL based connections are
   # susceptible to man-in-the-middle attacks. Use only for testing. Default is
   # `full`.
-  #ssl.verification_mode: full
+  ssl.verification_mode: full
 
   # List of supported/valid TLS versions. By default all TLS versions 1.0 up to
   # 1.2 are enabled.
-  #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
+  ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
 
   # Optional SSL configuration options. SSL is off by default.
   # List of root certificates for HTTPS server verifications
-  #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
+  ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
   # Certificate for SSL client authentication
-  #ssl.certificate: "/etc/pki/client/cert.pem"
+  ssl.certificate: "/etc/pki/client/cert.pem"
 
   # Client Certificate Key
-  #ssl.key: "/etc/pki/client/cert.key"
+  ssl.key: "/etc/pki/client/cert.key"
 
   # Optional passphrase for decrypting the Certificate Key.
-  #ssl.key_passphrase: ''
+  ssl.key_passphrase: ''
 
   # Configure cipher suites to be used for SSL connections
-  #ssl.cipher_suites: []
+  ssl.cipher_suites: []
 
   # Configure curve types for ECDHE based cipher suites
-  #ssl.curve_types: []
+  ssl.curve_types: []
 
 
 #------------------------------- File output -----------------------------------
-#output.file:
+output.file:
   # Boolean flag to enable or disable the output module.
-  #enabled: true
+  enabled: false
 
   # Path to the directory where to save the generated files. The option is
   # mandatory.
-  #path: "/tmp/heartbeat"
+  path: "/tmp/heartbeat"
 
   # Name of the generated files. The default is `heartbeat` and it generates
   # files: `heartbeat`, `heartbeat.1`, `heartbeat.2`, etc.
-  #filename: heartbeat
+  filename: heartbeat
 
   # Maximum size in kilobytes of each file. When this size is reached, and on
   # every heartbeat restart, the files are rotated. The default value is 10240
   # kB.
-  #rotate_every_kb: 10000
+  rotate_every_kb: 10000
 
   # Maximum number of files under path. When this number of files is reached,
   # the oldest file is deleted and the rest are shifted from last to first. The
   # default is 7 files.
-  #number_of_files: 7
+  number_of_files: 7
 
 
 #----------------------------- Console output ---------------------------------
-#output.console:
+output.console:
   # Boolean flag to enable or disable the output module.
-  #enabled: true
+  enabled: false
 
   # Pretty print json event
-  #pretty: false
+  pretty: false
 
 #================================= Paths ======================================
 
@@ -715,24 +715,24 @@ output.elasticsearch:
 # distribution (for example, the sample dashboards).
 # If not set by a CLI flag or in the configuration file, the default for the
 # home path is the location of the binary.
-#path.home:
+path.home:
 
 # The configuration path for the heartbeat installation. This is the default
 # base path for configuration files, including the main YAML configuration file
 # and the Elasticsearch template file. If not set by a CLI flag or in the
 # configuration file, the default for the configuration path is the home path.
-#path.config: ${path.home}
+path.config: ${path.home}
 
 # The data path for the heartbeat installation. This is the default base path
 # for all the files in which heartbeat needs to store its data. If not set by a
 # CLI flag or in the configuration file, the default for the data path is a data
 # subdirectory inside the home path.
-#path.data: ${path.home}/data
+path.data: ${path.home}/data
 
 # The logs path for a heartbeat installation. This is the default location for
 # the Beat's log files. If not set by a CLI flag or in the configuration file,
 # the default for the logs path is a logs subdirectory inside the home path.
-#path.logs: ${path.home}/logs
+path.logs: ${path.home}/logs
 
 #================================ Logging ======================================
 # There are three options for the log output: syslog, file, stderr.
@@ -741,24 +741,24 @@ output.elasticsearch:
 
 # Sets log level. The default log level is info.
 # Available log levels are: critical, error, warning, info, debug
-#logging.level: info
+logging.level: info
 
 # Enable debug output for selected components. To enable all selectors use ["*"]
 # Other available selectors are "beat", "publish", "service"
 # Multiple selectors can be chained.
-#logging.selectors: [ ]
+logging.selectors: [ ]
 
 # Send all logging output to syslog. The default is false.
-#logging.to_syslog: true
+logging.to_syslog: false
 
 # If enabled, heartbeat periodically logs its internal metrics that have changed
 # in the last period. For each metric that changed, the delta from the value at
 # the beginning of the period is logged. Also, the total values for
 # all non-zero internal metrics are logged on shutdown. The default is true.
-#logging.metrics.enabled: true
+logging.metrics.enabled: true
 
 # The period after which to log the internal metrics. The default is 30s.
-#logging.metrics.period: 30s
+logging.metrics.period: 30s
 
 # Logging to rotating files files. Set logging.to_files to false to disable logging to
 # files.
@@ -766,15 +766,15 @@ logging.to_files: true
 logging.files:
   # Configure the path where the logs are written. The default is the logs directory
   # under the home path (the binary location).
-  #path: /var/log/heartbeat
+  path: /var/log/heartbeat
 
   # The name of the files where the logs are written to.
-  #name: heartbeat
+  name: heartbeat
 
   # Configure log file size limit. If limit is reached, log file will be
   # automatically rotated
-  #rotateeverybytes: 10485760 # = 10MB
+  rotateeverybytes: 10485760 # = 10MB
 
   # Number of rotated log files to keep. Oldest files will be deleted first.
-  #keepfiles: 7
+  keepfiles: 7
 

--- a/libbeat/_meta/config.full.yml
+++ b/libbeat/_meta/config.full.yml
@@ -4,7 +4,7 @@
 # The name of the shipper that publishes the network data. It can be used to group
 # all the transactions sent by a single shipper in the web interface.
 # If this options is not defined, the hostname is used.
-#name:
+name:
 
 # The tags of the shipper are included in their own field with each
 # transaction published. Tags make it easy to group servers by different
@@ -20,14 +20,14 @@
 # If this option is set to true, the custom fields are stored as top-level
 # fields in the output document instead of being grouped under a fields
 # sub-dictionary. Default is false.
-#fields_under_root: false
+fields_under_root: false
 
 # Internal queue size for single events in processing pipeline
-#queue_size: 1000
+queue_size: 1000
 
 # The internal queue size for bulk events in the processing pipeline.
 # Do not modify this value.
-#bulk_queue_size: 0
+bulk_queue_size: 0
 
 # Sets the maximum number of CPUs that can be executing simultaneously. The
 # default is the number of logical CPUs available in the system.
@@ -78,7 +78,7 @@
 #-------------------------- Elasticsearch output -------------------------------
 output.elasticsearch:
   # Boolean flag to enable or disable the output module.
-  #enabled: true
+  enabled: true
 
   # Array of hosts to connect to.
   # Scheme and port can be left out and will be set to the default (http and 9200)
@@ -87,7 +87,7 @@ output.elasticsearch:
   hosts: ["localhost:9200"]
 
   # Set gzip compression level.
-  #compression_level: 0
+  compression_level: 0
 
   # Optional protocol and basic auth credentials.
   #protocol: "https"
@@ -100,422 +100,422 @@ output.elasticsearch:
     #param2: value2
 
   # Number of workers per Elasticsearch host.
-  #worker: 1
+  worker: 1
 
   # Optional index name. The default is "beatname" plus date
   # and generates [beatname-]YYYY.MM.DD keys.
-  #index: "beatname-%{+yyyy.MM.dd}"
+  index: "beatname-%{+yyyy.MM.dd}"
 
   # Optional ingest node pipeline. By default no pipeline will be used.
-  #pipeline: ""
+  pipeline: ""
 
-  # Optional HTTP Path
-  #path: "/elasticsearch"
+  # Optional HTTP Path. Example: /elasticsearch
+  path:
 
-  # Proxy server url
-  #proxy_url: http://proxy:3128
+  # Proxy server url. Example: http://proxy:3128
+  proxy_url:
 
   # The number of times a particular Elasticsearch index operation is attempted. If
   # the indexing operation doesn't succeed after this many retries, the events are
   # dropped. The default is 3.
-  #max_retries: 3
+  max_retries: 3
 
   # The maximum number of events to bulk in a single Elasticsearch bulk API index request.
   # The default is 50.
-  #bulk_max_size: 50
+  bulk_max_size: 50
 
   # Configure http request timeout before failing an request to Elasticsearch.
-  #timeout: 90
+  timeout: 90
 
   # The number of seconds to wait for new events between two bulk API index requests.
   # If `bulk_max_size` is reached before this interval expires, addition bulk index
   # requests are made.
-  #flush_interval: 1s
+  flush_interval: 1s
 
   # A template is used to set the mapping in Elasticsearch
   # By default template loading is enabled and the template is loaded.
   # These settings can be adjusted to load your own template or overwrite existing ones.
 
   # Set to false to disable template loading.
-  #template.enabled: true
+  template.enabled: true
 
   # Template name. By default the template name is beatname.
-  #template.name: "beatname"
+  template.name: "beatname"
 
   # Path to template file
-  #template.path: "${path.config}/beatname.template.json"
+  template.path: "${path.config}/beatname.template.json"
 
   # Overwrite existing template
-  #template.overwrite: false
+  #emplate.overwrite: false
 
   # If set to true, beatname checks the Elasticsearch version at connect time, and if it
   # is 2.x, it loads the file specified by the template.versions.2x.path setting. The
   # default is true.
-  #template.versions.2x.enabled: true
+  template.versions.2x.enabled: true
 
   # Path to the Elasticsearch 2.x version of the template file.
-  #template.versions.2x.path: "${path.config}/beatname.template-es2x.json"
+  template.versions.2x.path: "${path.config}/beatname.template-es2x.json"
 
   # Use SSL settings for HTTPS. Default is true.
-  #ssl.enabled: true
+  ssl.enabled: false
 
   # Configure SSL verification mode. If `none` is configured, all server hosts
   # and certificates will be accepted. In this mode, SSL based connections are
   # susceptible to man-in-the-middle attacks. Use only for testing. Default is
   # `full`.
-  #ssl.verification_mode: full
+  ssl.verification_mode: full
 
   # List of supported/valid TLS versions. By default all TLS versions 1.0 up to
   # 1.2 are enabled.
-  #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
+  ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
 
-  # SSL configuration. By default is off.
+  # SSL configuration. By default is off. TODO
   # List of root certificates for HTTPS server verifications
-  #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
+  ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
   # Certificate for SSL client authentication
-  #ssl.certificate: "/etc/pki/client/cert.pem"
+  ssl.certificate: "/etc/pki/client/cert.pem"
 
   # Client Certificate Key
-  #ssl.key: "/etc/pki/client/cert.key"
+  ssl.key: "/etc/pki/client/cert.key"
 
   # Optional passphrase for decrypting the Certificate Key.
-  #ssl.key_passphrase: ''
+  ssl.key_passphrase: ''
 
   # Configure cipher suites to be used for SSL connections
-  #ssl.cipher_suites: []
+  ssl.cipher_suites: []
 
   # Configure curve types for ECDHE based cipher suites
-  #ssl.curve_types: []
+  ssl.curve_types: []
 
 
 #----------------------------- Logstash output ---------------------------------
-#output.logstash:
+output.logstash:
   # Boolean flag to enable or disable the output module.
-  #enabled: true
+  enabled: false
 
   # The Logstash hosts
-  #hosts: ["localhost:5044"]
+  hosts: ["localhost:5044"]
 
   # Number of workers per Logstash host.
-  #worker: 1
+  worker: 1
 
   # Set gzip compression level.
-  #compression_level: 3
+  compression_level: 3
 
   # Optional load balance the events between the Logstash hosts
-  #loadbalance: true
+  loadbalance: true
 
   # Number of batches to be send asynchronously to logstash while processing
   # new batches.
-  #pipelining: 0
+  pipelining: 0
 
   # Optional index name. The default index name is set to name of the beat
   # in all lowercase.
-  #index: 'beatname'
+  index: 'beatname'
 
   # SOCKS5 proxy server URL
-  #proxy_url: socks5://user:password@socks5-server:2233
+  proxy_url: socks5://user:password@socks5-server:2233
 
   # Resolve names locally when using a proxy server. Defaults to false.
-  #proxy_use_local_resolver: false
+  proxy_use_local_resolver: false
 
   # Enable SSL support. SSL is automatically enabled, if any SSL setting is set.
-  #ssl.enabled: true
+  ssl.enabled: false
 
   # Configure SSL verification mode. If `none` is configured, all server hosts
   # and certificates will be accepted. In this mode, SSL based connections are
   # susceptible to man-in-the-middle attacks. Use only for testing. Default is
   # `full`.
-  #ssl.verification_mode: full
+  ssl.verification_mode: full
 
   # List of supported/valid TLS versions. By default all TLS versions 1.0 up to
   # 1.2 are enabled.
-  #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
+  ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
 
   # Optional SSL configuration options. SSL is off by default.
   # List of root certificates for HTTPS server verifications
-  #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
+  ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
   # Certificate for SSL client authentication
-  #ssl.certificate: "/etc/pki/client/cert.pem"
+  ssl.certificate: "/etc/pki/client/cert.pem"
 
   # Client Certificate Key
-  #ssl.key: "/etc/pki/client/cert.key"
+  ssl.key: "/etc/pki/client/cert.key"
 
   # Optional passphrase for decrypting the Certificate Key.
-  #ssl.key_passphrase: ''
+  ssl.key_passphrase: ''
 
   # Configure cipher suites to be used for SSL connections
-  #ssl.cipher_suites: []
+  ssl.cipher_suites: []
 
   # Configure curve types for ECDHE based cipher suites
-  #ssl.curve_types: []
+  ssl.curve_types: []
 
 #------------------------------- Kafka output ----------------------------------
-#output.kafka:
+output.kafka:
   # Boolean flag to enable or disable the output module.
-  #enabled: true
+  enabled: false
 
   # The list of Kafka broker addresses from where to fetch the cluster metadata.
   # The cluster metadata contain the actual Kafka brokers events are published
   # to.
-  #hosts: ["localhost:9092"]
+  hosts: ["localhost:9092"]
 
   # The Kafka topic used for produced events. The setting can be a format string
   # using any event field. To set the topic from document type use `%{[type]}`.
-  #topic: beats
+  topic: beats
 
   # The Kafka event key setting. Use format string to create unique event key.
   # By default no event key will be generated.
-  #key: ''
+  key: ''
 
   # The Kafka event partitioning strategy. Default hashing strategy is `hash`
   # using the `output.kafka.key` setting or randomly distributes events if
   # `output.kafka.key` is not configured.
-  #partition.hash:
+  partition.hash:
     # If enabled, events will only be published to partitions with reachable
     # leaders. Default is false.
-    #reachable_only: false
+    reachable_only: false
 
     # Configure alternative event field names used to compute the hash value.
     # If empty `output.kafka.key` setting will be used.
     # Default value is empty list.
-    #hash: []
+    hash: []
 
   # Authentication details. Password is required if username is set.
-  #username: ''
-  #password: ''
+  username: ''
+  password: ''
 
   # Kafka version beatname is assumed to run against. Defaults to the oldest
   # supported stable version (currently version 0.8.2.0)
-  #version: 0.8.2
+  version: 0.8.2
 
   # Metadata update configuration. Metadata do contain leader information
   # deciding which broker to use when publishing.
-  #metadata:
+  metadata:
     # Max metadata request retry attempts when cluster is in middle of leader
     # election. Defaults to 3 retries.
-    #retry.max: 3
+    retry.max: 3
 
     # Waiting time between retries during leader elections. Default is 250ms.
-    #retry.backoff: 250ms
+    retry.backoff: 250ms
 
     # Refresh metadata interval. Defaults to every 10 minutes.
-    #refresh_frequency: 10m
+    refresh_frequency: 10m
 
   # The number of concurrent load-balanced Kafka output workers.
-  #worker: 1
+  worker: 1
 
   # The number of times to retry publishing an event after a publishing failure.
   # After the specified number of retries, the events are typically dropped.
   # Some Beats, such as Filebeat, ignore the max_retries setting and retry until
   # all events are published.  Set max_retries to a value less than 0 to retry
   # until all events are published. The default is 3.
-  #max_retries: 3
+  max_retries: 3
 
   # The maximum number of events to bulk in a single Kafka request. The default
   # is 2048.
-  #bulk_max_size: 2048
+  bulk_max_size: 2048
 
   # The number of seconds to wait for responses from the Kafka brokers before
   # timing out. The default is 30s.
-  #timeout: 30s
+  timeout: 30s
 
   # The maximum duration a broker will wait for number of required ACKs. The
   # default is 10s.
-  #broker_timeout: 10s
+  broker_timeout: 10s
 
   # The number of messages buffered for each Kafka broker. The default is 256.
-  #channel_buffer_size: 256
+  channel_buffer_size: 256
 
   # The keep-alive period for an active network connection. If 0s, keep-alives
   # are disabled. The default is 0 seconds.
-  #keep_alive: 0
+  keep_alive: 0
 
   # Sets the output compression codec. Must be one of none, snappy and gzip. The
   # default is gzip.
-  #compression: gzip
+  compression: gzip
 
   # The maximum permitted size of JSON-encoded messages. Bigger messages will be
   # dropped. The default value is 1000000 (bytes). This value should be equal to
   # or less than the broker's message.max.bytes.
-  #max_message_bytes: 1000000
+  max_message_bytes: 1000000
 
   # The ACK reliability level required from broker. 0=no response, 1=wait for
   # local commit, -1=wait for all replicas to commit. The default is 1.  Note:
   # If set to 0, no ACKs are returned by Kafka. Messages might be lost silently
   # on error.
-  #required_acks: 1
+  required_acks: 1
 
   # The number of seconds to wait for new events between two producer API calls.
-  #flush_interval: 1s
+  flush_interval: 1s
 
   # The configurable ClientID used for logging, debugging, and auditing
   # purposes.  The default is "beats".
-  #client_id: beats
+  client_id: beats
 
   # Enable SSL support. SSL is automatically enabled, if any SSL setting is set.
-  #ssl.enabled: true
+  ssl.enabled: false
 
   # Optional SSL configuration options. SSL is off by default.
   # List of root certificates for HTTPS server verifications
-  #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
+  ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
   # Configure SSL verification mode. If `none` is configured, all server hosts
   # and certificates will be accepted. In this mode, SSL based connections are
   # susceptible to man-in-the-middle attacks. Use only for testing. Default is
   # `full`.
-  #ssl.verification_mode: full
+  ssl.verification_mode: full
 
   # List of supported/valid TLS versions. By default all TLS versions 1.0 up to
   # 1.2 are enabled.
-  #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
+  ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
 
   # Certificate for SSL client authentication
-  #ssl.certificate: "/etc/pki/client/cert.pem"
+  ssl.certificate: "/etc/pki/client/cert.pem"
 
   # Client Certificate Key
-  #ssl.key: "/etc/pki/client/cert.key"
+  ssl.key: "/etc/pki/client/cert.key"
 
   # Optional passphrase for decrypting the Certificate Key.
-  #ssl.key_passphrase: ''
+  ssl.key_passphrase: ''
 
   # Configure cipher suites to be used for SSL connections
-  #ssl.cipher_suites: []
+  ssl.cipher_suites: []
 
   # Configure curve types for ECDHE based cipher suites
-  #ssl.curve_types: []
+  ssl.curve_types: []
 
 #------------------------------- Redis output ----------------------------------
-#output.redis:
+output.redis:
   # Boolean flag to enable or disable the output module.
-  #enabled: true
+  enabled: false
 
   # The list of Redis servers to connect to. If load balancing is enabled, the
   # events are distributed to the servers in the list. If one server becomes
   # unreachable, the events are distributed to the reachable servers only.
-  #hosts: ["localhost:6379"]
+  hosts: ["localhost:6379"]
 
   # The Redis port to use if hosts does not contain a port number. The default
   # is 6379.
-  #port: 6379
+  port: 6379
 
   # The name of the Redis list or channel the events are published to. The
   # default is beatname.
-  #key: beatname
+  key: beatname
 
   # The password to authenticate with. The default is no authentication.
-  #password:
+  password:
 
   # The Redis database number where the events are published. The default is 0.
-  #db: 0
+  db: 0
 
   # The Redis data type to use for publishing events. If the data type is list,
   # the Redis RPUSH command is used. If the data type is channel, the Redis
   # PUBLISH command is used. The default value is list.
-  #datatype: list
+  datatype: list
 
   # The number of workers to use for each host configured to publish events to
   # Redis. Use this setting along with the loadbalance option. For example, if
   # you have 2 hosts and 3 workers, in total 6 workers are started (3 for each
   # host).
-  #worker: 1
+  worker: 1
 
   # If set to true and multiple hosts or workers are configured, the output
   # plugin load balances published events onto all Redis hosts. If set to false,
   # the output plugin sends all events to only one host (determined at random)
   # and will switch to another host if the currently selected one becomes
   # unreachable. The default value is true.
-  #loadbalance: true
+  loadbalance: true
 
   # The Redis connection timeout in seconds. The default is 5 seconds.
-  #timeout: 5s
+  timeout: 5s
 
   # The number of times to retry publishing an event after a publishing failure.
   # After the specified number of retries, the events are typically dropped.
   # Some Beats, such as Filebeat, ignore the max_retries setting and retry until
   # all events are published. Set max_retries to a value less than 0 to retry
   # until all events are published. The default is 3.
-  #max_retries: 3
+  max_retries: 3
 
   # The maximum number of events to bulk in a single Redis request or pipeline.
   # The default is 2048.
-  #bulk_max_size: 2048
+  bulk_max_size: 2048
 
   # The URL of the SOCKS5 proxy to use when connecting to the Redis servers. The
   # value must be a URL with a scheme of socks5://.
-  #proxy_url:
+  proxy_url:
 
   # This option determines whether Redis hostnames are resolved locally when
   # using a proxy. The default value is false, which means that name resolution
   # occurs on the proxy server.
-  #proxy_use_local_resolver: false
+  proxy_use_local_resolver: false
 
   # Enable SSL support. SSL is automatically enabled, if any SSL setting is set.
-  #ssl.enabled: true
+  ssl.enabled: false
 
   # Configure SSL verification mode. If `none` is configured, all server hosts
   # and certificates will be accepted. In this mode, SSL based connections are
   # susceptible to man-in-the-middle attacks. Use only for testing. Default is
   # `full`.
-  #ssl.verification_mode: full
+  ssl.verification_mode: full
 
   # List of supported/valid TLS versions. By default all TLS versions 1.0 up to
   # 1.2 are enabled.
-  #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
+  ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
 
   # Optional SSL configuration options. SSL is off by default.
   # List of root certificates for HTTPS server verifications
-  #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
+  ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
   # Certificate for SSL client authentication
-  #ssl.certificate: "/etc/pki/client/cert.pem"
+  ssl.certificate: "/etc/pki/client/cert.pem"
 
   # Client Certificate Key
-  #ssl.key: "/etc/pki/client/cert.key"
+  ssl.key: "/etc/pki/client/cert.key"
 
   # Optional passphrase for decrypting the Certificate Key.
-  #ssl.key_passphrase: ''
+  ssl.key_passphrase: ''
 
   # Configure cipher suites to be used for SSL connections
-  #ssl.cipher_suites: []
+  ssl.cipher_suites: []
 
   # Configure curve types for ECDHE based cipher suites
-  #ssl.curve_types: []
+  ssl.curve_types: []
 
 
 #------------------------------- File output -----------------------------------
-#output.file:
+output.file:
   # Boolean flag to enable or disable the output module.
-  #enabled: true
+  enabled: false
 
   # Path to the directory where to save the generated files. The option is
   # mandatory.
-  #path: "/tmp/beatname"
+  path: "/tmp/beatname"
 
   # Name of the generated files. The default is `beatname` and it generates
   # files: `beatname`, `beatname.1`, `beatname.2`, etc.
-  #filename: beatname
+  filename: beatname
 
   # Maximum size in kilobytes of each file. When this size is reached, and on
   # every beatname restart, the files are rotated. The default value is 10240
   # kB.
-  #rotate_every_kb: 10000
+  rotate_every_kb: 10000
 
   # Maximum number of files under path. When this number of files is reached,
   # the oldest file is deleted and the rest are shifted from last to first. The
   # default is 7 files.
-  #number_of_files: 7
+  number_of_files: 7
 
 
 #----------------------------- Console output ---------------------------------
-#output.console:
+output.console:
   # Boolean flag to enable or disable the output module.
-  #enabled: true
+  enabled: false
 
   # Pretty print json event
-  #pretty: false
+  pretty: false
 
 #================================= Paths ======================================
 
@@ -524,24 +524,24 @@ output.elasticsearch:
 # distribution (for example, the sample dashboards).
 # If not set by a CLI flag or in the configuration file, the default for the
 # home path is the location of the binary.
-#path.home:
+path.home:
 
 # The configuration path for the beatname installation. This is the default
 # base path for configuration files, including the main YAML configuration file
 # and the Elasticsearch template file. If not set by a CLI flag or in the
 # configuration file, the default for the configuration path is the home path.
-#path.config: ${path.home}
+path.config: ${path.home}
 
 # The data path for the beatname installation. This is the default base path
 # for all the files in which beatname needs to store its data. If not set by a
 # CLI flag or in the configuration file, the default for the data path is a data
 # subdirectory inside the home path.
-#path.data: ${path.home}/data
+path.data: ${path.home}/data
 
 # The logs path for a beatname installation. This is the default location for
 # the Beat's log files. If not set by a CLI flag or in the configuration file,
 # the default for the logs path is a logs subdirectory inside the home path.
-#path.logs: ${path.home}/logs
+path.logs: ${path.home}/logs
 
 #================================ Logging ======================================
 # There are three options for the log output: syslog, file, stderr.
@@ -550,24 +550,24 @@ output.elasticsearch:
 
 # Sets log level. The default log level is info.
 # Available log levels are: critical, error, warning, info, debug
-#logging.level: info
+logging.level: info
 
 # Enable debug output for selected components. To enable all selectors use ["*"]
 # Other available selectors are "beat", "publish", "service"
 # Multiple selectors can be chained.
-#logging.selectors: [ ]
+logging.selectors: [ ]
 
 # Send all logging output to syslog. The default is false.
-#logging.to_syslog: true
+logging.to_syslog: false
 
 # If enabled, beatname periodically logs its internal metrics that have changed
 # in the last period. For each metric that changed, the delta from the value at
 # the beginning of the period is logged. Also, the total values for
 # all non-zero internal metrics are logged on shutdown. The default is true.
-#logging.metrics.enabled: true
+logging.metrics.enabled: true
 
 # The period after which to log the internal metrics. The default is 30s.
-#logging.metrics.period: 30s
+logging.metrics.period: 30s
 
 # Logging to rotating files files. Set logging.to_files to false to disable logging to
 # files.
@@ -575,15 +575,15 @@ logging.to_files: true
 logging.files:
   # Configure the path where the logs are written. The default is the logs directory
   # under the home path (the binary location).
-  #path: /var/log/beatname
+  path: /var/log/beatname
 
   # The name of the files where the logs are written to.
-  #name: beatname
+  name: beatname
 
   # Configure log file size limit. If limit is reached, log file will be
   # automatically rotated
-  #rotateeverybytes: 10485760 # = 10MB
+  rotateeverybytes: 10485760 # = 10MB
 
   # Number of rotated log files to keep. Oldest files will be deleted first.
-  #keepfiles: 7
+  keepfiles: 7
 

--- a/metricbeat/_meta/beat.full.yml
+++ b/metricbeat/_meta/beat.full.yml
@@ -44,28 +44,28 @@ metricbeat.modules:
   processes: ['.*']
 
   # if true, exports the CPU usage in ticks, together with the percentage values
-  #cpu_ticks: false
+  cpu_ticks: false
 
   # EXPERIMENTAL: cgroups can be enabled for the process metricset.
-  #cgroups: false
+  cgroups: false
 
 #------------------------------- Apache Module -------------------------------
-#- module: apache
-  #metricsets: ["status"]
-  #enabled: true
-  #period: 10s
+- module: apache
+  metricsets: ["status"]
+  enabled: false
+  period: 10s
 
   # Apache hosts
-  #hosts: ["http://127.0.0.1"]
+  hosts: ["http://127.0.0.1"]
 
   # Path to server status. Default server-status
-  #server_status_path: "server-status"
+  server_status_path: "server-status"
 
   # Username of hosts.  Empty by default
-  #username: test
+  username:
 
   # Password of hosts. Empty by default
-  #password: test123
+  password:
 
 #------------------------------- docker Module -------------------------------
 #- module: docker
@@ -81,11 +81,11 @@ metricbeat.modules:
     #key:                   "/etc/pki/client/cert.key"
 
 #------------------------------- haproxy Module ------------------------------
-#- module: haproxy
-  #metricsets: ["info", "stat"]
-  #enabled: true
-  #period: 10s
-  #hosts: ["tcp://127.0.0.1:14567"]
+- module: haproxy
+  metricsets: ["info", "stat"]
+  enabled: false
+  period: 10s
+  hosts: ["tcp://127.0.0.1:14567"]
 
 #-------------------------------- kafka Module -------------------------------
 #- module: kafka
@@ -136,36 +136,38 @@ metricbeat.modules:
 
 
 #-------------------------------- MySQL Module -------------------------------
-#- module: mysql
-  #metricsets: ["status"]
-  #enabled: true
-  #period: 10s
+- module: mysql
+  metricsets: ["status"]
+  enabled: false
+  period: 10s
 
   # Host DSN should be defined as "user:pass@tcp(127.0.0.1:3306)/"
   # The username and password can either be set in the DSN or using the username
   # and password config options. Those specified in the DSN take precedence.
-  #hosts: ["root:secret@tcp(127.0.0.1:3306)/"]
+  hosts: ["root:secret@tcp(127.0.0.1:3306)/"]
 
   # Username of hosts. Empty by default.
-  #username: root
+  # Example: root
+  username: root
 
   # Password of hosts. Empty by default.
-  #password: secret
+  # Example: secret
+  password:
 
   # By setting raw to true, all raw fields from the status metricset will be added to the event.
-  #raw: false
+  raw: false
 
 #-------------------------------- Nginx Module -------------------------------
-#- module: nginx
-  #metricsets: ["stubstatus"]
-  #enabled: true
-  #period: 10s
+- module: nginx
+  metricsets: ["stubstatus"]
+  enabled: false
+  period: 10s
 
   # Nginx hosts
-  #hosts: ["http://127.0.0.1"]
+  hosts: ["http://127.0.0.1"]
 
   # Path to server status. Default server-status
-  #server_status_path: "server-status"
+  server_status_path: "server-status"
 
 #----------------------------- PostgreSQL Module -----------------------------
 #- module: postgresql
@@ -196,28 +198,28 @@ metricbeat.modules:
 
 
 #-------------------------------- Redis Module -------------------------------
-#- module: redis
-  #metricsets: ["info", "keyspace"]
-  #enabled: true
-  #period: 10s
+- module: redis
+  metricsets: ["info", "keyspace"]
+  enabled: false
+  period: 10s
 
   # Redis hosts
-  #hosts: ["127.0.0.1:6379"]
+  hosts: ["127.0.0.1:6379"]
 
   # Timeout after which time a metricset should return an error
   # Timeout is by default defined as period, as a fetch of a metricset
   # should never take longer then period, as otherwise calls can pile up.
-  #timeout: 1s
+  timeout: 1s
 
   # Optional fields to be added to each event
   #fields:
   #  datacenter: west
 
   # Network type to be used for redis connection. Default: tcp
-  #network: tcp
+  network: tcp
 
   # Max number of concurrent connections. Default: 10
-  #maxconn: 10
+  maxconn: 10
 
   # Filters can be used to reduce the number of fields sent.
   #filters:
@@ -225,7 +227,7 @@ metricbeat.modules:
   #      fields: ["stats"]
 
   # Redis AUTH password. Empty by default.
-  #password: foobared
+  password:
 
 #------------------------------ ZooKeeper Module -----------------------------
 #- module: zookeeper

--- a/metricbeat/metricbeat.full.yml
+++ b/metricbeat/metricbeat.full.yml
@@ -44,28 +44,28 @@ metricbeat.modules:
   processes: ['.*']
 
   # if true, exports the CPU usage in ticks, together with the percentage values
-  #cpu_ticks: false
+  cpu_ticks: false
 
   # EXPERIMENTAL: cgroups can be enabled for the process metricset.
-  #cgroups: false
+  cgroups: false
 
 #------------------------------- Apache Module -------------------------------
-#- module: apache
-  #metricsets: ["status"]
-  #enabled: true
-  #period: 10s
+- module: apache
+  metricsets: ["status"]
+  enabled: false
+  period: 10s
 
   # Apache hosts
-  #hosts: ["http://127.0.0.1"]
+  hosts: ["http://127.0.0.1"]
 
   # Path to server status. Default server-status
-  #server_status_path: "server-status"
+  server_status_path: "server-status"
 
   # Username of hosts.  Empty by default
-  #username: test
+  username:
 
   # Password of hosts. Empty by default
-  #password: test123
+  password:
 
 #------------------------------- docker Module -------------------------------
 #- module: docker
@@ -81,11 +81,11 @@ metricbeat.modules:
     #key:                   "/etc/pki/client/cert.key"
 
 #------------------------------- haproxy Module ------------------------------
-#- module: haproxy
-  #metricsets: ["info", "stat"]
-  #enabled: true
-  #period: 10s
-  #hosts: ["tcp://127.0.0.1:14567"]
+- module: haproxy
+  metricsets: ["info", "stat"]
+  enabled: false
+  period: 10s
+  hosts: ["tcp://127.0.0.1:14567"]
 
 #-------------------------------- kafka Module -------------------------------
 #- module: kafka
@@ -136,36 +136,38 @@ metricbeat.modules:
 
 
 #-------------------------------- MySQL Module -------------------------------
-#- module: mysql
-  #metricsets: ["status"]
-  #enabled: true
-  #period: 10s
+- module: mysql
+  metricsets: ["status"]
+  enabled: false
+  period: 10s
 
   # Host DSN should be defined as "user:pass@tcp(127.0.0.1:3306)/"
   # The username and password can either be set in the DSN or using the username
   # and password config options. Those specified in the DSN take precedence.
-  #hosts: ["root:secret@tcp(127.0.0.1:3306)/"]
+  hosts: ["root:secret@tcp(127.0.0.1:3306)/"]
 
   # Username of hosts. Empty by default.
-  #username: root
+  # Example: root
+  username: root
 
   # Password of hosts. Empty by default.
-  #password: secret
+  # Example: secret
+  password:
 
   # By setting raw to true, all raw fields from the status metricset will be added to the event.
-  #raw: false
+  raw: false
 
 #-------------------------------- Nginx Module -------------------------------
-#- module: nginx
-  #metricsets: ["stubstatus"]
-  #enabled: true
-  #period: 10s
+- module: nginx
+  metricsets: ["stubstatus"]
+  enabled: false
+  period: 10s
 
   # Nginx hosts
-  #hosts: ["http://127.0.0.1"]
+  hosts: ["http://127.0.0.1"]
 
   # Path to server status. Default server-status
-  #server_status_path: "server-status"
+  server_status_path: "server-status"
 
 #----------------------------- PostgreSQL Module -----------------------------
 #- module: postgresql
@@ -196,28 +198,28 @@ metricbeat.modules:
 
 
 #-------------------------------- Redis Module -------------------------------
-#- module: redis
-  #metricsets: ["info", "keyspace"]
-  #enabled: true
-  #period: 10s
+- module: redis
+  metricsets: ["info", "keyspace"]
+  enabled: false
+  period: 10s
 
   # Redis hosts
-  #hosts: ["127.0.0.1:6379"]
+  hosts: ["127.0.0.1:6379"]
 
   # Timeout after which time a metricset should return an error
   # Timeout is by default defined as period, as a fetch of a metricset
   # should never take longer then period, as otherwise calls can pile up.
-  #timeout: 1s
+  timeout: 1s
 
   # Optional fields to be added to each event
   #fields:
   #  datacenter: west
 
   # Network type to be used for redis connection. Default: tcp
-  #network: tcp
+  network: tcp
 
   # Max number of concurrent connections. Default: 10
-  #maxconn: 10
+  maxconn: 10
 
   # Filters can be used to reduce the number of fields sent.
   #filters:
@@ -225,7 +227,7 @@ metricbeat.modules:
   #      fields: ["stats"]
 
   # Redis AUTH password. Empty by default.
-  #password: foobared
+  password:
 
 #------------------------------ ZooKeeper Module -----------------------------
 #- module: zookeeper
@@ -241,7 +243,7 @@ metricbeat.modules:
 # The name of the shipper that publishes the network data. It can be used to group
 # all the transactions sent by a single shipper in the web interface.
 # If this options is not defined, the hostname is used.
-#name:
+name:
 
 # The tags of the shipper are included in their own field with each
 # transaction published. Tags make it easy to group servers by different
@@ -257,14 +259,14 @@ metricbeat.modules:
 # If this option is set to true, the custom fields are stored as top-level
 # fields in the output document instead of being grouped under a fields
 # sub-dictionary. Default is false.
-#fields_under_root: false
+fields_under_root: false
 
 # Internal queue size for single events in processing pipeline
-#queue_size: 1000
+queue_size: 1000
 
 # The internal queue size for bulk events in the processing pipeline.
 # Do not modify this value.
-#bulk_queue_size: 0
+bulk_queue_size: 0
 
 # Sets the maximum number of CPUs that can be executing simultaneously. The
 # default is the number of logical CPUs available in the system.
@@ -315,7 +317,7 @@ metricbeat.modules:
 #-------------------------- Elasticsearch output -------------------------------
 output.elasticsearch:
   # Boolean flag to enable or disable the output module.
-  #enabled: true
+  enabled: true
 
   # Array of hosts to connect to.
   # Scheme and port can be left out and will be set to the default (http and 9200)
@@ -324,7 +326,7 @@ output.elasticsearch:
   hosts: ["localhost:9200"]
 
   # Set gzip compression level.
-  #compression_level: 0
+  compression_level: 0
 
   # Optional protocol and basic auth credentials.
   #protocol: "https"
@@ -337,422 +339,422 @@ output.elasticsearch:
     #param2: value2
 
   # Number of workers per Elasticsearch host.
-  #worker: 1
+  worker: 1
 
   # Optional index name. The default is "metricbeat" plus date
   # and generates [metricbeat-]YYYY.MM.DD keys.
-  #index: "metricbeat-%{+yyyy.MM.dd}"
+  index: "metricbeat-%{+yyyy.MM.dd}"
 
   # Optional ingest node pipeline. By default no pipeline will be used.
-  #pipeline: ""
+  pipeline: ""
 
-  # Optional HTTP Path
-  #path: "/elasticsearch"
+  # Optional HTTP Path. Example: /elasticsearch
+  path:
 
-  # Proxy server url
-  #proxy_url: http://proxy:3128
+  # Proxy server url. Example: http://proxy:3128
+  proxy_url:
 
   # The number of times a particular Elasticsearch index operation is attempted. If
   # the indexing operation doesn't succeed after this many retries, the events are
   # dropped. The default is 3.
-  #max_retries: 3
+  max_retries: 3
 
   # The maximum number of events to bulk in a single Elasticsearch bulk API index request.
   # The default is 50.
-  #bulk_max_size: 50
+  bulk_max_size: 50
 
   # Configure http request timeout before failing an request to Elasticsearch.
-  #timeout: 90
+  timeout: 90
 
   # The number of seconds to wait for new events between two bulk API index requests.
   # If `bulk_max_size` is reached before this interval expires, addition bulk index
   # requests are made.
-  #flush_interval: 1s
+  flush_interval: 1s
 
   # A template is used to set the mapping in Elasticsearch
   # By default template loading is enabled and the template is loaded.
   # These settings can be adjusted to load your own template or overwrite existing ones.
 
   # Set to false to disable template loading.
-  #template.enabled: true
+  template.enabled: true
 
   # Template name. By default the template name is metricbeat.
-  #template.name: "metricbeat"
+  template.name: "metricbeat"
 
   # Path to template file
-  #template.path: "${path.config}/metricbeat.template.json"
+  template.path: "${path.config}/metricbeat.template.json"
 
   # Overwrite existing template
-  #template.overwrite: false
+  #emplate.overwrite: false
 
   # If set to true, metricbeat checks the Elasticsearch version at connect time, and if it
   # is 2.x, it loads the file specified by the template.versions.2x.path setting. The
   # default is true.
-  #template.versions.2x.enabled: true
+  template.versions.2x.enabled: true
 
   # Path to the Elasticsearch 2.x version of the template file.
-  #template.versions.2x.path: "${path.config}/metricbeat.template-es2x.json"
+  template.versions.2x.path: "${path.config}/metricbeat.template-es2x.json"
 
   # Use SSL settings for HTTPS. Default is true.
-  #ssl.enabled: true
+  ssl.enabled: false
 
   # Configure SSL verification mode. If `none` is configured, all server hosts
   # and certificates will be accepted. In this mode, SSL based connections are
   # susceptible to man-in-the-middle attacks. Use only for testing. Default is
   # `full`.
-  #ssl.verification_mode: full
+  ssl.verification_mode: full
 
   # List of supported/valid TLS versions. By default all TLS versions 1.0 up to
   # 1.2 are enabled.
-  #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
+  ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
 
-  # SSL configuration. By default is off.
+  # SSL configuration. By default is off. TODO
   # List of root certificates for HTTPS server verifications
-  #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
+  ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
   # Certificate for SSL client authentication
-  #ssl.certificate: "/etc/pki/client/cert.pem"
+  ssl.certificate: "/etc/pki/client/cert.pem"
 
   # Client Certificate Key
-  #ssl.key: "/etc/pki/client/cert.key"
+  ssl.key: "/etc/pki/client/cert.key"
 
   # Optional passphrase for decrypting the Certificate Key.
-  #ssl.key_passphrase: ''
+  ssl.key_passphrase: ''
 
   # Configure cipher suites to be used for SSL connections
-  #ssl.cipher_suites: []
+  ssl.cipher_suites: []
 
   # Configure curve types for ECDHE based cipher suites
-  #ssl.curve_types: []
+  ssl.curve_types: []
 
 
 #----------------------------- Logstash output ---------------------------------
-#output.logstash:
+output.logstash:
   # Boolean flag to enable or disable the output module.
-  #enabled: true
+  enabled: false
 
   # The Logstash hosts
-  #hosts: ["localhost:5044"]
+  hosts: ["localhost:5044"]
 
   # Number of workers per Logstash host.
-  #worker: 1
+  worker: 1
 
   # Set gzip compression level.
-  #compression_level: 3
+  compression_level: 3
 
   # Optional load balance the events between the Logstash hosts
-  #loadbalance: true
+  loadbalance: true
 
   # Number of batches to be send asynchronously to logstash while processing
   # new batches.
-  #pipelining: 0
+  pipelining: 0
 
   # Optional index name. The default index name is set to name of the beat
   # in all lowercase.
-  #index: 'metricbeat'
+  index: 'metricbeat'
 
   # SOCKS5 proxy server URL
-  #proxy_url: socks5://user:password@socks5-server:2233
+  proxy_url: socks5://user:password@socks5-server:2233
 
   # Resolve names locally when using a proxy server. Defaults to false.
-  #proxy_use_local_resolver: false
+  proxy_use_local_resolver: false
 
   # Enable SSL support. SSL is automatically enabled, if any SSL setting is set.
-  #ssl.enabled: true
+  ssl.enabled: false
 
   # Configure SSL verification mode. If `none` is configured, all server hosts
   # and certificates will be accepted. In this mode, SSL based connections are
   # susceptible to man-in-the-middle attacks. Use only for testing. Default is
   # `full`.
-  #ssl.verification_mode: full
+  ssl.verification_mode: full
 
   # List of supported/valid TLS versions. By default all TLS versions 1.0 up to
   # 1.2 are enabled.
-  #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
+  ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
 
   # Optional SSL configuration options. SSL is off by default.
   # List of root certificates for HTTPS server verifications
-  #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
+  ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
   # Certificate for SSL client authentication
-  #ssl.certificate: "/etc/pki/client/cert.pem"
+  ssl.certificate: "/etc/pki/client/cert.pem"
 
   # Client Certificate Key
-  #ssl.key: "/etc/pki/client/cert.key"
+  ssl.key: "/etc/pki/client/cert.key"
 
   # Optional passphrase for decrypting the Certificate Key.
-  #ssl.key_passphrase: ''
+  ssl.key_passphrase: ''
 
   # Configure cipher suites to be used for SSL connections
-  #ssl.cipher_suites: []
+  ssl.cipher_suites: []
 
   # Configure curve types for ECDHE based cipher suites
-  #ssl.curve_types: []
+  ssl.curve_types: []
 
 #------------------------------- Kafka output ----------------------------------
-#output.kafka:
+output.kafka:
   # Boolean flag to enable or disable the output module.
-  #enabled: true
+  enabled: false
 
   # The list of Kafka broker addresses from where to fetch the cluster metadata.
   # The cluster metadata contain the actual Kafka brokers events are published
   # to.
-  #hosts: ["localhost:9092"]
+  hosts: ["localhost:9092"]
 
   # The Kafka topic used for produced events. The setting can be a format string
   # using any event field. To set the topic from document type use `%{[type]}`.
-  #topic: beats
+  topic: beats
 
   # The Kafka event key setting. Use format string to create unique event key.
   # By default no event key will be generated.
-  #key: ''
+  key: ''
 
   # The Kafka event partitioning strategy. Default hashing strategy is `hash`
   # using the `output.kafka.key` setting or randomly distributes events if
   # `output.kafka.key` is not configured.
-  #partition.hash:
+  partition.hash:
     # If enabled, events will only be published to partitions with reachable
     # leaders. Default is false.
-    #reachable_only: false
+    reachable_only: false
 
     # Configure alternative event field names used to compute the hash value.
     # If empty `output.kafka.key` setting will be used.
     # Default value is empty list.
-    #hash: []
+    hash: []
 
   # Authentication details. Password is required if username is set.
-  #username: ''
-  #password: ''
+  username: ''
+  password: ''
 
   # Kafka version metricbeat is assumed to run against. Defaults to the oldest
   # supported stable version (currently version 0.8.2.0)
-  #version: 0.8.2
+  version: 0.8.2
 
   # Metadata update configuration. Metadata do contain leader information
   # deciding which broker to use when publishing.
-  #metadata:
+  metadata:
     # Max metadata request retry attempts when cluster is in middle of leader
     # election. Defaults to 3 retries.
-    #retry.max: 3
+    retry.max: 3
 
     # Waiting time between retries during leader elections. Default is 250ms.
-    #retry.backoff: 250ms
+    retry.backoff: 250ms
 
     # Refresh metadata interval. Defaults to every 10 minutes.
-    #refresh_frequency: 10m
+    refresh_frequency: 10m
 
   # The number of concurrent load-balanced Kafka output workers.
-  #worker: 1
+  worker: 1
 
   # The number of times to retry publishing an event after a publishing failure.
   # After the specified number of retries, the events are typically dropped.
   # Some Beats, such as Filebeat, ignore the max_retries setting and retry until
   # all events are published.  Set max_retries to a value less than 0 to retry
   # until all events are published. The default is 3.
-  #max_retries: 3
+  max_retries: 3
 
   # The maximum number of events to bulk in a single Kafka request. The default
   # is 2048.
-  #bulk_max_size: 2048
+  bulk_max_size: 2048
 
   # The number of seconds to wait for responses from the Kafka brokers before
   # timing out. The default is 30s.
-  #timeout: 30s
+  timeout: 30s
 
   # The maximum duration a broker will wait for number of required ACKs. The
   # default is 10s.
-  #broker_timeout: 10s
+  broker_timeout: 10s
 
   # The number of messages buffered for each Kafka broker. The default is 256.
-  #channel_buffer_size: 256
+  channel_buffer_size: 256
 
   # The keep-alive period for an active network connection. If 0s, keep-alives
   # are disabled. The default is 0 seconds.
-  #keep_alive: 0
+  keep_alive: 0
 
   # Sets the output compression codec. Must be one of none, snappy and gzip. The
   # default is gzip.
-  #compression: gzip
+  compression: gzip
 
   # The maximum permitted size of JSON-encoded messages. Bigger messages will be
   # dropped. The default value is 1000000 (bytes). This value should be equal to
   # or less than the broker's message.max.bytes.
-  #max_message_bytes: 1000000
+  max_message_bytes: 1000000
 
   # The ACK reliability level required from broker. 0=no response, 1=wait for
   # local commit, -1=wait for all replicas to commit. The default is 1.  Note:
   # If set to 0, no ACKs are returned by Kafka. Messages might be lost silently
   # on error.
-  #required_acks: 1
+  required_acks: 1
 
   # The number of seconds to wait for new events between two producer API calls.
-  #flush_interval: 1s
+  flush_interval: 1s
 
   # The configurable ClientID used for logging, debugging, and auditing
   # purposes.  The default is "beats".
-  #client_id: beats
+  client_id: beats
 
   # Enable SSL support. SSL is automatically enabled, if any SSL setting is set.
-  #ssl.enabled: true
+  ssl.enabled: false
 
   # Optional SSL configuration options. SSL is off by default.
   # List of root certificates for HTTPS server verifications
-  #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
+  ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
   # Configure SSL verification mode. If `none` is configured, all server hosts
   # and certificates will be accepted. In this mode, SSL based connections are
   # susceptible to man-in-the-middle attacks. Use only for testing. Default is
   # `full`.
-  #ssl.verification_mode: full
+  ssl.verification_mode: full
 
   # List of supported/valid TLS versions. By default all TLS versions 1.0 up to
   # 1.2 are enabled.
-  #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
+  ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
 
   # Certificate for SSL client authentication
-  #ssl.certificate: "/etc/pki/client/cert.pem"
+  ssl.certificate: "/etc/pki/client/cert.pem"
 
   # Client Certificate Key
-  #ssl.key: "/etc/pki/client/cert.key"
+  ssl.key: "/etc/pki/client/cert.key"
 
   # Optional passphrase for decrypting the Certificate Key.
-  #ssl.key_passphrase: ''
+  ssl.key_passphrase: ''
 
   # Configure cipher suites to be used for SSL connections
-  #ssl.cipher_suites: []
+  ssl.cipher_suites: []
 
   # Configure curve types for ECDHE based cipher suites
-  #ssl.curve_types: []
+  ssl.curve_types: []
 
 #------------------------------- Redis output ----------------------------------
-#output.redis:
+output.redis:
   # Boolean flag to enable or disable the output module.
-  #enabled: true
+  enabled: false
 
   # The list of Redis servers to connect to. If load balancing is enabled, the
   # events are distributed to the servers in the list. If one server becomes
   # unreachable, the events are distributed to the reachable servers only.
-  #hosts: ["localhost:6379"]
+  hosts: ["localhost:6379"]
 
   # The Redis port to use if hosts does not contain a port number. The default
   # is 6379.
-  #port: 6379
+  port: 6379
 
   # The name of the Redis list or channel the events are published to. The
   # default is metricbeat.
-  #key: metricbeat
+  key: metricbeat
 
   # The password to authenticate with. The default is no authentication.
-  #password:
+  password:
 
   # The Redis database number where the events are published. The default is 0.
-  #db: 0
+  db: 0
 
   # The Redis data type to use for publishing events. If the data type is list,
   # the Redis RPUSH command is used. If the data type is channel, the Redis
   # PUBLISH command is used. The default value is list.
-  #datatype: list
+  datatype: list
 
   # The number of workers to use for each host configured to publish events to
   # Redis. Use this setting along with the loadbalance option. For example, if
   # you have 2 hosts and 3 workers, in total 6 workers are started (3 for each
   # host).
-  #worker: 1
+  worker: 1
 
   # If set to true and multiple hosts or workers are configured, the output
   # plugin load balances published events onto all Redis hosts. If set to false,
   # the output plugin sends all events to only one host (determined at random)
   # and will switch to another host if the currently selected one becomes
   # unreachable. The default value is true.
-  #loadbalance: true
+  loadbalance: true
 
   # The Redis connection timeout in seconds. The default is 5 seconds.
-  #timeout: 5s
+  timeout: 5s
 
   # The number of times to retry publishing an event after a publishing failure.
   # After the specified number of retries, the events are typically dropped.
   # Some Beats, such as Filebeat, ignore the max_retries setting and retry until
   # all events are published. Set max_retries to a value less than 0 to retry
   # until all events are published. The default is 3.
-  #max_retries: 3
+  max_retries: 3
 
   # The maximum number of events to bulk in a single Redis request or pipeline.
   # The default is 2048.
-  #bulk_max_size: 2048
+  bulk_max_size: 2048
 
   # The URL of the SOCKS5 proxy to use when connecting to the Redis servers. The
   # value must be a URL with a scheme of socks5://.
-  #proxy_url:
+  proxy_url:
 
   # This option determines whether Redis hostnames are resolved locally when
   # using a proxy. The default value is false, which means that name resolution
   # occurs on the proxy server.
-  #proxy_use_local_resolver: false
+  proxy_use_local_resolver: false
 
   # Enable SSL support. SSL is automatically enabled, if any SSL setting is set.
-  #ssl.enabled: true
+  ssl.enabled: false
 
   # Configure SSL verification mode. If `none` is configured, all server hosts
   # and certificates will be accepted. In this mode, SSL based connections are
   # susceptible to man-in-the-middle attacks. Use only for testing. Default is
   # `full`.
-  #ssl.verification_mode: full
+  ssl.verification_mode: full
 
   # List of supported/valid TLS versions. By default all TLS versions 1.0 up to
   # 1.2 are enabled.
-  #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
+  ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
 
   # Optional SSL configuration options. SSL is off by default.
   # List of root certificates for HTTPS server verifications
-  #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
+  ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
   # Certificate for SSL client authentication
-  #ssl.certificate: "/etc/pki/client/cert.pem"
+  ssl.certificate: "/etc/pki/client/cert.pem"
 
   # Client Certificate Key
-  #ssl.key: "/etc/pki/client/cert.key"
+  ssl.key: "/etc/pki/client/cert.key"
 
   # Optional passphrase for decrypting the Certificate Key.
-  #ssl.key_passphrase: ''
+  ssl.key_passphrase: ''
 
   # Configure cipher suites to be used for SSL connections
-  #ssl.cipher_suites: []
+  ssl.cipher_suites: []
 
   # Configure curve types for ECDHE based cipher suites
-  #ssl.curve_types: []
+  ssl.curve_types: []
 
 
 #------------------------------- File output -----------------------------------
-#output.file:
+output.file:
   # Boolean flag to enable or disable the output module.
-  #enabled: true
+  enabled: false
 
   # Path to the directory where to save the generated files. The option is
   # mandatory.
-  #path: "/tmp/metricbeat"
+  path: "/tmp/metricbeat"
 
   # Name of the generated files. The default is `metricbeat` and it generates
   # files: `metricbeat`, `metricbeat.1`, `metricbeat.2`, etc.
-  #filename: metricbeat
+  filename: metricbeat
 
   # Maximum size in kilobytes of each file. When this size is reached, and on
   # every metricbeat restart, the files are rotated. The default value is 10240
   # kB.
-  #rotate_every_kb: 10000
+  rotate_every_kb: 10000
 
   # Maximum number of files under path. When this number of files is reached,
   # the oldest file is deleted and the rest are shifted from last to first. The
   # default is 7 files.
-  #number_of_files: 7
+  number_of_files: 7
 
 
 #----------------------------- Console output ---------------------------------
-#output.console:
+output.console:
   # Boolean flag to enable or disable the output module.
-  #enabled: true
+  enabled: false
 
   # Pretty print json event
-  #pretty: false
+  pretty: false
 
 #================================= Paths ======================================
 
@@ -761,24 +763,24 @@ output.elasticsearch:
 # distribution (for example, the sample dashboards).
 # If not set by a CLI flag or in the configuration file, the default for the
 # home path is the location of the binary.
-#path.home:
+path.home:
 
 # The configuration path for the metricbeat installation. This is the default
 # base path for configuration files, including the main YAML configuration file
 # and the Elasticsearch template file. If not set by a CLI flag or in the
 # configuration file, the default for the configuration path is the home path.
-#path.config: ${path.home}
+path.config: ${path.home}
 
 # The data path for the metricbeat installation. This is the default base path
 # for all the files in which metricbeat needs to store its data. If not set by a
 # CLI flag or in the configuration file, the default for the data path is a data
 # subdirectory inside the home path.
-#path.data: ${path.home}/data
+path.data: ${path.home}/data
 
 # The logs path for a metricbeat installation. This is the default location for
 # the Beat's log files. If not set by a CLI flag or in the configuration file,
 # the default for the logs path is a logs subdirectory inside the home path.
-#path.logs: ${path.home}/logs
+path.logs: ${path.home}/logs
 
 #================================ Logging ======================================
 # There are three options for the log output: syslog, file, stderr.
@@ -787,24 +789,24 @@ output.elasticsearch:
 
 # Sets log level. The default log level is info.
 # Available log levels are: critical, error, warning, info, debug
-#logging.level: info
+logging.level: info
 
 # Enable debug output for selected components. To enable all selectors use ["*"]
 # Other available selectors are "beat", "publish", "service"
 # Multiple selectors can be chained.
-#logging.selectors: [ ]
+logging.selectors: [ ]
 
 # Send all logging output to syslog. The default is false.
-#logging.to_syslog: true
+logging.to_syslog: false
 
 # If enabled, metricbeat periodically logs its internal metrics that have changed
 # in the last period. For each metric that changed, the delta from the value at
 # the beginning of the period is logged. Also, the total values for
 # all non-zero internal metrics are logged on shutdown. The default is true.
-#logging.metrics.enabled: true
+logging.metrics.enabled: true
 
 # The period after which to log the internal metrics. The default is 30s.
-#logging.metrics.period: 30s
+logging.metrics.period: 30s
 
 # Logging to rotating files files. Set logging.to_files to false to disable logging to
 # files.
@@ -812,15 +814,15 @@ logging.to_files: true
 logging.files:
   # Configure the path where the logs are written. The default is the logs directory
   # under the home path (the binary location).
-  #path: /var/log/metricbeat
+  path: /var/log/metricbeat
 
   # The name of the files where the logs are written to.
-  #name: metricbeat
+  name: metricbeat
 
   # Configure log file size limit. If limit is reached, log file will be
   # automatically rotated
-  #rotateeverybytes: 10485760 # = 10MB
+  rotateeverybytes: 10485760 # = 10MB
 
   # Number of rotated log files to keep. Oldest files will be deleted first.
-  #keepfiles: 7
+  keepfiles: 7
 

--- a/metricbeat/module/apache/_meta/config.full.yml
+++ b/metricbeat/module/apache/_meta/config.full.yml
@@ -1,16 +1,16 @@
-#- module: apache
-  #metricsets: ["status"]
-  #enabled: true
-  #period: 10s
+- module: apache
+  metricsets: ["status"]
+  enabled: false
+  period: 10s
 
   # Apache hosts
-  #hosts: ["http://127.0.0.1"]
+  hosts: ["http://127.0.0.1"]
 
   # Path to server status. Default server-status
-  #server_status_path: "server-status"
+  server_status_path: "server-status"
 
   # Username of hosts.  Empty by default
-  #username: test
+  username:
 
   # Password of hosts. Empty by default
-  #password: test123
+  password:

--- a/metricbeat/module/haproxy/_meta/config.full.yml
+++ b/metricbeat/module/haproxy/_meta/config.full.yml
@@ -1,5 +1,5 @@
-#- module: haproxy
-  #metricsets: ["info", "stat"]
-  #enabled: true
-  #period: 10s
-  #hosts: ["tcp://127.0.0.1:14567"]
+- module: haproxy
+  metricsets: ["info", "stat"]
+  enabled: false
+  period: 10s
+  hosts: ["tcp://127.0.0.1:14567"]

--- a/metricbeat/module/mysql/_meta/config.full.yml
+++ b/metricbeat/module/mysql/_meta/config.full.yml
@@ -1,18 +1,20 @@
-#- module: mysql
-  #metricsets: ["status"]
-  #enabled: true
-  #period: 10s
+- module: mysql
+  metricsets: ["status"]
+  enabled: false
+  period: 10s
 
   # Host DSN should be defined as "user:pass@tcp(127.0.0.1:3306)/"
   # The username and password can either be set in the DSN or using the username
   # and password config options. Those specified in the DSN take precedence.
-  #hosts: ["root:secret@tcp(127.0.0.1:3306)/"]
+  hosts: ["root:secret@tcp(127.0.0.1:3306)/"]
 
   # Username of hosts. Empty by default.
-  #username: root
+  # Example: root
+  username: root
 
   # Password of hosts. Empty by default.
-  #password: secret
+  # Example: secret
+  password:
 
   # By setting raw to true, all raw fields from the status metricset will be added to the event.
-  #raw: false
+  raw: false

--- a/metricbeat/module/nginx/_meta/config.full.yml
+++ b/metricbeat/module/nginx/_meta/config.full.yml
@@ -1,10 +1,10 @@
-#- module: nginx
-  #metricsets: ["stubstatus"]
-  #enabled: true
-  #period: 10s
+- module: nginx
+  metricsets: ["stubstatus"]
+  enabled: false
+  period: 10s
 
   # Nginx hosts
-  #hosts: ["http://127.0.0.1"]
+  hosts: ["http://127.0.0.1"]
 
   # Path to server status. Default server-status
-  #server_status_path: "server-status"
+  server_status_path: "server-status"

--- a/metricbeat/module/redis/_meta/config.full.yml
+++ b/metricbeat/module/redis/_meta/config.full.yml
@@ -1,25 +1,25 @@
-#- module: redis
-  #metricsets: ["info", "keyspace"]
-  #enabled: true
-  #period: 10s
+- module: redis
+  metricsets: ["info", "keyspace"]
+  enabled: false
+  period: 10s
 
   # Redis hosts
-  #hosts: ["127.0.0.1:6379"]
+  hosts: ["127.0.0.1:6379"]
 
   # Timeout after which time a metricset should return an error
   # Timeout is by default defined as period, as a fetch of a metricset
   # should never take longer then period, as otherwise calls can pile up.
-  #timeout: 1s
+  timeout: 1s
 
   # Optional fields to be added to each event
   #fields:
   #  datacenter: west
 
   # Network type to be used for redis connection. Default: tcp
-  #network: tcp
+  network: tcp
 
   # Max number of concurrent connections. Default: 10
-  #maxconn: 10
+  maxconn: 10
 
   # Filters can be used to reduce the number of fields sent.
   #filters:
@@ -27,4 +27,4 @@
   #      fields: ["stats"]
 
   # Redis AUTH password. Empty by default.
-  #password: foobared
+  password:

--- a/metricbeat/module/system/_meta/config.full.yml
+++ b/metricbeat/module/system/_meta/config.full.yml
@@ -31,7 +31,7 @@
   processes: ['.*']
 
   # if true, exports the CPU usage in ticks, together with the percentage values
-  #cpu_ticks: false
+  cpu_ticks: false
 
   # EXPERIMENTAL: cgroups can be enabled for the process metricset.
-  #cgroups: false
+  cgroups: false

--- a/packetbeat/_meta/beat.full.yml
+++ b/packetbeat/_meta/beat.full.yml
@@ -21,19 +21,19 @@ packetbeat.interfaces.device: any
 # * pf_ring, which makes use of an ntop.org project. This setting provides the
 # best sniffing speed, but it requires a kernel module, and it's Linux-specific.
 # The default sniffer type is pcap.
-#packetbeat.interfaces.type: pcap
+packetbeat.interfaces.type: pcap
 
 # The maximum size of the packets to capture. The default is 65535, which is
 # large enough for almost all networks and interface types. If you sniff on a
 # physical network interface, the optimal setting is the MTU size. On virtual
 # interfaces, however, it's safer to accept the default value.
-#packetbeat.interfaces.snaplen: 65535
+packetbeat.interfaces.snaplen: 65535
 
 # The maximum size of the shared memory buffer to use between the kernel and
 # user space. A bigger buffer usually results in lower CPU usage, but consumes
 # more memory. This setting is only available for the af_packet sniffer type.
 # The default is 30 MB.
-#packetbeat.interfaces.buffer_size_mb: 30
+packetbeat.interfaces.buffer_size_mb: 30
 
 # Packetbeat automatically generates a BPF for capturing only the traffic on
 # ports where it expects to find known protocols. Use this settings to tell
@@ -47,7 +47,7 @@ packetbeat.interfaces.device: any
 
 packetbeat.flows:
   # Enable Network flows. Default: true
-  #enabled: true
+  enabled: true
 
   # Set network flow timeout. Flow is killed if no packet is received before being
   # timed out.
@@ -60,44 +60,45 @@ packetbeat.flows:
 
 packetbeat.protocols.icmp:
   # Enable ICMPv4 and ICMPv6 monitoring. Default: true
-  #enabled: true
+  enabled: true
 
 packetbeat.protocols.amqp:
   # Enable AMQP monitoring. Default: true
-  #enabled: true
+  enabled: true
 
   # Configure the ports where to listen for AMQP traffic. You can disable
   # the AMQP protocol by commenting out the list of ports.
   ports: [5672]
+
   # Truncate messages that are published and avoid huge messages being
   # indexed.
   # Default: 1000
-  #max_body_length: 1000
+  max_body_length: 1000
 
   # Hide the header fields in header frames.
   # Default: false
-  #parse_headers: false
+  parse_headers: false
 
   # Hide the additional arguments of method frames.
   # Default: false
-  #parse_arguments: false
+  parse_arguments: false
 
   # Hide all methods relative to connection negociation between server and
   # client.
   # Default: true
-  #hide_connection_information: true
+  hide_connection_information: true
 
   # If this option is enabled, the raw message of the request (`request` field)
   # is sent to Elasticsearch. The default is false.
-  #send_request: false
+  send_request: false
 
   # If this option is enabled, the raw message of the response (`response`
   # field) is sent to Elasticsearch. The default is false.
-  #send_response: false
+  send_response: false
 
   # Transaction timeout. Expired transactions will no longer be correlated to
   # incoming responses, but sent to Elasticsearch immediately.
-  #transaction_timeout: 10s
+  transaction_timeout: 10s
 
 packetbeat.protocols.cassandra:
   #Cassandra port for traffic monitoring.
@@ -105,30 +106,30 @@ packetbeat.protocols.cassandra:
 
   # If this option is enabled, the raw message of the request (`cassandra_request` field)
   # is included in published events. The default is true.
-  #send_request: true
+  send_request: true
 
   # If this option is enabled, the raw message of the response (`cassandra_request.request_headers` field)
   # is included in published events. The default is true. enable `send_request` first before enable this option.
-  #send_request_header: true
+  send_request_header: true
 
   # If this option is enabled, the raw message of the response (`cassandra_response` field)
   # is included in published events. The default is true.
-  #send_response: true
+  send_response: true
 
   # If this option is enabled, the raw message of the response (`cassandra_response.response_headers` field)
   # is included in published events. The default is true. enable `send_response` first before enable this option.
-  #send_response_header: true
+  send_response_header: true
 
   # Configures the default compression algorithm being used to uncompress compressed frames by name. Currently only `snappy` is can be configured.
   # By default no compressor is configured.
-  #compressor: "snappy"
+  compressor: "snappy"
 
   # This option indicates which Operator/Operators will be ignored.
-  #ignored_ops: ["SUPPORTED","OPTIONS"]
+  ignored_ops: ["SUPPORTED","OPTIONS"]
 
 packetbeat.protocols.dns:
   # Enable DNS monitoring. Default: true
-  #enabled: true
+  enabled: true
 
   # Configure the ports where to listen for DNS traffic. You can disable
   # the DNS protocol by commenting out the list of ports.
@@ -149,16 +150,16 @@ packetbeat.protocols.dns:
   # fields, but this can be useful if you need visibility specifically
   # into the request or the response.
   # Default: false
-  # send_request:  true
-  # send_response: true
+  send_request:  false
+  send_response: false
 
   # Transaction timeout. Expired transactions will no longer be correlated to
   # incoming responses, but sent to Elasticsearch immediately.
-  #transaction_timeout: 10s
+  transaction_timeout: 10s
 
 packetbeat.protocols.http:
   # Enable HTTP monitoring. Default: true
-  #enabled: true
+  enabled: true
 
   # Configure the ports where to listen for HTTP traffic. You can disable
   # the HTTP protocol by commenting out the list of ports.
@@ -170,48 +171,48 @@ packetbeat.protocols.http:
   # This is generally useful for avoiding storing user passwords or other
   # sensitive information.
   # Only query parameters and top level form parameters are replaced.
-  # hide_keywords: ['pass', 'password', 'passwd']
+  #hide_keywords: ['pass', 'password', 'passwd']
 
   # A list of header names to capture and send to Elasticsearch. These headers
   # are placed under the `headers` dictionary in the resulting JSON.
-  #send_headers: false
+  send_headers: false
 
   # Instead of sending a white list of headers to Elasticsearch, you can send
   # all headers by setting this option to true. The default is false.
-  #send_all_headers: false
+  send_all_headers: false
 
   # The list of content types for which Packetbeat includes the full HTTP
   # payload in the response field.
-  #include_body_for: []
+  include_body_for: []
 
   # If the Cookie or Set-Cookie headers are sent, this option controls whether
   # they are split into individual values.
-  #split_cookie: false
+  split_cookie: false
 
   # The header field to extract the real IP from. This setting is useful when
   # you want to capture traffic behind a reverse proxy, but you want to get the
   # geo-location information.
-  #real_ip_header:
+  real_ip_header:
 
   # If this option is enabled, the raw message of the request (`request` field)
   # is sent to Elasticsearch. The default is false.
-  #send_request: false
+  send_request: false
 
   # If this option is enabled, the raw message of the response (`response`
   # field) is sent to Elasticsearch. The default is false.
-  #send_response: false
+  send_response: false
 
   # Transaction timeout. Expired transactions will no longer be correlated to
   # incoming responses, but sent to Elasticsearch immediately.
-  #transaction_timeout: 10s
+  transaction_timeout: 10s
 
   # Maximum message size. If an HTTP message is larger than this, it will
   # be trimmed to this size. Default is 10 MB.
-  #max_message_size: 10485760
+  max_message_size: 10485760
 
 packetbeat.protocols.memcache:
   # Enable memcache monitoring. Default: true
-  #enabled: true
+  enabled: true
 
   # Configure the ports where to listen for memcache traffic. You can disable
   # the Memcache protocol by commenting out the list of ports.
@@ -221,7 +222,7 @@ packetbeat.protocols.memcache:
   # to accept unknown commands.
   # Note: All unknown commands MUST not contain any data parts!
   # Default: false
-  # parseunknown: true
+  parseunknown: false
 
   # Update the maxvalue option to store the values - base64 encoded - in the
   # json output.
@@ -230,13 +231,13 @@ packetbeat.protocols.memcache:
   #    maxvalue: 0   # store no values at all
   #    maxvalue: N   # store up to N values
   # Default: 0
-  # maxvalues: -1
+  maxvalues: 0
 
   # Use maxbytespervalue to limit the number of bytes to be copied per value element.
   # Note: Values will be base64 encoded, so actual size in json document
   #       will be 4 times maxbytespervalue.
   # Default: unlimited
-  # maxbytespervalue: 100
+  #maxbytespervalue: 100
 
   # UDP transaction timeout in milliseconds.
   # Note: Quiet messages in UDP binary protocol will get response only in error case.
@@ -244,23 +245,23 @@ packetbeat.protocols.memcache:
   #       before publishing quiet messages. Non quiet messages or quiet requests with
   #       error response will not have to wait for the timeout.
   # Default: 200
-  # udptransactiontimeout: 1000
+  udptransactiontimeout: 200
 
   # If this option is enabled, the raw message of the request (`request` field)
   # is sent to Elasticsearch. The default is false.
-  #send_request: false
+  send_request: false
 
   # If this option is enabled, the raw message of the response (`response`
   # field) is sent to Elasticsearch. The default is false.
-  #send_response: false
+  send_response: false
 
   # Transaction timeout. Expired transactions will no longer be correlated to
   # incoming responses, but sent to Elasticsearch immediately.
-  #transaction_timeout: 10s
+  transaction_timeout: 10s
 
 packetbeat.protocols.mysql:
   # Enable mysql monitoring. Default: true
-  #enabled: true
+  enabled: true
 
   # Configure the ports where to listen for MySQL traffic. You can disable
   # the MySQL protocol by commenting out the list of ports.
@@ -268,19 +269,19 @@ packetbeat.protocols.mysql:
 
   # If this option is enabled, the raw message of the request (`request` field)
   # is sent to Elasticsearch. The default is false.
-  #send_request: false
+  send_request: false
 
   # If this option is enabled, the raw message of the response (`response`
   # field) is sent to Elasticsearch. The default is false.
-  #send_response: false
+  send_response: false
 
   # Transaction timeout. Expired transactions will no longer be correlated to
   # incoming responses, but sent to Elasticsearch immediately.
-  #transaction_timeout: 10s
+  transaction_timeout: 10s
 
 packetbeat.protocols.pgsql:
   # Enable pgsql monitoring. Default: true
-  #enabled: true
+  enabled: true
 
   # Configure the ports where to listen for Pgsql traffic. You can disable
   # the Pgsql protocol by commenting out the list of ports.
@@ -288,19 +289,19 @@ packetbeat.protocols.pgsql:
 
   # If this option is enabled, the raw message of the request (`request` field)
   # is sent to Elasticsearch. The default is false.
-  #send_request: false
+  send_request: false
 
   # If this option is enabled, the raw message of the response (`response`
   # field) is sent to Elasticsearch. The default is false.
-  #send_response: false
+  send_response: false
 
   # Transaction timeout. Expired transactions will no longer be correlated to
   # incoming responses, but sent to Elasticsearch immediately.
-  #transaction_timeout: 10s
+  transaction_timeout: 10s
 
 packetbeat.protocols.redis:
   # Enable redis monitoring. Default: true
-  #enabled: true
+  enabled: true
 
   # Configure the ports where to listen for Redis traffic. You can disable
   # the Redis protocol by commenting out the list of ports.
@@ -308,19 +309,19 @@ packetbeat.protocols.redis:
 
   # If this option is enabled, the raw message of the request (`request` field)
   # is sent to Elasticsearch. The default is false.
-  #send_request: false
+  send_request: false
 
   # If this option is enabled, the raw message of the response (`response`
   # field) is sent to Elasticsearch. The default is false.
-  #send_response: false
+  send_response: false
 
   # Transaction timeout. Expired transactions will no longer be correlated to
   # incoming responses, but sent to Elasticsearch immediately.
-  #transaction_timeout: 10s
+  transaction_timeout: 10s
 
 packetbeat.protocols.thrift:
   # Enable thrift monitoring. Default: true
-  #enabled: true
+  enabled: true
 
   # Configure the ports where to listen for Thrift-RPC traffic. You can disable
   # the Thrift-RPC protocol by commenting out the list of ports.
@@ -329,53 +330,53 @@ packetbeat.protocols.thrift:
   # The Thrift transport type. Currently this option accepts the values socket
   # for TSocket, which is the default Thrift transport, and framed for the
   # TFramed Thrift transport. The default is socket.
-  #transport_type: socket
+  transport_type: socket
 
   # The Thrift protocol type. Currently the only accepted value is binary for
   # the TBinary protocol, which is the default Thrift protocol.
-  #protocol_type: binary
+  protocol_type: binary
 
   # The Thrift interface description language (IDL) files for the service that
   # Packetbeat is monitoring.  Providing the IDL enables Packetbeat to include
   # parameter and exception names.
-  #idl_files: []
+  idl_files: []
 
   # The maximum length for strings in parameters or return values. If a string
   # is longer than this value, the string is automatically truncated to this
   # length.
-  #string_max_size: 200
+  string_max_size: 200
 
   # The maximum number of elements in a Thrift list, set, map, or structure.
-  #collection_max_size: 15
+  collection_max_size: 15
 
   # If this option is set to false, Packetbeat decodes the method name from the
   # reply and simply skips the rest of the response message.
-  #capture_reply: true
+  capture_reply: true
 
   # If this option is set to true, Packetbeat replaces all strings found in
   # method parameters, return codes, or exception structures with the "*"
   # string.
-  #obfuscate_strings: false
+  obfuscate_strings: false
 
   # The maximum number of fields that a structure can have before Packetbeat
   # ignores the whole transaction.
-  #drop_after_n_struct_fields: 500
+  drop_after_n_struct_fields: 500
 
   # If this option is enabled, the raw message of the request (`request` field)
   # is sent to Elasticsearch. The default is false.
-  #send_request: false
+  send_request: false
 
   # If this option is enabled, the raw message of the response (`response`
   # field) is sent to Elasticsearch. The default is false.
-  #send_response: false
+  send_response: false
 
   # Transaction timeout. Expired transactions will no longer be correlated to
   # incoming responses, but sent to Elasticsearch immediately.
-  #transaction_timeout: 10s
+  transaction_timeout: 10s
 
 packetbeat.protocols.mongodb:
   # Enable mongodb monitoring. Default: true
-  #enabled: true
+  enabled: true
 
   # Configure the ports where to listen for MongoDB traffic. You can disable
   # the MongoDB protocol by commenting out the list of ports.
@@ -384,28 +385,28 @@ packetbeat.protocols.mongodb:
 
   # The maximum number of documents from the response to index in the `response`
   # field. The default is 10.
-  #max_docs: 10
+  max_docs: 10
 
   # The maximum number of characters in a single document indexed in the
   # `response` field. The default is 5000. You can set this to 0 to index an
   # unlimited number of characters per document.
-  #max_doc_length: 5000
+  max_doc_length: 5000
 
   # If this option is enabled, the raw message of the request (`request` field)
   # is sent to Elasticsearch. The default is false.
-  #send_request: false
+  send_request: false
 
   # If this option is enabled, the raw message of the response (`response`
   # field) is sent to Elasticsearch. The default is false.
-  #send_response: false
+  send_response: false
 
   # Transaction timeout. Expired transactions will no longer be correlated to
   # incoming responses, but sent to Elasticsearch immediately.
-  #transaction_timeout: 10s
+  transaction_timeout: 10s
 
 packetbeat.protocols.nfs:
   # Enable NFS monitoring. Default: true
-  #enabled: true
+  enabled: true
 
   # Configure the ports where to listen for NFS traffic. You can disable
   # the NFS protocol by commenting out the list of ports.
@@ -413,15 +414,15 @@ packetbeat.protocols.nfs:
 
   # If this option is enabled, the raw message of the request (`request` field)
   # is sent to Elasticsearch. The default is false.
-  #send_request: false
+  send_request: false
 
   # If this option is enabled, the raw message of the response (`response`
   # field) is sent to Elasticsearch. The default is false.
-  #send_response: false
+  send_response: false
 
   # Transaction timeout. Expired transactions will no longer be correlated to
   # incoming responses, but sent to Elasticsearch immediately.
-  #transaction_timeout: 10s
+  transaction_timeout: 10s
 
 #=========================== Monitored processes ==============================
 
@@ -448,7 +449,7 @@ packetbeat.protocols.nfs:
 #    - process: app
 #      cmdline_grep: gunicorn
 
-# Uncomment the following if you want to ignore transactions created
+# Set the following to true if you want to ignore transactions created
 # by the server on which the shipper is installed. This option is useful
 # to remove duplicates if shippers are installed on multiple servers.
-#packetbeat.ignore_outgoing: true
+packetbeat.ignore_outgoing: false

--- a/packetbeat/packetbeat.full.yml
+++ b/packetbeat/packetbeat.full.yml
@@ -21,19 +21,19 @@ packetbeat.interfaces.device: any
 # * pf_ring, which makes use of an ntop.org project. This setting provides the
 # best sniffing speed, but it requires a kernel module, and it's Linux-specific.
 # The default sniffer type is pcap.
-#packetbeat.interfaces.type: pcap
+packetbeat.interfaces.type: pcap
 
 # The maximum size of the packets to capture. The default is 65535, which is
 # large enough for almost all networks and interface types. If you sniff on a
 # physical network interface, the optimal setting is the MTU size. On virtual
 # interfaces, however, it's safer to accept the default value.
-#packetbeat.interfaces.snaplen: 65535
+packetbeat.interfaces.snaplen: 65535
 
 # The maximum size of the shared memory buffer to use between the kernel and
 # user space. A bigger buffer usually results in lower CPU usage, but consumes
 # more memory. This setting is only available for the af_packet sniffer type.
 # The default is 30 MB.
-#packetbeat.interfaces.buffer_size_mb: 30
+packetbeat.interfaces.buffer_size_mb: 30
 
 # Packetbeat automatically generates a BPF for capturing only the traffic on
 # ports where it expects to find known protocols. Use this settings to tell
@@ -47,7 +47,7 @@ packetbeat.interfaces.device: any
 
 packetbeat.flows:
   # Enable Network flows. Default: true
-  #enabled: true
+  enabled: true
 
   # Set network flow timeout. Flow is killed if no packet is received before being
   # timed out.
@@ -60,44 +60,45 @@ packetbeat.flows:
 
 packetbeat.protocols.icmp:
   # Enable ICMPv4 and ICMPv6 monitoring. Default: true
-  #enabled: true
+  enabled: true
 
 packetbeat.protocols.amqp:
   # Enable AMQP monitoring. Default: true
-  #enabled: true
+  enabled: true
 
   # Configure the ports where to listen for AMQP traffic. You can disable
   # the AMQP protocol by commenting out the list of ports.
   ports: [5672]
+
   # Truncate messages that are published and avoid huge messages being
   # indexed.
   # Default: 1000
-  #max_body_length: 1000
+  max_body_length: 1000
 
   # Hide the header fields in header frames.
   # Default: false
-  #parse_headers: false
+  parse_headers: false
 
   # Hide the additional arguments of method frames.
   # Default: false
-  #parse_arguments: false
+  parse_arguments: false
 
   # Hide all methods relative to connection negociation between server and
   # client.
   # Default: true
-  #hide_connection_information: true
+  hide_connection_information: true
 
   # If this option is enabled, the raw message of the request (`request` field)
   # is sent to Elasticsearch. The default is false.
-  #send_request: false
+  send_request: false
 
   # If this option is enabled, the raw message of the response (`response`
   # field) is sent to Elasticsearch. The default is false.
-  #send_response: false
+  send_response: false
 
   # Transaction timeout. Expired transactions will no longer be correlated to
   # incoming responses, but sent to Elasticsearch immediately.
-  #transaction_timeout: 10s
+  transaction_timeout: 10s
 
 packetbeat.protocols.cassandra:
   #Cassandra port for traffic monitoring.
@@ -105,30 +106,30 @@ packetbeat.protocols.cassandra:
 
   # If this option is enabled, the raw message of the request (`cassandra_request` field)
   # is included in published events. The default is true.
-  #send_request: true
+  send_request: true
 
   # If this option is enabled, the raw message of the response (`cassandra_request.request_headers` field)
   # is included in published events. The default is true. enable `send_request` first before enable this option.
-  #send_request_header: true
+  send_request_header: true
 
   # If this option is enabled, the raw message of the response (`cassandra_response` field)
   # is included in published events. The default is true.
-  #send_response: true
+  send_response: true
 
   # If this option is enabled, the raw message of the response (`cassandra_response.response_headers` field)
   # is included in published events. The default is true. enable `send_response` first before enable this option.
-  #send_response_header: true
+  send_response_header: true
 
   # Configures the default compression algorithm being used to uncompress compressed frames by name. Currently only `snappy` is can be configured.
   # By default no compressor is configured.
-  #compressor: "snappy"
+  compressor: "snappy"
 
   # This option indicates which Operator/Operators will be ignored.
-  #ignored_ops: ["SUPPORTED","OPTIONS"]
+  ignored_ops: ["SUPPORTED","OPTIONS"]
 
 packetbeat.protocols.dns:
   # Enable DNS monitoring. Default: true
-  #enabled: true
+  enabled: true
 
   # Configure the ports where to listen for DNS traffic. You can disable
   # the DNS protocol by commenting out the list of ports.
@@ -149,16 +150,16 @@ packetbeat.protocols.dns:
   # fields, but this can be useful if you need visibility specifically
   # into the request or the response.
   # Default: false
-  # send_request:  true
-  # send_response: true
+  send_request:  false
+  send_response: false
 
   # Transaction timeout. Expired transactions will no longer be correlated to
   # incoming responses, but sent to Elasticsearch immediately.
-  #transaction_timeout: 10s
+  transaction_timeout: 10s
 
 packetbeat.protocols.http:
   # Enable HTTP monitoring. Default: true
-  #enabled: true
+  enabled: true
 
   # Configure the ports where to listen for HTTP traffic. You can disable
   # the HTTP protocol by commenting out the list of ports.
@@ -170,48 +171,48 @@ packetbeat.protocols.http:
   # This is generally useful for avoiding storing user passwords or other
   # sensitive information.
   # Only query parameters and top level form parameters are replaced.
-  # hide_keywords: ['pass', 'password', 'passwd']
+  #hide_keywords: ['pass', 'password', 'passwd']
 
   # A list of header names to capture and send to Elasticsearch. These headers
   # are placed under the `headers` dictionary in the resulting JSON.
-  #send_headers: false
+  send_headers: false
 
   # Instead of sending a white list of headers to Elasticsearch, you can send
   # all headers by setting this option to true. The default is false.
-  #send_all_headers: false
+  send_all_headers: false
 
   # The list of content types for which Packetbeat includes the full HTTP
   # payload in the response field.
-  #include_body_for: []
+  include_body_for: []
 
   # If the Cookie or Set-Cookie headers are sent, this option controls whether
   # they are split into individual values.
-  #split_cookie: false
+  split_cookie: false
 
   # The header field to extract the real IP from. This setting is useful when
   # you want to capture traffic behind a reverse proxy, but you want to get the
   # geo-location information.
-  #real_ip_header:
+  real_ip_header:
 
   # If this option is enabled, the raw message of the request (`request` field)
   # is sent to Elasticsearch. The default is false.
-  #send_request: false
+  send_request: false
 
   # If this option is enabled, the raw message of the response (`response`
   # field) is sent to Elasticsearch. The default is false.
-  #send_response: false
+  send_response: false
 
   # Transaction timeout. Expired transactions will no longer be correlated to
   # incoming responses, but sent to Elasticsearch immediately.
-  #transaction_timeout: 10s
+  transaction_timeout: 10s
 
   # Maximum message size. If an HTTP message is larger than this, it will
   # be trimmed to this size. Default is 10 MB.
-  #max_message_size: 10485760
+  max_message_size: 10485760
 
 packetbeat.protocols.memcache:
   # Enable memcache monitoring. Default: true
-  #enabled: true
+  enabled: true
 
   # Configure the ports where to listen for memcache traffic. You can disable
   # the Memcache protocol by commenting out the list of ports.
@@ -221,7 +222,7 @@ packetbeat.protocols.memcache:
   # to accept unknown commands.
   # Note: All unknown commands MUST not contain any data parts!
   # Default: false
-  # parseunknown: true
+  parseunknown: false
 
   # Update the maxvalue option to store the values - base64 encoded - in the
   # json output.
@@ -230,13 +231,13 @@ packetbeat.protocols.memcache:
   #    maxvalue: 0   # store no values at all
   #    maxvalue: N   # store up to N values
   # Default: 0
-  # maxvalues: -1
+  maxvalues: 0
 
   # Use maxbytespervalue to limit the number of bytes to be copied per value element.
   # Note: Values will be base64 encoded, so actual size in json document
   #       will be 4 times maxbytespervalue.
   # Default: unlimited
-  # maxbytespervalue: 100
+  #maxbytespervalue: 100
 
   # UDP transaction timeout in milliseconds.
   # Note: Quiet messages in UDP binary protocol will get response only in error case.
@@ -244,23 +245,23 @@ packetbeat.protocols.memcache:
   #       before publishing quiet messages. Non quiet messages or quiet requests with
   #       error response will not have to wait for the timeout.
   # Default: 200
-  # udptransactiontimeout: 1000
+  udptransactiontimeout: 200
 
   # If this option is enabled, the raw message of the request (`request` field)
   # is sent to Elasticsearch. The default is false.
-  #send_request: false
+  send_request: false
 
   # If this option is enabled, the raw message of the response (`response`
   # field) is sent to Elasticsearch. The default is false.
-  #send_response: false
+  send_response: false
 
   # Transaction timeout. Expired transactions will no longer be correlated to
   # incoming responses, but sent to Elasticsearch immediately.
-  #transaction_timeout: 10s
+  transaction_timeout: 10s
 
 packetbeat.protocols.mysql:
   # Enable mysql monitoring. Default: true
-  #enabled: true
+  enabled: true
 
   # Configure the ports where to listen for MySQL traffic. You can disable
   # the MySQL protocol by commenting out the list of ports.
@@ -268,19 +269,19 @@ packetbeat.protocols.mysql:
 
   # If this option is enabled, the raw message of the request (`request` field)
   # is sent to Elasticsearch. The default is false.
-  #send_request: false
+  send_request: false
 
   # If this option is enabled, the raw message of the response (`response`
   # field) is sent to Elasticsearch. The default is false.
-  #send_response: false
+  send_response: false
 
   # Transaction timeout. Expired transactions will no longer be correlated to
   # incoming responses, but sent to Elasticsearch immediately.
-  #transaction_timeout: 10s
+  transaction_timeout: 10s
 
 packetbeat.protocols.pgsql:
   # Enable pgsql monitoring. Default: true
-  #enabled: true
+  enabled: true
 
   # Configure the ports where to listen for Pgsql traffic. You can disable
   # the Pgsql protocol by commenting out the list of ports.
@@ -288,19 +289,19 @@ packetbeat.protocols.pgsql:
 
   # If this option is enabled, the raw message of the request (`request` field)
   # is sent to Elasticsearch. The default is false.
-  #send_request: false
+  send_request: false
 
   # If this option is enabled, the raw message of the response (`response`
   # field) is sent to Elasticsearch. The default is false.
-  #send_response: false
+  send_response: false
 
   # Transaction timeout. Expired transactions will no longer be correlated to
   # incoming responses, but sent to Elasticsearch immediately.
-  #transaction_timeout: 10s
+  transaction_timeout: 10s
 
 packetbeat.protocols.redis:
   # Enable redis monitoring. Default: true
-  #enabled: true
+  enabled: true
 
   # Configure the ports where to listen for Redis traffic. You can disable
   # the Redis protocol by commenting out the list of ports.
@@ -308,19 +309,19 @@ packetbeat.protocols.redis:
 
   # If this option is enabled, the raw message of the request (`request` field)
   # is sent to Elasticsearch. The default is false.
-  #send_request: false
+  send_request: false
 
   # If this option is enabled, the raw message of the response (`response`
   # field) is sent to Elasticsearch. The default is false.
-  #send_response: false
+  send_response: false
 
   # Transaction timeout. Expired transactions will no longer be correlated to
   # incoming responses, but sent to Elasticsearch immediately.
-  #transaction_timeout: 10s
+  transaction_timeout: 10s
 
 packetbeat.protocols.thrift:
   # Enable thrift monitoring. Default: true
-  #enabled: true
+  enabled: true
 
   # Configure the ports where to listen for Thrift-RPC traffic. You can disable
   # the Thrift-RPC protocol by commenting out the list of ports.
@@ -329,53 +330,53 @@ packetbeat.protocols.thrift:
   # The Thrift transport type. Currently this option accepts the values socket
   # for TSocket, which is the default Thrift transport, and framed for the
   # TFramed Thrift transport. The default is socket.
-  #transport_type: socket
+  transport_type: socket
 
   # The Thrift protocol type. Currently the only accepted value is binary for
   # the TBinary protocol, which is the default Thrift protocol.
-  #protocol_type: binary
+  protocol_type: binary
 
   # The Thrift interface description language (IDL) files for the service that
   # Packetbeat is monitoring.  Providing the IDL enables Packetbeat to include
   # parameter and exception names.
-  #idl_files: []
+  idl_files: []
 
   # The maximum length for strings in parameters or return values. If a string
   # is longer than this value, the string is automatically truncated to this
   # length.
-  #string_max_size: 200
+  string_max_size: 200
 
   # The maximum number of elements in a Thrift list, set, map, or structure.
-  #collection_max_size: 15
+  collection_max_size: 15
 
   # If this option is set to false, Packetbeat decodes the method name from the
   # reply and simply skips the rest of the response message.
-  #capture_reply: true
+  capture_reply: true
 
   # If this option is set to true, Packetbeat replaces all strings found in
   # method parameters, return codes, or exception structures with the "*"
   # string.
-  #obfuscate_strings: false
+  obfuscate_strings: false
 
   # The maximum number of fields that a structure can have before Packetbeat
   # ignores the whole transaction.
-  #drop_after_n_struct_fields: 500
+  drop_after_n_struct_fields: 500
 
   # If this option is enabled, the raw message of the request (`request` field)
   # is sent to Elasticsearch. The default is false.
-  #send_request: false
+  send_request: false
 
   # If this option is enabled, the raw message of the response (`response`
   # field) is sent to Elasticsearch. The default is false.
-  #send_response: false
+  send_response: false
 
   # Transaction timeout. Expired transactions will no longer be correlated to
   # incoming responses, but sent to Elasticsearch immediately.
-  #transaction_timeout: 10s
+  transaction_timeout: 10s
 
 packetbeat.protocols.mongodb:
   # Enable mongodb monitoring. Default: true
-  #enabled: true
+  enabled: true
 
   # Configure the ports where to listen for MongoDB traffic. You can disable
   # the MongoDB protocol by commenting out the list of ports.
@@ -384,28 +385,28 @@ packetbeat.protocols.mongodb:
 
   # The maximum number of documents from the response to index in the `response`
   # field. The default is 10.
-  #max_docs: 10
+  max_docs: 10
 
   # The maximum number of characters in a single document indexed in the
   # `response` field. The default is 5000. You can set this to 0 to index an
   # unlimited number of characters per document.
-  #max_doc_length: 5000
+  max_doc_length: 5000
 
   # If this option is enabled, the raw message of the request (`request` field)
   # is sent to Elasticsearch. The default is false.
-  #send_request: false
+  send_request: false
 
   # If this option is enabled, the raw message of the response (`response`
   # field) is sent to Elasticsearch. The default is false.
-  #send_response: false
+  send_response: false
 
   # Transaction timeout. Expired transactions will no longer be correlated to
   # incoming responses, but sent to Elasticsearch immediately.
-  #transaction_timeout: 10s
+  transaction_timeout: 10s
 
 packetbeat.protocols.nfs:
   # Enable NFS monitoring. Default: true
-  #enabled: true
+  enabled: true
 
   # Configure the ports where to listen for NFS traffic. You can disable
   # the NFS protocol by commenting out the list of ports.
@@ -413,15 +414,15 @@ packetbeat.protocols.nfs:
 
   # If this option is enabled, the raw message of the request (`request` field)
   # is sent to Elasticsearch. The default is false.
-  #send_request: false
+  send_request: false
 
   # If this option is enabled, the raw message of the response (`response`
   # field) is sent to Elasticsearch. The default is false.
-  #send_response: false
+  send_response: false
 
   # Transaction timeout. Expired transactions will no longer be correlated to
   # incoming responses, but sent to Elasticsearch immediately.
-  #transaction_timeout: 10s
+  transaction_timeout: 10s
 
 #=========================== Monitored processes ==============================
 
@@ -448,17 +449,17 @@ packetbeat.protocols.nfs:
 #    - process: app
 #      cmdline_grep: gunicorn
 
-# Uncomment the following if you want to ignore transactions created
+# Set the following to true if you want to ignore transactions created
 # by the server on which the shipper is installed. This option is useful
 # to remove duplicates if shippers are installed on multiple servers.
-#packetbeat.ignore_outgoing: true
+packetbeat.ignore_outgoing: false
 
 #================================ General ======================================
 
 # The name of the shipper that publishes the network data. It can be used to group
 # all the transactions sent by a single shipper in the web interface.
 # If this options is not defined, the hostname is used.
-#name:
+name:
 
 # The tags of the shipper are included in their own field with each
 # transaction published. Tags make it easy to group servers by different
@@ -474,14 +475,14 @@ packetbeat.protocols.nfs:
 # If this option is set to true, the custom fields are stored as top-level
 # fields in the output document instead of being grouped under a fields
 # sub-dictionary. Default is false.
-#fields_under_root: false
+fields_under_root: false
 
 # Internal queue size for single events in processing pipeline
-#queue_size: 1000
+queue_size: 1000
 
 # The internal queue size for bulk events in the processing pipeline.
 # Do not modify this value.
-#bulk_queue_size: 0
+bulk_queue_size: 0
 
 # Sets the maximum number of CPUs that can be executing simultaneously. The
 # default is the number of logical CPUs available in the system.
@@ -532,7 +533,7 @@ packetbeat.protocols.nfs:
 #-------------------------- Elasticsearch output -------------------------------
 output.elasticsearch:
   # Boolean flag to enable or disable the output module.
-  #enabled: true
+  enabled: true
 
   # Array of hosts to connect to.
   # Scheme and port can be left out and will be set to the default (http and 9200)
@@ -541,7 +542,7 @@ output.elasticsearch:
   hosts: ["localhost:9200"]
 
   # Set gzip compression level.
-  #compression_level: 0
+  compression_level: 0
 
   # Optional protocol and basic auth credentials.
   #protocol: "https"
@@ -554,422 +555,422 @@ output.elasticsearch:
     #param2: value2
 
   # Number of workers per Elasticsearch host.
-  #worker: 1
+  worker: 1
 
   # Optional index name. The default is "packetbeat" plus date
   # and generates [packetbeat-]YYYY.MM.DD keys.
-  #index: "packetbeat-%{+yyyy.MM.dd}"
+  index: "packetbeat-%{+yyyy.MM.dd}"
 
   # Optional ingest node pipeline. By default no pipeline will be used.
-  #pipeline: ""
+  pipeline: ""
 
-  # Optional HTTP Path
-  #path: "/elasticsearch"
+  # Optional HTTP Path. Example: /elasticsearch
+  path:
 
-  # Proxy server url
-  #proxy_url: http://proxy:3128
+  # Proxy server url. Example: http://proxy:3128
+  proxy_url:
 
   # The number of times a particular Elasticsearch index operation is attempted. If
   # the indexing operation doesn't succeed after this many retries, the events are
   # dropped. The default is 3.
-  #max_retries: 3
+  max_retries: 3
 
   # The maximum number of events to bulk in a single Elasticsearch bulk API index request.
   # The default is 50.
-  #bulk_max_size: 50
+  bulk_max_size: 50
 
   # Configure http request timeout before failing an request to Elasticsearch.
-  #timeout: 90
+  timeout: 90
 
   # The number of seconds to wait for new events between two bulk API index requests.
   # If `bulk_max_size` is reached before this interval expires, addition bulk index
   # requests are made.
-  #flush_interval: 1s
+  flush_interval: 1s
 
   # A template is used to set the mapping in Elasticsearch
   # By default template loading is enabled and the template is loaded.
   # These settings can be adjusted to load your own template or overwrite existing ones.
 
   # Set to false to disable template loading.
-  #template.enabled: true
+  template.enabled: true
 
   # Template name. By default the template name is packetbeat.
-  #template.name: "packetbeat"
+  template.name: "packetbeat"
 
   # Path to template file
-  #template.path: "${path.config}/packetbeat.template.json"
+  template.path: "${path.config}/packetbeat.template.json"
 
   # Overwrite existing template
-  #template.overwrite: false
+  #emplate.overwrite: false
 
   # If set to true, packetbeat checks the Elasticsearch version at connect time, and if it
   # is 2.x, it loads the file specified by the template.versions.2x.path setting. The
   # default is true.
-  #template.versions.2x.enabled: true
+  template.versions.2x.enabled: true
 
   # Path to the Elasticsearch 2.x version of the template file.
-  #template.versions.2x.path: "${path.config}/packetbeat.template-es2x.json"
+  template.versions.2x.path: "${path.config}/packetbeat.template-es2x.json"
 
   # Use SSL settings for HTTPS. Default is true.
-  #ssl.enabled: true
+  ssl.enabled: false
 
   # Configure SSL verification mode. If `none` is configured, all server hosts
   # and certificates will be accepted. In this mode, SSL based connections are
   # susceptible to man-in-the-middle attacks. Use only for testing. Default is
   # `full`.
-  #ssl.verification_mode: full
+  ssl.verification_mode: full
 
   # List of supported/valid TLS versions. By default all TLS versions 1.0 up to
   # 1.2 are enabled.
-  #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
+  ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
 
-  # SSL configuration. By default is off.
+  # SSL configuration. By default is off. TODO
   # List of root certificates for HTTPS server verifications
-  #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
+  ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
   # Certificate for SSL client authentication
-  #ssl.certificate: "/etc/pki/client/cert.pem"
+  ssl.certificate: "/etc/pki/client/cert.pem"
 
   # Client Certificate Key
-  #ssl.key: "/etc/pki/client/cert.key"
+  ssl.key: "/etc/pki/client/cert.key"
 
   # Optional passphrase for decrypting the Certificate Key.
-  #ssl.key_passphrase: ''
+  ssl.key_passphrase: ''
 
   # Configure cipher suites to be used for SSL connections
-  #ssl.cipher_suites: []
+  ssl.cipher_suites: []
 
   # Configure curve types for ECDHE based cipher suites
-  #ssl.curve_types: []
+  ssl.curve_types: []
 
 
 #----------------------------- Logstash output ---------------------------------
-#output.logstash:
+output.logstash:
   # Boolean flag to enable or disable the output module.
-  #enabled: true
+  enabled: false
 
   # The Logstash hosts
-  #hosts: ["localhost:5044"]
+  hosts: ["localhost:5044"]
 
   # Number of workers per Logstash host.
-  #worker: 1
+  worker: 1
 
   # Set gzip compression level.
-  #compression_level: 3
+  compression_level: 3
 
   # Optional load balance the events between the Logstash hosts
-  #loadbalance: true
+  loadbalance: true
 
   # Number of batches to be send asynchronously to logstash while processing
   # new batches.
-  #pipelining: 0
+  pipelining: 0
 
   # Optional index name. The default index name is set to name of the beat
   # in all lowercase.
-  #index: 'packetbeat'
+  index: 'packetbeat'
 
   # SOCKS5 proxy server URL
-  #proxy_url: socks5://user:password@socks5-server:2233
+  proxy_url: socks5://user:password@socks5-server:2233
 
   # Resolve names locally when using a proxy server. Defaults to false.
-  #proxy_use_local_resolver: false
+  proxy_use_local_resolver: false
 
   # Enable SSL support. SSL is automatically enabled, if any SSL setting is set.
-  #ssl.enabled: true
+  ssl.enabled: false
 
   # Configure SSL verification mode. If `none` is configured, all server hosts
   # and certificates will be accepted. In this mode, SSL based connections are
   # susceptible to man-in-the-middle attacks. Use only for testing. Default is
   # `full`.
-  #ssl.verification_mode: full
+  ssl.verification_mode: full
 
   # List of supported/valid TLS versions. By default all TLS versions 1.0 up to
   # 1.2 are enabled.
-  #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
+  ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
 
   # Optional SSL configuration options. SSL is off by default.
   # List of root certificates for HTTPS server verifications
-  #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
+  ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
   # Certificate for SSL client authentication
-  #ssl.certificate: "/etc/pki/client/cert.pem"
+  ssl.certificate: "/etc/pki/client/cert.pem"
 
   # Client Certificate Key
-  #ssl.key: "/etc/pki/client/cert.key"
+  ssl.key: "/etc/pki/client/cert.key"
 
   # Optional passphrase for decrypting the Certificate Key.
-  #ssl.key_passphrase: ''
+  ssl.key_passphrase: ''
 
   # Configure cipher suites to be used for SSL connections
-  #ssl.cipher_suites: []
+  ssl.cipher_suites: []
 
   # Configure curve types for ECDHE based cipher suites
-  #ssl.curve_types: []
+  ssl.curve_types: []
 
 #------------------------------- Kafka output ----------------------------------
-#output.kafka:
+output.kafka:
   # Boolean flag to enable or disable the output module.
-  #enabled: true
+  enabled: false
 
   # The list of Kafka broker addresses from where to fetch the cluster metadata.
   # The cluster metadata contain the actual Kafka brokers events are published
   # to.
-  #hosts: ["localhost:9092"]
+  hosts: ["localhost:9092"]
 
   # The Kafka topic used for produced events. The setting can be a format string
   # using any event field. To set the topic from document type use `%{[type]}`.
-  #topic: beats
+  topic: beats
 
   # The Kafka event key setting. Use format string to create unique event key.
   # By default no event key will be generated.
-  #key: ''
+  key: ''
 
   # The Kafka event partitioning strategy. Default hashing strategy is `hash`
   # using the `output.kafka.key` setting or randomly distributes events if
   # `output.kafka.key` is not configured.
-  #partition.hash:
+  partition.hash:
     # If enabled, events will only be published to partitions with reachable
     # leaders. Default is false.
-    #reachable_only: false
+    reachable_only: false
 
     # Configure alternative event field names used to compute the hash value.
     # If empty `output.kafka.key` setting will be used.
     # Default value is empty list.
-    #hash: []
+    hash: []
 
   # Authentication details. Password is required if username is set.
-  #username: ''
-  #password: ''
+  username: ''
+  password: ''
 
   # Kafka version packetbeat is assumed to run against. Defaults to the oldest
   # supported stable version (currently version 0.8.2.0)
-  #version: 0.8.2
+  version: 0.8.2
 
   # Metadata update configuration. Metadata do contain leader information
   # deciding which broker to use when publishing.
-  #metadata:
+  metadata:
     # Max metadata request retry attempts when cluster is in middle of leader
     # election. Defaults to 3 retries.
-    #retry.max: 3
+    retry.max: 3
 
     # Waiting time between retries during leader elections. Default is 250ms.
-    #retry.backoff: 250ms
+    retry.backoff: 250ms
 
     # Refresh metadata interval. Defaults to every 10 minutes.
-    #refresh_frequency: 10m
+    refresh_frequency: 10m
 
   # The number of concurrent load-balanced Kafka output workers.
-  #worker: 1
+  worker: 1
 
   # The number of times to retry publishing an event after a publishing failure.
   # After the specified number of retries, the events are typically dropped.
   # Some Beats, such as Filebeat, ignore the max_retries setting and retry until
   # all events are published.  Set max_retries to a value less than 0 to retry
   # until all events are published. The default is 3.
-  #max_retries: 3
+  max_retries: 3
 
   # The maximum number of events to bulk in a single Kafka request. The default
   # is 2048.
-  #bulk_max_size: 2048
+  bulk_max_size: 2048
 
   # The number of seconds to wait for responses from the Kafka brokers before
   # timing out. The default is 30s.
-  #timeout: 30s
+  timeout: 30s
 
   # The maximum duration a broker will wait for number of required ACKs. The
   # default is 10s.
-  #broker_timeout: 10s
+  broker_timeout: 10s
 
   # The number of messages buffered for each Kafka broker. The default is 256.
-  #channel_buffer_size: 256
+  channel_buffer_size: 256
 
   # The keep-alive period for an active network connection. If 0s, keep-alives
   # are disabled. The default is 0 seconds.
-  #keep_alive: 0
+  keep_alive: 0
 
   # Sets the output compression codec. Must be one of none, snappy and gzip. The
   # default is gzip.
-  #compression: gzip
+  compression: gzip
 
   # The maximum permitted size of JSON-encoded messages. Bigger messages will be
   # dropped. The default value is 1000000 (bytes). This value should be equal to
   # or less than the broker's message.max.bytes.
-  #max_message_bytes: 1000000
+  max_message_bytes: 1000000
 
   # The ACK reliability level required from broker. 0=no response, 1=wait for
   # local commit, -1=wait for all replicas to commit. The default is 1.  Note:
   # If set to 0, no ACKs are returned by Kafka. Messages might be lost silently
   # on error.
-  #required_acks: 1
+  required_acks: 1
 
   # The number of seconds to wait for new events between two producer API calls.
-  #flush_interval: 1s
+  flush_interval: 1s
 
   # The configurable ClientID used for logging, debugging, and auditing
   # purposes.  The default is "beats".
-  #client_id: beats
+  client_id: beats
 
   # Enable SSL support. SSL is automatically enabled, if any SSL setting is set.
-  #ssl.enabled: true
+  ssl.enabled: false
 
   # Optional SSL configuration options. SSL is off by default.
   # List of root certificates for HTTPS server verifications
-  #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
+  ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
   # Configure SSL verification mode. If `none` is configured, all server hosts
   # and certificates will be accepted. In this mode, SSL based connections are
   # susceptible to man-in-the-middle attacks. Use only for testing. Default is
   # `full`.
-  #ssl.verification_mode: full
+  ssl.verification_mode: full
 
   # List of supported/valid TLS versions. By default all TLS versions 1.0 up to
   # 1.2 are enabled.
-  #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
+  ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
 
   # Certificate for SSL client authentication
-  #ssl.certificate: "/etc/pki/client/cert.pem"
+  ssl.certificate: "/etc/pki/client/cert.pem"
 
   # Client Certificate Key
-  #ssl.key: "/etc/pki/client/cert.key"
+  ssl.key: "/etc/pki/client/cert.key"
 
   # Optional passphrase for decrypting the Certificate Key.
-  #ssl.key_passphrase: ''
+  ssl.key_passphrase: ''
 
   # Configure cipher suites to be used for SSL connections
-  #ssl.cipher_suites: []
+  ssl.cipher_suites: []
 
   # Configure curve types for ECDHE based cipher suites
-  #ssl.curve_types: []
+  ssl.curve_types: []
 
 #------------------------------- Redis output ----------------------------------
-#output.redis:
+output.redis:
   # Boolean flag to enable or disable the output module.
-  #enabled: true
+  enabled: false
 
   # The list of Redis servers to connect to. If load balancing is enabled, the
   # events are distributed to the servers in the list. If one server becomes
   # unreachable, the events are distributed to the reachable servers only.
-  #hosts: ["localhost:6379"]
+  hosts: ["localhost:6379"]
 
   # The Redis port to use if hosts does not contain a port number. The default
   # is 6379.
-  #port: 6379
+  port: 6379
 
   # The name of the Redis list or channel the events are published to. The
   # default is packetbeat.
-  #key: packetbeat
+  key: packetbeat
 
   # The password to authenticate with. The default is no authentication.
-  #password:
+  password:
 
   # The Redis database number where the events are published. The default is 0.
-  #db: 0
+  db: 0
 
   # The Redis data type to use for publishing events. If the data type is list,
   # the Redis RPUSH command is used. If the data type is channel, the Redis
   # PUBLISH command is used. The default value is list.
-  #datatype: list
+  datatype: list
 
   # The number of workers to use for each host configured to publish events to
   # Redis. Use this setting along with the loadbalance option. For example, if
   # you have 2 hosts and 3 workers, in total 6 workers are started (3 for each
   # host).
-  #worker: 1
+  worker: 1
 
   # If set to true and multiple hosts or workers are configured, the output
   # plugin load balances published events onto all Redis hosts. If set to false,
   # the output plugin sends all events to only one host (determined at random)
   # and will switch to another host if the currently selected one becomes
   # unreachable. The default value is true.
-  #loadbalance: true
+  loadbalance: true
 
   # The Redis connection timeout in seconds. The default is 5 seconds.
-  #timeout: 5s
+  timeout: 5s
 
   # The number of times to retry publishing an event after a publishing failure.
   # After the specified number of retries, the events are typically dropped.
   # Some Beats, such as Filebeat, ignore the max_retries setting and retry until
   # all events are published. Set max_retries to a value less than 0 to retry
   # until all events are published. The default is 3.
-  #max_retries: 3
+  max_retries: 3
 
   # The maximum number of events to bulk in a single Redis request or pipeline.
   # The default is 2048.
-  #bulk_max_size: 2048
+  bulk_max_size: 2048
 
   # The URL of the SOCKS5 proxy to use when connecting to the Redis servers. The
   # value must be a URL with a scheme of socks5://.
-  #proxy_url:
+  proxy_url:
 
   # This option determines whether Redis hostnames are resolved locally when
   # using a proxy. The default value is false, which means that name resolution
   # occurs on the proxy server.
-  #proxy_use_local_resolver: false
+  proxy_use_local_resolver: false
 
   # Enable SSL support. SSL is automatically enabled, if any SSL setting is set.
-  #ssl.enabled: true
+  ssl.enabled: false
 
   # Configure SSL verification mode. If `none` is configured, all server hosts
   # and certificates will be accepted. In this mode, SSL based connections are
   # susceptible to man-in-the-middle attacks. Use only for testing. Default is
   # `full`.
-  #ssl.verification_mode: full
+  ssl.verification_mode: full
 
   # List of supported/valid TLS versions. By default all TLS versions 1.0 up to
   # 1.2 are enabled.
-  #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
+  ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
 
   # Optional SSL configuration options. SSL is off by default.
   # List of root certificates for HTTPS server verifications
-  #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
+  ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
   # Certificate for SSL client authentication
-  #ssl.certificate: "/etc/pki/client/cert.pem"
+  ssl.certificate: "/etc/pki/client/cert.pem"
 
   # Client Certificate Key
-  #ssl.key: "/etc/pki/client/cert.key"
+  ssl.key: "/etc/pki/client/cert.key"
 
   # Optional passphrase for decrypting the Certificate Key.
-  #ssl.key_passphrase: ''
+  ssl.key_passphrase: ''
 
   # Configure cipher suites to be used for SSL connections
-  #ssl.cipher_suites: []
+  ssl.cipher_suites: []
 
   # Configure curve types for ECDHE based cipher suites
-  #ssl.curve_types: []
+  ssl.curve_types: []
 
 
 #------------------------------- File output -----------------------------------
-#output.file:
+output.file:
   # Boolean flag to enable or disable the output module.
-  #enabled: true
+  enabled: false
 
   # Path to the directory where to save the generated files. The option is
   # mandatory.
-  #path: "/tmp/packetbeat"
+  path: "/tmp/packetbeat"
 
   # Name of the generated files. The default is `packetbeat` and it generates
   # files: `packetbeat`, `packetbeat.1`, `packetbeat.2`, etc.
-  #filename: packetbeat
+  filename: packetbeat
 
   # Maximum size in kilobytes of each file. When this size is reached, and on
   # every packetbeat restart, the files are rotated. The default value is 10240
   # kB.
-  #rotate_every_kb: 10000
+  rotate_every_kb: 10000
 
   # Maximum number of files under path. When this number of files is reached,
   # the oldest file is deleted and the rest are shifted from last to first. The
   # default is 7 files.
-  #number_of_files: 7
+  number_of_files: 7
 
 
 #----------------------------- Console output ---------------------------------
-#output.console:
+output.console:
   # Boolean flag to enable or disable the output module.
-  #enabled: true
+  enabled: false
 
   # Pretty print json event
-  #pretty: false
+  pretty: false
 
 #================================= Paths ======================================
 
@@ -978,24 +979,24 @@ output.elasticsearch:
 # distribution (for example, the sample dashboards).
 # If not set by a CLI flag or in the configuration file, the default for the
 # home path is the location of the binary.
-#path.home:
+path.home:
 
 # The configuration path for the packetbeat installation. This is the default
 # base path for configuration files, including the main YAML configuration file
 # and the Elasticsearch template file. If not set by a CLI flag or in the
 # configuration file, the default for the configuration path is the home path.
-#path.config: ${path.home}
+path.config: ${path.home}
 
 # The data path for the packetbeat installation. This is the default base path
 # for all the files in which packetbeat needs to store its data. If not set by a
 # CLI flag or in the configuration file, the default for the data path is a data
 # subdirectory inside the home path.
-#path.data: ${path.home}/data
+path.data: ${path.home}/data
 
 # The logs path for a packetbeat installation. This is the default location for
 # the Beat's log files. If not set by a CLI flag or in the configuration file,
 # the default for the logs path is a logs subdirectory inside the home path.
-#path.logs: ${path.home}/logs
+path.logs: ${path.home}/logs
 
 #================================ Logging ======================================
 # There are three options for the log output: syslog, file, stderr.
@@ -1004,24 +1005,24 @@ output.elasticsearch:
 
 # Sets log level. The default log level is info.
 # Available log levels are: critical, error, warning, info, debug
-#logging.level: info
+logging.level: info
 
 # Enable debug output for selected components. To enable all selectors use ["*"]
 # Other available selectors are "beat", "publish", "service"
 # Multiple selectors can be chained.
-#logging.selectors: [ ]
+logging.selectors: [ ]
 
 # Send all logging output to syslog. The default is false.
-#logging.to_syslog: true
+logging.to_syslog: false
 
 # If enabled, packetbeat periodically logs its internal metrics that have changed
 # in the last period. For each metric that changed, the delta from the value at
 # the beginning of the period is logged. Also, the total values for
 # all non-zero internal metrics are logged on shutdown. The default is true.
-#logging.metrics.enabled: true
+logging.metrics.enabled: true
 
 # The period after which to log the internal metrics. The default is 30s.
-#logging.metrics.period: 30s
+logging.metrics.period: 30s
 
 # Logging to rotating files files. Set logging.to_files to false to disable logging to
 # files.
@@ -1029,15 +1030,15 @@ logging.to_files: true
 logging.files:
   # Configure the path where the logs are written. The default is the logs directory
   # under the home path (the binary location).
-  #path: /var/log/packetbeat
+  path: /var/log/packetbeat
 
   # The name of the files where the logs are written to.
-  #name: packetbeat
+  name: packetbeat
 
   # Configure log file size limit. If limit is reached, log file will be
   # automatically rotated
-  #rotateeverybytes: 10485760 # = 10MB
+  rotateeverybytes: 10485760 # = 10MB
 
   # Number of rotated log files to keep. Oldest files will be deleted first.
-  #keepfiles: 7
+  keepfiles: 7
 

--- a/winlogbeat/_meta/beat.full.yml
+++ b/winlogbeat/_meta/beat.full.yml
@@ -12,13 +12,13 @@
 # The registry file is where Winlogbeat persists its state so that the beat
 # can resume after shutdown or an outage. The default is .winlogbeat.yml
 # in the directory in which it was started.
-#winlogbeat.registry_file: .winlogbeat.yml
+winlogbeat.registry_file: .winlogbeat.yml
 
 # Diagnostic metrics that can retrieved through a web interface if a
 # bindaddress value (host:port) is specified. The web address will be
 # http://<bindaddress>/debug/vars
-#winlogbeat.metrics:
-#  bindaddress: 'localhost:8123'
+winlogbeat.metrics:
+  bindaddress: 'localhost:8123'
 
 # event_logs specifies a list of event logs to monitor as well as any
 # accompanying options. The YAML data type of event_logs is a list of

--- a/winlogbeat/winlogbeat.full.yml
+++ b/winlogbeat/winlogbeat.full.yml
@@ -12,13 +12,13 @@
 # The registry file is where Winlogbeat persists its state so that the beat
 # can resume after shutdown or an outage. The default is .winlogbeat.yml
 # in the directory in which it was started.
-#winlogbeat.registry_file: .winlogbeat.yml
+winlogbeat.registry_file: .winlogbeat.yml
 
 # Diagnostic metrics that can retrieved through a web interface if a
 # bindaddress value (host:port) is specified. The web address will be
 # http://<bindaddress>/debug/vars
-#winlogbeat.metrics:
-#  bindaddress: 'localhost:8123'
+winlogbeat.metrics:
+  bindaddress: 'localhost:8123'
 
 # event_logs specifies a list of event logs to monitor as well as any
 # accompanying options. The YAML data type of event_logs is a list of
@@ -39,7 +39,7 @@ winlogbeat.event_logs:
 # The name of the shipper that publishes the network data. It can be used to group
 # all the transactions sent by a single shipper in the web interface.
 # If this options is not defined, the hostname is used.
-#name:
+name:
 
 # The tags of the shipper are included in their own field with each
 # transaction published. Tags make it easy to group servers by different
@@ -55,14 +55,14 @@ winlogbeat.event_logs:
 # If this option is set to true, the custom fields are stored as top-level
 # fields in the output document instead of being grouped under a fields
 # sub-dictionary. Default is false.
-#fields_under_root: false
+fields_under_root: false
 
 # Internal queue size for single events in processing pipeline
-#queue_size: 1000
+queue_size: 1000
 
 # The internal queue size for bulk events in the processing pipeline.
 # Do not modify this value.
-#bulk_queue_size: 0
+bulk_queue_size: 0
 
 # Sets the maximum number of CPUs that can be executing simultaneously. The
 # default is the number of logical CPUs available in the system.
@@ -113,7 +113,7 @@ winlogbeat.event_logs:
 #-------------------------- Elasticsearch output -------------------------------
 output.elasticsearch:
   # Boolean flag to enable or disable the output module.
-  #enabled: true
+  enabled: true
 
   # Array of hosts to connect to.
   # Scheme and port can be left out and will be set to the default (http and 9200)
@@ -122,7 +122,7 @@ output.elasticsearch:
   hosts: ["localhost:9200"]
 
   # Set gzip compression level.
-  #compression_level: 0
+  compression_level: 0
 
   # Optional protocol and basic auth credentials.
   #protocol: "https"
@@ -135,422 +135,422 @@ output.elasticsearch:
     #param2: value2
 
   # Number of workers per Elasticsearch host.
-  #worker: 1
+  worker: 1
 
   # Optional index name. The default is "winlogbeat" plus date
   # and generates [winlogbeat-]YYYY.MM.DD keys.
-  #index: "winlogbeat-%{+yyyy.MM.dd}"
+  index: "winlogbeat-%{+yyyy.MM.dd}"
 
   # Optional ingest node pipeline. By default no pipeline will be used.
-  #pipeline: ""
+  pipeline: ""
 
-  # Optional HTTP Path
-  #path: "/elasticsearch"
+  # Optional HTTP Path. Example: /elasticsearch
+  path:
 
-  # Proxy server url
-  #proxy_url: http://proxy:3128
+  # Proxy server url. Example: http://proxy:3128
+  proxy_url:
 
   # The number of times a particular Elasticsearch index operation is attempted. If
   # the indexing operation doesn't succeed after this many retries, the events are
   # dropped. The default is 3.
-  #max_retries: 3
+  max_retries: 3
 
   # The maximum number of events to bulk in a single Elasticsearch bulk API index request.
   # The default is 50.
-  #bulk_max_size: 50
+  bulk_max_size: 50
 
   # Configure http request timeout before failing an request to Elasticsearch.
-  #timeout: 90
+  timeout: 90
 
   # The number of seconds to wait for new events between two bulk API index requests.
   # If `bulk_max_size` is reached before this interval expires, addition bulk index
   # requests are made.
-  #flush_interval: 1s
+  flush_interval: 1s
 
   # A template is used to set the mapping in Elasticsearch
   # By default template loading is enabled and the template is loaded.
   # These settings can be adjusted to load your own template or overwrite existing ones.
 
   # Set to false to disable template loading.
-  #template.enabled: true
+  template.enabled: true
 
   # Template name. By default the template name is winlogbeat.
-  #template.name: "winlogbeat"
+  template.name: "winlogbeat"
 
   # Path to template file
-  #template.path: "${path.config}/winlogbeat.template.json"
+  template.path: "${path.config}/winlogbeat.template.json"
 
   # Overwrite existing template
-  #template.overwrite: false
+  #emplate.overwrite: false
 
   # If set to true, winlogbeat checks the Elasticsearch version at connect time, and if it
   # is 2.x, it loads the file specified by the template.versions.2x.path setting. The
   # default is true.
-  #template.versions.2x.enabled: true
+  template.versions.2x.enabled: true
 
   # Path to the Elasticsearch 2.x version of the template file.
-  #template.versions.2x.path: "${path.config}/winlogbeat.template-es2x.json"
+  template.versions.2x.path: "${path.config}/winlogbeat.template-es2x.json"
 
   # Use SSL settings for HTTPS. Default is true.
-  #ssl.enabled: true
+  ssl.enabled: false
 
   # Configure SSL verification mode. If `none` is configured, all server hosts
   # and certificates will be accepted. In this mode, SSL based connections are
   # susceptible to man-in-the-middle attacks. Use only for testing. Default is
   # `full`.
-  #ssl.verification_mode: full
+  ssl.verification_mode: full
 
   # List of supported/valid TLS versions. By default all TLS versions 1.0 up to
   # 1.2 are enabled.
-  #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
+  ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
 
-  # SSL configuration. By default is off.
+  # SSL configuration. By default is off. TODO
   # List of root certificates for HTTPS server verifications
-  #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
+  ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
   # Certificate for SSL client authentication
-  #ssl.certificate: "/etc/pki/client/cert.pem"
+  ssl.certificate: "/etc/pki/client/cert.pem"
 
   # Client Certificate Key
-  #ssl.key: "/etc/pki/client/cert.key"
+  ssl.key: "/etc/pki/client/cert.key"
 
   # Optional passphrase for decrypting the Certificate Key.
-  #ssl.key_passphrase: ''
+  ssl.key_passphrase: ''
 
   # Configure cipher suites to be used for SSL connections
-  #ssl.cipher_suites: []
+  ssl.cipher_suites: []
 
   # Configure curve types for ECDHE based cipher suites
-  #ssl.curve_types: []
+  ssl.curve_types: []
 
 
 #----------------------------- Logstash output ---------------------------------
-#output.logstash:
+output.logstash:
   # Boolean flag to enable or disable the output module.
-  #enabled: true
+  enabled: false
 
   # The Logstash hosts
-  #hosts: ["localhost:5044"]
+  hosts: ["localhost:5044"]
 
   # Number of workers per Logstash host.
-  #worker: 1
+  worker: 1
 
   # Set gzip compression level.
-  #compression_level: 3
+  compression_level: 3
 
   # Optional load balance the events between the Logstash hosts
-  #loadbalance: true
+  loadbalance: true
 
   # Number of batches to be send asynchronously to logstash while processing
   # new batches.
-  #pipelining: 0
+  pipelining: 0
 
   # Optional index name. The default index name is set to name of the beat
   # in all lowercase.
-  #index: 'winlogbeat'
+  index: 'winlogbeat'
 
   # SOCKS5 proxy server URL
-  #proxy_url: socks5://user:password@socks5-server:2233
+  proxy_url: socks5://user:password@socks5-server:2233
 
   # Resolve names locally when using a proxy server. Defaults to false.
-  #proxy_use_local_resolver: false
+  proxy_use_local_resolver: false
 
   # Enable SSL support. SSL is automatically enabled, if any SSL setting is set.
-  #ssl.enabled: true
+  ssl.enabled: false
 
   # Configure SSL verification mode. If `none` is configured, all server hosts
   # and certificates will be accepted. In this mode, SSL based connections are
   # susceptible to man-in-the-middle attacks. Use only for testing. Default is
   # `full`.
-  #ssl.verification_mode: full
+  ssl.verification_mode: full
 
   # List of supported/valid TLS versions. By default all TLS versions 1.0 up to
   # 1.2 are enabled.
-  #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
+  ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
 
   # Optional SSL configuration options. SSL is off by default.
   # List of root certificates for HTTPS server verifications
-  #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
+  ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
   # Certificate for SSL client authentication
-  #ssl.certificate: "/etc/pki/client/cert.pem"
+  ssl.certificate: "/etc/pki/client/cert.pem"
 
   # Client Certificate Key
-  #ssl.key: "/etc/pki/client/cert.key"
+  ssl.key: "/etc/pki/client/cert.key"
 
   # Optional passphrase for decrypting the Certificate Key.
-  #ssl.key_passphrase: ''
+  ssl.key_passphrase: ''
 
   # Configure cipher suites to be used for SSL connections
-  #ssl.cipher_suites: []
+  ssl.cipher_suites: []
 
   # Configure curve types for ECDHE based cipher suites
-  #ssl.curve_types: []
+  ssl.curve_types: []
 
 #------------------------------- Kafka output ----------------------------------
-#output.kafka:
+output.kafka:
   # Boolean flag to enable or disable the output module.
-  #enabled: true
+  enabled: false
 
   # The list of Kafka broker addresses from where to fetch the cluster metadata.
   # The cluster metadata contain the actual Kafka brokers events are published
   # to.
-  #hosts: ["localhost:9092"]
+  hosts: ["localhost:9092"]
 
   # The Kafka topic used for produced events. The setting can be a format string
   # using any event field. To set the topic from document type use `%{[type]}`.
-  #topic: beats
+  topic: beats
 
   # The Kafka event key setting. Use format string to create unique event key.
   # By default no event key will be generated.
-  #key: ''
+  key: ''
 
   # The Kafka event partitioning strategy. Default hashing strategy is `hash`
   # using the `output.kafka.key` setting or randomly distributes events if
   # `output.kafka.key` is not configured.
-  #partition.hash:
+  partition.hash:
     # If enabled, events will only be published to partitions with reachable
     # leaders. Default is false.
-    #reachable_only: false
+    reachable_only: false
 
     # Configure alternative event field names used to compute the hash value.
     # If empty `output.kafka.key` setting will be used.
     # Default value is empty list.
-    #hash: []
+    hash: []
 
   # Authentication details. Password is required if username is set.
-  #username: ''
-  #password: ''
+  username: ''
+  password: ''
 
   # Kafka version winlogbeat is assumed to run against. Defaults to the oldest
   # supported stable version (currently version 0.8.2.0)
-  #version: 0.8.2
+  version: 0.8.2
 
   # Metadata update configuration. Metadata do contain leader information
   # deciding which broker to use when publishing.
-  #metadata:
+  metadata:
     # Max metadata request retry attempts when cluster is in middle of leader
     # election. Defaults to 3 retries.
-    #retry.max: 3
+    retry.max: 3
 
     # Waiting time between retries during leader elections. Default is 250ms.
-    #retry.backoff: 250ms
+    retry.backoff: 250ms
 
     # Refresh metadata interval. Defaults to every 10 minutes.
-    #refresh_frequency: 10m
+    refresh_frequency: 10m
 
   # The number of concurrent load-balanced Kafka output workers.
-  #worker: 1
+  worker: 1
 
   # The number of times to retry publishing an event after a publishing failure.
   # After the specified number of retries, the events are typically dropped.
   # Some Beats, such as Filebeat, ignore the max_retries setting and retry until
   # all events are published.  Set max_retries to a value less than 0 to retry
   # until all events are published. The default is 3.
-  #max_retries: 3
+  max_retries: 3
 
   # The maximum number of events to bulk in a single Kafka request. The default
   # is 2048.
-  #bulk_max_size: 2048
+  bulk_max_size: 2048
 
   # The number of seconds to wait for responses from the Kafka brokers before
   # timing out. The default is 30s.
-  #timeout: 30s
+  timeout: 30s
 
   # The maximum duration a broker will wait for number of required ACKs. The
   # default is 10s.
-  #broker_timeout: 10s
+  broker_timeout: 10s
 
   # The number of messages buffered for each Kafka broker. The default is 256.
-  #channel_buffer_size: 256
+  channel_buffer_size: 256
 
   # The keep-alive period for an active network connection. If 0s, keep-alives
   # are disabled. The default is 0 seconds.
-  #keep_alive: 0
+  keep_alive: 0
 
   # Sets the output compression codec. Must be one of none, snappy and gzip. The
   # default is gzip.
-  #compression: gzip
+  compression: gzip
 
   # The maximum permitted size of JSON-encoded messages. Bigger messages will be
   # dropped. The default value is 1000000 (bytes). This value should be equal to
   # or less than the broker's message.max.bytes.
-  #max_message_bytes: 1000000
+  max_message_bytes: 1000000
 
   # The ACK reliability level required from broker. 0=no response, 1=wait for
   # local commit, -1=wait for all replicas to commit. The default is 1.  Note:
   # If set to 0, no ACKs are returned by Kafka. Messages might be lost silently
   # on error.
-  #required_acks: 1
+  required_acks: 1
 
   # The number of seconds to wait for new events between two producer API calls.
-  #flush_interval: 1s
+  flush_interval: 1s
 
   # The configurable ClientID used for logging, debugging, and auditing
   # purposes.  The default is "beats".
-  #client_id: beats
+  client_id: beats
 
   # Enable SSL support. SSL is automatically enabled, if any SSL setting is set.
-  #ssl.enabled: true
+  ssl.enabled: false
 
   # Optional SSL configuration options. SSL is off by default.
   # List of root certificates for HTTPS server verifications
-  #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
+  ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
   # Configure SSL verification mode. If `none` is configured, all server hosts
   # and certificates will be accepted. In this mode, SSL based connections are
   # susceptible to man-in-the-middle attacks. Use only for testing. Default is
   # `full`.
-  #ssl.verification_mode: full
+  ssl.verification_mode: full
 
   # List of supported/valid TLS versions. By default all TLS versions 1.0 up to
   # 1.2 are enabled.
-  #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
+  ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
 
   # Certificate for SSL client authentication
-  #ssl.certificate: "/etc/pki/client/cert.pem"
+  ssl.certificate: "/etc/pki/client/cert.pem"
 
   # Client Certificate Key
-  #ssl.key: "/etc/pki/client/cert.key"
+  ssl.key: "/etc/pki/client/cert.key"
 
   # Optional passphrase for decrypting the Certificate Key.
-  #ssl.key_passphrase: ''
+  ssl.key_passphrase: ''
 
   # Configure cipher suites to be used for SSL connections
-  #ssl.cipher_suites: []
+  ssl.cipher_suites: []
 
   # Configure curve types for ECDHE based cipher suites
-  #ssl.curve_types: []
+  ssl.curve_types: []
 
 #------------------------------- Redis output ----------------------------------
-#output.redis:
+output.redis:
   # Boolean flag to enable or disable the output module.
-  #enabled: true
+  enabled: false
 
   # The list of Redis servers to connect to. If load balancing is enabled, the
   # events are distributed to the servers in the list. If one server becomes
   # unreachable, the events are distributed to the reachable servers only.
-  #hosts: ["localhost:6379"]
+  hosts: ["localhost:6379"]
 
   # The Redis port to use if hosts does not contain a port number. The default
   # is 6379.
-  #port: 6379
+  port: 6379
 
   # The name of the Redis list or channel the events are published to. The
   # default is winlogbeat.
-  #key: winlogbeat
+  key: winlogbeat
 
   # The password to authenticate with. The default is no authentication.
-  #password:
+  password:
 
   # The Redis database number where the events are published. The default is 0.
-  #db: 0
+  db: 0
 
   # The Redis data type to use for publishing events. If the data type is list,
   # the Redis RPUSH command is used. If the data type is channel, the Redis
   # PUBLISH command is used. The default value is list.
-  #datatype: list
+  datatype: list
 
   # The number of workers to use for each host configured to publish events to
   # Redis. Use this setting along with the loadbalance option. For example, if
   # you have 2 hosts and 3 workers, in total 6 workers are started (3 for each
   # host).
-  #worker: 1
+  worker: 1
 
   # If set to true and multiple hosts or workers are configured, the output
   # plugin load balances published events onto all Redis hosts. If set to false,
   # the output plugin sends all events to only one host (determined at random)
   # and will switch to another host if the currently selected one becomes
   # unreachable. The default value is true.
-  #loadbalance: true
+  loadbalance: true
 
   # The Redis connection timeout in seconds. The default is 5 seconds.
-  #timeout: 5s
+  timeout: 5s
 
   # The number of times to retry publishing an event after a publishing failure.
   # After the specified number of retries, the events are typically dropped.
   # Some Beats, such as Filebeat, ignore the max_retries setting and retry until
   # all events are published. Set max_retries to a value less than 0 to retry
   # until all events are published. The default is 3.
-  #max_retries: 3
+  max_retries: 3
 
   # The maximum number of events to bulk in a single Redis request or pipeline.
   # The default is 2048.
-  #bulk_max_size: 2048
+  bulk_max_size: 2048
 
   # The URL of the SOCKS5 proxy to use when connecting to the Redis servers. The
   # value must be a URL with a scheme of socks5://.
-  #proxy_url:
+  proxy_url:
 
   # This option determines whether Redis hostnames are resolved locally when
   # using a proxy. The default value is false, which means that name resolution
   # occurs on the proxy server.
-  #proxy_use_local_resolver: false
+  proxy_use_local_resolver: false
 
   # Enable SSL support. SSL is automatically enabled, if any SSL setting is set.
-  #ssl.enabled: true
+  ssl.enabled: false
 
   # Configure SSL verification mode. If `none` is configured, all server hosts
   # and certificates will be accepted. In this mode, SSL based connections are
   # susceptible to man-in-the-middle attacks. Use only for testing. Default is
   # `full`.
-  #ssl.verification_mode: full
+  ssl.verification_mode: full
 
   # List of supported/valid TLS versions. By default all TLS versions 1.0 up to
   # 1.2 are enabled.
-  #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
+  ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
 
   # Optional SSL configuration options. SSL is off by default.
   # List of root certificates for HTTPS server verifications
-  #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
+  ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
   # Certificate for SSL client authentication
-  #ssl.certificate: "/etc/pki/client/cert.pem"
+  ssl.certificate: "/etc/pki/client/cert.pem"
 
   # Client Certificate Key
-  #ssl.key: "/etc/pki/client/cert.key"
+  ssl.key: "/etc/pki/client/cert.key"
 
   # Optional passphrase for decrypting the Certificate Key.
-  #ssl.key_passphrase: ''
+  ssl.key_passphrase: ''
 
   # Configure cipher suites to be used for SSL connections
-  #ssl.cipher_suites: []
+  ssl.cipher_suites: []
 
   # Configure curve types for ECDHE based cipher suites
-  #ssl.curve_types: []
+  ssl.curve_types: []
 
 
 #------------------------------- File output -----------------------------------
-#output.file:
+output.file:
   # Boolean flag to enable or disable the output module.
-  #enabled: true
+  enabled: false
 
   # Path to the directory where to save the generated files. The option is
   # mandatory.
-  #path: "/tmp/winlogbeat"
+  path: "/tmp/winlogbeat"
 
   # Name of the generated files. The default is `winlogbeat` and it generates
   # files: `winlogbeat`, `winlogbeat.1`, `winlogbeat.2`, etc.
-  #filename: winlogbeat
+  filename: winlogbeat
 
   # Maximum size in kilobytes of each file. When this size is reached, and on
   # every winlogbeat restart, the files are rotated. The default value is 10240
   # kB.
-  #rotate_every_kb: 10000
+  rotate_every_kb: 10000
 
   # Maximum number of files under path. When this number of files is reached,
   # the oldest file is deleted and the rest are shifted from last to first. The
   # default is 7 files.
-  #number_of_files: 7
+  number_of_files: 7
 
 
 #----------------------------- Console output ---------------------------------
-#output.console:
+output.console:
   # Boolean flag to enable or disable the output module.
-  #enabled: true
+  enabled: false
 
   # Pretty print json event
-  #pretty: false
+  pretty: false
 
 #================================= Paths ======================================
 
@@ -559,24 +559,24 @@ output.elasticsearch:
 # distribution (for example, the sample dashboards).
 # If not set by a CLI flag or in the configuration file, the default for the
 # home path is the location of the binary.
-#path.home:
+path.home:
 
 # The configuration path for the winlogbeat installation. This is the default
 # base path for configuration files, including the main YAML configuration file
 # and the Elasticsearch template file. If not set by a CLI flag or in the
 # configuration file, the default for the configuration path is the home path.
-#path.config: ${path.home}
+path.config: ${path.home}
 
 # The data path for the winlogbeat installation. This is the default base path
 # for all the files in which winlogbeat needs to store its data. If not set by a
 # CLI flag or in the configuration file, the default for the data path is a data
 # subdirectory inside the home path.
-#path.data: ${path.home}/data
+path.data: ${path.home}/data
 
 # The logs path for a winlogbeat installation. This is the default location for
 # the Beat's log files. If not set by a CLI flag or in the configuration file,
 # the default for the logs path is a logs subdirectory inside the home path.
-#path.logs: ${path.home}/logs
+path.logs: ${path.home}/logs
 
 #================================ Logging ======================================
 # There are three options for the log output: syslog, file, stderr.
@@ -585,24 +585,24 @@ output.elasticsearch:
 
 # Sets log level. The default log level is info.
 # Available log levels are: critical, error, warning, info, debug
-#logging.level: info
+logging.level: info
 
 # Enable debug output for selected components. To enable all selectors use ["*"]
 # Other available selectors are "beat", "publish", "service"
 # Multiple selectors can be chained.
-#logging.selectors: [ ]
+logging.selectors: [ ]
 
 # Send all logging output to syslog. The default is false.
-#logging.to_syslog: true
+logging.to_syslog: false
 
 # If enabled, winlogbeat periodically logs its internal metrics that have changed
 # in the last period. For each metric that changed, the delta from the value at
 # the beginning of the period is logged. Also, the total values for
 # all non-zero internal metrics are logged on shutdown. The default is true.
-#logging.metrics.enabled: true
+logging.metrics.enabled: true
 
 # The period after which to log the internal metrics. The default is 30s.
-#logging.metrics.period: 30s
+logging.metrics.period: 30s
 
 # Logging to rotating files files. Set logging.to_files to false to disable logging to
 # files.
@@ -610,15 +610,15 @@ logging.to_files: true
 logging.files:
   # Configure the path where the logs are written. The default is the logs directory
   # under the home path (the binary location).
-  #path: /var/log/winlogbeat
+  path: /var/log/winlogbeat
 
   # The name of the files where the logs are written to.
-  #name: winlogbeat
+  name: winlogbeat
 
   # Configure log file size limit. If limit is reached, log file will be
   # automatically rotated
-  #rotateeverybytes: 10485760 # = 10MB
+  rotateeverybytes: 10485760 # = 10MB
 
   # Number of rotated log files to keep. Oldest files will be deleted first.
-  #keepfiles: 7
+  keepfiles: 7
 


### PR DESCRIPTION
Currently the full config has mostly the defaults in but not in all cases. The intention is to have clear rules on the structure and content of the full config files.

Rules:

* Starting filebeat with the default `filebeat.yml` or `filebeat.full.yml` must behave exactly the same
* All config options which can be uncommented, must be uncommented. This is for easy copy / pasting of options
* In case no defaults should be set like for `fields`, an example should be provided in the comment above it or below commented out
* In case not default is used, special comments must be left. Only option which are not default should be `enabled / default`.
* A second reason for no values set is if the value is dynamic like `max_procs`. Special comment must be left.
* In case not all options can be presented like for filters, link to documentation must be added. 2-3 examples should be provided.

This is currently only a started example for Filebeat to show the new structure

Question: What do we do about the special `stdin` case in Filebeat. Should we add `enabled` to the prospector for consistency. This would also make it easier for testing to just disable one prospector without having it to comment out.