### PR TITLE
Cherry-pick #4257 to 5.x: Fallback on LevelRaw If the Level is not in the RenderingInfo section of the event

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -81,6 +81,7 @@ https://github.com/elastic/beats/compare/v5.4.1...master[Check the HEAD diff]
 *Packetbeat*
 
 *Winlogbeat*
+- Add the ability to use LevelRaw if Level isn't populated in the event XML. {pull}4257[4257]
 
 ==== Deprecated
 


### PR DESCRIPTION
Cherry-pick of PR #4257 to 5.x branch. Original message: 

Applies to Windows Vista and above only.

https://discuss.elastic.co/t/event-fields-missing-if-renderinginfo-is-empty/84709
