### PR TITLE
Fix elasticsearch url parsing

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -38,6 +38,7 @@ https://github.com/elastic/beats/compare/v5.1.1...master[Check the HEAD diff]
 *Affecting all Beats*
 
 - Add `_id`, `_type`, `_index` and `_score` fields in the generated index pattern. {pull}3282[3282]
+- Fix potential elasticsearch output URL parsing error if protocol scheme is missing. {pull}3671[3671]
 
 *Filebeat*
 - Always use absolute path for event and registry. {pull}3328[3328]

--- a/libbeat/outputs/elasticsearch/url.go
+++ b/libbeat/outputs/elasticsearch/url.go
@@ -4,8 +4,11 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"regexp"
 	"strings"
 )
+
+var hasScheme = regexp.MustCompile(`^([a-z][a-z0-9+\-.]*)://`)
 
 // Creates the url based on the url configuration.
 // Adds missing parts with defaults (scheme, host, port)
@@ -13,6 +16,10 @@ func MakeURL(defaultScheme string, defaultPath string, rawURL string) (string, e
 
 	if defaultScheme == "" {
 		defaultScheme = "http"
+	}
+
+	if !hasScheme.MatchString(rawURL) {
+		rawURL = fmt.Sprintf("%v://%v", defaultScheme, rawURL)
 	}
 
 	addr, err := url.Parse(rawURL)
@@ -23,22 +30,6 @@ func MakeURL(defaultScheme string, defaultPath string, rawURL string) (string, e
 	scheme := addr.Scheme
 	host := addr.Host
 	port := "9200"
-
-	// sanitize parse errors if url does not contain scheme
-	// if parse url looks funny, prepend schema and try again:
-	if addr.Scheme == "" || (addr.Host == "" && addr.Path == "" && addr.Opaque != "") {
-		rawURL = fmt.Sprintf("%v://%v", defaultScheme, rawURL)
-		if tmpAddr, err := url.Parse(rawURL); err == nil {
-			addr = tmpAddr
-			scheme = addr.Scheme
-			host = addr.Host
-		} else {
-			// If url doesn't have a scheme, host is written into path. For example: 192.168.3.7
-			scheme = defaultScheme
-			host = addr.Path
-			addr.Path = ""
-		}
-	}
 
 	if host == "" {
 		host = "localhost"

--- a/libbeat/outputs/elasticsearch/url_test.go
+++ b/libbeat/outputs/elasticsearch/url_test.go
@@ -79,6 +79,8 @@ func TestGetUrl(t *testing.T) {
 		"http://localhost/":    "http://localhost:9200/",
 
 		// no schema + hostname
+		"33f3600fd5c1bb599af557c36a4efb08.host":       "http://33f3600fd5c1bb599af557c36a4efb08.host:9200",
+		"33f3600fd5c1bb599af557c36a4efb08.host:12345": "http://33f3600fd5c1bb599af557c36a4efb08.host:12345",
 		"localhost":        "http://localhost:9200",
 		"localhost:80":     "http://localhost:80",
 		"localhost:80/":    "http://localhost:80/",


### PR DESCRIPTION
use regex to check if host given contains the protocol scheme. If scheme is
missing, prepend before attempting to parse the complete URL