### PR TITLE
Add doc changes to improve getting started topics

### DIFF
--- a/filebeat/docs/getting-started.asciidoc
+++ b/filebeat/docs/getting-started.asciidoc
@@ -94,7 +94,8 @@ see <<filebeat-configuration-details>>.
 
 To configure Filebeat, you edit the configuration file. For rpm and deb, you'll
 find the configuration file at `/etc/filebeat/filebeat.yml`. For mac and win, look in
-the archive that you just extracted.
+the archive that you just extracted. There’s also a full example configuration file
+called `filebeat.full.yml` that shows all non-deprecated options.
 
 Here is a sample of the `filebeat` section of the `filebeat.yml` file. Filebeat uses predefined
 default values for most configuration options.
@@ -166,6 +167,10 @@ include::../../libbeat/docs/shared-template-load.asciidoc[]
 
 Start Filebeat by issuing the appropriate command for your platform.
 
+NOTE: If you use an init.d script to start Filebeat on deb or rpm, you can't
+specify command line flags (see <<filebeat-command-line>>). To specify flags,
+start Filebeat in the foreground.
+
 *deb:*
 
 [source,shell]
@@ -203,7 +208,12 @@ Filebeat is now ready to send log files to your defined output.
 
 We don't offer prebuilt dashboards for visualizing Filebeat data. However, to make it easier for you to explore Filebeat
 data in Kibana, we've created a Filebeat index pattern: `filebeat-*`. To load this pattern, you can use the script
-that's provided for importing dashboards.
+that's provided for importing dashboards:
+
+[source,shell]
+----------------------------------------------------------------------
+./scripts/import_dashboards -only-index
+----------------------------------------------------------------------
 
 For more information about running the script, see
 {libbeat}/import-dashboards.html[Importing Existing Beat Dashboards] in the _Beats Platform Reference_.

--- a/heartbeat/docs/getting-started.asciidoc
+++ b/heartbeat/docs/getting-started.asciidoc
@@ -108,7 +108,9 @@ options, see <<heartbeat-configuration-details>>.
 
 To configure Heartbeat, you edit the configuration file. For rpm and deb,
 you'll find the configuration file at +/etc/heartbeat/heartbeat.yml+.
-For mac and win, look in the archive that you just extracted.
+For mac and win, look in the archive that you just extracted. There’s also a
+full example configuration file called `heartbeat.full.yml` that shows all
+non-deprecated options.
 
 Heartbeat provides monitors to check the status of hosts at set intervals.
 You configure each monitor individually. Heartbeat currently provides monitors
@@ -184,6 +186,10 @@ include::../../libbeat/docs/shared-template-load.asciidoc[]
 === Step 4: Starting Heartbeat
 
 Start Heartbeat by issuing the appropriate command for your platform.
+
+NOTE: If you use an init.d script to start Heartbeat on deb or rpm, you can't
+specify command line flags (see <<heartbeat-command-line>>). To specify flags,
+start Heartbeat in the foreground.
 
 *deb:*
 

--- a/libbeat/docs/gettingstarted.asciidoc
+++ b/libbeat/docs/gettingstarted.asciidoc
@@ -112,14 +112,15 @@ You should see a response similar to this:
 ["source","sh",subs="attributes"]
 ----------------------------------------------------------------------
 {
-  "name" : "Angela Del Toro",
+  "name" : "ofgAtrJ",
   "cluster_name" : "elasticsearch",
+  "cluster_uuid" : "3h9xSrVlRJmDHgQ8FLnByA",
   "version" : {
     "number" : "{ES-version}",
-    "build_hash" : "8ff36d139e16f8720f2947ef62c8167a888992fe",
-    "build_timestamp" : "2016-01-27T13:32:39Z",
+    "build_hash" : "db0d481",
+    "build_date" : "2017-02-09T22:05:32.386Z",
     "build_snapshot" : false,
-    "lucene_version" : "6.1.0"
+    "lucene_version" : "6.4.1"
   },
   "tagline" : "You Know, for Search"
 }

--- a/metricbeat/docs/gettingstarted.asciidoc
+++ b/metricbeat/docs/gettingstarted.asciidoc
@@ -112,7 +112,9 @@ For more information about these options, see
 
 To configure Metricbeat, you edit the configuration file. For rpm and deb,
 you'll find the configuration file at `/etc/metricbeat/metricbeat.yml`. For mac
-and win, look in the archive that you just extracted.
+and win, look in the archive that you just extracted. There’s also a full
+example configuration file called `metricbeat.full.yml` that shows all
+non-deprecated options.
 
 Metricbeat uses <<metricbeat-modules,modules>> to collect metrics. You configure
 each module individually. The following example shows the default configuration
@@ -190,7 +192,11 @@ include::../../libbeat/docs/shared-template-load.asciidoc[]
 [[metricbeat-starting]]
 === Step 4: Starting Metricbeat
 
-Run Metricbeat by issuing the following command:
+Run Metricbeat by issuing the appropriate command for your platform.
+
+NOTE: If you use an init.d script to start Metricbeat on deb or rpm, you can't
+specify command line flags (see <<command-line-options>>). To specify flags,
+start Metricbeat in the foreground.
 
 *deb:*
 

--- a/packetbeat/docs/gettingstarted.asciidoc
+++ b/packetbeat/docs/gettingstarted.asciidoc
@@ -100,7 +100,8 @@ more information about these options, see <<packetbeat-configuration>>.
 
 To configure Packetbeat, you edit the configuration file. For rpm and deb, you'll
 find the configuration file at `/etc/packetbeat/packetbeat.yml`. For mac and win, look in
-the archive that you just extracted.
+the archive that you just extracted. There’s also a full example configuration file called
+`packetbeat.full.yml` that shows all non-deprecated options.
 
 To configure Packetbeat:
 
@@ -204,7 +205,11 @@ include::../../libbeat/docs/shared-template-load.asciidoc[]
 [[packetbeat-starting]]
 === Step 4: Starting Packetbeat
 
-Run Packetbeat by issuing the following command:
+Run Packetbeat by issuing the command that is appropriate for your platform.
+
+NOTE: If you use an init.d script to start Packetbeat on deb or rpm, you can't
+specify command line flags (see <<packetbeat-command>>). To specify flags,
+start Packetbeat in the foreground.
 
 *deb:*
 

--- a/winlogbeat/docs/getting-started.asciidoc
+++ b/winlogbeat/docs/getting-started.asciidoc
@@ -57,7 +57,9 @@ execution policy for the current session to allow the script to run. For example
 
 Before starting Winlogbeat, you should look at the configuration options in the
 configuration file, for example `C:\Program Files\Winlogbeat\winlogbeat.yml`.
-For more information about these options, see <<winlogbeat-configuration-details>>.
+There’s also a full example configuration file called `winlogbeat.full.yml` that
+shows all non-deprecated options. For more information about these options, see
+<<winlogbeat-configuration-details>>.
 
 [[winlogbeat-configuration]]
 === Step 2: Configuring Winlogbeat


### PR DESCRIPTION
Some minor improvements plus a couple of fixes that resolve the the getting started doc issues tracked in https://github.com/elastic/beats/issues/3539

- indicate the purpose of the full.yml file
- update example response returned by `curl http://127.0.0.1:9200`
- show command for importing Filebeat index pattern in the GS (why make users go to another file for one command, right?)
- mention that command line flags aren't available when you use init.d script (to my surprise, some users were confused by this, so it's better to be explicit)