### PR TITLE
Remove clean target from Metricbeat

### DIFF
--- a/metricbeat/Makefile
+++ b/metricbeat/Makefile
@@ -16,11 +16,6 @@ GOX_FLAGS=-arch="amd64 386 arm ppc64 ppc64le"
 
 include ${ES_BEATS}/libbeat/scripts/Makefile
 
-.PHONY: clean
-clean::
-	@rm -rf _meta/kibana/dashboard _meta/kibana/search _meta/kibana/visualization
-	@rm -rf docs/modules
-
 # Collects all module dashboards
 .PHONY: kibana
 kibana:


### PR DESCRIPTION
The clean target was removing files that are checked into the repo.
The tasks that generate the files are responsible for cleaning the old
files before generating the new ones so the custom clean target is
not required.