### PR TITLE
Fix handling of empty strings in UTF16BytesToString.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -60,6 +60,7 @@ https://github.com/elastic/beats/compare/v5.1.1...master[Check the HEAD diff]
 
 *Winlogbeat*
 
+- Fix handling of empty strings in event_data. {pull}3705[3705]
 
 ==== Added
 

--- a/winlogbeat/sys/strings.go
+++ b/winlogbeat/sys/strings.go
@@ -76,7 +76,7 @@ func UTF16BytesToString(b []byte) (string, int, error) {
 	offset := -1
 
 	// Find the null terminator if it exists and re-slice the b.
-	if nullIndex := indexNullTerminator(b); nullIndex > 0 {
+	if nullIndex := indexNullTerminator(b); nullIndex > -1 {
 		if len(b) > nullIndex+2 {
 			offset = nullIndex + 2
 		}

--- a/winlogbeat/sys/strings_test.go
+++ b/winlogbeat/sys/strings_test.go
@@ -55,7 +55,7 @@ func TestUTF16BytesToStringOffset(t *testing.T) {
 }
 
 func TestUTF16BytesToStringOffsetWithEmptyString(t *testing.T) {
-	in := bytes.Join([][]byte{toUTF16Bytes(""), toUTF16Bytes("two"), }, []byte{0, 0})
+	in := bytes.Join([][]byte{toUTF16Bytes(""), toUTF16Bytes("two")}, []byte{0, 0})
 
 	output, offset, err := UTF16BytesToString(in)
 	if err != nil {

--- a/winlogbeat/sys/strings_test.go
+++ b/winlogbeat/sys/strings_test.go
@@ -54,6 +54,25 @@ func TestUTF16BytesToStringOffset(t *testing.T) {
 	assert.Equal(t, -1, offset)
 }
 
+func TestUTF16BytesToStringOffsetWithEmptyString(t *testing.T) {
+	in := bytes.Join([][]byte{toUTF16Bytes(""), toUTF16Bytes("two"), }, []byte{0, 0})
+
+	output, offset, err := UTF16BytesToString(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, "", output)
+	assert.Equal(t, 2, offset)
+
+	in = in[offset:]
+	output, offset, err = UTF16BytesToString(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, "two", output)
+	assert.Equal(t, -1, offset)
+}
+
 func BenchmarkUTF16BytesToString(b *testing.B) {
 	utf16Bytes := toUTF16Bytes("A logon was attempted using explicit credentials.")
 


### PR DESCRIPTION
Hi,

I encountered a bug while using winlogbeat on Windows Server 2003.
Some events had errors in them:

```
{'@timestamp': '2017-03-01T08:53:18.000Z',
 '@version': '1',
 'beat': {'hostname': '...', 'name': '..', 'version': '5.2.1'},
 'computer_name': '...',
 'event_id': 540,
 'host': '...',
 'level': 'Audit Success',
 'log_name': 'Security',
 'message_error': 'Slice must have an even length (length=141)',
 'record_number': '1209',
 'source_name': 'Security',
 'tags': ['beats_input_raw_event'],
 'type': 'eventlogging',
 'user': {'...'}}
```

It seems to be a bug in the `UTF16BytesToString` function.
The function does not detect empty strings correctly (due to an off-by-one check on the return value of `indexNullTerminator`), and it creates a misaligned offset in the buffer.

I added a test and fixed it.

For completeness, this is an example of a 'bad' record I had (encoded in hex):
`140200004c664c6502000000ff95b658ff95b65876170080040007000000000000000000600000000000000060000000700100009e0000004500760065006e0074004c006f0067000000570049004e0032004b00330052003200450045000000000000000000000031003700350000003600300000003000200047004d00540020005300740061006e0064006100720064002000540069006d006500000031002e0031000000300000004d006900630072006f0073006f00660074002000570069006e0064006f0077007300200053006500720076006500720020003200300030003300200052003200000035002e0032002e00330037003900300020004200750069006c006400200033003700390030002000530065007200760069006300650020005000610063006b0020003200000055006e006900700072006f0063006500730073006f00720020004600720065006500000033003700390030002e00730072007600300033005f007300700032005f006700640072002e003000390030003800300035002d00310034003300380000003400620034003600330063003400350000004e006f007400200041007600610069006c00610062006c00650000004e006f007400200041007600610069006c00610062006c0065000000300000003100000032003500360000003400300039000000770069006e0032006b003300720032006500650000000000000014020000`