### PR TITLE
Non-xpack snaphosts for testing

### DIFF
--- a/testing/environments/docker/elasticsearch/Dockerfile-snapshot
+++ b/testing/environments/docker/elasticsearch/Dockerfile-snapshot
@@ -6,6 +6,7 @@ MAINTAINER Elastic Docker Team <docker@elastic.co>
 ARG ELASTIC_VERSION
 ARG DOWNLOAD_URL
 ARG ES_JAVA_OPTS
+ARG XPACK
 
 ENV ELASTIC_CONTAINER true
 ENV PATH /usr/share/elasticsearch/bin:$PATH
@@ -35,7 +36,7 @@ RUN set -ex && for esdirs in config data logs; do \
 USER elasticsearch
 
 # Install xpack
-RUN elasticsearch-plugin install --batch ${DOWNLOAD_URL}/packs/x-pack/x-pack-${ELASTIC_VERSION}.zip
+RUN if [ ${XPACK} = "1" ]; then elasticsearch-plugin install --batch ${DOWNLOAD_URL}/packs/x-pack/x-pack-${ELASTIC_VERSION}.zip; fi
 RUN elasticsearch-plugin install --batch ${DOWNLOAD_URL}/elasticsearch-plugins/ingest-user-agent/ingest-user-agent-${ELASTIC_VERSION}.zip
 RUN elasticsearch-plugin install --batch ${DOWNLOAD_URL}/elasticsearch-plugins/ingest-geoip/ingest-geoip-${ELASTIC_VERSION}.zip
 

--- a/testing/environments/docker/kibana/Dockerfile-snapshot
+++ b/testing/environments/docker/kibana/Dockerfile-snapshot
@@ -4,14 +4,17 @@ MAINTAINER Elastic Docker Team <docker@elastic.co>
 
 ARG DOWNLOAD_URL
 ARG ELASTIC_VERSION
+ARG XPACK
 
 HEALTHCHECK --retries=6 CMD curl -f http://localhost:5601
 EXPOSE 5601
 
 WORKDIR /usr/share/kibana
 RUN curl -Ls ${DOWNLOAD_URL}/kibana/kibana-${ELASTIC_VERSION}-linux-x86_64.tar.gz | tar --strip-components=1 -zxf - && \
-    bin/kibana-plugin install ${DOWNLOAD_URL}/kibana-plugins/x-pack/x-pack-${ELASTIC_VERSION}.zip && \
     ln -s /usr/share/kibana /opt/kibana
+
+# Install XPACK
+RUN if  [ ${XPACK} = 1]; then bin/kibana-plugin install ${DOWNLOAD_URL}/kibana-plugins/x-pack/x-pack-${ELASTIC_VERSION}.zip; fi
 
 # Set some Kibana configuration defaults.
 ADD config/kibana.yml /usr/share/kibana/config/

--- a/testing/environments/snapshot-noxpack.yml
+++ b/testing/environments/snapshot-noxpack.yml
@@ -10,13 +10,12 @@ services:
       context: ./docker/elasticsearch
       dockerfile: Dockerfile-snapshot
       args:
-        XPACK: 1
+        XPACK: 0
     environment:
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
       - "network.host="
       - "transport.host=127.0.0.1"
       - "http.host=0.0.0.0"
-      - "xpack.security.enabled=false"
 
   logstash:
     extends:
@@ -26,7 +25,7 @@ services:
       context: ./docker/logstash
       dockerfile: Dockerfile
       args:
-        XPACK: 1
+        XPACK: 0
     environment:
       - ES_HOST=elasticsearch
 


### PR DESCRIPTION
We're now testing with x-pack by default, but this means that we lack on testing without x-pack. This adds another version of the testing env: `make start ENV=snaphsot-noxpack.yml` which starts the stack without x-pack installed.