### PR TITLE
Increase template order of new templates to 1

### DIFF
--- a/filebeat/filebeat.template-es2x.json
+++ b/filebeat/filebeat.template-es2x.json
@@ -533,7 +533,7 @@
       }
     }
   },
-  "order": 0,
+  "order": 1,
   "settings": {
     "index.refresh_interval": "5s"
   },

--- a/filebeat/filebeat.template.json
+++ b/filebeat/filebeat.template.json
@@ -453,7 +453,7 @@
       }
     }
   },
-  "order": 0,
+  "order": 1,
   "settings": {
     "index": {
       "mapping": {

--- a/heartbeat/heartbeat.template-es2x.json
+++ b/heartbeat/heartbeat.template-es2x.json
@@ -211,7 +211,7 @@
       }
     }
   },
-  "order": 0,
+  "order": 1,
   "settings": {
     "index.refresh_interval": "5s"
   },

--- a/heartbeat/heartbeat.template.json
+++ b/heartbeat/heartbeat.template.json
@@ -183,7 +183,7 @@
       }
     }
   },
-  "order": 0,
+  "order": 1,
   "settings": {
     "index": {
       "mapping": {

--- a/libbeat/template/template.go
+++ b/libbeat/template/template.go
@@ -86,7 +86,7 @@ func createTemplate(properties common.MapStr, version string, esVersion Version,
 				"properties":        properties,
 			},
 		},
-		"order": 0,
+		"order": 1,
 		"settings": common.MapStr{
 			"index.refresh_interval": "5s",
 		},

--- a/metricbeat/metricbeat.template-es2x.json
+++ b/metricbeat/metricbeat.template-es2x.json
@@ -4296,7 +4296,7 @@
       }
     }
   },
-  "order": 0,
+  "order": 1,
   "settings": {
     "index.refresh_interval": "5s"
   },

--- a/metricbeat/metricbeat.template.json
+++ b/metricbeat/metricbeat.template.json
@@ -4235,7 +4235,7 @@
       }
     }
   },
-  "order": 0,
+  "order": 1,
   "settings": {
     "index": {
       "mapping": {

--- a/packetbeat/packetbeat.template-es2x.json
+++ b/packetbeat/packetbeat.template-es2x.json
@@ -1595,7 +1595,7 @@
       }
     }
   },
-  "order": 0,
+  "order": 1,
   "settings": {
     "index.refresh_interval": "5s"
   },

--- a/packetbeat/packetbeat.template.json
+++ b/packetbeat/packetbeat.template.json
@@ -1388,7 +1388,7 @@
       }
     }
   },
-  "order": 0,
+  "order": 1,
   "settings": {
     "index": {
       "mapping": {

--- a/winlogbeat/winlogbeat.template-es2x.json
+++ b/winlogbeat/winlogbeat.template-es2x.json
@@ -215,7 +215,7 @@
       }
     }
   },
-  "order": 0,
+  "order": 1,
   "settings": {
     "index.refresh_interval": "5s"
   },

--- a/winlogbeat/winlogbeat.template.json
+++ b/winlogbeat/winlogbeat.template.json
@@ -176,7 +176,7 @@
       }
     }
   },
-  "order": 0,
+  "order": 1,
   "settings": {
     "index": {
       "mapping": {


### PR DESCRIPTION
This makes sure, in case for example a metricbeat-* and a metricbeat-{beatversion}-* template exist, the more precise one / newer one overloads the older one. This is important for people migrating from 5.x to 6.x.

Closes https://github.com/elastic/beats/issues/3657