### PR TITLE
Remove kibana overloading as not needed anymore

### DIFF
--- a/metricbeat/docker-compose.yml
+++ b/metricbeat/docker-compose.yml
@@ -49,10 +49,6 @@ services:
     command: make
     entrypoint: /go/src/github.com/elastic/beats/metricbeat/docker-entrypoint.sh
 
-  # Overloading kibana with a simple image as it is not needed here
-  kibana:
-    image: alpine:latest
-
   # Modules
   apache:
     build: ${PWD}/module/apache/_meta


### PR DESCRIPTION
With the new compose structure, overloading of kibana image is not needed anymore as dependencies are created explicitly.