### PR TITLE
Always use absolute path for event and registry

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -17,6 +17,7 @@ https://github.com/elastic/beats/compare/v5.1.1...master[Check the HEAD diff]
 - Change beat generator. Use `$GOPATH/src/github.com/elastic/beats/script/generate.py` to generate a beat. {pull}3452[3452]
 
 *Filebeat*
+- Always use absolute path for event and registry. This can lead to issues when relative paths were used before. {pull}3328[3328]
 
 *Heartbeat*
 
@@ -38,6 +39,7 @@ https://github.com/elastic/beats/compare/v5.1.1...master[Check the HEAD diff]
 - Add `_id`, `_type`, `_index` and `_score` fields in the generated index pattern. {pull}3282[3282]
 
 *Filebeat*
+- Always use absolute path for event and registry. {pull}3328[3328]
 
 *Heartbeat*
 
@@ -46,7 +48,6 @@ https://github.com/elastic/beats/compare/v5.1.1...master[Check the HEAD diff]
 - Fix go routine leak in docker module. {pull}3492[3492]
 
 *Packetbeat*
-
 
 *Winlogbeat*
 

--- a/filebeat/_meta/fields.common.yml
+++ b/filebeat/_meta/fields.common.yml
@@ -7,7 +7,7 @@
       type: keyword
       required: true
       description: >
-        The file from which the line was read. This field contains the full path to the file.
+        The file from which the line was read. This field contains the absolute path to the file.
         For example: `/var/log/system.log`.
 
     - name: offset

--- a/filebeat/docs/fields.asciidoc
+++ b/filebeat/docs/fields.asciidoc
@@ -403,7 +403,7 @@ type: keyword
 
 required: True
 
-The file from which the line was read. This field contains the full path to the file. For example: `/var/log/system.log`.
+The file from which the line was read. This field contains the absolute path to the file. For example: `/var/log/system.log`.
 
 
 [float]

--- a/filebeat/prospector/prospector_log.go
+++ b/filebeat/prospector/prospector_log.go
@@ -215,6 +215,11 @@ func (p *ProspectorLog) scan() {
 		default:
 		}
 
+		var err error
+		path, err = filepath.Abs(path)
+		if err != nil {
+			logp.Err("could not fetch abs path for file %s: %s", path, err)
+		}
 		logp.Debug("prospector", "Check file for harvesting: %s", path)
 
 		// Create new state for comparison


### PR DESCRIPTION
During some testing with filebeat I realised that when a relative path glob is put into the filebeat config, the event will contain the relative path and also the state. In most cases this should not be an issue and so far no issues were reported.

For the state itself it is not an issue as they are compared based on inode/device. It could become an issue on restart in case a config was changed from a relative to an absolute path and the prospector does not detect, that the state would belong to the same prospector. This could also have an affect when migrating to this solutions. Old states could be left over in the registry file. But this requires, that someone was using relative paths before.