### PR TITLE
Add tags to docker images

### DIFF
--- a/metricbeat/module/ceph/_meta/Dockerfile
+++ b/metricbeat/module/ceph/_meta/Dockerfile
@@ -1,4 +1,4 @@
-FROM ceph/demo
+FROM ceph/demo:tag-build-master-jewel-centos-7
 
 ENV MON_IP 0.0.0.0
 ENV CEPH_PUBLIC_NETWORK 0.0.0.0/0

--- a/metricbeat/module/kafka/_meta/Dockerfile
+++ b/metricbeat/module/kafka/_meta/Dockerfile
@@ -1,3 +1,5 @@
+# TODO: No tags currently exist for this image. Tags should be used whever possible
+# as otherwise builds are not identical over time.
 FROM spotify/kafka
 
 EXPOSE 2181 9092

--- a/metricbeat/module/php_fpm/_meta/Dockerfile
+++ b/metricbeat/module/php_fpm/_meta/Dockerfile
@@ -1,4 +1,4 @@
-FROM richarvey/nginx-php-fpm
+FROM richarvey/nginx-php-fpm:php71
 
 RUN echo "pm.status_path = /status" >> /usr/local/etc/php-fpm.d/www.conf
 ADD ./php-fpm.conf /etc/nginx/sites-enabled

--- a/metricbeat/module/prometheus/_meta/Dockerfile
+++ b/metricbeat/module/prometheus/_meta/Dockerfile
@@ -1,3 +1,3 @@
-FROM  prom/prometheus
+FROM prom/prometheus:v1.5.1
 
 EXPOSE 9090


### PR DESCRIPTION
Some Dockerfiles were missing a tag for the image that should be pulled and used :latest. As latest can change over time, this could break CI builds. To make it consistent each Dockerfile must link to a specific version