### PR TITLE
Fix leaking go routine in docker stats fetching (#3492)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -8,7 +8,7 @@
 // Template, add newest changes here
 
 === Beats version HEAD
-https://github.com/elastic/beats/compare/v5.1.1...master[Check the HEAD diff]
+https://github.com/elastic/beats/compare/v5.2.0...master[Check the HEAD diff]
 
 ==== Breaking changes
 
@@ -33,6 +33,7 @@ https://github.com/elastic/beats/compare/v5.1.1...master[Check the HEAD diff]
 *Heartbeat*
 
 *Metricbeat*
+- Fix go routine leak in docker module. {pull}3492[3492]
 
 *Packetbeat*
 


### PR DESCRIPTION
Go routine on line 79 never stopped as queue was not closed.

Fixes https://github.com/elastic/beats/issues/3489
(cherry picked from commit 3366bdb62fe6c603119601bb17b115c8f99bd1e6)