### PR TITLE
Backport to 5.5: #4530 #4542 #4547 #4628 #4617

### DIFF
--- a/libbeat/docs/communitybeats.asciidoc
+++ b/libbeat/docs/communitybeats.asciidoc
@@ -50,6 +50,7 @@ https://github.com/kozlice/phpfpmbeat[phpfpmbeat]:: Reads status from PHP-FPM.
 https://github.com/joshuar/pingbeat[pingbeat]:: Sends ICMP pings to a list
 of targets and stores the round trip time (RTT) in Elasticsearch.
 https://github.com/carlpett/prombeat[prombeat]:: Indexes https://prometheus.io[Prometheus] metrics.
+https://github.com/infonova/prometheusbeat[prometheusbeat]:: Send Prometheus metrics to Elasticsearch via the remote write feature.
 https://github.com/hartfordfive/protologbeat[protologbeat]:: Accepts structured and unstructured logs via UDP or TCP.  Can also be used to receive syslog messages or GELF formatted messages. (To be used as a successor to udplogbeat)
 https://github.com/voigt/redditbeat[redditbeat]:: Collects new Reddit Submissions of one or multiple Subreddits.
 https://github.com/chrsblck/redisbeat[redisbeat]:: Used for Redis monitoring.

--- a/libbeat/docs/gettingstarted.asciidoc
+++ b/libbeat/docs/gettingstarted.asciidoc
@@ -1,5 +1,5 @@
 [[getting-started]]
-== Getting Started with Beats and the Elastic Stack 
+== Getting Started with Beats and the Elastic Stack
 
 Looking for an "ELK tutorial" that shows how to set up the Elastic stack for Beats? You've
 come to the right place. The topics in this section describe how to install and configure
@@ -12,8 +12,8 @@ A regular _Beats setup_ consists of:
  * Kibana for the UI. See <<kibana-installation>>.
  * One or more Beats. You install the Beats on your servers to capture operational data. See <<installing-beats>>.
  * Kibana dashboards for visualizing the data.
- 
-See the https://www.elastic.co/support/matrix[Elastic Support Matrix] for information 
+
+See the https://www.elastic.co/support/matrix[Elastic Support Matrix] for information
 about supported operating systems and product compatibility.
 
 NOTE: To get started, you can install Elasticsearch and Kibana on a
@@ -173,10 +173,10 @@ The simplest architecture for the Beats platform setup consists of one or more B
 Elasticsearch, and Kibana. This architecture is easy to get started
 with and sufficient for networks with low traffic. It also uses the minimum amount of
 servers: a single machine running Elasticsearch and Kibana. The Beats
-insert the transactions directly into the Elasticsearch instance. 
+insert the transactions directly into the Elasticsearch instance.
 
 If you want to perform additional processing or buffering on the data, however,
-you'll want to install Logstash. 
+you'll want to install Logstash.
 
 An important advantage to this approach is that you can
 use Logstash to modify the data captured by Beats in any way you like. You can also
@@ -267,44 +267,17 @@ endif::[]
 ==== Setting Up Logstash
 
 In this setup, the Beat sends events to Logstash. Logstash receives
-these events by using the {logstashdoc}/plugins-inputs-beats.html[Beats input plugin for Logstash] and then sends the transaction to Elasticsearch by using the
-{logstashdoc}/plugins-outputs-elasticsearch.html[Elasticsearch
-output plugin for Logstash]. The Elasticsearch output plugin uses the bulk API, making
-indexing very efficient.
+these events by using the
+{logstashdoc}/plugins-inputs-beats.html[Beats input plugin for Logstash]
+and then sends the transaction to Elasticsearch by using the
+{logstashdoc}/plugins-outputs-elasticsearch.html[Elasticsearch output plugin for Logstash].
+The Elasticsearch output plugin uses the bulk API, making indexing very efficient.
 
-To set up Logstash:
+To set up Logstash, you create a Logstash pipeline configuration file that
+configures Logstash to listen on port 5044 for incoming Beats connections
+and to index into Elasticsearch.  For example, you can save the following
+example configuration to a file called `logstash.conf`:
 
-. Make sure you have the latest compatible version of the Beats input plugin for
-Logstash installed.
-+
-The Beats input plugin requires Logstash 1.5.4 or later. If you are using
-Logstash 1.5.4, you must install the Beats input plugin before applying this
-configuration because the plugin is not shipped with 1.5.4. 
-+
-To install
-the required plugin, run the following command inside the logstash directory
-(for deb and rpm installs, the directory is `/opt/logstash`).
-+
-*deb, rpm, and mac:*
-+
-["source","sh",subs="attributes,callouts"]
-----------------------------------------------------------------------
-./bin/logstash-plugin install logstash-input-beats
-----------------------------------------------------------------------
-+
-*win:*
-+
-["source","sh",subs="attributes,callouts"]
-----------------------------------------------------------------------
-bin\logstash-plugin install logstash-input-beats
-----------------------------------------------------------------------
-
-. Configure Logstash to listen on port 5044 for incoming Beats connections
-and to index into Elasticsearch. You configure Logstash by creating a
-configuration file. For example, you can save the following example configuration
-to a file called `logstash.conf`:
-+
---
 [source,ruby]
 ------------------------------------------------------------------------------
 input {
@@ -312,6 +285,12 @@ input {
     port => 5044
   }
 }
+
+# The filter part of this file is commented out to indicate that it is
+# optional.
+# filter {
+#
+# }
 
 output {
   elasticsearch {
@@ -329,19 +308,21 @@ name to a date based on the Logstash `@timestamp` field. For example:
 <2> `%{[@metadata][type]}` sets the document type based on the value of the `type`
 metadata field.
 
-Logstash uses this configuration to index events in Elasticsearch in the same
-way that the Beat would, but you get additional buffering and other capabilities
-provided by Logstash.
---
+When you run Logstash with this configuration, it indexes events into
+Elasticsearch in the same way that the Beat would, but you get access to other
+capabilities provided by Logstash for collecting, enriching, and transforming
+data. See the {logstashdoc}/introduction.html[Logstash introduction] for more
+information about these capabilities.
 
-To use this setup, you'll also need to configure your Beat to use Logstash. For more information, see the documentation for the Beat.
+To use this setup, you'll also need to configure your Beat to use Logstash.
+For more information, see the documentation for the Beat.
 
 [[logstash-input-update]]
-==== Updating the Beats Input Plugin for Logstash
+===== Updating the Beats Input Plugin for Logstash
 
 Plugins have their own release cycle and are often released independent of
 Logstash’s core release cycle. To ensure that you have the latest version of
-the https://www.elastic.co/guide/en/logstash/current/plugins-inputs-beats.html[Beats input plugin for Logstash], 
+the https://www.elastic.co/guide/en/logstash/current/plugins-inputs-beats.html[Beats input plugin for Logstash],
 run the following command from your Logstash installation:
 
 *deb, rpm, and mac:*

--- a/libbeat/docs/shared-directory-layout.asciidoc
+++ b/libbeat/docs/shared-directory-layout.asciidoc
@@ -18,7 +18,7 @@ The directory layout of an installation is as follows:
 |=======================================================================
 | Type   | Description | Default Location | Config Option
 | home   | Home of the {beatname_uc} installation. | | path.home
-| bin    | The location for the binary files. | {path.home} |
+| bin    | The location for the binary files. | {path.home}/bin |
 | config | The location for configuration files. | {path.home} | path.config
 | data   | The location for persistent data files. | {path.home}/data| path.data
 | logs   | The location for the logs created by {beatname_uc}. | {path.home}/logs | path.logs
@@ -37,7 +37,7 @@ file.
 |=======================================================================
 | Type   | Description | Location
 | home   | Home of the {beatname_uc} installation. | /usr/share/{beatname_lc}
-| bin    | The location for the binary files. | /usr/share/{beatname_lc}
+| bin    | The location for the binary files. | /usr/share/{beatname_lc}/bin
 | config | The location for configuration files. | /etc/{beatname_lc}
 | data   | The location for persistent data files. | /var/lib/{beatname_lc}
 | logs   | The location for the logs created by {beatname_uc}. | /var/log/{beatname_lc}

--- a/libbeat/docs/shared-directory-layout.asciidoc
+++ b/libbeat/docs/shared-directory-layout.asciidoc
@@ -16,12 +16,12 @@ The directory layout of an installation is as follows:
 
 [cols="<h,<,<m,<m",options="header",]
 |=======================================================================
-| Type | Description | Default Location | Config Option
-| home | Home of the {beatname_uc} installation. | | path.home
-| bin  | The location for the binary files. | {path.home}/bin |
-| conf | The location for configuration files. | {path.home} | path.conf
-| data | The location for persistent data files. | {path.home}/data| path.data
-| logs | The location for the logs created by {beatname_uc}. | {path.home}/logs | path.logs
+| Type   | Description | Default Location | Config Option
+| home   | Home of the {beatname_uc} installation. | | path.home
+| bin    | The location for the binary files. | {path.home} |
+| config | The location for configuration files. | {path.home} | path.config
+| data   | The location for persistent data files. | {path.home}/data| path.data
+| logs   | The location for the logs created by {beatname_uc}. | {path.home}/logs | path.logs
 |=======================================================================
 
 You can change these settings by using CLI flags or setting <<configuration-path,path options>> in the configuration
@@ -35,12 +35,12 @@ file.
 ===== deb and rpm
 [cols="<h,<,<m",options="header",]
 |=======================================================================
-| Type | Description | Location
-| home | Home of the {beatname_uc} installation. | /usr/share/{beatname_lc}
-| bin  | The location for the binary files. | /usr/share/{beatname_lc}/bin
-| conf | The location for configuration files. | /etc/{beatname_lc}
-| data | The location for persistent data files. | /var/lib/{beatname_lc}
-| logs | The location for the logs created by {beatname_uc}. | /var/log/{beatname_lc}
+| Type   | Description | Location
+| home   | Home of the {beatname_uc} installation. | /usr/share/{beatname_lc}
+| bin    | The location for the binary files. | /usr/share/{beatname_lc}
+| config | The location for configuration files. | /etc/{beatname_lc}
+| data   | The location for persistent data files. | /var/lib/{beatname_lc}
+| logs   | The location for the logs created by {beatname_uc}. | /var/log/{beatname_lc}
 |=======================================================================
 
 For the deb and rpm distributions, these paths are set in the init script or in
@@ -52,24 +52,24 @@ Otherwise the paths might be set incorrectly.
 ===== docker
 [cols="<h,<,<m",options="header",]
 |=======================================================================
-| Type | Description | Location
-| home | Home of the {beatname_uc} installation. | /usr/share/{beatname_lc}
-| bin  | The location for the binary files. | /usr/share/{beatname_lc}
-| conf | The location for configuration files. | /usr/share/{beatname_lc}
-| data | The location for persistent data files. | /usr/share/{beatname_lc}/data
-| logs | The location for the logs created by {beatname_uc}. | /usr/share//{beatname_lc}/logs
+| Type   | Description | Location
+| home   | Home of the {beatname_uc} installation. | /usr/share/{beatname_lc}
+| bin    | The location for the binary files. | /usr/share/{beatname_lc}
+| config | The location for configuration files. | /usr/share/{beatname_lc}
+| data   | The location for persistent data files. | /usr/share/{beatname_lc}/data
+| logs   | The location for the logs created by {beatname_uc}. | /usr/share//{beatname_lc}/logs
 |=======================================================================
 
 [float]
 ===== zip, tar.gz, and tgz
 [cols="<h,<,<m",options="header",]
 |=======================================================================
-| Type | Description | Location
-| home | Home of the {beatname_uc} installation. | {extract.path}
-| bin  | The location for the binary files. | {extract.path}/bin
-| conf | The location for configuration files. | {extract.path}
-| data | The location for persistent data files. | {extract.path}/data
-| logs | The location for the logs created by {beatname_uc}. | {extract.path}/logs
+| Type   | Description | Location
+| home   | Home of the {beatname_uc} installation. | {extract.path}
+| bin    | The location for the binary files. | {extract.path}
+| config | The location for configuration files. | {extract.path}
+| data   | The location for persistent data files. | {extract.path}/data
+| logs   | The location for the logs created by {beatname_uc}. | {extract.path}/logs
 |=======================================================================
 
 For the zip, tar.gz and tgz distributions, these paths are based on the location of the

--- a/libbeat/docs/shared-path-config.asciidoc
+++ b/libbeat/docs/shared-path-config.asciidoc
@@ -26,12 +26,12 @@ Here is an example configuration:
 [source,yaml]
 ------------------------------------------------------------------------------
 path.home: /usr/share/beat
-path.conf: /etc/beat
+path.config: /etc/beat
 path.data: /var/lib/beat
 path.logs: /var/log/
 ------------------------------------------------------------------------------
 
-Note that it is possible to override these options by using command line flags. 
+Note that it is possible to override these options by using command line flags.
 
 ==== Path Options
 
@@ -62,7 +62,7 @@ Example:
 
 [source,yaml]
 ------------------------------------------------------------------------------
-path.conf: /usr/share/beats/config
+path.config: /usr/share/beats/config
 ------------------------------------------------------------------------------
 
 ===== data

--- a/libbeat/docs/shared-path-config.asciidoc
+++ b/libbeat/docs/shared-path-config.asciidoc
@@ -51,7 +51,7 @@ Example:
 path.home: /usr/share/beats
 ------------------------------------------------------------------------------
 
-===== conf
+===== config
 
 The configuration path for the {beatname_uc} installation. This is the default base path
 for configuration files, including the main YAML configuration file and the

--- a/metricbeat/module/system/process/_meta/docs.asciidoc
+++ b/metricbeat/module/system/process/_meta/docs.asciidoc
@@ -15,7 +15,7 @@ This metricset is available on:
 
 On Linux this metricset will collect metrics from any cgroups that the process
 is a member of. This feature is enabled by default and can be disabled by adding
-`process.cgroup.enabled: false` to the system module configuration.
+`process.cgroups.enabled: false` to the system module configuration.
 
 [float]
 === Process Environment Variables


### PR DESCRIPTION
Cherry-picks the following doc PRs into 5.5: #4530  #4542  #4547  #4628  #4617 

When I resolved conflicts, I noticed that a previously merged PR (https://github.com/elastic/beats/pull/3581) incorrectly added /bin to the path for  zip, tar.gz, and tgz. So I fixed it in this PR. 
 