### PR TITLE
Make it possible to disable integration tests for system tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ env:
     - TARGETS="-C heartbeat testsuite"
     - TARGETS="-C libbeat testsuite"
     - TARGETS="-C metricbeat testsuite"
+    - TARGETS="TEST_ENVIRONMENT=0 -C metricbeat testsuite"
     - TARGETS="-C packetbeat testsuite"
     - TARGETS="-C libbeat crosscompile"
     - TARGETS="-C metricbeat crosscompile"
@@ -52,6 +53,8 @@ matrix:
       env: TARGETS="-C hearbeat testsuite"
     - os: osx
       env: TARGETS="-C metricbeat testsuite"
+    - os: linux
+      env: TARGETS="TEST_ENVIRONMENT=0 -C metricbeat testsuite"
     - os: osx
       env: TARGETS="-C libbeat/dashboards"
     - os: osx

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -53,7 +53,7 @@ GOPACKAGES_COMMA_SEP=$(subst $(space),$(comma),$(strip ${GOPACKAGES}))
 PYTHON_ENV?=${BUILD_DIR}/python-env
 BUILDID?=$(shell git rev-parse HEAD)
 VIRTUALENV_PARAMS?=
-
+INTEGRATION_TESTS?=
 CGO?=false
 
 # Cross compiling targets
@@ -157,13 +157,13 @@ integration-tests-environment: prepare-tests build-image
 # Runs the system tests
 .PHONY: system-tests
 system-tests: ${BEATNAME}.test prepare-tests python-env
-	. ${PYTHON_ENV}/bin/activate; INTEGRATION_TESTS=1 nosetests -w tests/system --process-timeout=$(TIMEOUT) --with-timer
+	. ${PYTHON_ENV}/bin/activate; INTEGRATION_TESTS=${INTEGRATION_TESTS} nosetests -w tests/system --process-timeout=$(TIMEOUT) --with-timer
 	python ${ES_BEATS}/dev-tools/aggregate_coverage.py -o ${COVERAGE_DIR}/system.cov ./build/system-tests/run
 
 # Runs the system tests
 .PHONY: system-tests-environment
 system-tests-environment: prepare-tests build-image
-	${DOCKER_COMPOSE} run beat make system-tests
+	INTEGRATION_TESTS=1 ${DOCKER_COMPOSE} run beat  make system-tests
 
 # Runs system tests without coverage reports and in parallel
 .PHONY: fast-system-tests
@@ -205,17 +205,16 @@ testsuite: clean collect
 	$(MAKE) unit-tests
 
 	# Setups environment if TEST_ENVIRONMENT is set to true
+	# Only runs integration tests with test environemtn
 	if [ $(TEST_ENVIRONMENT) = true ]; then \
 		 $(MAKE) integration-tests-environment; \
-	else \
-		$(MAKE) integration-tests; \
 	fi
 
-	# Runs system tests if SYSTEM_TESTS is set to true
+	# Runs system and system integration tests if SYSTEM_TESTS is set to true
 	if [ $(SYSTEM_TESTS) = true ]; then \
 		if [ $(TEST_ENVIRONMENT) = true ]; then \
-			$(MAKE) system-tests-environment; \
-		else \
+        	$(MAKE) system-tests-environment; \
+    	else \
 			$(MAKE) system-tests; \
 		fi \
 	fi


### PR DESCRIPTION
The logic of testing has changed as following:

* Integration tests are only run if test environment is enabled
* For system tests, either all tests are run inside the test environment or a subset is run without the test environment

This makes it possible to run on linux with docker all integration tests and on other systems only a subset. By default when running tests, like `make system-test` no environment is required.