### PR TITLE
Add script to test against apm-server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,3 +140,8 @@ notice: python-env
 python-env:
 	@test -d $(PYTHON_ENV) || virtualenv $(VIRTUALENV_PARAMS) $(PYTHON_ENV)
 	@$(PYTHON_ENV)/bin/pip install -q --upgrade pip autopep8 six
+
+# Tests if apm works with the current code
+.PHONY: python-env
+test-apm:
+	sh ./script/test_apm.sh

--- a/script/test_apm.sh
+++ b/script/test_apm.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+# This script allows to test against the code from apm-server
+# By default it is checked against master. The env variable BRANCH
+# can be set to any value accepted by git checkout.
+#
+# go build is executed on the apm-server code to verify that it can
+# still be built and runs the go tests with make unit.
+
+set -e
+
+# Check if a special branch env variable is set
+if [ -z "${BRANCH}" ]; then
+    BRANCH=master
+fi
+
+echo "apm-server branch: $BRANCH"
+
+BASE_PATH=$(pwd)
+BUILD_DIR=$BASE_PATH/build
+ELASTIC_DIR=$BUILD_DIR/apm-test/src/github.com/elastic
+APM_SERVER_DIR=$ELASTIC_DIR/apm-server
+
+# Cleanup and create directories
+rm -rf $APM_SERVER_DIR
+mkdir -p $APM_SERVER_DIR
+
+# Clone and checkout defined branch
+git clone https://github.com/elastic/apm-server $APM_SERVER_DIR
+cd $APM_SERVER_DIR
+git checkout $BRANCH
+cd $BASE_PATH
+
+# Replace libbeat with local libbeat version
+rm -r $APM_SERVER_DIR/vendor/github.com/elastic/beats/libbeat
+cp -r libbeat $APM_SERVER_DIR/vendor/github.com/elastic/beats/
+
+cd $APM_SERVER_DIR
+
+echo "Build apm-server binary"
+
+# Set temporary GOPATH to make sure local version of libbeat is used
+GOPATH=$BUILD_DIR/apm-test go build
+
+echo "Run apm-server unit tests"
+GOPATH=$BUILD_DIR/apm-test make unit


### PR DESCRIPTION
apm-server depends on libbeat. To make sure we are aware when changes in libbeat break apm-server, this script allows to run the current code base against a specific branch / commit of apm-server. The idea is to add this also to our tests in a later PR but allow it to fail. Like this we always know when we break the code from apm-server.