### PR TITLE
Community beat can set/get their own version

### DIFF
--- a/dev-tools/get_version
+++ b/dev-tools/get_version
@@ -1,20 +1,33 @@
 #!/usr/bin/env python
 import os
+import re
 import argparse
 
-pattern = '''const defaultBeatVersion = "'''
-
+pattern = re.compile(r'(const\s|)\w*(v|V)ersion\s=\s"(?P<version>.*)"')
 
 def main():
     parser = argparse.ArgumentParser(
         description="Prints the current version at stdout.")
-    parser.parse_args()
+    parser.add_argument(
+        '--gofile',
+        metavar="version.go",
+        default=os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "libbeat","beat","version.go"),
+        help="the path of the go file that contains the version number")
+    args = parser.parse_args()
 
-    dir = os.path.dirname(os.path.realpath(__file__))
-    with open(dir + "/../libbeat/beat/version.go", "r") as f:
-        for line in f:
-            if line.startswith(pattern):
-                print(line[len(pattern):-2])  # -2 for \n and the final quote
+    goversion_filepath = os.path.abspath(args.gofile)
+
+    try:
+        with open(goversion_filepath, "r") as f:
+            for line in f:
+                match = pattern.match(line)
+                if match:
+                    print(match.group('version'))
+                    return
+            print ("No version found in file {}".format(goversion_filepath))
+    except:
+        print ("Can't read file {}".format(goversion_filepath))    
+    
 
 if __name__ == "__main__":
     main()

--- a/dev-tools/set_version
+++ b/dev-tools/set_version
@@ -1,38 +1,136 @@
 #!/usr/bin/env python
-import os
 import argparse
+import fileinput
+import os
+import re
+import sys
 from subprocess import check_call
 
-template_go = '''package beat
+pattern = re.compile(r'(const\s|)(\w*)(v|V)(ersion)(\s*)(:|=)(\s)(")(.*)(")(.*)')
+repl    = r'\1\2\3\4\5\6\7"{}"\11'
 
-const defaultBeatVersion = "{}"
+
+goversion_template = '''package main
+
+const appVersion = "{version}"
 '''
 
-template_packer = '''version: "{version}"
+goversion_template_libbeat = '''package beat
+
+const defaultBeatVersion = "{version}"
 '''
 
+
+yamlversion_template = '''version: "{version}"
+'''
+
+def split_path(path):
+    allparts = []
+    while 1:
+        parts = os.path.split(path)
+        if parts[0] == path:  # sentinel for absolute paths
+            allparts.insert(0, parts[0])
+            break
+        elif parts[1] == path: # sentinel for relative paths
+            allparts.insert(0, parts[1])
+            break
+        else:
+            path = parts[0]
+            allparts.insert(0, parts[1])
+    return allparts
+
+def get_substituted_content(filename, pattern, replacement, errormsg):
+    nbr_changes = 0
+    new_content = ""
+    with open(filename, "r") as file:
+        for line in file.readlines():
+            if pattern.match(line):
+                new_content += (re.sub(pattern, replacement, line))
+                nbr_changes += 1
+            else:
+                new_content += line
+    if nbr_changes == 0:
+        print (errormsg.format(filename))
+
+    
+    return [new_content, nbr_changes]
+    
+
+def create_from_template(filename, template, version):
+    try:
+        if not os.path.exists(filename):
+            print ("Create {} from template".format(filename))
+            with open(filename, "w") as f:
+                f.write(template.format(version=version))   
+    except:
+        print ("Can't create file {} from tepmplate".format(filename))
+        raise
 
 def main():
     parser = argparse.ArgumentParser(
         description="Used to set the current version. Doesn't commit changes.")
     parser.add_argument("version",
                         help="The new version")
+    parser.add_argument(
+        '--gofile',
+        metavar="version.go",
+        default=os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "libbeat","beat","version.go"),
+        help="the path of the go file that contains the version number of the application")
+    parser.add_argument(
+        '--yamlfile',
+        metavar="version.yml",
+        default=os.path.join(os.path.dirname(os.path.realpath(__file__)), "packer","version.yml"),
+        help="the path of the yml file that contains the version number of the package")
     args = parser.parse_args()
 
-    dir = os.path.dirname(os.path.realpath(__file__))
-    with open(dir + "/../libbeat/beat/version.go", "w") as f:
-        f.write(template_go.format(args.version))
-
     version = args.version
-    with open(dir + "/packer/version.yml", "w") as f:
-        f.write(template_packer.format(
-            version=version,
-        ))
+    goversion_filepath = os.path.abspath(args.gofile)
+    yamlversion_filepath = os.path.abspath(args.yamlfile)
 
-    # Updates all files with the new templates
-    os.chdir(dir + "/../")
-    print("Update build files")
-    check_call("make update", shell=True)
+    if  os.path.normpath("vendor/github.com/elastic/beats") in goversion_filepath:
+        print ("Community beat application can't set the version of libbeat. Please define the path of your version.go file")
+        return 1
+
+    if  os.path.normpath("vendor/github.com/elastic/beats") in yamlversion_filepath:
+        print ("Community beat application can't set the version of libbeat. Please define the path of your version.yml file")
+        return 1
+
+    is_libbeat = os.path.normpath("github.com/elastic/beats") in goversion_filepath
+
+    # Create version.go and version.yml files if they don't exist
+    go_template = goversion_template_libbeat if is_libbeat else goversion_template 
+    create_from_template(goversion_filepath, go_template, version)
+    create_from_template(yamlversion_filepath, yamlversion_template, version)
+
+    # Get the content of the existing version files and replace the version number 
+    errormsg = "Can't find a version in file {}"
+    new_go_content, nbr_changes_in_gofile = get_substituted_content(goversion_filepath, pattern, repl.format(version), errormsg)
+    new_yaml_content, nbr_changes_in_yamlfile = get_substituted_content(yamlversion_filepath, pattern, repl.format(version), errormsg)
+    
+    # Update the version files only if both contents have been updated
+    if nbr_changes_in_gofile > 0 and nbr_changes_in_yamlfile > 0:
+        try:
+            with open(goversion_filepath, "w") as new_go_file:
+                with open(yamlversion_filepath, "w") as new_yaml_file:
+                    new_go_file.write(new_go_content)
+                    new_yaml_file.write(new_yaml_content)
+        except:
+            print ("Can't write version to files")
+            raise
+        print ("Write version {} in file {}".format(args.version, goversion_filepath))
+        print ("Write version {} in file {}".format(args.version, yamlversion_filepath))
+    else:
+        print ("Abort.")
+        return 1
+
+    # libbeat: Updates all files with the new templates
+    if is_libbeat:
+        os.chdir(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
+        print("Update build files")
+        check_call("make update", shell=True)
+
+    return 0
 
 if __name__ == "__main__":
-    main()
+    status_code = main()
+    exit(status_code)

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -9,6 +9,8 @@ BEAT_DIR?=github.com/elastic/beats/${BEATNAME}
 ES_BEATS?=..
 GOPACKAGES?=${BEAT_DIR}/...
 PACKER_TEMPLATES_DIR?=${ES_BEATS}/dev-tools/packer
+VERSION_GOFILEPATH?=${ES_BEATS}/libbeat/beat/version.go
+VERSION_YAMLFILEPATH?=${ES_BEATS}/dev-tools/packer/version.yml
 
 # Makefile for a custom beat that includes this libbeat/scripts/Makefile:
 # if glide is used to manage vendor dependencies,
@@ -409,7 +411,7 @@ package: package-setup
 	echo "beat_vendor: ${BEAT_VENDOR}" >> ${BUILD_DIR}/package.yml
 	echo "beat_license: ${BEAT_LICENSE}" >> ${BUILD_DIR}/package.yml
 	echo "beat_doc_url: ${BEAT_DOC_URL}" >> ${BUILD_DIR}/package.yml
-	cat ${ES_BEATS}/dev-tools/packer/version.yml >> ${BUILD_DIR}/package.yml
+	cat ${VERSION_YAMLFILEPATH} >> ${BUILD_DIR}/package.yml
 
 	if [ $(CGO) = true ]; then \
 		 $(MAKE) prepare-package-cgo; \
@@ -430,3 +432,10 @@ package-dashboards: package-setup
 fix-permissions:
 	# Change ownership of all files inside /build folder from root/root to current user/group
 	docker run -v ${BUILD_DIR}:/build alpine:3.4 sh -c "chown -R $(shell id -u):$(shell id -g) /build"
+
+set_version:
+	${ES_BEATS}/dev-tools/set_version  --gofile ${VERSION_GOFILEPATH}  --yamlfile ${VERSION_YAMLFILEPATH} ${VERSION}
+	make update
+
+get_version:
+	@${ES_BEATS}/dev-tools/get_version --gofile ${VERSION_GOFILEPATH}


### PR DESCRIPTION
By default, community beats have the same version as libbeat.

Prerequisite
============

A community beat can set its own version by setting the following 2 variables in their Makefile:

Makefile
```
VERSION_GOFILEPATH=version.go
VERSION_YAMLFILEPATH=version.yml
```

main.go
```

package main

func main() {
    err := beat.Run("mybeat", appVersion, beater.New)
    if err != nil {
        os.Exit(1)
    }
}
```

Usage
=====

set version
-----------
the version number can be set with the following command:
     ```make set_version VERSION=0.1.0-alpha1```

1. if version.go and version.yml don't exist, the files will be created from a template

1. the script substitute the version numbers using a regular expression.
The files are updated only when there are no detected errors

1. when versions have been rewritten, make update is called

get version
-----------
the version number can be retrieved with the following command:
      ```make get_version```

Test
===
```
examplebeat $ make set_version VERSION=0.1.0-alpha1
./vendor/github.com/elastic/beats/dev-tools/set_version  --gofile version.go  --yamlfile version.yaml 0.1.0-alpha1
Create /home/cyrille/code/go/workspace/src/github.com/cyrille/examplebeat/version.go from template
Create /home/cyrille/code/go/workspace/src/github.com/cyrille/examplebeat/version.yaml from template
Write version 0.1.0-alpha1 in file /home/cyrille/code/go/workspace/src/github.com/cyrille/examplebeat/version.go
Write version 0.1.0-alpha1 in file /home/cyrille/code/go/workspace/src/github.com/cyrille/examplebeat/version.yaml

examplebeat $ make package
....

examplebeat $ ./build/examplebeat-linux-amd64 -version
examplebeat version 0.1.0-alpha1 (amd64), libbeat 1.1

examplebeat $ rpm -qip build/upload/examplebeat-0.1.0-alpha1-SNAPSHOT-i686.rpm
Name        : examplebeat
Version     : 0.1.0_alpha1_SNAPSHOT
```