### PR TITLE
Small fixes for the HTTP module docs

### DIFF
--- a/metricbeat/docs/modules/http.asciidoc
+++ b/metricbeat/docs/modules/http.asciidoc
@@ -3,13 +3,14 @@ This file is generated! See scripts/docs_collector.py
 ////
 
 [[metricbeat-module-http]]
-== http Module
+== HTTP Module
 
-Http module is a [Metricbeat](https://www.elastic.co/products/beats/metricbeat) module used to call arbitrary HTTP endpoints for which a dedicated metricbeat module is not available.
+The HTTP module is a Metricbeat module used to call arbitrary HTTP endpoints for which a dedicated Metricbeat module is not available.
 
-Multiple endpoints can be configured which are polled in a regular interval and the result is shipped to the configured output channel. It is recommended to install a metricbeat instance on each host from which data should be fetched.
+Multiple endpoints can be configured which are polled in a regular interval and the result is shipped to the configured output channel. It is recommended to install a Metricbeat instance on each host from which data should be fetched.
 
-Httpbeat is inspired by the Logstash [http_poller](https://www.elastic.co/guide/en/logstash/current/plugins-inputs-http_poller.html) input filter but doesn't require that the endpoint is reachable by Logstash as the Metricbeat module pushes the data to the configured output channels, e.g. Logstash or Elasticsearch.
+This module is inspired by the Logstash https://www.elastic.co/guide/en/logstash/current/plugins-inputs-http_poller.html[http_poller] input filter but doesn't require that the endpoint is reachable by Logstash as the Metricbeat module pushes the data to the configured output channels, e.g. Logstash or Elasticsearch.
+
 This is often necessary in security restricted network setups, where Logstash is not able to reach all servers. Instead the server to be monitored itself has Metricbeat installed and can send the data or a collector server has Metricbeat installed which is deployed in the secured network environment and can reach all servers to be monitored.
 
 

--- a/metricbeat/module/http/_meta/docs.asciidoc
+++ b/metricbeat/module/http/_meta/docs.asciidoc
@@ -1,8 +1,9 @@
-== http Module
+== HTTP Module
 
-Http module is a [Metricbeat](https://www.elastic.co/products/beats/metricbeat) module used to call arbitrary HTTP endpoints for which a dedicated metricbeat module is not available.
+The HTTP module is a Metricbeat module used to call arbitrary HTTP endpoints for which a dedicated Metricbeat module is not available.
 
-Multiple endpoints can be configured which are polled in a regular interval and the result is shipped to the configured output channel. It is recommended to install a metricbeat instance on each host from which data should be fetched.
+Multiple endpoints can be configured which are polled in a regular interval and the result is shipped to the configured output channel. It is recommended to install a Metricbeat instance on each host from which data should be fetched.
 
-Httpbeat is inspired by the Logstash [http_poller](https://www.elastic.co/guide/en/logstash/current/plugins-inputs-http_poller.html) input filter but doesn't require that the endpoint is reachable by Logstash as the Metricbeat module pushes the data to the configured output channels, e.g. Logstash or Elasticsearch.
+This module is inspired by the Logstash https://www.elastic.co/guide/en/logstash/current/plugins-inputs-http_poller.html[http_poller] input filter but doesn't require that the endpoint is reachable by Logstash as the Metricbeat module pushes the data to the configured output channels, e.g. Logstash or Elasticsearch.
+
 This is often necessary in security restricted network setups, where Logstash is not able to reach all servers. Instead the server to be monitored itself has Metricbeat installed and can send the data or a collector server has Metricbeat installed which is deployed in the secured network environment and can reach all servers to be monitored.


### PR DESCRIPTION
I've noticed some markdown in the HTTP module, so I've replaced them
with the asciidoc syntax, and also did some very light editing.

@dedemorton you might want to have an extra look at this module.