### PR TITLE
Cherry-pick #4042 to 5.3: Fix JSON panic

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -31,6 +31,7 @@ https://github.com/elastic/beats/compare/v5.3.1...master[Check the HEAD diff]
 
 *Filebeat*
 - Properly shut down crawler in case one prospector is misconfigured. {pull}4037[4037]
+- Fix panic in JSON decoding code if the input line is "null". {pull}4042[4042]
 
 *Heartbeat*
 

--- a/filebeat/harvester/reader/json.go
+++ b/filebeat/harvester/reader/json.go
@@ -30,7 +30,7 @@ func (r *JSON) decodeJSON(text []byte) ([]byte, common.MapStr) {
 	var jsonFields map[string]interface{}
 
 	err := unmarshal(text, &jsonFields)
-	if err != nil {
+	if err != nil || jsonFields == nil {
 		logp.Err("Error decoding JSON: %v", err)
 		if r.cfg.AddErrorKey {
 			jsonFields = common.MapStr{JsonErrorKey: fmt.Sprintf("Error decoding JSON: %v", err)}

--- a/filebeat/harvester/reader/json_test.go
+++ b/filebeat/harvester/reader/json_test.go
@@ -117,6 +117,13 @@ func TestDecodeJSON(t *testing.T) {
 			ExpectedMap:  nil,
 		},
 		{
+			// in case the JSON is "null", we should just not panic
+			Text:         `null`,
+			Config:       JSONConfig{MessageKey: "value", AddErrorKey: true},
+			ExpectedText: `null`,
+			ExpectedMap:  common.MapStr{"json_error": "Error decoding JSON: <nil>"},
+		},
+		{
 			// Add key error helps debugging this
 			Text:         `{"message": "test", "value": "`,
 			Config:       JSONConfig{MessageKey: "value", AddErrorKey: true},


### PR DESCRIPTION
Cherry-pick of PR #4042 to 5.3 branch. Original message: 

There can be a panic in the JSON decoding code if the input JSON line contains
"null" as a string, because that unmarshals without errors but results in a nil
map.

The added test was panicking before the change.