### PR TITLE
Fix make index-template command

### DIFF
--- a/dev-tools/cmd/index_template/index_template.go
+++ b/dev-tools/cmd/index_template/index_template.go
@@ -40,7 +40,7 @@ func main() {
 		*version = "2.0.0"
 	}
 
-	tmpl, err := template.New(beatVersion, *version, *index, template.TemplateSettings{})
+	tmpl, err := template.New(beatVersion, *index, *version, template.TemplateConfig{})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error generating template: %+v", err)
 		os.Exit(1)


### PR DESCRIPTION
Implementation of the index template generation changed slightly in a recent PR, but the generation command was not updated accordingly.