### PR TITLE
Cherry-pick #4823 to master: Add filesystem.ignore_types to ignore filesystem types

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -86,6 +86,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta1...master[Check the HEAD di
 - Add http server metricset to support push metrics via http. {pull}4770[4770]
 - Make config object public for graphite and http server {pull}4820[4820]
 - Add system uptime metricset. {issue}[4848[4848]
+- Add `filesystem.ignore_types` to system module for ignoring filesystem types. {issue}4685[4685]
  
 *Packetbeat*
 

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -52,6 +52,11 @@ metricbeat.modules:
   cpu.metrics:  ["percentages"]  # The other available options are normalized_percentages and ticks.
   core.metrics: ["percentages"]  # The other available option is ticks.
 
+  # A list of filesystem types to ignore. The filesystem metricset will not
+  # collect data from filesystems matching any of the specified types, and
+  # fsstats will not include data from these filesystems in its summary stats.
+  #filesystem.ignore_types: []
+
   # These options allow you to filter out all processes that are not
   # in the top N by CPU or memory, in order to reduce the number of documents created.
   # If both the `by_cpu` and `by_memory` options are used, the union of the two sets

--- a/metricbeat/module/system/_meta/config.reference.yml
+++ b/metricbeat/module/system/_meta/config.reference.yml
@@ -20,6 +20,11 @@
   cpu.metrics:  ["percentages"]  # The other available options are normalized_percentages and ticks.
   core.metrics: ["percentages"]  # The other available option is ticks.
 
+  # A list of filesystem types to ignore. The filesystem metricset will not
+  # collect data from filesystems matching any of the specified types, and
+  # fsstats will not include data from these filesystems in its summary stats.
+  #filesystem.ignore_types: []
+
   # These options allow you to filter out all processes that are not
   # in the top N by CPU or memory, in order to reduce the number of documents created.
   # If both the `by_cpu` and `by_memory` options are used, the union of the two sets

--- a/metricbeat/module/system/filesystem/_meta/docs.asciidoc
+++ b/metricbeat/module/system/filesystem/_meta/docs.asciidoc
@@ -12,14 +12,34 @@ This metricset is available on:
 - Windows
 
 [float]
+=== Configuration
+
+*`filesystem.ignore_types`* - A list of filesystem types to ignore. Metrics will
+not be collected from filesystems matching these types. This setting also
+affects the `fsstats` metricset.
+
+[float]
 === Filtering
 
 Often there are mounted filesystems that you do not want Metricbeat to report
-metrics on. A simple strategy to deal with these filesystems is to configure a
-drop_event filter that matches the `mount_point` or `type` using a regular
-expression.
+metrics on. One option is to configure Metricbeat to ignore specific filesystem
+types. This can be accomplished by configuring `filesystem.ignore_types` with
+a list of filesystem types to ignore. In this example we are ignoring three
+types of filesystems.
 
-Below is an example.
+[source,yaml]
+----
+metricbeat.modules:
+  - module: system
+    period: 30s
+    metricsets: ["filesystem"]
+    filesystem.ignore_types: [nfs, smbfs, autofs]
+----
+
+Another strategy to deal with these filesystems is to configure a `drop_event`
+filter that matches the `mount_point` using a regular expression. This type of
+filtering occurs after the data has been collected so it can be less efficient
+than the previous method.
 
 [source,yaml]
 ----

--- a/metricbeat/module/system/filesystem/helper.go
+++ b/metricbeat/module/system/filesystem/helper.go
@@ -13,6 +13,10 @@ import (
 	sigar "github.com/elastic/gosigar"
 )
 
+type Config struct {
+	IgnoreTypes []string `config:"filesystem.ignore_types"`
+}
+
 type FileSystemStat struct {
 	sigar.FileSystemUsage
 	DevName     string  `json:"device_name"`
@@ -89,5 +93,37 @@ func GetFilesystemEvent(fsStat *FileSystemStat) common.MapStr {
 			"pct":   fsStat.UsedPercent,
 			"bytes": fsStat.Used,
 		},
+	}
+}
+
+// Predicate is a function predicate for use with filesystems. It returns true
+// if the argument matches the predicate.
+type Predicate func(*sigar.FileSystem) bool
+
+// Filter returns a filtered list of filesystems. The in parameter
+// is used as the backing storage for the returned slice and is therefore
+// modified in this operation.
+func Filter(in []sigar.FileSystem, p Predicate) []sigar.FileSystem {
+	out := in[:0]
+	for _, fs := range in {
+		if p(&fs) {
+			out = append(out, fs)
+		}
+	}
+	return out
+}
+
+// BuildTypeFilter returns a predicate that returns false if the given
+// filesystem has a type that matches one of the ignoreType values.
+func BuildTypeFilter(ignoreType ...string) Predicate {
+	return func(fs *sigar.FileSystem) bool {
+		for _, fsType := range ignoreType {
+			// XXX (andrewkroh): SysTypeName appears to be used for non-Windows
+			// and TypeName is used exclusively for Windows.
+			if fs.SysTypeName == fsType || fs.TypeName == fsType {
+				return false
+			}
+		}
+		return true
 	}
 }

--- a/metricbeat/module/system/filesystem/helper_test.go
+++ b/metricbeat/module/system/filesystem/helper_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	sigar "github.com/elastic/gosigar"
 )
 
 func TestFileSystemList(t *testing.T) {
@@ -42,5 +44,20 @@ func TestFileSystemList(t *testing.T) {
 				assert.NotEqual(t, "", stat.SysTypeName)
 			}
 		}
+	}
+}
+
+func TestFilter(t *testing.T) {
+	in := []sigar.FileSystem{
+		{SysTypeName: "nfs"},
+		{SysTypeName: "ext4"},
+		{SysTypeName: "proc"},
+		{SysTypeName: "smb"},
+	}
+
+	out := Filter(in, BuildTypeFilter("nfs", "smb", "proc"))
+
+	if assert.Len(t, out, 1) {
+		assert.Equal(t, "ext4", out[0].SysTypeName)
 	}
 }

--- a/metricbeat/module/system/fsstat/_meta/docs.asciidoc
+++ b/metricbeat/module/system/fsstat/_meta/docs.asciidoc
@@ -9,3 +9,10 @@ This metricset is available on:
 - Linux
 - OpenBSD
 - Windows
+
+[float]
+=== Configuration
+
+*`filesystem.ignore_types`* - A list of filesystem types to ignore. Metrics will
+not be collected from filesystems matching these types. This setting also
+affects the `filesystem` metricset.


### PR DESCRIPTION
Cherry-pick of PR #4823 to master branch. Original message: 

Add `filesystem.ignore_types` to the system module for ignoring filesystems
in the `filesystem` and `fsstat` metricsets. The new configuration option
accepts a list of filesystem types.

    metricbeat.modules:
    - module: system
      metricsets: [filesystem, fsstat]
      filesystem.ignore_types: [nfs, smbfs, proc, cgroups]

Closes #4685