### PR TITLE
Deprecate usage of _type field

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -101,6 +101,7 @@ https://github.com/elastic/beats/compare/v5.1.1...master[Check the HEAD diff]
 ==== Deprecated
 
 *Affecting all Beats*
+- Usage of field _type is deprecated. It should not be used in queries or dashboards. {pull}3409[3409]
 
 *Metricbeat*
 


### PR DESCRIPTION
The type field is potentially removed in the future in elasticsearch: https://github.com/elastic/elasticsearch/issues/15613 There is currently no active use of `_type` features in beats. There is use of `type` which often contains the same value as `_type` but is a normal field.

`_type` is marked deprecated in 5.3 as it will be potentially be removed in the 6.0 release. For queries and dashboards the `_type` field should not be used anymore. Removal of `_type` on the beats side is probably not going to be a breaking change as it mainly affects the elasticsearch output.