### PR TITLE
Remove OS specific error message check from mockbeat

### DIFF
--- a/libbeat/tests/system/test_base.py
+++ b/libbeat/tests/system/test_base.py
@@ -27,7 +27,6 @@ class Test(BaseTest):
 
         assert exit_code == 1
         assert self.log_contains("error loading config file") is True
-        assert self.log_contains("no such file or directory") is True
 
     def test_invalid_config(self):
         """


### PR DESCRIPTION
The error message “no such file or directory” is an OS specific error message. There is a different error message on Windows. Simply checking for “error loading config file” should be sufficient.