### PR TITLE
Fix config reload when configured for both prospectors and modules

### DIFF
--- a/filebeat/crawler/crawler.go
+++ b/filebeat/crawler/crawler.go
@@ -15,14 +15,15 @@ import (
 )
 
 type Crawler struct {
-	prospectors       map[uint64]*prospector.Prospector
-	prospectorConfigs []*common.Config
-	out               channel.OutleterFactory
-	wg                sync.WaitGroup
-	reloader          *cfgfile.Reloader
-	once              bool
-	beatVersion       string
-	beatDone          chan struct{}
+	prospectors         map[uint64]*prospector.Prospector
+	prospectorConfigs   []*common.Config
+	out                 channel.OutleterFactory
+	wg                  sync.WaitGroup
+	modulesReloader     *cfgfile.Reloader
+	prospectorsReloader *cfgfile.Reloader
+	once                bool
+	beatVersion         string
+	beatDone            chan struct{}
 }
 
 func New(out channel.OutleterFactory, prospectorConfigs []*common.Config, beatVersion string, beatDone chan struct{}, once bool) (*Crawler, error) {
@@ -53,20 +54,20 @@ func (c *Crawler) Start(r *registrar.Registrar, configProspectors *common.Config
 	if configProspectors.Enabled() {
 		logp.Beta("Loading separate prospectors is enabled.")
 
-		c.reloader = cfgfile.NewReloader(configProspectors)
-		factory := prospector.NewFactory(c.out, r, c.beatDone)
+		c.prospectorsReloader = cfgfile.NewReloader(configProspectors)
+		prospectorsFactory := prospector.NewFactory(c.out, r, c.beatDone)
 		go func() {
-			c.reloader.Run(factory)
+			c.prospectorsReloader.Run(prospectorsFactory)
 		}()
 	}
 
 	if configModules.Enabled() {
 		logp.Beta("Loading separate modules is enabled.")
 
-		c.reloader = cfgfile.NewReloader(configModules)
-		factory := fileset.NewFactory(c.out, r, c.beatVersion, pipelineLoaderFactory, c.beatDone)
+		c.modulesReloader = cfgfile.NewReloader(configModules)
+		modulesFactory := fileset.NewFactory(c.out, r, c.beatVersion, pipelineLoaderFactory, c.beatDone)
 		go func() {
-			c.reloader.Run(factory)
+			c.modulesReloader.Run(modulesFactory)
 		}()
 	}
 
@@ -113,8 +114,12 @@ func (c *Crawler) Stop() {
 		asyncWaitStop(p.Stop)
 	}
 
-	if c.reloader != nil {
-		asyncWaitStop(c.reloader.Stop)
+	if c.prospectorsReloader != nil {
+		asyncWaitStop(c.prospectorsReloader.Stop)
+	}
+
+	if c.modulesReloader != nil {
+		asyncWaitStop(c.modulesReloader.Stop)
 	}
 
 	c.WaitForCompletion()


### PR DESCRIPTION
Steps to reproduce:

1. Configure config crawler for both modules and prospectors:
```
filebeat.config:
   prospectors:
     path: ${path.config}/prospectors.d/*.yml
     reload.enabled: false
   modules:
     path: ${path.config}/modules.d/*.yml
     reload.enabled: false
```
2. Add a prospector yml to `prospectors.d` folder
3. Run filebeat

Before this change the prospector is not loaded, it should be loaded after the fix