### PR TITLE
Set timezone for elasticsearch output

### DIFF
--- a/libbeat/outputs/elasticsearch/output.go
+++ b/libbeat/outputs/elasticsearch/output.go
@@ -60,7 +60,7 @@ func New(beat common.BeatInfo, cfg *common.Config, topologyExpire int) (outputs.
 	}
 
 	if !cfg.HasField("index") {
-		pattern := ""
+		pattern = fmt.Sprintf("%v-%v-%%{+yyyy.MM.dd}", beat.Beat, beat.Version)
 		if cfg.HasField("timezone") {
 			zone, err := cfg.String("timezone", -1)
 			if err != nil {
@@ -69,14 +69,10 @@ func New(beat common.BeatInfo, cfg *common.Config, topologyExpire int) (outputs.
 			loc, err := time.LoadLocation(zone)
 			if err != nil {
 				logp.Err(err.Error())
-				pattern = fmt.Sprintf("%v-%v-%%{+yyyy.MM.dd}", beat.Beat, beat.Version)
 			} else {
 				pattern = fmt.Sprintf("%v-%v-"+time.Now().In(loc).Format("2006.01.02"), beat.Beat, beat.Version)
 			}
-		} else {
-			pattern = fmt.Sprintf("%v-%v-%%{+yyyy.MM.dd}", beat.Beat, beat.Version)
-		}
-
+		} 
 		cfg.SetString("index", -1, pattern)
 	}
 

--- a/libbeat/outputs/elasticsearch/output.go
+++ b/libbeat/outputs/elasticsearch/output.go
@@ -60,7 +60,23 @@ func New(beat common.BeatInfo, cfg *common.Config, topologyExpire int) (outputs.
 	}
 
 	if !cfg.HasField("index") {
-		pattern := fmt.Sprintf("%v-%v-%%{+yyyy.MM.dd}", beat.Beat, beat.Version)
+		pattern := ""
+		if cfg.HasField("timezone") {
+			zone, err := cfg.String("timezone", -1)
+			if err != nil {
+				return nil, err
+			}
+			loc, err := time.LoadLocation(zone)
+			if err != nil {
+				logp.Err(err.Error())
+				pattern = fmt.Sprintf("%v-%v-%%{+yyyy.MM.dd}", beat.Beat, beat.Version)
+			} else {
+				pattern = fmt.Sprintf("%v-%v-"+time.Now().In(loc).Format("2006.01.02"), beat.Beat, beat.Version)
+			}
+		} else {
+			pattern = fmt.Sprintf("%v-%v-%%{+yyyy.MM.dd}", beat.Beat, beat.Version)
+		}
+
 		cfg.SetString("index", -1, pattern)
 	}
 


### PR DESCRIPTION
Discussed [here](https://discuss.elastic.co/t/metricbeat-index-date-timezone/78296), this PR gives the opportunity to set `timezone` as a parameter for elasticsearch output which is used when there is no index name is set.