### PR TITLE
Refactor harvester to send events directly to the spooler 

### DIFF
--- a/filebeat/beater/filebeat.go
+++ b/filebeat/beater/filebeat.go
@@ -11,6 +11,7 @@ import (
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/outputs/elasticsearch"
 
+	"github.com/elastic/beats/filebeat/channel"
 	cfg "github.com/elastic/beats/filebeat/config"
 	"github.com/elastic/beats/filebeat/crawler"
 	"github.com/elastic/beats/filebeat/fileset"
@@ -140,7 +141,7 @@ func (fb *Filebeat) Run(b *beat.Beat) error {
 		return err
 	}
 
-	crawler, err := crawler.New(newSpoolerOutlet(fb.done, spooler, wgEvents), config.Prospectors, fb.done, *once)
+	crawler, err := crawler.New(channel.NewOutlet(fb.done, spooler.Channel, wgEvents), config.Prospectors, fb.done, *once)
 	if err != nil {
 		logp.Err("Could not init crawler: %v", err)
 		return err

--- a/filebeat/harvester/config.go
+++ b/filebeat/harvester/config.go
@@ -8,7 +8,9 @@ import (
 	"github.com/elastic/beats/filebeat/harvester/reader"
 
 	"github.com/dustin/go-humanize"
+	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/match"
+	"github.com/elastic/beats/libbeat/processors"
 )
 
 var (
@@ -24,26 +26,35 @@ var (
 		CloseRenamed:  false,
 		CloseEOF:      false,
 		CloseTimeout:  0,
+		DocumentType:  "log",
+		CleanInactive: 0,
 	}
 )
 
 type harvesterConfig struct {
-	BufferSize    int                     `config:"harvester_buffer_size"`
-	Encoding      string                  `config:"encoding"`
-	InputType     string                  `config:"input_type"`
-	Backoff       time.Duration           `config:"backoff" validate:"min=0,nonzero"`
-	BackoffFactor int                     `config:"backoff_factor" validate:"min=1"`
-	MaxBackoff    time.Duration           `config:"max_backoff" validate:"min=0,nonzero"`
-	CloseInactive time.Duration           `config:"close_inactive"`
-	CloseRemoved  bool                    `config:"close_removed"`
-	CloseRenamed  bool                    `config:"close_renamed"`
-	CloseEOF      bool                    `config:"close_eof"`
-	CloseTimeout  time.Duration           `config:"close_timeout" validate:"min=0"`
-	ExcludeLines  []match.Matcher         `config:"exclude_lines"`
-	IncludeLines  []match.Matcher         `config:"include_lines"`
-	MaxBytes      int                     `config:"max_bytes" validate:"min=0,nonzero"`
-	Multiline     *reader.MultilineConfig `config:"multiline"`
-	JSON          *reader.JSONConfig      `config:"json"`
+	common.EventMetadata `config:",inline"`      // Fields and tags to add to events.
+	BufferSize           int                     `config:"harvester_buffer_size"`
+	Encoding             string                  `config:"encoding"`
+	InputType            string                  `config:"input_type"`
+	Backoff              time.Duration           `config:"backoff" validate:"min=0,nonzero"`
+	BackoffFactor        int                     `config:"backoff_factor" validate:"min=1"`
+	MaxBackoff           time.Duration           `config:"max_backoff" validate:"min=0,nonzero"`
+	CloseInactive        time.Duration           `config:"close_inactive"`
+	CloseRemoved         bool                    `config:"close_removed"`
+	CloseRenamed         bool                    `config:"close_renamed"`
+	CloseEOF             bool                    `config:"close_eof"`
+	CloseTimeout         time.Duration           `config:"close_timeout" validate:"min=0"`
+	ExcludeLines         []match.Matcher         `config:"exclude_lines"`
+	IncludeLines         []match.Matcher         `config:"include_lines"`
+	MaxBytes             int                     `config:"max_bytes" validate:"min=0,nonzero"`
+	Multiline            *reader.MultilineConfig `config:"multiline"`
+	JSON                 *reader.JSONConfig      `config:"json"`
+	DocumentType         string                  `config:"document_type"`
+	CleanInactive        time.Duration           `config:"clean_inactive" validate:"min=0"`
+	Pipeline             string                  `config:"pipeline"`
+	Module               string                  `config:"_module_name"`  // hidden option to set the module name
+	Fileset              string                  `config:"_fileset_name"` // hidden option to set the fileset name
+	Processors           processors.PluginConfig `config:"processors"`
 }
 
 func (config *harvesterConfig) Validate() error {

--- a/filebeat/harvester/log.go
+++ b/filebeat/harvester/log.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/elastic/beats/filebeat/config"
+	cfg "github.com/elastic/beats/filebeat/config"
 	"github.com/elastic/beats/filebeat/harvester/reader"
 	"github.com/elastic/beats/filebeat/harvester/source"
 	"github.com/elastic/beats/filebeat/input"
@@ -321,9 +322,12 @@ func (h *Harvester) close() {
 		logp.Debug("harvester", "Closing file: %s", h.state.Source)
 		harvesterOpenFiles.Add(-1)
 
-		// On completion, push offset so we can continue where we left off if we relaunch on the same file
-		// Only send offset if file object was created successfully
-		h.SendStateUpdate()
+		// On shutdown it can be that the stdin reader is still open
+		if h.config.InputType != cfg.StdinInputType {
+			// On completion, push offset so we can continue where we left off if we relaunch on the same file
+			// Only send offset if file object was created successfully
+			h.SendStateUpdate()
+		}
 	} else {
 		logp.Warn("Stopping harvester, NOT closing file as file info not available: %s", h.state.Source)
 	}

--- a/filebeat/harvester/log.go
+++ b/filebeat/harvester/log.go
@@ -3,13 +3,10 @@ package harvester
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"time"
-
-	"golang.org/x/text/transform"
-
-	"fmt"
 
 	"github.com/elastic/beats/filebeat/config"
 	"github.com/elastic/beats/filebeat/harvester/reader"
@@ -18,6 +15,8 @@ import (
 	"github.com/elastic/beats/filebeat/input/file"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/monitoring"
+
+	"golang.org/x/text/transform"
 )
 
 var (
@@ -171,7 +170,9 @@ func (h *Harvester) Stop() {
 // sendEvent sends event to the spooler channel
 // Return false if event was not sent
 func (h *Harvester) sendEvent(event *input.Event) bool {
-	return h.outlet.OnEventSignal(event)
+	h.states.Update(event.State)
+	err := h.forwardEvent(event)
+	return err == nil
 }
 
 // sendStateUpdate send an empty event with the current state to update the registry
@@ -179,10 +180,15 @@ func (h *Harvester) sendEvent(event *input.Event) bool {
 // case the output is blocked the harvester will stay open to make sure no new harvester
 // is started. As soon as the output becomes available again, the finished state is written
 // and processing can continue.
-func (h *Harvester) sendStateUpdate() {
+func (h *Harvester) SendStateUpdate() {
+
 	logp.Debug("harvester", "Update state: %s, offset: %v", h.state.Source, h.state.Offset)
+
 	event := input.NewEvent(h.state)
-	h.outlet.OnEvent(event)
+	h.states.Update(event.State)
+
+	data := event.GetData()
+	h.outlet.OnEvent(&data)
 }
 
 // shouldExportLine decides if the line is exported or not based on
@@ -317,7 +323,7 @@ func (h *Harvester) close() {
 
 		// On completion, push offset so we can continue where we left off if we relaunch on the same file
 		// Only send offset if file object was created successfully
-		h.sendStateUpdate()
+		h.SendStateUpdate()
 	} else {
 		logp.Warn("Stopping harvester, NOT closing file as file info not available: %s", h.state.Source)
 	}

--- a/filebeat/harvester/source/file.go
+++ b/filebeat/harvester/source/file.go
@@ -7,3 +7,4 @@ type File struct {
 }
 
 func (File) Continuable() bool { return true }
+func (File) HasState() bool    { return true }

--- a/filebeat/harvester/source/pipe.go
+++ b/filebeat/harvester/source/pipe.go
@@ -13,3 +13,4 @@ func (p Pipe) Close() error               { return p.File.Close() }
 func (p Pipe) Name() string               { return p.File.Name() }
 func (p Pipe) Stat() (os.FileInfo, error) { return p.File.Stat() }
 func (p Pipe) Continuable() bool          { return false }
+func (p Pipe) HasState() bool             { return false }

--- a/filebeat/harvester/source/source.go
+++ b/filebeat/harvester/source/source.go
@@ -14,4 +14,5 @@ type FileSource interface {
 	LogSource
 	Stat() (os.FileInfo, error)
 	Continuable() bool // can we continue processing after EOF?
+	HasState() bool    // does this source have a state?
 }

--- a/filebeat/input/file/state.go
+++ b/filebeat/input/file/state.go
@@ -39,7 +39,7 @@ func (s *State) IsEmpty() bool {
 // States handles list of FileState
 type States struct {
 	states []State
-	sync.Mutex
+	sync.RWMutex
 }
 
 func NewStates() *States {
@@ -66,9 +66,8 @@ func (s *States) Update(newState State) {
 }
 
 func (s *States) FindPrevious(newState State) State {
-	// TODO: This currently blocks writing updates every time state is fetched. Should be improved for performance
-	s.Lock()
-	defer s.Unlock()
+	s.RLock()
+	defer s.RUnlock()
 	_, state := s.findPrevious(newState)
 	return state
 }
@@ -122,16 +121,16 @@ func (s *States) Cleanup() int {
 
 // Count returns number of states
 func (s *States) Count() int {
-	s.Lock()
-	defer s.Unlock()
+	s.RLock()
+	defer s.RUnlock()
 
 	return len(s.states)
 }
 
 // Returns a copy of the file states
 func (s *States) GetStates() []State {
-	s.Lock()
-	defer s.Unlock()
+	s.RLock()
+	defer s.RUnlock()
 
 	newStates := make([]State, len(s.states))
 	copy(newStates, s.states)

--- a/filebeat/prospector/config.go
+++ b/filebeat/prospector/config.go
@@ -5,16 +5,12 @@ import (
 	"time"
 
 	cfg "github.com/elastic/beats/filebeat/config"
-	"github.com/elastic/beats/filebeat/harvester/reader"
-	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/match"
-	"github.com/elastic/beats/libbeat/processors"
 )
 
 var (
 	defaultConfig = prospectorConfig{
 		Enabled:        true,
-		DocumentType:   "log",
 		IgnoreOlder:    0,
 		ScanFrequency:  10 * time.Second,
 		InputType:      cfg.DefaultInputType,
@@ -27,25 +23,18 @@ var (
 )
 
 type prospectorConfig struct {
-	common.EventMetadata `config:",inline"`      // Fields and tags to add to events.
-	Enabled              bool                    `config:"enabled"`
-	DocumentType         string                  `config:"document_type"`
-	ExcludeFiles         []match.Matcher         `config:"exclude_files"`
-	IgnoreOlder          time.Duration           `config:"ignore_older"`
-	Paths                []string                `config:"paths"`
-	ScanFrequency        time.Duration           `config:"scan_frequency" validate:"min=0,nonzero"`
-	InputType            string                  `config:"input_type"`
-	CleanInactive        time.Duration           `config:"clean_inactive" validate:"min=0"`
-	CleanRemoved         bool                    `config:"clean_removed"`
-	HarvesterLimit       uint64                  `config:"harvester_limit" validate:"min=0"`
-	Symlinks             bool                    `config:"symlinks"`
-	TailFiles            bool                    `config:"tail_files"`
-	JSON                 *reader.JSONConfig      `config:"json"`
-	Pipeline             string                  `config:"pipeline"`
-	Module               string                  `config:"_module_name"`  // hidden option to set the module name
-	Fileset              string                  `config:"_fileset_name"` // hidden option to set the fileset name
-	Processors           processors.PluginConfig `config:"processors"`
-	recursiveGlob        bool                    `config:"recursive_glob.enabled"`
+	Enabled        bool            `config:"enabled"`
+	ExcludeFiles   []match.Matcher `config:"exclude_files"`
+	IgnoreOlder    time.Duration   `config:"ignore_older"`
+	Paths          []string        `config:"paths"`
+	ScanFrequency  time.Duration   `config:"scan_frequency" validate:"min=0,nonzero"`
+	InputType      string          `config:"input_type"`
+	CleanInactive  time.Duration   `config:"clean_inactive" validate:"min=0"`
+	CleanRemoved   bool            `config:"clean_removed"`
+	HarvesterLimit uint64          `config:"harvester_limit" validate:"min=0"`
+	Symlinks       bool            `config:"symlinks"`
+	TailFiles      bool            `config:"tail_files"`
+	recursiveGlob  bool            `config:"recursive_glob.enabled"`
 }
 
 func (config *prospectorConfig) Validate() error {

--- a/filebeat/prospector/prospector_log.go
+++ b/filebeat/prospector/prospector_log.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/elastic/beats/filebeat/harvester"
-	"github.com/elastic/beats/filebeat/input"
 	"github.com/elastic/beats/filebeat/input/file"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/monitoring"
@@ -60,7 +59,7 @@ func (l *Log) LoadStates(states []file.State) error {
 			}
 
 			// Update prospector states and send new states to registry
-			err := l.Prospector.updateState(input.NewEvent(state))
+			err := l.Prospector.updateState(state)
 			if err != nil {
 				logp.Err("Problem putting initial state: %+v", err)
 				return err
@@ -131,7 +130,7 @@ func (l *Log) removeState(state file.State) {
 	}
 
 	state.TTL = 0
-	err := l.Prospector.updateState(input.NewEvent(state))
+	err := l.Prospector.updateState(state)
 	if err != nil {
 		logp.Err("File cleanup state update error: %s", err)
 	}
@@ -323,7 +322,7 @@ func (l *Log) harvestExistingFile(newState file.State, oldState file.State) {
 			logp.Debug("prospector", "Updating state for renamed file: %s -> %s, Current offset: %v", oldState.Source, newState.Source, oldState.Offset)
 			// Update state because of file rotation
 			oldState.Source = newState.Source
-			err := l.Prospector.updateState(input.NewEvent(oldState))
+			err := l.Prospector.updateState(oldState)
 			if err != nil {
 				logp.Err("File rotation state update error: %s", err)
 			}
@@ -367,7 +366,7 @@ func (l *Log) handleIgnoreOlder(lastState, newState file.State) error {
 
 	// Write state for ignore_older file as none exists yet
 	newState.Finished = true
-	err := l.Prospector.updateState(input.NewEvent(newState))
+	err := l.Prospector.updateState(newState)
 	if err != nil {
 		return err
 	}

--- a/filebeat/prospector/prospector_log_other_test.go
+++ b/filebeat/prospector/prospector_log_other_test.go
@@ -155,4 +155,7 @@ func TestInit(t *testing.T) {
 // TestOutlet is an empty outlet for testing
 type TestOutlet struct{}
 
-func (o TestOutlet) OnEvent(event *input.Data) bool { return true }
+func (o TestOutlet) OnEvent(event *input.Data) bool       { return true }
+func (o TestOutlet) OnEventSignal(event *input.Data) bool { return true }
+func (o TestOutlet) SetSignal(signal <-chan struct{})     {}
+func (o TestOutlet) Copy() Outlet                         { return o }

--- a/filebeat/prospector/registry.go
+++ b/filebeat/prospector/registry.go
@@ -53,6 +53,12 @@ func (hr *harvesterRegistry) start(h *harvester.Harvester, r reader.Reader) {
 
 	hr.wg.Add(1)
 	hr.add(h)
+
+	// Update state before staring harvester
+	// This makes sure the states is set to Finished: false
+	// This is synchronous state update as part of the scan
+	h.SendStateUpdate()
+
 	go func() {
 		defer func() {
 			hr.remove(h)


### PR DESCRIPTION
Previously all events were sent through the prospector to update the send and process the data. The state update in the prospector is now done through a mutex and processing happens directly in the harvester. This is a major change in the architecture on how filebeat works. It should simplify the shutting down of harvester and prospectors as less channels are involved in the communication. Some of the configs were moved around between the prospector and harvester package, but in the long run the idea is to merge the two into one.

Further changes:

* Add read/write lock to state handling to make it more efficent
* Did some work on the communication channels. It's still a bit messy and needs cleanup in a follow up PR.
* Processing happens now in the harvester directly. This should be part of the publisher in the future.
* Prospector now only communicates with the spooler to update state, never events.
* Move initial state update logic to harvester to simplify code

This PR should not change any behavior in filebeat.