### PR TITLE
Remove windows module from the short config file

### DIFF
--- a/metricbeat/metricbeat.yml
+++ b/metricbeat/metricbeat.yml
@@ -46,13 +46,6 @@ metricbeat.modules:
   period: 10s
   processes: ['.*']
 
-#------------------------------- Windows Module ------------------------------
-#- module: windows
-#  metricsets: ["perfmon"]
-#  enabled: true
-#  period: 10s
-#  perfmon.counters:
-
 
 
 #================================ General =====================================

--- a/metricbeat/module/windows/_meta/fields.yml
+++ b/metricbeat/module/windows/_meta/fields.yml
@@ -3,6 +3,7 @@
   description: >
     []beta
     Module for Windows
+  short_config: false
   fields:
     - name: windows
       type: group


### PR DESCRIPTION
Remove the windows module from the short configuration file of Metricbeat, and leave only the system module by default. The configuration of the windows is available in the detailed configuration file of Metricbeat (metricbeat.full.yml).

Related to https://github.com/elastic/beats/pull/3758