### PR TITLE
Fix flaky tests in filebeat

### DIFF
--- a/filebeat/tests/system/test_harvester.py
+++ b/filebeat/tests/system/test_harvester.py
@@ -558,6 +558,8 @@ class Test(BaseTest):
         self.render_config_template(
             path=os.path.abspath(self.working_dir) + "/log/symlink.log",
             symlinks="true",
+            close_removed="false",
+            clean_removed="false",
         )
 
         os.mkdir(self.working_dir + "/log/")


### PR DESCRIPTION
test_symlink_rotated was flaky because change to clean_removed behaviour affects symlinks.