### PR TITLE
Close changelog for 5.5.2

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -8,7 +8,7 @@
 // Template, add newest changes here
 
 === Beats version HEAD
-https://github.com/elastic/beats/compare/v5.5.1...master[Check the HEAD diff]
+https://github.com/elastic/beats/compare/v5.5.2...master[Check the HEAD diff]
 
 ==== Breaking changes
 
@@ -81,6 +81,12 @@ https://github.com/elastic/beats/compare/v5.5.1...master[Check the HEAD diff]
 *Winlogbeat*
 
 ////////////////////////////////////////////////////////////
+
+[[release-notes-5.5.2]]
+=== Beats version 5.5.2
+https://github.com/elastic/beats/compare/v5.5.1...v5.5.2[View commits]
+
+No changes in this release.
 
 [[release-notes-5.5.1]]
 === Beats version 5.5.1

--- a/libbeat/docs/release.asciidoc
+++ b/libbeat/docs/release.asciidoc
@@ -6,6 +6,7 @@
 --
 This section summarizes the changes in each release.
 
+* <<release-notes-5.5.2>>
 * <<release-notes-5.5.1>>
 * <<release-notes-5.5.0>>
 * <<release-notes-5.4.2>>

--- a/testing/environments/args.yml
+++ b/testing/environments/args.yml
@@ -6,4 +6,4 @@ services:
     build:
       args:
         DOWNLOAD_URL: https://snapshots.elastic.co/downloads
-        ELASTIC_VERSION: 5.5.1-SNAPSHOT
+        ELASTIC_VERSION: 5.5.2-SNAPSHOT


### PR DESCRIPTION
It's an empty release. Also, update the testing env.