### PR TITLE
Cherry-pick #4912 to 6.0: Add 5.x rabbitmq dashboards

### DIFF
--- a/metricbeat/module/rabbitmq/_meta/kibana/5.x/dashboard/Metricbeat-Rabbitmq.json
+++ b/metricbeat/module/rabbitmq/_meta/kibana/5.x/dashboard/Metricbeat-Rabbitmq.json
@@ -1,0 +1,13 @@
+{
+  "hits": 0,
+  "timeRestore": false,
+  "description": "",
+  "title": "Metricbeat-Rabbitmq",
+  "uiStateJSON": "{}",
+  "panelsJSON": "[{\"col\":1,\"id\":\"RabbitMQ-Memory-Usage\",\"panelIndex\":8,\"row\":1,\"size_x\":6,\"size_y\":3,\"type\":\"visualization\"},{\"col\":8,\"id\":\"Rabbitmq-Number-of-Nodes\",\"panelIndex\":2,\"row\":1,\"size_x\":3,\"size_y\":3,\"type\":\"visualization\"},{\"col\":1,\"id\":\"RabbitMQ-Erlang-Process-Usage\",\"panelIndex\":10,\"row\":4,\"size_x\":6,\"size_y\":3,\"type\":\"visualization\"},{\"col\":7,\"id\":\"RabbitMQ-Queue-Index-Operations\",\"panelIndex\":9,\"row\":4,\"size_x\":6,\"size_y\":3,\"type\":\"visualization\"}]",
+  "optionsJSON": "{\"darkTheme\":false}",
+  "version": 1,
+  "kibanaSavedObjectMeta": {
+    "searchSourceJSON": "{\"filter\":[{\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}}}]}"
+    }
+}

--- a/metricbeat/module/rabbitmq/_meta/kibana/5.x/search/Metricbeat-Rabbitmq.json
+++ b/metricbeat/module/rabbitmq/_meta/kibana/5.x/search/Metricbeat-Rabbitmq.json
@@ -1,0 +1,14 @@
+{
+  "title": "Metricbeat-Rabbitmq",
+  "description": "",
+  "hits": 0,
+  "sort": [
+    "@timestamp",
+    "desc"
+  ],
+  "version": 1,
+  "kibanaSavedObjectMeta": {
+    "searchSourceJSON":
+    "{\"index\":\"metricbeat-*\",\"filter\":[],\"highlight\":{\"pre_tags\":[\"@kibana-highlighted-field@\"],\"post_tags\":[\"@/kibana-highlighted-field@\"],\"fields\":{\"*\":{}},\"require_field_match\":false,\"fragment_size\":2147483647},\"query\":{\"query_string\":{\"query\":\"metricset.module:rabbitmq\",\"analyze_wildcard\":true}}}"
+  }
+}

--- a/metricbeat/module/rabbitmq/_meta/kibana/5.x/visualization/Rabbitmq-Erlang-Process-Usage.json
+++ b/metricbeat/module/rabbitmq/_meta/kibana/5.x/visualization/Rabbitmq-Erlang-Process-Usage.json
@@ -1,0 +1,11 @@
+{
+  "title": "RabbitMQ Erlang Process Usage",
+  "visState": "{\"title\":\"RabbitMQ Erlang Process Usage\",\"type\":\"line\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"setYExtents\":false,\"shareYAxis\":true,\"showCircles\":false,\"smoothLines\":true,\"times\":[],\"yAxis\":{}},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"max\",\"schema\":\"metric\",\"params\":{\"field\":\"rabbitmq.node.proc.used\",\"customLabel\":\"Used Process\"}},{\"id\":\"3\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"custom\",\"customInterval\":\"30s\",\"min_doc_count\":1,\"extended_bounds\":{}}},{\"id\":\"4\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"group\",\"params\":{\"field\":\"rabbitmq.node.name.keyword\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"Node name\"}}],\"listeners\":{}}",
+  "uiStateJSON": "{}",
+  "description": "",
+  "savedSearchId": "Metricbeat-Rabbitmq",
+  "version": 1,
+  "kibanaSavedObjectMeta": {
+    "searchSourceJSON": "{\"filter\":[]}"
+  }
+}

--- a/metricbeat/module/rabbitmq/_meta/kibana/5.x/visualization/Rabbitmq-Memory-Usage.json
+++ b/metricbeat/module/rabbitmq/_meta/kibana/5.x/visualization/Rabbitmq-Memory-Usage.json
@@ -1,0 +1,11 @@
+{
+  "title": "RabbitMQ Memory Usage",
+  "visState": "{\"title\":\"RabbitMQ Memory Usage\",\"type\":\"line\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"top\",\"showCircles\":false,\"smoothLines\":true,\"interpolate\":\"linear\",\"scale\":\"linear\",\"drawLinesBetweenPoints\":true,\"radiusRatio\":9,\"times\":[],\"addTimeMarker\":false,\"defaultYExtents\":true,\"setYExtents\":false,\"yAxis\":{}},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"max\",\"schema\":\"metric\",\"params\":{\"field\":\"rabbitmq.node.mem.used.bytes\",\"json\":\"\",\"customLabel\":\"Used memory\"}},{\"id\":\"3\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"custom\",\"customInterval\":\"30s\",\"min_doc_count\":1,\"extended_bounds\":{}}},{\"id\":\"4\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"group\",\"params\":{\"field\":\"rabbitmq.node.name.keyword\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"Node name\"}}],\"listeners\":{}}",
+  "uiStateJSON": "{}",
+  "description": "",
+  "savedSearchId": "Metricbeat-Rabbitmq",
+  "version": 1,
+  "kibanaSavedObjectMeta": {
+    "searchSourceJSON": "{\"filter\":[]}"
+  }
+}

--- a/metricbeat/module/rabbitmq/_meta/kibana/5.x/visualization/Rabbitmq-Number-of-Nodes.json
+++ b/metricbeat/module/rabbitmq/_meta/kibana/5.x/visualization/Rabbitmq-Number-of-Nodes.json
@@ -1,0 +1,11 @@
+{
+  "title": "RabbitMQ Number of Nodes",
+  "visState": "{\n  \"title\": \"Rabbitmq-Number-of-Nodes\",\n  \"type\": \"metric\",\n  \"params\": {\n    \"handleNoResults\": true,\n    \"fontSize\": 60\n  },\n  \"aggs\": [\n    {\n      \"id\": \"1\",\n      \"enabled\": true,\n      \"type\": \"cardinality\",\n      \"schema\": \"metric\",\n      \"params\": {\n        \"field\": \"rabbitmq.node.name.keyword\",\n        \"customLabel\": \"RabbitMQ Nodes\"\n      }\n    }\n  ],\n  \"listeners\": {}\n}",
+  "uiStateJSON": "{}",
+  "description": "",
+  "savedSearchId": "Metricbeat-Rabbitmq",
+  "version": 1,
+  "kibanaSavedObjectMeta": {
+    "searchSourceJSON": "{\n  \"filter\": []\n}"
+  }
+}

--- a/metricbeat/module/rabbitmq/_meta/kibana/5.x/visualization/Rabbitmq-Queue-Index-Operations.json
+++ b/metricbeat/module/rabbitmq/_meta/kibana/5.x/visualization/Rabbitmq-Queue-Index-Operations.json
@@ -1,0 +1,11 @@
+{
+  "title": "RabbitMQ Queue Index Operations",
+  "visState": "{\"title\":\"RabbitMQ Queue Index Operations\",\"type\":\"line\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"top\",\"showCircles\":false,\"smoothLines\":false,\"interpolate\":\"linear\",\"scale\":\"linear\",\"drawLinesBetweenPoints\":true,\"radiusRatio\":9,\"times\":[],\"addTimeMarker\":false,\"defaultYExtents\":false,\"setYExtents\":false,\"yAxis\":{}},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"max\",\"schema\":\"metric\",\"params\":{\"field\":\"rabbitmq.node.queue.index.read.count\",\"customLabel\":\"Queue Index Read\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"custom\",\"customInterval\":\"30s\",\"min_doc_count\":1,\"extended_bounds\":{}}},{\"id\":\"3\",\"enabled\":true,\"type\":\"max\",\"schema\":\"metric\",\"params\":{\"field\":\"rabbitmq.node.queue.index.journal_write.count\",\"customLabel\":\"Queue Index Jornal Write\"}},{\"id\":\"4\",\"enabled\":true,\"type\":\"max\",\"schema\":\"metric\",\"params\":{\"field\":\"rabbitmq.node.queue.index.write.count\",\"customLabel\":\"Queue Index Write\"}}],\"listeners\":{}}",
+  "uiStateJSON": "{}",
+  "description": "",
+  "savedSearchId": "Metricbeat-Rabbitmq",
+  "version": 1,
+  "kibanaSavedObjectMeta": {
+    "searchSourceJSON": "{\"filter\":[]}"
+  }
+}

--- a/metricbeat/module/rabbitmq/_meta/kibana/default/dashboard/Metricbeat-Rabbitmq.json
+++ b/metricbeat/module/rabbitmq/_meta/kibana/default/dashboard/Metricbeat-Rabbitmq.json
@@ -1,0 +1,107 @@
+{
+  "objects": [
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\"filter\":[]}"
+        },
+        "savedSearchId": "Metricbeat-Rabbitmq",
+        "title": "RabbitMQ Memory Usage",
+        "uiStateJSON": "{}",
+        "version": 1,
+        "visState": "{\"title\":\"RabbitMQ Memory Usage\",\"type\":\"line\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"top\",\"showCircles\":false,\"smoothLines\":true,\"interpolate\":\"linear\",\"scale\":\"linear\",\"drawLinesBetweenPoints\":true,\"radiusRatio\":9,\"times\":[],\"addTimeMarker\":false,\"defaultYExtents\":true,\"setYExtents\":false,\"yAxis\":{}},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"max\",\"schema\":\"metric\",\"params\":{\"field\":\"rabbitmq.node.mem.used.bytes\",\"json\":\"\",\"customLabel\":\"Used memory\"}},{\"id\":\"3\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"custom\",\"customInterval\":\"30s\",\"min_doc_count\":1,\"extended_bounds\":{}}},{\"id\":\"4\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"group\",\"params\":{\"field\":\"rabbitmq.node.name.keyword\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"Node name\"}}],\"listeners\":{}}"
+      },
+      "col": 1,
+      "id": "RabbitMQ-Memory-Usage",
+      "panelIndex": 8,
+      "row": 1,
+      "size_x": 6,
+      "size_y": 3,
+      "type": "visualization",
+      "version": 9
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\n  \"filter\": []\n}"
+        },
+        "savedSearchId": "Metricbeat-Rabbitmq",
+        "title": "RabbitMQ Number of Nodes",
+        "uiStateJSON": "{}",
+        "version": 1,
+        "visState": "{\n  \"title\": \"Rabbitmq-Number-of-Nodes\",\n  \"type\": \"metric\",\n  \"params\": {\n    \"handleNoResults\": true,\n    \"fontSize\": 60\n  },\n  \"aggs\": [\n    {\n      \"id\": \"1\",\n      \"enabled\": true,\n      \"type\": \"cardinality\",\n      \"schema\": \"metric\",\n      \"params\": {\n        \"field\": \"rabbitmq.node.name.keyword\",\n        \"customLabel\": \"RabbitMQ Nodes\"\n      }\n    }\n  ],\n  \"listeners\": {}\n}"
+      },
+      "col": 8,
+      "id": "Rabbitmq-Number-of-Nodes",
+      "panelIndex": 2,
+      "row": 1,
+      "size_x": 3,
+      "size_y": 3,
+      "type": "visualization",
+      "version": 7
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\"filter\":[]}"
+        },
+        "savedSearchId": "Metricbeat-Rabbitmq",
+        "title": "RabbitMQ Erlang Process Usage",
+        "uiStateJSON": "{}",
+        "version": 1,
+        "visState": "{\"title\":\"RabbitMQ Erlang Process Usage\",\"type\":\"line\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"setYExtents\":false,\"shareYAxis\":true,\"showCircles\":false,\"smoothLines\":true,\"times\":[],\"yAxis\":{}},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"max\",\"schema\":\"metric\",\"params\":{\"field\":\"rabbitmq.node.proc.used\",\"customLabel\":\"Used Process\"}},{\"id\":\"3\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"custom\",\"customInterval\":\"30s\",\"min_doc_count\":1,\"extended_bounds\":{}}},{\"id\":\"4\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"group\",\"params\":{\"field\":\"rabbitmq.node.name.keyword\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"Node name\"}}],\"listeners\":{}}"
+      },
+      "col": 1,
+      "id": "RabbitMQ-Erlang-Process-Usage",
+      "panelIndex": 10,
+      "row": 4,
+      "size_x": 6,
+      "size_y": 3,
+      "type": "visualization",
+      "version": 6
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\"filter\":[]}"
+        },
+        "savedSearchId": "Metricbeat-Rabbitmq",
+        "title": "RabbitMQ Queue Index Operations",
+        "uiStateJSON": "{}",
+        "version": 1,
+        "visState": "{\"title\":\"RabbitMQ Queue Index Operations\",\"type\":\"line\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"top\",\"showCircles\":false,\"smoothLines\":false,\"interpolate\":\"linear\",\"scale\":\"linear\",\"drawLinesBetweenPoints\":true,\"radiusRatio\":9,\"times\":[],\"addTimeMarker\":false,\"defaultYExtents\":false,\"setYExtents\":false,\"yAxis\":{}},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"max\",\"schema\":\"metric\",\"params\":{\"field\":\"rabbitmq.node.queue.index.read.count\",\"customLabel\":\"Queue Index Read\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"custom\",\"customInterval\":\"30s\",\"min_doc_count\":1,\"extended_bounds\":{}}},{\"id\":\"3\",\"enabled\":true,\"type\":\"max\",\"schema\":\"metric\",\"params\":{\"field\":\"rabbitmq.node.queue.index.journal_write.count\",\"customLabel\":\"Queue Index Jornal Write\"}},{\"id\":\"4\",\"enabled\":true,\"type\":\"max\",\"schema\":\"metric\",\"params\":{\"field\":\"rabbitmq.node.queue.index.write.count\",\"customLabel\":\"Queue Index Write\"}}],\"listeners\":{}}"
+      },
+      "col": 7,
+      "id": "RabbitMQ-Queue-Index-Operations",
+      "panelIndex": 9,
+      "row": 4,
+      "size_x": 6,
+      "size_y": 3,
+      "type": "visualization",
+      "version": 5
+    },
+    {
+      "attributes": {
+        "description": "",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\"index\":\"metricbeat-*\",\"filter\":[],\"highlight\":{\"pre_tags\":[\"@kibana-highlighted-field@\"],\"post_tags\":[\"@/kibana-highlighted-field@\"],\"fields\":{\"*\":{}},\"require_field_match\":false,\"fragment_size\":2147483647},\"query\":{\"query_string\":{\"query\":\"metricset.module:rabbitmq\",\"analyze_wildcard\":true}}}"
+        },
+        "sort": [
+          "@timestamp",
+          "desc"
+        ],
+        "title": "Metricbeat-Rabbitmq",
+        "version": 1
+      },
+      "id": "Metricbeat-Rabbitmq",
+      "type": "search",
+      "version": 26
+    }
+  ],
+  "version": "5.6.0-SNAPSHOT"
+}


### PR DESCRIPTION
Cherry-pick of PR #4912 to 6.0 branch. Original message: 

Take over this PR:https://github.com/elastic/beats/pull/4497 where a dashboard for RabbitMQ is added.