### PR TITLE
Cherry-pick #4658 to 5.x: Normalize times to common.Time with UTC time zone

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -30,6 +30,10 @@ https://github.com/elastic/beats/compare/v5.4.1...master[Check the HEAD diff]
 - Fix console output {pull}4045[4045]
 
 - Usage of field `_type` is now ignored and hardcoded to `doc`. {pull}3757[3757]
+- Don't stop with error loading the ES template if the ES output is not enabled. {pull}4436[4436]
+- Fix race condition in internal logging rotator. {pull}4519[4519]
+- Normalize all times to UTC to ensure proper index naming. {issue}4569[4569]
+- Fix issue with loading dashboards to ES 6.0 when .kibana index did not already exist. {issue}4659[4659]
 
 *Filebeat*
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -30,10 +30,7 @@ https://github.com/elastic/beats/compare/v5.4.1...master[Check the HEAD diff]
 - Fix console output {pull}4045[4045]
 
 - Usage of field `_type` is now ignored and hardcoded to `doc`. {pull}3757[3757]
-- Don't stop with error loading the ES template if the ES output is not enabled. {pull}4436[4436]
-- Fix race condition in internal logging rotator. {pull}4519[4519]
 - Normalize all times to UTC to ensure proper index naming. {issue}4569[4569]
-- Fix issue with loading dashboards to ES 6.0 when .kibana index did not already exist. {issue}4659[4659]
 
 *Filebeat*
 

--- a/libbeat/common/event.go
+++ b/libbeat/common/event.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/elastic/beats/libbeat/logp"
 
@@ -116,6 +117,26 @@ func normalizeSlice(v reflect.Value, keys ...string) (interface{}, []error) {
 func normalizeValue(value interface{}, keys ...string) (interface{}, []error) {
 	if value == nil {
 		return nil, nil
+	}
+
+	// Normalize time values to a common.Time with UTC time zone.
+	switch v := value.(type) {
+	case time.Time:
+		value = Time(v.UTC())
+	case []time.Time:
+		times := make([]Time, 0, len(v))
+		for _, t := range v {
+			times = append(times, Time(t.UTC()))
+		}
+		value = times
+	case Time:
+		value = Time(time.Time(v).UTC())
+	case []Time:
+		times := make([]Time, 0, len(v))
+		for _, t := range v {
+			times = append(times, Time(time.Time(t).UTC()))
+		}
+		value = times
 	}
 
 	switch value.(type) {

--- a/libbeat/common/event_test.go
+++ b/libbeat/common/event_test.go
@@ -3,6 +3,7 @@ package common
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/stretchr/testify/assert"
@@ -313,6 +314,27 @@ func TestMarshalFloatValues(t *testing.T) {
 	b, err := json.Marshal(a)
 	assert.Nil(err)
 	assert.Equal(string(b), "{\"f\":5.000000}")
+}
+
+func TestNormalizeTime(t *testing.T) {
+	ny, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now().In(ny)
+	v, errs := normalizeValue(now, "@timestamp")
+	if len(errs) > 0 {
+		t.Fatal(errs)
+	}
+
+	utcCommonTime, ok := v.(Time)
+	if !ok {
+		t.Fatalf("expected common.Time, but got %T (%v)", v, v)
+	}
+
+	assert.Equal(t, time.UTC, time.Time(utcCommonTime).Location())
+	assert.True(t, now.Equal(time.Time(utcCommonTime)))
 }
 
 // Uses TextMarshaler interface.


### PR DESCRIPTION
Cherry-pick of PR #4658 to 5.x branch. Original message: 

During event normalization convert any time objects to a common.Time and ensure that the time zone is UTC.

Fixes #4569