### PR TITLE
Add config option to disable or enable cmdline cache for System Process Metricset

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -113,6 +113,7 @@ https://github.com/elastic/beats/compare/v5.1.1...master[Check the HEAD diff]
 - Add the ability to collect the environment variables from system processes. {pull}3337[3337]
 - Add experimental metricset `perfmon` to Windows module. {pull}3758[3758]
 - Add memcached module with stats metricset. {pull}3693[3693]
+- Add the `process.cmdline.cache` config option to the System Process Metricset. {pull}3891[3891]
 
 *Packetbeat*
 - Add `fields` and `fields_under_root` to packetbeat protocols configurations. {pull}3518[3518]

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -113,7 +113,7 @@ https://github.com/elastic/beats/compare/v5.1.1...master[Check the HEAD diff]
 - Add the ability to collect the environment variables from system processes. {pull}3337[3337]
 - Add experimental metricset `perfmon` to Windows module. {pull}3758[3758]
 - Add memcached module with stats metricset. {pull}3693[3693]
-- Add the `process.cmdline.cache` config option to the System Process Metricset. {pull}3891[3891]
+- Add the `process.cmdline.cache.enabled` config option to the System Process Metricset. {pull}3891[3891]
 
 *Packetbeat*
 - Add `fields` and `fields_under_root` to packetbeat protocols configurations. {pull}3518[3518]

--- a/metricbeat/metricbeat.full.yml
+++ b/metricbeat/metricbeat.full.yml
@@ -65,7 +65,7 @@ metricbeat.modules:
   #cpu_ticks: false
 
   # If false, cmdline of a process is not cached.
-  #process.cmdline.cache: true
+  #process.cmdline.cache.enabled: true
 
   # Enable collection of cgroup metrics from processes on Linux.
   #process.cgroups.enabled: true

--- a/metricbeat/metricbeat.full.yml
+++ b/metricbeat/metricbeat.full.yml
@@ -64,6 +64,9 @@ metricbeat.modules:
   # if true, exports the CPU usage in ticks, together with the percentage values
   #cpu_ticks: false
 
+  # If false, cmdline of a process is not cached.
+  #process.cmdline.cache: true
+
   # Enable collection of cgroup metrics from processes on Linux.
   #process.cgroups.enabled: true
 

--- a/metricbeat/module/system/_meta/config.full.yml
+++ b/metricbeat/module/system/_meta/config.full.yml
@@ -36,6 +36,9 @@
   # if true, exports the CPU usage in ticks, together with the percentage values
   #cpu_ticks: false
 
+  # If false, cmdline of a process is not cached.
+  #process.cmdline.cache: true
+
   # Enable collection of cgroup metrics from processes on Linux.
   #process.cgroups.enabled: true
 

--- a/metricbeat/module/system/_meta/config.full.yml
+++ b/metricbeat/module/system/_meta/config.full.yml
@@ -37,7 +37,7 @@
   #cpu_ticks: false
 
   # If false, cmdline of a process is not cached.
-  #process.cmdline.cache: true
+  #process.cmdline.cache.enabled: true
 
   # Enable collection of cgroup metrics from processes on Linux.
   #process.cgroups.enabled: true

--- a/metricbeat/module/system/process/_meta/docs.asciidoc
+++ b/metricbeat/module/system/process/_meta/docs.asciidoc
@@ -11,6 +11,14 @@ This metricset is available on:
 - Windows
 
 [float]
+=== Cache CmdLine
+
+This metricset caches the command line args for a running process. This means if you alter
+the command line for a process while this metricset is running, these changes are not detected.
+This feature can disabled by adding
+`process.cmdline.cache: false` to the system module configuration.
+
+[float]
 === Control Group (cgroup) Metrics
 
 On Linux this metricset will collect metrics from any cgroups that the process

--- a/metricbeat/module/system/process/_meta/docs.asciidoc
+++ b/metricbeat/module/system/process/_meta/docs.asciidoc
@@ -15,7 +15,7 @@ This metricset is available on:
 
 This metricset caches the command line args for a running process. This means if you alter
 the command line for a process while this metricset is running, these changes are not detected.
-This feature can disabled by adding
+This feature can be disabled by adding
 `process.cmdline.cache: false` to the system module configuration.
 
 [float]

--- a/metricbeat/module/system/process/_meta/docs.asciidoc
+++ b/metricbeat/module/system/process/_meta/docs.asciidoc
@@ -16,7 +16,7 @@ This metricset is available on:
 This metricset caches the command line args for a running process. This means if you alter
 the command line for a process while this metricset is running, these changes are not detected.
 This feature can be disabled by adding
-`process.cmdline.cache: false` to the system module configuration.
+`process.cmdline.cache.enabled: false` to the system module configuration.
 
 [float]
 === Control Group (cgroup) Metrics

--- a/metricbeat/module/system/process/helper.go
+++ b/metricbeat/module/system/process/helper.go
@@ -40,6 +40,7 @@ type ProcStats struct {
 	ProcsMap     ProcsMap
 	CpuTicks     bool
 	EnvWhitelist []string
+	CacheCmdLine bool
 
 	procRegexps []match.Matcher // List of regular expressions used to whitelist processes.
 	envRegexps  []match.Matcher // List of regular expressions used to whitelist env vars.
@@ -342,7 +343,9 @@ func (procStats *ProcStats) GetProcStats() ([]common.MapStr, error) {
 		var cmdline string
 		var env common.MapStr
 		if previousProc := procStats.ProcsMap[pid]; previousProc != nil {
-			cmdline = previousProc.CmdLine
+			if procStats.CacheCmdLine {
+				cmdline = previousProc.CmdLine
+			}
 			env = previousProc.Env
 		}
 

--- a/metricbeat/module/system/process/process.go
+++ b/metricbeat/module/system/process/process.go
@@ -39,7 +39,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 		Cgroups      *bool    `config:"process.cgroups.enabled"`
 		EnvWhitelist []string `config:"process.env.whitelist"`
 		CPUTicks     bool     `config:"cpu_ticks"`
-		CacheCmdLine bool     `config:"process.cmdline.cache"`
+		CacheCmdLine bool     `config:"process.cmdline.cache.enabled"`
 	}{
 		Procs:        []string{".*"}, // collect all processes by default
 		CacheCmdLine: true,

--- a/metricbeat/module/system/process/process.go
+++ b/metricbeat/module/system/process/process.go
@@ -27,8 +27,9 @@ func init() {
 // MetricSet that fetches process metrics.
 type MetricSet struct {
 	mb.BaseMetricSet
-	stats  *ProcStats
-	cgroup *cgroup.Reader
+	stats        *ProcStats
+	cgroup       *cgroup.Reader
+	cacheCmdLine bool
 }
 
 // New creates and returns a new MetricSet.
@@ -38,8 +39,10 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 		Cgroups      *bool    `config:"process.cgroups.enabled"`
 		EnvWhitelist []string `config:"process.env.whitelist"`
 		CPUTicks     bool     `config:"cpu_ticks"`
+		CacheCmdLine bool     `config:"process.cmdline.cache"`
 	}{
-		Procs: []string{".*"}, // collect all processes by default
+		Procs:        []string{".*"}, // collect all processes by default
+		CacheCmdLine: true,
 	}
 	if err := base.Module().UnpackConfig(&config); err != nil {
 		return nil, err
@@ -51,6 +54,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 			Procs:        config.Procs,
 			EnvWhitelist: config.EnvWhitelist,
 			CpuTicks:     config.CPUTicks,
+			CacheCmdLine: config.CacheCmdLine,
 		},
 	}
 	err := m.stats.InitProcStats()


### PR DESCRIPTION
fixes #3799 

This PR add a config option for the process metricset to disable or enable caching the commandline args for a process.