### PR TITLE
Rename heartbeat packages

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -22,6 +22,8 @@ https://github.com/elastic/beats/compare/v6.0.0-alpha2...master[Check the HEAD d
 
 *Heartbeat*
 
+- Renamed the heartbeat RPM/DEB name to `heartbeat-elastic`. {pull}4601[4601]
+
 *Metricbeat*
 - Change all `system.cpu.*.pct` metrics to be scaled by the number of CPU cores.
   This will make the CPU usage percentages from the system cpu metricset consistent

--- a/auditbeat/docs/index.asciidoc
+++ b/auditbeat/docs/index.asciidoc
@@ -6,6 +6,7 @@ include::../../libbeat/docs/version.asciidoc[]
 :version: {stack-version}
 :beatname_lc: auditbeat
 :beatname_uc: Auditbeat
+:beatname_pkg: {beatname_lc}
 :security: X-Pack Security
 :dockerimage: docker.elastic.co/beats/{beatname_lc}:{version}
 

--- a/dev-tools/packer/platforms/centos/init.j2
+++ b/dev-tools/packer/platforms/centos/init.j2
@@ -1,13 +1,13 @@
 #!/bin/bash
 #
-# {{.beat_name}}          {{.beat_name}} shipper
+# {{.beat_pkg_name}}          {{.beat_name}} shipper
 #
 # chkconfig: 2345 98 02
 # description: Starts and stops a single {{.beat_name}} instance on this system
 #
 
 ### BEGIN INIT INFO
-# Provides:          {{.beat_name}}
+# Provides:          {{.beat_pkg_name}}
 # Required-Start:    $local_fs $network $syslog
 # Required-Stop:     $local_fs $network $syslog
 # Default-Start:     2 3 4 5
@@ -22,8 +22,8 @@
 PATH=/usr/bin:/sbin:/bin:/usr/sbin
 export PATH
 
-[ -f /etc/sysconfig/{{.beat_name}} ] && . /etc/sysconfig/{{.beat_name}}
-pidfile=${PIDFILE-/var/run/{{.beat_name}}.pid}
+[ -f /etc/sysconfig/{{.beat_pkg_name}} ] && . /etc/sysconfig/{{.beat_pkg_name}}
+pidfile=${PIDFILE-/var/run/{{.beat_pkg_name}}.pid}
 agent=${BEATS_AGENT-/usr/share/{{.beat_name}}/bin/{{.beat_name}}}
 args="-c /etc/{{.beat_name}}/{{.beat_name}}.yml -path.home /usr/share/{{.beat_name}} -path.config /etc/{{.beat_name}} -path.data /var/lib/{{.beat_name}} -path.logs /var/log/{{.beat_name}}"
 test_args="-e -configtest"

--- a/dev-tools/packer/platforms/centos/run.sh.j2
+++ b/dev-tools/packer/platforms/centos/run.sh.j2
@@ -5,7 +5,7 @@ set -e
 cd /build
 
 # the init scripts needs to have the right name
-cp ${RUNID}.init /tmp/{{.beat_name}}.init
+cp ${RUNID}.init /tmp/{{.beat_pkg_name}}.init
 
 # create script to reload systemd config
 echo "#!/bin/bash" > /tmp/systemd-daemon-reload.sh
@@ -22,13 +22,13 @@ RPM_VERSION=`echo ${VERSION} | sed 's/-/_/g'`
 
 # create rpm
 fpm --force -s dir -t rpm \
-        -n {{.beat_name}} -v ${RPM_VERSION} \
+        -n {{.beat_pkg_name}} -v ${RPM_VERSION} \
         --architecture {{.rpm_arch}} \
         --vendor "{{.beat_vendor}}"  \
         --license "{{.beat_license}}"  \
         --description "{{.beat_description}}" \
         --url {{.beat_url}} \
-        --rpm-init /tmp/{{.beat_name}}.init \
+        --rpm-init /tmp/{{.beat_pkg_name}}.init \
         --after-install /tmp/systemd-daemon-reload.sh \
         --config-files /etc/{{.beat_name}}/{{.beat_name}}.yml \
         homedir/=/usr/share/{{.beat_name}} \
@@ -37,14 +37,14 @@ fpm --force -s dir -t rpm \
         {{.beat_name}}-linux.yml=/etc/{{.beat_name}}/{{.beat_name}}.yml \
         {{.beat_name}}-linux.reference.yml=/etc/{{.beat_name}}/{{.beat_name}}.reference.yml \
         fields.yml=/etc/{{.beat_name}}/fields.yml \
-        ${RUNID}.service=/lib/systemd/system/{{.beat_name}}.service \
+        ${RUNID}.service=/lib/systemd/system/{{.beat_pkg_name}}.service \
         god-linux-{{.arch}}=/usr/share/{{.beat_name}}/bin/{{.beat_name}}-god
 
 
 
 # rename so that the filename respects semver rules
 mkdir -p upload
-mv {{.beat_name}}-${RPM_VERSION}-1.{{.rpm_arch}}.rpm upload/{{.beat_name}}-${VERSION}-{{.rpm_arch}}.rpm
+mv {{.beat_pkg_name}}-${RPM_VERSION}-1.{{.rpm_arch}}.rpm upload/{{.beat_name}}-${VERSION}-{{.rpm_arch}}.rpm
 echo "Created upload/{{.beat_name}}-${VERSION}-{{.rpm_arch}}.rpm"
 
 # create sha1 file

--- a/dev-tools/packer/platforms/debian/init.j2
+++ b/dev-tools/packer/platforms/debian/init.j2
@@ -1,6 +1,6 @@
 #!/bin/sh
 ### BEGIN INIT INFO
-# Provides:          {{.beat_name}}
+# Provides:          {{.beat_pkg_name}}
 # Required-Start:    $local_fs $network $syslog
 # Required-Stop:     $local_fs $network $syslog
 # Default-Start:     2 3 4 5
@@ -19,7 +19,7 @@ NAME="{{.beat_name}}"
 DAEMON=/usr/share/{{.beat_name}}/bin/$NAME
 DAEMON_ARGS="-c /etc/{{.beat_name}}/{{.beat_name}}.yml -path.home /usr/share/{{.beat_name}} -path.config /etc/{{.beat_name}} -path.data /var/lib/{{.beat_name}} -path.logs /var/log/{{.beat_name}}"
 TEST_ARGS="-e -configtest"
-PIDFILE=/var/run/{{.beat_name}}.pid
+PIDFILE=/var/run/{{.beat_pkg_name}}.pid
 WRAPPER="/usr/share/{{.beat_name}}/bin/{{.beat_name}}-god"
 BEAT_USER="root"
 WRAPPER_ARGS="-r / -n -p $PIDFILE"
@@ -29,7 +29,7 @@ SCRIPTNAME=/etc/init.d/$NAME
 [ -x "$DAEMON" ] || exit 0
 
 # Read configuration variable file if it is present
-[ -r /etc/default/$NAME ] && . /etc/default/$NAME
+[ -r /etc/default/{{.beat_pkg_name}} ] && . /etc/default/{{.beat_pkg_name}}
 
 [ "$BEAT_USER" != "root" ] && WRAPPER_ARGS="$WRAPPER_ARGS -u $BEAT_USER"
 USER_WRAPPER="su"

--- a/dev-tools/packer/platforms/debian/run.sh.j2
+++ b/dev-tools/packer/platforms/debian/run.sh.j2
@@ -5,7 +5,7 @@ set -e
 cd /build
 
 # the init scripts needs to have the right name
-cp ${RUNID}.init /tmp/{{.beat_name}}.init
+cp ${RUNID}.init /tmp/{{.beat_pkg_name}}.init
 
 # create script to reload systemd config
 echo "#!/bin/bash" > /tmp/systemd-daemon-reload.sh
@@ -19,13 +19,13 @@ fi
 
 # create deb
 fpm --force -s dir -t deb \
-        -n {{.beat_name}} -v ${VERSION} \
+        -n {{.beat_pkg_name}} -v ${VERSION} \
         --vendor "{{.beat_vendor}}"  \
         --license "{{.beat_license}}"  \
         --architecture {{.deb_arch}} \
         --description "{{.beat_description}}" \
         --url {{.beat_url}} \
-        --deb-init /tmp/{{.beat_name}}.init \
+        --deb-init /tmp/{{.beat_pkg_name}}.init \
         --after-install /tmp/systemd-daemon-reload.sh \
         --config-files /etc/{{.beat_name}}/{{.beat_name}}.yml \
         homedir/=/usr/share/{{.beat_name}} \
@@ -34,12 +34,12 @@ fpm --force -s dir -t deb \
         {{.beat_name}}-linux.yml=/etc/{{.beat_name}}/{{.beat_name}}.yml \
         {{.beat_name}}-linux.reference.yml=/etc/{{.beat_name}}/{{.beat_name}}.reference.yml \
         fields.yml=/etc/{{.beat_name}}/fields.yml \
-        ${RUNID}.service=/lib/systemd/system/{{.beat_name}}.service \
+        ${RUNID}.service=/lib/systemd/system/{{.beat_pkg_name}}.service \
         god-linux-{{.arch}}=/usr/share/{{.beat_name}}/bin/{{.beat_name}}-god
 
 # move and rename to use the elastic conventions
 mkdir -p upload
-mv {{.beat_name}}_${VERSION}_{{.deb_arch}}.deb upload/{{.beat_name}}-${VERSION}-{{.deb_arch}}.deb
+mv {{.beat_pkg_name}}_${VERSION}_{{.deb_arch}}.deb upload/{{.beat_name}}-${VERSION}-{{.deb_arch}}.deb
 echo "Created upload/{{.beat_name}}-${VERSION}-{{.deb_arch}}.deb"
 
 # create sha1 file

--- a/filebeat/docs/index.asciidoc
+++ b/filebeat/docs/index.asciidoc
@@ -15,6 +15,7 @@ include::../../libbeat/docs/version.asciidoc[]
 :version: {stack-version}
 :beatname_lc: filebeat
 :beatname_uc: Filebeat
+:beatname_pkg: {beatname_lc}
 :security: X-Pack Security
 :dockerimage: docker.elastic.co/beats/{beatname_lc}:{version}
 

--- a/heartbeat/Makefile
+++ b/heartbeat/Makefile
@@ -1,4 +1,5 @@
 BEAT_NAME=heartbeat
+BEAT_PACKAGE_NAME=heartbeat-elastic
 BEAT_DESCRIPTION?=Ping remote services for availability and log results to Elasticsearch or send to Logstash.
 SYSTEM_TESTS=true
 TEST_ENVIRONMENT=false

--- a/heartbeat/docs/getting-started.asciidoc
+++ b/heartbeat/docs/getting-started.asciidoc
@@ -241,14 +241,14 @@ start Heartbeat in the foreground.
 
 ["source","sh",subs="attributes"]
 ----------------------------------------------------------------------
-sudo /etc/init.d/heartbeat start
+sudo /etc/init.d/heartbeat-elastic start
 ----------------------------------------------------------------------
 
 *rpm:*
 
 ["source","sh",subs="attributes"]
 ----------------------------------------------------------------------
-sudo /etc/init.d/heartbeat start
+sudo /etc/init.d/heartbeat-elastic start
 ----------------------------------------------------------------------
 
 *mac:*

--- a/heartbeat/docs/index.asciidoc
+++ b/heartbeat/docs/index.asciidoc
@@ -15,6 +15,7 @@ include::../../libbeat/docs/version.asciidoc[]
 :version: {stack-version}
 :beatname_lc: heartbeat
 :beatname_uc: Heartbeat
+:beatname_pkg: heartbeat-elastic
 :security: X-Pack Security
 :dockerimage: docker.elastic.co/beats/{beatname_lc}:{version}
 

--- a/libbeat/docs/repositories.asciidoc
+++ b/libbeat/docs/repositories.asciidoc
@@ -70,34 +70,19 @@ the following:
 Simply delete the `deb-src` entry from the `/etc/apt/sources.list` file, and the installation should work as expected.
 ==================================================
 
-ifeval::["{beatname_uc}"=="Heartbeat"]
-
-. On Debian or Ubuntu, pin the repository before installing to ensure that the
-correct Elastic Heartbeat package is installed. To do this, edit 
-`/etc/apt/preferences` (or `/etc/apt/preferences.d/heartbeat`) as follows:
-+
-[source,shell]
---------------------------------------------------
-Package: heartbeat
-Pin: origin artifacts.elastic.co
-Pin-Priority: 700
---------------------------------------------------
-
-endif::[]
-
 . Run `apt-get update`, and the repository is ready for use. For example, you can
 install {beatname_uc} by running:
 +
 ["source","sh",subs="attributes"]
 --------------------------------------------------
-sudo apt-get update && sudo apt-get install {beatname_lc}
+sudo apt-get update && sudo apt-get install {beatname_pkg}
 --------------------------------------------------
 
 . To configure the Beat to start automatically during boot, run:
 +
 ["source","sh",subs="attributes"]
 --------------------------------------------------
-sudo update-rc.d {beatname_lc} defaults 95 10
+sudo update-rc.d {beatname_pkg} defaults 95 10
 --------------------------------------------------
 
 endif::[]
@@ -142,14 +127,14 @@ running:
 +
 ["source","sh",subs="attributes"]
 --------------------------------------------------
-sudo yum install {beatname_lc}
+sudo yum install {beatname_pkg}
 --------------------------------------------------
 
 . To configure the Beat to start automatically during boot, run:
 +
 ["source","sh",subs="attributes"]
 --------------------------------------------------
-sudo chkconfig --add {beatname_lc}
+sudo chkconfig --add {beatname_pkg}
 --------------------------------------------------
 
 endif::[]

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -3,6 +3,7 @@
 BEAT_NAME?=libbeat ## @packaging Name of the application
 BEAT_DESCRIPTION?=Sends events to Elasticsearch or Logstash ## @packaging Description of the application
 BEAT_PATH?=github.com/elastic/beats/${BEAT_NAME}
+BEAT_PACKAGE_NAME?=${BEAT_NAME}
 BEAT_URL?=https://www.elastic.co/products/beats/${BEAT_NAME} ## @packaging Link to the homepage of the application
 BEAT_DOC_URL?=https://www.elastic.co/guide/en/beats/${BEAT_NAME}/current/index.html ## @packaging Link to the user documentation of the application
 BEAT_LICENSE?=ASL 2.0 ## @packaging Software license of the application
@@ -424,6 +425,7 @@ package: package-setup
 	echo "beat_name: ${BEAT_NAME}" > ${BUILD_DIR}/package.yml
 	echo "beat_url: ${BEAT_URL}" >> ${BUILD_DIR}/package.yml
 	echo "beat_repo: ${BEAT_PATH}" >> ${BUILD_DIR}/package.yml
+	echo "beat_pkg_name: ${BEAT_PACKAGE_NAME}" >> ${BUILD_DIR}/package.yml
 	echo "beat_description: ${BEAT_DESCRIPTION}" >> ${BUILD_DIR}/package.yml
 	echo "beat_vendor: ${BEAT_VENDOR}" >> ${BUILD_DIR}/package.yml
 	echo "beat_license: ${BEAT_LICENSE}" >> ${BUILD_DIR}/package.yml

--- a/metricbeat/docs/index.asciidoc
+++ b/metricbeat/docs/index.asciidoc
@@ -11,6 +11,7 @@ include::../../libbeat/docs/version.asciidoc[]
 :version: {stack-version}
 :beatname_lc: metricbeat
 :beatname_uc: Metricbeat
+:beatname_pkg: {beatname_lc}
 :security: X-Pack Security
 :monitoringdoc: https://www.elastic.co/guide/en/x-pack/current
 :dockerimage: docker.elastic.co/beats/{beatname_lc}:{version}

--- a/packetbeat/docs/index.asciidoc
+++ b/packetbeat/docs/index.asciidoc
@@ -16,6 +16,7 @@ include::../../libbeat/docs/version.asciidoc[]
 :version: {stack-version}
 :beatname_lc: packetbeat
 :beatname_uc: Packetbeat
+:beatname_pkg: {beatname_lc}
 :security: X-Pack Security
 :dockerimage: docker.elastic.co/beats/{beatname_lc}:{version}
 

--- a/winlogbeat/docs/index.asciidoc
+++ b/winlogbeat/docs/index.asciidoc
@@ -14,6 +14,7 @@ include::../../libbeat/docs/version.asciidoc[]
 :version: {stack-version}
 :beatname_lc: winlogbeat
 :beatname_uc: Winlogbeat
+:beatname_pkg: {beatname_lc}
 :security: X-Pack Security
 
 include::./overview.asciidoc[]


### PR DESCRIPTION
Due to a naming conflict on Debian (see #3765), we rename the name of the
RPM and DEB packages to be `heartbeat-elastic`. The artifacts that we offer for
download are still named `heartbeat`, only the package names in the repositories
will be `heartbeat-elastic`.

The init scripts and the service files are renamed, as well as the PID files
and setting files (e.g. `/etc/default/heartbeat-elastic`). The binaries, config
files, etc are not, so the changes are minimal.

Fixes #3765.

ToDOs:

* [x] Changelog
* [x] Docs updates