### PR TITLE
Switch to fully static compilation for the Beats requiring CGO

### DIFF
--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -411,6 +411,7 @@ prepare-package-cgo:
 		-e BEFORE_BUILD=before_build.sh \
 		-e SOURCE=/source \
 		-e TARGETS=${TARGETS_OLD} \
+		-e STATIC=true \
 		-e BUILDID=${BUILDID} \
 		-e ES_BEATS=${ES_BEATS} \
 		-e BEAT_PATH=${BEAT_PATH} \


### PR DESCRIPTION
This affects Metricbeat & Packetbeat. Should fix #4147.

Testing so far didn't reveal any side effects. DNS resolving seems to work
as expected.