### PR TITLE
Wait for the test index to be deleted

### DIFF
--- a/filebeat/tests/system/test_modules.py
+++ b/filebeat/tests/system/test_modules.py
@@ -71,6 +71,7 @@ class Test(BaseTest):
             self.es.indices.delete(index=self.index_name)
         except:
             pass
+        self.wait_until(lambda: not self.es.indices.exists(self.index_name))
 
         cmd = [
             self.filebeat, "-systemTest",


### PR DESCRIPTION
Makes sure the index is deleted before running the filebeat module tests.
I don't think this is enough to explain the flaky tests that we had, but it's
still a good measure.