### PR TITLE
Cherry-pick #4823 to 6.0: Add filesystem.ignore_types to ignore filesystem types

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -63,6 +63,8 @@ https://github.com/elastic/beats/compare/v6.0.0-beta1...master[Check the HEAD di
 
 *Metricbeat*
 
+- Add `filesystem.ignore_types` to system module for ignoring filesystem types. {issue}4685[4685]
+ 
 *Packetbeat*
 
 *Winlogbeat*

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -51,6 +51,11 @@ metricbeat.modules:
   cpu.metrics:  ["percentages"]  # The other available options are normalized_percentages and ticks.
   core.metrics: ["percentages"]  # The other available option is ticks.
 
+  # A list of filesystem types to ignore. The filesystem metricset will not
+  # collect data from filesystems matching any of the specified types, and
+  # fsstats will not include data from these filesystems in its summary stats.
+  #filesystem.ignore_types: []
+
   # These options allow you to filter out all processes that are not
   # in the top N by CPU or memory, in order to reduce the number of documents created.
   # If both the `by_cpu` and `by_memory` options are used, the union of the two sets

--- a/metricbeat/module/system/_meta/config.reference.yml
+++ b/metricbeat/module/system/_meta/config.reference.yml
@@ -19,6 +19,11 @@
   cpu.metrics:  ["percentages"]  # The other available options are normalized_percentages and ticks.
   core.metrics: ["percentages"]  # The other available option is ticks.
 
+  # A list of filesystem types to ignore. The filesystem metricset will not
+  # collect data from filesystems matching any of the specified types, and
+  # fsstats will not include data from these filesystems in its summary stats.
+  #filesystem.ignore_types: []
+
   # These options allow you to filter out all processes that are not
   # in the top N by CPU or memory, in order to reduce the number of documents created.
   # If both the `by_cpu` and `by_memory` options are used, the union of the two sets

--- a/metricbeat/module/system/filesystem/_meta/docs.asciidoc
+++ b/metricbeat/module/system/filesystem/_meta/docs.asciidoc
@@ -12,12 +12,34 @@ This metricset is available on:
 - Windows
 
 [float]
+=== Configuration
+
+*`filesystem.ignore_types`* - A list of filesystem types to ignore. Metrics will
+not be collected from filesystems matching these types. This setting also
+affects the `fsstats` metricset.
+
+[float]
 === Filtering
 
 Often there are mounted filesystems that you do not want Metricbeat to report
-metrics on. A simple strategy to deal with these filesystems is to configure a
-drop_event filter that matches the `mount_point` using a regular expression.
-Below is an example.
+metrics on. One option is to configure Metricbeat to ignore specific filesystem
+types. This can be accomplished by configuring `filesystem.ignore_types` with
+a list of filesystem types to ignore. In this example we are ignoring three
+types of filesystems.
+
+[source,yaml]
+----
+metricbeat.modules:
+  - module: system
+    period: 30s
+    metricsets: ["filesystem"]
+    filesystem.ignore_types: [nfs, smbfs, autofs]
+----
+
+Another strategy to deal with these filesystems is to configure a `drop_event`
+filter that matches the `mount_point` using a regular expression. This type of
+filtering occurs after the data has been collected so it can be less efficient
+than the previous method.
 
 [source,yaml]
 ----

--- a/metricbeat/module/system/filesystem/helper_test.go
+++ b/metricbeat/module/system/filesystem/helper_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	sigar "github.com/elastic/gosigar"
 )
 
 func TestFileSystemList(t *testing.T) {
@@ -38,5 +40,20 @@ func TestFileSystemList(t *testing.T) {
 			assert.True(t, (stat.Avail >= 0))
 			assert.True(t, (stat.Used >= 0))
 		}
+	}
+}
+
+func TestFilter(t *testing.T) {
+	in := []sigar.FileSystem{
+		{SysTypeName: "nfs"},
+		{SysTypeName: "ext4"},
+		{SysTypeName: "proc"},
+		{SysTypeName: "smb"},
+	}
+
+	out := Filter(in, BuildTypeFilter("nfs", "smb", "proc"))
+
+	if assert.Len(t, out, 1) {
+		assert.Equal(t, "ext4", out[0].SysTypeName)
 	}
 }

--- a/metricbeat/module/system/fsstat/_meta/docs.asciidoc
+++ b/metricbeat/module/system/fsstat/_meta/docs.asciidoc
@@ -9,3 +9,10 @@ This metricset is available on:
 - Linux
 - OpenBSD
 - Windows
+
+[float]
+=== Configuration
+
+*`filesystem.ignore_types`* - A list of filesystem types to ignore. Metrics will
+not be collected from filesystems matching these types. This setting also
+affects the `filesystem` metricset.


### PR DESCRIPTION
Cherry-pick of PR #4823 to 6.0 branch. Original message: 

Add `filesystem.ignore_types` to the system module for ignoring filesystems
in the `filesystem` and `fsstat` metricsets. The new configuration option
accepts a list of filesystem types.

    metricbeat.modules:
    - module: system
      metricsets: [filesystem, fsstat]
      filesystem.ignore_types: [nfs, smbfs, proc, cgroups]

Closes #4685