### PR TITLE
Add -insecure flag to import_dashboards

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -57,6 +57,7 @@ https://github.com/elastic/beats/compare/v5.0.1...master[Check the HEAD diff]
 - Added decode_json_fields processor for decoding fields containing JSON strings. {pull}2605[2605]
 - Add support for passing list and dictionary settings via -E flag.
 - Support for parsing list and dictionary setting from environment variables.
+- Added new flags to import_dashboards (-cacert, -cert, -key, -insecure). {pull}3139[3139] {pull}3163[3163]
 
 *Metricbeat*
 

--- a/libbeat/dashboards/import_dashboards.go
+++ b/libbeat/dashboards/import_dashboards.go
@@ -56,6 +56,7 @@ type Options struct {
 	Certificate          string
 	CertificateKey       string
 	CertificateAuthority string
+	Insecure             bool // Allow insecure SSL connections.
 	OnlyDashboards       bool
 	OnlyIndex            bool
 	Snapshot             bool
@@ -99,6 +100,7 @@ func DefineCommandLine() (*CommandLine, error) {
 	cl.flagSet.StringVar(&cl.opt.CertificateAuthority, "cacert", "", "Certificate Authority for server verification")
 	cl.flagSet.StringVar(&cl.opt.Certificate, "cert", "", "Certificate for SSL client authentication in PEM format.")
 	cl.flagSet.StringVar(&cl.opt.CertificateKey, "key", "", "Client Certificate Key in PEM format.")
+	cl.flagSet.BoolVar(&cl.opt.Insecure, "insecure", false, `Allows "insecure" SSL connections`)
 
 	return &cl, nil
 }
@@ -151,6 +153,10 @@ func New() (*Importer, error) {
 
 	var tlsConfig outputs.TLSConfig
 	var tls *transport.TLSConfig
+
+	if cl.opt.Insecure {
+		tlsConfig.VerificationMode = transport.VerifyNone
+	}
 
 	if len(cl.opt.Certificate) > 0 && len(cl.opt.CertificateKey) > 0 {
 		tlsConfig.Certificate = outputs.CertificateConfig{


### PR DESCRIPTION
Allow `-insecure` to be passed to import_dashboards.