### PR TITLE
Deploy Filebeat modules in the packages

### DIFF
--- a/filebeat/.gitignore
+++ b/filebeat/.gitignore
@@ -6,4 +6,5 @@ filebeat
 
 build
 _meta/kibana
+_meta/module.generated
 /tests/load/logs

--- a/filebeat/Makefile
+++ b/filebeat/Makefile
@@ -27,10 +27,16 @@ fields:
 	cat ${ES_BEATS}/filebeat/_meta/fields.common.yml > _meta/fields.generated.yml
 	. ${PYTHON_ENV}/bin/activate; python ${ES_BEATS}/metricbeat/scripts/fields_collector.py >> _meta/fields.generated.yml
 
+# Collects all modules files to be packaged in a temporary folder
+.PHONY: modules
+modules:
+	mkdir -p _meta/
+	rm -rf _meta/module.generated
+	rsync -av module/ _meta/module.generated --exclude "_meta" --exclude "*/*/test"
 
 # Runs all collection steps and updates afterwards
 .PHONY: collect
-collect: fields kibana
+collect: fields kibana modules
 
 
 # Creates a new fileset. Requires the params MODULE and FILESET

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -327,6 +327,10 @@ install-home:
 	if [ -a ${NOTICE_FILE} ]; then \
 		install -m 644 ${NOTICE_FILE} ${HOME_PREFIX}/; \
 	fi
+	if [ -d _meta/module.generated ]; then \
+		install -d -m 755 ${HOME_PREFIX}/module; \
+		rsync -av _meta/module.generated/ ${HOME_PREFIX}/module/; \
+	fi
 
 # Prepares for packaging. Builds binaries and creates homedir data
 .PHONY: prepare-package


### PR DESCRIPTION
Uses an intermediary `_meta/module.generated/` folder which is created on
`make collect`. This gives us the opportunity to select which files are
needed to be deployed in the package (currently everything but the `_meta` and
`test` folders).

The intermediary folder also allows us to avoid providing a custom `install-home`
target in Filebeat.

Part of #3159.