### PR TITLE
Don't log at Info level the registered modules/protos

### DIFF
--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -450,7 +450,7 @@ func (b *Beat) loadMeta() error {
 	}
 
 	metaPath := paths.Resolve(paths.Data, "meta.json")
-	logp.Info("Beat metadata path: %v", metaPath)
+	logp.Debug("beat", "Beat metadata path: %v", metaPath)
 
 	f, err := openRegular(metaPath)
 	if err != nil && !os.IsNotExist(err) {

--- a/libbeat/publisher/pipeline/module.go
+++ b/libbeat/publisher/pipeline/module.go
@@ -77,7 +77,7 @@ func Load(
 		return nil, err
 	}
 
-	logp.Info("Publisher name: %s", name)
+	logp.Info("Beat name: %s", name)
 	return p, err
 }
 

--- a/metricbeat/beater/metricbeat.go
+++ b/metricbeat/beater/metricbeat.go
@@ -34,7 +34,7 @@ type staticModule struct {
 // New creates and returns a new Metricbeat instance.
 func New(b *beat.Beat, rawConfig *common.Config) (beat.Beater, error) {
 	// List all registered modules and metricsets.
-	logp.Info("%s", mb.Registry.String())
+	logp.Debug("modules", "%s", mb.Registry.String())
 
 	config := defaultConfig
 	if err := rawConfig.Unpack(&config); err != nil {

--- a/packetbeat/protos/protos.go
+++ b/packetbeat/protos/protos.go
@@ -102,7 +102,7 @@ func (s ProtocolsStruct) Init(
 	}
 
 	for proto := range protocolSyms {
-		logp.Info("registered protocol plugin: %v", proto)
+		logp.Debug("protos", "registered protocol plugin: %v", proto)
 	}
 
 	for name, config := range configs {


### PR DESCRIPTION
These are somewhat confusing because the modules are just registered
at that point, not actually enabled. Also, they make the output on a
normal startup a bit long.

Also replaced the "Publisher name" to "Beat name" to be a little less confusing.

Closes #5049.