### PR TITLE
Fix docs build

### DIFF
--- a/packetbeat/docs/configuring-howto.asciidoc
+++ b/packetbeat/docs/configuring-howto.asciidoc
@@ -22,7 +22,6 @@ The following topics describe how to configure Packetbeat:
 * <<using-environ-vars>>
 * <<capturing-options>>
 * <<thrift-rpc>>
-* <<maintaining-topology>>
 * <<yaml-tips>>
 
 --

--- a/packetbeat/docs/index.asciidoc
+++ b/packetbeat/docs/index.asciidoc
@@ -46,8 +46,6 @@ include::./capturing.asciidoc[]
 
 include::./thrift.asciidoc[]
 
-include::./maintaining-topology.asciidoc[]
-
 :allplatforms:
 include::../../libbeat/docs/yaml.asciidoc[]
 

--- a/packetbeat/docs/reference/configuration.asciidoc
+++ b/packetbeat/docs/reference/configuration.asciidoc
@@ -25,3 +25,5 @@ configuration settings, you need to restart {beatname_uc} to pick up the changes
 * <<configuration-logging>>
 * <<configuration-run-options>>
 * <<configuration-processors>>
+
+include::configuration/packetbeat-options.asciidoc[]


### PR DESCRIPTION
The maintaining-topology reference was still used and an include line
was removed by mistake.