### PR TITLE
Modify fix-permissions to look at entire repo

### DIFF
--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -161,7 +161,7 @@ fast-system-tests: ${BEAT_NAME}.test python-env
 
 # Run benchmark tests
 .PHONY: benchmark-tests
-benchmark-tests: ## @testing Runs bechmarks (NOT YET IMPLEMENTED)
+benchmark-tests: ## @testing Runs benchmarks (NOT YET IMPLEMENTED)
 	# No benchmark tests exist so far
 	#go test -bench=. ${GOPACKAGES}
 
@@ -195,7 +195,7 @@ testsuite: clean update
 	$(MAKE) unit-tests
 
 	# Setups environment if TEST_ENVIRONMENT is set to true
-	# Only runs integration tests with test environemtn
+	# Only runs integration tests with test environment
 	if [ $(TEST_ENVIRONMENT) = true ]; then \
 		 $(MAKE) integration-tests-environment; \
 	fi
@@ -434,7 +434,7 @@ package-dashboards: package-setup
 
 fix-permissions:
 	# Change ownership of all files inside /build folder from root/root to current user/group
-	docker run -v ${BUILD_DIR}:/build alpine:3.4 sh -c "chown -R $(shell id -u):$(shell id -g) /build"
+	docker run -v ${PWD}:/beat alpine:3.4 sh -c "find /beat -user 0 -exec chown $(shell id -u):$(shell id -g) {} \;"
 
 set_version: ## @packaging VERSION=x.y.z set the version of the beat to x.y.z
 	${ES_BEATS}/dev-tools/set_version ${VERSION}


### PR DESCRIPTION
The list of files that are owned by root after running the build in docker extends outside of the build dir so just check everything in the repo. These are the files that this change will fix.

```
./filebeat/tests/system/test_load.pyc
./filebeat/tests/system/test_harvester.pyc
./filebeat/tests/system/filebeat.pyc
./filebeat/tests/system/test_fields.pyc
./filebeat/tests/system/test_multiline.pyc
./filebeat/tests/system/test_shutdown.pyc
./filebeat/tests/system/test_processors.pyc
./filebeat/tests/system/test_registrar.pyc
./filebeat/tests/system/test_modules.pyc
./filebeat/tests/system/test_publisher.pyc
./filebeat/tests/system/test_prospector.pyc
./filebeat/tests/system/test_reload.pyc
./filebeat/tests/system/test_json.pyc
./filebeat/tests/system/test_crawler.pyc
./filebeat/tests/system/test_migration.pyc
./filebeat/tests/files/logs/nasa-50k.log
./filebeat/data
find: `./filebeat/data': Permission denied
./filebeat/filebeat.test
./metricbeat/tests/system/test_kafka.pyc
./metricbeat/tests/system/test_base.pyc
./metricbeat/tests/system/metricbeat.pyc
./metricbeat/tests/system/test_docker.pyc
./metricbeat/tests/system/test_processors.pyc
./metricbeat/tests/system/test_mongodb.pyc
./metricbeat/tests/system/test_haproxy.pyc
./metricbeat/tests/system/test_postgresql.pyc
./metricbeat/tests/system/test_config.pyc
./metricbeat/tests/system/test_zookeeper.pyc
./metricbeat/tests/system/test_redis.pyc
./metricbeat/tests/system/test_reload.pyc
./metricbeat/tests/system/test_prometheus.pyc
./metricbeat/tests/system/test_system.pyc
./metricbeat/tests/system/test_apache.pyc
./metricbeat/tests/system/test_mysql.pyc
./metricbeat/metricbeat.test
./metricbeat/data
find: `./metricbeat/data': Permission denied
./libbeat/dashboards/import_dashboards
./libbeat/tests/system/test_base.pyc
./libbeat/tests/system/beat/beat.pyc
./libbeat/tests/system/beat/__init__.pyc
./libbeat/tests/system/base.pyc
./libbeat/tests/system/test_dashboard.pyc
./libbeat/libbeat.test
./libbeat/data
find: `./libbeat/data': Permission denied
```