### PR TITLE
Make packetbeat and filebeat better compatible with community beats

### DIFF
--- a/filebeat/Makefile
+++ b/filebeat/Makefile
@@ -2,11 +2,12 @@
 
 BEAT_NAME?=filebeat
 BEAT_DESCRIPTION?=Filebeat sends log files to Logstash or directly to Elasticsearch.
-SYSTEM_TESTS=true
+SYSTEM_TESTS?=true
 TEST_ENVIRONMENT?=true
 GOX_FLAGS=-arch="amd64 386 arm ppc64 ppc64le"
+ES_BEATS?=..
 
-include ../libbeat/scripts/Makefile
+include ${ES_BEATS}/libbeat/scripts/Makefile
 
 # This is called by the beats packer before building starts
 .PHONY: before-build

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -245,6 +245,7 @@ update: python-env collect
 	$(MAKE) -C ${ES_BEATS}/libbeat fields
 
 	# Update docs
+	mkdir -p docs
 	. ${PYTHON_ENV}/bin/activate && python ${ES_BEATS}/libbeat/scripts/generate_fields_docs.py $(PWD) ${BEAT_NAME} ${ES_BEATS}
 
 	# Generate index templates

--- a/metricbeat/Makefile
+++ b/metricbeat/Makefile
@@ -3,7 +3,7 @@
 # Name can be overwritten, as Metricbeat is also a library
 BEAT_NAME?=metricbeat
 BEAT_DESCRIPTION?=Metricbeat sends metrics to Elasticsearch.
-SYSTEM_TESTS=true
+SYSTEM_TESTS?=true
 TEST_ENVIRONMENT?=true
 GOPACKAGES=$(shell go list ${BEAT_PATH}/... | grep -v /vendor/)
 ES_BEATS?=..

--- a/packetbeat/Makefile
+++ b/packetbeat/Makefile
@@ -1,13 +1,14 @@
 
 BEAT_NAME?=packetbeat
 BEAT_DESCRIPTION?=Packetbeat analyzes network traffic and sends the data to Elasticsearch.
-SYSTEM_TESTS=true
+SYSTEM_TESTS?=true
 TEST_ENVIRONMENT=false
 TARGETS="windows/amd64 windows/386 darwin/amd64"
 TARGETS_OLD="linux/amd64 linux/386"
 CGO=true
+ES_BEATS?=..
 
-include ../libbeat/scripts/Makefile
+include ${ES_BEATS}/libbeat/scripts/Makefile
 
 .PHONY: with_pfring
 with_pfring:
@@ -32,8 +33,9 @@ collect: fields imports
 
 .PHONY: fields
 fields:
-	cat _meta/fields_base.yml > _meta/fields.yml
-	cat protos/*/_meta/fields.yml >> _meta/fields.yml
+	mkdir -p _meta
+	cat ${ES_BEATS}/packetbeat/_meta/fields_base.yml > _meta/fields.yml
+	-cat protos/*/_meta/fields.yml >> _meta/fields.yml
 
 .PHONY: benchmark
 benchmark:
@@ -41,10 +43,11 @@ benchmark:
 
 .PHONY: create-tcp-protocol
 create-tcp-protocol:
-	python scripts/create_tcp_protocol.py
+	python ${ES_BEATS}/packetbeat/scripts/create_tcp_protocol.py
 
 # Generates imports for all modules and metricsets
 .PHONY: imports
 imports:
 	mkdir -p include
+	mkdir -p protos
 	python ${ES_BEATS}/packetbeat/scripts/generate_imports.py ${BEAT_PATH} > include/list.go


### PR DESCRIPTION
Packetbeat and filebeat can be extended through protocols / modules. This requires both to be used as library if they are extended in their own beat. This is a first step to make it better compatible with this by adjusting import paths to depend on ES_BEATS.