### PR TITLE
Provide more detail on log levels

### DIFF
--- a/filebeat/docs/command-line.asciidoc
+++ b/filebeat/docs/command-line.asciidoc
@@ -1,4 +1,4 @@
-[[filebeat-command-line]]
+[[command-line-options]]
 === Command Line Options
 
 The following command line option is specific to Filebeat.

--- a/filebeat/docs/getting-started.asciidoc
+++ b/filebeat/docs/getting-started.asciidoc
@@ -18,7 +18,7 @@ After installing the Elastic Stack, read the following topics to learn how to in
 * <<filebeat-starting>>
 * <<filebeat-index-pattern>>
 * <<filebeat-modules-quickstart>>
-* <<filebeat-command-line>>
+* <<command-line-options>>
 * <<directory-layout>>
 
 [[filebeat-installation]]
@@ -223,7 +223,7 @@ include::../../libbeat/docs/shared-template-load.asciidoc[]
 Start Filebeat by issuing the appropriate command for your platform.
 
 NOTE: If you use an init.d script to start Filebeat on deb or rpm, you can't
-specify command line flags (see <<filebeat-command-line>>). To specify flags,
+specify command line flags (see <<command-line-options>>). To specify flags,
 start Filebeat in the foreground.
 
 *deb:*

--- a/filebeat/docs/migration.asciidoc
+++ b/filebeat/docs/migration.asciidoc
@@ -298,7 +298,7 @@ options with Logstash Forwarder, make sure that you add your options to the
 configuration file. For naming changes, see <<renamed-options>>.
 
 Filebeat does provide command line options that are common to all Beats. For more details about
-these options, see <<filebeat-command-line>>.
+these options, see <<command-line-options>>.
 
 [[renamed-options]]
 [float]

--- a/heartbeat/docs/command-line.asciidoc
+++ b/heartbeat/docs/command-line.asciidoc
@@ -1,4 +1,4 @@
-[[heartbeat-command-line]]
+[[command-line-options]]
 === Command Line Options
 
 Heartbeat does not have any Heartbeat-specific command line options.

--- a/heartbeat/docs/getting-started.asciidoc
+++ b/heartbeat/docs/getting-started.asciidoc
@@ -18,7 +18,7 @@ install, configure, and run Heartbeat:
 * <<heartbeat-configuration>>
 * <<heartbeat-template>>
 * <<heartbeat-starting>>
-* <<heartbeat-command-line>>
+* <<command-line-options>>
 * <<directory-layout>>
 
 
@@ -234,7 +234,7 @@ include::../../libbeat/docs/shared-template-load.asciidoc[]
 Start Heartbeat by issuing the appropriate command for your platform.
 
 NOTE: If you use an init.d script to start Heartbeat on deb or rpm, you can't
-specify command line flags (see <<heartbeat-command-line>>). To specify flags,
+specify command line flags (see <<command-line-options>>). To specify flags,
 start Heartbeat in the foreground.
 
 *deb:*

--- a/libbeat/docs/loggingconfig.asciidoc
+++ b/libbeat/docs/loggingconfig.asciidoc
@@ -15,8 +15,8 @@
 
 The `logging` section of the +{beatname_lc}.yml+ config file contains options
 for configuring the Beats logging output. The logging system can write logs to
-syslog or rotate log files. If logging is not explicitly configured, file output
-is used on Windows systems, and syslog output is used on Linux and OS X.
+the syslog or rotate log files. If logging is not explicitly configured, file
+output is used on Windows systems, and syslog output is used on Linux and OS X.
 
 [source,yaml]
 ------------------------------------------------------------------------------
@@ -29,8 +29,9 @@ logging.files:
   keepfiles: 7
 ------------------------------------------------------------------------------
 
-In addition to the logging system, the logging output configuration can be
-modified from the command line.
+TIP: In addition to setting logging options in the config file, you can modify
+the logging output configuration from the command line. See
+<<command-line-options>>.
 
 ==== Logging Options
 
@@ -38,20 +39,40 @@ You can specify the following options in the `logging` section of the +{beatname
 
 ===== to_syslog
 
-If enabled, sends all logging output to syslog. The default
-value is false. 
+When true, writes all logging output to the syslog.
 
 ===== to_files
 
-Writes all logging output to files subject to file rotation. The
-default value is true.
+When true, writes all logging output to files. The log files are automatically
+rotated when the log file size limit is reached.
 
+NOTE: {beatname_uc} only creates a log file if there is logging output. For
+example, if you set the log <<level,`level`>> to `error` and there are no errors,
+there will be no log file in the directory specified for logs.
+
+[[level]]
 ===== level
 
-Minimum log level. One of debug, info, warning, error or critical. If debug is
-used, but no selectors are configured, the `*` selector will be used.
-The default log level is "info".
+Minimum log level. One of `debug`, `info`, `warning`, `error`, or `critical`.
+The default log level is `info`.
 
+`debug`:: Logs debug messages, including a detailed printout of all events
+flushed by the Beat. Also logs informational messages, warnings, errors, and
+critical errors. When the log level is `debug`, you can specify a list of
+<<selectors,`selectors`>> to display debug messages for specific components.
+If no selectors are specified, the `*` selector is used to display debug
+messages for all components.
+
+`info`:: Logs informational messages, including the number of events
+that are published. Also logs any warnings, errors, or critical errors.
+
+`warning`:: Logs warnings, errors, and critical errors.
+
+`error`:: Logs errors and critical errors.
+
+`critical`:: Logs critical errors only.
+
+[[selectors]]
 ===== selectors
 
 The list of debugging-only selector tags used by different Beats components. Use `*`

--- a/packetbeat/docs/command-line.asciidoc
+++ b/packetbeat/docs/command-line.asciidoc
@@ -1,4 +1,4 @@
-[[packetbeat-command]]
+[[command-line-options]]
 === Command Line Options
 
 The following command line options are available for Packetbeat. To use these options,

--- a/packetbeat/docs/gettingstarted.asciidoc
+++ b/packetbeat/docs/gettingstarted.asciidoc
@@ -19,7 +19,7 @@ After installing the Elastic Stack, read the following topics to learn how to in
 * <<packetbeat-template>>
 * <<packetbeat-starting>>
 * <<packetbeat-sample-dashboards>>
-* <<packetbeat-command>>
+* <<command-line-options>>
 * <<directory-layout>>
 
 [[packetbeat-installation]]
@@ -259,7 +259,7 @@ include::../../libbeat/docs/shared-template-load.asciidoc[]
 Run Packetbeat by issuing the command that is appropriate for your platform.
 
 NOTE: If you use an init.d script to start Packetbeat on deb or rpm, you can't
-specify command line flags (see <<packetbeat-command>>). To specify flags,
+specify command line flags (see <<command-line-options>>). To specify flags,
 start Packetbeat in the foreground.
 
 *deb:*

--- a/winlogbeat/docs/command-line.asciidoc
+++ b/winlogbeat/docs/command-line.asciidoc
@@ -1,4 +1,4 @@
-[[winlogbeat-command-line-options]]
+[[command-line-options]]
 === Command Line Options
 
 Winlogbeat does not have any Winlogbeat-specific command line options. Instead,

--- a/winlogbeat/docs/getting-started.asciidoc
+++ b/winlogbeat/docs/getting-started.asciidoc
@@ -19,7 +19,7 @@ After installing the Elastic Stack, read the following topics to learn how to in
 * <<winlogbeat-template>>
 * <<winlogbeat-starting>>
 * <<winlogbeat-sample-dashboards>>
-* <<winlogbeat-command-line-options>>
+* <<command-line-options>>
 * <<directory-layout>>
 
 [[winlogbeat-installation]]


### PR DESCRIPTION
This issue adds more detail about log levels as requested in https://github.com/elastic/beats/issues/861.

I'm still being a bit vague in some of the descriptions (especially for debug) because I don't want to expose details about beat processing that might change over time.

Other changes:
- Had to do a bit of refactoring of anchor IDs to add a link to the topic about command line options.
- Removed defaults listed in to_file and to_syslog because they seemed to contradict what we say in the intro about the default logging output being platform-specific. 
- Didn't really understand what we meant by the following sentence, so I rewrote it to say what I think we mean: "In addition to the logging system, the logging output configuration can be
modified from the command line."
