### PR TITLE
Show all missing plugins in the same err message

### DIFF
--- a/filebeat/fileset/fileset.go
+++ b/filebeat/fileset/fileset.go
@@ -78,6 +78,16 @@ type manifest struct {
 	Vars           []map[string]interface{} `config:"var"`
 	IngestPipeline string                   `config:"ingest_pipeline"`
 	Prospector     string                   `config:"prospector"`
+	Requires       struct {
+		Processors []ProcessorRequirement `config:"processors"`
+	} `config:"requires"`
+}
+
+// ProcessorRequirement represents the declaration of a dependency to a particular
+// Ingest Node processor / plugin.
+type ProcessorRequirement struct {
+	Name   string `config:"name"`
+	Plugin string `config:"plugin"`
 }
 
 // readManifest reads the manifest file of the fileset.
@@ -293,4 +303,10 @@ func removeExt(path string) string {
 		}
 	}
 	return path
+}
+
+// GetRequiredProcessors returns the list of processors on which this
+// fileset depends.
+func (fs *Fileset) GetRequiredProcessors() []ProcessorRequirement {
+	return fs.manifest.Requires.Processors
 }

--- a/filebeat/fileset/modules_integration_test.go
+++ b/filebeat/fileset/modules_integration_test.go
@@ -77,3 +77,27 @@ func TestSetupNginx(t *testing.T) {
 	status, _, _ = client.Request("GET", "/_ingest/pipeline/filebeat-5.2.0-nginx-error-pipeline", "", nil, nil)
 	assert.Equal(t, 200, status)
 }
+
+func TestAvailableProcessors(t *testing.T) {
+	client := elasticsearch.GetTestingElasticsearch()
+
+	// these exists on our integration test setup
+	requiredProcessors := []ProcessorRequirement{
+		{Name: "user_agent", Plugin: "ingest-user-agent"},
+		{Name: "geoip", Plugin: "ingest-geoip"},
+	}
+
+	err := checkAvailableProcessors(client, requiredProcessors)
+	assert.NoError(t, err)
+
+	// these don't exists on our integration test setup
+	requiredProcessors = []ProcessorRequirement{
+		{Name: "test", Plugin: "ingest-test"},
+		{Name: "hello", Plugin: "ingest-hello"},
+	}
+
+	err = checkAvailableProcessors(client, requiredProcessors)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "ingest-test")
+	assert.Contains(t, err.Error(), "ingest-hello")
+}

--- a/filebeat/fileset/modules_test.go
+++ b/filebeat/fileset/modules_test.go
@@ -355,12 +355,12 @@ func TestInterpretError(t *testing.T) {
 		{
 			Test:   "geoip not installed",
 			Input:  `{"error":{"root_cause":[{"type":"parse_exception","reason":"No processor type exists with name [geoip]","header":{"processor_type":"geoip"}}],"type":"parse_exception","reason":"No processor type exists with name [geoip]","header":{"processor_type":"geoip"}},"status":400}`,
-			Output: "This module requires the ingest-geoip plugin to be installed in Elasticsearch. You can installing using the following command in the Elasticsearch home directory:\n    sudo bin/elasticsearch-plugin install ingest-geoip",
+			Output: "This module requires the ingest-geoip plugin to be installed in Elasticsearch. You can install it using the following command in the Elasticsearch home directory:\n    sudo bin/elasticsearch-plugin install ingest-geoip",
 		},
 		{
 			Test:   "user-agent not installed",
 			Input:  `{"error":{"root_cause":[{"type":"parse_exception","reason":"No processor type exists with name [user_agent]","header":{"processor_type":"user_agent"}}],"type":"parse_exception","reason":"No processor type exists with name [user_agent]","header":{"processor_type":"user_agent"}},"status":400}`,
-			Output: "This module requires the ingest-user-agent plugin to be installed in Elasticsearch. You can installing using the following command in the Elasticsearch home directory:\n    sudo bin/elasticsearch-plugin install ingest-user-agent",
+			Output: "This module requires the ingest-user-agent plugin to be installed in Elasticsearch. You can install it using the following command in the Elasticsearch home directory:\n    sudo bin/elasticsearch-plugin install ingest-user-agent",
 		},
 		{
 			Test:  "other plugin not installed",

--- a/filebeat/module/apache2/access/manifest.yml
+++ b/filebeat/module/apache2/access/manifest.yml
@@ -16,3 +16,9 @@ var:
 
 ingest_pipeline: ingest/{{.pipeline}}.json
 prospector: config/access.yml
+
+requires.processors:
+- name: user_agent
+  plugin: ingest-user-agent
+- name: geoip
+  plugin: ingest-geoip

--- a/filebeat/module/nginx/access/manifest.yml
+++ b/filebeat/module/nginx/access/manifest.yml
@@ -14,3 +14,9 @@ var:
 
 ingest_pipeline: ingest/{{.pipeline}}.json
 prospector: config/nginx-access.yml
+
+requires.processors:
+- name: user_agent
+  plugin: ingest-user-agent
+- name: geoip
+  plugin: ingest-geoip


### PR DESCRIPTION
A drawback of the error handling in #3676 was that if more than one
plugin is missing in ES, the error only reported the first one. This means
that the user might go through an annoying trial and error cycle.

To solve this, we make the modules declare their processor requirements
in the `manifest.yml` file and we compare them with the available processors
from calling `/_nodes/ingest`.

This is how the error looks like:

```
Exiting: Error loading pipeline for fileset apache2/access: This module requires the following
Elasticsearch plugins: ingest-user-agent, ingest-geoip. You can install them by running the
following commands on all the Elasticsearch nodes:
    sudo bin/elasticsearch-plugin install ingest-user-agent
    sudo bin/elasticsearch-plugin install ingest-geoip
```

In case the module author doesn't declare the required processor plugins, the
error handling in #3676 still applies.


Note: i opened in 5.3 to save time. Needs to be cherry-picked to master.