### PR TITLE
Fix crosscompile flags for Filebeat and Metricbeat

### DIFF
--- a/filebeat/Makefile
+++ b/filebeat/Makefile
@@ -4,7 +4,7 @@ BEATNAME?=filebeat
 BEAT_DESCRIPTION?=Filebeat sends log files to Logstash or directly to Elasticsearch.
 SYSTEM_TESTS=true
 TEST_ENVIRONMENT?=true
-GOX_FLAGS='-arch=amd64 386 arm ppc64 ppc64le'
+GOX_FLAGS=-arch="amd64 386 arm ppc64 ppc64le"
 
 include ../libbeat/scripts/Makefile
 

--- a/filebeat/Makefile
+++ b/filebeat/Makefile
@@ -4,7 +4,7 @@ BEATNAME?=filebeat
 BEAT_DESCRIPTION?=Filebeat sends log files to Logstash or directly to Elasticsearch.
 SYSTEM_TESTS=true
 TEST_ENVIRONMENT?=true
-GOX_FLAGS=-arch="amd64 386 arm ppc64 ppc64le"
+GOX_FLAGS=-arch="amd64 386 arm ppc64 ppc64le" -osarch="!darwin/arm"
 
 include ../libbeat/scripts/Makefile
 

--- a/metricbeat/Makefile
+++ b/metricbeat/Makefile
@@ -14,7 +14,7 @@ CGO=true
 
 # Metricbeat can only be cross-compiled on platforms not requiring CGO.
 GOX_OS=solaris netbsd linux windows
-GOX_FLAGS='-arch=amd64 386 arm ppc64 ppc64le'
+GOX_FLAGS=-arch="amd64 386 arm ppc64 ppc64le"
 
 
 include ${ES_BEATS}/libbeat/scripts/Makefile


### PR DESCRIPTION
The quoting was wrong for the GOX_FLAGS variable in the Filebeat and Metricbeat makefiles.