### PR TITLE
Add missing go generate lines for perfmon metricset

### DIFF
--- a/metricbeat/module/windows/perfmon/doc.go
+++ b/metricbeat/module/windows/perfmon/doc.go
@@ -2,3 +2,6 @@
 Package perfmon collect windows performance counters.
 */
 package perfmon
+
+// go:generate go tool cgo -godefs defs_windows.go > defs_windows_amd64.go
+// go:generate go tool cgo -godefs defs_windows.go > defs_windows_386.go


### PR DESCRIPTION
This PR add the missing `go generate` lines to `doc.go`.