### PR TITLE
Remove the _all field settings from the 5.x template (master/6.0 version)

### DIFF
--- a/libbeat/template/template.go
+++ b/libbeat/template/template.go
@@ -135,7 +135,7 @@ func (t *Template) generate(properties common.MapStr, dynamicTemplates []common.
 		basicStructure.Put("template", t.GetName()+"-*")
 	}
 
-	if t.esVersion.IsMajor(2) || t.esVersion.IsMajor(5) {
+	if t.esVersion.IsMajor(2) {
 		basicStructure.Put("mappings._default_._all.norms.enabled", false)
 	}
 

--- a/testing/environments/5x.yml
+++ b/testing/environments/5x.yml
@@ -3,7 +3,7 @@
 version: '2.1'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:5.4.1
+    image: docker.elastic.co/elasticsearch/elasticsearch:5.5.1
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9200"]
     environment:
@@ -18,13 +18,13 @@ services:
       context: docker/logstash
       dockerfile: Dockerfile
       args:
-        ELASTIC_VERSION: 5.4.1
+        ELASTIC_VERSION: 5.5.1
         DOWNLOAD_URL: https://artifacts.elastic.co/downloads
     environment:
       - ES_HOST=elasticsearch
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:5.4.1
+    image: docker.elastic.co/kibana/kibana:5.5.1
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:5601"]
       retries: 6


### PR DESCRIPTION
Part of #4901.

This also updates the `5.x.yml` testing env to use 5.5.1.