### PR TITLE
Allow custom beats-builder images

### DIFF
--- a/dev-tools/packer/Makefile
+++ b/dev-tools/packer/Makefile
@@ -1,6 +1,9 @@
 BUILDID?=$(shell git rev-parse HEAD)
 SNAPSHOT?=yes
 
+BEATS_BUILDER_IMAGE?=tudorg/beats-builder
+BEATS_BUILDER_DEB6_IMAGE?=tudorg/beats-builder-deb6
+
 makefile_abspath:=$(abspath $(lastword $(MAKEFILE_LIST)))
 packer_absdir=$(shell dirname ${makefile_abspath})
 beat_abspath=${GOPATH}/src/${BEAT_DIR}
@@ -73,29 +76,29 @@ run-interactive-builder-deb6:
 	docker run -t -i -v $(shell pwd)/build:/build \
 		-v $(shell pwd)/xgo-scripts/:/scripts \
 		-v $(shell pwd)/../..:/source \
-		--entrypoint=bash tudorg/beats-builder-deb6
+		--entrypoint=bash ${BEATS_BUILDER_DEB6_IMAGE}
 
 .PHONY: run-interactive-builder
 run-interactive-builder:
 	docker run -t -i -v $(shell pwd)/build:/build \
 		-v $(packer_absdir)/xgo-scripts/:/scripts \
 		-v $(shell pwd)/../..:/source \
-		--entrypoint=bash tudorg/beats-builder
+		--entrypoint=bash ${BEATS_BUILDER_IMAGE}
 
 .PHONY: images
 images: xgo-image fpm-image go-daemon-image
 
 .PHONY: push-images
 push-images:
-	docker push tudorg/beats-builder
-	docker push tudorg/beats-builder-deb6
+	docker push ${BEATS_BUILDER_IMAGE}
+	docker push ${BEATS_BUILDER_DEB6_IMAGE}
 	docker push tudorg/fpm
 	docker push tudorg/go-daemon
 
 .PHONY: pull-images
 pull-images:
-	docker pull tudorg/beats-builder
-	docker pull tudorg/beats-builder-deb6
+	docker pull ${BEATS_BUILDER_IMAGE}
+	docker pull ${BEATS_BUILDER_DEB6_IMAGE}
 	docker pull tudorg/fpm
 	docker pull tudorg/go-daemon
 
@@ -115,8 +118,8 @@ endef
 
 .PHONY: clean-images
 clean-images:
-	@$(call rm-image,tudorg/beats-builder-deb6)
-	@$(call rm-image,tudorg/beats-builder)
+	@$(call rm-image, ${BEATS_BUILDER_DEB6_IMAGE})
+	@$(call rm-image, ${BEATS_BUILDER_IMAGE})
 
 .PHONY: clean
 clean:

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -62,6 +62,8 @@ TARGETS?="linux/amd64 linux/386 windows/amd64 windows/386 darwin/amd64"
 TARGETS_OLD?=""
 PACKAGES?=${BEATNAME}/deb ${BEATNAME}/rpm ${BEATNAME}/darwin ${BEATNAME}/win ${BEATNAME}/bin
 SNAPSHOT?=yes
+BEATS_BUILDER_IMAGE?=tudorg/beats-builder
+BEATS_BUILDER_DEB6_IMAGE?=tudorg/beats-builder-deb6
 
 ifeq ($(DOCKER_CACHE),0)
 	DOCKER_NOCACHE=--no-cache
@@ -353,7 +355,7 @@ prepare-package:
 		-e SOURCE=/source \
 		-e TARGETS=${TARGETS} \
 		-e BUILDID=${BUILDID} \
-		tudorg/beats-builder \
+		${BEATS_BUILDER_IMAGE} \
 		${BEAT_DIR}
 
 # Prepares for packaging. Builds binaries with cgo
@@ -371,7 +373,7 @@ prepare-package-cgo:
 		-e SOURCE=/source \
 		-e TARGETS=${TARGETS} \
 		-e BUILDID=${BUILDID} \
-		tudorg/beats-builder \
+		${BEATS_BUILDER_IMAGE} \
 		${BEAT_DIR}
 
 	# linux builds on debian 6 for compatibility
@@ -385,7 +387,7 @@ prepare-package-cgo:
 		-e SOURCE=/source \
 		-e TARGETS=${TARGETS_OLD} \
 		-e BUILDID=${BUILDID} \
-		tudorg/beats-builder-deb6 \
+		${BEATS_BUILDER_DEB6_IMAGE} \
 		${BEAT_DIR}
 
 # Prepares images for packaging


### PR DESCRIPTION
Use case:
I created a custom beats-builder based on tudorg/beats-builder
that contains my dependencies (zeromq and google protobuf)

Having this custom image speeds up the packaging time as
the dependencies are no longer built  when `make package` is called


