### PR TITLE
Fix flaky windows filebeat test

### DIFF
--- a/filebeat/tests/system/test_registrar.py
+++ b/filebeat/tests/system/test_registrar.py
@@ -1054,6 +1054,10 @@ class Test(BaseTest):
             lambda: self.output_has(lines=1),
             max_timeout=30)
 
+        self.wait_until(
+            lambda: self.log_contains("Registry file updated. 1 states written.",
+            logfile="filebeat.log"), max_timeout=10)
+
         filebeat.check_kill_and_wait()
 
         # Check that ttl > 0 was set because of clean_inactive
@@ -1065,7 +1069,7 @@ class Test(BaseTest):
         self.render_config_template(
             path=os.path.abspath(self.working_dir) + "/log/test.log",
             clean_inactive="40s",
-            ignore_older="5s",
+            ignore_older="20s",
         )
 
         filebeat = self.start_beat(output="filebeat2.log")
@@ -1074,6 +1078,10 @@ class Test(BaseTest):
 
         self.wait_until(
             lambda: self.log_contains("Flushing spooler because of timeout. Events flushed: ",
+            logfile="filebeat2.log"), max_timeout=10)
+
+        self.wait_until(
+            lambda: self.log_contains("Registry file updated",
             logfile="filebeat2.log"), max_timeout=10)
 
         filebeat.check_kill_and_wait()


### PR DESCRIPTION
Under Windows the registry needs to be renamed and writing it takes longer. This adds some additional checks to wait until the registry is persisted.