### PR TITLE
Add libbeat/common/atomic package

### DIFF
--- a/libbeat/common/atomic/atomic.go
+++ b/libbeat/common/atomic/atomic.go
@@ -1,0 +1,77 @@
+// Package atomic provides common primitive types with atomic accessors.
+package atomic
+
+import a "sync/atomic"
+
+// Bool provides an atomic boolean type.
+type Bool struct{ u Uint32 }
+
+// Int32 provides an atomic int32 type.
+type Int32 struct{ value int32 }
+
+// Int64 provides an atomic int64 type.
+type Int64 struct{ value int64 }
+
+// Uint32 provides an atomic uint32 type.
+type Uint32 struct{ value uint32 }
+
+// Uint64 provides an atomic uint64 type.
+type Uint64 struct{ value uint64 }
+
+func MakeBool(v bool) Bool             { return Bool{MakeUint32(encBool(v))} }
+func NewBool(v bool) *Bool             { return &Bool{MakeUint32(encBool(v))} }
+func (b *Bool) Load() bool             { return b.u.Load() == 1 }
+func (b *Bool) Store(v bool)           { b.u.Store(encBool(v)) }
+func (b *Bool) Swap(new bool) bool     { return b.u.Swap(encBool(new)) == 1 }
+func (b *Bool) CAS(old, new bool) bool { return b.u.CAS(encBool(old), encBool(new)) }
+
+func MakeInt32(v int32) Int32            { return Int32{v} }
+func NewInt32(v int32) *Int32            { return &Int32{v} }
+func (i *Int32) Load() int32             { return a.LoadInt32(&i.value) }
+func (i *Int32) Store(v int32)           { a.StoreInt32(&i.value, v) }
+func (i *Int32) Swap(new int32) int32    { return a.SwapInt32(&i.value, new) }
+func (i *Int32) Add(delta int32) int32   { return a.AddInt32(&i.value, delta) }
+func (i *Int32) Sub(delta int32) int32   { return a.AddInt32(&i.value, -delta) }
+func (i *Int32) Inc() int32              { return i.Add(1) }
+func (i *Int32) Dec() int32              { return i.Add(-1) }
+func (i *Int32) CAS(old, new int32) bool { return a.CompareAndSwapInt32(&i.value, old, new) }
+
+func MakeInt64(v int64) Int64            { return Int64{v} }
+func NewInt64(v int64) *Int64            { return &Int64{v} }
+func (i *Int64) Load() int64             { return a.LoadInt64(&i.value) }
+func (i *Int64) Store(v int64)           { a.StoreInt64(&i.value, v) }
+func (i *Int64) Swap(new int64) int64    { return a.SwapInt64(&i.value, new) }
+func (i *Int64) Add(delta int64) int64   { return a.AddInt64(&i.value, delta) }
+func (i *Int64) Sub(delta int64) int64   { return a.AddInt64(&i.value, -delta) }
+func (i *Int64) Inc() int64              { return i.Add(1) }
+func (i *Int64) Dec() int64              { return i.Add(-1) }
+func (i *Int64) CAS(old, new int64) bool { return a.CompareAndSwapInt64(&i.value, old, new) }
+
+func MakeUint32(v uint32) Uint32           { return Uint32{v} }
+func NewUint32(v uint32) *Uint32           { return &Uint32{v} }
+func (u *Uint32) Load() uint32             { return a.LoadUint32(&u.value) }
+func (u *Uint32) Store(v uint32)           { a.StoreUint32(&u.value, v) }
+func (u *Uint32) Swap(new uint32) uint32   { return a.SwapUint32(&u.value, new) }
+func (u *Uint32) Add(delta uint32) uint32  { return a.AddUint32(&u.value, delta) }
+func (u *Uint32) Sub(delta uint32) uint32  { return a.AddUint32(&u.value, ^uint32(delta-1)) }
+func (u *Uint32) Inc() uint32              { return u.Add(1) }
+func (u *Uint32) Dec() uint32              { return u.Add(^uint32(0)) }
+func (u *Uint32) CAS(old, new uint32) bool { return a.CompareAndSwapUint32(&u.value, old, new) }
+
+func MakeUint64(v uint64) Uint64           { return Uint64{v} }
+func NewUint64(v uint64) *Uint64           { return &Uint64{v} }
+func (u *Uint64) Load() uint64             { return a.LoadUint64(&u.value) }
+func (u *Uint64) Store(v uint64)           { a.StoreUint64(&u.value, v) }
+func (u *Uint64) Swap(new uint64) uint64   { return a.SwapUint64(&u.value, new) }
+func (u *Uint64) Add(delta uint64) uint64  { return a.AddUint64(&u.value, delta) }
+func (u *Uint64) Sub(delta uint64) uint64  { return a.AddUint64(&u.value, ^uint64(delta-1)) }
+func (u *Uint64) Inc() uint64              { return u.Add(1) }
+func (u *Uint64) Dec() uint64              { return u.Add(^uint64(0)) }
+func (u *Uint64) CAS(old, new uint64) bool { return a.CompareAndSwapUint64(&u.value, old, new) }
+
+func encBool(b bool) uint32 {
+	if b {
+		return 1
+	}
+	return 0
+}

--- a/libbeat/common/atomic/atomic_test.go
+++ b/libbeat/common/atomic/atomic_test.go
@@ -1,0 +1,212 @@
+package atomic
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAtomicBool(t *testing.T) {
+	assert := assert.New(t)
+
+	var b Bool
+	assert.False(b.Load(), "check zero value is false")
+
+	b = MakeBool(true)
+	assert.True(b.Load(), "check value initializer with 'true' value")
+
+	b.Store(false)
+	assert.False(b.Load(), "check store to false")
+
+	old := b.Swap(true)
+	assert.False(old, "check old value of swap operation is 'false'")
+	assert.True(b.Load(), "check new value after swap is 'true'")
+
+	old = b.Swap(false)
+	assert.True(old, "check old value of second swap operation is 'true'")
+	assert.False(b.Load(), "check new value after second swap is 'false'")
+
+	ok := b.CAS(true, true)
+	assert.False(ok, "check CAS fails with wrong 'old' value")
+	assert.False(b.Load(), "check failed CAS did not change value 'false'")
+
+	ok = b.CAS(false, true)
+	assert.True(ok, "check CAS succeeds with correct 'old' value")
+	assert.True(b.Load(), "check CAS did change value to 'true'")
+}
+
+func TestAtomicInt32(t *testing.T) {
+	assert := assert.New(t)
+	check := func(expected, actual int32, msg string) {
+		assert.Equal(expected, actual, msg)
+	}
+
+	var v Int32
+	check(0, v.Load(), "check zero value")
+
+	v = MakeInt32(23)
+	check(23, v.Load(), "check value initializer")
+
+	v.Store(42)
+	check(42, v.Load(), "check store new value")
+
+	new := v.Inc()
+	check(43, new, "check increment returns new value")
+	check(43, v.Load(), "check increment did store new value")
+
+	new = v.Dec()
+	check(42, new, "check decrement returns new value")
+	check(42, v.Load(), "check decrement did store new value")
+
+	new = v.Add(8)
+	check(50, new, "check add returns new value")
+	check(50, v.Load(), "check add did store new value")
+
+	new = v.Sub(8)
+	check(42, new, "check sub returns new value")
+	check(42, v.Load(), "check sub did store new value")
+
+	old := v.Swap(101)
+	check(42, old, "check swap returns old value")
+	check(101, v.Load(), "check swap stores new value")
+
+	ok := v.CAS(0, 23)
+	assert.False(ok, "check CAS with wrong old value fails")
+	check(101, v.Load(), "check failed CAS did not change value")
+
+	ok = v.CAS(101, 23)
+	assert.True(ok, "check CAS succeeds")
+	check(23, v.Load(), "check CAS did store new value")
+}
+
+func TestAtomicInt64(t *testing.T) {
+	assert := assert.New(t)
+	check := func(expected, actual int64, msg string) {
+		assert.Equal(expected, actual, msg)
+	}
+
+	var v Int64
+	check(0, v.Load(), "check zero value")
+
+	v = MakeInt64(23)
+	check(23, v.Load(), "check value initializer")
+
+	v.Store(42)
+	check(42, v.Load(), "check store new value")
+
+	new := v.Inc()
+	check(43, new, "check increment returns new value")
+	check(43, v.Load(), "check increment did store new value")
+
+	new = v.Dec()
+	check(42, new, "check decrement returns new value")
+	check(42, v.Load(), "check decrement did store new value")
+
+	new = v.Add(8)
+	check(50, new, "check add returns new value")
+	check(50, v.Load(), "check add did store new value")
+
+	new = v.Sub(8)
+	check(42, new, "check sub returns new value")
+	check(42, v.Load(), "check sub did store new value")
+
+	old := v.Swap(101)
+	check(42, old, "check swap returns old value")
+	check(101, v.Load(), "check swap stores new value")
+
+	ok := v.CAS(0, 23)
+	assert.False(ok, "check CAS with wrong old value fails")
+	check(101, v.Load(), "check failed CAS did not change value")
+
+	ok = v.CAS(101, 23)
+	assert.True(ok, "check CAS succeeds")
+	check(23, v.Load(), "check CAS did store new value")
+}
+
+func TestAtomicUint32(t *testing.T) {
+	assert := assert.New(t)
+	check := func(expected, actual uint32, msg string) {
+		assert.Equal(expected, actual, msg)
+	}
+
+	var v Uint32
+	check(0, v.Load(), "check zero value")
+
+	v = MakeUint32(23)
+	check(23, v.Load(), "check value initializer")
+
+	v.Store(42)
+	check(42, v.Load(), "check store new value")
+
+	new := v.Inc()
+	check(43, new, "check increment returns new value")
+	check(43, v.Load(), "check increment did store new value")
+
+	new = v.Dec()
+	check(42, new, "check decrement returns new value")
+	check(42, v.Load(), "check decrement did store new value")
+
+	new = v.Add(8)
+	check(50, new, "check add returns new value")
+	check(50, v.Load(), "check add did store new value")
+
+	new = v.Sub(8)
+	check(42, new, "check sub returns new value")
+	check(42, v.Load(), "check sub did store new value")
+
+	old := v.Swap(101)
+	check(42, old, "check swap returns old value")
+	check(101, v.Load(), "check swap stores new value")
+
+	ok := v.CAS(0, 23)
+	assert.False(ok, "check CAS with wrong old value fails")
+	check(101, v.Load(), "check failed CAS did not change value")
+
+	ok = v.CAS(101, 23)
+	assert.True(ok, "check CAS succeeds")
+	check(23, v.Load(), "check CAS did store new value")
+}
+
+func TestAtomicUint64(t *testing.T) {
+	assert := assert.New(t)
+	check := func(expected, actual uint64, msg string) {
+		assert.Equal(expected, actual, msg)
+	}
+
+	var v Uint64
+	check(0, v.Load(), "check zero value")
+
+	v = MakeUint64(23)
+	check(23, v.Load(), "check value initializer")
+
+	v.Store(42)
+	check(42, v.Load(), "check store new value")
+
+	new := v.Inc()
+	check(43, new, "check increment returns new value")
+	check(43, v.Load(), "check increment did store new value")
+
+	new = v.Dec()
+	check(42, new, "check decrement returns new value")
+	check(42, v.Load(), "check decrement did store new value")
+
+	new = v.Add(8)
+	check(50, new, "check add returns new value")
+	check(50, v.Load(), "check add did store new value")
+
+	new = v.Sub(8)
+	check(42, new, "check sub returns new value")
+	check(42, v.Load(), "check sub did store new value")
+
+	old := v.Swap(101)
+	check(42, old, "check swap returns old value")
+	check(101, v.Load(), "check swap stores new value")
+
+	ok := v.CAS(0, 23)
+	assert.False(ok, "check CAS with wrong old value fails")
+	check(101, v.Load(), "check failed CAS did not change value")
+
+	ok = v.CAS(101, 23)
+	assert.True(ok, "check CAS succeeds")
+	check(23, v.Load(), "check CAS did store new value")
+}


### PR DESCRIPTION
The libbeat/common/atomic package wraps sync/atomic package, providing types
atomic.T with atomic accessors only.