### PR TITLE
Generate coverage report after fixing file permissions

### DIFF
--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -209,12 +209,12 @@ testsuite: clean update
 		fi \
 	fi
 
-	$(MAKE) benchmark-tests
-	$(MAKE) coverage-report
-
 	if [ $(TEST_ENVIRONMENT) = true ]; then \
 		$(MAKE) fix-permissions; \
 	fi
+
+	$(MAKE) benchmark-tests
+	$(MAKE) coverage-report
 
 # Generates a coverage report from the existing coverage files
 .PHONY: coverage-report


### PR DESCRIPTION
This changes the Makefile to run coverage-report after fix-permissions. This allows coverage-report to be able to fully traverse the contents the build dir.