### PR TITLE
Remove metrics endpoint in winlogbeat

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -36,7 +36,7 @@ https://github.com/elastic/beats/compare/v5.1.1...master[Check the HEAD diff]
 - Remove deprecated geoip. {pull}3766[3766]
 
 *Winlogbeat*
-- Remove metrics endpoint. Replaced by http endpoint in libbeat (#3717). {pull}x[x]
+- Remove metrics endpoint. Replaced by http endpoint in libbeat (see #3717). {pull}3901[3901]
 
 
 ==== Bugfixes

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -36,6 +36,7 @@ https://github.com/elastic/beats/compare/v5.1.1...master[Check the HEAD diff]
 - Remove deprecated geoip. {pull}3766[3766]
 
 *Winlogbeat*
+- Remove metrics endpoint. Replaced by http endpoint in libbeat (#3717). {pull}x[x]
 
 
 ==== Bugfixes

--- a/winlogbeat/_meta/beat.full.yml
+++ b/winlogbeat/_meta/beat.full.yml
@@ -14,12 +14,6 @@
 # in the directory in which it was started.
 #winlogbeat.registry_file: .winlogbeat.yml
 
-# Diagnostic metrics that can retrieved through a web interface if a
-# bindaddress value (host:port) is specified. The web address will be
-# http://<bindaddress>/debug/vars
-#winlogbeat.metrics:
-#  bindaddress: 'localhost:8123'
-
 # event_logs specifies a list of event logs to monitor as well as any
 # accompanying options. The YAML data type of event_logs is a list of
 # dictionaries.

--- a/winlogbeat/beater/winlogbeat.go
+++ b/winlogbeat/beater/winlogbeat.go
@@ -7,8 +7,6 @@ package beater
 import (
 	"expvar"
 	"fmt"
-	"net"
-	"net/http"
 	"sync"
 	"time"
 
@@ -35,8 +33,7 @@ func init() {
 
 // Debug logging functions for this package.
 var (
-	debugf    = logp.MakeDebug("winlogbeat")
-	memstatsf = logp.MakeDebug("memstats")
+	debugf = logp.MakeDebug("winlogbeat")
 )
 
 // Time the application was started.
@@ -113,21 +110,6 @@ func (eb *Winlogbeat) setup(b *beat.Beat) error {
 	eb.checkpoint, err = checkpoint.NewCheckpoint(config.RegistryFile, 10, 5*time.Second)
 	if err != nil {
 		return err
-	}
-
-	if config.Metrics.BindAddress != "" {
-		bindAddress := config.Metrics.BindAddress
-		sock, err := net.Listen("tcp", bindAddress)
-		if err != nil {
-			return err
-		}
-		go func() {
-			logp.Info("Metrics hosted at http://%s/debug/vars", bindAddress)
-			err := http.Serve(sock, nil)
-			if err != nil {
-				logp.Warn("Unable to launch HTTP service for metrics. %v", err)
-			}
-		}()
 	}
 
 	return nil

--- a/winlogbeat/config/config.go
+++ b/winlogbeat/config/config.go
@@ -3,9 +3,7 @@ package config
 
 import (
 	"fmt"
-	"net"
 	"sort"
-	"strconv"
 	"strings"
 
 	"github.com/joeshaw/multierror"
@@ -74,7 +72,6 @@ func (s Settings) Validate() error {
 // WinlogbeatConfig contains all of Winlogbeat configuration data.
 type WinlogbeatConfig struct {
 	EventLogs    []map[string]interface{} `config:"event_logs"`
-	Metrics      MetricsConfig            `config:"metrics"`
 	RegistryFile string                   `config:"registry_file"`
 }
 
@@ -88,46 +85,5 @@ func (ebc WinlogbeatConfig) Validate() error {
 			"configured as part of event_logs"))
 	}
 
-	if err := ebc.Metrics.Validate(); err != nil {
-		errs = append(errs, err)
-	}
-
 	return errs.Err()
-}
-
-// MetricsConfig holds the configuration data for the HTTP metric service.
-type MetricsConfig struct {
-	BindAddress string // Bind address for the metric service. Format is host:port.
-}
-
-// Validate validates the MetricsConfig data and returns an error describing any
-// problems or nil.
-func (mc MetricsConfig) Validate() error {
-	if mc.BindAddress == "" {
-		return nil
-	}
-
-	host, portStr, err := net.SplitHostPort(mc.BindAddress)
-	if err != nil {
-		return fmt.Errorf("bind_address must be formatted as host:port but "+
-			"was '%s' (%v)", mc.BindAddress, err)
-	}
-
-	if len(host) == 0 {
-		return fmt.Errorf("bind_address value ('%s') is missing a host",
-			mc.BindAddress)
-	}
-
-	port, err := strconv.Atoi(portStr)
-	if err != nil {
-		return fmt.Errorf("bind_address port value ('%s') must be a number "+
-			"(%v)", portStr, err)
-	}
-
-	if port < 1 || port > 65535 {
-		return fmt.Errorf("bind_address port must be within [1-65535] but "+
-			"was '%d'", port)
-	}
-
-	return nil
 }

--- a/winlogbeat/config/config_test.go
+++ b/winlogbeat/config/config_test.go
@@ -55,46 +55,6 @@ func TestConfigValidate(t *testing.T) {
 			"1 error: At least one event log must be configured as part of " +
 				"event_logs",
 		},
-		{
-			WinlogbeatConfig{
-				EventLogs: []map[string]interface{}{
-					{"Name": "App"},
-				},
-				Metrics: MetricsConfig{BindAddress: "example.com"},
-			},
-			"1 error: bind_address",
-		},
-		// MetricsConfig
-		{
-			MetricsConfig{},
-			"",
-		},
-		{
-			MetricsConfig{BindAddress: "example.com:6700"},
-			"",
-		},
-		{
-			MetricsConfig{BindAddress: "example.com"},
-			"bind_address must be formatted as host:port but was " +
-				"'example.com' (missing port in address example.com)",
-		},
-		{
-			MetricsConfig{BindAddress: ":1"},
-			"bind_address value (':1') is missing a host",
-		},
-		{
-			MetricsConfig{BindAddress: "example.com:1024f"},
-			"bind_address port value ('1024f') must be a number " +
-				"(strconv.ParseInt: parsing \"1024f\": invalid syntax)",
-		},
-		{
-			MetricsConfig{BindAddress: "example.com:0"},
-			"bind_address port must be within [1-65535] but was '0'",
-		},
-		{
-			MetricsConfig{BindAddress: "example.com:65536"},
-			"bind_address port must be within [1-65535] but was '65536'",
-		},
 	}
 
 	for _, test := range testCases {

--- a/winlogbeat/docs/reference/configuration/winlogbeat-options.asciidoc
+++ b/winlogbeat/docs/reference/configuration/winlogbeat-options.asciidoc
@@ -170,7 +170,7 @@ Windows will prevent Winlogbeat from reading the event log because it limits the
 number of conditions that can be used in an event log query. If this occurs a similar
 warning as shown below will be logged by Winlogbeat, and it will continue
 processing data from other event logs. For more information, see
-https://support.microsoft.com/en-us/kb/970453. 
+https://support.microsoft.com/en-us/kb/970453.
 
 `WARN EventLog[Application] Open() error. No events will be read from this
 source. The specified query is invalid.`
@@ -183,12 +183,12 @@ event IDs.
 
 [source,yaml]
 --------------------------------------------------------------------------------
-processors:                   
-- drop_event.when.and:               
-    - equals.log_name: Security      
-    - not.or:                   
-        - equals.event_id: 903     
-        - equals.event_id: 1024    
+processors:
+- drop_event.when.and:
+    - equals.log_name: Security
+    - not.or:
+        - equals.event_id: 903
+        - equals.event_id: 1024
         - equals.event_id: 4624
 --------------------------------------------------------------------------------
 
@@ -325,29 +325,6 @@ are stored as top-level fields in the output document instead of being grouped
 under a `fields` sub-dictionary. If the custom field names conflict with other
 field names added by Winlogbeat, then the custom fields overwrite the other
 fields.
-
-===== metrics.bindaddress
-
-The hostname and port where the Beat will host an HTTP web service that provides
-metrics. This field is optional.
-
-The following example specifies that the metrics service is available at
-http://localhost:8128/debug/vars:
-
-[source,yaml]
---------------------------------------------------------------------------------
-winlogbeat.metrics:
-  bindaddress: 'localhost:8123'
---------------------------------------------------------------------------------
-
-The metrics are served as a JSON document. The metrics include:
-
-- memory stats
-- number of published events from each log
-- total number of failures while publishing
-- total number of filtered events
-- total number of successfully published events
-- uptime
 
 include::../../../../libbeat/docs/generalconfig.asciidoc[]
 

--- a/winlogbeat/winlogbeat.full.yml
+++ b/winlogbeat/winlogbeat.full.yml
@@ -14,12 +14,6 @@
 # in the directory in which it was started.
 #winlogbeat.registry_file: .winlogbeat.yml
 
-# Diagnostic metrics that can retrieved through a web interface if a
-# bindaddress value (host:port) is specified. The web address will be
-# http://<bindaddress>/debug/vars
-#winlogbeat.metrics:
-#  bindaddress: 'localhost:8123'
-
 # event_logs specifies a list of event logs to monitor as well as any
 # accompanying options. The YAML data type of event_logs is a list of
 # dictionaries.


### PR DESCRIPTION
The metrics endpoint is replaced by the http endpoint in libbeat. See https://github.com/elastic/beats/pull/3717