### PR TITLE
Remove error log from runnerfactory as error is returned by API

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -70,6 +70,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Add PostgreSQL module with slowlog support. {pull}4763[4763]
 - Add Kafka log module. {pull}4885[4885]
 - Add support for `/var/log/containers/` log path in `add_kubernetes_metadata` processor. {pull}4981[4981]
+- Remove error log from runnerfactory as error is returned by API. {pull}5085[5085]
 
 *Heartbeat*
 

--- a/filebeat/prospector/runnerfactory.go
+++ b/filebeat/prospector/runnerfactory.go
@@ -5,7 +5,6 @@ import (
 	"github.com/elastic/beats/filebeat/registrar"
 	"github.com/elastic/beats/libbeat/cfgfile"
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/logp"
 )
 
 // RunnerFactory is a factory for registrars
@@ -28,7 +27,6 @@ func NewRunnerFactory(outlet channel.Factory, registrar *registrar.Registrar, be
 func (r *RunnerFactory) Create(c *common.Config) (cfgfile.Runner, error) {
 	p, err := New(c, r.outlet, r.beatDone, r.registrar.GetStates())
 	if err != nil {
-		logp.Err("Error creating prospector: %s", err)
 		// In case of error with loading state, prospector is still returned
 		return p, err
 	}


### PR DESCRIPTION
The same error that is being logged is also being returned by the API. it should be the caller's choice to decide if its a debug/info/error level log.