### PR TITLE
Log elasticsearch connect error

### DIFF
--- a/libbeat/outputs/elasticsearch/elasticsearch.go
+++ b/libbeat/outputs/elasticsearch/elasticsearch.go
@@ -185,7 +185,7 @@ func NewConnectedClient(cfg *common.Config) (*Client, error) {
 	for _, client := range clients {
 		err = client.Connect()
 		if err != nil {
-			logp.Err("Error connecting to Elasticsearch: %s", client.Connection.URL)
+			logp.Err("Error connecting to Elasticsearch at %v: %v", client.Connection.URL, err)
 			continue
 		}
 		return &client, nil


### PR DESCRIPTION
Include the actual connect error message in the log message.