### PR TITLE
Fix for flaky docker tests

### DIFF
--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -48,7 +48,7 @@ GOX_FLAGS?= ## @building Additional flags to append to the gox command used by "
 TESTING_ENVIRONMENT?=snapshot## @testing The name of the environment under test
 BEAT_VERSION=$(shell head -n 1 ${ES_BEATS}/libbeat/docs/version.asciidoc | cut -c 17- )
 COMMIT_ID=$(shell git rev-parse HEAD)
-DOCKER_COMPOSE_PROJECT_NAME?=${BEAT_NAME}_${TESTING_ENVIRONMENT}_${BEAT_VERSION}_${COMMIT_ID} ## @testing The name of the docker-compose project used by the integration and system tests
+DOCKER_COMPOSE_PROJECT_NAME?=${BEAT_NAME}${TESTING_ENVIRONMENT}${BEAT_VERSION}${COMMIT_ID} ## @testing The name of the docker-compose project used by the integration and system tests
 DOCKER_COMPOSE?=TESTING_ENVIRONMENT=${TESTING_ENVIRONMENT} ES_BEATS=${ES_BEATS} docker-compose -p ${DOCKER_COMPOSE_PROJECT_NAME} -f docker-compose.yml
 DOCKER_CACHE?=1 ## @miscellaneous If set to 0, all docker images are created without cache
 GOPACKAGES_COMMA_SEP=$(subst $(space),$(comma),$(strip ${GOPACKAGES}))

--- a/metricbeat/tests/system/config/metricbeat.yml.j2
+++ b/metricbeat/tests/system/config/metricbeat.yml.j2
@@ -117,10 +117,10 @@ tags: [
   {%- endif -%}
 ]
 
+
+#================================ Processors =====================================
+
 {%- if processors %}
-
-#================================ Filters =====================================
-
 processors:
 {%- for processor in processors %}
 {%- for name, settings in processor.iteritems() %}

--- a/metricbeat/tests/system/metricbeat.py
+++ b/metricbeat/tests/system/metricbeat.py
@@ -53,7 +53,7 @@ class BaseTest(TestCase):
 
         return fields
 
-    def assert_no_logged_warnings(self):
+    def assert_no_logged_warnings(self, replace=None):
         """
         Assert that the log file contains no ERR or WARN lines.
         """
@@ -63,4 +63,7 @@ class BaseTest(TestCase):
         # Jenkins runs as a Windows service and when Jenkins executes theses
         # tests the Beat is confused since it thinks it is running as a service.
         log = log.replace("ERR Error: The service process could not connect to the service controller.", "")
+        if replace:
+            for r in replace:
+                log = log.replace(r, "")
         self.assertNotRegexpMatches(log, "ERR|WARN")

--- a/metricbeat/tests/system/test_docker.py
+++ b/metricbeat/tests/system/test_docker.py
@@ -1,6 +1,7 @@
 import metricbeat
 
 import unittest
+import os
 from nose.plugins.attrib import attr
 
 
@@ -11,17 +12,33 @@ class Test(metricbeat.BaseTest):
         """
         test container fields
         """
-        self.render_config_template(modules=[{
-            "name": "docker",
-            "metricsets": ["container"],
-            "hosts": ["unix:///var/run/docker.sock"],
-            "period": "10s",
-        }])
+
+        test_env = os.environ.get('DOCKER_COMPOSE_PROJECT_NAME')
+        processors = None
+        if test_env:
+            processors = [{
+                "drop_event": {
+                    "when.not": "contains.docker.container.name: " + test_env,
+                },
+            }]
+
+        self.render_config_template(
+            modules=[{
+                "name": "docker",
+                "metricsets": ["container"],
+                "hosts": ["unix:///var/run/docker.sock"],
+                "period": "10s",
+            }],
+            processors=processors,
+        )
 
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0, max_timeout=20)
         proc.check_kill_and_wait()
-        self.assert_no_logged_warnings()
+        self.assert_no_logged_warnings(["WARN Container stopped when recovering stats",
+                                        "ERR An error occurred while getting docker stats"])
+
+        print(os.environ.get('TESTING_ENVIRONMENT'))
 
         output = self.read_output_json()
         evt = output[0]
@@ -44,7 +61,8 @@ class Test(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0, max_timeout=30)
         proc.check_kill_and_wait()
-        self.assert_no_logged_warnings()
+        self.assert_no_logged_warnings(["WARN Container stopped when recovering stats",
+                                        "ERR An error occurred while getting docker stats"])
 
         output = self.read_output_json()
         evt = output[0]
@@ -71,7 +89,8 @@ class Test(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0, max_timeout=30)
         proc.check_kill_and_wait()
-        self.assert_no_logged_warnings()
+        self.assert_no_logged_warnings(["WARN Container stopped when recovering stats",
+                                        "ERR An error occurred while getting docker stats"])
 
         output = self.read_output_json()
         evt = output[0]
@@ -95,7 +114,8 @@ class Test(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0, max_timeout=30)
         proc.check_kill_and_wait()
-        self.assert_no_logged_warnings()
+        self.assert_no_logged_warnings(["WARN Container stopped when recovering stats",
+                                        "ERR An error occurred while getting docker stats"])
 
         output = self.read_output_json()
         evt = output[0]
@@ -117,7 +137,8 @@ class Test(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0, max_timeout=30)
         proc.check_kill_and_wait()
-        self.assert_no_logged_warnings()
+        self.assert_no_logged_warnings(["WARN Container stopped when recovering stats",
+                                        "ERR An error occurred while getting docker stats"])
 
         output = self.read_output_json()
         evt = output[0]
@@ -140,7 +161,8 @@ class Test(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0, max_timeout=30)
         proc.check_kill_and_wait()
-        self.assert_no_logged_warnings()
+        self.assert_no_logged_warnings(["WARN Container stopped when recovering stats",
+                                        "ERR An error occurred while getting docker stats"])
 
         output = self.read_output_json()
         evt = output[0]
@@ -163,7 +185,8 @@ class Test(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0, max_timeout=20)
         proc.check_kill_and_wait()
-        self.assert_no_logged_warnings()
+        self.assert_no_logged_warnings(["WARN Container stopped when recovering stats",
+                                        "ERR An error occurred while getting docker stats"])
 
         output = self.read_output_json()
         evt = output[0]
@@ -186,7 +209,8 @@ class Test(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0, max_timeout=20)
         proc.check_kill_and_wait()
-        self.assert_no_logged_warnings()
+        self.assert_no_logged_warnings(["WARN Container stopped when recovering stats",
+                                        "ERR An error occurred while getting docker stats"])
 
         output = self.read_output_json()
         evt = output[0]


### PR DESCRIPTION
Docker tests were flaky because sometimes a container of an other test was monitored which was stopped at this time. Te log entries for containers which were removed during investigation are removed.

In addition a processor was introduced to only look at the events for docker containers which are from the same environment.