### PR TITLE
Filebeat module system/integration tests

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -51,7 +51,7 @@ install:
   - set PYTHONPATH=C:\Python27
   - set PATH=%PYTHONPATH%;%PYTHONPATH%\Scripts;%PATH%
   - python --version
-  - pip install jinja2 nose nose-timer PyYAML redis
+  - pip install jinja2 nose nose-timer PyYAML redis elasticsearch
   - easy_install C:/pywin_inst.exe
 
 # To run your custom scripts instead of automatic MSBuild

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ env:
   matrix:
     - TARGETS="check"
     - TARGETS="-C filebeat testsuite"
+    - TARGETS="TEST_ENVIRONMENT=0 -C filebeat testsuite"
     - TARGETS="-C heartbeat testsuite"
     - TARGETS="-C libbeat testsuite"
     - TARGETS="-C metricbeat testsuite"
@@ -55,6 +56,10 @@ matrix:
       env: TARGETS="-C metricbeat testsuite"
     - os: linux
       env: TARGETS="TEST_ENVIRONMENT=0 -C metricbeat testsuite"
+    - os: osx
+      env: TARGETS="-C filebeat testsuite"
+    - os: linux
+      env: TARGETS="TEST_ENVIRONMENT=0 -C filebeat testsuite"
     - os: osx
       env: TARGETS="-C libbeat/dashboards"
     - os: osx

--- a/filebeat/Dockerfile
+++ b/filebeat/Dockerfile
@@ -1,0 +1,14 @@
+FROM golang:1.7.1
+MAINTAINER Nicolas Ruflin <ruflin@elastic.co>
+
+RUN set -x && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+         netcat python-pip virtualenv && \
+    apt-get clean
+
+# Setup work environment
+ENV FILEBEAT_PATH /go/src/github.com/elastic/beats/filebeat
+
+RUN mkdir -p $FILEBEAT_PATH/build/coverage
+WORKDIR $FILEBEAT_PATH

--- a/filebeat/Makefile
+++ b/filebeat/Makefile
@@ -3,7 +3,7 @@
 BEATNAME?=filebeat
 BEAT_DESCRIPTION?=Filebeat sends log files to Logstash or directly to Elasticsearch.
 SYSTEM_TESTS=true
-TEST_ENVIRONMENT=false
+TEST_ENVIRONMENT?=true
 GOX_FLAGS='-arch=amd64 386 arm ppc64 ppc64le'
 
 include ../libbeat/scripts/Makefile

--- a/filebeat/_meta/fields.common.yml
+++ b/filebeat/_meta/fields.common.yml
@@ -38,7 +38,7 @@
         Ingestion pipeline error message, added in case there are errors reported by
         the Ingest Node in Elasticsearch.
 
-    - name: beat.read_timestamp
+    - name: read_timestamp
       description: >
         In case the ingest pipeline parses the timestamp from the log contents, it stores
         the original `@timestamp` (representing the time when the log line was read) in this

--- a/filebeat/_meta/fields.common.yml
+++ b/filebeat/_meta/fields.common.yml
@@ -38,3 +38,9 @@
         Ingestion pipeline error message, added in case there are errors reported by
         the Ingest Node in Elasticsearch.
 
+    - name: beat.read_timestamp
+      description: >
+        In case the ingest pipeline parses the timestamp from the log contents, it stores
+        the original `@timestamp` (representing the time when the log line was read) in this
+        field.
+

--- a/filebeat/docker-compose.yml
+++ b/filebeat/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '2'
+services:
+  beat:
+    build: ${PWD}/.
+    env_file:
+      - ${PWD}/build/test.env
+    working_dir: /go/src/github.com/elastic/beats/filebeat
+    volumes:
+      - ${PWD}/..:/go/src/github.com/elastic/beats/
+    command: make
+    entrypoint: /go/src/github.com/elastic/beats/filebeat/docker-entrypoint.sh

--- a/filebeat/docker-entrypoint.sh
+++ b/filebeat/docker-entrypoint.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+set -e
+
+# This script is the entrypoint to the filebeat Docker container. This will
+# verify that all services are running before executing the command provided
+# to the docker container.
+
+setDefaults() {
+  # Use default ports and hosts if not specified.
+  : ${ES_HOST:=localhost}
+  : ${ES_PORT:=9200}
+}
+
+es_url() {
+    local auth
+
+    auth=""
+    if [ -n "$ES_USER" ]; then
+        auth="$ES_USER"
+        if [ -n "$ES_PASS" ]; then
+            auth="$auth:$ES_PASS"
+        fi
+        auth="$auth@"
+    fi
+
+    if [ "$SHIELD" == "true" ]; then
+        code=$(curl --write-out "%{http_code}\n" --silent --output /dev/null "http://${ES_HOST}:${ES_PORT}/")
+
+        if [ $code != 401 ]; then
+            echo "Shield does not seem to be running"
+            exit 1
+        fi
+    fi
+    echo "http://${auth}${ES_HOST}:${ES_PORT}"
+}
+
+# Wait for elasticsearch to start. It requires that the status be either
+# green or yellow.
+waitForElasticsearch() {
+  echo -n "Waiting on elasticsearch($(es_url)) to start."
+  for ((i=1;i<=60;i++))
+  do
+    health=$(curl --silent "$(es_url)/_cat/health" | awk '{print $4}')
+    if [[ "$health" == "green" ]] || [[ "$health" == "yellow" ]]
+    then
+      echo
+      echo "Elasticsearch is ready!"
+      return 0
+    fi
+
+    echo -n '.'
+    sleep 1
+  done
+
+  echo
+  echo >&2 'Elasticsearch is not running or is not healthy.'
+  echo >&2 "Address: $(es_url)"
+  echo >&2 "$health"
+  exit 1
+}
+
+# Main
+setDefaults
+
+# Services need to test outputs
+# Wait until all services are started
+waitForElasticsearch
+
+exec "$@"

--- a/filebeat/docs/fields.asciidoc
+++ b/filebeat/docs/fields.asciidoc
@@ -184,7 +184,7 @@ Ingestion pipeline error message, added in case there are errors reported by the
 
 
 [float]
-=== beat.read_timestamp
+=== read_timestamp
 
 In case the ingest pipeline parses the timestamp from the log contents, it stores the original `@timestamp` (representing the time when the log line was read) in this field.
 

--- a/filebeat/docs/fields.asciidoc
+++ b/filebeat/docs/fields.asciidoc
@@ -183,6 +183,12 @@ The input type from which the event was generated. This field is set to the valu
 Ingestion pipeline error message, added in case there are errors reported by the Ingest Node in Elasticsearch.
 
 
+[float]
+=== beat.read_timestamp
+
+In case the ingest pipeline parses the timestamp from the log contents, it stores the original `@timestamp` (representing the time when the log line was read) in this field.
+
+
 [[exported-fields-mysql]]
 == MySQL Fields
 

--- a/filebeat/filebeat.py
+++ b/filebeat/filebeat.py
@@ -157,7 +157,6 @@ output.elasticsearch.pipeline: "%{[fields.pipeline_id]}"
 
     if args.once:
         cfg_template += "\nfilebeat.idle_timeout: 0.5s"
-        cfg_template += "\nfilebeat.shutdown_timeout: 1s"
 
     if args.registry:
         cfg_template += "\nfilebeat.registry_file: {}".format(args.registry)
@@ -170,7 +169,8 @@ output.elasticsearch.pipeline: "%{[fields.pipeline_id]}"
         print("Wrote configuration file: {}".format(cfgfile.name))
     os.close(fd)
 
-    cmd = ["./filebeat", "-e", "-c", cfgfile.name, "-d", "*"]
+    cmd = ["./filebeat.test", "-systemTest",
+           "-e", "-c", cfgfile.name, "-d", "*"]
     if args.once:
         cmd.append("-once")
     print("Starting filebeat: " + " ".join(cmd))

--- a/filebeat/filebeat.py
+++ b/filebeat/filebeat.py
@@ -17,11 +17,20 @@ def main():
                         help="From branch")
     parser.add_argument("--es", default="http://localhost:9200",
                         help="Elasticsearch URL")
+    parser.add_argument("--index", default=None,
+                        help="Elasticsearch index")
+    parser.add_argument("--registry", default=None,
+                        help="Registry file to use")
     parser.add_argument("-M", nargs="*", type=str, default=None,
                         help="Variables overrides. e.g. path=/test")
+    parser.add_argument("--once", action="store_true",
+                        help="Run filebeat with the -once flag")
 
     args = parser.parse_args()
     print args
+
+    # changing directory because we use paths relative to the binary
+    os.chdir(os.path.dirname(sys.argv[0]))
 
     modules = args.modules.split(",")
     if len(modules) == 0:
@@ -57,9 +66,8 @@ def load_datasets(args, modules):
             prospectors += load_fileset(args, module, fileset,
                                         os.path.join(path, fileset))
 
-    run_filebeat(args, prospectors)
-
     print("Generated configuration: {}".format(prospectors))
+    run_filebeat(args, prospectors)
 
 
 def load_fileset(args, module, fileset, path):
@@ -144,6 +152,16 @@ filebeat.prospectors:
 output.elasticsearch.hosts: ["{{es}}"]
 output.elasticsearch.pipeline: "%{[fields.pipeline_id]}"
 """
+    if args.index:
+        cfg_template += "\noutput.elasticsearch.index: {}".format(args.index)
+
+    if args.once:
+        cfg_template += "\nfilebeat.idle_timeout: 0.5s"
+        cfg_template += "\nfilebeat.shutdown_timeout: 1s"
+
+    if args.registry:
+        cfg_template += "\nfilebeat.registry_file: {}".format(args.registry)
+
     fd, fname = tempfile.mkstemp(suffix=".yml", prefix="filebeat-",
                                  text=True)
     with open(fname, "w") as cfgfile:
@@ -153,6 +171,9 @@ output.elasticsearch.pipeline: "%{[fields.pipeline_id]}"
     os.close(fd)
 
     cmd = ["./filebeat", "-e", "-c", cfgfile.name, "-d", "*"]
+    if args.once:
+        cmd.append("-once")
+    print("Starting filebeat: " + " ".join(cmd))
 
     subprocess.Popen(cmd).wait()
 
@@ -163,6 +184,12 @@ def generate_prospectors(var, prospectors):
         path = os.path.join(var["beat"]["path"], Template(pr).render(var))
         with open(path, "r") as f:
             contents = Template(f.read()).render(var)
+        if var["beat"]["args"].once:
+            contents += "\n  close_eof: true"
+            contents += "\n  scan_frequency: 0.2s"
+            if "multiline" in contents:
+                contents += "\n  multiline.timeout: 0.2s"
+
         var["beat"]["prospectors"] += "\n" + contents
 
 

--- a/filebeat/filebeat.template-es2x.json
+++ b/filebeat/filebeat.template-es2x.json
@@ -27,7 +27,17 @@
         },
         "beat": {
           "properties": {
-            "read_timestamp": {
+            "hostname": {
+              "ignore_above": 1024,
+              "index": "not_analyzed",
+              "type": "string"
+            },
+            "name": {
+              "ignore_above": 1024,
+              "index": "not_analyzed",
+              "type": "string"
+            },
+            "version": {
               "ignore_above": 1024,
               "index": "not_analyzed",
               "type": "string"
@@ -305,6 +315,11 @@
         },
         "offset": {
           "type": "long"
+        },
+        "read_timestamp": {
+          "ignore_above": 1024,
+          "index": "not_analyzed",
+          "type": "string"
         },
         "source": {
           "ignore_above": 1024,

--- a/filebeat/filebeat.template-es2x.json
+++ b/filebeat/filebeat.template-es2x.json
@@ -27,17 +27,7 @@
         },
         "beat": {
           "properties": {
-            "hostname": {
-              "ignore_above": 1024,
-              "index": "not_analyzed",
-              "type": "string"
-            },
-            "name": {
-              "ignore_above": 1024,
-              "index": "not_analyzed",
-              "type": "string"
-            },
-            "version": {
+            "read_timestamp": {
               "ignore_above": 1024,
               "index": "not_analyzed",
               "type": "string"

--- a/filebeat/filebeat.template.json
+++ b/filebeat/filebeat.template.json
@@ -24,15 +24,7 @@
         },
         "beat": {
           "properties": {
-            "hostname": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "name": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "version": {
+            "read_timestamp": {
               "ignore_above": 1024,
               "type": "keyword"
             }

--- a/filebeat/filebeat.template.json
+++ b/filebeat/filebeat.template.json
@@ -24,7 +24,15 @@
         },
         "beat": {
           "properties": {
-            "read_timestamp": {
+            "hostname": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "version": {
               "ignore_above": 1024,
               "type": "keyword"
             }
@@ -262,6 +270,10 @@
         },
         "offset": {
           "type": "long"
+        },
+        "read_timestamp": {
+          "ignore_above": 1024,
+          "type": "keyword"
         },
         "source": {
           "ignore_above": 1024,

--- a/filebeat/module/mysql/error/ingest/pipeline.json
+++ b/filebeat/module/mysql/error/ingest/pipeline.json
@@ -5,7 +5,7 @@
         "field": "message",
         "patterns": [
           "%{LOCALDATETIME:mysql.error.timestamp} (\\[%{DATA:mysql.error.level}\\] )?%{GREEDYDATA:mysql.error.message}",
-          "%{DATA:mysql.error.timestamp} %{NUMBER:mysql.error.id} \\[%{DATA:mysql.error.level}\\] %{GREEDYDATA:mysql.error.message1}",
+          "%{DATA:mysql.error.timestamp} %{NUMBER:mysql.error.thread_id} \\[%{DATA:mysql.error.level}\\] %{GREEDYDATA:mysql.error.message1}",
           "%{GREEDYDATA:mysql.error.message2}"
         ],
         "ignore_missing": true,

--- a/filebeat/module/nginx/access/ingest/no_plugins.json
+++ b/filebeat/module/nginx/access/ingest/no_plugins.json
@@ -15,7 +15,7 @@
   }, {
     "rename": {
       "field": "@timestamp",
-      "target_field": "beat.read_timestamp"
+      "target_field": "read_timestamp"
     }
   }, {
     "date": {

--- a/filebeat/module/nginx/access/ingest/with_plugins.json
+++ b/filebeat/module/nginx/access/ingest/with_plugins.json
@@ -15,7 +15,7 @@
   }, {
     "rename": {
       "field": "@timestamp",
-      "target_field": "beat.read_timestamp"
+      "target_field": "read_timestamp"
     }
   }, {
     "date": {

--- a/filebeat/module/nginx/error/ingest/pipeline.json
+++ b/filebeat/module/nginx/error/ingest/pipeline.json
@@ -15,7 +15,7 @@
   }, {
     "rename": {
       "field": "@timestamp",
-      "target_field": "beat.read_timestamp"
+      "target_field": "read_timestamp"
     }
   }, {
     "date": {

--- a/filebeat/module/syslog/system/test/darwin-syslog-sample.log
+++ b/filebeat/module/syslog/system/test/darwin-syslog-sample.log
@@ -1,0 +1,20 @@
+Dec 13 11:35:28 a-mac-with-esc-key GoogleSoftwareUpdateAgent[21412]: 2016-12-13 11:35:28.420 GoogleSoftwareUpdateAgent[21412/0x700007399000] [lvl=2] -[KSAgentApp updateProductWithProductID:usingEngine:] Checking for updates for "All Products" using engine <KSUpdateEngine:0x100341a00
+		ticketStore=<KSPersistentTicketStore:0x100204520 store=<KSKeyedPersistentStore:0x100213290
+			path="/Users/tsg/Library/Google/GoogleSoftwareUpdate/TicketStore/Keystone.ticketstore"
+			lockFile=<KSLockFile:0x1002160e0
+				path="/Users/tsg/Library/Google/GoogleSoftwareUpdate/TicketStore/Keystone.ticketstore.lock"
+				locked=NO
+			>
+		>>
+		processor=<KSActionProcessor:0x1003bb5f0
+			delegate=<KSUpdateEngine:0x100341a00>
+			isProcessing=NO actionsCompleted=0 progress=0.00
+			errors=0 currentActionErrors=0
+			events=0 currentActionEvents=0
+			actionQueue=( )
+		>
+		delegate=(null)
+		serverInfoStore=(null)
+		errors=0
+	>
+Dec 13 11:35:28 a-mac-with-esc-key GoogleSoftwareUpdateAgent[21412]: 2016-12-13 11:35:28.421 GoogleSoftwareUpdateAgent[21412/0x700007399000] [lvl=2] -[KSUpdateEngine updateAllExceptProduct:] KSUpdateEngine updating all installed products, except:'com.google.Keystone'.

--- a/filebeat/module/syslog/system/test/darwin-syslog-sample.log-expected.json
+++ b/filebeat/module/syslog/system/test/darwin-syslog-sample.log-expected.json
@@ -1,0 +1,80 @@
+[
+{
+  "_index": "filebeat-2016.12.15",
+  "_type": "log",
+  "_id": "AVkBzqQ6j7PoDSoX1nl9",
+  "_score": null,
+  "_source": {
+    "@timestamp": "2016-12-13T11:35:28.000Z",
+    "offset": 907,
+    "beat": {
+      "hostname": "a-mac-with-esc-key.local",
+      "name": "a-mac-with-esc-key.local",
+      "version": "6.0.0-alpha1"
+    },
+    "input_type": "log",
+    "source": "module/syslog/system/test/darwin-syslog-sample.log",
+    "syslog": {
+      "system": {
+        "hostname": "a-mac-with-esc-key",
+        "pid": "21412",
+        "program": "GoogleSoftwareUpdateAgent",
+        "message": "2016-12-13 11:35:28.420 GoogleSoftwareUpdateAgent[21412/0x700007399000] [lvl=2] -[KSAgentApp updateProductWithProductID:usingEngine:] Checking for updates for \"All Products\" using engine <KSUpdateEngine:0x100341a00\n\t\tticketStore=<KSPersistentTicketStore:0x100204520 store=<KSKeyedPersistentStore:0x100213290\n\t\t\tpath=\"/Users/tsg/Library/Google/GoogleSoftwareUpdate/TicketStore/Keystone.ticketstore\"\n\t\t\tlockFile=<KSLockFile:0x1002160e0\n\t\t\t\tpath=\"/Users/tsg/Library/Google/GoogleSoftwareUpdate/TicketStore/Keystone.ticketstore.lock\"\n\t\t\t\tlocked=NO\n\t\t\t>\n\t\t>>\n\t\tprocessor=<KSActionProcessor:0x1003bb5f0\n\t\t\tdelegate=<KSUpdateEngine:0x100341a00>\n\t\t\tisProcessing=NO actionsCompleted=0 progress=0.00\n\t\t\terrors=0 currentActionErrors=0\n\t\t\tevents=0 currentActionEvents=0\n\t\t\tactionQueue=( )\n\t\t>\n\t\tdelegate=(null)\n\t\tserverInfoStore=(null)\n\t\terrors=0\n\t>",
+        "timestamp": "Dec 13 11:35:28"
+      }
+    },
+    "fields": {
+      "pipeline_id": "syslog-system-pipeline",
+      "source_type": "syslog-system"
+    },
+    "type": "log"
+  },
+  "fields": {
+    "@timestamp": [
+      1481628928000
+    ]
+  },
+  "sort": [
+    1481628928000
+  ]
+},
+{
+  "_index": "filebeat-2016.12.15",
+  "_type": "log",
+  "_id": "AVkBzrcuj7PoDSoX1nl-",
+  "_score": null,
+  "_source": {
+    "@timestamp": "2016-12-13T11:35:28.000Z",
+    "offset": 1176,
+    "beat": {
+      "hostname": "a-mac-with-esc-key.local",
+      "name": "a-mac-with-esc-key.local",
+      "version": "6.0.0-alpha1"
+    },
+    "input_type": "log",
+    "source": "module/syslog/system/test/darwin-syslog-sample.log",
+    "syslog": {
+      "system": {
+        "hostname": "a-mac-with-esc-key",
+        "pid": "21412",
+        "program": "GoogleSoftwareUpdateAgent",
+        "message": "2016-12-13 11:35:28.421 GoogleSoftwareUpdateAgent[21412/0x700007399000] [lvl=2] -[KSUpdateEngine updateAllExceptProduct:] KSUpdateEngine updating all installed products, except:'com.google.Keystone'.",
+        "timestamp": "Dec 13 11:35:28"
+      }
+    },
+    "fields": {
+      "pipeline_id": "syslog-system-pipeline",
+      "source_type": "syslog-system"
+    },
+    "type": "log"
+  },
+  "fields": {
+    "@timestamp": [
+      1481628928000
+    ]
+  },
+  "sort": [
+    1481628928000
+  ]
+}
+]

--- a/filebeat/tests/system/filebeat.py
+++ b/filebeat/tests/system/filebeat.py
@@ -44,3 +44,14 @@ class BaseTest(TestCase):
 
         return tmp_entry
 
+    def assert_fields_are_documented(self, evt):
+        """
+        Assert that all keys present in evt are documented in fields.yml.
+        This reads from the global fields.yml, means `make collect` has to be run before the check.
+        """
+        expected_fields, dict_fields = self.load_fields()
+        flat = self.flatten_object(evt, dict_fields)
+
+        for key in flat.keys():
+            if key not in expected_fields:
+                raise Exception("Key '{}' found in event is not documented!".format(key))

--- a/filebeat/tests/system/test_crawler.py
+++ b/filebeat/tests/system/test_crawler.py
@@ -761,6 +761,9 @@ class Test(BaseTest):
         """
         Checks that filebeat handles files without reading permission well
         """
+        if os.name != "nt" and os.geteuid() == 0:
+            # root ignores permission flags, so we have to skip the test
+            raise SkipTest
 
         self.render_config_template(
             path=os.path.abspath(self.working_dir) + "/log/*",

--- a/filebeat/tests/system/test_modules.py
+++ b/filebeat/tests/system/test_modules.py
@@ -1,0 +1,88 @@
+from filebeat import BaseTest
+from beat.beat import INTEGRATION_TESTS
+import os
+import unittest
+import glob
+import subprocess
+from elasticsearch import Elasticsearch
+import json
+
+
+class Test(BaseTest):
+    def init(self):
+        self.elasticsearch_url = self.get_testing_elasticsearch_url()
+        print("Using elasticsearch: {}".format(self.elasticsearch_url))
+        self.es = Elasticsearch([self.elasticsearch_url])
+
+        self.modules_path = os.path.abspath(self.working_dir +
+                                            "/../../../../module")
+
+        self.filebeat = os.path.abspath(self.working_dir +
+                                        "/../../../../filebeat.py")
+
+    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
+    def test_modules(self):
+        self.init()
+        modules = os.getenv("TESTING_FILEBEAT_MODULES")
+        if modules:
+            modules = modules.split(",")
+        else:
+            modules = os.listdir(self.modules_path)
+
+        for module in modules:
+            path = os.path.join(self.modules_path, module)
+            filesets = [name for name in os.listdir(path) if
+                        os.path.isfile(os.path.join(path, name,
+                                                    "manifest.yml"))]
+
+            for fileset in filesets:
+                test_files = glob.glob(os.path.join(self.modules_path, module,
+                                                    fileset, "test", "*.log"))
+                for test_file in test_files:
+                    self.run_on_file(
+                        module=module,
+                        fileset=fileset,
+                        test_file=test_file)
+
+    def run_on_file(self, module, fileset, test_file):
+        print("Testing {}/{} on {}".format(module, fileset, test_file))
+
+        index_name = "test-filebeat-modules"
+        try:
+            self.es.indices.delete(index=index_name)
+        except:
+            pass
+
+        cmd = [
+            self.filebeat,
+            "--once",
+            "--modules={}".format(module),
+            "-M", "{module}.{fileset}.paths={test_file}".format(
+                module=module, fileset=fileset, test_file=test_file),
+            "--es", self.elasticsearch_url,
+            "--index", index_name,
+            "--registry", self.working_dir + "/registry"
+        ]
+        subprocess.Popen(cmd).wait()
+        self.es.indices.refresh(index=index_name)
+
+        res = self.es.search(index=index_name,
+                             body={"query": {"match_all": {}}})
+        objects = [o["_source"] for o in res["hits"]["hits"]]
+        assert len(objects) > 0
+        for obj in objects:
+            self.assert_fields_are_documented(obj)
+
+        if os.path.exists(test_file + "-expected.json"):
+            with open(test_file + "-expected.json", "r") as f:
+                expected = json.load(f)
+                assert len(expected) == len(objects)
+                for ev in expected:
+                    found = False
+                    for obj in objects:
+                        if ev["_source"][module] == obj[module]:
+                            found = True
+                            break
+                    if not found:
+                        raise Exception("The following expected object was" +
+                                        " not found: {}".format(obj))

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -158,7 +158,7 @@ integration-tests-environment: prepare-tests build-image
 
 # Runs the system tests
 .PHONY: system-tests
-system-tests: ${BEATNAME}.test prepare-tests python-env
+system-tests: ${BEATNAME}.test prepare-tests python-env ${ES_BEATS}/libbeat/dashboards/import_dashboards
 	. ${PYTHON_ENV}/bin/activate; INTEGRATION_TESTS=${INTEGRATION_TESTS} nosetests -w tests/system --process-timeout=$(TIMEOUT) --with-timer
 	python ${ES_BEATS}/dev-tools/aggregate_coverage.py -o ${COVERAGE_DIR}/system.cov ./build/system-tests/run
 
@@ -293,9 +293,11 @@ ES_URL?=http://localhost:9200
 export-dashboards: python-env update
 	. ${PYTHON_ENV}/bin/activate && python ${ES_BEATS}/dev-tools/export_dashboards.py --url ${ES_URL} --dir $(shell pwd)/_meta/kibana --regex ${BEATNAME}-*
 
-.PHONY: import-dashboards
-import-dashboards: update
+${ES_BEATS}/libbeat/dashboards/import_dashboards:
 	$(MAKE) -C ${ES_BEATS}/libbeat/dashboards import_dasboards
+
+.PHONY: import-dashboards
+import-dashboards: update ${ES_BEATS}/libbeat/dashboards/import_dashboards
 	${ES_BEATS}/libbeat/dashboards/import_dashboards -es ${ES_URL} -dir ${PWD}/_meta/kibana
 
 ### CONTAINER ENVIRONMENT ####

--- a/libbeat/tests/system/beat/beat.py
+++ b/libbeat/tests/system/beat/beat.py
@@ -401,7 +401,7 @@ class TestCase(unittest.TestCase):
                     dictfields.extend(subdictfields)
                 else:
                     fields.append(newName)
-                    if field.get("type") == "dict":
+                    if field.get("type") in ["dict", "geo_point"]:
                         dictfields.append(newName)
             return fields, dictfields
 
@@ -462,3 +462,13 @@ class TestCase(unittest.TestCase):
                 return pred(len([1 for line in f]))
         except IOError:
             return False
+
+    def get_testing_elasticsearch_url(self):
+        """
+        Returns an elasticsearch.Elasticsearch instance built from the
+        env variables like the integration tests.
+        """
+        return "http://{host}:{port}".format(
+            host=os.getenv("ES_HOST", "localhost"),
+            port=os.getenv("ES_PORT", "9200"),
+        )

--- a/libbeat/tests/system/beat/beat.py
+++ b/libbeat/tests/system/beat/beat.py
@@ -463,7 +463,7 @@ class TestCase(unittest.TestCase):
         except IOError:
             return False
 
-    def get_testing_elasticsearch_url(self):
+    def get_elasticsearch_url(self):
         """
         Returns an elasticsearch.Elasticsearch instance built from the
         env variables like the integration tests.

--- a/libbeat/tests/system/requirements.txt
+++ b/libbeat/tests/system/requirements.txt
@@ -5,3 +5,4 @@ PyYAML
 nose-timer
 redis
 elasticsearch
+requests

--- a/testing/environments/docker/elasticsearch/Dockerfile-snapshot
+++ b/testing/environments/docker/elasticsearch/Dockerfile-snapshot
@@ -32,6 +32,9 @@ USER elasticsearch
 # Install xpack
 #RUN eval ${ES_JAVA_OPTS:-} elasticsearch-plugin install --batch ${XPACK}
 
+RUN elasticsearch-plugin install --batch https://snapshots.elastic.co/downloads/elasticsearch-plugins/ingest-user-agent/ingest-user-agent-6.0.0-alpha1-SNAPSHOT.zip
+RUN elasticsearch-plugin install --batch https://snapshots.elastic.co/downloads/elasticsearch-plugins/ingest-geoip/ingest-geoip-6.0.0-alpha1-SNAPSHOT.zip
+
 COPY config/elasticsearch.yml config/
 COPY config/log4j2.properties config/
 COPY bin/es-docker bin/es-docker


### PR DESCRIPTION
The tests are taking all the logs from the modules `test` folders,
run filebeat on them (loading the template and the pipeline), then
do a search against Elasticsearch. On the result from Elasticsearch,
the test checks that all fields are documented.

In addition, the module writer can proved `-expected` files for each
log file, in which case we test the contents as well.

To run filebeat, the test is making use of the `-once` option, so each run is reasonably fast (usually under a second). The duration to test all the existing modules is 15 seconds at the moment.

This PR moves the filebeat system tests under Docker (if available) so that they have access to the testing environment. This broke one crawler test that was dealing with file permissions, because we're root under Docker which ignores permission. The "fix" is to skip the test if we detect we are root.

Part of #3159.