### PR TITLE
Monitoring enhancements

### DIFF
--- a/libbeat/logp/metrics_test.go
+++ b/libbeat/logp/metrics_test.go
@@ -14,7 +14,7 @@ func TestSnapshotExpvars(t *testing.T) {
 	test.Add(42)
 
 	vals := snapshotMetrics()
-	assert.Equal(t, vals.ints["test"], int64(42))
+	assert.Equal(t, vals.Ints["test"], int64(42))
 }
 
 func TestSnapshotExpvarsMap(t *testing.T) {
@@ -27,8 +27,8 @@ func TestSnapshotExpvarsMap(t *testing.T) {
 
 	vals := snapshotMetrics()
 
-	assert.Equal(t, vals.ints["testMap.hello"], int64(42))
-	assert.Equal(t, vals.ints["testMap.map2.test"], int64(5))
+	assert.Equal(t, vals.Ints["testMap.hello"], int64(42))
+	assert.Equal(t, vals.Ints["testMap.map2.test"], int64(5))
 }
 
 func TestBuildMetricsOutput(t *testing.T) {

--- a/libbeat/monitoring/adapter/go-metrics.go
+++ b/libbeat/monitoring/adapter/go-metrics.go
@@ -127,7 +127,7 @@ func (r *GoMetricsRegistry) doRegister(name string, metric interface{}) interfac
 	if st.action == actAccept {
 		w, ok := goMetricsWrap(st.metric)
 		if ok {
-			r.reg.Add(st.name, w)
+			r.reg.Add(st.name, w, st.mode)
 		}
 	}
 
@@ -171,6 +171,7 @@ func (r *GoMetricsRegistry) stateWith(k kind, name string, metric interface{}) s
 		action: actIgnore,
 		reg:    r.reg,
 		name:   name,
+		mode:   monitoring.Full,
 		metric: metric,
 	})
 }

--- a/libbeat/monitoring/adapter/go-metrics_test.go
+++ b/libbeat/monitoring/adapter/go-metrics_test.go
@@ -80,7 +80,7 @@ func TestGoMetricsAdapter(t *testing.T) {
 			t.Errorf("metric %v should not have been reported by each", name)
 		}
 	})
-	monReg.Do(func(name string, v interface{}) error {
+	monReg.Do(monitoring.Full, func(name string, v interface{}) error {
 		if !strings.HasPrefix(name, "test.mon") {
 			t.Errorf("metric %v should not have been reported by each", name)
 		}

--- a/libbeat/monitoring/metrics.go
+++ b/libbeat/monitoring/metrics.go
@@ -1,7 +1,10 @@
 package monitoring
 
 import (
+	"encoding/json"
+	"expvar"
 	"math"
+	"strconv"
 	"sync"
 	"sync/atomic"
 )
@@ -12,30 +15,54 @@ type makeExpvar func() string
 // Int is a 64 bit integer variable satisfying the Var interface.
 type Int struct{ i int64 }
 
-// NewInt registers a new global integer metrics.
-func NewInt(name string) *Int {
-	return Default.NewInt(name)
+// NewInt creates and registers a new integer variable.
+//
+// Note: If the registry is configured to publish variables to expvar, the
+// variable will be available via expvars package as well, but can not be removed
+// anymore.
+func NewInt(r *Registry, name string, opts ...Option) *Int {
+	if r == nil {
+		r = Default
+	}
+
+	v := &Int{}
+	addVar(r, name, varOpts(r.opts, opts), v, makeExpvar(func() string {
+		return strconv.FormatInt(v.Get(), 10)
+	}))
+	return v
 }
 
-func (v *Int) Visit(vs Visitor) error { return vs.OnInt(v.Get()) }
 func (v *Int) Get() int64             { return atomic.LoadInt64(&v.i) }
 func (v *Int) Set(value int64)        { atomic.StoreInt64(&v.i, value) }
 func (v *Int) Add(delta int64)        { atomic.AddInt64(&v.i, delta) }
 func (v *Int) Inc()                   { atomic.AddInt64(&v.i, 1) }
 func (v *Int) Dec()                   { atomic.AddInt64(&v.i, -1) }
+func (v *Int) Visit(vs Visitor) error { return vs.OnInt(v.Get()) }
 
 // Float is a 64 bit float variable satisfying the Var interface.
 type Float struct{ f uint64 }
 
-// NewFloat registers a new global floating point metric.
-func NewFloat(name string) *Float {
-	return Default.NewFloat(name)
+// NewFloat creates and registers a new float variable.
+//
+// Note: If the registry is configured to publish variables to expvar, the
+// variable will be available via expvars package as well, but can not be removed
+// anymore.
+func NewFloat(r *Registry, name string, opts ...Option) *Float {
+	if r == nil {
+		r = Default
+	}
+
+	v := &Float{}
+	addVar(r, name, varOpts(r.opts, opts), v, makeExpvar(func() string {
+		return strconv.FormatFloat(v.Get(), 'g', -1, 64)
+	}))
+	return v
 }
 
-func (v *Float) Visit(vs Visitor) error { return vs.OnFloat(v.Get()) }
 func (v *Float) Get() float64           { return math.Float64frombits(atomic.LoadUint64(&v.f)) }
 func (v *Float) Set(value float64)      { atomic.StoreUint64(&v.f, math.Float64bits(value)) }
 func (v *Float) Sub(delta float64)      { v.Add(-delta) }
+func (v *Float) Visit(vs Visitor) error { return vs.OnFloat(v.Get()) }
 
 func (v *Float) Add(delta float64) {
 	for {
@@ -53,12 +80,27 @@ type String struct {
 	s  string
 }
 
-// NewString registers a new global string metric.
-func NewString(name string) *String {
-	return Default.NewString(name)
+// NewString creates and registers a new string variable.
+//
+// Note: If the registry is configured to publish variables to expvar, the
+// variable will be available via expvars package as well, but can not be removed
+// anymore.
+func NewString(r *Registry, name string, opts ...Option) *String {
+	if r == nil {
+		r = Default
+	}
+
+	v := &String{}
+	addVar(r, name, varOpts(r.opts, opts), v, makeExpvar(func() string {
+		b, _ := json.Marshal(v.Get())
+		return string(b)
+	}))
+	return v
 }
 
-func (v *String) Visit(vs Visitor) error { return vs.OnString(v.Get()) }
+func (v *String) Visit(vs Visitor) error {
+	return vs.OnString(v.Get())
+}
 
 func (v *String) Get() string {
 	v.mu.RLock()
@@ -81,3 +123,17 @@ func (v *String) Fail(err error) {
 }
 
 func (m makeExpvar) String() string { return m() }
+
+func addVar(r *Registry, name string, opts options, v Var, ev expvar.Var) {
+	r.Add(name, v, opts.mode)
+	if opts.publishExpvar {
+		expvar.Publish(fullName(r, name), ev)
+	}
+}
+
+func fullName(r *Registry, name string) string {
+	if r.name == "" {
+		return name
+	}
+	return r.name + "." + name
+}

--- a/libbeat/monitoring/monitoring.go
+++ b/libbeat/monitoring/monitoring.go
@@ -2,21 +2,35 @@ package monitoring
 
 import "errors"
 
+type Mode uint8
+
+const (
+	// Reported mode, is lowest report level with most basic metrics only
+	Reported Mode = iota
+
+	// Full reports all metrics
+	Full
+)
+
 // Default is the global default metrics registry provided by the monitoring package.
 var Default = NewRegistry()
 
 var errNotFound = errors.New("Name unknown")
 var errInvalidName = errors.New("Name does not point to a valid variable")
 
+func VisitMode(mode Mode, vs Visitor) error {
+	return Default.VisitMode(mode, vs)
+}
+
 func Visit(vs Visitor) error {
 	return Default.Visit(vs)
 }
 
-func Do(f func(string, interface{}) error) error {
-	return Default.Do(f)
+func Do(mode Mode, f func(string, interface{}) error) error {
+	return Default.Do(mode, f)
 }
 
-func Get(name string) interface{} {
+func Get(name string) Var {
 	return Default.Get(name)
 }
 

--- a/libbeat/monitoring/opts.go
+++ b/libbeat/monitoring/opts.go
@@ -5,10 +5,12 @@ type Option func(options) options
 
 type options struct {
 	publishExpvar bool
+	mode          Mode
 }
 
 var defaultOptions = options{
 	publishExpvar: false,
+	mode:          Full,
 }
 
 // PublishExpvar enables publishing all registered variables via expvar interface.
@@ -22,6 +24,23 @@ func PublishExpvar(o options) options {
 func IgnorePublishExpvar(o options) options {
 	o.publishExpvar = false
 	return o
+}
+
+func Report(o options) options {
+	o.mode = Reported
+	return o
+}
+
+func varOpts(regOpts *options, opts []Option) options {
+	O := defaultOptions
+	if regOpts != nil {
+		O = *regOpts
+	}
+
+	for _, opt := range opts {
+		O = opt(O)
+	}
+	return O
 }
 
 func applyOpts(in *options, opts []Option) *options {

--- a/libbeat/monitoring/registry_test.go
+++ b/libbeat/monitoring/registry_test.go
@@ -46,11 +46,11 @@ func TestRegistryGet(t *testing.T) {
 	name3 := nameSub2 + "." + name1
 
 	// register top-level and recursive metric
-	v1 := NewInt(name1)
+	v1 := NewInt(Default, name1, Report)
 	sub1 := Default.NewRegistry(nameSub1)
 	sub2 := Default.NewRegistry(nameSub2)
-	v2 := NewString(name2)
-	v3 := sub2.NewFloat(name1)
+	v2 := NewString(nil, name2, Report)
+	v3 := NewFloat(sub2, name1, Report)
 
 	// get values
 	v := Get(name1)
@@ -86,11 +86,11 @@ func TestRegistryRemove(t *testing.T) {
 	name3 := nameSub2 + "." + name1
 
 	// register top-level and recursive metric
-	NewInt(name1)
+	NewInt(Default, name1, Report)
 	sub1 := Default.NewRegistry(nameSub1)
 	sub2 := Default.NewRegistry(nameSub2)
-	NewInt(name2)
-	sub2.NewInt(name1)
+	NewInt(Default, name2, Report)
+	NewInt(sub2, name1, Report)
 
 	// remove metrics:
 	Remove(name1)
@@ -113,12 +113,12 @@ func TestRegistryIter(t *testing.T) {
 	}
 
 	for name, v := range vars {
-		i := NewInt(name)
+		i := NewInt(Default, name, Report)
 		i.Add(v)
 	}
 
 	collected := map[string]int64{}
-	err := Do(func(name string, v interface{}) error {
+	err := Do(Full, func(name string, v interface{}) error {
 		collected[name] = v.(int64)
 		return nil
 	})

--- a/libbeat/monitoring/snapshot.go
+++ b/libbeat/monitoring/snapshot.go
@@ -1,0 +1,91 @@
+package monitoring
+
+import "strings"
+
+// FlatSnapshot represents a flatten snapshot of all metrics.
+// Names in the tree will be joined with `.` .
+type FlatSnapshot struct {
+	Bools   map[string]bool
+	Ints    map[string]int64
+	Floats  map[string]float64
+	Strings map[string]string
+}
+
+type snapshotVisitor struct {
+	snapshot FlatSnapshot
+	level    []string
+}
+
+// CollectFlatSnapshot collects a flattened snapshot of
+// a metrics tree start with the given registry.
+func CollectFlatSnapshot(r *Registry, expvar bool) FlatSnapshot {
+	vs := newSnapshotVisitor()
+	r.Visit(vs)
+	if expvar {
+		VisitExpvars(vs)
+	}
+	return vs.snapshot
+}
+
+func MakeFlatSnapshot() FlatSnapshot {
+	return FlatSnapshot{
+		Bools:   map[string]bool{},
+		Ints:    map[string]int64{},
+		Floats:  map[string]float64{},
+		Strings: map[string]string{},
+	}
+}
+
+func newSnapshotVisitor() *snapshotVisitor {
+	return &snapshotVisitor{snapshot: MakeFlatSnapshot()}
+}
+
+func (vs *snapshotVisitor) OnRegistryStart() error {
+	return nil
+}
+
+func (vs *snapshotVisitor) OnRegistryFinished() error {
+	if len(vs.level) > 0 {
+		vs.dropName()
+	}
+	return nil
+}
+
+func (vs *snapshotVisitor) OnKey(name string) error {
+	vs.level = append(vs.level, name)
+	return nil
+}
+
+func (vs *snapshotVisitor) OnKeyNext() error { return nil }
+
+func (vs *snapshotVisitor) getName() string {
+	defer vs.dropName()
+	if len(vs.level) == 1 {
+		return vs.level[0]
+	}
+	return strings.Join(vs.level, ".")
+}
+
+func (vs *snapshotVisitor) dropName() {
+	vs.level = vs.level[:len(vs.level)-1]
+}
+
+func (vs *snapshotVisitor) OnString(s string) error {
+	vs.snapshot.Strings[vs.getName()] = s
+	return nil
+}
+
+func (vs *snapshotVisitor) OnBool(b bool) error {
+	vs.snapshot.Bools[vs.getName()] = b
+	return nil
+}
+
+func (vs *snapshotVisitor) OnInt(i int64) error {
+	vs.snapshot.Ints[vs.getName()] = i
+	return nil
+}
+
+func (vs *snapshotVisitor) OnFloat(f float64) error {
+	vs.snapshot.Floats[vs.getName()] = f
+	return nil
+}

--- a/libbeat/monitoring/visitor.go
+++ b/libbeat/monitoring/visitor.go
@@ -9,12 +9,7 @@ type Visitor interface {
 type ValueVisitor interface {
 	OnString(s string) error
 	OnBool(b bool) error
-	OnNil() error
-
-	// int
 	OnInt(i int64) error
-
-	// float
 	OnFloat(f float64) error
 }
 

--- a/libbeat/monitoring/visitor_expvar_test.go
+++ b/libbeat/monitoring/visitor_expvar_test.go
@@ -19,7 +19,7 @@ func TestIterExpvarIgnoringMonitoringVars(t *testing.T) {
 
 	reg := NewRegistry(PublishExpvar)
 	for name, v := range vars {
-		i := reg.NewInt(name)
+		i := NewInt(reg, name, Report)
 		i.Add(v)
 	}
 

--- a/libbeat/service/service.go
+++ b/libbeat/service/service.go
@@ -1,7 +1,9 @@
 package service
 
 import (
+	"expvar"
 	"flag"
+	"fmt"
 	"log"
 	"os"
 	"os/signal"
@@ -11,10 +13,9 @@ import (
 	"syscall"
 
 	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/monitoring"
 
 	"net/http"
-
-	// blank pprof import to load HTTP handler for debugging endpoint
 	_ "net/http/pprof"
 )
 
@@ -72,9 +73,46 @@ func BeforeRun() {
 	if *httpprof != "" {
 		go func() {
 			logp.Info("start pprof endpoint")
-			logp.Info("finished pprof endpoint: %v", http.ListenAndServe(*httpprof, nil))
+			mux := http.NewServeMux()
+
+			// register pprof handler
+			mux.HandleFunc("/debug/pprof/", func(w http.ResponseWriter, r *http.Request) {
+				http.DefaultServeMux.ServeHTTP(w, r)
+			})
+
+			// register metrics handler
+			mux.HandleFunc("/debug/vars", metricsHandler)
+
+			endpoint := http.ListenAndServe(*httpprof, mux)
+			logp.Info("finished pprof endpoint: %v", endpoint)
 		}()
 	}
+}
+
+// report expvar and all libbeat/monitoring metrics
+func metricsHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+
+	first := true
+	report := func(key string, value interface{}) error {
+		if !first {
+			fmt.Fprintf(w, ",\n")
+		}
+		first = false
+		if str, ok := value.(string); ok {
+			fmt.Fprintf(w, "%q: %q", key, str)
+		} else {
+			fmt.Fprintf(w, "%q: %v", key, value)
+		}
+		return nil
+	}
+
+	fmt.Fprintf(w, "{\n")
+	monitoring.Do(monitoring.Full, report)
+	expvar.Do(func(kv expvar.KeyValue) {
+		report(kv.Key, kv.Value)
+	})
+	fmt.Fprintf(w, "\n}\n")
 }
 
 // Cleanup handles cleaning up the runtime and OS environments. This includes


### PR DESCRIPTION
- remove NewInt/Float/String from registry:
  replace NewInt/Float/String and (*Registry).NewX by one NewX accepting the
  target registry by default. if nil is choosen, we default to the Default
  registry
- Introduce 'Report' flag to metrics to mark some basic metrics
- Add new adapter filters: ReportIf and ReportNames
- apply variable options on registry or variable node. A variable 'inherits'
  the options from it's registry on Add => using `monitoring.Report` on registry
  will set `report` on all variables added to the sub-registry
- move flattened snapshot support to monitoring/snapshot.go
- Replace global http handler for httpprof with multiplexer configuring a
  only selected set of HTTP handlers (do not expose 'unknown' handlers from
  third party packages by accident)
- custom /debug/vars http handler support expvar and libbeat/monitoring (output
  fully compatible to old expvar output)