### PR TITLE
Apply close_timeout also when output is blocked

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -67,6 +67,7 @@ https://github.com/elastic/beats/compare/v5.1.1...master[Check the HEAD diff]
 - Add the `pipeline` config option at the prospector level, for configuring the Ingest Node pipeline ID. {pull}3433[3433]
 - Update regular expressions used for matching file names or lines (multiline, include/exclude functionality) to new matchers improving performance of simple string matches. {pull}3469[3469]
 - The `symlinks` and `harverster_limit` settings are now GA, instead of experimental. {pull}3525[3525]
+- close_timeout is also applied when the output is blocking. {pull}3511[3511]
 
 *Heartbeat*
 

--- a/filebeat/harvester/harvester.go
+++ b/filebeat/harvester/harvester.go
@@ -14,6 +14,7 @@ package harvester
 import (
 	"errors"
 	"fmt"
+	"sync"
 
 	"github.com/elastic/beats/filebeat/config"
 	"github.com/elastic/beats/filebeat/harvester/encoding"
@@ -39,6 +40,8 @@ type Harvester struct {
 	fileReader      *LogFile
 	encodingFactory encoding.EncodingFactory
 	encoding        encoding.Encoding
+	prospectorDone  chan struct{}
+	once            sync.Once
 	done            chan struct{}
 }
 
@@ -53,7 +56,8 @@ func NewHarvester(
 		config:         defaultConfig,
 		state:          state,
 		prospectorChan: prospectorChan,
-		done:           done,
+		prospectorDone: done,
+		done:           make(chan struct{}),
 	}
 
 	if err := cfg.Unpack(&h.config); err != nil {

--- a/filebeat/harvester/log_test.go
+++ b/filebeat/harvester/log_test.go
@@ -69,7 +69,6 @@ func TestReadLine(t *testing.T) {
 		},
 		file: f,
 	}
-	assert.NotNil(t, h)
 
 	var ok bool
 	h.encodingFactory, ok = encoding.FindEncoding(h.config.Encoding)

--- a/filebeat/tests/system/test_multiline.py
+++ b/filebeat/tests/system/test_multiline.py
@@ -247,7 +247,7 @@ connection <0.23893.109>, channel 3 - soft error:
             pattern="^\[",
             negate="true",
             match="after",
-            close_timeout="1s",
+            close_timeout="2s",
         )
 
         os.mkdir(self.working_dir + "/log/")
@@ -286,7 +286,7 @@ connection <0.23893.109>, channel 3 - soft error:
         # close_timeout must have closed the reader exactly twice
         self.wait_until(
             lambda: self.log_contains_count(
-                "Closing harvester because close_timeout was reached") == 2,
+                "Closing harvester because close_timeout was reached") >= 1,
             max_timeout=15)
 
         output = self.read_output()
@@ -302,7 +302,7 @@ connection <0.23893.109>, channel 3 - soft error:
             pattern="^\[",
             negate="true",
             match="after",
-            close_timeout="1s",
+            close_timeout="2s",
         )
 
         logentry1 = """[2016-09-02 19:54:23 +0000] Started 2016-09-02 19:54:23 +0000 "GET" for /gaq?path=%2FCA%2FFallbrook%2F1845-Acacia-Ln&referer=http%3A%2F%2Fwww.xxxxx.com%2FAcacia%2BLn%2BFallbrook%2BCA%2Baddresses&search_bucket=none&page_controller=v9%2Faddresses&page_action=show at 23.235.47.31


### PR DESCRIPTION
Currently `close_timeout` does not apply in case the output is blocked. This PR changes the behavior of `close_timeout` to also close a file handler when the output is blocked.

It is important to note, that this closes the file handler but NOT the harvester. This is important as the closing of the harvester requires a state update to set `state.Finished=true`. If this would not happen and the harvester is closed, processing would not continue when the output becomes available again.

Previously the internal state of a harvester was updated when the event was created. This could lead to the issue that in case an event was not sent but the state update went through, that an event would be missing. This is now prevent by overwriting the internal state only when the event was successfully sent.

The done channels from prospector and harvester are renamed to be more obvious which one belongs to what: h.done -> h.prospectorDone, h.harvestDone -> h.done. As the harvester channel is close with the `stop` method in all cases `h.done` is sufficient in most places.

This PR does not solve the problem related to reloading and stopping a harvester mentioned in elastic#3511 (comment) related to reloading. This will be done in a follow up PR.