### PR TITLE
Do not activate memcache by default (#4335)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -49,6 +49,7 @@ https://github.com/elastic/beats/compare/v6.0.0-alpha1...master[Check the HEAD d
 - Remove unnecessary print statement in schema apis {pull}4355[4355]
 
 *Packetbeat*
+- Enable memcache filtering only if a port is specified in the config file. {issue}4335[4335]
 
 *Winlogbeat*
 

--- a/packetbeat/protos/memcache/config.go
+++ b/packetbeat/protos/memcache/config.go
@@ -18,7 +18,6 @@ type memcacheConfig struct {
 var (
 	defaultConfig = memcacheConfig{
 		ProtocolCommon: config.ProtocolCommon{
-			Ports:              []int{11211},
 			TransactionTimeout: protos.DefaultTransactionExpiration,
 		},
 		UDPTransactionTimeout: protos.DefaultTransactionExpiration,


### PR DESCRIPTION
The documentation states that the memcache proto can be disabled
by commenting out the list of ports. In practice one had to comment
out the entire line.

Fix it by not initializing the Ports variable inside the
defaultConfig of the memcache proto. No other proto has Ports
initialized in the defaultConfig.