### PR TITLE
Fix import statement in beat generator

### DIFF
--- a/generator/beat/{beat}/cmd/root.go.tmpl
+++ b/generator/beat/{beat}/cmd/root.go.tmpl
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"github.com/elastic/beats/metricbeat/beater"
+	"{beat_path}/beater"
 
 	cmd "github.com/elastic/beats/libbeat/cmd"
 )


### PR DESCRIPTION
The generator was importing Metricbeat instead of the generated beater.