### PR TITLE
Remove newlines at start and end of methods

### DIFF
--- a/auditbeat/main_test.go
+++ b/auditbeat/main_test.go
@@ -20,7 +20,6 @@ func init() {
 
 // Test started when the test binary is started. Only calls main.
 func TestSystem(t *testing.T) {
-
 	if *systemTest {
 		main()
 	}

--- a/dev-tools/cmd/dashboards/export_dashboards.go
+++ b/dev-tools/cmd/dashboards/export_dashboards.go
@@ -22,7 +22,6 @@ type manifest struct {
 }
 
 func makeURL(url, path string, params url.Values) string {
-
 	if len(params) == 0 {
 		return url + path
 	}
@@ -31,7 +30,6 @@ func makeURL(url, path string, params url.Values) string {
 }
 
 func ExtractIndexPattern(body []byte) ([]byte, error) {
-
 	var contents common.MapStr
 
 	err := json.Unmarshal(body, &contents)
@@ -62,11 +60,9 @@ func ExtractIndexPattern(body []byte) ([]byte, error) {
 	}
 
 	return newBody, nil
-
 }
 
 func Export(client *http.Client, conn string, dashboard string, out string) error {
-
 	params := url.Values{}
 
 	params.Add("dashboard", dashboard)
@@ -104,7 +100,6 @@ func Export(client *http.Client, conn string, dashboard string, out string) erro
 }
 
 func ReadManifest(file string) ([]map[string]string, error) {
-
 	cfg, err := common.LoadFile(file)
 	if err != nil {
 		return nil, fmt.Errorf("error reading manifest file: %v", err)
@@ -116,11 +111,9 @@ func ReadManifest(file string) ([]map[string]string, error) {
 		return nil, fmt.Errorf("error unpacking manifest: %v", err)
 	}
 	return manifest.Dashboards, nil
-
 }
 
 func main() {
-
 	kibanaURL := flag.String("kibana", "http://localhost:5601", "Kibana URL")
 	dashboard := flag.String("dashboard", "", "Dashboard ID")
 	fileOutput := flag.String("output", "output.json", "Output file")

--- a/dev-tools/cmd/index_template/index_template.go
+++ b/dev-tools/cmd/index_template/index_template.go
@@ -12,7 +12,6 @@ import (
 
 // main generates index templates for the beats
 func main() {
-
 	beatVersion := version.GetDefaultVersion()
 	index := flag.String("index", "", "Base index name. Normally {beat_name} (required)")
 	output := flag.String("output", "", "Required: Full path to the output file (required)")

--- a/filebeat/config/config.go
+++ b/filebeat/config/config.go
@@ -39,7 +39,6 @@ var (
 // In case path is a file, it will be directly returned.
 // In case it is a directory, it will fetch all .yml files inside this directory
 func getConfigFiles(path string) (configFiles []string, err error) {
-
 	// Check if path is valid file or dir
 	stat, err := os.Stat(path)
 	if err != nil {
@@ -68,7 +67,6 @@ func getConfigFiles(path string) (configFiles []string, err error) {
 
 // mergeConfigFiles reads in all config files given by list configFiles and merges them into config
 func mergeConfigFiles(configFiles []string, config *Config) error {
-
 	for _, file := range configFiles {
 		logp.Info("Additional configs loaded from: %s", file)
 
@@ -88,7 +86,6 @@ func mergeConfigFiles(configFiles []string, config *Config) error {
 
 // Fetches and merges all config files given by configDir. All are put into one config object
 func (config *Config) FetchConfigs() error {
-
 	configDir := config.ConfigDir
 
 	// If option not set, do nothing

--- a/filebeat/fileset/fileset_test.go
+++ b/filebeat/fileset/fileset_test.go
@@ -63,7 +63,6 @@ func TestEvaluateVarsNginx(t *testing.T) {
 }
 
 func TestEvaluateVarsNginxOverride(t *testing.T) {
-
 	modulesPath, err := filepath.Abs("../module")
 	assert.NoError(t, err)
 	fs, err := New(modulesPath, "access", &ModuleConfig{Module: "nginx"}, &FilesetConfig{
@@ -188,7 +187,6 @@ func TestGetProspectorConfigNginxOverrides(t *testing.T) {
 	filesetName, err := cfg.String("_fileset_name", -1)
 	assert.NoError(t, err)
 	assert.Equal(t, "access", filesetName)
-
 }
 
 func TestGetPipelineNginx(t *testing.T) {

--- a/filebeat/fileset/flags.go
+++ b/filebeat/fileset/flags.go
@@ -39,7 +39,6 @@ func (mo *ModuleOverrides) Get(module, fileset string) []*common.Config {
 }
 
 func getModulesCLIConfig() ([]string, *ModuleOverrides, error) {
-
 	modulesList := []string{}
 	if modulesFlag != nil {
 		modulesList = strings.Split(*modulesFlag, ",")

--- a/filebeat/fileset/modules.go
+++ b/filebeat/fileset/modules.go
@@ -289,7 +289,6 @@ func (reg *ModuleRegistry) LoadPipelines(esClient PipelineLoader) error {
 // in the requiredProcessors list are available in Elasticsearch. Returns nil if all required
 // processors are available.
 func checkAvailableProcessors(esClient PipelineLoader, requiredProcessors []ProcessorRequirement) error {
-
 	var response struct {
 		Nodes map[string]struct {
 			Ingest struct {

--- a/filebeat/fileset/modules_test.go
+++ b/filebeat/fileset/modules_test.go
@@ -101,7 +101,6 @@ func TestNewModuleRegistryConfig(t *testing.T) {
 }
 
 func TestApplyOverrides(t *testing.T) {
-
 	falseVar := false
 	trueVar := true
 

--- a/filebeat/harvester/reader/json.go
+++ b/filebeat/harvester/reader/json.go
@@ -94,7 +94,6 @@ func createJSONError(message string) common.MapStr {
 // If MessageKey is defined, the Text value from the event always
 // takes precedence.
 func MergeJSONFields(data common.MapStr, jsonFields common.MapStr, text *string, config JSONConfig) {
-
 	// The message key might have been modified by multiline
 	if len(config.MessageKey) > 0 && text != nil {
 		jsonFields[config.MessageKey] = *text

--- a/filebeat/harvester/reader/line.go
+++ b/filebeat/harvester/reader/line.go
@@ -27,7 +27,6 @@ type Line struct {
 
 // NewLine creates a new Line reader object
 func NewLine(input io.Reader, codec encoding.Encoding, bufferSize int) (*Line, error) {
-
 	encoder := codec.NewEncoder()
 
 	// Create newline char based on encoding
@@ -49,7 +48,6 @@ func NewLine(input io.Reader, codec encoding.Encoding, bufferSize int) (*Line, e
 
 // Next reads the next line until the new line character
 func (l *Line) Next() ([]byte, int, error) {
-
 	// This loop is need in case advance detects an line ending which turns out
 	// not to be one when decoded. If that is the case, reading continues.
 	for {
@@ -94,7 +92,6 @@ func (l *Line) Next() ([]byte, int, error) {
 // Reads from the buffer until a new line character is detected
 // Returns an error otherwise
 func (l *Line) advance() error {
-
 	// Initial check if buffer has already a newLine character
 	idx := l.inBuffer.IndexFrom(l.inOffset, l.nl)
 

--- a/filebeat/harvester/reader/multiline.go
+++ b/filebeat/harvester/reader/multiline.go
@@ -248,7 +248,6 @@ func (mlr *Multiline) clear() {
 
 // finalize writes the existing content into the returned message and resets all reader variables.
 func (mlr *Multiline) finalize() Message {
-
 	// Copy message from existing content
 	msg := mlr.message
 	mlr.clear()

--- a/filebeat/harvester/reader/multiline_config.go
+++ b/filebeat/harvester/reader/multiline_config.go
@@ -17,7 +17,6 @@ type MultilineConfig struct {
 }
 
 func (c *MultilineConfig) Validate() error {
-
 	if c.Match != "after" && c.Match != "before" {
 		return fmt.Errorf("unknown matcher type: %s", c.Match)
 	}

--- a/filebeat/harvester/reader/reader_test.go
+++ b/filebeat/harvester/reader/reader_test.go
@@ -26,7 +26,6 @@ func TestIsLine(t *testing.T) {
 }
 
 func TestLineEndingChars(t *testing.T) {
-
 	line := []byte("Not ending line")
 	assert.Equal(t, 0, lineEndingChars(line))
 

--- a/filebeat/harvester/registry.go
+++ b/filebeat/harvester/registry.go
@@ -50,7 +50,6 @@ func (r *Registry) Stop() {
 			h.Stop()
 		}(hv)
 	}
-
 }
 
 // WaitForCompletion can be used to wait until all harvesters are stopped
@@ -60,7 +59,6 @@ func (r *Registry) WaitForCompletion() {
 
 // Start starts the given harvester and add its to the registry
 func (r *Registry) Start(h Harvester) {
-
 	// Make sure stop is not called during starting a harvester
 	r.Lock()
 	defer r.Unlock()

--- a/filebeat/harvester/util_test.go
+++ b/filebeat/harvester/util_test.go
@@ -30,7 +30,6 @@ func TestMatchAnyRegexps(t *testing.T) {
 	matchers, err := InitMatchers("\\.gz$")
 	assert.Nil(t, err)
 	assert.Equal(t, MatchAny(matchers, "/var/log/log.gz"), true)
-
 }
 
 func TestExcludeLine(t *testing.T) {

--- a/filebeat/input/file/file_other.go
+++ b/filebeat/input/file/file_other.go
@@ -15,7 +15,6 @@ type StateOS struct {
 
 // GetOSState returns the FileStateOS for non windows systems
 func GetOSState(info os.FileInfo) StateOS {
-
 	stat := info.Sys().(*syscall.Stat_t)
 
 	// Convert inode and dev to uint64 to be cross platform compatible

--- a/filebeat/input/file/file_windows.go
+++ b/filebeat/input/file/file_windows.go
@@ -15,7 +15,6 @@ type StateOS struct {
 
 // GetOSState returns the platform specific StateOS
 func GetOSState(info os.FileInfo) StateOS {
-
 	// os.SameFile must be called to populate the id fields. Otherwise in case for example
 	// os.Stat(file) is used to get the fileInfo, the ids are empty.
 	// https://github.com/elastic/beats/filebeat/pull/53
@@ -50,7 +49,6 @@ func (fs StateOS) String() string {
 // ReadOpen opens a file for reading only
 // As Windows blocks deleting a file when its open, some special params are passed here.
 func ReadOpen(path string) (*os.File, error) {
-
 	// Set all write flags
 	// This indirectly calls syscall_windows::Open method https://github.com/golang/go/blob/7ebcf5eac7047b1eef2443eda1786672b5c70f51/src/syscall/syscall_windows.go#L251
 	// As FILE_SHARE_DELETE cannot be passed to Open, os.CreateFile must be implemented directly

--- a/filebeat/input/file/state.go
+++ b/filebeat/input/file/state.go
@@ -92,7 +92,6 @@ func (s *States) FindPrevious(newState State) State {
 // findPreviousState returns the previous state fo the file
 // In case no previous state exists, index -1 is returned
 func (s *States) findPrevious(newState State) (int, State) {
-
 	// TODO: This could be made potentially more performance by using an index (harvester id) and only use iteration as fall back
 	for index, oldState := range s.states {
 		// This is using the FileStateOS for comparison as FileInfo identifiers can only be fetched for existing files
@@ -107,7 +106,6 @@ func (s *States) findPrevious(newState State) (int, State) {
 // Cleanup cleans up the state array. All states which are older then `older` are removed
 // The number of states that were cleaned up is returned
 func (s *States) Cleanup() int {
-
 	s.Lock()
 	defer s.Unlock()
 

--- a/filebeat/main_test.go
+++ b/filebeat/main_test.go
@@ -19,7 +19,6 @@ func init() {
 
 // Test started when the test binary is started. Only calls main.
 func TestSystem(t *testing.T) {
-
 	if *systemTest {
 		main()
 	}

--- a/filebeat/processor/add_kubernetes_metadata/indexing.go
+++ b/filebeat/processor/add_kubernetes_metadata/indexing.go
@@ -47,7 +47,6 @@ func newLogsPathMatcher(cfg common.Config) (add_kubernetes_metadata.Matcher, err
 }
 
 func (f *LogPathMatcher) MetadataIndex(event common.MapStr) string {
-
 	if value, ok := event["source"]; ok {
 		source := value.(string)
 		logp.Debug("kubernetes", "Incoming source value: ", source)

--- a/filebeat/processor/add_kubernetes_metadata/indexing_test.go
+++ b/filebeat/processor/add_kubernetes_metadata/indexing_test.go
@@ -28,5 +28,4 @@ func TestLogsPathMatcher(t *testing.T) {
 	output = logMatcher.MetadataIndex(input)
 
 	assert.Equal(t, output, cid)
-
 }

--- a/filebeat/prospector/log/config.go
+++ b/filebeat/prospector/log/config.go
@@ -115,7 +115,6 @@ var ValidScanSort = map[string]struct{}{
 }
 
 func (c *config) Validate() error {
-
 	// DEPRECATED 6.0.0: warning is already outputted on propsector level
 	if c.InputType != "" {
 		c.Type = c.InputType

--- a/filebeat/prospector/log/config_test.go
+++ b/filebeat/prospector/log/config_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 func TestCleanOlderError(t *testing.T) {
-
 	config := config{
 		CleanInactive: 10 * time.Hour,
 	}
@@ -22,7 +21,6 @@ func TestCleanOlderError(t *testing.T) {
 }
 
 func TestCleanOlderIgnoreOlderError(t *testing.T) {
-
 	config := config{
 		CleanInactive: 10 * time.Hour,
 		IgnoreOlder:   15 * time.Hour,
@@ -33,7 +31,6 @@ func TestCleanOlderIgnoreOlderError(t *testing.T) {
 }
 
 func TestCleanOlderIgnoreOlderErrorEqual(t *testing.T) {
-
 	config := config{
 		CleanInactive: 10 * time.Hour,
 		IgnoreOlder:   10 * time.Hour,
@@ -44,7 +41,6 @@ func TestCleanOlderIgnoreOlderErrorEqual(t *testing.T) {
 }
 
 func TestCleanOlderIgnoreOlder(t *testing.T) {
-
 	config := config{
 		CleanInactive: 10*time.Hour + defaultConfig.ScanFrequency + 1*time.Second,
 		IgnoreOlder:   10 * time.Hour,

--- a/filebeat/prospector/log/harvester.go
+++ b/filebeat/prospector/log/harvester.go
@@ -118,7 +118,6 @@ func NewHarvester(
 
 // open does open the file given under h.Path and assigns the file handler to h.log
 func (h *Harvester) open() error {
-
 	switch h.config.Type {
 	case harvester.StdinType:
 		return h.openStdin()
@@ -150,12 +149,10 @@ func (h *Harvester) Setup() error {
 	}
 
 	return nil
-
 }
 
 // Run start the harvester and reads files line by line and sends events to the defined output
 func (h *Harvester) Run() error {
-
 	// This is to make sure a harvester is not started anymore if stop was already
 	// called before the harvester was started. The waitgroup is not incremented afterwards
 	// as otherwise it could happend that between checking for the close channel and incrementing
@@ -328,7 +325,6 @@ func (h *Harvester) sendEvent(data *util.Data) bool {
 // is started. As soon as the output becomes available again, the finished state is written
 // and processing can continue.
 func (h *Harvester) SendStateUpdate() {
-
 	if !h.source.HasState() {
 		return
 	}
@@ -360,7 +356,6 @@ func (h *Harvester) shouldExportLine(line string) bool {
 	}
 
 	return true
-
 }
 
 // openFile opens a file and checks for the encoding. In case the encoding cannot be detected
@@ -368,7 +363,6 @@ func (h *Harvester) shouldExportLine(line string) bool {
 // is returned and the harvester is closed. The file will be picked up again the next time
 // the file system is scanned
 func (h *Harvester) openFile() error {
-
 	f, err := file.ReadOpen(h.state.Source)
 	if err != nil {
 		return fmt.Errorf("Failed opening %s: %s", h.state.Source, err)
@@ -389,7 +383,6 @@ func (h *Harvester) openFile() error {
 }
 
 func (h *Harvester) validateFile(f *os.File) error {
-
 	info, err := f.Stat()
 	if err != nil {
 		return fmt.Errorf("Failed getting stats for file %s: %s", h.state.Source, err)
@@ -428,7 +421,6 @@ func (h *Harvester) validateFile(f *os.File) error {
 }
 
 func (h *Harvester) initFileOffset(file *os.File) (int64, error) {
-
 	// continue from last known offset
 	if h.state.Offset > 0 {
 		logp.Debug("harvester", "Set previous offset for file: %s. Offset: %d ", h.state.Source, h.state.Offset)
@@ -442,7 +434,6 @@ func (h *Harvester) initFileOffset(file *os.File) (int64, error) {
 
 // getState returns an updated copy of the harvester state
 func (h *Harvester) getState() file.State {
-
 	if !h.source.HasState() {
 		return file.State{}
 	}
@@ -455,7 +446,6 @@ func (h *Harvester) getState() file.State {
 }
 
 func (h *Harvester) cleanup() {
-
 	// Mark harvester as finished
 	h.state.Finished = true
 
@@ -496,7 +486,6 @@ func (h *Harvester) cleanup() {
 // log_file implements io.Reader interface and encode reader is an adapter for io.Reader to
 // reader.Reader also handling file encodings. All other readers implement reader.Reader
 func (h *Harvester) newLogFileReader() (reader.Reader, error) {
-
 	var r reader.Reader
 	var err error
 

--- a/filebeat/prospector/log/harvester_test.go
+++ b/filebeat/prospector/log/harvester_test.go
@@ -18,7 +18,6 @@ import (
 )
 
 func TestReadLine(t *testing.T) {
-
 	absPath, err := filepath.Abs("../../tests/files/logs/")
 	// All files starting with tmp are ignored
 	logFile := absPath + "/tmp" + strconv.Itoa(rand.Int()) + ".log"

--- a/filebeat/prospector/log/log.go
+++ b/filebeat/prospector/log/log.go
@@ -47,7 +47,6 @@ func NewLog(
 // Read reads from the reader and updates the offset
 // The total number of bytes read is returned.
 func (f *Log) Read(buf []byte) (int, error) {
-
 	totalN := 0
 
 	for {
@@ -90,7 +89,6 @@ func (f *Log) Read(buf []byte) (int, error) {
 
 // errorChecks checks how the given error should be handled based on the config options
 func (f *Log) errorChecks(err error) error {
-
 	if err != io.EOF {
 		logp.Err("Unexpected state reading from %s; error: %s", f.fs.Name(), err)
 		return err
@@ -149,7 +147,6 @@ func (f *Log) errorChecks(err error) error {
 }
 
 func (f *Log) wait() {
-
 	// Wait before trying to read file again. File reached EOF.
 	select {
 	case <-f.done:

--- a/filebeat/prospector/log/prospector.go
+++ b/filebeat/prospector/log/prospector.go
@@ -182,7 +182,6 @@ func (p *Prospector) Run() {
 }
 
 func (p *Prospector) removeState(state file.State) {
-
 	// Only clean up files where state is Finished
 	if !state.Finished {
 		logp.Debug("prospector", "State for file not removed because harvester not finished: %s", state.Source)
@@ -194,13 +193,11 @@ func (p *Prospector) removeState(state file.State) {
 	if err != nil {
 		logp.Err("File cleanup state update error: %s", err)
 	}
-
 }
 
 // getFiles returns all files which have to be harvested
 // All globs are expanded and then directory and excluded files are removed
 func (p *Prospector) getFiles() map[string]os.FileInfo {
-
 	paths := map[string]os.FileInfo{}
 
 	for _, path := range p.config.Paths {
@@ -265,7 +262,6 @@ func (p *Prospector) getFiles() map[string]os.FileInfo {
 
 // matchesFile returns true in case the given filePath is part of this prospector, means matches its glob patterns
 func (p *Prospector) matchesFile(filePath string) bool {
-
 	// Path is cleaned to ensure we always compare clean paths
 	filePath = filepath.Clean(filePath)
 
@@ -295,7 +291,6 @@ type FileSortInfo struct {
 }
 
 func getSortInfos(paths map[string]os.FileInfo) []FileSortInfo {
-
 	sortInfos := make([]FileSortInfo, 0, len(paths))
 	for path, info := range paths {
 		sortInfo := FileSortInfo{info: info, path: path}
@@ -368,7 +363,6 @@ func getKeys(paths map[string]os.FileInfo) []string {
 
 // Scan starts a scanGlob for each provided path/glob
 func (p *Prospector) scan() {
-
 	var sortInfos []FileSortInfo
 	var files []string
 
@@ -439,7 +433,6 @@ func (p *Prospector) scan() {
 
 // harvestExistingFile continues harvesting a file with a known state if needed
 func (p *Prospector) harvestExistingFile(newState file.State, oldState file.State) {
-
 	logp.Debug("prospector", "Update existing file for harvesting: %s, offset: %v", newState.Source, oldState.Offset)
 
 	// No harvester is running for the file, start a new harvester
@@ -539,7 +532,6 @@ func (p *Prospector) isFileExcluded(file string) bool {
 
 // isIgnoreOlder checks if the given state reached ignore_older
 func (p *Prospector) isIgnoreOlder(state file.State) bool {
-
 	// ignore_older is disable
 	if p.config.IgnoreOlder == 0 {
 		return false
@@ -555,7 +547,6 @@ func (p *Prospector) isIgnoreOlder(state file.State) bool {
 
 // isCleanInactive checks if the given state false under clean_inactive
 func (p *Prospector) isCleanInactive(state file.State) bool {
-
 	// clean_inactive is disable
 	if p.config.CleanInactive <= 0 {
 		return false
@@ -571,7 +562,6 @@ func (p *Prospector) isCleanInactive(state file.State) bool {
 
 // createHarvester creates a new harvester instance from the given state
 func (p *Prospector) createHarvester(state file.State) (*Harvester, error) {
-
 	// Each wraps the outlet, for closing the outlet individualy
 	outlet := channel.SubOutlet(p.outlet)
 	h, err := NewHarvester(
@@ -590,7 +580,6 @@ func (p *Prospector) createHarvester(state file.State) (*Harvester, error) {
 // startHarvester starts a new harvester with the given offset
 // In case the HarvesterLimit is reached, an error is returned
 func (p *Prospector) startHarvester(state file.State, offset int64) error {
-
 	if p.config.HarvesterLimit > 0 && p.harvesters.Len() >= p.config.HarvesterLimit {
 		harvesterSkipped.Add(1)
 		return fmt.Errorf("Harvester limit reached")
@@ -651,7 +640,6 @@ func (p *Prospector) Wait() {
 
 // Stop stops all harvesters and then stops the prospector
 func (p *Prospector) Stop() {
-
 	// Stop all harvesters
 	// In case the beatDone channel is closed, this will not wait for completion
 	// Otherwise Stop will wait until output is complete

--- a/filebeat/prospector/log/prospector_other_test.go
+++ b/filebeat/prospector/log/prospector_other_test.go
@@ -57,7 +57,6 @@ var matchTests = []struct {
 }
 
 func TestMatchFile(t *testing.T) {
-
 	for _, test := range matchTests {
 
 		p := Prospector{
@@ -127,7 +126,6 @@ var initStateTests = []struct {
 // TestInit checks that the correct states are in a prospector after the init phase
 // This means only the ones that match the glob and not exclude files
 func TestInit(t *testing.T) {
-
 	for _, test := range initStateTests {
 		p := Prospector{
 			config: config{
@@ -147,7 +145,6 @@ func TestInit(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, test.count, p.states.Count())
 	}
-
 }
 
 // TestOutlet is an empty outlet for testing

--- a/filebeat/prospector/log/prospector_test.go
+++ b/filebeat/prospector/log/prospector_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 func TestProspectorFileExclude(t *testing.T) {
-
 	p := Prospector{
 		config: config{
 			ExcludeFiles: []match.Matcher{match.MustCompile(`\.gz$`)},
@@ -47,7 +46,6 @@ var cleanInactiveTests = []struct {
 }
 
 func TestIsCleanInactive(t *testing.T) {
-
 	for _, test := range cleanInactiveTests {
 
 		l := Prospector{

--- a/filebeat/prospector/log/prospector_windows_test.go
+++ b/filebeat/prospector/log/prospector_windows_test.go
@@ -56,7 +56,6 @@ var matchTestsWindows = []struct {
 // TestMatchFileWindows test if match works correctly on windows
 // Separate test are needed on windows because of automated path conversion
 func TestMatchFileWindows(t *testing.T) {
-
 	for _, test := range matchTestsWindows {
 
 		p := Prospector{

--- a/filebeat/prospector/prospector.go
+++ b/filebeat/prospector/prospector.go
@@ -72,7 +72,6 @@ func NewProspector(
 }
 
 func (p *Prospector) initProspectorer(outlet channel.OutleterFactory, states []file.State, config *common.Config) error {
-
 	var prospectorer Prospectorer
 	var err error
 
@@ -124,7 +123,6 @@ func (p *Prospector) Start() {
 
 // Run starts scanning through all the file paths and fetch the related files. Start a harvester for each file
 func (p *Prospector) Run() {
-
 	// Initial prospector run
 	p.prospectorer.Run()
 

--- a/filebeat/prospector/redis/prospector.go
+++ b/filebeat/prospector/redis/prospector.go
@@ -23,7 +23,6 @@ type Prospector struct {
 
 // NewProspector creates a new redis prospector
 func NewProspector(cfg *common.Config, outletFactory channel.OutleterFactory) (*Prospector, error) {
-
 	logp.Experimental("Redis slowlog prospector is enabled.")
 	config := defaultConfig
 

--- a/filebeat/prospector/stdin/prospector.go
+++ b/filebeat/prospector/stdin/prospector.go
@@ -23,7 +23,6 @@ type Prospector struct {
 // NewStdin creates a new stdin prospector
 // This prospector contains one harvester which is reading from stdin
 func NewProspector(cfg *common.Config, outlet channel.OutleterFactory) (*Prospector, error) {
-
 	out, err := outlet(cfg)
 	if err != nil {
 		return nil, err
@@ -46,7 +45,6 @@ func NewProspector(cfg *common.Config, outlet channel.OutleterFactory) (*Prospec
 
 // Run runs the prospector
 func (p *Prospector) Run() {
-
 	// Make sure stdin harvester is only started once
 	if !p.started {
 		err := p.harvester.Setup()

--- a/filebeat/prospector/udp/harvester.go
+++ b/filebeat/prospector/udp/harvester.go
@@ -27,7 +27,6 @@ func NewHarvester(forwarder *harvester.Forwarder, cfg *common.Config) *Harvester
 }
 
 func (h *Harvester) Run() error {
-
 	config := defaultConfig
 	err := h.cfg.Unpack(&config)
 	if err != nil {

--- a/filebeat/registrar/registrar.go
+++ b/filebeat/registrar/registrar.go
@@ -36,7 +36,6 @@ var (
 )
 
 func New(registryFile string, out successLogger) (*Registrar, error) {
-
 	r := &Registrar{
 		registryFile: registryFile,
 		done:         make(chan struct{}),
@@ -52,7 +51,6 @@ func New(registryFile string, out successLogger) (*Registrar, error) {
 
 // Init sets up the Registrar and make sure the registry file is setup correctly
 func (r *Registrar) Init() error {
-
 	// The registry file is opened in the data path
 	r.registryFile = paths.Resolve(paths.Data, r.registryFile)
 
@@ -96,7 +94,6 @@ func (r *Registrar) GetStates() []file.State {
 // loadStates fetches the previous reading state from the configure RegistryFile file
 // The default file is `registry` in the data path.
 func (r *Registrar) loadStates() error {
-
 	f, err := os.Open(r.registryFile)
 	if err != nil {
 		return err
@@ -123,7 +120,6 @@ func (r *Registrar) loadStates() error {
 // resetStates sets all states to finished and disable TTL on restart
 // For all states covered by a prospector, TTL will be overwritten with the prospector value
 func resetStates(states []file.State) []file.State {
-
 	for key, state := range states {
 		state.Finished = true
 		// Set ttl to -2 to easily spot which states are not managed by a prospector
@@ -134,7 +130,6 @@ func resetStates(states []file.State) []file.State {
 }
 
 func (r *Registrar) Start() error {
-
 	// Load the previous log file locations now, for use in prospector
 	err := r.loadStates()
 	if err != nil {

--- a/filebeat/util/data_test.go
+++ b/filebeat/util/data_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 func TestNewData(t *testing.T) {
-
 	data := NewData()
 
 	assert.False(t, data.HasEvent())
@@ -27,7 +26,6 @@ func TestNewData(t *testing.T) {
 }
 
 func TestGetEvent(t *testing.T) {
-
 	data := NewData()
 	data.Event.Fields = common.MapStr{"hello": "world"}
 	out := common.MapStr{"hello": "world"}

--- a/heartbeat/main_test.go
+++ b/heartbeat/main_test.go
@@ -19,7 +19,6 @@ func init() {
 
 // Test started when the test binary is started. Only calls main.
 func TestSystem(t *testing.T) {
-
 	if *systemTest {
 		main()
 	}

--- a/libbeat/beat/metrics.go
+++ b/libbeat/beat/metrics.go
@@ -13,7 +13,6 @@ var (
 )
 
 func init() {
-
 	var ms memstatsVar
 	metrics.Add("memstats", ms, monitoring.Reported)
 }

--- a/libbeat/cfgfile/cfgfile.go
+++ b/libbeat/cfgfile/cfgfile.go
@@ -63,7 +63,6 @@ func ChangeDefaultCfgfileFlag(beatName string) error {
 
 // HandleFlags adapts default config settings based on command line flags.
 func HandleFlags() error {
-
 	// default for the home path is the binary location
 	home, err := filepath.Abs(filepath.Dir(os.Args[0]))
 	if err != nil {

--- a/libbeat/cfgfile/glob_watcher.go
+++ b/libbeat/cfgfile/glob_watcher.go
@@ -30,7 +30,6 @@ func NewGlobWatcher(glob string) *GlobWatcher {
 // The modtime is compared based on second as normally mod-time is in seconds. If it is unclear if something changed
 // the method will return true for the changes. It is strongly recommend to call scan not more frequent then 1s.
 func (gw *GlobWatcher) Scan() ([]string, bool, error) {
-
 	globList, err := filepath.Glob(gw.glob)
 	if err != nil {
 		return nil, false, err

--- a/libbeat/cfgfile/glob_watcher_test.go
+++ b/libbeat/cfgfile/glob_watcher_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 func TestGlobWatcher(t *testing.T) {
-
 	// Create random temp directory
 	id := strconv.Itoa(rand.New(rand.NewSource(int64(time.Now().Nanosecond()))).Int())
 	dir, err := ioutil.TempDir("", id)

--- a/libbeat/cfgfile/reload.go
+++ b/libbeat/cfgfile/reload.go
@@ -60,7 +60,6 @@ type Reloader struct {
 
 // NewReloader creates new Reloader instance for the given config
 func NewReloader(cfg *common.Config) *Reloader {
-
 	config := DefaultDynamicConfig
 	cfg.Unpack(&config)
 
@@ -73,7 +72,6 @@ func NewReloader(cfg *common.Config) *Reloader {
 
 // Run runs the reloader
 func (rl *Reloader) Run(runnerFactory RunnerFactory) {
-
 	logp.Info("Config reloader started")
 
 	rl.wg.Add(1)
@@ -191,7 +189,6 @@ func (rl *Reloader) Stop() {
 }
 
 func (rl *Reloader) startRunners(list map[uint64]Runner) {
-
 	if len(list) == 0 {
 		return
 	}
@@ -208,7 +205,6 @@ func (rl *Reloader) startRunners(list map[uint64]Runner) {
 }
 
 func (rl *Reloader) stopRunners(list map[uint64]Runner) {
-
 	if len(list) == 0 {
 		return
 	}

--- a/libbeat/common/csv.go
+++ b/libbeat/common/csv.go
@@ -9,7 +9,6 @@ import (
 // DumpInCSVFormat takes a set of fields and rows and returns a string
 // representing the CSV representation for the fields and rows.
 func DumpInCSVFormat(fields []string, rows [][]string) string {
-
 	var buf bytes.Buffer
 	writer := csv.NewWriter(&buf)
 

--- a/libbeat/common/datetime_test.go
+++ b/libbeat/common/datetime_test.go
@@ -11,7 +11,6 @@ import (
 )
 
 func TestParseTime(t *testing.T) {
-
 	type inputOutput struct {
 		Input  string
 		Output time.Time

--- a/libbeat/common/droppriv/droppriv_windows.go
+++ b/libbeat/common/droppriv/droppriv_windows.go
@@ -8,7 +8,6 @@ type RunOptions struct {
 }
 
 func DropPrivileges(config RunOptions) error {
-
 	if config.Uid == nil {
 		// not found, no dropping privileges but no err
 		return nil

--- a/libbeat/common/event_test.go
+++ b/libbeat/common/event_test.go
@@ -117,7 +117,6 @@ func TestConvertNestedMapStr(t *testing.T) {
 	for i, test := range tests {
 		assert.Equal(t, test.Output, ConvertToGenericEvent(test.Input), "Test case %d", i)
 	}
-
 }
 
 func TestConvertNestedStruct(t *testing.T) {
@@ -300,7 +299,6 @@ func TestMarshalUnmarshalArray(t *testing.T) {
 }
 
 func TestMarshalFloatValues(t *testing.T) {
-
 	assert := assert.New(t)
 
 	var f float64

--- a/libbeat/common/file/helper_test.go
+++ b/libbeat/common/file/helper_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 func TestSafeFileRotateExistingFile(t *testing.T) {
-
 	tempdir, err := ioutil.TempDir("", "")
 	assert.NoError(t, err)
 	defer func() {

--- a/libbeat/common/fmtstr/formatstring_test.go
+++ b/libbeat/common/fmtstr/formatstring_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 func TestFormatString(t *testing.T) {
-
 	tests := []struct {
 		title       string
 		pattern     string

--- a/libbeat/common/match/optimize.go
+++ b/libbeat/common/match/optimize.go
@@ -116,7 +116,6 @@ func unconcat(r *syntax.Regexp) (bool, *syntax.Regexp) {
 // concatRepetition concatenates 2 consecutive repeated sub-patterns into a
 // repetition of length 2.
 func concatRepetition(r *syntax.Regexp) (bool, *syntax.Regexp) {
-
 	if r.Op != syntax.OpConcat {
 		// don't iterate sub-expressions if top-level is no OpConcat
 		return false, r

--- a/libbeat/common/schema/mapstriface/mapstriface.go
+++ b/libbeat/common/schema/mapstriface/mapstriface.go
@@ -71,7 +71,6 @@ type ConvMap struct {
 
 // Map drills down in the data dictionary by using the key
 func (convMap ConvMap) Map(key string, event common.MapStr, data map[string]interface{}) *schema.Errors {
-
 	subData, ok := data[convMap.Key].(map[string]interface{})
 	if !ok {
 		err := schema.NewError(convMap.Key, "Error accessing sub-dictionary")
@@ -226,7 +225,6 @@ func toTime(key string, data map[string]interface{}) (interface{}, error) {
 	}
 
 	return common.Time(time.Unix(0, 0)), fmt.Errorf("Expected date, found %T", emptyIface)
-
 }
 
 // Time creates a Conv object for converting Time objects.

--- a/libbeat/common/schema/mapstrstr/mapstrstr.go
+++ b/libbeat/common/schema/mapstrstr/mapstrstr.go
@@ -51,7 +51,6 @@ import (
 
 // toBool converts value to bool. In case of error, returns false
 func toBool(key string, data map[string]interface{}) (interface{}, error) {
-
 	str, err := getString(key, data)
 	if err != nil {
 		return false, err
@@ -72,7 +71,6 @@ func Bool(key string, opts ...schema.SchemaOption) schema.Conv {
 
 // toFloat converts value to float64. In case of error, returns 0.0
 func toFloat(key string, data map[string]interface{}) (interface{}, error) {
-
 	str, err := getString(key, data)
 	if err != nil {
 		return false, err
@@ -93,7 +91,6 @@ func Float(key string, opts ...schema.SchemaOption) schema.Conv {
 
 // toInt converts value to int. In case of error, returns 0
 func toInt(key string, data map[string]interface{}) (interface{}, error) {
-
 	str, err := getString(key, data)
 	if err != nil {
 		return false, err

--- a/libbeat/common/streambuf/net.go
+++ b/libbeat/common/streambuf/net.go
@@ -74,7 +74,6 @@ func (b *Buffer) ReadNetUint16At(index int) (uint16, error) {
 		return 0, b.bufferEndError()
 	}
 	return common.BytesNtohs(b.data[index+b.mark:]), nil
-
 }
 
 // Write 16bit binary value at index in network byte order to buffer.
@@ -117,7 +116,6 @@ func (b *Buffer) ReadNetUint32At(index int) (uint32, error) {
 		return 0, b.bufferEndError()
 	}
 	return common.BytesNtohl(b.data[index+b.mark:]), nil
-
 }
 
 // Write 32bit binary value at index in network byte order to buffer.
@@ -162,7 +160,6 @@ func (b *Buffer) ReadNetUint64At(index int) (uint64, error) {
 		return 0, b.bufferEndError()
 	}
 	return common.BytesNtohll(b.data[index+b.mark:]), nil
-
 }
 
 // Write 64bit binary value at index in network byte order to buffer.

--- a/libbeat/common/url.go
+++ b/libbeat/common/url.go
@@ -14,7 +14,6 @@ var hasScheme = regexp.MustCompile(`^([a-z][a-z0-9+\-.]*)://`)
 // MakeURL creates the url based on the url configuration.
 // Adds missing parts with defaults (scheme, host, port)
 func MakeURL(defaultScheme string, defaultPath string, rawURL string, defaultPort int) (string, error) {
-
 	if defaultScheme == "" {
 		defaultScheme = "http"
 	}
@@ -61,7 +60,6 @@ func MakeURL(defaultScheme string, defaultPath string, rawURL string, defaultPor
 }
 
 func EncodeURLParams(url string, params url.Values) string {
-
 	if len(params) == 0 {
 		return url
 	}

--- a/libbeat/common/url_test.go
+++ b/libbeat/common/url_test.go
@@ -11,7 +11,6 @@ import (
 )
 
 func TestGetUrl(t *testing.T) {
-
 	// List of inputs / outputs that must match after fetching url
 	// Setting a path without a scheme is not allowed. Example: 192.168.1.1:9200/hello
 	inputOutput := map[string]string{
@@ -80,11 +79,9 @@ func TestGetUrl(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, output, urlNew)
 	}
-
 }
 
 func TestURLParamsEncode(t *testing.T) {
-
 	inputOutputWithParams := map[string]string{
 		"http://localhost": "http://localhost:5601?dashboard=first&dashboard=second",
 	}
@@ -99,5 +96,4 @@ func TestURLParamsEncode(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, output, urlWithParams)
 	}
-
 }

--- a/libbeat/common/version.go
+++ b/libbeat/common/version.go
@@ -17,7 +17,6 @@ type Version struct {
 // NewVersion expects a string in the format:
 // major.minor.bugfix(-meta)
 func NewVersion(version string) (*Version, error) {
-
 	v := Version{
 		version: version,
 	}

--- a/libbeat/common/version_test.go
+++ b/libbeat/common/version_test.go
@@ -7,7 +7,6 @@ import (
 )
 
 func TestVersion(t *testing.T) {
-
 	tests := []struct {
 		version string
 		err     bool

--- a/libbeat/dashboards/dashboards.go
+++ b/libbeat/dashboards/dashboards.go
@@ -82,7 +82,6 @@ func ImportDashboardsViaKibana(config *common.Config, dashConfig *Config, msgOut
 }
 
 func ImportDashboardsViaElasticsearch(config *common.Config, dashConfig *Config, msgOutputter MessageOutputter) (bool, error) {
-
 	esLoader, err := NewElasticsearchLoader(config, dashConfig, msgOutputter)
 	if err != nil {
 		return false, fmt.Errorf("fail to create the Elasticsearch loader: %v", err)
@@ -118,7 +117,6 @@ func ImportDashboardsViaElasticsearch(config *common.Config, dashConfig *Config,
 }
 
 func getMajorAndMinorVersion(version string) (int, int, error) {
-
 	fields := strings.Split(version, ".")
 	if len(fields) != 3 {
 		return 0, 0, fmt.Errorf("wrong version %s", version)
@@ -140,7 +138,6 @@ func getMajorAndMinorVersion(version string) (int, int, error) {
 }
 
 func isKibanaAPIavailable(version string) bool {
-
 	majorVersion, minorVersion, err := getMajorAndMinorVersion(version)
 	if err != nil {
 		return false

--- a/libbeat/dashboards/importer.go
+++ b/libbeat/dashboards/importer.go
@@ -41,7 +41,6 @@ func NewImporter(version string, cfg *Config, loader Loader) (*Importer, error) 
 
 // Import imports the Kibana dashboards according to the configuration options.
 func (imp Importer) Import() error {
-
 	if imp.cfg.URL != "" || imp.cfg.File != "" {
 		err := imp.ImportArchive()
 		if err != nil {

--- a/libbeat/logp/file_rotator_test.go
+++ b/libbeat/logp/file_rotator_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 func Test_Rotator(t *testing.T) {
-
 	if testing.Verbose() {
 		LogInit(LOG_DEBUG, "", false, true, []string{"rotator"})
 	}
@@ -107,7 +106,6 @@ func Test_Rotator(t *testing.T) {
 }
 
 func Test_Rotator_By_Bytes(t *testing.T) {
-
 	if testing.Verbose() {
 		LogInit(LOG_DEBUG, "", false, true, []string{"rotator"})
 	}

--- a/libbeat/logp/log.go
+++ b/libbeat/logp/log.go
@@ -81,7 +81,6 @@ func debugMessage(calldepth int, selector, format string, v ...interface{}) {
 }
 
 func send(calldepth int, level Priority, prefix string, format string, v ...interface{}) {
-
 	message := fmt.Sprintf(format, v...)
 	timestamp := time.Now().Format(time.RFC3339)
 	var bytes []byte

--- a/libbeat/logp/metrics_test.go
+++ b/libbeat/logp/metrics_test.go
@@ -51,7 +51,6 @@ func TestBuildMetricsOutput(t *testing.T) {
 }
 
 func TestBuildMetricsOutputMissing(t *testing.T) {
-
 	prevVals := snapshotMetrics()
 
 	test := expvar.NewInt("testLogEmpty")

--- a/libbeat/ml-importer/importer.go
+++ b/libbeat/ml-importer/importer.go
@@ -97,7 +97,6 @@ func ImportMachineLearningJob(esClient MLLoader, cfg *MLConfig) error {
 
 // HaveXpackML checks whether X-pack is installed and has Machine Learning enabled.
 func HaveXpackML(esClient MLLoader) (bool, error) {
-
 	status, response, err := esClient.Request("GET", "/_xpack", "", nil, nil)
 	if status == 404 || status == 400 {
 		return false, nil

--- a/libbeat/outputs/elasticsearch/api_mock_test.go
+++ b/libbeat/outputs/elasticsearch/api_mock_test.go
@@ -16,7 +16,6 @@ import (
 )
 
 func ElasticsearchMock(code int, body []byte) *httptest.Server {
-
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/" { // send ok and a minimal JSON on ping
 			w.WriteHeader(200)
@@ -36,7 +35,6 @@ func ElasticsearchMock(code int, body []byte) *httptest.Server {
 }
 
 func TestOneHostSuccessResp(t *testing.T) {
-
 	if testing.Verbose() {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"elasticsearch"})
 	}
@@ -66,7 +64,6 @@ func TestOneHostSuccessResp(t *testing.T) {
 }
 
 func TestOneHost500Resp(t *testing.T) {
-
 	if testing.Verbose() {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"elasticsearch"})
 	}
@@ -101,7 +98,6 @@ func TestOneHost500Resp(t *testing.T) {
 }
 
 func TestOneHost503Resp(t *testing.T) {
-
 	if testing.Verbose() {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"elasticsearch"})
 	}

--- a/libbeat/outputs/elasticsearch/api_test.go
+++ b/libbeat/outputs/elasticsearch/api_test.go
@@ -38,7 +38,6 @@ func GetValidQueryResult() QueryResult {
 }
 
 func GetValidSearchResults() SearchResults {
-
 	hits := Hits{
 		Total: 0,
 		Hits:  nil,
@@ -59,7 +58,6 @@ func GetValidSearchResults() SearchResults {
 }
 
 func TestReadQueryResult(t *testing.T) {
-
 	queryResult := GetValidQueryResult()
 
 	json := queryResult.Source
@@ -85,7 +83,6 @@ func TestReadQueryResult_empty(t *testing.T) {
 
 // Check invalid query result object
 func TestReadQueryResult_invalid(t *testing.T) {
-
 	// Invalid json string
 	json := []byte(`{"name":"ruflin","234"}`)
 
@@ -124,7 +121,6 @@ func TestReadSearchResult_empty(t *testing.T) {
 }
 
 func TestReadSearchResult_invalid(t *testing.T) {
-
 	// Invalid json string
 	json := []byte(`{"took":"19","234"}`)
 

--- a/libbeat/outputs/elasticsearch/bulkapi_mock_test.go
+++ b/libbeat/outputs/elasticsearch/bulkapi_mock_test.go
@@ -14,7 +14,6 @@ import (
 )
 
 func TestOneHostSuccessResp_Bulk(t *testing.T) {
-
 	if testing.Verbose() {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"elasticsearch"})
 	}

--- a/libbeat/outputs/elasticsearch/client.go
+++ b/libbeat/outputs/elasticsearch/client.go
@@ -393,7 +393,6 @@ func getPipeline(event *beat.Event, pipelineSel *outil.Selector) (string, error)
 // Index is either defined in the config as part of the output
 // or can be overload by the event through setting index
 func getIndex(event *beat.Event, index outil.Selector) string {
-
 	if event.Meta != nil {
 		if str, exists := event.Meta["index"]; exists {
 			idx, ok := str.(string)

--- a/libbeat/outputs/elasticsearch/client_integration_test.go
+++ b/libbeat/outputs/elasticsearch/client_integration_test.go
@@ -18,7 +18,6 @@ import (
 )
 
 func TestClientConnect(t *testing.T) {
-
 	client := GetTestingElasticsearch(t)
 	err := client.Connect()
 	assert.NoError(t, err)

--- a/libbeat/outputs/elasticsearch/client_test.go
+++ b/libbeat/outputs/elasticsearch/client_test.go
@@ -171,7 +171,6 @@ func TestCollectPipelinePublishFail(t *testing.T) {
 }
 
 func TestGetIndexStandard(t *testing.T) {
-
 	ts := time.Now().UTC()
 	extension := fmt.Sprintf("%d.%02d.%02d", ts.Year(), ts.Month(), ts.Day())
 	fields := common.MapStr{"field": 1}
@@ -186,7 +185,6 @@ func TestGetIndexStandard(t *testing.T) {
 }
 
 func TestGetIndexOverwrite(t *testing.T) {
-
 	time := time.Now().UTC()
 	extension := fmt.Sprintf("%d.%02d.%02d", time.Year(), time.Month(), time.Day())
 

--- a/libbeat/outputs/elasticsearch/elasticsearch.go
+++ b/libbeat/outputs/elasticsearch/elasticsearch.go
@@ -177,7 +177,6 @@ func NewConnectedClient(cfg *common.Config) (*Client, error) {
 // template) .If multiple hosts are defined in the configuration, a client is returned
 // for each of them.
 func NewElasticsearchClients(cfg *common.Config) ([]Client, error) {
-
 	hosts, err := outputs.ReadHostList(cfg)
 	if err != nil {
 		return nil, err

--- a/libbeat/outputs/elasticsearch/testing.go
+++ b/libbeat/outputs/elasticsearch/testing.go
@@ -19,7 +19,6 @@ const (
 
 // GetEsHost returns the elasticsearch host.
 func GetEsHost() string {
-
 	host := os.Getenv("ES_HOST")
 
 	if len(host) == 0 {

--- a/libbeat/outputs/elasticsearch/url.go
+++ b/libbeat/outputs/elasticsearch/url.go
@@ -33,7 +33,6 @@ func urlEncode(pipeline string, params map[string]string) string {
 
 // Create path out of index, docType and id that is used for querying Elasticsearch
 func makePath(index string, docType string, id string) (string, error) {
-
 	var path string
 	if len(docType) > 0 {
 		if len(id) > 0 {

--- a/libbeat/outputs/elasticsearch/url_test.go
+++ b/libbeat/outputs/elasticsearch/url_test.go
@@ -5,7 +5,6 @@ package elasticsearch
 import "testing"
 
 func TestUrlEncode(t *testing.T) {
-
 	params := map[string]string{
 		"q": "agent:appserver1",
 	}
@@ -58,5 +57,4 @@ func TestMakePath(t *testing.T) {
 	if path != "/twitter" {
 		t.Errorf("Wrong path created: %s", path)
 	}
-
 }

--- a/libbeat/outputs/logstash/logstash_integration_test.go
+++ b/libbeat/outputs/logstash/logstash_integration_test.go
@@ -295,7 +295,6 @@ func TestSendMultipleViaLogstashTLS(t *testing.T) {
 }
 
 func testSendMultipleViaLogstash(t *testing.T, name string, tls bool) {
-
 	ls := newTestLogstashOutput(t, name, tls)
 	defer ls.Cleanup()
 	for i := 0; i < 10; i++ {
@@ -403,7 +402,6 @@ func TestLogstashElasticOutputPluginCompatibleMessageTLS(t *testing.T) {
 }
 
 func testLogstashElasticOutputPluginCompatibleMessage(t *testing.T, name string, tls bool) {
-
 	timeout := 10 * time.Second
 
 	ls := newTestLogstashOutput(t, name, tls)

--- a/libbeat/outputs/redis/redis_integration_test.go
+++ b/libbeat/outputs/redis/redis_integration_test.go
@@ -250,7 +250,6 @@ func getSRedisAddr() string {
 }
 
 func newRedisTestingOutput(t *testing.T, cfg map[string]interface{}) *client {
-
 	config, err := common.NewConfigFrom(cfg)
 	if err != nil {
 		t.Fatalf("Error reading config: %v", err)

--- a/libbeat/outputs/transport/client.go
+++ b/libbeat/outputs/transport/client.go
@@ -152,7 +152,6 @@ func (c *Client) LocalAddr() net.Addr {
 		return c.conn.LocalAddr()
 	}
 	return nil
-
 }
 
 func (c *Client) RemoteAddr() net.Addr {

--- a/libbeat/outputs/transport/transptest/testing_test.go
+++ b/libbeat/outputs/transport/transptest/testing_test.go
@@ -143,7 +143,6 @@ func TestTransportClosedOnWriteReadError(t *testing.T) {
 }
 
 func testServer(t *testing.T, config *transport.ProxyConfig, run func(*testing.T, MockServerFactory, *transport.ProxyConfig)) {
-
 	runner := func(f MockServerFactory, c *transport.ProxyConfig) func(t *testing.T) {
 		return func(t *testing.T) {
 			run(t, f, config)

--- a/libbeat/paths/paths_test.go
+++ b/libbeat/paths/paths_test.go
@@ -103,7 +103,6 @@ func TestDataPath(t *testing.T) {
 
 		assert.Equal(t, test.ResultData, Resolve(Data, test.Path), "failed on %+v", test)
 	}
-
 }
 
 func TestLogsPath(t *testing.T) {
@@ -149,7 +148,6 @@ func TestLogsPath(t *testing.T) {
 
 		assert.Equal(t, test.ResultLogs, Resolve(Logs, test.Path))
 	}
-
 }
 
 // rootDir builds an OS specific absolute root directory.

--- a/libbeat/processors/actions/decode_json_fields_test.go
+++ b/libbeat/processors/actions/decode_json_fields_test.go
@@ -43,7 +43,6 @@ func TestFieldNotString(t *testing.T) {
 	}
 
 	assert.Equal(t, expected.String(), actual.String())
-
 }
 
 func TestInvalidJSON(t *testing.T) {
@@ -59,7 +58,6 @@ func TestInvalidJSON(t *testing.T) {
 		"pipeline": "us1",
 	}
 	assert.Equal(t, expected.String(), actual.String())
-
 }
 
 func TestInvalidJSONMultiple(t *testing.T) {
@@ -75,7 +73,6 @@ func TestInvalidJSONMultiple(t *testing.T) {
 		"pipeline": "us1",
 	}
 	assert.Equal(t, expected.String(), actual.String())
-
 }
 
 func TestValidJSONDepthOne(t *testing.T) {
@@ -96,7 +93,6 @@ func TestValidJSONDepthOne(t *testing.T) {
 	}
 
 	assert.Equal(t, expected.String(), actual.String())
-
 }
 
 func TestValidJSONDepthTwo(t *testing.T) {
@@ -125,7 +121,6 @@ func TestValidJSONDepthTwo(t *testing.T) {
 	}
 
 	assert.Equal(t, expected.String(), actual.String())
-
 }
 
 func TestTargetOption(t *testing.T) {

--- a/libbeat/processors/add_kubernetes_metadata/kubernetes.go
+++ b/libbeat/processors/add_kubernetes_metadata/kubernetes.go
@@ -37,7 +37,6 @@ func init() {
 	Indexing.AddIndexer(PodNameIndexerName, NewPodNameIndexer)
 	Indexing.AddIndexer(ContainerIndexerName, NewContainerIndexer)
 	Indexing.AddMatcher(FieldMatcherName, NewFieldMatcher)
-
 }
 
 func newKubernetesAnnotator(cfg *common.Config) (processors.Processor, error) {

--- a/libbeat/processors/add_kubernetes_metadata/podwatcher.go
+++ b/libbeat/processors/add_kubernetes_metadata/podwatcher.go
@@ -99,7 +99,6 @@ func (p *PodWatcher) watchPods() {
 			p.podQueue <- pod
 		}
 	}
-
 }
 
 func (p *PodWatcher) Run() bool {
@@ -172,7 +171,6 @@ func (p *PodWatcher) getPodMeta(pod *corev1.Pod) *Pod {
 	}
 
 	return po
-
 }
 
 func (p *PodWatcher) worker() {
@@ -189,7 +187,6 @@ func (p *PodWatcher) worker() {
 			}
 		}
 	}
-
 }
 
 func (p *PodWatcher) GetMetaData(arg string) common.MapStr {

--- a/libbeat/processors/condition.go
+++ b/libbeat/processors/condition.go
@@ -106,7 +106,6 @@ func NewConditionList(config []ConditionConfig) ([]Condition, error) {
 }
 
 func (c *Condition) setEquals(cfg *ConditionFields) error {
-
 	c.equals = map[string]EqualsValue{}
 
 	for field, value := range cfg.fields {
@@ -152,7 +151,6 @@ func compileMatches(
 }
 
 func (c *Condition) setRange(cfg *ConditionFields) error {
-
 	c.rangexp = map[string]RangeValue{}
 
 	updateRangeValue := func(key string, op string, value float64) error {
@@ -198,7 +196,6 @@ func (c *Condition) setRange(cfg *ConditionFields) error {
 }
 
 func (c *Condition) Check(event *beat.Event) bool {
-
 	if len(c.or) > 0 {
 		return c.checkOR(event)
 	}
@@ -267,7 +264,6 @@ func (c *Condition) checkEquals(event *beat.Event) bool {
 	}
 
 	return true
-
 }
 
 func (c *Condition) checkMatches(event *beat.Event) bool {
@@ -310,7 +306,6 @@ func (c *Condition) checkMatches(event *beat.Event) bool {
 }
 
 func (c *Condition) checkRange(event *beat.Event) bool {
-
 	checkValue := func(value float64, rangeValue RangeValue) bool {
 
 		if rangeValue.gte != nil {
@@ -375,7 +370,6 @@ func (c *Condition) checkRange(event *beat.Event) bool {
 }
 
 func (c Condition) String() string {
-
 	s := ""
 
 	if len(c.equals) > 0 {
@@ -407,7 +401,6 @@ func (c Condition) String() string {
 }
 
 func (r RangeValue) String() string {
-
 	s := ""
 	if r.gte != nil {
 		s = s + fmt.Sprintf(">= %v", *r.gte)
@@ -436,7 +429,6 @@ func (r RangeValue) String() string {
 }
 
 func (e EqualsValue) String() string {
-
 	if len(e.Str) > 0 {
 		return e.Str
 	}

--- a/libbeat/processors/condition_test.go
+++ b/libbeat/processors/condition_test.go
@@ -23,7 +23,6 @@ func (c *countFilter) Run(e *beat.Event) (*beat.Event, error) {
 func (c *countFilter) String() string { return "count" }
 
 func TestConditions(t *testing.T) {
-
 	if testing.Verbose() {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"*"})
 	}
@@ -74,7 +73,6 @@ func GetConditions(t *testing.T, configs []ConditionConfig) []Condition {
 }
 
 func TestEqualsCondition(t *testing.T) {
-
 	if testing.Verbose() {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"*"})
 	}
@@ -129,7 +127,6 @@ func TestEqualsCondition(t *testing.T) {
 }
 
 func TestContainsCondition(t *testing.T) {
-
 	if testing.Verbose() {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"*"})
 	}
@@ -187,7 +184,6 @@ func TestContainsCondition(t *testing.T) {
 }
 
 func TestRegexpCondition(t *testing.T) {
-
 	if testing.Verbose() {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"*"})
 	}
@@ -246,7 +242,6 @@ func TestRegexpCondition(t *testing.T) {
 }
 
 func TestRangeCondition(t *testing.T) {
-
 	if testing.Verbose() {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"*"})
 	}
@@ -395,7 +390,6 @@ func TestORCondition(t *testing.T) {
 	}
 
 	assert.True(t, conds[0].Check(event))
-
 }
 
 func TestANDCondition(t *testing.T) {
@@ -454,7 +448,6 @@ func TestANDCondition(t *testing.T) {
 	}
 
 	assert.True(t, conds[0].Check(event))
-
 }
 
 func TestNOTCondition(t *testing.T) {
@@ -506,7 +499,6 @@ func TestNOTCondition(t *testing.T) {
 	}
 
 	assert.False(t, conds[0].Check(event))
-
 }
 
 func TestCombinedCondition(t *testing.T) {
@@ -575,7 +567,6 @@ func TestCombinedCondition(t *testing.T) {
 	}
 
 	assert.True(t, conds[0].Check(event))
-
 }
 
 func TestWhenProcessor(t *testing.T) {

--- a/libbeat/processors/processor_test.go
+++ b/libbeat/processors/processor_test.go
@@ -14,7 +14,6 @@ import (
 )
 
 func GetProcessors(t *testing.T, yml []map[string]interface{}) *processors.Processors {
-
 	config := processors.PluginConfig{}
 
 	for _, action := range yml {
@@ -34,11 +33,9 @@ func GetProcessors(t *testing.T, yml []map[string]interface{}) *processors.Proce
 	assert.Nil(t, err)
 
 	return list
-
 }
 
 func TestBadConfig(t *testing.T) {
-
 	if testing.Verbose() {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"*"})
 	}
@@ -75,11 +72,9 @@ func TestBadConfig(t *testing.T) {
 
 	_, err := processors.New(config)
 	assert.NotNil(t, err)
-
 }
 
 func TestIncludeFields(t *testing.T) {
-
 	if testing.Verbose() {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"*"})
 	}
@@ -148,7 +143,6 @@ func TestIncludeFields(t *testing.T) {
 }
 
 func TestIncludeFields1(t *testing.T) {
-
 	if testing.Verbose() {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"*"})
 	}
@@ -206,7 +200,6 @@ func TestIncludeFields1(t *testing.T) {
 }
 
 func TestDropFields(t *testing.T) {
-
 	yml := []map[string]interface{}{
 		{
 			"drop_fields": map[string]interface{}{
@@ -268,7 +261,6 @@ func TestDropFields(t *testing.T) {
 }
 
 func TestMultipleIncludeFields(t *testing.T) {
-
 	if testing.Verbose() {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"*"})
 	}
@@ -368,7 +360,6 @@ func TestMultipleIncludeFields(t *testing.T) {
 }
 
 func TestDropEvent(t *testing.T) {
-
 	if testing.Verbose() {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"*"})
 	}
@@ -423,7 +414,6 @@ func TestDropEvent(t *testing.T) {
 }
 
 func TestEmptyCondition(t *testing.T) {
-
 	if testing.Verbose() {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"*"})
 	}
@@ -470,7 +460,6 @@ func TestEmptyCondition(t *testing.T) {
 }
 
 func TestBadCondition(t *testing.T) {
-
 	if testing.Verbose() {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"*"})
 	}
@@ -505,11 +494,9 @@ func TestBadCondition(t *testing.T) {
 
 	_, err := processors.New(config)
 	assert.Error(t, err)
-
 }
 
 func TestMissingFields(t *testing.T) {
-
 	if testing.Verbose() {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"*"})
 	}
@@ -542,11 +529,9 @@ func TestMissingFields(t *testing.T) {
 
 	_, err := processors.New(config)
 	assert.NotNil(t, err)
-
 }
 
 func TestBadConditionConfig(t *testing.T) {
-
 	if testing.Verbose() {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"*"})
 	}
@@ -580,11 +565,9 @@ func TestBadConditionConfig(t *testing.T) {
 
 	_, err := processors.New(config)
 	assert.NotNil(t, err)
-
 }
 
 func TestDropMissingFields(t *testing.T) {
-
 	yml := []map[string]interface{}{
 		{
 			"drop_fields": map[string]interface{}{

--- a/libbeat/publisher/bc/publisher/client.go
+++ b/libbeat/publisher/bc/publisher/client.go
@@ -158,7 +158,6 @@ func (c *client) PublishEvents(events []common.MapStr, opts ...ClientOption) boo
 }
 
 func (c *client) getPipeline(opts []ClientOption) ([]common.MapStr, Context, sender, error) {
-
 	var err error
 	values, ctx := MakeContext(opts)
 

--- a/libbeat/publisher/pipeline/consumer.go
+++ b/libbeat/publisher/pipeline/consumer.go
@@ -178,7 +178,6 @@ func (c *eventConsumer) loop(consumer broker.Consumer) {
 			batch = nil
 		}
 	}
-
 }
 
 func (c *eventConsumer) paused() bool {

--- a/libbeat/service/service_windows.go
+++ b/libbeat/service/service_windows.go
@@ -14,7 +14,6 @@ type beatService struct{}
 // Execute runs the beat service with the arguments and manages changes that
 // occur in the environment or runtime that may affect the beat.
 func (m *beatService) Execute(args []string, r <-chan svc.ChangeRequest, changes chan<- svc.Status) (ssec bool, errno uint32) {
-
 	const cmdsAccepted = svc.AcceptStop | svc.AcceptShutdown
 	changes <- svc.Status{State: svc.StartPending}
 	changes <- svc.Status{State: svc.Running, Accepts: cmdsAccepted}

--- a/libbeat/setup/kibana/client.go
+++ b/libbeat/setup/kibana/client.go
@@ -31,7 +31,6 @@ type Client struct {
 }
 
 func addToURL(_url, _path string, params url.Values) string {
-
 	if len(params) == 0 {
 		return _url + _path
 	}
@@ -145,7 +144,6 @@ func (conn *Connection) Request(method, extraPath string,
 }
 
 func (client *Client) SetVersion() error {
-
 	type kibanaVersionResponse struct {
 		Name    string `json:"name"`
 		Version struct {

--- a/libbeat/template/field.go
+++ b/libbeat/template/field.go
@@ -136,7 +136,6 @@ func (f *Field) array() common.MapStr {
 }
 
 func (f *Field) object() common.MapStr {
-
 	dynProperties := f.getDefaultProperties()
 
 	switch f.ObjectType {
@@ -162,7 +161,6 @@ func (f *Field) object() common.MapStr {
 }
 
 func (f *Field) addDynamicTemplate(properties common.MapStr, matchType string) {
-
 	path := ""
 	if len(f.path) > 0 {
 		path = f.path + "."

--- a/libbeat/template/field_test.go
+++ b/libbeat/template/field_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 func TestField(t *testing.T) {
-
 	esVersion2, err := common.NewVersion("2.0.0")
 	assert.NoError(t, err)
 
@@ -141,7 +140,6 @@ func TestField(t *testing.T) {
 }
 
 func TestDynamicTemplate(t *testing.T) {
-
 	tests := []struct {
 		field  Field
 		method func(f Field) common.MapStr

--- a/libbeat/template/fields_test.go
+++ b/libbeat/template/fields_test.go
@@ -7,7 +7,6 @@ import (
 )
 
 func TestHasKey(t *testing.T) {
-
 	tests := []struct {
 		key    string
 		fields Fields

--- a/libbeat/template/load.go
+++ b/libbeat/template/load.go
@@ -23,7 +23,6 @@ type Loader struct {
 }
 
 func NewLoader(cfg *common.Config, client ESClient, beatInfo common.BeatInfo) (*Loader, error) {
-
 	config := DefaultConfig
 
 	err := cfg.Unpack(&config)
@@ -42,7 +41,6 @@ func NewLoader(cfg *common.Config, client ESClient, beatInfo common.BeatInfo) (*
 // In case the template is not already loaded or overwriting is enabled, the
 // template is written to index
 func (l *Loader) Load() error {
-
 	if l.config.Name == "" {
 		l.config.Name = l.beatInfo.Beat
 	}
@@ -84,7 +82,6 @@ func (l *Loader) Load() error {
 // template if it exists. If you wish to not overwrite an existing template
 // then use CheckTemplate prior to calling this method.
 func (l *Loader) LoadTemplate(templateName string, template map[string]interface{}) error {
-
 	logp.Info("load template: %s", templateName)
 	path := "/_template/" + templateName
 	body, err := l.client.LoadJSON(path, template)
@@ -98,7 +95,6 @@ func (l *Loader) LoadTemplate(templateName string, template map[string]interface
 // CheckTemplate checks if a given template already exist. It returns true if
 // and only if Elasticsearch returns with HTTP status code 200.
 func (l *Loader) CheckTemplate(templateName string) bool {
-
 	status, _, _ := l.client.Request("HEAD", "/_template/"+templateName, "", nil, nil)
 
 	if status != 200 {

--- a/libbeat/template/load_integration_test.go
+++ b/libbeat/template/load_integration_test.go
@@ -15,7 +15,6 @@ import (
 )
 
 func TestCheckTemplate(t *testing.T) {
-
 	client := elasticsearch.GetTestingElasticsearch(t)
 	if err := client.Connect(); err != nil {
 		t.Fatal(err)
@@ -30,7 +29,6 @@ func TestCheckTemplate(t *testing.T) {
 }
 
 func TestLoadTemplate(t *testing.T) {
-
 	// Setup ES
 	client := elasticsearch.GetTestingElasticsearch(t)
 	if err := client.Connect(); err != nil {
@@ -69,7 +67,6 @@ func TestLoadTemplate(t *testing.T) {
 }
 
 func TestLoadInvalidTemplate(t *testing.T) {
-
 	// Invalid Template
 	template := map[string]interface{}{
 		"json": "invalid",
@@ -96,7 +93,6 @@ func TestLoadInvalidTemplate(t *testing.T) {
 }
 
 func getTemplate(t *testing.T, client ESClient, templateName string) common.MapStr {
-
 	status, body, err := client.Request("GET", "/_template/"+templateName, "", nil, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, status, 200)
@@ -116,7 +112,6 @@ func newConfigFrom(t *testing.T, from interface{}) *common.Config {
 
 // Tests loading the templates for each beat
 func TestLoadBeatsTemplate(t *testing.T) {
-
 	beats := []string{
 		"libbeat",
 	}
@@ -161,7 +156,6 @@ func TestLoadBeatsTemplate(t *testing.T) {
 }
 
 func TestTemplateSettings(t *testing.T) {
-
 	// Setup ES
 	client := elasticsearch.GetTestingElasticsearch(t)
 	if err := client.Connect(); err != nil {
@@ -214,7 +208,6 @@ func TestTemplateSettings(t *testing.T) {
 }
 
 func TestOverwrite(t *testing.T) {
-
 	// Setup ES
 	client := elasticsearch.GetTestingElasticsearch(t)
 	if err := client.Connect(); err != nil {
@@ -334,7 +327,6 @@ var dataTests = []struct {
 
 // Tests if data can be loaded into elasticsearch with right types
 func TestTemplateWithData(t *testing.T) {
-
 	fieldsPath, err := filepath.Abs("./testdata/fields.yml")
 	assert.NotNil(t, fieldsPath)
 	assert.Nil(t, err)

--- a/libbeat/template/template.go
+++ b/libbeat/template/template.go
@@ -25,7 +25,6 @@ type Template struct {
 
 // New creates a new template instance
 func New(beatVersion string, esVersion string, index string, settings TemplateSettings) (*Template, error) {
-
 	bV, err := common.NewVersion(beatVersion)
 	if err != nil {
 		return nil, err
@@ -47,12 +46,10 @@ func New(beatVersion string, esVersion string, index string, settings TemplateSe
 		esVersion:   *esV,
 		settings:    settings,
 	}, nil
-
 }
 
 // Load the given input and generates the input based on it
 func (t *Template) Load(file string) (common.MapStr, error) {
-
 	fields, err := loadYaml(file)
 	if err != nil {
 		return nil, err
@@ -73,7 +70,6 @@ func (t *Template) GetName() string {
 // generate generates the full template
 // The default values are taken from the default variable.
 func (t *Template) generate(properties common.MapStr, dynamicTemplates []common.MapStr) common.MapStr {
-
 	// Add base dynamic template
 	var dynamicTemplateBase = common.MapStr{
 		"strings_as_keyword": common.MapStr{

--- a/metricbeat/helper/http.go
+++ b/metricbeat/helper/http.go
@@ -72,7 +72,6 @@ func NewHTTP(base mb.BaseMetricSet) *HTTP {
 // It's important that resp.Body has to be closed if this method is used. Before using this method
 // check if one of the other Fetch* methods could be used as they ensure that the Body is properly closed.
 func (h *HTTP) FetchResponse() (*http.Response, error) {
-
 	// Create a fresh reader every time
 	var reader io.Reader
 	if h.body != nil {
@@ -140,7 +139,6 @@ func (h *HTTP) FetchScanner() (*bufio.Scanner, error) {
 // FetchJSON makes an HTTP request to the configured url and returns the JSON content.
 // This only works if the JSON output needed is in map[string]interface format.
 func (h *HTTP) FetchJSON() (map[string]interface{}, error) {
-
 	body, err := h.FetchContent()
 	if err != nil {
 		return nil, err

--- a/metricbeat/main_test.go
+++ b/metricbeat/main_test.go
@@ -19,7 +19,6 @@ func init() {
 
 // Test started when the test binary is started. Only calls main.
 func TestSystem(t *testing.T) {
-
 	if *systemTest {
 		main()
 	}

--- a/metricbeat/mb/mb_test.go
+++ b/metricbeat/mb/mb_test.go
@@ -218,7 +218,6 @@ func TestNewModulesHostParser(t *testing.T) {
 		assert.Equal(t, host, ms.Host())
 		assert.Equal(t, HostData{URI: uri, Host: host}, ms.HostData())
 	})
-
 }
 
 func TestNewModulesMetricSetTypes(t *testing.T) {

--- a/metricbeat/module/aerospike/namespace/namespace.go
+++ b/metricbeat/module/aerospike/namespace/namespace.go
@@ -33,7 +33,6 @@ type MetricSet struct {
 // Part of new is also setting up the configuration by processing additional
 // configuration entries if needed.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-
 	config := struct{}{}
 
 	logp.Experimental("The aerospike namespace metricset is experimental")

--- a/metricbeat/module/ceph/cluster_disk/data.go
+++ b/metricbeat/module/ceph/cluster_disk/data.go
@@ -23,7 +23,6 @@ type DfRequest struct {
 }
 
 func eventMapping(content []byte) common.MapStr {
-
 	var d DfRequest
 	err := json.Unmarshal(content, &d)
 	if err != nil {

--- a/metricbeat/module/ceph/cluster_health/data.go
+++ b/metricbeat/module/ceph/cluster_health/data.go
@@ -24,7 +24,6 @@ type HealthRequest struct {
 }
 
 func eventMapping(content []byte) common.MapStr {
-
 	var d HealthRequest
 	err := json.Unmarshal(content, &d)
 	if err != nil {
@@ -41,5 +40,4 @@ func eventMapping(content []byte) common.MapStr {
 			},
 		},
 	}
-
 }

--- a/metricbeat/module/ceph/monitor_health/data.go
+++ b/metricbeat/module/ceph/monitor_health/data.go
@@ -69,7 +69,6 @@ type HealthRequest struct {
 }
 
 func eventsMapping(content []byte) []common.MapStr {
-
 	var d HealthRequest
 	err := json.Unmarshal(content, &d)
 	if err != nil {

--- a/metricbeat/module/ceph/pool_disk/data.go
+++ b/metricbeat/module/ceph/pool_disk/data.go
@@ -30,7 +30,6 @@ type DfRequest struct {
 }
 
 func eventsMapping(content []byte) []common.MapStr {
-
 	var d DfRequest
 	err := json.Unmarshal(content, &d)
 	if err != nil {

--- a/metricbeat/module/ceph/pool_disk/pool_disk_test.go
+++ b/metricbeat/module/ceph/pool_disk/pool_disk_test.go
@@ -50,5 +50,4 @@ func TestFetchEventContents(t *testing.T) {
 
 	available := stats["available"].(common.MapStr)
 	assert.EqualValues(t, uint64(5003444224), available["bytes"])
-
 }

--- a/metricbeat/module/couchbase/bucket/data.go
+++ b/metricbeat/module/couchbase/bucket/data.go
@@ -30,7 +30,6 @@ type Buckets []struct {
 }
 
 func eventsMapping(content []byte) []common.MapStr {
-
 	var d Buckets
 	err := json.Unmarshal(content, &d)
 	if err != nil {

--- a/metricbeat/module/couchbase/cluster/data.go
+++ b/metricbeat/module/couchbase/cluster/data.go
@@ -41,7 +41,6 @@ type Data struct {
 }
 
 func eventMapping(content []byte) common.MapStr {
-
 	var d Data
 	err := json.Unmarshal(content, &d)
 	if err != nil {

--- a/metricbeat/module/couchbase/node/data.go
+++ b/metricbeat/module/couchbase/node/data.go
@@ -57,7 +57,6 @@ type Data struct {
 }
 
 func eventsMapping(content []byte) []common.MapStr {
-
 	var d Data
 	err := json.Unmarshal(content, &d)
 	if err != nil {
@@ -144,5 +143,4 @@ func eventsMapping(content []byte) []common.MapStr {
 	}
 
 	return events
-
 }

--- a/metricbeat/module/docker/cpu/helper.go
+++ b/metricbeat/module/docker/cpu/helper.go
@@ -47,7 +47,6 @@ func (c *CPUService) getCPUStatsList(rawStats []docker.Stat) []CPUStats {
 }
 
 func (c *CPUService) getCpuStats(myRawStat *docker.Stat) CPUStats {
-
 	return CPUStats{
 		Time:                        common.Time(myRawStat.Stats.Read),
 		Container:                   docker.NewContainer(&myRawStat.Container),

--- a/metricbeat/module/dropwizard/collector/collector.go
+++ b/metricbeat/module/dropwizard/collector/collector.go
@@ -91,5 +91,4 @@ func (m *MetricSet) Fetch() ([]common.MapStr, error) {
 	}
 
 	return events, err
-
 }

--- a/metricbeat/module/dropwizard/collector/data.go
+++ b/metricbeat/module/dropwizard/collector/data.go
@@ -108,7 +108,6 @@ func splitTagsFromMetricName(metricName string) (string, common.MapStr) {
 
 // convertValue takes the input string and converts it to int of float
 func convertValue(value json.Number) interface{} {
-
 	if i, err := value.Int64(); err == nil {
 		return i
 	}

--- a/metricbeat/module/elasticsearch/node/data.go
+++ b/metricbeat/module/elasticsearch/node/data.go
@@ -25,7 +25,6 @@ var (
 )
 
 func eventsMapping(content []byte) ([]common.MapStr, error) {
-
 	nodesStruct := struct {
 		ClusterName string                            `json:"cluster_name"`
 		Nodes       map[string]map[string]interface{} `json:"nodes"`

--- a/metricbeat/module/elasticsearch/node/data_test.go
+++ b/metricbeat/module/elasticsearch/node/data_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 func TestGetMappings(t *testing.T) {
-
 	files, err := filepath.Glob("./_meta/test/node.*.json")
 	assert.NoError(t, err)
 
@@ -35,7 +34,6 @@ func TestGetMappings(t *testing.T) {
 }
 
 func TestInvalid(t *testing.T) {
-
 	file := "./_meta/test/invalid.json"
 
 	content, err := ioutil.ReadFile(file)

--- a/metricbeat/module/elasticsearch/node/node.go
+++ b/metricbeat/module/elasticsearch/node/node.go
@@ -42,7 +42,6 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // It returns the event which is then forward to the output. In case of an error, a
 // descriptive error must be returned.
 func (m *MetricSet) Fetch() ([]common.MapStr, error) {
-
 	content, err := m.http.FetchContent()
 	if err != nil {
 		return nil, err

--- a/metricbeat/module/elasticsearch/node_stats/data.go
+++ b/metricbeat/module/elasticsearch/node_stats/data.go
@@ -69,7 +69,6 @@ var (
 )
 
 func eventsMapping(content []byte) ([]common.MapStr, error) {
-
 	nodesStruct := struct {
 		ClusterName string                            `json:"cluster_name"`
 		Nodes       map[string]map[string]interface{} `json:"nodes"`

--- a/metricbeat/module/elasticsearch/node_stats/data_test.go
+++ b/metricbeat/module/elasticsearch/node_stats/data_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 func TestStats(t *testing.T) {
-
 	files, err := filepath.Glob("./_meta/test/node_stats.*.json")
 	assert.NoError(t, err)
 

--- a/metricbeat/module/elasticsearch/node_stats/node_stats.go
+++ b/metricbeat/module/elasticsearch/node_stats/node_stats.go
@@ -40,7 +40,6 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 
 // Fetch methods implements the data gathering and data conversion to the right format
 func (m *MetricSet) Fetch() ([]common.MapStr, error) {
-
 	content, err := m.http.FetchContent()
 	if err != nil {
 		return nil, err

--- a/metricbeat/module/golang/util.go
+++ b/metricbeat/module/golang/util.go
@@ -24,5 +24,4 @@ func GetCmdStr(v interface{}) interface{} {
 		logp.Debug("golang", "unexpected cmdline, %v, %v", t, v)
 		return v
 	}
-
 }

--- a/metricbeat/module/haproxy/haproxy.go
+++ b/metricbeat/module/haproxy/haproxy.go
@@ -190,7 +190,6 @@ func (c *Client) run(cmd string) (*bytes.Buffer, error) {
 
 // GetStat returns the result from the 'show stat' command
 func (c *Client) GetStat() ([]*Stat, error) {
-
 	runResult, err := c.run("show stat")
 	if err != nil {
 		return nil, err
@@ -206,12 +205,10 @@ func (c *Client) GetStat() ([]*Stat, error) {
 	}
 
 	return statRes, nil
-
 }
 
 // GetInfo returns the result from the 'show stat' command
 func (c *Client) GetInfo() (*Info, error) {
-
 	res, err := c.run("show info")
 	if err != nil {
 		return nil, err
@@ -245,5 +242,4 @@ func (c *Client) GetInfo() (*Info, error) {
 	}
 
 	return nil, err
-
 }

--- a/metricbeat/module/haproxy/stat/data.go
+++ b/metricbeat/module/haproxy/stat/data.go
@@ -110,7 +110,6 @@ var (
 
 // Map data to MapStr.
 func eventMapping(info []*haproxy.Stat) []common.MapStr {
-
 	var events []common.MapStr
 
 	for _, evt := range info {

--- a/metricbeat/module/http/json/json.go
+++ b/metricbeat/module/http/json/json.go
@@ -93,7 +93,6 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // It returns the event which is then forward to the output. In case of an error, a
 // descriptive error must be returned.
 func (m *MetricSet) Fetch() (common.MapStr, error) {
-
 	response, err := m.http.FetchResponse()
 	if err != nil {
 		return nil, err
@@ -140,7 +139,6 @@ func (m *MetricSet) Fetch() (common.MapStr, error) {
 }
 
 func (m *MetricSet) getHeaders(header http.Header) map[string]string {
-
 	headers := make(map[string]string)
 	for k, v := range header {
 		value := ""

--- a/metricbeat/module/jolokia/jmx/jmx.go
+++ b/metricbeat/module/jolokia/jmx/jmx.go
@@ -80,7 +80,6 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 		namespace:     config.Namespace,
 		http:          http,
 	}, nil
-
 }
 
 // Fetch methods implements the data gathering and data conversion to the right format

--- a/metricbeat/module/kibana/status/data.go
+++ b/metricbeat/module/kibana/status/data.go
@@ -35,7 +35,6 @@ type OverallMetrics struct {
 }
 
 func eventMapping(content []byte) common.MapStr {
-
 	var data map[string]interface{}
 	json.Unmarshal(content, &data)
 	event, _ := schema.Apply(data)

--- a/metricbeat/module/kibana/status/data_test.go
+++ b/metricbeat/module/kibana/status/data_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 func TestEventMapping(t *testing.T) {
-
 	content, err := ioutil.ReadFile("./_meta/test/input.json")
 	assert.NoError(t, err)
 

--- a/metricbeat/module/kibana/status/status.go
+++ b/metricbeat/module/kibana/status/status.go
@@ -41,7 +41,6 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // It returns the event which is then forward to the output. In case of an error, a
 // descriptive error must be returned.
 func (m *MetricSet) Fetch() (common.MapStr, error) {
-
 	content, err := m.http.FetchContent()
 	if err != nil {
 		return nil, err

--- a/metricbeat/module/kubernetes/container/container.go
+++ b/metricbeat/module/kubernetes/container/container.go
@@ -52,7 +52,6 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // It returns the event which is then forward to the output. In case of an error, a
 // descriptive error must be returned.
 func (m *MetricSet) Fetch() ([]common.MapStr, error) {
-
 	body, err := m.http.FetchContent()
 	if err != nil {
 		return nil, err

--- a/metricbeat/module/kubernetes/container/container_test.go
+++ b/metricbeat/module/kubernetes/container/container_test.go
@@ -14,7 +14,6 @@ import (
 const testFile = "../_meta/test/stats_summary.json"
 
 func TestEventMapping(t *testing.T) {
-
 	f, err := os.Open(testFile)
 	assert.NoError(t, err, "cannot open test file "+testFile)
 

--- a/metricbeat/module/kubernetes/container/data.go
+++ b/metricbeat/module/kubernetes/container/data.go
@@ -99,5 +99,4 @@ func eventMapping(content []byte) ([]common.MapStr, error) {
 	}
 
 	return events, nil
-
 }

--- a/metricbeat/module/kubernetes/event/event.go
+++ b/metricbeat/module/kubernetes/event/event.go
@@ -143,5 +143,4 @@ func generateMapStrFromEvent(eve *Event) common.MapStr {
 		},
 		"metadata": eventMeta,
 	}
-
 }

--- a/metricbeat/module/kubernetes/event/watcher.go
+++ b/metricbeat/module/kubernetes/event/watcher.go
@@ -88,7 +88,6 @@ func (w *Watcher) watchEvents() {
 
 		}
 	}
-
 }
 
 func (w *Watcher) Run() {
@@ -111,7 +110,6 @@ func (w *Watcher) getEventMeta(pod *corev1.Event) *Event {
 	}
 
 	return eve
-
 }
 
 func (w *Watcher) Stop() {

--- a/metricbeat/module/kubernetes/node/data.go
+++ b/metricbeat/module/kubernetes/node/data.go
@@ -89,5 +89,4 @@ func eventMapping(content []byte) (common.MapStr, error) {
 		},
 	}
 	return nodeEvent, nil
-
 }

--- a/metricbeat/module/kubernetes/node/node.go
+++ b/metricbeat/module/kubernetes/node/node.go
@@ -52,7 +52,6 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // It returns the event which is then forward to the output. In case of an error, a
 // descriptive error must be returned.
 func (m *MetricSet) Fetch() (common.MapStr, error) {
-
 	body, err := m.http.FetchContent()
 	if err != nil {
 		return nil, err

--- a/metricbeat/module/kubernetes/node/node_test.go
+++ b/metricbeat/module/kubernetes/node/node_test.go
@@ -14,7 +14,6 @@ import (
 const testFile = "../_meta/test/stats_summary.json"
 
 func TestEventMapping(t *testing.T) {
-
 	f, err := os.Open(testFile)
 	assert.NoError(t, err, "cannot open test file "+testFile)
 

--- a/metricbeat/module/kubernetes/pod/data.go
+++ b/metricbeat/module/kubernetes/pod/data.go
@@ -45,5 +45,4 @@ func eventMapping(content []byte) ([]common.MapStr, error) {
 		events = append(events, podEvent)
 	}
 	return events, nil
-
 }

--- a/metricbeat/module/kubernetes/pod/pod.go
+++ b/metricbeat/module/kubernetes/pod/pod.go
@@ -52,7 +52,6 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // It returns the event which is then forward to the output. In case of an error, a
 // descriptive error must be returned.
 func (m *MetricSet) Fetch() ([]common.MapStr, error) {
-
 	body, err := m.http.FetchContent()
 	if err != nil {
 		return nil, err

--- a/metricbeat/module/kubernetes/pod/pod_test.go
+++ b/metricbeat/module/kubernetes/pod/pod_test.go
@@ -14,7 +14,6 @@ import (
 const testFile = "../_meta/test/stats_summary.json"
 
 func TestEventMapping(t *testing.T) {
-
 	f, err := os.Open(testFile)
 	assert.NoError(t, err, "cannot open test file "+testFile)
 

--- a/metricbeat/module/kubernetes/state_container/state_container_test.go
+++ b/metricbeat/module/kubernetes/state_container/state_container_test.go
@@ -18,7 +18,6 @@ import (
 const testFile = "../_meta/test/kube-state-metrics"
 
 func TestEventMapping(t *testing.T) {
-
 	file, err := os.Open(testFile)
 	assert.NoError(t, err, "cannot open test file "+testFile)
 

--- a/metricbeat/module/kubernetes/state_deployment/state_deployment_test.go
+++ b/metricbeat/module/kubernetes/state_deployment/state_deployment_test.go
@@ -18,7 +18,6 @@ import (
 const testFile = "../_meta/test/kube-state-metrics"
 
 func TestEventMapping(t *testing.T) {
-
 	file, err := os.Open(testFile)
 	assert.NoError(t, err, "cannot open test file "+testFile)
 

--- a/metricbeat/module/kubernetes/state_node/state_node_test.go
+++ b/metricbeat/module/kubernetes/state_node/state_node_test.go
@@ -18,7 +18,6 @@ import (
 const testFile = "../_meta/test/kube-state-metrics"
 
 func TestEventMapping(t *testing.T) {
-
 	file, err := os.Open(testFile)
 	assert.NoError(t, err, "cannot open test file "+testFile)
 

--- a/metricbeat/module/kubernetes/state_pod/state_pod_test.go
+++ b/metricbeat/module/kubernetes/state_pod/state_pod_test.go
@@ -18,7 +18,6 @@ import (
 const testFile = "../_meta/test/kube-state-metrics"
 
 func TestEventMapping(t *testing.T) {
-
 	file, err := os.Open(testFile)
 	assert.NoError(t, err, "cannot open test file "+testFile)
 

--- a/metricbeat/module/kubernetes/state_replicaset/state_replicaset_test.go
+++ b/metricbeat/module/kubernetes/state_replicaset/state_replicaset_test.go
@@ -18,7 +18,6 @@ import (
 const testFile = "../_meta/test/kube-state-metrics"
 
 func TestEventMapping(t *testing.T) {
-
 	file, err := os.Open(testFile)
 	assert.NoError(t, err, "cannot open test file "+testFile)
 

--- a/metricbeat/module/kubernetes/system/data.go
+++ b/metricbeat/module/kubernetes/system/data.go
@@ -55,5 +55,4 @@ func eventMapping(content []byte) ([]common.MapStr, error) {
 	}
 
 	return events, nil
-
 }

--- a/metricbeat/module/kubernetes/system/system.go
+++ b/metricbeat/module/kubernetes/system/system.go
@@ -52,7 +52,6 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // It returns the event which is then forward to the output. In case of an error, a
 // descriptive error must be returned.
 func (m *MetricSet) Fetch() ([]common.MapStr, error) {
-
 	body, err := m.http.FetchContent()
 	if err != nil {
 		return nil, err

--- a/metricbeat/module/kubernetes/system/system_test.go
+++ b/metricbeat/module/kubernetes/system/system_test.go
@@ -14,7 +14,6 @@ import (
 const testFile = "../_meta/test/stats_summary.json"
 
 func TestEventMapping(t *testing.T) {
-
 	f, err := os.Open(testFile)
 	assert.NoError(t, err, "cannot open test file "+testFile)
 

--- a/metricbeat/module/kubernetes/volume/data.go
+++ b/metricbeat/module/kubernetes/volume/data.go
@@ -55,5 +55,4 @@ func eventMapping(content []byte) ([]common.MapStr, error) {
 
 	}
 	return events, nil
-
 }

--- a/metricbeat/module/kubernetes/volume/volume.go
+++ b/metricbeat/module/kubernetes/volume/volume.go
@@ -52,7 +52,6 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // It returns the event which is then forward to the output. In case of an error, a
 // descriptive error must be returned.
 func (m *MetricSet) Fetch() ([]common.MapStr, error) {
-
 	body, err := m.http.FetchContent()
 	if err != nil {
 		return nil, err

--- a/metricbeat/module/kubernetes/volume/volume_test.go
+++ b/metricbeat/module/kubernetes/volume/volume_test.go
@@ -14,7 +14,6 @@ import (
 const testFile = "../_meta/test/stats_summary.json"
 
 func TestEventMapping(t *testing.T) {
-
 	f, err := os.Open(testFile)
 	assert.NoError(t, err, "cannot open test file "+testFile)
 

--- a/metricbeat/module/mongodb/mongodb.go
+++ b/metricbeat/module/mongodb/mongodb.go
@@ -69,7 +69,6 @@ func ParseURL(module mb.Module, host string) (mb.HostData, error) {
 // NewDirectSession estbalishes direct connections with a list of hosts. It uses the supplied
 // dialInfo parameter as a template for establishing more direct connections
 func NewDirectSession(dialInfo *mgo.DialInfo) (*mgo.Session, error) {
-
 	// make a copy
 	nodeDialInfo := *dialInfo
 	nodeDialInfo.Direct = true

--- a/metricbeat/module/postgresql/activity/activity_integration_test.go
+++ b/metricbeat/module/postgresql/activity/activity_integration_test.go
@@ -35,7 +35,6 @@ func TestFetch(t *testing.T) {
 	assert.Contains(t, event, "user")
 	assert.Contains(t, event["user"].(common.MapStr), "name")
 	assert.Contains(t, event["user"].(common.MapStr), "id")
-
 }
 
 func TestData(t *testing.T) {

--- a/metricbeat/module/postgresql/bgwriter/bgwriter_integration_test.go
+++ b/metricbeat/module/postgresql/bgwriter/bgwriter_integration_test.go
@@ -37,7 +37,6 @@ func TestFetch(t *testing.T) {
 	assert.Contains(t, buffers, "backend")
 	assert.Contains(t, buffers, "backend_fsync")
 	assert.Contains(t, buffers, "allocated")
-
 }
 
 func TestData(t *testing.T) {

--- a/metricbeat/module/postgresql/database/database_integration_test.go
+++ b/metricbeat/module/postgresql/database/database_integration_test.go
@@ -37,7 +37,6 @@ func TestFetch(t *testing.T) {
 	assert.Contains(t, rows, "inserted")
 	assert.Contains(t, rows, "updated")
 	assert.Contains(t, rows, "deleted")
-
 }
 
 func TestData(t *testing.T) {

--- a/metricbeat/module/prometheus/stats/stats.go
+++ b/metricbeat/module/prometheus/stats/stats.go
@@ -43,7 +43,6 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 }
 
 func (m *MetricSet) Fetch() (common.MapStr, error) {
-
 	scanner, err := m.http.FetchScanner()
 	if err != nil {
 		return nil, err

--- a/metricbeat/module/rabbitmq/node/data.go
+++ b/metricbeat/module/rabbitmq/node/data.go
@@ -130,7 +130,6 @@ var (
 )
 
 func eventsMapping(content []byte) ([]common.MapStr, error) {
-
 	var nodes []map[string]interface{}
 	err := json.Unmarshal(content, &nodes)
 	if err != nil {

--- a/metricbeat/module/rabbitmq/node/node.go
+++ b/metricbeat/module/rabbitmq/node/node.go
@@ -32,7 +32,6 @@ type MetricSet struct {
 }
 
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-
 	logp.Experimental("The rabbitmq node metricset is experimental")
 
 	http := helper.NewHTTP(base)
@@ -45,7 +44,6 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 }
 
 func (m *MetricSet) Fetch() ([]common.MapStr, error) {
-
 	content, err := m.HTTP.FetchContent()
 
 	if err != nil {

--- a/metricbeat/module/rabbitmq/node/node_test.go
+++ b/metricbeat/module/rabbitmq/node/node_test.go
@@ -135,5 +135,4 @@ func TestFetchEventContents(t *testing.T) {
 	assert.EqualValues(t, "disc", event["type"])
 
 	assert.EqualValues(t, 37139, event["uptime"])
-
 }

--- a/metricbeat/module/redis/keyspace/data.go
+++ b/metricbeat/module/redis/keyspace/data.go
@@ -11,7 +11,6 @@ import (
 
 // Map data to MapStr
 func eventsMapping(info map[string]string) []common.MapStr {
-
 	events := []common.MapStr{}
 	for key, space := range getKeyspaceStats(info) {
 		space["id"] = key

--- a/metricbeat/module/redis/keyspace/keyspace_integration_test.go
+++ b/metricbeat/module/redis/keyspace/keyspace_integration_test.go
@@ -16,7 +16,6 @@ import (
 var host = redis.GetRedisEnvHost() + ":" + redis.GetRedisEnvPort()
 
 func TestFetch(t *testing.T) {
-
 	addEntry(t)
 
 	// Fetch data

--- a/metricbeat/module/system/memory/helper.go
+++ b/metricbeat/module/system/memory/helper.go
@@ -15,7 +15,6 @@ type MemStat struct {
 }
 
 func GetMemory() (*MemStat, error) {
-
 	mem := sigar.Mem{}
 	err := mem.Get()
 	if err != nil {
@@ -26,7 +25,6 @@ func GetMemory() (*MemStat, error) {
 }
 
 func AddMemPercentage(m *MemStat) {
-
 	if m.Mem.Total == 0 {
 		return
 	}
@@ -44,7 +42,6 @@ type SwapStat struct {
 }
 
 func GetSwap() (*SwapStat, error) {
-
 	swap := sigar.Swap{}
 	err := swap.Get()
 	if err != nil {
@@ -52,7 +49,6 @@ func GetSwap() (*SwapStat, error) {
 	}
 
 	return &SwapStat{Swap: swap}, nil
-
 }
 
 func GetMemoryEvent(memStat *MemStat) common.MapStr {

--- a/metricbeat/module/system/memory/helper_test.go
+++ b/metricbeat/module/system/memory/helper_test.go
@@ -25,7 +25,6 @@ func TestGetMemory(t *testing.T) {
 }
 
 func TestGetSwap(t *testing.T) {
-
 	if runtime.GOOS == "windows" {
 		return //no load data on windows
 	}
@@ -41,7 +40,6 @@ func TestGetSwap(t *testing.T) {
 }
 
 func TestMemPercentage(t *testing.T) {
-
 	m := MemStat{
 		Mem: gosigar.Mem{
 			Total: 7,
@@ -60,7 +58,6 @@ func TestMemPercentage(t *testing.T) {
 }
 
 func TestActualMemPercentage(t *testing.T) {
-
 	m := MemStat{
 		Mem: gosigar.Mem{
 			Total:      7,

--- a/metricbeat/module/system/process/helper.go
+++ b/metricbeat/module/system/process/helper.go
@@ -181,7 +181,6 @@ func getProcEnv(pid int, out common.MapStr, filter func(v string) bool) error {
 }
 
 func GetProcMemPercentage(proc *Process, totalPhyMem uint64) float64 {
-
 	// in unit tests, total_phymem is set to a value greater than zero
 	if totalPhyMem == 0 {
 		memStat, err := memory.GetMemory()
@@ -198,7 +197,6 @@ func GetProcMemPercentage(proc *Process, totalPhyMem uint64) float64 {
 }
 
 func Pids() ([]int, error) {
-
 	pids := sigar.ProcList{}
 	err := pids.Get()
 	if err != nil {
@@ -208,7 +206,6 @@ func Pids() ([]int, error) {
 }
 
 func getProcState(b byte) string {
-
 	switch b {
 	case 'S':
 		return "sleeping"
@@ -309,7 +306,6 @@ func GetProcCpuPercentage(s0, s1 *Process) (normalizedPct, pct float64) {
 }
 
 func (procStats *ProcStats) MatchProcess(name string) bool {
-
 	for _, reg := range procStats.procRegexps {
 		if reg.MatchString(name) {
 			return true
@@ -319,7 +315,6 @@ func (procStats *ProcStats) MatchProcess(name string) bool {
 }
 
 func (procStats *ProcStats) InitProcStats() error {
-
 	procStats.ProcsMap = make(ProcsMap)
 
 	if len(procStats.Procs) == 0 {
@@ -348,7 +343,6 @@ func (procStats *ProcStats) InitProcStats() error {
 }
 
 func (procStats *ProcStats) GetProcStats() ([]common.MapStr, error) {
-
 	if len(procStats.Procs) == 0 {
 		return nil, nil
 	}
@@ -405,7 +399,6 @@ func (procStats *ProcStats) GetProcStats() ([]common.MapStr, error) {
 }
 
 func (procStats *ProcStats) includeTopProcesses(processes []Process) []Process {
-
 	if !procStats.IncludeTop.Enabled ||
 		(procStats.IncludeTop.ByCPU == 0 && procStats.IncludeTop.ByMemory == 0) {
 

--- a/metricbeat/module/system/process_summary/process_summary.go
+++ b/metricbeat/module/system/process_summary/process_summary.go
@@ -33,7 +33,6 @@ type MetricSet struct {
 // Part of new is also setting up the configuration by processing additional
 // configuration entries if needed.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-
 	return &MetricSet{
 		BaseMetricSet: base,
 	}, nil
@@ -43,7 +42,6 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // It returns the event which is then forward to the output. In case of an error, a
 // descriptive error must be returned.
 func (m *MetricSet) Fetch() (common.MapStr, error) {
-
 	pids, err := process.Pids()
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to fetch the list of PIDs")

--- a/metricbeat/module/vsphere/datastore/datastore_test.go
+++ b/metricbeat/module/vsphere/datastore/datastore_test.go
@@ -72,7 +72,6 @@ func TestData(t *testing.T) {
 	if err := mbtest.WriteEvents(f, t); err != nil {
 		t.Fatal("write", err)
 	}
-
 }
 
 func getConfig(ts *simulator.Server) map[string]interface{} {

--- a/metricbeat/module/vsphere/host/data.go
+++ b/metricbeat/module/vsphere/host/data.go
@@ -7,7 +7,6 @@ import (
 )
 
 func eventMapping(hs mo.HostSystem, datacenterName string) common.MapStr {
-
 	totalCpu := int64(hs.Summary.Hardware.CpuMhz) * int64(hs.Summary.Hardware.NumCpuCores)
 	freeCpu := int64(totalCpu) - int64(hs.Summary.QuickStats.OverallCpuUsage)
 	usedMemory := int64(hs.Summary.QuickStats.OverallMemoryUsage) * 1024 * 1024
@@ -41,5 +40,4 @@ func eventMapping(hs mo.HostSystem, datacenterName string) common.MapStr {
 	}
 
 	return event
-
 }

--- a/metricbeat/module/vsphere/host/data_test.go
+++ b/metricbeat/module/vsphere/host/data_test.go
@@ -10,7 +10,6 @@ import (
 )
 
 func TestEventMapping(t *testing.T) {
-
 	var HostSystemTest = mo.HostSystem{
 		Summary: types.HostListSummary{
 			Host: &types.ManagedObjectReference{Type: "HostSystem", Value: "ha-host"},

--- a/metricbeat/module/vsphere/host/host_test.go
+++ b/metricbeat/module/vsphere/host/host_test.go
@@ -55,7 +55,6 @@ func TestFetchEventContents(t *testing.T) {
 
 	memoryFree := memory["free"].(common.MapStr)
 	assert.EqualValues(t, uint64(2822230016), memoryFree["bytes"])
-
 }
 
 func TestData(t *testing.T) {

--- a/packetbeat/beater/packetbeat.go
+++ b/packetbeat/beater/packetbeat.go
@@ -95,7 +95,6 @@ func New(b *beat.Beat, rawConfig *common.Config) (beat.Beater, error) {
 
 // init packetbeat components
 func (pb *packetbeat) init(b *beat.Beat) error {
-
 	cfg := &pb.config
 	err := procs.ProcWatcher.Init(cfg.Procs)
 	if err != nil {

--- a/packetbeat/main_test.go
+++ b/packetbeat/main_test.go
@@ -19,7 +19,6 @@ func init() {
 
 // Test started when the test binary is started. Only calls main.
 func TestSystem(t *testing.T) {
-
 	if *systemTest {
 		main()
 	}

--- a/packetbeat/procs/procs.go
+++ b/packetbeat/procs/procs.go
@@ -62,7 +62,6 @@ type ProcessesWatcher struct {
 var ProcWatcher ProcessesWatcher
 
 func (proc *ProcessesWatcher) Init(config ProcsConfig) error {
-
 	proc.procPrefix = ""
 	proc.portProcMap = make(map[uint16]portProcMapping)
 	proc.lastMapUpdate = time.Now()
@@ -283,7 +282,6 @@ func hexToIPPort(str []byte, ipv6 bool) (net.IP, uint16, error) {
 }
 
 func (proc *ProcessesWatcher) updateMap() {
-
 	logp.Debug("procs", "UpdateMap()")
 	ipv4socks, err := socketsFromProc("/proc/net/tcp", false)
 	if err != nil {
@@ -320,7 +318,6 @@ func (proc *ProcessesWatcher) updateMap() {
 
 		}
 	}
-
 }
 
 func socketsFromProc(filename string, ipv6 bool) ([]*socketInfo, error) {
@@ -389,7 +386,6 @@ func (proc *ProcessesWatcher) updateMappingEntry(port uint16, pid int, p *proces
 }
 
 func findSocketsOfPid(prefix string, pid int) (inodes []uint64, err error) {
-
 	dirname := filepath.Join(prefix, "/proc", strconv.Itoa(pid), "fd")
 	procfs, err := os.Open(dirname)
 	if err != nil {
@@ -423,7 +419,6 @@ func findSocketsOfPid(prefix string, pid int) (inodes []uint64, err error) {
 }
 
 func (proc *ProcessesWatcher) isLocalIP(ip net.IP) bool {
-
 	if ip.IsLoopback() {
 		return true
 	}

--- a/packetbeat/procs/procs_test.go
+++ b/packetbeat/procs/procs_test.go
@@ -19,7 +19,6 @@ type testProcFile struct {
 }
 
 func createFakeDirectoryStructure(prefix string, files []testProcFile) error {
-
 	var err error
 	for _, file := range files {
 		dir := filepath.Dir(file.path)
@@ -117,7 +116,6 @@ func TestFindPidsByCmdlineGrep(t *testing.T) {
 }
 
 func TestRefreshPids(t *testing.T) {
-
 	proc := []testProcFile{
 		{path: "/proc/1/cmdline", contents: "/sbin/init"},
 		{path: "/proc/1/cgroup", contents: ""},

--- a/packetbeat/protos/amqp/amqp.go
+++ b/packetbeat/protos/amqp/amqp.go
@@ -344,7 +344,6 @@ func (amqp *amqpPlugin) expireTransaction(trans *amqpTransaction) {
 //This method handles published messages from clients. Being an async
 //process, the method, header and body frames are regrouped in one transaction
 func (amqp *amqpPlugin) handlePublishing(client *amqpMessage) {
-
 	tuple := client.tcpTuple
 	trans := amqp.getTransaction(tuple.Hashable())
 
@@ -389,7 +388,6 @@ func (amqp *amqpPlugin) handlePublishing(client *amqpMessage) {
 //returned messages to clients. Being an async process, the method, header and
 //body frames are regrouped in one transaction
 func (amqp *amqpPlugin) handleDelivering(server *amqpMessage) {
-
 	tuple := server.tcpTuple
 	trans := amqp.getTransaction(tuple.Hashable())
 
@@ -434,7 +432,6 @@ func (amqp *amqpPlugin) handleDelivering(server *amqpMessage) {
 }
 
 func (amqp *amqpPlugin) publishTransaction(t *amqpTransaction) {
-
 	if amqp.results == nil {
 		return
 	}

--- a/packetbeat/protos/amqp/amqp_parser.go
+++ b/packetbeat/protos/amqp/amqp_parser.go
@@ -63,7 +63,6 @@ func (s *amqpStream) prepareForNewMessage() {
 }
 
 func isProtocolHeader(data []byte) (isHeader bool, version string) {
-
 	if (string(data[:4]) == "AMQP") && data[4] == 0 {
 		return true, string(data[5:8])
 	}

--- a/packetbeat/protos/amqp/amqp_test.go
+++ b/packetbeat/protos/amqp/amqp_test.go
@@ -314,7 +314,6 @@ func TestAmqp_ExchangeUnbindTransaction(t *testing.T) {
 	assert.Equal(t, "test2", fields["source"])
 	assert.Equal(t, "MSFT", fields["routing-key"])
 	assert.Equal(t, false, fields["no-wait"])
-
 }
 
 func TestAmqp_PublishMessage(t *testing.T) {
@@ -460,7 +459,6 @@ func TestAmqp_MessagePropertiesFields(t *testing.T) {
 	assert.Equal(t, "hihi", headers["yop"])
 	assert.Equal(t, nil, headers["nil"])
 	assert.Equal(t, 40.5, headers["number"])
-
 }
 
 func TestAmqp_ChannelError(t *testing.T) {

--- a/packetbeat/protos/cassandra/cassandra.go
+++ b/packetbeat/protos/cassandra/cassandra.go
@@ -68,7 +68,6 @@ func (cassandra *cassandra) init(results protos.Reporter, config *cassandraConfi
 }
 
 func (cassandra *cassandra) setFromConfig(config *cassandraConfig) error {
-
 	// set module configuration
 	if err := cassandra.ports.Set(config.Ports); err != nil {
 		return err

--- a/packetbeat/protos/cassandra/internal/gocql/frame.go
+++ b/packetbeat/protos/cassandra/internal/gocql/frame.go
@@ -66,7 +66,6 @@ type Framer struct {
 }
 
 func NewFramer(r *streambuf.Buffer, compressor Compressor) *Framer {
-
 	f := framerPool.Get().(*Framer)
 	f.compres = compressor
 	f.r = r
@@ -155,7 +154,6 @@ func (f *Framer) ReadHeader() (head *frameHeader, err error) {
 
 // reads a frame form the wire into the framers buffer
 func (f *Framer) ReadFrame() (data map[string]interface{}, err error) {
-
 	defer func() {
 		if r := recover(); r != nil {
 			if _, ok := r.(runtime.Error); ok {
@@ -257,7 +255,6 @@ func (f *Framer) ReadFrame() (data map[string]interface{}, err error) {
 }
 
 func (f *Framer) parseErrorFrame() (data map[string]interface{}) {
-
 	decoder := f.decoder
 	code := decoder.ReadInt()
 	msg := decoder.ReadString()
@@ -351,14 +348,12 @@ func (f *Framer) parseErrorFrame() (data map[string]interface{}) {
 }
 
 func (f *Framer) parseSupportedFrame() (data map[string]interface{}) {
-
 	data = make(map[string]interface{})
 	data["supported"] = (f.decoder).ReadStringMultiMap()
 	return data
 }
 
 func (f *Framer) parseResultMetadata(getPKinfo bool) map[string]interface{} {
-
 	decoder := f.decoder
 	meta := make(map[string]interface{})
 	flags := decoder.ReadInt()
@@ -407,7 +402,6 @@ func (f *Framer) parseQueryFrame() (data map[string]interface{}) {
 }
 
 func (f *Framer) parseResultFrame() (data map[string]interface{}) {
-
 	kind := (f.decoder).ReadInt()
 
 	data = make(map[string]interface{})
@@ -432,7 +426,6 @@ func (f *Framer) parseResultFrame() (data map[string]interface{}) {
 }
 
 func (f *Framer) parseResultRows() map[string]interface{} {
-
 	result := make(map[string]interface{})
 	result["meta"] = f.parseResultMetadata(false)
 	result["num_rows"] = (f.decoder).ReadInt()
@@ -441,7 +434,6 @@ func (f *Framer) parseResultRows() map[string]interface{} {
 }
 
 func (f *Framer) parseResultPrepared() map[string]interface{} {
-
 	result := make(map[string]interface{})
 
 	uuid, err := UUIDFromBytes((f.decoder).ReadShortBytes())
@@ -520,7 +512,6 @@ func (f *Framer) parseAuthChallengeFrame() (data map[string]interface{}) {
 }
 
 func (f *Framer) parseEventFrame() (data map[string]interface{}) {
-
 	data = make((map[string]interface{}))
 	decoder := f.decoder
 	eventType := decoder.ReadString()

--- a/packetbeat/protos/cassandra/internal/gocql/marshal.go
+++ b/packetbeat/protos/cassandra/internal/gocql/marshal.go
@@ -679,7 +679,6 @@ func (u UUID) String() string {
 	r[18] = '-'
 	r[23] = '-'
 	return string(r)
-
 }
 
 // UUIDFromBytes converts a raw byte slice to an UUID.

--- a/packetbeat/protos/cassandra/internal/gocql/stream_decoder.go
+++ b/packetbeat/protos/cassandra/internal/gocql/stream_decoder.go
@@ -16,7 +16,6 @@ func (f StreamDecoder) ReadByte() (byte, error) {
 }
 
 func (f StreamDecoder) ReadInt() (n int) {
-
 	data, err := f.r.ReadNetUint32()
 	if err != nil {
 		panic(err)
@@ -27,7 +26,6 @@ func (f StreamDecoder) ReadInt() (n int) {
 }
 
 func (f StreamDecoder) ReadShort() (n uint16) {
-
 	data, err := f.r.ReadNetUint16()
 	if err != nil {
 		panic(err)
@@ -38,7 +36,6 @@ func (f StreamDecoder) ReadShort() (n uint16) {
 }
 
 func (f StreamDecoder) ReadLong() (n int64) {
-
 	data, err := f.r.ReadNetUint64()
 	if err != nil {
 		panic(err)
@@ -62,7 +59,6 @@ func (f StreamDecoder) ReadString() (s string) {
 }
 
 func (f StreamDecoder) ReadLongString() (s string) {
-
 	size := f.ReadInt()
 
 	if !f.r.Avail(size) {
@@ -79,7 +75,6 @@ func (f StreamDecoder) ReadLongString() (s string) {
 }
 
 func (f StreamDecoder) ReadUUID() *UUID {
-
 	bytes := make([]byte, 16)
 	_, err := f.r.Read(bytes)
 	if err != nil {
@@ -88,7 +83,6 @@ func (f StreamDecoder) ReadUUID() *UUID {
 
 	u, _ := UUIDFromBytes(bytes)
 	return &u
-
 }
 
 func (f StreamDecoder) ReadStringList() []string {
@@ -114,7 +108,6 @@ func (f StreamDecoder) ReadBytesInternal() []byte {
 		panic(err)
 	}
 	return bytes
-
 }
 
 func (f StreamDecoder) ReadBytes() []byte {
@@ -131,11 +124,9 @@ func (f StreamDecoder) ReadShortBytes() []byte {
 		panic(err)
 	}
 	return bytes
-
 }
 
 func (f StreamDecoder) ReadInet() (net.IP, int) {
-
 	size, err := f.ReadByte()
 	if err != nil {
 		panic(err)
@@ -152,7 +143,6 @@ func (f StreamDecoder) ReadInet() (net.IP, int) {
 	}
 	port := f.ReadInt()
 	return net.IP(ip), port
-
 }
 
 func (f StreamDecoder) ReadConsistency() Consistency {

--- a/packetbeat/protos/cassandra/parser.go
+++ b/packetbeat/protos/cassandra/parser.go
@@ -27,7 +27,6 @@ type parserConfig struct {
 
 // check whether this ops is enabled or not
 func (p *parser) CheckFrameOpsIgnored() bool {
-
 	if p.config.ignoredOps != nil && len(p.config.ignoredOps) > 0 {
 		//default map value is false
 		v := p.config.ignoredOps[p.framer.Header.Op]
@@ -131,7 +130,6 @@ func (p *parser) newMessage(ts time.Time) *message {
 }
 
 func (p *parser) parserBody() (bool, error) {
-
 	headLen := p.framer.Header.HeadLength
 	bdyLen := p.framer.Header.BodyLength
 	if bdyLen <= 0 {
@@ -191,7 +189,6 @@ func (p *parser) parserBody() (bool, error) {
 }
 
 func (p *parser) parse() (*message, error) {
-
 	// if p.frame is nil then create a new framer, or continue to process the last message
 	if p.framer == nil {
 		if isDebug {

--- a/packetbeat/protos/cassandra/trans.go
+++ b/packetbeat/protos/cassandra/trans.go
@@ -118,13 +118,11 @@ func (trans *transactions) tryMergeRequests(
 }
 
 func (trans *transactions) tryMergeResponses(prev, msg *message) (merged bool, err error) {
-
 	msg.isComplete = true
 	return false, nil
 }
 
 func (trans *transactions) correlate() error {
-
 	requests := &trans.requests
 	responses := &trans.responses
 

--- a/packetbeat/protos/dns/dns.go
+++ b/packetbeat/protos/dns/dns.go
@@ -492,7 +492,6 @@ func addDNSToMapStr(m common.MapStr, dns *mkdns.Msg, authority bool, additional 
 			m["additionals"] = rrsMapStrs
 		}
 	}
-
 }
 
 func optToMapStr(rrOPT *mkdns.OPT) common.MapStr {

--- a/packetbeat/protos/http/http.go
+++ b/packetbeat/protos/http/http.go
@@ -151,7 +151,6 @@ func (http *httpPlugin) GetPorts() []int {
 // tcp stream. Decides if we can ignore the gap or it's a parser error
 // and we need to drop the stream.
 func (http *httpPlugin) messageGap(s *stream, nbytes int) (ok bool, complete bool) {
-
 	m := s.message
 	switch s.parseState {
 	case stateStart, stateHeaders:
@@ -523,7 +522,6 @@ func (http *httpPlugin) publishTransaction(event beat.Event) {
 }
 
 func (http *httpPlugin) collectHeaders(m *message) interface{} {
-
 	hdrs := map[string]interface{}{}
 
 	hdrs["content-length"] = m.contentLength
@@ -610,7 +608,6 @@ func (http *httpPlugin) cutMessageBody(m *message) []byte {
 
 	// add body
 	return append(cutMsg, http.extractBody(m)...)
-
 }
 
 func (http *httpPlugin) shouldIncludeInBody(contenttype []byte) bool {

--- a/packetbeat/protos/http/http_parser.go
+++ b/packetbeat/protos/http/http_parser.go
@@ -466,7 +466,6 @@ func (*parser) parseBodyChunkedStart(s *stream, m *message) (cont, ok, complete 
 }
 
 func (*parser) parseBodyChunked(s *stream, m *message) (cont, ok, complete bool) {
-
 	if len(s.data[s.parseOffset:]) >= m.chunkedLength-s.bodyReceived+2 /*\r\n*/ {
 		// Received more data than expected
 		m.chunkedBody = append(m.chunkedBody, s.data[s.parseOffset:s.parseOffset+m.chunkedLength-s.bodyReceived]...)

--- a/packetbeat/protos/http/http_test.go
+++ b/packetbeat/protos/http/http_test.go
@@ -708,7 +708,6 @@ func TestHttpParser_censorPasswordURL(t *testing.T) {
 }
 
 func TestHttpParser_censorPasswordPOST(t *testing.T) {
-
 	if testing.Verbose() {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"http", "httpdetailed"})
 	}
@@ -785,7 +784,6 @@ func TestHttpParser_censorPasswordGET(t *testing.T) {
 }
 
 func TestHttpParser_RedactAuthorization(t *testing.T) {
-
 	if testing.Verbose() {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"http", "httpdetailed"})
 	}
@@ -831,7 +829,6 @@ func TestHttpParser_RedactAuthorization(t *testing.T) {
 }
 
 func TestHttpParser_RedactAuthorization_raw(t *testing.T) {
-
 	http := httpModForTests(nil)
 	http.redactAuthorization = true
 	http.parserConfig.sendHeaders = false
@@ -868,7 +865,6 @@ func TestHttpParser_RedactAuthorization_raw(t *testing.T) {
 }
 
 func TestHttpParser_RedactAuthorization_Proxy_raw(t *testing.T) {
-
 	http := httpModForTests(nil)
 	http.redactAuthorization = true
 	http.parserConfig.sendHeaders = false
@@ -983,7 +979,6 @@ func Test_splitCookiesHeader(t *testing.T) {
 // If a TCP gap (lost packets) happen while we're waiting for
 // headers, drop the stream.
 func Test_gap_in_headers(t *testing.T) {
-
 	http := httpModForTests(nil)
 
 	data1 := []byte("HTTP/1.1 200 OK\r\n" +
@@ -1005,7 +1000,6 @@ func Test_gap_in_headers(t *testing.T) {
 // If a TCP gap (lost packets) happen while we're waiting for
 // parts of the body, it's ok.
 func Test_gap_in_body(t *testing.T) {
-
 	http := httpModForTests(nil)
 
 	data1 := []byte("HTTP/1.1 200 OK\r\n" +
@@ -1038,7 +1032,6 @@ func Test_gap_in_body(t *testing.T) {
 // If a TCP gap (lost packets) happen while we're waiting for
 // parts of the body, it's ok.
 func Test_gap_in_body_http1dot0(t *testing.T) {
-
 	http := httpModForTests(nil)
 
 	data1 := []byte("HTTP/1.0 200 OK\r\n" +
@@ -1061,7 +1054,6 @@ func Test_gap_in_body_http1dot0(t *testing.T) {
 	ok, complete = http.messageGap(st, 10)
 	assert.Equal(t, true, ok)
 	assert.Equal(t, false, complete)
-
 }
 
 func testCreateTCPTuple() *common.TCPTuple {
@@ -1132,7 +1124,6 @@ func Test_gap_in_body_http1dot0_fin(t *testing.T) {
 }
 
 func TestHttp_configsSettingAll(t *testing.T) {
-
 	http := httpModForTests(nil)
 	config := defaultConfig
 
@@ -1164,7 +1155,6 @@ func TestHttp_configsSettingAll(t *testing.T) {
 }
 
 func TestHttp_configsSettingHeaders(t *testing.T) {
-
 	http := httpModForTests(nil)
 	config := defaultConfig
 

--- a/packetbeat/protos/memcache/memcache.go
+++ b/packetbeat/protos/memcache/memcache.go
@@ -320,7 +320,6 @@ func checkResponseComplete(msg *message) bool {
 }
 
 func newTransaction(requ, resp *message) *transaction {
-
 	if requ == nil && resp == nil {
 		return nil
 	}

--- a/packetbeat/protos/memcache/plugin_udp.go
+++ b/packetbeat/protos/memcache/plugin_udp.go
@@ -192,7 +192,6 @@ func (mc *memcache) onUDPMessage(
 }
 
 func (mc *memcache) onUDPTrans(udp *udpTransaction) error {
-
 	debug("received memcache(udp) transaction")
 	trans := newTransaction(udp.request, udp.response)
 	return mc.finishTransaction(trans)

--- a/packetbeat/protos/memcache/plugin_udp_test.go
+++ b/packetbeat/protos/memcache/plugin_udp_test.go
@@ -43,7 +43,6 @@ func Test_UdpDatagramMultiple(t *testing.T) {
 
 	assert.Equal(t, 8, buf.Len())
 	assert.Equal(t, []byte{1, 2, 3, 4, 5, 6, 7, 8}, buf.Bytes())
-
 }
 
 func Test_UdpDatagramMultipleDups(t *testing.T) {

--- a/packetbeat/protos/mongodb/mongodb.go
+++ b/packetbeat/protos/mongodb/mongodb.go
@@ -362,7 +362,6 @@ func reconstructQuery(t *transaction, full bool) (query string) {
 }
 
 func (mongodb *mongodbPlugin) publishTransaction(t *transaction) {
-
 	if mongodb.results == nil {
 		debugf("Try to publish transaction with null results")
 		return

--- a/packetbeat/protos/mongodb/mongodb_test.go
+++ b/packetbeat/protos/mongodb/mongodb_test.go
@@ -261,7 +261,6 @@ func TestReconstructQuery(t *testing.T) {
 
 // max_docs option should be respected
 func TestMaxDocs(t *testing.T) {
-
 	if testing.Verbose() {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"mongodb", "mongodbdetailed"})
 	}

--- a/packetbeat/protos/mysql/mysql.go
+++ b/packetbeat/protos/mysql/mysql.go
@@ -196,7 +196,6 @@ func (stream *mysqlStream) prepareForNewMessage() {
 }
 
 func mysqlMessageParser(s *mysqlStream) (bool, bool) {
-
 	logp.Debug("mysqldetailed", "MySQL parser called. parseState = %s", s.parseState)
 
 	m := s.message
@@ -429,7 +428,6 @@ func mysqlMessageParser(s *mysqlStream) (bool, bool) {
 // tcp stream. Returns true if there is already enough data in the message
 // read so far that we can use it further in the stack.
 func (mysql *mysqlPlugin) messageGap(s *mysqlStream, nbytes int) (complete bool) {
-
 	m := s.message
 	switch s.parseState {
 	case mysqlStateStart, mysqlStateEatMessage:
@@ -674,7 +672,6 @@ func (mysql *mysqlPlugin) receivedMysqlResponse(msg *mysqlMessage) {
 }
 
 func (mysql *mysqlPlugin) parseMysqlResponse(data []byte) ([]string, [][]string) {
-
 	length, err := readLength(data, 0)
 	if err != nil {
 		logp.Warn("Invalid response: %v", err)
@@ -824,7 +821,6 @@ func (mysql *mysqlPlugin) parseMysqlResponse(data []byte) ([]string, [][]string)
 }
 
 func (mysql *mysqlPlugin) publishTransaction(t *mysqlTransaction) {
-
 	if mysql.results == nil {
 		return
 	}

--- a/packetbeat/protos/mysql/mysql_test.go
+++ b/packetbeat/protos/mysql/mysql_test.go
@@ -51,7 +51,6 @@ func Test_parseStateNames(t *testing.T) {
 }
 
 func TestMySQLParser_simpleRequest(t *testing.T) {
-
 	data := []byte(
 		"6f00000003494e5345525420494e544f20706f737" +
 			"42028757365726e616d652c207469746c652c2062" +
@@ -87,7 +86,6 @@ func TestMySQLParser_simpleRequest(t *testing.T) {
 	}
 }
 func TestMySQLParser_OKResponse(t *testing.T) {
-
 	data := []byte(
 		"0700000100010401000000")
 
@@ -124,7 +122,6 @@ func TestMySQLParser_OKResponse(t *testing.T) {
 }
 
 func TestMySQLParser_errorResponse(t *testing.T) {
-
 	data := []byte(
 		"2e000001ff7a042334325330325461626c6520276d696e69747769742e706f737373742720646f65736e2774206578697374")
 

--- a/packetbeat/protos/nfs/nfs.go
+++ b/packetbeat/protos/nfs/nfs.go
@@ -12,7 +12,6 @@ type nfs struct {
 }
 
 func (nfs *nfs) getRequestInfo(xdr *xdr) common.MapStr {
-
 	nfsInfo := common.MapStr{}
 	nfsInfo["version"] = nfs.vers
 

--- a/packetbeat/protos/nfs/nfs4.go
+++ b/packetbeat/protos/nfs/nfs4.go
@@ -123,7 +123,6 @@ var nfsOpnum4 = map[int]string{
 }
 
 func (nfs *nfs) eatData(op int, xdr *xdr) {
-
 	switch op {
 	case opGetattr:
 		xdr.getUIntVector()
@@ -180,7 +179,6 @@ func (nfs *nfs) eatData(op int, xdr *xdr) {
 //
 // GETATTR is the main operation.
 func (nfs *nfs) findV4MainOpcode(xdr *xdr) string {
-
 	// did we find a main operation opcode?
 	found := false
 

--- a/packetbeat/protos/nfs/request_handler.go
+++ b/packetbeat/protos/nfs/request_handler.go
@@ -36,7 +36,6 @@ func (r *rpc) handleExpiredPacket(nfs *nfs) {
 
 // called when we process a RPC call
 func (r *rpc) handleCall(xid string, xdr *xdr, ts time.Time, tcptuple *common.TCPTuple, dir uint8) {
-
 	// eat rpc version number
 	xdr.getUInt()
 	rpcProg := xdr.getUInt()

--- a/packetbeat/protos/nfs/rpc.go
+++ b/packetbeat/protos/nfs/rpc.go
@@ -228,7 +228,6 @@ func (r *rpc) handleRPCFragment(
 }
 
 func (r *rpc) handleRPCPacket(xdr *xdr, ts time.Time, tcptuple *common.TCPTuple, dir uint8) {
-
 	xid := fmt.Sprintf("%.8x", xdr.getUInt())
 
 	msgType := xdr.getUInt()

--- a/packetbeat/protos/pgsql/parse.go
+++ b/packetbeat/protos/pgsql/parse.go
@@ -238,7 +238,6 @@ func (pgsql *pgsqlPlugin) parseCommandComplete(s *pgsqlStream, length int) (bool
 }
 
 func (pgsql *pgsqlPlugin) parseReadyForQuery(s *pgsqlStream, length int) (bool, bool) {
-
 	// ReadyForQuery -> backend ready for a new query cycle
 	m := s.message
 	m.start = s.parseOffset
@@ -319,7 +318,6 @@ func (pgsql *pgsqlPlugin) parseExtResp(s *pgsqlStream, length int) (bool, bool) 
 }
 
 func (pgsql *pgsqlPlugin) parseSkipMessage(s *pgsqlStream, length int) (bool, bool) {
-
 	// TODO: add info from NoticeResponse in case there are warning messages for a query
 	// ignore command
 	s.parseOffset++ //type
@@ -639,7 +637,6 @@ func (pgsql *pgsqlPlugin) parseMessageExtendedQuery(s *pgsqlStream) (bool, bool)
 }
 
 func isSpecialPgsqlCommand(data []byte) (bool, int, int) {
-
 	if len(data) < 8 {
 		// 8 bytes required
 		return false, 0, 0

--- a/packetbeat/protos/pgsql/pgsql.go
+++ b/packetbeat/protos/pgsql/pgsql.go
@@ -182,7 +182,6 @@ func (stream *pgsqlStream) prepareForNewMessage() {
 
 // Extract the method from a SQL query
 func getQueryMethod(q string) string {
-
 	index := strings.Index(q, " ")
 	var method string
 	if index > 0 {
@@ -355,7 +354,6 @@ var handlePgsql = func(pgsql *pgsqlPlugin, m *pgsqlMessage, tcptuple *common.TCP
 }
 
 func (pgsql *pgsqlPlugin) receivedPgsqlRequest(msg *pgsqlMessage) {
-
 	tuple := msg.tcpTuple
 
 	// parse the query, as it might contain a list of pgsql command
@@ -403,7 +401,6 @@ func (pgsql *pgsqlPlugin) receivedPgsqlRequest(msg *pgsqlMessage) {
 }
 
 func (pgsql *pgsqlPlugin) receivedPgsqlResponse(msg *pgsqlMessage) {
-
 	tuple := msg.tcpTuple
 	transList := pgsql.getTransaction(tuple.Hashable())
 	if transList == nil || len(transList) == 0 {
@@ -443,7 +440,6 @@ func (pgsql *pgsqlPlugin) receivedPgsqlResponse(msg *pgsqlMessage) {
 }
 
 func (pgsql *pgsqlPlugin) publishTransaction(t *pgsqlTransaction) {
-
 	if pgsql.results == nil {
 		return
 	}

--- a/packetbeat/protos/pgsql/pgsql_test.go
+++ b/packetbeat/protos/pgsql/pgsql_test.go
@@ -123,7 +123,6 @@ func TestPgsqlParser_dataResponse(t *testing.T) {
 
 // Test parsing a pgsql response
 func TestPgsqlParser_response(t *testing.T) {
-
 	pgsql := pgsqlModForTests(nil)
 	data := []byte(
 		"54000000420003610000004009000100000413ffffffffffff0000620000004009000200000413ffffffffffff0000630000004009000300000413ffffffffffff0000" +
@@ -195,12 +194,10 @@ func TestPgsqlParser_incomplete_response(t *testing.T) {
 	if complete {
 		t.Error("Expecting an incomplete message")
 	}
-
 }
 
 // Test 3 responses in a row
 func TestPgsqlParser_threeResponses(t *testing.T) {
-
 	pgsql := pgsqlModForTests(nil)
 
 	data, err := hex.DecodeString(
@@ -232,7 +229,6 @@ func TestPgsqlParser_threeResponses(t *testing.T) {
 	if countHandlePgsql != 3 {
 		t.Error("handlePgsql not called three times")
 	}
-
 }
 
 // Test parsing an error response

--- a/packetbeat/protos/tcp/tcp_test.go
+++ b/packetbeat/protos/tcp/tcp_test.go
@@ -90,7 +90,6 @@ func (proto TestProtocol) ConnectionTimeout() time.Duration {
 }
 
 func Test_configToPortsMap(t *testing.T) {
-
 	type configTest struct {
 		Input  map[protos.Protocol]protos.TCPPlugin
 		Output map[uint16]protos.Protocol
@@ -143,7 +142,6 @@ func Test_configToPortsMap(t *testing.T) {
 }
 
 func Test_configToPortsMap_negative(t *testing.T) {
-
 	type errTest struct {
 		Input map[protos.Protocol]protos.TCPPlugin
 		Err   string

--- a/packetbeat/protos/thrift/thrift.go
+++ b/packetbeat/protos/thrift/thrift.go
@@ -584,7 +584,6 @@ func (thrift *thriftPlugin) readMap(data []byte) (value string, ok bool, complet
 }
 
 func (thrift *thriftPlugin) readStruct(data []byte) (value string, ok bool, complete bool, off int) {
-
 	var bytesRead int
 	offset := 0
 	fields := []thriftField{}
@@ -685,7 +684,6 @@ func (thrift *thriftPlugin) funcReadersByType(typ byte) (fn thriftFieldReader, e
 }
 
 func (thrift *thriftPlugin) readField(s *thriftStream) (ok bool, complete bool, field *thriftField) {
-
 	var off int
 
 	field = new(thriftField)
@@ -1004,7 +1002,6 @@ func (thrift *thriftPlugin) receivedRequest(msg *thriftMessage) {
 }
 
 func (thrift *thriftPlugin) receivedReply(msg *thriftMessage) {
-
 	// we need to search the request first.
 	tuple := msg.tcpTuple
 

--- a/packetbeat/protos/thrift/thrift_idl.go
+++ b/packetbeat/protos/thrift/thrift_idl.go
@@ -44,7 +44,6 @@ func fieldsToArrayByID(fields []*parser.Field) []*string {
 }
 
 func buildMethodsMap(thriftFiles map[string]parser.Thrift) map[string]*thriftIdlMethod {
-
 	output := make(map[string]*thriftIdlMethod)
 
 	for _, thrift := range thriftFiles {
@@ -91,7 +90,6 @@ func (thriftidl *thriftIdl) findMethod(name string) *thriftIdlMethod {
 }
 
 func newThriftIdl(idlFiles []string) (*thriftIdl, error) {
-
 	if len(idlFiles) == 0 {
 		return nil, nil
 	}

--- a/packetbeat/protos/thrift/thrift_idl_test.go
+++ b/packetbeat/protos/thrift/thrift_idl_test.go
@@ -24,7 +24,6 @@ func thriftIdlForTesting(t *testing.T, content string) *thriftIdl {
 }
 
 func TestThriftIdl_thriftReadFiles(t *testing.T) {
-
 	if testing.Verbose() {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"thrift", "thriftdetailed"})
 	}

--- a/packetbeat/protos/thrift/thrift_test.go
+++ b/packetbeat/protos/thrift/thrift_test.go
@@ -20,7 +20,6 @@ func thriftForTests() *thriftPlugin {
 }
 
 func TestThrift_thriftReadString(t *testing.T) {
-
 	if testing.Verbose() {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"thrift", "thriftdetailed"})
 	}
@@ -58,7 +57,6 @@ func TestThrift_thriftReadString(t *testing.T) {
 }
 
 func TestThrift_readMessageBegin(t *testing.T) {
-
 	if testing.Verbose() {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"thrift", "thriftdetailed"})
 	}
@@ -142,11 +140,9 @@ func TestThrift_readMessageBegin(t *testing.T) {
 	if !ok || complete {
 		t.Error("Bad result:", ok, complete)
 	}
-
 }
 
 func TestThrift_thriftReadField(t *testing.T) {
-
 	if testing.Verbose() {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"thrift", "thriftdetailed"})
 	}
@@ -405,11 +401,9 @@ func TestThrift_thriftReadField(t *testing.T) {
 			t.Error("Bad values:", field.id, field.Type, field.value)
 		}
 	}
-
 }
 
 func TestThrift_thriftMessageParser(t *testing.T) {
-
 	if testing.Verbose() {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"thrift", "thriftdetailed"})
 	}
@@ -595,7 +589,6 @@ func testTCPTuple() *common.TCPTuple {
 }
 
 func TestThrift_ParseSimpleTBinary(t *testing.T) {
-
 	if testing.Verbose() {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"thrift", "thriftdetailed"})
 	}
@@ -623,7 +616,6 @@ func TestThrift_ParseSimpleTBinary(t *testing.T) {
 }
 
 func TestThrift_ParseSimpleTFramed(t *testing.T) {
-
 	if testing.Verbose() {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"thrift", "thriftdetailed"})
 	}
@@ -650,11 +642,9 @@ func TestThrift_ParseSimpleTFramed(t *testing.T) {
 
 		t.Error("Bad result:", trans)
 	}
-
 }
 
 func TestThrift_ParseSimpleTFramedSplit(t *testing.T) {
-
 	if testing.Verbose() {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"thrift", "thriftdetailed"})
 	}
@@ -684,11 +674,9 @@ func TestThrift_ParseSimpleTFramedSplit(t *testing.T) {
 
 		t.Error("Bad result:", trans)
 	}
-
 }
 
 func TestThrift_ParseSimpleTFramedSplitInterleaved(t *testing.T) {
-
 	if testing.Verbose() {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"thrift", "thriftdetailed"})
 	}
@@ -721,7 +709,6 @@ func TestThrift_ParseSimpleTFramedSplitInterleaved(t *testing.T) {
 }
 
 func TestThrift_Parse_OneWayCallWithFin(t *testing.T) {
-
 	if testing.Verbose() {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"thrift", "thriftdetailed"})
 	}
@@ -748,7 +735,6 @@ func TestThrift_Parse_OneWayCallWithFin(t *testing.T) {
 }
 
 func TestThrift_Parse_OneWayCall2Requests(t *testing.T) {
-
 	if testing.Verbose() {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"thrift", "thriftdetailed"})
 	}
@@ -787,7 +773,6 @@ func TestThrift_Parse_OneWayCall2Requests(t *testing.T) {
 }
 
 func TestThrift_Parse_RequestReplyMismatch(t *testing.T) {
-
 	if testing.Verbose() {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"thrift", "thriftdetailed"})
 	}
@@ -815,7 +800,6 @@ func TestThrift_Parse_RequestReplyMismatch(t *testing.T) {
 }
 
 func TestThrift_ParseSimpleTFramed_NoReply(t *testing.T) {
-
 	if testing.Verbose() {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"thrift", "thriftdetailed"})
 	}
@@ -857,7 +841,6 @@ func TestThrift_ParseSimpleTFramed_NoReply(t *testing.T) {
 }
 
 func TestThrift_ParseObfuscateStrings(t *testing.T) {
-
 	if testing.Verbose() {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"thrift", "thriftdetailed"})
 	}
@@ -888,7 +871,6 @@ func TestThrift_ParseObfuscateStrings(t *testing.T) {
 }
 
 func BenchmarkThrift_ParseSkipReply(b *testing.B) {
-
 	if testing.Verbose() {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"thrift", "thriftdetailed"})
 	}
@@ -934,7 +916,6 @@ func BenchmarkThrift_ParseSkipReply(b *testing.B) {
 }
 
 func TestThrift_Parse_Exception(t *testing.T) {
-
 	if testing.Verbose() {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"thrift", "thriftdetailed"})
 	}
@@ -964,7 +945,6 @@ func TestThrift_Parse_Exception(t *testing.T) {
 }
 
 func TestThrift_ParametersNames(t *testing.T) {
-
 	if testing.Verbose() {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"thrift", "thriftdetailed"})
 	}
@@ -997,11 +977,9 @@ func TestThrift_ParametersNames(t *testing.T) {
 
 		t.Error("Bad result:", trans)
 	}
-
 }
 
 func TestThrift_ExceptionName(t *testing.T) {
-
 	if testing.Verbose() {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"thrift", "thriftdetailed"})
 	}
@@ -1043,7 +1021,6 @@ func TestThrift_ExceptionName(t *testing.T) {
 }
 
 func TestThrift_GapInStream_response(t *testing.T) {
-
 	if testing.Verbose() {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"thrift", "thriftdetailed"})
 	}
@@ -1094,7 +1071,6 @@ func TestThrift_GapInStream_response(t *testing.T) {
 }
 
 func TestThrift_GapInStream_request(t *testing.T) {
-
 	if testing.Verbose() {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"thrift", "thriftdetailed"})
 	}

--- a/packetbeat/publish/publish.go
+++ b/packetbeat/publish/publish.go
@@ -206,7 +206,6 @@ func (p *transProcessor) IsPublisherIP(ip string) bool {
 }
 
 func (p *transProcessor) GetServerName(ip string) string {
-
 	// in case the IP is localhost, return current shipper name
 	islocal, err := common.IsLoopback(ip)
 	if err != nil {

--- a/winlogbeat/eventlog/eventlogging_test.go
+++ b/winlogbeat/eventlog/eventlogging_test.go
@@ -157,7 +157,6 @@ func setLogSize(t testing.TB, provider string, sizeBytes int) {
 
 // Verify that all messages are read from the event log.
 func TestRead(t *testing.T) {
-
 	configureLogp()
 	log, err := initLog(providerName, sourceName, eventCreateMsgFile)
 	if err != nil {
@@ -256,7 +255,6 @@ func TestFormatMessageWithLargeMessage(t *testing.T) {
 // Test that when an unknown Event ID is found, that a message containing the
 // insert strings (the message parameters) is returned.
 func TestReadUnknownEventId(t *testing.T) {
-
 	configureLogp()
 	log, err := initLog(providerName, sourceName, servicesMsgFile)
 	if err != nil {
@@ -301,7 +299,6 @@ func TestReadUnknownEventId(t *testing.T) {
 // separated list of files. If the message for an event ID is not found in one
 // of the files then the next file should be checked.
 func TestReadTriesMultipleEventMsgFiles(t *testing.T) {
-
 	configureLogp()
 	log, err := initLog(providerName, sourceName,
 		servicesMsgFile+";"+eventCreateMsgFile)
@@ -342,7 +339,6 @@ func TestReadTriesMultipleEventMsgFiles(t *testing.T) {
 
 // Test event messages that require more than one message parameter.
 func TestReadMultiParameterMsg(t *testing.T) {
-
 	configureLogp()
 	log, err := initLog(providerName, sourceName, servicesMsgFile)
 	if err != nil {
@@ -389,7 +385,6 @@ func TestReadMultiParameterMsg(t *testing.T) {
 // Verify that opening an invalid provider succeeds. Windows opens the
 // Application event log provider when this happens (unfortunately).
 func TestOpenInvalidProvider(t *testing.T) {
-
 	configureLogp()
 
 	el := newTestEventLogging(t, map[string]interface{}{"name": "nonExistentProvider"})
@@ -401,7 +396,6 @@ func TestOpenInvalidProvider(t *testing.T) {
 
 // Test event messages that require no parameters.
 func TestReadNoParameterMsg(t *testing.T) {
-
 	configureLogp()
 	log, err := initLog(providerName, sourceName, netEventMsgFile)
 	if err != nil {
@@ -444,7 +438,6 @@ func TestReadNoParameterMsg(t *testing.T) {
 // TestReadWhileCleared tests that the Read method recovers from the event log
 // being cleared or reset while reading.
 func TestReadWhileCleared(t *testing.T) {
-
 	configureLogp()
 	log, err := initLog(providerName, sourceName, eventCreateMsgFile)
 	if err != nil {


### PR DESCRIPTION
This removes blank lines from the start and end of functions. For example, this function

    func foo() {

        return bar

    }

would become

    func foo() {
        return bar
    }

This tightens up the code and allows you to see more context when viewing
the source code.