### PR TITLE
Fix modules yml files permission on Deb

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -31,6 +31,8 @@ https://github.com/elastic/beats/compare/v5.3.0...master[Check the HEAD diff]
 
 *Filebeat*
 
+- Fix modules default file permissions. {pull}3879[3879]
+
 *Heartbeat*
 
 *Metricbeat*

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -327,7 +327,7 @@ install-home:
 	if [ -d _meta/module.generated ]; then \
 		install -d -m 755 ${HOME_PREFIX}/module; \
 		rsync -av _meta/module.generated/ ${HOME_PREFIX}/module/; \
-		chmod -R go-w _meta/module.generated; \
+		chmod -R go-w ${HOME_PREFIX}/module/; \
 	fi
 
 # Prepares for packaging. Builds binaries and creates homedir data


### PR DESCRIPTION
The fix in #3645 had a bug (chmod executed on the wrong folder). This fixes the fix and also adds permissions checks to the tests.