### PR TITLE
Add query count to metricbeat's mysql plugin output

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -126,6 +126,7 @@ https://github.com/elastic/beats/compare/v5.0.2...v5.1.1[View commits]
 - Add support for MongoDB 3.4 and WiredTiger metrics. {pull}2999[2999]
 - Add experimental kafka module with partition metricset. {pull}2969[2969]
 - Add raw config option for mysql/status metricset. {pull}3001[3001]
+- Add command fileds for mysql/status metricset. {pull}3251[3251]
 
 *Filebeat*
 

--- a/metricbeat/docs/fields.asciidoc
+++ b/metricbeat/docs/fields.asciidoc
@@ -3464,34 +3464,34 @@ type: long
 
 
 [float]
-== com Fields
+== command Fields
 
 
 
 
 [float]
-=== mysql.status.com.delete
+=== mysql.status.command.delete
 
 type: long
 
 
 
 [float]
-=== mysql.status.com.insert
+=== mysql.status.command.insert
 
 type: long
 
 
 
 [float]
-=== mysql.status.com.select
+=== mysql.status.command.select
 
 type: long
 
 
 
 [float]
-=== mysql.status.com.update
+=== mysql.status.command.update
 
 type: long
 

--- a/metricbeat/docs/fields.asciidoc
+++ b/metricbeat/docs/fields.asciidoc
@@ -3463,6 +3463,40 @@ type: long
 
 
 
+[float]
+== com Fields
+
+
+
+
+[float]
+=== mysql.status.com.delete
+
+type: long
+
+
+
+[float]
+=== mysql.status.com.insert
+
+type: long
+
+
+
+[float]
+=== mysql.status.com.select
+
+type: long
+
+
+
+[float]
+=== mysql.status.com.update
+
+type: long
+
+
+
 [[exported-fields-nginx]]
 == Nginx Fields
 

--- a/metricbeat/metricbeat.template-es2x.json
+++ b/metricbeat/metricbeat.template-es2x.json
@@ -1885,7 +1885,7 @@
                     }
                   }
                 },
-                "com": {
+                "command": {
                   "properties": {
                     "delete": {
                       "type": "long"

--- a/metricbeat/metricbeat.template-es2x.json
+++ b/metricbeat/metricbeat.template-es2x.json
@@ -1885,6 +1885,22 @@
                     }
                   }
                 },
+                "com": {
+                  "properties": {
+                    "delete": {
+                      "type": "long"
+                    },
+                    "insert": {
+                      "type": "long"
+                    },
+                    "select": {
+                      "type": "long"
+                    },
+                    "update": {
+                      "type": "long"
+                    }
+                  }
+                },
                 "connections": {
                   "type": "long"
                 },

--- a/metricbeat/metricbeat.template.json
+++ b/metricbeat/metricbeat.template.json
@@ -1878,7 +1878,7 @@
                     }
                   }
                 },
-                "com": {
+                "command": {
                   "properties": {
                     "delete": {
                       "type": "long"

--- a/metricbeat/metricbeat.template.json
+++ b/metricbeat/metricbeat.template.json
@@ -1878,6 +1878,22 @@
                     }
                   }
                 },
+                "com": {
+                  "properties": {
+                    "delete": {
+                      "type": "long"
+                    },
+                    "insert": {
+                      "type": "long"
+                    },
+                    "select": {
+                      "type": "long"
+                    },
+                    "update": {
+                      "type": "long"
+                    }
+                  }
+                },
                 "connections": {
                   "type": "long"
                 },

--- a/metricbeat/module/mysql/status/_meta/data.json
+++ b/metricbeat/module/mysql/status/_meta/data.json
@@ -26,6 +26,12 @@
                 "received": 992,
                 "sent": 40657
             },
+            "com": {
+              "delete": 0,
+              "insert": 0,
+              "select": 9,
+              "update": 0
+            },
             "connections": 11,
             "created": {
                 "tmp": {

--- a/metricbeat/module/mysql/status/_meta/data.json
+++ b/metricbeat/module/mysql/status/_meta/data.json
@@ -26,7 +26,7 @@
                 "received": 992,
                 "sent": 40657
             },
-            "com": {
+            "command": {
               "delete": 0,
               "insert": 0,
               "select": 9,

--- a/metricbeat/module/mysql/status/_meta/fields.yml
+++ b/metricbeat/module/mysql/status/_meta/fields.yml
@@ -135,3 +135,23 @@
     - name: opened_tables
       type: long
       description: >
+
+    - name: com
+      type: group
+      description: >
+      fields:
+        - name: delete
+          type: long
+          description: >
+
+        - name: insert
+          type: long
+          description: >
+
+        - name: select
+          type: long
+          description: >
+
+        - name: update
+          type: long
+          description: >

--- a/metricbeat/module/mysql/status/_meta/fields.yml
+++ b/metricbeat/module/mysql/status/_meta/fields.yml
@@ -136,7 +136,7 @@
       type: long
       description: >
 
-    - name: com
+    - name: command
       type: group
       description: >
       fields:

--- a/metricbeat/module/mysql/status/data.go
+++ b/metricbeat/module/mysql/status/data.go
@@ -49,7 +49,7 @@ var (
 			"tables":  c.Int("Open_tables"),
 		},
 		"opened_tables": c.Int("Opened_tables"),
-		"com": s.Object{
+		"command": s.Object{
 			"delete": c.Int("Com_delete"),
 			"insert": c.Int("Com_insert"),
 			"select": c.Int("Com_select"),

--- a/metricbeat/module/mysql/status/data.go
+++ b/metricbeat/module/mysql/status/data.go
@@ -54,7 +54,7 @@ var (
 			"insert": c.Int("Com_insert"),
 			"select": c.Int("Com_select"),
 			"update": c.Int("Com_update"),
-		}
+		},
 	}
 )
 

--- a/metricbeat/module/mysql/status/data.go
+++ b/metricbeat/module/mysql/status/data.go
@@ -49,6 +49,12 @@ var (
 			"tables":  c.Int("Open_tables"),
 		},
 		"opened_tables": c.Int("Opened_tables"),
+		"com": s.Object{
+			"delete": c.Int("Com_delete"),
+			"insert": c.Int("Com_insert"),
+			"select": c.Int("Com_select"),
+			"update": c.Int("Com_update"),
+		}
 	}
 )
 


### PR DESCRIPTION
Hello everyone.
Fix to issue the number of Query when using metricbeat 's MySQL module.
Since Com_select and Com_insert etc. are integrated values, we can not grasp the number of queries per second or every minute.
I was wondering whether this difference value should be implemented with metricbeat.
However, since the time interval you want to display is different, I'd like to adjust on the timelion side.