### PR TITLE
Export health metrics via expvar

### DIFF
--- a/libbeat/outputs/elasticsearch/client.go
+++ b/libbeat/outputs/elasticsearch/client.go
@@ -133,6 +133,8 @@ func NewClient(
 		Write:       statWriteBytes,
 		ReadErrors:  statReadErrors,
 		WriteErrors: statWriteErrors,
+		SendBytes:   outputs.SendBytes,
+		Failures:    outputs.Failures,
 	}
 	dialer = transport.StatsDialer(dialer, iostats)
 	tlsDialer = transport.StatsDialer(tlsDialer, iostats)

--- a/libbeat/outputs/elasticsearch/client.go
+++ b/libbeat/outputs/elasticsearch/client.go
@@ -259,6 +259,7 @@ func (client *Client) PublishEvents(
 	}
 
 	ackedEvents.Add(int64(len(data) - len(failedEvents)))
+	outputs.AckedEvents.Add(int64(len(data) - len(failedEvents)))
 	eventsNotAcked.Add(int64(len(failedEvents)))
 	if len(failedEvents) > 0 {
 		if sendErr == nil {

--- a/libbeat/outputs/kafka/client.go
+++ b/libbeat/outputs/kafka/client.go
@@ -234,12 +234,14 @@ func (r *msgRef) dec() {
 		eventsNotAcked.Add(int64(failed))
 		if success > 0 {
 			ackedEvents.Add(int64(success))
+			outputs.AckedEvents.Add(int64(success))
 		}
 
 		debugf("Kafka publish failed with: %v", err)
 		r.cb(r.failed, err)
 	} else {
 		ackedEvents.Add(int64(r.total))
+		outputs.AckedEvents.Add(int64(r.total))
 		r.cb(nil, nil)
 	}
 }

--- a/libbeat/outputs/logstash/async.go
+++ b/libbeat/outputs/logstash/async.go
@@ -165,6 +165,7 @@ func (r *msgRef) callback(seq uint32, err error) {
 
 func (r *msgRef) done(n uint32) {
 	ackedEvents.Add(int64(n))
+	outputs.AckedEvents.Add(int64(n))
 	r.batch = r.batch[n:]
 	r.win.tryGrowWindow(r.batchSize)
 	r.dec()
@@ -172,6 +173,7 @@ func (r *msgRef) done(n uint32) {
 
 func (r *msgRef) fail(n uint32, err error) {
 	ackedEvents.Add(int64(n))
+	outputs.AckedEvents.Add(int64(n))
 	r.err = err
 	r.batch = r.batch[n:]
 	r.win.shrinkWindow()

--- a/libbeat/outputs/logstash/logstash.go
+++ b/libbeat/outputs/logstash/logstash.go
@@ -84,6 +84,8 @@ func (lj *logstash) init(cfg *common.Config) error {
 			Write:       statWriteBytes,
 			ReadErrors:  statReadErrors,
 			WriteErrors: statWriteErrors,
+			SendBytes:   outputs.SendBytes,
+			Failures:    outputs.Failures,
 		},
 	}
 

--- a/libbeat/outputs/logstash/sync.go
+++ b/libbeat/outputs/logstash/sync.go
@@ -86,10 +86,12 @@ func (c *client) PublishEvents(
 
 			eventsNotAcked.Add(int64(len(data)))
 			ackedEvents.Add(int64(totalNumberOfEvents - len(data)))
+			outputs.AckedEvents.Add(int64(totalNumberOfEvents - len(data)))
 			return data, err
 		}
 	}
 	ackedEvents.Add(int64(totalNumberOfEvents))
+	outputs.AckedEvents.Add(int64(totalNumberOfEvents))
 	return nil, nil
 }
 

--- a/libbeat/outputs/outputs.go
+++ b/libbeat/outputs/outputs.go
@@ -1,6 +1,8 @@
 package outputs
 
 import (
+	"expvar"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/op"
 	"github.com/elastic/beats/libbeat/logp"
@@ -71,6 +73,10 @@ type bulkOutputAdapter struct {
 }
 
 var outputsPlugins = make(map[string]OutputBuilder)
+
+var (
+	AckedEvents = expvar.NewInt("libbeat.outputs.acked_events")
+)
 
 func RegisterOutputPlugin(name string, builder OutputBuilder) {
 	outputsPlugins[name] = builder

--- a/libbeat/outputs/outputs.go
+++ b/libbeat/outputs/outputs.go
@@ -76,6 +76,8 @@ var outputsPlugins = make(map[string]OutputBuilder)
 
 var (
 	AckedEvents = expvar.NewInt("libbeat.outputs.acked_events")
+	SendBytes   = expvar.NewInt("libbeat.outputs.send_bytes")
+	Failures    = expvar.NewInt("libbeat.outputs.failures")
 )
 
 func RegisterOutputPlugin(name string, builder OutputBuilder) {

--- a/libbeat/outputs/redis/redis.go
+++ b/libbeat/outputs/redis/redis.go
@@ -107,6 +107,8 @@ func (r *redisOut) init(cfg *common.Config, expireTopo int) error {
 			Write:       statWriteBytes,
 			ReadErrors:  statReadErrors,
 			WriteErrors: statWriteErrors,
+			SendBytes:   outputs.SendBytes,
+			Failures:    outputs.Failures,
 		},
 	}
 

--- a/libbeat/outputs/transport/stats.go
+++ b/libbeat/outputs/transport/stats.go
@@ -6,7 +6,7 @@ import (
 )
 
 type IOStats struct {
-	Read, Write, ReadErrors, WriteErrors *expvar.Int
+	Read, Write, ReadErrors, WriteErrors, SendBytes, Failures *expvar.Int
 }
 
 type statsConn struct {
@@ -33,7 +33,9 @@ func (s *statsConn) Write(b []byte) (int, error) {
 	n, err := s.Conn.Write(b)
 	if err != nil {
 		s.stats.WriteErrors.Add(1)
+		s.stats.Failures.Add(1)
 	}
 	s.stats.Write.Add(int64(n))
+	s.stats.SendBytes.Add(int64(n))
 	return n, err
 }


### PR DESCRIPTION
Part of https://github.com/elastic/beats/issues/3422
Exports the following health metrics over expvar:
- [x] libbeat.outputs.send_bytes
- [x] libbeat.outputs.failures
- [x] libbeat.publisher.acked_events
- [ ] libbeat.beat.cpu_usage
- [ ] libbeat.beat.memory_usage

**Limitations**: For Kafka, the Beats are not exporting `libbeat.kafka.publish.write_bytes` and `libbeat.kafka.publish.write_errors`.