### PR TITLE
Make metricbeat reloading beta instead of experimental

### DIFF
--- a/metricbeat/beater/metricbeat.go
+++ b/metricbeat/beater/metricbeat.go
@@ -73,7 +73,7 @@ func (bt *Metricbeat) Run(b *beat.Beat) error {
 	}
 
 	if bt.config.ReloadModules.Enabled() {
-		logp.Warn("EXPERIMENTAL feature dynamic configuration reloading is enabled.")
+		logp.Warn("BETA: feature dynamic configuration reloading is enabled.")
 		moduleReloader := cfgfile.NewReloader(bt.config.ReloadModules)
 		factory := module.NewFactory(b.Publisher)
 

--- a/metricbeat/docs/reference/configuration/reload-configuration.asciidoc
+++ b/metricbeat/docs/reference/configuration/reload-configuration.asciidoc
@@ -1,6 +1,6 @@
 === Reload Configuration
 
-experimental[]
+beta[]
 
 Reload configuration allows to dynamically reload module configuration files. A glob can be defined which should be watched
  for module configuration changes. New modules will started / stopped accordingly. This is especially useful in


### PR DESCRIPTION
This change was missed in 5.3.