### PR TITLE
Mark audit metricsets as beta

### DIFF
--- a/auditbeat/module/audit/file/metricset.go
+++ b/auditbeat/module/audit/file/metricset.go
@@ -45,7 +45,7 @@ type MetricSet struct {
 }
 
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Experimental("The %v metricset is an experimental feature", metricsetName)
+	logp.Beta("The %v metricset is an beta feature", metricsetName)
 
 	config := defaultConfig
 	if err := base.Module().UnpackConfig(&config); err != nil {

--- a/auditbeat/module/audit/kernel/audit_linux.go
+++ b/auditbeat/module/audit/kernel/audit_linux.go
@@ -20,10 +20,6 @@ import (
 const (
 	metricsetName = "audit.kernel"
 	logPrefix     = "[" + metricsetName + "]"
-
-	reassemblerMaxInFlight = 5
-	reassemblerTimeout     = 2 * time.Second
-	streamBufferLen        = 64
 )
 
 var (
@@ -51,7 +47,7 @@ type MetricSet struct {
 
 // New constructs a new MetricSet.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logp.Experimental("The %v metricset is a beta feature", metricsetName)
+	logp.Beta("The %v metricset is a beta feature", metricsetName)
 
 	config := defaultConfig
 	if err := base.Module().UnpackConfig(&config); err != nil {
@@ -184,8 +180,8 @@ func (ms *MetricSet) receiveEvents(done <-chan struct{}) (<-chan []*auparse.Audi
 		return nil, err
 	}
 
-	out := make(chan []*auparse.AuditMessage, streamBufferLen)
-	reassembler, err := libaudit.NewReassembler(reassemblerMaxInFlight, reassemblerTimeout, &stream{done, out})
+	out := make(chan []*auparse.AuditMessage, ms.config.StreamBufferQueueSize)
+	reassembler, err := libaudit.NewReassembler(int(ms.config.ReassemblerMaxInFlight), ms.config.ReassemblerTimeout, &stream{done, out})
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create Reassembler")
 	}
@@ -305,22 +301,24 @@ func buildMapStr(msgs []*auparse.AuditMessage, config Config) (common.MapStr, er
 	if len(event.Socket) > 0 {
 		m.Put("socket", event.Socket)
 	}
-	if config.RawMessage {
-		addMessages(msgs, m)
-	}
 	if config.Warnings && len(event.Warnings) > 0 {
 		warnings := make([]string, 0, len(event.Warnings))
 		for _, err := range event.Warnings {
 			warnings = append(warnings, err.Error())
 		}
 		m.Put("warnings", warnings)
+		addMessages(msgs, m)
+	}
+	if config.RawMessage {
+		addMessages(msgs, m)
 	}
 
 	return m, nil
 }
 
 func addMessages(msgs []*auparse.AuditMessage, m common.MapStr) {
-	if len(msgs) > 0 {
+	_, added := m["messages"]
+	if !added && len(msgs) > 0 {
 		rawMsgs := make([]string, 0, len(msgs))
 		for _, msg := range msgs {
 			rawMsgs = append(rawMsgs, "type="+msg.RecordType.String()+" msg="+msg.RawData)
@@ -347,5 +345,5 @@ func (s *stream) ReassemblyComplete(msgs []*auparse.AuditMessage) {
 }
 
 func (s *stream) EventsLost(count int) {
-	lostMetric.Add(int64(count))
+	lostMetric.Inc()
 }

--- a/auditbeat/module/audit/kernel/config.go
+++ b/auditbeat/module/audit/kernel/config.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"strings"
+	"time"
 
 	"github.com/joeshaw/multierror"
 	"github.com/pkg/errors"
@@ -21,6 +22,11 @@ type Config struct {
 	RawMessage   bool   `config:"kernel.include_raw_message"` // Include the list of raw audit messages in the event.
 	Warnings     bool   `config:"kernel.include_warnings"`    // Include warnings in the event (for dev/debug purposes only).
 	RulesBlob    string `config:"kernel.audit_rules"`         // Audit rules. One rule per line.
+
+	// Tuning options (advanced, use with care)
+	ReassemblerMaxInFlight uint32        `config:"kernel.reassembler.max_in_flight"`
+	ReassemblerTimeout     time.Duration `config:"kernel.reassembler.timeout"`
+	StreamBufferQueueSize  uint32        `config:"kernel.reassembler.queue_size"`
 }
 
 type auditRule struct {
@@ -100,10 +106,13 @@ func (c Config) failureMode() (uint32, error) {
 }
 
 var defaultConfig = Config{
-	ResolveIDs:   true,
-	FailureMode:  "silent",
-	BacklogLimit: 8192,
-	RateLimit:    0,
-	RawMessage:   false,
-	Warnings:     false,
+	ResolveIDs:             true,
+	FailureMode:            "silent",
+	BacklogLimit:           8192,
+	RateLimit:              0,
+	RawMessage:             false,
+	Warnings:               false,
+	ReassemblerMaxInFlight: 50,
+	ReassemblerTimeout:     2 * time.Second,
+	StreamBufferQueueSize:  64,
 }


### PR DESCRIPTION
- Change log messages from experimental to beta.

- Make reassembler tuning constants controllable via config and increase the default max_in_flight from 5 to 50. Someone might need to tune these so I'm making them configurable. Will add docs in a separate PR.

- When `include_warnings` is enabled and a warning message is present, the raw messages will now always be added to the event regardless of the `include_raw_message` setting. These raw message will be critical to understanding the root cause of the warning and debugging it after the fact.