### PR TITLE
Set release state to unreleased

### DIFF
--- a/libbeat/docs/version.asciidoc
+++ b/libbeat/docs/version.asciidoc
@@ -1,4 +1,4 @@
 :stack-version: 5.4.0
 :doc-branch: 5.x
 :go-version: 1.7.4
-:release-state: released
+:release-state: unreleased


### PR DESCRIPTION
Release state for 5.x should be `unreleased`.

Reviewer: Please feel free to merge this directly after reviewing. This does not need cherrypicking and is unlikely to break the build.