### PR TITLE
fix template for output filename and path

### DIFF
--- a/generator/beat/{beat}/tests/system/config/{beat}.yml.j2
+++ b/generator/beat/{beat}/tests/system/config/{beat}.yml.j2
@@ -14,12 +14,12 @@ output:
     enabled: true
 
     # Path to the directory where to save the generated files. The option is mandatory.
-    path: {{ '{{' }} output_file_path|default(beat.working_dir + "/output") {{ '}}' }}
+    path: {{ output_file_path|default(beat.working_dir + "/output") }}
 
 
     # Name of the generated files. The default is `{beat}` and it generates
     # files: `{beat}`, `{beat}.1`, `{beat}.2`, etc.
-    filename: "{{ '{{' }} output_file_filename|default("{beat}") {{ '}}' }}"
+    filename: {{ output_file_filename|default("{beat}") }}
 
     # Maximum size in kilobytes of each file. When this size is reached, the files are
     # rotated. The default value is 10 MB.


### PR DESCRIPTION
This fixes the generation of the yml file for system tests. After generating an "example" beat, the resulting `tests/system/config/example.yml.j2` would look like:

```
   # Path to the directory where to save the generated files. The option is mandatory.
    path: {{ output_file_path|default(beat.working_dir + "/output") }}


    # Name of the generated files. The default is `example` and it generates
    # files: `example`, `example.1`, `example.2`, etc.
    filename: {{ output_file_filename|default("example") }}
```