### PR TITLE
Add support for templates `index_patterns`field in ES >= 6.0

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -100,6 +100,7 @@ https://github.com/elastic/beats/compare/v5.1.1...master[Check the HEAD diff]
 - Updated to Go 1.8.1. {pull}4033[4033]
 - Add kubernetes processor {pull}3888[3888]
 - Add support for include_labels and include_annotations in kubernetes processor {pull}4043[4043]
+- Support new `index_patterns` field when loading templates for Elasticsearch >= 6.0 {pull}4056[4056]
 
 *Filebeat*
 

--- a/libbeat/template/template.go
+++ b/libbeat/template/template.go
@@ -106,7 +106,13 @@ func (t *Template) generate(properties common.MapStr, dynamicTemplates []common.
 		"settings": common.MapStr{
 			"index.refresh_interval": "5s",
 		},
-		"template": t.GetName() + "-*",
+	}
+
+	// ES 6 moved from template to index_patterns: https://github.com/elastic/elasticsearch/pull/21009
+	if t.esVersion.major >= 6 {
+		basicStructure.Put("index_patterns", []string{t.GetName() + "-*"})
+	} else {
+		basicStructure.Put("template", t.GetName()+"-*")
 	}
 
 	if t.esVersion.IsMajor(2) {


### PR DESCRIPTION
The change was introduced in
https://github.com/elastic/elasticsearch/pull/21009 and deprecates
old `template` field.

This change uses the new `index_patterns` field and keeps
compatibility with `template` for older version

closes #3133