### PR TITLE
Remove all references to removed output.X.flush_interval settings

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -15,6 +15,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta1...master[Check the HEAD di
 *Affecting all Beats*
 
 - The log directory (`path.log`) for Windows services is now set to `C:\ProgramData\[beatname]\logs`. {issue}4764[4764]
+- Fail if removed setting output.X.flush_interval is explicitly configured.
 
 *Auditbeat*
 

--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -236,11 +236,6 @@ output.elasticsearch:
   # Configure http request timeout before failing an request to Elasticsearch.
   #timeout: 90
 
-  # The number of seconds to wait for new events between two bulk API index requests.
-  # If `bulk_max_size` is reached before this interval expires, addition bulk index
-  # requests are made.
-  #flush_interval: 1s
-
   # Use SSL settings for HTTPS. Default is true.
   #ssl.enabled: true
 
@@ -439,9 +434,6 @@ output.elasticsearch:
   # If set to 0, no ACKs are returned by Kafka. Messages might be lost silently
   # on error.
   #required_acks: 1
-
-  # The number of seconds to wait for new events between two producer API calls.
-  #flush_interval: 1s
 
   # The configurable ClientID used for logging, debugging, and auditing
   # purposes.  The default is "beats".

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -641,11 +641,6 @@ output.elasticsearch:
   # Configure http request timeout before failing an request to Elasticsearch.
   #timeout: 90
 
-  # The number of seconds to wait for new events between two bulk API index requests.
-  # If `bulk_max_size` is reached before this interval expires, addition bulk index
-  # requests are made.
-  #flush_interval: 1s
-
   # Use SSL settings for HTTPS. Default is true.
   #ssl.enabled: true
 
@@ -844,9 +839,6 @@ output.elasticsearch:
   # If set to 0, no ACKs are returned by Kafka. Messages might be lost silently
   # on error.
   #required_acks: 1
-
-  # The number of seconds to wait for new events between two producer API calls.
-  #flush_interval: 1s
 
   # The configurable ClientID used for logging, debugging, and auditing
   # purposes.  The default is "beats".

--- a/heartbeat/heartbeat.reference.yml
+++ b/heartbeat/heartbeat.reference.yml
@@ -385,11 +385,6 @@ output.elasticsearch:
   # Configure http request timeout before failing an request to Elasticsearch.
   #timeout: 90
 
-  # The number of seconds to wait for new events between two bulk API index requests.
-  # If `bulk_max_size` is reached before this interval expires, addition bulk index
-  # requests are made.
-  #flush_interval: 1s
-
   # Use SSL settings for HTTPS. Default is true.
   #ssl.enabled: true
 
@@ -588,9 +583,6 @@ output.elasticsearch:
   # If set to 0, no ACKs are returned by Kafka. Messages might be lost silently
   # on error.
   #required_acks: 1
-
-  # The number of seconds to wait for new events between two producer API calls.
-  #flush_interval: 1s
 
   # The configurable ClientID used for logging, debugging, and auditing
   # purposes.  The default is "beats".

--- a/libbeat/_meta/config.reference.yml
+++ b/libbeat/_meta/config.reference.yml
@@ -171,11 +171,6 @@ output.elasticsearch:
   # Configure http request timeout before failing an request to Elasticsearch.
   #timeout: 90
 
-  # The number of seconds to wait for new events between two bulk API index requests.
-  # If `bulk_max_size` is reached before this interval expires, addition bulk index
-  # requests are made.
-  #flush_interval: 1s
-
   # Use SSL settings for HTTPS. Default is true.
   #ssl.enabled: true
 
@@ -374,9 +369,6 @@ output.elasticsearch:
   # If set to 0, no ACKs are returned by Kafka. Messages might be lost silently
   # on error.
   #required_acks: 1
-
-  # The number of seconds to wait for new events between two producer API calls.
-  #flush_interval: 1s
 
   # The configurable ClientID used for logging, debugging, and auditing
   # purposes.  The default is "beats".

--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -292,12 +292,6 @@ spooler size.
 
 The http request timeout in seconds for the Elasticsearch request. The default is 90.
 
-===== `flush_interval`
-
-The number of seconds to wait for new events between two bulk API index requests.
-If `bulk_max_size` is reached before this interval expires, additional bulk index
-requests are made.
-
 ===== `ssl`
 
 Configuration options for SSL parameters like the certificate authority to use
@@ -730,10 +724,6 @@ The maximum permitted size of JSON-encoded messages. Bigger messages will be dro
 The ACK reliability level required from broker. 0=no response, 1=wait for local commit, -1=wait for all replicas to commit. The default is 1.
 
 Note: If set to 0, no ACKs are returned by Kafka. Messages might be lost silently on error.
-
-===== `flush_interval`
-
-The number of seconds to wait for new events between two producer API calls.
 
 ===== `ssl`
 

--- a/libbeat/outputs/fileout/file.go
+++ b/libbeat/outputs/fileout/file.go
@@ -32,7 +32,6 @@ func makeFileout(
 	}
 
 	// disable bulk support in publisher pipeline
-	cfg.SetInt("flush_interval", -1, -1)
 	cfg.SetInt("bulk_max_size", -1, -1)
 
 	fo := &fileOutput{beat: beat, stats: stats}

--- a/libbeat/outputs/logstash/logstash_integration_test.go
+++ b/libbeat/outputs/logstash/logstash_integration_test.go
@@ -148,12 +148,10 @@ func newTestElasticsearchOutput(t *testing.T, test string) *testOutputer {
 	index := testElasticsearchIndex(test)
 	connection := esConnect(t, index)
 
-	flushInterval := 0
 	bulkSize := 0
 	config, _ := common.NewConfigFrom(map[string]interface{}{
 		"hosts":            []string{getElasticsearchHost()},
 		"index":            connection.index,
-		"flush_interval":   &flushInterval,
 		"bulk_max_size":    &bulkSize,
 		"username":         os.Getenv("ES_USER"),
 		"password":         os.Getenv("ES_PASS"),

--- a/libbeat/outputs/output_reg.go
+++ b/libbeat/outputs/output_reg.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
 )
 
 var outputReg = map[string]Factory{}
@@ -41,6 +42,10 @@ func Load(info beat.Info, stats *Stats, name string, config *common.Config) (Gro
 	factory := FindFactory(name)
 	if factory == nil {
 		return Group{}, fmt.Errorf("output type %v undefined", name)
+	}
+
+	if err := cfgwarn.CheckRemoved5xSetting(config, "flush_interval"); err != nil {
+		return Fail(err)
 	}
 
 	return factory(info, stats, config)

--- a/libbeat/tests/system/test_base.py
+++ b/libbeat/tests/system/test_base.py
@@ -154,7 +154,6 @@ class Test(BaseTest):
             console={
                 "pretty": "false",
                 "bulk_max_size": 1,
-                "flush_interval": "1h"
             }
         )
 

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -605,11 +605,6 @@ output.elasticsearch:
   # Configure http request timeout before failing an request to Elasticsearch.
   #timeout: 90
 
-  # The number of seconds to wait for new events between two bulk API index requests.
-  # If `bulk_max_size` is reached before this interval expires, addition bulk index
-  # requests are made.
-  #flush_interval: 1s
-
   # Use SSL settings for HTTPS. Default is true.
   #ssl.enabled: true
 
@@ -808,9 +803,6 @@ output.elasticsearch:
   # If set to 0, no ACKs are returned by Kafka. Messages might be lost silently
   # on error.
   #required_acks: 1
-
-  # The number of seconds to wait for new events between two producer API calls.
-  #flush_interval: 1s
 
   # The configurable ClientID used for logging, debugging, and auditing
   # purposes.  The default is "beats".

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -623,11 +623,6 @@ output.elasticsearch:
   # Configure http request timeout before failing an request to Elasticsearch.
   #timeout: 90
 
-  # The number of seconds to wait for new events between two bulk API index requests.
-  # If `bulk_max_size` is reached before this interval expires, addition bulk index
-  # requests are made.
-  #flush_interval: 1s
-
   # Use SSL settings for HTTPS. Default is true.
   #ssl.enabled: true
 
@@ -826,9 +821,6 @@ output.elasticsearch:
   # If set to 0, no ACKs are returned by Kafka. Messages might be lost silently
   # on error.
   #required_acks: 1
-
-  # The number of seconds to wait for new events between two producer API calls.
-  #flush_interval: 1s
 
   # The configurable ClientID used for logging, debugging, and auditing
   # purposes.  The default is "beats".

--- a/winlogbeat/winlogbeat.reference.yml
+++ b/winlogbeat/winlogbeat.reference.yml
@@ -200,11 +200,6 @@ output.elasticsearch:
   # Configure http request timeout before failing an request to Elasticsearch.
   #timeout: 90
 
-  # The number of seconds to wait for new events between two bulk API index requests.
-  # If `bulk_max_size` is reached before this interval expires, addition bulk index
-  # requests are made.
-  #flush_interval: 1s
-
   # Use SSL settings for HTTPS. Default is true.
   #ssl.enabled: true
 
@@ -403,9 +398,6 @@ output.elasticsearch:
   # If set to 0, no ACKs are returned by Kafka. Messages might be lost silently
   # on error.
   #required_acks: 1
-
-  # The number of seconds to wait for new events between two producer API calls.
-  #flush_interval: 1s
 
   # The configurable ClientID used for logging, debugging, and auditing
   # purposes.  The default is "beats".


### PR DESCRIPTION
- remove flush_interval from docs and reference configurations
- fail if flush_interval is explicitly configured by user