### PR TITLE
Unified Pipeline/output metrics

### DIFF
--- a/libbeat/cmd/test/output.go
+++ b/libbeat/cmd/test/output.go
@@ -28,7 +28,7 @@ func GenTestOutputCmd(name, beatVersion string) *cobra.Command {
 				os.Exit(1)
 			}
 
-			output, err := outputs.Load(b.Info, b.Config.Output.Name(), b.Config.Output.Config())
+			output, err := outputs.Load(b.Info, nil, b.Config.Output.Name(), b.Config.Output.Config())
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Error initializing output: %s\n", err)
 				os.Exit(1)

--- a/libbeat/monitoring/metrics.go
+++ b/libbeat/monitoring/metrics.go
@@ -6,14 +6,15 @@ import (
 	"math"
 	"strconv"
 	"sync"
-	"sync/atomic"
+
+	"github.com/elastic/beats/libbeat/common/atomic"
 )
 
 // makeExpvar wraps a callback for registering a metrics with expvar.Publish.
 type makeExpvar func() string
 
 // Int is a 64 bit integer variable satisfying the Var interface.
-type Int struct{ i int64 }
+type Int struct{ i atomic.Int64 }
 
 // NewInt creates and registers a new integer variable.
 //
@@ -32,15 +33,47 @@ func NewInt(r *Registry, name string, opts ...Option) *Int {
 	return v
 }
 
-func (v *Int) Get() int64               { return atomic.LoadInt64(&v.i) }
-func (v *Int) Set(value int64)          { atomic.StoreInt64(&v.i, value) }
-func (v *Int) Add(delta int64)          { atomic.AddInt64(&v.i, delta) }
-func (v *Int) Inc()                     { atomic.AddInt64(&v.i, 1) }
-func (v *Int) Dec()                     { atomic.AddInt64(&v.i, -1) }
+func (v *Int) Get() int64               { return v.i.Load() }
+func (v *Int) Set(value int64)          { v.i.Store(value) }
+func (v *Int) Add(delta int64)          { v.i.Add(delta) }
+func (v *Int) Sub(delta int64)          { v.i.Sub(delta) }
+func (v *Int) Inc()                     { v.i.Inc() }
+func (v *Int) Dec()                     { v.i.Dec() }
 func (v *Int) Visit(_ Mode, vs Visitor) { vs.OnInt(v.Get()) }
 
+// Uint is a 64bit unsigned integer variable satisfying the Var interface.
+type Uint struct{ u atomic.Uint64 }
+
+// NewUint creates and registers a new unsigned integer variable.
+//
+// Note: If the registry is configured to publish variables to expvar, the
+// variable will be available via expvars package as well, but can not be removed
+// anymore.
+func NewUint(r *Registry, name string, opts ...Option) *Uint {
+	if r == nil {
+		r = Default
+	}
+
+	v := &Uint{}
+	addVar(r, name, opts, v, makeExpvar(func() string {
+		return strconv.FormatUint(v.Get(), 10)
+	}))
+	return v
+}
+
+func (v *Uint) Get() uint64      { return v.u.Load() }
+func (v *Uint) Set(value uint64) { v.u.Store(value) }
+func (v *Uint) Add(delta uint64) { v.u.Add(delta) }
+func (v *Uint) Sub(delta uint64) { v.u.Sub(delta) }
+func (v *Uint) Inc()             { v.u.Inc() }
+func (v *Uint) Dec()             { v.u.Dec() }
+func (v *Uint) Visit(_ Mode, vs Visitor) {
+	value := v.Get() & (^uint64(1 << 63))
+	vs.OnInt(int64(value))
+}
+
 // Float is a 64 bit float variable satisfying the Var interface.
-type Float struct{ f uint64 }
+type Float struct{ f atomic.Uint64 }
 
 // NewFloat creates and registers a new float variable.
 //
@@ -59,16 +92,16 @@ func NewFloat(r *Registry, name string, opts ...Option) *Float {
 	return v
 }
 
-func (v *Float) Get() float64             { return math.Float64frombits(atomic.LoadUint64(&v.f)) }
-func (v *Float) Set(value float64)        { atomic.StoreUint64(&v.f, math.Float64bits(value)) }
+func (v *Float) Get() float64             { return math.Float64frombits(v.f.Load()) }
+func (v *Float) Set(value float64)        { v.f.Store(math.Float64bits(value)) }
 func (v *Float) Sub(delta float64)        { v.Add(-delta) }
 func (v *Float) Visit(_ Mode, vs Visitor) { vs.OnFloat(v.Get()) }
 
 func (v *Float) Add(delta float64) {
 	for {
-		cur := atomic.LoadUint64(&v.f)
+		cur := v.f.Load()
 		next := math.Float64bits(math.Float64frombits(cur) + delta)
-		if atomic.CompareAndSwapUint64(&v.f, cur, next) {
+		if v.f.CAS(cur, next) {
 			return
 		}
 	}

--- a/libbeat/monitoring/report/elasticsearch/elasticsearch.go
+++ b/libbeat/monitoring/report/elasticsearch/elasticsearch.go
@@ -110,10 +110,15 @@ func makeReporter(beat common.BeatInfo, cfg *common.Config) (report.Reporter, er
 			Events:  20,
 		}), nil
 	}
-	pipeline, err := pipeline.New(brokerFactory, out, pipeline.Settings{
-		WaitClose:     0,
-		WaitCloseMode: pipeline.NoWaitOnClose,
-	})
+
+	monitoring := monitoring.Default.NewRegistry("xpack.monitoring")
+
+	pipeline, err := pipeline.New(
+		monitoring,
+		brokerFactory, out, pipeline.Settings{
+			WaitClose:     0,
+			WaitCloseMode: pipeline.NoWaitOnClose,
+		})
 	if err != nil {
 		return nil, err
 	}

--- a/libbeat/outputs/console/console.go
+++ b/libbeat/outputs/console/console.go
@@ -17,6 +17,7 @@ import (
 
 type console struct {
 	out    *os.File
+	stats  *outputs.Stats
 	writer *bufio.Writer
 	codec  codec.Codec
 	index  string
@@ -33,7 +34,11 @@ func init() {
 	outputs.RegisterType("console", makeConsole)
 }
 
-func makeConsole(beat common.BeatInfo, cfg *common.Config) (outputs.Group, error) {
+func makeConsole(
+	beat common.BeatInfo,
+	stats *outputs.Stats,
+	cfg *common.Config,
+) (outputs.Group, error) {
 	config := defaultConfig
 	err := cfg.Unpack(&config)
 	if err != nil {
@@ -51,7 +56,7 @@ func makeConsole(beat common.BeatInfo, cfg *common.Config) (outputs.Group, error
 	}
 
 	index := beat.Beat
-	c, err := newConsole(index, enc)
+	c, err := newConsole(index, stats, enc)
 	if err != nil {
 		return outputs.Fail(fmt.Errorf("console output initialization failed with: %v", err))
 	}
@@ -67,46 +72,62 @@ func makeConsole(beat common.BeatInfo, cfg *common.Config) (outputs.Group, error
 	return outputs.Success(config.BatchSize, 0, c)
 }
 
-func newConsole(index string, codec codec.Codec) (*console, error) {
-	c := &console{out: os.Stdout, codec: codec, index: index}
+func newConsole(index string, stats *outputs.Stats, codec codec.Codec) (*console, error) {
+	c := &console{out: os.Stdout, codec: codec, stats: stats, index: index}
 	c.writer = bufio.NewWriterSize(c.out, 8*1024)
 	return c, nil
 }
 
 func (c *console) Close() error { return nil }
 func (c *console) Publish(batch publisher.Batch) error {
+	st := c.stats
 	events := batch.Events()
+	st.NewBatch(len(events))
+
+	dropped := 0
 	for i := range events {
-		c.publishEvent(&events[i])
+		ok := c.publishEvent(&events[i])
+		if !ok {
+			dropped++
+		}
 	}
 
 	c.writer.Flush()
 	batch.ACK()
+
+	st.Dropped(dropped)
+	st.Acked(len(events) - dropped)
+
 	return nil
 }
 
 var nl = []byte("\n")
 
-func (c *console) publishEvent(event *publisher.Event) {
+func (c *console) publishEvent(event *publisher.Event) bool {
 	serializedEvent, err := c.codec.Encode(c.index, &event.Content)
 	if err != nil {
 		if !event.Guaranteed() {
-			return
+			return false
 		}
 
 		logp.Critical("Unable to encode event: %v", err)
-		return
+		return false
 	}
 
 	if err := c.writeBuffer(serializedEvent); err != nil {
+		c.stats.WriteError()
 		logp.Critical("Unable to publish events to console: %v", err)
-		return
+		return false
 	}
 
 	if err := c.writeBuffer(nl); err != nil {
+		c.stats.WriteError()
 		logp.Critical("Error when appending newline to event: %v", err)
-		return
+		return false
 	}
+
+	c.stats.WriteBytes(len(serializedEvent) + 1)
+	return true
 }
 
 func (c *console) writeBuffer(buf []byte) error {

--- a/libbeat/outputs/console/console_test.go
+++ b/libbeat/outputs/console/console_test.go
@@ -104,7 +104,7 @@ func TestConsoleOutput(t *testing.T) {
 
 func run(codec codec.Codec, batches ...publisher.Batch) (string, error) {
 	return withStdout(func() {
-		c, _ := newConsole("test", codec)
+		c, _ := newConsole("test", nil, codec)
 		for _, b := range batches {
 			c.Publish(b)
 		}

--- a/libbeat/outputs/elasticsearch/client_integration_test.go
+++ b/libbeat/outputs/elasticsearch/client_integration_test.go
@@ -249,7 +249,7 @@ func connectTestEs(t *testing.T, cfg interface{}) (outputs.Client, *Client) {
 		t.Fatal(err)
 	}
 
-	output, err := makeES(common.BeatInfo{Beat: "libbeat"}, config)
+	output, err := makeES(common.BeatInfo{Beat: "libbeat"}, nil, config)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libbeat/outputs/elasticsearch/elasticsearch.go
+++ b/libbeat/outputs/elasticsearch/elasticsearch.go
@@ -7,10 +7,8 @@ import (
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
-	"github.com/elastic/beats/libbeat/monitoring"
 	"github.com/elastic/beats/libbeat/outputs"
 	"github.com/elastic/beats/libbeat/outputs/outil"
-	"github.com/elastic/beats/libbeat/outputs/transport"
 )
 
 func init() {
@@ -40,20 +38,6 @@ type callbacksRegistry struct {
 // XXX: it would be fantastic to do this without a package global
 var connectCallbackRegistry callbacksRegistry
 
-// Metrics that can retrieved through the expvar web interface.
-var (
-	esMetrics = outputs.Metrics.NewRegistry("elasticsearch")
-
-	ackedEvents            = monitoring.NewInt(esMetrics, "events.acked")
-	eventsNotAcked         = monitoring.NewInt(esMetrics, "events.not_acked")
-	publishEventsCallCount = monitoring.NewInt(esMetrics, "publishEvents.call.count")
-
-	statReadBytes   = monitoring.NewInt(esMetrics, "read.bytes")
-	statWriteBytes  = monitoring.NewInt(esMetrics, "write.bytes")
-	statReadErrors  = monitoring.NewInt(esMetrics, "read.errors")
-	statWriteErrors = monitoring.NewInt(esMetrics, "write.errors")
-)
-
 // RegisterConnectCallback registers a callback for the elasticsearch output
 // The callback is called each time the client connects to elasticsearch.
 func RegisterConnectCallback(callback connectCallback) {
@@ -62,7 +46,11 @@ func RegisterConnectCallback(callback connectCallback) {
 	connectCallbackRegistry.callbacks = append(connectCallbackRegistry.callbacks, callback)
 }
 
-func makeES(beat common.BeatInfo, cfg *common.Config) (outputs.Group, error) {
+func makeES(
+	beat common.BeatInfo,
+	stats *outputs.Stats,
+	cfg *common.Config,
+) (outputs.Group, error) {
 	if !cfg.HasField("bulk_max_size") {
 		cfg.SetInt("bulk_max_size", -1, defaultBulkSize)
 	}
@@ -123,20 +111,6 @@ func makeES(beat common.BeatInfo, cfg *common.Config) (outputs.Group, error) {
 	params := config.Params
 	if len(params) == 0 {
 		params = nil
-	}
-
-	stats := &ClientStats{
-		PublishCallCount: publishEventsCallCount,
-		EventsACKed:      ackedEvents,
-		EventsFailed:     eventsNotAcked,
-		IO: &transport.IOStats{
-			Read:               statReadBytes,
-			Write:              statWriteBytes,
-			ReadErrors:         statReadErrors,
-			WriteErrors:        statWriteErrors,
-			OutputsWrite:       outputs.WriteBytes,
-			OutputsWriteErrors: outputs.WriteErrors,
-		},
 	}
 
 	clients := make([]outputs.NetworkClient, len(hosts))

--- a/libbeat/outputs/kafka/kafka.go
+++ b/libbeat/outputs/kafka/kafka.go
@@ -94,7 +94,11 @@ func kafkaMetricsRegistry() gometrics.Registry {
 	return kafkaMetricsRegistryInstance
 }
 
-func makeKafka(beat common.BeatInfo, cfg *common.Config) (outputs.Group, error) {
+func makeKafka(
+	beat common.BeatInfo,
+	stats *outputs.Stats,
+	cfg *common.Config,
+) (outputs.Group, error) {
 	debugf("initialize kafka output")
 
 	config := defaultConfig
@@ -127,7 +131,7 @@ func makeKafka(beat common.BeatInfo, cfg *common.Config) (outputs.Group, error) 
 		return outputs.Fail(err)
 	}
 
-	client, err := newKafkaClient(hosts, beat.Beat, config.Key, topic, codec, libCfg)
+	client, err := newKafkaClient(stats, hosts, beat.Beat, config.Key, topic, codec, libCfg)
 	if err != nil {
 		return outputs.Fail(err)
 	}

--- a/libbeat/outputs/kafka/kafka_integration_test.go
+++ b/libbeat/outputs/kafka/kafka_integration_test.go
@@ -185,7 +185,7 @@ func TestKafkaPublish(t *testing.T) {
 		}
 
 		t.Run(name, func(t *testing.T) {
-			grp, err := makeKafka(common.BeatInfo{Beat: "libbeat"}, cfg)
+			grp, err := makeKafka(common.BeatInfo{Beat: "libbeat"}, nil, cfg)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/libbeat/outputs/logstash/async_test.go
+++ b/libbeat/outputs/logstash/async_test.go
@@ -35,7 +35,7 @@ func makeAsyncTestClient(conn *transport.Client) testClientDriver {
 	config := defaultConfig
 	config.Timeout = 1 * time.Second
 	config.Pipelining = 3
-	client, err := newAsyncClient(conn, &config)
+	client, err := newAsyncClient(conn, nil, &config)
 	if err != nil {
 		panic(err)
 	}

--- a/libbeat/outputs/logstash/logstash_integration_test.go
+++ b/libbeat/outputs/logstash/logstash_integration_test.go
@@ -159,7 +159,7 @@ func newTestElasticsearchOutput(t *testing.T, test string) *testOutputer {
 		"template.enabled": false,
 	})
 
-	grp, err := plugin(common.BeatInfo{Beat: "libbeat"}, config)
+	grp, err := plugin(common.BeatInfo{Beat: "libbeat"}, nil, config)
 	if err != nil {
 		t.Fatalf("init elasticsearch output plugin failed: %v", err)
 	}

--- a/libbeat/outputs/logstash/logstash_test.go
+++ b/libbeat/outputs/logstash/logstash_test.go
@@ -164,7 +164,7 @@ func newTestLumberjackOutput(
 	}
 
 	cfg, _ := common.NewConfigFrom(config)
-	grp, err := outputs.Load(common.BeatInfo{}, "logstash", cfg)
+	grp, err := outputs.Load(common.BeatInfo{}, nil, "logstash", cfg)
 	if err != nil {
 		t.Fatalf("init logstash output plugin failed: %v", err)
 	}

--- a/libbeat/outputs/logstash/sync_test.go
+++ b/libbeat/outputs/logstash/sync_test.go
@@ -48,7 +48,7 @@ func makeTestClient(conn *transport.Client) testClientDriver {
 	config := defaultConfig
 	config.Timeout = 1 * time.Second
 	config.TTL = 5 * time.Second
-	client, err := newSyncClient(conn, &config)
+	client, err := newSyncClient(conn, nil, &config)
 	if err != nil {
 		panic(err)
 	}

--- a/libbeat/outputs/metrics.go
+++ b/libbeat/outputs/metrics.go
@@ -1,0 +1,102 @@
+package outputs
+
+import "github.com/elastic/beats/libbeat/monitoring"
+
+// Stats provides a common type used by outputs to report common events.
+// The output events will update a set of unified output metrics in the
+// underlying monitoring.Registry.
+type Stats struct {
+	//
+	// Output event stats
+	//
+	batches *monitoring.Uint // total number of batches processed by output
+	events  *monitoring.Uint // total number of events processed by output
+
+	acked  *monitoring.Uint // total number of events ACKed by output
+	failed *monitoring.Uint // total number of events failed in output
+	active *monitoring.Uint // events sent and waiting for ACK/fail from output
+
+	//
+	// Output network connection stats
+	//
+	writeBytes  *monitoring.Uint // total amount of bytes written by output
+	writeErrors *monitoring.Uint // total number of errors on write
+
+	readBytes  *monitoring.Uint // total amount of bytes read
+	readErrors *monitoring.Uint // total number of errors while waiting for response on output
+}
+
+func MakeStats(reg *monitoring.Registry) Stats {
+	return Stats{
+		batches: monitoring.NewUint(reg, "events.batches"),
+		events:  monitoring.NewUint(reg, "events.total"),
+		acked:   monitoring.NewUint(reg, "events.acked"),
+		failed:  monitoring.NewUint(reg, "events.failed"),
+		active:  monitoring.NewUint(reg, "events.active"),
+
+		writeBytes:  monitoring.NewUint(reg, "write.bytes"),
+		writeErrors: monitoring.NewUint(reg, "write.errors"),
+
+		readBytes:  monitoring.NewUint(reg, "read.bytes"),
+		readErrors: monitoring.NewUint(reg, "read.errors"),
+	}
+}
+
+func (s *Stats) NewBatch(n int) {
+	if s != nil {
+		s.batches.Inc()
+		s.events.Add(uint64(n))
+		s.active.Add(uint64(n))
+	}
+}
+
+func (s *Stats) Acked(n int) {
+	if s != nil {
+		s.acked.Add(uint64(n))
+		s.active.Sub(uint64(n))
+	}
+}
+
+func (s *Stats) Failed(n int) {
+	if s != nil {
+		s.failed.Add(uint64(n))
+		s.active.Sub(uint64(n))
+	}
+}
+
+func (s *Stats) Dropped(n int) {
+	// number of dropped events (e.g. encoding failures)
+	if s != nil {
+		s.active.Sub(uint64(n))
+	}
+}
+
+func (s *Stats) Cancelled(n int) {
+	if s != nil {
+		s.active.Sub(uint64(n))
+	}
+}
+
+func (s *Stats) WriteError() {
+	if s != nil {
+		s.writeErrors.Inc()
+	}
+}
+
+func (s *Stats) WriteBytes(n int) {
+	if s != nil {
+		s.writeBytes.Add(uint64(n))
+	}
+}
+
+func (s *Stats) ReadError() {
+	if s != nil {
+		s.readErrors.Inc()
+	}
+}
+
+func (s *Stats) ReadBytes(n int) {
+	if s != nil {
+		s.readBytes.Add(uint64(n))
+	}
+}

--- a/libbeat/outputs/output.go
+++ b/libbeat/outputs/output.go
@@ -1,1 +1,0 @@
-package outputs

--- a/libbeat/outputs/output_reg.go
+++ b/libbeat/outputs/output_reg.go
@@ -9,7 +9,10 @@ import (
 var outputReg = map[string]Factory{}
 
 // Factory is used by output plugins to build an output instance
-type Factory func(beat common.BeatInfo, cfg *common.Config) (Group, error)
+type Factory func(
+	beat common.BeatInfo,
+	stats *Stats,
+	cfg *common.Config) (Group, error)
 
 // Group configures and combines multiple clients into load-balanced group of clients
 // being managed by the publisher pipeline.
@@ -33,11 +36,11 @@ func FindFactory(name string) Factory {
 }
 
 // Load creates and configures a output Group using a configuration object..
-func Load(info common.BeatInfo, name string, config *common.Config) (Group, error) {
+func Load(info common.BeatInfo, stats *Stats, name string, config *common.Config) (Group, error) {
 	factory := FindFactory(name)
 	if factory == nil {
 		return Group{}, fmt.Errorf("output type %v undefined", name)
 	}
 
-	return factory(info, config)
+	return factory(info, stats, config)
 }

--- a/libbeat/outputs/outputs.go
+++ b/libbeat/outputs/outputs.go
@@ -4,16 +4,7 @@
 package outputs
 
 import (
-	"github.com/elastic/beats/libbeat/monitoring"
 	"github.com/elastic/beats/libbeat/publisher"
-)
-
-var (
-	Metrics = monitoring.Default.NewRegistry("output")
-
-	AckedEvents = monitoring.NewInt(Metrics, "events.acked", monitoring.Report)
-	WriteBytes  = monitoring.NewInt(Metrics, "write.bytes", monitoring.Report)
-	WriteErrors = monitoring.NewInt(Metrics, "write.errors", monitoring.Report)
 )
 
 // Client provides the minimal interface an output must implement to be usable

--- a/libbeat/outputs/redis/redis_integration_test.go
+++ b/libbeat/outputs/redis/redis_integration_test.go
@@ -261,7 +261,7 @@ func newRedisTestingOutput(t *testing.T, cfg map[string]interface{}) *client {
 		t.Fatalf("redis output module not registered")
 	}
 
-	out, err := plugin(common.BeatInfo{Beat: "libbeat"}, config)
+	out, err := plugin(common.BeatInfo{Beat: "libbeat"}, nil, config)
 	if err != nil {
 		t.Fatalf("Failed to initialize redis output: %v", err)
 	}

--- a/libbeat/outputs/transport/client.go
+++ b/libbeat/outputs/transport/client.go
@@ -23,7 +23,7 @@ type Config struct {
 	Proxy   *ProxyConfig
 	TLS     *TLSConfig
 	Timeout time.Duration
-	Stats   *IOStats
+	Stats   IOStatser
 }
 
 func MakeDialer(c *Config) (Dialer, error) {

--- a/libbeat/outputs/transport/stats.go
+++ b/libbeat/outputs/transport/stats.go
@@ -2,20 +2,22 @@ package transport
 
 import (
 	"net"
-
-	"github.com/elastic/beats/libbeat/monitoring"
 )
 
-type IOStats struct {
-	Read, Write, ReadErrors, WriteErrors, OutputsWrite, OutputsWriteErrors *monitoring.Int
+type IOStatser interface {
+	WriteError()
+	WriteBytes(int)
+
+	ReadError()
+	ReadBytes(int)
 }
 
 type statsConn struct {
 	net.Conn
-	stats *IOStats
+	stats IOStatser
 }
 
-func StatsDialer(d Dialer, s *IOStats) Dialer {
+func StatsDialer(d Dialer, s IOStatser) Dialer {
 	return ConnWrapper(d, func(c net.Conn) net.Conn {
 		return &statsConn{c, s}
 	})
@@ -24,19 +26,17 @@ func StatsDialer(d Dialer, s *IOStats) Dialer {
 func (s *statsConn) Read(b []byte) (int, error) {
 	n, err := s.Conn.Read(b)
 	if err != nil {
-		s.stats.ReadErrors.Add(1)
+		s.stats.ReadError()
 	}
-	s.stats.Read.Add(int64(n))
+	s.stats.ReadBytes(n)
 	return n, err
 }
 
 func (s *statsConn) Write(b []byte) (int, error) {
 	n, err := s.Conn.Write(b)
 	if err != nil {
-		s.stats.WriteErrors.Add(1)
-		s.stats.OutputsWriteErrors.Add(1)
+		s.stats.WriteError()
 	}
-	s.stats.Write.Add(int64(n))
-	s.stats.OutputsWrite.Add(int64(n))
+	s.stats.WriteBytes(n)
 	return n, err
 }

--- a/libbeat/publisher/broker/membroker/eventloop.go
+++ b/libbeat/publisher/broker/membroker/eventloop.go
@@ -1,0 +1,183 @@
+package membroker
+
+import (
+	"time"
+)
+
+type eventLoop struct {
+	broker *Broker
+
+	// active broker API channels
+	events    chan pushRequest
+	get       chan getRequest
+	pubCancel chan producerCancelRequest
+
+	// ack handling
+	acks        chan int      // ackloop -> eventloop : total number of events ACKed by outputs
+	schedACKS   chan chanList // eventloop -> ackloop : active list of batches to be acked
+	pendingACKs chanList      // ordered list of active batches to be send to the ackloop
+	ackSeq      uint          // ack batch sequence number to validate ordering
+
+	// buffer flush timer state
+	timer      *time.Timer
+	idleC      <-chan time.Time
+	forceFlush bool
+}
+
+func newEventLoop(b *Broker) *eventLoop {
+	l := &eventLoop{
+		broker:    b,
+		events:    b.events,
+		pubCancel: b.pubCancel,
+		acks:      b.acks,
+	}
+
+	if to := b.idleTimeout; to > 0 {
+		// create initialy 'stopped' timer -> reset will be used
+		// on timer object, if flush timer becomes active.
+		l.timer = time.NewTimer(to)
+		if !l.timer.Stop() {
+			<-l.timer.C
+		}
+	}
+
+	return l
+}
+
+func (l *eventLoop) run() {
+	broker := l.broker
+	for {
+		select {
+		case <-broker.done:
+			return
+
+		case req := <-l.events: // producer pushing new event
+			l.handleInsert(&req)
+
+		case req := <-l.pubCancel: // producer cancellig active events
+			l.handleCancel(&req)
+
+		case req := <-l.get: // consumer asking for next batch
+			l.handleConsumer(&req)
+
+		case <-l.idleC:
+			// handle flush timer being triggered -> pending events can be forwarded via 'get'
+			l.enableFlushEvents()
+
+		case l.schedACKS <- l.pendingACKs:
+			// on send complete list of pending batches has been forwarded -> clear list and queue
+			l.schedACKS = nil
+			l.pendingACKs = chanList{}
+
+		case count := <-l.acks:
+			l.handleACK(count)
+
+		}
+
+		// update get and idle timer after state machine
+		l.get = broker.requests
+		if !l.forceFlush {
+			avail := broker.avail()
+			if avail == 0 || broker.totalAvail() < broker.minEvents {
+				l.get = nil
+
+				if avail > 0 {
+					l.startFlushTimer()
+				}
+			}
+		}
+	}
+}
+
+func (l *eventLoop) handleInsert(req *pushRequest) {
+	// log := l.broker.logger
+	// log.Debugf("push event: %v\t%v\t%p\n", req.event, req.seq, req.state)
+
+	if avail, ok := l.broker.insert(req); ok && avail == 0 {
+		// log.Debugf("buffer: all regions full")
+
+		// no more space to accept new events -> unset events queue for time being
+		l.events = nil
+	}
+}
+
+func (l *eventLoop) handleCancel(req *producerCancelRequest) {
+	// log := l.broker.logger
+	// log.Debug("handle cancel request")
+
+	var (
+		removed int
+		broker  = l.broker
+	)
+
+	if st := req.state; st != nil {
+		st.cancelled = true
+		removed = broker.cancel(st)
+	}
+
+	// signal cancel request being finished
+	if req.resp != nil {
+		req.resp <- producerCancelResponse{
+			removed: removed,
+		}
+	}
+
+	// re-enable pushRequest if buffer can take new events
+	if !broker.full() {
+		l.events = broker.events
+	}
+}
+
+func (l *eventLoop) handleConsumer(req *getRequest) {
+	// log := l.broker.logger
+
+	start, buf := l.broker.get(req.sz)
+	count := len(buf)
+	if count == 0 {
+		panic("empty batch returned")
+	}
+
+	// log.Debug("newACKChan: ", b.ackSeq, count)
+	ackCH := newACKChan(l.ackSeq, start, count)
+	l.ackSeq++
+
+	req.resp <- getResponse{buf, ackCH}
+	l.pendingACKs.append(ackCH)
+	l.schedACKS = l.broker.scheduledACKs
+
+	l.stopFlushTimer()
+}
+
+func (l *eventLoop) handleACK(count int) {
+	// log := l.broker.logger
+	// log.Debug("receive buffer ack:", count)
+
+	// Give broker/buffer a chance to clean up most recent ACKs
+	// After handling ACKs some buffer has been freed up
+	// -> always reenable producers
+	broker := l.broker
+	broker.cleanACKs(count)
+	l.events = l.broker.events
+}
+
+func (l *eventLoop) enableFlushEvents() {
+	l.forceFlush = true
+	l.idleC = nil
+}
+
+func (l *eventLoop) stopFlushTimer() {
+	l.forceFlush = false
+	if l.idleC != nil {
+		l.idleC = nil
+		if !l.timer.Stop() {
+			<-l.timer.C
+		}
+	}
+}
+
+func (l *eventLoop) startFlushTimer() {
+	if l.idleC == nil && l.timer != nil {
+		l.timer.Reset(l.broker.idleTimeout)
+		l.idleC = l.timer.C
+	}
+}

--- a/libbeat/publisher/broker/membroker/produce.go
+++ b/libbeat/publisher/broker/membroker/produce.go
@@ -52,11 +52,11 @@ func newProducer(b *Broker, cb ackHandler, dropCB func(beat.Event), dropOnCancel
 }
 
 func (p *forgetfullProducer) Publish(event publisher.Event) bool {
-	return publish(p.makeRequest(event), &p.openState)
+	return p.openState.publish(p.makeRequest(event))
 }
 
 func (p *forgetfullProducer) TryPublish(event publisher.Event) bool {
-	return tryPublish(p.makeRequest(event), &p.openState)
+	return p.openState.tryPublish(p.makeRequest(event))
 }
 
 func (p *forgetfullProducer) makeRequest(event publisher.Event) pushRequest {
@@ -69,11 +69,11 @@ func (p *forgetfullProducer) Cancel() int {
 }
 
 func (p *ackProducer) Publish(event publisher.Event) bool {
-	return publish(p.makeRequest(event), &p.openState)
+	return p.openState.publish(p.makeRequest(event))
 }
 
 func (p *ackProducer) TryPublish(event publisher.Event) bool {
-	return tryPublish(p.makeRequest(event), &p.openState)
+	return p.openState.tryPublish(p.makeRequest(event))
 }
 
 func (p *ackProducer) makeRequest(event publisher.Event) pushRequest {
@@ -108,7 +108,7 @@ func (st *openState) Close() {
 	close(st.done)
 }
 
-func publish(req pushRequest, st *openState) bool {
+func (st *openState) publish(req pushRequest) bool {
 	select {
 	case st.events <- req:
 		return true
@@ -118,7 +118,7 @@ func publish(req pushRequest, st *openState) bool {
 	}
 }
 
-func tryPublish(req pushRequest, st *openState) bool {
+func (st *openState) tryPublish(req pushRequest) bool {
 	select {
 	case st.events <- req:
 		return true

--- a/libbeat/publisher/pipeline/monitoring.go
+++ b/libbeat/publisher/pipeline/monitoring.go
@@ -1,0 +1,128 @@
+package pipeline
+
+import "github.com/elastic/beats/libbeat/monitoring"
+
+// observer is used by many component in the publisher pipeline, to report
+// internal events. The oberserver can call registered global event handlers or
+// updated shared counters/metrics for reporting.
+// All events required for reporting events/metrics on the pipeline-global level
+// are defined by observer. The components are only allowed to serve localized
+// event-handlers only (e.g. the client centric events callbacks)
+type observer struct {
+	metrics *monitoring.Registry
+
+	// clients metrics
+	clients *monitoring.Uint
+
+	// events publish/dropped stats
+	events, filtered, published, failed *monitoring.Uint
+	dropped, retry                      *monitoring.Uint // (retryer) drop/retry counters
+	activeEvents                        *monitoring.Uint
+
+	// queue metrics
+	ackedQueue *monitoring.Uint
+}
+
+func (o *observer) init(metrics *monitoring.Registry) {
+	o.metrics = metrics
+	reg := metrics.GetRegistry("pipeline")
+	if reg == nil {
+		reg = metrics.NewRegistry("pipeline")
+	}
+
+	*o = observer{
+		metrics: metrics,
+		clients: monitoring.NewUint(reg, "clients"),
+
+		events:    monitoring.NewUint(reg, "events.total"),
+		filtered:  monitoring.NewUint(reg, "events.filtered"),
+		published: monitoring.NewUint(reg, "events.published"),
+		failed:    monitoring.NewUint(reg, "events.failed"),
+		dropped:   monitoring.NewUint(reg, "events.dropped"),
+		retry:     monitoring.NewUint(reg, "events.retry"),
+
+		ackedQueue: monitoring.NewUint(reg, "queue.acked"),
+
+		activeEvents: monitoring.NewUint(reg, "events.active"),
+	}
+}
+
+func (o *observer) cleanup() {
+	o.metrics.Remove("pipeline") // drop all metrics from registry
+}
+
+//
+// client connects/disconnects
+//
+
+// (pipeline) pipeline did finish creating a new client instance
+func (o *observer) clientConnected() { o.clients.Inc() }
+
+// (client) close being called on client
+func (o *observer) clientClosing() {}
+
+// (client) client finished processing close
+func (o *observer) clientClosed() { o.clients.Dec() }
+
+//
+// client publish events
+//
+
+// (client) client is trying to publish a new event
+func (o *observer) newEvent() {
+	o.events.Inc()
+	o.activeEvents.Inc()
+}
+
+// (client) event is filtered out (on purpose or failed)
+func (o *observer) filteredEvent() {
+	o.filtered.Inc()
+	o.activeEvents.Dec()
+}
+
+// (client) managed to push an event into the publisher pipeline
+func (o *observer) publishedEvent() {
+	o.published.Inc()
+}
+
+// (client) client closing down or DropIfFull is set
+func (o *observer) failedPublishEvent() {
+	o.failed.Inc()
+	o.activeEvents.Dec()
+}
+
+//
+// queue events
+//
+
+// (queue) number of events ACKed by the queue/broker in use
+func (o *observer) queueACKed(n int) {
+	o.ackedQueue.Add(uint64(n))
+	o.activeEvents.Sub(uint64(n))
+}
+
+//
+// pipeline output events
+//
+
+// (controller) new output group is about to be loaded
+func (o *observer) updateOutputGroup() {}
+
+// (retryer) new failed batch has been received
+func (o *observer) eventsFailed(int) {}
+
+// (retryer) number of events dropped by retryer
+func (o *observer) eventsDropped(n int) {
+	o.dropped.Add(uint64(n))
+}
+
+// (retryer) number of events pushed to the output worker queue
+func (o *observer) eventsRetry(n int) {
+	o.retry.Add(uint64(n))
+}
+
+// (output) number of events to be forwarded to the output client
+func (o *observer) outBatchSend(int) {}
+
+// (output) number of events acked by the output batch
+func (o *observer) outBatchACKed(int) {}


### PR DESCRIPTION
This PR adds metrics support to the publisher pipeline + unifies the metrics used by outputs.

The metrics are registered dynamically and can be removed later on (e.g. pipeline already removes metrics after on close).

Metrics support is somewhat standardised and decoupled from outputs/publisher pipeline, by having some kind of event listener/observer/... object defining a set of common events. On every event from the outputs, the metrics (potentially multiple metrics) are updated accordingly.

The original per output type metrics have been removed (no more `output.elasticsearch...` and so on), in favor of a standardized set of metrics.

The observer is passed to the outputs and publisher pipeline. This is used to collect metrics for different pipeline instances (`xpack` and `libbeat` namespace).

pipeline metrics:

`pipeline.clients`: number of beat.Client instances (internal connections to pipeline)
`pipeline.events.total`: total number of events processed by a client
`pipeline.events.filtered`: total number of events removed by processors
`pipeline.events.published`: total number of events pushed to the queue/broker
`pipeline.events.failed`: total number of events failed to be pushed to queue (e.g. disconnect)
`pipeline.events.dropped`: total number of events dropped
`pipeline.events.retry`: total number of events retried
`pipeline.queue.acked`: total number of events ACKed by the event queue/buffer
`pipeline.events.active`: (gauge) number of active events in pipeline

output metrics:

`output.type`: configured output type (logstash, elasticsearch, ...)
`output.events.batches`: total number of batches processed by output
`output.events.total`: total number of events processed by output
`output.events.acked`: total number of events ACKed by output
`output.events.failed`: total number of events failed in output
`output.events.active`: (gauge) events sent and waiting for ACK/fail from output
`output.write.bytes`: total amount of bytes written by output
`output.write.errors`: total number of I/O errors on write
`output.read.bytes`: total amount of bytes read
`output.read.errors`: total number of I/O errors while waiting for response on output
