### PR TITLE
Cherry-pick #5043 to 6.0: Fix /usr/bin/beatname script to accept -d "*"

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -30,6 +30,8 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 
 *Affecting all Beats*
 
+- Fix the `/usr/bin/beatname` script to accept `-d "*"` as a parameter. {issue}5040[5040]
+
 *Auditbeat*
 
 *Filebeat*

--- a/dev-tools/packer/platforms/centos/beatname.sh.j2
+++ b/dev-tools/packer/platforms/centos/beatname.sh.j2
@@ -8,4 +8,4 @@
   -path.config /etc/{{.beat_name}} \
   -path.data /var/lib/{{.beat_name}} \
   -path.logs /var/log/{{.beat_name}} \
-  $@
+  "$@"

--- a/dev-tools/packer/platforms/debian/beatname.sh.j2
+++ b/dev-tools/packer/platforms/debian/beatname.sh.j2
@@ -8,4 +8,4 @@
   -path.config /etc/{{.beat_name}} \
   -path.data /var/lib/{{.beat_name}} \
   -path.logs /var/log/{{.beat_name}} \
-  $@
+  "$@"


### PR DESCRIPTION
Cherry-pick of PR #5043 to 6.0 branch. Original message: 

Fixes #5040.

Credit to @exekias for finding the solution.