### PR TITLE
Add module info to getting started

### DIFF
--- a/filebeat/docs/getting-started.asciidoc
+++ b/filebeat/docs/getting-started.asciidoc
@@ -33,8 +33,11 @@ formats, such as Nginx, Apache2, and MySQL, and can be run by issuing a simple
 command.  
 
 This topic shows you how to run the basic modules out of the box without extra
-configuration. For detailed documentation and the full list of supported
+configuration. For detailed documentation and the full list of available
 modules, see <<filebeat-modules>>.
+
+Skip this topic and go to <<filebeat-installation>> if you are using a log file
+type that isn't supported by one of the available Filebeat modules.
 
 ==== Prerequisites
 

--- a/filebeat/docs/getting-started.asciidoc
+++ b/filebeat/docs/getting-started.asciidoc
@@ -11,6 +11,7 @@ See {libbeat}/getting-started.html[Getting Started with Beats and the Elastic St
 
 After installing the Elastic Stack, read the following topics to learn how to install, configure, and run Filebeat:
 
+* <<filebeat-modules-quickstart>>
 * <<filebeat-installation>>
 * <<filebeat-configuration>>
 * <<config-filebeat-logstash>>
@@ -20,9 +21,119 @@ After installing the Elastic Stack, read the following topics to learn how to in
 * <<filebeat-command-line>>
 * <<directory-layout>>
 
+[[filebeat-modules-quickstart]]
+=== Quick Start for Common Log Formats
+
+beta[]
+
+Filebeat provides a set of pre-built modules that you can use to rapidly
+implement and deploy a log monitoring solution, complete with sample dashboards
+and data visualizations, in about 5 minutes. These modules support common log
+formats, such as Nginx, Apache2, and MySQL, and can be run by issuing a simple
+command.  
+
+This topic shows you how to run the basic modules out of the box without extra
+configuration. For detailed documentation and the full list of supported
+modules, see <<filebeat-modules>>.
+
+==== Prerequisites
+
+Before running Filebeat with modules enabled, you need to:
+
+* Install and configure the Elastic stack. See 
+{libbeat}/getting-started.html[Getting Started with Beats and the Elastic Stack].
+
+* Complete the Filebeat installation instructions described in
+<<filebeat-installation>>. After installing Filebeat, return to this
+quick start page. 
+
+* Install the Ingest Node GeoIP and User Agent plugins, which you can do by
+running the following commands in the Elasticsearch home path:
++
+[source,shell]
+----------------------------------------------------------------------
+sudo bin/elasticsearch-plugin install ingest-geoip
+sudo bin/elasticsearch-plugin install ingest-user-agent
+----------------------------------------------------------------------
++
+You need to restart Elasticsearch after running these commands.
+
+* Verify that Elasticsearch and Kibana are running and that Elasticsearch is
+ready to receive data from Filebeat.
+
+//TODO: Follow up to find out whether ingest-geoip and ingest-user-agent will be bundled with ES. If so, remove the last prepreq.
+
+[[running-modules-quickstart]]
+==== Running Filebeat with Modules Enabled
+
+To run one or more Filebeat modules, you issue the following command:
+
+[source,shell]
+----------------------------------------------------------------------
+filebeat -e -modules=MODULES -setup
+----------------------------------------------------------------------
+
+Where `MODULES` is the name of the module (or a comma-separated list of
+modules) that you want to enable. The `-e` flag is optional and sends output
+to standard error instead of syslog. The `-setup` flag is a one-time setup step.
+For subsequent runs of Filebeat, do not specify this flag.
+
+For example, to start Filebeat with the `system` module enabled and load the
+sample Kibana dashboards, run:
+
+[source,shell]
+----------------------------------------------------------------------
+filebeat -e -modules=system -setup
+----------------------------------------------------------------------
+
+This command takes care of configuring Filebeat, loading the recommended index
+template for writing to Elasticsearch, and deploying the sample dashboards
+for visualizing the data in Kibana. 
+
+To start Filebeat with the `system`, `nginx`, and `mysql` modules enabled
+and load the sample dashboards, run:
+
+[source,shell]
+----------------------------------------------------------------------
+filebeat -e -modules=system,nginx,mysql -setup
+----------------------------------------------------------------------
+
+To start Filebeat with the `system` module enabled (it's assumed that
+you've already loaded the sample dashboards), run:
+
+[source,shell]
+----------------------------------------------------------------------
+filebeat -e -modules=system
+----------------------------------------------------------------------
+
+TIP: In a production environment, you'll probably want to use a configuration
+file, rather than command-line flags, to specify which modules to run. See the
+detailed documentation for more about configuring and running modules.
+
+These examples assume that the logs you're harvesting are in the location
+expected for your OS and that the default behavior of Filebeat is appropriate
+for your environment. Each module provides a set of variables that you can set
+to fine tune the behavior of Filebeat, including the location where it looks
+for log files. See <<filebeat-modules>> for more info.
+
+[[visualizing-data]]
+==== Visualizing the Data in Kibana
+
+After you've confirmed that Filebeat is sending events to Elasticsearch, launch
+the Kibana web interface by pointing your browser to port 5601. For example,
+http://127.0.0.1:5601[http://127.0.0.1:5601].
+
+Open the dashboard and explore the visualizations for your parsed logs. 
+
+Here's an example of the syslog dashboard:
+
+image:./images/kibana-system.png[Sylog dashboard]
 
 [[filebeat-installation]]
 === Step 1: Installing Filebeat
+
+Before running Filebeat, you need to install and configure the Elastic stack. See 
+{libbeat}/getting-started.html[Getting Started with Beats and the Elastic Stack].
 
 To download and install Filebeat, use the commands that work with your system
 (<<deb, deb>> for Debian/Ubuntu, <<rpm, rpm>> for Redhat/Centos/Fedora, <<mac,
@@ -85,12 +196,21 @@ PS C:\Program Files\Filebeat> .\install-service-filebeat.ps1
 
 NOTE: If script execution is disabled on your system, you need to set the execution policy for the current session to allow the script to run. For example: `PowerShell.exe -ExecutionPolicy UnRestricted -File .\install-service-filebeat.ps1`.
 
+If you're using modules to get started with Filebeat, go back to the
+<<filebeat-modules-quickstart>> page.
+
+Otherwise, continue on to <<filebeat-configuration>>.
+
 Before starting Filebeat, you should look at the configuration options in the configuration
 file, for example `C:\Program Files\Filebeat\filebeat.yml` or `/etc/filebeat/filebeat.yml`. For more information about these options,
 see <<filebeat-configuration-details>>.
 
 [[filebeat-configuration]]
 === Step 2: Configuring Filebeat
+
+TIP: <<filebeat-modules-overview,Filebeat modules>> provide the fastest getting
+started experience for common log formats. See <<filebeat-modules-quickstart>> to
+learn how to get started with modules.
 
 To configure Filebeat, you edit the configuration file. For rpm and deb, you'll
 find the configuration file at `/etc/filebeat/filebeat.yml`. For mac and win, look in


### PR DESCRIPTION
I've added some "quick start" content about modules to the getting started guide because I want to highlight modules as the _easiest_ way to get started with common log formats. 

This is  meant to complement, not replace the info in the tutorial about modules. The tutorial explores lots of ways to do things, which I think is great, but doesn't showcase how simple it is to get started if you just want to get up and running to see how things work.

More changes coming to the actual modules doc in another PR.... 