### PR TITLE
Adding support for include_labels and include_annotations in kubernetes processor

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -97,6 +97,7 @@ https://github.com/elastic/beats/compare/v5.1.1...master[Check the HEAD diff]
 - Add http endpoint. {pull}3717[3717]
 - Updated to Go 1.8.1. {pull}4033[4033]
 - Add kubernetes processor {pull}3888[3888]
+- Add support for include_labels and include_annotations in kubernetes processor {pull}4043[4043]
 
 *Filebeat*
 

--- a/filebeat/processor/annotate/kubernetes/indexing.go
+++ b/filebeat/processor/annotate/kubernetes/indexing.go
@@ -11,37 +11,13 @@ import (
 
 func init() {
 	kubernetes.Indexing.AddMatcher(LogPathMatcherName, newLogsPathMatcher)
+	cfg := common.NewConfig()
 
-	indexer := kubernetes.Indexing.GetIndexer(kubernetes.ContainerIndexerName)
-	//Add a container indexer by default.
-	if indexer != nil {
-		cfg := common.NewConfig()
-		container, err := indexer(*cfg)
-
-		if err == nil {
-			kubernetes.Indexing.AddDefaultIndexer(container)
-		} else {
-			logp.Err("Unable to load indexer plugin due to error: %v", err)
-		}
-	} else {
-		logp.Err("Unable to get indexer plugin %s", kubernetes.ContainerIndexerName)
-	}
+	//Add a container indexer config by default.
+	kubernetes.Indexing.AddDefaultIndexerConfig(kubernetes.ContainerIndexerName, *cfg)
 
 	//Add a log path matcher which can extract container ID from the "source" field.
-	matcher := kubernetes.Indexing.GetMatcher(LogPathMatcherName)
-
-	if matcher != nil {
-		cfg := common.NewConfig()
-		logsPathMatcher, err := matcher(*cfg)
-		if err == nil {
-			kubernetes.Indexing.AddDefaultMatcher(logsPathMatcher)
-		} else {
-			logp.Err("Unable to load matcher plugin due to error: %v", err)
-		}
-	} else {
-		logp.Err("Unable to get matcher plugin %s", LogPathMatcherName)
-	}
-
+	kubernetes.Indexing.AddDefaultMatcherConfig(LogPathMatcherName, *cfg)
 }
 
 const LogPathMatcherName = "logs_path"

--- a/libbeat/processors/annotate/kubernetes/config.go
+++ b/libbeat/processors/annotate/kubernetes/config.go
@@ -6,15 +6,17 @@ import (
 )
 
 type kubeAnnotatorConfig struct {
-	InCluster       bool          `config:"in_cluster"`
-	KubeConfig      string        `config:"kube_config"`
-	Host            string        `config:"host"`
-	Namespace       string        `config:"namespace"`
-	SyncPeriod      time.Duration `config:"sync_period"`
-	Indexers        PluginConfig  `config:"indexers"`
-	Matchers        PluginConfig  `config:"matchers"`
-	DefaultMatchers Enabled       `config:"default_matchers"`
-	DefaultIndexers Enabled       `config:"default_indexers"`
+	InCluster          bool          `config:"in_cluster"`
+	KubeConfig         string        `config:"kube_config"`
+	Host               string        `config:"host"`
+	Namespace          string        `config:"namespace"`
+	SyncPeriod         time.Duration `config:"sync_period"`
+	Indexers           PluginConfig  `config:"indexers"`
+	Matchers           PluginConfig  `config:"matchers"`
+	DefaultMatchers    Enabled       `config:"default_matchers"`
+	DefaultIndexers    Enabled       `config:"default_indexers"`
+	IncludeLabels      []string      `config:"include_labels"`
+	IncludeAnnotations []string      `config:"include_annotations"`
 }
 
 type Enabled struct {

--- a/metricbeat/processor/annotate/kubernetes/indexing.go
+++ b/metricbeat/processor/annotate/kubernetes/indexing.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/processors/annotate/kubernetes"
 	corev1 "github.com/ericchiang/k8s/api/v1"
 )
@@ -15,54 +14,34 @@ const (
 )
 
 func init() {
-
 	// Register default indexers
 	kubernetes.Indexing.AddIndexer(IpPortIndexerName, newIpPortIndexer)
+	cfg := common.NewConfig()
 
-	indexer := kubernetes.Indexing.GetIndexer(IpPortIndexerName)
+	//Add IP Port Indexer as a default indexer
+	kubernetes.Indexing.AddDefaultIndexerConfig(IpPortIndexerName, *cfg)
 
-	if indexer != nil {
-		cfg := common.NewConfig()
-		ipPort, err := newIpPortIndexer(*cfg)
-		if err == nil {
-			kubernetes.Indexing.AddDefaultIndexer(ipPort)
-		} else {
-			logp.Err("Unable to load indexer plugin due to error: %v", err)
-		}
-	} else {
-		logp.Err("Unable to get indexer plugin %s", IpPortIndexerName)
+	config := map[string]interface{}{
+		"lookup_fields": []string{"metricset.host"},
 	}
-
-	matcher := kubernetes.Indexing.GetMatcher(kubernetes.FieldMatcherName)
-
-	if matcher != nil {
-		config := map[string]interface{}{
-			"lookup_fields": []string{"metricset.host"},
-		}
-		fieldCfg, err := common.NewConfigFrom(config)
-		if err == nil {
-			matcher, err := kubernetes.NewFieldMatcher(*fieldCfg)
-			if err == nil {
-				kubernetes.Indexing.AddDefaultMatcher(matcher)
-			}
-		} else {
-			logp.Err("Unable to load matcher plugin due to error: %v", err)
-		}
-	} else {
-		logp.Err("Unable to get matcher plugin %s", kubernetes.FieldMatcherName)
+	fieldCfg, err := common.NewConfigFrom(config)
+	if err == nil {
+		//Add field matcher with field to lookup as metricset.host
+		kubernetes.Indexing.AddDefaultMatcherConfig(kubernetes.FieldMatcherName, *fieldCfg)
 	}
-
 }
 
 // IpPortIndexer indexes pods based on all their host:port combinations
-type IpPortIndexer struct{}
+type IpPortIndexer struct {
+	genMeta kubernetes.GenMeta
+}
 
-func newIpPortIndexer(_ common.Config) (kubernetes.Indexer, error) {
-	return &IpPortIndexer{}, nil
+func newIpPortIndexer(_ common.Config, genMeta kubernetes.GenMeta) (kubernetes.Indexer, error) {
+	return &IpPortIndexer{genMeta: genMeta}, nil
 }
 
 func (h *IpPortIndexer) GetMetadata(pod *corev1.Pod) []kubernetes.MetadataIndex {
-	commonMeta := kubernetes.GenMetadata(pod)
+	commonMeta := h.genMeta.GenerateMetaData(pod)
 	hostPorts := h.GetIndexes(pod)
 	var metadata []kubernetes.MetadataIndex
 

--- a/metricbeat/processor/annotate/kubernetes/indexing_test.go
+++ b/metricbeat/processor/annotate/kubernetes/indexing_test.go
@@ -3,16 +3,19 @@ package kubernetes
 import (
 	"fmt"
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/processors/annotate/kubernetes"
 	corev1 "github.com/ericchiang/k8s/api/v1"
 	metav1 "github.com/ericchiang/k8s/apis/meta/v1"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
+var metagen = &kubernetes.GenDefaultMeta{}
+
 func TestIpPortIndexer(t *testing.T) {
 	var testConfig = common.NewConfig()
 
-	ipIndexer, err := newIpPortIndexer(*testConfig)
+	ipIndexer, err := newIpPortIndexer(*testConfig, metagen)
 	assert.Nil(t, err)
 
 	podName := "testpod"


### PR DESCRIPTION
`include_labels: ["foo"]` would make sure that only foo is part of the "labels" map in the kubernetes metadata.

if user wishes to add select annotations then it can be done using `include_annotations: ["xyz"]`