### PR TITLE
Persist beat UUID

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -66,6 +66,7 @@ https://github.com/elastic/beats/compare/v5.1.1...master[Check the HEAD diff]
 - Add the option to load the sample dashboards during the Beat startup phase. {pull}3506[3506]
 - Disabled date detection in Elasticsearch index templates. Date fields must be explicitly defined in index templates. {pull}3528[3528]
 - Using environment variables in the configuration file is now GA, instead of experimental. {pull}3525[3525]
+- Initialize a beats UUID from file on startup. {pull}3615[3615]
 
 *Filebeat*
 

--- a/libbeat/tests/system/test_base.py
+++ b/libbeat/tests/system/test_base.py
@@ -1,5 +1,6 @@
 from base import BaseTest
 
+import json
 import os
 import shutil
 import subprocess
@@ -160,3 +161,35 @@ class Test(BaseTest):
         self.wait_until(
             lambda: self.log_contains("Total non-zero values:"),
             max_timeout=2)
+
+    def test_persistent_uuid(self):
+        self.render_config_template()
+
+        # run starts and kills the beat, reading the meta file while
+        # the beat is alive
+        def run():
+            proc = self.start_beat(extra_args=["-path.home", self.working_dir])
+            self.wait_until(lambda: self.log_contains("Mockbeat is alive"),
+                            max_timeout=2)
+
+            # open meta file before killing the beat, checking the file being
+            # available right after startup
+            metaFile = os.path.join(self.working_dir, "data", "meta.json")
+            with open(metaFile) as f:
+                meta = json.loads(f.read())
+
+            proc.check_kill_and_wait()
+            return meta
+
+        meta0 = run()
+        assert self.log_contains("Beat UUID: {}".format(meta0["uuid"]))
+
+        # remove log, restart beat and check meta file did not change
+        # and same UUID is used in log output.
+
+        os.remove(os.path.join(self.working_dir, "mockbeat.log"))
+        meta1 = run()
+        assert self.log_contains("Beat UUID: {}".format(meta1["uuid"]))
+
+        # check meta file did not change between restarts
+        assert meta0 == meta1


### PR DESCRIPTION
read/write file ${path.data}/meta.json including UUID (json document) upon
startup to persist a beats generated UUID among multiple restarts.