### PR TITLE
Bring back prospector.type which went missing

### DIFF
--- a/filebeat/harvester/forwarder.go
+++ b/filebeat/harvester/forwarder.go
@@ -67,6 +67,7 @@ func (f *Forwarder) Send(data *util.Data) error {
 
 	if data.HasEvent() {
 		data.Event[common.EventMetadataKey] = f.Config.EventMetadata
+		data.Event.Put("prospector.type", f.Config.Type)
 
 		// run the filters before sending to spooler
 		data.Event = f.Processors.Run(data.Event)

--- a/filebeat/tests/system/test_base.py
+++ b/filebeat/tests/system/test_base.py
@@ -1,0 +1,28 @@
+from filebeat import BaseTest
+import os
+
+"""
+Test for basic object
+"""
+
+
+class Test(BaseTest):
+
+    def test_base(self):
+        """
+        Test if the basic fields exist.
+        """
+        self.render_config_template(
+            path=os.path.abspath(self.working_dir) + "/test.log",
+        )
+
+        with open(self.working_dir + "/test.log", "w") as f:
+            f.write("test message\n")
+
+        filebeat = self.start_beat()
+        self.wait_until(lambda: self.output_has(lines=1))
+        filebeat.check_kill_and_wait()
+
+        output = self.read_output()[0]
+        assert "@timestamp" in output
+        assert "prospector.type" in output


### PR DESCRIPTION
It seems in one of the recent refactorings prospector.type went missing. Test added to make sure it will not go missing again.