### PR TITLE
Fixing multiEventFetch error reporting when no events are returned

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -84,6 +84,7 @@ https://github.com/elastic/beats/compare/v5.1.1...master[Check the HEAD diff]
 - Fixing panic on prometheus collector when label has , {pull}3947[3947]
 - Fix MongoDB dbstats fields mapping. {pull}4025[4025]
 - Fixing prometheus collector to aggregate metrics based on metric family. {pull}4075[4075]
+- Fixing multiEventFetch error reporting when no events are returned {pull}4153[4153]
 
 *Packetbeat*
 

--- a/metricbeat/mb/module/wrapper.go
+++ b/metricbeat/mb/module/wrapper.go
@@ -255,8 +255,12 @@ func (msw *metricSetWrapper) singleEventFetch(fetcher mb.EventFetcher, reporter 
 func (msw *metricSetWrapper) multiEventFetch(fetcher mb.EventsFetcher, reporter *eventReporter) {
 	reporter.startFetchTimer()
 	events, err := fetcher.Fetch()
-	for _, event := range events {
-		reporter.ErrorWith(err, event)
+	if len(events) == 0 {
+		reporter.ErrorWith(err, nil)
+	} else {
+		for _, event := range events {
+			reporter.ErrorWith(err, event)
+		}
 	}
 }
 


### PR DESCRIPTION
When a metricbeat module implements `func (m *MetricSet) Fetch() ([]common.MapStr, error) ` and returns an error, it is not added to the output event because of:

```
events, err := fetcher.Fetch()
for _, event := range events {
	reporter.ErrorWith(err, event)
}
```
when events is of size 0 this is never executed and this prevents updating of module metrics like:

```
  "metricbeat": {
    "prometheus": {
      "collector": {
        "events": 0,
        "failures": 0,
        "success": 0
      }
    }
  },
```

which can be very misleading. 

This PR fixes the same by checking size of the event list and passing a `nil` event and the error object.