### PR TITLE
Cherry-pick #5077 to 6.0: Combine `fields.yml` properties when they are defined in different sources

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -31,6 +31,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 *Affecting all Beats*
 
 - Fix the `/usr/bin/beatname` script to accept `-d "*"` as a parameter. {issue}5040[5040]
+- Combine `fields.yml` properties when they are defined in different sources. {issue}5075[5075]
 
 *Auditbeat*
 

--- a/libbeat/template/field.go
+++ b/libbeat/template/field.go
@@ -125,7 +125,9 @@ func (f *Field) text() common.MapStr {
 	}
 
 	if len(f.MultiFields) > 0 {
-		properties["fields"] = f.MultiFields.process("", f.esVersion)
+		fields := common.MapStr{}
+		f.MultiFields.process("", f.esVersion, fields)
+		properties["fields"] = fields
 	}
 
 	return properties

--- a/libbeat/template/field_test.go
+++ b/libbeat/template/field_test.go
@@ -3,9 +3,9 @@ package template
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/elastic/beats/libbeat/common"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestField(t *testing.T) {

--- a/libbeat/template/fields_test.go
+++ b/libbeat/template/fields_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/libbeat/common"
 )
 
 func TestHasKey(t *testing.T) {
@@ -56,4 +58,53 @@ func TestHasKey(t *testing.T) {
 	for _, test := range tests {
 		assert.Equal(t, test.result, test.fields.HasKey(test.key))
 	}
+}
+
+func TestPropertiesCombine(t *testing.T) {
+	// Test common fields are combined even if they come from different objects
+	fields := Fields{
+		Field{
+			Name: "test",
+			Type: "group",
+			Fields: Fields{
+				Field{
+					Name: "one",
+					Type: "text",
+				},
+			},
+		},
+		Field{
+			Name: "test",
+			Type: "group",
+			Fields: Fields{
+				Field{
+					Name: "two",
+					Type: "text",
+				},
+			},
+		},
+	}
+
+	output := common.MapStr{}
+	version, err := common.NewVersion("6.0.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = fields.process("", *version, output)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	v1, err := output.GetValue("test.properties.one")
+	if err != nil {
+		t.Fatal(err)
+	}
+	v2, err := output.GetValue("test.properties.two")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, v1, common.MapStr{"type": "text", "norms": false})
+	assert.Equal(t, v2, common.MapStr{"type": "text", "norms": false})
 }

--- a/libbeat/template/template.go
+++ b/libbeat/template/template.go
@@ -99,7 +99,10 @@ func (t *Template) Load(file string) (common.MapStr, error) {
 	}
 
 	// Start processing at the root
-	properties := fields.process("", t.esVersion)
+	properties := common.MapStr{}
+	if err := fields.process("", t.esVersion, properties); err != nil {
+		return nil, err
+	}
 	output := t.generate(properties, dynamicTemplates)
 
 	return output, nil


### PR DESCRIPTION
Cherry-pick of PR #5077 to 6.0 branch. Original message: 

We define fields with the same root key across several files, this
change ensures all of them are combined in the final index template.

Fixes #5075