### PR TITLE
Update go-libaudit to v0.0.5

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -314,8 +314,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 --------------------------------------------------------------------
 Dependency: github.com/elastic/go-libaudit
-Version: v0.0.4
-Revision: c1565774e89c92d72a7b412217d83de180188887
+Version: v0.0.5
+Revision: 3a005d3d0bbcee26d60e3ab2f1890699746f4da6
 License type (autodetected): Apache License 2.0
 ./vendor/github.com/elastic/go-libaudit/LICENSE:
 --------------------------------------------------------------------

--- a/vendor/github.com/elastic/go-libaudit/CHANGELOG.md
+++ b/vendor/github.com/elastic/go-libaudit/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.0.5]
+
+### Changed
+- auparse - Apply hex decoding to CWD field. #10
+
 ## [0.0.4]
 
 ### Added

--- a/vendor/github.com/elastic/go-libaudit/Dockerfile
+++ b/vendor/github.com/elastic/go-libaudit/Dockerfile
@@ -1,5 +1,0 @@
-FROM golang:1.8.3
-
-RUN echo 'deb http://ftp.de.debian.org/debian sid main' >> /etc/apt/sources.list
-
-RUN apt-get update && apt-get install -y auditd && apt-get clean

--- a/vendor/github.com/elastic/go-libaudit/auparse/auparse.go
+++ b/vendor/github.com/elastic/go-libaudit/auparse/auparse.go
@@ -292,6 +292,8 @@ func enrichData(msg *AuditMessage) error {
 	// Normalize keys that are of the form key="key=user_command".
 	auditRuleKey(msg.data)
 
+	hexDecode("cwd", msg.data)
+
 	switch msg.RecordType {
 	case AUDIT_SYSCALL:
 		if err := arch(msg.data); err != nil {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -356,44 +356,44 @@
 			"revisionTime": "2016-08-05T00:47:13Z"
 		},
 		{
-			"checksumSHA1": "ROuRyxpAqN0jUjLN9ij3RS6YwTA=",
+			"checksumSHA1": "Pd9e8K98V1LGGScIG/u4Z36l0P0=",
 			"path": "github.com/elastic/go-libaudit",
-			"revision": "c1565774e89c92d72a7b412217d83de180188887",
-			"revisionTime": "2017-06-27T17:51:47Z",
-			"version": "v0.0.4",
-			"versionExact": "v0.0.4"
+			"revision": "3a005d3d0bbcee26d60e3ab2f1890699746f4da6",
+			"revisionTime": "2017-07-24T13:10:22Z",
+			"version": "v0.0.5",
+			"versionExact": "v0.0.5"
 		},
 		{
 			"checksumSHA1": "Ca2OhodWbbke1v+cctf9y/HdwZM=",
 			"path": "github.com/elastic/go-libaudit/aucoalesce",
-			"revision": "c1565774e89c92d72a7b412217d83de180188887",
-			"revisionTime": "2017-06-27T17:51:47Z",
-			"version": "v0.0.4",
-			"versionExact": "v0.0.4"
+			"revision": "3a005d3d0bbcee26d60e3ab2f1890699746f4da6",
+			"revisionTime": "2017-07-24T13:10:22Z",
+			"version": "v0.0.5",
+			"versionExact": "v0.0.5"
 		},
 		{
-			"checksumSHA1": "D09BquNtb1bpN2MrNewzY0u3O5c=",
+			"checksumSHA1": "N+9Ssj7RWKl2Sk1DqVmZ2Z3f8Ts=",
 			"path": "github.com/elastic/go-libaudit/auparse",
-			"revision": "c1565774e89c92d72a7b412217d83de180188887",
-			"revisionTime": "2017-06-27T17:51:47Z",
-			"version": "v0.0.4",
-			"versionExact": "v0.0.4"
+			"revision": "3a005d3d0bbcee26d60e3ab2f1890699746f4da6",
+			"revisionTime": "2017-07-24T13:10:22Z",
+			"version": "v0.0.5",
+			"versionExact": "v0.0.5"
 		},
 		{
 			"checksumSHA1": "H0rnscnKHbkjmXc4whC3gtIPR0c=",
 			"path": "github.com/elastic/go-libaudit/rule",
-			"revision": "c1565774e89c92d72a7b412217d83de180188887",
-			"revisionTime": "2017-06-27T17:51:47Z",
-			"version": "v0.0.4",
-			"versionExact": "v0.0.4"
+			"revision": "3a005d3d0bbcee26d60e3ab2f1890699746f4da6",
+			"revisionTime": "2017-07-24T13:10:22Z",
+			"version": "v0.0.5",
+			"versionExact": "v0.0.5"
 		},
 		{
 			"checksumSHA1": "36UaYid29Kyhrsa5D8N6BoM8dVw=",
 			"path": "github.com/elastic/go-libaudit/rule/flags",
-			"revision": "c1565774e89c92d72a7b412217d83de180188887",
-			"revisionTime": "2017-06-27T17:51:47Z",
-			"version": "v0.0.4",
-			"versionExact": "v0.0.4"
+			"revision": "3a005d3d0bbcee26d60e3ab2f1890699746f4da6",
+			"revisionTime": "2017-07-24T13:10:22Z",
+			"version": "v0.0.5",
+			"versionExact": "v0.0.5"
 		},
 		{
 			"checksumSHA1": "3jizmlZPCyo6FAZY8Trk9jA8NH4=",


### PR DESCRIPTION
Changes

- Apply hex decoding to CWD field. elastic/go-libaudit#10