### PR TITLE
Cherry-pick #3671 to 5.x: Fix elasticsearch url parsing

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -45,6 +45,8 @@ https://github.com/elastic/beats/compare/v5.3.0...master[Check the HEAD diff]
 *Affecting all Beats*
 
 - Update index mappings to support future Elasticsearch 6.X. {pull}3778[3778]
+- Add `_id`, `_type`, `_index` and `_score` fields in the generated index pattern. {pull}3282[3282]
+- Fix potential elasticsearch output URL parsing error if protocol scheme is missing. {pull}3671[3671]
 
 *Filebeat*
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -45,7 +45,6 @@ https://github.com/elastic/beats/compare/v5.3.0...master[Check the HEAD diff]
 *Affecting all Beats*
 
 - Update index mappings to support future Elasticsearch 6.X. {pull}3778[3778]
-- Add `_id`, `_type`, `_index` and `_score` fields in the generated index pattern. {pull}3282[3282]
 - Fix potential elasticsearch output URL parsing error if protocol scheme is missing. {pull}3671[3671]
 
 *Filebeat*

--- a/libbeat/outputs/elasticsearch/url_test.go
+++ b/libbeat/outputs/elasticsearch/url_test.go
@@ -79,6 +79,8 @@ func TestGetUrl(t *testing.T) {
 		"http://localhost/":    "http://localhost:9200/",
 
 		// no schema + hostname
+		"33f3600fd5c1bb599af557c36a4efb08.host":       "http://33f3600fd5c1bb599af557c36a4efb08.host:9200",
+		"33f3600fd5c1bb599af557c36a4efb08.host:12345": "http://33f3600fd5c1bb599af557c36a4efb08.host:12345",
 		"localhost":        "http://localhost:9200",
 		"localhost:80":     "http://localhost:80",
 		"localhost:80/":    "http://localhost:80/",


### PR DESCRIPTION
Cherry-pick of PR #3671 to 5.x branch. Original message: 

use regex to check if host given contains the protocol scheme. If scheme is
missing, prepend before attempting to parse the complete URL