### PR TITLE
Support to debug print configuration files

### DIFF
--- a/libbeat/beat/beat.go
+++ b/libbeat/beat/beat.go
@@ -228,9 +228,13 @@ func (b *Beat) handleFlags() error {
 		return GracefulExit
 	}
 
+	if err := logp.HandleFlags(b.Name); err != nil {
+		return err
+	}
 	if err := cfgfile.HandleFlags(); err != nil {
 		return err
 	}
+
 	return handleFlags(b)
 }
 

--- a/libbeat/cfgfile/cfgfile.go
+++ b/libbeat/cfgfile/cfgfile.go
@@ -74,6 +74,11 @@ func HandleFlags() error {
 	}
 
 	defaults.SetString("path.home", -1, home)
+
+	if len(overwrites.GetFields()) > 0 {
+		overwrites.PrintDebugf("CLI setting overwrites (-E flag):")
+	}
+
 	return nil
 }
 
@@ -120,11 +125,17 @@ func Load(path string) (*common.Config, error) {
 		return nil, err
 	}
 
-	return common.MergeConfigs(
+	config, err = common.MergeConfigs(
 		defaults,
 		config,
 		overwrites,
 	)
+	if err != nil {
+		return nil, err
+	}
+
+	config.PrintDebugf("Complete configuration loaded:")
+	return config, nil
 }
 
 // GetPathConfig returns ${path.config}. If ${path.config} is not set, ${path.home} is returned.

--- a/libbeat/common/config_test.go
+++ b/libbeat/common/config_test.go
@@ -1,0 +1,112 @@
+package common
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfigPrintDebug(t *testing.T) {
+	tests := []struct {
+		name      string
+		selectors string
+		config    map[string]interface{}
+		expected  string
+	}{
+		{
+			"No selector -> no output",
+			"",
+			map[string]interface{}{"name": "test"},
+			"",
+		},
+		{
+			"config selector redacts password in nested config",
+			"config",
+			map[string]interface{}{
+				"config": map[string]interface{}{
+					"password": "secret",
+				},
+			},
+			`test:
+{
+  "config": {
+    "password": "xxxxx"
+  }
+}
+`,
+		},
+		{
+			"config selector redacts password in nested array",
+			"config",
+			map[string]interface{}{
+				"arr": []interface{}{
+					map[string]interface{}{
+						"password": "secret",
+					},
+				},
+			},
+			`test:
+{
+  "arr": [
+    {
+      "password": "xxxxx"
+    }
+  ]
+}
+`,
+		},
+		{
+			"config-with-passwords does not redact",
+			"config-with-passwords",
+			map[string]interface{}{
+				"config": map[string]interface{}{
+					"password": "secret",
+				},
+			},
+			`test:
+{
+  "config": {
+    "password": "secret"
+  }
+}
+`,
+		},
+	}
+
+	origSelector := hasSelector
+	origDebugf := configDebugf
+	defer func() {
+		hasSelector = origSelector
+		configDebugf = origDebugf
+	}()
+
+	var buf string
+	configDebugf = func(selector, msg string, extra ...interface{}) {
+		if hasSelector(selector) {
+			buf = buf + fmt.Sprintf(msg, extra...) + "\n"
+		}
+	}
+
+	for i, test := range tests {
+		t.Logf("run test (%v): %v", i, test.name)
+
+		// reset selector and output buffer
+		selectors := MakeStringSet(strings.Split(test.selectors, ",")...)
+		buf = ""
+		hasSelector = selectors.Has
+
+		// create config
+		cfg, err := NewConfigFrom(test.config)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// create debug output
+		cfg.PrintDebugf("test:")
+
+		// validate debug output
+		assert.Equal(t, test.expected, buf)
+	}
+}

--- a/libbeat/common/stringset.go
+++ b/libbeat/common/stringset.go
@@ -1,0 +1,34 @@
+package common
+
+type StringSet map[string]struct{}
+
+func MakeStringSet(strings ...string) StringSet {
+	if len(strings) == 0 {
+		return nil
+	}
+
+	set := StringSet{}
+	for _, str := range strings {
+		set[str] = struct{}{}
+	}
+	return set
+}
+
+func (set StringSet) Add(s string) {
+	set[s] = struct{}{}
+}
+
+func (set StringSet) Del(s string) {
+	delete(set, s)
+}
+
+func (set StringSet) Count() int {
+	return len(set)
+}
+
+func (set StringSet) Has(s string) (exists bool) {
+	if set != nil {
+		_, exists = set[s]
+	}
+	return
+}

--- a/libbeat/logp/log.go
+++ b/libbeat/logp/log.go
@@ -28,7 +28,7 @@ type Logger struct {
 	toStderr          bool
 	toFile            bool
 	level             Priority
-	selectors         map[string]bool
+	selectors         map[string]struct{}
 	debugAllSelectors bool
 
 	logger  *log.Logger
@@ -36,17 +36,43 @@ type Logger struct {
 	rotator *FileRotator
 }
 
-var _log Logger
+// pre-init logger to debug mode + stderr before init
+
+const stderrLogFlags = log.Ldate | log.Ltime | log.Lmicroseconds | log.LUTC | log.Lshortfile
+
+var _log = Logger{}
+
+// TODO: remove toSyslog and toStderr from the init function
+func LogInit(level Priority, prefix string, toSyslog bool, toStderr bool, debugSelectors []string) {
+	_log.toSyslog = toSyslog
+	_log.toStderr = toStderr
+	_log.level = level
+
+	_log.selectors, _log.debugAllSelectors = parseSelectors(debugSelectors)
+
+	if _log.toSyslog {
+		SetToSyslog(true, prefix)
+	}
+
+	if _log.toStderr {
+		SetToStderr(true, prefix)
+	}
+}
+
+func parseSelectors(selectors []string) (map[string]struct{}, bool) {
+	all := false
+	set := map[string]struct{}{}
+	for _, selector := range selectors {
+		set[selector] = struct{}{}
+		if selector == "*" {
+			all = true
+		}
+	}
+	return set, all
+}
 
 func debugMessage(calldepth int, selector, format string, v ...interface{}) {
-	if _log.level >= LOG_DEBUG {
-		if !_log.debugAllSelectors {
-			selected := _log.selectors[selector]
-			if !selected {
-				return
-			}
-		}
-
+	if _log.level >= LOG_DEBUG && IsDebug(selector) {
 		send(calldepth+1, LOG_DEBUG, "DBG  ", format, v...)
 	}
 }
@@ -76,7 +102,12 @@ func MakeDebug(selector string) func(string, ...interface{}) {
 }
 
 func IsDebug(selector string) bool {
-	return _log.debugAllSelectors || _log.selectors[selector]
+	return _log.debugAllSelectors || HasSelector(selector)
+}
+
+func HasSelector(selector string) bool {
+	_, selected := _log.selectors[selector]
+	return selected
 }
 
 func msg(level Priority, prefix string, format string, v ...interface{}) {
@@ -115,35 +146,11 @@ func Recover(msg string) {
 	}
 }
 
-// TODO: remove toSyslog and toStderr from the init function
-func LogInit(level Priority, prefix string, toSyslog bool, toStderr bool, debugSelectors []string) {
-	_log.toSyslog = toSyslog
-	_log.toStderr = toStderr
-	_log.level = level
-
-	_log.selectors = make(map[string]bool)
-	for _, selector := range debugSelectors {
-		_log.selectors[selector] = true
-		if selector == "*" {
-			_log.debugAllSelectors = true
-		}
-	}
-
-	if _log.toSyslog {
-		SetToSyslog(true, prefix)
-	}
-
-	if _log.toStderr {
-		SetToStderr(true, prefix)
-	}
-}
-
 func SetToStderr(toStderr bool, prefix string) {
 	_log.toStderr = toStderr
 	if _log.toStderr {
 		// Add timestamp
-		flag := log.Ldate | log.Ltime | log.Lmicroseconds | log.LUTC | log.Lshortfile
-		_log.logger = log.New(os.Stderr, prefix, flag)
+		_log.logger = log.New(os.Stderr, prefix, stderrLogFlags)
 	}
 }
 

--- a/libbeat/outputs/outputs.go
+++ b/libbeat/outputs/outputs.go
@@ -91,6 +91,8 @@ func InitOutputs(
 		if !exists {
 			continue
 		}
+
+		config.PrintDebugf("Configure output plugin '%v' with:", name)
 		if !config.Enabled() {
 			continue
 		}

--- a/libbeat/processors/processor.go
+++ b/libbeat/processors/processor.go
@@ -30,6 +30,7 @@ func New(config PluginConfig) (*Processors, error) {
 				return nil, fmt.Errorf("the processor %s doesn't exist", processorName)
 			}
 
+			cfg.PrintDebugf("Configure processor '%v' with:", processorName)
 			constructor := gen.Plugin()
 			plugin, err := constructor(cfg)
 			if err != nil {


### PR DESCRIPTION
This PR adds support for printing loaded configurations as debug message. The config is JSON encoded before printing.

This is helpful in debugging configuration issues, as the JSON can be directly copied and tested locally + indentation errors become more visible.

Changes:
- apply CLI logging flags before loading config file + configure stderr
- add (common.*Config).DebugString to create formatted string from config
  object
- print config after loading
- print used sub-config when loading output plugins and configuring
  processors

