### PR TITLE
Cherry-pick #3884 to 5.x: Add DNS Tunneling dashboard for Packetbeat

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -168,12 +168,10 @@ https://github.com/elastic/beats/compare/v5.2.2...v5.3.0[View commits]
 - The Docker, Kafka, and Prometheus modules are now Beta, instead of experimental. {pull}3525[3525]
 - The HAProxy module is now GA, instead of experimental. {pull}3525[3525]
 - Add the ability to collect the environment variables from system processes. {pull}3337[3337]
+- Adding support for custom http headers and TLS for metricbeat modules {pull}3945[3945]
 
 *Packetbeat*
 - Add DNS Tunneling dashboard to highlight domains with large numbers of subdomains or high data volume. {pull}3884[3884]
-
-*Winlogbeat*
-- Adding support for custom http headers and TLS for metricbeat modules {pull}3945[3945]
 
 ==== Deprecated
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -167,6 +167,15 @@ https://github.com/elastic/beats/compare/v5.2.2...v5.3.0[View commits]
 - The Docker, Kafka, and Prometheus modules are now Beta, instead of experimental. {pull}3525[3525]
 - The HAProxy module is now GA, instead of experimental. {pull}3525[3525]
 - Add the ability to collect the environment variables from system processes. {pull}3337[3337]
+- Add experimental metricset `perfmon` to Windows module. {pull}3758[3758]
+- Add memcached module with stats metricset. {pull}3693[3693]
+
+*Packetbeat*
+- Add `fields` and `fields_under_root` to packetbeat protocols configurations. {pull}3518[3518]
+- Add list style packetbeat protocols configurations. This change supports specifying multiple configurations of the same protocol analyzer. {pull]3518[3518]
+- Add DNS Tunneling dashboard to highlight domains with large numbers of subdomains or high data volume. {pull}3884[3884]
+
+*Winlogbeat*
 
 ==== Deprecated
 

--- a/packetbeat/_meta/kibana/dashboard/DNS-Unique-Domains.json
+++ b/packetbeat/_meta/kibana/dashboard/DNS-Unique-Domains.json
@@ -1,0 +1,13 @@
+{
+  "hits": 0, 
+  "timeRestore": false, 
+  "description": "", 
+  "title": "DNS Tunneling", 
+  "uiStateJSON": "{\"P-1\":{\"spy\":{\"mode\":{\"fill\":false,\"name\":null}},\"vis\":{\"legendOpen\":false,\"colors\":{\"Unique count of dns.question.name\":\"#E0752D\",\"Count\":\"#1F78C1\",\"Unique Subdomain Count\":\"#EF843C\"}}},\"P-2\":{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":null,\"direction\":null}}}},\"P-4\":{\"vis\":{\"legendOpen\":false}},\"P-5\":{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":null,\"direction\":null}}}}}", 
+  "panelsJSON": "[{\"col\":1,\"id\":\"Unique-FQDNs-per-eTLD 1\",\"panelIndex\":1,\"row\":1,\"size_x\":12,\"size_y\":4,\"type\":\"visualization\"},{\"col\":1,\"id\":\"Unique-FQDNs-per-eTLD 1-Table\",\"panelIndex\":2,\"row\":8,\"size_x\":6,\"size_y\":4,\"type\":\"visualization\"},{\"col\":1,\"id\":\"Bytes-Transferred-per-Domain\",\"panelIndex\":4,\"row\":5,\"size_x\":12,\"size_y\":3,\"type\":\"visualization\"},{\"col\":7,\"id\":\"dc743240-1665-11e7-a6de-cbac1a3d0a7d\",\"panelIndex\":5,\"row\":8,\"size_x\":6,\"size_y\":4,\"type\":\"visualization\"}]", 
+  "optionsJSON": "{\"darkTheme\":false}", 
+  "version": 1, 
+  "kibanaSavedObjectMeta": {
+    "searchSourceJSON": "{\"filter\":[{\"query\":{\"query_string\":{\"query\":\"NOT dns.question.type:PTR\",\"analyze_wildcard\":true}}}]}"
+  }
+}

--- a/packetbeat/_meta/kibana/search/DNS.json
+++ b/packetbeat/_meta/kibana/search/DNS.json
@@ -1,0 +1,16 @@
+{
+  "sort": [
+    "@timestamp", 
+    "desc"
+  ], 
+  "hits": 0, 
+  "description": "", 
+  "title": "DNS", 
+  "version": 1, 
+  "kibanaSavedObjectMeta": {
+    "searchSourceJSON": "{\"index\":\"packetbeat-*\",\"query\":{\"query_string\":{\"query\":\"type: dns\",\"analyze_wildcard\":true}},\"filter\":[],\"highlight\":{\"pre_tags\":[\"@kibana-highlighted-field@\"],\"post_tags\":[\"@/kibana-highlighted-field@\"],\"fields\":{\"*\":{}},\"require_field_match\":false,\"fragment_size\":2147483647}}"
+  }, 
+  "columns": [
+    "_source"
+  ]
+}

--- a/packetbeat/_meta/kibana/visualization/Bytes-Transferred-per-Domain.json
+++ b/packetbeat/_meta/kibana/visualization/Bytes-Transferred-per-Domain.json
@@ -1,0 +1,11 @@
+{
+  "visState": "{\"title\":\"Bytes Transferred per Domain\",\"type\":\"histogram\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"scale\":\"linear\",\"mode\":\"grouped\",\"times\":[],\"addTimeMarker\":false,\"defaultYExtents\":true,\"setYExtents\":false,\"yAxis\":{},\"legendPosition\":\"right\"},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"sum\",\"schema\":\"metric\",\"params\":{\"field\":\"bytes_out\",\"customLabel\":\"Bytes Out\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"dns.question.etld_plus_one\",\"size\":20,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"Domains\"}},{\"id\":\"3\",\"enabled\":true,\"type\":\"sum\",\"schema\":\"metric\",\"params\":{\"field\":\"bytes_in\",\"customLabel\":\"Bytes In\"}}],\"listeners\":{}}", 
+  "description": "", 
+  "title": "Bytes Transferred per Domain", 
+  "uiStateJSON": "{\"vis\":{\"colors\":{\"Unique count of dns.question.name\":\"#E0752D\",\"Count\":\"#1F78C1\",\"Bytes Out\":\"#629E51\",\"Bytes In\":\"#F2C96D\"}}}", 
+  "version": 1, 
+  "savedSearchId": "DNS", 
+  "kibanaSavedObjectMeta": {
+    "searchSourceJSON": "{\"filter\":[]}"
+  }
+}

--- a/packetbeat/_meta/kibana/visualization/Unique-FQDNs-per-eTLD 1-Table.json
+++ b/packetbeat/_meta/kibana/visualization/Unique-FQDNs-per-eTLD 1-Table.json
@@ -1,0 +1,11 @@
+{
+  "visState": "{\"title\":\"Unique FQDNs per eTLD+1 Table\",\"type\":\"table\",\"params\":{\"perPage\":10,\"showPartialRows\":false,\"showMeticsAtAllLevels\":false,\"sort\":{\"columnIndex\":null,\"direction\":null},\"showTotal\":false,\"totalFunc\":\"sum\"},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{\"customLabel\":\"\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"dns.question.etld_plus_one\",\"size\":20,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"ETLD+1\"}},{\"id\":\"3\",\"enabled\":true,\"type\":\"cardinality\",\"schema\":\"metric\",\"params\":{\"field\":\"dns.question.name\",\"customLabel\":\"Unique Domains\"}}],\"listeners\":{}}", 
+  "description": "", 
+  "title": "Unique FQDNs per eTLD+1 Table", 
+  "uiStateJSON": "{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":null,\"direction\":null}}}}", 
+  "version": 1, 
+  "savedSearchId": "DNS", 
+  "kibanaSavedObjectMeta": {
+    "searchSourceJSON": "{\"filter\":[]}"
+  }
+}

--- a/packetbeat/_meta/kibana/visualization/Unique-FQDNs-per-eTLD 1.json
+++ b/packetbeat/_meta/kibana/visualization/Unique-FQDNs-per-eTLD 1.json
@@ -1,0 +1,11 @@
+{
+  "visState": "{\"title\":\"Unique FQDNs per eTLD+1\",\"type\":\"histogram\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"scale\":\"linear\",\"mode\":\"grouped\",\"times\":[],\"addTimeMarker\":false,\"defaultYExtents\":true,\"setYExtents\":false,\"yAxis\":{},\"legendPosition\":\"right\"},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"cardinality\",\"schema\":\"metric\",\"params\":{\"field\":\"dns.question.name\",\"customLabel\":\"Unique Subdomain Count\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"dns.question.etld_plus_one\",\"size\":20,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"Domains\"}}],\"listeners\":{}}", 
+  "description": "", 
+  "title": "Unique FQDNs per eTLD+1", 
+  "uiStateJSON": "{\"vis\":{\"colors\":{\"Unique count of dns.question.name\":\"#E0752D\",\"Count\":\"#1F78C1\"}}}", 
+  "version": 1, 
+  "savedSearchId": "DNS", 
+  "kibanaSavedObjectMeta": {
+    "searchSourceJSON": "{\"filter\":[]}"
+  }
+}

--- a/packetbeat/_meta/kibana/visualization/dc743240-1665-11e7-a6de-cbac1a3d0a7d.json
+++ b/packetbeat/_meta/kibana/visualization/dc743240-1665-11e7-a6de-cbac1a3d0a7d.json
@@ -1,0 +1,10 @@
+{
+  "visState": "{\"title\":\"Top Domains by Data Volume\",\"type\":\"table\",\"params\":{\"perPage\":10,\"showPartialRows\":false,\"showMeticsAtAllLevels\":false,\"sort\":{\"columnIndex\":null,\"direction\":null},\"showTotal\":false,\"totalFunc\":\"sum\"},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"sum\",\"schema\":\"metric\",\"params\":{\"field\":\"bytes_in\",\"customLabel\":\"Bytes In\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"dns.question.etld_plus_one\",\"size\":20,\"order\":\"desc\",\"orderBy\":\"3\",\"customLabel\":\"ETLD+1\"}},{\"id\":\"3\",\"enabled\":true,\"type\":\"sum\",\"schema\":\"metric\",\"params\":{\"field\":\"bytes_out\",\"customLabel\":\"Bytes Out\"}}],\"listeners\":{}}", 
+  "description": "", 
+  "title": "Top Domains by Data Volume", 
+  "uiStateJSON": "{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":null,\"direction\":null}}}}", 
+  "version": 1, 
+  "kibanaSavedObjectMeta": {
+    "searchSourceJSON": "{\"index\":\"packetbeat-*\",\"query\":{\"query_string\":{\"query\":\"type:dns\",\"analyze_wildcard\":true}},\"filter\":[]}"
+  }
+}


### PR DESCRIPTION
Cherry-pick of PR #3884 to 5.x branch. Original message: 

The dashboard highlights domains that have large numbers of unique subdomains or high volumes of data.

![dns-tunneling-dashboard](https://cloud.githubusercontent.com/assets/4565752/24572455/cdb10018-1646-11e7-95c3-00f7ddfe85c9.png)
