### PR TITLE
Filebeat modules: first phase of the Go implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 /beats.iml
 *.dev.yml
 *.generated.yml
+coverage.out
 
 # Editor swap files
 *.swp

--- a/filebeat/beater/filebeat.go
+++ b/filebeat/beater/filebeat.go
@@ -1,6 +1,7 @@
 package beater
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"sync"
@@ -11,6 +12,7 @@ import (
 
 	cfg "github.com/elastic/beats/filebeat/config"
 	"github.com/elastic/beats/filebeat/crawler"
+	"github.com/elastic/beats/filebeat/fileset"
 	"github.com/elastic/beats/filebeat/publisher"
 	"github.com/elastic/beats/filebeat/registrar"
 	"github.com/elastic/beats/filebeat/spooler"
@@ -20,8 +22,9 @@ var once = flag.Bool("once", false, "Run filebeat only once until all harvesters
 
 // Filebeat is a beater object. Contains all objects needed to run the beat
 type Filebeat struct {
-	config *cfg.Config
-	done   chan struct{}
+	config         *cfg.Config
+	moduleRegistry *fileset.ModuleRegistry
+	done           chan struct{}
 }
 
 // New creates a new Filebeat pointer instance.
@@ -30,13 +33,32 @@ func New(b *beat.Beat, rawConfig *common.Config) (beat.Beater, error) {
 	if err := rawConfig.Unpack(&config); err != nil {
 		return nil, fmt.Errorf("Error reading config file: %v", err)
 	}
+
+	moduleRegistry, err := fileset.NewModuleRegistry(config.Modules)
+	if err != nil {
+		return nil, err
+	}
+
+	moduleProspectors, err := moduleRegistry.GetProspectorConfigs()
+	if err != nil {
+		return nil, err
+	}
+
 	if err := config.FetchConfigs(); err != nil {
 		return nil, err
 	}
 
+	// Add prospectors created by the modules
+	config.Prospectors = append(config.Prospectors, moduleProspectors...)
+
+	if len(config.Prospectors) == 0 {
+		return nil, errors.New("No prospectors defined. What files do you want me to watch?")
+	}
+
 	fb := &Filebeat{
-		done:   make(chan struct{}),
-		config: &config,
+		done:           make(chan struct{}),
+		config:         &config,
+		moduleRegistry: moduleRegistry,
 	}
 	return fb, nil
 }

--- a/filebeat/config/config.go
+++ b/filebeat/config/config.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"errors"
 	"log"
 	"os"
 	"path/filepath"
@@ -26,6 +25,7 @@ type Config struct {
 	RegistryFile    string           `config:"registry_file"`
 	ConfigDir       string           `config:"config_dir"`
 	ShutdownTimeout time.Duration    `config:"shutdown_timeout"`
+	Modules         []*common.Config `config:"modules"`
 }
 
 var (
@@ -122,12 +122,6 @@ func (config *Config) FetchConfigs() error {
 	err = mergeConfigFiles(configFiles, config)
 	if err != nil {
 		log.Fatal("Error merging config files: ", err)
-		return err
-	}
-
-	if len(config.Prospectors) == 0 {
-		err := errors.New("No paths given. What files do you want me to watch?")
-		log.Fatalf("%v", err)
 		return err
 	}
 

--- a/filebeat/fileset/config.go
+++ b/filebeat/fileset/config.go
@@ -1,0 +1,19 @@
+package fileset
+
+// ModuleConfig contains the configuration file options for a module
+type ModuleConfig struct {
+	Module  string `config:"module"     validate:"required"`
+	Enabled *bool  `config:"enabled"`
+
+	// Filesets is inlined by code, see mcfgFromConfig
+	Filesets map[string]*FilesetConfig
+}
+
+// FilesetConfig contains the configuration file options for a fileset
+type FilesetConfig struct {
+	Enabled    *bool                  `config:"enabled"`
+	Var        map[string]interface{} `config:"var"`
+	Prospector map[string]interface{} `config:"prospector"`
+}
+
+var defaultFilesetConfig = FilesetConfig{}

--- a/filebeat/fileset/fileset.go
+++ b/filebeat/fileset/fileset.go
@@ -1,0 +1,257 @@
+/*
+Package fileset contains the code that loads Filebeat modules (which are
+composed of filesets).
+*/
+
+package fileset
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"text/template"
+
+	"github.com/elastic/beats/libbeat/common"
+)
+
+// Fileset struct is the representation of a fileset.
+type Fileset struct {
+	name       string
+	mcfg       *ModuleConfig
+	fcfg       *FilesetConfig
+	modulePath string
+	manifest   *manifest
+	vars       map[string]interface{}
+}
+
+// New allocates a new Fileset object with the given configuration.
+func New(
+	modulesPath string,
+	name string,
+	mcfg *ModuleConfig,
+	fcfg *FilesetConfig) (*Fileset, error) {
+
+	modulePath := filepath.Join(modulesPath, mcfg.Module)
+	if _, err := os.Stat(modulePath); os.IsNotExist(err) {
+		return nil, fmt.Errorf("Module %s (%s) doesn't exist.", mcfg.Module, modulePath)
+	}
+
+	return &Fileset{
+		name:       name,
+		mcfg:       mcfg,
+		fcfg:       fcfg,
+		modulePath: modulePath,
+	}, nil
+}
+
+// Read reads the manifest file and evaluates the variables.
+func (fs *Fileset) Read() error {
+	var err error
+	fs.manifest, err = fs.readManifest()
+	if err != nil {
+		return err
+	}
+
+	fs.vars, err = fs.evaluateVars()
+	if err != nil {
+		return err
+	}
+
+	pipeline_id, err := fs.getPipelineID()
+	if err != nil {
+		return err
+	}
+	fs.vars["beat"] = map[string]interface{}{
+		"pipeline_id": pipeline_id,
+	}
+
+	return nil
+}
+
+// manifest structure is the representation of the manifest.yml file from the
+// fileset.
+type manifest struct {
+	ModuleVersion  string                   `config:"module_version"`
+	Vars           []map[string]interface{} `config:"var"`
+	IngestPipeline string                   `config:"ingest_pipeline"`
+	Prospector     string                   `config:"prospector"`
+}
+
+// readManifest reads the manifest file of the fileset.
+func (fs *Fileset) readManifest() (*manifest, error) {
+	cfg, err := common.LoadFile(filepath.Join(fs.modulePath, fs.name, "manifest.yml"))
+	if err != nil {
+		return nil, fmt.Errorf("Error reading manifest file: %v", err)
+	}
+	var manifest manifest
+	err = cfg.Unpack(&manifest)
+	if err != nil {
+		return nil, fmt.Errorf("Error unpacking manifest: %v", err)
+	}
+	return &manifest, nil
+}
+
+// evaluateVars resolves the fileset variables.
+func (fs *Fileset) evaluateVars() (map[string]interface{}, error) {
+	var err error
+	vars := map[string]interface{}{}
+	vars["builtin"], err = fs.getBuiltinVars()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, vals := range fs.manifest.Vars {
+		var exists bool
+		name, exists := vals["name"].(string)
+		if !exists {
+			return nil, fmt.Errorf("Variable doesn't have a string 'name' key")
+		}
+
+		value, exists := vals["default"]
+		if !exists {
+			return nil, fmt.Errorf("Variable %s doesn't have a 'default' key", name)
+		}
+
+		// evaluate OS specific vars
+		osVals, exists := vals["os"].(map[string]interface{})
+		if exists {
+			osVal, exists := osVals[runtime.GOOS]
+			if exists {
+				value = osVal
+			}
+		}
+
+		vars[name], err = resolveVariable(vars, value)
+		if err != nil {
+			return nil, fmt.Errorf("Error resolving variables on %s: %v", name, err)
+		}
+	}
+
+	// overrides from the config
+	for name, val := range fs.fcfg.Var {
+		vars[name] = val
+	}
+
+	return vars, nil
+}
+
+// resolveVariable considers the value as a template so it can refer to built-in variables
+// as well as other variables defined before them.
+func resolveVariable(vars map[string]interface{}, value interface{}) (interface{}, error) {
+	switch v := value.(type) {
+	case string:
+		return applyTemplate(vars, v)
+	case []interface{}:
+		transformed := []interface{}{}
+		for _, val := range v {
+			s, ok := val.(string)
+			if ok {
+				transf, err := applyTemplate(vars, s)
+				if err != nil {
+					return nil, fmt.Errorf("array: %v", err)
+				}
+				transformed = append(transformed, transf)
+			} else {
+				transformed = append(transformed, val)
+			}
+		}
+		return transformed, nil
+	}
+	return value, nil
+}
+
+// applyTemplate applies a Golang text/template
+func applyTemplate(vars map[string]interface{}, templateString string) (string, error) {
+	tpl, err := template.New("text").Parse(templateString)
+	if err != nil {
+		return "", fmt.Errorf("Error parsing template %s: %v", templateString, err)
+	}
+	buf := bytes.NewBufferString("")
+	err = tpl.Execute(buf, vars)
+	if err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+// getBuiltinVars computes the supported built in variables and groups them
+// in a dictionary
+func (fs *Fileset) getBuiltinVars() (map[string]interface{}, error) {
+	host, err := os.Hostname()
+	if err != nil || len(host) == 0 {
+		return nil, fmt.Errorf("Error getting the hostname: %v", err)
+	}
+	split := strings.SplitN(host, ".", 2)
+	hostname := split[0]
+	domain := ""
+	if len(split) > 1 {
+		domain = split[1]
+	}
+
+	return map[string]interface{}{
+		"hostname": hostname,
+		"domain":   domain,
+	}, nil
+}
+
+func (fs *Fileset) getProspectorConfig() (*common.Config, error) {
+	path, err := applyTemplate(fs.vars, fs.manifest.Prospector)
+	if err != nil {
+		return nil, fmt.Errorf("Error expanding vars on the prospector path: %v", err)
+	}
+	contents, err := ioutil.ReadFile(filepath.Join(fs.modulePath, fs.name, path))
+	if err != nil {
+		return nil, fmt.Errorf("Error reading prospector file %s: %v", path, err)
+	}
+
+	yaml, err := applyTemplate(fs.vars, string(contents))
+	if err != nil {
+		return nil, fmt.Errorf("Error interpreting the template of the prospector: %v", err)
+	}
+
+	cfg, err := common.NewConfigWithYAML([]byte(yaml), "")
+	if err != nil {
+		return nil, fmt.Errorf("Error reading prospector config: %v", err)
+	}
+
+	// overrides
+	if len(fs.fcfg.Prospector) > 0 {
+		overrides, err := common.NewConfigFrom(fs.fcfg.Prospector)
+		if err != nil {
+			return nil, fmt.Errorf("Error creating config from prospector overrides: %v", err)
+		}
+		cfg, err = common.MergeConfigs(cfg, overrides)
+		if err != nil {
+			return nil, fmt.Errorf("Error applying config overrides: %v", err)
+		}
+	}
+
+	cfg.PrintDebugf("Merged prospector config for fileset %s/%s", fs.mcfg.Module, fs.name)
+
+	return cfg, nil
+}
+
+// getPipelineID returns the Ingest Node pipeline ID
+func (fs *Fileset) getPipelineID() (string, error) {
+	path, err := applyTemplate(fs.vars, fs.manifest.IngestPipeline)
+	if err != nil {
+		return "", fmt.Errorf("Error expanding vars on the ingest pipeline path: %v", err)
+	}
+
+	return fmt.Sprintf("%s-%s-%s", fs.mcfg.Module, fs.name, removeExt(filepath.Base(path))), nil
+}
+
+// removeExt returns the file name without the extension. If no dot is found,
+// returns the same as the input.
+func removeExt(path string) string {
+	for i := len(path) - 1; i >= 0 && !os.IsPathSeparator(path[i]); i-- {
+		if path[i] == '.' {
+			return path[:i]
+		}
+	}
+	return path
+}

--- a/filebeat/fileset/fileset_test.go
+++ b/filebeat/fileset/fileset_test.go
@@ -1,0 +1,182 @@
+package fileset
+
+import (
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func getModuleForTesting(t *testing.T, module, fileset string) *Fileset {
+	modulesPath, err := filepath.Abs("../module")
+	assert.NoError(t, err)
+	fs, err := New(modulesPath, fileset, &ModuleConfig{Module: module}, &FilesetConfig{})
+	assert.NoError(t, err)
+
+	return fs
+}
+
+func TestLoadManifestNginx(t *testing.T) {
+	fs := getModuleForTesting(t, "nginx", "access")
+
+	manifest, err := fs.readManifest()
+	assert.NoError(t, err)
+	assert.Equal(t, manifest.ModuleVersion, "1.0")
+	assert.Equal(t, manifest.IngestPipeline, "ingest/{{.pipeline}}.json")
+	assert.Equal(t, manifest.Prospector, "config/nginx-access.yml")
+
+	vars := manifest.Vars
+	assert.Equal(t, "paths", vars[0]["name"])
+	path := (vars[0]["default"]).([]interface{})[0].(string)
+	assert.Equal(t, path, "/var/log/nginx/access.log*")
+
+	assert.Equal(t, "pipeline", vars[1]["name"])
+	assert.Equal(t, "with_plugins", vars[1]["default"])
+}
+
+func TestGetBuiltinVars(t *testing.T) {
+	fs := getModuleForTesting(t, "nginx", "access")
+
+	vars, err := fs.getBuiltinVars()
+	assert.NoError(t, err)
+
+	assert.IsType(t, vars["hostname"], "a-mac-with-esc-key")
+	assert.IsType(t, vars["domain"], "local")
+}
+
+func TestEvaluateVarsNginx(t *testing.T) {
+	fs := getModuleForTesting(t, "nginx", "access")
+
+	var err error
+	fs.manifest, err = fs.readManifest()
+	assert.NoError(t, err)
+
+	vars, err := fs.evaluateVars()
+	assert.NoError(t, err)
+
+	builtin := vars["builtin"].(map[string]interface{})
+	assert.IsType(t, "a-mac-with-esc-key", builtin["hostname"])
+	assert.IsType(t, "local", builtin["domain"])
+
+	assert.Equal(t, "with_plugins", vars["pipeline"])
+	assert.IsType(t, []interface{}{"/usr/local/var/log/nginx/access.log*"}, vars["paths"])
+}
+
+func TestEvaluateVarsNginxOverride(t *testing.T) {
+
+	modulesPath, err := filepath.Abs("../module")
+	assert.NoError(t, err)
+	fs, err := New(modulesPath, "access", &ModuleConfig{Module: "nginx"}, &FilesetConfig{
+		Var: map[string]interface{}{
+			"pipeline": "no_plugins",
+		},
+	})
+	assert.NoError(t, err)
+
+	fs.manifest, err = fs.readManifest()
+	assert.NoError(t, err)
+
+	vars, err := fs.evaluateVars()
+	assert.NoError(t, err)
+
+	assert.Equal(t, "no_plugins", vars["pipeline"])
+}
+
+func TestEvaluateVarsMySQL(t *testing.T) {
+	fs := getModuleForTesting(t, "mysql", "slowlog")
+
+	var err error
+	fs.manifest, err = fs.readManifest()
+	assert.NoError(t, err)
+
+	vars, err := fs.evaluateVars()
+	assert.NoError(t, err)
+
+	builtin := vars["builtin"].(map[string]interface{})
+	assert.IsType(t, "a-mac-with-esc-key", builtin["hostname"])
+	assert.IsType(t, "local", builtin["domain"])
+
+	expectedPaths := []interface{}{
+		"/var/log/mysql/mysql-slow.log*",
+		fmt.Sprintf("/var/lib/mysql/%s-slow.log", builtin["hostname"]),
+	}
+	if runtime.GOOS == "darwin" {
+		expectedPaths = []interface{}{
+			fmt.Sprintf("/usr/local/var/mysql/%s-slow.log*", builtin["hostname"]),
+		}
+	}
+	if runtime.GOOS == "windows" {
+		expectedPaths = []interface{}{
+			"c:/programdata/MySQL/MySQL Server*/mysql-slow.log*",
+		}
+	}
+
+	assert.Equal(t, expectedPaths, vars["paths"])
+}
+
+func TestResolveVariable(t *testing.T) {
+	tests := []struct {
+		Value    interface{}
+		Vars     map[string]interface{}
+		Expected interface{}
+	}{
+		{
+			Value: "test-{{.value}}",
+			Vars: map[string]interface{}{
+				"value": 2,
+			},
+			Expected: "test-2",
+		},
+		{
+			Value: []interface{}{"test-{{.value}}", "test1-{{.value}}"},
+			Vars: map[string]interface{}{
+				"value": 2,
+			},
+			Expected: []interface{}{"test-2", "test1-2"},
+		},
+	}
+
+	for _, test := range tests {
+		result, err := resolveVariable(test.Vars, test.Value)
+		assert.NoError(t, err)
+		assert.Equal(t, test.Expected, result)
+	}
+}
+
+func TestGetProspectorConfigNginx(t *testing.T) {
+	fs := getModuleForTesting(t, "nginx", "access")
+	assert.NoError(t, fs.Read())
+
+	cfg, err := fs.getProspectorConfig()
+	assert.NoError(t, err)
+
+	assert.True(t, cfg.HasField("paths"))
+	assert.True(t, cfg.HasField("exclude_files"))
+	pipeline_id := fs.vars["beat"].(map[string]interface{})["pipeline_id"]
+	assert.Equal(t, "nginx-access-with_plugins", pipeline_id)
+}
+
+func TestGetProspectorConfigNginxOverrides(t *testing.T) {
+	modulesPath, err := filepath.Abs("../module")
+	assert.NoError(t, err)
+	fs, err := New(modulesPath, "access", &ModuleConfig{Module: "nginx"}, &FilesetConfig{
+		Prospector: map[string]interface{}{
+			"close_eof": true,
+		},
+	})
+	assert.NoError(t, err)
+
+	assert.NoError(t, fs.Read())
+
+	cfg, err := fs.getProspectorConfig()
+	assert.NoError(t, err)
+
+	assert.True(t, cfg.HasField("paths"))
+	assert.True(t, cfg.HasField("exclude_files"))
+	assert.True(t, cfg.HasField("close_eof"))
+	pipeline_id := fs.vars["beat"].(map[string]interface{})["pipeline_id"]
+	assert.Equal(t, "nginx-access-with_plugins", pipeline_id)
+
+}

--- a/filebeat/fileset/flags.go
+++ b/filebeat/fileset/flags.go
@@ -1,0 +1,59 @@
+package fileset
+
+import (
+	"flag"
+	"fmt"
+	"strings"
+
+	"github.com/elastic/beats/libbeat/common"
+)
+
+// Modules related command line flags.
+var (
+	modulesFlag     = flag.String("modules", "", "List of enabled modules (comma separated)")
+	moduleOverrides = common.NewFlagConfig(nil, nil, "M", "Module configuration overwrite")
+)
+
+type ModuleOverrides map[string]map[string]*common.Config // module -> fileset -> Config
+
+// Get returns an array of configuration overrides that should be merged in order.
+func (mo *ModuleOverrides) Get(module, fileset string) []*common.Config {
+	ret := []*common.Config{}
+
+	moduleWildcard := (*mo)["*"]["*"]
+	if moduleWildcard != nil {
+		ret = append(ret, moduleWildcard)
+	}
+
+	filesetWildcard := (*mo)[module]["*"]
+	if filesetWildcard != nil {
+		ret = append(ret, filesetWildcard)
+	}
+
+	cfg := (*mo)[module][fileset]
+	if cfg != nil {
+		ret = append(ret, cfg)
+	}
+
+	return ret
+}
+
+func getModulesCLIConfig() ([]string, *ModuleOverrides, error) {
+
+	modulesList := []string{}
+	if modulesFlag != nil {
+		modulesList = strings.Split(*modulesFlag, ",")
+	}
+
+	if moduleOverrides == nil {
+		return modulesList, nil, nil
+	}
+
+	var overrides ModuleOverrides
+	err := moduleOverrides.Unpack(&overrides)
+	if err != nil {
+		return []string{}, nil, fmt.Errorf("-M flags must be prefixed by the module and fileset: %v", err)
+	}
+
+	return modulesList, &overrides, nil
+}

--- a/filebeat/fileset/modules.go
+++ b/filebeat/fileset/modules.go
@@ -1,0 +1,234 @@
+package fileset
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/paths"
+)
+
+type ModuleRegistry struct {
+	registry map[string]map[string]*Fileset // module -> fileset -> Fileset
+}
+
+// newModuleRegistry reads and loads the configured module into the registry.
+func newModuleRegistry(modulesPath string,
+	moduleConfigs []ModuleConfig,
+	overrides *ModuleOverrides) (*ModuleRegistry, error) {
+
+	var reg ModuleRegistry
+	reg.registry = map[string]map[string]*Fileset{}
+
+	for _, mcfg := range moduleConfigs {
+		if mcfg.Enabled != nil && (*mcfg.Enabled) == false {
+			continue
+		}
+
+		reg.registry[mcfg.Module] = map[string]*Fileset{}
+		moduleFilesets, err := getModuleFilesets(modulesPath, mcfg.Module)
+		if err != nil {
+			return nil, fmt.Errorf("Error getting filesets for module %s: %v", mcfg.Module, err)
+		}
+
+		for _, filesetName := range moduleFilesets {
+			fcfg, exists := mcfg.Filesets[filesetName]
+			if !exists {
+				fcfg = &defaultFilesetConfig
+			}
+
+			if fcfg.Enabled != nil && (*fcfg.Enabled) == false {
+				continue
+			}
+
+			fcfg, err = applyOverrides(fcfg, mcfg.Module, filesetName, overrides)
+			if err != nil {
+				return nil, fmt.Errorf("Error applying overrides on fileset %s/%s: %v", mcfg.Module, filesetName, err)
+			}
+
+			fileset, err := New(modulesPath, filesetName, &mcfg, fcfg)
+			if err != nil {
+				return nil, err
+			}
+			err = fileset.Read()
+			if err != nil {
+				return nil, fmt.Errorf("Error reading fileset %s/%s: %v", mcfg.Module, filesetName, err)
+			}
+			reg.registry[mcfg.Module][filesetName] = fileset
+		}
+
+		// check that no extra filesets are configured
+		for filesetName, fcfg := range mcfg.Filesets {
+			if fcfg.Enabled != nil && (*fcfg.Enabled) == false {
+				continue
+			}
+			found := false
+			for _, name := range moduleFilesets {
+				if filesetName == name {
+					found = true
+				}
+			}
+			if !found {
+				return nil, fmt.Errorf("Fileset %s/%s is configured but doesn't exist", mcfg.Module, filesetName)
+			}
+		}
+	}
+
+	return &reg, nil
+}
+
+// NewModuleRegistry reads and loads the configured module into the registry.
+func NewModuleRegistry(moduleConfigs []*common.Config) (*ModuleRegistry, error) {
+	modulesPath := paths.Resolve(paths.Home, "module")
+	modulesCLIList, modulesOverrides, err := getModulesCLIConfig()
+	if err != nil {
+		return nil, err
+	}
+	mcfgs := []ModuleConfig{}
+	for _, moduleConfig := range moduleConfigs {
+		mcfg, err := mcfgFromConfig(moduleConfig)
+		if err != nil {
+			return nil, fmt.Errorf("Error unpacking module config: %v", err)
+		}
+		mcfgs = append(mcfgs, *mcfg)
+	}
+	mcfgs, err = appendWithoutDuplicates(mcfgs, modulesCLIList)
+	if err != nil {
+		return nil, err
+	}
+	return newModuleRegistry(modulesPath, mcfgs, modulesOverrides)
+}
+
+func mcfgFromConfig(cfg *common.Config) (*ModuleConfig, error) {
+	var mcfg ModuleConfig
+
+	err := cfg.Unpack(&mcfg)
+	if err != nil {
+		return nil, err
+	}
+
+	var dict map[string]interface{}
+
+	err = cfg.Unpack(&dict)
+	if err != nil {
+		return nil, fmt.Errorf("Error unpacking module %s in a dict: %v", mcfg.Module, err)
+	}
+
+	mcfg.Filesets = map[string]*FilesetConfig{}
+	for name, filesetConfig := range dict {
+		if name == "module" || name == "enabled" {
+			continue
+		}
+
+		var fcfg FilesetConfig
+		tmpCfg, err := common.NewConfigFrom(filesetConfig)
+		if err != nil {
+			return nil, fmt.Errorf("Error creating config from fileset %s/%s: %v", mcfg.Module, name, err)
+		}
+		err = tmpCfg.Unpack(&fcfg)
+		if err != nil {
+			return nil, fmt.Errorf("Error unpacking fileset %s/%s: %v", mcfg.Module, name, err)
+		}
+		mcfg.Filesets[name] = &fcfg
+
+	}
+
+	return &mcfg, nil
+}
+
+func getModuleFilesets(modulePath, module string) ([]string, error) {
+	fileInfos, err := ioutil.ReadDir(filepath.Join(modulePath, module))
+	if err != nil {
+		return []string{}, err
+	}
+
+	filesets := []string{}
+	for _, fi := range fileInfos {
+		if fi.IsDir() {
+			// check also that the `manifest.yml` file exists
+			_, err = os.Stat(filepath.Join(modulePath, module, fi.Name(), "manifest.yml"))
+			if err == nil {
+				filesets = append(filesets, fi.Name())
+			}
+		}
+	}
+
+	return filesets, nil
+}
+
+func applyOverrides(fcfg *FilesetConfig,
+	module, fileset string,
+	overrides *ModuleOverrides) (*FilesetConfig, error) {
+
+	if overrides == nil {
+		return fcfg, nil
+	}
+
+	overridesConfigs := overrides.Get(module, fileset)
+	if len(overridesConfigs) == 0 {
+		return fcfg, nil
+	}
+
+	config, err := common.NewConfigFrom(fcfg)
+	if err != nil {
+		return nil, fmt.Errorf("Error creating vars config object: %v", err)
+	}
+
+	toMerge := []*common.Config{config}
+	toMerge = append(toMerge, overridesConfigs...)
+
+	resultConfig, err := common.MergeConfigs(toMerge...)
+	if err != nil {
+		return nil, fmt.Errorf("Error merging configs: %v", err)
+	}
+
+	var res FilesetConfig
+	err = resultConfig.Unpack(&res)
+	if err != nil {
+		return nil, fmt.Errorf("Error unpacking configs: %v", err)
+	}
+
+	return &res, nil
+}
+
+// appendWithoutDuplicates appends basic module configuration for each module in the
+// modules list, unless the same module is not already loaded.
+func appendWithoutDuplicates(moduleConfigs []ModuleConfig, modules []string) ([]ModuleConfig, error) {
+	if len(modules) == 0 {
+		return moduleConfigs, nil
+	}
+
+	// built a dictionary with the configured modules
+	modulesMap := map[string]bool{}
+	for _, mcfg := range moduleConfigs {
+		if mcfg.Enabled != nil && (*mcfg.Enabled) == false {
+			continue
+		}
+		modulesMap[mcfg.Module] = true
+	}
+
+	// add the non duplicates to the list
+	for _, module := range modules {
+		if _, exists := modulesMap[module]; !exists {
+			moduleConfigs = append(moduleConfigs, ModuleConfig{Module: module})
+		}
+	}
+	return moduleConfigs, nil
+}
+
+func (reg *ModuleRegistry) GetProspectorConfigs() ([]*common.Config, error) {
+	result := []*common.Config{}
+	for module, filesets := range reg.registry {
+		for name, fileset := range filesets {
+			fcfg, err := fileset.getProspectorConfig()
+			if err != nil {
+				return result, fmt.Errorf("Error getting config for fielset %s/%s: %v",
+					module, name, err)
+			}
+			result = append(result, fcfg)
+		}
+	}
+	return result, nil
+}

--- a/filebeat/fileset/modules_test.go
+++ b/filebeat/fileset/modules_test.go
@@ -1,0 +1,324 @@
+package fileset
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/stretchr/testify/assert"
+)
+
+func load(t *testing.T, from interface{}) *common.Config {
+	config, err := common.NewConfigFrom(from)
+	if err != nil {
+		t.Fatalf("Config err: %v", err)
+	}
+	return config
+}
+
+func TestNewModuleRegistry(t *testing.T) {
+	modulesPath, err := filepath.Abs("../module")
+	assert.NoError(t, err)
+
+	configs := []ModuleConfig{
+		ModuleConfig{Module: "nginx"},
+		ModuleConfig{Module: "mysql"},
+		ModuleConfig{Module: "syslog"},
+	}
+
+	reg, err := newModuleRegistry(modulesPath, configs, nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, reg)
+
+	expectedModules := map[string][]string{
+		"nginx":  []string{"access", "error"},
+		"mysql":  []string{"slowlog", "error"},
+		"syslog": []string{"system"},
+	}
+
+	assert.Equal(t, len(expectedModules), len(reg.registry))
+	for name, filesets := range reg.registry {
+		expectedFilesets, exists := expectedModules[name]
+		assert.True(t, exists)
+
+		assert.Equal(t, len(expectedFilesets), len(filesets))
+		for _, fileset := range expectedFilesets {
+			fs := filesets[fileset]
+			assert.NotNil(t, fs)
+		}
+	}
+
+	for module, filesets := range reg.registry {
+		for name, fileset := range filesets {
+			_, err = fileset.getProspectorConfig()
+			assert.NoError(t, err, fmt.Sprintf("module: %s, fileset: %s", module, name))
+		}
+	}
+}
+
+func TestNewModuleRegistryConfig(t *testing.T) {
+	modulesPath, err := filepath.Abs("../module")
+	assert.NoError(t, err)
+
+	falseVar := false
+
+	configs := []ModuleConfig{
+		{
+			Module: "nginx",
+			Filesets: map[string]*FilesetConfig{
+				"access": &FilesetConfig{
+					Var: map[string]interface{}{
+						"paths": []interface{}{"/hello/test"},
+					},
+				},
+				"error": &FilesetConfig{
+					Enabled: &falseVar,
+				},
+			},
+		},
+		{
+			Module:  "mysql",
+			Enabled: &falseVar,
+		},
+	}
+
+	reg, err := newModuleRegistry(modulesPath, configs, nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, reg)
+
+	nginxAccess := reg.registry["nginx"]["access"]
+	assert.NotNil(t, nginxAccess)
+	assert.Equal(t, []interface{}{"/hello/test"}, nginxAccess.vars["paths"])
+
+	assert.NotContains(t, reg.registry["nginx"], "error")
+}
+
+func TestAppplyOverrides(t *testing.T) {
+
+	falseVar := false
+	trueVar := true
+
+	tests := []struct {
+		name            string
+		fcfg            FilesetConfig
+		module, fileset string
+		overrides       *ModuleOverrides
+		expected        FilesetConfig
+	}{
+		{
+			name: "var overrides",
+			fcfg: FilesetConfig{
+				Var: map[string]interface{}{
+					"a":   "test",
+					"b.c": "test",
+				},
+			},
+			module:  "nginx",
+			fileset: "access",
+			overrides: &ModuleOverrides{
+				"nginx": map[string]*common.Config{
+					"access": load(t, map[string]interface{}{
+						"var.a":   "test1",
+						"var.b.c": "test2"}),
+				},
+			},
+			expected: FilesetConfig{
+				Var: map[string]interface{}{
+					"a": "test1",
+					"b": map[string]interface{}{"c": "test2"},
+				},
+			},
+		},
+		{
+			name: "enable and var overrides",
+			fcfg: FilesetConfig{
+				Enabled: &falseVar,
+				Var: map[string]interface{}{
+					"paths": []string{"/var/log/nginx"},
+				},
+			},
+			module:  "nginx",
+			fileset: "access",
+			overrides: &ModuleOverrides{
+				"nginx": map[string]*common.Config{
+					"access": load(t, map[string]interface{}{
+						"enabled":   true,
+						"var.paths": []interface{}{"/var/local/nginx/log"}}),
+				},
+			},
+			expected: FilesetConfig{
+				Enabled: &trueVar,
+				Var: map[string]interface{}{
+					"paths": []interface{}{"/var/local/nginx/log"},
+				},
+			},
+		},
+		{
+			name:    "prospector overrides",
+			fcfg:    FilesetConfig{},
+			module:  "nginx",
+			fileset: "access",
+			overrides: &ModuleOverrides{
+				"nginx": map[string]*common.Config{
+					"access": load(t, map[string]interface{}{
+						"prospector.close_eof": true,
+					}),
+				},
+			},
+			expected: FilesetConfig{
+				Prospector: map[string]interface{}{
+					"close_eof": true,
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		result, err := applyOverrides(&test.fcfg, test.module, test.fileset, test.overrides)
+		assert.NoError(t, err)
+		assert.Equal(t, &test.expected, result, test.name)
+	}
+}
+
+func TestAppendWithoutDuplicates(t *testing.T) {
+	falseVar := false
+	tests := []struct {
+		name     string
+		configs  []ModuleConfig
+		modules  []string
+		expected []ModuleConfig
+	}{
+		{
+			name:    "just modules",
+			configs: []ModuleConfig{},
+			modules: []string{"moduleA", "moduleB", "moduleC"},
+			expected: []ModuleConfig{
+				{Module: "moduleA"},
+				{Module: "moduleB"},
+				{Module: "moduleC"},
+			},
+		},
+		{
+			name: "eliminate a duplicate, no override",
+			configs: []ModuleConfig{
+				{
+					Module: "moduleB",
+					Filesets: map[string]*FilesetConfig{
+						"fileset": &FilesetConfig{
+							Var: map[string]interface{}{
+								"paths": "test",
+							},
+						},
+					},
+				},
+			},
+			modules: []string{"moduleA", "moduleB", "moduleC"},
+			expected: []ModuleConfig{
+				{
+					Module: "moduleB",
+					Filesets: map[string]*FilesetConfig{
+						"fileset": &FilesetConfig{
+							Var: map[string]interface{}{
+								"paths": "test",
+							},
+						},
+					},
+				},
+				{Module: "moduleA"},
+				{Module: "moduleC"},
+			},
+		},
+		{
+			name: "disabled config",
+			configs: []ModuleConfig{
+				{
+					Module:  "moduleB",
+					Enabled: &falseVar,
+					Filesets: map[string]*FilesetConfig{
+						"fileset": &FilesetConfig{
+							Var: map[string]interface{}{
+								"paths": "test",
+							},
+						},
+					},
+				},
+			},
+			modules: []string{"moduleA", "moduleB", "moduleC"},
+			expected: []ModuleConfig{
+				{
+					Module:  "moduleB",
+					Enabled: &falseVar,
+					Filesets: map[string]*FilesetConfig{
+						"fileset": &FilesetConfig{
+							Var: map[string]interface{}{
+								"paths": "test",
+							},
+						},
+					},
+				},
+				{Module: "moduleA"},
+				{Module: "moduleB"},
+				{Module: "moduleC"},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		result, err := appendWithoutDuplicates(test.configs, test.modules)
+		assert.NoError(t, err, test.name)
+		assert.Equal(t, test.expected, result, test.name)
+	}
+}
+
+func TestMcfgFromConfig(t *testing.T) {
+	falseVar := false
+	tests := []struct {
+		name     string
+		config   *common.Config
+		expected ModuleConfig
+	}{
+		{
+			name: "disable fileset",
+			config: load(t, map[string]interface{}{
+				"module":        "nginx",
+				"error.enabled": false,
+			}),
+			expected: ModuleConfig{
+				Module: "nginx",
+				Filesets: map[string]*FilesetConfig{
+					"error": &FilesetConfig{
+						Enabled: &falseVar,
+					},
+				},
+			},
+		},
+		{
+			name: "set variable",
+			config: load(t, map[string]interface{}{
+				"module":          "nginx",
+				"access.var.test": false,
+			}),
+			expected: ModuleConfig{
+				Module: "nginx",
+				Filesets: map[string]*FilesetConfig{
+					"access": &FilesetConfig{
+						Var: map[string]interface{}{
+							"test": false,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		result, err := mcfgFromConfig(test.config)
+		assert.NoError(t, err, test.name)
+		assert.Equal(t, test.expected.Module, result.Module)
+		assert.Equal(t, len(test.expected.Filesets), len(result.Filesets))
+		for name, fileset := range test.expected.Filesets {
+			assert.Equal(t, fileset, result.Filesets[name])
+		}
+	}
+}

--- a/filebeat/module/apache2/access/config/access.yml
+++ b/filebeat/module/apache2/access/config/access.yml
@@ -1,9 +1,9 @@
-- input_type: log
-  paths:
-  {%- for path in paths %}
-   - {{path}}
-  {%- endfor %}
-  exclude_files: [".gz$"]
-  fields:
-    source_type: apache2-access
-    pipeline_id: {{beat.pipeline_id}}
+input_type: log
+paths:
+{{ range $i, $path := .paths }}
+ - {{$path}}
+{{ end }}
+exclude_files: [".gz$"]
+fields:
+  source_type: apache2-access
+  pipeline_id: {{.beat.pipeline_id}}

--- a/filebeat/module/apache2/access/manifest.yml
+++ b/filebeat/module/apache2/access/manifest.yml
@@ -1,7 +1,7 @@
 module_version: 1.0
 
-vars:
-  paths:
+var:
+  - name: paths
     default:
       - /var/log/apache2/access.log*
       - /var/log/apache2/other_vhosts_access.log*
@@ -9,10 +9,9 @@ vars:
       - /usr/local/var/log/apache2/access_log*
     os.windows:
       - "C:/Program Files/Apache Software Foundation/Apache2.4/logs/access.log*"
-  pipeline:
+  - name: pipeline
     # options: with_plugins, no_plugins
     default: with_plugins
 
-ingest_pipeline: ingest/{{pipeline}}.json
-prospectors:
-  - config/access.yml
+ingest_pipeline: ingest/{{.pipeline}}.json
+prospector: config/access.yml

--- a/filebeat/module/apache2/error/config/error.yml
+++ b/filebeat/module/apache2/error/config/error.yml
@@ -1,9 +1,9 @@
-- input_type: log
-  paths:
-  {%- for path in paths %}
-   - {{path}}
-  {%- endfor %}
-  exclude_files: [".gz$"]
-  fields:
-    source_type: apache2-error
-    pipeline_id: {{beat.pipeline_id}}
+input_type: log
+paths:
+{{ range $i, $path := .paths }}
+ - {{$path}}
+{{ end }}
+exclude_files: [".gz$"]
+fields:
+  source_type: apache2-error
+  pipeline_id: {{.beat.pipeline_id}}

--- a/filebeat/module/apache2/error/manifest.yml
+++ b/filebeat/module/apache2/error/manifest.yml
@@ -1,7 +1,7 @@
 module_version: 1.0
 
-vars:
-  paths:
+var:
+  - name: paths
     default:
       - /var/log/apache2/error.log*
     os.darwin:
@@ -10,5 +10,4 @@ vars:
       - "C:/Program Files/Apache Software Foundation/Apache2.4/logs/error.log*"
 
 ingest_pipeline: ingest/pipeline.json
-prospectors:
-  - config/error.yml
+prospector: config/error.yml

--- a/filebeat/module/mysql/error/config/error.yml
+++ b/filebeat/module/mysql/error/config/error.yml
@@ -1,9 +1,9 @@
-- input_type: log
-  paths:
-  {%- for path in paths %}
-   - {{path}}
-  {%- endfor %}
-  exclude_files: [".gz$"]
-  fields:
-    source_type: mysql-error
-    pipeline_id: {{beat.pipeline_id}}
+input_type: log
+paths:
+{{ range $i, $path := .paths }}
+ - {{$path}}
+{{ end }}
+exclude_files: [".gz$"]
+fields:
+  source_type: mysql-error
+  pipeline_id: {{.beat.pipeline_id}}

--- a/filebeat/module/mysql/error/manifest.yml
+++ b/filebeat/module/mysql/error/manifest.yml
@@ -1,15 +1,14 @@
-module_version: 1.0
+module_version: "1.0"
 
-vars:
-  paths:
+var:
+  - name: paths
     default:
       - /var/log/mysql/error.log*
       - /var/log/mysqld.log*
     os.darwin:
-      - /usr/local/var/mysql/{{builtin.hostname}}.{{builtin.domain}}.err*
+      - /usr/local/var/mysql/{{.builtin.hostname}}.{{.builtin.domain}}.err*
     os.windows:
       - "c:/programdata/MySQL/MySQL Server*/error.log*"
 
 ingest_pipeline: ingest/pipeline.json
-prospectors:
-  - config/error.yml
+prospector: config/error.yml

--- a/filebeat/module/mysql/slowlog/config/slowlog.yml
+++ b/filebeat/module/mysql/slowlog/config/slowlog.yml
@@ -1,13 +1,13 @@
-- input_type: log
-  paths:
-  {%- for path in paths %}
-   - {{path}}
-  {%- endfor %}
-  exclude_files: [".gz$"]
-  multiline:
-    pattern: "^# User@Host: "
-    negate: true
-    match: after
-  fields:
-    source_type: mysql-slowlog
-    pipeline_id: {{beat.pipeline_id}}
+input_type: log
+paths:
+{{ range $i, $path := .paths }}
+ - {{$path}}
+{{ end }}
+exclude_files: [".gz$"]
+multiline:
+  pattern: "^# User@Host: "
+  negate: true
+  match: after
+fields:
+  source_type: mysql-slowlog
+  pipeline_id: {{.beat.pipeline_id}}

--- a/filebeat/module/mysql/slowlog/manifest.yml
+++ b/filebeat/module/mysql/slowlog/manifest.yml
@@ -1,15 +1,14 @@
-module_version: 1.0
+module_version: "1.0"
 
-vars:
-  paths:
+var:
+  - name: paths
     default:
       - /var/log/mysql/mysql-slow.log*
-      - /var/lib/mysql/{{builtin.hostname}}-slow.log
+      - /var/lib/mysql/{{.builtin.hostname}}-slow.log
     os.darwin:
-      - /usr/local/var/mysql/{{builtin.hostname}}-slow.log*
+      - /usr/local/var/mysql/{{.builtin.hostname}}-slow.log*
     os.windows:
       - "c:/programdata/MySQL/MySQL Server*/mysql-slow.log*"
 
 ingest_pipeline: ingest/pipeline.json
-prospectors:
-  - config/slowlog.yml
+prospector: config/slowlog.yml

--- a/filebeat/module/nginx/_meta/config.full.yml
+++ b/filebeat/module/nginx/_meta/config.full.yml
@@ -1,0 +1,33 @@
+- module: nginx
+  # Access logs
+  filesets.access:
+    enabled: true
+
+    # Format. Options are with_plugins and no_plugins
+    #var.pipeline: with_plugins
+
+    # Set custom paths for the log files. If left empty,
+    # Filebeat choose the path depending on your OS.
+    #var.paths:
+
+    # Use a custom Ingest Node pipeline file (advanced).
+    #ingest_pipeline:
+
+    # Prospector configuration (advanced). Any prospector configuration option
+    # can be added under this section.
+    #prospector:
+
+  # Error logs
+  filesets.error:
+    enabled: true
+
+    # Set custom paths for the log files. If left empty,
+    # Filebeat choose the path depending on your OS.
+    #var.paths:
+
+    # Use a custom Ingest Node pipeline file (advanced).
+    #ingest_pipeline:
+
+    # Prospector configuration (advanced). Any prospector configuration option
+    # can be added under this section.
+    #prospector:

--- a/filebeat/module/nginx/_meta/config.yml
+++ b/filebeat/module/nginx/_meta/config.yml
@@ -1,0 +1,1 @@
+#- module: nginx

--- a/filebeat/module/nginx/access/config/nginx-access.yml
+++ b/filebeat/module/nginx/access/config/nginx-access.yml
@@ -1,9 +1,9 @@
-- input_type: log
-  paths:
-  {%- for path in paths %}
-   - {{path}}
-  {%- endfor %}
-  exclude_files: [".gz$"]
-  fields:
-    source_type: nginx-access
-    pipeline_id: {{beat.pipeline_id}}
+input_type: log
+paths:
+{{ range $i, $path := .paths }}
+ - {{$path}}
+{{ end }}
+exclude_files: [".gz$"]
+fields:
+  source_type: nginx-access
+  pipeline_id: {{.beat.pipeline_id}}

--- a/filebeat/module/nginx/access/manifest.yml
+++ b/filebeat/module/nginx/access/manifest.yml
@@ -1,17 +1,16 @@
-module_version: 1.0
+module_version: "1.0"
 
-vars:
-  paths:
+var:
+  - name: paths
     default:
       - /var/log/nginx/access.log*
     os.darwin:
       - /usr/local/var/log/nginx/access.log*
     os.windows:
       - c:/programfiles/nginx/logs/access.log*
-  pipeline:
+  - name: pipeline
     # options: with_plugins, no_plugins
     default: with_plugins
 
-ingest_pipeline: ingest/{{pipeline}}.json
-prospectors:
-  - config/nginx-access.yml
+ingest_pipeline: ingest/{{.pipeline}}.json
+prospector: config/nginx-access.yml

--- a/filebeat/module/nginx/error/config/nginx-error.yml
+++ b/filebeat/module/nginx/error/config/nginx-error.yml
@@ -1,10 +1,9 @@
-- input_type: log
-  paths:
-  {%- for path in paths %}
-   - {{path}}
-  {%- endfor %}
-  exclude_files: [".gz$"]
-  fields:
-    source_type: nginx-error
-    pipeline_id: {{beat.pipeline_id}}
-
+input_type: log
+paths:
+{{ range $i, $path := .paths }}
+ - {{$path}}
+{{ end }}
+exclude_files: [".gz$"]
+fields:
+  source_type: nginx-error
+  pipeline_id: {{.beat.pipeline_id}}

--- a/filebeat/module/nginx/error/manifest.yml
+++ b/filebeat/module/nginx/error/manifest.yml
@@ -1,7 +1,7 @@
-module_version: 1.0
+module_version: "1.0"
 
-vars:
-  paths:
+var:
+  - name: paths
     default:
       - /var/log/nginx/error.log*
     os.darwin:
@@ -10,5 +10,4 @@ vars:
       - c:/programfiles/nginx/logs/error.log*
 
 ingest_pipeline: ingest/pipeline.json
-prospectors:
-  - config/nginx-error.yml
+prospector: config/nginx-error.yml

--- a/filebeat/module/syslog/system/config/system.yml
+++ b/filebeat/module/syslog/system/config/system.yml
@@ -1,12 +1,12 @@
-- input_type: log
-  paths:
-  {%- for path in paths %}
-   - {{path}}
-  {%- endfor %}
-  exclude_files: [".gz$"]
-  multiline:
-    pattern: "^\\s"
-    match: after
-  fields:
-    source_type: syslog-system
-    pipeline_id: {{beat.pipeline_id}}
+input_type: log
+paths:
+{{ range $i, $path := .paths }}
+ - {{$path}}
+{{ end }}
+exclude_files: [".gz$"]
+multiline:
+  pattern: "^\\s"
+  match: after
+fields:
+  source_type: syslog-system
+  pipeline_id: {{.beat.pipeline_id}}

--- a/filebeat/module/syslog/system/manifest.yml
+++ b/filebeat/module/syslog/system/manifest.yml
@@ -1,7 +1,7 @@
-module_version: 1.0
+module_version: "1.0"
 
-vars:
-  paths:
+var:
+  - name: paths
     default:
       - /var/log/messages*
       - /var/log/syslog*
@@ -10,5 +10,4 @@ vars:
     os.windows: []
 
 ingest_pipeline: ingest/pipeline.json
-prospectors:
-  - config/system.yml
+prospector: config/system.yml

--- a/filebeat/tests/system/test_modules.py
+++ b/filebeat/tests/system/test_modules.py
@@ -62,7 +62,7 @@ class Test(BaseTest):
             self.filebeat,
             "--once",
             "--modules={}".format(module),
-            "-M", "{module}.{fileset}.paths={test_file}".format(
+            "-M", "{module}.{fileset}.var.paths=[{test_file}]".format(
                 module=module, fileset=fileset, test_file=test_file),
             "--es", self.elasticsearch_url,
             "--index", index_name,


### PR DESCRIPTION
This rewrites the following parts of the prototype in Go:

* Reading of the filesets
* Evaluation of variables, including the builtin variables
* Creation of the prospectors configurations and starting them
* Overriding of the variables from the config file and from the command line
* The -module and -M CLI flags
* The ability to override variables from multiple filesets using wildcards, for example: `-M "nginx.*.var.paths=[/var/log/syslog*]"`

At this point, the system tests are still using the filebeat.py wrapper, but
only for loading the ingest node pipeline. The prospector configuration part
and the overriding of settings is done by Filebeat itself.

Part of #3159.