### PR TITLE
Wait for registry to exist on tests

### DIFF
--- a/filebeat/tests/system/filebeat.py
+++ b/filebeat/tests/system/filebeat.py
@@ -19,7 +19,7 @@ class BaseTest(TestCase):
     def get_registry(self):
         # Returns content of the registry file
         dotFilebeat = self.working_dir + '/registry'
-        assert os.path.isfile(dotFilebeat) is True
+        self.wait_until(cond=lambda: os.path.isfile(dotFilebeat))
 
         with open(dotFilebeat) as file:
             return json.load(file)


### PR DESCRIPTION
Quite a few of our tests fail because the registry does not exist yet when checked. This PR changes the get_registry function to wait until the registry exists and then return it. This should make some of the tests more stable.