### PR TITLE
Reorder processors in publisher pipeline

### DIFF
--- a/libbeat/common/mapstr.go
+++ b/libbeat/common/mapstr.go
@@ -11,9 +11,8 @@ import (
 // Event metadata constants. These keys are used within libbeat to identify
 // metadata stored in an event.
 const (
-	EventMetadataKey = "_event_metadata"
-	FieldsKey        = "fields"
-	TagsKey          = "tags"
+	FieldsKey = "fields"
+	TagsKey   = "tags"
 )
 
 var (

--- a/libbeat/publisher/pipeline/pipeline.go
+++ b/libbeat/publisher/pipeline/pipeline.go
@@ -373,7 +373,9 @@ func makePipelineProcessors(
 	processors *processors.Processors,
 	disabled bool,
 ) pipelineProcessors {
-	p := pipelineProcessors{}
+	p := pipelineProcessors{
+		disabled: disabled,
+	}
 
 	hasProcessors := processors != nil && len(processors.List) > 0
 	if hasProcessors {
@@ -384,13 +386,13 @@ func makePipelineProcessors(
 		p.processors = tmp
 	}
 
-	fields := common.MapStr{}
 	if meta := annotations.Beat; meta != nil {
 		p.beatsMeta = common.MapStr{"beat": meta}
 	}
 
-	fields = buildFields(fields, annotations.Event)
-	if len(fields) > 0 {
+	if em := annotations.Event; len(em.Fields) > 0 {
+		fields := common.MapStr{}
+		common.MergeFields(fields, em.Fields.Clone(), em.FieldsUnderRoot)
 		p.fields = fields
 	}
 

--- a/libbeat/publisher/pipeline/pipeline.go
+++ b/libbeat/publisher/pipeline/pipeline.go
@@ -60,10 +60,9 @@ type pipelineProcessors struct {
 	// The pipeline its processor settings for
 	// constructing the clients complete processor
 	// pipeline on connect.
-	fieldsProcessor beat.Processor
-	tagsProcessor   beat.Processor
-	fields          common.MapStr
-	tags            []string
+	beatsMeta common.MapStr
+	fields    common.MapStr
+	tags      []string
 
 	processors beat.Processor
 
@@ -387,19 +386,16 @@ func makePipelineProcessors(
 
 	fields := common.MapStr{}
 	if meta := annotations.Beat; meta != nil {
-		fields["beat"] = meta
+		p.beatsMeta = common.MapStr{"beat": meta}
 	}
 
 	fields = buildFields(fields, annotations.Event)
 	if len(fields) > 0 {
-		needsCopy := hasProcessors
-		p.fieldsProcessor = pipelineEventFields(fields, needsCopy)
 		p.fields = fields
 	}
 
 	if t := annotations.Event.Tags; len(t) > 0 {
 		p.tags = t
-		p.tagsProcessor = makeAddTagsProcessor("globalTags", t)
 	}
 
 	return p

--- a/libbeat/publisher/pipeline/processor.go
+++ b/libbeat/publisher/pipeline/processor.go
@@ -29,73 +29,60 @@ type processorFn struct {
 //
 // Pipeline (C=client, P=pipeline)
 //
-// 1. (P) extract EventMetadataKey fields + tags (to be removed in favor of 4)
-// 2. (P) generalize/normalize event
-// 3. (P) add beats metadata (name, hostname, version)
-// 4. (C) add Meta from client Config to event.Meta
-// 5. (C) add Fields from client config to event.Fields
-// 6. (P) add pipeline fields + tags
-// 7. (C) add client fields + tags
-// 8. (P/C) apply EventMetadataKey fields + tags (to be removed in favor of 4)
-// 9. (C) client processors list
-// 10. (P) pipeline processors list
-// 11. (P) (if publish/debug enabled) log event
-// 12. (P) (if output disabled) dropEvent
+//  1. (P) generalize/normalize event
+//  2. (C) add Meta from client Config to event.Meta
+//  3. (C) add Fields from client config to event.Fields
+//  4. (C) add client fields + tags
+//  5. (C) client processors list
+//  6. (P) add beats metadata
+//  7. (P) add pipeline fields + tags
+//  8. (P) pipeline processors list
+//  9. (P) (if publish/debug enabled) log event
+// 10. (P) (if output disabled) dropEvent
 func (p *Pipeline) newProcessorPipeline(
 	config beat.ClientConfig,
 ) beat.Processor {
 	processors := &program{title: "processPipeline"}
 
 	global := p.processors
+	localProcessors := makeClientProcessors(config)
 
-	// setup 1: extract EventMetadataKey fields + tags
-	processors.add(preEventUserAnnotateProcessor)
-
-	// setup 2 and 3: generalize/normalize output (P)
+	// setup 1: generalize/normalize output (P)
 	processors.add(generalizeProcessor)
-	processors.add(global.beatMetaProcessor)
 
-	// setup 4: add Meta from client config
+	// setup 2: add Meta from client config (C)
 	if m := config.Meta; len(m) > 0 {
 		processors.add(clientEventMeta(m))
 	}
 
-	// setup 5: add Fields from client config
+	// setup 3: add Fields from client config (C)
 	if m := config.Fields; len(m) > 0 {
 		processors.add(clientEventFields(m))
 	}
 
-	// setup 6: add event fields + tags (P)
-	processors.add(global.eventMetaProcessor)
-
-	// setup 7: add fields + tags (C)
+	// setup 4: add fields + tags (C)
 	if em := config.EventMetadata; len(em.Fields) > 0 || len(em.Tags) > 0 {
 		processors.add(eventAnnotateProcessor(em))
 	}
 
-	// setup 8: apply EventMetadata fields + tags
-	processors.add(eventUserAnnotateProcessor)
+	// setup 5: client processors (C)
+	processors.add(localProcessors)
 
-	// setup 9: client processors (C)
-	if procs := config.Processor; procs != nil {
-		if lst := procs.All(); len(lst) > 0 {
+	// setup 6: add beats metadata (P)
+	processors.add(global.beatMetaProcessor)
 
-			processors.add(&program{
-				title: "client",
-				list:  lst,
-			})
-		}
-	}
+	// setup 7: add event fields + tags (P)
+	processors.add(global.eventMetaProcessor)
 
-	// setup 10: pipeline processors (P)
+	// setup 8: pipeline processors (P)
 	processors.add(global.processors)
 
-	// setup 11: debug print final event (P)
+	// setup 9: debug print final event (P)
 	if logp.IsDebug("publish") {
 		processors.add(debugPrintProcessor())
 	}
 
-	// setup 12: drop all events if outputs are disabled
+	// setup 10: drop all events if outputs are disabled (P)
 	if global.disabled {
 		processors.add(dropDisabledProcessor)
 	}
@@ -222,51 +209,6 @@ func clientEventFields(fields common.MapStr) *processorFn {
 	})
 }
 
-// TODO: remove var-section. Keep for backwards compatibility with old publisher API.
-//       Remove after updating all beats to new publisher API.
-// Note: this functionality is used by filebeat/winlogbeat, so prospector/harvesters
-//       can apply fields to events after generating the event type.
-//       This functionality will be removed, in favor of harvesters publishing
-//       event to a beat.Client with properly setup processor
-var (
-	preEventUserAnnotateProcessor = newAnnotateProcessor("annotateEventUserPre", func(event *beat.Event) {
-		const key = common.EventMetadataKey
-		val, exists := event.Fields[key]
-		if !exists {
-			return
-		}
-
-		delete(event.Fields, key)
-
-		if _, ok := val.(common.EventMetadata); ok {
-			if event.Meta == nil {
-				event.Meta = common.MapStr{}
-			}
-			event.Meta[key] = val
-		}
-	})
-
-	eventUserAnnotateProcessor = newAnnotateProcessor("annotateEventUser", func(event *beat.Event) {
-		const key = common.EventMetadataKey
-
-		tmp, ok := event.Meta[key]
-		if !ok {
-			return
-		}
-
-		delete(event.Meta, key)
-		if len(event.Meta) == 0 {
-			event.Meta = nil
-		}
-
-		eventMeta := tmp.(common.EventMetadata)
-		common.AddTags(event.Fields, eventMeta.Tags)
-		if fields := eventMeta.Fields; len(fields) > 0 {
-			common.MergeFields(event.Fields, fields.Clone(), eventMeta.FieldsUnderRoot)
-		}
-	})
-)
-
 func debugPrintProcessor() *processorFn {
 	// ensure only one go-routine is using the encoder (in case
 	// beat.Client is shared between multiple go-routines by accident)
@@ -285,4 +227,16 @@ func debugPrintProcessor() *processorFn {
 		logp.Debug("publish", "Publish event: %s", b)
 		return event, nil
 	})
+}
+
+func makeClientProcessors(config beat.ClientConfig) processors.Processor {
+	procs := config.Processor
+	if procs == nil || len(procs.All()) == 0 {
+		return nil
+	}
+
+	return &program{
+		title: "client",
+		list:  procs.All(),
+	}
 }

--- a/libbeat/publisher/pipeline/processor.go
+++ b/libbeat/publisher/pipeline/processor.go
@@ -275,20 +275,3 @@ func makeClientProcessors(config beat.ClientConfig) processors.Processor {
 		list:  procs.All(),
 	}
 }
-
-func buildFields(fields common.MapStr, em common.EventMetadata) common.MapStr {
-	if fields == nil {
-		fields = common.MapStr{}
-	} else {
-		fields = fields.Clone()
-	}
-
-	if fs := em.Fields; len(fs) > 0 {
-		common.MergeFields(fields, fs.Clone(), em.FieldsUnderRoot)
-	}
-
-	if len(fields) == 0 {
-		return nil
-	}
-	return fields
-}

--- a/metricbeat/mb/module/event.go
+++ b/metricbeat/mb/module/event.go
@@ -78,7 +78,6 @@ func (b EventBuilder) Build() (beat.Event, error) {
 	event := beat.Event{
 		Timestamp: time.Time(timestamp),
 		Fields: common.MapStr{
-			// common.EventMetadataKey: b.metadata,
 			b.ModuleName: moduleEvent,
 			"metricset":  metricsetData,
 		},

--- a/metricbeat/mb/testing/data_generator.go
+++ b/metricbeat/mb/testing/data_generator.go
@@ -85,9 +85,6 @@ func CreateFullEvent(ms mb.MetricSet, metricSetData common.MapStr) beat.Event {
 		"hostname": "host.example.com",
 	}
 
-	// Delete meta data as not needed for the event output here.
-	delete(fullEvent.Fields, common.EventMetadataKey)
-
 	return fullEvent
 }
 


### PR DESCRIPTION
- reorder processors, such that the `beat` namespace can not be removed from client processors
- remove support for EventsMetadataKey
- combine client internal field updates and configured field updates into one dictionary
- combine proessors for adding client and global fields+tags if no client processors are configured
- Do not Clone (deep copy) fields being added in the pipeline if no processors are configured.