### PR TITLE
Fix #3167 change ownership of files in build/

### DIFF
--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -220,6 +220,10 @@ testsuite: clean collect
 	$(MAKE) benchmark-tests
 	$(MAKE) coverage-report
 
+	if [ $(TEST_ENVIRONMENT) = true ]; then \
+		$(MAKE) fix-permissions; \
+	fi
+
 # Generates a coverage report from the existing coverage files
 .PHONY: coverage-report
 coverage-report:
@@ -405,7 +409,7 @@ package: package-setup
 	fi
 
 	SNAPSHOT=${SNAPSHOT} BUILDID=${BUILDID} BEAT_DIR=${BEAT_DIR} BUILD_DIR=${BUILD_DIR} $(MAKE) -C ${ES_BEATS}/dev-tools/packer ${PACKAGES} ${BUILD_DIR}/upload/build_id.txt
-
+	$(MAKE) fix-permissions
 	echo "Finished packages for ${BEATNAME}"
 
 package-dashboards: package-setup
@@ -413,3 +417,7 @@ package-dashboards: package-setup
 	cp -r _meta/kibana ${BUILD_DIR}/dashboards
 	# build the dashboards package
 	BEATNAME=${BEATNAME} BUILD_DIR=${BUILD_DIR} SNAPSHOT=$(SNAPSHOT) $(MAKE) -C ${ES_BEATS}/dev-tools/packer package-dashboards ${shell pwd}/build/upload/build_id.txt
+
+fix-permissions:
+	# Change ownership of all files inside /build folder from root/root to current user/group
+	docker run -v ${BUILD_DIR}:/build -it alpine:3.4 sh -c "chown -R $(shell id -u):$(shell id -g) /build"

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -420,4 +420,4 @@ package-dashboards: package-setup
 
 fix-permissions:
 	# Change ownership of all files inside /build folder from root/root to current user/group
-	docker run -v ${BUILD_DIR}:/build -it alpine:3.4 sh -c "chown -R $(shell id -u):$(shell id -g) /build"
+	docker run -v ${BUILD_DIR}:/build alpine:3.4 sh -c "chown -R $(shell id -u):$(shell id -g) /build"


### PR DESCRIPTION
Add a new Makefile rule: fix-permissions

fix-permissions runs a docker container that changes the ownership
of all files from root to the user that runs the Makefile