### PR TITLE
Load Filebeat modules pipelines on connect

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -48,6 +48,7 @@ https://github.com/elastic/beats/compare/v6.0.0-alpha1...master[Check the HEAD d
 
 - Add experimental Redis module. {pull}4441[4441]
 - Nginx module: use the first not-private IP address as the remote_ip. {pull}4417[4417]
+- Load Ingest Node pipelines when the Elasticsearch connection is established, instead of only once at startup. {pull}4479[4479]
 
 *Heartbeat*
 

--- a/filebeat/beater/filebeat.go
+++ b/filebeat/beater/filebeat.go
@@ -93,16 +93,13 @@ func (fb *Filebeat) modulesSetup(b *beat.Beat) error {
 			" can ignore this warning.")
 		return nil
 	}
-	esClient, err := elasticsearch.NewConnectedClient(esConfig)
-	if err != nil {
-		return fmt.Errorf("Error creating ES client: %v", err)
-	}
-	defer esClient.Close()
 
-	err = fb.moduleRegistry.LoadPipelines(esClient)
-	if err != nil {
-		return err
+	// register pipeline loading to happen every time a new ES connection is
+	// established
+	callback := func(esClient *elasticsearch.Client) error {
+		return fb.moduleRegistry.LoadPipelines(esClient)
 	}
+	elasticsearch.RegisterConnectCallback(callback)
 
 	return nil
 }


### PR DESCRIPTION
This is done by registering another callback to the elasticsearch output. We
used to support only one callback, this extends to support multiple callbacks
and also protects the list with a mutex.

There is plan to refactor the package global, but after the publisher refactoring.

Fixes #4444.