### PR TITLE
Update Kibana index pattern with index and enable from fields

### DIFF
--- a/libbeat/scripts/generate_index_pattern.py
+++ b/libbeat/scripts/generate_index_pattern.py
@@ -71,6 +71,18 @@ def field_to_json(fields, desc, path, output,
     else:
         field["type"] = "string"
 
+    if "enable" in desc and not desc["enabled"]:
+        # Skip objects which are not enabled
+        return
+
+    if "index" in desc and not desc["index"]:
+        # If fields is not indexed, mark it in Kibana
+        field["indexed"] = False
+        field["analyzed"] = False
+        field["doc_values"] = False
+        field["searchable"] = False
+        field["aggregatable"] = False
+
     output["fields"].append(field)
 
     if "format" in desc or "pattern" in desc:


### PR DESCRIPTION
With https://github.com/elastic/beats/pull/4853 in fields.yml fields can be marked as `enable: false` or `index: false`. This should also have an affect on the index pattern. Objects which are not enabled will be skipped in the index pattern and fields which are not indexed all settings are set to false.