### PR TITLE
Correct Libbeat docs directory layout

### DIFF
--- a/libbeat/docs/shared-directory-layout.asciidoc
+++ b/libbeat/docs/shared-directory-layout.asciidoc
@@ -18,7 +18,7 @@ The directory layout of an installation is as follows:
 |=======================================================================
 | Type | Description | Default Location | Config Option
 | home | Home of the {beatname_uc} installation. | | path.home
-| bin  | The location for the binary files. | {path.home} |
+| bin  | The location for the binary files. | {path.home}/bin |
 | conf | The location for configuration files. | {path.home} | path.conf
 | data | The location for persistent data files. | {path.home}/data| path.data
 | logs | The location for the logs created by {beatname_uc}. | {path.home}/logs | path.logs
@@ -37,7 +37,7 @@ file.
 |=======================================================================
 | Type | Description | Location
 | home | Home of the {beatname_uc} installation. | /usr/share/{beatname_lc}
-| bin  | The location for the binary files. | /usr/share/{beatname_lc}
+| bin  | The location for the binary files. | /usr/share/{beatname_lc}/bin
 | conf | The location for configuration files. | /etc/{beatname_lc}
 | data | The location for persistent data files. | /var/lib/{beatname_lc}
 | logs | The location for the logs created by {beatname_uc}. | /var/log/{beatname_lc}
@@ -54,7 +54,7 @@ Otherwise the paths might be set incorrectly.
 |=======================================================================
 | Type | Description | Location
 | home | Home of the {beatname_uc} installation. | {extract.path}
-| bin  | The location for the binary files. | {extract.path}
+| bin  | The location for the binary files. | {extract.path}/bin
 | conf | The location for configuration files. | {extract.path}
 | data | The location for persistent data files. | {extract.path}/data
 | logs | The location for the logs created by {beatname_uc}. | {extract.path}/logs


### PR DESCRIPTION
The `/bin` was missing from the docs.