### PR TITLE
Update gosigar to fix Windows service timeout

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -36,6 +36,8 @@ https://github.com/elastic/beats/compare/v6.0.0-alpha1...master[Check the HEAD d
 
 *Metricbeat*
 
+- Fix issue affecting Windows services timing out at startup. {pull}4491[4491]
+
 *Packetbeat*
 
 - Enabled /proc/net/tcp6 scanning and fixed ip v6 parsing. {pull}4442[4442]

--- a/NOTICE
+++ b/NOTICE
@@ -297,8 +297,8 @@ Apache License 2.0
 
 --------------------------------------------------------------------
 Dependency: github.com/elastic/gosigar
-Version: v0.3.0
-Revision: 026c67add059f36c9679ddc16fe57ebae37fb8d6
+Version: v0.4.0
+Revision: 5a9ad8e33837b4e4c776d129142fcd5ccf41f639
 License type (autodetected): Apache License 2.0
 ./vendor/github.com/elastic/gosigar/LICENSE:
 --------------------------------------------------------------------

--- a/vendor/github.com/elastic/gosigar/CHANGELOG.md
+++ b/vendor/github.com/elastic/gosigar/CHANGELOG.md
@@ -2,16 +2,25 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [0.3.0]
+## [Unreleased]
 
 ### Added
-- Read `MemAvailable` value for kernel 3.14+
 
 ### Changed
 
 ### Deprecated
 
 ### Removed
+
+## [0.4.0]
+
+### Changed
+- Fixed Windows issue that caused a hang during `init()` if WMI wasn't ready. #74
+
+## [0.3.0]
+
+### Added
+- Read `MemAvailable` value for kernel 3.14+ #71
 
 ## [0.2.0]
 

--- a/vendor/github.com/elastic/gosigar/sigar_openbsd.go
+++ b/vendor/github.com/elastic/gosigar/sigar_openbsd.go
@@ -341,7 +341,7 @@ func (self *CpuList) Get() error {
 	load := [C.CPUSTATES]C.long{C.CP_USER, C.CP_NICE, C.CP_SYS, C.CP_INTR, C.CP_IDLE}
 
 	self.List = make([]Cpu, ncpu)
-	for curcpu, _ := range self.List {
+	for curcpu := range self.List {
 		sysctlCptime(ncpu, curcpu, &load)
 		fillCpu(&self.List[curcpu], load)
 	}

--- a/vendor/github.com/elastic/gosigar/sigar_windows.go
+++ b/vendor/github.com/elastic/gosigar/sigar_windows.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -41,21 +42,14 @@ var (
 
 	// bootTime is the time when the OS was last booted. This value may be nil
 	// on operating systems that do not support the WMI query used to obtain it.
-	bootTime *time.Time
+	bootTime     *time.Time
+	bootTimeLock sync.Mutex
 )
 
 func init() {
 	if !version.IsWindowsVistaOrGreater() {
 		// PROCESS_QUERY_LIMITED_INFORMATION cannot be used on 2003 or XP.
 		processQueryLimitedInfoAccess = syscall.PROCESS_QUERY_INFORMATION
-	}
-
-	if version.IsWindowsVistaOrGreater() {
-		// The minimum supported client for Win32_OperatingSystem is Windows Vista.
-		os, err := getWin32OperatingSystem()
-		if err == nil {
-			bootTime = &os.LastBootUpTime
-		}
 	}
 }
 
@@ -80,9 +74,19 @@ func (self *ProcFDUsage) Get(pid int) error {
 }
 
 func (self *Uptime) Get() error {
-	if bootTime == nil {
-		// Minimum supported OS is Windows Vista.
+	// Minimum supported OS is Windows Vista.
+	if !version.IsWindowsVistaOrGreater() {
 		return ErrNotImplemented{runtime.GOOS}
+	}
+
+	bootTimeLock.Lock()
+	defer bootTimeLock.Unlock()
+	if bootTime == nil {
+		os, err := getWin32OperatingSystem()
+		if err != nil {
+			return errors.Wrap(err, "failed to get boot time using WMI")
+		}
+		bootTime = &os.LastBootUpTime
 	}
 
 	self.Length = time.Since(*bootTime).Seconds()

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -386,36 +386,36 @@
 			"revisionTime": "2017-02-07T06:38:51Z"
 		},
 		{
-			"checksumSHA1": "uUBlYUff9goenMwEP2tUIm9qObs=",
+			"checksumSHA1": "SF7Qsaj7bCzUfZrVzmK564Rgmk4=",
 			"path": "github.com/elastic/gosigar",
-			"revision": "026c67add059f36c9679ddc16fe57ebae37fb8d6",
-			"revisionTime": "2017-05-15T15:13:16Z",
-			"version": "v0.3.0",
-			"versionExact": "v0.3.0"
+			"revision": "5a9ad8e33837b4e4c776d129142fcd5ccf41f639",
+			"revisionTime": "2017-06-12T15:08:20Z",
+			"version": "v0.4.0",
+			"versionExact": "v0.4.0"
 		},
 		{
 			"checksumSHA1": "jE0nhsyuGyQ7vWoyBRPEU63mQ4g=",
 			"path": "github.com/elastic/gosigar/cgroup",
-			"revision": "026c67add059f36c9679ddc16fe57ebae37fb8d6",
-			"revisionTime": "2017-05-15T15:13:16Z",
-			"version": "v0.3.0",
-			"versionExact": "v0.3.0"
+			"revision": "5a9ad8e33837b4e4c776d129142fcd5ccf41f639",
+			"revisionTime": "2017-06-12T15:08:20Z",
+			"version": "v0.4.0",
+			"versionExact": "v0.4.0"
 		},
 		{
 			"checksumSHA1": "2VhOsaR4sv3S79HO6X+6dEphNKU=",
 			"path": "github.com/elastic/gosigar/sys/linux",
-			"revision": "026c67add059f36c9679ddc16fe57ebae37fb8d6",
-			"revisionTime": "2017-05-15T15:13:16Z",
-			"version": "v0.3.0",
-			"versionExact": "v0.3.0"
+			"revision": "5a9ad8e33837b4e4c776d129142fcd5ccf41f639",
+			"revisionTime": "2017-06-12T15:08:20Z",
+			"version": "v0.4.0",
+			"versionExact": "v0.4.0"
 		},
 		{
 			"checksumSHA1": "qDsgp2kAeI9nhj565HUScaUyjU4=",
 			"path": "github.com/elastic/gosigar/sys/windows",
-			"revision": "026c67add059f36c9679ddc16fe57ebae37fb8d6",
-			"revisionTime": "2017-05-15T15:13:16Z",
-			"version": "v0.3.0",
-			"versionExact": "v0.3.0"
+			"revision": "5a9ad8e33837b4e4c776d129142fcd5ccf41f639",
+			"revisionTime": "2017-06-12T15:08:20Z",
+			"version": "v0.4.0",
+			"versionExact": "v0.4.0"
 		},
 		{
 			"checksumSHA1": "P0CvGmmAM8uYPSE2ix4th/L9c/8=",


### PR DESCRIPTION
Fixed Windows issue that caused a hang during `init()` if WMI wasn't ready. elastic/gosigar#74

Fixes #4373