### PR TITLE
Update ES test version to 7.0.0-alpha1

### DIFF
--- a/libbeat/dashboards/es_loader_test.go
+++ b/libbeat/dashboards/es_loader_test.go
@@ -24,7 +24,8 @@ func TestImporter(t *testing.T) {
 	}
 
 	client := elasticsearch.GetTestingElasticsearch(t)
-	if strings.HasPrefix(client.Connection.GetVersion(), "6.") {
+	if strings.HasPrefix(client.Connection.GetVersion(), "6.") ||
+		strings.HasPrefix(client.Connection.GetVersion(), "7.") {
 		t.Skip("Skipping tests for Elasticsearch 6.x releases")
 	}
 
@@ -60,7 +61,8 @@ func TestImporterEmptyBeat(t *testing.T) {
 	}
 
 	client := elasticsearch.GetTestingElasticsearch(t)
-	if strings.HasPrefix(client.Connection.GetVersion(), "6.") {
+	if strings.HasPrefix(client.Connection.GetVersion(), "6.") ||
+		strings.HasPrefix(client.Connection.GetVersion(), "7.") {
 		t.Skip("Skipping tests for Elasticsearch 6.x releases")
 	}
 

--- a/testing/environments/args.yml
+++ b/testing/environments/args.yml
@@ -6,5 +6,5 @@ services:
     build:
       args:
         DOWNLOAD_URL: https://snapshots.elastic.co/downloads
-        ELASTIC_VERSION: 6.0.0-beta1-SNAPSHOT
-        CACHE_BUST: 20170720
+        ELASTIC_VERSION: 7.0.0-alpha1-SNAPSHOT
+        CACHE_BUST: 20170911


### PR DESCRIPTION
6.0.0-beta1 snapshot does not exist as its not a snapshot anymore. Also master should be tested againts ES 7.0.0-alpha1.