### PR TITLE
Move template and codec message to debug level

### DIFF
--- a/libbeat/outputs/codec/json/json.go
+++ b/libbeat/outputs/codec/json/json.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/outputs/codec"
 )
 
@@ -41,8 +40,6 @@ func init() {
 }
 
 func New(pretty bool) *Encoder {
-	logp.Info("load json codec")
-
 	e := &Encoder{pretty: pretty}
 	e.reset()
 	return e

--- a/libbeat/template/load.go
+++ b/libbeat/template/load.go
@@ -80,7 +80,7 @@ func (l *Loader) Load() error {
 // template if it exists. If you wish to not overwrite an existing template
 // then use CheckTemplate prior to calling this method.
 func (l *Loader) LoadTemplate(templateName string, template map[string]interface{}) error {
-	logp.Info("load template: %s", templateName)
+	logp.Debug("template", "Try loading template with name: %s", templateName)
 	path := "/_template/" + templateName
 	body, err := l.client.LoadJSON(path, template)
 	if err != nil {


### PR DESCRIPTION
Both messages show up on startup of the Beat. I do not think they are required on the Info level, so they are moved to the Debug level.