### PR TITLE
Compile libpcap from source while packaging

### DIFF
--- a/dev-tools/packer/docker/xgo-image-deb6/beats-builder/Dockerfile
+++ b/dev-tools/packer/docker/xgo-image-deb6/beats-builder/Dockerfile
@@ -2,18 +2,23 @@ FROM tudorg/xgo-deb6-1.8.1
 
 MAINTAINER Tudor Golubenco <tudor@elastic.co>
 
-# Get libpcap binaries for linux
+# Get libpcap-32 binaries from a DEB file
 RUN \
 	mkdir -p /libpcap && \
     wget http://archive.debian.org/debian/pool/main/libp/libpcap/libpcap0.8-dev_1.1.1-2+squeeze1_i386.deb && \
 	dpkg -x libpcap0.8-dev_*_i386.deb /libpcap/i386 && \
-	wget http://archive.debian.org/debian/pool/main/libp/libpcap/libpcap0.8-dev_1.1.1-2+squeeze1_amd64.deb && \
-	dpkg -x libpcap0.8-dev_*_amd64.deb /libpcap/amd64 && \
 	rm libpcap0.8-dev*.deb
+
+# Get libpcap-64 binaries by compiling from source
 RUN \
 	apt-get -o Acquire::Check-Valid-Until=false update && \
-	apt-get install -y libpcap0.8-dev
-
+	apt-get install -y flex bison
+RUN ./fetch.sh http://www.tcpdump.org/release/libpcap-1.8.1.tar.gz 32d7526dde8f8a2f75baf40c01670602aeef7e39 && \
+  mkdir -p /libpcap/amd64 && \
+  tar -C /libpcap/amd64/ -xvf libpcap-1.8.1.tar.gz && \
+  cd /libpcap/amd64/libpcap-1.8.1 && \
+  ./configure --enable-usb=no --enable-bluetooth=no --enable-dbus=no && \
+  make
 
 # Old git version which does not support proxy with go get requires to fetch go-yaml directly
 RUN git clone https://github.com/go-yaml/yaml.git /go/src/gopkg.in/yaml.v2

--- a/dev-tools/packer/docker/xgo-image-deb6/beats-builder/gopacket_pcap.patch
+++ b/dev-tools/packer/docker/xgo-image-deb6/beats-builder/gopacket_pcap.patch
@@ -1,14 +1,16 @@
 diff --git a/vendor/github.com/tsg/gopacket/pcap/pcap.go b/vendor/github.com/tsg/gopacket/pcap/pcap.go
-index d2465bb..7b23b84 100644
+index f5612e6..0c77efa 100644
 --- a/vendor/github.com/tsg/gopacket/pcap/pcap.go
 +++ b/vendor/github.com/tsg/gopacket/pcap/pcap.go
-@@ -8,14 +8,15 @@
+@@ -8,14 +8,17 @@
  package pcap
 
  /*
 -#cgo linux LDFLAGS: -lpcap
++#cgo linux,386 CFLAGS: -I /libpcap/i386/usr/include/
 +#cgo linux,386 LDFLAGS: /libpcap/i386/usr/lib/libpcap.a
-+#cgo linux,amd64 LDFLAGS: /libpcap/amd64/usr/lib/libpcap.a
++#cgo linux,amd64 CFLAGS: -I /libpcap/amd64/libpcap-1.8.1
++#cgo linux,amd64 LDFLAGS: /libpcap/amd64/libpcap-1.8.1/libpcap.a
  #cgo freebsd LDFLAGS: -lpcap
  #cgo openbsd LDFLAGS: -lpcap
  #cgo darwin LDFLAGS: -lpcap

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -411,7 +411,6 @@ prepare-package-cgo:
 		-e BEFORE_BUILD=before_build.sh \
 		-e SOURCE=/source \
 		-e TARGETS=${TARGETS_OLD} \
-		-e STATIC=true \
 		-e BUILDID=${BUILDID} \
 		-e ES_BEATS=${ES_BEATS} \
 		-e BEAT_PATH=${BEAT_PATH} \


### PR DESCRIPTION
This is a second attempt to fix #4174. It reverts #4203 and instead
compiles libpcap from source, to use a newer version and to make sure
`-fPIC` is used.