### PR TITLE
Introduce logp.Deprecate to be used for deprecation

### DIFF
--- a/libbeat/logp/log.go
+++ b/libbeat/logp/log.go
@@ -132,6 +132,13 @@ func Critical(format string, v ...interface{}) {
 	msg(LOG_CRIT, "CRIT ", format, v...)
 }
 
+// Deprecate logs a deprecation message
+// The version string contains the version when the future willb e removed
+func Deprecate(version string, format string, v ...interface{}) {
+	postfix := fmt.Sprintf(" Will be removed in version: %s", version)
+	msg(LOG_WARNING, "WARN DEPRECATED: ", format+postfix, v...)
+}
+
 // WTF prints the message at CRIT level and panics immediately with the same
 // message
 func WTF(format string, v ...interface{}) {

--- a/packetbeat/protos/protos.go
+++ b/packetbeat/protos/protos.go
@@ -92,7 +92,7 @@ func (s ProtocolsStruct) Init(
 	listConfigs []*common.Config,
 ) error {
 	if len(configs) > 0 {
-		logp.Warn("Deprecated: dictionary style protocols configuration has been deprecated. Please use list-style protocols configuration.")
+		logp.Deprecate("7.0.0", "dictionary style protocols configuration has been deprecated. Please use list-style protocols configuration.")
 	}
 
 	for proto := range protocolSyms {


### PR DESCRIPTION
This changes makes it possible on how to log deprecated feature in a standardised way. In addition it will potentially allow to write deprecation messages to a separate log file.

The version number when the feature will be removed is required. This makes it clear to the user when to expect removal and makes it easy to search for features which hshould be removed for a release.

All deprecation logs should be migrated in a future PR. Only one line was change as example and for testing.