### PR TITLE
Changes to enable building GS "mini-book"

### DIFF
--- a/filebeat/docs/getting-started.asciidoc
+++ b/filebeat/docs/getting-started.asciidoc
@@ -17,9 +17,9 @@ After installing the Elastic Stack, read the following topics to learn how to in
 * <<filebeat-template>>
 * <<filebeat-starting>>
 * <<filebeat-index-pattern>>
-* <<filebeat-modules-quickstart>>
-* <<command-line-options>>
-* <<directory-layout>>
+* {filebeat}/filebeat-modules-quickstart.html[Quick Start for Common Log Formats]
+* {filebeat}/command-line-options.html[Command Line Options]
+* {filebeat}/directory-layout.html[Directory Layout]
 
 [[filebeat-installation]]
 === Step 1: Installing Filebeat
@@ -140,12 +140,11 @@ endif::[]
 [[filebeat-configuration]]
 === Step 2: Configuring Filebeat
 
-TIP: <<filebeat-modules-overview,Filebeat modules>> provide the fastest getting
-started experience for common log formats. See <<filebeat-modules-quickstart>>
-to learn how to get started with modules. If you use Filebeat modules to get
+TIP: {filebeat}/filebeat-modules-overview.html[Filebeat modules] provide the fastest getting
+started experience for common log formats. See {filebeat}/filebeat-modules-quickstart.html[Quick
+Start for Common Log Formats] to learn how to get started with modules. If you use Filebeat modules to get
 started, you can skip the content in this section, including the remaining
-getting started steps, and go directly to the <<filebeat-modules-quickstart>>
-page. 
+getting started steps, and go directly to the {filebeat}/filebeat-modules-quickstart.html[Quick Start for Common Log Formats] page. 
 
 include::../../libbeat/docs/shared-configuring.asciidoc[]
 
@@ -197,13 +196,13 @@ If you are sending output to Logstash, see <<config-filebeat-logstash>> instead.
 TIP: To test your configuration file, change to the directory where the Filebeat
 binary is installed, and run Filebeat in the foreground with the following
 options specified: +./filebeat -configtest -e+. Make sure your config files are
-in the path expected by Filebeat (see <<directory-layout>>). If you
+in the path expected by Filebeat (see {filebeat}/directory-layout.html[Directory Layout]). If you
 installed from DEB or RPM packages, run +./filebeat.sh -configtest -e+.
 
 Before starting Filebeat, you should look at the configuration options in the
 configuration file, for example `C:\Program Files\Filebeat\filebeat.yml` or
 `/etc/filebeat/filebeat.yml`. For more information about these options,
-see <<filebeat-configuration-details>>.
+see {filebeat}/filebeat-configuration-details.html[Configuration Options].
 
 [[config-filebeat-logstash]]
 === Step 3: Configuring Filebeat to Use Logstash
@@ -223,7 +222,7 @@ include::../../libbeat/docs/shared-template-load.asciidoc[]
 Start Filebeat by issuing the appropriate command for your platform. 
 
 NOTE: If you use an init.d script to start Filebeat on deb or rpm, you can't
-specify command line flags (see <<command-line-options>>). To specify flags,
+specify command line flags (see {filebeat}/command-line-options.html[Command Line Options]). To specify flags,
 start Filebeat in the foreground.
 
 *deb:*

--- a/filebeat/docs/index.asciidoc
+++ b/filebeat/docs/index.asciidoc
@@ -14,6 +14,8 @@ include::../../libbeat/docs/version.asciidoc[]
 :version: {stack-version}
 :beatname_lc: filebeat
 :beatname_uc: Filebeat
+:directory-layout: http://www.elastic.co/guide/en/beats/{beatname_lc}/{doc-branch}/directory-layout.html
+:setup-repositories: http://www.elastic.co/guide/en/beats/{beatname_lc}/{doc-branch}/setup-repositories.html
 :security: X-Pack Security
 :dockerimage: docker.elastic.co/beats/{beatname_lc}:{version}
 

--- a/filebeat/docs/overview.asciidoc
+++ b/filebeat/docs/overview.asciidoc
@@ -8,7 +8,8 @@ Here's how Filebeat works: When you start Filebeat, it starts one or more prospe
 
 image:./images/filebeat.png[Beats design]
 
-For more information about prospectors and harvesters, see <<how-filebeat-works>>.
+For more information about prospectors and harvesters, see {filebeat}/how-filebeat-works[
+How Filebeat Works].
 
 Filebeat is a https://www.elastic.co/products/beats[Beat], and it is based on the libbeat framework.
 General information about libbeat and setting up Elasticsearch, Logstash, and Kibana are covered in the {libbeat}/index.html[Beats Platform Reference].

--- a/heartbeat/docs/getting-started.asciidoc
+++ b/heartbeat/docs/getting-started.asciidoc
@@ -18,8 +18,8 @@ install, configure, and run Heartbeat:
 * <<heartbeat-configuration>>
 * <<heartbeat-template>>
 * <<heartbeat-starting>>
-* <<command-line-options>>
-* <<directory-layout>>
+* {heartbeat}/command-line-options.html[Command Line Options]
+* {heartbeat}/directory-layout.html[Directory Layout]
 
 
 [[heartbeat-installation]]
@@ -151,7 +151,7 @@ endif::[]
 Before starting Heartbeat, you should look at the configuration options in
 the configuration file, for example +C:\Program Files\Heartbeat\heartbeat.yml+
 or +/etc/heartbeat/heartbeat.yml+. For more information about these
-options, see <<heartbeat-configuration-details>>.
+options, see {heartbeat}/heartbeat-configuration-details.html[Configuration Options].
 
 [[heartbeat-configuration]]
 === Step 2: Configuring Heartbeat
@@ -200,8 +200,8 @@ was started. Heartbeat adds the `@every` keyword to the syntax provided by the
 <3> The `mode` specifies whether to ping one IP (`any`) or all resolvable IPs
 (`all`).
 +
-See <<heartbeat-configuration-details>> for a full description of each
-configuration option.
+See {heartbeat}/heartbeat-configuration-details.html[Configuration Options]
+for a full description of each configuration option.
 
 . If you are sending output to Elasticsearch, set the IP address and port where
 Heartbeat can find the Elasticsearch installation:
@@ -212,14 +212,14 @@ output.elasticsearch:
   hosts: ["192.168.1.42:9200"]
 ----------------------------------------------------------------------
 +
-If you are sending output to Logstash, see <<config-heartbeat-logstash>>
-instead.
+If you are sending output to Logstash, see {heartbeat}/config-heartbeat-logstash.html[
+Configuring Heartbeat to use Logstash] instead.
 
 TIP: To test your configuration file, change to the directory where the
 Heartbeat binary is installed, and run Heartbeat in the foreground with
 the following options specified: +./heartbeat -configtest -e+. Make sure
 your config files are in the path expected by Heartbeat
-(see <<directory-layout>>). If you installed from DEB or RPM packages, run
+(see {heartbeat}/directory-layout.html[Directory Layout]). If you installed from DEB or RPM packages, run
 +./heartbeat.sh -configtest -e+.
 
 [[heartbeat-template]]
@@ -234,7 +234,7 @@ include::../../libbeat/docs/shared-template-load.asciidoc[]
 Start Heartbeat by issuing the appropriate command for your platform.
 
 NOTE: If you use an init.d script to start Heartbeat on deb or rpm, you can't
-specify command line flags (see <<command-line-options>>). To specify flags,
+specify command line flags (see {heartbeat}/command-line-options.html[Command Line Options]). To specify flags,
 start Heartbeat in the foreground.
 
 *deb:*

--- a/heartbeat/docs/index.asciidoc
+++ b/heartbeat/docs/index.asciidoc
@@ -6,6 +6,7 @@ include::../../libbeat/docs/version.asciidoc[]
 :packetbeat: http://www.elastic.co/guide/en/beats/packetbeat/{doc-branch}
 :metricbeat: http://www.elastic.co/guide/en/beats/metricbeat/{doc-branch}
 :filebeat: http://www.elastic.co/guide/en/beats/filebeat/{doc-branch}
+:heartbeat: http://www.elastic.co/guide/en/beats/heartbeat/{doc-branch}
 :winlogbeat: http://www.elastic.co/guide/en/beats/winlogbeat/{doc-branch}
 :logstashdoc: https://www.elastic.co/guide/en/logstash/{doc-branch}
 :elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/{doc-branch}
@@ -14,6 +15,8 @@ include::../../libbeat/docs/version.asciidoc[]
 :version: {stack-version}
 :beatname_lc: heartbeat
 :beatname_uc: Heartbeat
+:directory-layout: http://www.elastic.co/guide/en/beats/{beatname_lc}/{doc-branch}/directory-layout.html
+:setup-repositories: http://www.elastic.co/guide/en/beats/{beatname_lc}/{doc-branch}/setup-repositories.html
 :security: X-Pack Security
 :dockerimage: docker.elastic.co/beats/{beatname_lc}:{version}
 

--- a/libbeat/docs/communitybeats.asciidoc
+++ b/libbeat/docs/communitybeats.asciidoc
@@ -82,4 +82,4 @@ https://discuss.elastic.co/c/beats/community-beats[Community Beats] category of 
 [[contributing-beats]]
 === Contributing to Beats
 
-Remember, you can be a Beats developer, too. <<new-beat, Learn how>>
+Remember, you can be a Beats developer, too. {libbeat}/new-beat.html[Learn how]

--- a/libbeat/docs/gs-index.asciidoc
+++ b/libbeat/docs/gs-index.asciidoc
@@ -1,0 +1,41 @@
+[[beats-reference]]
+= Beats Reference
+
+include::./version.asciidoc[]
+
+:packetbeat: http://www.elastic.co/guide/en/beats/packetbeat/{doc-branch}
+:metricbeat: http://www.elastic.co/guide/en/beats/metricbeat/{doc-branch}
+:filebeat: http://www.elastic.co/guide/en/beats/filebeat/{doc-branch}
+:winlogbeat: http://www.elastic.co/guide/en/beats/winlogbeat/{doc-branch}
+:heartbeat: http://www.elastic.co/guide/en/beats/heartbeat/{doc-branch}
+:securitydoc: https://www.elastic.co/guide/en/x-pack/5.2
+:beatname_lc: beatname
+:beatname_uc: a Beat
+:directory-layout: http://www.elastic.co/guide/en/beats/{beatname_lc}/{doc-branch}/directory-layout.html
+:setup-repositories: http://www.elastic.co/guide/en/beats/{beatname_lc}/{doc-branch}/setup-repositories.html
+:security: X-Pack Security
+:ES-version: {stack-version}
+:LS-version: {stack-version}
+:Kibana-version: {stack-version}
+:dashboards: https://artifacts.elastic.co/downloads/beats/beats-dashboards/beats-dashboards-{stack-version}.zip
+
+include::./overview.asciidoc[]
+
+include::./communitybeats.asciidoc[]
+
+include::./gettingstarted.asciidoc[]
+
+include::./installing-beats.asciidoc[]
+
+include::../../packetbeat/docs/overview.asciidoc[]
+include::../../packetbeat/docs/gettingstarted.asciidoc[]
+include::../../metricbeat/docs/overview.asciidoc[]
+include::../../metricbeat/docs/gettingstarted.asciidoc[]
+include::../../filebeat/docs/overview.asciidoc[]
+include::../../filebeat/docs/getting-started.asciidoc[]
+include::../../winlogbeat/docs/overview.asciidoc[]
+include::../../winlogbeat/docs/getting-started.asciidoc[]
+include::../../heartbeat/docs/overview.asciidoc[]
+include::../../heartbeat/docs/getting-started.asciidoc[]
+
+

--- a/libbeat/docs/shared-download-and-install.asciidoc
+++ b/libbeat/docs/shared-download-and-install.asciidoc
@@ -5,8 +5,8 @@ Windows).
 
 [NOTE]
 ==================================================
-If you use Apt or Yum, you can <<setup-repositories,install {beatname_uc} from our
-repositories>> to update to the newest version more easily.
+If you use Apt or Yum, you can {<setup-repositories}[install {beatname_uc} from our
+repositories] to update to the newest version more easily.
 
 See our https://www.elastic.co/downloads/beats/{beatname_lc}[download page] for
 other installation options, such as 32-bit images.

--- a/libbeat/docs/shared-logstash-config.asciidoc
+++ b/libbeat/docs/shared-logstash-config.asciidoc
@@ -38,7 +38,7 @@ ifdef::allplatforms[]
 TIP: To test your configuration file, change to the directory where the {beatname_uc} 
 binary is installed, and run {beatname_uc} in the foreground with the following
 options specified: +./{beatname_lc} -configtest -e+. Make sure your config files are
-in the path expected by {beatname_uc} (see <<directory-layout>>). If you
+in the path expected by {beatname_uc} (see {directory-layout}[Directory Layout]). If you
 installed from DEB or RPM packages, run +./{beatname_lc}.sh -configtest -e+.
 
 endif::allplatforms[]

--- a/metricbeat/docs/gettingstarted.asciidoc
+++ b/metricbeat/docs/gettingstarted.asciidoc
@@ -20,8 +20,8 @@ After installing the Elastic Stack, read the following topics to learn how to in
 * <<metricbeat-template>>
 * <<metricbeat-starting>>
 * <<metricbeat-sample-dashboards>>
-* <<command-line-options>>
-* <<directory-layout>>
+* {metricbeat}/command-line-options.html[Command Line Options]
+* {metricbeat}/directory-layout.html[Directory Layout]
 
 [[metricbeat-installation]]
 === Step 1: Installing Metricbeat
@@ -152,14 +152,14 @@ endif::[]
 Before starting Metricbeat, you should look at the configuration options in the
 configuration file, for example `C:\Program Files\Metricbeat\metricbeat.yml`.
 For more information about these options, see
-<<metricbeat-configuration-options>>.
+{metricbeat}/metricbeat-configuration-options.html[Configuration Options].
 
 [[metricbeat-configuration]]
 === Step 2: Configuring Metricbeat
 
 include::../../libbeat/docs/shared-configuring.asciidoc[]
 
-Metricbeat uses <<metricbeat-modules,modules>> to collect metrics. You configure
+Metricbeat uses {metricbeat}/metricbeat-modules.html[modules] to collect metrics. You configure
 each module individually. The following example shows the default configuration
 in the `metricbeat.yml` file. The system status module is enabled by default to
 collect metrics about your server, such as CPU usage, memory usage, network IO
@@ -208,8 +208,8 @@ metricbeat.modules:
 To configure Metricbeat:
 
 . Define the Metricbeat modules that you want to enable. For each module, specify
-the metricsets that you want to collect. See <<configuring-howto-metricbeat>> for
-more details about configuring modules.
+the metricsets that you want to collect. See {metricbeat}/configuring-howto-metricbeat.html[
+Configuring {beatname_uc}] for more details about configuring modules.
 +
 If you accept the default configuration without specifying additional modules,
 Metricbeat will collect system metrics only.
@@ -223,8 +223,8 @@ output.elasticsearch:
   hosts: ["192.168.1.42:9200"]
 ----------------------------------------------------------------------
 +
-If you are sending output to Logstash, see <<config-metricbeat-logstash>>
-instead.
+If you are sending output to Logstash, see {metricbeat}/config-metricbeat-logstash.html[
+Configuring Metricbeat to use Logstash] instead.
 
 [[metricbeat-template]]
 === Step 3: Loading the Index Template in Elasticsearch
@@ -238,7 +238,7 @@ include::../../libbeat/docs/shared-template-load.asciidoc[]
 Run Metricbeat by issuing the appropriate command for your platform.
 
 NOTE: If you use an init.d script to start Metricbeat on deb or rpm, you can't
-specify command line flags (see <<command-line-options>>). To specify flags,
+specify command line flags (see {metricbeat}/command-line-options.html[Command Line Options]). To specify flags,
 start Metricbeat in the foreground.
 
 *deb:*

--- a/metricbeat/docs/index.asciidoc
+++ b/metricbeat/docs/index.asciidoc
@@ -4,12 +4,15 @@ include::../../libbeat/docs/version.asciidoc[]
 
 :libbeat: http://www.elastic.co/guide/en/beats/libbeat/{doc-branch}
 :filebeat: http://www.elastic.co/guide/en/beats/filebeat/{doc-branch}
+:metricbeat: http://www.elastic.co/guide/en/beats/metricbeat/{doc-branch}
 :logstashdoc: https://www.elastic.co/guide/en/logstash/{doc-branch}
 :elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/{doc-branch}
 :securitydoc: https://www.elastic.co/guide/en/x-pack/5.2
 :version: {stack-version}
 :beatname_lc: metricbeat
 :beatname_uc: Metricbeat
+:directory-layout: http://www.elastic.co/guide/en/beats/{beatname_lc}/{doc-branch}/directory-layout.html
+:setup-repositories: http://www.elastic.co/guide/en/beats/{beatname_lc}/{doc-branch}/setup-repositories.html
 :security: X-Pack Security
 :dockerimage: docker.elastic.co/beats/{beatname_lc}:{version}
 

--- a/metricbeat/docs/overview.asciidoc
+++ b/metricbeat/docs/overview.asciidoc
@@ -9,15 +9,15 @@ ships them to the output that you specify, such as Elasticsearch or Logstash.
 Metricbeat helps you monitor your servers by collecting metrics from the system
 and the following services:
 
-  * <<metricbeat-module-apache,Apache>>
-  * <<metricbeat-module-haproxy,HAProxy>>
-  * <<metricbeat-module-mongodb,MongoDB>>
-  * <<metricbeat-module-mysql,MySQL>>
-  * <<metricbeat-module-nginx,Nginx>>
-  * <<metricbeat-module-postgresql,PostgreSQL>>
-  * <<metricbeat-module-redis,Redis>>
-  * <<metricbeat-module-system,System>>
-  * <<metricbeat-module-zookeeper,Zookeeper>>
+  * {metricbeat}/metricbeat-module-apache.html[Apache]
+  * {metricbeat}/metricbeat-module-haproxy.html[HAProxy]
+  * {metricbeat}/metricbeat-module-mongodb.html[MongoDB]
+  * {metricbeat}/metricbeat-module-mysql.html[MySQL]
+  * {metricbeat}/metricbeat-module-nginx.html[Nginx]
+  * {metricbeat}/metricbeat-module-postgresql.html[PostgreSQL]
+  * {metricbeat}/metricbeat-module-redis.html[Redis]
+  * {metricbeat}/metricbeat-module-system.html[System]
+  * {metricbeat}/metricbeat-module-zookeeper.html[Zookeeper]
 
 Metricbeat can insert the collected metrics directly into Elasticsearch
 or send them to Logstash, Redis, or Kafka.

--- a/packetbeat/docs/gettingstarted.asciidoc
+++ b/packetbeat/docs/gettingstarted.asciidoc
@@ -19,8 +19,8 @@ After installing the Elastic Stack, read the following topics to learn how to in
 * <<packetbeat-template>>
 * <<packetbeat-starting>>
 * <<packetbeat-sample-dashboards>>
-* <<command-line-options>>
-* <<directory-layout>>
+* {packetbeat}/command-line-options.html[Command Line Options]
+* {packetbeat}/directory-layout.html[Directory Layout]
 
 [[packetbeat-installation]]
 === Step 1: Installing Packetbeat
@@ -142,7 +142,7 @@ endif::[]
 
 Before starting Packetbeat, you should look at the configuration options in the
 configuration file, for example `C:\Program Files\Packetbeat\packetbeat.yml` or `/etc/packetbeat/packetbeat.yml`. For
-more information about these options, see <<packetbeat-configuration>>.
+more information about these options, see {packetbeat}/packetbeat-configuration.html[Configuration Options].
 
 [[configuring-packetbeat]]
 === Step 2: Configuring Packetbeat
@@ -234,12 +234,13 @@ output.elasticsearch:
   hosts: ["192.168.1.42:9200"]
 ----------------------------------------------------------------------
 +
-If you are sending output to Logstash, see <<config-packetbeat-logstash>> instead.
+If you are sending output to Logstash, see {packetbeat}/config-packetbeat-logstash.html[
+Configuring Packetbeat to use Logstash] instead.
 
 TIP: To test your configuration file, change to the directory where the Packetbeat
 binary is installed, and run Packetbeat in the foreground with the following
 options specified: +sudo ./packetbeat -configtest -e+. Make sure your config files are
-in the path expected by Packetbeat (see <<directory-layout>>). If you
+in the path expected by Packetbeat (see {packetbeat}/directory-layout.html[Directory Layout]). If you
 installed from DEB or RPM packages, run +sudo ./packetbeat.sh -configtest -e+.
 Depending on your OS, you might run into file ownership issues when you run this
 test. See {libbeat}/config-file-permissions.html[Config File Ownership and Permissions]
@@ -257,7 +258,7 @@ include::../../libbeat/docs/shared-template-load.asciidoc[]
 Run Packetbeat by issuing the command that is appropriate for your platform.
 
 NOTE: If you use an init.d script to start Packetbeat on deb or rpm, you can't
-specify command line flags (see <<command-line-options>>). To specify flags,
+specify command line flags (see {packetbeat}/command-line-options.html[Command Line Options]). To specify flags,
 start Packetbeat in the foreground.
 
 *deb:*

--- a/packetbeat/docs/index.asciidoc
+++ b/packetbeat/docs/index.asciidoc
@@ -15,6 +15,8 @@ include::../../libbeat/docs/version.asciidoc[]
 :version: {stack-version}
 :beatname_lc: packetbeat
 :beatname_uc: Packetbeat
+:directory-layout: http://www.elastic.co/guide/en/beats/{beatname_lc}/{doc-branch}/directory-layout.html
+:setup-repositories: http://www.elastic.co/guide/en/beats/{beatname_lc}/{doc-branch}/setup-repositories.html
 :security: X-Pack Security
 :dockerimage: docker.elastic.co/beats/{beatname_lc}:{version}
 

--- a/packetbeat/docs/overview.asciidoc
+++ b/packetbeat/docs/overview.asciidoc
@@ -2,14 +2,14 @@
 == Overview
 
 Packetbeat is a real-time network packet analyzer that you can use 
-with Elasticsearch to provide an _application monitoring and performance
-analytics system_. Packetbeat completes the {libbeat}/index.html[Beats platform] 
+with Elasticsearch to provide an _application monitoring and performance analytics system_.
+Packetbeat completes the {libbeat}/index.html[Beats platform] 
 by providing visibility between the servers of your network.
 
 Packetbeat works by capturing the network traffic between your application servers,
 decoding the application layer protocols (HTTP, MySQL, Redis, and so on),
 correlating the requests with the responses, and recording the
-interesting <<exported-fields,fields>> for each transaction.
+interesting {packetbeat}/exported-fields[fields] for each transaction.
 
 Packetbeat can help you easily notice issues with your back-end application, such as bugs
 or performance problems, and it makes troubleshooting them - and therefore
@@ -28,11 +28,11 @@ Packetbeat can run on the same servers as your application processes or
 on its own servers. When running on dedicated servers, Packetbeat can get the
 traffic from the switch's mirror ports or from tapping devices. In such a
 deployment, there is zero overhead on the monitored application. See
-<<capturing-options>> for details.
+{packetbeat}/capturing-options.html[Setting Traffic Capturing Options] for details.
 
 After decoding the Layer 7 messages, Packetbeat correlates the requests with
 the responses in what we call _transactions_. For each transaction, Packetbeat 
-inserts a JSON document into Elasticsearch. See the <<exported-fields>> section
+inserts a JSON document into Elasticsearch. See the {packetbeat}/exported-fields.html[Exported Fields] section
 for details about which fields are indexed.
 
 The same Elasticsearch and Kibana instances that are used for analysing the

--- a/winlogbeat/docs/getting-started.asciidoc
+++ b/winlogbeat/docs/getting-started.asciidoc
@@ -19,8 +19,8 @@ After installing the Elastic Stack, read the following topics to learn how to in
 * <<winlogbeat-template>>
 * <<winlogbeat-starting>>
 * <<winlogbeat-sample-dashboards>>
-* <<command-line-options>>
-* <<directory-layout>>
+* {winlogbeat}/command-line-options.html[Command Line Options]
+* {winlogbeat}/directory-layout.html[Directory Layout]
 
 [[winlogbeat-installation]]
 === Step 1: Installing Winlogbeat
@@ -59,7 +59,7 @@ Before starting Winlogbeat, you should look at the configuration options in the
 configuration file, for example `C:\Program Files\Winlogbeat\winlogbeat.yml`.
 There’s also a full example configuration file called `winlogbeat.full.yml` that
 shows all non-deprecated options. For more information about these options, see
-<<winlogbeat-configuration-details>>. 
+{winlogbeat}/winlogbeat-configuration-details.html[Configuration Options]. 
 
 [[winlogbeat-configuration]]
 === Step 2: Configuring Winlogbeat
@@ -102,7 +102,7 @@ winlogbeat.event_logs:
 +
 To obtain a list of available event logs, run `Get-EventLog *` in PowerShell.
 For more information about this command, see the configuration details for
-<<configuration-winlogbeat-options-event_logs-name,event_logs.name>>.
+{winlogbeat}/configuration-winlogbeat-options.html#configuration-winlogbeat-options-event_logs-name[event_logs.name].
 
 . If you are sending output to Elasticsearch, set the IP address and port where
 Winlogbeat can find the Elasticsearch installation:

--- a/winlogbeat/docs/index.asciidoc
+++ b/winlogbeat/docs/index.asciidoc
@@ -13,6 +13,8 @@ include::../../libbeat/docs/version.asciidoc[]
 :version: {stack-version}
 :beatname_lc: winlogbeat
 :beatname_uc: Winlogbeat
+:directory-layout: http://www.elastic.co/guide/en/beats/{beatname_lc}/{doc-branch}/directory-layout.html
+:setup-repositories: http://www.elastic.co/guide/en/beats/{beatname_lc}/{doc-branch}/setup-repositories.html
 :security: X-Pack Security
 
 include::./overview.asciidoc[]


### PR DESCRIPTION
Changed the xrefs from the topics being translated to external links where needed to enable the mini-books to build. Also added directory-layout and setup-repositories attributes for the external links in the shared files.

I'm going to have to make some custom changes in the translated files to address the duplicate IDs, but I don't see a better way around that.