### PR TITLE
Add log message when multline event flushed

### DIFF
--- a/filebeat/harvester/reader/multiline.go
+++ b/filebeat/harvester/reader/multiline.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/elastic/beats/libbeat/common/match"
+	"github.com/elastic/beats/libbeat/logp"
 )
 
 // MultiLine reader combining multiple line events into one multi-line event.
@@ -122,6 +123,8 @@ func (mlr *Multiline) readFirst() (Message, error) {
 				continue
 			}
 
+			logp.Debug("multiline", "Multiline event flushed because timeout reached.")
+
 			// pass error to caller (next layer) for handling
 			return message, err
 		}
@@ -148,6 +151,8 @@ func (mlr *Multiline) readNext() (Message, error) {
 				if mlr.numLines == 0 {
 					continue
 				}
+
+				logp.Debug("multiline", "Multiline event flushed because timeout reached.")
 
 				// return collected multiline event and
 				// empty buffer for new multiline event


### PR DESCRIPTION
So far there was no log message when an incomplete multiline event was flushed. The reason this log message is on a debug level is that at the end of a file if there is no next multiline event, the timeout can be reached rather often.