### PR TITLE
Revert "Pin sources.list to a single debian archive server"

### DIFF
--- a/dev-tools/packer/docker/xgo-image-deb6/base/sources.list
+++ b/dev-tools/packer/docker/xgo-image-deb6/base/sources.list
@@ -1,2 +1,2 @@
-deb http://130.89.148.13/debian/ squeeze main contrib
-deb http://130.89.148.13/debian/ squeeze-lts main
+deb http://archive.debian.org/debian/ squeeze main contrib
+deb http://archive.debian.org/debian/ squeeze-lts main

--- a/dev-tools/packer/docker/xgo-image-deb6/beats-builder/Dockerfile
+++ b/dev-tools/packer/docker/xgo-image-deb6/beats-builder/Dockerfile
@@ -5,9 +5,9 @@ MAINTAINER Tudor Golubenco <tudor@elastic.co>
 # Get libpcap binaries for linux
 RUN \
 	mkdir -p /libpcap && \
-    wget http://130.89.148.13/debian/pool/main/libp/libpcap/libpcap0.8-dev_1.1.1-2+squeeze1_i386.deb && \
+    wget http://archive.debian.org/debian/pool/main/libp/libpcap/libpcap0.8-dev_1.1.1-2+squeeze1_i386.deb && \
 	dpkg -x libpcap0.8-dev_*_i386.deb /libpcap/i386 && \
-	wget http://130.89.148.13/debian/pool/main/libp/libpcap/libpcap0.8-dev_1.1.1-2+squeeze1_amd64.deb && \
+	wget http://archive.debian.org/debian/pool/main/libp/libpcap/libpcap0.8-dev_1.1.1-2+squeeze1_amd64.deb && \
 	dpkg -x libpcap0.8-dev_*_amd64.deb /libpcap/amd64 && \
 	rm libpcap0.8-dev*.deb
 RUN \


### PR DESCRIPTION
Reverts elastic/beats#3576. The hosts behind archive.debian.org are responding normally again.