### PR TITLE
Cherry-pick #4506 to 5.x: Filebeat modules: Machine learning jobs

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -70,6 +70,8 @@ https://github.com/elastic/beats/compare/v5.4.1...master[Check the HEAD diff]
 
 *Filebeat*
 
+- Add support for loading Xpack Machine Learning configurations from the modules, and added sample configurations for the Nginx module. {pull}4506[4506]
+
 *Heartbeat*
 
 *Metricbeat*

--- a/filebeat/fileset/modules.go
+++ b/filebeat/fileset/modules.go
@@ -2,15 +2,17 @@ package fileset
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/pkg/errors"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
+	mlimporter "github.com/elastic/beats/libbeat/ml-importer"
 	"github.com/elastic/beats/libbeat/paths"
 )
 
@@ -416,6 +418,31 @@ func interpretError(initialErr error, body []byte) error {
 	}
 
 	return fmt.Errorf("couldn't load pipeline: %v. Response body: %s", initialErr, body)
+}
+
+// LoadML loads the machine-learning configurations into Elasticsearch, if Xpack is avaiable
+func (reg *ModuleRegistry) LoadML(esClient PipelineLoader) error {
+	haveXpack, err := mlimporter.HaveXpackML(esClient)
+	if err != nil {
+		return errors.Errorf("Error checking if xpack is available: %v", err)
+	}
+	if !haveXpack {
+		logp.Warn("Xpack Machine Learning is not enabled")
+		return nil
+	}
+
+	for module, filesets := range reg.registry {
+		for name, fileset := range filesets {
+			for _, mlConfig := range fileset.GetMLConfigs() {
+				err = mlimporter.ImportMachineLearningJob(esClient, &mlConfig)
+				if err != nil {
+					return errors.Errorf("Error loading ML config from %s/%s: %v", module, name, err)
+				}
+			}
+		}
+	}
+
+	return nil
 }
 
 func (reg *ModuleRegistry) Empty() bool {

--- a/filebeat/module/nginx/access/machine_learning/datafeed_response_code.json
+++ b/filebeat/module/nginx/access/machine_learning/datafeed_response_code.json
@@ -1,0 +1,44 @@
+{
+    "job_id": "JOB_ID",
+    "query_delay": "60s",
+    "frequency": "60s",
+    "indexes": [
+      "filebeat-*"
+    ],
+    "types": [
+      "_default_",
+      "log"
+    ],
+    "query": {
+      "match_all": {
+        "boost": 1
+      }
+    },
+    "aggregations": {
+      "buckets": {
+        "date_histogram": {
+          "field": "@timestamp",
+          "interval": 3600000,
+          "offset": 0,
+          "order": {
+            "_key": "asc"
+          },
+          "keyed": false,
+          "min_doc_count": 0
+        },
+        "aggregations": {
+          "@timestamp": {
+            "max": {
+              "field": "@timestamp"
+            }
+          },
+          "nginx.access.response_code": {
+              "terms": {
+                "field": "nginx.access.response_code",
+                "size": 10000
+              }
+          }
+        }
+      }
+    }
+}

--- a/filebeat/module/nginx/access/machine_learning/response_code.json
+++ b/filebeat/module/nginx/access/machine_learning/response_code.json
@@ -1,0 +1,23 @@
+{
+  "description" : "Anomaly detector for changes in event rates of nginx.access.response_code responses",
+  "analysis_config" : {
+    "bucket_span": "1h",
+    "summary_count_field_name": "doc_count",
+    "detectors": [
+      {
+        "detector_description": "Event rate for nginx.access.response_code",
+        "function": "count",
+        "detector_rules": [],
+        "partition_field_name": "nginx.access.response_code"
+      }
+    ],
+    "influencers": ["nginx.access.response_code"]
+  },
+  "data_description": {
+    "time_field": "@timestamp",
+    "time_format": "epoch_ms"
+  },
+  "model_plot_config": {
+    "enabled": true
+  }
+}

--- a/filebeat/module/nginx/access/manifest.yml
+++ b/filebeat/module/nginx/access/manifest.yml
@@ -12,6 +12,11 @@ var:
 ingest_pipeline: ingest/default.json
 prospector: config/nginx-access.yml
 
+machine_learning:
+- name: response_code
+  job: machine_learning/response_code.json
+  datafeed: machine_learning/datafeed_response_code.json
+
 requires.processors:
 - name: user_agent
   plugin: ingest-user-agent

--- a/filebeat/tests/files/logs/nginx.log
+++ b/filebeat/tests/files/logs/nginx.log
@@ -1,0 +1,1 @@
+127.0.0.1 - - [07/Mar/2017:11:23:14 -0800] "GET / HTTP/1.1" 304 0 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36"

--- a/filebeat/tests/system/test_modules.py
+++ b/filebeat/tests/system/test_modules.py
@@ -183,3 +183,39 @@ class Test(BaseTest):
         assert len(objects) == 1
         o = objects[0]
         assert o["x-pipeline"] == "test-pipeline"
+
+    @unittest.skipIf(not INTEGRATION_TESTS or
+                     os.getenv("TESTING_ENVIRONMENT") == "2x",
+                     "integration test not available on 2.x")
+    def test_setup_machine_learning_nginx(self):
+        """
+        Tests that setup works and loads nginx dashboards.
+        """
+        self.init()
+        # generate a minimal configuration
+        cfgfile = os.path.join(self.working_dir, "filebeat.yml")
+        self.render_config_template(
+            template_name="filebeat_modules",
+            output=cfgfile,
+            index_name=self.index_name,
+            elasticsearch_url=self.elasticsearch_url)
+
+        cmd = [
+            self.filebeat, "-systemTest",
+            "-e", "-d", "*",
+            "-c", cfgfile,
+            "setup", "--modules=nginx", "--machine-learning"]
+
+        output = open(os.path.join(self.working_dir, "output.log"), "ab")
+        output.write(" ".join(cmd) + "\n")
+        subprocess.Popen(cmd,
+                         stdin=None,
+                         stdout=output,
+                         stderr=subprocess.STDOUT,
+                         bufsize=0).wait()
+
+        jobs = self.es.transport.perform_request("GET", "/_xpack/ml/anomaly_detectors/")
+        assert "filebeat-nginx-access-response_code" in (job["job_id"] for job in jobs["jobs"])
+
+        datafeeds = self.es.transport.perform_request("GET", "/_xpack/ml/datafeeds/")
+        assert "filebeat-nginx-access-response_code" in (df["job_id"] for df in datafeeds["datafeeds"])

--- a/filebeat/tests/system/test_prospector.py
+++ b/filebeat/tests/system/test_prospector.py
@@ -276,14 +276,8 @@ class Test(BaseTest):
 
         filebeat = self.start_beat()
 
-        # wait for first  "Start next scan" log message
         self.wait_until(
-            lambda: self.log_contains(
-                "No prospectors defined"),
-            max_timeout=10)
-
-        self.wait_until(
-            lambda: self.log_contains("No prospectors defined"),
+            lambda: self.log_contains("No modules or prospectors enabled"),
             max_timeout=10)
 
         filebeat.check_wait(exit_code=1)

--- a/libbeat/ml-importer/importer.go
+++ b/libbeat/ml-importer/importer.go
@@ -1,0 +1,104 @@
+// Package mlimporter contains code for loading Elastic X-Pack Machine Learning job configurations.
+package mlimporter
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/logp"
+	"github.com/pkg/errors"
+)
+
+// MLConfig contains the required configuration for loading one job and the associated
+// datafeed.
+type MLConfig struct {
+	ID           string `config:"id"`
+	JobPath      string `config:"job"`
+	DatafeedPath string `config:"datafeed"`
+}
+
+// MLLoader is a subset of the Elasticsearch client API capable of
+// loading the ML configs.
+type MLLoader interface {
+	Request(method, path string, pipeline string, params map[string]string, body interface{}) (int, []byte, error)
+	LoadJSON(path string, json map[string]interface{}) ([]byte, error)
+}
+
+func readJSONFile(path string) (common.MapStr, error) {
+	file, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var result common.MapStr
+	err = json.Unmarshal(file, &result)
+	return result, err
+}
+
+// ImportMachineLearningJob uploads the job and datafeed configuration to ES/xpack.
+func ImportMachineLearningJob(esClient MLLoader, cfg *MLConfig) error {
+	jobURL := fmt.Sprintf("/_xpack/ml/anomaly_detectors/%s", cfg.ID)
+	datafeedURL := fmt.Sprintf("/_xpack/ml/datafeeds/datafeed-%s", cfg.ID)
+
+	// We always overwrite ML job configs, so delete them before loading
+	status, response, err := esClient.Request("GET", jobURL, "", nil, nil)
+	if status == 200 {
+		logp.Debug("machine-learning", "Job %s already exists", cfg.ID)
+		return nil
+	}
+	if status != 404 && err != nil {
+		return errors.Errorf("Error checking that job exists: %v. Response %s", err, response)
+	}
+
+	job, err := readJSONFile(cfg.JobPath)
+	if err != nil {
+		return errors.Errorf("Error reading job file %s: %v", cfg.JobPath, err)
+	}
+
+	body, err := esClient.LoadJSON(jobURL, job)
+	if err != nil {
+		return errors.Wrapf(err, "load job under %s. Response body: %s", jobURL, body)
+	}
+
+	datafeed, err := readJSONFile(cfg.DatafeedPath)
+	if err != nil {
+		return errors.Errorf("Error reading datafeed path %s: %v", cfg.DatafeedPath, err)
+	}
+	// set the job ID
+	datafeed.Put("job_id", cfg.ID)
+
+	body, err = esClient.LoadJSON(datafeedURL, datafeed)
+	if err != nil {
+		return errors.Wrapf(err, "load datafeed under %s. Response body: %s", datafeedURL, body)
+	}
+
+	return nil
+}
+
+// HaveXpackML checks whether X-pack is installed and has Machine Learning enabled.
+func HaveXpackML(esClient MLLoader) (bool, error) {
+
+	status, response, err := esClient.Request("GET", "/_xpack", "", nil, nil)
+	if status == 404 {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+
+	type xpackResponse struct {
+		Features struct {
+			ML struct {
+				Available bool `json:"available"`
+				Enabled   bool `json:"enabled"`
+			} `json:"ml"`
+		} `json:"features"`
+	}
+	var xpack xpackResponse
+	err = json.Unmarshal(response, &xpack)
+	if err != nil {
+		return false, errors.Wrap(err, "unmarshal")
+	}
+	return xpack.Features.ML.Available && xpack.Features.ML.Enabled, nil
+}

--- a/libbeat/ml-importer/importer.go
+++ b/libbeat/ml-importer/importer.go
@@ -80,11 +80,11 @@ func ImportMachineLearningJob(esClient MLLoader, cfg *MLConfig) error {
 func HaveXpackML(esClient MLLoader) (bool, error) {
 
 	status, response, err := esClient.Request("GET", "/_xpack", "", nil, nil)
-	if status == 404 {
+	if status == 404 || status == 400 {
 		return false, nil
 	}
 	if err != nil {
-		return false, err
+		return false, errors.Wrapf(err, "Response: %s", response)
 	}
 
 	type xpackResponse struct {

--- a/libbeat/ml-importer/importer_integration_test.go
+++ b/libbeat/ml-importer/importer_integration_test.go
@@ -1,0 +1,177 @@
+// +build integration
+
+package mlimporter
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/outputs/elasticsearch"
+	"github.com/stretchr/testify/assert"
+)
+
+const sampleJob = `
+{
+  "description" : "Anomaly detector for changes in event rates of nginx.access.response_code responses",
+  "analysis_config" : {
+    "bucket_span": "1h",
+    "summary_count_field_name": "doc_count",
+    "detectors": [
+      {
+        "detector_description": "Event rate for nginx.access.response_code",
+        "function": "count",
+        "detector_rules": [],
+        "partition_field_name": "nginx.access.response_code"
+      }
+    ],
+    "influencers": ["nginx.access.response_code"]
+  },
+  "data_description": {
+    "time_field": "@timestamp",
+    "time_format": "epoch_ms"
+  },
+  "model_plot_config": {
+    "enabled": true
+  }
+}
+`
+
+const sampleDatafeed = `
+{
+    "job_id": "PLACEHOLDER",
+    "query_delay": "60s",
+    "frequency": "60s",
+    "indexes": [
+      "filebeat-*"
+    ],
+    "types": [
+      "_default_",
+      "log"
+    ],
+    "query": {
+      "match_all": {
+        "boost": 1
+      }
+    },
+    "aggregations": {
+      "buckets": {
+        "date_histogram": {
+          "field": "@timestamp",
+          "interval": 3600000,
+          "offset": 0,
+          "order": {
+            "_key": "asc"
+          },
+          "keyed": false,
+          "min_doc_count": 0
+        },
+        "aggregations": {
+          "@timestamp": {
+            "max": {
+              "field": "@timestamp"
+            }
+          },
+          "nginx.access.response_code": {
+              "terms": {
+                "field": "nginx.access.response_code",
+                "size": 10000
+              }
+          }
+        }
+      }
+    }
+}
+`
+
+func TestImportJobs(t *testing.T) {
+	client := elasticsearch.GetTestingElasticsearch(t)
+
+	if testing.Verbose() {
+		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"*"})
+	}
+
+	haveXpack, err := HaveXpackML(client)
+	assert.NoError(t, err)
+	if !haveXpack {
+		t.Skip("Skip ML tests because xpack/ML is not available in Elasticsearch")
+	}
+
+	workingDir, err := ioutil.TempDir("", "machine-learning")
+	assert.NoError(t, err)
+	defer os.RemoveAll(workingDir)
+
+	assert.NoError(t, ioutil.WriteFile(workingDir+"/job.json", []byte(sampleJob), 0644))
+	assert.NoError(t, ioutil.WriteFile(workingDir+"/datafeed.json", []byte(sampleDatafeed), 0644))
+
+	mlconfig := MLConfig{
+		ID:           "test-ml-config",
+		JobPath:      workingDir + "/job.json",
+		DatafeedPath: workingDir + "/datafeed.json",
+	}
+
+	err = ImportMachineLearningJob(client, &mlconfig)
+	assert.NoError(t, err)
+
+	// check by GETing back
+
+	status, response, err := client.Request("GET", "/_xpack/ml/anomaly_detectors", "", nil, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, status)
+
+	logp.Debug("mltest", "Response: %s", response)
+
+	type jobRes struct {
+		Count int `json:"count"`
+		Jobs  []struct {
+			JobId   string `json:"job_id"`
+			JobType string `json:"job_type"`
+		}
+	}
+	var res jobRes
+
+	err = json.Unmarshal(response, &res)
+	assert.NoError(t, err)
+	assert.True(t, res.Count >= 1)
+	found := false
+	for _, job := range res.Jobs {
+		if job.JobId == "test-ml-config" {
+			found = true
+			assert.Equal(t, job.JobType, "anomaly_detector")
+		}
+	}
+	assert.True(t, found)
+
+	status, response, err = client.Request("GET", "/_xpack/ml/datafeeds", "", nil, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, status)
+
+	logp.Debug("mltest", "Response: %s", response)
+	type datafeedRes struct {
+		Count     int `json:"count"`
+		Datafeeds []struct {
+			DatafeedId string `json:"datafeed_id"`
+			JobId      string `json:"job_id"`
+			QueryDelay string `json:"query_delay"`
+		}
+	}
+	var df datafeedRes
+	err = json.Unmarshal(response, &df)
+	assert.NoError(t, err)
+	assert.True(t, df.Count >= 1)
+	found = false
+	for _, datafeed := range df.Datafeeds {
+		if datafeed.DatafeedId == "datafeed-test-ml-config" {
+			found = true
+			assert.Equal(t, datafeed.JobId, "test-ml-config")
+			assert.Equal(t, datafeed.QueryDelay, "60s")
+		}
+	}
+	assert.True(t, found)
+
+	// importing again should not error out
+	err = ImportMachineLearningJob(client, &mlconfig)
+	assert.NoError(t, err)
+}

--- a/libbeat/ml-importer/importer_integration_test.go
+++ b/libbeat/ml-importer/importer_integration_test.go
@@ -87,7 +87,7 @@ const sampleDatafeed = `
 `
 
 func TestImportJobs(t *testing.T) {
-	client := elasticsearch.GetTestingElasticsearch(t)
+	client := elasticsearch.GetTestingElasticsearch()
 
 	if testing.Verbose() {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"*"})

--- a/testing/environments/args.yml
+++ b/testing/environments/args.yml
@@ -6,4 +6,4 @@ services:
     build:
       args:
         DOWNLOAD_URL: https://snapshots.elastic.co/downloads
-        ELASTIC_VERSION: 5.6.0-SNAPSHOT
+        ELASTIC_VERSION: 5.5.0-SNAPSHOT

--- a/testing/environments/args.yml
+++ b/testing/environments/args.yml
@@ -6,4 +6,4 @@ services:
     build:
       args:
         DOWNLOAD_URL: https://snapshots.elastic.co/downloads
-        ELASTIC_VERSION: 5.5.0-SNAPSHOT
+        ELASTIC_VERSION: 5.6.0-SNAPSHOT

--- a/testing/environments/docker/elasticsearch/Dockerfile-snapshot
+++ b/testing/environments/docker/elasticsearch/Dockerfile-snapshot
@@ -1,13 +1,19 @@
 # Copy of https://github.com/elastic/elasticsearch-docker/blob/master/build/elasticsearch/Dockerfile
-FROM docker.elastic.co/elasticsearch/elasticsearch-alpine-base:latest
+#FROM docker.elastic.co/elasticsearch/elasticsearch-alpine-base:latest
+FROM centos:7
 MAINTAINER Elastic Docker Team <docker@elastic.co>
 
 ARG ELASTIC_VERSION
 ARG DOWNLOAD_URL
 ARG ES_JAVA_OPTS
 
+ENV ELASTIC_CONTAINER true
 ENV PATH /usr/share/elasticsearch/bin:$PATH
 ENV JAVA_HOME /usr/lib/jvm/java-1.8-openjdk
+
+RUN yum update -y && yum install -y java-1.8.0-openjdk-headless wget which && yum clean all
+
+RUN groupadd -g 1000 elasticsearch && adduser -u 1000 -g 1000 -d /usr/share/elasticsearch elasticsearch
 
 WORKDIR /usr/share/elasticsearch
 
@@ -29,8 +35,7 @@ RUN set -ex && for esdirs in config data logs; do \
 USER elasticsearch
 
 # Install xpack
-#RUN eval ${ES_JAVA_OPTS:-} elasticsearch-plugin install --batch ${DOWNLOAD_URL}/packs/x-pack/x-pack-${ELASTIC_VERSION}.zip
-
+RUN elasticsearch-plugin install --batch ${DOWNLOAD_URL}/packs/x-pack/x-pack-${ELASTIC_VERSION}.zip
 RUN elasticsearch-plugin install --batch ${DOWNLOAD_URL}/elasticsearch-plugins/ingest-user-agent/ingest-user-agent-${ELASTIC_VERSION}.zip
 RUN elasticsearch-plugin install --batch ${DOWNLOAD_URL}/elasticsearch-plugins/ingest-geoip/ingest-geoip-${ELASTIC_VERSION}.zip
 

--- a/testing/environments/docker/kibana/Dockerfile-snapshot
+++ b/testing/environments/docker/kibana/Dockerfile-snapshot
@@ -9,7 +9,7 @@ EXPOSE 5601
 
 WORKDIR /usr/share/kibana
 RUN curl -Ls ${DOWNLOAD_URL}/kibana/kibana-${ELASTIC_VERSION}-linux-x86_64.tar.gz | tar --strip-components=1 -zxf - && \
-    #bin/kibana-plugin install ${DOWNLOAD_URL}/kibana-plugins/x-pack/x-pack-${ELASTIC_VERSION}.zip} && \
+    bin/kibana-plugin install ${DOWNLOAD_URL}/kibana-plugins/x-pack/x-pack-${ELASTIC_VERSION}.zip && \
     ln -s /usr/share/kibana /opt/kibana
 
 # Set some Kibana configuration defaults.

--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -16,6 +16,7 @@ services:
       - "network.host="
       - "transport.host=127.0.0.1"
       - "http.host=0.0.0.0"
+      - "xpack.security.enabled=false"
 
   logstash:
     extends:


### PR DESCRIPTION
Cherry-pick of PR #4506 to 5.x branch. Original message: 

This adds support for loading ML configurations (job + datafeed) from the filebeat modules.  An example ML configuration is added to the Nginx Filebeat module. This sample applies ML anomaly detection on the response codes.

The loading is implemented as part of the `setup` command and part of the `--setup` flag.

If a job configuration with the same ID exists, it is not overwritten, because deleting jobs could potentially delete user data. The user should manually delete the jobs in the UI if they want to upgrade.

ToDOs for the overall implementation:

* [x] Implement the jobs loading support in libbeat
* [x] Read the jobs configurations from the filesets
* [x] Add xpack to default testing env (`snaphost.yml`)
* [x] system tests
* [x] Docs & changelog