### PR TITLE
Add instance_name config option for perfmon metricset

### DIFF
--- a/metricbeat/module/windows/perfmon/_meta/docs.asciidoc
+++ b/metricbeat/module/windows/perfmon/_meta/docs.asciidoc
@@ -10,10 +10,11 @@ You must configure queries for the Windows performance counters that you wish
 to collect. The example below collects processor time and disk writes.
 With `format` you can set the output format for a specific counter. Possible values are
 `float` and `long`. If nothing is selected the default value is `float`.
-There is also an optional/required option `instance_name`.
-You have to set this in two cases. First if you want to name your instance other then it is computed. e.g `Total` instead of `_Total`.
-And second if you specify a counter which has no instance, for example: `\TCPIP Performance Diagnostics\IPv4 NBLs/sec indicated without prevalidation`.
-Then this option is required. For wildcard queries this option is needles.
+With `instance_name`, you can specify the name of the instance. Use this setting when:
+- You want to use an instance name that is different from the computed name. For example, `Total` instead of `_Total`.
+- You specify a counter that has no instance. For example, `\TCPIP Performance Diagnostics\IPv4 NBLs/sec indicated without prevalidation`.
+For wildcard queries this setting has no effect.
+
 
 [source,yaml]
 ----

--- a/metricbeat/module/windows/perfmon/_meta/docs.asciidoc
+++ b/metricbeat/module/windows/perfmon/_meta/docs.asciidoc
@@ -10,6 +10,10 @@ You must configure queries for the Windows performance counters that you wish
 to collect. The example below collects processor time and disk writes.
 With `format` you can set the output format for a specific counter. Possible values are
 `float` and `long`. If nothing is selected the default value is `float`.
+There is also an optional/required option `instance_name`.
+You have to set this in two cases. First if you want to name your instance other then it is computed. e.g `Total` instead of `_Total`.
+And second if you specify a counter which has no instance, for example: `\TCPIP Performance Diagnostics\IPv4 NBLs/sec indicated without prevalidation`.
+Then this option is required. For wildcard queries this option is needles.
 
 [source,yaml]
 ----
@@ -18,6 +22,7 @@ With `format` you can set the output format for a specific counter. Possible val
   period: 10s
   perfmon.counters:
     - instance_label: "processor.name"
+      instance_name: "Total"
       measurement_label: "processor.time.total.pct"
       query: '\Processor Information(_Total)\% Processor Time'
     - instance_label: "diskio.name"

--- a/metricbeat/module/windows/perfmon/pdh_integration_windows_test.go
+++ b/metricbeat/module/windows/perfmon/pdh_integration_windows_test.go
@@ -57,7 +57,7 @@ func TestQuery(t *testing.T) {
 	}
 	defer q.Close()
 
-	err = q.AddCounter(processorTimeCounter, FloatFlormat)
+	err = q.AddCounter(processorTimeCounter, FloatFlormat, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -145,7 +145,7 @@ func TestLongOutputFormat(t *testing.T) {
 	}
 	defer query.Close()
 
-	err = query.AddCounter(processorTimeCounter, LongFormat)
+	err = query.AddCounter(processorTimeCounter, LongFormat, nil)
 	if err != nil && err != PDH_NO_MORE_DATA {
 		t.Fatal(err)
 	}
@@ -179,7 +179,7 @@ func TestFloatOutputFormat(t *testing.T) {
 	}
 	defer query.Close()
 
-	err = query.AddCounter(processorTimeCounter, FloatFlormat)
+	err = query.AddCounter(processorTimeCounter, FloatFlormat, nil)
 	if err != nil && err != PDH_NO_MORE_DATA {
 		t.Fatal(err)
 	}
@@ -213,7 +213,7 @@ func TestRawValues(t *testing.T) {
 	}
 	defer query.Close()
 
-	err = query.AddCounter(processorTimeCounter, FloatFlormat)
+	err = query.AddCounter(processorTimeCounter, FloatFlormat, nil)
 	if err != nil && err != PDH_NO_MORE_DATA {
 		t.Fatal(err)
 	}

--- a/metricbeat/module/windows/perfmon/pdh_windows.go
+++ b/metricbeat/module/windows/perfmon/pdh_windows.go
@@ -163,8 +163,9 @@ func PdhCloseQuery(query PdhQueryHandle) error {
 }
 
 type Counter struct {
-	handle PdhCounterHandle
-	format PdhCounterFormat
+	handle       PdhCounterHandle
+	format       PdhCounterFormat
+	instanceName *string
 }
 
 type Counters map[string]*Counter
@@ -193,7 +194,7 @@ func NewQuery(dataSource string) (*Query, error) {
 	}, nil
 }
 
-func (q *Query) AddCounter(counterPath string, format Format) error {
+func (q *Query) AddCounter(counterPath string, format Format, instanceName *string) error {
 	if _, found := q.counters[counterPath]; found {
 		return errors.New("counter already added")
 	}
@@ -204,6 +205,7 @@ func (q *Query) AddCounter(counterPath string, format Format) error {
 	}
 
 	q.counters[counterPath] = &Counter{handle: h}
+	q.counters[counterPath].instanceName = instanceName
 	switch format {
 	case FloatFlormat:
 		q.counters[counterPath].format = PdhFmtDouble
@@ -255,9 +257,17 @@ func (q *Query) Values() (map[string][]Value, error) {
 				continue
 			}
 
-			re := regexp.MustCompile("\\((.*)\\)")
-			match := re.FindStringSubmatch(path)
-			name := match[1]
+			var name string
+			if counter.instanceName != nil {
+				name = *counter.instanceName
+			} else {
+				re := regexp.MustCompile("\\((.*)\\)")
+				match := re.FindStringSubmatch(path)
+				if cap(match) <= 0 {
+					return nil, errors.New("Your query doesn't contain an instance name. In this case you have to define one per `instance_name`")
+				}
+				name = match[1]
+			}
 
 			switch counter.format {
 			case PdhFmtDouble:
@@ -277,10 +287,10 @@ func (q *Query) Close() error {
 }
 
 type PerfmonReader struct {
-	query       *Query            // PDH Query
-	instance    map[string]string // Mapping of counter path to key used in output.
-	measurement map[string]string
-	executed    bool // Indicates if the query has been executed.
+	query         *Query            // PDH Query
+	instanceLabel map[string]string // Mapping of counter path to key used in output.
+	measurement   map[string]string
+	executed      bool // Indicates if the query has been executed.
 }
 
 func NewPerfmonReader(config []CounterConfig) (*PerfmonReader, error) {
@@ -290,9 +300,9 @@ func NewPerfmonReader(config []CounterConfig) (*PerfmonReader, error) {
 	}
 
 	r := &PerfmonReader{
-		query:       query,
-		instance:    map[string]string{},
-		measurement: map[string]string{},
+		query:         query,
+		instanceLabel: map[string]string{},
+		measurement:   map[string]string{},
 	}
 
 	for _, counter := range config {
@@ -303,12 +313,12 @@ func NewPerfmonReader(config []CounterConfig) (*PerfmonReader, error) {
 		case "long":
 			format = LongFormat
 		}
-		if err := query.AddCounter(counter.Query, format); err != nil {
+		if err := query.AddCounter(counter.Query, format, counter.InstanceName); err != nil {
 			query.Close()
 			return nil, err
 		}
 
-		r.instance[counter.Query] = counter.InstanceLabel
+		r.instanceLabel[counter.Query] = counter.InstanceLabel
 		r.measurement[counter.Query] = counter.MeasurementLabel
 
 	}
@@ -334,7 +344,7 @@ func (r *PerfmonReader) Read() ([]common.MapStr, error) {
 	for counterPath, counter := range values {
 		for _, val := range counter {
 			ev := common.MapStr{}
-			instanceKey := r.instance[counterPath]
+			instanceKey := r.instanceLabel[counterPath]
 			ev.Put(instanceKey, val.Instance)
 			measurementKey := r.measurement[counterPath]
 			ev.Put(measurementKey, val.Measurement)

--- a/metricbeat/module/windows/perfmon/perfmon.go
+++ b/metricbeat/module/windows/perfmon/perfmon.go
@@ -13,10 +13,11 @@ import (
 )
 
 type CounterConfig struct {
-	InstanceLabel    string `config:"instance_label" validate:"required"`
-	MeasurementLabel string `config:"measurement_label" validate:"required"`
-	Query            string `config:"query" validate:"required"`
-	Format           string `config:"format"`
+	InstanceLabel    string  `config:"instance_label" validate:"required"`
+	InstanceName     *string `config:"instance_name"`
+	MeasurementLabel string  `config:"measurement_label" validate:"required"`
+	Query            string  `config:"query" validate:"required"`
+	Format           string  `config:"format"`
 }
 
 func init() {


### PR DESCRIPTION
I have stumbled about this while testing some counters. In #4502 we add some new config options `instance_label` and `measurement_label`. The value for `instance_label` is computed by extracting the instance name from the query. This works fine as long as you define a wildcard query or your query contains a instance. For example `\Processor Information(_Total)\% Processor Time`. But if you define a query like this `\TCPIP Performance Diagnostics\IPv4 NBLs/sec indicated without prevalidation` there is no instance name. So we need an extra option to set the instance name. This has the side effect that we can change the instance name for normal queries. `\Processor Information(_Total)\% Processor Time` we can name the instance `Total` or `total` or whatever we want. I have changed the docs. Can you please check the grammar. Thanks!