### PR TITLE
Update Windows paths for chocolatey installed packages

### DIFF
--- a/filebeat/module/apache2/access/manifest.yml
+++ b/filebeat/module/apache2/access/manifest.yml
@@ -8,7 +8,8 @@ var:
     os.darwin:
       - /usr/local/var/log/apache2/access_log*
     os.windows:
-      - "C:/Program Files/Apache Software Foundation/Apache2.4/logs/access.log*"
+      - "C:/tools/Apache/httpd-2.*/Apache24/logs/access.log*"
+      - "C:/Program Files/Apache Software Foundation/Apache2.*/logs/access.log*"
   - name: pipeline
     # options: with_plugins, no_plugins
     default: with_plugins

--- a/filebeat/module/apache2/error/manifest.yml
+++ b/filebeat/module/apache2/error/manifest.yml
@@ -7,7 +7,8 @@ var:
     os.darwin:
       - /usr/local/var/log/apache2/error_log*
     os.windows:
-      - "C:/Program Files/Apache Software Foundation/Apache2.4/logs/error.log*"
+      - "C:/tools/Apache/httpd-2.*/Apache24/logs/error.log*"
+      - "C:/Program Files/Apache Software Foundation/Apache2.*/logs/error.log*"
 
 ingest_pipeline: ingest/pipeline.json
 prospector: config/error.yml

--- a/filebeat/module/nginx/access/manifest.yml
+++ b/filebeat/module/nginx/access/manifest.yml
@@ -7,7 +7,7 @@ var:
     os.darwin:
       - /usr/local/var/log/nginx/access.log*
     os.windows:
-      - c:/programfiles/nginx/logs/access.log*
+      - c:/programdata/nginx/logs/*access.log*
   - name: pipeline
     # options: with_plugins, no_plugins
     default: with_plugins

--- a/filebeat/module/nginx/error/manifest.yml
+++ b/filebeat/module/nginx/error/manifest.yml
@@ -7,7 +7,7 @@ var:
     os.darwin:
       - /usr/local/var/log/nginx/error.log*
     os.windows:
-      - c:/programfiles/nginx/logs/error.log*
+      - c:/programdata/nginx/logs/error.log*
 
 ingest_pipeline: ingest/pipeline.json
 prospector: config/nginx-error.yml


### PR DESCRIPTION
Done for:
- nginx
- apache

Mysql seems to use windows event logs by default.

Syslog doesn't really exist on Windows. Currently no paths are defined, which
result in an error when starting Filebeat.

Part of #3159.