### PR TITLE
Change release state to released

### DIFF
--- a/libbeat/docs/version.asciidoc
+++ b/libbeat/docs/version.asciidoc
@@ -1,4 +1,4 @@
 :stack-version: 5.4.0
 :doc-branch: 5.4
 :go-version: 1.7.4
-:release-state: unreleased
+:release-state: released


### PR DESCRIPTION
Changes the release state to "released" for 5.4 (required for the installation instructions to show in the docs).