### PR TITLE
Fix typo in regexp

### DIFF
--- a/libbeat/docs/processors-config.asciidoc
+++ b/libbeat/docs/processors-config.asciidoc
@@ -114,7 +114,7 @@ For example, the following condition checks if the process name starts with
 
 [source,yaml]
 -----
-reqexp:
+regexp:
   system.process.name: "foo.*"
 -----
 


### PR DESCRIPTION
Should be `regexp` and not `reqexp`