### PR TITLE
Cherry-pick #4765 to 6.0: Use ProgramData for Windows service logs

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -13,6 +13,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta1...master[Check the HEAD di
 ==== Breaking changes
 
 *Affecting all Beats*
+- The log directory (`path.log`) for Windows services is now set to `C:\ProgramData\[beatname]\logs`. {issue}4764[4764]
 
 *Auditbeat*
 

--- a/dev-tools/packer/platforms/windows/install-service.ps1.j2
+++ b/dev-tools/packer/platforms/windows/install-service.ps1.j2
@@ -11,4 +11,4 @@ $workdir = Split-Path $MyInvocation.MyCommand.Path
 # create new service
 New-Service -name {{.beat_name}} `
   -displayName {{.beat_name}} `
-  -binaryPathName "`"$workdir\\{{.beat_name}}.exe`" -c `"$workdir\\{{.beat_name}}.yml`" -path.home `"$workdir`" -path.data `"C:\\ProgramData\\{{.beat_name}}`""
+  -binaryPathName "`"$workdir\\{{.beat_name}}.exe`" -c `"$workdir\\{{.beat_name}}.yml`" -path.home `"$workdir`" -path.data `"C:\\ProgramData\\{{.beat_name}}`" -path.logs `"C:\\ProgramData\\{{.beat_name}}\logs`""


### PR DESCRIPTION
Cherry-pick of PR #4765 to 6.0 branch. Original message: 

The logs for Beats that are running as Windows services are currently written to `C:\Program Files\[beatname]\logs` (or the extract path which is `path.home`). Our Getting Started guides say that the logs go to `C:\ProgramData\[beatname]\Logs`. This PR sets `path.log` for the Windows service to `C:\ProgramData\[beatname]\logs`.

See #4764