### PR TITLE
Add source path matching to `add_docker_metadata` processor

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -47,6 +47,7 @@ https://github.com/elastic/beats/compare/v6.0.0-alpha1...master[Check the HEAD d
 *Affecting all Beats*
 
 - New cli subcommands interface. {pull}4420[4420]
+- Allow source path matching in `add_docker_metadata` processor {pull}4495[4495]
 
 *Filebeat*
 

--- a/filebeat/docs/fields.asciidoc
+++ b/filebeat/docs/fields.asciidoc
@@ -16,6 +16,7 @@ grouped in the following categories:
 * <<exported-fields-auditd>>
 * <<exported-fields-beat>>
 * <<exported-fields-cloud>>
+* <<exported-fields-docker-processor>>
 * <<exported-fields-icinga>>
 * <<exported-fields-kubernetes-processor>>
 * <<exported-fields-log>>
@@ -598,6 +599,47 @@ Name of the project in Google Cloud.
 === meta.cloud.region
 
 Region in which this host is running.
+
+
+[[exported-fields-docker-processor]]
+== docker Fields
+
+beta[]
+Docker stats collected from Docker.
+
+
+
+
+[float]
+=== docker.container.id
+
+type: keyword
+
+Unique container id.
+
+
+[float]
+=== docker.container.image
+
+type: keyword
+
+Name of the image the container was built on.
+
+
+[float]
+=== docker.container.name
+
+type: keyword
+
+Container name.
+
+
+[float]
+=== docker.container.labels
+
+type: object
+
+Image labels.
 
 
 [[exported-fields-icinga]]

--- a/filebeat/filebeat.full.yml
+++ b/filebeat/filebeat.full.yml
@@ -516,8 +516,10 @@ filebeat.prospectors:
 #
 #processors:
 #- add_docker_metadata:
+#    host: "unix:///var/run/docker.sock"
+#    match_source: true
+#    match_source_index: 4
 #    match_fields: ["system.process.cgroup.id"]
-#  host: "unix:///var/run/docker.sock"
 #  # To connect to Docker over TLS you must specify a client and CA certificate.
 #  #ssl:
 #  #  certificate_authority: "/etc/pki/root/ca.pem"

--- a/heartbeat/docs/fields.asciidoc
+++ b/heartbeat/docs/fields.asciidoc
@@ -15,6 +15,7 @@ grouped in the following categories:
 * <<exported-fields-beat>>
 * <<exported-fields-cloud>>
 * <<exported-fields-common>>
+* <<exported-fields-docker-processor>>
 * <<exported-fields-http>>
 * <<exported-fields-icmp>>
 * <<exported-fields-kubernetes-processor>>
@@ -253,6 +254,47 @@ type: keyword
 required: True
 
 Indicator if monitor could validate the service to be available.
+
+
+[[exported-fields-docker-processor]]
+== docker Fields
+
+beta[]
+Docker stats collected from Docker.
+
+
+
+
+[float]
+=== docker.container.id
+
+type: keyword
+
+Unique container id.
+
+
+[float]
+=== docker.container.image
+
+type: keyword
+
+Name of the image the container was built on.
+
+
+[float]
+=== docker.container.name
+
+type: keyword
+
+Container name.
+
+
+[float]
+=== docker.container.labels
+
+type: object
+
+Image labels.
 
 
 [[exported-fields-http]]

--- a/heartbeat/heartbeat.full.yml
+++ b/heartbeat/heartbeat.full.yml
@@ -280,8 +280,10 @@ heartbeat.scheduler:
 #
 #processors:
 #- add_docker_metadata:
+#    host: "unix:///var/run/docker.sock"
+#    match_source: true
+#    match_source_index: 4
 #    match_fields: ["system.process.cgroup.id"]
-#  host: "unix:///var/run/docker.sock"
 #  # To connect to Docker over TLS you must specify a client and CA certificate.
 #  #ssl:
 #  #  certificate_authority: "/etc/pki/root/ca.pem"

--- a/libbeat/_meta/config.full.yml
+++ b/libbeat/_meta/config.full.yml
@@ -82,8 +82,10 @@
 #
 #processors:
 #- add_docker_metadata:
+#    host: "unix:///var/run/docker.sock"
+#    match_source: true
+#    match_source_index: 4
 #    match_fields: ["system.process.cgroup.id"]
-#  host: "unix:///var/run/docker.sock"
 #  # To connect to Docker over TLS you must specify a client and CA certificate.
 #  #ssl:
 #  #  certificate_authority: "/etc/pki/root/ca.pem"

--- a/libbeat/docs/processors-using.asciidoc
+++ b/libbeat/docs/processors-using.asciidoc
@@ -572,20 +572,30 @@ from Docker containers:
 * Image
 * Labels
 
-Currently it supports enriching events by matching existing fields with the
-container ID in them, for example, cgroup IDs retrieved by metricbeat system
-module:
-
 [source,yaml]
 -------------------------------------------------------------------------------
 processors:
 - add_docker_metadata:
+    host: "unix:///var/run/docker.sock"
     match_fields: ["system.process.cgroup.id"]
-  host: "unix:///var/run/docker.sock"
+    match_source: true
+    match_source_index: 4
 
-  # To connect to Docker over TLS you must specify a client and CA certificate.
-  #ssl:
-  #  certificate_authority: "/etc/pki/root/ca.pem"
-  #  certificate:           "/etc/pki/client/cert.pem"
-  #  key:                   "/etc/pki/client/cert.key"
+    # To connect to Docker over TLS you must specify a client and CA certificate.
+    #ssl:
+    #  certificate_authority: "/etc/pki/root/ca.pem"
+    #  certificate:           "/etc/pki/client/cert.pem"
+    #  key:                   "/etc/pki/client/cert.key"
 -------------------------------------------------------------------------------
+
+It has the following settings:
+
+`host`:: (Optional) Docker socket (UNIX or TCP socket). It uses
+  `unix:///var/run/docker.sock` by default.
+`match_fields`:: (Optional) A list of fields to match a container id, at least
+  one of them should hold a container id to get the event enriched.
+`match_source`:: (Optional) Match container id from a log path present in
+  `source` field. Enabled by default.
+`match_source_index`:: (Optional) Index in the source path split by / to look
+  for container id. It defaults to 4 to match
+  `/var/lib/docker/containers/<container_id>/*.log`

--- a/libbeat/processors/actions/extract_field.go
+++ b/libbeat/processors/actions/extract_field.go
@@ -57,18 +57,18 @@ func NewExtractField(c common.Config) (processors.Processor, error) {
 func (f extract_field) Run(event common.MapStr) (common.MapStr, error) {
 	fieldValue, err := event.GetValue(f.Field)
 	if err != nil {
-		return nil, fmt.Errorf("Error getting field '%s' from event", f.Field)
+		return nil, fmt.Errorf("error getting field '%s' from event", f.Field)
 	}
 
 	value, ok := fieldValue.(string)
 	if !ok {
-		return nil, fmt.Errorf("Could not get a string from field '%s'", f.Field)
+		return nil, fmt.Errorf("could not get a string from field '%s'", f.Field)
 	}
 
 	parts := strings.Split(value, f.Separator)
 	parts = deleteEmpty(parts)
 	if len(parts) < f.Index+1 {
-		return nil, fmt.Errorf("Index is out of range for field '%s'", f.Field)
+		return nil, fmt.Errorf("index is out of range for field '%s'", f.Field)
 	}
 
 	event.Put(f.Target, parts[f.Index])

--- a/libbeat/processors/actions/extract_field.go
+++ b/libbeat/processors/actions/extract_field.go
@@ -1,0 +1,91 @@
+package actions
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/processors"
+)
+
+type extract_field struct {
+	Field     string
+	Separator string
+	Index     int
+	Target    string
+}
+
+/*
+This one won't be registered (yet)
+
+func init() {
+	processors.RegisterPlugin("extract_field",
+		configChecked(NewExtractField,
+			requireFields("field", "separator", "index", "target"),
+			allowedFields("field", "separator", "index", "target", "when")))
+}
+*/
+
+func NewExtractField(c common.Config) (processors.Processor, error) {
+	config := struct {
+		Field     string `config:"field"`
+		Separator string `config:"separator"`
+		Index     int    `config:"index"`
+		Target    string `config:"target"`
+	}{}
+	err := c.Unpack(&config)
+	if err != nil {
+		return nil, fmt.Errorf("fail to unpack the extract_field configuration: %s", err)
+	}
+
+	/* remove read only fields */
+	for _, readOnly := range processors.MandatoryExportedFields {
+		if config.Field == readOnly {
+			return nil, fmt.Errorf("%s is a read only field, cannot override", readOnly)
+		}
+	}
+
+	f := extract_field{
+		Field:     config.Field,
+		Separator: config.Separator,
+		Index:     config.Index,
+		Target:    config.Target,
+	}
+	return f, nil
+}
+
+func (f extract_field) Run(event common.MapStr) (common.MapStr, error) {
+	fieldValue, err := event.GetValue(f.Field)
+	if err != nil {
+		return nil, fmt.Errorf("Error getting field '%s' from event", f.Field)
+	}
+
+	value, ok := fieldValue.(string)
+	if !ok {
+		return nil, fmt.Errorf("Could not get a string from field '%s'", f.Field)
+	}
+
+	parts := strings.Split(value, f.Separator)
+	parts = deleteEmpty(parts)
+	if len(parts) < f.Index+1 {
+		return nil, fmt.Errorf("Index is out of range for field '%s'", f.Field)
+	}
+
+	event.Put(f.Target, parts[f.Index])
+
+	return event, nil
+}
+
+func (f extract_field) String() string {
+	return "extract_field=" + f.Target
+}
+
+func deleteEmpty(s []string) []string {
+	var r []string
+	for _, str := range s {
+		if str != "" {
+			r = append(r, str)
+		}
+	}
+	return r
+}

--- a/libbeat/processors/actions/extract_field_test.go
+++ b/libbeat/processors/actions/extract_field_test.go
@@ -64,7 +64,9 @@ func TestCommonPaths(t *testing.T) {
 		actual := runExtractField(t, testConfig, input)
 
 		result, err := actual.GetValue(test.Target)
-		assert.NoError(t, err)
+		if err != nil {
+			t.Fatalf("could not get target field: %s", err)
+		}
 		assert.Equal(t, result.(string), test.Result)
 	}
 }
@@ -76,12 +78,13 @@ func runExtractField(t *testing.T, config *common.Config, input common.MapStr) c
 
 	p, err := NewExtractField(*config)
 	if err != nil {
-		logp.Err("Error initializing decode_json_fields")
-		t.Fatal(err)
+		t.Fatalf("error initializing extract_field: %s", err)
 	}
 
 	actual, err := p.Run(input)
-	assert.NoError(t, err)
+	if err != nil {
+		t.Fatalf("error running extract_field: %s", err)
+	}
 
 	return actual
 }

--- a/libbeat/processors/actions/extract_field_test.go
+++ b/libbeat/processors/actions/extract_field_test.go
@@ -1,0 +1,87 @@
+package actions
+
+import (
+	"testing"
+
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/logp"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCommonPaths(t *testing.T) {
+	var tests = []struct {
+		Value, Field, Separator, Target, Result string
+		Index                                   int
+	}{
+		// Common docker case
+		{
+			Value:     "/var/lib/docker/containers/f1510836197d7c34da22cf796dba5640f87c04de5c95cf0adc11b85f1e1c1528/f1510836197d7c34da22cf796dba5640f87c04de5c95cf0adc11b85f1e1c1528-json.log",
+			Field:     "source",
+			Separator: "/",
+			Target:    "docker.container.id",
+			Index:     4,
+			Result:    "f1510836197d7c34da22cf796dba5640f87c04de5c95cf0adc11b85f1e1c1528",
+		},
+		{
+			Value:     "/var/lib/foo/bar",
+			Field:     "other_field",
+			Separator: "/",
+			Target:    "destination",
+			Index:     3,
+			Result:    "bar",
+		},
+		{
+			Value:     "-var-lib-foo-bar",
+			Field:     "source",
+			Separator: "-",
+			Target:    "destination",
+			Index:     2,
+			Result:    "foo",
+		},
+		{
+			Value:     "*var*lib*foo*bar",
+			Field:     "source",
+			Separator: "*",
+			Target:    "destination",
+			Index:     0,
+			Result:    "var",
+		},
+	}
+
+	for _, test := range tests {
+		var testConfig, _ = common.NewConfigFrom(map[string]interface{}{
+			"field":     test.Field,
+			"separator": test.Separator,
+			"index":     test.Index,
+			"target":    test.Target,
+		})
+
+		// Configure input to
+		input := common.MapStr{
+			test.Field: test.Value,
+		}
+
+		actual := runExtractField(t, testConfig, input)
+
+		result, err := actual.GetValue(test.Target)
+		assert.NoError(t, err)
+		assert.Equal(t, result.(string), test.Result)
+	}
+}
+
+func runExtractField(t *testing.T, config *common.Config, input common.MapStr) common.MapStr {
+	if testing.Verbose() {
+		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"*"})
+	}
+
+	p, err := NewExtractField(*config)
+	if err != nil {
+		logp.Err("Error initializing decode_json_fields")
+		t.Fatal(err)
+	}
+
+	actual, err := p.Run(input)
+	assert.NoError(t, err)
+
+	return actual
+}

--- a/libbeat/processors/add_docker_metadata/_meta/fields.yml
+++ b/libbeat/processors/add_docker_metadata/_meta/fields.yml
@@ -1,0 +1,29 @@
+- key: docker
+  title: docker
+  description: >
+    beta[]
+
+    Docker stats collected from Docker.
+  short_config: false
+  anchor: docker-processor
+  fields:
+    - name: docker
+      type: group
+      fields:
+        - name: container.id
+          type: keyword
+          description: >
+            Unique container id.
+        - name: container.image
+          type: keyword
+          description: >
+            Name of the image the container was built on.
+        - name: container.name
+          type: keyword
+          description: >
+            Container name.
+        - name: container.labels
+          type: object
+          object_type: keyword
+          description: >
+            Image labels.

--- a/libbeat/processors/add_docker_metadata/config.go
+++ b/libbeat/processors/add_docker_metadata/config.go
@@ -2,9 +2,11 @@ package add_docker_metadata
 
 // Config for docker processor
 type Config struct {
-	Host   string     `config:"host"`
-	TLS    *TLSConfig `config:"ssl"`
-	Fields []string   `config:"match_fields"`
+	Host        string     `config:"host"`
+	TLS         *TLSConfig `config:"ssl"`
+	Fields      []string   `config:"match_fields"`
+	MatchSource bool       `config:"match_source"`
+	SourceIndex int        `config:"match_source_index"`
 }
 
 // TLSConfig for docker socket connection
@@ -16,6 +18,8 @@ type TLSConfig struct {
 
 func defaultConfig() Config {
 	return Config{
-		Host: "unix:///var/run/docker.sock",
+		Host:        "unix:///var/run/docker.sock",
+		MatchSource: true,
+		SourceIndex: 4,
 	}
 }

--- a/metricbeat/docs/fields.asciidoc
+++ b/metricbeat/docs/fields.asciidoc
@@ -19,6 +19,7 @@ grouped in the following categories:
 * <<exported-fields-cloud>>
 * <<exported-fields-common>>
 * <<exported-fields-couchbase>>
+* <<exported-fields-docker-processor>>
 * <<exported-fields-docker>>
 * <<exported-fields-dropwizard>>
 * <<exported-fields-elasticsearch>>
@@ -3213,6 +3214,47 @@ type: long
 Number of items/documents that are replicas.
 
 
+[[exported-fields-docker-processor]]
+== docker Fields
+
+beta[]
+Docker stats collected from Docker.
+
+
+
+
+[float]
+=== docker.container.id
+
+type: keyword
+
+Unique container id.
+
+
+[float]
+=== docker.container.image
+
+type: keyword
+
+Name of the image the container was built on.
+
+
+[float]
+=== docker.container.name
+
+type: keyword
+
+Container name.
+
+
+[float]
+=== docker.container.labels
+
+type: object
+
+Image labels.
+
+
 [[exported-fields-docker]]
 == Docker Fields
 
@@ -3252,30 +3294,6 @@ Date when the container was created.
 
 
 [float]
-=== docker.container.id
-
-type: keyword
-
-Unique container id.
-
-
-[float]
-=== docker.container.image
-
-type: keyword
-
-Name of the image the container was built on.
-
-
-[float]
-=== docker.container.name
-
-type: keyword
-
-Container name.
-
-
-[float]
 === docker.container.status
 
 type: keyword
@@ -3304,14 +3322,6 @@ Total size of all the files in the container.
 type: long
 
 Size of the files that have been created or changed since creation.
-
-
-[float]
-=== docker.container.labels
-
-type: object
-
-Image labels.
 
 
 [float]

--- a/metricbeat/metricbeat.full.yml
+++ b/metricbeat/metricbeat.full.yml
@@ -539,8 +539,10 @@ metricbeat.modules:
 #
 #processors:
 #- add_docker_metadata:
+#    host: "unix:///var/run/docker.sock"
+#    match_source: true
+#    match_source_index: 4
 #    match_fields: ["system.process.cgroup.id"]
-#  host: "unix:///var/run/docker.sock"
 #  # To connect to Docker over TLS you must specify a client and CA certificate.
 #  #ssl:
 #  #  certificate_authority: "/etc/pki/root/ca.pem"

--- a/metricbeat/module/docker/container/_meta/fields.yml
+++ b/metricbeat/module/docker/container/_meta/fields.yml
@@ -11,18 +11,6 @@
       type: date
       description: >
         Date when the container was created.
-    - name: id
-      type: keyword
-      description: >
-        Unique container id.
-    - name: image
-      type: keyword
-      description: >
-        Name of the image the container was built on.
-    - name: name
-      type: keyword
-      description: >
-        Container name.
     - name: status
       type: keyword
       description: >
@@ -40,11 +28,6 @@
           type: long
           description: >
              Size of the files that have been created or changed since creation.
-    - name: labels
-      type: object
-      object_type: keyword
-      description: >
-        Image labels.
     - name: tags
       type: array
       description: >

--- a/packetbeat/docs/fields.asciidoc
+++ b/packetbeat/docs/fields.asciidoc
@@ -18,6 +18,7 @@ grouped in the following categories:
 * <<exported-fields-cloud>>
 * <<exported-fields-common>>
 * <<exported-fields-dns>>
+* <<exported-fields-docker-processor>>
 * <<exported-fields-flows_event>>
 * <<exported-fields-http>>
 * <<exported-fields-icmp>>
@@ -1497,6 +1498,47 @@ Extended response code field.
 type: long
 
 Requestor's UDP payload size (in bytes).
+
+[[exported-fields-docker-processor]]
+== docker Fields
+
+beta[]
+Docker stats collected from Docker.
+
+
+
+
+[float]
+=== docker.container.id
+
+type: keyword
+
+Unique container id.
+
+
+[float]
+=== docker.container.image
+
+type: keyword
+
+Name of the image the container was built on.
+
+
+[float]
+=== docker.container.name
+
+type: keyword
+
+Container name.
+
+
+[float]
+=== docker.container.labels
+
+type: object
+
+Image labels.
+
 
 [[exported-fields-flows_event]]
 == Flow Event Fields

--- a/packetbeat/packetbeat.full.yml
+++ b/packetbeat/packetbeat.full.yml
@@ -537,8 +537,10 @@ packetbeat.protocols:
 #
 #processors:
 #- add_docker_metadata:
+#    host: "unix:///var/run/docker.sock"
+#    match_source: true
+#    match_source_index: 4
 #    match_fields: ["system.process.cgroup.id"]
-#  host: "unix:///var/run/docker.sock"
 #  # To connect to Docker over TLS you must specify a client and CA certificate.
 #  #ssl:
 #  #  certificate_authority: "/etc/pki/root/ca.pem"

--- a/winlogbeat/docs/fields.asciidoc
+++ b/winlogbeat/docs/fields.asciidoc
@@ -15,6 +15,7 @@ grouped in the following categories:
 * <<exported-fields-beat>>
 * <<exported-fields-cloud>>
 * <<exported-fields-common>>
+* <<exported-fields-docker-processor>>
 * <<exported-fields-eventlog>>
 * <<exported-fields-kubernetes-processor>>
 
@@ -180,6 +181,47 @@ required: True
 
 The event log API type used to read the record. The possible values are "wineventlog" for the Windows Event Log API or "eventlogging" for the Event Logging API.
 The Event Logging API was designed for Windows Server 2003, Windows XP, or Windows 2000 operating systems. In Windows Vista, the event logging infrastructure was redesigned. On Windows Vista or later operating systems, the Windows Event Log API is used. Winlogbeat automatically detects which API to use for reading event logs.
+
+
+[[exported-fields-docker-processor]]
+== docker Fields
+
+beta[]
+Docker stats collected from Docker.
+
+
+
+
+[float]
+=== docker.container.id
+
+type: keyword
+
+Unique container id.
+
+
+[float]
+=== docker.container.image
+
+type: keyword
+
+Name of the image the container was built on.
+
+
+[float]
+=== docker.container.name
+
+type: keyword
+
+Container name.
+
+
+[float]
+=== docker.container.labels
+
+type: object
+
+Image labels.
 
 
 [[exported-fields-eventlog]]

--- a/winlogbeat/winlogbeat.full.yml
+++ b/winlogbeat/winlogbeat.full.yml
@@ -111,8 +111,10 @@ winlogbeat.event_logs:
 #
 #processors:
 #- add_docker_metadata:
+#    host: "unix:///var/run/docker.sock"
+#    match_source: true
+#    match_source_index: 4
 #    match_fields: ["system.process.cgroup.id"]
-#  host: "unix:///var/run/docker.sock"
 #  # To connect to Docker over TLS you must specify a client and CA certificate.
 #  #ssl:
 #  #  certificate_authority: "/etc/pki/root/ca.pem"


### PR DESCRIPTION
This change adds `match_source` setting to automatically match `source` field from filebeat events. Default settings take care of most common scenario. It will match `/var/lib/docker/containers/<container_id>/*.log`. The `match_source_index` setting allows changing this to match other position in the path. Just use:

```
processors:
   - add_docker_metadata: ~
```