### PR TITLE
Use the noxpack version of the env for Metricbeat

### DIFF
--- a/metricbeat/Makefile
+++ b/metricbeat/Makefile
@@ -5,6 +5,7 @@ BEAT_NAME?=metricbeat
 BEAT_DESCRIPTION?=Metricbeat sends metrics to Elasticsearch.
 SYSTEM_TESTS?=true
 TEST_ENVIRONMENT?=true
+TESTING_ENVIRONMENT?=snapshot-noxpack
 GOPACKAGES=$(shell go list ${BEAT_PATH}/... | grep -v /vendor/)
 ES_BEATS?=..
 


### PR DESCRIPTION
This is done only in an attempt to speed up the tests (by avoiding the
Kibana optimizing step). Once we use the snapshot docker images, we should switch
back to xpack.

Not tested yet, opening PR to see if it improves  the test times.