### PR TITLE
Make module directory optional

### DIFF
--- a/filebeat/beater/filebeat.go
+++ b/filebeat/beater/filebeat.go
@@ -39,9 +39,13 @@ func New(b *beat.Beat, rawConfig *common.Config) (beat.Beater, error) {
 		return nil, err
 	}
 
-	moduleProspectors, err := moduleRegistry.GetProspectorConfigs()
-	if err != nil {
-		return nil, err
+	var moduleProspectors []*common.Config
+	if moduleRegistry != nil {
+		var err error
+		moduleProspectors, err = moduleRegistry.GetProspectorConfigs()
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if err := config.FetchConfigs(); err != nil {

--- a/filebeat/fileset/modules.go
+++ b/filebeat/fileset/modules.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/paths"
 )
 
@@ -82,6 +83,13 @@ func newModuleRegistry(modulesPath string,
 // NewModuleRegistry reads and loads the configured module into the registry.
 func NewModuleRegistry(moduleConfigs []*common.Config) (*ModuleRegistry, error) {
 	modulesPath := paths.Resolve(paths.Home, "module")
+
+	stat, err := os.Stat(modulesPath)
+	if err != nil || !stat.IsDir() {
+		logp.Info("Not loading modules. Module directory not found: %s")
+		return nil, nil
+	}
+
 	modulesCLIList, modulesOverrides, err := getModulesCLIConfig()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Before filebeat was stopping when module directory did not exist. Module directory should not be required.