### PR TITLE
Metricbeat: store only top N processes by CPU/memory

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -152,6 +152,7 @@ https://github.com/elastic/beats/compare/v5.1.1...master[Check the HEAD diff]
 - Adding query APIs for metricsets and modules from metricbeat registry {pull}4102[4102]
 - Fixing nil pointer on prometheus collector when http response is nil {pull}4119[4119]
 - Add http module with json metricset. {pull}4092[4092]
+- Add the option to the system module to include only the first top N processes by CPU and memory. {pull}4127[4127].
 
 *Packetbeat*
 - Add `fields` and `fields_under_root` to packetbeat protocols configurations. {pull}3518[3518]

--- a/metricbeat/docs/modules/system.asciidoc
+++ b/metricbeat/docs/modules/system.asciidoc
@@ -26,6 +26,25 @@ metricbeat.modules:
   metricsets: ["process"]
   processes: ['.*']
 ----
+
+*`process.include_top_n`*:: These options allow you to filter out all processes
+that are not in the top N by CPU or memory, in order to reduce the number of
+documents created. If both the `by_cpu` and `by_memory` options are used, the
+reunion of the two tops is included.
+
+*`process.include_top_n.enabled`*:: Set to false to disable the top N feature and
+include all processes, regardless of the other options. The default is `true`,
+but nothing is filtered unless one of the other options (`by_cpu` or `by_memory`)
+is set to a non-zero value.
+
+*`process.include_top_n.by_cpu`*::  How many processes to include from the top
+by CPU. The processes are sorted by the `system.process.cpu.total.pct` field.
+The default is 0.
+
+*`process.include_top_n.by_memory`*:: How many processes to include from the top
+by memory. The processes are sorted by the `system.process.memory.rss.bytes`
+field. The default is 0.
+
 *`process.cgroups.enabled`*:: When the `process` metricset is enabled, you can
 use this boolean configuration option to disable cgroup metrics. By default
 cgroup metrics collection is enabled.
@@ -100,6 +119,9 @@ metricbeat.modules:
   enabled: true
   period: 10s
   processes: ['.*']
+  process.include_top_n:
+    by_cpu: 5      # include top 5 processes by CPU
+    by_memory: 5   # include top 5 processes by memory
 ----
 
 [float]

--- a/metricbeat/metricbeat.full.yml
+++ b/metricbeat/metricbeat.full.yml
@@ -64,6 +64,23 @@ metricbeat.modules:
   # if true, exports the CPU usage in ticks, together with the percentage values
   #cpu_ticks: false
 
+  # These options allow you to filter out all processes that are not
+  # in the top N by CPU or memory, in order to reduce the number of documents created.
+  # If both the `by_cpu` and `by_memory` options are used, the reunion of the two tops
+  # is included.
+  #process.include_top_n:
+    #
+    # Set to false to disable this feature and include all processes
+    #enabled: true
+
+    # How many processes to include from the top by CPU. The processes are sorted
+    # by the `system.process.cpu.total.pct` field.
+    #by_cpu: 0
+
+    # How many processes to include from the top by memory. The processes are sorted
+    # by the `system.process.memory.rss.bytes` field.
+    #by_memory: 0
+
   # If false, cmdline of a process is not cached.
   #process.cmdline.cache.enabled: true
 

--- a/metricbeat/metricbeat.yml
+++ b/metricbeat/metricbeat.yml
@@ -45,6 +45,9 @@ metricbeat.modules:
   enabled: true
   period: 10s
   processes: ['.*']
+  process.include_top_n:
+    by_cpu: 5      # include top 5 processes by CPU
+    by_memory: 5   # include top 5 processes by memory
 
 
 

--- a/metricbeat/module/system/_meta/config.full.yml
+++ b/metricbeat/module/system/_meta/config.full.yml
@@ -36,6 +36,23 @@
   # if true, exports the CPU usage in ticks, together with the percentage values
   #cpu_ticks: false
 
+  # These options allow you to filter out all processes that are not
+  # in the top N by CPU or memory, in order to reduce the number of documents created.
+  # If both the `by_cpu` and `by_memory` options are used, the reunion of the two tops
+  # is included.
+  #process.include_top_n:
+    #
+    # Set to false to disable this feature and include all processes
+    #enabled: true
+
+    # How many processes to include from the top by CPU. The processes are sorted
+    # by the `system.process.cpu.total.pct` field.
+    #by_cpu: 0
+
+    # How many processes to include from the top by memory. The processes are sorted
+    # by the `system.process.memory.rss.bytes` field.
+    #by_memory: 0
+
   # If false, cmdline of a process is not cached.
   #process.cmdline.cache.enabled: true
 

--- a/metricbeat/module/system/_meta/config.yml
+++ b/metricbeat/module/system/_meta/config.yml
@@ -32,3 +32,6 @@
   enabled: true
   period: 10s
   processes: ['.*']
+  process.include_top_n:
+    by_cpu: 5      # include top 5 processes by CPU
+    by_memory: 5   # include top 5 processes by memory

--- a/metricbeat/module/system/_meta/docs.asciidoc
+++ b/metricbeat/module/system/_meta/docs.asciidoc
@@ -21,6 +21,25 @@ metricbeat.modules:
   metricsets: ["process"]
   processes: ['.*']
 ----
+
+*`process.include_top_n`*:: These options allow you to filter out all processes
+that are not in the top N by CPU or memory, in order to reduce the number of
+documents created. If both the `by_cpu` and `by_memory` options are used, the
+reunion of the two tops is included.
+
+*`process.include_top_n.enabled`*:: Set to false to disable the top N feature and
+include all processes, regardless of the other options. The default is `true`,
+but nothing is filtered unless one of the other options (`by_cpu` or `by_memory`)
+is set to a non-zero value.
+
+*`process.include_top_n.by_cpu`*::  How many processes to include from the top
+by CPU. The processes are sorted by the `system.process.cpu.total.pct` field.
+The default is 0.
+
+*`process.include_top_n.by_memory`*:: How many processes to include from the top
+by memory. The processes are sorted by the `system.process.memory.rss.bytes`
+field. The default is 0.
+
 *`process.cgroups.enabled`*:: When the `process` metricset is enabled, you can
 use this boolean configuration option to disable cgroup metrics. By default
 cgroup metrics collection is enabled.


### PR DESCRIPTION
This adds the option to only report on the top N processes by CPU and/or memory. It is useful because storing metrics about each and every process from every host can be fairly expensive from the storage point of view. Previously it was possible to filter processes by name, which was useful if one knew in advance which are the most interesting processes. This adds a new option which should be quite convenient in practice, because the number of per-process documents gets limited while still allowing to display the top processes.

Closes #4126. 

Configuration wise it looks like this:

```
  process.include_top_n:
    by_cpu: 5      # include top 5 processes by CPU
    by_memory: 5   # include top 5 processes by memory
```

Remaining TODOs:

* [x] unit tests
* [x] document the new settings