### PR TITLE
Ensure harvesterCounter 8-byte alignment (#3273)

### DIFF
--- a/filebeat/prospector/prospector.go
+++ b/filebeat/prospector/prospector.go
@@ -21,6 +21,7 @@ var (
 )
 
 type Prospector struct {
+	harvesterCounter uint64 // Must be 8-byte aligned. Ensured if first field in struct
 	cfg              *common.Config // Raw config
 	config           prospectorConfig
 	prospectorer     Prospectorer
@@ -30,7 +31,6 @@ type Prospector struct {
 	states           *file.States
 	wg               sync.WaitGroup
 	channelWg        sync.WaitGroup // Separate waitgroup for channels as not stopped on completion
-	harvesterCounter uint64
 }
 
 type Prospectorer interface {


### PR DESCRIPTION
harvesterCounter is accessed atomically and will fault on x86-32 or ARM if not 8-byte aligned. See https://github.com/golang/go/issues/599 for more details on why it fails and https://golang.org/pkg/sync/atomic/#pkg-note-BUG for how putting the field first in the struct fixes it.