### PR TITLE
Properly shut down crawler in case one prospector is misconfigured (#4037)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -30,7 +30,7 @@ https://github.com/elastic/beats/compare/v5.3.1...master[Check the HEAD diff]
 *Affecting all Beats*
 
 *Filebeat*
-
+- Properly shut down crawler in case one prospector is misconfigured. {pull}4037[4037]
 
 *Heartbeat*
 
@@ -136,8 +136,6 @@ https://github.com/elastic/beats/compare/v5.2.2...v5.3.0[View commits]
 - Always use absolute path for event and registry. {pull}3328[3328]
 - Raise an exception in case there is a syntax error in one of the configuration files available under
   filebeat.config_dir. {pull}3573[3573]
-- Fix empty registry file on machine crash. {issue}3537[3537]
-
 - Fix empty registry file on machine crash. {issue}3537[3537]
 
 *Metricbeat*

--- a/filebeat/beater/filebeat.go
+++ b/filebeat/beater/filebeat.go
@@ -177,6 +177,7 @@ func (fb *Filebeat) Run(b *beat.Beat) error {
 
 	err = crawler.Start(registrar, config.ProspectorReload)
 	if err != nil {
+		crawler.Stop()
 		return err
 	}
 

--- a/filebeat/crawler/crawler.go
+++ b/filebeat/crawler/crawler.go
@@ -76,7 +76,7 @@ func (c *Crawler) startProspector(config *common.Config, states []file.State) er
 
 	err = p.LoadStates(states)
 	if err != nil {
-		return fmt.Errorf("error loading states for propsector %v: %v", p.ID(), err)
+		return fmt.Errorf("error loading states for prospector %v: %v", p.ID(), err)
 	}
 
 	c.prospectors[p.ID()] = p

--- a/filebeat/prospector/prospector.go
+++ b/filebeat/prospector/prospector.go
@@ -134,7 +134,7 @@ func (p *Prospector) Start() {
 				logp.Info("Prospector channel stopped")
 				return
 			case <-p.beatDone:
-				logp.Info("Prospector channel stopped")
+				logp.Info("Prospector channel stopped because beat is stopping.")
 				return
 			case event := <-p.harvesterChan:
 				// No stopping on error, because on error it is expected that beatDone is closed

--- a/filebeat/prospector/prospector_log.go
+++ b/filebeat/prospector/prospector_log.go
@@ -30,6 +30,10 @@ func NewProspectorLog(p *Prospector) (*ProspectorLog, error) {
 		config:     p.config,
 	}
 
+	if len(p.config.Paths) == 0 {
+		return nil, fmt.Errorf("each prospector must have at least one path defined")
+	}
+
 	return prospectorer, nil
 }
 

--- a/filebeat/prospector/prospector_test.go
+++ b/filebeat/prospector/prospector_test.go
@@ -28,6 +28,7 @@ func TestProspectorFileExclude(t *testing.T) {
 
 	prospector := Prospector{
 		config: prospectorConfig{
+			Paths:        []string{"test.log"},
 			ExcludeFiles: []match.Matcher{match.MustCompile(`\.gz$`)},
 		},
 	}

--- a/filebeat/tests/system/config/filebeat.yml.j2
+++ b/filebeat/tests/system/config/filebeat.yml.j2
@@ -70,6 +70,9 @@ filebeat.prospectors:
     max_lines: {{ max_lines|default(500) }}
   {% endif %}
 {% endif %}
+{% if prospector_raw %}
+{{prospector_raw}}
+{% endif %}
 
 filebeat.spool_size:
 filebeat.shutdown_timeout: {{ shutdown_timeout|default(0) }}


### PR DESCRIPTION
If one prospector started to already send data and a second one was misconfigured, the beat paniced during shutdown. This is no prevented by properly shutting down the crawler also on error.

Closes https://github.com/elastic/beats/issues/3917
(cherry picked from commit 95195cc855af9a345a67e160fc20c35529478081)