### PR TITLE
Add missing arg to logp.Warn

### DIFF
--- a/auditbeat/module/audit/kernel/audit_linux.go
+++ b/auditbeat/module/audit/kernel/audit_linux.go
@@ -131,7 +131,7 @@ func (ms *MetricSet) addRules(reporter mb.PushReporter) error {
 			// Treat rule add errors as warnings and continue.
 			err = errors.Wrapf(err, "failed to add kernel rule '%v'", rule.flags)
 			reporter.Error(err)
-			logp.Warn("%v %v", err)
+			logp.Warn("%v %v", logPrefix, err)
 		}
 	}
 	logp.Info("%v Successfully added %d kernel audit rules.", logPrefix, len(rules))


### PR DESCRIPTION
An argument was missing for the format string.