### PR TITLE
Change error to error.message

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -18,7 +18,8 @@ https://github.com/elastic/beats/compare/v5.1.1...master[Check the HEAD diff]
 - Configuration files must be owned by the user running the beat or by root, and
   they must not be writable by others. {pull}3544[3544] {pull}3689[3689]
 - Usage of field `_type` is now ignored and hardcoded to `doc`. {pull}3757[3757]
-- Change vendor manager from glide to govendor {pull}3851[3851]
+- Change vendor manager from glide to govendor. {pull}3851[3851]
+- Rename `error` field to `error.message`. {pull}3987[3987]
 
 *Filebeat*
 - Always use absolute path for event and registry. This can lead to issues when relative paths were used before. {pull}3328[3328]

--- a/filebeat/docs/fields.asciidoc
+++ b/filebeat/docs/fields.asciidoc
@@ -493,6 +493,37 @@ type: object
 Contains user configurable fields.
 
 
+[float]
+== error Fields
+
+Error fields containing additional info in case of errors.
+
+
+
+[float]
+=== error.message
+
+type: text
+
+Error message.
+
+
+[float]
+=== error.code
+
+type: long
+
+Error code.
+
+
+[float]
+=== error.type
+
+type: keyword
+
+Error type.
+
+
 [[exported-fields-cloud]]
 == Cloud Provider Metadata Fields
 

--- a/filebeat/docs/modules-dev-guide.asciidoc
+++ b/filebeat/docs/modules-dev-guide.asciidoc
@@ -159,7 +159,7 @@ exclude_files: [".gz$"]
 
 You'll find this example in the template file that gets generated automatically
 when you run `make create-fileset`. In this example, the `paths` variable is
-used to construct the `paths` list for the <<prospector-paths>> option. 
+used to construct the `paths` list for the <<prospector-paths>> option.
 
 Any template files that you add to the `config/` folder need to generate a valid
 Filebeat prospector configuration in YAML format. The options accepted by the
@@ -167,7 +167,7 @@ prospector configuration are documented in this
 <<configuration-filebeat-options,section>>.
 
 The template files use the templating language defined by the
-https://golang.org/pkg/text/template/[Golang standard library]. 
+https://golang.org/pkg/text/template/[Golang standard library].
 
 Here is another example that also configures multiline stitching:
 
@@ -192,7 +192,7 @@ variables to dynamically switch between configurations.
 [float]
 ==== ingest/*.json
 
-The `ingest/` folder contains Elasticsearch 
+The `ingest/` folder contains Elasticsearch
 {elasticsearch}/ingest.html[Ingest Node] pipeline configurations. The Ingest
 Node pipelines are responsible for parsing the log lines and doing other
 manipulations on the data.
@@ -212,7 +212,7 @@ The generator creates a JSON object similar to this one:
     ],
   "on_failure" : [{
     "set" : {
-      "field" : "error",
+      "field" : "error.message",
       "value" : "{{ _ingest.on_failure_message }}"
     }
   }]
@@ -221,7 +221,7 @@ The generator creates a JSON object similar to this one:
 
 From here, you would typically add processors to the `processors` array to do
 the actual parsing. For details on how to use ingest node processors, see the
-{elasticsearch}/ingest-processors.html[ingest node documentation]. In 
+{elasticsearch}/ingest-processors.html[ingest node documentation]. In
 particular, you will likely find the
 {elasticsearch}/grok-processor.html[Grok processor] to be useful for parsing.
 Here is an example for parsing the Nginx access logs.

--- a/filebeat/module/apache2/access/ingest/default.json
+++ b/filebeat/module/apache2/access/ingest/default.json
@@ -47,7 +47,7 @@
   }],
   "on_failure" : [{
     "set" : {
-      "field" : "error",
+      "field" : "error.message",
       "value" : "{{ _ingest.on_failure_message }}"
     }
   }]

--- a/filebeat/module/apache2/error/ingest/pipeline.json
+++ b/filebeat/module/apache2/error/ingest/pipeline.json
@@ -43,7 +43,7 @@
   ],
   "on_failure" : [{
     "set" : {
-      "field" : "error",
+      "field" : "error.message",
       "value" : "{{ _ingest.on_failure_message }}"
     }
   }]

--- a/filebeat/module/auditd/log/ingest/pipeline.json
+++ b/filebeat/module/auditd/log/ingest/pipeline.json
@@ -93,7 +93,7 @@
     "on_failure": [
         {
             "set": {
-                "field": "error",
+                "field": "error.message",
                 "value": "{{ _ingest.on_failure_message }}"
             }
         }

--- a/filebeat/module/mysql/error/ingest/pipeline.json
+++ b/filebeat/module/mysql/error/ingest/pipeline.json
@@ -43,7 +43,7 @@
     }],
   "on_failure" : [{
     "set" : {
-      "field" : "error",
+      "field" : "error.message",
       "value" : "{{ _ingest.on_failure_message }}"
     }
   }]

--- a/filebeat/module/mysql/slowlog/ingest/pipeline.json
+++ b/filebeat/module/mysql/slowlog/ingest/pipeline.json
@@ -32,7 +32,7 @@
   }],
   "on_failure" : [{
     "set" : {
-      "field" : "error",
+      "field" : "error.message",
       "value" : "{{ _ingest.on_failure_message }}"
     }
   }]

--- a/filebeat/module/nginx/access/ingest/default.json
+++ b/filebeat/module/nginx/access/ingest/default.json
@@ -44,7 +44,7 @@
   }],
   "on_failure" : [{
     "set" : {
-      "field" : "error",
+      "field" : "error.message",
       "value" : "{{ _ingest.on_failure_message }}"
     }
   }]

--- a/filebeat/module/nginx/error/ingest/pipeline.json
+++ b/filebeat/module/nginx/error/ingest/pipeline.json
@@ -30,7 +30,7 @@
   }],
   "on_failure" : [{
     "set" : {
-      "field" : "error",
+      "field" : "error.message",
       "value" : "{{ _ingest.on_failure_message }}"
     }
   }]

--- a/filebeat/module/system/auth/ingest/pipeline.json
+++ b/filebeat/module/system/auth/ingest/pipeline.json
@@ -45,7 +45,7 @@
   ],
   "on_failure" : [{
     "set" : {
-      "field" : "error",
+      "field" : "error.message",
       "value" : "{{ _ingest.on_failure_message }}"
     }
   }]

--- a/filebeat/module/system/syslog/ingest/pipeline.json
+++ b/filebeat/module/system/syslog/ingest/pipeline.json
@@ -33,7 +33,7 @@
 	],
   "on_failure" : [{
     "set" : {
-      "field" : "error",
+      "field" : "error.message",
       "value" : "{{ _ingest.on_failure_message }}"
     }
   }]

--- a/filebeat/scripts/module/fileset/ingest/pipeline.json
+++ b/filebeat/scripts/module/fileset/ingest/pipeline.json
@@ -4,7 +4,7 @@
     ],
   "on_failure" : [{
     "set" : {
-      "field" : "error",
+      "field" : "error.message",
       "value" : "{{ _ingest.on_failure_message }}"
     }
   }]

--- a/heartbeat/_meta/fields.yml
+++ b/heartbeat/_meta/fields.yml
@@ -130,17 +130,3 @@
       description: >
         Boolean indicator if monitor could validate the service to be available.
 
-    - name: error
-      type: group
-      description: >
-        Reason monitor flagging a service as down.
-      fields:
-        - name: type
-          type: keyword
-          description: >
-            Failure type. For example `io` or `validate`.
-
-        - name: message
-          type: text
-          description: >
-            Failure description.

--- a/heartbeat/docs/fields.asciidoc
+++ b/heartbeat/docs/fields.asciidoc
@@ -76,6 +76,37 @@ type: object
 Contains user configurable fields.
 
 
+[float]
+== error Fields
+
+Error fields containing additional info in case of errors.
+
+
+
+[float]
+=== error.message
+
+type: text
+
+Error message.
+
+
+[float]
+=== error.code
+
+type: long
+
+Error code.
+
+
+[float]
+=== error.type
+
+type: keyword
+
+Error type.
+
+
 [[exported-fields-cloud]]
 == Cloud Provider Metadata Fields
 
@@ -323,28 +354,5 @@ type: boolean
 required: True
 
 Boolean indicator if monitor could validate the service to be available.
-
-
-[float]
-== error Fields
-
-Reason monitor flagging a service as down.
-
-
-
-[float]
-=== error.type
-
-type: keyword
-
-Failure type. For example `io` or `validate`.
-
-
-[float]
-=== error.message
-
-type: text
-
-Failure description.
 
 

--- a/libbeat/_meta/fields.common.yml
+++ b/libbeat/_meta/fields.common.yml
@@ -42,3 +42,20 @@
       description: >
         Contains user configurable fields.
 
+    - name: error
+      type: group
+      description: >
+        Error fields containing additional info in case of errors.
+      fields:
+        - name: message
+          type: text
+          description: >
+            Error message.
+        - name: code
+          type: long
+          description: >
+            Error code.
+        - name: type
+          type: keyword
+          description: >
+            Error type.

--- a/metricbeat/docs/fields.asciidoc
+++ b/metricbeat/docs/fields.asciidoc
@@ -426,6 +426,37 @@ type: object
 Contains user configurable fields.
 
 
+[float]
+== error Fields
+
+Error fields containing additional info in case of errors.
+
+
+
+[float]
+=== error.message
+
+type: text
+
+Error message.
+
+
+[float]
+=== error.code
+
+type: long
+
+Error code.
+
+
+[float]
+=== error.type
+
+type: keyword
+
+Error type.
+
+
 [[exported-fields-ceph]]
 == ceph Fields
 

--- a/metricbeat/docs/how-metricbeat-works.asciidoc
+++ b/metricbeat/docs/how-metricbeat-works.asciidoc
@@ -98,7 +98,9 @@ reachable:
     "hostname": "host.example.com",
     "name": "host.example.com"
   },
-  "error": "Get http://127.0.0.1/server-status?auto: dial tcp 127.0.0.1:80: getsockopt: connection refused",
+  "error": {
+    "message": "Get http://127.0.0.1/server-status?auto: dial tcp 127.0.0.1:80: getsockopt: connection refused",
+  },
   "metricset": {
     "module": "apache",
     "name": "status",

--- a/metricbeat/mb/module/event.go
+++ b/metricbeat/mb/module/event.go
@@ -103,7 +103,9 @@ func (b EventBuilder) Build() (common.MapStr, error) {
 
 	// Adds error to event in case error happened
 	if b.fetchErr != nil {
-		event["error"] = b.fetchErr.Error()
+		event["error"] = common.MapStr{
+			"message": b.fetchErr.Error(),
+		}
 	}
 
 	return event, nil

--- a/metricbeat/mb/module/event_test.go
+++ b/metricbeat/mb/module/event_test.go
@@ -65,7 +65,7 @@ func TestEventBuilderError(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assert.Equal(t, errFetch.Error(), event["error"])
+	assert.Equal(t, errFetch.Error(), event["error"].(common.MapStr)["message"])
 }
 
 func TestEventBuilderNoHost(t *testing.T) {

--- a/packetbeat/docs/fields.asciidoc
+++ b/packetbeat/docs/fields.asciidoc
@@ -415,6 +415,37 @@ type: object
 Contains user configurable fields.
 
 
+[float]
+== error Fields
+
+Error fields containing additional info in case of errors.
+
+
+
+[float]
+=== error.message
+
+type: text
+
+Error message.
+
+
+[float]
+=== error.code
+
+type: long
+
+Error code.
+
+
+[float]
+=== error.type
+
+type: keyword
+
+Error type.
+
+
 [[exported-fields-cassandra]]
 == Cassandra Fields
 

--- a/winlogbeat/docs/fields.asciidoc
+++ b/winlogbeat/docs/fields.asciidoc
@@ -77,6 +77,37 @@ type: object
 Contains user configurable fields.
 
 
+[float]
+== error Fields
+
+Error fields containing additional info in case of errors.
+
+
+
+[float]
+=== error.message
+
+type: text
+
+Error message.
+
+
+[float]
+=== error.code
+
+type: long
+
+Error code.
+
+
+[float]
+=== error.type
+
+type: keyword
+
+Error type.
+
+
 [[exported-fields-cloud]]
 == Cloud Provider Metadata Fields
 


### PR DESCRIPTION
Currently error message in metricbeat are written into the `error` field. In heartbeat `error.message` is used. To unify the error structure and allow in the future to support things like `error.code` and others inside the error, `error` is changed to `error.message`.

Currently internally all `error` are just written to `error.message`. In future PR's an internal logic should be added to support `error.code` and others so  Metricsets, Prospectors etc. can make use of it.

Changes

* Change `error` to `error.message`
* Move error mappings from heartbeat to libbeat

Closes #3951