### PR TITLE
Cherry-pick #4544 to master: Scale system.cpu.*.pct metrics by the number of cores

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -8,7 +8,7 @@
 // Template, add newest changes here
 
 === Beats version HEAD
-https://github.com/elastic/beats/compare/v6.0.0-alpha1...master[Check the HEAD diff]
+https://github.com/elastic/beats/compare/v6.0.0-alpha2...master[Check the HEAD diff]
 
 ==== Breaking changes
 
@@ -21,6 +21,10 @@ https://github.com/elastic/beats/compare/v6.0.0-alpha1...master[Check the HEAD d
 *Heartbeat*
 
 *Metricbeat*
+- Change all `system.cpu.*.pct` metrics to be scaled by the number of CPU cores.
+  This will make the CPU usage percentages from the system cpu metricset consistent
+  with the system process metricset. The documentation for these metrics already
+  stated that on multi-core systems the percentages could be greater than 100%. {pull}4544[4544]
 
 *Packetbeat*
 

--- a/metricbeat/docs/fields.asciidoc
+++ b/metricbeat/docs/fields.asciidoc
@@ -10038,7 +10038,7 @@ The amount of CPU time spent in involuntary wait by the virtual CPU while the hy
 
 type: long
 
-The number of CPU cores.
+The number of CPU cores. The CPU percentages can range from `[0, 100% * cores]`.
 
 
 [float]
@@ -10048,7 +10048,7 @@ type: scaled_float
 
 format: percent
 
-The percentage of CPU time spent in user space. On multi-core systems, you can have percentages that are greater than 100%. For example, if 3 cores are at 60% use, then the `cpu.user_p` will be 180%.
+The percentage of CPU time spent in user space. On multi-core systems, you can have percentages that are greater than 100%. For example, if 3 cores are at 60% use, then the `system.cpu.user.pct` will be 180%.
 
 
 [float]

--- a/metricbeat/module/system/cpu/_meta/data.json
+++ b/metricbeat/module/system/cpu/_meta/data.json
@@ -11,13 +11,14 @@
     },
     "system": {
         "cpu": {
+            "cores": 8,
             "idle": {
-                "pct": 0.852,
-                "ticks": 44421033
+                "pct": 7.0854,
+                "ticks": 1617015818
             },
             "iowait": {
                 "pct": 0,
-                "ticks": 159735
+                "ticks": 0
             },
             "irq": {
                 "pct": 0,
@@ -29,19 +30,19 @@
             },
             "softirq": {
                 "pct": 0,
-                "ticks": 14070
+                "ticks": 0
             },
             "steal": {
                 "pct": 0,
                 "ticks": 0
             },
             "system": {
-                "pct": 0.0408,
-                "ticks": 305704
+                "pct": 0.3317,
+                "ticks": 40488863
             },
             "user": {
-                "pct": 0.1071,
-                "ticks": 841974
+                "pct": 0.5829,
+                "ticks": 48194733
             }
         }
     },

--- a/metricbeat/module/system/cpu/_meta/fields.yml
+++ b/metricbeat/module/system/cpu/_meta/fields.yml
@@ -6,14 +6,14 @@
     - name: cores
       type: long
       description: >
-        The number of CPU cores.
+        The number of CPU cores. The CPU percentages can range from `[0, 100% * cores]`.
 
     - name: user.pct
       type: scaled_float
       format: percent
       description: >
         The percentage of CPU time spent in user space. On multi-core systems, you can have percentages that are greater than 100%.
-        For example, if 3 cores are at 60% use, then the `cpu.user_p` will be 180%.
+        For example, if 3 cores are at 60% use, then the `system.cpu.user.pct` will be 180%.
 
     - name: system.pct
       type: scaled_float

--- a/metricbeat/module/system/cpu/helper.go
+++ b/metricbeat/module/system/cpu/helper.go
@@ -9,6 +9,9 @@ import (
 	sigar "github.com/elastic/gosigar"
 )
 
+// NumCPU is the number of CPU cores the system has.
+var NumCPU = runtime.NumCPU()
+
 type CPU struct {
 	CpuPerCore       bool
 	LastCpuTimes     *CpuTimes
@@ -72,7 +75,7 @@ func GetCpuPercentage(last *CpuTimes, current *CpuTimes) *CpuTimes {
 			perc := 0.0
 			delta := int64(field2 - field1)
 			perc = float64(delta) / float64(allDelta)
-			return system.Round(perc, .5, 4)
+			return system.Round(perc*float64(NumCPU), .5, 4)
 		}
 
 		current.UserPercent = calculate(current.Cpu.User, last.Cpu.User)

--- a/metricbeat/module/system/cpu/helper_test.go
+++ b/metricbeat/module/system/cpu/helper_test.go
@@ -4,6 +4,7 @@
 package cpu
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/elastic/gosigar"
@@ -21,6 +22,8 @@ func TestGetCpuTimes(t *testing.T) {
 }
 
 func TestCpuPercentage(t *testing.T) {
+	NumCPU = 1
+	defer func() { NumCPU = runtime.NumCPU() }()
 
 	cpu := CPU{}
 


### PR DESCRIPTION
Cherry-pick of PR #4544 to master branch. Original message:

Change all `system.cpu.*.pct` metrics to be scaled by the number of CPU cores such that the values range on `[0, 100% * number_of_cores]`. This will make the CPU usage percentages from the system cpu metricset consistent with the system process metricset. The documentation for these metrics already stated that on multi-core systems the percentages could be greater than 100%. This makes the code match the docs, but does cause a change in behavior to the user.

(cherry picked from commit 67e206482bd4fbcbccef7d3703901c4b8ba476d2)