### PR TITLE
Fix protocol plugin import statement in Packetbeat

### DIFF
--- a/packetbeat/main.go
+++ b/packetbeat/main.go
@@ -4,8 +4,10 @@ import (
 	"os"
 
 	"github.com/elastic/beats/libbeat/beat"
-	_ "github.com/elastic/beats/metricbeat/include"
 	"github.com/elastic/beats/packetbeat/beater"
+
+	// import protocol modules
+	_ "github.com/elastic/beats/packetbeat/include"
 )
 
 var Name = "packetbeat"


### PR DESCRIPTION
No protocols were registered because the import statement was for Metricbeat modules and not Packetbeat protocols.