### PR TITLE
Fix the Syslog search in the Dashboards

### DIFF
--- a/filebeat/module/system/_meta/kibana/search/Syslog-system-logs.json
+++ b/filebeat/module/system/_meta/kibana/search/Syslog-system-logs.json
@@ -8,7 +8,7 @@
   "title": "Syslog system logs", 
   "version": 1, 
   "kibanaSavedObjectMeta": {
-    "searchSourceJSON": "{\"index\":\"filebeat-*\",\"filter\":[],\"highlight\":{\"pre_tags\":[\"@kibana-highlighted-field@\"],\"post_tags\":[\"@/kibana-highlighted-field@\"],\"fields\":{\"*\":{}},\"require_field_match\":false,\"fragment_size\":2147483647},\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}}}"
+    "searchSourceJSON": "{\"index\":\"filebeat-*\",\"filter\":[],\"highlight\":{\"pre_tags\":[\"@kibana-highlighted-field@\"],\"post_tags\":[\"@/kibana-highlighted-field@\"],\"fields\":{\"*\":{}},\"require_field_match\":false,\"fragment_size\":2147483647},\"query\":{\"query_string\":{\"query\":\"_exists_:system.syslog\",\"analyze_wildcard\":true}},\"highlightAll\":true}"
   }, 
   "columns": [
     "system.syslog.hostname", 


### PR DESCRIPTION
It used to query `*` and I changed it to query `_exists_:system.syslog`, which
will cause less confusion on the Syslog module dashboard.

Probably it added to the confusion in #3912.