### PR TITLE
Increase priority of the 6.0 template to overwrite the 5.x settings

### DIFF
--- a/metricbeat/metricbeat.template.json
+++ b/metricbeat/metricbeat.template.json
@@ -4123,7 +4123,7 @@
       }
     }
   },
-  "order": 0,
+  "order": 1,
   "settings": {
     "index.mapping.total_fields.limit": 10000,
     "index.refresh_interval": "5s"


### PR DESCRIPTION
As of https://github.com/elastic/beats/pull/3527, Beat versioning is added in the index template by default: 
```
beatname-%{[beat.version]}-%{+yyyy.MM.dd}
```

Notes:
1. If two Beats are running of different versions (5.x and 6.0) or we upgrade from 5.x to 6.0, then there are:
indexes: `beatname-*` and `beatname-6.0.0-*` 
`beatname` template that applies to all `beatname-*` indexes
`beatname-6.0.0` template that applies to `beatname-6.0.0-*` indexes.
As a result, the `beatname` template applies for `beatname-6.0.0-*` indexes as well, so we need to set a   higher priority to the `beatname-6.0.0` template to overwrite the settings in 5.x. 


2. The difference between the template used after upgrading 5.x to 6.0 (master) and the template after a fresh 6.0 (master) installation is the following:

```
 diff metricbeat-6.0.0-alpha1-2017.02.23-without-upgrade metricbeat-6.0.0-alpha1-2017.02.23
8a9,11
>         "_all": {
>           "norms": false
>         },
4130a4134,4136
>         "_all": {
>           "norms": false
>         },
8260c8266
<         "creation_date": "1487849241372",
---
>         "creation_date": "1487848996929",
8262c8268
<         "uuid": "jYJf-6BJTLST07ZpN8TwMA",
---
>         "uuid": "tv36cO3QQKije38f_xtw_g",
```
