### PR TITLE
Fix packaging which broke because of asciidocs comments

### DIFF
--- a/libbeat/docs/version.asciidoc
+++ b/libbeat/docs/version.asciidoc
@@ -1,8 +1,4 @@
 :stack-version: 6.0.0-alpha1
 :doc-branch: master
 :go-version: 1.7.4
-
-//////////
-release-state can be: released | prerelease | unreleased
-//////////
 :release-state: unreleased


### PR DESCRIPTION
The version.asciidoc is used during packaging to read out the version number. Recently a comment was introduce in the file which broke the packaging. In before_build.sh the content of the file is copied over and converted to yaml, see https://github.com/elastic/beats/blob/master/dev-tools/packer/xgo-scripts/before_build.sh#L58. As these lines to not seem to be required, I removed them. Alternatively the sed script could be adapted which would be more complex.