### PR TITLE
Remove runner creation from every reload check

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -37,6 +37,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Combine `fields.yml` properties when they are defined in different sources. {issue}5075[5075]
 - Keep Docker & Kubernetes pod metadata after container dies while they are needed by processors. {pull}5084[5084]
 - Fix `fields.yml` lookup when using `export template` with a custom `path.config` param. {issue}5089[5089]
+- Remove runner creation from every reload check {pull}5141[5141]
 
 *Auditbeat*
 

--- a/libbeat/cfgfile/reload.go
+++ b/libbeat/cfgfile/reload.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/joeshaw/multierror"
+	"github.com/mitchellh/hashstructure"
 	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/libbeat/common"
@@ -134,7 +135,7 @@ func (rl *Reloader) Run(runnerFactory RunnerFactory) {
 		rl.config.Reload.Period = 0
 	}
 
-	overwriteUpate := true
+	overwriteUpdate := true
 
 	for {
 		select {
@@ -154,8 +155,8 @@ func (rl *Reloader) Run(runnerFactory RunnerFactory) {
 			}
 
 			// no file changes
-			if !updated && !overwriteUpate {
-				overwriteUpate = false
+			if !updated && !overwriteUpdate {
+				overwriteUpdate = false
 				continue
 			}
 
@@ -174,29 +175,34 @@ func (rl *Reloader) Run(runnerFactory RunnerFactory) {
 					continue
 				}
 
-				runner, err := runnerFactory.Create(c)
-				if err != nil {
-					// Make sure the next run also updates because some runners were not properly loaded
-					overwriteUpate = true
+				rawCfg := map[string]interface{}{}
+				err := c.Unpack(rawCfg)
 
-					// In case prospector already is running, do not stop it
-					if runner != nil && rl.registry.Has(runner.ID()) {
-						debugf("Remove module from stoplist: %v", runner.ID())
-						delete(stopList, runner.ID())
-					} else {
-						logp.Err("Error creating module: %s", err)
-					}
+				if err != nil {
+					logp.Err("Unable to unpack config file due to error: %v", err)
 					continue
 				}
 
-				debugf("Remove module from stoplist: %v", runner.ID())
-				delete(stopList, runner.ID())
+				hash, err := hashstructure.Hash(rawCfg, nil)
+				if err != nil {
+					// Make sure the next run also updates because some runners were not properly loaded
+					overwriteUpdate = true
+					debugf("Unable to generate hash for config file %v due to error: %v", c, err)
+					continue
+				}
+
+				debugf("Remove module from stoplist: %v", hash)
+				delete(stopList, hash)
 
 				// As module already exist, it must be removed from the stop list and not started
-				if !rl.registry.Has(runner.ID()) {
-					debugf("Add module to startlist: %v", runner.ID())
-					startList[runner.ID()] = runner
-					continue
+				if !rl.registry.Has(hash) {
+					debugf("Add module to startlist: %v", hash)
+					runner, err := runnerFactory.Create(c)
+					if err != nil {
+						logp.Err("Unable to create runner due to error: %v", err)
+						continue
+					}
+					startList[hash] = runner
 				}
 			}
 


### PR DESCRIPTION
This PR will partly mitigate https://github.com/elastic/beats/issues/5139 as it removes runner creation during every reload interval. 