### PR TITLE
fix libbeat conversion panic

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -33,6 +33,7 @@ https://github.com/elastic/beats/compare/v5.1.1...master[Check the HEAD diff]
 
 - Fix service times-out at startup. {pull}3056[3056]
 - Kafka module case sensitive host name matching. {pull}3193[3193]
+- Fix interface conversion panic in couchbase module {pull}3272[3272]
 
 *Packetbeat*
 

--- a/metricbeat/module/couchbase/node/data.go
+++ b/metricbeat/module/couchbase/node/data.go
@@ -10,7 +10,7 @@ import (
 )
 
 type NodeSystemStats struct {
-	CPUUtilizationRate float32 `json:"cpu_utilization_rate"`
+	CPUUtilizationRate float64 `json:"cpu_utilization_rate"`
 	SwapTotal          int64   `json:"swap_total"`
 	SwapUsed           int64   `json:"swap_used"`
 	MemTotal           int64   `json:"mem_total"`


### PR DESCRIPTION
on 64_86 systems there is a interface conversion panic where a float64 is expected.