### PR TITLE
filebeat: fix golint warnings in prospector

### DIFF
--- a/filebeat/prospector/config.go
+++ b/filebeat/prospector/config.go
@@ -52,11 +52,11 @@ func (config *prospectorConfig) Validate() error {
 	}
 
 	if config.CleanInactive != 0 && config.IgnoreOlder == 0 {
-		return fmt.Errorf("ignore_older must be enabled when clean_inactive is used.")
+		return fmt.Errorf("ignore_older must be enabled when clean_inactive is used")
 	}
 
 	if config.CleanInactive != 0 && config.CleanInactive <= config.IgnoreOlder+config.ScanFrequency {
-		return fmt.Errorf("clean_inactive must be > ignore_older + scan_frequency to make sure only files which are not monitored anymore are removed.")
+		return fmt.Errorf("clean_inactive must be > ignore_older + scan_frequency to make sure only files which are not monitored anymore are removed")
 	}
 
 	return nil

--- a/filebeat/prospector/factory.go
+++ b/filebeat/prospector/factory.go
@@ -7,12 +7,14 @@ import (
 	"github.com/elastic/beats/libbeat/logp"
 )
 
+// Factory is a factory for registrars
 type Factory struct {
 	outlet    Outlet
 	registrar *registrar.Registrar
 	beatDone  chan struct{}
 }
 
+// NewFactory instantiates a new Factory
 func NewFactory(outlet Outlet, registrar *registrar.Registrar, beatDone chan struct{}) *Factory {
 	return &Factory{
 		outlet:    outlet,
@@ -21,6 +23,7 @@ func NewFactory(outlet Outlet, registrar *registrar.Registrar, beatDone chan str
 	}
 }
 
+// Create creates a prospector based on a config
 func (r *Factory) Create(c *common.Config) (cfgfile.Runner, error) {
 
 	p, err := NewProspector(c, r.outlet, r.beatDone)

--- a/filebeat/prospector/prospector_log.go
+++ b/filebeat/prospector/prospector_log.go
@@ -18,14 +18,16 @@ var (
 	filesTruncated = monitoring.NewInt(nil, "filebeat.prospector.log.files.truncated")
 )
 
-type ProspectorLog struct {
+// Log contains the prospector and its config
+type Log struct {
 	Prospector *Prospector
 	config     prospectorConfig
 }
 
-func NewProspectorLog(p *Prospector) (*ProspectorLog, error) {
+// NewLog instantiates a new Log
+func NewLog(p *Prospector) (*Log, error) {
 
-	prospectorer := &ProspectorLog{
+	prospectorer := &Log{
 		Prospector: p,
 		config:     p.config,
 	}
@@ -36,12 +38,12 @@ func NewProspectorLog(p *Prospector) (*ProspectorLog, error) {
 // LoadStates loads states into prospector
 // It goes through all states coming from the registry. Only the states which match the glob patterns of
 // the prospector will be loaded and updated. All other states will not be touched.
-func (p *ProspectorLog) LoadStates(states []file.State) error {
-	logp.Debug("prospector", "exclude_files: %s", p.config.ExcludeFiles)
+func (l *Log) LoadStates(states []file.State) error {
+	logp.Debug("prospector", "exclude_files: %s", l.config.ExcludeFiles)
 
 	for _, state := range states {
 		// Check if state source belongs to this prospector. If yes, update the state.
-		if p.matchesFile(state.Source) {
+		if l.matchesFile(state.Source) {
 			state.TTL = -1
 
 			// In case a prospector is tried to be started with an unfinished state matching the glob pattern
@@ -50,7 +52,7 @@ func (p *ProspectorLog) LoadStates(states []file.State) error {
 			}
 
 			// Update prospector states and send new states to registry
-			err := p.Prospector.updateState(input.NewEvent(state))
+			err := l.Prospector.updateState(input.NewEvent(state))
 			if err != nil {
 				logp.Err("Problem putting initial state: %+v", err)
 				return err
@@ -58,45 +60,46 @@ func (p *ProspectorLog) LoadStates(states []file.State) error {
 		}
 	}
 
-	logp.Info("Prospector with previous states loaded: %v", p.Prospector.states.Count())
+	logp.Info("Prospector with previous states loaded: %v", l.Prospector.states.Count())
 	return nil
 }
 
-func (p *ProspectorLog) Run() {
+// Run runs the prospector
+func (l *Log) Run() {
 	logp.Debug("prospector", "Start next scan")
 
 	// TailFiles is like ignore_older = 1ns and only on startup
-	if p.config.TailFiles {
-		ignoreOlder := p.config.IgnoreOlder
+	if l.config.TailFiles {
+		ignoreOlder := l.config.IgnoreOlder
 
 		// Overwrite ignore_older for the first scan
-		p.config.IgnoreOlder = 1
+		l.config.IgnoreOlder = 1
 		defer func() {
 			// Reset ignore_older after first run
-			p.config.IgnoreOlder = ignoreOlder
+			l.config.IgnoreOlder = ignoreOlder
 			// Disable tail_files after the first run
-			p.config.TailFiles = false
+			l.config.TailFiles = false
 		}()
 	}
-	p.scan()
+	l.scan()
 
 	// It is important that a first scan is run before cleanup to make sure all new states are read first
-	if p.config.CleanInactive > 0 || p.config.CleanRemoved {
-		beforeCount := p.Prospector.states.Count()
-		cleanedStates := p.Prospector.states.Cleanup()
+	if l.config.CleanInactive > 0 || l.config.CleanRemoved {
+		beforeCount := l.Prospector.states.Count()
+		cleanedStates := l.Prospector.states.Cleanup()
 		logp.Debug("prospector", "Prospector states cleaned up. Before: %d, After: %d", beforeCount, beforeCount-cleanedStates)
 	}
 
 	// Marking removed files to be cleaned up. Cleanup happens after next scan to make sure all states are updated first
-	if p.config.CleanRemoved {
-		for _, state := range p.Prospector.states.GetStates() {
+	if l.config.CleanRemoved {
+		for _, state := range l.Prospector.states.GetStates() {
 			// os.Stat will return an error in case the file does not exist
 			_, err := os.Stat(state.Source)
 			if err != nil {
 				// Only clean up files where state is Finished
 				if state.Finished {
 					state.TTL = 0
-					err := p.Prospector.updateState(input.NewEvent(state))
+					err := l.Prospector.updateState(input.NewEvent(state))
 					if err != nil {
 						logp.Err("File cleanup state update error: %s", err)
 					}
@@ -111,11 +114,11 @@ func (p *ProspectorLog) Run() {
 
 // getFiles returns all files which have to be harvested
 // All globs are expanded and then directory and excluded files are removed
-func (p *ProspectorLog) getFiles() map[string]os.FileInfo {
+func (l *Log) getFiles() map[string]os.FileInfo {
 
 	paths := map[string]os.FileInfo{}
 
-	for _, glob := range p.config.Paths {
+	for _, glob := range l.config.Paths {
 		// Evaluate the path as a wildcards/shell glob
 		matches, err := filepath.Glob(glob)
 		if err != nil {
@@ -128,7 +131,7 @@ func (p *ProspectorLog) getFiles() map[string]os.FileInfo {
 		for _, file := range matches {
 
 			// check if the file is in the exclude_files list
-			if p.isFileExcluded(file) {
+			if l.isFileExcluded(file) {
 				logp.Debug("prospector", "Exclude file: %s", file)
 				continue
 			}
@@ -146,7 +149,7 @@ func (p *ProspectorLog) getFiles() map[string]os.FileInfo {
 			}
 
 			isSymlink := fileInfo.Mode()&os.ModeSymlink > 0
-			if isSymlink && !p.config.Symlinks {
+			if isSymlink && !l.config.Symlinks {
 				logp.Debug("prospector", "File %s skipped as it is a symlink.", file)
 				continue
 			}
@@ -160,7 +163,7 @@ func (p *ProspectorLog) getFiles() map[string]os.FileInfo {
 
 			// If symlink is enabled, it is checked that original is not part of same prospector
 			// It original is harvested by other prospector, states will potentially overwrite each other
-			if p.config.Symlinks {
+			if l.config.Symlinks {
 				for _, finfo := range paths {
 					if os.SameFile(finfo, fileInfo) {
 						logp.Info("Same file found as symlink and original. Skipping file: %s", file)
@@ -177,12 +180,12 @@ func (p *ProspectorLog) getFiles() map[string]os.FileInfo {
 }
 
 // matchesFile returns true in case the given filePath is part of this prospector, means matches its glob patterns
-func (p *ProspectorLog) matchesFile(filePath string) bool {
+func (l *Log) matchesFile(filePath string) bool {
 
 	// Path is cleaned to ensure we always compare clean paths
 	filePath = filepath.Clean(filePath)
 
-	for _, glob := range p.config.Paths {
+	for _, glob := range l.config.Paths {
 
 		// Glob is cleaned to ensure we always compare clean paths
 		glob = filepath.Clean(glob)
@@ -195,7 +198,7 @@ func (p *ProspectorLog) matchesFile(filePath string) bool {
 		}
 
 		// Check if file is not excluded
-		if match && !p.isFileExcluded(filePath) {
+		if match && !l.isFileExcluded(filePath) {
 			return true
 		}
 	}
@@ -203,12 +206,12 @@ func (p *ProspectorLog) matchesFile(filePath string) bool {
 }
 
 // Scan starts a scanGlob for each provided path/glob
-func (p *ProspectorLog) scan() {
+func (l *Log) scan() {
 
-	for path, info := range p.getFiles() {
+	for path, info := range l.getFiles() {
 
 		select {
-		case <-p.Prospector.runDone:
+		case <-l.Prospector.runDone:
 			logp.Info("Scan aborted because prospector stopped.")
 			return
 		default:
@@ -225,11 +228,11 @@ func (p *ProspectorLog) scan() {
 		newState := file.NewState(info, path)
 
 		// Load last state
-		lastState := p.Prospector.states.FindPrevious(newState)
+		lastState := l.Prospector.states.FindPrevious(newState)
 
 		// Ignores all files which fall under ignore_older
-		if p.isIgnoreOlder(newState) {
-			err := p.handleIgnoreOlder(lastState, newState)
+		if l.isIgnoreOlder(newState) {
+			err := l.handleIgnoreOlder(lastState, newState)
 			if err != nil {
 				logp.Err("Updating ignore_older state error: %s", err)
 			}
@@ -239,18 +242,18 @@ func (p *ProspectorLog) scan() {
 		// Decides if previous state exists
 		if lastState.IsEmpty() {
 			logp.Debug("prospector", "Start harvester for new file: %s", newState.Source)
-			err := p.Prospector.startHarvester(newState, 0)
+			err := l.Prospector.startHarvester(newState, 0)
 			if err != nil {
 				logp.Err("Harvester could not be started on new file: %s, Err: %s", newState.Source, err)
 			}
 		} else {
-			p.harvestExistingFile(newState, lastState)
+			l.harvestExistingFile(newState, lastState)
 		}
 	}
 }
 
 // harvestExistingFile continues harvesting a file with a known state if needed
-func (p *ProspectorLog) harvestExistingFile(newState file.State, oldState file.State) {
+func (l *Log) harvestExistingFile(newState file.State, oldState file.State) {
 
 	logp.Debug("prospector", "Update existing file for harvesting: %s, offset: %v", newState.Source, oldState.Offset)
 
@@ -262,7 +265,7 @@ func (p *ProspectorLog) harvestExistingFile(newState file.State, oldState file.S
 		// This could also be an issue with force_close_older that a new harvester is started after each scan but not needed?
 		// One problem with comparing modTime is that it is in seconds, and scans can happen more then once a second
 		logp.Debug("prospector", "Resuming harvesting of file: %s, offset: %v", newState.Source, oldState.Offset)
-		err := p.Prospector.startHarvester(newState, oldState.Offset)
+		err := l.Prospector.startHarvester(newState, oldState.Offset)
 		if err != nil {
 			logp.Err("Harvester could not be started on existing file: %s, Err: %s", newState.Source, err)
 		}
@@ -272,7 +275,7 @@ func (p *ProspectorLog) harvestExistingFile(newState file.State, oldState file.S
 	// File size was reduced -> truncated file
 	if oldState.Finished && newState.Fileinfo.Size() < oldState.Offset {
 		logp.Debug("prospector", "Old file was truncated. Starting from the beginning: %s", newState.Source)
-		err := p.Prospector.startHarvester(newState, 0)
+		err := l.Prospector.startHarvester(newState, 0)
 		if err != nil {
 			logp.Err("Harvester could not be started on truncated file: %s, Err: %s", newState.Source, err)
 		}
@@ -291,7 +294,7 @@ func (p *ProspectorLog) harvestExistingFile(newState file.State, oldState file.S
 			logp.Debug("prospector", "Updating state for renamed file: %s -> %s, Current offset: %v", oldState.Source, newState.Source, oldState.Offset)
 			// Update state because of file rotation
 			oldState.Source = newState.Source
-			err := p.Prospector.updateState(input.NewEvent(oldState))
+			err := l.Prospector.updateState(input.NewEvent(oldState))
 			if err != nil {
 				logp.Err("File rotation state update error: %s", err)
 			}
@@ -312,7 +315,7 @@ func (p *ProspectorLog) harvestExistingFile(newState file.State, oldState file.S
 
 // handleIgnoreOlder handles states which fall under ignore older
 // Based on the state information it is decided if the state information has to be updated or not
-func (p *ProspectorLog) handleIgnoreOlder(lastState, newState file.State) error {
+func (l *Log) handleIgnoreOlder(lastState, newState file.State) error {
 	logp.Debug("prospector", "Ignore file because ignore_older reached: %s", newState.Source)
 
 	if !lastState.IsEmpty() {
@@ -324,7 +327,7 @@ func (p *ProspectorLog) handleIgnoreOlder(lastState, newState file.State) error 
 	}
 
 	// Make sure file is not falling under clean_inactive yet
-	if p.isCleanInactive(newState) {
+	if l.isCleanInactive(newState) {
 		logp.Debug("prospector", "Do not write state for ignore_older because clean_inactive reached")
 		return nil
 	}
@@ -335,7 +338,7 @@ func (p *ProspectorLog) handleIgnoreOlder(lastState, newState file.State) error 
 
 	// Write state for ignore_older file as none exists yet
 	newState.Finished = true
-	err := p.Prospector.updateState(input.NewEvent(newState))
+	err := l.Prospector.updateState(input.NewEvent(newState))
 	if err != nil {
 		return err
 	}
@@ -344,21 +347,21 @@ func (p *ProspectorLog) handleIgnoreOlder(lastState, newState file.State) error 
 }
 
 // isFileExcluded checks if the given path should be excluded
-func (p *ProspectorLog) isFileExcluded(file string) bool {
-	patterns := p.config.ExcludeFiles
+func (l *Log) isFileExcluded(file string) bool {
+	patterns := l.config.ExcludeFiles
 	return len(patterns) > 0 && harvester.MatchAny(patterns, file)
 }
 
 // isIgnoreOlder checks if the given state reached ignore_older
-func (p *ProspectorLog) isIgnoreOlder(state file.State) bool {
+func (l *Log) isIgnoreOlder(state file.State) bool {
 
 	// ignore_older is disable
-	if p.config.IgnoreOlder == 0 {
+	if l.config.IgnoreOlder == 0 {
 		return false
 	}
 
 	modTime := state.Fileinfo.ModTime()
-	if time.Since(modTime) > p.config.IgnoreOlder {
+	if time.Since(modTime) > l.config.IgnoreOlder {
 		return true
 	}
 
@@ -366,15 +369,15 @@ func (p *ProspectorLog) isIgnoreOlder(state file.State) bool {
 }
 
 // isCleanInactive checks if the given state false under clean_inactive
-func (p *ProspectorLog) isCleanInactive(state file.State) bool {
+func (l *Log) isCleanInactive(state file.State) bool {
 
 	// clean_inactive is disable
-	if p.config.CleanInactive <= 0 {
+	if l.config.CleanInactive <= 0 {
 		return false
 	}
 
 	modTime := state.Fileinfo.ModTime()
-	if time.Since(modTime) > p.config.CleanInactive {
+	if time.Since(modTime) > l.config.CleanInactive {
 		return true
 	}
 

--- a/filebeat/prospector/prospector_log_other_test.go
+++ b/filebeat/prospector/prospector_log_other_test.go
@@ -60,14 +60,14 @@ func TestMatchFile(t *testing.T) {
 
 	for _, test := range matchTests {
 
-		p := ProspectorLog{
+		l := Log{
 			config: prospectorConfig{
 				Paths:        test.paths,
 				ExcludeFiles: test.excludeFiles,
 			},
 		}
 
-		assert.Equal(t, test.result, p.matchesFile(test.file))
+		assert.Equal(t, test.result, l.matchesFile(test.file))
 	}
 }
 
@@ -129,7 +129,7 @@ var initStateTests = []struct {
 func TestInit(t *testing.T) {
 
 	for _, test := range initStateTests {
-		p := ProspectorLog{
+		l := Log{
 			Prospector: &Prospector{
 				states: &file.States{},
 				outlet: TestOutlet{},
@@ -145,9 +145,9 @@ func TestInit(t *testing.T) {
 			test.states[i] = state
 		}
 		states.SetStates(test.states)
-		err := p.LoadStates(states.GetStates())
+		err := l.LoadStates(states.GetStates())
 		assert.NoError(t, err)
-		assert.Equal(t, test.count, p.Prospector.states.Count())
+		assert.Equal(t, test.count, l.Prospector.states.Count())
 	}
 
 }

--- a/filebeat/prospector/prospector_log_test.go
+++ b/filebeat/prospector/prospector_log_test.go
@@ -37,7 +37,7 @@ func TestIsCleanInactive(t *testing.T) {
 
 	for _, test := range cleanInactiveTests {
 
-		prospector := ProspectorLog{
+		l := Log{
 			config: prospectorConfig{
 				CleanInactive: test.cleanInactive,
 			},
@@ -48,7 +48,7 @@ func TestIsCleanInactive(t *testing.T) {
 			},
 		}
 
-		assert.Equal(t, test.result, prospector.isCleanInactive(state))
+		assert.Equal(t, test.result, l.isCleanInactive(state))
 	}
 }
 

--- a/filebeat/prospector/prospector_log_windows_test.go
+++ b/filebeat/prospector/prospector_log_windows_test.go
@@ -59,13 +59,13 @@ func TestMatchFileWindows(t *testing.T) {
 
 	for _, test := range matchTestsWindows {
 
-		p := ProspectorLog{
+		l := Log{
 			config: prospectorConfig{
 				Paths:        test.paths,
 				ExcludeFiles: test.excludeFiles,
 			},
 		}
 
-		assert.Equal(t, test.result, p.matchesFile(test.file))
+		assert.Equal(t, test.result, l.matchesFile(test.file))
 	}
 }

--- a/filebeat/prospector/prospector_stdin.go
+++ b/filebeat/prospector/prospector_stdin.go
@@ -8,16 +8,17 @@ import (
 	"github.com/elastic/beats/libbeat/logp"
 )
 
-type ProspectorStdin struct {
+// Stdin is a prospector for stdin
+type Stdin struct {
 	harvester *harvester.Harvester
 	started   bool
 }
 
-// NewProspectorStdin creates a new stdin prospector
+// NewStdin creates a new stdin prospector
 // This prospector contains one harvester which is reading from stdin
-func NewProspectorStdin(p *Prospector) (*ProspectorStdin, error) {
+func NewStdin(p *Prospector) (*Stdin, error) {
 
-	prospectorer := &ProspectorStdin{
+	prospectorer := &Stdin{
 		started: false,
 	}
 
@@ -31,20 +32,22 @@ func NewProspectorStdin(p *Prospector) (*ProspectorStdin, error) {
 	return prospectorer, nil
 }
 
-func (p *ProspectorStdin) LoadStates(states []file.State) error {
+// LoadStates loads the states
+func (s *Stdin) LoadStates(states []file.State) error {
 	return nil
 }
 
-func (p *ProspectorStdin) Run() {
+// Run runs the prospector
+func (s *Stdin) Run() {
 
 	// Make sure stdin harvester is only started once
-	if !p.started {
-		reader, err := p.harvester.Setup()
+	if !s.started {
+		reader, err := s.harvester.Setup()
 		if err != nil {
 			logp.Err("Error starting stdin harvester: %s", err)
 			return
 		}
-		go p.harvester.Harvest(reader)
-		p.started = true
+		go s.harvester.Harvest(reader)
+		s.started = true
 	}
 }

--- a/filebeat/prospector/prospector_test.go
+++ b/filebeat/prospector/prospector_test.go
@@ -32,9 +32,9 @@ func TestProspectorFileExclude(t *testing.T) {
 		},
 	}
 
-	p, err := NewProspectorLog(&prospector)
+	l, err := NewLog(&prospector)
 	assert.NoError(t, err)
 
-	assert.True(t, p.isFileExcluded("/tmp/log/logw.gz"))
-	assert.False(t, p.isFileExcluded("/tmp/log/logw.log"))
+	assert.True(t, l.isFileExcluded("/tmp/log/logw.gz"))
+	assert.False(t, l.isFileExcluded("/tmp/log/logw.log"))
 }


### PR DESCRIPTION
The somewhat bigger change was renaming some of the public structs so the names would make sense with the `prospector.` package qualifier.