### PR TITLE
Do not execut start / stop runners if no runners

### DIFF
--- a/libbeat/cfgfile/reload.go
+++ b/libbeat/cfgfile/reload.go
@@ -190,6 +190,10 @@ func (rl *Reloader) Stop() {
 
 func (rl *Reloader) startRunners(list map[uint64]Runner) {
 
+	if len(list) == 0 {
+		return
+	}
+
 	logp.Info("Starting %v runners ...", len(list))
 	for id, runner := range list {
 		runner.Start()
@@ -202,6 +206,11 @@ func (rl *Reloader) startRunners(list map[uint64]Runner) {
 }
 
 func (rl *Reloader) stopRunners(list map[uint64]Runner) {
+
+	if len(list) == 0 {
+		return
+	}
+
 	logp.Info("Stopping %v runners ...", len(list))
 
 	wg := sync.WaitGroup{}


### PR DESCRIPTION
Having executing the start and stop runner each time also when no changes happened added a lot of log messages to log file on the info level. Now start/stopRunner directly return if there are not changes.