### PR TITLE
Filter relative mounts in system filesystem metricset

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -44,6 +44,8 @@ https://github.com/elastic/beats/compare/v6.0.0-alpha1...master[Check the HEAD d
 - Fix a debug statement that said a module wrapper had stopped when it hadn't. {pull}4264[4264]
 - Use MemAvailable value from /proc/meminfo on Linux 3.14. {pull}4316[4316]
 - Fix panic when events were dropped by filters. {issue}4327[4327]
+- Add filtering to system filesystem metricset to remove relative mountpoints like those
+  from Linux network namespaces. {pull}4370[4370]
 
 *Packetbeat*
 

--- a/metricbeat/module/system/filesystem/filesystem.go
+++ b/metricbeat/module/system/filesystem/filesystem.go
@@ -11,7 +11,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-var debugf = logp.MakeDebug("system-filesystem")
+var debugf = logp.MakeDebug("system.filesystem")
 
 func init() {
 	if err := mb.Registry.AddMetricSet("system", "filesystem", New, parse.EmptyHostParser); err != nil {

--- a/metricbeat/module/system/filesystem/helper.go
+++ b/metricbeat/module/system/filesystem/helper.go
@@ -3,10 +3,10 @@
 package filesystem
 
 import (
+	"path/filepath"
 	"time"
 
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/metricbeat/module/system"
 	sigar "github.com/elastic/gosigar"
 )
@@ -20,12 +20,20 @@ type FileSystemStat struct {
 }
 
 func GetFileSystemList() ([]sigar.FileSystem, error) {
-
 	fss := sigar.FileSystemList{}
-	err := fss.Get()
-	if err != nil {
+	if err := fss.Get(); err != nil {
 		return nil, err
 	}
+
+	// Ignore relative mount points, which are present for example
+	// in /proc/mounts on Linux with network namespaces.
+	filtered := fss.List[:0]
+	for _, fs := range fss.List {
+		if filepath.IsAbs(fs.DirName) {
+			filtered = append(filtered, fs)
+		}
+	}
+	fss.List = filtered
 
 	return fss.List, nil
 }
@@ -54,26 +62,6 @@ func AddFileSystemUsedPercentage(f *FileSystemStat) {
 	f.UsedPercent = system.Round(perc, .5, 4)
 }
 
-func CollectFileSystemStats(fss []sigar.FileSystem) []common.MapStr {
-	events := make([]common.MapStr, 0, len(fss))
-	for _, fs := range fss {
-		fsStat, err := GetFileSystemStat(fs)
-		if err != nil {
-			logp.Debug("system", "Skip filesystem %d: %v", fsStat, err)
-			continue
-		}
-		AddFileSystemUsedPercentage(fsStat)
-
-		event := common.MapStr{
-			"@timestamp": common.Time(time.Now()),
-			"type":       "filesystem",
-			"fs":         GetFilesystemEvent(fsStat),
-		}
-		events = append(events, event)
-	}
-	return events
-}
-
 func GetFilesystemEvent(fsStat *FileSystemStat) common.MapStr {
 	return common.MapStr{
 		"device_name": fsStat.DevName,
@@ -88,14 +76,4 @@ func GetFilesystemEvent(fsStat *FileSystemStat) common.MapStr {
 			"bytes": fsStat.Used,
 		},
 	}
-}
-
-func GetFileSystemStats() ([]common.MapStr, error) {
-	fss, err := GetFileSystemList()
-	if err != nil {
-		logp.Warn("Getting filesystem list: %v", err)
-		return nil, err
-	}
-
-	return CollectFileSystemStats(fss), nil
 }

--- a/metricbeat/module/system/filesystem/helper.go
+++ b/metricbeat/module/system/filesystem/helper.go
@@ -31,7 +31,9 @@ func GetFileSystemList() ([]sigar.FileSystem, error) {
 	for _, fs := range fss.List {
 		if filepath.IsAbs(fs.DirName) {
 			filtered = append(filtered, fs)
+			continue
 		}
+		debugf("Filtering filesystem with relative mountpoint %+v", fs)
 	}
 	fss.List = filtered
 


### PR DESCRIPTION
Add filtering to system filesystem metricset to remove relative mountpoints like those from Linux network namespaces.