### PR TITLE
MB mongodb module: connect on fetch, not on init

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -52,6 +52,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Fix a memory allocation issue where more memory was allocated than needed in the windows-perfmon metricset. {issue}5035[5035]
 - Don't start metricbeat if external modules config is wrong and reload is disabled {pull}5053[5053]
 - Fix kubernetes events module to be able to index time fields properly. {issue}5093[5093]
+- The MongoDB module now connects on each fetch, to avoid stopping the whole Metricbeat instance if MongoDB is not up when starting. {pull}5120[5120]
 
 *Packetbeat*
 

--- a/metricbeat/module/mongodb/mongodb.go
+++ b/metricbeat/module/mongodb/mongodb.go
@@ -74,7 +74,7 @@ func NewDirectSession(dialInfo *mgo.DialInfo) (*mgo.Session, error) {
 	nodeDialInfo.Direct = true
 	nodeDialInfo.FailFast = true
 
-	logp.Info("Connecting to MongoDB node at %v", nodeDialInfo.Addrs)
+	logp.Debug("mongodb", "Connecting to MongoDB node at %v", nodeDialInfo.Addrs)
 
 	session, err := mgo.DialWithInfo(&nodeDialInfo)
 	if err != nil {


### PR DESCRIPTION
Moving the Dial call to the Fetch, so that in case Mongodb is not (yet)
available, Metricbeat doesn't exit with an error, but just reports the
service being down. This is consistent with the way most of the other
modules are working.

Fixes #5090