### PR TITLE
Make topic about installing from repositories shared

### DIFF
--- a/filebeat/docs/getting-started.asciidoc
+++ b/filebeat/docs/getting-started.asciidoc
@@ -30,7 +30,7 @@ mac>> for OS X, and <<win, win>> for Windows).
 
 [NOTE]
 ==================================================
-If you use Apt or Yum, you can {libbeat}/setup-repositories.html[install Filebeat from our repositories] to update to the newest version more easily.
+If you use Apt or Yum, you can <<setup-repositories,install Filebeat from our repositories>> to update to the newest version more easily.
 
 See our https://www.elastic.co/downloads/beats/filebeat[download page] for other installation options, such as 32-bit images.
 

--- a/filebeat/docs/index.asciidoc
+++ b/filebeat/docs/index.asciidoc
@@ -22,6 +22,8 @@ include::./command-line.asciidoc[]
 
 include::../../libbeat/docs/shared-directory-layout.asciidoc[]
 
+include::../../libbeat/docs/repositories.asciidoc[]
+
 include::./upgrading.asciidoc[]
 
 include::./how-filebeat-works.asciidoc[]

--- a/heartbeat/docs/getting-started.asciidoc
+++ b/heartbeat/docs/getting-started.asciidoc
@@ -38,7 +38,7 @@ system (<<deb, deb>> for Debian/Ubuntu, <<rpm, rpm>> for Redhat/Centos/Fedora,
 
 [NOTE]
 ==================================================
-If you use Apt or Yum, you can {libbeat}/setup-repositories.html[install Heartbeat from our repositories] to update to the newest version more easily.
+If you use Apt or Yum, you can <<setup-repositories,install Heartbeat from our repositories>> to update to the newest version more easily.
 
 See our https://www.elastic.co/downloads/beats/heartbeat[download page] for other installation options, such as 32-bit images.
 

--- a/heartbeat/docs/index.asciidoc
+++ b/heartbeat/docs/index.asciidoc
@@ -23,6 +23,8 @@ include::./command-line.asciidoc[]
 
 include::../../libbeat/docs/shared-directory-layout.asciidoc[]
 
+include::../../libbeat/docs/repositories.asciidoc[]
+
 //
 //include::./upgrading.asciidoc[]
 

--- a/libbeat/docs/index.asciidoc
+++ b/libbeat/docs/index.asciidoc
@@ -9,6 +9,8 @@ include::./version.asciidoc[]
 :winlogbeat: http://www.elastic.co/guide/en/beats/winlogbeat/{doc-branch}
 :heartbeat: http://www.elastic.co/guide/en/beats/heartbeat/{doc-branch}
 :securitydoc: https://www.elastic.co/guide/en/x-pack/5.2
+:beatname_lc: beatname
+:beatname_uc: a Beat
 :security: X-Pack Security
 :ES-version: {stack-version}
 :LS-version: {stack-version}

--- a/libbeat/docs/repositories.asciidoc
+++ b/libbeat/docs/repositories.asciidoc
@@ -1,3 +1,14 @@
+//////////////////////////////////////////////////////////////////////////
+//// This content is shared by all Elastic Beats. Make sure you keep the
+//// descriptions here generic enough to work for all Beats that include
+//// this file. When using cross references, make sure that the cross
+//// references resolve correctly for any files that include this one.
+//// Use the appropriate variables defined in the index.asciidoc file to
+//// resolve Beat names: beatname_uc and beatname_lc.
+//// Use the following include to pull this content into a doc file:
+//// include::../../libbeat/docs/setup-repositories.asciidoc[]
+//////////////////////////////////////////////////////////////////////////
+
 [[setup-repositories]]
 === Repositories for APT and YUM
 
@@ -52,18 +63,18 @@ Simply delete the `deb-src` entry from the `/etc/apt/sources.list` file, and the
 ==================================================
 
 . Run `apt-get update`, and the repository is ready for use. For example, you can
-install Filebeat by running:
+install {beatname_uc} by running:
 +
-[source,sh]
+["source","sh",subs="attributes"]
 --------------------------------------------------
-sudo apt-get update && sudo apt-get install filebeat
+sudo apt-get update && sudo apt-get install {beatname_lc}
 --------------------------------------------------
 
-. To configure the beat to start automatically during boot, run:
+. To configure the Beat to start automatically during boot, run:
 +
-[source,sh]
+["source","sh",subs="attributes"]
 --------------------------------------------------
-sudo update-rc.d filebeat defaults 95 10
+sudo update-rc.d {beatname_lc} defaults 95 10
 --------------------------------------------------
 
 [float]
@@ -93,17 +104,17 @@ autorefresh=1
 type=rpm-md
 --------------------------------------------------
 +
-Your repository is ready to use. For example, you can install Filebeat by
+Your repository is ready to use. For example, you can install {beatname_uc} by
 running:
 +
-[source,sh]
+["source","sh",subs="attributes"]
 --------------------------------------------------
-sudo yum install filebeat
+sudo yum install {beatname_lc}
 --------------------------------------------------
 
-. To configure the beat to start automatically during boot, run:
+. To configure the Beat to start automatically during boot, run:
 +
-[source,sh]
+["source","sh",subs="attributes"]
 --------------------------------------------------
-sudo chkconfig --add filebeat
+sudo chkconfig --add {beatname_lc}
 --------------------------------------------------

--- a/metricbeat/docs/gettingstarted.asciidoc
+++ b/metricbeat/docs/gettingstarted.asciidoc
@@ -41,7 +41,7 @@ mac>> for OS X, and <<win, win>> for Windows).
 [NOTE]
 ==================================================
 If you use Apt or Yum, you can
-{libbeat}/setup-repositories.html[install Metricbeat from our repositories] to
+<<setup-repositories,install Metricbeat from our repositories>> to
 update to the newest version more easily.
 
 See our https://www.elastic.co/downloads/beats/metricbeat[download page] for

--- a/metricbeat/docs/index.asciidoc
+++ b/metricbeat/docs/index.asciidoc
@@ -19,6 +19,8 @@ include::./command-line.asciidoc[]
 
 include::../../libbeat/docs/shared-directory-layout.asciidoc[]
 
+include::../../libbeat/docs/repositories.asciidoc[]
+
 include::./upgrading.asciidoc[]
 
 include::./how-metricbeat-works.asciidoc[]

--- a/packetbeat/docs/gettingstarted.asciidoc
+++ b/packetbeat/docs/gettingstarted.asciidoc
@@ -31,7 +31,7 @@ Redhat/Centos/Fedora, <<mac, mac>> for OS X, and <<win, win>> for Windows).
 
 [NOTE]
 ==================================================
-If you use Apt or Yum, you can {libbeat}/setup-repositories.html[install Packetbeat from our repositories] to update to the newest version more easily.
+If you use Apt or Yum, you can <<setup-repositories,install Packetbeat from our repositories>> to update to the newest version more easily.
 
 See our https://www.elastic.co/downloads/beats/packetbeat[download page] for other installation options, such as 32-bit images.
 ==================================================

--- a/packetbeat/docs/index.asciidoc
+++ b/packetbeat/docs/index.asciidoc
@@ -26,6 +26,8 @@ include::./command-line.asciidoc[]
 
 include::../../libbeat/docs/shared-directory-layout.asciidoc[]
 
+include::../../libbeat/docs/repositories.asciidoc[]
+
 include::./upgrading.asciidoc[]
 
 include::./configuring-howto.asciidoc[]


### PR DESCRIPTION
This PR makes the content about installing from repositories shared so that the content appears in the all the Beats guides (except Winlogbeat).

This PR is meant to clear up the confusion for users who are reading the getting started content and follow the link that takes them to the platform reference where the doc mentions Filebeat. See https://github.com/elastic/beats/issues/2425.

I've kept the topic in the platform reference (but set the beatname variables so that the content is more generic) because IMO there is some value in keeping that content in the platform reference. 

Right now the product pages point to the topic in the platform reference. We need to decide if we'd rather have the product pages link to the topics in the individual guides. WDYT?