### PR TITLE
Add support for analyzers and multifields

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -58,7 +58,8 @@ https://github.com/elastic/beats/compare/v6.0.0-alpha2...master[Check the HEAD d
 *Affecting all Beats*
 
 - New cli subcommands interface. {pull}4420[4420]
-- Allow source path matching in `add_docker_metadata` processor {pull}4495[4495]
+- Allow source path matching in `add_docker_metadata` processor. {pull}4495[4495]
+- Add support for analyzers and multifields in fields.yml. {pull}4574[4574]
 
 *Filebeat*
 

--- a/libbeat/template/field_test.go
+++ b/libbeat/template/field_test.go
@@ -65,6 +65,73 @@ func TestField(t *testing.T) {
 				"enabled": false,
 			},
 		},
+		{
+			field:  Field{Type: "text", Analyzer: "autocomplete"},
+			method: func(f Field) common.MapStr { return f.text() },
+			output: common.MapStr{
+				"type":     "text",
+				"analyzer": "autocomplete",
+				"norms":    false,
+			},
+		},
+		{
+			field:  Field{Type: "text", Analyzer: "autocomplete", Norms: true},
+			method: func(f Field) common.MapStr { return f.text() },
+			output: common.MapStr{
+				"type":     "text",
+				"analyzer": "autocomplete",
+			},
+		},
+		{
+			field:  Field{Type: "text", SearchAnalyzer: "standard", Norms: true},
+			method: func(f Field) common.MapStr { return f.text() },
+			output: common.MapStr{
+				"type":            "text",
+				"search_analyzer": "standard",
+			},
+		},
+		{
+			field:  Field{Type: "text", Analyzer: "autocomplete", SearchAnalyzer: "standard", Norms: true},
+			method: func(f Field) common.MapStr { return f.text() },
+			output: common.MapStr{
+				"type":            "text",
+				"analyzer":        "autocomplete",
+				"search_analyzer": "standard",
+			},
+		},
+		{
+			field:  Field{Type: "text", MultiFields: Fields{Field{Name: "raw", Type: "keyword"}}, Norms: true},
+			method: func(f Field) common.MapStr { return f.text() },
+			output: common.MapStr{
+				"type": "text",
+				"fields": common.MapStr{
+					"raw": common.MapStr{
+						"type":         "keyword",
+						"ignore_above": 1024,
+					},
+				},
+			},
+		},
+		{
+			field: Field{Type: "text", MultiFields: Fields{
+				Field{Name: "raw", Type: "keyword"},
+				Field{Name: "indexed", Type: "text"},
+			}, Norms: true},
+			method: func(f Field) common.MapStr { return f.text() },
+			output: common.MapStr{
+				"type": "text",
+				"fields": common.MapStr{
+					"raw": common.MapStr{
+						"type":         "keyword",
+						"ignore_above": 1024,
+					},
+					"indexed": common.MapStr{
+						"type":  "text",
+						"norms": false,
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
This PR enhances fields.yml to support `analyzer`, `search_analyzer`, `norms` and `multi_fields`. Currently `multi_fields` are only supported for `text` fields. Norms is still disabled by default but can now be overwritten. Below is an example on the usage:

```
fields:
  - name: phrase
    type: text
    multi_fields:
      - name: raw
        type: keyword
      - name: english
        type: text
        analyzer: english
        search_analyzer: englishenhanced
        norms: true
```