### PR TITLE
Temporary workaround Travis failing Metricbeat builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -115,7 +115,7 @@ before_install:
 install: true
 
 script:
-  - make $TARGETS
+  - travis_wait 60 make $TARGETS
 
 notifications:
   slack:


### PR DESCRIPTION
The Metricbeat tests are sometimes failing because no output is generated for 10m. This is trying a [workaround](https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received) that sort of disables the 10m check, so it's hopefully temporary :).