### PR TITLE
Cherry-pick #4956 to 6.0: Adapt packetbeat tcp protocol generator to new publisher pipeline

### DIFF
--- a/packetbeat/scripts/tcp-protocol/{protocol}/pub.go.tmpl
+++ b/packetbeat/scripts/tcp-protocol/{protocol}/pub.go.tmpl
@@ -1,8 +1,10 @@
 package {protocol}
 
 import (
+	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/packetbeat/publish"
+
+	"github.com/elastic/beats/packetbeat/protos"
 )
 
 // Transaction Publisher.
@@ -10,7 +12,7 @@ type transPub struct {
 	sendRequest        bool
 	sendResponse       bool
 
-	results publish.Transactions
+	results protos.Reporter
 }
 
 func (pub *transPub) onTransaction(requ, resp *message) error {
@@ -18,12 +20,11 @@ func (pub *transPub) onTransaction(requ, resp *message) error {
 		return nil
 	}
 
-	event := pub.createEvent(requ, resp)
-	pub.results.PublishTransaction(event)
+	pub.results(pub.createEvent(requ, resp))
 	return nil
 }
 
-func (pub *transPub) createEvent(requ, resp *message) common.MapStr {
+func (pub *transPub) createEvent(requ, resp *message) beat.Event {
 	status := common.OK_STATUS
 
 	// resp_time in milliseconds
@@ -40,8 +41,7 @@ func (pub *transPub) createEvent(requ, resp *message) common.MapStr {
 		Proc: string(requ.CmdlineTuple.Dst),
 	}
 
-	event := common.MapStr{
-		"@timestamp":   common.Time(requ.Ts),
+	fields := common.MapStr{
 		"type":         "{protocol}",
 		"status":       status,
 		"responsetime": responseTime,
@@ -53,15 +53,18 @@ func (pub *transPub) createEvent(requ, resp *message) common.MapStr {
 
 	// add processing notes/errors to event
 	if len(requ.Notes)+len(resp.Notes) > 0 {
-		event["notes"] = append(requ.Notes, resp.Notes...)
+		fields["notes"] = append(requ.Notes, resp.Notes...)
 	}
 
 	if pub.sendRequest {
-		// event["request"] =
+		// fields["request"] =
 	}
 	if pub.sendResponse {
-		// event["response"] =
+		// fields["response"] =
 	}
 
-	return event
+	return beat.Event{
+		Timestamp: requ.Ts,
+		Fields: fields,
+	}
 }

--- a/packetbeat/scripts/tcp-protocol/{protocol}/{protocol}.go.tmpl
+++ b/packetbeat/scripts/tcp-protocol/{protocol}/{protocol}.go.tmpl
@@ -8,7 +8,6 @@ import (
 
 	"github.com/elastic/beats/packetbeat/protos"
 	"github.com/elastic/beats/packetbeat/protos/tcp"
-	"github.com/elastic/beats/packetbeat/publish"
 )
 
 // {plugin_type} application level protocol analyzer plugin
@@ -45,7 +44,7 @@ func init() {
 // New create and initializes a new {protocol} protocol analyzer instance.
 func New(
 	testMode bool,
-	results publish.Transactions,
+	results protos.Reporter,
 	cfg *common.Config,
 ) (protos.Plugin, error) {
 	p := &{plugin_type}{}
@@ -62,7 +61,7 @@ func New(
 	return p, nil
 }
 
-func ({plugin_var} *{plugin_type}) init(results publish.Transactions, config *{protocol}Config) error {
+func ({plugin_var} *{plugin_type}) init(results protos.Reporter, config *{protocol}Config) error {
 	if err := {plugin_var}.setFromConfig(config); err != nil {
 		return err
 	}


### PR DESCRIPTION
Cherry-pick of PR #4956 to 6.0 branch. Original message: 

- Update to the tcp protocol generator to work with changes to the publisher pipeline in beats
- minor fixes in readme