### PR TITLE
Fix flaky filebeat test

### DIFF
--- a/filebeat/tests/system/test_registrar.py
+++ b/filebeat/tests/system/test_registrar.py
@@ -237,6 +237,7 @@ class Test(BaseTest):
             path=os.path.abspath(self.working_dir) + "/log/input*",
             scan_frequency="1s",
             close_inactive="1s",
+            clean_removed="false",
         )
 
         if os.name == "nt":


### PR DESCRIPTION
On slow machines (Travis) this test sometimes failed because checking the registrar took so long that it already was cleaned up and some states removed. To make sure no states are removed, clean_removed was disabled for this tests.