### PR TITLE
Update experimental notices for 5.3

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -16,16 +16,16 @@ https://github.com/elastic/beats/compare/v5.1.1...master[Check the HEAD diff]
 
 - Change beat generator. Use `$GOPATH/src/github.com/elastic/beats/script/generate.py` to generate a beat. {pull}3452[3452]
 
+*Filebeat*
+
+*Heartbeat*
+
 *Metricbeat*
 - Linux cgroup metrics are now enabled by default for the system process
   metricset. The configuration option for the feature was renamed from
   `cgroups` to `process.cgroups.enabled`. {pull}3519[3519]
 
 *Packetbeat*
-
-*Topbeat*
-
-*Filebeat*
 
 *Winlogbeat*
 
@@ -34,105 +34,154 @@ https://github.com/elastic/beats/compare/v5.1.1...master[Check the HEAD diff]
 
 *Affecting all Beats*
 
-- Add `_id`, `_type`, `_index` and `_score` fields in the generated index pattern. {pull}3282}[3282]
+- Add `_id`, `_type`, `_index` and `_score` fields in the generated index pattern. {pull}3282[3282]
+
+*Filebeat*
+
+*Heartbeat*
 
 *Metricbeat*
 
-- Fix service times-out at startup. {pull}3056[3056]
-- Kafka module case sensitive host name matching. {pull}3193[3193]
-- Fix interface conversion panic in couchbase module {pull}3272[3272]
-- Fix overwriting explicit empty config sections {issue}2918[2918]
 - Fix go routine leak in docker module. {pull}3492[3492]
 
 *Packetbeat*
 
-- Fix issue where some Cassandra visualizations were showing data from all protocols. {issue}3314[3314]
-
-*Topbeat*
-
-*Filebeat*
-- Fix registry cleanup issue when files falling under ignore_older after restart. {issue}2818[2818]
-- Fix registry migration issue from old states were files were only harvested after second restart. {pull}3322[3322]
-- Fix alignment issue were Filebeat compiled with Go 1.7.4 was crashing on 32 bits system. {issue}3273[3273]
 
 *Winlogbeat*
-- Fix for "The array bounds are invalid" error when reading large events. {issue}3076[3076]
+
 
 ==== Added
 
 *Affecting all Beats*
-- Add support for passing list and dictionary settings via -E flag.
-- Support for parsing list and dictionary setting from environment variables.
-- Added new flags to import_dashboards (-cacert, -cert, -key, -insecure). {pull}3139[3139] {pull}3163[3163]
-- The limit for the number of fields is increased via the mapping template. {pull}3275[3275]
-- Updated to Go 1.7.4. {pull}3277[3277]
-- Added a NOTICE file containing the notices and licenses of the dependencies. {pull}3334[3334].
+
 - Files created by Beats (logs, registry, file output) will have 0600 permissions. {pull}3387[3387].
 - RPM/deb packages will now install the config file with 0600 permissions. {pull}3382[3382]
 - Add the option to pass custom HTTP headers to the Elasticsearch output. {pull}3400[3400]
 - Unify `regexp` and `contains` conditionals, for both to support array of strings and convert numbers to strings if required. {pull}3469[3469]
 - Add the option to load the sample dashboards during the Beat startup phase. {pull}3506[3506]
 - Disabled date detection in Elasticsearch index templates. Date fields must be explicitly defined in index templates. {pull}3528[3528]
+- Using environment variables in the configuration file is now GA, instead of experimental. {pull}3525[3525]
+
+*Filebeat*
+
+- Add the `pipeline` config option at the prospector level, for configuring the Ingest Node pipeline ID. {pull}3433[3433]
+- Update regular expressions used for matching file names or lines (multiline, include/exclude functionality) to new matchers improving performance of simple string matches. {pull}3469[3469]
+- The `symlinks` and `harverster_limit` settings are now GA, instead of experimental. {pull}3525[3525]
+
+*Heartbeat*
 
 *Metricbeat*
 
-- Add experimental filebeat metricset in the beats module. {pull}2297[2297]
-- Add experimental libbeat metricset in the beats module. {pull}2339[2339]
-- Add experimental docker module. Provided by Ingensi and @douaejeouit based on dockbeat.
-- Add username and password config options to the MongoDB module. {pull}2889[2889]
-- Add username and password config options to the PostgreSQL module. {pull}2889[2890]
-- Add system core metricset for Windows. {pull}2883[2883]
-- Add a sample Redis Kibana dashboard. {pull}2916[2916]
-- Add support for MongoDB 3.4 and WiredTiger metrics. {pull}2999[2999]
-- Add experimental kafka module with partition metricset. {pull}2969[2969]
-- Add raw config option for mysql/status metricset. {pull}3001[3001]
 - Add experimental dbstats metricset to MongoDB module. {pull}3228[3228]
 - Use persistent, direct connections to the configured nodes for MongoDB module. {pull}3228[3228]
-- Kafka module broker matching enhancements. {pull}3129[3129]
-- Add a couchbase module with metricsets for node, cluster and bucket. {pull}3081[3081]
-- Export number of cores for cpu module. {pull}3192[3192]
-- Experimental Prometheus module. {pull}3202[3202]
-- Add system socket module that reports all TCP sockets. {pull}3246[3246]
-- Kafka consumer groups metricset. {pull}3240[3240]
 - Add dynamic configuration reloading for modules. {pull}3281[3281]
 - Add docker health metricset {pull}3357[3357]
 - Add docker image metricset {pull}3467[3467]
 - System module uses new matchers for white-listing processes. {pull}3469[3469]
-- Add CEPH module with health metricset. {pull}3311[3311]
-- Add php_fpm module with pool metricset. {pull}3415[3415]
-- Add cluster_disk and pool_disk metricsets to CEPH module. {pull}3499[3499]
+- Add Beta CEPH module with health metricset. {pull}3311[3311]
+- Add Beta php_fpm module with pool metricset. {pull}3415[3415]
+- The Docker, Kafka, and Prometheus modules are now Beta, instead of experimental. {pull}3525[3525]
+- The HAProxy module is now GA, instead of experimental. {pull}3525[3525]
 
 *Packetbeat*
 
-*Topbeat*
-
-*Filebeat*
-- Add enabled config option to prospectors. {pull}3157[3157]
-- Add target option for decoded_json_field. {pull}3169[3169]
-- Add the `pipeline` config option at the prospector level, for configuring the Ingest Node pipeline ID. {pull}3433[3433]
-- Update regular expressions used for matching file names or lines (multiline, include/exclude functionality) to new matchers improving performance of simple string matches. {pull}3469[3469]
-
 *Winlogbeat*
-
-- Reduced amount of memory allocated while reading event log records. {pull}3113[3113] {pull}3118[3113]
 
 ==== Deprecated
 
 *Affecting all Beats*
+
 - Usage of field _type is deprecated. It should not be used in queries or dashboards. {pull}3409[3409]
+
+*Filebeat*
+
+- The experimental `publish_async` option is now deprecated and is planned to be removed in 6.0. {pull}3525[3525]
+
+*Heartbeat*
 
 *Metricbeat*
 
 *Packetbeat*
 
-*Topbeat*
-- Fix error on importing dashboards due to colons in the Caassandra dashboard. {issue}3140[3140]
-
-*Filebeat*
-
 *Winlogbeat*
 
 ////////////////////////////////////////////////////////////
+
+[[release-notes-5.2.0]]
+=== Beats version 5.2.0
+https://github.com/elastic/beats/compare/v5.1.2...v5.2.0[View commits]
+
+==== Bugfixes
+
+*Affecting all Beats*
+
+- Fix overwriting explicit empty config sections. {issue}2918[2918]
+
+*Filebeat*
+
+- Fix alignment issue were Filebeat compiled with Go 1.7.4 was crashing on 32 bits system. {issue}3273[3273]
+
+*Metricbeat*
+
+- Fix service times-out at startup. {pull}3056[3056]
+- Kafka module case sensitive host name matching. {pull}3193[3193]
+- Fix interface conversion panic in couchbase module {pull}3272[3272]
+
+*Packetbeat*
+
+- Fix issue where some Cassandra visualizations were showing data from all protocols. {issue}3314[3314]
+
+==== Added
+
+*Affecting all Beats*
+
+- Add support for passing list and dictionary settings via -E flag.
+- Support for parsing list and dictionary setting from environment variables.
+- Added new flags to import_dashboards (-cacert, -cert, -key, -insecure). {pull}3139[3139] {pull}3163[3163]
+- The limit for the number of fields is increased via the mapping template. {pull}3275[3275]
+- Updated to Go 1.7.4. {pull}3277[3277]
+- Added a NOTICE file containing the notices and licenses of the dependencies. {pull}3334[3334].
+
+*Heartbeat*
+
+- First release, containing monitors for ICMP, TCP, and HTTP.
+
+*Filebeat*
+
+- Add enabled config option to prospectors. {pull}3157[3157]
+- Add target option for decoded_json_field. {pull}3169[3169]
+
+*Metricbeat*
+
+- Kafka module broker matching enhancements. {pull}3129[3129]
+- Add a couchbase module with metricsets for node, cluster and bucket. {pull}3081[3081]
+- Export number of cores for CPU module. {pull}3192[3192]
+- Experimental Prometheus module. {pull}3202[3202]
+- Add system socket module that reports all TCP sockets. {pull}3246[3246]
+- Kafka consumer groups metricset. {pull}3240[3240]
+
+*Winlogbeat*
+
+- Reduced amount of memory allocated while reading event log records. {pull}3113[3113] {pull}3118[3118]
+
+[[release-notes-5.1.2]]
+=== Beats version 5.1.2
+https://github.com/elastic/beats/compare/v5.1.1...v5.1.2[View commits]
+
+==== Bugfixes
+
+*Filebeat*
+
+- Fix registry migration issue from old states where files were only harvested after second restart. {pull}3322[3322]
+
+*Packetbeat*
+
+- Fix error on importing dashboards due to colons in the Cassandra dashboard. {issue}3140[3140]
+- Fix error on importing dashboards due to the wrong type for the geo_point fields. {pull}3147[3147]
+
+*Winlogbeat*
+
+- Fix for "The array bounds are invalid" error when reading large events. {issue}3076[3076]
 
 [[release-notes-5.1.1]]
 === Beats version 5.1.1

--- a/filebeat/_meta/common.full.p2.yml
+++ b/filebeat/_meta/common.full.p2.yml
@@ -138,7 +138,7 @@ filebeat.prospectors:
   # overwrites the pipeline option from the Elasticsearch output.
   #pipeline:
 
-  # Experimental: If symlinks is enabled, symlinks are opened and harvested. The harvester is openening the
+  # If symlinks is enabled, symlinks are opened and harvested. The harvester is openening the
   # original for harvesting but will report the symlink name as source.
   #symlinks: false
 
@@ -160,7 +160,7 @@ filebeat.prospectors:
   # The backoff value will be multiplied each time with the backoff_factor until max_backoff is reached
   #backoff_factor: 2
 
-  # Experimental: Max number of harvesters that are started in parallel.
+  # Max number of harvesters that are started in parallel.
   # Default is 0 which means unlimited
   #harvester_limit: 0
 

--- a/filebeat/crawler/crawler.go
+++ b/filebeat/crawler/crawler.go
@@ -44,7 +44,7 @@ func (c *Crawler) Start(r *registrar.Registrar, reloaderConfig *common.Config) e
 	}
 
 	if reloaderConfig.Enabled() {
-		logp.Warn("EXPERIMENTAL feature dynamic configuration reloading is enabled.")
+		logp.Warn("BETA feature dynamic configuration reloading is enabled.")
 
 		c.reloader = cfgfile.NewReloader(reloaderConfig)
 		factory := prospector.NewFactory(c.out, r)

--- a/filebeat/docs/reference/configuration/filebeat-options.asciidoc
+++ b/filebeat/docs/reference/configuration/filebeat-options.asciidoc
@@ -415,8 +415,6 @@ NOTE: The pipeline ID can also be configured in the Elasticsearch output, but th
 
 ===== symlinks
 
-experimental[]
-
 The `symlinks` option allows Filebeat to harvest symlinks in addition to regular files. When harvesting symlinks, Filebeat opens and reads the original file even though it reports the path of the symlink.
 
 When you configure a symlink for harvesting, make sure the original path is excluded. If a single prospector is configured to harvest both the symlink and the original file, the prospector will detect the problem and only process the first file it finds. However, if two different prospectors are configured (one to read the symlink and the other the original path), both paths will be harvested, causing Filebeat to send duplicate data and the prospectors to overwrite each other's state.
@@ -457,8 +455,6 @@ lines. The `backoff` value will be multiplied each time with the `backoff_factor
 [[harvester-limit]]
 ===== harvester_limit
 
-experimental[]
-
 The `harvester_limit` option limits the number of harvesters that are started in parallel for one prospector. This directly relates
 to the maximum number of file handlers that are opened. The default for `harvester_limit` is 0, which means there is no limit. This
 configuration is useful if the number of files to be harvested exceeds the open file handler limit of the operating system.
@@ -498,6 +494,7 @@ See <<load-balancing>> for more information about how this setting affects load 
 ===== publish_async
 
 experimental[]
+deprecated[5.3.0]
 
 If enabled, the publisher pipeline in Filebeat operates in async mode preparing
 a new batch of lines while waiting for ACK. This option can improve load-balancing

--- a/filebeat/docs/reference/configuration/reload-configuration.asciidoc
+++ b/filebeat/docs/reference/configuration/reload-configuration.asciidoc
@@ -1,7 +1,7 @@
 [[filebeat-configuration-reloading]]
 === Reload Configuration
 
-experimental[]
+beta[]
 
 Reload configuration allows to dynamically reload prospector configuration files. A glob can be defined which should be watched
  for prospector configuration changes. New prospectors will be started / stopped accordingly. This is especially useful in

--- a/filebeat/filebeat.full.yml
+++ b/filebeat/filebeat.full.yml
@@ -254,7 +254,7 @@ filebeat.prospectors:
   # overwrites the pipeline option from the Elasticsearch output.
   #pipeline:
 
-  # Experimental: If symlinks is enabled, symlinks are opened and harvested. The harvester is openening the
+  # If symlinks is enabled, symlinks are opened and harvested. The harvester is openening the
   # original for harvesting but will report the symlink name as source.
   #symlinks: false
 
@@ -276,7 +276,7 @@ filebeat.prospectors:
   # The backoff value will be multiplied each time with the backoff_factor until max_backoff is reached
   #backoff_factor: 2
 
-  # Experimental: Max number of harvesters that are started in parallel.
+  # Max number of harvesters that are started in parallel.
   # Default is 0 which means unlimited
   #harvester_limit: 0
 

--- a/filebeat/publisher/publisher.go
+++ b/filebeat/publisher/publisher.go
@@ -34,7 +34,7 @@ func New(
 	pub publisher.Publisher,
 ) LogPublisher {
 	if async {
-		logp.Warn("Using publish_async is experimental!")
+		logp.Warn("publish_async is experimental and will be removed in a future version!")
 		return newAsyncLogPublisher(in, out, pub)
 	}
 	return newSyncLogPublisher(in, out, pub)

--- a/libbeat/docs/shared-env-vars.asciidoc
+++ b/libbeat/docs/shared-env-vars.asciidoc
@@ -12,8 +12,6 @@
 [[using-environ-vars]]
 == Using Environment Variables in the Configuration
 
-experimental[]
-
 You can use environment variable references in the +{beatname_lc}.yml+ file to
 set values that need to be configurable during deployment. To do this, use:
 

--- a/metricbeat/docs/fields.asciidoc
+++ b/metricbeat/docs/fields.asciidoc
@@ -416,7 +416,8 @@ Contains user configurable fields.
 [[exported-fields-ceph]]
 == ceph Fields
 
-experimental[] ceph Module
+beta[]
+ceph Module
 
 
 
@@ -780,7 +781,7 @@ The document type. Always set to "metricsets".
 [[exported-fields-couchbase]]
 == couchbase Fields
 
-experimental[]
+beta[]
 couchbase Module
 
 
@@ -795,7 +796,7 @@ couchbase Module
 [float]
 == bucket Fields
 
-experimental[]
+beta[]
 Couchbase bucket metrics
 
 
@@ -893,7 +894,7 @@ Number of items associated with the bucket
 [float]
 == cluster Fields
 
-experimental[]
+beta[]
 Couchbase Cluster metrics
 
 
@@ -1045,7 +1046,7 @@ Ram used by the data in the cluster (bytes)
 [float]
 == node Fields
 
-experimental[]
+beta[]
 Couchbase node metrics
 
 
@@ -1243,7 +1244,7 @@ Number of items/documents that are replicas
 [[exported-fields-docker]]
 == Docker Fields
 
-experimental[]
+beta[]
 Docker stats collected from Docker.
 
 
@@ -1559,7 +1560,7 @@ Total size of the all cached images associated to the current image.
 [float]
 == info Fields
 
-experimental[]
+beta[]
 Info metrics based on https://docs.docker.com/engine/reference/api/docker_remote_api_v1.24/#/display-system-wide-information.
 
 
@@ -1804,7 +1805,6 @@ Total number of outgoing packets.
 [[exported-fields-haproxy]]
 == HAProxy Fields
 
-experimental[]
 HAProxy Module
 
 
@@ -2779,7 +2779,7 @@ The average queue time in ms over the last 1024 requests.
 == kafka Fields
 
 kafka Module
-experimental[]
+beta[]
 
 
 
@@ -4190,8 +4190,8 @@ The current number of idle client connections waiting for a request.
 [[exported-fields-php_fpm]]
 == php_fpm Fields
 
+beta[]
 PHP-FPM server status metrics collected from PHP-FPM.
-experimental[]
 
 
 
@@ -4675,8 +4675,8 @@ Time at which these statistics were last reset.
 [[exported-fields-prometheus]]
 == Prometheus Fields
 
+beta[]
 Prometheus Module
-experimental[]
 
 
 

--- a/metricbeat/docs/modules/ceph.asciidoc
+++ b/metricbeat/docs/modules/ceph.asciidoc
@@ -5,6 +5,8 @@ This file is generated! See scripts/docs_collector.py
 [[metricbeat-module-ceph]]
 == ceph Module
 
+beta[]
+
 This is the ceph Module. Metrics are collected submitting HTTP GET requests to ceph-rest-api.
 Reference: http://docs.ceph.com/docs/master/man/8/ceph-rest-api/
 

--- a/metricbeat/docs/modules/couchbase.asciidoc
+++ b/metricbeat/docs/modules/couchbase.asciidoc
@@ -5,7 +5,7 @@ This file is generated! See scripts/docs_collector.py
 [[metricbeat-module-couchbase]]
 == couchbase Module
 
-experimental[]
+beta[]
 
 This is the couchbase Module.
 

--- a/metricbeat/docs/modules/docker.asciidoc
+++ b/metricbeat/docs/modules/docker.asciidoc
@@ -5,7 +5,7 @@ This file is generated! See scripts/docs_collector.py
 [[metricbeat-module-docker]]
 == Docker Module
 
-experimental[]
+beta[]
 
 This module fetches metrics from https://www.docker.com/[Docker] containers.
 

--- a/metricbeat/docs/modules/kafka.asciidoc
+++ b/metricbeat/docs/modules/kafka.asciidoc
@@ -5,7 +5,7 @@ This file is generated! See scripts/docs_collector.py
 [[metricbeat-module-kafka]]
 == kafka Module
 
-experimental[]
+beta[]
 
 This is the kafka Module.
 

--- a/metricbeat/docs/modules/php_fpm.asciidoc
+++ b/metricbeat/docs/modules/php_fpm.asciidoc
@@ -5,6 +5,8 @@ This file is generated! See scripts/docs_collector.py
 [[metricbeat-module-php_fpm]]
 == PHP-FPM Module
 
+beta[]
+
 This module periodically fetches metrics from https://php-fpm.org[PHP-FPM]
 servers.
 

--- a/metricbeat/docs/modules/prometheus.asciidoc
+++ b/metricbeat/docs/modules/prometheus.asciidoc
@@ -5,6 +5,8 @@ This file is generated! See scripts/docs_collector.py
 [[metricbeat-module-prometheus]]
 == prometheus Module
 
+beta[]
+
 This is the prometheus Module.
 
 

--- a/metricbeat/module/ceph/_meta/docs.asciidoc
+++ b/metricbeat/module/ceph/_meta/docs.asciidoc
@@ -1,4 +1,6 @@
 == ceph Module
 
+beta[]
+
 This is the ceph Module. Metrics are collected submitting HTTP GET requests to ceph-rest-api.
 Reference: http://docs.ceph.com/docs/master/man/8/ceph-rest-api/

--- a/metricbeat/module/ceph/_meta/fields.yml
+++ b/metricbeat/module/ceph/_meta/fields.yml
@@ -1,7 +1,8 @@
 - key: ceph
   title: "ceph"
   description: >
-    experimental[]
+    beta[]
+
     ceph Module
   short_config: false
   fields:

--- a/metricbeat/module/ceph/cluster_health/cluster_health.go
+++ b/metricbeat/module/ceph/cluster_health/cluster_health.go
@@ -32,7 +32,7 @@ type MetricSet struct {
 }
 
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Warn("EXPERIMENTAL: The ceph cluster_health metricset is experimental")
+	logp.Warn("BETA: The ceph cluster_health metricset is beta")
 
 	http := helper.NewHTTP(base)
 	http.SetHeader("Accept", "application/json")

--- a/metricbeat/module/ceph/monitor_health/monitor_health.go
+++ b/metricbeat/module/ceph/monitor_health/monitor_health.go
@@ -34,7 +34,7 @@ type MetricSet struct {
 }
 
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Warn("EXPERIMENTAL: The ceph monitor_health metricset is experimental")
+	logp.Warn("BETA: The ceph monitor_health metricset is beta")
 
 	http := helper.NewHTTP(base)
 	http.SetHeader("Accept", "application/json")

--- a/metricbeat/module/couchbase/_meta/docs.asciidoc
+++ b/metricbeat/module/couchbase/_meta/docs.asciidoc
@@ -1,6 +1,6 @@
 == couchbase Module
 
-experimental[]
+beta[]
 
 This is the couchbase Module.
 

--- a/metricbeat/module/couchbase/_meta/fields.yml
+++ b/metricbeat/module/couchbase/_meta/fields.yml
@@ -1,7 +1,7 @@
 - key: couchbase
   title: "couchbase"
   description: >
-    experimental[]
+    beta[]
 
     couchbase Module
   short_config: false

--- a/metricbeat/module/couchbase/bucket/_meta/fields.yml
+++ b/metricbeat/module/couchbase/bucket/_meta/fields.yml
@@ -1,7 +1,7 @@
 - name: bucket
   type: group
   description: >
-    experimental[]
+    beta[]
 
     Couchbase bucket metrics
   fields:

--- a/metricbeat/module/couchbase/bucket/bucket.go
+++ b/metricbeat/module/couchbase/bucket/bucket.go
@@ -36,7 +36,7 @@ type MetricSet struct {
 
 // New create a new instance of the MetricSet
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Warn("EXPERIMENTAL: The couchbase bucket metricset is experimental")
+	logp.Warn("BETA: The couchbase bucket metricset is beta")
 
 	return &MetricSet{
 		BaseMetricSet: base,

--- a/metricbeat/module/couchbase/cluster/_meta/fields.yml
+++ b/metricbeat/module/couchbase/cluster/_meta/fields.yml
@@ -1,7 +1,7 @@
 - name: cluster
   type: group
   description: >
-    experimental[]
+    beta[]
 
     Couchbase Cluster metrics
   fields:

--- a/metricbeat/module/couchbase/cluster/cluster.go
+++ b/metricbeat/module/couchbase/cluster/cluster.go
@@ -36,7 +36,7 @@ type MetricSet struct {
 
 // New create a new instance of the MetricSet
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Warn("EXPERIMENTAL: The couchbase cluster metricset is experimental")
+	logp.Warn("BETA: The couchbase cluster metricset is beta")
 
 	return &MetricSet{
 		BaseMetricSet: base,

--- a/metricbeat/module/couchbase/node/_meta/fields.yml
+++ b/metricbeat/module/couchbase/node/_meta/fields.yml
@@ -1,7 +1,7 @@
 - name: node
   type: group
   description: >
-    experimental[]
+    beta[]
 
     Couchbase node metrics
   fields:

--- a/metricbeat/module/couchbase/node/node.go
+++ b/metricbeat/module/couchbase/node/node.go
@@ -36,7 +36,7 @@ type MetricSet struct {
 
 // New create a new instance of the MetricSet
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Warn("EXPERIMENTAL: The couchbase node metricset is experimental")
+	logp.Warn("BETA: The couchbase node metricset is beta")
 
 	return &MetricSet{
 		BaseMetricSet: base,

--- a/metricbeat/module/docker/_meta/docs.asciidoc
+++ b/metricbeat/module/docker/_meta/docs.asciidoc
@@ -1,6 +1,6 @@
 == Docker Module
 
-experimental[]
+beta[]
 
 This module fetches metrics from https://www.docker.com/[Docker] containers.
 

--- a/metricbeat/module/docker/_meta/fields.yml
+++ b/metricbeat/module/docker/_meta/fields.yml
@@ -1,7 +1,7 @@
 - key: docker
   title: "Docker"
   description: >
-    experimental[]
+    beta[]
 
     Docker stats collected from Docker.
   short_config: false

--- a/metricbeat/module/docker/container/container.go
+++ b/metricbeat/module/docker/container/container.go
@@ -22,7 +22,7 @@ type MetricSet struct {
 
 // New creates a new instance of the docker container MetricSet.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Warn("EXPERIMENTAL: The docker container metricset is experimental")
+	logp.Warn("BETA: The docker container metricset is beta")
 
 	config := docker.Config{}
 	if err := base.Module().UnpackConfig(&config); err != nil {

--- a/metricbeat/module/docker/cpu/cpu.go
+++ b/metricbeat/module/docker/cpu/cpu.go
@@ -23,7 +23,7 @@ type MetricSet struct {
 
 // New creates a new instance of the docker cpu MetricSet.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Warn("EXPERIMENTAL: The docker cpu metricset is experimental")
+	logp.Warn("BETA: The docker cpu metricset is beta")
 
 	config := docker.Config{}
 	if err := base.Module().UnpackConfig(&config); err != nil {

--- a/metricbeat/module/docker/diskio/diskio.go
+++ b/metricbeat/module/docker/diskio/diskio.go
@@ -23,7 +23,7 @@ type MetricSet struct {
 
 // New create a new instance of the docker diskio MetricSet.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Warn("EXPERIMENTAL: The docker diskio metricset is experimental")
+	logp.Warn("BETA: The docker diskio metricset is beta")
 
 	config := docker.Config{}
 	if err := base.Module().UnpackConfig(&config); err != nil {

--- a/metricbeat/module/docker/healthcheck/healthcheck.go
+++ b/metricbeat/module/docker/healthcheck/healthcheck.go
@@ -22,7 +22,7 @@ type MetricSet struct {
 
 // New creates a new instance of the docker healthcheck MetricSet.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Warn("EXPERIMENTAL: The docker healthcheck metricset is experimental")
+	logp.Warn("BETA: The docker healthcheck metricset is beta")
 
 	config := docker.Config{}
 	if err := base.Module().UnpackConfig(&config); err != nil {

--- a/metricbeat/module/docker/image/image.go
+++ b/metricbeat/module/docker/image/image.go
@@ -31,7 +31,7 @@ type MetricSet struct {
 // configuration entries if needed.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 
-	logp.Warn("EXPERIMENTAL: The docker info metricset is experimental")
+	logp.Warn("BETA: The docker info metricset is beta")
 
 	config := docker.Config{}
 	if err := base.Module().UnpackConfig(&config); err != nil {

--- a/metricbeat/module/docker/info/_meta/fields.yml
+++ b/metricbeat/module/docker/info/_meta/fields.yml
@@ -1,7 +1,7 @@
 - name: info
   type: group
   description: >
-    experimental[]
+    beta[]
 
     Info metrics based on https://docs.docker.com/engine/reference/api/docker_remote_api_v1.24/#/display-system-wide-information.
   fields:

--- a/metricbeat/module/docker/info/info.go
+++ b/metricbeat/module/docker/info/info.go
@@ -22,7 +22,7 @@ type MetricSet struct {
 
 // New create a new instance of the docker info MetricSet.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Warn("EXPERIMENTAL: The docker info metricset is experimental")
+	logp.Warn("BETA: The docker info metricset is beta")
 
 	config := docker.Config{}
 	if err := base.Module().UnpackConfig(&config); err != nil {

--- a/metricbeat/module/docker/memory/memory.go
+++ b/metricbeat/module/docker/memory/memory.go
@@ -23,7 +23,7 @@ type MetricSet struct {
 
 // New creates a new instance of the docker memory MetricSet.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Warn("EXPERIMENTAL: The docker memory metricset is experimental")
+	logp.Warn("BETA: The docker memory metricset is beta")
 
 	config := docker.Config{}
 	if err := base.Module().UnpackConfig(&config); err != nil {

--- a/metricbeat/module/docker/network/network.go
+++ b/metricbeat/module/docker/network/network.go
@@ -23,7 +23,7 @@ type MetricSet struct {
 
 // New creates a new instance of the docker network MetricSet.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Warn("EXPERIMENTAL: The docker network metricset is experimental")
+	logp.Warn("BETA: The docker network metricset is beta")
 
 	config := docker.Config{}
 	if err := base.Module().UnpackConfig(&config); err != nil {

--- a/metricbeat/module/haproxy/_meta/fields.yml
+++ b/metricbeat/module/haproxy/_meta/fields.yml
@@ -1,8 +1,6 @@
 - key: haproxy
   title: "HAProxy"
   description: >
-    experimental[]
-
     HAProxy Module
   short_config: false
   fields:

--- a/metricbeat/module/haproxy/info/info.go
+++ b/metricbeat/module/haproxy/info/info.go
@@ -31,8 +31,6 @@ type MetricSet struct {
 
 // New creates a haproxy info MetricSet.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Warn("EXPERIMENTAL: The %v %v metricset is experimental", base.Module().Name(), base.Name())
-
 	return &MetricSet{BaseMetricSet: base}, nil
 }
 

--- a/metricbeat/module/haproxy/stat/stat.go
+++ b/metricbeat/module/haproxy/stat/stat.go
@@ -31,8 +31,6 @@ type MetricSet struct {
 
 // New creates a new haproxy stat MetricSet.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Warn("EXPERIMENTAL: The %v %v metricset is experimental", base.Module().Name(), base.Name())
-
 	return &MetricSet{BaseMetricSet: base}, nil
 }
 

--- a/metricbeat/module/kafka/_meta/docs.asciidoc
+++ b/metricbeat/module/kafka/_meta/docs.asciidoc
@@ -1,6 +1,6 @@
 == kafka Module
 
-experimental[]
+beta[]
 
 This is the kafka Module.
 

--- a/metricbeat/module/kafka/_meta/fields.yml
+++ b/metricbeat/module/kafka/_meta/fields.yml
@@ -3,7 +3,7 @@
   description: >
     kafka Module
 
-    experimental[]
+    beta[]
   short_config: false
   fields:
     - name: kafka

--- a/metricbeat/module/kafka/consumergroup/consumergroup.go
+++ b/metricbeat/module/kafka/consumergroup/consumergroup.go
@@ -36,7 +36,7 @@ var debugf = logp.MakeDebug("kafka")
 
 // New creates a new instance of the MetricSet.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Warn("EXPERIMENTAL: The kafka consumergroup metricset is experimental")
+	logp.Warn("BETA: The kafka consumergroup metricset is beta")
 
 	config := defaultConfig
 	if err := base.Module().UnpackConfig(&config); err != nil {

--- a/metricbeat/module/kafka/partition/partition.go
+++ b/metricbeat/module/kafka/partition/partition.go
@@ -37,7 +37,7 @@ var debugf = logp.MakeDebug("kafka")
 
 // New creates a new instance of the partition MetricSet.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Warn("EXPERIMENTAL: The kafka partition metricset is experimental")
+	logp.Warn("BETA: The kafka partition metricset is beta")
 
 	config := defaultConfig
 	if err := base.Module().UnpackConfig(&config); err != nil {

--- a/metricbeat/module/php_fpm/_meta/docs.asciidoc
+++ b/metricbeat/module/php_fpm/_meta/docs.asciidoc
@@ -1,5 +1,7 @@
 == PHP-FPM Module
 
+beta[]
+
 This module periodically fetches metrics from https://php-fpm.org[PHP-FPM]
 servers.
 

--- a/metricbeat/module/php_fpm/_meta/fields.yml
+++ b/metricbeat/module/php_fpm/_meta/fields.yml
@@ -1,9 +1,9 @@
 - key: php_fpm
   title: "php_fpm"
   description: >
-    PHP-FPM server status metrics collected from PHP-FPM.
+    beta[]
 
-    experimental[]
+    PHP-FPM server status metrics collected from PHP-FPM.
   short_config: false
   fields:
     - name: php_fpm

--- a/metricbeat/module/php_fpm/pool/pool.go
+++ b/metricbeat/module/php_fpm/pool/pool.go
@@ -39,7 +39,7 @@ type MetricSet struct {
 
 // New create a new instance of the MetricSet
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Warn("EXPERIMENTAL: The php-fpm pool metricset is experimental")
+	logp.Warn("BETA: The php-fpm pool metricset is beta")
 	return &MetricSet{
 		base,
 		helper.NewHTTP(base),

--- a/metricbeat/module/prometheus/_meta/docs.asciidoc
+++ b/metricbeat/module/prometheus/_meta/docs.asciidoc
@@ -1,4 +1,6 @@
 == prometheus Module
 
+beta[]
+
 This is the prometheus Module.
 

--- a/metricbeat/module/prometheus/_meta/fields.yml
+++ b/metricbeat/module/prometheus/_meta/fields.yml
@@ -1,9 +1,9 @@
 - key: prometheus
   title: "Prometheus"
   description: >
-    Prometheus Module
+    beta[]
 
-    experimental[]
+    Prometheus Module
   short_config: false
   fields:
     - name: prometheus

--- a/metricbeat/module/prometheus/collector/collector.go
+++ b/metricbeat/module/prometheus/collector/collector.go
@@ -34,7 +34,7 @@ type MetricSet struct {
 }
 
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Warn("EXPERIMENTAL: The prometheus collector metricset is experimental")
+	logp.Warn("BETA: The prometheus collector metricset is beta")
 
 	config := struct {
 		Namespace string `config:"namespace" validate:"required"`

--- a/metricbeat/module/prometheus/stats/stats.go
+++ b/metricbeat/module/prometheus/stats/stats.go
@@ -34,7 +34,7 @@ type MetricSet struct {
 }
 
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Warn("EXPERIMENTAL: The prometheus stats metricset is experimental")
+	logp.Warn("BETA: The prometheus stats metricset is beta")
 
 	return &MetricSet{
 		BaseMetricSet: base,

--- a/metricbeat/tests/system/test_docker.py
+++ b/metricbeat/tests/system/test_docker.py
@@ -24,7 +24,7 @@ class Test(metricbeat.BaseTest):
 
         # Ensure no errors or warnings exist in the log.
         log = self.get_log()
-        self.assertNotRegexpMatches(log.replace("WARN EXPERIMENTAL", ""), "ERR|WARN")
+        self.assertNotRegexpMatches(log.replace("WARN BETA", ""), "ERR|WARN")
 
         output = self.read_output_json()
         evt = output[0]
@@ -50,7 +50,7 @@ class Test(metricbeat.BaseTest):
 
         # Ensure no errors or warnings exist in the log.
         log = self.get_log()
-        self.assertNotRegexpMatches(log.replace("WARN EXPERIMENTAL", ""), "ERR|WARN")
+        self.assertNotRegexpMatches(log.replace("WARN BETA", ""), "ERR|WARN")
 
         output = self.read_output_json()
         evt = output[0]
@@ -80,7 +80,7 @@ class Test(metricbeat.BaseTest):
 
         # Ensure no errors or warnings exist in the log.
         log = self.get_log()
-        self.assertNotRegexpMatches(log.replace("WARN EXPERIMENTAL", ""), "ERR|WARN")
+        self.assertNotRegexpMatches(log.replace("WARN BETA", ""), "ERR|WARN")
 
         output = self.read_output_json()
         evt = output[0]
@@ -107,7 +107,7 @@ class Test(metricbeat.BaseTest):
 
         # Ensure no errors or warnings exist in the log.
         log = self.get_log()
-        self.assertNotRegexpMatches(log.replace("WARN EXPERIMENTAL", ""), "ERR|WARN")
+        self.assertNotRegexpMatches(log.replace("WARN BETA", ""), "ERR|WARN")
 
         output = self.read_output_json()
         evt = output[0]
@@ -132,7 +132,7 @@ class Test(metricbeat.BaseTest):
 
         # Ensure no errors or warnings exist in the log.
         log = self.get_log()
-        self.assertNotRegexpMatches(log.replace("WARN EXPERIMENTAL", ""), "ERR|WARN")
+        self.assertNotRegexpMatches(log.replace("WARN BETA", ""), "ERR|WARN")
 
         output = self.read_output_json()
         evt = output[0]
@@ -158,7 +158,7 @@ class Test(metricbeat.BaseTest):
 
         # Ensure no errors or warnings exist in the log.
         log = self.get_log()
-        self.assertNotRegexpMatches(log.replace("WARN EXPERIMENTAL", ""), "ERR|WARN")
+        self.assertNotRegexpMatches(log.replace("WARN BETA", ""), "ERR|WARN")
 
         output = self.read_output_json()
         evt = output[0]
@@ -184,7 +184,7 @@ class Test(metricbeat.BaseTest):
 
         # Ensure no errors or warnings exist in the log.
         log = self.get_log()
-        self.assertNotRegexpMatches(log.replace("WARN EXPERIMENTAL", ""), "ERR|WARN")
+        self.assertNotRegexpMatches(log.replace("WARN BETA", ""), "ERR|WARN")
 
         output = self.read_output_json()
         evt = output[0]
@@ -210,7 +210,7 @@ class Test(metricbeat.BaseTest):
 
         # Ensure no errors or warnings exist in the log.
         log = self.get_log()
-        self.assertNotRegexpMatches(log.replace("WARN EXPERIMENTAL", ""), "ERR|WARN")
+        self.assertNotRegexpMatches(log.replace("WARN BETA", ""), "ERR|WARN")
 
         output = self.read_output_json()
         evt = output[0]

--- a/metricbeat/tests/system/test_haproxy.py
+++ b/metricbeat/tests/system/test_haproxy.py
@@ -25,7 +25,7 @@ class Test(metricbeat.BaseTest):
 
         # Ensure no errors or warnings exist in the log.
         log = self.get_log()
-        self.assertNotRegexpMatches(log.replace("WARN EXPERIMENTAL", ""), "ERR|WARN")
+        self.assertNotRegexpMatches(log, "ERR|WARN")
 
         output = self.read_output_json()
         self.assertEqual(len(output), 1)
@@ -52,7 +52,7 @@ class Test(metricbeat.BaseTest):
 
         # Ensure no errors or warnings exist in the log.
         log = self.get_log()
-        self.assertNotRegexpMatches(log.replace("WARN EXPERIMENTAL", ""), "ERR|WARN")
+        self.assertNotRegexpMatches(log, "ERR|WARN")
 
         output = self.read_output_json()
         self.assertGreater(len(output), 0)

--- a/metricbeat/tests/system/test_phpfpm.py
+++ b/metricbeat/tests/system/test_phpfpm.py
@@ -1,7 +1,6 @@
 import os
 import metricbeat
 import unittest
-from nose.plugins.attrib import attr
 
 PHPFPM_FIELDS = metricbeat.COMMON_FIELDS + ["php_fpm"]
 
@@ -25,7 +24,7 @@ class Test(metricbeat.BaseTest):
 
         # Ensure no errors or warnings exist in the log.
         log = self.get_log()
-        self.assertNotRegexpMatches(log.replace("WARN EXPERIMENTAL", ""), "ERR|WARN")
+        self.assertNotRegexpMatches(log.replace("WARN BETA", ""), "ERR|WARN")
 
         output = self.read_output_json()
         self.assertEqual(len(output), 1)

--- a/metricbeat/tests/system/test_prometheus.py
+++ b/metricbeat/tests/system/test_prometheus.py
@@ -1,7 +1,6 @@
 import os
 import metricbeat
 import unittest
-from nose.plugins.attrib import attr
 
 PROMETHEUS_FIELDS = metricbeat.COMMON_FIELDS + ["prometheus"]
 
@@ -25,7 +24,7 @@ class Test(metricbeat.BaseTest):
 
         # Ensure no errors or warnings exist in the log.
         log = self.get_log()
-        self.assertNotRegexpMatches(log.replace("WARN EXPERIMENTAL", ""), "ERR|WARN")
+        self.assertNotRegexpMatches(log.replace("WARN BETA", ""), "ERR|WARN")
 
         output = self.read_output_json()
         self.assertEqual(len(output), 1)


### PR DESCRIPTION
Changes:

* [x] Configuration reloading -> make beta[]
* [x] Filebeat symlinks -> GA
* [x] Filebeat harvester_limit -> GA
* [x] Filebeat publish_async -> experimental & deprecated
* [x] Using environment variables in the Configuration -> GA
* [x] Metricbeat ceph -> beta[]
* [x] Metricbeat couchbase -> beta[]
* [x] Metricbeat docker -> beta[]
* [x] Metricbeat haproxy -> GA
* [x] Metricbeat kafka -> beta[]
* [x] Metricbeat php_fpm -> beta[]
* [x] Metricbeat prometheus -> beta[]
* [x] Metricbeat cgroup -> GA <-- in a different PR (https://github.com/elastic/beats/pull/3519)
