### PR TITLE
Experiment: How to run metricbeat module tests differently

### DIFF
--- a/metricbeat/Makefile
+++ b/metricbeat/Makefile
@@ -93,3 +93,7 @@ test-module: ## @testing Tests the given module. Needs $MODULE as param an run-m
 test-module: python-env
 	go test -tags=integration ${BEAT_PATH}/module/${MODULE}/... -v
 	. ${PYTHON_ENV}/bin/activate && INTEGRATION_TESTS=1 nosetests tests/system/test_${MODULE}.py
+
+modules-tests:
+	./scripts/module_tests.sh
+

--- a/metricbeat/module/apache/status/status_integration_test.go
+++ b/metricbeat/module/apache/status/status_integration_test.go
@@ -39,6 +39,6 @@ func getConfig() map[string]interface{} {
 	return map[string]interface{}{
 		"module":     "apache",
 		"metricsets": []string{"status"},
-		"hosts":      []string{apache.GetApacheEnvHost()},
+		"hosts":      []string{apache.GetApacheEnvHost(): apache.GetApacheEnvPort()},
 	}
 }

--- a/metricbeat/module/apache/testing.go
+++ b/metricbeat/module/apache/testing.go
@@ -17,3 +17,15 @@ func GetApacheEnvHost() string {
 	}
 	return host
 }
+
+// GetApacheEnvPort returns the port of the apache server to use for testing.
+// It reads the value from the APACHE_PORT environment variable and returns
+// 80 if it is not set.
+func GetApacheEnvPort() string {
+	port := os.Getenv("APACHE_PORT")
+
+	if len(port) == 0 {
+		port = "80"
+	}
+	return port
+}

--- a/metricbeat/module/docker-compose.yml
+++ b/metricbeat/module/docker-compose.yml
@@ -11,5 +11,5 @@ services:
   module:
     build: ${PWD}/module/${MODULE}/_meta
     ports:
-      - ${PORT}:${PORT}
+      - 12345:${PORT}
 

--- a/metricbeat/module/docker-compose.yml
+++ b/metricbeat/module/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '2.1'
+services:
+  # This is a proxy used to block starting until all services are healthy.
+  # See: https://github.com/docker/compose/issues/4369
+  proxy:
+    image: busybox
+    depends_on:
+      module:
+        condition: service_healthy
+
+  module:
+    build: ${PWD}/module/${MODULE}/_meta
+    ports:
+      - ${PORT}:${PORT}
+

--- a/metricbeat/module/mysql/_meta/env
+++ b/metricbeat/module/mysql/_meta/env
@@ -1,3 +1,3 @@
-MYSQL_DSN=root:test@tcp(mysql:3306)/
+MYSQL_DSN="root:test@tcp(mysql:3306)/"
 MYSQL_HOST=mysql
 MYSQL_PORT=3306

--- a/metricbeat/scripts/module_tests.sh
+++ b/metricbeat/scripts/module_tests.sh
@@ -27,7 +27,7 @@ for d in * ; do
             export "${VAR_NAME}"="12345"
             # Using docker compose to wait for healthy container
             MODULE=$d PORT=${PORT} docker-compose -f module/docker-compose.yml up -d
-            go test -tags=integration ${BEAT_PATH}/module/${d}/... -v
+            source module/$d/_meta/env || true; go test -tags=integration ${BEAT_PATH}/module/${d}/... -v
             MODULE=$d PORT=${PORT} docker-compose -f module/docker-compose.yml down
             cd module
 

--- a/metricbeat/scripts/module_tests.sh
+++ b/metricbeat/scripts/module_tests.sh
@@ -23,12 +23,13 @@ for d in * ; do
         # Only modules with a port are expected to have system tests
         if [ "$PORT" -ne "0" ]; then
             cd ..
+
+            export "${VAR_NAME}"="12345"
             # Using docker compose to wait for healthy container
             MODULE=$d PORT=${PORT} docker-compose -f module/docker-compose.yml up -d
             go test -tags=integration ${BEAT_PATH}/module/${d}/... -v
             MODULE=$d PORT=${PORT} docker-compose -f module/docker-compose.yml down
             cd module
-
 
             #docker build -t ${d}:metricbeat ../module/${d}/_meta/
             #docker run -p ${PORT}:${PORT} -d --name metricbeat-${MODULE} ${d}:metricbeat

--- a/metricbeat/scripts/module_tests.sh
+++ b/metricbeat/scripts/module_tests.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+BEAT_PATH=github.com/elastic/beats/metricbeat
+
+cd module
+
+for d in * ; do
+    if [[ -d $d ]]; then
+
+        # Create names from directory name
+        MODULE=$(echo $d | tr 'a-z' 'A-Z')
+        VAR_NAME=${MODULE}_PORT
+        declare "${VAR_NAME}"=0
+
+        # Load part from env file
+        source $d/_meta/env || true
+        PORT=${!VAR_NAME}
+
+        # TODO: How to load env variables like mysql password?
+
+        echo $d:$PORT
+
+        # Only modules with a port are expected to have system tests
+        if [ "$PORT" -ne "0" ]; then
+            cd ..
+            # Using docker compose to wait for healthy container
+            MODULE=$d PORT=${PORT} docker-compose -f module/docker-compose.yml up -d
+            go test -tags=integration ${BEAT_PATH}/module/${d}/... -v
+            MODULE=$d PORT=${PORT} docker-compose -f module/docker-compose.yml down
+            cd module
+
+
+            #docker build -t ${d}:metricbeat ../module/${d}/_meta/
+            #docker run -p ${PORT}:${PORT} -d --name metricbeat-${MODULE} ${d}:metricbeat
+            #go test -tags=integration ${BEAT_PATH}/module/${d}/... -v
+            #docker stop  metricbeat-${MODULE}
+            #docker rm --name metricbeat-${MODULE}
+        fi;
+
+    fi;
+done
+
+


### PR DESCRIPTION
This introduces a script that starts the environment for each module and tears it down again after the tests.

Currently missing is setting the right environment parameters like the password for the tests. I'm sure there is a way to easily load and set ENV variables from a file.

Other open issues:

* How would `integration-tests` execute this command?
* This requires that the ports which are needed for testing are available on the machine. This could be especially problematic for port 80 for example. We could generate a temp env file to have different ports or always export to a specific port instead.