### PR TITLE
[WIP] Add command `filebeat test multiline`

### DIFF
--- a/filebeat/cmd/multiline/config.go
+++ b/filebeat/cmd/multiline/config.go
@@ -1,0 +1,125 @@
+package multiline
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/elastic/beats/filebeat/harvester/reader"
+	"github.com/elastic/beats/libbeat/cfgfile"
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/match"
+)
+
+type prospectorConfig struct {
+	Encoding  string                 `config:"encoding"`
+	MaxBytes  int                    `config:"max_bytes" validate:"min=0,nonzero"`
+	Multiline reader.MultilineConfig `config:"multiline"`
+}
+
+// flags
+var (
+	negate       bool
+	pattern      string
+	matchType    string
+	maxLines     int
+	maxBytes     int
+	flushPattern string
+	codec        string
+
+	prospectorID int
+)
+
+func addFlags(cmd *cobra.Command) {
+	fs := cmd.PersistentFlags()
+	fs.BoolVarP(&negate, "negate", "n", false, "Negate the pattern matching")
+	fs.StringVarP(&pattern, "pattern", "p", "", "Multiline regex pattern")
+	fs.StringVarP(&matchType, "match", "m", "after", "Multiline match type (before/after)")
+	fs.IntVarP(&maxLines, "lines", "l", 0, "Maximum number of lines per event")
+	fs.IntVar(&maxBytes, "max_bytes", 0, "Maximum bytes per event")
+	fs.StringVar(&flushPattern, "flush", "", "Multiline flush pattern")
+	fs.StringVar(&codec, "encoding", "", "File encoding")
+	fs.IntVarP(&prospectorID, "idx", "i", 0, "Select prospector from filebeat config")
+}
+
+func loadConfig() (*prospectorConfig, error) {
+	if checkConfigFileSet() {
+		loadConfigFromFile()
+	}
+
+	config := &prospectorConfig{}
+	config.Encoding = codec
+	config.MaxBytes = maxBytes
+	config.Multiline.Negate = negate
+	config.Multiline.Match = matchType
+
+	if maxLines > 0 {
+		config.Multiline.MaxLines = &maxLines
+	}
+
+	if pattern == "" {
+		return nil, errors.New("pattern is required")
+	}
+	tmp, err := match.Compile(pattern)
+	if err != nil {
+		return nil, fmt.Errorf("compiling pattern failed with %v", err)
+	}
+	config.Multiline.Pattern = &tmp
+
+	if flushPattern != "" {
+		tmp, err := match.Compile(flushPattern)
+		if err != nil {
+			return nil, fmt.Errorf("compiling flush pattern failed with %v", err)
+		}
+		config.Multiline.FlushPattern = &tmp
+	}
+
+	return config, nil
+}
+
+func loadConfigFromFile() (*prospectorConfig, error) {
+	// load config file
+
+	cfg, err := cfgfile.Load("")
+	if err != nil {
+		return nil, err
+	}
+
+	var prospectors = struct {
+		List []*common.Config `config:"filebeat.prospectors"`
+	}{}
+	if err := cfg.Unpack(&prospectors); err != nil {
+		return nil, err
+	}
+
+	if prospectorID < 0 {
+		return nil, fmt.Errorf("prospector id %v is invalid", prospectorID)
+	}
+	if L := prospectors.List; prospectorID >= len(L) {
+		return nil, fmt.Errorf("prospector list of length %v is less then index %v", L, prospectorID)
+	}
+
+	cfg = prospectors.List[prospectorID]
+	prospector := prospectorConfig{}
+	if err := cfg.Unpack(&prospector); err != nil {
+		return nil, err
+	}
+
+	return &prospector, nil
+}
+
+func checkConfigFileSet() bool {
+	f := flag.Lookup("c")
+	if f == nil {
+		return false
+	}
+
+	type tester interface {
+		IsSet() bool
+	}
+
+	t, ok := f.Value.(tester)
+	return ok && t.IsSet()
+}

--- a/filebeat/cmd/multiline/multiline.go
+++ b/filebeat/cmd/multiline/multiline.go
@@ -1,0 +1,58 @@
+package multiline
+
+import (
+	"fmt"
+	"io"
+	"log"
+
+	"github.com/spf13/cobra"
+)
+
+var Command *cobra.Command
+
+const name = "multiline"
+
+func init() {
+	Command = &cobra.Command{
+		Use:   name,
+		Short: "Multiline tester",
+		Run: func(_ *cobra.Command, args []string) {
+			err := run(args)
+			if err != nil {
+				log.Fatal(err)
+			}
+		},
+	}
+
+	addFlags(Command)
+}
+
+func run(args []string) error {
+	config, err := loadConfig()
+	if err != nil {
+		return err
+	}
+
+	in, err := createReader(args)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	reader, err := createPipeline(config, in)
+	if err != nil {
+		return fmt.Errorf("creating reader pipeline failed: %v", err)
+	}
+
+	for {
+		msg, err := reader.Next()
+		if err != nil {
+			if err == io.EOF {
+				return nil
+			}
+			return err
+		}
+
+		fmt.Printf("%s\n", msg.Content)
+	}
+}

--- a/filebeat/cmd/multiline/reader.go
+++ b/filebeat/cmd/multiline/reader.go
@@ -1,0 +1,108 @@
+package multiline
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+
+	"github.com/elastic/beats/filebeat/harvester/encoding"
+	"github.com/elastic/beats/filebeat/harvester/reader"
+)
+
+type concatReader struct {
+	current io.ReadCloser
+	idx     int
+	paths   []string
+}
+
+func createReader(paths []string) (io.ReadCloser, error) {
+	switch len(paths) {
+	case 0:
+		return ioutil.NopCloser(os.Stdin), nil
+	case 1:
+		return os.Open(paths[0])
+	}
+	return newConcatReader(paths)
+}
+
+func createPipeline(config *prospectorConfig, in io.Reader) (reader.Reader, error) {
+	var (
+		r   reader.Reader
+		err error
+	)
+
+	ef, ok := encoding.FindEncoding(config.Encoding)
+	if !ok || ef == nil {
+		return nil, fmt.Errorf("unknown encoding('%v')", config.Encoding)
+	}
+
+	enc, err := ef(in)
+	if err != nil {
+		return nil, err
+	}
+
+	r, err = reader.NewEncode(in, enc, 8*1024)
+	if err != nil {
+		return nil, err
+	}
+
+	r = reader.NewStripNewline(r)
+
+	r, err = reader.NewMultiline(r, "\n", config.MaxBytes, &config.Multiline)
+	if err != nil {
+		return nil, err
+	}
+
+	return reader.NewLimit(r, config.MaxBytes), nil
+}
+
+func newConcatReader(paths []string) (*concatReader, error) {
+	init, err := os.Open(paths[0])
+	if err != nil {
+		return nil, err
+	}
+
+	return &concatReader{
+		current: init,
+		idx:     0,
+		paths:   paths,
+	}, nil
+}
+
+func (r *concatReader) Close() (err error) {
+	if r.current != nil {
+		err = r.current.Close()
+		r.current = nil
+	}
+	return
+}
+
+func (r *concatReader) Read(b []byte) (int, error) {
+	N := 0
+	for len(b) > 0 {
+		n, err := r.current.Read(b)
+		N += n
+		if err == nil || err != io.EOF {
+			return N, nil
+		}
+
+		b = b[n:]
+
+		// close old file
+		r.current.Close()
+		r.current = nil
+
+		// advance to next file
+		r.idx++
+		if r.idx >= len(r.paths) {
+			return n, io.EOF
+		}
+		next, err := os.Open(r.paths[r.idx])
+		if err != nil {
+			return n, err
+		}
+		r.current = next
+	}
+	return N, nil
+}

--- a/filebeat/cmd/root.go
+++ b/filebeat/cmd/root.go
@@ -5,9 +5,10 @@ import (
 
 	"github.com/spf13/pflag"
 
-	"github.com/elastic/beats/filebeat/beater"
-
 	cmd "github.com/elastic/beats/libbeat/cmd"
+
+	"github.com/elastic/beats/filebeat/beater"
+	"github.com/elastic/beats/filebeat/cmd/multiline"
 )
 
 // Name of this beat
@@ -24,6 +25,7 @@ func init() {
 	RootCmd = cmd.GenRootCmdWithRunFlags(Name, "", beater.New, runFlags)
 	RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("M"))
 	RootCmd.TestCmd.Flags().AddGoFlag(flag.CommandLine.Lookup("modules"))
+	RootCmd.TestCmd.AddCommand(multiline.Command)
 	RootCmd.SetupCmd.Flags().AddGoFlag(flag.CommandLine.Lookup("modules"))
 	RootCmd.AddCommand(cmd.GenModulesCmd(Name, "", buildModulesManager))
 }

--- a/libbeat/cfgfile/flags.go
+++ b/libbeat/cfgfile/flags.go
@@ -53,6 +53,10 @@ func (l *argList) Set(v string) error {
 	return nil
 }
 
+func (l *argList) IsSet() bool {
+	return l.isDefault == false
+}
+
 func (l *argList) Get() interface{} {
 	return l.list
 }


### PR DESCRIPTION
Add new command `filebeat test multiline` to filebeat. The multiline configuration can be read from one prospector, or completely set via command line (TODO: allow command line to overwrite setting in config).

The multiline tester only writes the contents read to stdout. The single events are separated by newlines.

Note: I started to add more parameters to the tester and realized the logs prospector already has a quite rich set of input processing settings. Moving the tester code to the prospector types themselves might give us support for more settings, without having to duplicate that much code. I only worry about the command line usage. E.g. `filebeat test prospector <prospector type> ...`. Plus how extensive is a test supposed to be? E.g. the log prospector might check files are available + permissions are correct, or just test the reader pipeline (user has to specify files). This might result in commands like `filebeat test prospector log permissions`, `filebeat test prospector log multiline ...`, ...