### PR TITLE
Upgrade to Go 1.7.6

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,7 +6,7 @@ os: Windows Server 2012 R2
 
 # Environment variables
 environment:
-  GOROOT: c:\go1.7.4
+  GOROOT: c:\go1.7.6
   GOPATH: c:\gopath
   PYWIN_DL: https://beats-files.s3.amazonaws.com/deps/pywin32-220.win32-py2.7.exe
   matrix:
@@ -24,13 +24,13 @@ clone_folder: c:\gopath\src\github.com\elastic\beats
 cache:
 - C:\ProgramData\chocolatey\bin -> .appveyor.yml
 - C:\ProgramData\chocolatey\lib -> .appveyor.yml
-- C:\go1.7.4 -> .appveyor.yml
+- C:\go1.7.6 -> .appveyor.yml
 - C:\tools\mingw64 -> .appveyor.yml
 - C:\pywin_inst.exe -> .appveyor.yml
 
 # Scripts that run after cloning repository
 install:
-  - ps: c:\gopath\src\github.com\elastic\beats\libbeat\scripts\install-go.ps1 -version 1.7.4
+  - ps: c:\gopath\src\github.com\elastic\beats\libbeat\scripts\install-go.ps1 -version 1.7.6
   - set PATH=%GOROOT%\bin;%PATH%
   # AppVeyor installed mingw is 32-bit only.
   - ps: >-

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
     # Cross-compile for amd64 only to speed up testing.
     - GOX_FLAGS="-arch amd64"
     - DOCKER_COMPOSE_VERSION: 1.9.0
-    - &go_version 1.7.4
+    - &go_version 1.7.6
 
 matrix:
   include:

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -102,6 +102,10 @@ https://github.com/elastic/beats/compare/v5.4.0...v5.4.1[View commits]
 
 ==== Added
 
+*Affecting all Beats*
+
+- Binaries upgraded to Go 1.7.6 which contains security fixes. {pull}4400[4400]
+
 *Winlogbeat*
 
 - Add the ability to use LevelRaw if Level isn't populated in the event XML. {pull}4257[4257]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ Beats](https://github.com/elastic/beats/blob/master/libbeat/docs/communitybeats.
 
 The Beats are Go programs, so install the latest version of
 [golang](http://golang.org/) if you don't have it already. The current Go version
-used for development is Golang 1.7.4.
+used for development is Golang 1.7.6.
 
 The location where you clone is important. Please clone under the source
 directory of your `GOPATH`. If you don't have `GOPATH` already set, you can

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.7.4
+FROM golang:1.7.6
 MAINTAINER Nicolas Ruflin <ruflin@elastic.co>
 
 RUN set -x && \

--- a/dev-tools/packer/docker/xgo-image-deb6/beats-builder/Dockerfile
+++ b/dev-tools/packer/docker/xgo-image-deb6/beats-builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM tudorg/xgo-deb6-1.7.4
+FROM tudorg/xgo-deb6-1.7.6
 
 MAINTAINER Tudor Golubenco <tudor@elastic.co>
 

--- a/dev-tools/packer/docker/xgo-image-deb6/build.sh
+++ b/dev-tools/packer/docker/xgo-image-deb6/build.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 docker build --rm=true -t tudorg/xgo-deb6-base base/ && \
-    docker build --rm=true -t tudorg/xgo-deb6-1.7.4 go-1.7.4/ &&
+    docker build --rm=true -t tudorg/xgo-deb6-1.7.6 go-1.7.6/ &&
     docker build --rm=true -t tudorg/beats-builder-deb6 beats-builder

--- a/dev-tools/packer/docker/xgo-image-deb6/go-1.7.6/Dockerfile
+++ b/dev-tools/packer/docker/xgo-image-deb6/go-1.7.6/Dockerfile
@@ -1,4 +1,4 @@
-# Go cross compiler (xgo): Go 1.7.4 layer
+# Go cross compiler (xgo): Go 1.7.6 layer
 # Copyright (c) 2014 Péter Szilágyi. All rights reserved.
 #
 # Released under the MIT license.
@@ -9,7 +9,7 @@ MAINTAINER Tudor Golubenco <tudor@elastic.co>
 
 # Configure the root Go distribution and bootstrap based on it
 RUN \
-  export ROOT_DIST="https://storage.googleapis.com/golang/go1.7.4.linux-amd64.tar.gz" && \
-  export ROOT_DIST_SHA1="2e5baf03d1590e048c84d1d5b4b6f2540efaaea1" && \
+  export ROOT_DIST="https://storage.googleapis.com/golang/go1.7.6.linux-amd64.tar.gz" && \
+  export ROOT_DIST_SHA1="6a7014f34048d95ab60247814a1b8b98018810ff" && \
   \
   $BOOTSTRAP_PURE

--- a/dev-tools/packer/docker/xgo-image/beats-builder/Dockerfile
+++ b/dev-tools/packer/docker/xgo-image/beats-builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM tudorg/xgo-1.7.4
+FROM tudorg/xgo-1.7.6
 
 MAINTAINER Tudor Golubenco <tudor@elastic.co>
 

--- a/dev-tools/packer/docker/xgo-image/build.sh
+++ b/dev-tools/packer/docker/xgo-image/build.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 docker build --rm=true -t tudorg/xgo-base base/ && \
-    docker build --rm=true -t tudorg/xgo-1.7.4 go-1.7.4/ &&
+    docker build --rm=true -t tudorg/xgo-1.7.6 go-1.7.6/ &&
     docker build --rm=true -t tudorg/beats-builder beats-builder

--- a/dev-tools/packer/docker/xgo-image/go-1.7.6/Dockerfile
+++ b/dev-tools/packer/docker/xgo-image/go-1.7.6/Dockerfile
@@ -1,4 +1,4 @@
-# Go cross compiler (xgo): Go 1.7.4 layer
+# Go cross compiler (xgo): Go 1.7.6 layer
 # Copyright (c) 2014 Péter Szilágyi. All rights reserved.
 #
 # Released under the MIT license.
@@ -9,7 +9,7 @@ MAINTAINER Tudor Golubenco <tudor@elastic.co>
 
 # Configure the root Go distribution and bootstrap based on it
 RUN \
-  export ROOT_DIST="https://storage.googleapis.com/golang/go1.7.4.linux-amd64.tar.gz" && \
-  export ROOT_DIST_SHA1="2e5baf03d1590e048c84d1d5b4b6f2540efaaea1" && \
+  export ROOT_DIST="https://storage.googleapis.com/golang/go1.7.6.linux-amd64.tar.gz" && \
+  export ROOT_DIST_SHA1="6a7014f34048d95ab60247814a1b8b98018810ff" && \
   \
   $BOOTSTRAP_PURE

--- a/filebeat/Dockerfile
+++ b/filebeat/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.7.4
+FROM golang:1.7.6
 MAINTAINER Nicolas Ruflin <ruflin@elastic.co>
 
 RUN set -x && \

--- a/libbeat/Dockerfile
+++ b/libbeat/Dockerfile
@@ -1,5 +1,5 @@
 # Beats dockerfile used for testing
-FROM golang:1.7.4
+FROM golang:1.7.6
 MAINTAINER Nicolas Ruflin <ruflin@elastic.co>
 
 RUN set -x && \

--- a/libbeat/docs/version.asciidoc
+++ b/libbeat/docs/version.asciidoc
@@ -1,4 +1,4 @@
 :stack-version: 5.4.0
 :doc-branch: 5.4
-:go-version: 1.7.4
+:go-version: 1.7.6
 :release-state: released

--- a/metricbeat/Dockerfile
+++ b/metricbeat/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.7.4
+FROM golang:1.7.6
 MAINTAINER Nicolas Ruflin <ruflin@elastic.co>
 
 RUN set -x && \

--- a/metricbeat/mb/mb_test.go
+++ b/metricbeat/mb/mb_test.go
@@ -3,6 +3,7 @@
 package mb
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -95,7 +96,7 @@ func TestModuleConfig(t *testing.T) {
 			continue
 		}
 		if test.err != "" &&
-			assert.Error(t, err, "expected '%v' in testcase %d", test.err, i) {
+			assert.Error(t, err, fmt.Sprintf("expected '%v' in testcase %d", test.err, i)) {
 			assert.Contains(t, err.Error(), test.err, "testcase %d", i)
 			continue
 		}

--- a/metricbeat/module/mysql/status/status_test.go
+++ b/metricbeat/module/mysql/status/status_test.go
@@ -1,6 +1,7 @@
 package status
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/elastic/beats/libbeat/common"
@@ -72,7 +73,7 @@ func TestConfigValidation(t *testing.T) {
 			t.Errorf("unexpected error in testcase %d: %v", i, err)
 			continue
 		}
-		if test.err != "" && assert.Error(t, err, "expected '%v' in testcase %d", test.err, i) {
+		if test.err != "" && assert.Error(t, err, fmt.Sprintf("expected '%v' in testcase %d", test.err, i)) {
 			assert.Contains(t, err.Error(), test.err, "testcase %d", i)
 			continue
 		}

--- a/packetbeat/Dockerfile
+++ b/packetbeat/Dockerfile
@@ -1,5 +1,5 @@
 # Beats dockerfile used for testing
-FROM golang:1.7.4
+FROM golang:1.7.6
 MAINTAINER Nicolas Ruflin <ruflin@elastic.co>
 
 RUN set -x && \

--- a/winlogbeat/config/config_test.go
+++ b/winlogbeat/config/config_test.go
@@ -3,6 +3,7 @@
 package config
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -18,7 +19,7 @@ func (v validationTestCase) run(t *testing.T) {
 		assert.NoError(t, v.config.Validate())
 	} else {
 		err := v.config.Validate()
-		if assert.Error(t, err, "expected '%s'", v.errMsg) {
+		if assert.Error(t, err, fmt.Sprintf("expected '%s'", v.errMsg)) {
 			assert.Contains(t, err.Error(), v.errMsg)
 		}
 	}


### PR DESCRIPTION
Updates all docker files and testing files to use Go 1.7.6 instead of Go 1.7.4.