### PR TITLE
Cherry-pick #3721 to 5.4: @timestamp doesnt get printed when specfied in message codec

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -95,6 +95,7 @@ https://github.com/elastic/beats/compare/v5.3.1...v5.4.0[View commits]
 - Improve error message when downloading the dashboards fails. {pull}3805[3805]
 - Fix potential Elasticsearch output URL parsing error if protocol scheme is missing. {pull}3671[3671]
 - Downgrade Elasticsearch per batch item failure log to debug level. {issue}3953[3953]
+- Make `@timestamp` accessible from format strings. {pull}3721[3721]
 
 *Filebeat*
 

--- a/libbeat/common/datetime.go
+++ b/libbeat/common/datetime.go
@@ -43,6 +43,10 @@ func ParseTime(timespec string) (Time, error) {
 	return Time(t), err
 }
 
+func (t Time) String() string {
+	return time.Time(t).Format(TsLayout)
+}
+
 // MustParseTime is a convenience equivalent of the ParseTime function
 // that panics in case of errors.
 func MustParseTime(timespec string) Time {
@@ -50,5 +54,6 @@ func MustParseTime(timespec string) Time {
 	if err != nil {
 		panic(err)
 	}
+
 	return ts
 }

--- a/libbeat/common/fmtstr/formatevents.go
+++ b/libbeat/common/fmtstr/formatevents.go
@@ -408,6 +408,7 @@ func fieldString(event common.MapStr, field string) (string, error) {
 	if err != nil {
 		logp.Warn("Can not convert key '%v' value to string", v)
 	}
+
 	return s, err
 }
 
@@ -419,6 +420,8 @@ func tryConvString(v interface{}) (string, error) {
 	switch s := v.(type) {
 	case string:
 		return s, nil
+	case common.Time:
+		return s.String(), nil
 	case []byte:
 		return string(s), nil
 	case stringer:

--- a/libbeat/common/fmtstr/formatevents_test.go
+++ b/libbeat/common/fmtstr/formatevents_test.go
@@ -91,6 +91,18 @@ func TestEventFormatString(t *testing.T) {
 			"timestamp: 2015.05.01",
 			[]string{"key"},
 		},
+		{
+			"test timestamp formatter",
+			"%{[@timestamp]}: %{+YYYY.MM.dd}",
+			common.MapStr{
+				"@timestamp": common.Time(
+					time.Date(2015, 5, 1, 20, 12, 34, 0, time.Local),
+				),
+				"key": "timestamp",
+			},
+			"2015-05-01T20:12:34.000Z: 2015.05.01",
+			[]string{"@timestamp"},
+		},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
Cherry-pick of PR #3721 to 5.4 branch. Original message: 

For the following output config:

```
output.console:
  codec.format:
    string: '%{[@timestamp]} %{[message]}'
```

the output is always empty because there is no switch case in the formatevents to handle `common.Time`

This PR fixes that.