### PR TITLE
Downgrade ES bulk item log message

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -118,6 +118,7 @@ https://github.com/elastic/beats/compare/v5.2.2...v5.3.0[View commits]
 - Add `_id`, `_type`, `_index` and `_score` fields in the generated index pattern. {pull}3282[3282]
 - Fix potential elasticsearch output URL parsing error if protocol scheme is missing. {pull}3671[3671]
 - Improve error message when downloading the dashboards fails. {pull}3805[3805]
+- Downgrade Elasticsearch per batch item failure log to debug level. {issue}3953[3953]
 
 *Filebeat*
 

--- a/libbeat/outputs/elasticsearch/client.go
+++ b/libbeat/outputs/elasticsearch/client.go
@@ -443,7 +443,7 @@ func bulkCollectPublishFails(
 			continue
 		}
 
-		logp.Info("Bulk item insert failed (i=%v, status=%v): %s", i, status, msg)
+		debugf("Bulk item insert failed (i=%v, status=%v): %s", i, status, msg)
 		failed = append(failed, data[i])
 	}
 


### PR DESCRIPTION
Downgrade logging of per bulk item failures from INFO to DEBUG. In worst case,
every item in a bulk might fail, poluting the logs with loads of similar
messages (one log messages per `bulk_max_size`).

(cherry picked from commit 58bd0e16954f374f0104bf5a1e725952e5189b85)