### PR TITLE
Cherrypick multiple doc changes into 5.4 (forward and backports)

### DIFF
--- a/filebeat/docs/how-filebeat-works.asciidoc
+++ b/filebeat/docs/how-filebeat-works.asciidoc
@@ -41,6 +41,8 @@ filebeat.prospectors:
 
 Filebeat currently supports two `prospector` types: `log` and `stdin`. Each prospector type can be defined multiple times. The `log` prospector checks each file to see whether a harvester needs to be started, whether one is already running, or whether the file can be ignored (see <<ignore-older,`ignore_older`>>). New files are only picked up if the size of the file has changed since the harvester was closed.
 
+NOTE: Filebeat prospectors can only read local files. There is no functionality to connect to remote hosts to read stored files or logs.
+
 [float]
 === How Does Filebeat Keep the State of Files?
 

--- a/filebeat/docs/how-filebeat-works.asciidoc
+++ b/filebeat/docs/how-filebeat-works.asciidoc
@@ -39,7 +39,7 @@ filebeat.prospectors:
     - /var/path2/*.log
 -------------------------------------------------------------------------------------
 
-Filebeat currently supports two `prospector` types: `log` and `stdin`. Each prospector type can be defined multiple times. The `log` prospector checks each file to see whether a harvester needs to be started, whether one is already running, or whether the file can be ignored (see <<ignore-older,`ignore_older`>>). New files are only picked up if the size of the file has changed since the harvester was closed.
+Filebeat currently supports two `prospector` types: `log` and `stdin`. Each prospector type can be defined multiple times. The `log` prospector checks each file to see whether a harvester needs to be started, whether one is already running, or whether the file can be ignored (see <<ignore-older,`ignore_older`>>). New lines are only picked up if the size of the file has changed since the harvester was closed.
 
 NOTE: Filebeat prospectors can only read local files. There is no functionality to connect to remote hosts to read stored files or logs.
 

--- a/filebeat/docs/overview.asciidoc
+++ b/filebeat/docs/overview.asciidoc
@@ -1,10 +1,10 @@
 [[filebeat-overview]]
 == Overview
 
-Filebeat is a log data shipper. Installed as an agent on your servers, Filebeat monitors the log directories or specific log files, tails the files,
+Filebeat is a log data shipper for local files. Installed as an agent on your servers, Filebeat monitors the log directories or specific log files, tails the files,
 and forwards them either to https://www.elastic.co/products/elasticsearch[Elasticsearch] or https://www.elastic.co/products/logstash[Logstash] for indexing.
 
-Here's how Filebeat works: When you start Filebeat, it starts one or more prospectors that look in the paths you've specified for log files. For each log file that the prospector locates, Filebeat starts a harvester. Each harvester reads a single log file for new content and sends the new log data to the spooler, which aggregates the events and sends the aggregated data to the output that you've configured for Filebeat.
+Here's how Filebeat works: When you start Filebeat, it starts one or more prospectors that look in the local paths you've specified for log files. For each log file that the prospector locates, Filebeat starts a harvester. Each harvester reads a single log file for new content and sends the new log data to the spooler, which aggregates the events and sends the aggregated data to the output that you've configured for Filebeat.
 
 image:./images/filebeat.png[Beats design]
 

--- a/libbeat/docs/config-file-format.asciidoc
+++ b/libbeat/docs/config-file-format.asciidoc
@@ -351,7 +351,7 @@ writable by the owner but the permissions are "-rw-rw-r--" (to fix the
 permissions use: 'chmod go-w /etc/{beatname}/{beatname}.yml')
 --------------------------------------------------------------------------------
 
-To correct this problem, use `chown go-w /etc/{beatname}/{beatname}.yml` to
+To correct this problem, use `chmod go-w /etc/{beatname}/{beatname}.yml` to
 remove write privileges from anyone other than the owner.
 
 ==== Disabling Strict Permission Checks

--- a/metricbeat/docs/developer-guide/create-module.asciidoc
+++ b/metricbeat/docs/developer-guide/create-module.asciidoc
@@ -15,7 +15,7 @@ metricset by running `make create-metricset`, default versions of these files ar
 * `docs.asciidoc`
 * `fields.yml`
 
-After updating any of these files, make sure you run `make collect` in your beat directory so all generated
+After updating any of these files, make sure you run `make update` in your beat directory so all generated
 files are updated.
 
 

--- a/metricbeat/docs/metricbeat-in-a-container.asciidoc
+++ b/metricbeat/docs/metricbeat-in-a-container.asciidoc
@@ -1,8 +1,23 @@
 [[running-in-container]]
 == Running Metricbeat in a Container
 
-Elastic does not provide any official container images for Metricbeat. The
-examples on this page assume you are using your own Metricbeat container image.
+ifeval::["{release-state}"=="released"]
+
+[NOTE]
+==================================================
+The https://github.com/elastic/beats-docker[official Docker images] for Beats
+are available from the Elastic Docker registry. To retrieve the images, simply
+issue the `docker pull` command:
+
++docker pull docker.elastic.co/beats/metricbeat:{stack-version}+.
+
+The images are currently under development and should be considered
+alpha-quality. We strongly recommend that you do not run these images
+in a production environment.
+
+==================================================
+
+endif::[]
 
 When executing Metricbeat in a container, there are some important
 things to be aware of if you want to monitor the host machine or other
@@ -17,14 +32,14 @@ This example highlights the changes required to make the system module
 work properly inside of a container. This enables Metricbeat to monitor the
 host machine from within the container.
 
-[source,sh]
+["source","sh",subs="attributes"]
 ----
 sudo docker run \
   --volume=/proc:/hostfs/proc:ro \ <1>
   --volume=/sys/fs/cgroup:/hostfs/sys/fs/cgroup:ro \ <2>
   --volume=/:/hostfs:ro \ <3>
   --net=host <4>
-  my/metricbeat:latest -system.hostfs=/hostfs
+  docker.elastic.co/beats/metricbeat:{stack-version} -system.hostfs=/hostfs
 ----
 
 <1> Metricbeat's <<metricbeat-module-system,system module>> collects much of its data through the Linux proc
@@ -54,12 +69,12 @@ to `/hostfs/proc` is not sufficient.
 Next let's look at an example of monitoring a containerized service from a
 Metricbeat container.
 
-[source,sh]
+["source","sh",subs="attributes"]
 ----
 sudo docker run \
   --link some-mysql:mysql \ <1>
   -e MYSQL_PASSWORD=secret \ <2>
-  my/metricbeat:latest
+  docker.elastic.co/beats/metricbeat:{stack-version} 
 ----
 
 <1> Linking the containers enables Metricbeat access the exposed ports of the

--- a/winlogbeat/docs/reference/configuration/winlogbeat-options.asciidoc
+++ b/winlogbeat/docs/reference/configuration/winlogbeat-options.asciidoc
@@ -332,7 +332,7 @@ The hostname and port where the Beat will host an HTTP web service that provides
 metrics. This field is optional.
 
 The following example specifies that the metrics service is available at
-http://localhost:8128/debug/vars:
+http://localhost:8123/debug/vars:
 
 [source,yaml]
 --------------------------------------------------------------------------------


### PR DESCRIPTION
Cherrypicks the following PRs into 5.4:

https://github.com/elastic/beats/pull/4139
https://github.com/elastic/beats/pull/4155
https://github.com/elastic/beats/pull/4179
https://github.com/elastic/beats/pull/4194
https://github.com/elastic/beats/pull/4195
https://github.com/elastic/beats/pull/4196
https://github.com/elastic/beats/pull/4199