### PR TITLE
Fix dashboards config naming

### DIFF
--- a/filebeat/filebeat.full.yml
+++ b/filebeat/filebeat.full.yml
@@ -920,16 +920,16 @@ output.elasticsearch:
 #dashboards.file:
 
 # If this option is enabled, the snapshot URL is used instead of the default URL.
-#dashboard.snapshot: false
+#dashboards.snapshot: false
 
 # The URL from where to download the snapshot version of the dashboards. By default
 # this has a value which is computed based on the Beat name and version.
-#dashboard.snapshot_url
+#dashboards.snapshot_url
 
 # In case the archive contains the dashboards from multiple Beats, this lets you
 # select which one to load. You can load all the dashboards in the archive by
 # setting this to the empty string.
-#dashboard.beat: filebeat
+#dashboards.beat: filebeat
 
 # The name of the Kibana index to use for setting the configuration. Default is ".kibana"
 #dashboards.kibana_index: .kibana

--- a/heartbeat/heartbeat.full.yml
+++ b/heartbeat/heartbeat.full.yml
@@ -768,16 +768,16 @@ output.elasticsearch:
 #dashboards.file:
 
 # If this option is enabled, the snapshot URL is used instead of the default URL.
-#dashboard.snapshot: false
+#dashboards.snapshot: false
 
 # The URL from where to download the snapshot version of the dashboards. By default
 # this has a value which is computed based on the Beat name and version.
-#dashboard.snapshot_url
+#dashboards.snapshot_url
 
 # In case the archive contains the dashboards from multiple Beats, this lets you
 # select which one to load. You can load all the dashboards in the archive by
 # setting this to the empty string.
-#dashboard.beat: heartbeat
+#dashboards.beat: heartbeat
 
 # The name of the Kibana index to use for setting the configuration. Default is ".kibana"
 #dashboards.kibana_index: .kibana

--- a/libbeat/_meta/config.full.yml
+++ b/libbeat/_meta/config.full.yml
@@ -570,16 +570,16 @@ output.elasticsearch:
 #dashboards.file:
 
 # If this option is enabled, the snapshot URL is used instead of the default URL.
-#dashboard.snapshot: false
+#dashboards.snapshot: false
 
 # The URL from where to download the snapshot version of the dashboards. By default
 # this has a value which is computed based on the Beat name and version.
-#dashboard.snapshot_url
+#dashboards.snapshot_url
 
 # In case the archive contains the dashboards from multiple Beats, this lets you
 # select which one to load. You can load all the dashboards in the archive by
 # setting this to the empty string.
-#dashboard.beat: beatname
+#dashboards.beat: beatname
 
 # The name of the Kibana index to use for setting the configuration. Default is ".kibana"
 #dashboards.kibana_index: .kibana

--- a/metricbeat/metricbeat.full.yml
+++ b/metricbeat/metricbeat.full.yml
@@ -876,16 +876,16 @@ output.elasticsearch:
 #dashboards.file:
 
 # If this option is enabled, the snapshot URL is used instead of the default URL.
-#dashboard.snapshot: false
+#dashboards.snapshot: false
 
 # The URL from where to download the snapshot version of the dashboards. By default
 # this has a value which is computed based on the Beat name and version.
-#dashboard.snapshot_url
+#dashboards.snapshot_url
 
 # In case the archive contains the dashboards from multiple Beats, this lets you
 # select which one to load. You can load all the dashboards in the archive by
 # setting this to the empty string.
-#dashboard.beat: metricbeat
+#dashboards.beat: metricbeat
 
 # The name of the Kibana index to use for setting the configuration. Default is ".kibana"
 #dashboards.kibana_index: .kibana

--- a/packetbeat/packetbeat.full.yml
+++ b/packetbeat/packetbeat.full.yml
@@ -1025,16 +1025,16 @@ output.elasticsearch:
 #dashboards.file:
 
 # If this option is enabled, the snapshot URL is used instead of the default URL.
-#dashboard.snapshot: false
+#dashboards.snapshot: false
 
 # The URL from where to download the snapshot version of the dashboards. By default
 # this has a value which is computed based on the Beat name and version.
-#dashboard.snapshot_url
+#dashboards.snapshot_url
 
 # In case the archive contains the dashboards from multiple Beats, this lets you
 # select which one to load. You can load all the dashboards in the archive by
 # setting this to the empty string.
-#dashboard.beat: packetbeat
+#dashboards.beat: packetbeat
 
 # The name of the Kibana index to use for setting the configuration. Default is ".kibana"
 #dashboards.kibana_index: .kibana

--- a/winlogbeat/winlogbeat.full.yml
+++ b/winlogbeat/winlogbeat.full.yml
@@ -605,16 +605,16 @@ output.elasticsearch:
 #dashboards.file:
 
 # If this option is enabled, the snapshot URL is used instead of the default URL.
-#dashboard.snapshot: false
+#dashboards.snapshot: false
 
 # The URL from where to download the snapshot version of the dashboards. By default
 # this has a value which is computed based on the Beat name and version.
-#dashboard.snapshot_url
+#dashboards.snapshot_url
 
 # In case the archive contains the dashboards from multiple Beats, this lets you
 # select which one to load. You can load all the dashboards in the archive by
 # setting this to the empty string.
-#dashboard.beat: winlogbeat
+#dashboards.beat: winlogbeat
 
 # The name of the Kibana index to use for setting the configuration. Default is ".kibana"
 #dashboards.kibana_index: .kibana


### PR DESCRIPTION
Some of the dashboards config option were singular and did not work because of this.