### PR TITLE
Remove setup deprecation message

### DIFF
--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -245,10 +245,6 @@ func (b *Beat) launch(bt beat.Creator) error {
 
 	svc.HandleSignals(beater.Stop)
 
-	// TODO Deprecate this in favor of setup subcommand (7.0)
-	if setup {
-		cfgwarn.Deprecate("6.0", "-setup flag has been deprectad, use setup subcommand")
-	}
 	err = b.loadDashboards(false)
 	if err != nil {
 		return err

--- a/libbeat/cmd/run.go
+++ b/libbeat/cmd/run.go
@@ -31,11 +31,10 @@ func genRunCmd(name, version string, beatCreator beat.Creator, runFlags *pflag.F
 
 	// TODO deprecate in favor of subcommands (7.0):
 	runCmd.Flags().AddGoFlag(flag.CommandLine.Lookup("configtest"))
-	runCmd.Flags().AddGoFlag(flag.CommandLine.Lookup("setup"))
 	runCmd.Flags().AddGoFlag(flag.CommandLine.Lookup("version"))
 
 	runCmd.Flags().MarkDeprecated("version", "version flag has been deprectad, use version subcommand")
-	runCmd.Flags().MarkDeprecated("configtest", "setup flag has been deprectad, use configtest subcommand")
+	runCmd.Flags().MarkDeprecated("configtest", "configtest flag has been deprectad, use test config subcommand")
 
 	if runFlags != nil {
 		runCmd.Flags().AddFlagSet(runFlags)

--- a/libbeat/cmd/test/output.go
+++ b/libbeat/cmd/test/output.go
@@ -14,7 +14,7 @@ import (
 func GenTestOutputCmd(name, beatVersion string) *cobra.Command {
 	return &cobra.Command{
 		Use:   "output",
-		Short: "Test output works with current settings",
+		Short: "Test " + name + " can connect to the output by using the current settings",
 		Run: func(cmd *cobra.Command, args []string) {
 			b, err := instance.NewBeat(name, beatVersion)
 			if err != nil {


### PR DESCRIPTION
We decided to keep `-setup` as a shorthand for setup + run