### PR TITLE
Adding support to exclude labels from kubernetes pod metadata

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -109,6 +109,7 @@ https://github.com/elastic/beats/compare/v6.0.0-alpha2...master[Check the HEAD d
 - Vsphere module: collect custom fields from virtual machines. {issue}4464[4464]
 - Add `test modules` command, to test modules expected output. {pull}4656[4656]
 - Add `processors` setting to metricbeat modules. {pull}4699[4699]
+- Add support to exclude labels from kubernetes pod metadata. {pull}4757[4757]
 
 *Packetbeat*
 

--- a/libbeat/_meta/kibana/default/index-pattern/libbeat.json
+++ b/libbeat/_meta/kibana/default/index-pattern/libbeat.json
@@ -1,5 +1,5 @@
 {
-  "version": "6.0.0-alpha2", 
+  "version": "7.0.0-alpha1", 
   "objects": [
     {
       "attributes": {

--- a/libbeat/processors/add_kubernetes_metadata/config.go
+++ b/libbeat/processors/add_kubernetes_metadata/config.go
@@ -17,6 +17,7 @@ type kubeAnnotatorConfig struct {
 	DefaultMatchers    Enabled       `config:"default_matchers"`
 	DefaultIndexers    Enabled       `config:"default_indexers"`
 	IncludeLabels      []string      `config:"include_labels"`
+	ExcludeLabels      []string      `config:"exclude_labels"`
 	IncludeAnnotations []string      `config:"include_annotations"`
 }
 

--- a/libbeat/processors/add_kubernetes_metadata/indexing.go
+++ b/libbeat/processors/add_kubernetes_metadata/indexing.go
@@ -172,8 +172,9 @@ func (m *Matchers) MetadataIndex(event common.MapStr) string {
 }
 
 type GenDefaultMeta struct {
-	annotations []string
-	labels      []string
+	annotations   []string
+	labels        []string
+	labelsExclude []string
 }
 
 // GenerateMetaData generates default metadata for the given pod taking to account certain filters
@@ -187,6 +188,11 @@ func (g *GenDefaultMeta) GenerateMetaData(pod *Pod) common.MapStr {
 		}
 	} else {
 		labelMap = generateMapSubset(pod.Metadata.Labels, g.labels)
+	}
+
+	// Exclude any labels that are present in the exclude_labels config
+	for _, label := range g.labelsExclude {
+		delete(labelMap, label)
 	}
 
 	annotationsMap = generateMapSubset(pod.Metadata.Annotations, g.annotations)

--- a/libbeat/processors/add_kubernetes_metadata/kubernetes.go
+++ b/libbeat/processors/add_kubernetes_metadata/kubernetes.go
@@ -74,8 +74,9 @@ func newKubernetesAnnotator(cfg *common.Config) (processors.Processor, error) {
 	}
 
 	metaGen := &GenDefaultMeta{
-		labels:      config.IncludeLabels,
-		annotations: config.IncludeAnnotations,
+		labels:        config.IncludeLabels,
+		annotations:   config.IncludeAnnotations,
+		labelsExclude: config.ExcludeLabels,
 	}
 
 	indexers := Indexers{


### PR DESCRIPTION
We have seen instances where there are labels that have too high of a cardinality for which support to exclude/filter out would be good to have on the `add_kubernetes_metadata` processor.