### PR TITLE
Print error when downloading dashboards

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -42,6 +42,7 @@ https://github.com/elastic/beats/compare/v5.1.1...master[Check the HEAD diff]
 
 - Add `_id`, `_type`, `_index` and `_score` fields in the generated index pattern. {pull}3282[3282]
 - Fix potential elasticsearch output URL parsing error if protocol scheme is missing. {pull}3671[3671]
+- Improve error message when downloading the dashboards fails. {pull}3805[3805]
 
 *Filebeat*
 - Always use absolute path for event and registry. {pull}3328[3328]

--- a/libbeat/dashboards/importer.go
+++ b/libbeat/dashboards/importer.go
@@ -404,12 +404,12 @@ func (imp Importer) ImportArchive() error {
 		url := imp.cfg.SnapshotURL
 		archive, err = imp.downloadFile(url, target)
 		if err != nil {
-			return fmt.Errorf("Failed to download snapshot file: %s", url)
+			return fmt.Errorf("Failed to download snapshot file: %s. Error: %v", url, err)
 		}
 	} else if imp.cfg.URL != "" {
 		archive, err = imp.downloadFile(imp.cfg.URL, target)
 		if err != nil {
-			return fmt.Errorf("Failed to download file: %s", imp.cfg.URL)
+			return fmt.Errorf("Failed to download file: %s. Error: %v", imp.cfg.URL, err)
 		}
 	} else {
 		return errors.New("No archive file or URL is set - please use -file or -url option")


### PR DESCRIPTION
An error was printed, but not what it was, and there can be two main
causes:
 * the download itself failed
 * the creation of the file on disk failed