### PR TITLE
reviewdog: ignore underscores in package names

### DIFF
--- a/reviewdog.yml
+++ b/reviewdog.yml
@@ -1,3 +1,3 @@
 runner:
   golint:
-    cmd: golint $(go list ./... | grep -v /vendor/)
+    cmd: golint $(go list ./... | grep -v /vendor/) | grep -v "don't use an underscore in package name"


### PR DESCRIPTION
Unfortunately this is the best we can do between golint and reviewdog:

https://github.com/golang/lint/issues/98#issuecomment-69813135