### PR TITLE
Ignore debug files generated by vscode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,13 @@
 /*/fields.yml
 /*/*.template*.json
 
+# Debug binary files
+/filebeat/debug
+/heartbeat/debug
+/metricbeat/debug
+/packetbeat/debug
+/winlogbeat/debug
+
 # Files
 .DS_Store
 /beats.iml


### PR DESCRIPTION
The following files are generated by Visual Studio Code editor when debugging.
It's will be nice to ignore them too. 

```
/filebeat/debug
/heartbeat/debug
/metricbeat/debug
/packetbeat/debug
/winlogbeat/debug
```