### PR TITLE
Enhancements to auditbeat file metricset

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -16,6 +16,10 @@ https://github.com/elastic/beats/compare/v6.0.0-beta1...master[Check the HEAD di
 
 - The log directory (`path.log`) for Windows services is now set to `C:\ProgramData\[beatname]\logs`. {issue}4764[4764]
 
+*Auditbeat*
+
+- Changed file metricset config to make `file.paths` a list instead of a dictionary. {pull}4796[4796]
+
 *Filebeat*
 
 *Heartbeat*
@@ -30,6 +34,11 @@ https://github.com/elastic/beats/compare/v6.0.0-beta1...master[Check the HEAD di
 
 *Affecting all Beats*
 - Fix go plugins not loaded when beat starts {pull}4799[4799]
+
+*Auditbeat*
+
+- Fix `file.max_file_size` config option for the audit file metricset. {pull}4796[4796]
+
 *Filebeat*
 
 - Fix issue where the `fileset.module` could have the wrong value. {issue}4761[4761]
@@ -47,6 +56,11 @@ https://github.com/elastic/beats/compare/v6.0.0-beta1...master[Check the HEAD di
 ==== Added
 
 *Affecting all Beats*
+
+*Auditbeat*
+
+- Added `file.hash_types` config option for controlling the hash types. {pull}4796[4796]
+- Added the ability to specify byte unit suffixes to `file.max_file_size`. {pull}4796[4796]
 
 *Filebeat*
 

--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -46,21 +46,22 @@ auditbeat.modules:
     #-a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -k access
 
 # The file integrity metricset sends events when files are changed (created,
-# updated, deleted). The events contain file metadata and hashes (MD5, SHA1, and
-# SHA256).
+# updated, deleted). The events contain file metadata and hashes.
 - module: audit
   metricsets: [file]
   file.paths:
-    binaries:
-    - /bin
-    - /usr/bin
-    - /sbin
-    - /usr/sbin
-    conf:
-    - /etc
+  - /bin
+  - /usr/bin
+  - /sbin
+  - /usr/sbin
+  - /etc
   
-  # Limit in bytes on the size of files that will be hashed.
-  file.max_file_size: 1073741824 # 1 GiB
+  # Limit on the size of files that will be hashed. Default is 100 MiB.
+  file.max_file_size: 100 MiB
+
+  # Hash types to compute when the file changes. Supported types are md5, sha1,
+  # sha224, sha256, sha384, sha512, sha512_224, and sha512_256. Default is sha1.
+  file.hash_types: [sha1]
 
 
 #================================ General ======================================

--- a/auditbeat/auditbeat.yml
+++ b/auditbeat/auditbeat.yml
@@ -21,13 +21,11 @@ auditbeat.modules:
 - module: audit
   metricsets: [file]
   file.paths:
-    binaries:
-    - /bin
-    - /usr/bin
-    - /sbin
-    - /usr/sbin
-    conf:
-    - /etc
+  - /bin
+  - /usr/bin
+  - /sbin
+  - /usr/sbin
+  - /etc
   
 
 

--- a/auditbeat/docs/auditbeat-modules-config.asciidoc
+++ b/auditbeat/docs/auditbeat-modules-config.asciidoc
@@ -21,13 +21,11 @@ auditbeat.modules:
 - module: audit
   metricsets: [file]
   file.paths:
-    binaries:
-    - /bin
-    - /usr/bin
-    - /sbin
-    - /usr/sbin
-    conf:
-    - /etc
+  - /bin
+  - /usr/bin
+  - /sbin
+  - /usr/sbin
+  - /etc
 ----
 
 The configuration details vary by module. See the

--- a/auditbeat/docs/getting-started.asciidoc
+++ b/auditbeat/docs/getting-started.asciidoc
@@ -152,13 +152,11 @@ auditbeat.modules:
 - module: audit
   metricsets: [file]
   file.paths:
-    binaries:
-    - /bin
-    - /usr/bin
-    - /sbin
-    - /usr/sbin
-    conf:
-    - /etc
+  - /bin
+  - /usr/bin
+  - /sbin
+  - /usr/sbin
+  - /etc
 -------------------------------------
 +
 If you accept the default configuration without specifying additional modules,

--- a/auditbeat/docs/modules/audit.asciidoc
+++ b/auditbeat/docs/modules/audit.asciidoc
@@ -32,13 +32,11 @@ auditbeat.modules:
 - module: audit
   metricsets: [file]
   file.paths:
-    binaries:
-    - /bin
-    - /usr/bin
-    - /sbin
-    - /usr/sbin
-    conf:
-    - /etc
+  - /bin
+  - /usr/bin
+  - /sbin
+  - /usr/sbin
+  - /etc
   
 ----
 

--- a/auditbeat/module/audit/_meta/config.yml.tpl
+++ b/auditbeat/module/audit/_meta/config.yml.tpl
@@ -23,39 +23,37 @@
 
 {{ if .reference -}}
 # The file integrity metricset sends events when files are changed (created,
-# updated, deleted). The events contain file metadata and hashes (MD5, SHA1, and
-# SHA256).
+# updated, deleted). The events contain file metadata and hashes.
 {{ end -}}
 - module: audit
   metricsets: [file]
   {{ if eq .goos "darwin" -}}
   file.paths:
-    binaries:
-    - /bin
-    - /usr/bin
-    - /usr/local/bin
-    - /sbin
-    - /usr/sbin
-    - /usr/local/sbin
+  - /bin
+  - /usr/bin
+  - /usr/local/bin
+  - /sbin
+  - /usr/sbin
+  - /usr/local/sbin
   {{ else if eq .goos "windows" -}}
   file.paths:
-    windows:
-    - C:/windows
-    - C:/windows/system32
-    programs:
-    - C:/Program Files
-    - C:/Program Files (x86)
+  - C:/windows
+  - C:/windows/system32
+  - C:/Program Files
+  - C:/Program Files (x86)
   {{ else -}}
   file.paths:
-    binaries:
-    - /bin
-    - /usr/bin
-    - /sbin
-    - /usr/sbin
-    conf:
-    - /etc
+  - /bin
+  - /usr/bin
+  - /sbin
+  - /usr/sbin
+  - /etc
   {{ end -}}
   {{ if .reference }}
-  # Limit in bytes on the size of files that will be hashed.
-  file.max_file_size: 1073741824 # 1 GiB
+  # Limit on the size of files that will be hashed. Default is 100 MiB.
+  file.max_file_size: 100 MiB
+
+  # Hash types to compute when the file changes. Supported types are md5, sha1,
+  # sha224, sha256, sha384, sha512, sha512_224, and sha512_256. Default is sha1.
+  file.hash_types: [sha1]
   {{- end }}

--- a/auditbeat/module/audit/file/_meta/data.json
+++ b/auditbeat/module/audit/file/_meta/data.json
@@ -1,33 +1,35 @@
 {
-    "@timestamp": "2017-07-10T18:13:08.197Z",
-    "audit": {
-        "file": {
-            "action": "created",
-            "atime": "2017-07-10T18:13:08Z",
-            "ctime": "2017-07-10T18:13:08Z",
-            "gid": 20,
-            "group": "staff",
-            "hashed": true,
-            "inode": "11706872",
-            "md5": "5eb63bbbe01eeed093cb22bb8f5acdc3",
-            "mode": "0600",
-            "mtime": "2017-07-10T18:13:08Z",
-            "owner": "akroh",
-            "path": "/var/folders/8x/rnyk6yxn6w97lddn3bs02gf00000gn/T/audit-file232876074/file.data",
-            "sha1": "2aae6c35c94fcfb415dbe95f408b9ce91ee846ed",
-            "sha256": "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
-            "size": 11,
-            "type": "file",
-            "uid": 501
-        }
-    },
-    "beat": {
-        "hostname": "host.example.com",
-        "name": "host.example.com"
-    },
-    "metricset": {
-        "module": "audit",
-        "name": "file",
-        "rtt": 115
+  "@timestamp": "2017-07-31T14:40:28.173Z",
+  "@metadata": {
+    "beat": "noindex",
+    "type": "doc"
+  },
+  "audit": {
+    "file": {
+      "hashed": true,
+      "group": "staff",
+      "path": "/var/folders/8x/rnyk6yxn6w97lddn3bs02gf00000gn/T/audit-file927187403/file.data",
+      "inode": "12512120",
+      "size": 11,
+      "ctime": "2017-07-31T14:40:28.000Z",
+      "mode": "0600",
+      "owner": "akroh",
+      "atime": "2017-07-31T14:40:28.000Z",
+      "sha1": "2aae6c35c94fcfb415dbe95f408b9ce91ee846ed",
+      "action": "created",
+      "mtime": "2017-07-31T14:40:28.000Z",
+      "type": "file",
+      "uid": 501,
+      "gid": 20
     }
+  },
+  "metricset": {
+    "module": "audit",
+    "name": "file",
+    "rtt": 115
+  },
+  "beat": {
+    "name": "host.example.com",
+    "hostname": "host.example.com"
+  }
 }

--- a/auditbeat/module/audit/file/_meta/docs.asciidoc
+++ b/auditbeat/module/audit/file/_meta/docs.asciidoc
@@ -1,36 +1,67 @@
 === Audit file metricset
 
 The `file` metricset sends events when a file is changed (created, updated, or
-deleted) on disk. The events contain file metadata and hashes (MD5, SHA1, and
-SHA256).
+deleted) on disk. The events contain file metadata and hashes.
 
-////
+The metricset is implemented for Linux, macOS (Darwin), and Windows.
+
 [float]
 === How it works
 
-This metricset...
-////
+This metricset uses features of the operating system to monitor file changes in
+realtime. When the metricset starts it creates a subscription with the OS to
+receive notifications of changes to the specified files or directories. Upon
+receiving notification of a change the metricset will read the file's metadata
+and the compute a hash of the file's contents.
+
+This metricset does not perform an initial scan of the given paths to generate
+events for the files as they existed at start time. It is strictly driven by
+change notifications from the OS.
+
+The operating system features that power this feature are as follows.
+
+* Linux - `inotify` is used, and therefore the kernel must have inotify support.
+Inotify was initially merged into the 2.6.13 Linux kernel.
+* macOS (Darwin) - `kqueue` is used. It requires one file descriptor for each
+file so please check the `ulimit` values used with {beatname_uc}. The FSEvents
+API was considered for the implementation, but FSEvents coalesces multiple
+notifications into a single event which is inconsistent with the metricset's
+behavior on other operating systems.
+* Windows - `ReadDirectoryChangesW` is used.
+
+The file metricset should not be used to monitor paths on network file systems.
 
 [float]
 === Configuration options
 
 This metricset has some configuration options for tuning its behavior. The
-following example shows all configuration options with their default values.
+following example shows all configuration options with their default values for
+Linux.
 
 [source,yaml]
 ----
 - module: audit
   metricsets: [file]
   file.paths:
-    binaries:
-    - /bin
-    - /usr/bin
-    - /sbin
-    - /usr/sbin
-    conf:
-    - /etc
+  - /bin
+  - /usr/bin
+  - /sbin
+  - /usr/sbin
+  - /etc
+  file.max_file_size: 100 MiB
+  file.hash_types: [sha1]
 ----
 
+*`file.paths`*:: A list of paths (directories or files) to watch. The watches
+are non-recursive and globs are not supported. The specified paths should exist
+when the metricset is started.
 
-*`file.paths`*:: A dictionary of arbitrary names (strings) to a list of paths
-(directories or files).
+*`file.max_file_size`*:: The maximum size of a file in bytes for which
+{beatname_uc} will compute hashes. Files larger than this size will not be
+hashed. The default value is 100 MiB. For convenience units can be specified as
+a suffix to the value. The supported units are `b`, `kib`, `kb`, `mib`, `mb`,
+`gib`, `gb`, `tib`, `tb`, `pib`, `pb`, `eib`, and `eb`.
+
+*`file.hash_types`*:: A list of hash types to compute when the file changes.
+The supported hash types are md5, sha1, sha224, sha256, sha384, sha512,
+sha512_224, and sha512_256. The default value is sha1.

--- a/auditbeat/module/audit/file/config.go
+++ b/auditbeat/module/audit/file/config.go
@@ -1,0 +1,42 @@
+package file
+
+import (
+	"strings"
+
+	"github.com/dustin/go-humanize"
+	"github.com/joeshaw/multierror"
+	"github.com/pkg/errors"
+)
+
+type Config struct {
+	Paths            []string `config:"file.paths" validate:"required"`
+	HashTypes        []string `config:"file.hash_types"`
+	MaxFileSize      string   `config:"file.max_file_size"`
+	MaxFileSizeBytes uint64   `config:",ignore"`
+}
+
+func (c *Config) Validate() error {
+	var errs multierror.Errors
+	var err error
+
+	c.MaxFileSizeBytes, err = humanize.ParseBytes(c.MaxFileSize)
+	if err != nil {
+		errs = append(errs, errors.Wrap(err, "invalid file.max_file_size value"))
+	}
+
+	for _, ht := range c.HashTypes {
+		switch strings.ToLower(ht) {
+		case "md5", "sha1", "sha224", "sha256", "sha384", "sha512", "sha512_224", "sha512_256":
+		default:
+			errs = append(errs, errors.Errorf("invalid hash type '%v'", ht))
+		}
+	}
+
+	return errs.Err()
+}
+
+var defaultConfig = Config{
+	MaxFileSize:      "100 MiB",
+	MaxFileSizeBytes: 100 * 1024 * 1024,
+	HashTypes:        []string{"sha1"},
+}

--- a/auditbeat/module/audit/file/config_test.go
+++ b/auditbeat/module/audit/file/config_test.go
@@ -1,0 +1,46 @@
+package file
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/libbeat/common"
+)
+
+func TestConfig(t *testing.T) {
+	config, err := common.NewConfigFrom(map[string]interface{}{
+		"file.paths":         []string{"/usr/bin"},
+		"file.hash_types":    []string{"md5", "sha256"},
+		"file.max_file_size": "1 GiB",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c := defaultConfig
+	if err := config.Unpack(&c); err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, []string{"md5", "sha256"}, c.HashTypes)
+	assert.EqualValues(t, 1024*1024*1024, c.MaxFileSizeBytes)
+}
+
+func TestInvalidConfig(t *testing.T) {
+	config, err := common.NewConfigFrom(map[string]interface{}{
+		"file.hash_types":    []string{"crc32", "sha256"},
+		"file.max_file_size": "32 Hz",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c := defaultConfig
+	if err := config.Unpack(&c); err != nil {
+		assert.Error(t, err)
+		return
+	}
+
+	t.Fatal("expected error")
+}

--- a/auditbeat/module/audit/file/event.go
+++ b/auditbeat/module/audit/file/event.go
@@ -4,8 +4,10 @@ import (
 	"crypto/md5"
 	"crypto/sha1"
 	"crypto/sha256"
+	"crypto/sha512"
 	"encoding/hex"
 	"fmt"
+	"hash"
 	"io"
 	"os"
 	"runtime"
@@ -47,15 +49,12 @@ var actionNames = map[Action]string{
 
 // Event describe the filesystem change and includes metadata about the file.
 type Event struct {
-	Timestamp  time.Time // Time of event.
-	Path       string    // The path associated with the event.
-	TargetPath string    // Target path for symlinks.
-	Action     string    // Action (like created, updated).
-	Info       *Metadata // File metadata (if the file exists).
-	Hashed     bool      // True if hashed.
-	MD5        string
-	SHA1       string
-	SHA256     string
+	Timestamp  time.Time         // Time of event.
+	Path       string            // The path associated with the event.
+	TargetPath string            // Target path for symlinks.
+	Action     string            // Action (like created, updated).
+	Info       *Metadata         // File metadata (if the file exists).
+	Hashes     map[string]string // File hashes.
 
 	errors []error
 }
@@ -81,7 +80,7 @@ func buildMapStr(e *Event) common.MapStr {
 		"@timestamp": e.Timestamp,
 		"path":       e.Path,
 		"action":     e.Action,
-		"hashed":     e.Hashed,
+		"hashed":     len(e.Hashes) > 0,
 	}
 
 	if e.TargetPath != "" {
@@ -118,33 +117,65 @@ func buildMapStr(e *Event) common.MapStr {
 		}
 	}
 
-	if e.Hashed {
-		m["md5"] = e.MD5
-		m["sha1"] = e.SHA1
-		m["sha256"] = e.SHA256
+	for name, hash := range e.Hashes {
+		m[name] = hash
 	}
 
 	return m
 }
 
-func hashFile(name string) (md5sum, sha1sum, sha256sum string, err error) {
+func hashFile(name string, hashType ...string) (map[string]string, error) {
+	if len(hashType) == 0 {
+		return nil, nil
+	}
+
+	var hashes []hash.Hash
+	for _, name := range hashType {
+		switch name {
+		case "md5":
+			hashes = append(hashes, md5.New())
+		case "sha1":
+			hashes = append(hashes, sha1.New())
+		case "sha224":
+			hashes = append(hashes, sha256.New224())
+		case "sha256":
+			hashes = append(hashes, sha256.New())
+		case "sha384":
+			hashes = append(hashes, sha512.New384())
+		case "sha512":
+			hashes = append(hashes, sha512.New())
+		case "sha512_224":
+			hashes = append(hashes, sha512.New512_224())
+		case "sha512_256":
+			hashes = append(hashes, sha512.New512_256())
+		default:
+			return nil, errors.Errorf("unknown hash type '%v'", name)
+		}
+	}
+
 	f, err := os.Open(name)
 	if err != nil {
-		return "", "", "", errors.Wrap(err, "failed to open file for hashing")
+		return nil, errors.Wrap(err, "failed to open file for hashing")
 	}
 	defer f.Close()
 
-	m5 := md5.New()
-	s1 := sha1.New()
-	s256 := sha256.New()
-
-	hashWriter := io.MultiWriter(m5, s1, s256)
+	hashWriter := multiWriter(hashes)
 	if _, err := io.Copy(hashWriter, f); err != nil {
-		return "", "", "", errors.Wrap(err, "failed to calculate file hashes")
+		return nil, errors.Wrap(err, "failed to calculate file hashes")
 	}
 
-	return hex.EncodeToString(m5.Sum(nil)),
-		hex.EncodeToString(s1.Sum(nil)),
-		hex.EncodeToString(s256.Sum(nil)),
-		nil
+	nameToHash := make(map[string]string, len(hashes))
+	for i, h := range hashes {
+		nameToHash[hashType[i]] = hex.EncodeToString(h.Sum(nil))
+	}
+
+	return nameToHash, nil
+}
+
+func multiWriter(hash []hash.Hash) io.Writer {
+	writers := make([]io.Writer, 0, len(hash))
+	for _, h := range hash {
+		writers = append(writers, h)
+	}
+	return io.MultiWriter(writers...)
 }

--- a/auditbeat/module/audit/file/metricset.go
+++ b/auditbeat/module/audit/file/metricset.go
@@ -26,15 +26,6 @@ func init() {
 	}
 }
 
-type Config struct {
-	Paths       map[string][]string `config:"file.paths"`
-	MaxFileSize int64               `config:"max_file_size"`
-}
-
-var defaultConfig = Config{
-	MaxFileSize: 1 << 30, // 1 Gibibyte
-}
-
 type EventReader interface {
 	Start(done <-chan struct{}) (<-chan Event, error)
 }

--- a/auditbeat/module/audit/file/metricset_test.go
+++ b/auditbeat/module/audit/file/metricset_test.go
@@ -47,9 +47,7 @@ func getConfig(path string) map[string]interface{} {
 	return map[string]interface{}{
 		"module":     "audit",
 		"metricsets": []string{"file"},
-		"file.paths": map[string][]string{
-			"binaries": {path},
-		},
+		"file.paths": []string{path},
 	}
 }
 
@@ -63,9 +61,7 @@ func TestEventReader(t *testing.T) {
 
 	// Create a new EventReader.
 	config := defaultConfig
-	config.Paths = map[string][]string{
-		"testdir": {dir},
-	}
+	config.Paths = []string{dir}
 	r, err := NewEventReader(config)
 	if err != nil {
 		t.Fatal(err)
@@ -351,5 +347,29 @@ func rename(t *testing.T, oldPath, newPath string) {
 		}
 
 		t.Fatal(err)
+	}
+}
+
+func BenchmarkHashFile(b *testing.B) {
+	f, err := ioutil.TempFile("", "hash")
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+
+	zeros := make([]byte, 100)
+	for i := 0; i < 1024*1024; i++ {
+		if _, err = f.Write(zeros); err != nil {
+			b.Fatal(err)
+		}
+	}
+	f.Close()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, err = hashFile(f.Name(), "sha256")
+		if err != nil {
+			b.Fatal(err)
+		}
 	}
 }

--- a/auditbeat/module/audit/kernel/_meta/docs.asciidoc
+++ b/auditbeat/module/audit/kernel/_meta/docs.asciidoc
@@ -8,7 +8,7 @@ This metricset is available only for Linux.
 [float]
 === How it works
 
-This metricset establishes a subscription to the `kernel` to receive the events
+This metricset establishes a subscription to the kernel to receive the events
 as they occur. So unlike most other metricsets, the `period` configuration
 option is unused because it is not implemented using polling.
 
@@ -16,8 +16,8 @@ The Linux kernel only supports a single subscriber to the audit events so this
 metricset cannot be used simultaneously with a service like `auditd`. `auditd`
 should be disabled if this metricset is being used. If you wish to continue to
 use `auditd` instead of this metricset to receive audit messages from the kernel
-then consider using {filebeat}/filebeat-module-auditd.html[Filebeat] to collect the daemon's
-log files.
+then consider using {filebeat}/filebeat-module-auditd.html[Filebeat] to collect
+the daemon's log files.
 
 The Linux Audit Framework can send multiple messages for a single auditable
 event. For example, a `rename` syscall causes the kernel to send eight separate
@@ -73,10 +73,12 @@ include each of the raw messages that contributed to the event in the document
 as a field called `messages`. The default value is false. This setting is
 primarily used for development and debugging purposes.
 
-*`kernel.include_warnings`*:: This boolean setting causes {beatname_uc} to include
-as warnings any issues that were encountered while parsing the raw messages.
-The default value is false. This setting is primarily used for development and
-debugging purposes.
+*`kernel.include_warnings`*:: This boolean setting causes {beatname_uc} to
+include as warnings any issues that were encountered while parsing the raw
+messages. The default value is false. When this setting is enabled the raw
+messages will be included in the event regardless of the
+`kernel.include_raw_message` config setting. This setting is primarily used for
+development and debugging purposes.
 
 *`kernel.audit_rules`*:: A string containing the audit rules that should be
 installed to the kernel. There should be one rule per line. Comments can be
@@ -102,9 +104,9 @@ the most active rules first in order to speed up evaluation.
 You can assign keys to each rule for better identification of the rule that
 triggered an event and easier filtering later in Elasticsearch.
 
-Defining any audit rules in the config causes {beatname_uc} to purge all existing
-audit rules prior to adding the rules specified in the config. Therefore it is
-unnecessary and unsupported to include a `-D` (delete all) rule.
+Defining any audit rules in the config causes {beatname_uc} to purge all
+existing audit rules prior to adding the rules specified in the config.
+Therefore it is unnecessary and unsupported to include a `-D` (delete all) rule.
 
 ["source","sh",subs="attributes"]
 ----


### PR DESCRIPTION
- Modify `file.paths` to be a list instead of a dictionary.
- Added `file.hash_types` config option for controlling the hash types.
- Added new hash types.
- Fixed `file.max_file_size` config option. It was missing the "file." prefix when reading the option.
- Added the ability to specify byte unit suffixes to `file.max_file_size`.
- Added documentation for the audit file metricset.