### PR TITLE
Cherrypick doc changes into 5.3

### DIFF
--- a/filebeat/docs/faq.asciidoc
+++ b/filebeat/docs/faq.asciidoc
@@ -33,7 +33,7 @@ it's publishing events successfully:
 
 [float]
 [[open-file-handlers]]
-== Too many open file handlers?
+=== Too many open file handlers?
 
 Filebeat keeps the file handler open in case it reaches the end of a file so that it can read new log lines in near real time. If Filebeat is harvesting a large number of files, the number of open files can become an issue. In most environments, the number of files that are actively updated is low. The `close_inactive` configuration option should be set accordingly to close files that are no longer active.
 

--- a/filebeat/docs/getting-started.asciidoc
+++ b/filebeat/docs/getting-started.asciidoc
@@ -153,14 +153,32 @@ See our https://www.elastic.co/downloads/beats/filebeat[download page] for other
 [[deb]]
 *deb:*
 
+ifeval::["{release-state}"=="unreleased"]
+
+Version {version} of {beatname_uc} has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
+
 ["source","sh",subs="attributes,callouts"]
 ------------------------------------------------
 curl -L -O https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-{version}-amd64.deb
 sudo dpkg -i filebeat-{version}-amd64.deb
 ------------------------------------------------
 
+endif::[]
+
 [[rpm]]
 *rpm:*
+
+ifeval::["{release-state}"=="unreleased"]
+
+Version {version} of {beatname_uc} has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
 
 ["source","sh",subs="attributes,callouts"]
 ------------------------------------------------
@@ -168,8 +186,18 @@ curl -L -O https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-{versi
 sudo rpm -vi filebeat-{version}-x86_64.rpm
 ------------------------------------------------
 
+endif::[]
+
 [[mac]]
 *mac:*
+
+ifeval::["{release-state}"=="unreleased"]
+
+Version {version} of {beatname_uc} has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
 
 ["source","sh",subs="attributes,callouts"]
 ------------------------------------------------
@@ -177,8 +205,18 @@ curl -L -O https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-{versi
 tar xzvf filebeat-{version}-darwin-x86_64.tar.gz
 ------------------------------------------------
 
+endif::[]
+
 [[win]]
 *win:*
+
+ifeval::["{release-state}"=="unreleased"]
+
+Version {version} of {beatname_uc} has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
 
 . Download the Filebeat Windows zip file from the
 https://www.elastic.co/downloads/beats/filebeat[downloads page].
@@ -198,6 +236,8 @@ PS C:\Program Files\Filebeat> .\install-service-filebeat.ps1
 ----------------------------------------------------------------------
 
 NOTE: If script execution is disabled on your system, you need to set the execution policy for the current session to allow the script to run. For example: `PowerShell.exe -ExecutionPolicy UnRestricted -File .\install-service-filebeat.ps1`.
+
+endif::[]
 
 If you're using modules to get started with Filebeat, go back to the
 <<filebeat-modules-quickstart>> page.

--- a/heartbeat/docs/getting-started.asciidoc
+++ b/heartbeat/docs/getting-started.asciidoc
@@ -47,14 +47,32 @@ See our https://www.elastic.co/downloads/beats/heartbeat[download page] for othe
 [[deb]]
 *deb:*
 
+ifeval::["{release-state}"=="unreleased"]
+
+Version {version} of {beatname_uc} has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
+
 ["source","sh",subs="attributes"]
 ----------------------------------------------------------------------
 curl -L -O {downloads}/heartbeat/heartbeat-{version}-amd64.deb
 sudo dpkg -i heartbeat-{version}-amd64.deb
 ----------------------------------------------------------------------
 
+endif::[]
+
 [[rpm]]
 *rpm:*
+
+ifeval::["{release-state}"=="unreleased"]
+
+Version {version} of {beatname_uc} has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
 
 ["source","sh",subs="attributes"]
 ----------------------------------------------------------------------
@@ -62,8 +80,18 @@ curl -L -O {downloads}/heartbeat/heartbeat-{version}-x86_64.rpm
 sudo rpm -vi heartbeat-{version}-x86_64.rpm
 ----------------------------------------------------------------------
 
+endif::[]
+
 [[mac]]
 *mac:*
+
+ifeval::["{release-state}"=="unreleased"]
+
+Version {version} of {beatname_uc} has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
 
 ["source","sh",subs="attributes"]
 ------------------------------------------------
@@ -71,8 +99,18 @@ curl -L -O {downloads}/heartbeat/heartbeat-{version}-darwin-x86_64.tar.gz
 tar xzvf heartbeat-{version}-darwin-x86_64.tar.gz
 ------------------------------------------------
 
+endif::[]
+
 [[win]]
 *win:*
+
+ifeval::["{release-state}"=="unreleased"]
+
+Version {version} of {beatname_uc} has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
 
 . Download the Heartbeat Windows zip file from the
 https://www.elastic.co/downloads/beats/heartbeat[downloads page].
@@ -97,6 +135,8 @@ NOTE: If script execution is disabled on your system, you need to set the
 execution policy for the current session to allow the script to run. For
 example:
 +PowerShell.exe -ExecutionPolicy UnRestricted -File .\install-service-heartbeat.ps1+.
+
+endif::[]
 
 Before starting Heartbeat, you should look at the configuration options in
 the configuration file, for example +C:\Program Files\Heartbeat\heartbeat.yml+

--- a/libbeat/docs/config-file-format.asciidoc
+++ b/libbeat/docs/config-file-format.asciidoc
@@ -199,8 +199,8 @@ field references `[fieldname]`. Optional default values can be specified in case
 field name is missing from the event.
 
 You can also format time stored in the
-`@timestamp` field using the `+FORMAT` syntax where FORMAT is a valid (time
-format)[https://godoc.org/github.com/elastic/beats/libbeat/common/dtfmt].
+`@timestamp` field using the `+FORMAT` syntax where FORMAT is a valid https://godoc.org/github.com/elastic/beats/libbeat/common/dtfmt[time
+format].
 
 ["source","yaml",subs="attributes"]
 ------------------------------------------------------------------------------

--- a/libbeat/docs/gettingstarted.asciidoc
+++ b/libbeat/docs/gettingstarted.asciidoc
@@ -39,6 +39,14 @@ mac>> for OS X, and <<win, win>> for Windows):
 
 [[deb]]*deb:*
 
+ifeval::["{release-state}"=="unreleased"]
+
+Version {stack-version} of Elasticsearch has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
+
 ["source","sh",subs="attributes,callouts"]
 ----------------------------------------------------------------------
 sudo apt-get install openjdk-8-jre
@@ -47,7 +55,17 @@ sudo dpkg -i elasticsearch-{ES-version}.deb
 sudo /etc/init.d/elasticsearch start
 ----------------------------------------------------------------------
 
+endif::[]
+
 [[rpm]]*rpm:*
+
+ifeval::["{release-state}"=="unreleased"]
+
+Version {stack-version} of Elasticsearch has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
 
 ["source","sh",subs="attributes,callouts"]
 ----------------------------------------------------------------------
@@ -57,7 +75,17 @@ sudo rpm -i elasticsearch-{ES-version}.rpm
 sudo service elasticsearch start
 ----------------------------------------------------------------------
 
+endif::[]
+
 [[mac]]*mac:*
+
+ifeval::["{release-state}"=="unreleased"]
+
+Version {stack-version} of Elasticsearch has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
 
 ["source","sh",subs="attributes,callouts"]
 ----------------------------------------------------------------------
@@ -68,7 +96,17 @@ cd elasticsearch-{ES-version}
 ./bin/elasticsearch
 ----------------------------------------------------------------------
 
+endif::[]
+
 [[win]]*win:*
+
+ifeval::["{release-state}"=="unreleased"]
+
+Version {stack-version} of Elasticsearch has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
 
 . If necessary, download and install the latest version of the Java from https://www.java.com[www.java.com].
 
@@ -90,6 +128,8 @@ cd C:\Program Files\elasticsearch-{ES-version}
 ----------------------------------------------------------------------
 bin\elasticsearch.bat
 ----------------------------------------------------------------------
+
+endif::[]
 
 You can learn more about installing, configuring, and running Elasticsearch in the
 https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html[Elasticsearch Reference].
@@ -147,6 +187,14 @@ with your system:
 
 *deb:*
 
+ifeval::["{release-state}"=="unreleased"]
+
+Version {stack-version} of Logstash has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
+
 ["source","sh",subs="attributes,callouts"]
 ----------------------------------------------------------------------
 sudo apt-get install openjdk-8-jre
@@ -154,7 +202,17 @@ curl -L -O https://artifacts.elastic.co/downloads/logstash/logstash-{LS-version}
 sudo dpkg -i logstash-{LS-version}.deb
 ----------------------------------------------------------------------
 
+endif::[]
+
 *rpm:*
+
+ifeval::["{release-state}"=="unreleased"]
+
+Version {stack-version} of Logstash has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
 
 ["source","sh",subs="attributes,callouts"]
 ----------------------------------------------------------------------
@@ -163,7 +221,17 @@ curl -L -O https://artifacts.elastic.co/downloads/logstash/logstash-{LS-version}
 sudo rpm -i logstash-{LS-version}.rpm
 ----------------------------------------------------------------------
 
+endif::[]
+
 *mac:*
+
+ifeval::["{release-state}"=="unreleased"]
+
+Version {stack-version} of Logstash has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
 
 ["source","sh",subs="attributes,callouts"]
 ----------------------------------------------------------------------
@@ -172,7 +240,17 @@ curl -L -O https://artifacts.elastic.co/downloads/logstash/logstash-{LS-version}
 unzip logstash-{LS-version}.zip
 ----------------------------------------------------------------------
 
+endif::[]
+
 *win:*
+
+ifeval::["{release-state}"=="unreleased"]
+
+Version {stack-version} of Logstash has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
 
 . If necessary, download and install the latest version of the Java from https://www.java.com[www.java.com].
 
@@ -182,6 +260,8 @@ https://www.elastic.co/downloads/logstash[downloads page].
 . Extract the contents of the zip file to a directory on your computer, for example, `C:\Program Files`.
 
 Don't start Logstash yet. You need to set a couple of configuration options first.
+
+endif::[]
 
 [[logstash-setup]]
 ==== Setting Up Logstash
@@ -334,6 +414,14 @@ Use the following commands to download and run Kibana.
 
 *deb or rpm:*
 
+ifeval::["{release-state}"=="unreleased"]
+
+Version {stack-version} of Kibana has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
+
 ["source","sh",subs="attributes,callouts"]
 ----------------------------------------------------------------------
 curl -L -O https://artifacts.elastic.co/downloads/kibana/kibana-{Kibana-version}-linux-x86_64.tar.gz
@@ -342,7 +430,17 @@ cd kibana-{Kibana-version}-linux-x86_64/
 ./bin/kibana
 ----------------------------------------------------------------------
 
+endif::[]
+
 *mac:*
+
+ifeval::["{release-state}"=="unreleased"]
+
+Version {stack-version} of Kibana has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
 
 ["source","sh",subs="attributes,callouts"]
 ----------------------------------------------------------------------
@@ -352,7 +450,17 @@ cd kibana-{Kibana-version}-darwin-x86_64/
 ./bin/kibana
 ----------------------------------------------------------------------
 
+endif::[]
+
 *win:*
+
+ifeval::["{release-state}"=="unreleased"]
+
+Version {stack-version} of Kibana has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
 
 . Download the Kibana {Kibana-version} Windows zip file from the
 https://www.elastic.co/downloads/kibana[downloads page].
@@ -373,6 +481,8 @@ cd C:\Program Files\kibana-{Kibana-version}-windows
 ----------------------------------------------------------------------
 bin\kibana.bat
 ----------------------------------------------------------------------
+
+endif::[]
 
 You can find Kibana binaries for other operating systems on the
 https://www.elastic.co/downloads/kibana[Kibana downloads page].

--- a/libbeat/docs/repositories.asciidoc
+++ b/libbeat/docs/repositories.asciidoc
@@ -25,6 +25,14 @@ to sign all our packages. It is available from https://pgp.mit.edu.
 [float]
 ==== APT
 
+ifeval::["{release-state}"=="unreleased"]
+
+Version {stack-version} of Beats has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
+
 To add the Beats repository for APT:
 
 . Download and install the Public Signing Key:
@@ -77,8 +85,18 @@ sudo apt-get update && sudo apt-get install {beatname_lc}
 sudo update-rc.d {beatname_lc} defaults 95 10
 --------------------------------------------------
 
+endif::[]
+
 [float]
 ==== YUM
+
+ifeval::["{release-state}"=="unreleased"]
+
+Version {stack-version} of Beats has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
 
 To add the Beats repository for YUM:
 
@@ -118,3 +136,6 @@ sudo yum install {beatname_lc}
 --------------------------------------------------
 sudo chkconfig --add {beatname_lc}
 --------------------------------------------------
+
+endif::[]
+

--- a/libbeat/docs/version.asciidoc
+++ b/libbeat/docs/version.asciidoc
@@ -1,3 +1,8 @@
 :stack-version: 5.3.0
 :doc-branch: 5.3
 :go-version: 1.7.4
+
+//////////
+release-state can be: released | prerelease | unreleased
+//////////
+:release-state: unreleased

--- a/libbeat/docs/version.asciidoc
+++ b/libbeat/docs/version.asciidoc
@@ -5,4 +5,4 @@
 //////////
 release-state can be: released | prerelease | unreleased
 //////////
-:release-state: unreleased
+:release-state: released

--- a/metricbeat/docs/gettingstarted.asciidoc
+++ b/metricbeat/docs/gettingstarted.asciidoc
@@ -51,14 +51,32 @@ other installation options, such as 32-bit images.
 [[deb]]
 *deb:*
 
+ifeval::["{release-state}"=="unreleased"]
+
+Version {stack-version} of {beatname_uc} has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
+
 ["source","sh",subs="attributes,callouts"]
 ------------------------------------------------
 curl -L -O https://artifacts.elastic.co/downloads/beats/metricbeat/metricbeat-{version}-amd64.deb
 sudo dpkg -i metricbeat-{version}-amd64.deb
 ------------------------------------------------
 
+endif::[]
+
 [[rpm]]
 *rpm:*
+
+ifeval::["{release-state}"=="unreleased"]
+
+Version {stack-version} of {beatname_uc} has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
 
 ["source","sh",subs="attributes,callouts"]
 ------------------------------------------------
@@ -66,8 +84,18 @@ curl -L -O https://artifacts.elastic.co/downloads/beats/metricbeat/metricbeat-{v
 sudo rpm -vi metricbeat-{version}-x86_64.rpm
 ------------------------------------------------
 
+endif::[]
+
 [[mac]]
 *mac:*
+
+ifeval::["{release-state}"=="unreleased"]
+
+Version {stack-version} of {beatname_uc} has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
 
 ["source","sh",subs="attributes,callouts"]
 ------------------------------------------------
@@ -75,8 +103,18 @@ curl -L -O https://artifacts.elastic.co/downloads/beats/metricbeat/metricbeat-{v
 tar xzvf metricbeat-{version}-darwin-x86_64.tar.gz
 ------------------------------------------------
 
+endif::[]
+
 [[win]]
 *win:*
+
+ifeval::["{release-state}"=="unreleased"]
+
+Version {stack-version} of {beatname_uc} has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
 
 . Download the Metricbeat Windows zip file from the
 https://www.elastic.co/downloads/beats/metricbeat[downloads page].
@@ -101,6 +139,8 @@ NOTE: If script execution is disabled on your system, you need to set the
 execution policy for the current session to allow the script to run. For
 example: `PowerShell.exe -ExecutionPolicy UnRestricted -File
 .\install-service-metricbeat.ps1`.
+
+endif::[]
 
 Before starting Metricbeat, you should look at the configuration options in the
 configuration file, for example `C:\Program Files\Metricbeat\metricbeat.yml`.

--- a/packetbeat/docs/gettingstarted.asciidoc
+++ b/packetbeat/docs/gettingstarted.asciidoc
@@ -39,6 +39,14 @@ See our https://www.elastic.co/downloads/beats/packetbeat[download page] for oth
 [[deb]]
 *deb:*
 
+ifeval::["{release-state}"=="unreleased"]
+
+Version {stack-version} of {beatname_uc} has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
+
 ["source","sh",subs="attributes,callouts"]
 ----------------------------------------------------------------------
 sudo apt-get install libpcap0.8
@@ -46,8 +54,18 @@ curl -L -O https://artifacts.elastic.co/downloads/beats/packetbeat/packetbeat-{v
 sudo dpkg -i packetbeat-{version}-amd64.deb
 ----------------------------------------------------------------------
 
+endif::[]
+
 [[rpm]]
 *rpm:*
+
+ifeval::["{release-state}"=="unreleased"]
+
+Version {stack-version} of {beatname_uc} has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
 
 ["source","sh",subs="attributes,callouts"]
 ----------------------------------------------------------------------
@@ -56,8 +74,18 @@ curl -L -O https://artifacts.elastic.co/downloads/beats/packetbeat/packetbeat-{v
 sudo rpm -vi packetbeat-{version}-x86_64.rpm
 ----------------------------------------------------------------------
 
+endif::[]
+
 [[mac]]
 *mac:*
+
+ifeval::["{release-state}"=="unreleased"]
+
+Version {stack-version} of {beatname_uc} has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
 
 ["source","sh",subs="attributes,callouts"]
 ----------------------------------------------------------------------
@@ -65,8 +93,18 @@ curl -L -O https://artifacts.elastic.co/downloads/beats/packetbeat/packetbeat-{v
 tar xzvf packetbeat-{version}-darwin-x86_64.tar.gz
 ----------------------------------------------------------------------
 
+endif::[]
+
 [[win]]
 *win:*
+
+ifeval::["{release-state}"=="unreleased"]
+
+Version {stack-version} of {beatname_uc} has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
 
 . Download and install WinPcap from this
 http://www.winpcap.org/install/default.htm[page]. WinPcap is a library that uses
@@ -90,6 +128,8 @@ PS C:\Program Files\Packetbeat> .\install-service-packetbeat.ps1
 ----------------------------------------------------------------------
 
 NOTE: If script execution is disabled on your system, you need to set the execution policy for the current session to allow the script to run. For example: `PowerShell.exe -ExecutionPolicy UnRestricted -File .\install-service-packetbeat.ps1`.
+
+endif::[]
 
 Before starting Packetbeat, you should look at the configuration options in the
 configuration file, for example `C:\Program Files\Packetbeat\packetbeat.yml` or `/etc/packetbeat/packetbeat.yml`. For


### PR DESCRIPTION
Cherry-picks #3803 into 5.3

@tsg Since we are so close, I set `release-state `to `released`, so you don't have to worry about that for 5.3.