### PR TITLE
Remove _all from our templates

### DIFF
--- a/filebeat/filebeat.template.json
+++ b/filebeat/filebeat.template.json
@@ -1,9 +1,6 @@
 {
   "mappings": {
     "_default_": {
-      "_all": {
-        "norms": false
-      },
       "_meta": {
         "version": "6.0.0-alpha1"
       },

--- a/heartbeat/heartbeat.template.json
+++ b/heartbeat/heartbeat.template.json
@@ -1,9 +1,6 @@
 {
   "mappings": {
     "_default_": {
-      "_all": {
-        "norms": false
-      },
       "_meta": {
         "version": "6.0.0-alpha1"
       },

--- a/libbeat/scripts/generate_template.py
+++ b/libbeat/scripts/generate_template.py
@@ -50,9 +50,6 @@ def fields_to_es_template(args, input, output, index, version):
         },
         "mappings": {
             "_default_": {
-                "_all": {
-                    "norms": False
-                },
                 "properties": {},
                 "_meta": {
                     "version": version,
@@ -61,10 +58,19 @@ def fields_to_es_template(args, input, output, index, version):
         }
     }
 
+    # should be done only for es5x. For es6x, any "_all" setting results
+    # in an error.
+    # TODO: https://github.com/elastic/beats/issues/3368
+    # template["mappings"]["_default"]["_all"] = {
+    #     "norms": False
+    # }
+
     if args.es2x:
         # different syntax for norms
-        template["mappings"]["_default_"]["_all"]["norms"] = {
-            "enabled": False
+        template["mappings"]["_default_"]["_all"] = {
+            "norms": {
+                "enabled": False
+            }
         }
     else:
         # For ES 5.x, increase the limit on the max number of fields.

--- a/libbeat/tests/files/template.json
+++ b/libbeat/tests/files/template.json
@@ -1,12 +1,6 @@
 {
   "mappings": {
     "_default_": {
-      "_all": {
-        "enabled": true,
-        "norms": {
-          "enabled": false
-        }
-      },
       "dynamic_templates": [
         {
           "template1": {

--- a/metricbeat/metricbeat.template.json
+++ b/metricbeat/metricbeat.template.json
@@ -1,9 +1,6 @@
 {
   "mappings": {
     "_default_": {
-      "_all": {
-        "norms": false
-      },
       "_meta": {
         "version": "6.0.0-alpha1"
       },

--- a/packetbeat/packetbeat.template.json
+++ b/packetbeat/packetbeat.template.json
@@ -1,9 +1,6 @@
 {
   "mappings": {
     "_default_": {
-      "_all": {
-        "norms": false
-      },
       "_meta": {
         "version": "6.0.0-alpha1"
       },

--- a/winlogbeat/winlogbeat.template.json
+++ b/winlogbeat/winlogbeat.template.json
@@ -1,9 +1,6 @@
 {
   "mappings": {
     "_default_": {
-      "_all": {
-        "norms": false
-      },
       "_meta": {
         "version": "6.0.0-alpha1"
       },


### PR DESCRIPTION
This is a temporary workaround for #3368. We'll need to add the `_all` setting
only in the 2x/5x versions of the templates. Should fix the builds.