### PR TITLE
Improve `add_docker_metadata` examples for their common cases

### DIFF
--- a/filebeat/filebeat.full.yml
+++ b/filebeat/filebeat.full.yml
@@ -517,15 +517,19 @@ filebeat.prospectors:
 #processors:
 #- add_docker_metadata:
 #    host: "unix:///var/run/docker.sock"
-#    match_source: true
-#    match_source_index: 4
 #    match_fields: ["system.process.cgroup.id"]
-#  # To connect to Docker over TLS you must specify a client and CA certificate.
-#  #ssl:
-#  #  certificate_authority: "/etc/pki/root/ca.pem"
-#  #  certificate:           "/etc/pki/client/cert.pem"
-#  #  key:                   "/etc/pki/client/cert.key"
+#    # To connect to Docker over TLS you must specify a client and CA certificate.
+#    #ssl:
+#    #  certificate_authority: "/etc/pki/root/ca.pem"
+#    #  certificate:           "/etc/pki/client/cert.pem"
+#    #  key:                   "/etc/pki/client/cert.key"
 #
+# The following example enriches each event with docker metadata, it matches
+# container id from log path available in `source` field (by default it expects
+# it to be /var/lib/docker/containers/*/*.log).
+#
+#processors:
+#- add_docker_metadata: ~
 
 #================================ Outputs ======================================
 

--- a/heartbeat/heartbeat.full.yml
+++ b/heartbeat/heartbeat.full.yml
@@ -281,15 +281,19 @@ heartbeat.scheduler:
 #processors:
 #- add_docker_metadata:
 #    host: "unix:///var/run/docker.sock"
-#    match_source: true
-#    match_source_index: 4
 #    match_fields: ["system.process.cgroup.id"]
-#  # To connect to Docker over TLS you must specify a client and CA certificate.
-#  #ssl:
-#  #  certificate_authority: "/etc/pki/root/ca.pem"
-#  #  certificate:           "/etc/pki/client/cert.pem"
-#  #  key:                   "/etc/pki/client/cert.key"
+#    # To connect to Docker over TLS you must specify a client and CA certificate.
+#    #ssl:
+#    #  certificate_authority: "/etc/pki/root/ca.pem"
+#    #  certificate:           "/etc/pki/client/cert.pem"
+#    #  key:                   "/etc/pki/client/cert.key"
 #
+# The following example enriches each event with docker metadata, it matches
+# container id from log path available in `source` field (by default it expects
+# it to be /var/lib/docker/containers/*/*.log).
+#
+#processors:
+#- add_docker_metadata: ~
 
 #================================ Outputs ======================================
 

--- a/libbeat/_meta/config.full.yml
+++ b/libbeat/_meta/config.full.yml
@@ -83,15 +83,19 @@
 #processors:
 #- add_docker_metadata:
 #    host: "unix:///var/run/docker.sock"
-#    match_source: true
-#    match_source_index: 4
 #    match_fields: ["system.process.cgroup.id"]
-#  # To connect to Docker over TLS you must specify a client and CA certificate.
-#  #ssl:
-#  #  certificate_authority: "/etc/pki/root/ca.pem"
-#  #  certificate:           "/etc/pki/client/cert.pem"
-#  #  key:                   "/etc/pki/client/cert.key"
+#    # To connect to Docker over TLS you must specify a client and CA certificate.
+#    #ssl:
+#    #  certificate_authority: "/etc/pki/root/ca.pem"
+#    #  certificate:           "/etc/pki/client/cert.pem"
+#    #  key:                   "/etc/pki/client/cert.key"
 #
+# The following example enriches each event with docker metadata, it matches
+# container id from log path available in `source` field (by default it expects
+# it to be /var/lib/docker/containers/*/*.log).
+#
+#processors:
+#- add_docker_metadata: ~
 
 #================================ Outputs ======================================
 

--- a/metricbeat/metricbeat.full.yml
+++ b/metricbeat/metricbeat.full.yml
@@ -549,15 +549,19 @@ metricbeat.modules:
 #processors:
 #- add_docker_metadata:
 #    host: "unix:///var/run/docker.sock"
-#    match_source: true
-#    match_source_index: 4
 #    match_fields: ["system.process.cgroup.id"]
-#  # To connect to Docker over TLS you must specify a client and CA certificate.
-#  #ssl:
-#  #  certificate_authority: "/etc/pki/root/ca.pem"
-#  #  certificate:           "/etc/pki/client/cert.pem"
-#  #  key:                   "/etc/pki/client/cert.key"
+#    # To connect to Docker over TLS you must specify a client and CA certificate.
+#    #ssl:
+#    #  certificate_authority: "/etc/pki/root/ca.pem"
+#    #  certificate:           "/etc/pki/client/cert.pem"
+#    #  key:                   "/etc/pki/client/cert.key"
 #
+# The following example enriches each event with docker metadata, it matches
+# container id from log path available in `source` field (by default it expects
+# it to be /var/lib/docker/containers/*/*.log).
+#
+#processors:
+#- add_docker_metadata: ~
 
 #================================ Outputs ======================================
 

--- a/packetbeat/packetbeat.full.yml
+++ b/packetbeat/packetbeat.full.yml
@@ -538,15 +538,19 @@ packetbeat.protocols:
 #processors:
 #- add_docker_metadata:
 #    host: "unix:///var/run/docker.sock"
-#    match_source: true
-#    match_source_index: 4
 #    match_fields: ["system.process.cgroup.id"]
-#  # To connect to Docker over TLS you must specify a client and CA certificate.
-#  #ssl:
-#  #  certificate_authority: "/etc/pki/root/ca.pem"
-#  #  certificate:           "/etc/pki/client/cert.pem"
-#  #  key:                   "/etc/pki/client/cert.key"
+#    # To connect to Docker over TLS you must specify a client and CA certificate.
+#    #ssl:
+#    #  certificate_authority: "/etc/pki/root/ca.pem"
+#    #  certificate:           "/etc/pki/client/cert.pem"
+#    #  key:                   "/etc/pki/client/cert.key"
 #
+# The following example enriches each event with docker metadata, it matches
+# container id from log path available in `source` field (by default it expects
+# it to be /var/lib/docker/containers/*/*.log).
+#
+#processors:
+#- add_docker_metadata: ~
 
 #================================ Outputs ======================================
 

--- a/winlogbeat/winlogbeat.full.yml
+++ b/winlogbeat/winlogbeat.full.yml
@@ -112,15 +112,19 @@ winlogbeat.event_logs:
 #processors:
 #- add_docker_metadata:
 #    host: "unix:///var/run/docker.sock"
-#    match_source: true
-#    match_source_index: 4
 #    match_fields: ["system.process.cgroup.id"]
-#  # To connect to Docker over TLS you must specify a client and CA certificate.
-#  #ssl:
-#  #  certificate_authority: "/etc/pki/root/ca.pem"
-#  #  certificate:           "/etc/pki/client/cert.pem"
-#  #  key:                   "/etc/pki/client/cert.key"
+#    # To connect to Docker over TLS you must specify a client and CA certificate.
+#    #ssl:
+#    #  certificate_authority: "/etc/pki/root/ca.pem"
+#    #  certificate:           "/etc/pki/client/cert.pem"
+#    #  key:                   "/etc/pki/client/cert.key"
 #
+# The following example enriches each event with docker metadata, it matches
+# container id from log path available in `source` field (by default it expects
+# it to be /var/lib/docker/containers/*/*.log).
+#
+#processors:
+#- add_docker_metadata: ~
 
 #================================ Outputs ======================================
 


### PR DESCRIPTION
Fields are already documented in
https://github.com/elastic/beats/blob/master/libbeat/docs/processors-using.asciidoc#adding-docker-metadata
so I left them out of examples