### PR TITLE
Cherry-pick #4042 to 5.4: Fix JSON panic

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -131,6 +131,7 @@ https://github.com/elastic/beats/compare/v5.2.2...v5.3.0[View commits]
 - Allow `-` in Apache access log byte count. {pull}3863[3863]
 - Downgrade Elasticsearch per batch item failure log to debug level. {issue}3953[3953]
 - Allow log lines without a program name in the Syslog fileset. {pull}3944[3944]
+- Fix panic in JSON decoding code if the input line is "null". {pull}4042[4042]
 
 *Heartbeat*
 

--- a/filebeat/harvester/reader/json.go
+++ b/filebeat/harvester/reader/json.go
@@ -30,7 +30,7 @@ func (r *JSON) decodeJSON(text []byte) ([]byte, common.MapStr) {
 	var jsonFields map[string]interface{}
 
 	err := unmarshal(text, &jsonFields)
-	if err != nil {
+	if err != nil || jsonFields == nil {
 		logp.Err("Error decoding JSON: %v", err)
 		if r.cfg.AddErrorKey {
 			jsonFields = common.MapStr{JsonErrorKey: fmt.Sprintf("Error decoding JSON: %v", err)}

--- a/filebeat/harvester/reader/json_test.go
+++ b/filebeat/harvester/reader/json_test.go
@@ -117,6 +117,13 @@ func TestDecodeJSON(t *testing.T) {
 			ExpectedMap:  nil,
 		},
 		{
+			// in case the JSON is "null", we should just not panic
+			Text:         `null`,
+			Config:       JSONConfig{MessageKey: "value", AddErrorKey: true},
+			ExpectedText: `null`,
+			ExpectedMap:  common.MapStr{"json_error": "Error decoding JSON: <nil>"},
+		},
+		{
 			// Add key error helps debugging this
 			Text:         `{"message": "test", "value": "`,
 			Config:       JSONConfig{MessageKey: "value", AddErrorKey: true},


### PR DESCRIPTION
Cherry-pick of PR #4042 to 5.4 branch. Original message: 

There can be a panic in the JSON decoding code if the input JSON line contains
"null" as a string, because that unmarshals without errors but results in a nil
map.

The added test was panicking before the change.