### PR TITLE
Simplify building of docker containers test environment

### DIFF
--- a/testing/environments/Makefile
+++ b/testing/environments/Makefile
@@ -1,4 +1,4 @@
-ENV?=latest.yml
+ENV?=snapshot.yml
 BASE_COMMAND=docker-compose -f ${ENV} -f local.yml
 
 start:

--- a/testing/environments/README.md
+++ b/testing/environments/README.md
@@ -45,7 +45,7 @@ It is useful to sometimes access the containers from a browser, especially for K
 http://docker-machine-ip:5601/
 ```
 
-Often de default ip is `192.168.99.100`.
+Often the default address is `localhost`.
 
 
 ## Cleanup

--- a/testing/environments/args.yml
+++ b/testing/environments/args.yml
@@ -1,0 +1,9 @@
+# This file contains the build arguments which are shared between all elastic stack containers
+# This allows to change the build id and download path in a single place.
+version: '2'
+services:
+  args:
+    build:
+      args:
+        DOWNLOAD_URL: https://snapshots.elastic.co/downloads
+        ELASTIC_VERSION: 6.0.0-alpha1-SNAPSHOT

--- a/testing/environments/docker/elasticsearch/Dockerfile-snapshot
+++ b/testing/environments/docker/elasticsearch/Dockerfile-snapshot
@@ -3,9 +3,8 @@ FROM docker.elastic.co/elasticsearch/elasticsearch-alpine-base:latest
 MAINTAINER Elastic Docker Team <docker@elastic.co>
 
 ARG ELASTIC_VERSION
-ARG ES_DOWNLOAD_URL
+ARG DOWNLOAD_URL
 ARG ES_JAVA_OPTS
-ARG XPACK=x-pack
 
 ENV PATH /usr/share/elasticsearch/bin:$PATH
 ENV JAVA_HOME /usr/lib/jvm/java-1.8-openjdk
@@ -13,8 +12,8 @@ ENV JAVA_HOME /usr/lib/jvm/java-1.8-openjdk
 WORKDIR /usr/share/elasticsearch
 
 # Download/extract defined ES version. busybox tar can't strip leading dir.
-RUN wget ${ES_DOWNLOAD_URL}/elasticsearch-${ELASTIC_VERSION}.tar.gz && \
-    EXPECTED_SHA=$(wget -O - ${ES_DOWNLOAD_URL}/elasticsearch-${ELASTIC_VERSION}.tar.gz.sha1) && \
+RUN wget ${DOWNLOAD_URL}/elasticsearch/elasticsearch-${ELASTIC_VERSION}.tar.gz && \
+    EXPECTED_SHA=$(wget -O - ${DOWNLOAD_URL}/elasticsearch/elasticsearch-${ELASTIC_VERSION}.tar.gz.sha1) && \
     test $EXPECTED_SHA == $(sha1sum elasticsearch-${ELASTIC_VERSION}.tar.gz | awk '{print $1}') && \
     tar zxf elasticsearch-${ELASTIC_VERSION}.tar.gz && \
     chown -R elasticsearch:elasticsearch elasticsearch-${ELASTIC_VERSION} && \
@@ -30,10 +29,10 @@ RUN set -ex && for esdirs in config data logs; do \
 USER elasticsearch
 
 # Install xpack
-#RUN eval ${ES_JAVA_OPTS:-} elasticsearch-plugin install --batch ${XPACK}
+#RUN eval ${ES_JAVA_OPTS:-} elasticsearch-plugin install --batch ${DOWNLOAD_URL}/packs/x-pack/x-pack-${ELASTIC_VERSION}.zip
 
-RUN elasticsearch-plugin install --batch https://snapshots.elastic.co/downloads/elasticsearch-plugins/ingest-user-agent/ingest-user-agent-6.0.0-alpha1-SNAPSHOT.zip
-RUN elasticsearch-plugin install --batch https://snapshots.elastic.co/downloads/elasticsearch-plugins/ingest-geoip/ingest-geoip-6.0.0-alpha1-SNAPSHOT.zip
+RUN elasticsearch-plugin install --batch ${DOWNLOAD_URL}/elasticsearch-plugins/ingest-user-agent/ingest-user-agent-${ELASTIC_VERSION}.zip
+RUN elasticsearch-plugin install --batch ${DOWNLOAD_URL}/elasticsearch-plugins/ingest-geoip/ingest-geoip-${ELASTIC_VERSION}.zip
 
 COPY config/elasticsearch.yml config/
 COPY config/log4j2.properties config/

--- a/testing/environments/docker/kibana/Dockerfile-snapshot
+++ b/testing/environments/docker/kibana/Dockerfile-snapshot
@@ -2,14 +2,14 @@
 FROM docker.elastic.co/kibana/kibana-ubuntu-base:latest
 MAINTAINER Elastic Docker Team <docker@elastic.co>
 
-ARG KIBANA_DOWNLOAD_URL=https://snapshots.elastic.co/downloads/kibana/kibana-6.0.0-alpha1-SNAPSHOT-linux-x86_64.tar.gz
-ARG X_PACK_URL
+ARG DOWNLOAD_URL
+ARG ELASTIC_VERSION
 
 EXPOSE 5601
 
 WORKDIR /usr/share/kibana
-RUN curl -Ls ${KIBANA_DOWNLOAD_URL} | tar --strip-components=1 -zxf - && \
-    #bin/kibana-plugin install ${X_PACK_URL} && \
+RUN curl -Ls ${DOWNLOAD_URL}/kibana/kibana-${ELASTIC_VERSION}-linux-x86_64.tar.gz | tar --strip-components=1 -zxf - && \
+    #bin/kibana-plugin install ${DOWNLOAD_URL}/kibana-plugins/x-pack/x-pack-${ELASTIC_VERSION}.zip} && \
     ln -s /usr/share/kibana /opt/kibana
 
 # Set some Kibana configuration defaults.

--- a/testing/environments/docker/logstash/Dockerfile
+++ b/testing/environments/docker/logstash/Dockerfile
@@ -1,10 +1,10 @@
 FROM java:8-jre
 
-ARG LS_DOWNLOAD_URL
-ARG LS_VERSION
+ARG DOWNLOAD_URL
+ARG ELASTIC_VERSION
 
-ENV URL ${LS_DOWNLOAD_URL}/logstash-${LS_VERSION}.tar.gz
-ENV PATH $PATH:/opt/logstash-${LS_VERSION}/bin
+ENV URL ${DOWNLOAD_URL}/logstash/logstash-${ELASTIC_VERSION}.tar.gz
+ENV PATH $PATH:/opt/logstash-${ELASTIC_VERSION}/bin
 
 # Cache variable can be set during building to invalidate the build cache with `--build-arg CACHE=$(date +%s) .`
 ARG CACHE=1

--- a/testing/environments/latest.yml
+++ b/testing/environments/latest.yml
@@ -4,7 +4,7 @@
 version: '2'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:5.1.1
+    image: docker.elastic.co/elasticsearch/elasticsearch:5.1.2
     environment:
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
       - "network.host="
@@ -17,10 +17,10 @@ services:
       context: docker/logstash
       dockerfile: Dockerfile
       args:
-        LS_VERSION: 5.1.1
-        LS_DOWNLOAD_URL: https://artifacts.elastic.co/downloads/logstash
+        ELASTIC_VERSION: 5.1.2
+        DOWNLOAD_URL: https://artifacts.elastic.co/downloads
     environment:
       - ES_HOST=elasticsearch
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:5.1.1
+    image: docker.elastic.co/kibana/kibana:5.1.2

--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -1,15 +1,16 @@
 # This should test the environment with the latest snapshots
 # This is based on base.yml
+
+
 version: '2'
 services:
   elasticsearch:
+    extends:
+      file: ./args.yml
+      service: args
     build:
       context: ./docker/elasticsearch
       dockerfile: Dockerfile-snapshot
-      args:
-        ELASTIC_VERSION: 6.0.0-alpha1-SNAPSHOT
-        ES_DOWNLOAD_URL: https://snapshots.elastic.co/downloads/elasticsearch
-        #XPACK: http://snapshots.elastic.co/downloads/packs/x-pack/x-pack-6.0.0-alpha1-SNAPSHOT.zip
     environment:
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
       - "network.host="
@@ -17,19 +18,21 @@ services:
       - "http.host=0.0.0.0"
 
   logstash:
+    extends:
+      file: ./args.yml
+      service: args
     build:
       context: ./docker/logstash
       dockerfile: Dockerfile
-      args:
-        LS_VERSION: 6.0.0-alpha1-SNAPSHOT
-        LS_DOWNLOAD_URL: https://snapshots.elastic.co/downloads/logstash
     environment:
       - ES_HOST=elasticsearch
 
   kibana:
+    extends:
+      file: ./args.yml
+      service: args
     build:
       context: ./docker/kibana
       dockerfile: Dockerfile-snapshot
-      args: [ ]
-        #KIBANA_DOWNLOAD_URL: https://snapshots.elastic.co/downloads/kibana/kibana-6.0.0-alpha1-SNAPSHOT-linux-x86_64.tar.gz
-        #X_PACK_URL: http://snapshots.elastic.co/downloads/kibana-plugins/x-pack/x-pack-6.0.0-alpha1-SNAPSHOT.zip
+
+


### PR DESCRIPTION
This change will allow to change download path and stack version in a single place (`args.yml`) instead of having it to apply multiple times. This should simplify updating the stack to a new version.

* Set default env to snapshot as this is the most used one for manual testing
* Change also allows to use env to set different environments
* Update latest build to 5.1.2