### PR TITLE
Ignore .vscode in project root path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Directories
 /.vagrant
 /.idea
+/.vscode
 /build
 /*/data
 /*/logs


### PR DESCRIPTION
Hi there,
I am reading and debugging the project source using Visual Studio Code. 
By default the editor generates a `.vscode` folder under the project root path.
It will be nice to ignore this.