### PR TITLE
Fix ceph cluster_status field mapping

### DIFF
--- a/metricbeat/docs/fields.asciidoc
+++ b/metricbeat/docs/fields.asciidoc
@@ -1027,7 +1027,7 @@ Cluster status version
 [float]
 === `ceph.cluster_status.osd.full`
 
-type: bool
+type: boolean
 
 Is osd full
 
@@ -1035,7 +1035,7 @@ Is osd full
 [float]
 === `ceph.cluster_status.osd.nearfull`
 
-type: bool
+type: boolean
 
 Is osd near full
 

--- a/metricbeat/module/ceph/cluster_status/_meta/fields.yml
+++ b/metricbeat/module/ceph/cluster_status/_meta/fields.yml
@@ -84,11 +84,11 @@
       description: >
         Cluster status version
     - name: osd.full
-      type: bool
+      type: boolean
       description: >
         Is osd full
     - name: osd.nearfull
-      type: bool
+      type: boolean
       description: >
         Is osd near full
     - name: osd.num_osds


### PR DESCRIPTION
The fields.yml had `bool` instead of `boolean` causing a `mapper_parsing_exception` due to `No handler for type [bool]`.

Fixes #5069