### PR TITLE
Improve winlogbeat checkpoint test

### DIFF
--- a/winlogbeat/checkpoint/checkpoint_test.go
+++ b/winlogbeat/checkpoint/checkpoint_test.go
@@ -27,7 +27,10 @@ func TestWriteMaxUpdates(t *testing.T) {
 	}()
 
 	file := filepath.Join(dir, "some", "new", "dir", ".winlogbeat.yml")
-	assert.False(t, fileExists(file), "%s should not exist", file)
+	if !assert.False(t, fileExists(file), "%s should not exist", file) {
+		return
+	}
+
 	cp, err := NewCheckpoint(file, 2, time.Hour)
 	if err != nil {
 		t.Fatal(err)
@@ -39,18 +42,24 @@ func TestWriteMaxUpdates(t *testing.T) {
 	time.Sleep(500 * time.Millisecond)
 	_, found := cp.States()["App"]
 	assert.True(t, found)
+
 	ps, err := cp.read()
-	assert.NoError(t, err)
+	if err != nil {
+		t.Fatal("read failed", err)
+	}
 	assert.Len(t, ps.States, 0)
 
 	// Send update - it is written to disk.
 	cp.Persist("App", 2, time.Now())
-	time.Sleep(500 * time.Millisecond)
+	time.Sleep(750 * time.Millisecond)
 	ps, err = cp.read()
-	assert.NoError(t, err)
-	assert.Len(t, ps.States, 1)
-	assert.Equal(t, "App", ps.States[0].Name)
-	assert.Equal(t, uint64(2), ps.States[0].RecordNumber)
+	if err != nil {
+		t.Fatal("read failed", err)
+	}
+	if assert.Len(t, ps.States, 1, "state not written, could be a flush timing issue, retry") {
+		assert.Equal(t, "App", ps.States[0].Name)
+		assert.Equal(t, uint64(2), ps.States[0].RecordNumber)
+	}
 }
 
 // Test that a write is triggered when the maximum time period since the last
@@ -68,7 +77,10 @@ func TestWriteTimedFlush(t *testing.T) {
 	}()
 
 	file := filepath.Join(dir, ".winlogbeat.yml")
-	assert.False(t, fileExists(file), "%s should not exist", file)
+	if !assert.False(t, fileExists(file), "%s should not exist", file) {
+		return
+	}
+
 	cp, err := NewCheckpoint(file, 100, time.Second)
 	if err != nil {
 		t.Fatal(err)
@@ -80,10 +92,13 @@ func TestWriteTimedFlush(t *testing.T) {
 	cp.Persist("App", 1, time.Now())
 	time.Sleep(1500 * time.Millisecond)
 	ps, err := cp.read()
-	assert.NoError(t, err)
-	assert.Len(t, ps.States, 1)
-	assert.Equal(t, "App", ps.States[0].Name)
-	assert.Equal(t, uint64(1), ps.States[0].RecordNumber)
+	if err != nil {
+		t.Fatal("read failed", err)
+	}
+	if assert.Len(t, ps.States, 1) {
+		assert.Equal(t, "App", ps.States[0].Name)
+		assert.Equal(t, uint64(1), ps.States[0].RecordNumber)
+	}
 }
 
 // Test that createDir creates the directory with 0750 permissions.
@@ -103,17 +118,24 @@ func TestCreateDir(t *testing.T) {
 	file := filepath.Join(stateDir, ".winlogbeat.yml")
 	cp := &Checkpoint{file: file}
 
-	assert.False(t, fileExists(stateDir), "%s should not exist", file)
-	assert.NoError(t, cp.createDir())
-	assert.True(t, fileExists(stateDir), "%s should exist", file)
+	if !assert.False(t, fileExists(file), "%s should not exist", file) {
+		return
+	}
+	if err = cp.createDir(); err != nil {
+		t.Fatal("createDir", err)
+	}
+	if !assert.True(t, fileExists(stateDir), "%s should exist", file) {
+		return
+	}
 
 	// mkdir on Windows does not pass the POSIX mode to the CreateDirectory
 	// syscall so doesn't test the mode.
 	if runtime.GOOS != "windows" {
 		fileInfo, err := os.Stat(stateDir)
-		assert.NoError(t, err)
-		assert.Equal(t, true, fileInfo.IsDir())
-		assert.Equal(t, os.FileMode(0750), fileInfo.Mode().Perm())
+		if assert.NoError(t, err) {
+			assert.Equal(t, true, fileInfo.IsDir())
+			assert.Equal(t, os.FileMode(0750), fileInfo.Mode().Perm())
+		}
 	}
 }
 
@@ -134,7 +156,9 @@ func TestCreateDirAlreadyExists(t *testing.T) {
 	file := filepath.Join(dir, ".winlogbeat.yml")
 	cp := &Checkpoint{file: file}
 
-	assert.True(t, fileExists(dir), "%s should exist", file)
+	if !assert.True(t, fileExists(dir), "%s should exist", file) {
+		return
+	}
 	assert.NoError(t, cp.createDir())
 }
 


### PR DESCRIPTION
- Check for errors and exit to stop panics from occurring when the test fails.
- Increase the sleep to 750ms to give the checkpoint more time to flush states to disk.