### PR TITLE
[MetricBeat] Add possibility to add a minCpu and minMemory filter

### DIFF
--- a/metricbeat/metricbeat.full.yml
+++ b/metricbeat/metricbeat.full.yml
@@ -61,6 +61,12 @@ metricbeat.modules:
   period: 10s
   processes: ['.*']
 
+  # Min cpu percent require to send data of the process. Default : 0.
+  #minCpu: 0.0000
+
+  # Min rss memory in bytes requite to send data of the process. Default : 0.
+  #minMemory: 0
+
   # if true, exports the CPU usage in ticks, together with the percentage values
   #cpu_ticks: false
 

--- a/metricbeat/module/system/_meta/config.full.yml
+++ b/metricbeat/module/system/_meta/config.full.yml
@@ -33,6 +33,12 @@
   period: 10s
   processes: ['.*']
 
+  # Min cpu percent require to send data of the process. Default : 0.
+  #minCpu: 0.0000
+
+  # Min rss memory in bytes requite to send data of the process. Default : 0.
+  #minMemory: 0
+
   # if true, exports the CPU usage in ticks, together with the percentage values
   #cpu_ticks: false
 

--- a/metricbeat/module/system/process/helper.go
+++ b/metricbeat/module/system/process/helper.go
@@ -40,6 +40,8 @@ type ProcStats struct {
 	ProcsMap     ProcsMap
 	CpuTicks     bool
 	EnvWhitelist []string
+	MinCpu       float64
+	MinMemory    uint64
 
 	procRegexps []match.Matcher // List of regular expressions used to whitelist processes.
 	envRegexps  []match.Matcher // List of regular expressions used to whitelist env vars.
@@ -364,7 +366,12 @@ func (procStats *ProcStats) GetProcStats() ([]common.MapStr, error) {
 			last := procStats.ProcsMap[process.Pid]
 			proc := procStats.GetProcessEvent(process, last)
 
-			processes = append(processes, proc)
+			currentCpu := proc["cpu"].(common.MapStr)["total"].(common.MapStr)["pct"].(float64)
+			currentMemory := proc["memory"].(common.MapStr)["rss"].(common.MapStr)["bytes"].(uint64)
+
+			if currentCpu >= procStats.MinCpu || currentMemory >= procStats.MinMemory {
+				processes = append(processes, proc)
+			}
 		}
 	}
 

--- a/metricbeat/module/system/process/process.go
+++ b/metricbeat/module/system/process/process.go
@@ -38,6 +38,8 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 		Cgroups      *bool    `config:"process.cgroups.enabled"`
 		EnvWhitelist []string `config:"process.env.whitelist"`
 		CPUTicks     bool     `config:"cpu_ticks"`
+		MinCpu       float64  `config:"minCpu"`
+		MinMemory    uint64   `config:"minMemory"`
 	}{
 		Procs: []string{".*"}, // collect all processes by default
 	}
@@ -51,6 +53,8 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 			Procs:        config.Procs,
 			EnvWhitelist: config.EnvWhitelist,
 			CpuTicks:     config.CPUTicks,
+			MinCpu:       config.MinCpu,
+			MinMemory:    config.MinMemory,
 		},
 	}
 	err := m.stats.InitProcStats()


### PR DESCRIPTION
We had the need to monitor 5000 servers with a small cluster.
In order to limit the volume of data sent, we have set up a more dynamic filter on the process.
Process info is sent only if the cpu or rss exceeds the configured minimums.