### PR TITLE
Skip empty events without error

### DIFF
--- a/metricbeat/mb/module/wrapper.go
+++ b/metricbeat/mb/module/wrapper.go
@@ -311,6 +311,10 @@ func (r *eventReporter) Error(err error) bool {
 }
 
 func (r *eventReporter) ErrorWith(err error, meta common.MapStr) bool {
+	// Skip nil events without error
+	if err == nil && meta == nil {
+		return true
+	}
 	timestamp := r.start
 	elapsed := time.Duration(0)
 


### PR DESCRIPTION
In some cases, a metricset does not return an event but also not an error. This can be the case if a metricset for a distributed system should only send events for the master. All metricbeat instances are running on all nodes, but only one node should send the events and the other skip the event. This changes makes this behaviour possible.