### PR TITLE
Bring back the _all field in 5.x

### DIFF
--- a/filebeat/filebeat.template.json
+++ b/filebeat/filebeat.template.json
@@ -1,6 +1,9 @@
 {
   "mappings": {
     "_default_": {
+      "_all": {
+        "norms": false
+      },
       "_meta": {
         "version": "5.3.0"
       },

--- a/heartbeat/heartbeat.template.json
+++ b/heartbeat/heartbeat.template.json
@@ -1,6 +1,9 @@
 {
   "mappings": {
     "_default_": {
+      "_all": {
+        "norms": false
+      },
       "_meta": {
         "version": "5.3.0"
       },

--- a/libbeat/scripts/generate_template.py
+++ b/libbeat/scripts/generate_template.py
@@ -59,13 +59,6 @@ def fields_to_es_template(args, input, output, index, version):
         }
     }
 
-    # should be done only for es5x. For es6x, any "_all" setting results
-    # in an error.
-    # TODO: https://github.com/elastic/beats/issues/3368
-    # template["mappings"]["_default"]["_all"] = {
-    #     "norms": False
-    # }
-
     if args.es2x:
         # different syntax for norms
         template["mappings"]["_default_"]["_all"] = {
@@ -78,6 +71,13 @@ def fields_to_es_template(args, input, output, index, version):
         # In a typical scenario, most fields are not used, so increasing the
         # limit shouldn't be that bad.
         template["settings"]["index.mapping.total_fields.limit"] = 10000
+
+        # should be done only for es5x. For es6x, any "_all" setting results
+        # in an error.
+        # TODO: https://github.com/elastic/beats/issues/3368
+        template["mappings"]["_default_"]["_all"] = {
+            "norms": False
+        }
 
     properties = {}
     dynamic_templates = []

--- a/metricbeat/metricbeat.template.json
+++ b/metricbeat/metricbeat.template.json
@@ -1,6 +1,9 @@
 {
   "mappings": {
     "_default_": {
+      "_all": {
+        "norms": false
+      },
       "_meta": {
         "version": "5.3.0"
       },

--- a/packetbeat/packetbeat.template.json
+++ b/packetbeat/packetbeat.template.json
@@ -1,6 +1,9 @@
 {
   "mappings": {
     "_default_": {
+      "_all": {
+        "norms": false
+      },
       "_meta": {
         "version": "5.3.0"
       },

--- a/testing/environments/args.yml
+++ b/testing/environments/args.yml
@@ -6,4 +6,4 @@ services:
     build:
       args:
         DOWNLOAD_URL: https://snapshots.elastic.co/downloads
-        ELASTIC_VERSION: 6.0.0-alpha1-SNAPSHOT
+        ELASTIC_VERSION: 5.3.0-SNAPSHOT

--- a/winlogbeat/winlogbeat.template.json
+++ b/winlogbeat/winlogbeat.template.json
@@ -1,6 +1,9 @@
 {
   "mappings": {
     "_default_": {
+      "_all": {
+        "norms": false
+      },
       "_meta": {
         "version": "5.3.0"
       },


### PR DESCRIPTION
This is a temporary solution for #3368, to avoid a breaking change
in 5.x.