### PR TITLE
Fixes to import_dashboards

### DIFF
--- a/libbeat/dashboards/dashboards.go
+++ b/libbeat/dashboards/dashboards.go
@@ -12,6 +12,7 @@ import (
 type DashboardLoader interface {
 	LoadJSON(path string, json map[string]interface{}) ([]byte, error)
 	CreateIndex(index string, body interface{}) (int, *elasticsearch.QueryResult, error)
+	IndexExists(index string) (int, error)
 }
 
 func ImportDashboards(beatName, beatVersion string, esClient DashboardLoader, cfg *common.Config) error {

--- a/libbeat/dashboards/importer.go
+++ b/libbeat/dashboards/importer.go
@@ -73,7 +73,7 @@ func (imp Importer) Import() error {
 // some index properties which are needed as a workaround for:
 // https://github.com/elastic/beats-dashboards/issues/94
 func (imp Importer) CreateKibanaIndex() error {
-	status, err := imp.client.IndexExists(imp.cfg.KibanaIndex) 
+	status, err := imp.client.IndexExists(imp.cfg.KibanaIndex)
 
 	if err != nil {
 		if status != 404 {
@@ -505,7 +505,7 @@ func (imp Importer) downloadFile(url string, target string) (string, error) {
 	if err != nil {
 		return targetPath, err
 	}
-	if (resp.StatusCode != 200) {
+	if resp.StatusCode != 200 {
 		return targetPath, fmt.Errorf("Server returned: %s", resp.Status)
 	}
 	defer resp.Body.Close()

--- a/libbeat/dashboards/importer.go
+++ b/libbeat/dashboards/importer.go
@@ -79,7 +79,7 @@ func (imp Importer) CreateKibanaIndex() error {
 		if status != 404 {
 			return err
 		} else {
-			_, _, err := imp.client.CreateIndex(imp.cfg.KibanaIndex,
+			_, _, err = imp.client.CreateIndex(imp.cfg.KibanaIndex,
 				common.MapStr{
 					"settings": common.MapStr{
 						"index.mapping.single_type": false,

--- a/libbeat/dashboards/importer.go
+++ b/libbeat/dashboards/importer.go
@@ -73,28 +73,40 @@ func (imp Importer) Import() error {
 // some index properties which are needed as a workaround for:
 // https://github.com/elastic/beats-dashboards/issues/94
 func (imp Importer) CreateKibanaIndex() error {
-	imp.client.CreateIndex(imp.cfg.KibanaIndex,
-		common.MapStr{
-			"settings": common.MapStr{
-				"index.mapping.single_type": false,
-			},
-		})
-	_, _, err := imp.client.CreateIndex(imp.cfg.KibanaIndex+"/_mapping/search",
-		common.MapStr{
-			"search": common.MapStr{
-				"properties": common.MapStr{
-					"hits": common.MapStr{
-						"type": "integer",
-					},
-					"version": common.MapStr{
-						"type": "integer",
+	status, err := imp.client.IndexExists(imp.cfg.KibanaIndex) 
+	if err != nil {
+		return err
+	}
+
+	if status == 404 {
+		_, _, err := imp.client.CreateIndex(imp.cfg.KibanaIndex,
+			common.MapStr{
+				"settings": common.MapStr{
+					"index.mapping.single_type": false,
+				},
+			})
+		if err != nil {
+			return fmt.Errorf("Failed to create index: %v", err)
+		}
+
+		_, _, err = imp.client.CreateIndex(imp.cfg.KibanaIndex+"/_mapping/search",
+			common.MapStr{
+				"search": common.MapStr{
+					"properties": common.MapStr{
+						"hits": common.MapStr{
+							"type": "integer",
+						},
+						"version": common.MapStr{
+							"type": "integer",
+						},
 					},
 				},
-			},
-		})
-	if err != nil {
-		imp.statusMsg("Failed to set the mapping: %v", err)
+			})
+		if err != nil {
+			return fmt.Errorf("Failed to set the mapping: %v", err)
+		}
 	}
+
 	return nil
 }
 
@@ -491,6 +503,9 @@ func (imp Importer) downloadFile(url string, target string) (string, error) {
 	resp, err := http.Get(url)
 	if err != nil {
 		return targetPath, err
+	}
+	if (resp.StatusCode != 200) {
+		return targetPath, fmt.Errorf("Server returned: %s", resp.Status)
 	}
 	defer resp.Body.Close()
 

--- a/libbeat/dashboards/importer.go
+++ b/libbeat/dashboards/importer.go
@@ -505,11 +505,7 @@ func (imp Importer) downloadFile(url string, target string) (string, error) {
 	if err != nil {
 		return targetPath, err
 	}
-<<<<<<< HEAD
 	if resp.StatusCode != 200 {
-=======
-	if (resp.StatusCode != 200) {
->>>>>>> Check if .kibana exists before trying to create it
 		return targetPath, fmt.Errorf("Server returned: %s", resp.Status)
 	}
 	defer resp.Body.Close()

--- a/libbeat/dashboards/importer.go
+++ b/libbeat/dashboards/importer.go
@@ -505,7 +505,11 @@ func (imp Importer) downloadFile(url string, target string) (string, error) {
 	if err != nil {
 		return targetPath, err
 	}
+<<<<<<< HEAD
 	if resp.StatusCode != 200 {
+=======
+	if (resp.StatusCode != 200) {
+>>>>>>> Check if .kibana exists before trying to create it
 		return targetPath, fmt.Errorf("Server returned: %s", resp.Status)
 	}
 	defer resp.Body.Close()

--- a/libbeat/dashboards/importer.go
+++ b/libbeat/dashboards/importer.go
@@ -74,36 +74,37 @@ func (imp Importer) Import() error {
 // https://github.com/elastic/beats-dashboards/issues/94
 func (imp Importer) CreateKibanaIndex() error {
 	status, err := imp.client.IndexExists(imp.cfg.KibanaIndex) 
+
 	if err != nil {
-		return err
-	}
+		if status != 404 {
+			return err
+		} else {
+			_, _, err := imp.client.CreateIndex(imp.cfg.KibanaIndex,
+				common.MapStr{
+					"settings": common.MapStr{
+						"index.mapping.single_type": false,
+					},
+				})
+			if err != nil {
+				return fmt.Errorf("Failed to create index: %v", err)
+			}
 
-	if status == 404 {
-		_, _, err := imp.client.CreateIndex(imp.cfg.KibanaIndex,
-			common.MapStr{
-				"settings": common.MapStr{
-					"index.mapping.single_type": false,
-				},
-			})
-		if err != nil {
-			return fmt.Errorf("Failed to create index: %v", err)
-		}
-
-		_, _, err = imp.client.CreateIndex(imp.cfg.KibanaIndex+"/_mapping/search",
-			common.MapStr{
-				"search": common.MapStr{
-					"properties": common.MapStr{
-						"hits": common.MapStr{
-							"type": "integer",
-						},
-						"version": common.MapStr{
-							"type": "integer",
+			_, _, err = imp.client.CreateIndex(imp.cfg.KibanaIndex+"/_mapping/search",
+				common.MapStr{
+					"search": common.MapStr{
+						"properties": common.MapStr{
+							"hits": common.MapStr{
+								"type": "integer",
+							},
+							"version": common.MapStr{
+								"type": "integer",
+							},
 						},
 					},
-				},
-			})
-		if err != nil {
-			return fmt.Errorf("Failed to set the mapping: %v", err)
+				})
+			if err != nil {
+				return fmt.Errorf("Failed to set the mapping: %v", err)
+			}
 		}
 	}
 

--- a/libbeat/outputs/elasticsearch/api.go
+++ b/libbeat/outputs/elasticsearch/api.go
@@ -140,6 +140,14 @@ func (es *Connection) CreateIndex(index string, body interface{}) (int, *QueryRe
 	return withQueryResult(es.apiCall("PUT", index, "", "", "", nil, body))
 }
 
+// IndexExists checks if an index exists.
+// Implements: https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-  exists.html
+//
+func (es *Connection) IndexExists(index string) (int, error) {
+	status, _, err := es.apiCall("HEAD", index, "", "", "", nil, nil)
+	return status, err
+}
+
 // Delete deletes a typed JSON document from a specific index based on its id.
 // Implements: http://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete.html
 func (es *Connection) Delete(index string, docType string, id string, params map[string]string) (int, *QueryResult, error) {

--- a/libbeat/outputs/elasticsearch/api.go
+++ b/libbeat/outputs/elasticsearch/api.go
@@ -141,7 +141,7 @@ func (es *Connection) CreateIndex(index string, body interface{}) (int, *QueryRe
 }
 
 // IndexExists checks if an index exists.
-// Implements: https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-  exists.html
+// Implements: https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-exists.html
 //
 func (es *Connection) IndexExists(index string) (int, error) {
 	status, _, err := es.apiCall("HEAD", index, "", "", "", nil, nil)


### PR DESCRIPTION
Fixes issues with `import_dashboards`:

 1. Do not try to re-create the `.kibana` index. First check if it already exists.
 2. Stop and report HTTP error code when dashboards archive cannot be downloaded.
