### PR TITLE
Make state comparison more generic

### DIFF
--- a/filebeat/input/file/file_other.go
+++ b/filebeat/input/file/file_other.go
@@ -3,6 +3,7 @@
 package file
 
 import (
+	"fmt"
 	"os"
 	"syscall"
 
@@ -31,6 +32,10 @@ func GetOSState(info os.FileInfo) StateOS {
 // IsSame file checks if the files are identical
 func (fs StateOS) IsSame(state StateOS) bool {
 	return fs.Inode == state.Inode && fs.Device == state.Device
+}
+
+func (fs StateOS) String() string {
+	return fmt.Sprintf("%d-%d", fs.Inode, fs.Device)
 }
 
 // SafeFileRotate safely rotates an existing file under path and replaces it with the tempfile

--- a/filebeat/input/file/file_windows.go
+++ b/filebeat/input/file/file_windows.go
@@ -45,6 +45,10 @@ func (fs StateOS) IsSame(state StateOS) bool {
 	return fs.IdxHi == state.IdxHi && fs.IdxLo == state.IdxLo && fs.Vol == state.Vol
 }
 
+func (fs StateOS) String() string {
+	return fmt.Sprintf("%d-%d-%d", fs.IdxHi, fs.IdxLo, fs.Vol)
+}
+
 // SafeFileRotate safely rotates an existing file under path and replaces it with the tempfile
 func SafeFileRotate(path, tempfile string) error {
 	old := path + ".old"

--- a/filebeat/input/file/state.go
+++ b/filebeat/input/file/state.go
@@ -1,7 +1,6 @@
 package file
 
 import (
-	"fmt"
 	"os"
 	"sync"
 	"time"
@@ -11,6 +10,7 @@ import (
 
 // State is used to communicate the reading state of a file
 type State struct {
+	Id          string        `json:"-"` // local unique id to make comparison more efficient
 	Finished    bool          `json:"-"` // harvester state
 	Fileinfo    os.FileInfo   `json:"-"` // the file info
 	Source      string        `json:"source"`
@@ -34,14 +34,18 @@ func NewState(fileInfo os.FileInfo, path string, t string) State {
 	}
 }
 
-// String returns a unique id for the state as a string
-func (s *State) String() string {
-	return s.FileStateOS.String()
+// ID returns a unique id for the state as a string
+func (s *State) ID() string {
+	// Generate id on first request. This is needed as id is not set when converting back from json
+	if s.Id == "" {
+		s.Id = s.FileStateOS.String()
+	}
+	return s.Id
 }
 
 // IsEqual compares the state to an other state supporing stringer based on the unique string
-func (s *State) IsEqual(c fmt.Stringer) bool {
-	return s.String() == c.String()
+func (s *State) IsEqual(c *State) bool {
+	return s.ID() == c.ID()
 }
 
 // IsEmpty returns true if the state is empty

--- a/filebeat/input/file/state.go
+++ b/filebeat/input/file/state.go
@@ -1,6 +1,7 @@
 package file
 
 import (
+	"fmt"
 	"os"
 	"sync"
 	"time"
@@ -31,6 +32,16 @@ func NewState(fileInfo os.FileInfo, path string, t string) State {
 		TTL:         -1, // By default, state does have an infinite ttl
 		Type:        t,
 	}
+}
+
+// String returns a unique id for the state as a string
+func (s *State) String() string {
+	return s.FileStateOS.String()
+}
+
+// IsEqual compares the state to an other state supporing stringer based on the unique string
+func (s *State) IsEqual(c fmt.Stringer) bool {
+	return s.String() == c.String()
 }
 
 // IsEmpty returns true if the state is empty
@@ -81,7 +92,7 @@ func (s *States) findPrevious(newState State) (int, State) {
 	// TODO: This could be made potentially more performance by using an index (harvester id) and only use iteration as fall back
 	for index, oldState := range s.states {
 		// This is using the FileStateOS for comparison as FileInfo identifiers can only be fetched for existing files
-		if oldState.FileStateOS.IsSame(newState.FileStateOS) {
+		if oldState.IsEqual(&newState) {
 			return index, oldState
 		}
 	}

--- a/filebeat/prospector/log/prospector_other_test.go
+++ b/filebeat/prospector/log/prospector_other_test.go
@@ -93,35 +93,35 @@ var initStateTests = []struct {
 	},
 	{
 		[]file.State{
-			{Source: "test1.log", FileStateOS: file.StateOS{Inode: 1}},
-			{Source: "test2.log", FileStateOS: file.StateOS{Inode: 2}},
+			{Source: "test1.log", Id: "1"},
+			{Source: "test2.log", Id: "2"},
 		},
 		[]string{"*.log"},
 		2,
 	},
 	{
 		[]file.State{
-			{Source: "test1.log", FileStateOS: file.StateOS{Inode: 1}},
-			{Source: "test2.log", FileStateOS: file.StateOS{Inode: 2}},
+			{Source: "test1.log", Id: "1"},
+			{Source: "test2.log", Id: "2"},
 		},
 		[]string{"test1.log"},
 		1,
 	},
 	{
 		[]file.State{
-			{Source: "test1.log", FileStateOS: file.StateOS{Inode: 1}},
-			{Source: "test2.log", FileStateOS: file.StateOS{Inode: 2}},
+			{Source: "test1.log", Id: "1"},
+			{Source: "test2.log", Id: "2"},
 		},
 		[]string{"test.log"},
 		0,
 	},
 	{
 		[]file.State{
-			{Source: "test1.log", FileStateOS: file.StateOS{Inode: 1}},
-			{Source: "test2.log", FileStateOS: file.StateOS{Inode: 1}},
+			{Source: "test1.log", Id: "1"},
+			{Source: "test2.log", Id: "1"},
 		},
 		[]string{"*.log"},
-		1, // Expecting only 1 state because of some inode (this is only a theoretical case)
+		1, // Expecting only 1 state because of same inode (this is only a theoretical case)
 	},
 }
 


### PR DESCRIPTION
For the state comparison FileStateOS was accessed directly. By having new prospector types there might be different state objects. This is a first step to remove the dependency on FileStateOS and do state comparison string based.