### PR TITLE
Cherry-pick #4955 to 6.0: Fix flow timestamp update

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -57,6 +57,8 @@ https://github.com/elastic/beats/compare/v6.0.0-beta1...master[Check the HEAD di
 
 *Packetbeat*
 
+- Update flow timestamp on each packet being received. {issue}4895[4895]
+
 *Winlogbeat*
 
 ==== Added

--- a/packetbeat/flows/table.go
+++ b/packetbeat/flows/table.go
@@ -58,6 +58,8 @@ func (t *flowMetaTable) get(id *FlowID, counter *counterReg) Flow {
 }
 
 func (t *flowTable) get(id *FlowID, counter *counterReg) Flow {
+	ts := time.Now()
+
 	t.mutex.Lock()
 	defer t.mutex.Unlock()
 
@@ -66,13 +68,14 @@ func (t *flowTable) get(id *FlowID, counter *counterReg) Flow {
 	if bf == nil || !bf.isAlive() {
 		debugf("create new flow")
 
-		bf = newBiFlow(id.rawFlowID.clone(), time.Now(), id.dir)
+		bf = newBiFlow(id.rawFlowID.clone(), ts, id.dir)
 		t.table[string(bf.id.flowID)] = bf
 		t.flows.append(bf)
 	} else if bf.dir != id.dir {
 		dir = flowDirReversed
 	}
 
+	bf.ts = ts
 	stats := bf.stats[dir]
 	if stats == nil {
 		stats = newFlowStats(counter)

--- a/packetbeat/tests/system/test_0060_flows.py
+++ b/packetbeat/tests/system/test_0060_flows.py
@@ -1,5 +1,6 @@
 from packetbeat import (BaseTest, FLOWS_REQUIRED_FIELDS)
 from pprint import PrettyPrinter
+from datetime import datetime
 import six
 
 
@@ -9,6 +10,10 @@ def pprint(x): return PrettyPrinter().pprint(x)
 def check_fields(flow, fields):
     for k, v in six.iteritems(fields):
         assert flow[k] == v
+
+
+def parse_timestamp(ts):
+    return datetime.strptime(ts, "%Y-%m-%dT%H:%M:%S.%fZ")
 
 
 class Test(BaseTest):
@@ -42,6 +47,10 @@ class Test(BaseTest):
             'dest.stats.net_packets_total': 10,
             'dest.stats.net_bytes_total': 181133,
         })
+
+        start_ts = parse_timestamp(objs[0]['start_time'])
+        last_ts = parse_timestamp(objs[0]['last_time'])
+        assert last_ts > start_ts
 
     def test_memcache_udp_flow(self):
         self.render_config_template(


### PR DESCRIPTION
Cherry-pick of PR #4955 to 6.0 branch. Original message: 

Resolve: #4895 

The flow timestamp was not updated on newly received packets. The last_time field was not correctly reported. Plus this could lead to flows timing out prematurely.