### PR TITLE
Backport: Fixed socket scanning for tcp6 (#4442) into 5.5

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -36,14 +36,10 @@ https://github.com/elastic/beats/compare/v5.4.1...master[Check the HEAD diff]
 - Fix modules default file permissions. {pull}3879[3879]
 - Properly shut down crawler in case one prospector is misconfigured. {pull}4037[4037]
 - Fix importing the dashboards when the limit for max open files is too low. {issue}4244[4244]
-
-*Filebeat*
 - Fix issue that new prospector was not reloaded on conflict {pull}4128[4128]
 - Fix grok pattern in filebeat module system/auth without hostname. {pull}4224[4224]
 - Fix the Mysql slowlog parsing of IP addresses. {pull}4183[4183]
 - Allow string characters in user agent patch version (NGINX and Apache) {pull}4415[4415]
-
-*Filebeat*
 
 *Heartbeat*
 
@@ -60,6 +56,7 @@ https://github.com/elastic/beats/compare/v5.4.1...master[Check the HEAD diff]
 
 - Clean configured geoip.paths before attempting to open the database. {pull}4306[4306]
 - Fix `packetbeat.interface` options that contain underscores (e.g. `with_vlans` or `bpf_filter`). {pull}4378[4378]
+- Enabled /proc/net/tcp6 scanning and fixed ip v6 parsing. {pull}4442[4442]
 
 *Winlogbeat*
 

--- a/packetbeat/procs/procs.go
+++ b/packetbeat/procs/procs.go
@@ -244,7 +244,7 @@ func hexToIpv4(word string) (net.IP, error) {
 func hexToIpv6(word string) (net.IP, error) {
 	p := make(net.IP, net.IPv6len)
 	for i := 0; i < 4; i++ {
-		part, err := strconv.ParseInt(word[i*8:(i+1)*8], 16, 32)
+		part, err := strconv.ParseUint(word[i*8:(i+1)*8], 16, 32)
 		if err != nil {
 			return nil, err
 		}
@@ -324,12 +324,12 @@ func (proc *ProcessesWatcher) updateMap() {
 }
 
 func socketsFromProc(filename string, ipv6 bool) ([]*socketInfo, error) {
-	file, err := os.Open("/proc/net/tcp")
+	file, err := os.Open(filename)
 	if err != nil {
 		return nil, err
 	}
 	defer file.Close()
-	return parseProcNetTCP(file, false)
+	return parseProcNetTCP(file, ipv6)
 }
 
 // Parses the /proc/net/tcp file


### PR DESCRIPTION
* Fixed socket scanning for tcp6
* Fixed ip6 parsing

(cherry picked from commit 1426260a616e361c826ca11f7974c46c1c6d34be) #4442 