### PR TITLE
Add url format in the index pattern

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -106,6 +106,7 @@ https://github.com/elastic/beats/compare/v5.1.1...master[Check the HEAD diff]
 - Add kubernetes processor {pull}3888[3888]
 - Add support for include_labels and include_annotations in kubernetes processor {pull}4043[4043]
 - Support new `index_patterns` field when loading templates for Elasticsearch >= 6.0 {pull}4056[4056]
+- Add the Url format in fields.yml. {pull}3979[3979]
 
 *Filebeat*
 

--- a/libbeat/_meta/fields.common.yml
+++ b/libbeat/_meta/fields.common.yml
@@ -11,15 +11,15 @@
         set in the configuration file, then that value is used. If it is not
         set, the hostname is used. To set the Beat name, use the `name`
         option in the configuration file.
-      format: url
-      params: 
-        urlTemplate: "../app/kibana#/dashboard/79ffd6e0-faa0-11e6-947f-177f697178b8?_a=(query:(query_string:(analyze_wildcard:!t,query:'beat.hostname:{{value}}')))"
-        labelTemplate: "{{value}}"
-
     - name: beat.hostname
       description: >
         The hostname as returned by the operating system on which the Beat is
         running.
+      metricbeat.format: url
+      metricbeat.params:
+        urlTemplate: "../app/kibana#/dashboard/79ffd6e0-faa0-11e6-947f-177f697178b8?_a=(query:(query_string:(analyze_wildcard:!t,query:'beat.hostname:{{value}}')))"
+        labelTemplate: "{{value}}"
+
     - name: beat.timezone
       description: >
         The timezone as returned by the operating system on which the Beat is

--- a/libbeat/_meta/fields.common.yml
+++ b/libbeat/_meta/fields.common.yml
@@ -11,6 +11,11 @@
         set in the configuration file, then that value is used. If it is not
         set, the hostname is used. To set the Beat name, use the `name`
         option in the configuration file.
+      format: url
+      params: 
+        urlTemplate: "../app/kibana#/dashboard/79ffd6e0-faa0-11e6-947f-177f697178b8?_a=(query:(query_string:(analyze_wildcard:!t,query:'beat.hostname:{{value}}')))"
+        labelTemplate: "{{value}}"
+
     - name: beat.hostname
       description: >
         The hostname as returned by the operating system on which the Beat is

--- a/libbeat/scripts/generate_index_pattern.py
+++ b/libbeat/scripts/generate_index_pattern.py
@@ -76,9 +76,13 @@ def field_to_json(desc, path, output,
     output["fields"].append(field)
 
     if "format" in desc:
-        output["fieldFormatMap"][path] = {
+        format = {
             "id": desc["format"],
         }
+        if "params" in desc:
+            format["params"] = desc["params"]
+
+        output["fieldFormatMap"][path] = format
 
 
 def fields_to_index_pattern(args, input):

--- a/libbeat/scripts/generate_index_pattern.py
+++ b/libbeat/scripts/generate_index_pattern.py
@@ -17,7 +17,7 @@ import sys
 unique_fields = []
 
 
-def fields_to_json(section, path, output):
+def fields_to_json(section, path, output, beat_name):
 
     # Need in case there are no fields
     if section["fields"] is None:
@@ -30,12 +30,36 @@ def fields_to_json(section, path, output):
             newpath = path + "." + field["name"]
 
         if "type" in field and field["type"] == "group":
-            fields_to_json(field, newpath, output)
+            fields_to_json(field, newpath, output, beat_name)
         else:
-            field_to_json(field, newpath, output)
+            field_to_json(field, newpath, output, beat_name)
 
 
-def field_to_json(desc, path, output,
+#####
+# This functions eliminates from the description of a field, the options that are
+# defined for other Beats than beat_name
+# Example:
+#  name: beat.name
+#  metricbeat.format: url
+#  metricbeat.params: ...
+#####
+def filter_field_desc(desc, beat_name):
+
+    new_desc = {}
+
+    for key in desc:
+        namespaces = key.split('.')
+
+        if len(namespaces) > 1:
+            if namespaces[0] == beat_name:
+                new_desc[namespaces[1]] = desc[key]
+        else:
+            new_desc[key] = desc[key]
+
+    return new_desc
+
+
+def field_to_json(desc, path, output, beat_name,
                   indexed=True, analyzed=False, doc_values=True,
                   searchable=True, aggregatable=True):
 
@@ -47,6 +71,8 @@ def field_to_json(desc, path, output,
         sys.exit(1)
     else:
         unique_fields.append(path)
+
+    desc = filter_field_desc(desc, beat_name)
 
     field = {
         "name": path,
@@ -85,7 +111,7 @@ def field_to_json(desc, path, output,
         output["fieldFormatMap"][path] = format
 
 
-def fields_to_index_pattern(args, input):
+def fields_to_index_pattern(args, input, beat_name):
 
     docs = yaml.load(input)
 
@@ -102,23 +128,23 @@ def fields_to_index_pattern(args, input):
     }
 
     for k, section in enumerate(docs):
-        fields_to_json(section, "", output)
+        fields_to_json(section, "", output, beat_name)
 
     # add meta fields
 
-    field_to_json({"name": "_id", "type": "keyword"}, "_id", output,
+    field_to_json({"name": "_id", "type": "keyword"}, "_id", output, beat_name,
                   indexed=False, analyzed=False, doc_values=False,
                   searchable=False, aggregatable=False)
 
-    field_to_json({"name": "_type", "type": "keyword"}, "_type", output,
+    field_to_json({"name": "_type", "type": "keyword"}, "_type", output, beat_name,
                   indexed=False, analyzed=False, doc_values=False,
                   searchable=True, aggregatable=True)
 
-    field_to_json({"name": "_index", "type": "keyword"}, "_index", output,
+    field_to_json({"name": "_index", "type": "keyword"}, "_index", output, beat_name,
                   indexed=False, analyzed=False, doc_values=False,
                   searchable=False, aggregatable=False)
 
-    field_to_json({"name": "_score", "type": "integer"}, "_score", output,
+    field_to_json({"name": "_score", "type": "integer"}, "_score", output, beat_name,
                   indexed=False, analyzed=False, doc_values=False,
                   searchable=False, aggregatable=False)
 
@@ -144,13 +170,14 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     fields_yml = args.beat + "/fields.yml"
+    beat_name = os.path.basename(args.beat)
 
     # generate the index-pattern content
     with open(fields_yml, 'r') as f:
         fields = f.read()
 
         # with open(target, 'w') as output:
-        output = fields_to_index_pattern(args, fields)
+        output = fields_to_index_pattern(args, fields, beat_name)
 
     # dump output to a json file
     fileName = get_index_pattern_name(args.index)

--- a/metricbeat/docs/fields.asciidoc
+++ b/metricbeat/docs/fields.asciidoc
@@ -378,6 +378,8 @@ Contains common beat fields available in all event types.
 [float]
 === beat.name
 
+format: url
+
 The name of the Beat sending the log messages. If the Beat name is set in the configuration file, then that value is used. If it is not set, the hostname is used. To set the Beat name, use the `name` option in the configuration file.
 
 

--- a/metricbeat/docs/fields.asciidoc
+++ b/metricbeat/docs/fields.asciidoc
@@ -378,8 +378,6 @@ Contains common beat fields available in all event types.
 [float]
 === beat.name
 
-format: url
-
 The name of the Beat sending the log messages. If the Beat name is set in the configuration file, then that value is used. If it is not set, the hostname is used. To set the Beat name, use the `name` option in the configuration file.
 
 


### PR DESCRIPTION
Add the Url format in the `fields.yml`, in order to generate an index pattern with an Url field. The Url link is needed in order to link the `beat.name` to a host-specific dashboard.

Here is an example on how to make `beat.name` a link to a dashboard:
```
name: beat.name
   metricbeat.format: url
   metricbeat.params: 
       urlTemplate: "../app/kibana#/dashboard/79ffd6e0-faa0-11e6-947f-177f697178b8?_a=(query:    (query_string:(analyze_wildcard:!t,query:'beat.hostname:{{value}}'"
       labelTemplate: "{{value}}"
```
As a result, the host name appears as a link to the dashboard in all the tables.
![screen shot 2017-04-10 at 7 35 00 pm](https://cloud.githubusercontent.com/assets/11757159/24874410/d40e6b18-1e24-11e7-8f69-300d2e4d55fe.png)