### PR TITLE
Fix mulitple json elements in one log entry

### DIFF
--- a/libbeat/processors/actions/decode_json_fields.go
+++ b/libbeat/processors/actions/decode_json_fields.go
@@ -165,6 +165,10 @@ func DecodeJSON(text []byte, to *interface{}) error {
 		return err
 	}
 
+	if dec.More() {
+		return errors.New("Multiple json elements found")
+	}
+
 	switch O := interface{}(*to).(type) {
 	case map[string]interface{}:
 		jsontransform.TransformNumbers(O)

--- a/libbeat/processors/actions/decode_json_fields.go
+++ b/libbeat/processors/actions/decode_json_fields.go
@@ -166,7 +166,7 @@ func DecodeJSON(text []byte, to *interface{}) error {
 	}
 
 	if dec.More() {
-		return errors.New("Multiple json elements found")
+		return errors.New("multiple json elements found")
 	}
 
 	switch O := interface{}(*to).(type) {

--- a/libbeat/processors/actions/decode_json_fields_test.go
+++ b/libbeat/processors/actions/decode_json_fields_test.go
@@ -61,6 +61,22 @@ func TestInvalidJSON(t *testing.T) {
 
 }
 
+func TestInvalidJSONMultiple(t *testing.T) {
+	input := common.MapStr{
+		"msg":      "11:38:04,323 |-INFO testing",
+		"pipeline": "us1",
+	}
+
+	actual := getActualValue(t, testConfig, input)
+
+	expected := common.MapStr{
+		"msg":      "11:38:04,323 |-INFO testing",
+		"pipeline": "us1",
+	}
+	assert.Equal(t, expected.String(), actual.String())
+
+}
+
 func TestValidJSONDepthOne(t *testing.T) {
 	input := common.MapStr{
 		"msg":      "{\"log\":\"{\\\"level\\\":\\\"info\\\"}\",\"stream\":\"stderr\",\"count\":3}",


### PR DESCRIPTION
We had a problem where non-JSON log entries were being decoded incorrectly as json, e.g.:

```
11:38:04,323 |-INFO testing
```

This is because the json.Decode would only take the first element (in this case '11') and use it as a json decoded field with no errors. This doesn't seem like the expected behaviour. It will now return an error if there are elements remaining after the first is taken.