### PR TITLE
Fix Winlogbeat test by checking full hostname

### DIFF
--- a/winlogbeat/tests/system/winlogbeat.py
+++ b/winlogbeat/tests/system/winlogbeat.py
@@ -1,4 +1,5 @@
 import os
+import platform
 import sys
 
 if sys.platform.startswith("win"):
@@ -96,7 +97,7 @@ class WriteReadTest(BaseTest):
 
     def assert_common_fields(self, evt, msg=None, eventID=10, sid=None,
                              level="Information", extra=None):
-        assert evt["computer_name"].lower() == win32api.GetComputerName().lower()
+        assert evt["computer_name"].lower() == platform.node().lower()
         assert "record_number" in evt
         self.assertDictContainsSubset({
             "event_id": eventID,


### PR DESCRIPTION
The `computer_name` field in events is the full hostname, but the `win32api.GetComputerName` was returning the shortened netbios name. So the test fail on machines with longer hostnames.