### PR TITLE
Update docs.asciidoc

### DIFF
--- a/metricbeat/module/system/fsstat/_meta/docs.asciidoc
+++ b/metricbeat/module/system/fsstat/_meta/docs.asciidoc
@@ -1,6 +1,6 @@
 === System Fsstat Metricset
 
-The System `fsstats` metricset provides overall file system statistics.
+The System `fsstat` metricset provides overall file system statistics.
 
 This metricset is available on:
 


### PR DESCRIPTION
fsstats doesn't work anymore because of a previous merge. 
Would be helpful to change fsstats -> fsstat to avoid confusion.