### PR TITLE
Fix invalid filter error in packetbeat

### DIFF
--- a/packetbeat/sniffer/sniffer.go
+++ b/packetbeat/sniffer/sniffer.go
@@ -258,7 +258,10 @@ func validatePcapFilter(expr string) error {
 	defer p.Close()
 
 	_, err = p.NewBPF(expr)
-	return fmt.Errorf("invalid filter: %s", err)
+	if err != nil {
+		return fmt.Errorf("invalid filter '%s': %v", expr, err)
+	}
+	return nil
 }
 
 func openPcap(filter string, cfg *config.InterfacesConfig) (snifferHandle, error) {

--- a/packetbeat/tests/system/config/packetbeat.yml.j2
+++ b/packetbeat/tests/system/config/packetbeat.yml.j2
@@ -4,6 +4,10 @@
 # keyword to sniff on all connected interfaces.
 packetbeat.interfaces.device: {{ iface_device|default("any") }}
 
+{% if bpf_filter %}
+packetbeat.interfaces.bpf_filter: {{ bpf_filter }}
+{% endif %}
+
 {% if flows %}
 #================================== Flows =====================================
 # Set network flow timeout. Flow is killed if no packet is received before being

--- a/packetbeat/tests/system/test_0026_test_config.py
+++ b/packetbeat/tests/system/test_0026_test_config.py
@@ -27,6 +27,6 @@ class Test(BaseTest):
         return a non-zero error code.
         """
         self.render_config_template(
-            iface_device="NoSuchDevice"
+            bpf_filter="invalid BPF filter"
         )
         self.start_packetbeat(extra_args=["-configtest"]).check_wait(exit_code=1)


### PR DESCRIPTION
Looks like after a refactoring, the code was changed to always return an
error.

Fixes #5039.