### PR TITLE
Move prospector log to its own package

### DIFF
--- a/filebeat/harvester/util_test.go
+++ b/filebeat/harvester/util_test.go
@@ -32,3 +32,24 @@ func TestMatchAnyRegexps(t *testing.T) {
 	assert.Equal(t, MatchAny(matchers, "/var/log/log.gz"), true)
 
 }
+
+func TestExcludeLine(t *testing.T) {
+	regexp, err := InitMatchers("^DBG")
+	assert.Nil(t, err)
+	assert.True(t, MatchAny(regexp, "DBG: a debug message"))
+	assert.False(t, MatchAny(regexp, "ERR: an error message"))
+}
+
+func TestIncludeLine(t *testing.T) {
+	regexp, err := InitMatchers("^ERR", "^WARN")
+
+	assert.Nil(t, err)
+	assert.False(t, MatchAny(regexp, "DBG: a debug message"))
+	assert.True(t, MatchAny(regexp, "ERR: an error message"))
+	assert.True(t, MatchAny(regexp, "WARNING: a simple warning message"))
+}
+
+func TestInitRegexp(t *testing.T) {
+	_, err := InitMatchers("(((((")
+	assert.NotNil(t, err)
+}

--- a/filebeat/prospector/config.go
+++ b/filebeat/prospector/config.go
@@ -1,55 +1,19 @@
 package prospector
 
 import (
-	"fmt"
 	"time"
 
 	cfg "github.com/elastic/beats/filebeat/config"
-	"github.com/elastic/beats/libbeat/common/match"
 )
 
 var (
 	defaultConfig = prospectorConfig{
-		Enabled:        true,
-		IgnoreOlder:    0,
-		ScanFrequency:  10 * time.Second,
-		InputType:      cfg.DefaultInputType,
-		CleanInactive:  0,
-		CleanRemoved:   true,
-		HarvesterLimit: 0,
-		Symlinks:       false,
-		TailFiles:      false,
+		ScanFrequency: 10 * time.Second,
+		InputType:     cfg.DefaultInputType,
 	}
 )
 
 type prospectorConfig struct {
-	Enabled        bool            `config:"enabled"`
-	ExcludeFiles   []match.Matcher `config:"exclude_files"`
-	IgnoreOlder    time.Duration   `config:"ignore_older"`
-	Paths          []string        `config:"paths"`
-	ScanFrequency  time.Duration   `config:"scan_frequency" validate:"min=0,nonzero"`
-	InputType      string          `config:"input_type"`
-	CleanInactive  time.Duration   `config:"clean_inactive" validate:"min=0"`
-	CleanRemoved   bool            `config:"clean_removed"`
-	HarvesterLimit uint64          `config:"harvester_limit" validate:"min=0"`
-	Symlinks       bool            `config:"symlinks"`
-	TailFiles      bool            `config:"tail_files"`
-	recursiveGlob  bool            `config:"recursive_glob.enabled"`
-}
-
-func (config *prospectorConfig) Validate() error {
-
-	if config.InputType == cfg.LogInputType && len(config.Paths) == 0 {
-		return fmt.Errorf("No paths were defined for prospector")
-	}
-
-	if config.CleanInactive != 0 && config.IgnoreOlder == 0 {
-		return fmt.Errorf("ignore_older must be enabled when clean_inactive is used")
-	}
-
-	if config.CleanInactive != 0 && config.CleanInactive <= config.IgnoreOlder+config.ScanFrequency {
-		return fmt.Errorf("clean_inactive must be > ignore_older + scan_frequency to make sure only files which are not monitored anymore are removed")
-	}
-
-	return nil
+	ScanFrequency time.Duration `config:"scan_frequency" validate:"min=0,nonzero"`
+	InputType     string        `config:"input_type"`
 }

--- a/filebeat/prospector/log/config_test.go
+++ b/filebeat/prospector/log/config_test.go
@@ -1,6 +1,6 @@
 // +build !integration
 
-package prospector
+package log
 
 import (
 	"testing"
@@ -12,7 +12,7 @@ import (
 
 func TestCleanOlderError(t *testing.T) {
 
-	config := prospectorConfig{
+	config := config{
 		CleanInactive: 10 * time.Hour,
 	}
 
@@ -22,7 +22,7 @@ func TestCleanOlderError(t *testing.T) {
 
 func TestCleanOlderIgnoreOlderError(t *testing.T) {
 
-	config := prospectorConfig{
+	config := config{
 		CleanInactive: 10 * time.Hour,
 		IgnoreOlder:   15 * time.Hour,
 	}
@@ -33,7 +33,7 @@ func TestCleanOlderIgnoreOlderError(t *testing.T) {
 
 func TestCleanOlderIgnoreOlderErrorEqual(t *testing.T) {
 
-	config := prospectorConfig{
+	config := config{
 		CleanInactive: 10 * time.Hour,
 		IgnoreOlder:   10 * time.Hour,
 	}
@@ -44,9 +44,11 @@ func TestCleanOlderIgnoreOlderErrorEqual(t *testing.T) {
 
 func TestCleanOlderIgnoreOlder(t *testing.T) {
 
-	config := prospectorConfig{
+	config := config{
 		CleanInactive: 10*time.Hour + defaultConfig.ScanFrequency + 1*time.Second,
 		IgnoreOlder:   10 * time.Hour,
+		InputType:     "log",
+		Paths:         []string{"hello"},
 	}
 
 	err := config.Validate()

--- a/filebeat/prospector/log/harvester.go
+++ b/filebeat/prospector/log/harvester.go
@@ -9,7 +9,7 @@
 //  line. As soon as the line is completed, it is read and returned.
 //
 //  The stdin harvesters reads data from stdin.
-package harvester
+package log
 
 import (
 	"errors"
@@ -18,7 +18,7 @@ import (
 
 	"github.com/satori/go.uuid"
 
-	"github.com/elastic/beats/filebeat/config"
+	cfg "github.com/elastic/beats/filebeat/config"
 	"github.com/elastic/beats/filebeat/harvester/encoding"
 	"github.com/elastic/beats/filebeat/harvester/source"
 	"github.com/elastic/beats/filebeat/input/file"
@@ -43,7 +43,7 @@ type Outlet interface {
 }
 
 type Harvester struct {
-	config          harvesterConfig
+	config          config
 	state           file.State
 	states          *file.States
 	file            source.FileSource /* the file being watched */
@@ -59,7 +59,7 @@ type Harvester struct {
 }
 
 func NewHarvester(
-	cfg *common.Config,
+	config *common.Config,
 	state file.State,
 	states *file.States,
 	outlet Outlet,
@@ -75,7 +75,7 @@ func NewHarvester(
 		ID:     uuid.NewV4(),
 	}
 
-	if err := cfg.Unpack(&h.config); err != nil {
+	if err := config.Unpack(&h.config); err != nil {
 		return nil, err
 	}
 
@@ -107,12 +107,12 @@ func NewHarvester(
 func (h *Harvester) open() error {
 
 	switch h.config.InputType {
-	case config.StdinInputType:
+	case cfg.StdinInputType:
 		return h.openStdin()
-	case config.LogInputType:
+	case cfg.LogInputType:
 		return h.openFile()
 	default:
-		return fmt.Errorf("Invalid input type")
+		return fmt.Errorf("Invalid harvester type: %+v", h.config)
 	}
 }
 

--- a/filebeat/prospector/log/harvester_test.go
+++ b/filebeat/prospector/log/harvester_test.go
@@ -1,3 +1,3 @@
 // +build !integration
 
-package harvester
+package log

--- a/filebeat/prospector/log/json_test.go
+++ b/filebeat/prospector/log/json_test.go
@@ -1,4 +1,4 @@
-package harvester
+package log
 
 import (
 	"testing"

--- a/filebeat/prospector/log/log_file.go
+++ b/filebeat/prospector/log/log_file.go
@@ -1,4 +1,4 @@
-package harvester
+package log
 
 import (
 	"io"
@@ -13,7 +13,7 @@ import (
 type LogFile struct {
 	fs           source.FileSource
 	offset       int64
-	config       harvesterConfig
+	config       config
 	lastTimeRead time.Time
 	backoff      time.Duration
 	done         chan struct{}
@@ -21,7 +21,7 @@ type LogFile struct {
 
 func NewLogFile(
 	fs source.FileSource,
-	config harvesterConfig,
+	config config,
 ) (*LogFile, error) {
 	var offset int64
 	if seeker, ok := fs.(io.Seeker); ok {

--- a/filebeat/prospector/log/log_test.go
+++ b/filebeat/prospector/log/log_test.go
@@ -1,6 +1,6 @@
 // +build !integration
 
-package harvester
+package log
 
 import (
 	"fmt"
@@ -20,7 +20,7 @@ import (
 
 func TestReadLine(t *testing.T) {
 
-	absPath, err := filepath.Abs("../tests/files/logs/")
+	absPath, err := filepath.Abs("../../tests/files/logs/")
 	// All files starting with tmp are ignored
 	logFile := absPath + "/tmp" + strconv.Itoa(rand.Int()) + ".log"
 
@@ -59,7 +59,7 @@ func TestReadLine(t *testing.T) {
 	f := source.File{File: readFile}
 
 	h := Harvester{
-		config: harvesterConfig{
+		config: config{
 			CloseInactive: 500 * time.Millisecond,
 			Backoff:       100 * time.Millisecond,
 			MaxBackoff:    1 * time.Second,
@@ -100,27 +100,6 @@ func TestReadLine(t *testing.T) {
 	assert.Equal(t, "", text)
 	assert.Equal(t, bytesread, 0)
 	assert.Equal(t, err, ErrInactive)
-}
-
-func TestExcludeLine(t *testing.T) {
-	regexp, err := InitMatchers("^DBG")
-	assert.Nil(t, err)
-	assert.True(t, MatchAny(regexp, "DBG: a debug message"))
-	assert.False(t, MatchAny(regexp, "ERR: an error message"))
-}
-
-func TestIncludeLine(t *testing.T) {
-	regexp, err := InitMatchers("^ERR", "^WARN")
-
-	assert.Nil(t, err)
-	assert.False(t, MatchAny(regexp, "DBG: a debug message"))
-	assert.True(t, MatchAny(regexp, "ERR: an error message"))
-	assert.True(t, MatchAny(regexp, "WARNING: a simple warning message"))
-}
-
-func TestInitRegexp(t *testing.T) {
-	_, err := InitMatchers("(((((")
-	assert.NotNil(t, err)
 }
 
 // readLine reads a full line into buffer and returns it.

--- a/filebeat/prospector/log/prospector_other_test.go
+++ b/filebeat/prospector/log/prospector_other_test.go
@@ -1,6 +1,6 @@
 // +build !windows
 
-package prospector
+package log
 
 import (
 	"testing"
@@ -61,14 +61,14 @@ func TestMatchFile(t *testing.T) {
 
 	for _, test := range matchTests {
 
-		l := Log{
-			config: prospectorConfig{
+		p := Prospector{
+			config: config{
 				Paths:        test.paths,
 				ExcludeFiles: test.excludeFiles,
 			},
 		}
 
-		assert.Equal(t, test.result, l.matchesFile(test.file))
+		assert.Equal(t, test.result, p.matchesFile(test.file))
 	}
 }
 
@@ -130,8 +130,8 @@ var initStateTests = []struct {
 func TestInit(t *testing.T) {
 
 	for _, test := range initStateTests {
-		l := Log{
-			config: prospectorConfig{
+		p := Prospector{
+			config: config{
 				Paths: test.paths,
 			},
 			states: &file.States{},
@@ -144,9 +144,9 @@ func TestInit(t *testing.T) {
 			test.states[i] = state
 		}
 
-		err := l.loadStates(test.states)
+		err := p.loadStates(test.states)
 		assert.NoError(t, err)
-		assert.Equal(t, test.count, l.states.Count())
+		assert.Equal(t, test.count, p.states.Count())
 	}
 
 }

--- a/filebeat/prospector/log/prospector_test.go
+++ b/filebeat/prospector/log/prospector_test.go
@@ -1,6 +1,6 @@
 // +build !integration
 
-package prospector
+package log
 
 import (
 	"os"
@@ -14,8 +14,8 @@ import (
 
 func TestProspectorFileExclude(t *testing.T) {
 
-	p := Log{
-		config: prospectorConfig{
+	p := Prospector{
+		config: config{
 			ExcludeFiles: []match.Matcher{match.MustCompile(`\.gz$`)},
 		},
 	}
@@ -50,8 +50,8 @@ func TestIsCleanInactive(t *testing.T) {
 
 	for _, test := range cleanInactiveTests {
 
-		l := Log{
-			config: prospectorConfig{
+		l := Prospector{
+			config: config{
 				CleanInactive: test.cleanInactive,
 			},
 		}

--- a/filebeat/prospector/log/prospector_windows_test.go
+++ b/filebeat/prospector/log/prospector_windows_test.go
@@ -1,6 +1,6 @@
 // +build !integration
 
-package prospector
+package log
 
 import (
 	"testing"
@@ -59,13 +59,13 @@ func TestMatchFileWindows(t *testing.T) {
 
 	for _, test := range matchTestsWindows {
 
-		l := Log{
-			config: prospectorConfig{
+		p := Prospector{
+			config: config{
 				Paths:        test.paths,
 				ExcludeFiles: test.excludeFiles,
 			},
 		}
 
-		assert.Equal(t, test.result, l.matchesFile(test.file))
+		assert.Equal(t, test.result, p.matchesFile(test.file))
 	}
 }

--- a/filebeat/prospector/log/registry.go
+++ b/filebeat/prospector/log/registry.go
@@ -1,32 +1,31 @@
-package prospector
+package log
 
 import (
 	"sync"
 
-	"github.com/elastic/beats/filebeat/harvester"
 	"github.com/elastic/beats/filebeat/harvester/reader"
 	uuid "github.com/satori/go.uuid"
 )
 
 type harvesterRegistry struct {
 	sync.Mutex
-	harvesters map[uuid.UUID]*harvester.Harvester
+	harvesters map[uuid.UUID]*Harvester
 	wg         sync.WaitGroup
 }
 
 func newHarvesterRegistry() *harvesterRegistry {
 	return &harvesterRegistry{
-		harvesters: map[uuid.UUID]*harvester.Harvester{},
+		harvesters: map[uuid.UUID]*Harvester{},
 	}
 }
 
-func (hr *harvesterRegistry) add(h *harvester.Harvester) {
+func (hr *harvesterRegistry) add(h *Harvester) {
 	hr.Lock()
 	defer hr.Unlock()
 	hr.harvesters[h.ID] = h
 }
 
-func (hr *harvesterRegistry) remove(h *harvester.Harvester) {
+func (hr *harvesterRegistry) remove(h *Harvester) {
 	hr.Lock()
 	defer hr.Unlock()
 	delete(hr.harvesters, h.ID)
@@ -36,7 +35,7 @@ func (hr *harvesterRegistry) Stop() {
 	hr.Lock()
 	for _, hv := range hr.harvesters {
 		hr.wg.Add(1)
-		go func(h *harvester.Harvester) {
+		go func(h *Harvester) {
 			hr.wg.Done()
 			h.Stop()
 		}(hv)
@@ -49,7 +48,7 @@ func (hr *harvesterRegistry) waitForCompletion() {
 	hr.wg.Wait()
 }
 
-func (hr *harvesterRegistry) start(h *harvester.Harvester, r reader.Reader) {
+func (hr *harvesterRegistry) start(h *Harvester, r reader.Reader) {
 
 	hr.wg.Add(1)
 	hr.add(h)

--- a/filebeat/prospector/log/stdin.go
+++ b/filebeat/prospector/log/stdin.go
@@ -1,4 +1,4 @@
-package harvester
+package log
 
 import (
 	"os"


### PR DESCRIPTION
This is the last step in reorganising the packages related to prospector and harvester. Follow up PR's will mainly focusing on abstracting out common functionality, standardise naming and have proper interfaces.

* Merge log harvester and log prospector config into one config
* Rename Log to prospector as part of the new package structure
* Move log harvester logic to log prospector package
* Keep common harvester logic in its own package
* stdin harvester still heavily depends on log harvester, needs to be split up and simplified at a later stage
* Further cleanup of Prospector interface. `Wait()` only exists as a temporary solution.