### PR TITLE
Report cwd

### DIFF
--- a/metricbeat/docs/fields.asciidoc
+++ b/metricbeat/docs/fields.asciidoc
@@ -6585,7 +6585,7 @@ The username of the user that created the process. If the username cannot be det
 
 type: keyword
 
-The current working directory of the process.
+The current working directory of the process. This field is only available on Linux.
 
 
 [float]

--- a/metricbeat/docs/fields.asciidoc
+++ b/metricbeat/docs/fields.asciidoc
@@ -6581,6 +6581,14 @@ The username of the user that created the process. If the username cannot be det
 
 
 [float]
+=== system.process.cwd
+
+type: keyword
+
+The current working directory of the process.
+
+
+[float]
 === system.process.env
 
 type: object

--- a/metricbeat/metricbeat.template-es2x.json
+++ b/metricbeat/metricbeat.template-es2x.json
@@ -4049,6 +4049,11 @@
                     }
                   }
                 },
+                "cwd": {
+                  "ignore_above": 1024,
+                  "index": "not_analyzed",
+                  "type": "string"
+                },
                 "env": {
                   "properties": {}
                 },

--- a/metricbeat/metricbeat.template.json
+++ b/metricbeat/metricbeat.template.json
@@ -4008,6 +4008,10 @@
                     }
                   }
                 },
+                "cwd": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "env": {
                   "properties": {}
                 },

--- a/metricbeat/module/system/process/_meta/fields.yml
+++ b/metricbeat/module/system/process/_meta/fields.yml
@@ -35,6 +35,10 @@
         cannot be determined, the field will contain the user's
         numeric identifier (UID). On Windows, this field includes the user's
         domain and is formatted as `domain\username`.
+    - name: cwd
+      type: keyword
+      description: >
+        The current working directory of the process.
     - name: env
       type: object
       object_type: keyword

--- a/metricbeat/module/system/process/_meta/fields.yml
+++ b/metricbeat/module/system/process/_meta/fields.yml
@@ -38,7 +38,8 @@
     - name: cwd
       type: keyword
       description: >
-        The current working directory of the process.
+        The current working directory of the process. This field is only
+        available on Linux.
     - name: env
       type: object
       object_type: keyword

--- a/metricbeat/module/system/process/helper.go
+++ b/metricbeat/module/system/process/helper.go
@@ -223,7 +223,6 @@ func (procStats *ProcStats) GetProcessEvent(process *Process, last *Process) com
 		"name":     process.Name,
 		"state":    process.State,
 		"username": process.Username,
-		"cwd":      process.Cwd,
 		"memory": common.MapStr{
 			"size": process.Mem.Size,
 			"rss": common.MapStr{
@@ -236,6 +235,10 @@ func (procStats *ProcStats) GetProcessEvent(process *Process, last *Process) com
 
 	if process.CmdLine != "" {
 		proc["cmdline"] = process.CmdLine
+	}
+
+	if process.Cwd != "" {
+		proc["cwd"] = process.Cwd
 	}
 
 	if len(process.Env) > 0 {

--- a/metricbeat/module/system/process/helper.go
+++ b/metricbeat/module/system/process/helper.go
@@ -55,7 +55,7 @@ func newProcess(pid int, cmdline string, env common.MapStr) (*Process, error) {
 	}
 
 	exe := sigar.ProcExe{}
-	if err := exe.Get(pid); err != nil {
+	if err := exe.Get(pid); err != nil && !sigar.IsNotImplemented(err) && !os.IsPermission(err) {
 		return nil, fmt.Errorf("error getting process exe for pid=%d: %v", pid, err)
 	}
 

--- a/metricbeat/module/system/process/helper.go
+++ b/metricbeat/module/system/process/helper.go
@@ -27,6 +27,7 @@ type Process struct {
 	Username string `json:"username"`
 	State    string `json:"state"`
 	CmdLine  string `json:"cmdline"`
+	Cwd      string `json:"cwd"`
 	Mem      sigar.ProcMem
 	Cpu      sigar.ProcTime
 	Ctime    time.Time
@@ -53,6 +54,11 @@ func newProcess(pid int, cmdline string, env common.MapStr) (*Process, error) {
 		return nil, fmt.Errorf("error getting process state for pid=%d: %v", pid, err)
 	}
 
+	exe := sigar.ProcExe{}
+	if err := exe.Get(pid); err != nil {
+		return nil, fmt.Errorf("error getting process exe for pid=%d: %v", pid, err)
+	}
+
 	proc := Process{
 		Pid:      pid,
 		Ppid:     state.Ppid,
@@ -61,6 +67,7 @@ func newProcess(pid int, cmdline string, env common.MapStr) (*Process, error) {
 		Username: state.Username,
 		State:    getProcState(byte(state.State)),
 		CmdLine:  cmdline,
+		Cwd:      exe.Cwd,
 		Ctime:    time.Now(),
 		Env:      env,
 	}
@@ -216,6 +223,7 @@ func (procStats *ProcStats) GetProcessEvent(process *Process, last *Process) com
 		"name":     process.Name,
 		"state":    process.State,
 		"username": process.Username,
+		"cwd":      process.Cwd,
 		"memory": common.MapStr{
 			"size": process.Mem.Size,
 			"rss": common.MapStr{

--- a/metricbeat/module/system/process/helper_test.go
+++ b/metricbeat/module/system/process/helper_test.go
@@ -57,6 +57,11 @@ func TestGetProcess(t *testing.T) {
 	case "darwin", "linux", "freebsd":
 		assert.True(t, len(process.Env) > 0, "empty environment")
 	}
+
+	switch runtime.GOOS {
+	case "linux":
+		assert.True(t, (len(process.Cwd) > 0))
+	}
 }
 
 func TestProcState(t *testing.T) {

--- a/metricbeat/tests/system/test_system.py
+++ b/metricbeat/tests/system/test_system.py
@@ -39,7 +39,7 @@ SYSTEM_NETWORK_FIELDS = ["name", "out.bytes", "in.bytes", "out.packets",
 # is not available on all OSes and requires root to read for all processes.
 # cgroup is only available on linux.
 SYSTEM_PROCESS_FIELDS = ["cpu", "memory", "name", "pid", "ppid", "pgid",
-                         "state", "username", "cgroup"]
+                         "state", "username", "cgroup", "cwd"]
 
 
 class Test(metricbeat.BaseTest):

--- a/metricbeat/tests/system/test_system.py
+++ b/metricbeat/tests/system/test_system.py
@@ -329,6 +329,9 @@ class Test(metricbeat.BaseTest):
         if not sys.platform.startswith("linux") and "cgroup" in SYSTEM_PROCESS_FIELDS:
             SYSTEM_PROCESS_FIELDS.remove("cgroup")
 
+        if not sys.platform.startswith("linux") and "cwd" in SYSTEM_PROCESS_FIELDS:
+            SYSTEM_PROCESS_FIELDS.remove("cwd")
+
         self.render_config_template(modules=[{
             "name": "system",
             "metricsets": ["process"],


### PR DESCRIPTION
(A restart of #3639)

I need metricbeat's system process metricset to report current working directory (cwd).

It was straightforward to use gosigar's ProcExe, but Linux seems to be the only platform for which gosigar can provide cwd in any feasible manner. On Darwin, gosigar uses libproc.h which is not a public interface. On FreeBSD, gosigar relies on procfs and Linux-compatible linprocfs which do not provide cwd in an obvious way. On Windows, gosigar's `(*ProcExe) Get(int)` returns ErrNotImplemented.