### PR TITLE
Add HasKey method to Fields

### DIFF
--- a/libbeat/template/fields.go
+++ b/libbeat/template/fields.go
@@ -1,6 +1,10 @@
 package template
 
-import "github.com/elastic/beats/libbeat/common"
+import (
+	"strings"
+
+	"github.com/elastic/beats/libbeat/common"
+)
 
 var (
 	defaultType = "keyword"
@@ -59,4 +63,39 @@ func (f Fields) process(path string, esVersion common.Version) common.MapStr {
 	}
 
 	return output
+}
+
+// HasKey checks if inside fields the given key exists
+// The key can be in the form of a.b.c and it will check if the nested field exist
+// In case the key is `a` and there is a value `a.b` false is return as it only
+// returns true if it's a leave node
+func (f Fields) HasKey(key string) bool {
+	keys := strings.Split(key, ".")
+	return f.hasKey(keys)
+}
+
+func (f Fields) hasKey(keys []string) bool {
+	// Nothing to compare anymore
+	if len(keys) == 0 {
+		return false
+	}
+
+	key := keys[0]
+	keys = keys[1:]
+
+	for _, field := range f {
+		if field.Name == key {
+
+			if len(field.Fields) > 0 {
+				return field.Fields.hasKey(keys)
+			}
+			// Last entry in the tree but still more keys
+			if len(keys) > 0 {
+				return false
+			}
+
+			return true
+		}
+	}
+	return false
 }

--- a/libbeat/template/fields_test.go
+++ b/libbeat/template/fields_test.go
@@ -1,0 +1,60 @@
+package template
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHasKey(t *testing.T) {
+
+	tests := []struct {
+		key    string
+		fields Fields
+		result bool
+	}{
+		{
+			key:    "test.find",
+			fields: Fields{},
+			result: false,
+		},
+		{
+			key: "test.find",
+			fields: Fields{
+				Field{Name: "test"},
+				Field{Name: "find"},
+			},
+			result: false,
+		},
+		{
+			key: "test.find",
+			fields: Fields{
+				Field{
+					Name: "test", Fields: Fields{
+						Field{
+							Name: "find",
+						},
+					},
+				},
+			},
+			result: true,
+		},
+		{
+			key: "test",
+			fields: Fields{
+				Field{
+					Name: "test", Fields: Fields{
+						Field{
+							Name: "find",
+						},
+					},
+				},
+			},
+			result: false,
+		},
+	}
+
+	for _, test := range tests {
+		assert.Equal(t, test.result, test.fields.HasKey(test.key))
+	}
+}


### PR DESCRIPTION
This can be used for checks if a specific key exists in a Fields array. This becomes useful for checking if all fields are documented for example.