### PR TITLE
Disable date detection in index templates

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -69,6 +69,7 @@ https://github.com/elastic/beats/compare/v5.1.1...master[Check the HEAD diff]
 - Add the option to pass custom HTTP headers to the Elasticsearch output. {pull}3400[3400]
 - Unify `regexp` and `contains` conditionals, for both to support array of strings and convert numbers to strings if required. {pull}3469[3469]
 - Add the option to load the sample dashboards during the Beat startup phase. {pull}3506[3506]
+- Disabled date detection in Elasticsearch index templates. Date fields must be explicitly defined in index templates. {pull}3528[3528]
 
 *Metricbeat*
 

--- a/filebeat/filebeat.template-es2x.json
+++ b/filebeat/filebeat.template-es2x.json
@@ -9,6 +9,7 @@
       "_meta": {
         "version": "6.0.0-alpha1"
       },
+      "date_detection": false,
       "dynamic_templates": [
         {
           "strings_as_keyword": {

--- a/filebeat/filebeat.template.json
+++ b/filebeat/filebeat.template.json
@@ -4,6 +4,7 @@
       "_meta": {
         "version": "6.0.0-alpha1"
       },
+      "date_detection": false,
       "dynamic_templates": [
         {
           "strings_as_keyword": {

--- a/heartbeat/heartbeat.template-es2x.json
+++ b/heartbeat/heartbeat.template-es2x.json
@@ -9,6 +9,7 @@
       "_meta": {
         "version": "6.0.0-alpha1"
       },
+      "date_detection": false,
       "dynamic_templates": [
         {
           "strings_as_keyword": {

--- a/heartbeat/heartbeat.template.json
+++ b/heartbeat/heartbeat.template.json
@@ -4,6 +4,7 @@
       "_meta": {
         "version": "6.0.0-alpha1"
       },
+      "date_detection": false,
       "dynamic_templates": [
         {
           "strings_as_keyword": {

--- a/libbeat/scripts/generate_template.py
+++ b/libbeat/scripts/generate_template.py
@@ -50,6 +50,7 @@ def fields_to_es_template(args, input, output, index, version):
         },
         "mappings": {
             "_default_": {
+                "date_detection": False,
                 "properties": {},
                 "_meta": {
                     "version": version,

--- a/metricbeat/metricbeat.template-es2x.json
+++ b/metricbeat/metricbeat.template-es2x.json
@@ -9,6 +9,7 @@
       "_meta": {
         "version": "6.0.0-alpha1"
       },
+      "date_detection": false,
       "dynamic_templates": [
         {
           "strings_as_keyword": {

--- a/metricbeat/metricbeat.template.json
+++ b/metricbeat/metricbeat.template.json
@@ -4,6 +4,7 @@
       "_meta": {
         "version": "6.0.0-alpha1"
       },
+      "date_detection": false,
       "dynamic_templates": [
         {
           "strings_as_keyword": {

--- a/packetbeat/packetbeat.template-es2x.json
+++ b/packetbeat/packetbeat.template-es2x.json
@@ -9,6 +9,7 @@
       "_meta": {
         "version": "6.0.0-alpha1"
       },
+      "date_detection": false,
       "dynamic_templates": [
         {
           "strings_as_keyword": {

--- a/packetbeat/packetbeat.template.json
+++ b/packetbeat/packetbeat.template.json
@@ -4,6 +4,7 @@
       "_meta": {
         "version": "6.0.0-alpha1"
       },
+      "date_detection": false,
       "dynamic_templates": [
         {
           "strings_as_keyword": {

--- a/winlogbeat/winlogbeat.template-es2x.json
+++ b/winlogbeat/winlogbeat.template-es2x.json
@@ -9,6 +9,7 @@
       "_meta": {
         "version": "6.0.0-alpha1"
       },
+      "date_detection": false,
       "dynamic_templates": [
         {
           "strings_as_keyword": {

--- a/winlogbeat/winlogbeat.template.json
+++ b/winlogbeat/winlogbeat.template.json
@@ -4,6 +4,7 @@
       "_meta": {
         "version": "6.0.0-alpha1"
       },
+      "date_detection": false,
       "dynamic_templates": [
         {
           "strings_as_keyword": {


### PR DESCRIPTION
We use dynamic fields in some places and date detection is enabled by default so if a Beat sends a dynamic string field that looks like a date, the field mapping will be date. This means that all follow on data using the same field name must also be a date or else a field mapping exception will occur. Disabling date detection will make the generated index mappings more predicable.

Closes #3389