### PR TITLE
Update test to use named field in composite literal

### DIFF
--- a/auditbeat/module/audit/kernel/audit_linux_test.go
+++ b/auditbeat/module/audit/kernel/audit_linux_test.go
@@ -28,7 +28,7 @@ func TestData(t *testing.T) {
 	ms := mbtest.NewPushMetricSet(t, getConfig())
 	auditMetricSet := ms.(*MetricSet)
 	auditMetricSet.client.Close()
-	auditMetricSet.client = &libaudit.AuditClient{mock}
+	auditMetricSet.client = &libaudit.AuditClient{Netlink: mock}
 
 	events, errs := mbtest.RunPushMetricSet(time.Second, ms)
 	if len(errs) > 0 {

--- a/metricbeat/docs/fields.asciidoc
+++ b/metricbeat/docs/fields.asciidoc
@@ -2790,7 +2790,7 @@ Bytes in non-idle span.
 
 
 [[exported-fields-graphite]]
-== graphite Fields
+== graphite fields
 
 []experimental
 graphite Module
@@ -2798,20 +2798,20 @@ graphite Module
 
 
 [float]
-== graphite Fields
+== graphite fields
 
 
 
 
 [float]
-== server Fields
+== server fields
 
 server
 
 
 
 [float]
-=== graphite.server.example
+=== `graphite.server.example`
 
 type: keyword
 


### PR DESCRIPTION
Fixes a `go vet` warning.

    module/audit/kernel/audit_linux_test.go:31: github.com/elastic/beats/vendor/github.com/elastic/go-libaudit.AuditClient composite literal uses unkeyed fields