### PR TITLE
Cherry-pick #4855 to 6.0: Fix wrong timestamp in heartbeat events

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -39,6 +39,8 @@ https://github.com/elastic/beats/compare/v6.0.0-beta1...master[Check the HEAD di
 
 *Heartbeat*
 
+- Fix wrong event timestamps. {issue}4851[4851]
+
 *Metricbeat*
 
 *Packetbeat*

--- a/heartbeat/monitors/util.go
+++ b/heartbeat/monitors/util.go
@@ -97,7 +97,11 @@ func MakeJob(settings JobSettings, f func() (common.MapStr, []TaskRunner, error)
 		},
 	})
 
-	return &funcJob{settings, annotated(settings, time.Now(), f)}
+	return &funcJob{settings, func() (beat.Event, []JobRunner, error) {
+		// Create and run new annotated Job whenever the Jobs root is Task is executed.
+		// This will set the jobs active start timestamp to the time.Now().
+		return annotated(settings, time.Now(), f)()
+	}}
 }
 
 // annotated lifts a TaskRunner into a job, annotating events with common fields and start timestamp.
@@ -405,12 +409,6 @@ func (f *funcJob) Name() string { return f.settings.Name }
 func (f *funcJob) Run() (beat.Event, []JobRunner, error) { return f.run() }
 
 func (f funcTask) Run() (common.MapStr, []TaskRunner, error) { return f.run() }
-
-/*
-func (f funcTask) annotated(settings JobSettings, start time.Time) TaskRunner {
-	return annotated(settings, start, f.run)
-}
-*/
 
 // Unpack sets PingMode from a constant string. Unpack will be called by common.Unpack when
 // unpacking into an IPSettings type.


### PR DESCRIPTION
Cherry-pick of PR #4855 to 6.0 branch. Original message: 

Resolves: #4851 