### PR TITLE
Miscellaneous test fixes

### DIFF
--- a/heartbeat/Makefile
+++ b/heartbeat/Makefile
@@ -1,6 +1,6 @@
 BEAT_NAME=heartbeat
 BEAT_DESCRIPTION?=Ping remote services for availability and log results to Elasticsearch or send to Logstash.
-SYSTEM_TESTS=false
+SYSTEM_TESTS=true
 TEST_ENVIRONMENT=false
 
 # Path to the libbeat Makefile

--- a/heartbeat/tests/system/config/heartbeat.yml.j2
+++ b/heartbeat/tests/system/config/heartbeat.yml.j2
@@ -1,78 +1,8 @@
-################### Beat Configuration #########################
+heartbeat.monitors:
+- type: icmp
+  hosts: ["localhost"]
+  schedule: '@every 10s'
 
-
-
-############################# Output ##########################################
-
-# Configure what outputs to use when sending the data collected by the beat.
-# You can enable one or multiple outputs by setting enabled option to true.
-output:
-
-  ### File as output
-  file:
-    # Enabling file output
-    enabled: true
-
-    # Path to the directory where to save the generated files. The option is mandatory.
-    path: {{ output_file_path|default(beat.working_dir + "/output") }}
-
-
-    # Name of the generated files. The default is `heartbeat` and it generates
-    # files: `heartbeat`, `heartbeat.1`, `heartbeat.2`, etc.
-    filename: "{{ output_file_filename|default("heartbeat") }}"
-
-    # Maximum size in kilobytes of each file. When this size is reached, the files are
-    # rotated. The default value is 10 MB.
-    #rotate_every_kb: 10000
-
-    # Maximum number of files under path. When this number of files is reached, the
-    # oldest file is deleted and the rest are shifted from last to first. The default
-    # is 7 files.
-    #number_of_files: 7
-
-
-
-############################# Beat #########################################
-
-# The name of the shipper that publishes the network data. It can be used to group
-# all the transactions sent by a single shipper in the web interface.
-# If this options is not defined, the hostname is used.
-#name:
-
-# The tags of the shipper are included in their own field with each
-# transaction published. Tags make it easy to group servers by different
-# logical properties.
-#tags: ["service-X", "web-tier"]
-
-
-
-############################# Logging #########################################
-
-#logging:
-  # Send all logging output to syslog. On Windows default is false, otherwise
-  # default is true.
-  #to_syslog: true
-
-  # Write all logging output to files. Beats automatically rotate files if configurable
-  # limit is reached.
-  #to_files: false
-
-  # Enable debug output for selected components.
-  #selectors: []
-
-  # Set log level
-  #level: error
-
-  #files:
-    # The directory where the log files will written to.
-    #path: /var/log/heartbeat
-
-    # The name of the files where the logs are written to.
-    #name: heartbeat
-
-    # Configure log file size limit. If limit is reached, log file will be
-    # automatically rotated
-    #rotateeverybytes: 10485760 # = 10MB
-
-    # Number of rotated log files to keep. Oldest files will be deleted first.
-    #keepfiles: 7
+output.file:
+  path: {{ output_file_path|default(beat.working_dir + "/output") }}
+  filename: "{{ output_file_filename|default("heartbeat") }}"

--- a/heartbeat/tests/system/heartbeat.py
+++ b/heartbeat/tests/system/heartbeat.py
@@ -1,3 +1,4 @@
+import os
 import sys
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '../../../libbeat/tests/system'))
@@ -6,8 +7,8 @@ from beat.beat import TestCase
 
 
 class BaseTest(TestCase):
-
     @classmethod
     def setUpClass(self):
         self.beat_name = "heartbeat"
         self.beat_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../"))
+        super(BaseTest, self).setUpClass()

--- a/heartbeat/tests/system/test_base.py
+++ b/heartbeat/tests/system/test_base.py
@@ -1,10 +1,9 @@
-from heartbeat import BaseTest
-
 import os
+
+from heartbeat import BaseTest
 
 
 class Test(BaseTest):
-
     def test_base(self):
         """
         Basic test with exiting Heartbeat normally
@@ -15,5 +14,4 @@ class Test(BaseTest):
 
         heartbeat_proc = self.start_beat()
         self.wait_until(lambda: self.log_contains("heartbeat is running"))
-        exit_code = heartbeat_proc.kill_and_wait()
-        assert exit_code == 0
+        heartbeat_proc.check_kill_and_wait()

--- a/metricbeat/module/ceph/monitor_health/monitor_health.go
+++ b/metricbeat/module/ceph/monitor_health/monitor_health.go
@@ -1,8 +1,6 @@
 package monitor_health
 
 import (
-	"fmt"
-
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/metricbeat/helper"
@@ -46,15 +44,10 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 }
 
 func (m *MetricSet) Fetch() ([]common.MapStr, error) {
-
 	content, err := m.HTTP.FetchContent()
 	if err != nil {
 		return nil, err
 	}
 
-	fmt.Printf("%+v", string(content))
-	fmt.Printf("%+v", eventsMapping(content))
-
 	return eventsMapping(content), nil
-
 }

--- a/metricbeat/module/ceph/monitor_health/monitor_health_test.go
+++ b/metricbeat/module/ceph/monitor_health/monitor_health_test.go
@@ -32,10 +32,10 @@ func TestFetchEventContents(t *testing.T) {
 
 	f := mbtest.NewEventsFetcher(t, config)
 	events, err := f.Fetch()
-	event := events[0]
-	if !assert.NoError(t, err) {
-		t.FailNow()
+	if err != nil {
+		t.Fatal(err)
 	}
+	event := events[0]
 
 	t.Logf("%s/%s event: %+v", f.Module().Name(), f.Name(), event.StringToPrint())
 
@@ -68,5 +68,4 @@ func TestFetchEventContents(t *testing.T) {
 
 	total = store_stats["total"].(common.MapStr)
 	assert.EqualValues(t, 8488943, total["bytes"])
-
 }

--- a/packetbeat/procs/procs_test.go
+++ b/packetbeat/procs/procs_test.go
@@ -94,7 +94,7 @@ func TestFindPidsByCmdlineGrep(t *testing.T) {
 	}
 
 	// Create fake proc file system
-	pathPrefix, err := ioutil.TempDir("/tmp", "")
+	pathPrefix, err := ioutil.TempDir("", "find-pids")
 	if err != nil {
 		t.Error("TempDir failed:", err)
 		return
@@ -129,7 +129,7 @@ func TestRefreshPids(t *testing.T) {
 	}
 
 	// Create fake proc file system
-	pathPrefix, err := ioutil.TempDir("/tmp", "")
+	pathPrefix, err := ioutil.TempDir("", "refresh-pids")
 	if err != nil {
 		t.Error("TempDir failed:", err)
 		return
@@ -187,7 +187,7 @@ func TestFindSocketsOfPid(t *testing.T) {
 	}
 
 	// Create fake proc file system
-	pathPrefix, err := ioutil.TempDir("/tmp", "")
+	pathPrefix, err := ioutil.TempDir("", "find-sockets")
 	if err != nil {
 		t.Error("TempDir failed:", err)
 		return


### PR DESCRIPTION
- Fix and enable the python smoke test for heartbeat
- Remove fmt.Printf from metricbeat ceph module (it messed up `go test` output which broke parsing with github.com/jstemmer/go-junit-report)
- Fix Windows path issues in libbeat/paths tests
- Fix ioutil.TempDir usage in Packetbeat tests (it broke windows)

I'm working off the list of failures from here: https://beats-ci.elastic.co/job/elastic+beats+master+tests-windows/3/testReport/