### PR TITLE
Alphabetize system metricsets

### DIFF
--- a/metricbeat/docs/modules/system.asciidoc
+++ b/metricbeat/docs/modules/system.asciidoc
@@ -92,11 +92,11 @@ metricbeat.modules:
     - cpu
     - load
     - memory
+    - network
+    - process
+    - process_summary
     #- core
     #- diskio
-    - network
-    - process_summary
-    - process
     #- socket
   processes: ['.*']
   process.include_top_n:

--- a/metricbeat/metricbeat.full.yml
+++ b/metricbeat/metricbeat.full.yml
@@ -32,38 +32,17 @@ metricbeat.modules:
 #------------------------------- System Module -------------------------------
 - module: system
   metricsets:
-    # CPU stats
-    - cpu
-
-    # System Load stats
-    - load
-
-    # Per CPU core stats
-    #- core
-
-    # IO stats
-    #- diskio
-
-    # Per filesystem stats
-    - filesystem
-
-    # File system summary stats
-    - fsstat
-
-    # Memory stats
-    - memory
-
-    # Network stats
-    - network
-
-    # Processes summary
-    - process_summary
-
-    # Per process stats
-    - process
-
-    # Sockets and connection info (linux only)
-    #- socket
+    - cpu             # CPU usage
+    - filesystem      # File system usage for each mountpoint
+    - fsstat          # File system summary metrics
+    - load            # CPU load averages
+    - memory          # Memory usage
+    - network         # Network IO
+    - process         # Per process metrics
+    - process_summary # Process summary
+    #- core           # Per CPU core usage
+    #- diskio         # Disk IO
+    #- socket         # Sockets and connection info (linux only)
   enabled: true
   period: 10s
   processes: ['.*']

--- a/metricbeat/metricbeat.yml
+++ b/metricbeat/metricbeat.yml
@@ -18,11 +18,11 @@ metricbeat.modules:
     - cpu
     - load
     - memory
+    - network
+    - process
+    - process_summary
     #- core
     #- diskio
-    - network
-    - process_summary
-    - process
     #- socket
   processes: ['.*']
   process.include_top_n:

--- a/metricbeat/module/system/_meta/config.full.yml
+++ b/metricbeat/module/system/_meta/config.full.yml
@@ -1,37 +1,16 @@
 - module: system
   metricsets:
-    # CPU stats
-    - cpu
-
-    # System Load stats
-    - load
-
-    # Per CPU core stats
-    #- core
-
-    # IO stats
-    #- diskio
-
-    # Per filesystem stats
-    - filesystem
-
-    # File system summary stats
-    - fsstat
-
-    # Memory stats
-    - memory
-
-    # Network stats
-    - network
-
-    # Processes summary
-    - process_summary
-
-    # Per process stats
-    - process
-
-    # Sockets and connection info (linux only)
-    #- socket
+    - cpu             # CPU usage
+    - filesystem      # File system usage for each mountpoint
+    - fsstat          # File system summary metrics
+    - load            # CPU load averages
+    - memory          # Memory usage
+    - network         # Network IO
+    - process         # Per process metrics
+    - process_summary # Process summary
+    #- core           # Per CPU core usage
+    #- diskio         # Disk IO
+    #- socket         # Sockets and connection info (linux only)
   enabled: true
   period: 10s
   processes: ['.*']

--- a/metricbeat/module/system/_meta/config.yml
+++ b/metricbeat/module/system/_meta/config.yml
@@ -5,11 +5,11 @@
     - cpu
     - load
     - memory
+    - network
+    - process
+    - process_summary
     #- core
     #- diskio
-    - network
-    - process_summary
-    - process
     #- socket
   processes: ['.*']
   process.include_top_n:


### PR DESCRIPTION
This alphabetizes the list of system metricsets and puts the commented out ones at the end of the list. I also tightened up the spacing by placing the comments at the end of the lines.