### PR TITLE
Unify cluster.name and node.name in elasticsearch metricsets

### DIFF
--- a/metricbeat/docs/fields.asciidoc
+++ b/metricbeat/docs/fields.asciidoc
@@ -1890,6 +1890,14 @@ elasticsearch Module
 
 
 [float]
+=== elasticsearch.cluster.name
+
+type: keyword
+
+Elasticsearch cluster name.
+
+
+[float]
 == node Fields
 
 node

--- a/metricbeat/module/elasticsearch/_meta/fields.yml
+++ b/metricbeat/module/elasticsearch/_meta/fields.yml
@@ -10,3 +10,7 @@
       type: group
       description: >
       fields:
+        - name: cluster.name
+          type: keyword
+          description: >
+            Elasticsearch cluster name.

--- a/metricbeat/module/elasticsearch/node/_meta/data.json
+++ b/metricbeat/module/elasticsearch/node/_meta/data.json
@@ -5,6 +5,9 @@
         "name": "host.example.com"
     },
     "elasticsearch": {
+        "cluster": {
+            "name": "elasticsearch"
+        },
         "node": {
             "jvm": {
                 "memory": {
@@ -12,9 +15,9 @@
                         "bytes": 536870912
                     }
                 },
-                "version": "1.8.0_92-internal"
+                "version": "1.8.0_121"
             },
-            "name": "4Il1NmqoQEi-x8a50GNUIw",
+            "name": "fLk5w1-IR2a03fUrs5KbWA",
             "version": "6.0.0-alpha1"
         }
     },

--- a/metricbeat/module/elasticsearch/node/data.go
+++ b/metricbeat/module/elasticsearch/node/data.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/metricbeat/mb"
 	s "github.com/elastic/beats/metricbeat/schema"
 	c "github.com/elastic/beats/metricbeat/schema/mapstriface"
 )
@@ -26,7 +27,8 @@ var (
 func eventsMapping(content []byte) ([]common.MapStr, error) {
 
 	nodesStruct := struct {
-		Nodes map[string]map[string]interface{} `json:"nodes"`
+		ClusterName string                            `json:"cluster_name"`
+		Nodes       map[string]map[string]interface{} `json:"nodes"`
 	}{}
 
 	json.Unmarshal(content, &nodesStruct)
@@ -38,6 +40,11 @@ func eventsMapping(content []byte) ([]common.MapStr, error) {
 		event, errs := eventMapping(node)
 		// Write name here as full name only available as key
 		event["name"] = name
+		event[mb.ModuleData] = common.MapStr{
+			"cluster": common.MapStr{
+				"name": nodesStruct.ClusterName,
+			},
+		}
 		events = append(events, event)
 		errors.AddErrors(errs)
 	}

--- a/metricbeat/module/elasticsearch/node_stats/_meta/data.json
+++ b/metricbeat/module/elasticsearch/node_stats/_meta/data.json
@@ -5,20 +5,26 @@
         "name": "host.example.com"
     },
     "elasticsearch": {
+        "cluster": {
+            "name": "elasticsearch"
+        },
+        "node": {
+            "name": "hU3Tsxk0TXCAs8vIfBNJ2g"
+        },
         "node_stats": {
             "jvm": {
                 "gc": {
                     "collectors": {
                         "old": {
                             "collection": {
-                                "count": 2,
-                                "ms": 884
+                                "count": 1,
+                                "ms": 187
                             }
                         },
                         "young": {
                             "collection": {
-                                "count": 5,
-                                "ms": 2796
+                                "count": 4,
+                                "ms": 2125
                             }
                         }
                     }
@@ -30,13 +36,13 @@
                                 "bytes": 362414080
                             },
                             "peak": {
-                                "bytes": 73126424
+                                "bytes": 13945280
                             },
                             "peak_max": {
                                 "bytes": 362414080
                             },
                             "used": {
-                                "bytes": 73126424
+                                "bytes": 13945280
                             }
                         },
                         "survivor": {
@@ -44,13 +50,13 @@
                                 "bytes": 17432576
                             },
                             "peak": {
-                                "bytes": 17432576
+                                "bytes": 17432560
                             },
                             "peak_max": {
                                 "bytes": 17432576
                             },
                             "used": {
-                                "bytes": 9680488
+                                "bytes": 17432560
                             }
                         },
                         "young": {
@@ -64,13 +70,12 @@
                                 "bytes": 139591680
                             },
                             "used": {
-                                "bytes": 21138856
+                                "bytes": 137025152
                             }
                         }
                     }
                 }
-            },
-            "name": "fLk5w1-IR2a03fUrs5KbWA"
+            }
         }
     },
     "metricset": {

--- a/metricbeat/module/elasticsearch/stats/_meta/data.json
+++ b/metricbeat/module/elasticsearch/stats/_meta/data.json
@@ -7,29 +7,29 @@
     "elasticsearch": {
         "stats": {
             "docs": {
-                "count": 4,
+                "count": 1,
                 "deleted": 0
             },
             "segments": {
-                "count": 4,
+                "count": 1,
                 "memory": {
-                    "bytes": 6647
+                    "bytes": 1433
                 }
             },
             "shards": {
                 "failed": 0,
-                "successful": 11,
-                "total": 22
+                "successful": 6,
+                "total": 12
             },
             "store": {
                 "size": {
-                    "bytes": 16148
+                    "bytes": 3732
                 }
             }
         }
     },
     "metricset": {
-        "host": "127.0.0.1:9200",
+        "host": "elasticsearch:9200",
         "module": "elasticsearch",
         "name": "stats",
         "rtt": 115


### PR DESCRIPTION
Both metricsets now put cluster.name and node.name into the same fields. This makes it easier to filter by cluster or node name.