### PR TITLE
Add random startup delay to each metricset

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -59,6 +59,7 @@ https://github.com/elastic/beats/compare/v6.0.0-alpha1...master[Check the HEAD d
 *Heartbeat*
 
 *Metricbeat*
+- Add random startup delay to each metricset to avoid the thundering herd problem. {issue}4010[4010]
 
 *Packetbeat*
 

--- a/metricbeat/_meta/common.full.yml
+++ b/metricbeat/_meta/common.full.yml
@@ -21,3 +21,7 @@ metricbeat.config.modules:
 
   # Set to true to enable config reloading
   reload.enabled: false
+
+# Maximum amount of time to randomly delay the start of a metricset. Use 0 to
+# disable startup delay.
+metricbeat.max_start_delay: 10s

--- a/metricbeat/beater/config.go
+++ b/metricbeat/beater/config.go
@@ -1,10 +1,19 @@
 package beater
 
-import "github.com/elastic/beats/libbeat/common"
+import (
+	"time"
+
+	"github.com/elastic/beats/libbeat/common"
+)
 
 // Config is the root of the Metricbeat configuration hierarchy.
 type Config struct {
 	// Modules is a list of module specific configuration data.
 	Modules       []*common.Config `config:"modules"`
 	ReloadModules *common.Config   `config:"config.modules"`
+	MaxStartDelay time.Duration    `config:"max_start_delay"` // Upper bound on the random startup delay for metricsets (use 0 to disable startup delay).
+}
+
+var defaultConfig = Config{
+	MaxStartDelay: 10 * time.Second,
 }

--- a/metricbeat/docs/reference/configuration/metricbeat-options.asciidoc
+++ b/metricbeat/docs/reference/configuration/metricbeat-options.asciidoc
@@ -22,7 +22,22 @@ metricbeat.modules:
   hosts: ["root@tcp(127.0.0.1:3306)/"]
 ------------------------------------------------------------------------------
 
-==== Metricbeat Options
+==== General Options
+
+===== max_start_delay
+
+The maximum random delay to apply to the startup of a metricset. Random delays
+ranging from [0, _max_start_delay_) are applied to reduce the thundering herd
+effect that can occur if a fleet of machines running Metricbeat are restarted at
+the same time. Specifying a value of 0 disables the startup delay. The default
+is 10s.
+
+[source,yaml]
+----
+metricbeat.max_start_delay: 10s
+----
+
+==== Module Options
 
 You can specify the following options in the `metricbeat` section of the +{beatname_lc}.yml+ config file. These options
 are the same for all modules. Each module may have additional configuration options that are specific to that module.

--- a/metricbeat/mb/module/example_test.go
+++ b/metricbeat/mb/module/example_test.go
@@ -28,7 +28,7 @@ func ExampleWrapper() {
 	}
 
 	// Create a new Wrapper based on the configuration.
-	m, err := module.NewWrapper(config, mb.Registry)
+	m, err := module.NewWrapper(0, config, mb.Registry)
 	if err != nil {
 		fmt.Println("Error:", err)
 		return
@@ -97,7 +97,7 @@ func ExampleRunner() {
 	}
 
 	// Create a new Wrapper based on the configuration.
-	m, err := module.NewWrapper(config, mb.Registry)
+	m, err := module.NewWrapper(0, config, mb.Registry)
 	if err != nil {
 		return
 	}

--- a/metricbeat/mb/module/factory.go
+++ b/metricbeat/mb/module/factory.go
@@ -1,6 +1,8 @@
 package module
 
 import (
+	"time"
+
 	"github.com/elastic/beats/libbeat/cfgfile"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/publisher"
@@ -9,18 +11,20 @@ import (
 
 // Factory is used to register and reload modules
 type Factory struct {
-	client func() publisher.Client
+	client        func() publisher.Client
+	maxStartDelay time.Duration
 }
 
 // NewFactory creates new Reloader instance for the given config
-func NewFactory(p publisher.Publisher) *Factory {
+func NewFactory(maxStartDelay time.Duration, p publisher.Publisher) *Factory {
 	return &Factory{
-		client: p.Connect,
+		client:        p.Connect,
+		maxStartDelay: maxStartDelay,
 	}
 }
 
 func (r *Factory) Create(c *common.Config) (cfgfile.Runner, error) {
-	w, err := NewWrapper(c, mb.Registry)
+	w, err := NewWrapper(r.maxStartDelay, c, mb.Registry)
 	if err != nil {
 		return nil, err
 	}

--- a/metricbeat/mb/module/runner_test.go
+++ b/metricbeat/mb/module/runner_test.go
@@ -26,7 +26,7 @@ func TestRunner(t *testing.T) {
 	}
 
 	// Create a new Wrapper based on the configuration.
-	m, err := module.NewWrapper(config, mb.Registry)
+	m, err := module.NewWrapper(0, config, mb.Registry)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/metricbeat/mb/module/wrapper_test.go
+++ b/metricbeat/mb/module/wrapper_test.go
@@ -121,7 +121,7 @@ func TestWrapperOfEventFetcher(t *testing.T) {
 		"hosts":      hosts,
 	})
 
-	m, err := module.NewWrapper(c, newTestRegistry(t))
+	m, err := module.NewWrapper(0, c, newTestRegistry(t))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -154,7 +154,7 @@ func TestWrapperOfReportingFetcher(t *testing.T) {
 		"hosts":      hosts,
 	})
 
-	m, err := module.NewWrapper(c, newTestRegistry(t))
+	m, err := module.NewWrapper(0, c, newTestRegistry(t))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -187,7 +187,7 @@ func TestWrapperOfPushMetricSet(t *testing.T) {
 		"hosts":      hosts,
 	})
 
-	m, err := module.NewWrapper(c, newTestRegistry(t))
+	m, err := module.NewWrapper(0, c, newTestRegistry(t))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/metricbeat/metricbeat.full.yml
+++ b/metricbeat/metricbeat.full.yml
@@ -22,6 +22,10 @@ metricbeat.config.modules:
   # Set to true to enable config reloading
   reload.enabled: false
 
+# Maximum amount of time to randomly delay the start of a metricset. Use 0 to
+# disable startup delay.
+metricbeat.max_start_delay: 10s
+
 #==========================  Modules configuration ============================
 metricbeat.modules:
 

--- a/metricbeat/tests/system/config/metricbeat.yml.j2
+++ b/metricbeat/tests/system/config/metricbeat.yml.j2
@@ -98,6 +98,9 @@ metricbeat.config.modules:
   reload.enabled: true
 {% endif -%}
 
+# Disable random start delay for metricsets.
+metricbeat.max_start_delay: 0
+
 #================================ General =====================================
 
 # The name of the shipper that publishes the network data. It can be used to group


### PR DESCRIPTION
Add random startup delay to each metricset to avoid the thundering herd problem. Fixes #4010.

Running with debug, at startup you will see:

```
2017/06/14 14:24:03.652815 wrapper.go:197: DBG  system/memory will start after 6.287460518s
2017/06/14 14:24:03.652818 wrapper.go:197: DBG  system/cpu will start after 1.102366376s
2017/06/14 14:24:03.652827 wrapper.go:197: DBG  system/load will start after 4.933446568s
2017/06/14 14:24:03.652838 wrapper.go:197: DBG  system/filesystem will start after 4.47437156s
2017/06/14 14:24:03.652847 wrapper.go:197: DBG  system/fsstat will start after 5.52497095s
2017/06/14 14:24:03.652823 wrapper.go:197: DBG  system/process_summary will start after 8.93791103s
2017/06/14 14:24:03.652837 wrapper.go:197: DBG  system/network will start after 1.274884509s
2017/06/14 14:24:03.652821 wrapper.go:197: DBG  system/process will start after 6.207285781s
```