### PR TITLE
Added required alias property to documentation

### DIFF
--- a/metricbeat/module/windows/perfmon/_meta/docs.asciidoc
+++ b/metricbeat/module/windows/perfmon/_meta/docs.asciidoc
@@ -22,11 +22,13 @@ For wildcard queries this setting has no effect.
   metricsets: ["perfmon"]
   period: 10s
   perfmon.counters:
-    - instance_label: "processor.name"
+    - alias: "procesor.name.stats"
+      instance_label: "processor.name"
       instance_name: "Total"
       measurement_label: "processor.time.total.pct"
       query: '\Processor Information(_Total)\% Processor Time'
-    - instance_label: "diskio.name"
+    - alias: "diskio.name.stats"
+      instance_label: "diskio.name"
       measurement_label: "diskio.write.bytes"
       query: '\PhysicalDisk(*)\Disk Writes/sec'
       format: "long"


### PR DESCRIPTION
Trying to start metricbeat for capturing performance counters with default configuration form documentation fails complaining on absent "alias" field in counters definitions.