### PR TITLE
Fix permissions on module files

### DIFF
--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -330,6 +330,7 @@ install-home:
 	if [ -d _meta/module.generated ]; then \
 		install -d -m 755 ${HOME_PREFIX}/module; \
 		rsync -av _meta/module.generated/ ${HOME_PREFIX}/module/; \
+		chmod -R go-w _meta/module.generated; \
 	fi
 
 # Prepares for packaging. Builds binaries and creates homedir data

--- a/libbeat/tests/system/beat/beat.py
+++ b/libbeat/tests/system/beat/beat.py
@@ -102,8 +102,6 @@ class TestCase(unittest.TestCase):
     @classmethod
     def setUpClass(self):
 
-
-
         # Path to test binary
         if not hasattr(self, 'beat_name'):
             self.beat_name = "beat"


### PR DESCRIPTION
They contain configuration files, so they shouldn't be group writable,
which was the case before this patch.

Fixes #3644.