### PR TITLE
Cherry-pick #4949 to 6.0: Change index name in the dashboards and index-pattern 

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -73,6 +73,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta1...master[Check the HEAD di
 - Added `cloud.id` and `cloud.auth` settings, for simplifying using Beats with the Elastic Cloud. {issue}4959[4959]
 - Add lz4 compression support to kafka output. {pull}4977[4977]
 - Add newer kafka versions to kafka output. {pull}4977[4977]
+- Configure the index name when loading the dashboards and the index pattern. {pull}4949[4949]
 
 *Auditbeat*
 

--- a/libbeat/dashboards/modify_json.go
+++ b/libbeat/dashboards/modify_json.go
@@ -1,0 +1,105 @@
+package dashboards
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/logp"
+)
+
+type JSONObjectAttribute struct {
+	Description           string                 `json:"description"`
+	KibanaSavedObjectMeta map[string]interface{} `json:"kibanaSavedObjectMeta"`
+	Title                 string                 `json:"title"`
+	Type                  string                 `json:"type"`
+}
+
+type JSONObject struct {
+	Attributes JSONObjectAttribute `json:"attributes"`
+}
+
+type JSONFormat struct {
+	Objects []JSONObject `json:"objects"`
+}
+
+func ReplaceIndexInIndexPattern(index string, content common.MapStr) common.MapStr {
+
+	if index != "" {
+		// change index pattern name
+		if objects, ok := content["objects"].([]interface{}); ok {
+			for i, object := range objects {
+				if objectMap, ok := object.(map[string]interface{}); ok {
+					objectMap["id"] = index
+
+					if attributes, ok := objectMap["attributes"].(map[string]interface{}); ok {
+						attributes["title"] = index
+						objectMap["attributes"] = attributes
+					}
+					objects[i] = objectMap
+				}
+			}
+			content["objects"] = objects
+		}
+	}
+
+	return content
+}
+
+func replaceIndexInSearchObject(index string, savedObject string) (string, error) {
+
+	var record common.MapStr
+	err := json.Unmarshal([]byte(savedObject), &record)
+	if err != nil {
+		return "", fmt.Errorf("fail to unmarshal searchSourceJSON from search : %v", err)
+	}
+
+	if _, ok := record["index"]; ok {
+		record["index"] = index
+	}
+	searchSourceJSON, err := json.Marshal(record)
+	if err != nil {
+		return "", fmt.Errorf("fail to marshal searchSourceJSON: %v", err)
+	}
+
+	return string(searchSourceJSON), nil
+}
+
+func ReplaceIndexInSavedObject(index string, kibanaSavedObject map[string]interface{}) map[string]interface{} {
+
+	if searchSourceJSON, ok := kibanaSavedObject["searchSourceJSON"].(string); ok {
+		searchSourceJSON, err := replaceIndexInSearchObject(index, searchSourceJSON)
+		if err != nil {
+			logp.Err("Fail to replace searchSourceJSON: %v", err)
+			return kibanaSavedObject
+		}
+		kibanaSavedObject["searchSourceJSON"] = searchSourceJSON
+	}
+
+	return kibanaSavedObject
+}
+
+func ReplaceIndexInDashboardObject(index string, content common.MapStr) common.MapStr {
+
+	if index == "" {
+		return content
+	}
+	if objects, ok := content["objects"].([]interface{}); ok {
+		for i, object := range objects {
+			if objectMap, ok := object.(map[string]interface{}); ok {
+				if attributes, ok := objectMap["attributes"].(map[string]interface{}); ok {
+
+					if kibanaSavedObject, ok := attributes["kibanaSavedObjectMeta"].(map[string]interface{}); ok {
+
+						attributes["kibanaSavedObjectMeta"] = ReplaceIndexInSavedObject(index, kibanaSavedObject)
+					}
+
+					objectMap["attributes"] = attributes
+				}
+				objects[i] = objectMap
+			}
+		}
+		content["objects"] = objects
+	}
+	return content
+}

--- a/libbeat/setup/kibana/client.go
+++ b/libbeat/setup/kibana/client.go
@@ -196,8 +196,15 @@ func (client *Client) SetVersion() error {
 
 func (client *Client) GetVersion() string { return client.version }
 
-func (client *Client) ImportJSON(url string, params url.Values, body io.Reader) error {
-	statusCode, response, err := client.Connection.Request("POST", url, params, body)
+func (client *Client) ImportJSON(url string, params url.Values, jsonBody map[string]interface{}) error {
+
+	body, err := json.Marshal(jsonBody)
+	if err != nil {
+		logp.Err("Failed to json encode body (%v): %#v", err, jsonBody)
+		return fmt.Errorf("fail to marshal the json content: %v", err)
+	}
+
+	statusCode, response, err := client.Connection.Request("POST", url, params, bytes.NewBuffer(body))
 	if err != nil {
 		return fmt.Errorf("%v. Response: %s", err, truncateString(response))
 	}


### PR DESCRIPTION
Cherry-pick of PR #4949 to 6.0 branch. Original message: 

When loading the dashboards and the index-pattern, you can configure the name of the index under `setup.dashboards.index`:

```
$ ./metricbeat setup -E setup.dashboards.directory=_meta/kibana -E setup.dashboards.index=testbeat-* -e 
```
This replaces the index name from the index-pattern and all the dashboards.

This change is done for loading the 5.x and 6.x dashboards.

**Note** This doesn't work for dashboards containing the Timelion visualizations. 

cc-ed @ruflin 