### PR TITLE
Fix race condition for harvester Start / Stop in registry

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -31,6 +31,7 @@ https://github.com/elastic/beats/compare/v6.0.0-alpha1...master[Check the HEAD d
 - Fix importing the dashboards when the limit for max open files is too low. {issue}4244[4244]
 
 *Filebeat*
+- Fix race condition on harvester stopping with reloading enabled. {issue}3779[3779]
 
 *Heartbeat*
 


### PR DESCRIPTION
It was possible that with reloading enabled that during the shutdown of filebeat, a new harvester was started. This is now prevent by having a lock on the starting of the harvester so no new harvesters can be started when shutdown started.

This is not backported to 5.x because it can only happen on shutdown and does not have any side affects.

Closes #3779