### PR TITLE
Add SetValue method to libbeat common.MapStr

### DIFF
--- a/libbeat/common/mapstr.go
+++ b/libbeat/common/mapstr.go
@@ -138,13 +138,13 @@ func (m MapStr) Put(key string, value interface{}) (interface{}, error) {
 	return walkMap(key, m, mapStrOperation{putOperation{value}, true})
 }
 
-// Dereferences a value if it is a pointer. Sets the dereferenced value if not nil.
+// SetValue dereferences a value if it is a pointer. Sets the dereferenced value if not nil.
 // If value is a MapStr or an array, the value is set if not empty.
 // Supported data types so far: *string, *int, *boolean, common.MapStr, array[]int, array[]string.
 // Values of unsupported types are set if they are not nil.
 // Sets a value for a given key if the (dereferenced) value is not nil or empty.
 func (m MapStr) SetValue(key string, value interface{}) {
-	walkMap(key, m, mapStrOperation{setOperation{value}, true})
+	walkMap(key, m, mapStrOperation{setValueOperation{value}, true})
 }
 
 // StringToPrint returns the MapStr as pretty JSON.
@@ -390,11 +390,11 @@ func (op putOperation) Do(key string, data MapStr) (interface{}, error) {
 	return existingValue, nil
 }
 
-type setOperation struct {
+type setValueOperation struct {
 	Value interface{}
 }
 
-func (op setOperation) Do(key string, data MapStr) (interface{}, error) {
+func (op setValueOperation) Do(key string, data MapStr) (interface{}, error) {
 	if op.Value == nil {
 		return data, nil
 	}

--- a/libbeat/common/mapstr.go
+++ b/libbeat/common/mapstr.go
@@ -138,6 +138,15 @@ func (m MapStr) Put(key string, value interface{}) (interface{}, error) {
 	return walkMap(key, m, mapStrOperation{putOperation{value}, true})
 }
 
+// Dereferences a value if it is a pointer. Sets the dereferenced value if not nil.
+// If value is a MapStr or an array, the value is set if not empty.
+// Supported data types so far: *string, *int, *boolean, common.MapStr, array[]int, array[]string.
+// Values of unsupported types are set if they are not nil.
+// Sets a value for a given key if the (dereferenced) value is not nil or empty.
+func (m MapStr) SetValue(key string, value interface{}) {
+	walkMap(key, m, mapStrOperation{setOperation{value}, true})
+}
+
 // StringToPrint returns the MapStr as pretty JSON.
 func (m MapStr) StringToPrint() string {
 	json, err := json.MarshalIndent(m, "", "  ")
@@ -379,4 +388,44 @@ func (op putOperation) Do(key string, data MapStr) (interface{}, error) {
 	existingValue, _ := data[key]
 	data[key] = op.Value
 	return existingValue, nil
+}
+
+type setOperation struct {
+	Value interface{}
+}
+
+func (op setOperation) Do(key string, data MapStr) (interface{}, error) {
+	if op.Value == nil {
+		return data, nil
+	}
+
+	switch op.Value.(type) {
+	case *bool:
+		if newVal := op.Value.(*bool); newVal != nil {
+			data[key] = *newVal
+		}
+	case *int:
+		if newVal := op.Value.(*int); newVal != nil {
+			data[key] = *newVal
+		}
+	case *string:
+		if newVal := op.Value.(*string); newVal != nil {
+			data[key] = *newVal
+		}
+	case MapStr:
+		if valMap := op.Value.(MapStr); len(valMap) > 0 {
+			data[key] = valMap
+		}
+	case []int:
+		if valArr := op.Value.([]int); len(valArr) > 0 {
+			data[key] = valArr
+		}
+	case []string:
+		if valArr := op.Value.([]string); len(valArr) > 0 {
+			data[key] = valArr
+		}
+	default:
+		data[key] = op.Value
+	}
+	return data, nil
 }

--- a/libbeat/common/mapstr_test.go
+++ b/libbeat/common/mapstr_test.go
@@ -221,6 +221,60 @@ func TestMapStrPut(t *testing.T) {
 	assert.Equal(t, MapStr{"subMap": MapStr{"newMap": MapStr{"a": 1}}}, m)
 }
 
+func TestMapStrSet(t *testing.T) {
+	m := MapStr{
+		"i1": 123,
+		"s1": "123",
+		"b1": false,
+		"x3": MapStr{
+			"b41": "val.b41",
+		},
+	}
+	type io struct {
+		Key      string
+		Val      interface{}
+		Fetch    string
+		Expected interface{}
+	}
+
+	mapVal := MapStr{"newKey": "newVal"}
+	arrStrVal := []string{"v1", "v2"}
+	arrIntVal := []int{1, 2, 3}
+	str := "strPtr"
+	var emptyStrPtr *string
+	i := 44
+	var emptyIntPtr *int
+	b := false
+	var emptyBoolPtr *bool
+	tests := []io{
+		{Key: "x3.b42", Val: "b42New", Fetch: "x3", Expected: MapStr{"b41": "val.b41", "b42": "b42New"}},
+		{Key: "m1", Val: mapVal, Fetch: "m1", Expected: mapVal},
+		{Key: "m2", Val: MapStr{}, Fetch: "m2", Expected: nil},
+		{Key: "a1", Val: arrStrVal, Fetch: "a1", Expected: arrStrVal},
+		{Key: "a2", Val: []string{}, Fetch: "a2", Expected: nil},
+		{Key: "a3", Val: arrIntVal, Fetch: "a3", Expected: arrIntVal},
+		{Key: "a4", Val: []int{}, Fetch: "a2", Expected: nil},
+		{Key: "s1", Val: nil, Fetch: "s1", Expected: "123"},
+		{Key: "s1", Val: "s1New", Fetch: "s1", Expected: "s1New"},
+		{Key: "s2", Val: emptyStrPtr, Fetch: "s2", Expected: nil},
+		{Key: "s3", Val: &str, Fetch: "s3", Expected: "strPtr"},
+		{Key: "i1", Val: nil, Fetch: "i1", Expected: 123},
+		{Key: "i1", Val: 456, Fetch: "i1", Expected: 456},
+		{Key: "i2", Val: emptyIntPtr, Fetch: "i2", Expected: nil},
+		{Key: "i3", Val: &i, Fetch: "i3", Expected: 44},
+		{Key: "b1", Val: nil, Fetch: "b1", Expected: false},
+		{Key: "b1", Val: true, Fetch: "b1", Expected: true},
+		{Key: "b2", Val: emptyBoolPtr, Fetch: "b2", Expected: nil},
+		{Key: "b3", Val: &b, Fetch: "b3", Expected: false},
+	}
+	for idx, test := range tests {
+		m.SetValue(test.Key, test.Val)
+		fetched, _ := m.GetValue(test.Fetch)
+		errMsg := fmt.Sprintf("Failed for %v: Expected %v, Received %v", idx, test.Expected, fetched)
+		assert.Equal(t, test.Expected, fetched, errMsg)
+	}
+}
+
 func TestClone(t *testing.T) {
 	assert := assert.New(t)
 


### PR DESCRIPTION
SetValue dereferences given values for *int, *string and *boolean,
otherwise it just sets the value for the given key as long as the value
is not nil or empty.