### PR TITLE
Close changelog for 5.3.2 and bump the docs version

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -30,8 +30,6 @@ https://github.com/elastic/beats/compare/v5.3.1...master[Check the HEAD diff]
 *Affecting all Beats*
 
 *Filebeat*
-- Properly shut down crawler in case one prospector is misconfigured. {pull}4037[4037]
-- Fix panic in JSON decoding code if the input line is "null". {pull}4042[4042]
 
 *Heartbeat*
 
@@ -86,6 +84,18 @@ https://github.com/elastic/beats/compare/v5.3.1...master[Check the HEAD diff]
 
 
 ////////////////////////////////////////////////////////////
+
+[[release-notes-5.3.2]]
+=== Beats version 5.3.2
+https://github.com/elastic/beats/compare/v5.3.1...v5.3.2[View commits]
+
+==== Bugfixes
+
+*Filebeat*
+
+- Properly shut down crawler in case one prospector is misconfigured. {pull}4037[4037]
+- Fix panic in JSON decoding code if the input line is "null". {pull}4042[4042]
+
 
 [[release-notes-5.3.1]]
 === Beats version 5.3.1

--- a/libbeat/docs/release.asciidoc
+++ b/libbeat/docs/release.asciidoc
@@ -6,6 +6,7 @@
 --
 This section summarizes the changes in each release.
 
+* <<release-notes-5.3.2>>
 * <<release-notes-5.3.1>>
 * <<release-notes-5.3.0>>
 * <<release-notes-5.2.2>>

--- a/libbeat/docs/version.asciidoc
+++ b/libbeat/docs/version.asciidoc
@@ -1,4 +1,4 @@
-:stack-version: 5.3.1
+:stack-version: 5.3.2
 :doc-branch: 5.3
 :go-version: 1.7.4
 :release-state: released


### PR DESCRIPTION
Doing it in one PR this time since the release day is today.