### PR TITLE
Run make fmt inside python env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ misspell:
 fmt: python-env
 	$(foreach var,$(PROJECTS),$(MAKE) -C $(var) fmt || exit 1;)
 	# Cleans also python files which are not part of the beats
-	find . -type f -name *.py -not -path "*/vendor/*" -not -path "*/build/*" -not -path "*/.git/*" -exec autopep8 --in-place --max-line-length 120  {} \;
+	. ${PYTHON_ENV}/bin/activate && find . -type f -name *.py -not -path "*/vendor/*" -not -path "*/build/*" -not -path "*/.git/*" -exec autopep8 --in-place --max-line-length 120  {} \;
 
 .PHONY: lint
 lint:

--- a/heartbeat/tests/system/heartbeat.py
+++ b/heartbeat/tests/system/heartbeat.py
@@ -7,6 +7,7 @@ from beat.beat import TestCase
 
 
 class BaseTest(TestCase):
+
     @classmethod
     def setUpClass(self):
         self.beat_name = "heartbeat"

--- a/heartbeat/tests/system/test_base.py
+++ b/heartbeat/tests/system/test_base.py
@@ -4,6 +4,7 @@ from heartbeat import BaseTest
 
 
 class Test(BaseTest):
+
     def test_base(self):
         """
         Basic test with exiting Heartbeat normally

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -104,7 +104,7 @@ check: python-env ## @build Checks project and source code if everything is acco
 .PHONY: fmt
 fmt: python-env ## @build Runs `goimports -l -w` and `autopep8`on the project's source code, modifying any files that do not match its style.
 	goimports -l -w ${GOFILES_NOVENDOR}
-	${FIND} -name *.py -exec autopep8 --in-place --max-line-length 120  {} \;
+	. ${PYTHON_ENV}/bin/activate && ${FIND} -name *.py -exec autopep8 --in-place --max-line-length 120  {} \;
 
 .PHONY: lint
 lint:

--- a/metricbeat/module/docker/cpu/helper.go
+++ b/metricbeat/module/docker/cpu/helper.go
@@ -4,8 +4,8 @@ import (
 	"strconv"
 
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/metricbeat/module/docker"
 	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/metricbeat/module/docker"
 
 	dc "github.com/fsouza/go-dockerclient"
 )
@@ -101,7 +101,7 @@ func systemUsage(stats *dc.Stats) float64 {
 func calculateLoad(newValue uint64, oldValue uint64) float64 {
 	value := float64(newValue) - float64(oldValue)
 	if value < 0 {
-		logp.Err("Error calculating CPU time change for docker module: new stats value (%v) is lower than the old one(%v)",newValue,oldValue)
+		logp.Err("Error calculating CPU time change for docker module: new stats value (%v) is lower than the old one(%v)", newValue, oldValue)
 		return -1
 	}
 	return value / float64(1000000000)


### PR DESCRIPTION
This ensures all use the same autopep8 version.

Fixes liniting issue.