### PR TITLE
Update curl examples to include content-type

### DIFF
--- a/libbeat/docs/shared-config-ingest.asciidoc
+++ b/libbeat/docs/shared-config-ingest.asciidoc
@@ -50,7 +50,7 @@ To add the pipeline in Elasticsearch, you would run:
 
 [source,shell]
 ------------------------------------------------------------------------------
-curl -XPUT 'http://localhost:9200/_ingest/pipeline/test-pipeline' -d@pipeline.json
+curl -H 'Content-Type: application/json' -XPUT 'http://localhost:9200/_ingest/pipeline/test-pipeline' -d@pipeline.json
 ------------------------------------------------------------------------------
 
 Then in the +{beatname_lc}.yml+ file, you would specify:

--- a/libbeat/docs/shared-template-load.asciidoc
+++ b/libbeat/docs/shared-template-load.asciidoc
@@ -67,7 +67,7 @@ ifdef::allplatforms[]
 
 ["source","sh",subs="attributes,callouts"]
 ----------------------------------------------------------------------
-curl -XPUT 'http://localhost:9200/_template/{beatname_lc}' -d@/etc/{beatname_lc}/{beatname_lc}.template.json
+curl -H 'Content-Type: application/json' -XPUT 'http://localhost:9200/_template/{beatname_lc}' -d@/etc/{beatname_lc}/{beatname_lc}.template.json
 ----------------------------------------------------------------------
 
 *mac:*
@@ -75,7 +75,7 @@ curl -XPUT 'http://localhost:9200/_template/{beatname_lc}' -d@/etc/{beatname_lc}
 ["source","sh",subs="attributes,callouts"]
 ----------------------------------------------------------------------
 cd {beatname_lc}-{version}-darwin-x86_64
-curl -XPUT 'http://localhost:9200/_template/{beatname_lc}' -d@{beatname_lc}.template.json
+curl -H 'Content-Type: application/json' -XPUT 'http://localhost:9200/_template/{beatname_lc}' -d@{beatname_lc}.template.json
 ----------------------------------------------------------------------
 
 *win:*
@@ -84,7 +84,7 @@ endif::allplatforms[]
 
 ["source","sh",subs="attributes,callouts"]
 ----------------------------------------------------------------------
-PS C:\Program Files{backslash}{beatname_uc}> Invoke-WebRequest -Method Put -InFile {beatname_lc}.template.json -Uri http://localhost:9200/_template/{beatname_lc}?pretty
+PS C:\Program Files{backslash}{beatname_uc}> Invoke-WebRequest -Method Put -InFile {beatname_lc}.template.json -Uri  http://localhost:9200/_template/{beatname_lc}?pretty -ContentType application/json
 ----------------------------------------------------------------------
 
 where `localhost:9200` is the IP and port where Elasticsearch is listening.

--- a/packetbeat/docs/gettingstarted.asciidoc
+++ b/packetbeat/docs/gettingstarted.asciidoc
@@ -241,6 +241,9 @@ binary is installed, and run Packetbeat in the foreground with the following
 options specified: +sudo ./packetbeat -configtest -e+. Make sure your config files are
 in the path expected by Packetbeat (see <<directory-layout>>). If you
 installed from DEB or RPM packages, run +sudo ./packetbeat.sh -configtest -e+.
+Depending on your OS, you might run into file ownership issues when you run this
+test. See {libbeat}/config-file-permissions.html[Config File Ownership and Permissions]
+in the _Beats Platform Reference_ for more information.
 
 [[packetbeat-template]]
 === Step 3: Loading the Index Template in Elasticsearch


### PR DESCRIPTION
This PR fixes issue #3991. I've only updated the curl commands that pass content to Elasticsearch. Please let me know if I've missed anything. 

This PR needs to be backported to 5.3.