### PR TITLE
Cherry-pick of #3805: Print error when downloading dashboards

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -111,6 +111,8 @@ https://github.com/elastic/beats/compare/v5.2.2...v5.3.0[View commits]
 *Affecting all Beats*
 
 - Add `_id`, `_type`, `_index` and `_score` fields in the generated index pattern. {pull}3282[3282]
+- Fix potential elasticsearch output URL parsing error if protocol scheme is missing. {pull}3671[3671]
+- Improve error message when downloading the dashboards fails. {pull}3805[3805]
 
 *Filebeat*
 

--- a/libbeat/dashboards/dashboards/importer.go
+++ b/libbeat/dashboards/dashboards/importer.go
@@ -404,12 +404,12 @@ func (imp Importer) ImportArchive() error {
 		url := imp.cfg.SnapshotURL
 		archive, err = imp.downloadFile(url, target)
 		if err != nil {
-			return fmt.Errorf("Failed to download snapshot file: %s", url)
+			return fmt.Errorf("Failed to download snapshot file: %s. Error: %v", url, err)
 		}
 	} else if imp.cfg.URL != "" {
 		archive, err = imp.downloadFile(imp.cfg.URL, target)
 		if err != nil {
-			return fmt.Errorf("Failed to download file: %s", imp.cfg.URL)
+			return fmt.Errorf("Failed to download file: %s. Error: %v", imp.cfg.URL, err)
 		}
 	} else {
 		return errors.New("No archive file or URL is set - please use -file or -url option")


### PR DESCRIPTION
Backport of #3805 to branch 5.x.

An error was printed, but not what it was, and there can be two main
causes:
 * the download itself failed
 * the creation of the file on disk failed
(cherry picked from commit be8cb0a1ba94995dcba9208e5526c853d14bdda9)