### PR TITLE
Cherry-pick: Use kebab_case in the settings for the JSON processor (#3111)

### DIFF
--- a/libbeat/processors/actions/decode_json_fields.go
+++ b/libbeat/processors/actions/decode_json_fields.go
@@ -21,8 +21,8 @@ type decodeJSONFields struct {
 
 type config struct {
 	Fields       []string `config:"fields"`
-	MaxDepth     int      `config:"maxDepth" validate:"min=1"`
-	ProcessArray bool     `config:"processArray"`
+	MaxDepth     int      `config:"max_depth" validate:"min=1"`
+	ProcessArray bool     `config:"process_array"`
 }
 
 var (
@@ -38,7 +38,7 @@ func init() {
 	processors.RegisterPlugin("decode_json_fields",
 		configChecked(newDecodeJSONFields,
 			requireFields("fields"),
-			allowedFields("fields", "maxDepth", "processArray")))
+			allowedFields("fields", "max_depth", "process_array")))
 }
 
 func newDecodeJSONFields(c common.Config) (processors.Processor, error) {

--- a/libbeat/processors/actions/decode_json_fields_test.go
+++ b/libbeat/processors/actions/decode_json_fields_test.go
@@ -89,9 +89,9 @@ func TestValidJSONDepthTwo(t *testing.T) {
 	}
 
 	testConfig, _ = common.NewConfigFrom(map[string]interface{}{
-		"fields":       fields,
-		"processArray": false,
-		"maxDepth":     2,
+		"fields":        fields,
+		"process_array": false,
+		"max_depth":     2,
 	})
 
 	actual := getActualValue(t, testConfig, input)


### PR DESCRIPTION
Cherry-pick of #3111 to master. Left our the Changelog line, since it wasn't released.

This is to align them with the rest of our configuration files.
(cherry picked from commit 79e4bb55c465e29af58283f0d22b439fc2ebffe0)