### PR TITLE
Fixed BEAT_PATH issue when packaging metricbeat based community beats

### DIFF
--- a/dev-tools/packer/docker/xgo-image/base/build.sh
+++ b/dev-tools/packer/docker/xgo-image/base/build.sh
@@ -21,7 +21,8 @@
 # Download the canonical import path (may fail, don't allow failures beyond)
 SRC_FOLDER=$SOURCE
 
-BEAT_PATH=$1
+BEAT_NAME=$PACK
+BEAT_PATH=$1/$BEAT_NAME
 DST_FOLDER=`dirname $GOPATH/src/$BEAT_PATH`
 GIT_REPO=$BEAT_PATH
 


### PR DESCRIPTION
see issue #3294 for details.

Fixes issue when packaging metricbeat based community beats. BEAT_PATH was not properly set in build.sh and before_build.sh failed.

BEAT_PATH is now set to BEAT_DIR/BEAT_NAME instead of BEAT_DIR in build.sh

Only tested with metricbased community beats.

Fixes issue #3294