### PR TITLE
Document all fields used in auditd dashboards

### DIFF
--- a/filebeat/docs/fields.asciidoc
+++ b/filebeat/docs/fields.asciidoc
@@ -346,9 +346,13 @@ The audit event sequence number.
 
 
 [float]
-=== auditd.log.pid
+=== auditd.log.acct
 
-type: long
+The user account name associated with the event.
+
+
+[float]
+=== auditd.log.pid
 
 The ID of the process.
 
@@ -356,15 +360,11 @@ The ID of the process.
 [float]
 === auditd.log.ppid
 
-type: long
-
 The ID of the process.
 
 
 [float]
 === auditd.log.items
-
-type: long
 
 The number of items in an event.
 
@@ -372,9 +372,19 @@ The number of items in an event.
 [float]
 === auditd.log.item
 
-type: long
-
 The item field indicates which item out of the total number of items. This number is zero-based; a value of 0 means it is the first item.
+
+
+[float]
+=== auditd.log.a0
+
+This first argument to the system call.
+
+
+[float]
+=== auditd.log.res
+
+This result of the system call (success or failure).
 
 
 [float]

--- a/filebeat/docs/fields.asciidoc
+++ b/filebeat/docs/fields.asciidoc
@@ -378,13 +378,13 @@ The item field indicates which item out of the total number of items. This numbe
 [float]
 === auditd.log.a0
 
-This first argument to the system call.
+The first argument to the system call.
 
 
 [float]
 === auditd.log.res
 
-This result of the system call (success or failure).
+The result of the system call (success or failure).
 
 
 [float]

--- a/filebeat/module/auditd/log/_meta/fields.yml
+++ b/filebeat/module/auditd/log/_meta/fields.yml
@@ -46,10 +46,10 @@
         This number is zero-based; a value of 0 means it is the first item.
     - name: a0
       description: >
-        This first argument to the system call.
+        The first argument to the system call.
     - name: res
       description: >
-        This result of the system call (success or failure).
+        The result of the system call (success or failure).
     - name: geoip
       type: group
       description: >

--- a/filebeat/module/auditd/log/_meta/fields.yml
+++ b/filebeat/module/auditd/log/_meta/fields.yml
@@ -28,23 +28,28 @@
       type: long
       description: >
         The audit event sequence number.
+    - name: acct
+      description: >
+        The user account name associated with the event.
     - name: pid
-      type: long
       description: >
         The ID of the process.
     - name: ppid
-      type: long
       description: >
         The ID of the process.
     - name: items
-      type: long
       description: >
         The number of items in an event.
     - name: item
-      type: long
       description: >
         The item field indicates which item out of the total number of items.
         This number is zero-based; a value of 0 means it is the first item.
+    - name: a0
+      description: >
+        This first argument to the system call.
+    - name: res
+      description: >
+        This result of the system call (success or failure).
     - name: geoip
       type: group
       description: >

--- a/filebeat/module/auditd/log/ingest/pipeline.json
+++ b/filebeat/module/auditd/log/ingest/pipeline.json
@@ -77,34 +77,6 @@
             }
         },
         {
-            "convert": {
-                "field" : "auditd.log.pid",
-                "type": "integer",
-                "ignore_missing": true
-            }
-        },
-        {
-            "convert": {
-                "field" : "auditd.log.ppid",
-                "type": "integer",
-                "ignore_missing": true
-            }
-        },
-        {
-            "convert": {
-                "field" : "auditd.log.item",
-                "type": "integer",
-                "ignore_missing": true
-            }
-        },
-        {
-            "convert": {
-                "field" : "auditd.log.items",
-                "type": "integer",
-                "ignore_missing": true
-            }
-        },
-        {
             "script": {
                 "lang": "painless",
                 "inline": "    String trimQuotes(def v) {\n        if (v.startsWith(\"'\") || v.startsWith('\"')) {\n          v = v.substring(1, v.length());\n        }\n        if (v.endsWith(\"'\") || v.endsWith('\"')) {\n          v = v.substring(0, v.length()-1);\n        }  \n        return v;\n    }\n    \n    boolean isHexAscii(String v) {\n      def len = v.length();\n      if (len == 0 || len % 2 != 0) {\n        return false; \n      }\n  \n      for (int i = 0 ; i < len ; i++) {\n        if (Character.digit(v.charAt(i), 16) == -1) {\n          return false;\n        }\n      }\n\n      return true;\n    }\n    \n    String convertHexToString(String hex) {\n\t    StringBuilder sb = new StringBuilder();\n\n      for (int i=0; i < hex.length() - 1; i+=2) {\n          String output = hex.substring(i, (i + 2));\n          int decimal = Integer.parseInt(output, 16);\n          sb.append((char)decimal);\n      }\n\n      return sb.toString();\n    }\n    \n    def possibleHexKeys = ['exe', 'cmd'];\n    \n    def audit = ctx.auditd.get(\"log\");\n    Iterator entries = audit.entrySet().iterator();\n    while (entries.hasNext()) {\n      def e = entries.next();\n      def k = e.getKey();\n      def v = e.getValue(); \n\n      // Remove entries whose value is ?\n      if (v == \"?\" || v == \"(null)\" || v == \"\") {\n        entries.remove();\n        continue;\n      }\n      \n      // Convert hex values to ASCII.\n      if (possibleHexKeys.contains(k) && isHexAscii(v)) {\n        v = convertHexToString(v);\n        audit.put(k, v);\n      }\n      \n      // Trim quotes.\n      if (v instanceof String) {\n        v = trimQuotes(v);\n        audit.put(k, v);\n      }\n      \n      // Convert arch.\n      if (k == \"arch\" && v == \"c000003e\") {\n        audit.put(k, \"x86_64\");\n      }\n    }"

--- a/filebeat/module/auditd/log/test/test.log-expected.json
+++ b/filebeat/module/auditd/log/test/test.log-expected.json
@@ -59,7 +59,7 @@
                     "syscall": "44",
                     "gid": "0",
                     "fsgid": "0",
-                    "pid": 1281,
+                    "pid": "1281",
                     "suid": "0",
                     "record_type": "SYSCALL",
                     "uid": "0",
@@ -72,7 +72,7 @@
                     "euid": "0",
                     "sequence": 18877199,
                     "a0": "9",
-                    "ppid": 1240,
+                    "ppid": "1240",
                     "a1": "7f564b2672a0",
                     "fsuid": "0",
                     "exit": "184",
@@ -81,7 +81,7 @@
                     "success": "yes",
                     "tty": "(none)",
                     "arch": "x86_64",
-                    "items": 0
+                    "items": "0"
                 }
             },
             "beat": {


### PR DESCRIPTION
To allow the dashboards to load all fields used in the dashboards need to be in the Kibana index pattern.

I also changed pid, ppid, item, and item to just be keywords. There wasn’t really a good reason reason for these to be stored as numbers and sometimes in the events these were set to characters like “?”.