### PR TITLE
Remove the HTTP endpoint from configuration

### DIFF
--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -677,7 +677,7 @@ output.elasticsearch:
 
 #============================== Kibana =====================================
 
-# Starting with Beats version 6.0.0, the dashboards are loaded via the Kibana API. 
+# Starting with Beats version 6.0.0, the dashboards are loaded via the Kibana API.
 # This requires a Kibana endpoint configuration.
 setup.kibana:
 
@@ -728,19 +728,6 @@ setup.kibana:
   #ssl.curve_types: []
 
 
-
-#================================ HTTP Endpoint ======================================
-# Each beat can expose internal data points through a http endpoint. For security
-# reason the endpoint is disabled by default. This feature is currently in beta.
-
-# Defines if http endpoint is enabled
-#http.enabled: false
-
-# Host to expose the http endpoint to. It is recommended to use only localhost.
-#http.host: localhost
-
-# Port on which the http endpoint is exposed. Default is 5066
-#http.port: 5066
 
 #================================ Logging ======================================
 # There are three options for the log output: syslog, file, stderr.

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -1065,7 +1065,7 @@ output.elasticsearch:
 
 #============================== Kibana =====================================
 
-# Starting with Beats version 6.0.0, the dashboards are loaded via the Kibana API. 
+# Starting with Beats version 6.0.0, the dashboards are loaded via the Kibana API.
 # This requires a Kibana endpoint configuration.
 setup.kibana:
 
@@ -1116,19 +1116,6 @@ setup.kibana:
   #ssl.curve_types: []
 
 
-
-#================================ HTTP Endpoint ======================================
-# Each beat can expose internal data points through a http endpoint. For security
-# reason the endpoint is disabled by default. This feature is currently in beta.
-
-# Defines if http endpoint is enabled
-#http.enabled: false
-
-# Host to expose the http endpoint to. It is recommended to use only localhost.
-#http.host: localhost
-
-# Port on which the http endpoint is exposed. Default is 5066
-#http.port: 5066
 
 #================================ Logging ======================================
 # There are three options for the log output: syslog, file, stderr.

--- a/heartbeat/heartbeat.reference.yml
+++ b/heartbeat/heartbeat.reference.yml
@@ -832,7 +832,7 @@ output.elasticsearch:
 
 #============================== Kibana =====================================
 
-# Starting with Beats version 6.0.0, the dashboards are loaded via the Kibana API. 
+# Starting with Beats version 6.0.0, the dashboards are loaded via the Kibana API.
 # This requires a Kibana endpoint configuration.
 setup.kibana:
 
@@ -883,19 +883,6 @@ setup.kibana:
   #ssl.curve_types: []
 
 
-
-#================================ HTTP Endpoint ======================================
-# Each beat can expose internal data points through a http endpoint. For security
-# reason the endpoint is disabled by default. This feature is currently in beta.
-
-# Defines if http endpoint is enabled
-#http.enabled: false
-
-# Host to expose the http endpoint to. It is recommended to use only localhost.
-#http.host: localhost
-
-# Port on which the http endpoint is exposed. Default is 5066
-#http.port: 5066
 
 #================================ Logging ======================================
 # There are three options for the log output: syslog, file, stderr.

--- a/libbeat/_meta/config.reference.yml
+++ b/libbeat/_meta/config.reference.yml
@@ -618,7 +618,7 @@ output.elasticsearch:
 
 #============================== Kibana =====================================
 
-# Starting with Beats version 6.0.0, the dashboards are loaded via the Kibana API. 
+# Starting with Beats version 6.0.0, the dashboards are loaded via the Kibana API.
 # This requires a Kibana endpoint configuration.
 setup.kibana:
 
@@ -669,19 +669,6 @@ setup.kibana:
   #ssl.curve_types: []
 
 
-
-#================================ HTTP Endpoint ======================================
-# Each beat can expose internal data points through a http endpoint. For security
-# reason the endpoint is disabled by default. This feature is currently in beta.
-
-# Defines if http endpoint is enabled
-#http.enabled: false
-
-# Host to expose the http endpoint to. It is recommended to use only localhost.
-#http.host: localhost
-
-# Port on which the http endpoint is exposed. Default is 5066
-#http.port: 5066
 
 #================================ Logging ======================================
 # There are three options for the log output: syslog, file, stderr.

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -1056,7 +1056,7 @@ output.elasticsearch:
 
 #============================== Kibana =====================================
 
-# Starting with Beats version 6.0.0, the dashboards are loaded via the Kibana API. 
+# Starting with Beats version 6.0.0, the dashboards are loaded via the Kibana API.
 # This requires a Kibana endpoint configuration.
 setup.kibana:
 
@@ -1107,19 +1107,6 @@ setup.kibana:
   #ssl.curve_types: []
 
 
-
-#================================ HTTP Endpoint ======================================
-# Each beat can expose internal data points through a http endpoint. For security
-# reason the endpoint is disabled by default. This feature is currently in beta.
-
-# Defines if http endpoint is enabled
-#http.enabled: false
-
-# Host to expose the http endpoint to. It is recommended to use only localhost.
-#http.host: localhost
-
-# Port on which the http endpoint is exposed. Default is 5066
-#http.port: 5066
 
 #================================ Logging ======================================
 # There are three options for the log output: syslog, file, stderr.

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -1070,7 +1070,7 @@ output.elasticsearch:
 
 #============================== Kibana =====================================
 
-# Starting with Beats version 6.0.0, the dashboards are loaded via the Kibana API. 
+# Starting with Beats version 6.0.0, the dashboards are loaded via the Kibana API.
 # This requires a Kibana endpoint configuration.
 setup.kibana:
 
@@ -1121,19 +1121,6 @@ setup.kibana:
   #ssl.curve_types: []
 
 
-
-#================================ HTTP Endpoint ======================================
-# Each beat can expose internal data points through a http endpoint. For security
-# reason the endpoint is disabled by default. This feature is currently in beta.
-
-# Defines if http endpoint is enabled
-#http.enabled: false
-
-# Host to expose the http endpoint to. It is recommended to use only localhost.
-#http.host: localhost
-
-# Port on which the http endpoint is exposed. Default is 5066
-#http.port: 5066
 
 #================================ Logging ======================================
 # There are three options for the log output: syslog, file, stderr.

--- a/winlogbeat/winlogbeat.reference.yml
+++ b/winlogbeat/winlogbeat.reference.yml
@@ -647,7 +647,7 @@ output.elasticsearch:
 
 #============================== Kibana =====================================
 
-# Starting with Beats version 6.0.0, the dashboards are loaded via the Kibana API. 
+# Starting with Beats version 6.0.0, the dashboards are loaded via the Kibana API.
 # This requires a Kibana endpoint configuration.
 setup.kibana:
 
@@ -698,19 +698,6 @@ setup.kibana:
   #ssl.curve_types: []
 
 
-
-#================================ HTTP Endpoint ======================================
-# Each beat can expose internal data points through a http endpoint. For security
-# reason the endpoint is disabled by default. This feature is currently in beta.
-
-# Defines if http endpoint is enabled
-#http.enabled: false
-
-# Host to expose the http endpoint to. It is recommended to use only localhost.
-#http.host: localhost
-
-# Port on which the http endpoint is exposed. Default is 5066
-#http.port: 5066
 
 #================================ Logging ======================================
 # There are three options for the log output: syslog, file, stderr.


### PR DESCRIPTION
The monitoring feature is not ready yet, so we decided to leave the
HTTP endpoint undocumented for now.