### PR TITLE
Cherry-pick #5091 to 6.0: Fix `fields.yml` lookup when using `export template` with a custom config path

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -32,6 +32,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 
 - Fix the `/usr/bin/beatname` script to accept `-d "*"` as a parameter. {issue}5040[5040]
 - Combine `fields.yml` properties when they are defined in different sources. {issue}5075[5075]
+- Fix `fields.yml` lookup when using `export template` with a custom `path.config` param. {issue}5089[5089]
 
 *Auditbeat*
 

--- a/libbeat/cmd/export/template.go
+++ b/libbeat/cmd/export/template.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/elastic/beats/libbeat/cmd/instance"
+	"github.com/elastic/beats/libbeat/paths"
 	"github.com/elastic/beats/libbeat/template"
 )
 
@@ -44,7 +45,8 @@ func GenTemplateConfigCmd(name, beatVersion string) *cobra.Command {
 				os.Exit(1)
 			}
 
-			templateString, err := tmpl.Load(cfg.Fields)
+			fieldsPath := paths.Resolve(paths.Config, cfg.Fields)
+			templateString, err := tmpl.Load(fieldsPath)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Error generating template: %+v", err)
 				os.Exit(1)


### PR DESCRIPTION
Cherry-pick of PR #5091 to 6.0 branch. Original message: 

Fixes #5089