### PR TITLE
Report cwd

### DIFF
--- a/metricbeat/docs/fields.asciidoc
+++ b/metricbeat/docs/fields.asciidoc
@@ -5698,6 +5698,14 @@ The username of the user that created the process. If the username cannot be det
 
 
 [float]
+=== system.process.cwd
+
+type: keyword
+
+The current working directory of the process.
+
+
+[float]
 == cpu Fields
 
 CPU-specific statistics per process.

--- a/metricbeat/metricbeat.template-es2x.json
+++ b/metricbeat/metricbeat.template-es2x.json
@@ -3551,6 +3551,11 @@
                     }
                   }
                 },
+                "cwd": {
+                  "ignore_above": 1024,
+                  "index": "not_analyzed",
+                  "type": "string"
+                },
                 "fd": {
                   "properties": {
                     "limit": {

--- a/metricbeat/metricbeat.template.json
+++ b/metricbeat/metricbeat.template.json
@@ -3526,6 +3526,10 @@
                     }
                   }
                 },
+                "cwd": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "fd": {
                   "properties": {
                     "limit": {

--- a/metricbeat/module/system/process/_meta/fields.yml
+++ b/metricbeat/module/system/process/_meta/fields.yml
@@ -35,6 +35,10 @@
         cannot be determined, the field will contain the user's
         numeric identifier (UID). On Windows, this field includes the user's
         domain and is formatted as `domain\username`.
+    - name: cwd
+      type: keyword
+      description: >
+        The current working directory of the process.
     - name: cpu
       type: group
       prefix: "[float]"

--- a/metricbeat/module/system/process/helper.go
+++ b/metricbeat/module/system/process/helper.go
@@ -49,6 +49,11 @@ func newProcess(pid int) (*Process, error) {
 		return nil, fmt.Errorf("error getting process state for pid=%d: %v", pid, err)
 	}
 
+	exe := sigar.ProcExe{}
+	if err := exe.Get(pid); err != nil {
+		return nil, fmt.Errorf("error getting process exe for pid=%d: %v", pid, err)
+	}
+
 	proc := Process{
 		Pid:      pid,
 		Ppid:     state.Ppid,
@@ -57,6 +62,7 @@ func newProcess(pid int) (*Process, error) {
 		State:    getProcState(byte(state.State)),
 		Username: state.Username,
 		Ctime:    time.Now(),
+		Cwd:      exe.Cwd,
 	}
 
 	return &proc, nil
@@ -181,6 +187,7 @@ func (procStats *ProcStats) GetProcessEvent(process *Process, last *Process) com
 			},
 			"share": process.Mem.Share,
 		},
+		"cwd":      process.Cwd,
 	}
 
 	if process.CmdLine != "" {

--- a/metricbeat/module/system/process/helper.go
+++ b/metricbeat/module/system/process/helper.go
@@ -31,6 +31,7 @@ type Process struct {
 	Cpu      sigar.ProcTime
 	Ctime    time.Time
 	FD       sigar.ProcFDUsage
+	Cwd      string `json:"cwd"`
 }
 
 type ProcStats struct {

--- a/metricbeat/module/system/process/helper.go
+++ b/metricbeat/module/system/process/helper.go
@@ -179,6 +179,7 @@ func (procStats *ProcStats) GetProcessEvent(process *Process, last *Process) com
 		"name":     process.Name,
 		"state":    process.State,
 		"username": process.Username,
+		"cwd":      process.Cwd,
 		"memory": common.MapStr{
 			"size": process.Mem.Size,
 			"rss": common.MapStr{
@@ -187,7 +188,6 @@ func (procStats *ProcStats) GetProcessEvent(process *Process, last *Process) com
 			},
 			"share": process.Mem.Share,
 		},
-		"cwd":      process.Cwd,
 	}
 
 	if process.CmdLine != "" {

--- a/metricbeat/module/system/process/helper_test.go
+++ b/metricbeat/module/system/process/helper_test.go
@@ -40,6 +40,7 @@ func TestGetProcess(t *testing.T) {
 		assert.True(t, (process.Ppid >= 0))
 		assert.True(t, (process.Pgid >= 0))
 		assert.True(t, (len(process.Name) > 0))
+		assert.True(t, (len(process.Cwd) > 0))
 		assert.True(t, (len(process.Username) > 0))
 		assert.NotEqual(t, "unknown", process.State)
 

--- a/metricbeat/module/system/process/helper_test.go
+++ b/metricbeat/module/system/process/helper_test.go
@@ -4,6 +4,7 @@
 package process
 
 import (
+	"runtime"
 	"testing"
 	"time"
 
@@ -40,7 +41,10 @@ func TestGetProcess(t *testing.T) {
 		assert.True(t, (process.Ppid >= 0))
 		assert.True(t, (process.Pgid >= 0))
 		assert.True(t, (len(process.Name) > 0))
-		assert.True(t, (len(process.Cwd) > 0))
+		switch runtime.GOOS {
+		case "linux":
+			assert.True(t, (len(process.Cwd) > 0))
+		}
 		assert.True(t, (len(process.Username) > 0))
 		assert.NotEqual(t, "unknown", process.State)
 

--- a/metricbeat/tests/system/test_system.py
+++ b/metricbeat/tests/system/test_system.py
@@ -38,7 +38,7 @@ SYSTEM_NETWORK_FIELDS = ["name", "out.bytes", "in.bytes", "out.packets",
 # for some kernel level processes. fd is also part of the system process, but
 # is not available on all OSes and requires root to read for all processes.
 SYSTEM_PROCESS_FIELDS = ["cpu", "memory", "name", "pid", "ppid", "pgid",
-                         "state", "username"]
+                         "state", "username", "cwd"]
 
 
 class SystemTest(metricbeat.BaseTest):


### PR DESCRIPTION
I need metricbeat's system process metricset to report current working directory (cwd).

It was straightforward to use gosigar's ProcExe, at least for linux. I had to skip the test on darwin since gosigar doesn't get cwd, and libproc.h is not a public interface anyway. I have not checked freebsd and windows.
