### PR TITLE
Cherry-pick #4246 to 5.4: Fix import dashboards when ulimit -n is low

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -29,6 +29,8 @@ https://github.com/elastic/beats/compare/v5.3.0...master[Check the HEAD diff]
 *Affecting all Beats*
 - Fix console output {pull}4045[4045]
 
+- Fix importing the dashboards when the limit for max open files is too low. {issue}4244[4244]
+
 *Filebeat*
 - Fix grok pattern in filebeat module system/auth without hostname. {pull}4224[4224]
 

--- a/libbeat/dashboards/dashboards/importer.go
+++ b/libbeat/dashboards/dashboards/importer.go
@@ -73,7 +73,12 @@ func (imp Importer) Import() error {
 // some index properties which are needed as a workaround for:
 // https://github.com/elastic/beats-dashboards/issues/94
 func (imp Importer) CreateKibanaIndex() error {
-	imp.client.CreateIndex(imp.cfg.KibanaIndex, nil)
+	imp.client.CreateIndex(imp.cfg.KibanaIndex,
+		common.MapStr{
+			"settings": common.MapStr{
+				"index.mapping.single_type": false,
+			},
+		})
 	_, _, err := imp.client.CreateIndex(imp.cfg.KibanaIndex+"/_mapping/search",
 		common.MapStr{
 			"search": common.MapStr{
@@ -88,7 +93,7 @@ func (imp Importer) CreateKibanaIndex() error {
 			},
 		})
 	if err != nil {
-		fmt.Fprintln(os.Stderr, fmt.Sprintf("Failed to set the mapping - %s", err))
+		imp.statusMsg("Failed to set the mapping: %v", err)
 	}
 	return nil
 }
@@ -355,12 +360,13 @@ func (imp Importer) unzip(archive, target string) error {
 		return err
 	}
 
-	for _, file := range reader.File {
+	// Closure to close the files on each iteration
+	unzipFile := func(file *zip.File) error {
 		filePath := filepath.Join(target, file.Name)
 
 		if file.FileInfo().IsDir() {
 			os.MkdirAll(filePath, file.Mode())
-			continue
+			return nil
 		}
 		fileReader, err := file.Open()
 		if err != nil {
@@ -377,6 +383,14 @@ func (imp Importer) unzip(archive, target string) error {
 		if _, err := io.Copy(targetFile, fileReader); err != nil {
 			return err
 		}
+		return nil
+	}
+
+	for _, file := range reader.File {
+		err := unzipFile(file)
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -387,16 +401,16 @@ func (imp Importer) ImportArchive() error {
 
 	target, err := ioutil.TempDir("", "tmp")
 	if err != nil {
-		return errors.New("Failed to generate a temporary directory name")
+		return fmt.Errorf("Failed to generate a temporary directory name: %v", err)
 	}
 
 	if err = os.MkdirAll(target, 0755); err != nil {
-		return fmt.Errorf("Failed to create a temporary directory: %v", target)
+		return fmt.Errorf("Failed to create a temporary directory %s: %v", target, err)
 	}
 
 	defer os.RemoveAll(target) // clean up
 
-	imp.statusMsg("Create temporary directory %s", target)
+	imp.statusMsg("Created temporary directory %s", target)
 	if imp.cfg.File != "" {
 		archive = imp.cfg.File
 	} else if imp.cfg.Snapshot {
@@ -417,7 +431,7 @@ func (imp Importer) ImportArchive() error {
 
 	err = imp.unzip(archive, target)
 	if err != nil {
-		return fmt.Errorf("Failed to unzip the archive: %s", archive)
+		return fmt.Errorf("Failed to unzip the archive: %s: %v", archive, err)
 	}
 	dirs, err := getDirectories(target)
 	if err != nil {


### PR DESCRIPTION
Cherry-pick of PR #4246 to 5.4 branch. Original message: 

The unzip routine was deferring close functions in a loop, so it kept
each file open. This adds a closure so the files are closed immediately.

Fixes #4244.

This also improves the error handling to always report the original error.