### PR TITLE
Move libbeat filebeat dependency to libbeat

### DIFF
--- a/filebeat/input/file/file_other.go
+++ b/filebeat/input/file/file_other.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"os"
 	"syscall"
-
-	"github.com/elastic/beats/libbeat/logp"
 )
 
 type StateOS struct {
@@ -36,15 +34,6 @@ func (fs StateOS) IsSame(state StateOS) bool {
 
 func (fs StateOS) String() string {
 	return fmt.Sprintf("%d-%d", fs.Inode, fs.Device)
-}
-
-// SafeFileRotate safely rotates an existing file under path and replaces it with the tempfile
-func SafeFileRotate(path, tempfile string) error {
-	if e := os.Rename(tempfile, path); e != nil {
-		logp.Err("Rotate error: %s", e)
-		return e
-	}
-	return nil
 }
 
 // ReadOpen opens a file for reading only

--- a/filebeat/input/file/file_test.go
+++ b/filebeat/input/file/file_test.go
@@ -3,7 +3,6 @@
 package file
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -44,60 +43,4 @@ func TestIsSameFile(t *testing.T) {
 
 	assert.True(t, file3.IsSameFile(file2))
 	assert.True(t, file2.IsSameFile(file3))
-}
-
-func TestSafeFileRotateExistingFile(t *testing.T) {
-
-	tempdir, err := ioutil.TempDir("", "")
-	assert.NoError(t, err)
-	defer func() {
-		assert.NoError(t, os.RemoveAll(tempdir))
-	}()
-
-	// create an existing registry file
-	err = ioutil.WriteFile(filepath.Join(tempdir, "registry"),
-		[]byte("existing filebeat"), 0x777)
-	assert.NoError(t, err)
-
-	// create a new registry.new file
-	err = ioutil.WriteFile(filepath.Join(tempdir, "registry.new"),
-		[]byte("new filebeat"), 0x777)
-	assert.NoError(t, err)
-
-	// rotate registry.new into registry
-	err = SafeFileRotate(filepath.Join(tempdir, "registry"),
-		filepath.Join(tempdir, "registry.new"))
-	assert.NoError(t, err)
-
-	contents, err := ioutil.ReadFile(filepath.Join(tempdir, "registry"))
-	assert.NoError(t, err)
-	assert.Equal(t, []byte("new filebeat"), contents)
-
-	// do it again to make sure we deal with deleting the old file
-
-	err = ioutil.WriteFile(filepath.Join(tempdir, "registry.new"),
-		[]byte("new filebeat 1"), 0x777)
-	assert.NoError(t, err)
-
-	err = SafeFileRotate(filepath.Join(tempdir, "registry"),
-		filepath.Join(tempdir, "registry.new"))
-	assert.NoError(t, err)
-
-	contents, err = ioutil.ReadFile(filepath.Join(tempdir, "registry"))
-	assert.NoError(t, err)
-	assert.Equal(t, []byte("new filebeat 1"), contents)
-
-	// and again for good measure
-
-	err = ioutil.WriteFile(filepath.Join(tempdir, "registry.new"),
-		[]byte("new filebeat 2"), 0x777)
-	assert.NoError(t, err)
-
-	err = SafeFileRotate(filepath.Join(tempdir, "registry"),
-		filepath.Join(tempdir, "registry.new"))
-	assert.NoError(t, err)
-
-	contents, err = ioutil.ReadFile(filepath.Join(tempdir, "registry"))
-	assert.NoError(t, err)
-	assert.Equal(t, []byte("new filebeat 2"), contents)
 }

--- a/filebeat/input/file/file_windows.go
+++ b/filebeat/input/file/file_windows.go
@@ -5,8 +5,6 @@ import (
 	"os"
 	"reflect"
 	"syscall"
-
-	"github.com/elastic/beats/libbeat/logp"
 )
 
 type StateOS struct {
@@ -47,31 +45,6 @@ func (fs StateOS) IsSame(state StateOS) bool {
 
 func (fs StateOS) String() string {
 	return fmt.Sprintf("%d-%d-%d", fs.IdxHi, fs.IdxLo, fs.Vol)
-}
-
-// SafeFileRotate safely rotates an existing file under path and replaces it with the tempfile
-func SafeFileRotate(path, tempfile string) error {
-	old := path + ".old"
-	var e error
-
-	// In Windows, one cannot rename a file if the destination already exists, at least
-	// not with using the os.Rename function that Golang offers.
-	// This tries to move the existing file into an old file first and only do the
-	// move after that.
-	if e = os.Remove(old); e != nil {
-		logp.Debug("filecompare", "delete old: %v", e)
-		// ignore error in case old doesn't exit yet
-	}
-	if e = os.Rename(path, old); e != nil {
-		logp.Debug("filecompare", "rotate to old: %v", e)
-		// ignore error in case path doesn't exist
-	}
-
-	if e = os.Rename(tempfile, path); e != nil {
-		logp.Err("rotate: %v", e)
-		return e
-	}
-	return nil
 }
 
 // ReadOpen opens a file for reading only

--- a/filebeat/registrar/registrar.go
+++ b/filebeat/registrar/registrar.go
@@ -10,6 +10,7 @@ import (
 	"github.com/elastic/beats/filebeat/input/file"
 	"github.com/elastic/beats/filebeat/publisher"
 	"github.com/elastic/beats/filebeat/util"
+	helper "github.com/elastic/beats/libbeat/common/file"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/monitoring"
 	"github.com/elastic/beats/libbeat/paths"
@@ -228,7 +229,7 @@ func (r *Registrar) writeRegistry() error {
 	// Directly close file because of windows
 	f.Close()
 
-	err = file.SafeFileRotate(r.registryFile, tempfile)
+	err = helper.SafeFileRotate(r.registryFile, tempfile)
 
 	logp.Debug("registrar", "Registry file updated. %d states written.", len(states))
 	registryWrites.Add(1)

--- a/libbeat/beat/beat.go
+++ b/libbeat/beat/beat.go
@@ -45,10 +45,10 @@ import (
 
 	"github.com/satori/go.uuid"
 
-	"github.com/elastic/beats/filebeat/input/file"
 	"github.com/elastic/beats/libbeat/api"
 	"github.com/elastic/beats/libbeat/cfgfile"
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/file"
 	"github.com/elastic/beats/libbeat/dashboards"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/monitoring/report"

--- a/libbeat/common/file/helper_other.go
+++ b/libbeat/common/file/helper_other.go
@@ -1,0 +1,18 @@
+// +build !windows
+
+package file
+
+import (
+	"os"
+
+	"github.com/elastic/beats/libbeat/logp"
+)
+
+// SafeFileRotate safely rotates an existing file under path and replaces it with the tempfile
+func SafeFileRotate(path, tempfile string) error {
+	if e := os.Rename(tempfile, path); e != nil {
+		logp.Err("Rotate error: %s", e)
+		return e
+	}
+	return nil
+}

--- a/libbeat/common/file/helper_test.go
+++ b/libbeat/common/file/helper_test.go
@@ -1,0 +1,68 @@
+// +build !integration
+
+package file
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSafeFileRotateExistingFile(t *testing.T) {
+
+	tempdir, err := ioutil.TempDir("", "")
+	assert.NoError(t, err)
+	defer func() {
+		assert.NoError(t, os.RemoveAll(tempdir))
+	}()
+
+	// create an existing registry file
+	err = ioutil.WriteFile(filepath.Join(tempdir, "registry"),
+		[]byte("existing filebeat"), 0x777)
+	assert.NoError(t, err)
+
+	// create a new registry.new file
+	err = ioutil.WriteFile(filepath.Join(tempdir, "registry.new"),
+		[]byte("new filebeat"), 0x777)
+	assert.NoError(t, err)
+
+	// rotate registry.new into registry
+	err = SafeFileRotate(filepath.Join(tempdir, "registry"),
+		filepath.Join(tempdir, "registry.new"))
+	assert.NoError(t, err)
+
+	contents, err := ioutil.ReadFile(filepath.Join(tempdir, "registry"))
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("new filebeat"), contents)
+
+	// do it again to make sure we deal with deleting the old file
+
+	err = ioutil.WriteFile(filepath.Join(tempdir, "registry.new"),
+		[]byte("new filebeat 1"), 0x777)
+	assert.NoError(t, err)
+
+	err = SafeFileRotate(filepath.Join(tempdir, "registry"),
+		filepath.Join(tempdir, "registry.new"))
+	assert.NoError(t, err)
+
+	contents, err = ioutil.ReadFile(filepath.Join(tempdir, "registry"))
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("new filebeat 1"), contents)
+
+	// and again for good measure
+
+	err = ioutil.WriteFile(filepath.Join(tempdir, "registry.new"),
+		[]byte("new filebeat 2"), 0x777)
+	assert.NoError(t, err)
+
+	err = SafeFileRotate(filepath.Join(tempdir, "registry"),
+		filepath.Join(tempdir, "registry.new"))
+	assert.NoError(t, err)
+
+	contents, err = ioutil.ReadFile(filepath.Join(tempdir, "registry"))
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("new filebeat 2"), contents)
+}

--- a/libbeat/common/file/helper_windows.go
+++ b/libbeat/common/file/helper_windows.go
@@ -1,0 +1,32 @@
+package file
+
+import (
+	"os"
+
+	"github.com/elastic/beats/libbeat/logp"
+)
+
+// SafeFileRotate safely rotates an existing file under path and replaces it with the tempfile
+func SafeFileRotate(path, tempfile string) error {
+	old := path + ".old"
+	var e error
+
+	// In Windows, one cannot rename a file if the destination already exists, at least
+	// not with using the os.Rename function that Golang offers.
+	// This tries to move the existing file into an old file first and only do the
+	// move after that.
+	if e = os.Remove(old); e != nil {
+		logp.Debug("filecompare", "delete old: %v", e)
+		// ignore error in case old doesn't exit yet
+	}
+	if e = os.Rename(path, old); e != nil {
+		logp.Debug("filecompare", "rotate to old: %v", e)
+		// ignore error in case path doesn't exist
+	}
+
+	if e = os.Rename(tempfile, path); e != nil {
+		logp.Err("rotate: %v", e)
+		return e
+	}
+	return nil
+}


### PR DESCRIPTION
Libbeat had a dependency on filebeat because of file rotation. This PR removes the dependency by moving the file rotation code to