### PR TITLE
Event ACK callbacks only report the events private field

### DIFF
--- a/filebeat/beater/acker.go
+++ b/filebeat/beater/acker.go
@@ -1,9 +1,7 @@
 package beater
 
 import (
-	"github.com/elastic/beats/libbeat/beat"
-
-	"github.com/elastic/beats/filebeat/util"
+	"github.com/elastic/beats/filebeat/input/file"
 )
 
 // eventAcker handles publisher pipeline ACKs and forwards
@@ -13,30 +11,29 @@ type eventACKer struct {
 }
 
 type successLogger interface {
-	Published(events []*util.Data) bool
+	Published(states []file.State)
 }
 
 func newEventACKer(out successLogger) *eventACKer {
 	return &eventACKer{out: out}
 }
 
-func (a *eventACKer) ackEvents(events []beat.Event) {
-	data := make([]*util.Data, 0, len(events))
-	for _, event := range events {
-		p := event.Private
-		if p == nil {
+func (a *eventACKer) ackEvents(data []interface{}) {
+	states := make([]file.State, 0, len(data))
+	for _, datum := range data {
+		if datum == nil {
 			continue
 		}
 
-		datum, ok := p.(*util.Data)
-		if !ok || !datum.HasState() {
+		st, ok := datum.(file.State)
+		if !ok {
 			continue
 		}
 
-		data = append(data, datum)
+		states = append(states, st)
 	}
 
-	if len(data) > 0 {
-		a.out.Published(data)
+	if len(states) > 0 {
+		a.out.Published(states)
 	}
 }

--- a/filebeat/channel/outlet.go
+++ b/filebeat/channel/outlet.go
@@ -36,7 +36,7 @@ func (o *outlet) OnEvent(d *util.Data) bool {
 
 	event := d.GetEvent()
 	if d.HasState() {
-		event.Private = d
+		event.Private = d.GetState()
 	}
 
 	if o.wg != nil {

--- a/libbeat/beat/pipeline.go
+++ b/libbeat/beat/pipeline.go
@@ -58,13 +58,14 @@ type ClientConfig struct {
 	// by the pipeline.
 	ACKCount func(int)
 
-	// ACKEvents reports the events recently acknowledged by the pipeline.
+	// ACKEvents reports the events private data of recently acknowledged events.
 	// Note: The slice passed must be copied if the events are to be processed
 	//       after the handler returns.
-	ACKEvents func([]Event)
+	ACKEvents func([]interface{})
 
 	// ACKLastEvent reports the last ACKed event out of a batch of ACKed events only.
-	ACKLastEvent func(Event)
+	// Only the events 'Private' field will be reported.
+	ACKLastEvent func(interface{})
 }
 
 // ClientEventer provides access to internal client events.
@@ -84,10 +85,12 @@ type PipelineACKHandler struct {
 	ACKCount func(int)
 
 	// ACKEvents reports the events recently acknowledged by the pipeline.
-	ACKEvents func([]Event)
+	// Only the events 'Private' field will be reported.
+	ACKEvents func([]interface{})
 
 	// ACKLastEvent reports the last ACKed event per pipeline client.
-	ACKLastEvents func([]Event)
+	// Only the events 'Private' field will be reported.
+	ACKLastEvents func([]interface{})
 }
 
 type ProcessorList interface {

--- a/libbeat/publisher/pipeline/acker.go
+++ b/libbeat/publisher/pipeline/acker.go
@@ -304,27 +304,27 @@ func (a *boundGapCountACK) onACK(total, acked int) {
 	a.fn(total, acked)
 }
 
-// eventACK reports all dropped and ACKed events.
-// An instance of eventACK requires a counting ACKer (boundGapCountACK or countACK),
+// eventDataACK reports all dropped and ACKed events private fields.
+// An instance of eventDataACK requires a counting ACKer (boundGapCountACK or countACK),
 // for accounting for potentially dropped events.
-type eventACK struct {
+type eventDataACK struct {
 	mutex sync.Mutex
 
 	acker    acker
 	pipeline *Pipeline
 
 	// TODO: replace with more efficient dynamic sized ring-buffer?
-	events []beat.Event
-	fn     func(events []beat.Event, acked int)
+	data []interface{}
+	fn   func(data []interface{}, acked int)
 }
 
 func newEventACK(
 	pipeline *Pipeline,
 	canDrop bool,
 	sema *sema,
-	fn func([]beat.Event, int),
-) *eventACK {
-	a := &eventACK{pipeline: pipeline, fn: fn}
+	fn func([]interface{}, int),
+) *eventDataACK {
+	a := &eventDataACK{pipeline: pipeline, fn: fn}
 	a.acker = makeCountACK(pipeline, canDrop, sema, a.onACK)
 
 	return a
@@ -337,15 +337,15 @@ func makeCountACK(pipeline *Pipeline, canDrop bool, sema *sema, fn func(int, int
 	return newCountACK(fn)
 }
 
-func (a *eventACK) close() {
+func (a *eventDataACK) close() {
 	a.acker.close()
 }
 
-func (a *eventACK) addEvent(event beat.Event, published bool) bool {
+func (a *eventDataACK) addEvent(event beat.Event, published bool) bool {
 	a.mutex.Lock()
 	active := a.pipeline.ackActive.Load()
 	if active {
-		a.events = append(a.events, event)
+		a.data = append(a.data, event.Private)
 	}
 	a.mutex.Unlock()
 
@@ -355,17 +355,17 @@ func (a *eventACK) addEvent(event beat.Event, published bool) bool {
 	return false
 }
 
-func (a *eventACK) ackEvents(n int) { a.acker.ackEvents(n) }
-func (a *eventACK) onACK(total, acked int) {
+func (a *eventDataACK) ackEvents(n int) { a.acker.ackEvents(n) }
+func (a *eventDataACK) onACK(total, acked int) {
 	n := total
 
 	a.mutex.Lock()
-	events := a.events[:n]
-	a.events = a.events[n:]
+	data := a.data[:n]
+	a.data = a.data[n:]
 	a.mutex.Unlock()
 
-	if len(events) > 0 && a.pipeline.ackActive.Load() {
-		a.fn(events, acked)
+	if len(data) > 0 && a.pipeline.ackActive.Load() {
+		a.fn(data, acked)
 	}
 }
 

--- a/libbeat/publisher/pipeline/client_ack.go
+++ b/libbeat/publisher/pipeline/client_ack.go
@@ -44,8 +44,8 @@ func (p *Pipeline) makeACKer(
 	return newWaitACK(acker, waitClose)
 }
 
-func lastEventACK(fn func(beat.Event)) func([]beat.Event) {
-	return func(events []beat.Event) {
+func lastEventACK(fn func(interface{})) func([]interface{}) {
+	return func(events []interface{}) {
 		fn(events[len(events)-1])
 	}
 }
@@ -91,7 +91,7 @@ func buildClientEventACK(
 	pipeline *Pipeline,
 	canDrop bool,
 	sema *sema,
-	mk func(*clientACKer) func([]beat.Event, int),
+	mk func(*clientACKer) func([]interface{}, int),
 ) acker {
 	guard := &clientACKer{}
 	guard.lift(newEventACK(pipeline, canDrop, sema, mk(guard)))

--- a/libbeat/publisher/pipeline/pipeline_ack.go
+++ b/libbeat/publisher/pipeline/pipeline_ack.go
@@ -9,7 +9,7 @@ import (
 type ackBuilder interface {
 	createPipelineACKer(canDrop bool, sema *sema) acker
 	createCountACKer(canDrop bool, sema *sema, fn func(int)) acker
-	createEventACKer(canDrop bool, sema *sema, fn func([]beat.Event)) acker
+	createEventACKer(canDrop bool, sema *sema, fn func([]interface{})) acker
 }
 
 type pipelineEmptyACK struct {
@@ -33,10 +33,10 @@ func (b *pipelineEmptyACK) createCountACKer(canDrop bool, sema *sema, fn func(in
 func (b *pipelineEmptyACK) createEventACKer(
 	canDrop bool,
 	sema *sema,
-	fn func([]beat.Event),
+	fn func([]interface{}),
 ) acker {
-	return buildClientEventACK(b.pipeline, canDrop, sema, func(guard *clientACKer) func([]beat.Event, int) {
-		return func(events []beat.Event, acked int) {
+	return buildClientEventACK(b.pipeline, canDrop, sema, func(guard *clientACKer) func([]interface{}, int) {
+		return func(events []interface{}, acked int) {
 			if guard.Active() {
 				fn(events)
 			}
@@ -67,13 +67,13 @@ func (b *pipelineCountACK) createCountACKer(canDrop bool, sema *sema, fn func(in
 func (b *pipelineCountACK) createEventACKer(
 	canDrop bool,
 	sema *sema,
-	fn func([]beat.Event),
+	fn func([]interface{}),
 ) acker {
-	return buildClientEventACK(b.pipeline, canDrop, sema, func(guard *clientACKer) func([]beat.Event, int) {
-		return func(events []beat.Event, acked int) {
-			b.cb(len(events), acked)
+	return buildClientEventACK(b.pipeline, canDrop, sema, func(guard *clientACKer) func([]interface{}, int) {
+		return func(data []interface{}, acked int) {
+			b.cb(len(data), acked)
 			if guard.Active() {
-				fn(events)
+				fn(data)
 			}
 		}
 	})
@@ -81,7 +81,7 @@ func (b *pipelineCountACK) createEventACKer(
 
 type pipelineEventsACK struct {
 	pipeline *Pipeline
-	cb       func([]beat.Event, int)
+	cb       func([]interface{}, int)
 }
 
 func (b *pipelineEventsACK) createPipelineACKer(canDrop bool, sema *sema) acker {
@@ -89,22 +89,22 @@ func (b *pipelineEventsACK) createPipelineACKer(canDrop bool, sema *sema) acker 
 }
 
 func (b *pipelineEventsACK) createCountACKer(canDrop bool, sema *sema, fn func(int)) acker {
-	return buildClientEventACK(b.pipeline, canDrop, sema, func(guard *clientACKer) func([]beat.Event, int) {
-		return func(events []beat.Event, acked int) {
-			b.cb(events, acked)
+	return buildClientEventACK(b.pipeline, canDrop, sema, func(guard *clientACKer) func([]interface{}, int) {
+		return func(data []interface{}, acked int) {
+			b.cb(data, acked)
 			if guard.Active() {
-				fn(len(events))
+				fn(len(data))
 			}
 		}
 	})
 }
 
-func (b *pipelineEventsACK) createEventACKer(canDrop bool, sema *sema, fn func([]beat.Event)) acker {
-	return buildClientEventACK(b.pipeline, canDrop, sema, func(guard *clientACKer) func([]beat.Event, int) {
-		return func(events []beat.Event, acked int) {
-			b.cb(events, acked)
+func (b *pipelineEventsACK) createEventACKer(canDrop bool, sema *sema, fn func([]interface{})) acker {
+	return buildClientEventACK(b.pipeline, canDrop, sema, func(guard *clientACKer) func([]interface{}, int) {
+		return func(data []interface{}, acked int) {
+			b.cb(data, acked)
 			if guard.Active() {
-				fn(events)
+				fn(data)
 			}
 		}
 	})
@@ -124,15 +124,15 @@ type pipelineEventCB struct {
 
 	acks chan int
 
-	events        chan eventsMsg
-	droppedEvents chan eventsMsg
+	events        chan eventsDataMsg
+	droppedEvents chan eventsDataMsg
 
 	mode    pipelineACKMode
 	handler beat.PipelineACKHandler
 }
 
-type eventsMsg struct {
-	events       []beat.Event
+type eventsDataMsg struct {
+	data         []interface{}
 	total, acked int
 	sig          chan struct{}
 }
@@ -173,8 +173,8 @@ func newPipelineEventCB(handler beat.PipelineACKHandler) (*pipelineEventCB, erro
 		acks:          make(chan int),
 		mode:          mode,
 		handler:       handler,
-		events:        make(chan eventsMsg),
-		droppedEvents: make(chan eventsMsg),
+		events:        make(chan eventsDataMsg),
+		droppedEvents: make(chan eventsDataMsg),
 	}
 	go cb.worker()
 	return cb, nil
@@ -196,15 +196,15 @@ func (p *pipelineEventCB) close() {
 //       by the pipeline, before receiving/processing another ACK event.
 //       In the meantime the queue has the chance of batching-up more ACK events,
 //       such that only one ACK event is being reported to the pipeline handler
-func (p *pipelineEventCB) onEvents(events []beat.Event, acked int) {
-	p.pushMsg(eventsMsg{events: events, total: len(events), acked: acked})
+func (p *pipelineEventCB) onEvents(data []interface{}, acked int) {
+	p.pushMsg(eventsDataMsg{data: data, total: len(data), acked: acked})
 }
 
 func (p *pipelineEventCB) onCounts(total, acked int) {
-	p.pushMsg(eventsMsg{total: total, acked: acked})
+	p.pushMsg(eventsDataMsg{total: total, acked: acked})
 }
 
-func (p *pipelineEventCB) pushMsg(msg eventsMsg) {
+func (p *pipelineEventCB) pushMsg(msg eventsDataMsg) {
 	if msg.acked == 0 {
 		p.droppedEvents <- msg
 	} else {
@@ -235,7 +235,7 @@ func (p *pipelineEventCB) worker() {
 			// short circuite dropped events, but have client block until all events
 			// have been processed by pipeline ack handler
 		case msg := <-p.droppedEvents:
-			p.reportEvents(msg.events, msg.total)
+			p.reportEventsData(msg.data, msg.total)
 			if msg.sig != nil {
 				close(msg.sig)
 			}
@@ -249,13 +249,13 @@ func (p *pipelineEventCB) worker() {
 func (p *pipelineEventCB) collect(count int) (exit bool) {
 	var (
 		signalers []chan struct{}
-		events    []beat.Event
+		data      []interface{}
 		acked     int
 		total     int
 	)
 
 	for acked < count {
-		var msg eventsMsg
+		var msg eventsDataMsg
 		select {
 		case msg = <-p.events:
 		case msg = <-p.droppedEvents:
@@ -276,11 +276,11 @@ func (p *pipelineEventCB) collect(count int) (exit bool) {
 
 		switch p.mode {
 		case eventsACKMode:
-			events = append(events, msg.events...)
+			data = append(data, msg.data...)
 
 		case lastEventsACKMode:
-			if L := len(msg.events); L > 0 {
-				events = append(events, msg.events[L-1])
+			if L := len(msg.data); L > 0 {
+				data = append(data, msg.data[L-1])
 			}
 		}
 	}
@@ -289,18 +289,18 @@ func (p *pipelineEventCB) collect(count int) (exit bool) {
 	for _, sig := range signalers {
 		close(sig)
 	}
-	p.reportEvents(events, total)
+	p.reportEventsData(data, total)
 	return
 }
 
-func (p *pipelineEventCB) reportEvents(events []beat.Event, total int) {
+func (p *pipelineEventCB) reportEventsData(data []interface{}, total int) {
 	// report ACK back to the beat
 	switch p.mode {
 	case countACKMode:
 		p.handler.ACKCount(total)
 	case eventsACKMode:
-		p.handler.ACKEvents(events)
+		p.handler.ACKEvents(data)
 	case lastEventsACKMode:
-		p.handler.ACKLastEvents(events)
+		p.handler.ACKLastEvents(data)
 	}
 }

--- a/winlogbeat/beater/winlogbeat.go
+++ b/winlogbeat/beater/winlogbeat.go
@@ -121,19 +121,11 @@ func (eb *Winlogbeat) Run(b *beat.Beat) error {
 
 	// setup global event ACK handler
 	err := eb.pipeline.SetACKHandler(beat.PipelineACKHandler{
-		ACKLastEvents: func(events []beat.Event) {
-			for _, event := range events {
-				priv := event.Private
-				if priv == nil {
-					continue
+		ACKLastEvents: func(data []interface{}) {
+			for _, datum := range data {
+				if st, ok := datum.(checkpoint.EventLogState); ok {
+					eb.checkpoint.PersistState(st)
 				}
-
-				st, ok := priv.(checkpoint.EventLogState)
-				if !ok {
-					continue
-				}
-
-				eb.checkpoint.PersistState(st)
 			}
 		},
 	})


### PR DESCRIPTION
- only `beat.Event.Private` field is reported in ACK handlers -> events actual fields can be GC'ed
more early
- update filebeat/winlogbeat to only store and process state updates in the registrar