### PR TITLE
Warn Beats users not to do multiline handling in Logstash

### DIFF
--- a/filebeat/docs/multiline.asciidoc
+++ b/filebeat/docs/multiline.asciidoc
@@ -1,8 +1,15 @@
 [[multiline-examples]]
 == Managing Multiline Messages
 
-You can specify `multiline` settings in the +{beatname_lc}.yml+ file to control how Filebeat deals with messages that
-span multiple lines. At a minimum, you need to configure:
+The files harvested by {beatname_uc} may contain messages that span multiple lines of text. In order to correctly handle
+these multiline events, you need to configure `multiline` settings in the +{beatname_lc}.yml+ file to specify which
+lines are part of a single event. 
+
+IMPORTANT: If you are sending multiline events to Logstash, use the options described here to handle multiline events
+before sending the event data to Logstash. Trying to implement multiline event handling in Logstash (for example, by
+using the Logstash multiline codec) may result in the mixing of streams and corrupted data. 
+
+At a minimum, you need to configure these `multiline` options:
 
 * the `pattern` option, which specifies a regular expression. Depending on how you configure other multiline options, 
 lines that match the specified regular expression are considered either continuations of a previous line or the start of a new multiline event. You can set the `negate` option to negate the pattern.

--- a/filebeat/docs/reference/configuration/filebeat-options.asciidoc
+++ b/filebeat/docs/reference/configuration/filebeat-options.asciidoc
@@ -346,6 +346,10 @@ occur.
 [[multiline]]
 ===== multiline
 
+IMPORTANT: If you are sending multiline events to Logstash, use the options described here to handle multiline events
+before sending the event data to Logstash. Trying to implement multiline event handling in Logstash (for example, by
+using the Logstash multiline codec) may result in the mixing of streams and corrupted data.
+
 Options that control how Filebeat deals with log messages that span multiple lines. Multiline messages are common in files that contain Java stack traces.
 
 The following example shows how to configure Filebeat to handle a multiline message where the first line of the message begins with a bracket (`[`).


### PR DESCRIPTION
Added to address https://github.com/elastic/beats/issues/4008

Since we've already decided that we won't allow the LS multiline codec to be used with the Filebeat input plugin, I think we should keep the documentation simple and not explain what happens if you try to do mutliline handling in LS when multiple hosts are configured in Beats. I think this could get confusing for users who just want to understand how to configure `hosts`.

I've added notes to all the places where we describe how to implement multiline handling (in both the LS and Beats doc) so we are covered.

@ppf2 You should take a look at this, too.

