### PR TITLE
Configuration files must not be writeable by other users

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,6 +88,8 @@ addons:
       - geoip-database
 
 before_install:
+  - umask 022
+  - chmod -R go-w $GOPATH/src/github.com/elastic/beats
   # Docker-compose installation
   - sudo rm /usr/local/bin/docker-compose || true
   - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -15,6 +15,7 @@ https://github.com/elastic/beats/compare/v5.1.1...master[Check the HEAD diff]
 *Affecting all Beats*
 
 - Change beat generator. Use `$GOPATH/src/github.com/elastic/beats/script/generate.py` to generate a beat. {pull}3452[3452]
+- Configuration files must not be writable by other users. {pull}3544[3544]
 
 *Metricbeat*
 - Linux cgroup metrics are now enabled by default for the system process

--- a/dev-tools/jenkins_ci
+++ b/dev-tools/jenkins_ci
@@ -131,6 +131,7 @@ main() {
     err "--build and --cleanup cannot be used together"
     exit 1
   elif [ "$BUILD" == "true" ]; then
+    chmod -R go-w "${GOPATH}/src/github.com/elastic/beats"
     build
   elif [ "$CLEANUP" == "true" ]; then
     cleanup
@@ -140,4 +141,5 @@ main() {
   fi
 }
 
+umask 022
 main $*

--- a/filebeat/fileset/modules_integration_test.go
+++ b/filebeat/fileset/modules_integration_test.go
@@ -45,8 +45,9 @@ func TestLoadPipeline(t *testing.T) {
 
 	var res map[string]interface{}
 	err = json.Unmarshal(response, &res)
-	assert.NoError(t, err)
-	assert.Equal(t, "describe pipeline", res["my-pipeline-id"].(map[string]interface{})["description"], string(response))
+	if assert.NoError(t, err) {
+		assert.Equal(t, "describe pipeline", res["my-pipeline-id"].(map[string]interface{})["description"], string(response))
+	}
 }
 
 func TestSetupNginx(t *testing.T) {
@@ -62,10 +63,14 @@ func TestSetupNginx(t *testing.T) {
 	}
 
 	reg, err := newModuleRegistry(modulesPath, configs, nil, "5.2.0")
-	assert.NoError(t, err)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	err = reg.LoadPipelines(client)
-	assert.NoError(t, err)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	status, _, _ := client.Request("GET", "/_ingest/pipeline/filebeat-5.2.0-nginx-access-with_plugins", "", nil, nil)
 	assert.Equal(t, 200, status)

--- a/libbeat/cfgfile/cfgfile.go
+++ b/libbeat/cfgfile/cfgfile.go
@@ -91,7 +91,7 @@ func HandleFlags() error {
 func Read(out interface{}, path string) error {
 	config, err := Load(path)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	return config.Unpack(out)

--- a/libbeat/cfgfile/cfgfile_test.go
+++ b/libbeat/cfgfile/cfgfile_test.go
@@ -34,8 +34,9 @@ func TestRead(t *testing.T) {
 
 	config := &TestConfig{}
 
-	err = Read(config, absPath+"/config.yml")
-	assert.Nil(t, err)
+	if err = Read(config, absPath+"/config.yml"); err != nil {
+		t.Fatal(err)
+	}
 
 	// validate
 	assert.Equal(t, "localhost", config.Output.Elasticsearch.Host)

--- a/libbeat/common/file/fileinfo.go
+++ b/libbeat/common/file/fileinfo.go
@@ -1,0 +1,49 @@
+package file
+
+import (
+	"errors"
+	"os"
+)
+
+// A FileInfo describes a file and is returned by Stat and Lstat.
+type FileInfo interface {
+	os.FileInfo
+	UID() (int, error) // UID of the file owner. Returns an error on non-POSIX file systems.
+	GID() (int, error) // GID of the file owner. Returns an error on non-POSIX file systems.
+}
+
+// Stat returns a FileInfo describing the named file.
+// If there is an error, it will be of type *PathError.
+func Stat(name string) (FileInfo, error) {
+	return stat(name, os.Stat)
+}
+
+// Lstat returns a FileInfo describing the named file.
+// If the file is a symbolic link, the returned FileInfo
+// describes the symbolic link. Lstat makes no attempt to follow the link.
+// If there is an error, it will be of type *PathError.
+func Lstat(name string) (FileInfo, error) {
+	return stat(name, os.Lstat)
+}
+
+type fileInfo struct {
+	os.FileInfo
+	uid *int
+	gid *int
+}
+
+func (f fileInfo) UID() (int, error) {
+	if f.uid == nil {
+		return -1, errors.New("uid not implemented")
+	}
+
+	return *f.uid, nil
+}
+
+func (f fileInfo) GID() (int, error) {
+	if f.gid == nil {
+		return -1, errors.New("gid not implemented")
+	}
+
+	return *f.gid, nil
+}

--- a/libbeat/common/file/fileinfo_test.go
+++ b/libbeat/common/file/fileinfo_test.go
@@ -1,0 +1,73 @@
+// +build !windows
+
+package file_test
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/elastic/beats/libbeat/common/file"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStat(t *testing.T) {
+	f, err := ioutil.TempFile("", "teststat")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+
+	link := filepath.Join(os.TempDir(), "teststat-link")
+	if err := os.Symlink(f.Name(), link); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(link)
+
+	info, err := file.Stat(link)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.True(t, info.Mode().IsRegular())
+
+	uid, err := info.UID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.EqualValues(t, os.Geteuid(), uid)
+
+	gid, err := info.GID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.EqualValues(t, os.Getegid(), gid)
+}
+
+func TestLstat(t *testing.T) {
+	link := filepath.Join(os.TempDir(), "link")
+	if err := os.Symlink("dummy", link); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(link)
+
+	info, err := file.Lstat(link)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.True(t, info.Mode()&os.ModeSymlink > 0)
+
+	uid, err := info.UID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.EqualValues(t, os.Geteuid(), uid)
+
+	gid, err := info.GID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.EqualValues(t, os.Getegid(), gid)
+}

--- a/libbeat/common/file/fileinfo_unix.go
+++ b/libbeat/common/file/fileinfo_unix.go
@@ -1,0 +1,25 @@
+// +build !windows
+
+package file
+
+import (
+	"errors"
+	"os"
+	"syscall"
+)
+
+func stat(name string, statFunc func(name string) (os.FileInfo, error)) (FileInfo, error) {
+	info, err := statFunc(name)
+	if err != nil {
+		return nil, err
+	}
+
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return nil, errors.New("failed to get uid/gid")
+	}
+
+	uid := int(stat.Uid)
+	gid := int(stat.Gid)
+	return fileInfo{FileInfo: info, uid: &uid, gid: &gid}, nil
+}

--- a/libbeat/common/file/fileinfo_windows.go
+++ b/libbeat/common/file/fileinfo_windows.go
@@ -1,0 +1,14 @@
+package file
+
+import (
+	"os"
+)
+
+func stat(name string, statFunc func(name string) (os.FileInfo, error)) (FileInfo, error) {
+	info, err := statFunc(name)
+	if err != nil {
+		return nil, err
+	}
+
+	return fileInfo{FileInfo: info}, nil
+}

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -301,7 +301,8 @@ stop-environment:
 .PHONY: write-environment
 write-environment:
 	mkdir -p ${BUILD_DIR}
-	echo "ES_HOST=${ES_HOST}" > ${BUILD_DIR}/test.env
+	echo "BEAT_STRICT_PERMS=false" > ${BUILD_DIR}/test.env
+	echo "ES_HOST=${ES_HOST}" >> ${BUILD_DIR}/test.env
 	echo "ES_PORT=9200" >> ${BUILD_DIR}/test.env
 	echo "ES_USER=beats" >> ${BUILD_DIR}/test.env
 	echo "ES_PASS=testing" >> ${BUILD_DIR}/test.env


### PR DESCRIPTION
This PR adds enforcement of ownership and file permissions on configuration files. Any configuration file must be owned by the same user that the Beat is running as and the file must not be writable by anyone other than the owner.

This strict permission checking is limited to platforms with POSIX file permissions. The DACLs used by Windows are not checked at this time.

The check can be disabled on the CLI with `-strict.perms=false`.