### PR TITLE
Fix GH username in case it is diffrerent from the remote

### DIFF
--- a/dev-tools/cherrypick_pr
+++ b/dev-tools/cherrypick_pr
@@ -5,6 +5,7 @@ import argparse
 from os.path import expanduser
 from subprocess import check_call, call, check_output
 import requests
+import re
 
 """
 Example usage:
@@ -110,11 +111,15 @@ def main():
 
         original_pr = s.get(base+"/pulls/"+args.pr_number).json()
 
+        # get the github username from the remote where we pushed
+        remote_url = check_output("git remote get-url {}".format(remote))
+        remote_user = re.search("github.com:(.+)/beats", remote_url).group(1)
+
         # create PR
         r = s.post(base+"/pulls", json=dict(
             title="Cherry-pick to {}: {}"
                   .format(args.to_branch, original_pr["title"]),
-            head=remote + ":" + tmp_branch,
+            head=remote_user + ":" + tmp_branch,
             base=args.to_branch,
             body="Cherry-pick of PR #{} to {} branch. Original message: \n\n{}"
                  .format(args.pr_number, args.to_branch, original_pr["body"])


### PR DESCRIPTION
So far it was assuming that the remote name and the GH username where the branch is pushed is the same. This calls `git remote get-url` and then extracts it from there, to avoid asking the user for another parameter.