### PR TITLE
Cherry-pick 4955 to 5.6: Fix flow timestamp update

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -42,14 +42,14 @@ https://github.com/elastic/beats/compare/v5.4.1...master[Check the HEAD diff]
 - Properly shut down crawler in case one prospector is misconfigured. {pull}4037[4037]
 - Fix importing the dashboards when the limit for max open files is too low. {issue}4244[4244]
 - Fix issue where the `fileset.module` could have the wrong value. {issue}4761[4761]
-
-*Filebeat*
 - Fix issue that new prospector was not reloaded on conflict {pull}4128[4128]
 - Fix grok pattern in filebeat module system/auth without hostname. {pull}4224[4224]
 - Fix the Mysql slowlog parsing of IP addresses. {pull}4183[4183]
 - Allow string characters in user agent patch version (NGINX and Apache) {pull}4415[4415]
 
-*Filebeat*
+*Packetbeat*
+
+- Update flow timestamp on each packet being received. {issue}4895[4895]
 
 *Heartbeat*
 

--- a/packetbeat/flows/table.go
+++ b/packetbeat/flows/table.go
@@ -58,6 +58,8 @@ func (t *flowMetaTable) get(id *FlowID, counter *counterReg) Flow {
 }
 
 func (t *flowTable) get(id *FlowID, counter *counterReg) Flow {
+	ts := time.Now()
+
 	t.mutex.Lock()
 	defer t.mutex.Unlock()
 
@@ -66,13 +68,14 @@ func (t *flowTable) get(id *FlowID, counter *counterReg) Flow {
 	if bf == nil || !bf.isAlive() {
 		debugf("create new flow")
 
-		bf = newBiFlow(id.rawFlowID.clone(), time.Now(), id.dir)
+		bf = newBiFlow(id.rawFlowID.clone(), ts, id.dir)
 		t.table[string(bf.id.flowID)] = bf
 		t.flows.append(bf)
 	} else if bf.dir != id.dir {
 		dir = flowDirReversed
 	}
 
+	bf.ts = ts
 	stats := bf.stats[dir]
 	if stats == nil {
 		stats = newFlowStats(counter)

--- a/packetbeat/tests/system/test_0060_flows.py
+++ b/packetbeat/tests/system/test_0060_flows.py
@@ -1,6 +1,7 @@
 from packetbeat import (BaseTest, FLOWS_REQUIRED_FIELDS)
 
 from pprint import PrettyPrinter
+from datetime import datetime
 
 
 pprint = lambda x: PrettyPrinter().pprint(x)
@@ -9,6 +10,10 @@ pprint = lambda x: PrettyPrinter().pprint(x)
 def check_fields(flow, fields):
     for k, v in fields.iteritems():
         assert flow[k] == v
+
+
+def parse_timestamp(ts):
+    return datetime.strptime(ts, "%Y-%m-%dT%H:%M:%S.%fZ")
 
 
 class Test(BaseTest):
@@ -42,6 +47,10 @@ class Test(BaseTest):
             'dest.stats.net_packets_total': 10,
             'dest.stats.net_bytes_total': 181133,
         })
+
+        start_ts = parse_timestamp(objs[0]['start_time'])
+        last_ts = parse_timestamp(objs[0]['last_time'])
+        assert last_ts > start_ts
 
     def test_memcache_udp_flow(self):
         self.render_config_template(


### PR DESCRIPTION
(cherry picked from commit cbbd9ea3c68ea379dbfc5986fdc2aee6e39f3c86)