### PR TITLE
Add support for interface and object to schema

### DIFF
--- a/libbeat/common/schema/mapstriface/mapstriface.go
+++ b/libbeat/common/schema/mapstriface/mapstriface.go
@@ -142,6 +142,19 @@ func Str(key string, opts ...schema.SchemaOption) schema.Conv {
 	return schema.SetOptions(schema.Conv{Key: key, Func: toStr}, opts)
 }
 
+func toIfc(key string, data map[string]interface{}) (interface{}, error) {
+	intf, err := common.MapStr(data).GetValue(key)
+	if err != nil {
+		return "", fmt.Errorf("Key %s not found: %s", key, err.Error())
+	}
+	return intf, nil
+}
+
+// Ifc creates a schema.Conv object for converting the given data to interface.
+func Ifc(key string, opts ...schema.SchemaOption) schema.Conv {
+	return schema.SetOptions(schema.Conv{Key: key, Func: toIfc}, opts)
+}
+
 func toBool(key string, data map[string]interface{}) (interface{}, error) {
 	emptyIface, exists := data[key]
 	if !exists {

--- a/libbeat/common/schema/mapstriface/mapstriface_test.go
+++ b/libbeat/common/schema/mapstriface/mapstriface_test.go
@@ -26,6 +26,12 @@ func TestConversions(t *testing.T) {
 		"testObj": map[string]interface{}{
 			"testObjString": "hello, object",
 		},
+		"rawObject": map[string]interface{}{
+			"nest1": map[string]interface{}{
+				"nest2": "world",
+			},
+		},
+		"testArray":        []string{"a", "b", "c"},
 		"testNonNestedObj": "hello from top level",
 		"testTime":         ts,
 		"commonTime":       cTs,
@@ -54,6 +60,8 @@ func TestConversions(t *testing.T) {
 		"test_obj_2": Dict("testObj", s.Schema{
 			"test": Str("testObjString"),
 		}),
+		"test_nested":       Ifc("rawObject"),
+		"test_array":        Ifc("testArray"),
 		"test_error_int":    Int("testErrorInt", s.Optional),
 		"test_error_time":   Time("testErrorTime", s.Optional),
 		"test_error_bool":   Bool("testErrorBool", s.Optional),
@@ -77,6 +85,12 @@ func TestConversions(t *testing.T) {
 		"test_obj_2": common.MapStr{
 			"test": "hello, object",
 		},
+		"test_nested": map[string]interface{}{
+			"nest1": map[string]interface{}{
+				"nest2": "world",
+			},
+		},
+		"test_array": []string{"a", "b", "c"},
 	}
 
 	output, _ := schema.Apply(input)


### PR DESCRIPTION
Currently schema was only able to process values where the full tree was visible. For cases where the sub tree should be take as is, now `Ifc` can be used. It takes whaever type it is and adds it to an event. This works for Objects or Arrays.