### PR TITLE
Fix flaky metricbeat test

### DIFF
--- a/filebeat/tests/system/test_registrar.py
+++ b/filebeat/tests/system/test_registrar.py
@@ -1196,6 +1196,10 @@ class Test(BaseTest):
             lambda: self.log_contains("Flushing spooler because of timeout. Events flushed: ", logfile="filebeat2.log"),
             max_timeout=10)
 
+        self.wait_until(
+            lambda: self.log_contains("Registry file updated",
+                                      logfile="filebeat2.log"), max_timeout=10)
+
         filebeat.check_kill_and_wait()
 
         # Check that ttl was reset correctly

--- a/metricbeat/tests/system/test_reload.py
+++ b/metricbeat/tests/system/test_reload.py
@@ -78,7 +78,7 @@ class Test(metricbeat.BaseTest):
 
         # Wait until offset for new line is updated
         self.wait_until(
-            lambda: self.log_contains("Stopping 1 modules"),
+            lambda: self.log_contains("Module stopped:"),
             max_timeout=10)
 
         lines = self.output_lines()


### PR DESCRIPTION
Log was checked for Stopping instead of Stopped which made it possible that an even still slipped through.

Add one more fix for filebeat appveyor.