### PR TITLE
Export libbeat.outputs.acked_events via expvar

### DIFF
--- a/libbeat/outputs/elasticsearch/client.go
+++ b/libbeat/outputs/elasticsearch/client.go
@@ -259,6 +259,7 @@ func (client *Client) PublishEvents(
 	}
 
 	ackedEvents.Add(int64(len(data) - len(failedEvents)))
+	outputs.AckedEvents.Add(int64(len(data) - len(failedEvents)))
 	eventsNotAcked.Add(int64(len(failedEvents)))
 	if len(failedEvents) > 0 {
 		if sendErr == nil {

--- a/libbeat/outputs/kafka/client.go
+++ b/libbeat/outputs/kafka/client.go
@@ -234,12 +234,14 @@ func (r *msgRef) dec() {
 		eventsNotAcked.Add(int64(failed))
 		if success > 0 {
 			ackedEvents.Add(int64(success))
+			outputs.AckedEvents.Add(int64(success))
 		}
 
 		debugf("Kafka publish failed with: %v", err)
 		r.cb(r.failed, err)
 	} else {
 		ackedEvents.Add(int64(r.total))
+		outputs.AckedEvents.Add(int64(r.total))
 		r.cb(nil, nil)
 	}
 }

--- a/libbeat/outputs/logstash/async.go
+++ b/libbeat/outputs/logstash/async.go
@@ -165,6 +165,7 @@ func (r *msgRef) callback(seq uint32, err error) {
 
 func (r *msgRef) done(n uint32) {
 	ackedEvents.Add(int64(n))
+	outputs.AckedEvents.Add(int64(n))
 	r.batch = r.batch[n:]
 	r.win.tryGrowWindow(r.batchSize)
 	r.dec()
@@ -172,6 +173,7 @@ func (r *msgRef) done(n uint32) {
 
 func (r *msgRef) fail(n uint32, err error) {
 	ackedEvents.Add(int64(n))
+	outputs.AckedEvents.Add(int64(n))
 	r.err = err
 	r.batch = r.batch[n:]
 	r.win.shrinkWindow()

--- a/libbeat/outputs/logstash/sync.go
+++ b/libbeat/outputs/logstash/sync.go
@@ -86,10 +86,12 @@ func (c *client) PublishEvents(
 
 			eventsNotAcked.Add(int64(len(data)))
 			ackedEvents.Add(int64(totalNumberOfEvents - len(data)))
+			outputs.AckedEvents.Add(int64(totalNumberOfEvents - len(data)))
 			return data, err
 		}
 	}
 	ackedEvents.Add(int64(totalNumberOfEvents))
+	outputs.AckedEvents.Add(int64(totalNumberOfEvents))
 	return nil, nil
 }
 

--- a/libbeat/outputs/outputs.go
+++ b/libbeat/outputs/outputs.go
@@ -1,6 +1,8 @@
 package outputs
 
 import (
+	"expvar"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/op"
 	"github.com/elastic/beats/libbeat/logp"
@@ -71,6 +73,10 @@ type bulkOutputAdapter struct {
 }
 
 var outputsPlugins = make(map[string]OutputBuilder)
+
+var (
+	AckedEvents = expvar.NewInt("libbeat.outputs.acked_events")
+)
 
 func RegisterOutputPlugin(name string, builder OutputBuilder) {
 	outputsPlugins[name] = builder


### PR DESCRIPTION
Part of https://github.com/elastic/beats/issues/3422

With this PR, each Beat exports `libbeat.redis.published_and_acked_events` and `libbeat.redis.published_but_not_acked_events` via expvar for Redis. 

In addition, `libbeat.outputs.acked_events` is exported in order to send one metric for all outputs instead of one metric per output. In the case two outputs are enabled, the number of published events will be double. 
 For example in case Redis and Elasticsearch outputs are enabled, then `libbeat.redis.published_and_acked_events: 48`, `libbeat.elasticsearch.published_and_acked_events: 48` and `libbeat.outputs.acked_events: 96`.