### PR TITLE
Added new response validator to check body contains a string

### DIFF
--- a/heartbeat/_meta/beat.full.yml
+++ b/heartbeat/_meta/beat.full.yml
@@ -189,6 +189,9 @@ heartbeat.monitors:
     # Required response contents.
     #body:
 
+    # Required response contents must contain value.
+    #body_contains:
+
 heartbeat.scheduler:
   # Limit number of concurrent tasks executed by heartbeat. The task limit if
   # disabled if set to 0. The default is 0.

--- a/heartbeat/heartbeat.full.yml
+++ b/heartbeat/heartbeat.full.yml
@@ -189,6 +189,9 @@ heartbeat.monitors:
     # Required response contents.
     #body:
 
+    # Required response contents must contain value.
+    #body_contains:
+
 heartbeat.scheduler:
   # Limit number of concurrent tasks executed by heartbeat. The task limit if
   # disabled if set to 0. The default is 0.

--- a/heartbeat/monitors/active/http/check.go
+++ b/heartbeat/monitors/active/http/check.go
@@ -32,6 +32,10 @@ func makeValidateResponse(config *responseParameters) RespCheck {
 		checks = append(checks, checkBody([]byte(config.RecvBody)))
 	}
 
+	if len(config.RecvBodyContains) > 0 {
+		checks = append(checks, checkBodyContains([]byte(config.RecvBodyContains)))
+	}
+
 	return checkAll(checks...)
 }
 
@@ -94,6 +98,20 @@ func checkBody(body []byte) RespCheck {
 		}
 
 		if !bytes.Equal(body, content) {
+			return errBodyMismatch
+		}
+		return nil
+	}
+}
+
+func checkBodyContains(bodyContains []byte) RespCheck {
+	return func(r *http.Response) error {
+		body, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			return err
+		}
+
+		if !bytes.Contains(body, bodyContains) {
 			return errBodyMismatch
 		}
 		return nil

--- a/heartbeat/monitors/active/http/config.go
+++ b/heartbeat/monitors/active/http/config.go
@@ -50,9 +50,10 @@ type requestParameters struct {
 
 type responseParameters struct {
 	// expected HTTP response configuration
-	Status      uint16            `config:"status" verify:"min=0, max=699"`
-	RecvHeaders map[string]string `config:"headers"`
-	RecvBody    string            `config:"body"`
+	Status      		uint16            `config:"status" verify:"min=0, max=699"`
+	RecvHeaders 		map[string]string `config:"headers"`
+	RecvBody    		string            `config:"body"`
+	RecvBodyContains	string		  `config:"body_contains"`
 }
 
 type compressionConfig struct {
@@ -72,9 +73,10 @@ var defaultConfig = Config{
 			SendBody:    "",
 		},
 		Response: responseParameters{
-			Status:      0,
-			RecvHeaders: nil,
-			RecvBody:    "",
+			Status:           0,
+			RecvHeaders:      nil,
+			RecvBody:         "",
+			RecvBodyContains: "",
 		},
 	},
 }

--- a/heartbeat/monitors/active/http/config.go
+++ b/heartbeat/monitors/active/http/config.go
@@ -50,10 +50,10 @@ type requestParameters struct {
 
 type responseParameters struct {
 	// expected HTTP response configuration
-	Status      		uint16            `config:"status" verify:"min=0, max=699"`
-	RecvHeaders 		map[string]string `config:"headers"`
-	RecvBody    		string            `config:"body"`
-	RecvBodyContains	string		  `config:"body_contains"`
+	Status           uint16            `config:"status" verify:"min=0, max=699"`
+	RecvHeaders      map[string]string `config:"headers"`
+	RecvBody         string            `config:"body"`
+	RecvBodyContains string            `config:"body_contains"`
 }
 
 type compressionConfig struct {


### PR DESCRIPTION
Needed a validator to check if a string matches within the body of the response. Useful in the case of large responses or inconsistent white spacing.