### PR TITLE
Add NOTICE file to the packages

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -60,6 +60,7 @@ https://github.com/elastic/beats/compare/v5.1.1...master[Check the HEAD diff]
 - Added new flags to import_dashboards (-cacert, -cert, -key, -insecure). {pull}3139[3139] {pull}3163[3163]
 - The limit for the number of fields is increased via the mapping template. {pull}3275[3275]
 - Updated to Go 1.7.4. {pull}3277[3277]
+- Added a NOTICE file containing the notices and licenses of the dependencies. {pull}3334[3334].
 
 *Metricbeat*
 

--- a/generate/beat/{beat}/Makefile
+++ b/generate/beat/{beat}/Makefile
@@ -7,6 +7,7 @@ TEST_ENVIRONMENT=false
 ES_BEATS?=./vendor/github.com/elastic/beats
 GOPACKAGES=$(shell glide novendor)
 PREFIX?=.
+NOTICE_FILE=NOTICE
 
 # Path to the libbeat Makefile
 -include $(ES_BEATS)/libbeat/scripts/Makefile

--- a/generate/beat/{beat}/NOTICE
+++ b/generate/beat/{beat}/NOTICE
@@ -1,0 +1,5 @@
+{beat}
+Copyright 2017 {full_name}
+
+This product includes software developed by The Apache Software
+Foundation (http://www.apache.org/).

--- a/generate/metricbeat/metricset/{{cookiecutter.beat}}/Makefile
+++ b/generate/metricbeat/metricset/{{cookiecutter.beat}}/Makefile
@@ -6,6 +6,7 @@ TEST_ENVIRONMENT=false
 ES_BEATS?=./vendor/github.com/elastic/beats
 GOPACKAGES=$(shell glide novendor)
 PREFIX?=.
+NOTICE_FILE=NOTICE
 
 # Path to the libbeat Makefile
 -include $(ES_BEATS)/metricbeat/Makefile

--- a/generate/metricbeat/metricset/{{cookiecutter.beat}}/NOTICE
+++ b/generate/metricbeat/metricset/{{cookiecutter.beat}}/NOTICE
@@ -1,0 +1,5 @@
+{{cookiecutter.beat}}
+Copyright 2017 {{cookiecutter.full_name}}
+
+This product includes software developed by The Apache Software
+Foundation (http://www.apache.org/).

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -11,6 +11,7 @@ BEAT_GOPATH=$(firstword $(subst :, ,${GOPATH}))
 ES_BEATS?=..## @community_beat Must be set to ./vendor/github.com/elastic/beats
 GOPACKAGES?=${BEAT_PATH}/...## @community_beat Must be set to $(shell glide novendor)
 PACKER_TEMPLATES_DIR?=${ES_BEATS}/dev-tools/packer ## @Building Directory of templates that are used by "make package"
+NOTICE_FILE?=../NOTICE
 
 space:=$() #
 comma:=,
@@ -320,6 +321,9 @@ HOME_PREFIX?=/tmp/${BEAT_NAME}
 install-home:
 	install -d -m 755 ${HOME_PREFIX}/scripts/
 	install -m 755 ${ES_BEATS}/libbeat/scripts/migrate_beat_config_1_x_to_5_0.py ${HOME_PREFIX}/scripts/
+	if [ -a ${NOTICE_FILE} ]; then \
+		install -m 644 ${NOTICE_FILE} ${HOME_PREFIX}/; \
+	fi
 
 # Prepares for packaging. Builds binaries and creates homedir data
 .PHONY: prepare-package


### PR DESCRIPTION
Added to the home path. Also modifies the generators to include a simple
NOTICE file, which is anyway good practice for Apache licensed projects.

Tested the beat and the metricbeat generators by hand.

Follow up for #3334.