### PR TITLE
Fix Metricbeat module debug statement

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -35,6 +35,7 @@ https://github.com/elastic/beats/compare/v6.0.0-alpha1...master[Check the HEAD d
 *Heartbeat*
 
 *Metricbeat*
+- Fix a debug statement that said a module wrapper had stopped when it hadn't. {pull}4264[4264]
 
 *Packetbeat*
 
@@ -71,7 +72,7 @@ https://github.com/elastic/beats/compare/v6.0.0-alpha1...master[Check the HEAD d
 
 *Winlogbeat*
 
-==== Knwon Issue
+==== Known Issue
 
 
 ////////////////////////////////////////////////////////////
@@ -192,7 +193,7 @@ https://github.com/elastic/beats/compare/v5.4.0...v6.0.0-alpha1[View commits]
 
 *Winlogbeat*
 
-==== Knwon Issue
+==== Known Issue
 
 *Filebeat*
 

--- a/metricbeat/mb/module/wrapper.go
+++ b/metricbeat/mb/module/wrapper.go
@@ -131,7 +131,6 @@ func NewWrappers(modulesConfig []*common.Config, r *mb.Register) ([]*Wrapper, er
 // Start should be called only once in the life of a Wrapper.
 func (mw *Wrapper) Start(done <-chan struct{}) <-chan common.MapStr {
 	debugf("Starting %s", mw)
-	defer debugf("Stopped %s", mw)
 
 	out := make(chan common.MapStr, 1)
 
@@ -151,6 +150,7 @@ func (mw *Wrapper) Start(done <-chan struct{}) <-chan common.MapStr {
 	go func() {
 		wg.Wait()
 		close(out)
+		debugf("Stopped %s", mw)
 	}()
 
 	return out


### PR DESCRIPTION
The "Stopped Wrapper" statement was logged at the wrong time.

    2017-05-09T09:35:52-04:00 DBG Starting Wrapper[name=system, len(metricSetWrappers)=3]
    2017-05-09T09:35:52-04:00 DBG Stopped Wrapper[name=system, len(metricSetWrappers)=3]
    2017-05-09T09:35:52-04:00 DBG Starting metricSetWrapper[module=system, name=cpu, host=]
    2017-05-09T09:35:52-04:00 DBG Starting metricSetWrapper[module=system, name=process, host=]
    2017-05-09T09:35:52-04:00 DBG Starting metricSetWrapper[module=system, name=memory, host=]