### PR TITLE
Cherry-pick #3924 to 5.x: heartbeat: setup default ports in http monitors

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -123,7 +123,9 @@ https://github.com/elastic/beats/compare/v5.2.2...v5.3.0[View commits]
 *Filebeat*
 
 - Fix empty registry file on machine crash. {issue}3537[3537]
+
 *Heartbeat*
+
 - Add default ports in HTTP monitor. {pull}3924[3924]
 
 *Metricbeat*

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -123,6 +123,8 @@ https://github.com/elastic/beats/compare/v5.2.2...v5.3.0[View commits]
 *Filebeat*
 
 - Fix empty registry file on machine crash. {issue}3537[3537]
+*Heartbeat*
+- Add default ports in HTTP monitor. {pull}3924[3924]
 
 *Metricbeat*
 

--- a/heartbeat/monitors/active/http/task.go
+++ b/heartbeat/monitors/active/http/task.go
@@ -213,25 +213,24 @@ func execPing(
 }
 
 func splitHostnamePort(requ *http.Request) (string, uint16, error) {
-	host, port, err := net.SplitHostPort(requ.URL.Host)
+	host := requ.URL.Host
+	// Try to add a default port if needed
+	if strings.LastIndex(host, ":") == -1 {
+		switch requ.URL.Scheme {
+		case urlSchemaHTTP:
+			host += ":80"
+		case urlSchemaHTTPS:
+			host += ":443"
+		}
+	}
+	host, port, err := net.SplitHostPort(host)
 	if err != nil {
 		return "", 0, err
 	}
-	var p uint64
-	if port == "" {
-		switch requ.URL.Scheme {
-		case urlSchemaHTTP:
-			p = 80
-		case urlSchemaHTTPS:
-			p = 443
-		}
-	} else {
-		p, err = strconv.ParseUint(port, 10, 16)
-		if err != nil {
-			return "", 0, fmt.Errorf("'%v' is no valid port number in '%v'", port, requ.URL.Host)
-		}
+	p, err := strconv.ParseUint(port, 10, 16)
+	if err != nil {
+		return "", 0, fmt.Errorf("'%v' is no valid port number in '%v'", port, requ.URL.Host)
 	}
-
 	return host, uint16(p), nil
 }
 

--- a/heartbeat/monitors/active/http/task.go
+++ b/heartbeat/monitors/active/http/task.go
@@ -217,10 +217,19 @@ func splitHostnamePort(requ *http.Request) (string, uint16, error) {
 	if err != nil {
 		return "", 0, err
 	}
-
-	p, err := strconv.ParseUint(port, 10, 16)
-	if err != nil {
-		return "", 0, fmt.Errorf("'%v' is no valid port number in '%v'", port, requ.URL.Host)
+	var p uint64
+	if port == "" {
+		switch requ.URL.Scheme {
+		case urlSchemaHTTP:
+			p = 80
+		case urlSchemaHTTPS:
+			p = 443
+		}
+	} else {
+		p, err = strconv.ParseUint(port, 10, 16)
+		if err != nil {
+			return "", 0, fmt.Errorf("'%v' is no valid port number in '%v'", port, requ.URL.Host)
+		}
 	}
 
 	return host, uint16(p), nil

--- a/heartbeat/monitors/active/http/task_test.go
+++ b/heartbeat/monitors/active/http/task_test.go
@@ -1,0 +1,93 @@
+package http
+
+import (
+	"net"
+	"net/http"
+	"net/url"
+	"reflect"
+	"testing"
+)
+
+func TestSplitHostnamePort(t *testing.T) {
+	var urlTests = []struct {
+		scheme        string
+		host          string
+		expectedHost  string
+		expectedPort  uint16
+		expectedError error
+	}{
+		{
+			"http",
+			"foo",
+			"foo",
+			80,
+			nil,
+		},
+		{
+			"http",
+			"www.foo.com",
+			"www.foo.com",
+			80,
+			nil,
+		},
+		{
+			"http",
+			"www.foo.com:8080",
+			"www.foo.com",
+			8080,
+			nil,
+		},
+		{
+			"https",
+			"foo",
+			"foo",
+			443,
+			nil,
+		},
+		{
+			"http",
+			"foo:81",
+			"foo",
+			81,
+			nil,
+		},
+		{
+			"https",
+			"foo:444",
+			"foo",
+			444,
+			nil,
+		},
+		{
+			"httpz",
+			"foo",
+			"foo",
+			81,
+			&net.AddrError{},
+		},
+	}
+	for _, test := range urlTests {
+		url := &url.URL{
+			Scheme: test.scheme,
+			Host:   test.host,
+		}
+		request := &http.Request{
+			URL: url,
+		}
+		host, port, err := splitHostnamePort(request)
+		if err != nil {
+			if test.expectedError == nil {
+				t.Error(err)
+			} else if reflect.TypeOf(err) != reflect.TypeOf(test.expectedError) {
+				t.Errorf("Expected %T but got %T", err, test.expectedError)
+			}
+			continue
+		}
+		if host != test.expectedHost {
+			t.Errorf("Unexpected host for %#v: expected %q, got %q", request, test.expectedHost, host)
+		}
+		if port != test.expectedPort {
+			t.Errorf("Unexpected port for %#v: expected %q, got %q", request, test.expectedPort, port)
+		}
+	}
+}


### PR DESCRIPTION
Cherry-pick of PR #3924 to 5.x branch. Original message: 

Default http to 80 and https to 443

Resolves https://github.com/elastic/beats/issues/3915