### PR TITLE
Support Tencent Cloud provider for add_cloud_metadata proccessor

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -272,6 +272,7 @@ https://github.com/elastic/beats/compare/v5.0.2...v5.1.1[View commits]
 
 - Add add_cloud_metadata processor for collecting cloud provider metadata. {pull}2728[2728]
 - Added decode_json_fields processor for decoding fields containing JSON strings. {pull}2605[2605]
+- Add Tencent Cloud provider for add_cloud_metadata processor. {pull}4023[4023]
 
 *Metricbeat*
 

--- a/libbeat/docs/processors-config.asciidoc
+++ b/libbeat/docs/processors-config.asciidoc
@@ -266,12 +266,12 @@ The `add_cloud_metadata` processor enriches each event with instance metadata
 from the machine's hosting provider. At startup it will detect the hosting
 provider and cache the instance metadata.
 
-Four cloud providers are supported.
+The following cloud providers are supported:
 
 - Amazon Elastic Compute Cloud (EC2)
 - Digital Ocean
 - Google Compute Engine (GCE)
-- [Tencent Cloud](https://www.qcloud.com/?lang=en) (QCloud)
+- https://www.qcloud.com/?lang=en[Tencent Cloud] (QCloud)
 
 The simple configuration below enables the processor.
 

--- a/libbeat/docs/processors-config.asciidoc
+++ b/libbeat/docs/processors-config.asciidoc
@@ -266,11 +266,12 @@ The `add_cloud_metadata` processor enriches each event with instance metadata
 from the machine's hosting provider. At startup it will detect the hosting
 provider and cache the instance metadata.
 
-Three cloud providers are supported.
+Four cloud providers are supported.
 
 - Amazon Elastic Compute Cloud (EC2)
 - Digital Ocean
 - Google Compute Engine (GCE)
+- [Tencent Cloud](https://www.qcloud.com/?lang=en) (QCloud)
 
 The simple configuration below enables the processor.
 
@@ -336,6 +337,22 @@ _GCE_
       "machine_type": "projects/1234567890/machineTypes/f1-micro",
       "project_id": "my-dev",
       "provider": "gce"
+    }
+  }
+}
+-------------------------------------------------------------------------------
+
+_Tencent Clound_
+
+[source,json]
+-------------------------------------------------------------------------------
+{
+  "meta": {
+    "cloud": {
+      "availability_zone": "gz-azone2",
+      "instance_id": "ins-qcloudv5",
+      "provider": "qcloud",
+      "region": "china-south-gz"
     }
   }
 }


### PR DESCRIPTION
Hey there,
Currently the `add_cloud_metadata` processor supports  3 main providers by default, it's awesome!

However, a lot of companies in China prefer to use `Tencent Cloud` and `AliCloud`.  AFAIK, the two providers did hold a large marke share. It will be nice to support these two providers by default too.

This PR amis to support Tencent Cloud. Unlike the other 3 providers, Tencent Cloud Metadata behaves a bit different. 
You can not get the full JSON format metadata in one single round trip, only one field of the metadata can by queried every request. 
For example, you wanna to get the the metadata contains `instance-id` and `region`, you have to send two requests separately.

```
curl http://metadata.tencentyun.com/meta-data/instance-id
```

```
curl http://metadata.tencentyun.com/meta-data/placement/region
```
Here is the [document](https://www.qcloud.com/document/product/213/4934) 

Summary of the changes:

- refactor and abstract a data struct named `fetcher` who did the network/text processing job for specified provider.
- generalize origin `fetchJSON` to `fetcher.fetchRaw`.
- allow multiple requests to fetch the full metadata in the provider's fetcher level.
- replace hard code of the goroutinue number in  waiting loop with dynamic length cauculation.

Ps, I tested it on my qcloud instance with os `ubuntu-16.04` , I can offer a instance for testing, feel free to ping me if you need one.