### PR TITLE
Add description to the mysql.status.command fields.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -134,7 +134,7 @@ https://github.com/elastic/beats/compare/v5.0.2...v5.1.1[View commits]
 - Add support for MongoDB 3.4 and WiredTiger metrics. {pull}2999[2999]
 - Add experimental kafka module with partition metricset. {pull}2969[2969]
 - Add raw config option for mysql/status metricset. {pull}3001[3001]
-- Add command fileds for mysql/status metricset. {pull}3251[3251]
+- Add command fields for mysql/status metricset. {pull}3251[3251]
 
 *Filebeat*
 

--- a/metricbeat/docs/fields.asciidoc
+++ b/metricbeat/docs/fields.asciidoc
@@ -3575,6 +3575,7 @@ type: long
 
 type: long
 
+The number of DELETE queries since startup.
 
 
 [float]
@@ -3582,6 +3583,7 @@ type: long
 
 type: long
 
+The number of INSERT queries since startup.
 
 
 [float]
@@ -3589,6 +3591,7 @@ type: long
 
 type: long
 
+The number of SELECT queries since startup.
 
 
 [float]
@@ -3596,6 +3599,7 @@ type: long
 
 type: long
 
+The number of UPDATE queries since startup.
 
 
 [[exported-fields-nginx]]

--- a/metricbeat/module/mysql/status/_meta/fields.yml
+++ b/metricbeat/module/mysql/status/_meta/fields.yml
@@ -143,15 +143,19 @@
         - name: delete
           type: long
           description: >
+            The number of DELETE queries since startup.
 
         - name: insert
           type: long
           description: >
+            The number of INSERT queries since startup.
 
         - name: select
           type: long
           description: >
+            The number of SELECT queries since startup.
 
         - name: update
           type: long
           description: >
+            The number of UPDATE queries since startup.


### PR DESCRIPTION
Add description for the `mysql.status.command` fields in the documentations. 

This PR completes https://github.com/elastic/beats/pull/3251