### PR TITLE
Use stable artifacts for 5.1 builds

### DIFF
--- a/testing/environments/docker/kibana/Dockerfile-snapshot
+++ b/testing/environments/docker/kibana/Dockerfile-snapshot
@@ -2,7 +2,7 @@
 FROM docker.elastic.co/kibana/kibana-ubuntu-base:latest
 MAINTAINER Elastic Docker Team <docker@elastic.co>
 
-ARG KIBANA_DOWNLOAD_URL=https://staging.elastic.co/5.1.2-ad675786/downloads/kibana/kibana-5.1.2-linux-x86_64.tar.gz
+ARG KIBANA_DOWNLOAD_URL=https://artifacts.elastic.co/downloads/kibana/kibana-5.1.2-linux-x86_64.tar.gz
 ARG X_PACK_URL
 
 EXPOSE 5601

--- a/testing/environments/docker/logstash/Dockerfile-snapshot
+++ b/testing/environments/docker/logstash/Dockerfile-snapshot
@@ -3,7 +3,7 @@ FROM java:8-jre
 ENV LS_VERSION 5
 
 ENV VERSION 5.1.2
-ENV URL https://staging.elastic.co/5.1.2-ad675786/downloads/logstash/logstash-5.1.2.tar.gz
+ENV URL https://artifacts.elastic.co/downloads/logstash/logstash-5.1.2.tar.gz
 ENV PATH $PATH:/opt/logstash-$VERSION/bin
 
 # Cache variable can be set during building to invalidate the build cache with `--build-arg CACHE=$(date +%s) .`

--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -8,7 +8,7 @@ services:
       dockerfile: Dockerfile-snapshot
       args:
         ELASTIC_VERSION: 5.1.2
-        ES_DOWNLOAD_URL: 'https://staging.elastic.co/5.1.2-ad675786/downloads/elasticsearch'
+        ES_DOWNLOAD_URL: 'https://artifacts.elastic.co/downloads/elasticsearch'
         #XPACK: http://snapshots.elastic.co/downloads/packs/x-pack/x-pack-6.0.0-alpha1-SNAPSHOT.zip
     environment:
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"


### PR DESCRIPTION
The snapshot artifacts were not available anymore.