### PR TITLE
Fixes for dev-tool/jenkins_ci

### DIFF
--- a/dev-tools/common.bash
+++ b/dev-tools/common.bash
@@ -44,7 +44,8 @@ install_gimme() {
     chmod +x ${HOME}/bin/gimme
   fi
 
-  debug "Gimme version $(gimme version)"
+  GIMME="${HOME}/bin/gimme"
+  debug "Gimme version $(${GIMME} version)"
 }
 
 # setup_go_root "version"
@@ -57,7 +58,7 @@ setup_go_root() {
   install_gimme
 
   # Setup GOROOT and add go to the PATH.
-  gimme "${version}" > /dev/null
+  ${GIMME} "${version}" > /dev/null
   source "${HOME}/.gimme/envs/go${version}.env" 2> /dev/null
 
   debug "$(go version)"

--- a/dev-tools/jenkins_ci
+++ b/dev-tools/jenkins_ci
@@ -81,7 +81,7 @@ parse_args() {
       exit 0
       ;;
     -r|--race)
-      RACE_DETECTOR=1
+      export RACE_DETECTOR=1
       shift
       ;;
     -v|--verbose)

--- a/filebeat/Makefile
+++ b/filebeat/Makefile
@@ -4,7 +4,7 @@ BEATNAME?=filebeat
 BEAT_DESCRIPTION?=Filebeat sends log files to Logstash or directly to Elasticsearch.
 SYSTEM_TESTS=true
 TEST_ENVIRONMENT?=true
-GOX_FLAGS=-arch="amd64 386 arm ppc64 ppc64le" -osarch="!darwin/arm"
+GOX_FLAGS=-arch="amd64 386 arm ppc64 ppc64le"
 
 include ../libbeat/scripts/Makefile
 

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -48,6 +48,8 @@ NOSETESTS_OPTIONS?=--process-timeout=$(TIMEOUT) --with-timer ## @testing the opt
 TEST_ENVIRONMENT?=false ## @testing if true, "make testsuite" runs integration tests and system tests in a dockerized test environment
 SYSTEM_TESTS?=false ## @testing if true, "make test" and "make testsuite" run unit tests and system tests
 GOX_OS?=linux darwin windows solaris freebsd netbsd openbsd ## @Building List of all OS to be supported by "make crosscompile".
+GOX_OSARCH?=!darwin/arm ## @building Space separated list of GOOS/GOARCH pairs to build by "make crosscompile".
+GOX_FLAGS?= ## @building Additional flags to append to the gox command used by "make crosscompile".
 TESTING_ENVIRONMENT?=snapshot ## @testing The name of the environment under test
 DOCKER_COMPOSE_PROJECT_NAME?=${BEATNAME}_${TESTING_ENVIRONMENT} ## @testing The name of the docker-compose project used by the integration and system tests
 DOCKER_COMPOSE?=TESTING_ENVIRONMENT=${TESTING_ENVIRONMENT} ES_BEATS=${ES_BEATS} docker-compose -p ${DOCKER_COMPOSE_PROJECT_NAME} -f docker-compose.yml
@@ -92,7 +94,7 @@ crosscompile: ## @build Cross-compile beat for the OS'es specified in GOX_OS var
 crosscompile: $(GOFILES)
 	go get github.com/mitchellh/gox
 	mkdir -p ${BUILD_DIR}/bin
-	gox -output="${BUILD_DIR}/bin/{{.Dir}}-{{.OS}}-{{.Arch}}" -os="${GOX_OS}" ${GOX_FLAGS}
+	gox -output="${BUILD_DIR}/bin/{{.Dir}}-{{.OS}}-{{.Arch}}" -os="$(strip $(GOX_OS))" -osarch="$(strip $(GOX_OSARCH))" ${GOX_FLAGS}
 
 
 .PHONY: check


### PR DESCRIPTION
Fix issues with the script for executing CI builds.

- Use absolute path to gimme inside of scripts to avoid requiring $HOME/bin be on the PATH.
- export the RACE_DETECTOR variable from the jenkins_ci script so that it is picked up by make.
- Disable cross-compile for darwin/arm by default.