### PR TITLE
Bump docs version to 6.0.0-alpha2

### DIFF
--- a/libbeat/docs/version.asciidoc
+++ b/libbeat/docs/version.asciidoc
@@ -1,4 +1,4 @@
-:stack-version: 6.0.0-alpha1
+:stack-version: 6.0.0-alpha2
 :doc-branch: master
 :go-version: 1.8.3
 :release-state: prerelease


### PR DESCRIPTION
Let's wait for a few hours before the release for this one.