### PR TITLE
Cherry-pick #4098 to 5.3: Fix race in go-metrics adapater

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -96,6 +96,7 @@ https://github.com/elastic/beats/compare/v5.3.0...v5.3.1[View commits]
 *Affecting all Beats*
 
 - Fix panic when testing regex-AST to match against date patterns. {issue}3889[3889]
+- Fix panic due to race condition in kafka output. {pull}4098[4098]
 
 *Filebeat*
 


### PR DESCRIPTION
Cherry-pick of PR #4098 to 5.3 branch. Original message: 

Fix race in go-metrics adapter, if registry is updated concurrently from
multiple go routines.