### PR TITLE
Update to Elastic Stack 6.0.0-beta1 for testing

### DIFF
--- a/testing/environments/args.yml
+++ b/testing/environments/args.yml
@@ -6,4 +6,4 @@ services:
     build:
       args:
         DOWNLOAD_URL: https://snapshots.elastic.co/downloads
-        ELASTIC_VERSION: 6.0.0-alpha3-SNAPSHOT
+        ELASTIC_VERSION: 6.0.0-beta1-SNAPSHOT


### PR DESCRIPTION
Bump snapshot version so we test against 6.0.0-beta1 snapshot artifacts.