### PR TITLE
Fix reloader error message to only print on actual error

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -60,6 +60,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Move TCP UDP start up into `server.Start()` {pull}4903[4903]
 - Changed the hashbang used in the beat helper script from `/bin/bash` to `/usr/bin/env bash`. {pull}5051[5051]
 - Changed beat helper script to use `exec` when running the beat. {pull}5051[5051]
+- Fix reloader error message to only print on actual error {pull}5066[5066]
 
 *Auditbeat*
 

--- a/libbeat/cfgfile/reload.go
+++ b/libbeat/cfgfile/reload.go
@@ -150,8 +150,9 @@ func (rl *Reloader) Run(runnerFactory RunnerFactory) {
 					if runner != nil && rl.registry.Has(runner.ID()) {
 						debugf("Remove module from stoplist: %v", runner.ID())
 						delete(stopList, runner.ID())
+					} else {
+						logp.Err("Error creating module: %s", err)
 					}
-					logp.Err("Error creating module: %s", err)
 					continue
 				}
 


### PR DESCRIPTION
Error message for `runnerFactory.Create(c)` should only be printed when there is no other runner for the same config that is already active.

When there is a runner active for a prospector, log prospector would return:
```
2017/08/31 09:17:53.951071 registrarcontext.go:31: ERR Error creating prospector: Can only start a prospector when all related states are finished: {Id: Finished:false Fileinfo:0xc420491ba0 Source:/var/lib/docker/containers/3108a14952a84074e6a28eeb8af17348860cd26f0b40550cd18ac3883570712f/3108a14952a84074e6a28eeb8af17348860cd26f0b40550cd18ac3883570712f-json.log Offset:51008 Timestamp:2017-08-31 09:17:43.943364786 +0000 UTC TTL:-1ns Type:log FileStateOS:310155-2049}
```

this being printed each time is incorrect as the prospector is already running and is not being reloaded each time. the error should be printed only if there is no active runner and a `factory.Create` fails.