### PR TITLE
Enable Cgo for Filebeat & Heartbeat

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -62,8 +62,11 @@ https://github.com/elastic/beats/compare/v6.0.0-alpha1...master[Check the HEAD d
 - Load Ingest Node pipelines when the Elasticsearch connection is established, instead of only once at startup. {pull}4479[4479]
 - Add support for loading Xpack Machine Learning configurations from the modules, and added sample configurations for the Nginx module. {pull}4506[4506]
 - Add udp prospector type. {pull}4452[4452]
+- Enabled Cgo which means libc is dynamically compiled. {pull}4546[4546]
 
 *Heartbeat*
+
+- Enabled Cgo which means libc is dynamically compiled. {pull}4546[4546]
 
 *Metricbeat*
 - Add random startup delay to each metricset to avoid the thundering herd problem. {issue}4010[4010]

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -56,12 +56,12 @@ PYTHON_ENV?=${BUILD_DIR}/python-env
 BUILDID?=$(shell git rev-parse HEAD) ## @Building The build ID
 VIRTUALENV_PARAMS?=
 INTEGRATION_TESTS?=
-CGO?=false ## @building if true, Build with C Go support
 FIND=. ${PYTHON_ENV}/bin/activate; find . -type f -not -path "*/vendor/*" -not -path "*/build/*" -not -path "*/.git/*"
 
 # Cross compiling targets
-TARGETS?="linux/amd64 linux/386 windows/amd64 windows/386 darwin/amd64" ## @building list of platforms/architecture to be built by "make package"
-TARGETS_OLD?="" ## @building list of Debian6 architecture to be built by "make package" when CGO is true
+CGO?=true ## @building if true, Build with C Go support
+TARGETS?="windows/amd64 windows/386 darwin/amd64" ## @building list of platforms/architecture to be built by "make package"
+TARGETS_OLD?="linux/amd64 linux/386" ## @building list of Debian6 architecture to be built by "make package" when CGO is true
 PACKAGES?=${BEAT_NAME}/deb ${BEAT_NAME}/rpm ${BEAT_NAME}/darwin ${BEAT_NAME}/win ${BEAT_NAME}/bin ## @Building List of OS to be supported by "make package"
 SNAPSHOT?=yes ## @Building If yes, builds a snapshot version
 BEATS_BUILDER_IMAGE?=tudorg/beats-builder ## @Building Name of the docker image to use when packaging the application

--- a/metricbeat/Makefile
+++ b/metricbeat/Makefile
@@ -8,10 +8,6 @@ TEST_ENVIRONMENT?=true
 GOPACKAGES=$(shell go list ${BEAT_PATH}/... | grep -v /vendor/)
 ES_BEATS?=..
 
-TARGETS?="windows/amd64 windows/386 darwin/amd64"
-TARGETS_OLD?="linux/amd64 linux/386"
-CGO=true
-
 # Metricbeat can only be cross-compiled on platforms not requiring CGO.
 GOX_OS=solaris netbsd linux windows
 GOX_FLAGS=-arch="amd64 386 arm ppc64 ppc64le"

--- a/packetbeat/Makefile
+++ b/packetbeat/Makefile
@@ -3,9 +3,6 @@ BEAT_NAME?=packetbeat
 BEAT_DESCRIPTION?=Packetbeat analyzes network traffic and sends the data to Elasticsearch.
 SYSTEM_TESTS?=true
 TEST_ENVIRONMENT=false
-TARGETS="windows/amd64 windows/386 darwin/amd64"
-TARGETS_OLD="linux/amd64 linux/386"
-CGO=true
 ES_BEATS?=..
 
 include ${ES_BEATS}/libbeat/scripts/Makefile

--- a/winlogbeat/Makefile
+++ b/winlogbeat/Makefile
@@ -7,6 +7,8 @@ GOX_OS=windows
 TARGETS="windows/amd64 windows/386"
 PACKAGES=winlogbeat/win
 
+CGO=false		# don't need Cgo in Winlogbeat
+
 include ../libbeat/scripts/Makefile
 
 .PHONY: gen


### PR DESCRIPTION
This is to enable plugin support, and to enable future support (during the
6.x cycle) for importing other C libraries.

Metricbeat & Packetbeat already had Cgo enabled. We're leaving Winlogbeat
without Cgo because we don't foresee a reason for it to need it.

This change also affects the community Beats, but they can revert to pure-go
    by adding `CGO=false` in their Makefile.