### PR TITLE
Ignore permission errors in Metricbeat’s TestFileSystemList

### DIFF
--- a/metricbeat/module/system/filesystem/helper_test.go
+++ b/metricbeat/module/system/filesystem/helper_test.go
@@ -28,6 +28,10 @@ func TestFileSystemList(t *testing.T) {
 		}
 
 		stat, err := GetFileSystemStat(fs)
+		if os.IsPermission(err) {
+			continue
+		}
+
 		if assert.NoError(t, err, "%v", err) {
 			assert.True(t, (stat.Total >= 0))
 			assert.True(t, (stat.Free >= 0))


### PR DESCRIPTION
The test can fail if some calls to statfs fail due to permission errors. For example:

`stat("/var/lib/docker/aufs/mnt/50d0d5f599f0f19450e7649f73a0e23da1f172048e555df2b1cb78b3fefa355b", 0x7ffd2e5b8ed0) = -1 EACCES (Permission denied)`