### PR TITLE
New beats-dashboards snapshot URL

### DIFF
--- a/libbeat/dashboards/config.go
+++ b/libbeat/dashboards/config.go
@@ -19,5 +19,5 @@ var defaultDashboardsConfig = DashboardsConfig{
 }
 var (
 	defaultURLPattern  = "https://artifacts.elastic.co/downloads/beats/beats-dashboards/beats-dashboards-%s.zip"
-	snapshotURLPattern = "https://beats-nightlies.s3.amazonaws.com/dashboards/beats-dashboards-%s-SNAPSHOT.zip"
+	snapshotURLPattern = "https://snapshots.elastic.co/downloads/beats/beats-dashboards/beats-dashboards-%s-SNAPSHOT.zip"
 )


### PR DESCRIPTION
The snapshot URL was pointing to the beats-nightly S3 bucket, which we plan to retire.
This uses a more stable URL.