### PR TITLE
Fix race in filebeat shutdown with timeouts

### DIFF
--- a/filebeat/beater/filebeat.go
+++ b/filebeat/beater/filebeat.go
@@ -3,13 +3,13 @@ package beater
 import (
 	"flag"
 	"fmt"
-	"sync"
 
 	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/monitoring"
 	"github.com/elastic/beats/libbeat/outputs/elasticsearch"
 	pub "github.com/elastic/beats/libbeat/publisher/beat"
 
@@ -151,7 +151,11 @@ func (fb *Filebeat) Run(b *beat.Beat) error {
 	waitEvents := newSignalWait()
 
 	// count active events for waiting on shutdown
-	wgEvents := &sync.WaitGroup{}
+	wgEvents := &eventCounter{
+		count: monitoring.NewInt(nil, "filebeat.events.active"),
+		added: monitoring.NewUint(nil, "filebeat.events.added"),
+		done:  monitoring.NewUint(nil, "filebeat.events.done"),
+	}
 	finishedLogger := newFinishedLogger(wgEvents)
 
 	// Setup registrar to persist state

--- a/filebeat/channel/factory.go
+++ b/filebeat/channel/factory.go
@@ -1,8 +1,6 @@
 package channel
 
 import (
-	"sync"
-
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/processors"
 	"github.com/elastic/beats/libbeat/publisher/bc/publisher"
@@ -14,12 +12,17 @@ type OutletFactory struct {
 	pipeline publisher.Publisher
 
 	eventer  beat.ClientEventer
-	wgEvents *sync.WaitGroup
+	wgEvents eventCounter
+}
+
+type eventCounter interface {
+	Add(n int)
+	Done()
 }
 
 // clientEventer adjusts wgEvents if events are dropped during shutdown.
 type clientEventer struct {
-	wgEvents *sync.WaitGroup
+	wgEvents eventCounter
 }
 
 // prospectorOutletConfig defines common prospector settings
@@ -46,7 +49,7 @@ type prospectorOutletConfig struct {
 func NewOutletFactory(
 	done <-chan struct{},
 	pipeline publisher.Publisher,
-	wgEvents *sync.WaitGroup,
+	wgEvents eventCounter,
 ) *OutletFactory {
 	o := &OutletFactory{
 		done:     done,

--- a/filebeat/channel/outlet.go
+++ b/filebeat/channel/outlet.go
@@ -1,20 +1,18 @@
 package channel
 
 import (
-	"sync"
-
 	"github.com/elastic/beats/filebeat/util"
 	"github.com/elastic/beats/libbeat/common/atomic"
 	"github.com/elastic/beats/libbeat/publisher/beat"
 )
 
 type outlet struct {
-	wg     *sync.WaitGroup
+	wg     eventCounter
 	client beat.Client
 	isOpen atomic.Bool
 }
 
-func newOutlet(client beat.Client, wg *sync.WaitGroup) *outlet {
+func newOutlet(client beat.Client, wg eventCounter) *outlet {
 	o := &outlet{
 		wg:     wg,
 		client: client,

--- a/libbeat/publisher/broker/membroker/broker.go
+++ b/libbeat/publisher/broker/membroker/broker.go
@@ -252,7 +252,7 @@ func (b *Broker) reportACK(states []clientState, start, N int) {
 		if count == 0 || count > math.MaxUint32/2 {
 			// seq number comparison did underflow. This happens only if st.seq has
 			// allready been acknowledged
-			b.logger.Debug("seq number already acked: ", st.seq)
+			// b.logger.Debug("seq number already acked: ", st.seq)
 
 			st.state = nil
 			continue


### PR DESCRIPTION
- Fix race on filebeat shutdown in the ack handler quitting early.
- add metrics 
  `filebeat.events.active`: active events in filebeat (harvester -> registry)
  `filebeat.events.added`: number of events published by harvesters
  `filebeat.events.done`: number of events finalised by registry