### PR TITLE
Fail build if one of the docs builds fail

### DIFF
--- a/libbeat/scripts/build_docs.sh
+++ b/libbeat/scripts/build_docs.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 # Checks if docs clone already exists
 if [ ! -d "build/docs" ]; then
     # Only head is cloned


### PR DESCRIPTION
On jenkins some of the builds went green even though the doc builds failed. This should fix it.