### PR TITLE
Change grok pattern to fetch correct IP from X-Forwarded-For list

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -172,6 +172,7 @@ https://github.com/elastic/beats/compare/v5.4.0...v6.0.0-alpha1[View commits]
 - Add filebeat.config.path as replacement for config_dir. {pull}4051[4051]
 - Add a `recursive_glob.enabled` setting to expand `**` in patterns. {pull}3980[3980]
 - Add Icinga module. {pull}3904[3904]
+- Add ability to parse nginx logs exposing the X-Forwarded-For header instead of the remote address.
 
 *Heartbeat*
 

--- a/filebeat/module/nginx/access/ingest/default.json
+++ b/filebeat/module/nginx/access/ingest/default.json
@@ -4,7 +4,7 @@
     "grok": {
       "field": "message",
       "patterns":[
-        "%{IPORHOST:nginx.access.remote_ip} - %{DATA:nginx.access.user_name} \\[%{HTTPDATE:nginx.access.time}\\] \"%{WORD:nginx.access.method} %{DATA:nginx.access.url} HTTP/%{NUMBER:nginx.access.http_version}\" %{NUMBER:nginx.access.response_code} %{NUMBER:nginx.access.body_sent.bytes} \"%{DATA:nginx.access.referrer}\" \"%{DATA:nginx.access.agent}\""
+        "%{IPORHOST:nginx.access.remote_ip}(,\\s%{IPORHOST})* - %{DATA:nginx.access.user_name} \\[%{HTTPDATE:nginx.access.time}\\] \"%{WORD:nginx.access.method} %{DATA:nginx.access.url} HTTP/%{NUMBER:nginx.access.http_version}\" %{NUMBER:nginx.access.response_code} %{NUMBER:nginx.access.body_sent.bytes} \"%{DATA:nginx.access.referrer}\" \"%{DATA:nginx.access.agent}\""
         ],
       "ignore_missing": true
     }

--- a/filebeat/module/nginx/access/test/test.log
+++ b/filebeat/module/nginx/access/test/test.log
@@ -1,0 +1,1 @@
+10.0.0.2, 10.0.0.1, 127.0.0.1 - - [07/Dec/2016:11:05:07 +0100] "GET /ocelot HTTP/1.1" 200 571 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:49.0) Gecko/20100101 Firefox/49.0"

--- a/filebeat/module/nginx/access/test/test.log-expected.json
+++ b/filebeat/module/nginx/access/test/test.log-expected.json
@@ -1,0 +1,58 @@
+[
+    {
+        "_index": "filebeat-2016.12.27",
+        "_type": "log",
+        "_id": "AVlBCaYsqYg9cc5KQfcT",
+        "_score": null,
+        "_source": {
+            "@timestamp": "2016-12-07T10:05:07.000Z",
+            "offset": 191,
+            "nginx": {
+                "access": {
+                    "referrer": "-",
+                    "response_code": "200",
+                    "remote_ip": "10.0.0.2",
+                    "method": "GET",
+                    "user_name": "-",
+                    "http_version": "1.1",
+                    "body_sent": {
+                        "bytes": "571"
+                    },
+                    "url": "/ocelot",
+                    "user_agent": {
+                        "major": "49",
+                        "minor": "0",
+                        "os": "Mac OS X 10.12",
+                        "os_minor": "12",
+                        "os_major": "10",
+                        "name": "Firefox",
+                        "os_name": "Mac OS X",
+                        "device": "Other"
+                    }
+                }
+            },
+            "beat": {
+                "hostname": "192-168-0-7.rdsnet.ro",
+                "name": "192-168-0-7.rdsnet.ro",
+                "version": "6.0.0-alpha1"
+            },
+            "read_timestamp": "2016-12-27T15:52:23.304Z",
+            "source": "module/nginx/access/test/test.log",
+            "fields": {
+                "pipeline_id": "nginx-access-with_plugins",
+                "source_type": "nginx-access"
+            },
+            "prospector": {
+                "type": "log"
+            }
+        },
+        "fields": {
+            "@timestamp": [
+                1481105107000
+            ]
+        },
+        "sort": [
+            1481105107000
+        ]
+    }
+]


### PR DESCRIPTION
This PR changes the grok pattern for the nginx access logs ingest file in a way, that it retrieves the correct IP if the X-Forwarded-For header was logged into instead of the remote_addr variable.

The X-Forwarded-For header is a non standard header which creates a lists of IPs through which proxies the request has passed as well as the original clients IP and looks basically like this:
```
X-Forwarded-For: client1, proxy1, proxy2
```
which results in a log line like this:
```
192.228.32.190, 108.162.246.21, 127.0.0.1 - - [15/May/2017:12:16:27 +0200] "GET /jobs/24237/it-back-end HTTP/1.1" 301 5 "-" "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)"
```

The new pattern retrieves the first IP, which is the important one, and matches non or all succeeding IPs that are concatinated with a comma and a space.