### PR TITLE
Fix broken doc build by changing kubernetes processor

### DIFF
--- a/libbeat/processors/kubernetes/_meta/fields.yml
+++ b/libbeat/processors/kubernetes/_meta/fields.yml
@@ -2,6 +2,7 @@
   title: Kubernetes info
   description: >
     Kubernetes metadata added by the kubernetes processor
+  anchor: kubernetes-processor
   fields:
     - name: kubernetes.pod.name
       type: keyword

--- a/libbeat/scripts/generate_fields_docs.py
+++ b/libbeat/scripts/generate_fields_docs.py
@@ -94,7 +94,8 @@ grouped in the following categories:
     # Sort alphabetically by key
     for section in sorted(docs, key=lambda field: field["key"]):
         section["name"] = section["title"]
-        section["anchor"] = section["key"]
+        if "anchor" not in section:
+            section["anchor"] = section["key"]
         document_fields(output, section, sections, "")
 
 

--- a/metricbeat/docs/fields.asciidoc
+++ b/metricbeat/docs/fields.asciidoc
@@ -3863,7 +3863,7 @@ type: long
 Total number of connections.
 
 
-[[exported-fields-kubernetes]]
+[[exported-fields-kubernetes-processor]]
 == Kubernetes info Fields
 
 Kubernetes metadata added by the kubernetes processor


### PR DESCRIPTION
The doc build was broken because the kuberentes reference existed twice. As we now start to have overlapping fields between libbeat and metricbeat for example, we most find a good solution on how we generate docs to prevent naming conflicts.