### PR TITLE
add_kubernetes_metadata processor: add support for "/var/log/containers/" log path 

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -85,6 +85,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta1...master[Check the HEAD di
 
 - Add PostgreSQL module with slowlog support. {pull}4763[4763]
 - Add Kafka log module. {pull}4885[4885]
+- Add support for `/var/log/containers/` log path in `add_kubernetes_metadata` processor. {pull}4981[4981]
 
 *Heartbeat*
 

--- a/filebeat/processor/add_kubernetes_metadata/indexing.go
+++ b/filebeat/processor/add_kubernetes_metadata/indexing.go
@@ -66,19 +66,17 @@ func (f *LogPathMatcher) MetadataIndex(event common.MapStr) string {
 
 		// In case of the Kubernetes log path "/var/log/containers/",
 		// the container ID will be located right before the ".log" extension.
-		if strings.HasPrefix(f.LogsPath, "/var/log/containers/") &&
-		   strings.HasSuffix(source, ".log") &&
-		   sourceLen >= containerIdLen + 4 {
+		if strings.HasPrefix(f.LogsPath, "/var/log/containers/") && strings.HasSuffix(source, ".log") && sourceLen >= containerIdLen+4 {
 			containerIdEnd := sourceLen - 4
-			cid := source[containerIdEnd - containerIdLen : containerIdEnd]
+			cid := source[containerIdEnd-containerIdLen : containerIdEnd]
 			logp.Debug("kubernetes", "Using container id: %s", cid)
 			return cid
 		}
 
 		// In any other case, we assume the container ID will follow right after the log path.
 		// However we need to check the length to prevent "slice bound out of range" runtime errors.
-		if sourceLen >= logsPathLen + containerIdLen {
-			cid := source[logsPathLen : logsPathLen + containerIdLen]
+		if sourceLen >= logsPathLen+containerIdLen {
+			cid := source[logsPathLen : logsPathLen+containerIdLen]
 			logp.Debug("kubernetes", "Using container id: %s", cid)
 			return cid
 		}

--- a/filebeat/processor/add_kubernetes_metadata/indexing.go
+++ b/filebeat/processor/add_kubernetes_metadata/indexing.go
@@ -43,19 +43,31 @@ func newLogsPathMatcher(cfg common.Config) (add_kubernetes_metadata.Matcher, err
 		logPath = logPath + "/"
 	}
 
+	logp.Debug("kubernetes", "logs_path matcher log path: %s", logPath)
+
 	return &LogPathMatcher{LogsPath: logPath}, nil
 }
 
 func (f *LogPathMatcher) MetadataIndex(event common.MapStr) string {
 	if value, ok := event["source"]; ok {
 		source := value.(string)
-		logp.Debug("kubernetes", "Incoming source value: ", source)
+		logp.Debug("kubernetes", "Incoming source value: %s", source)
 		cid := ""
 		if strings.Contains(source, f.LogsPath) {
-			//Docker container is 64 chars in length
-			cid = source[len(f.LogsPath) : len(f.LogsPath)+64]
+			if f.LogsPath == "/var/log/containers/" && strings.HasSuffix(source, ".log") {
+				// In case of the Kubernetes log path "/var/log/containers/",
+				// the container ID will be located right before the ".log" ending.
+				sourceLen := len(source)
+				cid = source[sourceLen-68 : sourceLen-4]
+			} else {
+				// In any other case, we assume the container ID will follow right after the log path.
+				//Docker container is 64 chars in length
+				cid = source[len(f.LogsPath) : len(f.LogsPath)+64]
+			}
+			logp.Debug("kubernetes", "Using container id: %s", cid)
+		} else {
+			logp.Debug("kubernetes", "Error extracting container id - source value does not contain log path.")
 		}
-		logp.Debug("kubernetes", "Using container id: ", cid)
 
 		if cid != "" {
 			return cid

--- a/filebeat/processor/add_kubernetes_metadata/indexing_test.go
+++ b/filebeat/processor/add_kubernetes_metadata/indexing_test.go
@@ -30,3 +30,22 @@ func TestLogsPathMatcher(t *testing.T) {
 
 	assert.Equal(t, output, cid)
 }
+
+func TestLogsPathMatcherVarLogContainers(t *testing.T) {
+	var testConfig = common.NewConfig()
+	testConfig.SetString("logs_path", -1, "/var/log/containers/")
+
+	logMatcher, err := newLogsPathMatcher(*testConfig)
+	assert.Nil(t, err)
+
+	cid := "0069869de9adf97f574c62029aeba65d1ecd85a2a112e87fbc28afe4dec2b843"
+	logPath := fmt.Sprintf("/var/log/containers/kube-proxy-4d7nt_kube-system_kube-proxy-%s.log", cid)
+
+	input := common.MapStr{
+		"source": logPath,
+	}
+
+	output := logMatcher.MetadataIndex(input)
+
+	assert.Equal(t, output, cid)
+}

--- a/filebeat/processor/add_kubernetes_metadata/indexing_test.go
+++ b/filebeat/processor/add_kubernetes_metadata/indexing_test.go
@@ -9,43 +9,63 @@ import (
 	"github.com/elastic/beats/libbeat/common"
 )
 
-func TestLogsPathMatcher(t *testing.T) {
-	var testConfig = common.NewConfig()
+// A random container ID that we use for our tests
+const cid = "0069869de9adf97f574c62029aeba65d1ecd85a2a112e87fbc28afe4dec2b843"
 
-	logMatcher, err := newLogsPathMatcher(*testConfig)
-	assert.Nil(t, err)
-
-	cid := "0069869de9adf97f574c62029aeba65d1ecd85a2a112e87fbc28afe4dec2b843"
-	logPath := fmt.Sprintf("/var/lib/docker/containers/%s/%s-json.log", cid, cid)
-
-	input := common.MapStr{
-		"source": "/var/log/messages",
-	}
-
-	output := logMatcher.MetadataIndex(input)
-	assert.Equal(t, output, "")
-
-	input["source"] = logPath
-	output = logMatcher.MetadataIndex(input)
-
-	assert.Equal(t, output, cid)
+func TestLogsPathMatcher_InvalidSource1(t *testing.T) {
+  cfgLogsPath := "" // use the default matcher configuration
+	source := "/var/log/messages"
+	expectedResult := ""
+	executeTest(t, cfgLogsPath, source, expectedResult);
 }
 
-func TestLogsPathMatcherVarLogContainers(t *testing.T) {
+func TestLogsPathMatcher_InvalidSource2(t *testing.T) {
+	cfgLogsPath := "" // use the default matcher configuration
+	source := "/var/lib/docker/containers/01234567/89abcdef-json.log"
+	expectedResult := ""
+	executeTest(t, cfgLogsPath, source, expectedResult);
+}
+
+func TestLogsPathMatcher_InvalidSource3(t *testing.T) {
+	cfgLogsPath := "/var/log/containers/"
+	source := "/var/log/containers/pod_ns_container_01234567.log"
+	expectedResult := ""
+	executeTest(t, cfgLogsPath, source, expectedResult);
+}
+
+func TestLogsPathMatcher_VarLibDockerContainers(t *testing.T) {
+	cfgLogsPath := "" // use the default matcher configuration
+	source := fmt.Sprintf("/var/lib/docker/containers/%s/%s-json.log", cid, cid)
+	expectedResult := cid;
+	executeTest(t, cfgLogsPath, source, expectedResult);
+}
+
+func TestLogsPathMatcher_VarLogContainers(t *testing.T) {
+	cfgLogsPath := "/var/log/containers/"
+	source := fmt.Sprintf("/var/log/containers/kube-proxy-4d7nt_kube-system_kube-proxy-%s.log", cid)
+	expectedResult := cid;
+	executeTest(t, cfgLogsPath, source, expectedResult);
+}
+
+func TestLogsPathMatcher_AnotherLogDir(t *testing.T) {
+	cfgLogsPath := "/var/log/other/"
+	source := fmt.Sprintf("/var/log/other/%s.log", cid)
+	expectedResult := cid;
+	executeTest(t, cfgLogsPath, source, expectedResult);
+}
+
+func executeTest(t *testing.T, cfgLogsPath string, source string, expectedResult string) {
 	var testConfig = common.NewConfig()
-	testConfig.SetString("logs_path", -1, "/var/log/containers/")
+	if cfgLogsPath != "" {
+		testConfig.SetString("logs_path", -1, cfgLogsPath)
+	}
 
 	logMatcher, err := newLogsPathMatcher(*testConfig)
 	assert.Nil(t, err)
 
-	cid := "0069869de9adf97f574c62029aeba65d1ecd85a2a112e87fbc28afe4dec2b843"
-	logPath := fmt.Sprintf("/var/log/containers/kube-proxy-4d7nt_kube-system_kube-proxy-%s.log", cid)
-
 	input := common.MapStr{
-		"source": logPath,
+		"source": source,
 	}
-
 	output := logMatcher.MetadataIndex(input)
-
-	assert.Equal(t, output, cid)
+	assert.Equal(t, output, expectedResult)
 }

--- a/filebeat/processor/add_kubernetes_metadata/indexing_test.go
+++ b/filebeat/processor/add_kubernetes_metadata/indexing_test.go
@@ -13,45 +13,45 @@ import (
 const cid = "0069869de9adf97f574c62029aeba65d1ecd85a2a112e87fbc28afe4dec2b843"
 
 func TestLogsPathMatcher_InvalidSource1(t *testing.T) {
-  cfgLogsPath := "" // use the default matcher configuration
+	cfgLogsPath := "" // use the default matcher configuration
 	source := "/var/log/messages"
 	expectedResult := ""
-	executeTest(t, cfgLogsPath, source, expectedResult);
+	executeTest(t, cfgLogsPath, source, expectedResult)
 }
 
 func TestLogsPathMatcher_InvalidSource2(t *testing.T) {
 	cfgLogsPath := "" // use the default matcher configuration
 	source := "/var/lib/docker/containers/01234567/89abcdef-json.log"
 	expectedResult := ""
-	executeTest(t, cfgLogsPath, source, expectedResult);
+	executeTest(t, cfgLogsPath, source, expectedResult)
 }
 
 func TestLogsPathMatcher_InvalidSource3(t *testing.T) {
 	cfgLogsPath := "/var/log/containers/"
 	source := "/var/log/containers/pod_ns_container_01234567.log"
 	expectedResult := ""
-	executeTest(t, cfgLogsPath, source, expectedResult);
+	executeTest(t, cfgLogsPath, source, expectedResult)
 }
 
 func TestLogsPathMatcher_VarLibDockerContainers(t *testing.T) {
 	cfgLogsPath := "" // use the default matcher configuration
 	source := fmt.Sprintf("/var/lib/docker/containers/%s/%s-json.log", cid, cid)
-	expectedResult := cid;
-	executeTest(t, cfgLogsPath, source, expectedResult);
+	expectedResult := cid
+	executeTest(t, cfgLogsPath, source, expectedResult)
 }
 
 func TestLogsPathMatcher_VarLogContainers(t *testing.T) {
 	cfgLogsPath := "/var/log/containers/"
 	source := fmt.Sprintf("/var/log/containers/kube-proxy-4d7nt_kube-system_kube-proxy-%s.log", cid)
-	expectedResult := cid;
-	executeTest(t, cfgLogsPath, source, expectedResult);
+	expectedResult := cid
+	executeTest(t, cfgLogsPath, source, expectedResult)
 }
 
 func TestLogsPathMatcher_AnotherLogDir(t *testing.T) {
 	cfgLogsPath := "/var/log/other/"
 	source := fmt.Sprintf("/var/log/other/%s.log", cid)
-	expectedResult := cid;
-	executeTest(t, cfgLogsPath, source, expectedResult);
+	expectedResult := cid
+	executeTest(t, cfgLogsPath, source, expectedResult)
 }
 
 func executeTest(t *testing.T, cfgLogsPath string, source string, expectedResult string) {


### PR DESCRIPTION
Following up on this topic:
https://discuss.elastic.co/t/add-kubernetes-metadata-should-work-in-var-log-containers/97945

# The Issue

The “add_kubernetes_metadata” processor should also work on the "/var/log/containers/" log path for the following reasons:

1. You may want to exclude log files from certain pods, e.g. the filebeat pod itself with the `exclude_files: ['filebeat-*.log']` option. That would work only in `/var/log/containers`, as only the symlinks there contain the pod name.

2. You may want to read only the log files of docker containers used by active Kubernetes pods, not any other docker containers running on the system now or in the past. That also works only by following the symlinks in `/var/log/containers`.

3. The “source” field in the log documents would be much more informative if it contained a value like `/var/log/containers/kube-proxy-4d7nt_kube-system_kube-proxy-1bddb0001161285462528b7170a53d13dfe4e17b541319485b9020eef5433266.log` 
instead of
`/var/lib/docker/containers/1bddb0001161285462528b7170a53d13dfe4e17b541319485b9020eef5433266/1bddb0001161285462528b7170a53d13dfe4e17b541319485b9020eef5433266-json.log`

# About the Pull Request

The pull requests contains a simple solution, in which the container ID is extracted in a different way when the logs_path matcher's `logs_path` setting is "/var/log/containers/".

So the processor needs to be configured like this:

```
processors:
- add_kubernetes_metadata:
    in_cluster: true
    default_matchers.enabled: false
    matchers:
    - logs_path:
        logs_path: /var/log/containers/
```

However, it seems that the `logs_path` setting is used only in the code that extracts the container ID from the source. Wouldn't it make more sense to extract the log path from the `source` variable? Then the `logs_path` setting can be removed and the processor can be used with it's default configuration:

```
processors:
- add_kubernetes_metadata:
    in_cluster: true
```
