### PR TITLE
Disable `_all.norms` also for ES 5.X

### DIFF
--- a/libbeat/template/template.go
+++ b/libbeat/template/template.go
@@ -109,7 +109,7 @@ func (t *Template) generate(properties common.MapStr, dynamicTemplates []common.
 		"template": t.GetName() + "-*",
 	}
 
-	if t.esVersion.IsMajor(2) {
+	if t.esVersion.IsMajor(2) || t.esVersion.IsMajor(5) {
 		basicStructure.Put("mappings._default_._all.norms.enabled", false)
 	} else {
 		// Metricbeat exceeds the default of 1000 fields


### PR DESCRIPTION
This is the behavior for the whole Beats 5.X branch but after switching
to `template.go` in master we missed ES 5.X here. This change takes it
back while keeping things 6.X compatible.

I already disabled `_all.norms` for ES 6.X in #3368