### PR TITLE
Use t.Run on transport helper tests

### DIFF
--- a/libbeat/outputs/transport/transptest/testing_test.go
+++ b/libbeat/outputs/transport/transptest/testing_test.go
@@ -54,7 +54,7 @@ func TestTransportReconnectsOnConnect(t *testing.T) {
 	timeout := 2 * time.Second
 	GenCertsForIPIfMIssing(t, net.IP{127, 0, 0, 1}, certName)
 
-	run := func(makeServer MockServerFactory, proxy *transport.ProxyConfig) {
+	testServer(t, &config, func(t *testing.T, makeServer MockServerFactory, proxy *transport.ProxyConfig) {
 		server := makeServer(t, timeout, certName, proxy)
 		defer server.Close()
 
@@ -81,12 +81,7 @@ func TestTransportReconnectsOnConnect(t *testing.T) {
 		}
 
 		transp.Close()
-	}
-
-	run(NewMockServerTCP, nil)
-	run(NewMockServerTLS, nil)
-	run(NewMockServerTCP, &config)
-	run(NewMockServerTLS, &config)
+	})
 }
 
 func TestTransportFailConnectUnknownAddress(t *testing.T) {
@@ -98,21 +93,28 @@ func TestTransportFailConnectUnknownAddress(t *testing.T) {
 
 	invalidAddr := "invalid.dns.fqdn-unknown.invalid:100"
 
-	run := func(makeTransp TransportFactory, proxy *transport.ProxyConfig) {
-		transp, err := makeTransp(invalidAddr, proxy)
-		if err != nil {
-			t.Fatalf("failed to generate transport client: %v", err)
-		}
+	run := func(makeTransp TransportFactory, proxy *transport.ProxyConfig) func(*testing.T) {
+		return func(t *testing.T) {
+			transp, err := makeTransp(invalidAddr, proxy)
+			if err != nil {
+				t.Fatalf("failed to generate transport client: %v", err)
+			}
 
-		err = transp.Connect()
-		assert.NotNil(t, err)
+			err = transp.Connect()
+			assert.NotNil(t, err)
+		}
+	}
+
+	factoryTests := func(f TransportFactory) func(*testing.T) {
+		return func(t *testing.T) {
+			t.Run("connect", run(f, nil))
+			t.Run("socks5", run(f, &config))
+		}
 	}
 
 	timeout := 100 * time.Millisecond
-	run(connectTCP(timeout), nil)
-	run(connectTLS(timeout, certName), nil)
-	run(connectTCP(timeout), &config)
-	run(connectTLS(timeout, certName), &config)
+	t.Run("tcp", factoryTests(connectTCP(timeout)))
+	t.Run("tls", factoryTests(connectTLS(timeout, certName)))
 }
 
 func TestTransportClosedOnWriteReadError(t *testing.T) {
@@ -123,7 +125,7 @@ func TestTransportClosedOnWriteReadError(t *testing.T) {
 	timeout := 2 * time.Second
 	GenCertsForIPIfMIssing(t, net.IP{127, 0, 0, 1}, certName)
 
-	run := func(makeServer MockServerFactory, proxy *transport.ProxyConfig) {
+	testServer(t, &config, func(t *testing.T, makeServer MockServerFactory, proxy *transport.ProxyConfig) {
 		server := makeServer(t, timeout, certName, proxy)
 		defer server.Close()
 
@@ -137,10 +139,24 @@ func TestTransportClosedOnWriteReadError(t *testing.T) {
 		transp.Write([]byte("test3"))
 		_, err = transp.Read(buf[:])
 		assert.NotNil(t, err)
+	})
+}
+
+func testServer(t *testing.T, config *transport.ProxyConfig, run func(*testing.T, MockServerFactory, *transport.ProxyConfig)) {
+
+	runner := func(f MockServerFactory, c *transport.ProxyConfig) func(t *testing.T) {
+		return func(t *testing.T) {
+			run(t, f, config)
+		}
 	}
 
-	run(NewMockServerTCP, nil)
-	run(NewMockServerTLS, nil)
-	run(NewMockServerTCP, &config)
-	run(NewMockServerTLS, &config)
+	factoryTests := func(f MockServerFactory) func(t *testing.T) {
+		return func(t *testing.T) {
+			t.Run("connect", runner(f, nil))
+			t.Run("socks5", runner(f, config))
+		}
+	}
+
+	t.Run("tcp", factoryTests(NewMockServerTCP))
+	t.Run("tls", factoryTests(NewMockServerTLS))
 }


### PR DESCRIPTION
Currently up to 4 tests (tls/tcp with and without socks5 proxy) are run within
one unit test. If one fails, no hint which of these 4 tests did fail is given.
Plus, `-test.run` option can not be used to select particular tests.

Using t.Run ensures each sub-test has a name for reporting and filtering
purposes.

New test output:

```
=== RUN   TestTransportReconnectsOnConnect
=== RUN   TestTransportReconnectsOnConnect/tcp
=== RUN   TestTransportReconnectsOnConnect/tcp/connect
=== RUN   TestTransportReconnectsOnConnect/tcp/socks5
=== RUN   TestTransportReconnectsOnConnect/tls
=== RUN   TestTransportReconnectsOnConnect/tls/connect
=== RUN   TestTransportReconnectsOnConnect/tls/socks5
--- PASS: TestTransportReconnectsOnConnect (0.08s)
    --- PASS: TestTransportReconnectsOnConnect/tcp (0.00s)
        --- PASS: TestTransportReconnectsOnConnect/tcp/connect (0.00s)
        --- PASS: TestTransportReconnectsOnConnect/tcp/socks5 (0.00s)
    --- PASS: TestTransportReconnectsOnConnect/tls (0.07s)
        --- PASS: TestTransportReconnectsOnConnect/tls/connect (0.04s)
        --- PASS: TestTransportReconnectsOnConnect/tls/socks5 (0.04s)
=== RUN   TestTransportFailConnectUnknownAddress
=== RUN   TestTransportFailConnectUnknownAddress/tcp
=== RUN   TestTransportFailConnectUnknownAddress/tcp/connect
=== RUN   TestTransportFailConnectUnknownAddress/tcp/socks5
=== RUN   TestTransportFailConnectUnknownAddress/tls
2017/04/10 13:03:18 [ERR] socks: Failed to handle request: Failed to resolve destination 'invalid.dns.fqdn-unknown.invalid': lookup invalid.dns.fqdn-unknown.invalid: no such host
=== RUN   TestTransportFailConnectUnknownAddress/tls/connect
=== RUN   TestTransportFailConnectUnknownAddress/tls/socks5
2017/04/10 13:03:18 [ERR] socks: Failed to handle request: Failed to resolve destination 'invalid.dns.fqdn-unknown.invalid': lookup invalid.dns.fqdn-unknown.invalid: no such host
--- PASS: TestTransportFailConnectUnknownAddress (0.01s)
    --- PASS: TestTransportFailConnectUnknownAddress/tcp (0.00s)
        --- PASS: TestTransportFailConnectUnknownAddress/tcp/connect (0.00s)
        --- PASS: TestTransportFailConnectUnknownAddress/tcp/socks5 (0.00s)
    --- PASS: TestTransportFailConnectUnknownAddress/tls (0.00s)
        --- PASS: TestTransportFailConnectUnknownAddress/tls/connect (0.00s)
        --- PASS: TestTransportFailConnectUnknownAddress/tls/socks5 (0.00s)
=== RUN   TestTransportClosedOnWriteReadError
=== RUN   TestTransportClosedOnWriteReadError/tcp
=== RUN   TestTransportClosedOnWriteReadError/tcp/connect
=== RUN   TestTransportClosedOnWriteReadError/tcp/socks5
=== RUN   TestTransportClosedOnWriteReadError/tls
=== RUN   TestTransportClosedOnWriteReadError/tls/connect
=== RUN   TestTransportClosedOnWriteReadError/tls/socks5
--- PASS: TestTransportClosedOnWriteReadError (0.04s)
    --- PASS: TestTransportClosedOnWriteReadError/tcp (0.00s)
        --- PASS: TestTransportClosedOnWriteReadError/tcp/connect (0.00s)
        --- PASS: TestTransportClosedOnWriteReadError/tcp/socks5 (0.00s)
    --- PASS: TestTransportClosedOnWriteReadError/tls (0.04s)
        --- PASS: TestTransportClosedOnWriteReadError/tls/connect (0.02s)
        --- PASS: TestTransportClosedOnWriteReadError/tls/socks5 (0.02s)
PASS
```