### PR TITLE
Fix panic on Metricbeat filters

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -40,6 +40,7 @@ https://github.com/elastic/beats/compare/v6.0.0-alpha1...master[Check the HEAD d
 *Metricbeat*
 - Fix a debug statement that said a module wrapper had stopped when it hadn't. {pull}4264[4264]
 - Use MemAvailable value from /proc/meminfo on Linux 3.14. {pull}4316[4316]
+- Fix panic when events were dropped by filters. {issue}4327[4327]
 
 *Packetbeat*
 

--- a/metricbeat/mb/module/wrapper.go
+++ b/metricbeat/mb/module/wrapper.go
@@ -340,10 +340,13 @@ func (r *eventReporter) ErrorWith(err error, meta common.MapStr) bool {
 		return false
 	}
 
-	if !writeEvent(r.done, r.out, event) {
-		return false
+	if event != nil { // event can be nil if it was dropped by processors
+		if !writeEvent(r.done, r.out, event) {
+			return false
+		}
+		r.msw.stats.events.Add(1)
 	}
-	r.msw.stats.events.Add(1)
+
 	return true
 }
 


### PR DESCRIPTION
`nil` can happen if the event is dropped by processors. Fixes #4327.