### PR TITLE
Cherry-pick #4751 to 6.0: Support `npipe` URLs in host parser

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -34,6 +34,8 @@ https://github.com/elastic/beats/compare/v6.0.0-beta1...master[Check the HEAD di
 
 *Metricbeat*
 
+- Support `npipe` protocol (Windows) in Docker module. {pull}4751[4751]
+
 *Packetbeat*
 
 *Winlogbeat*

--- a/metricbeat/mb/parse/url.go
+++ b/metricbeat/mb/parse/url.go
@@ -61,7 +61,8 @@ func (b URLHostParserBuilder) Build() mb.HostParser {
 
 // NewHostDataFromURL returns a new HostData based on the contents of the URL.
 // If the URLs scheme is "unix" or end is "unix" (e.g. "http+unix://") then
-// the HostData.Host field is set to the URLs path instead of the URLs host.
+// the HostData.Host field is set to the URLs path instead of the URLs host,
+// the same happens for "npipe".
 func NewHostDataFromURL(u *url.URL) mb.HostData {
 	var user, pass string
 	if u.User != nil {
@@ -70,7 +71,7 @@ func NewHostDataFromURL(u *url.URL) mb.HostData {
 	}
 
 	host := u.Host
-	if strings.HasSuffix(u.Scheme, "unix") {
+	if strings.HasSuffix(u.Scheme, "unix") || strings.HasSuffix(u.Scheme, "npipe") {
 		host = u.Path
 	}
 
@@ -140,7 +141,7 @@ func getURL(rawURL, scheme, username, password, path, query string) (*url.URL, e
 
 	SetURLUser(u, username, password)
 
-	if !strings.HasSuffix(u.Scheme, "unix") {
+	if !strings.HasSuffix(u.Scheme, "unix") && !strings.HasSuffix(u.Scheme, "npipe") {
 		if u.Host == "" {
 			return nil, fmt.Errorf("error parsing URL: empty host")
 		}

--- a/metricbeat/mb/parse/url_test.go
+++ b/metricbeat/mb/parse/url_test.go
@@ -41,6 +41,18 @@ func TestParseURL(t *testing.T) {
 		}
 	})
 
+	t.Run("npipe", func(t *testing.T) {
+		rawURL := "npipe://./pipe/docker_engine"
+		hostData, err := ParseURL(rawURL, "tcp", "", "", "", "")
+		if assert.NoError(t, err) {
+			assert.Equal(t, "npipe://./pipe/docker_engine", hostData.URI)
+			assert.Equal(t, "npipe://./pipe/docker_engine", hostData.SanitizedURI)
+			assert.Equal(t, "/pipe/docker_engine", hostData.Host)
+			assert.Equal(t, "", hostData.User)
+			assert.Equal(t, "", hostData.Password)
+		}
+	})
+
 	t.Run("set default user", func(t *testing.T) {
 		rawURL := "http://:secret@localhost"
 		h, err := ParseURL(rawURL, "https", "root", "passwd", "", "")


### PR DESCRIPTION
Cherry-pick of PR #4751 to 6.0 branch. Original message: 

Docker for Windows uses URLs like `npipe://./pipe/docker_engine`. This
change makes sure they are supported by our host validators

Fixes #4748