### PR TITLE
Update broker/pipeline setup

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -19,6 +19,7 @@ https://github.com/elastic/beats/compare/v6.0.0-alpha2...master[Check the HEAD d
 - The `scripts/import_dashboards` is removed from packages. Use the `setup` command instead. {pull}4586[4586]
 - Change format of the saved kibana dashboards to have a single JSON file for each dashboard {pull}4413[4413]
 - Rename `configtest` command to `test config`. {pull}4590[4590]
+- Remove setting `queue_size` and `bulk_queue_size`. {pull}4650[4650]
 
 *Filebeat*
 
@@ -70,6 +71,8 @@ https://github.com/elastic/beats/compare/v6.0.0-alpha2...master[Check the HEAD d
 - Add support for analyzers and multifields in fields.yml. {pull}4574[4574]
 - Add support for JSON logging. {pull}4523[4523]
 - Add `test output` command, to test Elasticsearch and Logstash output settings. {pull}4590[4590]
+- Introduce configurable event queue settings: queue.mem.events, queue.mem.flush.min_events and queue.mem.flush.timeout. {pull}4650[4650]
+- Enable pipelining in Logstash output by default. {pull}4650[4650]
 
 *Filebeat*
 
@@ -81,6 +84,7 @@ https://github.com/elastic/beats/compare/v6.0.0-alpha2...master[Check the HEAD d
 - Add udp prospector type. {pull}4452[4452]
 - Enabled Cgo which means libc is dynamically compiled. {pull}4546[4546]
 - Add Beta module config reloading mechanism {pull}4566[4566]
+- Remove spooler and publisher components and settings. {pull}4644[4644]
 
 *Heartbeat*
 

--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -86,12 +86,25 @@ auditbeat.modules:
 # sub-dictionary. Default is false.
 #fields_under_root: false
 
-# Internal queue size for single events in processing pipeline
-#queue_size: 1000
+# Internal queue configuration for buffering events to be published.
+#queue:
+  # Queue type by name (default 'mem')
+  # The memory queue will present all available events (up to the outputs
+  # bulk_max_size) to the output, the moment the output is ready to server
+  # another batch of events.
+  #mem:
+    # Max number of events the queue can buffer.
+    #events: 4096
 
-# The internal queue size for bulk events in the processing pipeline.
-# Do not modify this value.
-#bulk_queue_size: 0
+    # Hints the minimum number of events stored in the queue,
+    # before providing a batch of events to the outputs.
+    # A value of 0 (the default) ensures events are immediately available
+    # to be sent to the outputs.
+    #flush.min_events: 0
+
+    # Maximum duration after which events are available to the outputs,
+    # if the number of events stored in the queue is < min_flush_events.
+    #flush.timeout: 0s
 
 # Sets the maximum number of CPUs that can be executing simultaneously. The
 # default is the number of logical CPUs available in the system.
@@ -284,9 +297,9 @@ output.elasticsearch:
   # Optional load balance the events between the Logstash hosts
   #loadbalance: true
 
-  # Number of batches to be send asynchronously to logstash while processing
+  # Number of batches to be sent asynchronously to logstash while processing
   # new batches.
-  #pipelining: 0
+  #pipelining: 5
 
   # Optional index name. The default index name is set to name of the beat
   # in all lowercase.

--- a/filebeat/_meta/common.reference.p2.yml
+++ b/filebeat/_meta/common.reference.p2.yml
@@ -240,21 +240,10 @@ filebeat.prospectors:
 
 #========================= Filebeat global options ============================
 
-# Event count spool threshold - forces network flush if exceeded
-#filebeat.spool_size: 2048
-
-# Enable async publisher pipeline in filebeat (Experimental!)
-#filebeat.publish_async: false
-
-# Defines how often the spooler is flushed. After idle_timeout the spooler is
-# Flush even though spool_size is not reached.
-#filebeat.idle_timeout: 5s
-
 # Name of the registry file. If a relative path is used, it is considered relative to the
 # data path.
 #filebeat.registry_file: ${path.data}/registry
 
-#
 # These config files must have the full filebeat config part inside, but only
 # the prospector part is processed. All global options like spool_size are ignored.
 # The config_dir MUST point to a different directory then where the main filebeat config file is in.

--- a/filebeat/config/config.go
+++ b/filebeat/config/config.go
@@ -20,9 +20,6 @@ const (
 
 type Config struct {
 	Prospectors      []*common.Config `config:"prospectors"`
-	SpoolSize        uint64           `config:"spool_size" validate:"min=1"`
-	PublishAsync     bool             `config:"publish_async"`
-	IdleTimeout      time.Duration    `config:"idle_timeout" validate:"nonzero,min=0s"`
 	RegistryFile     string           `config:"registry_file"`
 	ConfigDir        string           `config:"config_dir"`
 	ShutdownTimeout  time.Duration    `config:"shutdown_timeout"`
@@ -34,8 +31,6 @@ type Config struct {
 var (
 	DefaultConfig = Config{
 		RegistryFile:    "registry",
-		SpoolSize:       2048,
-		IdleTimeout:     5 * time.Second,
 		ShutdownTimeout: 0,
 	}
 )

--- a/filebeat/config/config_test.go
+++ b/filebeat/config/config_test.go
@@ -22,8 +22,6 @@ func TestReadConfig2(t *testing.T) {
 	// Reads second config file
 	err = cfgfile.Read(config, absPath+"/config2.yml")
 	assert.Nil(t, err)
-
-	assert.Equal(t, uint64(0), config.SpoolSize)
 }
 
 func TestGetConfigFiles_File(t *testing.T) {

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -409,21 +409,10 @@ filebeat.prospectors:
 
 #========================= Filebeat global options ============================
 
-# Event count spool threshold - forces network flush if exceeded
-#filebeat.spool_size: 2048
-
-# Enable async publisher pipeline in filebeat (Experimental!)
-#filebeat.publish_async: false
-
-# Defines how often the spooler is flushed. After idle_timeout the spooler is
-# Flush even though spool_size is not reached.
-#filebeat.idle_timeout: 5s
-
 # Name of the registry file. If a relative path is used, it is considered relative to the
 # data path.
 #filebeat.registry_file: ${path.data}/registry
 
-#
 # These config files must have the full filebeat config part inside, but only
 # the prospector part is processed. All global options like spool_size are ignored.
 # The config_dir MUST point to a different directory then where the main filebeat config file is in.
@@ -469,12 +458,25 @@ filebeat.prospectors:
 # sub-dictionary. Default is false.
 #fields_under_root: false
 
-# Internal queue size for single events in processing pipeline
-#queue_size: 1000
+# Internal queue configuration for buffering events to be published.
+#queue:
+  # Queue type by name (default 'mem')
+  # The memory queue will present all available events (up to the outputs
+  # bulk_max_size) to the output, the moment the output is ready to server
+  # another batch of events.
+  #mem:
+    # Max number of events the queue can buffer.
+    #events: 4096
 
-# The internal queue size for bulk events in the processing pipeline.
-# Do not modify this value.
-#bulk_queue_size: 0
+    # Hints the minimum number of events stored in the queue,
+    # before providing a batch of events to the outputs.
+    # A value of 0 (the default) ensures events are immediately available
+    # to be sent to the outputs.
+    #flush.min_events: 0
+
+    # Maximum duration after which events are available to the outputs,
+    # if the number of events stored in the queue is < min_flush_events.
+    #flush.timeout: 0s
 
 # Sets the maximum number of CPUs that can be executing simultaneously. The
 # default is the number of logical CPUs available in the system.
@@ -667,9 +669,9 @@ output.elasticsearch:
   # Optional load balance the events between the Logstash hosts
   #loadbalance: true
 
-  # Number of batches to be send asynchronously to logstash while processing
+  # Number of batches to be sent asynchronously to logstash while processing
   # new batches.
-  #pipelining: 0
+  #pipelining: 5
 
   # Optional index name. The default index name is set to name of the beat
   # in all lowercase.

--- a/filebeat/tests/system/config/filebeat.yml.j2
+++ b/filebeat/tests/system/config/filebeat.yml.j2
@@ -89,13 +89,10 @@ filebeat.prospectors:
 {{prospector_raw}}
 {% endif %}
 
-filebeat.spool_size:
 filebeat.shutdown_timeout: {{ shutdown_timeout|default(0) }}
-filebeat.idle_timeout: 0.1s
 {% if not skip_registry_config %}
 filebeat.registry_file: {{ beat.working_dir + '/' }}{{ registryFile|default("registry")}}
 {%endif%}
-filebeat.publish_async: {{publish_async}}
 
 {% if reload or reload_path -%}
 filebeat.config.{{ reload_type|default("prospectors") }}:

--- a/filebeat/tests/system/test_publisher.py
+++ b/filebeat/tests/system/test_publisher.py
@@ -23,7 +23,6 @@ class Test(BaseTest):
 
         self.render_config_template(
             path=os.path.abspath(self.working_dir) + "/log/*",
-            publish_async=True
         )
         os.mkdir(self.working_dir + "/log/")
 

--- a/heartbeat/heartbeat.reference.yml
+++ b/heartbeat/heartbeat.reference.yml
@@ -236,12 +236,25 @@ heartbeat.scheduler:
 # sub-dictionary. Default is false.
 #fields_under_root: false
 
-# Internal queue size for single events in processing pipeline
-#queue_size: 1000
+# Internal queue configuration for buffering events to be published.
+#queue:
+  # Queue type by name (default 'mem')
+  # The memory queue will present all available events (up to the outputs
+  # bulk_max_size) to the output, the moment the output is ready to server
+  # another batch of events.
+  #mem:
+    # Max number of events the queue can buffer.
+    #events: 4096
 
-# The internal queue size for bulk events in the processing pipeline.
-# Do not modify this value.
-#bulk_queue_size: 0
+    # Hints the minimum number of events stored in the queue,
+    # before providing a batch of events to the outputs.
+    # A value of 0 (the default) ensures events are immediately available
+    # to be sent to the outputs.
+    #flush.min_events: 0
+
+    # Maximum duration after which events are available to the outputs,
+    # if the number of events stored in the queue is < min_flush_events.
+    #flush.timeout: 0s
 
 # Sets the maximum number of CPUs that can be executing simultaneously. The
 # default is the number of logical CPUs available in the system.
@@ -434,9 +447,9 @@ output.elasticsearch:
   # Optional load balance the events between the Logstash hosts
   #loadbalance: true
 
-  # Number of batches to be send asynchronously to logstash while processing
+  # Number of batches to be sent asynchronously to logstash while processing
   # new batches.
-  #pipelining: 0
+  #pipelining: 5
 
   # Optional index name. The default index name is set to name of the beat
   # in all lowercase.

--- a/libbeat/_meta/config.reference.yml
+++ b/libbeat/_meta/config.reference.yml
@@ -22,12 +22,25 @@
 # sub-dictionary. Default is false.
 #fields_under_root: false
 
-# Internal queue size for single events in processing pipeline
-#queue_size: 1000
+# Internal queue configuration for buffering events to be published.
+#queue:
+  # Queue type by name (default 'mem')
+  # The memory queue will present all available events (up to the outputs
+  # bulk_max_size) to the output, the moment the output is ready to server
+  # another batch of events.
+  #mem:
+    # Max number of events the queue can buffer.
+    #events: 4096
 
-# The internal queue size for bulk events in the processing pipeline.
-# Do not modify this value.
-#bulk_queue_size: 0
+    # Hints the minimum number of events stored in the queue,
+    # before providing a batch of events to the outputs.
+    # A value of 0 (the default) ensures events are immediately available
+    # to be sent to the outputs.
+    #flush.min_events: 0
+
+    # Maximum duration after which events are available to the outputs,
+    # if the number of events stored in the queue is < min_flush_events.
+    #flush.timeout: 0s
 
 # Sets the maximum number of CPUs that can be executing simultaneously. The
 # default is the number of logical CPUs available in the system.
@@ -220,9 +233,9 @@ output.elasticsearch:
   # Optional load balance the events between the Logstash hosts
   #loadbalance: true
 
-  # Number of batches to be send asynchronously to logstash while processing
+  # Number of batches to be sent asynchronously to logstash while processing
   # new batches.
-  #pipelining: 0
+  #pipelining: 5
 
   # Optional index name. The default index name is set to name of the beat
   # in all lowercase.

--- a/libbeat/monitoring/report/elasticsearch/elasticsearch.go
+++ b/libbeat/monitoring/report/elasticsearch/elasticsearch.go
@@ -105,7 +105,10 @@ func makeReporter(beat common.BeatInfo, cfg *common.Config) (report.Reporter, er
 	}
 
 	brokerFactory := func(e broker.Eventer) (broker.Broker, error) {
-		return membroker.NewBroker(e, 20, false), nil
+		return membroker.NewBroker(membroker.Settings{
+			Eventer: e,
+			Events:  20,
+		}), nil
 	}
 	pipeline, err := pipeline.New(brokerFactory, out, pipeline.Settings{
 		WaitClose:     0,

--- a/libbeat/outputs/logstash/config.go
+++ b/libbeat/outputs/logstash/config.go
@@ -30,6 +30,7 @@ type Backoff struct {
 var defaultConfig = Config{
 	Port:             5044,
 	LoadBalance:      false,
+	Pipelining:       5,
 	BulkMaxSize:      2048,
 	CompressionLevel: 3,
 	Timeout:          30 * time.Second,

--- a/libbeat/publisher/bc/publisher/pipeline.go
+++ b/libbeat/publisher/bc/publisher/pipeline.go
@@ -2,17 +2,15 @@ package publisher
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/outputs"
 	"github.com/elastic/beats/libbeat/processors"
 	"github.com/elastic/beats/libbeat/publisher/broker"
-	"github.com/elastic/beats/libbeat/publisher/broker/membroker"
 	"github.com/elastic/beats/libbeat/publisher/pipeline"
 )
-
-const defaultBrokerSize = 8 * 1024
 
 func createPipeline(
 	beatInfo common.BeatInfo,
@@ -20,13 +18,6 @@ func createPipeline(
 	processors *processors.Processors,
 	outcfg common.ConfigNamespace,
 ) (*pipeline.Pipeline, error) {
-	queueSize := defaultBrokerSize
-	if qs := shipper.QueueSize; qs != nil {
-		if sz := *qs; sz > 0 {
-			queueSize = sz
-		}
-	}
-
 	var out outputs.Group
 	if !(*publishDisabled) {
 		var err error
@@ -63,11 +54,27 @@ func createPipeline(
 		},
 	}
 
-	brokerFactory := func(e broker.Eventer) (broker.Broker, error) {
-		return membroker.NewBroker(e, queueSize, false), nil
+	brokerType := "mem"
+	if b := shipper.Queue.Name(); b != "" {
+		brokerType = b
 	}
 
-	p, err := pipeline.New(brokerFactory, out, settings)
+	brokerFactory := broker.FindFactory(brokerType)
+	if brokerFactory == nil {
+		return nil, fmt.Errorf("'%v' is no valid queue type", brokerType)
+	}
+
+	brokerConfig := shipper.Queue.Config()
+	if brokerConfig == nil {
+		brokerConfig = common.NewConfig()
+	}
+
+	p, err := pipeline.New(
+		func(eventer broker.Eventer) (broker.Broker, error) {
+			return brokerFactory(eventer, brokerConfig)
+		},
+		out, settings,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/libbeat/publisher/bc/publisher/publish.go
+++ b/libbeat/publisher/bc/publisher/publish.go
@@ -48,19 +48,13 @@ type BeatPublisher struct {
 }
 
 type ShipperConfig struct {
-	common.EventMetadata `config:",inline"` // Fields and tags to add to each event.
-	Name                 string             `config:"name"`
+	common.EventMetadata `config:",inline"`     // Fields and tags to add to each event.
+	Name                 string                 `config:"name"`
+	Queue                common.ConfigNamespace `config:"queue"`
 
 	// internal publisher queue sizes
-	QueueSize     *int `config:"queue_size"`
-	BulkQueueSize *int `config:"bulk_queue_size"`
-	MaxProcs      *int `config:"max_procs"`
+	MaxProcs *int `config:"max_procs"`
 }
-
-const (
-	DefaultQueueSize     = 1000
-	DefaultBulkQueueSize = 0
-)
 
 func init() {
 	publishDisabled = flag.Bool("N", false, "Disable actual publishing for testing")
@@ -92,8 +86,6 @@ func (publisher *BeatPublisher) init(
 	if publisher.disabled {
 		logp.Info("Dry run mode. All output types except the file based one are disabled.")
 	}
-
-	shipper.InitShipperConfig()
 
 	publisher.name = shipper.Name
 	if publisher.name == "" {
@@ -132,18 +124,4 @@ func (publisher *BeatPublisher) SetACKHandler(h beat.PipelineACKHandler) error {
 
 func (publisher *BeatPublisher) GetName() string {
 	return publisher.name
-}
-
-func (config *ShipperConfig) InitShipperConfig() {
-
-	// TODO: replace by ucfg
-	if config.QueueSize == nil || *config.QueueSize <= 0 {
-		queueSize := DefaultQueueSize
-		config.QueueSize = &queueSize
-	}
-
-	if config.BulkQueueSize == nil || *config.BulkQueueSize < 0 {
-		bulkQueueSize := DefaultBulkQueueSize
-		config.BulkQueueSize = &bulkQueueSize
-	}
 }

--- a/libbeat/publisher/broker/membroker/broker_test.go
+++ b/libbeat/publisher/broker/membroker/broker_test.go
@@ -50,6 +50,6 @@ func TestProducerCancelRemovesEvents(t *testing.T) {
 
 func makeTestBroker(sz int) brokertest.BrokerFactory {
 	return func() broker.Broker {
-		return NewBroker(nil, sz, true)
+		return NewBroker(Settings{Events: sz, WaitOnClose: true})
 	}
 }

--- a/libbeat/publisher/broker/membroker/buf.go
+++ b/libbeat/publisher/broker/membroker/buf.go
@@ -240,6 +240,14 @@ func (b *brokerBuffer) Empty() bool {
 	return (b.regA.size - b.reserved) == 0
 }
 
+func (b *brokerBuffer) Avail() int {
+	return b.regA.size - b.reserved
+}
+
+func (b *brokerBuffer) TotalAvail() int {
+	return b.regA.size + b.regB.size - b.reserved
+}
+
 func (b *brokerBuffer) Full() bool {
 	var avail int
 	if b.regB.size > 0 {

--- a/libbeat/publisher/broker/membroker/config.go
+++ b/libbeat/publisher/broker/membroker/config.go
@@ -1,9 +1,26 @@
 package membroker
 
+import (
+	"errors"
+	"time"
+)
+
 type config struct {
-	Events int `config:"events" validate:"min=32"`
+	Events         int           `config:"events" validate:"min=32"`
+	FlushMinEvents int           `config:"flush.min_events" validate:"min=0"`
+	FlushTimeout   time.Duration `config:"flush.timeout"`
 }
 
 var defaultConfig = config{
-	Events: 4096,
+	Events:         4 * 1024,
+	FlushMinEvents: 0,
+	FlushTimeout:   0,
+}
+
+func (c *config) Validate() error {
+	if c.FlushMinEvents > c.Events {
+		return errors.New("flush.min_events must be less events")
+	}
+
+	return nil
 }

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -431,12 +431,25 @@ metricbeat.modules:
 # sub-dictionary. Default is false.
 #fields_under_root: false
 
-# Internal queue size for single events in processing pipeline
-#queue_size: 1000
+# Internal queue configuration for buffering events to be published.
+#queue:
+  # Queue type by name (default 'mem')
+  # The memory queue will present all available events (up to the outputs
+  # bulk_max_size) to the output, the moment the output is ready to server
+  # another batch of events.
+  #mem:
+    # Max number of events the queue can buffer.
+    #events: 4096
 
-# The internal queue size for bulk events in the processing pipeline.
-# Do not modify this value.
-#bulk_queue_size: 0
+    # Hints the minimum number of events stored in the queue,
+    # before providing a batch of events to the outputs.
+    # A value of 0 (the default) ensures events are immediately available
+    # to be sent to the outputs.
+    #flush.min_events: 0
+
+    # Maximum duration after which events are available to the outputs,
+    # if the number of events stored in the queue is < min_flush_events.
+    #flush.timeout: 0s
 
 # Sets the maximum number of CPUs that can be executing simultaneously. The
 # default is the number of logical CPUs available in the system.
@@ -629,9 +642,9 @@ output.elasticsearch:
   # Optional load balance the events between the Logstash hosts
   #loadbalance: true
 
-  # Number of batches to be send asynchronously to logstash while processing
+  # Number of batches to be sent asynchronously to logstash while processing
   # new batches.
-  #pipelining: 0
+  #pipelining: 5
 
   # Optional index name. The default index name is set to name of the beat
   # in all lowercase.

--- a/packetbeat/beater/packetbeat.go
+++ b/packetbeat/beater/packetbeat.go
@@ -103,9 +103,6 @@ func (pb *packetbeat) init(b *beat.Beat) error {
 		return err
 	}
 
-	// This is required as init Beat is called before the beat publisher is initialised
-	b.Config.Shipper.InitShipperConfig()
-
 	pb.pipeline = b.Publisher
 	pb.transPub, err = publish.NewTransactionPublisher(
 		b.Publisher,

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -474,12 +474,25 @@ packetbeat.protocols:
 # sub-dictionary. Default is false.
 #fields_under_root: false
 
-# Internal queue size for single events in processing pipeline
-#queue_size: 1000
+# Internal queue configuration for buffering events to be published.
+#queue:
+  # Queue type by name (default 'mem')
+  # The memory queue will present all available events (up to the outputs
+  # bulk_max_size) to the output, the moment the output is ready to server
+  # another batch of events.
+  #mem:
+    # Max number of events the queue can buffer.
+    #events: 4096
 
-# The internal queue size for bulk events in the processing pipeline.
-# Do not modify this value.
-#bulk_queue_size: 0
+    # Hints the minimum number of events stored in the queue,
+    # before providing a batch of events to the outputs.
+    # A value of 0 (the default) ensures events are immediately available
+    # to be sent to the outputs.
+    #flush.min_events: 0
+
+    # Maximum duration after which events are available to the outputs,
+    # if the number of events stored in the queue is < min_flush_events.
+    #flush.timeout: 0s
 
 # Sets the maximum number of CPUs that can be executing simultaneously. The
 # default is the number of logical CPUs available in the system.
@@ -672,9 +685,9 @@ output.elasticsearch:
   # Optional load balance the events between the Logstash hosts
   #loadbalance: true
 
-  # Number of batches to be send asynchronously to logstash while processing
+  # Number of batches to be sent asynchronously to logstash while processing
   # new batches.
-  #pipelining: 0
+  #pipelining: 5
 
   # Optional index name. The default index name is set to name of the beat
   # in all lowercase.

--- a/winlogbeat/config/config.go
+++ b/winlogbeat/config/config.go
@@ -43,10 +43,8 @@ func (s Settings) Validate() error {
 	// TODO: winlogbeat should not try to validate top-level beats config
 
 	validKeys := []string{
-		"fields", "fields_under_root", "tags", "name",
-		"queue_size", "bulk_queue_size", "max_procs",
-		"processors", "logging", "output", "path", "winlogbeat",
-		"dashboards",
+		"fields", "fields_under_root", "tags", "name", "queue", "max_procs",
+		"processors", "logging", "output", "path", "winlogbeat", "dashboards",
 	}
 	sort.Strings(validKeys)
 

--- a/winlogbeat/config/config_test.go
+++ b/winlogbeat/config/config_test.go
@@ -46,9 +46,9 @@ func TestConfigValidate(t *testing.T) {
 				},
 				map[string]interface{}{"other": "value"},
 			},
-			"1 error: Invalid top-level key 'other' found. Valid keys are bulk_queue_size, dashboards, " +
+			"1 error: Invalid top-level key 'other' found. Valid keys are dashboards, " +
 				"fields, fields_under_root, logging, max_procs, " +
-				"name, output, path, processors, queue_size, tags, winlogbeat",
+				"name, output, path, processors, queue, tags, winlogbeat",
 		},
 		{
 			WinlogbeatConfig{},

--- a/winlogbeat/winlogbeat.reference.yml
+++ b/winlogbeat/winlogbeat.reference.yml
@@ -51,12 +51,25 @@ winlogbeat.event_logs:
 # sub-dictionary. Default is false.
 #fields_under_root: false
 
-# Internal queue size for single events in processing pipeline
-#queue_size: 1000
+# Internal queue configuration for buffering events to be published.
+#queue:
+  # Queue type by name (default 'mem')
+  # The memory queue will present all available events (up to the outputs
+  # bulk_max_size) to the output, the moment the output is ready to server
+  # another batch of events.
+  #mem:
+    # Max number of events the queue can buffer.
+    #events: 4096
 
-# The internal queue size for bulk events in the processing pipeline.
-# Do not modify this value.
-#bulk_queue_size: 0
+    # Hints the minimum number of events stored in the queue,
+    # before providing a batch of events to the outputs.
+    # A value of 0 (the default) ensures events are immediately available
+    # to be sent to the outputs.
+    #flush.min_events: 0
+
+    # Maximum duration after which events are available to the outputs,
+    # if the number of events stored in the queue is < min_flush_events.
+    #flush.timeout: 0s
 
 # Sets the maximum number of CPUs that can be executing simultaneously. The
 # default is the number of logical CPUs available in the system.
@@ -249,9 +262,9 @@ output.elasticsearch:
   # Optional load balance the events between the Logstash hosts
   #loadbalance: true
 
-  # Number of batches to be send asynchronously to logstash while processing
+  # Number of batches to be sent asynchronously to logstash while processing
   # new batches.
-  #pipelining: 0
+  #pipelining: 5
 
   # Optional index name. The default index name is set to name of the beat
   # in all lowercase.


### PR DESCRIPTION
- remove settings: `filebeat.spooler`, `filebeat.publish_async`, `filebeat.idle_timeout`, `queue_size`, `bulk_queue_size`
- introduce new setting: `queue.<queue_type>`
- expose memory queue (type = 'mem') settings: `events`, `flush.min_events`, `flush.timeout`

Note: docs will be updated in a separate PR.