### PR TITLE
Add umask to generator travis to fix system tests

### DIFF
--- a/generator/beat/{beat}/.editorconfig
+++ b/generator/beat/{beat}/.editorconfig
@@ -1,0 +1,27 @@
+# See: http://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.json]
+indent_size = 4
+indent_style = space
+
+[*.py]
+indent_style = space
+indent_size = 4
+
+[*.yml]
+indent_style = space
+indent_size = 2
+
+[Makefile]
+indent_style = tab
+
+[Vagrantfile]
+indent_size = 2
+indent_style = space

--- a/generator/beat/{beat}/.travis.yml
+++ b/generator/beat/{beat}/.travis.yml
@@ -6,7 +6,7 @@ services:
 language: go
 
 go:
-  - 1.6
+  - 1.8.3
 
 os:
   - linux
@@ -27,6 +27,8 @@ addons:
       - python-virtualenv
 
 before_install:
+  - umask 022
+  - chmod -R go-w $GOPATH/src/github.com/elastic/beats
   # Redo the travis setup but with the elastic/libbeat path. This is needed so the package path is correct
   - mkdir -p $HOME/gopath/src/github.com/{github_name}/{beat}/
   - rsync -az ${TRAVIS_BUILD_DIR}/ $HOME/gopath/src/github.com/{github_name}/{beat}/

--- a/generator/metricbeat/{beat}/.editorconfig
+++ b/generator/metricbeat/{beat}/.editorconfig
@@ -1,0 +1,27 @@
+# See: http://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.json]
+indent_size = 4
+indent_style = space
+
+[*.py]
+indent_style = space
+indent_size = 4
+
+[*.yml]
+indent_style = space
+indent_size = 2
+
+[Makefile]
+indent_style = tab
+
+[Vagrantfile]
+indent_size = 2
+indent_style = space


### PR DESCRIPTION
System tests require on travis the umask to be changed as otherwise the config files generated for the system tests have the wrong access rights.