### PR TITLE
Change `dashboards.*` config options to `setup.dashboards.*`

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -20,6 +20,7 @@ https://github.com/elastic/beats/compare/v5.1.1...master[Check the HEAD diff]
 - Usage of field `_type` is now ignored and hardcoded to `doc`. {pull}3757[3757]
 - Change vendor manager from glide to govendor. {pull}3851[3851]
 - Rename `error` field to `error.message`. {pull}3987[3987]
+- Change `dashboards.*` config options to `setup.dashboards.*`. {pull}3921[3921]
 
 *Filebeat*
 - Always use absolute path for event and registry. This can lead to issues when relative paths were used before. {pull}3328[3328]

--- a/filebeat/filebeat.full.yml
+++ b/filebeat/filebeat.full.yml
@@ -913,40 +913,40 @@ output.elasticsearch:
 # These settings control loading the sample dashboards to the Kibana index. Loading
 # the dashboards is disabled by default and can be enabled either by setting the
 # options here, or by using the `-setup` CLI flag.
-#dashboards.enabled: false
+#setup.dashboards.enabled: false
 
 # The URL from where to download the dashboards archive. By default this URL
 # has a value which is computed based on the Beat name and version. For released
 # versions, this URL points to the dashboard archive on the artifacts.elastic.co
 # website.
-#dashboards.url:
+#setup.dashboards.url:
 
 # The directory from where to read the dashboards. It is used instead of the URL
 # when it has a value.
-#dashboards.directory:
+#setup.dashboards.directory:
 
 # The file archive (zip file) from where to read the dashboards. It is used instead
 # of the URL when it has a value.
-#dashboards.file:
+#setup.dashboards.file:
 
 # If this option is enabled, the snapshot URL is used instead of the default URL.
-#dashboards.snapshot: false
+#setup.dashboards.snapshot: false
 
 # The URL from where to download the snapshot version of the dashboards. By default
 # this has a value which is computed based on the Beat name and version.
-#dashboards.snapshot_url
+#setup.dashboards.snapshot_url
 
 # In case the archive contains the dashboards from multiple Beats, this lets you
 # select which one to load. You can load all the dashboards in the archive by
 # setting this to the empty string.
-#dashboards.beat: filebeat
+#setup.dashboards.beat: filebeat
 
 # The name of the Kibana index to use for setting the configuration. Default is ".kibana"
-#dashboards.kibana_index: .kibana
+#setup.dashboards.kibana_index: .kibana
 
 # The Elasticsearch index name. This overwrites the index name defined in the
 # dashboards and index pattern. Example: testbeat-*
-#dashboards.index:
+#setup.dashboards.index:
 
 #================================ HTTP Endpoint ======================================
 # Each beat can expose internal data points through a http endpoint. For security

--- a/heartbeat/heartbeat.full.yml
+++ b/heartbeat/heartbeat.full.yml
@@ -748,40 +748,40 @@ output.elasticsearch:
 # These settings control loading the sample dashboards to the Kibana index. Loading
 # the dashboards is disabled by default and can be enabled either by setting the
 # options here, or by using the `-setup` CLI flag.
-#dashboards.enabled: false
+#setup.dashboards.enabled: false
 
 # The URL from where to download the dashboards archive. By default this URL
 # has a value which is computed based on the Beat name and version. For released
 # versions, this URL points to the dashboard archive on the artifacts.elastic.co
 # website.
-#dashboards.url:
+#setup.dashboards.url:
 
 # The directory from where to read the dashboards. It is used instead of the URL
 # when it has a value.
-#dashboards.directory:
+#setup.dashboards.directory:
 
 # The file archive (zip file) from where to read the dashboards. It is used instead
 # of the URL when it has a value.
-#dashboards.file:
+#setup.dashboards.file:
 
 # If this option is enabled, the snapshot URL is used instead of the default URL.
-#dashboards.snapshot: false
+#setup.dashboards.snapshot: false
 
 # The URL from where to download the snapshot version of the dashboards. By default
 # this has a value which is computed based on the Beat name and version.
-#dashboards.snapshot_url
+#setup.dashboards.snapshot_url
 
 # In case the archive contains the dashboards from multiple Beats, this lets you
 # select which one to load. You can load all the dashboards in the archive by
 # setting this to the empty string.
-#dashboards.beat: heartbeat
+#setup.dashboards.beat: heartbeat
 
 # The name of the Kibana index to use for setting the configuration. Default is ".kibana"
-#dashboards.kibana_index: .kibana
+#setup.dashboards.kibana_index: .kibana
 
 # The Elasticsearch index name. This overwrites the index name defined in the
 # dashboards and index pattern. Example: testbeat-*
-#dashboards.index:
+#setup.dashboards.index:
 
 #================================ HTTP Endpoint ======================================
 # Each beat can expose internal data points through a http endpoint. For security

--- a/libbeat/_meta/config.full.yml
+++ b/libbeat/_meta/config.full.yml
@@ -550,40 +550,40 @@ output.elasticsearch:
 # These settings control loading the sample dashboards to the Kibana index. Loading
 # the dashboards is disabled by default and can be enabled either by setting the
 # options here, or by using the `-setup` CLI flag.
-#dashboards.enabled: false
+#setup.dashboards.enabled: false
 
 # The URL from where to download the dashboards archive. By default this URL
 # has a value which is computed based on the Beat name and version. For released
 # versions, this URL points to the dashboard archive on the artifacts.elastic.co
 # website.
-#dashboards.url:
+#setup.dashboards.url:
 
 # The directory from where to read the dashboards. It is used instead of the URL
 # when it has a value.
-#dashboards.directory:
+#setup.dashboards.directory:
 
 # The file archive (zip file) from where to read the dashboards. It is used instead
 # of the URL when it has a value.
-#dashboards.file:
+#setup.dashboards.file:
 
 # If this option is enabled, the snapshot URL is used instead of the default URL.
-#dashboards.snapshot: false
+#setup.dashboards.snapshot: false
 
 # The URL from where to download the snapshot version of the dashboards. By default
 # this has a value which is computed based on the Beat name and version.
-#dashboards.snapshot_url
+#setup.dashboards.snapshot_url
 
 # In case the archive contains the dashboards from multiple Beats, this lets you
 # select which one to load. You can load all the dashboards in the archive by
 # setting this to the empty string.
-#dashboards.beat: beatname
+#setup.dashboards.beat: beatname
 
 # The name of the Kibana index to use for setting the configuration. Default is ".kibana"
-#dashboards.kibana_index: .kibana
+#setup.dashboards.kibana_index: .kibana
 
 # The Elasticsearch index name. This overwrites the index name defined in the
 # dashboards and index pattern. Example: testbeat-*
-#dashboards.index:
+#setup.dashboards.index:
 
 #================================ HTTP Endpoint ======================================
 # Each beat can expose internal data points through a http endpoint. For security

--- a/libbeat/beat/beat.go
+++ b/libbeat/beat/beat.go
@@ -112,7 +112,7 @@ type BeatConfig struct {
 	Logging    logp.Logging              `config:"logging"`
 	Processors processors.PluginConfig   `config:"processors"`
 	Path       paths.Path                `config:"path"`
-	Dashboards *common.Config            `config:"dashboards"`
+	Dashboards *common.Config            `config:"setup.dashboards"`
 	Http       *common.Config            `config:"http"`
 }
 

--- a/metricbeat/metricbeat.full.yml
+++ b/metricbeat/metricbeat.full.yml
@@ -909,40 +909,40 @@ output.elasticsearch:
 # These settings control loading the sample dashboards to the Kibana index. Loading
 # the dashboards is disabled by default and can be enabled either by setting the
 # options here, or by using the `-setup` CLI flag.
-#dashboards.enabled: false
+#setup.dashboards.enabled: false
 
 # The URL from where to download the dashboards archive. By default this URL
 # has a value which is computed based on the Beat name and version. For released
 # versions, this URL points to the dashboard archive on the artifacts.elastic.co
 # website.
-#dashboards.url:
+#setup.dashboards.url:
 
 # The directory from where to read the dashboards. It is used instead of the URL
 # when it has a value.
-#dashboards.directory:
+#setup.dashboards.directory:
 
 # The file archive (zip file) from where to read the dashboards. It is used instead
 # of the URL when it has a value.
-#dashboards.file:
+#setup.dashboards.file:
 
 # If this option is enabled, the snapshot URL is used instead of the default URL.
-#dashboards.snapshot: false
+#setup.dashboards.snapshot: false
 
 # The URL from where to download the snapshot version of the dashboards. By default
 # this has a value which is computed based on the Beat name and version.
-#dashboards.snapshot_url
+#setup.dashboards.snapshot_url
 
 # In case the archive contains the dashboards from multiple Beats, this lets you
 # select which one to load. You can load all the dashboards in the archive by
 # setting this to the empty string.
-#dashboards.beat: metricbeat
+#setup.dashboards.beat: metricbeat
 
 # The name of the Kibana index to use for setting the configuration. Default is ".kibana"
-#dashboards.kibana_index: .kibana
+#setup.dashboards.kibana_index: .kibana
 
 # The Elasticsearch index name. This overwrites the index name defined in the
 # dashboards and index pattern. Example: testbeat-*
-#dashboards.index:
+#setup.dashboards.index:
 
 #================================ HTTP Endpoint ======================================
 # Each beat can expose internal data points through a http endpoint. For security

--- a/packetbeat/packetbeat.full.yml
+++ b/packetbeat/packetbeat.full.yml
@@ -1005,40 +1005,40 @@ output.elasticsearch:
 # These settings control loading the sample dashboards to the Kibana index. Loading
 # the dashboards is disabled by default and can be enabled either by setting the
 # options here, or by using the `-setup` CLI flag.
-#dashboards.enabled: false
+#setup.dashboards.enabled: false
 
 # The URL from where to download the dashboards archive. By default this URL
 # has a value which is computed based on the Beat name and version. For released
 # versions, this URL points to the dashboard archive on the artifacts.elastic.co
 # website.
-#dashboards.url:
+#setup.dashboards.url:
 
 # The directory from where to read the dashboards. It is used instead of the URL
 # when it has a value.
-#dashboards.directory:
+#setup.dashboards.directory:
 
 # The file archive (zip file) from where to read the dashboards. It is used instead
 # of the URL when it has a value.
-#dashboards.file:
+#setup.dashboards.file:
 
 # If this option is enabled, the snapshot URL is used instead of the default URL.
-#dashboards.snapshot: false
+#setup.dashboards.snapshot: false
 
 # The URL from where to download the snapshot version of the dashboards. By default
 # this has a value which is computed based on the Beat name and version.
-#dashboards.snapshot_url
+#setup.dashboards.snapshot_url
 
 # In case the archive contains the dashboards from multiple Beats, this lets you
 # select which one to load. You can load all the dashboards in the archive by
 # setting this to the empty string.
-#dashboards.beat: packetbeat
+#setup.dashboards.beat: packetbeat
 
 # The name of the Kibana index to use for setting the configuration. Default is ".kibana"
-#dashboards.kibana_index: .kibana
+#setup.dashboards.kibana_index: .kibana
 
 # The Elasticsearch index name. This overwrites the index name defined in the
 # dashboards and index pattern. Example: testbeat-*
-#dashboards.index:
+#setup.dashboards.index:
 
 #================================ HTTP Endpoint ======================================
 # Each beat can expose internal data points through a http endpoint. For security

--- a/winlogbeat/winlogbeat.full.yml
+++ b/winlogbeat/winlogbeat.full.yml
@@ -579,40 +579,40 @@ output.elasticsearch:
 # These settings control loading the sample dashboards to the Kibana index. Loading
 # the dashboards is disabled by default and can be enabled either by setting the
 # options here, or by using the `-setup` CLI flag.
-#dashboards.enabled: false
+#setup.dashboards.enabled: false
 
 # The URL from where to download the dashboards archive. By default this URL
 # has a value which is computed based on the Beat name and version. For released
 # versions, this URL points to the dashboard archive on the artifacts.elastic.co
 # website.
-#dashboards.url:
+#setup.dashboards.url:
 
 # The directory from where to read the dashboards. It is used instead of the URL
 # when it has a value.
-#dashboards.directory:
+#setup.dashboards.directory:
 
 # The file archive (zip file) from where to read the dashboards. It is used instead
 # of the URL when it has a value.
-#dashboards.file:
+#setup.dashboards.file:
 
 # If this option is enabled, the snapshot URL is used instead of the default URL.
-#dashboards.snapshot: false
+#setup.dashboards.snapshot: false
 
 # The URL from where to download the snapshot version of the dashboards. By default
 # this has a value which is computed based on the Beat name and version.
-#dashboards.snapshot_url
+#setup.dashboards.snapshot_url
 
 # In case the archive contains the dashboards from multiple Beats, this lets you
 # select which one to load. You can load all the dashboards in the archive by
 # setting this to the empty string.
-#dashboards.beat: winlogbeat
+#setup.dashboards.beat: winlogbeat
 
 # The name of the Kibana index to use for setting the configuration. Default is ".kibana"
-#dashboards.kibana_index: .kibana
+#setup.dashboards.kibana_index: .kibana
 
 # The Elasticsearch index name. This overwrites the index name defined in the
 # dashboards and index pattern. Example: testbeat-*
-#dashboards.index:
+#setup.dashboards.index:
 
 #================================ HTTP Endpoint ======================================
 # Each beat can expose internal data points through a http endpoint. For security


### PR DESCRIPTION
The dashboards config options were moved under the new setup namespace. This allows more flexibility in the future together with template loading. For more details see https://github.com/elastic/beats/issues/3921.