### PR TITLE
Extract stdin prospector

### DIFF
--- a/filebeat/channel/interface.go
+++ b/filebeat/channel/interface.go
@@ -1,0 +1,11 @@
+package channel
+
+import "github.com/elastic/beats/filebeat/input"
+
+// Outleter is the outlet for a prospector
+type Outleter interface {
+	SetSignal(signal <-chan struct{})
+	OnEventSignal(event *input.Data) bool
+	OnEvent(event *input.Data) bool
+	Copy() Outleter
+}

--- a/filebeat/channel/outlet.go
+++ b/filebeat/channel/outlet.go
@@ -5,7 +5,6 @@ import (
 	"sync/atomic"
 
 	"github.com/elastic/beats/filebeat/input"
-	"github.com/elastic/beats/filebeat/prospector"
 )
 
 // Outlet struct is used to be passed to an object which needs an outlet
@@ -90,6 +89,6 @@ func (o *Outlet) OnEventSignal(event *input.Data) bool {
 	}
 }
 
-func (o *Outlet) Copy() prospector.Outlet {
+func (o *Outlet) Copy() Outleter {
 	return NewOutlet(o.done, o.channel, o.wg)
 }

--- a/filebeat/crawler/crawler.go
+++ b/filebeat/crawler/crawler.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/elastic/beats/filebeat/channel"
 	"github.com/elastic/beats/filebeat/input/file"
 	"github.com/elastic/beats/filebeat/prospector"
 	"github.com/elastic/beats/filebeat/registrar"
@@ -15,14 +16,14 @@ import (
 type Crawler struct {
 	prospectors       map[uint64]*prospector.Prospector
 	prospectorConfigs []*common.Config
-	out               prospector.Outlet
+	out               channel.Outleter
 	wg                sync.WaitGroup
 	reloader          *cfgfile.Reloader
 	once              bool
 	beatDone          chan struct{}
 }
 
-func New(out prospector.Outlet, prospectorConfigs []*common.Config, beatDone chan struct{}, once bool) (*Crawler, error) {
+func New(out channel.Outleter, prospectorConfigs []*common.Config, beatDone chan struct{}, once bool) (*Crawler, error) {
 
 	return &Crawler{
 		out:               out,

--- a/filebeat/prospector/factory.go
+++ b/filebeat/prospector/factory.go
@@ -1,6 +1,7 @@
 package prospector
 
 import (
+	"github.com/elastic/beats/filebeat/channel"
 	"github.com/elastic/beats/filebeat/registrar"
 	"github.com/elastic/beats/libbeat/cfgfile"
 	"github.com/elastic/beats/libbeat/common"
@@ -9,13 +10,13 @@ import (
 
 // Factory is a factory for registrars
 type Factory struct {
-	outlet    Outlet
+	outlet    channel.Outleter
 	registrar *registrar.Registrar
 	beatDone  chan struct{}
 }
 
 // NewFactory instantiates a new Factory
-func NewFactory(outlet Outlet, registrar *registrar.Registrar, beatDone chan struct{}) *Factory {
+func NewFactory(outlet channel.Outleter, registrar *registrar.Registrar, beatDone chan struct{}) *Factory {
 	return &Factory{
 		outlet:    outlet,
 		registrar: registrar,

--- a/filebeat/prospector/prospector_log_other_test.go
+++ b/filebeat/prospector/prospector_log_other_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/elastic/beats/filebeat/input/file"
 	"github.com/elastic/beats/libbeat/common/match"
 
+	"github.com/elastic/beats/filebeat/channel"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -158,4 +159,4 @@ type TestOutlet struct{}
 func (o TestOutlet) OnEvent(event *input.Data) bool       { return true }
 func (o TestOutlet) OnEventSignal(event *input.Data) bool { return true }
 func (o TestOutlet) SetSignal(signal <-chan struct{})     {}
-func (o TestOutlet) Copy() Outlet                         { return o }
+func (o TestOutlet) Copy() channel.Outleter               { return o }


### PR DESCRIPTION
This a first step in the direction of having a package for each prospector together with its harvester. Stdin prospector was tackled first as it has much less dependencies. Until the refactoring is completed there will be some duplicated code.