### PR TITLE
Fix issue that new prospector was not reloaded on conflict (#4128)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -30,6 +30,7 @@ https://github.com/elastic/beats/compare/v5.3.0...master[Check the HEAD diff]
 - Fix console output {pull}4045[4045]
 
 *Filebeat*
+- Fix issue that new prospector was not reloaded on conflict {pull}4128[4128]
 
 *Heartbeat*
 

--- a/filebeat/prospector/factory.go
+++ b/filebeat/prospector/factory.go
@@ -32,7 +32,8 @@ func (r *Factory) Create(c *common.Config) (cfgfile.Runner, error) {
 	err = p.LoadStates(r.registrar.GetStates())
 	if err != nil {
 		logp.Err("Error loading states for prospector %v: %v", p.ID(), err)
-		return nil, err
+		// In case of error with loading state, prospector is still returne
+		return p, err
 	}
 
 	return p, nil

--- a/filebeat/tests/system/config/filebeat.yml.j2
+++ b/filebeat/tests/system/config/filebeat.yml.j2
@@ -82,11 +82,14 @@ filebeat.registry_file: {{ beat.working_dir + '/' }}{{ registryFile|default("reg
 {%endif%}
 filebeat.publish_async: {{publish_async}}
 
-{% if reload -%}
+{% if reload or reload_path -%}
 filebeat.config.prospectors:
+  enabled: true
   path: {{ reload_path }}
+  {% if reload  -%}
   reload.period: 1s
   reload.enabled: true
+  {% endif -%}
 {% endif -%}
 
 #================================ General =====================================


### PR DESCRIPTION
A new prospector cannot be started if one of the states he starts with is not set to Finished. In this case the prospector should wait until the old prospector is shutdown and try again on the next reload. This did not work as intended so far because if loading failed, the running prospector was stopped and the non running was not started again on the next run. This change should fix it.

See also https://discuss.elastic.co/t/error-when-reloading-prospectors-for-filebeat/83082/5

Closes https://github.com/elastic/beats/issues/4133
(cherry picked from commit d98e54e9ed77c8c2f9375d3e488e94d435b5132c)