### PR TITLE
Update codecov config

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,14 +1,26 @@
 # Enable coverage report message for diff on commit
+# Docs can be found here: https://docs.codecov.io/v4.3.0/docs/commit-status
 coverage:
   status:
-    project: off
+    project:
+      default:
+        target: auto
+        # Overall coverage should never drop more then 0.5%
+        threshold: 0.5
+        base: auto
+        branches: null
+        if_no_uploads: error
+        if_not_found: success
+        if_ci_failed: error
+        only_pulls: false
+        flags: null
+        paths: null
     patch:
       default:
-        # basic
         target: auto
-        threshold: 0.1
+        # Allows PRs without tests, overall stats count
+        threshold: 100
         base: auto
-        # advanced
         branches: null
         if_no_uploads: error
         if_not_found: success


### PR DESCRIPTION
Codecov will report coverage for the patch and for the project based on the pull request. In case the overall coverage drops by more then 0.5% the pull request will fail. It is still possible to have pull requests without tests which will not fail because the overall coverage did not change too much.