### PR TITLE
Add tests for different Apache status outputs

### DIFF
--- a/metricbeat/module/apache/status/_meta/test/status_apache-2.4.18-Debian
+++ b/metricbeat/module/apache/status/_meta/test/status_apache-2.4.18-Debian
@@ -1,0 +1,31 @@
+apache
+ServerVersion: Apache/2.4.18 (Unix)
+ServerMPM: event
+Server Built: Mar  2 2016 21:08:47
+CurrentTime: Thursday, 12-May-2016 20:30:25 UTC
+RestartTime: Saturday, 30-Apr-2016 23:17:22 UTC
+ParentServerConfigGeneration: 1
+ParentServerMPMGeneration: 0
+ServerUptimeSeconds: 1026782
+ServerUptime: 11 days 21 hours 13 minutes 2 seconds
+Load1: 0.02
+Load5: 0.01
+Load15: 0.05
+Total Accesses: 167
+Total kBytes: 63
+CPUUser: 14076.6
+CPUSystem: 6750.8
+CPUChildrenUser: 10.1
+CPUChildrenSystem: 11.2
+CPULoad: 2.02841
+Uptime: 1026782
+ReqPerSec: .000162644
+BytesPerSec: .0628293
+BytesPerReq: 386.299
+BusyWorkers: 1
+IdleWorkers: 99
+ConnsTotal: 6
+ConnsAsyncWriting: 1
+ConnsAsyncKeepAlive: 2
+ConnsAsyncClosing: 3
+Scoreboard: __________________________________________________________________________________W_________________............................................................................................................................................................................................................................................................................................................

--- a/metricbeat/module/apache/status/_meta/test/status_apache-2.4.23-CentOS6
+++ b/metricbeat/module/apache/status/_meta/test/status_apache-2.4.23-CentOS6
@@ -1,0 +1,43 @@
+127.0.0.1
+ServerVersion: Apache/2.4.23 (CentOS) OpenSSL/1.0.1e-fips
+ServerMPM: prefork
+Server Built: Jul 22 2016 09:11:01
+CurrentTime: Wednesday, 30-Nov-2016 05:32:43 NZDT
+RestartTime: Tuesday, 29-Nov-2016 20:41:30 NZDT
+ParentServerConfigGeneration: 1
+ParentServerMPMGeneration: 0
+ServerUptimeSeconds: 31873
+ServerUptime: 8 hours 51 minutes 13 seconds
+Load1: 0.00
+Load5: 0.01
+Load15: 0.05
+Total Accesses: 2181
+Total kBytes: 53079
+CPUUser: 8.4
+CPUSystem: 1.22
+CPUChildrenUser: 0
+CPUChildrenSystem: 0
+CPULoad: .0301823
+Uptime: 31873
+ReqPerSec: .0684278
+BytesPerSec: 1705.3
+BytesPerReq: 24921.1
+BusyWorkers: 1
+IdleWorkers: 9
+Scoreboard: .W.___....................................................................................................................................................................................................................................................
+TLSSessionCacheStatus
+CacheType: SHMCB
+CacheSharedMemory: 512000
+CacheCurrentEntries: 0
+CacheSubcaches: 32
+CacheIndexesPerSubcaches: 88
+CacheIndexUsage: 0%
+CacheUsage: 0%
+CacheStoreCount: 35
+CacheReplaceCount: 0
+CacheExpireCount: 35
+CacheDiscardCount: 0
+CacheRetrieveHitCount: 0
+CacheRetrieveMissCount: 89
+CacheRemoveHitCount: 0
+CacheRemoveMissCount: 0

--- a/metricbeat/module/apache/status/_meta/test/status_apache-2.4.24-Ubuntu-16.04
+++ b/metricbeat/module/apache/status/_meta/test/status_apache-2.4.24-Ubuntu-16.04
@@ -1,0 +1,31 @@
+localhost
+ServerVersion: Apache/2.4.25 (Ubuntu)
+ServerMPM: event
+Server Built: 2017-02-10T16:53:43
+CurrentTime: Monday, 27-Mar-2017 15:39:28 UTC
+RestartTime: Monday, 27-Mar-2017 15:38:33 UTC
+ParentServerConfigGeneration: 1
+ParentServerMPMGeneration: 0
+ServerUptimeSeconds: 55
+ServerUptime: 55 seconds
+Load1: 0.69
+Load5: 0.61
+Load15: 0.58
+Total Accesses: 18
+Total kBytes: 23
+CPUUser: 0
+CPUSystem: .01
+CPUChildrenUser: 0
+CPUChildrenSystem: 0
+CPULoad: .0181818
+Uptime: 55
+ReqPerSec: .327273
+BytesPerSec: 428.218
+BytesPerReq: 1308.44
+BusyWorkers: 1
+IdleWorkers: 49
+ConnsTotal: 0
+ConnsAsyncWriting: 0
+ConnsAsyncKeepAlive: 0
+ConnsAsyncClosing: 0
+Scoreboard: _W________________________________________________....................................................................................................

--- a/metricbeat/module/apache/status/data.go
+++ b/metricbeat/module/apache/status/data.go
@@ -54,7 +54,7 @@ var (
 )
 
 // Map body to MapStr
-func eventMapping(scanner *bufio.Scanner, hostname string) common.MapStr {
+func eventMapping(scanner *bufio.Scanner, hostname string) (common.MapStr, *s.Errors) {
 	var (
 		totalS          int
 		totalR          int
@@ -140,9 +140,9 @@ func eventMapping(scanner *bufio.Scanner, hostname string) common.MapStr {
 			"total":                  totalAll,
 		},
 	}
-	schema.ApplyTo(event, fullEvent)
+	_, err := schema.ApplyTo(event, fullEvent)
 
-	return event
+	return event, err
 }
 
 /*

--- a/metricbeat/module/apache/status/status.go
+++ b/metricbeat/module/apache/status/status.go
@@ -61,5 +61,6 @@ func (m *MetricSet) Fetch() (common.MapStr, error) {
 		return nil, err
 	}
 
-	return eventMapping(scanner, m.Host()), nil
+	data, _ := eventMapping(scanner, m.Host())
+	return data, nil
 }

--- a/metricbeat/module/apache/status/status_test.go
+++ b/metricbeat/module/apache/status/status_test.go
@@ -3,9 +3,12 @@
 package status
 
 import (
+	"bufio"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -219,5 +222,20 @@ func TestHostParser(t *testing.T) {
 		} else if assert.NoError(t, err, "unexpected error") {
 			assert.Equal(t, test.url, hostData.URI)
 		}
+	}
+}
+
+// Test event mapping for different apache status outputs
+func TestStatusOutputs(t *testing.T) {
+	files, err := filepath.Glob("./_meta/test/status_*")
+	assert.NoError(t, err)
+
+	for _, filename := range files {
+		f, err := os.Open(filename)
+		assert.NoError(t, err, "cannot open test file "+filename)
+		scanner := bufio.NewScanner(f)
+
+		_, errors := eventMapping(scanner, "localhost")
+		assert.False(t, errors.HasRequiredErrors(), "error mapping "+filename)
 	}
 }


### PR DESCRIPTION
This unit tests output mapping from different Apache2 version (and underlying systems). Related to #3808 