### PR TITLE
Add handling of LayerTypeRaw used by tun devices for pcap (#4426)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -83,6 +83,8 @@ https://github.com/elastic/beats/compare/v6.0.0-alpha1...master[Check the HEAD d
 
 *Packetbeat*
 
+- Add support to capture from a tun device. {issue}4426{4426}
+
 *Winlogbeat*
 
 ==== Deprecated

--- a/packetbeat/decoder/decoder.go
+++ b/packetbeat/decoder/decoder.go
@@ -24,6 +24,7 @@ type Decoder struct {
 	sll       layers.LinuxSLL
 	lo        layers.Loopback
 	eth       layers.Ethernet
+	raw       layers.Raw
 	d1q       [2]layers.Dot1Q
 	ip4       [2]layers.IPv4
 	ip6       [2]layers.IPv6
@@ -107,6 +108,9 @@ func New(
 	case layers.LinkTypeNull: // loopback on OSx
 		d.linkLayerDecoder = &d.lo
 		d.linkLayerType = layers.LayerTypeLoopback
+	case layers.LinkTypeRaw:
+		d.linkLayerDecoder = &d.raw
+		d.linkLayerType = layers.LayerTypeRaw
 	default:
 		return nil, fmt.Errorf("Unsupported link type: %s", datalink.String())
 	}


### PR DESCRIPTION
Be able to capture from a tun device. It has been manually tested by
invoking packetbeat with:

 $ ./packetbeat -c packetbeat.yml  -N -e -I tuncap.pcap

Loglines with "DBG  Layer type: Raw" and "flowid: add ipv4" can be
seen. Support for af_packet is not added here. It is not clear if raw
should be added to the defaultLayerTypes.