### PR TITLE
Remove duplicate error key in fields.yml

### DIFF
--- a/filebeat/_meta/fields.common.yml
+++ b/filebeat/_meta/fields.common.yml
@@ -33,11 +33,6 @@
       description: >
         The input type from which the event was generated. This field is set to the value specified for the `input_type` option in the prospector section of the Filebeat config file.
 
-    - name: error
-      description: >
-        Ingestion pipeline error message, added in case there are errors reported by
-        the Ingest Node in Elasticsearch.
-
     - name: read_timestamp
       description: >
         In case the ingest pipeline parses the timestamp from the log contents, it stores

--- a/filebeat/docs/fields.asciidoc
+++ b/filebeat/docs/fields.asciidoc
@@ -784,12 +784,6 @@ The input type from which the event was generated. This field is set to the valu
 
 
 [float]
-=== error
-
-Ingestion pipeline error message, added in case there are errors reported by the Ingest Node in Elasticsearch.
-
-
-[float]
 === read_timestamp
 
 In case the ingest pipeline parses the timestamp from the log contents, it stores the original `@timestamp` (representing the time when the log line was read) in this field.


### PR DESCRIPTION
`error` is now an object, but the old `error` key definition was still in `fields.yml`. This
led to some weird behaviours on objects having an error key.