### PR TITLE
Cherry-pick to 5.3: Fix permissions on module files

### DIFF
--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -327,6 +327,7 @@ install-home:
 	if [ -d _meta/module.generated ]; then \
 		install -d -m 755 ${HOME_PREFIX}/module; \
 		rsync -av _meta/module.generated/ ${HOME_PREFIX}/module/; \
+		chmod -R go-w _meta/module.generated; \
 	fi
 
 # Prepares for packaging. Builds binaries and creates homedir data


### PR DESCRIPTION
Cherry-pick of PR #3645 to 5.3 branch. Original message: 

They contain configuration files, so they shouldn't be group writable,
which was the case before this patch.

Fixes #3644.