### PR TITLE
Added output for AWS CloudWatch Logs

### DIFF
--- a/filebeat/docs/reference/configuration.asciidoc
+++ b/filebeat/docs/reference/configuration.asciidoc
@@ -22,6 +22,7 @@ configuration settings, you need to restart {beatname_uc} to pick up the changes
 * <<redis-output>>
 * <<file-output>>
 * <<console-output>>
+* <<awscwl-output>>
 * <<configuration-output-ssl>>
 * <<configuration-output-codec>>
 * <<configuration-path>>

--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -1037,6 +1037,144 @@ Output codec configuration. If the `codec` section is missing, events will be js
 
 See <<configuration-output-codec>> for more information.
 
+[[awscwl-output]]
+=== AWS CloudWatch Logs Output
+
+When you specify AWS CloudWatch Logs for the output, the Beat sends the transactions
+directly to AWS CloudWatch logs using the https://aws.amazon.com/sdk-for-go/[AWS SDK for Go].
+
+The logs are sent in bulk every `bulk_max_size` records or `flush_interval`, whichever comes first.
+
+Check https://aws.amazon.com/cloudwatch/pricing/[CloudWatch Log Pricing] first so you understand
+the costs involved.
+
+Example configuration:
+
+["source","yaml",subs="attributes"]
+------------------------------------------------------------------------------
+output.awscwl:
+  codec.format:
+     string: '%{[message]}'
+  region: "us-east-1"
+  log_group_name: "/prod/linux/syslog"
+  log_stream_name_prefix: "MY_IP"
+  # access_key_id: XXXXXX
+  # secret_access_key: XXXXXX
+  # session_token: XXXXXX
+  # bulk_max_size: 1024 # default 1024 events in bulk publish
+  # flush_interval: 60 # default 60 seconds
+------------------------------------------------------------------------------
+
+The CloudWatch Log Group must already exist in your environment.  This plugin only creates
+streams within an existing group.  You would typically set a different `log_stream_name_prefix`
+for each server so the logs don't all get jumbled together.  Use whatever identifier
+makes sense for your environment (instance-id, ip address, etc.).
+
+The credentials for AWS are provided using the default credentials provider
+chain as documented http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html[here].
+In most deployments using this output, credentials are provided automatically
+to EC2 instances with an IAM Role.  If you are deploying via a docker container
+you should use one of the common mechanisms used today (environment variables or
+bind mount a credentials file).
+
+The credentials must be granted the following actions as demonstrated in this sample policy
+(although you should probably restrict the `Resource` to adhere to
+https://en.wikipedia.org/wiki/Principle_of_least_privilege[the principle of least privilege]):
+
+["source","json"]
+------------------------------------------------------------------------------
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogStream",
+        "logs:DescribeLogStreams",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "arn:aws:logs:*:*:*"
+    }
+  ]
+}
+------------------------------------------------------------------------------
+
+==== AWS CloudWatch Logs Output Options
+
+You can specify the following options in the `awscwl` section of the +{beatname_lc}.yml+
+config file:
+
+===== enabled
+
+The enabled config is a boolean setting to enable or disable the output. If set
+to false, the output is disabled.
+
+The default value is true.
+
+===== region
+
+Since CloudWatch Logs are region specific, a required parameter is the destination region.
+Keep https://aws.amazon.com/ec2/pricing/[cross region data transfer costs] in
+mind should you set this to a different region than where you are running {beatname_lc}.
+
+===== log_group_name
+
+The destination CloudWatch
+http://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/CloudWatchLogsConcepts.html[Log Group]
+that will hold the output.
+
+Be sure to set sensible
+http://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/CloudWatchLogsConcepts.html[Retention Settings]
+to keep your archival costs down.  Don't keep more than what you need.
+
+===== log_stream_name_prefix
+
+The target CloudWatch
+http://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/CloudWatchLogsConcepts.html[Log Stream]
+to create or append records.
+
+Usually, you want this to be unique to the source of the data (ip, instance-id, whatever).
+
+===== access_key_id
+
+You can override the
+http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html[default credentials chain]
+by specifying AWS API keys directly (mostly used for testing).
+
+===== secret_access_key
+
+You can override the
+http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html[default credentials chain]
+by specifying AWS API keys directly (mostly used for testing).
+
+===== session_token
+
+You can override the
+http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html[default credentials chain]
+by specifying AWS API keys directly (mostly used for testing).
+
+`session_token` should only be specified if the `access_key_id`/`secret_access_key` pair are
+http://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.html[temporary keys from STS].
+
+===== bulk_max_size
+
+The maximum number of records to push in one API call.  When this size is reached
+the records are sent even if the `flush_interval` hasn't passed.  The default value
+is 1024 (records).
+
+===== flush_interval
+
+The number of seconds between bulk sends to CloudWatch Logs.  Any unsent records will be sent on this
+interval.  The default value is 60 (seconds).
+
+===== codec
+
+Output codec configuration. If the `codec` section is missing, events will be json encoded.
+
+See <<configuration-output-codec>> for more information.
+
+The example configuration above uses a simple line format for the payload.
+
 [[console-output]]
 === Console Output
 

--- a/libbeat/outputs/awscwl/awscwl.go
+++ b/libbeat/outputs/awscwl/awscwl.go
@@ -1,0 +1,201 @@
+package awscwl
+
+import (
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/op"
+	"github.com/elastic/beats/libbeat/outputs"
+)
+
+func init() {
+	outputs.RegisterOutputPlugin("awscwl", New)
+}
+
+type awsCloudWatchStream struct {
+	nextToken *string
+	svc       *cloudwatchlogs.CloudWatchLogs
+}
+
+type awscwlOutput struct {
+	beat                common.BeatInfo
+	codec               outputs.Codec
+	logGroupName        string
+	logStreamNamePrefix string
+	session             *session.Session
+	stream              *awsCloudWatchStream
+}
+
+// New instantiates a new awscwlOutput instance.
+func New(beat common.BeatInfo, cfg *common.Config) (outputs.Outputer, error) {
+	config := defaultConfig
+	if err := cfg.Unpack(&config); err != nil {
+		return nil, err
+	}
+
+	// bulk_max_size is the numner of events in a bulk message request.
+	// default: 1024
+	if !cfg.HasField("bulk_max_size") {
+		cfg.SetInt("bulk_max_size", -1, defaultBulkSize)
+	}
+
+	// flush_interval is the number of seconds to wait in between bulk
+	// messages.
+	// default: 300 (seconds)
+	if !cfg.HasField("flush_interval") {
+		cfg.SetInt("flush_interval", -1, defaultFlushInterval)
+	}
+
+	output := &awscwlOutput{beat: beat, session: nil,
+		stream: &awsCloudWatchStream{nextToken: nil, svc: nil},
+	}
+	if err := output.init(config); err != nil {
+		return nil, err
+	}
+	return output, nil
+}
+
+func (out *awscwlOutput) init(config awscwlConfig) error {
+	var err error
+
+	// configure the codec passed in or create a default
+	codec, err := outputs.CreateEncoder(config.Codec)
+	if err != nil {
+		return err
+	}
+	out.codec = codec
+
+	// we need these variables ongoing to copy them to our output config
+	out.logStreamNamePrefix = config.LogStreamNamePrefix
+	out.logGroupName = config.LogGroupName
+
+	// create an aws session based off the credentials in the config. If the
+	// credentials are not specified then the aws SDK automagically checks
+	// the environment. if you are running this on an aws instance you probably
+	// wont need to specifiy credentials... maybe :)
+
+	if config.AccessKeyId != "" && config.SecretAccessKey != "" {
+		out.session, err = session.NewSession(&aws.Config{
+			Region: aws.String(config.Region),
+			Credentials: credentials.NewStaticCredentials(config.AccessKeyId,
+				config.SecretAccessKey,
+				config.SessionToken),
+		})
+	} else {
+		out.session, err = session.NewSession(&aws.Config{
+			Region: aws.String(config.Region),
+		})
+	}
+	// return the err from either of the two above scenarios
+	if err != nil {
+		return err
+	}
+
+	// create a new instance of cloudwatchlogs
+	out.stream.svc = cloudwatchlogs.New(out.session, aws.NewConfig())
+
+	// see if the stream is a part of the configured LogGroup
+	params := &cloudwatchlogs.DescribeLogStreamsInput{
+		LogGroupName:        aws.String(out.logGroupName),
+		Limit:               aws.Int64(1),
+		LogStreamNamePrefix: aws.String(out.logStreamNamePrefix),
+	}
+	resp, err := out.stream.svc.DescribeLogStreams(params)
+	if err != nil {
+		return err
+	}
+
+	// if the stream exists we need to get the uploadSequenceToken. if the
+	// stream does not exist we need to create it.
+	if len(resp.LogStreams) == 0 {
+		params := &cloudwatchlogs.CreateLogStreamInput{
+			LogGroupName:  aws.String(out.logGroupName),
+			LogStreamName: aws.String(out.logStreamNamePrefix),
+		}
+		if _, err := out.stream.svc.CreateLogStream(params); err != nil {
+			return err
+		}
+	} else {
+		if resp.LogStreams[0].UploadSequenceToken != nil {
+			out.stream.nextToken = resp.LogStreams[0].UploadSequenceToken
+		}
+	}
+
+	// at this point we have located a logGroup that we can write to and we
+	// had access to create a stream. we will now wait for publish events
+	// and then write them.
+
+	return nil
+}
+
+// Implement Outputer
+func (out *awscwlOutput) Close() error {
+	return nil
+}
+
+// PublishEvent is called for single events if the BulkPublish service is
+// disabled. this is a less than optimal function to call for rest based
+// aws calls but we still need to handle single events
+func (out *awscwlOutput) PublishEvent(
+	sig op.Signaler,
+	opts outputs.Options,
+	data outputs.Data,
+) error {
+	dataAr := make([]outputs.Data, 0)
+	dataAr = append(dataAr, data)
+	return out.BulkPublish(sig, opts, dataAr)
+}
+
+// BulkPublish is called whenever the bulk_max_size queues the proper number of
+// events or whenever flush_interval has reached its limit.
+func (out *awscwlOutput) BulkPublish(
+	sig op.Signaler,
+	opts outputs.Options,
+	data []outputs.Data,
+) error {
+	logEvents := make([]*cloudwatchlogs.InputLogEvent, 0) // empty events array
+	var serializedEvent []byte
+	var err error
+
+	// get the current month
+	t := time.Now().UnixNano() / int64(time.Millisecond)
+
+	for _, v := range data {
+		serializedEvent, err = out.codec.Encode(v.Event)
+		if err != nil {
+			op.SigFailed(sig, err)
+			return err
+		}
+		logEvents = append(logEvents, &cloudwatchlogs.InputLogEvent{
+			Message:   aws.String(string(serializedEvent)),
+			Timestamp: aws.Int64(t),
+		})
+	}
+
+	// push logEvents() to aws
+	params := &cloudwatchlogs.PutLogEventsInput{
+		LogEvents:     logEvents,
+		LogGroupName:  aws.String(out.logGroupName),
+		LogStreamName: aws.String(out.logStreamNamePrefix),
+		SequenceToken: out.stream.nextToken,
+	}
+	resp, err := out.stream.svc.PutLogEvents(params)
+	if err != nil {
+		op.SigFailed(sig, err)
+		return err
+	}
+
+	// the NextSequenceToken must be passed to future calls of PutLogEvents()
+	if resp.NextSequenceToken != nil {
+		out.stream.nextToken = resp.NextSequenceToken
+	}
+
+	// instruct the prospector that messages have been successfully processed
+	op.SigCompleted(sig)
+
+	return nil
+}

--- a/libbeat/outputs/awscwl/awscwl_test.go
+++ b/libbeat/outputs/awscwl/awscwl_test.go
@@ -1,0 +1,3 @@
+// +build !integration
+
+package awscwl

--- a/libbeat/outputs/awscwl/config.go
+++ b/libbeat/outputs/awscwl/config.go
@@ -1,0 +1,32 @@
+package awscwl
+
+import (
+	//	"github.com/aws/aws-sdk-go/aws"
+	//	"github.com/aws/aws-sdk-go/aws/credentials"
+	//	"github.com/aws/aws-sdk-go/aws/session"
+	//	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
+	"github.com/elastic/beats/libbeat/outputs"
+)
+
+type awscwlConfig struct {
+	Region              string              `config:"region"`
+	LogGroupName        string              `config:"log_group_name"`
+	LogStreamNamePrefix string              `config:"log_stream_name_prefix"`
+	AccessKeyId         string              `config:"access_key_id"`
+	SecretAccessKey     string              `config:"secret_access_key"`
+	SessionToken        string              `config:"session_token"`
+	Codec               outputs.CodecConfig `config:"codec"`
+}
+
+var (
+	defaultConfig = awscwlConfig{
+		AccessKeyId:     "",
+		SecretAccessKey: "",
+		SessionToken:    "",
+	}
+)
+
+const (
+	defaultBulkSize      = 1024
+	defaultFlushInterval = 60
+)

--- a/libbeat/publisher/publish.go
+++ b/libbeat/publisher/publish.go
@@ -12,6 +12,7 @@ import (
 	"github.com/elastic/beats/libbeat/processors"
 
 	// load supported output plugins
+	_ "github.com/elastic/beats/libbeat/outputs/awscwl"
 	_ "github.com/elastic/beats/libbeat/outputs/console"
 	_ "github.com/elastic/beats/libbeat/outputs/elasticsearch"
 	_ "github.com/elastic/beats/libbeat/outputs/fileout"


### PR DESCRIPTION
We have added an output that will push data taken in by beats to AWS CloudWatch Logs. This should be a useful addition to the beats output plugins and give greater flexibility on what beats can push to.

The only requirement for this to work other than a valid AWS account is to pre-create the log group name you are pushing to. We chose not to create that automatically. The stream name, as defined by the configuration file will be created automatically once the program starts.

AWS credentials can be passed in via several methods. First, you can hard code them in the config file, though we do not recommend this method. Second, the credentials will be read directly from an AWS instance, assuming it has the proper IAM role. Third, credentials will be read through various environment variables per Amazon's AWS SDK documentation. Finally, the credentials will be read from a configuration file that gets created when you install the AWS SDK (~/.aws/credentials) on Linux. 