### PR TITLE
Fix repositories in docs

### DIFF
--- a/libbeat/docs/repositories.asciidoc
+++ b/libbeat/docs/repositories.asciidoc
@@ -49,11 +49,11 @@ wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | sudo apt-key add
 sudo apt-get install apt-transport-https
 --------------------------------------------------
 
-. Save the repository definition to  +/etc/apt/sources.list.d/elastic-5.x.list+:
+. Save the repository definition to  +/etc/apt/sources.list.d/elastic-6.x-prerelease.list+:
 +
 ["source","sh",subs="attributes,callouts"]
 --------------------------------------------------
-echo "deb https://artifacts.elastic.co/packages/5.x/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-5.x.list
+echo "deb https://artifacts.elastic.co/packages/6.x-prerelease/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-6.x-prerelease.list
 --------------------------------------------------
 +
 [WARNING]
@@ -127,9 +127,9 @@ your `/etc/yum.repos.d/` directory and add the following lines:
 +
 ["source","sh",subs="attributes,callouts"]
 --------------------------------------------------
-[elastic-5.x]
-name=Elastic repository for 5.x packages
-baseurl=https://artifacts.elastic.co/packages/5.x/yum
+[elastic-6.x-prerelease]
+name=Elastic repository for 6.x prerelease packages
+baseurl=https://artifacts.elastic.co/packages/6.x-prerelease/yum
 gpgcheck=1
 gpgkey=https://artifacts.elastic.co/GPG-KEY-elasticsearch
 enabled=1


### PR DESCRIPTION
To use 6.x-prerelease. This should be updated to either use the `:release-status:`
variable or changed to 6.x once we reach GA.