### PR TITLE
set defaultDateDetection to true

### DIFF
--- a/libbeat/template/template.go
+++ b/libbeat/template/template.go
@@ -9,7 +9,7 @@ import (
 
 var (
 	// Defaults used in the template
-	defaultDateDetection    = false
+	defaultDateDetection    = true
 	defaultTotalFieldsLimit = 10000
 
 	// Array to store dynamicTemplate parts in


### PR DESCRIPTION
Elasticsearch documentation states that date_detection dynamic mapping is enabled by default. However, generated filebeat mapping have this disabled by default.

I assume that there is possibly a reason to not have that enabled by default and documentation is inconsistent, so this PR should be declined and documentation should be updated instead.

Otherwise, it would be nice to not have sane defaults changed by filebeat mapping.