### PR TITLE
Cherry-pick #4717 to 6.0: Adds a "type" field to the filesystem beat

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -140,6 +140,7 @@ https://github.com/elastic/beats/compare/v6.0.0-alpha2...v6.0.0-beta1[View commi
   with the system process metricset. The documentation for these metrics already
   stated that on multi-core systems the percentages could be greater than 100%. {pull}4544[4544]
 - Remove filters setting from metricbeat modules. {pull}4699[4699]
+- Added `type` field to filesystem metrics. {pull}4717[4717]
 
 *Packetbeat*
 

--- a/metricbeat/docs/fields.asciidoc
+++ b/metricbeat/docs/fields.asciidoc
@@ -8782,6 +8782,14 @@ The disk name. For example: `/dev/disk1`
 
 
 [float]
+=== system.filesystem.type
+
+type: keyword
+
+The disk type. For example: `ext4`
+
+
+[float]
 === system.filesystem.mount_point
 
 type: keyword

--- a/metricbeat/module/system/filesystem/_meta/data.json
+++ b/metricbeat/module/system/filesystem/_meta/data.json
@@ -4,6 +4,10 @@
         "hostname": "host.example.com",
         "name": "host.example.com"
     },
+    "@metadata": {
+        "beat": "noindex",
+        "type": "doc"
+    },
     "metricset": {
         "module": "system",
         "name": "filesystem",
@@ -11,18 +15,18 @@
     },
     "system": {
         "filesystem": {
-            "available": 38688276480,
-            "device_name": "none",
-            "files": 3940352,
-            "free": 41930997760,
-            "free_files": 3276976,
+            "available": 105569656832,
+            "device_name": "/dev/disk1",
+            "type": "hfs",
+            "files": 4294967279
+            "free": 105831800832,
+            "free_files": 4292793781,
             "mount_point": "/",
-            "total": 63371726848,
+            "total": 249779191808,
             "used": {
-                "bytes": 21440729088,
-                "pct": 0.3383
-            }
+                "bytes": 143947390976,
+                "pct": 0.5763
+            },
         }
-    },
-    "type": "metricsets"
+    }
 }

--- a/metricbeat/module/system/filesystem/_meta/fields.yml
+++ b/metricbeat/module/system/filesystem/_meta/fields.yml
@@ -12,6 +12,10 @@
       type: keyword
       description: >
         The disk name. For example: `/dev/disk1`
+    - name: type
+      type: keyword
+      description: >
+        The disk type. For example: `ext4`
     - name: mount_point
       type: keyword
       description: >

--- a/metricbeat/module/system/filesystem/doc.go
+++ b/metricbeat/module/system/filesystem/doc.go
@@ -5,30 +5,36 @@ for each of the mounted file systems.
 An example event looks as following:
 
 {
-  "@timestamp": "2016-05-25T20:51:36.813Z",
-  "beat": {
-    "hostname": "host.example.com",
-    "name": "host.example.com"
-  },
-  "metricset": {
-    "module": "system",
-    "name": "filesystem",
-    "rtt": 55
-  },
-  "system": {
-    "filesystem": {
-      "avail": 13838553088,
-      "device_name": "/dev/disk1",
-      "files": 60981246,
-      "free": 14100697088,
-      "free_files": 3378553,
-      "mount_point": "/",
-      "total": 249779191808,
-      "used": 235678494720,
-      "used_p": 0.9435
+    "@timestamp": "2016-05-23T08:05:34.853Z",
+    "beat": {
+        "hostname": "host.example.com",
+        "name": "host.example.com"
+    },
+    "@metadata": {
+        "beat": "noindex",
+        "type": "doc"
+    },
+    "metricset": {
+        "module": "system",
+        "name": "filesystem",
+        "rtt": 115
+    },
+    "system": {
+        "filesystem": {
+            "available": 105569656832,
+            "device_name": "/dev/disk1",
+            "type": "hfs",
+            "files": 4294967279
+            "free": 105831800832,
+            "free_files": 4292793781,
+            "mount_point": "/",
+            "total": 249779191808,
+            "used": {
+                "bytes": 143947390976,
+                "pct": 0.5763
+            },
+        }
     }
-  },
-  "type": "metricsets"
 }
 
 */

--- a/metricbeat/module/system/filesystem/helper_test.go
+++ b/metricbeat/module/system/filesystem/helper_test.go
@@ -39,6 +39,10 @@ func TestFileSystemList(t *testing.T) {
 			assert.True(t, (stat.Free >= 0))
 			assert.True(t, (stat.Avail >= 0))
 			assert.True(t, (stat.Used >= 0))
+
+			if runtime.GOOS != "windows" {
+				assert.NotEqual(t, "", stat.SysTypeName)
+			}
 		}
 	}
 }

--- a/metricbeat/tests/system/test_system.py
+++ b/metricbeat/tests/system/test_system.py
@@ -27,7 +27,7 @@ SYSTEM_CORE_FIELDS_ALL = SYSTEM_CORE_FIELDS + ["idle.ticks", "iowait.ticks", "ir
 SYSTEM_DISKIO_FIELDS = ["name", "read.count", "write.count", "read.bytes",
                         "write.bytes", "read.time", "write.time", "io.time"]
 
-SYSTEM_FILESYSTEM_FIELDS = ["available", "device_name", "files", "free",
+SYSTEM_FILESYSTEM_FIELDS = ["available", "device_name", "type", "files", "free",
                             "free_files", "mount_point", "total", "used.bytes",
                             "used.pct"]
 

--- a/winlogbeat/docs/fields.asciidoc
+++ b/winlogbeat/docs/fields.asciidoc
@@ -225,7 +225,7 @@ Image labels.
 
 
 [[exported-fields-eventlog]]
-== Event Log Record Fields
+== Event log record Fields
 
 Contains data from a Windows event log record.
 

--- a/winlogbeat/docs/fields.asciidoc
+++ b/winlogbeat/docs/fields.asciidoc
@@ -225,7 +225,7 @@ Image labels.
 
 
 [[exported-fields-eventlog]]
-== Event log record Fields
+== Event Log Record Fields
 
 Contains data from a Windows event log record.
 


### PR DESCRIPTION
Cherry-pick of PR #4717 to 6.0 branch. Original message: 

Its value is copied from `sigar.FileSystem.SysTypeName` and passed through so that it becomes possible to filter out `overlay`, `tmpfs` or otherwise uninteresting filesystems.

Fixes #3459.