### PR TITLE
Disable logging for module command tests

### DIFF
--- a/filebeat/tests/system/test_cmd.py
+++ b/filebeat/tests/system/test_cmd.py
@@ -25,7 +25,8 @@ class TestCommands(filebeat.BaseTest):
         self.touch(self.working_dir + "/modules.d/enabled.yml")
         self.touch(self.working_dir + "/modules.d/disabled.yml.disabled")
 
-        exit_code = self.run_beat(extra_args=["modules", "list"])
+        exit_code = self.run_beat(logging_args=None,
+                                  extra_args=["modules", "list"])
 
         assert exit_code == 0
         assert "Enabled:\nenabled" in self.get_log()
@@ -33,7 +34,8 @@ class TestCommands(filebeat.BaseTest):
 
         # Add one more disabled module
         self.touch(self.working_dir + "/modules.d/disabled2.yml.disabled")
-        exit_code = self.run_beat(extra_args=["modules", "list"])
+        exit_code = self.run_beat(logging_args=None,
+                                  extra_args=["modules", "list"])
 
         assert exit_code == 0
         assert "Enabled:\nenabled" in self.get_log()

--- a/metricbeat/tests/system/test_cmd.py
+++ b/metricbeat/tests/system/test_cmd.py
@@ -21,7 +21,8 @@ class TestCommands(metricbeat.BaseTest):
         self.touch(self.working_dir + "/modules.d/enabled.yml")
         self.touch(self.working_dir + "/modules.d/disabled.yml.disabled")
 
-        exit_code = self.run_beat(extra_args=["modules", "list"])
+        exit_code = self.run_beat(logging_args=None,
+                                  extra_args=["modules", "list"])
 
         assert exit_code == 0
         assert "Enabled:\nenabled" in self.get_log()
@@ -29,7 +30,8 @@ class TestCommands(metricbeat.BaseTest):
 
         # Add one more disabled module
         self.touch(self.working_dir + "/modules.d/disabled2.yml.disabled")
-        exit_code = self.run_beat(extra_args=["modules", "list"])
+        exit_code = self.run_beat(logging_args=None,
+                                  extra_args=["modules", "list"])
 
         assert exit_code == 0
         assert "Enabled:\nenabled" in self.get_log()


### PR DESCRIPTION
Disable logging for the tests that check for specific output that spans multiple lines. The logger output was being interleaved with the output from the module commands which could cause the test to [fail](https://beats-ci.elastic.co/job/elastic+beats+pull-request+multijob-linux/690/beat=metricbeat,label=ubuntu/artifact/src/github.com/elastic/beats/metricbeat/build/system-tests/run/test_cmd.TestCommands.test_modules_list/metricbeat.log/*view*/). For example,

    Enabled:
    enabled

    Disabled:
    2017/07/10 20:22:39.125125 metrics.go:23: INFO Metrics logging every 30s
    disabled
    disabled2