### PR TITLE
Use gopsutil library for getting memory and swap stats

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -90,6 +90,7 @@ https://github.com/elastic/beats/compare/v5.1.1...master[Check the HEAD diff]
 - Fix MongoDB dbstats fields mapping. {pull}4025[4025]
 - Fixing prometheus collector to aggregate metrics based on metric family. {pull}4075[4075]
 - Fixing multiEventFetch error reporting when no events are returned {pull}4153[4153]
+- Use gopsutil library for getting memory and swap information {pull}4206[4206]
 
 *Packetbeat*
 

--- a/metricbeat/docs/fields.asciidoc
+++ b/metricbeat/docs/fields.asciidoc
@@ -7763,7 +7763,7 @@ type: long
 
 format: bytes
 
-Actual free memory in bytes. It is calculated based on the OS. On Linux it consists of the free memory plus caches and buffers. On OSX it is a sum of free memory and the inactive memory. On Windows, it is equal to `system.memory.free`.
+Available memory in bytes. It is calculated based on the OS. On Linux kernel 3.14+, it has the MemAvailable value, and on older Linux kernel versions, it consists of the free memory plus caches and buffers. On OSX it is a sum of free memory and the inactive memory. On Windows, it is equal to `system.memory.free`.
 
 
 [float]

--- a/metricbeat/module/system/memory/_meta/fields.yml
+++ b/metricbeat/module/system/memory/_meta/fields.yml
@@ -45,7 +45,8 @@
           type: long
           format: bytes
           description: >
-            Actual free memory in bytes. It is calculated based on the OS. On Linux it consists of the free memory
+            Available memory in bytes. It is calculated based on the OS. On Linux kernel 3.14+, it has the
+            MemAvailable value, and on older Linux kernel versions, it consists of the free memory
             plus caches and buffers. On OSX it is a sum of free memory and the inactive memory. On Windows, it is equal
             to `system.memory.free`.
 

--- a/metricbeat/module/system/memory/helper.go
+++ b/metricbeat/module/system/memory/helper.go
@@ -2,85 +2,14 @@
 
 package memory
 
-import (
-	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/metricbeat/module/system"
-	sigar "github.com/elastic/gosigar"
-)
+import "github.com/elastic/beats/metricbeat/module/system"
 
-type MemStat struct {
-	sigar.Mem
-	UsedPercent       float64 `json:"used_p"`
-	ActualUsedPercent float64 `json:"actual_used_p"`
-}
+func GetPercentage(t1 uint64, t2 uint64) float64 {
 
-func GetMemory() (*MemStat, error) {
-
-	mem := sigar.Mem{}
-	err := mem.Get()
-	if err != nil {
-		return nil, err
+	if t2 == 0 {
+		return 0.0
 	}
 
-	return &MemStat{Mem: mem}, nil
-}
-
-func AddMemPercentage(m *MemStat) {
-
-	if m.Mem.Total == 0 {
-		return
-	}
-
-	perc := float64(m.Mem.Used) / float64(m.Mem.Total)
-	m.UsedPercent = system.Round(perc, .5, 4)
-
-	actualPerc := float64(m.Mem.ActualUsed) / float64(m.Mem.Total)
-	m.ActualUsedPercent = system.Round(actualPerc, .5, 4)
-}
-
-type SwapStat struct {
-	sigar.Swap
-	UsedPercent float64 `json:"used_p"`
-}
-
-func GetSwap() (*SwapStat, error) {
-
-	swap := sigar.Swap{}
-	err := swap.Get()
-	if err != nil {
-		return nil, err
-	}
-
-	return &SwapStat{Swap: swap}, nil
-
-}
-
-func GetMemoryEvent(memStat *MemStat) common.MapStr {
-	return common.MapStr{
-		"total":         memStat.Total,
-		"used":          memStat.Used,
-		"free":          memStat.Free,
-		"actual_used":   memStat.ActualUsed,
-		"actual_free":   memStat.ActualFree,
-		"used_p":        memStat.UsedPercent,
-		"actual_used_p": memStat.ActualUsedPercent,
-	}
-}
-
-func GetSwapEvent(swapStat *SwapStat) common.MapStr {
-	return common.MapStr{
-		"total":  swapStat.Total,
-		"used":   swapStat.Used,
-		"free":   swapStat.Free,
-		"used_p": swapStat.UsedPercent,
-	}
-}
-
-func AddSwapPercentage(s *SwapStat) {
-	if s.Swap.Total == 0 {
-		return
-	}
-
-	perc := float64(s.Swap.Used) / float64(s.Swap.Total)
-	s.UsedPercent = system.Round(perc, .5, 4)
+	perc := float64(t1) / float64(t2)
+	return system.Round(perc, .5, 4)
 }

--- a/metricbeat/module/system/memory/helper_test.go
+++ b/metricbeat/module/system/memory/helper_test.go
@@ -7,30 +7,29 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/elastic/gosigar"
+	"github.com/shirou/gopsutil/mem"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestGetMemory(t *testing.T) {
-	mem, err := GetMemory()
+	stat, err := mem.VirtualMemory()
 
-	assert.NotNil(t, mem)
+	assert.NotNil(t, stat)
 	assert.Nil(t, err)
 
-	assert.True(t, (mem.Total > 0))
-	assert.True(t, (mem.Used > 0))
-	assert.True(t, (mem.Free >= 0))
-	assert.True(t, (mem.ActualFree >= 0))
-	assert.True(t, (mem.ActualUsed > 0))
+	assert.True(t, (stat.Total > 0))
+	assert.True(t, (stat.Used > 0))
+	assert.True(t, (stat.Free >= 0))
+	assert.True(t, (stat.Available >= 0))
 }
 
 func TestGetSwap(t *testing.T) {
 
 	if runtime.GOOS == "windows" {
-		return //no load data on windows
+		return //no swap data on windows
 	}
 
-	swap, err := GetSwap()
+	swap, err := mem.SwapMemory()
 
 	assert.NotNil(t, swap)
 	assert.Nil(t, err)
@@ -40,42 +39,8 @@ func TestGetSwap(t *testing.T) {
 	assert.True(t, (swap.Free >= 0))
 }
 
-func TestMemPercentage(t *testing.T) {
+func TestGetPercentage(t *testing.T) {
 
-	m := MemStat{
-		Mem: gosigar.Mem{
-			Total: 7,
-			Used:  5,
-			Free:  2,
-		},
-	}
-	AddMemPercentage(&m)
-	assert.Equal(t, m.UsedPercent, 0.7143)
-
-	m = MemStat{
-		Mem: gosigar.Mem{Total: 0},
-	}
-	AddMemPercentage(&m)
-	assert.Equal(t, m.UsedPercent, 0.0)
-}
-
-func TestActualMemPercentage(t *testing.T) {
-
-	m := MemStat{
-		Mem: gosigar.Mem{
-			Total:      7,
-			ActualUsed: 5,
-			ActualFree: 2,
-		},
-	}
-	AddMemPercentage(&m)
-	assert.Equal(t, m.ActualUsedPercent, 0.7143)
-
-	m = MemStat{
-		Mem: gosigar.Mem{
-			Total: 0,
-		},
-	}
-	AddMemPercentage(&m)
-	assert.Equal(t, m.ActualUsedPercent, 0.0)
+	assert.Equal(t, GetPercentage(5, 7), 0.7143)
+	assert.Equal(t, GetPercentage(5, 0), 0.0)
 }

--- a/metricbeat/module/system/process/helper.go
+++ b/metricbeat/module/system/process/helper.go
@@ -14,8 +14,8 @@ import (
 	"github.com/elastic/beats/libbeat/common/match"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/metricbeat/module/system"
-	"github.com/elastic/beats/metricbeat/module/system/memory"
 	sigar "github.com/elastic/gosigar"
+	"github.com/shirou/gopsutil/mem"
 )
 
 type ProcsMap map[int]*Process
@@ -179,12 +179,12 @@ func GetProcMemPercentage(proc *Process, totalPhyMem uint64) float64 {
 
 	// in unit tests, total_phymem is set to a value greater than zero
 	if totalPhyMem == 0 {
-		memStat, err := memory.GetMemory()
+		memStat, err := mem.VirtualMemory()
 		if err != nil {
 			logp.Warn("Getting memory details: %v", err)
 			return 0
 		}
-		totalPhyMem = memStat.Mem.Total
+		totalPhyMem = memStat.Total
 	}
 
 	perc := (float64(proc.Mem.Resident) / float64(totalPhyMem))

--- a/vendor/github.com/shirou/gopsutil/mem/mem.go
+++ b/vendor/github.com/shirou/gopsutil/mem/mem.go
@@ -1,0 +1,80 @@
+package mem
+
+import (
+	"encoding/json"
+
+	"github.com/shirou/gopsutil/internal/common"
+)
+
+var invoke common.Invoker
+
+func init() {
+	invoke = common.Invoke{}
+}
+
+// Memory usage statistics. Total, Available and Used contain numbers of bytes
+// for human consumption.
+//
+// The other fields in this struct contain kernel specific values.
+type VirtualMemoryStat struct {
+	// Total amount of RAM on this system
+	Total uint64 `json:"total"`
+
+	// RAM available for programs to allocate
+	//
+	// This value is computed from the kernel specific values.
+	Available uint64 `json:"available"`
+
+	// RAM used by programs
+	//
+	// This value is computed from the kernel specific values.
+	Used uint64 `json:"used"`
+
+	// Percentage of RAM used by programs
+	//
+	// This value is computed from the kernel specific values.
+	UsedPercent float64 `json:"usedPercent"`
+
+	// This is the kernel's notion of free memory; RAM chips whose bits nobody
+	// cares about the value of right now. For a human consumable number,
+	// Available is what you really want.
+	Free uint64 `json:"free"`
+
+	// OS X / BSD specific numbers:
+	// http://www.macyourself.com/2010/02/17/what-is-free-wired-active-and-inactive-system-memory-ram/
+	Active   uint64 `json:"active"`
+	Inactive uint64 `json:"inactive"`
+	Wired    uint64 `json:"wired"`
+
+	// Linux specific numbers
+	// https://www.centos.org/docs/5/html/5.1/Deployment_Guide/s2-proc-meminfo.html
+	// https://www.kernel.org/doc/Documentation/filesystems/proc.txt
+	Buffers      uint64 `json:"buffers"`
+	Cached       uint64 `json:"cached"`
+	Writeback    uint64 `json:"writeback"`
+	Dirty        uint64 `json:"dirty"`
+	WritebackTmp uint64 `json:"writebacktmp"`
+	Shared       uint64 `json:"shared"`
+	Slab         uint64 `json:"slab"`
+	PageTables   uint64 `json:"pagetables"`
+	SwapCached   uint64 `json:"swapcached"`
+}
+
+type SwapMemoryStat struct {
+	Total       uint64  `json:"total"`
+	Used        uint64  `json:"used"`
+	Free        uint64  `json:"free"`
+	UsedPercent float64 `json:"usedPercent"`
+	Sin         uint64  `json:"sin"`
+	Sout        uint64  `json:"sout"`
+}
+
+func (m VirtualMemoryStat) String() string {
+	s, _ := json.Marshal(m)
+	return string(s)
+}
+
+func (m SwapMemoryStat) String() string {
+	s, _ := json.Marshal(m)
+	return string(s)
+}

--- a/vendor/github.com/shirou/gopsutil/mem/mem_darwin.go
+++ b/vendor/github.com/shirou/gopsutil/mem/mem_darwin.go
@@ -1,0 +1,69 @@
+// +build darwin
+
+package mem
+
+import (
+	"encoding/binary"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"github.com/shirou/gopsutil/internal/common"
+)
+
+func getHwMemsize() (uint64, error) {
+	totalString, err := syscall.Sysctl("hw.memsize")
+	if err != nil {
+		return 0, err
+	}
+
+	// syscall.sysctl() helpfully assumes the result is a null-terminated string and
+	// removes the last byte of the result if it's 0 :/
+	totalString += "\x00"
+
+	total := uint64(binary.LittleEndian.Uint64([]byte(totalString)))
+
+	return total, nil
+}
+
+// SwapMemory returns swapinfo.
+func SwapMemory() (*SwapMemoryStat, error) {
+	var ret *SwapMemoryStat
+
+	swapUsage, err := common.DoSysctrl("vm.swapusage")
+	if err != nil {
+		return ret, err
+	}
+
+	total := strings.Replace(swapUsage[2], "M", "", 1)
+	used := strings.Replace(swapUsage[5], "M", "", 1)
+	free := strings.Replace(swapUsage[8], "M", "", 1)
+
+	total_v, err := strconv.ParseFloat(total, 64)
+	if err != nil {
+		return nil, err
+	}
+	used_v, err := strconv.ParseFloat(used, 64)
+	if err != nil {
+		return nil, err
+	}
+	free_v, err := strconv.ParseFloat(free, 64)
+	if err != nil {
+		return nil, err
+	}
+
+	u := float64(0)
+	if total_v != 0 {
+		u = ((total_v - free_v) / total_v) * 100.0
+	}
+
+	// vm.swapusage shows "M", multiply 1024 * 1024 to convert bytes.
+	ret = &SwapMemoryStat{
+		Total:       uint64(total_v * 1024 * 1024),
+		Used:        uint64(used_v * 1024 * 1024),
+		Free:        uint64(free_v * 1024 * 1024),
+		UsedPercent: u,
+	}
+
+	return ret, nil
+}

--- a/vendor/github.com/shirou/gopsutil/mem/mem_darwin_cgo.go
+++ b/vendor/github.com/shirou/gopsutil/mem/mem_darwin_cgo.go
@@ -1,0 +1,53 @@
+// +build darwin
+// +build cgo
+
+package mem
+
+/*
+#include <mach/mach_host.h>
+*/
+import "C"
+
+import (
+	"fmt"
+	"syscall"
+	"unsafe"
+)
+
+// VirtualMemory returns VirtualmemoryStat.
+func VirtualMemory() (*VirtualMemoryStat, error) {
+	count := C.mach_msg_type_number_t(C.HOST_VM_INFO_COUNT)
+	var vmstat C.vm_statistics_data_t
+
+	status := C.host_statistics(C.host_t(C.mach_host_self()),
+		C.HOST_VM_INFO,
+		C.host_info_t(unsafe.Pointer(&vmstat)),
+		&count)
+
+	if status != C.KERN_SUCCESS {
+		return nil, fmt.Errorf("host_statistics error=%d", status)
+	}
+
+	pageSize := uint64(syscall.Getpagesize())
+	total, err := getHwMemsize()
+	if err != nil {
+		return nil, err
+	}
+	totalCount := C.natural_t(total / pageSize)
+
+	availableCount := vmstat.inactive_count + vmstat.free_count
+	usedPercent := 100 * float64(totalCount-availableCount) / float64(totalCount)
+
+	usedCount := totalCount - availableCount
+
+	return &VirtualMemoryStat{
+		Total:       total,
+		Available:   pageSize * uint64(availableCount),
+		Used:        pageSize * uint64(usedCount),
+		UsedPercent: usedPercent,
+		Free:        pageSize * uint64(vmstat.free_count),
+		Active:      pageSize * uint64(vmstat.active_count),
+		Inactive:    pageSize * uint64(vmstat.inactive_count),
+		Wired:       pageSize * uint64(vmstat.wire_count),
+	}, nil
+}

--- a/vendor/github.com/shirou/gopsutil/mem/mem_darwin_nocgo.go
+++ b/vendor/github.com/shirou/gopsutil/mem/mem_darwin_nocgo.go
@@ -1,0 +1,88 @@
+// +build darwin
+// +build !cgo
+
+package mem
+
+import (
+	"os/exec"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+// Runs vm_stat and returns Free and inactive pages
+func getVMStat(vms *VirtualMemoryStat) error {
+	vm_stat, err := exec.LookPath("vm_stat")
+	if err != nil {
+		return err
+	}
+	out, err := invoke.Command(vm_stat)
+	if err != nil {
+		return err
+	}
+	return parseVMStat(string(out), vms)
+}
+
+func parseVMStat(out string, vms *VirtualMemoryStat) error {
+	var err error
+
+	lines := strings.Split(out, "\n")
+	pagesize := uint64(syscall.Getpagesize())
+	for _, line := range lines {
+		fields := strings.Split(line, ":")
+		if len(fields) < 2 {
+			continue
+		}
+		key := strings.TrimSpace(fields[0])
+		value := strings.Trim(fields[1], " .")
+		switch key {
+		case "Pages free":
+			free, e := strconv.ParseUint(value, 10, 64)
+			if e != nil {
+				err = e
+			}
+			vms.Free = free * pagesize
+		case "Pages inactive":
+			inactive, e := strconv.ParseUint(value, 10, 64)
+			if e != nil {
+				err = e
+			}
+			vms.Inactive = inactive * pagesize
+		case "Pages active":
+			active, e := strconv.ParseUint(value, 10, 64)
+			if e != nil {
+				err = e
+			}
+			vms.Active = active * pagesize
+		case "Pages wired down":
+			wired, e := strconv.ParseUint(value, 10, 64)
+			if e != nil {
+				err = e
+			}
+			vms.Wired = wired * pagesize
+		}
+	}
+	return err
+}
+
+// VirtualMemory returns VirtualmemoryStat.
+func VirtualMemory() (*VirtualMemoryStat, error) {
+	ret := &VirtualMemoryStat{}
+
+	total, err := getHwMemsize()
+	if err != nil {
+		return nil, err
+	}
+	err = getVMStat(ret)
+	if err != nil {
+		return nil, err
+	}
+
+	ret.Available = ret.Free + ret.Inactive
+	ret.Total = total
+
+	ret.Used = ret.Total - ret.Available
+	ret.UsedPercent = 100 * float64(ret.Used) / float64(ret.Total)
+
+	return ret, nil
+}

--- a/vendor/github.com/shirou/gopsutil/mem/mem_darwin_test.go
+++ b/vendor/github.com/shirou/gopsutil/mem/mem_darwin_test.go
@@ -1,0 +1,46 @@
+// +build darwin
+
+package mem
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVirtualMemoryDarwin(t *testing.T) {
+	v, err := VirtualMemory()
+	assert.Nil(t, err)
+
+	outBytes, err := invoke.Command("/usr/sbin/sysctl", "hw.memsize")
+	assert.Nil(t, err)
+	outString := string(outBytes)
+	outString = strings.TrimSpace(outString)
+	outParts := strings.Split(outString, " ")
+	actualTotal, err := strconv.ParseInt(outParts[1], 10, 64)
+	assert.Nil(t, err)
+	assert.Equal(t, uint64(actualTotal), v.Total)
+
+	assert.True(t, v.Available > 0)
+	assert.Equal(t, v.Available, v.Free+v.Inactive, "%v", v)
+
+	assert.True(t, v.Used > 0)
+	assert.True(t, v.Used < v.Total)
+
+	assert.True(t, v.UsedPercent > 0)
+	assert.True(t, v.UsedPercent < 100)
+
+	assert.True(t, v.Free > 0)
+	assert.True(t, v.Free < v.Available)
+
+	assert.True(t, v.Active > 0)
+	assert.True(t, v.Active < v.Total)
+
+	assert.True(t, v.Inactive > 0)
+	assert.True(t, v.Inactive < v.Total)
+
+	assert.True(t, v.Wired > 0)
+	assert.True(t, v.Wired < v.Total)
+}

--- a/vendor/github.com/shirou/gopsutil/mem/mem_fallback.go
+++ b/vendor/github.com/shirou/gopsutil/mem/mem_fallback.go
@@ -1,0 +1,13 @@
+// +build !darwin,!linux,!freebsd,!openbsd,!solaris,!windows
+
+package mem
+
+import "github.com/shirou/gopsutil/internal/common"
+
+func VirtualMemory() (*VirtualMemoryStat, error) {
+	return nil, common.ErrNotImplementedError
+}
+
+func SwapMemory() (*SwapMemoryStat, error) {
+	return nil, common.ErrNotImplementedError
+}

--- a/vendor/github.com/shirou/gopsutil/mem/mem_freebsd.go
+++ b/vendor/github.com/shirou/gopsutil/mem/mem_freebsd.go
@@ -1,0 +1,134 @@
+// +build freebsd
+
+package mem
+
+import (
+	"errors"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/shirou/gopsutil/internal/common"
+)
+
+func VirtualMemory() (*VirtualMemoryStat, error) {
+	pageSize, err := common.DoSysctrl("vm.stats.vm.v_page_size")
+	if err != nil {
+		return nil, err
+	}
+	p, err := strconv.ParseUint(pageSize[0], 10, 64)
+	if err != nil {
+		return nil, err
+	}
+
+	pageCount, err := common.DoSysctrl("vm.stats.vm.v_page_count")
+	if err != nil {
+		return nil, err
+	}
+	free, err := common.DoSysctrl("vm.stats.vm.v_free_count")
+	if err != nil {
+		return nil, err
+	}
+	active, err := common.DoSysctrl("vm.stats.vm.v_active_count")
+	if err != nil {
+		return nil, err
+	}
+	inactive, err := common.DoSysctrl("vm.stats.vm.v_inactive_count")
+	if err != nil {
+		return nil, err
+	}
+	cache, err := common.DoSysctrl("vm.stats.vm.v_cache_count")
+	if err != nil {
+		return nil, err
+	}
+	buffer, err := common.DoSysctrl("vfs.bufspace")
+	if err != nil {
+		return nil, err
+	}
+	wired, err := common.DoSysctrl("vm.stats.vm.v_wire_count")
+	if err != nil {
+		return nil, err
+	}
+
+	parsed := make([]uint64, 0, 7)
+	vv := []string{
+		pageCount[0],
+		free[0],
+		active[0],
+		inactive[0],
+		cache[0],
+		buffer[0],
+		wired[0],
+	}
+	for _, target := range vv {
+		t, err := strconv.ParseUint(target, 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		parsed = append(parsed, t)
+	}
+
+	ret := &VirtualMemoryStat{
+		Total:    parsed[0] * p,
+		Free:     parsed[1] * p,
+		Active:   parsed[2] * p,
+		Inactive: parsed[3] * p,
+		Cached:   parsed[4] * p,
+		Buffers:  parsed[5],
+		Wired:    parsed[6] * p,
+	}
+
+	ret.Available = ret.Inactive + ret.Cached + ret.Free
+	ret.Used = ret.Total - ret.Available
+	ret.UsedPercent = float64(ret.Used) / float64(ret.Total) * 100.0
+
+	return ret, nil
+}
+
+// Return swapinfo
+// FreeBSD can have multiple swap devices. but use only first device
+func SwapMemory() (*SwapMemoryStat, error) {
+	swapinfo, err := exec.LookPath("swapinfo")
+	if err != nil {
+		return nil, err
+	}
+
+	out, err := invoke.Command(swapinfo)
+	if err != nil {
+		return nil, err
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		values := strings.Fields(line)
+		// skip title line
+		if len(values) == 0 || values[0] == "Device" {
+			continue
+		}
+
+		u := strings.Replace(values[4], "%", "", 1)
+		total_v, err := strconv.ParseUint(values[1], 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		used_v, err := strconv.ParseUint(values[2], 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		free_v, err := strconv.ParseUint(values[3], 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		up_v, err := strconv.ParseFloat(u, 64)
+		if err != nil {
+			return nil, err
+		}
+
+		return &SwapMemoryStat{
+			Total:       total_v,
+			Used:        used_v,
+			Free:        free_v,
+			UsedPercent: up_v,
+		}, nil
+	}
+
+	return nil, errors.New("no swap devices found")
+}

--- a/vendor/github.com/shirou/gopsutil/mem/mem_linux.go
+++ b/vendor/github.com/shirou/gopsutil/mem/mem_linux.go
@@ -1,0 +1,114 @@
+// +build linux
+
+package mem
+
+import (
+	"strconv"
+	"strings"
+	"syscall"
+
+	"github.com/shirou/gopsutil/internal/common"
+)
+
+func VirtualMemory() (*VirtualMemoryStat, error) {
+	filename := common.HostProc("meminfo")
+	lines, _ := common.ReadLines(filename)
+	// flag if MemAvailable is in /proc/meminfo (kernel 3.14+)
+	memavail := false
+
+	ret := &VirtualMemoryStat{}
+	for _, line := range lines {
+		fields := strings.Split(line, ":")
+		if len(fields) != 2 {
+			continue
+		}
+		key := strings.TrimSpace(fields[0])
+		value := strings.TrimSpace(fields[1])
+		value = strings.Replace(value, " kB", "", -1)
+
+		t, err := strconv.ParseUint(value, 10, 64)
+		if err != nil {
+			return ret, err
+		}
+		switch key {
+		case "MemTotal":
+			ret.Total = t * 1024
+		case "MemFree":
+			ret.Free = t * 1024
+		case "MemAvailable":
+			memavail = true
+			ret.Available = t * 1024
+		case "Buffers":
+			ret.Buffers = t * 1024
+		case "Cached":
+			ret.Cached = t * 1024
+		case "Active":
+			ret.Active = t * 1024
+		case "Inactive":
+			ret.Inactive = t * 1024
+		case "Writeback":
+			ret.Writeback = t * 1024
+		case "WritebackTmp":
+			ret.WritebackTmp = t * 1024
+		case "Dirty":
+			ret.Dirty = t * 1024
+		case "Shmem":
+			ret.Shared = t * 1024
+		case "Slab":
+			ret.Slab = t * 1024
+		case "PageTables":
+			ret.PageTables = t * 1024
+		case "SwapCached":
+			ret.SwapCached = t * 1024
+		}
+	}
+	if !memavail {
+		ret.Available = ret.Free + ret.Buffers + ret.Cached
+	}
+	ret.Used = ret.Total - ret.Available
+	ret.UsedPercent = float64(ret.Total-ret.Available) / float64(ret.Total) * 100.0
+
+	return ret, nil
+}
+
+func SwapMemory() (*SwapMemoryStat, error) {
+	sysinfo := &syscall.Sysinfo_t{}
+
+	if err := syscall.Sysinfo(sysinfo); err != nil {
+		return nil, err
+	}
+	ret := &SwapMemoryStat{
+		Total: uint64(sysinfo.Totalswap) * uint64(sysinfo.Unit),
+		Free:  uint64(sysinfo.Freeswap) * uint64(sysinfo.Unit),
+	}
+	ret.Used = ret.Total - ret.Free
+	//check Infinity
+	if ret.Total != 0 {
+		ret.UsedPercent = float64(ret.Total-ret.Free) / float64(ret.Total) * 100.0
+	} else {
+		ret.UsedPercent = 0
+	}
+	filename := common.HostProc("vmstat")
+	lines, _ := common.ReadLines(filename)
+	for _, l := range lines {
+		fields := strings.Fields(l)
+		if len(fields) < 2 {
+			continue
+		}
+		switch fields[0] {
+		case "pswpin":
+			value, err := strconv.ParseUint(fields[1], 10, 64)
+			if err != nil {
+				continue
+			}
+			ret.Sin = value * 4 * 1024
+		case "pswpout":
+			value, err := strconv.ParseUint(fields[1], 10, 64)
+			if err != nil {
+				continue
+			}
+			ret.Sout = value * 4 * 1024
+		}
+	}
+	return ret, nil
+}

--- a/vendor/github.com/shirou/gopsutil/mem/mem_openbsd.go
+++ b/vendor/github.com/shirou/gopsutil/mem/mem_openbsd.go
@@ -1,0 +1,110 @@
+// +build openbsd
+
+package mem
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"github.com/shirou/gopsutil/internal/common"
+	"os/exec"
+)
+
+func GetPageSize() (uint64, error) {
+	mib := []int32{CTLVm, VmUvmexp}
+	buf, length, err := common.CallSyscall(mib)
+	if err != nil {
+		return 0, err
+	}
+	if length < sizeOfUvmexp {
+		return 0, fmt.Errorf("short syscall ret %d bytes", length)
+	}
+	var uvmexp Uvmexp
+	br := bytes.NewReader(buf)
+	err = common.Read(br, binary.LittleEndian, &uvmexp)
+	if err != nil {
+		return 0, err
+	}
+	return uint64(uvmexp.Pagesize), nil
+}
+
+func VirtualMemory() (*VirtualMemoryStat, error) {
+	mib := []int32{CTLVm, VmUvmexp}
+	buf, length, err := common.CallSyscall(mib)
+	if err != nil {
+		return nil, err
+	}
+	if length < sizeOfUvmexp {
+		return nil, fmt.Errorf("short syscall ret %d bytes", length)
+	}
+	var uvmexp Uvmexp
+	br := bytes.NewReader(buf)
+	err = common.Read(br, binary.LittleEndian, &uvmexp)
+	if err != nil {
+		return nil, err
+	}
+	p := uint64(uvmexp.Pagesize)
+
+	ret := &VirtualMemoryStat{
+		Total:    uint64(uvmexp.Npages) * p,
+		Free:     uint64(uvmexp.Free) * p,
+		Active:   uint64(uvmexp.Active) * p,
+		Inactive: uint64(uvmexp.Inactive) * p,
+		Cached:   0, // not available
+		Wired:    uint64(uvmexp.Wired) * p,
+	}
+
+	ret.Available = ret.Inactive + ret.Cached + ret.Free
+	ret.Used = ret.Total - ret.Available
+	ret.UsedPercent = float64(ret.Used) / float64(ret.Total) * 100.0
+
+	mib = []int32{CTLVfs, VfsGeneric, VfsBcacheStat}
+	buf, length, err = common.CallSyscall(mib)
+	if err != nil {
+		return nil, err
+	}
+	if length < sizeOfBcachestats {
+		return nil, fmt.Errorf("short syscall ret %d bytes", length)
+	}
+	var bcs Bcachestats
+	br = bytes.NewReader(buf)
+	err = common.Read(br, binary.LittleEndian, &bcs)
+	if err != nil {
+		return nil, err
+	}
+	ret.Buffers = uint64(bcs.Numbufpages) * p
+
+	return ret, nil
+}
+
+// Return swapctl summary info
+func SwapMemory() (*SwapMemoryStat, error) {
+	swapctl, err := exec.LookPath("swapctl")
+	if err != nil {
+		return nil, err
+	}
+
+	out, err := invoke.Command(swapctl, "-sk")
+	if err != nil {
+		return &SwapMemoryStat{}, nil
+	}
+
+	line := string(out)
+	var total, used, free uint64
+
+	_, err = fmt.Sscanf(line,
+		"total: %d 1K-blocks allocated, %d used, %d available",
+		&total, &used, &free)
+	if err != nil {
+		return nil, errors.New("failed to parse swapctl output")
+	}
+
+	percent := float64(used) / float64(total) * 100
+	return &SwapMemoryStat{
+		Total:       total * 1024,
+		Used:        used * 1024,
+		Free:        free * 1024,
+		UsedPercent: percent,
+	}, nil
+}

--- a/vendor/github.com/shirou/gopsutil/mem/mem_openbsd_amd64.go
+++ b/vendor/github.com/shirou/gopsutil/mem/mem_openbsd_amd64.go
@@ -1,0 +1,122 @@
+// Created by cgo -godefs - DO NOT EDIT
+// cgo -godefs types_openbsd.go
+
+package mem
+
+const (
+	CTLVm         = 2
+	CTLVfs        = 10
+	VmUvmexp      = 4
+	VfsGeneric    = 0
+	VfsBcacheStat = 3
+)
+
+const (
+	sizeOfUvmexp      = 0x154
+	sizeOfBcachestats = 0x78
+)
+
+type Uvmexp struct {
+	Pagesize           int32
+	Pagemask           int32
+	Pageshift          int32
+	Npages             int32
+	Free               int32
+	Active             int32
+	Inactive           int32
+	Paging             int32
+	Wired              int32
+	Zeropages          int32
+	Reserve_pagedaemon int32
+	Reserve_kernel     int32
+	Anonpages          int32
+	Vnodepages         int32
+	Vtextpages         int32
+	Freemin            int32
+	Freetarg           int32
+	Inactarg           int32
+	Wiredmax           int32
+	Anonmin            int32
+	Vtextmin           int32
+	Vnodemin           int32
+	Anonminpct         int32
+	Vtextminpct        int32
+	Vnodeminpct        int32
+	Nswapdev           int32
+	Swpages            int32
+	Swpginuse          int32
+	Swpgonly           int32
+	Nswget             int32
+	Nanon              int32
+	Nanonneeded        int32
+	Nfreeanon          int32
+	Faults             int32
+	Traps              int32
+	Intrs              int32
+	Swtch              int32
+	Softs              int32
+	Syscalls           int32
+	Pageins            int32
+	Obsolete_swapins   int32
+	Obsolete_swapouts  int32
+	Pgswapin           int32
+	Pgswapout          int32
+	Forks              int32
+	Forks_ppwait       int32
+	Forks_sharevm      int32
+	Pga_zerohit        int32
+	Pga_zeromiss       int32
+	Zeroaborts         int32
+	Fltnoram           int32
+	Fltnoanon          int32
+	Fltpgwait          int32
+	Fltpgrele          int32
+	Fltrelck           int32
+	Fltrelckok         int32
+	Fltanget           int32
+	Fltanretry         int32
+	Fltamcopy          int32
+	Fltnamap           int32
+	Fltnomap           int32
+	Fltlget            int32
+	Fltget             int32
+	Flt_anon           int32
+	Flt_acow           int32
+	Flt_obj            int32
+	Flt_prcopy         int32
+	Flt_przero         int32
+	Pdwoke             int32
+	Pdrevs             int32
+	Pdswout            int32
+	Pdfreed            int32
+	Pdscans            int32
+	Pdanscan           int32
+	Pdobscan           int32
+	Pdreact            int32
+	Pdbusy             int32
+	Pdpageouts         int32
+	Pdpending          int32
+	Pddeact            int32
+	Pdreanon           int32
+	Pdrevnode          int32
+	Pdrevtext          int32
+	Fpswtch            int32
+	Kmapent            int32
+}
+type Bcachestats struct {
+	Numbufs       int64
+	Numbufpages   int64
+	Numdirtypages int64
+	Numcleanpages int64
+	Pendingwrites int64
+	Pendingreads  int64
+	Numwrites     int64
+	Numreads      int64
+	Cachehits     int64
+	Busymapped    int64
+	Dmapages      int64
+	Highpages     int64
+	Delwribufs    int64
+	Kvaslots      int64
+	Avail         int64
+}

--- a/vendor/github.com/shirou/gopsutil/mem/mem_solaris.go
+++ b/vendor/github.com/shirou/gopsutil/mem/mem_solaris.go
@@ -1,0 +1,109 @@
+package mem
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/shirou/gopsutil/internal/common"
+)
+
+// VirtualMemory for Solaris is a minimal implementation which only returns
+// what Nomad needs. It does take into account global vs zone, however.
+func VirtualMemory() (*VirtualMemoryStat, error) {
+	result := &VirtualMemoryStat{}
+
+	zoneName, err := zoneName()
+	if err != nil {
+		return nil, err
+	}
+
+	if zoneName == "global" {
+		cap, err := globalZoneMemoryCapacity()
+		if err != nil {
+			return nil, err
+		}
+		result.Total = cap
+	} else {
+		cap, err := nonGlobalZoneMemoryCapacity()
+		if err != nil {
+			return nil, err
+		}
+		result.Total = cap
+	}
+
+	return result, nil
+}
+
+func SwapMemory() (*SwapMemoryStat, error) {
+	return nil, common.ErrNotImplementedError
+}
+
+func zoneName() (string, error) {
+	zonename, err := exec.LookPath("/usr/bin/zonename")
+	if err != nil {
+		return "", err
+	}
+
+	out, err := invoke.Command(zonename)
+	if err != nil {
+		return "", err
+	}
+
+	return strings.TrimSpace(string(out)), nil
+}
+
+var globalZoneMemoryCapacityMatch = regexp.MustCompile(`memory size: ([\d]+) Megabytes`)
+
+func globalZoneMemoryCapacity() (uint64, error) {
+	prtconf, err := exec.LookPath("/usr/sbin/prtconf")
+	if err != nil {
+		return 0, err
+	}
+
+	out, err := invoke.Command(prtconf)
+	if err != nil {
+		return 0, err
+	}
+
+	match := globalZoneMemoryCapacityMatch.FindAllStringSubmatch(string(out), -1)
+	if len(match) != 1 {
+		return 0, errors.New("memory size not contained in output of /usr/sbin/prtconf")
+	}
+
+	totalMB, err := strconv.ParseUint(match[0][1], 10, 64)
+	if err != nil {
+		return 0, err
+	}
+
+	return totalMB * 1024 * 1024, nil
+}
+
+var kstatMatch = regexp.MustCompile(`([^\s]+)[\s]+([^\s]*)`)
+
+func nonGlobalZoneMemoryCapacity() (uint64, error) {
+	kstat, err := exec.LookPath("/usr/bin/kstat")
+	if err != nil {
+		return 0, err
+	}
+
+	out, err := invoke.Command(kstat, "-p", "-c", "zone_memory_cap", "memory_cap:*:*:physcap")
+	if err != nil {
+		return 0, err
+	}
+
+	kstats := kstatMatch.FindAllStringSubmatch(string(out), -1)
+	if len(kstats) != 1 {
+		return 0, fmt.Errorf("expected 1 kstat, found %d", len(kstats))
+	}
+
+	memSizeBytes, err := strconv.ParseUint(kstats[0][2], 10, 64)
+	if err != nil {
+		return 0, err
+	}
+
+	return memSizeBytes, nil
+}

--- a/vendor/github.com/shirou/gopsutil/mem/mem_windows.go
+++ b/vendor/github.com/shirou/gopsutil/mem/mem_windows.go
@@ -1,0 +1,50 @@
+// +build windows
+
+package mem
+
+import (
+	"syscall"
+	"unsafe"
+
+	"github.com/shirou/gopsutil/internal/common"
+)
+
+var (
+	procGlobalMemoryStatusEx = common.Modkernel32.NewProc("GlobalMemoryStatusEx")
+)
+
+type memoryStatusEx struct {
+	cbSize                  uint32
+	dwMemoryLoad            uint32
+	ullTotalPhys            uint64 // in bytes
+	ullAvailPhys            uint64
+	ullTotalPageFile        uint64
+	ullAvailPageFile        uint64
+	ullTotalVirtual         uint64
+	ullAvailVirtual         uint64
+	ullAvailExtendedVirtual uint64
+}
+
+func VirtualMemory() (*VirtualMemoryStat, error) {
+	var memInfo memoryStatusEx
+	memInfo.cbSize = uint32(unsafe.Sizeof(memInfo))
+	mem, _, _ := procGlobalMemoryStatusEx.Call(uintptr(unsafe.Pointer(&memInfo)))
+	if mem == 0 {
+		return nil, syscall.GetLastError()
+	}
+
+	ret := &VirtualMemoryStat{
+		Total:       memInfo.ullTotalPhys,
+		Available:   memInfo.ullAvailPhys,
+		UsedPercent: float64(memInfo.dwMemoryLoad),
+	}
+
+	ret.Used = ret.Total - ret.Available
+	return ret, nil
+}
+
+func SwapMemory() (*SwapMemoryStat, error) {
+	ret := &SwapMemoryStat{}
+
+	return ret, nil
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -335,6 +335,12 @@
 			"revisionTime": "2017-03-30T04:27:26Z"
 		},
 		{
+			"checksumSHA1": "aKNMuXyexu9Q40UTpJl6JlN7Cj0=",
+			"path": "github.com/shirou/gopsutil/mem",
+			"revision": "f7c38fa2f893474cdd88342539df9c1f9bd66668",
+			"revisionTime": "2017-05-04T12:34:56Z"
+		},
+		{
 			"checksumSHA1": "zqdJo70e2vfUaNAs8hs3CA7ZmfQ=",
 			"path": "github.com/shirou/gopsutil/net",
 			"revision": "f18f7dcbae9dcf766ffefecb4c953cd6aab0bc6d",


### PR DESCRIPTION
Use gopsutil library for getting memory statistics. This should fix the issue https://github.com/elastic/beats/issues/4202. 

Note: This PR keeps the old fields. In a later PR, I would like to reduce the number of exported fields. For example, we should be able to delete `system.actual.used` as it can be with the Time Series Visual Bilder in Kibana.