### PR TITLE
add h.file.Close()

### DIFF
--- a/filebeat/harvester/log.go
+++ b/filebeat/harvester/log.go
@@ -117,6 +117,9 @@ func (h *Harvester) Harvest(r reader.Reader) {
 			default:
 				logp.Err("Read line error: %s; File: ", err, h.state.Source)
 			}
+			if h.file != nil {
+				h.file.Close()
+			}
 			return
 		}
 


### PR DESCRIPTION
It generate many file handles when h.file.Close()  not exist.
Test method: 
1、change filebeat.yml 
Add 
filebeat.prospectors:
- input_type: log
  paths:
    - "/tmp/x.out"
  document_type: stderr

2、run filebeat(hasn't /tmp/x.out)
3、generate a file /tmp/x.out(recommend file size > 5MB)
4、you can use lsof cmd for check file handle, and you will found /tmp/x.out
5、remove  /tmp/x.out  when you found /tmp/x.out by lsof cmd, and you will found /tmp/x.out (deleted)
6、even if read the file /tmp/x.out finished , the file handle not release, and add  h.file.Close()  will resolve it