### PR TITLE
Fix race condition in logging

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -31,6 +31,7 @@ https://github.com/elastic/beats/compare/v6.0.0-alpha1...master[Check the HEAD d
 *Affecting all Beats*
 
 - Don't stop with error loading the ES template if the ES output is not enabled. {pull}4436[4436]
+- Fix race condition in internal logging rotator. {pull}4519[4519]
 
 *Filebeat*
 

--- a/libbeat/logp/file_rotator_test.go
+++ b/libbeat/logp/file_rotator_test.go
@@ -174,3 +174,32 @@ func TestConfigSane(t *testing.T) {
 	}
 	assert.NotNil(t, rotator.CheckIfConfigSane())
 }
+
+func TestRaceConditions(t *testing.T) {
+	// Make sure concurrent `WriteLine` calls don't end up in race conditions around `rotator.current`
+	if testing.Verbose() {
+		LogInit(LOG_DEBUG, "", false, true, []string{"rotator"})
+	}
+
+	dir, err := ioutil.TempDir("", "test_rotator_")
+	if err != nil {
+		t.Errorf("Error: %s", err.Error())
+		return
+	}
+
+	Debug("rotator", "Directory: %s", dir)
+
+	rotateeverybytes := uint64(10)
+	keepfiles := 20
+
+	rotator := FileRotator{
+		Path:             dir,
+		Name:             "testbeat",
+		RotateEveryBytes: &rotateeverybytes,
+		KeepFiles:        &keepfiles,
+	}
+
+	for i := 0; i < 1000; i++ {
+		go rotator.WriteLine([]byte(string(i)))
+	}
+}


### PR DESCRIPTION
`logp.FileRotator` had an issue when `WriteLines` is called concurrently. Added a RWLock to protect both `rotator.current` and `rotator.currentSize`