### PR TITLE
Extract common harvester parts to forwarder

### DIFF
--- a/filebeat/harvester/forwarder.go
+++ b/filebeat/harvester/forwarder.go
@@ -1,0 +1,82 @@
+package harvester
+
+import (
+	"errors"
+
+	"github.com/elastic/beats/filebeat/util"
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/processors"
+)
+
+// Outlet interface is used for forwarding events
+type Outlet interface {
+	SetSignal(signal <-chan struct{})
+	OnEventSignal(data *util.Data) bool
+	OnEvent(data *util.Data) bool
+}
+
+// Forwarder contains shared options between all harvesters needed to forward events
+type Forwarder struct {
+	Config     ForwarderConfig
+	Outlet     Outlet
+	Processors *processors.Processors
+}
+
+// ForwarderConfig contains all config options shared by all harvesters
+type ForwarderConfig struct {
+	common.EventMetadata `config:",inline"`      // Fields and tags to add to events.
+	Type                 string                  `config:"type"`
+	Pipeline             string                  `config:"pipeline"`
+	Module               string                  `config:"_module_name"`  // hidden option to set the module name
+	Fileset              string                  `config:"_fileset_name"` // hidden option to set the fileset name
+	Processors           processors.PluginConfig `config:"processors"`
+}
+
+// NewForwarder creates a new forwarder instances and initialises processors if configured
+func NewForwarder(cfg *common.Config, outlet Outlet) (*Forwarder, error) {
+
+	config := ForwarderConfig{}
+	if err := cfg.Unpack(&config); err != nil {
+		return nil, err
+	}
+
+	processors, err := processors.New(config.Processors)
+	if err != nil {
+		return nil, err
+	}
+
+	f := &Forwarder{
+		Outlet:     outlet,
+		Processors: processors,
+		Config:     config,
+	}
+
+	return f, nil
+
+}
+
+// Send updates the prospector state and sends the event to the spooler
+// All state updates done by the prospector itself are synchronous to make sure not states are overwritten
+func (f *Forwarder) Send(data *util.Data) error {
+
+	// Add additional prospector meta data to the event
+	data.Meta.Pipeline = f.Config.Pipeline
+	data.Meta.Module = f.Config.Module
+	data.Meta.Fileset = f.Config.Fileset
+
+	if data.HasEvent() {
+		data.Event[common.EventMetadataKey] = f.Config.EventMetadata
+
+		// run the filters before sending to spooler
+		data.Event = f.Processors.Run(data.Event)
+	}
+
+	ok := f.Outlet.OnEventSignal(data)
+	if !ok {
+		logp.Info("Prospector outlet closed")
+		return errors.New("prospector outlet closed")
+	}
+
+	return nil
+}

--- a/filebeat/harvester/harvester.go
+++ b/filebeat/harvester/harvester.go
@@ -1,6 +1,8 @@
 package harvester
 
-import uuid "github.com/satori/go.uuid"
+import (
+	uuid "github.com/satori/go.uuid"
+)
 
 // Harvester contains all methods which must be supported by each harvester
 // so the registry can be used by the prospector.

--- a/filebeat/prospector/log/config.go
+++ b/filebeat/prospector/log/config.go
@@ -6,16 +6,17 @@ import (
 
 	"github.com/dustin/go-humanize"
 	cfg "github.com/elastic/beats/filebeat/config"
+	"github.com/elastic/beats/filebeat/harvester"
 	"github.com/elastic/beats/filebeat/harvester/reader"
-	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/match"
-	"github.com/elastic/beats/libbeat/processors"
 )
 
 var (
 	defaultConfig = config{
 		// Common
-		Type:          cfg.DefaultType,
+		ForwarderConfig: harvester.ForwarderConfig{
+			Type: cfg.DefaultType,
+		},
 		CleanInactive: 0,
 
 		// Prospector
@@ -42,9 +43,9 @@ var (
 )
 
 type config struct {
+	harvester.ForwarderConfig `config:",inline"`
 
 	// Common
-	Type          string        `config:"type"`
 	InputType     string        `config:"input_type"`
 	CleanInactive time.Duration `config:"clean_inactive" validate:"min=0"`
 
@@ -61,26 +62,21 @@ type config struct {
 	recursiveGlob  bool            `config:"recursive_glob.enabled"`
 
 	// Harvester
-	common.EventMetadata `config:",inline"`      // Fields and tags to add to events.
-	BufferSize           int                     `config:"harvester_buffer_size"`
-	Encoding             string                  `config:"encoding"`
-	Backoff              time.Duration           `config:"backoff" validate:"min=0,nonzero"`
-	BackoffFactor        int                     `config:"backoff_factor" validate:"min=1"`
-	MaxBackoff           time.Duration           `config:"max_backoff" validate:"min=0,nonzero"`
-	CloseInactive        time.Duration           `config:"close_inactive"`
-	CloseRemoved         bool                    `config:"close_removed"`
-	CloseRenamed         bool                    `config:"close_renamed"`
-	CloseEOF             bool                    `config:"close_eof"`
-	CloseTimeout         time.Duration           `config:"close_timeout" validate:"min=0"`
-	ExcludeLines         []match.Matcher         `config:"exclude_lines"`
-	IncludeLines         []match.Matcher         `config:"include_lines"`
-	MaxBytes             int                     `config:"max_bytes" validate:"min=0,nonzero"`
-	Multiline            *reader.MultilineConfig `config:"multiline"`
-	JSON                 *reader.JSONConfig      `config:"json"`
-	Pipeline             string                  `config:"pipeline"`
-	Module               string                  `config:"_module_name"`  // hidden option to set the module name
-	Fileset              string                  `config:"_fileset_name"` // hidden option to set the fileset name
-	Processors           processors.PluginConfig `config:"processors"`
+	BufferSize    int                     `config:"harvester_buffer_size"`
+	Encoding      string                  `config:"encoding"`
+	Backoff       time.Duration           `config:"backoff" validate:"min=0,nonzero"`
+	BackoffFactor int                     `config:"backoff_factor" validate:"min=1"`
+	MaxBackoff    time.Duration           `config:"max_backoff" validate:"min=0,nonzero"`
+	CloseInactive time.Duration           `config:"close_inactive"`
+	CloseRemoved  bool                    `config:"close_removed"`
+	CloseRenamed  bool                    `config:"close_renamed"`
+	CloseEOF      bool                    `config:"close_eof"`
+	CloseTimeout  time.Duration           `config:"close_timeout" validate:"min=0"`
+	ExcludeLines  []match.Matcher         `config:"exclude_lines"`
+	IncludeLines  []match.Matcher         `config:"include_lines"`
+	MaxBytes      int                     `config:"max_bytes" validate:"min=0,nonzero"`
+	Multiline     *reader.MultilineConfig `config:"multiline"`
+	JSON          *reader.JSONConfig      `config:"json"`
 }
 
 func (c *config) Validate() error {

--- a/filebeat/prospector/log/config_test.go
+++ b/filebeat/prospector/log/config_test.go
@@ -7,6 +7,7 @@ import (
 
 	"time"
 
+	"github.com/elastic/beats/filebeat/harvester"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -47,8 +48,10 @@ func TestCleanOlderIgnoreOlder(t *testing.T) {
 	config := config{
 		CleanInactive: 10*time.Hour + defaultConfig.ScanFrequency + 1*time.Second,
 		IgnoreOlder:   10 * time.Hour,
-		Type:          "log",
 		Paths:         []string{"hello"},
+		ForwarderConfig: harvester.ForwarderConfig{
+			Type: "log",
+		},
 	}
 
 	err := config.Validate()

--- a/filebeat/prospector/log/log.go
+++ b/filebeat/prospector/log/log.go
@@ -197,7 +197,8 @@ func (h *Harvester) sendEvent(data *util.Data) bool {
 	if h.file.HasState() {
 		h.states.Update(data.GetState())
 	}
-	err := h.forwardEvent(data)
+
+	err := h.forwarder.Send(data)
 	return err == nil
 }
 
@@ -217,7 +218,7 @@ func (h *Harvester) SendStateUpdate() {
 
 	d := util.NewData()
 	d.SetState(h.state)
-	h.outlet.OnEvent(d)
+	h.forwarder.Outlet.OnEvent(d)
 }
 
 // shouldExportLine decides if the line is exported or not based on


### PR DESCRIPTION
This will allow to reuse the forwarder part in other harvester types. Adding meta data to events will be the same across all harvester types.