### PR TITLE
Added stub docs for Auditbeat

### DIFF
--- a/auditbeat/docs/index.asciidoc
+++ b/auditbeat/docs/index.asciidoc
@@ -1,5 +1,22 @@
-= Auditbeat Docs
+= Auditbeat Reference
 
-Welcome to the Auditbeat documentation.
+include::../../libbeat/docs/version.asciidoc[]
 
+:libbeat: http://www.elastic.co/guide/en/beats/libbeat/{doc-branch}
+:version: {stack-version}
+:beatname_lc: auditbeat
+:beatname_uc: Auditbeat
+:security: X-Pack Security
+:dockerimage: docker.elastic.co/beats/{beatname_lc}:{version}
 
+include::../../libbeat/docs/contributing-to-beats.asciidoc[]
+
+include::../../libbeat/docs/repositories.asciidoc[]
+
+:standalone:
+include::../../libbeat/docs/shared-env-vars.asciidoc[]
+:standalone:
+:allplatforms:
+include::../../libbeat/docs/yaml.asciidoc[]
+
+include::./fields.asciidoc[]


### PR DESCRIPTION
The jenkins docs build was failing on the Auditbeat docs because the
`index.asciidoc` file was invalid. This adds a bit of the shared content,
just to fix the build.