### PR TITLE
Ignore audit fileset on macOS

### DIFF
--- a/filebeat/module/system/audit/manifest.yml
+++ b/filebeat/module/system/audit/manifest.yml
@@ -4,7 +4,7 @@ var:
   - name: paths
     default:
       - /var/log/audit/audit.log*
-    os.darwin: []
+    os.darwin: [""]
     os.windows: []
 
 ingest_pipeline: ingest/pipeline.json


### PR DESCRIPTION
Silently ignore audit fileset on macOS.

Fixes #3918