### PR TITLE
Always traverse sub-registries

### DIFF
--- a/libbeat/monitoring/registry.go
+++ b/libbeat/monitoring/registry.go
@@ -56,8 +56,10 @@ func (r *Registry) doVisit(mode Mode, vs Visitor) {
 	defer r.mu.RUnlock()
 
 	for key, v := range r.entries {
-		if v.Mode > mode {
-			continue
+		if _, isReg := v.Var.(*Registry); !isReg {
+			if v.Mode > mode {
+				continue
+			}
 		}
 
 		vs.OnKey(key)


### PR DESCRIPTION
- always traverse sub-registries to catch all variables at lower leaf-nodes
  being marked as 'Report'