### PR TITLE
Fix redis prospector default type

### DIFF
--- a/filebeat/prospector/redis/config.go
+++ b/filebeat/prospector/redis/config.go
@@ -3,14 +3,13 @@ package redis
 import (
 	"time"
 
-	cfg "github.com/elastic/beats/filebeat/config"
 	"github.com/elastic/beats/filebeat/harvester"
 )
 
 var defaultConfig = config{
 
 	ForwarderConfig: harvester.ForwarderConfig{
-		Type: cfg.DefaultType,
+		Type: "redis",
 	},
 	Network:  "tcp",
 	MaxConn:  10,

--- a/filebeat/prospector/redis/harvester.go
+++ b/filebeat/prospector/redis/harvester.go
@@ -132,9 +132,6 @@ func (h *Harvester) Run() error {
 				"slowlog": subEvent,
 			},
 			"read_timestamp": common.Time(time.Now()),
-			"prospector": common.MapStr{
-				"type": "redis",
-			},
 		}
 
 		h.forwarder.Send(data)


### PR DESCRIPTION
This did not have any affect yet I think as the default never applied.

Simplifying the event generation as the type is automatically set by the forwarder.