### PR TITLE
Set path.home in system tests

### DIFF
--- a/libbeat/tests/system/beat/beat.py
+++ b/libbeat/tests/system/beat/beat.py
@@ -163,6 +163,7 @@ class TestCase(unittest.TestCase):
                 "-systemTest",
                 "-test.coverprofile",
                 os.path.join(self.working_dir, "coverage.cov"),
+                "-path.home", os.path.normpath(self.working_dir),
                 "-c", os.path.join(self.working_dir, config)
                 ]
 


### PR DESCRIPTION
Files were being written to disk outside of the build dir while tests were running (i.e. `./data/meta.json`).