### PR TITLE
Cherry-pick to 5.3: Document process.env.whitelist config option

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -93,6 +93,7 @@ https://github.com/elastic/beats/compare/v5.1.1...master[Check the HEAD diff]
 - Add Beta php_fpm module with pool metricset. {pull}3415[3415]
 - The Docker, Kafka, and Prometheus modules are now Beta, instead of experimental. {pull}3525[3525]
 - The HAProxy module is now GA, instead of experimental. {pull}3525[3525]
+- Add the ability to collect the environment variables from system processes. {pull}3337[3337]
 
 *Packetbeat*
 

--- a/metricbeat/module/system/process/_meta/docs.asciidoc
+++ b/metricbeat/module/system/process/_meta/docs.asciidoc
@@ -17,3 +17,21 @@ On Linux this metricset will collect metrics from any cgroups that the process
 is a member of. This feature is enabled by default and can be disabled by adding
 `process.cgroup.enabled: false` to the system module configuration.
 
+[float]
+=== Process Environment Variables
+
+This metricset can collect the environment variables that were used to start the
+process. This feature is available on Linux, Darwin, and FreeBSD. No environment
+variables are collected by default because they could contain sensitive information.
+You must configure the environment variables that you wish to collect by
+specifying a list of regular expressions that match the variable name.
+
+[source,yaml]
+----
+metricbeat.modules:
+- module: system
+  metricsets: ["process"]
+  process.env.whitelist:
+  - '^PATH$'
+  - '^SSH_.*'
+----


### PR DESCRIPTION
Cherry-pick of PR #3694 to 5.3 branch. Original message: 

Document `process.env.whitelist` which is used by the Metricbeat system process metricset to specify what environment variables should be captured.

Adds documentation for #3337.

Needs back port to 5.3.