### PR TITLE
Assert on errors in the filebeat modules

### DIFF
--- a/filebeat/module/mysql/slowlog/config/slowlog.yml
+++ b/filebeat/module/mysql/slowlog/config/slowlog.yml
@@ -3,8 +3,9 @@ paths:
 {{ range $i, $path := .paths }}
  - {{$path}}
 {{ end }}
-exclude_files: [".gz$"]
+exclude_files: ['.gz$']
 multiline:
-  pattern: "^# User@Host: "
+  pattern: '^# User@Host: '
   negate: true
   match: after
+exclude_lines: ['^[\/\w\.]+, Version: .* started with:.*']   # Exclude the header

--- a/filebeat/module/mysql/slowlog/test/mysql-debian-5.7.17.log
+++ b/filebeat/module/mysql/slowlog/test/mysql-debian-5.7.17.log
@@ -1,5 +1,4 @@
-# Time: 2017-04-28T09:07:39.777791Z
-# User@Host: apphost[apphost] @ apphost [ip]  Id: 10997316
+# User@Host: apphost[apphost] @ apphost [1.1.1.1]  Id: 10997316
 # Query_time: 4.071491  Lock_time: 0.000212 Rows_sent: 1000  Rows_examined: 1489615
 SET timestamp=1493370459;
 SELECT mcu.mcu_guid, mcu.cus_guid, mcu.mcu_url, mcu.mcu_crawlelements, mcu.mcu_order, GROUP_CONCAT(mca.mca_guid SEPARATOR ";") as mca_guid
@@ -14,12 +13,12 @@ SELECT mcu.mcu_guid, mcu.cus_guid, mcu.mcu_url, mcu.mcu_crawlelements, mcu.mcu_o
                     ORDER BY mcu.mcu_order ASC
                     LIMIT 1000;
 # Time: 2017-04-28T09:16:30.738365Z
-# User@Host: apphost[apphost] @ apphost [ip]  Id: 10999834
+# User@Host: apphost[apphost] @ apphost [1.1.1.1]  Id: 10999834
 # Query_time: 10.346539  Lock_time: 0.000036 Rows_sent: 0  Rows_examined: 4751313
 SET timestamp=1493370990;
 call load_stats(1, '2017-04-28 00:00:00');
 # Time: 2017-04-28T09:31:31.133657Z
-# User@Host: apphost[apphost] @ apphost [ip]  Id: 11004208
+# User@Host: apphost[apphost] @ apphost [1.1.1.1]  Id: 11004208
 # Query_time: 10.508030  Lock_time: 0.000034 Rows_sent: 0  Rows_examined: 4754675
 SET timestamp=1493371891;
 call load_stats(1, '2017-04-28 00:00:00');

--- a/filebeat/tests/system/test_modules.py
+++ b/filebeat/tests/system/test_modules.py
@@ -108,9 +108,7 @@ class Test(BaseTest):
             assert obj["fileset"]["module"] == module, "expected fileset.module={} but got {}".format(
                 module, obj["fileset"]["module"])
 
-            if not (module == "mysql" and fileset == "slowlog") and not (module == "system" and fileset == "auth"):
-                # TODO: There are errors parsing the test logs from these modules.
-                assert "error" not in obj
+            assert "error" not in obj
 
             if module != "auditd" and fileset != "log":
                 # There are dynamic fields in audit logs that are not documented.


### PR DESCRIPTION
We used to whitelist the mysql/slowlog and system/auth fileset when
checking if there were any errors while parsing. This removes all whitelisted
entries and always fails if there are error keys generated.

The mysql module was whitelisted because Mysql writes a header that doesn't match
the patterns. I solved this by excluding the header via the Filebeat config.

The auth fileset was already fixed to not generate errors, at least for the current
test set.