### PR TITLE
Make IP port indexer constructor public

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -207,6 +207,7 @@ https://github.com/elastic/beats/compare/v5.4.0...v6.0.0-alpha1[View commits]
 - Add experimental Elasticsearch module. {pull}3903[3903]
 - Add experimental Kibana module. {pull}3895[3895]
 - Move elasticsearch metricset node_stats under node.stats namespace. {pull}4142[4142]
+- Make IP port indexer constructor public {pull}4434[4434]
 
 *Packetbeat*
 

--- a/metricbeat/processor/kubernetes/indexing.go
+++ b/metricbeat/processor/kubernetes/indexing.go
@@ -14,7 +14,7 @@ const (
 
 func init() {
 	// Register default indexers
-	kubernetes.Indexing.AddIndexer(IpPortIndexerName, newIpPortIndexer)
+	kubernetes.Indexing.AddIndexer(IpPortIndexerName, NewIpPortIndexer)
 	cfg := common.NewConfig()
 
 	//Add IP Port Indexer as a default indexer
@@ -35,7 +35,7 @@ type IpPortIndexer struct {
 	genMeta kubernetes.GenMeta
 }
 
-func newIpPortIndexer(_ common.Config, genMeta kubernetes.GenMeta) (kubernetes.Indexer, error) {
+func NewIpPortIndexer(_ common.Config, genMeta kubernetes.GenMeta) (kubernetes.Indexer, error) {
 	return &IpPortIndexer{genMeta: genMeta}, nil
 }
 

--- a/metricbeat/processor/kubernetes/indexing_test.go
+++ b/metricbeat/processor/kubernetes/indexing_test.go
@@ -14,7 +14,7 @@ var metagen = &kubernetes.GenDefaultMeta{}
 func TestIpPortIndexer(t *testing.T) {
 	var testConfig = common.NewConfig()
 
-	ipIndexer, err := newIpPortIndexer(*testConfig, metagen)
+	ipIndexer, err := NewIpPortIndexer(*testConfig, metagen)
 	assert.Nil(t, err)
 
 	podName := "testpod"


### PR DESCRIPTION
`NewIpPortIndexer()` has scope to be used and extended by other beats. We could make the method public like all the other indexers