### PR TITLE
Refactor docs related to GOPATH

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,9 +57,11 @@ The location where you clone is important. Please clone under the source
 directory of your `GOPATH`. If you don't have `GOPATH` already set, you can
 simply set it to your home directory (`export GOPATH=$HOME`).
 
-    $ mkdir -p ${GOPATH%%:*}/src/github.com/elastic
-    $ cd ${GOPATH%%:*}/src/github.com/elastic
+    $ mkdir -p ${GOPATH}/src/github.com/elastic
+    $ cd ${GOPATH}/src/github.com/elastic
     $ git clone https://github.com/elastic/beats.git
+
+Note: If you have multiple go paths use `${GOPATH%%:*}`instead of `${GOPATH}`.
 
 Then you can compile a particular Beat by using the Makefile. For example, for
 Packetbeat:

--- a/generate/packetbeat/tcp-protocol/README.md
+++ b/generate/packetbeat/tcp-protocol/README.md
@@ -7,8 +7,10 @@ want to create the protocol analyzer (stand-alone, within packetbeat based
 project or packetbeat itself):
 
 ```
-cookiecutter ${GOPATH%%:*}/src/github.com/elastic/beats/generate/packetbeat/tcp-protocol
+cookiecutter ${GOPATH}/src/github.com/elastic/beats/generate/packetbeat/tcp-protocol
 ```
+
+Note: If you have multiple go paths use `${GOPATH%%:*}`instead of `${GOPATH}`.
 
 This requires [python](https://www.python.org/downloads/) and [cookiecutter](https://github.com/audreyr/cookiecutter) to be installed. More details on how to install cookiecutter can be found [here](http://cookiecutter.readthedocs.io/en/latest/installation.html).
 
@@ -100,8 +102,8 @@ func echo(sock net.Conn) {
 Create analyzer skeleton from code generator template. 
 
 ```
-  $ cd ${GOPATH%%:*}/src/github.com/elastic/beats/packetbeat/protos
-  $ cookiecutter ${GOPATH%%:*}/src/github.com/elastic/beats/generate/packetbeat/tcp-protocol
+  $ cd ${GOPATH}/src/github.com/elastic/beats/packetbeat/protos
+  $ cookiecutter ${GOPATH}/src/github.com/elastic/beats/generate/packetbeat/tcp-protocol
 ```
 
 Load plugin into packetbeat by adding `_ "github.com/elastic/beats/packetbeat/protos/echo"` to packetbeat import list in `$GOPATH/src/github.com/elastic/beats/packetbeat/main.go`
@@ -117,8 +119,8 @@ packetbeat later by copying the final plugin to
 Create custom beat (e.g. github.com/<username>/pb_echo):
 
 ```
-$ mkdir -p ${GOPATH%%:*}/src/github.com/<username>/pb_echo
-$ cd ${GOPATH%%:*}/src/github.com/<username>/pb_echo
+$ mkdir -p ${GOPATH}/src/github.com/<username>/pb_echo
+$ cd ${GOPATH}/src/github.com/<username>/pb_echo
 ```
 
 Add main.go importing packetbeat + new protocol (to be added to pb_echo/proto)
@@ -150,7 +152,7 @@ Create protocol analyzer module (use name ‘echo’ for new protocol):
 ```
 $ mkdir proto
 $ cd proto
-$ cookiecutter ${GOPATH%%:*}/src/github.com/elastic/beats/generate/packetbeat/tcp-protocol
+$ cookiecutter ${GOPATH}/src/github.com/elastic/beats/generate/packetbeat/tcp-protocol
 ```
 
 ### 3 Implement application layer analyzer

--- a/libbeat/docs/newbeat.asciidoc
+++ b/libbeat/docs/newbeat.asciidoc
@@ -57,9 +57,11 @@ on a specific version of libbeat, check out the specific branch ({doc-branch} in
 
 ["source","sh",subs="attributes"]
 ----
-cd ${GOPATH%%:*}/src/github.com/elastic/beats
+cd ${GOPATH}/src/github.com/elastic/beats
 git checkout {doc-branch}
 ----
+
+Note: If you have multiple go paths use `${GOPATH%%:*}`instead of `${GOPATH}`.
 
 [[newbeat-overview]]
 === Overview
@@ -132,8 +134,8 @@ Now create a directory under $GOPATH for your repository and change to the new d
 
 [source,shell]
 --------------------
-mkdir ${GOPATH%%:*}/src/github.com/{user}
-cd ${GOPATH%%:*}/src/github.com/{user}
+mkdir ${GOPATH}/src/github.com/{user}
+cd ${GOPATH}/src/github.com/{user}
 --------------------
 
 Run python and specify the path to the Beat generator:
@@ -170,7 +172,7 @@ To fetch dependencies and set up the Beat, run:
 
 [source,shell]
 ---------
-cd ${GOPATH%%:*}/src/github.com/{user}/countbeat
+cd ${GOPATH}/src/github.com/{user}/countbeat
 make setup
 ---------
 

--- a/metricbeat/docs/developer-guide/creating-beat-from-metricbeat.asciidoc
+++ b/metricbeat/docs/developer-guide/creating-beat-from-metricbeat.asciidoc
@@ -32,10 +32,11 @@ on a specific version of libbeat, check out the specific branch ({doc-branch} in
 
 ["source","sh",subs="attributes"]
 ----
-cd ${GOPATH%%:*}/src/github.com/elastic/beats
+cd ${GOPATH}/src/github.com/elastic/beats
 git checkout {doc-branch}
 ----
 
+Note: If you have multiple go paths use `${GOPATH%%:*}`instead of `${GOPATH}`.
 
 Now change to the directory where you want to create the beat.
 This directory is normally located under `$GOPATH/src/github.com/{your-github-name}`. Inside this directory, run the command to create the beat.
@@ -48,7 +49,7 @@ Run the command:
 
 [source,bash]
 ----
-cookiecutter ${GOPATH%%:*}/src/github.com/elastic/beats/generate/metricbeat/metricset
+cookiecutter ${GOPATH}/src/github.com/elastic/beats/generate/metricbeat/metricset
 ----
 
 When prompted, enter the Beat name and path.

--- a/packetbeat/docs/new_protocol.asciidoc
+++ b/packetbeat/docs/new_protocol.asciidoc
@@ -42,10 +42,12 @@ following commands:
 
 [source,shell]
 ----------------------------------------------------------------------
-$ mkdir -p ${GOPATH%%:*}/src/github.com/elastic
-$ cd ${GOPATH%%:*}/src/github.com/elastic
+$ mkdir -p ${GOPATH}/src/github.com/elastic
+$ cd ${GOPATH}/src/github.com/elastic
 $ git clone https://github.com/elastic/beats.git
 ----------------------------------------------------------------------
+
+Note: If you have multiple go paths use `${GOPATH%%:*}`instead of `${GOPATH}`.
 
 Then you can compile it with:
 
@@ -401,7 +403,7 @@ through the publisher client interface, which is received by the `Init`
 function. The publisher client accepts structures of type `common.MapStr`, which
 is essentially a `map[string]interface{}` with a few more convenience methods
 added (see the `beats/libbeat/common` package in the https://github.com/elastic/beats[Beats GitHub repository]).
- 
+
 As an example, here is the relevant code from the Redis module:
 
 [source,go]
@@ -426,7 +428,7 @@ As an example, here is the relevant code from the Redis module:
 	if redis.SendResponse {
 		event["response"] = resp.Message
 	}
-    
+
     return event
 ----------------------------------------------------------------------
 
@@ -583,8 +585,8 @@ test cases containing the inputs and expected outputs. For an example, see the
 in the https://github.com/elastic/beats[Beats GitHub repository].
 
 You can also have unit tests that treat the whole module as a black box, calling
-its interface functions, then reading the result and checking it. This pattern 
-is especially useful for checking corner cases related to packet boundaries or 
+its interface functions, then reading the result and checking it. This pattern
+is especially useful for checking corner cases related to packet boundaries or
 correlation issues. Here is an example from the HTTP module:
 
 [source,go]


### PR DESCRIPTION
Add a note about using `${GOPATH%%:*}` for multiple go paths instead of having it directly in the source code. This makes it easier to understand what the line you are copy pasting is doing but still preserves the additional knowledge.