### PR TITLE
Fix for older style params to always be strings

### DIFF
--- a/winlogbeat/winlogbeat.template.json
+++ b/winlogbeat/winlogbeat.template.json
@@ -16,6 +16,18 @@
             },
             "match_mapping_type": "string"
           }
+        },
+        {
+          "params_as_strings": {
+            "match_pattern": "regex",
+            "mapping": {
+              "ignore_above": 1024,
+              "index": "not_analyzed",
+              "type": "string"
+            },
+            "match_mapping_type": "*",
+            "match": "^param\\d+$"
+          }
         }
       ],
       "properties": {


### PR DESCRIPTION
Update to the index template so that params that are older are forced to be strings no matter what es thinks they are. Fixes an issue we saw with event_data.param2 was created as type date and should be string to support other values like "stopped".

My issue is similar to what was discussed on the forum here: https://discuss.elastic.co/t/winlogbeat-5-0-mapper-parsing-exception-from-elasticsearch/57223 