### PR TITLE
Disable default prospector and adjust short configs

### DIFF
--- a/filebeat/_meta/common.full.p2.yml
+++ b/filebeat/_meta/common.full.p2.yml
@@ -16,6 +16,9 @@ filebeat.prospectors:
 #------------------------------ Log prospector --------------------------------
 - input_type: log
 
+  # Change to true to enable this prospector configuration.
+  enabled: false
+
   # Paths that should be crawled and fetched. Glob based paths.
   # To fetch all ".log" files from a specific level of subdirectories
   # /var/log/*/*.log can be used.

--- a/filebeat/_meta/common.p2.yml
+++ b/filebeat/_meta/common.p2.yml
@@ -11,6 +11,9 @@ filebeat.prospectors:
 
 - input_type: log
 
+  # Change to true to enable this prospector configuration.
+  enabled: false
+
   # Paths that should be crawled and fetched. Glob based paths.
   paths:
     - /var/log/*.log

--- a/filebeat/beater/filebeat.go
+++ b/filebeat/beater/filebeat.go
@@ -57,8 +57,16 @@ func New(b *beat.Beat, rawConfig *common.Config) (beat.Beater, error) {
 	// Add prospectors created by the modules
 	config.Prospectors = append(config.Prospectors, moduleProspectors...)
 
-	if !config.ConfigProspector.Enabled() && len(config.Prospectors) == 0 {
-		return nil, errors.New("No prospectors defined. What files do you want me to watch?")
+	haveEnabledProspectors := false
+	for _, prospector := range config.Prospectors {
+		if prospector.Enabled() {
+			haveEnabledProspectors = true
+			break
+		}
+	}
+
+	if !config.ConfigProspector.Enabled() && !haveEnabledProspectors {
+		return nil, errors.New("No modules or prospectors enabled and configuration reloading disabled. What files do you want me to watch?")
 	}
 
 	if *once && config.ConfigProspector.Enabled() {

--- a/filebeat/filebeat.full.yml
+++ b/filebeat/filebeat.full.yml
@@ -25,6 +25,18 @@ filebeat.modules:
     # can be added under this section.
     #prospector:
 
+  # Authorization logs
+  #auth:
+    #enabled: true
+
+    # Set custom paths for the log files. If left empty,
+    # Filebeat will choose the paths depending on your OS.
+    #var.paths:
+
+    # Prospector configuration (advanced). Any prospector configuration option
+    # can be added under this section.
+    #prospector:
+
 #------------------------------- Apache2 Module ------------------------------
 #- module: apache2
   # Access logs

--- a/filebeat/filebeat.full.yml
+++ b/filebeat/filebeat.full.yml
@@ -31,11 +31,6 @@ filebeat.modules:
   #access:
     #enabled: true
 
-    # Ingest Node pipeline to use. Options are `with_plugins` (default)
-    # and `no_plugins`. Use `no_plugins` if you don't have the geoip or
-    # the user agent Node ingest plugins installed.
-    #var.pipeline: with_plugins
-
     # Set custom paths for the log files. If left empty,
     # Filebeat will choose the paths depending on your OS.
     #var.paths:
@@ -139,11 +134,6 @@ filebeat.modules:
   #access:
     #enabled: true
 
-    # Ingest Node pipeline to use. Options are `with_plugins` (default)
-    # and `no_plugins`. Use `no_plugins` if you don't have the geoip or
-    # the user agent Node ingest plugins installed.
-    #var.pipeline: with_plugins
-
     # Set custom paths for the log files. If left empty,
     # Filebeat will choose the paths depending on your OS.
     #var.paths:
@@ -182,6 +172,9 @@ filebeat.prospectors:
 
 #------------------------------ Log prospector --------------------------------
 - input_type: log
+
+  # Change to true to enable this prospector configuration.
+  enabled: false
 
   # Paths that should be crawled and fetched. Glob based paths.
   # To fetch all ".log" files from a specific level of subdirectories

--- a/filebeat/filebeat.yml
+++ b/filebeat/filebeat.yml
@@ -13,19 +13,77 @@ filebeat.modules:
 
 #------------------------------- System Module -------------------------------
 #- module: system
+  # Syslog
+  #syslog:
+    #enabled: true
+
+    # Set custom paths for the log files. If left empty,
+    # Filebeat will choose the paths depending on your OS.
+    #var.paths:
+
+#------------------------------- Apache2 Module ------------------------------
+#- module: apache2
+  # Access logs
+  #access:
+    #enabled: true
+
+    # Set custom paths for the log files. If left empty,
+    # Filebeat will choose the paths depending on your OS.
+    #var.paths:
+
+  # Error logs
+  #error:
+    #enabled: true
+
+    # Set custom paths for the log files. If left empty,
+    # Filebeat will choose the paths depending on your OS.
+    #var.paths:
 
 #------------------------------- Auditd Module -------------------------------
 #- module: auditd
+  #log:
+    #enabled: true
+
+    # Set custom paths for the log files. If left empty,
+    # Filebeat will choose the paths depending on your OS.
+    #var.paths:
+
 
 #-------------------------------- MySQL Module -------------------------------
 #- module: mysql
+  # Error logs
+  #error:
+    #enabled: true
+
+    # Set custom paths for the log files. If left empty,
+    # Filebeat will choose the paths depending on your OS.
+    #var.paths:
+
+  # Slow logs
+  #slowlog:
+    #enabled: true
+
+    # Set custom paths for the log files. If left empty,
+    # Filebeat will choose the paths depending on your OS.
+    #var.paths:
 
 #-------------------------------- Nginx Module -------------------------------
 #- module: nginx
-  # Ingest Node pipeline to use. Options are `with_plugins` (default)
-  # and `no_plugins`. Use `no_plugins` if you don't have the geoip or
-  # the user agent Node ingest plugins installed.
-  #access.var.pipeline: with_plugins
+  # Access logs
+  #access:
+    #enabled: true
+
+    # Set custom paths for the log files. If left empty,
+    # Filebeat will choose the paths depending on your OS.
+    #var.paths:
+
+  # Error logs
+  #error:
+    #enabled: true
+
+    # Set custom paths for the log files. If left empty,
+    # Filebeat will choose the paths depending on your OS.
+    #var.paths:
 
 
 # For more available modules and options, please see the filebeat.full.yml sample
@@ -40,6 +98,9 @@ filebeat.prospectors:
 # Below are the prospector specific configurations.
 
 - input_type: log
+
+  # Change to true to enable this prospector configuration.
+  enabled: false
 
   # Paths that should be crawled and fetched. Glob based paths.
   paths:

--- a/filebeat/filebeat.yml
+++ b/filebeat/filebeat.yml
@@ -21,6 +21,14 @@ filebeat.modules:
     # Filebeat will choose the paths depending on your OS.
     #var.paths:
 
+  # Authorization logs
+  #auth:
+    #enabled: true
+
+    # Set custom paths for the log files. If left empty,
+    # Filebeat will choose the paths depending on your OS.
+    #var.paths:
+
 #------------------------------- Apache2 Module ------------------------------
 #- module: apache2
   # Access logs

--- a/filebeat/module/apache2/_meta/config.full.yml
+++ b/filebeat/module/apache2/_meta/config.full.yml
@@ -3,11 +3,6 @@
   #access:
     #enabled: true
 
-    # Ingest Node pipeline to use. Options are `with_plugins` (default)
-    # and `no_plugins`. Use `no_plugins` if you don't have the geoip or
-    # the user agent Node ingest plugins installed.
-    #var.pipeline: with_plugins
-
     # Set custom paths for the log files. If left empty,
     # Filebeat will choose the paths depending on your OS.
     #var.paths:

--- a/filebeat/module/apache2/_meta/config.yml
+++ b/filebeat/module/apache2/_meta/config.yml
@@ -1,4 +1,4 @@
-#- module: nginx
+#- module: apache2
   # Access logs
   #access:
     #enabled: true
@@ -7,10 +7,6 @@
     # Filebeat will choose the paths depending on your OS.
     #var.paths:
 
-    # Prospector configuration (advanced). Any prospector configuration option
-    # can be added under this section.
-    #prospector:
-
   # Error logs
   #error:
     #enabled: true
@@ -18,7 +14,3 @@
     # Set custom paths for the log files. If left empty,
     # Filebeat will choose the paths depending on your OS.
     #var.paths:
-
-    # Prospector configuration (advanced). Any prospector configuration option
-    # can be added under this section.
-    #prospector:

--- a/filebeat/module/auditd/_meta/config.yml
+++ b/filebeat/module/auditd/_meta/config.yml
@@ -1,1 +1,8 @@
 #- module: auditd
+  #log:
+    #enabled: true
+
+    # Set custom paths for the log files. If left empty,
+    # Filebeat will choose the paths depending on your OS.
+    #var.paths:
+

--- a/filebeat/module/icinga/_meta/config.yml
+++ b/filebeat/module/icinga/_meta/config.yml
@@ -1,1 +1,24 @@
 #- module: icinga
+  # Main logs
+  #main:
+    #enabled: true
+
+    # Set custom paths for the log files. If left empty,
+    # Filebeat will choose the paths depending on your OS.
+    #var.paths:
+
+  # Debug logs
+  #debug:
+    #enabled: true
+
+    # Set custom paths for the log files. If left empty,
+    # Filebeat will choose the paths depending on your OS.
+    #var.paths:
+
+  # Startup logs
+  #startup:
+    #enabled: true
+
+    # Set custom paths for the log files. If left empty,
+    # Filebeat will choose the paths depending on your OS.
+    #var.paths:

--- a/filebeat/module/mysql/_meta/config.yml
+++ b/filebeat/module/mysql/_meta/config.yml
@@ -1,1 +1,16 @@
 #- module: mysql
+  # Error logs
+  #error:
+    #enabled: true
+
+    # Set custom paths for the log files. If left empty,
+    # Filebeat will choose the paths depending on your OS.
+    #var.paths:
+
+  # Slow logs
+  #slowlog:
+    #enabled: true
+
+    # Set custom paths for the log files. If left empty,
+    # Filebeat will choose the paths depending on your OS.
+    #var.paths:

--- a/filebeat/module/nginx/_meta/config.yml
+++ b/filebeat/module/nginx/_meta/config.yml
@@ -1,5 +1,16 @@
 #- module: nginx
-  # Ingest Node pipeline to use. Options are `with_plugins` (default)
-  # and `no_plugins`. Use `no_plugins` if you don't have the geoip or
-  # the user agent Node ingest plugins installed.
-  #access.var.pipeline: with_plugins
+  # Access logs
+  #access:
+    #enabled: true
+
+    # Set custom paths for the log files. If left empty,
+    # Filebeat will choose the paths depending on your OS.
+    #var.paths:
+
+  # Error logs
+  #error:
+    #enabled: true
+
+    # Set custom paths for the log files. If left empty,
+    # Filebeat will choose the paths depending on your OS.
+    #var.paths:

--- a/filebeat/module/system/_meta/config.full.yml
+++ b/filebeat/module/system/_meta/config.full.yml
@@ -10,3 +10,15 @@
     # Prospector configuration (advanced). Any prospector configuration option
     # can be added under this section.
     #prospector:
+
+  # Authorization logs
+  #auth:
+    #enabled: true
+
+    # Set custom paths for the log files. If left empty,
+    # Filebeat will choose the paths depending on your OS.
+    #var.paths:
+
+    # Prospector configuration (advanced). Any prospector configuration option
+    # can be added under this section.
+    #prospector:

--- a/filebeat/module/system/_meta/config.yml
+++ b/filebeat/module/system/_meta/config.yml
@@ -1,1 +1,8 @@
 #- module: system
+  # Syslog
+  #syslog:
+    #enabled: true
+
+    # Set custom paths for the log files. If left empty,
+    # Filebeat will choose the paths depending on your OS.
+    #var.paths:

--- a/filebeat/module/system/_meta/config.yml
+++ b/filebeat/module/system/_meta/config.yml
@@ -6,3 +6,11 @@
     # Set custom paths for the log files. If left empty,
     # Filebeat will choose the paths depending on your OS.
     #var.paths:
+
+  # Authorization logs
+  #auth:
+    #enabled: true
+
+    # Set custom paths for the log files. If left empty,
+    # Filebeat will choose the paths depending on your OS.
+    #var.paths:

--- a/filebeat/tests/system/test_prospector.py
+++ b/filebeat/tests/system/test_prospector.py
@@ -276,14 +276,9 @@ class Test(BaseTest):
 
         filebeat = self.start_beat()
 
-        # wait for first  "Start next scan" log message
         self.wait_until(
             lambda: self.log_contains(
-                "No prospectors defined"),
-            max_timeout=10)
-
-        self.wait_until(
-            lambda: self.log_contains("No prospectors defined"),
+                "No modules or prospectors enabled"),
             max_timeout=10)
 
         filebeat.check_wait(exit_code=1)


### PR DESCRIPTION
This does two changes:

* Adds `enabled: false` in the default prospector in the short and long configs.
  (which fixes #3442)
* Updates the short config files of the modules to include the path definitions.
  I think this is better for a "module first" experience, where it gives a bit of
  context on how they work.

This means that the default configuration starts and gives no errors, but also doesn't
publish anything. IMO, this behaviour is fine considering configuration reloading.