### PR TITLE
Cherry-pick #4410 to 5.x: Fix type for HAProxy health.last field

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -47,6 +47,8 @@ https://github.com/elastic/beats/compare/v5.3.0...master[Check the HEAD diff]
 
 *Metricbeat*
 
+- Fix type of field `haproxy.stat.check.health.last`. {issue}4407[4407]
+
 *Packetbeat*
 
 - Clean configured geoip.paths before attempting to open the database. {pull}4306[4306]

--- a/metricbeat/docs/fields.asciidoc
+++ b/metricbeat/docs/fields.asciidoc
@@ -2635,8 +2635,9 @@ Time in ms that it took to finish the last health check.
 [float]
 === haproxy.stat.check.health.last
 
-type: long
+type: keyword
 
+The result of the last health check.
 
 
 [float]
@@ -2644,6 +2645,7 @@ type: long
 
 type: long
 
+Number of failed checks.
 
 
 [float]

--- a/metricbeat/metricbeat.template-es2x.json
+++ b/metricbeat/metricbeat.template-es2x.json
@@ -1283,7 +1283,9 @@
                           "type": "long"
                         },
                         "last": {
-                          "type": "long"
+                          "ignore_above": 1024,
+                          "index": "not_analyzed",
+                          "type": "string"
                         }
                       }
                     },

--- a/metricbeat/metricbeat.template-es6x.json
+++ b/metricbeat/metricbeat.template-es6x.json
@@ -1281,7 +1281,8 @@
                           "type": "long"
                         },
                         "last": {
-                          "type": "long"
+                          "ignore_above": 1024,
+                          "type": "keyword"
                         }
                       }
                     },

--- a/metricbeat/metricbeat.template.json
+++ b/metricbeat/metricbeat.template.json
@@ -1284,7 +1284,8 @@
                           "type": "long"
                         },
                         "last": {
-                          "type": "long"
+                          "ignore_above": 1024,
+                          "type": "keyword"
                         }
                       }
                     },

--- a/metricbeat/module/haproxy/stat/_meta/fields.yml
+++ b/metricbeat/module/haproxy/stat/_meta/fields.yml
@@ -298,12 +298,14 @@
             Time in ms that it took to finish the last health check.
 
         - name: health.last
-          type: long
+          type: keyword
           description: >
+            The result of the last health check.
 
         - name: health.fail
           type: long
           description: >
+            Number of failed checks.
 
         - name: agent.last
           type: integer


### PR DESCRIPTION
Cherry-pick of PR #4410 to 5.x branch. Original message: 

Fixes #4407. Also adds docs for two fields where docs were missing.