### PR TITLE
Backport #4491 to 5.4: Update gosigar to fix Windows service timeout

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -33,11 +33,9 @@ https://github.com/elastic/beats/compare/v5.4.1...master[Check the HEAD diff]
 *Heartbeat*
 
 *Metricbeat*
-- Fix a debug statement that said a module wrapper had stopped when it hadn't. {pull}4264[4264]
-- Use MemAvailable value from /proc/meminfo on Linux 3.14. {pull}4316[4316]
-- Fix panic when events were dropped by filters. {issue}4327[4327]
 - Add filtering to system filesystem metricset to remove relative mountpoints like those
   from Linux network namespaces. {pull}4370[4370]
+- Fix issue affecting Windows services timing out at startup. {pull}4491[4491]
 
 *Packetbeat*
 

--- a/glide.yaml
+++ b/glide.yaml
@@ -25,7 +25,7 @@ import:
   subpackages:
   - /difflib
 - package: github.com/elastic/gosigar
-  version: v0.2.0
+  version: v0.2.1
 - package: github.com/elastic/procfs
   version: abf152e5f3e97f2fafac028d2cc06c1feb87ffa5
 - package: github.com/samuel/go-parser

--- a/vendor/github.com/elastic/gosigar/CHANGELOG.md
+++ b/vendor/github.com/elastic/gosigar/CHANGELOG.md
@@ -2,15 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased]
-
-### Added
+## [0.2.1]
 
 ### Changed
-
-### Deprecated
-
-### Removed
+- Fixed Windows issue that caused a hang during `init()` if WMI wasn't ready. #74
 
 ## [0.2.0]
 

--- a/vendor/github.com/elastic/gosigar/sigar_windows.go
+++ b/vendor/github.com/elastic/gosigar/sigar_windows.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -41,21 +42,14 @@ var (
 
 	// bootTime is the time when the OS was last booted. This value may be nil
 	// on operating systems that do not support the WMI query used to obtain it.
-	bootTime *time.Time
+	bootTime     *time.Time
+	bootTimeLock sync.Mutex
 )
 
 func init() {
 	if !version.IsWindowsVistaOrGreater() {
 		// PROCESS_QUERY_LIMITED_INFORMATION cannot be used on 2003 or XP.
 		processQueryLimitedInfoAccess = syscall.PROCESS_QUERY_INFORMATION
-	}
-
-	if version.IsWindowsVistaOrGreater() {
-		// The minimum supported client for Win32_OperatingSystem is Windows Vista.
-		os, err := getWin32OperatingSystem()
-		if err == nil {
-			bootTime = &os.LastBootUpTime
-		}
 	}
 }
 
@@ -80,9 +74,19 @@ func (self *ProcFDUsage) Get(pid int) error {
 }
 
 func (self *Uptime) Get() error {
-	if bootTime == nil {
-		// Minimum supported OS is Windows Vista.
+	// Minimum supported OS is Windows Vista.
+	if !version.IsWindowsVistaOrGreater() {
 		return ErrNotImplemented{runtime.GOOS}
+	}
+
+	bootTimeLock.Lock()
+	defer bootTimeLock.Unlock()
+	if bootTime == nil {
+		os, err := getWin32OperatingSystem()
+		if err != nil {
+			return errors.Wrap(err, "failed to get boot time using WMI")
+		}
+		bootTime = &os.LastBootUpTime
 	}
 
 	self.Length = time.Since(*bootTime).Seconds()


### PR DESCRIPTION
This PR updates gosigar to v0.2.1 to include the fix from elastic/gosigar#76.

Fixed Windows issue that caused a hang during `init()` if WMI wasn't ready. elastic/gosigar#74 

Fixes #4373