### PR TITLE
metricbeat: enhance the system/diskio

### DIFF
--- a/metricbeat/docs/fields.asciidoc
+++ b/metricbeat/docs/fields.asciidoc
@@ -8773,6 +8773,94 @@ The total number of of milliseconds spent doing I/Os.
 
 
 [float]
+=== `system.diskio.iostat.read_request_merged_per_sec`
+
+type: float
+
+The number of read requests merged per second that were queued to the device.
+
+
+[float]
+=== `system.diskio.iostat.write_request_merged_per_sec`
+
+type: float
+
+The number of write requests merged per second that were queued to the device.
+
+
+[float]
+=== `system.diskio.iostat.read_request_per_sec`
+
+type: float
+
+The number of read requests that were issued to the device per second
+
+
+[float]
+=== `system.diskio.iostat.write_request_per_sec`
+
+type: float
+
+The number of write requests that were issued to the device per second
+
+
+[float]
+=== `system.diskio.iostat.read_byte_per_sec`
+
+type: float
+
+The number of Bytes read from the device per second.
+
+
+[float]
+=== `system.diskio.iostat.write_byte_per_sec`
+
+type: float
+
+The number of Bytes write from the device per second.
+
+
+[float]
+=== `system.diskio.iostat.avg_request_size`
+
+type: float
+
+The average size (in sectors) of the requests that were issued to the device.
+
+
+[float]
+=== `system.diskio.iostat.avg_queue_size`
+
+type: float
+
+The average queue length of the requests that were issued to the device.
+
+
+[float]
+=== `system.diskio.iostat.await`
+
+type: float
+
+The average queue length of the requests that were issued to the device.
+
+
+[float]
+=== `system.diskio.iostat.service_time`
+
+type: float
+
+The average service time (in milliseconds) for I/O requests that were issued to the device.
+
+
+[float]
+=== `system.diskio.iostat.busy`
+
+type: float
+
+Percentage of CPU time during which I/O requests were issued to the device (bandwidth utilization for the device). Device saturation occurs when this value is close to 100%.
+
+
+[float]
 == filesystem fields
 
 `filesystem` contains local filesystem stats.

--- a/metricbeat/module/system/diskio/_meta/data.json
+++ b/metricbeat/module/system/diskio/_meta/data.json
@@ -25,6 +25,19 @@
                 "bytes": 2281472,
                 "count": 224,
                 "time": 29700
+            },
+            "iostat": {
+                "avg_queue_size": 0.020000,
+                "avg_request_size": 5120.000000,
+                "await": 0.010000,
+                "busy": 0.100000,
+                "read_byte_per_sec": 1034.420132,
+                "read_request_per_sec": 2.938410,
+                "read_request_merged_per_sec": 0.000000,
+                "service_time": 0.030000,
+                "write_byte_per_sec": 20531.328321,
+                "write_request_per_sec": 4.010025,
+                "write_request_merged_per_sec": 0.000000
             }
         }
     },

--- a/metricbeat/module/system/diskio/_meta/fields.yml
+++ b/metricbeat/module/system/diskio/_meta/fields.yml
@@ -54,3 +54,58 @@
       type: long
       description: >
         The total number of of milliseconds spent doing I/Os.
+
+    - name: iostat.read_request_merged_per_sec
+      type: float
+      description: >
+          The number of read requests merged per second that were queued to the device.
+
+    - name: iostat.write_request_merged_per_sec
+      type: float
+      description: >
+          The number of write requests merged per second that were queued to the device.
+
+    - name: iostat.read_request_per_sec
+      type: float
+      description: >
+          The number of read requests that were issued to the device per second
+
+    - name: iostat.write_request_per_sec
+      type: float
+      description: >
+          The number of write requests that were issued to the device per second
+
+    - name: iostat.read_byte_per_sec
+      type: float
+      description: >
+          The number of Bytes read from the device per second.
+
+    - name: iostat.write_byte_per_sec
+      type: float
+      description: >
+          The number of Bytes write from the device per second.
+
+    - name: iostat.avg_request_size
+      type: float
+      description: >
+          The average size (in sectors) of the requests that were issued to the device.
+
+    - name: iostat.avg_queue_size
+      type: float
+      description: >
+          The average queue length of the requests that were issued to the device.
+
+    - name: iostat.await
+      type: float
+      description: >
+          The average queue length of the requests that were issued to the device.
+
+    - name: iostat.service_time
+      type: float
+      description: >
+          The average service time (in milliseconds) for I/O requests that were issued to the device.
+
+    - name: iostat.busy
+      type: float
+      description: >
+          Percentage of CPU time during which I/O requests were issued to the device (bandwidth utilization for the device). Device saturation occurs when this value is close to 100%.

--- a/metricbeat/module/system/diskio/diskio.go
+++ b/metricbeat/module/system/diskio/diskio.go
@@ -20,11 +20,16 @@ func init() {
 // MetricSet for fetching system disk IO metrics.
 type MetricSet struct {
 	mb.BaseMetricSet
+	statistics *DiskIOStat
 }
 
 // New is a mb.MetricSetFactory that returns a new MetricSet.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	return &MetricSet{base}, nil
+	ms := &MetricSet{
+		BaseMetricSet: base,
+		statistics:    NewDiskIOStat(),
+	}
+	return ms, nil
 }
 
 // Fetch fetches disk IO metrics from the OS.
@@ -34,8 +39,12 @@ func (m *MetricSet) Fetch() ([]common.MapStr, error) {
 		return nil, errors.Wrap(err, "disk io counters")
 	}
 
+	// open a sampling means sample the current cpu counter
+	m.statistics.OpenSampling()
+
 	events := make([]common.MapStr, 0, len(stats))
 	for _, counters := range stats {
+
 		event := common.MapStr{
 			"name": counters.Name,
 			"read": common.MapStr{
@@ -52,12 +61,33 @@ func (m *MetricSet) Fetch() ([]common.MapStr, error) {
 				"time": counters.IoTime,
 			},
 		}
+
+		extraMetrics, err := m.statistics.CalIOStatistics(counters)
+		if err == nil {
+			event["iostat"] = common.MapStr{
+				"read_request_merged_per_sec":  extraMetrics.ReadRequestMergeCountPerSec,
+				"write_request_merged_per_sec": extraMetrics.WriteRequestMergeCountPerSec,
+				"read_request_per_sec":         extraMetrics.ReadRequestCountPerSec,
+				"write_request_per_sec":        extraMetrics.WriteRequestCountPerSec,
+				"read_byte_per_sec":            extraMetrics.ReadBytesPerSec,
+				"write_byte_per_sec":           extraMetrics.WriteBytesPerSec,
+				"avg_request_size":             extraMetrics.AvgRequestSize,
+				"avg_queue_size":               extraMetrics.AvgQueueSize,
+				"await":                        extraMetrics.AvgAwaitTime,
+				"service_time":                 extraMetrics.AvgServiceTime,
+				"busy":                         extraMetrics.BusyPct,
+			}
+		}
+
 		events = append(events, event)
 
 		if counters.SerialNumber != "" {
 			event["serial_number"] = counters.SerialNumber
 		}
 	}
+
+	// open a sampling means store the last cpu counter
+	m.statistics.CloseSampling()
 
 	return events, nil
 }

--- a/metricbeat/module/system/diskio/diskstat.go
+++ b/metricbeat/module/system/diskio/diskstat.go
@@ -1,0 +1,34 @@
+// +build darwin freebsd linux windows
+
+package diskio
+
+import (
+	"github.com/shirou/gopsutil/disk"
+
+	sigar "github.com/elastic/gosigar"
+)
+
+// mapping fields which output by `iostat -x` on linux
+//
+// Device:         rrqm/s   wrqm/s     r/s     w/s   rsec/s   wsec/s avgrq-sz avgqu-sz   await r_await w_await  svctm  %util
+// sda               0.06     0.78    0.09    0.27     9.42     8.06    48.64     0.00    1.34    0.99    1.45   0.77   0.03
+type DiskIOMetric struct {
+	ReadRequestMergeCountPerSec  float64 `json:"rrqmCps"`
+	WriteRequestMergeCountPerSec float64 `json:"wrqmCps"`
+	ReadRequestCountPerSec       float64 `json:"rrqCps"`
+	WriteRequestCountPerSec      float64 `json:"wrqCps"`
+	// using bytes instead of sector
+	ReadBytesPerSec  float64 `json:"rBps"`
+	WriteBytesPerSec float64 `json:"wBps"`
+	AvgRequestSize   float64 `json:"avgrqSz"`
+	AvgQueueSize     float64 `json:"avgquSz"`
+	AvgAwaitTime     float64 `json:"await"`
+	AvgServiceTime   float64 `json:"svctm"`
+	BusyPct          float64 `json:"busy"`
+}
+
+type DiskIOStat struct {
+	lastDiskIOCounters map[string]disk.IOCountersStat
+	lastCpu            sigar.Cpu
+	curCpu             sigar.Cpu
+}

--- a/metricbeat/module/system/diskio/diskstat_linux.go
+++ b/metricbeat/module/system/diskio/diskstat_linux.go
@@ -1,0 +1,97 @@
+// +build linux
+
+package diskio
+
+import (
+	"github.com/pkg/errors"
+	"github.com/shirou/gopsutil/disk"
+
+	"github.com/elastic/beats/metricbeat/module/system"
+)
+
+func Get_CLK_TCK() uint32 {
+	//return uint32(C.sysconf(C._SC_CLK_TCK))
+	//NOTE: _SC_CLK_TCK should be fetched from sysconf using cgo
+	return uint32(100)
+}
+
+func NewDiskIOStat() *DiskIOStat {
+	d := &DiskIOStat{}
+	d.lastDiskIOCounters = make(map[string]disk.IOCountersStat)
+	return d
+}
+
+// create current cpu sampling
+// need call as soon as get IOCounters
+func (stat *DiskIOStat) OpenSampling() error {
+	return stat.curCpu.Get()
+}
+
+func (stat *DiskIOStat) CalIOStatistics(counter disk.IOCountersStat) (DiskIOMetric, error) {
+	var last disk.IOCountersStat
+	var ok bool
+	var result DiskIOMetric
+
+	// if last counter not found, create one and return all 0
+	if last, ok = stat.lastDiskIOCounters[counter.Name]; !ok {
+		stat.lastDiskIOCounters[counter.Name] = counter
+		return result, nil
+	}
+
+	// calculate the delta ms between the CloseSampling and OpenSampling
+	deltams := 1000.0 * float64(stat.curCpu.Total()-stat.lastCpu.Total()) / float64(system.NumCPU) / float64(Get_CLK_TCK())
+	if deltams <= 0 {
+		return result, errors.New("The delta cpu time between close sampling and open sampling is less or equal to 0")
+	}
+
+	rd_ios := counter.ReadCount - last.ReadCount
+	rd_merges := counter.MergedReadCount - last.MergedReadCount
+	rd_bytes := counter.ReadBytes - last.ReadBytes
+	rd_ticks := counter.ReadTime - last.ReadTime
+	wr_ios := counter.WriteCount - last.WriteCount
+	wr_merges := counter.MergedWriteCount - last.MergedWriteCount
+	wr_bytes := counter.WriteBytes - last.WriteBytes
+	wr_ticks := counter.WriteTime - last.WriteTime
+	ticks := counter.IoTime - last.IoTime
+	aveq := counter.WeightedIO - last.WeightedIO
+	n_ios := rd_ios + wr_ios
+	n_ticks := rd_ticks + wr_ticks
+	n_bytes := rd_bytes + wr_bytes
+	size := float64(0)
+	wait := float64(0)
+	svct := float64(0)
+
+	if n_ios > 0 {
+		size = float64(n_bytes) / float64(n_ios)
+		wait = float64(n_ticks) / float64(n_ios)
+		svct = float64(ticks) / float64(n_ios)
+	}
+
+	queue := float64(aveq) / deltams
+	per_sec := func(x uint64) float64 {
+		return 1000.0 * float64(x) / deltams
+	}
+
+	result.ReadRequestMergeCountPerSec = per_sec(rd_merges)
+	result.WriteRequestMergeCountPerSec = per_sec(wr_merges)
+	result.ReadRequestCountPerSec = per_sec(rd_ios)
+	result.WriteRequestCountPerSec = per_sec(wr_ios)
+	result.ReadBytesPerSec = per_sec(rd_bytes)
+	result.WriteBytesPerSec = per_sec(wr_bytes)
+	result.AvgRequestSize = size
+	result.AvgQueueSize = queue
+	result.AvgAwaitTime = wait
+	result.AvgServiceTime = svct
+	result.BusyPct = 100.0 * float64(ticks) / deltams
+	if result.BusyPct > 100.0 {
+		result.BusyPct = 100.0
+	}
+
+	stat.lastDiskIOCounters[counter.Name] = counter
+	return result, nil
+
+}
+
+func (stat *DiskIOStat) CloseSampling() {
+	stat.lastCpu = stat.curCpu
+}

--- a/metricbeat/module/system/diskio/diskstat_linux_test.go
+++ b/metricbeat/module/system/diskio/diskstat_linux_test.go
@@ -1,0 +1,14 @@
+// +build linux
+
+package diskio
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_Get_CLK_TCK(t *testing.T) {
+	//usually the tick is 100
+	assert.Equal(t, uint32(100), Get_CLK_TCK())
+}

--- a/metricbeat/module/system/diskio/diskstat_other.go
+++ b/metricbeat/module/system/diskio/diskstat_other.go
@@ -1,0 +1,27 @@
+// +build darwin,cgo freebsd windows
+
+package diskio
+
+import (
+	"github.com/pkg/errors"
+	"github.com/shirou/gopsutil/disk"
+)
+
+func NewDiskIOStat() *DiskIOStat {
+	d := &DiskIOStat{}
+	d.lastDiskIOCounters = make(map[string]disk.IOCountersStat)
+	return d
+}
+
+func (stat *DiskIOStat) OpenSampling() error {
+	return nil
+}
+
+func (stat *DiskIOStat) CalIOStatistics(counter disk.IOCountersStat) (DiskIOMetric, error) {
+	var result DiskIOMetric
+	return result, errors.New("Not implemented out of linux")
+}
+
+func (stat *DiskIOStat) CloseSampling() {
+	return
+}


### PR DESCRIPTION
metricbeat: enhance the system/diskio, add more metrics in output, includes:

- iostat.rrqmCps
- iostat.wrqmCps
- iostat.rrqCps
- iostat.wrqCps
- iostat.rBps
- iostat.wBps
- iostat.avgrqSz
- iostat.avgquSz
- iostat.await
- iostat.svctm
- iostat.busy

these metrics has same meaninig of `iostat`. docs and data.json are both updated.
this feature is only avaliable on linux.

the associated topic in elastic discuss is [Why system.diskio doesn’t produce I/O statistics fields like “iostat”](https://discuss.elastic.co/t/why-system-diskio-doesnt-produce-i-o-statistics-fields-like-iostat/91354)