### PR TITLE
Fix php-fpm docker image

### DIFF
--- a/metricbeat/module/php_fpm/_meta/Dockerfile
+++ b/metricbeat/module/php_fpm/_meta/Dockerfile
@@ -1,6 +1,6 @@
 FROM richarvey/nginx-php-fpm
 
-RUN echo "pm.status_path = /status" >> /etc/php7/php-fpm.d/www.conf
+RUN echo "pm.status_path = /status" >> /usr/local/etc/php-fpm.d/www.conf
 ADD ./php-fpm.conf /etc/nginx/sites-enabled
 
 EXPOSE 81


### PR DESCRIPTION
It seems in the most recent version of the Docker image the path does not exist anymore so it must be generated.