### PR TITLE
Export cpu cores

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -54,6 +54,7 @@ https://github.com/elastic/beats/compare/v5.1.1...master[Check the HEAD diff]
 *Metricbeat*
 - Kafka module broker matching enhancements. {pull}3129[3129]
 - Add a couchbase module with metricsets for node, cluster and bucker. {pull}3081[3081]
+- Export number of cores for cpu module. {pull}3192[3192]
 
 
 *Packetbeat*

--- a/metricbeat/docs/fields.asciidoc
+++ b/metricbeat/docs/fields.asciidoc
@@ -4775,6 +4775,14 @@ The amount of CPU time spent in involuntary wait by the virtual CPU while the hy
 
 
 [float]
+=== system.cpu.cores
+
+type: long
+
+The number of CPU cores.
+
+
+[float]
 === system.cpu.user.pct
 
 type: scaled_float

--- a/metricbeat/metricbeat.template-es2x.json
+++ b/metricbeat/metricbeat.template-es2x.json
@@ -2712,6 +2712,9 @@
             },
             "cpu": {
               "properties": {
+                "cores": {
+                  "type": "long"
+                },
                 "idle": {
                   "properties": {
                     "pct": {

--- a/metricbeat/metricbeat.template.json
+++ b/metricbeat/metricbeat.template.json
@@ -2694,6 +2694,9 @@
             },
             "cpu": {
               "properties": {
+                "cores": {
+                  "type": "long"
+                },
                 "idle": {
                   "properties": {
                     "pct": {

--- a/metricbeat/module/system/cpu/_meta/fields.yml
+++ b/metricbeat/module/system/cpu/_meta/fields.yml
@@ -3,6 +3,11 @@
   description: >
     `cpu` contains local CPU stats.
   fields:
+  - name: cores
+      type: int
+      description: >
+        The number of CPU cores.
+
     - name: user.pct
       type: scaled_float
       format: percent

--- a/metricbeat/module/system/cpu/_meta/fields.yml
+++ b/metricbeat/module/system/cpu/_meta/fields.yml
@@ -3,8 +3,8 @@
   description: >
     `cpu` contains local CPU stats.
   fields:
-  - name: cores
-      type: int
+    - name: cores
+      type: long
       description: >
         The number of CPU cores.
 

--- a/metricbeat/module/system/cpu/cpu.go
+++ b/metricbeat/module/system/cpu/cpu.go
@@ -52,7 +52,10 @@ func (m *MetricSet) Fetch() (common.MapStr, error) {
 	}
 	m.cpu.AddCpuPercentage(stat)
 
+	cpuCores := GetCores()
+
 	cpuStat := common.MapStr{
+		"cores": cpuCores,
 		"user": common.MapStr{
 			"pct": stat.UserPercent,
 		},

--- a/metricbeat/module/system/cpu/helper.go
+++ b/metricbeat/module/system/cpu/helper.go
@@ -3,6 +3,8 @@
 package cpu
 
 import (
+	"runtime"
+
 	"github.com/elastic/beats/metricbeat/module/system"
 	sigar "github.com/elastic/gosigar"
 )
@@ -12,6 +14,7 @@ type CPU struct {
 	LastCpuTimes     *CpuTimes
 	LastCpuTimesList []CpuTimes
 	CpuTicks         bool
+	Cores            int
 }
 
 type CpuTimes struct {
@@ -113,6 +116,11 @@ func GetCpuPercentageList(last, current []CpuTimes) []CpuTimes {
 	}
 
 	return current
+}
+
+func GetCores() int {
+	cores := runtime.NumCPU()
+	return cores
 }
 
 func (cpu *CPU) AddCpuPercentage(t2 *CpuTimes) {

--- a/metricbeat/tests/system/test_processors.py
+++ b/metricbeat/tests/system/test_processors.py
@@ -39,7 +39,7 @@ class TestProcessors(metricbeat.BaseTest):
         cpu = evt["system"]["cpu"]
         print(cpu.keys())
         self.assertItemsEqual(self.de_dot([
-            "system", "user", "softirq", "iowait",
+            "system", "cores", "user", "softirq", "iowait",
             "idle", "irq", "steal", "nice"
         ]), cpu.keys())
 

--- a/metricbeat/tests/system/test_system.py
+++ b/metricbeat/tests/system/test_system.py
@@ -5,10 +5,10 @@ import metricbeat
 import getpass
 import os
 
-SYSTEM_CPU_FIELDS = ["idle.pct", "iowait.pct", "irq.pct", "nice.pct",
+SYSTEM_CPU_FIELDS = ["cores", "idle.pct", "iowait.pct", "irq.pct", "nice.pct",
                      "softirq.pct", "steal.pct", "system.pct", "user.pct"]
 
-SYSTEM_CPU_FIELDS_ALL = ["idle.pct", "idle.ticks", "iowait.pct", "iowait.ticks", "irq.pct", "irq.ticks", "nice.pct", "nice.ticks",
+SYSTEM_CPU_FIELDS_ALL = ["cores", "idle.pct", "idle.ticks", "iowait.pct", "iowait.ticks", "irq.pct", "irq.ticks", "nice.pct", "nice.ticks",
                      "softirq.pct", "softirq.ticks", "steal.pct", "steal.ticks", "system.pct", "system.ticks", "user.pct", "user.ticks"]
 
 SYSTEM_LOAD_FIELDS = ["1", "5", "15", "norm.1", "norm.5", "norm.15"]


### PR DESCRIPTION
Fixes #3186

Add number of cpu cores to metricbeat cpu module