### PR TITLE
Add fileset.name and fileset.module fields

### DIFF
--- a/filebeat/_meta/fields.common.yml
+++ b/filebeat/_meta/fields.common.yml
@@ -44,3 +44,10 @@
         the original `@timestamp` (representing the time when the log line was read) in this
         field.
 
+    - name: fileset.module
+      description: >
+        The Filebeat module that generated this event.
+
+    - name: fileset.name
+      description: >
+        The Filebeat fileset that generated this event.

--- a/filebeat/docs/fields.asciidoc
+++ b/filebeat/docs/fields.asciidoc
@@ -454,6 +454,18 @@ Ingestion pipeline error message, added in case there are errors reported by the
 In case the ingest pipeline parses the timestamp from the log contents, it stores the original `@timestamp` (representing the time when the log line was read) in this field.
 
 
+[float]
+=== fileset.module
+
+The Filebeat module that generated this event.
+
+
+[float]
+=== fileset.name
+
+The Filebeat fileset that generated this event.
+
+
 [[exported-fields-mysql]]
 == MySQL Fields
 

--- a/filebeat/filebeat.template-es2x.json
+++ b/filebeat/filebeat.template-es2x.json
@@ -196,6 +196,20 @@
         "fields": {
           "properties": {}
         },
+        "fileset": {
+          "properties": {
+            "module": {
+              "ignore_above": 1024,
+              "index": "not_analyzed",
+              "type": "string"
+            },
+            "name": {
+              "ignore_above": 1024,
+              "index": "not_analyzed",
+              "type": "string"
+            }
+          }
+        },
         "input_type": {
           "ignore_above": 1024,
           "index": "not_analyzed",

--- a/filebeat/filebeat.template.json
+++ b/filebeat/filebeat.template.json
@@ -165,6 +165,18 @@
         "fields": {
           "properties": {}
         },
+        "fileset": {
+          "properties": {
+            "module": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
         "input_type": {
           "ignore_above": 1024,
           "type": "keyword"

--- a/filebeat/fileset/fileset.go
+++ b/filebeat/fileset/fileset.go
@@ -235,6 +235,16 @@ func (fs *Fileset) getProspectorConfig() (*common.Config, error) {
 		return nil, fmt.Errorf("Error setting the pipeline ID in the prospector config: %v", err)
 	}
 
+	// force our the module/fileset name
+	err = cfg.SetString("_module_name", -1, fs.mcfg.Module)
+	if err != nil {
+		return nil, fmt.Errorf("Error setting the _module_name cfg in the prospector config: %v", err)
+	}
+	err = cfg.SetString("_fileset_name", -1, fs.name)
+	if err != nil {
+		return nil, fmt.Errorf("Error setting the _fileset_name cfg in the prospector config: %v", err)
+	}
+
 	cfg.PrintDebugf("Merged prospector config for fileset %s/%s", fs.mcfg.Module, fs.name)
 
 	return cfg, nil

--- a/filebeat/fileset/fileset_test.go
+++ b/filebeat/fileset/fileset_test.go
@@ -185,6 +185,14 @@ func TestGetProspectorConfigNginxOverrides(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "filebeat-5.2.0-nginx-access-with_plugins", pipelineID)
 
+	moduleName, err := cfg.String("_module_name", -1)
+	assert.NoError(t, err)
+	assert.Equal(t, "nginx", moduleName)
+
+	filesetName, err := cfg.String("_fileset_name", -1)
+	assert.NoError(t, err)
+	assert.Equal(t, "access", filesetName)
+
 }
 
 func TestGetPipelineNginx(t *testing.T) {

--- a/filebeat/harvester/config.go
+++ b/filebeat/harvester/config.go
@@ -53,6 +53,8 @@ type harvesterConfig struct {
 	Multiline            *reader.MultilineConfig `config:"multiline"`
 	JSON                 *reader.JSONConfig      `config:"json"`
 	Pipeline             string                  `config:"pipeline"`
+	Module               string                  `config:"_module_name"`  // hidden option to set the module name
+	Fileset              string                  `config:"_fileset_name"` // hidden option to set the fileset name
 }
 
 func (config *harvesterConfig) Validate() error {

--- a/filebeat/harvester/log.go
+++ b/filebeat/harvester/log.go
@@ -138,6 +138,8 @@ func (h *Harvester) Harvest(r reader.Reader) {
 			event.DocumentType = h.config.DocumentType
 			event.JSONConfig = h.config.JSON
 			event.Pipeline = h.config.Pipeline
+			event.Module = h.config.Module
+			event.Fileset = h.config.Fileset
 		}
 
 		// Always send event to update state, also if lines was skipped

--- a/filebeat/input/event.go
+++ b/filebeat/input/event.go
@@ -21,6 +21,8 @@ type Event struct {
 	State        file.State
 	Data         common.MapStr // Use in readers to add data to the event
 	Pipeline     string
+	Fileset      string
+	Module       string
 }
 
 func NewEvent(state file.State) *Event {
@@ -37,6 +39,13 @@ func (e *Event) ToMapStr() common.MapStr {
 		"offset":                e.State.Offset, // Offset here is the offset before the starting char.
 		"type":                  e.DocumentType,
 		"input_type":            e.InputType,
+	}
+
+	if e.Fileset != "" && e.Module != "" {
+		event["fileset"] = common.MapStr{
+			"name":   e.Fileset,
+			"module": e.Module,
+		}
 	}
 
 	// Add data fields which are added by the readers

--- a/filebeat/module/apache2/access/config/access.yml
+++ b/filebeat/module/apache2/access/config/access.yml
@@ -4,5 +4,3 @@ paths:
  - {{$path}}
 {{ end }}
 exclude_files: [".gz$"]
-fields:
-  source_type: apache2-access

--- a/filebeat/module/apache2/error/config/error.yml
+++ b/filebeat/module/apache2/error/config/error.yml
@@ -4,5 +4,3 @@ paths:
  - {{$path}}
 {{ end }}
 exclude_files: [".gz$"]
-fields:
-  source_type: apache2-error

--- a/filebeat/module/mysql/error/config/error.yml
+++ b/filebeat/module/mysql/error/config/error.yml
@@ -4,5 +4,3 @@ paths:
  - {{$path}}
 {{ end }}
 exclude_files: [".gz$"]
-fields:
-  source_type: mysql-error

--- a/filebeat/module/mysql/slowlog/config/slowlog.yml
+++ b/filebeat/module/mysql/slowlog/config/slowlog.yml
@@ -8,5 +8,3 @@ multiline:
   pattern: "^# User@Host: "
   negate: true
   match: after
-fields:
-  source_type: mysql-slowlog

--- a/filebeat/module/nginx/access/config/nginx-access.yml
+++ b/filebeat/module/nginx/access/config/nginx-access.yml
@@ -4,5 +4,3 @@ paths:
  - {{$path}}
 {{ end }}
 exclude_files: [".gz$"]
-fields:
-  source_type: nginx-access

--- a/filebeat/module/nginx/error/config/nginx-error.yml
+++ b/filebeat/module/nginx/error/config/nginx-error.yml
@@ -4,5 +4,3 @@ paths:
  - {{$path}}
 {{ end }}
 exclude_files: [".gz$"]
-fields:
-  source_type: nginx-error

--- a/filebeat/module/system/syslog/config/syslog.yml
+++ b/filebeat/module/system/syslog/config/syslog.yml
@@ -7,5 +7,3 @@ exclude_files: [".gz$"]
 multiline:
   pattern: "^\\s"
   match: after
-fields:
-  source_type: system-syslog

--- a/filebeat/tests/system/test_modules.py
+++ b/filebeat/tests/system/test_modules.py
@@ -97,6 +97,7 @@ class Test(BaseTest):
         for obj in objects:
             self.assert_fields_are_documented(obj)
             # assert "error" not in obj  # no parsing errors
+            assert obj["fileset"]["module"] == module
 
         if os.path.exists(test_file + "-expected.json"):
             with open(test_file + "-expected.json", "r") as f:


### PR DESCRIPTION
This replaces the `fields.source_type` hack with a `fileset` object that
resembles the Metricbeat `metricset` object.

The implementation still uses a hack: adds two hidden options to the prospector
config, but it's the smaller evil IMHO.

Part of #3159.