### PR TITLE
Make nosetests more verbose

### DIFF
--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -39,7 +39,7 @@ REVIEWDOG_OPTIONS?=-diff "git diff master"
 REVIEWDOG_REPO=github.com/haya14busa/reviewdog/cmd/reviewdog
 PROCESSES?= 4
 TIMEOUT?= 90
-NOSETESTS_OPTIONS?=--process-timeout=$(TIMEOUT) --with-timer ## @testing the options to pass when calling nosetests
+NOSETESTS_OPTIONS?=--process-timeout=$(TIMEOUT) --with-timer -v ## @testing the options to pass when calling nosetests
 TEST_ENVIRONMENT?=false ## @testing if true, "make testsuite" runs integration tests and system tests in a dockerized test environment
 SYSTEM_TESTS?=false ## @testing if true, "make test" and "make testsuite" run unit tests and system tests
 GOX_OS?=linux darwin windows solaris freebsd netbsd openbsd ## @Building List of all OS to be supported by "make crosscompile".


### PR DESCRIPTION
This can simplify finding the failing tests when running the system tests locally or on CI.

Also it should prevent Jenkins from triggering a timeout too early because otherwise all dots are written on the same line and Jenkins listens for new log lines to check if the build is stuck.