### PR TITLE
Add edits for prometheus module docs

### DIFF
--- a/metricbeat/docs/fields.asciidoc
+++ b/metricbeat/docs/fields.asciidoc
@@ -4708,7 +4708,7 @@ Time at which these statistics were last reset.
 == Prometheus Fields
 
 beta[]
-Prometheus Module
+Stats collected from Prometheus.
 
 
 
@@ -4721,14 +4721,14 @@ Prometheus Module
 [float]
 == stats Fields
 
-stats
+Stats about the Prometheus server.
 
 
 
 [float]
 == notifications Fields
 
-Notification stats
+Notification stats.
 
 
 
@@ -4737,7 +4737,7 @@ Notification stats
 
 type: long
 
-Current queue length
+Current queue length.
 
 
 [float]
@@ -4745,7 +4745,7 @@ Current queue length
 
 type: long
 
-Dropped queue events
+Number of dropped queue events.
 
 
 [float]
@@ -4753,7 +4753,7 @@ Dropped queue events
 
 type: long
 
-Open file descriptors gauge
+Number of open file descriptors.
 
 
 [float]
@@ -4761,7 +4761,7 @@ Open file descriptors gauge
 
 type: long
 
-Gauge on chunks which are not persisted to disk yet
+Number of memory chunks that are not yet persisted to disk.
 
 
 [[exported-fields-redis]]

--- a/metricbeat/docs/modules/prometheus.asciidoc
+++ b/metricbeat/docs/modules/prometheus.asciidoc
@@ -3,12 +3,13 @@ This file is generated! See scripts/docs_collector.py
 ////
 
 [[metricbeat-module-prometheus]]
-== prometheus Module
+
+== Prometheus Module
 
 beta[]
 
-This is the prometheus Module.
-
+This module periodically fetches metrics from
+https://prometheus.io/docs/[Prometheus].
 
 
 [float]

--- a/metricbeat/docs/modules/prometheus.asciidoc
+++ b/metricbeat/docs/modules/prometheus.asciidoc
@@ -3,7 +3,6 @@ This file is generated! See scripts/docs_collector.py
 ////
 
 [[metricbeat-module-prometheus]]
-
 == Prometheus Module
 
 beta[]

--- a/metricbeat/module/prometheus/_meta/docs.asciidoc
+++ b/metricbeat/module/prometheus/_meta/docs.asciidoc
@@ -1,6 +1,6 @@
-== prometheus Module
+== Prometheus Module
 
 beta[]
 
-This is the prometheus Module.
-
+This module periodically fetches metrics from
+https://prometheus.io/docs/[Prometheus].

--- a/metricbeat/module/prometheus/_meta/fields.yml
+++ b/metricbeat/module/prometheus/_meta/fields.yml
@@ -2,8 +2,8 @@
   title: "Prometheus"
   description: >
     beta[]
-
-    Prometheus Module
+    
+    Stats collected from Prometheus.
   short_config: false
   fields:
     - name: prometheus

--- a/metricbeat/module/prometheus/collector/_meta/docs.asciidoc
+++ b/metricbeat/module/prometheus/collector/_meta/docs.asciidoc
@@ -2,6 +2,6 @@
 
 The Prometheus `collector` metricset fetches data from https://prometheus.io/docs/instrumenting/exporters/[prometheus exporters].
 
-All events with the same labels are grouped together as one event.
-
-//REVIEWERS: Should we say something about which Prometheus exporters are supported? Users might follow the link and think that all the exporters listed on the page are supported, but I'm not sure if that's true.
+All events with the same labels are grouped together as one event. The fields
+exported by this metricset vary depending on the Prometheus exporter that you're
+using.

--- a/metricbeat/module/prometheus/collector/_meta/docs.asciidoc
+++ b/metricbeat/module/prometheus/collector/_meta/docs.asciidoc
@@ -1,5 +1,7 @@
-=== prometheus collector MetricSet
+=== Prometheus Collector Metricset
 
-This is the collector metricset of the module prometheus. It allows to fetch data from https://prometheus.io/docs/instrumenting/exporters/[prometheus exporters].
+The Prometheus `collector` metricset fetches data from https://prometheus.io/docs/instrumenting/exporters/[prometheus exporters].
 
 All events with the same labels are grouped together as one event.
+
+//REVIEWERS: Should we say something about which Prometheus exporters are supported? Users might follow the link and think that all the exporters listed on the page are supported, but I'm not sure if that's true.

--- a/metricbeat/module/prometheus/stats/_meta/docs.asciidoc
+++ b/metricbeat/module/prometheus/stats/_meta/docs.asciidoc
@@ -1,3 +1,4 @@
-=== prometheus stats MetricSet
+=== Prometheus Stats Metricset
 
-This is the stats metricset of the module prometheus.
+The Prometheus `stats` metricset collects statistics about the Prometheus
+server.

--- a/metricbeat/module/prometheus/stats/_meta/fields.yml
+++ b/metricbeat/module/prometheus/stats/_meta/fields.yml
@@ -1,26 +1,26 @@
 - name: stats
   type: group
   description: >
-    stats
+    Stats about the Prometheus server.
   fields:
     - name: notifications
       type: group
       description: >
-        Notification stats
+        Notification stats.
       fields:
         - name: queue_length
           type: long
           description: >
-            Current queue length
+            Current queue length.
         - name: dropped
           type: long
           description: >
-            Dropped queue events
+            Number of dropped queue events.
     - name: processes.open_fds
       type: long
       description: >
-        Open file descriptors gauge
+        Number of open file descriptors.
     - name: storage.chunks_to_persist
       type: long
       description: >
-        Gauge on chunks which are not persisted to disk yet
+        Number of memory chunks that are not yet persisted to disk.


### PR DESCRIPTION
A few minor editorial fixes.

@ruflin The fields.yml file for the `collector` metricset is empty: https://github.com/elastic/beats/blob/master/metricbeat/module/prometheus/collector/_meta/fields.yml. Can you update the fields.yml file (or let me know the fields/descriptions, and I can add them)?