### PR TITLE
Fix grok pattern in filebeat module system/auth without hostname (#4224)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -30,6 +30,7 @@ https://github.com/elastic/beats/compare/v5.3.0...master[Check the HEAD diff]
 - Fix console output {pull}4045[4045]
 
 *Filebeat*
+- Fix grok pattern in filebeat module system/auth without hostname. {pull}4224[4224]
 
 *Heartbeat*
 

--- a/filebeat/module/system/auth/ingest/pipeline.json
+++ b/filebeat/module/system/auth/ingest/pipeline.json
@@ -15,7 +15,7 @@
           "%{SYSLOGTIMESTAMP:system.auth.timestamp} %{SYSLOGHOST:system.auth.hostname} sudo(?:\\[%{POSINT:system.auth.pid}\\])?: \\s*%{DATA:system.auth.user} :( %{DATA:system.auth.sudo.error} ;)? TTY=%{DATA:system.auth.sudo.tty} ; PWD=%{DATA:system.auth.sudo.pwd} ; USER=%{DATA:system.auth.sudo.user} ; COMMAND=%{GREEDYDATA:system.auth.sudo.command}",
           "%{SYSLOGTIMESTAMP:system.auth.timestamp} %{SYSLOGHOST:system.auth.hostname} groupadd(?:\\[%{POSINT:system.auth.pid}\\])?: new group: name=%{DATA:system.auth.groupadd.name}, GID=%{NUMBER:system.auth.groupadd.gid}",
           "%{SYSLOGTIMESTAMP:system.auth.timestamp} %{SYSLOGHOST:system.auth.hostname} useradd(?:\\[%{POSINT:system.auth.pid}\\])?: new user: name=%{DATA:system.auth.useradd.name}, UID=%{NUMBER:system.auth.useradd.uid}, GID=%{NUMBER:system.auth.useradd.gid}, home=%{DATA:system.auth.useradd.home}, shell=%{DATA:system.auth.useradd.shell}$",
-					"%{SYSLOGTIMESTAMP:system.auth.timestamp} %{SYSLOGHOST:system.auth.hostname} %{DATA:system.auth.program}(?:\\[%{POSINT:system.auth.pid}\\])?: %{GREEDYMULTILINE:system.auth.message}"
+					"%{SYSLOGTIMESTAMP:system.auth.timestamp} %{SYSLOGHOST:system.auth.hostname}? %{DATA:system.auth.program}(?:\\[%{POSINT:system.auth.pid}\\])?: %{GREEDYMULTILINE:system.auth.message}"
         ]
       }
     },

--- a/filebeat/tests/system/test_modules.py
+++ b/filebeat/tests/system/test_modules.py
@@ -100,9 +100,9 @@ class Test(BaseTest):
             assert obj["fileset"]["module"] == module, "expected fileset.module={} but got {}".format(
                 module, obj["fileset"]["module"])
 
-            if not (module == "mysql" and fileset == "slowlog") and not (module == "system" and fileset == "auth"):
+            if not (module == "mysql" and fileset == "slowlog"):
                 # TODO: There are errors parsing the test logs from these modules.
-                assert "error" not in obj
+                assert "error" not in obj, "not error expected but got: {}".format(obj)
 
             if module != "auditd" and fileset != "log":
                 # There are dynamic fields in audit logs that are not documented.


### PR DESCRIPTION
Some log lines like `Feb  9 21:20:08  sshd[8317]: last message repeated 2 times` do not contain a hostname. This change in the grok pattern makes the hostname optional.

* Make system module tests more verbose on error
(cherry picked from commit 598672b0303ca96f56e5a2b5bd95e5544818c369)