### PR TITLE
Clean geoip.paths before using the path

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -47,6 +47,8 @@ https://github.com/elastic/beats/compare/v5.3.0...master[Check the HEAD diff]
 
 *Packetbeat*
 
+- Clean configured geoip.paths before attempting to open the database. {pull}4306[4306]
+
 *Winlogbeat*
 
 

--- a/libbeat/common/geolite.go
+++ b/libbeat/common/geolite.go
@@ -30,6 +30,7 @@ func LoadGeoIPData(config Geoip) *libgeo.GeoIP {
 	// look for the first existing path
 	var geoipPath string
 	for _, path := range geoipPaths {
+		path = filepath.Clean(path)
 		fi, err := os.Lstat(path)
 		if err != nil {
 			logp.Err("GeoIP path could not be loaded: %s", path)

--- a/packetbeat/tests/system/test_0011_geoip.py
+++ b/packetbeat/tests/system/test_0011_geoip.py
@@ -1,5 +1,8 @@
-from packetbeat import BaseTest
 import os
+import unittest
+import sys
+
+from packetbeat import BaseTest
 
 """
 Tests for reading the geoip files.
@@ -43,6 +46,7 @@ class Test(BaseTest):
         assert o["real_ip"] == "89.247.39.104"
         assert o["client_location"] == "52.528503, 13.410904"
 
+    @unittest.skipIf(sys.platform.startswith("win"), "requires unix for symlinks")
     def test_geoip_symlink(self):
         """
         Should be able to follow symlinks to GeoIP libs.


### PR DESCRIPTION
Use `filepath.Clean` on the configured paths to fix any invalid OS path separators.

Skip the geoip test with symlinks on Windows (`os.symlink` isn’t supported on Windows).

This should fix the failures seen here: https://beats-ci.elastic.co/job/elastic+beats+5.x+tests-windows/4/testReport/