### PR TITLE
Fix init script

### DIFF
--- a/dev-tools/packer/platforms/centos/init.j2
+++ b/dev-tools/packer/platforms/centos/init.j2
@@ -29,7 +29,7 @@ args="-c /etc/{{.beat_name}}/{{.beat_name}}.yml -path.home /usr/share/{{.beat_na
 test_args="-e -configtest"
 beat_user="${BEAT_USER:-root}"
 wrapper="/usr/share/{{.beat_name}}/bin/{{.beat_name}}-god"
-wrapperopts="-r / -n -p $pidfile -u $beat_user"
+wrapperopts="-r / -n -p $pidfile"
 user_wrapper="su"
 user_wrapperopts="$beat_user -c"
 RETVAL=0
@@ -44,9 +44,11 @@ if status | grep -q -- '-p' 2>/dev/null; then
     pidopts="-p $pidfile"
 fi
 
-if runuser -v &> /dev/null; then
+if command -v runuser >/dev/null 2>&1; then
     user_wrapper="runuser"
 fi
+
+[ "$beat_user" != "root" ] && wrapperopts="$wrapperopts -u $beat_user"
 
 test() {
 	$user_wrapper $user_wrapperopts "$agent $args $test_args"

--- a/dev-tools/packer/platforms/debian/init.j2
+++ b/dev-tools/packer/platforms/debian/init.j2
@@ -31,11 +31,11 @@ SCRIPTNAME=/etc/init.d/$NAME
 # Read configuration variable file if it is present
 [ -r /etc/default/$NAME ] && . /etc/default/$NAME
 
-WRAPPER_ARGS="-r / -n -p $PIDFILE -u $BEAT_USER"
+[ "$BEAT_USER" != "root" ] && WRAPPER_ARGS="$WRAPPER_ARGS -u $BEAT_USER"
 USER_WRAPPER="su"
 USER_WRAPPER_ARGS="$BEAT_USER -c"
 
-if runuser -v &> /dev/null; then
+if command -v runuser >/dev/null 2>&1; then
     USER_WRAPPER="runuser"
 fi
 


### PR DESCRIPTION
* Correct the way runuser is called
* Only use `-u $beat_user` if `beat_user` is not `root`. That's because the `-u` command seems to have issues on ubuntu systems.

Fixes #4429.