### PR TITLE
Cherry-pick various test fixes to 5.x

### DIFF
--- a/filebeat/tests/system/test_prospector.py
+++ b/filebeat/tests/system/test_prospector.py
@@ -490,16 +490,17 @@ class Test(BaseTest):
         Test that close_inactive still applies also if file was rotated,
         new file created, and rotated file removed.
         """
+        log_path = os.path.abspath(os.path.join(self.working_dir, "log"))
+        os.mkdir(log_path)
+        testfile = os.path.join(log_path, "a.log")
+        renamed_file = os.path.join(log_path, "b.log")
+
         self.render_config_template(
-            path=os.path.abspath(self.working_dir) + "/log/test.log",
+            path=testfile,
             ignore_older="1h",
             close_inactive="3s",
             scan_frequency="0.1s",
         )
-
-        os.mkdir(self.working_dir + "/log/")
-        testfile = self.working_dir + "/log/test.log"
-        renamed_file = self.working_dir + "/log/test_renamed.log"
 
         filebeat = self.start_beat()
 

--- a/heartbeat/Makefile
+++ b/heartbeat/Makefile
@@ -1,6 +1,6 @@
 BEAT_NAME=heartbeat
 BEAT_DESCRIPTION?=Ping remote services for availability and log results to Elasticsearch or send to Logstash.
-SYSTEM_TESTS=false
+SYSTEM_TESTS=true
 TEST_ENVIRONMENT=false
 
 # Path to the libbeat Makefile

--- a/heartbeat/tests/system/config/heartbeat.yml.j2
+++ b/heartbeat/tests/system/config/heartbeat.yml.j2
@@ -1,78 +1,8 @@
-################### Beat Configuration #########################
+heartbeat.monitors:
+- type: icmp
+  hosts: ["localhost"]
+  schedule: '@every 10s'
 
-
-
-############################# Output ##########################################
-
-# Configure what outputs to use when sending the data collected by the beat.
-# You can enable one or multiple outputs by setting enabled option to true.
-output:
-
-  ### File as output
-  file:
-    # Enabling file output
-    enabled: true
-
-    # Path to the directory where to save the generated files. The option is mandatory.
-    path: {{ output_file_path|default(beat.working_dir + "/output") }}
-
-
-    # Name of the generated files. The default is `heartbeat` and it generates
-    # files: `heartbeat`, `heartbeat.1`, `heartbeat.2`, etc.
-    filename: "{{ output_file_filename|default("heartbeat") }}"
-
-    # Maximum size in kilobytes of each file. When this size is reached, the files are
-    # rotated. The default value is 10 MB.
-    #rotate_every_kb: 10000
-
-    # Maximum number of files under path. When this number of files is reached, the
-    # oldest file is deleted and the rest are shifted from last to first. The default
-    # is 7 files.
-    #number_of_files: 7
-
-
-
-############################# Beat #########################################
-
-# The name of the shipper that publishes the network data. It can be used to group
-# all the transactions sent by a single shipper in the web interface.
-# If this options is not defined, the hostname is used.
-#name:
-
-# The tags of the shipper are included in their own field with each
-# transaction published. Tags make it easy to group servers by different
-# logical properties.
-#tags: ["service-X", "web-tier"]
-
-
-
-############################# Logging #########################################
-
-#logging:
-  # Send all logging output to syslog. On Windows default is false, otherwise
-  # default is true.
-  #to_syslog: true
-
-  # Write all logging output to files. Beats automatically rotate files if configurable
-  # limit is reached.
-  #to_files: false
-
-  # Enable debug output for selected components.
-  #selectors: []
-
-  # Set log level
-  #level: error
-
-  #files:
-    # The directory where the log files will written to.
-    #path: /var/log/heartbeat
-
-    # The name of the files where the logs are written to.
-    #name: heartbeat
-
-    # Configure log file size limit. If limit is reached, log file will be
-    # automatically rotated
-    #rotateeverybytes: 10485760 # = 10MB
-
-    # Number of rotated log files to keep. Oldest files will be deleted first.
-    #keepfiles: 7
+output.file:
+  path: {{ output_file_path|default(beat.working_dir + "/output") }}
+  filename: "{{ output_file_filename|default("heartbeat") }}"

--- a/heartbeat/tests/system/heartbeat.py
+++ b/heartbeat/tests/system/heartbeat.py
@@ -1,12 +1,13 @@
+import os
 import sys
-sys.path.append('../../vendor/github.com/elastic/beats/libbeat/tests/system')
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '../../../libbeat/tests/system'))
+
 from beat.beat import TestCase
 
 
 class BaseTest(TestCase):
-
     @classmethod
     def setUpClass(self):
         self.beat_name = "heartbeat"
-        self.build_path = "../../build/system-tests/"
-        self.beat_path = "../../heartbeat.test"
+        super(BaseTest, self).setUpClass()

--- a/heartbeat/tests/system/test_base.py
+++ b/heartbeat/tests/system/test_base.py
@@ -1,10 +1,9 @@
-from heartbeat import BaseTest
-
 import os
+
+from heartbeat import BaseTest
 
 
 class Test(BaseTest):
-
     def test_base(self):
         """
         Basic test with exiting Heartbeat normally
@@ -15,5 +14,4 @@ class Test(BaseTest):
 
         heartbeat_proc = self.start_beat()
         self.wait_until(lambda: self.log_contains("heartbeat is running"))
-        exit_code = heartbeat_proc.kill_and_wait()
-        assert exit_code == 0
+        heartbeat_proc.check_kill_and_wait()

--- a/libbeat/processors/condition_test.go
+++ b/libbeat/processors/condition_test.go
@@ -20,7 +20,7 @@ func (c *countFilter) Run(e common.MapStr) (common.MapStr, error) {
 
 func (c *countFilter) String() string { return "count" }
 
-func TestBadCondition(t *testing.T) {
+func TestConditions(t *testing.T) {
 
 	if testing.Verbose() {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"*"})

--- a/libbeat/tests/system/test_base.py
+++ b/libbeat/tests/system/test_base.py
@@ -26,7 +26,6 @@ class Test(BaseTest):
 
         assert exit_code == 1
         assert self.log_contains("error loading config file") is True
-        assert self.log_contains("no such file or directory") is True
 
     def test_invalid_config(self):
         """

--- a/metricbeat/module/ceph/monitor_health/monitor_health.go
+++ b/metricbeat/module/ceph/monitor_health/monitor_health.go
@@ -1,8 +1,6 @@
 package monitor_health
 
 import (
-	"fmt"
-
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/metricbeat/helper"
@@ -46,15 +44,10 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 }
 
 func (m *MetricSet) Fetch() ([]common.MapStr, error) {
-
 	content, err := m.HTTP.FetchContent()
 	if err != nil {
 		return nil, err
 	}
 
-	fmt.Printf("%+v", string(content))
-	fmt.Printf("%+v", eventsMapping(content))
-
 	return eventsMapping(content), nil
-
 }

--- a/metricbeat/module/ceph/monitor_health/monitor_health_test.go
+++ b/metricbeat/module/ceph/monitor_health/monitor_health_test.go
@@ -32,10 +32,10 @@ func TestFetchEventContents(t *testing.T) {
 
 	f := mbtest.NewEventsFetcher(t, config)
 	events, err := f.Fetch()
-	event := events[0]
-	if !assert.NoError(t, err) {
-		t.FailNow()
+	if err != nil {
+		t.Fatal(err)
 	}
+	event := events[0]
 
 	t.Logf("%s/%s event: %+v", f.Module().Name(), f.Name(), event.StringToPrint())
 
@@ -68,5 +68,4 @@ func TestFetchEventContents(t *testing.T) {
 
 	total = store_stats["total"].(common.MapStr)
 	assert.EqualValues(t, 8488943, total["bytes"])
-
 }

--- a/metricbeat/module/system/filesystem/helper_test.go
+++ b/metricbeat/module/system/filesystem/helper_test.go
@@ -28,6 +28,10 @@ func TestFileSystemList(t *testing.T) {
 		}
 
 		stat, err := GetFileSystemStat(fs)
+		if os.IsPermission(err) {
+			continue
+		}
+
 		if assert.NoError(t, err, "%v", err) {
 			assert.True(t, (stat.Total >= 0))
 			assert.True(t, (stat.Free >= 0))

--- a/metricbeat/module/system/filesystem/helper_test.go
+++ b/metricbeat/module/system/filesystem/helper_test.go
@@ -32,7 +32,7 @@ func TestFileSystemList(t *testing.T) {
 			continue
 		}
 
-		if assert.NoError(t, err, "%v", err) {
+		if assert.NoError(t, err, "filesystem=%v: %v", fs, err) {
 			assert.True(t, (stat.Total >= 0))
 			assert.True(t, (stat.Free >= 0))
 			assert.True(t, (stat.Avail >= 0))

--- a/metricbeat/tests/system/metricbeat.py
+++ b/metricbeat/tests/system/metricbeat.py
@@ -51,3 +51,15 @@ class BaseTest(TestCase):
                 fields[key] = self.de_dot(fields[key])
 
         return fields
+
+    def assert_no_logged_warnings(self):
+        """
+        Assert that the log file contains no ERR or WARN lines.
+        """
+        log = self.get_log()
+        log = log.replace("WARN EXPERIMENTAL", "")
+        log = log.replace("WARN BETA", "")
+        # Jenkins runs as a Windows service and when Jenkins executes theses
+        # tests the Beat is confused since it thinks it is running as a service.
+        log = log.replace("ERR Error: The service process could not connect to the service controller.", "")
+        self.assertNotRegexpMatches(log, "ERR|WARN")

--- a/metricbeat/tests/system/test_apache.py
+++ b/metricbeat/tests/system/test_apache.py
@@ -44,10 +44,7 @@ class ApacheStatusTest(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0)
         proc.check_kill_and_wait()
-
-        # Ensure no errors or warnings exist in the log.
-        log = self.get_log()
-        self.assertNotRegexpMatches(log, "ERR|WARN")
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         self.assertEqual(len(output), 1)

--- a/metricbeat/tests/system/test_base.py
+++ b/metricbeat/tests/system/test_base.py
@@ -19,10 +19,7 @@ class Test(BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.log_contains("start running"))
         proc.check_kill_and_wait()
-
-        # Ensure no errors or warnings exist in the log.
-        log = self.get_log()
-        self.assertNotRegexpMatches(log, "ERR|WARN")
+        self.assert_no_logged_warnings()
 
         # Ensure all Beater stages are used.
         assert self.log_contains("Setup Beat: metricbeat")

--- a/metricbeat/tests/system/test_couchbase.py
+++ b/metricbeat/tests/system/test_couchbase.py
@@ -18,6 +18,7 @@ class Test(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0, max_timeout=20)
         proc.check_kill_and_wait()
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         self.assertTrue(len(output) >= 1)
@@ -40,6 +41,7 @@ class Test(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0, max_timeout=20)
         proc.check_kill_and_wait()
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         self.assertTrue(len(output) >= 1)
@@ -62,6 +64,7 @@ class Test(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0, max_timeout=20)
         proc.check_kill_and_wait()
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         self.assertTrue(len(output) >= 1)

--- a/metricbeat/tests/system/test_docker.py
+++ b/metricbeat/tests/system/test_docker.py
@@ -21,10 +21,7 @@ class Test(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0, max_timeout=20)
         proc.check_kill_and_wait()
-
-        # Ensure no errors or warnings exist in the log.
-        log = self.get_log()
-        self.assertNotRegexpMatches(log.replace("WARN BETA", ""), "ERR|WARN")
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         evt = output[0]
@@ -47,10 +44,7 @@ class Test(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0, max_timeout=30)
         proc.check_kill_and_wait()
-
-        # Ensure no errors or warnings exist in the log.
-        log = self.get_log()
-        self.assertNotRegexpMatches(log.replace("WARN BETA", ""), "ERR|WARN")
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         evt = output[0]
@@ -77,10 +71,7 @@ class Test(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0, max_timeout=30)
         proc.check_kill_and_wait()
-
-        # Ensure no errors or warnings exist in the log.
-        log = self.get_log()
-        self.assertNotRegexpMatches(log.replace("WARN BETA", ""), "ERR|WARN")
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         evt = output[0]
@@ -104,10 +95,7 @@ class Test(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0, max_timeout=30)
         proc.check_kill_and_wait()
-
-        # Ensure no errors or warnings exist in the log.
-        log = self.get_log()
-        self.assertNotRegexpMatches(log.replace("WARN BETA", ""), "ERR|WARN")
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         evt = output[0]
@@ -129,10 +117,7 @@ class Test(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0, max_timeout=30)
         proc.check_kill_and_wait()
-
-        # Ensure no errors or warnings exist in the log.
-        log = self.get_log()
-        self.assertNotRegexpMatches(log.replace("WARN BETA", ""), "ERR|WARN")
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         evt = output[0]
@@ -155,10 +140,7 @@ class Test(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0, max_timeout=30)
         proc.check_kill_and_wait()
-
-        # Ensure no errors or warnings exist in the log.
-        log = self.get_log()
-        self.assertNotRegexpMatches(log.replace("WARN BETA", ""), "ERR|WARN")
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         evt = output[0]
@@ -181,10 +163,7 @@ class Test(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0, max_timeout=20)
         proc.check_kill_and_wait()
-
-        # Ensure no errors or warnings exist in the log.
-        log = self.get_log()
-        self.assertNotRegexpMatches(log.replace("WARN BETA", ""), "ERR|WARN")
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         evt = output[0]
@@ -207,10 +186,7 @@ class Test(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0, max_timeout=20)
         proc.check_kill_and_wait()
-
-        # Ensure no errors or warnings exist in the log.
-        log = self.get_log()
-        self.assertNotRegexpMatches(log.replace("WARN BETA", ""), "ERR|WARN")
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         evt = output[0]

--- a/metricbeat/tests/system/test_haproxy.py
+++ b/metricbeat/tests/system/test_haproxy.py
@@ -22,10 +22,7 @@ class Test(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0)
         proc.check_kill_and_wait()
-
-        # Ensure no errors or warnings exist in the log.
-        log = self.get_log()
-        self.assertNotRegexpMatches(log, "ERR|WARN")
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         self.assertEqual(len(output), 1)
@@ -49,10 +46,7 @@ class Test(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0)
         proc.check_kill_and_wait()
-
-        # Ensure no errors or warnings exist in the log.
-        log = self.get_log()
-        self.assertNotRegexpMatches(log, "ERR|WARN")
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         self.assertGreater(len(output), 0)

--- a/metricbeat/tests/system/test_jolokia.py
+++ b/metricbeat/tests/system/test_jolokia.py
@@ -31,6 +31,7 @@ class Test(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0, max_timeout=20)
         proc.check_kill_and_wait()
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         self.assertTrue(len(output) >= 1)

--- a/metricbeat/tests/system/test_mongodb.py
+++ b/metricbeat/tests/system/test_mongodb.py
@@ -23,10 +23,7 @@ class Test(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0)
         proc.check_kill_and_wait()
-
-        # Ensure no errors or warnings exist in the log.
-        log = self.get_log()
-        self.assertNotRegexpMatches(log, "ERR|WARN")
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         self.assertEqual(len(output), 1)

--- a/metricbeat/tests/system/test_mysql.py
+++ b/metricbeat/tests/system/test_mysql.py
@@ -26,10 +26,7 @@ class Test(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0)
         proc.check_kill_and_wait()
-
-        # Ensure no errors or warnings exist in the log.
-        log = self.get_log()
-        self.assertNotRegexpMatches(log, "ERR|WARN")
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         self.assertEqual(len(output), 1)

--- a/metricbeat/tests/system/test_phpfpm.py
+++ b/metricbeat/tests/system/test_phpfpm.py
@@ -21,10 +21,7 @@ class Test(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0)
         proc.check_kill_and_wait()
-
-        # Ensure no errors or warnings exist in the log.
-        log = self.get_log()
-        self.assertNotRegexpMatches(log.replace("WARN BETA", ""), "ERR|WARN")
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         self.assertEqual(len(output), 1)

--- a/metricbeat/tests/system/test_prometheus.py
+++ b/metricbeat/tests/system/test_prometheus.py
@@ -21,10 +21,7 @@ class Test(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0)
         proc.check_kill_and_wait()
-
-        # Ensure no errors or warnings exist in the log.
-        log = self.get_log()
-        self.assertNotRegexpMatches(log.replace("WARN BETA", ""), "ERR|WARN")
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         self.assertEqual(len(output), 1)

--- a/metricbeat/tests/system/test_redis.py
+++ b/metricbeat/tests/system/test_redis.py
@@ -35,10 +35,7 @@ class Test(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0)
         proc.check_kill_and_wait()
-
-        # Ensure no errors or warnings exist in the log.
-        log = self.get_log()
-        self.assertNotRegexpMatches(log, "ERR|WARN")
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         self.assertEqual(len(output), 1)
@@ -71,10 +68,7 @@ class Test(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0)
         proc.check_kill_and_wait()
-
-        # Ensure no errors or warnings exist in the log.
-        log = self.get_log()
-        self.assertNotRegexpMatches(log, "ERR|WARN")
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         self.assertEqual(len(output), 1)
@@ -104,10 +98,7 @@ class Test(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0)
         proc.check_kill_and_wait()
-
-        # Ensure no errors or warnings exist in the log.
-        log = self.get_log()
-        self.assertNotRegexpMatches(log, "ERR|WARN")
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         self.assertEqual(len(output), 1)

--- a/metricbeat/tests/system/test_system.py
+++ b/metricbeat/tests/system/test_system.py
@@ -57,10 +57,7 @@ class SystemTest(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0)
         proc.check_kill_and_wait()
-
-        # Ensure no errors or warnings exist in the log.
-        log = self.get_log()
-        self.assertNotRegexpMatches(log, "ERR|WARN")
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         self.assertEqual(len(output), 1)
@@ -86,10 +83,7 @@ class SystemTest(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0)
         proc.check_kill_and_wait()
-
-        # Ensure no errors or warnings exist in the log.
-        log = self.get_log()
-        self.assertNotRegexpMatches(log, "ERR|WARN")
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         self.assertGreater(len(output), 0)
@@ -112,10 +106,7 @@ class SystemTest(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0)
         proc.check_kill_and_wait()
-
-        # Ensure no errors or warnings exist in the log.
-        log = self.get_log()
-        self.assertNotRegexpMatches(log, "ERR|WARN")
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         self.assertGreater(len(output), 0)
@@ -141,10 +132,7 @@ class SystemTest(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0)
         proc.check_kill_and_wait()
-
-        # Ensure no errors or warnings exist in the log.
-        log = self.get_log()
-        self.assertNotRegexpMatches(log, "ERR|WARN")
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         self.assertGreater(len(output), 0)
@@ -167,10 +155,7 @@ class SystemTest(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0)
         proc.check_kill_and_wait()
-
-        # Ensure no errors or warnings exist in the log.
-        log = self.get_log()
-        self.assertNotRegexpMatches(log, "ERR|WARN")
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         self.assertEqual(len(output), 1)
@@ -193,10 +178,7 @@ class SystemTest(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0)
         proc.check_kill_and_wait()
-
-        # Ensure no errors or warnings exist in the log.
-        log = self.get_log()
-        self.assertNotRegexpMatches(log, "ERR|WARN")
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         self.assertGreater(len(output), 0)
@@ -219,10 +201,7 @@ class SystemTest(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0)
         proc.check_kill_and_wait()
-
-        # Ensure no errors or warnings exist in the log.
-        log = self.get_log()
-        self.assertNotRegexpMatches(log, "ERR|WARN")
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         self.assertGreater(len(output), 0)
@@ -245,10 +224,7 @@ class SystemTest(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0)
         proc.check_kill_and_wait()
-
-        # Ensure no errors or warnings exist in the log.
-        log = self.get_log()
-        self.assertNotRegexpMatches(log, "ERR|WARN")
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         self.assertEqual(len(output), 1)
@@ -271,10 +247,7 @@ class SystemTest(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0)
         proc.check_kill_and_wait()
-
-        # Ensure no errors or warnings exist in the log.
-        log = self.get_log()
-        self.assertNotRegexpMatches(log, "ERR|WARN")
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         self.assertEqual(len(output), 1)
@@ -308,10 +281,7 @@ class SystemTest(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0)
         proc.check_kill_and_wait()
-
-        # Ensure no errors or warnings exist in the log.
-        log = self.get_log()
-        self.assertNotRegexpMatches(log, "ERR|WARN")
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         self.assertGreater(len(output), 0)
@@ -340,10 +310,7 @@ class SystemTest(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0)
         proc.check_kill_and_wait()
-
-        # Ensure no errors or warnings exist in the log.
-        log = self.get_log()
-        self.assertNotRegexpMatches(log, "ERR|WARN")
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         self.assertGreater(len(output), 0)

--- a/metricbeat/tests/system/test_zookeeper.py
+++ b/metricbeat/tests/system/test_zookeeper.py
@@ -29,10 +29,7 @@ class ZooKeeperMntrTest(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0)
         proc.check_kill_and_wait()
-
-        # Ensure no errors or warnings exist in the log.
-        log = self.get_log()
-        self.assertNotRegexpMatches(log, "ERR|WARN")
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         self.assertEqual(len(output), 1)

--- a/packetbeat/procs/procs_test.go
+++ b/packetbeat/procs/procs_test.go
@@ -94,7 +94,7 @@ func TestFindPidsByCmdlineGrep(t *testing.T) {
 	}
 
 	// Create fake proc file system
-	pathPrefix, err := ioutil.TempDir("/tmp", "")
+	pathPrefix, err := ioutil.TempDir("", "find-pids")
 	if err != nil {
 		t.Error("TempDir failed:", err)
 		return
@@ -129,7 +129,7 @@ func TestRefreshPids(t *testing.T) {
 	}
 
 	// Create fake proc file system
-	pathPrefix, err := ioutil.TempDir("/tmp", "")
+	pathPrefix, err := ioutil.TempDir("", "refresh-pids")
 	if err != nil {
 		t.Error("TempDir failed:", err)
 		return
@@ -187,7 +187,7 @@ func TestFindSocketsOfPid(t *testing.T) {
 	}
 
 	// Create fake proc file system
-	pathPrefix, err := ioutil.TempDir("/tmp", "")
+	pathPrefix, err := ioutil.TempDir("", "find-sockets")
 	if err != nil {
 		t.Error("TempDir failed:", err)
 		return

--- a/packetbeat/tests/system/config/packetbeat.yml.j2
+++ b/packetbeat/tests/system/config/packetbeat.yml.j2
@@ -111,12 +111,10 @@ packetbeat.protocols.thrift:
   ports: [{{ thrift_ports|default([9090])|join(", ") }}]
   transport_type: "{{ thrift_transport_type|default('socket') }}"
 {% if thrift_idl_files %}
-  idl_files: [
-      {%- for file in thrift_idl_files -%}
-              "{{ beat.working_dir + '/' + file }}"
-              {%- if not loop.last %}, {% endif -%}
-      {%- endfor -%}
-  ]
+  idl_files:
+  {%- for file in thrift_idl_files %}
+  - '{{ beat.working_dir + '/' + file }}'
+  {%- endfor -%}
 {%- endif %}
 {% if thrift_send_request %}  send_request: true{%- endif %}
 {% if thrift_send_response %}  send_response: true{%- endif %}

--- a/winlogbeat/config/config_test.go
+++ b/winlogbeat/config/config_test.go
@@ -73,8 +73,7 @@ func TestConfigValidate(t *testing.T) {
 		},
 		{
 			MetricsConfig{BindAddress: "example.com"},
-			"bind_address must be formatted as host:port but was " +
-				"'example.com' (missing port in address example.com)",
+			"bind_address must be formatted as host:port but was 'example.com'",
 		},
 		{
 			MetricsConfig{BindAddress: ":1"},
@@ -82,8 +81,7 @@ func TestConfigValidate(t *testing.T) {
 		},
 		{
 			MetricsConfig{BindAddress: "example.com:1024f"},
-			"bind_address port value ('1024f') must be a number " +
-				"(strconv.ParseInt: parsing \"1024f\": invalid syntax)",
+			"bind_address port value ('1024f') must be a number",
 		},
 		{
 			MetricsConfig{BindAddress: "example.com:0"},


### PR DESCRIPTION
- Ignore permission errors in Metricbeat’s TestFileSystemList (#3562)
  
  The test can fail if some calls to statfs fail due to permission errors. For example:
  `stat("/var/lib/docker/aufs/mnt/50d0d5f599f0f19450e7649f73a0e23da1f172048e555df2b1cb78b3fefa355b", 0x7ffd2e5b8ed0) = -1 EACCES (Permission denied)`

- Less strict error matching in Winlogbeat config_test 
  Error string testing is brittle. The PR makes the test less stringent by not checking the full error message that includes the Golang stdlib error.

- Miscellaneous test fixes (#4216)
  - Fix and enable the python smoke test for heartbeat
  - Remove fmt.Printf from metricbeat ceph module
  - Fix Windows path issues in libbeat/paths tests
  - Fix ioutil.TempDir usage in Packetbeat tests (it broke windows)

- Using single quotes around Windows paths (#4235)
  The thrift test config used double quotes around Windows path separators and this was interpreted incorrectly in YAML parsing.

- Rename TestBadCondition to TestConditions  (#4235)
  This test doesn’t actually test any bad conditions. Plus there is another test in the same directory with the name TestBadCondition.

- Use logp.Beta or logp.Experimental in metricsets  (#4235)
  And in system tests, centralize the logic for asserting that there are no ERR or WARN in logs.

  Filter out errors about “The service process could not connect to the service controller” that occur when testing on Jenkins where Jenkins itself is running as a service. This confuses the Beat because it thinks that it is running as service, but it’s not.

- Remove OS specific error message check from mockbeat  (#4267)
  The error message “no such file or directory” is an OS specific error message. There is a different error message on Windows. Simply checking for “error loading config file” should be sufficient.

- Use shorter filename in Filebeat test for Windows (#4271)
  The test was failing on Windows when `os.rename` failed with `[Error 3] The system cannot find the path specified`. The root cause of the failure was that the path was ~260 characters on Jenkins which is greater than the `MAX_PATH` value in Windows. This PR shortens the test log’s name to resolve the issue.

  The other changes to normalize the filepath are nice to have for Windows, but not strictly required.

- Add filesystem name to test error message (#4272)
  Errors that are logged by the system/filesystem test case don’t have enough context to debug them. This adds the filesystem that caused the error to the message.

