### PR TITLE
Fix default paths in macOS for Redis 4.0.1

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -42,6 +42,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 *Auditbeat*
 
 *Filebeat*
+- Fix default paths for redis 4.0.1 logs on macOS {pull}5173[5173] 
 
 *Heartbeat*
 

--- a/filebeat/docs/modules/redis.asciidoc
+++ b/filebeat/docs/modules/redis.asciidoc
@@ -13,8 +13,9 @@ This module has two filesets:
 * connects to Redis via the network and retrieves the slow logs
   by using the `SLOWLOG` command.
 
-For the `log` fileset, make sure the `logfile` option is set in the Redis configuration file. For
-the `slowlog` fileset, make sure the `slowlog-log-slower-than` is set.
+For the `log` fileset, make sure the `logfile` option, from the Redis configuration file, is set to `redis-server.log`.
+
+For the `slowlog` fileset, make sure the `slowlog-log-slower-than` option, from the Redis configuration file, is set to a lower value than the default one.
 
 [float]
 === Compatibility

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -210,7 +210,7 @@ filebeat.modules:
     #enabled: true
 
     # The Redis hosts to connect to.
-    #var.hosts: ["localhost:6378"]
+    #var.hosts: ["localhost:6379"]
 
     # Optional, the password to use when connecting to Redis.
     #var.password:

--- a/filebeat/module/redis/_meta/config.reference.yml
+++ b/filebeat/module/redis/_meta/config.reference.yml
@@ -12,7 +12,7 @@
     #enabled: true
 
     # The Redis hosts to connect to.
-    #var.hosts: ["localhost:6378"]
+    #var.hosts: ["localhost:6379"]
 
     # Optional, the password to use when connecting to Redis.
     #var.password:

--- a/filebeat/module/redis/_meta/config.yml
+++ b/filebeat/module/redis/_meta/config.yml
@@ -12,7 +12,7 @@
     enabled: true
 
     # The Redis hosts to connect to.
-    #var.hosts: ["localhost:6378"]
+    #var.hosts: ["localhost:6379"]
 
     # Optional, the password to use when connecting to Redis.
     #var.password:

--- a/filebeat/module/redis/_meta/docs.asciidoc
+++ b/filebeat/module/redis/_meta/docs.asciidoc
@@ -8,8 +8,9 @@ This module has two filesets:
 * connects to Redis via the network and retrieves the slow logs
   by using the `SLOWLOG` command.
 
-For the `log` fileset, make sure the `logfile` option is set in the Redis configuration file. For
-the `slowlog` fileset, make sure the `slowlog-log-slower-than` is set.
+For the `log` fileset, make sure the `logfile` option, from the Redis configuration file, is set to `redis-server.log`.
+
+For the `slowlog` fileset, make sure the `slowlog-log-slower-than` option, from the Redis configuration file, is set to a lower value than the default one.
 
 [float]
 === Compatibility

--- a/filebeat/module/redis/log/manifest.yml
+++ b/filebeat/module/redis/log/manifest.yml
@@ -6,6 +6,7 @@ var:
       - /var/log/redis/redis-server.log*
     os.darwin:
       - /usr/local/var/log/redis/redis-server.log*
+      - /usr/local/var/db/redis/redis-server.log*
     os.windows:
       - "c:/program files/Redis/logs/redis.log*"
 

--- a/filebeat/modules.d/redis.yml.disabled
+++ b/filebeat/modules.d/redis.yml.disabled
@@ -12,7 +12,7 @@
     enabled: true
 
     # The Redis hosts to connect to.
-    #var.hosts: ["localhost:6378"]
+    #var.hosts: ["localhost:6379"]
 
     # Optional, the password to use when connecting to Redis.
     #var.password:


### PR DESCRIPTION
Add another default path that works for newer versions of Redis (4.0.1), for macOS.