### PR TITLE
Make python scripts python 3 compatible

### DIFF
--- a/dev-tools/aggregate_coverage.py
+++ b/dev-tools/aggregate_coverage.py
@@ -36,12 +36,12 @@ def main(arguments):
                         stmt = int(stmt)
                         count = int (count)
                         prev_count = 0
-                        if lines.has_key(position):
+                        if position in lines:
                             (_, prev_stmt, prev_count) = lines[position]
                             assert prev_stmt == stmt
                         lines[position] = (position, stmt, prev_count + count)
 
-    for line in sorted(["%s %d %d\n" % lines[key] for key in lines.keys()]):
+    for line in sorted(["%s %d %d\n" % lines[key] for key in list(lines.keys())]):
         args.outfile.write(line)
 
 

--- a/dev-tools/export_dashboards.py
+++ b/dev-tools/export_dashboards.py
@@ -14,13 +14,13 @@ def ExportDashboards(es, regex, kibana_index, output_directory):
     try:
         reg_exp = re.compile(regex, re.IGNORECASE)
     except:
-        print("Wrong regex {}".format(regex))
+        print(("Wrong regex {}".format(regex)))
         return
 
     for doc in res['hits']['hits']:
 
         if not reg_exp.match(doc["_source"]["title"]):
-            print("Ignore dashboard", doc["_source"]["title"])
+            print(("Ignore dashboard", doc["_source"]["title"]))
             continue
 
         # save dashboard
@@ -42,7 +42,7 @@ def ExportDashboards(es, regex, kibana_index, output_directory):
                     kibana_index,
                     output_directory)
             else:
-                print("Unknown type {} in dashboard".format(panel["type"]))
+                print(("Unknown type {} in dashboard".format(panel["type"])))
 
 
 def ExportVisualization(es, visualization, kibana_index, output_directory):
@@ -83,7 +83,7 @@ def SaveJson(doc_type, doc, output_directory):
     filepath = os.path.join(dir, re.sub(r'[\>\<:"/\\\|\?\*]', '', doc['_id']) + '.json')
     with open(filepath, 'w') as f:
         json.dump(doc['_source'], f, indent=2)
-        print("Written {}".format(filepath))
+        print(("Written {}".format(filepath)))
 
 
 def main():
@@ -104,10 +104,10 @@ def main():
 
     args = parser.parse_args()
 
-    print("Export {} dashboards to {} directory".format(args.regex, args.dir))
-    print("Elasticsearch URL: {}".format(args.url))
-    print("Elasticsearch index to store Kibana's"
-          " dashboards: {}".format(args.kibana))
+    print(("Export {} dashboards to {} directory".format(args.regex, args.dir)))
+    print(("Elasticsearch URL: {}".format(args.url)))
+    print(("Elasticsearch index to store Kibana's"
+          " dashboards: {}".format(args.kibana)))
 
     es = Elasticsearch(args.url)
     ExportDashboards(es, args.regex, args.kibana, args.dir)

--- a/dev-tools/generate_notice.py
+++ b/dev-tools/generate_notice.py
@@ -8,7 +8,7 @@ import argparse
 def read_file(filename):
 
     if not os.path.isfile(filename):
-        print("File not found {}".format(filename))
+        print(("File not found {}".format(filename)))
         return ""
 
     with open(filename, 'r') as f:
@@ -92,7 +92,7 @@ if __name__ == "__main__":
                                    '**/**/**/LICENSE*')
             licenses.append(license)
 
-    print("Get the licenses available from {}".format(licenses))
+    print(("Get the licenses available from {}".format(licenses)))
     create_notice(notice, args.beat, args.copyright, licenses)
 
-    print("Available at {}\n".format(notice))
+    print(("Available at {}\n".format(notice)))

--- a/filebeat/filebeat.py
+++ b/filebeat/filebeat.py
@@ -27,7 +27,7 @@ def main():
                         help="Run filebeat with the -once flag")
 
     args = parser.parse_args()
-    print args
+    print(args)
 
     # changing directory because we use paths relative to the binary
     os.chdir(os.path.dirname(sys.argv[0]))
@@ -52,14 +52,14 @@ def load_datasets(args, modules):
     for module in modules:
         path = os.path.join("module", module)
         if not os.path.isdir(path):
-            print("Module {} not found".format(module))
+            print(("Module {} not found".format(module)))
             sys.exit(1)
-        print("Found module {} in {}".format(module, path))
+        print(("Found module {} in {}".format(module, path)))
 
         filesets = [name for name in os.listdir(path) if
                     os.path.isfile(os.path.join(path, name, "manifest.yml"))]
 
-        print("Found filesets: {}".format(filesets))
+        print(("Found filesets: {}".format(filesets)))
 
         for fileset in filesets:
             load_fileset(args, module, fileset,
@@ -72,7 +72,7 @@ def load_fileset(args, module, fileset, path):
     manifest = yaml.load(file(os.path.join(path, "manifest.yml"), "r"))
     var = evaluate_vars(args, manifest["var"], module, fileset)
     var["beat"] = dict(module=module, fileset=fileset, path=path, args=args)
-    print("Evaluated variables: {}".format(var))
+    print(("Evaluated variables: {}".format(var)))
 
     load_pipeline(var, manifest["ingest_pipeline"])
 
@@ -89,7 +89,7 @@ def evaluate_vars(args, var_in, module, fileset):
         elif sys.platform == "windows" and "os.windows" in vals:
             var[name] = vals["os.windows"]
 
-        if isinstance(var[name], basestring):
+        if isinstance(var[name], str):
             var[name] = apply_template(var[name], var)
         elif isinstance(var[name], list):
             # only supports array of strings atm
@@ -115,10 +115,10 @@ def get_builtin_vars():
 
 def load_pipeline(var, pipeline):
     path = os.path.join(var["beat"]["path"], apply_template(pipeline, var))
-    print("Loading ingest pipeline: {}".format(path))
+    print(("Loading ingest pipeline: {}".format(path)))
     var["beat"]["pipeline_id"] = var["beat"]["module"] + '-' + var["beat"]["fileset"] + \
         '-' + os.path.splitext(os.path.basename(path))[0]
-    print("Pipeline id: {}".format(var["beat"]["pipeline_id"]))
+    print(("Pipeline id: {}".format(var["beat"]["pipeline_id"])))
 
     with open(path, "r") as f:
         contents = f.read()
@@ -128,7 +128,7 @@ def load_pipeline(var, pipeline):
                              var["beat"]["pipeline_id"]),
                      data=contents)
     if r.status_code >= 300:
-        print("Error posting pipeline: {}".format(r.text))
+        print(("Error posting pipeline: {}".format(r.text)))
         sys.exit(1)
 
 
@@ -151,7 +151,7 @@ output.elasticsearch.pipeline: "%{[fields.pipeline_id]}"
     with open(fname, "w") as cfgfile:
         cfgfile.write(Template(cfg_template).render(
             dict(es=args.es)))
-        print("Wrote configuration file: {}".format(cfgfile.name))
+        print(("Wrote configuration file: {}".format(cfgfile.name)))
     os.close(fd)
 
     cmd = ["./filebeat.test", "-systemTest",
@@ -162,7 +162,7 @@ output.elasticsearch.pipeline: "%{[fields.pipeline_id]}"
     if args.once:
         cmd.extend(["-M", "*.*.prospector.close_eof=true"])
         cmd.append("-once")
-    print("Starting filebeat: " + " ".join(cmd))
+    print(("Starting filebeat: " + " ".join(cmd)))
 
     subprocess.Popen(cmd).wait()
 

--- a/filebeat/scripts/create_fileset.py
+++ b/filebeat/scripts/create_fileset.py
@@ -12,8 +12,8 @@ def generate_fileset(base_path, metricbeat_path, module, fileset):
     meta_path = fileset_path + "/_meta"
 
     if os.path.isdir(fileset_path):
-        print("Fileset already exists. Skipping creating fileset {}"
-              .format(fileset))
+        print(("Fileset already exists. Skipping creating fileset {}"
+              .format(fileset)))
         return
 
     os.makedirs(meta_path)
@@ -39,7 +39,7 @@ def generate_fileset(base_path, metricbeat_path, module, fileset):
     with open("{}/manifest.yml".format(fileset_path), "w") as f:
         f.write(content)
 
-    print("Fileset {} created.".format(fileset))
+    print(("Fileset {} created.".format(fileset)))
 
 
 def generate_module(base_path, metricbeat_path, module, fileset):
@@ -48,8 +48,8 @@ def generate_module(base_path, metricbeat_path, module, fileset):
     meta_path = module_path + "/_meta"
 
     if os.path.isdir(module_path):
-        print("Module already exists. Skipping creating module {}"
-              .format(module))
+        print(("Module already exists. Skipping creating module {}"
+              .format(module)))
         return
 
     os.makedirs(meta_path)
@@ -60,7 +60,7 @@ def generate_module(base_path, metricbeat_path, module, fileset):
     with open(meta_path + "/fields.yml", "w") as f:
         f.write(content)
 
-    print("Module {} created.".format(module))
+    print(("Module {} created.".format(module)))
 
 
 def load_file(file, module, fileset):
@@ -84,17 +84,17 @@ if __name__ == "__main__":
 
     if args.path is None:
         args.path = './'
-        print "Set default path for beat path: " + args.path
+        print("Set default path for beat path: " + args.path)
 
     if args.es_beats is None:
         args.es_beats = '../'
-        print "Set default path for es_beats path: " + args.es_beats
+        print("Set default path for es_beats path: " + args.es_beats)
 
     if args.module is None or args.module == '':
-        args.module = raw_input("Module name: ")
+        args.module = input("Module name: ")
 
     if args.fileset is None or args.fileset == '':
-        args.fileset = raw_input("Fileset name: ")
+        args.fileset = input("Fileset name: ")
 
     path = os.path.abspath(args.path)
     filebeat_path = os.path.abspath(args.es_beats + "/filebeat")

--- a/filebeat/tests/open-file-handlers/log_stdout.py
+++ b/filebeat/tests/open-file-handlers/log_stdout.py
@@ -2,7 +2,7 @@ import time
 import sys
 
 for x in range(0, 100):
-    print x
+    print(x)
     time.sleep(1)
     sys.stdout.flush()
 

--- a/filebeat/tests/system/filebeat.py
+++ b/filebeat/tests/system/filebeat.py
@@ -52,6 +52,6 @@ class BaseTest(TestCase):
         expected_fields, dict_fields = self.load_fields()
         flat = self.flatten_object(evt, dict_fields)
 
-        for key in flat.keys():
+        for key in list(flat.keys()):
             if key not in expected_fields:
                 raise Exception("Key '{}' found in event is not documented!".format(key))

--- a/filebeat/tests/system/test_crawler.py
+++ b/filebeat/tests/system/test_crawler.py
@@ -547,19 +547,19 @@ class Test(BaseTest):
         # Sample texts are from http://www.columbia.edu/~kermit/utf8.html
         encodings = [
             # golang, python, sample text
-            ("plain", "ascii", u"I can eat glass"),
+            ("plain", "ascii", "I can eat glass"),
             ("utf-8", "utf_8",
-             u"ὕαλον ϕαγεῖν δύναμαι· τοῦτο οὔ με βλάπτει."),
+             "ὕαλον ϕαγεῖν δύναμαι· τοῦτο οὔ με βλάπτει."),
             ("utf-16be", "utf_16_be",
-             u"Pot să mănânc sticlă și ea nu mă rănește."),
+             "Pot să mănânc sticlă și ea nu mă rănește."),
             ("utf-16le", "utf_16_le",
-             u"काचं शक्नोम्यत्तुम् । नोपहिनस्ति माम् ॥"),
+             "काचं शक्नोम्यत्तुम् । नोपहिनस्ति माम् ॥"),
             ("latin1", "latin1",
-             u"I kå Glas frässa, ond des macht mr nix!"),
-            ("BIG5", "big5", u"我能吞下玻璃而不傷身體。"),
-            ("gb18030", "gb18030", u"我能吞下玻璃而不傷身。體"),
-            ("euc-kr", "euckr", u" 나는 유리를 먹을 수 있어요. 그래도 아프지 않아요"),
-            ("euc-jp", "eucjp", u"私はガラスを食べられます。それは私を傷つけません。")
+             "I kå Glas frässa, ond des macht mr nix!"),
+            ("BIG5", "big5", "我能吞下玻璃而不傷身體。"),
+            ("gb18030", "gb18030", "我能吞下玻璃而不傷身。體"),
+            ("euc-kr", "euckr", " 나는 유리를 먹을 수 있어요. 그래도 아프지 않아요"),
+            ("euc-jp", "eucjp", "私はガラスを食べられます。それは私を傷つけません。")
         ]
 
         # create a file in each encoding

--- a/filebeat/tests/system/test_fields.py
+++ b/filebeat/tests/system/test_fields.py
@@ -54,7 +54,7 @@ class Test(BaseTest):
 
         output = self.read_output()
         doc = output[0]
-        print doc
+        print(doc)
         assert doc["hello"] == "world"
         assert doc["type"] == "log2"
         assert doc["timestamp"] == 2

--- a/filebeat/tests/system/test_json.py
+++ b/filebeat/tests/system/test_json.py
@@ -194,8 +194,8 @@ class Test(BaseTest):
 
         output = self.read_output()
         assert len(output) == 5
-        assert all(isinstance(o["@timestamp"], basestring) for o in output)
-        assert all(isinstance(o["type"], basestring) for o in output)
+        assert all(isinstance(o["@timestamp"], str) for o in output)
+        assert all(isinstance(o["type"], str) for o in output)
         assert output[0]["@timestamp"] == "2016-04-05T18:47:18.444Z"
 
         assert output[1]["@timestamp"] != "invalid"
@@ -237,8 +237,8 @@ class Test(BaseTest):
 
         output = self.read_output()
         assert len(output) == 3
-        assert all(isinstance(o["@timestamp"], basestring) for o in output)
-        assert all(isinstance(o["type"], basestring) for o in output)
+        assert all(isinstance(o["@timestamp"], str) for o in output)
+        assert all(isinstance(o["type"], str) for o in output)
         assert output[0]["type"] == "test"
 
         assert output[1]["type"] == "log"

--- a/filebeat/tests/system/test_load.py
+++ b/filebeat/tests/system/test_load.py
@@ -177,7 +177,7 @@ class Test(BaseTest):
 
         total_lines = number_of_files * lines_per_file
 
-        print total_lines
+        print(total_lines)
         # wait until all lines are read
         self.wait_until(
             lambda: self.output_has(lines=total_lines),

--- a/filebeat/tests/system/test_modules.py
+++ b/filebeat/tests/system/test_modules.py
@@ -12,7 +12,7 @@ import logging
 class Test(BaseTest):
     def init(self):
         self.elasticsearch_url = self.get_elasticsearch_url()
-        print("Using elasticsearch: {}".format(self.elasticsearch_url))
+        print(("Using elasticsearch: {}".format(self.elasticsearch_url)))
         self.es = Elasticsearch([self.elasticsearch_url])
         logging.getLogger("urllib3").setLevel(logging.WARNING)
         logging.getLogger("elasticsearch").setLevel(logging.ERROR)
@@ -50,7 +50,7 @@ class Test(BaseTest):
                         test_file=test_file)
 
     def run_on_file(self, module, fileset, test_file):
-        print("Testing {}/{} on {}".format(module, fileset, test_file))
+        print(("Testing {}/{} on {}".format(module, fileset, test_file)))
 
         index_name = "test-filebeat-modules"
         try:

--- a/generate/beat.py
+++ b/generate/beat.py
@@ -19,17 +19,17 @@ def read_input():
     global project_name, github_name, beat, beat_path, full_name
 
     if project_name == "":
-        project_name = raw_input("Beat Name [Examplebeat]: ") or "examplebeat"
+        project_name = input("Beat Name [Examplebeat]: ") or "examplebeat"
 
     if github_name == "":
-        github_name = raw_input("Your Github Name [your-github-name]: ") or "your-github-name"
+        github_name = input("Your Github Name [your-github-name]: ") or "your-github-name"
     beat = project_name.lower()
 
     if beat_path == "":
-        beat_path = raw_input("Beat Path [github.com/" + github_name + "]: ") or "github.com/" + github_name
+        beat_path = input("Beat Path [github.com/" + github_name + "]: ") or "github.com/" + github_name
 
     if full_name == "":
-        full_name = raw_input("Firstname Lastname: ") or "Firstname Lastname"
+        full_name = input("Firstname Lastname: ") or "Firstname Lastname"
 
 def process_file():
 

--- a/libbeat/scripts/create_packer.py
+++ b/libbeat/scripts/create_packer.py
@@ -8,10 +8,10 @@ def generate_packer(es_beats, abs_path, beat, beat_path, version):
     # create dev-tools/packer
     packer_path = abs_path + "/dev-tools/packer"
 
-    print packer_path
+    print(packer_path)
 
     if os.path.isdir(packer_path):
-        print "Dev tools already exists. Stopping..."
+        print("Dev tools already exists. Stopping...")
         return
 
     # create all directories needed
@@ -33,7 +33,7 @@ def generate_packer(es_beats, abs_path, beat, beat_path, version):
     with open(packer_path + "/beats/" + beat + ".yml", "w") as f:
         f.write(content)
 
-    print "Packer directories created"
+    print("Packer directories created")
 
 
 def load_file(file, beat, beat_path, version):
@@ -62,8 +62,8 @@ if __name__ == "__main__":
     # Removes the gopath + /src/ from the directory name to fetch the path
     beat_path = abs_path[len(gopath)+5:]
 
-    print beat_path
-    print abs_path
+    print(beat_path)
+    print(abs_path)
 
     es_beats = os.path.abspath(args.es_beats)
     generate_packer(es_beats, abs_path, args.beat, beat_path, args.version)

--- a/libbeat/scripts/generate_index_pattern.py
+++ b/libbeat/scripts/generate_index_pattern.py
@@ -38,7 +38,7 @@ def field_to_json(desc, path, output,
     global unique_fields
 
     if path in unique_fields:
-        print("ERROR: Field {} is duplicated. Please delete it and try again. Fields already are {}".format(path, ", ".join(unique_fields)))
+        print(("ERROR: Field {} is duplicated. Please delete it and try again. Fields already are {}".format(path, ", ".join(unique_fields))))
         sys.exit(1)
     else:
         unique_fields.append(path)
@@ -165,4 +165,4 @@ if __name__ == "__main__":
     with open(target_file, 'w') as f:
         f.write(output)
 
-    print ("The index pattern was created under {}".format(target_file))
+    print(("The index pattern was created under {}".format(target_file)))

--- a/libbeat/scripts/generate_makefile_doc.py
+++ b/libbeat/scripts/generate_makefile_doc.py
@@ -116,17 +116,17 @@ def substitute_variable_targets(targets, variables):
 def print_help(categories, categories_set):
     column_size = max(len(rule["name"]) for category in categories_set for rule in categories[category])
     for category in categories_set:
-        print ("\n{}:".format(category))
+        print(("\n{}:".format(category)))
         for rule in categories[category]:
             if "name" in rule:
                 name = rule["name"]
             if "varname" in rule:
                 name = rule["varname"]
             default = rule["default"]
-            print ("\t{target: <{fill}}\t{doc}.{default}".format(
+            print(("\t{target: <{fill}}\t{doc}.{default}".format(
                 target=rule["name"], fill=column_size,
                  doc=rule["doc"],
-            default=(" Default: {}".format(default) if default else "")))
+            default=(" Default: {}".format(default) if default else ""))))
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(

--- a/libbeat/scripts/generate_template.py
+++ b/libbeat/scripts/generate_template.py
@@ -31,9 +31,9 @@ def fields_to_es_template(args, input, output, index, version):
         return
 
     # Each template needs defaults
-    if "defaults" not in docs.keys():
-        print("No defaults are defined. Each template needs at" +
-              " least defaults defined.")
+    if "defaults" not in list(docs.keys()):
+        print(("No defaults are defined. Each template needs at" +
+              " least defaults defined."))
         return
 
     defaults = docs["defaults"]
@@ -154,7 +154,7 @@ def dedot(group):
             fields.append(dedot(field))
         else:
             fields.append(field)
-    for _, field in dedotted.items():
+    for _, field in list(dedotted.items()):
         fields.append(dedot(field))
     group["fields"] = fields
     return group
@@ -185,7 +185,7 @@ def fill_field_properties(args, field, defaults, path):
     properties = {}
     dynamic_templates = []
 
-    for key in defaults.keys():
+    for key in list(defaults.keys()):
         if key not in field:
             field[key] = defaults[key]
 

--- a/libbeat/scripts/migrate_beat_config_1_x_to_5_0.py
+++ b/libbeat/scripts/migrate_beat_config_1_x_to_5_0.py
@@ -110,7 +110,7 @@ def migrate_tls_settings(content):
 
         v_start = get_old_tls_version(v_start, "1.0")
         v_end = get_old_tls_version(v_end, "1.2")
-        versions = (ssl_versions_new[i] for i in xrange(v_start, v_end+1))
+        versions = (ssl_versions_new[i] for i in range(v_start, v_end+1))
 
         line = indent * ' ' + ('#' if commented_out else '')
         line += "supported_protocols:"
@@ -227,7 +227,7 @@ def main():
         print(content)
     else:
         os.rename(args.file, args.file + ".bak")
-        print("Backup file created: {}".format(args.file + ".bak"))
+        print(("Backup file created: {}".format(args.file + ".bak")))
         with open(args.file, "w") as f:
             f.write(content)
 

--- a/libbeat/tests/system/beat/beat.py
+++ b/libbeat/tests/system/beat/beat.py
@@ -101,7 +101,7 @@ class TestCase(unittest.TestCase):
 
         # Create build path
         build_dir = "../../build"
-        if 'BUILD_DIR' in os.environ.keys() and os.environ['BUILD_DIR'] != '':
+        if 'BUILD_DIR' in list(os.environ.keys()) and os.environ['BUILD_DIR'] != '':
             build_dir = os.environ['BUILD_DIR']
         self.build_path = build_dir + "/system-tests/"
 
@@ -208,7 +208,7 @@ class TestCase(unittest.TestCase):
                 try:
                     jsons.append(self.flatten_object(json.loads(line), []))
                 except:
-                    print("Fail to load the json {}".format(line))
+                    print(("Fail to load the json {}".format(line)))
                     raise
 
         self.all_have_fields(jsons, required_fields or BEAT_REQUIRED_FIELDS)
@@ -371,7 +371,7 @@ class TestCase(unittest.TestCase):
         given list of expected fields.
         """
         for o in objs:
-            for key in o.keys():
+            for key in list(o.keys()):
                 if key not in dict_fields and key not in expected_fields:
                     raise Exception("Unexpected key '{}' found"
                                     .format(key))
@@ -430,7 +430,7 @@ class TestCase(unittest.TestCase):
 
     def flatten_object(self, obj, dict_fields, prefix=""):
         result = {}
-        for key, value in obj.items():
+        for key, value in list(obj.items()):
             if isinstance(value, dict) and prefix + key not in dict_fields:
                 new_prefix = prefix + key + "."
                 result.update(self.flatten_object(value, dict_fields,

--- a/libbeat/tests/system/test_dashboard.py
+++ b/libbeat/tests/system/test_dashboard.py
@@ -27,7 +27,7 @@ class Test(BaseTest):
             if os.name == "nt":
                 command = "go run ..\..\dashboards\import_dashboards.go -es http:\\"+self.get_elasticsearch_host() + " -dir ..\..\..\\" + beat + "\_meta\kibana"
 
-            print command
+            print(command)
             p = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             content, err = p.communicate()
 
@@ -61,7 +61,7 @@ class Test(BaseTest):
             if os.name == "nt":
                 command = "python ..\..\..\dev-tools/export_dashboards.py --url http://"+ self.get_elasticsearch_host() + " --dir " + path + " --regex " + beat + "-*"
 
-            print command
+            print(command)
 
             p = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             content, err = p.communicate()

--- a/metricbeat/scripts/config_collector.py
+++ b/metricbeat/scripts/config_collector.py
@@ -63,7 +63,7 @@ def collect(beat_name, beat_path, full=False):
 
         config_yml += "\n"
     # output string so it can be concatenated
-    print config_yml
+    print(config_yml)
 
 
 # Makes sure every title line is 79 + newline chars long

--- a/metricbeat/scripts/create_metricset.py
+++ b/metricbeat/scripts/create_metricset.py
@@ -12,8 +12,8 @@ def generate_metricset(base_path, metricbeat_path, module, metricset):
     meta_path = metricset_path + "/_meta"
 
     if os.path.isdir(metricset_path):
-        print("Metricset already exists. Skipping creating metricset {}"
-              .format(metricset))
+        print(("Metricset already exists. Skipping creating metricset {}"
+              .format(metricset)))
         return
 
     os.makedirs(meta_path)
@@ -36,7 +36,7 @@ def generate_metricset(base_path, metricbeat_path, module, metricset):
     with open(meta_path + "/data.json", "w") as f:
         f.write(content)
 
-    print("Metricset {} created.".format(metricset))
+    print(("Metricset {} created.".format(metricset)))
 
 
 def generate_module(base_path, metricbeat_path, module, metricset):
@@ -45,8 +45,8 @@ def generate_module(base_path, metricbeat_path, module, metricset):
     meta_path = module_path + "/_meta"
 
     if os.path.isdir(module_path):
-        print("Module already exists. Skipping creating module {}"
-              .format(module))
+        print(("Module already exists. Skipping creating module {}"
+              .format(module)))
         return
 
     os.makedirs(meta_path)
@@ -69,7 +69,7 @@ def generate_module(base_path, metricbeat_path, module, metricset):
     with open(module_path + "/doc.go", "w") as f:
         f.write(content)
 
-    print("Module {} created.".format(module))
+    print(("Module {} created.".format(module)))
 
 
 def load_file(file, module, metricset):
@@ -94,17 +94,17 @@ if __name__ == "__main__":
 
     if args.path is None:
         args.path = './'
-        print "Set default path for beat path: " + args.path
+        print("Set default path for beat path: " + args.path)
 
     if args.es_beats is None:
         args.es_beats = '../'
-        print "Set default path for es_beats path: " + args.es_beats
+        print("Set default path for es_beats path: " + args.es_beats)
 
     if args.module is None or args.module == '':
-        args.module = raw_input("Module name: ")
+        args.module = input("Module name: ")
 
     if args.metricset is None or args.metricset == '':
-        args.metricset = raw_input("Metricset name: ")
+        args.metricset = input("Metricset name: ")
 
     path = os.path.abspath(args.path)
     metricbeat_path = os.path.abspath(args.es_beats + "/metricbeat")

--- a/metricbeat/scripts/docs_collector.py
+++ b/metricbeat/scripts/docs_collector.py
@@ -136,11 +136,11 @@ For a description of each field in the metricset, see the
             f.write(module_file)
 
     module_list_output = generated_note
-    for m, title in sorted(modules_list.iteritems()):
+    for m, title in sorted(modules_list.items()):
         module_list_output += "  * <<metricbeat-module-" + m + "," + title + ">>\n"
 
     module_list_output += "\n\n--\n\n"
-    for m, title in sorted(modules_list.iteritems()):
+    for m, title in sorted(modules_list.items()):
         module_list_output += "include::modules/"+ m + ".asciidoc[]\n"
 
     # Write module link list

--- a/metricbeat/scripts/fields_collector.py
+++ b/metricbeat/scripts/fields_collector.py
@@ -48,7 +48,7 @@ def collect():
             fields_yml += "\n"
 
     # output string so it can be concatenated
-    print fields_yml
+    print(fields_yml)
 
 if __name__ == "__main__":
     collect()

--- a/metricbeat/scripts/generate_imports.py
+++ b/metricbeat/scripts/generate_imports.py
@@ -41,7 +41,7 @@ def generate(go_beat_path):
     list_file += ")"
 
     # output string so it can be concatenated
-    print list_file
+    print(list_file)
 
 if __name__ == "__main__":
     # First argument is the beat path under GOPATH.

--- a/metricbeat/tests/system/metricbeat.py
+++ b/metricbeat/tests/system/metricbeat.py
@@ -24,7 +24,7 @@ class BaseTest(TestCase):
         expected_fields, _ = self.load_fields()
         flat = self.flatten_object(evt, [])
 
-        for key in flat.keys():
+        for key in list(flat.keys()):
             if key not in expected_fields:
                 raise Exception("Key '{}' found in event is not documented!".format(key))
 

--- a/metricbeat/tests/system/test_apache.py
+++ b/metricbeat/tests/system/test_apache.py
@@ -2,7 +2,7 @@ import os
 import metricbeat
 import unittest
 from nose.plugins.attrib import attr
-import urllib2
+import urllib.request, urllib.error, urllib.parse
 import time
 
 APACHE_FIELDS = metricbeat.COMMON_FIELDS + ["apache"]
@@ -35,7 +35,7 @@ class ApacheStatusTest(metricbeat.BaseTest):
         found = False
         # Waits until CPULoad is part of the status
         while found == False:
-            res = urllib2.urlopen(hosts[0] + "/server-status?auto").read()
+            res = urllib.request.urlopen(hosts[0] + "/server-status?auto").read()
             if "CPULoad"  in res:
                 found = True
             time.sleep(0.5)
@@ -53,10 +53,10 @@ class ApacheStatusTest(metricbeat.BaseTest):
         evt = output[0]
 
         # Verify the required fields are present.
-        self.assertItemsEqual(self.de_dot(APACHE_FIELDS), evt.keys())
+        self.assertItemsEqual(self.de_dot(APACHE_FIELDS), list(evt.keys()))
         apache_status = evt["apache"]["status"]
-        self.assertItemsEqual(self.de_dot(APACHE_STATUS_FIELDS), apache_status.keys())
-        self.assertItemsEqual(self.de_dot(CPU_FIELDS), apache_status["cpu"].keys())
+        self.assertItemsEqual(self.de_dot(APACHE_STATUS_FIELDS), list(apache_status.keys()))
+        self.assertItemsEqual(self.de_dot(CPU_FIELDS), list(apache_status["cpu"].keys()))
         # There are more fields that could be checked.
 
         # Verify all fields present are documented.

--- a/metricbeat/tests/system/test_config.py
+++ b/metricbeat/tests/system/test_config.py
@@ -2,7 +2,7 @@ import os
 import metricbeat
 import unittest
 from nose.plugins.attrib import attr
-import urllib2
+import urllib.request, urllib.error, urllib.parse
 import time
 
 
@@ -53,13 +53,13 @@ class ConfigTest(metricbeat.BaseTest):
             fullLine = fullLog[i]
 
             if shortLine not in fullLog:
-                print shortLine
-                print fullLine
+                print(shortLine)
+                print(fullLine)
                 same = False
 
             if fullLine not in shortLog:
-                print shortLine
-                print fullLine
+                print(shortLine)
+                print(fullLine)
                 same = False
 
         assert same == True

--- a/metricbeat/tests/system/test_haproxy.py
+++ b/metricbeat/tests/system/test_haproxy.py
@@ -29,7 +29,7 @@ class Test(metricbeat.BaseTest):
         self.assertEqual(len(output), 1)
         evt = output[0]
 
-        self.assertItemsEqual(self.de_dot(HAPROXY_FIELDS), evt.keys(), evt)
+        self.assertItemsEqual(self.de_dot(HAPROXY_FIELDS), list(evt.keys()), evt)
 
         self.assert_fields_are_documented(evt)
 
@@ -56,8 +56,8 @@ class Test(metricbeat.BaseTest):
         self.assertGreater(len(output), 0)
 
         for evt in output:
-            print evt
-            self.assertItemsEqual(self.de_dot(HAPROXY_FIELDS), evt.keys(), evt)
+            print(evt)
+            self.assertItemsEqual(self.de_dot(HAPROXY_FIELDS), list(evt.keys()), evt)
             self.assert_fields_are_documented(evt)
 
     def get_hosts(self):

--- a/metricbeat/tests/system/test_kafka.py
+++ b/metricbeat/tests/system/test_kafka.py
@@ -23,7 +23,7 @@ class Test(metricbeat.BaseTest):
         output = self.read_output_json()
         self.assertTrue(len(output) >= 1)
         evt = output[0]
-        print evt
+        print(evt)
 
         self.assert_fields_are_documented(evt)
 

--- a/metricbeat/tests/system/test_mongodb.py
+++ b/metricbeat/tests/system/test_mongodb.py
@@ -32,7 +32,7 @@ class Test(metricbeat.BaseTest):
         self.assertEqual(len(output), 1)
         evt = output[0]
 
-        self.assertItemsEqual(self.de_dot(MONGODB_FIELDS), evt.keys())
+        self.assertItemsEqual(self.de_dot(MONGODB_FIELDS), list(evt.keys()))
 
         self.assert_fields_are_documented(evt)
 

--- a/metricbeat/tests/system/test_mysql.py
+++ b/metricbeat/tests/system/test_mysql.py
@@ -35,7 +35,7 @@ class Test(metricbeat.BaseTest):
         self.assertEqual(len(output), 1)
         evt = output[0]
 
-        self.assertItemsEqual(self.de_dot(MYSQL_FIELDS), evt.keys())
+        self.assertItemsEqual(self.de_dot(MYSQL_FIELDS), list(evt.keys()))
         mysql_info = evt["mysql"]["status"]
 
         self.assert_fields_are_documented(evt)

--- a/metricbeat/tests/system/test_postgresql.py
+++ b/metricbeat/tests/system/test_postgresql.py
@@ -13,7 +13,7 @@ class Test(metricbeat.BaseTest):
 
         for evt in output:
             top_level_fields = metricbeat.COMMON_FIELDS + ["postgresql"]
-            self.assertItemsEqual(self.de_dot(top_level_fields), evt.keys())
+            self.assertItemsEqual(self.de_dot(top_level_fields), list(evt.keys()))
 
             self.assert_fields_are_documented(evt)
 

--- a/metricbeat/tests/system/test_processors.py
+++ b/metricbeat/tests/system/test_processors.py
@@ -31,17 +31,17 @@ class TestProcessors(metricbeat.BaseTest):
         self.assert_fields_are_documented(evt)
 
         print(evt)
-        print(evt.keys())
+        print((list(evt.keys())))
         self.assertItemsEqual(self.de_dot([
             'beat', '@timestamp', 'system', 'metricset.module',
             'metricset.rtt', 'type', 'metricset.name'
-        ]), evt.keys())
+        ]), list(evt.keys()))
         cpu = evt["system"]["cpu"]
-        print(cpu.keys())
+        print((list(cpu.keys())))
         self.assertItemsEqual(self.de_dot([
             "system", "cores", "user", "softirq", "iowait",
             "idle", "irq", "steal", "nice"
-        ]), cpu.keys())
+        ]), list(cpu.keys()))
 
 
     def test_dropfields_with_condition(self):

--- a/metricbeat/tests/system/test_prometheus.py
+++ b/metricbeat/tests/system/test_prometheus.py
@@ -29,7 +29,7 @@ class Test(metricbeat.BaseTest):
         self.assertEqual(len(output), 1)
         evt = output[0]
 
-        self.assertItemsEqual(self.de_dot(PROMETHEUS_FIELDS), evt.keys(), evt)
+        self.assertItemsEqual(self.de_dot(PROMETHEUS_FIELDS), list(evt.keys()), evt)
 
         self.assert_fields_are_documented(evt)
 

--- a/metricbeat/tests/system/test_redis.py
+++ b/metricbeat/tests/system/test_redis.py
@@ -43,11 +43,11 @@ class Test(metricbeat.BaseTest):
         self.assertEqual(len(output), 1)
         evt = output[0]
 
-        self.assertItemsEqual(self.de_dot(REDIS_FIELDS), evt.keys())
+        self.assertItemsEqual(self.de_dot(REDIS_FIELDS), list(evt.keys()))
         redis_info = evt["redis"]["info"]
-        self.assertItemsEqual(self.de_dot(REDIS_INFO_FIELDS), redis_info.keys())
-        self.assertItemsEqual(self.de_dot(CLIENTS_FIELDS), redis_info["clients"].keys())
-        self.assertItemsEqual(self.de_dot(CPU_FIELDS), redis_info["cpu"].keys())
+        self.assertItemsEqual(self.de_dot(REDIS_INFO_FIELDS), list(redis_info.keys()))
+        self.assertItemsEqual(self.de_dot(CLIENTS_FIELDS), list(redis_info["clients"].keys()))
+        self.assertItemsEqual(self.de_dot(CPU_FIELDS), list(redis_info["cpu"].keys()))
         self.assert_fields_are_documented(evt)
 
     @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
@@ -79,9 +79,9 @@ class Test(metricbeat.BaseTest):
         self.assertEqual(len(output), 1)
         evt = output[0]
 
-        self.assertItemsEqual(self.de_dot(REDIS_FIELDS), evt.keys())
+        self.assertItemsEqual(self.de_dot(REDIS_FIELDS), list(evt.keys()))
         redis_info = evt["redis"]["keyspace"]
-        self.assertItemsEqual(self.de_dot(REDIS_KEYSPACE_FIELDS), redis_info.keys())
+        self.assertItemsEqual(self.de_dot(REDIS_KEYSPACE_FIELDS), list(redis_info.keys()))
         self.assert_fields_are_documented(evt)
 
     @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
@@ -112,12 +112,12 @@ class Test(metricbeat.BaseTest):
         self.assertEqual(len(output), 1)
         evt = output[0]
 
-        self.assertItemsEqual(self.de_dot(REDIS_FIELDS), evt.keys())
+        self.assertItemsEqual(self.de_dot(REDIS_FIELDS), list(evt.keys()))
         redis_info = evt["redis"]["info"]
-        print redis_info
-        self.assertItemsEqual(fields, redis_info.keys())
-        self.assertItemsEqual(self.de_dot(CLIENTS_FIELDS), redis_info["clients"].keys())
-        self.assertItemsEqual(self.de_dot(CPU_FIELDS), redis_info["cpu"].keys())
+        print(redis_info)
+        self.assertItemsEqual(fields, list(redis_info.keys()))
+        self.assertItemsEqual(self.de_dot(CLIENTS_FIELDS), list(redis_info["clients"].keys()))
+        self.assertItemsEqual(self.de_dot(CPU_FIELDS), list(redis_info["cpu"].keys()))
 
     def get_hosts(self):
         return [os.getenv('REDIS_HOST', 'localhost') + ':' +

--- a/metricbeat/tests/system/test_system.py
+++ b/metricbeat/tests/system/test_system.py
@@ -66,7 +66,7 @@ class SystemTest(metricbeat.BaseTest):
         self.assert_fields_are_documented(evt)
 
         cpu = evt["system"]["cpu"]
-        self.assertItemsEqual(self.de_dot(SYSTEM_CPU_FIELDS), cpu.keys())
+        self.assertItemsEqual(self.de_dot(SYSTEM_CPU_FIELDS), list(cpu.keys()))
 
     @unittest.skipUnless(re.match("(?i)win|linux|darwin|freebsd|openbsd", sys.platform), "os")
     def test_cpu_ticks_option(self):
@@ -95,7 +95,7 @@ class SystemTest(metricbeat.BaseTest):
         for evt in output:
             self.assert_fields_are_documented(evt)
             cpuStats = evt["system"]["cpu"]
-            self.assertItemsEqual(self.de_dot(SYSTEM_CPU_FIELDS_ALL), cpuStats.keys())
+            self.assertItemsEqual(self.de_dot(SYSTEM_CPU_FIELDS_ALL), list(cpuStats.keys()))
 
     @unittest.skipUnless(re.match("(?i)win|linux|darwin|freebsd|openbsd", sys.platform), "os")
     def test_core(self):
@@ -121,7 +121,7 @@ class SystemTest(metricbeat.BaseTest):
         for evt in output:
             self.assert_fields_are_documented(evt)
             core = evt["system"]["core"]
-            self.assertItemsEqual(self.de_dot(SYSTEM_CORE_FIELDS), core.keys())
+            self.assertItemsEqual(self.de_dot(SYSTEM_CORE_FIELDS), list(core.keys()))
 
     @unittest.skipUnless(re.match("(?i)win|linux|darwin|freebsd|openbsd", sys.platform), "os")
     def test_core_with_cpu_ticks(self):
@@ -150,7 +150,7 @@ class SystemTest(metricbeat.BaseTest):
         for evt in output:
             self.assert_fields_are_documented(evt)
             core = evt["system"]["core"]
-            self.assertItemsEqual(self.de_dot(SYSTEM_CORE_FIELDS_ALL), core.keys())
+            self.assertItemsEqual(self.de_dot(SYSTEM_CORE_FIELDS_ALL), list(core.keys()))
 
     @unittest.skipUnless(re.match("(?i)linux|darwin|freebsd|openbsd", sys.platform), "os")
     def test_load(self):
@@ -176,7 +176,7 @@ class SystemTest(metricbeat.BaseTest):
         self.assert_fields_are_documented(evt)
 
         cpu = evt["system"]["load"]
-        self.assertItemsEqual(self.de_dot(SYSTEM_LOAD_FIELDS), cpu.keys())
+        self.assertItemsEqual(self.de_dot(SYSTEM_LOAD_FIELDS), list(cpu.keys()))
 
     @unittest.skipUnless(re.match("(?i)win|linux|freebsd", sys.platform), "os")
     def test_diskio(self):
@@ -202,7 +202,7 @@ class SystemTest(metricbeat.BaseTest):
         for evt in output:
             self.assert_fields_are_documented(evt)
             diskio = evt["system"]["diskio"]
-            self.assertItemsEqual(self.de_dot(SYSTEM_DISKIO_FIELDS), diskio.keys())
+            self.assertItemsEqual(self.de_dot(SYSTEM_DISKIO_FIELDS), list(diskio.keys()))
 
     @unittest.skipUnless(re.match("(?i)win|linux|darwin|freebsd|openbsd", sys.platform), "os")
     def test_filesystem(self):
@@ -228,7 +228,7 @@ class SystemTest(metricbeat.BaseTest):
         for evt in output:
             self.assert_fields_are_documented(evt)
             filesystem = evt["system"]["filesystem"]
-            self.assertItemsEqual(self.de_dot(SYSTEM_FILESYSTEM_FIELDS), filesystem.keys())
+            self.assertItemsEqual(self.de_dot(SYSTEM_FILESYSTEM_FIELDS), list(filesystem.keys()))
 
     @unittest.skipUnless(re.match("(?i)win|linux|darwin|freebsd|openbsd", sys.platform), "os")
     def test_fsstat(self):
@@ -254,7 +254,7 @@ class SystemTest(metricbeat.BaseTest):
         self.assert_fields_are_documented(evt)
 
         fsstat = evt["system"]["fsstat"]
-        self.assertItemsEqual(SYSTEM_FSSTAT_FIELDS, fsstat.keys())
+        self.assertItemsEqual(SYSTEM_FSSTAT_FIELDS, list(fsstat.keys()))
 
     @unittest.skipUnless(re.match("(?i)win|linux|darwin|freebsd|openbsd", sys.platform), "os")
     def test_memory(self):
@@ -280,7 +280,7 @@ class SystemTest(metricbeat.BaseTest):
         self.assert_fields_are_documented(evt)
 
         memory = evt["system"]["memory"]
-        self.assertItemsEqual(self.de_dot(SYSTEM_MEMORY_FIELDS), memory.keys())
+        self.assertItemsEqual(self.de_dot(SYSTEM_MEMORY_FIELDS), list(memory.keys()))
 
         # Check that percentages are calculated.
         mem = memory
@@ -317,7 +317,7 @@ class SystemTest(metricbeat.BaseTest):
         for evt in output:
             self.assert_fields_are_documented(evt)
             network = evt["system"]["network"]
-            self.assertItemsEqual(self.de_dot(SYSTEM_NETWORK_FIELDS), network.keys())
+            self.assertItemsEqual(self.de_dot(SYSTEM_NETWORK_FIELDS), list(network.keys()))
 
     @unittest.skipUnless(re.match("(?i)win|linux|darwin|freebsd", sys.platform), "os")
     def test_process(self):
@@ -364,7 +364,7 @@ class SystemTest(metricbeat.BaseTest):
             if fd is not None:
                 found_fd = True
 
-            self.assertItemsEqual(SYSTEM_PROCESS_FIELDS, process.keys())
+            self.assertItemsEqual(SYSTEM_PROCESS_FIELDS, list(process.keys()))
 
         self.assertTrue(found_cmdline, "cmdline not found in any process events")
 
@@ -396,8 +396,8 @@ class SystemTest(metricbeat.BaseTest):
 
         assert re.match("(?i)metricbeat.test(.exe)?", output["system.process.name"])
         assert re.match("(?i).*metricbeat.test(.exe)? -systemTest", output["system.process.cmdline"])
-        assert isinstance(output["system.process.state"], basestring)
-        assert isinstance(output["system.process.cpu.start_time"], basestring)
+        assert isinstance(output["system.process.state"], str)
+        assert isinstance(output["system.process.cpu.start_time"], str)
         self.check_username(output["system.process.username"])
 
     def check_username(self, observed, expected = None):
@@ -406,7 +406,7 @@ class SystemTest(metricbeat.BaseTest):
 
         if os.name == 'nt':
             parts = observed.split("\\", 2)
-            assert len(parts) == 2, "Expected proc.username to be of form DOMAIN\username, but was %s" % observed
+            assert len(parts) == 2, "Expected proc.username to be of form DOMAIN\\username, but was %s" % observed
             observed = parts[1]
 
         assert expected == observed, "proc.username = %s, but expected %s" % (observed, expected)

--- a/metricbeat/tests/system/test_zookeeper.py
+++ b/metricbeat/tests/system/test_zookeeper.py
@@ -36,7 +36,7 @@ class ZooKeeperMntrTest(metricbeat.BaseTest):
         self.assertEqual(len(output), 1)
         evt = output[0]
 
-        self.assertItemsEqual(self.de_dot(ZK_FIELDS), evt.keys())
+        self.assertItemsEqual(self.de_dot(ZK_FIELDS), list(evt.keys()))
         zk_mntr = evt["zookeeper"]["mntr"]
 
         zk_mntr.pop("pending_syncs", None)
@@ -45,7 +45,7 @@ class ZooKeeperMntrTest(metricbeat.BaseTest):
         zk_mntr.pop("max_file_descriptor_count", None)
         zk_mntr.pop("followers", None)
 
-        self.assertItemsEqual(self.de_dot(MNTR_FIELDS), zk_mntr.keys())
+        self.assertItemsEqual(self.de_dot(MNTR_FIELDS), list(zk_mntr.keys()))
 
         self.assert_fields_are_documented(evt)
 

--- a/packetbeat/tests/system/gen/memcache/tcp_counter_ops.py
+++ b/packetbeat/tests/system/gen/memcache/tcp_counter_ops.py
@@ -9,7 +9,7 @@ def run(mc):
     mc.set('cnt', 0)
     mc.incr('cnt', 2)
     mc.decr('cnt', 5)
-    print(mc.get('cnt'))
+    print((mc.get('cnt')))
 
 if __name__ == '__main__':
     mc.run_tcp(run)

--- a/packetbeat/tests/system/gen/memcache/tcp_delete.py
+++ b/packetbeat/tests/system/gen/memcache/tcp_delete.py
@@ -8,7 +8,7 @@ def run(mc):
 
     mc.set('key', 'abc')
     mc.delete('key')
-    print(mc.get('key'))
+    print((mc.get('key')))
 
 if __name__ == '__main__':
     mc.run_tcp(run)

--- a/packetbeat/tests/system/gen/memcache/tcp_stats.py
+++ b/packetbeat/tests/system/gen/memcache/tcp_stats.py
@@ -6,8 +6,8 @@ import mc
 def run(mc):
     print('run')
     mc.set('key', 'abc')
-    print(mc.get('key'))
-    print(mc.get_stats())
+    print((mc.get('key')))
+    print((mc.get_stats()))
 
 if __name__ == '__main__':
     mc.run_tcp(run)

--- a/packetbeat/tests/system/test_0001_mysql_spaces.py
+++ b/packetbeat/tests/system/test_0001_mysql_spaces.py
@@ -31,5 +31,5 @@ class Test(BaseTest):
         assert objs[5]["status"] == "OK"
         assert objs[5]["bytes_out"] == 118
 
-        assert all(["bytes_in" in o.keys() for o in objs])
-        assert all(["bytes_out" in o.keys() for o in objs])
+        assert all(["bytes_in" in list(o.keys()) for o in objs])
+        assert all(["bytes_out" in list(o.keys()) for o in objs])

--- a/packetbeat/tests/system/test_0006_wsgi.py
+++ b/packetbeat/tests/system/test_0006_wsgi.py
@@ -108,7 +108,7 @@ class Test(BaseTest):
         assert len(o["http.request.headers"]) > 0
         assert len(o["http.response.headers"]) > 0
         assert isinstance(o["http.response.headers"]["set-cookie"],
-                          basestring)
+                          str)
 
         self.render_config_template(
             http_ports=[8888],
@@ -138,7 +138,7 @@ class Test(BaseTest):
         objs = self.read_output()
         assert len(objs) == 1
         o = objs[0]
-        print o
+        print(o)
 
         assert len(o["http.request.headers"]) > 0
         assert len(o["http.response.headers"]) > 0

--- a/packetbeat/tests/system/test_0013_redis_basic.py
+++ b/packetbeat/tests/system/test_0013_redis_basic.py
@@ -39,9 +39,9 @@ class Test(BaseTest):
         # the rest should be successful
         assert all([o["status"] == "OK" for o in objs[3:]])
         assert all(["redis.return_value" in o for o in objs[3:]])
-        assert all([isinstance(o["method"], basestring) for o in objs[3:]])
-        assert all([isinstance(o["resource"], basestring) for o in objs[3:]])
-        assert all([isinstance(o["query"], basestring) for o in objs[3:]])
+        assert all([isinstance(o["method"], str) for o in objs[3:]])
+        assert all([isinstance(o["resource"], str) for o in objs[3:]])
+        assert all([isinstance(o["query"], str) for o in objs[3:]])
 
         assert all(["bytes_in" in o for o in objs])
         assert all(["bytes_out" in o for o in objs])

--- a/packetbeat/tests/system/test_0017_mysql_long_result.py
+++ b/packetbeat/tests/system/test_0017_mysql_long_result.py
@@ -27,7 +27,7 @@ class Test(BaseTest):
         assert len(lines) == 11    # 10 plus header
 
         for line in lines[3:]:
-            print len(line)
+            print(len(line))
             assert len(line) == 261
 
     def test_max_row_length(self):

--- a/packetbeat/tests/system/test_0018_pgsql_long_result.py
+++ b/packetbeat/tests/system/test_0018_pgsql_long_result.py
@@ -27,7 +27,7 @@ class Test(BaseTest):
         assert len(lines) == 11    # 10 plus header
 
         for line in lines[4:]:
-            print line, len(line)
+            print(line, len(line))
             assert len(line) == 237
 
     def test_max_row_length(self):
@@ -51,7 +51,7 @@ class Test(BaseTest):
         assert len(lines) == 11    # 10 plus header
 
         for line in lines[4:]:
-            print line, len(line)
+            print(line, len(line))
             assert len(line) == 83   # 79 plus two separators and two quotes
 
     def test_max_rows(self):

--- a/packetbeat/tests/system/test_0019_hide_params.py
+++ b/packetbeat/tests/system/test_0019_hide_params.py
@@ -24,8 +24,8 @@ class Test(BaseTest):
         assert o["type"] == "http"
         assert o["http.request.params"] == "pass=xxxxx&user=monica"
         assert o["path"] == "/login"
-        for _, val in o.items():
-            if isinstance(val, basestring):
+        for _, val in list(o.items()):
+            if isinstance(val, str):
                 assert "secret" not in val
 
     def test_http_hide_get(self):
@@ -45,8 +45,8 @@ class Test(BaseTest):
         assert o["type"] == "http"
         assert o["http.request.params"] == "pass=xxxxx&user=monica"
         assert o["path"] == "/login"
-        for _, val in o.items():
-            if isinstance(val, basestring):
+        for _, val in list(o.items()):
+            if isinstance(val, str):
                 assert "secret" not in val
 
     def test_http_hide_post_default(self):

--- a/packetbeat/tests/system/test_0023_http_params.py
+++ b/packetbeat/tests/system/test_0023_http_params.py
@@ -34,7 +34,7 @@ class Test(BaseTest):
 
         assert len(objs) == 1
         o = objs[0]
-        print o
+        print(o)
         assert o["type"] == "http"
         assert len(o["http.request.params"]) > 0
         assert o["http.request.params"] == "input=packetbeat&src_ip=192.35.243.1"

--- a/packetbeat/tests/system/test_0025_mongodb_basic.py
+++ b/packetbeat/tests/system/test_0025_mongodb_basic.py
@@ -180,7 +180,7 @@ class Test(BaseTest):
                             debug_selectors=["mongodb"])
 
         objs = self.read_output()
-        print len(objs)
+        print(len(objs))
         assert len([o for o in objs if o["method"] == "insert"]) == 2
         assert len([o for o in objs if o["method"] == "update"]) == 1
         assert len([o for o in objs if o["method"] == "findandmodify"]) == 1

--- a/packetbeat/tests/system/test_0029_http_gap.py
+++ b/packetbeat/tests/system/test_0029_http_gap.py
@@ -22,6 +22,6 @@ class Test(BaseTest):
         o = objs[0]
 
         assert o["status"] == "OK"
-        print o["notes"]
+        print(o["notes"])
         assert len(o["notes"]) == 1
         assert o["notes"][0] == "Packet loss while capturing the response"

--- a/packetbeat/tests/system/test_0030_mysql_gap.py
+++ b/packetbeat/tests/system/test_0030_mysql_gap.py
@@ -25,6 +25,6 @@ class Test(BaseTest):
         assert o["method"] == "SELECT"
         assert o["mysql.num_rows"] > 1
 
-        print o["notes"]
+        print(o["notes"])
         assert len(o["notes"]) == 1
         assert o["notes"][0] == "Packet loss while capturing the response"

--- a/packetbeat/tests/system/test_0040_memcache_tcp_bin_basic.py
+++ b/packetbeat/tests/system/test_0040_memcache_tcp_bin_basic.py
@@ -76,37 +76,37 @@ class Test(BaseTest):
         assert sets['k2']['memcache.request.bytes'] == 20
         assert sets['k3']['memcache.request.bytes'] == 10
         assert all(o['memcache.request.opcode'] == 'Set'
-                   for o in sets.itervalues())
+                   for o in sets.values())
         assert all('memcache.response.cas_unique' in o
-                   for o in sets.itervalues())
+                   for o in sets.values())
         assert all(o['memcache.response.status'] == 'Success'
-                   for o in sets.itervalues())
+                   for o in sets.values())
         assert all((o['memcache.request.opaque'] ==
                     o['memcache.response.opaque'])
-                   for o in sets.itervalues())
+                   for o in sets.values())
 
         gets = dict([(o['memcache.request.keys'][0], o) for o in objs[3:8]])
         # check all gets are quiet (transaction piping)
         assert all(o['memcache.request.opcode'] == 'GetKQ'
-                   for o in gets.itervalues())
+                   for o in gets.values())
         assert all(o['memcache.request.command'] == 'get'
-                   for o in gets.itervalues())
+                   for o in gets.values())
         assert all(o['memcache.request.quiet']
-                   for o in gets.itervalues())
+                   for o in gets.values())
         assert 'memcache.response.opcode' not in gets['x']
         assert 'memcache.response.opcode' not in gets['y']
 
         # gets with actual return values
         gets = dict((k, v)
-                    for k, v in gets.iteritems()
+                    for k, v in gets.items()
                     if k in ['k1', 'k2', 'k3'])
         assert all('memcache.response.cas_unique' in o
-                   for o in gets.itervalues())
+                   for o in gets.values())
         assert all(o['memcache.response.status'] == 'Success'
-                   for o in gets.itervalues())
+                   for o in gets.values())
         assert all((o['memcache.request.opaque'] ==
                     o['memcache.response.opaque'])
-                   for o in gets.itervalues())
+                   for o in gets.values())
 
         noop = objs[8]
         assert noop['memcache.request.command'] == 'noop'

--- a/packetbeat/tests/system/test_0040_memcache_tcp_text_basic.py
+++ b/packetbeat/tests/system/test_0040_memcache_tcp_text_basic.py
@@ -68,7 +68,7 @@ class Test(BaseTest):
         assert sets['k2']['memcache.request.bytes'] == 20
         assert sets['k3']['memcache.request.bytes'] == 10
         assert all(o['memcache.response.type'] == 'Success'
-                   for o in sets.itervalues())
+                   for o in sets.values())
 
         get = objs[3]
         assert get['memcache.request.keys'] == ['x', 'k1', 'k2', 'k3', 'y']

--- a/packetbeat/tests/system/test_0041_memcache_udp_bin_basic.py
+++ b/packetbeat/tests/system/test_0041_memcache_udp_bin_basic.py
@@ -64,9 +64,9 @@ class Test(BaseTest):
         assert sets['k2']['memcache.request.bytes'] == 20
         assert sets['k3']['memcache.request.bytes'] == 10
         assert all(o['memcache.request.opcode'] == 'SetQ'
-                   for o in sets.itervalues())
+                   for o in sets.values())
         assert all(o['memcache.request.quiet']
-                   for o in sets.itervalues())
+                   for o in sets.values())
 
     def test_delete(self):
         objs = self._run('memcache/memcache_bin_udp_delete.pcap')

--- a/packetbeat/tests/system/test_0041_memcache_udp_text_basic.py
+++ b/packetbeat/tests/system/test_0041_memcache_udp_text_basic.py
@@ -62,7 +62,7 @@ class Test(BaseTest):
         assert sets['k2']['memcache.request.bytes'] == 20
         assert sets['k3']['memcache.request.bytes'] == 10
         assert all(o['memcache.request.noreply']
-                   for o in sets.itervalues())
+                   for o in sets.values())
 
     def test_delete(self):
         objs = self._run('memcache/memcache_text_udp_delete.pcap')

--- a/packetbeat/tests/system/test_0060_flows.py
+++ b/packetbeat/tests/system/test_0060_flows.py
@@ -7,7 +7,7 @@ pprint = lambda x: PrettyPrinter().pprint(x)
 
 
 def check_fields(flow, fields):
-    for k, v in fields.iteritems():
+    for k, v in fields.items():
         assert flow[k] == v
 
 

--- a/packetbeat/tests/system/test_0060_processors.py
+++ b/packetbeat/tests/system/test_0060_processors.py
@@ -113,7 +113,7 @@ class Test(BaseTest):
         assert len(objs) == 3
         assert all([o["type"] == "http" for o in objs])
 
-        print(objs[0])
+        print((objs[0]))
         assert "response" not in objs[0]
         assert "request" not in objs[0]
 

--- a/packetbeat/tests/system/test_0062_cassandra.py
+++ b/packetbeat/tests/system/test_0062_cassandra.py
@@ -91,7 +91,7 @@ class Test(BaseTest):
         self.run_packetbeat(pcap="cassandra/v4/cassandra_insert.pcap",debug_selectors=["*"])
         objs = self.read_output()
         o = objs[0]
-        print o
+        print(o)
         assert o["type"] == "cassandra"
         assert o["port"] == 9042
 
@@ -193,7 +193,7 @@ class Test(BaseTest):
         assert o["bytes_in"] == 55
         assert o["bytes_out"] == 62
         assert o["cassandra.request.query"] == "DROP KEYSPACE mykeyspace;"
-        print o
+        print(o)
 
         assert o["cassandra.request.headers.version"] == "4"
         assert o["cassandra.request.headers.op"] == "QUERY"
@@ -225,7 +225,7 @@ class Test(BaseTest):
         self.run_packetbeat(pcap="cassandra/v4/cassandra_select_via_index.pcap",debug_selectors=["*"])
         objs = self.read_output()
         o = objs[0]
-        print o
+        print(o)
         assert o["type"] == "cassandra"
         assert o["port"] == 9042
 
@@ -262,7 +262,7 @@ class Test(BaseTest):
         objs = self.read_output()
 
         o = objs[0]
-        print o
+        print(o)
         assert o["type"] == "cassandra"
         assert o["port"] == 9042
         assert o["bytes_in"] == 9
@@ -284,7 +284,7 @@ class Test(BaseTest):
         assert o["cassandra.response.headers.stream"] == 0
 
         o = objs[1]
-        print o
+        print(o)
         assert o["type"] == "cassandra"
         assert o["port"] == 9042
         assert o["bytes_in"] == 31
@@ -306,7 +306,7 @@ class Test(BaseTest):
         assert o["cassandra.response.headers.stream"] == 1
 
         o = objs[2]
-        print o
+        print(o)
         assert o["type"] == "cassandra"
         assert o["port"] == 9042
         assert o["bytes_in"] == 58
@@ -402,7 +402,7 @@ class Test(BaseTest):
         objs = self.read_output()
 
         o = objs[0]
-        print o
+        print(o)
         assert o["type"] == "cassandra"
         assert o["port"] == 9042
         assert o["bytes_in"] == 52
@@ -424,7 +424,7 @@ class Test(BaseTest):
         assert o["cassandra.response.headers.stream"] == 0
 
         o = objs[1]
-        print o
+        print(o)
         assert o["type"] == "cassandra"
         assert o["port"] == 9042
         assert o["bytes_in"] == 53
@@ -446,7 +446,7 @@ class Test(BaseTest):
         assert o["cassandra.response.headers.stream"] == 64
 
         o = objs[2]
-        print o
+        print(o)
         assert o["type"] == "cassandra"
         assert o["port"] == 9042
         assert o["bytes_in"] == 62

--- a/packetbeat/tests/system/test_0063_http_body.py
+++ b/packetbeat/tests/system/test_0063_http_body.py
@@ -77,7 +77,7 @@ class Test(BaseTest):
 
         assert len(objs) == 1
         o = objs[0]
-        print o
+        print(o)
 
         assert o["type"] == "http"
 
@@ -107,7 +107,7 @@ class Test(BaseTest):
 
         assert len(objs) == 1
         o = objs[0]
-        print len(o["http.response.body"])
+        print(len(o["http.response.body"]))
 
         # response body should be included but trimmed
         assert len(o["http.response.body"]) < 2000

--- a/vendor/github.com/tsg/gopacket/layers/test_creator.py
+++ b/vendor/github.com/tsg/gopacket/layers/test_creator.py
@@ -96,8 +96,8 @@ def main():
   for arg in args.files:
     for path in glob.glob(arg):
       for i, packet in enumerate(TcpdumpOutputToPackets(GetTcpdumpOutput(path))):
-        print '\n'.join(packet.Test(
-          args.name % i, args.link_type))
+        print('\n'.join(packet.Test(
+          args.name % i, args.link_type)))
 
 if __name__ == '__main__':
     main()

--- a/winlogbeat/tests/system/test_eventlogging.py
+++ b/winlogbeat/tests/system/test_eventlogging.py
@@ -153,10 +153,10 @@ class Test(WriteReadTest):
         """
         eventlogging - UTF-16 characters
         """
-        msg = (u'\u89E3\u51CD\u3057\u305F\u30D5\u30A9\u30EB\u30C0\u306E'
-               u'\u30A4\u30F3\u30B9\u30C8\u30FC\u30EB\u30B9\u30AF\u30EA'
-               u'\u30D7\u30C8\u3092\u5B9F\u884C\u3057'
-               u'\u8C61\u5F62\u5B57')
+        msg = ('\u89E3\u51CD\u3057\u305F\u30D5\u30A9\u30EB\u30C0\u306E'
+               '\u30A4\u30F3\u30B9\u30C8\u30FC\u30EB\u30B9\u30AF\u30EA'
+               '\u30D7\u30C8\u3092\u5B9F\u884C\u3057'
+               '\u8C61\u5F62\u5B57')
         self.write_event_log(msg)
         evts = self.read_events(config={
             "event_logs": [

--- a/winlogbeat/tests/system/test_wineventlog.py
+++ b/winlogbeat/tests/system/test_wineventlog.py
@@ -290,10 +290,10 @@ class Test(WriteReadTest):
         """
         wineventlog - UTF-16 characters
         """
-        msg = (u'\u89E3\u51CD\u3057\u305F\u30D5\u30A9\u30EB\u30C0\u306E'
-               u'\u30A4\u30F3\u30B9\u30C8\u30FC\u30EB\u30B9\u30AF\u30EA'
-               u'\u30D7\u30C8\u3092\u5B9F\u884C\u3057'
-               u'\u8C61\u5F62\u5B57')
+        msg = ('\u89E3\u51CD\u3057\u305F\u30D5\u30A9\u30EB\u30C0\u306E'
+               '\u30A4\u30F3\u30B9\u30C8\u30FC\u30EB\u30B9\u30AF\u30EA'
+               '\u30D7\u30C8\u3092\u5B9F\u884C\u3057'
+               '\u8C61\u5F62\u5B57')
         self.write_event_log(msg)
         evts = self.read_events(config={
             "event_logs": [

--- a/winlogbeat/tests/system/winlogbeat.py
+++ b/winlogbeat/tests/system/winlogbeat.py
@@ -104,17 +104,17 @@ class WriteReadTest(BaseTest):
         if msg == None:
             assert "message" not in evt
         else:
-            self.assertEquals(evt["message"], msg)
+            self.assertEqual(evt["message"], msg)
             self.assertDictContainsSubset({"event_data.param1": msg}, evt)
 
         if sid == None:
-            self.assertEquals(evt["user.identifier"], self.get_sid_string())
-            self.assertEquals(evt["user.name"].lower(),
+            self.assertEqual(evt["user.identifier"], self.get_sid_string())
+            self.assertEqual(evt["user.name"].lower(),
                               win32api.GetUserName().lower())
-            self.assertEquals(evt["user.type"], "User")
+            self.assertEqual(evt["user.type"], "User")
             assert "user.domain" in evt
         else:
-            self.assertEquals(evt["user.identifier"], sid)
+            self.assertEqual(evt["user.identifier"], sid)
             assert "user.name" not in evt
             assert "user.type" not in evt
 


### PR DESCRIPTION
Run `2to3 -w -n ./` to automatically make python scripts compatible with version 3.