### PR TITLE
Simplify environment testing for module

### DIFF
--- a/docs/devguide/create-module.asciidoc
+++ b/docs/devguide/create-module.asciidoc
@@ -76,3 +76,26 @@ It's a common pattern to use a `testing.go` file in the module package to share 
 the metricsets. This file does not have `_test.go` in the name because otherwise it would not be compiled for sub packages.
 
 To see an example of the `testing.go` file, look at the https://github.com/elastic/beats/tree/master/metricbeat/module/mysql[mysql module].
+
+[float]
+===== Run Environment tests for one module
+
+All the environments are setup with docker. `make integration-tests-environment` and `make system-tests-environment` can be used to run tests for all modules. In case you are developing a module it is convenient to run the tests only for one module and directly run it on your machine.
+
+First you need to start the environment for your module to test and expose the port to your local machien. For this you can run the following command inside the metricbeat directory:
+
+[source,bash]
+----
+MODULE=apache PORT=80 make run-module
+----
+
+Note: The apache module with port 80 is taken here as an example. You must put the name and port for your own module here.
+
+This will start the environment and you must wait until the service is completely started. After that you can run the test which require an environment:
+
+[source,bash]
+----
+MODULE=apache make test-module
+----
+
+This will run the integration and system tests connecting to the environment in your docker container.

--- a/metricbeat/Makefile
+++ b/metricbeat/Makefile
@@ -87,3 +87,15 @@ create-metricset:
 .PHONY: generate-json
 generate-json: build-image
 	 ${DOCKER_COMPOSE} run beat go test -tags=integration github.com/elastic/beats/metricbeat/module/... -data
+
+.PHONY: run-module
+run-module: ## @testing Runs the given module with exposing the port. Needs $MODULE and $PORT as param
+run-module:
+	${DOCKER_COMPOSE} build ${MODULE}
+	${DOCKER_COMPOSE} run -p ${PORT}:${PORT} ${MODULE}
+
+.PHONY: test-module
+test-module: ## @testing Tests the given module. Needs $MODULE as param an run-module must be started first.
+test-module: python-env
+	go test -tags=integration ${BEAT_PATH}/module/${MODULE}/... -v
+	. ${PYTHON_ENV}/bin/activate && INTEGRATION_TESTS=1 nosetests tests/system/test_${MODULE}.py


### PR DESCRIPTION
Currently it is quite tricky to test just one module with the environment manually. The two makefile commands `run-module` and `test-module` were introduced to simplify the testing.

The commands can be used as following:

```
MODULE=apache PORT=80 make run-module
MODULE=apache make test-module
```