### PR TITLE
Add type to state info

### DIFF
--- a/filebeat/input/file/state.go
+++ b/filebeat/input/file/state.go
@@ -10,17 +10,18 @@ import (
 
 // State is used to communicate the reading state of a file
 type State struct {
-	Source      string      `json:"source"`
-	Offset      int64       `json:"offset"`
-	Finished    bool        `json:"-"` // harvester state
-	Fileinfo    os.FileInfo `json:"-"` // the file info
-	FileStateOS StateOS
+	Finished    bool          `json:"-"` // harvester state
+	Fileinfo    os.FileInfo   `json:"-"` // the file info
+	Source      string        `json:"source"`
+	Offset      int64         `json:"offset"`
 	Timestamp   time.Time     `json:"timestamp"`
 	TTL         time.Duration `json:"ttl"`
+	Type        string        `json:"type"`
+	FileStateOS StateOS
 }
 
 // NewState creates a new file state
-func NewState(fileInfo os.FileInfo, path string) State {
+func NewState(fileInfo os.FileInfo, path string, t string) State {
 	return State{
 		Fileinfo:    fileInfo,
 		Source:      path,
@@ -28,6 +29,7 @@ func NewState(fileInfo os.FileInfo, path string) State {
 		FileStateOS: GetOSState(fileInfo),
 		Timestamp:   time.Now(),
 		TTL:         -1, // By default, state does have an infinite ttl
+		Type:        t,
 	}
 }
 

--- a/filebeat/prospector/prospector_log.go
+++ b/filebeat/prospector/prospector_log.go
@@ -111,7 +111,7 @@ func (l *Log) Run() {
 				}
 			} else {
 				// Check if existing source on disk and state are the same. Remove if not the case.
-				newState := file.NewState(stat, state.Source)
+				newState := file.NewState(stat, state.Source, l.config.InputType)
 				if !newState.FileStateOS.IsSame(state.FileStateOS) {
 					l.removeState(state)
 					logp.Debug("prospector", "Remove state for file as file removed or renamed: %s", state.Source)
@@ -253,7 +253,7 @@ func (l *Log) scan() {
 		logp.Debug("prospector", "Check file for harvesting: %s", path)
 
 		// Create new state for comparison
-		newState := file.NewState(info, path)
+		newState := file.NewState(info, path, l.config.InputType)
 
 		// Load last state
 		lastState := l.Prospector.states.FindPrevious(newState)


### PR DESCRIPTION
With the introduction of new prospector types each prospector can have different state information. To differentiate between the different states for the prospector the `type` was added to each registry state.