### PR TITLE
Set array type to ObjectType of field if available.

### DIFF
--- a/libbeat/template/field.go
+++ b/libbeat/template/field.go
@@ -137,7 +137,11 @@ func (f *Field) text() common.MapStr {
 }
 
 func (f *Field) array() common.MapStr {
-	return f.getDefaultProperties()
+	properties := f.getDefaultProperties()
+	if f.ObjectType != "" {
+		properties["type"] = f.ObjectType
+	}
+	return properties
 }
 
 func (f *Field) object() common.MapStr {

--- a/libbeat/template/field_test.go
+++ b/libbeat/template/field_test.go
@@ -60,6 +60,21 @@ func TestField(t *testing.T) {
 			},
 		},
 		{
+			field:  Field{Type: "array"},
+			method: func(f Field) common.MapStr { return f.array() },
+			output: common.MapStr{},
+		},
+		{
+			field:  Field{Type: "array", ObjectType: "text"},
+			method: func(f Field) common.MapStr { return f.array() },
+			output: common.MapStr{"type": "text"},
+		},
+		{
+			field:  Field{Type: "array", Index: &falseVar, ObjectType: "keyword"},
+			method: func(f Field) common.MapStr { return f.array() },
+			output: common.MapStr{"index": false, "type": "keyword"},
+		},
+		{
 			field:  Field{Type: "object", Enabled: &falseVar},
 			method: func(f Field) common.MapStr { return f.object() },
 			output: common.MapStr{


### PR DESCRIPTION
Type of array items needs to be defined when creating a mapping for arrays. For dynamic mapping ES uses the type of the first array item. For pre-defined mapping use ObjectType information set in the fields.yml if available.