### PR TITLE
Order imports stdlib, third party, then elastic

### DIFF
--- a/auditbeat/module/audit/file/event.go
+++ b/auditbeat/module/audit/file/event.go
@@ -12,8 +12,9 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/elastic/beats/libbeat/common"
 	"github.com/pkg/errors"
+
+	"github.com/elastic/beats/libbeat/common"
 )
 
 // Action is a description of the change that occurred.

--- a/auditbeat/module/audit/file/eventreader_fsnotify.go
+++ b/auditbeat/module/audit/file/eventreader_fsnotify.go
@@ -7,8 +7,9 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/elastic/beats/libbeat/logp"
 	"github.com/fsnotify/fsnotify"
+
+	"github.com/elastic/beats/libbeat/logp"
 )
 
 // NewEventReader creates a new EventReader backed by fsnotify.

--- a/auditbeat/module/audit/file/fileinfo_windows.go
+++ b/auditbeat/module/audit/file/fileinfo_windows.go
@@ -9,9 +9,10 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/elastic/beats/filebeat/input/file"
 	"github.com/joeshaw/multierror"
 	"github.com/pkg/errors"
+
+	"github.com/elastic/beats/filebeat/input/file"
 )
 
 func Stat(path string) (*Metadata, error) {

--- a/auditbeat/module/audit/kernel/config_linux_test.go
+++ b/auditbeat/module/audit/kernel/config_linux_test.go
@@ -3,8 +3,9 @@ package kernel
 import (
 	"testing"
 
-	"github.com/elastic/beats/libbeat/common"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/libbeat/common"
 )
 
 func TestConfigValidate(t *testing.T) {

--- a/filebeat/config/config_test.go
+++ b/filebeat/config/config_test.go
@@ -6,8 +6,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/elastic/beats/libbeat/cfgfile"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/libbeat/cfgfile"
 )
 
 func TestReadConfig2(t *testing.T) {

--- a/filebeat/fileset/factory.go
+++ b/filebeat/fileset/factory.go
@@ -1,15 +1,15 @@
 package fileset
 
 import (
-	"github.com/elastic/beats/libbeat/cfgfile"
-	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/logp"
-	"github.com/elastic/beats/libbeat/outputs/elasticsearch"
 	"github.com/mitchellh/hashstructure"
 
 	"github.com/elastic/beats/filebeat/channel"
 	"github.com/elastic/beats/filebeat/prospector"
 	"github.com/elastic/beats/filebeat/registrar"
+	"github.com/elastic/beats/libbeat/cfgfile"
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/outputs/elasticsearch"
 )
 
 // Factory for modules

--- a/filebeat/fileset/modules_integration_test.go
+++ b/filebeat/fileset/modules_integration_test.go
@@ -8,8 +8,9 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/elastic/beats/libbeat/outputs/elasticsearch"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/libbeat/outputs/elasticsearch"
 )
 
 func TestLoadPipeline(t *testing.T) {

--- a/filebeat/fileset/modules_test.go
+++ b/filebeat/fileset/modules_test.go
@@ -8,9 +8,10 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/paths"
-	"github.com/stretchr/testify/assert"
 )
 
 func load(t *testing.T, from interface{}) *common.Config {

--- a/filebeat/harvester/reader/json_test.go
+++ b/filebeat/harvester/reader/json_test.go
@@ -4,8 +4,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/elastic/beats/libbeat/common"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/libbeat/common"
 )
 
 func TestUnmarshal(t *testing.T) {

--- a/filebeat/harvester/reader/line_test.go
+++ b/filebeat/harvester/reader/line_test.go
@@ -7,10 +7,10 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/elastic/beats/filebeat/harvester/encoding"
 	"github.com/stretchr/testify/assert"
-
 	"golang.org/x/text/transform"
+
+	"github.com/elastic/beats/filebeat/harvester/encoding"
 )
 
 // Sample texts are from http://www.columbia.edu/~kermit/utf8.html

--- a/filebeat/harvester/reader/multiline_test.go
+++ b/filebeat/harvester/reader/multiline_test.go
@@ -10,9 +10,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/beats/filebeat/harvester/encoding"
 	"github.com/elastic/beats/libbeat/common/match"
-	"github.com/stretchr/testify/assert"
 )
 
 type bufferSource struct{ buf *bytes.Buffer }

--- a/filebeat/harvester/registry.go
+++ b/filebeat/harvester/registry.go
@@ -3,8 +3,9 @@ package harvester
 import (
 	"sync"
 
-	"github.com/elastic/beats/libbeat/logp"
 	uuid "github.com/satori/go.uuid"
+
+	"github.com/elastic/beats/libbeat/logp"
 )
 
 // Registry struct manages (start / stop) a list of harvesters

--- a/filebeat/processor/add_kubernetes_metadata/indexing_test.go
+++ b/filebeat/processor/add_kubernetes_metadata/indexing_test.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/elastic/beats/libbeat/common"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/libbeat/common"
 )
 
 func TestLogsPathMatcher(t *testing.T) {

--- a/filebeat/prospector/log/config.go
+++ b/filebeat/prospector/log/config.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/dustin/go-humanize"
+
 	cfg "github.com/elastic/beats/filebeat/config"
 	"github.com/elastic/beats/filebeat/harvester"
 	"github.com/elastic/beats/filebeat/harvester/reader"

--- a/filebeat/prospector/log/config_test.go
+++ b/filebeat/prospector/log/config_test.go
@@ -4,11 +4,11 @@ package log
 
 import (
 	"testing"
-
 	"time"
 
-	"github.com/elastic/beats/filebeat/harvester"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/filebeat/harvester"
 )
 
 func TestCleanOlderError(t *testing.T) {

--- a/filebeat/prospector/log/harvester_test.go
+++ b/filebeat/prospector/log/harvester_test.go
@@ -11,10 +11,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/beats/filebeat/harvester/encoding"
 	"github.com/elastic/beats/filebeat/harvester/reader"
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestReadLine(t *testing.T) {

--- a/filebeat/prospector/log/prospector_test.go
+++ b/filebeat/prospector/log/prospector_test.go
@@ -7,9 +7,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/beats/filebeat/input/file"
 	"github.com/elastic/beats/libbeat/common/match"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestProspectorFileExclude(t *testing.T) {

--- a/filebeat/prospector/log/prospector_windows_test.go
+++ b/filebeat/prospector/log/prospector_windows_test.go
@@ -5,8 +5,9 @@ package log
 import (
 	"testing"
 
-	"github.com/elastic/beats/libbeat/common/match"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/libbeat/common/match"
 )
 
 var matchTestsWindows = []struct {

--- a/filebeat/prospector/redis/harvester.go
+++ b/filebeat/prospector/redis/harvester.go
@@ -2,18 +2,17 @@ package redis
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
+	rd "github.com/garyburd/redigo/redis"
+	"github.com/satori/go.uuid"
+
+	"github.com/elastic/beats/filebeat/harvester"
 	"github.com/elastic/beats/filebeat/util"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/publisher/beat"
-
-	"strings"
-
-	"github.com/elastic/beats/filebeat/harvester"
-	rd "github.com/garyburd/redigo/redis"
-	"github.com/satori/go.uuid"
 )
 
 // Harvester contains all redis harvester data

--- a/filebeat/prospector/redis/prospector.go
+++ b/filebeat/prospector/redis/prospector.go
@@ -3,13 +3,13 @@ package redis
 import (
 	"time"
 
+	rd "github.com/garyburd/redigo/redis"
+
 	"github.com/elastic/beats/filebeat/channel"
+	"github.com/elastic/beats/filebeat/harvester"
 	"github.com/elastic/beats/filebeat/input/file"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
-
-	"github.com/elastic/beats/filebeat/harvester"
-	rd "github.com/garyburd/redigo/redis"
 )
 
 // Prospector is a prospector for redis

--- a/filebeat/util/data_test.go
+++ b/filebeat/util/data_test.go
@@ -3,9 +3,10 @@ package util
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/beats/filebeat/input/file"
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestNewData(t *testing.T) {

--- a/libbeat/cfgfile/glob_watcher.go
+++ b/libbeat/cfgfile/glob_watcher.go
@@ -5,8 +5,9 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/elastic/beats/libbeat/logp"
 	"github.com/mitchellh/hashstructure"
+
+	"github.com/elastic/beats/libbeat/logp"
 )
 
 type GlobWatcher struct {

--- a/libbeat/common/event_test.go
+++ b/libbeat/common/event_test.go
@@ -5,8 +5,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/elastic/beats/libbeat/logp"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/libbeat/logp"
 )
 
 func TestConvertNestedMapStr(t *testing.T) {

--- a/libbeat/common/file/fileinfo_test.go
+++ b/libbeat/common/file/fileinfo_test.go
@@ -12,8 +12,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/elastic/beats/libbeat/common/file"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/libbeat/common/file"
 )
 
 func TestStat(t *testing.T) {

--- a/libbeat/common/fmtstr/formatevents_test.go
+++ b/libbeat/common/fmtstr/formatevents_test.go
@@ -4,9 +4,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/publisher/beat"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestEventFormatString(t *testing.T) {

--- a/libbeat/common/schema/mapstriface/mapstriface_test.go
+++ b/libbeat/common/schema/mapstriface/mapstriface_test.go
@@ -5,9 +5,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/beats/libbeat/common"
 	s "github.com/elastic/beats/libbeat/common/schema"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestConversions(t *testing.T) {

--- a/libbeat/common/schema/mapstrstr/mapstrstr_test.go
+++ b/libbeat/common/schema/mapstrstr/mapstrstr_test.go
@@ -4,9 +4,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/beats/libbeat/common"
 	s "github.com/elastic/beats/libbeat/common/schema"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestConversions(t *testing.T) {

--- a/libbeat/common/schema/schema_test.go
+++ b/libbeat/common/schema/schema_test.go
@@ -3,8 +3,9 @@ package schema
 import (
 	"testing"
 
-	"github.com/elastic/beats/libbeat/common"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/libbeat/common"
 )
 
 func nop(key string, data map[string]interface{}) (interface{}, error) {

--- a/libbeat/dashboards/es_loader_test.go
+++ b/libbeat/dashboards/es_loader_test.go
@@ -6,9 +6,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/outputs/elasticsearch"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestImporter(t *testing.T) {

--- a/libbeat/ml-importer/importer.go
+++ b/libbeat/ml-importer/importer.go
@@ -6,9 +6,10 @@ import (
 	"fmt"
 	"io/ioutil"
 
+	"github.com/pkg/errors"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
-	"github.com/pkg/errors"
 )
 
 // MLConfig contains the required configuration for loading one job and the associated

--- a/libbeat/ml-importer/importer_integration_test.go
+++ b/libbeat/ml-importer/importer_integration_test.go
@@ -8,9 +8,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/outputs/elasticsearch"
-	"github.com/stretchr/testify/assert"
 )
 
 const sampleJob = `

--- a/libbeat/monitoring/adapter/go-metrics-wrapper.go
+++ b/libbeat/monitoring/adapter/go-metrics-wrapper.go
@@ -1,8 +1,9 @@
 package adapter
 
 import (
-	"github.com/elastic/beats/libbeat/monitoring"
 	metrics "github.com/rcrowley/go-metrics"
+
+	"github.com/elastic/beats/libbeat/monitoring"
 )
 
 // go-metrics wrapper interface required to unpack the original metric

--- a/libbeat/monitoring/adapter/go-metrics.go
+++ b/libbeat/monitoring/adapter/go-metrics.go
@@ -5,9 +5,10 @@ import (
 	"reflect"
 	"sync"
 
+	metrics "github.com/rcrowley/go-metrics"
+
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/monitoring"
-	metrics "github.com/rcrowley/go-metrics"
 )
 
 // implement adapter for adding go-metrics based counters

--- a/libbeat/monitoring/adapter/go-metrics_test.go
+++ b/libbeat/monitoring/adapter/go-metrics_test.go
@@ -4,9 +4,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/elastic/beats/libbeat/monitoring"
 	metrics "github.com/rcrowley/go-metrics"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/libbeat/monitoring"
 )
 
 func TestGoMetricsAdapter(t *testing.T) {

--- a/libbeat/outputs/codec/json/json.go
+++ b/libbeat/outputs/codec/json/json.go
@@ -4,12 +4,13 @@ import (
 	"bytes"
 	stdjson "encoding/json"
 
+	"github.com/urso/go-structform/gotype"
+	"github.com/urso/go-structform/json"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/outputs/codec"
 	"github.com/elastic/beats/libbeat/publisher/beat"
-	"github.com/urso/go-structform/gotype"
-	"github.com/urso/go-structform/json"
 )
 
 type Encoder struct {

--- a/libbeat/outputs/elasticsearch/api_test.go
+++ b/libbeat/outputs/elasticsearch/api_test.go
@@ -5,8 +5,9 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/elastic/beats/libbeat/logp"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/libbeat/logp"
 )
 
 func GetValidQueryResult() QueryResult {

--- a/libbeat/outputs/kafka/partition.go
+++ b/libbeat/outputs/kafka/partition.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 
 	"github.com/Shopify/sarama"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 )

--- a/libbeat/outputs/kafka/partition_test.go
+++ b/libbeat/outputs/kafka/partition_test.go
@@ -9,10 +9,11 @@ import (
 	"time"
 
 	"github.com/Shopify/sarama"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/publisher"
 	"github.com/elastic/beats/libbeat/publisher/beat"
-	"github.com/stretchr/testify/assert"
 )
 
 type partTestScenario func(*testing.T, bool, sarama.Partitioner) error

--- a/libbeat/outputs/logstash/logstash_integration_test.go
+++ b/libbeat/outputs/logstash/logstash_integration_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/fmtstr"
 	"github.com/elastic/beats/libbeat/outputs"
@@ -17,7 +19,6 @@ import (
 	"github.com/elastic/beats/libbeat/outputs/outest"
 	"github.com/elastic/beats/libbeat/outputs/outil"
 	"github.com/elastic/beats/libbeat/publisher/beat"
-	"github.com/stretchr/testify/assert"
 )
 
 const (

--- a/libbeat/outputs/outil/select_test.go
+++ b/libbeat/outputs/outil/select_test.go
@@ -5,9 +5,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/publisher/beat"
-	"github.com/stretchr/testify/assert"
 )
 
 type node map[string]interface{}

--- a/libbeat/outputs/tls.go
+++ b/libbeat/outputs/tls.go
@@ -9,9 +9,10 @@ import (
 	"fmt"
 	"io/ioutil"
 
+	"github.com/joeshaw/multierror"
+
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/outputs/transport"
-	"github.com/joeshaw/multierror"
 )
 
 var (

--- a/libbeat/outputs/tls_test.go
+++ b/libbeat/outputs/tls_test.go
@@ -6,9 +6,10 @@ import (
 	"crypto/tls"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/outputs/transport"
-	"github.com/stretchr/testify/assert"
 )
 
 // test TLS config loading

--- a/libbeat/outputs/transport/proxy.go
+++ b/libbeat/outputs/transport/proxy.go
@@ -4,8 +4,9 @@ import (
 	"net"
 	"net/url"
 
-	"github.com/elastic/beats/libbeat/logp"
 	"golang.org/x/net/proxy"
+
+	"github.com/elastic/beats/libbeat/logp"
 )
 
 // ProxyConfig holds the configuration information required to proxy

--- a/libbeat/processors/actions/decode_json_fields.go
+++ b/libbeat/processors/actions/decode_json_fields.go
@@ -5,12 +5,13 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/pkg/errors"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/jsontransform"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/processors"
 	"github.com/elastic/beats/libbeat/publisher/beat"
-	"github.com/pkg/errors"
 )
 
 type decodeJSONFields struct {

--- a/libbeat/processors/actions/decode_json_fields_test.go
+++ b/libbeat/processors/actions/decode_json_fields_test.go
@@ -3,10 +3,11 @@ package actions
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/publisher/beat"
-	"github.com/stretchr/testify/assert"
 )
 
 var fields = [1]string{"msg"}

--- a/libbeat/processors/actions/extract_field_test.go
+++ b/libbeat/processors/actions/extract_field_test.go
@@ -3,10 +3,11 @@ package actions
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/publisher/beat"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestCommonPaths(t *testing.T) {

--- a/libbeat/processors/actions/include_fields.go
+++ b/libbeat/processors/actions/include_fields.go
@@ -4,10 +4,11 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/pkg/errors"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/processors"
 	"github.com/elastic/beats/libbeat/publisher/beat"
-	"github.com/pkg/errors"
 )
 
 type includeFields struct {

--- a/libbeat/processors/add_cloud_metadata/add_cloud_metadata.go
+++ b/libbeat/processors/add_cloud_metadata/add_cloud_metadata.go
@@ -10,11 +10,12 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/pkg/errors"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/processors"
 	"github.com/elastic/beats/libbeat/publisher/beat"
-	"github.com/pkg/errors"
 )
 
 const (

--- a/libbeat/processors/add_cloud_metadata/provider_alibaba_cloud_test.go
+++ b/libbeat/processors/add_cloud_metadata/provider_alibaba_cloud_test.go
@@ -5,10 +5,11 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/publisher/beat"
-	"github.com/stretchr/testify/assert"
 )
 
 func initECSTestServer() *httptest.Server {

--- a/libbeat/processors/add_cloud_metadata/provider_aws_ec2_test.go
+++ b/libbeat/processors/add_cloud_metadata/provider_aws_ec2_test.go
@@ -5,10 +5,11 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/publisher/beat"
-	"github.com/stretchr/testify/assert"
 )
 
 const ec2InstanceIdentityDocument = `{

--- a/libbeat/processors/add_cloud_metadata/provider_digital_ocean_test.go
+++ b/libbeat/processors/add_cloud_metadata/provider_digital_ocean_test.go
@@ -5,10 +5,11 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/publisher/beat"
-	"github.com/stretchr/testify/assert"
 )
 
 const digitalOceanMetadataV1 = `{

--- a/libbeat/processors/add_cloud_metadata/provider_google_gce_test.go
+++ b/libbeat/processors/add_cloud_metadata/provider_google_gce_test.go
@@ -5,10 +5,11 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/publisher/beat"
-	"github.com/stretchr/testify/assert"
 )
 
 const gceMetadataV1 = `{

--- a/libbeat/processors/add_cloud_metadata/provider_tencent_cloud_test.go
+++ b/libbeat/processors/add_cloud_metadata/provider_tencent_cloud_test.go
@@ -5,10 +5,11 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/publisher/beat"
-	"github.com/stretchr/testify/assert"
 )
 
 func initQCloudTestServer() *httptest.Server {

--- a/libbeat/processors/add_docker_metadata/add_docker_metadata_test.go
+++ b/libbeat/processors/add_docker_metadata/add_docker_metadata_test.go
@@ -3,9 +3,10 @@ package add_docker_metadata
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/publisher/beat"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestInitialization(t *testing.T) {

--- a/libbeat/processors/add_kubernetes_metadata/indexing_test.go
+++ b/libbeat/processors/add_kubernetes_metadata/indexing_test.go
@@ -3,8 +3,9 @@ package add_kubernetes_metadata
 import (
 	"testing"
 
-	"github.com/elastic/beats/libbeat/common"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/libbeat/common"
 )
 
 var metagen = &GenDefaultMeta{}

--- a/libbeat/processors/add_locale/add_locale_test.go
+++ b/libbeat/processors/add_locale/add_locale_test.go
@@ -5,10 +5,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/publisher/beat"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestExportTimezone(t *testing.T) {

--- a/libbeat/processors/condition_test.go
+++ b/libbeat/processors/condition_test.go
@@ -5,10 +5,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/publisher/beat"
-	"github.com/stretchr/testify/assert"
 )
 
 type countFilter struct {

--- a/libbeat/processors/namespace_test.go
+++ b/libbeat/processors/namespace_test.go
@@ -4,9 +4,10 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/publisher/beat"
-	"github.com/stretchr/testify/assert"
 )
 
 type testFilterRule struct {

--- a/libbeat/processors/processor_test.go
+++ b/libbeat/processors/processor_test.go
@@ -4,13 +4,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/processors"
 	_ "github.com/elastic/beats/libbeat/processors/actions"
 	_ "github.com/elastic/beats/libbeat/processors/add_cloud_metadata"
 	"github.com/elastic/beats/libbeat/publisher/beat"
-	"github.com/stretchr/testify/assert"
 )
 
 func GetProcessors(t *testing.T, yml []map[string]interface{}) *processors.Processors {

--- a/libbeat/publisher/testing/testing_test.go
+++ b/libbeat/publisher/testing/testing_test.go
@@ -3,9 +3,10 @@ package testing
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/publisher/beat"
-	"github.com/stretchr/testify/assert"
 )
 
 var cnt = 0

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -33,6 +33,7 @@ COVERAGE_TOOL_REPO=github.com/elastic/beats/vendor/github.com/pierrre/gotestcove
 TESTIFY_TOOL_REPO=github.com/elastic/beats/vendor/github.com/stretchr/testify
 GOIMPORTS=goimports
 GOIMPORTS_REPO=golang.org/x/tools/cmd/goimports
+GOIMPORTS_LOCAL_PREFIX?=github.com/elastic
 GOLINT=golint
 GOLINT_REPO=github.com/golang/lint/golint
 REVIEWDOG=reviewdog -conf ${ES_BEATS}/reviewdog.yml
@@ -99,12 +100,12 @@ crosscompile: $(GOFILES)
 check: python-env ## @build Checks project and source code if everything is according to standard
 	@go vet ${GOPACKAGES}
 	@go get $(GOIMPORTS_REPO)
-	@goimports -l ${GOFILES_NOVENDOR} | (! grep . -q) || (echo "Code differs from goimports' style" && false)
+	@goimports -local ${GOIMPORTS_LOCAL_PREFIX} -l ${GOFILES_NOVENDOR} | (! grep . -q) || (echo "Code differs from goimports' style" && false)
 	@${FIND} -name *.py -exec autopep8 -d --max-line-length 120  {} \; | (! grep . -q) || (echo "Code differs from autopep8's style" && false)
 
 .PHONY: fmt
 fmt: python-env ## @build Runs `goimports -l -w` and `autopep8`on the project's source code, modifying any files that do not match its style.
-	@goimports -l -w ${GOFILES_NOVENDOR}
+	@goimports -local ${GOIMPORTS_LOCAL_PREFIX} -l -w ${GOFILES_NOVENDOR}
 	@${FIND} -name *.py -exec ${PYTHON_ENV}/bin/autopep8 --in-place --max-line-length 120  {} \;
 
 .PHONY: lint

--- a/libbeat/service/service_windows.go
+++ b/libbeat/service/service_windows.go
@@ -4,9 +4,10 @@ import (
 	"os"
 	"time"
 
-	"github.com/elastic/beats/libbeat/logp"
 	"golang.org/x/sys/windows/svc"
 	"golang.org/x/sys/windows/svc/debug"
+
+	"github.com/elastic/beats/libbeat/logp"
 )
 
 type beatService struct{}

--- a/libbeat/template/field_test.go
+++ b/libbeat/template/field_test.go
@@ -3,8 +3,9 @@ package template
 import (
 	"testing"
 
-	"github.com/elastic/beats/libbeat/common"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/libbeat/common"
 )
 
 func TestField(t *testing.T) {

--- a/metricbeat/beater/metricbeat.go
+++ b/metricbeat/beater/metricbeat.go
@@ -4,15 +4,15 @@ import (
 	"sync"
 	"time"
 
+	"github.com/joeshaw/multierror"
+	"github.com/pkg/errors"
+
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/cfgfile"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/mb/module"
-	"github.com/joeshaw/multierror"
-
-	"github.com/pkg/errors"
 
 	// Add metricbeat specific processors
 	_ "github.com/elastic/beats/metricbeat/processor/add_kubernetes_metadata"

--- a/metricbeat/mb/module/event_test.go
+++ b/metricbeat/mb/module/event_test.go
@@ -7,8 +7,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/elastic/beats/libbeat/common"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/libbeat/common"
 )
 
 const (

--- a/metricbeat/mb/parse/hostparsers.go
+++ b/metricbeat/mb/parse/hostparsers.go
@@ -1,8 +1,9 @@
 package parse
 
 import (
-	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/pkg/errors"
+
+	"github.com/elastic/beats/metricbeat/mb"
 )
 
 // PassThruHostParser is a HostParser that sets the HostData URI, SanitizedURI,

--- a/metricbeat/module/aerospike/namespace/namespace.go
+++ b/metricbeat/module/aerospike/namespace/namespace.go
@@ -3,13 +3,13 @@ package namespace
 import (
 	"strings"
 
+	as "github.com/aerospike/aerospike-client-go"
+	"github.com/pkg/errors"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/module/aerospike"
-	"github.com/pkg/errors"
-
-	as "github.com/aerospike/aerospike-client-go"
 )
 
 // init registers the MetricSet with the central registry.

--- a/metricbeat/module/couchbase/cluster/cluster_test.go
+++ b/metricbeat/module/couchbase/cluster/cluster_test.go
@@ -9,10 +9,10 @@ import (
 	"path/filepath"
 	"testing"
 
-	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/stretchr/testify/assert"
+	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
 )
 
 func TestFetchEventContents(t *testing.T) {

--- a/metricbeat/module/dropwizard/collector/collector_integration_test.go
+++ b/metricbeat/module/dropwizard/collector/collector_integration_test.go
@@ -6,9 +6,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/beats/libbeat/common"
 	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestFetch(t *testing.T) {

--- a/metricbeat/module/http/json/json_integration_test.go
+++ b/metricbeat/module/http/json/json_integration_test.go
@@ -6,8 +6,9 @@ import (
 	"os"
 	"testing"
 
-	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
 	"github.com/stretchr/testify/assert"
+
+	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
 )
 
 func TestFetch(t *testing.T) {

--- a/metricbeat/module/jolokia/jmx/data.go
+++ b/metricbeat/module/jolokia/jmx/data.go
@@ -3,9 +3,10 @@ package jmx
 import (
 	"encoding/json"
 
-	"github.com/elastic/beats/libbeat/common"
 	"github.com/joeshaw/multierror"
 	"github.com/pkg/errors"
+
+	"github.com/elastic/beats/libbeat/common"
 )
 
 type Entry struct {

--- a/metricbeat/module/jolokia/jmx/data_test.go
+++ b/metricbeat/module/jolokia/jmx/data_test.go
@@ -5,8 +5,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/elastic/beats/libbeat/common"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/libbeat/common"
 )
 
 func TestEventMapper(t *testing.T) {

--- a/metricbeat/module/jolokia/jmx/jmx_integration_test.go
+++ b/metricbeat/module/jolokia/jmx/jmx_integration_test.go
@@ -6,8 +6,9 @@ import (
 	"os"
 	"testing"
 
-	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
 	"github.com/stretchr/testify/assert"
+
+	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
 )
 
 func TestFetch(t *testing.T) {

--- a/metricbeat/module/kafka/broker.go
+++ b/metricbeat/module/kafka/broker.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/Shopify/sarama"
+
 	"github.com/elastic/beats/libbeat/common"
 )
 

--- a/metricbeat/module/kafka/consumergroup/query.go
+++ b/metricbeat/module/kafka/consumergroup/query.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 
 	"github.com/Shopify/sarama"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/metricbeat/module/kafka"

--- a/metricbeat/module/kafka/consumergroup/query_test.go
+++ b/metricbeat/module/kafka/consumergroup/query_test.go
@@ -6,8 +6,9 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/elastic/beats/libbeat/common"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/libbeat/common"
 )
 
 func TestFetchGroupInfo(t *testing.T) {

--- a/metricbeat/module/kafka/partition/partition_integration_test.go
+++ b/metricbeat/module/kafka/partition/partition_integration_test.go
@@ -11,10 +11,11 @@ import (
 	"time"
 
 	"github.com/Shopify/sarama"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
-	"github.com/stretchr/testify/assert"
 )
 
 const (

--- a/metricbeat/module/kibana/status/status_integration_test.go
+++ b/metricbeat/module/kibana/status/status_integration_test.go
@@ -6,8 +6,9 @@ import (
 	"os"
 	"testing"
 
-	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
 	"github.com/stretchr/testify/assert"
+
+	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
 )
 
 func TestFetch(t *testing.T) {

--- a/metricbeat/module/kubernetes/container/container_test.go
+++ b/metricbeat/module/kubernetes/container/container_test.go
@@ -7,8 +7,9 @@ import (
 	"os"
 	"testing"
 
-	"github.com/elastic/beats/libbeat/common"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/libbeat/common"
 )
 
 const testFile = "../_meta/test/stats_summary.json"

--- a/metricbeat/module/kubernetes/node/node_test.go
+++ b/metricbeat/module/kubernetes/node/node_test.go
@@ -7,8 +7,9 @@ import (
 	"os"
 	"testing"
 
-	"github.com/elastic/beats/libbeat/common"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/libbeat/common"
 )
 
 const testFile = "../_meta/test/stats_summary.json"

--- a/metricbeat/module/kubernetes/pod/pod_test.go
+++ b/metricbeat/module/kubernetes/pod/pod_test.go
@@ -7,8 +7,9 @@ import (
 	"os"
 	"testing"
 
-	"github.com/elastic/beats/libbeat/common"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/libbeat/common"
 )
 
 const testFile = "../_meta/test/stats_summary.json"

--- a/metricbeat/module/kubernetes/system/system_test.go
+++ b/metricbeat/module/kubernetes/system/system_test.go
@@ -7,8 +7,9 @@ import (
 	"os"
 	"testing"
 
-	"github.com/elastic/beats/libbeat/common"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/libbeat/common"
 )
 
 const testFile = "../_meta/test/stats_summary.json"

--- a/metricbeat/module/kubernetes/volume/volume_test.go
+++ b/metricbeat/module/kubernetes/volume/volume_test.go
@@ -7,8 +7,9 @@ import (
 	"os"
 	"testing"
 
-	"github.com/elastic/beats/libbeat/common"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/libbeat/common"
 )
 
 const testFile = "../_meta/test/stats_summary.json"

--- a/metricbeat/module/mongodb/dbstats/dbstats_integration_test.go
+++ b/metricbeat/module/mongodb/dbstats/dbstats_integration_test.go
@@ -5,9 +5,10 @@ package dbstats
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
 	"github.com/elastic/beats/metricbeat/module/mongodb"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestFetch(t *testing.T) {

--- a/metricbeat/module/mongodb/status/status_integration_test.go
+++ b/metricbeat/module/mongodb/status/status_integration_test.go
@@ -5,10 +5,11 @@ package status
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/beats/libbeat/common"
 	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
 	"github.com/elastic/beats/metricbeat/module/mongodb"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestFetch(t *testing.T) {

--- a/metricbeat/module/postgresql/bgwriter/bgwriter.go
+++ b/metricbeat/module/postgresql/bgwriter/bgwriter.go
@@ -4,10 +4,11 @@ import (
 	"database/sql"
 	"fmt"
 
+	"github.com/pkg/errors"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/module/postgresql"
-	"github.com/pkg/errors"
 
 	// Register postgresql database/sql driver
 	_ "github.com/lib/pq"

--- a/metricbeat/module/postgresql/database/database.go
+++ b/metricbeat/module/postgresql/database/database.go
@@ -3,10 +3,11 @@ package database
 import (
 	"database/sql"
 
+	"github.com/pkg/errors"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/module/postgresql"
-	"github.com/pkg/errors"
 
 	// Register postgresql database/sql driver
 	_ "github.com/lib/pq"

--- a/metricbeat/module/postgresql/postgresql.go
+++ b/metricbeat/module/postgresql/postgresql.go
@@ -10,11 +10,12 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/lib/pq"
+	"github.com/pkg/errors"
+
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/mb/parse"
-	"github.com/lib/pq"
-	"github.com/pkg/errors"
 )
 
 func init() {

--- a/metricbeat/module/system/core/config.go
+++ b/metricbeat/module/system/core/config.go
@@ -3,8 +3,9 @@ package core
 import (
 	"strings"
 
-	"github.com/elastic/beats/libbeat/logp"
 	"github.com/pkg/errors"
+
+	"github.com/elastic/beats/libbeat/logp"
 )
 
 // Core metric types.

--- a/metricbeat/module/system/cpu/config.go
+++ b/metricbeat/module/system/cpu/config.go
@@ -3,8 +3,9 @@ package cpu
 import (
 	"strings"
 
-	"github.com/elastic/beats/libbeat/logp"
 	"github.com/pkg/errors"
+
+	"github.com/elastic/beats/libbeat/logp"
 )
 
 // CPU metric types.

--- a/metricbeat/module/system/memory/helper_test.go
+++ b/metricbeat/module/system/memory/helper_test.go
@@ -7,8 +7,9 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/elastic/gosigar"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/gosigar"
 )
 
 func TestGetMemory(t *testing.T) {

--- a/metricbeat/module/system/process/helper.go
+++ b/metricbeat/module/system/process/helper.go
@@ -10,13 +10,14 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pkg/errors"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/match"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/metricbeat/module/system"
 	"github.com/elastic/beats/metricbeat/module/system/memory"
 	sigar "github.com/elastic/gosigar"
-	"github.com/pkg/errors"
 )
 
 var NumCPU = runtime.NumCPU()

--- a/metricbeat/module/system/process/helper_test.go
+++ b/metricbeat/module/system/process/helper_test.go
@@ -10,9 +10,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/gosigar"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestPids(t *testing.T) {

--- a/metricbeat/module/system/process/process.go
+++ b/metricbeat/module/system/process/process.go
@@ -6,14 +6,14 @@ import (
 	"fmt"
 	"runtime"
 
+	"github.com/pkg/errors"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/mb/parse"
 	"github.com/elastic/beats/metricbeat/module/system"
-
 	"github.com/elastic/gosigar/cgroup"
-	"github.com/pkg/errors"
 )
 
 var debugf = logp.MakeDebug("system.process")

--- a/metricbeat/module/system/process_summary/process_summary.go
+++ b/metricbeat/module/system/process_summary/process_summary.go
@@ -3,13 +3,13 @@
 package process_summary
 
 import (
+	"github.com/pkg/errors"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/mb/parse"
 	"github.com/elastic/beats/metricbeat/module/system/process"
-	"github.com/pkg/errors"
-
 	sigar "github.com/elastic/gosigar"
 )
 

--- a/metricbeat/module/system/process_summary/process_summary_test.go
+++ b/metricbeat/module/system/process_summary/process_summary_test.go
@@ -5,8 +5,9 @@ package process_summary
 import (
 	"testing"
 
-	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
 	"github.com/stretchr/testify/assert"
+
+	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
 )
 
 func TestData(t *testing.T) {

--- a/metricbeat/module/system/socket/ptable.go
+++ b/metricbeat/module/system/socket/ptable.go
@@ -5,8 +5,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/elastic/procfs"
 	"github.com/joeshaw/multierror"
+
+	"github.com/elastic/procfs"
 )
 
 // process tools

--- a/metricbeat/module/system/system_windows.go
+++ b/metricbeat/module/system/system_windows.go
@@ -3,9 +3,10 @@ package system
 import (
 	"syscall"
 
+	"github.com/pkg/errors"
+
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/gosigar/sys/windows"
-	"github.com/pkg/errors"
 )
 
 // errMissingSeDebugPrivilege indicates that the SeDebugPrivilege is not

--- a/metricbeat/module/system/util_test.go
+++ b/metricbeat/module/system/util_test.go
@@ -7,8 +7,9 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/elastic/gosigar"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/gosigar"
 )
 
 func TestCPUMonitorSample(t *testing.T) {

--- a/metricbeat/module/windows/perfmon/pdh_windows.go
+++ b/metricbeat/module/windows/perfmon/pdh_windows.go
@@ -9,10 +9,11 @@ import (
 	"unicode/utf16"
 	"unsafe"
 
-	"github.com/elastic/beats/libbeat/common"
 	"github.com/joeshaw/multierror"
 	"github.com/pkg/errors"
 	"golang.org/x/sys/windows"
+
+	"github.com/elastic/beats/libbeat/common"
 )
 
 // Windows API calls

--- a/metricbeat/module/windows/perfmon/perfmon.go
+++ b/metricbeat/module/windows/perfmon/perfmon.go
@@ -6,10 +6,11 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/pkg/errors"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/metricbeat/mb"
-	"github.com/pkg/errors"
 )
 
 type CounterConfig struct {

--- a/packetbeat/beater/packetbeat.go
+++ b/packetbeat/beater/packetbeat.go
@@ -7,6 +7,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/tsg/gopacket/layers"
+
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/droppriv"
@@ -15,8 +17,6 @@ import (
 	"github.com/elastic/beats/libbeat/publisher/bc/publisher"
 	pub "github.com/elastic/beats/libbeat/publisher/beat"
 	"github.com/elastic/beats/libbeat/service"
-	"github.com/tsg/gopacket/layers"
-
 	"github.com/elastic/beats/packetbeat/config"
 	"github.com/elastic/beats/packetbeat/decoder"
 	"github.com/elastic/beats/packetbeat/flows"

--- a/packetbeat/flows/flows_test.go
+++ b/packetbeat/flows/flows_test.go
@@ -7,11 +7,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/publisher/beat"
 	"github.com/elastic/beats/packetbeat/config"
-	"github.com/stretchr/testify/assert"
 )
 
 type flowsChan struct {

--- a/packetbeat/protos/amqp/amqp_test.go
+++ b/packetbeat/protos/amqp/amqp_test.go
@@ -5,11 +5,12 @@ import (
 	"net"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/publisher/beat"
 	"github.com/elastic/beats/packetbeat/protos"
-	"github.com/stretchr/testify/assert"
 )
 
 type eventStore struct {

--- a/packetbeat/protos/cassandra/internal/gocql/marshal.go
+++ b/packetbeat/protos/cassandra/internal/gocql/marshal.go
@@ -6,16 +6,16 @@ package cassandra
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"math/big"
 	"reflect"
+	"strings"
 	"time"
 
-	"errors"
-	"strings"
+	"gopkg.in/inf.v0"
 
 	"github.com/elastic/beats/libbeat/logp"
-	"gopkg.in/inf.v0"
 )
 
 // TypeInfo describes a Cassandra specific data type.

--- a/packetbeat/protos/dns/dns_test.go
+++ b/packetbeat/protos/dns/dns_test.go
@@ -11,13 +11,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/elastic/beats/packetbeat/protos"
+	mkdns "github.com/miekg/dns"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/publisher/beat"
-	mkdns "github.com/miekg/dns"
-	"github.com/stretchr/testify/assert"
+	"github.com/elastic/beats/packetbeat/protos"
 )
 
 // Test Constants

--- a/packetbeat/protos/http/http_test.go
+++ b/packetbeat/protos/http/http_test.go
@@ -10,11 +10,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/publisher/beat"
 	"github.com/elastic/beats/packetbeat/protos"
-	"github.com/stretchr/testify/assert"
 )
 
 type testParser struct {

--- a/packetbeat/protos/icmp/message.go
+++ b/packetbeat/protos/icmp/message.go
@@ -4,8 +4,9 @@ import (
 	"encoding/binary"
 	"time"
 
-	"github.com/elastic/beats/libbeat/logp"
 	"github.com/tsg/gopacket/layers"
+
+	"github.com/elastic/beats/libbeat/logp"
 )
 
 // TODO: more types (that are not provided as constants in gopacket)

--- a/packetbeat/protos/mongodb/mongodb_test.go
+++ b/packetbeat/protos/mongodb/mongodb_test.go
@@ -7,11 +7,12 @@ import (
 	"net"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/publisher/beat"
 	"github.com/elastic/beats/packetbeat/protos"
-	"github.com/stretchr/testify/assert"
 )
 
 type eventStore struct {

--- a/packetbeat/protos/mysql/mysql_test.go
+++ b/packetbeat/protos/mysql/mysql_test.go
@@ -7,10 +7,11 @@ import (
 	"net"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/publisher/beat"
-	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/beats/packetbeat/protos"
 

--- a/packetbeat/protos/pgsql/pgsql_test.go
+++ b/packetbeat/protos/pgsql/pgsql_test.go
@@ -8,10 +8,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/publisher/beat"
-	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/beats/packetbeat/protos"
 )

--- a/packetbeat/publish/publish_test.go
+++ b/packetbeat/publish/publish_test.go
@@ -6,10 +6,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/publisher/bc/publisher"
 	"github.com/elastic/beats/libbeat/publisher/beat"
-	"github.com/stretchr/testify/assert"
 )
 
 func testEvent() beat.Event {

--- a/winlogbeat/checkpoint/checkpoint.go
+++ b/winlogbeat/checkpoint/checkpoint.go
@@ -12,8 +12,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/elastic/beats/libbeat/logp"
 	"gopkg.in/yaml.v2"
+
+	"github.com/elastic/beats/libbeat/logp"
 )
 
 // Checkpoint persists event log state information to disk.

--- a/winlogbeat/config/config.go
+++ b/winlogbeat/config/config.go
@@ -4,8 +4,9 @@ package config
 import (
 	"fmt"
 
-	"github.com/elastic/beats/libbeat/common"
 	"github.com/joeshaw/multierror"
+
+	"github.com/elastic/beats/libbeat/common"
 )
 
 const (

--- a/winlogbeat/config/config_test.go
+++ b/winlogbeat/config/config_test.go
@@ -5,8 +5,9 @@ package config
 import (
 	"testing"
 
-	"github.com/elastic/beats/libbeat/common"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/libbeat/common"
 )
 
 type validationTestCase struct {

--- a/winlogbeat/eventlog/eventlogging.go
+++ b/winlogbeat/eventlog/eventlogging.go
@@ -7,11 +7,12 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/joeshaw/multierror"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/winlogbeat/sys"
 	win "github.com/elastic/beats/winlogbeat/sys/eventlogging"
-	"github.com/joeshaw/multierror"
 )
 
 const (

--- a/winlogbeat/eventlog/eventlogging_test.go
+++ b/winlogbeat/eventlog/eventlogging_test.go
@@ -11,10 +11,11 @@ import (
 	"testing"
 
 	elog "github.com/andrewkroh/sys/windows/svc/eventlog"
-	"github.com/elastic/beats/libbeat/logp"
-	"github.com/elastic/beats/winlogbeat/sys/eventlogging"
 	"github.com/joeshaw/multierror"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/winlogbeat/sys/eventlogging"
 )
 
 // Names that are registered by the test for logging events.

--- a/winlogbeat/eventlog/factory.go
+++ b/winlogbeat/eventlog/factory.go
@@ -5,8 +5,9 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/elastic/beats/libbeat/common"
 	"github.com/joeshaw/multierror"
+
+	"github.com/elastic/beats/libbeat/common"
 )
 
 var commonConfigKeys = []string{"api", "name", "fields", "fields_under_root", "tags"}

--- a/winlogbeat/eventlog/wineventlog.go
+++ b/winlogbeat/eventlog/wineventlog.go
@@ -8,13 +8,14 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/joeshaw/multierror"
+	"github.com/pkg/errors"
+	"golang.org/x/sys/windows"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/winlogbeat/sys"
 	win "github.com/elastic/beats/winlogbeat/sys/wineventlog"
-	"github.com/joeshaw/multierror"
-	"github.com/pkg/errors"
-	"golang.org/x/sys/windows"
 )
 
 const (

--- a/winlogbeat/sys/eventlogging/eventlogging_windows.go
+++ b/winlogbeat/sys/eventlogging/eventlogging_windows.go
@@ -10,10 +10,11 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/elastic/beats/libbeat/logp"
-	"github.com/elastic/beats/winlogbeat/sys"
 	"golang.org/x/sys/windows"
 	"golang.org/x/sys/windows/registry"
+
+	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/winlogbeat/sys"
 )
 
 // The value of EventID element contains the low-order 16 bits of the event

--- a/winlogbeat/sys/wineventlog/wineventlog_windows.go
+++ b/winlogbeat/sys/wineventlog/wineventlog_windows.go
@@ -10,8 +10,9 @@ import (
 	"runtime"
 	"syscall"
 
-	"github.com/elastic/beats/winlogbeat/sys"
 	"golang.org/x/sys/windows"
+
+	"github.com/elastic/beats/winlogbeat/sys"
 )
 
 // Errors


### PR DESCRIPTION
Apply a consistent order to imports (stdlib, third party, then elastic).
This uses the `-local` flag of goimports to group our imports separate from
third-party imports. For example:

    import (
        "fmt"

        "github.com/pkg/errors"

        "github.com/elastic/beats/libbeat/common"
    )