### PR TITLE
Remove empty properties from the template files

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -30,6 +30,7 @@ https://github.com/elastic/beats/compare/v5.4.1...master[Check the HEAD diff]
 - Fix console output {pull}4045[4045]
 
 - Usage of field `_type` is now ignored and hardcoded to `doc`. {pull}3757[3757]
+- Removed empty sections from the template files, causing indexing errors for array objects. {pull}4488[4488]
 
 *Filebeat*
 

--- a/filebeat/filebeat.template-es2x.json
+++ b/filebeat/filebeat.template-es2x.json
@@ -293,9 +293,6 @@
           "index": "not_analyzed",
           "type": "string"
         },
-        "fields": {
-          "properties": {}
-        },
         "fileset": {
           "properties": {
             "module": {

--- a/filebeat/filebeat.template-es6x.json
+++ b/filebeat/filebeat.template-es6x.json
@@ -245,9 +245,6 @@
           "ignore_above": 1024,
           "type": "keyword"
         },
-        "fields": {
-          "properties": {}
-        },
         "fileset": {
           "properties": {
             "module": {

--- a/filebeat/filebeat.template.json
+++ b/filebeat/filebeat.template.json
@@ -248,9 +248,6 @@
           "ignore_above": 1024,
           "type": "keyword"
         },
-        "fields": {
-          "properties": {}
-        },
         "fileset": {
           "properties": {
             "module": {

--- a/heartbeat/heartbeat.template-es2x.json
+++ b/heartbeat/heartbeat.template-es2x.json
@@ -68,9 +68,6 @@
             }
           }
         },
-        "fields": {
-          "properties": {}
-        },
         "host": {
           "ignore_above": 1024,
           "index": "not_analyzed",

--- a/heartbeat/heartbeat.template-es6x.json
+++ b/heartbeat/heartbeat.template-es6x.json
@@ -55,9 +55,6 @@
             }
           }
         },
-        "fields": {
-          "properties": {}
-        },
         "host": {
           "ignore_above": 1024,
           "type": "keyword"

--- a/heartbeat/heartbeat.template.json
+++ b/heartbeat/heartbeat.template.json
@@ -58,9 +58,6 @@
             }
           }
         },
-        "fields": {
-          "properties": {}
-        },
         "host": {
           "ignore_above": 1024,
           "type": "keyword"

--- a/libbeat/libbeat.template-es6x.json
+++ b/libbeat/libbeat.template-es6x.json
@@ -36,9 +36,6 @@
             }
           }
         },
-        "fields": {
-          "properties": {}
-        },
         "meta": {
           "properties": {
             "cloud": {

--- a/libbeat/scripts/generate_template.py
+++ b/libbeat/scripts/generate_template.py
@@ -305,13 +305,6 @@ def fill_field_properties(args, field, defaults, path):
                 }
             })
 
-
-        properties[field["name"]] = {
-            "properties": {}
-        }
-
-
-
     elif field.get("type") == "group":
         if len(path) > 0:
             path = path + "." + field["name"]

--- a/metricbeat/metricbeat.template-es2x.json
+++ b/metricbeat/metricbeat.template-es2x.json
@@ -771,9 +771,6 @@
                   "index": "not_analyzed",
                   "type": "string"
                 },
-                "labels": {
-                  "properties": {}
-                },
                 "name": {
                   "ignore_above": 1024,
                   "index": "not_analyzed",
@@ -793,9 +790,6 @@
                   "ignore_above": 1024,
                   "index": "not_analyzed",
                   "type": "string"
-                },
-                "tags": {
-                  "properties": {}
                 }
               }
             },
@@ -902,9 +896,6 @@
                     }
                   }
                 },
-                "labels": {
-                  "properties": {}
-                },
                 "size": {
                   "properties": {
                     "regular": {
@@ -914,9 +905,6 @@
                       "type": "long"
                     }
                   }
-                },
-                "tags": {
-                  "properties": {}
                 }
               }
             },
@@ -1027,9 +1015,6 @@
               }
             }
           }
-        },
-        "fields": {
-          "properties": {}
         },
         "haproxy": {
           "properties": {
@@ -1671,9 +1656,6 @@
                     },
                     "insync_replica": {
                       "type": "boolean"
-                    },
-                    "isr": {
-                      "properties": {}
                     },
                     "leader": {
                       "type": "long"
@@ -3641,9 +3623,6 @@
                           "index": "not_analyzed",
                           "type": "string"
                         },
-                        "percpu": {
-                          "properties": {}
-                        },
                         "stats": {
                           "properties": {
                             "system": {
@@ -3936,9 +3915,6 @@
                       "type": "long"
                     }
                   }
-                },
-                "env": {
-                  "properties": {}
                 },
                 "fd": {
                   "properties": {

--- a/metricbeat/metricbeat.template-es6x.json
+++ b/metricbeat/metricbeat.template-es6x.json
@@ -763,9 +763,6 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
-                "labels": {
-                  "properties": {}
-                },
                 "name": {
                   "ignore_above": 1024,
                   "type": "keyword"
@@ -783,9 +780,6 @@
                 "status": {
                   "ignore_above": 1024,
                   "type": "keyword"
-                },
-                "tags": {
-                  "properties": {}
                 }
               }
             },
@@ -895,9 +889,6 @@
                     }
                   }
                 },
-                "labels": {
-                  "properties": {}
-                },
                 "size": {
                   "properties": {
                     "regular": {
@@ -907,9 +898,6 @@
                       "type": "long"
                     }
                   }
-                },
-                "tags": {
-                  "properties": {}
                 }
               }
             },
@@ -1023,9 +1011,6 @@
               }
             }
           }
-        },
-        "fields": {
-          "properties": {}
         },
         "haproxy": {
           "properties": {
@@ -1655,9 +1640,6 @@
                     },
                     "insync_replica": {
                       "type": "boolean"
-                    },
-                    "isr": {
-                      "properties": {}
                     },
                     "leader": {
                       "type": "long"
@@ -3605,9 +3587,6 @@
                           "ignore_above": 1024,
                           "type": "keyword"
                         },
-                        "percpu": {
-                          "properties": {}
-                        },
                         "stats": {
                           "properties": {
                             "system": {
@@ -3896,9 +3875,6 @@
                       "type": "long"
                     }
                   }
-                },
-                "env": {
-                  "properties": {}
                 },
                 "fd": {
                   "properties": {

--- a/metricbeat/metricbeat.template.json
+++ b/metricbeat/metricbeat.template.json
@@ -766,9 +766,6 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
-                "labels": {
-                  "properties": {}
-                },
                 "name": {
                   "ignore_above": 1024,
                   "type": "keyword"
@@ -786,9 +783,6 @@
                 "status": {
                   "ignore_above": 1024,
                   "type": "keyword"
-                },
-                "tags": {
-                  "properties": {}
                 }
               }
             },
@@ -898,9 +892,6 @@
                     }
                   }
                 },
-                "labels": {
-                  "properties": {}
-                },
                 "size": {
                   "properties": {
                     "regular": {
@@ -910,9 +901,6 @@
                       "type": "long"
                     }
                   }
-                },
-                "tags": {
-                  "properties": {}
                 }
               }
             },
@@ -1026,9 +1014,6 @@
               }
             }
           }
-        },
-        "fields": {
-          "properties": {}
         },
         "haproxy": {
           "properties": {
@@ -1658,9 +1643,6 @@
                     },
                     "insync_replica": {
                       "type": "boolean"
-                    },
-                    "isr": {
-                      "properties": {}
                     },
                     "leader": {
                       "type": "long"
@@ -3608,9 +3590,6 @@
                           "ignore_above": 1024,
                           "type": "keyword"
                         },
-                        "percpu": {
-                          "properties": {}
-                        },
                         "stats": {
                           "properties": {
                             "system": {
@@ -3899,9 +3878,6 @@
                       "type": "long"
                     }
                   }
-                },
-                "env": {
-                  "properties": {}
                 },
                 "fd": {
                   "properties": {

--- a/packetbeat/packetbeat.template-es2x.json
+++ b/packetbeat/packetbeat.template-es2x.json
@@ -33,9 +33,6 @@
               "index": "not_analyzed",
               "type": "string"
             },
-            "arguments": {
-              "properties": {}
-            },
             "auto-delete": {
               "type": "boolean"
             },
@@ -93,9 +90,6 @@
               "ignore_above": 1024,
               "index": "not_analyzed",
               "type": "string"
-            },
-            "headers": {
-              "properties": {}
             },
             "if-empty": {
               "type": "boolean"
@@ -574,9 +568,6 @@
                     }
                   }
                 },
-                "supported": {
-                  "properties": {}
-                },
                 "warnings": {
                   "ignore_above": 1024,
                   "index": "not_analyzed",
@@ -864,9 +855,6 @@
         "domloadtime": {
           "type": "long"
         },
-        "fields": {
-          "properties": {}
-        },
         "final": {
           "ignore_above": 1024,
           "index": "not_analyzed",
@@ -888,9 +876,6 @@
                   },
                   "type": "string"
                 },
-                "headers": {
-                  "properties": {}
-                },
                 "params": {
                   "ignore_above": 1024,
                   "index": "not_analyzed",
@@ -909,9 +894,6 @@
                   "ignore_above": 1024,
                   "index": "not_analyzed",
                   "type": "string"
-                },
-                "headers": {
-                  "properties": {}
                 },
                 "phrase": {
                   "ignore_above": 1024,
@@ -1020,9 +1002,6 @@
                 "initial": {
                   "type": "long"
                 },
-                "keys": {
-                  "properties": {}
-                },
                 "line": {
                   "ignore_above": 1024,
                   "index": "not_analyzed",
@@ -1061,9 +1040,6 @@
                   "index": "not_analyzed",
                   "type": "string"
                 },
-                "values": {
-                  "properties": {}
-                },
                 "vbucket": {
                   "type": "long"
                 },
@@ -1096,9 +1072,6 @@
                 "flags": {
                   "type": "long"
                 },
-                "keys": {
-                  "properties": {}
-                },
                 "opaque": {
                   "type": "long"
                 },
@@ -1109,9 +1082,6 @@
                 },
                 "opcode_value": {
                   "type": "long"
-                },
-                "stats": {
-                  "properties": {}
                 },
                 "status": {
                   "ignore_above": 1024,
@@ -1128,9 +1098,6 @@
                 },
                 "value": {
                   "type": "long"
-                },
-                "values": {
-                  "properties": {}
                 },
                 "version": {
                   "ignore_above": 1024,

--- a/packetbeat/packetbeat.template-es6x.json
+++ b/packetbeat/packetbeat.template-es6x.json
@@ -26,9 +26,6 @@
               "ignore_above": 1024,
               "type": "keyword"
             },
-            "arguments": {
-              "properties": {}
-            },
             "auto-delete": {
               "type": "boolean"
             },
@@ -78,9 +75,6 @@
             "expiration": {
               "ignore_above": 1024,
               "type": "keyword"
-            },
-            "headers": {
-              "properties": {}
             },
             "if-empty": {
               "type": "boolean"
@@ -498,9 +492,6 @@
                     }
                   }
                 },
-                "supported": {
-                  "properties": {}
-                },
                 "warnings": {
                   "ignore_above": 1024,
                   "type": "keyword"
@@ -755,9 +746,6 @@
         "domloadtime": {
           "type": "long"
         },
-        "fields": {
-          "properties": {}
-        },
         "final": {
           "ignore_above": 1024,
           "type": "keyword"
@@ -774,9 +762,6 @@
                   "norms": false,
                   "type": "text"
                 },
-                "headers": {
-                  "properties": {}
-                },
                 "params": {
                   "ignore_above": 1024,
                   "type": "keyword"
@@ -792,9 +777,6 @@
                 "code": {
                   "ignore_above": 1024,
                   "type": "keyword"
-                },
-                "headers": {
-                  "properties": {}
                 },
                 "phrase": {
                   "ignore_above": 1024,
@@ -894,9 +876,6 @@
                 "initial": {
                   "type": "long"
                 },
-                "keys": {
-                  "properties": {}
-                },
                 "line": {
                   "ignore_above": 1024,
                   "type": "keyword"
@@ -931,9 +910,6 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
-                "values": {
-                  "properties": {}
-                },
                 "vbucket": {
                   "type": "long"
                 },
@@ -964,9 +940,6 @@
                 "flags": {
                   "type": "long"
                 },
-                "keys": {
-                  "properties": {}
-                },
                 "opaque": {
                   "type": "long"
                 },
@@ -976,9 +949,6 @@
                 },
                 "opcode_value": {
                   "type": "long"
-                },
-                "stats": {
-                  "properties": {}
                 },
                 "status": {
                   "ignore_above": 1024,
@@ -993,9 +963,6 @@
                 },
                 "value": {
                   "type": "long"
-                },
-                "values": {
-                  "properties": {}
                 },
                 "version": {
                   "ignore_above": 1024,

--- a/packetbeat/packetbeat.template.json
+++ b/packetbeat/packetbeat.template.json
@@ -29,9 +29,6 @@
               "ignore_above": 1024,
               "type": "keyword"
             },
-            "arguments": {
-              "properties": {}
-            },
             "auto-delete": {
               "type": "boolean"
             },
@@ -81,9 +78,6 @@
             "expiration": {
               "ignore_above": 1024,
               "type": "keyword"
-            },
-            "headers": {
-              "properties": {}
             },
             "if-empty": {
               "type": "boolean"
@@ -501,9 +495,6 @@
                     }
                   }
                 },
-                "supported": {
-                  "properties": {}
-                },
                 "warnings": {
                   "ignore_above": 1024,
                   "type": "keyword"
@@ -758,9 +749,6 @@
         "domloadtime": {
           "type": "long"
         },
-        "fields": {
-          "properties": {}
-        },
         "final": {
           "ignore_above": 1024,
           "type": "keyword"
@@ -777,9 +765,6 @@
                   "norms": false,
                   "type": "text"
                 },
-                "headers": {
-                  "properties": {}
-                },
                 "params": {
                   "ignore_above": 1024,
                   "type": "keyword"
@@ -795,9 +780,6 @@
                 "code": {
                   "ignore_above": 1024,
                   "type": "keyword"
-                },
-                "headers": {
-                  "properties": {}
                 },
                 "phrase": {
                   "ignore_above": 1024,
@@ -897,9 +879,6 @@
                 "initial": {
                   "type": "long"
                 },
-                "keys": {
-                  "properties": {}
-                },
                 "line": {
                   "ignore_above": 1024,
                   "type": "keyword"
@@ -934,9 +913,6 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
-                "values": {
-                  "properties": {}
-                },
                 "vbucket": {
                   "type": "long"
                 },
@@ -967,9 +943,6 @@
                 "flags": {
                   "type": "long"
                 },
-                "keys": {
-                  "properties": {}
-                },
                 "opaque": {
                   "type": "long"
                 },
@@ -979,9 +952,6 @@
                 },
                 "opcode_value": {
                   "type": "long"
-                },
-                "stats": {
-                  "properties": {}
                 },
                 "status": {
                   "ignore_above": 1024,
@@ -996,9 +966,6 @@
                 },
                 "value": {
                   "type": "long"
-                },
-                "values": {
-                  "properties": {}
                 },
                 "version": {
                   "ignore_above": 1024,

--- a/winlogbeat/winlogbeat.template-es2x.json
+++ b/winlogbeat/winlogbeat.template-es2x.json
@@ -55,14 +55,8 @@
           "index": "not_analyzed",
           "type": "string"
         },
-        "event_data": {
-          "properties": {}
-        },
         "event_id": {
           "type": "long"
-        },
-        "fields": {
-          "properties": {}
         },
         "keywords": {
           "ignore_above": 1024,
@@ -198,9 +192,6 @@
               "type": "string"
             }
           }
-        },
-        "user_data": {
-          "properties": {}
         },
         "version": {
           "type": "long"

--- a/winlogbeat/winlogbeat.template-es6x.json
+++ b/winlogbeat/winlogbeat.template-es6x.json
@@ -44,14 +44,8 @@
           "ignore_above": 1024,
           "type": "keyword"
         },
-        "event_data": {
-          "properties": {}
-        },
         "event_id": {
           "type": "long"
-        },
-        "fields": {
-          "properties": {}
         },
         "keywords": {
           "ignore_above": 1024,
@@ -162,9 +156,6 @@
               "type": "keyword"
             }
           }
-        },
-        "user_data": {
-          "properties": {}
         },
         "version": {
           "type": "long"

--- a/winlogbeat/winlogbeat.template.json
+++ b/winlogbeat/winlogbeat.template.json
@@ -47,14 +47,8 @@
           "ignore_above": 1024,
           "type": "keyword"
         },
-        "event_data": {
-          "properties": {}
-        },
         "event_id": {
           "type": "long"
-        },
-        "fields": {
-          "properties": {}
         },
         "keywords": {
           "ignore_above": 1024,
@@ -165,9 +159,6 @@
               "type": "keyword"
             }
           }
-        },
-        "user_data": {
-          "properties": {}
         },
         "version": {
           "type": "long"


### PR DESCRIPTION
This were introduced in #3515, but I think they cause issues like
the one in #4483, at least in recent versions of ES.

We already removed these in master, but I didn't
realize the 5.x branches are affected.

Fixes #4483.