### PR TITLE
Add link to topic about config file format

### DIFF
--- a/filebeat/docs/configuring-howto.asciidoc
+++ b/filebeat/docs/configuring-howto.asciidoc
@@ -11,6 +11,10 @@ To configure {beatname_uc}, you edit the configuration file. For rpm and deb, yo
 +/etc/{beatname_lc}/{beatname_lc}.yml+. There's also a full example configuration file at
 +/etc/{beatname_lc}/{beatname_lc}.full.yml+ that shows all non-deprecated options.  For mac and win, look in the archive that you extracted.
 
+See the
+{libbeat}/config-file-format.html[Config File Format] section of the
+_Beats Platform Reference_ for more about the structure of the config file.
+
 The following topics describe how to configure Filebeat:
 
 * <<filebeat-configuration-details>>

--- a/filebeat/docs/getting-started.asciidoc
+++ b/filebeat/docs/getting-started.asciidoc
@@ -260,6 +260,10 @@ find the configuration file at `/etc/filebeat/filebeat.yml`. For mac and win, lo
 the archive that you just extracted. There’s also a full example configuration file
 called `filebeat.full.yml` that shows all non-deprecated options.
 
+See the
+{libbeat}/config-file-format.html[Config File Format] section of the
+_Beats Platform Reference_ for more about the structure of the config file.
+
 Here is a sample of the `filebeat` section of the `filebeat.yml` file. Filebeat uses predefined
 default values for most configuration options.
 

--- a/filebeat/docs/reference/configuration.asciidoc
+++ b/filebeat/docs/reference/configuration.asciidoc
@@ -5,7 +5,10 @@
 Before modifying configuration settings, make sure you've completed the
 <<filebeat-configuration,configuration steps>> in the Getting Started.
 
-The {beatname_uc} configuration file, +{beatname_lc}.yml+, uses http://yaml.org/[YAML] for its syntax.
+The {beatname_uc} configuration file, +{beatname_lc}.yml+, uses http://yaml.org/[YAML] for its syntax.  See the
+{libbeat}/config-file-format.html[Config File Format] section of the
+_Beats Platform Reference_ for more about the structure of the config file.
+
 The configuration options are described in the following sections. After changing
 configuration settings, you need to restart {beatname_uc} to pick up the changes.
 

--- a/heartbeat/docs/configuring-howto.asciidoc
+++ b/heartbeat/docs/configuring-howto.asciidoc
@@ -14,6 +14,10 @@ configuration file at +/etc/heartbeat/heartbeat.full.yml+ that shows
 all non-deprecated options. For mac and win, look in the archive that you
 extracted.
 
+See the
+{libbeat}/config-file-format.html[Config File Format] section of the
+_Beats Platform Reference_ for more about the structure of the config file.
+
 The following topics describe how to configure Heartbeat:
 
 * <<heartbeat-configuration-details>>

--- a/heartbeat/docs/getting-started.asciidoc
+++ b/heartbeat/docs/getting-started.asciidoc
@@ -152,6 +152,10 @@ For mac and win, look in the archive that you just extracted. There’s also a
 full example configuration file called `heartbeat.full.yml` that shows all
 non-deprecated options.
 
+See the
+{libbeat}/config-file-format.html[Config File Format] section of the
+_Beats Platform Reference_ for more about the structure of the config file.
+
 Heartbeat provides monitors to check the status of hosts at set intervals.
 You configure each monitor individually. Heartbeat currently provides monitors
 for ICMP, TCP, and HTTP (see <<heartbeat-overview>> for more about these

--- a/heartbeat/docs/reference/configuration.asciidoc
+++ b/heartbeat/docs/reference/configuration.asciidoc
@@ -5,7 +5,10 @@
 Before modifying configuration settings, make sure you've completed the
 <<heartbeat-configuration,configuration steps>> in the Getting Started.
 
-The Heartbeat configuration file, +heartbeat.yml+, uses http://yaml.org/[YAML] for its syntax.
+The Heartbeat configuration file, +heartbeat.yml+, uses http://yaml.org/[YAML] for its syntax. See the
+{libbeat}/config-file-format.html[Config File Format] section of the
+_Beats Platform Reference_ for more about the structure of the config file.
+
 The configuration options are described in the following sections. After changing
 configuration settings, you need to restart Heartbeat to pick up the changes.
 

--- a/metricbeat/docs/configuring-howto.asciidoc
+++ b/metricbeat/docs/configuring-howto.asciidoc
@@ -12,6 +12,10 @@ To configure {beatname_uc}, you edit the configuration file. For rpm and deb, yo
 +/etc/{beatname_lc}/{beatname_lc}.full.yml+ that shows all non-deprecated options.
 For mac and win, look in the archive that you extracted.
 
+See the
+{libbeat}/config-file-format.html[Config File Format] section of the
+_Beats Platform Reference_ for more about the structure of the config file.
+
 The following topics describe how to configure Metricbeat:
 
 * <<metricbeat-configuration-options>>

--- a/metricbeat/docs/gettingstarted.asciidoc
+++ b/metricbeat/docs/gettingstarted.asciidoc
@@ -156,6 +156,10 @@ and win, look in the archive that you just extracted. There’s also a full
 example configuration file called `metricbeat.full.yml` that shows all
 non-deprecated options.
 
+See the
+{libbeat}/config-file-format.html[Config File Format] section of the
+_Beats Platform Reference_ for more about the structure of the config file.
+
 Metricbeat uses <<metricbeat-modules,modules>> to collect metrics. You configure
 each module individually. The following example shows the default configuration
 in the `metricbeat.yml` file. The system status module is enabled by default to

--- a/metricbeat/docs/reference/configuration.asciidoc
+++ b/metricbeat/docs/reference/configuration.asciidoc
@@ -4,7 +4,10 @@
 Before modifying configuration settings, make sure you've completed the
 <<metricbeat-configuration,configuration steps>> in the Getting Started.
 
-The {beatname_uc} configuration file, +{beatname_lc}.yml+, uses http://yaml.org/[YAML] for its syntax.
+The {beatname_uc} configuration file, +{beatname_lc}.yml+, uses http://yaml.org/[YAML] for its syntax.  See the
+{libbeat}/config-file-format.html[Config File Format] section of the
+_Beats Platform Reference_ for more about the structure of the config file.
+
 The configuration options are described in the following sections. After changing
 configuration settings, you need to restart {beatname_uc} to pick up the changes.
 

--- a/packetbeat/docs/configuring-howto.asciidoc
+++ b/packetbeat/docs/configuring-howto.asciidoc
@@ -12,6 +12,10 @@ To configure {beatname_uc}, you edit the configuration file. For rpm and deb, yo
 +/etc/{beatname_lc}/{beatname_lc}.full.yml+ that shows all non-deprecated options. For mac and win, look in the archive
 that you extracted.
 
+See the
+{libbeat}/config-file-format.html[Config File Format] section of the
+_Beats Platform Reference_ for more about the structure of the config file.
+
 The following topics describe how to configure Packetbeat:
 
 * <<packetbeat-configuration>>

--- a/packetbeat/docs/gettingstarted.asciidoc
+++ b/packetbeat/docs/gettingstarted.asciidoc
@@ -143,6 +143,10 @@ find the configuration file at `/etc/packetbeat/packetbeat.yml`. For mac and win
 the archive that you just extracted. There’s also a full example configuration file called
 `packetbeat.full.yml` that shows all non-deprecated options.
 
+See the
+{libbeat}/config-file-format.html[Config File Format] section of the
+_Beats Platform Reference_ for more about the structure of the config file.
+
 To configure Packetbeat:
 
 . Select the network interface from which to capture the traffic.

--- a/packetbeat/docs/reference/configuration.asciidoc
+++ b/packetbeat/docs/reference/configuration.asciidoc
@@ -4,7 +4,10 @@
 
 Before modifying configuration settings, make sure you've completed the <<configuring-packetbeat,configuration steps>> in the Getting Started.
 
-The {beatname_uc} configuration file, +{beatname_lc}.yml+, uses http://yaml.org/[YAML] for its syntax.
+The {beatname_uc} configuration file, +{beatname_lc}.yml+, uses http://yaml.org/[YAML] for its syntax. See the
+{libbeat}/config-file-format.html[Config File Format] section of the
+_Beats Platform Reference_ for more about the structure of the config file.
+
 The configuration options are described in the following sections. After changing
 configuration settings, you need to restart {beatname_uc} to pick up the changes.
 

--- a/winlogbeat/docs/configuring-howto.asciidoc
+++ b/winlogbeat/docs/configuring-howto.asciidoc
@@ -11,6 +11,10 @@ To configure {beatname_uc}, you edit the configuration file. You’ll find the c
 +{beatname_lc}.yml+, in the archive that you extracted. There's also a full example configuration file at
 +/etc/{beatname_lc}/{beatname_lc}.full.yml+ that shows all non-deprecated options.
 
+See the
+{libbeat}/config-file-format.html[Config File Format] section of the
+_Beats Platform Reference_ for more about the structure of the config file.
+
 The following topics describe how to configure Winlogbeat:
 
 * <<winlogbeat-configuration-details>>

--- a/winlogbeat/docs/getting-started.asciidoc
+++ b/winlogbeat/docs/getting-started.asciidoc
@@ -59,13 +59,16 @@ Before starting Winlogbeat, you should look at the configuration options in the
 configuration file, for example `C:\Program Files\Winlogbeat\winlogbeat.yml`.
 There’s also a full example configuration file called `winlogbeat.full.yml` that
 shows all non-deprecated options. For more information about these options, see
-<<winlogbeat-configuration-details>>.
+<<winlogbeat-configuration-details>>. 
 
 [[winlogbeat-configuration]]
 === Step 2: Configuring Winlogbeat
 
-To configure Winlogbeat, you edit the `winlogbeat.yml` configuration file. Here
-is a sample of the `winlogbeat.yml` file:
+To configure Winlogbeat, you edit the `winlogbeat.yml` configuration file. See the
+{libbeat}/config-file-format.html[Config File Format] section of the
+_Beats Platform Reference_ for more about the structure of the config file.
+
+Here is a sample of the `winlogbeat.yml` file:
 
 [source,yaml]
 --------------------------------------------------------------------------------

--- a/winlogbeat/docs/reference/configuration.asciidoc
+++ b/winlogbeat/docs/reference/configuration.asciidoc
@@ -5,7 +5,10 @@
 Before modifying configuration settings, make sure you've completed the
 <<winlogbeat-configuration,configuration steps>> in the Getting Started.
 
-The {beatname_uc} configuration file, +{beatname_lc}.yml+, uses http://yaml.org/[YAML] for its syntax.
+The {beatname_uc} configuration file, +{beatname_lc}.yml+, uses http://yaml.org/[YAML] for its syntax. See the
+{libbeat}/config-file-format.html[Config File Format] section of the
+_Beats Platform Reference_ for more about the structure of the config file.
+
 The configuration options are described in the following sections. After changing
 configuration settings, you need to restart {beatname_uc} to pick up the changes.
 


### PR DESCRIPTION
Resolves #3305 by adding links that point to the topic about the config file format in the Beats Platform Reference.

I'd prefer to have content about the config file format live in individual guides (like we do for other shared content) but I'm not doing that right now because I don't want the hassle for us (and users) of moving stuff around, setting up redirects, and then having to do the same thing over again when we create the _One Beats Book to Rule Them All_.

@tsg fixed this since you brought it up.