### PR TITLE
Fallback on LevelRaw If the Level is not in the RenderingInfo section of the event

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -54,6 +54,7 @@ https://github.com/elastic/beats/compare/v5.3.0...master[Check the HEAD diff]
 *Packetbeat*
 
 *Winlogbeat*
+- Add the ability to use LevelRaw if Level isn't populated in the event XML. {pull}4257[4257]
 
 ==== Deprecated
 
@@ -69,7 +70,7 @@ https://github.com/elastic/beats/compare/v5.3.0...master[Check the HEAD diff]
 
 *Winlogbeat*
 
-==== Knwon Issue
+==== Known Issue
 
 *Affecting all Beats*
 

--- a/winlogbeat/eventlog/wineventlog.go
+++ b/winlogbeat/eventlog/wineventlog.go
@@ -11,7 +11,6 @@ import (
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/winlogbeat/sys"
-	"github.com/elastic/beats/winlogbeat/sys/wineventlog"
 	win "github.com/elastic/beats/winlogbeat/sys/wineventlog"
 	"github.com/joeshaw/multierror"
 	"github.com/pkg/errors"
@@ -218,8 +217,8 @@ func (l *winEventLog) buildRecordFromXML(x []byte, recoveredErr error) (Record, 
 	}
 
 	if e.Level == "" {
-		//Let's fallback on LevelRaw if the level is not set in the RenderingInfo
-		e.Level = wineventlog.EventLevel(e.LevelRaw).String()
+		// Fallback on LevelRaw if the Level is not set in the RenderingInfo.
+		e.Level = win.EventLevel(e.LevelRaw).String()
 	}
 
 	if logp.IsDebug(detailSelector) {

--- a/winlogbeat/eventlog/wineventlog.go
+++ b/winlogbeat/eventlog/wineventlog.go
@@ -11,6 +11,7 @@ import (
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/winlogbeat/sys"
+	"github.com/elastic/beats/winlogbeat/sys/wineventlog"
 	win "github.com/elastic/beats/winlogbeat/sys/wineventlog"
 	"github.com/joeshaw/multierror"
 	"github.com/pkg/errors"
@@ -214,6 +215,11 @@ func (l *winEventLog) buildRecordFromXML(x []byte, recoveredErr error) (Record, 
 		e.RenderErr = syscall.Errno(e.RenderErrorCode).Error()
 	} else if recoveredErr != nil {
 		e.RenderErr = recoveredErr.Error()
+	}
+
+	if e.Level == "" {
+		//Let's fallback on LevelRaw if the level is not set in the RenderingInfo
+		e.Level = wineventlog.EventLevel(e.LevelRaw).String()
 	}
 
 	if logp.IsDebug(detailSelector) {

--- a/winlogbeat/sys/wineventlog/syscall_windows.go
+++ b/winlogbeat/sys/wineventlog/syscall_windows.go
@@ -194,6 +194,35 @@ func (e EvtSystemPropertyID) String() string {
 	return s
 }
 
+// EventLevel identifies the six levels of events that can be logged
+type EventLevel uint16
+
+// EventLevel values.
+const (
+	// Do not reorder.
+	EVENTLOG_LOGALWAYS_LEVEL EventLevel = iota
+	EVENTLOG_CRITICAL_LEVEL
+	EVENTLOG_ERROR_LEVEL
+	EVENTLOG_WARNING_LEVEL
+	EVENTLOG_INFORMATION_LEVEL
+	EVENTLOG_VERBOSE_LEVEL
+)
+
+// Mapping of event levels to their string representations.
+var EventLevelToString = map[EventLevel]string{
+	EVENTLOG_LOGALWAYS_LEVEL:   "Information",
+	EVENTLOG_INFORMATION_LEVEL: "Information",
+	EVENTLOG_CRITICAL_LEVEL:    "Critical",
+	EVENTLOG_ERROR_LEVEL:       "Error",
+	EVENTLOG_WARNING_LEVEL:     "Warning",
+	EVENTLOG_VERBOSE_LEVEL:     "Verbose",
+}
+
+// String returns string representation of EventLevel.
+func (et EventLevel) String() string {
+	return EventLevelToString[et]
+}
+
 // Add -trace to enable debug prints around syscalls.
 //go:generate go run $GOROOT/src/syscall/mksyscall_windows.go -output zsyscall_windows.go syscall_windows.go
 


### PR DESCRIPTION
Applies to Windows Vista and above only.

https://discuss.elastic.co/t/event-fields-missing-if-renderinginfo-is-empty/84709
