### PR TITLE
Adjust script to generate fields of type geo_point

### DIFF
--- a/libbeat/scripts/generate_index_pattern.py
+++ b/libbeat/scripts/generate_index_pattern.py
@@ -60,6 +60,8 @@ def field_to_json(desc, path, output):
                 field["aggregatable"] = False
         elif desc["type"] == "date":
             field["type"] = "date"
+        elif desc["type"] == "geo_point":
+            field["type"] = "geo_point"
     else:
         field["type"] = "string"
 


### PR DESCRIPTION
Add functionality to generate fields of type `geo_point` in the `generate_index_pattern` script. 
NOTE: Without this fix, the user needs to reload the `packetbeat-*` index pattern in Kibana.