### PR TITLE
Added 'result' field to Elasticsearch QueryResult

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -74,6 +74,7 @@ https://github.com/elastic/beats/compare/v6.0.0-alpha2...master[Check the HEAD d
 - Add `test output` command, to test Elasticsearch and Logstash output settings. {pull}4590[4590]
 - Introduce configurable event queue settings: queue.mem.events, queue.mem.flush.min_events and queue.mem.flush.timeout. {pull}4650[4650]
 - Enable pipelining in Logstash output by default. {pull}4650[4650]
+- Added 'result' field to Elasticsearch QueryResult struct for compatibility with 6.x Index and Delete API responses. {issue]4661[4661]
 
 *Filebeat*
 

--- a/libbeat/outputs/elasticsearch/api.go
+++ b/libbeat/outputs/elasticsearch/api.go
@@ -14,9 +14,10 @@ type QueryResult struct {
 	ID           string          `json:"_id"`
 	Source       json.RawMessage `json:"_source"`
 	Version      int             `json:"_version"`
-	Found        bool            `json:"found"`
 	Exists       bool            `json:"exists"`
-	Created      bool            `json:"created"`
+	Found        bool            `json:"found"`   // Only used prior to ES 6. You must also check for Result == "found".
+	Created      bool            `json:"created"` // Only used prior to ES 6. You must also check for Result == "created".
+	Result       string          `json:"result"`  // Only used in ES 6+.
 	Acknowledged bool            `json:"acknowledged"`
 	Matches      []string        `json:"matches"`
 }

--- a/libbeat/outputs/elasticsearch/api_integration_test.go
+++ b/libbeat/outputs/elasticsearch/api_integration_test.go
@@ -36,8 +36,8 @@ func TestIndex(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Index() returns error: %s", err)
 	}
-	if !resp.Created {
-		t.Errorf("Index() fails: %s", resp)
+	if !resp.Created && resp.Result != "created" {
+		t.Fatalf("Index() fails: %s", resp)
 	}
 
 	params = map[string]string{
@@ -103,7 +103,7 @@ func TestIngest(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Ingest() returns error: %s", err)
 	}
-	if !resp.Created {
+	if !resp.Created && resp.Result != "created" {
 		t.Errorf("Ingest() fails: %s", resp)
 	}
 


### PR DESCRIPTION
Added 'result' field to Elasticsearch QueryResult struct for compatibility with 6.x Index and Delete API responses. See elastic/elasticsearch#25516 for more info.

Fixes #4661 