### PR TITLE
Deprecate the metrics endpoint in Winlogbeat

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -80,8 +80,9 @@ https://github.com/elastic/beats/compare/v5.3.0...master[Check the HEAD diff]
 *Packetbeat*
 
 *Winlogbeat*
+- Deprecated metrics endpoint. It is superseded by a libbeat feature that can serve metrics on an HTTP endpoint. {pull}4145[4145]
 
-==== Knwon Issue
+==== Known Issue
 
 *Affecting all Beats*
 

--- a/winlogbeat/_meta/beat.full.yml
+++ b/winlogbeat/_meta/beat.full.yml
@@ -14,12 +14,6 @@
 # in the directory in which it was started.
 #winlogbeat.registry_file: .winlogbeat.yml
 
-# Diagnostic metrics that can retrieved through a web interface if a
-# bindaddress value (host:port) is specified. The web address will be
-# http://<bindaddress>/debug/vars
-#winlogbeat.metrics:
-#  bindaddress: 'localhost:8123'
-
 # event_logs specifies a list of event logs to monitor as well as any
 # accompanying options. The YAML data type of event_logs is a list of
 # dictionaries.

--- a/winlogbeat/beater/winlogbeat.go
+++ b/winlogbeat/beater/winlogbeat.go
@@ -116,6 +116,7 @@ func (eb *Winlogbeat) setup(b *beat.Beat) error {
 	}
 
 	if config.Metrics.BindAddress != "" {
+		logp.Warn("DEPRECATED: Metrics endpoint is deprecated and will be removed in 6.0")
 		bindAddress := config.Metrics.BindAddress
 		sock, err := net.Listen("tcp", bindAddress)
 		if err != nil {

--- a/winlogbeat/docs/reference/configuration/winlogbeat-options.asciidoc
+++ b/winlogbeat/docs/reference/configuration/winlogbeat-options.asciidoc
@@ -170,7 +170,7 @@ Windows will prevent Winlogbeat from reading the event log because it limits the
 number of conditions that can be used in an event log query. If this occurs a similar
 warning as shown below will be logged by Winlogbeat, and it will continue
 processing data from other event logs. For more information, see
-https://support.microsoft.com/en-us/kb/970453. 
+https://support.microsoft.com/en-us/kb/970453.
 
 `WARN EventLog[Application] Open() error. No events will be read from this
 source. The specified query is invalid.`
@@ -183,12 +183,12 @@ event IDs.
 
 [source,yaml]
 --------------------------------------------------------------------------------
-processors:                   
-- drop_event.when.and:               
-    - equals.log_name: Security      
-    - not.or:                   
-        - equals.event_id: 903     
-        - equals.event_id: 1024    
+processors:
+- drop_event.when.and:
+    - equals.log_name: Security
+    - not.or:
+        - equals.event_id: 903
+        - equals.event_id: 1024
         - equals.event_id: 4624
 --------------------------------------------------------------------------------
 
@@ -327,6 +327,8 @@ field names added by Winlogbeat, then the custom fields overwrite the other
 fields.
 
 ===== metrics.bindaddress
+
+[]deprecated
 
 The hostname and port where the Beat will host an HTTP web service that provides
 metrics. This field is optional.

--- a/winlogbeat/winlogbeat.full.yml
+++ b/winlogbeat/winlogbeat.full.yml
@@ -14,12 +14,6 @@
 # in the directory in which it was started.
 #winlogbeat.registry_file: .winlogbeat.yml
 
-# Diagnostic metrics that can retrieved through a web interface if a
-# bindaddress value (host:port) is specified. The web address will be
-# http://<bindaddress>/debug/vars
-#winlogbeat.metrics:
-#  bindaddress: 'localhost:8123'
-
 # event_logs specifies a list of event logs to monitor as well as any
 # accompanying options. The YAML data type of event_logs is a list of
 # dictionaries.


### PR DESCRIPTION
The metrics endpoint is replaced by the http endpoing for all beats in 6.0. See https://github.com/elastic/beats/pull/3717