### PR TITLE
Improve speed and stability of CI builds

### DIFF
--- a/libbeat/Dockerfile
+++ b/libbeat/Dockerfile
@@ -4,7 +4,8 @@ MAINTAINER Nicolas Ruflin <ruflin@elastic.co>
 
 RUN set -x && \
     apt-get update && \
-    apt-get install -y netcat python-virtualenv python-pip && \
+    apt-get install -y --no-install-recommends \
+         netcat python-pip virtualenv && \
     apt-get clean
 
 ENV PYTHON_ENV=/tmp/python-env

--- a/libbeat/docker-compose.yml
+++ b/libbeat/docker-compose.yml
@@ -59,7 +59,4 @@ services:
 
   # Overloading kibana with a simple image as it is not needed here
   kibana:
-    build:
-      context: ${PWD}/../testing/environments/
-      dockerfile: Dockerfile
-      args: []
+    image: alpine:latest

--- a/libbeat/scripts/docker-entrypoint.sh
+++ b/libbeat/scripts/docker-entrypoint.sh
@@ -81,7 +81,7 @@ waitFor() {
     done
 
     echo
-    echo >&2 '${3} is not available'
+    echo >&2 "${3} is not available"
     echo >&2 "Address: ${1}:${2}"
 }
 

--- a/metricbeat/Dockerfile
+++ b/metricbeat/Dockerfile
@@ -3,7 +3,8 @@ MAINTAINER Nicolas Ruflin <ruflin@elastic.co>
 
 RUN set -x && \
     apt-get update && \
-    apt-get install -y netcat python-virtualenv python-pip && \
+    apt-get install -y --no-install-recommends \
+         netcat python-pip virtualenv && \
     apt-get clean
 
 # Setup work environment

--- a/metricbeat/docker-compose.yml
+++ b/metricbeat/docker-compose.yml
@@ -44,9 +44,7 @@ services:
 
   # Overloading kibana with a simple image as it is not needed here
   kibana:
-    build:
-      context: ${PWD}/../testing/environments/
-      dockerfile: Dockerfile
+    image: alpine:latest
 
   # Modules
   apache:

--- a/testing/environments/Dockerfile
+++ b/testing/environments/Dockerfile
@@ -6,6 +6,3 @@ MAINTAINER Nicolas Ruflin <ruflin@elastic.co>
 RUN apt-get update && \
     apt-get install -y curl nano wget zip && \
     apt-get clean
-
-
-ARG KIBANA_VERSION

--- a/testing/environments/docker/sredis/Dockerfile
+++ b/testing/environments/docker/sredis/Dockerfile
@@ -1,8 +1,6 @@
-FROM debian:8.4
+FROM alpine:edge
 
-RUN apt-get update \
-  && apt-get upgrade -y \
-  && apt-get install stunnel4 -y
+RUN apk add --no-cache stunnel
 
 COPY stunnel.conf /etc/stunnel/stunnel.conf
 COPY pki /etc/pki


### PR DESCRIPTION
Loading and creating docker images takes quite a bit of time on the travis builds. Especially calls like apt-get update and install take lots of time and bandwidth and fail from time to time, as a host is not available.

Following actions were taken:

* Fake Kibana container is now based on alpine
* Redis stunnel container was also switched to alpine