### PR TITLE
Use more global paths for system tests

### DIFF
--- a/filebeat/tests/system/filebeat.py
+++ b/filebeat/tests/system/filebeat.py
@@ -2,7 +2,7 @@ import json
 import os
 import sys
 
-sys.path.append('../../../libbeat/tests/system')
+sys.path.append(os.path.join(os.path.dirname(__file__), '../../../libbeat/tests/system'))
 
 from beat.beat import TestCase
 
@@ -12,6 +12,8 @@ class BaseTest(TestCase):
     @classmethod
     def setUpClass(self):
         self.beat_name = "filebeat"
+        self.beat_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../"))
+
         super(BaseTest, self).setUpClass()
 
     def get_registry(self):

--- a/filebeat/tests/system/test_crawler.py
+++ b/filebeat/tests/system/test_crawler.py
@@ -577,7 +577,7 @@ class Test(BaseTest):
                 "encoding": enc_go
             })
         self.render_config_template(
-            template="filebeat_prospectors.yml.j2",
+            template_name="filebeat_prospectors",
             prospectors=prospectors
         )
 

--- a/filebeat/tests/system/test_modules.py
+++ b/filebeat/tests/system/test_modules.py
@@ -40,7 +40,7 @@ class Test(BaseTest):
         # generate a minimal configuration
         cfgfile = os.path.join(self.working_dir, "filebeat.yml")
         self.render_config_template(
-            template="filebeat_modules.yml.j2",
+            template_name="filebeat_modules",
             output=cfgfile,
             index_name=self.index_name,
             elasticsearch_url=self.elasticsearch_url)

--- a/filebeat/tests/system/test_prospector.py
+++ b/filebeat/tests/system/test_prospector.py
@@ -119,7 +119,7 @@ class Test(BaseTest):
             close_eof="true",
         )
 
-        args = [self.beat_path,
+        args = [self.test_binary,
                 "-systemTest",
                 "-test.coverprofile",
                 os.path.join(self.working_dir, "coverage.cov"),

--- a/generator/beat/{beat}/tests/system/{beat}.py
+++ b/generator/beat/{beat}/tests/system/{beat}.py
@@ -1,3 +1,4 @@
+import os
 import sys
 sys.path.append('../../vendor/github.com/elastic/beats/libbeat/tests/system')
 from beat.beat import TestCase
@@ -8,5 +9,5 @@ class BaseTest(TestCase):
     @classmethod
     def setUpClass(self):
         self.beat_name = "{beat}"
-        self.build_path = "../../build/system-tests/"
-        self.beat_path = "../../{beat}.test"
+        self.beat_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../"))
+        super(BaseTest, self).setUpClass()

--- a/heartbeat/tests/system/heartbeat.py
+++ b/heartbeat/tests/system/heartbeat.py
@@ -1,5 +1,7 @@
 import sys
-sys.path.append('../../vendor/github.com/elastic/beats/libbeat/tests/system')
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '../../../libbeat/tests/system'))
+
 from beat.beat import TestCase
 
 
@@ -8,5 +10,4 @@ class BaseTest(TestCase):
     @classmethod
     def setUpClass(self):
         self.beat_name = "heartbeat"
-        self.build_path = "../../build/system-tests/"
-        self.beat_path = "../../heartbeat.test"
+        self.beat_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../"))

--- a/libbeat/tests/system/base.py
+++ b/libbeat/tests/system/base.py
@@ -1,3 +1,4 @@
+import os
 from beat.beat import TestCase
 
 
@@ -6,5 +7,6 @@ class BaseTest(TestCase):
     @classmethod
     def setUpClass(self):
         self.beat_name = "mockbeat"
-        self.build_path = "../../build/system-tests/"
-        self.beat_path = "../../libbeat.test"
+        self.beat_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../"))
+        self.test_binary = self.beat_path + "/libbeat.test"
+        super(BaseTest, self).setUpClass()

--- a/libbeat/tests/system/beat/beat.py
+++ b/libbeat/tests/system/beat/beat.py
@@ -102,19 +102,22 @@ class TestCase(unittest.TestCase):
     @classmethod
     def setUpClass(self):
 
-        # Create build path
-        build_dir = "../../build"
-        if 'BUILD_DIR' in os.environ.keys() and os.environ['BUILD_DIR'] != '':
-            build_dir = os.environ['BUILD_DIR']
-        self.build_path = build_dir + "/system-tests/"
+
 
         # Path to test binary
         if not hasattr(self, 'beat_name'):
             self.beat_name = "beat"
 
-        # Path to test binary
         if not hasattr(self, 'beat_path'):
-            self.beat_path = "../../" + self.beat_name + ".test"
+            self.beat_path = "."
+
+        # Path to test binary
+        if not hasattr(self, 'test_binary'):
+            self.test_binary = os.path.abspath(self.beat_path + "/" + self.beat_name + ".test")
+
+        # Create build path
+        build_dir = self.beat_path + "/build"
+        self.build_path = build_dir + "/system-tests/"
 
     def run_beat(self,
                  cmd=None,
@@ -150,7 +153,7 @@ class TestCase(unittest.TestCase):
 
         # Init defaults
         if cmd is None:
-            cmd = self.beat_path
+            cmd = self.test_binary
 
         if config is None:
             config = self.beat_name + ".yml"
@@ -175,17 +178,19 @@ class TestCase(unittest.TestCase):
         proc.start()
         return proc
 
-    def render_config_template(self, template=None,
+    def render_config_template(self, template_name=None,
                                output=None, **kargs):
 
         # Init defaults
-        if template is None:
-            template = self.beat_name + ".yml.j2"
+        if template_name is None:
+            template_name = self.beat_name
+
+        template_path = "./tests/system/config/" + template_name + ".yml.j2"
 
         if output is None:
             output = self.beat_name + ".yml"
 
-        template = self.template_env.get_template(template)
+        template = self.template_env.get_template(template_path)
 
         kargs["beat"] = self
         output_str = template.render(**kargs)
@@ -242,7 +247,7 @@ class TestCase(unittest.TestCase):
     def setUp(self):
 
         self.template_env = jinja2.Environment(
-            loader=jinja2.FileSystemLoader("config")
+            loader=jinja2.FileSystemLoader(self.beat_path)
         )
 
         # create working dir
@@ -379,7 +384,7 @@ class TestCase(unittest.TestCase):
                     raise Exception("Unexpected key '{}' found"
                                     .format(key))
 
-    def load_fields(self, fields_doc="../../_meta/fields.generated.yml"):
+    def load_fields(self, fields_doc=None):
         """
         Returns a list of fields to expect in the output dictionaries
         and a second list that contains the fields that have a
@@ -387,6 +392,10 @@ class TestCase(unittest.TestCase):
 
         Reads these lists from the fields documentation.
         """
+
+        if fields_doc is None:
+            fields_doc = self.beat_path + "/_meta/fields.generated.yml"
+
         def extract_fields(doc_list, name):
             fields = []
             dictfields = []
@@ -414,12 +423,12 @@ class TestCase(unittest.TestCase):
 
         # Not all beats have a fields.generated.yml. Fall back to fields.yml
         if not os.path.isfile(fields_doc):
-            fields_doc = "../../_meta/fields.yml"
+            fields_doc = self.beat_path + "/_meta/fields.yml"
 
         # TODO: Make fields_doc path more generic to work with beat-generator
         with open(fields_doc, "r") as f:
-            # TODO: Make this path more generic to work with beat-generator.
-            with open("../../../libbeat/_meta/fields.common.yml") as f2:
+            path = os.path.abspath(os.path.dirname(__file__) + "../../../../_meta/fields.common.yml")
+            with open(path) as f2:
                 content = f2.read()
 
             #content = "fields:\n"

--- a/libbeat/tests/system/test_base.py
+++ b/libbeat/tests/system/test_base.py
@@ -32,7 +32,7 @@ class Test(BaseTest):
         """
         Checks stop on invalid config
         """
-        shutil.copy("../files/invalid.yml",
+        shutil.copy(self.beat_path + "/tests/files/invalid.yml",
                     os.path.join(self.working_dir, "invalid.yml"))
 
         exit_code = self.run_beat(config="invalid.yml")
@@ -67,7 +67,7 @@ class Test(BaseTest):
         """
         Checks if -configtest works as expected
         """
-        shutil.copy("../../_meta/config.yml",
+        shutil.copy(self.beat_path + "/_meta/config.yml",
                     os.path.join(self.working_dir, "libbeat.yml"))
         with open(self.working_dir + "/mockbeat.template.json", "w") as f:
             f.write('{"template": true}')
@@ -93,7 +93,7 @@ class Test(BaseTest):
         """
         Checks if version param works
         """
-        args = ["../../libbeat.test"]
+        args = [self.beat_path + "/libbeat.test"]
 
         args.extend(["-version",
                      "-e",

--- a/metricbeat/tests/system/metricbeat.py
+++ b/metricbeat/tests/system/metricbeat.py
@@ -1,7 +1,8 @@
 import sys
 import os
 
-sys.path.append('../../../libbeat/tests/system')
+sys.path.append(os.path.join(os.path.dirname(__file__), '../../../libbeat/tests/system'))
+
 from beat.beat import TestCase
 
 COMMON_FIELDS = ["@timestamp", "beat", "metricset.name", "metricset.host",
@@ -15,8 +16,8 @@ class BaseTest(TestCase):
     @classmethod
     def setUpClass(self):
         self.beat_name = "metricbeat"
-        self.build_path = "../../build/system-tests/"
-        self.beat_path = "../../metricbeat.test"
+        self.beat_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../"))
+        super(BaseTest, self).setUpClass()
 
     def assert_fields_are_documented(self, evt):
         """

--- a/metricbeat/tests/system/test_system.py
+++ b/metricbeat/tests/system/test_system.py
@@ -42,7 +42,7 @@ SYSTEM_PROCESS_FIELDS = ["cpu", "memory", "name", "pid", "ppid", "pgid",
                          "state", "username", "cgroup"]
 
 
-class SystemTest(metricbeat.BaseTest):
+class Test(metricbeat.BaseTest):
 
     @unittest.skipUnless(re.match("(?i)win|linux|darwin|freebsd|openbsd", sys.platform), "os")
     def test_cpu(self):

--- a/winlogbeat/tests/system/winlogbeat.py
+++ b/winlogbeat/tests/system/winlogbeat.py
@@ -1,3 +1,4 @@
+import os
 import sys
 
 if sys.platform.startswith("win"):
@@ -7,7 +8,8 @@ if sys.platform.startswith("win"):
     import win32security
     import win32evtlogutil
 
-sys.path.append('../../../libbeat/tests/system')
+sys.path.append(os.path.join(os.path.dirname(__file__), '../../../libbeat/tests/system'))
+
 from beat.beat import TestCase
 
 
@@ -16,6 +18,7 @@ class BaseTest(TestCase):
     @classmethod
     def setUpClass(self):
         self.beat_name = "winlogbeat"
+        self.beat_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../"))
         super(BaseTest, self).setUpClass()
 
 


### PR DESCRIPTION
This change is the first step to make it possible to execute system tests from different locations. Currently all system test execution relies on the convention that everything is under `tests/system/` and that `nosetests` is executed in this directory. Based on this it is not possible to place system tests in different location, for example inside a metricbeat module. In addition it should simplify the creation of system tests in community beats.


* Unify handling of setUpClass
* Rename SystemTest to Test to be consistent
* Rename `beat_path` variable to `test_binary` because that is what it is
* Expect full template path in template loader
* Use absolute paths for importing other python files
* Remove duplicated code from packetbeat setUp