### PR TITLE
Fix composite literal uses unkeyed fields error in check

### DIFF
--- a/filebeat/harvester/log.go
+++ b/filebeat/harvester/log.go
@@ -226,7 +226,7 @@ func (h *Harvester) openFile() error {
 		return err
 	}
 
-	h.file = source.File{f}
+	h.file = source.File{File: f}
 	return nil
 }
 

--- a/filebeat/harvester/log_test.go
+++ b/filebeat/harvester/log_test.go
@@ -56,7 +56,7 @@ func TestReadLine(t *testing.T) {
 	defer readFile.Close()
 	assert.Nil(t, err)
 
-	f := source.File{readFile}
+	f := source.File{File: readFile}
 
 	h := Harvester{
 		config: harvesterConfig{

--- a/filebeat/harvester/stdin.go
+++ b/filebeat/harvester/stdin.go
@@ -9,7 +9,7 @@ import (
 // Stdin reads all incoming traffic from stdin and sends it directly to the output
 
 func (h *Harvester) openStdin() error {
-	h.file = source.Pipe{os.Stdin}
+	h.file = source.Pipe{File: os.Stdin}
 
 	var err error
 	h.encoding, err = h.encodingFactory(h.file)

--- a/libbeat/outputs/kafka/partition_test.go
+++ b/libbeat/outputs/kafka/partition_test.go
@@ -220,7 +220,7 @@ func partTestSimple(N int, makeKey bool) partTestScenario {
 			}
 
 			msg := &message{partition: -1}
-			msg.data = outputs.Data{event, nil}
+			msg.data = outputs.Data{Event: event, Values: nil}
 			msg.topic = "test"
 			if makeKey {
 				msg.key = randASCIIBytes(10)
@@ -273,7 +273,7 @@ func partTestHashInvariant(N int) partTestScenario {
 			}
 
 			msg := &message{partition: -1}
-			msg.data = outputs.Data{event, nil}
+			msg.data = outputs.Data{Event: event, Values: nil}
 			msg.topic = "test"
 			msg.key = randASCIIBytes(10)
 			msg.value = jsonEvent

--- a/libbeat/outputs/mode/modetest/modetest.go
+++ b/libbeat/outputs/mode/modetest/modetest.go
@@ -171,7 +171,7 @@ func doPublishWith(
 
 	var expectedData [][]outputs.Data
 	ch := make(chan op.SignalResponse, numSignals)
-	signal := &op.SignalChannel{ch}
+	signal := &op.SignalChannel{C: ch}
 	idx := 0
 	for _, pubEvents := range data {
 		if pubEvents.Single {

--- a/metricbeat/module/mongodb/status/status.go
+++ b/metricbeat/module/mongodb/status/status.go
@@ -60,7 +60,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // descriptive error must be returned.
 func (m *MetricSet) Fetch() (common.MapStr, error) {
 	result := map[string]interface{}{}
-	if err := m.mongoSession.DB("admin").Run(bson.D{{"serverStatus", 1}}, &result); err != nil {
+	if err := m.mongoSession.DB("admin").Run(bson.D{{Name: "serverStatus", Value: 1}}, &result); err != nil {
 		return nil, err
 	}
 

--- a/packetbeat/protos/amqp/amqp_test.go
+++ b/packetbeat/protos/amqp/amqp_test.go
@@ -14,7 +14,7 @@ import (
 
 func amqpModForTests() *amqpPlugin {
 	var amqp amqpPlugin
-	results := &publish.ChanTransactions{make(chan common.MapStr, 10)}
+	results := &publish.ChanTransactions{Channel: make(chan common.MapStr, 10)}
 	config := defaultConfig
 	amqp.init(results, &config)
 	return &amqp

--- a/packetbeat/protos/dns/dns_test.go
+++ b/packetbeat/protos/dns/dns_test.go
@@ -63,7 +63,7 @@ func newDNS(verbose bool) *dnsPlugin {
 		logp.LogInit(logp.LOG_EMERG, "", false, true, []string{"dns"})
 	}
 
-	results := &publish.ChanTransactions{make(chan common.MapStr, 100)}
+	results := &publish.ChanTransactions{Channel: make(chan common.MapStr, 100)}
 	cfg, _ := common.NewConfigFrom(map[string]interface{}{
 		"ports":               []int{serverPort},
 		"include_authorities": true,

--- a/packetbeat/protos/icmp/icmp_test.go
+++ b/packetbeat/protos/icmp/icmp_test.go
@@ -45,7 +45,7 @@ func BenchmarkIcmpProcessICMPv4(b *testing.B) {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"icmp", "icmpdetailed"})
 	}
 
-	results := &publish.ChanTransactions{make(chan common.MapStr, 10)}
+	results := &publish.ChanTransactions{Channel: make(chan common.MapStr, 10)}
 	icmp, err := New(true, results, common.NewConfig())
 	if err != nil {
 		b.Error("Failed to create ICMP processor")

--- a/packetbeat/protos/mongodb/mongodb_test.go
+++ b/packetbeat/protos/mongodb/mongodb_test.go
@@ -18,7 +18,7 @@ import (
 // in tests. It publishes the transactions in the results channel.
 func mongodbModForTests() *mongodbPlugin {
 	var mongodb mongodbPlugin
-	results := &publish.ChanTransactions{make(chan common.MapStr, 10)}
+	results := &publish.ChanTransactions{Channel: make(chan common.MapStr, 10)}
 	config := defaultConfig
 	mongodb.init(results, &config)
 	return &mongodb

--- a/packetbeat/protos/mysql/mysql_test.go
+++ b/packetbeat/protos/mysql/mysql_test.go
@@ -19,7 +19,7 @@ import (
 
 func mysqlModForTests() *mysqlPlugin {
 	var mysql mysqlPlugin
-	results := &publish.ChanTransactions{make(chan common.MapStr, 10)}
+	results := &publish.ChanTransactions{Channel: make(chan common.MapStr, 10)}
 	config := defaultConfig
 	mysql.init(results, &config)
 	return &mysql

--- a/packetbeat/protos/pgsql/pgsql_test.go
+++ b/packetbeat/protos/pgsql/pgsql_test.go
@@ -18,7 +18,7 @@ import (
 
 func pgsqlModForTests() *pgsqlPlugin {
 	var pgsql pgsqlPlugin
-	results := &publish.ChanTransactions{make(chan common.MapStr, 10)}
+	results := &publish.ChanTransactions{Channel: make(chan common.MapStr, 10)}
 	config := defaultConfig
 	pgsql.init(results, &config)
 	return &pgsql


### PR DESCRIPTION
`go vet` has become stricter under golang 1.8