### PR TITLE
Fix go vet issue with assert.Error

### DIFF
--- a/winlogbeat/config/config_test.go
+++ b/winlogbeat/config/config_test.go
@@ -18,8 +18,10 @@ func (v validationTestCase) run(t *testing.T) {
 		assert.NoError(t, v.config.Validate())
 	} else {
 		err := v.config.Validate()
-		if assert.Error(t, err, "expected '%s'", v.errMsg) {
+		if err != nil {
 			assert.Contains(t, err.Error(), v.errMsg)
+		} else {
+			t.Errorf("expected error with '%s'", v.errMsg)
 		}
 	}
 }


### PR DESCRIPTION
```
go vet github.com/elastic/beats/winlogbeat/...
config/config_test.go:21: possible formatting directive in Error call
exit status 1
```