### PR TITLE
Backport: #4147 and #4135 to 5.4

### DIFF
--- a/filebeat/docs/getting-started.asciidoc
+++ b/filebeat/docs/getting-started.asciidoc
@@ -116,7 +116,8 @@ https://www.elastic.co/downloads/beats/filebeat[downloads page].
 
 . Open a PowerShell prompt as an Administrator (right-click the PowerShell icon and select *Run As Administrator*). If you are running Windows XP, you may need to download and install PowerShell.
 
-. Run the following commands to install Filebeat as a Windows service:
+. From the PowerShell prompt, run the following commands to install Filebeat as a
+Windows service:
 +
 [source,shell]
 ----------------------------------------------------------------------

--- a/heartbeat/docs/getting-started.asciidoc
+++ b/heartbeat/docs/getting-started.asciidoc
@@ -123,7 +123,8 @@ https://www.elastic.co/downloads/beats/heartbeat[downloads page].
 and select *Run As Administrator*). If you are running Windows XP, you may need
 to download and install PowerShell.
 
-. Run the following commands to install Heartbeat as a Windows service:
+. From the PowerShell prompt, run the following commands to install Heartbeat as
+a Windows service:
 +
 ["source","sh",subs="attributes"]
 ----------------------------------------------------------------------

--- a/libbeat/docs/dashboards.asciidoc
+++ b/libbeat/docs/dashboards.asciidoc
@@ -65,7 +65,8 @@ Open a PowerShell prompt as an Administrator (right-click the PowerShell icon
 and select *Run As Administrator*). If you are running Windows XP, you may need
 to download and install PowerShell. 
 
-From the directory where you installed {beatname_uc}, run the `import_dashboards.exe` script:
+From the PowerShell prompt, change to the directory where you installed {beatname_uc}, and run the
+`import_dashboards.exe` script:
 
 ["source","sh",subs="attributes,callouts"]
 ----------------------------------------------------------------------

--- a/metricbeat/docs/gettingstarted.asciidoc
+++ b/metricbeat/docs/gettingstarted.asciidoc
@@ -127,7 +127,8 @@ https://www.elastic.co/downloads/beats/metricbeat[downloads page].
 and select *Run As Administrator*). If you are running Windows XP, you may need
 to download and install PowerShell.
 
-. Run the following commands to install Metricbeat as a Windows service:
+. From the PowerShell prompt, run the following commands to install Metricbeat
+as a Windows service:
 +
 [source,shell]
 ----------------------------------------------------------------------

--- a/metricbeat/docs/modules/docker.asciidoc
+++ b/metricbeat/docs/modules/docker.asciidoc
@@ -10,6 +10,15 @@ beta[]
 This module fetches metrics from https://www.docker.com/[Docker] containers.
 
 
+[float]
+=== Module-Specific Configuration Notes
+
+It is strongly recommended that you run Docker metricsets with a
+<<metricset-period,`period`>> that is 3 seconds or longer. The request to the
+Docker API already takes up to 2 seconds. Specifying less than 3 seconds will
+result in requests that timeout, and no data will be reported for those
+requests.
+
 
 [float]
 === Example Configuration

--- a/metricbeat/docs/modules/docker.asciidoc
+++ b/metricbeat/docs/modules/docker.asciidoc
@@ -9,6 +9,7 @@ beta[]
 
 This module fetches metrics from https://www.docker.com/[Docker] containers.
 
+The docker module is currently not tested on Windows.
 
 [float]
 === Module-Specific Configuration Notes

--- a/metricbeat/docs/modules/system.asciidoc
+++ b/metricbeat/docs/modules/system.asciidoc
@@ -49,9 +49,6 @@ metricbeat.modules:
   cpu_ticks: true
 ----
 
-It is strongly recommended to not run docker metricsets with a period smaller then 3 seconds. The request to the docker
-API already takes up to 2s seconds. Otherwise all the requests would timeout and no data is reported.
-
 [float]
 === Dashboard
 

--- a/metricbeat/docs/reference/configuration/metricbeat-options.asciidoc
+++ b/metricbeat/docs/reference/configuration/metricbeat-options.asciidoc
@@ -44,6 +44,7 @@ A Boolean value that specifies whether the module is enabled. If you use the def
 the System module is enabled (set to `enabled: true`) by default. If the `enabled` option is missing from the
 configuration block, the module is enabled by default.
 
+[[metricset-period]]
 ===== period
 
 How often the metricsets are executed. If a system is not reachable, Metricbeat returns an error for each period. This setting is required.

--- a/metricbeat/module/docker/_meta/docs.asciidoc
+++ b/metricbeat/module/docker/_meta/docs.asciidoc
@@ -4,3 +4,13 @@ beta[]
 
 This module fetches metrics from https://www.docker.com/[Docker] containers.
 
+The docker module is currently not tested on Windows.
+
+[float]
+=== Module-Specific Configuration Notes
+
+It is strongly recommended that you run Docker metricsets with a
+<<metricset-period,`period`>> that is 3 seconds or longer. The request to the
+Docker API already takes up to 2 seconds. Specifying less than 3 seconds will
+result in requests that timeout, and no data will be reported for those
+requests.

--- a/metricbeat/module/system/_meta/docs.asciidoc
+++ b/metricbeat/module/system/_meta/docs.asciidoc
@@ -44,9 +44,6 @@ metricbeat.modules:
   cpu_ticks: true
 ----
 
-It is strongly recommended to not run docker metricsets with a period smaller then 3 seconds. The request to the docker
-API already takes up to 2s seconds. Otherwise all the requests would timeout and no data is reported.
-
 [float]
 === Dashboard
 

--- a/packetbeat/docs/gettingstarted.asciidoc
+++ b/packetbeat/docs/gettingstarted.asciidoc
@@ -119,7 +119,7 @@ https://www.elastic.co/downloads/beats/packetbeat[downloads page].
 
 . Open a PowerShell prompt as an Administrator (right-click the PowerShell icon and select *Run As Administrator*). If you are running Windows XP, you may need to download and install PowerShell.
 
-. Run the following commands to install Packetbeat as a Windows service:
+. From the PowerShell prompt, run the following commands to install Packetbeat as a Windows service:
 +
 [source,shell]
 ----------------------------------------------------------------------

--- a/winlogbeat/docs/getting-started.asciidoc
+++ b/winlogbeat/docs/getting-started.asciidoc
@@ -32,7 +32,7 @@ https://www.elastic.co/downloads/beats/winlogbeat[downloads page].
 . Open a PowerShell prompt as an Administrator (right-click on the PowerShell
 icon and select Run As Administrator). If you are running Windows XP, you may
 need to download and install PowerShell.
-. Run the following commands to install the service.
+. From the PowerShell prompt, run the following commands to install the service.
 
 ["source","sh",subs="attributes,callouts"]
 ------------------------------------------------


### PR DESCRIPTION
Cherry-picks #4147 and #4135 into 5.4.

@ruflin The changes that you made in #3559 never got into the 5.4 branch for some reason, but I saw them when I resolved a merge conflict. Let me know if this statement is no longer true, and I will remove it: "The docker module is currently not tested on Windows." Otherwise, I'll leave it in.

Please feel free to merge this if it looks OK.