### PR TITLE
Cherry-pick #4378 to 5.x: Fix parsing of interface options with _ (#4334)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -49,6 +49,7 @@ https://github.com/elastic/beats/compare/v5.3.0...master[Check the HEAD diff]
 *Packetbeat*
 
 - Clean configured geoip.paths before attempting to open the database. {pull}4306[4306]
+- Fix `packetbeat.interface` options that contain underscores (e.g. `with_vlans` or `bpf_filter`). {pull}4378[4378]
 
 *Winlogbeat*
 

--- a/packetbeat/config/config.go
+++ b/packetbeat/config/config.go
@@ -18,13 +18,13 @@ type Config struct {
 }
 
 type InterfacesConfig struct {
-	Device       string
-	Type         string
-	File         string
-	WithVlans    bool
-	BpfFilter    string
-	Snaplen      int
-	BufferSizeMb int
+	Device       string `config:"device"`
+	Type         string `config:"type"`
+	File         string `config:"file"`
+	WithVlans    bool   `config:"with_vlans"`
+	BpfFilter    string `config:"bpf_filter"`
+	Snaplen      int    `config:"snaplen"`
+	BufferSizeMb int    `config:"buffer_size_mb"`
 	TopSpeed     bool
 	Dumpfile     string
 	OneAtATime   bool


### PR DESCRIPTION
Cherry-pick of PR #4378 to 5.x branch. Original message: 

In commit 55470602d1459ae6312fdec26b85c1c4d8da8d6c linting issues
were addresses and variables containing _ were renamed. This broke
the config parsing.

In packetbeat this seems to effect the with_vlans, bpf_filter and
the buffer_size_mb options. Correct it by using a tag in the structure.