### PR TITLE
Cherry-pick #4856 to 6.0: Fix monitor.name being empty by default

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -39,6 +39,8 @@ https://github.com/elastic/beats/compare/v6.0.0-beta1...master[Check the HEAD di
 
 *Heartbeat*
 
+- Fix monitor.name being empty by default. {issue}4852[4852]
+
 *Metricbeat*
 
 *Packetbeat*

--- a/heartbeat/_meta/kibana/5.x/search/02014c80-29d2-11e7-a68f-bfaa2341cc52.json
+++ b/heartbeat/_meta/kibana/5.x/search/02014c80-29d2-11e7-a68f-bfaa2341cc52.json
@@ -8,7 +8,7 @@
   "title": "Heartbeat HTTP pings", 
   "version": 1, 
   "kibanaSavedObjectMeta": {
-    "searchSourceJSON": "{\n  \"index\": \"heartbeat-*\",\n  \"highlightAll\": true,\n  \"query\": {\n    \"query_string\": {\n      \"analyze_wildcard\": true,\n      \"query\": \"*\"\n    }\n  },\n  \"filter\": [\n    {\n      \"$state\": {\n        \"store\": \"appState\"\n      },\n      \"meta\": {\n        \"alias\": null,\n        \"disabled\": false,\n        \"index\": \"heartbeat-*\",\n        \"key\": \"monitor.name\",\n        \"negate\": false,\n        \"value\": \"http\"\n      },\n      \"query\": {\n        \"match\": {\n          \"monitor.name\": {\n            \"query\": \"http\",\n            \"type\": \"phrase\"\n          }\n        }\n      }\n    }\n  ]\n}"
+    "searchSourceJSON": "{\n  \"index\": \"heartbeat-*\",\n  \"highlightAll\": true,\n  \"query\": {\n    \"query_string\": {\n      \"analyze_wildcard\": true,\n      \"query\": \"*\"\n    }\n  },\n  \"filter\": [\n    {\n      \"$state\": {\n        \"store\": \"appState\"\n      },\n      \"meta\": {\n        \"alias\": null,\n        \"disabled\": false,\n        \"index\": \"heartbeat-*\",\n        \"key\": \"monitor.type\",\n        \"negate\": false,\n        \"value\": \"http\"\n      },\n      \"query\": {\n        \"match\": {\n          \"monitor.type\": {\n            \"query\": \"http\",\n            \"type\": \"phrase\"\n          }\n        }\n      }\n    }\n  ]\n}"
   }, 
   "columns": [
     "monitor.id", 

--- a/heartbeat/_meta/kibana/default/dashboard/Heartbeat-http-monitor.json
+++ b/heartbeat/_meta/kibana/default/dashboard/Heartbeat-http-monitor.json
@@ -96,7 +96,7 @@
         "description": "",
         "hits": 0,
         "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\n  \"index\": \"heartbeat-*\",\n  \"highlightAll\": true,\n  \"query\": {\n    \"query_string\": {\n      \"analyze_wildcard\": true,\n      \"query\": \"*\"\n    }\n  },\n  \"filter\": [\n    {\n      \"$state\": {\n        \"store\": \"appState\"\n      },\n      \"meta\": {\n        \"alias\": null,\n        \"disabled\": false,\n        \"index\": \"heartbeat-*\",\n        \"key\": \"monitor.name\",\n        \"negate\": false,\n        \"value\": \"http\"\n      },\n      \"query\": {\n        \"match\": {\n          \"monitor.name\": {\n            \"query\": \"http\",\n            \"type\": \"phrase\"\n          }\n        }\n      }\n    }\n  ]\n}"
+          "searchSourceJSON": "{\n  \"index\": \"heartbeat-*\",\n  \"highlightAll\": true,\n  \"query\": {\n    \"query_string\": {\n      \"analyze_wildcard\": true,\n      \"query\": \"*\"\n    }\n  },\n  \"filter\": [\n    {\n      \"$state\": {\n        \"store\": \"appState\"\n      },\n      \"meta\": {\n        \"alias\": null,\n        \"disabled\": false,\n        \"index\": \"heartbeat-*\",\n        \"key\": \"monitor.type\",\n        \"negate\": false,\n        \"value\": \"http\"\n      },\n      \"query\": {\n        \"match\": {\n          \"monitor.type\": {\n            \"query\": \"http\",\n            \"type\": \"phrase\"\n          }\n        }\n      }\n    }\n  ]\n}"
         },
         "sort": [
           "@timestamp",

--- a/heartbeat/beater/manager.go
+++ b/heartbeat/beater/manager.go
@@ -271,7 +271,7 @@ func createWatchUpdater(monitor *monitor) func(content []byte) {
 func (m *monitorTask) createJob(client beat.Client) scheduler.TaskFunc {
 	name := m.config.Name
 	if name == "" {
-		name = m.config.Name
+		name = m.config.Type
 	}
 
 	meta := common.MapStr{


### PR DESCRIPTION
Cherry-pick of PR #4856 to 6.0 branch. Original message: 

Resolve #4852 

- Fixes the `monitor.name` field default to `monitor.type` if not configured
- Update HTTP dashboards to filter on `monitor.type`, which will always be `http` for all HTTP related monitors.