### PR TITLE
Reduce perfmon memory allocations

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -60,6 +60,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta1...master[Check the HEAD di
 - Added missing mongodb configuration file to the `modules.d` folder. {pull}4870[4870]
 - Fix wrong MySQL CRUD queries timelion visualization {pull}4857[4857]
 - Add new metrics to CPU metricsset {pull}4969[4969]
+- Fix a memory allocation issue where more memory was allocated than needed in the windows-perfmon metricset. {issue}5035[5035]
 
 *Packetbeat*
 

--- a/metricbeat/module/windows/perfmon/defs_pdh_windows.go
+++ b/metricbeat/module/windows/perfmon/defs_pdh_windows.go
@@ -219,10 +219,6 @@ const (
 // PdhCounterValue is the structure that receives the counter value.
 type PdhCounterValue C.PDH_FMT_COUNTERVALUE
 
-type PdhCounterValueItem C.PDH_FMT_COUNTERVALUE_ITEM
-
-type PdhRawCounterItem C.PDH_RAW_COUNTER_ITEM
-
 // PdhRawCounter is the structure that receives the raw counter.
 type PdhRawCounter C.PDH_RAW_COUNTER
 

--- a/metricbeat/module/windows/perfmon/defs_pdh_windows_386.go
+++ b/metricbeat/module/windows/perfmon/defs_pdh_windows_386.go
@@ -206,16 +206,6 @@ type PdhCounterValue struct {
 	Pad_cgo_1 [4]byte
 }
 
-type PdhCounterValueItem struct {
-	SzName   *int8
-	FmtValue PdhCounterValue
-}
-
-type PdhRawCounterItem struct {
-	SzName   *int8
-	RawValue PdhRawCounter
-}
-
 type PdhRawCounter struct {
 	CStatus     uint32
 	TimeStamp   PdhFileTime

--- a/metricbeat/module/windows/perfmon/defs_pdh_windows_amd64.go
+++ b/metricbeat/module/windows/perfmon/defs_pdh_windows_amd64.go
@@ -206,16 +206,6 @@ type PdhCounterValue struct {
 	Pad_cgo_1 [4]byte
 }
 
-type PdhCounterValueItem struct {
-	SzName   *int8
-	FmtValue PdhCounterValue
-}
-
-type PdhRawCounterItem struct {
-	SzName   *int8
-	RawValue PdhRawCounter
-}
-
 type PdhRawCounter struct {
 	CStatus     uint32
 	TimeStamp   PdhFileTime

--- a/metricbeat/module/windows/perfmon/mkpdh_defs.go
+++ b/metricbeat/module/windows/perfmon/mkpdh_defs.go
@@ -81,10 +81,6 @@ const (
 // PdhCounterValue is the structure that receives the counter value.
 type PdhCounterValue C.PDH_FMT_COUNTERVALUE
 
-type PdhCounterValueItem C.PDH_FMT_COUNTERVALUE_ITEM
-
-type PdhRawCounterItem C.PDH_RAW_COUNTER_ITEM 
-
 // PdhRawCounter is the structure that receives the raw counter.
 type PdhRawCounter C.PDH_RAW_COUNTER
 

--- a/metricbeat/module/windows/perfmon/pdh_integration_windows_test.go
+++ b/metricbeat/module/windows/perfmon/pdh_integration_windows_test.go
@@ -57,7 +57,7 @@ func TestQuery(t *testing.T) {
 	}
 	defer q.Close()
 
-	err = q.AddCounter(processorTimeCounter, FloatFlormat, nil)
+	err = q.AddCounter(processorTimeCounter, FloatFlormat, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -145,7 +145,7 @@ func TestLongOutputFormat(t *testing.T) {
 	}
 	defer query.Close()
 
-	err = query.AddCounter(processorTimeCounter, LongFormat, nil)
+	err = query.AddCounter(processorTimeCounter, LongFormat, "")
 	if err != nil && err != PDH_NO_MORE_DATA {
 		t.Fatal(err)
 	}
@@ -179,7 +179,7 @@ func TestFloatOutputFormat(t *testing.T) {
 	}
 	defer query.Close()
 
-	err = query.AddCounter(processorTimeCounter, FloatFlormat, nil)
+	err = query.AddCounter(processorTimeCounter, FloatFlormat, "")
 	if err != nil && err != PDH_NO_MORE_DATA {
 		t.Fatal(err)
 	}
@@ -213,7 +213,7 @@ func TestRawValues(t *testing.T) {
 	}
 	defer query.Close()
 
-	err = query.AddCounter(processorTimeCounter, FloatFlormat, nil)
+	err = query.AddCounter(processorTimeCounter, FloatFlormat, "")
 	if err != nil && err != PDH_NO_MORE_DATA {
 		t.Fatal(err)
 	}
@@ -221,13 +221,11 @@ func TestRawValues(t *testing.T) {
 	var values []float64
 
 	for i := 0; i < 2; i++ {
-
 		if err = query.Execute(); err != nil {
 			t.Fatal(err)
 		}
 
 		_, rawvalue1, err := PdhGetRawCounterValue(query.counters[processorTimeCounter].handle)
-
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -239,19 +237,16 @@ func TestRawValues(t *testing.T) {
 		}
 
 		_, rawvalue2, err := PdhGetRawCounterValue(query.counters[processorTimeCounter].handle)
-
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		value, err := PdhCalculateCounterFromRawValue(query.counters[processorTimeCounter].handle, PdhFmtDouble|PdhFmtNoCap100, rawvalue2, rawvalue1)
-
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		values = append(values, *(*float64)(unsafe.Pointer(&value.LongValue)))
-
 	}
 
 	t.Log(values)
@@ -274,7 +269,6 @@ func TestWildcardQuery(t *testing.T) {
 	time.Sleep(time.Millisecond * 1000)
 
 	values, err = handle.Read()
-
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/metricbeat/module/windows/perfmon/perfmon.go
+++ b/metricbeat/module/windows/perfmon/perfmon.go
@@ -14,11 +14,11 @@ import (
 )
 
 type CounterConfig struct {
-	InstanceLabel    string  `config:"instance_label" validate:"required"`
-	InstanceName     *string `config:"instance_name"`
-	MeasurementLabel string  `config:"measurement_label" validate:"required"`
-	Query            string  `config:"query" validate:"required"`
-	Format           string  `config:"format"`
+	InstanceLabel    string `config:"instance_label" validate:"required"`
+	InstanceName     string `config:"instance_name"`
+	MeasurementLabel string `config:"measurement_label" validate:"required"`
+	Query            string `config:"query" validate:"required"`
+	Format           string `config:"format"`
 }
 
 func init() {

--- a/metricbeat/module/windows/perfmon/run.go
+++ b/metricbeat/module/windows/perfmon/run.go
@@ -36,7 +36,7 @@ func run() error {
 	cmd.Env = os.Environ()
 
 	if *goarch != "" {
-		cmd.Env = append(cmd.Env, "GOARCH"+*goarch)
+		cmd.Env = append(cmd.Env, "GOARCH="+*goarch)
 	}
 
 	if *output != "" {

--- a/metricbeat/module/windows/perfmon/zpdh_windows.go
+++ b/metricbeat/module/windows/perfmon/zpdh_windows.go
@@ -92,7 +92,7 @@ func _PdhGetFormattedCounterValue(counter PdhCounterHandle, format PdhCounterFor
 	return
 }
 
-func _PdhGetFormattedCounterArray(counter PdhCounterHandle, format PdhCounterFormat, bufferSize *uint32, bufferCount *uint32, itemBuffer *PdhCounterValueItem) (errcode error) {
+func _PdhGetFormattedCounterArray(counter PdhCounterHandle, format PdhCounterFormat, bufferSize *uint32, bufferCount *uint32, itemBuffer *byte) (errcode error) {
 	r0, _, _ := syscall.Syscall6(procPdhGetFormattedCounterArrayW.Addr(), 5, uintptr(counter), uintptr(format), uintptr(unsafe.Pointer(bufferSize)), uintptr(unsafe.Pointer(bufferCount)), uintptr(unsafe.Pointer(itemBuffer)), 0)
 	if r0 != 0 {
 		errcode = syscall.Errno(r0)
@@ -108,7 +108,7 @@ func _PdhGetRawCounterValue(counter PdhCounterHandle, counterType *uint32, value
 	return
 }
 
-func _PdhGetRawCounterArray(counter PdhCounterHandle, bufferSize *uint32, bufferCount *uint32, itemBuffer *PdhRawCounterItem) (errcode error) {
+func _PdhGetRawCounterArray(counter PdhCounterHandle, bufferSize *uint32, bufferCount *uint32, itemBuffer *pdhRawCounterItem) (errcode error) {
 	r0, _, _ := syscall.Syscall6(procPdhGetRawCounterArray.Addr(), 4, uintptr(counter), uintptr(unsafe.Pointer(bufferSize)), uintptr(unsafe.Pointer(bufferCount)), uintptr(unsafe.Pointer(itemBuffer)), 0, 0)
 	if r0 != 0 {
 		errcode = syscall.Errno(r0)


### PR DESCRIPTION
In `PdhGetFormattedCounterArray` the code was allocating memory for `bufferSize` x `sizeof(PdhCounterValueItem)`, but it only needed to allocate `bufferSize`. The buffer size is provided by Windows and already accounts for the sizeof PdhCounterValueItem.

Made an improvement to create regexp objects once at startup instead of on every use.

Moved config validation to startup for non-wildcard counter paths. This allows the check to only be performed one time and for any errors to be returned during the config test.

Fixes #5035