### PR TITLE
Fix testing env in the 5.x branch

### DIFF
--- a/testing/environments/args.yml
+++ b/testing/environments/args.yml
@@ -5,5 +5,5 @@ services:
   args:
     build:
       args:
-        DOWNLOAD_URL: https://staging.elastic.co/5.4.0-555a617b/downloads
-        ELASTIC_VERSION: 5.4.0
+        DOWNLOAD_URL: https://snapshots.elastic.co/downloads
+        ELASTIC_VERSION: 5.5.0-SNAPSHOT


### PR DESCRIPTION
It was set on 5.4.0 BC, which got removed in the mean time.