### PR TITLE
Make system process metricset honor cpu_ticks config option

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -57,6 +57,7 @@ https://github.com/elastic/beats/compare/v5.1.1...master[Check the HEAD diff]
 - Set timeout to period instead of 1s by default as documented.
 - Add error handling to system process metricset for when Linux cgroups are missing from the kernel. {pull}3692[3692]
 - Add labels to the Docker healthcheck metricset output. {pull}3707[3707]
+- Make system process metricset honor the cpu_ticks config option. {issue}3590[3590]
 
 *Packetbeat*
 

--- a/metricbeat/module/system/process/helper.go
+++ b/metricbeat/module/system/process/helper.go
@@ -245,23 +245,17 @@ func (procStats *ProcStats) GetProcessEvent(process *Process, last *Process) com
 		proc["env"] = process.Env
 	}
 
+	proc["cpu"] = common.MapStr{
+		"total": common.MapStr{
+			"pct": GetProcCpuPercentage(last, process),
+		},
+		"start_time": unixTimeMsToTime(process.Cpu.StartTime),
+	}
+
 	if procStats.CpuTicks {
-		proc["cpu"] = common.MapStr{
-			"user":   process.Cpu.User,
-			"system": process.Cpu.Sys,
-			"total": common.MapStr{
-				"ticks": process.Cpu.Total,
-				"pct":   GetProcCpuPercentage(last, process),
-			},
-			"start_time": unixTimeMsToTime(process.Cpu.StartTime),
-		}
-	} else {
-		proc["cpu"] = common.MapStr{
-			"total": common.MapStr{
-				"pct": GetProcCpuPercentage(last, process),
-			},
-			"start_time": unixTimeMsToTime(process.Cpu.StartTime),
-		}
+		proc.Put("cpu.user", process.Cpu.User)
+		proc.Put("cpu.system", process.Cpu.Sys)
+		proc.Put("cpu.total.ticks", process.Cpu.Total)
 	}
 
 	if process.FD != (sigar.ProcFDUsage{}) {

--- a/metricbeat/module/system/process/process.go
+++ b/metricbeat/module/system/process/process.go
@@ -37,6 +37,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 		Procs        []string `config:"processes"`
 		Cgroups      *bool    `config:"process.cgroups.enabled"`
 		EnvWhitelist []string `config:"process.env.whitelist"`
+		CPUTicks     bool     `config:"cpu_ticks"`
 	}{
 		Procs: []string{".*"}, // collect all processes by default
 	}
@@ -49,6 +50,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 		stats: &ProcStats{
 			Procs:        config.Procs,
 			EnvWhitelist: config.EnvWhitelist,
+			CpuTicks:     config.CPUTicks,
 		},
 	}
 	err := m.stats.InitProcStats()


### PR DESCRIPTION
When `cpu_ticks` is true in the config file, the system process metricset will report the number of “ticks” (actually jiffies on linux) used in user space (`system.process.cpu.user`), system (`system.process.cpu.system`), and total (`system.process.cpu.total.ticks`).

Fixes #3590