### PR TITLE
Fix parsing of interface options with _ (#4334)

### DIFF
--- a/packetbeat/config/config.go
+++ b/packetbeat/config/config.go
@@ -20,13 +20,13 @@ type Config struct {
 }
 
 type InterfacesConfig struct {
-	Device       string
-	Type         string
-	File         string
-	WithVlans    bool
-	BpfFilter    string
-	Snaplen      int
-	BufferSizeMb int
+	Device       string `config:"device"`
+	Type         string `config:"type"`
+	File         string `config:"file"`
+	WithVlans    bool   `config:"with_vlans"`
+	BpfFilter    string `config:"bpf_filter"`
+	Snaplen      int    `config:"snaplen"`
+	BufferSizeMb int    `config:"buffer_size_mb"`
 	TopSpeed     bool
 	Dumpfile     string
 	OneAtATime   bool


### PR DESCRIPTION
In commit 55470602d1459ae6312fdec26b85c1c4d8da8d6c linting issues
were addresses and variables containing _ were renamed. This broke
the config parsing.

In packetbeat this seems to effect the with_vlans, bpf_filter and
the buffer_size_mb options. Correct it by using a tag in the structure.