### PR TITLE
Wait killing the test beat

### DIFF
--- a/libbeat/tests/system/test_base.py
+++ b/libbeat/tests/system/test_base.py
@@ -53,7 +53,7 @@ class Test(BaseTest):
         # first run with default config, validating config being
         # actually correct.
         proc = self.start_beat()
-        self.wait_until(lambda: self.log_contains("Setup Beat"))
+        self.wait_until(lambda: self.log_contains("mockbeat start running."))
         proc.check_kill_and_wait()
 
         # start beat with invalid config setting on command line


### PR DESCRIPTION
wait killing the test beat until the signal handler is in place.
Should fix flaky tests with mockbeat having exitcode 2, caused by
kill while signal handlers missing.