### PR TITLE
Fix race condition for harvester Start / Stop in registry

### DIFF
--- a/filebeat/harvester/harvester.go
+++ b/filebeat/harvester/harvester.go
@@ -53,7 +53,7 @@ type Harvester struct {
 	encoding        encoding.Encoding
 	done            chan struct{}
 	stopOnce        sync.Once
-	stopWg          *sync.WaitGroup
+	StopWg          *sync.WaitGroup
 	outlet          Outlet
 	ID              uuid.UUID
 	processors      *processors.Processors
@@ -71,7 +71,7 @@ func NewHarvester(
 		state:  state,
 		states: states,
 		done:   make(chan struct{}),
-		stopWg: &sync.WaitGroup{},
+		StopWg: &sync.WaitGroup{},
 		outlet: outlet,
 		ID:     uuid.NewV4(),
 	}

--- a/filebeat/harvester/log.go
+++ b/filebeat/harvester/log.go
@@ -54,7 +54,6 @@ func (h *Harvester) Harvest(r reader.Reader) {
 	harvesterStarted.Add(1)
 	harvesterRunning.Add(1)
 
-	h.stopWg.Add(1)
 	defer func() {
 		// Channel to stop internal harvester routines
 		h.stop()
@@ -64,7 +63,7 @@ func (h *Harvester) Harvest(r reader.Reader) {
 		harvesterRunning.Add(-1)
 
 		// Marks harvester stopping completed
-		h.stopWg.Done()
+		h.StopWg.Done()
 	}()
 
 	// Closes reader after timeout or when done channel is closed
@@ -164,7 +163,7 @@ func (h *Harvester) stop() {
 // Stop stops harvester and waits for completion
 func (h *Harvester) Stop() {
 	h.stop()
-	h.stopWg.Wait()
+	h.StopWg.Wait()
 }
 
 // sendEvent sends event to the spooler channel


### PR DESCRIPTION
There is still a case where a race condition could happen (see TODO). Registry must be improved to also handle this case.

This should not be backported as the issue can only happen on shutdown in very rare cases and should not have any side effect.

Closes https://github.com/elastic/beats/issues/3779