### PR TITLE
Remove os.path.realpath from deploy script

### DIFF
--- a/dev-tools/deploy
+++ b/dev-tools/deploy
@@ -10,7 +10,7 @@ def main():
                         help="Don't append -SNAPSHOT to the version.")
     args = parser.parse_args()
 
-    dir = os.path.dirname(os.path.realpath(__file__))
+    dir = os.path.dirname(__file__)
     os.chdir(dir + "/../")
     print("Getting dependencies")
     check_call("make clean", shell=True)


### PR DESCRIPTION
The realpath call resolves the symlink that we setup have the beats checkout located on the GOPATH. https://github.com/elastic/release-manager/blob/f46408ac941fd9f51949607452095f8b2fd10e8d/build.gradle#L202-L205