### PR TITLE
Increase api version for Beats monitoring

### DIFF
--- a/libbeat/monitoring/report/elasticsearch/elasticsearch.go
+++ b/libbeat/monitoring/report/elasticsearch/elasticsearch.go
@@ -45,7 +45,7 @@ var errNoMonitoring = errors.New("xpack monitoring not available")
 // default monitoring api parameters
 var defaultParams = map[string]string{
 	"system_id":          "beats",
-	"system_api_version": "2",
+	"system_api_version": "6",
 }
 
 func init() {

--- a/libbeat/outputs/elasticsearch/client.go
+++ b/libbeat/outputs/elasticsearch/client.go
@@ -719,19 +719,18 @@ func (conn *Connection) execHTTPRequest(req *http.Request) (int, []byte, error) 
 	}
 	defer closing(resp.Body)
 
-	var retErr error
 	status := resp.StatusCode
 	obj, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return status, nil, retErr
+		return status, nil, err
 	}
 
 	if status >= 300 {
 		// add the response body with the error returned by Elasticsearch
-		retErr = fmt.Errorf("%v: %s", resp.Status, obj)
+		err = fmt.Errorf("%v: %s", resp.Status, obj)
 	}
 
-	return status, obj, retErr
+	return status, obj, err
 }
 
 func (conn *Connection) GetVersion() string {

--- a/libbeat/outputs/elasticsearch/client.go
+++ b/libbeat/outputs/elasticsearch/client.go
@@ -719,16 +719,18 @@ func (conn *Connection) execHTTPRequest(req *http.Request) (int, []byte, error) 
 	}
 	defer closing(resp.Body)
 
-	status := resp.StatusCode
 	var retErr error
-	if status >= 300 {
-		retErr = fmt.Errorf("%v", resp.Status)
-	}
-
+	status := resp.StatusCode
 	obj, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return status, nil, retErr
 	}
+
+	if status >= 300 {
+		// add the response body with the error returned by Elasticsearch
+		retErr = fmt.Errorf("%v: %s", resp.Status, obj)
+	}
+
 	return status, obj, retErr
 }
 


### PR DESCRIPTION
This PR contains two changes:
- increase the version of the API for Beats monitoring
- add the response body with the error message returned by Elasticsearch, in case of an error