### PR TITLE
Use the beta1-snapshot in the testing env

### DIFF
--- a/testing/environments/args.yml
+++ b/testing/environments/args.yml
@@ -6,4 +6,4 @@ services:
     build:
       args:
         DOWNLOAD_URL: https://snapshots.elastic.co/downloads
-        ELASTIC_VERSION: 6.0.0-alpha3-SNAPSHOT
+        ELASTIC_VERSION: 6.0.0-beta1-SNAPSHOT

--- a/testing/environments/args.yml
+++ b/testing/environments/args.yml
@@ -7,3 +7,4 @@ services:
       args:
         DOWNLOAD_URL: https://snapshots.elastic.co/downloads
         ELASTIC_VERSION: 6.0.0-beta1-SNAPSHOT
+        CACHE_BUST: 20170720

--- a/testing/environments/docker/elasticsearch/Dockerfile-snapshot
+++ b/testing/environments/docker/elasticsearch/Dockerfile-snapshot
@@ -6,6 +6,7 @@ MAINTAINER Elastic Docker Team <docker@elastic.co>
 ARG ELASTIC_VERSION
 ARG DOWNLOAD_URL
 ARG ES_JAVA_OPTS
+ARG CACHE_BUST=1
 ARG XPACK
 
 ENV ELASTIC_CONTAINER true
@@ -19,7 +20,7 @@ RUN groupadd -g 1000 elasticsearch && adduser -u 1000 -g 1000 -d /usr/share/elas
 WORKDIR /usr/share/elasticsearch
 
 # Download/extract defined ES version. busybox tar can't strip leading dir.
-RUN wget ${DOWNLOAD_URL}/elasticsearch/elasticsearch-${ELASTIC_VERSION}.tar.gz && \
+RUN curl -L -o elasticsearch-${ELASTIC_VERSION}.tar.gz ${DOWNLOAD_URL}/elasticsearch/elasticsearch-${ELASTIC_VERSION}.tar.gz?c=${CACHE_BUST} && \
     EXPECTED_SHA=$(wget -O - ${DOWNLOAD_URL}/elasticsearch/elasticsearch-${ELASTIC_VERSION}.tar.gz.sha1) && \
     test $EXPECTED_SHA == $(sha1sum elasticsearch-${ELASTIC_VERSION}.tar.gz | awk '{print $1}') && \
     tar zxf elasticsearch-${ELASTIC_VERSION}.tar.gz && \
@@ -36,9 +37,9 @@ RUN set -ex && for esdirs in config data logs; do \
 USER elasticsearch
 
 # Install xpack
-RUN if [ ${XPACK} = "1" ]; then elasticsearch-plugin install --batch ${DOWNLOAD_URL}/packs/x-pack/x-pack-${ELASTIC_VERSION}.zip; fi
-RUN elasticsearch-plugin install --batch ${DOWNLOAD_URL}/elasticsearch-plugins/ingest-user-agent/ingest-user-agent-${ELASTIC_VERSION}.zip
-RUN elasticsearch-plugin install --batch ${DOWNLOAD_URL}/elasticsearch-plugins/ingest-geoip/ingest-geoip-${ELASTIC_VERSION}.zip
+RUN if [ ${XPACK} = "1" ]; then elasticsearch-plugin install --batch ${DOWNLOAD_URL}/packs/x-pack/x-pack-${ELASTIC_VERSION}.zip?c=${CACHE_BUST}; fi
+RUN elasticsearch-plugin install --batch ${DOWNLOAD_URL}/elasticsearch-plugins/ingest-user-agent/ingest-user-agent-${ELASTIC_VERSION}.zip?c=${CACHE_BUST}
+RUN elasticsearch-plugin install --batch ${DOWNLOAD_URL}/elasticsearch-plugins/ingest-geoip/ingest-geoip-${ELASTIC_VERSION}.zip?c=${CACHE_BUST}
 
 COPY config/elasticsearch.yml config/
 COPY config/log4j2.properties config/

--- a/testing/environments/docker/kibana/Dockerfile-snapshot
+++ b/testing/environments/docker/kibana/Dockerfile-snapshot
@@ -4,6 +4,7 @@ MAINTAINER Elastic Docker Team <docker@elastic.co>
 
 ARG DOWNLOAD_URL
 ARG ELASTIC_VERSION
+ARG CACHE_BUST=1
 ARG XPACK
 
 RUN apt-get update && apt-get install -y jq && apt-get clean
@@ -12,11 +13,11 @@ HEALTHCHECK --retries=6 CMD curl -f http://localhost:5601/api/status | jq '. | .
 EXPOSE 5601
 
 WORKDIR /usr/share/kibana
-RUN curl -Ls ${DOWNLOAD_URL}/kibana/kibana-${ELASTIC_VERSION}-linux-x86_64.tar.gz | tar --strip-components=1 -zxf - && \
+RUN curl -Ls ${DOWNLOAD_URL}/kibana/kibana-${ELASTIC_VERSION}-linux-x86_64.tar.gz?c=${CACHE_BUST} | tar --strip-components=1 -zxf - && \
     ln -s /usr/share/kibana /opt/kibana
 
 # Install XPACK
-RUN if [ ${XPACK} = "1" ]; then bin/kibana-plugin install ${DOWNLOAD_URL}/kibana-plugins/x-pack/x-pack-${ELASTIC_VERSION}.zip; fi
+RUN if [ ${XPACK} = "1" ]; then bin/kibana-plugin install ${DOWNLOAD_URL}/kibana-plugins/x-pack/x-pack-${ELASTIC_VERSION}.zip?c=${CACHE_BUST}; fi
 
 # Set some Kibana configuration defaults.
 ADD config/kibana.yml /usr/share/kibana/config/

--- a/testing/environments/docker/logstash/Dockerfile
+++ b/testing/environments/docker/logstash/Dockerfile
@@ -5,17 +5,15 @@ RUN apt-get update && \
 
 ARG DOWNLOAD_URL
 ARG ELASTIC_VERSION
+ARG CACHE_BUST=1
 
 ENV URL ${DOWNLOAD_URL}/logstash/logstash-${ELASTIC_VERSION}.tar.gz
 ENV PATH $PATH:/opt/logstash-${ELASTIC_VERSION}/bin
 
-# Cache variable can be set during building to invalidate the build cache with `--build-arg CACHE=$(date +%s) .`
-ARG CACHE=1
-
 # As all snapshot builds have the same url, the image is cached. The date at then can be used to invalidate the image
 RUN set -x && \
     cd /opt && \
-    wget -qO logstash.tar.gz $URL?${CACHE} && \
+    wget -qO logstash.tar.gz $URL?${CACHE_BUST} && \
     tar xzf logstash.tar.gz
 
 


### PR DESCRIPTION
🤞🤞

This also adds a `CACHE_BUST` parameter to the dockfiles, making it easier to make sure all our jenkins slaves are using a new image.