### PR TITLE
Add golang version to version.asciidoc for jenkins

### DIFF
--- a/filebeat/docs/version.asciidoc
+++ b/filebeat/docs/version.asciidoc
@@ -1,2 +1,3 @@
 :stack-version: 5.1.1
 :doc-branch: 5.1
+:go-version: 1.7.1

--- a/heartbeat/docs/version.asciidoc
+++ b/heartbeat/docs/version.asciidoc
@@ -1,2 +1,3 @@
 :stack-version: 5.1.1
 :doc-branch: 5.1
+:go-version: 1.7.1

--- a/libbeat/docs/version.asciidoc
+++ b/libbeat/docs/version.asciidoc
@@ -1,2 +1,3 @@
 :stack-version: 5.1.1
 :doc-branch: 5.1
+:go-version: 1.7.1

--- a/metricbeat/docs/version.asciidoc
+++ b/metricbeat/docs/version.asciidoc
@@ -1,2 +1,3 @@
 :stack-version: 5.1.1
 :doc-branch: 5.1
+:go-version: 1.7.1

--- a/packetbeat/docs/version.asciidoc
+++ b/packetbeat/docs/version.asciidoc
@@ -1,2 +1,3 @@
 :stack-version: 5.1.1
 :doc-branch: 5.1
+:go-version: 1.7.1

--- a/testing/environments/docker/kibana/Dockerfile-snapshot
+++ b/testing/environments/docker/kibana/Dockerfile-snapshot
@@ -2,7 +2,7 @@
 FROM docker.elastic.co/kibana/kibana-ubuntu-base:latest
 MAINTAINER Elastic Docker Team <docker@elastic.co>
 
-ARG KIBANA_DOWNLOAD_URL=https://staging.elastic.co/5.1.1-719df589/downloads/kibana/kibana-5.1.0-linux-x86_64.tar.gz
+ARG KIBANA_DOWNLOAD_URL=https://artifacts.elastic.co/downloads/kibana/kibana-5.1.1-linux-x86_64.tar.gz
 ARG X_PACK_URL
 
 EXPOSE 5601

--- a/testing/environments/docker/logstash/Dockerfile-snapshot
+++ b/testing/environments/docker/logstash/Dockerfile-snapshot
@@ -3,7 +3,7 @@ FROM java:8-jre
 ENV LS_VERSION 5
 
 ENV VERSION 5.1.1
-ENV URL https://staging.elastic.co/5.1.1-719df589/downloads/logstash/logstash-${VERSION}.tar.gz
+ENV URL https://artifacts.elastic.co/downloads/logstash/logstash-${VERSION}.tar.gz
 ENV PATH $PATH:/opt/logstash-$VERSION/bin
 
 # Cache variable can be set during building to invalidate the build cache with `--build-arg CACHE=$(date +%s) .`

--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -8,7 +8,7 @@ services:
       dockerfile: Dockerfile-snapshot
       args:
         ELASTIC_VERSION: 5.1.1
-        ES_DOWNLOAD_URL: 'https://staging.elastic.co/5.1.1-719df589/downloads/elasticsearch'
+        ES_DOWNLOAD_URL: 'https://artifacts.elastic.co/downloads/elasticsearch'
         #XPACK: http://snapshots.elastic.co/downloads/packs/x-pack/x-pack-6.0.0-alpha1-SNAPSHOT.zip
     environment:
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"

--- a/winlogbeat/docs/version.asciidoc
+++ b/winlogbeat/docs/version.asciidoc
@@ -1,2 +1,3 @@
 :stack-version: 5.1.1
 :doc-branch: 5.1
+:go-version: 1.7.1


### PR DESCRIPTION
This is required to keep the 5.1 branch compatible with the jenkins setup.