### PR TITLE
Check if the pipeline exists before loading

### DIFF
--- a/filebeat/fileset/modules.go
+++ b/filebeat/fileset/modules.go
@@ -245,6 +245,7 @@ func (reg *ModuleRegistry) GetProspectorConfigs() ([]*common.Config, error) {
 // the pipelines.
 type PipelineLoader interface {
 	LoadJSON(path string, json map[string]interface{}) error
+	Request(method, path string, pipeline string, params map[string]string, body interface{}) (int, []byte, error)
 }
 
 // Setup is called on -setup and loads the pipelines for each configured fileset.
@@ -266,6 +267,11 @@ func (reg *ModuleRegistry) Setup(esClient PipelineLoader) error {
 
 func loadPipeline(esClient PipelineLoader, pipelineID string, content map[string]interface{}) error {
 	path := "/_ingest/pipeline/" + pipelineID
+	status, _, _ := esClient.Request("GET", path, "", nil, nil)
+	if status == 200 {
+		logp.Debug("modules", "Pipeline %s already loaded", pipelineID)
+		return nil
+	}
 	err := esClient.LoadJSON(path, content)
 	if err != nil {
 		return fmt.Errorf("couldn't load template: %v", err)


### PR DESCRIPTION
This is probably safer since if one has lots and lots of Beats
this is less likely to block the Ingest node processing.

Part of #3159.