### PR TITLE
Use packetbeat protocols to publish beat.Event to new pipeline

### DIFF
--- a/packetbeat/beater/packetbeat.go
+++ b/packetbeat/beater/packetbeat.go
@@ -11,6 +11,9 @@ import (
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/droppriv"
 	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/processors"
+	"github.com/elastic/beats/libbeat/publisher/bc/publisher"
+	pub "github.com/elastic/beats/libbeat/publisher/beat"
 	"github.com/elastic/beats/libbeat/service"
 	"github.com/tsg/gopacket/layers"
 
@@ -30,8 +33,11 @@ import (
 type packetbeat struct {
 	config      config.Config
 	cmdLineArgs flags
-	pub         *publish.PacketbeatPublisher
 	sniff       *sniffer.SnifferSetup
+
+	// publisher/pipeline
+	pipeline publisher.Publisher
+	transPub *publish.TransactionPublisher
 
 	services []interface {
 		Start()
@@ -100,13 +106,18 @@ func (pb *packetbeat) init(b *beat.Beat) error {
 	// This is required as init Beat is called before the beat publisher is initialised
 	b.Config.Shipper.InitShipperConfig()
 
-	pb.pub, err = publish.NewPublisher(b.Publisher, *b.Config.Shipper.QueueSize, *b.Config.Shipper.BulkQueueSize, pb.config.IgnoreOutgoing)
+	pb.pipeline = b.Publisher
+	pb.transPub, err = publish.NewTransactionPublisher(
+		b.Publisher,
+		pb.config.IgnoreOutgoing,
+		pb.config.Interfaces.File == "",
+	)
 	if err != nil {
-		return fmt.Errorf("Initializing publisher failed: %v", err)
+		return err
 	}
 
 	logp.Debug("main", "Initializing protocol plugins")
-	err = protos.Protos.Init(false, pb.pub, cfg.Protocols, cfg.ProtocolsList)
+	err = protos.Protos.Init(false, pb.transPub, cfg.Protocols, cfg.ProtocolsList)
 	if err != nil {
 		return fmt.Errorf("Initializing protocol analyzers failed: %v", err)
 	}
@@ -127,12 +138,7 @@ func (pb *packetbeat) Run(b *beat.Beat) error {
 			time.Sleep(time.Duration(float64(protos.DefaultTransactionExpiration) * 1.2))
 			logp.Debug("main", "Streams and transactions should all be expired now.")
 		}
-
-		// TODO:
-		// pb.TransPub.Stop()
 	}()
-
-	pb.pub.Start()
 
 	// This needs to be after the sniffer Init but before the sniffer Run.
 	if err := droppriv.DropPrivileges(pb.config.RunOptions); err != nil {
@@ -151,6 +157,9 @@ func (pb *packetbeat) Run(b *beat.Beat) error {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
+
+		defer pb.transPub.Stop()
+
 		err := pb.sniff.Run()
 		if err != nil {
 			errC <- fmt.Errorf("Sniffer main loop failed: %v", err)
@@ -182,7 +191,6 @@ func (pb *packetbeat) Run(b *beat.Beat) error {
 func (pb *packetbeat) Stop() {
 	logp.Info("Packetbeat send stop signal")
 	pb.sniff.Stop()
-	pb.pub.Stop()
 }
 
 func (pb *packetbeat) setupSniffer() error {
@@ -211,7 +219,20 @@ func (pb *packetbeat) createWorker(dl layers.LinkType) (sniffer.Worker, error) {
 	config := &pb.config
 
 	if config.Flows.IsEnabled() {
-		f, err = flows.NewFlows(pb.pub, config.Flows)
+		processors, err := processors.New(config.Flows.Processors)
+		if err != nil {
+			return nil, err
+		}
+
+		client, err := pb.pipeline.ConnectX(pub.ClientConfig{
+			EventMetadata: config.Flows.EventMetadata,
+			Processor:     processors,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		f, err = flows.NewFlows(client.PublishAll, config.Flows)
 		if err != nil {
 			return nil, err
 		}
@@ -224,7 +245,12 @@ func (pb *packetbeat) createWorker(dl layers.LinkType) (sniffer.Worker, error) {
 		return nil, err
 	}
 	if cfg.Enabled() {
-		icmp, err := icmp.New(false, pb.pub, cfg)
+		reporter, err := pb.transPub.CreateReporter(cfg)
+		if err != nil {
+			return nil, err
+		}
+
+		icmp, err := icmp.New(false, reporter, cfg)
 		if err != nil {
 			return nil, err
 		}

--- a/packetbeat/config/config.go
+++ b/packetbeat/config/config.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/droppriv"
+	"github.com/elastic/beats/libbeat/processors"
 	"github.com/elastic/beats/packetbeat/procs"
 )
 
@@ -34,9 +35,11 @@ type InterfacesConfig struct {
 }
 
 type Flows struct {
-	Enabled *bool  `config:"enabled"`
-	Timeout string `config:"timeout"`
-	Period  string `config:"period"`
+	Enabled       *bool                   `config:"enabled"`
+	Timeout       string                  `config:"timeout"`
+	Period        string                  `config:"period"`
+	EventMetadata common.EventMetadata    `config:",inline"`
+	Processors    processors.PluginConfig `config:"processors"`
 }
 
 type ProtocolCommon struct {

--- a/packetbeat/flows/flows.go
+++ b/packetbeat/flows/flows.go
@@ -4,8 +4,8 @@ import (
 	"time"
 
 	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/publisher/beat"
 	"github.com/elastic/beats/packetbeat/config"
-	"github.com/elastic/beats/packetbeat/publish"
 )
 
 type Flows struct {
@@ -14,6 +14,9 @@ type Flows struct {
 	counterReg *counterReg
 }
 
+// Reporter callback type, to report flow events to.
+type Reporter func([]beat.Event)
+
 var debugf = logp.MakeDebug("flows")
 
 const (
@@ -21,7 +24,7 @@ const (
 	defaultPeriod  = 10 * time.Second
 )
 
-func NewFlows(pub publish.Flows, config *config.Flows) (*Flows, error) {
+func NewFlows(pub Reporter, config *config.Flows) (*Flows, error) {
 	duration := func(s string, d time.Duration) (time.Duration, error) {
 		if s == "" {
 			return d, nil

--- a/packetbeat/flows/flows_test.go
+++ b/packetbeat/flows/flows_test.go
@@ -9,17 +9,17 @@ import (
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/publisher/beat"
 	"github.com/elastic/beats/packetbeat/config"
 	"github.com/stretchr/testify/assert"
 )
 
 type flowsChan struct {
-	ch chan []common.MapStr
+	ch chan []beat.Event
 }
 
-func (f *flowsChan) PublishFlows(events []common.MapStr) bool {
+func (f *flowsChan) PublishFlows(events []beat.Event) {
 	f.ch <- events
-	return true
 }
 
 func TestFlowsCounting(t *testing.T) {
@@ -45,14 +45,14 @@ func TestFlowsCounting(t *testing.T) {
 
 	assert.NoError(t, err)
 
-	pub := &flowsChan{make(chan []common.MapStr, 1)}
+	pub := &flowsChan{make(chan []beat.Event, 1)}
 
 	processor := &flowsProcessor{
 		table:    module.table,
 		counters: module.counterReg,
 		timeout:  20 * time.Millisecond,
 	}
-	processor.spool.init(pub, 1)
+	processor.spool.init(pub.PublishFlows, 1)
 
 	worker, err := makeWorker(
 		processor,
@@ -101,7 +101,7 @@ func TestFlowsCounting(t *testing.T) {
 		module.Unlock()
 	}
 
-	var events []common.MapStr
+	var events []beat.Event
 	select {
 	case events = <-pub.ch:
 	case <-time.After(5 * time.Second):
@@ -110,7 +110,7 @@ func TestFlowsCounting(t *testing.T) {
 	if events == nil {
 		t.Fatalf("no event received in time")
 	}
-	event := events[0]
+	event := events[0].Fields
 	t.Logf("event: %v", event)
 
 	source := event["source"].(common.MapStr)

--- a/packetbeat/flows/util.go
+++ b/packetbeat/flows/util.go
@@ -4,9 +4,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
-	"github.com/elastic/beats/packetbeat/publish"
+	"github.com/elastic/beats/libbeat/publisher/beat"
 )
 
 type worker struct {
@@ -16,8 +15,8 @@ type worker struct {
 }
 
 type spool struct {
-	pub    publish.Flows
-	events []common.MapStr
+	pub    Reporter
+	events []beat.Event
 }
 
 func newWorker(fn func(w *worker)) *worker {
@@ -83,12 +82,12 @@ func (w *worker) periodically(tick time.Duration, fn func() error) {
 	}
 }
 
-func (s *spool) init(pub publish.Flows, sz int) {
+func (s *spool) init(pub Reporter, sz int) {
 	s.pub = pub
-	s.events = make([]common.MapStr, 0, sz)
+	s.events = make([]beat.Event, 0, sz)
 }
 
-func (s *spool) publish(event common.MapStr) {
+func (s *spool) publish(event beat.Event) {
 	s.events = append(s.events, event)
 	if len(s.events) == cap(s.events) {
 		s.flush()
@@ -100,8 +99,8 @@ func (s *spool) flush() {
 		return
 	}
 
-	s.pub.PublishFlows(s.events)
-	s.events = make([]common.MapStr, 0, cap(s.events))
+	s.pub(s.events)
+	s.events = make([]beat.Event, 0, cap(s.events))
 }
 
 func gcd(a, b int64) int64 {

--- a/packetbeat/protos/applayer/applayer.go
+++ b/packetbeat/protos/applayer/applayer.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/streambuf"
+	"github.com/elastic/beats/libbeat/publisher/beat"
 )
 
 // A Message its direction indicator
@@ -210,18 +211,20 @@ func (t *Transaction) InitWithMsg(
 }
 
 // Event fills common event fields.
-func (t *Transaction) Event(event common.MapStr) error {
-	event["type"] = t.Type
-	event["@timestamp"] = common.Time(t.Ts.Ts)
-	event["responsetime"] = t.ResponseTime
-	event["src"] = &t.Src
-	event["dst"] = &t.Dst
-	event["transport"] = t.Transport.String()
-	event["bytes_out"] = t.BytesOut
-	event["bytes_in"] = t.BytesIn
-	event["status"] = t.Status
+func (t *Transaction) Event(event *beat.Event) error {
+	event.Timestamp = t.Ts.Ts
+
+	fields := event.Fields
+	fields["type"] = t.Type
+	fields["responsetime"] = t.ResponseTime
+	fields["src"] = &t.Src
+	fields["dst"] = &t.Dst
+	fields["transport"] = t.Transport.String()
+	fields["bytes_out"] = t.BytesOut
+	fields["bytes_in"] = t.BytesIn
+	fields["status"] = t.Status
 	if len(t.Notes) > 0 {
-		event["notes"] = t.Notes
+		fields["notes"] = t.Notes
 	}
 	return nil
 }

--- a/packetbeat/protos/cassandra/cassandra.go
+++ b/packetbeat/protos/cassandra/cassandra.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/elastic/beats/packetbeat/protos"
 	"github.com/elastic/beats/packetbeat/protos/tcp"
-	"github.com/elastic/beats/packetbeat/publish"
 
 	gocql "github.com/elastic/beats/packetbeat/protos/cassandra/internal/gocql"
 )
@@ -43,7 +42,7 @@ func init() {
 // New create and initializes a new cassandra protocol analyzer instance.
 func New(
 	testMode bool,
-	results publish.Transactions,
+	results protos.Reporter,
 	cfg *common.Config,
 ) (protos.Plugin, error) {
 	p := &cassandra{}
@@ -60,7 +59,7 @@ func New(
 	return p, nil
 }
 
-func (cassandra *cassandra) init(results publish.Transactions, config *cassandraConfig) error {
+func (cassandra *cassandra) init(results protos.Reporter, config *cassandraConfig) error {
 	if err := cassandra.setFromConfig(config); err != nil {
 		return err
 	}

--- a/packetbeat/protos/dns/dns_tcp_test.go
+++ b/packetbeat/protos/dns/dns_tcp_test.go
@@ -10,14 +10,12 @@
 package dns
 
 import (
-	"fmt"
 	"math/rand"
 	"net"
 	"testing"
 
 	"github.com/elastic/beats/packetbeat/protos"
 	"github.com/elastic/beats/packetbeat/protos/tcp"
-	"github.com/elastic/beats/packetbeat/publish"
 
 	"github.com/elastic/beats/libbeat/common"
 
@@ -207,7 +205,8 @@ func TestDecodeTcp_splitRequest(t *testing.T) {
 
 func TestParseTcp_errorNonDnsMsgResponse(t *testing.T) {
 	var private protos.ProtocolData
-	dns := newDNS(testing.Verbose())
+	results := &eventStore{}
+	dns := newDNS(results, testing.Verbose())
 	tcptuple := testTCPTuple()
 	q := elasticATcp
 	packet := newPacket(forward, q.request)
@@ -220,7 +219,7 @@ func TestParseTcp_errorNonDnsMsgResponse(t *testing.T) {
 	dns.Parse(packet, tcptuple, tcp.TCPDirectionReverse, private)
 	assert.Empty(t, dns.transactions.Size(), "There should be no transaction.")
 
-	m := expectResult(t, dns)
+	m := expectResult(t, results)
 	assertRequest(t, m, q)
 	assert.Equal(t, "tcp", mapValue(t, m, "transport"))
 	assert.Equal(t, len(q.request), mapValue(t, m, "bytes_in"))
@@ -232,21 +231,21 @@ func TestParseTcp_errorNonDnsMsgResponse(t *testing.T) {
 // Verify that a request message with length (first two bytes value) of zero is not published
 func TestParseTcp_zeroLengthMsgRequest(t *testing.T) {
 	var private protos.ProtocolData
-	dns := newDNS(testing.Verbose())
+	store := &eventStore{}
+	dns := newDNS(store, testing.Verbose())
 	tcptuple := testTCPTuple()
 	packet := newPacket(forward, []byte{0, 0, 1, 2})
 
 	dns.Parse(packet, tcptuple, tcp.TCPDirectionOriginal, private)
 	assert.Empty(t, dns.transactions.Size(), "There should be no transactions.")
-	client := dns.results.(*publish.ChanTransactions)
-	close(client.Channel)
-	assert.Nil(t, <-client.Channel, "No result should have been published.")
+	assert.True(t, store.empty(), "No result should have been published.")
 }
 
 // Verify that a response message with length (first two bytes value) of zero is published with the corresponding Notes
 func TestParseTcp_errorZeroLengthMsgResponse(t *testing.T) {
 	var private protos.ProtocolData
-	dns := newDNS(testing.Verbose())
+	results := &eventStore{}
+	dns := newDNS(results, testing.Verbose())
 	tcptuple := testTCPTuple()
 	q := elasticATcp
 	packet := newPacket(forward, q.request)
@@ -259,7 +258,7 @@ func TestParseTcp_errorZeroLengthMsgResponse(t *testing.T) {
 	dns.Parse(packet, tcptuple, tcp.TCPDirectionReverse, private)
 	assert.Empty(t, dns.transactions.Size(), "There should be no transaction.")
 
-	m := expectResult(t, dns)
+	m := expectResult(t, results)
 	assertRequest(t, m, q)
 	assert.Equal(t, "tcp", mapValue(t, m, "transport"))
 	assert.Equal(t, len(q.request), mapValue(t, m, "bytes_in"))
@@ -271,21 +270,20 @@ func TestParseTcp_errorZeroLengthMsgResponse(t *testing.T) {
 // Verify that an empty packet is safely handled (no panics).
 func TestParseTcp_emptyPacket(t *testing.T) {
 	var private protos.ProtocolData
-	dns := newDNS(testing.Verbose())
+	store := &eventStore{}
+	dns := newDNS(store, testing.Verbose())
 	packet := newPacket(forward, []byte{})
 	tcptuple := testTCPTuple()
 
 	dns.Parse(packet, tcptuple, tcp.TCPDirectionOriginal, private)
 	assert.Empty(t, dns.transactions.Size(), "There should be no transactions.")
-	client := dns.results.(*publish.ChanTransactions)
-	close(client.Channel)
-	assert.Nil(t, <-client.Channel, "No result should have been published.")
+	assert.True(t, store.empty(), "No result should have been published.")
 }
 
 // Verify that a malformed packet is safely handled (no panics).
 func TestParseTcp_malformedPacket(t *testing.T) {
 	var private protos.ProtocolData
-	dns := newDNS(testing.Verbose())
+	dns := newDNS(nil, testing.Verbose())
 	garbage := []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13}
 	tcptuple := testTCPTuple()
 	packet := newPacket(forward, garbage)
@@ -297,28 +295,28 @@ func TestParseTcp_malformedPacket(t *testing.T) {
 // Verify that the lone request packet is parsed.
 func TestParseTcp_requestPacket(t *testing.T) {
 	var private protos.ProtocolData
-	dns := newDNS(testing.Verbose())
+	store := &eventStore{}
+	dns := newDNS(store, testing.Verbose())
 	packet := newPacket(forward, elasticATcp.request)
 	tcptuple := testTCPTuple()
 
 	dns.Parse(packet, tcptuple, tcp.TCPDirectionOriginal, private)
 	assert.Equal(t, 1, dns.transactions.Size(), "There should be one transaction.")
-	client := dns.results.(*publish.ChanTransactions)
-	close(client.Channel)
-	assert.Nil(t, <-client.Channel, "No result should have been published.")
+	assert.True(t, store.empty(), "No result should have been published.")
 }
 
 // Verify that the lone response packet is parsed and that an error
 // result is published.
 func TestParseTcp_errorResponseOnly(t *testing.T) {
 	var private protos.ProtocolData
-	dns := newDNS(testing.Verbose())
+	results := &eventStore{}
+	dns := newDNS(results, testing.Verbose())
 	q := elasticATcp
 	packet := newPacket(reverse, q.response)
 	tcptuple := testTCPTuple()
 
 	dns.Parse(packet, tcptuple, tcp.TCPDirectionOriginal, private)
-	m := expectResult(t, dns)
+	m := expectResult(t, results)
 	assert.Equal(t, "tcp", mapValue(t, m, "transport"))
 	assert.Nil(t, mapValue(t, m, "bytes_in"))
 	assert.Equal(t, len(q.response), mapValue(t, m, "bytes_out"))
@@ -333,7 +331,8 @@ func TestParseTcp_errorResponseOnly(t *testing.T) {
 // map awaiting a response.
 func TestParseTcp_errorDuplicateRequests(t *testing.T) {
 	var private protos.ProtocolData
-	dns := newDNS(testing.Verbose())
+	results := &eventStore{}
+	dns := newDNS(results, testing.Verbose())
 	q := elasticATcp
 	packet := newPacket(forward, q.request)
 	tcptuple := testTCPTuple()
@@ -345,7 +344,7 @@ func TestParseTcp_errorDuplicateRequests(t *testing.T) {
 	// The first request is published and this one becomes a transaction
 	assert.Equal(t, 1, dns.transactions.Size(), "There should be one transaction.")
 
-	m := expectResult(t, dns)
+	m := expectResult(t, results)
 	assertRequest(t, m, q)
 	assert.Equal(t, "tcp", mapValue(t, m, "transport"))
 	assert.Equal(t, len(q.request), mapValue(t, m, "bytes_in"))
@@ -359,7 +358,8 @@ func TestParseTcp_errorDuplicateRequests(t *testing.T) {
 // Checks that PrepareNewMessage and Parse can manage two messages on the same stream, in different packets
 func TestParseTcp_errorDuplicateRequestsOneStream(t *testing.T) {
 	var private protos.ProtocolData
-	dns := newDNS(testing.Verbose())
+	results := &eventStore{}
+	dns := newDNS(results, testing.Verbose())
 	q := elasticATcp
 	packet := newPacket(forward, q.request)
 	tcptuple := testTCPTuple()
@@ -371,7 +371,7 @@ func TestParseTcp_errorDuplicateRequestsOneStream(t *testing.T) {
 	// The first query is published and this one becomes a transaction
 	assert.Equal(t, 1, dns.transactions.Size(), "There should be one transaction.")
 
-	m := expectResult(t, dns)
+	m := expectResult(t, results)
 	assertRequest(t, m, q)
 	assert.Equal(t, "tcp", mapValue(t, m, "transport"))
 	assert.Equal(t, len(q.request), mapValue(t, m, "bytes_in"))
@@ -385,7 +385,8 @@ func TestParseTcp_errorDuplicateRequestsOneStream(t *testing.T) {
 // It typically happens when a SOA is followed by AXFR
 func TestParseTcp_errorDuplicateRequestsOnePacket(t *testing.T) {
 	var private protos.ProtocolData
-	dns := newDNS(testing.Verbose())
+	results := &eventStore{}
+	dns := newDNS(results, testing.Verbose())
 	q := elasticATcp
 	offset := 4
 
@@ -400,7 +401,7 @@ func TestParseTcp_errorDuplicateRequestsOnePacket(t *testing.T) {
 	dns.Parse(packet, tcptuple, tcp.TCPDirectionOriginal, private)
 	assert.Equal(t, 1, dns.transactions.Size(), "There should be one transaction.")
 
-	m := expectResult(t, dns)
+	m := expectResult(t, results)
 	assertRequest(t, m, q)
 	assert.Equal(t, "tcp", mapValue(t, m, "transport"))
 	assert.Equal(t, len(q.request), mapValue(t, m, "bytes_in"))
@@ -413,7 +414,8 @@ func TestParseTcp_errorDuplicateRequestsOnePacket(t *testing.T) {
 // Verify that a split response packet is parsed and published
 func TestParseTcp_splitResponse(t *testing.T) {
 	var private protos.ProtocolData
-	dns := newDNS(testing.Verbose())
+	results := &eventStore{}
+	dns := newDNS(results, testing.Verbose())
 	tcpQuery := elasticATcp
 	q := tcpQuery.request
 	r0 := tcpQuery.response[:1]
@@ -437,7 +439,7 @@ func TestParseTcp_splitResponse(t *testing.T) {
 	dns.Parse(packet, tcptuple, tcp.TCPDirectionReverse, private)
 	assert.Empty(t, dns.transactions.Size(), "There should be no transaction.")
 
-	m := expectResult(t, dns)
+	m := expectResult(t, results)
 	assert.Equal(t, "tcp", mapValue(t, m, "transport"))
 	assert.Equal(t, len(tcpQuery.request), mapValue(t, m, "bytes_in"))
 	assert.Equal(t, len(tcpQuery.response), mapValue(t, m, "bytes_out"))
@@ -449,7 +451,8 @@ func TestParseTcp_splitResponse(t *testing.T) {
 
 func TestGap_requestDrop(t *testing.T) {
 	var private protos.ProtocolData
-	dns := newDNS(testing.Verbose())
+	store := &eventStore{}
+	dns := newDNS(store, testing.Verbose())
 	q := sophosTxtTCP.request[:10]
 	packet := newPacket(forward, q)
 	tcptuple := testTCPTuple()
@@ -462,16 +465,14 @@ func TestGap_requestDrop(t *testing.T) {
 
 	dns.ReceivedFin(tcptuple, tcp.TCPDirectionOriginal, private)
 
-	client := dns.results.(*publish.ChanTransactions)
-	close(client.Channel)
-	mapStr := <-client.Channel
-	assert.Nil(t, mapStr, "No result should have been published.")
+	assert.True(t, store.empty(), "No result should have been published.")
 }
 
 // Verify that a gap during the response publish the request with Notes
 func TestGap_errorResponse(t *testing.T) {
 	var private protos.ProtocolData
-	dns := newDNS(testing.Verbose())
+	results := &eventStore{}
+	dns := newDNS(results, testing.Verbose())
 	q := sophosTxtTCP.request
 	r := sophosTxtTCP.response[:10]
 	tcptuple := testTCPTuple()
@@ -489,7 +490,7 @@ func TestGap_errorResponse(t *testing.T) {
 
 	dns.ReceivedFin(tcptuple, tcp.TCPDirectionReverse, private)
 
-	m := expectResult(t, dns)
+	m := expectResult(t, results)
 	assertRequest(t, m, sophosTxtTCP)
 	assert.Equal(t, incompleteMsg.responseError(), mapValue(t, m, "notes"))
 	assert.Nil(t, mapValue(t, m, "answers"))
@@ -498,7 +499,8 @@ func TestGap_errorResponse(t *testing.T) {
 // Verify that a gap/fin happening after a valid query create only one tansaction
 func TestGapFin_validMessage(t *testing.T) {
 	var private protos.ProtocolData
-	dns := newDNS(testing.Verbose())
+	store := &eventStore{}
+	dns := newDNS(store, testing.Verbose())
 	q := sophosTxtTCP.request
 	tcptuple := testTCPTuple()
 
@@ -512,17 +514,14 @@ func TestGapFin_validMessage(t *testing.T) {
 	dns.ReceivedFin(tcptuple, tcp.TCPDirectionReverse, private)
 	assert.Equal(t, 1, dns.transactions.Size(), "There should be one transaction.")
 
-	client := dns.results.(*publish.ChanTransactions)
-	close(client.Channel)
-	mapStr := <-client.Channel
-	assert.Nil(t, mapStr, "No result should have been published.")
-	assert.Empty(t, mapStr["notes"], "There should be no notes")
+	assert.True(t, store.empty(), "No result should have been published.")
 }
 
 // Verify that a Fin during the response publish the request with Notes
 func TestFin_errorResponse(t *testing.T) {
 	var private protos.ProtocolData
-	dns := newDNS(testing.Verbose())
+	results := &eventStore{}
+	dns := newDNS(results, testing.Verbose())
 	q := zoneAxfrTCP.request
 	r := zoneAxfrTCP.response[:10]
 	tcptuple := testTCPTuple()
@@ -537,7 +536,7 @@ func TestFin_errorResponse(t *testing.T) {
 
 	dns.ReceivedFin(tcptuple, tcp.TCPDirectionReverse, private)
 
-	m := expectResult(t, dns)
+	m := expectResult(t, results)
 	assertRequest(t, m, zoneAxfrTCP)
 	assert.Equal(t, incompleteMsg.responseError(), mapValue(t, m, "notes"))
 	assert.Nil(t, mapValue(t, m, "answers"))
@@ -545,7 +544,7 @@ func TestFin_errorResponse(t *testing.T) {
 
 // parseTcpRequestResponse parses a request then a response packet and validates
 // the published result.
-func parseTCPRequestResponse(t testing.TB, dns *dnsPlugin, q dnsTestMessage) {
+func parseTCPRequestResponse(t testing.TB, dns *dnsPlugin, results *eventStore, q dnsTestMessage) {
 	var private protos.ProtocolData
 	packet := newPacket(forward, q.request)
 	tcptuple := testTCPTuple()
@@ -556,7 +555,7 @@ func parseTCPRequestResponse(t testing.TB, dns *dnsPlugin, q dnsTestMessage) {
 
 	assert.Empty(t, dns.transactions.Size(), "There should be no transactions.")
 
-	m := expectResult(t, dns)
+	m := expectResult(t, results)
 	assert.Equal(t, "tcp", mapValue(t, m, "transport"))
 	assert.Equal(t, len(q.request), mapValue(t, m, "bytes_in"))
 	assert.Equal(t, len(q.response), mapValue(t, m, "bytes_out"))
@@ -575,21 +574,25 @@ func parseTCPRequestResponse(t testing.TB, dns *dnsPlugin, q dnsTestMessage) {
 // Verify that the request/response pair are parsed and that a result
 // is published.
 func TestParseTcp_requestResponse(t *testing.T) {
-	parseTCPRequestResponse(t, newDNS(testing.Verbose()), elasticATcp)
+	store := &eventStore{}
+	dns := newDNS(store, testing.Verbose())
+	parseTCPRequestResponse(t, dns, store, elasticATcp)
 }
 
 // Verify all DNS TCP test messages are parsed correctly.
 func TestParseTcp_allTestMessages(t *testing.T) {
-	dns := newDNS(testing.Verbose())
+	store := &eventStore{}
+	dns := newDNS(store, testing.Verbose())
 	for _, q := range messagesTCP {
 		t.Logf("Testing with query for %s", q.qName)
-		parseTCPRequestResponse(t, dns, q)
+		store.events = nil
+		parseTCPRequestResponse(t, dns, store, q)
 	}
 }
 
 // Benchmarks TCP parsing for the given test message.
 func benchmarkTCP(b *testing.B, q dnsTestMessage) {
-	dns := newDNS(false)
+	dns := newDNS(nil, false)
 	for i := 0; i < b.N; i++ {
 		var private protos.ProtocolData
 		packet := newPacket(forward, q.request)
@@ -598,9 +601,6 @@ func benchmarkTCP(b *testing.B, q dnsTestMessage) {
 
 		packet = newPacket(reverse, q.response)
 		dns.Parse(packet, tcptuple, tcp.TCPDirectionReverse, private)
-
-		client := dns.results.(*publish.ChanTransactions)
-		<-client.Channel
 	}
 }
 
@@ -616,18 +616,7 @@ func BenchmarkTcpSophosTxt(b *testing.B) { benchmarkTCP(b, sophosTxtTCP) }
 func BenchmarkParallelTcpParse(b *testing.B) {
 	rand.Seed(22)
 	numMessages := len(messagesTCP)
-	dns := newDNS(false)
-	client := dns.results.(*publish.ChanTransactions)
-
-	// Drain the results channel while the test is running.
-	go func() {
-		totalMessages := 0
-		for r := range client.Channel {
-			_ = r
-			totalMessages++
-		}
-		fmt.Printf("Parsed %d messages.\n", totalMessages)
-	}()
+	dns := newDNS(nil, false)
 
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
@@ -649,6 +638,4 @@ func BenchmarkParallelTcpParse(b *testing.B) {
 			dns.Parse(packet, tcptuple, tcp.TCPDirectionOriginal, private)
 		}
 	})
-
-	defer close(client.Channel)
 }

--- a/packetbeat/protos/dns/dns_test.go
+++ b/packetbeat/protos/dns/dns_test.go
@@ -12,10 +12,10 @@ import (
 	"time"
 
 	"github.com/elastic/beats/packetbeat/protos"
-	"github.com/elastic/beats/packetbeat/publish"
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/publisher/beat"
 	mkdns "github.com/miekg/dns"
 	"github.com/stretchr/testify/assert"
 )
@@ -56,14 +56,30 @@ var (
 		net.ParseIP(serverIP), serverPort)
 )
 
-func newDNS(verbose bool) *dnsPlugin {
+type eventStore struct {
+	events []beat.Event
+}
+
+func (e *eventStore) publish(event beat.Event) {
+	e.events = append(e.events, event)
+}
+
+func (e *eventStore) empty() bool {
+	return len(e.events) == 0
+}
+
+func newDNS(store *eventStore, verbose bool) *dnsPlugin {
 	if verbose {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"dns"})
 	} else {
 		logp.LogInit(logp.LOG_EMERG, "", false, true, []string{"dns"})
 	}
 
-	results := &publish.ChanTransactions{Channel: make(chan common.MapStr, 100)}
+	callback := func(beat.Event) {}
+	if store != nil {
+		callback = store.publish
+	}
+
 	cfg, _ := common.NewConfigFrom(map[string]interface{}{
 		"ports":               []int{serverPort},
 		"include_authorities": true,
@@ -71,7 +87,7 @@ func newDNS(verbose bool) *dnsPlugin {
 		"send_request":        true,
 		"send_response":       true,
 	})
-	dns, err := New(false, results, cfg)
+	dns, err := New(false, callback, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -89,15 +105,15 @@ func newPacket(t common.IPPortTuple, payload []byte) *protos.Packet {
 
 // expectResult returns one MapStr result from the Dns results channel. If
 // no result is available then the test fails.
-func expectResult(t testing.TB, dns *dnsPlugin) common.MapStr {
-	client := dns.results.(*publish.ChanTransactions)
-	select {
-	case result := <-client.Channel:
-		return result
-	default:
-		t.Error("Expected a result to be published.")
+func expectResult(t testing.TB, e *eventStore) common.MapStr {
+	if len(e.events) == 0 {
+		t.Error("No transaction")
+		return nil
 	}
-	return nil
+
+	event := e.events[0]
+	e.events = e.events[1:]
+	return event.Fields
 }
 
 // Retrieves a map value. The key should be the full dotted path to the element.

--- a/packetbeat/protos/icmp/icmp_test.go
+++ b/packetbeat/protos/icmp/icmp_test.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/publisher/beat"
 
 	"github.com/elastic/beats/packetbeat/protos"
-	"github.com/elastic/beats/packetbeat/publish"
 
 	"github.com/tsg/gopacket"
 	"github.com/tsg/gopacket/layers"
@@ -45,8 +45,7 @@ func BenchmarkIcmpProcessICMPv4(b *testing.B) {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"icmp", "icmpdetailed"})
 	}
 
-	results := &publish.ChanTransactions{Channel: make(chan common.MapStr, 10)}
-	icmp, err := New(true, results, common.NewConfig())
+	icmp, err := New(true, func(beat.Event) {}, common.NewConfig())
 	if err != nil {
 		b.Error("Failed to create ICMP processor")
 		return
@@ -63,9 +62,6 @@ func BenchmarkIcmpProcessICMPv4(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		icmp.ProcessICMPv4(nil, icmpRequestData, packetRequestData)
 		icmp.ProcessICMPv4(nil, icmpResponseData, packetResponseData)
-
-		client := icmp.results.(*publish.ChanTransactions)
-		<-client.Channel
 	}
 }
 

--- a/packetbeat/protos/memcache/memcache_test.go
+++ b/packetbeat/protos/memcache/memcache_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/publisher/beat"
 )
 
 type memcacheTest struct {
@@ -56,12 +57,14 @@ func makeBinMessage(
 }
 
 func makeTransactionEvent(t *testing.T, trans *transaction) common.MapStr {
-	event := common.MapStr{}
-	err := trans.Event(event)
+	event := beat.Event{
+		Fields: common.MapStr{},
+	}
+	err := trans.Event(&event)
 	if err != nil {
 		t.Fatalf("serializing transaction failed with: %v", err)
 	}
-	return event
+	return event.Fields
 }
 
 func Test_TryMergeUnmergeableRespnses(t *testing.T) {

--- a/packetbeat/protos/mongodb/mongodb.go
+++ b/packetbeat/protos/mongodb/mongodb.go
@@ -8,10 +8,10 @@ import (
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/monitoring"
+	"github.com/elastic/beats/libbeat/publisher/beat"
 	"github.com/elastic/beats/packetbeat/procs"
 	"github.com/elastic/beats/packetbeat/protos"
 	"github.com/elastic/beats/packetbeat/protos/tcp"
-	"github.com/elastic/beats/packetbeat/publish"
 )
 
 var debugf = logp.MakeDebug("mongodb")
@@ -28,7 +28,7 @@ type mongodbPlugin struct {
 	responses          *common.Cache
 	transactionTimeout time.Duration
 
-	results publish.Transactions
+	results protos.Reporter
 }
 
 type transactionKey struct {
@@ -46,7 +46,7 @@ func init() {
 
 func New(
 	testMode bool,
-	results publish.Transactions,
+	results protos.Reporter,
 	cfg *common.Config,
 ) (protos.Plugin, error) {
 	p := &mongodbPlugin{}
@@ -63,7 +63,7 @@ func New(
 	return p, nil
 }
 
-func (mongodb *mongodbPlugin) init(results publish.Transactions, config *mongodbConfig) error {
+func (mongodb *mongodbPlugin) init(results protos.Reporter, config *mongodbConfig) error {
 	debugf("Init a MongoDB protocol parser")
 	mongodb.setFromConfig(config)
 
@@ -368,27 +368,27 @@ func (mongodb *mongodbPlugin) publishTransaction(t *transaction) {
 		return
 	}
 
-	event := common.MapStr{}
-	event["type"] = "mongodb"
+	timestamp := t.ts
+	fields := common.MapStr{}
+	fields["type"] = "mongodb"
 	if t.error == "" {
-		event["status"] = common.OK_STATUS
+		fields["status"] = common.OK_STATUS
 	} else {
 		t.event["error"] = t.error
-		event["status"] = common.ERROR_STATUS
+		fields["status"] = common.ERROR_STATUS
 	}
-	event["mongodb"] = t.event
-	event["method"] = t.method
-	event["resource"] = t.resource
-	event["query"] = reconstructQuery(t, false)
-	event["responsetime"] = t.responseTime
-	event["bytes_in"] = uint64(t.bytesIn)
-	event["bytes_out"] = uint64(t.bytesOut)
-	event["@timestamp"] = common.Time(t.ts)
-	event["src"] = &t.src
-	event["dst"] = &t.dst
+	fields["mongodb"] = t.event
+	fields["method"] = t.method
+	fields["resource"] = t.resource
+	fields["query"] = reconstructQuery(t, false)
+	fields["responsetime"] = t.responseTime
+	fields["bytes_in"] = uint64(t.bytesIn)
+	fields["bytes_out"] = uint64(t.bytesOut)
+	fields["src"] = &t.src
+	fields["dst"] = &t.dst
 
 	if mongodb.sendRequest {
-		event["request"] = reconstructQuery(t, true)
+		fields["request"] = reconstructQuery(t, true)
 	}
 	if mongodb.sendResponse {
 		if len(t.documents) > 0 {
@@ -409,9 +409,12 @@ func (mongodb *mongodbPlugin) publishTransaction(t *transaction) {
 					docs = append(docs, str)
 				}
 			}
-			event["response"] = strings.Join(docs, "\n")
+			fields["response"] = strings.Join(docs, "\n")
 		}
 	}
 
-	mongodb.results.PublishTransaction(event)
+	mongodb.results(beat.Event{
+		Timestamp: timestamp,
+		Fields:    fields,
+	})
 }

--- a/packetbeat/protos/mysql/mysql.go
+++ b/packetbeat/protos/mysql/mysql.go
@@ -9,11 +9,11 @@ import (
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/monitoring"
+	"github.com/elastic/beats/libbeat/publisher/beat"
 
 	"github.com/elastic/beats/packetbeat/procs"
 	"github.com/elastic/beats/packetbeat/protos"
 	"github.com/elastic/beats/packetbeat/protos/tcp"
-	"github.com/elastic/beats/packetbeat/publish"
 )
 
 // Packet types
@@ -123,7 +123,7 @@ type mysqlPlugin struct {
 	transactions       *common.Cache
 	transactionTimeout time.Duration
 
-	results publish.Transactions
+	results protos.Reporter
 
 	// function pointer for mocking
 	handleMysql func(mysql *mysqlPlugin, m *mysqlMessage, tcp *common.TCPTuple,
@@ -136,7 +136,7 @@ func init() {
 
 func New(
 	testMode bool,
-	results publish.Transactions,
+	results protos.Reporter,
 	cfg *common.Config,
 ) (protos.Plugin, error) {
 	p := &mysqlPlugin{}
@@ -153,7 +153,7 @@ func New(
 	return p, nil
 }
 
-func (mysql *mysqlPlugin) init(results publish.Transactions, config *mysqlConfig) error {
+func (mysql *mysqlPlugin) init(results protos.Reporter, config *mysqlConfig) error {
 	mysql.setFromConfig(config)
 
 	mysql.transactions = common.NewCache(
@@ -831,38 +831,40 @@ func (mysql *mysqlPlugin) publishTransaction(t *mysqlTransaction) {
 
 	logp.Debug("mysql", "mysql.results exists")
 
-	event := common.MapStr{}
-	event["type"] = "mysql"
+	fields := common.MapStr{}
+	fields["type"] = "mysql"
 
 	if t.mysql["iserror"].(bool) {
-		event["status"] = common.ERROR_STATUS
+		fields["status"] = common.ERROR_STATUS
 	} else {
-		event["status"] = common.OK_STATUS
+		fields["status"] = common.OK_STATUS
 	}
 
-	event["responsetime"] = t.responseTime
+	fields["responsetime"] = t.responseTime
 	if mysql.sendRequest {
-		event["request"] = t.requestRaw
+		fields["request"] = t.requestRaw
 	}
 	if mysql.sendResponse {
-		event["response"] = t.responseRaw
+		fields["response"] = t.responseRaw
 	}
-	event["method"] = t.method
-	event["query"] = t.query
-	event["mysql"] = t.mysql
-	event["path"] = t.path
-	event["bytes_out"] = t.bytesOut
-	event["bytes_in"] = t.bytesIn
+	fields["method"] = t.method
+	fields["query"] = t.query
+	fields["mysql"] = t.mysql
+	fields["path"] = t.path
+	fields["bytes_out"] = t.bytesOut
+	fields["bytes_in"] = t.bytesIn
 
 	if len(t.notes) > 0 {
-		event["notes"] = t.notes
+		fields["notes"] = t.notes
 	}
 
-	event["@timestamp"] = common.Time(t.ts)
-	event["src"] = &t.src
-	event["dst"] = &t.dst
+	fields["src"] = &t.src
+	fields["dst"] = &t.dst
 
-	mysql.results.PublishTransaction(event)
+	mysql.results(beat.Event{
+		Timestamp: t.ts,
+		Fields:    fields,
+	})
 }
 
 func readLstring(data []byte, offset int) ([]byte, int, bool, error) {

--- a/packetbeat/protos/mysql/mysql_test.go
+++ b/packetbeat/protos/mysql/mysql_test.go
@@ -9,19 +9,35 @@ import (
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/publisher/beat"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/beats/packetbeat/protos"
-	"github.com/elastic/beats/packetbeat/publish"
 
 	"time"
 )
 
-func mysqlModForTests() *mysqlPlugin {
+type eventStore struct {
+	events []beat.Event
+}
+
+func (e *eventStore) publish(event beat.Event) {
+	e.events = append(e.events, event)
+}
+
+func (e *eventStore) empty() bool {
+	return len(e.events) == 0
+}
+
+func mysqlModForTests(store *eventStore) *mysqlPlugin {
+	callback := func(beat.Event) {}
+	if store != nil {
+		callback = store.publish
+	}
+
 	var mysql mysqlPlugin
-	results := &publish.ChanTransactions{Channel: make(chan common.MapStr, 10)}
 	config := defaultConfig
-	mysql.init(results, &config)
+	mysql.init(callback, &config)
 	return &mysql
 }
 
@@ -143,7 +159,7 @@ func TestMySQLParser_dataResponse(t *testing.T) {
 	if testing.Verbose() {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"mysqldetailed"})
 	}
-	mysql := mysqlModForTests()
+	mysql := mysqlModForTests(nil)
 
 	data := []byte(
 		"0100000105" +
@@ -316,7 +332,7 @@ func TestParseMySQL_simpleUpdateResponse(t *testing.T) {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"mysql", "mysqldetailed"})
 	}
 
-	mysql := mysqlModForTests()
+	mysql := mysqlModForTests(nil)
 	data, err := hex.DecodeString("300000010001000100000028526f7773206d61746368" +
 		"65643a203120204368616e6765643a203120205761726e696e67733a2030")
 	if err != nil {
@@ -354,7 +370,7 @@ func TestParseMySQL_threeResponses(t *testing.T) {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"mysql", "mysqldetailed"})
 	}
 
-	mysql := mysqlModForTests()
+	mysql := mysqlModForTests(nil)
 
 	data, err := hex.DecodeString(
 		"0700000100000000000000" +
@@ -397,7 +413,7 @@ func TestParseMySQL_splitResponse(t *testing.T) {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"mysql", "mysqldetailed"})
 	}
 
-	mysql := mysqlModForTests()
+	mysql := mysqlModForTests(nil)
 
 	data, err := hex.DecodeString(
 		"0100000105" +
@@ -469,15 +485,15 @@ func testTCPTuple() *common.TCPTuple {
 }
 
 // Helper function to read from the Publisher Queue
-func expectTransaction(t *testing.T, mysql *mysqlPlugin) common.MapStr {
-	client := mysql.results.(*publish.ChanTransactions)
-	select {
-	case trans := <-client.Channel:
-		return trans
-	default:
+func expectTransaction(t *testing.T, e *eventStore) common.MapStr {
+	if len(e.events) == 0 {
 		t.Error("No transaction")
+		return nil
 	}
-	return nil
+
+	event := e.events[0]
+	e.events = e.events[1:]
+	return event.Fields
 }
 
 // Test that loss of data during the response (but not at the beginning)
@@ -487,7 +503,8 @@ func Test_gap_in_response(t *testing.T) {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"mysql", "mysqldetailed"})
 	}
 
-	mysql := mysqlModForTests()
+	store := &eventStore{}
+	mysql := mysqlModForTests(store)
 
 	// request and response from tests/pcaps/mysql_result_long.pcap
 	// select * from test
@@ -528,7 +545,7 @@ func Test_gap_in_response(t *testing.T) {
 	_, drop := mysql.GapInStream(tcptuple, 1, 10, private)
 	assert.Equal(t, true, drop)
 
-	trans := expectTransaction(t, mysql)
+	trans := expectTransaction(t, store)
 	assert.NotNil(t, trans)
 	assert.Equal(t, trans["notes"], []string{"Packet loss while capturing the response"})
 }
@@ -540,7 +557,7 @@ func Test_gap_in_eat_message(t *testing.T) {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"mysql", "mysqldetailed"})
 	}
 
-	mysql := mysqlModForTests()
+	mysql := mysqlModForTests(nil)
 
 	// request from tests/pcaps/mysql_result_long.pcap
 	// "select * from test". Last byte missing.
@@ -582,7 +599,7 @@ func Test_parseMysqlResponse_invalid(t *testing.T) {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"mysql", "mysqldetailed"})
 	}
 
-	mysql := mysqlModForTests()
+	mysql := mysqlModForTests(nil)
 
 	tests := [][]byte{
 		{},

--- a/packetbeat/protos/nfs/nfs.go
+++ b/packetbeat/protos/nfs/nfs.go
@@ -2,12 +2,13 @@ package nfs
 
 import (
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/publisher/beat"
 )
 
 type nfs struct {
 	vers  uint32
 	proc  uint32
-	event common.MapStr
+	event beat.Event
 }
 
 func (nfs *nfs) getRequestInfo(xdr *xdr) common.MapStr {

--- a/packetbeat/protos/nfs/request_handler.go
+++ b/packetbeat/protos/nfs/request_handler.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/monitoring"
+	"github.com/elastic/beats/libbeat/publisher/beat"
 	"github.com/elastic/beats/packetbeat/protos/tcp"
 )
 
@@ -28,8 +29,8 @@ var (
 
 // called by Cache, when re reply seen within expected time window
 func (r *rpc) handleExpiredPacket(nfs *nfs) {
-	nfs.event["status"] = "NO_REPLY"
-	r.results.PublishTransaction(nfs.event)
+	nfs.event.Fields["status"] = "NO_REPLY"
+	r.results(nfs.event)
 	unmatchedRequests.Add(1)
 }
 
@@ -59,11 +60,10 @@ func (r *rpc) handleCall(xid string, xdr *xdr, ts time.Time, tcptuple *common.TC
 		src, dst = dst, src
 	}
 
-	event := common.MapStr{}
-	event["@timestamp"] = common.Time(ts)
-	event["status"] = common.OK_STATUS // all packages are OK for now
-	event["src"] = &src
-	event["dst"] = &dst
+	fields := common.MapStr{}
+	fields["status"] = common.OK_STATUS // all packages are OK for now
+	fields["src"] = &src
+	fields["dst"] = &dst
 
 	nfsVers := xdr.getUInt()
 	nfsProc := xdr.getUInt()
@@ -102,10 +102,17 @@ func (r *rpc) handleCall(xid string, xdr *xdr, ts time.Time, tcptuple *common.TC
 	xdr.getUInt()
 	xdr.getDynamicOpaque()
 
-	event["type"] = "nfs"
-	event["rpc"] = rpcInfo
-	nfs := nfs{vers: nfsVers, proc: nfsProc, event: event}
-	event["nfs"] = nfs.getRequestInfo(xdr)
+	fields["type"] = "nfs"
+	fields["rpc"] = rpcInfo
+	nfs := nfs{
+		vers: nfsVers,
+		proc: nfsProc,
+		event: beat.Event{
+			Timestamp: ts,
+			Fields:    fields,
+		},
+	}
+	fields["nfs"] = nfs.getRequestInfo(xdr)
 
 	// use xid+src ip to uniquely identify request
 	reqID := xid + tcptuple.SrcIP.String()
@@ -141,9 +148,10 @@ func (r *rpc) handleReply(xid string, xdr *xdr, ts time.Time, tcptuple *common.T
 	if v != nil {
 		nfs := v.(*nfs)
 		event := nfs.event
-		rpcInfo := event["rpc"].(common.MapStr)
+		fields := event.Fields
+		rpcInfo := fields["rpc"].(common.MapStr)
 		rpcInfo["reply_size"] = xdr.size()
-		rpcTime := ts.Sub(time.Time(event["@timestamp"].(common.Time)))
+		rpcTime := ts.Sub(event.Timestamp)
 		rpcInfo["time"] = rpcTime
 		// the same in human readable form
 		rpcInfo["time_str"] = fmt.Sprintf("%v", rpcTime)
@@ -152,9 +160,9 @@ func (r *rpc) handleReply(xid string, xdr *xdr, ts time.Time, tcptuple *common.T
 
 		// populate nfs info for successfully executed requests
 		if status == 0 {
-			nfsInfo := event["nfs"].(common.MapStr)
+			nfsInfo := fields["nfs"].(common.MapStr)
 			nfsInfo["status"] = nfs.getNFSReplyStatus(xdr)
 		}
-		r.results.PublishTransaction(event)
+		r.results(event)
 	}
 }

--- a/packetbeat/protos/nfs/rpc.go
+++ b/packetbeat/protos/nfs/rpc.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/elastic/beats/packetbeat/protos"
 	"github.com/elastic/beats/packetbeat/protos/tcp"
-	"github.com/elastic/beats/packetbeat/publish"
 )
 
 var debugf = logp.MakeDebug("rpc")
@@ -45,7 +44,7 @@ type rpc struct {
 	callsSeen          *common.Cache
 	transactionTimeout time.Duration
 
-	results publish.Transactions // Channel where results are pushed.
+	results protos.Reporter // Channel where results are pushed.
 }
 
 func init() {
@@ -54,7 +53,7 @@ func init() {
 
 func New(
 	testMode bool,
-	results publish.Transactions,
+	results protos.Reporter,
 	cfg *common.Config,
 ) (protos.Plugin, error) {
 	p := &rpc{}
@@ -73,7 +72,7 @@ func New(
 	return p, nil
 }
 
-func (r *rpc) init(results publish.Transactions, config *rpcConfig) error {
+func (r *rpc) init(results protos.Reporter, config *rpcConfig) error {
 	r.setFromConfig(config)
 	r.results = results
 	r.callsSeen = common.NewCacheWithRemovalListener(

--- a/packetbeat/protos/pgsql/pgsql.go
+++ b/packetbeat/protos/pgsql/pgsql.go
@@ -8,11 +8,11 @@ import (
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/monitoring"
+	"github.com/elastic/beats/libbeat/publisher/beat"
 
 	"github.com/elastic/beats/packetbeat/procs"
 	"github.com/elastic/beats/packetbeat/protos"
 	"github.com/elastic/beats/packetbeat/protos/tcp"
-	"github.com/elastic/beats/packetbeat/publish"
 )
 
 type pgsqlPlugin struct {
@@ -27,7 +27,7 @@ type pgsqlPlugin struct {
 	transactions       *common.Cache
 	transactionTimeout time.Duration
 
-	results publish.Transactions
+	results protos.Reporter
 
 	// function pointer for mocking
 	handlePgsql func(pgsql *pgsqlPlugin, m *pgsqlMessage, tcp *common.TCPTuple,
@@ -122,7 +122,7 @@ func init() {
 
 func New(
 	testMode bool,
-	results publish.Transactions,
+	results protos.Reporter,
 	cfg *common.Config,
 ) (protos.Plugin, error) {
 	p := &pgsqlPlugin{}
@@ -139,7 +139,7 @@ func New(
 	return p, nil
 }
 
-func (pgsql *pgsqlPlugin) init(results publish.Transactions, config *pgsqlConfig) error {
+func (pgsql *pgsqlPlugin) init(results protos.Reporter, config *pgsqlConfig) error {
 	pgsql.setFromConfig(config)
 
 	pgsql.transactions = common.NewCache(
@@ -448,36 +448,38 @@ func (pgsql *pgsqlPlugin) publishTransaction(t *pgsqlTransaction) {
 		return
 	}
 
-	event := common.MapStr{}
+	fields := common.MapStr{}
 
-	event["type"] = "pgsql"
+	fields["type"] = "pgsql"
 	if t.pgsql["iserror"].(bool) {
-		event["status"] = common.ERROR_STATUS
+		fields["status"] = common.ERROR_STATUS
 	} else {
-		event["status"] = common.OK_STATUS
+		fields["status"] = common.OK_STATUS
 	}
-	event["responsetime"] = t.responseTime
+	fields["responsetime"] = t.responseTime
 	if pgsql.sendRequest {
-		event["request"] = t.requestRaw
+		fields["request"] = t.requestRaw
 	}
 	if pgsql.sendResponse {
-		event["response"] = t.responseRaw
+		fields["response"] = t.responseRaw
 	}
-	event["query"] = t.query
-	event["method"] = t.method
-	event["bytes_out"] = t.bytesOut
-	event["bytes_in"] = t.bytesIn
-	event["pgsql"] = t.pgsql
+	fields["query"] = t.query
+	fields["method"] = t.method
+	fields["bytes_out"] = t.bytesOut
+	fields["bytes_in"] = t.bytesIn
+	fields["pgsql"] = t.pgsql
 
-	event["@timestamp"] = common.Time(t.ts)
-	event["src"] = &t.src
-	event["dst"] = &t.dst
+	fields["src"] = &t.src
+	fields["dst"] = &t.dst
 
 	if len(t.notes) > 0 {
-		event["notes"] = t.notes
+		fields["notes"] = t.notes
 	}
 
-	pgsql.results.PublishTransaction(event)
+	pgsql.results(beat.Event{
+		Timestamp: t.ts,
+		Fields:    fields,
+	})
 }
 
 func (pgsql *pgsqlPlugin) removeTransaction(transList []*pgsqlTransaction,

--- a/packetbeat/protos/pgsql/pgsql_test.go
+++ b/packetbeat/protos/pgsql/pgsql_test.go
@@ -10,23 +10,39 @@ import (
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/publisher/beat"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/beats/packetbeat/protos"
-	"github.com/elastic/beats/packetbeat/publish"
 )
 
-func pgsqlModForTests() *pgsqlPlugin {
+type eventStore struct {
+	events []beat.Event
+}
+
+func (e *eventStore) publish(event beat.Event) {
+	e.events = append(e.events, event)
+}
+
+func (e *eventStore) empty() bool {
+	return len(e.events) == 0
+}
+
+func pgsqlModForTests(store *eventStore) *pgsqlPlugin {
+	callback := func(beat.Event) {}
+	if store != nil {
+		callback = store.publish
+	}
+
 	var pgsql pgsqlPlugin
-	results := &publish.ChanTransactions{Channel: make(chan common.MapStr, 10)}
 	config := defaultConfig
-	pgsql.init(results, &config)
+	pgsql.init(callback, &config)
 	return &pgsql
 }
 
 // Test parsing a request with a single query
 func TestPgsqlParser_simpleRequest(t *testing.T) {
-	pgsql := pgsqlModForTests()
+	pgsql := pgsqlModForTests(nil)
 
 	data := []byte(
 		"510000001a53454c454354202a2046524f4d20466f6f6261723b00")
@@ -63,7 +79,7 @@ func TestPgsqlParser_dataResponse(t *testing.T) {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"pgsql", "pgsqldetailed"})
 	}
 
-	pgsql := pgsqlModForTests()
+	pgsql := pgsqlModForTests(nil)
 	data := []byte(
 		"5400000033000269640000008fc40001000000170004ffffffff000076616c75650000008fc4000200000019ffffffffffff0000" +
 			"44000000130002000000013100000004746f746f" +
@@ -108,7 +124,7 @@ func TestPgsqlParser_dataResponse(t *testing.T) {
 // Test parsing a pgsql response
 func TestPgsqlParser_response(t *testing.T) {
 
-	pgsql := pgsqlModForTests()
+	pgsql := pgsqlModForTests(nil)
 	data := []byte(
 		"54000000420003610000004009000100000413ffffffffffff0000620000004009000200000413ffffffffffff0000630000004009000300000413ffffffffffff0000" +
 			"440000001b0003000000036d6561000000036d6562000000036d6563" +
@@ -156,7 +172,7 @@ func TestPgsqlParser_incomplete_response(t *testing.T) {
 	if testing.Verbose() {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"pgsql", "pgsqldetailed"})
 	}
-	pgsql := pgsqlModForTests()
+	pgsql := pgsqlModForTests(nil)
 
 	data := []byte(
 		"54000000420003610000004009000100000413ffffffffffff0000620000004009000200000413ffffffffffff0000630000004009000300000413ffffffffffff0000" +
@@ -185,7 +201,7 @@ func TestPgsqlParser_incomplete_response(t *testing.T) {
 // Test 3 responses in a row
 func TestPgsqlParser_threeResponses(t *testing.T) {
 
-	pgsql := pgsqlModForTests()
+	pgsql := pgsqlModForTests(nil)
 
 	data, err := hex.DecodeString(
 		"5300000017446174655374796c650049534f2c204d445900430000000853455400430000000853455400540000005700036f696400000004eefffe0000001a0004ffffffff0000656e636f64696e6700000000000000000000130040ffffffff00006461746c6173747379736f696400000004ee00090000001a0004ffffffff0000440000002000030000000531313836350000000455544638000000053131383537430000000d53454c4543542031005a0000000549")
@@ -225,7 +241,7 @@ func TestPgsqlParser_errorResponse(t *testing.T) {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"pgsql", "pgsqldetailed"})
 	}
 
-	pgsql := pgsqlModForTests()
+	pgsql := pgsqlModForTests(nil)
 	data := []byte(
 		"4500000088534552524f5200433235503032004d63757272656e74207472616e73616374696f6e2069732061626f727465642c20636f6d6d616e64732069676e6f72656420756e74696c20656e64206f66207472616e73616374696f6e20626c6f636b0046706f7374677265732e63004c3932310052657865635f73696d706c655f71756572790000")
 
@@ -270,7 +286,7 @@ func TestPgsqlParser_invalidMessage(t *testing.T) {
 	if testing.Verbose() {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"pgsql", "pgsqldetailed"})
 	}
-	pgsql := pgsqlModForTests()
+	pgsql := pgsqlModForTests(nil)
 	data := []byte(
 		"4300000002")
 
@@ -302,15 +318,15 @@ func testTCPTuple() *common.TCPTuple {
 }
 
 // Helper function to read from the Publisher Queue
-func expectTransaction(t *testing.T, pgsql *pgsqlPlugin) common.MapStr {
-	client := pgsql.results.(*publish.ChanTransactions)
-	select {
-	case trans := <-client.Channel:
-		return trans
-	default:
+func expectTransaction(t *testing.T, e *eventStore) common.MapStr {
+	if len(e.events) == 0 {
 		t.Error("No transaction")
+		return nil
 	}
-	return nil
+
+	event := e.events[0]
+	e.events = e.events[1:]
+	return event.Fields
 }
 
 // Test that loss of data during the response (but not at the beginning)
@@ -320,7 +336,8 @@ func Test_gap_in_response(t *testing.T) {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"pgsql", "pgsqldetailed"})
 	}
 
-	pgsql := pgsqlModForTests()
+	store := &eventStore{}
+	pgsql := pgsqlModForTests(store)
 
 	// request and response from tests/pcaps/pgsql_request_response.pcap
 	// select * from test
@@ -356,7 +373,7 @@ func Test_gap_in_response(t *testing.T) {
 	_, drop := pgsql.GapInStream(tcptuple, 1, 10, private)
 	assert.Equal(t, true, drop)
 
-	trans := expectTransaction(t, pgsql)
+	trans := expectTransaction(t, store)
 	assert.NotNil(t, trans)
 	assert.Equal(t, trans["notes"], []string{"Packet loss while capturing the response"})
 }

--- a/packetbeat/protos/registry.go
+++ b/packetbeat/protos/registry.go
@@ -4,14 +4,17 @@ import (
 	"time"
 
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/packetbeat/publish"
+	"github.com/elastic/beats/libbeat/publisher/beat"
 )
 
 type ProtocolPlugin func(
 	testMode bool,
-	results publish.Transactions,
+	results Reporter,
 	cfg *common.Config,
 ) (Plugin, error)
+
+// Reporter is used by plugin instances to report new transaction events.
+type Reporter func(beat.Event)
 
 // Functions to be exported by a protocol plugin
 type Plugin interface {

--- a/packetbeat/protos/tcp/tcp_test.go
+++ b/packetbeat/protos/tcp/tcp_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/packetbeat/protos"
-	"github.com/elastic/beats/packetbeat/publish"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/tsg/gopacket/layers"
@@ -28,7 +27,7 @@ var (
 )
 
 func init() {
-	new := func(_ bool, _ publish.Transactions, _ *common.Config) (protos.Plugin, error) {
+	new := func(_ bool, _ protos.Reporter, _ *common.Config) (protos.Plugin, error) {
 		return &TestProtocol{}, nil
 	}
 
@@ -44,14 +43,14 @@ func init() {
 type TestProtocol struct {
 	Ports []int
 
-	init  func(testMode bool, results publish.Transactions) error
+	init  func(testMode bool, results protos.Reporter) error
 	parse func(*protos.Packet, *common.TCPTuple, uint8, protos.ProtocolData) protos.ProtocolData
 	onFin func(*common.TCPTuple, uint8, protos.ProtocolData) protos.ProtocolData
 	gap   func(*common.TCPTuple, uint8, int, protos.ProtocolData) (protos.ProtocolData, bool)
 }
 
 var _ protos.Plugin = &TestProtocol{
-	init: func(m bool, r publish.Transactions) error { return nil },
+	init: func(m bool, r protos.Reporter) error { return nil },
 	parse: func(p *protos.Packet, t *common.TCPTuple, d uint8, priv protos.ProtocolData) protos.ProtocolData {
 		return priv
 	},
@@ -63,7 +62,7 @@ var _ protos.Plugin = &TestProtocol{
 	},
 }
 
-func (proto *TestProtocol) Init(testMode bool, results publish.Transactions) error {
+func (proto *TestProtocol) Init(testMode bool, results protos.Reporter) error {
 	return proto.init(testMode, results)
 }
 

--- a/packetbeat/protos/udp/udp_test.go
+++ b/packetbeat/protos/udp/udp_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/packetbeat/protos"
-	"github.com/elastic/beats/packetbeat/publish"
 
 	// import plugins for testing
 	_ "github.com/elastic/beats/packetbeat/protos/http"
@@ -69,7 +68,7 @@ type TestProtocol struct {
 	pkt   *protos.Packet // UDP packet that the plugin was called to process.
 }
 
-func (proto *TestProtocol) Init(testMode bool, results publish.Transactions) error {
+func (proto *TestProtocol) Init(testMode bool, results protos.Reporter) error {
 	return nil
 }
 

--- a/packetbeat/publish/publish.go
+++ b/packetbeat/publish/publish.go
@@ -2,191 +2,139 @@ package publish
 
 import (
 	"errors"
-	"sync"
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/processors"
 	"github.com/elastic/beats/libbeat/publisher/bc/publisher"
+	"github.com/elastic/beats/libbeat/publisher/beat"
 )
 
-type Transactions interface {
-	PublishTransaction(common.MapStr) bool
+type TransactionPublisher struct {
+	done      chan struct{}
+	pipeline  publisher.Publisher
+	canDrop   bool
+	processor transProcessor
 }
 
-type Flows interface {
-	PublishFlows([]common.MapStr) bool
-}
-
-type PacketbeatPublisher struct {
-	beatPublisher *publisher.BeatPublisher
-	client        publisher.Client
-
-	localIPs []string
-
+type transProcessor struct {
 	ignoreOutgoing bool
-
-	wg   sync.WaitGroup
-	done chan struct{}
-
-	trans chan common.MapStr
-	flows chan []common.MapStr
-}
-
-type ChanTransactions struct {
-	Channel chan common.MapStr
-}
-
-func (t *ChanTransactions) PublishTransaction(event common.MapStr) bool {
-	t.Channel <- event
-	return true
+	localIPs       []string
+	name           string
 }
 
 var debugf = logp.MakeDebug("publish")
 
-func NewPublisher(
-	pub publisher.Publisher,
-	hwm, bulkHWM int,
+func NewTransactionPublisher(
+	pipeline publisher.Publisher,
 	ignoreOutgoing bool,
-) (*PacketbeatPublisher, error) {
-
+	canDrop bool,
+) (*TransactionPublisher, error) {
 	localIPs, err := common.LocalIPAddrsAsStrings(false)
 	if err != nil {
 		return nil, err
 	}
 
-	return &PacketbeatPublisher{
-		beatPublisher:  pub.(*publisher.BeatPublisher),
-		ignoreOutgoing: ignoreOutgoing,
-		client:         pub.Connect(),
-		localIPs:       localIPs,
-		done:           make(chan struct{}),
-		trans:          make(chan common.MapStr, hwm),
-		flows:          make(chan []common.MapStr, bulkHWM),
+	name := pipeline.(*publisher.BeatPublisher).GetName()
+	p := &TransactionPublisher{
+		done:     make(chan struct{}),
+		pipeline: pipeline,
+		canDrop:  canDrop,
+		processor: transProcessor{
+			localIPs:       localIPs,
+			name:           name,
+			ignoreOutgoing: ignoreOutgoing,
+		},
+	}
+	return p, nil
+}
+
+func (p *TransactionPublisher) Stop() {
+	close(p.done)
+}
+
+func (p *TransactionPublisher) CreateReporter(
+	config *common.Config,
+) (func(beat.Event), error) {
+
+	// load and register the module it's fields, tags and processors settings
+	meta := struct {
+		Event      common.EventMetadata    `config:",inline"`
+		Processors processors.PluginConfig `config:"processors"`
+	}{}
+	if err := config.Unpack(&meta); err != nil {
+		return nil, err
+	}
+
+	processors, err := processors.New(meta.Processors)
+	if err != nil {
+		return nil, err
+	}
+
+	clientConfig := beat.ClientConfig{
+		EventMetadata: meta.Event,
+		Processor:     processors,
+	}
+	if p.canDrop {
+		clientConfig.PublishMode = beat.DropIfFull
+	}
+
+	client, err := p.pipeline.ConnectX(clientConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	// start worker, so post-processing and processor-pipeline
+	// can work concurrently to sniffer acquiring new events
+	ch := make(chan beat.Event, 3)
+	go p.worker(ch, client)
+	return func(event beat.Event) {
+		ch <- event
 	}, nil
 }
 
-func (p *PacketbeatPublisher) PublishTransaction(event common.MapStr) bool {
-	select {
-	case p.trans <- event:
-		return true
-	default:
-		// drop event if queue is full
-		return false
+func (p *TransactionPublisher) worker(ch chan beat.Event, client beat.Client) {
+	go func() {
+		<-p.done
+		close(ch)
+	}()
+
+	for event := range ch {
+		pub, _ := p.processor.Run(&event)
+		if pub != nil {
+			client.Publish(*pub)
+		}
 	}
 }
 
-func (p *PacketbeatPublisher) PublishFlows(event []common.MapStr) bool {
-	select {
-	case p.flows <- event:
-		return true
-	case <-p.done:
-		// drop event, if worker has been stopped
-		return false
-	}
-}
-
-func (p *PacketbeatPublisher) Start() {
-	p.wg.Add(1)
-	go func() {
-		defer p.wg.Done()
-		for {
-			select {
-			case <-p.done:
-				return
-			case event := <-p.trans:
-				p.onTransaction(event)
-			}
-		}
-	}()
-
-	p.wg.Add(1)
-	go func() {
-		defer p.wg.Done()
-		for {
-			select {
-			case <-p.done:
-				return
-			case events := <-p.flows:
-				p.onFlow(events)
-			}
-		}
-	}()
-}
-
-func (p *PacketbeatPublisher) Stop() {
-	p.client.Close()
-	close(p.done)
-	p.wg.Wait()
-}
-
-func (p *PacketbeatPublisher) onTransaction(event common.MapStr) {
+func (p *transProcessor) Run(event *beat.Event) (*beat.Event, error) {
 	if err := validateEvent(event); err != nil {
 		logp.Warn("Dropping invalid event: %v", err)
-		return
+		return nil, nil
 	}
 
-	if !p.normalizeTransAddr(event) {
-		return
+	if !p.normalizeTransAddr(event.Fields) {
+		return nil, nil
 	}
 
-	p.client.PublishEvent(event)
-}
-
-func (p *PacketbeatPublisher) onFlow(events []common.MapStr) {
-	pub := events[:0]
-	for _, event := range events {
-		if err := validateEvent(event); err != nil {
-			logp.Warn("Dropping invalid event: %v", err)
-			continue
-		}
-
-		pub = append(pub, event)
-	}
-
-	p.client.PublishEvents(pub)
-}
-
-func (p *PacketbeatPublisher) IsPublisherIP(ip string) bool {
-
-	for _, myip := range p.localIPs {
-		if myip == ip {
-			return true
-		}
-	}
-
-	return false
-}
-
-func (p *PacketbeatPublisher) GetServerName(ip string) string {
-
-	// in case the IP is localhost, return current shipper name
-	islocal, err := common.IsLoopback(ip)
-	if err != nil {
-		logp.Err("Parsing IP %s fails with: %s", ip, err)
-		return ""
-	}
-
-	if islocal {
-		return p.beatPublisher.GetName()
-	}
-
-	return ""
+	return event, nil
 }
 
 // filterEvent validates an event for common required fields with types.
 // If event is to be filtered out the reason is returned as error.
-func validateEvent(event common.MapStr) error {
-	ts, ok := event["@timestamp"]
-	if !ok {
-		return errors.New("missing '@timestamp' field from event")
+func validateEvent(event *beat.Event) error {
+	fields := event.Fields
+
+	if event.Timestamp.IsZero() {
+		return errors.New("missing '@timestamp'")
 	}
 
-	_, ok = ts.(common.Time)
-	if !ok {
-		return errors.New("invalid '@timestamp' field from event")
+	_, ok := fields["@timestamp"]
+	if ok {
+		return errors.New("duplicate '@timestamp' field from event")
 	}
 
-	t, ok := event["type"]
+	t, ok := fields["type"]
 	if !ok {
 		return errors.New("missing 'type' field from event")
 	}
@@ -199,7 +147,7 @@ func validateEvent(event common.MapStr) error {
 	return nil
 }
 
-func (p *PacketbeatPublisher) normalizeTransAddr(event common.MapStr) bool {
+func (p *transProcessor) normalizeTransAddr(event common.MapStr) bool {
 	debugf("normalize address for: %v", event)
 
 	var srcServer, dstServer string
@@ -246,4 +194,29 @@ func (p *PacketbeatPublisher) normalizeTransAddr(event common.MapStr) bool {
 	}
 
 	return true
+}
+
+func (p *transProcessor) IsPublisherIP(ip string) bool {
+	for _, myip := range p.localIPs {
+		if myip == ip {
+			return true
+		}
+	}
+	return false
+}
+
+func (p *transProcessor) GetServerName(ip string) string {
+
+	// in case the IP is localhost, return current shipper name
+	islocal, err := common.IsLoopback(ip)
+	if err != nil {
+		logp.Err("Parsing IP %s fails with: %s", ip, err)
+		return ""
+	}
+
+	if islocal {
+		return p.name
+	}
+
+	return ""
 }

--- a/packetbeat/publish/publish_test.go
+++ b/packetbeat/publish/publish_test.go
@@ -8,111 +8,137 @@ import (
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/publisher/bc/publisher"
+	"github.com/elastic/beats/libbeat/publisher/beat"
 	"github.com/stretchr/testify/assert"
 )
 
-func testEvent() common.MapStr {
-	event := common.MapStr{}
-	event["@timestamp"] = common.Time(time.Now())
-	event["type"] = "test"
-	event["src"] = &common.Endpoint{}
-	event["dst"] = &common.Endpoint{}
-	return event
+func testEvent() beat.Event {
+	return beat.Event{
+		Timestamp: time.Now(),
+		Fields: common.MapStr{
+			"type": "test",
+			"src":  &common.Endpoint{},
+			"dst":  &common.Endpoint{},
+		},
+	}
 }
 
 // Test that FilterEvent detects events that do not contain the required fields
 // and returns error.
 func TestFilterEvent(t *testing.T) {
 	var testCases = []struct {
-		f   func() common.MapStr
+		f   func() beat.Event
 		err string
 	}{
-		{func() common.MapStr {
-			return testEvent()
-		}, ""},
-
-		{func() common.MapStr {
-			m := testEvent()
-			m["@timestamp"] = time.Now()
-			return m
-		}, "invalid '@timestamp'"},
-
-		{func() common.MapStr {
-			m := testEvent()
-			delete(m, "@timestamp")
-			return m
-		}, "missing '@timestamp'"},
-
-		{func() common.MapStr {
-			m := testEvent()
-			delete(m, "type")
-			return m
-		}, "missing 'type'"},
-
-		{func() common.MapStr {
-			m := testEvent()
-			m["type"] = 123
-			return m
-		}, "invalid 'type'"},
+		{testEvent, ""},
+		{
+			func() beat.Event {
+				e := testEvent()
+				e.Fields["@timestamp"] = time.Now()
+				return e
+			},
+			"duplicate '@timestamp'",
+		},
+		{
+			func() beat.Event {
+				e := testEvent()
+				e.Timestamp = time.Time{}
+				return e
+			},
+			"missing '@timestamp'",
+		},
+		{
+			func() beat.Event {
+				e := testEvent()
+				delete(e.Fields, "type")
+				return e
+			},
+			"missing 'type'",
+		},
+		{
+			func() beat.Event {
+				e := testEvent()
+				e.Fields["type"] = 123
+				return e
+			},
+			"invalid 'type'",
+		},
 	}
 
 	for _, test := range testCases {
-		assert.Regexp(t, test.err, validateEvent(test.f()))
+		event := test.f()
+		assert.Regexp(t, test.err, validateEvent(&event))
 	}
 }
 
 func TestDirectionOut(t *testing.T) {
-	publisher := newTestPublisher()
-	ppub, _ := NewPublisher(publisher, 1000, 1, false)
-	ppub.localIPs = []string{"192.145.2.4"}
+	processor := transProcessor{
+		localIPs:       []string{"192.145.2.4"},
+		ignoreOutgoing: false,
+		name:           "test",
+	}
 
-	event := common.MapStr{
-		"src": &common.Endpoint{
-			IP:      "192.145.2.4",
-			Port:    3267,
-			Name:    "server1",
-			Cmdline: "proc1 start",
-			Proc:    "proc1",
-		},
-		"dst": &common.Endpoint{
-			IP:      "192.145.2.5",
-			Port:    32232,
-			Name:    "server2",
-			Cmdline: "proc2 start",
-			Proc:    "proc2",
+	event := beat.Event{
+		Timestamp: time.Now(),
+		Fields: common.MapStr{
+			"type": "test",
+			"src": &common.Endpoint{
+				IP:      "192.145.2.4",
+				Port:    3267,
+				Name:    "server1",
+				Cmdline: "proc1 start",
+				Proc:    "proc1",
+			},
+			"dst": &common.Endpoint{
+				IP:      "192.145.2.5",
+				Port:    32232,
+				Name:    "server2",
+				Cmdline: "proc2 start",
+				Proc:    "proc2",
+			},
 		},
 	}
 
-	assert.True(t, ppub.normalizeTransAddr(event))
-	assert.True(t, event["client_ip"] == "192.145.2.4")
-	assert.True(t, event["direction"] == "out")
+	if res, _ := processor.Run(&event); res == nil {
+		t.Fatalf("event has been filtered out")
+	}
+	assert.True(t, event.Fields["client_ip"] == "192.145.2.4")
+	assert.True(t, event.Fields["direction"] == "out")
 }
 
 func TestDirectionIn(t *testing.T) {
-	publisher := newTestPublisher()
-	ppub, _ := NewPublisher(publisher, 1000, 1, false)
-	ppub.localIPs = []string{"192.145.2.5"}
+	processor := transProcessor{
+		localIPs:       []string{"192.145.2.5"},
+		ignoreOutgoing: false,
+		name:           "test",
+	}
 
-	event := common.MapStr{
-		"src": &common.Endpoint{
-			IP:      "192.145.2.4",
-			Port:    3267,
-			Name:    "server1",
-			Cmdline: "proc1 start",
-			Proc:    "proc1",
-		},
-		"dst": &common.Endpoint{
-			IP:      "192.145.2.5",
-			Port:    32232,
-			Name:    "server2",
-			Cmdline: "proc2 start",
-			Proc:    "proc2",
+	event := beat.Event{
+		Timestamp: time.Now(),
+		Fields: common.MapStr{
+			"type": "test",
+			"src": &common.Endpoint{
+				IP:      "192.145.2.4",
+				Port:    3267,
+				Name:    "server1",
+				Cmdline: "proc1 start",
+				Proc:    "proc1",
+			},
+			"dst": &common.Endpoint{
+				IP:      "192.145.2.5",
+				Port:    32232,
+				Name:    "server2",
+				Cmdline: "proc2 start",
+				Proc:    "proc2",
+			},
 		},
 	}
 
-	assert.True(t, ppub.normalizeTransAddr(event))
-	assert.True(t, event["client_ip"] == "192.145.2.4")
-	assert.True(t, event["direction"] == "in")
+	if res, _ := processor.Run(&event); res == nil {
+		t.Fatalf("event has been filtered out")
+	}
+	assert.True(t, event.Fields["client_ip"] == "192.145.2.4")
+	assert.True(t, event.Fields["direction"] == "in")
 }
 
 func newTestPublisher() *publisher.BeatPublisher {
@@ -121,29 +147,37 @@ func newTestPublisher() *publisher.BeatPublisher {
 }
 
 func TestNoDirection(t *testing.T) {
-	publisher := newTestPublisher()
-	ppub, _ := NewPublisher(publisher, 1000, 1, false)
-	ppub.localIPs = []string{"192.145.2.6"}
+	processor := transProcessor{
+		localIPs:       []string{"192.145.2.6"},
+		ignoreOutgoing: false,
+		name:           "test",
+	}
 
-	event := common.MapStr{
-		"src": &common.Endpoint{
-			IP:      "192.145.2.4",
-			Port:    3267,
-			Name:    "server1",
-			Cmdline: "proc1 start",
-			Proc:    "proc1",
-		},
-		"dst": &common.Endpoint{
-			IP:      "192.145.2.5",
-			Port:    32232,
-			Name:    "server2",
-			Cmdline: "proc2 start",
-			Proc:    "proc2",
+	event := beat.Event{
+		Timestamp: time.Now(),
+		Fields: common.MapStr{
+			"type": "test",
+			"src": &common.Endpoint{
+				IP:      "192.145.2.4",
+				Port:    3267,
+				Name:    "server1",
+				Cmdline: "proc1 start",
+				Proc:    "proc1",
+			},
+			"dst": &common.Endpoint{
+				IP:      "192.145.2.5",
+				Port:    32232,
+				Name:    "server2",
+				Cmdline: "proc2 start",
+				Proc:    "proc2",
+			},
 		},
 	}
 
-	assert.True(t, ppub.normalizeTransAddr(event))
-	assert.True(t, event["client_ip"] == "192.145.2.4")
-	_, ok := event["direction"]
+	if res, _ := processor.Run(&event); res == nil {
+		t.Fatalf("event has been filtered out")
+	}
+	assert.True(t, event.Fields["client_ip"] == "192.145.2.4")
+	_, ok := event.Fields["direction"]
 	assert.False(t, ok)
 }


### PR DESCRIPTION
- Use packetbeat protocols to publish beat.Event to new pipeline
- Move flows to new publisher pipeline
- Do not drop events on publish, if input is via pcap file (stabilize system
  tests with potential large number of transactions)
- add fields, tags and processor settings to flows and analyzer plugins (requires docs updates)

Followup: I noticed quite some duplication in protocols unit tests, for capturing/handling transactions. Some additional cleanup providing helpers common functionality for protocols unit-testing will be provided.