### PR TITLE
Cleanup before_build script

### DIFF
--- a/dev-tools/packer/docker/xgo-image-deb6/beats-builder/Dockerfile
+++ b/dev-tools/packer/docker/xgo-image-deb6/beats-builder/Dockerfile
@@ -14,5 +14,12 @@ RUN \
 	apt-get -o Acquire::Check-Valid-Until=false update && \
 	apt-get install -y libpcap0.8-dev
 
+
+# Old git version which does not support proxy with go get requires to fetch go-yaml directly
+RUN git clone https://github.com/go-yaml/yaml.git /go/src/gopkg.in/yaml.v2
+
+# Load gotpl which is needed for creating the templates.
+RUN go get github.com/tsg/gotpl
+
 # add patch for gopacket
 ADD gopacket_pcap.patch /gopacket_pcap.patch

--- a/dev-tools/packer/docker/xgo-image/base/build.sh
+++ b/dev-tools/packer/docker/xgo-image/base/build.sh
@@ -21,7 +21,6 @@
 # Download the canonical import path (may fail, don't allow failures beyond)
 SRC_FOLDER=$SOURCE
 
-BEAT_PATH=$1
 DST_FOLDER=`dirname $GOPATH/src/$BEAT_PATH`
 GIT_REPO=$BEAT_PATH
 
@@ -110,8 +109,8 @@ if [ "$STATIC" == "true" ]; then LDARGS=--ldflags\ \'-extldflags\ \"-static\"\';
 
 if [ -n $BEFORE_BUILD ]; then
 	chmod +x /scripts/$BEFORE_BUILD
-	echo "Execute /scripts/$BEFORE_BUILD ${BEAT_PATH}"
-	/scripts/$BEFORE_BUILD ${BEAT_PATH}
+	echo "Execute /scripts/$BEFORE_BUILD ${BEAT_PATH} ${ES_BEATS}"
+	/scripts/$BEFORE_BUILD
 fi
 
 

--- a/dev-tools/packer/docker/xgo-image/beats-builder/Dockerfile
+++ b/dev-tools/packer/docker/xgo-image/beats-builder/Dockerfile
@@ -24,6 +24,9 @@ RUN \
 	unzip `basename $WPDPACK_URL` -d /libpcap/win && \
 	rm `basename $WPDPACK_URL`
 
+# Load gotpl
+RUN go get github.com/tsg/gotpl
+
 # Add patch for gopacket.
 ADD gopacket_pcap.patch /gopacket_pcap.patch
 

--- a/dev-tools/packer/xgo-scripts/before_build.sh
+++ b/dev-tools/packer/xgo-scripts/before_build.sh
@@ -2,59 +2,15 @@
 
 set -e
 
-BEAT_PATH=/go/src/${1}
-# BEAT_NAME is in the $PACK variable
-BEAT_NAME=$PACK
-
 if [ $BEAT_NAME = "packetbeat" ]; then
 	patch -p1 < /gopacket_pcap.patch
 fi
 
-cd $BEAT_PATH
+cd $GOPATH/src/$BEAT_PATH
+
+# Files must be copied before before-build calls to allow modifications on the config files
 
 PREFIX=/build
-
-# Add data to the home directory
-mkdir -p $PREFIX/homedir
-make install-home HOME_PREFIX=$PREFIX/homedir
-
-# Compile the import_dashboards binary for the requested targets.
-if [ -d $BEAT_PATH/../libbeat/ ]; then
-	# official Beats have libbeat in the top level folder
-	LIBBEAT_PATH=$BEAT_PATH/../libbeat/
-elif [ -d $BEAT_PATH/vendor/github.com/elastic/beats/libbeat/ ]; then
-	# community Beats have libbeat vendored
-	LIBBEAT_PATH=$BEAT_PATH/vendor/github.com/elastic/beats/libbeat/
-else
-	echo "Couldn't find the libbeat location"
-	exit 1
-fi
-
-for TARGET in $TARGETS; do
-	echo "Compiling import_dashboards for $TARGET"
-	XGOOS=`echo $TARGET | cut -d '/' -f 1`
-	XGOARCH=`echo $TARGET | cut -d '/' -f 2`
-
-	GOOS=$XGOOS GOARCH=$XGOARCH go build -ldflags "-X main.beat=${BEAT_NAME}" -o $PREFIX/import_dashboards-$XGOOS-$XGOARCH $LIBBEAT_PATH/dashboards/import_dashboards.go
-done
-
-if [ -n "BUILDID" ]; then
-    echo "$BUILDID" > $PREFIX/homedir/.build_hash.txt
-fi
-
-# Install gotpl. Clone and copy needed as go-yaml is behind a proxy which doesn't work
-# with git 1.7
-git clone https://github.com/tsg/gotpl.git /go/src/github.com/tsg/gotpl
-mkdir -p /go/src/gopkg.in/yaml.v2
-
-cp -r $LIBBEAT_PATH/../vendor/gopkg.in/yaml.v2 /go/src/gopkg.in/
-go install github.com/tsg/gotpl
-
-# Append doc versions to package.yml
-cat ${LIBBEAT_PATH}/docs/version.asciidoc >> ${PREFIX}/package.yml
-# Make variable naming of doc-branch compatible with gotpl. Generate and copy README.md into homedir
-sed -i -e 's/:doc-branch/doc_branch/g' ${PREFIX}/package.yml
-/go/bin/gotpl /templates/readme.md.j2 < ${PREFIX}/package.yml > ${PREFIX}/homedir/README.md
 
 # Copy template
 cp $BEAT_NAME.template.json $PREFIX/$BEAT_NAME.template.json
@@ -75,5 +31,32 @@ cp $BEAT_NAME.yml $PREFIX/$BEAT_NAME-win.yml
 chmod 0600 $PREFIX/$BEAT_NAME-win.yml
 cp $BEAT_NAME.full.yml $PREFIX/$BEAT_NAME-win.full.yml
 
-# Contains beat specific adjustments. As it is platform specific knowledge, it should be in packer not the beats itself
+# Runs beat specific tasks which should be done before building
 PREFIX=$PREFIX make before-build
+
+# Add data to the home directory
+mkdir -p $PREFIX/homedir
+make install-home HOME_PREFIX=$PREFIX/homedir
+
+# Build dashboards
+for TARGET in $TARGETS; do
+	echo "Compiling import_dashboards for $TARGET"
+	XGOOS=`echo $TARGET | cut -d '/' -f 1`
+	XGOARCH=`echo $TARGET | cut -d '/' -f 2`
+
+	GOOS=$XGOOS GOARCH=$XGOARCH go build -ldflags "-X main.beat=${BEAT_NAME}" -o $PREFIX/import_dashboards-$XGOOS-$XGOARCH ${ES_BEATS}/libbeat/dashboards/import_dashboards.go
+done
+
+if [ -n "BUILDID" ]; then
+    echo "$BUILDID" > $PREFIX/homedir/.build_hash.txt
+fi
+
+# Append doc versions to package.yml
+cat ${ES_BEATS}/libbeat/docs/version.asciidoc >> ${PREFIX}/package.yml
+
+# Make variable naming of doc-branch compatible with gotpl. Generate and copy README.md into homedir
+sed -i -e 's/:doc-branch/doc_branch/g' ${PREFIX}/package.yml
+
+# Create README file
+/go/bin/gotpl /templates/readme.md.j2 < ${PREFIX}/package.yml > ${PREFIX}/homedir/README.md
+

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -340,8 +340,10 @@ prepare-package:
 		-e SOURCE=/source \
 		-e TARGETS=${TARGETS} \
 		-e BUILDID=${BUILDID} \
-		${BEATS_BUILDER_IMAGE} \
-		${BEAT_PATH}
+		-e ES_BEATS=${ES_BEATS} \
+		-e BEAT_PATH=${BEAT_PATH} \
+		-e BEAT_NAME=${BEAT_NAME} \
+		${BEATS_BUILDER_IMAGE}
 
 # Prepares for packaging. Builds binaries with cgo
 .PHONY: prepare-package-cgo
@@ -358,8 +360,10 @@ prepare-package-cgo:
 		-e SOURCE=/source \
 		-e TARGETS=${TARGETS} \
 		-e BUILDID=${BUILDID} \
-		${BEATS_BUILDER_IMAGE} \
-		${BEAT_PATH}
+		-e ES_BEATS=${ES_BEATS} \
+		-e BEAT_PATH=${BEAT_PATH} \
+		-e BEAT_NAME=${BEAT_NAME} \
+		${BEATS_BUILDER_IMAGE}
 
 	# linux builds on debian 6 for compatibility
 	docker run --rm \
@@ -372,8 +376,10 @@ prepare-package-cgo:
 		-e SOURCE=/source \
 		-e TARGETS=${TARGETS_OLD} \
 		-e BUILDID=${BUILDID} \
-		${BEATS_BUILDER_DEB6_IMAGE} \
-		${BEAT_PATH}
+		-e ES_BEATS=${ES_BEATS} \
+		-e BEAT_PATH=${BEAT_PATH} \
+		-e BEAT_NAME=${BEAT_NAME} \
+        ${BEATS_BUILDER_DEB6_IMAGE}
 
 # Prepares images for packaging
 .PHONY: package-setup


### PR DESCRIPTION
* Pass ES_BEATS variable to before_build.sh scripts. This removes the logic to figure out which is the correct path. ES_BEAT path should be passed relative to the BEAT_PATH.
* Move gotpl and go-yaml installation to the Dockerfile itself. This removes the requirement to install go dependencies in the scripts and moves the special handling for debian6 to the debian6 image.
* Improve naming of variables
* Pass BEAT_NAME, BEAT_PATH, ES_BEATS as environment variables. This makes it possible to use the same naming/logic in all scripts.

The above allows more flexibility on how community beats can use package. As before-build is now executed as the first step, a beat can use this step to fetch beat dependencies with `go get github.com/elastic/beats`. This would fetch the master branch for building every time and does not require to vendor it. A disadvantage of the above is that `before-build` is called twice, once for each debian version.