### PR TITLE
Support Alibaba Cloud provider for add_cloud_metadata proccessor

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -290,6 +290,7 @@ https://github.com/elastic/beats/compare/v5.0.2...v5.1.1[View commits]
 - Add add_cloud_metadata processor for collecting cloud provider metadata. {pull}2728[2728]
 - Added decode_json_fields processor for decoding fields containing JSON strings. {pull}2605[2605]
 - Add Tencent Cloud provider for add_cloud_metadata processor. {pull}4023[4023]
+- Add Alibaba Cloud provider for add_cloud_metadata processor. {pull}4111[4111]
 
 *Metricbeat*
 

--- a/libbeat/docs/processors-config.asciidoc
+++ b/libbeat/docs/processors-config.asciidoc
@@ -273,6 +273,7 @@ The following cloud providers are supported:
 - Digital Ocean
 - Google Compute Engine (GCE)
 - https://www.qcloud.com/?lang=en[Tencent Cloud] (QCloud)
+- Alibaba Cloud (ECS)
 
 The simple configuration below enables the processor.
 
@@ -354,6 +355,22 @@ _Tencent Cloud_
       "instance_id": "ins-qcloudv5",
       "provider": "qcloud",
       "region": "china-south-gz"
+    }
+  }
+}
+-------------------------------------------------------------------------------
+
+_Alibaba Cloud_
+
+[source,json]
+-------------------------------------------------------------------------------
+{
+  "meta": {
+    "cloud": {
+      "availability_zone": "cn-shenzhen",
+      "instance_id": "i-wz9g2hqiikg0aliyun2b",
+      "provider": "ecs",
+      "region": "cn-shenzhen-a"
     }
   }
 }

--- a/libbeat/docs/processors-config.asciidoc
+++ b/libbeat/docs/processors-config.asciidoc
@@ -362,6 +362,8 @@ _Tencent Cloud_
 
 _Alibaba Cloud_
 
+This metadata is only available when VPC is selected as the network type of the ECS instance.
+
 [source,json]
 -------------------------------------------------------------------------------
 {

--- a/libbeat/processors/add_cloud_metadata/add_cloud_metadata.go
+++ b/libbeat/processors/add_cloud_metadata/add_cloud_metadata.go
@@ -254,12 +254,17 @@ func setupFetchers(c common.Config) ([]*metadataFetcher, error) {
 	if err != nil {
 		return fetchers, err
 	}
+	ecsFetcher, err := newAlibabaCloudMetadataFetcher(c)
+	if err != nil {
+		return fetchers, err
+	}
 
 	fetchers = []*metadataFetcher{
 		doFetcher,
 		ec2Fetcher,
 		gceFetcher,
 		qcloudFetcher,
+		ecsFetcher,
 	}
 	return fetchers, nil
 }

--- a/libbeat/processors/add_cloud_metadata/provider_alibaba_cloud.go
+++ b/libbeat/processors/add_cloud_metadata/provider_alibaba_cloud.go
@@ -1,0 +1,41 @@
+package add_cloud_metadata
+
+import "github.com/elastic/beats/libbeat/common"
+
+// Alibaba Cloud Metadata Service
+// Document https://help.aliyun.com/knowledge_detail/49122.html
+func newAlibabaCloudMetadataFetcher(c common.Config) (*metadataFetcher, error) {
+	ecsMetadataHost := "100.100.100.200"
+	ecsMetadataInstanceIDURI := "/latest/meta-data/instance-id"
+	ecsMetadataRegionURI := "/latest/meta-data/region-id"
+	ecsMetadataZoneURI := "/latest/meta-data/zone-id"
+
+	ecsSchema := func(m map[string]interface{}) common.MapStr {
+		return common.MapStr(m)
+	}
+
+	urls, err := getMetadataURLs(c, ecsMetadataHost, []string{
+		ecsMetadataInstanceIDURI,
+		ecsMetadataRegionURI,
+		ecsMetadataZoneURI,
+	})
+	if err != nil {
+		return nil, err
+	}
+	responseHandlers := map[string]responseHandler{
+		urls[0]: func(all []byte, result *result) error {
+			result.metadata["instance_id"] = string(all)
+			return nil
+		},
+		urls[1]: func(all []byte, result *result) error {
+			result.metadata["region"] = string(all)
+			return nil
+		},
+		urls[2]: func(all []byte, result *result) error {
+			result.metadata["availability_zone"] = string(all)
+			return nil
+		},
+	}
+	fetcher := &metadataFetcher{"ecs", nil, responseHandlers, ecsSchema}
+	return fetcher, nil
+}

--- a/libbeat/processors/add_cloud_metadata/provider_alibaba_cloud_test.go
+++ b/libbeat/processors/add_cloud_metadata/provider_alibaba_cloud_test.go
@@ -1,0 +1,69 @@
+package add_cloud_metadata
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/logp"
+	"github.com/stretchr/testify/assert"
+)
+
+func initECSTestServer() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.RequestURI == "/latest/meta-data/instance-id" {
+			w.Write([]byte("i-wz9g2hqiikg0aliyun2b"))
+			return
+		}
+		if r.RequestURI == "/latest/meta-data/region-id" {
+			w.Write([]byte("cn-shenzhen"))
+			return
+		}
+		if r.RequestURI == "/latest/meta-data/zone-id" {
+			w.Write([]byte("cn-shenzhen-a"))
+			return
+		}
+
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+}
+
+func TestRetrieveAlibabaCloudMetadata(t *testing.T) {
+	if testing.Verbose() {
+		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"*"})
+	}
+
+	server := initECSTestServer()
+	defer server.Close()
+
+	config, err := common.NewConfigFrom(map[string]interface{}{
+		"host": server.Listener.Addr().String(),
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p, err := newCloudMetadata(*config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	actual, err := p.Run(common.MapStr{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := common.MapStr{
+		"meta": common.MapStr{
+			"cloud": common.MapStr{
+				"provider":          "ecs",
+				"instance_id":       "i-wz9g2hqiikg0aliyun2b",
+				"region":            "cn-shenzhen",
+				"availability_zone": "cn-shenzhen-a",
+			},
+		},
+	}
+	assert.Equal(t, expected, actual)
+}

--- a/libbeat/processors/add_cloud_metadata/provider_tencent_cloud.go
+++ b/libbeat/processors/add_cloud_metadata/provider_tencent_cloud.go
@@ -3,6 +3,7 @@ package add_cloud_metadata
 import "github.com/elastic/beats/libbeat/common"
 
 // Tenccent Cloud Metadata Service
+// Document https://www.qcloud.com/document/product/213/4934
 func newQcloudMetadataFetcher(c common.Config) (*metadataFetcher, error) {
 	qcloudMetadataHost := "metadata.tencentyun.com"
 	qcloudMetadataInstanceIDURI := "/meta-data/instance-id"

--- a/libbeat/processors/add_cloud_metadata/provider_tencent_cloud.go
+++ b/libbeat/processors/add_cloud_metadata/provider_tencent_cloud.go
@@ -2,7 +2,7 @@ package add_cloud_metadata
 
 import "github.com/elastic/beats/libbeat/common"
 
-// Tenccent Cloud Metadata Service
+// Tencent Cloud Metadata Service
 // Document https://www.qcloud.com/document/product/213/4934
 func newQcloudMetadataFetcher(c common.Config) (*metadataFetcher, error) {
 	qcloudMetadataHost := "metadata.tencentyun.com"


### PR DESCRIPTION
Follow PR of #4023 
Aims to support Alibaba Cloud provider  for add_cloud_metadata processor.
Similar with Tencent Cloud, Alibaba's metadata services requires multiple requests too.
Here is the official [document](https://help.aliyun.com/knowledge_detail/49122.html).
Tested on an esc instance with os ubuntu 16.04. 
Note, Alibaba cloud's metadata services works only when the instance's network type is VPC.