### PR TITLE
Removed validation of top-level config keys from Winlogbeat

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -62,6 +62,9 @@ https://github.com/elastic/beats/compare/v6.0.0-alpha2...master[Check the HEAD d
 
 *Winlogbeat*
 
+- Removed validation of top-level config keys. This behavior was inconsistent with other Beats
+  and caused maintainability issues. {pull}4657[4657]
+
 ==== Added
 
 *Affecting all Beats*

--- a/winlogbeat/config/config.go
+++ b/winlogbeat/config/config.go
@@ -3,8 +3,6 @@ package config
 
 import (
 	"fmt"
-	"sort"
-	"strings"
 
 	"github.com/joeshaw/multierror"
 )
@@ -40,31 +38,7 @@ var (
 // Validate validates the Settings data and returns an error describing
 // all problems or nil if there are none.
 func (s Settings) Validate() error {
-	// TODO: winlogbeat should not try to validate top-level beats config
-
-	validKeys := []string{
-		"fields", "fields_under_root", "tags", "name", "queue", "max_procs",
-		"processors", "logging", "output", "path", "winlogbeat", "dashboards",
-	}
-	sort.Strings(validKeys)
-
-	// Check for invalid top-level keys.
-	var errs multierror.Errors
-	for k := range s.Raw {
-		k = strings.ToLower(k)
-		i := sort.SearchStrings(validKeys, k)
-		if i >= len(validKeys) || validKeys[i] != k {
-			errs = append(errs, fmt.Errorf("Invalid top-level key '%s' "+
-				"found. Valid keys are %s", k, strings.Join(validKeys, ", ")))
-		}
-	}
-
-	err := s.Winlogbeat.Validate()
-	if err != nil {
-		errs = append(errs, err)
-	}
-
-	return errs.Err()
+	return s.Winlogbeat.Validate()
 }
 
 // WinlogbeatConfig contains all of Winlogbeat configuration data.

--- a/winlogbeat/config/config_test.go
+++ b/winlogbeat/config/config_test.go
@@ -38,19 +38,6 @@ func TestConfigValidate(t *testing.T) {
 			"", // No Error
 		},
 		{
-			Settings{
-				WinlogbeatConfig{
-					EventLogs: []map[string]interface{}{
-						{"Name": "App"},
-					},
-				},
-				map[string]interface{}{"other": "value"},
-			},
-			"1 error: Invalid top-level key 'other' found. Valid keys are dashboards, " +
-				"fields, fields_under_root, logging, max_procs, " +
-				"name, output, path, processors, queue, tags, winlogbeat",
-		},
-		{
 			WinlogbeatConfig{},
 			"1 error: At least one event log must be configured as part of " +
 				"event_logs",


### PR DESCRIPTION
This behavior was inconsistent with other Beats and caused maintainability issues.