### PR TITLE
Fix a couple of doc nits

### DIFF
--- a/libbeat/docs/newbeat.asciidoc
+++ b/libbeat/docs/newbeat.asciidoc
@@ -75,8 +75,7 @@ Logstash.
 The publisher is already implemented in libbeat, so you typically only have to worry about the logic
 specific to your Beat (the code that creates the event and sends it to the publisher).
 Libbeat also offers common services like configuration management, logging,
-daemonzing, and Windows service handling, and in the future, will offer data processing modules,
-such as filtering or sampling.
+daemonzing, and Windows service handling, and data processing modules.
 
 image:./images/beat_overview.png[Beat overview architecture]
 

--- a/libbeat/docs/shared-command-line.asciidoc
+++ b/libbeat/docs/shared-command-line.asciidoc
@@ -10,12 +10,15 @@
 //////////////////////////////////////////////////////////////////////////
 
 *`-E <setting>=<value>`*::
-Overwrite an individual setting in the config file. For example:
+Override a specific configuration setting. For example:
 +
 ["source","sh",subs="attributes"]
 ----------------------------------------------------------------------
 sudo ./{beatname_lc} -c {beatname_lc}.yml -E name=mybeat
 ----------------------------------------------------------------------
++
+This setting is applied to the currently running {beatname_uc} process.
+The {beatname_uc} configuration file is not changed. 
 
 *`-N`*::
 Disable the publishing of events to the defined output. This option is useful only


### PR DESCRIPTION
Fixes a couple of minor doc problems:
* Processors are no longer "future" functionality.
* Users were a little confused about -E option because they thought it might actually change the setting in the config file.