### PR TITLE
Reduce the number of notifications from travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -103,6 +103,9 @@ script:
 
 notifications:
   slack:
+    on_success: change
+    on_failure: always
+    on_pull_requests: false
     rooms:
       secure: "e25J5puEA31dOooTI4T+K+zrTs8XeWIGq2cgmiPt9u/g7eqWeQj1UJnVsr8GOu1RPDyuJZJHXqfrvuOYJTdHzXbwjD0JTbwwVVZMkkZW2SWZHG46HCXPiucjWXEr3hXJKBJDDpIx6VxrN7r17dejv1biQ8QuEFZfiB1H8kbH/ho="
 


### PR DESCRIPTION
- Disable PR notifications.
- Send failed build notifications.
- Send an update when build transistions from red -> green.