### PR TITLE
Add support for multiple paths per fileset

### DIFF
--- a/filebeat/module/mysql/error/config/error.yml
+++ b/filebeat/module/mysql/error/config/error.yml
@@ -1,6 +1,9 @@
 - input_type: log
   paths:
-    - {{path}}
+  {%- for path in paths %}
+   - {{path}}
+  {%- endfor %}
+  exclude_files: [".gz$"]
   fields:
     source_type: mysql-error
     pipeline_id: {{beat.pipeline_id}}

--- a/filebeat/module/mysql/error/manifest.yml
+++ b/filebeat/module/mysql/error/manifest.yml
@@ -1,10 +1,14 @@
 module_version: 1.0
 
 vars:
-  path:
-    default: /var/log/mysql/error.log
-    os.darwin: /usr/local/var/mysql/{{builtin.hostname}}.{{builtin.domain}}.err
-    os.windows: "c:/programdata/MySQL/MySQL Server*/error.log"
+  paths:
+    default:
+      - /var/log/mysql/error.log*
+      - /var/log/mysqld.log*
+    os.darwin:
+      - /usr/local/var/mysql/{{builtin.hostname}}.{{builtin.domain}}.err*
+    os.windows:
+      - "c:/programdata/MySQL/MySQL Server*/error.log*"
 
 ingest_pipeline: ingest/pipeline.json
 prospectors:

--- a/filebeat/module/mysql/slowlog/config/slowlog.yml
+++ b/filebeat/module/mysql/slowlog/config/slowlog.yml
@@ -1,6 +1,9 @@
 - input_type: log
   paths:
-    - {{path}}
+  {%- for path in paths %}
+   - {{path}}
+  {%- endfor %}
+  exclude_files: [".gz$"]
   multiline:
     pattern: "^# User@Host: "
     negate: true

--- a/filebeat/module/mysql/slowlog/manifest.yml
+++ b/filebeat/module/mysql/slowlog/manifest.yml
@@ -1,10 +1,14 @@
 module_version: 1.0
 
 vars:
-  path:
-    default: /var/log/mysql/mysql-slow.log
-    os.darwin: /usr/local/var/mysql/{{builtin.hostname}}-slow.log
-    os.windows: "c:/programdata/MySQL/MySQL Server*/mysql-slow.log"
+  paths:
+    default:
+      - /var/log/mysql/mysql-slow.log*
+      - /var/lib/mysql/{{builtin.hostname}}-slow.log
+    os.darwin:
+      - /usr/local/var/mysql/{{builtin.hostname}}-slow.log*
+    os.windows:
+      - "c:/programdata/MySQL/MySQL Server*/mysql-slow.log*"
 
 ingest_pipeline: ingest/pipeline.json
 prospectors:

--- a/filebeat/module/nginx/access/config/nginx-access.yml
+++ b/filebeat/module/nginx/access/config/nginx-access.yml
@@ -1,6 +1,9 @@
 - input_type: log
   paths:
-  - {{path}}/access*.log
+  {%- for path in paths %}
+   - {{path}}
+  {%- endfor %}
+  exclude_files: [".gz$"]
   fields:
     source_type: nginx-access
     pipeline_id: {{beat.pipeline_id}}

--- a/filebeat/module/nginx/access/manifest.yml
+++ b/filebeat/module/nginx/access/manifest.yml
@@ -1,10 +1,13 @@
 module_version: 1.0
 
 vars:
-  path:
-    default: /var/log/nginx
-    os.darwin: /usr/local/var/log/nginx
-    os.windows: c:/programfiles/nginx/logs
+  paths:
+    default:
+      - /var/log/nginx/access.log*
+    os.darwin:
+      - /usr/local/var/log/nginx/access.log*
+    os.windows:
+      - c:/programfiles/nginx/logs/access.log*
   pipeline:
     # options: with_plugins, no_plugins, json_with_plugins, json_no_plugins
     default: with_plugins

--- a/filebeat/module/nginx/error/config/nginx-error.yml
+++ b/filebeat/module/nginx/error/config/nginx-error.yml
@@ -1,6 +1,9 @@
 - input_type: log
   paths:
-  - {{path}}/error.log
+  {%- for path in paths %}
+   - {{path}}
+  {%- endfor %}
+  exclude_files: [".gz$"]
   fields:
     source_type: nginx-error
     pipeline_id: {{beat.pipeline_id}}

--- a/filebeat/module/nginx/error/ingest/pipeline.json
+++ b/filebeat/module/nginx/error/ingest/pipeline.json
@@ -6,11 +6,7 @@
       "patterns": [
         "%{DATA:nginx.error.time} \\[%{DATA:nginx.error.level}\\] %{NUMBER:nginx.error.pid}#%{NUMBER:nginx.error.tid}: (\\*%{NUMBER:nginx.error.connection_id} )?%{GREEDYDATA:nginx.error.message}"
       ],
-      "on_failure" : [{
-        "set" : {
-          "field" : "error",
-          "value" : "The error pattern didn't match on this event."
-        }
+      "ignore_missing": true
     }
   },{
     "remove":{
@@ -30,6 +26,12 @@
   }, {
     "remove": {
       "field": "nginx.error.time"
+    }
+  }],
+  "on_failure" : [{
+    "set" : {
+      "field" : "error",
+      "value" : "{{ _ingest.on_failure_message }}"
     }
   }]
 }

--- a/filebeat/module/nginx/error/manifest.yml
+++ b/filebeat/module/nginx/error/manifest.yml
@@ -1,10 +1,13 @@
 module_version: 1.0
 
 vars:
-  path:
-    default: /var/log/nginx
-    os.darwin: /usr/local/var/log/nginx
-    os.windows: c:/programfiles/nginx/logs
+  paths:
+    default:
+      - /var/log/nginx/error.log*
+    os.darwin:
+      - /usr/local/var/log/nginx/error.log*
+    os.windows:
+      - c:/programfiles/nginx/logs/error.log*
 
 ingest_pipeline: ingest/pipeline.json
 prospectors:

--- a/filebeat/module/syslog/system/config/system.yml
+++ b/filebeat/module/syslog/system/config/system.yml
@@ -1,6 +1,9 @@
 - input_type: log
   paths:
-    - {{path}}
+  {%- for path in paths %}
+   - {{path}}
+  {%- endfor %}
+  exclude_files: [".gz$"]
   multiline:
     pattern: "^\\s"
     match: after

--- a/filebeat/module/syslog/system/manifest.yml
+++ b/filebeat/module/syslog/system/manifest.yml
@@ -1,9 +1,13 @@
 module_version: 1.0
 
 vars:
-  path:
-    default: /var/log/messages
-    os.darwin: /var/log/system.log
+  paths:
+    default:
+      - /var/log/messages*
+      - /var/log/syslog*
+    os.darwin:
+      - /var/log/system.log*
+    os.windows: []
 
 ingest_pipeline: ingest/pipeline.json
 prospectors:


### PR DESCRIPTION
We generally need more than one path per OS, because the logs location
is not always the same. For example, depending on the linux distribution
and how you installed it, MySQL can have it's error logs in a number of
default "paths". The solution is to configure them all, which means that
Filebeat might try to access unexisting folders.

This also improves the python prototype to accept multiple modules and
to accept namespaced parameters. E.g.:

./filebeat.py --modules=nginx,syslog -M nginx.access.paths=...

Part of #3159.