### PR TITLE
Cherry-pick #4757 to 6.0: Adding support to exclude labels from kubernetes pod metadata

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -77,6 +77,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta1...master[Check the HEAD di
 *Metricbeat*
 
 - Add `filesystem.ignore_types` to system module for ignoring filesystem types. {issue}4685[4685]
+- Add support to exclude labels from kubernetes pod metadata. {pull}4757[4757]
 
 *Packetbeat*
 

--- a/libbeat/processors/add_kubernetes_metadata/config.go
+++ b/libbeat/processors/add_kubernetes_metadata/config.go
@@ -17,6 +17,7 @@ type kubeAnnotatorConfig struct {
 	DefaultMatchers    Enabled       `config:"default_matchers"`
 	DefaultIndexers    Enabled       `config:"default_indexers"`
 	IncludeLabels      []string      `config:"include_labels"`
+	ExcludeLabels      []string      `config:"exclude_labels"`
 	IncludeAnnotations []string      `config:"include_annotations"`
 }
 

--- a/libbeat/processors/add_kubernetes_metadata/indexing.go
+++ b/libbeat/processors/add_kubernetes_metadata/indexing.go
@@ -178,8 +178,9 @@ func (m *Matchers) MetadataIndex(event common.MapStr) string {
 }
 
 type GenDefaultMeta struct {
-	annotations []string
-	labels      []string
+	annotations   []string
+	labels        []string
+	labelsExclude []string
 }
 
 // GenerateMetaData generates default metadata for the given pod taking to account certain filters
@@ -193,6 +194,11 @@ func (g *GenDefaultMeta) GenerateMetaData(pod *Pod) common.MapStr {
 		}
 	} else {
 		labelMap = generateMapSubset(pod.Metadata.Labels, g.labels)
+	}
+
+	// Exclude any labels that are present in the exclude_labels config
+	for _, label := range g.labelsExclude {
+		delete(labelMap, label)
 	}
 
 	annotationsMap = generateMapSubset(pod.Metadata.Annotations, g.annotations)

--- a/libbeat/processors/add_kubernetes_metadata/indexing_test.go
+++ b/libbeat/processors/add_kubernetes_metadata/indexing_test.go
@@ -256,3 +256,49 @@ func TestFieldFormatMatcher(t *testing.T) {
 	out = matcher.MetadataIndex(event)
 	assert.Equal(t, "foo/bar", out)
 }
+
+func TestFilteredGenMetaExclusion(t *testing.T) {
+	var testConfig = common.NewConfig()
+
+	filteredGen := &GenDefaultMeta{
+		labelsExclude: []string{"x"},
+	}
+	podIndexer, err := NewPodNameIndexer(*testConfig, filteredGen)
+	assert.Nil(t, err)
+
+	podName := "testpod"
+	ns := "testns"
+	pod := Pod{
+		Metadata: ObjectMeta{
+			Name:      podName,
+			Namespace: ns,
+			Labels: map[string]string{
+				"foo": "bar",
+				"x":   "y",
+			},
+			Annotations: map[string]string{
+				"a": "b",
+				"c": "d",
+			},
+		},
+		Spec: PodSpec{},
+	}
+
+	assert.Nil(t, err)
+
+	indexers := podIndexer.GetMetadata(&pod)
+	assert.Equal(t, len(indexers), 1)
+
+	rawLabels, _ := indexers[0].Data["labels"]
+	assert.NotNil(t, rawLabels)
+
+	labelMap, ok := rawLabels.(common.MapStr)
+	assert.Equal(t, ok, true)
+	assert.Equal(t, len(labelMap), 1)
+
+	ok, _ = labelMap.HasKey("foo")
+	assert.Equal(t, ok, true)
+
+	ok, _ = labelMap.HasKey("x")
+	assert.Equal(t, ok, false)
+}

--- a/libbeat/processors/add_kubernetes_metadata/kubernetes.go
+++ b/libbeat/processors/add_kubernetes_metadata/kubernetes.go
@@ -75,8 +75,9 @@ func newKubernetesAnnotator(cfg *common.Config) (processors.Processor, error) {
 	}
 
 	metaGen := &GenDefaultMeta{
-		labels:      config.IncludeLabels,
-		annotations: config.IncludeAnnotations,
+		labels:        config.IncludeLabels,
+		annotations:   config.IncludeAnnotations,
+		labelsExclude: config.ExcludeLabels,
 	}
 
 	indexers := Indexers{


### PR DESCRIPTION
Cherry-pick of PR #4757 to 6.0 branch. Original message: 

We have seen instances where there are labels that have too high of a cardinality for which support to exclude/filter out would be good to have on the `add_kubernetes_metadata` processor.