### PR TITLE
add_kubernetes_metadata processor: add support for "/var/log/containers/" log path (version 3)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -85,6 +85,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta1...master[Check the HEAD di
 
 - Add PostgreSQL module with slowlog support. {pull}4763[4763]
 - Add Kafka log module. {pull}4885[4885]
+- Add support for `/var/log/containers/` log path in `add_kubernetes_metadata` processor. {pull}5011[5011]
 
 *Heartbeat*
 

--- a/filebeat/processor/add_kubernetes_metadata/indexing.go
+++ b/filebeat/processor/add_kubernetes_metadata/indexing.go
@@ -46,20 +46,44 @@ func newLogsPathMatcher(cfg common.Config) (add_kubernetes_metadata.Matcher, err
 	return &LogPathMatcher{LogsPath: logPath}, nil
 }
 
+// Docker container ID is a 64-character-long hexadecimal string
+const containerIdLen = 64
+
+// Minimum `source` lengths are calculated in order to prevent "slice bound out of range"
+// runtime errors in case `source` is shorter than expected.
+const kubernetesLogPath = "/var/log/containers/"
+const kubernetesMinSourceLen = len(kubernetesLogPath) + containerIdLen + 4
+
+const dockerLogPath = "/var/lib/docker/containers/"
+const dockerLogPathLen = len(dockerLogPath)
+const dockerMinSourceLen = dockerLogPathLen + containerIdLen
+
 func (f *LogPathMatcher) MetadataIndex(event common.MapStr) string {
 	if value, ok := event["source"]; ok {
 		source := value.(string)
-		logp.Debug("kubernetes", "Incoming source value: ", source)
-		cid := ""
-		if strings.Contains(source, f.LogsPath) {
-			//Docker container is 64 chars in length
-			cid = source[len(f.LogsPath) : len(f.LogsPath)+64]
-		}
-		logp.Debug("kubernetes", "Using container id: ", cid)
+		logp.Debug("kubernetes", "Incoming source value: %s", source)
 
-		if cid != "" {
-			return cid
+		sourceLen := len(source)
+
+		// Variant 1: Kubernetes log path "/var/log/containers/...-${cid}.log"
+		if strings.HasPrefix(source, kubernetesLogPath) &&
+		   strings.HasSuffix(source, ".log") &&
+		   sourceLen >= kubernetesMinSourceLen {
+			containerIdEnd := sourceLen - 4
+			cid := source[containerIdEnd - containerIdLen : containerIdEnd]
+			logp.Debug("kubernetes", "Using container id: %s", cid)
+			return cid;
 		}
+
+		// Variant 2: Docker log path "/var/lib/docker/containers/${cid}/${cid}-json.log"
+		if strings.HasPrefix(source, dockerLogPath) &&
+		   sourceLen >= dockerMinSourceLen {
+			cid := source[dockerLogPathLen : dockerLogPathLen + containerIdLen]
+			logp.Debug("kubernetes", "Using container id: %s", cid)
+			return cid;
+		}
+
+		logp.Debug("kubernetes", "No container id found in source.")
 	}
 
 	return ""

--- a/filebeat/processor/add_kubernetes_metadata/indexing_test.go
+++ b/filebeat/processor/add_kubernetes_metadata/indexing_test.go
@@ -9,24 +9,47 @@ import (
 	"github.com/elastic/beats/libbeat/common"
 )
 
-func TestLogsPathMatcher(t *testing.T) {
-	var testConfig = common.NewConfig()
+// A random container ID that we use for our tests
+const cid = "0069869de9adf97f574c62029aeba65d1ecd85a2a112e87fbc28afe4dec2b843"
 
+func TestLogsPathMatcher_InvalidSource1(t *testing.T) {
+	source := "/var/log/messages"
+	expectedResult := ""
+	executeTest(t, source, expectedResult);
+}
+
+func TestLogsPathMatcher_InvalidSource2(t *testing.T) {
+	source := "/var/lib/docker/containers/01234567/89abcdef-json.log"
+	expectedResult := ""
+	executeTest(t, source, expectedResult);
+}
+
+func TestLogsPathMatcher_InvalidSource3(t *testing.T) {
+	source := "/var/log/containers/pod_ns_container_01234567.log"
+	expectedResult := ""
+	executeTest(t, source, expectedResult);
+}
+
+func TestLogsPathMatcher_VarLibDockerContainers(t *testing.T) {
+	source := fmt.Sprintf("/var/lib/docker/containers/%s/%s-json.log", cid, cid)
+	expectedResult := cid;
+	executeTest(t, source, expectedResult);
+}
+
+func TestLogsPathMatcher_VarLogContainers(t *testing.T) {
+	source := fmt.Sprintf("/var/log/containers/kube-proxy-4d7nt_kube-system_kube-proxy-%s.log", cid)
+	expectedResult := cid;
+	executeTest(t, source, expectedResult);
+}
+
+func executeTest(t *testing.T, source string, expectedResult string) {
+	var testConfig = common.NewConfig()
 	logMatcher, err := newLogsPathMatcher(*testConfig)
 	assert.Nil(t, err)
 
-	cid := "0069869de9adf97f574c62029aeba65d1ecd85a2a112e87fbc28afe4dec2b843"
-	logPath := fmt.Sprintf("/var/lib/docker/containers/%s/%s-json.log", cid, cid)
-
 	input := common.MapStr{
-		"source": "/var/log/messages",
+		"source": source,
 	}
-
 	output := logMatcher.MetadataIndex(input)
-	assert.Equal(t, output, "")
-
-	input["source"] = logPath
-	output = logMatcher.MetadataIndex(input)
-
-	assert.Equal(t, output, cid)
+	assert.Equal(t, output, expectedResult)
 }


### PR DESCRIPTION
Following up on this topic:
https://discuss.elastic.co/t/add-kubernetes-metadata-should-work-in-var-log-containers/97945
and on my previous pull requests https://github.com/elastic/beats/pull/4981 and https://github.com/elastic/beats/pull/4995.

This is the third implementation, more details below in "About the Pull Request".

# The Issue

The “add_kubernetes_metadata” processor should also work on the "/var/log/containers/" log path for the following reasons:

1. You may want to exclude log files from certain pods, e.g. the filebeat pod itself with the `exclude_files: ['filebeat-*.log']` option. That would work only in `/var/log/containers`, as only the symlinks there contain the pod name.

2. You may want to read only the log files of docker containers used by active Kubernetes pods, not any other docker containers running on the system now or in the past. That also works only by following the symlinks in `/var/log/containers`.

3. The “source” field in the log documents would be much more informative if it contained a value like `/var/log/containers/kube-proxy-4d7nt_kube-system_kube-proxy-1bddb0001161285462528b7170a53d13dfe4e17b541319485b9020eef5433266.log` 
instead of
`/var/lib/docker/containers/1bddb0001161285462528b7170a53d13dfe4e17b541319485b9020eef5433266/1bddb0001161285462528b7170a53d13dfe4e17b541319485b9020eef5433266-json.log`

# About the Pull Request

This solution
* solves the issue with basic string operations;
* doesn't require the redundant `logs_path` configuration in the processor as in https://github.com/elastic/beats/pull/4981;
* performs better than https://github.com/elastic/beats/pull/4995 as it doesn't use regular expressions;
* also covers most cases,
* and prevents "slice bound out of range" runtime errors that could happen in the original implementation if `source` was too short.

The unit tests are exactly the same as in https://github.com/elastic/beats/pull/4995, except that the generic test case was removed as this solution doesn't have a generic fallback anymore.