### PR TITLE
case insensitive hostname comparison in kafka broker matching

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -32,6 +32,7 @@ https://github.com/elastic/beats/compare/v5.1.1...master[Check the HEAD diff]
 *Metricbeat*
 
 - Fix service times-out at startup. {pull}3056[3056]
+- Kafka module case sensitive host name matching. {pull}3193[3193]
 
 *Packetbeat*
 

--- a/libbeat/common/net.go
+++ b/libbeat/common/net.go
@@ -8,15 +8,29 @@ import (
 // LocalIPAddrs finds the IP addresses of the hosts on which
 // the shipper currently runs on.
 func LocalIPAddrs() ([]net.IP, error) {
-	var localIPAddrs = []net.IP{}
+	var localIPAddrs []net.IP
 	ipaddrs, err := net.InterfaceAddrs()
 	if err != nil {
-		return []net.IP{}, err
+		return nil, err
 	}
-	for _, ipaddr := range ipaddrs {
-		if ipnet, ok := ipaddr.(*net.IPNet); ok {
-			localIPAddrs = append(localIPAddrs, ipnet.IP)
+	for _, addr := range ipaddrs {
+		var ip net.IP
+		ok := true
+
+		switch v := addr.(type) {
+		case *net.IPNet:
+			ip = v.IP
+		case *net.IPAddr:
+			ip = v.IP
+		default:
+			ok = false
 		}
+
+		if !ok {
+			continue
+		}
+
+		localIPAddrs = append(localIPAddrs, ip)
 	}
 	return localIPAddrs, nil
 }


### PR DESCRIPTION
- re-use common.LocalIPAddrs in partition module for resolving IPs
- add missing net.IPAddr type switch to common.LocalIPAddrs
- update matching to extract addresses early on using strings.ToLower
  => ensure case insensitive matching by lowercasing