### PR TITLE
Set the pipeline ID in the prospector configuration

### DIFF
--- a/filebeat/fileset/fileset.go
+++ b/filebeat/fileset/fileset.go
@@ -27,6 +27,7 @@ type Fileset struct {
 	modulePath string
 	manifest   *manifest
 	vars       map[string]interface{}
+	pipelineID string
 }
 
 // New allocates a new Fileset object with the given configuration.
@@ -62,12 +63,9 @@ func (fs *Fileset) Read() error {
 		return err
 	}
 
-	pipeline_id, err := fs.getPipelineID()
+	fs.pipelineID, err = fs.getPipelineID()
 	if err != nil {
 		return err
-	}
-	fs.vars["beat"] = map[string]interface{}{
-		"pipeline_id": pipeline_id,
 	}
 
 	return nil
@@ -229,6 +227,12 @@ func (fs *Fileset) getProspectorConfig() (*common.Config, error) {
 		if err != nil {
 			return nil, fmt.Errorf("Error applying config overrides: %v", err)
 		}
+	}
+
+	// force our pipeline ID
+	err = cfg.SetString("pipeline", -1, fs.pipelineID)
+	if err != nil {
+		return nil, fmt.Errorf("Error setting the pipeline ID in the prospector config: %v", err)
 	}
 
 	cfg.PrintDebugf("Merged prospector config for fileset %s/%s", fs.mcfg.Module, fs.name)

--- a/filebeat/fileset/fileset_test.go
+++ b/filebeat/fileset/fileset_test.go
@@ -156,8 +156,10 @@ func TestGetProspectorConfigNginx(t *testing.T) {
 
 	assert.True(t, cfg.HasField("paths"))
 	assert.True(t, cfg.HasField("exclude_files"))
-	pipeline_id := fs.vars["beat"].(map[string]interface{})["pipeline_id"]
-	assert.Equal(t, "nginx-access-with_plugins", pipeline_id)
+	assert.True(t, cfg.HasField("pipeline"))
+	pipelineID, err := cfg.String("pipeline", -1)
+	assert.NoError(t, err)
+	assert.Equal(t, "nginx-access-with_plugins", pipelineID)
 }
 
 func TestGetProspectorConfigNginxOverrides(t *testing.T) {
@@ -178,7 +180,9 @@ func TestGetProspectorConfigNginxOverrides(t *testing.T) {
 	assert.True(t, cfg.HasField("paths"))
 	assert.True(t, cfg.HasField("exclude_files"))
 	assert.True(t, cfg.HasField("close_eof"))
-	pipelineID := fs.vars["beat"].(map[string]interface{})["pipeline_id"]
+	assert.True(t, cfg.HasField("pipeline"))
+	pipelineID, err := cfg.String("pipeline", -1)
+	assert.NoError(t, err)
 	assert.Equal(t, "nginx-access-with_plugins", pipelineID)
 
 }

--- a/filebeat/module/apache2/access/config/access.yml
+++ b/filebeat/module/apache2/access/config/access.yml
@@ -6,4 +6,3 @@ paths:
 exclude_files: [".gz$"]
 fields:
   source_type: apache2-access
-  pipeline_id: {{.beat.pipeline_id}}

--- a/filebeat/module/apache2/error/config/error.yml
+++ b/filebeat/module/apache2/error/config/error.yml
@@ -6,4 +6,3 @@ paths:
 exclude_files: [".gz$"]
 fields:
   source_type: apache2-error
-  pipeline_id: {{.beat.pipeline_id}}

--- a/filebeat/module/mysql/error/config/error.yml
+++ b/filebeat/module/mysql/error/config/error.yml
@@ -6,4 +6,3 @@ paths:
 exclude_files: [".gz$"]
 fields:
   source_type: mysql-error
-  pipeline_id: {{.beat.pipeline_id}}

--- a/filebeat/module/mysql/slowlog/config/slowlog.yml
+++ b/filebeat/module/mysql/slowlog/config/slowlog.yml
@@ -10,4 +10,3 @@ multiline:
   match: after
 fields:
   source_type: mysql-slowlog
-  pipeline_id: {{.beat.pipeline_id}}

--- a/filebeat/module/nginx/access/config/nginx-access.yml
+++ b/filebeat/module/nginx/access/config/nginx-access.yml
@@ -6,4 +6,3 @@ paths:
 exclude_files: [".gz$"]
 fields:
   source_type: nginx-access
-  pipeline_id: {{.beat.pipeline_id}}

--- a/filebeat/module/nginx/error/config/nginx-error.yml
+++ b/filebeat/module/nginx/error/config/nginx-error.yml
@@ -6,4 +6,3 @@ paths:
 exclude_files: [".gz$"]
 fields:
   source_type: nginx-error
-  pipeline_id: {{.beat.pipeline_id}}

--- a/filebeat/module/syslog/system/config/system.yml
+++ b/filebeat/module/syslog/system/config/system.yml
@@ -9,4 +9,3 @@ multiline:
   match: after
 fields:
   source_type: syslog-system
-  pipeline_id: {{.beat.pipeline_id}}

--- a/filebeat/tests/system/config/filebeat_modules.yml.j2
+++ b/filebeat/tests/system/config/filebeat_modules.yml.j2
@@ -3,4 +3,3 @@ filebeat.registry_file: {{ beat.working_dir + '/' }}{{ registryFile|default("reg
 
 output.elasticsearch.hosts: ["{{ elasticsearch_url }}"]
 output.elasticsearch.index: {{ index_name }}
-output.elasticsearch.pipeline: "%{[fields.pipeline_id]}"


### PR DESCRIPTION
Now that prospectors have a pipeline config option, use it in the
filebeat modules. This gets rid of the requirement to have a weird
pipeline option in the output, and removes one hack from the fields.

Part of #3159.