### PR TITLE
add_kubernetes_metadata processor: add support for "/var/log/containers/" log path (generic version)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -85,6 +85,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta1...master[Check the HEAD di
 
 - Add PostgreSQL module with slowlog support. {pull}4763[4763]
 - Add Kafka log module. {pull}4885[4885]
+- Add support for `/var/log/containers/` log path in `add_kubernetes_metadata` processor. {pull}4995[4995]
 
 *Heartbeat*
 

--- a/filebeat/processor/add_kubernetes_metadata/indexing_test.go
+++ b/filebeat/processor/add_kubernetes_metadata/indexing_test.go
@@ -9,24 +9,53 @@ import (
 	"github.com/elastic/beats/libbeat/common"
 )
 
-func TestLogsPathMatcher(t *testing.T) {
-	var testConfig = common.NewConfig()
+// A random container ID that we use for our tests
+const cid = "0069869de9adf97f574c62029aeba65d1ecd85a2a112e87fbc28afe4dec2b843"
 
+func TestLogsPathMatcher_InvalidSource1(t *testing.T) {
+	source := "/var/log/messages"
+	expectedResult := ""
+	executeTest(t, source, expectedResult);
+}
+
+func TestLogsPathMatcher_InvalidSource2(t *testing.T) {
+	source := "/var/lib/docker/containers/01234567/89abcdef-json.log"
+	expectedResult := ""
+	executeTest(t, source, expectedResult);
+}
+
+func TestLogsPathMatcher_InvalidSource3(t *testing.T) {
+	source := "/var/log/containers/pod_ns_container_01234567.log"
+	expectedResult := ""
+	executeTest(t, source, expectedResult);
+}
+
+func TestLogsPathMatcher_VarLibDockerContainers(t *testing.T) {
+	source := fmt.Sprintf("/var/lib/docker/containers/%s/%s-json.log", cid, cid)
+	expectedResult := cid;
+	executeTest(t, source, expectedResult);
+}
+
+func TestLogsPathMatcher_VarLogContainers(t *testing.T) {
+	source := fmt.Sprintf("/var/log/containers/kube-proxy-4d7nt_kube-system_kube-proxy-%s.log", cid)
+	expectedResult := cid;
+	executeTest(t, source, expectedResult);
+}
+
+func TestLogsPathMatcher_GenericFallback(t *testing.T) {
+	source := fmt.Sprintf("/var/log/foo/bar-%s-baz.log", cid)
+	expectedResult := cid;
+	executeTest(t, source, expectedResult);
+}
+
+func executeTest(t *testing.T, source string, expectedResult string) {
+	var testConfig = common.NewConfig()
 	logMatcher, err := newLogsPathMatcher(*testConfig)
 	assert.Nil(t, err)
 
-	cid := "0069869de9adf97f574c62029aeba65d1ecd85a2a112e87fbc28afe4dec2b843"
-	logPath := fmt.Sprintf("/var/lib/docker/containers/%s/%s-json.log", cid, cid)
-
 	input := common.MapStr{
-		"source": "/var/log/messages",
+		"source": source,
 	}
-
 	output := logMatcher.MetadataIndex(input)
-	assert.Equal(t, output, "")
-
-	input["source"] = logPath
-	output = logMatcher.MetadataIndex(input)
-
-	assert.Equal(t, output, cid)
+	assert.Equal(t, output, expectedResult)
 }


### PR DESCRIPTION
Following up on this topic:
https://discuss.elastic.co/t/add-kubernetes-metadata-should-work-in-var-log-containers/97945
and on my previous pull request https://github.com/elastic/beats/pull/4981.

This is a cleaner and more generic solution for the issue.

# The Issue

The “add_kubernetes_metadata” processor should also work on the "/var/log/containers/" log path for the following reasons:

1. You may want to exclude log files from certain pods, e.g. the filebeat pod itself with the `exclude_files: ['filebeat-*.log']` option. That would work only in `/var/log/containers`, as only the symlinks there contain the pod name.

2. You may want to read only the log files of docker containers used by active Kubernetes pods, not any other docker containers running on the system now or in the past. That also works only by following the symlinks in `/var/log/containers`.

3. The “source” field in the log documents would be much more informative if it contained a value like `/var/log/containers/kube-proxy-4d7nt_kube-system_kube-proxy-1bddb0001161285462528b7170a53d13dfe4e17b541319485b9020eef5433266.log` 
instead of
`/var/lib/docker/containers/1bddb0001161285462528b7170a53d13dfe4e17b541319485b9020eef5433266/1bddb0001161285462528b7170a53d13dfe4e17b541319485b9020eef5433266-json.log`

# About the Pull Request

The container ID is extracted from the `source` variable via regular expressions in the following order:

1. A regular expression that matches a log file in `/var/log/containers` and returns the container ID
2. A regular expression that matches a log file in `/var/lib/docker/containers` and returns the container ID
3. A generic fallback regular expression that matches any file containing a 64-character-long hexadecimal ID in its name and returns that as container ID

In contrast to my previous pull request https://github.com/elastic/beats/pull/4981, the processor configuration does not need to be changed.
