### PR TITLE
Add special fields in the index pattern

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -29,6 +29,8 @@ https://github.com/elastic/beats/compare/v5.1.1...master[Check the HEAD diff]
 
 *Affecting all Beats*
 
+- Add `_id`, `_type`, `_index` and `_score` fields in the generated index pattern. {pull}3282}[3282]
+
 *Metricbeat*
 
 - Fix service times-out at startup. {pull}3056[3056]

--- a/libbeat/scripts/generate_index_pattern.py
+++ b/libbeat/scripts/generate_index_pattern.py
@@ -16,6 +16,7 @@ import sys
 
 unique_fields = []
 
+
 def fields_to_json(section, path, output):
 
     for field in section["fields"]:
@@ -91,6 +92,18 @@ def fields_to_index_pattern(args, input):
 
     for k, section in enumerate(docs["fields"]):
         fields_to_json(section, "", output)
+
+    # add special fields
+    special_fields = {
+        "fields": [
+            {"name": "_index", "type": "text"},
+            {"name": "_id", "type": "text"},
+            {"name": "_type", "type": "text"},
+            {"name": "_score", "type": "integer"}
+        ],
+    }
+
+    fields_to_json(special_fields, "", output)
 
     output["fields"] = json.dumps(output["fields"])
     output["fieldFormatMap"] = json.dumps(output["fieldFormatMap"])


### PR DESCRIPTION
Trying to fix https://github.com/elastic/beats/issues/3261 by adding `_id`, `_type`, `_index` and `_score` fields to the generated index pattern.