### PR TITLE
Modify add_docker_metadata processor to lookup ContainerId from source path in case of filebeat

### DIFF
--- a/filebeat/beater/filebeat.go
+++ b/filebeat/beater/filebeat.go
@@ -95,16 +95,13 @@ func (fb *Filebeat) modulesSetup(b *beat.Beat) error {
 			" can ignore this warning.")
 		return nil
 	}
-	esClient, err := elasticsearch.NewConnectedClient(esConfig)
-	if err != nil {
-		return fmt.Errorf("Error creating ES client: %v", err)
-	}
-	defer esClient.Close()
 
-	err = fb.moduleRegistry.LoadPipelines(esClient)
-	if err != nil {
-		return err
+	// register pipeline loading to happen every time a new ES connection is
+	// established
+	callback := func(esClient *elasticsearch.Client) error {
+		return fb.moduleRegistry.LoadPipelines(esClient)
 	}
+	elasticsearch.RegisterConnectCallback(callback)
 
 	return nil
 }

--- a/filebeat/processor/add_docker_metadata/add_docker_metadata.go
+++ b/filebeat/processor/add_docker_metadata/add_docker_metadata.go
@@ -1,0 +1,55 @@
+package add_docker_metadata
+
+import (
+"strings"
+
+"github.com/elastic/beats/libbeat/common"
+"github.com/elastic/beats/libbeat/logp"
+"github.com/elastic/beats/libbeat/processors/add_docker_metadata"
+)
+const LogPathMatcherName = "logs_path"
+
+
+func init() {
+	add_docker_metadata.Matcher=&FileMatch{}
+}
+
+type FileMatch struct {
+	LogsPath string
+}
+
+func (match *FileMatch) MetadataIndex(event common.MapStr) string{
+	if value, ok := event["source"]; ok {
+		source := value.(string)
+		cid := ""
+		if strings.Contains(source, match.LogsPath) {
+			//Docker container is 64 chars in length
+			cid = source[len(match.LogsPath) : len(match.LogsPath)+64]
+		}
+		if cid != "" {
+			return cid
+		}
+	}
+
+	return ""
+}
+
+func (match *FileMatch) InitMatcher(cfg common.Config) error{
+	config := struct {
+		LogsPath string `config:"logs_path"`
+	}{
+		LogsPath: "/var/lib/docker/containers/",
+	}
+
+	err := cfg.Unpack(&config)
+	if err != nil || config.LogsPath == "" {
+		return err
+	}
+
+	match.LogsPath = config.LogsPath
+	return nil
+}
+
+
+
+

--- a/filebeat/processor/add_docker_metadata/add_docker_metadata_test.go
+++ b/filebeat/processor/add_docker_metadata/add_docker_metadata_test.go
@@ -1,0 +1,80 @@
+package add_docker_metadata
+
+import (
+	"testing"
+
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/elastic/beats/libbeat/processors/add_docker_metadata"
+)
+
+func TestLogPath(t *testing.T) {
+	testConfig, err := common.NewConfigFrom(map[string]interface{}{
+		"logs_path": "/path1/path2/",
+	})
+	assert.NoError(t, err)
+
+	p, err := add_docker_metadata.BuildDockerMetadataProcessor(*testConfig, MockWatcherFactory(
+		map[string]*add_docker_metadata.Container{
+			"9b11fc6df837c05fe81a174b80fb3731c32a5dba442af6146944cb0f85e30e56": &add_docker_metadata.Container{
+				ID:    "9b11fc6df837c05fe81a174b80fb3731c32a5dba442af6146944cb0f85e30e56",
+				Image: "image",
+				Name:  "name",
+				Labels: map[string]string{
+					"a": "1",
+					"b": "2",
+				},
+			},
+		}))
+	assert.NoError(t, err, "initializing add_docker_metadata processor")
+
+	input := common.MapStr{
+		"source": "/path1/path2/9b11fc6df837c05fe81a174b80fb3731c32a5dba442af6146944cb0f85e30e56/container.log",
+	}
+	result, err := p.Run(input)
+	assert.NoError(t, err, "processing an event")
+
+	assert.EqualValues(t, common.MapStr{
+		"source":"/path1/path2/9b11fc6df837c05fe81a174b80fb3731c32a5dba442af6146944cb0f85e30e56/container.log",
+		"docker": common.MapStr{
+			"container": common.MapStr{
+				"id":    "9b11fc6df837c05fe81a174b80fb3731c32a5dba442af6146944cb0f85e30e56",
+				"image": "image",
+				"labels": common.MapStr{
+					"a": "1",
+					"b": "2",
+				},
+				"name": "name",
+			},
+		},
+	}, result)
+}
+
+func MockWatcherFactory(containers map[string]*add_docker_metadata.Container) add_docker_metadata.WatcherConstructor {
+	if containers == nil {
+		containers = make(map[string]*add_docker_metadata.Container)
+	}
+	return func(host string, tls *add_docker_metadata.TLSConfig) (add_docker_metadata.Watcher, error) {
+		return &mockWatcher{containers: containers}, nil
+	}
+}
+
+type mockWatcher struct {
+	containers map[string]*add_docker_metadata.Container
+}
+
+func (m *mockWatcher) Start() error {
+	return nil
+}
+
+func (m *mockWatcher) Container(ID string) *add_docker_metadata.Container {
+	return m.containers[ID]
+}
+
+func (m *mockWatcher) Containers() map[string]*add_docker_metadata.Container {
+	return m.containers
+}
+
+
+
+

--- a/libbeat/docs/processors-using.asciidoc
+++ b/libbeat/docs/processors-using.asciidoc
@@ -574,13 +574,15 @@ from Docker containers:
 
 Currently it supports enriching events by matching existing fields with the
 container ID in them, for example, cgroup IDs retrieved by metricbeat system
-module:
+module. In case of filebeat, it supports parsing Docker Container ID from the prospector
+path:
 
 [source,yaml]
 -------------------------------------------------------------------------------
 processors:
 - add_docker_metadata:
     match_fields: ["system.process.cgroup.id"]
+    logs_path: "/var/lib/docker/containers"
   host: "unix:///var/run/docker.sock"
 
   # To connect to Docker over TLS you must specify a client and CA certificate.

--- a/libbeat/processors/add_docker_metadata/add_docker_metadata_test.go
+++ b/libbeat/processors/add_docker_metadata/add_docker_metadata_test.go
@@ -10,7 +10,7 @@ import (
 func TestInitialization(t *testing.T) {
 	var testConfig = common.NewConfig()
 
-	p, err := buildDockerMetadataProcessor(*testConfig, MockWatcherFactory(nil))
+	p, err := BuildDockerMetadataProcessor(*testConfig, MockWatcherFactory(nil))
 	assert.NoError(t, err, "initializing add_docker_metadata processor")
 
 	input := common.MapStr{}
@@ -26,7 +26,7 @@ func TestNoMatch(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	p, err := buildDockerMetadataProcessor(*testConfig, MockWatcherFactory(nil))
+	p, err := BuildDockerMetadataProcessor(*testConfig, MockWatcherFactory(nil))
 	assert.NoError(t, err, "initializing add_docker_metadata processor")
 
 	input := common.MapStr{
@@ -44,7 +44,7 @@ func TestMatchNoContainer(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	p, err := buildDockerMetadataProcessor(*testConfig, MockWatcherFactory(nil))
+	p, err := BuildDockerMetadataProcessor(*testConfig, MockWatcherFactory(nil))
 	assert.NoError(t, err, "initializing add_docker_metadata processor")
 
 	input := common.MapStr{
@@ -62,7 +62,7 @@ func TestMatchContainer(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	p, err := buildDockerMetadataProcessor(*testConfig, MockWatcherFactory(
+	p, err := BuildDockerMetadataProcessor(*testConfig, MockWatcherFactory(
 		map[string]*Container{
 			"container_id": &Container{
 				ID:    "container_id",


### PR DESCRIPTION
The add_docker_metadata processor cannot work with Filebeat because in typical docker json logs, the container id is not present. This change is to lookup the ContainerId from the source path,similar to Kubernetes processor. Being a newbie in go, please excuse if some of the usages are not per go coding standards. The solution is to basically make the "matching" for ContainerId pluggable and use  a different implementation for filebeat.