### PR TITLE
Cleanup and close changelog for 5.4.0

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -31,18 +31,9 @@ https://github.com/elastic/beats/compare/v5.3.0...master[Check the HEAD diff]
 
 *Filebeat*
 
-- Fix modules default file permissions. {pull}3879[3879]
-- Properly shut down crawler in case one prospector is misconfigured. {pull}4037[4037]
-
 *Heartbeat*
 
 *Metricbeat*
-
-- Avoid errors when some Apache status fields are missing. {issue}3074[3074]
-- Linux cgroup metrics are now enabled by default for the system process
-  metricset. The configuration option for the feature was renamed from
-  `cgroups` to `process.cgroups.enabled`. {pull}3519[3519]
-- Change fieldnames couchbase.node.couch.*.actual_disk_size.* to couchbase.node.couch.*.disk_size.* {pull}3545[3545]
 
 *Packetbeat*
 
@@ -53,15 +44,11 @@ https://github.com/elastic/beats/compare/v5.3.0...master[Check the HEAD diff]
 
 *Affecting all Beats*
 
-- Update index mappings to support future Elasticsearch 6.X. {pull}3778[3778]
-- Fix potential elasticsearch output URL parsing error if protocol scheme is missing. {pull}3671[3671]
-
 *Filebeat*
 
 *Heartbeat*
 
 *Metricbeat*
-- Add beta Jolokia module. {pull}3844[3844]
 
 *Packetbeat*
 
@@ -97,6 +84,80 @@ https://github.com/elastic/beats/compare/v5.3.0...master[Check the HEAD diff]
 
 ////////////////////////////////////////////////////////////
 
+[[release-notes-5.4.0]]
+=== Beats version 5.4.0
+https://github.com/elastic/beats/compare/v5.3.1...v5.4.0[View commits]
+
+==== Bugfixes
+
+*Affecting all Beats*
+
+- Improve error message when downloading the dashboards fails. {pull}3805[3805]
+- Fix potential Elasticsearch output URL parsing error if protocol scheme is missing. {pull}3671[3671]
+- Downgrade Elasticsearch per batch item failure log to debug level. {issue}3953[3953]
+
+*Filebeat*
+
+- Allow log lines without a program name in the Syslog fileset. {pull}3944[3944]
+- Don't stop Filebeat when modules are used with the Logstash output. {pull}3929[3929]
+- Properly shut down crawler in case one prospector is misconfigured. {pull}4037[4037]
+
+*Metricbeat*
+
+- Fixing panic on the Prometheus collector when label has a comma. {pull}3947[3947]
+- Make system process metricset honor the `cpu_ticks` config option. {issue}3590[3590]
+
+*Winlogbeat*
+
+- Fix null terminators include in raw XML string when include_xml is enabled. {pull}3943[3943]
+
+==== Added
+
+*Affecting all Beats*
+
+- Update index mappings to support future Elasticsearch 6.X. {pull}3778[3778]
+
+*Filebeat*
+
+- Add auditd module for reading audit logs on Linux. {pull}3750[3750] {pull}3941[3941]
+- Add fileset for the Linux authorization logs. {pull}3669[3669]
+
+*Heartbeat*
+
+- Add default ports in HTTP monitor. {pull}3924[3924]
+
+*Metricbeat*
+
+- Add beta Jolokia module. {pull}3844[3844]
+- Add dashboard for the MySQL module. {pull}3716[3716]
+- Module configuration reloading is now beta instead of experimental. {pull}3841[3841]
+- Marked http fields from the HAProxy module optional to improve compatibility with 1.5. {pull}3788[3788]
+- Add support for custom HTTP headers and TLS for the Metricbeat modules. {pull}3945[3945]
+
+*Packetbeat*
+
+- Add DNS dashboard for an overview the DNS traffic. {pull}3883[3883]
+- Add DNS Tunneling dashboard to highlight domains with large numbers of subdomains or high data volume. {pull}3884[3884]
+
+[[release-notes-5.3.1]]
+=== Beats version 5.3.1
+https://github.com/elastic/beats/compare/v5.3.0...v5.3.1[View commits]
+
+==== Bugfixes
+
+*Affecting all Beats*
+
+- Fix panic when testing regex-AST to match against date patterns. {issue}3889[3889]
+
+*Filebeat*
+
+- Fix modules default file permissions. {pull}3879[3879]
+- Allow `-` in Apache access log byte count. {pull}3863[3863]
+
+*Metricbeat*
+
+- Avoid errors when some Apache status fields are missing. {issue}3074[3074]
+
 [[release-notes-5.3.0]]
 === Beats version 5.3.0
 https://github.com/elastic/beats/compare/v5.2.2...v5.3.0[View commits]
@@ -128,30 +189,19 @@ https://github.com/elastic/beats/compare/v5.2.2...v5.3.0[View commits]
 - Fix panic due to race condition in kafka output. {pull}4098[4098]
 
 *Filebeat*
-
+- Always use absolute path for event and registry. {pull}3328[3328]
+- Raise an exception in case there is a syntax error in one of the configuration files available under
+  filebeat.config_dir. {pull}3573[3573]
 - Fix empty registry file on machine crash. {issue}3537[3537]
-- Allow `-` in Apache access log byte count. {pull}3863[3863]
-- Downgrade Elasticsearch per batch item failure log to debug level. {issue}3953[3953]
-- Allow log lines without a program name in the Syslog fileset. {pull}3944[3944]
-- Fix panic in JSON decoding code if the input line is "null". {pull}4042[4042]
-
-*Heartbeat*
-
-- Add default ports in HTTP monitor. {pull}3924[3924]
 
 *Metricbeat*
 
 - Add error handling to system process metricset for when Linux cgroups are missing from the kernel. {pull}3692[3692]
 - Add labels to the Docker healthcheck metricset output. {pull}3707[3707]
-- Make system process metricset honor the cpu_ticks config option. {issue}3590[3590]
-- Support common.Time in mapstriface.toTime() {pull}3812[3812]
-- Fixing panic on prometheus collector when label has , {pull}3947[3947]
-*Packetbeat*
 
 *Winlogbeat*
 
 - Fix handling of empty strings in event_data. {pull}3705[3705]
-- Fix null terminators include in raw XML string when include_xml is enabled. {pull}3943[3943]
 
 ==== Added
 
@@ -173,7 +223,6 @@ https://github.com/elastic/beats/compare/v5.2.2...v5.3.0[View commits]
 - The `symlinks` and `harverster_limit` settings are now GA, instead of experimental. {pull}3525[3525]
 - close_timeout is also applied when the output is blocking. {pull}3511[3511]
 - Improve handling of different path variants on Windows. {pull}3781[3781]
-- Add auditd module for reading audit logs on Linux. {pull}3750[3750] {pull}3941[3941]
 
 
 *Metricbeat*
@@ -189,29 +238,6 @@ https://github.com/elastic/beats/compare/v5.2.2...v5.3.0[View commits]
 - The Docker, Kafka, and Prometheus modules are now Beta, instead of experimental. {pull}3525[3525]
 - The HAProxy module is now GA, instead of experimental. {pull}3525[3525]
 - Add the ability to collect the environment variables from system processes. {pull}3337[3337]
-- Add experimental metricset `perfmon` to Windows module. {pull}3758[3758]
-- Add memcached module with stats metricset. {pull}3693[3693]
-- Adding support for custom http headers and TLS for metricbeat modules {pull}3945[3945]
-- Add experimental metricset `perfmon` to Windows module. {pull}3758[3758]
-- Add memcached module with stats metricset. {pull}3693[3693]
-- Add the `process.cmdline.cache.enabled` config option to the System Process Metricset. {pull}3891[3891]
-- Adding support for custom http headers and TLS for metricbeat modules {pull}3945[3945]
-- Add new MetricSet interfaces for developers (`Closer`, `ReportingFetcher`, and `PushMetricSet`). {pull}3908[3908]
-
-*Packetbeat*
-- Add `fields` and `fields_under_root` to packetbeat protocols configurations. {pull}3518[3518]
-- Add list style packetbeat protocols configurations. This change supports specifying multiple configurations of the same protocol analyzer. {pull}3518[3518]
-- Add DNS dashboard for an overview the DNS traffic. {pull}3883[3883]
-- Add DNS Tunneling dashboard to highlight domains with large numbers of subdomains or high data volume. {pull}3884[3884]
-
-*Winlogbeat*
-
-*Packetbeat*
-- Add DNS Tunneling dashboard to highlight domains with large numbers of subdomains or high data volume. {pull}3884[3884]
-
-*Packetbeat*
-- Add DNS dashboard for an overview the DNS traffic. {pull}3883[3883]
-- Add DNS Tunneling dashboard to highlight domains with large numbers of subdomains or high data volume. {pull}3884[3884]
 
 ==== Deprecated
 

--- a/libbeat/docs/release.asciidoc
+++ b/libbeat/docs/release.asciidoc
@@ -6,6 +6,7 @@
 --
 This section summarizes the changes in each release.
 
+* <<release-notes-5.4.0>>
 * <<release-notes-5.3.1>>
 * <<release-notes-5.3.0>>
 * <<release-notes-5.2.2>>


### PR DESCRIPTION
The Changelog in the 5.4/5.x branch got completely messed up, so this
is cleaning it. Some changes might be required still depending on what exactly
makes it into 5.3.2, but this should be fairly sane.