### PR TITLE
Bump docs version for 5.5.3

### DIFF
--- a/libbeat/docs/version.asciidoc
+++ b/libbeat/docs/version.asciidoc
@@ -1,4 +1,4 @@
-:stack-version: 5.5.2
+:stack-version: 5.5.3
 :doc-branch: 5.5
 :go-version: 1.7.6
 :release-state: released


### PR DESCRIPTION
This should be merged the day of the release only.