### PR TITLE
Publisher pipeline enhancements

### DIFF
--- a/libbeat/publisher/bc/publisher/pipeline.go
+++ b/libbeat/publisher/bc/publisher/pipeline.go
@@ -7,6 +7,7 @@ import (
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/outputs"
 	"github.com/elastic/beats/libbeat/processors"
+	"github.com/elastic/beats/libbeat/publisher/broker"
 	"github.com/elastic/beats/libbeat/publisher/broker/membroker"
 	"github.com/elastic/beats/libbeat/publisher/pipeline"
 )
@@ -61,10 +62,13 @@ func createPipeline(
 			},
 		},
 	}
-	broker := membroker.NewBroker(queueSize, false)
-	p, err := pipeline.New(broker, out, settings)
+
+	brokerFactory := func(e broker.Eventer) (broker.Broker, error) {
+		return membroker.NewBroker(e, queueSize, false), nil
+	}
+
+	p, err := pipeline.New(brokerFactory, out, settings)
 	if err != nil {
-		broker.Close()
 		return nil, err
 	}
 

--- a/libbeat/publisher/bc/publisher/publish.go
+++ b/libbeat/publisher/bc/publisher/publish.go
@@ -32,8 +32,8 @@ type TransactionalEventPublisher interface {
 
 type Publisher interface {
 	Connect() Client
-
 	ConnectX(beat.ClientConfig) (beat.Client, error)
+	SetACKHandler(beat.PipelineACKHandler) error
 }
 
 type BeatPublisher struct {
@@ -124,6 +124,10 @@ func (publisher *BeatPublisher) Connect() Client {
 
 func (publisher *BeatPublisher) ConnectX(config beat.ClientConfig) (beat.Client, error) {
 	return publisher.pipeline.ConnectWith(config)
+}
+
+func (publisher *BeatPublisher) SetACKHandler(h beat.PipelineACKHandler) error {
+	return publisher.pipeline.SetACKHandler(h)
 }
 
 func (publisher *BeatPublisher) GetName() string {

--- a/libbeat/publisher/beat/pipeline.go
+++ b/libbeat/publisher/beat/pipeline.go
@@ -7,9 +7,10 @@ import (
 )
 
 type Pipeline interface {
+	Close() error
 	Connect() (Client, error)
 	ConnectWith(ClientConfig) (Client, error)
-	Close() error
+	SetACKHandler(PipelineACKHandler) error
 }
 
 // Client holds a connection to the beats publisher pipeline
@@ -27,6 +28,10 @@ type ClientConfig struct {
 	// EventMetadata configures additional fields/tags to be added to published events.
 	EventMetadata common.EventMetadata
 
+	// Meta provides additional meta data to be added to the Meta field in the beat.Event
+	// structure.
+	Meta common.MapStr
+
 	// Processors passes additional processor to the client, to be executed before
 	// the pipeline processors.
 	Processor ProcessorList
@@ -36,6 +41,9 @@ type ClientConfig struct {
 	// WaitClose is only effective if one of ACKCount, ACKEvents and ACKLastEvents
 	// is configured
 	WaitClose time.Duration
+
+	// Events configures callbacks for common client callbacks
+	Events ClientEventer
 
 	// ACK handler strategies.
 	// Note: ack handlers are run in another go-routine owned by the publisher pipeline.
@@ -55,6 +63,16 @@ type ClientConfig struct {
 
 	// ACKLastEvent reports the last ACKed event out of a batch of ACKed events only.
 	ACKLastEvent func(Event)
+}
+
+// ClientEventer provides access to internal client events.
+type ClientEventer interface {
+	Closing() // Closing indicates the client is being shutdown next
+	Closed()  // Closed indicates the client being fully shutdown
+
+	Published()             // event been has successfully forwarded to the publisher pipeline
+	FilteredOut(Event)      // event has been filtered out/dropped by processors
+	DroppedOnPublish(Event) // event has been dropped, while waiting for the broker
 }
 
 // PipelineACKHandler configures some pipeline-wide event ACK handler.

--- a/libbeat/publisher/beat/pipeline.go
+++ b/libbeat/publisher/beat/pipeline.go
@@ -57,6 +57,19 @@ type ClientConfig struct {
 	ACKLastEvent func(Event)
 }
 
+// PipelineACKHandler configures some pipeline-wide event ACK handler.
+type PipelineACKHandler struct {
+	// ACKCount reports the number of published events recently acknowledged
+	// by the pipeline.
+	ACKCount func(int)
+
+	// ACKEvents reports the events recently acknowledged by the pipeline.
+	ACKEvents func([]Event)
+
+	// ACKLastEvent reports the last ACKed event per pipeline client.
+	ACKLastEvents func([]Event)
+}
+
 type ProcessorList interface {
 	All() []Processor
 }

--- a/libbeat/publisher/broker/broker.go
+++ b/libbeat/publisher/broker/broker.go
@@ -55,6 +55,10 @@ type ProducerConfig struct {
 	// gives a brokers user a chance to keep track of total number of events
 	// being buffered by the broker.
 	OnDrop func(count int)
+
+	// DropOnCancel is a hint to the broker to drop events if the producer disconnects
+	// via Cancel.
+	DropOnCancel bool
 }
 
 // Producer interface to be used by the pipelines client to forward events to be
@@ -64,7 +68,7 @@ type ProducerConfig struct {
 // Note: A broker is still allowed to send the ACK signal after Cancel. The
 //       pipeline client must filter out ACKs after cancel.
 type Producer interface {
-	Publish(event publisher.Event)
+	Publish(event publisher.Event) bool
 	TryPublish(event publisher.Event) bool
 	Cancel() int
 }

--- a/libbeat/publisher/broker/broker.go
+++ b/libbeat/publisher/broker/broker.go
@@ -22,8 +22,19 @@ type Factory func(*common.Config) (Broker, error)
 type Broker interface {
 	io.Closer
 
+	BufferConfig() BufferConfig
+
 	Producer(cfg ProducerConfig) Producer
 	Consumer() Consumer
+}
+
+// BufferConfig returns the pipelines buffering settings,
+// for the pipeline to use.
+// In case of the pipeline itself storing events for reporting ACKs to clients,
+// but still dropping events, the pipeline can use the buffer information,
+// to define an upper bound of events being active in the pipeline.
+type BufferConfig struct {
+	Events int // can be <= 0, if broker can not determine limit
 }
 
 // ProducerConfig as used by the Pipeline to configure some custom callbacks

--- a/libbeat/publisher/broker/broker.go
+++ b/libbeat/publisher/broker/broker.go
@@ -8,7 +8,12 @@ import (
 )
 
 // Factory for creating a broker used by a pipeline instance.
-type Factory func(*common.Config) (Broker, error)
+type Factory func(Eventer, *common.Config) (Broker, error)
+
+// Eventer listens to special events to be send by broker implementations.
+type Eventer interface {
+	OnACK(int) // number of consecutively published messages, acked by producers
+}
 
 // Broker is responsible for accepting, forwarding and ACKing events.
 // A broker will receive and buffer single events from its producers.
@@ -40,8 +45,8 @@ type BufferConfig struct {
 // ProducerConfig as used by the Pipeline to configure some custom callbacks
 // between pipeline and broker.
 type ProducerConfig struct {
-	// if ACK is set, the callback will be called with number of events being ACKed
-	// by the broker
+	// if ACK is set, the callback will be called with number of events produced
+	// by the producer instance and being ACKed by the broker.
 	ACK func(count int)
 
 	// OnDrop provided to the broker, to report events being silently dropped by

--- a/libbeat/publisher/broker/broker_reg.go
+++ b/libbeat/publisher/broker/broker_reg.go
@@ -24,7 +24,7 @@ func FindFactory(name string) Factory {
 }
 
 // Load instantiates a new broker.
-func Load(config common.ConfigNamespace) (Broker, error) {
+func Load(eventer Eventer, config common.ConfigNamespace) (Broker, error) {
 	t, cfg := config.Name(), config.Config()
 	if t == "" {
 		t = "mem"
@@ -34,5 +34,5 @@ func Load(config common.ConfigNamespace) (Broker, error) {
 	if factory == nil {
 		return nil, fmt.Errorf("broker type %v undefined", t)
 	}
-	return factory(cfg)
+	return factory(eventer, cfg)
 }

--- a/libbeat/publisher/broker/brokertest/producer_cancel.go
+++ b/libbeat/publisher/broker/brokertest/producer_cancel.go
@@ -30,7 +30,8 @@ func TestProducerCancelRemovesEvents(t *testing.T, factory BrokerFactory) {
 
 		log.Debug("create first producer")
 		producer := b.Producer(broker.ProducerConfig{
-			ACK: func(int) {}, // install function pointer, so 'cancel' will remove events
+			ACK:          func(int) {}, // install function pointer, so 'cancel' will remove events
+			DropOnCancel: true,
 		})
 
 		for ; i < N1; i++ {

--- a/libbeat/publisher/broker/membroker/ackloop.go
+++ b/libbeat/publisher/broker/membroker/ackloop.go
@@ -96,9 +96,7 @@ func (l *ackLoop) handleBatchSig() int {
 		}
 	}
 
-	// return acks to waiting clients
-	// TODO: global boolean to check if clients will need an ACK
-	//       no need to report ACKs if no client is interested in ACKs
+	// report acks to waiting clients
 	states := l.broker.buf.buf.clients
 	end := start + count
 	if end > len(states) {

--- a/libbeat/publisher/broker/membroker/ackloop.go
+++ b/libbeat/publisher/broker/membroker/ackloop.go
@@ -97,13 +97,8 @@ func (l *ackLoop) handleBatchSig() int {
 	}
 
 	// report acks to waiting clients
-	events := l.broker.buf.buf.events
 	states := l.broker.buf.buf.clients
-	end := start + count
-	if end > len(states) {
-		end -= len(states)
-	}
-	l.broker.reportACK(events, states, start, end)
+	l.broker.reportACK(states, start, count)
 
 	// return final ACK to EventLoop, in order to clean up internal buffer
 	l.broker.logger.Debug("ackloop: return ack to broker loop:", count)

--- a/libbeat/publisher/broker/membroker/ackloop.go
+++ b/libbeat/publisher/broker/membroker/ackloop.go
@@ -97,12 +97,13 @@ func (l *ackLoop) handleBatchSig() int {
 	}
 
 	// report acks to waiting clients
+	events := l.broker.buf.buf.events
 	states := l.broker.buf.buf.clients
 	end := start + count
 	if end > len(states) {
 		end -= len(states)
 	}
-	l.broker.reportACK(states, start, end)
+	l.broker.reportACK(events, states, start, end)
 
 	// return final ACK to EventLoop, in order to clean up internal buffer
 	l.broker.logger.Debug("ackloop: return ack to broker loop:", count)

--- a/libbeat/publisher/broker/membroker/broker_test.go
+++ b/libbeat/publisher/broker/membroker/broker_test.go
@@ -50,6 +50,6 @@ func TestProducerCancelRemovesEvents(t *testing.T) {
 
 func makeTestBroker(sz int) brokertest.BrokerFactory {
 	return func() broker.Broker {
-		return NewBroker(sz, true)
+		return NewBroker(nil, sz, true)
 	}
 }

--- a/libbeat/publisher/broker/membroker/buf.go
+++ b/libbeat/publisher/broker/membroker/buf.go
@@ -225,7 +225,7 @@ func (b *brokerBuffer) ack(sz int) {
 		b.buf.events[i] = publisher.Event{}
 	}
 
-	b.regA.index += end
+	b.regA.index = end
 	b.regA.size -= sz
 	b.reserved -= sz
 	if b.regA.size == 0 {

--- a/libbeat/publisher/broker/membroker/buf.go
+++ b/libbeat/publisher/broker/membroker/buf.go
@@ -219,7 +219,13 @@ func (b *brokerBuffer) ack(sz int) {
 		))
 	}
 
-	b.regA.index += sz
+	// clear region, so published events can be collected by the garbage collector:
+	end := b.regA.index + sz
+	for i := b.regA.index; i < end; i++ {
+		b.buf.events[i] = publisher.Event{}
+	}
+
+	b.regA.index += end
 	b.regA.size -= sz
 	b.reserved -= sz
 	if b.regA.size == 0 {
@@ -242,6 +248,10 @@ func (b *brokerBuffer) Full() bool {
 		avail = b.buf.Len() - b.regA.index - b.regA.size
 	}
 	return avail == 0
+}
+
+func (b *brokerBuffer) Size() int {
+	return b.buf.Len()
 }
 
 func (b *eventBuffer) init(size int) {

--- a/libbeat/publisher/pipeline/acker.go
+++ b/libbeat/publisher/pipeline/acker.go
@@ -1,0 +1,417 @@
+package pipeline
+
+import (
+	"sync"
+	"time"
+
+	"github.com/elastic/beats/libbeat/common/atomic"
+	"github.com/elastic/beats/libbeat/publisher/beat"
+)
+
+// acker is used to account for published and non-published events to be ACKed
+// to the beats client.
+// All pipeline and client ACK handling support is provided by acker instances.
+type acker interface {
+	close()
+	addEvent(event beat.Event, published bool)
+	ackEvents(int)
+}
+
+type pipelineAcker interface {
+	addEvent(beat.Event, bool)
+	ackEvents(int)
+}
+
+// emptyACK ignores any ACK signals and events.
+type emptyACK struct{}
+
+var nilACKer acker = (*emptyACK)(nil)
+
+func (*emptyACK) close()                        {}
+func (*emptyACK) addEvent(_ beat.Event, _ bool) {}
+func (*emptyACK) ackEvents(_ int)               {}
+
+type ackerFn struct {
+	Close     func()
+	AddEvent  func(beat.Event, bool)
+	AckEvents func(int)
+}
+
+func (a *ackerFn) close()                        { a.Close() }
+func (a *ackerFn) addEvent(e beat.Event, b bool) { a.AddEvent(e, b) }
+func (a *ackerFn) ackEvents(n int)               { a.AckEvents(n) }
+
+// countACK is used when broker ACK events can be simply forwarded to the
+// producers ACKCount callback.
+// The countACK is only applicable if no processors are configured.
+// ACKs for closed clients will be ignored.
+type countACK struct {
+	pipeline *Pipeline
+	fn       func(total, acked int)
+}
+
+func newCountACK(fn func(total, acked int)) *countACK {
+	a := &countACK{fn: fn}
+	return a
+}
+
+func (a *countACK) close()                        {}
+func (a *countACK) addEvent(_ beat.Event, _ bool) {}
+func (a *countACK) ackEvents(n int) {
+	if a.pipeline.ackActive.Load() {
+		a.fn(n, n)
+	}
+}
+
+// gapCountACK returns event ACKs to the producer, taking account for dropped events.
+// Events being dropped by processors will always be ACKed with the last batch ACKed
+// by the broker. This way clients waiting for ACKs can expect all processed
+// events being alwyas ACKed.
+type gapCountACK struct {
+	pipeline *Pipeline
+
+	fn func(total int, acked int)
+
+	done         chan struct{}
+	clientClosed bool
+
+	drop chan struct{}
+	acks chan int
+
+	lst gapList
+}
+
+type gapList struct {
+	sync.Mutex
+	head, tail *gapInfo
+}
+
+type gapInfo struct {
+	sync.Mutex
+	next          *gapInfo
+	send, dropped int
+}
+
+func newGapCountACK(pipeline *Pipeline, fn func(total, acked int)) *gapCountACK {
+	a := &gapCountACK{}
+	a.init(pipeline, fn)
+	return a
+}
+
+func (a *gapCountACK) init(pipeline *Pipeline, fn func(int, int)) {
+	*a = gapCountACK{
+		fn:   fn,
+		done: make(chan struct{}),
+		drop: make(chan struct{}),
+		acks: make(chan int, 1),
+	}
+
+	init := &gapInfo{}
+	a.lst.head = init
+	a.lst.tail = init
+
+	go a.ackLoop()
+}
+
+func (a *gapCountACK) ackLoop() {
+	// close channels, as no more events should be ACKed:
+	// - once pipeline is closed
+	// - all events of the closed client have been acked/processed by the pipeline
+	defer close(a.drop)
+	defer close(a.acks)
+
+	for {
+		select {
+		case <-a.done:
+			a.clientClosed = true
+			a.done = nil
+
+		case <-a.pipeline.ackDone:
+			return
+
+		case n := <-a.acks:
+			empty := a.handleACK(n)
+			if empty && a.clientClosed {
+				return
+			}
+
+		case <-a.drop:
+			// TODO: accumulate mulitple drop events + flush count with timer
+			a.fn(1, 0)
+		}
+	}
+}
+
+func (a *gapCountACK) handleACK(n int) bool {
+	// collect items and compute total count from gapList
+
+	var (
+		total    = 0
+		emptyLst bool
+	)
+
+	for n > 0 {
+		a.lst.Lock()
+		current := a.lst.head
+
+		current.Lock()
+		if n >= current.send {
+			nxt := current.next
+			emptyLst = nxt == nil
+			if !emptyLst {
+				// advance list all event in current entry have been send and list as
+				// more then 1 gapInfo entry. If only 1 entry is present, list item will be
+				// reset and reused
+				a.lst.head = nxt
+			}
+		}
+
+		// hand over lock list-entry, so ACK handler and producer can operate
+		// on potentially different list ends
+		a.lst.Unlock()
+
+		if n < current.send {
+			total += n
+			n = 0
+			current.send -= n
+		} else {
+			total += current.send + current.dropped
+			n -= current.send
+			current.dropped = 0
+			current.send = 0
+		}
+		current.Unlock()
+	}
+
+	a.fn(total, n)
+	return emptyLst
+}
+
+func (a *gapCountACK) close() {
+	// close client only, pipeline itself still can handle pending ACKs
+	close(a.done)
+}
+
+func (a *gapCountACK) addEvent(_ beat.Event, published bool) {
+	// if gapList is empty and event is being dropped, forward drop event to ack
+	// loop worker:
+	if !published {
+		a.lst.Lock()
+		current := a.lst.tail
+		if current.send == 0 {
+			a.lst.Unlock()
+
+			// send can only be 0 if no no events/gaps present yet
+			if a.lst.head != a.lst.tail {
+				panic("gap list expected to be empty")
+			}
+
+			a.drop <- struct{}{}
+		} else {
+			current.Lock()
+			a.lst.Unlock()
+
+			current.dropped++
+			current.Unlock()
+		}
+
+		return
+	}
+
+	// event is publisher -> add a new gap list entry if gap is present in current
+	// gapInfo
+
+	a.lst.Lock()
+
+	current := a.lst.tail
+	if current.dropped > 0 {
+		current = &gapInfo{}
+		a.lst.tail.next = current
+	}
+
+	current.Lock()
+	a.lst.Unlock()
+
+	current.send++
+	current.Unlock()
+}
+
+func (a *gapCountACK) ackEvents(n int) {
+	select {
+	case <-a.pipeline.ackDone: // pipeline is closing down -> ignore event
+	case a.acks <- n: // send ack event to worker
+	}
+}
+
+// boundGapCountACK guards a gapCountACK instance by bounding the maximum number of
+// active events.
+// As beats might accumulate state while waiting for ACK, the boundGapCountACK blocks
+// if too many events have been filtered out by processors.
+type boundGapCountACK struct {
+	active bool
+	fn     func(total, acked int)
+
+	acker gapCountACK
+	sema  *sema
+}
+
+func newBoundGapCountACK(
+	pipeline *Pipeline,
+	sema *sema,
+	fn func(total, acked int),
+) *boundGapCountACK {
+	a := &boundGapCountACK{active: true, sema: sema, fn: fn}
+	a.acker.init(pipeline, a.onACK)
+	return a
+}
+
+func (a *boundGapCountACK) close() {
+	a.acker.close()
+}
+
+func (a *boundGapCountACK) addEvent(event beat.Event, published bool) {
+	a.sema.inc()
+	a.acker.addEvent(event, published)
+}
+
+func (a *boundGapCountACK) ackEvents(n int) { a.acker.ackEvents(n) }
+func (a *boundGapCountACK) onACK(total, acked int) {
+	a.sema.release(total)
+	a.fn(total, acked)
+}
+
+// eventACK reports all dropped and ACKed events.
+// An instance of eventACK requires a counting ACKer (boundGapCountACK or countACK),
+// for accounting for potentially dropped events.
+type eventACK struct {
+	mutex  sync.Mutex
+	active bool
+
+	acker    acker
+	pipeline *Pipeline
+
+	// TODO: replace with more efficient dynamic sized ring-buffer?
+	events []beat.Event
+	fn     func(events []beat.Event, acked int)
+}
+
+func newEventACK(
+	pipeline *Pipeline,
+	canDrop bool,
+	sema *sema,
+	fn func([]beat.Event, int),
+) *eventACK {
+	a := &eventACK{fn: fn}
+	a.active = true
+	a.acker = makeCountACK(pipeline, canDrop, sema, a.onACK)
+
+	return a
+}
+
+func makeCountACK(pipeline *Pipeline, canDrop bool, sema *sema, fn func(int, int)) acker {
+	if canDrop {
+		return newBoundGapCountACK(pipeline, sema, fn)
+	}
+	return newCountACK(fn)
+}
+
+func (a *eventACK) close() {
+	a.mutex.Lock()
+	a.active = false
+	a.mutex.Unlock()
+
+	a.acker.close()
+}
+
+func (a *eventACK) addEvent(event beat.Event, published bool) {
+	a.mutex.Lock()
+	active := a.active
+	if active {
+		a.events = append(a.events, event)
+	}
+	a.mutex.Unlock()
+
+	if active {
+		a.acker.addEvent(event, published)
+	}
+}
+
+func (a *eventACK) ackEvents(n int) { a.acker.ackEvents(n) }
+func (a *eventACK) onACK(total, acked int) {
+	n := total
+
+	a.mutex.Lock()
+	events := a.events[:n]
+	a.events = a.events[n:]
+	a.mutex.Unlock()
+
+	if len(events) > 0 && a.pipeline.ackActive.Load() {
+		a.fn(events, acked)
+	}
+}
+
+// waitACK keeps track of events being produced and ACKs for events.
+// On close waitACK will wait for pending events to be ACKed by the broker.
+// The acker continues the closing operation if all events have been published
+// or the maximum configured sleep time has been reached.
+type waitACK struct {
+	acker acker
+
+	signal    chan struct{}
+	waitClose time.Duration
+
+	active atomic.Bool
+
+	// number of active events
+	events atomic.Uint64
+}
+
+func newWaitACK(acker acker, timeout time.Duration) *waitACK {
+	return &waitACK{
+		acker:     acker,
+		signal:    make(chan struct{}, 1),
+		waitClose: timeout,
+		active:    atomic.MakeBool(true),
+	}
+}
+
+func (a *waitACK) close() {
+	// TODO: wait for events
+
+	a.active.Store(false)
+	if a.events.Load() > 0 {
+		select {
+		case <-a.signal:
+		case <-time.After(a.waitClose):
+		}
+	}
+
+	// close the underlying acker upon exit
+	a.acker.close()
+}
+
+func (a *waitACK) addEvent(event beat.Event, published bool) {
+	if published {
+		a.events.Inc()
+	}
+	a.acker.addEvent(event, published)
+}
+
+func (a *waitACK) ackEvents(n int) {
+	// return ACK signal to upper layers
+	a.acker.ackEvents(n)
+	a.releaseEvents(n)
+}
+
+func (a *waitACK) releaseEvents(n int) {
+	value := a.events.Sub(uint64(n))
+	if value != 0 {
+		return
+	}
+
+	// send done signal, if close is waiting
+	if !a.active.Load() {
+		a.signal <- struct{}{}
+	}
+
+}

--- a/libbeat/publisher/pipeline/client.go
+++ b/libbeat/publisher/pipeline/client.go
@@ -67,15 +67,15 @@ func (c *client) Publish(e beat.Event) {
 	dropped := false
 	if c.canDrop {
 		if c.reportEvents {
-			c.pipeline.events.Add(1)
+			c.pipeline.waitCloser.inc()
 		}
 		dropped = !c.producer.TryPublish(pubEvent)
 		if dropped && c.reportEvents {
-			c.pipeline.activeEventsDone(1)
+			c.pipeline.waitCloser.dec(1)
 		}
 	} else {
 		if c.reportEvents {
-			c.pipeline.activeEventsAdd(1)
+			c.pipeline.waitCloser.inc()
 		}
 		c.producer.Publish(pubEvent)
 	}
@@ -99,7 +99,7 @@ func (c *client) Close() error {
 
 		if c.reportEvents {
 			log.Debugf("client: remove client events")
-			c.pipeline.activeEventsDone(n)
+			c.pipeline.waitCloser.dec(n)
 		}
 	}
 

--- a/libbeat/publisher/pipeline/client.go
+++ b/libbeat/publisher/pipeline/client.go
@@ -1,6 +1,8 @@
 package pipeline
 
 import (
+	"sync"
+
 	"github.com/elastic/beats/libbeat/publisher"
 	"github.com/elastic/beats/libbeat/publisher/beat"
 	"github.com/elastic/beats/libbeat/publisher/broker"
@@ -16,24 +18,37 @@ type client struct {
 	pipeline   *Pipeline
 	processors beat.Processor
 	producer   broker.Producer
+	mutex      sync.Mutex
 	acker      acker
 
 	eventFlags   publisher.EventFlags
 	canDrop      bool
-	cancelEvents bool
 	reportEvents bool
+
+	eventer beat.ClientEventer
 }
 
 func (c *client) PublishAll(events []beat.Event) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
 	for _, e := range events {
-		c.Publish(e)
+		c.publish(e)
 	}
 }
 
 func (c *client) Publish(e beat.Event) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	c.publish(e)
+}
+
+func (c *client) publish(e beat.Event) {
 	var (
 		event   = &e
 		publish = true
+		log     = c.pipeline.logger
 	)
 
 	if c.processors != nil {
@@ -44,7 +59,6 @@ func (c *client) Publish(e beat.Event) {
 		if err != nil {
 			// TODO: introduce dead-letter queue?
 
-			log := c.pipeline.logger
 			log.Errf("Failed to publish event: %v", err)
 		}
 	}
@@ -53,8 +67,15 @@ func (c *client) Publish(e beat.Event) {
 		e = *event
 	}
 
-	c.acker.addEvent(e, publish)
+	open := c.acker.addEvent(e, publish)
+	if !open {
+		// client is closing down -> report event as dropped and return
+		c.onDroppedOnPublish(e)
+		return
+	}
+
 	if !publish {
+		c.onFilteredOut(e)
 		return
 	}
 
@@ -64,20 +85,24 @@ func (c *client) Publish(e beat.Event) {
 		Flags:   c.eventFlags,
 	}
 
-	dropped := false
+	if c.reportEvents {
+		c.pipeline.waitCloser.inc()
+	}
+
+	var published bool
 	if c.canDrop {
+		published = c.producer.TryPublish(pubEvent)
+	} else {
+		published = c.producer.Publish(pubEvent)
+	}
+
+	if published {
+		c.onPublished()
+	} else {
+		c.onDroppedOnPublish(e)
 		if c.reportEvents {
-			c.pipeline.waitCloser.inc()
-		}
-		dropped = !c.producer.TryPublish(pubEvent)
-		if dropped && c.reportEvents {
 			c.pipeline.waitCloser.dec(1)
 		}
-	} else {
-		if c.reportEvents {
-			c.pipeline.waitCloser.inc()
-		}
-		c.producer.Publish(pubEvent)
 	}
 }
 
@@ -87,21 +112,53 @@ func (c *client) Close() error {
 
 	log := c.pipeline.logger
 
+	c.onClosing()
+	defer c.onClosed()
+
 	log.Debug("client: closing acker")
 	c.acker.close()
 	log.Debug("client: done closing acker")
 
 	// finally disconnect client from broker
-	if c.cancelEvents {
+	n := c.producer.Cancel()
+	log.Debugf("client: cancelled %v events", n)
 
-		n := c.producer.Cancel()
-		log.Debugf("client: cancelled %v events", n)
-
-		if c.reportEvents {
-			log.Debugf("client: remove client events")
+	if c.reportEvents {
+		log.Debugf("client: remove client events")
+		if n > 0 {
 			c.pipeline.waitCloser.dec(n)
 		}
 	}
 
 	return nil
+}
+
+func (c *client) onClosing() {
+	if c.eventer != nil {
+		c.eventer.Closing()
+	}
+}
+
+func (c *client) onClosed() {
+	if c.eventer != nil {
+		c.eventer.Closed()
+	}
+}
+
+func (c *client) onPublished() {
+	if c.eventer != nil {
+		c.eventer.Published()
+	}
+}
+
+func (c *client) onFilteredOut(e beat.Event) {
+	if c.eventer != nil {
+		c.eventer.FilteredOut(e)
+	}
+}
+
+func (c *client) onDroppedOnPublish(e beat.Event) {
+	if c.eventer != nil {
+		c.eventer.DroppedOnPublish(e)
+	}
 }

--- a/libbeat/publisher/pipeline/client_ack.go
+++ b/libbeat/publisher/pipeline/client_ack.go
@@ -64,10 +64,11 @@ func (a *clientACKer) close() {
 	a.acker.close()
 }
 
-func (a *clientACKer) addEvent(event beat.Event, published bool) {
+func (a *clientACKer) addEvent(event beat.Event, published bool) bool {
 	if a.active.Load() {
-		a.acker.addEvent(event, published)
+		return a.acker.addEvent(event, published)
 	}
+	return false
 }
 
 func (a *clientACKer) ackEvents(n int) {

--- a/libbeat/publisher/pipeline/client_ack.go
+++ b/libbeat/publisher/pipeline/client_ack.go
@@ -1,424 +1,98 @@
 package pipeline
 
 import (
-	"sync"
 	"time"
 
 	"github.com/elastic/beats/libbeat/common/atomic"
 	"github.com/elastic/beats/libbeat/publisher/beat"
 )
 
-// acker is used to account for published and non-published events to be ACKed
-// to the beats client.
-// All pipeline and client ACK handling support is provided by acker instances.
-type acker interface {
-	close()
-	addEvent(event beat.Event, published bool)
-	ackEvents(int)
-}
-
-type emptyACK struct{}
-
-// acker ignoring events and any ACK signals
-var nilACKer acker = (*emptyACK)(nil)
-
-// countACK is used when broker ACK events can be simply forwarded to the
-// producers ACKCount callback.
-// The countACK is only applicable if no processors are configured.
-// ACKs for closed clients will be ignored.
-type countACK struct {
-	active atomic.Bool
-	fn     func(int)
-}
-
-// gapCountACK returns event ACKs to the producer, taking account for dropped events.
-// Events being dropped by processors will always be ACKed with the last batch ACKed
-// by the broker. This way clients waiting for ACKs can expect all processed
-// events being alwyas ACKed.
-type gapCountACK struct {
-	fn func(int)
-
-	active atomic.Bool
-	done   chan struct{}
-	drop   chan struct{}
-	acks   chan int
-
-	lst gapList
-}
-
-type gapList struct {
-	sync.Mutex
-	head, tail *gapInfo
-}
-
-type gapInfo struct {
-	sync.Mutex
-	next          *gapInfo
-	send, dropped int
-}
-
-// eventACK reports all ACKed events
-type eventACK struct {
-	mutex  sync.Mutex
-	active bool
-
-	// TODO: replace with more efficient dynamic sized ring-buffer?
-	events []beat.Event
-
-	acker acker
-
-	fn func([]beat.Event)
-}
-
-// boundGapCountACK guards a gapCountACK instance by bounding the maximum number of
-// active events.
-// As beats might accumulate state while waiting for ACK, the boundGapCountACK blocks
-// if too many events have been filtered out by processors.
-type boundGapCountACK struct {
-	active bool
-	fn     func(int)
-
-	acker *gapCountACK
-
-	// simulate cancellable counting semaphore using counter + mutex + cond
-	mutex      sync.Mutex
-	cond       sync.Cond
-	count, max int
-}
-
-// ACKer waiting for events being ACKed on shutdown
-type waitACK struct {
-	acker acker
-
-	signal    chan struct{}
-	waitClose time.Duration
-
-	active atomic.Bool
-
-	// number of active events
-	events atomic.Uint64
-}
-
-// pipelineACK forwards event ACKs to the pipeline for
-// global event accounting.
-// Only overwrites ackEvents. The events counter must be incremented by the client,
-// in case the event has been dropped by broker on TryPublish.
-type pipelineACK struct {
+type clientACKer struct {
 	acker
-	pipeline *Pipeline
+	active atomic.Bool
 }
 
-func (*emptyACK) close()                        {}
-func (*emptyACK) addEvent(_ beat.Event, _ bool) {}
-func (*emptyACK) ackEvents(_ int)               {}
+func (p *Pipeline) makeACKer(
+	withProcessors bool,
+	cfg *beat.ClientConfig,
+	waitClose time.Duration,
+) acker {
+	var (
+		bld   = p.ackBuilder
+		acker acker
+	)
 
-func makeCountACK(canDrop bool, max int, waitClose time.Duration, fn func(int)) acker {
-	var acker acker
-	if canDrop {
-		acker = newBoundGapCountACK(max, fn)
-	} else {
-		acker = newCountACK(fn)
+	sema := p.eventSema
+	switch {
+	case cfg.ACKCount != nil:
+		acker = bld.createCountACKer(withProcessors, sema, cfg.ACKCount)
+	case cfg.ACKEvents != nil:
+		acker = bld.createEventACKer(withProcessors, sema, cfg.ACKEvents)
+	case cfg.ACKLastEvent != nil:
+		cb := lastEventACK(cfg.ACKLastEvent)
+		acker = bld.createEventACKer(withProcessors, sema, cb)
+	default:
+		if waitClose <= 0 {
+			return bld.createPipelineACKer(withProcessors, sema)
+		}
+		acker = bld.createCountACKer(withProcessors, sema, func(_ int) {})
 	}
 
 	if waitClose <= 0 {
 		return acker
 	}
-
-	wait := &waitACK{
-		acker:     acker,
-		signal:    make(chan struct{}, 1),
-		waitClose: waitClose,
-	}
-	wait.active.Store(true)
-
-	return wait
-}
-
-func newCountACK(fn func(int)) *countACK {
-	a := &countACK{fn: fn}
-	a.active.Store(true)
-	return a
-}
-
-func (a *countACK) close()                        { a.active.Store(false) }
-func (a *countACK) addEvent(_ beat.Event, _ bool) {}
-func (a *countACK) ackEvents(n int) {
-	if a.active.Load() {
-		a.fn(n)
-	}
-}
-
-func newGapCountACK(fn func(int)) *gapCountACK {
-	a := &gapCountACK{
-		fn:   fn,
-		done: make(chan struct{}),
-		drop: make(chan struct{}),
-		acks: make(chan int, 1),
-	}
-	a.active.Store(true)
-
-	init := &gapInfo{}
-	a.lst.head = init
-	a.lst.tail = init
-
-	go a.ackLoop()
-	return a
-}
-
-func (a *gapCountACK) ackLoop() {
-	for {
-		select {
-		case <-a.done:
-			return
-		case n := <-a.acks:
-			a.handleACK(n)
-		case <-a.drop:
-			// TODO: accumulate mulitple drop events + flush count with timer
-			a.fn(1)
-		}
-	}
-}
-
-func (a *gapCountACK) handleACK(n int) {
-	// collect items and compute total count from gapList
-
-	total := 0
-	for n > 0 {
-		a.lst.Lock()
-		current := a.lst.head
-
-		current.Lock()
-		if n >= current.send {
-			if nxt := current.next; nxt != nil {
-				// advance list all event in current entry have been send and list as
-				// more then 1 gapInfo entry. If only 1 entry is present, list item will be
-				// reset and reused
-
-				a.lst.head = nxt
-			}
-		}
-
-		// hand over lock list-entry, so ACK handler and producer can operate
-		// on potentially different list ends
-		a.lst.Unlock()
-
-		if n < current.send {
-			total += n
-			n = 0
-			current.send -= n
-		} else {
-			total += current.send + current.dropped
-			n -= current.send
-			current.dropped = 0
-			current.send = 0
-		}
-		current.Unlock()
-	}
-
-	a.fn(total)
-}
-
-func (a *gapCountACK) close() {
-	if a.active.Load() {
-		close(a.done)
-		a.active.Store(false)
-	}
-}
-
-func (a *gapCountACK) addEvent(_ beat.Event, published bool) {
-	if !a.active.Load() {
-		return
-	}
-
-	// if gapList is empty and event is being dropped, forward drop event to ack
-	// loop worker:
-	if !published {
-		a.lst.Lock()
-		current := a.lst.tail
-		if current.send == 0 {
-			a.lst.Unlock()
-
-			// send can only be 0 if no no events/gaps present yet
-			if a.lst.head != a.lst.tail {
-				panic("gap list expected to be empty")
-			}
-
-			a.drop <- struct{}{}
-		} else {
-			current.Lock()
-			a.lst.Unlock()
-
-			current.dropped++
-			current.Unlock()
-		}
-
-		return
-	}
-
-	// event is publisher -> add a new gap list entry if gap is present in current
-	// gapInfo
-
-	a.lst.Lock()
-
-	current := a.lst.tail
-	if current.dropped > 0 {
-		current = &gapInfo{}
-		a.lst.tail.next = current
-	}
-
-	current.Lock()
-	a.lst.Unlock()
-
-	current.send++
-	current.Unlock()
-}
-
-func (a *gapCountACK) ackEvents(n int) {
-	if !a.active.Load() {
-		return
-	}
-
-	select {
-	case <-a.done:
-	case a.acks <- n:
-	}
-}
-
-func newBoundGapCountACK(max int, fn func(int)) *boundGapCountACK {
-	a := &boundGapCountACK{active: true, max: max, fn: fn}
-	a.cond.L = &a.mutex
-	a.acker = newGapCountACK(a.onACK)
-	return a
-}
-
-func (a *boundGapCountACK) close() {
-	a.mutex.Lock()
-	a.active = false
-	a.cond.Broadcast()
-	a.mutex.Unlock()
-}
-
-func (a *boundGapCountACK) addEvent(event beat.Event, published bool) {
-	a.mutex.Lock()
-	// block until some more 'space' has become available
-	for a.active && a.count == a.max {
-		a.cond.Wait()
-	}
-
-	a.count++
-	active := a.active
-	a.mutex.Unlock()
-
-	if active {
-		a.acker.addEvent(event, published)
-	}
-}
-
-func (a *boundGapCountACK) ackEvents(n int) { a.acker.ackEvents(n) }
-func (a *boundGapCountACK) onACK(n int) {
-	a.mutex.Lock()
-
-	old := a.count
-	a.count -= n
-	if old == a.max {
-		a.cond.Broadcast()
-	}
-
-	a.mutex.Unlock()
-
-	a.fn(n)
-}
-
-func newEventACK(canDrop bool, max int, waitClose time.Duration, fn func([]beat.Event)) *eventACK {
-	a := &eventACK{fn: fn}
-	a.active = true
-	a.acker = makeCountACK(canDrop, max, waitClose, a.onACK)
-	return a
-}
-
-func (a *eventACK) close() {
-	a.mutex.Lock()
-	a.mutex.Unlock()
-
-	a.active = false
-	a.events = nil
-
-	a.acker.close()
-}
-
-func (a *eventACK) addEvent(event beat.Event, published bool) {
-	a.mutex.Lock()
-	a.events = append(a.events, event)
-	a.mutex.Unlock()
-
-	a.acker.addEvent(event, published)
-}
-
-func (a *eventACK) ackEvents(n int) {
-	a.acker.ackEvents(n)
-}
-
-func (a *eventACK) onACK(n int) {
-	a.mutex.Lock()
-	if !a.active {
-		a.mutex.Unlock()
-		return
-	}
-
-	events := a.events[:n]
-	a.events = a.events[n:]
-	a.mutex.Unlock()
-
-	if len(events) > 0 { // should always be true, just some safety-net
-		a.fn(events)
-	}
-}
-
-func (a *waitACK) close() {
-	// TODO: wait for events
-
-	a.active.Store(false)
-	if a.events.Load() > 0 {
-		select {
-		case <-a.signal:
-		case <-time.After(a.waitClose):
-		}
-	}
-}
-
-func (a *waitACK) addEvent(event beat.Event, published bool) {
-	if published {
-		a.events.Inc()
-	}
-	a.acker.addEvent(event, published)
-}
-
-func (a *waitACK) ackEvents(n int) {
-	// return ACK signal to upper layers
-	a.acker.ackEvents(n)
-	a.releaseEvents(n)
-}
-
-func (a *waitACK) releaseEvents(n int) {
-	value := a.events.Sub(uint64(n))
-	if value != 0 {
-		return
-	}
-
-	// send done signal, if close is waiting
-	if !a.active.Load() {
-		a.signal <- struct{}{}
-	}
-
-}
-
-func (a *pipelineACK) ackEvents(n int) {
-	a.acker.ackEvents(n)
-	a.pipeline.activeEventsDone(n)
+	return newWaitACK(acker, waitClose)
 }
 
 func lastEventACK(fn func(beat.Event)) func([]beat.Event) {
 	return func(events []beat.Event) {
 		fn(events[len(events)-1])
 	}
+}
+
+func (a *clientACKer) lift(acker acker) {
+	a.active = atomic.MakeBool(true)
+	a.acker = acker
+}
+
+func (a *clientACKer) Active() bool {
+	return a.active.Load()
+}
+
+func (a *clientACKer) close() {
+	a.active.Store(false)
+	a.acker.close()
+}
+
+func (a *clientACKer) addEvent(event beat.Event, published bool) {
+	if a.active.Load() {
+		a.acker.addEvent(event, published)
+	}
+}
+
+func (a *clientACKer) ackEvents(n int) {
+	a.acker.ackEvents(n)
+}
+
+func buildClientCountACK(
+	pipeline *Pipeline,
+	canDrop bool,
+	sema *sema,
+	mk func(*clientACKer) func(int, int),
+) acker {
+	guard := &clientACKer{}
+	cb := mk(guard)
+	guard.lift(makeCountACK(pipeline, canDrop, sema, cb))
+	return guard
+}
+
+func buildClientEventACK(
+	pipeline *Pipeline,
+	canDrop bool,
+	sema *sema,
+	mk func(*clientACKer) func([]beat.Event, int),
+) acker {
+	guard := &clientACKer{}
+	guard.lift(newEventACK(pipeline, canDrop, sema, mk(guard)))
+	return guard
 }

--- a/libbeat/publisher/pipeline/config.go
+++ b/libbeat/publisher/pipeline/config.go
@@ -45,7 +45,6 @@ func validateClientConfig(c *beat.ClientConfig) error {
 	// ACK handlers can not be registered DropIfFull is set, as dropping events
 	// due to full broker can not be accounted for in the clients acker.
 	if fnCount != 0 && withDrop {
-
 		return errors.New("ACK handlers with DropIfFull mode not supported")
 	}
 

--- a/libbeat/publisher/pipeline/pipeline.go
+++ b/libbeat/publisher/pipeline/pipeline.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/atomic"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/outputs"
 	"github.com/elastic/beats/libbeat/processors"
@@ -35,12 +36,24 @@ type Pipeline struct {
 	broker broker.Broker
 	output *outputController
 
-	waitClose     time.Duration
-	waitCloseMode WaitCloseMode
+	eventer pipelineEventer
 
-	// keep track of total number of active events (minus dropped by processors)
-	events sync.WaitGroup
+	// wait close support
+	waitCloseMode    WaitCloseMode
+	waitCloseTimeout time.Duration
+	waitCloser       *waitCloser
 
+	// pipeline ack
+	ackMode    pipelineACKMode
+	ackActive  atomic.Bool
+	ackDone    chan struct{}
+	ackBuilder ackBuilder
+	eventSema  *sema
+
+	processors pipelineProcessors
+}
+
+type pipelineProcessors struct {
 	// The pipeline its processor settings for
 	// constructing the clients complete processor
 	// pipeline on connect.
@@ -91,6 +104,21 @@ const (
 	WaitOnClientClose
 )
 
+type pipelineEventer struct {
+	mutex      sync.Mutex
+	modifyable bool
+
+	waitClose *waitCloser
+	cb        *pipelineEventCB
+}
+
+type waitCloser struct {
+	// keep track of total number of active events (minus dropped by processors)
+	events sync.WaitGroup
+}
+
+type brokerFactory func(broker.Eventer) (broker.Broker, error)
+
 // Load uses a Config object to create a new complete Pipeline instance with
 // configured broker and outputs.
 func Load(beatInfo common.BeatInfo, config Config) (*Pipeline, error) {
@@ -98,24 +126,21 @@ func Load(beatInfo common.BeatInfo, config Config) (*Pipeline, error) {
 		return nil, errors.New("no output configured")
 	}
 
-	broker, err := broker.Load(config.Broker)
-	if err != nil {
-		return nil, err
+	brokerFactory := func(e broker.Eventer) (broker.Broker, error) {
+		return broker.Load(e, config.Broker)
 	}
 
 	output, err := outputs.Load(beatInfo, config.Output.Name(), config.Output.Config())
 	if err != nil {
-		broker.Close()
 		return nil, err
 	}
 
 	// TODO: configure pipeline processors
-	pipeline, err := New(broker, output, Settings{
+	pipeline, err := New(brokerFactory, output, Settings{
 		WaitClose:     config.WaitShutdown,
 		WaitCloseMode: WaitOnPipelineClose,
 	})
 	if err != nil {
-		broker.Close()
 		for _, c := range output.Clients {
 			c.Close()
 		}
@@ -129,12 +154,13 @@ func Load(beatInfo common.BeatInfo, config Config) (*Pipeline, error) {
 // The new pipeline will take ownership of broker and outputs. On Close, the
 // broker and outputs will be closed.
 func New(
-	broker broker.Broker,
+	brokerFactory brokerFactory,
 	out outputs.Group,
 	settings Settings,
 ) (*Pipeline, error) {
 
 	annotations := settings.Annotations
+	var err error
 
 	var beatMeta beat.Processor
 	if meta := annotations.Beat; meta != nil {
@@ -157,19 +183,75 @@ func New(
 
 	log := defaultLogger
 	p := &Pipeline{
-		logger:             log,
-		broker:             broker,
-		output:             newOutputController(log, broker),
-		waitClose:          settings.WaitClose,
-		waitCloseMode:      settings.WaitCloseMode,
-		beatMetaProcessor:  beatMeta,
-		eventMetaProcessor: eventMeta,
-		processors:         prog,
-		disabled:           settings.Disabled,
+		logger:           log,
+		waitCloseMode:    settings.WaitCloseMode,
+		waitCloseTimeout: settings.WaitClose,
+		processors: pipelineProcessors{
+			beatMetaProcessor:  beatMeta,
+			eventMetaProcessor: eventMeta,
+			processors:         prog,
+			disabled:           settings.Disabled,
+		},
+	}
+	p.ackBuilder = &pipelineEmptyACK{p}
+	p.eventer.modifyable = true
+
+	if settings.WaitCloseMode == WaitOnPipelineClose && settings.WaitClose > 0 {
+		p.waitCloser = &waitCloser{}
+
+		// waitCloser decrements counter on broker ACK (not per client)
+		p.eventer.waitClose = p.waitCloser
 	}
 
+	p.broker, err = brokerFactory(&p.eventer)
+	if err != nil {
+		return nil, err
+	}
+	p.eventSema = newSema(p.broker.BufferConfig().Events)
+
+	p.output = newOutputController(log, p.broker)
 	p.output.Set(out)
+
 	return p, nil
+}
+
+// SetACKHandler sets a global ACK handler on all events published to the pipeline.
+// SetACKHandler must be called before any connection is made.
+func (p *Pipeline) SetACKHandler(handler beat.PipelineACKHandler) error {
+	p.eventer.mutex.Lock()
+	defer p.eventer.mutex.Unlock()
+
+	if !p.eventer.modifyable {
+		return errors.New("can not set ack handler on already active pipeline")
+	}
+
+	// TODO: check only one type being configured
+
+	cb, err := newPipelineEventCB(handler)
+	if err != nil {
+		return err
+	}
+
+	if cb == nil {
+		p.ackBuilder = &pipelineEmptyACK{p}
+		p.eventer.cb = nil
+		return nil
+	}
+
+	p.eventer.cb = cb
+	if cb.mode == countACKMode {
+		p.ackBuilder = &pipelineCountACK{
+			pipeline: p,
+			cb:       cb.onCounts,
+		}
+	} else {
+		p.ackBuilder = &pipelineEventsACK{
+			pipeline: p,
+			cb:       cb.onEvents,
+		}
+	}
+
+	return nil
 }
 
 // Close stops the pipeline, outputs and broker.
@@ -181,10 +263,10 @@ func (p *Pipeline) Close() error {
 
 	log.Debug("close pipeline")
 
-	if p.waitClose > 0 && p.waitCloseMode == WaitOnPipelineClose {
+	if p.waitCloser != nil {
 		ch := make(chan struct{})
 		go func() {
-			p.events.Wait()
+			p.waitCloser.wait()
 			ch <- struct{}{}
 		}()
 
@@ -192,9 +274,10 @@ func (p *Pipeline) Close() error {
 		case <-ch:
 			// all events have been ACKed
 
-		case <-time.After(p.waitClose):
+		case <-time.After(p.waitCloseTimeout):
 			// timeout -> close pipeline with pending events
 		}
+
 	}
 
 	// TODO: close/disconnect still active clients
@@ -216,16 +299,6 @@ func (p *Pipeline) Connect() (beat.Client, error) {
 	return p.ConnectWith(beat.ClientConfig{})
 }
 
-func (p *Pipeline) activeEventsAdd(n int) {
-	p.events.Add(n)
-}
-
-func (p *Pipeline) activeEventsDone(n int) {
-	for i := 0; i < n; i++ {
-		p.events.Done()
-	}
-}
-
 // ConnectWith create a new Client for publishing events to the pipeline.
 // The client behavior on close and ACK handling can be configured by setting
 // the appropriate fields in the passed ClientConfig.
@@ -240,6 +313,10 @@ func (p *Pipeline) ConnectWith(cfg beat.ClientConfig) (beat.Client, error) {
 		return nil, err
 	}
 
+	p.eventer.mutex.Lock()
+	p.eventer.modifyable = false
+	p.eventer.mutex.Unlock()
+
 	switch cfg.PublishMode {
 	case beat.GuaranteedSend:
 		eventFlags = publisher.GuaranteedSend
@@ -248,39 +325,26 @@ func (p *Pipeline) ConnectWith(cfg beat.ClientConfig) (beat.Client, error) {
 	}
 
 	waitClose := cfg.WaitClose
-	var reportEvents bool
+	reportEvents := p.waitCloser != nil
 
 	switch p.waitCloseMode {
 	case NoWaitOnClose:
 
 	case WaitOnClientClose:
 		if waitClose <= 0 {
-			waitClose = p.waitClose
+			waitClose = p.waitCloseTimeout
 		}
-
-	case WaitOnPipelineClose:
-		reportEvents = p.waitClose > 0
 	}
 
 	processors := p.newProcessorPipeline(cfg)
-	acker := makeACKer(processors != nil, &cfg, waitClose)
+	acker := p.makeACKer(processors != nil, &cfg, waitClose)
 	producerCfg := broker.ProducerConfig{}
 
 	// only cancel events from broker if acker is configured
 	cancelEvents := acker != nil
 
-	// configure client and acker to report events to pipeline.events
-	// for handling waitClose
 	if reportEvents {
-		if acker == nil {
-			acker = nilACKer
-		}
-
-		acker = &pipelineACK{
-			pipeline: p,
-			acker:    acker,
-		}
-		producerCfg.OnDrop = p.activeEventsDone
+		producerCfg.OnDrop = p.waitCloser.dec
 	}
 
 	if acker != nil {
@@ -304,23 +368,25 @@ func (p *Pipeline) ConnectWith(cfg beat.ClientConfig) (beat.Client, error) {
 	return client, nil
 }
 
-func makeACKer(
-	withProcessors bool,
-	cfg *beat.ClientConfig,
-	waitClose time.Duration,
-) acker {
-	// maximum number of events that can be published (including drops) without ACK.
-	//
-	// TODO: this MUST be configurable and should be max broker buffer size...
-	gapEventBuffer := 64
-
-	switch {
-	case cfg.ACKCount != nil:
-		return makeCountACK(withProcessors, gapEventBuffer, waitClose, cfg.ACKCount)
-	case cfg.ACKEvents != nil:
-		return newEventACK(withProcessors, gapEventBuffer, waitClose, cfg.ACKEvents)
-	case cfg.ACKLastEvent != nil:
-		return newEventACK(withProcessors, gapEventBuffer, waitClose, lastEventACK(cfg.ACKLastEvent))
+func (e *pipelineEventer) OnACK(n int) {
+	if wc := e.waitClose; wc != nil {
+		wc.dec(n)
 	}
-	return nil
+	if e.cb != nil {
+		e.cb.reportBrokerACK(n)
+	}
+}
+
+func (e *waitCloser) inc() {
+	e.events.Add(1)
+}
+
+func (e *waitCloser) dec(n int) {
+	for i := 0; i < n; i++ {
+		e.events.Done()
+	}
+}
+
+func (e *waitCloser) wait() {
+	e.events.Wait()
 }

--- a/libbeat/publisher/pipeline/pipeline_ack.go
+++ b/libbeat/publisher/pipeline/pipeline_ack.go
@@ -1,0 +1,323 @@
+package pipeline
+
+import (
+	"errors"
+
+	"github.com/elastic/beats/libbeat/publisher/beat"
+)
+
+type ackBuilder interface {
+	createPipelineACKer(canDrop bool, sema *sema) acker
+	createCountACKer(canDrop bool, sema *sema, fn func(int)) acker
+	createEventACKer(canDrop bool, sema *sema, fn func([]beat.Event)) acker
+}
+
+type pipelineEmptyACK struct {
+	pipeline *Pipeline
+}
+
+func (b *pipelineEmptyACK) createPipelineACKer(canDrop bool, sema *sema) acker {
+	return nilACKer
+}
+
+func (b *pipelineEmptyACK) createCountACKer(canDrop bool, sema *sema, fn func(int)) acker {
+	return buildClientCountACK(b.pipeline, canDrop, sema, func(guard *clientACKer) func(int, int) {
+		return func(total, acked int) {
+			if guard.Active() {
+				fn(total)
+			}
+		}
+	})
+}
+
+func (b *pipelineEmptyACK) createEventACKer(
+	canDrop bool,
+	sema *sema,
+	fn func([]beat.Event),
+) acker {
+	return buildClientEventACK(b.pipeline, canDrop, sema, func(guard *clientACKer) func([]beat.Event, int) {
+		return func(events []beat.Event, acked int) {
+			if guard.Active() {
+				fn(events)
+			}
+		}
+	})
+}
+
+type pipelineCountACK struct {
+	pipeline *Pipeline
+	cb       func(int, int)
+}
+
+func (b *pipelineCountACK) createPipelineACKer(canDrop bool, sema *sema) acker {
+	return makeCountACK(b.pipeline, canDrop, sema, b.cb)
+}
+
+func (b *pipelineCountACK) createCountACKer(canDrop bool, sema *sema, fn func(int)) acker {
+	return buildClientCountACK(b.pipeline, canDrop, sema, func(guard *clientACKer) func(int, int) {
+		return func(total, acked int) {
+			b.cb(total, acked)
+			if guard.Active() {
+				fn(total)
+			}
+		}
+	})
+}
+
+func (b *pipelineCountACK) createEventACKer(
+	canDrop bool,
+	sema *sema,
+	fn func([]beat.Event),
+) acker {
+	return buildClientEventACK(b.pipeline, canDrop, sema, func(guard *clientACKer) func([]beat.Event, int) {
+		return func(events []beat.Event, acked int) {
+			b.cb(len(events), acked)
+			if guard.Active() {
+				fn(events)
+			}
+		}
+	})
+}
+
+type pipelineEventsACK struct {
+	pipeline *Pipeline
+	cb       func([]beat.Event, int)
+}
+
+func (b *pipelineEventsACK) createPipelineACKer(canDrop bool, sema *sema) acker {
+	return newEventACK(b.pipeline, canDrop, sema, b.cb)
+}
+
+func (b *pipelineEventsACK) createCountACKer(canDrop bool, sema *sema, fn func(int)) acker {
+	return buildClientEventACK(b.pipeline, canDrop, sema, func(guard *clientACKer) func([]beat.Event, int) {
+		return func(events []beat.Event, acked int) {
+			b.cb(events, acked)
+			if guard.Active() {
+				fn(len(events))
+			}
+		}
+	})
+}
+
+func (b *pipelineEventsACK) createEventACKer(canDrop bool, sema *sema, fn func([]beat.Event)) acker {
+	return buildClientEventACK(b.pipeline, canDrop, sema, func(guard *clientACKer) func([]beat.Event, int) {
+		return func(events []beat.Event, acked int) {
+			b.cb(events, acked)
+			if guard.Active() {
+				fn(events)
+			}
+		}
+	})
+}
+
+// pipelineEventCB internally handles active ACKs in the pipeline.
+// It receives ACK events from the broker and the individual clients.
+// Once the broker returns an ACK to the pipelineEventCB, the worker loop will collect
+// events from all clients having published events in the last batch of events
+// being ACKed.
+// the PipelineACKHandler will be notified, once all events being ACKed
+// (including dropped events) have been collected. Only one ACK-event is handled
+// at a time. The pipeline global and clients ACK handler will be blocked for the time
+// an ACK event is being processed.
+type pipelineEventCB struct {
+	done chan struct{}
+
+	acks chan int
+
+	events        chan eventsMsg
+	droppedEvents chan eventsMsg
+
+	counts        chan eventsMsg
+	droppedCounts chan eventsMsg
+
+	mode    pipelineACKMode
+	handler beat.PipelineACKHandler
+}
+
+type eventsMsg struct {
+	events       []beat.Event
+	total, acked int
+	sig          chan struct{}
+}
+
+type pipelineACKMode uint8
+
+const (
+	noACKMode pipelineACKMode = iota
+	countACKMode
+	eventsACKMode
+	lastEventsACKMode
+)
+
+func newPipelineEventCB(handler beat.PipelineACKHandler) (*pipelineEventCB, error) {
+	mode := noACKMode
+	if handler.ACKCount != nil {
+		mode = countACKMode
+	}
+	if handler.ACKEvents != nil {
+		if mode != noACKMode {
+			return nil, errors.New("only one callback can be set")
+		}
+		mode = eventsACKMode
+	}
+	if handler.ACKLastEvents != nil {
+		if mode != noACKMode {
+			return nil, errors.New("only one callback can be set")
+		}
+		mode = lastEventsACKMode
+	}
+
+	// yay, no work
+	if mode == noACKMode {
+		return nil, nil
+	}
+
+	cb := &pipelineEventCB{
+		acks:          make(chan int),
+		mode:          mode,
+		handler:       handler,
+		events:        make(chan eventsMsg),
+		droppedEvents: make(chan eventsMsg),
+	}
+	go cb.worker()
+	return cb, nil
+}
+
+func (p *pipelineEventCB) close() {
+	close(p.done)
+}
+
+// reportEvents sends a batch of ACKed events to the ACKer.
+// The events array contains send and dropped events. The `acked` counters
+// indicates the total number of events acked by the pipeline.
+// That is, the number of dropped events is given by `len(events) - acked`.
+// A client can report events with acked=0, iff the client has no waiting events
+// in the pipeline (ACK ordering requirements)
+//
+// Note: the call blocks, until the ACK handler has collected all active events
+//       from all clients. This ensure an ACK event being fully 'captured'
+//       by the pipeline, before receiving/processing another ACK event.
+//       In the meantime the broker has the chance of batching-up more ACK events,
+//       such that only one ACK event is being reported to the pipeline handler
+func (p *pipelineEventCB) onEvents(events []beat.Event, acked int) {
+	ch := p.events
+	if acked == 0 {
+		ch = p.droppedEvents
+	}
+
+	msg := eventsMsg{
+		events: events,
+		total:  len(events),
+		acked:  acked,
+		sig:    make(chan struct{}),
+	}
+
+	// send message to worker and wait for completion signal
+	ch <- msg
+	<-msg.sig
+}
+
+func (p *pipelineEventCB) onCounts(total, acked int) {
+	ch := p.events
+	if acked == 0 {
+		ch = p.droppedEvents
+	}
+
+	msg := eventsMsg{
+		total: total,
+		acked: acked,
+		sig:   make(chan struct{}),
+	}
+
+	ch <- msg
+	<-msg.sig
+}
+
+// Starts a new ACKed event.
+func (p *pipelineEventCB) reportBrokerACK(acked int) {
+	p.acks <- acked
+}
+
+func (p *pipelineEventCB) worker() {
+	defer close(p.acks)
+	if p.mode == countACKMode {
+		defer close(p.counts)
+		defer close(p.droppedCounts)
+	} else {
+		defer close(p.events)
+		defer close(p.droppedEvents)
+	}
+
+	for {
+		select {
+		case count := <-p.acks:
+			exit := p.collect(count)
+			if exit {
+				return
+			}
+
+			// short circuite dropped events, but have client block until all events
+			// have been processed by pipeline ack handler
+		case msg := <-p.droppedEvents:
+			p.reportEvents(msg.events, len(msg.events))
+			close(msg.sig)
+
+		case <-p.done:
+			return
+		}
+	}
+}
+
+func (p *pipelineEventCB) collect(count int) (exit bool) {
+	var (
+		signalers []chan struct{}
+		events    []beat.Event
+		acked     int
+		total     int
+	)
+
+	for acked < count {
+		var msg eventsMsg
+		select {
+		case msg = <-p.events:
+		case msg = <-p.droppedEvents:
+		case <-p.done:
+			exit = true
+			return
+		}
+
+		signalers = append(signalers, msg.sig)
+		total += msg.total
+		acked += msg.acked
+
+		switch p.mode {
+		case eventsACKMode:
+			events = append(events, msg.events...)
+
+		case lastEventsACKMode:
+			if L := len(msg.events); L > 0 {
+				events = append(events, msg.events[L-1])
+			}
+		}
+	}
+
+	// signal clients we processed all active ACKs, as reported by broker
+	for _, sig := range signalers {
+		close(sig)
+	}
+
+	p.reportEvents(events, total)
+	return
+}
+
+func (p *pipelineEventCB) reportEvents(events []beat.Event, total int) {
+	// report ACK back to the beat
+	switch p.mode {
+	case countACKMode:
+		p.handler.ACKCount(total)
+	case eventsACKMode:
+		p.handler.ACKEvents(events)
+	case lastEventsACKMode:
+		p.handler.ACKLastEvents(events)
+	}
+}

--- a/libbeat/publisher/pipeline/processor.go
+++ b/libbeat/publisher/pipeline/processor.go
@@ -44,15 +44,17 @@ func (p *Pipeline) newProcessorPipeline(
 ) beat.Processor {
 	processors := &program{title: "processPipeline"}
 
+	global := p.processors
+
 	// setup 1: extract EventMetadataKey fields + tags
 	processors.add(preEventUserAnnotateProcessor)
 
 	// setup 2 and 3: generalize/normalize output (P)
 	processors.add(generalizeProcessor)
-	processors.add(p.beatMetaProcessor)
+	processors.add(global.beatMetaProcessor)
 
 	// setup 4: add event fields + tags (P)
-	processors.add(p.eventMetaProcessor)
+	processors.add(global.eventMetaProcessor)
 
 	// setup 5: add fields + tags (C)
 	if em := config.EventMetadata; len(em.Fields) > 0 || len(em.Tags) > 0 {
@@ -74,14 +76,14 @@ func (p *Pipeline) newProcessorPipeline(
 	}
 
 	// setup 8: pipeline processors (P)
-	processors.add(p.processors)
+	processors.add(global.processors)
 
 	// setup 9: debug print final event (P)
 	if logp.IsDebug("publish") {
 		processors.add(debugPrintProcessor())
 	}
 
-	if p.disabled {
+	if global.disabled {
 		processors.add(dropDisabledProcessor)
 	}
 

--- a/libbeat/publisher/pipeline/util.go
+++ b/libbeat/publisher/pipeline/util.go
@@ -1,0 +1,38 @@
+package pipeline
+
+import "sync"
+
+type sema struct {
+	// simulate cancellable counting semaphore using counter + mutex + cond
+	mutex      sync.Mutex
+	cond       sync.Cond
+	count, max int
+}
+
+func newSema(max int) *sema {
+	s := &sema{max: max}
+	s.cond.L = &s.mutex
+	return s
+}
+
+func (s *sema) inc() {
+	s.mutex.Lock()
+	for s.count == s.max {
+		s.cond.Wait()
+	}
+	s.mutex.Unlock()
+}
+
+func (s *sema) release(n int) {
+	s.mutex.Lock()
+	old := s.count
+	s.count -= n
+	if old == s.max {
+		if n == 1 {
+			s.cond.Signal()
+		} else {
+			s.cond.Broadcast()
+		}
+	}
+	s.mutex.Unlock()
+}

--- a/libbeat/publisher/testing/testing.go
+++ b/libbeat/publisher/testing/testing.go
@@ -36,6 +36,10 @@ func (pub *TestPublisher) ConnectX(_ beat.ClientConfig) (beat.Client, error) {
 	panic("Not supported")
 }
 
+func (pub *TestPublisher) SetACKHandler(_ beat.PipelineACKHandler) error {
+	panic("Not supported")
+}
+
 func NewChanClient(bufSize int) *ChanClient {
 	return NewChanClientWith(make(chan PublishMessage, bufSize))
 }


### PR DESCRIPTION
Changes/Improvements to the publisher pipeline (required for filebeat integration).

- Clear the broker event buffer when events got ACKed by outputs. This helps
  the garbage collector to pick up already ACKed events
- Introduce BufferConfig, for the pipeline to ask some of the brokers settings
  on event buffering.
- have broker report a max number of events. Have an upper bound on events
  (published/dropped) in the pipeline.
  Note:
  - The counter is currently only used for pipeline clients potentially
    dropping events. Due to the new pipeline setup normalizing events in the
    processors, this condition is always true.
  - still, the broker blocks if max event count is reached
    -> even in worst case the total number of events in the publisher pipeline
       should only be 2*max
- add ClientConfig.DropOnCancel:
  producer.Cancel disconnects the producer from the publisher pipeline.
  Only if DropOnCancel is true, an additional signal will be send to the
  publisher pipeline, to drop any active event.
  This allows the pipeline client to determine if dropping events on close is
  feasible or not
- Producer.Publish returns a boolean to indicate publish potentially
  failed by the producer being closed
- properly disconnect blocked producer on close of producer
- add assert/panic if ACKed events succeeds total events in membroker
- fix index update summing the end-pointer eventually leading to
  slice-out-of-bounds panic
- add `SetACKHandler(PipelineACKHandler) error` to pipeline interface
  => global listener for events being ACKed by publisher pipeline (in order)
- add more settings to ClientConfig:
  - Meta: provide `@metadata` to be added to each single event published
          (e.g. pipeline)
  - Events: registers callbacks for pipeline client internal events like:
      - Closing, Closed, Published, FilteredOut, DroppedOnPublish
- redo acker and creating acker:
  - ackers operate mostly on pipeline now, so PipelineACKHandler can be served
  - client ACKer hooks into pipeline ACKing when building the ACKer.
    When client is closed, the client ACK will see no more events from the
    still active pipeline ACKer
- add asserts/panics to pipeline ACKers in case of too many events (acked >
  published) being ACKed
- make pipeline.Client thread-safe (big mutex on Publish), so multiple
  go-routines can share a beat client for publishing events (requirement for
  filebeat)
- filter out empty events (event.Fields == nil), but ensure events are
- update pipeline processors order to:
  1. (P) extract EventMetadataKey fields + tags (to be removed in favor of 4)
  2. (P) generalize/normalize event
  3. (P) add beats metadata (name, hostname, version)
  4. (C) add Meta from client Config to event.Meta
  5. (P) add pipeline fields + tags
  6. (C) add client fields + tags
  7. (P/C) apply EventMetadataKey fields + tags (to be removed in favor of 4)
  8. (C) client processors list
  9. (P) pipeline processors list
  10. (P) (if publish/debug enabled) log event
  11. (P) (if output disabled) dropEvent