### PR TITLE
Fix missing MongoDB config from the `modules.d` folder

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -52,6 +52,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta1...master[Check the HEAD di
 *Metricbeat*
 
 - Support `npipe` protocol (Windows) in Docker module. {pull}4751[4751]
+- Added missing mongodb configuration file to the `modules.d` folder. {pull}4870[4870]
 
 *Packetbeat*
 
@@ -80,7 +81,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta1...master[Check the HEAD di
 - Add graphite protocol metricbeat module. {pull}4734[4734]
 - Add http server metricset to support push metrics via http. {pull}4770[4770]
 - Make config object public for graphite and http server {pull}4820[4820]
- 
+
 *Packetbeat*
 
 *Winlogbeat*

--- a/filebeat/Makefile
+++ b/filebeat/Makefile
@@ -41,7 +41,7 @@ configs: python-env
 	@${PYTHON_ENV}/bin/python  ${ES_BEATS}/script/config_collector.py --beat ${BEAT_NAME} --full $(PWD) >> _meta/beat.reference.yml
 	@cat ${ES_BEATS}/filebeat/_meta/common.reference.p2.yml >> _meta/beat.reference.yml
 	@rm -rf modules.d && mkdir -p modules.d
-	@for MODULE in `ls module | grep -v .go`; do cp -a $(PWD)/module/$$MODULE/_meta/config.yml modules.d/$$MODULE.yml.disabled; done
+	@for MODULE in `find module -type d -maxdepth 1 -mindepth 1 -exec basename {} \;`; do cp -a $(PWD)/module/$$MODULE/_meta/config.yml modules.d/$$MODULE.yml.disabled; done
 	@chmod go-w modules.d/*
 
 # Collects all module docs

--- a/metricbeat/Makefile
+++ b/metricbeat/Makefile
@@ -46,7 +46,7 @@ configs: python-env
 	@cat ${ES_BEATS}/metricbeat/_meta/common.reference.yml > _meta/beat.reference.yml
 	@${PYTHON_ENV}/bin/python ${ES_BEATS}/script/config_collector.py --beat ${BEAT_NAME} --full $(PWD) >> _meta/beat.reference.yml
 	@rm -rf modules.d && mkdir -p modules.d
-	@for MODULE in `ls module | grep -v .go`; do cp -a $(PWD)/module/$$MODULE/_meta/config.yml modules.d/$$MODULE.yml.disabled; done
+	@for MODULE in `find module -type d -maxdepth 1 -mindepth 1 -exec basename {} \;`; do cp -a $(PWD)/module/$$MODULE/_meta/config.yml modules.d/$$MODULE.yml.disabled; done
 	@chmod go-w modules.d/*
 	@# Enable system by default:
 	@if [ -f modules.d/system.yml.disabled ]; then mv modules.d/system.yml.disabled modules.d/system.yml; fi

--- a/metricbeat/modules.d/mongodb.yml.disabled
+++ b/metricbeat/modules.d/mongodb.yml.disabled
@@ -1,0 +1,16 @@
+- module: mongodb
+  metricsets: ["dbstats", "status"]
+  period: 10s
+
+  # The hosts must be passed as MongoDB URLs in the format:
+  # [mongodb://][user:pass@]host[:port].
+  # The username and password can also be set using the respective configuration
+  # options. The credentials in the URL take precedence over the username and
+  # password configuration options.
+  hosts: ["localhost:27017"]
+
+  # Username to use when connecting to MongoDB. Empty by default.
+  #username: user
+
+  # Password to use when connecting to MongoDB. Empty by default.
+  #password: pass


### PR DESCRIPTION
The command that collected the configurations, used something like
this to list the modules:

    ls module | grep -v .go

Problem was, `mongodb` matched the `.go` grep, so it was excluded :)

This PR uses `find` to list the directories.