### PR TITLE
Add support for dynamic param in fields

### DIFF
--- a/libbeat/template/field_test.go
+++ b/libbeat/template/field_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/go-ucfg/yaml"
 )
 
 func TestField(t *testing.T) {
@@ -132,6 +133,27 @@ func TestField(t *testing.T) {
 				},
 			},
 		},
+		{
+			field:  Field{Dynamic: dynamicType{false}},
+			method: func(f Field) common.MapStr { return f.other() },
+			output: common.MapStr{
+				"dynamic": false,
+			},
+		},
+		{
+			field:  Field{Dynamic: dynamicType{true}},
+			method: func(f Field) common.MapStr { return f.other() },
+			output: common.MapStr{
+				"dynamic": true,
+			},
+		},
+		{
+			field:  Field{Dynamic: dynamicType{"strict"}},
+			method: func(f Field) common.MapStr { return f.other() },
+			output: common.MapStr{
+				"dynamic": "strict",
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -194,5 +216,65 @@ func TestDynamicTemplate(t *testing.T) {
 		dynamicTemplates = nil
 		test.method(test.field)
 		assert.Equal(t, test.output, dynamicTemplates[0])
+	}
+}
+
+func TestDynamicYaml(t *testing.T) {
+	tests := []struct {
+		input  []byte
+		output Field
+		error  bool
+	}{
+		{
+			input: []byte(`
+name: test
+dynamic: true
+`),
+			output: Field{
+				Name:    "test",
+				Dynamic: dynamicType{true},
+			},
+		},
+		{
+			input: []byte(`
+name: test
+dynamic: "true"
+`),
+			output: Field{
+				Name:    "test",
+				Dynamic: dynamicType{true},
+			},
+		},
+		{
+			input: []byte(`
+name: test
+dynamic: "blue"
+`),
+			error: true,
+		},
+		{
+			input: []byte(`
+name: test
+dynamic: "strict"
+`),
+			output: Field{
+				Name:    "test",
+				Dynamic: dynamicType{"strict"},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		keys := Field{}
+
+		cfg, err := yaml.NewConfig(test.input)
+		assert.NoError(t, err)
+		err = cfg.Unpack(&keys)
+
+		if err != nil {
+			assert.True(t, test.error)
+		} else {
+			assert.Equal(t, test.output.Dynamic, keys.Dynamic)
+		}
 	}
 }


### PR DESCRIPTION
In fields.yml `dynamic: false` or `dynamic: strict` can now be used. For more details see https://www.elastic.co/guide/en/elasticsearch/reference/current/dynamic.html