### PR TITLE
Bump docs version to 5.3.3

### DIFF
--- a/libbeat/docs/version.asciidoc
+++ b/libbeat/docs/version.asciidoc
@@ -1,4 +1,4 @@
-:stack-version: 5.3.2
+:stack-version: 5.3.3
 :doc-branch: 5.3
 :go-version: 1.7.4
 :release-state: released


### PR DESCRIPTION
Don't merge this one yet, we should wait and do it a few hours before the release.