### PR TITLE
Fix autopep8 checks

### DIFF
--- a/libbeat/scripts/create_packer.py
+++ b/libbeat/scripts/create_packer.py
@@ -42,6 +42,7 @@ def load_file(file, beat, beat_path, version):
 
     return content.replace("{beat}", beat).replace("{beat_path}", beat_path).replace("{version}", version)
 
+
 if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(description="Creates the beats packer structure")

--- a/libbeat/scripts/generate_fields_docs.py
+++ b/libbeat/scripts/generate_fields_docs.py
@@ -97,6 +97,7 @@ grouped in the following categories:
         section["anchor"] = section["key"]
         document_fields(output, section, sections, "")
 
+
 if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(

--- a/libbeat/scripts/generate_makefile_doc.py
+++ b/libbeat/scripts/generate_makefile_doc.py
@@ -131,6 +131,7 @@ def print_help(categories, categories_set):
                 doc=rule["doc"],
                 default=(" Default: {}".format(default) if default else "")))
 
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="Generate documentation from a list of Makefile files")

--- a/metricbeat/scripts/config_collector.py
+++ b/metricbeat/scripts/config_collector.py
@@ -78,6 +78,7 @@ def get_title_line(title):
 
     return line[0:78] + "\n"
 
+
 if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(

--- a/metricbeat/scripts/create_metricset.py
+++ b/metricbeat/scripts/create_metricset.py
@@ -80,6 +80,7 @@ def load_file(file, module, metricset):
     return content.replace("{module}", module).replace("{metricset}",
                                                        metricset)
 
+
 if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(description="Creates a metricset")

--- a/metricbeat/scripts/fields_collector.py
+++ b/metricbeat/scripts/fields_collector.py
@@ -49,5 +49,6 @@ def collect():
     # output string so it can be concatenated
     print(fields_yml)
 
+
 if __name__ == "__main__":
     collect()

--- a/metricbeat/scripts/generate_imports.py
+++ b/metricbeat/scripts/generate_imports.py
@@ -42,6 +42,7 @@ def generate(go_beat_path):
     # output string so it can be concatenated
     print(list_file)
 
+
 if __name__ == "__main__":
     # First argument is the beat path under GOPATH.
     # (e.g. github.com/elastic/beats/metricbeat)

--- a/packetbeat/scripts/generate_imports.py
+++ b/packetbeat/scripts/generate_imports.py
@@ -34,6 +34,7 @@ def generate(go_beat_path):
     # output string so it can be concatenated
     print(list_file)
 
+
 if __name__ == "__main__":
     # First argument is the beat path under GOPATH.
     # (e.g. github.com/elastic/beats/packetbeat)

--- a/packetbeat/tests/system/gen/memcache/tcp_counter_ops.py
+++ b/packetbeat/tests/system/gen/memcache/tcp_counter_ops.py
@@ -11,5 +11,6 @@ def run(mc):
     mc.decr('cnt', 5)
     print(mc.get('cnt'))
 
+
 if __name__ == '__main__':
     mc.run_tcp(run)

--- a/packetbeat/tests/system/gen/memcache/tcp_delete.py
+++ b/packetbeat/tests/system/gen/memcache/tcp_delete.py
@@ -10,5 +10,6 @@ def run(mc):
     mc.delete('key')
     print(mc.get('key'))
 
+
 if __name__ == '__main__':
     mc.run_tcp(run)

--- a/packetbeat/tests/system/gen/memcache/tcp_multi_store_load.py
+++ b/packetbeat/tests/system/gen/memcache/tcp_multi_store_load.py
@@ -18,5 +18,6 @@ def run(mc):
     res = mc.get_multi(["x", "k1", "k2", "k3", "y"])
     print(res)
 
+
 if __name__ == '__main__':
     mc.run_tcp(run)

--- a/packetbeat/tests/system/gen/memcache/tcp_single_load_store.py
+++ b/packetbeat/tests/system/gen/memcache/tcp_single_load_store.py
@@ -14,5 +14,6 @@ def run(mc):
     if v != mc.get('test_key'):
         raise RuntimeError("returned value differs")
 
+
 if __name__ == '__main__':
     mc.run_tcp(run)

--- a/packetbeat/tests/system/gen/memcache/tcp_stats.py
+++ b/packetbeat/tests/system/gen/memcache/tcp_stats.py
@@ -9,5 +9,6 @@ def run(mc):
     print(mc.get('key'))
     print(mc.get_stats())
 
+
 if __name__ == '__main__':
     mc.run_tcp(run)

--- a/packetbeat/tests/system/gen/memcache/udp_counter_ops.py
+++ b/packetbeat/tests/system/gen/memcache/udp_counter_ops.py
@@ -8,5 +8,6 @@ def run(mc):
     mc.incr('cnt', 2)
     mc.decr('cnt', 5)
 
+
 if __name__ == '__main__':
     mc.run_udp(run)

--- a/packetbeat/tests/system/gen/memcache/udp_delete.py
+++ b/packetbeat/tests/system/gen/memcache/udp_delete.py
@@ -9,5 +9,6 @@ def run(mc):
     mc.set('key', 'abc')
     mc.delete('key')
 
+
 if __name__ == '__main__':
     mc.run_udp(run)

--- a/packetbeat/tests/system/gen/memcache/udp_multi_store.py
+++ b/packetbeat/tests/system/gen/memcache/udp_multi_store.py
@@ -13,5 +13,6 @@ def run(mc):
     })
     print(res)
 
+
 if __name__ == '__main__':
     mc.run_udp(run)

--- a/packetbeat/tests/system/gen/memcache/udp_single_store.py
+++ b/packetbeat/tests/system/gen/memcache/udp_single_store.py
@@ -11,5 +11,6 @@ def run(mc):
     if not mc.set('test_key', v):
         raise RuntimeError("failed to set value")
 
+
 if __name__ == '__main__':
     mc.run_udp(run)

--- a/packetbeat/tests/system/test_0060_flows.py
+++ b/packetbeat/tests/system/test_0060_flows.py
@@ -3,7 +3,7 @@ from packetbeat import (BaseTest, FLOWS_REQUIRED_FIELDS)
 from pprint import PrettyPrinter
 
 
-pprint = lambda x: PrettyPrinter().pprint(x)
+def pprint(x): return PrettyPrinter().pprint(x)
 
 
 def check_fields(flow, fields):


### PR DESCRIPTION
It seems something changed in the most recent version of autopep8 and lots of new fiels are cleaned up when run.