### PR TITLE
Clarify module quick start steps

### DIFF
--- a/filebeat/docs/getting-started.asciidoc
+++ b/filebeat/docs/getting-started.asciidoc
@@ -11,132 +11,15 @@ See {libbeat}/getting-started.html[Getting Started with Beats and the Elastic St
 
 After installing the Elastic Stack, read the following topics to learn how to install, configure, and run Filebeat:
 
-* <<filebeat-modules-quickstart>>
 * <<filebeat-installation>>
 * <<filebeat-configuration>>
 * <<config-filebeat-logstash>>
 * <<filebeat-template>>
 * <<filebeat-starting>>
 * <<filebeat-index-pattern>>
+* <<filebeat-modules-quickstart>>
 * <<filebeat-command-line>>
 * <<directory-layout>>
-
-[[filebeat-modules-quickstart]]
-=== Quick Start for Common Log Formats
-
-beta[]
-
-Filebeat provides a set of pre-built modules that you can use to rapidly
-implement and deploy a log monitoring solution, complete with sample dashboards
-and data visualizations, in about 5 minutes. These modules support common log
-formats, such as Nginx, Apache2, and MySQL, and can be run by issuing a simple
-command.
-
-This topic shows you how to run the basic modules out of the box without extra
-configuration. For detailed documentation and the full list of available
-modules, see <<filebeat-modules>>.
-
-Skip this topic and go to <<filebeat-installation>> if you are using a log file
-type that isn't supported by one of the available Filebeat modules.
-
-==== Prerequisites
-
-Before running Filebeat with modules enabled, you need to:
-
-* Install and configure the Elastic stack. See
-{libbeat}/getting-started.html[Getting Started with Beats and the Elastic Stack].
-
-* Complete the Filebeat installation instructions described in
-<<filebeat-installation>>. After installing Filebeat, return to this
-quick start page.
-
-* Install the Ingest Node GeoIP and User Agent plugins, which you can do by
-running the following commands in the Elasticsearch home path:
-+
-[source,shell]
-----------------------------------------------------------------------
-sudo bin/elasticsearch-plugin install ingest-geoip
-sudo bin/elasticsearch-plugin install ingest-user-agent
-----------------------------------------------------------------------
-+
-You need to restart Elasticsearch after running these commands.
-
-* Verify that Elasticsearch and Kibana are running and that Elasticsearch is
-ready to receive data from Filebeat.
-
-//TODO: Follow up to find out whether ingest-geoip and ingest-user-agent will be bundled with ES. If so, remove the last prepreq.
-
-[[running-modules-quickstart]]
-==== Running Filebeat with Modules Enabled
-
-To run one or more Filebeat modules, you issue the following command:
-
-[source,shell]
-----------------------------------------------------------------------
-filebeat -e -modules=MODULES -setup
-----------------------------------------------------------------------
-
-Where `MODULES` is the name of the module (or a comma-separated list of
-modules) that you want to enable. The `-e` flag is optional and sends output
-to standard error instead of syslog. The `-setup` flag is a one-time setup step.
-For subsequent runs of Filebeat, do not specify this flag.
-
-NOTE: Depending on how you've installed Filebeat, you might see errors
-related to file ownership or permissions when you try to run Filebeat modules.
-See {libbeat}/config-file-permissions.html[Config File Ownership and Permissions]
-in the _Beats Platform Reference_ if you encounter errors related to file
-ownership or permissions.
-
-The following example starts Filebeat with the `system` module enabled and
-loads the sample Kibana dashboards:
-
-[source,shell]
-----------------------------------------------------------------------
-filebeat -e -modules=system -setup
-----------------------------------------------------------------------
-
-This command takes care of configuring Filebeat, loading the recommended index
-template for writing to Elasticsearch, and deploying the sample dashboards
-for visualizing the data in Kibana.
-
-To start Filebeat with the `system`, `nginx`, and `mysql` modules enabled
-and load the sample dashboards, run:
-
-[source,shell]
-----------------------------------------------------------------------
-filebeat -e -modules=system,nginx,mysql -setup
-----------------------------------------------------------------------
-
-To start Filebeat with the `system` module enabled (it's assumed that
-you've already loaded the sample dashboards), run:
-
-[source,shell]
-----------------------------------------------------------------------
-filebeat -e -modules=system
-----------------------------------------------------------------------
-
-TIP: In a production environment, you'll probably want to use a configuration
-file, rather than command-line flags, to specify which modules to run. See the
-detailed documentation for more about configuring and running modules.
-
-These examples assume that the logs you're harvesting are in the location
-expected for your OS and that the default behavior of Filebeat is appropriate
-for your environment. Each module provides a set of variables that you can set
-to fine tune the behavior of Filebeat, including the location where it looks
-for log files. See <<filebeat-modules>> for more info.
-
-[[visualizing-data]]
-==== Visualizing the Data in Kibana
-
-After you've confirmed that Filebeat is sending events to Elasticsearch, launch
-the Kibana web interface by pointing your browser to port 5601. For example,
-http://127.0.0.1:5601[http://127.0.0.1:5601].
-
-Open the dashboard and explore the visualizations for your parsed logs.
-
-Here's an example of the syslog dashboard:
-
-image:./images/kibana-system.png[Sylog dashboard]
 
 [[filebeat-installation]]
 === Step 1: Installing Filebeat
@@ -245,26 +128,21 @@ NOTE: If script execution is disabled on your system, you need to set the execut
 
 endif::[]
 
-If you're using modules to get started with Filebeat, go back to the
-<<filebeat-modules-quickstart>> page.
-
-Otherwise, continue on to <<filebeat-configuration>>.
-
-Before starting Filebeat, you should look at the configuration options in the configuration
-file, for example `C:\Program Files\Filebeat\filebeat.yml` or `/etc/filebeat/filebeat.yml`. For more information about these options,
-see <<filebeat-configuration-details>>.
-
 [[filebeat-configuration]]
 === Step 2: Configuring Filebeat
 
 TIP: <<filebeat-modules-overview,Filebeat modules>> provide the fastest getting
-started experience for common log formats. See <<filebeat-modules-quickstart>> to
-learn how to get started with modules.
+started experience for common log formats. See <<filebeat-modules-quickstart>>
+to learn how to get started with modules. If you use Filebeat modules to get
+started, you can skip the content in this section, including the remaining
+getting started steps, and go directly to the <<filebeat-modules-quickstart>>
+page. 
 
-To configure Filebeat, you edit the configuration file. For rpm and deb, you'll
-find the configuration file at `/etc/filebeat/filebeat.yml`. For mac and win, look in
-the archive that you just extracted. There’s also a full example configuration file
-called `filebeat.full.yml` that shows all non-deprecated options.
+To configure Filebeat manually, you edit the configuration file. For rpm and deb,
+you'll find the configuration file at `/etc/filebeat/filebeat.yml`. For mac and
+win, look in the archive that you just extracted. There’s also a full example
+configuration file called `filebeat.full.yml` that shows all non-deprecated
+options.
 
 See the
 {libbeat}/config-file-format.html[Config File Format] section of the
@@ -321,7 +199,10 @@ options specified: +./filebeat -configtest -e+. Make sure your config files are
 in the path expected by Filebeat (see <<directory-layout>>). If you
 installed from DEB or RPM packages, run +./filebeat.sh -configtest -e+.
 
-See <<filebeat-configuration-details>> for more details about each configuration option.
+Before starting Filebeat, you should look at the configuration options in the
+configuration file, for example `C:\Program Files\Filebeat\filebeat.yml` or
+`/etc/filebeat/filebeat.yml`. For more information about these options,
+see <<filebeat-configuration-details>>.
 
 [[config-filebeat-logstash]]
 === Step 3: Configuring Filebeat to Use Logstash

--- a/filebeat/docs/index.asciidoc
+++ b/filebeat/docs/index.asciidoc
@@ -20,6 +20,8 @@ include::./overview.asciidoc[]
 
 include::./getting-started.asciidoc[]
 
+include::./modules-getting-started.asciidoc[]
+
 include::./command-line.asciidoc[]
 
 include::../../libbeat/docs/shared-directory-layout.asciidoc[]

--- a/filebeat/docs/modules-getting-started.asciidoc
+++ b/filebeat/docs/modules-getting-started.asciidoc
@@ -1,0 +1,119 @@
+[[filebeat-modules-quickstart]]
+=== Quick Start for Common Log Formats
+
+beta[]
+
+Filebeat provides a set of pre-built modules that you can use to rapidly
+implement and deploy a log monitoring solution, complete with sample dashboards
+and data visualizations, in about 5 minutes. These modules support common log
+formats, such as Nginx, Apache2, and MySQL, and can be run by issuing a simple
+command.
+
+This topic shows you how to run the basic modules out of the box without extra
+configuration. For detailed documentation and the full list of available
+modules, see <<filebeat-modules>>.
+
+If you are using a log file type that isn't supported by one of the available
+Filebeat modules, you'll need to set up and configure Filebeat manually by
+following the numbered steps under <<filebeat-getting-started>>. 
+
+==== Prerequisites
+
+Before running Filebeat with modules enabled, you need to:
+
+* Install and configure the Elastic stack. See
+{libbeat}/getting-started.html[Getting Started with Beats and the Elastic Stack].
+
+* Complete the Filebeat installation instructions described in
+<<filebeat-installation>>. After installing Filebeat, return to this
+quick start page.
+
+* Install the Ingest Node GeoIP and User Agent plugins. These plugins are
+required to capture the geographical location and browser information used by
+some of the visualizations available in the sample dashboards. You can install
+these plugins by running the following commands in the Elasticsearch home path:
++
+[source,shell]
+----------------------------------------------------------------------
+sudo bin/elasticsearch-plugin install ingest-geoip
+sudo bin/elasticsearch-plugin install ingest-user-agent
+----------------------------------------------------------------------
++
+You need to restart Elasticsearch after running these commands.
+
+* Verify that Elasticsearch and Kibana are running and that Elasticsearch is
+ready to receive data from Filebeat.
+
+[[running-modules-quickstart]]
+==== Running Filebeat with Modules Enabled
+
+To run one or more Filebeat modules, you issue the following command:
+
+[source,shell]
+----------------------------------------------------------------------
+./filebeat -e -modules=MODULES -setup
+----------------------------------------------------------------------
+
+Where `MODULES` is the name of the module (or a comma-separated list of
+modules) that you want to enable. The `-e` flag is optional and sends output
+to standard error instead of syslog. The `-setup` flag is a one-time setup step.
+For subsequent runs of Filebeat, do not specify this flag.
+
+The following example starts Filebeat with the `system` module enabled and
+loads the sample Kibana dashboards:
+
+[source,shell]
+----------------------------------------------------------------------
+./filebeat -e -modules=system -setup
+----------------------------------------------------------------------
+
+This command takes care of configuring Filebeat, loading the recommended index
+template for writing to Elasticsearch, and deploying the sample dashboards
+for visualizing the data in Kibana.
+
+NOTE: Depending on how you've installed Filebeat, you might see errors
+related to file ownership or permissions when you try to run Filebeat modules.
+See {libbeat}/config-file-permissions.html[Config File Ownership and Permissions]
+in the _Beats Platform Reference_ if you encounter errors related to file
+ownership or permissions.
+
+include::system-module-note.asciidoc[]
+
+To start Filebeat with the `system`, `nginx`, and `mysql` modules enabled
+and load the sample dashboards, run:
+
+[source,shell]
+----------------------------------------------------------------------
+./filebeat -e -modules=system,nginx,mysql -setup
+----------------------------------------------------------------------
+
+To start Filebeat with the `system` module enabled (it's assumed that
+you've already loaded the sample dashboards), run:
+
+[source,shell]
+----------------------------------------------------------------------
+./filebeat -e -modules=system
+----------------------------------------------------------------------
+
+TIP: In a production environment, you'll probably want to use a configuration
+file, rather than command-line flags, to specify which modules to run. See the
+detailed documentation for more about configuring and running modules.
+
+These examples assume that the logs you're harvesting are in the location
+expected for your OS and that the default behavior of Filebeat is appropriate
+for your environment. Each module provides a set of variables that you can set
+to fine tune the behavior of Filebeat, including the location where it looks
+for log files. See <<filebeat-modules>> for more info.
+
+[[visualizing-data]]
+==== Visualizing the Data in Kibana
+
+After you've confirmed that Filebeat is sending events to Elasticsearch, launch
+the Kibana web interface by pointing your browser to port 5601. For example,
+http://127.0.0.1:5601[http://127.0.0.1:5601].
+
+Open the dashboard and explore the visualizations for your parsed logs.
+
+Here's an example of the syslog dashboard:
+
+image:./images/kibana-system.png[Sylog dashboard]

--- a/filebeat/docs/modules-overview.asciidoc
+++ b/filebeat/docs/modules-overview.asciidoc
@@ -37,13 +37,14 @@ Node.
 This tutorial assumes you have Elasticsearch and Kibana installed and
 accessible from Filebeat (see the <<filebeat-getting-started,getting started>>
 section). It also assumes that the Ingest Node GeoIP and User Agent plugins are
-installed, which you can do with the following two commands executed in the
-Elasticsearch home path:
+installed. These plugins are required to capture the geographical location and
+browser information used by some of the visualizations available in the sample
+dashboards. You can install these plugins by running the following commands in the Elasticsearch home path:
 
 [source,shell]
 ----------------------------------------------------------------------
-$ sudo bin/elasticsearch-plugin install ingest-geoip
-$ sudo bin/elasticsearch-plugin install ingest-user-agent
+sudo bin/elasticsearch-plugin install ingest-geoip
+sudo bin/elasticsearch-plugin install ingest-user-agent
 ----------------------------------------------------------------------
 
 You need to restart Elasticsearch after running these commands.
@@ -59,7 +60,7 @@ You can start Filebeat with the following command:
 
 [source,shell]
 ----------------------------------------------------------------------
-$ filebeat -e -modules=nginx -setup
+./filebeat -e -modules=nginx -setup
 ----------------------------------------------------------------------
 
 The `-e` flag tells Filebeat to output its logs to standard error, instead of
@@ -82,8 +83,10 @@ You can also start multiple modules at once:
 
 [source,shell]
 ----------------------------------------------------------------------
-$ filebeat -e -modules=nginx,mysql,system
+./filebeat -e -modules=nginx,mysql,system
 ----------------------------------------------------------------------
+
+include::system-module-note.asciidoc[]
 
 While enabling the modules from the CLI file is handy for getting started and
 for testing, you will probably want to use the configuration file for the
@@ -95,7 +98,7 @@ production setup. The equivalent of the above in the configuration file is:
 filebeat.modules:
 - module: nginx
 - module: mysql
-- module: syslog
+- module: system
 ----------------------------------------------------------------------
 
 Then you can start Filebeat simply with: `./filebeat -e`.
@@ -116,7 +119,7 @@ files are in a custom location:
 
 [source,shell]
 ----------------------------------------------------------------------
-$ filebeat -e -modules=nginx -M "nginx.access.var.paths=[/var/log/nginx/access.log*]"
+./filebeat -e -modules=nginx -M "nginx.access.var.paths=[/var/log/nginx/access.log*]"
 ----------------------------------------------------------------------
 
 Or via the configuration file:
@@ -138,7 +141,7 @@ cannot install the plugins, you can use the following:
 
 [source,shell]
 ----------------------------------------------------------------------
-$ filebeat -e -modules=nginx -M "nginx.access.var.pipeline=no_plugins"
+./filebeat -e -modules=nginx -M "nginx.access.var.pipeline=no_plugins"
 ----------------------------------------------------------------------
 
 ==== Advanced settings
@@ -162,7 +165,7 @@ Or like this:
 
 [source,shell]
 ----------------------------------------------------------------------
-$ filebeat -e -modules=nginx -M "nginx.access.prospector.close_eof=true"
+./filebeat -e -modules=nginx -M "nginx.access.prospector.close_eof=true"
 ----------------------------------------------------------------------
 
 From the CLI, it's possible to change variables or settings for multiple
@@ -171,7 +174,7 @@ modules/fileset at once. For example, the following works and will enable
 
 [source,shell]
 ----------------------------------------------------------------------
-$ filebeat -e -modules=nginx -M "nginx.*.prospector.close_eof=true"
+./filebeat -e -modules=nginx -M "nginx.*.prospector.close_eof=true"
 ----------------------------------------------------------------------
 
 The following also works and will enable `close_eof` for all prospectors
@@ -179,5 +182,5 @@ created by any of the modules:
 
 [source,shell]
 ----------------------------------------------------------------------
-filebeat -e -modules=nginx,mysql -M "*.*.prospector.close_eof=true"
+./filebeat -e -modules=nginx,mysql -M "*.*.prospector.close_eof=true"
 ----------------------------------------------------------------------

--- a/filebeat/docs/system-module-note.asciidoc
+++ b/filebeat/docs/system-module-note.asciidoc
@@ -1,0 +1,19 @@
+[NOTE]
+===============================================================================
+Because Filebeat modules are currently in Beta, the default Filebeat
+configuration may interfere with the Filebeat `system` module configuration. If
+you plan to run the `system` module, edit the Filebeat configuration file,
+`filebeat.yml`, and comment out the following lines:
+
+[source,yaml]
+----------------------------------------------------------------------
+#- input_type: log
+  #paths:
+    #- /var/log/*.log
+----------------------------------------------------------------------
+
+For rpm and deb, you'll find the configuration file at
+`/etc/filebeat/filebeat.yml`. For mac and win, look in the archive that you
+extracted when you installed Filebeat.
+
+===============================================================================


### PR DESCRIPTION
Reorganized content because having the quick start before the install instructions caused some confusion. Decided to keep the quick start in the Getting Started section because I think it raises the visibility of the feature. Created a separate file for the quick start so we can move the content around more easily, if necessary (sorry that it makes it harder to see the diff).

This PR also resolves the following issues:

https://github.com/elastic/beats/issues/3912 - added note
https://github.com/elastic/beats/issues/3910 - added explanation as to why the plugins are required (dev should confirm).  
https://github.com/elastic/beats/issues/3911 - change CLI examples to include `./` but I still think we should revisit this as a larger issue as noted in my comments on the PR

NOTE: I've removed the `$` from CLI examples because we've heard from customers that the symbol is annoying because it makes copying/pasting harder.