### PR TITLE
Add 5x build for cross version testing

### DIFF
--- a/testing/environments/5x.yml
+++ b/testing/environments/5x.yml
@@ -1,4 +1,4 @@
-# This is the latest stable release environment.
+# This is the latest stable 5x release environment.
 
 version: '2.1'
 services:


### PR DESCRIPTION
We have a 2x build to test against 2.x ES and LS. This 5x test environment is to test 6.x against 5.x.

A new jenkins job should be created to run these tests.