### PR TITLE
Cherry-pick #4257 to master: Fallback on LevelRaw If the Level is not in the RenderingInfo section of the event

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -109,6 +109,7 @@ https://github.com/elastic/beats/compare/v6.0.0-alpha2...master[Check the HEAD d
 *Packetbeat*
 
 *Winlogbeat*
+- Add the ability to use LevelRaw if Level isn't populated in the event XML. {pull}4257[4257]
 
 *Auditbeat*
 - Add file integrity metricset to the audit module. {pull}4486[4486]

--- a/winlogbeat/eventlog/wineventlog.go
+++ b/winlogbeat/eventlog/wineventlog.go
@@ -215,6 +215,11 @@ func (l *winEventLog) buildRecordFromXML(x []byte, recoveredErr error) (Record, 
 		e.RenderErr = recoveredErr.Error()
 	}
 
+	if e.Level == "" {
+		// Fallback on LevelRaw if the Level is not set in the RenderingInfo.
+		e.Level = win.EventLevel(e.LevelRaw).String()
+	}
+
 	if logp.IsDebug(detailSelector) {
 		detailf("%s XML=%s Event=%+v", l.logPrefix, string(x), e)
 	}

--- a/winlogbeat/sys/wineventlog/syscall_windows.go
+++ b/winlogbeat/sys/wineventlog/syscall_windows.go
@@ -194,6 +194,35 @@ func (e EvtSystemPropertyID) String() string {
 	return s
 }
 
+// EventLevel identifies the six levels of events that can be logged
+type EventLevel uint16
+
+// EventLevel values.
+const (
+	// Do not reorder.
+	EVENTLOG_LOGALWAYS_LEVEL EventLevel = iota
+	EVENTLOG_CRITICAL_LEVEL
+	EVENTLOG_ERROR_LEVEL
+	EVENTLOG_WARNING_LEVEL
+	EVENTLOG_INFORMATION_LEVEL
+	EVENTLOG_VERBOSE_LEVEL
+)
+
+// Mapping of event levels to their string representations.
+var EventLevelToString = map[EventLevel]string{
+	EVENTLOG_LOGALWAYS_LEVEL:   "Information",
+	EVENTLOG_INFORMATION_LEVEL: "Information",
+	EVENTLOG_CRITICAL_LEVEL:    "Critical",
+	EVENTLOG_ERROR_LEVEL:       "Error",
+	EVENTLOG_WARNING_LEVEL:     "Warning",
+	EVENTLOG_VERBOSE_LEVEL:     "Verbose",
+}
+
+// String returns string representation of EventLevel.
+func (et EventLevel) String() string {
+	return EventLevelToString[et]
+}
+
 // Add -trace to enable debug prints around syscalls.
 //go:generate go run $GOROOT/src/syscall/mksyscall_windows.go -output zsyscall_windows.go syscall_windows.go
 


### PR DESCRIPTION
Cherry-pick of PR #4257 to master branch. Original message: 

Applies to Windows Vista and above only.

https://discuss.elastic.co/t/event-fields-missing-if-renderinginfo-is-empty/84709
