### PR TITLE
Fix environments tests in 5.0 by updating dependency

### DIFF
--- a/testing/environments/docker/elasticsearch/Dockerfile-snapshot
+++ b/testing/environments/docker/elasticsearch/Dockerfile-snapshot
@@ -4,7 +4,7 @@ ENV ELASTICSEARCH_MAJOR 5.0
 ENV ELASTICSEARCH_VERSION 5.0
 ENV VERSION 5.0.2
 ENV FILENAME_VERSION 5.0.2
-ENV URL https://staging.elastic.co/5.0.2-b2495b70/downloads/elasticsearch/elasticsearch-5.0.2.tar.gz
+ENV URL https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.0.2.tar.gz
 
 ENV ESHOME /opt/elasticsearch-${FILENAME_VERSION}
 

--- a/testing/environments/docker/kibana/Dockerfile-snapshot
+++ b/testing/environments/docker/kibana/Dockerfile-snapshot
@@ -2,7 +2,7 @@ FROM debian:jessie
 
 ENV VERSION 5.0.2
 ENV FILENAME_VERSION 5.0.2-linux-x86_64
-ENV URL http://staging.elastic.co/5.0.2-b2495b70/downloads/kibana/kibana-${FILENAME_VERSION}.tar.gz
+ENV URL https://artifacts.elastic.co/downloads/kibana/kibana-${FILENAME_VERSION}.tar.gz
 
 # Cache variable can be set during building to invalidate the build cache with `--build-arg CACHE=$(date +%s) .`
 ARG CACHE=1

--- a/testing/environments/docker/logstash/Dockerfile-snapshot
+++ b/testing/environments/docker/logstash/Dockerfile-snapshot
@@ -3,7 +3,7 @@ FROM java:8-jre
 ENV LS_VERSION 5
 
 ENV VERSION 5.0.2
-ENV URL http://staging.elastic.co/5.0.2-b2495b70/downloads/logstash/logstash-${VERSION}.tar.gz
+ENV URL https://artifacts.elastic.co/downloads/logstash/logstash-${VERSION}.tar.gz
 ENV PATH $PATH:/opt/logstash-$VERSION/bin
 
 # Cache variable can be set during building to invalidate the build cache with `--build-arg CACHE=$(date +%s) .`


### PR DESCRIPTION
Use stable versions which will not disappear.