### PR TITLE
Deprecate filebeat.config_dir config option

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -111,6 +111,7 @@ https://github.com/elastic/beats/compare/v5.1.1...master[Check the HEAD diff]
 - Fix error on importing dashboards due to colons in the Caassandra dashboard. {issue}3140[3140]
 
 *Filebeat*
+- Config option filebeat.config_dir is deprecated. It will be replaced in version 6.0 with a new implementation that also supports configuration reloading. {issue}3430[3430]
 
 *Winlogbeat*
 

--- a/filebeat/config/config.go
+++ b/filebeat/config/config.go
@@ -106,6 +106,8 @@ func (config *Config) FetchConfigs() error {
 		return nil
 	}
 
+	logp.Warn("Config option filebeat.config_dir is deprecated.")
+
 	// If configDir is relative, consider it relative to the config path
 	configDir = paths.Resolve(paths.Config, configDir)
 


### PR DESCRIPTION
The plan is replace this with a better implementation in the future similar to prospector reloading. See https://github.com/elastic/beats/pull/3362.