### PR TITLE
Fix print statement to be python 3 compliant.

### DIFF
--- a/libbeat/scripts/generate_index_pattern.py
+++ b/libbeat/scripts/generate_index_pattern.py
@@ -35,7 +35,7 @@ def field_to_json(desc, path, output):
     global unique_fields
 
     if path in unique_fields:
-        print "ERROR: Field", path, "is duplicated. Please delete it and try again. Fields already are", unique_fields
+        print("ERROR: Field {} is duplicated. Please delete it and try again. Fields already are {}".format(path, ", ".join(unique_fields)))
         sys.exit(1)
     else:
         unique_fields.append(path)


### PR DESCRIPTION
Fixes #3017

I tested this by duplicating the print statement outside the if clause. The output, should the if condition be true, will look like:

    ERROR: Field counter is duplicated. Please delete it and try again. Fields already are beat.name, beat.hostname, beat.version, @timestamp, tags, fields, meta.cloud.provider, meta.cloud.instance_id, meta.cloud.machine_type, meta.cloud.availability_zone, meta.cloud.project_id, meta.cloud.region

With this fix `make setup` as described at https://www.elastic.co/guide/en/beats/libbeat/master/setting-up-beat.html completes without error.

This is based on:

    34e464a7 (upstream/master) Remove --always-copy from virtualenv and make it a param (#3136)

I have signed and confirmed the CLA.

Thanks!