### PR TITLE
Add Flatten method to MapStr

### DIFF
--- a/libbeat/common/mapstr.go
+++ b/libbeat/common/mapstr.go
@@ -156,6 +156,39 @@ func (m MapStr) String() string {
 	return string(bytes)
 }
 
+// Flatten flattens the given MapStr and returns a flat MapStr.
+//
+// Example:
+//   "hello": MapStr{"world": "test" }
+//
+// This is converted to:
+//   "hello.world": "test"
+//
+// This can be useful for testing or logging.
+func (m MapStr) Flatten() MapStr {
+	return flatten("", m, MapStr{})
+}
+
+// flatten is a helper for Flatten. See docs for Flatten. For convenience the
+// out parameter is returned.
+func flatten(prefix string, in, out MapStr) MapStr {
+	for k, v := range in {
+		var fullKey string
+		if prefix == "" {
+			fullKey = k
+		} else {
+			fullKey = fmt.Sprintf("%s.%s", prefix, k)
+		}
+
+		if m, ok := tryToMapStr(v); ok {
+			flatten(fullKey, m, out)
+		} else {
+			out[fullKey] = v
+		}
+	}
+	return out
+}
+
 // MapStrUnion creates a new MapStr containing the union of the
 // key-value pairs of the two maps. If the same key is present in
 // both, the key-value pairs from dict2 overwrite the ones from dict1.

--- a/libbeat/common/mapstr_test.go
+++ b/libbeat/common/mapstr_test.go
@@ -423,3 +423,71 @@ func TestAddTag(t *testing.T) {
 		}
 	}
 }
+
+func TestFlatten(t *testing.T) {
+	type data struct {
+		Event    MapStr
+		Expected MapStr
+	}
+	tests := []data{
+		{
+			Event: MapStr{
+				"hello": MapStr{
+					"world": 15,
+				},
+			},
+			Expected: MapStr{
+				"hello.world": 15,
+			},
+		},
+		{
+			Event: MapStr{
+				"test": 15,
+			},
+			Expected: MapStr{
+				"test": 15,
+			},
+		},
+		{
+			Event: MapStr{
+				"test": 15,
+				"hello": MapStr{
+					"world": MapStr{
+						"ok": "test",
+					},
+				},
+				"elastic": MapStr{
+					"for": "search",
+				},
+			},
+			Expected: MapStr{
+				"test":           15,
+				"hello.world.ok": "test",
+				"elastic.for":    "search",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		assert.Equal(t, test.Expected, test.Event.Flatten())
+	}
+}
+
+func BenchmarkMapStrFlatten(b *testing.B) {
+	m := MapStr{
+		"test": 15,
+		"hello": MapStr{
+			"world": MapStr{
+				"ok": "test",
+			},
+		},
+		"elastic": MapStr{
+			"for": "search",
+		},
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = m.Flatten()
+	}
+}


### PR DESCRIPTION
This allows to flatten a MapStr to a flat map[string]interface{}. Nested keys are transformed to keys seperated by dots for each namespace. This can be useful for testing and logging.