### PR TITLE
Mark 5.6.0 as released

### DIFF
--- a/libbeat/docs/version.asciidoc
+++ b/libbeat/docs/version.asciidoc
@@ -1,4 +1,4 @@
 :stack-version: 5.6.0
 :doc-branch: 5.6
 :go-version: 1.7.6
-:release-state: unreleased
+:release-state: released


### PR DESCRIPTION
This should be merged the day of the release.