### PR TITLE
[Docs] Add udp prospector to list of types

### DIFF
--- a/filebeat/docs/filebeat-options.asciidoc
+++ b/filebeat/docs/filebeat-options.asciidoc
@@ -32,9 +32,10 @@ filebeat.prospectors:
 
 One of the following input types:
 
-    * log: Reads every line of the log file (default)
-    * stdin: Reads the standard in
-    * redis: Reads slow log entries from redis (experimental)
+    * log: Reads every line of the log file (default).
+    * stdin: Reads the standard in.
+    * redis: Reads slow log entries from redis (experimental).
+    * udp: Reads events over UDP. Also see <<max-message-size>>.
 
 The value that you specify here is used as the `type` for each event published to Logstash and Elasticsearch.
 
@@ -491,4 +492,10 @@ by assigning a higher limit of harvesters.
 ==== `enabled`
 
 The `enabled` option can be used with each prospector to define if a prospector is enabled or not. By default, enabled is set to true.
+
+[float]
+[[max-message-size]]
+==== `max_message_size`
+
+When used with `type: udp`, specifies the maximum size of the message received over UDP. The default is 10240.
 


### PR DESCRIPTION
This bare bones, but there wasn't much for me to go on in the related PR #4452.  For example, it's not clear to me how Filebeat knows which port to listen on.