### PR TITLE
Docs version bump for 5.2.1

### DIFF
--- a/libbeat/docs/version.asciidoc
+++ b/libbeat/docs/version.asciidoc
@@ -1,3 +1,3 @@
-:stack-version: 5.2.0
+:stack-version: 5.2.1
 :doc-branch: 5.2
 :go-version: 1.7.4


### PR DESCRIPTION
As usual, please don't merge this until a couple of hours before the release, otherwise we're break the links in the getting started guide.