### PR TITLE
correct format for memory module in dockerbeat

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -143,6 +143,7 @@ https://github.com/elastic/beats/compare/v6.0.0-alpha1...v6.0.0-alpha2[View comm
 
 *Metricbeat*
 
+- Set correct format for percent fields in memory module. {pull}4619[4619]
 - Fix a debug statement that said a module wrapper had stopped when it hadn't. {pull}4264[4264]
 - Use MemAvailable value from /proc/meminfo on Linux 3.14. {pull}4316[4316]
 - Fix panic when events were dropped by filters. {issue}4327[4327]

--- a/metricbeat/docs/fields.asciidoc
+++ b/metricbeat/docs/fields.asciidoc
@@ -2063,6 +2063,8 @@ Total memory resident set size.
 
 type: scaled_float
 
+format: percentage
+
 Memory resident set size percentage.
 
 
@@ -2087,6 +2089,8 @@ Max memory usage.
 === docker.memory.usage.pct
 
 type: scaled_float
+
+format: percentage
 
 Memory usage percentage.
 

--- a/metricbeat/module/docker/memory/_meta/fields.yml
+++ b/metricbeat/module/docker/memory/_meta/fields.yml
@@ -25,6 +25,7 @@
             Total memory resident set size.
         - name: pct
           type: scaled_float
+          format: percentage
           description: >
             Memory resident set size percentage.
     - name: usage
@@ -39,6 +40,7 @@
             Max memory usage.
         - name: pct
           type: scaled_float
+          format: percentage
           description: >
             Memory usage percentage.
         - name: total


### PR DESCRIPTION
As discussed [here](https://discuss.elastic.co/t/docker-fields-documentation/91225), `docker.memory.usage.pct` in dockerbeat was off by a factor of 100. As per @andrewkroh, I updated the fields.