### PR TITLE
Fix missing BABEL_CACHE_PATH by hardcoding it

### DIFF
--- a/testing/environments/docker/kibana/Dockerfile-snapshot
+++ b/testing/environments/docker/kibana/Dockerfile-snapshot
@@ -24,5 +24,6 @@ ADD bin/kibana-docker /usr/local/bin/
 
 RUN usermod --home /usr/share/kibana kibana
 USER kibana
+ENV BABEL_CACHE_PATH /usr/share/kibana/optimize/.babelcache.json
 ENV PATH=/usr/share/kibana/bin:$PATH
 CMD /usr/local/bin/kibana-docker


### PR DESCRIPTION
This can be reverted as soon as https://github.com/elastic/kibana/issues/10430 is closed.