### PR TITLE
Assume no xpack installed on 400 answer

### DIFF
--- a/libbeat/ml-importer/importer.go
+++ b/libbeat/ml-importer/importer.go
@@ -80,7 +80,7 @@ func ImportMachineLearningJob(esClient MLLoader, cfg *MLConfig) error {
 func HaveXpackML(esClient MLLoader) (bool, error) {
 
 	status, response, err := esClient.Request("GET", "/_xpack", "", nil, nil)
-	if status == 404 {
+	if status == 404 || status == 400 {
 		return false, nil
 	}
 	if err != nil {


### PR DESCRIPTION
`GET /_xpack` returns 400 when xpack is not installed, so accept that as an
acceptable error. It would be nice to first check the `_nodes` API, but I think
we need this check anyway.