### PR TITLE
Cherry-pick #4880 to 6.0: Remove all references to removed output.X.flush_interval settings

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -19,6 +19,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta1...master[Check the HEAD di
 - Fail if removed setting output.X.flush_interval is explicitly configured.
 - Rename the `/usr/bin/beatname.sh` script (e.g. `metricbeat.sh`) to `/usr/bin/beatname`. {pull}4933[4933]
 - Beat does not start if elasticsearch index pattern was modified but not the template name and pattern. {issue}4769[4769]
+- Fail if removed setting output.X.flush_interval is explicitly configured.
 
 *Auditbeat*
 

--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -237,11 +237,6 @@ output.elasticsearch:
   # Configure http request timeout before failing an request to Elasticsearch.
   #timeout: 90
 
-  # The number of seconds to wait for new events between two bulk API index requests.
-  # If `bulk_max_size` is reached before this interval expires, addition bulk index
-  # requests are made.
-  #flush_interval: 1s
-
   # Use SSL settings for HTTPS. Default is true.
   #ssl.enabled: true
 
@@ -440,9 +435,6 @@ output.elasticsearch:
   # If set to 0, no ACKs are returned by Kafka. Messages might be lost silently
   # on error.
   #required_acks: 1
-
-  # The number of seconds to wait for new events between two producer API calls.
-  #flush_interval: 1s
 
   # The configurable ClientID used for logging, debugging, and auditing
   # purposes.  The default is "beats".

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -628,11 +628,6 @@ output.elasticsearch:
   # Configure http request timeout before failing an request to Elasticsearch.
   #timeout: 90
 
-  # The number of seconds to wait for new events between two bulk API index requests.
-  # If `bulk_max_size` is reached before this interval expires, addition bulk index
-  # requests are made.
-  #flush_interval: 1s
-
   # Use SSL settings for HTTPS. Default is true.
   #ssl.enabled: true
 
@@ -831,9 +826,6 @@ output.elasticsearch:
   # If set to 0, no ACKs are returned by Kafka. Messages might be lost silently
   # on error.
   #required_acks: 1
-
-  # The number of seconds to wait for new events between two producer API calls.
-  #flush_interval: 1s
 
   # The configurable ClientID used for logging, debugging, and auditing
   # purposes.  The default is "beats".

--- a/heartbeat/heartbeat.reference.yml
+++ b/heartbeat/heartbeat.reference.yml
@@ -386,11 +386,6 @@ output.elasticsearch:
   # Configure http request timeout before failing an request to Elasticsearch.
   #timeout: 90
 
-  # The number of seconds to wait for new events between two bulk API index requests.
-  # If `bulk_max_size` is reached before this interval expires, addition bulk index
-  # requests are made.
-  #flush_interval: 1s
-
   # Use SSL settings for HTTPS. Default is true.
   #ssl.enabled: true
 
@@ -589,9 +584,6 @@ output.elasticsearch:
   # If set to 0, no ACKs are returned by Kafka. Messages might be lost silently
   # on error.
   #required_acks: 1
-
-  # The number of seconds to wait for new events between two producer API calls.
-  #flush_interval: 1s
 
   # The configurable ClientID used for logging, debugging, and auditing
   # purposes.  The default is "beats".

--- a/libbeat/_meta/config.reference.yml
+++ b/libbeat/_meta/config.reference.yml
@@ -172,11 +172,6 @@ output.elasticsearch:
   # Configure http request timeout before failing an request to Elasticsearch.
   #timeout: 90
 
-  # The number of seconds to wait for new events between two bulk API index requests.
-  # If `bulk_max_size` is reached before this interval expires, addition bulk index
-  # requests are made.
-  #flush_interval: 1s
-
   # Use SSL settings for HTTPS. Default is true.
   #ssl.enabled: true
 
@@ -375,9 +370,6 @@ output.elasticsearch:
   # If set to 0, no ACKs are returned by Kafka. Messages might be lost silently
   # on error.
   #required_acks: 1
-
-  # The number of seconds to wait for new events between two producer API calls.
-  #flush_interval: 1s
 
   # The configurable ClientID used for logging, debugging, and auditing
   # purposes.  The default is "beats".

--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -292,12 +292,6 @@ spooler size.
 
 The http request timeout in seconds for the Elasticsearch request. The default is 90.
 
-===== `flush_interval`
-
-The number of seconds to wait for new events between two bulk API index requests.
-If `bulk_max_size` is reached before this interval expires, additional bulk index
-requests are made.
-
 ===== `ssl`
 
 Configuration options for SSL parameters like the certificate authority to use
@@ -730,10 +724,6 @@ The maximum permitted size of JSON-encoded messages. Bigger messages will be dro
 The ACK reliability level required from broker. 0=no response, 1=wait for local commit, -1=wait for all replicas to commit. The default is 1.
 
 Note: If set to 0, no ACKs are returned by Kafka. Messages might be lost silently on error.
-
-===== `flush_interval`
-
-The number of seconds to wait for new events between two producer API calls.
 
 ===== `ssl`
 

--- a/libbeat/outputs/fileout/file.go
+++ b/libbeat/outputs/fileout/file.go
@@ -31,7 +31,6 @@ func makeFileout(
 	}
 
 	// disable bulk support in publisher pipeline
-	cfg.SetInt("flush_interval", -1, -1)
 	cfg.SetInt("bulk_max_size", -1, -1)
 
 	fo := &fileOutput{beat: beat, stats: stats}

--- a/libbeat/outputs/logstash/logstash_integration_test.go
+++ b/libbeat/outputs/logstash/logstash_integration_test.go
@@ -148,12 +148,10 @@ func newTestElasticsearchOutput(t *testing.T, test string) *testOutputer {
 	index := testElasticsearchIndex(test)
 	connection := esConnect(t, index)
 
-	flushInterval := 0
 	bulkSize := 0
 	config, _ := common.NewConfigFrom(map[string]interface{}{
 		"hosts":            []string{getElasticsearchHost()},
 		"index":            connection.index,
-		"flush_interval":   &flushInterval,
 		"bulk_max_size":    &bulkSize,
 		"username":         os.Getenv("ES_USER"),
 		"password":         os.Getenv("ES_PASS"),

--- a/libbeat/outputs/output_reg.go
+++ b/libbeat/outputs/output_reg.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
 )
 
 var outputReg = map[string]Factory{}
@@ -40,6 +41,10 @@ func Load(info common.BeatInfo, stats *Stats, name string, config *common.Config
 	factory := FindFactory(name)
 	if factory == nil {
 		return Group{}, fmt.Errorf("output type %v undefined", name)
+	}
+
+	if err := cfgwarn.CheckRemoved5xSetting(config, "flush_interval"); err != nil {
+		return Fail(err)
 	}
 
 	return factory(info, stats, config)

--- a/libbeat/tests/system/test_base.py
+++ b/libbeat/tests/system/test_base.py
@@ -154,7 +154,6 @@ class Test(BaseTest):
             console={
                 "pretty": "false",
                 "bulk_max_size": 1,
-                "flush_interval": "1h"
             }
         )
 

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -592,11 +592,6 @@ output.elasticsearch:
   # Configure http request timeout before failing an request to Elasticsearch.
   #timeout: 90
 
-  # The number of seconds to wait for new events between two bulk API index requests.
-  # If `bulk_max_size` is reached before this interval expires, addition bulk index
-  # requests are made.
-  #flush_interval: 1s
-
   # Use SSL settings for HTTPS. Default is true.
   #ssl.enabled: true
 
@@ -795,9 +790,6 @@ output.elasticsearch:
   # If set to 0, no ACKs are returned by Kafka. Messages might be lost silently
   # on error.
   #required_acks: 1
-
-  # The number of seconds to wait for new events between two producer API calls.
-  #flush_interval: 1s
 
   # The configurable ClientID used for logging, debugging, and auditing
   # purposes.  The default is "beats".

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -624,11 +624,6 @@ output.elasticsearch:
   # Configure http request timeout before failing an request to Elasticsearch.
   #timeout: 90
 
-  # The number of seconds to wait for new events between two bulk API index requests.
-  # If `bulk_max_size` is reached before this interval expires, addition bulk index
-  # requests are made.
-  #flush_interval: 1s
-
   # Use SSL settings for HTTPS. Default is true.
   #ssl.enabled: true
 
@@ -827,9 +822,6 @@ output.elasticsearch:
   # If set to 0, no ACKs are returned by Kafka. Messages might be lost silently
   # on error.
   #required_acks: 1
-
-  # The number of seconds to wait for new events between two producer API calls.
-  #flush_interval: 1s
 
   # The configurable ClientID used for logging, debugging, and auditing
   # purposes.  The default is "beats".

--- a/winlogbeat/winlogbeat.reference.yml
+++ b/winlogbeat/winlogbeat.reference.yml
@@ -201,11 +201,6 @@ output.elasticsearch:
   # Configure http request timeout before failing an request to Elasticsearch.
   #timeout: 90
 
-  # The number of seconds to wait for new events between two bulk API index requests.
-  # If `bulk_max_size` is reached before this interval expires, addition bulk index
-  # requests are made.
-  #flush_interval: 1s
-
   # Use SSL settings for HTTPS. Default is true.
   #ssl.enabled: true
 
@@ -404,9 +399,6 @@ output.elasticsearch:
   # If set to 0, no ACKs are returned by Kafka. Messages might be lost silently
   # on error.
   #required_acks: 1
-
-  # The number of seconds to wait for new events between two producer API calls.
-  #flush_interval: 1s
 
   # The configurable ClientID used for logging, debugging, and auditing
   # purposes.  The default is "beats".


### PR DESCRIPTION
Cherry-pick of PR #4880 to 6.0 branch. Original message: 

- remove flush_interval from docs and reference configurations
- fail if flush_interval is explicitly configured by user