### PR TITLE
Fix import dashboards when ulimit -n is low

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -28,6 +28,8 @@ https://github.com/elastic/beats/compare/v6.0.0-alpha1...master[Check the HEAD d
 
 *Affecting all Beats*
 
+- Fix importing the dashboards when the limit for max open files is too low. {issue}4244[4244]
+
 *Filebeat*
 
 *Heartbeat*


### PR DESCRIPTION
The unzip routine was deferring close functions in a loop, so it kept
each file open. This adds a closure so the files are closed immediately.

Fixes #4244.

This also improves the error handling to always report the original error.