### PR TITLE
Cleanup prospector shutdown

### DIFF
--- a/filebeat/prospector/prospector_log.go
+++ b/filebeat/prospector/prospector_log.go
@@ -239,7 +239,7 @@ func (l *Log) scan() {
 	for path, info := range l.getFiles() {
 
 		select {
-		case <-l.Prospector.runDone:
+		case <-l.Prospector.done:
 			logp.Info("Scan aborted because prospector stopped.")
 			return
 		default:


### PR DESCRIPTION
As the harvesters are now sending events directly to the spooler, prospector only has to wait for the stopping of the harvester and not completion of sending events. As a harvester only shuts down if all events are passed to the spooler, it is up to the spooler to guarantee that all events are forwarded.

Further cleanup

* rename `runDone` to `done` for consistency and there is only one done channel left
* runWG is replaced by local onceWg as only needed now when `-once` is enabled. Proper harvester shutdown is taken care of by the harvester registry.
* Remove eventCounter and channelDone as not needed anymore