### PR TITLE
Improve handling of different path variants on Windows (#3781)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -142,6 +142,7 @@ https://github.com/elastic/beats/compare/v5.2.2...v5.3.0[View commits]
 - Update regular expressions used for matching file names or lines (multiline, include/exclude functionality) to new matchers improving performance of simple string matches. {pull}3469[3469]
 - The `symlinks` and `harverster_limit` settings are now GA, instead of experimental. {pull}3525[3525]
 - close_timeout is also applied when the output is blocking. {pull}3511[3511]
+- Improve handling of different path variants on Windows. {pull}3781[3781]
 
 
 *Metricbeat*

--- a/filebeat/prospector/prospector_log.go
+++ b/filebeat/prospector/prospector_log.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
-	"strings"
 	"time"
 
 	"github.com/elastic/beats/filebeat/harvester"
@@ -180,13 +178,14 @@ func (p *ProspectorLog) getFiles() map[string]os.FileInfo {
 
 // matchesFile returns true in case the given filePath is part of this prospector, means matches its glob patterns
 func (p *ProspectorLog) matchesFile(filePath string) bool {
+
+	// Path is cleaned to ensure we always compare clean paths
+	filePath = filepath.Clean(filePath)
+
 	for _, glob := range p.config.Paths {
 
-		if runtime.GOOS == "windows" {
-			// Windows allows / slashes which makes glob patterns with / work
-			// But for match we need paths with \ as only file names are compared and no lookup happens
-			glob = strings.Replace(glob, "/", "\\", -1)
-		}
+		// Glob is cleaned to ensure we always compare clean paths
+		glob = filepath.Clean(glob)
 
 		// Evaluate if glob matches filePath
 		match, err := filepath.Match(glob, filePath)

--- a/filebeat/prospector/prospector_log_windows_test.go
+++ b/filebeat/prospector/prospector_log_windows_test.go
@@ -16,14 +16,38 @@ var matchTestsWindows = []struct {
 	result       bool
 }{
 	{
-		"C:\\\\hello\\test\\test.log",      // Path are always in windows format
-		[]string{"C:\\\\hello/test/*.log"}, // Globs can also be with forward slashes
+		`C:\\hello\test\test.log`,
+		[]string{`C:\\hello/test/*.log`},
 		nil,
 		true,
 	},
 	{
-		"C:\\\\hello\\test\\test.log",       // Path are always in windows format
-		[]string{"C:\\\\hello\\test/*.log"}, // Globs can also be mixed
+		`C:\\hello\test\test.log`,
+		[]string{`C:\\hello\test/*.log`},
+		nil,
+		true,
+	},
+	{
+		`C:\\hello\test\test.log`,
+		[]string{`C://hello/test/*.log`},
+		nil,
+		true,
+	},
+	{
+		`C:\\hello\test\test.log`,
+		[]string{`C://hello//test//*.log`},
+		nil,
+		true,
+	},
+	{
+		`C://hello/test/test.log`,
+		[]string{`C:\\hello\test\*.log`},
+		nil,
+		true,
+	},
+	{
+		`C://hello/test/test.log`,
+		[]string{`C:/hello/test/*.log`},
 		nil,
 		true,
 	},


### PR DESCRIPTION
* Improve handling of different path variants on Windows

If forward slashes were used on Windows the glob was not matching on startup which lead to the issue that data was resent. This is solved in 5.3 by using path.Abs for all paths which also includes Clean. To make sure Path and Glob are always clean, Cleanup was added to the MatchFile part. This makes sure in case old data / incorrect data is loaded, the comparison will still work. More tests were added for windows to verify change.

Before this change, option 1 below did not work.

```
"F:/wwwLogs/flights-wsapi/WebServicesWebApi.log"
"F:\\wwwLogs\\flights-wsapi\\WebServicesWebApi.log"
'F:\wwwLogs\flights-wsapi\WebServicesWebApi.log'
```

Based on https://discuss.elastic.co/t/duplicate-events-with-filebeat-on-windows-on-service-restart/78743/10

* Move clean path outside for loop

(cherry picked from commit 45271627f685be6a87cf32b1a4a6d685ab95f03c)