### PR TITLE
Add more info to debug Kibana client error

### DIFF
--- a/testing/environments/docker/kibana/Dockerfile-snapshot
+++ b/testing/environments/docker/kibana/Dockerfile-snapshot
@@ -6,7 +6,9 @@ ARG DOWNLOAD_URL
 ARG ELASTIC_VERSION
 ARG XPACK
 
-HEALTHCHECK --retries=6 CMD curl -f http://localhost:5601
+RUN apt-get update && apt-get install -y jq && apt-get clean
+
+HEALTHCHECK --retries=6 CMD curl -f http://localhost:5601/api/status | jq '. | .status.overall.state' | grep -q green
 EXPOSE 5601
 
 WORKDIR /usr/share/kibana


### PR DESCRIPTION
Log the raw response with errors to make it easier to understand the cause of the error.

I also enhanced the docker healthcheck to look at the `/api/status` response from Kibana rather than just a plain HTTP 200 from `/`.

For example:


> Exiting: Error importing Kibana dashboards: fail to create the Kibana loader: Error creating Kibana client: fail to get the Kibana version:fail to unmarshal the response from GET http://localhost:5601/api/status: invalid character '<' looking for beginning of value, response=<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"... (truncated)
