### PR TITLE
Move processors into new pipeline

### DIFF
--- a/filebeat/harvester/forwarder.go
+++ b/filebeat/harvester/forwarder.go
@@ -70,7 +70,7 @@ func (f *Forwarder) Send(data *util.Data) error {
 		data.Event.Put("prospector.type", f.Config.Type)
 
 		// run the filters before sending to spooler
-		data.Event = f.Processors.Run(data.Event)
+		data.Event = f.Processors.RunBC(data.Event)
 	}
 
 	ok := f.Outlet.OnEventSignal(data)

--- a/filebeat/harvester/reader/json.go
+++ b/filebeat/harvester/reader/json.go
@@ -4,10 +4,12 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/jsontransform"
 	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/publisher/beat"
 )
 
 type JSON struct {
@@ -102,6 +104,24 @@ func MergeJSONFields(data common.MapStr, jsonFields common.MapStr, text *string,
 		// Delete existing json key
 		delete(data, "json")
 
-		jsontransform.WriteJSONKeys(data, jsonFields, config.OverwriteKeys)
+		var ts time.Time
+		if v, ok := data["@timestamp"]; ok {
+			switch t := v.(type) {
+			case time.Time:
+				ts = t
+			case common.Time:
+				ts = time.Time(ts)
+			}
+		}
+		event := &beat.Event{
+			Timestamp: ts,
+			Fields:    data,
+		}
+		jsontransform.WriteJSONKeys(event, jsonFields, config.OverwriteKeys)
+
+		// if timestamp has been set -> add to data
+		if !event.Timestamp.IsZero() {
+			data["@timestamp"] = common.Time(event.Timestamp)
+		}
 	}
 }

--- a/libbeat/common/jsontransform/jsonhelper.go
+++ b/libbeat/common/jsontransform/jsonhelper.go
@@ -6,48 +6,70 @@ import (
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/publisher/beat"
 )
 
 // WriteJSONKeys writes the json keys to the given event based on the overwriteKeys option
-func WriteJSONKeys(event common.MapStr, keys map[string]interface{}, overwriteKeys bool) {
-	for k, v := range keys {
-		if overwriteKeys {
-			if k == "@timestamp" {
-				vstr, ok := v.(string)
-				if !ok {
-					logp.Err("JSON: Won't overwrite @timestamp because value is not string")
-					event["error"] = createJSONError("@timestamp not overwritten (not string)")
-					continue
-				}
-
-				// @timestamp must be of format RFC3339
-				ts, err := time.Parse(time.RFC3339, vstr)
-				if err != nil {
-					logp.Err("JSON: Won't overwrite @timestamp because of parsing error: %v", err)
-					event["error"] = createJSONError(fmt.Sprintf("@timestamp not overwritten (parse error on %s)", vstr))
-					continue
-				}
-				event[k] = common.Time(ts)
-			} else if k == "type" {
-				vstr, ok := v.(string)
-				if !ok {
-					logp.Err("JSON: Won't overwrite type because value is not string")
-					event["error"] = createJSONError("type not overwritten (not string)")
-					continue
-				}
-				if len(vstr) == 0 || vstr[0] == '_' {
-					logp.Err("JSON: Won't overwrite type because value is empty or starts with an underscore")
-					event["error"] = createJSONError(fmt.Sprintf("type not overwritten (invalid value [%s])", vstr))
-					continue
-				}
-				event[k] = vstr
-			} else {
-				event[k] = v
+func WriteJSONKeys(event *beat.Event, keys map[string]interface{}, overwriteKeys bool) {
+	if !overwriteKeys {
+		for k, v := range keys {
+			if _, exists := event.Fields[k]; !exists && k != "@timestamp" && k != "@metadata" {
+				event.Fields[k] = v
 			}
-		} else if _, exists := event[k]; !exists {
-			event[k] = v
 		}
+		return
+	}
 
+	for k, v := range keys {
+		switch k {
+		case "@timestamp":
+			vstr, ok := v.(string)
+			if !ok {
+				logp.Err("JSON: Won't overwrite @timestamp because value is not string")
+				event.Fields["error"] = createJSONError("@timestamp not overwritten (not string)")
+				continue
+			}
+
+			// @timestamp must be of format RFC3339
+			ts, err := time.Parse(time.RFC3339, vstr)
+			if err != nil {
+				logp.Err("JSON: Won't overwrite @timestamp because of parsing error: %v", err)
+				event.Fields["error"] = createJSONError(fmt.Sprintf("@timestamp not overwritten (parse error on %s)", vstr))
+				continue
+			}
+			event.Timestamp = ts
+
+		case "@metadata":
+			switch m := v.(type) {
+			case map[string]string:
+				for meta, value := range m {
+					event.Meta[meta] = value
+				}
+
+			case map[string]interface{}:
+				event.Meta.Update(common.MapStr(m))
+
+			default:
+				event.Fields["error"] = createJSONError("failed to update @metadata")
+			}
+
+		case "type":
+			vstr, ok := v.(string)
+			if !ok {
+				logp.Err("JSON: Won't overwrite type because value is not string")
+				event.Fields["error"] = createJSONError("type not overwritten (not string)")
+				continue
+			}
+			if len(vstr) == 0 || vstr[0] == '_' {
+				logp.Err("JSON: Won't overwrite type because value is empty or starts with an underscore")
+				event.Fields["error"] = createJSONError(fmt.Sprintf("type not overwritten (invalid value [%s])", vstr))
+				continue
+			}
+			event.Fields[k] = vstr
+
+		default:
+			event.Fields[k] = v
+		}
 	}
 }
 

--- a/libbeat/monitoring/report/elasticsearch/elasticsearch.go
+++ b/libbeat/monitoring/report/elasticsearch/elasticsearch.go
@@ -104,8 +104,11 @@ func makeReporter(beat common.BeatInfo, cfg *common.Config) (report.Reporter, er
 	}
 
 	broker := membroker.NewBroker(20, false)
-	settings := pipeline.Settings{}
-	pipeline, err := pipeline.New(broker, nil, out, settings)
+	settings := pipeline.Settings{
+		WaitClose:     0,
+		WaitCloseMode: pipeline.NoWaitOnClose,
+	}
+	pipeline, err := pipeline.New(broker, out, settings)
 	if err != nil {
 		broker.Close()
 		return nil, err

--- a/libbeat/outputs/outil/select.go
+++ b/libbeat/outputs/outil/select.go
@@ -325,7 +325,7 @@ func (s *listSelector) sel(evt *beat.Event) (string, error) {
 }
 
 func (s *condSelector) sel(evt *beat.Event) (string, error) {
-	if !s.cond.Check(evt.Fields) {
+	if !s.cond.Check(evt) {
 		return "", nil
 	}
 	return s.s.sel(evt)

--- a/libbeat/processors/actions/checks.go
+++ b/libbeat/processors/actions/checks.go
@@ -9,21 +9,21 @@ import (
 
 func configChecked(
 	constr processors.Constructor,
-	checks ...func(common.Config) error,
+	checks ...func(*common.Config) error,
 ) processors.Constructor {
 	validator := checkAll(checks...)
-	return func(c common.Config) (processors.Processor, error) {
-		err := validator(c)
+	return func(cfg *common.Config) (processors.Processor, error) {
+		err := validator(cfg)
 		if err != nil {
-			return nil, fmt.Errorf("%v in %v", err.Error(), c.Path())
+			return nil, fmt.Errorf("%v in %v", err.Error(), cfg.Path())
 		}
 
-		return constr(c)
+		return constr(cfg)
 	}
 }
 
-func checkAll(checks ...func(common.Config) error) func(common.Config) error {
-	return func(c common.Config) error {
+func checkAll(checks ...func(*common.Config) error) func(*common.Config) error {
+	return func(c *common.Config) error {
 		for _, check := range checks {
 			if err := check(c); err != nil {
 				return err
@@ -33,10 +33,10 @@ func checkAll(checks ...func(common.Config) error) func(common.Config) error {
 	}
 }
 
-func requireFields(fields ...string) func(common.Config) error {
-	return func(c common.Config) error {
+func requireFields(fields ...string) func(*common.Config) error {
+	return func(cfg *common.Config) error {
 		for _, field := range fields {
-			if !c.HasField(field) {
+			if !cfg.HasField(field) {
 				return fmt.Errorf("missing %v option", field)
 			}
 		}
@@ -44,9 +44,9 @@ func requireFields(fields ...string) func(common.Config) error {
 	}
 }
 
-func allowedFields(fields ...string) func(common.Config) error {
-	return func(c common.Config) error {
-		for _, field := range c.GetFields() {
+func allowedFields(fields ...string) func(*common.Config) error {
+	return func(cfg *common.Config) error {
+		for _, field := range cfg.GetFields() {
 			found := false
 			for _, allowed := range fields {
 				if field == allowed {

--- a/libbeat/processors/actions/decode_json_fields.go
+++ b/libbeat/processors/actions/decode_json_fields.go
@@ -1,7 +1,6 @@
 package actions
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -10,6 +9,7 @@ import (
 	"github.com/elastic/beats/libbeat/common/jsontransform"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/processors"
+	"github.com/elastic/beats/libbeat/publisher/beat"
 	"github.com/pkg/errors"
 )
 
@@ -45,21 +45,20 @@ func init() {
 			allowedFields("fields", "max_depth", "overwrite_keys", "process_array", "target", "when")))
 }
 
-func newDecodeJSONFields(c common.Config) (processors.Processor, error) {
+func newDecodeJSONFields(c *common.Config) (processors.Processor, error) {
 	config := defaultConfig
 
 	err := c.Unpack(&config)
-
 	if err != nil {
 		logp.Warn("Error unpacking config for decode_json_fields")
 		return nil, fmt.Errorf("fail to unpack the decode_json_fields configuration: %s", err)
 	}
 
-	f := decodeJSONFields{fields: config.Fields, maxDepth: config.MaxDepth, overwriteKeys: config.OverwriteKeys, processArray: config.ProcessArray, target: config.Target}
+	f := &decodeJSONFields{fields: config.Fields, maxDepth: config.MaxDepth, overwriteKeys: config.OverwriteKeys, processArray: config.ProcessArray, target: config.Target}
 	return f, nil
 }
 
-func (f decodeJSONFields) Run(event common.MapStr) (common.MapStr, error) {
+func (f *decodeJSONFields) Run(event *beat.Event) (*beat.Event, error) {
 	var errs []string
 
 	for _, field := range f.fields {
@@ -69,36 +68,41 @@ func (f decodeJSONFields) Run(event common.MapStr) (common.MapStr, error) {
 			errs = append(errs, err.Error())
 			continue
 		}
+
 		text, ok := data.(string)
-		if ok {
-			var output interface{}
-			err := unmarshal(f.maxDepth, []byte(text), &output, f.processArray)
-			if err != nil {
-				debug("Error trying to unmarshal %s", event[field])
-				errs = append(errs, err.Error())
-				continue
-			}
+		if !ok {
+			// ignore non string fields when unmarshaling
+			continue
+		}
 
-			if f.target != nil {
-				if len(*f.target) > 0 {
-					_, err = event.Put(*f.target, output)
-				} else {
-					switch t := output.(type) {
-					default:
-						errs = append(errs, errors.New("Error trying to add target to root.").Error())
-					case map[string]interface{}:
-						jsontransform.WriteJSONKeys(event, t, f.overwriteKeys)
-					}
-				}
-			} else {
-				_, err = event.Put(field, output)
-			}
+		var output interface{}
+		err = unmarshal(f.maxDepth, text, &output, f.processArray)
+		if err != nil {
+			debug("Error trying to unmarshal %s", text)
+			errs = append(errs, err.Error())
+			continue
+		}
 
-			if err != nil {
-				debug("Error trying to Put value %v for field : %s", output, field)
-				errs = append(errs, err.Error())
-				continue
+		target := field
+		if f.target != nil {
+			target = *f.target
+		}
+
+		if target != "" {
+			_, err = event.PutValue(target, output)
+		} else {
+			switch t := output.(type) {
+			case map[string]interface{}:
+				jsontransform.WriteJSONKeys(event, t, f.overwriteKeys)
+			default:
+				errs = append(errs, "failed to add target to root")
 			}
+		}
+
+		if err != nil {
+			debug("Error trying to Put value %v for field : %s", output, field)
+			errs = append(errs, err.Error())
+			continue
 		}
 	}
 
@@ -108,8 +112,8 @@ func (f decodeJSONFields) Run(event common.MapStr) (common.MapStr, error) {
 	return event, nil
 }
 
-func unmarshal(maxDepth int, text []byte, fields *interface{}, processArray bool) error {
-	if err := DecodeJSON(text, fields); err != nil {
+func unmarshal(maxDepth int, text string, fields *interface{}, processArray bool) error {
+	if err := decodeJSON(text, fields); err != nil {
 		return err
 	}
 
@@ -125,7 +129,7 @@ func unmarshal(maxDepth int, text []byte, fields *interface{}, processArray bool
 		}
 
 		var tmp interface{}
-		err := unmarshal(maxDepth, []byte(str), &tmp, processArray)
+		err := unmarshal(maxDepth, str, &tmp, processArray)
 		if err != nil {
 			return v, false
 		}
@@ -156,8 +160,8 @@ func unmarshal(maxDepth int, text []byte, fields *interface{}, processArray bool
 	return nil
 }
 
-func DecodeJSON(text []byte, to *interface{}) error {
-	dec := json.NewDecoder(bytes.NewReader(text))
+func decodeJSON(text string, to *interface{}) error {
+	dec := json.NewDecoder(strings.NewReader(text))
 	dec.UseNumber()
 	err := dec.Decode(to)
 

--- a/libbeat/processors/actions/decode_json_fields_test.go
+++ b/libbeat/processors/actions/decode_json_fields_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/publisher/beat"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -190,13 +191,12 @@ func getActualValue(t *testing.T, config *common.Config, input common.MapStr) co
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"*"})
 	}
 
-	p, err := newDecodeJSONFields(*config)
+	p, err := newDecodeJSONFields(config)
 	if err != nil {
 		logp.Err("Error initializing decode_json_fields")
 		t.Fatal(err)
 	}
 
-	actual, err := p.Run(input)
-
-	return actual
+	actual, _ := p.Run(&beat.Event{Fields: input})
+	return actual.Fields
 }

--- a/libbeat/processors/actions/drop_event.go
+++ b/libbeat/processors/actions/drop_event.go
@@ -3,6 +3,7 @@ package actions
 import (
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/processors"
+	"github.com/elastic/beats/libbeat/publisher/beat"
 )
 
 type dropEvent struct{}
@@ -12,13 +13,15 @@ func init() {
 		configChecked(newDropEvent, allowedFields("when")))
 }
 
-func newDropEvent(c common.Config) (processors.Processor, error) {
-	return dropEvent{}, nil
+var dropEventsSingleton = (*dropEvent)(nil)
+
+func newDropEvent(c *common.Config) (processors.Processor, error) {
+	return dropEventsSingleton, nil
 }
 
-func (f dropEvent) Run(event common.MapStr) (common.MapStr, error) {
+func (*dropEvent) Run(_ *beat.Event) (*beat.Event, error) {
 	// return event=nil to delete the entire event
 	return nil, nil
 }
 
-func (f dropEvent) String() string { return "drop_event" }
+func (*dropEvent) String() string { return "drop_event" }

--- a/libbeat/processors/actions/drop_fields.go
+++ b/libbeat/processors/actions/drop_fields.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/processors"
+	"github.com/elastic/beats/libbeat/publisher/beat"
 )
 
 type dropFields struct {
@@ -19,7 +20,7 @@ func init() {
 			allowedFields("fields", "when")))
 }
 
-func newDropFields(c common.Config) (processors.Processor, error) {
+func newDropFields(c *common.Config) (processors.Processor, error) {
 	config := struct {
 		Fields []string `config:"fields"`
 	}{}
@@ -37,11 +38,11 @@ func newDropFields(c common.Config) (processors.Processor, error) {
 		}
 	}
 
-	f := dropFields{Fields: config.Fields}
+	f := &dropFields{Fields: config.Fields}
 	return f, nil
 }
 
-func (f dropFields) Run(event common.MapStr) (common.MapStr, error) {
+func (f *dropFields) Run(event *beat.Event) (*beat.Event, error) {
 	var errors []string
 
 	for _, field := range f.Fields {
@@ -58,6 +59,6 @@ func (f dropFields) Run(event common.MapStr) (common.MapStr, error) {
 	return event, nil
 }
 
-func (f dropFields) String() string {
+func (f *dropFields) String() string {
 	return "drop_fields=" + strings.Join(f.Fields, ", ")
 }

--- a/libbeat/processors/actions/extract_field.go
+++ b/libbeat/processors/actions/extract_field.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/processors"
+	"github.com/elastic/beats/libbeat/publisher/beat"
 )
 
 type extract_field struct {
@@ -26,7 +27,7 @@ func init() {
 }
 */
 
-func NewExtractField(c common.Config) (processors.Processor, error) {
+func NewExtractField(c *common.Config) (processors.Processor, error) {
 	config := struct {
 		Field     string `config:"field"`
 		Separator string `config:"separator"`
@@ -45,7 +46,7 @@ func NewExtractField(c common.Config) (processors.Processor, error) {
 		}
 	}
 
-	f := extract_field{
+	f := &extract_field{
 		Field:     config.Field,
 		Separator: config.Separator,
 		Index:     config.Index,
@@ -54,7 +55,7 @@ func NewExtractField(c common.Config) (processors.Processor, error) {
 	return f, nil
 }
 
-func (f extract_field) Run(event common.MapStr) (common.MapStr, error) {
+func (f *extract_field) Run(event *beat.Event) (*beat.Event, error) {
 	fieldValue, err := event.GetValue(f.Field)
 	if err != nil {
 		return nil, fmt.Errorf("error getting field '%s' from event", f.Field)
@@ -71,7 +72,7 @@ func (f extract_field) Run(event common.MapStr) (common.MapStr, error) {
 		return nil, fmt.Errorf("index is out of range for field '%s'", f.Field)
 	}
 
-	event.Put(f.Target, parts[f.Index])
+	event.PutValue(f.Target, parts[f.Index])
 
 	return event, nil
 }

--- a/libbeat/processors/actions/extract_field_test.go
+++ b/libbeat/processors/actions/extract_field_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/publisher/beat"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -76,15 +77,15 @@ func runExtractField(t *testing.T, config *common.Config, input common.MapStr) c
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"*"})
 	}
 
-	p, err := NewExtractField(*config)
+	p, err := NewExtractField(config)
 	if err != nil {
 		t.Fatalf("error initializing extract_field: %s", err)
 	}
 
-	actual, err := p.Run(input)
+	actual, err := p.Run(&beat.Event{Fields: input})
 	if err != nil {
 		t.Fatalf("error running extract_field: %s", err)
 	}
 
-	return actual
+	return actual.Fields
 }

--- a/libbeat/processors/actions/include_fields.go
+++ b/libbeat/processors/actions/include_fields.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/processors"
+	"github.com/elastic/beats/libbeat/publisher/beat"
 	"github.com/pkg/errors"
 )
 
@@ -20,7 +21,7 @@ func init() {
 			allowedFields("fields", "when")))
 }
 
-func newIncludeFields(c common.Config) (processors.Processor, error) {
+func newIncludeFields(c *common.Config) (processors.Processor, error) {
 	config := struct {
 		Fields []string `config:"fields"`
 	}{}
@@ -42,28 +43,33 @@ func newIncludeFields(c common.Config) (processors.Processor, error) {
 		}
 	}
 
-	f := includeFields{Fields: config.Fields}
-	return &f, nil
+	f := &includeFields{Fields: config.Fields}
+	return f, nil
 }
 
-func (f includeFields) Run(event common.MapStr) (common.MapStr, error) {
+func (f *includeFields) Run(event *beat.Event) (*beat.Event, error) {
 	filtered := common.MapStr{}
 	var errs []string
 
 	for _, field := range f.Fields {
-		err := event.CopyFieldsTo(filtered, field)
-		// Ignore errors caused by a field not existing in the event.
+		v, err := event.GetValue(field)
+		if err == nil {
+			_, err = filtered.Put(field, v)
+		}
+
+		// Ignore ErrKeyNotFound errors
 		if err != nil && errors.Cause(err) != common.ErrKeyNotFound {
 			errs = append(errs, err.Error())
 		}
 	}
 
+	event.Fields = filtered
 	if len(errs) > 0 {
-		return filtered, fmt.Errorf(strings.Join(errs, ", "))
+		return event, fmt.Errorf(strings.Join(errs, ", "))
 	}
-	return filtered, nil
+	return event, nil
 }
 
-func (f includeFields) String() string {
+func (f *includeFields) String() string {
 	return "include_fields=" + strings.Join(f.Fields, ", ")
 }

--- a/libbeat/processors/add_cloud_metadata/add_cloud_metadata.go
+++ b/libbeat/processors/add_cloud_metadata/add_cloud_metadata.go
@@ -13,6 +13,7 @@ import (
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/processors"
+	"github.com/elastic/beats/libbeat/publisher/beat"
 	"github.com/pkg/errors"
 )
 
@@ -186,7 +187,7 @@ func fetchMetadata(metadataFetchers []*metadataFetcher, timeout time.Duration) *
 }
 
 // getMetadataURLs loads config and generates the metadata URLs.
-func getMetadataURLs(c common.Config, defaultHost string, metadataURIs []string) ([]string, error) {
+func getMetadataURLs(c *common.Config, defaultHost string, metadataURIs []string) ([]string, error) {
 	var urls []string
 	config := struct {
 		MetadataHostAndPort string `config:"host"` // Specifies the host and port of the metadata service (for testing purposes only).
@@ -220,7 +221,7 @@ func makeJSONPicker(provider string) responseHandler {
 
 // newMetadataFetcher return metadataFetcher with one pass JSON responseHandler.
 func newMetadataFetcher(
-	c common.Config,
+	c *common.Config,
 	provider string,
 	headers map[string]string,
 	host string,
@@ -236,7 +237,7 @@ func newMetadataFetcher(
 	return fetcher, nil
 }
 
-func setupFetchers(c common.Config) ([]*metadataFetcher, error) {
+func setupFetchers(c *common.Config) ([]*metadataFetcher, error) {
 	var fetchers []*metadataFetcher
 	doFetcher, err := newDoMetadataFetcher(c)
 	if err != nil {
@@ -269,7 +270,7 @@ func setupFetchers(c common.Config) ([]*metadataFetcher, error) {
 	return fetchers, nil
 }
 
-func newCloudMetadata(c common.Config) (processors.Processor, error) {
+func newCloudMetadata(c *common.Config) (processors.Processor, error) {
 	config := struct {
 		Timeout time.Duration `config:"timeout"` // Amount of time to wait for responses from the metadata services.
 	}{
@@ -288,27 +289,27 @@ func newCloudMetadata(c common.Config) (processors.Processor, error) {
 	result := fetchMetadata(fetchers, config.Timeout)
 	if result == nil {
 		logp.Info("add_cloud_metadata: hosting provider type not detected.")
-		return addCloudMetadata{}, nil
+		return &addCloudMetadata{}, nil
 	}
 
 	logp.Info("add_cloud_metadata: hosting provider type detected as %v, metadata=%v",
 		result.provider, result.metadata.String())
 
-	return addCloudMetadata{metadata: result.metadata}, nil
+	return &addCloudMetadata{metadata: result.metadata}, nil
 }
 
 type addCloudMetadata struct {
 	metadata common.MapStr
 }
 
-func (p addCloudMetadata) Run(event common.MapStr) (common.MapStr, error) {
+func (p addCloudMetadata) Run(event *beat.Event) (*beat.Event, error) {
 	if len(p.metadata) == 0 {
 		return event, nil
 	}
 
 	// This overwrites the meta.cloud if it exists. But the cloud key should be
 	// reserved for this processor so this should happen.
-	_, err := event.Put("meta.cloud", p.metadata)
+	_, err := event.PutValue("meta.cloud", p.metadata)
 
 	return event, err
 }

--- a/libbeat/processors/add_cloud_metadata/provider_alibaba_cloud.go
+++ b/libbeat/processors/add_cloud_metadata/provider_alibaba_cloud.go
@@ -4,7 +4,7 @@ import "github.com/elastic/beats/libbeat/common"
 
 // Alibaba Cloud Metadata Service
 // Document https://help.aliyun.com/knowledge_detail/49122.html
-func newAlibabaCloudMetadataFetcher(c common.Config) (*metadataFetcher, error) {
+func newAlibabaCloudMetadataFetcher(c *common.Config) (*metadataFetcher, error) {
 	ecsMetadataHost := "100.100.100.200"
 	ecsMetadataInstanceIDURI := "/latest/meta-data/instance-id"
 	ecsMetadataRegionURI := "/latest/meta-data/region-id"

--- a/libbeat/processors/add_cloud_metadata/provider_alibaba_cloud_test.go
+++ b/libbeat/processors/add_cloud_metadata/provider_alibaba_cloud_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/publisher/beat"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -45,12 +46,12 @@ func TestRetrieveAlibabaCloudMetadata(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	p, err := newCloudMetadata(*config)
+	p, err := newCloudMetadata(config)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	actual, err := p.Run(common.MapStr{})
+	actual, err := p.Run(&beat.Event{Fields: common.MapStr{}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -65,5 +66,5 @@ func TestRetrieveAlibabaCloudMetadata(t *testing.T) {
 			},
 		},
 	}
-	assert.Equal(t, expected, actual)
+	assert.Equal(t, expected, actual.Fields)
 }

--- a/libbeat/processors/add_cloud_metadata/provider_aws_ec2.go
+++ b/libbeat/processors/add_cloud_metadata/provider_aws_ec2.go
@@ -7,7 +7,7 @@ import (
 )
 
 // AWS EC2 Metadata Service
-func newEc2MetadataFetcher(config common.Config) (*metadataFetcher, error) {
+func newEc2MetadataFetcher(config *common.Config) (*metadataFetcher, error) {
 	ec2InstanceIdentityURI := "/2014-02-25/dynamic/instance-identity/document"
 	ec2Schema := func(m map[string]interface{}) common.MapStr {
 		out, _ := s.Schema{

--- a/libbeat/processors/add_cloud_metadata/provider_aws_ec2_test.go
+++ b/libbeat/processors/add_cloud_metadata/provider_aws_ec2_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/publisher/beat"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -53,12 +54,12 @@ func TestRetrieveAWSMetadata(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	p, err := newCloudMetadata(*config)
+	p, err := newCloudMetadata(config)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	actual, err := p.Run(common.MapStr{})
+	actual, err := p.Run(&beat.Event{Fields: common.MapStr{}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -74,5 +75,5 @@ func TestRetrieveAWSMetadata(t *testing.T) {
 			},
 		},
 	}
-	assert.Equal(t, expected, actual)
+	assert.Equal(t, expected, actual.Fields)
 }

--- a/libbeat/processors/add_cloud_metadata/provider_digital_ocean.go
+++ b/libbeat/processors/add_cloud_metadata/provider_digital_ocean.go
@@ -7,7 +7,7 @@ import (
 )
 
 // DigitalOcean Metadata Service
-func newDoMetadataFetcher(config common.Config) (*metadataFetcher, error) {
+func newDoMetadataFetcher(config *common.Config) (*metadataFetcher, error) {
 	doSchema := func(m map[string]interface{}) common.MapStr {
 		out, _ := s.Schema{
 			"instance_id": c.StrFromNum("droplet_id"),

--- a/libbeat/processors/add_cloud_metadata/provider_digital_ocean_test.go
+++ b/libbeat/processors/add_cloud_metadata/provider_digital_ocean_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/publisher/beat"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -84,12 +85,12 @@ func TestRetrieveDigitalOceanMetadata(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	p, err := newCloudMetadata(*config)
+	p, err := newCloudMetadata(config)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	actual, err := p.Run(common.MapStr{})
+	actual, err := p.Run(&beat.Event{Fields: common.MapStr{}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -103,5 +104,5 @@ func TestRetrieveDigitalOceanMetadata(t *testing.T) {
 			},
 		},
 	}
-	assert.Equal(t, expected, actual)
+	assert.Equal(t, expected, actual.Fields)
 }

--- a/libbeat/processors/add_cloud_metadata/provider_google_gce.go
+++ b/libbeat/processors/add_cloud_metadata/provider_google_gce.go
@@ -7,7 +7,7 @@ import (
 )
 
 // Google GCE Metadata Service
-func newGceMetadataFetcher(config common.Config) (*metadataFetcher, error) {
+func newGceMetadataFetcher(config *common.Config) (*metadataFetcher, error) {
 	gceMetadataURI := "/computeMetadata/v1/?recursive=true&alt=json"
 	gceHeaders := map[string]string{"Metadata-Flavor": "Google"}
 	gceSchema := func(m map[string]interface{}) common.MapStr {

--- a/libbeat/processors/add_cloud_metadata/provider_google_gce_test.go
+++ b/libbeat/processors/add_cloud_metadata/provider_google_gce_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/publisher/beat"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -123,12 +124,12 @@ func TestRetrieveGCEMetadata(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	p, err := newCloudMetadata(*config)
+	p, err := newCloudMetadata(config)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	actual, err := p.Run(common.MapStr{})
+	actual, err := p.Run(&beat.Event{Fields: common.MapStr{}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -145,5 +146,5 @@ func TestRetrieveGCEMetadata(t *testing.T) {
 			},
 		},
 	}
-	assert.Equal(t, expected, actual)
+	assert.Equal(t, expected, actual.Fields)
 }

--- a/libbeat/processors/add_cloud_metadata/provider_tencent_cloud.go
+++ b/libbeat/processors/add_cloud_metadata/provider_tencent_cloud.go
@@ -4,7 +4,7 @@ import "github.com/elastic/beats/libbeat/common"
 
 // Tencent Cloud Metadata Service
 // Document https://www.qcloud.com/document/product/213/4934
-func newQcloudMetadataFetcher(c common.Config) (*metadataFetcher, error) {
+func newQcloudMetadataFetcher(c *common.Config) (*metadataFetcher, error) {
 	qcloudMetadataHost := "metadata.tencentyun.com"
 	qcloudMetadataInstanceIDURI := "/meta-data/instance-id"
 	qcloudMetadataRegionURI := "/meta-data/placement/region"

--- a/libbeat/processors/add_cloud_metadata/provider_tencent_cloud_test.go
+++ b/libbeat/processors/add_cloud_metadata/provider_tencent_cloud_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/publisher/beat"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -45,12 +46,12 @@ func TestRetrieveQCloudMetadata(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	p, err := newCloudMetadata(*config)
+	p, err := newCloudMetadata(config)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	actual, err := p.Run(common.MapStr{})
+	actual, err := p.Run(&beat.Event{Fields: common.MapStr{}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -65,5 +66,5 @@ func TestRetrieveQCloudMetadata(t *testing.T) {
 			},
 		},
 	}
-	assert.Equal(t, expected, actual)
+	assert.Equal(t, expected, actual.Fields)
 }

--- a/libbeat/processors/add_docker_metadata/add_docker_metadata_test.go
+++ b/libbeat/processors/add_docker_metadata/add_docker_metadata_test.go
@@ -4,20 +4,21 @@ import (
 	"testing"
 
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/publisher/beat"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestInitialization(t *testing.T) {
 	var testConfig = common.NewConfig()
 
-	p, err := buildDockerMetadataProcessor(*testConfig, MockWatcherFactory(nil))
+	p, err := buildDockerMetadataProcessor(testConfig, MockWatcherFactory(nil))
 	assert.NoError(t, err, "initializing add_docker_metadata processor")
 
 	input := common.MapStr{}
-	result, err := p.Run(input)
+	result, err := p.Run(&beat.Event{Fields: input})
 	assert.NoError(t, err, "processing an event")
 
-	assert.Equal(t, common.MapStr{}, result)
+	assert.Equal(t, common.MapStr{}, result.Fields)
 }
 
 func TestNoMatch(t *testing.T) {
@@ -26,16 +27,16 @@ func TestNoMatch(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	p, err := buildDockerMetadataProcessor(*testConfig, MockWatcherFactory(nil))
+	p, err := buildDockerMetadataProcessor(testConfig, MockWatcherFactory(nil))
 	assert.NoError(t, err, "initializing add_docker_metadata processor")
 
 	input := common.MapStr{
 		"field": "value",
 	}
-	result, err := p.Run(input)
+	result, err := p.Run(&beat.Event{Fields: input})
 	assert.NoError(t, err, "processing an event")
 
-	assert.Equal(t, common.MapStr{"field": "value"}, result)
+	assert.Equal(t, common.MapStr{"field": "value"}, result.Fields)
 }
 
 func TestMatchNoContainer(t *testing.T) {
@@ -44,16 +45,16 @@ func TestMatchNoContainer(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	p, err := buildDockerMetadataProcessor(*testConfig, MockWatcherFactory(nil))
+	p, err := buildDockerMetadataProcessor(testConfig, MockWatcherFactory(nil))
 	assert.NoError(t, err, "initializing add_docker_metadata processor")
 
 	input := common.MapStr{
 		"foo": "garbage",
 	}
-	result, err := p.Run(input)
+	result, err := p.Run(&beat.Event{Fields: input})
 	assert.NoError(t, err, "processing an event")
 
-	assert.Equal(t, common.MapStr{"foo": "garbage"}, result)
+	assert.Equal(t, common.MapStr{"foo": "garbage"}, result.Fields)
 }
 
 func TestMatchContainer(t *testing.T) {
@@ -62,7 +63,7 @@ func TestMatchContainer(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	p, err := buildDockerMetadataProcessor(*testConfig, MockWatcherFactory(
+	p, err := buildDockerMetadataProcessor(testConfig, MockWatcherFactory(
 		map[string]*Container{
 			"container_id": &Container{
 				ID:    "container_id",
@@ -79,7 +80,7 @@ func TestMatchContainer(t *testing.T) {
 	input := common.MapStr{
 		"foo": "container_id",
 	}
-	result, err := p.Run(input)
+	result, err := p.Run(&beat.Event{Fields: input})
 	assert.NoError(t, err, "processing an event")
 
 	assert.EqualValues(t, common.MapStr{
@@ -95,7 +96,7 @@ func TestMatchContainer(t *testing.T) {
 			},
 		},
 		"foo": "container_id",
-	}, result)
+	}, result.Fields)
 }
 
 func TestMatchSource(t *testing.T) {
@@ -103,7 +104,7 @@ func TestMatchSource(t *testing.T) {
 	testConfig, err := common.NewConfigFrom(map[string]interface{}{})
 	assert.NoError(t, err)
 
-	p, err := buildDockerMetadataProcessor(*testConfig, MockWatcherFactory(
+	p, err := buildDockerMetadataProcessor(testConfig, MockWatcherFactory(
 		map[string]*Container{
 			"FABADA": &Container{
 				ID:    "FABADA",
@@ -120,7 +121,7 @@ func TestMatchSource(t *testing.T) {
 	input := common.MapStr{
 		"source": "/var/lib/docker/containers/FABADA/foo.log",
 	}
-	result, err := p.Run(input)
+	result, err := p.Run(&beat.Event{Fields: input})
 	assert.NoError(t, err, "processing an event")
 
 	assert.EqualValues(t, common.MapStr{
@@ -136,7 +137,7 @@ func TestMatchSource(t *testing.T) {
 			},
 		},
 		"source": "/var/lib/docker/containers/FABADA/foo.log",
-	}, result)
+	}, result.Fields)
 }
 
 func TestDisableSource(t *testing.T) {
@@ -146,7 +147,7 @@ func TestDisableSource(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	p, err := buildDockerMetadataProcessor(*testConfig, MockWatcherFactory(
+	p, err := buildDockerMetadataProcessor(testConfig, MockWatcherFactory(
 		map[string]*Container{
 			"FABADA": &Container{
 				ID:    "FABADA",
@@ -163,11 +164,11 @@ func TestDisableSource(t *testing.T) {
 	input := common.MapStr{
 		"source": "/var/lib/docker/containers/FABADA/foo.log",
 	}
-	result, err := p.Run(input)
+	result, err := p.Run(&beat.Event{Fields: input})
 	assert.NoError(t, err, "processing an event")
 
 	// remains unchanged
-	assert.EqualValues(t, input, result)
+	assert.EqualValues(t, input, result.Fields)
 }
 
 // Mock container watcher

--- a/libbeat/processors/add_locale/add_locale.go
+++ b/libbeat/processors/add_locale/add_locale.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/processors"
+	"github.com/elastic/beats/libbeat/publisher/beat"
 )
 
 type addLocale struct {
@@ -37,7 +38,7 @@ func init() {
 	processors.RegisterPlugin("add_locale", newAddLocale)
 }
 
-func newAddLocale(c common.Config) (processors.Processor, error) {
+func newAddLocale(c *common.Config) (processors.Processor, error) {
 	config := struct {
 		Format string `config:"format"`
 	}{
@@ -65,11 +66,10 @@ func newAddLocale(c common.Config) (processors.Processor, error) {
 	return loc, nil
 }
 
-func (l addLocale) Run(event common.MapStr) (common.MapStr, error) {
+func (l addLocale) Run(event *beat.Event) (*beat.Event, error) {
 	zone, offset := time.Now().Zone()
 	format := l.Format(zone, offset)
-	event.Put("beat.timezone", format)
-
+	event.PutValue("beat.timezone", format)
 	return event, nil
 }
 

--- a/libbeat/processors/add_locale/add_locale_test.go
+++ b/libbeat/processors/add_locale/add_locale_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/publisher/beat"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -70,15 +71,14 @@ func getActualValue(t *testing.T, config *common.Config, input common.MapStr) co
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"*"})
 	}
 
-	p, err := newAddLocale(*config)
+	p, err := newAddLocale(config)
 	if err != nil {
 		logp.Err("Error initializing add_locale")
 		t.Fatal(err)
 	}
 
-	actual, err := p.Run(input)
-
-	return actual
+	actual, err := p.Run(&beat.Event{Fields: input})
+	return actual.Fields
 }
 
 func BenchmarkConstruct(b *testing.B) {
@@ -86,12 +86,12 @@ func BenchmarkConstruct(b *testing.B) {
 
 	input := common.MapStr{}
 
-	p, err := newAddLocale(*testConfig)
+	p, err := newAddLocale(testConfig)
 	if err != nil {
 		b.Fatal(err)
 	}
 
 	for i := 0; i < b.N; i++ {
-		_, err = p.Run(input)
+		_, err = p.Run(&beat.Event{Fields: input})
 	}
 }

--- a/libbeat/processors/config.go
+++ b/libbeat/processors/config.go
@@ -22,10 +22,10 @@ type ConditionFields struct {
 	fields map[string]interface{}
 }
 
-type PluginConfig []map[string]common.Config
+type PluginConfig []map[string]*common.Config
 
 // fields that should be always exported
-var MandatoryExportedFields = []string{"@timestamp", "type"}
+var MandatoryExportedFields = []string{"type"}
 
 func (f *ConditionFields) Unpack(to interface{}) error {
 	m, ok := to.(map[string]interface{})

--- a/libbeat/processors/namespace.go
+++ b/libbeat/processors/namespace.go
@@ -69,7 +69,7 @@ func (ns *Namespace) add(names []string, p pluginer) error {
 }
 
 func (ns *Namespace) Plugin() Constructor {
-	return NewConditional(func(cfg common.Config) (Processor, error) {
+	return NewConditional(func(cfg *common.Config) (Processor, error) {
 		var section string
 		for _, name := range cfg.GetFields() {
 			if name == "when" { // TODO: remove check for "when" once fields are filtered
@@ -99,7 +99,7 @@ func (ns *Namespace) Plugin() Constructor {
 		}
 
 		constructor := backend.Plugin()
-		return constructor(*config)
+		return constructor(config)
 	})
 }
 

--- a/libbeat/processors/processor.go
+++ b/libbeat/processors/processor.go
@@ -6,19 +6,19 @@ import (
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/publisher/beat"
 )
 
 type Processors struct {
-	list []Processor
+	List []Processor
 }
 
 type Processor interface {
-	Run(event common.MapStr) (common.MapStr, error)
+	Run(event *beat.Event) (*beat.Event, error)
 	String() string
 }
 
 func New(config PluginConfig) (*Processors, error) {
-
 	procs := Processors{}
 
 	for _, processor := range config {
@@ -51,38 +51,66 @@ func New(config PluginConfig) (*Processors, error) {
 }
 
 func (procs *Processors) add(p Processor) {
-	procs.list = append(procs.list, p)
+	procs.List = append(procs.List, p)
+}
+
+// RunBC (run backwards-compatible) applies the processors, by providing the
+// old interface based on common.MapStr.
+// The event us temporarily converted to beat.Event. By this 'conversion' the
+// '@timestamp' field can not be accessed by processors.
+// Note: this method will be removed, when the publisher pipeline BC-API is to
+//       be removed.
+func (procs *Processors) RunBC(event common.MapStr) common.MapStr {
+	ret := procs.Run(&beat.Event{Fields: event})
+	if ret == nil {
+		return nil
+	}
+	return ret.Fields
+}
+
+func (procs *Processors) All() []beat.Processor {
+	if procs == nil || len(procs.List) == 0 {
+		return nil
+	}
+
+	ret := make([]beat.Processor, len(procs.List))
+	for i, p := range procs.List {
+		ret[i] = p
+	}
+	return ret
 }
 
 // Applies a sequence of processing rules and returns the filtered event
-func (procs *Processors) Run(event common.MapStr) common.MapStr {
-
+func (procs *Processors) Run(event *beat.Event) *beat.Event {
 	// Check if processors are set, just return event if not
-	if len(procs.list) == 0 {
+	if len(procs.List) == 0 {
 		return event
 	}
 
-	// clone the event at first, before starting filtering
-	filtered := event.Clone()
-	var err error
-
-	for _, p := range procs.list {
-		filtered, err = p.Run(filtered)
+	for _, p := range procs.List {
+		var err error
+		event, err = p.Run(event)
 		if err != nil {
+			// XXX: We don't drop the event, but continue filtering here iff the most
+			//      recent processor did return an event.
+			//      We want processors having this kind of implicit behavior
+			//      on errors?
+
 			logp.Debug("filter", "fail to apply processor %s: %s", p, err)
 		}
-		if filtered == nil {
+
+		if event == nil {
 			// drop event
 			return nil
 		}
 	}
 
-	return filtered
+	return event
 }
 
 func (procs Processors) String() string {
 	var s []string
-	for _, p := range procs.list {
+	for _, p := range procs.List {
 		s = append(s, p.String())
 	}
 	return strings.Join(s, ", ")

--- a/libbeat/processors/registry.go
+++ b/libbeat/processors/registry.go
@@ -30,7 +30,7 @@ func init() {
 	})
 }
 
-type Constructor func(config common.Config) (Processor, error)
+type Constructor func(config *common.Config) (Processor, error)
 
 var registry = NewNamespace()
 

--- a/libbeat/publisher/TODO.txt
+++ b/libbeat/publisher/TODO.txt
@@ -3,14 +3,7 @@ followup:
 - make broker configurable
 - elasticsearch output update:
   - replace json reader with go-structform on struct
-- update processors to operate on beat.Event
 - move package pipeline go files to libbeat/publisher if possible
 - '@metadata' accessor from withing fmtstr
 - remove publisher/bc package
-
-PR notes:
----------
-- add note on elasitcsearch output:
-  remove output_test.go, as with new reduced interfaces tests will give us redundant tests in client_integration_test 
-- describe logstash json encoding
-- PR restricts output configuration to exactly one output
+- register some pipeline metrics for consumption

--- a/libbeat/publisher/bc/publisher/publish.go
+++ b/libbeat/publisher/bc/publisher/publish.go
@@ -32,18 +32,13 @@ type TransactionalEventPublisher interface {
 
 type Publisher interface {
 	Connect() Client
+
+	ConnectX(beat.ClientConfig) (beat.Client, error)
 }
 
 type BeatPublisher struct {
-	shipperName string // Shipper name as set in the configuration file
-	hostname    string // Host name as returned by the operation system
-	name        string // The shipperName if configured, the hostname otherwise
-	version     string
-
-	disabled   bool
-	processors *processors.Processors
-
-	globalEventMetadata common.EventMetadata // Fields and tags to add to each event.
+	disabled bool
+	name     string
 
 	// keep count of clients connected to publisher. A publisher is allowed to
 	// Stop only if all clients have been disconnected
@@ -93,31 +88,24 @@ func (publisher *BeatPublisher) init(
 	processors *processors.Processors,
 ) error {
 	var err error
-	publisher.processors = processors
-
 	publisher.disabled = *publishDisabled
 	if publisher.disabled {
 		logp.Info("Dry run mode. All output types except the file based one are disabled.")
 	}
 
 	shipper.InitShipperConfig()
-	publisher.shipperName = shipper.Name
-	publisher.hostname = beat.Hostname
-	publisher.version = beat.Version
-	if len(publisher.shipperName) > 0 {
-		publisher.name = publisher.shipperName
-	} else {
-		publisher.name = publisher.hostname
+
+	publisher.name = shipper.Name
+	if publisher.name == "" {
+		publisher.name = beat.Hostname
 	}
 
-	publisher.pipeline, err = createPipeline(beat, shipper, outConfig)
+	publisher.pipeline, err = createPipeline(beat, shipper, processors, outConfig)
 	if err != nil {
 		return err
 	}
 
 	logp.Info("Publisher name: %s", publisher.name)
-
-	publisher.globalEventMetadata = shipper.EventMetadata
 	return nil
 }
 
@@ -132,6 +120,10 @@ func (publisher *BeatPublisher) Stop() {
 func (publisher *BeatPublisher) Connect() Client {
 	publisher.numClients.Inc()
 	return newClient(publisher)
+}
+
+func (publisher *BeatPublisher) ConnectX(config beat.ClientConfig) (beat.Client, error) {
+	return publisher.pipeline.ConnectWith(config)
 }
 
 func (publisher *BeatPublisher) GetName() string {

--- a/libbeat/publisher/bc/publisher/sync.go
+++ b/libbeat/publisher/bc/publisher/sync.go
@@ -51,6 +51,10 @@ func newSyncClient(pub *BeatPublisher, done <-chan struct{}) (*syncClient, error
 
 func (c *syncClient) onACK(count int) {
 	c.active.count -= count
+	if c.active.count < 0 {
+		panic("negative event count")
+	}
+
 	if c.active.count == 0 {
 		c.active.sig <- struct{}{}
 	}

--- a/libbeat/publisher/beat/pipeline.go
+++ b/libbeat/publisher/beat/pipeline.go
@@ -2,6 +2,8 @@ package beat
 
 import (
 	"time"
+
+	"github.com/elastic/beats/libbeat/common"
 )
 
 type Pipeline interface {
@@ -22,9 +24,12 @@ type Client interface {
 type ClientConfig struct {
 	PublishMode PublishMode
 
+	// EventMetadata configures additional fields/tags to be added to published events.
+	EventMetadata common.EventMetadata
+
 	// Processors passes additional processor to the client, to be executed before
 	// the pipeline processors.
-	Processor Processor
+	Processor ProcessorList
 
 	// WaitClose sets the maximum duration to wait on ACK, if client still has events
 	// active non-acknowledged events in the publisher pipeline.
@@ -52,11 +57,15 @@ type ClientConfig struct {
 	ACKLastEvent func(Event)
 }
 
+type ProcessorList interface {
+	All() []Processor
+}
+
 // Processor defines the minimal required interface for processor, that can be
 // registered with the publisher pipeline.
 type Processor interface {
 	String() string // print full processor description
-	Run(in Event) (event Event, publish bool, err error)
+	Run(in *Event) (event *Event, err error)
 }
 
 // PublishMode enum sets some requirements on the client connection to the beats

--- a/libbeat/publisher/pipeline/client_ack.go
+++ b/libbeat/publisher/pipeline/client_ack.go
@@ -181,22 +181,25 @@ func (a *gapCountACK) ackLoop() {
 
 func (a *gapCountACK) handleACK(n int) {
 	// collect items and compute total count from gapList
-	total := n
+
+	total := 0
 	for n > 0 {
 		a.lst.Lock()
 		current := a.lst.head
+
+		current.Lock()
 		if n >= current.send {
-			if current.next != nil {
+			if nxt := current.next; nxt != nil {
 				// advance list all event in current entry have been send and list as
 				// more then 1 gapInfo entry. If only 1 entry is present, list item will be
 				// reset and reused
-				a.lst.head = current.next
+
+				a.lst.head = nxt
 			}
 		}
 
 		// hand over lock list-entry, so ACK handler and producer can operate
 		// on potentially different list ends
-		current.Lock()
 		a.lst.Unlock()
 
 		if n < current.send {

--- a/libbeat/publisher/pipeline/processor.go
+++ b/libbeat/publisher/pipeline/processor.go
@@ -1,0 +1,250 @@
+package pipeline
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/outputs/codec/json"
+	"github.com/elastic/beats/libbeat/processors"
+	"github.com/elastic/beats/libbeat/publisher/beat"
+)
+
+type program struct {
+	title string
+	list  []beat.Processor
+}
+
+type processorFn struct {
+	name string
+	fn   func(event *beat.Event) (*beat.Event, error)
+}
+
+// newProcessorPipeline prepares the processor pipeline, merging
+// post processing, event annotations and actual configured processors.
+// The pipeline generated ensure the client and pipeline processors
+// will see the complete events with all meta data applied.
+//
+// Pipeline (C=client, P=pipeline)
+//
+// 1. (P) extract EventMetadataKey fields + tags (to be removed in favor of 4)
+// 2. (P) generalize/normalize event
+// 3. (P) add beats metadata (name, hostname, version)
+// 4. (P) add pipeline fields + tags
+// 5. (C) add client fields + tags
+// 6. (P/C) apply EventMetadataKey fields + tags (to be removed in favor of 4)
+// 7. (C) client processors list
+// 8. (P) pipeline processors list
+// 9. (P) (if publish/debug enabled) log event
+// 10. (P) (if output disabled) dropEvent
+func (p *Pipeline) newProcessorPipeline(
+	config beat.ClientConfig,
+) beat.Processor {
+	processors := &program{title: "processPipeline"}
+
+	// setup 1: extract EventMetadataKey fields + tags
+	processors.add(preEventUserAnnotateProcessor)
+
+	// setup 2 and 3: generalize/normalize output (P)
+	processors.add(generalizeProcessor)
+	processors.add(p.beatMetaProcessor)
+
+	// setup 4: add event fields + tags (P)
+	processors.add(p.eventMetaProcessor)
+
+	// setup 5: add fields + tags (C)
+	if em := config.EventMetadata; len(em.Fields) > 0 || len(em.Tags) > 0 {
+		processors.add(eventAnnotateProcessor(em))
+	}
+
+	// setup 6: apply EventMetadata fields + tags
+	processors.add(eventUserAnnotateProcessor)
+
+	// setup 7: client processors (C)
+	if procs := config.Processor; procs != nil {
+		if lst := procs.All(); len(lst) > 0 {
+
+			processors.add(&program{
+				title: "client",
+				list:  lst,
+			})
+		}
+	}
+
+	// setup 8: pipeline processors (P)
+	processors.add(p.processors)
+
+	// setup 9: debug print final event (P)
+	if logp.IsDebug("publish") {
+		processors.add(debugPrintProcessor())
+	}
+
+	if p.disabled {
+		processors.add(dropDisabledProcessor)
+	}
+
+	return processors
+}
+
+func (p *program) add(processor processors.Processor) {
+	if processor != nil {
+		p.list = append(p.list, processor)
+	}
+}
+
+func (p *program) String() string {
+	var s []string
+	for _, p := range p.list {
+		s = append(s, p.String())
+	}
+
+	str := strings.Join(s, ", ")
+	if p.title == "" {
+		return str
+	}
+	return fmt.Sprintf("%v{%v}", p.title, str)
+}
+
+func (p *program) Run(event *beat.Event) (*beat.Event, error) {
+	if p == nil || len(p.list) == 0 {
+		return event, nil
+	}
+
+	for _, sub := range p.list {
+		var err error
+
+		event, err = sub.Run(event)
+		if err != nil {
+			// XXX: We don't drop the event, but continue filtering here iff the most
+			//      recent processor did return an event.
+			//      We want processors having this kind of implicit behavior
+			//      on errors?
+
+			logp.Debug("filter", "fail to apply processor %s: %s", p, err)
+		}
+
+		if event == nil {
+			return nil, err
+		}
+	}
+
+	return event, nil
+}
+
+func newProcessor(name string, fn func(*beat.Event) (*beat.Event, error)) *processorFn {
+	return &processorFn{name: name, fn: fn}
+}
+
+func newAnnotateProcessor(name string, fn func(*beat.Event)) *processorFn {
+	return newProcessor(name, func(event *beat.Event) (*beat.Event, error) {
+		fn(event)
+		return event, nil
+	})
+}
+
+func (p *processorFn) String() string                         { return p.name }
+func (p *processorFn) Run(e *beat.Event) (*beat.Event, error) { return p.fn(e) }
+
+var generalizeProcessor = newProcessor("generalizeEvent", func(event *beat.Event) (*beat.Event, error) {
+	fields := common.ConvertToGenericEvent(event.Fields)
+	if fields == nil {
+		logp.Err("fail to convert to generic event")
+		return nil, nil
+	}
+
+	event.Fields = fields
+	return event, nil
+})
+
+var dropDisabledProcessor = newProcessor("dropDisabled", func(event *beat.Event) (*beat.Event, error) {
+	return nil, nil
+})
+
+func beatAnnotateProcessor(beatMeta common.MapStr) *processorFn {
+	const key = "beat"
+	return newAnnotateProcessor("annotateBeat", func(event *beat.Event) {
+		if orig, exists := event.Fields["beat"]; !exists {
+			event.Fields[key] = beatMeta.Clone()
+		} else if M, ok := orig.(common.MapStr); !ok {
+			event.Fields[key] = beatMeta.Clone()
+		} else {
+			event.Fields[key] = common.MapStrUnion(beatMeta, M)
+		}
+	})
+}
+
+func eventAnnotateProcessor(eventMeta common.EventMetadata) *processorFn {
+	return newAnnotateProcessor("annotateEvent", func(event *beat.Event) {
+		common.AddTags(event.Fields, eventMeta.Tags)
+		if fields := eventMeta.Fields; len(fields) > 0 {
+			common.MergeFields(event.Fields, fields.Clone(), eventMeta.FieldsUnderRoot)
+		}
+	})
+}
+
+// TODO: remove var-section. Keep for backwards compatibility with old publisher API.
+//       Remove after updating all beats to new publisher API.
+// Note: this functionality is used by filebeat/winlogbeat, so prospector/harvesters
+//       can apply fields to events after generating the event type.
+//       This functionality will be removed, in favor of harvesters publishing
+//       event to a beat.Client with properly setup processor
+var (
+	preEventUserAnnotateProcessor = newAnnotateProcessor("annotateEventUserPre", func(event *beat.Event) {
+		const key = common.EventMetadataKey
+		val, exists := event.Fields[key]
+		if !exists {
+			return
+		}
+
+		delete(event.Fields, key)
+
+		if _, ok := val.(common.EventMetadata); ok {
+			if event.Meta == nil {
+				event.Meta = common.MapStr{}
+			}
+			event.Meta[key] = val
+		}
+	})
+
+	eventUserAnnotateProcessor = newAnnotateProcessor("annotateEventUser", func(event *beat.Event) {
+		const key = common.EventMetadataKey
+
+		tmp, ok := event.Meta[key]
+		if !ok {
+			return
+		}
+
+		delete(event.Meta, key)
+		if len(event.Meta) == 0 {
+			event.Meta = nil
+		}
+
+		eventMeta := tmp.(common.EventMetadata)
+		common.AddTags(event.Fields, eventMeta.Tags)
+		if fields := eventMeta.Fields; len(fields) > 0 {
+			common.MergeFields(event.Fields, fields.Clone(), eventMeta.FieldsUnderRoot)
+		}
+	})
+)
+
+func debugPrintProcessor() *processorFn {
+	// ensure only one go-routine is using the encoder (in case
+	// beat.Client is shared between multiple go-routines by accident)
+	var mux sync.Mutex
+
+	encoder := json.New(true)
+	return newProcessor("debugPrint", func(event *beat.Event) (*beat.Event, error) {
+		mux.Lock()
+		defer mux.Unlock()
+
+		b, err := encoder.Encode("<not set>", event)
+		if err != nil {
+			return event, nil
+		}
+
+		logp.Debug("publish", "Publish event: %s", b)
+		return event, nil
+	})
+}

--- a/libbeat/publisher/testing/testing.go
+++ b/libbeat/publisher/testing/testing.go
@@ -4,6 +4,7 @@ package testing
 import (
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/publisher/bc/publisher"
+	"github.com/elastic/beats/libbeat/publisher/beat"
 )
 
 type TestPublisher struct {
@@ -29,6 +30,10 @@ func PublisherWithClient(client publisher.Client) publisher.Publisher {
 
 func (pub *TestPublisher) Connect() publisher.Client {
 	return pub.client
+}
+
+func (pub *TestPublisher) ConnectX(_ beat.ClientConfig) (beat.Client, error) {
+	panic("Not supported")
 }
 
 func NewChanClient(bufSize int) *ChanClient {

--- a/metricbeat/mb/module/event.go
+++ b/metricbeat/mb/module/event.go
@@ -38,7 +38,7 @@ func (b EventBuilder) Build() (common.MapStr, error) {
 
 	// Apply filters.
 	if b.filters != nil {
-		if event = b.filters.Run(event); event == nil {
+		if event = b.filters.RunBC(event); event == nil {
 			return nil, nil
 		}
 	}


### PR DESCRIPTION
- Update all processors to operate in *beat.Event
- Update processors factory to use `*common.Config`, not `common.Config`. `common.Config` works, but go-ucfg interfaces/API assume to operate on pointers (passing by value might break functionality in future?)
- Update most processors interface to pass the processors type/context by pointer instead of by value (due to use of interfaces, the processors have been allocated on heap anyways).
- Install list of processors in new publisher pipeline. This allows publisher pipeline to account for events being dropped by filters, when reporting ACKs. From beats point of view, there should be no difference between dropped events (by filters) and ACKed events (by outputs). Interface mandates all events being properly ACKed by the publisher pipeline.
- Tags, Fields and beat meta data settings are now implicitely converted to Processors as well
- -> change ensures, all metadata (local and global) being applied before the
actual processors (installed with the pipeline) are executed. Ensures all
processors will see the very same events.
- introduce `(*processors.Processors).RunBC(common.MapStr) common.MapStr`. Will be removed, once the beats themselves configure publisher pipeline to run processors (filebeat/metricbeat are executing processors on their own).
- add `Private` field to `beat.Event` for event-based ACK callbacks. Use `Private` field to store additional event-metadata required for post-processing in the ACK callback (as processor pipeline can change event at will)
- Prepare moving beats to new pipeline, but introducing `ConnectX` to BC API, for beats to connect to shared global pipeline (Note: will be removed when BC layer is removed).
- Processors are still executed by the go-routine calling `(beat.Client).Publish`.
- New Processor Execution Order (C=client based processor, P=pipeline based processor)
  1. (P) extract EventMetadataKey fields + tags (to be removed in favor of 4)
  2. (P) generalize/normalize event
  3. (P) add beats metadata (name, hostname, version)
  4. (P) add pipeline fields + tags
  5. (C) add client fields + tags
  6. (P/C) apply EventMetadataKey fields + tags (to be removed in favor of 4)
  7. (C) client processors list
  8. (P) pipeline processors list
  9. (P) (if publish/debug enabled) log event
  10. (P) (if output disabled) dropEvent

For docs: event processing execution order would be nice to have.