### PR TITLE
Add Githubbeats to community beats

### DIFF
--- a/libbeat/docs/communitybeats.asciidoc
+++ b/libbeat/docs/communitybeats.asciidoc
@@ -36,6 +36,7 @@ Logstash or Elasticsearch.
 https://github.com/jarpy/factbeat[factbeat]:: Collects facts from https://puppetlabs.com/facter[Facter].
 https://github.com/FStelzer/flowbeat[flowbeat]:: Collects, parses, and indexes http://www.sflow.org/index.php[sflow] samples.
 https://github.com/GeneralElectric/GABeat[gabeat]:: Collects data from Google Analytics Realtime API.
+https://github.com/jlevesy/githubbeat[githubbeat]:: Easily monitor github repositories activity
 https://github.com/hpcugent/gpfsbeat[gpfsbeat]:: Collects GPFS metric and quota information.
 https://github.com/YaSuenag/hsbeat[hsbeat]:: Reads all performance counters in Java HotSpot VM.
 https://github.com/christiangalsterer/httpbeat[httpbeat]:: Polls multiple HTTP(S) endpoints and sends the data to


### PR DESCRIPTION
Hi folks,

I'm currently working on a new beat, [Githubbeat](https://github.com/jlevesy/githubbeat) which enables to collect data from github repositories and organization repositories and push them to any available beats output.

At the moment, I have a working proof of concept, but there is still work to do, I try to document where I am going on the repository README.

Any feedback is very welcome !

Cheers !