### PR TITLE
Add commit id to build environment

### DIFF
--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -47,7 +47,8 @@ GOX_OSARCH?=!darwin/arm !darwin/arm64 !darwin/386 ## @building Space separated l
 GOX_FLAGS?= ## @building Additional flags to append to the gox command used by "make crosscompile".
 TESTING_ENVIRONMENT?=snapshot## @testing The name of the environment under test
 BEAT_VERSION=$(shell head -n 1 ${ES_BEATS}/libbeat/docs/version.asciidoc | cut -c 17- )
-DOCKER_COMPOSE_PROJECT_NAME?=${BEAT_NAME}_${TESTING_ENVIRONMENT}_${BEAT_VERSION} ## @testing The name of the docker-compose project used by the integration and system tests
+COMMIT_ID=$(shell git rev-parse HEAD)
+DOCKER_COMPOSE_PROJECT_NAME?=${BEAT_NAME}_${TESTING_ENVIRONMENT}_${BEAT_VERSION}_${COMMIT_ID} ## @testing The name of the docker-compose project used by the integration and system tests
 DOCKER_COMPOSE?=TESTING_ENVIRONMENT=${TESTING_ENVIRONMENT} ES_BEATS=${ES_BEATS} docker-compose -p ${DOCKER_COMPOSE_PROJECT_NAME} -f docker-compose.yml
 DOCKER_CACHE?=1 ## @miscellaneous If set to 0, all docker images are created without cache
 GOPACKAGES_COMMA_SEP=$(subst $(space),$(comma),$(strip ${GOPACKAGES}))


### PR DESCRIPTION
This should reduce conflicts in case 2 builds from the same beat version run in parallel. The only restriction now is not having 2 builds with the same commit id running in parallel, same beat and same test environment running in parallel.

For having its own ids, each CI system can also overload `DOCKER_COMPOSE_PROJECT_NAME` variable if needed.