### PR TITLE
Add option to adjust _source options + improvements

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -46,7 +46,7 @@ https://github.com/elastic/beats/compare/v6.0.0-alpha1...master[Check the HEAD d
 
 *Affecting all Beats*
 
-- Added the possibility to set Elasticsearch mapping template settings from the Beat configuration file. {pull}4284[4284]
+- Added the possibility to set Elasticsearch mapping template settings from the Beat configuration file. {pull}4284[4284] {pull}4317[4317]
 
 *Filebeat*
 

--- a/libbeat/beat/beat.go
+++ b/libbeat/beat/beat.go
@@ -487,12 +487,14 @@ func (b *Beat) registerTemplateLoading() error {
 
 			loader, err := template.NewLoader(b.Config.Template, esClient, b.Info)
 			if err != nil {
-				return fmt.Errorf("Error loading elasticsearch template: %v", err)
+				return fmt.Errorf("Error creating Elasticsearch template: %v", err)
 			}
 
-			loader.Load()
+			err = loader.Load()
+			if err != nil {
+				return fmt.Errorf("Error loading Elasticsearch template: %v", err)
+			}
 
-			logp.Info("ES template successfully loaded.")
 			return nil
 		}
 

--- a/libbeat/docs/template-config.asciidoc
+++ b/libbeat/docs/template-config.asciidoc
@@ -20,11 +20,11 @@ section for details.
 *`overwrite`*:: A boolean that specifies whether to overwrite the existing template. The default
 is false.
 
-*`settings`*:: A dictionary of settings to place into the `settings` dictionary of the Elasticsearch
-template. For more details about the available Elasticsearch mapping options, please see the
-Elasticsearch {elasticsearch}/mapping.html[mapping reference].
+*`settings.index`*:: A dictionary of settings to place into the `settings.index` dictionary of the
+Elasticsearch template. For more details about the available Elasticsearch mapping options, please
+see the Elasticsearch {elasticsearch}/mapping.html[mapping reference].
 
-For example:
+Example:
 
 ["source","yaml",subs="attributes,callouts"]
 ----------------------------------------------------------------------
@@ -34,4 +34,18 @@ setup.template.overwrite: false
 setup.template.settings:
   index.number_of_shards: 1
   index.number_of_replicas: 1
+----------------------------------------------------------------------
+
+*`settings._source`*:: A dictionary of settings for the `_source` field. For the available settings,
+please see the Elasticsearch {elasticsearch}/mapping-source-field.html[reference].
+
+Example:
+
+["source","yaml",subs="attributes,callouts"]
+----------------------------------------------------------------------
+setup.template.name: "{beatname_lc}"
+setup.template.fields: "fields.yml"
+setup.template.overwrite: false
+setup.template.settings:
+  _source.enabled: false
 ----------------------------------------------------------------------

--- a/libbeat/template/config.go
+++ b/libbeat/template/config.go
@@ -1,12 +1,17 @@
 package template
 
 type TemplateConfig struct {
-	Enabled      bool                   `config:"enabled"`
-	Name         string                 `config:"name"`
-	Fields       string                 `config:"fields"`
-	Overwrite    bool                   `config:"overwrite"`
-	OutputToFile string                 `config:"output_to_file"`
-	Settings     map[string]interface{} `config:"settings"`
+	Enabled      bool             `config:"enabled"`
+	Name         string           `config:"name"`
+	Fields       string           `config:"fields"`
+	Overwrite    bool             `config:"overwrite"`
+	OutputToFile string           `config:"output_to_file"`
+	Settings     templateSettings `config:"settings"`
+}
+
+type templateSettings struct {
+	Index  map[string]interface{} `config:"index"`
+	Source map[string]interface{} `config:"_source"`
 }
 
 var (

--- a/libbeat/template/load.go
+++ b/libbeat/template/load.go
@@ -43,23 +43,23 @@ func NewLoader(cfg *common.Config, client ESClient, beatInfo common.BeatInfo) (*
 // template is written to index
 func (l *Loader) Load() error {
 
+	if l.config.Name == "" {
+		l.config.Name = l.beatInfo.Beat
+	}
+
+	tmpl, err := New(l.beatInfo.Version, l.client.GetVersion(), l.config.Name, l.config.Settings)
+	if err != nil {
+		return fmt.Errorf("error creating template instance: %v", err)
+	}
+
 	// Check if template already exist or should be overwritten
-	exists := l.CheckTemplate(l.config.Name)
+	exists := l.CheckTemplate(tmpl.GetName())
 	if !exists || l.config.Overwrite {
 
-		logp.Info("Loading template for elasticsearch version: %s", l.client.GetVersion())
+		logp.Info("Loading template for Elasticsearch version: %s", l.client.GetVersion())
 
 		if l.config.Overwrite {
 			logp.Info("Existing template will be overwritten, as overwrite is enabled.")
-		}
-
-		if l.config.Name == "" {
-			l.config.Name = l.beatInfo.Beat
-		}
-
-		tmpl, err := New(l.beatInfo.Version, l.client.GetVersion(), l.config.Name, l.config.Settings)
-		if err != nil {
-			return fmt.Errorf("error creating template instance: %v", err)
 		}
 
 		fieldsPath := paths.Resolve(paths.Config, l.config.Fields)


### PR DESCRIPTION
This PR adds/fixes:

* Ability to disable _source, or set other _source related options
* Fixes the overwrite logic (was using the wrong template name on the check)
* Fixes error handling
* Integration tests for overwritting

The source can be disabled like this:

```
setup.template:
  settings._source.enabled: false
```

And _source can be also partially enabled via "includes" and "excludes", for example:

```
setup.template:
  settings._source.excludes: ["metricset", "system.process.cmdline"]
```

Adding the discuss label for naming. I hesitated between using `_source` or `source_settings` for these options, but I like the look of `_source.enabled: false`.

Part of #3654 and #4112.

Remaining TODOs:

* [x] Update docs
* [x] Changelog