### PR TITLE
Let docs build fail if not index.asciidoc found

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ beats-dashboards:
 .PHONY: docs
 docs:
 	@$(foreach var,$(PROJECTS),BUILD_DIR=${BUILD_DIR} $(MAKE) -C $(var) docs || exit 1;)
-	sh ./script/build_docs.sh dev-guide github.com/elastic/beats/docs/dev-guide ${BUILD_DIR}
+	sh ./script/build_docs.sh dev-guide github.com/elastic/beats/docs/devguide ${BUILD_DIR}
 
 .PHONY: package
 package: update beats-dashboards

--- a/script/build_docs.sh
+++ b/script/build_docs.sh
@@ -20,13 +20,14 @@ fi
 
 index="${GOPATH%%:*}/src/${path}/index.asciidoc"
 
-if [ -f "$index" ]; then
-  echo "Building docs for ${name}..."
-  dest_dir="$html_dir/${name}"
-  mkdir -p "$dest_dir"
-  params=""
-  if [ "$PREVIEW" = "1" ]; then
-    params="--chunk=1 -open chunk=1 -open"
-  fi
-  $docs_dir/build_docs.pl $params --doc "$index" -out "$dest_dir"
+echo "Building docs for ${name}..."
+echo "Index document: ${index}"
+
+dest_dir="$html_dir/${name}"
+mkdir -p "$dest_dir"
+params=""
+if [ "$PREVIEW" = "1" ]; then
+  params="--chunk=1 -open chunk=1 -open"
 fi
+$docs_dir/build_docs.pl $params --doc "$index" -out "$dest_dir"
+


### PR DESCRIPTION
Currently if the index.asciidoc is not found, the doc build just carries on without an error. With this change in case the index file is missing, the doc build will fail. This should not be a problem as all beats have the index file.