### PR TITLE
Improve `make notice` to work on libs not 3 dirs long

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1962,6 +1962,37 @@ Apache License
 
 
 --------------------------------------------------------------------
+github.com/vmware/govmomi/vim25/xml
+--------------------------------------------------------------------
+Copyright (c) 2012 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+--------------------------------------------------------------------
 github.com/vmware/vic
 --------------------------------------------------------------------
 Apache License
@@ -2092,6 +2123,67 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------
+gopkg.in/inf.v0
+--------------------------------------------------------------------
+Copyright (c) 2012 Péter Surányi. Portions Copyright (c) 2009 The Go
+Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+--------------------------------------------------------------------
+gopkg.in/mgo.v2
+--------------------------------------------------------------------
+mgo - MongoDB driver for Go
+
+Copyright (c) 2010-2013 - Gustavo Niemeyer <gustavo@niemeyer.net>
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met: 
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer. 
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+--------------------------------------------------------------------
 gopkg.in/mgo.v2/bson
 --------------------------------------------------------------------
 BSON library for Go
@@ -2119,3 +2211,69 @@ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
 ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+--------------------------------------------------------------------
+gopkg.in/mgo.v2/internal/json
+--------------------------------------------------------------------
+Copyright (c) 2012 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+--------------------------------------------------------------------
+gopkg.in/yaml.v2
+--------------------------------------------------------------------
+The following files were ported to Go from C files of libyaml, and thus
+are still covered by their original copyright and license:
+
+    apic.go
+    emitterc.go
+    parserc.go
+    readerc.go
+    scannerc.go
+    writerc.go
+    yamlh.go
+    yamlprivateh.go
+
+Copyright (c) 2006 Kirill Simonov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/dev-tools/generate_notice.py
+++ b/dev-tools/generate_notice.py
@@ -16,29 +16,27 @@ def read_file(filename):
 
 
 def get_library_path(license):
-
-    lib = ""
-    path = os.path.dirname(license)
-    # get the last three directories
-    for i in range(0, 3):
-        path, x = os.path.split(path)
-        if len(lib) == 0:
-            lib = x
-        elif len(x) > 0:
-            lib = x + "/" + lib
-
-    return lib
+    """
+    Get the contents up to the vendor folder.
+    """
+    split = license.split(os.sep)
+    for i, word in reversed(list(enumerate(split))):
+        if word == "vendor":
+            return "/".join(split[i+1:])
+    return "/".join(split)
 
 
-def add_licenses(f, license_globs):
-
+def add_licenses(f, vendor_dirs):
     licenses = {}
-    for license_glob in license_globs:
-        for license_file in glob.glob(license_glob):
-            lib_path = get_library_path(license_file)
-            if lib_path in licenses:
-                print("WARNING: Dependency appears multiple times: {}".format(lib_path))
-            licenses[lib_path] = license_file
+    for vendor in vendor_dirs:
+        # walk looking for LICENSE files
+        for root, dirs, filenames in os.walk(vendor):
+            for filename in filenames:
+                if filename.startswith("LICENSE"):
+                    lib_path = get_library_path(root)
+                    if lib_path in licenses:
+                        print("WARNING: Dependency appears multiple times: {}".format(lib_path))
+                    licenses[lib_path] = os.path.abspath(os.path.join(root, filename))
 
     # Sort licenses by package path, ignore upper / lower case
     for key in sorted(licenses, key=str.lower):
@@ -57,7 +55,7 @@ def add_licenses(f, license_globs):
                 f.write(read_file(notice_file))
 
 
-def create_notice(filename, beat, copyright, license_globs):
+def create_notice(filename, beat, copyright, vendor_dirs):
 
     now = datetime.datetime.now()
 
@@ -67,13 +65,14 @@ def create_notice(filename, beat, copyright, license_globs):
         f.write("{}\n".format(beat))
         f.write("Copyright 2014-{0} {1}\n".format(now.year, copyright))
         f.write("\n")
-        f.write("This product includes software developed by The Apache Software \nFoundation (http://www.apache.org/).\n\n")
+        f.write("This product includes software developed by The Apache Software \n" +
+                "Foundation (http://www.apache.org/).\n\n")
 
         # Add licenses for 3rd party libraries
         f.write("==========================================================================\n")
         f.write("Third party libraries used by the Beats project:\n")
         f.write("==========================================================================\n\n")
-        add_licenses(f, license_globs)
+        add_licenses(f, vendor_dirs)
 
 
 if __name__ == "__main__":
@@ -91,7 +90,7 @@ if __name__ == "__main__":
 
     cwd = os.getcwd()
     notice = os.path.join(cwd, "NOTICE")
-    license_globs = []
+    vendor_dirs = []
 
     print args.vendor
 
@@ -102,11 +101,9 @@ if __name__ == "__main__":
             continue
 
         if 'vendor' in dirs:
-            license_glob = os.path.join(os.path.join(root, 'vendor'),
-                                        '**/**/**/LICENSE*')
-            license_globs.append(license_glob)
+            vendor_dirs.append(os.path.join(root, 'vendor'))
 
-    print("Get the licenses available from {}".format(license_globs))
-    create_notice(notice, args.beat, args.copyright, license_globs)
+    print("Get the licenses available from {}".format(vendor_dirs))
+    create_notice(notice, args.beat, args.copyright, vendor_dirs)
 
     print("Available at {}\n".format(notice))

--- a/dev-tools/generate_notice.py
+++ b/dev-tools/generate_notice.py
@@ -31,7 +31,7 @@ def add_licenses(f, vendor_dirs):
     for vendor in vendor_dirs:
         # walk looking for LICENSE files
         for root, dirs, filenames in os.walk(vendor):
-            for filename in filenames:
+            for filename in sorted(filenames):
                 if filename.startswith("LICENSE"):
                     lib_path = get_library_path(root)
                     if lib_path in licenses:


### PR DESCRIPTION
Did this refactoring in preparation for a change that adds the version in,
but opening it as its own PR so we can verify the diff. There were a few
libs that were not exactly "3 dirs long".