### PR TITLE
Typo in heartbeat description (#3351)

### DIFF
--- a/heartbeat/Makefile
+++ b/heartbeat/Makefile
@@ -1,5 +1,5 @@
 BEATNAME=heartbeat
-BEAT_DESCRIPTION?=Ping remote services for availablity and log results to Elasticsearch or send to Logstash.
+BEAT_DESCRIPTION?=Ping remote services for availability and log results to Elasticsearch or send to Logstash.
 SYSTEM_TESTS=false
 TEST_ENVIRONMENT=false
 


### PR DESCRIPTION
Backport of #3351.

(cherry picked from commit 7db9e92db5796b4b7427efbe9d6a3a55b7ecd786)