### PR TITLE
Cherry-pick to 5.3: Fix empty registry file on machine crash

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -41,6 +41,7 @@ https://github.com/elastic/beats/compare/v5.1.1...master[Check the HEAD diff]
 
 *Filebeat*
 - Always use absolute path for event and registry. {pull}3328[3328]
+- Fix empty registry file on machine crash. {issue}3537[3537]
 
 *Heartbeat*
 

--- a/filebeat/registrar/registrar.go
+++ b/filebeat/registrar/registrar.go
@@ -298,7 +298,7 @@ func (r *Registrar) writeRegistry() error {
 	logp.Debug("registrar", "Write registry file: %s", r.registryFile)
 
 	tempfile := r.registryFile + ".new"
-	f, err := os.OpenFile(tempfile, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
+	f, err := os.OpenFile(tempfile, os.O_RDWR|os.O_CREATE|os.O_TRUNC|os.O_SYNC, 0600)
 	if err != nil {
 		logp.Err("Failed to create tempfile (%s) for writing: %s", tempfile, err)
 		return err

--- a/winlogbeat/checkpoint/file_unix.go
+++ b/winlogbeat/checkpoint/file_unix.go
@@ -5,5 +5,5 @@ package checkpoint
 import "os"
 
 func create(path string) (*os.File, error) {
-	return os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
+	return os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC|os.O_SYNC, 0600)
 }


### PR DESCRIPTION
Cherry-pick of PR #3668 to 5.3 branch. Original message: 

Closes https://github.com/elastic/beats/issues/3537