### PR TITLE
Set default ES port in Logstash docker-entrypoint

### DIFF
--- a/testing/environments/2x.yml
+++ b/testing/environments/2x.yml
@@ -17,6 +17,8 @@ services:
       dockerfile: Dockerfile-2x
       args:
         LOGSTASH_VERSION: 2.4.1
+    environment:
+      - ES_HOST=elasticsearch
 
   kibana:
     build:

--- a/testing/environments/docker/logstash/docker-entrypoint.sh
+++ b/testing/environments/docker/logstash/docker-entrypoint.sh
@@ -64,6 +64,7 @@ updateConfigFile() {
 
 # Main
 
+readParams
 updateConfigFile
 waitForElasticsearch
 exec "$@"


### PR DESCRIPTION
There was a missing call to readParams which sets a default value for the ES_PORT if it’s not set. If you ran `make up` in testing/environments, Logstash would fail to start.