### PR TITLE
Change deprecated _default_ mapping to doc in index templates

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -35,6 +35,8 @@ https://github.com/elastic/beats/compare/v6.0.0-beta1...master[Check the HEAD di
 *Affecting all Beats*
 - Fix go plugins not loaded when beat starts {pull}4799[4799]
 
+- Eliminate deprecated _default_ mapping in 6.x {pull}4864[4864]
+
 *Auditbeat*
 
 - Fix `file.max_file_size` config option for the audit file metricset. {pull}4796[4796]

--- a/libbeat/ml-importer/importer_integration_test.go
+++ b/libbeat/ml-importer/importer_integration_test.go
@@ -49,7 +49,7 @@ const sampleDatafeed = `
       "filebeat-*"
     ],
     "types": [
-      "_default_",
+      "doc",
       "log"
     ],
     "query": {

--- a/libbeat/template/load_integration_test.go
+++ b/libbeat/template/load_integration_test.go
@@ -197,7 +197,7 @@ func TestTemplateSettings(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, val.(string), "1")
 
-	val, err = templateJSON.GetValue("mappings._default_._source.enabled")
+	val, err = templateJSON.GetValue("mappings.doc._source.enabled")
 	assert.NoError(t, err)
 	assert.Equal(t, val.(bool), false)
 
@@ -255,7 +255,7 @@ func TestOverwrite(t *testing.T) {
 
 	// Overwrite was not enabled, so the first version should still be there
 	templateJSON := getTemplate(t, client, templateName)
-	_, err = templateJSON.GetValue("mappings._default_._source.enabled")
+	_, err = templateJSON.GetValue("mappings.doc._source.enabled")
 	assert.Error(t, err)
 
 	// Load template again, this time with custom settings AND overwrite: true
@@ -276,7 +276,7 @@ func TestOverwrite(t *testing.T) {
 
 	// Overwrite was enabled, so the custom setting should be there
 	templateJSON = getTemplate(t, client, templateName)
-	val, err := templateJSON.GetValue("mappings._default_._source.enabled")
+	val, err := templateJSON.GetValue("mappings.doc._source.enabled")
 	assert.NoError(t, err)
 	assert.Equal(t, val.(bool), false)
 

--- a/libbeat/template/template.go
+++ b/libbeat/template/template.go
@@ -98,10 +98,17 @@ func (t *Template) generate(properties common.MapStr, dynamicTemplates []common.
 	}
 	indexSettings.DeepUpdate(t.settings.Index)
 
+	var mappingName string
+	if t.esVersion.Major >= 6 {
+		mappingName = "doc"
+	} else {
+		mappingName = "_default_"
+	}
+
 	// Load basic structure
 	basicStructure := common.MapStr{
 		"mappings": common.MapStr{
-			"_default_": common.MapStr{
+			mappingName: common.MapStr{
 				"_meta": common.MapStr{
 					"version": t.beatVersion.String(),
 				},
@@ -117,7 +124,8 @@ func (t *Template) generate(properties common.MapStr, dynamicTemplates []common.
 	}
 
 	if len(t.settings.Source) > 0 {
-		basicStructure.Put("mappings._default_._source", t.settings.Source)
+		key := fmt.Sprintf("mappings.%s._source", mappingName)
+		basicStructure.Put(key, t.settings.Source)
 	}
 
 	// ES 6 moved from template to index_patterns: https://github.com/elastic/elasticsearch/pull/21009


### PR DESCRIPTION
`_default_` has been changed to `doc` as seen in this example: https://www.elastic.co/guide/en/elasticsearch/reference/master/mapping.html#_example_mapping

Closes #4840