### PR TITLE
Fix Winlogbeat bug affecting include_xml

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -73,6 +73,7 @@ https://github.com/elastic/beats/compare/v5.1.1...master[Check the HEAD diff]
 *Winlogbeat*
 
 - Fix handling of empty strings in event_data. {pull}3705[3705]
+- Fix null terminators include in raw XML string when include_xml is enabled. {pull}3943[3943]
 
 ==== Added
 

--- a/winlogbeat/sys/strings.go
+++ b/winlogbeat/sys/strings.go
@@ -40,6 +40,10 @@ func UTF16ToUTF8Bytes(in []byte, out io.Writer) error {
 	var v1, v2 uint16
 	for i := 0; i < len(in); i += 2 {
 		v1 = uint16(in[i]) | uint16(in[i+1])<<8
+		// Stop at null-terminator.
+		if v1 == 0 {
+			return nil
+		}
 
 		switch {
 		case v1 < surr1, surr3 <= v1:

--- a/winlogbeat/sys/strings_test.go
+++ b/winlogbeat/sys/strings_test.go
@@ -107,6 +107,20 @@ func TestUTF16ToUTF8(t *testing.T) {
 	assert.Equal(t, []byte(input), outputBuf.Bytes())
 }
 
+func TestUTF16BytesToStringTrimNullTerm(t *testing.T) {
+	input := "abc"
+	utf16Bytes := append(toUTF16Bytes(input), []byte{0, 0, 0, 0, 0, 0}...)
+
+	outputBuf := &bytes.Buffer{}
+	err := UTF16ToUTF8Bytes(utf16Bytes, outputBuf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b := outputBuf.Bytes()
+	assert.Len(t, b, 3)
+	assert.Equal(t, input, string(b))
+}
+
 func BenchmarkUTF16ToUTF8(b *testing.B) {
 	utf16Bytes := toUTF16Bytes("A logon was attempted using explicit credentials.")
 	outputBuf := &bytes.Buffer{}

--- a/winlogbeat/tests/system/test_wineventlog.py
+++ b/winlogbeat/tests/system/test_wineventlog.py
@@ -142,6 +142,7 @@ class Test(WriteReadTest):
         self.assertTrue(len(evts), 1)
         self.assert_common_fields(evts[0], msg=msg)
         self.assertTrue("xml" in evts[0])
+        self.assertTrue(evts[0]["xml"].endswith('</Event>'), 'xml value: "{}"'.format(evts[0]["xml"]))
 
     def test_query_event_id(self):
         """


### PR DESCRIPTION
Then `include_xml: true` is used in the config file the raw `xml` value contains null terminators. This PR removes the null characters from the end of the XML string.