### PR TITLE
Deprecate document_type in filebeat 5.5

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -73,6 +73,7 @@ https://github.com/elastic/beats/compare/v5.3.0...master[Check the HEAD diff]
 *Affecting all Beats*
 
 *Filebeat*
+- Deprecate `document_type` prospector config option as _type is removed in elasticsearch 6.0. Use fields instead. {pull}4225[4225]
 
 *Heartbeat*
 

--- a/filebeat/docs/reference/configuration/filebeat-options.asciidoc
+++ b/filebeat/docs/reference/configuration/filebeat-options.asciidoc
@@ -296,6 +296,8 @@ The default setting is 10s.
 
 ===== document_type
 
+deprecated[5.5,Use `fields` instead]
+
 The event type to use for published lines read by harvesters. For Elasticsearch
 output, the value that you specify here is used to set the `type` field in the output
 document. The default value is `log`.

--- a/filebeat/harvester/config.go
+++ b/filebeat/harvester/config.go
@@ -2,6 +2,7 @@ package harvester
 
 import (
 	"fmt"
+	"sync"
 	"time"
 
 	cfg "github.com/elastic/beats/filebeat/config"
@@ -57,6 +58,8 @@ type harvesterConfig struct {
 	Fileset              string                  `config:"_fileset_name"` // hidden option to set the fileset name
 }
 
+var onceCheck sync.Once
+
 func (config *harvesterConfig) Validate() error {
 
 	// DEPRECATED: remove in 6.0
@@ -87,5 +90,10 @@ func (config *harvesterConfig) Validate() error {
 		return fmt.Errorf("When using the JSON decoder and line filtering together, you need to specify a message_key value")
 	}
 
+	if config.DocumentType != "log" {
+		onceCheck.Do(func() {
+			logp.Warn("DEPRECATED: document_type is deprecated. Use fields instead.")
+		})
+	}
 	return nil
 }


### PR DESCRIPTION
`_type` is removed in elasticsearch 6.0 and `document_type` is removed in filebeat 6.0. Use `fields` instead.