### PR TITLE
add cloudwatchlogsbeat to community beats

### DIFF
--- a/libbeat/docs/communitybeats.asciidoc
+++ b/libbeat/docs/communitybeats.asciidoc
@@ -26,6 +26,7 @@ https://github.com/goomzee/burrowbeat[burrowbeat]:: Monitors Kafka consumer lag 
 https://github.com/goomzee/cassandrabeat[cassandrabeat]:: Uses Cassandra's nodetool cfstats utility to monitor Cassandra database nodes and lag.
 https://github.com/hartfordfive/cloudflarebeat[cloudflarebeat]:: Indexes log entries from the Cloudflare Enterprise Log Share API.
 https://github.com/aidan-/cloudtrailbeat[cloudtrailbeat]:: Reads events from Amazon Web Services' https://aws.amazon.com/cloudtrail/[CloudTrail].
+https://github.com/e-travel/cloudwatchlogsbeat[cloudwatchlogsbeat]:: Reads log events from Amazon Web Services' https://aws.amazon.com/cloudwatch/details/#log-monitoring[CloudWatch Logs].
 https://github.com/raboof/connbeat[connbeat]:: Exposes metadata about TCP connections.
 https://github.com/Pravoru/consulbeat[consulbeat]:: Reads services health checks from consul and pushes them to Elastic.
 https://github.com/Ingensi/dockbeat[dockbeat]:: Reads Docker container


### PR DESCRIPTION
We have developed a new beat for harvesting log events from AWS CloudWatch Logs and forwarding them to logstash / elasticsearch etc.

This PR adds our beat to the list of community beats.