### PR TITLE
Set default credentials for Kibana

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -60,6 +60,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta1...master[Check the HEAD di
 *Affecting all Beats*
 
 - Update init scripts to use the `test config` subcommand instead of the deprecated `-configtest` flag. {issue}4600[4600]
+- Get by default the credentials for connecting to Kibana from the Elasticsearch output configuration. {pull}4867[4867]
 
 *Auditbeat*
 

--- a/libbeat/dashboards/importer.go
+++ b/libbeat/dashboards/importer.go
@@ -272,11 +272,22 @@ func (imp Importer) ImportKibanaDir(dir string) error {
 		return fmt.Errorf("The directory %s does not contain the %s subdirectory."+
 			" There is nothing to import into Kibana.", dir, strings.Join(check, " or "))
 	}
+
+	importDashboards := false
 	for _, t := range types {
 		err = imp.ImportDir(t, dir)
 		if err != nil {
 			return fmt.Errorf("Failed to import %s: %v", t, err)
 		}
+
+		if t == "dashboard" {
+			importDashboards = true
+		}
+	}
+
+	if !importDashboards {
+		return fmt.Errorf("No dashboards to import. Please make sure the %s directory contains a dashboard directory.",
+			dir)
 	}
 	return nil
 }

--- a/libbeat/dashboards/kibana_loader.go
+++ b/libbeat/dashboards/kibana_loader.go
@@ -21,6 +21,11 @@ type KibanaLoader struct {
 }
 
 func NewKibanaLoader(cfg *common.Config, dashboardsConfig *Config, msgOutputter MessageOutputter) (*KibanaLoader, error) {
+
+	if cfg == nil || !cfg.Enabled() {
+		return nil, fmt.Errorf("Kibana is not configured or enabled")
+	}
+
 	client, err := kibana.NewKibanaClient(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("Error creating Kibana client: %v", err)


### PR DESCRIPTION
When loading the dashboards from Beats 6.0, the user needs to configure:
- Elasticsearch URL
- Kibana URL
- Elasticsearch credentials 
- Kibana credentials

In Could, the credentials for connecting to Elasticsearch are the same as for connecting to Kibana, so the last step can be removed if we take (by default) the Kibana credentials from the Elasticsearch credentials.

This PR gets by default the credentials for Kibana from Elasticsearch configuration.