### PR TITLE
Set short_config option to false by default in Metricbeat

### DIFF
--- a/filebeat/Makefile
+++ b/filebeat/Makefile
@@ -39,10 +39,10 @@ modules:
 .PHONY: configs
 configs: python-env
 	cat ${ES_BEATS}/filebeat/_meta/common.p1.yml > _meta/beat.yml
-	. ${PYTHON_ENV}/bin/activate; python ${ES_BEATS}/metricbeat/scripts/config_collector.py --beat ${BEAT_NAME} $(PWD) >> _meta/beat.yml
+	. ${PYTHON_ENV}/bin/activate; python ${ES_BEATS}/script/config_collector.py --beat ${BEAT_NAME} $(PWD) >> _meta/beat.yml
 	cat ${ES_BEATS}/filebeat/_meta/common.p2.yml >> _meta/beat.yml
 	cat ${ES_BEATS}/filebeat/_meta/common.full.p1.yml > _meta/beat.full.yml
-	. ${PYTHON_ENV}/bin/activate; python ${ES_BEATS}/metricbeat/scripts/config_collector.py --beat ${BEAT_NAME} --full $(PWD) >> _meta/beat.full.yml
+	. ${PYTHON_ENV}/bin/activate; python ${ES_BEATS}/script/config_collector.py --beat ${BEAT_NAME} --full $(PWD) >> _meta/beat.full.yml
 	cat ${ES_BEATS}/filebeat/_meta/common.full.p2.yml >> _meta/beat.full.yml
 
 # Collects all module docs

--- a/filebeat/module/apache2/_meta/fields.yml
+++ b/filebeat/module/apache2/_meta/fields.yml
@@ -2,6 +2,7 @@
   title: "Apache2"
   description: >
     Apache2 Module
+  short_config: true
   fields:
     - name: apache2
       type: group

--- a/filebeat/module/auditd/_meta/fields.yml
+++ b/filebeat/module/auditd/_meta/fields.yml
@@ -2,6 +2,7 @@
   title: "Auditd"
   description: >
     Module for parsing auditd logs.
+  short_config: true
   fields:
     - name: auditd
       type: group

--- a/filebeat/module/mysql/_meta/fields.yml
+++ b/filebeat/module/mysql/_meta/fields.yml
@@ -2,6 +2,7 @@
   title: "MySQL"
   description: >
     Module for parsing the MySQL log files.
+  short_config: true
   fields:
     - name: mysql
       type: group

--- a/filebeat/module/nginx/_meta/fields.yml
+++ b/filebeat/module/nginx/_meta/fields.yml
@@ -2,6 +2,7 @@
   title: "Nginx"
   description: >
     Module for parsing the Nginx log files.
+  short_config: true
   fields:
     - name: nginx
       type: group

--- a/filebeat/module/system/_meta/fields.yml
+++ b/filebeat/module/system/_meta/fields.yml
@@ -2,6 +2,7 @@
   title: "System"
   description: >
     Module for parsing system log files.
+  short_config: true
   fields:
     - name: system
       type: group

--- a/metricbeat/Makefile
+++ b/metricbeat/Makefile
@@ -52,9 +52,9 @@ collect-docs: python-env
 .PHONY: configs
 configs: python-env
 	cat ${ES_BEATS}/metricbeat/_meta/common.yml > _meta/beat.yml
-	. ${PYTHON_ENV}/bin/activate; python ${ES_BEATS}/metricbeat/scripts/config_collector.py --beat ${BEAT_NAME} $(PWD) >> _meta/beat.yml
+	. ${PYTHON_ENV}/bin/activate; python ${ES_BEATS}/script/config_collector.py --beat ${BEAT_NAME} $(PWD) >> _meta/beat.yml
 	cat ${ES_BEATS}/metricbeat/_meta/common.full.yml > _meta/beat.full.yml
-	. ${PYTHON_ENV}/bin/activate; python ${ES_BEATS}/metricbeat/scripts/config_collector.py --beat ${BEAT_NAME} --full $(PWD) >> _meta/beat.full.yml
+	. ${PYTHON_ENV}/bin/activate; python ${ES_BEATS}/script/config_collector.py --beat ${BEAT_NAME} --full $(PWD) >> _meta/beat.full.yml
 
 # Generates imports for all modules and metricsets
 .PHONY: imports

--- a/metricbeat/metricbeat.yml
+++ b/metricbeat/metricbeat.yml
@@ -46,14 +46,6 @@ metricbeat.modules:
   period: 10s
   processes: ['.*']
 
-#------------------------------- kibana Module -------------------------------
-- module: kibana
-  metricsets: ["status"]
-  enabled: true
-  period: 10s
-  hosts: ["localhost:5601"]
-
-
 
 
 #================================ General =====================================

--- a/metricbeat/module/redis/_meta/fields.yml
+++ b/metricbeat/module/redis/_meta/fields.yml
@@ -2,7 +2,6 @@
   title: "Redis"
   description: >
     Redis metrics collected from Redis.
-  short_config: false
   fields:
     - name: redis
       type: group

--- a/metricbeat/module/system/_meta/fields.yml
+++ b/metricbeat/module/system/_meta/fields.yml
@@ -2,6 +2,7 @@
   title: "System"
   description: >
     System status metrics, like CPU and memory usage, that are collected from the operating system.
+  short_config: true
   fields:
     - name: system
       type: group

--- a/script/config_collector.py
+++ b/script/config_collector.py
@@ -31,7 +31,7 @@ def collect(beat_name, beat_path, full=False):
         module_configs = beat_path + "/config.yml"
 
         # By default, short config is read if short is set
-        short_config = True
+        short_config = False
 
         # Check if full config exists
         if full:


### PR DESCRIPTION
So far for each new module the configs were added to the short config by default. But by default we didnt want to have it there. So not every module has to add `short_config: false` to each module, short_config is now set to False by default. This will not have any affect except for new modules.

* System module short_config was set to true
* Redis short_config entry was removed as an example
* Update filebeat modules as all modules are in short_config at the moment
* Move config_collector.py to global script directory so all beats can use it