### PR TITLE
Cherry-pick #5105 to 6.0: Fix kubernetes events module to be able to index time fields properly

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -50,6 +50,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Add new metrics to CPU metricsset {pull}4969[4969]
 - Fix a memory allocation issue where more memory was allocated than needed in the windows-perfmon metricset. {issue}5035[5035]
 - Don't start metricbeat if external modules config is wrong and reload is disabled {pull}5053[5053]
+- Fix kubernetes events module to be able to index time fields properly. {issue}5093[5093]
 
 *Packetbeat*
 

--- a/metricbeat/docs/fields.asciidoc
+++ b/metricbeat/docs/fields.asciidoc
@@ -4518,14 +4518,6 @@ Timestamp of creation of the given event
 
 
 [float]
-=== kubernetes.event.metadata.timestamp.deleted
-
-type: date
-
-Timestamp of deletion of the given event
-
-
-[float]
 === kubernetes.event.metadata.name
 
 type: keyword

--- a/metricbeat/module/kubernetes/event/_meta/fields.yml
+++ b/metricbeat/module/kubernetes/event/_meta/fields.yml
@@ -44,10 +44,6 @@
         type: date
         description: >
           Timestamp of creation of the given event
-      - name: deleted
-        type: date
-        description: >
-          Timestamp of deletion of the given event
     - name: name
       type: keyword
       description: >

--- a/metricbeat/module/kubernetes/event/event.go
+++ b/metricbeat/module/kubernetes/event/event.go
@@ -84,10 +84,8 @@ func (m *MetricSet) Run(reporter mb.PushReporter) {
 			return
 		case msg := <-m.watcher.eventQueue:
 			// Ignore events that are deleted
-			if msg.Metadata.DeletionTimestamp == "" {
-				if msg.Metadata.DeletionTimestamp == "" {
-					reporter.Event(generateMapStrFromEvent(msg))
-				}
+			if msg.Metadata.DeletionTimestamp == nil {
+				reporter.Event(generateMapStrFromEvent(msg))
 			}
 		}
 	}
@@ -97,7 +95,6 @@ func generateMapStrFromEvent(eve *Event) common.MapStr {
 	eventMeta := common.MapStr{
 		"timestamp": common.MapStr{
 			"created": eve.Metadata.CreationTimestamp,
-			"deleted": eve.Metadata.DeletionTimestamp,
 		},
 		"name":             eve.Metadata.Name,
 		"namespace":        eve.Metadata.Namespace,
@@ -125,11 +122,7 @@ func generateMapStrFromEvent(eve *Event) common.MapStr {
 		eventMeta["annotations"] = annotations
 	}
 
-	return common.MapStr{
-		"timestamp": common.MapStr{
-			"first_occurrence": eve.FirstTimestamp.UTC(),
-			"last_occurrence":  eve.LastTimestamp.UTC(),
-		},
+	output := common.MapStr{
 		"message": eve.Message,
 		"reason":  eve.Reason,
 		"type":    eve.Type,
@@ -143,4 +136,20 @@ func generateMapStrFromEvent(eve *Event) common.MapStr {
 		},
 		"metadata": eventMeta,
 	}
+
+	tsMap := make(common.MapStr)
+
+	if eve.FirstTimestamp != nil {
+		tsMap["first_occurrence"] = eve.FirstTimestamp.UTC()
+	}
+
+	if eve.LastTimestamp != nil {
+		tsMap["last_occurrence"] = eve.LastTimestamp.UTC()
+	}
+
+	if len(tsMap) != 0 {
+		output["timestamp"] = tsMap
+	}
+
+	return output
 }

--- a/metricbeat/module/kubernetes/event/types.go
+++ b/metricbeat/module/kubernetes/event/types.go
@@ -4,8 +4,8 @@ import "time"
 
 type ObjectMeta struct {
 	Annotations       map[string]string `json:"annotations"`
-	CreationTimestamp string            `json:"creationTimestamp"`
-	DeletionTimestamp string            `json:"deletionTimestamp"`
+	CreationTimestamp *time.Time        `json:"creationTimestamp"`
+	DeletionTimestamp *time.Time        `json:"deletionTimestamp"`
 	GenerateName      string            `json:"generateName"`
 	Labels            map[string]string `json:"labels"`
 	Name              string            `json:"name"`
@@ -23,9 +23,9 @@ type ObjectMeta struct {
 }
 
 type Event struct {
-	APIVersion     string    `json:"apiVersion"`
-	Count          int64     `json:"count"`
-	FirstTimestamp time.Time `json:"firstTimestamp"`
+	APIVersion     string     `json:"apiVersion"`
+	Count          int64      `json:"count"`
+	FirstTimestamp *time.Time `json:"firstTimestamp"`
 	InvolvedObject struct {
 		APIVersion      string `json:"apiVersion"`
 		Kind            string `json:"kind"`
@@ -34,7 +34,7 @@ type Event struct {
 		UID             string `json:"uid"`
 	} `json:"involvedObject"`
 	Kind          string     `json:"kind"`
-	LastTimestamp time.Time  `json:"lastTimestamp"`
+	LastTimestamp *time.Time `json:"lastTimestamp"`
 	Message       string     `json:"message"`
 	Metadata      ObjectMeta `json:"metadata"`
 	Reason        string     `json:"reason"`


### PR DESCRIPTION
Cherry-pick of PR #5105 to 6.0 branch. Original message: 

Fixes https://github.com/elastic/beats/issues/5093