### PR TITLE
Pin sources.list to a single debian archive server

### DIFF
--- a/dev-tools/packer/docker/xgo-image-deb6/base/sources.list
+++ b/dev-tools/packer/docker/xgo-image-deb6/base/sources.list
@@ -1,2 +1,2 @@
-deb http://archive.debian.org/debian/ squeeze main contrib
-deb http://archive.debian.org/debian/ squeeze-lts main
+deb http://130.89.148.13/debian/ squeeze main contrib
+deb http://130.89.148.13/debian/ squeeze-lts main

--- a/dev-tools/packer/docker/xgo-image-deb6/beats-builder/Dockerfile
+++ b/dev-tools/packer/docker/xgo-image-deb6/beats-builder/Dockerfile
@@ -5,9 +5,9 @@ MAINTAINER Tudor Golubenco <tudor@elastic.co>
 # Get libpcap binaries for linux
 RUN \
 	mkdir -p /libpcap && \
-    wget http://archive.debian.org/debian/pool/main/libp/libpcap/libpcap0.8-dev_1.1.1-2+squeeze1_i386.deb && \
+    wget http://130.89.148.13/debian/pool/main/libp/libpcap/libpcap0.8-dev_1.1.1-2+squeeze1_i386.deb && \
 	dpkg -x libpcap0.8-dev_*_i386.deb /libpcap/i386 && \
-	wget http://archive.debian.org/debian/pool/main/libp/libpcap/libpcap0.8-dev_1.1.1-2+squeeze1_amd64.deb && \
+	wget http://130.89.148.13/debian/pool/main/libp/libpcap/libpcap0.8-dev_1.1.1-2+squeeze1_amd64.deb && \
 	dpkg -x libpcap0.8-dev_*_amd64.deb /libpcap/amd64 && \
 	rm libpcap0.8-dev*.deb
 RUN \


### PR DESCRIPTION
We are getting back “403  Forbidden [IP: 193.62.202.28 80]” when building the docker images. The server at 130.89.148.13 seems to be responding normally for the moment.