### PR TITLE
Remove import_dashboards from packaging

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -15,7 +15,8 @@ https://github.com/elastic/beats/compare/v6.0.0-alpha2...master[Check the HEAD d
 *Affecting all Beats*
 
 - Rename `kubernetes` processor to `add_kubernetes_metadata`. {pull}4473[4473]
-- Rename `*.full.yml` config files to `*.reference.yml`. {pull}
+- Rename `*.full.yml` config files to `*.reference.yml`. {pull}4563[4563]
+- The `scripts/import_dashboards` is removed from packages. Use the `setup` command instead. {pull}4586[4586]
 
 *Filebeat*
 

--- a/dev-tools/packer/platforms/binary/run.sh.j2
+++ b/dev-tools/packer/platforms/binary/run.sh.j2
@@ -12,7 +12,6 @@ fi
 
 mkdir /{{.beat_name}}-${VERSION}-linux-{{.bin_arch}}
 cp -a homedir/. /{{.beat_name}}-${VERSION}-linux-{{.bin_arch}}/
-install -D -m 755 import_dashboards-linux-{{.arch}} /{{.beat_name}}-${VERSION}-linux-{{.bin_arch}}/scripts/import_dashboards
 cp {{.beat_name}}-linux-{{.arch}} /{{.beat_name}}-${VERSION}-linux-{{.bin_arch}}/{{.beat_name}}
 cp {{.beat_name}}-linux.yml /{{.beat_name}}-${VERSION}-linux-{{.bin_arch}}/{{.beat_name}}.yml
 cp {{.beat_name}}-linux.reference.yml /{{.beat_name}}-${VERSION}-linux-{{.bin_arch}}/{{.beat_name}}.reference.yml

--- a/dev-tools/packer/platforms/centos/run.sh.j2
+++ b/dev-tools/packer/platforms/centos/run.sh.j2
@@ -38,8 +38,7 @@ fpm --force -s dir -t rpm \
         {{.beat_name}}-linux.reference.yml=/etc/{{.beat_name}}/{{.beat_name}}.reference.yml \
         fields.yml=/etc/{{.beat_name}}/fields.yml \
         ${RUNID}.service=/lib/systemd/system/{{.beat_name}}.service \
-        god-linux-{{.arch}}=/usr/share/{{.beat_name}}/bin/{{.beat_name}}-god \
-        import_dashboards-linux-{{.arch}}=/usr/share/{{.beat_name}}/scripts/import_dashboards
+        god-linux-{{.arch}}=/usr/share/{{.beat_name}}/bin/{{.beat_name}}-god
 
 
 

--- a/dev-tools/packer/platforms/darwin/run.sh.j2
+++ b/dev-tools/packer/platforms/darwin/run.sh.j2
@@ -12,7 +12,6 @@ fi
 
 mkdir /{{.beat_name}}-${VERSION}-darwin-x86_64
 cp -a homedir/. /{{.beat_name}}-${VERSION}-darwin-x86_64/
-install -D -m 755 import_dashboards-darwin-{{.arch}} /{{.beat_name}}-${VERSION}-darwin-x86_64/scripts/import_dashboards
 cp {{.beat_name}}-darwin-amd64 /{{.beat_name}}-${VERSION}-darwin-x86_64/{{.beat_name}}
 cp {{.beat_name}}-darwin.yml /{{.beat_name}}-${VERSION}-darwin-x86_64/{{.beat_name}}.yml
 cp {{.beat_name}}-darwin.reference.yml /{{.beat_name}}-${VERSION}-darwin-x86_64/{{.beat_name}}.reference.yml

--- a/dev-tools/packer/platforms/debian/run.sh.j2
+++ b/dev-tools/packer/platforms/debian/run.sh.j2
@@ -35,8 +35,7 @@ fpm --force -s dir -t deb \
         {{.beat_name}}-linux.reference.yml=/etc/{{.beat_name}}/{{.beat_name}}.reference.yml \
         fields.yml=/etc/{{.beat_name}}/fields.yml \
         ${RUNID}.service=/lib/systemd/system/{{.beat_name}}.service \
-        god-linux-{{.arch}}=/usr/share/{{.beat_name}}/bin/{{.beat_name}}-god \
-        import_dashboards-linux-{{.arch}}=/usr/share/{{.beat_name}}/scripts/import_dashboards
+        god-linux-{{.arch}}=/usr/share/{{.beat_name}}/bin/{{.beat_name}}-god
 
 # move and rename to use the elastic conventions
 mkdir -p upload

--- a/dev-tools/packer/platforms/windows/run.sh.j2
+++ b/dev-tools/packer/platforms/windows/run.sh.j2
@@ -12,7 +12,6 @@ fi
 
 mkdir /{{.beat_name}}-${VERSION}-windows-{{.win_arch}}
 cp -a homedir/. /{{.beat_name}}-${VERSION}-windows-{{.win_arch}}/
-install -D -m 755 import_dashboards-windows-{{.arch}} /{{.beat_name}}-${VERSION}-windows-{{.win_arch}}/scripts/import_dashboards.exe
 cp {{.beat_name}}-windows-{{.arch}}.exe /{{.beat_name}}-${VERSION}-windows-{{.win_arch}}/{{.beat_name}}.exe
 unix2dos {{.beat_name}}-win.yml
 cp {{.beat_name}}-win.yml /{{.beat_name}}-${VERSION}-windows-{{.win_arch}}/{{.beat_name}}.yml

--- a/dev-tools/packer/readme.md.j2
+++ b/dev-tools/packer/readme.md.j2
@@ -6,11 +6,11 @@
 
 To get started with {{.beat_name}}, you need to set up Elasticsearch on your localhost first. After that, start {{.beat_name}} with:
 
-     ./{{.beat_name}}  -c {{.beat_name}}.yml -e
+     ./{{.beat_name}} -c {{.beat_name}}.yml -e
 
 This will start the beat and send the data to your Elasticsearch instance. To load the dashboards for {{.beat_name}} into Kibana, run:
 
-    ./scripts/import_dashboards
+    ./{{.beat_name}} setup -e
 
 For further steps visit the [Getting started](https://www.elastic.co/guide/en/beats/{{.beat_name}}/{{.doc_branch}}/{{.beat_name}}-getting-started.html) guide.
 

--- a/dev-tools/packer/xgo-scripts/before_build.sh
+++ b/dev-tools/packer/xgo-scripts/before_build.sh
@@ -37,15 +37,6 @@ PREFIX=$PREFIX make before-build
 mkdir -p $PREFIX/homedir
 make install-home HOME_PREFIX=$PREFIX/homedir
 
-# Build dashboards
-for TARGET in $TARGETS; do
-	echo "Compiling import_dashboards for $TARGET"
-	XGOOS=`echo $TARGET | cut -d '/' -f 1`
-	XGOARCH=`echo $TARGET | cut -d '/' -f 2`
-
-	GOOS=$XGOOS GOARCH=$XGOARCH go build -ldflags "-X main.beat=${BEAT_NAME}" -o $PREFIX/import_dashboards-$XGOOS-$XGOARCH ${ES_BEATS}/dev-tools/cmd/import_dashboards/import_dashboards.go
-done
-
 if [ -n "BUILDID" ]; then
     echo "$BUILDID" > $PREFIX/homedir/.build_hash.txt
 fi


### PR DESCRIPTION
The `import_dashboards` program is no longer needed as we introduced the `setup` command. It's also being removed from code in #4413, so I'm removing it form packaging.

Related to #4409. 