### PR TITLE
More test fixes

### DIFF
--- a/libbeat/processors/condition_test.go
+++ b/libbeat/processors/condition_test.go
@@ -20,7 +20,7 @@ func (c *countFilter) Run(e common.MapStr) (common.MapStr, error) {
 
 func (c *countFilter) String() string { return "count" }
 
-func TestBadCondition(t *testing.T) {
+func TestConditions(t *testing.T) {
 
 	if testing.Verbose() {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"*"})

--- a/metricbeat/module/ceph/cluster_disk/cluster_disk.go
+++ b/metricbeat/module/ceph/cluster_disk/cluster_disk.go
@@ -32,7 +32,7 @@ type MetricSet struct {
 }
 
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Warn("EXPERIMENTAL: The ceph cluster_disk metricset is experimental")
+	logp.Experimental("The ceph cluster_disk metricset is experimental")
 
 	http := helper.NewHTTP(base)
 	http.SetHeader("Accept", "application/json")
@@ -44,7 +44,6 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 }
 
 func (m *MetricSet) Fetch() (common.MapStr, error) {
-
 	content, err := m.HTTP.FetchContent()
 
 	if err != nil {

--- a/metricbeat/module/ceph/cluster_health/cluster_health.go
+++ b/metricbeat/module/ceph/cluster_health/cluster_health.go
@@ -32,7 +32,7 @@ type MetricSet struct {
 }
 
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Warn("BETA: The ceph cluster_health metricset is beta")
+	logp.Beta("The ceph cluster_health metricset is beta")
 
 	http := helper.NewHTTP(base)
 	http.SetHeader("Accept", "application/json")
@@ -44,7 +44,6 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 }
 
 func (m *MetricSet) Fetch() (common.MapStr, error) {
-
 	content, err := m.HTTP.FetchContent()
 	if err != nil {
 		return nil, err

--- a/metricbeat/module/ceph/monitor_health/monitor_health.go
+++ b/metricbeat/module/ceph/monitor_health/monitor_health.go
@@ -32,7 +32,7 @@ type MetricSet struct {
 }
 
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Warn("BETA: The ceph monitor_health metricset is beta")
+	logp.Beta("The ceph monitor_health metricset is beta")
 
 	http := helper.NewHTTP(base)
 	http.SetHeader("Accept", "application/json")

--- a/metricbeat/module/ceph/pool_disk/pool_disk.go
+++ b/metricbeat/module/ceph/pool_disk/pool_disk.go
@@ -32,7 +32,7 @@ type MetricSet struct {
 }
 
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Warn("EXPERIMENTAL: The ceph pool_disk metricset is experimental")
+	logp.Experimental("The ceph pool_disk metricset is experimental")
 
 	http := helper.NewHTTP(base)
 	http.SetHeader("Accept", "application/json")
@@ -44,7 +44,6 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 }
 
 func (m *MetricSet) Fetch() ([]common.MapStr, error) {
-
 	content, err := m.HTTP.FetchContent()
 
 	if err != nil {

--- a/metricbeat/module/couchbase/bucket/bucket.go
+++ b/metricbeat/module/couchbase/bucket/bucket.go
@@ -36,7 +36,7 @@ type MetricSet struct {
 
 // New create a new instance of the MetricSet
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Warn("BETA: The couchbase bucket metricset is beta")
+	logp.Beta("The couchbase bucket metricset is beta")
 
 	return &MetricSet{
 		BaseMetricSet: base,

--- a/metricbeat/module/couchbase/cluster/cluster.go
+++ b/metricbeat/module/couchbase/cluster/cluster.go
@@ -36,7 +36,7 @@ type MetricSet struct {
 
 // New create a new instance of the MetricSet
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Warn("BETA: The couchbase cluster metricset is beta")
+	logp.Beta("The couchbase cluster metricset is beta")
 
 	return &MetricSet{
 		BaseMetricSet: base,

--- a/metricbeat/module/couchbase/node/node.go
+++ b/metricbeat/module/couchbase/node/node.go
@@ -36,7 +36,7 @@ type MetricSet struct {
 
 // New create a new instance of the MetricSet
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Warn("BETA: The couchbase node metricset is beta")
+	logp.Beta("The couchbase node metricset is beta")
 
 	return &MetricSet{
 		BaseMetricSet: base,

--- a/metricbeat/module/docker/container/container.go
+++ b/metricbeat/module/docker/container/container.go
@@ -22,7 +22,7 @@ type MetricSet struct {
 
 // New creates a new instance of the docker container MetricSet.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Warn("BETA: The docker container metricset is beta")
+	logp.Beta("The docker container metricset is beta")
 
 	config := docker.Config{}
 	if err := base.Module().UnpackConfig(&config); err != nil {

--- a/metricbeat/module/docker/cpu/cpu.go
+++ b/metricbeat/module/docker/cpu/cpu.go
@@ -23,7 +23,7 @@ type MetricSet struct {
 
 // New creates a new instance of the docker cpu MetricSet.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Warn("BETA: The docker cpu metricset is beta")
+	logp.Beta("The docker cpu metricset is beta")
 
 	config := docker.Config{}
 	if err := base.Module().UnpackConfig(&config); err != nil {

--- a/metricbeat/module/docker/diskio/diskio.go
+++ b/metricbeat/module/docker/diskio/diskio.go
@@ -23,7 +23,7 @@ type MetricSet struct {
 
 // New create a new instance of the docker diskio MetricSet.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Warn("BETA: The docker diskio metricset is beta")
+	logp.Beta("The docker diskio metricset is beta")
 
 	config := docker.Config{}
 	if err := base.Module().UnpackConfig(&config); err != nil {

--- a/metricbeat/module/docker/healthcheck/healthcheck.go
+++ b/metricbeat/module/docker/healthcheck/healthcheck.go
@@ -22,7 +22,7 @@ type MetricSet struct {
 
 // New creates a new instance of the docker healthcheck MetricSet.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Warn("BETA: The docker healthcheck metricset is beta")
+	logp.Beta("The docker healthcheck metricset is beta")
 
 	config := docker.Config{}
 	if err := base.Module().UnpackConfig(&config); err != nil {

--- a/metricbeat/module/docker/image/image.go
+++ b/metricbeat/module/docker/image/image.go
@@ -30,8 +30,7 @@ type MetricSet struct {
 // Part of new is also setting up the configuration by processing additional
 // configuration entries if needed.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-
-	logp.Warn("BETA: The docker info metricset is beta")
+	logp.Beta("The docker info metricset is beta")
 
 	config := docker.Config{}
 	if err := base.Module().UnpackConfig(&config); err != nil {
@@ -53,7 +52,6 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // It returns the event which is then forward to the output. In case of an error, a
 // descriptive error must be returned.
 func (m *MetricSet) Fetch() ([]common.MapStr, error) {
-
 	images, err := m.dockerClient.ListImages(dc.ListImagesOptions{})
 	if err != nil {
 		return nil, err

--- a/metricbeat/module/docker/info/info.go
+++ b/metricbeat/module/docker/info/info.go
@@ -22,7 +22,7 @@ type MetricSet struct {
 
 // New create a new instance of the docker info MetricSet.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Warn("BETA: The docker info metricset is beta")
+	logp.Beta("The docker info metricset is beta")
 
 	config := docker.Config{}
 	if err := base.Module().UnpackConfig(&config); err != nil {

--- a/metricbeat/module/docker/memory/memory.go
+++ b/metricbeat/module/docker/memory/memory.go
@@ -23,7 +23,7 @@ type MetricSet struct {
 
 // New creates a new instance of the docker memory MetricSet.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Warn("BETA: The docker memory metricset is beta")
+	logp.Beta("The docker memory metricset is beta")
 
 	config := docker.Config{}
 	if err := base.Module().UnpackConfig(&config); err != nil {

--- a/metricbeat/module/docker/network/network.go
+++ b/metricbeat/module/docker/network/network.go
@@ -23,7 +23,7 @@ type MetricSet struct {
 
 // New creates a new instance of the docker network MetricSet.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Warn("BETA: The docker network metricset is beta")
+	logp.Beta("The docker network metricset is beta")
 
 	config := docker.Config{}
 	if err := base.Module().UnpackConfig(&config); err != nil {

--- a/metricbeat/module/golang/expvar/expvar.go
+++ b/metricbeat/module/golang/expvar/expvar.go
@@ -44,8 +44,7 @@ type MetricSet struct {
 // Part of new is also setting up the configuration by processing additional
 // configuration entries if needed.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-
-	logp.Warn("EXPERIMENTAL: The golang expvar metricset is experimental")
+	logp.Experimental("The golang expvar metricset is experimental")
 
 	config := struct {
 		Namespace string `config:"expvar.namespace" validate:"required"`
@@ -66,7 +65,6 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // It returns the event which is then forward to the output. In case of an error, a
 // descriptive error must be returned.
 func (m *MetricSet) Fetch() (common.MapStr, error) {
-
 	json, err := m.http.FetchJSON()
 
 	if err != nil {

--- a/metricbeat/module/golang/heap/heap.go
+++ b/metricbeat/module/golang/heap/heap.go
@@ -47,8 +47,7 @@ type MetricSet struct {
 // Part of new is also setting up the configuration by processing additional
 // configuration entries if needed.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-
-	logp.Warn("EXPERIMENTAL: The golang heap metricset is experimental")
+	logp.Experimental("The golang heap metricset is experimental")
 
 	return &MetricSet{
 		BaseMetricSet: base,
@@ -60,7 +59,6 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // It returns the event which is then forward to the output. In case of an error, a
 // descriptive error must be returned.
 func (m *MetricSet) Fetch() (common.MapStr, error) {
-
 	data, err := m.http.FetchContent()
 	if err != nil {
 		return nil, err

--- a/metricbeat/module/http/json/json.go
+++ b/metricbeat/module/http/json/json.go
@@ -55,8 +55,7 @@ type MetricSet struct {
 // Part of new is also setting up the configuration by processing additional
 // configuration entries if needed.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-
-	logp.Warn("The http json metricset is in beta.")
+	logp.Beta("The http json metricset is in beta.")
 
 	config := struct {
 		Namespace       string `config:"namespace" validate:"required"`

--- a/metricbeat/module/jolokia/jmx/jmx.go
+++ b/metricbeat/module/jolokia/jmx/jmx.go
@@ -46,7 +46,7 @@ type MetricSet struct {
 
 // New create a new instance of the MetricSet
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Warn("BETA: The jolokia jmx metricset is beta")
+	logp.Beta("The jolokia jmx metricset is beta")
 
 	// Additional configuration options
 	config := struct {
@@ -78,7 +78,6 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 
 // Fetch methods implements the data gathering and data conversion to the right format
 func (m *MetricSet) Fetch() (common.MapStr, error) {
-
 	body, err := m.http.FetchContent()
 	if err != nil {
 		return nil, err

--- a/metricbeat/module/kafka/consumergroup/consumergroup.go
+++ b/metricbeat/module/kafka/consumergroup/consumergroup.go
@@ -36,7 +36,7 @@ var debugf = logp.MakeDebug("kafka")
 
 // New creates a new instance of the MetricSet.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Warn("BETA: The kafka consumergroup metricset is beta")
+	logp.Beta("The kafka consumergroup metricset is beta")
 
 	config := defaultConfig
 	if err := base.Module().UnpackConfig(&config); err != nil {

--- a/metricbeat/module/kafka/partition/partition.go
+++ b/metricbeat/module/kafka/partition/partition.go
@@ -37,7 +37,7 @@ var debugf = logp.MakeDebug("kafka")
 
 // New creates a new instance of the partition MetricSet.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Warn("BETA: The kafka partition metricset is beta")
+	logp.Beta("The kafka partition metricset is beta")
 
 	config := defaultConfig
 	if err := base.Module().UnpackConfig(&config); err != nil {

--- a/metricbeat/module/memcached/stats/stats.go
+++ b/metricbeat/module/memcached/stats/stats.go
@@ -21,8 +21,7 @@ type MetricSet struct {
 }
 
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-
-	logp.Warn("BETA: The memcached stats metricset is beta")
+	logp.Beta("The memcached stats metricset is beta")
 
 	return &MetricSet{
 		BaseMetricSet: base,
@@ -30,7 +29,6 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 }
 
 func (m *MetricSet) Fetch() (common.MapStr, error) {
-
 	conn, err := net.DialTimeout("tcp", m.Host(), m.Module().Config().Timeout)
 	if err != nil {
 		return nil, err

--- a/metricbeat/module/mongodb/dbstats/dbstats.go
+++ b/metricbeat/module/mongodb/dbstats/dbstats.go
@@ -34,7 +34,7 @@ type MetricSet struct {
 // Part of new is also setting up the configuration by processing additional
 // configuration entries if needed.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Warn("EXPERIMENTAL: The %v %v metricset is experimental", base.Module().Name(), base.Name())
+	logp.Experimental("The %v %v metricset is experimental", base.Module().Name(), base.Name())
 
 	dialInfo, err := mgo.ParseURL(base.HostData().URI)
 	if err != nil {

--- a/metricbeat/module/php_fpm/pool/pool.go
+++ b/metricbeat/module/php_fpm/pool/pool.go
@@ -39,7 +39,8 @@ type MetricSet struct {
 
 // New create a new instance of the MetricSet
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Warn("BETA: The php-fpm pool metricset is beta")
+	logp.Beta("The php_fpm pool metricset is beta")
+
 	return &MetricSet{
 		base,
 		helper.NewHTTP(base),

--- a/metricbeat/module/prometheus/collector/collector.go
+++ b/metricbeat/module/prometheus/collector/collector.go
@@ -37,7 +37,7 @@ type MetricSet struct {
 }
 
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Warn("BETA: The prometheus collector metricset is beta")
+	logp.Beta("The prometheus collector metricset is beta")
 
 	config := struct {
 		Namespace string `config:"namespace" validate:"required"`

--- a/metricbeat/module/prometheus/stats/stats.go
+++ b/metricbeat/module/prometheus/stats/stats.go
@@ -34,7 +34,7 @@ type MetricSet struct {
 }
 
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Warn("BETA: The prometheus stats metricset is beta")
+	logp.Beta("The prometheus stats metricset is beta")
 
 	return &MetricSet{
 		BaseMetricSet: base,

--- a/metricbeat/module/vsphere/datastore/datastore.go
+++ b/metricbeat/module/vsphere/datastore/datastore.go
@@ -29,7 +29,7 @@ type MetricSet struct {
 }
 
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Warn("EXPERIMENTAL: The vsphere datastore metricset is experimental")
+	logp.Experimental("The vsphere datastore metricset is experimental")
 
 	config := struct {
 		Username string `config:"username"`

--- a/metricbeat/module/vsphere/host/host.go
+++ b/metricbeat/module/vsphere/host/host.go
@@ -29,8 +29,7 @@ type MetricSet struct {
 }
 
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-
-	logp.Warn("EXPERIMENTAL: The vsphere host metricset is experimental")
+	logp.Experimental("The vsphere host metricset is experimental")
 
 	config := struct {
 		Username string `config:"username"`
@@ -61,7 +60,6 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 }
 
 func (m *MetricSet) Fetch() ([]common.MapStr, error) {
-
 	f := find.NewFinder(m.Client, true)
 	if f == nil {
 		return nil, errors.New("Finder undefined for vsphere.")

--- a/metricbeat/module/vsphere/virtualmachine/virtualmachine.go
+++ b/metricbeat/module/vsphere/virtualmachine/virtualmachine.go
@@ -30,8 +30,7 @@ type MetricSet struct {
 }
 
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-
-	logp.Warn("EXPERIMENTAL: The vsphere virtualmachine metricset is experimental")
+	logp.Experimental("The vsphere virtualmachine metricset is experimental")
 
 	config := struct {
 		Username string `config:"username"`
@@ -62,7 +61,6 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 }
 
 func (m *MetricSet) Fetch() ([]common.MapStr, error) {
-
 	f := find.NewFinder(m.Client, true)
 	if f == nil {
 		return nil, errors.New("Finder undefined for vsphere.")

--- a/metricbeat/module/windows/perfmon/perfmon.go
+++ b/metricbeat/module/windows/perfmon/perfmon.go
@@ -31,7 +31,7 @@ type MetricSet struct {
 
 // New create a new instance of the MetricSet.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Warn("BETA: The perfmon metricset is beta")
+	logp.Beta("The perfmon metricset is beta")
 
 	config := struct {
 		CounterConfig []CounterConfig `config:"perfmon.counters" validate:"required"`

--- a/metricbeat/tests/system/metricbeat.py
+++ b/metricbeat/tests/system/metricbeat.py
@@ -52,3 +52,15 @@ class BaseTest(TestCase):
                 fields[key] = self.de_dot(fields[key])
 
         return fields
+
+    def assert_no_logged_warnings(self):
+        """
+        Assert that the log file contains no ERR or WARN lines.
+        """
+        log = self.get_log()
+        log = log.replace("WARN EXPERIMENTAL", "")
+        log = log.replace("WARN BETA", "")
+        # Jenkins runs as a Windows service and when Jenkins executes theses
+        # tests the Beat is confused since it thinks it is running as a service.
+        log = log.replace("ERR Error: The service process could not connect to the service controller.", "")
+        self.assertNotRegexpMatches(log, "ERR|WARN")

--- a/metricbeat/tests/system/test_apache.py
+++ b/metricbeat/tests/system/test_apache.py
@@ -44,10 +44,7 @@ class ApacheStatusTest(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0)
         proc.check_kill_and_wait()
-
-        # Ensure no errors or warnings exist in the log.
-        log = self.get_log()
-        self.assertNotRegexpMatches(log, "ERR|WARN")
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         self.assertEqual(len(output), 1)

--- a/metricbeat/tests/system/test_base.py
+++ b/metricbeat/tests/system/test_base.py
@@ -19,10 +19,7 @@ class Test(BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.log_contains("start running"))
         proc.check_kill_and_wait()
-
-        # Ensure no errors or warnings exist in the log.
-        log = self.get_log()
-        self.assertNotRegexpMatches(log, "ERR|WARN")
+        self.assert_no_logged_warnings()
 
         # Ensure all Beater stages are used.
         assert self.log_contains("Setup Beat: metricbeat")

--- a/metricbeat/tests/system/test_couchbase.py
+++ b/metricbeat/tests/system/test_couchbase.py
@@ -19,6 +19,7 @@ class Test(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0, max_timeout=20)
         proc.check_kill_and_wait()
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         self.assertTrue(len(output) >= 1)
@@ -41,6 +42,7 @@ class Test(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0, max_timeout=20)
         proc.check_kill_and_wait()
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         self.assertTrue(len(output) >= 1)
@@ -63,6 +65,7 @@ class Test(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0, max_timeout=20)
         proc.check_kill_and_wait()
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         self.assertTrue(len(output) >= 1)

--- a/metricbeat/tests/system/test_docker.py
+++ b/metricbeat/tests/system/test_docker.py
@@ -21,10 +21,7 @@ class Test(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0, max_timeout=20)
         proc.check_kill_and_wait()
-
-        # Ensure no errors or warnings exist in the log.
-        log = self.get_log()
-        self.assertNotRegexpMatches(log.replace("WARN BETA", ""), "ERR|WARN")
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         evt = output[0]
@@ -47,10 +44,7 @@ class Test(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0, max_timeout=30)
         proc.check_kill_and_wait()
-
-        # Ensure no errors or warnings exist in the log.
-        log = self.get_log()
-        self.assertNotRegexpMatches(log.replace("WARN BETA", ""), "ERR|WARN")
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         evt = output[0]
@@ -77,10 +71,7 @@ class Test(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0, max_timeout=30)
         proc.check_kill_and_wait()
-
-        # Ensure no errors or warnings exist in the log.
-        log = self.get_log()
-        self.assertNotRegexpMatches(log.replace("WARN BETA", ""), "ERR|WARN")
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         evt = output[0]
@@ -104,10 +95,7 @@ class Test(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0, max_timeout=30)
         proc.check_kill_and_wait()
-
-        # Ensure no errors or warnings exist in the log.
-        log = self.get_log()
-        self.assertNotRegexpMatches(log.replace("WARN BETA", ""), "ERR|WARN")
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         evt = output[0]
@@ -129,10 +117,7 @@ class Test(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0, max_timeout=30)
         proc.check_kill_and_wait()
-
-        # Ensure no errors or warnings exist in the log.
-        log = self.get_log()
-        self.assertNotRegexpMatches(log.replace("WARN BETA", ""), "ERR|WARN")
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         evt = output[0]
@@ -155,10 +140,7 @@ class Test(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0, max_timeout=30)
         proc.check_kill_and_wait()
-
-        # Ensure no errors or warnings exist in the log.
-        log = self.get_log()
-        self.assertNotRegexpMatches(log.replace("WARN BETA", ""), "ERR|WARN")
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         evt = output[0]
@@ -181,10 +163,7 @@ class Test(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0, max_timeout=20)
         proc.check_kill_and_wait()
-
-        # Ensure no errors or warnings exist in the log.
-        log = self.get_log()
-        self.assertNotRegexpMatches(log.replace("WARN BETA", ""), "ERR|WARN")
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         evt = output[0]
@@ -207,10 +186,7 @@ class Test(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0, max_timeout=20)
         proc.check_kill_and_wait()
-
-        # Ensure no errors or warnings exist in the log.
-        log = self.get_log()
-        self.assertNotRegexpMatches(log.replace("WARN BETA", ""), "ERR|WARN")
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         evt = output[0]

--- a/metricbeat/tests/system/test_dropwizard.py
+++ b/metricbeat/tests/system/test_dropwizard.py
@@ -22,6 +22,7 @@ class Test(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0, max_timeout=10)
         proc.check_kill_and_wait()
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         self.assertTrue(len(output) >= 1)

--- a/metricbeat/tests/system/test_elasticsearch.py
+++ b/metricbeat/tests/system/test_elasticsearch.py
@@ -19,6 +19,7 @@ class Test(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0, max_timeout=20)
         proc.check_kill_and_wait()
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         self.assertTrue(len(output) >= 1)
@@ -41,6 +42,7 @@ class Test(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0, max_timeout=20)
         proc.check_kill_and_wait()
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         self.assertTrue(len(output) >= 1)

--- a/metricbeat/tests/system/test_golang.py
+++ b/metricbeat/tests/system/test_golang.py
@@ -32,14 +32,7 @@ class Test(metricbeat.BaseTest):
 
         self.wait_until(lambda: self.output_lines() > 0)
         proc.check_kill_and_wait()
-
-        # Ensure no errors or warnings exist in the log.
-        log = self.get_log()
-        self.assertNotRegexpMatches(
-            log.replace(
-                "WARN EXPERIMENTAL",
-                ""),
-            "ERR|WARN")
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         evt = output[0]

--- a/metricbeat/tests/system/test_haproxy.py
+++ b/metricbeat/tests/system/test_haproxy.py
@@ -22,10 +22,7 @@ class Test(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0)
         proc.check_kill_and_wait()
-
-        # Ensure no errors or warnings exist in the log.
-        log = self.get_log()
-        self.assertNotRegexpMatches(log, "ERR|WARN")
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         self.assertEqual(len(output), 1)
@@ -49,10 +46,7 @@ class Test(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0)
         proc.check_kill_and_wait()
-
-        # Ensure no errors or warnings exist in the log.
-        log = self.get_log()
-        self.assertNotRegexpMatches(log, "ERR|WARN")
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         self.assertGreater(len(output), 0)

--- a/metricbeat/tests/system/test_http.py
+++ b/metricbeat/tests/system/test_http.py
@@ -23,10 +23,7 @@ class Test(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0)
         proc.check_kill_and_wait()
-
-        # Ensure no errors or warnings exist in the log.
-        log = self.get_log()
-        self.assertNotRegexpMatches(log.replace("WARN The http json metricset is in beta.", ""), "ERR|WARN")
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         self.assertEqual(len(output), 1)

--- a/metricbeat/tests/system/test_jolokia.py
+++ b/metricbeat/tests/system/test_jolokia.py
@@ -31,6 +31,7 @@ class Test(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0, max_timeout=20)
         proc.check_kill_and_wait()
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         self.assertTrue(len(output) >= 1)

--- a/metricbeat/tests/system/test_kibana.py
+++ b/metricbeat/tests/system/test_kibana.py
@@ -19,6 +19,7 @@ class Test(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0, max_timeout=20)
         proc.check_kill_and_wait()
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         self.assertTrue(len(output) >= 1)

--- a/metricbeat/tests/system/test_memcached.py
+++ b/metricbeat/tests/system/test_memcached.py
@@ -19,6 +19,7 @@ class Test(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0, max_timeout=20)
         proc.check_kill_and_wait()
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         self.assertTrue(len(output) >= 1)

--- a/metricbeat/tests/system/test_mongodb.py
+++ b/metricbeat/tests/system/test_mongodb.py
@@ -23,10 +23,7 @@ class Test(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0)
         proc.check_kill_and_wait()
-
-        # Ensure no errors or warnings exist in the log.
-        log = self.get_log()
-        self.assertNotRegexpMatches(log, "ERR|WARN")
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         self.assertEqual(len(output), 1)

--- a/metricbeat/tests/system/test_mysql.py
+++ b/metricbeat/tests/system/test_mysql.py
@@ -26,10 +26,7 @@ class Test(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0)
         proc.check_kill_and_wait()
-
-        # Ensure no errors or warnings exist in the log.
-        log = self.get_log()
-        self.assertNotRegexpMatches(log, "ERR|WARN")
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         self.assertEqual(len(output), 1)

--- a/metricbeat/tests/system/test_phpfpm.py
+++ b/metricbeat/tests/system/test_phpfpm.py
@@ -21,10 +21,7 @@ class Test(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0)
         proc.check_kill_and_wait()
-
-        # Ensure no errors or warnings exist in the log.
-        log = self.get_log()
-        self.assertNotRegexpMatches(log.replace("WARN BETA", ""), "ERR|WARN")
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         self.assertEqual(len(output), 1)

--- a/metricbeat/tests/system/test_prometheus.py
+++ b/metricbeat/tests/system/test_prometheus.py
@@ -21,10 +21,7 @@ class Test(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0)
         proc.check_kill_and_wait()
-
-        # Ensure no errors or warnings exist in the log.
-        log = self.get_log()
-        self.assertNotRegexpMatches(log.replace("WARN BETA", ""), "ERR|WARN")
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         self.assertEqual(len(output), 1)

--- a/metricbeat/tests/system/test_redis.py
+++ b/metricbeat/tests/system/test_redis.py
@@ -35,10 +35,7 @@ class Test(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0)
         proc.check_kill_and_wait()
-
-        # Ensure no errors or warnings exist in the log.
-        log = self.get_log()
-        self.assertNotRegexpMatches(log, "ERR|WARN")
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         self.assertEqual(len(output), 1)
@@ -71,10 +68,7 @@ class Test(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0)
         proc.check_kill_and_wait()
-
-        # Ensure no errors or warnings exist in the log.
-        log = self.get_log()
-        self.assertNotRegexpMatches(log, "ERR|WARN")
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         self.assertEqual(len(output), 1)
@@ -104,10 +98,7 @@ class Test(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0)
         proc.check_kill_and_wait()
-
-        # Ensure no errors or warnings exist in the log.
-        log = self.get_log()
-        self.assertNotRegexpMatches(log, "ERR|WARN")
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         self.assertEqual(len(output), 1)

--- a/metricbeat/tests/system/test_system.py
+++ b/metricbeat/tests/system/test_system.py
@@ -57,10 +57,7 @@ class Test(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0)
         proc.check_kill_and_wait()
-
-        # Ensure no errors or warnings exist in the log.
-        log = self.get_log()
-        self.assertNotRegexpMatches(log, "ERR|WARN")
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         self.assertEqual(len(output), 1)
@@ -86,10 +83,7 @@ class Test(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0)
         proc.check_kill_and_wait()
-
-        # Ensure no errors or warnings exist in the log.
-        log = self.get_log()
-        self.assertNotRegexpMatches(log, "ERR|WARN")
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         self.assertGreater(len(output), 0)
@@ -112,10 +106,7 @@ class Test(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0)
         proc.check_kill_and_wait()
-
-        # Ensure no errors or warnings exist in the log.
-        log = self.get_log()
-        self.assertNotRegexpMatches(log, "ERR|WARN")
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         self.assertGreater(len(output), 0)
@@ -141,10 +132,7 @@ class Test(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0)
         proc.check_kill_and_wait()
-
-        # Ensure no errors or warnings exist in the log.
-        log = self.get_log()
-        self.assertNotRegexpMatches(log, "ERR|WARN")
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         self.assertGreater(len(output), 0)
@@ -167,10 +155,7 @@ class Test(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0)
         proc.check_kill_and_wait()
-
-        # Ensure no errors or warnings exist in the log.
-        log = self.get_log()
-        self.assertNotRegexpMatches(log, "ERR|WARN")
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         self.assertEqual(len(output), 1)
@@ -193,10 +178,7 @@ class Test(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0)
         proc.check_kill_and_wait()
-
-        # Ensure no errors or warnings exist in the log.
-        log = self.get_log()
-        self.assertNotRegexpMatches(log, "ERR|WARN")
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         self.assertGreater(len(output), 0)
@@ -219,10 +201,7 @@ class Test(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0)
         proc.check_kill_and_wait()
-
-        # Ensure no errors or warnings exist in the log.
-        log = self.get_log()
-        self.assertNotRegexpMatches(log, "ERR|WARN")
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         self.assertGreater(len(output), 0)
@@ -245,10 +224,7 @@ class Test(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0)
         proc.check_kill_and_wait()
-
-        # Ensure no errors or warnings exist in the log.
-        log = self.get_log()
-        self.assertNotRegexpMatches(log, "ERR|WARN")
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         self.assertEqual(len(output), 1)
@@ -271,10 +247,7 @@ class Test(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0)
         proc.check_kill_and_wait()
-
-        # Ensure no errors or warnings exist in the log.
-        log = self.get_log()
-        self.assertNotRegexpMatches(log, "ERR|WARN")
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         self.assertEqual(len(output), 1)
@@ -308,10 +281,7 @@ class Test(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0)
         proc.check_kill_and_wait()
-
-        # Ensure no errors or warnings exist in the log.
-        log = self.get_log()
-        self.assertNotRegexpMatches(log, "ERR|WARN")
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         self.assertGreater(len(output), 0)
@@ -343,10 +313,7 @@ class Test(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0)
         proc.check_kill_and_wait()
-
-        # Ensure no errors or warnings exist in the log.
-        log = self.get_log()
-        self.assertNotRegexpMatches(log, "ERR|WARN")
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         self.assertGreater(len(output), 0)

--- a/metricbeat/tests/system/test_zookeeper.py
+++ b/metricbeat/tests/system/test_zookeeper.py
@@ -29,10 +29,7 @@ class ZooKeeperMntrTest(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0)
         proc.check_kill_and_wait()
-
-        # Ensure no errors or warnings exist in the log.
-        log = self.get_log()
-        self.assertNotRegexpMatches(log, "ERR|WARN")
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         self.assertEqual(len(output), 1)

--- a/packetbeat/tests/system/config/packetbeat.yml.j2
+++ b/packetbeat/tests/system/config/packetbeat.yml.j2
@@ -112,12 +112,10 @@ packetbeat.protocols:
   ports: [{{ thrift_ports|default([9090])|join(", ") }}]
   transport_type: "{{ thrift_transport_type|default('socket') }}"
 {% if thrift_idl_files %}
-  idl_files: [
-      {%- for file in thrift_idl_files -%}
-              "{{ beat.working_dir + '/' + file }}"
-              {%- if not loop.last %}, {% endif -%}
-      {%- endfor -%}
-  ]
+  idl_files:
+  {%- for file in thrift_idl_files %}
+  - '{{ beat.working_dir + '/' + file }}'
+  {%- endfor -%}
 {%- endif %}
 {% if thrift_send_request %}  send_request: true{%- endif %}
 {% if thrift_send_response %}  send_response: true{%- endif %}


### PR DESCRIPTION
A follow up to #4216 to fix some more tests on Windows.

These are the failures being addressed (except the Filebeat ones, those need specialized attention): https://beats-ci.elastic.co/job/elastic+beats+master+tests-windows/4/testReport/

- Using single quotes around Windows paths 	e86d38b
  
  The thrift test config used double quotes around Windows path separators and this was interpreted incorrectly in YAML parsing.

- Use logp.Beta or logp.Experimental in metricsets 	077d508

  And in system tests, centralize the logic for asserting that there are no ERR or WARN in logs.

  Filter out errors about “The service process could not connect to the service controller” that occur when testing on Jenkins where Jenkins itself is running as a service. This confuses the Beat because it thinks that it is running as service, but it’s not.

- Rename TestBadCondition to TestConditions  ab84099

  This test doesn’t actually test any bad conditions. Plus there is another test in the same directory with the name TestBadCondition.