### PR TITLE
Refactoring config handling for perfmon metricset

### DIFF
--- a/metricbeat/docs/fields.asciidoc
+++ b/metricbeat/docs/fields.asciidoc
@@ -7534,23 +7534,14 @@ Name of the user running the process.
 
 
 [float]
-== counters Fields
+== perfmon.counters Fields
 
-Grouping of different counters
-
-
-
-[float]
-=== windows.perfmon.counters.group
-
-type: string
-
-Name of the group. For example `processor` or `disk`
+Grouping of different counters   
 
 
 
 [float]
-=== windows.perfmon.counters.collectors.alias
+=== windows.perfmon.perfmon.counters.alias
 
 type: string
 
@@ -7558,7 +7549,7 @@ Short form for the query
 
 
 [float]
-=== windows.perfmon.counters.collectors.query
+=== windows.perfmon.perfmon.counters.query
 
 type: string
 

--- a/metricbeat/module/windows/perfmon/_meta/data.json
+++ b/metricbeat/module/windows/perfmon/_meta/data.json
@@ -1,19 +1,19 @@
 {
-    "@timestamp":"2016-05-23T08:05:34.853Z",
-    "beat":{
-        "hostname":"beathost",
-        "name":"beathost"
+    "@timestamp": "2016-05-23T08:05:34.853Z",
+    "beat": {
+        "hostname": "beathost",
+        "name": "beathost"
     },
-    "metricset":{
-        "host":"localhost",
-        "module":"mysql",
-        "name":"status",
-        "rtt":44269
+    "metricset": {
+        "module": "windows",
+        "name": "perfmon",
+        "rtt": 0
     },
-    "windows":{
-        "perfmon":{
-            "example": "perfmon"
+    "type": "metricsets",
+    "windows": {
+        "perfmon": {
+            "processor.processor_performance": 52.522315,
+            "processor.processor_time": 18.287520
         }
-    },
-    "type":"metricsets"
+    }
 }

--- a/metricbeat/module/windows/perfmon/_meta/docs.asciidoc
+++ b/metricbeat/module/windows/perfmon/_meta/docs.asciidoc
@@ -15,12 +15,8 @@ to collect. The example below collects processor time and disk writes.
   metricsets: ["perfmon"]
   period: 10s
   perfmon.counters:
-    - group: "processor"
-      collectors:
-        - alias: "processor_time"
-          query: '\Processor Information(_Total)\% Processor Time'
-    - group: "disk"
-      collectors:
-        - alias: "bytes_written"
-          query: '\PhysicalDisk(_Total)\Disk Writes/sec'
+    - alias: "processor.processor_time"
+      query: '\Processor Information(_Total)\% Processor Time'
+    - alias: "processor.processor_performance"
+      query: '\Processor Information(_Total)\% Processor Performance'
 ----

--- a/metricbeat/module/windows/perfmon/_meta/fields.yml
+++ b/metricbeat/module/windows/perfmon/_meta/fields.yml
@@ -1,26 +1,18 @@
 - name: perfmon
   type: group
   fields:
-    - name: counters
+    - name: perfmon.counters
       type: group
       description: >
-        Grouping of different counters
-      fields: 
-        - name: group
+        Grouping of different counters   
+      fields:
+        - name: alias
           type: string
           description: >
-            Name of the group. For example `processor` or `disk`
-
-        - name: collectors
-          type: group
-          fields:
-            - name: alias
-              type: string
-              description: >
-                Short form for the query
-                
-            - name: query
-              type: string
-              description: >
-                The query. For example `\\Processor Information(_Total)\\% Processor Performance`. Backslashes have to be escaped.
+            Short form for the query
+            
+        - name: query
+          type: string
+          description: >
+            The query. For example `\\Processor Information(_Total)\\% Processor Performance`. Backslashes have to be escaped.
 

--- a/metricbeat/module/windows/perfmon/pdh_integration_windows_test.go
+++ b/metricbeat/module/windows/perfmon/pdh_integration_windows_test.go
@@ -9,11 +9,9 @@ import (
 )
 
 func TestExistingCounter(t *testing.T) {
-	config := make([]CounterConfig, 1)
-	config[0].Name = "process"
-	config[0].Group = make([]CounterConfigGroup, 1)
-	config[0].Group[0].Alias = "processor_time"
-	config[0].Group[0].Query = "\\Processor Information(_Total)\\% Processor Time"
+	config := make([]CounterConfigGroup, 1)
+	config[0].Alias = "processore.processor_time"
+	config[0].Query = "\\Processor Information(_Total)\\% Processor Time"
 	handle, err := GetHandle(config)
 
 	assert.Zero(t, err)
@@ -24,11 +22,9 @@ func TestExistingCounter(t *testing.T) {
 }
 
 func TestNonExistingCounter(t *testing.T) {
-	config := make([]CounterConfig, 1)
-	config[0].Name = "process"
-	config[0].Group = make([]CounterConfigGroup, 1)
-	config[0].Group[0].Alias = "processor_performance"
-	config[0].Group[0].Query = "\\Processor Information(_Total)\\not existing counter"
+	config := make([]CounterConfigGroup, 1)
+	config[0].Alias = "processore.processor_performance"
+	config[0].Query = "\\Processor Information(_Total)\\not existing counter"
 	handle, err := GetHandle(config)
 
 	assert.Equal(t, 3221228473, int(err))
@@ -41,11 +37,9 @@ func TestNonExistingCounter(t *testing.T) {
 }
 
 func TestNonExistingObject(t *testing.T) {
-	config := make([]CounterConfig, 1)
-	config[0].Name = "process"
-	config[0].Group = make([]CounterConfigGroup, 1)
-	config[0].Group[0].Alias = "processor_performance"
-	config[0].Group[0].Query = "\\non existing object\\% Processor Performance"
+	config := make([]CounterConfigGroup, 1)
+	config[0].Alias = "processore.processor_performance"
+	config[0].Query = "\\non existing object\\% Processor Performance"
 	handle, err := GetHandle(config)
 
 	assert.Equal(t, 3221228472, int(err))

--- a/metricbeat/module/windows/perfmon/pdh_windows.go
+++ b/metricbeat/module/windows/perfmon/pdh_windows.go
@@ -13,12 +13,7 @@ type Handle struct {
 	status      error
 	query       uintptr
 	counterType int
-	counters    []CounterGroup
-}
-
-type CounterGroup struct {
-	GroupName string
-	Counters  []Counter
+	counters    []Counter
 }
 
 type Counter struct {
@@ -41,24 +36,21 @@ var errorMapping = map[PdhError]string{
 	PDH_STATUS_NO_OBJECT:    `PDH_STATUS_NO_OBJECT`,
 }
 
-func GetHandle(config []CounterConfig) (*Handle, PdhError) {
+func GetHandle(config []CounterConfigGroup) (*Handle, PdhError) {
 	q := &Handle{}
 	err := _PdhOpenQuery(0, 0, &q.query)
 	if err != ERROR_SUCCESS {
 		return nil, PdhError(err)
 	}
 
-	counterGroups := make([]CounterGroup, len(config))
-	q.counters = counterGroups
+	counters := make([]Counter, len(config))
+	q.counters = counters
 
 	for i, v := range config {
-		counterGroups[i] = CounterGroup{GroupName: v.Name, Counters: make([]Counter, len(v.Group))}
-		for j, v1 := range v.Group {
-			counterGroups[i].Counters[j] = Counter{counterName: v1.Alias, counterPath: v1.Query}
-			err := _PdhAddCounter(q.query, counterGroups[i].Counters[j].counterPath, 0, &counterGroups[i].Counters[j].counter)
-			if err != ERROR_SUCCESS {
-				return nil, PdhError(err)
-			}
+		counters[i] = Counter{counterName: v.Alias, counterPath: v.Query}
+		err := _PdhAddCounter(q.query, counters[i].counterPath, 0, &counters[i].counter)
+		if err != ERROR_SUCCESS {
+			return nil, PdhError(err)
 		}
 	}
 
@@ -82,28 +74,24 @@ func (q *Handle) ReadData(firstFetch bool) (common.MapStr, PdhError) {
 	result := common.MapStr{}
 
 	for _, v := range q.counters {
-		groupVal := make(map[string]interface{})
-		for _, v1 := range v.Counters {
-			err := _PdhGetFormattedCounterValue(v1.counter, PdhFmtDouble, q.counterType, &v1.displayValue)
-			if err != ERROR_SUCCESS {
-				switch err {
-				case PDH_CALC_NEGATIVE_DENOMINATOR:
-					{
-						//Sometimes counters return negative values. We can ignore this error. See here for a good explanation https://www.netiq.com/support/kb/doc.php?id=7010545
-						groupVal[v1.counterName] = 0
-						continue
-					}
-				default:
-					{
-						return nil, PdhError(err)
-					}
+		err := _PdhGetFormattedCounterValue(v.counter, PdhFmtDouble, q.counterType, &v.displayValue)
+		if err != ERROR_SUCCESS {
+			switch err {
+			case PDH_CALC_NEGATIVE_DENOMINATOR:
+				{
+					//Sometimes counters return negative values. We can ignore this error. See here for a good explanation https://www.netiq.com/support/kb/doc.php?id=7010545
+					result[v.counterName] = 0
+					continue
+				}
+			default:
+				{
+					return nil, PdhError(err)
 				}
 			}
-			doubleValue := (*float64)(unsafe.Pointer(&v1.displayValue.LongValue))
-			groupVal[v1.counterName] = *doubleValue
-
 		}
-		result[v.GroupName] = groupVal
+		doubleValue := (*float64)(unsafe.Pointer(&v.displayValue.LongValue))
+
+		result[v.counterName] = *doubleValue
 	}
 	return result, 0
 }

--- a/metricbeat/module/windows/perfmon/perfmon.go
+++ b/metricbeat/module/windows/perfmon/perfmon.go
@@ -10,11 +10,6 @@ import (
 	"github.com/elastic/beats/metricbeat/mb"
 )
 
-type CounterConfig struct {
-	Name  string               `config:"group" validate:"required"`
-	Group []CounterConfigGroup `config:"collectors" validate:"required"`
-}
-
 type CounterConfigGroup struct {
 	Alias string `config:"alias" validate:"required"`
 	Query string `config:"query" validate:"required"`
@@ -34,7 +29,7 @@ func init() {
 // multiple fetch calls.
 type MetricSet struct {
 	mb.BaseMetricSet
-	counters   []CounterConfig
+	counters   []CounterConfigGroup
 	handle     *Handle
 	firstFetch bool
 }
@@ -46,14 +41,14 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	logp.Warn("BETA: The perfmon metricset is beta")
 
 	config := struct {
-		CounterConfig []CounterConfig `config:"perfmon.counters" validate:"required"`
+		CounterConfigGroup []CounterConfigGroup `config:"perfmon.counters" validate:"required"`
 	}{}
 
 	if err := base.Module().UnpackConfig(&config); err != nil {
 		return nil, err
 	}
 
-	query, err := GetHandle(config.CounterConfig)
+	query, err := GetHandle(config.CounterConfigGroup)
 
 	if err != ERROR_SUCCESS {
 		return nil, errors.New("initialization fails with error: " + err.Error())
@@ -61,7 +56,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 
 	return &MetricSet{
 		BaseMetricSet: base,
-		counters:      config.CounterConfig,
+		counters:      config.CounterConfigGroup,
 		handle:        query,
 		firstFetch:    true,
 	}, nil


### PR DESCRIPTION
This PR simplified the using of the config for the perfmon metricset.
Sample output
```
{
  "@timestamp": "2017-03-30T09:17:59.012Z",
  "beat": {
    "hostname": "4201halwsd00001",
    "name": "4201halwsd00001",
    "version": "6.0.0-alpha1"
  },
  "metricset": {
    "module": "windows",
    "name": "perfmon",
    "rtt": 0
  },
  "type": "metricsets",
  "windows": {
    "perfmon": {
      "processor.processor_performance": 52.522315,
      "processor.processor_time": 18.287520
    }
  }
}
```