### PR TITLE
Fix release state and update versions for 5.5

### DIFF
--- a/libbeat/docs/version.asciidoc
+++ b/libbeat/docs/version.asciidoc
@@ -1,4 +1,4 @@
-:stack-version: 5.4.1
-:doc-branch: 5.4
+:stack-version: 5.5.0
+:doc-branch: 5.5
 :go-version: 1.7.6
-:release-state: released
+:release-state: unreleased


### PR DESCRIPTION
Just realized we're building the preliminary docs for 5.5 now, so we need to bump the versions and change the release-state to unreleased.