### PR TITLE
Add filesystem name to test error message

### DIFF
--- a/metricbeat/module/system/filesystem/helper_test.go
+++ b/metricbeat/module/system/filesystem/helper_test.go
@@ -32,7 +32,7 @@ func TestFileSystemList(t *testing.T) {
 			continue
 		}
 
-		if assert.NoError(t, err, "%v", err) {
+		if assert.NoError(t, err, "filesystem=%v: %v", fs, err) {
 			assert.True(t, (stat.Total >= 0))
 			assert.True(t, (stat.Free >= 0))
 			assert.True(t, (stat.Avail >= 0))


### PR DESCRIPTION
Errors that are logged by the system/filesystem test case don’t have enough context to debug them. This adds the filesystem that caused the error to the message.