### PR TITLE
Backport: Heartbeat ICMP without IPv6 (#3414)

### DIFF
--- a/heartbeat/monitors/active/icmp/icmp.go
+++ b/heartbeat/monitors/active/icmp/icmp.go
@@ -57,6 +57,10 @@ func create(
 		return nil, loopErr
 	}
 
+	if err := loop.checkNetworkMode(ipVersion); err != nil {
+		return nil, err
+	}
+
 	typ := config.Name
 	network := config.Mode.Network()
 	pingFactory := monitors.MakePingIPFactory(nil, createPingIPFactory(&config))

--- a/heartbeat/monitors/active/icmp/loop.go
+++ b/heartbeat/monitors/active/icmp/loop.go
@@ -3,6 +3,7 @@ package icmp
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"math/rand"
 	"net"
@@ -12,6 +13,8 @@ import (
 	"golang.org/x/net/icmp"
 	"golang.org/x/net/ipv4"
 	"golang.org/x/net/ipv6"
+
+	"github.com/elastic/beats/libbeat/logp"
 )
 
 type icmpLoop struct {
@@ -66,16 +69,12 @@ var (
 )
 
 func newICMPLoop() (*icmpLoop, error) {
-	conn4, err := icmp.ListenPacket("ip4:icmp", "")
-	if err != nil {
-		return nil, err
-	}
-
-	conn6, err := icmp.ListenPacket("ip6:ipv6-icmp", "")
-	if err != nil {
-		conn4.Close()
-		return nil, err
-	}
+	// Log errors at info level, as the loop is setup globally when ICMP module is loaded
+	// first (not yet configured).
+	// With multiple configurations using the icmp loop, we have to postpose
+	// IPv4/IPv6 checking
+	conn4 := createListener("IPv4", "ip4:icmp")
+	conn6 := createListener("IPv6", "ip6:ipv6-icmp")
 
 	l := &icmpLoop{
 		conn4:    conn4,
@@ -83,10 +82,38 @@ func newICMPLoop() (*icmpLoop, error) {
 		recv:     make(chan packet, 16),
 		requests: map[requestID]*requestContext{},
 	}
-	go l.runICMPRecv(conn4, protocolICMP)
-	go l.runICMPRecv(conn6, protocolIPv6ICMP)
+
+	if conn4 != nil {
+		go l.runICMPRecv(conn4, protocolICMP)
+	}
+	if conn6 != nil {
+		go l.runICMPRecv(conn6, protocolIPv6ICMP)
+	}
 
 	return l, nil
+}
+
+func (l *icmpLoop) checkNetworkMode(mode string) error {
+	ip4, ip6 := false, false
+	switch mode {
+	case "ip4":
+		ip4 = true
+	case "ip6":
+		ip6 = true
+	case "ip":
+		ip4, ip6 = true, true
+	default:
+		return fmt.Errorf("'%v' is not supported", mode)
+	}
+
+	if ip4 && l.conn4 == nil {
+		return errors.New("failed to initiate IPv4 support")
+	}
+	if ip6 && l.conn6 == nil {
+		return errors.New("failed to initiate IPv6 support")
+	}
+
+	return nil
 }
 
 func (l *icmpLoop) runICMPRecv(conn *icmp.PacketConn, proto int) {
@@ -99,7 +126,7 @@ func (l *icmpLoop) runICMPRecv(conn *icmp.PacketConn, proto int) {
 				if neterr.Timeout() {
 					continue
 				} else {
-					// TODO: report error and quit loop
+					// TODO: report error and quit loop?
 					return
 				}
 			}
@@ -291,6 +318,19 @@ func (l *icmpLoop) sendEchoRequest(addr *net.IPAddr) (*requestContext, error) {
 
 	ctx.ts = ts
 	return ctx, nil
+}
+
+func createListener(name, network string) *icmp.PacketConn {
+	conn, err := icmp.ListenPacket(network, "")
+
+	// XXX: need to check for conn == nil, as 'err != nil' seems always to be
+	//      true, even if error value itself is `nil`. Checking for conn supresses
+	//      missleading log message.
+	if conn == nil && err != nil {
+		logp.Info("%v ICMP not supported: %v", name, err)
+		return nil
+	}
+	return conn
 }
 
 // timeoutError implements net.Error interface


### PR DESCRIPTION
Backport of #3414 to 5.2. Original message:

Fix heartbeat startup failing if ICMP is configured and IPv6 support is
disabled on boot or not available in kernel.

Heartbeat starts one global loop for IPv4 EchoRequest/Reply and one for IPv6.
If one queue fails to start, the ICMP module will only fail if the actual
IP-type loop is really required. If `ipv6` is `false` in config file and no
IPv6 loop is available we can continue instantiating the module.
(cherry picked from commit ae445a7a24f5aac410f89f5c66ad954a0fa0c4e0)