### PR TITLE
Cherry-pick to 5.3: Exempt root owned config files from ownership checker

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -15,7 +15,8 @@ https://github.com/elastic/beats/compare/v5.1.1...master[Check the HEAD diff]
 *Affecting all Beats*
 
 - Change beat generator. Use `$GOPATH/src/github.com/elastic/beats/script/generate.py` to generate a beat. {pull}3452[3452]
-- Configuration files must not be writable by other users. {pull}3544[3544]
+- Configuration files must be owned by the user running the beat or by root, and
+  they must not be writable by others. {pull}3544[3544] {pull}3689[3689]
 
 *Filebeat*
 - Always use absolute path for event and registry. This can lead to issues when relative paths were used before. {pull}3328[3328]


### PR DESCRIPTION
Cherry-pick of PR #3689 to 5.3 branch. Original message: 

If a config file is owned by root, but the process is running as a non-privileged user the Beat should run. This change exempts root from the ownership test. This makes it possible to drop privileges before executing the beat.