### PR TITLE
Bump version for xpack doc URL

### DIFF
--- a/filebeat/docs/index.asciidoc
+++ b/filebeat/docs/index.asciidoc
@@ -8,7 +8,7 @@ include::../../libbeat/docs/version.asciidoc[]
 :filebeat: http://www.elastic.co/guide/en/beats/filebeat/{doc-branch}
 :winlogbeat: http://www.elastic.co/guide/en/beats/winlogbeat/{doc-branch}
 :elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/{doc-branch}
-:securitydoc: https://www.elastic.co/guide/en/x-pack/5.0
+:securitydoc: https://www.elastic.co/guide/en/x-pack/5.2
 :version: {stack-version}
 :beatname_lc: filebeat
 :beatname_uc: Filebeat

--- a/heartbeat/docs/index.asciidoc
+++ b/heartbeat/docs/index.asciidoc
@@ -8,7 +8,7 @@ include::../../libbeat/docs/version.asciidoc[]
 :filebeat: http://www.elastic.co/guide/en/beats/filebeat/{doc-branch}
 :winlogbeat: http://www.elastic.co/guide/en/beats/winlogbeat/{doc-branch}
 :elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/{doc-branch}
-:securitydoc: https://www.elastic.co/guide/en/x-pack/5.0
+:securitydoc: https://www.elastic.co/guide/en/x-pack/5.2
 :downloads: https://artifacts.elastic.co/downloads/beats
 :version: {stack-version}
 :beatname_lc: heartbeat

--- a/libbeat/docs/index.asciidoc
+++ b/libbeat/docs/index.asciidoc
@@ -7,7 +7,7 @@ include::./version.asciidoc[]
 :metricbeat: http://www.elastic.co/guide/en/beats/metricbeat/{doc-branch}
 :filebeat: http://www.elastic.co/guide/en/beats/filebeat/{doc-branch}
 :winlogbeat: http://www.elastic.co/guide/en/beats/winlogbeat/{doc-branch}
-:securitydoc: https://www.elastic.co/guide/en/x-pack/5.0
+:securitydoc: https://www.elastic.co/guide/en/x-pack/5.2
 :security: X-Pack Security
 :ES-version: {stack-version}
 :LS-version: {stack-version}

--- a/metricbeat/docs/index.asciidoc
+++ b/metricbeat/docs/index.asciidoc
@@ -5,7 +5,7 @@ include::../../libbeat/docs/version.asciidoc[]
 :libbeat: http://www.elastic.co/guide/en/beats/libbeat/{doc-branch}
 :filebeat: http://www.elastic.co/guide/en/beats/filebeat/{doc-branch}
 :elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/{doc-branch}
-:securitydoc: https://www.elastic.co/guide/en/x-pack/5.0
+:securitydoc: https://www.elastic.co/guide/en/x-pack/5.2
 :version: {stack-version}
 :beatname_lc: metricbeat
 :beatname_uc: Metricbeat

--- a/packetbeat/docs/index.asciidoc
+++ b/packetbeat/docs/index.asciidoc
@@ -9,7 +9,7 @@ include::../../libbeat/docs/version.asciidoc[]
 :winlogbeat: http://www.elastic.co/guide/en/beats/winlogbeat/{doc-branch}
 :elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/{doc-branch}
 :logstashdoc: https://www.elastic.co/guide/en/logstash/{doc-branch}
-:securitydoc: https://www.elastic.co/guide/en/x-pack/5.0
+:securitydoc: https://www.elastic.co/guide/en/x-pack/5.2
 :kibanadoc: https://www.elastic.co/guide/en/kibana/{doc-branch}
 :plugindoc: https://www.elastic.co/guide/en/elasticsearch/plugins/{doc-branch}
 :version: {stack-version}

--- a/winlogbeat/docs/index.asciidoc
+++ b/winlogbeat/docs/index.asciidoc
@@ -8,7 +8,7 @@ include::../../libbeat/docs/version.asciidoc[]
 :filebeat: http://www.elastic.co/guide/en/beats/filebeat/{doc-branch}
 :winlogbeat: http://www.elastic.co/guide/en/beats/winlogbeat/{doc-branch}
 :elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/{doc-branch}
-:securitydoc: https://www.elastic.co/guide/en/x-pack/5.0
+:securitydoc: https://www.elastic.co/guide/en/x-pack/5.2
 :version: {stack-version}
 :beatname_lc: winlogbeat
 :beatname_uc: Winlogbeat


### PR DESCRIPTION
Note that I don't use `{doc-branch}` here for X-Pack because it causes build errors (we don't build the X-Pack docs in `master`). 