### PR TITLE
Fix MongoDB dbstats fields mapping

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -73,6 +73,8 @@ https://github.com/elastic/beats/compare/v5.1.1...master[Check the HEAD diff]
 - Make system process metricset honor the cpu_ticks config option. {issue}3590[3590]
 - Support common.Time in mapstriface.toTime() {pull}3812[3812]
 - Fixing panic on prometheus collector when label has , {pull}3947[3947]
+- Fix MongoDB dbstats fields mapping. {pull}4025[4025]
+
 *Packetbeat*
 
 *Winlogbeat*

--- a/metricbeat/module/mongodb/dbstats/_meta/data.json
+++ b/metricbeat/module/mongodb/dbstats/_meta/data.json
@@ -12,15 +12,25 @@
     },
     "mongodb": {
         "dbstats": {
-            "avg_obj_size": 59,
+            "avg_obj_size": {
+                "bytes": 59
+            },
             "collections": 1,
-            "data_size": 59,
+            "data_size": {
+                "bytes": 59
+            },
             "db": "admin",
-            "index_size": 32768,
+            "file_size": {},
+            "index_size": {
+                "bytes": 32768
+            },
             "indexes": 2,
+            "ns_size_mb": {},
             "num_extents": 0,
             "objects": 1,
-            "storage_size": 16384
+            "storage_size": {
+                "bytes": 16384
+            }
         }
     },
     "type": "metricsets"

--- a/metricbeat/module/mongodb/dbstats/data.go
+++ b/metricbeat/module/mongodb/dbstats/data.go
@@ -6,19 +6,31 @@ import (
 )
 
 var schema = s.Schema{
-	"db":           c.Str("db"),
-	"collections":  c.Int("collections"),
-	"objects":      c.Int("objects"),
-	"avg_obj_size": c.Int("avgObjSize"),
-	"data_size":    c.Int("dataSize"),
-	"storage_size": c.Int("storageSize"),
-	"num_extents":  c.Int("numExtents"),
-	"indexes":      c.Int("indexes"),
-	"index_size":   c.Int("indexSize"),
+	"db":          c.Str("db"),
+	"collections": c.Int("collections"),
+	"objects":     c.Int("objects"),
+	"avg_obj_size": s.Object{
+		"bytes": c.Int("avgObjSize"),
+	},
+	"data_size": s.Object{
+		"bytes": c.Int("dataSize"),
+	},
+	"storage_size": s.Object{
+		"bytes": c.Int("storageSize"),
+	},
+	"num_extents": c.Int("numExtents"),
+	"indexes":     c.Int("indexes"),
+	"index_size": s.Object{
+		"bytes": c.Int("indexSize"),
+	},
 	// mmapv1 only
-	"ns_size_mb": c.Int("nsSizeMB", s.Optional),
+	"ns_size_mb": s.Object{
+		"mb": c.Int("nsSizeMB", s.Optional),
+	},
 	// mmapv1 only
-	"file_size": c.Int("fileSize", s.Optional),
+	"file_size": s.Object{
+		"bytes": c.Int("fileSize", s.Optional),
+	},
 	// mmapv1 only
 	"data_file_version": c.Dict("dataFileVersion", s.Schema{
 		"major": c.Int("major"),
@@ -26,7 +38,9 @@ var schema = s.Schema{
 	}, c.DictOptional),
 	// mmapv1 only
 	"extent_free_list": c.Dict("extentFreeList", s.Schema{
-		"num":  c.Int("num"),
-		"size": c.Int("size"),
+		"num": c.Int("num"),
+		"size": s.Object{
+			"bytes": c.Int("size", s.Optional),
+		},
 	}, c.DictOptional),
 }

--- a/metricbeat/module/mongodb/dbstats/dbstats_integration_test.go
+++ b/metricbeat/module/mongodb/dbstats/dbstats_integration_test.go
@@ -30,14 +30,17 @@ func TestFetch(t *testing.T) {
 		objects := event["objects"].(int64)
 		assert.True(t, objects > 0)
 
-		avgObjSize := event["avg_obj_size"].(int64)
-		assert.True(t, avgObjSize > 0)
+		avgObjSize, err := event.GetValue("avg_obj_size.bytes")
+		assert.NoError(t, err)
+		assert.True(t, avgObjSize.(int64) > 0)
 
-		dataSize := event["data_size"].(int64)
-		assert.True(t, dataSize > 0)
+		dataSize, err := event.GetValue("data_size.bytes")
+		assert.NoError(t, err)
+		assert.True(t, dataSize.(int64) > 0)
 
-		storageSize := event["storage_size"].(int64)
-		assert.True(t, storageSize > 0)
+		storageSize, err := event.GetValue("storage_size.bytes")
+		assert.NoError(t, err)
+		assert.True(t, storageSize.(int64) > 0)
 
 		numExtents := event["num_extents"].(int64)
 		assert.True(t, numExtents >= 0)
@@ -45,8 +48,9 @@ func TestFetch(t *testing.T) {
 		indexes := event["indexes"].(int64)
 		assert.True(t, indexes >= 0)
 
-		indexSize := event["index_size"].(int64)
-		assert.True(t, indexSize > 0)
+		indexSize, err := event.GetValue("index_size.bytes")
+		assert.NoError(t, err)
+		assert.True(t, indexSize.(int64) > 0)
 	}
 }
 

--- a/metricbeat/module/mongodb/status/_meta/fields.yml
+++ b/metricbeat/module/mongodb/status/_meta/fields.yml
@@ -424,11 +424,3 @@
               type: long
               description: >
                 Number of sync operations.
-
-
-
-
-
-
-
-


### PR DESCRIPTION
Fix mongodb dbstats mapping to avoid errors like this:

```
WARN Can not index event (status=400): {"type":"mapper_parsing_exception","reason":"object mapping for [mongodb.dbstats.avg_obj_size] tried to parse field [avg_obj_size] as object, but found a concrete value"}
```

closes #3989 
