### PR TITLE
Cherry-pick #4909 to 6.0: Update and reorganize system module config docs

### DIFF
--- a/metricbeat/docs/modules/system.asciidoc
+++ b/metricbeat/docs/modules/system.asciidoc
@@ -5,67 +5,8 @@ This file is generated! See scripts/docs_collector.py
 [[metricbeat-module-system]]
 == System module
 
-The System module allows you to monitor your servers. Because the System module always applies to the local
-server, the `hosts` config option is not needed.
-
-[float]
-=== Module-specific configuration notes
-
-The System module has these additional config options:
-
-*`processes`*:: When the `process` metricset is enabled, you can use the `processes` option to define a list of
-regexp expressions to filter the processes that are reported. For more complex filtering, you should use the `processors` configuration option. See <<filtering-and-enhancing-data>> for more information.
-+
-The following example config returns metrics for all processes:
-+
-[source,yaml]
-----
-metricbeat.modules:
-- module: system
-  metricsets: ["process"]
-  processes: ['.*']
-----
-
-*`process.include_top_n`*:: These options allow you to filter out all processes
-that are not in the top N by CPU or memory, in order to reduce the number of
-documents created. If both the `by_cpu` and `by_memory` options are used, the
-union of the two sets is included.
-
-*`process.include_top_n.enabled`*:: Set to false to disable the top N feature and
-include all processes, regardless of the other options. The default is `true`,
-but nothing is filtered unless one of the other options (`by_cpu` or `by_memory`)
-is set to a non-zero value.
-
-*`process.include_top_n.by_cpu`*::  How many processes to include from the top
-by CPU. The processes are sorted by the `system.process.cpu.total.pct` field.
-The default is 0.
-
-*`process.include_top_n.by_memory`*:: How many processes to include from the top
-by memory. The processes are sorted by the `system.process.memory.rss.bytes`
-field. The default is 0.
-
-*`process.cgroups.enabled`*:: When the `process` metricset is enabled, you can
-use this boolean configuration option to disable cgroup metrics. By default
-cgroup metrics collection is enabled.
-+
-The following example config disables cgroup metrics on Linux.
-+
-[source,yaml]
-----
-metricbeat.modules:
-- module: system
-  metricsets: ["process"]
-  process.cgroups.enabled: false
-----
-*`cpu_ticks`*:: When the `cpu` or `core` metricset is enabled, you can specify `cpu_ticks: true` to report CPU ticks in addition to CPU percentages stats. For example:
-+
-[source,yaml]
-----
-metricbeat.modules:
-- module: system
-  metricsets: ["cpu", "core"]
-  cpu_ticks: true
-----
+The System module allows you to monitor your servers. Because the System module
+always applies to the local server, the `hosts` config option is not needed.
 
 [float]
 === Dashboard

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -78,6 +78,10 @@ metricbeat.modules:
   # reported with the process metricset's events. Defaults to empty.
   #process.env.whitelist: []
 
+  # Include the cumulative CPU tick values with the process metrics. Defaults
+  # to false.
+  #process.include_cpu_ticks: false
+
   # Configure reverse DNS lookup on remote IP addresses in the socket metricset.
   #socket.reverse_lookup.enabled: false
   #socket.reverse_lookup.success_ttl: 60s

--- a/metricbeat/module/system/_meta/config.reference.yml
+++ b/metricbeat/module/system/_meta/config.reference.yml
@@ -46,6 +46,10 @@
   # reported with the process metricset's events. Defaults to empty.
   #process.env.whitelist: []
 
+  # Include the cumulative CPU tick values with the process metrics. Defaults
+  # to false.
+  #process.include_cpu_ticks: false
+
   # Configure reverse DNS lookup on remote IP addresses in the socket metricset.
   #socket.reverse_lookup.enabled: false
   #socket.reverse_lookup.success_ttl: 60s

--- a/metricbeat/module/system/_meta/docs.asciidoc
+++ b/metricbeat/module/system/_meta/docs.asciidoc
@@ -1,66 +1,7 @@
 == System module
 
-The System module allows you to monitor your servers. Because the System module always applies to the local
-server, the `hosts` config option is not needed.
-
-[float]
-=== Module-specific configuration notes
-
-The System module has these additional config options:
-
-*`processes`*:: When the `process` metricset is enabled, you can use the `processes` option to define a list of
-regexp expressions to filter the processes that are reported. For more complex filtering, you should use the `processors` configuration option. See <<filtering-and-enhancing-data>> for more information.
-+
-The following example config returns metrics for all processes:
-+
-[source,yaml]
-----
-metricbeat.modules:
-- module: system
-  metricsets: ["process"]
-  processes: ['.*']
-----
-
-*`process.include_top_n`*:: These options allow you to filter out all processes
-that are not in the top N by CPU or memory, in order to reduce the number of
-documents created. If both the `by_cpu` and `by_memory` options are used, the
-union of the two sets is included.
-
-*`process.include_top_n.enabled`*:: Set to false to disable the top N feature and
-include all processes, regardless of the other options. The default is `true`,
-but nothing is filtered unless one of the other options (`by_cpu` or `by_memory`)
-is set to a non-zero value.
-
-*`process.include_top_n.by_cpu`*::  How many processes to include from the top
-by CPU. The processes are sorted by the `system.process.cpu.total.pct` field.
-The default is 0.
-
-*`process.include_top_n.by_memory`*:: How many processes to include from the top
-by memory. The processes are sorted by the `system.process.memory.rss.bytes`
-field. The default is 0.
-
-*`process.cgroups.enabled`*:: When the `process` metricset is enabled, you can
-use this boolean configuration option to disable cgroup metrics. By default
-cgroup metrics collection is enabled.
-+
-The following example config disables cgroup metrics on Linux.
-+
-[source,yaml]
-----
-metricbeat.modules:
-- module: system
-  metricsets: ["process"]
-  process.cgroups.enabled: false
-----
-*`cpu_ticks`*:: When the `cpu` or `core` metricset is enabled, you can specify `cpu_ticks: true` to report CPU ticks in addition to CPU percentages stats. For example:
-+
-[source,yaml]
-----
-metricbeat.modules:
-- module: system
-  metricsets: ["cpu", "core"]
-  cpu_ticks: true
-----
+The System module allows you to monitor your servers. Because the System module
+always applies to the local server, the `hosts` config option is not needed.
 
 [float]
 === Dashboard

--- a/metricbeat/module/system/core/_meta/docs.asciidoc
+++ b/metricbeat/module/system/core/_meta/docs.asciidoc
@@ -1,11 +1,26 @@
 === System core metricset
 
-The System `core` metricset provides load statistics for each CPU core.
+The System `core` metricset provides usage statistics for each CPU core.
 
 This metricset is available on:
 
-- Darwin
 - FreeBSD
 - Linux
+- macOS
 - OpenBSD
 - Windows
+
+[float]
+=== Configuration
+
+*`core.metrics`*:: This option controls what metrics are reported for each CPU
+core. The value is a list and two metric types are supported - `percentages` and
+`ticks`. The default value is `core.metrics: [percentages]`.
++
+[source,yaml]
+----
+metricbeat.modules:
+- module: system
+  metricsets: [core]
+  core.metrics: [percentages, ticks]
+----

--- a/metricbeat/module/system/cpu/_meta/docs.asciidoc
+++ b/metricbeat/module/system/cpu/_meta/docs.asciidoc
@@ -4,8 +4,24 @@ The System `cpu` metricset provides CPU statistics.
 
 This metricset is available on:
 
-- Darwin
 - FreeBSD
 - Linux
+- macOS
 - OpenBSD
 - Windows
+
+[float]
+=== Configuration
+
+*`cpu.metrics`*:: This option controls what CPU metrics are reported. The value
+is a list and three metric types are supported - `percentages`,
+`normalized_percentages`, and `ticks`. The default value is
+`cpu.metrics: [percentages]`.
++
+[source,yaml]
+----
+metricbeat.modules:
+- module: system
+  metricsets: [cpu]
+  cpu.metrics: [percentages, normalized_percentages, ticks]
+----

--- a/metricbeat/module/system/diskio/_meta/docs.asciidoc
+++ b/metricbeat/module/system/diskio/_meta/docs.asciidoc
@@ -1,11 +1,16 @@
 === System diskio metricset
 
-The System `diskio` metricset provides disk IO metrics collected from the operating
-system. One event is created for each disk mounted on the system.
+The System `diskio` metricset provides disk IO metrics collected from the
+operating system. One event is created for each disk mounted on the system.
 
 This metricset is available on:
 
-- macOS (requires 10.10+)
 - Linux
+- macOS (requires 10.10+)
 - Windows
 - FreeBSD (amd64)
+
+[float]
+=== Configuration
+
+There are no configuration options for this metricset.

--- a/metricbeat/module/system/filesystem/_meta/docs.asciidoc
+++ b/metricbeat/module/system/filesystem/_meta/docs.asciidoc
@@ -5,9 +5,9 @@ system, one document is provided.
 
 This metricset is available on:
 
-- Darwin
 - FreeBSD
 - Linux
+- macOS
 - OpenBSD
 - Windows
 

--- a/metricbeat/module/system/fsstat/_meta/docs.asciidoc
+++ b/metricbeat/module/system/fsstat/_meta/docs.asciidoc
@@ -4,8 +4,8 @@ The System `fsstat` metricset provides overall file system statistics.
 
 This metricset is available on:
 
-- Darwin
 - FreeBSD
 - Linux
+- macOS
 - OpenBSD
 - Windows

--- a/metricbeat/module/system/load/_meta/docs.asciidoc
+++ b/metricbeat/module/system/load/_meta/docs.asciidoc
@@ -4,7 +4,12 @@ The System `load` metricset provides load statistics.
 
 This metricset is available on:
 
- - Darwin
- - FreeBSD
- - Linux
- - OpenBSD
+- FreeBSD
+- Linux
+- macOS
+- OpenBSD
+
+[float]
+=== Configuration
+
+There are no configuration options for this metricset.

--- a/metricbeat/module/system/memory/_meta/docs.asciidoc
+++ b/metricbeat/module/system/memory/_meta/docs.asciidoc
@@ -4,8 +4,13 @@ The System `memory` metricset provides memory statistics.
 
 This metricset is available on:
 
-- Darwin
 - FreeBSD
 - Linux
+- macOS
 - OpenBSD
 - Windows
+
+[float]
+=== Configuration
+
+There are no configuration options for this metricset.

--- a/metricbeat/module/system/network/_meta/docs.asciidoc
+++ b/metricbeat/module/system/network/_meta/docs.asciidoc
@@ -3,9 +3,20 @@
 The System `network` metricset provides network IO metrics collected from the
 operating system. One event is created for each network interface.
 
-By default metrics are reported from all network interfaces. To select which
-interfaces metrics are reported from, use the `interfaces` configuration
-option. The value must be an array of interface names. For example:
+This metricset is available on:
+
+- FreeBSD
+- Linux
+- macOS
+- Windows
+
+[float]
+=== Configuration
+
+*`interfaces`*:: By default metrics are reported from all network interfaces.
+To select which interfaces metrics are reported from, use the `interfaces`
+configuration option. The value must be an array of interface names. For
+example:
 
 [source,yaml]
 ----------------------------
@@ -15,9 +26,3 @@ metricbeat.modules:
   interfaces: [eth0]
 ----------------------------
 
-This metricset is available on:
-
-- Darwin
-- Linux
-- Windows
-- FreeBSD

--- a/metricbeat/module/system/process/_meta/docs.asciidoc
+++ b/metricbeat/module/system/process/_meta/docs.asciidoc
@@ -5,35 +5,57 @@ provided for each process.
 
 This metricset is available on:
 
-- Darwin
 - FreeBSD
 - Linux
+- macOS
 - Windows
 
 [float]
-=== Cache cmdline
+=== Configuration
 
-This metricset caches the command line args for a running process. This means if you alter
-the command line for a process while this metricset is running, these changes are not detected.
-This feature can be disabled by adding
-`process.cmdline.cache.enabled: false` to the system module configuration.
+*`processes`*:: When the `process` metricset is enabled, you can use the
+`processes` option to define a list of regexp expressions to filter the
+processes that are reported. For more complex filtering, you should use the
+`processors` configuration option. See <<filtering-and-enhancing-data>> for more
+information.
++
+The following example config returns metrics for all processes:
++
+[source,yaml]
+----
+metricbeat.modules:
+- module: system
+  metricsets: ["process"]
+  processes: ['.*']
+----
 
-[float]
-=== Control group (cgroup) metrics
+*`process.cgroups.enabled`*:: When the `process` metricset is enabled, you can
+use this boolean configuration option to disable cgroup metrics. By default
+cgroup metrics collection is enabled.
++
+The following example config disables cgroup metrics on Linux.
++
+[source,yaml]
+----
+metricbeat.modules:
+- module: system
+  metricsets: ["process"]
+  process.cgroups.enabled: false
+----
 
-On Linux this metricset will collect metrics from any cgroups that the process
-is a member of. This feature is enabled by default and can be disabled by adding
-`process.cgroups.enabled: false` to the system module configuration.
+*`process.cmdline.cache.enabled`*:: This metricset caches the command line args
+for a running process by default. This means if you alter the command line for a
+process while this metricset is running, these changes are not detected. Caching
+can be disabled by setting `process.cmdline.cache.enabled: false` in the
+configuration.
 
-[float]
-=== Process environment variables
-
-This metricset can collect the environment variables that were used to start the
-process. This feature is available on Linux, Darwin, and FreeBSD. No environment
-variables are collected by default because they could contain sensitive information.
-You must configure the environment variables that you wish to collect by
-specifying a list of regular expressions that match the variable name.
-
+*`process.env.whitelist`*:: This metricset can collect the environment variables
+that were used to start the process. This feature is available on Linux, Darwin,
+and FreeBSD. No environment variables are collected by default because they
+could contain sensitive information. You must configure the environment
+variables that you wish to collect by specifying a list of regular expressions
+that match the variable name.
++
 [source,yaml]
 ----
 metricbeat.modules:
@@ -43,3 +65,34 @@ metricbeat.modules:
   - '^PATH$'
   - '^SSH_.*'
 ----
+
+*`process.include_cpu_ticks`*:: By default the cumulative CPU tick values
+are not reported by this metricset (only percentages are reported). Setting
+this option to true will enable the reporting of the raw CPU tick values
+(for user, system, and total CPU time).
++
+[source,yaml]
+----
+metricbeat.modules:
+- module: system
+  metricsets: ["process"]
+  process.include_cpu_ticks: true
+----
+
+*`process.include_top_n`*:: These options allow you to filter out all processes
+that are not in the top N by CPU or memory, in order to reduce the number of
+documents created. If both the `by_cpu` and `by_memory` options are used, the
+union of the two sets is included.
+
+*`process.include_top_n.enabled`*:: Set to false to disable the top N feature
+and include all processes, regardless of the other options. The default is
+`true`, but nothing is filtered unless one of the other options (`by_cpu` or
+`by_memory`) is set to a non-zero value.
+
+*`process.include_top_n.by_cpu`*::  How many processes to include from the top
+by CPU. The processes are sorted by the `system.process.cpu.total.pct` field.
+The default is 0.
+
+*`process.include_top_n.by_memory`*:: How many processes to include from the top
+by memory. The processes are sorted by the `system.process.memory.rss.bytes`
+field. The default is 0.

--- a/metricbeat/module/system/process_summary/_meta/docs.asciidoc
+++ b/metricbeat/module/system/process_summary/_meta/docs.asciidoc
@@ -2,3 +2,15 @@
 
 The `process_summary` metricset collects high level statistics about the running
 processes.
+
+This metricset is available on:
+
+- FreeBSD
+- Linux
+- macOS
+- Windows
+
+[float]
+=== Configuration
+
+There are no configuration options for this metricset.

--- a/metricbeat/module/system/socket/_meta/docs.asciidoc
+++ b/metricbeat/module/system/socket/_meta/docs.asciidoc
@@ -27,13 +27,8 @@ The metricset reports the process that has the socket open. In order to provide
 this information, Metricbeat must be running as root. Root access is also
 required to read the file descriptor information of other processes.
 
-You can configure the metricset to perform a reverse lookup on the remote IP,
-and the returned hostname will be added to the event and cached. If a hostname
-is found, then the eTLD+1 (effective top-level domain plus one level) value will
-also be added to the event. Reverse lookups are disabled by default.
-
-The following example shows the full configuration for the metricset along with
-the defaults.
+[float]
+=== Configuration
 
 [source,yaml]
 ----
@@ -43,3 +38,17 @@ the defaults.
   socket.reverse_lookup.success_ttl: 60s
   socket.reverse_lookup.failure_ttl: 60s
 ----
+
+*`socket.reverse_lookup.enabled`*::
+You can configure the metricset to perform a reverse lookup on the remote IP,
+and the returned hostname will be added to the event and cached. If a hostname
+is found, then the eTLD+1 (effective top-level domain plus one level) value will
+also be added to the event. Reverse lookups are disabled by default.
+
+*`socket.reverse_lookup.success_ttl`*::
+The results of successful reverse lookups are cached for the period of time
+defined by this option. The default value is 60s.
+
+*`socket.reverse_lookup.failure_ttl`*::
+The results of failed reverse lookups are cached for the period of time
+defined by this option. The default value is 60s.


### PR DESCRIPTION
Cherry-pick of PR #4909 to 6.0 branch. Original message: 

Move configuration options from module page to their respective metricset pages.

- Add `process.include_cpu_ticks` to reference config file (it was missing).
- Rename Darwin to macOS in list of supported operating systems.
- Add docs for `core.metrics` and `cpu.metrics`.

Needs backport to 6.0 branch.