### PR TITLE
Revert "Bump docs version to 5.3.3"

### DIFF
--- a/libbeat/docs/version.asciidoc
+++ b/libbeat/docs/version.asciidoc
@@ -1,4 +1,4 @@
-:stack-version: 5.3.3
+:stack-version: 5.3.2
 :doc-branch: 5.3
 :go-version: 1.7.4
 :release-state: released


### PR DESCRIPTION
Reverts elastic/beats#4392

The release was postponed so we should revert this one to avoid broken links :(.