### PR TITLE
Create Kibana index after checking ES version

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -45,6 +45,7 @@ https://github.com/elastic/beats/compare/v6.0.0-alpha2...master[Check the HEAD d
 
 - Don't stop with error loading the ES template if the ES output is not enabled. {pull}4436[4436]
 - Fix race condition in internal logging rotator. {pull}4519[4519]
+- Fix issue with loading dashboards to ES 6.0 when .kibana index did not already exist. {issue}4659[4659]
 
 *Filebeat*
 

--- a/libbeat/dashboards/config.go
+++ b/libbeat/dashboards/config.go
@@ -1,6 +1,6 @@
 package dashboards
 
-type DashboardsConfig struct {
+type Config struct {
 	Enabled        bool   `config:"enabled"`
 	KibanaIndex    string `config:"kibana_index"`
 	Index          string `config:"index"`
@@ -14,7 +14,7 @@ type DashboardsConfig struct {
 	SnapshotURL    string `config:"snapshot_url"`
 }
 
-var defaultDashboardsConfig = DashboardsConfig{
+var defaultConfig = Config{
 	KibanaIndex: ".kibana",
 }
 var (

--- a/libbeat/dashboards/dashboards.go
+++ b/libbeat/dashboards/dashboards.go
@@ -15,7 +15,7 @@ func ImportDashboards(beatName, beatVersion string, kibanaConfig *common.Config,
 		return nil
 	}
 
-	dashConfig := defaultDashboardsConfig
+	dashConfig := defaultConfig
 	dashConfig.Beat = beatName
 	dashConfig.URL = fmt.Sprintf(defaultURLPattern, beatVersion)
 	dashConfig.SnapshotURL = fmt.Sprintf(snapshotURLPattern, beatVersion)
@@ -30,7 +30,7 @@ func ImportDashboards(beatName, beatVersion string, kibanaConfig *common.Config,
 		if err != nil {
 			return err
 		}
-		if status == true {
+		if status {
 			// the dashboards were imported via Elasticsearch
 			return nil
 		}
@@ -44,8 +44,7 @@ func ImportDashboards(beatName, beatVersion string, kibanaConfig *common.Config,
 	return nil
 }
 
-func ImportDashboardsViaKibana(config *common.Config, dashConfig *DashboardsConfig) error {
-
+func ImportDashboardsViaKibana(config *common.Config, dashConfig *Config) error {
 	if config == nil {
 		config = common.NewConfig()
 	}
@@ -81,13 +80,11 @@ func ImportDashboardsViaKibana(config *common.Config, dashConfig *DashboardsConf
 	return nil
 }
 
-func ImportDashboardsViaElasticsearch(config *common.Config, dashConfig *DashboardsConfig) (bool, error) {
-
+func ImportDashboardsViaElasticsearch(config *common.Config, dashConfig *Config) (bool, error) {
 	esLoader, err := NewElasticsearchLoader(config, dashConfig, nil)
 	if err != nil {
 		return false, fmt.Errorf("fail to create the Elasticsearch loader: %v", err)
 	}
-
 	defer esLoader.Close()
 
 	logp.Debug("dashboards", "Elasticsearch URL %v", esLoader.client.Connection.URL)
@@ -116,10 +113,9 @@ func ImportDashboardsViaElasticsearch(config *common.Config, dashConfig *Dashboa
 	}
 
 	return true, nil
-
 }
-func getMajorVersion(version string) (int, error) {
 
+func getMajorVersion(version string) (int, error) {
 	fields := strings.Split(version, ".")
 	if len(fields) != 3 {
 		return 0, fmt.Errorf("wrong version %s", version)

--- a/libbeat/dashboards/dashboards.go
+++ b/libbeat/dashboards/dashboards.go
@@ -102,6 +102,10 @@ func ImportDashboardsViaElasticsearch(config *common.Config, dashConfig *Dashboa
 		return false, nil
 	}
 
+	if err := esLoader.CreateKibanaIndex(); err != nil {
+		return false, fmt.Errorf("fail to create the kibana index: %v", err)
+	}
+
 	importer, err := NewImporter("5.x", dashConfig, *esLoader)
 	if err != nil {
 		return false, fmt.Errorf("fail to create an Elasticsearch importer for loading the dashboards: %v", err)

--- a/libbeat/dashboards/es_loader.go
+++ b/libbeat/dashboards/es_loader.go
@@ -13,17 +13,14 @@ import (
 	"github.com/elastic/beats/libbeat/outputs/elasticsearch"
 )
 
-var KibanaApiStartingWith = "6.0.0-alpha2"
-
 type ElasticsearchLoader struct {
 	client       *elasticsearch.Client
-	config       *DashboardsConfig
+	config       *Config
 	version      string
-	msgOutputter *MessageOutputter
+	msgOutputter MessageOutputter
 }
 
-func NewElasticsearchLoader(cfg *common.Config, dashboardsConfig *DashboardsConfig, msgOutputter *MessageOutputter) (*ElasticsearchLoader, error) {
-
+func NewElasticsearchLoader(cfg *common.Config, dashboardsConfig *Config, msgOutputter MessageOutputter) (*ElasticsearchLoader, error) {
 	if cfg == nil || !cfg.Enabled() {
 		return nil, fmt.Errorf("Elasticsearch output is not configured/enabled")
 	}
@@ -56,28 +53,28 @@ func (loader ElasticsearchLoader) CreateKibanaIndex() error {
 	if err != nil {
 		if status != 404 {
 			return err
-		} else {
-			_, _, err = loader.client.CreateIndex(loader.config.KibanaIndex, nil)
-			if err != nil {
-				return fmt.Errorf("Failed to create index: %v", err)
-			}
+		}
 
-			_, _, err = loader.client.CreateIndex(loader.config.KibanaIndex+"/_mapping/search",
-				common.MapStr{
-					"search": common.MapStr{
-						"properties": common.MapStr{
-							"hits": common.MapStr{
-								"type": "integer",
-							},
-							"version": common.MapStr{
-								"type": "integer",
-							},
+		_, _, err = loader.client.CreateIndex(loader.config.KibanaIndex, nil)
+		if err != nil {
+			return fmt.Errorf("Failed to create index: %v", err)
+		}
+
+		_, _, err = loader.client.CreateIndex(loader.config.KibanaIndex+"/_mapping/search",
+			common.MapStr{
+				"search": common.MapStr{
+					"properties": common.MapStr{
+						"hits": common.MapStr{
+							"type": "integer",
+						},
+						"version": common.MapStr{
+							"type": "integer",
 						},
 					},
-				})
-			if err != nil {
-				return fmt.Errorf("Failed to set the mapping: %v", err)
-			}
+				},
+			})
+		if err != nil {
+			return fmt.Errorf("Failed to set the mapping: %v", err)
 		}
 	}
 
@@ -113,7 +110,6 @@ func (loader ElasticsearchLoader) ImportIndex(file string) error {
 }
 
 func (loader ElasticsearchLoader) importJSONFile(fileType string, file string) error {
-
 	path := "/" + loader.config.KibanaIndex + "/" + fileType
 
 	reader, err := ioutil.ReadFile(file)
@@ -133,7 +129,6 @@ func (loader ElasticsearchLoader) importJSONFile(fileType string, file string) e
 }
 
 func (loader ElasticsearchLoader) importPanelsFromDashboard(file string) (err error) {
-
 	// directory with the dashboards
 	dir := filepath.Dir(file)
 
@@ -160,7 +155,6 @@ func (loader ElasticsearchLoader) importPanelsFromDashboard(file string) (err er
 	json.Unmarshal([]byte(jsonContent.PanelsJSON), &widgets)
 
 	for _, widget := range widgets {
-
 		if widget.Type == "visualization" {
 			err = loader.importVisualization(path.Join(mainDir, "visualization", widget.ID+".json"))
 			if err != nil {
@@ -180,21 +174,15 @@ func (loader ElasticsearchLoader) importPanelsFromDashboard(file string) (err er
 }
 
 func (loader ElasticsearchLoader) importVisualization(file string) error {
-
 	loader.statusMsg("Import visualization %s", file)
 	if err := loader.importJSONFile("visualization", file); err != nil {
 		return err
 	}
 
-	err := loader.importSearchFromVisualization(file)
-	if err != nil {
-		return err
-	}
-	return nil
+	return loader.importSearchFromVisualization(file)
 }
 
 func (loader ElasticsearchLoader) importSearch(file string) error {
-
 	reader, err := ioutil.ReadFile(file)
 	if err != nil {
 		return err
@@ -208,7 +196,6 @@ func (loader ElasticsearchLoader) importSearch(file string) error {
 	}
 
 	if loader.config.Index != "" {
-
 		// change index pattern name
 		if savedObject, ok := searchContent["kibanaSavedObjectMeta"].(map[string]interface{}); ok {
 			if source, ok := savedObject["searchSourceJSON"].(string); ok {
@@ -229,7 +216,6 @@ func (loader ElasticsearchLoader) importSearch(file string) error {
 				savedObject["searchSourceJSON"] = string(searchSourceJSON)
 			}
 		}
-
 	}
 
 	path := "/" + loader.config.KibanaIndex + "/search/" + searchName
@@ -279,7 +265,6 @@ func (loader ElasticsearchLoader) importSearchFromVisualization(file string) err
 }
 
 func (loader ElasticsearchLoader) ImportDashboard(file string) error {
-
 	/* load dashboard */
 	err := loader.importJSONFile("dashboard", file)
 	if err != nil {
@@ -287,12 +272,7 @@ func (loader ElasticsearchLoader) ImportDashboard(file string) error {
 	}
 
 	/* load the visualizations and searches that depend on the dashboard */
-	err = loader.importPanelsFromDashboard(file)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return loader.importPanelsFromDashboard(file)
 }
 
 func (loader ElasticsearchLoader) Close() error {
@@ -301,9 +281,8 @@ func (loader ElasticsearchLoader) Close() error {
 
 func (loader ElasticsearchLoader) statusMsg(msg string, a ...interface{}) {
 	if loader.msgOutputter != nil {
-		(*loader.msgOutputter)(msg, a...)
+		loader.msgOutputter(msg, a...)
 	} else {
 		logp.Debug("dashboards", msg, a...)
 	}
-
 }

--- a/libbeat/dashboards/es_loader_test.go
+++ b/libbeat/dashboards/es_loader_test.go
@@ -16,7 +16,7 @@ func TestImporter(t *testing.T) {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"*"})
 	}
 
-	dashboardsConfig := DashboardsConfig{
+	dashboardsConfig := Config{
 		KibanaIndex: ".kibana-test",
 		File:        "testdata/testbeat-dashboards.zip",
 		Beat:        "testbeat",
@@ -45,7 +45,6 @@ func TestImporter(t *testing.T) {
 
 	status, _, _ := client.Request("GET", "/.kibana-test/dashboard/1e4389f0-e871-11e6-911d-3f8ed6f72700", "", nil, nil)
 	assert.Equal(t, 200, status)
-
 }
 
 func TestImporterEmptyBeat(t *testing.T) {
@@ -53,7 +52,7 @@ func TestImporterEmptyBeat(t *testing.T) {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"*"})
 	}
 
-	dashboardsConfig := DashboardsConfig{
+	dashboardsConfig := Config{
 		KibanaIndex: ".kibana-test-nobeat",
 		File:        "testdata/testbeat-dashboards.zip",
 		Beat:        "",
@@ -78,5 +77,4 @@ func TestImporterEmptyBeat(t *testing.T) {
 
 	status, _, _ := client.Request("GET", "/.kibana-test-nobeat/dashboard/1e4389f0-e871-11e6-911d-3f8ed6f72700", "", nil, nil)
 	assert.Equal(t, 200, status)
-
 }

--- a/libbeat/dashboards/es_loader_test.go
+++ b/libbeat/dashboards/es_loader_test.go
@@ -32,7 +32,7 @@ func TestImporter(t *testing.T) {
 		config: &dashboardsConfig,
 	}
 
-	err := loader.createKibanaIndex()
+	err := loader.CreateKibanaIndex()
 
 	assert.NoError(t, err)
 

--- a/libbeat/dashboards/importer.go
+++ b/libbeat/dashboards/importer.go
@@ -18,7 +18,7 @@ import (
 type MessageOutputter func(msg string, a ...interface{})
 
 type Importer struct {
-	cfg     *DashboardsConfig
+	cfg     *Config
 	version string
 
 	loader Loader
@@ -31,7 +31,7 @@ type Loader interface {
 	Close() error
 }
 
-func NewImporter(version string, cfg *DashboardsConfig, loader Loader) (*Importer, error) {
+func NewImporter(version string, cfg *Config, loader Loader) (*Importer, error) {
 	return &Importer{
 		cfg:     cfg,
 		version: version,
@@ -41,7 +41,6 @@ func NewImporter(version string, cfg *DashboardsConfig, loader Loader) (*Importe
 
 // Import imports the Kibana dashboards according to the configuration options.
 func (imp Importer) Import() error {
-
 	if imp.cfg.Dir != "" {
 		err := imp.ImportKibanaDir(imp.cfg.Dir)
 		if err != nil {
@@ -61,14 +60,12 @@ func (imp Importer) Import() error {
 }
 
 func (imp Importer) ImportDashboard(file string) error {
-
 	imp.loader.statusMsg("Import dashboard %s", file)
 
 	return imp.loader.ImportDashboard(file)
 }
 
 func (imp Importer) ImportFile(fileType string, file string) error {
-
 	imp.loader.statusMsg("Import %s from %s\n", fileType, file)
 
 	if fileType == "dashboard" {
@@ -80,21 +77,20 @@ func (imp Importer) ImportFile(fileType string, file string) error {
 }
 
 func (imp Importer) ImportDir(dirType string, dir string) error {
+	imp.loader.statusMsg("Import directory %s", dir)
 
 	dir = path.Join(dir, dirType)
-
-	imp.loader.statusMsg("Import directory %s", dir)
-	errors := []string{}
+	var errors []string
 
 	files, err := filepath.Glob(path.Join(dir, "*.json"))
 	if err != nil {
 		return fmt.Errorf("Failed to read directory %s. Error: %s", dir, err)
 	}
+
 	if len(files) == 0 {
 		return fmt.Errorf("The directory %s is empty, nothing to import", dir)
 	}
 	for _, file := range files {
-
 		err = imp.ImportFile(dirType, file)
 		if err != nil {
 			errors = append(errors, fmt.Sprintf("  error loading %s: %s", file, err))
@@ -104,11 +100,9 @@ func (imp Importer) ImportDir(dirType string, dir string) error {
 		return fmt.Errorf("Failed to load directory %s:\n%s", dir, strings.Join(errors, "\n"))
 	}
 	return nil
-
 }
 
 func (imp Importer) unzip(archive, target string) error {
-
 	imp.loader.statusMsg("Unzip archive %s", target)
 
 	reader, err := zip.OpenReader(archive)
@@ -121,8 +115,7 @@ func (imp Importer) unzip(archive, target string) error {
 		filePath := filepath.Join(target, file.Name)
 
 		if file.FileInfo().IsDir() {
-			os.MkdirAll(filePath, file.Mode())
-			return nil
+			return os.MkdirAll(filePath, file.Mode())
 		}
 		fileReader, err := file.Open()
 		if err != nil {
@@ -152,7 +145,6 @@ func (imp Importer) unzip(archive, target string) error {
 }
 
 func (imp Importer) ImportArchive() error {
-
 	var archive string
 
 	target, err := ioutil.TempDir("", "tmp")
@@ -215,7 +207,6 @@ func (imp Importer) ImportArchive() error {
 }
 
 func getDirectories(target string) ([]string, error) {
-
 	files, err := ioutil.ReadDir(target)
 	if err != nil {
 		return nil, err
@@ -231,7 +222,6 @@ func getDirectories(target string) ([]string, error) {
 }
 
 func (imp Importer) downloadFile(url string, target string) (string, error) {
-
 	fileName := filepath.Base(url)
 	targetPath := path.Join(target, fileName)
 	imp.loader.statusMsg("Downloading %s", url)
@@ -264,7 +254,6 @@ func (imp Importer) downloadFile(url string, target string) (string, error) {
 
 // import Kibana dashboards and index-pattern or only one of these
 func (imp Importer) ImportKibanaDir(dir string) error {
-
 	var err error
 
 	dir = path.Join(dir, imp.version)

--- a/libbeat/dashboards/kibana_loader.go
+++ b/libbeat/dashboards/kibana_loader.go
@@ -15,13 +15,12 @@ var importAPI = "/api/kibana/dashboards/import"
 
 type KibanaLoader struct {
 	client       *kibana.Client
-	config       *DashboardsConfig
+	config       *Config
 	version      string
-	msgOutputter *MessageOutputter
+	msgOutputter MessageOutputter
 }
 
-func NewKibanaLoader(cfg *common.Config, dashboardsConfig *DashboardsConfig, msgOutputter *MessageOutputter) (*KibanaLoader, error) {
-
+func NewKibanaLoader(cfg *common.Config, dashboardsConfig *Config, msgOutputter MessageOutputter) (*KibanaLoader, error) {
 	client, err := kibana.NewKibanaClient(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("Error creating Kibana client: %v", err)
@@ -40,7 +39,6 @@ func NewKibanaLoader(cfg *common.Config, dashboardsConfig *DashboardsConfig, msg
 }
 
 func (loader KibanaLoader) ImportIndex(file string) error {
-
 	params := url.Values{}
 	params.Set("force", "true") //overwrite the existing dashboards
 
@@ -51,11 +49,9 @@ func (loader KibanaLoader) ImportIndex(file string) error {
 	}
 
 	return loader.client.ImportJSON(importAPI, params, bytes.NewBuffer(content))
-
 }
 
 func (loader KibanaLoader) ImportDashboard(file string) error {
-
 	params := url.Values{}
 	params.Set("force", "true")            //overwrite the existing dashboards
 	params.Add("exclude", "index-pattern") //don't import the index pattern from the dashboards
@@ -75,7 +71,7 @@ func (loader KibanaLoader) Close() error {
 
 func (loader KibanaLoader) statusMsg(msg string, a ...interface{}) {
 	if loader.msgOutputter != nil {
-		(*loader.msgOutputter)(msg, a...)
+		loader.msgOutputter(msg, a...)
 	} else {
 		logp.Debug("dashboards", msg, a...)
 	}


### PR DESCRIPTION
Only create the .kibana index after checking that the ES version is < 6.0 because on > 6.0 the Kibana API is used.

I also removed the code to set `index.mapping.single_type` because that setting is no longer accepted by 6.0.

Fixes #4659


