### PR TITLE
Use fpm --deb-systemd option for systemd unit file

### DIFF
--- a/dev-tools/packer/platforms/debian/run.sh.j2
+++ b/dev-tools/packer/platforms/debian/run.sh.j2
@@ -7,10 +7,6 @@ cd /build
 # the init scripts needs to have the right name
 cp ${RUNID}.init /tmp/{{.beat_pkg_name}}.init
 
-# create script to reload systemd config
-echo "#!/bin/bash" > /tmp/systemd-daemon-reload.sh
-echo "systemctl daemon-reload 2> /dev/null || true" >> /tmp/systemd-daemon-reload.sh
-
 # add SNAPSHOT if it was requested
 VERSION="{{.version}}"
 if [ "$SNAPSHOT" = "yes" ]; then
@@ -27,7 +23,7 @@ FPM_ARGS=(
         --description "{{.beat_description}}"
         --url {{.beat_url}}
         --deb-init /tmp/{{.beat_pkg_name}}.init
-        --after-install /tmp/systemd-daemon-reload.sh
+        --deb-systemd ${RUNID}.service
         --config-files /etc/{{.beat_name}}/{{.beat_name}}.yml
         homedir/=/usr/share/{{.beat_name}}
         beatname-${RUNID}.sh=/usr/bin/{{.beat_name}}
@@ -35,7 +31,6 @@ FPM_ARGS=(
         {{.beat_name}}-linux.yml=/etc/{{.beat_name}}/{{.beat_name}}.yml
         {{.beat_name}}-linux.reference.yml=/etc/{{.beat_name}}/{{.beat_name}}.reference.yml
         fields.yml=/etc/{{.beat_name}}/fields.yml
-        ${RUNID}.service=/lib/systemd/system/{{.beat_pkg_name}}.service
         god-linux-{{.arch}}=/usr/share/{{.beat_name}}/bin/{{.beat_name}}-god
   )
 


### PR DESCRIPTION
This allows fpm to do the heavy lifting regarding systemd. Unfortunately [this option does not yet exist for rpm](https://github.com/jordansissel/fpm/issues/1163).