### PR TITLE
Improvements to beatname.sh

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -58,6 +58,8 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 *Affecting all Beats*
 
 - Move TCP UDP start up into `server.Start()` {pull}4903[4903]
+- Changed the hashbang used in the beat helper script from `/bin/bash` to `/usr/bin/env bash`. {pull}5051[5051]
+- Changed beat helper script to use `exec` when running the beat. {pull}5051[5051]
 
 *Auditbeat*
 

--- a/dev-tools/packer/platforms/centos/beatname.sh.j2
+++ b/dev-tools/packer/platforms/centos/beatname.sh.j2
@@ -1,9 +1,9 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Script to run {.beat_name} in foreground with the same path settings that
 # the init script / systemd unit file would do.
 
-/usr/share/{{.beat_name}}/bin/{{.beat_name}} \
+exec /usr/share/{{.beat_name}}/bin/{{.beat_name}} \
   -path.home /usr/share/{{.beat_name}} \
   -path.config /etc/{{.beat_name}} \
   -path.data /var/lib/{{.beat_name}} \

--- a/dev-tools/packer/platforms/debian/beatname.sh.j2
+++ b/dev-tools/packer/platforms/debian/beatname.sh.j2
@@ -1,9 +1,9 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Script to run {{.beat_name}} in foreground with the same path settings that
 # the init script / systemd unit file would do.
 
-/usr/share/{{.beat_name}}/bin/{{.beat_name}} \
+exec /usr/share/{{.beat_name}}/bin/{{.beat_name}} \
   -path.home /usr/share/{{.beat_name}} \
   -path.config /etc/{{.beat_name}} \
   -path.data /var/lib/{{.beat_name}} \


### PR DESCRIPTION
Use `exec` with the command to start the beat so that it replaces the shell process leaving only the beat process. This is nicer because you don't have the "beatname.sh" process showing up in `ps` output.

Change the hashbang to `#!/usr/bin/env bash` instead of `#!/bin/bash`. This is generally more portable.