### PR TITLE
Use docker-compose down to remove networks

### DIFF
--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -327,8 +327,7 @@ start-environment: stop-environment
 
 .PHONY: stop-environment
 stop-environment:
-	-${DOCKER_COMPOSE} stop
-	-${DOCKER_COMPOSE} rm -f -v
+	-${DOCKER_COMPOSE} down -v
 
 .PHONY: write-environment
 write-environment:

--- a/testing/environments/Makefile
+++ b/testing/environments/Makefile
@@ -7,8 +7,7 @@ start:
 	${BASE_COMMAND} run beat bash
 
 stop:
-	${BASE_COMMAND} stop
-	${BASE_COMMAND} rm -f
+	${BASE_COMMAND} down -v
 
 
 up:


### PR DESCRIPTION
Docker-compose creates a unique network for each build now. docker-compose rm -v -f did not remove the created networks. The command `docker-compose down` does also remove the networks.

This is important as docker-compose has a default limit of 31 networks.