### PR TITLE
Shorten test name to shorten path for windows

### DIFF
--- a/filebeat/tests/system/test_prospector.py
+++ b/filebeat/tests/system/test_prospector.py
@@ -480,7 +480,7 @@ class Test(BaseTest):
 
         filebeat.check_kill_and_wait()
 
-    def test_close_inactive_file_rotation_and_removal_while_new_file_created(self):
+    def test_close_inactive_file_rotation_and_removal2(self):
         """
         Test that close_inactive still applies also if file was rotated,
         new file created, and rotated file removed.


### PR DESCRIPTION
On our CI system we get the following error:
```
WindowsError: [Error 206] The filename or extension is too long: 'C:\\Users\\jenkins\\workspace\\elastic+beats+pull-request+multijob-windows\\beat\\filebeat\\label\\windows\\src\\github.com\\elastic\\beats\\filebeat\\build\\system-tests\\run\\test_prospector.Test.test_close_inactive_file_rotation_and_removal_while_new_file_created'
```

The problem is that this path is 267 characters long. According to https://msdn.microsoft.com/en-us/library/windows/desktop/aa365247(v=vs.85).aspx the MAX_PATH length is 260. In general it seems we could hit this limitation also in lots of other ways where we cannot just reduce the length of the test name. There seems to be some possibility to increase this limit:

    To specify an extended-length path, use the "\\?\" prefix. For example, "\\?\D:\very long path".

We should test if this could also solve the problem as it raises the limit to 32767.