### PR TITLE
Update community beat list

### DIFF
--- a/libbeat/docs/communitybeats.asciidoc
+++ b/libbeat/docs/communitybeats.asciidoc
@@ -26,7 +26,6 @@ https://github.com/goomzee/burrowbeat[burrowbeat]:: Monitors Kafka consumer lag 
 https://github.com/goomzee/cassandrabeat[cassandrabeat]:: Uses Cassandra's nodetool cfstats utility to monitor Cassandra database nodes and lag.
 https://github.com/hartfordfive/cloudflarebeat[cloudflarebeat]:: Indexes log entries from the Cloudflare Enterprise Log Share API.
 https://github.com/aidan-/cloudtrailbeat[cloudtrailbeat]:: Reads events from Amazon Web Services' https://aws.amazon.com/cloudtrail/[CloudTrail].
-https://github.com/stanxii/cockroachbeat[cockroachbeat]:: Run any query on CockroachDB and send results to Elasticsearch.
 https://github.com/raboof/connbeat[connbeat]:: Exposes metadata about TCP connections.
 https://github.com/Pravoru/consulbeat[consulbeat]:: Reads services health checks from consul and pushes them to Elastic.
 https://github.com/Ingensi/dockbeat[dockbeat]:: Reads Docker container


### PR DESCRIPTION
Reverts elastic/beats#4501 because the beat is the default code from the generator. We can add it back when the Beat logic is implemented.