### PR TITLE
Remove invalid links to releases

### DIFF
--- a/libbeat/docs/release.asciidoc
+++ b/libbeat/docs/release.asciidoc
@@ -6,8 +6,6 @@
 --
 This section summarizes the changes in each release.
 
-* <<release-notes-5.5.0>>
-* <<release-notes-5.4.2>>
 * <<release-notes-5.4.1>>
 * <<release-notes-5.4.0>>
 * <<release-notes-5.3.1>>


### PR DESCRIPTION
Happened on the merge from 5.5, likely. Will clean up the changelog later,
this is just to fix the doc build.