### PR TITLE
Add registry for prospectors

### DIFF
--- a/filebeat/channel/interface.go
+++ b/filebeat/channel/interface.go
@@ -5,8 +5,8 @@ import (
 	"github.com/elastic/beats/libbeat/common"
 )
 
-// OutletFactory is used to create a new Outlet instance
-type OutleterFactory func(*common.Config) (Outleter, error)
+// Factory is used to create a new Outlet instance
+type Factory func(*common.Config) (Outleter, error)
 
 // Outleter is the outlet for a prospector
 type Outleter interface {

--- a/filebeat/crawler/crawler.go
+++ b/filebeat/crawler/crawler.go
@@ -13,6 +13,8 @@ import (
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/libbeat/logp"
+
+	_ "github.com/elastic/beats/filebeat/include"
 )
 
 type Crawler struct {
@@ -56,9 +58,9 @@ func (c *Crawler) Start(r *registrar.Registrar, configProspectors *common.Config
 		cfgwarn.Beta("Loading separate prospectors is enabled.")
 
 		c.prospectorsReloader = cfgfile.NewReloader(configProspectors)
-		prospectorsFactory := prospector.NewFactory(c.out, r, c.beatDone)
+		registrarContext := prospector.NewRegistrarContext(c.out, r, c.beatDone)
 		go func() {
-			c.prospectorsReloader.Run(prospectorsFactory)
+			c.prospectorsReloader.Run(registrarContext)
 		}()
 	}
 

--- a/filebeat/crawler/crawler.go
+++ b/filebeat/crawler/crawler.go
@@ -20,7 +20,7 @@ import (
 type Crawler struct {
 	prospectors         map[uint64]*prospector.Prospector
 	prospectorConfigs   []*common.Config
-	out                 channel.OutleterFactory
+	out                 channel.Factory
 	wg                  sync.WaitGroup
 	modulesReloader     *cfgfile.Reloader
 	prospectorsReloader *cfgfile.Reloader
@@ -29,7 +29,7 @@ type Crawler struct {
 	beatDone            chan struct{}
 }
 
-func New(out channel.OutleterFactory, prospectorConfigs []*common.Config, beatVersion string, beatDone chan struct{}, once bool) (*Crawler, error) {
+func New(out channel.Factory, prospectorConfigs []*common.Config, beatVersion string, beatDone chan struct{}, once bool) (*Crawler, error) {
 	return &Crawler{
 		out:               out,
 		prospectors:       map[uint64]*prospector.Prospector{},

--- a/filebeat/fileset/factory.go
+++ b/filebeat/fileset/factory.go
@@ -4,7 +4,7 @@ import (
 	"github.com/mitchellh/hashstructure"
 
 	"github.com/elastic/beats/filebeat/channel"
-	"github.com/elastic/beats/filebeat/prospector"
+	pros "github.com/elastic/beats/filebeat/prospector"
 	"github.com/elastic/beats/filebeat/registrar"
 	"github.com/elastic/beats/libbeat/cfgfile"
 	"github.com/elastic/beats/libbeat/common"
@@ -25,7 +25,7 @@ type Factory struct {
 type prospectorsRunner struct {
 	id                    uint64
 	moduleRegistry        *ModuleRegistry
-	prospectors           []*prospector.Prospector
+	prospectors           []*pros.Prospector
 	pipelineLoaderFactory PipelineLoaderFactory
 }
 
@@ -62,9 +62,9 @@ func (f *Factory) Create(c *common.Config) (cfgfile.Runner, error) {
 		return nil, err
 	}
 
-	prospectors := make([]*prospector.Prospector, len(pConfigs))
+	prospectors := make([]*pros.Prospector, len(pConfigs))
 	for i, pConfig := range pConfigs {
-		prospectors[i], err = prospector.NewProspector(pConfig, f.outlet, f.beatDone, f.registrar.GetStates())
+		prospectors[i], err = pros.NewProspector(pConfig, f.outlet, f.beatDone, f.registrar.GetStates())
 		if err != nil {
 			logp.Err("Error creating prospector: %s", err)
 			return nil, err

--- a/filebeat/fileset/factory.go
+++ b/filebeat/fileset/factory.go
@@ -14,7 +14,7 @@ import (
 
 // Factory for modules
 type Factory struct {
-	outlet                channel.OutleterFactory
+	outlet                channel.Factory
 	registrar             *registrar.Registrar
 	beatVersion           string
 	pipelineLoaderFactory PipelineLoaderFactory
@@ -30,7 +30,7 @@ type prospectorsRunner struct {
 }
 
 // NewFactory instantiates a new Factory
-func NewFactory(outlet channel.OutleterFactory, registrar *registrar.Registrar, beatVersion string,
+func NewFactory(outlet channel.Factory, registrar *registrar.Registrar, beatVersion string,
 	pipelineLoaderFactory PipelineLoaderFactory, beatDone chan struct{}) *Factory {
 	return &Factory{
 		outlet:                outlet,

--- a/filebeat/include/list.go
+++ b/filebeat/include/list.go
@@ -1,0 +1,8 @@
+package include
+
+import (
+	_ "github.com/elastic/beats/filebeat/prospector/log"
+	_ "github.com/elastic/beats/filebeat/prospector/redis"
+	_ "github.com/elastic/beats/filebeat/prospector/stdin"
+	_ "github.com/elastic/beats/filebeat/prospector/udp"
+)

--- a/filebeat/prospector/log/prospector.go
+++ b/filebeat/prospector/log/prospector.go
@@ -12,6 +12,7 @@ import (
 	"github.com/elastic/beats/filebeat/channel"
 	"github.com/elastic/beats/filebeat/harvester"
 	"github.com/elastic/beats/filebeat/input/file"
+	"github.com/elastic/beats/filebeat/prospector"
 	"github.com/elastic/beats/filebeat/util"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
@@ -28,6 +29,13 @@ var (
 	harvesterSkipped = monitoring.NewInt(nil, "filebeat.harvester.skipped")
 )
 
+func init() {
+	err := prospector.Register("log", NewProspector)
+	if err != nil {
+		panic(err)
+	}
+}
+
 // Prospector contains the prospector and its config
 type Prospector struct {
 	cfg         *common.Config
@@ -42,10 +50,9 @@ type Prospector struct {
 // NewProspector instantiates a new Log
 func NewProspector(
 	cfg *common.Config,
-	states []file.State,
 	outlet channel.OutleterFactory,
-	done, beatDone chan struct{},
-) (*Prospector, error) {
+	context prospector.Context,
+) (prospector.Prospectorer, error) {
 
 	// Note: underlying output.
 	//  The prospector and harvester do have different requirements
@@ -61,7 +68,7 @@ func NewProspector(
 	// stateOut will only be unblocked if the beat is shut down.
 	// otherwise it can block on a full publisher pipeline, so state updates
 	// can be forwarded correctly to the registrar.
-	stateOut := channel.CloseOnSignal(channel.SubOutlet(out), beatDone)
+	stateOut := channel.CloseOnSignal(channel.SubOutlet(out), context.BeatDone)
 
 	p := &Prospector{
 		config:      defaultConfig,
@@ -70,7 +77,7 @@ func NewProspector(
 		outlet:      out,
 		stateOutlet: stateOut,
 		states:      &file.States{},
-		done:        done,
+		done:        context.Done,
 	}
 
 	if err := cfg.Unpack(&p.config); err != nil {
@@ -92,7 +99,7 @@ func NewProspector(
 		return nil, fmt.Errorf("each prospector must have at least one path defined")
 	}
 
-	err = p.loadStates(states)
+	err = p.loadStates(context.States)
 	if err != nil {
 		return nil, err
 	}

--- a/filebeat/prospector/log/prospector.go
+++ b/filebeat/prospector/log/prospector.go
@@ -50,7 +50,7 @@ type Prospector struct {
 // NewProspector instantiates a new Log
 func NewProspector(
 	cfg *common.Config,
-	outlet channel.OutleterFactory,
+	outlet channel.Factory,
 	context prospector.Context,
 ) (prospector.Prospectorer, error) {
 

--- a/filebeat/prospector/prospector.go
+++ b/filebeat/prospector/prospector.go
@@ -1,22 +1,23 @@
 package prospector
 
 import (
-	"fmt"
 	"sync"
 	"time"
 
 	"github.com/mitchellh/hashstructure"
 
 	"github.com/elastic/beats/filebeat/channel"
-	"github.com/elastic/beats/filebeat/harvester"
 	"github.com/elastic/beats/filebeat/input/file"
-	"github.com/elastic/beats/filebeat/prospector/log"
-	"github.com/elastic/beats/filebeat/prospector/redis"
-	"github.com/elastic/beats/filebeat/prospector/stdin"
-	"github.com/elastic/beats/filebeat/prospector/udp"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 )
+
+// Prospectorer is the interface common to all prospectors
+type Prospectorer interface {
+	Run()
+	Stop()
+	Wait()
+}
 
 // Prospector contains the prospector
 type Prospector struct {
@@ -27,13 +28,6 @@ type Prospector struct {
 	id           uint64
 	Once         bool
 	beatDone     chan struct{}
-}
-
-// Prospectorer is the interface common to all prospectors
-type Prospectorer interface {
-	Run()
-	Stop()
-	Wait()
 }
 
 // NewProspector instantiates a new prospector
@@ -63,38 +57,25 @@ func NewProspector(
 		return nil, err
 	}
 
-	err = prospector.initProspectorer(outlet, states, conf)
+	var f Factory
+	f, err = GetFactory(prospector.config.Type)
 	if err != nil {
 		return prospector, err
 	}
 
-	return prospector, nil
-}
-
-func (p *Prospector) initProspectorer(outlet channel.OutleterFactory, states []file.State, config *common.Config) error {
+	context := Context{
+		States:   states,
+		Done:     prospector.done,
+		BeatDone: prospector.beatDone,
+	}
 	var prospectorer Prospectorer
-	var err error
-
-	switch p.config.Type {
-	case harvester.StdinType:
-		prospectorer, err = stdin.NewProspector(config, outlet)
-	case harvester.RedisType:
-		prospectorer, err = redis.NewProspector(config, outlet)
-	case harvester.LogType:
-		prospectorer, err = log.NewProspector(config, states, outlet, p.done, p.beatDone)
-	case harvester.UdpType:
-		prospectorer, err = udp.NewProspector(config, outlet)
-	default:
-		return fmt.Errorf("invalid prospector type: %v. Change type", p.config.Type)
-	}
-
+	prospectorer, err = f(conf, outlet, context)
 	if err != nil {
-		return err
+		return prospector, err
 	}
+	prospector.prospectorer = prospectorer
 
-	p.prospectorer = prospectorer
-
-	return nil
+	return prospector, nil
 }
 
 // Start starts the prospector

--- a/filebeat/prospector/prospector.go
+++ b/filebeat/prospector/prospector.go
@@ -33,7 +33,7 @@ type Prospector struct {
 // NewProspector instantiates a new prospector
 func NewProspector(
 	conf *common.Config,
-	outlet channel.OutleterFactory,
+	outlet channel.Factory,
 	beatDone chan struct{},
 	states []file.State,
 ) (*Prospector, error) {

--- a/filebeat/prospector/redis/prospector.go
+++ b/filebeat/prospector/redis/prospector.go
@@ -31,7 +31,7 @@ type Prospector struct {
 }
 
 // NewProspector creates a new redis prospector
-func NewProspector(cfg *common.Config, outletFactory channel.OutleterFactory, context prospector.Context) (prospector.Prospectorer, error) {
+func NewProspector(cfg *common.Config, outletFactory channel.Factory, context prospector.Context) (prospector.Prospectorer, error) {
 	cfgwarn.Experimental("Redis slowlog prospector is enabled.")
 
 	config := defaultConfig

--- a/filebeat/prospector/redis/prospector.go
+++ b/filebeat/prospector/redis/prospector.go
@@ -8,10 +8,18 @@ import (
 	"github.com/elastic/beats/filebeat/channel"
 	"github.com/elastic/beats/filebeat/harvester"
 	"github.com/elastic/beats/filebeat/input/file"
+	"github.com/elastic/beats/filebeat/prospector"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/libbeat/logp"
 )
+
+func init() {
+	err := prospector.Register("redis", NewProspector)
+	if err != nil {
+		panic(err)
+	}
+}
 
 // Prospector is a prospector for redis
 type Prospector struct {
@@ -23,7 +31,7 @@ type Prospector struct {
 }
 
 // NewProspector creates a new redis prospector
-func NewProspector(cfg *common.Config, outletFactory channel.OutleterFactory) (*Prospector, error) {
+func NewProspector(cfg *common.Config, outletFactory channel.OutleterFactory, context prospector.Context) (prospector.Prospectorer, error) {
 	cfgwarn.Experimental("Redis slowlog prospector is enabled.")
 
 	config := defaultConfig

--- a/filebeat/prospector/registrarcontext.go
+++ b/filebeat/prospector/registrarcontext.go
@@ -10,13 +10,13 @@ import (
 
 // RegistrarContext is a factory for registrars
 type RegistrarContext struct {
-	outlet    channel.OutleterFactory
+	outlet    channel.Factory
 	registrar *registrar.Registrar
 	beatDone  chan struct{}
 }
 
 // NewRegistrarContext instantiates a new RegistrarContext
-func NewRegistrarContext(outlet channel.OutleterFactory, registrar *registrar.Registrar, beatDone chan struct{}) *RegistrarContext {
+func NewRegistrarContext(outlet channel.Factory, registrar *registrar.Registrar, beatDone chan struct{}) *RegistrarContext {
 	return &RegistrarContext{
 		outlet:    outlet,
 		registrar: registrar,

--- a/filebeat/prospector/registrarcontext.go
+++ b/filebeat/prospector/registrarcontext.go
@@ -8,16 +8,16 @@ import (
 	"github.com/elastic/beats/libbeat/logp"
 )
 
-// Factory is a factory for registrars
-type Factory struct {
+// RegistrarContext is a factory for registrars
+type RegistrarContext struct {
 	outlet    channel.OutleterFactory
 	registrar *registrar.Registrar
 	beatDone  chan struct{}
 }
 
-// NewFactory instantiates a new Factory
-func NewFactory(outlet channel.OutleterFactory, registrar *registrar.Registrar, beatDone chan struct{}) *Factory {
-	return &Factory{
+// NewRegistrarContext instantiates a new RegistrarContext
+func NewRegistrarContext(outlet channel.OutleterFactory, registrar *registrar.Registrar, beatDone chan struct{}) *RegistrarContext {
+	return &RegistrarContext{
 		outlet:    outlet,
 		registrar: registrar,
 		beatDone:  beatDone,
@@ -25,7 +25,7 @@ func NewFactory(outlet channel.OutleterFactory, registrar *registrar.Registrar, 
 }
 
 // Create creates a prospector based on a config
-func (r *Factory) Create(c *common.Config) (cfgfile.Runner, error) {
+func (r *RegistrarContext) Create(c *common.Config) (cfgfile.Runner, error) {
 	p, err := NewProspector(c, r.outlet, r.beatDone, r.registrar.GetStates())
 	if err != nil {
 		logp.Err("Error creating prospector: %s", err)

--- a/filebeat/prospector/registry.go
+++ b/filebeat/prospector/registry.go
@@ -1,0 +1,45 @@
+package prospector
+
+import (
+	"fmt"
+
+	"github.com/elastic/beats/filebeat/channel"
+	"github.com/elastic/beats/filebeat/input/file"
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/logp"
+)
+
+type Context struct {
+	States   []file.State
+	Done     chan struct{}
+	BeatDone chan struct{}
+}
+
+type Factory func(config *common.Config, outletFactory channel.OutleterFactory, context Context) (Prospectorer, error)
+
+var registry = make(map[string]Factory)
+
+func Register(name string, factory Factory) error {
+	logp.Info("Registering prospector factory")
+	if name == "" {
+		return fmt.Errorf("Error registering prospector: name cannot be empty")
+	}
+	if factory == nil {
+		return fmt.Errorf("Error registering prospector '%v': factory cannot be empty", name)
+	}
+	if _, exists := registry[name]; exists {
+		return fmt.Errorf("Error registering prospector '%v': already registered", name)
+	}
+
+	registry[name] = factory
+	logp.Info("Succesfully registered prospector")
+
+	return nil
+}
+
+func GetFactory(name string) (Factory, error) {
+	if _, exists := registry[name]; !exists {
+		return nil, fmt.Errorf("Error retrieving factory for prospector '%v'", name)
+	}
+	return registry[name], nil
+}

--- a/filebeat/prospector/registry.go
+++ b/filebeat/prospector/registry.go
@@ -15,7 +15,7 @@ type Context struct {
 	BeatDone chan struct{}
 }
 
-type Factory func(config *common.Config, outletFactory channel.OutleterFactory, context Context) (Prospectorer, error)
+type Factory func(config *common.Config, outletFactory channel.Factory, context Context) (Prospectorer, error)
 
 var registry = make(map[string]Factory)
 

--- a/filebeat/prospector/registry_test.go
+++ b/filebeat/prospector/registry_test.go
@@ -1,0 +1,57 @@
+package prospector
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/filebeat/channel"
+	"github.com/elastic/beats/libbeat/common"
+)
+
+var fakeFactory = func(config *common.Config, outletFactory channel.OutleterFactory, context Context) (Prospectorer, error) {
+	return nil, nil
+}
+
+func TestAddFactoryEmptyName(t *testing.T) {
+	err := Register("", nil)
+	if assert.Error(t, err) {
+		assert.Equal(t, "Error registering prospector: name cannot be empty", err.Error())
+	}
+}
+
+func TestAddNilFactory(t *testing.T) {
+	err := Register("name", nil)
+	if assert.Error(t, err) {
+		assert.Equal(t, "Error registering prospector 'name': factory cannot be empty", err.Error())
+	}
+}
+
+func TestAddFactoryTwice(t *testing.T) {
+	var err error
+	err = Register("name", fakeFactory)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = Register("name", fakeFactory)
+	if assert.Error(t, err) {
+		assert.Equal(t, "Error registering prospector 'name': already registered", err.Error())
+	}
+}
+
+func TestGetFactory(t *testing.T) {
+	f, err := GetFactory("name")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.NotNil(t, f)
+}
+
+func TestGetNonExistentFactory(t *testing.T) {
+	f, err := GetFactory("noSuchFactory")
+	assert.Nil(t, f)
+	if assert.Error(t, err) {
+		assert.Equal(t, "Error retrieving factory for prospector 'noSuchFactory'", err.Error())
+	}
+}

--- a/filebeat/prospector/registry_test.go
+++ b/filebeat/prospector/registry_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/elastic/beats/libbeat/common"
 )
 
-var fakeFactory = func(config *common.Config, outletFactory channel.OutleterFactory, context Context) (Prospectorer, error) {
+var fakeFactory = func(config *common.Config, outletFactory channel.Factory, context Context) (Prospectorer, error) {
 	return nil, nil
 }
 

--- a/filebeat/prospector/stdin/prospector.go
+++ b/filebeat/prospector/stdin/prospector.go
@@ -30,7 +30,7 @@ type Prospector struct {
 
 // NewStdin creates a new stdin prospector
 // This prospector contains one harvester which is reading from stdin
-func NewProspector(cfg *common.Config, outlet channel.OutleterFactory, context prospector.Context) (prospector.Prospectorer, error) {
+func NewProspector(cfg *common.Config, outlet channel.Factory, context prospector.Context) (prospector.Prospectorer, error) {
 	out, err := outlet(cfg)
 	if err != nil {
 		return nil, err

--- a/filebeat/prospector/stdin/prospector.go
+++ b/filebeat/prospector/stdin/prospector.go
@@ -6,10 +6,18 @@ import (
 	"github.com/elastic/beats/filebeat/channel"
 	"github.com/elastic/beats/filebeat/harvester"
 	"github.com/elastic/beats/filebeat/input/file"
+	"github.com/elastic/beats/filebeat/prospector"
 	"github.com/elastic/beats/filebeat/prospector/log"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 )
+
+func init() {
+	err := prospector.Register("stdin", NewProspector)
+	if err != nil {
+		panic(err)
+	}
+}
 
 // Prospector is a prospector for stdin
 type Prospector struct {
@@ -22,7 +30,7 @@ type Prospector struct {
 
 // NewStdin creates a new stdin prospector
 // This prospector contains one harvester which is reading from stdin
-func NewProspector(cfg *common.Config, outlet channel.OutleterFactory) (*Prospector, error) {
+func NewProspector(cfg *common.Config, outlet channel.OutleterFactory, context prospector.Context) (prospector.Prospectorer, error) {
 	out, err := outlet(cfg)
 	if err != nil {
 		return nil, err

--- a/filebeat/prospector/udp/prospector.go
+++ b/filebeat/prospector/udp/prospector.go
@@ -3,10 +3,18 @@ package udp
 import (
 	"github.com/elastic/beats/filebeat/channel"
 	"github.com/elastic/beats/filebeat/harvester"
+	"github.com/elastic/beats/filebeat/prospector"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/libbeat/logp"
 )
+
+func init() {
+	err := prospector.Register("udp", NewProspector)
+	if err != nil {
+		panic(err)
+	}
+}
 
 type Prospector struct {
 	harvester *Harvester
@@ -14,7 +22,7 @@ type Prospector struct {
 	outlet    channel.Outleter
 }
 
-func NewProspector(cfg *common.Config, outlet channel.OutleterFactory) (*Prospector, error) {
+func NewProspector(cfg *common.Config, outlet channel.OutleterFactory, context prospector.Context) (prospector.Prospectorer, error) {
 	cfgwarn.Experimental("UDP prospector type is used")
 
 	out, err := outlet(cfg)

--- a/filebeat/prospector/udp/prospector.go
+++ b/filebeat/prospector/udp/prospector.go
@@ -22,7 +22,7 @@ type Prospector struct {
 	outlet    channel.Outleter
 }
 
-func NewProspector(cfg *common.Config, outlet channel.OutleterFactory, context prospector.Context) (prospector.Prospectorer, error) {
+func NewProspector(cfg *common.Config, outlet channel.Factory, context prospector.Context) (prospector.Prospectorer, error) {
 	cfgwarn.Experimental("UDP prospector type is used")
 
 	out, err := outlet(cfg)


### PR DESCRIPTION
From now on it is possible to register prospectors in `init` functions, just like in Metricbeat.

Example:
```
func init() {
	err := prospectors.Register("log", NewProspector)
	if err != nil {
		panic(err)
	}
}
```
General `prospector` functions were moved to `prospectors` package (for a lack of a better name). In `prospector.go` new prospectors should be imported to register.