### PR TITLE
docker-compose fails to build kibana snapshot image

### DIFF
--- a/testing/environments/docker/kibana/Dockerfile-snapshot
+++ b/testing/environments/docker/kibana/Dockerfile-snapshot
@@ -9,7 +9,7 @@ EXPOSE 5601
 
 WORKDIR /usr/share/kibana
 RUN curl -Ls ${KIBANA_DOWNLOAD_URL} | tar --strip-components=1 -zxf - && \
-    #bin/kibana-plugin install ${X_PACK_URL} && \
+    `#bin/kibana-plugin install ${X_PACK_URL}` && \
     ln -s /usr/share/kibana /opt/kibana
 
 # Set some Kibana configuration defaults.


### PR DESCRIPTION
i could not build the kibana image when doing make generate-json with metricbeat

this pr fixes the failing docker build