### PR TITLE
Update Filebeat development guide && create _meta/kibana/default folder

### DIFF
--- a/docs/devguide/modules-dev-guide.asciidoc
+++ b/docs/devguide/modules-dev-guide.asciidoc
@@ -52,6 +52,8 @@ module/{module}/{fileset}
 │   └── pipeline.json
 ├── _meta
 │   └── fields.yml
+│   └── kibana
+│       └── default
 └── test
 ----
 
@@ -306,11 +308,24 @@ them, you can build them visually in Kibana and then run the following command:
 
 [source,shell]
 ----
-$ cd filebeat/module/{module}/
-python ../../../dev-tools/export_dashboards.py --regex {module} --dir _meta/kibana
+$ cd dev-tools/cmd/dashboards
+$ make # if export_dashboard is not built
+$ ./export_dashboards -dashboard '{dashboard-id}' -output '../../../filebeat/module/{module}/_meta/kibana/default/dashboard'
+----
+
+New Filebeat modules might not be compatible with Kibana 5.x. To export dashboards that are compatible with 5.x, run the following command inside the developer virtualenv:
+
+[source,shell]
+----
+$ cd filebeat
+$ make python-env
+$ cd module/{module}/
+$ python ../../../dev-tools/export_5x_dashboards.py --regex {module} --dir _meta/kibana/5.x
 ----
 
 Where the `--regex` parameter should match the dashboard you want to export.
+
+Please note that dashboards exported from Kibana 5.x are not compatible with Kibana 6.x.
 
 You can find more details about the process of creating and exporting the Kibana
 dashboards by reading {beatsdevguide}/new-dashboards.html[this guide].

--- a/filebeat/scripts/create_fileset.py
+++ b/filebeat/scripts/create_fileset.py
@@ -46,13 +46,16 @@ def generate_module(base_path, metricbeat_path, module, fileset):
 
     module_path = base_path + "/module/" + module
     meta_path = module_path + "/_meta"
+    kibana_default_path = meta_path + "/kibana/default"
 
     if os.path.isdir(module_path):
         print("Module already exists. Skipping creating module {}"
               .format(module))
         return
 
-    os.makedirs(meta_path)
+    paths_to_create = [meta_path, kibana_default_path]
+    for path_to_create in paths_to_create:
+        os.makedirs(path_to_create)
 
     templates = metricbeat_path + "/scripts/module/"
 


### PR DESCRIPTION
This PR contains two small updates which is highly coupled. But please note that it includes code changes in `create_fileset.py`.

Also I am not sure if I added all of the required documentation files.

* "Creating a new Filebeat module" is updated so it includes instructions on how to export dashboards from Kibana 6.x. Furthermore, exporting from Kibana 5.x has also changed, so it is followed-up, too.
* In `create_fileset.py` creating both `_meta/kibana` and `_meta/kibana/default` is included.