### PR TITLE
Export health metrics

### DIFF
--- a/libbeat/beat/metrics.go
+++ b/libbeat/beat/metrics.go
@@ -1,0 +1,33 @@
+package beat
+
+import (
+	"runtime"
+
+	"github.com/elastic/beats/libbeat/monitoring"
+)
+
+type memstatsVar struct{}
+
+var (
+	metrics = monitoring.Default.NewRegistry("beat")
+)
+
+func init() {
+
+	var ms memstatsVar
+	metrics.Add("memstats", ms, monitoring.Reported)
+}
+
+func (memstatsVar) Visit(m monitoring.Mode, V monitoring.Visitor) {
+	var stats runtime.MemStats
+	runtime.ReadMemStats(&stats)
+
+	V.OnRegistryStart()
+	defer V.OnRegistryFinished()
+
+	monitoring.ReportInt(V, "memory_total", int64(stats.TotalAlloc))
+	if m == monitoring.Full {
+		monitoring.ReportInt(V, "memory_alloc", int64(stats.Alloc))
+		monitoring.ReportInt(V, "gc_next", int64(stats.NextGC))
+	}
+}

--- a/libbeat/outputs/kafka/kafka.go
+++ b/libbeat/outputs/kafka/kafka.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/Shopify/sarama"
-	metrics "github.com/rcrowley/go-metrics"
+	gometrics "github.com/rcrowley/go-metrics"
 	"github.com/rcrowley/go-metrics/exp"
 
 	"github.com/elastic/beats/libbeat/common"
@@ -40,12 +40,12 @@ const (
 	defaultMaxWaitRetry = 60 * time.Second
 )
 
-var kafkaMetricsRegistryInstance metrics.Registry
+var kafkaMetricsRegistryInstance gometrics.Registry
 
 func init() {
 	sarama.Logger = kafkaLogger{}
 
-	reg := metrics.NewPrefixedRegistry("libbeat.kafka.")
+	reg := gometrics.NewPrefixedRegistry("libbeat.kafka.")
 
 	// Note: registers /debug/metrics handler for displaying all expvar counters
 	exp.Exp(reg)
@@ -56,7 +56,7 @@ func init() {
 
 var kafkaMetricsOnce sync.Once
 
-func kafkaMetricsRegistry() metrics.Registry {
+func kafkaMetricsRegistry() gometrics.Registry {
 	return kafkaMetricsRegistryInstance
 }
 

--- a/libbeat/outputs/logstash/async.go
+++ b/libbeat/outputs/logstash/async.go
@@ -165,6 +165,7 @@ func (r *msgRef) callback(seq uint32, err error) {
 
 func (r *msgRef) done(n uint32) {
 	ackedEvents.Add(int64(n))
+	outputs.AckedEvents.Add(int64(n))
 	r.batch = r.batch[n:]
 	r.win.tryGrowWindow(r.batchSize)
 	r.dec()
@@ -172,6 +173,7 @@ func (r *msgRef) done(n uint32) {
 
 func (r *msgRef) fail(n uint32, err error) {
 	ackedEvents.Add(int64(n))
+	outputs.AckedEvents.Add(int64(n))
 	r.err = err
 	r.batch = r.batch[n:]
 	r.win.shrinkWindow()

--- a/libbeat/outputs/logstash/logstash.go
+++ b/libbeat/outputs/logstash/logstash.go
@@ -4,7 +4,6 @@ package logstash
 // registered with all output plugins
 
 import (
-	"expvar"
 	"time"
 
 	"github.com/elastic/go-lumber/log"
@@ -12,6 +11,7 @@ import (
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/op"
 	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/monitoring"
 	"github.com/elastic/beats/libbeat/outputs"
 	"github.com/elastic/beats/libbeat/outputs/mode"
 	"github.com/elastic/beats/libbeat/outputs/mode/modeutil"
@@ -22,14 +22,14 @@ var debug = logp.MakeDebug("logstash")
 
 // Metrics that can retrieved through the expvar web interface.
 var (
-	ackedEvents            = expvar.NewInt("libbeat.logstash.published_and_acked_events")
-	eventsNotAcked         = expvar.NewInt("libbeat.logstash.published_but_not_acked_events")
-	publishEventsCallCount = expvar.NewInt("libbeat.logstash.call_count.PublishEvents")
+	ackedEvents            = monitoring.NewInt(outputs.Metrics, "logstash.events.acked")
+	eventsNotAcked         = monitoring.NewInt(outputs.Metrics, "logstash.events.not_acked")
+	publishEventsCallCount = monitoring.NewInt(outputs.Metrics, "logstash.publishEvents.call.count")
 
-	statReadBytes   = expvar.NewInt("libbeat.logstash.publish.read_bytes")
-	statWriteBytes  = expvar.NewInt("libbeat.logstash.publish.write_bytes")
-	statReadErrors  = expvar.NewInt("libbeat.logstash.publish.read_errors")
-	statWriteErrors = expvar.NewInt("libbeat.logstash.publish.write_errors")
+	statReadBytes   = monitoring.NewInt(outputs.Metrics, "logstash.read.bytes")
+	statWriteBytes  = monitoring.NewInt(outputs.Metrics, "logstash.write.bytes")
+	statReadErrors  = monitoring.NewInt(outputs.Metrics, "logstash.read.errors")
+	statWriteErrors = monitoring.NewInt(outputs.Metrics, "logstash.write.errors")
 )
 
 const (
@@ -80,10 +80,12 @@ func (lj *logstash) init(cfg *common.Config) error {
 		Proxy:   &config.Proxy,
 		TLS:     tls,
 		Stats: &transport.IOStats{
-			Read:        statReadBytes,
-			Write:       statWriteBytes,
-			ReadErrors:  statReadErrors,
-			WriteErrors: statWriteErrors,
+			Read:               statReadBytes,
+			Write:              statWriteBytes,
+			ReadErrors:         statReadErrors,
+			WriteErrors:        statWriteErrors,
+			OutputsWrite:       outputs.WriteBytes,
+			OutputsWriteErrors: outputs.WriteErrors,
 		},
 	}
 

--- a/libbeat/outputs/logstash/sync.go
+++ b/libbeat/outputs/logstash/sync.go
@@ -86,10 +86,12 @@ func (c *client) PublishEvents(
 
 			eventsNotAcked.Add(int64(len(data)))
 			ackedEvents.Add(int64(totalNumberOfEvents - len(data)))
+			outputs.AckedEvents.Add(int64(totalNumberOfEvents - len(data)))
 			return data, err
 		}
 	}
 	ackedEvents.Add(int64(totalNumberOfEvents))
+	outputs.AckedEvents.Add(int64(totalNumberOfEvents))
 	return nil, nil
 }
 

--- a/libbeat/outputs/mode/mode.go
+++ b/libbeat/outputs/mode/mode.go
@@ -4,17 +4,17 @@ package mode
 
 import (
 	"errors"
-	"expvar"
 	"time"
 
 	"github.com/elastic/beats/libbeat/common/op"
 	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/monitoring"
 	"github.com/elastic/beats/libbeat/outputs"
 )
 
 // Metrics that can retrieved through the expvar web interface.
 var (
-	messagesDropped = expvar.NewInt("libbeat.outputs.messages_dropped")
+	messagesDropped = monitoring.NewInt(outputs.Metrics, "messages.dropped")
 )
 
 // ErrNoHostsConfigured indicates missing host or hosts configuration

--- a/libbeat/outputs/outputs.go
+++ b/libbeat/outputs/outputs.go
@@ -4,6 +4,7 @@ import (
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/op"
 	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/monitoring"
 )
 
 type Options struct {
@@ -71,6 +72,14 @@ type bulkOutputAdapter struct {
 }
 
 var outputsPlugins = make(map[string]OutputBuilder)
+
+var (
+	Metrics = monitoring.Default.NewRegistry("output")
+
+	AckedEvents = monitoring.NewInt(Metrics, "events.acked", monitoring.Report)
+	WriteBytes  = monitoring.NewInt(Metrics, "write.bytes", monitoring.Report)
+	WriteErrors = monitoring.NewInt(Metrics, "write.errors", monitoring.Report)
+)
 
 func RegisterOutputPlugin(name string, builder OutputBuilder) {
 	outputsPlugins[name] = builder

--- a/libbeat/outputs/redis/redis.go
+++ b/libbeat/outputs/redis/redis.go
@@ -2,12 +2,12 @@ package redis
 
 import (
 	"errors"
-	"expvar"
 	"time"
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/op"
 	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/monitoring"
 	"github.com/elastic/beats/libbeat/outputs"
 	"github.com/elastic/beats/libbeat/outputs/mode"
 	"github.com/elastic/beats/libbeat/outputs/mode/modeutil"
@@ -25,10 +25,10 @@ var debugf = logp.MakeDebug("redis")
 
 // Metrics that can retrieved through the expvar web interface.
 var (
-	statReadBytes   = expvar.NewInt("libbeat.redis.publish.read_bytes")
-	statWriteBytes  = expvar.NewInt("libbeat.redis.publish.write_bytes")
-	statReadErrors  = expvar.NewInt("libbeat.redis.publish.read_errors")
-	statWriteErrors = expvar.NewInt("libbeat.redis.publish.write_errors")
+	statReadBytes   = monitoring.NewInt(outputs.Metrics, "redis.read.bytes")
+	statWriteBytes  = monitoring.NewInt(outputs.Metrics, "redis.write.bytes")
+	statReadErrors  = monitoring.NewInt(outputs.Metrics, "redis.read.errors")
+	statWriteErrors = monitoring.NewInt(outputs.Metrics, "redis.write.errors")
 )
 
 const (
@@ -103,10 +103,12 @@ func (r *redisOut) init(cfg *common.Config, expireTopo int) error {
 		Proxy:   &config.Proxy,
 		TLS:     tls,
 		Stats: &transport.IOStats{
-			Read:        statReadBytes,
-			Write:       statWriteBytes,
-			ReadErrors:  statReadErrors,
-			WriteErrors: statWriteErrors,
+			Read:               statReadBytes,
+			Write:              statWriteBytes,
+			ReadErrors:         statReadErrors,
+			WriteErrors:        statWriteErrors,
+			OutputsWrite:       outputs.WriteBytes,
+			OutputsWriteErrors: outputs.WriteErrors,
 		},
 	}
 

--- a/libbeat/outputs/transport/stats.go
+++ b/libbeat/outputs/transport/stats.go
@@ -1,12 +1,13 @@
 package transport
 
 import (
-	"expvar"
 	"net"
+
+	"github.com/elastic/beats/libbeat/monitoring"
 )
 
 type IOStats struct {
-	Read, Write, ReadErrors, WriteErrors *expvar.Int
+	Read, Write, ReadErrors, WriteErrors, OutputsWrite, OutputsWriteErrors *monitoring.Int
 }
 
 type statsConn struct {
@@ -33,7 +34,9 @@ func (s *statsConn) Write(b []byte) (int, error) {
 	n, err := s.Conn.Write(b)
 	if err != nil {
 		s.stats.WriteErrors.Add(1)
+		s.stats.OutputsWriteErrors.Add(1)
 	}
 	s.stats.Write.Add(int64(n))
+	s.stats.OutputsWrite.Add(int64(n))
 	return n, err
 }

--- a/libbeat/publisher/client.go
+++ b/libbeat/publisher/client.go
@@ -13,7 +13,7 @@ import (
 
 // Metrics that can retrieved through the expvar web interface.
 var (
-	publishedEvents = expvar.NewInt("libbeat.publisher.published_events")
+	publishedEvents = expvar.NewInt("publisher.events.count")
 )
 
 var (

--- a/libbeat/publisher/worker.go
+++ b/libbeat/publisher/worker.go
@@ -10,7 +10,7 @@ import (
 
 // Metrics that can retrieved through the expvar web interface.
 var (
-	messagesInWorkerQueues = expvar.NewInt("libbeat.publisher.messages_in_worker_queues")
+	messagesInWorkerQueues = expvar.NewInt("publisher.queue.messages.count")
 )
 
 type worker interface {

--- a/libbeat/tests/system/test_base.py
+++ b/libbeat/tests/system/test_base.py
@@ -154,7 +154,7 @@ class Test(BaseTest):
         )
         proc = self.start_beat(logging_args=["-e"])
         self.wait_until(
-            lambda: self.log_contains("No non-zero metrics in the last 100ms"),
+            lambda: self.log_contains("Non-zero metrics in the last 100ms:"),
             max_timeout=2)
         proc.check_kill_and_wait()
         self.wait_until(


### PR DESCRIPTION
Part of https://github.com/elastic/beats/issues/3422

Exports the following health metrics over expvar:

Sum of all outputs:
- [x] output.write.errors
- [x] output.write.bytes
- [x] output.events.acked
- [x] publisher.events.count
- [x] publisher.queue.messages.count
- [x] output.messages.dropped
- [x] beat.memstats.memory_total 
- [x] beat.memstats.memory_alloc (bytes allocated and not yet freed)
- [x] beat.memstats.gc_next (next collection will happen when HeapAlloc ≥ this amount)

Per output:

Redis:
- [x] output.redis.events.acked
- [x] output.redis.events.not_acked
- [x] output.redis.read.errors
- [x] output.redis.read.bytes
- [x] output.redis.write.bytes
- [x] output.redis.write.errors

Elasticsearch:
- [x] output.elasticsearch.events.acked
- [x] output.elasticsearch.events.not_acked
- [x] output.elasticsearch.publishEvents.call.count
- [x] output.elasticsearch.read.bytes
- [x] output.elasticsearch.read.errors
- [x] output.elasticsearch.write.bytes
- [x] output.elasticsearch.write.errors

Kafka:
- [x] output.kafka.events.acked
- [x] output.kafka.events.not_acked
- [x] output.kafka.publishEvents.call.count
- [ ] output.kafka.read.errors (cannot be calculated)
- [ ] output.kafka.read.bytes (cannot be calculated)
- [ ] output.kafka.write.bytes (cannot be calculated)
- [ ] output.kafka.write.errors (cannot be calculated)

Logstash:
- [x] output.logstash.events.acked
- [x] output.logstash.events.not_acked
- [x] output.logstash.publishEvents.call.count
- [x] output.logstash.read.errors
- [x] output.logstash.read.bytes
- [x] output.logstash.write.bytes
- [x] output.logstash.write.errors

**Limitations**: For Kafka, the Beats are not exporting `output.kafka.write_bytes` and `output.kafka.write_errors`. So, for Kafka we cannot calculate `write.bytes` and `write.errors`, and the values of `output.write.bytes` and `output.write.errors` don't include Kafka output.