### PR TITLE
Cherry-pick to 5.3: Remove duplicate include in the docs

### DIFF
--- a/filebeat/docs/index.asciidoc
+++ b/filebeat/docs/index.asciidoc
@@ -24,8 +24,6 @@ include::../../libbeat/docs/shared-directory-layout.asciidoc[]
 
 include::../../libbeat/docs/repositories.asciidoc[]
 
-include::./modules.asciidoc[]
-
 include::./upgrading.asciidoc[]
 
 include::./how-filebeat-works.asciidoc[]


### PR DESCRIPTION
Cherry-pick of PR #3636 to 5.3 branch. Original message: 

This was breaking the docs build, because the file was included twice. Probably
happened on merge/rebase.