### PR TITLE
Downgrade ES bulk item log message

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -55,6 +55,7 @@ https://github.com/elastic/beats/compare/v5.1.1...master[Check the HEAD diff]
   filebeat.config_dir. {pull}3573[3573]
 - Fix empty registry file on machine crash. {issue}3537[3537]
 - Allow `-` in Apache access log byte count. {pull}3863[3863]
+- Downgrade Elasticsearch per batch item failure log to debug level. {issue}3953[3953]
 
 *Heartbeat*
 

--- a/libbeat/outputs/elasticsearch/client.go
+++ b/libbeat/outputs/elasticsearch/client.go
@@ -455,7 +455,7 @@ func bulkCollectPublishFails(
 			continue
 		}
 
-		logp.Info("Bulk item insert failed (i=%v, status=%v): %s", i, status, msg)
+		debugf("Bulk item insert failed (i=%v, status=%v): %s", i, status, msg)
 		failed = append(failed, data[i])
 	}
 


### PR DESCRIPTION
Resolve: #3953

Downgrade logging of per bulk item failures from INFO to DEBUG. In worst case,
every item in a bulk might fail, poluting the logs with loads of similar
messages (one log messages per `bulk_max_size`).