### PR TITLE
Add gc collection stats to es node_stats metricset

### DIFF
--- a/metricbeat/docs/fields.asciidoc
+++ b/metricbeat/docs/fields.asciidoc
@@ -2082,6 +2082,55 @@ format: bytes
 Used bytes.
 
 [float]
+== gc.collectors Fields
+
+GC collector stats.
+
+
+
+[float]
+== old.collection Fields
+
+Old colletion gc.
+
+
+
+[float]
+=== elasticsearch.node_stats.gc.collectors.old.collection.count
+
+type: long
+
+
+
+[float]
+=== elasticsearch.node_stats.gc.collectors.old.collection.ms
+
+type: long
+
+
+
+[float]
+== young.collection Fields
+
+Young collection gc.
+
+
+
+[float]
+=== elasticsearch.node_stats.gc.collectors.young.collection.count
+
+type: long
+
+
+
+[float]
+=== elasticsearch.node_stats.gc.collectors.young.collection.ms
+
+type: long
+
+
+
+[float]
 == stats Fields
 
 stats

--- a/metricbeat/module/elasticsearch/node_stats/_meta/data.json
+++ b/metricbeat/module/elasticsearch/node_stats/_meta/data.json
@@ -7,6 +7,22 @@
     "elasticsearch": {
         "node_stats": {
             "jvm": {
+                "gc": {
+                    "collectors": {
+                        "old": {
+                            "collection": {
+                                "count": 2,
+                                "ms": 884
+                            }
+                        },
+                        "young": {
+                            "collection": {
+                                "count": 5,
+                                "ms": 2796
+                            }
+                        }
+                    }
+                },
                 "mem": {
                     "pools": {
                         "old": {
@@ -14,13 +30,13 @@
                                 "bytes": 362414080
                             },
                             "peak": {
-                                "bytes": 212130904
+                                "bytes": 73126424
                             },
                             "peak_max": {
                                 "bytes": 362414080
                             },
                             "used": {
-                                "bytes": 154487944
+                                "bytes": 73126424
                             }
                         },
                         "survivor": {
@@ -34,7 +50,7 @@
                                 "bytes": 17432576
                             },
                             "used": {
-                                "bytes": 7878680
+                                "bytes": 9680488
                             }
                         },
                         "young": {
@@ -48,13 +64,13 @@
                                 "bytes": 139591680
                             },
                             "used": {
-                                "bytes": 100266128
+                                "bytes": 21138856
                             }
                         }
                     }
                 }
             },
-            "name": "4Il1NmqoQEi-x8a50GNUIw"
+            "name": "fLk5w1-IR2a03fUrs5KbWA"
         }
     },
     "metricset": {

--- a/metricbeat/module/elasticsearch/node_stats/_meta/fields.yml
+++ b/metricbeat/module/elasticsearch/node_stats/_meta/fields.yml
@@ -87,3 +87,31 @@
               format: bytes
               description:
                 Used bytes.
+
+    - name: gc.collectors
+      type: group
+      description: >
+        GC collector stats.
+      fields:
+        - name: old.collection
+          type: group
+          description: >
+            Old colletion gc.
+          fields:
+            - name: count
+              type: long
+              description: >
+            - name: ms
+              type: long
+              description: >
+        - name: young.collection
+          type: group
+          description: >
+            Young collection gc.
+          fields:
+            - name: count
+              type: long
+              description: >
+            - name: ms
+              type: long
+              description: >

--- a/metricbeat/module/elasticsearch/node_stats/data.go
+++ b/metricbeat/module/elasticsearch/node_stats/data.go
@@ -18,6 +18,12 @@ var (
 					"old":      c.Dict("old", poolSchema),
 				}),
 			}),
+			"gc": c.Dict("gc", s.Schema{
+				"collectors": c.Dict("collectors", s.Schema{
+					"young": c.Dict("young", collectorSchema),
+					"old":   c.Dict("old", collectorSchema),
+				}),
+			}),
 		}),
 	}
 
@@ -33,6 +39,13 @@ var (
 		},
 		"peak_max": s.Object{
 			"bytes": c.Int("peak_max_in_bytes"),
+		},
+	}
+
+	collectorSchema = s.Schema{
+		"collection": s.Object{
+			"count": c.Int("collection_count"),
+			"ms":    c.Int("collection_time_in_millis"),
 		},
 	}
 )


### PR DESCRIPTION
Add garbage collection stats to the node_stats metricset in elasticsearch. This adds the following statistics from the `_nodes/stats` endpoint.

```
"jvm": {
    "gc": {
        "collectors": {
            "old": {
                "collection": {
                    "count": 2,
                    "ms": 884
                }
            },
            "young": {
                "collection": {
                    "count": 5,
                    "ms": 2796
                }
            }
        }
    },
}
```