### PR TITLE
Cherry-pick #4681 to 5.x: Check ML job against a minimal version of ES

### DIFF
--- a/filebeat/fileset/fileset.go
+++ b/filebeat/fileset/fileset.go
@@ -80,9 +80,10 @@ type manifest struct {
 	IngestPipeline  string                   `config:"ingest_pipeline"`
 	Prospector      string                   `config:"prospector"`
 	MachineLearning []struct {
-		Name     string `config:"name"`
-		Job      string `config:"job"`
-		Datafeed string `config:"datafeed"`
+		Name       string `config:"name"`
+		Job        string `config:"job"`
+		Datafeed   string `config:"datafeed"`
+		MinVersion string `config:"min_version"`
 	} `config:"machine_learning"`
 	Requires struct {
 		Processors []ProcessorRequirement `config:"processors"`
@@ -326,6 +327,7 @@ func (fs *Fileset) GetMLConfigs() []mlimporter.MLConfig {
 			ID:           fmt.Sprintf("filebeat-%s-%s-%s", fs.mcfg.Module, fs.name, ml.Name),
 			JobPath:      filepath.Join(fs.modulePath, fs.name, ml.Job),
 			DatafeedPath: filepath.Join(fs.modulePath, fs.name, ml.Datafeed),
+			MinVersion:   ml.MinVersion,
 		})
 	}
 	return mlConfigs

--- a/filebeat/fileset/modules.go
+++ b/filebeat/fileset/modules.go
@@ -252,6 +252,7 @@ func (reg *ModuleRegistry) GetProspectorConfigs() ([]*common.Config, error) {
 type PipelineLoader interface {
 	LoadJSON(path string, json map[string]interface{}) ([]byte, error)
 	Request(method, path string, pipeline string, params map[string]string, body interface{}) (int, []byte, error)
+	GetVersion() string
 }
 
 // LoadPipelines loads the pipelines for each configured fileset.

--- a/filebeat/module/nginx/access/manifest.yml
+++ b/filebeat/module/nginx/access/manifest.yml
@@ -16,18 +16,23 @@ machine_learning:
 - name: response_code
   job: machine_learning/response_code.json
   datafeed: machine_learning/datafeed_response_code.json
+  min_version: 5.5.0
 - name: low_request_rate
   job: machine_learning/low_request_rate.json
   datafeed: machine_learning/datafeed_low_request_rate.json
+  min_version: 5.5.0
 - name: remote_ip_url_count
   job: machine_learning/remote_ip_url_count.json
   datafeed: machine_learning/datafeed_remote_ip_url_count.json
+  min_version: 5.5.0
 - name: remote_ip_request_rate
   job: machine_learning/remote_ip_request_rate.json
   datafeed: machine_learning/datafeed_remote_ip_request_rate.json
+  min_version: 5.5.0
 - name: visitor_rate
   job: machine_learning/visitor_rate.json
   datafeed: machine_learning/datafeed_visitor_rate.json
+  min_version: 5.5.0
 
 requires.processors:
 - name: user_agent

--- a/libbeat/common/version.go
+++ b/libbeat/common/version.go
@@ -1,0 +1,79 @@
+package common
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type Version struct {
+	version string
+	Major   int
+	Minor   int
+	Bugfix  int
+	Meta    string
+}
+
+// NewVersion expects a string in the format:
+// major.minor.bugfix(-meta)
+func NewVersion(version string) (*Version, error) {
+
+	v := Version{
+		version: version,
+	}
+
+	// Check for meta info
+	if strings.Contains(version, "-") {
+		tmp := strings.Split(version, "-")
+		version = tmp[0]
+		v.Meta = tmp[1]
+	}
+
+	versions := strings.Split(version, ".")
+	if len(versions) != 3 {
+		return nil, fmt.Errorf("Passed version is not semver: %s", version)
+	}
+
+	var err error
+	v.Major, err = strconv.Atoi(versions[0])
+	if err != nil {
+		return nil, fmt.Errorf("Could not convert major to integer: %s", versions[0])
+	}
+
+	v.Minor, err = strconv.Atoi(versions[1])
+	if err != nil {
+		return nil, fmt.Errorf("Could not convert minor to integer: %s", versions[1])
+	}
+
+	v.Bugfix, err = strconv.Atoi(versions[2])
+	if err != nil {
+		return nil, fmt.Errorf("Could not convert bugfix to integer: %s", versions[2])
+	}
+
+	return &v, nil
+}
+
+func (v *Version) IsMajor(major int) bool {
+	return major == v.Major
+}
+
+// LessThan returns true if v is strictly smaller than v1. When comparing, the major,
+// minor and bugfix numbers are compared in order. The meta part is not taken into account.
+func (v *Version) LessThan(v1 *Version) bool {
+	if v.Major < v1.Major {
+		return true
+	} else if v.Major == v1.Major {
+		if v.Minor < v1.Minor {
+			return true
+		} else if v.Minor == v1.Minor {
+			if v.Bugfix < v1.Bugfix {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (v *Version) String() string {
+	return v.version
+}

--- a/libbeat/common/version_test.go
+++ b/libbeat/common/version_test.go
@@ -1,0 +1,96 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVersion(t *testing.T) {
+
+	tests := []struct {
+		version string
+		err     bool
+		result  Version
+	}{
+		{
+			version: "1.2.3",
+			err:     false,
+			result:  Version{Major: 1, Minor: 2, Bugfix: 3, version: "1.2.3"},
+		},
+		{
+			version: "1.3.3",
+			err:     false,
+			result:  Version{Major: 1, Minor: 3, Bugfix: 3, version: "1.3.3"},
+		},
+		{
+			version: "1.3.2-alpha1",
+			err:     false,
+			result:  Version{Major: 1, Minor: 3, Bugfix: 2, version: "1.3.2-alpha1", Meta: "alpha1"},
+		},
+		{
+			version: "alpha1",
+			err:     true,
+		},
+	}
+
+	for _, test := range tests {
+		v, err := NewVersion(test.version)
+		if test.err {
+			assert.Error(t, err)
+			continue
+		} else {
+			assert.NoError(t, err)
+		}
+		assert.Equal(t, *v, test.result)
+	}
+}
+
+func TestVersionLessThan(t *testing.T) {
+	tests := []struct {
+		name     string
+		version  string
+		version1 string
+		result   bool
+	}{
+		{
+			name:     "1.2.3 < 2.0.0",
+			version:  "1.2.3",
+			version1: "2.0.0",
+			result:   true,
+		},
+		{
+			name:     "1.2.3 = 1.2.3-beta1",
+			version:  "1.2.3",
+			version1: "1.2.3-beta1",
+			result:   false,
+		},
+		{
+			name:     "5.4.1 < 5.4.2",
+			version:  "5.4.1",
+			version1: "5.4.2",
+			result:   true,
+		},
+		{
+			name:     "5.5.1 > 5.4.2",
+			version:  "5.5.1",
+			version1: "5.4.2",
+			result:   false,
+		},
+		{
+			name:     "6.1.1-alpha3 < 6.2.0",
+			version:  "6.1.1-alpha3",
+			version1: "6.2.0",
+			result:   true,
+		},
+	}
+
+	for _, test := range tests {
+		v, err := NewVersion(test.version)
+		assert.NoError(t, err)
+		v1, err := NewVersion(test.version1)
+		assert.NoError(t, err)
+
+		assert.Equal(t, v.LessThan(v1), test.result, test.name)
+	}
+}

--- a/libbeat/outputs/elasticsearch/client.go
+++ b/libbeat/outputs/elasticsearch/client.go
@@ -605,6 +605,11 @@ func (client *Client) LoadJSON(path string, json map[string]interface{}) ([]byte
 	return body, nil
 }
 
+// GetVersion returns the elasticsearch version the client is connected to
+func (client *Client) GetVersion() string {
+	return client.Connection.version
+}
+
 // CheckTemplate checks if a given template already exist. It returns true if
 // and only if Elasticsearch returns with HTTP status code 200.
 func (client *Client) CheckTemplate(templateName string) bool {

--- a/testing/environments/latest.yml
+++ b/testing/environments/latest.yml
@@ -4,7 +4,7 @@
 version: '2'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:5.1.2
+    image: docker.elastic.co/elasticsearch/elasticsearch:5.4.1
     environment:
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
       - "network.host="
@@ -17,10 +17,10 @@ services:
       context: docker/logstash
       dockerfile: Dockerfile
       args:
-        ELASTIC_VERSION: 5.1.2
+        ELASTIC_VERSION: 5.4.1
         DOWNLOAD_URL: https://artifacts.elastic.co/downloads
     environment:
       - ES_HOST=elasticsearch
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:5.1.2
+    image: docker.elastic.co/kibana/kibana:5.4.1


### PR DESCRIPTION
Cherry-pick of PR #4681 to 5.x branch. Original message: 

This is used to avoid installing the jobs in versions >= 5.4.0 and < 5.5.0, which
don't accept the current format. Jobs that don't pass the minimum version check are ignored (with a debug message) at load time.

It can be also used in the future to restrict Jobs to particular ES versions.

Part of #4680.