### PR TITLE
Remove ApplyNoError from Schema

### DIFF
--- a/libbeat/processors/add_cloud_metadata/add_cloud_metadata.go
+++ b/libbeat/processors/add_cloud_metadata/add_cloud_metadata.go
@@ -36,17 +36,23 @@ const (
 var debugf = logp.MakeDebug("filters")
 
 var (
-	ec2Schema = s.Schema{
-		"instance_id":       c.Str("instanceId"),
-		"machine_type":      c.Str("instanceType"),
-		"region":            c.Str("region"),
-		"availability_zone": c.Str("availabilityZone"),
-	}.ApplyNoError
+	ec2Schema = func(m map[string]interface{}) common.MapStr {
+		out, _ := s.Schema{
+			"instance_id":       c.Str("instanceId"),
+			"machine_type":      c.Str("instanceType"),
+			"region":            c.Str("region"),
+			"availability_zone": c.Str("availabilityZone"),
+		}.Apply(m)
+		return out
+	}
 
-	doSchema = s.Schema{
-		"instance_id": c.StrFromNum("droplet_id"),
-		"region":      c.Str("region"),
-	}.ApplyNoError
+	doSchema = func(m map[string]interface{}) common.MapStr {
+		out, _ := s.Schema{
+			"instance_id": c.StrFromNum("droplet_id"),
+			"region":      c.Str("region"),
+		}.Apply(m)
+		return out
+	}
 
 	gceHeaders = map[string]string{"Metadata-Flavor": "Google"}
 	gceSchema  = func(m map[string]interface{}) common.MapStr {

--- a/metricbeat/schema/schema.go
+++ b/metricbeat/schema/schema.go
@@ -76,12 +76,6 @@ func (s Schema) ApplyTo(event common.MapStr, data map[string]interface{}) (commo
 	return event, errors
 }
 
-// Apply converts the fields extracted from data, using the schema, into a new map.
-func (s Schema) ApplyNoError(data map[string]interface{}) common.MapStr {
-	event, _ := s.ApplyTo(common.MapStr{}, data)
-	return event
-}
-
 // Apply converts the fields extracted from data, using the schema, into a new map and reports back the errors.
 func (s Schema) Apply(data map[string]interface{}) (common.MapStr, *Errors) {
 	return s.ApplyTo(common.MapStr{}, data)


### PR DESCRIPTION
The ApplyNoError function is not needed because users can just call Apply and ignore the error.

See #3807