### PR TITLE
Simplify template generation and handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /*/data
 /*/logs
 /*/_meta/kibana/index-pattern
+/*/fields.yml
 
 # Files
 .DS_Store

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -247,17 +247,17 @@ update: python-env collect
 	# Generate full fields for each beat. Create fields.generated.yml in case it does not exist yet.
 	# Most beats have their own way of generating it.
 	test -s  _meta/fields.generated.yml || cp _meta/fields.yml _meta/fields.generated.yml
-	cat ${ES_BEATS}/libbeat/_meta/fields.generated.yml _meta/fields.generated.yml > _meta/fields.full.generated.yml
+	cat ${ES_BEATS}/libbeat/_meta/fields.generated.yml _meta/fields.generated.yml > fields.yml
 	# Revert changes to libbeat fields as it otherwise contains duplicates in full
-	cat ${ES_BEATS}/libbeat/_meta/fields.generated.yml > ${ES_BEATS}/libbeat/_meta/fields.full.generated.yml
+	cat ${ES_BEATS}/libbeat/_meta/fields.generated.yml > ${ES_BEATS}/libbeat/fields.yml
 
 	# Update docs
 	mkdir -p docs
 	. ${PYTHON_ENV}/bin/activate && python ${ES_BEATS}/libbeat/scripts/generate_fields_docs.py $(PWD) ${BEAT_NAME} ${ES_BEATS}
 
 	# Generate index templates
-	go run ${ES_BEATS}/dev-tools/cmd/index_template/index_template.go -beat.name ${BEAT_NAME} -output ${BEAT_GOPATH}/src/${BEAT_PATH}/${BEAT_NAME}.template.json ${BEAT_GOPATH}/src/${BEAT_PATH}/_meta/fields.full.generated.yml
-	go run ${ES_BEATS}/dev-tools/cmd/index_template/index_template.go -es.version 2.0.0 -beat.name ${BEAT_NAME} -output ${BEAT_GOPATH}/src/${BEAT_PATH}/${BEAT_NAME}.template-es2x.json ${BEAT_GOPATH}/src/${BEAT_PATH}/_meta/fields.full.generated.yml
+	go run ${ES_BEATS}/dev-tools/cmd/index_template/index_template.go -index ${BEAT_NAME} -output ${BEAT_GOPATH}/src/${BEAT_PATH}/${BEAT_NAME}.template.json -file ${BEAT_GOPATH}/src/${BEAT_PATH}/fields.yml
+	go run ${ES_BEATS}/dev-tools/cmd/index_template/index_template.go -es.version 2.0.0 -index ${BEAT_NAME} -output ${BEAT_GOPATH}/src/${BEAT_PATH}/${BEAT_NAME}.template-es2x.json -file ${BEAT_GOPATH}/src/${BEAT_PATH}/fields.yml
 
 	# Generate index-pattern
 	echo "Generate index pattern"

--- a/libbeat/scripts/generate_fields_docs.py
+++ b/libbeat/scripts/generate_fields_docs.py
@@ -111,7 +111,7 @@ if __name__ == "__main__":
     beat_name = args.beatname
     es_beats = args.es_beats
 
-    fields_yml = beat_path + "/_meta/fields.full.generated.yml"
+    fields_yml = beat_path + "/fields.yml"
 
     # Read fields.yml
     with open(fields_yml) as f:

--- a/libbeat/scripts/generate_index_pattern.py
+++ b/libbeat/scripts/generate_index_pattern.py
@@ -139,7 +139,7 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    fields_yml = args.beat + "/_meta/fields.full.generated.yml"
+    fields_yml = args.beat + "/fields.yml"
 
     # generate the index-pattern content
     with open(fields_yml, 'r') as f:


### PR DESCRIPTION
* Only one file is passed instead of an array as now only file is needed. Introduce `-file` param.
* Local loading of beats version was removed as it can lean to cyclic imports
* Move `_meta/fields.full.generated.yml` to `fields.yml` in preparation for packaging `fields.yml` and ignore it in git
* Cleanup Template generation package
* Rename -beat.name param to -index as this describes it better

Part of https://github.com/elastic/beats/issues/3654