### PR TITLE
should use strings.Contains(string(cmdline), process) instead

### DIFF
--- a/packetbeat/procs/procs.go
+++ b/packetbeat/procs/procs.go
@@ -173,7 +173,7 @@ func findPidsByCmdlineGrep(prefix string, process string) ([]int, error) {
 			continue
 		}
 
-		if strings.Index(string(cmdline), process) >= 0 {
+		if strings.Contains(string(cmdline), process) {
 			pids = append(pids, pid)
 		}
 	}


### PR DESCRIPTION
should use strings.Contains(string(cmdline), process) instead