### PR TITLE
Add pattern option in the fields.yml

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -83,6 +83,7 @@ https://github.com/elastic/beats/compare/v6.0.0-alpha2...master[Check the HEAD d
 - Enable pipelining in Logstash output by default. {pull}4650[4650]
 - Added 'result' field to Elasticsearch QueryResult struct for compatibility with 6.x Index and Delete API responses. {issue]4661[4661]
 - The sample dashboards are now included in the Beats packages. {pull}4675[4675]
+- Add `pattern` option to be used in the fields.yml to specify the pattern for a number field. {pull}4731[4731]
 
 *Filebeat*
 

--- a/libbeat/scripts/generate_index_pattern.py
+++ b/libbeat/scripts/generate_index_pattern.py
@@ -73,10 +73,18 @@ def field_to_json(fields, desc, path, output,
 
     output["fields"].append(field)
 
-    if "format" in desc:
-        output["fieldFormatMap"][path] = {
-            "id": desc["format"],
-        }
+    if "format" in desc or "pattern" in desc:
+        fieldFormat = {}
+
+        if "format" in desc:
+            fieldFormat["id"] = desc["format"]
+
+        if "pattern" in desc:
+            fieldFormat["params"] = {
+                "pattern": desc["pattern"]
+            }
+
+        output["fieldFormatMap"][path] = fieldFormat
 
 
 def fields_to_index_pattern(version, args, input):


### PR DESCRIPTION
This PR adds the `pattern` option to be used in `fields.yml`. The `pattern` option is used to generate the index pattern with the right pattern for a number field.

cc-ed @ruflin 