### PR TITLE
Add additional mysql slow log to system tests

### DIFF
--- a/filebeat/module/mysql/slowlog/test/mysql-debian-5.7.17.log
+++ b/filebeat/module/mysql/slowlog/test/mysql-debian-5.7.17.log
@@ -1,0 +1,25 @@
+# Time: 2017-04-28T09:07:39.777791Z
+# User@Host: apphost[apphost] @ apphost [ip]  Id: 10997316
+# Query_time: 4.071491  Lock_time: 0.000212 Rows_sent: 1000  Rows_examined: 1489615
+SET timestamp=1493370459;
+SELECT mcu.mcu_guid, mcu.cus_guid, mcu.mcu_url, mcu.mcu_crawlelements, mcu.mcu_order, GROUP_CONCAT(mca.mca_guid SEPARATOR ";") as mca_guid
+                    FROM kat_mailcustomerurl mcu, kat_customer cus, kat_mailcampaign mca
+                    WHERE cus.cus_guid = mcu.cus_guid
+                        AND cus.pro_code = 'CYB'
+                        AND cus.cus_offline = 0
+                        AND mca.cus_guid = cus.cus_guid
+                        AND (mcu.mcu_date IS NULL OR mcu.mcu_date < CURDATE())
+                        AND mcu.mcu_crawlelements IS NOT NULL
+                    GROUP BY mcu.mcu_guid
+                    ORDER BY mcu.mcu_order ASC
+                    LIMIT 1000;
+# Time: 2017-04-28T09:16:30.738365Z
+# User@Host: apphost[apphost] @ apphost [ip]  Id: 10999834
+# Query_time: 10.346539  Lock_time: 0.000036 Rows_sent: 0  Rows_examined: 4751313
+SET timestamp=1493370990;
+call load_stats(1, '2017-04-28 00:00:00');
+# Time: 2017-04-28T09:31:31.133657Z
+# User@Host: apphost[apphost] @ apphost [ip]  Id: 11004208
+# Query_time: 10.508030  Lock_time: 0.000034 Rows_sent: 0  Rows_examined: 4754675
+SET timestamp=1493371891;
+call load_stats(1, '2017-04-28 00:00:00');

--- a/filebeat/tests/system/test_modules.py
+++ b/filebeat/tests/system/test_modules.py
@@ -30,6 +30,9 @@ class Test(BaseTest):
                      os.getenv("TESTING_ENVIRONMENT") == "2x",
                      "integration test not available on 2.x")
     def test_modules(self):
+        """
+        Tests all filebeat modules
+        """
         self.init()
         modules = os.getenv("TESTING_FILEBEAT_MODULES")
         if modules:
@@ -80,7 +83,12 @@ class Test(BaseTest):
                 module=module, fileset=fileset, test_file=test_file),
             "-M", "*.*.prospector.close_eof=true",
         ]
-        output = open(os.path.join(self.working_dir, "output.log"), "ab")
+
+        output_path = os.path.join(self.working_dir, module, fileset, os.path.basename(test_file))
+        if not os.path.exists(output_path):
+            os.makedirs(output_path)
+
+        output = open(os.path.join(output_path, "output.log"), "ab")
         output.write(" ".join(cmd) + "\n")
         subprocess.Popen(cmd,
                          stdin=None,


### PR DESCRIPTION
* Change tests to output one log file for each tests. This makes debugging tests easier as not only the most recent log files is available
* Add test description

See https://discuss.elastic.co/t/mysql-slow-query-parsing-error/83726