### PR TITLE
Add filesystem.ignore_types to ignore filesystem types

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -81,6 +81,8 @@ https://github.com/elastic/beats/compare/v5.4.1...master[Check the HEAD diff]
 
 *Metricbeat*
 
+- Add `filesystem.ignore_types` to system module for ignoring filesystem types. {issue}4685[4685]
+
 *Packetbeat*
 
 *Winlogbeat*

--- a/metricbeat/metricbeat.full.yml
+++ b/metricbeat/metricbeat.full.yml
@@ -65,7 +65,7 @@ metricbeat.modules:
   #cpu_ticks: false
 
   # A list of filesystem types to ignore. The filesystem metricset will not
-  # collect data from filesystems matching any of the specified types and
+  # collect data from filesystems matching any of the specified types, and
   # fsstats will not include data from these filesystems in its summary stats.
   #filesystem.ignore_types: []
 

--- a/metricbeat/metricbeat.full.yml
+++ b/metricbeat/metricbeat.full.yml
@@ -64,6 +64,11 @@ metricbeat.modules:
   # if true, exports the CPU usage in ticks, together with the percentage values
   #cpu_ticks: false
 
+  # A list of filesystem types to ignore. The filesystem metricset will not
+  # collect data from filesystems matching any of the specified types and
+  # fsstats will not include data from these filesystems in its summary stats.
+  #filesystem.ignore_types: []
+
   # Enable collection of cgroup metrics from processes on Linux.
   #process.cgroups.enabled: true
 

--- a/metricbeat/module/system/_meta/config.full.yml
+++ b/metricbeat/module/system/_meta/config.full.yml
@@ -37,7 +37,7 @@
   #cpu_ticks: false
 
   # A list of filesystem types to ignore. The filesystem metricset will not
-  # collect data from filesystems matching any of the specified types and
+  # collect data from filesystems matching any of the specified types, and
   # fsstats will not include data from these filesystems in its summary stats.
   #filesystem.ignore_types: []
 

--- a/metricbeat/module/system/_meta/config.full.yml
+++ b/metricbeat/module/system/_meta/config.full.yml
@@ -36,6 +36,11 @@
   # if true, exports the CPU usage in ticks, together with the percentage values
   #cpu_ticks: false
 
+  # A list of filesystem types to ignore. The filesystem metricset will not
+  # collect data from filesystems matching any of the specified types and
+  # fsstats will not include data from these filesystems in its summary stats.
+  #filesystem.ignore_types: []
+
   # Enable collection of cgroup metrics from processes on Linux.
   #process.cgroups.enabled: true
 

--- a/metricbeat/module/system/filesystem/_meta/docs.asciidoc
+++ b/metricbeat/module/system/filesystem/_meta/docs.asciidoc
@@ -39,7 +39,7 @@ metricbeat.modules:
 Another strategy to deal with these filesystems is to configure a `drop_event`
 filter that matches the `mount_point` using a regular expression. This type of
 filtering occurs after the data has been collected so it can be less efficient
-that the previous method.
+than the previous method.
 
 [source,yaml]
 ----

--- a/metricbeat/module/system/filesystem/_meta/docs.asciidoc
+++ b/metricbeat/module/system/filesystem/_meta/docs.asciidoc
@@ -12,12 +12,34 @@ This metricset is available on:
 - Windows
 
 [float]
+=== Configuration
+
+*`filesystem.ignore_types`* - A list of filesystem types to ignore. Metrics will
+not be collected from filesystems matching these types. This setting also
+affects the `fsstats` metricset.
+
+[float]
 === Filtering
 
 Often there are mounted filesystems that you do not want Metricbeat to report
-metrics on. A simple strategy to deal with these filesystems is to configure a
-drop_event filter that matches the `mount_point` using a regular expression.
-Below is an example.
+metrics on. One option is to configure Metricbeat to ignore specific filesystem
+types. This can be accomplished by configuring `filesystem.ignore_types` with
+a list of filesystem types to ignore. In this example we are ignoring three
+types of filesystems.
+
+[source,yaml]
+----
+metricbeat.modules:
+  - module: system
+    period: 30s
+    metricsets: ["filesystem"]
+    filesystem.ignore_types: [nfs, smbfs, autofs]
+----
+
+Another strategy to deal with these filesystems is to configure a `drop_event`
+filter that matches the `mount_point` using a regular expression. This type of
+filtering occurs after the data has been collected so it can be less efficient
+that the previous method.
 
 [source,yaml]
 ----

--- a/metricbeat/module/system/filesystem/helper_test.go
+++ b/metricbeat/module/system/filesystem/helper_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	sigar "github.com/elastic/gosigar"
 )
 
 func TestFileSystemList(t *testing.T) {
@@ -38,5 +40,20 @@ func TestFileSystemList(t *testing.T) {
 			assert.True(t, (stat.Avail >= 0))
 			assert.True(t, (stat.Used >= 0))
 		}
+	}
+}
+
+func TestFilter(t *testing.T) {
+	in := []sigar.FileSystem{
+		{SysTypeName: "nfs"},
+		{SysTypeName: "ext4"},
+		{SysTypeName: "proc"},
+		{SysTypeName: "smb"},
+	}
+
+	out := Filter(in, BuildTypeFilter("nfs", "smb", "proc"))
+
+	if assert.Len(t, out, 1) {
+		assert.Equal(t, "ext4", out[0].SysTypeName)
 	}
 }

--- a/metricbeat/module/system/fsstat/_meta/docs.asciidoc
+++ b/metricbeat/module/system/fsstat/_meta/docs.asciidoc
@@ -9,3 +9,10 @@ This metricset is available on:
 - Linux
 - OpenBSD
 - Windows
+
+[float]
+=== Configuration
+
+*`filesystem.ignore_types`* - A list of filesystem types to ignore. Metrics will
+not be collected from filesystems matching these types. This setting also
+affects the `filesystem` metricset.


### PR DESCRIPTION
Add `filesystem.ignore_types` to the system module for ignoring filesystems
in the `filesystem` and `fsstat` metricsets. The new configuration option
accepts a list of filesystem types.

    metricbeat.modules:
    - module: system
      metricsets: [filesystem, fsstat]
      filesystem.ignore_types: [nfs, smbfs, proc, cgroups]

Closes #4685