### PR TITLE
Fix command line template generation

### DIFF
--- a/dev-tools/cmd/index_template/index_template.go
+++ b/dev-tools/cmd/index_template/index_template.go
@@ -41,7 +41,7 @@ func main() {
 		*version = "2.0.0"
 	}
 
-	tmpl, err := template.New(beatVersion, *version, *index)
+	tmpl, err := template.New(beatVersion, *version, *index, template.TemplateSettings{})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error generating template: %+v", err)
 		os.Exit(1)

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -300,7 +300,7 @@ docs-preview:  ## @build Preview the documents for the beat in the browser
 
 .PHONY: index-template
 index-template: ## @build Generate index templates for the given $VERSION. This is for manual testing.
-	go run ${ES_BEATS}/dev-tools/cmd/index_template/index_template.go -es.version ${VERSION} -index ${BEAT_NAME} -output ${BEAT_GOPATH}/src/${BEAT_PATH}/${BEAT_NAME}.template-es${VERSION}.json -file ${BEAT_GOPATH}/src/${BEAT_PATH}/fields.yml
+	go run ${ES_BEATS}/dev-tools/cmd/index_template/index_template.go -index ${BEAT_NAME} -output ${BEAT_GOPATH}/src/${BEAT_PATH}/${BEAT_NAME}.template-es${VERSION}.json -file ${BEAT_GOPATH}/src/${BEAT_PATH}/fields.yml -es.version=${VERSION}
 
 ### KIBANA FILES HANDLING ###
 ES_URL?=http://localhost:9200

--- a/libbeat/template/config.go
+++ b/libbeat/template/config.go
@@ -5,7 +5,7 @@ type TemplateConfig struct {
 	Name         string           `config:"name"`
 	Fields       string           `config:"fields"`
 	Overwrite    bool             `config:"overwrite"`
-	Settings     templateSettings `config:"settings"`
+	Settings     TemplateSettings `config:"settings"`
 	OutputToFile OutputToFile     `config:"output_to_file"`
 }
 
@@ -16,7 +16,7 @@ type OutputToFile struct {
 	Version string `config:"version"`
 }
 
-type templateSettings struct {
+type TemplateSettings struct {
 	Index  map[string]interface{} `config:"index"`
 	Source map[string]interface{} `config:"_source"`
 }

--- a/libbeat/template/load_integration_test.go
+++ b/libbeat/template/load_integration_test.go
@@ -45,7 +45,7 @@ func TestLoadTemplate(t *testing.T) {
 	fieldsPath := absPath + "/fields.yml"
 	index := "testbeat"
 
-	tmpl, err := New(version.GetDefaultVersion(), client.GetVersion(), index, templateSettings{})
+	tmpl, err := New(version.GetDefaultVersion(), client.GetVersion(), index, TemplateSettings{})
 	assert.NoError(t, err)
 	content, err := tmpl.Load(fieldsPath)
 	assert.NoError(t, err)
@@ -135,7 +135,7 @@ func TestLoadBeatsTemplate(t *testing.T) {
 		fieldsPath := absPath + "/fields.yml"
 		index := beat
 
-		tmpl, err := New(version.GetDefaultVersion(), client.GetVersion(), index, templateSettings{})
+		tmpl, err := New(version.GetDefaultVersion(), client.GetVersion(), index, TemplateSettings{})
 		assert.NoError(t, err)
 		content, err := tmpl.Load(fieldsPath)
 		assert.NoError(t, err)
@@ -173,7 +173,7 @@ func TestTemplateSettings(t *testing.T) {
 
 	fieldsPath := absPath + "/fields.yml"
 
-	settings := templateSettings{
+	settings := TemplateSettings{
 		Index: common.MapStr{
 			"number_of_shards": 1,
 		},
@@ -245,7 +245,7 @@ func TestOverwrite(t *testing.T) {
 	config = newConfigFrom(t, TemplateConfig{
 		Enabled: true,
 		Fields:  absPath + "/fields.yml",
-		Settings: templateSettings{
+		Settings: TemplateSettings{
 			Source: map[string]interface{}{
 				"enabled": false,
 			},
@@ -266,7 +266,7 @@ func TestOverwrite(t *testing.T) {
 		Enabled:   true,
 		Overwrite: true,
 		Fields:    absPath + "/fields.yml",
-		Settings: templateSettings{
+		Settings: TemplateSettings{
 			Source: map[string]interface{}{
 				"enabled": false,
 			},

--- a/libbeat/template/template.go
+++ b/libbeat/template/template.go
@@ -20,11 +20,11 @@ type Template struct {
 	index       string
 	beatVersion Version
 	esVersion   Version
-	settings    templateSettings
+	settings    TemplateSettings
 }
 
 // New creates a new template instance
-func New(beatVersion string, esVersion string, index string, settings templateSettings) (*Template, error) {
+func New(beatVersion string, esVersion string, index string, settings TemplateSettings) (*Template, error) {
 
 	bV, err := NewVersion(beatVersion)
 	if err != nil {


### PR DESCRIPTION
The params for `New` change in the template package. This PR adjusts to the new params. It requires to make the settings available globally.

In addition the version handling is changed so the command can also be run without `$VERSION` and just the beats version is used.