### PR TITLE
Bump docs version to 5.2.2

### DIFF
--- a/libbeat/docs/version.asciidoc
+++ b/libbeat/docs/version.asciidoc
@@ -1,3 +1,3 @@
-:stack-version: 5.2.1
+:stack-version: 5.2.2
 :doc-branch: 5.2
 :go-version: 1.7.4


### PR DESCRIPTION
This should be merged shortly before the release.