### PR TITLE
Experimental go 1.8 plugin support

### DIFF
--- a/heartbeat/monitors/plugin.go
+++ b/heartbeat/monitors/plugin.go
@@ -1,0 +1,30 @@
+package monitors
+
+import (
+	"errors"
+
+	"github.com/elastic/beats/libbeat/plugin"
+)
+
+type monitorPlugin struct {
+	name    string
+	typ     Type
+	builder ActiveBuilder
+}
+
+var pluginKey = "heartbeat.monitor"
+
+func ActivePlugin(name string, b ActiveBuilder) map[string][]interface{} {
+	return plugin.MakePlugin(pluginKey, monitorPlugin{name, ActiveMonitor, b})
+}
+
+func init() {
+	plugin.MustRegisterLoader(pluginKey, func(ifc interface{}) error {
+		p, ok := ifc.(monitorPlugin)
+		if !ok {
+			return errors.New("plugin does not match monitor plugin type")
+		}
+
+		return Registry.Register(p.name, p.typ, p.builder)
+	})
+}

--- a/libbeat/beat/beat.go
+++ b/libbeat/beat/beat.go
@@ -46,6 +46,7 @@ import (
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/paths"
+	"github.com/elastic/beats/libbeat/plugin"
 	"github.com/elastic/beats/libbeat/processors"
 	"github.com/elastic/beats/libbeat/publisher"
 	svc "github.com/elastic/beats/libbeat/service"
@@ -152,6 +153,10 @@ func newBeat(name, version string) *Beat {
 func (b *Beat) launch(bt Creator) error {
 	err := b.handleFlags()
 	if err != nil {
+		return err
+	}
+
+	if err := plugin.Initialize(); err != nil {
 		return err
 	}
 

--- a/libbeat/outputs/codecs/codecs.go
+++ b/libbeat/outputs/codecs/codecs.go
@@ -1,0 +1,38 @@
+package codecs
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/elastic/beats/libbeat/outputs"
+	"github.com/elastic/beats/libbeat/plugin"
+)
+
+type codecPlugin struct {
+	name    string
+	factory outputs.CodecFactory
+}
+
+var pluginKey = "libbeat.output.codec"
+
+func Plugin(name string, f outputs.CodecFactory) map[string][]interface{} {
+	return plugin.MakePlugin(name, codecPlugin{name, f})
+}
+
+func init() {
+	plugin.MustRegisterLoader(pluginKey, func(ifc interface{}) (err error) {
+		b, ok := ifc.(codecPlugin)
+		if !ok {
+			return errors.New("plugin does not match output codec plugin type")
+		}
+
+		defer func() {
+			if msg := recover(); msg != nil {
+				err = fmt.Errorf("%s", msg)
+			}
+		}()
+
+		outputs.RegisterOutputCodec(b.name, b.factory)
+		return
+	})
+}

--- a/libbeat/outputs/plugin.go
+++ b/libbeat/outputs/plugin.go
@@ -1,0 +1,36 @@
+package outputs
+
+import (
+	"errors"
+	"fmt"
+
+	p "github.com/elastic/beats/libbeat/plugin"
+)
+
+type outputPlugin struct {
+	name    string
+	builder OutputBuilder
+}
+
+var pluginKey = "libbeat.output"
+
+func Plugin(name string, l OutputBuilder) map[string][]interface{} {
+	return p.MakePlugin(pluginKey, outputPlugin{name, l})
+}
+
+func init() {
+	p.MustRegisterLoader(pluginKey, func(ifc interface{}) error {
+		b, ok := ifc.(outputPlugin)
+		if !ok {
+			return errors.New("plugin does not match output plugin type")
+		}
+
+		name := b.name
+		if outputsPlugins[name] != nil {
+			return fmt.Errorf("output type %v already registered", name)
+		}
+
+		RegisterOutputPlugin(name, b.builder)
+		return nil
+	})
+}

--- a/libbeat/plugin/cli.go
+++ b/libbeat/plugin/cli.go
@@ -1,0 +1,47 @@
+//+build linux,go1.8,cgo
+
+package plugin
+
+import (
+	"flag"
+	"strings"
+
+	"github.com/elastic/beats/libbeat/logp"
+)
+
+type pluginList struct {
+	paths []string
+}
+
+func (p *pluginList) String() string {
+	return strings.Join(p.paths, ",")
+}
+
+func (p *pluginList) Set(v string) error {
+	// TODO: check file exists
+
+	p.paths = append(p.paths, v)
+	return nil
+}
+
+var plugins = &pluginList{}
+
+func init() {
+	flag.Var(plugins, "plugin", "Load additional plugins")
+}
+
+func Initialize() error {
+	if len(plugins.paths) > 0 {
+		logp.Warn("EXPERIMENTAL: loadable plugin support is experimental")
+	}
+
+	for _, path := range plugins.paths {
+		logp.Info("loading plugin bundle: %v", path)
+
+		if err := LoadPlugins(path); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/libbeat/plugin/cli_stub.go
+++ b/libbeat/plugin/cli_stub.go
@@ -1,0 +1,7 @@
+//+build !linux !go1.8 !cgo
+
+package plugin
+
+func Initialize() error {
+	return nil
+}

--- a/libbeat/plugin/load.go
+++ b/libbeat/plugin/load.go
@@ -1,0 +1,41 @@
+//+build linux,go1.8,cgo
+
+package plugin
+
+import (
+	"errors"
+	goplugin "plugin"
+)
+
+func loadPlugins(path string) error {
+	p, err := goplugin.Open(path)
+	if err != nil {
+		return err
+	}
+
+	sym, err := p.Lookup("Bundle")
+	if err != nil {
+		return err
+	}
+
+	ptr, ok := sym.(*map[string][]interface{})
+	if !ok {
+		return errors.New("invalid bundle type")
+	}
+
+	bundle := *ptr
+	for name, plugins := range bundle {
+		loader := registry[name]
+		if loader == nil {
+			continue
+		}
+
+		for _, plugin := range plugins {
+			if err := loader(plugin); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/libbeat/plugin/load_stub.go
+++ b/libbeat/plugin/load_stub.go
@@ -1,0 +1,11 @@
+//+build !linux !go1.8 !cgo
+
+package plugin
+
+import "errors"
+
+var errNotSupported = errors.New("plugins not supported")
+
+func loadPlugins(path string) error {
+	return errNotSupported
+}

--- a/libbeat/plugin/plugin.go
+++ b/libbeat/plugin/plugin.go
@@ -1,0 +1,48 @@
+package plugin
+
+import "fmt"
+
+type PluginLoader func(p interface{}) error
+
+var registry = map[string]PluginLoader{}
+
+func Bundle(
+	bundles ...map[string][]interface{},
+) map[string][]interface{} {
+	ret := map[string][]interface{}{}
+
+	for _, bundle := range bundles {
+		for name, plugins := range bundle {
+			ret[name] = append(ret[name], plugins...)
+		}
+	}
+
+	return ret
+}
+
+func MakePlugin(key string, ifc interface{}) map[string][]interface{} {
+	return map[string][]interface{}{
+		key: {ifc},
+	}
+}
+
+func MustRegisterLoader(name string, l PluginLoader) {
+	err := RegisterLoader(name, l)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func RegisterLoader(name string, l PluginLoader) error {
+	if l := registry[name]; l != nil {
+		return fmt.Errorf("plugin loader '%v' already registered", name)
+	}
+
+	registry[name] = l
+	return nil
+}
+
+func LoadPlugins(path string) error {
+	// TODO: add flag to enable/disable plugins?
+	return loadPlugins(path)
+}

--- a/libbeat/processors/registry.go
+++ b/libbeat/processors/registry.go
@@ -1,9 +1,34 @@
 package processors
 
 import (
+	"errors"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
+	p "github.com/elastic/beats/libbeat/plugin"
 )
+
+type processorPlugin struct {
+	name   string
+	constr Constructor
+}
+
+var pluginKey = "libbeat.processor"
+
+func Plugin(name string, c Constructor) map[string][]interface{} {
+	return p.MakePlugin(pluginKey, processorPlugin{name, c})
+}
+
+func init() {
+	p.MustRegisterLoader(pluginKey, func(ifc interface{}) error {
+		p, ok := ifc.(processorPlugin)
+		if !ok {
+			return errors.New("plugin does not match processor plugin type")
+		}
+
+		return registry.Register(p.name, p.constr)
+	})
+}
 
 type Processor interface {
 	Run(event common.MapStr) (common.MapStr, error)

--- a/metricbeat/module/plugin.go
+++ b/metricbeat/module/plugin.go
@@ -1,0 +1,55 @@
+package module
+
+import (
+	"errors"
+
+	"github.com/elastic/beats/libbeat/plugin"
+
+	"github.com/elastic/beats/metricbeat/mb"
+)
+
+type modulePlugin struct {
+	name       string
+	factory    mb.ModuleFactory
+	metricsets map[string]mb.MetricSetFactory
+}
+
+const pluginKey = "metricbeat.module"
+
+func init() {
+	plugin.MustRegisterLoader(pluginKey, func(ifc interface{}) error {
+		p, ok := ifc.(modulePlugin)
+		if !ok {
+			return errors.New("plugin does not match metricbeat module plugin type")
+		}
+
+		if p.factory != nil {
+			if err := mb.Registry.AddModule(p.name, p.factory); err != nil {
+				return err
+			}
+		}
+
+		for name, factory := range p.metricsets {
+			if err := mb.Registry.AddMetricSet(p.name, name, factory); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+}
+
+func Plugin(
+	module string,
+	factory mb.ModuleFactory,
+	metricsets map[string]mb.MetricSetFactory,
+) map[string][]interface{} {
+	return plugin.MakePlugin(pluginKey, modulePlugin{module, factory, metricsets})
+}
+
+func MetricSetsPlugin(
+	module string,
+	metricsets map[string]mb.MetricSetFactory,
+) map[string][]interface{} {
+	return Plugin(module, nil, metricsets)
+}

--- a/packetbeat/protocols/plugin.go
+++ b/packetbeat/protocols/plugin.go
@@ -1,0 +1,31 @@
+package protocols
+
+import (
+	"errors"
+
+	"github.com/elastic/beats/libbeat/plugin"
+	"github.com/elastic/beats/packetbeat/protos"
+)
+
+type protocolPlugin struct {
+	name string
+	p    protos.ProtocolPlugin
+}
+
+const pluginKey = "packetbeat.protocol"
+
+func init() {
+	plugin.MustRegisterLoader(pluginKey, func(ifc interface{}) error {
+		p, ok := ifc.(protocolPlugin)
+		if !ok {
+			return errors.New("plugin does not match protocol plugin type")
+		}
+
+		protos.Register(p.name, p.p)
+		return nil
+	})
+}
+
+func Plugin(name string, p protos.ProtocolPlugin) map[string][]interface{} {
+	return plugin.MakePlugin(pluginKey, protocolPlugin{name, p})
+}


### PR DESCRIPTION
This PR introduces support for loadable plugins to beats. Requires linux, go1.8 beta2+, cgo. If any is missing, the API is still valid, but plugin loading is disabled (CLI flag is missing as well).

Shared libraries export a bundle of plugins in global `Bundle` variable of type `map[string][]interface{}`. The `string` key is the plugin module type, individual plugins are loadable for.

Beats modules supporting plugin support have to register a module type before startup via `plugin.RegisterLoader`. In addition modules must provide a `Plugin` function for building a valid type-correct bundle with correct module type key. See `outputs.Plugin` and `processors.Plugin` as example.
Alternatively a solution with `Bundle` of type `[]interface{}` or `interface{}` might be possible too (no potential naming collisions). Loading can use reflection and/or type switches. This might work, by passing all loadable plugins to all module loaders. With public API as is, this implementation detail can be easily applied later without enforcing any changes on plugin writers.

Every plugin is a valid bundle itself. Use `plugin.Bundle` to flatten and combine multiple bundles/plugins into one bundle.

Bundles can be loaded from command line only. Use `-plugin <path>` to load a plugin.

Versioning: the plugin loader does no explicit version checks. A possible solution is to have `plugin.Bundle` include a version and be strict (e.g. on major version). On the other hand, the compiler already hashes all packages. The runtime already ensures no plugin with failing hash-check can be used.

thisnPR adds plugin support for:
- libbout outputs
- libbeat processors
- packetbeat protocol analyzers
- heartbeat monitors
- metricbeat modules