### PR TITLE
Use the Beat version in the Ingest Node pipeline

### DIFF
--- a/filebeat/beater/filebeat.go
+++ b/filebeat/beater/filebeat.go
@@ -37,7 +37,7 @@ func New(b *beat.Beat, rawConfig *common.Config) (beat.Beater, error) {
 		return nil, fmt.Errorf("Error reading config file: %v", err)
 	}
 
-	moduleRegistry, err := fileset.NewModuleRegistry(config.Modules)
+	moduleRegistry, err := fileset.NewModuleRegistry(config.Modules, b.Version)
 	if err != nil {
 		return nil, err
 	}

--- a/filebeat/fileset/fileset_test.go
+++ b/filebeat/fileset/fileset_test.go
@@ -149,7 +149,7 @@ func TestResolveVariable(t *testing.T) {
 
 func TestGetProspectorConfigNginx(t *testing.T) {
 	fs := getModuleForTesting(t, "nginx", "access")
-	assert.NoError(t, fs.Read())
+	assert.NoError(t, fs.Read("5.2.0"))
 
 	cfg, err := fs.getProspectorConfig()
 	assert.NoError(t, err)
@@ -159,7 +159,7 @@ func TestGetProspectorConfigNginx(t *testing.T) {
 	assert.True(t, cfg.HasField("pipeline"))
 	pipelineID, err := cfg.String("pipeline", -1)
 	assert.NoError(t, err)
-	assert.Equal(t, "nginx-access-with_plugins", pipelineID)
+	assert.Equal(t, "filebeat-5.2.0-nginx-access-with_plugins", pipelineID)
 }
 
 func TestGetProspectorConfigNginxOverrides(t *testing.T) {
@@ -172,7 +172,7 @@ func TestGetProspectorConfigNginxOverrides(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	assert.NoError(t, fs.Read())
+	assert.NoError(t, fs.Read("5.2.0"))
 
 	cfg, err := fs.getProspectorConfig()
 	assert.NoError(t, err)
@@ -183,17 +183,17 @@ func TestGetProspectorConfigNginxOverrides(t *testing.T) {
 	assert.True(t, cfg.HasField("pipeline"))
 	pipelineID, err := cfg.String("pipeline", -1)
 	assert.NoError(t, err)
-	assert.Equal(t, "nginx-access-with_plugins", pipelineID)
+	assert.Equal(t, "filebeat-5.2.0-nginx-access-with_plugins", pipelineID)
 
 }
 
 func TestGetPipelineNginx(t *testing.T) {
 	fs := getModuleForTesting(t, "nginx", "access")
-	assert.NoError(t, fs.Read())
+	assert.NoError(t, fs.Read("5.2.0"))
 
 	pipelineID, content, err := fs.GetPipeline()
 	assert.NoError(t, err)
-	assert.Equal(t, "nginx-access-with_plugins", pipelineID)
+	assert.Equal(t, "filebeat-5.2.0-nginx-access-with_plugins", pipelineID)
 	assert.Contains(t, content, "description")
 	assert.Contains(t, content, "processors")
 }

--- a/filebeat/fileset/modules.go
+++ b/filebeat/fileset/modules.go
@@ -18,7 +18,8 @@ type ModuleRegistry struct {
 // newModuleRegistry reads and loads the configured module into the registry.
 func newModuleRegistry(modulesPath string,
 	moduleConfigs []ModuleConfig,
-	overrides *ModuleOverrides) (*ModuleRegistry, error) {
+	overrides *ModuleOverrides,
+	beatVersion string) (*ModuleRegistry, error) {
 
 	var reg ModuleRegistry
 	reg.registry = map[string]map[string]*Fileset{}
@@ -53,7 +54,7 @@ func newModuleRegistry(modulesPath string,
 			if err != nil {
 				return nil, err
 			}
-			err = fileset.Read()
+			err = fileset.Read(beatVersion)
 			if err != nil {
 				return nil, fmt.Errorf("Error reading fileset %s/%s: %v", mcfg.Module, filesetName, err)
 			}
@@ -81,7 +82,7 @@ func newModuleRegistry(modulesPath string,
 }
 
 // NewModuleRegistry reads and loads the configured module into the registry.
-func NewModuleRegistry(moduleConfigs []*common.Config) (*ModuleRegistry, error) {
+func NewModuleRegistry(moduleConfigs []*common.Config, beatVersion string) (*ModuleRegistry, error) {
 	modulesPath := paths.Resolve(paths.Home, "module")
 
 	stat, err := os.Stat(modulesPath)
@@ -106,7 +107,7 @@ func NewModuleRegistry(moduleConfigs []*common.Config) (*ModuleRegistry, error) 
 	if err != nil {
 		return nil, err
 	}
-	return newModuleRegistry(modulesPath, mcfgs, modulesOverrides)
+	return newModuleRegistry(modulesPath, mcfgs, modulesOverrides, beatVersion)
 }
 
 func mcfgFromConfig(cfg *common.Config) (*ModuleConfig, error) {

--- a/filebeat/fileset/modules_integration_test.go
+++ b/filebeat/fileset/modules_integration_test.go
@@ -35,8 +35,8 @@ func TestLoadPipeline(t *testing.T) {
 
 func TestSetupNginx(t *testing.T) {
 	client := elasticsearch.GetTestingElasticsearch()
-	client.Request("DELETE", "/_ingest/pipeline/nginx-access-with_plugins", "", nil, nil)
-	client.Request("DELETE", "/_ingest/pipeline/nginx-error-pipeline", "", nil, nil)
+	client.Request("DELETE", "/_ingest/pipeline/filebeat-5.2.0-nginx-access-with_plugins", "", nil, nil)
+	client.Request("DELETE", "/_ingest/pipeline/filebeat-5.2.0-nginx-error-pipeline", "", nil, nil)
 
 	modulesPath, err := filepath.Abs("../module")
 	assert.NoError(t, err)
@@ -45,14 +45,14 @@ func TestSetupNginx(t *testing.T) {
 		{Module: "nginx"},
 	}
 
-	reg, err := newModuleRegistry(modulesPath, configs, nil)
+	reg, err := newModuleRegistry(modulesPath, configs, nil, "5.2.0")
 	assert.NoError(t, err)
 
 	err = reg.LoadPipelines(client)
 	assert.NoError(t, err)
 
-	status, _, _ := client.Request("GET", "/_ingest/pipeline/nginx-access-with_plugins", "", nil, nil)
+	status, _, _ := client.Request("GET", "/_ingest/pipeline/filebeat-5.2.0-nginx-access-with_plugins", "", nil, nil)
 	assert.Equal(t, 200, status)
-	status, _, _ = client.Request("GET", "/_ingest/pipeline/nginx-error-pipeline", "", nil, nil)
+	status, _, _ = client.Request("GET", "/_ingest/pipeline/filebeat-5.2.0-nginx-error-pipeline", "", nil, nil)
 	assert.Equal(t, 200, status)
 }

--- a/filebeat/fileset/modules_test.go
+++ b/filebeat/fileset/modules_test.go
@@ -30,7 +30,7 @@ func TestNewModuleRegistry(t *testing.T) {
 		{Module: "system"},
 	}
 
-	reg, err := newModuleRegistry(modulesPath, configs, nil)
+	reg, err := newModuleRegistry(modulesPath, configs, nil, "5.2.0")
 	assert.NoError(t, err)
 	assert.NotNil(t, reg)
 
@@ -86,7 +86,7 @@ func TestNewModuleRegistryConfig(t *testing.T) {
 		},
 	}
 
-	reg, err := newModuleRegistry(modulesPath, configs, nil)
+	reg, err := newModuleRegistry(modulesPath, configs, nil, "5.2.0")
 	assert.NoError(t, err)
 	assert.NotNil(t, reg)
 
@@ -335,7 +335,7 @@ func TestMissingModuleFolder(t *testing.T) {
 		load(t, map[string]interface{}{"module": "nginx"}),
 	}
 
-	reg, err := NewModuleRegistry(configs)
+	reg, err := NewModuleRegistry(configs, "5.2.0")
 	assert.NoError(t, err)
 	assert.NotNil(t, reg)
 


### PR DESCRIPTION
This adds the Beat version to the pipeline ID, which means that if
we change the pipeline between versions, the new version will be used
automatically. It also means that one can run different versions of the
same Beat and the pipelines won't override each other. The pipelines
are loaded automatically on the Beat start.

Part of #3159.
