### PR TITLE
Use kibana names when exporting visualization jsons

### DIFF
--- a/dev-tools/export_dashboards.py
+++ b/dev-tools/export_dashboards.py
@@ -80,7 +80,8 @@ def SaveJson(doc_type, doc, output_directory):
     if not os.path.exists(dir):
         os.makedirs(dir)
     # replace unsupported characters
-    filepath = os.path.join(dir, re.sub(r'[\>\<:"/\\\|\?\*]', '', doc['_id']) + '.json')
+    filename = '-'.join(re.sub(r'[\>\<:"/\\\|\?\*]', '', doc['_source']['title']).split(' '))
+    filepath = os.path.join(dir, filename + '.json')
     with open(filepath, 'w') as f:
         json.dump(doc['_source'], f, indent=2)
         print("Written {}".format(filepath))


### PR DESCRIPTION
Instead of current internal id, this should make resulting files more
human readable, ie:

 _meta/kibana/dashboard/Kubernetes overview.json
 _meta/kibana/visualization/Kubernetes - Available pods per deployment.json
 _meta/kibana/visualization/Kubernetes - Available pods.json
 _meta/kibana/visualization/Kubernetes - CPU usage by node.json
 _meta/kibana/visualization/Kubernetes - Deployments.json
 ...