### PR TITLE
Fix doc build links

### DIFF
--- a/filebeat/docs/fields.asciidoc
+++ b/filebeat/docs/fields.asciidoc
@@ -17,7 +17,7 @@ grouped in the following categories:
 * <<exported-fields-beat>>
 * <<exported-fields-cloud>>
 * <<exported-fields-icinga>>
-* <<exported-fields-kubernetes>>
+* <<exported-fields-kubernetes-processor>>
 * <<exported-fields-log>>
 * <<exported-fields-mysql>>
 * <<exported-fields-nginx>>
@@ -683,7 +683,7 @@ type: text
 The logged message.
 
 
-[[exported-fields-kubernetes]]
+[[exported-fields-kubernetes-processor]]
 == Kubernetes info Fields
 
 Kubernetes metadata added by the kubernetes processor

--- a/heartbeat/docs/fields.asciidoc
+++ b/heartbeat/docs/fields.asciidoc
@@ -17,7 +17,7 @@ grouped in the following categories:
 * <<exported-fields-common>>
 * <<exported-fields-http>>
 * <<exported-fields-icmp>>
-* <<exported-fields-kubernetes>>
+* <<exported-fields-kubernetes-processor>>
 * <<exported-fields-resolve>>
 * <<exported-fields-socks5>>
 * <<exported-fields-tcp>>
@@ -410,7 +410,7 @@ type: long
 
 Duration in microseconds
 
-[[exported-fields-kubernetes]]
+[[exported-fields-kubernetes-processor]]
 == Kubernetes info Fields
 
 Kubernetes metadata added by the kubernetes processor

--- a/libbeat/scripts/generate_fields_docs.py
+++ b/libbeat/scripts/generate_fields_docs.py
@@ -87,8 +87,11 @@ grouped in the following categories:
     for v in docs:
         sections[v["key"]] = v["title"]
 
-    for key in sorted(sections):
-        output.write("* <<exported-fields-{}>>\n".format(key))
+    for section in sorted(docs, key=lambda field: field["key"]):
+        if "anchor" not in section:
+            section["anchor"] = section["key"]
+
+        output.write("* <<exported-fields-{}>>\n".format(section["anchor"]))
     output.write("\n--\n")
 
     # Sort alphabetically by key

--- a/metricbeat/docs/fields.asciidoc
+++ b/metricbeat/docs/fields.asciidoc
@@ -27,6 +27,7 @@ grouped in the following categories:
 * <<exported-fields-jolokia>>
 * <<exported-fields-kafka>>
 * <<exported-fields-kibana>>
+* <<exported-fields-kubernetes-processor>>
 * <<exported-fields-kubernetes>>
 * <<exported-fields-memcached>>
 * <<exported-fields-mongodb>>

--- a/packetbeat/docs/fields.asciidoc
+++ b/packetbeat/docs/fields.asciidoc
@@ -21,7 +21,7 @@ grouped in the following categories:
 * <<exported-fields-flows_event>>
 * <<exported-fields-http>>
 * <<exported-fields-icmp>>
-* <<exported-fields-kubernetes>>
+* <<exported-fields-kubernetes-processor>>
 * <<exported-fields-memcache>>
 * <<exported-fields-mongodb>>
 * <<exported-fields-mysql>>
@@ -1902,7 +1902,7 @@ type: long
 
 The response code.
 
-[[exported-fields-kubernetes]]
+[[exported-fields-kubernetes-processor]]
 == Kubernetes info Fields
 
 Kubernetes metadata added by the kubernetes processor

--- a/winlogbeat/docs/fields.asciidoc
+++ b/winlogbeat/docs/fields.asciidoc
@@ -16,7 +16,7 @@ grouped in the following categories:
 * <<exported-fields-cloud>>
 * <<exported-fields-common>>
 * <<exported-fields-eventlog>>
-* <<exported-fields-kubernetes>>
+* <<exported-fields-kubernetes-processor>>
 
 --
 [[exported-fields-beat]]
@@ -428,7 +428,7 @@ The raw XML representation of the event obtained from Windows. This field is onl
 The XML representation of the event is useful for troubleshooting purposes. The data in the fields reported by Winlogbeat can be compared to the data in the XML to diagnose problems.
 
 
-[[exported-fields-kubernetes]]
+[[exported-fields-kubernetes-processor]]
 == Kubernetes info Fields
 
 Kubernetes metadata added by the kubernetes processor


### PR DESCRIPTION
Because of the renaming of the processing anchor, some of the links were generated wrongly in the Beats.