### PR TITLE
Community beat can set/get their own version

### DIFF
--- a/dev-tools/get_version
+++ b/dev-tools/get_version
@@ -25,17 +25,13 @@ def main():
 
     goversion_filepath = get_filepath("version.go")
 
-    try:
-        with open(goversion_filepath, "r") as f:
-            for line in f:
-                match = pattern.match(line)
-                if match:
-                    print(match.group('version'))
-                    return
-            print ("No version found in file {}".format(goversion_filepath))
-    except:
-        print ("Can't read file {}".format(goversion_filepath))
-
+    with open(goversion_filepath, "r") as f:
+        for line in f:
+            match = pattern.match(line)
+            if match:
+                print(match.group('version'))
+                return
+        print ("No version found in file {}".format(goversion_filepath))
 
 if __name__ == "__main__":
     main()

--- a/dev-tools/get_version
+++ b/dev-tools/get_version
@@ -1,20 +1,41 @@
 #!/usr/bin/env python
 import os
+import re
 import argparse
 
-pattern = '''const defaultBeatVersion = "'''
+pattern = re.compile(r'(const\s|)\w*(v|V)ersion\s=\s"(?P<version>.*)"')
+vendored_libbeat = os.path.normpath("vendor/github.com/elastic/beats")
+
+
+def get_filepath(filename):
+    script_directory = os.path.abspath(os.path.dirname(os.path.realpath(__file__)))
+    index = script_directory.find(vendored_libbeat)
+    if index > 0:
+        # Community beat detected
+        filename = os.path.join(script_directory[:index], filename)
+        if os.path.exists(filename):
+            return filename # Community beat version exists
+    return  os.path.abspath(os.path.join(script_directory, os.pardir, "libbeat","beat","version.go"))
 
 
 def main():
     parser = argparse.ArgumentParser(
         description="Prints the current version at stdout.")
-    parser.parse_args()
+    args = parser.parse_args()
 
-    dir = os.path.dirname(os.path.realpath(__file__))
-    with open(dir + "/../libbeat/beat/version.go", "r") as f:
-        for line in f:
-            if line.startswith(pattern):
-                print(line[len(pattern):-2])  # -2 for \n and the final quote
+    goversion_filepath = get_filepath("version.go")
+
+    try:
+        with open(goversion_filepath, "r") as f:
+            for line in f:
+                match = pattern.match(line)
+                if match:
+                    print(match.group('version'))
+                    return
+            print ("No version found in file {}".format(goversion_filepath))
+    except:
+        print ("Can't read file {}".format(goversion_filepath))
+
 
 if __name__ == "__main__":
     main()

--- a/dev-tools/set_version
+++ b/dev-tools/set_version
@@ -1,16 +1,46 @@
 #!/usr/bin/env python
-import os
 import argparse
+import os
+import re
+import sys
 from subprocess import check_call
 
-template_go = '''package beat
+vendored_libbeat = os.path.normpath("vendor/github.com/elastic/beats")
 
-const defaultBeatVersion = "{}"
+
+goversion_template = '''package main
+
+const appVersion = "{version}"
 '''
 
-template_packer = '''version: "{version}"
+goversion_template_libbeat = '''package beat
+
+const defaultBeatVersion = "{version}"
 '''
 
+
+yamlversion_template = '''version: "{version}"
+'''
+
+def get_rootfolder():
+    vendored_libbeat = os.path.normpath("vendor/github.com/elastic/beats")
+    script_directory = os.path.abspath(os.path.dirname(os.path.realpath(__file__)))
+    index = script_directory.find(vendored_libbeat)
+    if index > 0:
+        # Community beat detected, version files are stored at the root folder of the project
+        return os.path.abspath(script_directory[:index])
+
+    # Libbeat detected
+    return os.path.dirname(script_directory)
+
+def create_from_template(filename, template, version):
+    try:
+        with open(filename, "w") as f:
+            f.write(template.format(version=version))
+            print ("Set version {} in file {}".format(version, filename))
+    except:
+        print ("Can't create file {} from template".format(filename))
+        raise
 
 def main():
     parser = argparse.ArgumentParser(
@@ -18,21 +48,30 @@ def main():
     parser.add_argument("version",
                         help="The new version")
     args = parser.parse_args()
-
-    dir = os.path.dirname(os.path.realpath(__file__))
-    with open(dir + "/../libbeat/beat/version.go", "w") as f:
-        f.write(template_go.format(args.version))
-
     version = args.version
-    with open(dir + "/packer/version.yml", "w") as f:
-        f.write(template_packer.format(
-            version=version,
-        ))
 
-    # Updates all files with the new templates
-    os.chdir(dir + "/../")
+    is_libbeat = vendored_libbeat not in os.path.realpath(__file__)
+    if is_libbeat:
+        goversion_filepath  = os.path.join(get_rootfolder(), "libbeat","beat", "version.go")
+        ymlversion_filepath = os.path.join(get_rootfolder(), "dev-tools", "packer", "version.yml")
+        go_template = goversion_template_libbeat
+    else:
+        goversion_filepath  = os.path.join(get_rootfolder(), "version.go")
+        ymlversion_filepath = os.path.join(get_rootfolder(), "version.yml")
+        go_template = goversion_template
+
+    # Create version.go and version.yml files
+    create_from_template(goversion_filepath, go_template, version)
+    create_from_template(ymlversion_filepath, yamlversion_template, version)
+
+    # Updates all version files with the new templates
+    print (get_rootfolder())
+    os.chdir(get_rootfolder())
     print("Update build files")
     check_call("make update", shell=True)
 
+    return 0
+
 if __name__ == "__main__":
-    main()
+    status_code = main()
+    exit(status_code)

--- a/dev-tools/set_version
+++ b/dev-tools/set_version
@@ -34,13 +34,9 @@ def get_rootfolder():
     return os.path.dirname(script_directory)
 
 def create_from_template(filename, template, version):
-    try:
-        with open(filename, "w") as f:
-            f.write(template.format(version=version))
-            print ("Set version {} in file {}".format(version, filename))
-    except:
-        print ("Can't create file {} from template".format(filename))
-        raise
+    with open(filename, "w") as f:
+        f.write(template.format(version=version))
+        print ("Set version {} in file {}".format(version, filename))
 
 def main():
     parser = argparse.ArgumentParser(
@@ -65,13 +61,10 @@ def main():
     create_from_template(ymlversion_filepath, yamlversion_template, version)
 
     # Updates all version files with the new templates
-    print (get_rootfolder())
     os.chdir(get_rootfolder())
     print("Update build files")
     check_call("make update", shell=True)
 
-    return 0
-
 if __name__ == "__main__":
-    status_code = main()
-    exit(status_code)
+    main()
+    

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -438,7 +438,6 @@ fix-permissions:
 
 set_version:
 	${ES_BEATS}/dev-tools/set_version ${VERSION}
-	make update
 
 get_version:
 	@${ES_BEATS}/dev-tools/get_version

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -409,7 +409,12 @@ package: package-setup
 	echo "beat_vendor: ${BEAT_VENDOR}" >> ${BUILD_DIR}/package.yml
 	echo "beat_license: ${BEAT_LICENSE}" >> ${BUILD_DIR}/package.yml
 	echo "beat_doc_url: ${BEAT_DOC_URL}" >> ${BUILD_DIR}/package.yml
-	cat ${ES_BEATS}/dev-tools/packer/version.yml >> ${BUILD_DIR}/package.yml
+
+	if [ -a version.yml ]; then \
+		cat version.yml >> ${BUILD_DIR}/package.yml; \
+	else \
+		cat ${ES_BEATS}/dev-tools/packer/version.yml >> ${BUILD_DIR}/package.yml; \
+	fi
 
 	if [ $(CGO) = true ]; then \
 		 $(MAKE) prepare-package-cgo; \
@@ -430,3 +435,10 @@ package-dashboards: package-setup
 fix-permissions:
 	# Change ownership of all files inside /build folder from root/root to current user/group
 	docker run -v ${BUILD_DIR}:/build alpine:3.4 sh -c "chown -R $(shell id -u):$(shell id -g) /build"
+
+set_version:
+	${ES_BEATS}/dev-tools/set_version ${VERSION}
+	make update
+
+get_version:
+	@${ES_BEATS}/dev-tools/get_version


### PR DESCRIPTION
By default, community beats have the same version as libbeat.

Usage
=====

set version
-----------
the version number can be set with the following command:
     `make set_version VERSION=0.1.0-alpha1`

the script writes `version.go` and `version.yml` files at the root folder of the community beat project.

get version
 -----------
 the version number can be retrieved with the following command:
       `make get_version`

Test community beat
===
```
           examplebeat $ make make get_version
           6.0.0-alpha1

           examplebeat $ make set_version VERSION=1.0.0
           ./vendor/github.com/elastic/beats/dev-tools/set_version 1.0.0
           Set version 1.0.0 in file /home/cyrille/code/go/workspace/src/github.com/cyrille/examplebeat/version.go
           Set version 1.0.0 in file /home/cyrille/code/go/workspace/src/github.com/cyrille/examplebeat/version.yml

           examplebeat $ make get_version
           1.0.0

           examplebeat $ make package
           ....

           examplebeat $ ./build/examplebeat-linux-amd64 -version
           examplebeat version 1.0.0 (amd64), 6.0.0-alpha1

           examplebeat $ rpm -qip build/upload/examplebeat-1.0.0-SNAPSHOT-i686.rpm
           Name        : examplebeat
           Version     : 1.0.0_alpha1_SNAPSHOT
```

Test libbeat
============

```
           beats $ ./dev-tools/get_version
           6.0.0-alpha1

           beats $ ./dev-tools/set_version 6.0.0-alpha2
           Set version 6.0.0-alpha2 in file /home/cyrille/code/go/workspace/src/github.com/elastic/beats/libbeat/beat/version.go
           Set version 6.0.0-alpha2 in file /home/cyrille/code/go/workspace/src/github.com/elastic/beats/dev-tools/packer/version.yml

           beats $ cat cat libbeat/beat/version.go
           package beat

           const defaultBeatVersion = "6.0.0-alpha2"
```