### PR TITLE
Fix freebsd tests by setting hostname

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -92,6 +92,7 @@ Vagrant.configure(2) do |config|
     config.vm.synced_folder ".", "/vagrant", id: "vagrant-root", :nfs => true, disabled: true
     #config.vm.network "private_network", ip: "192.168.135.18"
 
+    freebsd.vm.hostname = "beats-tester"
     freebsd.vm.provision "shell", inline: $unixProvision, privileged: false
   end
 


### PR DESCRIPTION
On freebsd the filebeat tests fail because no hostname is set. This change sets the hostname to `beats-tester`.