### PR TITLE
Add labels to Docker healthcheck output

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -55,6 +55,7 @@ https://github.com/elastic/beats/compare/v5.1.1...master[Check the HEAD diff]
 - Fix bug docker module hanging when docker container killed. {issue}3610[3610]
 - Set timeout to period instead of 1s by default as documented.
 - Add error handling to system process metricset for when Linux cgroups are missing from the kernel. {pull}3692[3692]
+- Add labels to the Docker healthcheck metricset output. {pull}3707[3707]
 
 *Packetbeat*
 

--- a/metricbeat/module/docker/healthcheck/_meta/data.json
+++ b/metricbeat/module/docker/healthcheck/_meta/data.json
@@ -6,15 +6,23 @@
     },
     "docker": {
         "container": {
-            "id": "6d01caff41f2f9118c0ced423579d70b6161eec614270e3cbf1b72e2bb40f84e",
-            "name": "gifted_hugle"
+            "id": "1bab78b8101e4d4df7de3dd9747512641bd0e97f886ca44be2f3f22a7b90ea2b",
+            "labels": {
+                "com_docker_compose_config-hash": "1b78c28e8f14c2d7804c5b002c0f1dd29afac4a82737d38d079d227029013732",
+                "com_docker_compose_container-number": "1",
+                "com_docker_compose_oneoff": "False",
+                "com_docker_compose_project": "metricbeatdocker",
+                "com_docker_compose_service": "elasticsearch",
+                "com_docker_compose_version": "1.11.1"
+            },
+            "name": "elasticsearch"
         },
         "healthcheck": {
             "event": {
-                "end_date": "2017-01-25T10:58:51.171Z",
+                "end_date": "2017-03-02T05:19:07.701Z",
                 "exit_code": 0,
-                "output": "",
-                "start_date": "2017-01-25T10:58:51.114Z"
+                "output": "{\n  \"name\" : \"iElnwHE\",\n  \"cluster_name\" : \"elasticsearch\",\n  \"cluster_uuid\" : \"phQC_WOFRBK10LUqTQS5lA\",\n  \"version\" : {\n    \"number\" : \"6.0.0-alpha1\",\n    \"build_hash\" : \"d02170b\",\n    \"build_date\" : \"2017-02-06T12:00:50.817Z\",\n    \"build_snapshot\" : true,\n    \"lucene_version\" : \"6.4.1\"\n  },\n  \"tagline\" : \"You Know, for Search\"\n}\n",
+                "start_date": "2017-03-02T05:19:07.646Z"
             },
             "failingstreak": 0,
             "status": "healthy"

--- a/metricbeat/module/docker/healthcheck/data.go
+++ b/metricbeat/module/docker/healthcheck/data.go
@@ -41,10 +41,7 @@ func eventMapping(cont *dc.APIContainers, m *MetricSet) common.MapStr {
 
 	return common.MapStr{
 		mb.ModuleData: common.MapStr{
-			"container": common.MapStr{
-				"name": docker.ExtractContainerName(cont.Names),
-				"id":   cont.ID,
-			},
+			"container": docker.NewContainer(cont).ToMapStr(),
 		},
 		"status":        container.State.Health.Status,
 		"failingstreak": container.State.Health.FailingStreak,
@@ -55,7 +52,6 @@ func eventMapping(cont *dc.APIContainers, m *MetricSet) common.MapStr {
 			"output":     container.State.Health.Log[lastEvent].Output,
 		},
 	}
-
 }
 
 // hasHealthCheck detects if healthcheck is available for container


### PR DESCRIPTION
The healthcheck output was inconsistent with the other docker metricsets and did not include labels.