### PR TITLE
Fix unpacking exec cache config unpacking

### DIFF
--- a/libbeat/processors/actions/lookup/exec/config.go
+++ b/libbeat/processors/actions/lookup/exec/config.go
@@ -9,7 +9,7 @@ import (
 
 type execLookupConfig struct {
 	Key    []string           `config:"key"`
-	Cache  lutool.CacheConfig `config:"inline"`
+	Cache  lutool.CacheConfig `config:",inline"`
 	Runner execRunnerConfig   `config:",inline"`
 }
 


### PR DESCRIPTION
properly set config unpack options in tags struct, so cache configs are
properly unpacked when loading the configuration file.