### PR TITLE
Add support for post-update command

### DIFF
--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -293,6 +293,9 @@ endif
 	@mkdir -p $(PWD)/_meta/kibana/default/index-pattern
 	@${PYTHON_ENV}/bin/python ${ES_BEATS}/libbeat/scripts/generate_index_pattern.py --index '${BEAT_NAME}-*' --beat $(PWD) --version ${BEAT_VERSION}
 
+	# Runs the post-update target if it exists. Will not return errors
+	@-$(MAKE) post-update
+
 
 .PHONY: docs
 docs:  ## @build Builds the documents for the beat


### PR DESCRIPTION
This command can be used in the beats to be run after `make update` is executed. This allows for example to modify the libbeat specific parts of the config file if needed.

The command is optional in a beat, meaning if it does not exist it won't return an error. Also if it exist and it returns an error, make update will still skip the error.