### PR TITLE
Cherry-pick #3942 to 5.x: Fix Winlogbeat test by checking full hostname

### DIFF
--- a/winlogbeat/tests/system/winlogbeat.py
+++ b/winlogbeat/tests/system/winlogbeat.py
@@ -1,3 +1,5 @@
+import os
+import platform
 import sys
 
 if sys.platform.startswith("win"):
@@ -93,7 +95,7 @@ class WriteReadTest(BaseTest):
 
     def assert_common_fields(self, evt, msg=None, eventID=10, sid=None,
                              level="Information", extra=None):
-        assert evt["computer_name"].lower() == win32api.GetComputerName().lower()
+        assert evt["computer_name"].lower() == platform.node().lower()
         assert "record_number" in evt
         self.assertDictContainsSubset({
             "event_id": eventID,


### PR DESCRIPTION
Cherry-pick of PR #3942 to 5.x branch. Original message: 

The `computer_name` field in events is the full hostname, but the `win32api.GetComputerName` was returning the shortened netbios name. So the test fail on machines with longer hostnames.