### PR TITLE
Fix generation of object with enabled: false 

### DIFF
--- a/libbeat/template/field.go
+++ b/libbeat/template/field.go
@@ -111,30 +111,31 @@ func (f *Field) text() common.MapStr {
 }
 
 func (f *Field) array() common.MapStr {
-	return common.MapStr{}
+	return f.getDefaultProperties()
 }
 
 func (f *Field) object() common.MapStr {
 
 	if f.ObjectType == "text" {
-		properties := f.getDefaultProperties()
-		properties["type"] = "text"
+		dynProperties := f.getDefaultProperties()
+		dynProperties["type"] = "text"
 
 		if f.esVersion.IsMajor(2) {
-			properties["type"] = "string"
-			properties["index"] = "analyzed"
+			dynProperties["type"] = "string"
+			dynProperties["index"] = "analyzed"
 		}
-		f.addDynamicTemplate(properties, "string")
+		f.addDynamicTemplate(dynProperties, "string")
 	}
 
 	if f.ObjectType == "long" {
-		properties := f.getDefaultProperties()
-		properties["type"] = "long"
-		f.addDynamicTemplate(properties, "long")
+		dynProperties := f.getDefaultProperties()
+		dynProperties["type"] = "long"
+		f.addDynamicTemplate(dynProperties, "long")
 	}
-	return common.MapStr{
-		"properties": common.MapStr{},
-	}
+
+	properties := f.getDefaultProperties()
+	properties["type"] = "object"
+	return properties
 }
 
 func (f *Field) addDynamicTemplate(properties common.MapStr, matchType string) {

--- a/libbeat/template/field_test.go
+++ b/libbeat/template/field_test.go
@@ -57,6 +57,14 @@ func TestField(t *testing.T) {
 				"enabled": false,
 			},
 		},
+		{
+			field:  Field{Type: "object", Enabled: &falseVar},
+			method: func(f Field) common.MapStr { return f.object() },
+			output: common.MapStr{
+				"type":    "object",
+				"enabled": false,
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/libbeat/template/testdata/fields.yml
+++ b/libbeat/template/testdata/fields.yml
@@ -1,0 +1,22 @@
+- key: test
+  title: Test fields.yml
+  description: >
+    Contains all types for testing
+  fields:
+
+    - name: object
+      type: object
+
+    - name: array
+      type: array
+
+    - name: keyword
+      type: keyword
+
+    - name: object_disabled
+      type: object
+      enabled: false
+
+    - name: array_disabled
+      type: array
+      enabled: false


### PR DESCRIPTION
Each `object` type now contains `"type": "object"`. Previously it was `"properties": {}`. Having `object` defined instead of properties allows to add more entries and the usage of the default properties object.

This is a follow up PR for #4532