### PR TITLE
introduce libbeat.monitoring to unify collection from internal metrics

### DIFF
--- a/libbeat/logp/logp.go
+++ b/libbeat/logp/logp.go
@@ -1,13 +1,11 @@
 package logp
 
 import (
-	"expvar"
 	"flag"
 	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
-	"strconv"
 	"strings"
 	"time"
 
@@ -160,7 +158,7 @@ func Init(name string, config *Logging) error {
 		log.SetOutput(ioutil.Discard)
 	}
 
-	go logExpvars(&config.Metrics)
+	go logMetrics(&config.Metrics)
 
 	return nil
 }
@@ -190,84 +188,4 @@ func getLogLevel(config *Logging) (Priority, error) {
 		return 0, fmt.Errorf("unknown log level: %v", config.Level)
 	}
 	return level, nil
-}
-
-// snapshotMap recursively walks expvar Maps and records their integer expvars
-// in a separate flat map.
-func snapshotMap(varsMap map[string]int64, path string, mp *expvar.Map) {
-	mp.Do(func(kv expvar.KeyValue) {
-		switch kv.Value.(type) {
-		case *expvar.Int:
-			varsMap[path+"."+kv.Key], _ = strconv.ParseInt(kv.Value.String(), 10, 64)
-		case *expvar.Map:
-			snapshotMap(varsMap, path+"."+kv.Key, kv.Value.(*expvar.Map))
-		}
-	})
-}
-
-// snapshotExpvars iterates through all the defined expvars, and for the vars
-// that are integers it snapshots the name and value in a separate (flat) map.
-func snapshotExpvars(varsMap map[string]int64) {
-	expvar.Do(func(kv expvar.KeyValue) {
-		switch kv.Value.(type) {
-		case *expvar.Int:
-			varsMap[kv.Key], _ = strconv.ParseInt(kv.Value.String(), 10, 64)
-		case *expvar.Map:
-			snapshotMap(varsMap, kv.Key, kv.Value.(*expvar.Map))
-		}
-	})
-}
-
-// buildMetricsOutput makes the delta between vals and prevVals and builds
-// a printable string with the non-zero deltas.
-func buildMetricsOutput(prevVals map[string]int64, vals map[string]int64) string {
-	metrics := ""
-	for k, v := range vals {
-		delta := v - prevVals[k]
-		if delta != 0 {
-			metrics = fmt.Sprintf("%s %s=%d", metrics, k, delta)
-		}
-	}
-	return metrics
-}
-
-// logExpvars logs at Info level the integer expvars that have changed in the
-// last interval. For each expvar, the delta from the beginning of the interval
-// is logged.
-func logExpvars(metricsCfg *LoggingMetricsConfig) {
-	if metricsCfg.Enabled != nil && *metricsCfg.Enabled == false {
-		Info("Metrics logging disabled")
-		return
-	}
-	if metricsCfg.Period == nil {
-		metricsCfg.Period = &defaultMetricsPeriod
-	}
-	Info("Metrics logging every %s", metricsCfg.Period)
-
-	ticker := time.NewTicker(*metricsCfg.Period)
-	prevVals := map[string]int64{}
-	for {
-		<-ticker.C
-		vals := map[string]int64{}
-		snapshotExpvars(vals)
-		metrics := buildMetricsOutput(prevVals, vals)
-		prevVals = vals
-		if len(metrics) > 0 {
-			Info("Non-zero metrics in the last %s:%s", metricsCfg.Period, metrics)
-		} else {
-			Info("No non-zero metrics in the last %s", metricsCfg.Period)
-		}
-	}
-}
-
-func LogTotalExpvars(cfg *Logging) {
-	if cfg.Metrics.Enabled != nil && *cfg.Metrics.Enabled == false {
-		return
-	}
-	vals := map[string]int64{}
-	prevVals := map[string]int64{}
-	snapshotExpvars(vals)
-	metrics := buildMetricsOutput(prevVals, vals)
-	Info("Total non-zero values: %s", metrics)
-	Info("Uptime: %s", time.Now().Sub(startTime))
 }

--- a/libbeat/logp/metrics.go
+++ b/libbeat/logp/metrics.go
@@ -1,0 +1,186 @@
+package logp
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/elastic/beats/libbeat/monitoring"
+)
+
+type snapshotVisitor struct {
+	snapshot snapshot
+	level    []string
+}
+
+type snapshot struct {
+	bools   map[string]bool
+	ints    map[string]int64
+	floats  map[string]float64
+	strings map[string]string
+}
+
+// logExpvars logs at Info level the integer expvars that have changed in the
+// last interval. For each expvar, the delta from the beginning of the interval
+// is logged.
+func logMetrics(metricsCfg *LoggingMetricsConfig) {
+	if metricsCfg.Enabled != nil && *metricsCfg.Enabled == false {
+		Info("Metrics logging disabled")
+		return
+	}
+	if metricsCfg.Period == nil {
+		metricsCfg.Period = &defaultMetricsPeriod
+	}
+	Info("Metrics logging every %s", metricsCfg.Period)
+
+	ticker := time.NewTicker(*metricsCfg.Period)
+
+	prevVals := makeSnapshot()
+	for range ticker.C {
+		snapshot := snapshotMetrics()
+		delta := snapshotDelta(prevVals, snapshot)
+		prevVals = snapshot
+
+		if len(delta) == 0 {
+			Info("No non-zero metrics in the last %s", metricsCfg.Period)
+			continue
+		}
+
+		metrics := formatMetrics(delta)
+		Info("Non-zero metrics in the last %s:%s", metricsCfg.Period, metrics)
+	}
+}
+
+func LogTotalExpvars(cfg *Logging) {
+	if cfg.Metrics.Enabled != nil && *cfg.Metrics.Enabled == false {
+		return
+	}
+
+	metrics := formatMetrics(snapshotDelta(makeSnapshot(), snapshotMetrics()))
+	Info("Total non-zero values: %s", metrics)
+	Info("Uptime: %s", time.Now().Sub(startTime))
+}
+
+func snapshotMetrics() snapshot {
+	vs := newSnapshotVisitor()
+	monitoring.Default.Visit(vs)
+	monitoring.VisitExpvars(vs)
+	return vs.snapshot
+}
+
+func newSnapshotVisitor() *snapshotVisitor {
+	return &snapshotVisitor{snapshot: makeSnapshot()}
+}
+
+func makeSnapshot() snapshot {
+	return snapshot{
+		bools:   map[string]bool{},
+		ints:    map[string]int64{},
+		floats:  map[string]float64{},
+		strings: map[string]string{},
+	}
+}
+
+func (vs *snapshotVisitor) OnRegistryStart() error {
+	return nil
+}
+
+func (vs *snapshotVisitor) OnRegistryFinished() error {
+	if len(vs.level) > 0 {
+		vs.dropName()
+	}
+	return nil
+}
+
+func (vs *snapshotVisitor) OnKey(name string) error {
+	vs.level = append(vs.level, name)
+	return nil
+}
+
+func (vs *snapshotVisitor) OnKeyNext() error { return nil }
+
+func (vs *snapshotVisitor) getName() string {
+	defer vs.dropName()
+	if len(vs.level) == 1 {
+		return vs.level[0]
+	}
+	return strings.Join(vs.level, ".")
+}
+
+func (vs *snapshotVisitor) dropName() {
+	vs.level = vs.level[:len(vs.level)-1]
+}
+
+func (vs *snapshotVisitor) OnString(s string) error {
+	vs.snapshot.strings[vs.getName()] = s
+	return nil
+}
+
+func (vs *snapshotVisitor) OnBool(b bool) error {
+	vs.snapshot.bools[vs.getName()] = b
+	return nil
+}
+
+func (vs *snapshotVisitor) OnNil() error {
+	vs.snapshot.strings[vs.getName()] = "<nil>"
+	return nil
+}
+
+func (vs *snapshotVisitor) OnInt(i int64) error {
+	vs.snapshot.ints[vs.getName()] = i
+	return nil
+}
+
+func (vs *snapshotVisitor) OnFloat(f float64) error {
+	vs.snapshot.floats[vs.getName()] = f
+	return nil
+}
+
+func snapshotDelta(prev, cur snapshot) map[string]interface{} {
+	out := map[string]interface{}{}
+
+	for k, b := range cur.bools {
+		if p, ok := prev.bools[k]; !ok || p != b {
+			out[k] = b
+		}
+	}
+
+	for k, s := range cur.strings {
+		if p, ok := prev.strings[k]; !ok || p != s {
+			out[k] = s
+		}
+	}
+
+	for k, i := range cur.ints {
+		if p := prev.ints[k]; p != i {
+			out[k] = i - p
+		}
+	}
+
+	for k, f := range cur.floats {
+		if p := prev.floats[k]; p != f {
+			out[k] = f - p
+		}
+	}
+
+	return out
+}
+
+func formatMetrics(ms map[string]interface{}) string {
+	keys := make([]string, 0, len(ms))
+	for key := range ms {
+		keys = append(keys, key)
+	}
+
+	sort.Strings(keys)
+	var buf bytes.Buffer
+	for _, key := range keys {
+		buf.WriteByte(' ')
+		buf.WriteString(key)
+		buf.WriteString("=")
+		buf.WriteString(fmt.Sprintf("%v", ms[key]))
+	}
+	return buf.String()
+}

--- a/libbeat/logp/metrics.go
+++ b/libbeat/logp/metrics.go
@@ -22,7 +22,7 @@ type snapshot struct {
 	strings map[string]string
 }
 
-// logExpvars logs at Info level the integer expvars that have changed in the
+// logMetrics logs at Info level the integer expvars that have changed in the
 // last interval. For each expvar, the delta from the beginning of the interval
 // is logged.
 func logMetrics(metricsCfg *LoggingMetricsConfig) {
@@ -53,6 +53,7 @@ func logMetrics(metricsCfg *LoggingMetricsConfig) {
 	}
 }
 
+// LogTotalExpvars logs all registered expvar metrics.
 func LogTotalExpvars(cfg *Logging) {
 	if cfg.Metrics.Enabled != nil && *cfg.Metrics.Enabled == false {
 		return

--- a/libbeat/logp/metrics_test.go
+++ b/libbeat/logp/metrics_test.go
@@ -13,10 +13,8 @@ func TestSnapshotExpvars(t *testing.T) {
 	test := expvar.NewInt("test")
 	test.Add(42)
 
-	vals := map[string]int64{}
-	snapshotExpvars(vals)
-
-	assert.Equal(t, vals["test"], int64(42))
+	vals := snapshotMetrics()
+	assert.Equal(t, vals.ints["test"], int64(42))
 }
 
 func TestSnapshotExpvarsMap(t *testing.T) {
@@ -27,46 +25,39 @@ func TestSnapshotExpvarsMap(t *testing.T) {
 	map2.Add("test", 5)
 	test.Set("map2", map2)
 
-	vals := map[string]int64{}
-	snapshotExpvars(vals)
+	vals := snapshotMetrics()
 
-	assert.Equal(t, vals["testMap.hello"], int64(42))
-	assert.Equal(t, vals["testMap.map2.test"], int64(5))
+	assert.Equal(t, vals.ints["testMap.hello"], int64(42))
+	assert.Equal(t, vals.ints["testMap.map2.test"], int64(5))
 }
 
 func TestBuildMetricsOutput(t *testing.T) {
 	test := expvar.NewInt("testLog")
 	test.Add(1)
 
-	prevVals := map[string]int64{}
-	snapshotExpvars(prevVals)
+	prevVals := snapshotMetrics()
 
 	test.Add(5)
 
-	vals := map[string]int64{}
-	snapshotExpvars(vals)
-
-	metrics := buildMetricsOutput(prevVals, vals)
+	vals := snapshotMetrics()
+	metrics := formatMetrics(snapshotDelta(prevVals, vals))
 	assert.Equal(t, " testLog=5", metrics)
 	prevVals = vals
 
 	test.Add(3)
-	vals = map[string]int64{}
-	snapshotExpvars(vals)
-	metrics = buildMetricsOutput(prevVals, vals)
+	vals = snapshotMetrics()
+	metrics = formatMetrics(snapshotDelta(prevVals, vals))
 	assert.Equal(t, " testLog=3", metrics)
 }
 
 func TestBuildMetricsOutputMissing(t *testing.T) {
 
-	prevVals := map[string]int64{}
-	snapshotExpvars(prevVals)
+	prevVals := snapshotMetrics()
 
 	test := expvar.NewInt("testLogEmpty")
 	test.Add(7)
 
-	vals := map[string]int64{}
-	snapshotExpvars(vals)
-	metrics := buildMetricsOutput(prevVals, vals)
+	vals := snapshotMetrics()
+	metrics := formatMetrics(snapshotDelta(prevVals, vals))
 	assert.Equal(t, " testLogEmpty=7", metrics)
 }

--- a/libbeat/monitoring/adapter/filters.go
+++ b/libbeat/monitoring/adapter/filters.go
@@ -1,0 +1,144 @@
+package adapter
+
+import (
+	"strings"
+
+	"github.com/elastic/beats/libbeat/monitoring"
+)
+
+// provide filters for filtering and adapting a metric type
+// to monitoring.Var.
+
+// MetricFilter type used to defined and combine filters.
+type MetricFilter func(*metricFilters) *metricFilters
+
+// metricFilters provides set of filters to apply to a new metric.
+type metricFilters struct {
+	filters []varFilter
+}
+
+type varFilter func(state) state
+
+// state provides the filter state to be changed by every filter.
+//
+// After filtering the state will be used to choose on the metric name, the
+// metric type , or wether the metric is to be ignored.
+type state struct {
+	kind   kind
+	action action
+	reg    *monitoring.Registry
+	name   string
+	metric interface{}
+}
+
+// action defines the action to be
+type action uint8
+
+// kind defines the kind of operation to be executed
+type kind uint8
+
+const (
+	kndFind kind = iota
+	kndAdd
+	kndRemove
+)
+
+const (
+	actIgnore action = iota
+	actAccept
+)
+
+func makeFilters(in ...MetricFilter) *metricFilters {
+	if len(in) == 0 {
+		return nil
+	}
+
+	m := &metricFilters{}
+	for _, mk := range in {
+		m = mk(m)
+	}
+	return m
+}
+
+func (m *metricFilters) apply(st state) state {
+	if m != nil {
+		for _, filter := range m.filters {
+			st = filter(st)
+		}
+	}
+	return st
+}
+
+func ApplyIf(pred func(name string) bool, filters ...MetricFilter) MetricFilter {
+	then := makeFilters(filters...)
+	return withVarFilter(func(st state) state {
+		if pred(st.name) {
+			st = then.apply(st)
+		}
+		return st
+	})
+}
+
+var Accept = withVarFilter(func(st state) state {
+	st.action = actAccept
+	return st
+})
+
+// WhitelistIf will accept a metric if the metrics name matches
+// the given predicate.
+func WhitelistIf(pred func(string) bool) MetricFilter {
+	return ApplyIf(pred, Accept)
+}
+
+// Whitelist sets a list of metric names to be accepted.
+func Whitelist(names ...string) MetricFilter {
+	return WhitelistIf(func(name string) bool {
+		for _, n := range names {
+			if name == n {
+				return true
+			}
+		}
+		return false
+	})
+}
+
+// ModifyName changes a metric its name using the provided
+// function.
+func ModifyName(f func(string) string) MetricFilter {
+	return withVarFilter(func(st state) state {
+		st.name = f(st.name)
+		return st
+	})
+}
+
+// Rename renames a metric to `to`, if the names matches `from`
+// If the name matches, it will be automatically white-listed.
+func Rename(from, to string) MetricFilter {
+	return withVarFilter(func(st state) state {
+		if st.name == from {
+			st.action, st.name = actAccept, to
+		}
+		return st
+	})
+}
+
+// NameReplace replaces substrings in a metrics names with `new`.
+func NameReplace(old, new string) MetricFilter {
+	return ModifyName(func(name string) string {
+		return strings.Replace(name, old, new, -1)
+	})
+}
+
+// ToLowerName converts all metric names to lower-case
+var ToLowerName = ModifyName(strings.ToLower)
+
+// ToUpperName converts all metric name to upper-case
+var ToUpperName = ModifyName(strings.ToUpper)
+
+// withVarFilter lifts a varFilter into a MetricFilter
+func withVarFilter(f varFilter) MetricFilter {
+	return func(m *metricFilters) *metricFilters {
+		m.filters = append(m.filters, f)
+		return m
+	}
+}

--- a/libbeat/monitoring/adapter/filters_test.go
+++ b/libbeat/monitoring/adapter/filters_test.go
@@ -1,0 +1,77 @@
+package adapter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFilters(t *testing.T) {
+	tests := []struct {
+		start    state
+		filters  *metricFilters
+		expected state
+	}{
+		{
+			state{action: actIgnore, name: "test"},
+			nil,
+			state{action: actIgnore, name: "test"},
+		},
+		{
+			state{action: actIgnore, name: "test"},
+			makeFilters(),
+			state{action: actIgnore, name: "test"},
+		},
+		{
+			state{action: actIgnore, name: "test"},
+			makeFilters(
+				WhitelistIf(func(_ string) bool { return true }),
+			),
+			state{action: actAccept, name: "test"},
+		},
+		{
+			state{action: actIgnore, name: "test"},
+			makeFilters(
+				WhitelistIf(func(_ string) bool { return false }),
+			),
+			state{action: actIgnore, name: "test"},
+		},
+		{
+			state{action: actIgnore, name: "test"},
+			makeFilters(Whitelist("other")),
+			state{action: actIgnore, name: "test"},
+		},
+		{
+			state{action: actIgnore, name: "test"},
+			makeFilters(Whitelist("test")),
+			state{action: actAccept, name: "test"},
+		},
+		{
+			state{action: actIgnore, name: "test"},
+			makeFilters(Rename("test", "new")),
+			state{action: actAccept, name: "new"},
+		},
+		{
+			state{action: actIgnore, name: "t-e-s-t"},
+			makeFilters(NameReplace("-", ".")),
+			state{action: actIgnore, name: "t.e.s.t"},
+		},
+		{
+			state{action: actIgnore, name: "test"},
+			makeFilters(ToUpperName),
+			state{action: actIgnore, name: "TEST"},
+		},
+		{
+			state{action: actIgnore, name: "TEST"},
+			makeFilters(ToLowerName),
+			state{action: actIgnore, name: "test"},
+		},
+	}
+
+	for i, test := range tests {
+		t.Logf("run test (%v): %v => %v", i, test.start, test.expected)
+
+		actual := test.filters.apply(test.start)
+		assert.Equal(t, test.expected, actual)
+	}
+}

--- a/libbeat/monitoring/adapter/go-metrics-wrapper.go
+++ b/libbeat/monitoring/adapter/go-metrics-wrapper.go
@@ -1,0 +1,77 @@
+package adapter
+
+import (
+	"github.com/elastic/beats/libbeat/monitoring"
+	metrics "github.com/rcrowley/go-metrics"
+)
+
+// go-metrics wrapper interface required to unpack the original metric
+type goMetricsWrapper interface {
+	wrapped() interface{}
+}
+
+// go-metrics wrappers
+type (
+	goMetricsCounter struct{ c metrics.Counter }
+
+	goMetricsGauge        struct{ g metrics.Gauge }
+	goMetricsGaugeFloat64 struct{ g metrics.GaugeFloat64 }
+
+	goMetricsFuncGauge      struct{ g metrics.FunctionalGauge }
+	goMetricsFuncGaugeFloat struct {
+		g metrics.FunctionalGaugeFloat64
+	}
+
+	goMetricsHistogram struct{ h metrics.Histogram }
+
+	goMetricsMeter struct{ m metrics.Meter }
+)
+
+// goMetricsWrap tries to wrap a metric for use with monitoring package.
+func goMetricsWrap(metric interface{}) (monitoring.Var, bool) {
+	switch v := metric.(type) {
+	case *metrics.StandardCounter:
+		return goMetricsCounter{v}, true
+	case *metrics.StandardGauge:
+		return goMetricsGauge{v}, true
+	case *metrics.StandardGaugeFloat64:
+		return goMetricsGaugeFloat64{v}, true
+	case metrics.FunctionalGauge:
+		return goMetricsFuncGauge{v}, true
+	case metrics.FunctionalGaugeFloat64:
+		return goMetricsFuncGaugeFloat{v}, true
+	case *metrics.StandardHistogram:
+		return goMetricsHistogram{v}, true
+	case *metrics.StandardMeter:
+		return goMetricsMeter{v}, true
+	}
+	return nil, false
+}
+
+func (w goMetricsCounter) wrapped() interface{}              { return w.c }
+func (w goMetricsCounter) Get() int64                        { return w.c.Count() }
+func (w goMetricsCounter) Visit(vs monitoring.Visitor) error { return vs.OnInt(w.Get()) }
+
+func (w goMetricsGauge) wrapped() interface{}              { return w.g }
+func (w goMetricsGauge) Get() int64                        { return w.g.Value() }
+func (w goMetricsGauge) Visit(vs monitoring.Visitor) error { return vs.OnInt(w.Get()) }
+
+func (w goMetricsGaugeFloat64) wrapped() interface{}              { return w.g }
+func (w goMetricsGaugeFloat64) Get() float64                      { return w.g.Value() }
+func (w goMetricsGaugeFloat64) Visit(vs monitoring.Visitor) error { return vs.OnFloat(w.Get()) }
+
+func (w goMetricsFuncGauge) wrapped() interface{}              { return w.g }
+func (w goMetricsFuncGauge) Get() int64                        { return w.g.Value() }
+func (w goMetricsFuncGauge) Visit(vs monitoring.Visitor) error { return vs.OnInt(w.Get()) }
+
+func (w goMetricsFuncGaugeFloat) wrapped() interface{}              { return w.g }
+func (w goMetricsFuncGaugeFloat) Get() float64                      { return w.g.Value() }
+func (w goMetricsFuncGaugeFloat) Visit(vs monitoring.Visitor) error { return vs.OnFloat(w.Get()) }
+
+func (w goMetricsHistogram) wrapped() interface{}              { return w.h }
+func (w goMetricsHistogram) Get() int64                        { return w.h.Sum() }
+func (w goMetricsHistogram) Visit(vs monitoring.Visitor) error { return vs.OnInt(w.Get()) }
+
+func (w goMetricsMeter) wrapped() interface{}              { return w.m }
+func (w goMetricsMeter) Get() int64                        { return w.m.Count() }
+func (w goMetricsMeter) Visit(vs monitoring.Visitor) error { return vs.OnInt(w.Get()) }

--- a/libbeat/monitoring/adapter/go-metrics.go
+++ b/libbeat/monitoring/adapter/go-metrics.go
@@ -1,0 +1,207 @@
+package adapter
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/monitoring"
+	metrics "github.com/rcrowley/go-metrics"
+)
+
+// implement adapter for adding go-metrics based counters
+// to monitoring
+
+// GoMetricsRegistry wraps a monitoring.Registry for filtering and registering
+// go-metrics based metrics with the monitoring package. GoMetricsRegistry implements
+// the go-metrics.Registry interface.
+//
+// Note: with the go-metrics using `interface{}`, there is no guarantee
+//       a variable satisfying any of go-metrics interfaces is returned.
+//       It's recommended to not mix go-metrics with other metrics types
+//       in the same namespace.
+type GoMetricsRegistry struct {
+	reg     *monitoring.Registry
+	filters *metricFilters
+
+	shadow metrics.Registry // store non-accepted metrics
+}
+
+// GetGoMetrics wraps an existing monitoring.Registry with `name` into a
+// GoMetricsRegistry for using the registry with go-metrics.Registry.
+// If the monitoring.Registry does not exist yet, a new one will be generated.
+//
+// Note: with users of go-metrics potentially removing any metric at runtime,
+//       it's recommended to have the underlying registry being generated with
+//       `monitoring.IgnorePublishExpvar`.
+func GetGoMetrics(parent *monitoring.Registry, name string, filters ...MetricFilter) *GoMetricsRegistry {
+	v := parent.Get(name)
+	if v == nil {
+		return NewGoMetrics(parent, name, filters...)
+	}
+
+	reg := v.(*monitoring.Registry)
+	return &GoMetricsRegistry{
+		reg:     reg,
+		shadow:  metrics.NewRegistry(),
+		filters: makeFilters(filters...),
+	}
+}
+
+// NewGoMetrics creates and registers a new GoMetricsRegistry with the parent
+// registry.
+func NewGoMetrics(parent *monitoring.Registry, name string, filters ...MetricFilter) *GoMetricsRegistry {
+	return &GoMetricsRegistry{
+		reg:     parent.NewRegistry(name, monitoring.IgnorePublishExpvar),
+		shadow:  metrics.NewRegistry(),
+		filters: makeFilters(filters...),
+	}
+}
+
+// Each only iterates the shadowed metrics, not registered to the monitoring package,
+// as those metrics are owned by monitoring.Registry only.
+func (r *GoMetricsRegistry) Each(f func(string, interface{})) {
+	r.shadow.Each(f)
+}
+
+func (r *GoMetricsRegistry) find(name string) interface{} {
+	st := r.findState(name)
+	if st.action == actIgnore {
+		return nil
+	}
+
+	return r.reg.Get(st.name)
+}
+
+// Get retrieves a registered metric by name. If the name is unknown, Get returns nil.
+//
+// Note: with the return values being `interface{}`, there is no guarantee
+//       a variable satisfying any of go-metrics interfaces is returned.
+//       It's recommended to not mix go-metrics with other metrics types in one
+//       namespace.
+func (r *GoMetricsRegistry) Get(name string) interface{} {
+	m := r.find(name)
+	if m == nil {
+		return r.shadow.Get(name)
+	}
+
+	if w, ok := m.(goMetricsWrapper); ok {
+		return w.wrapped()
+	}
+
+	return m
+}
+
+// GetOrRegister retries an existing metric via `Get` or registers a new one
+// if the metric is unknown. For lazy instantiation metric can be a function.
+func (r *GoMetricsRegistry) GetOrRegister(name string, metric interface{}) interface{} {
+	v := r.Get(name)
+	if v != nil {
+		return v
+	}
+
+	return r.doRegister(name, metric)
+}
+
+// Register adds a new metric.
+// An error is returned if the metric is already known.
+func (r *GoMetricsRegistry) Register(name string, metric interface{}) error {
+	if r.Get(name) != nil {
+		return fmt.Errorf("metric '%v' already registered", name)
+	}
+
+	r.doRegister(name, metric)
+	return nil
+}
+
+func (r *GoMetricsRegistry) doRegister(name string, metric interface{}) interface{} {
+	if v := reflect.ValueOf(metric); v.Kind() == reflect.Func {
+		metric = v.Call(nil)[0].Interface()
+	}
+
+	st := r.addState(name, metric)
+	if st.action == actIgnore {
+		return r.shadow.GetOrRegister(name, st.metric)
+	}
+
+	if st.action == actAccept {
+		w, ok := goMetricsWrap(st.metric)
+		if ok {
+			r.reg.Add(st.name, w)
+		}
+	}
+
+	return st.metric
+}
+
+// RunHealthchecks is a noop, required to satisfy the metrics.Registry interface.
+func (r *GoMetricsRegistry) RunHealthchecks() {}
+
+// Unregister removes a metric.
+func (r *GoMetricsRegistry) Unregister(name string) {
+	st := r.rmState(name)
+	r.reg.Remove(st.name)
+	r.shadow.Unregister(name)
+}
+
+// UnregisterAll calls `Clear` on the underlying monitoring.Registry
+func (r *GoMetricsRegistry) UnregisterAll() {
+	r.shadow.UnregisterAll()
+	err := r.reg.Clear()
+	if err != nil {
+		logp.Err("Failed to clear registry: %v", err)
+	}
+}
+
+func (r *GoMetricsRegistry) findState(name string) state {
+	return r.stateWith(kndFind, name, nil)
+}
+
+func (r *GoMetricsRegistry) addState(name string, metric interface{}) state {
+	return r.stateWith(kndAdd, name, metric)
+}
+
+func (r *GoMetricsRegistry) rmState(name string) state {
+	return r.stateWith(kndRemove, name, nil)
+}
+
+func (r *GoMetricsRegistry) stateWith(k kind, name string, metric interface{}) state {
+	return r.filters.apply(state{
+		kind:   k,
+		action: actIgnore,
+		reg:    r.reg,
+		name:   name,
+		metric: metric,
+	})
+}
+
+// GoMetricsRegistry MetricFilter used to convert all metrics not being
+// accepted by the filters to be replace with a Noop-metric.
+// This can be used to disable metrics in go-metrics users lazily generating
+// metrics via GetOrRegister.
+var GoMetricsNilify = withVarFilter(func(st state) state {
+	if st.action != actIgnore {
+		return st
+	}
+
+	switch st.metric.(type) {
+	case *metrics.StandardCounter:
+		st.metric = metrics.NilCounter{}
+	case *metrics.StandardEWMA:
+		st.metric = metrics.NilEWMA{}
+	case *metrics.StandardGauge:
+		st.metric = metrics.NilGauge{}
+	case *metrics.StandardGaugeFloat64:
+		st.metric = metrics.NilGaugeFloat64{}
+	case *metrics.StandardHealthcheck:
+		st.metric = metrics.NilHealthcheck{}
+	case *metrics.StandardHistogram:
+		st.metric = metrics.NilHistogram{}
+	case *metrics.StandardMeter:
+		st.metric = metrics.NilMeter{}
+	case *metrics.StandardTimer:
+		st.metric = metrics.NilTimer{}
+	}
+
+	return st
+})

--- a/libbeat/monitoring/adapter/go-metrics_test.go
+++ b/libbeat/monitoring/adapter/go-metrics_test.go
@@ -1,0 +1,89 @@
+package adapter
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/elastic/beats/libbeat/monitoring"
+	metrics "github.com/rcrowley/go-metrics"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGoMetricsAdapter(t *testing.T) {
+	filters := []MetricFilter{
+		WhitelistIf(func(name string) bool {
+			return strings.HasPrefix(name, "mon")
+		}),
+		ApplyIf(
+			func(name string) bool {
+				return strings.HasPrefix(name, "ign")
+			},
+			GoMetricsNilify,
+		),
+	}
+
+	counters := map[string]int64{
+		"mon-counter": 42,
+		"ign-counter": 0,
+		"counter":     42,
+	}
+	meters := map[string]int64{
+		"mon-meter": 23,
+		"ign-meter": 0,
+		"meter":     23,
+	}
+
+	monReg := monitoring.NewRegistry()
+	var reg metrics.Registry = GetGoMetrics(monReg, "test", filters...)
+
+	// register some metrics and check they're satisfying the go-metrics interface
+	// no matter if owned by monitoring or go-metrics
+	for name := range counters {
+		cnt := reg.GetOrRegister(name, func() interface{} {
+			return metrics.NewCounter()
+		}).(metrics.Counter)
+		cnt.Clear()
+	}
+
+	for name := range meters {
+		meter := reg.GetOrRegister(name, func() interface{} {
+			return metrics.NewMeter()
+		}).(metrics.Meter)
+		meter.Count()
+	}
+
+	// get and increase registered metrics
+	for name := range counters {
+		cnt := reg.Get(name).(metrics.Counter)
+		cnt.Inc(21)
+		cnt.Inc(21)
+	}
+	for name := range meters {
+		meter := reg.Get(name).(metrics.Meter)
+		meter.Mark(11)
+		meter.Mark(12)
+	}
+
+	// compare metric values to expected values
+	for name, value := range counters {
+		cnt := reg.Get(name).(metrics.Counter)
+		assert.Equal(t, value, cnt.Count())
+	}
+	for name, value := range meters {
+		meter := reg.Get(name).(metrics.Meter)
+		assert.Equal(t, value, meter.Count())
+	}
+
+	// check Each only returns metrics not registered with monitoring.Registry
+	reg.Each(func(name string, v interface{}) {
+		if strings.HasPrefix(name, "mon") {
+			t.Errorf("metric %v should not have been reported by each", name)
+		}
+	})
+	monReg.Do(func(name string, v interface{}) error {
+		if !strings.HasPrefix(name, "test.mon") {
+			t.Errorf("metric %v should not have been reported by each", name)
+		}
+		return nil
+	})
+}

--- a/libbeat/monitoring/metrics.go
+++ b/libbeat/monitoring/metrics.go
@@ -1,0 +1,83 @@
+package monitoring
+
+import (
+	"math"
+	"sync"
+	"sync/atomic"
+)
+
+// makeExpvar wraps a callback for registering a metrics with expvar.Publish.
+type makeExpvar func() string
+
+// Int is a 64 bit integer variable satisfying the Var interface.
+type Int struct{ i int64 }
+
+// NewInt registers a new global integer metrics.
+func NewInt(name string) *Int {
+	return Default.NewInt(name)
+}
+
+func (v *Int) Visit(vs Visitor) error { return vs.OnInt(v.Get()) }
+func (v *Int) Get() int64             { return atomic.LoadInt64(&v.i) }
+func (v *Int) Set(value int64)        { atomic.StoreInt64(&v.i, value) }
+func (v *Int) Add(delta int64)        { atomic.AddInt64(&v.i, delta) }
+func (v *Int) Inc()                   { atomic.AddInt64(&v.i, 1) }
+func (v *Int) Dec()                   { atomic.AddInt64(&v.i, -1) }
+
+// Float is a 64 bit float variable satisfying the Var interface.
+type Float struct{ f uint64 }
+
+// NewFloat registers a new global floating point metric.
+func NewFloat(name string) *Float {
+	return Default.NewFloat(name)
+}
+
+func (v *Float) Visit(vs Visitor) error { return vs.OnFloat(v.Get()) }
+func (v *Float) Get() float64           { return math.Float64frombits(atomic.LoadUint64(&v.f)) }
+func (v *Float) Set(value float64)      { atomic.StoreUint64(&v.f, math.Float64bits(value)) }
+func (v *Float) Sub(delta float64)      { v.Add(-delta) }
+
+func (v *Float) Add(delta float64) {
+	for {
+		cur := atomic.LoadUint64(&v.f)
+		next := math.Float64bits(math.Float64frombits(cur) + delta)
+		if atomic.CompareAndSwapUint64(&v.f, cur, next) {
+			return
+		}
+	}
+}
+
+// String is a string variable satisfying the Var interface.
+type String struct {
+	mu sync.RWMutex
+	s  string
+}
+
+// NewString registers a new global string metric.
+func NewString(name string) *String {
+	return Default.NewString(name)
+}
+
+func (v *String) Visit(vs Visitor) error { return vs.OnString(v.Get()) }
+
+func (v *String) Get() string {
+	v.mu.RLock()
+	defer v.mu.RUnlock()
+	return v.s
+}
+
+func (v *String) Set(s string) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	v.s = s
+}
+
+func (v *String) Clear() {
+	v.Set("")
+}
+
+func (v *String) Fail(err error) {
+	v.Set(err.Error())
+}
+
+func (m makeExpvar) String() string { return m() }

--- a/libbeat/monitoring/monitoring.go
+++ b/libbeat/monitoring/monitoring.go
@@ -1,0 +1,33 @@
+package monitoring
+
+import "errors"
+
+// Default is the global default metrics registry provided by the monitoring package.
+var Default = NewRegistry()
+
+var errNotFound = errors.New("Name unknown")
+var errInvalidName = errors.New("Name does not point to a valid variable")
+
+func Visit(vs Visitor) error {
+	return Default.Visit(vs)
+}
+
+func Do(f func(string, interface{}) error) error {
+	return Default.Do(f)
+}
+
+func Get(name string) interface{} {
+	return Default.Get(name)
+}
+
+func GetRegistry(name string) *Registry {
+	return Default.GetRegistry(name)
+}
+
+func Remove(name string) {
+	Default.Remove(name)
+}
+
+func Clear() error {
+	return Default.Clear()
+}

--- a/libbeat/monitoring/opts.go
+++ b/libbeat/monitoring/opts.go
@@ -1,0 +1,46 @@
+package monitoring
+
+// Option type for passing additional options to NewRegistry.
+type Option func(options) options
+
+type options struct {
+	publishExpvar bool
+}
+
+var defaultOptions = options{
+	publishExpvar: false,
+}
+
+// PublishExpvar enables publishing all registered variables via expvar interface.
+// Note: expvar does not allow removal of any stats.
+func PublishExpvar(o options) options {
+	o.publishExpvar = true
+	return o
+}
+
+// IgnorePublishExpvar disables publishing expvar variables in a sub-registry.
+func IgnorePublishExpvar(o options) options {
+	o.publishExpvar = false
+	return o
+}
+
+func applyOpts(in *options, opts []Option) *options {
+	if len(opts) == 0 {
+		return ensureOptions(in)
+	}
+
+	tmp := *ensureOptions(in)
+	for _, opt := range opts {
+		tmp = opt(tmp)
+	}
+	return &tmp
+}
+
+func ensureOptions(in *options) *options {
+	if in != nil {
+		return in
+	}
+
+	tmp := defaultOptions
+	return &tmp
+}

--- a/libbeat/monitoring/opts_test.go
+++ b/libbeat/monitoring/opts_test.go
@@ -1,0 +1,67 @@
+// +build !integration
+
+package monitoring
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOptions(t *testing.T) {
+	tests := []struct {
+		name     string
+		parent   *options
+		options  []Option
+		expected options
+	}{
+		{
+			"empty parent without opts should generate defaults",
+			nil,
+			nil,
+			defaultOptions,
+		},
+		{
+			"non empty parent should return same options",
+			&options{},
+			nil,
+			options{},
+		},
+		{
+			"apply publishexpvar",
+			&options{publishExpvar: false},
+			[]Option{PublishExpvar},
+			options{publishExpvar: true},
+		},
+		{
+			"apply disable publishexpvar",
+			&options{publishExpvar: true},
+			[]Option{IgnorePublishExpvar},
+			options{publishExpvar: false},
+		},
+	}
+
+	for i, test := range tests {
+		t.Logf("run test (%v): %v", i, test.name)
+
+		origParent := options{}
+		if test.parent != nil {
+			origParent = *test.parent
+		}
+		actual := applyOpts(test.parent, test.options)
+		assert.NotNil(t, actual)
+
+		// test parent has not been modified by accident
+		if test.parent != nil {
+			assert.Equal(t, origParent, *test.parent)
+		}
+
+		// check parent and actual are same object if options is nil
+		if test.parent != nil && test.options == nil {
+			assert.Equal(t, test.parent, actual)
+		}
+
+		// validate output
+		assert.Equal(t, test.expected, *actual)
+	}
+}

--- a/libbeat/monitoring/registry.go
+++ b/libbeat/monitoring/registry.go
@@ -1,0 +1,289 @@
+package monitoring
+
+import (
+	"encoding/json"
+	"errors"
+	"expvar"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// Registry to store variables and sub-registries.
+// When adding or retrieving variables, all names are split on the `.`-symbol and
+// intermediate registries will be generated.
+type Registry struct {
+	mu sync.RWMutex
+
+	name    string
+	entries map[string]Var
+
+	opts *options
+}
+
+// Var interface required for every metric to implement.
+type Var interface {
+	Visit(Visitor) error
+}
+
+// NewRegistry create a new empty unregistered registry
+func NewRegistry(opts ...Option) *Registry {
+	return &Registry{
+		opts:    applyOpts(nil, opts),
+		entries: map[string]Var{},
+	}
+}
+
+func (r *Registry) Do(f func(string, interface{}) error) error {
+	return r.Visit(NewKeyValueVisitor(f))
+}
+
+// Visit uses the Visitor interface to iterate the complete metrics hieararchie.
+// In case of the visitor reporting an error, Visit will return immediately,
+// reporting the very same error.
+func (r *Registry) Visit(vs Visitor) error {
+	if err := vs.OnRegistryStart(); err != nil {
+		return err
+	}
+
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	first := true
+	for key, v := range r.entries {
+		if first {
+			first = false
+		} else {
+			if err := vs.OnKeyNext(); err != nil {
+				return err
+			}
+		}
+
+		if err := vs.OnKey(key); err != nil {
+			return err
+		}
+
+		if err := v.Visit(vs); err != nil {
+			return err
+		}
+	}
+
+	return vs.OnRegistryFinished()
+}
+
+// NewRegistry creates and register a new registry
+func (r *Registry) NewRegistry(name string, opts ...Option) *Registry {
+	v := &Registry{
+		name:    r.fullName(name),
+		opts:    applyOpts(r.opts, opts),
+		entries: map[string]Var{},
+	}
+	r.Add(name, v)
+	return v
+}
+
+// NewInt creates and registers a new integer variable.
+//
+// Note: If the registry is configured to publish variables to expvar, the
+// variable will be available via expvars package as well, but can not be removed
+// anymore.
+func (r *Registry) NewInt(name string) *Int {
+	v := &Int{}
+	r.Add(name, v)
+	r.publish(name, makeExpvar(func() string {
+		return strconv.FormatInt(v.Get(), 10)
+	}))
+	return v
+}
+
+// NewFloat creates and registers a new float variable.
+//
+// Note: If the registry is configured to publish variables to expvar, the
+// variable will be available via expvars package as well, but can not be removed
+// anymore.
+func (r *Registry) NewFloat(name string) *Float {
+	v := &Float{}
+	r.Add(name, v)
+	r.publish(name, makeExpvar(func() string {
+		return strconv.FormatFloat(v.Get(), 'g', -1, 64)
+	}))
+	return v
+}
+
+// NewString creates and registers a new string variable.
+//
+// Note: If the registry is configured to publish variables to expvar, the
+// variable will be available via expvars package as well, but can not be removed
+// anymore.
+func (r *Registry) NewString(name string) *String {
+	v := &String{}
+	r.Add(name, v)
+	r.publish(name, makeExpvar(func() string {
+		b, _ := json.Marshal(v.Get())
+		return string(b)
+	}))
+	return v
+}
+
+// Get tries to find a registered variable by name.
+func (r *Registry) Get(name string) interface{} {
+	v, err := r.find(name)
+	if err != nil {
+		return nil
+	}
+	return v
+}
+
+// GetRegistry tries to find a sub-registry by name.
+func (r *Registry) GetRegistry(name string) *Registry {
+	v, err := r.find(name)
+	if err != nil {
+		return nil
+	}
+
+	if v == nil {
+		return nil
+	}
+
+	reg, ok := v.(*Registry)
+	if !ok {
+		return nil
+	}
+
+	return reg
+}
+
+// Remove removes a variable or a sub-registry by name
+func (r *Registry) Remove(name string) {
+	r.removeNames(strings.Split(name, "."))
+}
+
+// Clear removes all entries from the current registry
+func (r *Registry) Clear() error {
+	r.mu.Lock()
+	r.mu.Unlock()
+
+	if r.opts.publishExpvar {
+		return errors.New("Can not clear registry with metrics being exported via expvar")
+	}
+
+	r.entries = map[string]Var{}
+	return nil
+}
+
+func (r *Registry) publish(name string, v expvar.Var) {
+	if !r.opts.publishExpvar {
+		return
+	}
+
+	expvar.Publish(r.fullName(name), v)
+}
+
+func (r *Registry) fullName(name string) string {
+	if r.name == "" {
+		return name
+	}
+	return r.name + "." + name
+}
+
+// Add adds a new variable to the registry. The method panics if the variables
+// name is already in use.
+func (r *Registry) Add(name string, v Var) {
+	panicErr(r.addNames(strings.Split(name, "."), v))
+}
+
+func (r *Registry) addNames(names []string, v Var) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	name := names[0]
+	if len(names) == 1 {
+		if _, found := r.entries[name]; found {
+			return fmt.Errorf("name %v already used", name)
+		}
+
+		r.entries[name] = v
+		return nil
+	}
+
+	if tmp, found := r.entries[name]; found {
+		reg, ok := tmp.(*Registry)
+		if !ok {
+			return fmt.Errorf("name %v already used", name)
+		}
+
+		return reg.addNames(names[1:], v)
+	}
+
+	sub := NewRegistry()
+	sub.opts = r.opts
+	if err := sub.addNames(names[1:], v); err != nil {
+		return err
+	}
+
+	r.entries[name] = sub
+	return nil
+}
+
+func (r *Registry) find(name string) (interface{}, error) {
+	return r.findNames(strings.Split(name, "."))
+}
+
+func (r *Registry) findNames(names []string) (interface{}, error) {
+	switch len(names) {
+	case 0:
+		return r, nil
+	case 1:
+		r.mu.RLock()
+		defer r.mu.RUnlock()
+		return r.entries[names[0]], nil
+	}
+
+	r.mu.RLock()
+	next := r.entries[names[0]]
+	r.mu.RUnlock()
+
+	if next == nil {
+		return nil, errNotFound
+	}
+
+	if reg, ok := next.(*Registry); ok {
+		return reg.findNames(names[1:])
+	}
+	return nil, errInvalidName
+}
+
+func (r *Registry) removeNames(names []string) {
+	switch len(names) {
+	case 0:
+		return
+	case 1:
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		delete(r.entries, names[0])
+		return
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	next := r.entries[names[0]]
+	sub, ok := next.(*Registry)
+
+	// if name does not exist => don't remove anything
+	if ok {
+		sub.removeNames(names[1:])
+		sub.mu.RLock()
+		sub.mu.RUnlock()
+
+		if len(sub.entries) == 0 {
+			delete(r.entries, names[0])
+		}
+	}
+}
+
+func panicErr(err error) {
+	if err != nil {
+		panic(err)
+	}
+}

--- a/libbeat/monitoring/registry_test.go
+++ b/libbeat/monitoring/registry_test.go
@@ -1,0 +1,128 @@
+// +build !integration
+
+package monitoring
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRegistryEmpty(t *testing.T) {
+	defer Clear()
+
+	// get value
+	v := Get("missing")
+	if v != nil {
+		t.Errorf("got %v, wanted nil", v)
+	}
+
+	// get value with recursive lookup
+	v = Get("missing.value")
+	if v != nil {
+		t.Errorf("got %v, wanted nil", v)
+	}
+
+	// get missing registry
+	reg := GetRegistry("missing")
+	if reg != nil {
+		t.Errorf("got %v, wanted nil", reg)
+	}
+
+	// get registry with recursive lookup
+	reg = GetRegistry("missing.registry")
+	if reg != nil {
+		t.Errorf("got %v, wanted nil", reg)
+	}
+}
+
+func TestRegistryGet(t *testing.T) {
+	defer Clear()
+
+	name1 := "v"
+	nameSub1 := "sub.registry1"
+	nameSub2 := "sub.registry2"
+	name2 := nameSub1 + "." + name1
+	name3 := nameSub2 + "." + name1
+
+	// register top-level and recursive metric
+	v1 := NewInt(name1)
+	sub1 := Default.NewRegistry(nameSub1)
+	sub2 := Default.NewRegistry(nameSub2)
+	v2 := NewString(name2)
+	v3 := sub2.NewFloat(name1)
+
+	// get values
+	v := Get(name1)
+	assert.Equal(t, v, v1)
+
+	// get nested metric from top-level
+	v = Get(name2)
+	assert.Equal(t, v, v2)
+	v = Get(name3)
+	assert.Equal(t, v, v3)
+
+	// get sub registry
+	reg1 := GetRegistry(nameSub1)
+	assert.Equal(t, sub1, reg1)
+	reg2 := GetRegistry(nameSub2)
+	assert.Equal(t, sub2, reg2)
+
+	// get value from sub-registry
+	v = reg1.Get(name1)
+	assert.Equal(t, v, v2)
+
+	v = reg2.Get(name1)
+	assert.Equal(t, v, v3)
+}
+
+func TestRegistryRemove(t *testing.T) {
+	defer Clear()
+
+	name1 := "v"
+	nameSub1 := "sub.registry1"
+	nameSub2 := "sub.registry2"
+	name2 := nameSub1 + "." + name1
+	name3 := nameSub2 + "." + name1
+
+	// register top-level and recursive metric
+	NewInt(name1)
+	sub1 := Default.NewRegistry(nameSub1)
+	sub2 := Default.NewRegistry(nameSub2)
+	NewInt(name2)
+	sub2.NewInt(name1)
+
+	// remove metrics:
+	Remove(name1)
+	sub1.Remove(name1) // == Remove(name2)
+	Remove(name3)      // remove name 3 recursively
+
+	// check no variable is reachable
+	assert.Nil(t, Get(name1))
+	assert.Nil(t, Get(name2))
+	assert.Nil(t, Get(name3))
+}
+
+func TestRegistryIter(t *testing.T) {
+	defer Clear()
+
+	vars := map[string]int64{
+		"sub.registry.v1": 1,
+		"sub.registry.v2": 2,
+		"v3":              3,
+	}
+
+	for name, v := range vars {
+		i := NewInt(name)
+		i.Add(v)
+	}
+
+	collected := map[string]int64{}
+	err := Do(func(name string, v interface{}) error {
+		collected[name] = v.(int64)
+		return nil
+	})
+
+	assert.Nil(t, err)
+	assert.Equal(t, vars, collected)
+}

--- a/libbeat/monitoring/visitor.go
+++ b/libbeat/monitoring/visitor.go
@@ -1,0 +1,26 @@
+package monitoring
+
+// Visitor interface supports traversing a monitoring registry
+type Visitor interface {
+	ValueVisitor
+	RegistryVisitor
+}
+
+type ValueVisitor interface {
+	OnString(s string) error
+	OnBool(b bool) error
+	OnNil() error
+
+	// int
+	OnInt(i int64) error
+
+	// float
+	OnFloat(f float64) error
+}
+
+type RegistryVisitor interface {
+	OnRegistryStart() error
+	OnRegistryFinished() error
+	OnKey(s string) error
+	OnKeyNext() error
+}

--- a/libbeat/monitoring/visitor_expvar.go
+++ b/libbeat/monitoring/visitor_expvar.go
@@ -1,0 +1,87 @@
+package monitoring
+
+import (
+	"encoding/json"
+	"expvar"
+	"strconv"
+)
+
+// VisitExpvars iterates all expvar metrics using the Visitor interface.
+// The top-level metrics "memstats" and "cmdline", plus all monitoring.X metric types
+// are ignored.
+func VisitExpvars(vs Visitor) {
+	vs.OnRegistryStart()
+	expvar.Do(makeExparVisitor(0, vs))
+	vs.OnRegistryFinished()
+}
+
+func DoExpvars(f func(string, interface{})) {
+	VisitExpvars(NewKeyValueVisitor(func(name string, v interface{}) error {
+		f(name, v)
+		return nil
+	}))
+}
+
+func makeExparVisitor(level int, vs Visitor) func(expvar.KeyValue) {
+	first := true
+	return func(kv expvar.KeyValue) {
+		if ignoreExpvar(level, kv) {
+			return
+		}
+
+		if first {
+			first = false
+		} else {
+			vs.OnKeyNext()
+		}
+
+		name := kv.Key
+		variable := kv.Value
+		switch v := variable.(type) {
+		case *expvar.Int:
+			i, _ := strconv.ParseInt(v.String(), 10, 64)
+			vs.OnKey(name)
+			vs.OnInt(i)
+
+		case *expvar.Float:
+			f, _ := strconv.ParseFloat(v.String(), 64)
+			vs.OnKey(name)
+			vs.OnFloat(f)
+
+		case *expvar.Map:
+			vs.OnKey(name)
+			vs.OnRegistryStart()
+			v.Do(makeExparVisitor(level+1, vs))
+			vs.OnRegistryFinished()
+
+		default:
+			vs.OnKey(name)
+			s := v.String()
+			if len(s) >= 2 && s[0] == '"' && s[len(s)-1] == '"' {
+				var tmp string
+				if err := json.Unmarshal([]byte(s), &tmp); err == nil {
+					s = tmp
+				}
+			}
+			vs.OnString(s)
+		}
+	}
+}
+
+// ignore if `monitoring` variable or some other internals
+// autmoatically registered by expvar against our wishes
+func ignoreExpvar(level int, kv expvar.KeyValue) bool {
+	switch kv.Value.(type) {
+	case makeExpvar, Var:
+		return true
+	}
+
+	if level == 0 {
+		switch kv.Key {
+		case "memstats", "cmdline":
+			return true
+		}
+	}
+
+	return false
+}

--- a/libbeat/monitoring/visitor_expvar_test.go
+++ b/libbeat/monitoring/visitor_expvar_test.go
@@ -1,0 +1,79 @@
+// +build !integration
+
+package monitoring
+
+import (
+	"expvar"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIterExpvarIgnoringMonitoringVars(t *testing.T) {
+	vars := map[string]int64{
+		"sub.registry.v1": 1,
+		"sub.registry.v2": 2,
+		"v3":              3,
+	}
+	collected := map[string]int64{}
+
+	reg := NewRegistry(PublishExpvar)
+	for name, v := range vars {
+		i := reg.NewInt(name)
+		i.Add(v)
+	}
+
+	DoExpvars(func(name string, v interface{}) {
+		if _, exists := vars[name]; exists {
+			collected[name] = v.(int64)
+		}
+	})
+	assert.Equal(t, map[string]int64{}, collected)
+}
+
+func TestIterExpvarCaptureVars(t *testing.T) {
+	i := getOrCreateInt("test.integer")
+	i.Set(42)
+
+	s := getOrCreateString("test.string")
+	s.Set("testing")
+
+	var m *expvar.Map
+	if v := expvar.Get("test.map"); v != nil {
+		m = v.(*expvar.Map)
+	} else {
+		m = expvar.NewMap("test.map")
+		m.Add("i1", 1)
+		m.Add("i2", 2)
+	}
+
+	expected := map[string]interface{}{
+		"test.integer": int64(42),
+		"test.string":  "testing",
+		"test.map.i1":  int64(1),
+		"test.map.i2":  int64(2),
+	}
+
+	collected := map[string]interface{}{}
+	DoExpvars(func(name string, v interface{}) {
+		if _, exists := expected[name]; exists {
+			collected[name] = v
+		}
+	})
+
+	assert.Equal(t, collected, expected)
+}
+
+func getOrCreateInt(name string) *expvar.Int {
+	if v := expvar.Get(name); v != nil {
+		return v.(*expvar.Int)
+	}
+	return expvar.NewInt(name)
+}
+
+func getOrCreateString(name string) *expvar.String {
+	if v := expvar.Get(name); v != nil {
+		return v.(*expvar.String)
+	}
+	return expvar.NewString(name)
+}

--- a/libbeat/monitoring/visitor_kv.go
+++ b/libbeat/monitoring/visitor_kv.go
@@ -1,0 +1,62 @@
+package monitoring
+
+import "strings"
+
+type KeyValueVisitor struct {
+	cb    func(key string, value interface{}) error
+	level []string
+}
+
+func NewKeyValueVisitor(cb func(string, interface{}) error) *KeyValueVisitor {
+	return &KeyValueVisitor{cb: cb}
+}
+
+func (vs *KeyValueVisitor) OnRegistryStart() error {
+	return nil
+}
+
+func (vs *KeyValueVisitor) OnRegistryFinished() error {
+	if len(vs.level) > 0 {
+		vs.dropName()
+	}
+	return nil
+}
+
+func (vs *KeyValueVisitor) OnKey(name string) error {
+	vs.level = append(vs.level, name)
+	return nil
+}
+
+func (vs *KeyValueVisitor) OnKeyNext() error { return nil }
+
+func (vs *KeyValueVisitor) getName() string {
+	defer vs.dropName()
+	if len(vs.level) == 1 {
+		return vs.level[0]
+	}
+	return strings.Join(vs.level, ".")
+}
+
+func (vs *KeyValueVisitor) dropName() {
+	vs.level = vs.level[:len(vs.level)-1]
+}
+
+func (vs *KeyValueVisitor) OnString(s string) error {
+	return vs.cb(vs.getName(), s)
+}
+
+func (vs *KeyValueVisitor) OnBool(b bool) error {
+	return vs.cb(vs.getName(), b)
+}
+
+func (vs *KeyValueVisitor) OnNil() error {
+	return vs.cb(vs.getName(), nil)
+}
+
+func (vs *KeyValueVisitor) OnInt(i int64) error {
+	return vs.cb(vs.getName(), i)
+}
+
+func (vs *KeyValueVisitor) OnFloat(f float64) error {
+	return vs.cb(vs.getName(), f)
+}

--- a/libbeat/outputs/kafka/kafka.go
+++ b/libbeat/outputs/kafka/kafka.go
@@ -14,6 +14,8 @@ import (
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/op"
 	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/monitoring"
+	"github.com/elastic/beats/libbeat/monitoring/adapter"
 	"github.com/elastic/beats/libbeat/outputs"
 	"github.com/elastic/beats/libbeat/outputs/mode"
 	"github.com/elastic/beats/libbeat/outputs/mode/modeutil"
@@ -270,6 +272,15 @@ func (k *kafka) newKafkaConfig() (*sarama.Config, error) {
 	}
 
 	cfg.Producer.Partitioner = k.partitioner
+
+	// TODO: figure out which metrics we want to collect
+	cfg.MetricRegistry = adapter.GetGoMetrics(
+		monitoring.Default,
+		"libbeat.output.kafka",
+		adapter.Rename("incoming-byte-rate", "bytes_read"),
+		adapter.Rename("outgoing-byte-rate", "bytes_write"),
+		adapter.GoMetricsNilify,
+	)
 	return cfg, nil
 }
 


### PR DESCRIPTION
expose some simple metrics collection via `libbeat/monitoring` package. 

Changes/Features:
- 30s metrics snapshot is now based on `libbeat/monitoring`, adding:
  - support for bool/float/string variables
  - keys are sorted before being printed
-  The package manages a hierarchical registry of known KPIs (names are split on `.`) with optional support for registering created KPIs to expvar package (metrics registered via expvar can not be removed).
- All metrics registered must support the `monitoring.Var` interface providing a `Visit` method for reporting metric values. The `monitoring.Visitor` explicitly limits the type of values being reportable, so no `interface{}` will be used, simplifying/unifying reporting/collecting metrics.
- Registry provides `Do` method to iterate all variables, with names being 'flattened' and thanks to limitations imposed by `monitoring.Var/Visitor` the values reported can only be int64, float64, string, bool or untyped nil. 
- Having a registry lowers chances of typos. e.g.

```
var (
    metrics := monitoring.Default.NewRegistry("libbeat.outputs.logstash")
    bytesSend := metrics.NewInt("bytes_send")
    ...
)
```
- package adds support for dynamic removal of metrics
- provides adapter for go-metrics (e.g. collect stats from kafka output) with selective whitelisting/renaming... for collecting stats we otherwise would have no access to.