### PR TITLE
Don't stop Filebeat when modules + logstash are used together

### DIFF
--- a/filebeat/beater/filebeat.go
+++ b/filebeat/beater/filebeat.go
@@ -75,7 +75,11 @@ func New(b *beat.Beat, rawConfig *common.Config) (beat.Beater, error) {
 func (fb *Filebeat) modulesSetup(b *beat.Beat) error {
 	esConfig := b.Config.Output["elasticsearch"]
 	if esConfig == nil || !esConfig.Enabled() {
-		return fmt.Errorf("Filebeat modules configured but the Elasticsearch output is not configured/enabled")
+		logp.Warn("Filebeat is unable to load the Ingest Node pipelines for the configured" +
+			" modules because the Elasticsearch output is not configured/enabled. If you have" +
+			" already loaded the Ingest Node pipelines or are using Logstash pipelines, you" +
+			" can ignore this warning.")
+		return nil
 	}
 	esClient, err := elasticsearch.NewConnectedClient(esConfig)
 	if err != nil {


### PR DESCRIPTION
To simplify the migration from Ingest Node to Logstash, we replace the
hard error ("Filebeat modules require an Elasticsearch output defined") with
a warning.