### PR TITLE
Cherry-pick to 5.3: Make some Apache server status fields optional

### DIFF
--- a/metricbeat/module/apache/status/data.go
+++ b/metricbeat/module/apache/status/data.go
@@ -38,17 +38,17 @@ var (
 			"children_system": c.Float("CPUChildrenSystem"),
 		},
 		"connections": s.Object{
-			"total": c.Int("ConnsTotal"),
+			"total": c.Int("ConnsTotal", s.Optional),
 			"async": s.Object{
-				"writing":    c.Int("ConnsAsyncWriting"),
-				"keep_alive": c.Int("ConnsAsyncKeepAlive"),
-				"closing":    c.Int("ConnsAsyncClosing"),
+				"writing":    c.Int("ConnsAsyncWriting", s.Optional),
+				"keep_alive": c.Int("ConnsAsyncKeepAlive", s.Optional),
+				"closing":    c.Int("ConnsAsyncClosing", s.Optional),
 			},
 		},
 		"load": s.Object{
-			"1":  c.Float("Load1"),
-			"5":  c.Float("Load5"),
-			"15": c.Float("Load15"),
+			"1":  c.Float("Load1", s.Optional),
+			"5":  c.Float("Load5", s.Optional),
+			"15": c.Float("Load15", s.Optional),
 		},
 	}
 )


### PR DESCRIPTION
As they are not reported by some systems

Backport from #3808