### PR TITLE
Add Beta and Experimental logging

### DIFF
--- a/libbeat/logp/log.go
+++ b/libbeat/logp/log.go
@@ -132,11 +132,21 @@ func Critical(format string, v ...interface{}) {
 	msg(LOG_CRIT, "CRIT ", format, v...)
 }
 
-// Deprecate logs a deprecation message
-// The version string contains the version when the future willb e removed
+// Deprecate logs a deprecation message.
+// The version string contains the version when the future will be removed
 func Deprecate(version string, format string, v ...interface{}) {
 	postfix := fmt.Sprintf(" Will be removed in version: %s", version)
-	msg(LOG_WARNING, "WARN DEPRECATED: ", format+postfix, v...)
+	Warn("DEPRECATED: "+format+postfix, v...)
+}
+
+// Experimental logs the usage of an experimental feature.
+func Experimental(format string, v ...interface{}) {
+	Warn("EXPERIMENTAL: "+format, v...)
+}
+
+// Beta logs the usage of an beta feature.
+func Beta(format string, v ...interface{}) {
+	Warn("BETA: "+format, v...)
 }
 
 // WTF prints the message at CRIT level and panics immediately with the same

--- a/metricbeat/beater/metricbeat.go
+++ b/metricbeat/beater/metricbeat.go
@@ -73,7 +73,7 @@ func (bt *Metricbeat) Run(b *beat.Beat) error {
 	}
 
 	if bt.config.ReloadModules.Enabled() {
-		logp.Warn("EXPERIMENTAL feature dynamic configuration reloading is enabled.")
+		logp.Beta("feature dynamic configuration reloading is enabled.")
 		moduleReloader := cfgfile.NewReloader(bt.config.ReloadModules)
 		factory := module.NewFactory(b.Publisher)
 

--- a/metricbeat/docs/reference/configuration/reload-configuration.asciidoc
+++ b/metricbeat/docs/reference/configuration/reload-configuration.asciidoc
@@ -1,6 +1,6 @@
 === Reload Configuration
 
-experimental[]
+beta[]
 
 Reload configuration allows to dynamically reload module configuration files. A glob can be defined which should be watched
  for module configuration changes. New modules will started / stopped accordingly. This is especially useful in


### PR DESCRIPTION
These two logging methods can be used for logging beta and experimental features. This makes sure all of the features are logged the same way.

Reload Configuration was changed to beta from experimental.