### PR TITLE
Cherry-pick to 5.x: Fileset for the Linux authorization logs auth

### DIFF
--- a/filebeat/docs/fields.asciidoc
+++ b/filebeat/docs/fields.asciidoc
@@ -866,6 +866,246 @@ Fields from the system log files.
 
 
 [float]
+== auth Fields
+
+Fields from the Linux authorization logs.
+
+
+
+[float]
+=== system.auth.timestamp
+
+The timestamp as read from the auth message.
+
+
+[float]
+=== system.auth.hostname
+
+The hostname as read from the auth message.
+
+
+[float]
+=== system.auth.program
+
+The process name as read from the auth message.
+
+
+[float]
+=== system.auth.pid
+
+type: long
+
+The PID of the process that sent the auth message.
+
+
+[float]
+=== system.auth.message
+
+The message in the log line.
+
+
+[float]
+=== system.auth.user
+
+The Unix user that this event refers to.
+
+
+[float]
+== ssh Fields
+
+Fields specific to SSH login events.
+
+
+
+[float]
+=== system.auth.ssh.event
+
+The SSH login event. Can be one of "Accepted", "Failed", or "Invalid". "Accepted" means a successful login. "Invalid" means that the user is not configured on the system. "Failed" means that the SSH login attempt has failed.
+
+
+[float]
+=== system.auth.ssh.method
+
+The SSH authentication method. Can be one of "password" or "publickey".
+
+
+[float]
+=== system.auth.ssh.ip
+
+type: ip
+
+The client IP from where the login attempt was made.
+
+
+[float]
+=== system.auth.ssh.dropped_ip
+
+type: ip
+
+The client IP from SSH connections that are open and immediately dropped.
+
+
+[float]
+=== system.auth.ssh.port
+
+type: long
+
+The client port from where the login attempt was made.
+
+
+[float]
+=== system.auth.ssh.signature
+
+The signature of the client public key.
+
+
+[float]
+== geoip Fields
+
+Contains GeoIP information gathered based on the `system.auth.ip` field. Only present if the GeoIP Elasticsearch plugin is available and used.
+
+
+
+[float]
+=== system.auth.ssh.geoip.continent_name
+
+type: keyword
+
+The name of the continent.
+
+
+[float]
+=== system.auth.ssh.geoip.city_name
+
+type: keyword
+
+The name of the city.
+
+
+[float]
+=== system.auth.ssh.geoip.region_name
+
+type: keyword
+
+The name of the region.
+
+
+[float]
+=== system.auth.ssh.geoip.country_iso_code
+
+type: keyword
+
+Country ISO code.
+
+
+[float]
+=== system.auth.ssh.geoip.location
+
+type: geo_point
+
+The longitude and latitude.
+
+
+[float]
+== sudo Fields
+
+Fields specific to events created by the `sudo` command.
+
+
+
+[float]
+=== system.auth.sudo.error
+
+example: user NOT in sudoers
+
+The error message in case the sudo command failed.
+
+
+[float]
+=== system.auth.sudo.tty
+
+The TTY where the sudo command is executed.
+
+
+[float]
+=== system.auth.sudo.pwd
+
+The current directory where the sudo command is executed.
+
+
+[float]
+=== system.auth.sudo.user
+
+example: root
+
+The target user to which the sudo command is switching.
+
+
+[float]
+=== system.auth.sudo.command
+
+The command executed via sudo.
+
+
+[float]
+== useradd Fields
+
+Fields specific to events created by the `useradd` command.
+
+
+
+[float]
+=== system.auth.useradd.name
+
+The user name being added.
+
+
+[float]
+=== system.auth.useradd.uid
+
+type: long
+
+The user ID.
+
+[float]
+=== system.auth.useradd.gid
+
+type: long
+
+The group ID.
+
+[float]
+=== system.auth.useradd.home
+
+The home folder for the new user.
+
+[float]
+=== system.auth.useradd.shell
+
+The default shell for the new user.
+
+[float]
+== groupadd Fields
+
+Fields specific to events created by the `groupadd` command.
+
+
+
+[float]
+=== system.auth.groupadd.name
+
+The name of the new group.
+
+
+[float]
+=== system.auth.groupadd.gid
+
+type: long
+
+The ID of the new group.
+
+
+[float]
 == syslog Fields
 
 Contains fields from the syslog system logs.

--- a/filebeat/filebeat.template-es2x.json
+++ b/filebeat/filebeat.template-es2x.json
@@ -489,6 +489,163 @@
         },
         "system": {
           "properties": {
+            "auth": {
+              "properties": {
+                "groupadd": {
+                  "properties": {
+                    "gid": {
+                      "type": "long"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "index": "not_analyzed",
+                      "type": "string"
+                    }
+                  }
+                },
+                "hostname": {
+                  "ignore_above": 1024,
+                  "index": "not_analyzed",
+                  "type": "string"
+                },
+                "message": {
+                  "ignore_above": 1024,
+                  "index": "not_analyzed",
+                  "type": "string"
+                },
+                "pid": {
+                  "type": "long"
+                },
+                "program": {
+                  "ignore_above": 1024,
+                  "index": "not_analyzed",
+                  "type": "string"
+                },
+                "ssh": {
+                  "properties": {
+                    "dropped_ip": {
+                      "ignore_above": 1024,
+                      "index": "not_analyzed",
+                      "type": "string"
+                    },
+                    "event": {
+                      "ignore_above": 1024,
+                      "index": "not_analyzed",
+                      "type": "string"
+                    },
+                    "geoip": {
+                      "properties": {
+                        "city_name": {
+                          "ignore_above": 1024,
+                          "index": "not_analyzed",
+                          "type": "string"
+                        },
+                        "continent_name": {
+                          "ignore_above": 1024,
+                          "index": "not_analyzed",
+                          "type": "string"
+                        },
+                        "country_iso_code": {
+                          "ignore_above": 1024,
+                          "index": "not_analyzed",
+                          "type": "string"
+                        },
+                        "location": {
+                          "type": "geo_point"
+                        },
+                        "region_name": {
+                          "ignore_above": 1024,
+                          "index": "not_analyzed",
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "ip": {
+                      "ignore_above": 1024,
+                      "index": "not_analyzed",
+                      "type": "string"
+                    },
+                    "method": {
+                      "ignore_above": 1024,
+                      "index": "not_analyzed",
+                      "type": "string"
+                    },
+                    "port": {
+                      "type": "long"
+                    },
+                    "signature": {
+                      "ignore_above": 1024,
+                      "index": "not_analyzed",
+                      "type": "string"
+                    }
+                  }
+                },
+                "sudo": {
+                  "properties": {
+                    "command": {
+                      "ignore_above": 1024,
+                      "index": "not_analyzed",
+                      "type": "string"
+                    },
+                    "error": {
+                      "ignore_above": 1024,
+                      "index": "not_analyzed",
+                      "type": "string"
+                    },
+                    "pwd": {
+                      "ignore_above": 1024,
+                      "index": "not_analyzed",
+                      "type": "string"
+                    },
+                    "tty": {
+                      "ignore_above": 1024,
+                      "index": "not_analyzed",
+                      "type": "string"
+                    },
+                    "user": {
+                      "ignore_above": 1024,
+                      "index": "not_analyzed",
+                      "type": "string"
+                    }
+                  }
+                },
+                "timestamp": {
+                  "ignore_above": 1024,
+                  "index": "not_analyzed",
+                  "type": "string"
+                },
+                "user": {
+                  "ignore_above": 1024,
+                  "index": "not_analyzed",
+                  "type": "string"
+                },
+                "useradd": {
+                  "properties": {
+                    "gid": {
+                      "type": "long"
+                    },
+                    "home": {
+                      "ignore_above": 1024,
+                      "index": "not_analyzed",
+                      "type": "string"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "index": "not_analyzed",
+                      "type": "string"
+                    },
+                    "shell": {
+                      "ignore_above": 1024,
+                      "index": "not_analyzed",
+                      "type": "string"
+                    },
+                    "uid": {
+                      "type": "long"
+                    }
+                  }
+                }
+              }
+            },
             "syslog": {
               "properties": {
                 "hostname": {

--- a/filebeat/filebeat.template.json
+++ b/filebeat/filebeat.template.json
@@ -419,6 +419,138 @@
         },
         "system": {
           "properties": {
+            "auth": {
+              "properties": {
+                "groupadd": {
+                  "properties": {
+                    "gid": {
+                      "type": "long"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "hostname": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "message": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "pid": {
+                  "type": "long"
+                },
+                "program": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "ssh": {
+                  "properties": {
+                    "dropped_ip": {
+                      "type": "ip"
+                    },
+                    "event": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "geoip": {
+                      "properties": {
+                        "city_name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "continent_name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "country_iso_code": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "location": {
+                          "type": "geo_point"
+                        },
+                        "region_name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      }
+                    },
+                    "ip": {
+                      "type": "ip"
+                    },
+                    "method": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "port": {
+                      "type": "long"
+                    },
+                    "signature": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "sudo": {
+                  "properties": {
+                    "command": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "error": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "pwd": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "tty": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "user": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "timestamp": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "user": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "useradd": {
+                  "properties": {
+                    "gid": {
+                      "type": "long"
+                    },
+                    "home": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "shell": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "uid": {
+                      "type": "long"
+                    }
+                  }
+                }
+              }
+            },
             "syslog": {
               "properties": {
                 "hostname": {

--- a/filebeat/fileset/modules_test.go
+++ b/filebeat/fileset/modules_test.go
@@ -37,7 +37,7 @@ func TestNewModuleRegistry(t *testing.T) {
 	expectedModules := map[string][]string{
 		"nginx":  {"access", "error"},
 		"mysql":  {"slowlog", "error"},
-		"system": {"syslog"},
+		"system": {"syslog", "auth"},
 	}
 
 	assert.Equal(t, len(expectedModules), len(reg.registry))

--- a/filebeat/module/system/_meta/kibana/dashboard/0d3f2380-fa78-11e6-ae9b-81e5311e8cab.json
+++ b/filebeat/module/system/_meta/kibana/dashboard/0d3f2380-fa78-11e6-ae9b-81e5311e8cab.json
@@ -1,0 +1,13 @@
+{
+  "hits": 0, 
+  "timeRestore": false, 
+  "description": "", 
+  "title": "Filebeat New users and groups", 
+  "uiStateJSON": "{\"P-1\":{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":null,\"direction\":null}}}},\"P-5\":{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":null,\"direction\":null}}}}}", 
+  "panelsJSON": "[{\"col\":1,\"id\":\"f398d2f0-fa77-11e6-ae9b-81e5311e8cab\",\"panelIndex\":1,\"row\":1,\"size_x\":6,\"size_y\":3,\"type\":\"visualization\"},{\"col\":7,\"id\":\"5dd15c00-fa78-11e6-ae9b-81e5311e8cab\",\"panelIndex\":2,\"row\":1,\"size_x\":6,\"size_y\":3,\"type\":\"visualization\"},{\"col\":1,\"id\":\"e121b140-fa78-11e6-a1df-a78bd7504d38\",\"panelIndex\":3,\"row\":4,\"size_x\":6,\"size_y\":3,\"type\":\"visualization\"},{\"col\":7,\"id\":\"d56ee420-fa79-11e6-a1df-a78bd7504d38\",\"panelIndex\":4,\"row\":4,\"size_x\":6,\"size_y\":3,\"type\":\"visualization\"},{\"col\":1,\"id\":\"12667040-fa80-11e6-a1df-a78bd7504d38\",\"panelIndex\":5,\"row\":7,\"size_x\":6,\"size_y\":3,\"type\":\"visualization\"},{\"size_x\":6,\"size_y\":3,\"panelIndex\":6,\"type\":\"visualization\",\"id\":\"346bb290-fa80-11e6-a1df-a78bd7504d38\",\"col\":7,\"row\":7}]", 
+  "optionsJSON": "{\"darkTheme\":false}", 
+  "version": 1, 
+  "kibanaSavedObjectMeta": {
+    "searchSourceJSON": "{\"filter\":[{\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}}}]}"
+  }
+}

--- a/filebeat/module/system/_meta/kibana/dashboard/277876d0-fa2c-11e6-bbd3-29c986c96e5a.json
+++ b/filebeat/module/system/_meta/kibana/dashboard/277876d0-fa2c-11e6-bbd3-29c986c96e5a.json
@@ -1,0 +1,13 @@
+{
+  "hits": 0, 
+  "timeRestore": false, 
+  "description": "", 
+  "title": "Filebeat Auth - Sudo commands", 
+  "uiStateJSON": "{\"P-3\":{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":null,\"direction\":null}}}}}", 
+  "panelsJSON": "[{\"col\":1,\"id\":\"5c7af030-fa2a-11e6-bbd3-29c986c96e5a\",\"panelIndex\":1,\"row\":5,\"size_x\":12,\"size_y\":4,\"type\":\"visualization\"},{\"col\":1,\"id\":\"51164310-fa2b-11e6-bbd3-29c986c96e5a\",\"panelIndex\":2,\"row\":9,\"size_x\":12,\"size_y\":3,\"type\":\"visualization\"},{\"col\":1,\"id\":\"dc589770-fa2b-11e6-bbd3-29c986c96e5a\",\"panelIndex\":3,\"row\":1,\"size_x\":12,\"size_y\":4,\"type\":\"visualization\"}]", 
+  "optionsJSON": "{\"darkTheme\":false}", 
+  "version": 1, 
+  "kibanaSavedObjectMeta": {
+    "searchSourceJSON": "{\"filter\":[{\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}}}]}"
+  }
+}

--- a/filebeat/module/system/_meta/kibana/dashboard/5517a150-f9ce-11e6-8115-a7c18106d86a.json
+++ b/filebeat/module/system/_meta/kibana/dashboard/5517a150-f9ce-11e6-8115-a7c18106d86a.json
@@ -1,0 +1,13 @@
+{
+  "hits": 0, 
+  "timeRestore": false, 
+  "description": "", 
+  "title": "Filebeat SSH login attempts", 
+  "uiStateJSON": "{\"P-4\":{\"mapCenter\":[39.774769485295465,23.203125],\"mapZoom\":3}}", 
+  "panelsJSON": "[{\"col\":1,\"id\":\"d16bb400-f9cc-11e6-8115-a7c18106d86a\",\"panelIndex\":1,\"row\":4,\"size_x\":12,\"size_y\":3,\"type\":\"visualization\"},{\"col\":1,\"id\":\"78b74f30-f9cd-11e6-8115-a7c18106d86a\",\"panelIndex\":2,\"row\":1,\"size_x\":12,\"size_y\":3,\"type\":\"visualization\"},{\"col\":1,\"id\":\"341ffe70-f9ce-11e6-8115-a7c18106d86a\",\"panelIndex\":3,\"row\":7,\"size_x\":6,\"size_y\":4,\"type\":\"visualization\"},{\"col\":7,\"id\":\"3cec3eb0-f9d3-11e6-8a3e-2b904044ea1d\",\"panelIndex\":4,\"row\":7,\"size_x\":6,\"size_y\":4,\"type\":\"visualization\"},{\"size_x\":12,\"size_y\":3,\"panelIndex\":5,\"type\":\"search\",\"id\":\"62439dc0-f9c9-11e6-a747-6121780e0414\",\"col\":1,\"row\":11,\"columns\":[\"system.auth.ssh.event\",\"system.auth.ssh.method\",\"system.auth.user\",\"system.auth.ssh.ip\",\"system.auth.ssh.geoip.country_iso_code\"],\"sort\":[\"@timestamp\",\"desc\"]}]", 
+  "optionsJSON": "{\"darkTheme\":false}", 
+  "version": 1, 
+  "kibanaSavedObjectMeta": {
+    "searchSourceJSON": "{\"filter\":[{\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}}}]}"
+  }
+}

--- a/filebeat/module/system/_meta/kibana/search/62439dc0-f9c9-11e6-a747-6121780e0414.json
+++ b/filebeat/module/system/_meta/kibana/search/62439dc0-f9c9-11e6-a747-6121780e0414.json
@@ -1,0 +1,20 @@
+{
+  "sort": [
+    "@timestamp", 
+    "desc"
+  ], 
+  "hits": 0, 
+  "description": "", 
+  "title": "SSH login attempts", 
+  "version": 1, 
+  "kibanaSavedObjectMeta": {
+    "searchSourceJSON": "{\"index\":\"filebeat-*\",\"highlightAll\":true,\"query\":{\"query_string\":{\"query\":\"_exists_:system.auth.ssh.event\",\"analyze_wildcard\":true}},\"filter\":[]}"
+  }, 
+  "columns": [
+    "system.auth.ssh.event", 
+    "system.auth.ssh.method", 
+    "system.auth.user", 
+    "system.auth.ssh.ip", 
+    "system.auth.ssh.geoip.country_iso_code"
+  ]
+}

--- a/filebeat/module/system/_meta/kibana/search/8030c1b0-fa77-11e6-ae9b-81e5311e8cab.json
+++ b/filebeat/module/system/_meta/kibana/search/8030c1b0-fa77-11e6-ae9b-81e5311e8cab.json
@@ -1,0 +1,20 @@
+{
+  "sort": [
+    "@timestamp", 
+    "desc"
+  ], 
+  "hits": 0, 
+  "description": "", 
+  "title": "useradd logs", 
+  "version": 1, 
+  "kibanaSavedObjectMeta": {
+    "searchSourceJSON": "{\"index\":\"filebeat-*\",\"highlightAll\":true,\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"_exists_:system.auth.useradd\"}},\"filter\":[]}"
+  }, 
+  "columns": [
+    "system.auth.useradd.name", 
+    "system.auth.useradd.uid", 
+    "system.auth.useradd.gid", 
+    "system.auth.useradd.home", 
+    "system.auth.useradd.shell"
+  ]
+}

--- a/filebeat/module/system/_meta/kibana/search/b6f321e0-fa25-11e6-bbd3-29c986c96e5a.json
+++ b/filebeat/module/system/_meta/kibana/search/b6f321e0-fa25-11e6-bbd3-29c986c96e5a.json
@@ -1,0 +1,19 @@
+{
+  "sort": [
+    "@timestamp", 
+    "desc"
+  ], 
+  "hits": 0, 
+  "description": "", 
+  "title": "Sudo commands", 
+  "version": 1, 
+  "kibanaSavedObjectMeta": {
+    "searchSourceJSON": "{\"index\":\"filebeat-*\",\"highlightAll\":true,\"query\":{\"query_string\":{\"query\":\"_exists_:system.auth.sudo\",\"analyze_wildcard\":true}},\"filter\":[]}"
+  }, 
+  "columns": [
+    "system.auth.user", 
+    "system.auth.sudo.user", 
+    "system.auth.sudo.pwd", 
+    "system.auth.sudo.command"
+  ]
+}

--- a/filebeat/module/system/_meta/kibana/search/eb0039f0-fa7f-11e6-a1df-a78bd7504d38.json
+++ b/filebeat/module/system/_meta/kibana/search/eb0039f0-fa7f-11e6-a1df-a78bd7504d38.json
@@ -1,0 +1,17 @@
+{
+  "sort": [
+    "@timestamp", 
+    "desc"
+  ], 
+  "hits": 0, 
+  "description": "", 
+  "title": "groupadd logs", 
+  "version": 1, 
+  "kibanaSavedObjectMeta": {
+    "searchSourceJSON": "{\"index\":\"filebeat-*\",\"highlightAll\":true,\"query\":{\"query_string\":{\"query\":\"_exists_:system.auth.groupadd\",\"analyze_wildcard\":true}},\"filter\":[]}"
+  }, 
+  "columns": [
+    "system.auth.groupadd.name", 
+    "system.auth.groupadd.gid"
+  ]
+}

--- a/filebeat/module/system/_meta/kibana/visualization/12667040-fa80-11e6-a1df-a78bd7504d38.json
+++ b/filebeat/module/system/_meta/kibana/visualization/12667040-fa80-11e6-a1df-a78bd7504d38.json
@@ -1,0 +1,11 @@
+{
+  "visState": "{\"title\":\"New groups\",\"type\":\"table\",\"params\":{\"perPage\":10,\"showPartialRows\":false,\"showMeticsAtAllLevels\":false,\"sort\":{\"columnIndex\":null,\"direction\":null},\"showTotal\":false,\"totalFunc\":\"sum\"},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"system.auth.groupadd.name\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\"}},{\"id\":\"3\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"system.auth.groupadd.gid\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}", 
+  "description": "", 
+  "title": "New groups", 
+  "uiStateJSON": "{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":null,\"direction\":null}}}}", 
+  "version": 1, 
+  "savedSearchId": "eb0039f0-fa7f-11e6-a1df-a78bd7504d38", 
+  "kibanaSavedObjectMeta": {
+    "searchSourceJSON": "{\"filter\":[]}"
+  }
+}

--- a/filebeat/module/system/_meta/kibana/visualization/341ffe70-f9ce-11e6-8115-a7c18106d86a.json
+++ b/filebeat/module/system/_meta/kibana/visualization/341ffe70-f9ce-11e6-8115-a7c18106d86a.json
@@ -1,0 +1,10 @@
+{
+  "visState": "{\"title\":\"SSH users of failed login attempts\",\"type\":\"tagcloud\",\"params\":{\"maxFontSize\":72,\"minFontSize\":18,\"orientation\":\"single\",\"scale\":\"linear\"},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"system.auth.user\",\"size\":50,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}", 
+  "description": "", 
+  "title": "SSH users of failed login attempts", 
+  "uiStateJSON": "{}", 
+  "version": 1, 
+  "kibanaSavedObjectMeta": {
+    "searchSourceJSON": "{\"filter\":[],\"index\":\"filebeat-*\",\"highlightAll\":true,\"query\":{\"query_string\":{\"query\":\"system.auth.ssh.event:Failed OR system.auth.ssh.event:Invalid\",\"analyze_wildcard\":true}}}"
+  }
+}

--- a/filebeat/module/system/_meta/kibana/visualization/346bb290-fa80-11e6-a1df-a78bd7504d38.json
+++ b/filebeat/module/system/_meta/kibana/visualization/346bb290-fa80-11e6-a1df-a78bd7504d38.json
@@ -1,0 +1,11 @@
+{
+  "visState": "{\"title\":\"New groups over time\",\"type\":\"histogram\",\"params\":{\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"bottom\",\"scale\":\"linear\",\"mode\":\"stacked\",\"times\":[],\"addTimeMarker\":false,\"defaultYExtents\":false,\"setYExtents\":false},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"auto\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}},{\"id\":\"3\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"group\",\"params\":{\"field\":\"system.auth.groupadd.name\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}", 
+  "description": "", 
+  "title": "New groups over time", 
+  "uiStateJSON": "{}", 
+  "version": 1, 
+  "savedSearchId": "eb0039f0-fa7f-11e6-a1df-a78bd7504d38", 
+  "kibanaSavedObjectMeta": {
+    "searchSourceJSON": "{\"filter\":[]}"
+  }
+}

--- a/filebeat/module/system/_meta/kibana/visualization/3cec3eb0-f9d3-11e6-8a3e-2b904044ea1d.json
+++ b/filebeat/module/system/_meta/kibana/visualization/3cec3eb0-f9d3-11e6-8a3e-2b904044ea1d.json
@@ -1,0 +1,10 @@
+{
+  "visState": "{\"title\":\"SSH failed login attempts source locations\",\"type\":\"tile_map\",\"params\":{\"mapType\":\"Shaded Circle Markers\",\"isDesaturated\":true,\"addTooltip\":true,\"heatMaxZoom\":16,\"heatMinOpacity\":0.1,\"heatRadius\":25,\"heatBlur\":15,\"heatNormalizeData\":true,\"legendPosition\":\"bottomright\",\"mapZoom\":2,\"mapCenter\":[15,5],\"wms\":{\"enabled\":false,\"url\":\"https://basemap.nationalmap.gov/arcgis/services/USGSTopo/MapServer/WMSServer\",\"options\":{\"version\":\"1.3.0\",\"layers\":\"0\",\"format\":\"image/png\",\"transparent\":true,\"attribution\":\"Maps provided by USGS\",\"styles\":\"\"}}},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"geohash_grid\",\"schema\":\"segment\",\"params\":{\"field\":\"system.auth.ssh.geoip.location\",\"autoPrecision\":true,\"precision\":2}}],\"listeners\":{}}", 
+  "description": "", 
+  "title": "SSH failed login attempts source locations", 
+  "uiStateJSON": "{\"mapZoom\":2,\"mapCenter\":[17.602139123350838,69.697265625]}", 
+  "version": 1, 
+  "kibanaSavedObjectMeta": {
+    "searchSourceJSON": "{\"filter\":[],\"index\":\"filebeat-*\",\"highlightAll\":true,\"query\":{\"query_string\":{\"query\":\"system.auth.ssh.event:Failed OR system.auth.ssh.event:Invalid\",\"analyze_wildcard\":true}}}"
+  }
+}

--- a/filebeat/module/system/_meta/kibana/visualization/51164310-fa2b-11e6-bbd3-29c986c96e5a.json
+++ b/filebeat/module/system/_meta/kibana/visualization/51164310-fa2b-11e6-bbd3-29c986c96e5a.json
@@ -1,0 +1,10 @@
+{
+  "visState": "{\"title\":\"Sudo errors\",\"type\":\"histogram\",\"params\":{\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"scale\":\"linear\",\"mode\":\"stacked\",\"times\":[],\"addTimeMarker\":false,\"defaultYExtents\":false,\"setYExtents\":false},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"auto\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}},{\"id\":\"3\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"group\",\"params\":{\"field\":\"system.auth.sudo.error\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}", 
+  "description": "", 
+  "title": "Sudo errors", 
+  "uiStateJSON": "{}", 
+  "version": 1, 
+  "kibanaSavedObjectMeta": {
+    "searchSourceJSON": "{\"filter\":[],\"index\":\"filebeat-*\",\"highlightAll\":true,\"query\":{\"query_string\":{\"query\":\"_exists_:system.auth.sudo.error\",\"analyze_wildcard\":true}}}"
+  }
+}

--- a/filebeat/module/system/_meta/kibana/visualization/5c7af030-fa2a-11e6-bbd3-29c986c96e5a.json
+++ b/filebeat/module/system/_meta/kibana/visualization/5c7af030-fa2a-11e6-bbd3-29c986c96e5a.json
@@ -1,0 +1,11 @@
+{
+  "visState": "{\"title\":\"Sudo commands by user\",\"type\":\"histogram\",\"params\":{\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"scale\":\"linear\",\"mode\":\"stacked\",\"times\":[],\"addTimeMarker\":false,\"defaultYExtents\":false,\"setYExtents\":false},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"auto\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}},{\"id\":\"3\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"group\",\"params\":{\"field\":\"system.auth.user\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}", 
+  "description": "", 
+  "title": "Sudo commands by user", 
+  "uiStateJSON": "{}", 
+  "version": 1, 
+  "savedSearchId": "b6f321e0-fa25-11e6-bbd3-29c986c96e5a", 
+  "kibanaSavedObjectMeta": {
+    "searchSourceJSON": "{\"filter\":[]}"
+  }
+}

--- a/filebeat/module/system/_meta/kibana/visualization/5dd15c00-fa78-11e6-ae9b-81e5311e8cab.json
+++ b/filebeat/module/system/_meta/kibana/visualization/5dd15c00-fa78-11e6-ae9b-81e5311e8cab.json
@@ -1,0 +1,11 @@
+{
+  "visState": "{\"title\":\"New users over time\",\"type\":\"histogram\",\"params\":{\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"bottom\",\"scale\":\"linear\",\"mode\":\"stacked\",\"times\":[],\"addTimeMarker\":false,\"defaultYExtents\":false,\"setYExtents\":false},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"auto\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}},{\"id\":\"3\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"group\",\"params\":{\"field\":\"system.auth.useradd.name\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}", 
+  "description": "", 
+  "title": "New users over time", 
+  "uiStateJSON": "{}", 
+  "version": 1, 
+  "savedSearchId": "8030c1b0-fa77-11e6-ae9b-81e5311e8cab", 
+  "kibanaSavedObjectMeta": {
+    "searchSourceJSON": "{\"filter\":[]}"
+  }
+}

--- a/filebeat/module/system/_meta/kibana/visualization/78b74f30-f9cd-11e6-8115-a7c18106d86a.json
+++ b/filebeat/module/system/_meta/kibana/visualization/78b74f30-f9cd-11e6-8115-a7c18106d86a.json
@@ -1,0 +1,10 @@
+{
+  "visState": "{\"aggs\":[{\"enabled\":true,\"id\":\"1\",\"params\":{},\"schema\":\"metric\",\"type\":\"count\"},{\"enabled\":true,\"id\":\"2\",\"params\":{\"customInterval\":\"2h\",\"extended_bounds\":{},\"field\":\"@timestamp\",\"interval\":\"auto\",\"min_doc_count\":1},\"schema\":\"segment\",\"type\":\"date_histogram\"},{\"enabled\":true,\"id\":\"3\",\"params\":{\"field\":\"system.auth.ssh.event\",\"order\":\"desc\",\"orderBy\":\"1\",\"size\":5},\"schema\":\"group\",\"type\":\"terms\"}],\"listeners\":{},\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"defaultYExtents\":false,\"legendPosition\":\"right\",\"mode\":\"stacked\",\"scale\":\"linear\",\"setYExtents\":false,\"times\":[]},\"title\":\"SSH login attempts\",\"type\":\"histogram\"}", 
+  "description": "", 
+  "title": "SSH login attempts", 
+  "uiStateJSON": "{\"vis\":{\"colors\":{\"Accepted\":\"#3F6833\",\"Failed\":\"#F9934E\",\"Invalid\":\"#447EBC\"}}}", 
+  "version": 1, 
+  "kibanaSavedObjectMeta": {
+    "searchSourceJSON": "{\"filter\":[],\"index\":\"filebeat-*\",\"highlightAll\":true}"
+  }
+}

--- a/filebeat/module/system/_meta/kibana/visualization/d16bb400-f9cc-11e6-8115-a7c18106d86a.json
+++ b/filebeat/module/system/_meta/kibana/visualization/d16bb400-f9cc-11e6-8115-a7c18106d86a.json
@@ -1,0 +1,10 @@
+{
+  "visState": "{\"title\":\"Successful SSH logins\",\"type\":\"histogram\",\"params\":{\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"scale\":\"linear\",\"mode\":\"stacked\",\"times\":[],\"addTimeMarker\":false,\"defaultYExtents\":false,\"setYExtents\":false},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"auto\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}},{\"id\":\"3\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"group\",\"params\":{\"field\":\"system.auth.ssh.method\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}", 
+  "description": "", 
+  "title": "Successful SSH logins", 
+  "uiStateJSON": "{\"vis\":{\"colors\":{\"Accepted\":\"#3F6833\",\"Failed\":\"#F9934E\",\"Invalid\":\"#447EBC\",\"publickey\":\"#629E51\",\"password\":\"#BF1B00\"}}}", 
+  "version": 1, 
+  "kibanaSavedObjectMeta": {
+    "searchSourceJSON": "{\"filter\":[],\"index\":\"filebeat-*\",\"highlightAll\":true,\"query\":{\"query_string\":{\"query\":\"system.auth.ssh.event:Accepted\",\"analyze_wildcard\":true}}}"
+  }
+}

--- a/filebeat/module/system/_meta/kibana/visualization/d56ee420-fa79-11e6-a1df-a78bd7504d38.json
+++ b/filebeat/module/system/_meta/kibana/visualization/d56ee420-fa79-11e6-a1df-a78bd7504d38.json
@@ -1,0 +1,11 @@
+{
+  "visState": "{\"title\":\"New users by home directory\",\"type\":\"pie\",\"params\":{\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"isDonut\":false},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"system.auth.useradd.home\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\"}},{\"id\":\"3\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"system.auth.useradd.name\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}", 
+  "description": "", 
+  "title": "New users by home directory", 
+  "uiStateJSON": "{\"vis\":{\"colors\":{\"/bin/bash\":\"#E24D42\",\"/bin/false\":\"#508642\",\"/sbin/nologin\":\"#7EB26D\",\"/nonexistent\":\"#629E51\"},\"legendOpen\":true}}", 
+  "version": 1, 
+  "savedSearchId": "8030c1b0-fa77-11e6-ae9b-81e5311e8cab", 
+  "kibanaSavedObjectMeta": {
+    "searchSourceJSON": "{\"filter\":[]}"
+  }
+}

--- a/filebeat/module/system/_meta/kibana/visualization/dc589770-fa2b-11e6-bbd3-29c986c96e5a.json
+++ b/filebeat/module/system/_meta/kibana/visualization/dc589770-fa2b-11e6-bbd3-29c986c96e5a.json
@@ -1,0 +1,11 @@
+{
+  "visState": "{\"title\":\"Top sudo commands\",\"type\":\"table\",\"params\":{\"perPage\":10,\"showPartialRows\":false,\"showMeticsAtAllLevels\":false,\"sort\":{\"columnIndex\":null,\"direction\":null},\"showTotal\":false,\"totalFunc\":\"sum\"},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"system.auth.sudo.command\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\"}},{\"id\":\"3\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"system.auth.user\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}", 
+  "description": "", 
+  "title": "Top sudo commands", 
+  "uiStateJSON": "{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":null,\"direction\":null}}}}", 
+  "version": 1, 
+  "savedSearchId": "b6f321e0-fa25-11e6-bbd3-29c986c96e5a", 
+  "kibanaSavedObjectMeta": {
+    "searchSourceJSON": "{\"filter\":[]}"
+  }
+}

--- a/filebeat/module/system/_meta/kibana/visualization/e121b140-fa78-11e6-a1df-a78bd7504d38.json
+++ b/filebeat/module/system/_meta/kibana/visualization/e121b140-fa78-11e6-a1df-a78bd7504d38.json
@@ -1,0 +1,11 @@
+{
+  "visState": "{\"title\":\"New users by shell\",\"type\":\"pie\",\"params\":{\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"isDonut\":false},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"system.auth.useradd.shell\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\"}},{\"id\":\"3\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"system.auth.useradd.name\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}", 
+  "description": "", 
+  "title": "New users by shell", 
+  "uiStateJSON": "{\"vis\":{\"colors\":{\"/bin/bash\":\"#E24D42\",\"/bin/false\":\"#508642\",\"/sbin/nologin\":\"#7EB26D\"},\"legendOpen\":true}}", 
+  "version": 1, 
+  "savedSearchId": "8030c1b0-fa77-11e6-ae9b-81e5311e8cab", 
+  "kibanaSavedObjectMeta": {
+    "searchSourceJSON": "{\"filter\":[]}"
+  }
+}

--- a/filebeat/module/system/_meta/kibana/visualization/f398d2f0-fa77-11e6-ae9b-81e5311e8cab.json
+++ b/filebeat/module/system/_meta/kibana/visualization/f398d2f0-fa77-11e6-ae9b-81e5311e8cab.json
@@ -1,0 +1,11 @@
+{
+  "visState": "{\"title\":\"New users\",\"type\":\"table\",\"params\":{\"perPage\":10,\"showPartialRows\":false,\"showMeticsAtAllLevels\":false,\"sort\":{\"columnIndex\":null,\"direction\":null},\"showTotal\":false,\"totalFunc\":\"sum\"},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"system.auth.hostname\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"Host\"}},{\"id\":\"3\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"system.auth.useradd.name\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"User\"}},{\"id\":\"4\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"system.auth.useradd.uid\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"UID\"}},{\"id\":\"5\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"system.auth.useradd.gid\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"GID\"}},{\"id\":\"6\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"system.auth.useradd.home\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"Home\"}},{\"id\":\"7\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"system.auth.useradd.shell\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"Shell\"}}],\"listeners\":{}}", 
+  "description": "", 
+  "title": "New users", 
+  "uiStateJSON": "{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":null,\"direction\":null}}}}", 
+  "version": 1, 
+  "savedSearchId": "8030c1b0-fa77-11e6-ae9b-81e5311e8cab", 
+  "kibanaSavedObjectMeta": {
+    "searchSourceJSON": "{\"filter\":[]}"
+  }
+}

--- a/filebeat/module/system/auth/_meta/fields.yml
+++ b/filebeat/module/system/auth/_meta/fields.yml
@@ -1,0 +1,139 @@
+- name: auth
+  type: group
+  description: >
+    Fields from the Linux authorization logs.
+  fields:
+    - name: timestamp
+      description: >
+        The timestamp as read from the auth message.
+    - name: hostname
+      description: >
+        The hostname as read from the auth message.
+    - name: program
+      description: >
+        The process name as read from the auth message.
+    - name: pid
+      type: long
+      description: >
+        The PID of the process that sent the auth message.
+    - name: message
+      description: >
+        The message in the log line.
+    - name: user
+      description: >
+        The Unix user that this event refers to.
+
+    - name: ssh
+      type: group
+      description: >
+        Fields specific to SSH login events.
+      fields:
+      - name: event
+        description: >
+          The SSH login event. Can be one of "Accepted", "Failed", or "Invalid". "Accepted"
+          means a successful login. "Invalid" means that the user is not configured on the
+          system. "Failed" means that the SSH login attempt has failed.
+      - name: method
+        description: >
+          The SSH authentication method. Can be one of "password" or "publickey".
+      - name: ip
+        type: ip
+        description: >
+          The client IP from where the login attempt was made.
+      - name: dropped_ip
+        type: ip
+        description: >
+          The client IP from SSH connections that are open and immediately dropped.
+      - name: port
+        type: long
+        description: >
+          The client port from where the login attempt was made.
+      - name: signature
+        description: >
+          The signature of the client public key.
+      - name: geoip
+        type: group
+        description: >
+          Contains GeoIP information gathered based on the `system.auth.ip` field.
+          Only present if the GeoIP Elasticsearch plugin is available and
+          used.
+        fields:
+          - name: continent_name
+            type: keyword
+            description: >
+              The name of the continent.
+          - name: city_name
+            type: keyword
+            description: >
+              The name of the city.
+          - name: region_name
+            type: keyword
+            description: >
+              The name of the region.
+          - name: country_iso_code
+            type: keyword
+            description: >
+              Country ISO code.
+          - name: location
+            type: geo_point
+            description: >
+              The longitude and latitude.
+
+    - name: sudo
+      type: group
+      description: >
+        Fields specific to events created by the `sudo` command.
+      fields:
+      - name: error
+        example: user NOT in sudoers
+        description: >
+          The error message in case the sudo command failed.
+      - name: tty
+        description: >
+          The TTY where the sudo command is executed.
+      - name: pwd
+        description: >
+          The current directory where the sudo command is executed.
+      - name: user
+        example: root
+        description: >
+          The target user to which the sudo command is switching.
+      - name: command
+        description: >
+          The command executed via sudo.
+
+    - name: useradd
+      type: group
+      description: >
+        Fields specific to events created by the `useradd` command.
+      fields:
+      - name: name
+        description: >
+          The user name being added.
+      - name: uid
+        type: long
+        description:
+          The user ID.
+      - name: gid
+        type: long
+        description:
+          The group ID.
+      - name: home
+        description:
+          The home folder for the new user.
+      - name: shell
+        description:
+          The default shell for the new user.
+
+    - name: groupadd
+      type: group
+      description: >
+        Fields specific to events created by the `groupadd` command.
+      fields:
+      - name: name
+        description: >
+          The name of the new group.
+      - name: gid
+        type: long
+        description: >
+          The ID of the new group.

--- a/filebeat/module/system/auth/config/auth.yml
+++ b/filebeat/module/system/auth/config/auth.yml
@@ -1,0 +1,9 @@
+input_type: log
+paths:
+{{ range $i, $path := .paths }}
+ - {{$path}}
+{{ end }}
+exclude_files: [".gz$"]
+multiline:
+  pattern: "^\\s"
+  match: after

--- a/filebeat/module/system/auth/ingest/pipeline.json
+++ b/filebeat/module/system/auth/ingest/pipeline.json
@@ -1,0 +1,52 @@
+{
+  "description": "Pipeline for parsing system authorisation/secure logs",
+  "processors": [
+    {
+      "grok": {
+        "field": "message",
+        "ignore_missing": true,
+        "pattern_definitions" : {
+          "GREEDYMULTILINE" : "(.|\n)*"
+        },
+        "patterns": [
+          "%{SYSLOGTIMESTAMP:system.auth.timestamp} %{SYSLOGHOST:system.auth.hostname} sshd(?:\\[%{POSINT:system.auth.pid}\\])?: %{DATA:system.auth.ssh.event} %{DATA:system.auth.ssh.method} for (invalid user )?%{DATA:system.auth.user} from %{IPORHOST:system.auth.ssh.ip} port %{NUMBER:system.auth.ssh.port} ssh2(: %{GREEDYDATA:system.auth.ssh.signature})?",
+          "%{SYSLOGTIMESTAMP:system.auth.timestamp} %{SYSLOGHOST:system.auth.hostname} sshd(?:\\[%{POSINT:system.auth.pid}\\])?: %{DATA:system.auth.ssh.event} user %{DATA:system.auth.user} from %{IPORHOST:system.auth.ssh.ip}",
+          "%{SYSLOGTIMESTAMP:system.auth.timestamp} %{SYSLOGHOST:system.auth.hostname} sshd(?:\\[%{POSINT:system.auth.pid}\\])?: Did not receive identification string from %{IPORHOST:system.auth.ssh.dropped_ip}",
+          "%{SYSLOGTIMESTAMP:system.auth.timestamp} %{SYSLOGHOST:system.auth.hostname} sudo(?:\\[%{POSINT:system.auth.pid}\\])?: \\s*%{DATA:system.auth.user} :( %{DATA:system.auth.sudo.error} ;)? TTY=%{DATA:system.auth.sudo.tty} ; PWD=%{DATA:system.auth.sudo.pwd} ; USER=%{DATA:system.auth.sudo.user} ; COMMAND=%{GREEDYDATA:system.auth.sudo.command}",
+          "%{SYSLOGTIMESTAMP:system.auth.timestamp} %{SYSLOGHOST:system.auth.hostname} groupadd(?:\\[%{POSINT:system.auth.pid}\\])?: new group: name=%{DATA:system.auth.groupadd.name}, GID=%{NUMBER:system.auth.groupadd.gid}",
+          "%{SYSLOGTIMESTAMP:system.auth.timestamp} %{SYSLOGHOST:system.auth.hostname} useradd(?:\\[%{POSINT:system.auth.pid}\\])?: new user: name=%{DATA:system.auth.useradd.name}, UID=%{NUMBER:system.auth.useradd.uid}, GID=%{NUMBER:system.auth.useradd.gid}, home=%{DATA:system.auth.useradd.home}, shell=%{DATA:system.auth.useradd.shell}$",
+					"%{SYSLOGTIMESTAMP:system.auth.timestamp} %{SYSLOGHOST:system.auth.hostname} %{DATA:system.auth.program}(?:\\[%{POSINT:system.auth.pid}\\])?: %{GREEDYMULTILINE:system.auth.message}"
+        ]
+      }
+    },
+		{
+      "remove": {
+        "field": "message"
+      }
+    },
+		{
+      "date": {
+        "field": "system.auth.timestamp",
+        "target_field": "@timestamp",
+        "formats": [
+					"MMM  d HH:mm:ss",
+					"MMM dd HH:mm:ss"
+        ],
+        "ignore_failure": true
+      }
+    },
+    {
+      "geoip": {
+        "field": "system.auth.ssh.ip",
+        "target_field": "system.auth.ssh.geoip",
+        "ignore_failure": true
+      }
+    }
+  ],
+  "on_failure" : [{
+    "set" : {
+      "field" : "error",
+      "value" : "{{ _ingest.on_failure_message }}"
+    }
+  }]
+}

--- a/filebeat/module/system/auth/manifest.yml
+++ b/filebeat/module/system/auth/manifest.yml
@@ -1,0 +1,15 @@
+module_version: 1.0
+
+var:
+  - name: paths
+    default:
+      - /var/log/auth.log*
+      - /var/log/secure*
+    os.darwin:
+      # this works in OS X < 10.8. Newer darwin versions don't write
+      # ssh logs to files
+      - /var/log/secure.log*
+    os.windows: []
+
+ingest_pipeline: ingest/pipeline.json
+prospector: config/auth.yml

--- a/filebeat/module/system/auth/test/auth-ubuntu1204.log
+++ b/filebeat/module/system/auth/test/auth-ubuntu1204.log
@@ -1,0 +1,1000 @@
+Feb  9 21:19:40 precise32 sshd[8317]: subsystem request for sftp by user vagrant
+Feb  9 21:19:40 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-lhspyyxxlfzpytwsebjoegenjxyjombo; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1486675177.72-26828938879074/get_url; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1486675177.72-26828938879074/ >/dev/null 2>&1
+Feb  9 21:19:40 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb  9 21:19:41 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb  9 21:19:41 precise32 sshd[8317]: subsystem request for sftp by user vagrant
+Feb  9 21:19:48 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-xspkubktopzqiwiofvdhqaglconkrgwp; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1486675181.24-158548606882799/get_url; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1486675181.24-158548606882799/ >/dev/null 2>&1
+Feb  9 21:19:48 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb  9 21:19:53 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb  9 21:20:02 precise32 sshd[8317]: subsystem request for sftp by user vagrant
+Feb  9 21:20:03 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-vxcrqvczsrjrrsjcokculalhrgfsxqzl; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1486675202.4-199750250589919/command; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1486675202.4-199750250589919/ >/dev/null 2>&1
+Feb  9 21:20:03 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb  9 21:20:03 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb  9 21:20:03 precise32 sshd[8317]: subsystem request for sftp by user vagrant
+Feb  9 21:20:03 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-gruorqbeefuuhfprfoqzsftalatgwwvf; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1486675203.3-59927285912173/file; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1486675203.3-59927285912173/ >/dev/null 2>&1
+Feb  9 21:20:03 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb  9 21:20:03 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb  9 21:20:05 precise32 sshd[8317]: subsystem request for sftp by user vagrant
+Feb  9 21:20:05 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-fnthqelgspkbnpnxlsknzcbyxbqqxpmt; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1486675204.07-135388534337396/command; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1486675204.07-135388534337396/ >/dev/null 2>&1
+Feb  9 21:20:05 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb  9 21:20:05 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb  9 21:20:06 precise32 sshd[8317]: subsystem request for sftp by user vagrant
+Feb  9 21:20:08  sshd[8317]: last message repeated 2 times
+Feb  9 21:20:08 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-wagdvfiuqxtryvmyrqlfcwoxeqqrxejt; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1486675206.28-198308747142204/async_wrapper 321853834469 45 /home/vagrant/.ansible/tmp/ansible-tmp-1486675206.28-198308747142204/command /home/vagrant/.ansible/tmp/ansible-tmp-1486675206.28-198308747142204/arguments; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1486675206.28-198308747142204/ >/dev/null 2>&1
+Feb  9 21:20:08 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb  9 21:20:09 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb  9 21:20:12 precise32 sshd[8317]: subsystem request for sftp by user vagrant
+Feb  9 21:20:12 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-lkgydmrwiywdfvxfoxmgntufiumtzpmq; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1486675212.66-81790186240643/command; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1486675212.66-81790186240643/ >/dev/null 2>&1
+Feb  9 21:20:12 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb  9 21:20:13 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb  9 21:20:19 precise32 sshd[8317]: subsystem request for sftp by user vagrant
+Feb  9 21:20:19 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-mjsapklbglujaoktlsyytirwygexdily; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1486675218.96-234174787135180/command; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1486675218.96-234174787135180/ >/dev/null 2>&1
+Feb  9 21:20:19 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb  9 21:20:19 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb  9 21:20:19 precise32 sshd[8317]: subsystem request for sftp by user vagrant
+Feb  9 21:20:19 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-kvmafqtdnnvnyfyqlnoovickcavkqwdy; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1486675219.83-99205535237718/setup; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1486675219.83-99205535237718/ >/dev/null 2>&1
+Feb  9 21:20:19 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb  9 21:20:20 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb  9 21:20:24 precise32 sshd[8317]: subsystem request for sftp by user vagrant
+Feb  9 21:20:24 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-nhrnwbdpypmsmvcstuihfqfbcvpxrmys; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1486675224.58-12467498973476/get_url; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1486675224.58-12467498973476/ >/dev/null 2>&1
+Feb  9 21:20:24 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb  9 21:20:25 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb  9 21:20:28 precise32 sshd[8317]: subsystem request for sftp by user vagrant
+Feb  9 21:20:28 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-buzartmsbrirxgcoibjpsqjkldihhexh; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1486675228.25-195852789001210/get_url; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1486675228.25-195852789001210/ >/dev/null 2>&1
+Feb  9 21:20:28 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb  9 21:20:31 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb  9 21:20:47 precise32 sshd[8317]: subsystem request for sftp by user vagrant
+Feb  9 21:20:47 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-swwkpvmnxhcuduxerfbgclhsmgbhwzie; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1486675247.78-128146395950020/command; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1486675247.78-128146395950020/ >/dev/null 2>&1
+Feb  9 21:20:47 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb  9 21:20:48 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb  9 21:20:50 precise32 sshd[8317]: subsystem request for sftp by user vagrant
+Feb  9 21:20:50 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-raffykohamlcbnpxzipksbvfpjbfpagy; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1486675250.82-190689706060358/apt; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1486675250.82-190689706060358/ >/dev/null 2>&1
+Feb  9 21:20:50 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb  9 21:20:51 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb  9 21:20:51 precise32 sshd[8317]: subsystem request for sftp by user vagrant
+Feb  9 21:20:51 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-dfoxiractbmtavfiwfnhzfkftipjumph; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1486675251.6-137767038423665/apt; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1486675251.6-137767038423665/ >/dev/null 2>&1
+Feb  9 21:20:51 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb  9 21:20:53 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb  9 21:21:01 precise32 sshd[8317]: subsystem request for sftp by user vagrant
+Feb  9 21:21:01 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-jveaoynmhsmeodakzfhhaodihyroxobu; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1486675261.29-208287411335817/file; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1486675261.29-208287411335817/ >/dev/null 2>&1
+Feb  9 21:21:01 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb  9 21:21:01 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb  9 21:21:02 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-lwzhcvorajmjyxsrqydafzapoeescwaf; rc=flag; [ -r /etc/metricbeat/metricbeat.yml ] || rc=2; [ -f /etc/metricbeat/metricbeat.yml ] || rc=1; [ -d /etc/metricbeat/metricbeat.yml ] && rc=3; python -V 2>/dev/null || rc=4; [ x"$rc" != "xflag" ] && echo "${rc}  "/etc/metricbeat/metricbeat.yml && exit 0; (python -c 'import hashlib; BLOCKSIZE = 65536; hasher = hashlib.sha1();#012afile = open("'/etc/metricbeat/metricbeat.yml'", "rb")#012buf = afile.read(BLOCKSIZE)#012while len(buf) > 0:#012#011hasher.update(buf)#012#011buf = afile.read(BLOCKSIZE)#012afile.close()#012print(hasher.hexdigest())' 2>/dev/null) || (python -c 'import sha; BLOCKSIZE = 65536; hasher = sha.sha();#012afile = open("'/etc/metricbeat/metricbeat.yml'", "rb")#012buf = afile.read(BLOCKSIZE)#012while len(buf) > 0:#012#011hasher.update(buf)#012#011buf = afile.read(BLOCKSIZE)#012afile.close()#012print(hasher.hexdigest())' 2>/dev/null) || (echo '0 
+Feb  9 21:21:02 precise32 sudo:  vagrant : (command continued) '/etc/metricbeat/metricbeat.yml)
+Feb  9 21:21:02 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb  9 21:21:02 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb  9 21:21:02 precise32 sshd[8317]: subsystem request for sftp by user vagrant
+Feb  9 21:21:02 precise32 sshd[8317]: subsystem request for sftp by user vagrant
+Feb  9 21:21:02 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-yesyhegdrhiolusidthffdemrxphqdfm; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1486675262.15-83340738940485/copy; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1486675262.15-83340738940485/ >/dev/null 2>&1
+Feb  9 21:21:02 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb  9 21:21:02 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb  9 21:21:03 precise32 sshd[8317]: subsystem request for sftp by user vagrant
+Feb  9 21:21:03 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-vqbyiylfjufyxlwvxcwusklrtmiekpia; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1486675263.16-15325827909434/service; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1486675263.16-15325827909434/ >/dev/null 2>&1
+Feb  9 21:21:03 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb  9 21:21:03 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb  9 21:21:04 precise32 sshd[8317]: subsystem request for sftp by user vagrant
+Feb  9 21:21:05 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-osrbplljwskuafamtjuanhwfxqdxmfbj; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1486675264.47-179299683847940/wait_for; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1486675264.47-179299683847940/ >/dev/null 2>&1
+Feb  9 21:21:05 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb  9 21:21:05 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb  9 21:21:05 precise32 sshd[8317]: subsystem request for sftp by user vagrant
+Feb  9 21:21:05 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-xqypdfdxashhaekghbfnpdlcgsmfarmy; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1486675265.39-273766954542007/service; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1486675265.39-273766954542007/ >/dev/null 2>&1
+Feb  9 21:21:05 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb  9 21:21:05 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb  9 21:21:06 precise32 sshd[8317]: subsystem request for sftp by user vagrant
+Feb  9 21:21:06 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-ktkmpxhjivossxngupfgrqfobhopruzp; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1486675266.58-47565152594552/apt; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1486675266.58-47565152594552/ >/dev/null 2>&1
+Feb  9 21:21:06 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb  9 21:21:08 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb  9 21:21:15 precise32 sshd[8317]: subsystem request for sftp by user vagrant
+Feb  9 21:21:15 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-erpqyqrmifxazcclvbqytjwxgdplhtpy; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1486675275.74-155140815824587/file; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1486675275.74-155140815824587/ >/dev/null 2>&1
+Feb  9 21:21:15 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb  9 21:21:15 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb  9 21:21:16 precise32 sshd[8317]: subsystem request for sftp by user vagrant
+Feb  9 21:21:16 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-cfqjebskszjdqpksprlbjpbttastwzyp; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1486675276.62-248748589735433/get_url; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1486675276.62-248748589735433/ >/dev/null 2>&1
+Feb  9 21:21:16 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb  9 21:21:17 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb  9 21:21:20 precise32 sshd[8317]: subsystem request for sftp by user vagrant
+Feb  9 21:21:30 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-oxbowrzvfhsebemuiblilqwvdxvnwztv; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1486675280.28-272460786101534/get_url; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1486675280.28-272460786101534/ >/dev/null 2>&1
+Feb  9 21:21:30 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb  9 21:21:33 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb  9 21:21:42 precise32 sshd[8317]: subsystem request for sftp by user vagrant
+Feb  9 21:21:42 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-ohlhhhazvtawqawluadjlxglowwenmyc; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1486675302.51-201837201796085/command; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1486675302.51-201837201796085/ >/dev/null 2>&1
+Feb  9 21:21:42 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb  9 21:21:42 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb  9 21:21:43 precise32 sshd[8317]: subsystem request for sftp by user vagrant
+Feb  9 21:21:43 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-fxkkbzmbdrxgbhejuievvukihnyxxqru; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1486675303.65-64589423443234/file; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1486675303.65-64589423443234/ >/dev/null 2>&1
+Feb  9 21:21:43 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb  9 21:21:43 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb  9 21:21:46 precise32 sshd[8317]: subsystem request for sftp by user vagrant
+Feb  9 21:21:46 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-teszjmcjmewxckcimdrpzexuffcbqxao; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1486675304.47-137831346757512/command; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1486675304.47-137831346757512/ >/dev/null 2>&1
+Feb  9 21:21:46 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb  9 21:21:46 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb  9 21:21:46 precise32 sshd[8317]: subsystem request for sftp by user vagrant
+Feb  9 21:21:47  sshd[8317]: last message repeated 2 times
+Feb  9 21:21:47 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-pcgidnbwkzuhorearmbjkeyqhxbtoryr; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1486675306.84-180653352879797/async_wrapper 40788874474 45 /home/vagrant/.ansible/tmp/ansible-tmp-1486675306.84-180653352879797/command /home/vagrant/.ansible/tmp/ansible-tmp-1486675306.84-180653352879797/arguments; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1486675306.84-180653352879797/ >/dev/null 2>&1
+Feb  9 21:21:47 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb  9 21:21:48 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb  9 21:21:52 precise32 sshd[8317]: subsystem request for sftp by user vagrant
+Feb  9 21:21:52 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-uiafyjflnjoezymltalnhkurjonjaxsb; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1486675312.77-162101214367573/command; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1486675312.77-162101214367573/ >/dev/null 2>&1
+Feb  9 21:21:52 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb  9 21:21:53 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb  9 21:21:58 precise32 sshd[8317]: subsystem request for sftp by user vagrant
+Feb  9 21:21:59 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-awdbaonvfappmyhngzuxzbnrgrvmxxmq; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1486675318.92-83212533004754/wait_for; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1486675318.92-83212533004754/ >/dev/null 2>&1
+Feb  9 21:21:59 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb  9 21:21:59 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb  9 21:22:00 precise32 sshd[8317]: subsystem request for sftp by user vagrant
+Feb  9 21:22:00 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-epglqzpqtvukjkntkhcypzqakykknrhq; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1486675319.97-182898557012273/command; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1486675319.97-182898557012273/ >/dev/null 2>&1
+Feb  9 21:22:00 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb  9 21:22:00 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb  9 21:22:01 precise32 sshd[8317]: subsystem request for sftp by user vagrant
+Feb  9 21:22:01 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-adsulhhhqeihfgdctumfajchfpykjanw; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1486675320.85-143796414377457/setup; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1486675320.85-143796414377457/ >/dev/null 2>&1
+Feb  9 21:22:01 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb  9 21:22:02 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb  9 21:22:06 precise32 sshd[8317]: subsystem request for sftp by user vagrant
+Feb  9 21:22:07 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-ikwqsmlxlzbtrcfoklcfexlshzphvbqf; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1486675326.05-203247712855500/get_url; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1486675326.05-203247712855500/ >/dev/null 2>&1
+Feb  9 21:22:07 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb  9 21:22:07 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb  9 21:22:09 precise32 sshd[8317]: subsystem request for sftp by user vagrant
+Feb  9 21:22:09 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-xhyimrwqolspqnrwuvixgrnmbeceaozk; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1486675329.7-68540523481235/get_url; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1486675329.7-68540523481235/ >/dev/null 2>&1
+Feb  9 21:22:09 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb  9 21:22:13 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb  9 21:22:29 precise32 sshd[8317]: subsystem request for sftp by user vagrant
+Feb  9 21:22:29 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-dlbnvyqsiivzagpchvvbtwvxmwqxphun; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1486675349.52-51181422479289/command; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1486675349.52-51181422479289/ >/dev/null 2>&1
+Feb  9 21:22:29 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb  9 21:22:29 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb  9 21:22:32 precise32 sshd[8317]: subsystem request for sftp by user vagrant
+Feb  9 21:22:32 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-mpdyxmjmnedlqsbagcvkhcqtilemaxnj; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1486675352.75-31376555221975/apt; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1486675352.75-31376555221975/ >/dev/null 2>&1
+Feb  9 21:22:32 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb  9 21:22:33 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb  9 21:22:33 precise32 sshd[8317]: subsystem request for sftp by user vagrant
+Feb  9 21:22:34 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-fjfnzqcwaxwyrarfaquhblztpezkynfm; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1486675353.58-232202092763250/apt; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1486675353.58-232202092763250/ >/dev/null 2>&1
+Feb  9 21:22:34 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb  9 21:22:36 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb  9 21:22:43 precise32 sshd[8317]: subsystem request for sftp by user vagrant
+Feb  9 21:22:43 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-hjkoqjulpizhatgojelxjvwmqmeqebpo; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1486675362.92-74451552200205/file; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1486675362.92-74451552200205/ >/dev/null 2>&1
+Feb  9 21:22:43 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb  9 21:22:43 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb  9 21:22:44 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-qlixydmzekacecpiurdomusznjsqtvvp; rc=flag; [ -r /etc/heartbeat/heartbeat.yml ] || rc=2; [ -f /etc/heartbeat/heartbeat.yml ] || rc=1; [ -d /etc/heartbeat/heartbeat.yml ] && rc=3; python -V 2>/dev/null || rc=4; [ x"$rc" != "xflag" ] && echo "${rc}  "/etc/heartbeat/heartbeat.yml && exit 0; (python -c 'import hashlib; BLOCKSIZE = 65536; hasher = hashlib.sha1();#012afile = open("'/etc/heartbeat/heartbeat.yml'", "rb")#012buf = afile.read(BLOCKSIZE)#012while len(buf) > 0:#012#011hasher.update(buf)#012#011buf = afile.read(BLOCKSIZE)#012afile.close()#012print(hasher.hexdigest())' 2>/dev/null) || (python -c 'import sha; BLOCKSIZE = 65536; hasher = sha.sha();#012afile = open("'/etc/heartbeat/heartbeat.yml'", "rb")#012buf = afile.read(BLOCKSIZE)#012while len(buf) > 0:#012#011hasher.update(buf)#012#011buf = afile.read(BLOCKSIZE)#012afile.close()#012print(hasher.hexdigest())' 2>/dev/null) || (echo '0 
+Feb  9 21:22:44 precise32 sudo:  vagrant : (command continued) '/etc/heartbeat/heartbeat.yml)
+Feb  9 21:22:44 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb  9 21:22:44 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb  9 21:22:44 precise32 sshd[8317]: subsystem request for sftp by user vagrant
+Feb  9 21:22:44 precise32 sshd[8317]: subsystem request for sftp by user vagrant
+Feb  9 21:22:44 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-ajqomrxbnhudtprtcsrbntwrkcjeibxi; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1486675364.45-217362589658234/copy; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1486675364.45-217362589658234/ >/dev/null 2>&1
+Feb  9 21:22:44 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb  9 21:22:44 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb  9 21:22:45 precise32 sshd[8317]: subsystem request for sftp by user vagrant
+Feb  9 21:22:45 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-acvwapcldjqoeakolbpynaqpoldxbjxn; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1486675365.11-82479565966466/service; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1486675365.11-82479565966466/ >/dev/null 2>&1
+Feb  9 21:22:45 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb  9 21:22:45 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb  9 21:22:46 precise32 sshd[8317]: subsystem request for sftp by user vagrant
+Feb  9 21:22:46 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-ovavtenadmsuwjadjpdzgnzkzcrdtcrl; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1486675366.39-91454860430660/wait_for; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1486675366.39-91454860430660/ >/dev/null 2>&1
+Feb  9 21:22:46 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb  9 21:22:47 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb  9 21:22:48 precise32 sshd[8317]: subsystem request for sftp by user vagrant
+Feb  9 21:22:48 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-lcouezrlyawlsxyxqtteptekjflkxgvl; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1486675368.21-115041673323332/service; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1486675368.21-115041673323332/ >/dev/null 2>&1
+Feb  9 21:22:48 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb  9 21:22:48 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb  9 21:22:49 precise32 sshd[8317]: subsystem request for sftp by user vagrant
+Feb  9 21:22:51 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-dlvojyckxrrunoxvzdtrrjnasqwvhrir; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1486675369.58-23315001061866/apt; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1486675369.58-23315001061866/ >/dev/null 2>&1
+Feb  9 21:22:51 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb  9 21:22:52 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb  9 21:22:58 precise32 sshd[8317]: subsystem request for sftp by user vagrant
+Feb  9 21:22:58 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-yiotgcbibvnhentlusjejfibawiojokv; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1486675378.05-28330678876735/file; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1486675378.05-28330678876735/ >/dev/null 2>&1
+Feb  9 21:22:58 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb  9 21:22:58 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb  9 21:22:59 precise32 sshd[8317]: subsystem request for sftp by user vagrant
+Feb  9 21:22:59 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-cujnxfaprouklabmdpyojwiswgtknxyr; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1486675379.11-115543127564480/get_url; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1486675379.11-115543127564480/ >/dev/null 2>&1
+Feb  9 21:22:59 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb  9 21:22:59 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb  9 21:23:02 precise32 sshd[8317]: subsystem request for sftp by user vagrant
+Feb  9 21:23:02 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-lbfdybsgwoexbttukdvmqdqeihvyivds; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1486675382.79-175899445627464/get_url; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1486675382.79-175899445627464/ >/dev/null 2>&1
+Feb  9 21:23:02 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb  9 21:23:06 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb  9 21:23:22 precise32 sshd[8317]: subsystem request for sftp by user vagrant
+Feb  9 21:23:22 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-htlyhfgwucqsaucceyrodskdpmmkdste; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1486675401.72-28086953836565/command; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1486675401.72-28086953836565/ >/dev/null 2>&1
+Feb  9 21:23:22 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb  9 21:23:22 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb  9 21:23:22 precise32 sshd[8317]: subsystem request for sftp by user vagrant
+Feb  9 21:23:22 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-dcfnygpdavffrbrogmsybfxkhccsnqqw; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1486675402.55-52286886998725/file; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1486675402.55-52286886998725/ >/dev/null 2>&1
+Feb  9 21:23:22 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb  9 21:23:22 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb  9 21:23:23 precise32 sshd[8317]: subsystem request for sftp by user vagrant
+Feb  9 21:23:23 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-ggpdimpxsyacqevtqfkprmzbmlzzrkan; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1486675403.27-231673287482858/command; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1486675403.27-231673287482858/ >/dev/null 2>&1
+Feb  9 21:23:23 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb  9 21:23:23 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb  9 21:23:25 precise32 sshd[8317]: subsystem request for sftp by user vagrant
+Feb  9 21:23:25  sshd[8317]: last message repeated 2 times
+Feb  9 21:23:25 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-fumdsdwhnsyqdpxdtlguuplqfqgcsayx; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1486675405.35-15951944312742/async_wrapper 669982207445 45 /home/vagrant/.ansible/tmp/ansible-tmp-1486675405.35-15951944312742/command /home/vagrant/.ansible/tmp/ansible-tmp-1486675405.35-15951944312742/arguments; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1486675405.35-15951944312742/ >/dev/null 2>&1
+Feb  9 21:23:25 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb  9 21:23:26 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb  9 21:23:31 precise32 sshd[8317]: subsystem request for sftp by user vagrant
+Feb  9 21:23:34 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-jiaetvfxpwjlomrcorahxgplhvzrubfa; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1486675411.21-151981974783794/command; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1486675411.21-151981974783794/ >/dev/null 2>&1
+Feb  9 21:23:34 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb  9 21:23:35 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb  9 21:23:37 precise32 sshd[8317]: subsystem request for sftp by user vagrant
+Feb  9 21:23:37 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-mguewlrhhlvqjpdmsutqaqmchdrsuidz; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1486675417.39-200931953942031/command; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1486675417.39-200931953942031/ >/dev/null 2>&1
+Feb  9 21:23:37 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb  9 21:23:37 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb  9 21:24:37 precise32 sshd[8317]: Received disconnect from 10.0.2.2: 11: disconnected by user
+Feb  9 21:24:37 precise32 sshd[8302]: pam_unix(sshd:session): session closed for user vagrant
+Feb  9 22:17:01 precise32 CRON[9966]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb  9 22:17:01 precise32 CRON[9966]: pam_unix(cron:session): session closed for user root
+Feb  9 23:17:01 precise32 CRON[9979]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb  9 23:17:01 precise32 CRON[9979]: pam_unix(cron:session): session closed for user root
+Feb 10 08:29:29 precise32 sshd[9987]: Accepted publickey for vagrant from 10.0.2.2 port 52776 ssh2
+Feb 10 08:29:29 precise32 sshd[9987]: pam_unix(sshd:session): session opened for user vagrant by (uid=0)
+Feb 10 08:29:40 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/usr/bin/vi /etc/apt/sources.list
+Feb 10 08:29:40 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 10 08:29:43 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 10 08:29:56 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/usr/bin/vi /etc/apt/sources.list.d/elastic
+Feb 10 08:29:56 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 10 08:30:07 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 10 08:30:11 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/usr/bin/apt-get update
+Feb 10 08:30:11 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 10 08:30:18 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 10 08:30:40 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/mv /etc/apt/sources.list.d/elastic /etc/apt/sources.list.d/elastic.list
+Feb 10 08:30:40 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 10 08:30:40 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 10 08:30:41 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/usr/bin/apt-get update
+Feb 10 08:30:41 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 10 08:30:52 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 10 08:31:03 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/usr/bin/apt-get install filebeat
+Feb 10 08:31:03 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 10 08:31:19 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 10 08:31:43 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/usr/bin/apt-get install filebeat=5.2.0
+Feb 10 08:31:43 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 10 08:31:43 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 10 08:31:51 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/usr/bin/apt-get install metricbeat=5.2.0
+Feb 10 08:31:51 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 10 08:31:51 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 10 08:37:00 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/usr/bin/apt-get install metricbeat
+Feb 10 08:37:00 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 10 08:37:08 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 10 08:37:09 precise32 sshd[10002]: Received disconnect from 10.0.2.2: 11: disconnected by user
+Feb 10 08:37:09 precise32 sshd[9987]: pam_unix(sshd:session): session closed for user vagrant
+Feb 10 09:17:01 precise32 CRON[10439]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 10 09:17:01 precise32 CRON[10439]: pam_unix(cron:session): session closed for user root
+Feb 10 10:17:01 precise32 CRON[10454]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 10 10:17:01 precise32 CRON[10454]: pam_unix(cron:session): session closed for user root
+Feb 10 11:17:01 precise32 CRON[10469]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 10 11:17:01 precise32 CRON[10469]: pam_unix(cron:session): session closed for user root
+Feb 10 12:17:01 precise32 CRON[10488]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 10 12:17:01 precise32 CRON[10488]: pam_unix(cron:session): session closed for user root
+Feb 10 13:17:01 precise32 CRON[10503]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 10 13:17:01 precise32 CRON[10503]: pam_unix(cron:session): session closed for user root
+Feb 10 14:17:01 precise32 CRON[10537]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 10 14:17:01 precise32 CRON[10537]: pam_unix(cron:session): session closed for user root
+Feb 10 17:17:01 precise32 CRON[10553]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 10 17:17:01 precise32 CRON[10553]: pam_unix(cron:session): session closed for user root
+Feb 10 18:17:01 precise32 CRON[10570]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 10 18:17:01 precise32 CRON[10570]: pam_unix(cron:session): session closed for user root
+Feb 10 19:17:01 precise32 CRON[10588]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 10 19:17:01 precise32 CRON[10588]: pam_unix(cron:session): session closed for user root
+Feb 10 20:17:01 precise32 CRON[10606]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 10 20:17:01 precise32 CRON[10606]: pam_unix(cron:session): session closed for user root
+Feb 10 21:17:01 precise32 CRON[10623]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 10 21:17:01 precise32 CRON[10623]: pam_unix(cron:session): session closed for user root
+Feb 11 09:17:01 precise32 CRON[10641]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 11 09:17:01 precise32 CRON[10641]: pam_unix(cron:session): session closed for user root
+Feb 11 10:17:01 precise32 CRON[10658]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 11 10:17:01 precise32 CRON[10658]: pam_unix(cron:session): session closed for user root
+Feb 11 11:17:01 precise32 CRON[10673]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 11 11:17:01 precise32 CRON[10673]: pam_unix(cron:session): session closed for user root
+Feb 11 12:17:01 precise32 CRON[10693]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 11 12:17:01 precise32 CRON[10693]: pam_unix(cron:session): session closed for user root
+Feb 11 13:17:01 precise32 CRON[10711]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 11 13:17:01 precise32 CRON[10711]: pam_unix(cron:session): session closed for user root
+Feb 11 14:17:01 precise32 CRON[10807]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 11 14:17:01 precise32 CRON[10807]: pam_unix(cron:session): session closed for user root
+Feb 11 15:17:01 precise32 CRON[10825]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 11 15:17:01 precise32 CRON[10825]: pam_unix(cron:session): session closed for user root
+Feb 11 16:17:01 precise32 CRON[10841]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 11 16:17:01 precise32 CRON[10841]: pam_unix(cron:session): session closed for user root
+Feb 11 17:17:01 precise32 CRON[10858]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 11 17:17:01 precise32 CRON[10858]: pam_unix(cron:session): session closed for user root
+Feb 11 18:17:01 precise32 CRON[10875]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 11 18:17:01 precise32 CRON[10875]: pam_unix(cron:session): session closed for user root
+Feb 11 19:17:01 precise32 CRON[10893]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 11 19:17:01 precise32 CRON[10893]: pam_unix(cron:session): session closed for user root
+Feb 11 20:17:01 precise32 CRON[10909]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 11 20:17:01 precise32 CRON[10909]: pam_unix(cron:session): session closed for user root
+Feb 11 21:17:01 precise32 CRON[10923]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 11 21:17:01 precise32 CRON[10923]: pam_unix(cron:session): session closed for user root
+Feb 11 22:17:01 precise32 CRON[10941]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 11 22:17:01 precise32 CRON[10941]: pam_unix(cron:session): session closed for user root
+Feb 12 16:17:01 precise32 CRON[10952]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 12 16:17:01 precise32 CRON[10952]: pam_unix(cron:session): session closed for user root
+Feb 12 17:17:01 precise32 CRON[10971]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 12 17:17:01 precise32 CRON[10971]: pam_unix(cron:session): session closed for user root
+Feb 12 18:17:01 precise32 CRON[11064]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 12 18:17:01 precise32 CRON[11064]: pam_unix(cron:session): session closed for user root
+Feb 12 19:17:01 precise32 CRON[11082]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 12 19:17:01 precise32 CRON[11082]: pam_unix(cron:session): session closed for user root
+Feb 12 20:17:01 precise32 CRON[11101]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 12 20:17:01 precise32 CRON[11101]: pam_unix(cron:session): session closed for user root
+Feb 12 21:17:01 precise32 CRON[11118]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 12 21:17:01 precise32 CRON[11118]: pam_unix(cron:session): session closed for user root
+Feb 12 22:17:01 precise32 CRON[11137]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 12 22:17:01 precise32 CRON[11137]: pam_unix(cron:session): session closed for user root
+Feb 13 08:17:01 precise32 CRON[11153]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 13 08:17:01 precise32 CRON[11153]: pam_unix(cron:session): session closed for user root
+Feb 13 09:17:01 precise32 CRON[11170]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 13 09:17:01 precise32 CRON[11170]: pam_unix(cron:session): session closed for user root
+Feb 13 10:17:01 precise32 CRON[11185]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 13 10:17:01 precise32 CRON[11185]: pam_unix(cron:session): session closed for user root
+Feb 13 11:17:01 precise32 CRON[11199]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 13 11:17:01 precise32 CRON[11199]: pam_unix(cron:session): session closed for user root
+Feb 13 12:17:01 precise32 CRON[11214]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 13 12:17:01 precise32 CRON[11214]: pam_unix(cron:session): session closed for user root
+Feb 13 13:17:01 precise32 CRON[11228]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 13 13:17:01 precise32 CRON[11228]: pam_unix(cron:session): session closed for user root
+Feb 13 14:17:01 precise32 CRON[11262]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 13 14:17:01 precise32 CRON[11262]: pam_unix(cron:session): session closed for user root
+Feb 13 15:17:01 precise32 CRON[11276]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 13 15:17:01 precise32 CRON[11276]: pam_unix(cron:session): session closed for user root
+Feb 13 16:17:01 precise32 CRON[11283]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 13 16:17:01 precise32 CRON[11283]: pam_unix(cron:session): session closed for user root
+Feb 13 17:17:01 precise32 CRON[11295]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 13 17:17:01 precise32 CRON[11295]: pam_unix(cron:session): session closed for user root
+Feb 13 18:17:01 precise32 CRON[11308]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 13 18:17:01 precise32 CRON[11308]: pam_unix(cron:session): session closed for user root
+Feb 13 19:17:01 precise32 CRON[11326]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 13 19:17:01 precise32 CRON[11326]: pam_unix(cron:session): session closed for user root
+Feb 13 20:17:01 precise32 CRON[11341]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 13 20:17:01 precise32 CRON[11341]: pam_unix(cron:session): session closed for user root
+Feb 13 21:17:01 precise32 CRON[11359]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 13 21:17:01 precise32 CRON[11359]: pam_unix(cron:session): session closed for user root
+Feb 13 22:17:01 precise32 CRON[11375]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 13 22:17:01 precise32 CRON[11375]: pam_unix(cron:session): session closed for user root
+Feb 14 07:17:01 precise32 CRON[11385]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 14 07:17:01 precise32 CRON[11385]: pam_unix(cron:session): session closed for user root
+Feb 14 08:17:01 precise32 CRON[11401]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 14 08:17:01 precise32 CRON[11401]: pam_unix(cron:session): session closed for user root
+Feb 14 09:17:01 precise32 CRON[11417]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 14 09:17:01 precise32 CRON[11417]: pam_unix(cron:session): session closed for user root
+Feb 14 10:17:01 precise32 CRON[11453]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 14 10:17:01 precise32 CRON[11453]: pam_unix(cron:session): session closed for user root
+Feb 14 11:17:01 precise32 CRON[11466]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 14 11:17:01 precise32 CRON[11466]: pam_unix(cron:session): session closed for user root
+Feb 14 12:17:01 precise32 CRON[11480]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 14 12:17:01 precise32 CRON[11480]: pam_unix(cron:session): session closed for user root
+Feb 14 13:17:01 precise32 CRON[11495]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 14 13:17:01 precise32 CRON[11495]: pam_unix(cron:session): session closed for user root
+Feb 14 14:17:01 precise32 CRON[11510]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 14 14:17:02 precise32 CRON[11510]: pam_unix(cron:session): session closed for user root
+Feb 14 15:17:01 precise32 CRON[11527]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 14 15:17:01 precise32 CRON[11527]: pam_unix(cron:session): session closed for user root
+Feb 14 16:17:01 precise32 CRON[11542]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 14 16:17:01 precise32 CRON[11542]: pam_unix(cron:session): session closed for user root
+Feb 14 17:17:01 precise32 CRON[11558]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 14 17:17:01 precise32 CRON[11558]: pam_unix(cron:session): session closed for user root
+Feb 14 18:17:01 precise32 CRON[11574]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 14 18:17:01 precise32 CRON[11574]: pam_unix(cron:session): session closed for user root
+Feb 14 19:17:01 precise32 CRON[11586]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 14 19:17:01 precise32 CRON[11586]: pam_unix(cron:session): session closed for user root
+Feb 15 09:17:01 precise32 CRON[11627]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 15 09:17:01 precise32 CRON[11627]: pam_unix(cron:session): session closed for user root
+Feb 15 10:17:01 precise32 CRON[11639]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 15 10:17:01 precise32 CRON[11639]: pam_unix(cron:session): session closed for user root
+Feb 15 11:17:01 precise32 CRON[11656]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 15 11:17:01 precise32 CRON[11656]: pam_unix(cron:session): session closed for user root
+Feb 15 12:17:01 precise32 CRON[11671]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 15 12:17:01 precise32 CRON[11671]: pam_unix(cron:session): session closed for user root
+Feb 15 13:17:01 precise32 CRON[11685]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 15 13:17:01 precise32 CRON[11685]: pam_unix(cron:session): session closed for user root
+Feb 15 14:17:01 precise32 CRON[11700]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 15 14:17:01 precise32 CRON[11700]: pam_unix(cron:session): session closed for user root
+Feb 15 15:17:01 precise32 CRON[11713]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 15 15:17:01 precise32 CRON[11713]: pam_unix(cron:session): session closed for user root
+Feb 15 16:17:01 precise32 CRON[11728]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 15 16:17:01 precise32 CRON[11728]: pam_unix(cron:session): session closed for user root
+Feb 15 17:17:01 precise32 CRON[11743]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 15 17:17:01 precise32 CRON[11743]: pam_unix(cron:session): session closed for user root
+Feb 15 18:17:01 precise32 CRON[11784]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 15 18:17:01 precise32 CRON[11784]: pam_unix(cron:session): session closed for user root
+Feb 15 19:17:01 precise32 CRON[11797]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 15 19:17:01 precise32 CRON[11797]: pam_unix(cron:session): session closed for user root
+Feb 15 20:17:01 precise32 CRON[11838]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 15 20:17:01 precise32 CRON[11838]: pam_unix(cron:session): session closed for user root
+Feb 16 06:04:36 precise32 sshd[11846]: Accepted publickey for vagrant from 10.0.2.2 port 57698 ssh2
+Feb 16 06:04:36 precise32 sshd[11846]: pam_unix(sshd:session): session opened for user vagrant by (uid=0)
+Feb 16 06:04:36 precise32 sudo:  vagrant : TTY=unknown ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/bash -l
+Feb 16 06:04:36 precise32 sudo: pam_unix(sudo:session): session opened for user root by (uid=1000)
+Feb 16 06:04:36 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 21 20:53:59 precise32 sshd[524]: Received signal 15; terminating.
+Feb 21 20:53:59 precise32 sshd[786]: Server listening on 0.0.0.0 port 22.
+Feb 21 20:53:59 precise32 sshd[786]: Server listening on :: port 22.
+Feb 21 20:54:05 precise32 sshd[1049]: Accepted publickey for vagrant from 10.0.2.2 port 63645 ssh2
+Feb 21 20:54:05 precise32 sshd[1049]: pam_unix(sshd:session): session opened for user vagrant by (uid=0)
+Feb 21 20:54:07 precise32 sudo:  vagrant : TTY=unknown ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/bash -l
+Feb 21 20:54:07 precise32 sudo: pam_unix(sudo:session): session opened for user root by (uid=1000)
+Feb 21 20:54:07 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 21 20:54:07 precise32 sudo:  vagrant : TTY=unknown ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/bash -l
+Feb 21 20:54:07 precise32 sudo: pam_unix(sudo:session): session opened for user root by (uid=1000)
+Feb 21 20:54:07 precise32 sshd[786]: Received signal 15; terminating.
+Feb 21 20:54:07 precise32 sshd[1173]: Server listening on 0.0.0.0 port 22.
+Feb 21 20:54:07 precise32 sshd[1173]: Server listening on :: port 22.
+Feb 21 20:54:07 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 21 20:54:08 precise32 sudo:  vagrant : TTY=unknown ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/bash -l
+Feb 21 20:54:08 precise32 sudo: pam_unix(sudo:session): session opened for user root by (uid=1000)
+Feb 21 20:54:08 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 21 20:54:08 precise32 sudo:  vagrant : TTY=unknown ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/bash -l
+Feb 21 20:54:08 precise32 sudo: pam_unix(sudo:session): session opened for user root by (uid=1000)
+Feb 21 20:54:08 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 21 20:54:08 precise32 sudo:  vagrant : TTY=unknown ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/bash -l
+Feb 21 20:54:08 precise32 sudo: pam_unix(sudo:session): session opened for user root by (uid=1000)
+Feb 21 20:54:08 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 21 20:54:08 precise32 sudo:  vagrant : TTY=unknown ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/bash -l
+Feb 21 20:54:08 precise32 sudo: pam_unix(sudo:session): session opened for user root by (uid=1000)
+Feb 21 20:54:08 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 21 20:54:08 precise32 sshd[1049]: pam_unix(sshd:session): session closed for user vagrant
+Feb 21 20:54:10 precise32 sshd[1235]: Did not receive identification string from 10.0.2.2
+Feb 21 21:17:01 precise32 CRON[1264]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 21 21:17:01 precise32 CRON[1264]: pam_unix(cron:session): session closed for user root
+Feb 21 22:17:01 precise32 CRON[1278]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 21 22:17:01 precise32 CRON[1278]: pam_unix(cron:session): session closed for user root
+Feb 22 09:17:01 precise32 CRON[1298]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 22 09:17:01 precise32 CRON[1298]: pam_unix(cron:session): session closed for user root
+Feb 22 10:17:01 precise32 CRON[1313]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 22 10:17:01 precise32 CRON[1313]: pam_unix(cron:session): session closed for user root
+Feb 22 10:17:35 precise32 sshd[1317]: Accepted publickey for vagrant from 10.0.2.2 port 50649 ssh2
+Feb 22 10:17:35 precise32 sshd[1317]: pam_unix(sshd:session): session opened for user vagrant by (uid=0)
+Feb 22 10:17:36 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:17:36 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-xssosunoadzrupbslukboshizrdrioxa; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487758643.54-191473960698523/setup; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487758643.54-191473960698523/ >/dev/null 2>&1
+Feb 22 10:17:36 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:17:36 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:17:37 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:17:37 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-hxipbwbkxeioyitdwspukfecshzmmznq; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487758657.4-158751358978750/get_url; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487758657.4-158751358978750/ >/dev/null 2>&1
+Feb 22 10:17:37 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:17:38 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:17:57 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:17:57 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-emhyhjenolvqmuddzjsrvdrlshuozvbt; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487758673.45-1328499317378/get_url; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487758673.45-1328499317378/ >/dev/null 2>&1
+Feb 22 10:17:57 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:18:02 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:18:07 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:18:07 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-tnuospsrbdizfiuhbtlkwjlthrsmjllm; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487758687.19-221944793882694/command; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487758687.19-221944793882694/ >/dev/null 2>&1
+Feb 22 10:18:07 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:18:07 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:18:14 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:18:15 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-glkfubgvldbatmtdrtbyjplvhybyetdi; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487758694.65-96114020740224/apt; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487758694.65-96114020740224/ >/dev/null 2>&1
+Feb 22 10:18:15 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:18:15 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:18:15 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:18:15 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-ijzrnnvvtrdgpaulzxwvpwlvokztvosi; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487758695.82-89251362907242/apt; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487758695.82-89251362907242/ >/dev/null 2>&1
+Feb 22 10:18:15 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:18:17 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:18:37 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:18:37 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-pogpznvhgeqrtzlcudaddelhakmqzyvc; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487758717.06-179621344002611/file; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487758717.06-179621344002611/ >/dev/null 2>&1
+Feb 22 10:18:37 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:18:37 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:18:38 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-cgnuoyhpluwhkezwnsqvydawomlfskny; rc=flag; [ -r /etc/packetbeat/packetbeat.yml ] || rc=2; [ -f /etc/packetbeat/packetbeat.yml ] || rc=1; [ -d /etc/packetbeat/packetbeat.yml ] && rc=3; python -V 2>/dev/null || rc=4; [ x"$rc" != "xflag" ] && echo "${rc}  "/etc/packetbeat/packetbeat.yml && exit 0; (python -c 'import hashlib; BLOCKSIZE = 65536; hasher = hashlib.sha1();#012afile = open("'/etc/packetbeat/packetbeat.yml'", "rb")#012buf = afile.read(BLOCKSIZE)#012while len(buf) > 0:#012#011hasher.update(buf)#012#011buf = afile.read(BLOCKSIZE)#012afile.close()#012print(hasher.hexdigest())' 2>/dev/null) || (python -c 'import sha; BLOCKSIZE = 65536; hasher = sha.sha();#012afile = open("'/etc/packetbeat/packetbeat.yml'", "rb")#012buf = afile.read(BLOCKSIZE)#012while len(buf) > 0:#012#011hasher.update(buf)#012#011buf = afile.read(BLOCKSIZE)#012afile.close()#012print(hasher.hexdigest())' 2>/dev/null) || (echo '0 
+Feb 22 10:18:38 precise32 sudo:  vagrant : (command continued) '/etc/packetbeat/packetbeat.yml)
+Feb 22 10:18:38 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:18:38 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:18:38 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:18:38 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:18:38 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-vxlqeahufmmmbvyqklrzqgkjctmdkgus; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487758717.91-56384930409930/copy; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487758717.91-56384930409930/ >/dev/null 2>&1
+Feb 22 10:18:38 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:18:38 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:18:39 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:18:39 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-xakfsqpdonqkzaedehbsdzszbbyertxw; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487758719.2-243819058722243/service; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487758719.2-243819058722243/ >/dev/null 2>&1
+Feb 22 10:18:39 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:18:40 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:18:46 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:18:46 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-dytuqoopxigowdsexoxljahexcrgrusl; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487758721.63-238019605938202/command; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487758721.63-238019605938202/ >/dev/null 2>&1
+Feb 22 10:18:46 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:18:47 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:18:47 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:18:47 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-yyxjqzypwilthsoesuioieestjumujju; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487758727.59-206889470588032/command; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487758727.59-206889470588032/ >/dev/null 2>&1
+Feb 22 10:18:47 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:18:48 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:18:50 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:18:50 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-ntvmfwclgszgjkggyrefquijrpduwmgb; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487758730.11-121092091456552/wait_for; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487758730.11-121092091456552/ >/dev/null 2>&1
+Feb 22 10:18:50 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:18:50 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:18:51 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:18:51 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-ibplwyrudxqiewtnazajakyxfkkcptyq; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487758731.03-34005853522249/service; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487758731.03-34005853522249/ >/dev/null 2>&1
+Feb 22 10:18:51 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:18:52 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:18:55 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:18:55 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-dgeumohveckrnbwermrtgsjoarogauts; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487758735.15-203882260553837/apt; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487758735.15-203882260553837/ >/dev/null 2>&1
+Feb 22 10:18:55 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:18:57 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:19:04 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:19:05 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-ojjhntgihxndnhavcctzukxgjofssmzd; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487758744.84-77760196415518/file; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487758744.84-77760196415518/ >/dev/null 2>&1
+Feb 22 10:19:05 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:19:05 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:19:05 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:19:05 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-pmqqiowsxeslareuueooxspvwjhjemfb; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487758745.72-98459850115685/get_url; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487758745.72-98459850115685/ >/dev/null 2>&1
+Feb 22 10:19:05 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:19:06 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:19:10 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:19:14 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-qwihjodhuysbsmpziijlzwshyltrzcyq; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487758750.05-149759005698820/get_url; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487758750.05-149759005698820/ >/dev/null 2>&1
+Feb 22 10:19:14 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:19:18 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:19:29 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:19:30 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-yvxsufrhkjpmpjrppduubympcvtrkvaj; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487758769.71-145821006475810/command; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487758769.71-145821006475810/ >/dev/null 2>&1
+Feb 22 10:19:30 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:19:30 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:19:30 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:19:31 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-aiqgiatpajrwljvsshlnkgevpbpsklww; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487758770.86-179475170836781/file; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487758770.86-179475170836781/ >/dev/null 2>&1
+Feb 22 10:19:31 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:19:31 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:19:33 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:19:33 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-pgdnhbifitnqwakjzgmcvkqmnzsrpfco; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487758771.76-102255502158149/command; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487758771.76-102255502158149/ >/dev/null 2>&1
+Feb 22 10:19:33 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:19:34 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:19:34 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:19:34  sshd[1332]: last message repeated 2 times
+Feb 22 10:19:34 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-xgucwwayjxcvonkbqpgxmfyjenwzyeoe; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487758774.27-3510546063127/async_wrapper 237258794263 45 /home/vagrant/.ansible/tmp/ansible-tmp-1487758774.27-3510546063127/command /home/vagrant/.ansible/tmp/ansible-tmp-1487758774.27-3510546063127/arguments; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487758774.27-3510546063127/ >/dev/null 2>&1
+Feb 22 10:19:34 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:19:35 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:19:40 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:19:41 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-qaweqylanyknzgjbwefkqyrvqyqoxndl; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487758780.79-49892349010220/command; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487758780.79-49892349010220/ >/dev/null 2>&1
+Feb 22 10:19:41 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:19:42 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:19:47 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:19:48 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-khughpifzkpjcrntbljswmyirtsjrxvi; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487758787.81-128455052873531/command; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487758787.81-128455052873531/ >/dev/null 2>&1
+Feb 22 10:19:48 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:19:48 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:19:51 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:19:51 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-mzzvwtfwbwzduvdadylfesruqyisjvbn; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487758790.9-209098267326353/wait_for; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487758790.9-209098267326353/ >/dev/null 2>&1
+Feb 22 10:19:51 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:19:51 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:19:52 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:19:53 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-mrirjjotfyalxyssrfyxzwlvqgfsxwif; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487758792.57-141403876569108/command; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487758792.57-141403876569108/ >/dev/null 2>&1
+Feb 22 10:19:53 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:19:54 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:19:55 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:19:55 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-mgndoeogsbwbiiyommokxzrgcviyurzn; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487758795.11-164059807202479/setup; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487758795.11-164059807202479/ >/dev/null 2>&1
+Feb 22 10:19:55 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:19:56 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:20:01 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:20:02 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-nqcissdyplqbywhbdgliygpmcvsntqyr; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487758801.05-59435378275017/get_url; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487758801.05-59435378275017/ >/dev/null 2>&1
+Feb 22 10:20:02 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:20:03 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:20:12 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:20:16 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-chgutesiryamamuplkzptdzlruibkljn; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487758805.06-177283137429784/get_url; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487758805.06-177283137429784/ >/dev/null 2>&1
+Feb 22 10:20:16 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:20:24 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:20:28 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:20:28 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-xsijqxjrtjsvhsdapgoggsglqpduyjsl; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487758828.17-30183388747526/command; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487758828.17-30183388747526/ >/dev/null 2>&1
+Feb 22 10:20:28 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:20:28 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:20:33 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:20:33 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-heeyxwtdvgnuzqrqrjbklxakhrzdqivd; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487758832.98-8399030937476/apt; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487758832.98-8399030937476/ >/dev/null 2>&1
+Feb 22 10:20:33 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:20:35 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:20:35 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:20:36 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-fjjvrhktdnfgkbduajrjfghkenlxixng; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487758835.24-68380542949187/apt; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487758835.24-68380542949187/ >/dev/null 2>&1
+Feb 22 10:20:36 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:20:37 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:20:45 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:20:46 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-pekyfcnfxapysvffjjsmdqlzamplbxjl; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487758845.87-75931053700416/file; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487758845.87-75931053700416/ >/dev/null 2>&1
+Feb 22 10:20:46 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:20:46 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:20:46 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-jzemhvdzpkifymfzmttbqlyjwovpxren; rc=flag; [ -r /etc/filebeat/filebeat.yml ] || rc=2; [ -f /etc/filebeat/filebeat.yml ] || rc=1; [ -d /etc/filebeat/filebeat.yml ] && rc=3; python -V 2>/dev/null || rc=4; [ x"$rc" != "xflag" ] && echo "${rc}  "/etc/filebeat/filebeat.yml && exit 0; (python -c 'import hashlib; BLOCKSIZE = 65536; hasher = hashlib.sha1();#012afile = open("'/etc/filebeat/filebeat.yml'", "rb")#012buf = afile.read(BLOCKSIZE)#012while len(buf) > 0:#012#011hasher.update(buf)#012#011buf = afile.read(BLOCKSIZE)#012afile.close()#012print(hasher.hexdigest())' 2>/dev/null) || (python -c 'import sha; BLOCKSIZE = 65536; hasher = sha.sha();#012afile = open("'/etc/filebeat/filebeat.yml'", "rb")#012buf = afile.read(BLOCKSIZE)#012while len(buf) > 0:#012#011hasher.update(buf)#012#011buf = afile.read(BLOCKSIZE)#012afile.close()#012print(hasher.hexdigest())' 2>/dev/null) || (echo '0  '/etc/filebeat/filebeat.yml)
+Feb 22 10:20:46 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:20:47 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:20:47 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:20:47 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:20:47 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-kfdqplikbqzasatjrfslxlhvxtweqxmu; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487758846.86-111987636158347/copy; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487758846.86-111987636158347/ >/dev/null 2>&1
+Feb 22 10:20:47 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:20:47 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:20:48 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:20:48 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-hvjvjngqzsnarkdzeeyddqgydgglplgl; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487758848.05-64229506558727/service; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487758848.05-64229506558727/ >/dev/null 2>&1
+Feb 22 10:20:48 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:20:49 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:20:49 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:20:49 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-awoeidxghevopktwtjfwfmwtaubmgrtn; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487758849.45-216653274395348/command; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487758849.45-216653274395348/ >/dev/null 2>&1
+Feb 22 10:20:49 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:20:49 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:20:50 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:21:05 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-gpodhiipyobwmtxzmxkandqienviezld; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487758850.57-165808785745658/wait_for; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487758850.57-165808785745658/ >/dev/null 2>&1
+Feb 22 10:21:05 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:21:05 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:21:06 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:21:06 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-dshvmkemikwrmprtjacyfujniswtlwqg; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487758865.79-222508069804943/service; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487758865.79-222508069804943/ >/dev/null 2>&1
+Feb 22 10:21:06 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:21:06 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:21:07 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:21:07 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-mjkqieqkbjnymontbyhkepipbfaghuid; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487758866.98-253775251408361/apt; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487758866.98-253775251408361/ >/dev/null 2>&1
+Feb 22 10:21:07 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:21:08 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:21:16 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:21:16 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-hjteklymrhtjicprfxpjqlvxlhxxyymg; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487758875.97-141490377689356/file; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487758875.97-141490377689356/ >/dev/null 2>&1
+Feb 22 10:21:16 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:21:16 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:21:16 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:21:18 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-csrtpqzzmibovgmwoajbfboolghcicgv; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487758876.86-158843529685187/get_url; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487758876.86-158843529685187/ >/dev/null 2>&1
+Feb 22 10:21:18 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:21:19 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:21:31 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:21:35 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-kymwttnnegazqcmshnjhsnxvaqtrgcpp; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487758880.63-176357803389666/get_url; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487758880.63-176357803389666/ >/dev/null 2>&1
+Feb 22 10:21:35 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:21:38 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:21:38 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:21:38 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-mxfzdolrqsdlmbcwaifuskpzfjruulee; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487758898.33-12314181836482/command; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487758898.33-12314181836482/ >/dev/null 2>&1
+Feb 22 10:21:38 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:21:38 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:21:39 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:21:39 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-umsywgtorqzclqkpsvatkxyykcxkdkgs; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487758899.33-192709141415230/file; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487758899.33-192709141415230/ >/dev/null 2>&1
+Feb 22 10:21:39 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:21:39 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:21:40 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:21:42 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-eakxsbfxjrmdsismhvfyyvvztecejoyc; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487758900.34-189990522471438/command; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487758900.34-189990522471438/ >/dev/null 2>&1
+Feb 22 10:21:42 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:21:42 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:21:42 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:21:43  sshd[1332]: last message repeated 2 times
+Feb 22 10:21:43 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-dgadmykrlzraqgkcmnphakuguadntfsl; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487758902.74-199509623193790/async_wrapper 816499674548 45 /home/vagrant/.ansible/tmp/ansible-tmp-1487758902.74-199509623193790/command /home/vagrant/.ansible/tmp/ansible-tmp-1487758902.74-199509623193790/arguments; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487758902.74-199509623193790/ >/dev/null 2>&1
+Feb 22 10:21:43 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:21:44 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:21:49 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:21:53 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-vwfooorrnflwboszxctmeqzeclcqwqzb; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487758908.96-210248164703691/command; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487758908.96-210248164703691/ >/dev/null 2>&1
+Feb 22 10:21:53 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:21:54 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:21:56 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:21:56 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-nnyixufntvdqvskhwuonusiivtsvojgh; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487758915.44-145306896810131/command; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487758915.44-145306896810131/ >/dev/null 2>&1
+Feb 22 10:21:56 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:21:56 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:21:57 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:21:58 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-mrcsndxoihslbpebrbhcnfgjqwsmlhpe; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487758916.36-254700287237800/setup; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487758916.36-254700287237800/ >/dev/null 2>&1
+Feb 22 10:21:58 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:21:58 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:22:01 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:22:01 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-dwxuhfbnbmpewdwihojqgkaxemyudefv; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487758921.44-15417091956419/get_url; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487758921.44-15417091956419/ >/dev/null 2>&1
+Feb 22 10:22:01 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:22:02 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:22:06 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:22:06 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-vorqpnjghsoyipiylridtecbdkjbjggj; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487758926.16-63625452155831/get_url; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487758926.16-63625452155831/ >/dev/null 2>&1
+Feb 22 10:22:06 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:22:11 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:22:28 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:22:28 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-sjnzdfvhlkhghuekfrjxtciyfkfofhbw; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487758948.07-151612679899505/command; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487758948.07-151612679899505/ >/dev/null 2>&1
+Feb 22 10:22:28 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:22:29 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:22:31 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:22:31 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-bqghhittgonzjreztgtrovtgvjuthyll; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487758951.62-253778658902595/apt; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487758951.62-253778658902595/ >/dev/null 2>&1
+Feb 22 10:22:31 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:22:33 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:22:34 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:22:35 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-zzdubdcrvzdozuqntajprljngcjihspk; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487758954.0-200796609083801/apt; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487758954.0-200796609083801/ >/dev/null 2>&1
+Feb 22 10:22:35 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:22:36 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:22:47 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:22:47 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-nkaglrldajapqdielsancxfiszgsoljk; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487758966.88-266261809895740/file; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487758966.88-266261809895740/ >/dev/null 2>&1
+Feb 22 10:22:47 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:22:47 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:22:48 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-hkcqwojfpwljfelfdpzhmyvrudplkhav; rc=flag; [ -r /etc/metricbeat/metricbeat.yml ] || rc=2; [ -f /etc/metricbeat/metricbeat.yml ] || rc=1; [ -d /etc/metricbeat/metricbeat.yml ] && rc=3; python -V 2>/dev/null || rc=4; [ x"$rc" != "xflag" ] && echo "${rc}  "/etc/metricbeat/metricbeat.yml && exit 0; (python -c 'import hashlib; BLOCKSIZE = 65536; hasher = hashlib.sha1();#012afile = open("'/etc/metricbeat/metricbeat.yml'", "rb")#012buf = afile.read(BLOCKSIZE)#012while len(buf) > 0:#012#011hasher.update(buf)#012#011buf = afile.read(BLOCKSIZE)#012afile.close()#012print(hasher.hexdigest())' 2>/dev/null) || (python -c 'import sha; BLOCKSIZE = 65536; hasher = sha.sha();#012afile = open("'/etc/metricbeat/metricbeat.yml'", "rb")#012buf = afile.read(BLOCKSIZE)#012while len(buf) > 0:#012#011hasher.update(buf)#012#011buf = afile.read(BLOCKSIZE)#012afile.close()#012print(hasher.hexdigest())' 2>/dev/null) || (echo '0 
+Feb 22 10:22:48 precise32 sudo:  vagrant : (command continued) '/etc/metricbeat/metricbeat.yml)
+Feb 22 10:22:48 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:22:48 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:22:48 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:22:48 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:22:48 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-qeeogyaubusemwuivumoknkyllgqifqc; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487758967.93-2413198329354/copy; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487758967.93-2413198329354/ >/dev/null 2>&1
+Feb 22 10:22:48 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:22:49 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:22:49 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:22:49 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-wleytkdmeuzrrfocyjqnlnrnhvvmqnhj; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487758969.36-189021904374208/service; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487758969.36-189021904374208/ >/dev/null 2>&1
+Feb 22 10:22:49 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:22:49 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:22:51 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:22:52 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-xzgycnxdoiaxjliycnakgwtiediaqskc; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487758971.32-235095819876869/wait_for; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487758971.32-235095819876869/ >/dev/null 2>&1
+Feb 22 10:22:52 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:22:52 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:22:52 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:22:52 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-upihslyxhlhsmolzjezjcbfgfdyudqea; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487758972.67-153306624674709/service; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487758972.67-153306624674709/ >/dev/null 2>&1
+Feb 22 10:22:52 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:22:53 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:22:54 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:22:54 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-mezdvjkbyixfajeijestjexjbusaqrhb; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487758974.47-274076590596000/apt; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487758974.47-274076590596000/ >/dev/null 2>&1
+Feb 22 10:22:54 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:22:56 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:23:08 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:23:08 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-wycmwfzcoiymnuhdymorxjysksrmjqcd; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487758988.59-114925555291248/file; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487758988.59-114925555291248/ >/dev/null 2>&1
+Feb 22 10:23:08 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:23:08 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:23:09 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:23:11 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-uuaaiyzwzwvpgjxsrvpuldxursddupwu; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487758989.68-236755099981530/get_url; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487758989.68-236755099981530/ >/dev/null 2>&1
+Feb 22 10:23:11 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:23:12 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:23:13 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:23:29 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-fdkxeotnfawfmixnoetubimwvktnuney; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487758993.69-243714943255957/get_url; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487758993.69-243714943255957/ >/dev/null 2>&1
+Feb 22 10:23:29 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:23:32 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:23:33 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:23:33 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-pzligihucshudlaypravoqhwbyszpwzm; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487759013.13-207637999650885/command; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487759013.13-207637999650885/ >/dev/null 2>&1
+Feb 22 10:23:33 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:23:34 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:23:34 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:23:34 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-sapsykckcxjjfkdyewlufthenwbjlreq; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487759014.33-250741217844628/file; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487759014.33-250741217844628/ >/dev/null 2>&1
+Feb 22 10:23:34 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:23:34 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:23:35 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:23:36 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-ujkefpwcuprdzgvxmqsttcaduitzpreb; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487759015.32-255004096786183/command; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487759015.32-255004096786183/ >/dev/null 2>&1
+Feb 22 10:23:36 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:23:37 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:23:38 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:23:38  sshd[1332]: last message repeated 2 times
+Feb 22 10:23:38 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-wzvgaupyzevaqpewfanpzwbbjbrgjyxa; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487759018.34-224146594813589/async_wrapper 410374908727 45 /home/vagrant/.ansible/tmp/ansible-tmp-1487759018.34-224146594813589/command /home/vagrant/.ansible/tmp/ansible-tmp-1487759018.34-224146594813589/arguments; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487759018.34-224146594813589/ >/dev/null 2>&1
+Feb 22 10:23:38 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:23:39 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:23:44 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:23:44 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-wsxswpmqlawotxhiuihospylbndtqluo; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487759024.5-136675909330225/command; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487759024.5-136675909330225/ >/dev/null 2>&1
+Feb 22 10:23:44 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:23:45 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:23:51 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:23:51 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-vorifscmganfsjedaedjhlnokfdqyuyt; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487759031.38-273404504950212/wait_for; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487759031.38-273404504950212/ >/dev/null 2>&1
+Feb 22 10:23:51 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:23:51 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:23:53 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:23:53 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-dfyhnziutzyjkxvgaszqbncngwzfmbkj; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487759032.63-195213430058226/command; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487759032.63-195213430058226/ >/dev/null 2>&1
+Feb 22 10:23:53 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:23:53 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:23:53 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:23:54 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-oshlszshpobiexosodofiliquogpcrch; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487759033.86-259824119157880/setup; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487759033.86-259824119157880/ >/dev/null 2>&1
+Feb 22 10:23:54 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:23:54 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:24:03 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:24:05 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-bnsprfojytndjkrmmatjbhdmhmknbjcw; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487759043.64-230997147212314/get_url; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487759043.64-230997147212314/ >/dev/null 2>&1
+Feb 22 10:24:05 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:24:06 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:24:07 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:24:15 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-zjgvfvohclzccihbhkjmgsceoysdgsuk; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487759047.85-178830207294016/get_url; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487759047.85-178830207294016/ >/dev/null 2>&1
+Feb 22 10:24:15 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:24:20 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:24:29 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:24:30 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-tzhedkhxrmostbfutqxrioqpnhfxbfov; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487759069.42-32472306062955/command; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487759069.42-32472306062955/ >/dev/null 2>&1
+Feb 22 10:24:30 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:24:30 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:24:33 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:24:34 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-eeszonjwbylnqtvgspsxyxozxljkepff; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487759073.89-12256629657244/apt; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487759073.89-12256629657244/ >/dev/null 2>&1
+Feb 22 10:24:34 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:24:34 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:24:35 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:24:35 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-pawilqhuoycqyksktjsmxumuwbmuywvr; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487759074.92-98763948895300/apt; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487759074.92-98763948895300/ >/dev/null 2>&1
+Feb 22 10:24:35 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:24:36 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:24:48 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:24:48 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-fpcrlnvrjfuuwjvlqbvjknuguatdrkdt; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487759088.08-95836653427652/file; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487759088.08-95836653427652/ >/dev/null 2>&1
+Feb 22 10:24:48 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:24:48 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:24:49 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-ippzqmywwjlstxlqlpyxbnzzgeigarma; rc=flag; [ -r /etc/heartbeat/heartbeat.yml ] || rc=2; [ -f /etc/heartbeat/heartbeat.yml ] || rc=1; [ -d /etc/heartbeat/heartbeat.yml ] && rc=3; python -V 2>/dev/null || rc=4; [ x"$rc" != "xflag" ] && echo "${rc}  "/etc/heartbeat/heartbeat.yml && exit 0; (python -c 'import hashlib; BLOCKSIZE = 65536; hasher = hashlib.sha1();#012afile = open("'/etc/heartbeat/heartbeat.yml'", "rb")#012buf = afile.read(BLOCKSIZE)#012while len(buf) > 0:#012#011hasher.update(buf)#012#011buf = afile.read(BLOCKSIZE)#012afile.close()#012print(hasher.hexdigest())' 2>/dev/null) || (python -c 'import sha; BLOCKSIZE = 65536; hasher = sha.sha();#012afile = open("'/etc/heartbeat/heartbeat.yml'", "rb")#012buf = afile.read(BLOCKSIZE)#012while len(buf) > 0:#012#011hasher.update(buf)#012#011buf = afile.read(BLOCKSIZE)#012afile.close()#012print(hasher.hexdigest())' 2>/dev/null) || (echo '0 
+Feb 22 10:24:49 precise32 sudo:  vagrant : (command continued) '/etc/heartbeat/heartbeat.yml)
+Feb 22 10:24:49 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:24:49 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:24:49 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:24:49 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:24:50 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-lmkcndbwyqwirrupuyaoxvjpcgqrspjv; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487759089.25-13919817848020/copy; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487759089.25-13919817848020/ >/dev/null 2>&1
+Feb 22 10:24:50 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:24:50 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:24:50 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:24:51 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-lmimwtwvnahmfimdjcpxecnaxkikqzkb; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487759090.54-208394951526157/service; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487759090.54-208394951526157/ >/dev/null 2>&1
+Feb 22 10:24:51 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:24:51 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:24:52 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:24:53 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-hnjbwpwylotrkdvltxlvqwqjnzenlieh; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487759092.2-167518908535129/wait_for; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487759092.2-167518908535129/ >/dev/null 2>&1
+Feb 22 10:24:53 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:24:54 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:24:54 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:24:54 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-wlhgjrshdmicpsqhmvnzqsoekdwxwfao; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487759094.19-57829294311136/service; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487759094.19-57829294311136/ >/dev/null 2>&1
+Feb 22 10:24:54 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:24:54 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:24:55 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:24:57 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-czztgxumavfzugnaxrzgsdrxilpkbflz; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487759095.85-211164222926167/apt; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487759095.85-211164222926167/ >/dev/null 2>&1
+Feb 22 10:24:57 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:25:00 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:25:07 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:25:08 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-hkjwhgysjpvjcknmpwicwmnijuwmxafv; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487759107.52-210302790044830/file; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487759107.52-210302790044830/ >/dev/null 2>&1
+Feb 22 10:25:08 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:25:08 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:25:08 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:25:08 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-tfvrkyzdcfjxhusybnzxkcmuwxblfoti; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487759108.49-234130386314936/get_url; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487759108.49-234130386314936/ >/dev/null 2>&1
+Feb 22 10:25:08 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:25:09 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:25:13 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:25:13 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-gnjtaevjcrhacnacvsvihakgsyhqcwod; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487759113.81-179783319147604/get_url; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487759113.81-179783319147604/ >/dev/null 2>&1
+Feb 22 10:25:13 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:25:18 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:25:35 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:25:35 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-bahevnlzztjypsgntszgstmvovuabxfg; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487759135.03-159695980315135/command; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487759135.03-159695980315135/ >/dev/null 2>&1
+Feb 22 10:25:35 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:25:35 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:25:36 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:25:36 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-obuzxrxcfsypdbeutjpxvvbpmqcadysb; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487759135.97-154168175733053/file; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487759135.97-154168175733053/ >/dev/null 2>&1
+Feb 22 10:25:36 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:25:36 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:25:36 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:25:37 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-rfqorfecrhqenaiihbafxqgzxukylnmv; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487759136.82-129523565034232/command; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487759136.82-129523565034232/ >/dev/null 2>&1
+Feb 22 10:25:37 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:25:38 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:25:39 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:25:43  sshd[1332]: last message repeated 2 times
+Feb 22 10:25:43 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-zjvdsaammnhugthzrjdbretryqmrvulm; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487759139.04-250524005502190/async_wrapper 442060242590 45 /home/vagrant/.ansible/tmp/ansible-tmp-1487759139.04-250524005502190/command /home/vagrant/.ansible/tmp/ansible-tmp-1487759139.04-250524005502190/arguments; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487759139.04-250524005502190/ >/dev/null 2>&1
+Feb 22 10:25:43 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:25:44 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:25:47 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:25:48 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-igtduwziazbzcigerpdstpbubtijpoha; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487759145.15-69304479737447/command; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487759145.15-69304479737447/ >/dev/null 2>&1
+Feb 22 10:25:48 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:25:49 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:25:51 precise32 sshd[1332]: subsystem request for sftp by user vagrant
+Feb 22 10:25:52 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/sh -c echo BECOME-SUCCESS-fwvsibdnrdsafikdwkihqdaavmthawfo; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1487759151.73-135710032587634/command; rm -rf /home/vagrant/.ansible/tmp/ansible-tmp-1487759151.73-135710032587634/ >/dev/null 2>&1
+Feb 22 10:25:52 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:25:52 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:26:52 precise32 sshd[1332]: Received disconnect from 10.0.2.2: 11: disconnected by user
+Feb 22 10:26:52 precise32 sshd[1317]: pam_unix(sshd:session): session closed for user vagrant
+Feb 22 10:49:54 precise32 sshd[3007]: Accepted publickey for vagrant from 10.0.2.2 port 52059 ssh2
+Feb 22 10:49:54 precise32 sshd[3007]: pam_unix(sshd:session): session opened for user vagrant by (uid=0)
+Feb 22 10:50:01 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/usr/bin/vi /etc/apt/sources.list.d/elastic.list
+Feb 22 10:50:01 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:50:14 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:50:17 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/usr/bin/apt-get update
+Feb 22 10:50:17 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:50:28 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:50:42 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/usr/bin/apt-get install filebeat
+Feb 22 10:50:42 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:50:50 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:51:05 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/usr/bin/vi /etc/filebeat/filebeat.yml
+Feb 22 10:51:05 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:51:26 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:51:31 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/etc/init.d/filebeat start
+Feb 22 10:51:31 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:51:31 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:51:35 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/usr/bin/vi /etc/filebeat/filebeat.yml
+Feb 22 10:51:35 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:51:39 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 10:51:40 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/etc/init.d/filebeat start
+Feb 22 10:51:40 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 10:51:40 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 11:04:28 precise32 sshd[3403]: Accepted publickey for vagrant from 10.0.2.2 port 52321 ssh2
+Feb 22 11:04:28 precise32 sshd[3403]: pam_unix(sshd:session): session opened for user vagrant by (uid=0)
+Feb 22 11:04:32 precise32 sshd[3418]: Received disconnect from 10.0.2.2: 11: disconnected by user
+Feb 22 11:04:32 precise32 sshd[3403]: pam_unix(sshd:session): session closed for user vagrant
+Feb 22 11:17:01 precise32 CRON[3448]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 22 11:17:01 precise32 CRON[3448]: pam_unix(cron:session): session closed for user root
+Feb 22 11:21:21 precise32 sshd[3452]: Accepted publickey for vagrant from 10.0.2.2 port 52747 ssh2
+Feb 22 11:21:21 precise32 sshd[3452]: pam_unix(sshd:session): session opened for user vagrant by (uid=0)
+Feb 22 11:21:24 precise32 sshd[3467]: Received disconnect from 10.0.2.2: 11: disconnected by user
+Feb 22 11:21:24 precise32 sshd[3452]: pam_unix(sshd:session): session closed for user vagrant
+Feb 22 11:24:38 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/usr/bin/vi /etc/apt/sources.list
+Feb 22 11:24:38 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 11:24:39 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 11:24:43 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/usr/bin/vi /etc/filebeat/filebeat.full.yml
+Feb 22 11:24:43 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 22 12:17:01 precise32 CRON[3561]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 22 12:17:01 precise32 CRON[3561]: pam_unix(cron:session): session closed for user root
+Feb 22 13:17:01 precise32 CRON[3578]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 22 13:17:01 precise32 CRON[3578]: pam_unix(cron:session): session closed for user root
+Feb 22 14:17:01 precise32 CRON[3594]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 22 14:17:01 precise32 CRON[3594]: pam_unix(cron:session): session closed for user root
+Feb 22 15:17:01 precise32 CRON[3610]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 22 15:17:01 precise32 CRON[3610]: pam_unix(cron:session): session closed for user root
+Feb 22 16:17:01 precise32 CRON[3648]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 22 16:17:01 precise32 CRON[3648]: pam_unix(cron:session): session closed for user root
+Feb 22 17:17:01 precise32 CRON[3663]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 22 17:17:01 precise32 CRON[3663]: pam_unix(cron:session): session closed for user root
+Feb 22 18:17:01 precise32 CRON[3679]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 22 18:17:01 precise32 CRON[3679]: pam_unix(cron:session): session closed for user root
+Feb 22 19:17:01 precise32 CRON[3697]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 22 19:17:01 precise32 CRON[3697]: pam_unix(cron:session): session closed for user root
+Feb 22 20:17:01 precise32 CRON[3712]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 22 20:17:01 precise32 CRON[3712]: pam_unix(cron:session): session closed for user root
+Feb 22 21:17:01 precise32 CRON[3729]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 22 21:17:01 precise32 CRON[3729]: pam_unix(cron:session): session closed for user root
+Feb 22 22:17:01 precise32 CRON[3744]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 22 22:17:01 precise32 CRON[3744]: pam_unix(cron:session): session closed for user root
+Feb 22 23:17:01 precise32 CRON[3760]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 22 23:17:01 precise32 CRON[3760]: pam_unix(cron:session): session closed for user root
+Feb 22 23:29:50 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 22 23:29:50 precise32 sshd[3007]: pam_unix(sshd:session): session closed for user vagrant
+Feb 23 09:17:02 precise32 CRON[3779]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 23 09:17:02 precise32 CRON[3779]: pam_unix(cron:session): session closed for user root
+Feb 23 10:17:01 precise32 CRON[3815]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 23 10:17:01 precise32 CRON[3815]: pam_unix(cron:session): session closed for user root
+Feb 23 11:17:01 precise32 CRON[3828]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 23 11:17:01 precise32 CRON[3828]: pam_unix(cron:session): session closed for user root
+Feb 23 12:17:01 precise32 CRON[3845]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 23 12:17:01 precise32 CRON[3845]: pam_unix(cron:session): session closed for user root
+Feb 23 13:17:01 precise32 CRON[3860]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 23 13:17:01 precise32 CRON[3860]: pam_unix(cron:session): session closed for user root
+Feb 23 14:17:01 precise32 CRON[3875]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 23 14:17:01 precise32 CRON[3875]: pam_unix(cron:session): session closed for user root
+Feb 23 15:17:01 precise32 CRON[3890]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 23 15:17:01 precise32 CRON[3890]: pam_unix(cron:session): session closed for user root
+Feb 23 17:17:01 precise32 CRON[3908]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 23 17:17:01 precise32 CRON[3908]: pam_unix(cron:session): session closed for user root
+Feb 23 18:17:01 precise32 CRON[3923]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 23 18:17:01 precise32 CRON[3923]: pam_unix(cron:session): session closed for user root
+Feb 23 19:17:01 precise32 CRON[3938]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 23 19:17:01 precise32 CRON[3938]: pam_unix(cron:session): session closed for user root
+Feb 23 19:26:35 precise32 sshd[3945]: Accepted publickey for vagrant from 10.0.2.2 port 58363 ssh2
+Feb 23 19:26:35 precise32 sshd[3945]: pam_unix(sshd:session): session opened for user vagrant by (uid=0)
+Feb 23 20:05:18 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/usr/bin/less /var/log/auth.log
+Feb 23 20:05:18 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 23 20:15:04 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 23 20:15:09 precise32 sshd[3960]: Received disconnect from 10.0.2.2: 11: disconnected by user
+Feb 23 20:15:09 precise32 sshd[3945]: pam_unix(sshd:session): session closed for user vagrant
+Feb 23 20:17:01 precise32 CRON[4104]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 23 20:17:01 precise32 CRON[4104]: pam_unix(cron:session): session closed for user root
+Feb 23 21:17:01 precise32 CRON[4140]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 23 21:17:01 precise32 CRON[4140]: pam_unix(cron:session): session closed for user root
+Feb 23 22:17:01 precise32 CRON[4155]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 23 22:17:01 precise32 CRON[4155]: pam_unix(cron:session): session closed for user root
+Feb 23 23:17:01 precise32 CRON[4170]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 23 23:17:01 precise32 CRON[4170]: pam_unix(cron:session): session closed for user root
+Feb 24 00:11:15 precise32 sshd[4185]: Accepted publickey for vagrant from 10.0.2.2 port 60839 ssh2
+Feb 24 00:11:15 precise32 sshd[4185]: pam_unix(sshd:session): session opened for user vagrant by (uid=0)
+Feb 24 00:11:24 precise32 sshd[4302]: Accepted publickey for vagrant from 10.0.2.2 port 60840 ssh2
+Feb 24 00:11:24 precise32 sshd[4302]: pam_unix(sshd:session): session opened for user vagrant by (uid=0)
+Feb 24 00:11:26 precise32 sudo:  vagrant : TTY=pts/1 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/bash
+Feb 24 00:11:26 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 24 00:12:02 precise32 groupadd[4480]: group added to /etc/group: name=tsg, GID=1003
+Feb 24 00:12:02 precise32 groupadd[4480]: group added to /etc/gshadow: name=tsg
+Feb 24 00:12:02 precise32 groupadd[4480]: new group: name=tsg, GID=1003
+Feb 24 00:12:02 precise32 useradd[4484]: new user: name=tsg, UID=1001, GID=1003, home=/home/tsg, shell=/bin/bash
+Feb 24 00:12:07 precise32 passwd[4491]: pam_unix(passwd:chauthtok): password changed for tsg
+Feb 24 00:12:10 precise32 chfn[4492]: changed user 'tsg' information
+Feb 24 00:12:14 precise32 su[4496]: Successful su for tsg by root
+Feb 24 00:12:14 precise32 su[4496]: + /dev/pts/1 root:tsg
+Feb 24 00:12:14 precise32 su[4496]: pam_unix(su:session): session opened for user tsg by vagrant(uid=0)
+Feb 24 00:12:20 precise32 sudo: pam_unix(sudo:auth): authentication failure; logname=vagrant uid=1001 euid=0 tty=/dev/pts/1 ruser=tsg rhost=  user=tsg
+Feb 24 00:12:37 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/cat /var/log/auth.log
+Feb 24 00:12:37 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 24 00:12:37 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 24 00:12:42 precise32 sudo:      tsg : 3 incorrect password attempts ; TTY=pts/1 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/ls
+Feb 24 00:12:42 precise32 sudo: unable to execute /usr/sbin/sendmail: No such file or directory
+Feb 24 00:12:50 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/cat /var/log/auth.log
+Feb 24 00:12:50 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 24 00:12:50 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 24 00:13:02 precise32 sudo:      tsg : user NOT in sudoers ; TTY=pts/1 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/ls
+Feb 24 00:13:02 precise32 sudo: unable to execute /usr/sbin/sendmail: No such file or directory
+Feb 24 00:13:06 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/cat /var/log/auth.log
+Feb 24 00:13:06 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 24 00:13:06 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 24 00:17:01 precise32 CRON[4588]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 24 00:17:01 precise32 CRON[4588]: pam_unix(cron:session): session closed for user root
+Feb 24 00:45:47 precise32 su[4496]: pam_unix(su:session): session closed for user tsg
+Feb 24 00:45:48 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 24 00:45:49 precise32 sshd[4317]: Received disconnect from 10.0.2.2: 11: disconnected by user
+Feb 24 00:45:49 precise32 sshd[4302]: pam_unix(sshd:session): session closed for user vagrant
+Feb 24 00:46:32 precise32 sshd[4598]: Accepted publickey for vagrant from 10.0.2.2 port 61852 ssh2
+Feb 24 00:46:32 precise32 sshd[4598]: pam_unix(sshd:session): session opened for user vagrant by (uid=0)
+Feb 24 00:46:32 precise32 sshd[4613]: Received disconnect from 10.0.2.2: 11: disconnected by user
+Feb 24 00:46:32 precise32 sshd[4598]: pam_unix(sshd:session): session closed for user vagrant
+Feb 24 01:05:42 precise32 sshd[4185]: pam_unix(sshd:session): session closed for user vagrant
+Feb 24 08:17:01 precise32 CRON[4626]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 24 08:17:01 precise32 CRON[4626]: pam_unix(cron:session): session closed for user root
+Feb 24 09:17:01 precise32 CRON[4642]: pam_unix(cron:session): session opened for user root by (uid=0)
+Feb 24 09:17:01 precise32 CRON[4642]: pam_unix(cron:session): session closed for user root
+Feb 24 09:18:35 precise32 sshd[4645]: Accepted publickey for vagrant from 10.0.2.2 port 53513 ssh2
+Feb 24 09:18:35 precise32 sshd[4645]: pam_unix(sshd:session): session opened for user vagrant by (uid=0)
+Feb 24 09:18:40 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/usr/bin/apt-get install nginx
+Feb 24 09:18:40 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 24 09:18:46 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 24 09:18:53 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/cat /var/log/auth.log
+Feb 24 09:18:53 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 24 09:18:53 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 24 09:19:04 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/cat /var/log/auth.log
+Feb 24 09:19:04 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 24 09:19:04 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 24 09:19:09 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/cat /var/log/auth.log
+Feb 24 09:19:09 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 24 09:19:09 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 24 09:19:29 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/usr/bin/apt-get install mysql-server
+Feb 24 09:19:29 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 24 09:19:55 precise32 groupadd[7996]: group added to /etc/group: name=mysql, GID=111
+Feb 24 09:19:55 precise32 groupadd[7996]: group added to /etc/gshadow: name=mysql
+Feb 24 09:19:55 precise32 groupadd[7996]: new group: name=mysql, GID=111
+Feb 24 09:19:55 precise32 useradd[8002]: new user: name=mysql, UID=106, GID=111, home=/nonexistent, shell=/bin/false
+Feb 24 09:19:55 precise32 chage[8007]: changed password expiry for mysql
+Feb 24 09:19:55 precise32 chfn[8010]: changed user 'mysql' information
+Feb 24 09:20:08 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 24 09:20:10 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/cat /var/log/auth.log
+Feb 24 09:20:10 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 24 09:20:10 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 24 09:26:29 precise32 sudo:  vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/cat /var/log/auth.log
+Feb 24 09:26:29 precise32 sudo: pam_unix(sudo:session): session opened for user root by vagrant(uid=1000)
+Feb 24 09:26:29 precise32 sudo: pam_unix(sudo:session): session closed for user root
+Feb 24 09:26:59 precise32 sshd[10535]: Accepted publickey for vagrant from 10.0.2.2 port 58988 ssh2
+Feb 24 09:26:59 precise32 sshd[10535]: pam_unix(sshd:session): session opened for user vagrant by (uid=0)

--- a/filebeat/module/system/auth/test/secure-rhel7.log
+++ b/filebeat/module/system/auth/test/secure-rhel7.log
@@ -1,0 +1,1000 @@
+Feb 22 16:45:20 slave22 sshd[2738]: Failed password for root from 202.109.143.106 port 1786 ssh2
+Feb 22 16:45:20 slave22 sshd[2738]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:45:22 slave22 sshd[2738]: Failed password for root from 202.109.143.106 port 1786 ssh2
+Feb 22 16:45:23 slave22 sshd[2738]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:45:26 slave22 sshd[2738]: Failed password for root from 202.109.143.106 port 1786 ssh2
+Feb 22 16:45:26 slave22 sshd[2738]: fatal: Read from socket failed: Connection reset by peer [preauth]
+Feb 22 16:45:26 slave22 sshd[2738]: PAM 4 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 16:45:26 slave22 sshd[2738]: PAM service(sshd) ignoring max retries; 5 > 3
+Feb 22 16:45:32 slave22 sshd[2742]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 16:45:32 slave22 sshd[2742]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:45:34 slave22 sshd[2742]: Failed password for root from 202.109.143.106 port 3576 ssh2
+Feb 22 16:45:34 slave22 sshd[2742]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:45:36 slave22 sshd[2742]: Failed password for root from 202.109.143.106 port 3576 ssh2
+Feb 22 16:45:37 slave22 sshd[2742]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:45:39 slave22 sshd[2742]: Failed password for root from 202.109.143.106 port 3576 ssh2
+Feb 22 16:45:39 slave22 sshd[2742]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:45:41 slave22 sshd[2742]: Failed password for root from 202.109.143.106 port 3576 ssh2
+Feb 22 16:45:41 slave22 sshd[2742]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:45:44 slave22 sshd[2742]: Failed password for root from 202.109.143.106 port 3576 ssh2
+Feb 22 16:45:44 slave22 sshd[2742]: fatal: Read from socket failed: Connection reset by peer [preauth]
+Feb 22 16:45:44 slave22 sshd[2742]: PAM 4 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 16:45:44 slave22 sshd[2742]: PAM service(sshd) ignoring max retries; 5 > 3
+Feb 22 16:45:54 slave22 sshd[2754]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 16:45:54 slave22 sshd[2754]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:45:56 slave22 sshd[2758]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=116.31.116.27  user=root
+Feb 22 16:45:56 slave22 sshd[2758]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:45:57 slave22 sshd[2754]: Failed password for root from 202.109.143.106 port 1996 ssh2
+Feb 22 16:45:57 slave22 sshd[2754]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:45:57 slave22 sshd[2758]: Failed password for root from 116.31.116.27 port 26714 ssh2
+Feb 22 16:45:58 slave22 sshd[2758]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:45:59 slave22 sshd[2754]: Failed password for root from 202.109.143.106 port 1996 ssh2
+Feb 22 16:45:59 slave22 sshd[2754]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:46:00 slave22 sshd[2758]: Failed password for root from 116.31.116.27 port 26714 ssh2
+Feb 22 16:46:00 slave22 sshd[2758]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:46:01 slave22 sshd[2754]: Failed password for root from 202.109.143.106 port 1996 ssh2
+Feb 22 16:46:02 slave22 sshd[2754]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:46:03 slave22 sshd[2758]: Failed password for root from 116.31.116.27 port 26714 ssh2
+Feb 22 16:46:03 slave22 sshd[2758]: Received disconnect from 116.31.116.27: 11:  [preauth]
+Feb 22 16:46:03 slave22 sshd[2758]: PAM 2 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=116.31.116.27  user=root
+Feb 22 16:46:04 slave22 sshd[2754]: Failed password for root from 202.109.143.106 port 1996 ssh2
+Feb 22 16:46:04 slave22 sshd[2754]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:46:06 slave22 sshd[2754]: Failed password for root from 202.109.143.106 port 1996 ssh2
+Feb 22 16:46:06 slave22 sshd[2754]: fatal: Read from socket failed: Connection reset by peer [preauth]
+Feb 22 16:46:06 slave22 sshd[2754]: PAM 4 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 16:46:06 slave22 sshd[2754]: PAM service(sshd) ignoring max retries; 5 > 3
+Feb 22 16:46:16 slave22 sshd[2762]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 16:46:16 slave22 sshd[2762]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:46:18 slave22 sshd[2762]: Failed password for root from 202.109.143.106 port 1605 ssh2
+Feb 22 16:46:18 slave22 sshd[2762]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:46:21 slave22 sshd[2762]: Failed password for root from 202.109.143.106 port 1605 ssh2
+Feb 22 16:46:21 slave22 sshd[2762]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:46:23 slave22 sshd[2762]: Failed password for root from 202.109.143.106 port 1605 ssh2
+Feb 22 16:46:24 slave22 sshd[2762]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:46:26 slave22 sshd[2762]: Failed password for root from 202.109.143.106 port 1605 ssh2
+Feb 22 16:46:26 slave22 sshd[2762]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:46:28 slave22 sshd[2762]: Failed password for root from 202.109.143.106 port 1605 ssh2
+Feb 22 16:46:29 slave22 sshd[2762]: fatal: Read from socket failed: Connection reset by peer [preauth]
+Feb 22 16:46:29 slave22 sshd[2762]: PAM 4 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 16:46:29 slave22 sshd[2762]: PAM service(sshd) ignoring max retries; 5 > 3
+Feb 22 16:46:41 slave22 sshd[2766]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 16:46:41 slave22 sshd[2766]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:46:44 slave22 sshd[2766]: Failed password for root from 202.109.143.106 port 1166 ssh2
+Feb 22 16:46:44 slave22 sshd[2766]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:46:46 slave22 sshd[2766]: Failed password for root from 202.109.143.106 port 1166 ssh2
+Feb 22 16:46:46 slave22 sshd[2766]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:46:48 slave22 sshd[2766]: Failed password for root from 202.109.143.106 port 1166 ssh2
+Feb 22 16:46:48 slave22 sshd[2766]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:46:51 slave22 sshd[2766]: Failed password for root from 202.109.143.106 port 1166 ssh2
+Feb 22 16:46:51 slave22 sshd[2766]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:46:53 slave22 sshd[2766]: Failed password for root from 202.109.143.106 port 1166 ssh2
+Feb 22 16:46:53 slave22 sshd[2766]: fatal: Read from socket failed: Connection reset by peer [preauth]
+Feb 22 16:46:53 slave22 sshd[2766]: PAM 4 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 16:46:53 slave22 sshd[2766]: PAM service(sshd) ignoring max retries; 5 > 3
+Feb 22 16:46:57 slave22 sshd[2778]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=116.31.116.27  user=root
+Feb 22 16:46:57 slave22 sshd[2778]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:46:59 slave22 sshd[2778]: Failed password for root from 116.31.116.27 port 13996 ssh2
+Feb 22 16:46:59 slave22 sshd[2778]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:47:02 slave22 sshd[2778]: Failed password for root from 116.31.116.27 port 13996 ssh2
+Feb 22 16:47:03 slave22 sshd[2778]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:47:05 slave22 sshd[2778]: Failed password for root from 116.31.116.27 port 13996 ssh2
+Feb 22 16:47:05 slave22 sshd[2778]: Received disconnect from 116.31.116.27: 11:  [preauth]
+Feb 22 16:47:05 slave22 sshd[2778]: PAM 2 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=116.31.116.27  user=root
+Feb 22 16:47:32 slave22 sshd[2785]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 16:47:32 slave22 sshd[2785]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:47:34 slave22 sshd[2785]: Failed password for root from 202.109.143.106 port 3300 ssh2
+Feb 22 16:47:35 slave22 sshd[2785]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:47:36 slave22 sshd[2785]: Failed password for root from 202.109.143.106 port 3300 ssh2
+Feb 22 16:47:37 slave22 sshd[2785]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:47:38 slave22 sshd[2785]: Failed password for root from 202.109.143.106 port 3300 ssh2
+Feb 22 16:47:39 slave22 sshd[2785]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:47:41 slave22 sshd[2785]: Failed password for root from 202.109.143.106 port 3300 ssh2
+Feb 22 16:47:42 slave22 sshd[2785]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:47:44 slave22 sshd[2785]: Failed password for root from 202.109.143.106 port 3300 ssh2
+Feb 22 16:47:44 slave22 sshd[2785]: fatal: Read from socket failed: Connection reset by peer [preauth]
+Feb 22 16:47:44 slave22 sshd[2785]: PAM 4 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 16:47:44 slave22 sshd[2785]: PAM service(sshd) ignoring max retries; 5 > 3
+Feb 22 16:47:52 slave22 sshd[2797]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 16:47:52 slave22 sshd[2797]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:47:54 slave22 sshd[2797]: Failed password for root from 202.109.143.106 port 1347 ssh2
+Feb 22 16:47:54 slave22 sshd[2797]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:47:56 slave22 sshd[2797]: Failed password for root from 202.109.143.106 port 1347 ssh2
+Feb 22 16:47:56 slave22 sshd[2797]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:47:58 slave22 sshd[2801]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=116.31.116.27  user=root
+Feb 22 16:47:58 slave22 sshd[2801]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:47:59 slave22 sshd[2797]: Failed password for root from 202.109.143.106 port 1347 ssh2
+Feb 22 16:47:59 slave22 sshd[2797]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:48:00 slave22 sshd[2801]: Failed password for root from 116.31.116.27 port 50793 ssh2
+Feb 22 16:48:00 slave22 sshd[2801]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:48:01 slave22 sshd[2797]: Failed password for root from 202.109.143.106 port 1347 ssh2
+Feb 22 16:48:01 slave22 sshd[2797]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:48:02 slave22 sshd[2801]: Failed password for root from 116.31.116.27 port 50793 ssh2
+Feb 22 16:48:03 slave22 sshd[2801]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:48:03 slave22 sshd[2797]: Failed password for root from 202.109.143.106 port 1347 ssh2
+Feb 22 16:48:04 slave22 sshd[2805]: Accepted publickey for drewr from 69.245.39.97 port 34202 ssh2: RSA 01:67:32:d9:b3:20:5d:2d:5f:b4:35:c5:a5:8b:0a:5e
+Feb 22 16:48:04 slave22 sshd[2805]: pam_unix(sshd:session): session opened for user drewr by (uid=0)
+Feb 22 16:48:04 slave22 sshd[2797]: fatal: Read from socket failed: Connection reset by peer [preauth]
+Feb 22 16:48:04 slave22 sshd[2797]: PAM 4 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 16:48:04 slave22 sshd[2797]: PAM service(sshd) ignoring max retries; 5 > 3
+Feb 22 16:48:04 slave22 sshd[2809]: Received disconnect from 69.245.39.97: 11: disconnected by user
+Feb 22 16:48:04 slave22 sshd[2805]: pam_unix(sshd:session): session closed for user drewr
+Feb 22 16:48:05 slave22 sshd[2801]: Failed password for root from 116.31.116.27 port 50793 ssh2
+Feb 22 16:48:05 slave22 sshd[2801]: Received disconnect from 116.31.116.27: 11:  [preauth]
+Feb 22 16:48:05 slave22 sshd[2801]: PAM 2 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=116.31.116.27  user=root
+Feb 22 16:48:08 slave22 sshd[2817]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 16:48:08 slave22 sshd[2817]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:48:10 slave22 sshd[2817]: Failed password for root from 202.109.143.106 port 4450 ssh2
+Feb 22 16:48:10 slave22 sshd[2817]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:48:12 slave22 sshd[2817]: Failed password for root from 202.109.143.106 port 4450 ssh2
+Feb 22 16:48:12 slave22 sshd[2817]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:48:14 slave22 sshd[2817]: Failed password for root from 202.109.143.106 port 4450 ssh2
+Feb 22 16:48:15 slave22 sshd[2817]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:48:17 slave22 sshd[2817]: Failed password for root from 202.109.143.106 port 4450 ssh2
+Feb 22 16:48:17 slave22 sshd[2817]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:48:19 slave22 sshd[2817]: Failed password for root from 202.109.143.106 port 4450 ssh2
+Feb 22 16:48:20 slave22 sshd[2817]: fatal: Read from socket failed: Connection reset by peer [preauth]
+Feb 22 16:48:20 slave22 sshd[2817]: PAM 4 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 16:48:20 slave22 sshd[2817]: PAM service(sshd) ignoring max retries; 5 > 3
+Feb 22 16:48:28 slave22 sshd[2821]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 16:48:28 slave22 sshd[2821]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:48:30 slave22 sshd[2821]: Failed password for root from 202.109.143.106 port 3346 ssh2
+Feb 22 16:48:31 slave22 sshd[2821]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:48:32 slave22 sshd[2821]: Failed password for root from 202.109.143.106 port 3346 ssh2
+Feb 22 16:48:33 slave22 sshd[2821]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:48:34 slave22 sshd[2821]: Failed password for root from 202.109.143.106 port 3346 ssh2
+Feb 22 16:48:35 slave22 sshd[2821]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:48:37 slave22 sshd[2821]: Failed password for root from 202.109.143.106 port 3346 ssh2
+Feb 22 16:48:37 slave22 sshd[2821]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:48:39 slave22 sshd[2821]: Failed password for root from 202.109.143.106 port 3346 ssh2
+Feb 22 16:48:39 slave22 sshd[2821]: fatal: Read from socket failed: Connection reset by peer [preauth]
+Feb 22 16:48:39 slave22 sshd[2821]: PAM 4 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 16:48:39 slave22 sshd[2821]: PAM service(sshd) ignoring max retries; 5 > 3
+Feb 22 16:48:52 slave22 sshd[2825]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=116.31.116.27  user=root
+Feb 22 16:48:52 slave22 sshd[2825]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:48:53 slave22 sshd[2837]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 16:48:53 slave22 sshd[2837]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:48:54 slave22 sshd[2825]: Failed password for root from 116.31.116.27 port 30743 ssh2
+Feb 22 16:48:54 slave22 sshd[2825]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:48:55 slave22 sshd[2837]: Failed password for root from 202.109.143.106 port 1074 ssh2
+Feb 22 16:48:55 slave22 sshd[2837]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:48:56 slave22 sshd[2825]: Failed password for root from 116.31.116.27 port 30743 ssh2
+Feb 22 16:48:57 slave22 sshd[2837]: Failed password for root from 202.109.143.106 port 1074 ssh2
+Feb 22 16:48:57 slave22 sshd[2825]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:48:57 slave22 sshd[2837]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:48:59 slave22 sshd[2825]: Failed password for root from 116.31.116.27 port 30743 ssh2
+Feb 22 16:48:59 slave22 sshd[2837]: Failed password for root from 202.109.143.106 port 1074 ssh2
+Feb 22 16:49:00 slave22 sshd[2837]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:49:00 slave22 sshd[2825]: Received disconnect from 116.31.116.27: 11:  [preauth]
+Feb 22 16:49:00 slave22 sshd[2825]: PAM 2 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=116.31.116.27  user=root
+Feb 22 16:49:02 slave22 sshd[2837]: Failed password for root from 202.109.143.106 port 1074 ssh2
+Feb 22 16:49:02 slave22 sshd[2837]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:49:04 slave22 sshd[2837]: Failed password for root from 202.109.143.106 port 1074 ssh2
+Feb 22 16:49:05 slave22 sshd[2837]: fatal: Read from socket failed: Connection reset by peer [preauth]
+Feb 22 16:49:05 slave22 sshd[2837]: PAM 4 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 16:49:05 slave22 sshd[2837]: PAM service(sshd) ignoring max retries; 5 > 3
+Feb 22 16:49:07 slave22 sshd[2841]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 16:49:07 slave22 sshd[2841]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:49:08 slave22 sshd[2841]: Failed password for root from 202.109.143.106 port 4014 ssh2
+Feb 22 16:49:09 slave22 sshd[2841]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:49:10 slave22 sshd[2841]: Failed password for root from 202.109.143.106 port 4014 ssh2
+Feb 22 16:49:11 slave22 sshd[2841]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:49:13 slave22 sshd[2841]: Failed password for root from 202.109.143.106 port 4014 ssh2
+Feb 22 16:49:13 slave22 sshd[2841]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:49:15 slave22 sshd[2841]: Failed password for root from 202.109.143.106 port 4014 ssh2
+Feb 22 16:49:15 slave22 sshd[2841]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:49:17 slave22 sshd[2841]: Failed password for root from 202.109.143.106 port 4014 ssh2
+Feb 22 16:49:17 slave22 sshd[2841]: fatal: Read from socket failed: Connection reset by peer [preauth]
+Feb 22 16:49:17 slave22 sshd[2841]: PAM 4 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 16:49:17 slave22 sshd[2841]: PAM service(sshd) ignoring max retries; 5 > 3
+Feb 22 16:49:47 slave22 sshd[2846]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=116.31.116.27  user=root
+Feb 22 16:49:47 slave22 sshd[2846]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:49:49 slave22 sshd[2846]: Failed password for root from 116.31.116.27 port 40854 ssh2
+Feb 22 16:49:49 slave22 sshd[2846]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:49:51 slave22 sshd[2846]: Failed password for root from 116.31.116.27 port 40854 ssh2
+Feb 22 16:49:51 slave22 sshd[2846]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:49:53 slave22 sshd[2846]: Failed password for root from 116.31.116.27 port 40854 ssh2
+Feb 22 16:49:55 slave22 sshd[2846]: Received disconnect from 116.31.116.27: 11:  [preauth]
+Feb 22 16:49:55 slave22 sshd[2846]: PAM 2 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=116.31.116.27  user=root
+Feb 22 16:50:06 slave22 sshd[2865]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 16:50:06 slave22 sshd[2865]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:50:08 slave22 sshd[2865]: Failed password for root from 202.109.143.106 port 1208 ssh2
+Feb 22 16:50:08 slave22 sshd[2865]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:50:10 slave22 sshd[2865]: Failed password for root from 202.109.143.106 port 1208 ssh2
+Feb 22 16:50:10 slave22 sshd[2865]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:50:13 slave22 sshd[2865]: Failed password for root from 202.109.143.106 port 1208 ssh2
+Feb 22 16:50:13 slave22 sshd[2865]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:50:14 slave22 sshd[2865]: Failed password for root from 202.109.143.106 port 1208 ssh2
+Feb 22 16:50:15 slave22 sshd[2865]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:50:16 slave22 sshd[2865]: Failed password for root from 202.109.143.106 port 1208 ssh2
+Feb 22 16:50:17 slave22 sshd[2865]: fatal: Read from socket failed: Connection reset by peer [preauth]
+Feb 22 16:50:17 slave22 sshd[2865]: PAM 4 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 16:50:17 slave22 sshd[2865]: PAM service(sshd) ignoring max retries; 5 > 3
+Feb 22 16:50:27 slave22 sshd[2869]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 16:50:27 slave22 sshd[2869]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:50:29 slave22 sshd[2869]: Failed password for root from 202.109.143.106 port 2112 ssh2
+Feb 22 16:50:30 slave22 sshd[2869]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:50:32 slave22 sshd[2869]: Failed password for root from 202.109.143.106 port 2112 ssh2
+Feb 22 16:50:32 slave22 sshd[2869]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:50:34 slave22 sshd[2869]: Failed password for root from 202.109.143.106 port 2112 ssh2
+Feb 22 16:50:34 slave22 sshd[2869]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:50:37 slave22 sshd[2869]: Failed password for root from 202.109.143.106 port 2112 ssh2
+Feb 22 16:50:37 slave22 sshd[2869]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:50:38 slave22 sshd[2869]: Failed password for root from 202.109.143.106 port 2112 ssh2
+Feb 22 16:50:38 slave22 sshd[2869]: fatal: Read from socket failed: Connection reset by peer [preauth]
+Feb 22 16:50:38 slave22 sshd[2869]: PAM 4 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 16:50:38 slave22 sshd[2869]: PAM service(sshd) ignoring max retries; 5 > 3
+Feb 22 16:50:42 slave22 sshd[2873]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=116.31.116.27  user=root
+Feb 22 16:50:42 slave22 sshd[2873]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:50:44 slave22 sshd[2873]: Failed password for root from 116.31.116.27 port 33827 ssh2
+Feb 22 16:50:46 slave22 sshd[2873]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:50:48 slave22 sshd[2873]: Failed password for root from 116.31.116.27 port 33827 ssh2
+Feb 22 16:50:49 slave22 sshd[2873]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:50:50 slave22 sshd[2873]: Failed password for root from 116.31.116.27 port 33827 ssh2
+Feb 22 16:50:50 slave22 sshd[2873]: Received disconnect from 116.31.116.27: 11:  [preauth]
+Feb 22 16:50:50 slave22 sshd[2873]: PAM 2 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=116.31.116.27  user=root
+Feb 22 16:51:35 slave22 sshd[2885]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=116.31.116.27  user=root
+Feb 22 16:51:35 slave22 sshd[2885]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:51:37 slave22 sshd[2885]: Failed password for root from 116.31.116.27 port 22460 ssh2
+Feb 22 16:51:37 slave22 sshd[2885]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:51:39 slave22 sshd[2885]: Failed password for root from 116.31.116.27 port 22460 ssh2
+Feb 22 16:51:39 slave22 sshd[2885]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:51:41 slave22 sshd[2885]: Failed password for root from 116.31.116.27 port 22460 ssh2
+Feb 22 16:51:42 slave22 sshd[2885]: Received disconnect from 116.31.116.27: 11:  [preauth]
+Feb 22 16:51:42 slave22 sshd[2885]: PAM 2 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=116.31.116.27  user=root
+Feb 22 16:52:07 slave22 sshd[2897]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 16:52:07 slave22 sshd[2897]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:52:09 slave22 sshd[2897]: Failed password for root from 202.109.143.106 port 4097 ssh2
+Feb 22 16:52:09 slave22 sshd[2897]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:52:11 slave22 sshd[2897]: Failed password for root from 202.109.143.106 port 4097 ssh2
+Feb 22 16:52:11 slave22 sshd[2897]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:52:14 slave22 sshd[2897]: Failed password for root from 202.109.143.106 port 4097 ssh2
+Feb 22 16:52:14 slave22 sshd[2897]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:52:16 slave22 sshd[2897]: Failed password for root from 202.109.143.106 port 4097 ssh2
+Feb 22 16:52:16 slave22 sshd[2897]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:52:18 slave22 sshd[2897]: Failed password for root from 202.109.143.106 port 4097 ssh2
+Feb 22 16:52:19 slave22 sshd[2897]: fatal: Read from socket failed: Connection reset by peer [preauth]
+Feb 22 16:52:19 slave22 sshd[2897]: PAM 4 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 16:52:19 slave22 sshd[2897]: PAM service(sshd) ignoring max retries; 5 > 3
+Feb 22 16:52:27 slave22 sshd[2901]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 16:52:27 slave22 sshd[2901]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:52:29 slave22 sshd[2901]: Failed password for root from 202.109.143.106 port 3046 ssh2
+Feb 22 16:52:29 slave22 sshd[2901]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:52:32 slave22 sshd[2901]: Failed password for root from 202.109.143.106 port 3046 ssh2
+Feb 22 16:52:32 slave22 sshd[2905]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=116.31.116.27  user=root
+Feb 22 16:52:32 slave22 sshd[2905]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:52:32 slave22 sshd[2901]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:52:34 slave22 sshd[2905]: Failed password for root from 116.31.116.27 port 16865 ssh2
+Feb 22 16:52:34 slave22 sshd[2901]: Failed password for root from 202.109.143.106 port 3046 ssh2
+Feb 22 16:52:34 slave22 sshd[2901]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:52:35 slave22 sshd[2905]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:52:36 slave22 sshd[2901]: Failed password for root from 202.109.143.106 port 3046 ssh2
+Feb 22 16:52:37 slave22 sshd[2901]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:52:37 slave22 sshd[2905]: Failed password for root from 116.31.116.27 port 16865 ssh2
+Feb 22 16:52:38 slave22 sshd[2905]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:52:38 slave22 sshd[2901]: Failed password for root from 202.109.143.106 port 3046 ssh2
+Feb 22 16:52:38 slave22 sshd[2901]: fatal: Read from socket failed: Connection reset by peer [preauth]
+Feb 22 16:52:38 slave22 sshd[2901]: PAM 4 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 16:52:38 slave22 sshd[2901]: PAM service(sshd) ignoring max retries; 5 > 3
+Feb 22 16:52:40 slave22 sshd[2905]: Failed password for root from 116.31.116.27 port 16865 ssh2
+Feb 22 16:52:40 slave22 sshd[2905]: Received disconnect from 116.31.116.27: 11:  [preauth]
+Feb 22 16:52:40 slave22 sshd[2905]: PAM 2 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=116.31.116.27  user=root
+Feb 22 16:52:45 slave22 sshd[2909]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 16:52:45 slave22 sshd[2909]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:52:47 slave22 sshd[2909]: Failed password for root from 202.109.143.106 port 2078 ssh2
+Feb 22 16:52:47 slave22 sshd[2909]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:52:50 slave22 sshd[2909]: Failed password for root from 202.109.143.106 port 2078 ssh2
+Feb 22 16:52:50 slave22 sshd[2909]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:52:52 slave22 sshd[2909]: Failed password for root from 202.109.143.106 port 2078 ssh2
+Feb 22 16:52:52 slave22 sshd[2909]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:52:54 slave22 sshd[2909]: Failed password for root from 202.109.143.106 port 2078 ssh2
+Feb 22 16:52:55 slave22 sshd[2909]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:52:57 slave22 sshd[2909]: Failed password for root from 202.109.143.106 port 2078 ssh2
+Feb 22 16:52:57 slave22 sshd[2909]: fatal: Read from socket failed: Connection reset by peer [preauth]
+Feb 22 16:52:57 slave22 sshd[2909]: PAM 4 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 16:52:57 slave22 sshd[2909]: PAM service(sshd) ignoring max retries; 5 > 3
+Feb 22 16:53:21 slave22 sshd[2921]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 16:53:21 slave22 sshd[2921]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:53:23 slave22 sshd[2921]: Failed password for root from 202.109.143.106 port 2283 ssh2
+Feb 22 16:53:23 slave22 sshd[2921]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:53:24 slave22 sshd[2925]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=116.31.116.27  user=root
+Feb 22 16:53:24 slave22 sshd[2925]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:53:26 slave22 sshd[2921]: Failed password for root from 202.109.143.106 port 2283 ssh2
+Feb 22 16:53:26 slave22 sshd[2925]: Failed password for root from 116.31.116.27 port 64169 ssh2
+Feb 22 16:53:26 slave22 sshd[2921]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:53:26 slave22 sshd[2925]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:53:28 slave22 sshd[2921]: Failed password for root from 202.109.143.106 port 2283 ssh2
+Feb 22 16:53:28 slave22 sshd[2921]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:53:28 slave22 sshd[2925]: Failed password for root from 116.31.116.27 port 64169 ssh2
+Feb 22 16:53:28 slave22 sshd[2925]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:53:30 slave22 sshd[2921]: Failed password for root from 202.109.143.106 port 2283 ssh2
+Feb 22 16:53:30 slave22 sshd[2921]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:53:30 slave22 sshd[2925]: Failed password for root from 116.31.116.27 port 64169 ssh2
+Feb 22 16:53:30 slave22 sshd[2925]: Received disconnect from 116.31.116.27: 11:  [preauth]
+Feb 22 16:53:30 slave22 sshd[2925]: PAM 2 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=116.31.116.27  user=root
+Feb 22 16:53:33 slave22 sshd[2921]: Failed password for root from 202.109.143.106 port 2283 ssh2
+Feb 22 16:53:33 slave22 sshd[2921]: fatal: Read from socket failed: Connection reset by peer [preauth]
+Feb 22 16:53:33 slave22 sshd[2921]: PAM 4 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 16:53:33 slave22 sshd[2921]: PAM service(sshd) ignoring max retries; 5 > 3
+Feb 22 16:54:08 slave22 sshd[2937]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 16:54:08 slave22 sshd[2937]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:54:10 slave22 sshd[2937]: Failed password for root from 202.109.143.106 port 1864 ssh2
+Feb 22 16:54:12 slave22 sshd[2937]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:54:14 slave22 sshd[2937]: Failed password for root from 202.109.143.106 port 1864 ssh2
+Feb 22 16:54:14 slave22 sshd[2937]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:54:15 slave22 sshd[2937]: Failed password for root from 202.109.143.106 port 1864 ssh2
+Feb 22 16:54:15 slave22 sshd[2937]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:54:17 slave22 sshd[2937]: Failed password for root from 202.109.143.106 port 1864 ssh2
+Feb 22 16:54:17 slave22 sshd[2937]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:54:20 slave22 sshd[2937]: Failed password for root from 202.109.143.106 port 1864 ssh2
+Feb 22 16:54:20 slave22 sshd[2937]: fatal: Read from socket failed: Connection reset by peer [preauth]
+Feb 22 16:54:20 slave22 sshd[2937]: PAM 4 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 16:54:20 slave22 sshd[2937]: PAM service(sshd) ignoring max retries; 5 > 3
+Feb 22 16:54:21 slave22 sshd[2941]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=116.31.116.27  user=root
+Feb 22 16:54:21 slave22 sshd[2941]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:54:23 slave22 sshd[2945]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 16:54:23 slave22 sshd[2945]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:54:23 slave22 sshd[2941]: Failed password for root from 116.31.116.27 port 59778 ssh2
+Feb 22 16:54:23 slave22 sshd[2941]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:54:25 slave22 sshd[2945]: Failed password for root from 202.109.143.106 port 1750 ssh2
+Feb 22 16:54:25 slave22 sshd[2945]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:54:25 slave22 sshd[2941]: Failed password for root from 116.31.116.27 port 59778 ssh2
+Feb 22 16:54:25 slave22 sshd[2941]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:54:27 slave22 sshd[2945]: Failed password for root from 202.109.143.106 port 1750 ssh2
+Feb 22 16:54:27 slave22 sshd[2945]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:54:27 slave22 sshd[2941]: Failed password for root from 116.31.116.27 port 59778 ssh2
+Feb 22 16:54:28 slave22 sshd[2941]: Received disconnect from 116.31.116.27: 11:  [preauth]
+Feb 22 16:54:28 slave22 sshd[2941]: PAM 2 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=116.31.116.27  user=root
+Feb 22 16:54:29 slave22 sshd[2945]: Failed password for root from 202.109.143.106 port 1750 ssh2
+Feb 22 16:54:29 slave22 sshd[2945]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:54:31 slave22 sshd[2945]: Failed password for root from 202.109.143.106 port 1750 ssh2
+Feb 22 16:54:32 slave22 sshd[2945]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:54:34 slave22 sshd[2945]: Failed password for root from 202.109.143.106 port 1750 ssh2
+Feb 22 16:54:34 slave22 sshd[2945]: fatal: Read from socket failed: Connection reset by peer [preauth]
+Feb 22 16:54:34 slave22 sshd[2945]: PAM 4 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 16:54:34 slave22 sshd[2945]: PAM service(sshd) ignoring max retries; 5 > 3
+Feb 22 16:54:37 slave22 sshd[2949]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 16:54:37 slave22 sshd[2949]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:54:38 slave22 sshd[2949]: Failed password for root from 202.109.143.106 port 4014 ssh2
+Feb 22 16:54:38 slave22 sshd[2949]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:54:40 slave22 sshd[2949]: Failed password for root from 202.109.143.106 port 4014 ssh2
+Feb 22 16:54:40 slave22 sshd[2949]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:54:42 slave22 sshd[2949]: Failed password for root from 202.109.143.106 port 4014 ssh2
+Feb 22 16:54:42 slave22 sshd[2949]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:54:45 slave22 sshd[2949]: Failed password for root from 202.109.143.106 port 4014 ssh2
+Feb 22 16:54:45 slave22 sshd[2949]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:54:47 slave22 sshd[2949]: Failed password for root from 202.109.143.106 port 4014 ssh2
+Feb 22 16:54:47 slave22 sshd[2949]: fatal: Read from socket failed: Connection reset by peer [preauth]
+Feb 22 16:54:47 slave22 sshd[2949]: PAM 4 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 16:54:47 slave22 sshd[2949]: PAM service(sshd) ignoring max retries; 5 > 3
+Feb 22 16:54:51 slave22 sshd[2953]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 16:54:51 slave22 sshd[2953]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:54:53 slave22 sshd[2953]: Failed password for root from 202.109.143.106 port 4817 ssh2
+Feb 22 16:54:53 slave22 sshd[2953]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:54:56 slave22 sshd[2953]: Failed password for root from 202.109.143.106 port 4817 ssh2
+Feb 22 16:54:56 slave22 sshd[2953]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:54:57 slave22 sshd[2953]: Failed password for root from 202.109.143.106 port 4817 ssh2
+Feb 22 16:54:58 slave22 sshd[2953]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:54:59 slave22 sshd[2953]: Failed password for root from 202.109.143.106 port 4817 ssh2
+Feb 22 16:54:59 slave22 sshd[2953]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:55:01 slave22 sshd[2953]: Failed password for root from 202.109.143.106 port 4817 ssh2
+Feb 22 16:55:02 slave22 sshd[2953]: fatal: Read from socket failed: Connection reset by peer [preauth]
+Feb 22 16:55:02 slave22 sshd[2953]: PAM 4 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 16:55:02 slave22 sshd[2953]: PAM service(sshd) ignoring max retries; 5 > 3
+Feb 22 16:55:04 slave22 sshd[2965]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 16:55:04 slave22 sshd[2965]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:55:06 slave22 sshd[2965]: Failed password for root from 202.109.143.106 port 4413 ssh2
+Feb 22 16:55:06 slave22 sshd[2965]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:55:09 slave22 sshd[2965]: Failed password for root from 202.109.143.106 port 4413 ssh2
+Feb 22 16:55:09 slave22 sshd[2965]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:55:10 slave22 sshd[2965]: Failed password for root from 202.109.143.106 port 4413 ssh2
+Feb 22 16:55:11 slave22 sshd[2965]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:55:13 slave22 sshd[2965]: Failed password for root from 202.109.143.106 port 4413 ssh2
+Feb 22 16:55:13 slave22 sshd[2965]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:55:15 slave22 sshd[2965]: Failed password for root from 202.109.143.106 port 4413 ssh2
+Feb 22 16:55:16 slave22 sshd[2965]: fatal: Read from socket failed: Connection reset by peer [preauth]
+Feb 22 16:55:16 slave22 sshd[2965]: PAM 4 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 16:55:16 slave22 sshd[2965]: PAM service(sshd) ignoring max retries; 5 > 3
+Feb 22 16:55:28 slave22 sshd[2969]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=116.31.116.27  user=root
+Feb 22 16:55:28 slave22 sshd[2969]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:55:30 slave22 sshd[2969]: Failed password for root from 116.31.116.27 port 58195 ssh2
+Feb 22 16:55:30 slave22 sshd[2969]: Received disconnect from 116.31.116.27: 11:  [preauth]
+Feb 22 16:55:35 slave22 sshd[2973]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 16:55:35 slave22 sshd[2973]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:55:37 slave22 sshd[2973]: Failed password for root from 202.109.143.106 port 3222 ssh2
+Feb 22 16:55:37 slave22 sshd[2973]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:55:39 slave22 sshd[2973]: Failed password for root from 202.109.143.106 port 3222 ssh2
+Feb 22 16:55:39 slave22 sshd[2973]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:55:42 slave22 sshd[2973]: Failed password for root from 202.109.143.106 port 3222 ssh2
+Feb 22 16:55:42 slave22 sshd[2973]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:55:45 slave22 sshd[2973]: Failed password for root from 202.109.143.106 port 3222 ssh2
+Feb 22 16:55:45 slave22 sshd[2973]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:55:47 slave22 sshd[2973]: Failed password for root from 202.109.143.106 port 3222 ssh2
+Feb 22 16:55:47 slave22 sshd[2973]: fatal: Read from socket failed: Connection reset by peer [preauth]
+Feb 22 16:55:47 slave22 sshd[2973]: PAM 4 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 16:55:47 slave22 sshd[2973]: PAM service(sshd) ignoring max retries; 5 > 3
+Feb 22 16:55:50 slave22 sshd[2977]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 16:55:50 slave22 sshd[2977]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:55:52 slave22 sshd[2977]: Failed password for root from 202.109.143.106 port 2455 ssh2
+Feb 22 16:55:52 slave22 sshd[2977]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:55:54 slave22 sshd[2977]: Failed password for root from 202.109.143.106 port 2455 ssh2
+Feb 22 16:55:54 slave22 sshd[2977]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:55:56 slave22 sshd[2977]: Failed password for root from 202.109.143.106 port 2455 ssh2
+Feb 22 16:55:56 slave22 sshd[2977]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:55:58 slave22 sshd[2977]: Failed password for root from 202.109.143.106 port 2455 ssh2
+Feb 22 16:55:58 slave22 sshd[2977]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:56:00 slave22 sshd[2977]: Failed password for root from 202.109.143.106 port 2455 ssh2
+Feb 22 16:56:00 slave22 sshd[2977]: fatal: Read from socket failed: Connection reset by peer [preauth]
+Feb 22 16:56:00 slave22 sshd[2977]: PAM 4 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 16:56:00 slave22 sshd[2977]: PAM service(sshd) ignoring max retries; 5 > 3
+Feb 22 16:56:03 slave22 sshd[2989]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 16:56:03 slave22 sshd[2989]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:56:05 slave22 sshd[2989]: Failed password for root from 202.109.143.106 port 3616 ssh2
+Feb 22 16:56:05 slave22 sshd[2989]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:56:07 slave22 sshd[2989]: Failed password for root from 202.109.143.106 port 3616 ssh2
+Feb 22 16:56:07 slave22 sshd[2989]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:56:09 slave22 sshd[2989]: Failed password for root from 202.109.143.106 port 3616 ssh2
+Feb 22 16:56:10 slave22 sshd[2989]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:56:11 slave22 sshd[2989]: Failed password for root from 202.109.143.106 port 3616 ssh2
+Feb 22 16:56:12 slave22 sshd[2989]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:56:13 slave22 sshd[2993]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=116.31.116.27  user=root
+Feb 22 16:56:13 slave22 sshd[2993]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:56:14 slave22 sshd[2989]: Failed password for root from 202.109.143.106 port 3616 ssh2
+Feb 22 16:56:14 slave22 sshd[2989]: fatal: Read from socket failed: Connection reset by peer [preauth]
+Feb 22 16:56:14 slave22 sshd[2989]: PAM 4 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 16:56:14 slave22 sshd[2989]: PAM service(sshd) ignoring max retries; 5 > 3
+Feb 22 16:56:15 slave22 sshd[2993]: Failed password for root from 116.31.116.27 port 54178 ssh2
+Feb 22 16:56:16 slave22 sshd[2993]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:56:17 slave22 sshd[2993]: Failed password for root from 116.31.116.27 port 54178 ssh2
+Feb 22 16:56:18 slave22 sshd[2993]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:56:19 slave22 sshd[2993]: Failed password for root from 116.31.116.27 port 54178 ssh2
+Feb 22 16:56:21 slave22 sshd[2993]: Received disconnect from 116.31.116.27: 11:  [preauth]
+Feb 22 16:56:21 slave22 sshd[2993]: PAM 2 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=116.31.116.27  user=root
+Feb 22 16:56:53 slave22 sshd[3005]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 16:56:53 slave22 sshd[3005]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:56:55 slave22 sshd[3005]: Failed password for root from 202.109.143.106 port 2757 ssh2
+Feb 22 16:56:55 slave22 sshd[3005]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:56:57 slave22 sshd[3005]: Failed password for root from 202.109.143.106 port 2757 ssh2
+Feb 22 16:56:58 slave22 sshd[3005]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:57:00 slave22 sshd[3005]: Failed password for root from 202.109.143.106 port 2757 ssh2
+Feb 22 16:57:01 slave22 sshd[3005]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:57:03 slave22 sshd[3005]: Failed password for root from 202.109.143.106 port 2757 ssh2
+Feb 22 16:57:05 slave22 sshd[3009]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=116.31.116.27  user=root
+Feb 22 16:57:05 slave22 sshd[3009]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:57:06 slave22 sshd[3005]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:57:07 slave22 sshd[3009]: Failed password for root from 116.31.116.27 port 47019 ssh2
+Feb 22 16:57:07 slave22 sshd[3009]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:57:08 slave22 sshd[3005]: Failed password for root from 202.109.143.106 port 2757 ssh2
+Feb 22 16:57:09 slave22 sshd[3005]: fatal: Read from socket failed: Connection reset by peer [preauth]
+Feb 22 16:57:09 slave22 sshd[3005]: PAM 4 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 16:57:09 slave22 sshd[3005]: PAM service(sshd) ignoring max retries; 5 > 3
+Feb 22 16:57:10 slave22 sshd[3009]: Failed password for root from 116.31.116.27 port 47019 ssh2
+Feb 22 16:57:10 slave22 sshd[3009]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:57:12 slave22 sshd[3009]: Failed password for root from 116.31.116.27 port 47019 ssh2
+Feb 22 16:57:12 slave22 sshd[3009]: Received disconnect from 116.31.116.27: 11:  [preauth]
+Feb 22 16:57:12 slave22 sshd[3009]: PAM 2 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=116.31.116.27  user=root
+Feb 22 16:57:42 slave22 sshd[3013]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 16:57:42 slave22 sshd[3013]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:57:44 slave22 sshd[3013]: Failed password for root from 202.109.143.106 port 4016 ssh2
+Feb 22 16:57:45 slave22 sshd[3013]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:57:47 slave22 sshd[3013]: Failed password for root from 202.109.143.106 port 4016 ssh2
+Feb 22 16:57:47 slave22 sshd[3013]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:57:49 slave22 sshd[3013]: Failed password for root from 202.109.143.106 port 4016 ssh2
+Feb 22 16:57:50 slave22 sshd[3013]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:57:51 slave22 sshd[3013]: Failed password for root from 202.109.143.106 port 4016 ssh2
+Feb 22 16:57:51 slave22 sshd[3013]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:57:53 slave22 sshd[3013]: Failed password for root from 202.109.143.106 port 4016 ssh2
+Feb 22 16:57:53 slave22 sshd[3013]: fatal: Read from socket failed: Connection reset by peer [preauth]
+Feb 22 16:57:53 slave22 sshd[3013]: PAM 4 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 16:57:53 slave22 sshd[3013]: PAM service(sshd) ignoring max retries; 5 > 3
+Feb 22 16:58:01 slave22 sshd[3025]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 16:58:01 slave22 sshd[3025]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:58:03 slave22 sshd[3025]: Failed password for root from 202.109.143.106 port 1650 ssh2
+Feb 22 16:58:03 slave22 sshd[3025]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:58:03 slave22 sshd[3033]: Accepted publickey for drewr from 69.245.39.97 port 42136 ssh2: RSA 01:67:32:d9:b3:20:5d:2d:5f:b4:35:c5:a5:8b:0a:5e
+Feb 22 16:58:03 slave22 sshd[3033]: pam_unix(sshd:session): session opened for user drewr by (uid=0)
+Feb 22 16:58:04 slave22 sshd[3037]: Received disconnect from 69.245.39.97: 11: disconnected by user
+Feb 22 16:58:04 slave22 sshd[3033]: pam_unix(sshd:session): session closed for user drewr
+Feb 22 16:58:04 slave22 sshd[3029]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=116.31.116.27  user=root
+Feb 22 16:58:04 slave22 sshd[3029]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:58:06 slave22 sshd[3025]: Failed password for root from 202.109.143.106 port 1650 ssh2
+Feb 22 16:58:06 slave22 sshd[3025]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:58:07 slave22 sshd[3029]: Failed password for root from 116.31.116.27 port 53314 ssh2
+Feb 22 16:58:07 slave22 sshd[3029]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:58:08 slave22 sshd[3025]: Failed password for root from 202.109.143.106 port 1650 ssh2
+Feb 22 16:58:08 slave22 sshd[3025]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:58:09 slave22 sshd[3029]: Failed password for root from 116.31.116.27 port 53314 ssh2
+Feb 22 16:58:09 slave22 sshd[3029]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:58:10 slave22 sshd[3025]: Failed password for root from 202.109.143.106 port 1650 ssh2
+Feb 22 16:58:11 slave22 sshd[3025]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:58:11 slave22 sshd[3029]: Failed password for root from 116.31.116.27 port 53314 ssh2
+Feb 22 16:58:12 slave22 sshd[3029]: Received disconnect from 116.31.116.27: 11:  [preauth]
+Feb 22 16:58:12 slave22 sshd[3029]: PAM 2 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=116.31.116.27  user=root
+Feb 22 16:58:13 slave22 sshd[3025]: Failed password for root from 202.109.143.106 port 1650 ssh2
+Feb 22 16:58:13 slave22 sshd[3025]: fatal: Read from socket failed: Connection reset by peer [preauth]
+Feb 22 16:58:13 slave22 sshd[3025]: PAM 4 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 16:58:13 slave22 sshd[3025]: PAM service(sshd) ignoring max retries; 5 > 3
+Feb 22 16:58:34 slave22 sshd[3044]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 16:58:34 slave22 sshd[3044]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:58:37 slave22 sshd[3044]: Failed password for root from 202.109.143.106 port 3023 ssh2
+Feb 22 16:58:38 slave22 sshd[3044]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:58:41 slave22 sshd[3044]: Failed password for root from 202.109.143.106 port 3023 ssh2
+Feb 22 16:58:41 slave22 sshd[3044]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:58:43 slave22 sshd[3044]: Failed password for root from 202.109.143.106 port 3023 ssh2
+Feb 22 16:58:43 slave22 sshd[3044]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:58:45 slave22 sshd[3044]: Failed password for root from 202.109.143.106 port 3023 ssh2
+Feb 22 16:58:46 slave22 sshd[3044]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:58:48 slave22 sshd[3044]: Failed password for root from 202.109.143.106 port 3023 ssh2
+Feb 22 16:58:48 slave22 sshd[3044]: fatal: Read from socket failed: Connection reset by peer [preauth]
+Feb 22 16:58:48 slave22 sshd[3044]: PAM 4 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 16:58:48 slave22 sshd[3044]: PAM service(sshd) ignoring max retries; 5 > 3
+Feb 22 16:58:52 slave22 sshd[3056]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 16:58:52 slave22 sshd[3056]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:58:54 slave22 sshd[3056]: Failed password for root from 202.109.143.106 port 4898 ssh2
+Feb 22 16:58:54 slave22 sshd[3056]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:58:56 slave22 sshd[3056]: Failed password for root from 202.109.143.106 port 4898 ssh2
+Feb 22 16:58:57 slave22 sshd[3056]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:58:59 slave22 sshd[3060]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=116.31.116.27  user=root
+Feb 22 16:58:59 slave22 sshd[3060]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:58:59 slave22 sshd[3056]: Failed password for root from 202.109.143.106 port 4898 ssh2
+Feb 22 16:58:59 slave22 sshd[3056]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:59:01 slave22 sshd[3060]: Failed password for root from 116.31.116.27 port 49903 ssh2
+Feb 22 16:59:01 slave22 sshd[3060]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:59:01 slave22 sshd[3056]: Failed password for root from 202.109.143.106 port 4898 ssh2
+Feb 22 16:59:02 slave22 sshd[3056]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:59:03 slave22 sshd[3060]: Failed password for root from 116.31.116.27 port 49903 ssh2
+Feb 22 16:59:03 slave22 sshd[3056]: Failed password for root from 202.109.143.106 port 4898 ssh2
+Feb 22 16:59:04 slave22 sshd[3056]: fatal: Read from socket failed: Connection reset by peer [preauth]
+Feb 22 16:59:04 slave22 sshd[3056]: PAM 4 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 16:59:04 slave22 sshd[3056]: PAM service(sshd) ignoring max retries; 5 > 3
+Feb 22 16:59:05 slave22 sshd[3060]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:59:07 slave22 sshd[3060]: Failed password for root from 116.31.116.27 port 49903 ssh2
+Feb 22 16:59:08 slave22 sshd[3060]: Received disconnect from 116.31.116.27: 11:  [preauth]
+Feb 22 16:59:08 slave22 sshd[3060]: PAM 2 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=116.31.116.27  user=root
+Feb 22 16:59:15 slave22 sshd[3064]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=223.99.60.46  user=root
+Feb 22 16:59:15 slave22 sshd[3064]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:59:17 slave22 sshd[3064]: Failed password for root from 223.99.60.46 port 43257 ssh2
+Feb 22 16:59:21 slave22 sshd[3064]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:59:21 slave22 sshd[3068]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 16:59:21 slave22 sshd[3068]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:59:24 slave22 sshd[3064]: Failed password for root from 223.99.60.46 port 43257 ssh2
+Feb 22 16:59:24 slave22 sshd[3068]: Failed password for root from 202.109.143.106 port 3101 ssh2
+Feb 22 16:59:24 slave22 sshd[3068]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:59:24 slave22 sshd[3064]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:59:26 slave22 sshd[3068]: Failed password for root from 202.109.143.106 port 3101 ssh2
+Feb 22 16:59:27 slave22 sshd[3068]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:59:27 slave22 sshd[3064]: Failed password for root from 223.99.60.46 port 43257 ssh2
+Feb 22 16:59:27 slave22 sshd[3064]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:59:29 slave22 sshd[3068]: Failed password for root from 202.109.143.106 port 3101 ssh2
+Feb 22 16:59:29 slave22 sshd[3068]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:59:30 slave22 sshd[3064]: Failed password for root from 223.99.60.46 port 43257 ssh2
+Feb 22 16:59:30 slave22 sshd[3064]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:59:31 slave22 sshd[3068]: Failed password for root from 202.109.143.106 port 3101 ssh2
+Feb 22 16:59:31 slave22 sshd[3068]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:59:32 slave22 sshd[3064]: Failed password for root from 223.99.60.46 port 43257 ssh2
+Feb 22 16:59:33 slave22 sshd[3068]: Failed password for root from 202.109.143.106 port 3101 ssh2
+Feb 22 16:59:33 slave22 sshd[3064]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:59:33 slave22 sshd[3068]: fatal: Read from socket failed: Connection reset by peer [preauth]
+Feb 22 16:59:33 slave22 sshd[3068]: PAM 4 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 16:59:33 slave22 sshd[3068]: PAM service(sshd) ignoring max retries; 5 > 3
+Feb 22 16:59:35 slave22 sshd[3064]: Failed password for root from 223.99.60.46 port 43257 ssh2
+Feb 22 16:59:35 slave22 sshd[3064]: Disconnecting: Too many authentication failures for root [preauth]
+Feb 22 16:59:35 slave22 sshd[3064]: PAM 5 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=223.99.60.46  user=root
+Feb 22 16:59:35 slave22 sshd[3064]: PAM service(sshd) ignoring max retries; 6 > 3
+Feb 22 16:59:38 slave22 sshd[3072]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=223.99.60.46  user=root
+Feb 22 16:59:38 slave22 sshd[3072]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:59:40 slave22 sshd[3072]: Failed password for root from 223.99.60.46 port 4679 ssh2
+Feb 22 16:59:41 slave22 sshd[3072]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:59:42 slave22 sshd[3072]: Failed password for root from 223.99.60.46 port 4679 ssh2
+Feb 22 16:59:43 slave22 sshd[3072]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:59:45 slave22 sshd[3072]: Failed password for root from 223.99.60.46 port 4679 ssh2
+Feb 22 16:59:46 slave22 sshd[3072]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:59:48 slave22 sshd[3072]: Failed password for root from 223.99.60.46 port 4679 ssh2
+Feb 22 16:59:54 slave22 sshd[3084]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=116.31.116.27  user=root
+Feb 22 16:59:54 slave22 sshd[3084]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:59:56 slave22 sshd[3072]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:59:56 slave22 sshd[3084]: Failed password for root from 116.31.116.27 port 43528 ssh2
+Feb 22 16:59:56 slave22 sshd[3084]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:59:56 slave22 sshd[3088]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 16:59:56 slave22 sshd[3088]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:59:58 slave22 sshd[3072]: Failed password for root from 223.99.60.46 port 4679 ssh2
+Feb 22 16:59:58 slave22 sshd[3084]: Failed password for root from 116.31.116.27 port 43528 ssh2
+Feb 22 16:59:59 slave22 sshd[3088]: Failed password for root from 202.109.143.106 port 4450 ssh2
+Feb 22 16:59:59 slave22 sshd[3084]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:59:59 slave22 sshd[3072]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 16:59:59 slave22 sshd[3088]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:00:01 slave22 sshd[3084]: Failed password for root from 116.31.116.27 port 43528 ssh2
+Feb 22 17:00:01 slave22 sshd[3072]: Failed password for root from 223.99.60.46 port 4679 ssh2
+Feb 22 17:00:01 slave22 sshd[3072]: Disconnecting: Too many authentication failures for root [preauth]
+Feb 22 17:00:01 slave22 sshd[3072]: PAM 5 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=223.99.60.46  user=root
+Feb 22 17:00:01 slave22 sshd[3072]: PAM service(sshd) ignoring max retries; 6 > 3
+Feb 22 17:00:01 slave22 sshd[3088]: Failed password for root from 202.109.143.106 port 4450 ssh2
+Feb 22 17:00:01 slave22 sshd[3084]: Received disconnect from 116.31.116.27: 11:  [preauth]
+Feb 22 17:00:01 slave22 sshd[3084]: PAM 2 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=116.31.116.27  user=root
+Feb 22 17:00:01 slave22 sshd[3088]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:00:03 slave22 sshd[3088]: Failed password for root from 202.109.143.106 port 4450 ssh2
+Feb 22 17:00:04 slave22 sshd[3088]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:00:04 slave22 sshd[3099]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=223.99.60.46  user=root
+Feb 22 17:00:04 slave22 sshd[3099]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:00:06 slave22 sshd[3088]: Failed password for root from 202.109.143.106 port 4450 ssh2
+Feb 22 17:00:06 slave22 sshd[3099]: Failed password for root from 223.99.60.46 port 31185 ssh2
+Feb 22 17:00:06 slave22 sshd[3088]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:00:07 slave22 sshd[3099]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:00:08 slave22 sshd[3088]: Failed password for root from 202.109.143.106 port 4450 ssh2
+Feb 22 17:00:08 slave22 sshd[3088]: fatal: Read from socket failed: Connection reset by peer [preauth]
+Feb 22 17:00:08 slave22 sshd[3088]: PAM 4 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 17:00:08 slave22 sshd[3088]: PAM service(sshd) ignoring max retries; 5 > 3
+Feb 22 17:00:09 slave22 sshd[3099]: Failed password for root from 223.99.60.46 port 31185 ssh2
+Feb 22 17:00:10 slave22 sshd[3099]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:00:13 slave22 sshd[3099]: Failed password for root from 223.99.60.46 port 31185 ssh2
+Feb 22 17:00:14 slave22 sshd[3099]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:00:15 slave22 sshd[3103]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 17:00:15 slave22 sshd[3103]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:00:15 slave22 sshd[3099]: Failed password for root from 223.99.60.46 port 31185 ssh2
+Feb 22 17:00:16 slave22 sshd[3099]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:00:17 slave22 sshd[3103]: Failed password for root from 202.109.143.106 port 1807 ssh2
+Feb 22 17:00:17 slave22 sshd[3103]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:00:18 slave22 sshd[3099]: Failed password for root from 223.99.60.46 port 31185 ssh2
+Feb 22 17:00:18 slave22 sshd[3103]: Failed password for root from 202.109.143.106 port 1807 ssh2
+Feb 22 17:00:19 slave22 sshd[3103]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:00:19 slave22 sshd[3099]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:00:21 slave22 sshd[3103]: Failed password for root from 202.109.143.106 port 1807 ssh2
+Feb 22 17:00:21 slave22 sshd[3099]: Failed password for root from 223.99.60.46 port 31185 ssh2
+Feb 22 17:00:21 slave22 sshd[3099]: Disconnecting: Too many authentication failures for root [preauth]
+Feb 22 17:00:21 slave22 sshd[3099]: PAM 5 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=223.99.60.46  user=root
+Feb 22 17:00:21 slave22 sshd[3099]: PAM service(sshd) ignoring max retries; 6 > 3
+Feb 22 17:00:21 slave22 sshd[3103]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:00:23 slave22 sshd[3103]: Failed password for root from 202.109.143.106 port 1807 ssh2
+Feb 22 17:00:24 slave22 sshd[3103]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:00:24 slave22 sshd[3107]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=223.99.60.46  user=root
+Feb 22 17:00:24 slave22 sshd[3107]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:00:25 slave22 sshd[3103]: Failed password for root from 202.109.143.106 port 1807 ssh2
+Feb 22 17:00:26 slave22 sshd[3103]: fatal: Read from socket failed: Connection reset by peer [preauth]
+Feb 22 17:00:26 slave22 sshd[3103]: PAM 4 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 17:00:26 slave22 sshd[3103]: PAM service(sshd) ignoring max retries; 5 > 3
+Feb 22 17:00:26 slave22 sshd[3107]: Failed password for root from 223.99.60.46 port 56365 ssh2
+Feb 22 17:00:27 slave22 sshd[3107]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:00:29 slave22 sshd[3107]: Failed password for root from 223.99.60.46 port 56365 ssh2
+Feb 22 17:00:30 slave22 sshd[3107]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:00:32 slave22 sshd[3107]: Failed password for root from 223.99.60.46 port 56365 ssh2
+Feb 22 17:00:33 slave22 sshd[3107]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:00:35 slave22 sshd[3107]: Failed password for root from 223.99.60.46 port 56365 ssh2
+Feb 22 17:00:36 slave22 sshd[3107]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:00:38 slave22 sshd[3107]: Failed password for root from 223.99.60.46 port 56365 ssh2
+Feb 22 17:00:38 slave22 sshd[3107]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:00:40 slave22 sshd[3107]: Failed password for root from 223.99.60.46 port 56365 ssh2
+Feb 22 17:00:40 slave22 sshd[3107]: Disconnecting: Too many authentication failures for root [preauth]
+Feb 22 17:00:40 slave22 sshd[3107]: PAM 5 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=223.99.60.46  user=root
+Feb 22 17:00:40 slave22 sshd[3107]: PAM service(sshd) ignoring max retries; 6 > 3
+Feb 22 17:00:46 slave22 sshd[3115]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 17:00:46 slave22 sshd[3115]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:00:48 slave22 sshd[3119]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=116.31.116.27  user=root
+Feb 22 17:00:48 slave22 sshd[3119]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:00:49 slave22 sshd[3115]: Failed password for root from 202.109.143.106 port 3310 ssh2
+Feb 22 17:00:49 slave22 sshd[3115]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:00:50 slave22 sshd[3119]: Failed password for root from 116.31.116.27 port 26757 ssh2
+Feb 22 17:00:50 slave22 sshd[3119]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:00:51 slave22 sshd[3115]: Failed password for root from 202.109.143.106 port 3310 ssh2
+Feb 22 17:00:52 slave22 sshd[3119]: Failed password for root from 116.31.116.27 port 26757 ssh2
+Feb 22 17:00:52 slave22 sshd[3119]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:00:53 slave22 sshd[3115]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:00:53 slave22 sshd[3111]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=223.99.60.46  user=root
+Feb 22 17:00:53 slave22 sshd[3111]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:00:54 slave22 sshd[3119]: Failed password for root from 116.31.116.27 port 26757 ssh2
+Feb 22 17:00:54 slave22 sshd[3115]: Failed password for root from 202.109.143.106 port 3310 ssh2
+Feb 22 17:00:54 slave22 sshd[3119]: Received disconnect from 116.31.116.27: 11:  [preauth]
+Feb 22 17:00:54 slave22 sshd[3119]: PAM 2 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=116.31.116.27  user=root
+Feb 22 17:00:54 slave22 sshd[3115]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:00:55 slave22 sshd[3111]: Failed password for root from 223.99.60.46 port 6597 ssh2
+Feb 22 17:00:56 slave22 sshd[3111]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:00:56 slave22 sshd[3115]: Failed password for root from 202.109.143.106 port 3310 ssh2
+Feb 22 17:00:57 slave22 sshd[3115]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:00:58 slave22 sshd[3111]: Failed password for root from 223.99.60.46 port 6597 ssh2
+Feb 22 17:00:58 slave22 sshd[3111]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:01:00 slave22 sshd[3115]: Failed password for root from 202.109.143.106 port 3310 ssh2
+Feb 22 17:01:00 slave22 sshd[3115]: fatal: Read from socket failed: Connection reset by peer [preauth]
+Feb 22 17:01:00 slave22 sshd[3115]: PAM 4 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 17:01:00 slave22 sshd[3115]: PAM service(sshd) ignoring max retries; 5 > 3
+Feb 22 17:01:01 slave22 sshd[3111]: Failed password for root from 223.99.60.46 port 6597 ssh2
+Feb 22 17:01:02 slave22 sshd[3111]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:01:03 slave22 sshd[3111]: Failed password for root from 223.99.60.46 port 6597 ssh2
+Feb 22 17:01:04 slave22 sshd[3111]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:01:06 slave22 sshd[3111]: Failed password for root from 223.99.60.46 port 6597 ssh2
+Feb 22 17:01:07 slave22 sshd[3111]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:01:09 slave22 sshd[3111]: Failed password for root from 223.99.60.46 port 6597 ssh2
+Feb 22 17:01:09 slave22 sshd[3111]: Disconnecting: Too many authentication failures for root [preauth]
+Feb 22 17:01:09 slave22 sshd[3111]: PAM 5 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=223.99.60.46  user=root
+Feb 22 17:01:09 slave22 sshd[3111]: PAM service(sshd) ignoring max retries; 6 > 3
+Feb 22 17:01:12 slave22 sshd[3192]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 17:01:12 slave22 sshd[3192]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:01:14 slave22 sshd[3192]: Failed password for root from 202.109.143.106 port 4288 ssh2
+Feb 22 17:01:15 slave22 sshd[3192]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:01:17 slave22 sshd[3192]: Failed password for root from 202.109.143.106 port 4288 ssh2
+Feb 22 17:01:17 slave22 sshd[3192]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:01:19 slave22 sshd[3188]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=223.99.60.46  user=root
+Feb 22 17:01:19 slave22 sshd[3188]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:01:19 slave22 sshd[3192]: Failed password for root from 202.109.143.106 port 4288 ssh2
+Feb 22 17:01:21 slave22 sshd[3192]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:01:21 slave22 sshd[3188]: Failed password for root from 223.99.60.46 port 37514 ssh2
+Feb 22 17:01:22 slave22 sshd[3188]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:01:23 slave22 sshd[3192]: Failed password for root from 202.109.143.106 port 4288 ssh2
+Feb 22 17:01:23 slave22 sshd[3192]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:01:24 slave22 sshd[3188]: Failed password for root from 223.99.60.46 port 37514 ssh2
+Feb 22 17:01:25 slave22 sshd[3188]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:01:25 slave22 sshd[3192]: Failed password for root from 202.109.143.106 port 4288 ssh2
+Feb 22 17:01:25 slave22 sshd[3192]: fatal: Read from socket failed: Connection reset by peer [preauth]
+Feb 22 17:01:25 slave22 sshd[3192]: PAM 4 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 17:01:25 slave22 sshd[3192]: PAM service(sshd) ignoring max retries; 5 > 3
+Feb 22 17:01:26 slave22 sshd[3188]: Failed password for root from 223.99.60.46 port 37514 ssh2
+Feb 22 17:01:27 slave22 sshd[3188]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:01:29 slave22 sshd[3188]: Failed password for root from 223.99.60.46 port 37514 ssh2
+Feb 22 17:01:29 slave22 sshd[3188]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:01:31 slave22 sshd[3188]: Failed password for root from 223.99.60.46 port 37514 ssh2
+Feb 22 17:01:32 slave22 sshd[3188]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:01:34 slave22 sshd[3188]: Failed password for root from 223.99.60.46 port 37514 ssh2
+Feb 22 17:01:34 slave22 sshd[3188]: Disconnecting: Too many authentication failures for root [preauth]
+Feb 22 17:01:34 slave22 sshd[3188]: PAM 5 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=223.99.60.46  user=root
+Feb 22 17:01:34 slave22 sshd[3188]: PAM service(sshd) ignoring max retries; 6 > 3
+Feb 22 17:01:46 slave22 sshd[3200]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=116.31.116.27  user=root
+Feb 22 17:01:46 slave22 sshd[3200]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:01:47 slave22 sshd[3196]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=223.99.60.46  user=root
+Feb 22 17:01:47 slave22 sshd[3196]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:01:47 slave22 sshd[3200]: Failed password for root from 116.31.116.27 port 36880 ssh2
+Feb 22 17:01:48 slave22 sshd[3200]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:01:49 slave22 sshd[3196]: Failed password for root from 223.99.60.46 port 55116 ssh2
+Feb 22 17:01:49 slave22 sshd[3200]: Failed password for root from 116.31.116.27 port 36880 ssh2
+Feb 22 17:01:49 slave22 sshd[3196]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:01:49 slave22 sshd[3200]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:01:49 slave22 sshd[3204]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 17:01:49 slave22 sshd[3204]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:01:51 slave22 sshd[3196]: Failed password for root from 223.99.60.46 port 55116 ssh2
+Feb 22 17:01:51 slave22 sshd[3200]: Failed password for root from 116.31.116.27 port 36880 ssh2
+Feb 22 17:01:51 slave22 sshd[3204]: Failed password for root from 202.109.143.106 port 3480 ssh2
+Feb 22 17:01:51 slave22 sshd[3204]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:01:52 slave22 sshd[3196]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:01:53 slave22 sshd[3204]: Failed password for root from 202.109.143.106 port 3480 ssh2
+Feb 22 17:01:53 slave22 sshd[3204]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:01:53 slave22 sshd[3200]: Received disconnect from 116.31.116.27: 11:  [preauth]
+Feb 22 17:01:53 slave22 sshd[3200]: PAM 2 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=116.31.116.27  user=root
+Feb 22 17:01:54 slave22 sshd[3196]: Failed password for root from 223.99.60.46 port 55116 ssh2
+Feb 22 17:01:55 slave22 sshd[3196]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:01:55 slave22 sshd[3204]: Failed password for root from 202.109.143.106 port 3480 ssh2
+Feb 22 17:01:56 slave22 sshd[3204]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:01:57 slave22 sshd[3196]: Failed password for root from 223.99.60.46 port 55116 ssh2
+Feb 22 17:01:57 slave22 sshd[3204]: Failed password for root from 202.109.143.106 port 3480 ssh2
+Feb 22 17:01:58 slave22 sshd[3204]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:01:58 slave22 sshd[3196]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:01:59 slave22 sshd[3204]: Failed password for root from 202.109.143.106 port 3480 ssh2
+Feb 22 17:02:00 slave22 sshd[3204]: fatal: Read from socket failed: Connection reset by peer [preauth]
+Feb 22 17:02:00 slave22 sshd[3204]: PAM 4 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 17:02:00 slave22 sshd[3204]: PAM service(sshd) ignoring max retries; 5 > 3
+Feb 22 17:02:00 slave22 sshd[3196]: Failed password for root from 223.99.60.46 port 55116 ssh2
+Feb 22 17:02:01 slave22 sshd[3196]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:02:03 slave22 sshd[3196]: Failed password for root from 223.99.60.46 port 55116 ssh2
+Feb 22 17:02:03 slave22 sshd[3196]: Disconnecting: Too many authentication failures for root [preauth]
+Feb 22 17:02:03 slave22 sshd[3196]: PAM 5 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=223.99.60.46  user=root
+Feb 22 17:02:03 slave22 sshd[3196]: PAM service(sshd) ignoring max retries; 6 > 3
+Feb 22 17:02:14 slave22 sshd[3216]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=223.99.60.46  user=root
+Feb 22 17:02:14 slave22 sshd[3216]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:02:16 slave22 sshd[3216]: Failed password for root from 223.99.60.46 port 22291 ssh2
+Feb 22 17:02:17 slave22 sshd[3216]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:02:18 slave22 sshd[3216]: Failed password for root from 223.99.60.46 port 22291 ssh2
+Feb 22 17:02:19 slave22 sshd[3216]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:02:21 slave22 sshd[3216]: Failed password for root from 223.99.60.46 port 22291 ssh2
+Feb 22 17:02:22 slave22 sshd[3216]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:02:24 slave22 sshd[3216]: Failed password for root from 223.99.60.46 port 22291 ssh2
+Feb 22 17:02:24 slave22 sshd[3216]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:02:26 slave22 sshd[3216]: Failed password for root from 223.99.60.46 port 22291 ssh2
+Feb 22 17:02:27 slave22 sshd[3216]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:02:27 slave22 sshd[3220]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 17:02:27 slave22 sshd[3220]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:02:29 slave22 sshd[3216]: Failed password for root from 223.99.60.46 port 22291 ssh2
+Feb 22 17:02:29 slave22 sshd[3216]: Disconnecting: Too many authentication failures for root [preauth]
+Feb 22 17:02:29 slave22 sshd[3216]: PAM 5 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=223.99.60.46  user=root
+Feb 22 17:02:29 slave22 sshd[3216]: PAM service(sshd) ignoring max retries; 6 > 3
+Feb 22 17:02:29 slave22 sshd[3220]: Failed password for root from 202.109.143.106 port 1203 ssh2
+Feb 22 17:02:29 slave22 sshd[3220]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:02:31 slave22 sshd[3220]: Failed password for root from 202.109.143.106 port 1203 ssh2
+Feb 22 17:02:31 slave22 sshd[3220]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:02:33 slave22 sshd[3220]: Failed password for root from 202.109.143.106 port 1203 ssh2
+Feb 22 17:02:33 slave22 sshd[3220]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:02:36 slave22 sshd[3220]: Failed password for root from 202.109.143.106 port 1203 ssh2
+Feb 22 17:02:36 slave22 sshd[3220]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:02:37 slave22 sshd[3220]: Failed password for root from 202.109.143.106 port 1203 ssh2
+Feb 22 17:02:38 slave22 sshd[3220]: fatal: Read from socket failed: Connection reset by peer [preauth]
+Feb 22 17:02:38 slave22 sshd[3220]: PAM 4 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 17:02:38 slave22 sshd[3220]: PAM service(sshd) ignoring max retries; 5 > 3
+Feb 22 17:02:38 slave22 sshd[3224]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=223.99.60.46  user=root
+Feb 22 17:02:38 slave22 sshd[3224]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:02:39 slave22 sshd[3232]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 17:02:39 slave22 sshd[3232]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:02:39 slave22 sshd[3228]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=116.31.116.27  user=root
+Feb 22 17:02:39 slave22 sshd[3228]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:02:39 slave22 sshd[3224]: Failed password for root from 223.99.60.46 port 46820 ssh2
+Feb 22 17:02:40 slave22 sshd[3224]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:02:42 slave22 sshd[3232]: Failed password for root from 202.109.143.106 port 1140 ssh2
+Feb 22 17:02:42 slave22 sshd[3232]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:02:42 slave22 sshd[3228]: Failed password for root from 116.31.116.27 port 30327 ssh2
+Feb 22 17:02:42 slave22 sshd[3224]: Failed password for root from 223.99.60.46 port 46820 ssh2
+Feb 22 17:02:42 slave22 sshd[3228]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:02:43 slave22 sshd[3224]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:02:43 slave22 sshd[3232]: Failed password for root from 202.109.143.106 port 1140 ssh2
+Feb 22 17:02:44 slave22 sshd[3232]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:02:44 slave22 sshd[3228]: Failed password for root from 116.31.116.27 port 30327 ssh2
+Feb 22 17:02:44 slave22 sshd[3228]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:02:44 slave22 sshd[3224]: Failed password for root from 223.99.60.46 port 46820 ssh2
+Feb 22 17:02:45 slave22 sshd[3224]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:02:46 slave22 sshd[3232]: Failed password for root from 202.109.143.106 port 1140 ssh2
+Feb 22 17:02:46 slave22 sshd[3232]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:02:46 slave22 sshd[3228]: Failed password for root from 116.31.116.27 port 30327 ssh2
+Feb 22 17:02:47 slave22 sshd[3228]: Received disconnect from 116.31.116.27: 11:  [preauth]
+Feb 22 17:02:47 slave22 sshd[3228]: PAM 2 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=116.31.116.27  user=root
+Feb 22 17:02:47 slave22 sshd[3224]: Failed password for root from 223.99.60.46 port 46820 ssh2
+Feb 22 17:02:48 slave22 sshd[3224]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:02:48 slave22 sshd[3232]: Failed password for root from 202.109.143.106 port 1140 ssh2
+Feb 22 17:02:49 slave22 sshd[3232]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:02:49 slave22 sshd[3224]: Failed password for root from 223.99.60.46 port 46820 ssh2
+Feb 22 17:02:50 slave22 sshd[3224]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:02:51 slave22 sshd[3232]: Failed password for root from 202.109.143.106 port 1140 ssh2
+Feb 22 17:02:51 slave22 sshd[3232]: fatal: Read from socket failed: Connection reset by peer [preauth]
+Feb 22 17:02:51 slave22 sshd[3232]: PAM 4 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 17:02:51 slave22 sshd[3232]: PAM service(sshd) ignoring max retries; 5 > 3
+Feb 22 17:02:52 slave22 sshd[3224]: Failed password for root from 223.99.60.46 port 46820 ssh2
+Feb 22 17:02:52 slave22 sshd[3224]: Disconnecting: Too many authentication failures for root [preauth]
+Feb 22 17:02:52 slave22 sshd[3224]: PAM 5 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=223.99.60.46  user=root
+Feb 22 17:02:52 slave22 sshd[3224]: PAM service(sshd) ignoring max retries; 6 > 3
+Feb 22 17:02:52 slave22 sshd[3244]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 17:02:52 slave22 sshd[3244]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:02:54 slave22 sshd[3244]: Failed password for root from 202.109.143.106 port 1140 ssh2
+Feb 22 17:02:54 slave22 sshd[3244]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:02:55 slave22 sshd[3248]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=223.99.60.46  user=root
+Feb 22 17:02:55 slave22 sshd[3248]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:02:56 slave22 sshd[3244]: Failed password for root from 202.109.143.106 port 1140 ssh2
+Feb 22 17:02:56 slave22 sshd[3244]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:02:57 slave22 sshd[3248]: Failed password for root from 223.99.60.46 port 1676 ssh2
+Feb 22 17:02:58 slave22 sshd[3244]: Failed password for root from 202.109.143.106 port 1140 ssh2
+Feb 22 17:02:59 slave22 sshd[3244]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:03:00 slave22 sshd[3244]: Failed password for root from 202.109.143.106 port 1140 ssh2
+Feb 22 17:03:00 slave22 sshd[3244]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:03:02 slave22 sshd[3244]: Failed password for root from 202.109.143.106 port 1140 ssh2
+Feb 22 17:03:02 slave22 sshd[3244]: fatal: Read from socket failed: Connection reset by peer [preauth]
+Feb 22 17:03:02 slave22 sshd[3244]: PAM 4 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 17:03:02 slave22 sshd[3244]: PAM service(sshd) ignoring max retries; 5 > 3
+Feb 22 17:03:07 slave22 sshd[3248]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:03:09 slave22 sshd[3248]: Failed password for root from 223.99.60.46 port 1676 ssh2
+Feb 22 17:03:10 slave22 sshd[3248]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:03:12 slave22 sshd[3248]: Failed password for root from 223.99.60.46 port 1676 ssh2
+Feb 22 17:03:12 slave22 sshd[3248]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:03:14 slave22 sshd[3248]: Failed password for root from 223.99.60.46 port 1676 ssh2
+Feb 22 17:03:15 slave22 sshd[3248]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:03:18 slave22 sshd[3248]: Failed password for root from 223.99.60.46 port 1676 ssh2
+Feb 22 17:03:18 slave22 sshd[3248]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:03:20 slave22 sshd[3252]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 17:03:20 slave22 sshd[3252]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:03:20 slave22 sshd[3248]: Failed password for root from 223.99.60.46 port 1676 ssh2
+Feb 22 17:03:20 slave22 sshd[3248]: Disconnecting: Too many authentication failures for root [preauth]
+Feb 22 17:03:20 slave22 sshd[3248]: PAM 5 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=223.99.60.46  user=root
+Feb 22 17:03:20 slave22 sshd[3248]: PAM service(sshd) ignoring max retries; 6 > 3
+Feb 22 17:03:21 slave22 sshd[3252]: Failed password for root from 202.109.143.106 port 4411 ssh2
+Feb 22 17:03:22 slave22 sshd[3252]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:03:22 slave22 sshd[3260]: Accepted publickey for tsg from 78.52.112.222 port 57936 ssh2: RSA 7c:28:53:4b:dd:5d:1e:07:77:0e:98:01:96:0d:c5:95
+Feb 22 17:03:22 slave22 sshd[3260]: pam_unix(sshd:session): session opened for user tsg by (uid=0)
+Feb 22 17:03:23 slave22 sshd[3252]: Failed password for root from 202.109.143.106 port 4411 ssh2
+Feb 22 17:03:24 slave22 sshd[3252]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:03:26 slave22 sshd[3252]: Failed password for root from 202.109.143.106 port 4411 ssh2
+Feb 22 17:03:26 slave22 sshd[3252]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:03:28 slave22 sshd[3252]: Failed password for root from 202.109.143.106 port 4411 ssh2
+Feb 22 17:03:28 slave22 sshd[3252]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:03:31 slave22 sshd[3252]: Failed password for root from 202.109.143.106 port 4411 ssh2
+Feb 22 17:03:31 slave22 sshd[3252]: fatal: Read from socket failed: Connection reset by peer [preauth]
+Feb 22 17:03:31 slave22 sshd[3252]: PAM 4 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 17:03:31 slave22 sshd[3252]: PAM service(sshd) ignoring max retries; 5 > 3
+Feb 22 17:03:33 slave22 sshd[3256]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=223.99.60.46  user=root
+Feb 22 17:03:33 slave22 sshd[3256]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:03:35 slave22 sshd[3256]: Failed password for root from 223.99.60.46 port 30094 ssh2
+Feb 22 17:03:35 slave22 sudo:     tsg : TTY=pts/0 ; PWD=/home/tsg ; USER=root ; COMMAND=/bin/cat /var/log/secure
+Feb 22 17:03:36 slave22 sshd[3256]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:03:37 slave22 sshd[3298]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=116.31.116.27  user=root
+Feb 22 17:03:37 slave22 sshd[3298]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:03:37 slave22 sshd[3256]: Failed password for root from 223.99.60.46 port 30094 ssh2
+Feb 22 17:03:38 slave22 sshd[3256]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:03:38 slave22 sshd[3298]: Failed password for root from 116.31.116.27 port 52640 ssh2
+Feb 22 17:03:39 slave22 sshd[3298]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:03:40 slave22 sshd[3256]: Failed password for root from 223.99.60.46 port 30094 ssh2
+Feb 22 17:03:41 slave22 sshd[3298]: Failed password for root from 116.31.116.27 port 52640 ssh2
+Feb 22 17:03:41 slave22 sshd[3256]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:03:41 slave22 sshd[3298]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:03:42 slave22 sshd[3256]: Failed password for root from 223.99.60.46 port 30094 ssh2
+Feb 22 17:03:42 slave22 sshd[3298]: Failed password for root from 116.31.116.27 port 52640 ssh2
+Feb 22 17:03:43 slave22 sshd[3256]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:03:43 slave22 sshd[3298]: Received disconnect from 116.31.116.27: 11:  [preauth]
+Feb 22 17:03:43 slave22 sshd[3298]: PAM 2 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=116.31.116.27  user=root
+Feb 22 17:03:45 slave22 sshd[3256]: Failed password for root from 223.99.60.46 port 30094 ssh2
+Feb 22 17:03:46 slave22 sshd[3256]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:03:48 slave22 sshd[3256]: Failed password for root from 223.99.60.46 port 30094 ssh2
+Feb 22 17:03:48 slave22 sshd[3256]: Disconnecting: Too many authentication failures for root [preauth]
+Feb 22 17:03:48 slave22 sshd[3256]: PAM 5 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=223.99.60.46  user=root
+Feb 22 17:03:48 slave22 sshd[3256]: PAM service(sshd) ignoring max retries; 6 > 3
+Feb 22 17:03:53 slave22 sshd[3317]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 17:03:53 slave22 sshd[3317]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:03:55 slave22 sshd[3317]: Failed password for root from 202.109.143.106 port 4037 ssh2
+Feb 22 17:03:55 slave22 sshd[3317]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:03:57 slave22 sshd[3317]: Failed password for root from 202.109.143.106 port 4037 ssh2
+Feb 22 17:03:57 slave22 sshd[3317]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:04:00 slave22 sshd[3317]: Failed password for root from 202.109.143.106 port 4037 ssh2
+Feb 22 17:04:00 slave22 sshd[3317]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:04:01 slave22 sshd[3317]: Failed password for root from 202.109.143.106 port 4037 ssh2
+Feb 22 17:04:02 slave22 sshd[3313]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=223.99.60.46  user=root
+Feb 22 17:04:02 slave22 sshd[3313]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:04:02 slave22 sshd[3317]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:04:04 slave22 sshd[3313]: Failed password for root from 223.99.60.46 port 57812 ssh2
+Feb 22 17:04:04 slave22 sshd[3317]: Failed password for root from 202.109.143.106 port 4037 ssh2
+Feb 22 17:04:04 slave22 sshd[3317]: fatal: Read from socket failed: Connection reset by peer [preauth]
+Feb 22 17:04:04 slave22 sshd[3317]: PAM 4 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 17:04:04 slave22 sshd[3317]: PAM service(sshd) ignoring max retries; 5 > 3
+Feb 22 17:04:04 slave22 sshd[3313]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:04:07 slave22 sshd[3313]: Failed password for root from 223.99.60.46 port 57812 ssh2
+Feb 22 17:04:08 slave22 sshd[3313]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:04:10 slave22 sshd[3313]: Failed password for root from 223.99.60.46 port 57812 ssh2
+Feb 22 17:04:10 slave22 sshd[3313]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:04:11 slave22 sshd[3321]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 17:04:11 slave22 sshd[3321]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:04:12 slave22 sshd[3321]: Failed password for root from 202.109.143.106 port 2592 ssh2
+Feb 22 17:04:12 slave22 sshd[3321]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:04:13 slave22 sshd[3313]: Failed password for root from 223.99.60.46 port 57812 ssh2
+Feb 22 17:04:13 slave22 sshd[3313]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:04:14 slave22 sshd[3321]: Failed password for root from 202.109.143.106 port 2592 ssh2
+Feb 22 17:04:14 slave22 sshd[3321]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:04:15 slave22 sshd[3313]: Failed password for root from 223.99.60.46 port 57812 ssh2
+Feb 22 17:04:16 slave22 sshd[3321]: Failed password for root from 202.109.143.106 port 2592 ssh2
+Feb 22 17:04:16 slave22 sshd[3313]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:04:16 slave22 sshd[3321]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:04:18 slave22 sshd[3313]: Failed password for root from 223.99.60.46 port 57812 ssh2
+Feb 22 17:04:18 slave22 sshd[3313]: Disconnecting: Too many authentication failures for root [preauth]
+Feb 22 17:04:18 slave22 sshd[3313]: PAM 5 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=223.99.60.46  user=root
+Feb 22 17:04:18 slave22 sshd[3313]: PAM service(sshd) ignoring max retries; 6 > 3
+Feb 22 17:04:19 slave22 sshd[3321]: Failed password for root from 202.109.143.106 port 2592 ssh2
+Feb 22 17:04:19 slave22 sshd[3321]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:04:21 slave22 sshd[3321]: Failed password for root from 202.109.143.106 port 2592 ssh2
+Feb 22 17:04:21 slave22 sshd[3321]: fatal: Read from socket failed: Connection reset by peer [preauth]
+Feb 22 17:04:21 slave22 sshd[3321]: PAM 4 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 17:04:21 slave22 sshd[3321]: PAM service(sshd) ignoring max retries; 5 > 3
+Feb 22 17:04:29 slave22 sshd[3325]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=223.99.60.46  user=root
+Feb 22 17:04:29 slave22 sshd[3325]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:04:30 slave22 sshd[3325]: Failed password for root from 223.99.60.46 port 33646 ssh2
+Feb 22 17:04:31 slave22 sshd[3325]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:04:33 slave22 sshd[3325]: Failed password for root from 223.99.60.46 port 33646 ssh2
+Feb 22 17:04:34 slave22 sshd[3325]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:04:35 slave22 sshd[3333]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=116.31.116.27  user=root
+Feb 22 17:04:35 slave22 sshd[3333]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:04:35 slave22 sshd[3329]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 17:04:35 slave22 sshd[3329]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:04:36 slave22 sshd[3325]: Failed password for root from 223.99.60.46 port 33646 ssh2
+Feb 22 17:04:36 slave22 sshd[3333]: Failed password for root from 116.31.116.27 port 37886 ssh2
+Feb 22 17:04:36 slave22 sshd[3329]: Failed password for root from 202.109.143.106 port 3203 ssh2
+Feb 22 17:04:37 slave22 sshd[3333]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:04:37 slave22 sshd[3329]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:04:37 slave22 sshd[3325]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:04:39 slave22 sshd[3333]: Failed password for root from 116.31.116.27 port 37886 ssh2
+Feb 22 17:04:39 slave22 sshd[3329]: Failed password for root from 202.109.143.106 port 3203 ssh2
+Feb 22 17:04:39 slave22 sshd[3325]: Failed password for root from 223.99.60.46 port 33646 ssh2
+Feb 22 17:04:39 slave22 sshd[3333]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:04:39 slave22 sshd[3325]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:04:40 slave22 sshd[3329]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:04:41 slave22 sshd[3333]: Failed password for root from 116.31.116.27 port 37886 ssh2
+Feb 22 17:04:42 slave22 sshd[3325]: Failed password for root from 223.99.60.46 port 33646 ssh2
+Feb 22 17:04:42 slave22 sshd[3333]: Received disconnect from 116.31.116.27: 11:  [preauth]
+Feb 22 17:04:42 slave22 sshd[3333]: PAM 2 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=116.31.116.27  user=root
+Feb 22 17:04:42 slave22 sshd[3325]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:04:42 slave22 sshd[3329]: Failed password for root from 202.109.143.106 port 3203 ssh2
+Feb 22 17:04:44 slave22 sshd[3325]: Failed password for root from 223.99.60.46 port 33646 ssh2
+Feb 22 17:04:44 slave22 sshd[3325]: Disconnecting: Too many authentication failures for root [preauth]
+Feb 22 17:04:44 slave22 sshd[3325]: PAM 5 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=223.99.60.46  user=root
+Feb 22 17:04:44 slave22 sshd[3325]: PAM service(sshd) ignoring max retries; 6 > 3
+Feb 22 17:04:44 slave22 sshd[3329]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:04:46 slave22 sshd[3329]: Failed password for root from 202.109.143.106 port 3203 ssh2
+Feb 22 17:04:47 slave22 sshd[3329]: pam_succeed_if(sshd:auth): requirement "uid >= 1000" not met by user "root"
+Feb 22 17:04:48 slave22 sshd[3329]: Failed password for root from 202.109.143.106 port 3203 ssh2
+Feb 22 17:04:49 slave22 sshd[3329]: fatal: Read from socket failed: Connection reset by peer [preauth]
+Feb 22 17:04:49 slave22 sshd[3329]: PAM 4 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=202.109.143.106  user=root
+Feb 22 17:04:49 slave22 sshd[3329]: PAM service(sshd) ignoring max retries; 5 > 3
+Feb 22 17:04:51 slave22 sudo:     tsg : TTY=pts/0 ; PWD=/home/tsg ; USER=root ; COMMAND=/bin/cp /var/log/secure .

--- a/filebeat/module/system/auth/test/test.log
+++ b/filebeat/module/system/auth/test/test.log
@@ -1,0 +1,10 @@
+Feb 21 21:54:44 localhost sshd[3402]: Accepted publickey for vagrant from 10.0.2.2 port 63673 ssh2: RSA 39:33:99:e9:a0:dc:f2:33:a3:e5:72:3b:7c:3a:56:84
+Feb 23 00:13:35 localhost sshd[7483]: Accepted password for vagrant from 192.168.33.1 port 58803 ssh2
+Feb 21 21:56:12 localhost sshd[3430]: Invalid user test from 10.0.2.2
+Feb 20 08:35:22 slave22 sshd[5774]: Failed password for root from 116.31.116.24 port 29160 ssh2
+Feb 21 23:35:33 localhost sudo: vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/ls
+Feb 19 15:30:04 slave22 sshd[18406]: Did not receive identification string from 123.57.245.163
+Feb 23 00:08:48 localhost sudo: vagrant : TTY=pts/1 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/cat /var/log/secure
+Feb 24 00:13:02 precise32 sudo:      tsg : user NOT in sudoers ; TTY=pts/1 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/ls
+Feb 22 11:47:05 localhost groupadd[6991]: new group: name=apache, GID=48
+Feb 22 11:47:05 localhost useradd[6995]: new user: name=apache, UID=48, GID=48, home=/usr/share/httpd, shell=/sbin/nologin

--- a/filebeat/module/system/auth/test/test.log-expected.json
+++ b/filebeat/module/system/auth/test/test.log-expected.json
@@ -1,0 +1,362 @@
+[
+  {
+    "_index" : "test-filebeat-modules",
+    "_type" : "log",
+    "_id" : "AVpwYhxbd3MQAzSWoGjF",
+    "_score" : 1.0,
+    "_source" : {
+      "@timestamp" : "2017-02-23T00:13:35.000Z",
+      "system" : {
+        "auth" : {
+          "hostname" : "localhost",
+          "ssh" : {
+            "method" : "password",
+            "port" : "58803",
+            "ip" : "192.168.33.1",
+            "event" : "Accepted"
+          },
+          "pid" : "7483",
+          "user" : "vagrant",
+          "timestamp" : "Feb 23 00:13:35"
+        }
+      },
+      "offset" : 254,
+      "beat" : {
+        "hostname" : "a-mac-with-esc-key.local",
+        "name" : "a-mac-with-esc-key.local",
+        "version" : "6.0.0-alpha1"
+      },
+      "input_type" : "log",
+      "source" : "/Users/tsg/src/github.com/elastic/beats/filebeat/module/system/auth/test/test.log",
+      "fileset" : {
+        "module" : "system",
+        "name" : "auth"
+      },
+      "type" : "log"
+    }
+  },
+  {
+    "_index" : "test-filebeat-modules",
+    "_type" : "log",
+    "_id" : "AVpwYhxbd3MQAzSWoGjK",
+    "_score" : 1.0,
+    "_source" : {
+      "@timestamp" : "2017-02-23T00:08:48.000Z",
+      "system" : {
+        "auth" : {
+          "hostname" : "localhost",
+          "sudo" : {
+            "tty" : "pts/1",
+            "pwd" : "/home/vagrant",
+            "user" : "root",
+            "command" : "/bin/cat /var/log/secure"
+          },
+          "user" : "vagrant",
+          "timestamp" : "Feb 23 00:08:48"
+        }
+      },
+      "offset" : 736,
+      "beat" : {
+        "hostname" : "a-mac-with-esc-key.local",
+        "name" : "a-mac-with-esc-key.local",
+        "version" : "6.0.0-alpha1"
+      },
+      "input_type" : "log",
+      "source" : "/Users/tsg/src/github.com/elastic/beats/filebeat/module/system/auth/test/test.log",
+      "fileset" : {
+        "module" : "system",
+        "name" : "auth"
+      },
+      "type" : "log"
+    }
+  },
+  {
+    "_index" : "test-filebeat-modules",
+    "_type" : "log",
+    "_id" : "AVpwYhxbd3MQAzSWoGjG",
+    "_score" : 1.0,
+    "_source" : {
+      "@timestamp" : "2017-02-21T21:56:12.000Z",
+      "system" : {
+        "auth" : {
+          "hostname" : "localhost",
+          "ssh" : {
+            "ip" : "10.0.2.2",
+            "event" : "Invalid"
+          },
+          "pid" : "3430",
+          "user" : "test",
+          "timestamp" : "Feb 21 21:56:12"
+        }
+      },
+      "offset" : 324,
+      "beat" : {
+        "hostname" : "a-mac-with-esc-key.local",
+        "name" : "a-mac-with-esc-key.local",
+        "version" : "6.0.0-alpha1"
+      },
+      "input_type" : "log",
+      "source" : "/Users/tsg/src/github.com/elastic/beats/filebeat/module/system/auth/test/test.log",
+      "fileset" : {
+        "module" : "system",
+        "name" : "auth"
+      },
+      "type" : "log"
+    }
+  },
+  {
+    "_index" : "test-filebeat-modules",
+    "_type" : "log",
+    "_id" : "AVpwYhxbd3MQAzSWoGjJ",
+    "_score" : 1.0,
+    "_source" : {
+      "@timestamp" : "2017-02-19T15:30:04.000Z",
+      "system" : {
+        "auth" : {
+          "hostname" : "slave22",
+          "ssh" : {
+            "dropped_ip" : "123.57.245.163"
+          },
+          "pid" : "18406",
+          "timestamp" : "Feb 19 15:30:04"
+        }
+      },
+      "offset" : 617,
+      "beat" : {
+        "hostname" : "a-mac-with-esc-key.local",
+        "name" : "a-mac-with-esc-key.local",
+        "version" : "6.0.0-alpha1"
+      },
+      "input_type" : "log",
+      "source" : "/Users/tsg/src/github.com/elastic/beats/filebeat/module/system/auth/test/test.log",
+      "fileset" : {
+        "module" : "system",
+        "name" : "auth"
+      },
+      "type" : "log"
+    }
+  },
+  {
+    "_index" : "test-filebeat-modules",
+    "_type" : "log",
+    "_id" : "AVpwYhxbd3MQAzSWoGjL",
+    "_score" : 1.0,
+    "_source" : {
+      "@timestamp" : "2017-02-24T00:13:02.000Z",
+      "system" : {
+        "auth" : {
+          "hostname" : "precise32",
+          "sudo" : {
+            "tty" : "pts/1",
+            "pwd" : "/home/vagrant",
+            "error" : "user NOT in sudoers",
+            "user" : "root",
+            "command" : "/bin/ls"
+          },
+          "user" : "tsg",
+          "timestamp" : "Feb 24 00:13:02"
+        }
+      },
+      "offset" : 861,
+      "beat" : {
+        "hostname" : "a-mac-with-esc-key.local",
+        "name" : "a-mac-with-esc-key.local",
+        "version" : "6.0.0-alpha1"
+      },
+      "input_type" : "log",
+      "source" : "/Users/tsg/src/github.com/elastic/beats/filebeat/module/system/auth/test/test.log",
+      "fileset" : {
+        "module" : "system",
+        "name" : "auth"
+      },
+      "type" : "log"
+    }
+  },
+  {
+    "_index" : "test-filebeat-modules",
+    "_type" : "log",
+    "_id" : "AVpwYhxbd3MQAzSWoGjM",
+    "_score" : 1.0,
+    "_source" : {
+      "@timestamp" : "2017-02-22T11:47:05.000Z",
+      "system" : {
+        "auth" : {
+          "hostname" : "localhost",
+          "pid" : "6991",
+          "groupadd" : {
+            "gid" : "48",
+            "name" : "apache"
+          },
+          "timestamp" : "Feb 22 11:47:05"
+        }
+      },
+      "offset" : 934,
+      "beat" : {
+        "hostname" : "a-mac-with-esc-key.local",
+        "name" : "a-mac-with-esc-key.local",
+        "version" : "6.0.0-alpha1"
+      },
+      "input_type" : "log",
+      "source" : "/Users/tsg/src/github.com/elastic/beats/filebeat/module/system/auth/test/test.log",
+      "fileset" : {
+        "module" : "system",
+        "name" : "auth"
+      },
+      "type" : "log"
+    }
+  },
+  {
+    "_index" : "test-filebeat-modules",
+    "_type" : "log",
+    "_id" : "AVpwYhxbd3MQAzSWoGjN",
+    "_score" : 1.0,
+    "_source" : {
+      "@timestamp" : "2017-02-22T11:47:05.000Z",
+      "system" : {
+        "auth" : {
+          "hostname" : "localhost",
+          "pid" : "6995",
+          "useradd" : {
+            "uid" : "48",
+            "gid" : "48",
+            "shell" : "/sbin/nologin",
+            "name" : "apache",
+            "home" : "/usr/share/httpd"
+          },
+          "timestamp" : "Feb 22 11:47:05"
+        }
+      },
+      "offset" : 1057,
+      "beat" : {
+        "hostname" : "a-mac-with-esc-key.local",
+        "name" : "a-mac-with-esc-key.local",
+        "version" : "6.0.0-alpha1"
+      },
+      "input_type" : "log",
+      "source" : "/Users/tsg/src/github.com/elastic/beats/filebeat/module/system/auth/test/test.log",
+      "fileset" : {
+        "module" : "system",
+        "name" : "auth"
+      },
+      "type" : "log"
+    }
+  },
+  {
+    "_index" : "test-filebeat-modules",
+    "_type" : "log",
+    "_id" : "AVpwYhxbd3MQAzSWoGjE",
+    "_score" : 1.0,
+    "_source" : {
+      "@timestamp" : "2017-02-21T21:54:44.000Z",
+      "system" : {
+        "auth" : {
+          "hostname" : "localhost",
+          "ssh" : {
+            "method" : "publickey",
+            "signature" : "RSA 39:33:99:e9:a0:dc:f2:33:a3:e5:72:3b:7c:3a:56:84",
+            "port" : "63673",
+            "ip" : "10.0.2.2",
+            "event" : "Accepted"
+          },
+          "pid" : "3402",
+          "user" : "vagrant",
+          "timestamp" : "Feb 21 21:54:44"
+        }
+      },
+      "offset" : 152,
+      "beat" : {
+        "hostname" : "a-mac-with-esc-key.local",
+        "name" : "a-mac-with-esc-key.local",
+        "version" : "6.0.0-alpha1"
+      },
+      "input_type" : "log",
+      "source" : "/Users/tsg/src/github.com/elastic/beats/filebeat/module/system/auth/test/test.log",
+      "fileset" : {
+        "module" : "system",
+        "name" : "auth"
+      },
+      "type" : "log"
+    }
+  },
+  {
+    "_index" : "test-filebeat-modules",
+    "_type" : "log",
+    "_id" : "AVpwYhxbd3MQAzSWoGjH",
+    "_score" : 1.0,
+    "_source" : {
+      "@timestamp" : "2017-02-20T08:35:22.000Z",
+      "system" : {
+        "auth" : {
+          "hostname" : "slave22",
+          "ssh" : {
+            "geoip" : {
+              "continent_name" : "Asia",
+              "city_name" : "Guangzhou",
+              "country_iso_code" : "CN",
+              "region_name" : "Guangdong",
+              "location" : {
+                "lon" : 113.25,
+                "lat" : 23.1167
+              }
+            },
+            "method" : "password",
+            "port" : "29160",
+            "ip" : "116.31.116.24",
+            "event" : "Failed"
+          },
+          "pid" : "5774",
+          "user" : "root",
+          "timestamp" : "Feb 20 08:35:22"
+        }
+      },
+      "offset" : 420,
+      "beat" : {
+        "hostname" : "a-mac-with-esc-key.local",
+        "name" : "a-mac-with-esc-key.local",
+        "version" : "6.0.0-alpha1"
+      },
+      "input_type" : "log",
+      "source" : "/Users/tsg/src/github.com/elastic/beats/filebeat/module/system/auth/test/test.log",
+      "fileset" : {
+        "module" : "system",
+        "name" : "auth"
+      },
+      "type" : "log"
+    }
+  },
+  {
+    "_index" : "test-filebeat-modules",
+    "_type" : "log",
+    "_id" : "AVpwYhxbd3MQAzSWoGjI",
+    "_score" : 1.0,
+    "_source" : {
+      "@timestamp" : "2017-02-21T23:35:33.000Z",
+      "system" : {
+        "auth" : {
+          "hostname" : "localhost",
+          "sudo" : {
+            "tty" : "pts/0",
+            "pwd" : "/home/vagrant",
+            "user" : "root",
+            "command" : "/bin/ls"
+          },
+          "user" : "vagrant",
+          "timestamp" : "Feb 21 23:35:33"
+        }
+      },
+      "offset" : 522,
+      "beat" : {
+        "hostname" : "a-mac-with-esc-key.local",
+        "name" : "a-mac-with-esc-key.local",
+        "version" : "6.0.0-alpha1"
+      },
+      "input_type" : "log",
+      "source" : "/Users/tsg/src/github.com/elastic/beats/filebeat/module/system/auth/test/test.log",
+      "fileset" : {
+        "module" : "system",
+        "name" : "auth"
+      },
+      "type" : "log"
+    }
+  }
+]


### PR DESCRIPTION
Cherry-pick of PR #3669 to 5.x branch. Original message: 

This adds a new fileset under the system module: system/auth. It parses
the authorization logs (typically `/var/log/auth.log` or `/var/log/secure`) and
creates events for things like:

* SSH login attempts
* Commands executed with SUDO
* New users or groups created

The fileset includes several dashboards for visualizing this data. The dashboards are in a separate commit.