### PR TITLE
Move elasticsearch node_stats metricset under node.stats namespace

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -170,6 +170,7 @@ https://github.com/elastic/beats/compare/v5.4.0...v6.0.0-alpha1[View commits]
 - Add experimental Vsphere module. {pull}4028[4028]
 - Add experimental Elasticsearch module. {pull}3903[3903]
 - Add experimental Kibana module. {pull}3895[3895]
+- Move elasticsearch metricset node_stats under node.stats namespace. {pull}4142[4142]
 
 *Packetbeat*
 

--- a/libbeat/tests/system/beat/beat.py
+++ b/libbeat/tests/system/beat/beat.py
@@ -11,7 +11,7 @@ import time
 import yaml
 from datetime import datetime, timedelta
 
-BEAT_REQUIRED_FIELDS = ["@timestamp", "type",
+BEAT_REQUIRED_FIELDS = ["@timestamp",
                         "beat.name", "beat.hostname", "beat.version"]
 
 INTEGRATION_TESTS = os.environ.get('INTEGRATION_TESTS', False)

--- a/metricbeat/docs/fields.asciidoc
+++ b/metricbeat/docs/fields.asciidoc
@@ -1956,18 +1956,10 @@ Node version.
 
 
 [float]
-== node_stats Fields
+== node.stats Fields
 
 node_stats
 
-
-
-[float]
-=== elasticsearch.node_stats.name
-
-type: keyword
-
-Node name.
 
 
 [float]
@@ -1978,7 +1970,7 @@ Node indices stats
 
 
 [float]
-=== elasticsearch.node_stats.indices.docs.count
+=== elasticsearch.node.stats.indices.docs.count
 
 type: long
 
@@ -1986,7 +1978,7 @@ Total number of existing documents.
 
 
 [float]
-=== elasticsearch.node_stats.indices.docs.deleted
+=== elasticsearch.node.stats.indices.docs.deleted
 
 type: long
 
@@ -1994,7 +1986,7 @@ Total number of deleted documents.
 
 
 [float]
-=== elasticsearch.node_stats.indices.segments.count
+=== elasticsearch.node.stats.indices.segments.count
 
 type: long
 
@@ -2002,7 +1994,7 @@ Total number of segments.
 
 
 [float]
-=== elasticsearch.node_stats.indices.segments.memory.bytes
+=== elasticsearch.node.stats.indices.segments.memory.bytes
 
 type: long
 
@@ -2012,7 +2004,7 @@ Total size of segments in bytes.
 
 
 [float]
-=== elasticsearch.node_stats.indices.store.size.bytes
+=== elasticsearch.node.stats.indices.store.size.bytes
 
 type: long
 
@@ -2034,7 +2026,7 @@ Old memory pool stats.
 
 
 [float]
-=== elasticsearch.node_stats.jvm.mem.pools.old.max.bytes
+=== elasticsearch.node.stats.jvm.mem.pools.old.max.bytes
 
 type: long
 
@@ -2043,7 +2035,7 @@ format: bytes
 Max bytes.
 
 [float]
-=== elasticsearch.node_stats.jvm.mem.pools.old.peak.bytes
+=== elasticsearch.node.stats.jvm.mem.pools.old.peak.bytes
 
 type: long
 
@@ -2052,7 +2044,7 @@ format: bytes
 Peak bytes.
 
 [float]
-=== elasticsearch.node_stats.jvm.mem.pools.old.peak_max.bytes
+=== elasticsearch.node.stats.jvm.mem.pools.old.peak_max.bytes
 
 type: long
 
@@ -2061,7 +2053,7 @@ format: bytes
 Peak max bytes.
 
 [float]
-=== elasticsearch.node_stats.jvm.mem.pools.old.used.bytes
+=== elasticsearch.node.stats.jvm.mem.pools.old.used.bytes
 
 type: long
 
@@ -2077,7 +2069,7 @@ Young memory pool stats.
 
 
 [float]
-=== elasticsearch.node_stats.jvm.mem.pools.young.max.bytes
+=== elasticsearch.node.stats.jvm.mem.pools.young.max.bytes
 
 type: long
 
@@ -2086,7 +2078,7 @@ format: bytes
 Max bytes.
 
 [float]
-=== elasticsearch.node_stats.jvm.mem.pools.young.peak.bytes
+=== elasticsearch.node.stats.jvm.mem.pools.young.peak.bytes
 
 type: long
 
@@ -2095,7 +2087,7 @@ format: bytes
 Peak bytes.
 
 [float]
-=== elasticsearch.node_stats.jvm.mem.pools.young.peak_max.bytes
+=== elasticsearch.node.stats.jvm.mem.pools.young.peak_max.bytes
 
 type: long
 
@@ -2104,7 +2096,7 @@ format: bytes
 Peak max bytes.
 
 [float]
-=== elasticsearch.node_stats.jvm.mem.pools.young.used.bytes
+=== elasticsearch.node.stats.jvm.mem.pools.young.used.bytes
 
 type: long
 
@@ -2120,7 +2112,7 @@ Survivor memory pool stats.
 
 
 [float]
-=== elasticsearch.node_stats.jvm.mem.pools.survivor.max.bytes
+=== elasticsearch.node.stats.jvm.mem.pools.survivor.max.bytes
 
 type: long
 
@@ -2129,7 +2121,7 @@ format: bytes
 Max bytes.
 
 [float]
-=== elasticsearch.node_stats.jvm.mem.pools.survivor.peak.bytes
+=== elasticsearch.node.stats.jvm.mem.pools.survivor.peak.bytes
 
 type: long
 
@@ -2138,7 +2130,7 @@ format: bytes
 Peak bytes.
 
 [float]
-=== elasticsearch.node_stats.jvm.mem.pools.survivor.peak_max.bytes
+=== elasticsearch.node.stats.jvm.mem.pools.survivor.peak_max.bytes
 
 type: long
 
@@ -2147,7 +2139,7 @@ format: bytes
 Peak max bytes.
 
 [float]
-=== elasticsearch.node_stats.jvm.mem.pools.survivor.used.bytes
+=== elasticsearch.node.stats.jvm.mem.pools.survivor.used.bytes
 
 type: long
 
@@ -2170,14 +2162,14 @@ Old collection gc.
 
 
 [float]
-=== elasticsearch.node_stats.jvm.gc.collectors.old.collection.count
+=== elasticsearch.node.stats.jvm.gc.collectors.old.collection.count
 
 type: long
 
 
 
 [float]
-=== elasticsearch.node_stats.jvm.gc.collectors.old.collection.ms
+=== elasticsearch.node.stats.jvm.gc.collectors.old.collection.ms
 
 type: long
 
@@ -2191,14 +2183,14 @@ Young collection gc.
 
 
 [float]
-=== elasticsearch.node_stats.jvm.gc.collectors.young.collection.count
+=== elasticsearch.node.stats.jvm.gc.collectors.young.collection.count
 
 type: long
 
 
 
 [float]
-=== elasticsearch.node_stats.jvm.gc.collectors.young.collection.ms
+=== elasticsearch.node.stats.jvm.gc.collectors.young.collection.ms
 
 type: long
 

--- a/metricbeat/mb/mb.go
+++ b/metricbeat/mb/mb.go
@@ -13,11 +13,17 @@ import (
 )
 
 const (
-	// ModuleData is the key used in events created by MetricSets to add data
+	// ModuleDataKey is the key used in events created by MetricSets to add data
 	// to an event that is common to the module. The data must be a
 	// common.MapStr and when the final event is built the object will be stored
 	// in the event under a key that is the module name.
-	ModuleData string = "_module"
+	ModuleDataKey string = "_module"
+
+	// NamespaceKey is used to define a different namespace for the metricset
+	// This is useful for dynamic metricsets or metricsets which do not
+	// put the name under the same name as the package. This is for example
+	// the case in elasticsearch `node_stats` which puts the data under `node.stats`.
+	NamespaceKey string = "_namespace"
 )
 
 // Module interfaces

--- a/metricbeat/mb/module/event.go
+++ b/metricbeat/mb/module/event.go
@@ -9,10 +9,6 @@ import (
 	"github.com/elastic/beats/metricbeat/mb"
 )
 
-const (
-	defaultType = "metricsets"
-)
-
 // EventBuilder is used for building MetricSet events. MetricSets generate a
 // data in the form of a common.MapStr. This builder transforms that data into
 // a complete event and applies any Module-level filtering.
@@ -38,8 +34,6 @@ func (b EventBuilder) Build() (common.MapStr, error) {
 	}
 
 	// Get and remove meta fields from the event created by the MetricSet.
-	indexName := getIndex(event, "")
-	typeName := getType(event, defaultType)
 	timestamp := getTimestamp(event, common.Time(b.StartTime))
 
 	// Apply filters.
@@ -49,16 +43,13 @@ func (b EventBuilder) Build() (common.MapStr, error) {
 		}
 	}
 
-	// Checks if additional meta information is provided by the MetricSet under the key ModuleData
-	// This is based on the convention that each MetricSet can provide module data under the key ModuleData
-	moduleData, moudleDataExists := event[mb.ModuleData]
-	if moudleDataExists {
-		delete(event, mb.ModuleData)
-	}
-
 	metricsetData := common.MapStr{
 		"module": b.ModuleName,
 		"name":   b.MetricSetName,
+	}
+	// Adds host name to event.
+	if b.Host != "" {
+		metricsetData["host"] = b.Host
 	}
 	if b.FetchDuration != 0 {
 		metricsetData["rtt"] = b.FetchDuration.Nanoseconds() / int64(time.Microsecond)
@@ -67,38 +58,36 @@ func (b EventBuilder) Build() (common.MapStr, error) {
 	namespace := b.MetricSetName
 	if n, ok := event["_namespace"]; ok {
 		delete(event, "_namespace")
-		namespace = n.(string)
-		// TODO: check if namespace does not already exist
+		if ns, ok := n.(string); ok {
+			namespace = ns
+		}
+
 		metricsetData["namespace"] = namespace
+	}
+
+	// Checks if additional meta information is provided by the MetricSet under the key ModuleData
+	// This is based on the convention that each MetricSet can provide module data under the key ModuleData
+	moduleData, moudleDataExists := event[mb.ModuleDataKey]
+	if moudleDataExists {
+		delete(event, mb.ModuleDataKey)
+	}
+
+	moduleEvent := common.MapStr{}
+	moduleEvent.Put(namespace, event)
+
+	// In case meta data exists, it is added on the module level
+	// This is mostly used for shared fields across multiple metricsets in one module
+	if moudleDataExists {
+		if data, ok := moduleData.(common.MapStr); ok {
+			moduleEvent.DeepUpdate(data)
+		}
 	}
 
 	event = common.MapStr{
 		"@timestamp":            timestamp,
-		"type":                  typeName,
 		common.EventMetadataKey: b.metadata,
-		b.ModuleName: common.MapStr{
-			namespace: event,
-		},
-		"metricset": metricsetData,
-	}
-
-	// In case meta data exists, it is added on the module level
-	if moudleDataExists {
-		if _, ok := moduleData.(common.MapStr); ok {
-			event[b.ModuleName].(common.MapStr).Update(moduleData.(common.MapStr))
-		}
-	}
-
-	// Overwrite default index if set.
-	if indexName != "" {
-		event["beat"] = common.MapStr{
-			"index": indexName,
-		}
-	}
-
-	// Adds host name to event.
-	if b.Host != "" {
-		event["metricset"].(common.MapStr)["host"] = b.Host
+		b.ModuleName:            moduleEvent,
+		"metricset":             metricsetData,
 	}
 
 	// Adds error to event in case error happened
@@ -109,33 +98,6 @@ func (b EventBuilder) Build() (common.MapStr, error) {
 	}
 
 	return event, nil
-}
-
-func getIndex(event common.MapStr, indexName string) string {
-	// Set index from event if set
-
-	if _, ok := event["index"]; ok {
-		indexName, ok = event["index"].(string)
-		if !ok {
-			logp.Err("Index couldn't be overwritten because event index is not string")
-		}
-		delete(event, "index")
-	}
-	return indexName
-}
-
-func getType(event common.MapStr, typeName string) string {
-
-	// Set type from event if set
-	if _, ok := event["type"]; ok {
-		typeName, ok = event["type"].(string)
-		if !ok {
-			logp.Err("Type couldn't be overwritten because event type is not string")
-		}
-		delete(event, "type")
-	}
-
-	return typeName
 }
 
 func getTimestamp(event common.MapStr, timestamp common.Time) common.Time {

--- a/metricbeat/mb/module/event_test.go
+++ b/metricbeat/mb/module/event_test.go
@@ -45,7 +45,6 @@ func TestEventBuilder(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assert.Equal(t, defaultType, event["type"])
 	assert.Equal(t, common.Time(startTime), event["@timestamp"])
 
 	metricset := event["metricset"].(common.MapStr)

--- a/metricbeat/mb/module/example_test.go
+++ b/metricbeat/mb/module/example_test.go
@@ -76,8 +76,7 @@ func ExampleWrapper() {
 	//     "module": "fake",
 	//     "name": "eventfetcher",
 	//     "rtt": 111
-	//   },
-	//   "type": "metricsets"
+	//   }
 	// }
 }
 

--- a/metricbeat/module/docker/cpu/data.go
+++ b/metricbeat/module/docker/cpu/data.go
@@ -15,7 +15,7 @@ func eventsMapping(cpuStatsList []CPUStats) []common.MapStr {
 
 func eventMapping(stats *CPUStats) common.MapStr {
 	event := common.MapStr{
-		mb.ModuleData: common.MapStr{
+		mb.ModuleDataKey: common.MapStr{
 			"container": stats.Container.ToMapStr(),
 		},
 		"core": stats.PerCpuUsage,

--- a/metricbeat/module/docker/diskio/data.go
+++ b/metricbeat/module/docker/diskio/data.go
@@ -15,7 +15,7 @@ func eventsMapping(blkioStatsList []BlkioStats) []common.MapStr {
 
 func eventMapping(stats *BlkioStats) common.MapStr {
 	event := common.MapStr{
-		mb.ModuleData: common.MapStr{
+		mb.ModuleDataKey: common.MapStr{
 			"container": stats.Container.ToMapStr(),
 		},
 		"reads":  stats.reads,

--- a/metricbeat/module/docker/healthcheck/data.go
+++ b/metricbeat/module/docker/healthcheck/data.go
@@ -40,7 +40,7 @@ func eventMapping(cont *dc.APIContainers, m *MetricSet) common.MapStr {
 	}
 
 	return common.MapStr{
-		mb.ModuleData: common.MapStr{
+		mb.ModuleDataKey: common.MapStr{
 			"container": docker.NewContainer(cont).ToMapStr(),
 		},
 		"status":        container.State.Health.Status,

--- a/metricbeat/module/docker/memory/data.go
+++ b/metricbeat/module/docker/memory/data.go
@@ -15,7 +15,7 @@ func eventsMapping(memoryDataList []MemoryData) []common.MapStr {
 
 func eventMapping(memoryData *MemoryData) common.MapStr {
 	event := common.MapStr{
-		mb.ModuleData: common.MapStr{
+		mb.ModuleDataKey: common.MapStr{
 			"container": memoryData.Container.ToMapStr(),
 		},
 		"fail": common.MapStr{

--- a/metricbeat/module/docker/network/data.go
+++ b/metricbeat/module/docker/network/data.go
@@ -15,7 +15,7 @@ func eventsMapping(netsStatsList []NetStats) []common.MapStr {
 
 func eventMapping(stats *NetStats) common.MapStr {
 	event := common.MapStr{
-		mb.ModuleData: common.MapStr{
+		mb.ModuleDataKey: common.MapStr{
 			"container": stats.Container.ToMapStr(),
 		},
 		"interface": stats.NameInterface,

--- a/metricbeat/module/dropwizard/collector/collector.go
+++ b/metricbeat/module/dropwizard/collector/collector.go
@@ -85,9 +85,9 @@ func (m *MetricSet) Fetch() ([]common.MapStr, error) {
 
 	// Converts hash list to slice
 	events := []common.MapStr{}
-	for _, e := range eventList {
-		e["_namespace"] = m.namespace
-		events = append(events, e)
+	for _, event := range eventList {
+		event[mb.NamespaceKey] = m.namespace
+		events = append(events, event)
 	}
 
 	return events, err

--- a/metricbeat/module/elasticsearch/node/_meta/data.json
+++ b/metricbeat/module/elasticsearch/node/_meta/data.json
@@ -17,15 +17,14 @@
                 },
                 "version": "1.8.0_121"
             },
-            "name": "fLk5w1-IR2a03fUrs5KbWA",
+            "name": "8zgOwJ24TMamDDH9amWINQ",
             "version": "6.0.0-alpha1"
         }
     },
     "metricset": {
-        "host": "elasticsearch:9200",
+        "host": "127.0.0.1:9200",
         "module": "elasticsearch",
         "name": "node",
         "rtt": 115
-    },
-    "type": "metricsets"
+    }
 }

--- a/metricbeat/module/elasticsearch/node/data.go
+++ b/metricbeat/module/elasticsearch/node/data.go
@@ -40,7 +40,7 @@ func eventsMapping(content []byte) ([]common.MapStr, error) {
 		event, errs := eventMapping(node)
 		// Write name here as full name only available as key
 		event["name"] = name
-		event[mb.ModuleData] = common.MapStr{
+		event[mb.ModuleDataKey] = common.MapStr{
 			"cluster": common.MapStr{
 				"name": nodesStruct.ClusterName,
 			},

--- a/metricbeat/module/elasticsearch/node_stats/_meta/data.json
+++ b/metricbeat/module/elasticsearch/node_stats/_meta/data.json
@@ -9,85 +9,85 @@
             "name": "elasticsearch"
         },
         "node": {
-            "name": "OIBwp_5vSAG16PyX6B4eUA"
-        },
-        "node_stats": {
-            "indices": {
-                "docs": {
-                    "count": 2,
-                    "deleted": 0
-                },
-                "segments": {
-                    "count": 2,
-                    "memory": {
-                        "bytes": 3476
-                    }
-                },
-                "store": {
-                    "size": {
-                        "bytes": 8078
-                    }
-                }
-            },
-            "jvm": {
-                "gc": {
-                    "collectors": {
-                        "old": {
-                            "collection": {
-                                "count": 1,
-                                "ms": 71
-                            }
-                        },
-                        "young": {
-                            "collection": {
-                                "count": 4,
-                                "ms": 193
-                            }
+            "name": "8zgOwJ24TMamDDH9amWINQ",
+            "stats": {
+                "indices": {
+                    "docs": {
+                        "count": 0,
+                        "deleted": 0
+                    },
+                    "segments": {
+                        "count": 0,
+                        "memory": {
+                            "bytes": 0
+                        }
+                    },
+                    "store": {
+                        "size": {
+                            "bytes": 0
                         }
                     }
                 },
-                "mem": {
-                    "pools": {
-                        "old": {
-                            "max": {
-                                "bytes": 362414080
+                "jvm": {
+                    "gc": {
+                        "collectors": {
+                            "old": {
+                                "collection": {
+                                    "count": 1,
+                                    "ms": 80
+                                }
                             },
-                            "peak": {
-                                "bytes": 16151432
-                            },
-                            "peak_max": {
-                                "bytes": 362414080
-                            },
-                            "used": {
-                                "bytes": 16151432
+                            "young": {
+                                "collection": {
+                                    "count": 4,
+                                    "ms": 151
+                                }
                             }
-                        },
-                        "survivor": {
-                            "max": {
-                                "bytes": 17432576
+                        }
+                    },
+                    "mem": {
+                        "pools": {
+                            "old": {
+                                "max": {
+                                    "bytes": 362414080
+                                },
+                                "peak": {
+                                    "bytes": 20109096
+                                },
+                                "peak_max": {
+                                    "bytes": 362414080
+                                },
+                                "used": {
+                                    "bytes": 20109096
+                                }
                             },
-                            "peak": {
-                                "bytes": 17432568
+                            "survivor": {
+                                "max": {
+                                    "bytes": 17432576
+                                },
+                                "peak": {
+                                    "bytes": 17432576
+                                },
+                                "peak_max": {
+                                    "bytes": 17432576
+                                },
+                                "used": {
+                                    "bytes": 17432560
+                                }
                             },
-                            "peak_max": {
-                                "bytes": 17432576
-                            },
-                            "used": {
-                                "bytes": 17432568
-                            }
-                        },
-                        "young": {
-                            "max": {
-                                "bytes": 139591680
-                            },
-                            "peak": {
-                                "bytes": 139591680
-                            },
-                            "peak_max": {
-                                "bytes": 139591680
-                            },
-                            "used": {
-                                "bytes": 136064336
+                            "young": {
+                                "max": {
+                                    "bytes": 139591680
+                                },
+                                "peak": {
+                                    "bytes": 139591680
+                                },
+                                "peak_max": {
+                                    "bytes": 139591680
+                                },
+                                "used": {
+                                    "bytes": 98778408
+                                }
                             }
                         }
                     }
@@ -99,7 +99,7 @@
         "host": "127.0.0.1:9200",
         "module": "elasticsearch",
         "name": "node_stats",
+        "namespace": "node.stats",
         "rtt": 115
-    },
-    "type": "metricsets"
+    }
 }

--- a/metricbeat/module/elasticsearch/node_stats/_meta/fields.yml
+++ b/metricbeat/module/elasticsearch/node_stats/_meta/fields.yml
@@ -1,12 +1,8 @@
-- name: node_stats
+- name: node.stats
   type: group
   description: >
     node_stats
   fields:
-    - name: name
-      type: keyword
-      description: >
-        Node name.
     - name: indices
       type: group
       description: >

--- a/metricbeat/module/elasticsearch/node_stats/data.go
+++ b/metricbeat/module/elasticsearch/node_stats/data.go
@@ -83,7 +83,7 @@ func eventsMapping(content []byte) ([]common.MapStr, error) {
 	for name, node := range nodesStruct.Nodes {
 		event, errs := schema.Apply(node)
 		// Write name here as full name only available as key
-		event[mb.ModuleData] = common.MapStr{
+		event[mb.ModuleDataKey] = common.MapStr{
 			"node": common.MapStr{
 				"name": name,
 			},
@@ -91,6 +91,7 @@ func eventsMapping(content []byte) ([]common.MapStr, error) {
 				"name": nodesStruct.ClusterName,
 			},
 		}
+		event[mb.NamespaceKey] = "node.stats"
 		events = append(events, event)
 		errors.AddErrors(errs)
 	}

--- a/metricbeat/module/golang/expvar/expvar.go
+++ b/metricbeat/module/golang/expvar/expvar.go
@@ -75,7 +75,7 @@ func (m *MetricSet) Fetch() (common.MapStr, error) {
 	json["cmdline"] = golang.GetCmdStr(json["cmdline"])
 
 	//set namespace
-	json["_namespace"] = m.namespace
+	json[mb.NamespaceKey] = m.namespace
 
 	return json, nil
 }

--- a/metricbeat/module/http/json/json.go
+++ b/metricbeat/module/http/json/json.go
@@ -115,7 +115,7 @@ func (m *MetricSet) Fetch() (common.MapStr, error) {
 	event := jsonBody
 
 	if m.requestEnabled {
-		event[mb.ModuleData] = common.MapStr{
+		event[mb.ModuleDataKey] = common.MapStr{
 			"request": common.MapStr{
 				"headers": m.getHeaders(response.Request.Header),
 				"method":  response.Request.Method,
@@ -125,7 +125,7 @@ func (m *MetricSet) Fetch() (common.MapStr, error) {
 	}
 
 	if m.responseEnabled {
-		event[mb.ModuleData] = common.MapStr{
+		event[mb.ModuleDataKey] = common.MapStr{
 			"response": common.MapStr{
 				"status_code": response.StatusCode,
 				"headers":     m.getHeaders(response.Header),

--- a/metricbeat/module/jolokia/jmx/jmx.go
+++ b/metricbeat/module/jolokia/jmx/jmx.go
@@ -89,7 +89,7 @@ func (m *MetricSet) Fetch() (common.MapStr, error) {
 	}
 
 	// Set dynamic namespace
-	event["_namespace"] = m.namespace
+	event[mb.NamespaceKey] = m.namespace
 
 	return event, nil
 }

--- a/metricbeat/module/kubernetes/container/data.go
+++ b/metricbeat/module/kubernetes/container/data.go
@@ -22,7 +22,7 @@ func eventMapping(content []byte) ([]common.MapStr, error) {
 	for _, pod := range summary.Pods {
 		for _, container := range pod.Containers {
 			containerEvent := common.MapStr{
-				mb.ModuleData: common.MapStr{
+				mb.ModuleDataKey: common.MapStr{
 					"namespace": pod.PodRef.Namespace,
 					"node": common.MapStr{
 						"name": node.NodeName,

--- a/metricbeat/module/kubernetes/pod/data.go
+++ b/metricbeat/module/kubernetes/pod/data.go
@@ -22,7 +22,7 @@ func eventMapping(content []byte) ([]common.MapStr, error) {
 
 	for _, pod := range summary.Pods {
 		podEvent := common.MapStr{
-			mb.ModuleData: common.MapStr{
+			mb.ModuleDataKey: common.MapStr{
 				"namespace": pod.PodRef.Namespace,
 				"node": common.MapStr{
 					"name": node.NodeName,

--- a/metricbeat/module/kubernetes/system/data.go
+++ b/metricbeat/module/kubernetes/system/data.go
@@ -22,7 +22,7 @@ func eventMapping(content []byte) ([]common.MapStr, error) {
 
 	for _, syscontainer := range node.SystemContainers {
 		containerEvent := common.MapStr{
-			mb.ModuleData: common.MapStr{
+			mb.ModuleDataKey: common.MapStr{
 				"node": common.MapStr{
 					"name": node.NodeName,
 				},

--- a/metricbeat/module/kubernetes/volume/data.go
+++ b/metricbeat/module/kubernetes/volume/data.go
@@ -22,7 +22,7 @@ func eventMapping(content []byte) ([]common.MapStr, error) {
 	for _, pod := range summary.Pods {
 		for _, volume := range pod.Volume {
 			volumeEvent := common.MapStr{
-				mb.ModuleData: common.MapStr{
+				mb.ModuleDataKey: common.MapStr{
 					"namespace": pod.PodRef.Namespace,
 					"node": common.MapStr{
 						"name": node.NodeName,

--- a/metricbeat/module/prometheus/collector/collector.go
+++ b/metricbeat/module/prometheus/collector/collector.go
@@ -91,7 +91,7 @@ func (m *MetricSet) Fetch() ([]common.MapStr, error) {
 	// Converts hash list to slice
 	events := []common.MapStr{}
 	for _, e := range eventList {
-		e["_namespace"] = m.namespace
+		e[mb.NamespaceKey] = m.namespace
 		events = append(events, e)
 	}
 

--- a/metricbeat/tests/system/metricbeat.py
+++ b/metricbeat/tests/system/metricbeat.py
@@ -6,7 +6,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '../../../libbeat/tests/
 from beat.beat import TestCase
 
 COMMON_FIELDS = ["@timestamp", "beat", "metricset.name", "metricset.host",
-                 "metricset.module", "metricset.rtt", "type"]
+                 "metricset.module", "metricset.rtt"]
 
 INTEGRATION_TESTS = os.environ.get('INTEGRATION_TESTS', False)
 

--- a/metricbeat/tests/system/test_processors.py
+++ b/metricbeat/tests/system/test_processors.py
@@ -35,7 +35,7 @@ class TestProcessors(metricbeat.BaseTest):
         print(evt.keys())
         self.assertItemsEqual(self.de_dot([
             'beat', '@timestamp', 'system', 'metricset.module',
-            'metricset.rtt', 'type', 'metricset.name'
+            'metricset.rtt', 'metricset.name'
         ]), evt.keys())
         cpu = evt["system"]["cpu"]
         print(cpu.keys())
@@ -69,7 +69,7 @@ class TestProcessors(metricbeat.BaseTest):
         metricbeat.kill_and_wait()
 
         output = self.read_output(
-            required_fields=["@timestamp", "type"],
+            required_fields=["@timestamp"],
         )
 
         for event in output:
@@ -102,7 +102,7 @@ class TestProcessors(metricbeat.BaseTest):
         metricbeat.kill_and_wait()
 
         output = self.read_output(
-            required_fields=["@timestamp", "type"],
+            required_fields=["@timestamp"],
         )
         for event in output:
             assert float(event["system.process.cpu.total.pct"]) >= 0.001
@@ -131,7 +131,7 @@ class TestProcessors(metricbeat.BaseTest):
         metricbeat.kill_and_wait()
 
         output = self.read_output(
-            required_fields=["@timestamp", "type"],
+            required_fields=["@timestamp"],
         )
         assert len(output) >= 1
 
@@ -157,7 +157,7 @@ class TestProcessors(metricbeat.BaseTest):
         metricbeat.kill_and_wait()
 
         output = self.read_output(
-            required_fields=["@timestamp", "type"],
+            required_fields=["@timestamp"],
         )[0]
         print(output)
 
@@ -201,7 +201,7 @@ class TestProcessors(metricbeat.BaseTest):
         metricbeat.kill_and_wait()
 
         output = self.read_output(
-            required_fields=["@timestamp", "type"],
+            required_fields=["@timestamp"],
         )[0]
 
         for key in [
@@ -246,7 +246,7 @@ class TestProcessors(metricbeat.BaseTest):
         metricbeat.kill_and_wait()
 
         output = self.read_output(
-            required_fields=["@timestamp", "type"],
+            required_fields=["@timestamp"],
         )[0]
 
         for key in [


### PR DESCRIPTION
So far the node_stats was putting all its data under `elasticsearch.node_stats.*`. This was changed to `elasticsearch.node.stats.*`.

Further changes:

* Remove support for setting index in metricset. This was never used and can now be done through using format string in the index setting.
* Remove support for setting type in metricset. Type will be removed in elasticsearch.
* Rename ModuleData constant to ModuleDataKey.
* Introduce NamespaceKey as constant to replace hardcoded `_namespace`.
* Cleanup event generation for metricbeat.
* Remove `type` from event as not needed.