### PR TITLE
Enable new travis image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: required
 dist: trusty
+group: edge     # in preparation for https://blog.travis-ci.com/2017-06-19-trusty-updates-2017-Q2
 services:
   - docker
 


### PR DESCRIPTION
As per https://blog.travis-ci.com/2017-06-19-trusty-updates-2017-Q2

Not sure if we should merge this, since it's going to be made the default tomorrow, but opening it to see if the tests are passing on the new infra.