### PR TITLE
Change input_type to type in config examples

### DIFF
--- a/docs/devguide/modules-dev-guide.asciidoc
+++ b/docs/devguide/modules-dev-guide.asciidoc
@@ -149,7 +149,7 @@ A typical example looks like this:
 
 [source,yaml]
 ----
-input_type: log
+type: log
 paths:
 {{ range $i, $path := .paths }}
  - {{$path}}
@@ -174,7 +174,7 @@ Here is another example that also configures multiline stitching:
 
 [source,yaml]
 ----
-input_type: log
+type: log
 paths:
 {{ range $i, $path := .paths }}
  - {{$path}}

--- a/libbeat/docs/config-file-format.asciidoc
+++ b/libbeat/docs/config-file-format.asciidoc
@@ -35,7 +35,7 @@ Lists and dictionaries are used in beats to build structured configurations.
 ------------------------------------------------------------------------------
 filebeat:
   prospectors:
-    - input_type: log
+    - type: log
       paths:
         - /var/log/*.log
       multiline:
@@ -92,11 +92,11 @@ For example this filebeat setting:
 
 filebeat:
   prospectors:
-    - input_type: log
+    - type: log
 
 ------------------------------------------------------------------------------
 
-Gets collapsed into `filebeat.prospectors.0.input_type: log`.
+Gets collapsed into `filebeat.prospectors.0.type: log`.
 
 Alternatively to using indentation, setting names can be used in collapsed form too.
 
@@ -109,7 +109,7 @@ Simple filebeat example with partially collapsed setting names and use of compac
 ------------------------------------------------------------------------------
 
 filebeat.prospectors:
-- input_type: log
+- type: log
   paths: ["/var/log/*.log"] 
   multiline.pattern: '^['
   multiline.match: after


### PR DESCRIPTION
Changes `input_type` to `type` to be consistent with https://github.com/elastic/beats/pull/4294

These aren't exactly examples that users will follow, but it's probably best to be consistent.
