### PR TITLE
Fix environment variable passing to system environment tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ BUILD_DIR=build
 COVERAGE_DIR=${BUILD_DIR}/coverage
 BEATS=packetbeat filebeat winlogbeat metricbeat heartbeat
 PROJECTS=libbeat ${BEATS}
-PROJECTS_ENV=libbeat metricbeat
+PROJECTS_ENV=libbeat filebeat metricbeat
 SNAPSHOT?=yes
 
 # Runs complete testsuites (unit, system, integration) for all beats with coverage and race detection.

--- a/filebeat/docker-compose.yml
+++ b/filebeat/docker-compose.yml
@@ -9,3 +9,10 @@ services:
       - ${PWD}/..:/go/src/github.com/elastic/beats/
     command: make
     entrypoint: /go/src/github.com/elastic/beats/filebeat/docker-entrypoint.sh
+
+  # Overload Kibana and Logstash as not needed here
+  kibana:
+    image: alpine:latest
+
+  logstash:
+    image: alpine:latest

--- a/filebeat/tests/system/test_modules.py
+++ b/filebeat/tests/system/test_modules.py
@@ -73,6 +73,9 @@ class Test(BaseTest):
                          stderr=subprocess.STDOUT,
                          bufsize=0).wait()
 
+        # Make sure index exists
+        self.wait_until(lambda: self.es.indices.exists(index_name))
+
         self.es.indices.refresh(index=index_name)
         res = self.es.search(index=index_name,
                              body={"query": {"match_all": {}}})

--- a/filebeat/tests/system/test_registrar.py
+++ b/filebeat/tests/system/test_registrar.py
@@ -790,12 +790,12 @@ class Test(BaseTest):
         # Wait until states are removed from prospectors
         self.wait_until(
             lambda: self.log_contains_count(
-                "State removed for") == 4,
+                "State removed for") >= 3,
             max_timeout=15)
 
         filebeat.check_kill_and_wait()
 
-        # Check that the first to files were removed from the registry
+        # Check that the first two files were removed from the registry
         data = self.get_registry()
         assert len(data) == 1
 

--- a/libbeat/dashboards/Makefile
+++ b/libbeat/dashboards/Makefile
@@ -1,5 +1,5 @@
 
 BEAT?=
 
-import_dasboards: import_dashboards.go
+import_dashboards:
 	go build -ldflags "-X main.beat=${BEAT}" -o import_dashboards

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -165,7 +165,7 @@ system-tests: ${BEATNAME}.test prepare-tests python-env ${ES_BEATS}/libbeat/dash
 # Runs the system tests
 .PHONY: system-tests-environment
 system-tests-environment: prepare-tests build-image
-	INTEGRATION_TESTS=1 ${DOCKER_COMPOSE} run beat  make system-tests
+	${DOCKER_COMPOSE} run -e INTEGRATION_TESTS=1 beat make system-tests
 
 # Runs system tests without coverage reports and in parallel
 .PHONY: fast-system-tests
@@ -291,7 +291,7 @@ export-dashboards: python-env update
 	. ${PYTHON_ENV}/bin/activate && python ${ES_BEATS}/dev-tools/export_dashboards.py --url ${ES_URL} --dir $(shell pwd)/_meta/kibana --regex ${BEATNAME}-*
 
 ${ES_BEATS}/libbeat/dashboards/import_dashboards:
-	$(MAKE) -C ${ES_BEATS}/libbeat/dashboards import_dasboards
+	$(MAKE) -C ${ES_BEATS}/libbeat/dashboards import_dashboards
 
 .PHONY: import-dashboards
 import-dashboards: update ${ES_BEATS}/libbeat/dashboards/import_dashboards


### PR DESCRIPTION
Currently system tests with environment were still skipped.

* Fix flaky filebeat tests
* Fix flaky module tests
* Always rebuild dashboards. Reason is that during tests it is possible that it was previously built for a different architecture.