### PR TITLE
Fix expvar metricset doc

### DIFF
--- a/metricbeat/module/golang/expvar/_meta/docs.asciidoc
+++ b/metricbeat/module/golang/expvar/_meta/docs.asciidoc
@@ -1,5 +1,4 @@
 === golang expvar MetricSet
 
 This is the expvar metricset of the module golang.
-Golang can exposes it's variables by expvar api, with this metricset, user can collect these metrics,
-collect all the expvar exposed variables except memstats(if you need memstats, check out another `heap` metricset in this module.
+Golang can exposes it's variables by expvar api, with this metricset, user can collect all the expvar exposed variables.


### PR DESCRIPTION
Currently the heapinfo was not excluded from expvar metricset, user have to filter it by themself.
this pr is fix the doc which is not updated.