### PR TITLE
Skip the modules test on the 2.x environment

### DIFF
--- a/filebeat/tests/system/test_modules.py
+++ b/filebeat/tests/system/test_modules.py
@@ -23,7 +23,9 @@ class Test(BaseTest):
         self.filebeat = os.path.abspath(self.working_dir +
                                         "/../../../../filebeat.py")
 
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
+    @unittest.skipIf(not INTEGRATION_TESTS or
+                     os.getenv("TESTING_ENVIRONMENT") == "2x",
+                     "integration test not available on 2.x")
     def test_modules(self):
         self.init()
         modules = os.getenv("TESTING_FILEBEAT_MODULES")

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -152,14 +152,14 @@ integration-tests-environment: prepare-tests build-image
 .PHONY: system-tests
 system-tests: ## @testing Runs the system tests
 system-tests: ${BEATNAME}.test prepare-tests python-env ${ES_BEATS}/libbeat/dashboards/import_dashboards
-	. ${PYTHON_ENV}/bin/activate; INTEGRATION_TESTS=${INTEGRATION_TESTS} nosetests -w tests/system ${NOSETESTS_OPTIONS}
+	. ${PYTHON_ENV}/bin/activate; INTEGRATION_TESTS=${INTEGRATION_TESTS} TESTING_ENVIRONMENT=${TESTING_ENVIRONMENT} nosetests -w tests/system ${NOSETESTS_OPTIONS}
 	python ${ES_BEATS}/dev-tools/aggregate_coverage.py -o ${COVERAGE_DIR}/system.cov ./build/system-tests/run
 
 # Runs the system tests
 .PHONY: system-tests-environment
 system-tests-environment:  ## @testing Runs the system tests inside a virtual environment. This can be run on any docker-machine (local, remote)
 system-tests-environment: prepare-tests build-image
-	${DOCKER_COMPOSE} run -e INTEGRATION_TESTS=1 beat make system-tests
+	${DOCKER_COMPOSE} run -e INTEGRATION_TESTS=1 -e TESTING_ENVIRONMENT=${TESTING_ENVIRONMENT} beat make system-tests
 
 
 .PHONY: fast-system-tests


### PR DESCRIPTION
ES 2.x doesn't have Ingest Node, so there's no chance to work. In the
non-prototype phase, we should find a way to detect this situation and
inform the user properly.