### PR TITLE
Return empty registry if module path doesn't exist

### DIFF
--- a/filebeat/beater/filebeat.go
+++ b/filebeat/beater/filebeat.go
@@ -39,13 +39,9 @@ func New(b *beat.Beat, rawConfig *common.Config) (beat.Beater, error) {
 		return nil, err
 	}
 
-	var moduleProspectors []*common.Config
-	if moduleRegistry != nil {
-		var err error
-		moduleProspectors, err = moduleRegistry.GetProspectorConfigs()
-		if err != nil {
-			return nil, err
-		}
+	moduleProspectors, err := moduleRegistry.GetProspectorConfigs()
+	if err != nil {
+		return nil, err
 	}
 
 	if err := config.FetchConfigs(); err != nil {

--- a/filebeat/fileset/modules.go
+++ b/filebeat/fileset/modules.go
@@ -86,8 +86,8 @@ func NewModuleRegistry(moduleConfigs []*common.Config) (*ModuleRegistry, error) 
 
 	stat, err := os.Stat(modulesPath)
 	if err != nil || !stat.IsDir() {
-		logp.Info("Not loading modules. Module directory not found: %s")
-		return nil, nil
+		logp.Err("Not loading modules. Module directory not found: %s", modulesPath)
+		return &ModuleRegistry{}, nil // empty registry, no error
 	}
 
 	modulesCLIList, modulesOverrides, err := getModulesCLIConfig()

--- a/filebeat/fileset/modules_test.go
+++ b/filebeat/fileset/modules_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/paths"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -321,4 +322,23 @@ func TestMcfgFromConfig(t *testing.T) {
 			assert.Equal(t, fileset, result.Filesets[name])
 		}
 	}
+}
+
+func TestMissingModuleFolder(t *testing.T) {
+	home := paths.Paths.Home
+	paths.Paths.Home = "/no/such/path"
+	defer func() { paths.Paths.Home = home }()
+
+	configs := []*common.Config{
+		load(t, map[string]interface{}{"module": "nginx"}),
+	}
+
+	reg, err := NewModuleRegistry(configs)
+	assert.NoError(t, err)
+	assert.NotNil(t, reg)
+
+	// this should return an empty list, but no error
+	prospectors, err := reg.GetProspectorConfigs()
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(prospectors))
 }


### PR DESCRIPTION
This is a follow up for #3405, to avoid having a nil moduleRegistry. Upgraded the Info to Warn since that indicates a faulty installation.

Also adds a unit test for that case.