### PR TITLE
Setup 5.5.0 docs state to "released"

### DIFF
--- a/libbeat/docs/version.asciidoc
+++ b/libbeat/docs/version.asciidoc
@@ -1,4 +1,4 @@
 :stack-version: 5.5.0
 :doc-branch: 5.5
 :go-version: 1.7.6
-:release-state: unreleased
+:release-state: released


### PR DESCRIPTION
This should be merged only in the day of the release.

cc @andrewkroh 