### PR TITLE
Add format option for add_locale processor

### DIFF
--- a/libbeat/processors/add_locale/add_locale.go
+++ b/libbeat/processors/add_locale/add_locale.go
@@ -62,7 +62,8 @@ func newAddLocale(c common.Config) (processors.Processor, error) {
 }
 
 func (l addLocale) Run(event common.MapStr) (common.MapStr, error) {
-	format := l.Format()
+	zone, offset := time.Now().Zone()
+	format := l.Format(zone, offset)
 	event.Put("beat.timezone", format)
 
 	return event, nil
@@ -74,15 +75,12 @@ const (
 	hour = 60 * min
 )
 
-func (l addLocale) Format() string {
-	tm := time.Now()
+func (l addLocale) Format(zone string, offset int) string {
 	var ft string
 	switch l.TimezoneFormat {
 	case Abbrevation:
-		ft, _ = tm.Zone()
+		ft = zone
 	case Offset:
-		_, offset := tm.Zone()
-
 		sign := "+"
 		if offset < 0 {
 			sign = "-"

--- a/libbeat/processors/add_locale/add_locale.go
+++ b/libbeat/processors/add_locale/add_locale.go
@@ -13,8 +13,10 @@ type addLocale struct {
 	TimezoneFormat TimezoneFormat
 }
 
+// TimezoneFormat type
 type TimezoneFormat int
 
+// Timezone formats
 const (
 	Abbrevation TimezoneFormat = iota
 	Offset

--- a/libbeat/processors/add_locale/add_locale.go
+++ b/libbeat/processors/add_locale/add_locale.go
@@ -22,9 +22,9 @@ const (
 	Offset
 )
 
-var timezoneFormats = [...]string{
-	"abbrevation",
-	"offset",
+var timezoneFormats = map[TimezoneFormat]string{
+	Abbrevation: "abbrevation",
+	Offset:      "offset",
 }
 
 func (t TimezoneFormat) String() string {

--- a/libbeat/processors/add_locale/add_locale.go
+++ b/libbeat/processors/add_locale/add_locale.go
@@ -2,7 +2,6 @@ package actions
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 	"time"
 
@@ -67,32 +66,32 @@ func (l addLocale) Run(event common.MapStr) (common.MapStr, error) {
 	return event, nil
 }
 
+const (
+	sec  = 1
+	min  = 60 * sec
+	hour = 60 * min
+)
+
 func (l addLocale) Format() string {
 	tm := time.Now()
-	var fmt string
+	var ft string
 	switch l.TimezoneFormat {
 	case Abbrevation:
-		fmt, _ = tm.Zone()
+		ft, _ = tm.Zone()
 	case Offset:
 		_, offset := tm.Zone()
 
-		offset = offset / 3600
-
+		sign := "+"
 		if offset < 0 {
-			offset = offset - (offset * 2)
-			fmt += "-"
-		} else {
-			fmt += "+"
+			sign = "-"
+			offset *= -1
 		}
 
-		if offset < 10 {
-			fmt += "0"
-		}
-
-		fmt += strconv.Itoa(offset)
-		fmt += ":00"
+		h := offset / hour
+		m := (offset - (h * hour)) / min
+		ft = fmt.Sprintf("%s%02d:%02d", sign, h, m)
 	}
-	return fmt
+	return ft
 }
 
 func (l addLocale) String() string {

--- a/libbeat/processors/add_locale/add_locale.go
+++ b/libbeat/processors/add_locale/add_locale.go
@@ -36,8 +36,11 @@ func init() {
 
 func newAddLocale(c common.Config) (processors.Processor, error) {
 	config := struct {
-		Format string `config:"format" validate:"required"`
-	}{}
+		Format string `config:"format"`
+	}{
+		Format: "offset",
+	}
+
 	err := c.Unpack(&config)
 	if err != nil {
 		return nil, fmt.Errorf("fail to unpack the include_fields configuration: %s", err)

--- a/libbeat/processors/add_locale/add_locale.go
+++ b/libbeat/processors/add_locale/add_locale.go
@@ -1,7 +1,6 @@
 package actions
 
 import (
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -52,7 +51,7 @@ func newAddLocale(c common.Config) (processors.Processor, error) {
 	case "offset":
 		loc.TimezoneFormat = Offset
 	default:
-		return nil, errors.New("given format is not valid")
+		return nil, fmt.Errorf("'%s' is not a valid format option for processor add_locale. Valid options are 'abbrevation' and 'offset'", config.Format)
 
 	}
 	return loc, nil
@@ -72,7 +71,6 @@ func (l addLocale) Format() string {
 	case Abbrevation:
 		fmt, _ = tm.Zone()
 	case Offset:
-		//loc, _ := time.LoadLocation("America/Belize")
 		_, offset := tm.Zone()
 
 		offset = offset / 3600

--- a/libbeat/processors/add_locale/add_locale.go
+++ b/libbeat/processors/add_locale/add_locale.go
@@ -1,29 +1,99 @@
 package actions
 
 import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/processors"
 )
 
-type addLocale struct{}
+type addLocale struct {
+	TimezoneFormat TimezoneFormat
+}
+
+type TimezoneFormat int
+
+const (
+	Abbrevation TimezoneFormat = iota
+	Offset
+)
+
+var timezoneFormats = [...]string{
+	"abbrevation",
+	"offset",
+}
+
+func (t TimezoneFormat) String() string {
+	return timezoneFormats[t]
+}
 
 func init() {
 	processors.RegisterPlugin("add_locale", newAddLocale)
 }
 
 func newAddLocale(c common.Config) (processors.Processor, error) {
-	return addLocale{}, nil
+	config := struct {
+		Format string `config:"format" validate:"required"`
+	}{}
+	err := c.Unpack(&config)
+	if err != nil {
+		return nil, fmt.Errorf("fail to unpack the include_fields configuration: %s", err)
+	}
+
+	loc := addLocale{}
+
+	switch strings.ToLower(config.Format) {
+	case "abbrevation":
+		loc.TimezoneFormat = Abbrevation
+	case "offset":
+		loc.TimezoneFormat = Offset
+	default:
+		return nil, errors.New("given format is not valid")
+
+	}
+	return loc, nil
 }
 
 func (l addLocale) Run(event common.MapStr) (common.MapStr, error) {
-	zone, _ := time.Now().Zone()
-	event.Put("beat.timezone", zone)
+	format := l.Format()
+	event.Put("beat.timezone", format)
 
 	return event, nil
 }
 
+func (l addLocale) Format() string {
+	tm := time.Now()
+	var fmt string
+	switch l.TimezoneFormat {
+	case Abbrevation:
+		fmt, _ = tm.Zone()
+	case Offset:
+		//loc, _ := time.LoadLocation("America/Belize")
+		_, offset := tm.Zone()
+
+		offset = offset / 3600
+
+		if offset < 0 {
+			offset = offset - (offset * 2)
+			fmt += "-"
+		} else {
+			fmt += "+"
+		}
+
+		if offset < 10 {
+			fmt += "0"
+		}
+
+		fmt += strconv.Itoa(offset)
+		fmt += ":00"
+	}
+	return fmt
+}
+
 func (l addLocale) String() string {
-	return "add_locale"
+	return "add_locale=" + l.TimezoneFormat.String()
 }

--- a/libbeat/processors/add_locale/add_locale_test.go
+++ b/libbeat/processors/add_locale/add_locale_test.go
@@ -1,6 +1,7 @@
 package actions
 
 import (
+	"regexp"
 	"testing"
 	"time"
 
@@ -9,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestExportTimeZone(t *testing.T) {
+func TestExportTimezone(t *testing.T) {
 	testConfig, err := common.NewConfigFrom(map[string]interface{}{
 		"format": "abbrevation",
 	})
@@ -30,6 +31,38 @@ func TestExportTimeZone(t *testing.T) {
 	}
 
 	assert.Equal(t, expected.String(), actual.String())
+}
+
+func TestTimezoneFormat(t *testing.T) {
+	// Test positive format
+
+	posLoc, err := time.LoadLocation("Africa/Asmara")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	posZone, posOffset := time.Now().In(posLoc).Zone()
+
+	posAddLocal := addLocale{TimezoneFormat: Offset}
+
+	posVal := posAddLocal.Format(posZone, posOffset)
+
+	assert.Regexp(t, regexp.MustCompile(`\+[\d]{2}\:[\d]{2}`), posVal)
+
+	// Test negative format
+
+	negLoc, err := time.LoadLocation("America/Curacao")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	negZone, negOffset := time.Now().In(negLoc).Zone()
+
+	negAddLocal := addLocale{TimezoneFormat: Offset}
+
+	negVal := negAddLocal.Format(negZone, negOffset)
+
+	assert.Regexp(t, regexp.MustCompile(`\-[\d]{2}\:[\d]{2}`), negVal)
 }
 
 func getActualValue(t *testing.T, config *common.Config, input common.MapStr) common.MapStr {

--- a/libbeat/processors/add_locale/add_locale_test.go
+++ b/libbeat/processors/add_locale/add_locale_test.go
@@ -10,7 +10,12 @@ import (
 )
 
 func TestExportTimeZone(t *testing.T) {
-	var testConfig = common.NewConfig()
+	testConfig, err := common.NewConfigFrom(map[string]interface{}{
+		"format": "abbrevation",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	input := common.MapStr{}
 


### PR DESCRIPTION
Like discussed in #3974, this PR add the option to format the timezoneoutput. I have decided to just use `abbrevation` and `offset` as options. Because is not so trivial to format time to a canonical_id. [Here](https://github.com/golang/go/issues/20091) is a discussion about the topic. One thing which have to decide is should be format option required or should be `abbrevation` the default option.