### PR TITLE
Cherry-pick to 5.3: Handle missing cgroups in Metricbeat

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -50,6 +50,7 @@ https://github.com/elastic/beats/compare/v5.1.1...master[Check the HEAD diff]
 - Fix go routine leak in docker module. {pull}3492[3492]
 - Fix bug docker module hanging when docker container killed. {issue}3610[3610]
 - Set timeout to period instead of 1s by default as documented.
+- Add error handling to system process metricset for when Linux cgroups are missing from the kernel. {pull}3692[3692]
 
 *Packetbeat*
 

--- a/glide.yaml
+++ b/glide.yaml
@@ -25,7 +25,7 @@ import:
   subpackages:
   - /difflib
 - package: github.com/elastic/gosigar
-  version: b49e01eb1e5c68c469392a63feaccae9352ceb12
+  version: v0.2.0
 - package: github.com/elastic/procfs
   version: abf152e5f3e97f2fafac028d2cc06c1feb87ffa5
 - package: github.com/samuel/go-parser

--- a/metricbeat/module/system/process/process.go
+++ b/metricbeat/module/system/process/process.go
@@ -63,10 +63,14 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 		}
 
 		if config.Cgroups == nil || *config.Cgroups {
-			debugf("process cgroup data collection is enabled")
+			debugf("process cgroup data collection is enabled, using hostfs='%v'", systemModule.HostFS)
 			m.cgroup, err = cgroup.NewReader(systemModule.HostFS, true)
 			if err != nil {
-				return nil, errors.Wrap(err, "error initializing cgroup reader")
+				if err == cgroup.ErrCgroupsMissing {
+					logp.Warn("cgroup data collection will be disabled: %v", err)
+				} else {
+					return nil, errors.Wrap(err, "error initializing cgroup reader")
+				}
 			}
 		}
 	}

--- a/vendor/github.com/elastic/gosigar/CHANGELOG.md
+++ b/vendor/github.com/elastic/gosigar/CHANGELOG.md
@@ -5,6 +5,26 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+## [0.2.0]
+
+### Added
+- Added `ErrCgroupsMissing` to indicate that /proc/cgroups is missing which is
+  an indicator that cgroups were disabled at compile time. #64
+
+### Changed
+- Changed `cgroup.SupportedSubsystems()` to honor the "enabled" column in the
+  /proc/cgroups file. #64
+
+## [0.1.0]
+
+### Added
 - Added `CpuList` implementation for Windows that returns CPU timing information
   on a per CPU basis. #55
 - Added `Uptime` implementation for Windows. #55
@@ -21,10 +41,6 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added OS version checks to `ProcArgs.Get` on Windows because the
   `Win32_Process` WMI query is not available prior to Windows vista. On XP and
   Windows 2003, this method returns `ErrNotImplemented`. #55
-
-### Deprecated
-
-### Removed
 
 ### Fixed
 - Fixed value of `Mem.ActualFree` and `Mem.ActualUsed` on Windows. #49


### PR DESCRIPTION
Cherry-pick of PR #3692 to 5.3 branch. Original message: 

Add error handling to system process metricset for when Linux cgroups are missing from the kernel.

Adds fix from elastic/gosigar#64.
Fixes elastic/beats#3666.