### PR TITLE
Use shorter filename in Filebeat test for Windows

### DIFF
--- a/filebeat/tests/system/test_prospector.py
+++ b/filebeat/tests/system/test_prospector.py
@@ -485,16 +485,17 @@ class Test(BaseTest):
         Test that close_inactive still applies also if file was rotated,
         new file created, and rotated file removed.
         """
+        log_path = os.path.abspath(os.path.join(self.working_dir, "log"))
+        os.mkdir(log_path)
+        testfile = os.path.join(log_path, "a.log")
+        renamed_file = os.path.join(log_path, "b.log")
+
         self.render_config_template(
-            path=os.path.abspath(self.working_dir) + "/log/test.log",
+            path=testfile,
             ignore_older="1h",
             close_inactive="3s",
             scan_frequency="0.1s",
         )
-
-        os.mkdir(self.working_dir + "/log/")
-        testfile = self.working_dir + "/log/test.log"
-        renamed_file = self.working_dir + "/log/test_renamed.log"
 
         filebeat = self.start_beat()
 


### PR DESCRIPTION
The test was failing on Windows when `os.rename` failed with `[Error 3] The system cannot find the path specified`. The root cause of the failure was that the path was ~260 characters on Jenkins which is greater than the `MAX_PATH` value in Windows. This PR shortens the test log’s name to resolve the issue.

The other changes to normalize the filepath are nice to have for Windows, but not strictly required.