### PR TITLE
Introduce MetaData and BulkMetadata PublishEvent options

### DIFF
--- a/libbeat/outputs/values.go
+++ b/libbeat/outputs/values.go
@@ -1,5 +1,7 @@
 package outputs
 
+import "github.com/elastic/beats/libbeat/common"
+
 // Values is a recursive key/value store for use by output plugins and publisher
 // pipeline to share context-dependent values.
 type Values struct {
@@ -39,4 +41,25 @@ func (v *Values) Get(key interface{}) (interface{}, bool) {
 		return v.value, true
 	}
 	return v.parent.Get(key)
+}
+
+// standard outputs values utilities
+
+type keyMetadata int
+
+func ValuesWithMetadata(parent *Values, meta common.MapStr) *Values {
+	return parent.Append(keyMetadata(0), meta)
+}
+
+func GetMetadata(v *Values) common.MapStr {
+	value, ok := v.Get(keyMetadata(0))
+	if !ok {
+		return nil
+	}
+
+	if m, ok := value.(common.MapStr); ok {
+		return m
+	}
+	return nil
+
 }

--- a/libbeat/publisher/client.go
+++ b/libbeat/publisher/client.go
@@ -103,27 +103,57 @@ func (c *client) PublishEvent(event common.MapStr, opts ...ClientOption) bool {
 		return false
 	}
 
-	ctx, pipeline := c.getPipeline(opts)
+	var values *outputs.Values
+	meta, ctx, pipeline := c.getPipeline(opts)
+	if len(meta) != 0 {
+		if len(meta) != 1 {
+			logp.Debug("publish", "too many metadata, pick first")
+			meta = meta[:1]
+		}
+		values = outputs.ValuesWithMetadata(nil, meta[0])
+	}
+
 	publishedEvents.Add(1)
 	return pipeline.publish(message{
 		client:  c,
 		context: ctx,
-		datum:   outputs.Data{Event: *publishEvent},
+		datum:   outputs.Data{Event: *publishEvent, Values: values},
 	})
 }
 
 func (c *client) PublishEvents(events []common.MapStr, opts ...ClientOption) bool {
-	data := make([]outputs.Data, 0, len(events))
-	for _, event := range events {
-		c.annotateEvent(event)
+	var valuesAll *outputs.Values
 
-		publishEvent := c.filterEvent(event)
-		if publishEvent != nil {
-			data = append(data, outputs.Data{Event: *publishEvent})
+	meta, ctx, pipeline := c.getPipeline(opts)
+	if len(meta) != 0 && len(events) != len(meta) {
+		if len(meta) != 1 {
+			logp.Debug("publish",
+				"Number of metadata elements does not match number of events => dropping metadata")
+			meta = nil
+		} else {
+			valuesAll = outputs.ValuesWithMetadata(nil, meta[0])
+			meta = nil
 		}
 	}
 
-	ctx, pipeline := c.getPipeline(opts)
+	data := make([]outputs.Data, 0, len(events))
+	for i, event := range events {
+		c.annotateEvent(event)
+
+		publishEvent := c.filterEvent(event)
+		if publishEvent == nil {
+			continue
+		}
+
+		evt := outputs.Data{Event: *publishEvent, Values: valuesAll}
+		if meta != nil {
+			if m := meta[i]; m != nil {
+				evt.Values = outputs.ValuesWithMetadata(valuesAll, meta[i])
+			}
+		}
+		data = append(data, evt)
+	}
+
 	if len(data) == 0 {
 		logp.Debug("filter", "No events to publish")
 		return true
@@ -186,18 +216,27 @@ func (c *client) filterEvent(event common.MapStr) *common.MapStr {
 	return &publishEvent
 }
 
-func (c *client) getPipeline(opts []ClientOption) (Context, pipeline) {
-	ctx := MakeContext(opts)
+func (c *client) getPipeline(opts []ClientOption) ([]common.MapStr, Context, pipeline) {
+	values, ctx := MakeContext(opts)
 	if ctx.Sync {
-		return ctx, c.publisher.pipelines.sync
+		return values, ctx, c.publisher.pipelines.sync
 	}
-	return ctx, c.publisher.pipelines.async
+	return values, ctx, c.publisher.pipelines.async
 }
 
-func MakeContext(opts []ClientOption) Context {
+func MakeContext(opts []ClientOption) ([]common.MapStr, Context) {
 	var ctx Context
+	var meta []common.MapStr
 	for _, opt := range opts {
-		ctx = opt(ctx)
+		var m []common.MapStr
+		m, ctx = opt(ctx)
+		if m != nil {
+			if meta == nil {
+				meta = m
+			} else {
+				meta = append(meta, m...)
+			}
+		}
 	}
-	return ctx
+	return nil, ctx
 }

--- a/libbeat/publisher/client_test.go
+++ b/libbeat/publisher/client_test.go
@@ -36,7 +36,7 @@ func TestGetClient(t *testing.T) {
 
 	for _, test := range testCases {
 		expected := reflect.ValueOf(test.out)
-		_, client := c.getPipeline(test.in)
+		_, _, client := c.getPipeline(test.in)
 		actual := reflect.ValueOf(client)
 		assert.Equal(t, expected.Pointer(), actual.Pointer())
 	}

--- a/libbeat/publisher/opts.go
+++ b/libbeat/publisher/opts.go
@@ -1,31 +1,56 @@
 package publisher
 
-import "github.com/elastic/beats/libbeat/common/op"
+import (
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/op"
+)
 
 // ClientOption allows API users to set additional options when publishing events.
-type ClientOption func(option Context) Context
+type ClientOption func(option Context) ([]common.MapStr, Context)
 
 // Guaranteed option will retry publishing the event, until send attempt have
 // been ACKed by output plugin.
-func Guaranteed(o Context) Context {
+func Guaranteed(o Context) ([]common.MapStr, Context) {
 	o.Guaranteed = true
-	return o
+	return nil, o
 }
 
 // Sync option will block the event publisher until an event has been ACKed by
 // the output plugin or failed.
-func Sync(o Context) Context {
+func Sync(o Context) ([]common.MapStr, Context) {
 	o.Sync = true
-	return o
+	return nil, o
 }
 
 func Signal(signaler op.Signaler) ClientOption {
-	return func(ctx Context) Context {
+	return func(ctx Context) ([]common.MapStr, Context) {
 		if ctx.Signal == nil {
 			ctx.Signal = signaler
 		} else {
 			ctx.Signal = op.CombineSignalers(ctx.Signal, signaler)
 		}
-		return ctx
+		return nil, ctx
 	}
+}
+
+func Metadata(m common.MapStr) ClientOption {
+	if len(m) == 0 {
+		return nilOption
+	}
+	return func(ctx Context) ([]common.MapStr, Context) {
+		return []common.MapStr{m}, ctx
+	}
+}
+
+func MetadataBatch(m []common.MapStr) ClientOption {
+	if len(m) == 0 {
+		return nilOption
+	}
+	return func(ctx Context) ([]common.MapStr, Context) {
+		return m, ctx
+	}
+}
+
+func nilOption(o Context) ([]common.MapStr, Context) {
+	return nil, o
 }

--- a/libbeat/publisher/testing/testing.go
+++ b/libbeat/publisher/testing/testing.go
@@ -60,7 +60,8 @@ func (c *ChanClient) PublishEvent(event common.MapStr, opts ...publisher.ClientO
 // PublishEvents publishes all event on the configured channel. Options will be ignored.
 // Always returns true.
 func (c *ChanClient) PublishEvents(events []common.MapStr, opts ...publisher.ClientOption) bool {
-	msg := PublishMessage{publisher.MakeContext(opts), events}
+	_, ctx := publisher.MakeContext(opts)
+	msg := PublishMessage{ctx, events}
 	select {
 	case <-c.done:
 		return false


### PR DESCRIPTION
Introduce MetaData and BulkMetadata options to PublishEvent.
The Metadata will be combines with the events to be published in order
to pass additional meta-data to the outputs.

This comment adds support for the "pipeline" meta-data element to the
elasticsearch output.