### PR TITLE
Change php-fpm docker image tag to 1.1.2

### DIFF
--- a/metricbeat/module/php_fpm/_meta/Dockerfile
+++ b/metricbeat/module/php_fpm/_meta/Dockerfile
@@ -1,4 +1,4 @@
-FROM richarvey/nginx-php-fpm:php71
+FROM richarvey/nginx-php-fpm:1.1.2
 
 RUN echo "pm.status_path = /status" >> /usr/local/etc/php-fpm.d/www.conf
 ADD ./php-fpm.conf /etc/nginx/sites-enabled


### PR DESCRIPTION
Previously there was a tag 7.1. This was now removed and instead new tags were added.