### PR TITLE
Add enabled config for prospectors

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -81,6 +81,7 @@ https://github.com/elastic/beats/compare/v5.0.1...master[Check the HEAD diff]
 - Reset all states ttl on startup to make sure it is overwritten by new config {pull}2840[2840]
 - Persist all states for files which fall under ignore_older to have consistent behaviour {pull}2859[2859]
 - Improve shutdown behaviour with large number of files. {pull}3035[3035]
+- Add enabled config option to prospectors.
 
 *Winlogbeat*
 

--- a/filebeat/_meta/beat.full.yml
+++ b/filebeat/_meta/beat.full.yml
@@ -205,6 +205,9 @@ filebeat.prospectors:
   # Note: Potential data loss. Make sure to read and understand the docs for this option.
   #close_timeout: 0
 
+  # Defines if prospectors is enabled
+  #enabled: true
+
 #----------------------------- Stdin prospector -------------------------------
 # Configuration to use stdin input
 #- input_type: stdin

--- a/filebeat/crawler/crawler.go
+++ b/filebeat/crawler/crawler.go
@@ -40,7 +40,9 @@ func (c *Crawler) Start(states file.States, once bool) error {
 		if err != nil {
 			return fmt.Errorf("Error in initing prospector: %s", err)
 		}
-		c.prospectors = append(c.prospectors, prospector)
+		if prospector.IsEnabled() {
+			c.prospectors = append(c.prospectors, prospector)
+		}
 	}
 
 	logp.Info("Loading Prospectors completed. Number of prospectors: %v", len(c.prospectors))

--- a/filebeat/docs/reference/configuration/filebeat-options.asciidoc
+++ b/filebeat/docs/reference/configuration/filebeat-options.asciidoc
@@ -462,6 +462,10 @@ Currently if a new harvester can be started again, the harvester is picked rando
 This configuration option applies per prospector. You can use this option to indirectly set higher priorities on certain prospectors
 by assigning a higher limit of harvesters.
 
+===== enabled
+
+The `enabled` option can be used with each prospector to define if a prospector is enabled or not. By default, enabled is set to true.
+
 [[configuration-global-options]]
 === Filebeat Global Configuration
 

--- a/filebeat/filebeat.full.yml
+++ b/filebeat/filebeat.full.yml
@@ -205,6 +205,9 @@ filebeat.prospectors:
   # Note: Potential data loss. Make sure to read and understand the docs for this option.
   #close_timeout: 0
 
+  # Defines if prospectors is enabled
+  #enabled: true
+
 #----------------------------- Stdin prospector -------------------------------
 # Configuration to use stdin input
 #- input_type: stdin

--- a/filebeat/prospector/config.go
+++ b/filebeat/prospector/config.go
@@ -10,6 +10,7 @@ import (
 
 var (
 	defaultConfig = prospectorConfig{
+		Enabled:        true,
 		IgnoreOlder:    0,
 		ScanFrequency:  10 * time.Second,
 		InputType:      cfg.DefaultInputType,
@@ -22,6 +23,7 @@ var (
 )
 
 type prospectorConfig struct {
+	Enabled        bool             `config:"enabled"`
 	ExcludeFiles   []*regexp.Regexp `config:"exclude_files"`
 	IgnoreOlder    time.Duration    `config:"ignore_older"`
 	Paths          []string         `config:"paths"`

--- a/filebeat/prospector/prospector.go
+++ b/filebeat/prospector/prospector.go
@@ -158,6 +158,11 @@ func (p *Prospector) Run(once bool) {
 	}
 }
 
+// IsEnabled returns true if the prospector is eanbled
+func (p *Prospector) IsEnabled() bool {
+	return p.config.Enabled
+}
+
 // updateState updates the prospector state and forwards the event to the spooler
 // All state updates done by the prospector itself are synchronous to make sure not states are overwritten
 func (p *Prospector) updateState(event *input.Event) error {


### PR DESCRIPTION
The enabled config allows easily to enable and disable a specific prospector. This is consistent with metricbeat where each modules has an enabled config. By default enabled is set to true.