### PR TITLE
Cherry-pick #3863 to 5.3: Allow `-` in Apache access log byte count

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -115,6 +115,11 @@ https://github.com/elastic/beats/compare/v5.2.2...v5.3.0[View commits]
 - Add `_id`, `_type`, `_index` and `_score` fields in the generated index pattern. {pull}3282[3282]
 
 *Filebeat*
+- Always use absolute path for event and registry. {pull}3328[3328]
+- Raise an exception in case there is a syntax error in one of the configuration files available under
+  filebeat.config_dir. {pull}3573[3573]
+- Fix empty registry file on machine crash. {issue}3537[3537]
+- Allow `-` in Apache access log byte count. {pull}3863[3863]
 
 - Fix empty registry file on machine crash. {issue}3537[3537]
 

--- a/filebeat/module/apache2/access/ingest/default.json
+++ b/filebeat/module/apache2/access/ingest/default.json
@@ -1,10 +1,10 @@
 {
-  "description": "Pipeline for parsing Nginx access logs. Requires the geoip and user_agent plugins.",
+  "description": "Pipeline for parsing Apache2 access logs. Requires the geoip and user_agent plugins.",
   "processors": [{
     "grok": {
       "field": "message",
       "patterns":[
-        "%{IPORHOST:apache2.access.remote_ip} - %{DATA:apache2.access.user_name} \\[%{HTTPDATE:apache2.access.time}\\] \"%{WORD:apache2.access.method} %{DATA:apache2.access.url} HTTP/%{NUMBER:apache2.access.http_version}\" %{NUMBER:apache2.access.response_code} %{NUMBER:apache2.access.body_sent.bytes}( \"%{DATA:apache2.access.referrer}\")?( \"%{DATA:apache2.access.agent}\")?",
+        "%{IPORHOST:apache2.access.remote_ip} - %{DATA:apache2.access.user_name} \\[%{HTTPDATE:apache2.access.time}\\] \"%{WORD:apache2.access.method} %{DATA:apache2.access.url} HTTP/%{NUMBER:apache2.access.http_version}\" %{NUMBER:apache2.access.response_code} (?:%{NUMBER:apache2.access.body_sent.bytes}|-)( \"%{DATA:apache2.access.referrer}\")?( \"%{DATA:apache2.access.agent}\")?",
         "%{IPORHOST:apache2.access.remote_ip} - %{DATA:apache2.access.user_name} \\[%{HTTPDATE:apache2.access.time}\\] \"-\" %{NUMBER:apache2.access.response_code} -"
         ],
       "ignore_missing": true


### PR DESCRIPTION
Cherry-pick of PR #3863 to 5.3 branch. Original message: 

Allows a `-` instead of a number for the byte sent part of the Apache access log, as described in http://httpd.apache.org/docs/current/mod/mod_log_config.html

In contrast, Nginx will always output `0` - so no need to change anything there.

There are a few more pieces in the Grok pattern that are not quite in line with what Apache can produce. The Elasticsearch grok processor inherited [a list of patterns](https://github.com/elastic/elasticsearch/blob/master/modules/ingest-common/src/main/resources/patterns/grok-patterns#L95) from Logstash. One of them being `COMBINEDAPACHELOG`, we might want to mirror that in Filebeat. I guess that might be a more intrusive change, while this PR as-is can do no harm and should be fully backward compatible.