### PR TITLE
Update running-on-docker.asciidoc

### DIFF
--- a/metricbeat/docs/running-on-docker.asciidoc
+++ b/metricbeat/docs/running-on-docker.asciidoc
@@ -19,7 +19,7 @@ docker run \
   --volume=/sys/fs/cgroup:/hostfs/sys/fs/cgroup:ro \ <2>
   --volume=/:/hostfs:ro \ <3>
   --net=host <4>
-  {dockerimage} -system.hostfs=/hostfs
+  {dockerimage} metricbeat -e -system.hostfs=/hostfs
 ----
 
 <1> Metricbeat's <<metricbeat-module-system,system module>> collects much of its data through the Linux proc


### PR DESCRIPTION
Add full command for metricbeat in the monitoring-host section.
In the metricbeat DockerFile, that use CMD, and not ENTRYPOINT.
It's must be input full command until the ENTRYPOINT instead of CMD.