### PR TITLE
Disable HTML escaping during JSON Marshaling

### DIFF
--- a/libbeat/common/json.go
+++ b/libbeat/common/json.go
@@ -1,0 +1,28 @@
+package common
+
+import (
+	"bytes"
+	"encoding/json"
+
+	"fmt"
+)
+
+// JSONEncode encodes the given interface to JSON
+func JSONEncode(data interface{}, pretty bool) ([]byte, error) {
+
+	buffer := &bytes.Buffer{}
+	enc := json.NewEncoder(buffer)
+	enc.SetEscapeHTML(true)
+
+	enc.SetIndent("", "")
+	if pretty {
+		enc.SetIndent("", "  ")
+	}
+
+	err := enc.Encode(data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert the data to JSON (%v): %#v", err, data)
+	}
+
+	return buffer.Bytes(), nil
+}

--- a/libbeat/common/mapstr.go
+++ b/libbeat/common/mapstr.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+
+	"github.com/elastic/beats/libbeat/logp"
 )
 
 // Event metadata constants. These keys are used within libbeat to identify
@@ -142,11 +144,14 @@ func (m MapStr) Put(key string, value interface{}) (interface{}, error) {
 
 // StringToPrint returns the MapStr as pretty JSON.
 func (m MapStr) StringToPrint() string {
-	json, err := json.MarshalIndent(m, "", "  ")
+
+	buffer, err := JSONEncode(m, true)
 	if err != nil {
-		return fmt.Sprintf("Not valid json: %v", err)
+		logp.Err("Fail to convert the event to JSON (%v): %#v", err, m)
+		return ""
 	}
-	return string(json)
+
+	return string(buffer)
 }
 
 // String returns the MapStr as JSON.

--- a/libbeat/logp/file_rotator.go
+++ b/libbeat/logp/file_rotator.go
@@ -67,7 +67,6 @@ func (rotator *FileRotator) WriteLine(line []byte) error {
 		}
 	}
 
-	line = append(line, '\n')
 	_, err := rotator.current.Write(line)
 	if err != nil {
 		return err

--- a/libbeat/outputs/codecs/json/json.go
+++ b/libbeat/outputs/codecs/json/json.go
@@ -1,8 +1,6 @@
 package json
 
 import (
-	"encoding/json"
-
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/outputs"
@@ -38,17 +36,12 @@ func New(pretty bool) *Encoder {
 }
 
 func (e *Encoder) Encode(event common.MapStr) ([]byte, error) {
-	var err error
-	var serializedEvent []byte
 
-	if e.Pretty {
-		serializedEvent, err = json.MarshalIndent(event, "", "  ")
-	} else {
-		serializedEvent, err = json.Marshal(event)
-	}
+	buffer, err := common.JSONEncode(event, e.Pretty)
 	if err != nil {
 		logp.Err("Fail to convert the event to JSON (%v): %#v", err, event)
+		return nil, err
 	}
 
-	return serializedEvent, err
+	return buffer, nil
 }


### PR DESCRIPTION
By default the golang JSON Marshaller escapes HTML entries. As this is not required for beats this is disabling this option.

* Unification of json marshalling

Closes https://github.com/elastic/beats/issues/2581

* Add changelog