### PR TITLE
Convert heartbeat to new publisher pipeline

### DIFF
--- a/heartbeat/beater/heartbeat.go
+++ b/heartbeat/beater/heartbeat.go
@@ -7,7 +7,6 @@ import (
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
-	"github.com/elastic/beats/libbeat/publisher/bc/publisher"
 
 	"github.com/elastic/beats/heartbeat/config"
 	"github.com/elastic/beats/heartbeat/monitors"
@@ -17,9 +16,8 @@ import (
 type Heartbeat struct {
 	done chan struct{}
 
-	client    publisher.Client
 	scheduler *scheduler.Scheduler
-	manager   *MonitorManager
+	manager   *monitorManager
 }
 
 func New(b *beat.Beat, cfg *common.Config) (beat.Beater, error) {
@@ -40,16 +38,14 @@ func New(b *beat.Beat, cfg *common.Config) (beat.Beater, error) {
 		return nil, err
 	}
 
-	client := b.Publisher.Connect()
 	sched := scheduler.NewWithLocation(limit, location)
-	manager, err := newMonitorManager(client, sched, monitors.Registry, config.Monitors)
+	manager, err := newMonitorManager(b.Publisher, sched, monitors.Registry, config.Monitors)
 	if err != nil {
 		return nil, err
 	}
 
 	bt := &Heartbeat{
 		done:      make(chan struct{}),
-		client:    client,
 		scheduler: sched,
 		manager:   manager,
 	}
@@ -66,11 +62,12 @@ func (bt *Heartbeat) Run(b *beat.Beat) error {
 
 	<-bt.done
 
+	bt.manager.Stop()
+
 	logp.Info("Shutting down.")
 	return nil
 }
 
 func (bt *Heartbeat) Stop() {
-	bt.client.Close()
 	close(bt.done)
 }

--- a/heartbeat/monitors/monitors.go
+++ b/heartbeat/monitors/monitors.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/publisher/beat"
 )
 
 type Factory func(*common.Config) ([]Job, error)
@@ -14,8 +15,10 @@ type ActiveBuilder func(Info, *common.Config) ([]Job, error)
 
 type Job interface {
 	Name() string
-	TaskRunner
+	Run() (beat.Event, []JobRunner, error)
 }
+
+type JobRunner func() (beat.Event, []JobRunner, error)
 
 type TaskRunner interface {
 	Run() (common.MapStr, []TaskRunner, error)

--- a/heartbeat/tests/system/config/heartbeat.yml.j2
+++ b/heartbeat/tests/system/config/heartbeat.yml.j2
@@ -1,11 +1,60 @@
 heartbeat.monitors:
-- type: http
-  urls: ["http://localhost:9200"]
+{% for monitor in monitors -%}
+- type: {{ monitor.type }}
+  {%- if monitor.hosts is defined %}
+  hosts:
+    {%- for host in monitor.hosts %}
+    - '{{ host }}'
+    {% endfor -%}
+  {% endif -%}
+
+  {%- if monitor.urls is defined %}
+  urls:
+    {%- for url in monitor.urls %}
+    - '{{ url }}'
+    {% endfor %}
+  {% endif -%}
+
+  {%- if monitor.schedule is defined %}
+  schedule: '{{ monitor.schedule }}'
+  {%- else -%}
   schedule: '@every 1s'
-  tags: ["http_monitor_tags"]
-  fields_under_root: true
+  {% endif -%}
+
+  {%- if monitor.tags is defined %}
+  tags:
+    {% for tag in monitor.tags -%}
+    - '{{ tag }}'
+    {% endfor %}
+  {% endif -%}
+
+  {%- if monitor.fields is defined %}
+  {% if monitor.fields_under_root %}fields_under_root: true{% endif %}
   fields:
-    hello: world
+    {% for k, v in monitor.fields.items() -%}
+    {{ k }}: {{ v }}
+    {% endfor %}
+  {% endif %}
+{% endfor -%}
+
+{%- if shipper_name %}
+name: {{ shipper_name }}
+{% endif %}
+
+{%- if tags %}
+tags:
+  {% for tag in tags -%}
+  - {{ tag }}
+  {% endfor -%}
+{% endif %}
+
+{%- if fields %}
+{% if fields_under_root %}fields_under_root: true{% endif %}
+fields:
+  {% for k, v in fields.items() -%}
+  {{ k }}: {{ v }}
+  {% endfor -%}
+{% endif %}
 
 output.file:
   path: {{ output_file_path|default(beat.working_dir + "/output") }}

--- a/heartbeat/tests/system/test_base.py
+++ b/heartbeat/tests/system/test_base.py
@@ -9,20 +9,96 @@ class Test(BaseTest):
         """
         Basic test with exiting Heartbeat normally
         """
+
+        config = {
+            "monitors": [
+                {
+                    "type": "http",
+                    "urls": ["http://localhost:9200"],
+                }
+            ]
+        }
+
         self.render_config_template(
-            path=os.path.abspath(self.working_dir) + "/log/*"
+            path=os.path.abspath(self.working_dir) + "/log/*",
+            **config
         )
 
         heartbeat_proc = self.start_beat()
         self.wait_until(lambda: self.log_contains("heartbeat is running"))
         heartbeat_proc.check_kill_and_wait()
 
-    def test_monitor_config(self):
+    def test_fields_under_root(self):
         """
         Basic test with fields and tags in monitor
         """
+
+        self.run_fields(
+            local={
+                "tags": ["local"],
+                "fields_under_root": True,
+                "fields": {"local": "field", "env": "dev"},
+            },
+            top={
+                "tags": ["global"],
+                "fields": {
+                    "global": "field",
+                    "env": "prod",
+                    "level": "overwrite"
+                },
+                "fields_under_root": True,
+            },
+            expected={
+                "tags": ["global", "local"],
+                "global": "field",
+                "local": "field",
+                "env": "dev"
+            }
+        )
+
+    def test_fields_not_under_root(self):
+        """
+        Basic test with fields and tags (not under root)
+        """
+        self.run_fields(
+            local={
+                "tags": ["local"],
+                "fields": {"local": "field", "env": "dev", "num": 1}
+            },
+            top={
+                "tags": ["global"],
+                "fields": {
+                    "global": "field",
+                    "env": "prod",
+                    "level": "overwrite",
+                    "num": 0
+                }
+            },
+            expected={
+                "tags": ["global", "local"],
+                "fields.global": "field",
+                "fields.local": "field",
+                "fields.env": "dev"
+            }
+        )
+
+    def run_fields(self, expected, local=None, top=None):
+        monitor = {
+            "type": "http",
+            "urls": ["http://localhost:9200"],
+        }
+        if local:
+            monitor.update(local)
+
+        config = {
+            "monitors": [monitor]
+        }
+        if top:
+            config.update(top)
+
         self.render_config_template(
-            path=os.path.abspath(self.working_dir) + "/*"
+            path=os.path.abspath(self.working_dir) + "/*",
+            **config
         )
 
         heartbeat_proc = self.start_beat()
@@ -30,6 +106,5 @@ class Test(BaseTest):
         heartbeat_proc.check_kill_and_wait()
 
         doc = self.read_output()[0]
-        assert doc["hello"] == "world"
-        assert doc["tags"] == ["http_monitor_tags"]
-        assert "fields" not in doc
+        self.assertDictContainsSubset(expected, doc)
+        return doc


### PR DESCRIPTION
Requires: #4554 

- install EventMetadata processing with beat.Client on connect
- now Task and Job have different return type:
  - a Task can optionally return event fields of type common.MapStr
  - a Job returns/reports full events by wrapping the tasks events into a beat.Event type with additional annotations and start timestamp
  - unexport some 'local' types
- slight enhancements to fields/tags testing in heartbeat system tests
- add 'processors' setting to heartbeat monitors (requires doc update)