### PR TITLE
Change haproxy.stat.check.health.last to string from long

### DIFF
--- a/metricbeat/docs/fields.asciidoc
+++ b/metricbeat/docs/fields.asciidoc
@@ -5188,7 +5188,7 @@ Time in ms that it took to finish the last health check.
 [float]
 === haproxy.stat.check.health.last
 
-type: long
+type: string
 
 
 


### PR DESCRIPTION
My metricbeat sends values like "HTTP status check returned code <200>" in that field