### PR TITLE
Fix docs, logs for setting UID/GID in Packetbeat

### DIFF
--- a/libbeat/common/droppriv/droppriv_unix.go
+++ b/libbeat/common/droppriv/droppriv_unix.go
@@ -27,7 +27,7 @@ func DropPrivileges(config RunOptions) error {
 		return errors.New("GID must be specified for dropping privileges")
 	}
 
-	logp.Info("Switching to user: %d.%d", config.UID, config.GID)
+	logp.Info("Switching to user: %d.%d", *config.UID, *config.GID)
 
 	if err = syscall.Setgid(*config.GID); err != nil {
 		return fmt.Errorf("setgid: %s", err.Error())

--- a/packetbeat/docs/reference/configuration/runconfig.asciidoc
+++ b/packetbeat/docs/reference/configuration/runconfig.asciidoc
@@ -16,8 +16,8 @@ Example configuration for the `runoptions` section of the +{beatname_lc}.yml+ co
 [source,yaml]
 ------------------------------------------------------------------------------
 packetbeat.runoptions:
-  uid=501
-  gid=501
+  uid: 501
+  gid: 501
 ------------------------------------------------------------------------------
 
 The `runoptions` configuration is supported on Linux only.


### PR DESCRIPTION
* Example for 'packetbeat.runopts' is now valid YAML.

* Log output now correctly dereferences UID, GID variables.