### PR TITLE
Add support for keyword in dynamic fields

### DIFF
--- a/libbeat/template/field.go
+++ b/libbeat/template/field.go
@@ -139,7 +139,8 @@ func (f *Field) object() common.MapStr {
 
 	dynProperties := f.getDefaultProperties()
 
-	if f.ObjectType == "text" {
+	switch f.ObjectType {
+	case "text":
 		dynProperties["type"] = "text"
 
 		if f.esVersion.IsMajor(2) {
@@ -147,14 +148,10 @@ func (f *Field) object() common.MapStr {
 			dynProperties["index"] = "analyzed"
 		}
 		f.addDynamicTemplate(dynProperties, "string")
-	}
-
-	if f.ObjectType == "long" {
+	case "long":
 		dynProperties["type"] = f.ObjectType
 		f.addDynamicTemplate(dynProperties, "long")
-	}
-
-	if f.ObjectType == "keyword" {
+	case "keyword":
 		dynProperties["type"] = f.ObjectType
 		f.addDynamicTemplate(dynProperties, "string")
 	}

--- a/libbeat/template/field_test.go
+++ b/libbeat/template/field_test.go
@@ -139,3 +139,61 @@ func TestField(t *testing.T) {
 		assert.Equal(t, test.output, output)
 	}
 }
+
+func TestDynamicTemplate(t *testing.T) {
+
+	tests := []struct {
+		field  Field
+		method func(f Field) common.MapStr
+		output common.MapStr
+	}{
+		{
+			field: Field{
+				Type: "object", ObjectType: "keyword",
+				Name: "context",
+			},
+			method: func(f Field) common.MapStr { return f.object() },
+			output: common.MapStr{
+				"context": common.MapStr{
+					"mapping":            common.MapStr{"type": "keyword"},
+					"match_mapping_type": "string",
+					"path_match":         "context.*",
+				},
+			},
+		},
+		{
+			field: Field{
+				Type: "object", ObjectType: "long",
+				path: "language", Name: "english",
+			},
+			method: func(f Field) common.MapStr { return f.object() },
+			output: common.MapStr{
+				"language.english": common.MapStr{
+					"mapping":            common.MapStr{"type": "long"},
+					"match_mapping_type": "long",
+					"path_match":         "language.english.*",
+				},
+			},
+		},
+		{
+			field: Field{
+				Type: "object", ObjectType: "text",
+				path: "language", Name: "english",
+			},
+			method: func(f Field) common.MapStr { return f.object() },
+			output: common.MapStr{
+				"language.english": common.MapStr{
+					"mapping":            common.MapStr{"type": "text"},
+					"match_mapping_type": "string",
+					"path_match":         "language.english.*",
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		dynamicTemplates = nil
+		test.method(test.field)
+		assert.Equal(t, test.output, dynamicTemplates[0])
+	}
+}


### PR DESCRIPTION
This PR allows fields under a namespace to be set to keyword instead of auto detection from elasticsearch.

* Fixes issue where dynamic fields needed a path in addition to a name, means it did not work properly on the top level
* Add tests for dynamic fields.