### PR TITLE
Add local timestamp to event

### DIFF
--- a/winlogbeat/eventlog/eventlog.go
+++ b/winlogbeat/eventlog/eventlog.go
@@ -10,6 +10,7 @@ import (
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/winlogbeat/sys"
+	"time"
 )
 
 // Debug selectors used in this package.
@@ -64,6 +65,7 @@ func (e Record) ToMapStr() common.MapStr {
 		"type":                  e.API,
 		common.EventMetadataKey: e.EventMetadata,
 		"@timestamp":            common.Time(e.TimeCreated.SystemTime),
+		"@localtimestamp":       e.TimeCreated.SystemTime.In(time.Local),
 		"log_name":              e.Channel,
 		"source_name":           e.Provider.Name,
 		"computer_name":         e.Computer,


### PR DESCRIPTION
Hi!
I want to add a tiny change to the wineventlog. 
Currently only the UTC time (which is saved in the event xml) is included in the event. 
It is very useful to also get the event time in the local timezone of the computer.
This is the same behavior as the Windows Event Viewer (shows the event local time).

![image](https://cloud.githubusercontent.com/assets/2358365/23126763/f42b4364-f780-11e6-952f-dc5cc16804ea.png)
