### PR TITLE
Wrong start command for deb distrib

### DIFF
--- a/heartbeat/docs/getting-started.asciidoc
+++ b/heartbeat/docs/getting-started.asciidoc
@@ -235,7 +235,7 @@ start Heartbeat in the foreground.
 
 ["source","sh",subs="attributes"]
 ----------------------------------------------------------------------
-sudo /etc/init.d/ start
+sudo /etc/init.d/heartbeat start
 ----------------------------------------------------------------------
 
 *rpm:*


### PR DESCRIPTION
Missing **heartbeat** in command
`sudo /etc/init.d/ start`
