### PR TITLE
Fix HTTP 404 URLs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Beat  | Description
 [Winlogbeat](https://github.com/elastic/beats/tree/master/winlogbeat) | Fetches and ships Windows Event logs
 
 In addition to the above Beats, which are officially supported by
-[Elastic](elastic.co), the
+[Elastic](https://elastic.co), the
 community has created a set of other Beats that make use of libbeat but live
 outside of this Github repository. We maintain a list of community Beats
 [here](https://www.elastic.co/guide/en/beats/libbeat/master/community-beats.html).
@@ -67,7 +67,7 @@ Please start by reading our [CONTRIBUTING](CONTRIBUTING.md) file.
 If you are creating a new Beat, you don't need to submit the code to this
 repository. You can simply start working in a new repository and make use of
 the libbeat packages, by following our [developer
-guide](https://www.elastic.co/guide/en/beats/libbeat/master/new-beat.html).
+guide](https://www.elastic.co/guide/en/beats/libbeat/current/new-beat.html).
 After you have a working prototype, open a pull request to add your Beat to the
 list of [community
 Beats](https://github.com/elastic/beats/blob/master/libbeat/docs/communitybeats.asciidoc).


### PR DESCRIPTION
This PR fixes 2 URLs in the README.md file:
 * fix Beats current developer guide URL
 * add https protocol on Elastic website URL