### PR TITLE
Allow string characters in user agent patch version

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -37,6 +37,7 @@ https://github.com/elastic/beats/compare/v6.0.0-alpha1...master[Check the HEAD d
 *Filebeat*
 - Fix race condition on harvester stopping with reloading enabled. {issue}3779[3779]
 - Fix recursive glob config parsing and resolution across restarts. {pull}4269[4269]
+- Allow string characters in user agent patch version (NGINX and Apache) {pull}4415[4415]
 
 *Heartbeat*
 

--- a/filebeat/docs/fields.asciidoc
+++ b/filebeat/docs/fields.asciidoc
@@ -155,7 +155,7 @@ The minor version of the user agent.
 [float]
 === apache2.access.user_agent.patch
 
-type: long
+type: keyword
 
 The patch version of the user agent.
 
@@ -1063,7 +1063,7 @@ The minor version of the user agent.
 [float]
 === nginx.access.user_agent.patch
 
-type: long
+type: keyword
 
 The patch version of the user agent.
 

--- a/filebeat/module/apache2/access/_meta/fields.yml
+++ b/filebeat/module/apache2/access/_meta/fields.yml
@@ -61,7 +61,7 @@
           description: >
             The minor version of the user agent.
         - name: patch
-          type: long
+          type: keyword
           description: >
             The patch version of the user agent.
         - name: name

--- a/filebeat/module/apache2/access/test/test.log
+++ b/filebeat/module/apache2/access/test/test.log
@@ -1,3 +1,4 @@
 ::1 - - [26/Dec/2016:16:16:29 +0200] "GET /favicon.ico HTTP/1.1" 404 209
 192.168.33.1 - - [26/Dec/2016:16:22:13 +0000] "GET /hello HTTP/1.1" 404 499 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:50.0) Gecko/20100101 Firefox/50.0"
 ::1 - - [26/Dec/2016:16:16:48 +0200] "-" 408 -
+172.17.0.1 - - [29/May/2017:19:02:48 +0000] "GET /stringpatch HTTP/1.1" 404 612 "-" "Mozilla/5.0 (Windows NT 6.1; rv:15.0) Gecko/20120716 Firefox/15.0a2" "-"

--- a/filebeat/module/apache2/access/test/test.log-expected.json
+++ b/filebeat/module/apache2/access/test/test.log-expected.json
@@ -138,6 +138,56 @@
         "sort": [
             1482761808000
         ]
+    },
+    {
+        "_id": "AVxVs7QZsqw9BQCgtCgc",
+        "_index": "filebeat-6.0.0-alpha2-2017.05.29",
+        "_score": null,
+        "_source": {
+            "@timestamp": "2017-05-29T19:02:48.000Z",
+            "apache2": {
+                "access": {
+                    "body_sent": {
+                        "bytes": "612"
+                    },
+                    "http_version": "1.1",
+                    "method": "GET",
+                    "referrer": "-",
+                    "remote_ip": "172.17.0.1",
+                    "response_code": "404",
+                    "url": "/stringpatch",
+                    "user_agent": {
+                        "device": "Other",
+                        "major": "15",
+                        "minor": "0",
+                        "name": "Firefox Alpha",
+                        "os": "Windows 7",
+                        "os_name": "Windows 7",
+                        "patch": "a2"
+                    },
+                    "user_name": "-"
+                }
+            },
+            "beat": {
+                "hostname": "X1",
+                "name": "X1",
+                "version": "6.0.0-alpha2"
+            },
+            "offset": 443,
+            "prospector": {
+                "type": "log"
+            },
+            "read_timestamp": "2017-05-29T19:34:14.378Z",
+            "source": "/home/exekias/go/src/github.com/elastic/beats/filebeat/apache2.log"
+        },
+        "_type": "doc",
+        "fields": {
+            "@timestamp": [
+                1496084568000
+            ]
+        },
+        "sort": [
+            1496084568000
+        ]
     }
 ]
-

--- a/filebeat/module/nginx/access/_meta/fields.yml
+++ b/filebeat/module/nginx/access/_meta/fields.yml
@@ -61,7 +61,7 @@
           description: >
             The minor version of the user agent.
         - name: patch
-          type: long
+          type: keyword
           description: >
             The patch version of the user agent.
         - name: name

--- a/filebeat/module/nginx/access/test/test.log
+++ b/filebeat/module/nginx/access/test/test.log
@@ -1,1 +1,2 @@
 10.0.0.2, 10.0.0.1, 127.0.0.1 - - [07/Dec/2016:11:05:07 +0100] "GET /ocelot HTTP/1.1" 200 571 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:49.0) Gecko/20100101 Firefox/49.0"
+172.17.0.1 - - [29/May/2017:19:02:48 +0000] "GET /stringpatch HTTP/1.1" 404 612 "-" "Mozilla/5.0 (Windows NT 6.1; rv:15.0) Gecko/20120716 Firefox/15.0a2" "-"

--- a/filebeat/module/nginx/access/test/test.log-expected.json
+++ b/filebeat/module/nginx/access/test/test.log-expected.json
@@ -54,5 +54,56 @@
         "sort": [
             1481105107000
         ]
+    },
+    {
+        "_id": "AVxVuTJrsqw9BQCgtCgi",
+        "_index": "filebeat-6.0.0-alpha2-2017.05.29",
+        "_score": null,
+        "_source": {
+            "@timestamp": "2017-05-29T19:02:48.000Z",
+            "beat": {
+                "hostname": "X1",
+                "name": "X1",
+                "version": "6.0.0-alpha2"
+            },
+            "nginx": {
+                "access": {
+                    "body_sent": {
+                        "bytes": "612"
+                    },
+                    "http_version": "1.1",
+                    "method": "GET",
+                    "referrer": "-",
+                    "remote_ip": "172.17.0.1",
+                    "response_code": "404",
+                    "url": "/stringpatch",
+                    "user_agent": {
+                        "device": "Other",
+                        "major": "15",
+                        "minor": "0",
+                        "name": "Firefox Alpha",
+                        "os": "Windows 7",
+                        "os_name": "Windows 7",
+                        "patch": "a2"
+                    },
+                    "user_name": "-"
+                }
+            },
+            "offset": 341,
+            "prospector": {
+                "type": "log"
+            },
+            "read_timestamp": "2017-05-29T19:40:14.373Z",
+            "source": "/home/exekias/go/src/github.com/elastic/beats/filebeat/nginx.log"
+        },
+        "_type": "doc",
+        "fields": {
+            "@timestamp": [
+                1496084568000
+            ]
+        },
+        "sort": [
+            1496084568000
+        ]
     }
 ]


### PR DESCRIPTION
Both for NGINX and Apache logs

Fixes #3836 

This changes the mapping, what's our policy for these cases?