### PR TITLE
Fix flaky harvester_limit test

### DIFF
--- a/filebeat/tests/system/test_prospector.py
+++ b/filebeat/tests/system/test_prospector.py
@@ -611,19 +611,15 @@ class Test(BaseTest):
 
         # check that not all harvesters were started
         self.wait_until(
-            lambda: self.log_contains("Harvester limit reached"),
-            max_timeout=10)
+            lambda: self.log_contains("Harvester limit reached"))
 
-        # wait for registry to be written
-        self.wait_until(
-            lambda: self.log_contains_count("Registry file updated") > 1,
-            max_timeout=10)
+        self.wait_until(lambda: self.output_lines() > 0)
 
         # Make sure not all events were written so far
         data = self.read_output()
         assert len(data) < 3
 
-        self.wait_until(lambda: self.output_has(lines=3), max_timeout=15)
+        self.wait_until(lambda: self.output_has(lines=3))
 
         data = self.read_output()
         assert len(data) == 3


### PR DESCRIPTION
The test sometimes failed on slow machines. The reason was that the registry was written before the first event was published. So the waiting for the registry was triggered before an event ended up on disk and the test crashed because no output file was there. Now it waits until it contains at least one line.