### PR TITLE
Fix path.conf in docs to path.config

### DIFF
--- a/libbeat/docs/shared-directory-layout.asciidoc
+++ b/libbeat/docs/shared-directory-layout.asciidoc
@@ -16,12 +16,12 @@ The directory layout of an installation is as follows:
 
 [cols="<h,<,<m,<m",options="header",]
 |=======================================================================
-| Type | Description | Default Location | Config Option
-| home | Home of the {beatname_uc} installation. | | path.home
-| bin  | The location for the binary files. | {path.home} |
-| conf | The location for configuration files. | {path.home} | path.conf
-| data | The location for persistent data files. | {path.home}/data| path.data
-| logs | The location for the logs created by {beatname_uc}. | {path.home}/logs | path.logs
+| Type   | Description | Default Location | Config Option
+| home   | Home of the {beatname_uc} installation. | | path.home
+| bin    | The location for the binary files. | {path.home} |
+| config | The location for configuration files. | {path.home} | path.config
+| data   | The location for persistent data files. | {path.home}/data| path.data
+| logs   | The location for the logs created by {beatname_uc}. | {path.home}/logs | path.logs
 |=======================================================================
 
 You can change these settings by using CLI flags or setting <<configuration-path,path options>> in the configuration
@@ -35,12 +35,12 @@ file.
 ===== deb and rpm
 [cols="<h,<,<m",options="header",]
 |=======================================================================
-| Type | Description | Location
-| home | Home of the {beatname_uc} installation. | /usr/share/{beatname_lc}
-| bin  | The location for the binary files. | /usr/share/{beatname_lc}
-| conf | The location for configuration files. | /etc/{beatname_lc}
-| data | The location for persistent data files. | /var/lib/{beatname_lc}
-| logs | The location for the logs created by {beatname_uc}. | /var/log/{beatname_lc}
+| Type   | Description | Location
+| home   | Home of the {beatname_uc} installation. | /usr/share/{beatname_lc}
+| bin    | The location for the binary files. | /usr/share/{beatname_lc}
+| config | The location for configuration files. | /etc/{beatname_lc}
+| data   | The location for persistent data files. | /var/lib/{beatname_lc}
+| logs   | The location for the logs created by {beatname_uc}. | /var/log/{beatname_lc}
 |=======================================================================
 
 For the deb and rpm distributions, these paths are set in the init script or in
@@ -52,24 +52,24 @@ Otherwise the paths might be set incorrectly.
 ===== docker
 [cols="<h,<,<m",options="header",]
 |=======================================================================
-| Type | Description | Location
-| home | Home of the {beatname_uc} installation. | /usr/share/{beatname_lc}
-| bin  | The location for the binary files. | /usr/share/{beatname_lc}
-| conf | The location for configuration files. | /usr/share/{beatname_lc}
-| data | The location for persistent data files. | /usr/share/{beatname_lc}/data
-| logs | The location for the logs created by {beatname_uc}. | /usr/share//{beatname_lc}/logs
+| Type   | Description | Location
+| home   | Home of the {beatname_uc} installation. | /usr/share/{beatname_lc}
+| bin    | The location for the binary files. | /usr/share/{beatname_lc}
+| config | The location for configuration files. | /usr/share/{beatname_lc}
+| data   | The location for persistent data files. | /usr/share/{beatname_lc}/data
+| logs   | The location for the logs created by {beatname_uc}. | /usr/share//{beatname_lc}/logs
 |=======================================================================
 
 [float]
 ===== zip, tar.gz, and tgz
 [cols="<h,<,<m",options="header",]
 |=======================================================================
-| Type | Description | Location
-| home | Home of the {beatname_uc} installation. | {extract.path}
-| bin  | The location for the binary files. | {extract.path}
-| conf | The location for configuration files. | {extract.path}
-| data | The location for persistent data files. | {extract.path}/data
-| logs | The location for the logs created by {beatname_uc}. | {extract.path}/logs
+| Type   | Description | Location
+| home   | Home of the {beatname_uc} installation. | {extract.path}
+| bin    | The location for the binary files. | {extract.path}
+| config | The location for configuration files. | {extract.path}
+| data   | The location for persistent data files. | {extract.path}/data
+| logs   | The location for the logs created by {beatname_uc}. | {extract.path}/logs
 |=======================================================================
 
 For the zip, tar.gz and tgz distributions, these paths are based on the location of the

--- a/libbeat/docs/shared-path-config.asciidoc
+++ b/libbeat/docs/shared-path-config.asciidoc
@@ -26,12 +26,12 @@ Here is an example configuration:
 [source,yaml]
 ------------------------------------------------------------------------------
 path.home: /usr/share/beat
-path.conf: /etc/beat
+path.config: /etc/beat
 path.data: /var/lib/beat
 path.logs: /var/log/
 ------------------------------------------------------------------------------
 
-Note that it is possible to override these options by using command line flags. 
+Note that it is possible to override these options by using command line flags.
 
 ==== Path Options
 
@@ -62,7 +62,7 @@ Example:
 
 [source,yaml]
 ------------------------------------------------------------------------------
-path.conf: /usr/share/beats/config
+path.config: /usr/share/beats/config
 ------------------------------------------------------------------------------
 
 ===== data


### PR DESCRIPTION
In some docs file `path.conf` instead of `path.config` was mentioned. To reduce confusion I also changed the type from `conf` to `config`.