### PR TITLE
Add beta header to every page

### DIFF
--- a/heartbeat/docs/overview.asciidoc
+++ b/heartbeat/docs/overview.asciidoc
@@ -1,8 +1,6 @@
 [[heartbeat-overview]]
 == Overview
 
-beta[]
-
 Heartbeat is a lightweight daemon that you install on a remote server
 to periodically check the status of your services and determine whether they are
 available. Unlike {metricbeat}/index.html[Metricbeat], which only tells you if

--- a/heartbeat/docs/page_header.html
+++ b/heartbeat/docs/page_header.html
@@ -1,0 +1,4 @@
+This functionality is in beta and is subject to change. The design and
+code is considered to be less mature than official GA features. Elastic will
+take a best effort approach to fix any issues, but beta features are not
+subject to the support SLA of official GA features.


### PR DESCRIPTION
This PR puts the beta disclaimer on every page of the Heartbeat doc rather than just the overview page. I used a page header instead of the beta[ ] tag because it will be easier to remove when the feature is no longer GA level. Otherwise, I would have had to add the tag manually.

Here's what the page header looks like when rendered in HTML:

![disclaimer](https://cloud.githubusercontent.com/assets/14206422/22271441/684e3636-e249-11e6-9ce1-43fc0b81c3a4.png)
