### PR TITLE
Fix structure of module topics

### DIFF
--- a/filebeat/docs/modules-overview.asciidoc
+++ b/filebeat/docs/modules-overview.asciidoc
@@ -6,7 +6,7 @@ beta[]
 Filebeat modules simplify the collection, parsing, and visualization of common
 log formats.
 
-A typical module (say, for the Nginx logs) is composed of one ore
+A typical module (say, for the Nginx logs) is composed of one or
 more filesets (in the case of Nginx, `access` and `error`). A fileset contains
 the following:
 
@@ -103,6 +103,7 @@ filebeat.modules:
 
 Then you can start Filebeat simply with: `./filebeat -e`.
 
+[[module-varialbe-overrides]]
 ==== Variable overrides
 
 Each module and fileset has a set of "variables" which allow adjusting their
@@ -132,7 +133,7 @@ filebeat.modules:
     var.paths = ["/var/log/nginx/access.log*"]
 ----------------------------------------------------------------------
 
-The Nginx `access` fileset also has a `pipeline` variables which allows
+The Nginx `access` fileset also has a `pipeline` variable which allows
 selecting which of the available Ingest Node pipelines is used for parsing. At
 the moment, two such pipelines are available, one that requires the two ingest
 plugins (`ingest-geoip` and `ingest-user-agent`) and one that doesn't. If you

--- a/filebeat/docs/modules/apache2.asciidoc
+++ b/filebeat/docs/modules/apache2.asciidoc
@@ -47,6 +47,7 @@ An array of paths where to look for the log files. If left empty, Filebeat
 will choose the paths depending on your operating systems.
 
 
+[float]
 === Fields
 
 For a description of each field in the metricset, see the

--- a/filebeat/docs/modules/auditd.asciidoc
+++ b/filebeat/docs/modules/auditd.asciidoc
@@ -34,6 +34,7 @@ An array of paths where to look for the log files. If left empty, Filebeat
 will choose the paths depending on your operating systems.
 
 
+[float]
 === Fields
 
 For a description of each field in the metricset, see the

--- a/filebeat/docs/modules/mysql.asciidoc
+++ b/filebeat/docs/modules/mysql.asciidoc
@@ -7,12 +7,14 @@ This file is generated! See scripts/docs_collector.py
 
 This module collects and parses the slow logs and error logs created by https://www.mysql.com/[MySQL].
 
+[float]
 === Compatibility
 
 The MySQL module was tested with logs from versions 5.5 and 5.7.
 
 On Windows, the module was tested with MySQL installed from the Chocolatey repository.
 
+[float]
 === Dashboard
 
 This module comes with a sample dashboard.
@@ -38,6 +40,7 @@ An array of paths where to look for the log files. If left empty, Filebeat
 will choose the paths depending on your operating systems.
 
 
+[float]
 === Fields
 
 For a description of each field in the metricset, see the

--- a/filebeat/docs/modules/nginx.asciidoc
+++ b/filebeat/docs/modules/nginx.asciidoc
@@ -47,6 +47,7 @@ will choose the paths depending on your operating systems.
 
 
 
+[float]
 === Fields
 
 For a description of each field in the metricset, see the

--- a/filebeat/docs/modules/system.asciidoc
+++ b/filebeat/docs/modules/system.asciidoc
@@ -33,6 +33,7 @@ An array of paths where to look for the log files. If left empty, Filebeat
 will choose the paths depending on your operating systems.
 
 
+[float]
 === Fields
 
 For a description of each field in the metricset, see the

--- a/filebeat/module/mysql/_meta/docs.asciidoc
+++ b/filebeat/module/mysql/_meta/docs.asciidoc
@@ -2,12 +2,14 @@
 
 This module collects and parses the slow logs and error logs created by https://www.mysql.com/[MySQL].
 
+[float]
 === Compatibility
 
 The MySQL module was tested with logs from versions 5.5 and 5.7.
 
 On Windows, the module was tested with MySQL installed from the Chocolatey repository.
 
+[float]
 === Dashboard
 
 This module comes with a sample dashboard.

--- a/filebeat/scripts/docs_collector.py
+++ b/filebeat/scripts/docs_collector.py
@@ -44,6 +44,7 @@ This file is generated! See scripts/docs_collector.py
 
         module_file += """
 
+[float]
 === Fields
 
 For a description of each field in the metricset, see the


### PR DESCRIPTION
Adds float tags to fix the structure of the topics about each module type. Also fixed a couple of typos.

Needs backport to 5.4.