### PR TITLE
Remove waitgroup handling from Stopping of harvesters

### DIFF
--- a/filebeat/harvester/registry.go
+++ b/filebeat/harvester/registry.go
@@ -29,6 +29,12 @@ func (r *Registry) remove(h Harvester) {
 	delete(r.harvesters, h.ID())
 }
 
+func (r *Registry) add(h Harvester) {
+	r.Lock()
+	defer r.Unlock()
+	r.harvesters[h.ID()] = h
+}
+
 // Stop stops all harvesters in the registry
 func (r *Registry) Stop() {
 	r.Lock()
@@ -40,9 +46,7 @@ func (r *Registry) Stop() {
 	close(r.done)
 
 	for _, hv := range r.harvesters {
-		r.wg.Add(1)
 		go func(h Harvester) {
-			r.wg.Done()
 			h.Stop()
 		}(hv)
 	}
@@ -62,20 +66,17 @@ func (r *Registry) Start(h Harvester) {
 	defer r.Unlock()
 
 	// Make sure no new harvesters are started after stop was called
-	select {
-	case <-r.done:
+	if !r.active() {
 		return
-	default:
 	}
 
 	r.wg.Add(1)
-	r.harvesters[h.ID()] = h
-
 	go func() {
 		defer func() {
 			r.remove(h)
 			r.wg.Done()
 		}()
+		r.add(h)
 		// Starts harvester and picks the right type. In case type is not set, set it to default (log)
 		err := h.Run()
 		if err != nil {
@@ -89,4 +90,13 @@ func (r *Registry) Len() uint64 {
 	r.RLock()
 	defer r.RUnlock()
 	return uint64(len(r.harvesters))
+}
+
+func (r *Registry) active() bool {
+	select {
+	case <-r.done:
+		return false
+	default:
+		return true
+	}
 }


### PR DESCRIPTION
During trying to reproduce https://github.com/elastic/beats/issues/4332 it seems the waitgroup in the Stop part is not needed. Even more it could cause issues.

The initial approach to fix the race was to pass the waitgroup to the harvester. But this would change the harvester interface which I would like to keep as simple as possible.

Before one of the problems was, that the harvester was added to the registry early which means Stop was potentially called on a harvester that was not started yet. This should now be prevented by checking on Start if the harvester was already stopped before any callback methods are registered.