### PR TITLE
Bump docs version for 5.5.2

### DIFF
--- a/libbeat/docs/version.asciidoc
+++ b/libbeat/docs/version.asciidoc
@@ -1,4 +1,4 @@
-:stack-version: 5.5.1
+:stack-version: 5.5.2
 :doc-branch: 5.5
 :go-version: 1.7.6
 :release-state: released


### PR DESCRIPTION
To be merged later today, the day of the release.