### PR TITLE
Add workaround for Heartbeat install issue

### DIFF
--- a/libbeat/docs/repositories.asciidoc
+++ b/libbeat/docs/repositories.asciidoc
@@ -70,6 +70,21 @@ the following:
 Simply delete the `deb-src` entry from the `/etc/apt/sources.list` file, and the installation should work as expected.
 ==================================================
 
+ifeval::["{beatname_uc}"=="Heartbeat"]
+
+. On Debian or Ubuntu, pin the repository before installing to ensure that the
+correct Elastic Heartbeat package is installed. To do this, edit 
+`/etc/apt/preferences` (or `/etc/apt/preferences.d/heartbeat`) as follows:
++
+[source,shell]
+--------------------------------------------------
+Package: heartbeat
+Pin: origin artifacts.elastic.co
+Pin-Priority: 700
+--------------------------------------------------
+
+endif::[]
+
 . Run `apt-get update`, and the repository is ready for use. For example, you can
 install {beatname_uc} by running:
 +


### PR DESCRIPTION
Documents the workaround for https://github.com/elastic/beats/issues/3765

@geekpete Can you test and confirm that this is accurate?

Here's what the change looks like rendered in the Heartbeat docs:

![image](https://cloud.githubusercontent.com/assets/14206422/24432797/59a98a06-13d9-11e7-9210-190745f18f75.png)
![image](https://cloud.githubusercontent.com/assets/14206422/24432888/e1e46652-13d9-11e7-8bd5-123745adf4b4.png)

