### PR TITLE
Workaround the dashboards' reliance on types

### DIFF
--- a/libbeat/dashboards/importer.go
+++ b/libbeat/dashboards/importer.go
@@ -73,7 +73,12 @@ func (imp Importer) Import() error {
 // some index properties which are needed as a workaround for:
 // https://github.com/elastic/beats-dashboards/issues/94
 func (imp Importer) CreateKibanaIndex() error {
-	imp.client.CreateIndex(imp.cfg.KibanaIndex, nil)
+	imp.client.CreateIndex(imp.cfg.KibanaIndex,
+		common.MapStr{
+			"settings": common.MapStr{
+				"index.mapping.single_type": false,
+			},
+		})
 	_, _, err := imp.client.CreateIndex(imp.cfg.KibanaIndex+"/_mapping/search",
 		common.MapStr{
 			"search": common.MapStr{


### PR DESCRIPTION
Kibana still relies on types, and works around it by setting `index.mapping.single_type=false`
when creating the `.kibana` index. If the Beats dashboards are inserted before this index
is created, however, the import will fail. This adds `single_type=false` when creating the
`.kibana` index.

This is a temporary solution until Kibana removes types from its usage and we have an API
to index the dashboards.

This was inspired by https://github.com/elastic/kibana/pull/11451 and should fix our failing integration tests.