### PR TITLE
Check for removed settings on startup

### DIFF
--- a/auditbeat/module/audit/file/metricset.go
+++ b/auditbeat/module/audit/file/metricset.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/mb/parse"
@@ -45,7 +46,7 @@ type MetricSet struct {
 }
 
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Beta("The %v metricset is an beta feature", metricsetName)
+	cfgwarn.Experimental("The %v metricset is an experimental feature", metricsetName)
 
 	config := defaultConfig
 	if err := base.Module().UnpackConfig(&config); err != nil {

--- a/auditbeat/module/audit/kernel/audit_linux.go
+++ b/auditbeat/module/audit/kernel/audit_linux.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/monitoring"
 	"github.com/elastic/beats/metricbeat/mb"
@@ -47,7 +48,7 @@ type MetricSet struct {
 
 // New constructs a new MetricSet.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Beta("The %v metricset is a beta feature", metricsetName)
+	cfgwarn.Experimental("The %v metricset is a beta feature", metricsetName)
 
 	config := defaultConfig
 	if err := base.Module().UnpackConfig(&config); err != nil {

--- a/filebeat/beater/filebeat.go
+++ b/filebeat/beater/filebeat.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/monitoring"
 	"github.com/elastic/beats/libbeat/outputs/elasticsearch"
@@ -44,6 +45,11 @@ func New(b *beat.Beat, rawConfig *common.Config) (beat.Beater, error) {
 	config := cfg.DefaultConfig
 	if err := rawConfig.Unpack(&config); err != nil {
 		return nil, fmt.Errorf("Error reading config file: %v", err)
+	}
+
+	err := cfgwarn.CheckRemoved5xSettings(rawConfig, "spool_size", "publish_async", "idle_timeout")
+	if err != nil {
+		return nil, err
 	}
 
 	moduleRegistry, err := fileset.NewModuleRegistry(config.Modules, b.Info.Version)

--- a/filebeat/crawler/crawler.go
+++ b/filebeat/crawler/crawler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/elastic/beats/filebeat/registrar"
 	"github.com/elastic/beats/libbeat/cfgfile"
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/libbeat/logp"
 )
 
@@ -51,7 +52,7 @@ func (c *Crawler) Start(r *registrar.Registrar, configProspectors *common.Config
 	}
 
 	if configProspectors.Enabled() {
-		logp.Beta("Loading separate prospectors is enabled.")
+		cfgwarn.Beta("Loading separate prospectors is enabled.")
 
 		c.reloader = cfgfile.NewReloader(configProspectors)
 		factory := prospector.NewFactory(c.out, r, c.beatDone)
@@ -61,7 +62,7 @@ func (c *Crawler) Start(r *registrar.Registrar, configProspectors *common.Config
 	}
 
 	if configModules.Enabled() {
-		logp.Beta("Loading separate modules is enabled.")
+		cfgwarn.Beta("Loading separate modules is enabled.")
 
 		c.reloader = cfgfile.NewReloader(configModules)
 		factory := fileset.NewFactory(c.out, r, c.beatVersion, pipelineLoaderFactory, c.beatDone)

--- a/filebeat/prospector/config.go
+++ b/filebeat/prospector/config.go
@@ -4,7 +4,7 @@ import (
 	"time"
 
 	cfg "github.com/elastic/beats/filebeat/config"
-	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
 )
 
 var (
@@ -22,7 +22,7 @@ type prospectorConfig struct {
 
 func (c *prospectorConfig) Validate() error {
 	if c.InputType != "" {
-		logp.Deprecate("6.0.0", "input_type prospector config is deprecated. Use type instead.")
+		cfgwarn.Deprecate("6.0.0", "input_type prospector config is deprecated. Use type instead.")
 		c.Type = c.InputType
 	}
 	return nil

--- a/filebeat/prospector/log/config.go
+++ b/filebeat/prospector/log/config.go
@@ -10,6 +10,7 @@ import (
 	"github.com/elastic/beats/filebeat/harvester"
 	"github.com/elastic/beats/filebeat/harvester/reader"
 	"github.com/elastic/beats/filebeat/input/file"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/libbeat/common/match"
 	"github.com/elastic/beats/libbeat/logp"
 )
@@ -151,7 +152,7 @@ func (c *config) Validate() error {
 	}
 
 	if c.ScanSort != "" {
-		logp.Experimental("scan_sort is used.")
+		cfgwarn.Experimental("scan_sort is used.")
 
 		// Check input type
 		if _, ok := ValidScanSort[c.ScanSort]; !ok {

--- a/filebeat/prospector/redis/prospector.go
+++ b/filebeat/prospector/redis/prospector.go
@@ -9,6 +9,7 @@ import (
 	"github.com/elastic/beats/filebeat/harvester"
 	"github.com/elastic/beats/filebeat/input/file"
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/libbeat/logp"
 )
 
@@ -23,7 +24,8 @@ type Prospector struct {
 
 // NewProspector creates a new redis prospector
 func NewProspector(cfg *common.Config, outletFactory channel.OutleterFactory) (*Prospector, error) {
-	logp.Experimental("Redis slowlog prospector is enabled.")
+	cfgwarn.Experimental("Redis slowlog prospector is enabled.")
+
 	config := defaultConfig
 
 	err := cfg.Unpack(&config)

--- a/filebeat/prospector/udp/prospector.go
+++ b/filebeat/prospector/udp/prospector.go
@@ -4,6 +4,7 @@ import (
 	"github.com/elastic/beats/filebeat/channel"
 	"github.com/elastic/beats/filebeat/harvester"
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/libbeat/logp"
 )
 
@@ -14,7 +15,7 @@ type Prospector struct {
 }
 
 func NewProspector(cfg *common.Config, outlet channel.OutleterFactory) (*Prospector, error) {
-	logp.Experimental("UDP prospector type is used")
+	cfgwarn.Experimental("UDP prospector type is used")
 
 	out, err := outlet(cfg)
 	if err != nil {

--- a/filebeat/tests/system/config/filebeat_modules.yml.j2
+++ b/filebeat/tests/system/config/filebeat_modules.yml.j2
@@ -1,4 +1,3 @@
-filebeat.idle_timeout: 0.5s
 filebeat.registry_file: {{ beat.working_dir + '/' }}{{ registryFile|default("registry")}}
 
 output.elasticsearch.hosts: ["{{ elasticsearch_url }}"]

--- a/filebeat/tests/system/config/filebeat_prospectors.yml.j2
+++ b/filebeat/tests/system/config/filebeat_prospectors.yml.j2
@@ -5,7 +5,6 @@ filebeat.prospectors:
   scan_frequency: 0.5s
   encoding: {{prospector.encoding | default("plain") }}
 {% endfor %}
-filebeat.idle_timeout: 0.5s
 filebeat.registry_file: {{ beat.working_dir + '/' }}{{ registryFile|default("registry")}}
 
 output.file:

--- a/filebeat/tests/system/test_base.py
+++ b/filebeat/tests/system/test_base.py
@@ -26,3 +26,23 @@ class Test(BaseTest):
         output = self.read_output()[0]
         assert "@timestamp" in output
         assert "prospector.type" in output
+
+    def test_invalid_config_with_removed_settings(self):
+        """
+        Checks if filebeat fails to load if removed settings have been used:
+        """
+        self.render_config_template(console={"pretty": "false"})
+
+        exit_code = self.run_beat(extra_args=[
+            "-E", "filebeat.spool_size=2048",
+            "-E", "filebeat.publish_async=true",
+            "-E", "filebeat.idle_timeout=1s",
+        ])
+
+        assert exit_code == 1
+        assert self.log_contains("setting 'filebeat.spool_size'"
+                                 " has been removed")
+        assert self.log_contains("setting 'filebeat.publish_async'"
+                                 " has been removed")
+        assert self.log_contains("setting 'filebeat.idle_timeout'"
+                                 " has been removed")

--- a/libbeat/api/server.go
+++ b/libbeat/api/server.go
@@ -7,13 +7,14 @@ import (
 	"strconv"
 
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/monitoring"
 )
 
 // Start starts the metrics api endpoint on the configured host and port
 func Start(cfg *common.Config, info common.BeatInfo) {
-	logp.Beta("Metrics endpoint is enabled.")
+	cfgwarn.Beta("Metrics endpoint is enabled.")
 	config := DefaultConfig
 	cfg.Unpack(&config)
 

--- a/libbeat/common/cfgwarn/cfgwarn.go
+++ b/libbeat/common/cfgwarn/cfgwarn.go
@@ -1,0 +1,24 @@
+package cfgwarn
+
+import (
+	"fmt"
+
+	"github.com/elastic/beats/libbeat/logp"
+)
+
+// Beta logs the usage of an beta feature.
+func Beta(format string, v ...interface{}) {
+	logp.Warn("BETA: "+format, v...)
+}
+
+// Deprecate logs a deprecation message.
+// The version string contains the version when the future will be removed
+func Deprecate(version string, format string, v ...interface{}) {
+	postfix := fmt.Sprintf(" Will be removed in version: %s", version)
+	logp.Warn("DEPRECATED: "+format+postfix, v...)
+}
+
+// Experimental logs the usage of an experimental feature.
+func Experimental(format string, v ...interface{}) {
+	logp.Warn("EXPERIMENTAL: "+format, v...)
+}

--- a/libbeat/common/cfgwarn/removed.go
+++ b/libbeat/common/cfgwarn/removed.go
@@ -1,0 +1,49 @@
+package cfgwarn
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/joeshaw/multierror"
+
+	"github.com/elastic/beats/libbeat/common"
+)
+
+func CheckRemoved5xSettings(cfg *common.Config, settings ...string) error {
+	var errs multierror.Errors
+	for _, setting := range settings {
+		if err := CheckRemoved5xSetting(cfg, setting); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	return errs.Err()
+}
+
+// CheckRemoved5xSetting prints a warning if the obsolete setting is used.
+func CheckRemoved5xSetting(cfg *common.Config, setting string) error {
+	segments := strings.Split(setting, ".")
+
+	L := len(segments)
+	name := segments[L-1]
+	path := segments[:L-1]
+
+	current := cfg
+	for _, p := range path {
+		current, _ := current.Child(p, -1)
+		if current == nil {
+			break
+		}
+	}
+
+	// full path to setting not available -> setting not found
+	if current == nil {
+		return nil
+	}
+
+	if !current.HasField(name) {
+		return nil
+	}
+
+	return fmt.Errorf("setting '%v' has been removed", current.PathOf(name))
+}

--- a/libbeat/logp/log.go
+++ b/libbeat/logp/log.go
@@ -163,23 +163,6 @@ func Critical(format string, v ...interface{}) {
 	msg(LOG_CRIT, "CRIT", format, v...)
 }
 
-// Deprecate logs a deprecation message.
-// The version string contains the version when the future will be removed
-func Deprecate(version string, format string, v ...interface{}) {
-	postfix := fmt.Sprintf(" Will be removed in version: %s", version)
-	Warn("DEPRECATED: "+format+postfix, v...)
-}
-
-// Experimental logs the usage of an experimental feature.
-func Experimental(format string, v ...interface{}) {
-	Warn("EXPERIMENTAL: "+format, v...)
-}
-
-// Beta logs the usage of an beta feature.
-func Beta(format string, v ...interface{}) {
-	Warn("BETA: "+format, v...)
-}
-
 // WTF prints the message at CRIT level and panics immediately with the same
 // message
 func WTF(format string, v ...interface{}) {

--- a/libbeat/processors/add_docker_metadata/add_docker_metadata.go
+++ b/libbeat/processors/add_docker_metadata/add_docker_metadata.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/processors"
 	"github.com/elastic/beats/libbeat/processors/actions"
@@ -26,7 +27,7 @@ func newDockerMetadataProcessor(cfg *common.Config) (processors.Processor, error
 }
 
 func buildDockerMetadataProcessor(cfg *common.Config, watcherConstructor WatcherConstructor) (processors.Processor, error) {
-	logp.Beta("The add_docker_metadata processor is beta")
+	cfgwarn.Beta("The add_docker_metadata processor is beta")
 
 	config := defaultConfig()
 

--- a/libbeat/processors/add_kubernetes_metadata/kubernetes.go
+++ b/libbeat/processors/add_kubernetes_metadata/kubernetes.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/processors"
 	"github.com/elastic/beats/libbeat/publisher/beat"
@@ -40,7 +41,7 @@ func init() {
 }
 
 func newKubernetesAnnotator(cfg *common.Config) (processors.Processor, error) {
-	logp.Beta("The kubernetes processor is beta")
+	cfgwarn.Beta("The kubernetes processor is beta")
 
 	config := defaultKuberentesAnnotatorConfig()
 

--- a/libbeat/tests/system/test_base.py
+++ b/libbeat/tests/system/test_base.py
@@ -82,6 +82,21 @@ class Test(BaseTest):
         assert exit_code == 0
         assert self.log_contains("Config OK") is True
 
+    def test_invalid_config_with_removed_settings(self):
+        """
+        Checks if libbeat fails to load if removed settings have been used:
+        """
+        self.render_config_template(console={"pretty": "false"})
+
+        exit_code = self.run_beat(extra_args=[
+            "-E", "queue_size=2048",
+            "-E", "bulk_queue_size=1",
+        ])
+
+        assert exit_code == 1
+        assert self.log_contains("setting 'queue_size' has been removed")
+        assert self.log_contains("setting 'bulk_queue_size' has been removed")
+
     def test_version_simple(self):
         """
         Tests -version prints a version and exits.

--- a/metricbeat/beater/metricbeat.go
+++ b/metricbeat/beater/metricbeat.go
@@ -10,6 +10,7 @@ import (
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/cfgfile"
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/mb/module"
@@ -53,6 +54,13 @@ func New(b *beat.Beat, rawConfig *common.Config) (beat.Beater, error) {
 		}
 
 		failed := false
+
+		err := cfgwarn.CheckRemoved5xSettings(moduleCfg, "filters")
+		if err != nil {
+			errs = append(errs, err)
+			failed = true
+		}
+
 		connector, err := module.NewConnector(b.Publisher, moduleCfg)
 		if err != nil {
 			errs = append(errs, err)
@@ -68,6 +76,7 @@ func New(b *beat.Beat, rawConfig *common.Config) (beat.Beater, error) {
 		if failed {
 			continue
 		}
+
 		modules = append(modules, staticModule{
 			connector: connector,
 			module:    module,

--- a/metricbeat/docs/modules/redis.asciidoc
+++ b/metricbeat/docs/modules/redis.asciidoc
@@ -63,9 +63,9 @@ metricbeat.modules:
   #maxconn: 10
 
   # Filters can be used to reduce the number of fields sent.
-  #filters:
+  #processors:
   #  - include_fields:
-  #      fields: ["stats"]
+  #      fields: ["beat", "metricset", "redis.info.stats"]
 
   # Redis AUTH password. Empty by default.
   #password: foobared

--- a/metricbeat/docs/modules/system.asciidoc
+++ b/metricbeat/docs/modules/system.asciidoc
@@ -107,8 +107,9 @@ metricbeat.modules:
   metricsets:
     - filesystem
     - fsstat
-  filters:
-    - drop_event.when.regexp.mount_point: '^/(sys|cgroup|proc|dev|etc|host|lib)($|/)'
+  processors:
+  - drop_event.when.regexp:
+      system.filesystem.mount_point: '^/(sys|cgroup|proc|dev|etc|host|lib)($|/)'
 ----
 
 [float]

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -376,9 +376,9 @@ metricbeat.modules:
   #maxconn: 10
 
   # Filters can be used to reduce the number of fields sent.
-  #filters:
+  #processors:
   #  - include_fields:
-  #      fields: ["stats"]
+  #      fields: ["beat", "metricset", "redis.info.stats"]
 
   # Redis AUTH password. Empty by default.
   #password: foobared

--- a/metricbeat/module/aerospike/namespace/namespace.go
+++ b/metricbeat/module/aerospike/namespace/namespace.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/module/aerospike"
@@ -35,7 +36,7 @@ type MetricSet struct {
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	config := struct{}{}
 
-	logp.Experimental("The aerospike namespace metricset is experimental")
+	cfgwarn.Experimental("The aerospike namespace metricset is experimental")
 
 	if err := base.Module().UnpackConfig(&config); err != nil {
 		return nil, err

--- a/metricbeat/module/ceph/cluster_disk/cluster_disk.go
+++ b/metricbeat/module/ceph/cluster_disk/cluster_disk.go
@@ -2,7 +2,7 @@ package cluster_disk
 
 import (
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/metricbeat/helper"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/mb/parse"
@@ -32,7 +32,7 @@ type MetricSet struct {
 }
 
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Experimental("The ceph cluster_disk metricset is experimental")
+	cfgwarn.Experimental("The ceph cluster_disk metricset is experimental")
 
 	http := helper.NewHTTP(base)
 	http.SetHeader("Accept", "application/json")

--- a/metricbeat/module/ceph/cluster_health/cluster_health.go
+++ b/metricbeat/module/ceph/cluster_health/cluster_health.go
@@ -2,7 +2,7 @@ package cluster_health
 
 import (
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/metricbeat/helper"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/mb/parse"
@@ -32,7 +32,7 @@ type MetricSet struct {
 }
 
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Beta("The ceph cluster_health metricset is beta")
+	cfgwarn.Beta("The ceph cluster_health metricset is beta")
 
 	http := helper.NewHTTP(base)
 	http.SetHeader("Accept", "application/json")

--- a/metricbeat/module/ceph/monitor_health/monitor_health.go
+++ b/metricbeat/module/ceph/monitor_health/monitor_health.go
@@ -2,7 +2,7 @@ package monitor_health
 
 import (
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/metricbeat/helper"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/mb/parse"
@@ -32,7 +32,7 @@ type MetricSet struct {
 }
 
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Beta("The ceph monitor_health metricset is beta")
+	cfgwarn.Beta("The ceph monitor_health metricset is beta")
 
 	http := helper.NewHTTP(base)
 	http.SetHeader("Accept", "application/json")

--- a/metricbeat/module/ceph/pool_disk/pool_disk.go
+++ b/metricbeat/module/ceph/pool_disk/pool_disk.go
@@ -2,7 +2,7 @@ package pool_disk
 
 import (
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/metricbeat/helper"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/mb/parse"
@@ -32,7 +32,7 @@ type MetricSet struct {
 }
 
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Experimental("The ceph pool_disk metricset is experimental")
+	cfgwarn.Experimental("The ceph pool_disk metricset is experimental")
 
 	http := helper.NewHTTP(base)
 	http.SetHeader("Accept", "application/json")

--- a/metricbeat/module/couchbase/bucket/bucket.go
+++ b/metricbeat/module/couchbase/bucket/bucket.go
@@ -2,7 +2,7 @@ package bucket
 
 import (
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/metricbeat/helper"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/mb/parse"
@@ -36,7 +36,7 @@ type MetricSet struct {
 
 // New create a new instance of the MetricSet
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Beta("The couchbase bucket metricset is beta")
+	cfgwarn.Beta("The couchbase bucket metricset is beta")
 
 	return &MetricSet{
 		BaseMetricSet: base,

--- a/metricbeat/module/couchbase/cluster/cluster.go
+++ b/metricbeat/module/couchbase/cluster/cluster.go
@@ -2,7 +2,7 @@ package cluster
 
 import (
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/metricbeat/helper"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/mb/parse"
@@ -36,7 +36,7 @@ type MetricSet struct {
 
 // New create a new instance of the MetricSet
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Beta("The couchbase cluster metricset is beta")
+	cfgwarn.Beta("The couchbase cluster metricset is beta")
 
 	return &MetricSet{
 		BaseMetricSet: base,

--- a/metricbeat/module/couchbase/node/node.go
+++ b/metricbeat/module/couchbase/node/node.go
@@ -2,7 +2,7 @@ package node
 
 import (
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/metricbeat/helper"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/mb/parse"
@@ -36,7 +36,7 @@ type MetricSet struct {
 
 // New create a new instance of the MetricSet
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Beta("The couchbase node metricset is beta")
+	cfgwarn.Beta("The couchbase node metricset is beta")
 
 	return &MetricSet{
 		BaseMetricSet: base,

--- a/metricbeat/module/docker/container/container.go
+++ b/metricbeat/module/docker/container/container.go
@@ -4,7 +4,7 @@ import (
 	dc "github.com/fsouza/go-dockerclient"
 
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/module/docker"
 )
@@ -22,7 +22,7 @@ type MetricSet struct {
 
 // New creates a new instance of the docker container MetricSet.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Beta("The docker container metricset is beta")
+	cfgwarn.Beta("The docker container metricset is beta")
 
 	config := docker.Config{}
 	if err := base.Module().UnpackConfig(&config); err != nil {

--- a/metricbeat/module/docker/cpu/cpu.go
+++ b/metricbeat/module/docker/cpu/cpu.go
@@ -2,7 +2,7 @@ package cpu
 
 import (
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/module/docker"
 
@@ -23,7 +23,7 @@ type MetricSet struct {
 
 // New creates a new instance of the docker cpu MetricSet.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Beta("The docker cpu metricset is beta")
+	cfgwarn.Beta("The docker cpu metricset is beta")
 
 	config := docker.Config{}
 	if err := base.Module().UnpackConfig(&config); err != nil {

--- a/metricbeat/module/docker/diskio/diskio.go
+++ b/metricbeat/module/docker/diskio/diskio.go
@@ -2,7 +2,7 @@ package diskio
 
 import (
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/module/docker"
 
@@ -23,7 +23,7 @@ type MetricSet struct {
 
 // New create a new instance of the docker diskio MetricSet.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Beta("The docker diskio metricset is beta")
+	cfgwarn.Beta("The docker diskio metricset is beta")
 
 	config := docker.Config{}
 	if err := base.Module().UnpackConfig(&config); err != nil {

--- a/metricbeat/module/docker/healthcheck/healthcheck.go
+++ b/metricbeat/module/docker/healthcheck/healthcheck.go
@@ -4,7 +4,7 @@ import (
 	dc "github.com/fsouza/go-dockerclient"
 
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/module/docker"
 )
@@ -22,7 +22,7 @@ type MetricSet struct {
 
 // New creates a new instance of the docker healthcheck MetricSet.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Beta("The docker healthcheck metricset is beta")
+	cfgwarn.Beta("The docker healthcheck metricset is beta")
 
 	config := docker.Config{}
 	if err := base.Module().UnpackConfig(&config); err != nil {

--- a/metricbeat/module/docker/image/image.go
+++ b/metricbeat/module/docker/image/image.go
@@ -2,7 +2,7 @@ package image
 
 import (
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/module/docker"
 
@@ -30,7 +30,7 @@ type MetricSet struct {
 // Part of new is also setting up the configuration by processing additional
 // configuration entries if needed.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Beta("The docker info metricset is beta")
+	cfgwarn.Beta("The docker info metricset is beta")
 
 	config := docker.Config{}
 	if err := base.Module().UnpackConfig(&config); err != nil {

--- a/metricbeat/module/docker/info/info.go
+++ b/metricbeat/module/docker/info/info.go
@@ -2,7 +2,7 @@ package info
 
 import (
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/module/docker"
 
@@ -22,7 +22,7 @@ type MetricSet struct {
 
 // New create a new instance of the docker info MetricSet.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Beta("The docker info metricset is beta")
+	cfgwarn.Beta("The docker info metricset is beta")
 
 	config := docker.Config{}
 	if err := base.Module().UnpackConfig(&config); err != nil {

--- a/metricbeat/module/docker/memory/memory.go
+++ b/metricbeat/module/docker/memory/memory.go
@@ -2,7 +2,7 @@ package memory
 
 import (
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/module/docker"
 
@@ -23,7 +23,7 @@ type MetricSet struct {
 
 // New creates a new instance of the docker memory MetricSet.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Beta("The docker memory metricset is beta")
+	cfgwarn.Beta("The docker memory metricset is beta")
 
 	config := docker.Config{}
 	if err := base.Module().UnpackConfig(&config); err != nil {

--- a/metricbeat/module/docker/network/network.go
+++ b/metricbeat/module/docker/network/network.go
@@ -2,7 +2,7 @@ package network
 
 import (
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/module/docker"
 
@@ -23,7 +23,7 @@ type MetricSet struct {
 
 // New creates a new instance of the docker network MetricSet.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Beta("The docker network metricset is beta")
+	cfgwarn.Beta("The docker network metricset is beta")
 
 	config := docker.Config{}
 	if err := base.Module().UnpackConfig(&config); err != nil {

--- a/metricbeat/module/dropwizard/collector/collector.go
+++ b/metricbeat/module/dropwizard/collector/collector.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/metricbeat/helper"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/mb/parse"
@@ -47,7 +47,7 @@ type MetricSet struct {
 // Part of new is also setting up the configuration by processing additional
 // configuration entries if needed.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Beta("The dropwizard collector metricset is beta")
+	cfgwarn.Beta("The dropwizard collector metricset is beta")
 	config := struct {
 		Namespace string `config:"namespace" validate:"required"`
 	}{}

--- a/metricbeat/module/golang/expvar/expvar.go
+++ b/metricbeat/module/golang/expvar/expvar.go
@@ -2,7 +2,7 @@ package expvar
 
 import (
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/metricbeat/helper"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/mb/parse"
@@ -44,7 +44,7 @@ type MetricSet struct {
 // Part of new is also setting up the configuration by processing additional
 // configuration entries if needed.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Experimental("The golang expvar metricset is experimental")
+	cfgwarn.Experimental("The golang expvar metricset is experimental")
 
 	config := struct {
 		Namespace string `config:"expvar.namespace" validate:"required"`

--- a/metricbeat/module/golang/heap/heap.go
+++ b/metricbeat/module/golang/heap/heap.go
@@ -5,6 +5,7 @@ import (
 	"runtime"
 
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/metricbeat/helper"
 	"github.com/elastic/beats/metricbeat/mb"
@@ -47,7 +48,7 @@ type MetricSet struct {
 // Part of new is also setting up the configuration by processing additional
 // configuration entries if needed.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Experimental("The golang heap metricset is experimental")
+	cfgwarn.Experimental("The golang heap metricset is experimental")
 
 	return &MetricSet{
 		BaseMetricSet: base,

--- a/metricbeat/module/http/json/json.go
+++ b/metricbeat/module/http/json/json.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/metricbeat/helper"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/mb/parse"
@@ -55,7 +55,7 @@ type MetricSet struct {
 // Part of new is also setting up the configuration by processing additional
 // configuration entries if needed.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Beta("The http json metricset is in beta.")
+	cfgwarn.Beta("The http json metricset is in beta.")
 
 	config := struct {
 		Namespace       string `config:"namespace" validate:"required"`

--- a/metricbeat/module/jolokia/jmx/jmx.go
+++ b/metricbeat/module/jolokia/jmx/jmx.go
@@ -2,6 +2,7 @@ package jmx
 
 import (
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/metricbeat/helper"
 	"github.com/elastic/beats/metricbeat/mb"
@@ -48,7 +49,7 @@ type MetricSet struct {
 
 // New create a new instance of the MetricSet
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Beta("The jolokia jmx metricset is beta")
+	cfgwarn.Beta("The jolokia jmx metricset is beta")
 
 	// Additional configuration options
 	config := struct {

--- a/metricbeat/module/kafka/consumergroup/consumergroup.go
+++ b/metricbeat/module/kafka/consumergroup/consumergroup.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/outputs"
 	"github.com/elastic/beats/metricbeat/mb"
@@ -36,7 +37,7 @@ var debugf = logp.MakeDebug("kafka")
 
 // New creates a new instance of the MetricSet.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Beta("The kafka consumergroup metricset is beta")
+	cfgwarn.Beta("The kafka consumergroup metricset is beta")
 
 	config := defaultConfig
 	if err := base.Module().UnpackConfig(&config); err != nil {

--- a/metricbeat/module/kafka/partition/partition.go
+++ b/metricbeat/module/kafka/partition/partition.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/outputs"
 	"github.com/elastic/beats/metricbeat/mb"
@@ -37,7 +38,7 @@ var debugf = logp.MakeDebug("kafka")
 
 // New creates a new instance of the partition MetricSet.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Beta("The kafka partition metricset is beta")
+	cfgwarn.Beta("The kafka partition metricset is beta")
 
 	config := defaultConfig
 	if err := base.Module().UnpackConfig(&config); err != nil {

--- a/metricbeat/module/kubernetes/container/container.go
+++ b/metricbeat/module/kubernetes/container/container.go
@@ -2,7 +2,7 @@ package container
 
 import (
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/metricbeat/helper"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/mb/parse"
@@ -41,7 +41,7 @@ type MetricSet struct {
 // Part of new is also setting up the configuration by processing additional
 // configuration entries if needed.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Beta("The kubernetes container metricset is beta")
+	cfgwarn.Beta("The kubernetes container metricset is beta")
 	return &MetricSet{
 		BaseMetricSet: base,
 		http:          helper.NewHTTP(base),

--- a/metricbeat/module/kubernetes/event/event.go
+++ b/metricbeat/module/kubernetes/event/event.go
@@ -5,7 +5,7 @@ import (
 	"io/ioutil"
 
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/metricbeat/mb"
 
 	"github.com/ericchiang/k8s"
@@ -32,7 +32,7 @@ type MetricSet struct {
 // Part of new is also setting up the configuration by processing additional
 // configuration entries if needed.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Experimental("The kubernetes event metricset is experimental")
+	cfgwarn.Experimental("The kubernetes event metricset is experimental")
 
 	config := defaultKuberentesEventsConfig()
 

--- a/metricbeat/module/kubernetes/node/node.go
+++ b/metricbeat/module/kubernetes/node/node.go
@@ -2,7 +2,7 @@ package node
 
 import (
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/metricbeat/helper"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/mb/parse"
@@ -41,7 +41,7 @@ type MetricSet struct {
 // Part of new is also setting up the configuration by processing additional
 // configuration entries if needed.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Beta("The kubernetes node metricset is beta")
+	cfgwarn.Beta("The kubernetes node metricset is beta")
 	return &MetricSet{
 		BaseMetricSet: base,
 		http:          helper.NewHTTP(base),

--- a/metricbeat/module/kubernetes/pod/pod.go
+++ b/metricbeat/module/kubernetes/pod/pod.go
@@ -2,7 +2,7 @@ package pod
 
 import (
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/metricbeat/helper"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/mb/parse"
@@ -41,7 +41,7 @@ type MetricSet struct {
 // Part of new is also setting up the configuration by processing additional
 // configuration entries if needed.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Beta("The kubernetes pod metricset is beta")
+	cfgwarn.Beta("The kubernetes pod metricset is beta")
 	return &MetricSet{
 		BaseMetricSet: base,
 		http:          helper.NewHTTP(base),

--- a/metricbeat/module/kubernetes/state_container/state_container.go
+++ b/metricbeat/module/kubernetes/state_container/state_container.go
@@ -2,7 +2,7 @@ package state_container
 
 import (
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/metricbeat/helper"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/mb/parse"
@@ -41,7 +41,7 @@ type MetricSet struct {
 // Part of new is also setting up the configuration by processing additional
 // configuration entries if needed.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Beta("The kubernetes state_container metricset is beta")
+	cfgwarn.Beta("The kubernetes state_container metricset is beta")
 
 	return &MetricSet{
 		BaseMetricSet: base,

--- a/metricbeat/module/kubernetes/state_deployment/state_deployment.go
+++ b/metricbeat/module/kubernetes/state_deployment/state_deployment.go
@@ -2,7 +2,7 @@ package state_deployment
 
 import (
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/metricbeat/helper"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/mb/parse"
@@ -41,7 +41,7 @@ type MetricSet struct {
 // Part of new is also setting up the configuration by processing additional
 // configuration entries if needed.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Beta("The kubernetes state_deployment metricset is beta")
+	cfgwarn.Beta("The kubernetes state_deployment metricset is beta")
 
 	return &MetricSet{
 		BaseMetricSet: base,

--- a/metricbeat/module/kubernetes/state_node/state_node.go
+++ b/metricbeat/module/kubernetes/state_node/state_node.go
@@ -2,7 +2,7 @@ package state_node
 
 import (
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/metricbeat/helper"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/mb/parse"
@@ -41,7 +41,7 @@ type MetricSet struct {
 // Part of new is also setting up the configuration by processing additional
 // configuration entries if needed.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Beta("The kubernetes state_node metricset is beta")
+	cfgwarn.Beta("The kubernetes state_node metricset is beta")
 
 	return &MetricSet{
 		BaseMetricSet: base,

--- a/metricbeat/module/kubernetes/state_pod/state_pod.go
+++ b/metricbeat/module/kubernetes/state_pod/state_pod.go
@@ -2,7 +2,7 @@ package state_pod
 
 import (
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/metricbeat/helper"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/mb/parse"
@@ -41,7 +41,7 @@ type MetricSet struct {
 // Part of new is also setting up the configuration by processing additional
 // configuration entries if needed.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Beta("The kubernetes state_pod metricset is beta")
+	cfgwarn.Beta("The kubernetes state_pod metricset is beta")
 
 	return &MetricSet{
 		BaseMetricSet: base,

--- a/metricbeat/module/kubernetes/state_replicaset/state_replicaset.go
+++ b/metricbeat/module/kubernetes/state_replicaset/state_replicaset.go
@@ -2,7 +2,7 @@ package state_replicaset
 
 import (
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/metricbeat/helper"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/mb/parse"
@@ -41,7 +41,7 @@ type MetricSet struct {
 // Part of new is also setting up the configuration by processing additional
 // configuration entries if needed.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Beta("The kubernetes state_replicaset metricset is beta")
+	cfgwarn.Beta("The kubernetes state_replicaset metricset is beta")
 
 	return &MetricSet{
 		BaseMetricSet: base,

--- a/metricbeat/module/kubernetes/system/system.go
+++ b/metricbeat/module/kubernetes/system/system.go
@@ -2,7 +2,7 @@ package system
 
 import (
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/metricbeat/helper"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/mb/parse"
@@ -41,7 +41,7 @@ type MetricSet struct {
 // Part of new is also setting up the configuration by processing additional
 // configuration entries if needed.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Beta("The kubernetes system metricset is beta")
+	cfgwarn.Beta("The kubernetes system metricset is beta")
 	return &MetricSet{
 		BaseMetricSet: base,
 		http:          helper.NewHTTP(base),

--- a/metricbeat/module/kubernetes/volume/volume.go
+++ b/metricbeat/module/kubernetes/volume/volume.go
@@ -2,7 +2,7 @@ package volume
 
 import (
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/metricbeat/helper"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/mb/parse"
@@ -41,7 +41,7 @@ type MetricSet struct {
 // Part of new is also setting up the configuration by processing additional
 // configuration entries if needed.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Beta("The kubernetes volume metricset is beta")
+	cfgwarn.Beta("The kubernetes volume metricset is beta")
 	return &MetricSet{
 		BaseMetricSet: base,
 		http:          helper.NewHTTP(base),

--- a/metricbeat/module/memcached/stats/stats.go
+++ b/metricbeat/module/memcached/stats/stats.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/metricbeat/mb"
 )
 
@@ -21,7 +21,7 @@ type MetricSet struct {
 }
 
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Beta("The memcached stats metricset is beta")
+	cfgwarn.Beta("The memcached stats metricset is beta")
 
 	return &MetricSet{
 		BaseMetricSet: base,

--- a/metricbeat/module/mongodb/dbstats/dbstats.go
+++ b/metricbeat/module/mongodb/dbstats/dbstats.go
@@ -6,6 +6,7 @@ import (
 	"gopkg.in/mgo.v2"
 
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/module/mongodb"
@@ -34,7 +35,7 @@ type MetricSet struct {
 // Part of new is also setting up the configuration by processing additional
 // configuration entries if needed.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Experimental("The %v %v metricset is experimental", base.Module().Name(), base.Name())
+	cfgwarn.Experimental("The %v %v metricset is experimental", base.Module().Name(), base.Name())
 
 	dialInfo, err := mgo.ParseURL(base.HostData().URI)
 	if err != nil {

--- a/metricbeat/module/php_fpm/pool/pool.go
+++ b/metricbeat/module/php_fpm/pool/pool.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/metricbeat/helper"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/mb/parse"
@@ -39,7 +39,7 @@ type MetricSet struct {
 
 // New create a new instance of the MetricSet
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Beta("The php_fpm pool metricset is beta")
+	cfgwarn.Beta("The php_fpm pool metricset is beta")
 
 	return &MetricSet{
 		base,

--- a/metricbeat/module/prometheus/collector/collector.go
+++ b/metricbeat/module/prometheus/collector/collector.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/metricbeat/helper"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/mb/parse"
@@ -36,7 +36,7 @@ type MetricSet struct {
 }
 
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Beta("The prometheus collector metricset is beta")
+	cfgwarn.Beta("The prometheus collector metricset is beta")
 
 	config := struct {
 		Namespace string `config:"namespace" validate:"required"`

--- a/metricbeat/module/prometheus/stats/stats.go
+++ b/metricbeat/module/prometheus/stats/stats.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/metricbeat/helper"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/mb/parse"
@@ -34,7 +34,7 @@ type MetricSet struct {
 }
 
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Beta("The prometheus stats metricset is beta")
+	cfgwarn.Beta("The prometheus stats metricset is beta")
 
 	return &MetricSet{
 		BaseMetricSet: base,

--- a/metricbeat/module/rabbitmq/node/node.go
+++ b/metricbeat/module/rabbitmq/node/node.go
@@ -2,7 +2,7 @@ package node
 
 import (
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/metricbeat/helper"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/mb/parse"
@@ -32,7 +32,7 @@ type MetricSet struct {
 }
 
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Experimental("The rabbitmq node metricset is experimental")
+	cfgwarn.Experimental("The rabbitmq node metricset is experimental")
 
 	http := helper.NewHTTP(base)
 	http.SetHeader("Accept", "application/json")

--- a/metricbeat/module/redis/_meta/config.yml
+++ b/metricbeat/module/redis/_meta/config.yml
@@ -21,9 +21,9 @@
   #maxconn: 10
 
   # Filters can be used to reduce the number of fields sent.
-  #filters:
+  #processors:
   #  - include_fields:
-  #      fields: ["stats"]
+  #      fields: ["beat", "metricset", "redis.info.stats"]
 
   # Redis AUTH password. Empty by default.
   #password: foobared

--- a/metricbeat/module/system/_meta/config.yml
+++ b/metricbeat/module/system/_meta/config.yml
@@ -20,5 +20,6 @@
   metricsets:
     - filesystem
     - fsstat
-  filters:
-    - drop_event.when.regexp.mount_point: '^/(sys|cgroup|proc|dev|etc|host|lib)($|/)'
+  processors:
+  - drop_event.when.regexp:
+      system.filesystem.mount_point: '^/(sys|cgroup|proc|dev|etc|host|lib)($|/)'

--- a/metricbeat/module/system/core/config.go
+++ b/metricbeat/module/system/core/config.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
 )
 
 // Core metric types.
@@ -23,7 +23,7 @@ type Config struct {
 // Validate validates the core config.
 func (c Config) Validate() error {
 	if c.CPUTicks != nil {
-		logp.Deprecate("6.1", "cpu_ticks is deprecated. Add 'ticks' to the core.metrics list.")
+		cfgwarn.Deprecate("6.1", "cpu_ticks is deprecated. Add 'ticks' to the core.metrics list.")
 	}
 
 	if len(c.Metrics) == 0 {

--- a/metricbeat/module/system/cpu/config.go
+++ b/metricbeat/module/system/cpu/config.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
 )
 
 // CPU metric types.
@@ -24,7 +24,7 @@ type Config struct {
 // Validate validates the cpu config.
 func (c Config) Validate() error {
 	if c.CPUTicks != nil {
-		logp.Deprecate("6.1", "cpu_ticks is deprecated. Add 'ticks' to the cpu.metrics list.")
+		cfgwarn.Deprecate("6.1", "cpu_ticks is deprecated. Add 'ticks' to the cpu.metrics list.")
 	}
 
 	if len(c.Metrics) == 0 {

--- a/metricbeat/module/system/process/config.go
+++ b/metricbeat/module/system/process/config.go
@@ -1,6 +1,6 @@
 package process
 
-import "github.com/elastic/beats/libbeat/logp"
+import "github.com/elastic/beats/libbeat/common/cfgwarn"
 
 // includeTopConfig is the configuration for the "top N processes
 // filtering" feature
@@ -22,7 +22,7 @@ type Config struct {
 
 func (c Config) Validate() error {
 	if c.CPUTicks != nil {
-		logp.Deprecate("6.1", "cpu_ticks is deprecated. Use process.include_cpu_ticks instead")
+		cfgwarn.Deprecate("6.1", "cpu_ticks is deprecated. Use process.include_cpu_ticks instead")
 	}
 	return nil
 }

--- a/metricbeat/module/vsphere/datastore/datastore.go
+++ b/metricbeat/module/vsphere/datastore/datastore.go
@@ -5,7 +5,7 @@ import (
 	"net/url"
 
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/metricbeat/mb"
 
 	"github.com/pkg/errors"
@@ -29,7 +29,7 @@ type MetricSet struct {
 }
 
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Experimental("The vsphere datastore metricset is experimental")
+	cfgwarn.Experimental("The vsphere datastore metricset is experimental")
 
 	config := struct {
 		Username string `config:"username"`

--- a/metricbeat/module/vsphere/host/host.go
+++ b/metricbeat/module/vsphere/host/host.go
@@ -5,7 +5,7 @@ import (
 	"net/url"
 
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/metricbeat/mb"
 
 	"github.com/pkg/errors"
@@ -29,7 +29,7 @@ type MetricSet struct {
 }
 
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Experimental("The vsphere host metricset is experimental")
+	cfgwarn.Experimental("The vsphere host metricset is experimental")
 
 	config := struct {
 		Username string `config:"username"`

--- a/metricbeat/module/vsphere/virtualmachine/virtualmachine.go
+++ b/metricbeat/module/vsphere/virtualmachine/virtualmachine.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/metricbeat/mb"
 
 	"github.com/pkg/errors"
@@ -33,7 +33,7 @@ type MetricSet struct {
 }
 
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Experimental("The vsphere virtualmachine metricset is experimental")
+	cfgwarn.Experimental("The vsphere virtualmachine metricset is experimental")
 
 	config := struct {
 		Username        string `config:"username"`

--- a/metricbeat/module/windows/perfmon/perfmon.go
+++ b/metricbeat/module/windows/perfmon/perfmon.go
@@ -9,7 +9,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/metricbeat/mb"
 )
 
@@ -33,7 +33,7 @@ type MetricSet struct {
 
 // New create a new instance of the MetricSet.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Beta("The perfmon metricset is beta")
+	cfgwarn.Beta("The perfmon metricset is beta")
 
 	config := struct {
 		CounterConfig []CounterConfig `config:"perfmon.counters" validate:"required"`

--- a/metricbeat/modules.d/redis.yml.disabled
+++ b/metricbeat/modules.d/redis.yml.disabled
@@ -21,9 +21,9 @@
   #maxconn: 10
 
   # Filters can be used to reduce the number of fields sent.
-  #filters:
+  #processors:
   #  - include_fields:
-  #      fields: ["stats"]
+  #      fields: ["beat", "metricset", "redis.info.stats"]
 
   # Redis AUTH password. Empty by default.
   #password: foobared

--- a/metricbeat/modules.d/system.yml
+++ b/metricbeat/modules.d/system.yml
@@ -20,5 +20,6 @@
   metricsets:
     - filesystem
     - fsstat
-  filters:
-    - drop_event.when.regexp.mount_point: '^/(sys|cgroup|proc|dev|etc|host|lib)($|/)'
+  processors:
+  - drop_event.when.regexp:
+      system.filesystem.mount_point: '^/(sys|cgroup|proc|dev|etc|host|lib)($|/)'

--- a/metricbeat/tests/system/test_config.py
+++ b/metricbeat/tests/system/test_config.py
@@ -65,5 +65,23 @@ class ConfigTest(metricbeat.BaseTest):
 
         assert same == True
 
+    def test_invalid_config_with_removed_settings(self):
+        """
+        Checks if metricbeat fails to load a module if remove settings have been used:
+        """
+        self.render_config_template(modules=[{
+            "name": "system",
+            "metricsets": ["cpu"],
+            "period": "5s",
+        }])
+
+        exit_code = self.run_beat(extra_args=[
+            "-E",
+            "metricbeat.modules.0.filters.0.include_fields='field1,field2'"
+        ])
+        assert exit_code == 1
+        assert self.log_contains("setting 'metricbeat.modules.0.filters'"
+                                 " has been removed")
+
     def get_host(self):
         return 'http://' + os.getenv('ELASTICSEARCH_HOST', 'localhost') + ':' + os.getenv('ELASTICSEARCH_PORT', '9200')

--- a/packetbeat/protos/protos.go
+++ b/packetbeat/protos/protos.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/publisher/beat"
 )
@@ -97,7 +98,7 @@ func (s ProtocolsStruct) Init(
 	listConfigs []*common.Config,
 ) error {
 	if len(configs) > 0 {
-		logp.Deprecate("7.0.0", "dictionary style protocols configuration has been deprecated. Please use list-style protocols configuration.")
+		cfgwarn.Deprecate("7.0.0", "dictionary style protocols configuration has been deprecated. Please use list-style protocols configuration.")
 	}
 
 	for proto := range protocolSyms {


### PR DESCRIPTION
- Introduce cfgwarn package
- move Beta/Deprecated/Experimental to from `logp` to `cfgwarn`
- introduce CheckRemoved5xSettings looking for removed settings in a config object + constructs an error message with completely expanded setting name
- use CheckRemoved5xSettigns in libbeat/filebeat/metricbeat to fail on startup if any settings removed by publisher refactoring is used
- Add system tests for libbeat/filebeat/metricbeat checking removed settings are correctly identified.