### PR TITLE
Cherry-pick #5159 to 6.0: Fix kubernetes matcher registry lookup

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -13,6 +13,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 ==== Breaking changes
 
 *Affecting all Beats*
+- Fix kubernetes matcher registry lookup. {pull}5159[5159]
 
 *Auditbeat*
 

--- a/libbeat/processors/add_kubernetes_metadata/registry.go
+++ b/libbeat/processors/add_kubernetes_metadata/registry.go
@@ -34,7 +34,7 @@ func init() {
 	p.MustRegisterLoader(indexerKey, func(ifc interface{}) error {
 		i, ok := ifc.(indexerPlugin)
 		if !ok {
-			return errors.New("plugin does not match output plugin type")
+			return errors.New("plugin does not match indexer plugin type")
 		}
 
 		name := i.name
@@ -49,11 +49,11 @@ func init() {
 	p.MustRegisterLoader(matcherKey, func(ifc interface{}) error {
 		m, ok := ifc.(matcherPlugin)
 		if !ok {
-			return errors.New("plugin does not match output plugin type")
+			return errors.New("plugin does not match matcher plugin type")
 		}
 
 		name := m.name
-		if Indexing.indexers[name] != nil {
+		if Indexing.matchers[name] != nil {
 			return fmt.Errorf("matcher type %v already registered", name)
 		}
 


### PR DESCRIPTION
Cherry-pick of PR #5159 to 6.0 branch. Original message: 

