### PR TITLE
Provide broker implementation in kafka module for reuse

### DIFF
--- a/metricbeat/module/kafka/broker.go
+++ b/metricbeat/module/kafka/broker.go
@@ -1,0 +1,374 @@
+package kafka
+
+import (
+	"bytes"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/Shopify/sarama"
+	"github.com/elastic/beats/libbeat/common"
+)
+
+// Broker provides functionality for communicating with a single kafka broker
+type Broker struct {
+	b   *sarama.Broker
+	cfg *sarama.Config
+
+	id      int32
+	matchID bool
+}
+
+// BrokerSettings defines common configurations used when connecting to a broker
+type BrokerSettings struct {
+	MatchID                  bool
+	DialTimeout, ReadTimeout time.Duration
+	ClientID                 string
+	Retries                  int
+	Backoff                  time.Duration
+	TLS                      *tls.Config
+	Username, Password       string
+}
+
+const noID = -1
+
+// NewBroker creates a new unconnected kafka Broker connection instance.
+func NewBroker(host string, settings BrokerSettings) *Broker {
+	cfg := sarama.NewConfig()
+	cfg.Net.DialTimeout = settings.DialTimeout
+	cfg.Net.ReadTimeout = settings.ReadTimeout
+	cfg.ClientID = settings.ClientID
+	cfg.Metadata.Retry.Max = settings.Retries
+	cfg.Metadata.Retry.Backoff = settings.Backoff
+	if tls := settings.TLS; tls != nil {
+		cfg.Net.TLS.Enable = true
+		cfg.Net.TLS.Config = tls
+	}
+	if user := settings.Username; user != "" {
+		cfg.Net.SASL.Enable = true
+		cfg.Net.SASL.User = user
+		cfg.Net.SASL.Password = settings.Password
+	}
+
+	return &Broker{
+		b:       sarama.NewBroker(host),
+		cfg:     cfg,
+		id:      noID,
+		matchID: settings.MatchID,
+	}
+}
+
+// Close the broker connection
+func (b *Broker) Close() error {
+	closeBroker(b.b)
+	return nil
+}
+
+// Connect connects the broker to the configured host
+func (b *Broker) Connect() error {
+	if err := b.b.Open(b.cfg); err != nil {
+		return err
+	}
+
+	if b.id != noID || !b.matchID {
+		return nil
+	}
+
+	// current broker is bootstrap only. Get metadata to find id:
+	meta, err := queryMetadataWithRetry(b.b, b.cfg, nil)
+	if err != nil {
+		closeBroker(b.b)
+		return err
+	}
+
+	other := findMatchingBroker(brokerAddress(b.b), meta.Brokers)
+	if other == nil { // no broker found
+		closeBroker(b.b)
+		return fmt.Errorf("No advertised broker with address %v found", b.Addr())
+	}
+
+	debugf("found matching broker %v with id %v", other.Addr(), other.ID())
+	b.id = other.ID()
+	return nil
+}
+
+// Addr returns the configured broker endpoint.
+func (b *Broker) Addr() string {
+	return b.b.Addr()
+}
+
+// GetMetadata fetches most recent cluster metadata from the broker.
+func (b *Broker) GetMetadata(topics ...string) (*sarama.MetadataResponse, error) {
+	return queryMetadataWithRetry(b.b, b.cfg, topics)
+}
+
+// GetTopicsMetadata fetches most recent topics/partition metadata from the broker.
+func (b *Broker) GetTopicsMetadata(topics ...string) ([]*sarama.TopicMetadata, error) {
+	r, err := b.GetMetadata(topics...)
+	if err != nil {
+		return nil, err
+	}
+	return r.Topics, nil
+}
+
+// PartitionOffset fetches the available offset from a partition.
+func (b *Broker) PartitionOffset(
+	replicaID int32,
+	topic string,
+	partition int32,
+	time int64,
+) (int64, error) {
+	req := &sarama.OffsetRequest{}
+	if replicaID != noID {
+		req.SetReplicaID(replicaID)
+	}
+	req.AddBlock(topic, partition, time, 1)
+	resp, err := b.b.GetAvailableOffsets(req)
+	if err != nil {
+		return -1, err
+	}
+
+	block := resp.GetBlock(topic, partition)
+	if len(block.Offsets) == 0 {
+		return -1, nil
+	}
+
+	return block.Offsets[0], nil
+}
+
+// ID returns the broker or -1 if the broker id is unknown.
+func (b *Broker) ID() int32 {
+	if b.id == noID {
+		return b.b.ID()
+	}
+	return b.id
+}
+
+func queryMetadataWithRetry(
+	b *sarama.Broker,
+	cfg *sarama.Config,
+	topics []string,
+) (r *sarama.MetadataResponse, err error) {
+	err = withRetry(b, cfg, func() (e error) {
+		requ := &sarama.MetadataRequest{Topics: topics}
+		r, e = b.GetMetadata(requ)
+		return
+	})
+	return
+}
+
+func closeBroker(b *sarama.Broker) {
+	if ok, _ := b.Connected(); ok {
+		b.Close()
+	}
+}
+
+func withRetry(
+	b *sarama.Broker,
+	cfg *sarama.Config,
+	f func() error,
+) error {
+	var err error
+	for max := 0; max < cfg.Metadata.Retry.Max; max++ {
+		if ok, _ := b.Connected(); !ok {
+			if err = b.Open(cfg); err == nil {
+				err = f()
+			}
+		} else {
+			err = f()
+		}
+
+		if err == nil {
+			return nil
+		}
+
+		retry, reconnect := checkRetryQuery(err)
+		if !retry {
+			return err
+		}
+
+		time.Sleep(cfg.Metadata.Retry.Backoff)
+		if reconnect {
+			closeBroker(b)
+		}
+	}
+	return err
+}
+
+func checkRetryQuery(err error) (retry, reconnect bool) {
+	if err == nil {
+		return false, false
+	}
+
+	if err == io.EOF {
+		return true, true
+	}
+
+	k, ok := err.(sarama.KError)
+	if !ok {
+		return false, false
+	}
+
+	switch k {
+	case sarama.ErrLeaderNotAvailable, sarama.ErrReplicaNotAvailable,
+		sarama.ErrOffsetsLoadInProgress, sarama.ErrRebalanceInProgress:
+		return true, false
+	case sarama.ErrRequestTimedOut, sarama.ErrBrokerNotAvailable,
+		sarama.ErrNetworkException:
+		return true, true
+	}
+
+	return false, false
+}
+
+func findMatchingBroker(
+	addr string,
+	brokers []*sarama.Broker,
+) *sarama.Broker {
+	lst := brokerAddresses(brokers)
+	if idx, found := findMatchingAddress(addr, lst); found {
+		return brokers[idx]
+	}
+	return nil
+}
+
+func findMatchingAddress(
+	addr string,
+	brokers []string,
+) (int, bool) {
+	debugf("Try to match broker to: %v", addr)
+
+	// compare connection address to list of broker addresses
+	if i, found := indexOf(addr, brokers); found {
+		return i, true
+	}
+
+	// get connection 'port'
+	_, port, err := net.SplitHostPort(addr)
+	if err != nil || port == "" {
+		port = "9092"
+	}
+
+	// lookup local machines ips for comparing with broker addresses
+	localIPs, err := common.LocalIPAddrs()
+	if err != nil || len(localIPs) == 0 {
+		return -1, false
+	}
+	debugf("local machine ips: %v", localIPs)
+
+	// try to find broker by comparing the fqdn for each known ip to list of
+	// brokers
+	localHosts := lookupHosts(localIPs)
+	debugf("local machine addresses: %v", localHosts)
+	for _, host := range localHosts {
+		debugf("try to match with fqdn: %v (%v)", host, port)
+		if i, found := indexOf(net.JoinHostPort(host, port), brokers); found {
+			return i, true
+		}
+	}
+
+	// try to find broker id by comparing the machines local hostname to
+	// broker hostnames in metadata
+	if host, err := os.Hostname(); err == nil {
+		debugf("try to match with hostname only: %v (%v)", host, port)
+
+		tmp := net.JoinHostPort(strings.ToLower(host), port)
+		if i, found := indexOf(tmp, brokers); found {
+			return i, true
+		}
+	}
+
+	// lookup ips for all brokers
+	debugf("match by ips")
+	for i, b := range brokers {
+		debugf("test broker address: %v", b)
+		bh, bp, err := net.SplitHostPort(b)
+		if err != nil {
+			continue
+		}
+
+		// port numbers do not match
+		if bp != port {
+			continue
+		}
+
+		// lookup all ips for brokers host:
+		ips, err := net.LookupIP(bh)
+		debugf("broker %v ips: %v, %v", bh, ips, err)
+		if err != nil {
+			continue
+		}
+
+		debugf("broker (%v) ips: %v", bh, ips)
+
+		// check if ip is known
+		if anyIPsMatch(ips, localIPs) {
+			return i, true
+		}
+	}
+
+	return -1, false
+}
+
+func lookupHosts(ips []net.IP) []string {
+	set := map[string]struct{}{}
+	for _, ip := range ips {
+		txt, err := ip.MarshalText()
+		if err != nil {
+			continue
+		}
+
+		hosts, err := net.LookupAddr(string(txt))
+		debugf("lookup %v => %v, %v", string(txt), hosts, err)
+		if err != nil {
+			continue
+		}
+
+		for _, host := range hosts {
+			h := strings.ToLower(strings.TrimSuffix(host, "."))
+			set[h] = struct{}{}
+		}
+	}
+
+	hosts := make([]string, 0, len(set))
+	for host := range set {
+		hosts = append(hosts, host)
+	}
+	return hosts
+}
+
+func anyIPsMatch(as, bs []net.IP) bool {
+	for _, a := range as {
+		for _, b := range bs {
+			if bytes.Equal(a, b) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func brokerAddresses(brokers []*sarama.Broker) []string {
+	addresses := make([]string, len(brokers))
+	for i, b := range brokers {
+		addresses[i] = brokerAddress(b)
+	}
+	return addresses
+}
+
+func brokerAddress(b *sarama.Broker) string {
+	return strings.ToLower(b.Addr())
+}
+
+func indexOf(s string, lst []string) (int, bool) {
+	for i, v := range lst {
+		if s == v {
+			return i, true
+		}
+	}
+	return -1, false
+}

--- a/metricbeat/module/kafka/kafka.go
+++ b/metricbeat/module/kafka/kafka.go
@@ -1,0 +1,5 @@
+package kafka
+
+import "github.com/elastic/beats/libbeat/logp"
+
+var debugf = logp.MakeDebug("kafka")

--- a/metricbeat/module/kafka/partition/config.go
+++ b/metricbeat/module/kafka/partition/config.go
@@ -17,9 +17,6 @@ type connConfig struct {
 	Topics   []string           `config:"topics"`
 }
 
-type metaConfig struct {
-}
-
 var defaultConfig = connConfig{
 	Retries:  3,
 	Backoff:  250 * time.Millisecond,

--- a/metricbeat/module/kafka/partition/partition.go
+++ b/metricbeat/module/kafka/partition/partition.go
@@ -1,20 +1,15 @@
 package partition
 
 import (
-	"bytes"
+	"crypto/tls"
 	"errors"
-	"fmt"
-	"io"
-	"net"
-	"os"
-	"strings"
-	"time"
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/outputs"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/mb/parse"
+	"github.com/elastic/beats/metricbeat/module/kafka"
 
 	"github.com/Shopify/sarama"
 )
@@ -30,9 +25,7 @@ func init() {
 type MetricSet struct {
 	mb.BaseMetricSet
 
-	broker *sarama.Broker
-	cfg    *sarama.Config
-	id     int32
+	broker *kafka.Broker
 	topics []string
 }
 
@@ -42,71 +35,45 @@ var errFailQueryOffset = errors.New("operation failed")
 
 var debugf = logp.MakeDebug("kafka")
 
-// New create a new instance of the partition MetricSet
+// New creates a new instance of the partition MetricSet.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	config := defaultConfig
 	if err := base.Module().UnpackConfig(&config); err != nil {
 		return nil, err
 	}
 
-	tls, err := outputs.LoadTLSConfig(config.TLS)
+	var tls *tls.Config
+	tlsCfg, err := outputs.LoadTLSConfig(config.TLS)
 	if err != nil {
 		return nil, err
 	}
-
-	cfg := sarama.NewConfig()
-	cfg.Net.DialTimeout = base.Module().Config().Timeout
-	cfg.Net.ReadTimeout = base.Module().Config().Timeout
-	cfg.ClientID = config.ClientID
-	cfg.Metadata.Retry.Max = config.Retries
-	cfg.Metadata.Retry.Backoff = config.Backoff
-	if tls != nil {
-		cfg.Net.TLS.Enable = true
-		cfg.Net.TLS.Config = tls.BuildModuleConfig("")
-	}
-	if config.Username != "" {
-		cfg.Net.SASL.Enable = true
-		cfg.Net.SASL.User = config.Username
-		cfg.Net.SASL.Password = config.Password
+	if tlsCfg != nil {
+		tls = tlsCfg.BuildModuleConfig("")
 	}
 
-	broker := sarama.NewBroker(base.Host())
+	timeout := base.Module().Config().Timeout
+	cfg := kafka.BrokerSettings{
+		MatchID:     true,
+		DialTimeout: timeout,
+		ReadTimeout: timeout,
+		ClientID:    config.ClientID,
+		Retries:     config.Retries,
+		Backoff:     config.Backoff,
+		TLS:         tls,
+		Username:    config.Username,
+		Password:    config.Password,
+	}
+
 	return &MetricSet{
 		BaseMetricSet: base,
-		broker:        broker,
-		cfg:           cfg,
-		id:            noID,
+		broker:        kafka.NewBroker(base.Host(), cfg),
 		topics:        config.Topics,
 	}, nil
 }
 
-func (m *MetricSet) connect() (*sarama.Broker, error) {
-	b := m.broker
-	if err := b.Open(m.cfg); err != nil {
-		return nil, err
-	}
-
-	if m.id != noID {
-		return b, nil
-	}
-
-	// current broker is bootstrap only. Get metadata to find id:
-	meta, err := queryMetadataWithRetry(b, m.cfg, m.topics)
-	if err != nil {
-		closeBroker(b)
-		return nil, err
-	}
-
-	other := findMatchingBroker(brokerAddress(b), meta.Brokers)
-	if other == nil { // no broker found
-		closeBroker(b)
-		return nil, fmt.Errorf("No advertised broker with address %v found", b.Addr())
-	}
-
-	debugf("found matching broker %v with id %v", other.Addr(), other.ID())
-
-	m.id = other.ID()
-	return b, nil
+func (m *MetricSet) connect() (*kafka.Broker, error) {
+	err := m.broker.Connect()
+	return m.broker, err
 }
 
 // Fetch partition stats list from kafka
@@ -116,19 +83,20 @@ func (m *MetricSet) Fetch() ([]common.MapStr, error) {
 		return nil, err
 	}
 
-	defer closeBroker(b)
-	response, err := queryMetadataWithRetry(b, m.cfg, m.topics)
+	defer b.Close()
+	topics, err := b.GetTopicsMetadata(m.topics...)
 	if err != nil {
 		return nil, err
 	}
 
 	events := []common.MapStr{}
 	evtBroker := common.MapStr{
-		"id":      m.id,
+		"id":      b.ID(),
 		"address": b.Addr(),
 	}
 
-	for _, topic := range response.Topics {
+	for _, topic := range topics {
+		debugf("fetch events for topic: ", topic.Name)
 		evtTopic := common.MapStr{
 			"name": topic.Name,
 		}
@@ -141,7 +109,8 @@ func (m *MetricSet) Fetch() ([]common.MapStr, error) {
 
 		for _, partition := range topic.Partitions {
 			// partition offsets can be queried from leader only
-			if m.id != partition.Leader {
+			if b.ID() != partition.Leader {
+				debugf("broker is not leader (broker=%v, leader=%v)", b.ID(), partition.Leader)
 				continue
 			}
 
@@ -193,6 +162,29 @@ func (m *MetricSet) Fetch() ([]common.MapStr, error) {
 	return events, nil
 }
 
+// queryOffsetRange queries the broker for the oldest and the newest offsets in
+// a kafka topics partition for a given replica.
+func queryOffsetRange(
+	b *kafka.Broker,
+	replicaID int32,
+	topic string,
+	partition int32,
+) (int64, int64, bool, error) {
+	oldest, err := b.PartitionOffset(replicaID, topic, partition, sarama.OffsetOldest)
+	if err != nil {
+		return -1, -1, false, err
+	}
+
+	newest, err := b.PartitionOffset(replicaID, topic, partition, sarama.OffsetNewest)
+	if err != nil {
+		return -1, -1, false, err
+	}
+
+	okOld := oldest != -1
+	okNew := newest != -1
+	return oldest, newest, okOld && okNew, nil
+}
+
 func hasID(id int32, lst []int32) bool {
 	for _, other := range lst {
 		if id == other {
@@ -200,274 +192,4 @@ func hasID(id int32, lst []int32) bool {
 		}
 	}
 	return false
-}
-
-// queryOffsetRange queries the broker for the oldest and the newest offsets in
-// a kafka topics partition for a given replica.
-func queryOffsetRange(
-	b *sarama.Broker,
-	replicaID int32,
-	topic string,
-	partition int32,
-) (int64, int64, bool, error) {
-	oldest, okOld, err := queryOffset(b, replicaID, topic, partition, sarama.OffsetOldest)
-	if err != nil {
-		return -1, -1, false, err
-	}
-
-	newest, okNew, err := queryOffset(b, replicaID, topic, partition, sarama.OffsetNewest)
-	if err != nil {
-		return -1, -1, false, err
-	}
-
-	return oldest, newest, okOld && okNew, nil
-}
-
-func queryOffset(
-	b *sarama.Broker,
-	replicaID int32,
-	topic string,
-	partition int32,
-	time int64,
-) (int64, bool, error) {
-	req := &sarama.OffsetRequest{}
-	if replicaID != noID {
-		req.SetReplicaID(replicaID)
-	}
-	req.AddBlock(topic, partition, time, 1)
-	resp, err := b.GetAvailableOffsets(req)
-	if err != nil {
-		return -1, false, err
-	}
-
-	block := resp.GetBlock(topic, partition)
-	if len(block.Offsets) == 0 {
-		return -1, false, nil
-	}
-
-	return block.Offsets[0], true, nil
-}
-
-func closeBroker(b *sarama.Broker) {
-	if ok, _ := b.Connected(); ok {
-		b.Close()
-	}
-}
-
-func queryMetadataWithRetry(
-	b *sarama.Broker,
-	cfg *sarama.Config,
-	topics []string,
-) (r *sarama.MetadataResponse, err error) {
-	err = withRetry(b, cfg, func() (e error) {
-		r, e = b.GetMetadata(&sarama.MetadataRequest{topics})
-		return
-	})
-	return
-}
-
-func withRetry(
-	b *sarama.Broker,
-	cfg *sarama.Config,
-	f func() error,
-) error {
-	var err error
-	for max := 0; max < cfg.Metadata.Retry.Max; max++ {
-		if ok, _ := b.Connected(); !ok {
-			if err = b.Open(cfg); err == nil {
-				err = f()
-			}
-		} else {
-			err = f()
-		}
-
-		if err == nil {
-			return nil
-		}
-
-		retry, reconnect := checkRetryQuery(err)
-		if !retry {
-			return err
-		}
-
-		time.Sleep(cfg.Metadata.Retry.Backoff)
-		if reconnect {
-			closeBroker(b)
-		}
-	}
-	return err
-}
-
-func checkRetryQuery(err error) (retry, reconnect bool) {
-	if err == nil {
-		return false, false
-	}
-
-	if err == io.EOF {
-		return true, true
-	}
-
-	k, ok := err.(sarama.KError)
-	if !ok {
-		return false, false
-	}
-
-	switch k {
-	case sarama.ErrLeaderNotAvailable, sarama.ErrReplicaNotAvailable,
-		sarama.ErrOffsetsLoadInProgress, sarama.ErrRebalanceInProgress:
-		return true, false
-	case sarama.ErrRequestTimedOut, sarama.ErrBrokerNotAvailable,
-		sarama.ErrNetworkException:
-		return true, true
-	}
-
-	return false, false
-}
-
-func findMatchingBroker(
-	addr string,
-	brokers []*sarama.Broker,
-) *sarama.Broker {
-	lst := brokerAddresses(brokers)
-	if idx, found := findMatchingAddress(addr, lst); found {
-		return brokers[idx]
-	}
-	return nil
-}
-
-func findMatchingAddress(
-	addr string,
-	brokers []string,
-) (int, bool) {
-	debugf("Try to match broker to: %v", addr)
-
-	// compare connection address to list of broker addresses
-	if i, found := indexOf(addr, brokers); found {
-		return i, true
-	}
-
-	// get connection 'port'
-	_, port, err := net.SplitHostPort(addr)
-	if err != nil || port == "" {
-		port = "9092"
-	}
-
-	// lookup local machines ips for comparing with broker addresses
-	localIPs, err := common.LocalIPAddrs()
-	if err != nil || len(localIPs) == 0 {
-		return -1, false
-	}
-	debugf("local machine ips: %v", localIPs)
-
-	// try to find broker by comparing the fqdn for each known ip to list of
-	// brokers
-	localHosts := lookupHosts(localIPs)
-	debugf("local machine addresses: %v", localHosts)
-	for _, host := range localHosts {
-		debugf("try to match with fqdn: %v (%v)", host, port)
-		if i, found := indexOf(net.JoinHostPort(host, port), brokers); found {
-			return i, true
-		}
-	}
-
-	// try to find broker id by comparing the machines local hostname to
-	// broker hostnames in metadata
-	if host, err := os.Hostname(); err == nil {
-		debugf("try to match with hostname only: %v (%v)", host, port)
-
-		tmp := net.JoinHostPort(strings.ToLower(host), port)
-		if i, found := indexOf(tmp, brokers); found {
-			return i, true
-		}
-	}
-
-	// lookup ips for all brokers
-	debugf("match by ips")
-	for i, b := range brokers {
-		debugf("test broker address: %v", b)
-		bh, bp, err := net.SplitHostPort(b)
-		if err != nil {
-			continue
-		}
-
-		// port numbers do not match
-		if bp != port {
-			continue
-		}
-
-		// lookup all ips for brokers host:
-		ips, err := net.LookupIP(bh)
-		debugf("broker %v ips: %v, %v", bh, ips, err)
-		if err != nil {
-			continue
-		}
-
-		debugf("broker (%v) ips: %v", bh, ips)
-
-		// check if ip is known
-		if anyIPsMatch(ips, localIPs) {
-			return i, true
-		}
-	}
-
-	return -1, false
-}
-
-func lookupHosts(ips []net.IP) []string {
-	set := map[string]struct{}{}
-	for _, ip := range ips {
-		txt, err := ip.MarshalText()
-		if err != nil {
-			continue
-		}
-
-		hosts, err := net.LookupAddr(string(txt))
-		debugf("lookup %v => %v, %v", string(txt), hosts, err)
-		if err != nil {
-			continue
-		}
-
-		for _, host := range hosts {
-			h := strings.ToLower(strings.TrimSuffix(host, "."))
-			set[h] = struct{}{}
-		}
-	}
-
-	hosts := make([]string, 0, len(set))
-	for host := range set {
-		hosts = append(hosts, host)
-	}
-	return hosts
-}
-
-func anyIPsMatch(as, bs []net.IP) bool {
-	for _, a := range as {
-		for _, b := range bs {
-			if bytes.Equal(a, b) {
-				return true
-			}
-		}
-	}
-	return false
-}
-
-func brokerAddresses(brokers []*sarama.Broker) []string {
-	addresses := make([]string, len(brokers))
-	for i, b := range brokers {
-		addresses[i] = brokerAddress(b)
-	}
-	return addresses
-}
-
-func brokerAddress(b *sarama.Broker) string {
-	return strings.ToLower(b.Addr())
-}
-
-func indexOf(s string, lst []string) (int, bool) {
-	for i, v := range lst {
-		if s == v {
-			return i, true
-		}
-	}
-	return -1, false
 }

--- a/metricbeat/module/kafka/partition/partition_integration_test.go
+++ b/metricbeat/module/kafka/partition/partition_integration_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/Shopify/sarama"
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/logp"
 	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
 	"github.com/stretchr/testify/assert"
 )
@@ -24,7 +25,7 @@ const (
 func TestData(t *testing.T) {
 	generateKafkaData(t, "metricbeat-generate-data")
 
-	f := mbtest.NewEventsFetcher(t, getConfig())
+	f := mbtest.NewEventsFetcher(t, getConfig(""))
 	err := mbtest.WriteEvents(f, t)
 	if err != nil {
 		t.Fatal("write", err)
@@ -32,17 +33,25 @@ func TestData(t *testing.T) {
 }
 
 func TestTopic(t *testing.T) {
+	if testing.Verbose() {
+		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"kafka"})
+	}
+
 	id := strconv.Itoa(rand.New(rand.NewSource(int64(time.Now().Nanosecond()))).Int())
 	testTopic := fmt.Sprintf("test-metricbeat-%s", id)
 
 	// Create initial topic
 	generateKafkaData(t, testTopic)
 
-	f := mbtest.NewEventsFetcher(t, getConfig())
+	f := mbtest.NewEventsFetcher(t, getConfig(testTopic))
 	dataBefore, err := f.Fetch()
 	if err != nil {
 		t.Fatal("write", err)
 	}
+	if len(dataBefore) == 0 {
+		t.Errorf("No offsets fetched from topic (before): %v", testTopic)
+	}
+	t.Logf("before: %v", dataBefore)
 
 	var n int64 = 10
 	var i int64 = 0
@@ -55,6 +64,10 @@ func TestTopic(t *testing.T) {
 	if err != nil {
 		t.Fatal("write", err)
 	}
+	if len(dataAfter) == 0 {
+		t.Errorf("No offsets fetched from topic (after): %v", testTopic)
+	}
+	t.Logf("after: %v", dataAfter)
 
 	// Checks that no new topics / partitions were added
 	assert.True(t, len(dataBefore) == len(dataAfter))
@@ -84,6 +97,8 @@ func TestTopic(t *testing.T) {
 }
 
 func generateKafkaData(t *testing.T, topic string) {
+	t.Logf("Send Kafka Event to topic: %v", topic)
+
 	config := sarama.NewConfig()
 	client, err := sarama.NewClient([]string{getTestKafkaHost()}, config)
 	if err != nil {
@@ -109,11 +124,17 @@ func generateKafkaData(t *testing.T, topic string) {
 	client.RefreshMetadata(topic)
 }
 
-func getConfig() map[string]interface{} {
+func getConfig(topic string) map[string]interface{} {
+	var topics []string
+	if topic != "" {
+		topics = []string{topic}
+	}
+
 	return map[string]interface{}{
 		"module":     "kafka",
 		"metricsets": []string{"partition"},
 		"hosts":      []string{getTestKafkaHost()},
+		"topics":     topics,
 	}
 }
 


### PR DESCRIPTION
In preparation for other metricset using a broker connection only, I moved the broker from partitions metricset to the kafka module.