### PR TITLE
Fix process summary test case

### DIFF
--- a/metricbeat/tests/system/test_system.py
+++ b/metricbeat/tests/system/test_system.py
@@ -304,10 +304,7 @@ class Test(metricbeat.BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0)
         proc.check_kill_and_wait()
-
-        # Ensure no errors or warnings exist in the log.
-        log = self.get_log()
-        self.assertNotRegexpMatches(log, "ERR|WARN")
+        self.assert_no_logged_warnings()
 
         output = self.read_output_json()
         self.assertGreater(len(output), 0)


### PR DESCRIPTION
Change test_process_summary to use assert_no_logged_warnings() instead
of a looking for "ERR|WARN". assert_no_logged_warnings() filters out
some expected messages.