### PR TITLE
Rename object-type to object_type

### DIFF
--- a/libbeat/_meta/fields.common.yml
+++ b/libbeat/_meta/fields.common.yml
@@ -34,7 +34,7 @@
 
     - name: fields
       type: object
-      object-type: keyword
+      object_type: keyword
       description: >
         Contains user configurable fields.
 

--- a/libbeat/scripts/generate_template.py
+++ b/libbeat/scripts/generate_template.py
@@ -258,7 +258,7 @@ def fill_field_properties(args, field, defaults, path):
         }
 
     elif field["type"] in ["object"]:
-        if field.get("object-type") == "text":
+        if field.get("object_type") == "text":
             # add a dynamic template to set all members of
             # the object as text
             if len(path) > 0:
@@ -288,7 +288,7 @@ def fill_field_properties(args, field, defaults, path):
                     }
                 })
 
-        if field.get("object-type") == "long":
+        if field.get("object_type") == "long":
             if len(path) > 0:
                 name = path + "." + field["name"]
             else:

--- a/metricbeat/module/docker/container/_meta/fields.yml
+++ b/metricbeat/module/docker/container/_meta/fields.yml
@@ -42,7 +42,7 @@
              Size of the files that have been created or changed since creation.
     - name: labels
       type: object
-      object-type: keyword
+      object_type: keyword
       description: >
         Image labels.
     - name: tags

--- a/metricbeat/module/docker/image/_meta/fields.yml
+++ b/metricbeat/module/docker/image/_meta/fields.yml
@@ -36,7 +36,7 @@
 
     - name: labels
       type: object
-      object-type: keyword
+      object_type: keyword
       description: >
         Image labels.
 

--- a/metricbeat/module/system/process/_meta/fields.yml
+++ b/metricbeat/module/system/process/_meta/fields.yml
@@ -37,7 +37,7 @@
         domain and is formatted as `domain\username`.
     - name: env
       type: object
-      object-type: keyword
+      object_type: keyword
       description: >
         The environment variables used to start the process. The data is
         available on FreeBSD, Linux, and OS X.
@@ -236,7 +236,7 @@
 
             - name: percpu
               type: object
-              object-type: long
+              object_type: long
               description: >
                 CPU time (in nanoseconds) consumed on each CPU by all tasks in
                 this cgroup.

--- a/packetbeat/_meta/fields.yml
+++ b/packetbeat/_meta/fields.yml
@@ -597,7 +597,7 @@
 
         - name: headers
           type: object
-          object-type: keyword
+          object_type: keyword
           description: >
             Message header field table.
 
@@ -829,7 +829,7 @@
 
             - name: supported
               type: object
-              object-type: keyword
+              object_type: keyword
               description:  Indicates which startup options are supported by the server. This message comes as a response to an OPTIONS message.
 
             - name: authentication
@@ -1177,7 +1177,7 @@
                 and the form values are set in the HTTP body when the content-type is set to `x-www-form-urlencoded`.
             - name: headers
               type: object
-              object-type: keyword
+              object_type: keyword
               description: >
                 A map containing the captured header fields from the request.
                 Which headers to capture is configurable. If headers with the same
@@ -1201,7 +1201,7 @@
 
             - name: headers
               type: object
-              object-type: keyword
+              object_type: keyword
               description: >
                 A map containing the captured header fields from the response.
                 Which headers to capture is configurable. If headers with the

--- a/packetbeat/protos/amqp/_meta/fields.yml
+++ b/packetbeat/protos/amqp/_meta/fields.yml
@@ -153,7 +153,7 @@
 
         - name: headers
           type: object
-          object-type: keyword
+          object_type: keyword
           description: >
             Message header field table.
 

--- a/packetbeat/protos/cassandra/_meta/fields.yml
+++ b/packetbeat/protos/cassandra/_meta/fields.yml
@@ -176,7 +176,7 @@
 
             - name: supported
               type: object
-              object-type: keyword
+              object_type: keyword
               description:  Indicates which startup options are supported by the server. This message comes as a response to an OPTIONS message.
 
             - name: authentication

--- a/packetbeat/protos/http/_meta/fields.yml
+++ b/packetbeat/protos/http/_meta/fields.yml
@@ -16,7 +16,7 @@
                 and the form values are set in the HTTP body when the content-type is set to `x-www-form-urlencoded`.
             - name: headers
               type: object
-              object-type: keyword
+              object_type: keyword
               description: >
                 A map containing the captured header fields from the request.
                 Which headers to capture is configurable. If headers with the same
@@ -40,7 +40,7 @@
 
             - name: headers
               type: object
-              object-type: keyword
+              object_type: keyword
               description: >
                 A map containing the captured header fields from the response.
                 Which headers to capture is configurable. If headers with the

--- a/winlogbeat/_meta/fields.yml
+++ b/winlogbeat/_meta/fields.yml
@@ -39,7 +39,7 @@
 
     - name: event_data
       type: object
-      object-type: keyword
+      object_type: keyword
       required: false
       description: >
         The event-specific data. This field is mutually exclusive with
@@ -151,7 +151,7 @@
 
     - name: user_data
       type: object
-      object-type: keyword
+      object_type: keyword
       required: false
       description: >
         The event specific data. This field is mutually exclusive with


### PR DESCRIPTION
This brings the naming in line with all the other keys.

Part of https://github.com/elastic/beats/issues/3654