### PR TITLE
[WIP] Restructure Harvester and Prospector Shutdown

### DIFF
--- a/filebeat/beater/filebeat.go
+++ b/filebeat/beater/filebeat.go
@@ -133,7 +133,7 @@ func (fb *Filebeat) Run(b *beat.Beat) error {
 		return err
 	}
 
-	crawler, err := crawler.New(newSpoolerOutlet(fb.done, spooler, wgEvents), config.Prospectors, *once)
+	crawler, err := crawler.New(newSpoolerOutlet(fb.done, spooler, wgEvents), config.Prospectors, fb.done, *once)
 	if err != nil {
 		logp.Err("Could not init crawler: %v", err)
 		return err

--- a/filebeat/harvester/harvester.go
+++ b/filebeat/harvester/harvester.go
@@ -16,6 +16,8 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/satori/go.uuid"
+
 	"github.com/elastic/beats/filebeat/config"
 	"github.com/elastic/beats/filebeat/harvester/encoding"
 	"github.com/elastic/beats/filebeat/harvester/source"
@@ -40,24 +42,28 @@ type Harvester struct {
 	fileReader      *LogFile
 	encodingFactory encoding.EncodingFactory
 	encoding        encoding.Encoding
-	prospectorDone  chan struct{}
 	once            sync.Once
 	done            chan struct{}
+	wg              sync.WaitGroup
+	ID              uuid.UUID
+	beatDone        chan struct{}
 }
 
 func NewHarvester(
 	cfg *common.Config,
 	state file.State,
 	prospectorChan chan *input.Event,
-	done chan struct{},
+	beatDone chan struct{},
 ) (*Harvester, error) {
 
 	h := &Harvester{
 		config:         defaultConfig,
 		state:          state,
 		prospectorChan: prospectorChan,
-		prospectorDone: done,
 		done:           make(chan struct{}),
+		ID:             uuid.NewV4(),
+		wg:             sync.WaitGroup{},
+		beatDone:       beatDone,
 	}
 
 	if err := cfg.Unpack(&h.config); err != nil {

--- a/filebeat/harvester/harvester.go
+++ b/filebeat/harvester/harvester.go
@@ -44,9 +44,10 @@ type Harvester struct {
 	encoding        encoding.Encoding
 	once            sync.Once
 	done            chan struct{}
-	wg              sync.WaitGroup
+	wg              *sync.WaitGroup
 	ID              uuid.UUID
 	beatDone        chan struct{}
+	eventCounter    *sync.WaitGroup
 }
 
 func NewHarvester(
@@ -54,6 +55,7 @@ func NewHarvester(
 	state file.State,
 	prospectorChan chan *input.Event,
 	beatDone chan struct{},
+	eventCounter *sync.WaitGroup,
 ) (*Harvester, error) {
 
 	h := &Harvester{
@@ -62,8 +64,9 @@ func NewHarvester(
 		prospectorChan: prospectorChan,
 		done:           make(chan struct{}),
 		ID:             uuid.NewV4(),
-		wg:             sync.WaitGroup{},
+		wg:             &sync.WaitGroup{},
 		beatDone:       beatDone,
+		eventCounter:   eventCounter,
 	}
 
 	if err := cfg.Unpack(&h.config); err != nil {

--- a/filebeat/harvester/log.go
+++ b/filebeat/harvester/log.go
@@ -177,9 +177,11 @@ func (h *Harvester) Stop() {
 // sendEvent sends event to the spooler channel
 // Return false if event was not sent
 func (h *Harvester) sendEvent(event *input.Event) bool {
+	h.eventCounter.Add(1)
 
 	select {
 	case <-h.done:
+		h.eventCounter.Done()
 		return false
 	case h.prospectorChan <- event: // ship the new event downstream
 		return true
@@ -195,8 +197,11 @@ func (h *Harvester) sendStateUpdate() {
 	logp.Debug("harvester", "Update state: %s, offset: %v", h.state.Source, h.state.Offset)
 	event := input.NewEvent(h.state)
 
+	h.eventCounter.Add(1)
+
 	select {
 	case <-h.beatDone:
+		h.eventCounter.Done()
 	case h.prospectorChan <- event: // ship the new event downstream
 	}
 }

--- a/filebeat/prospector/factory.go
+++ b/filebeat/prospector/factory.go
@@ -10,18 +10,20 @@ import (
 type Factory struct {
 	outlet    Outlet
 	registrar *registrar.Registrar
+	beatDone  chan struct{}
 }
 
-func NewFactory(outlet Outlet, registrar *registrar.Registrar) *Factory {
+func NewFactory(outlet Outlet, registrar *registrar.Registrar, beatDone chan struct{}) *Factory {
 	return &Factory{
 		outlet:    outlet,
 		registrar: registrar,
+		beatDone:  beatDone,
 	}
 }
 
 func (r *Factory) Create(c *common.Config) (cfgfile.Runner, error) {
 
-	p, err := NewProspector(c, r.outlet)
+	p, err := NewProspector(c, r.outlet, r.beatDone)
 	if err != nil {
 		logp.Err("Error creating prospector: %s", err)
 		return nil, err

--- a/filebeat/prospector/prospector.go
+++ b/filebeat/prospector/prospector.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/mitchellh/hashstructure"
+	"github.com/satori/go.uuid"
 
 	cfg "github.com/elastic/beats/filebeat/config"
 	"github.com/elastic/beats/filebeat/harvester"
@@ -30,12 +31,17 @@ type Prospector struct {
 	prospectorer     Prospectorer
 	outlet           Outlet
 	harvesterChan    chan *input.Event
-	done             chan struct{}
+	channelDone      chan struct{}
+	runDone          chan struct{}
+	runWg            sync.WaitGroup
 	states           *file.States
 	wg               sync.WaitGroup
 	channelWg        sync.WaitGroup // Separate waitgroup for channels as not stopped on completion
 	id               uint64
 	Once             bool
+	harvesters       map[uuid.UUID]*harvester.Harvester
+	harvestersMutex  sync.Mutex
+	beatDone         chan struct{}
 }
 
 type Prospectorer interface {
@@ -47,17 +53,21 @@ type Outlet interface {
 	OnEvent(event *input.Event) bool
 }
 
-func NewProspector(cfg *common.Config, outlet Outlet) (*Prospector, error) {
+func NewProspector(cfg *common.Config, outlet Outlet, beatDone chan struct{}) (*Prospector, error) {
 	prospector := &Prospector{
 		cfg:           cfg,
 		config:        defaultConfig,
 		outlet:        outlet,
 		harvesterChan: make(chan *input.Event),
-		done:          make(chan struct{}),
+		channelDone:   make(chan struct{}),
 		wg:            sync.WaitGroup{},
+		runDone:       make(chan struct{}),
+		runWg:         sync.WaitGroup{},
 		states:        &file.States{},
 		channelWg:     sync.WaitGroup{},
 		Once:          false,
+		harvesters:    map[uuid.UUID]*harvester.Harvester{},
+		beatDone:      beatDone,
 	}
 
 	var err error
@@ -115,22 +125,14 @@ func (p *Prospector) Start() {
 	logp.Info("Starting prospector of type: %v; id: %v ", p.config.InputType, p.ID())
 
 	if p.Once {
-		// If only run once, waiting for completion of prospector / harvesters
-		defer p.wg.Wait()
+		// If only run once, waiting for completion of scan and prospector stopping
+		defer func() {
+			// Wait until run is finished
+			p.runWg.Wait()
+			// Wait until all harvesters are stopped
+			p.wg.Wait()
+		}()
 	}
-
-	// Add waitgroup to make sure prospectors finished
-	p.wg.Add(1)
-
-	go func() {
-		defer p.wg.Done()
-		p.Run()
-	}()
-
-}
-
-// Starts scanning through all the file paths and fetch the related files. Start a harvester for each file
-func (p *Prospector) Run() {
 
 	// Open channel to receive events from harvester and forward them to spooler
 	// Here potential filtering can happen
@@ -139,7 +141,12 @@ func (p *Prospector) Run() {
 		defer p.channelWg.Done()
 		for {
 			select {
-			case <-p.done:
+
+			case <-p.channelDone:
+				// TODO: Introduce same magic here as we have for shutdown_timeout to drain channel
+				logp.Info("Prospector channel stopped")
+				return
+			case <-p.beatDone:
 				logp.Info("Prospector channel stopped")
 				return
 			case event := <-p.harvesterChan:
@@ -151,6 +158,18 @@ func (p *Prospector) Run() {
 		}
 	}()
 
+	// Add waitgroup to make sure prospectors finished
+	p.runWg.Add(1)
+	go func() {
+		defer p.runWg.Done()
+		p.Run()
+	}()
+
+}
+
+// Starts scanning through all the file paths and fetch the related files. Start a harvester for each file
+func (p *Prospector) Run() {
+
 	// Initial prospector run
 	p.prospectorer.Run()
 
@@ -161,7 +180,7 @@ func (p *Prospector) Run() {
 
 	for {
 		select {
-		case <-p.done:
+		case <-p.runDone:
 			logp.Info("Prospector ticker stopped")
 			return
 		case <-time.After(p.config.ScanFrequency):
@@ -195,10 +214,46 @@ func (p *Prospector) updateState(event *input.Event) error {
 	return nil
 }
 
+// Stop stops the prospector and with it all harvesters
+//
+// The shutdown order is as follwoing
+// - stop run and scanning
+// - wait until last scan finishes to make sure no new harvesters are added
+// - stop harvesters
+// - wait until all harvester finished
+// - stop communication channel
+// - wait on internal waitgroup to make sure all prospector go routines are stopped
 func (p *Prospector) Stop() {
 	logp.Info("Stopping Prospector: %v", p.ID())
-	close(p.done)
+
+	// Stop scanning and wait for completion
+	close(p.runDone)
+	p.runWg.Wait()
+
+	wg := sync.WaitGroup{}
+
+	// Stop all harvesters
+	// In case the beatDone channel is closed, this will not wait for completion
+	// Otherwise Stop will wait until output is complete
+	p.harvestersMutex.Lock()
+	for _, hv := range p.harvesters {
+		wg.Add(1)
+		go func(h *harvester.Harvester) {
+			defer wg.Done()
+			h.Stop()
+		}(hv)
+	}
+	p.harvestersMutex.Unlock()
+
+	// Waits on stopping all harvesters to make sure all events made it into the channel
+	wg.Wait()
+
+	// Wait for completion of sending events
+	// TODO: If not beatDone, it should be waited until channel is drained -> how?
+	close(p.channelDone)
 	p.channelWg.Wait()
+
+	// Makes sure all prospector go routines are stopped
 	p.wg.Wait()
 }
 
@@ -209,7 +264,7 @@ func (p *Prospector) createHarvester(state file.State) (*harvester.Harvester, er
 		p.cfg,
 		state,
 		p.harvesterChan,
-		p.done,
+		p.beatDone,
 	)
 
 	return h, err
@@ -246,19 +301,40 @@ func (p *Prospector) startHarvester(state file.State, offset int64) error {
 		return err
 	}
 
-	p.wg.Add(1)
 	// startHarvester is not run concurrently, but atomic operations are need for the decrementing of the counter
 	// inside the following go routine
 	atomic.AddUint64(&p.harvesterCounter, 1)
+	p.wg.Add(1)
 	go func() {
-		defer func() {
-			atomic.AddUint64(&p.harvesterCounter, ^uint64(0))
-			p.wg.Done()
-		}()
 
+		p.addHarvester(h)
+		defer func() {
+			p.removeHarvester(h)
+			p.wg.Done()
+			atomic.AddUint64(&p.harvesterCounter, ^uint64(0))
+
+		}()
 		// Starts harvester and picks the right type. In case type is not set, set it to defeault (log)
 		h.Harvest(reader)
 	}()
 
 	return nil
+}
+
+func (p *Prospector) addHarvester(h *harvester.Harvester) {
+	p.harvestersMutex.Lock()
+	defer p.harvestersMutex.Unlock()
+	p.harvesters[h.ID] = h
+}
+
+func (p *Prospector) removeHarvester(h *harvester.Harvester) {
+	p.harvestersMutex.Lock()
+	defer p.harvestersMutex.Unlock()
+	delete(p.harvesters, h.ID)
+}
+
+func (p *Prospector) getHarvesters() map[uuid.UUID]*harvester.Harvester {
+	p.harvestersMutex.Lock()
+	defer p.harvestersMutex.Unlock()
+	return p.harvesters
 }

--- a/filebeat/prospector/prospector_log.go
+++ b/filebeat/prospector/prospector_log.go
@@ -209,7 +209,7 @@ func (p *ProspectorLog) scan() {
 	for path, info := range p.getFiles() {
 
 		select {
-		case <-p.Prospector.done:
+		case <-p.Prospector.runDone:
 			logp.Info("Scan aborted because prospector stopped.")
 			return
 		default:


### PR DESCRIPTION
There are two options for stopping a harvester or a prospector. Either the harvester and prospector finish sending all events and stop themself or they are killed because the output is blocking.

In case of shutting down filebeat without using `shutdown_timeout` filebeat is expected to shut down as fast as possible. This means channels are directly closed and the events are not passed through to the registry.

In case of dynamic prospector reloading, prospectors and harvesters must be stopped properly as otherwise no new harvester for the same file can be started.

So far the following changes were made:

* Introduce harvester tracking in prospector to better control / manage the harvesters
* Use `beatDone` channel coming from the beat itself for direct shutdown as this channel is closed when the beat is stopped.
* Introduce more done channels in prospector to make shutdown more fine grained
* Add system tests to verify new behaviour

TODO
* Make sure all events are drained from channel to not guarantee that state updates will be persisted.