### PR TITLE
Wrong start command for deb distrib

### DIFF
--- a/heartbeat/docs/getting-started.asciidoc
+++ b/heartbeat/docs/getting-started.asciidoc
@@ -235,7 +235,7 @@ start Heartbeat in the foreground.
 
 ["source","sh",subs="attributes"]
 ----------------------------------------------------------------------
-sudo /etc/init.d/ start
+sudo /etc/init.d/heartbeat start
 ----------------------------------------------------------------------
 
 *rpm:*


### PR DESCRIPTION
Apply fix https://github.com/elastic/beats/pull/3855 in master, but needs to be backported to 5.x as well.