### PR TITLE
fix comment of network IO metrics

### DIFF
--- a/metricbeat/module/system/network/network.go
+++ b/metricbeat/module/system/network/network.go
@@ -54,7 +54,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	}, nil
 }
 
-// Fetch fetches disk IO metrics from the OS.
+// Fetch fetches network IO metrics from the OS.
 func (m *MetricSet) Fetch() ([]common.MapStr, error) {
 	stats, err := net.IOCounters(true)
 	if err != nil {


### PR DESCRIPTION
Fixed comments in network.go.
I think that it is network io instead of disk io.