### PR TITLE
Update yaml tips

### DIFF
--- a/filebeat/docs/index.asciidoc
+++ b/filebeat/docs/index.asciidoc
@@ -44,6 +44,7 @@ include::./multiple-prospectors.asciidoc[]
 
 include::./load-balancing.asciidoc[]
 
+:standalone:
 :allplatforms:
 include::../../libbeat/docs/yaml.asciidoc[]
 

--- a/heartbeat/docs/index.asciidoc
+++ b/heartbeat/docs/index.asciidoc
@@ -43,6 +43,7 @@ include::./configuring-logstash.asciidoc[]
 
 include::../../libbeat/docs/shared-env-vars.asciidoc[]
 
+:standalone:
 :allplatforms:
 include::../../libbeat/docs/yaml.asciidoc[]
 

--- a/libbeat/docs/config-file-format.asciidoc
+++ b/libbeat/docs/config-file-format.asciidoc
@@ -375,44 +375,5 @@ individual settings can be overwritten using `-E <setting>=<value>`.
 [[config-file-format-tips]]
 === YAML Tips and Gotchas
 
-When you edit the configuration file, there are a few things that you should know.
-
-[float]
-==== Use Spaces for Indentation
-
-Indentation is meaningful in YAML. Make sure that you use spaces, rather than
-tab characters, to indent sections.
-
-In the default configuration files and in all the examples in the documentation,
-we use 2 spaces per indentation level. We recommend you do the same.
-
-[float]
-==== Look at the Default Config File for Structure
-
-The best way to understand where to define a configuration option is by looking
-at the provided sample configuration files. The configuration files contain most
-of the default configurations that are available per beat. To change a setting,
-simply uncomment the line and change the values.
-
-[float]
-==== Test Your Config File
-
-You can test your configuration file to verify that the structure is valid.
-Simply change to the directory where the binary is installed, and run
-your Beat in the foreground with the `-configtest` flag specified. For example:
-
-["source","yaml",subs="attributes,callouts"]
-----------------------------------------------------------------------
-filebeat -c filebeat.yml -configtest
-----------------------------------------------------------------------
-
-You'll see a message if an error in the configuration file is found.
-
-[float]
-==== Wrap Regular Expressions in Single Quotation Marks
-
-If you need to specify a regular expression in a YAML file, it's a good idea to
-wrap the regular expression in single quotation marks to work around YAML's
-tricky rules for string escaping.
-
-For more information about YAML, see http://yaml.org/.
+:allplatforms:
+include::yaml.asciidoc[]

--- a/libbeat/docs/shared-faq.asciidoc
+++ b/libbeat/docs/shared-faq.asciidoc
@@ -22,6 +22,19 @@ See {libbeat}/config-file-permissions.html[Config File Ownership and Permissions
 for more about resolving these errors.
 
 [float]
+[[error-found-unexpected-character]]
+=== Found Unexpected or Unknown Characters?
+
+Either there is a problem with the structure of your config file, or you have
+used a path or expression that the YAML parser cannot resolve because the config
+file contains characters that aren't properly escaped.
+
+If the YAML file contains paths with spaces or unusual characters, wrap the
+paths in single quotation marks (see <<wrap-paths-in-quotes>>).
+
+Also see the general advice under <<yaml-tips>>.
+
+[float]
 [[connection-problem]]
 === Logstash connection doesn't work?
 

--- a/libbeat/docs/yaml.asciidoc
+++ b/libbeat/docs/yaml.asciidoc
@@ -9,31 +9,38 @@
 //// include::../../libbeat/docs/yaml.asciidoc[]
 //////////////////////////////////////////////////////////////////////////
 
+ifdef::standalone[]
+
 [[yaml-tips]]
 == YAML Tips and Gotchas
 
-The {beatname_uc} configuration file uses http://yaml.org/[YAML] for its syntax. When you edit the
+endif::[]
+
+The configuration file uses http://yaml.org/[YAML] for its syntax. When you edit the
 file to modify configuration settings, there are a few things that you should know.
 
 [float]
 === Use Spaces for Indentation
 
-Indentation is meaningful in YAML. Make sure that you use spaces, rather than tab characters, to indent sections. 
+Indentation is meaningful in YAML. Make sure that you use spaces, rather than tab characters, to indent sections.
+
+In the default configuration files and in all the examples in the documentation,
+we use 2 spaces per indentation level. We recommend you do the same.
 
 [float]
 === Look at the Default Config File for Structure
 
-The best way to understand where to define a configuration option is by looking at
-the {beatname_lc}.yml configuration file. The configuration file contains most of the
-configuration options that are available for {beatname_uc}. To change a configuration setting,
-simply uncomment the line and change the setting.
+The best way to understand where to define a configuration option is by looking
+at the provided sample configuration files. The configuration files contain most
+of the default configurations that are available for the Beat. To change a setting,
+simply uncomment the line and change the values.
 
 [float]
 === Test Your Config File
 
 You can test your configuration file to verify that the structure is valid.
 Simply change to the directory where the binary is installed, and run
-{beatname_uc} in the foreground with the `-configtest` flag specified. For example: 
+the Beat in the foreground with the `-configtest` flag specified. For example: 
 
 ifdef::allplatforms[]
 
@@ -53,7 +60,7 @@ ifdef::win[]
 
 endif::win[]
 
-You'll see a message if {beatname_uc} finds an error in the file.
+You'll see a message if the Beat finds an error in the file.
 
 [float]
 === Wrap Regular Expressions in Single Quotation Marks
@@ -61,3 +68,25 @@ You'll see a message if {beatname_uc} finds an error in the file.
 If you need to specify a regular expression in a YAML file, it's a good idea to wrap the regular expression in single quotation marks to work around YAML's tricky rules for string escaping. 
 
 For more information about YAML, see http://yaml.org/.
+
+[float]
+[[wrap-paths-in-quotes]]
+=== Wrap Paths in Single Quotation Marks
+
+Windows paths in particular sometimes contain spaces or characters, such as drive
+letters or triple dots, that may be misinterpreted by the YAML parser. 
+
+To avoid this problem, it's a good idea to wrap paths in single quotation marks. 
+
+[float]
+[[avoid-leading-zeros]]
+=== Avoid Using Leading Zeros in Numeric Values
+
+If you use a leading zero (for example, `09`) in a numeric field without
+wrapping the value in single quotation marks, the value may be interpreted
+incorrectly by the YAML parser. If the value is a valid octal, it's converted
+to an integer. If not, it's converted to a float. 
+
+To prevent unwanted type conversions, avoid using leading zeros in field values,
+or wrap the values in single quotation marks.
+

--- a/metricbeat/docs/index.asciidoc
+++ b/metricbeat/docs/index.asciidoc
@@ -38,6 +38,7 @@ include::./configuring-logstash.asciidoc[]
 
 include::../../libbeat/docs/shared-env-vars.asciidoc[]
 
+:standalone:
 :allplatforms:
 include::../../libbeat/docs/yaml.asciidoc[]
 

--- a/packetbeat/docs/index.asciidoc
+++ b/packetbeat/docs/index.asciidoc
@@ -46,6 +46,7 @@ include::./capturing.asciidoc[]
 
 include::./thrift.asciidoc[]
 
+:standalone:
 :allplatforms:
 include::../../libbeat/docs/yaml.asciidoc[]
 

--- a/winlogbeat/docs/index.asciidoc
+++ b/winlogbeat/docs/index.asciidoc
@@ -33,6 +33,7 @@ include::../../libbeat/docs/shared-config-ingest.asciidoc[]
 
 include::../../libbeat/docs/shared-env-vars.asciidoc[]
 
+:standalone:
 :win:
 include::../../libbeat/docs/yaml.asciidoc[]
 


### PR DESCRIPTION
- Removed duplicated content from platform ref and used shared content instead
- Added guidance to "YAML Tips and Gotchas" and the FAQs to resolve this issue: https://github.com/elastic/beats/issues/1495

@geekpete This PR address the issue that you brought up (see Avoid Using Leading Zeros in Numeric Values). Not sure I have the details 100% correct, but I'm sure the reviewers will correct me where I'm wrong. I didn't add this to the FAQ because I wasn't sure how often users are likely or run into the problem. 
