### PR TITLE
Bump docs version to 6.0-beta2

### DIFF
--- a/libbeat/docs/version.asciidoc
+++ b/libbeat/docs/version.asciidoc
@@ -1,4 +1,4 @@
-:stack-version: 6.0.0-beta1
+:stack-version: 6.0.0-beta2
 :doc-branch: 6.0
 :go-version: 1.8.3
 :release-state: prerelease


### PR DESCRIPTION
This should be merged only in the day of the release.