### PR TITLE
cms_get and cmd_set mixed up in memcached module

### DIFF
--- a/metricbeat/module/memcached/stats/data.go
+++ b/metricbeat/module/memcached/stats/data.go
@@ -21,8 +21,8 @@ var (
 			"misses": c.Int("get_misses"),
 		},
 		"cmd": s.Object{
-			"get": c.Int("cmd_set"),
-			"set": c.Int("cmd_get"),
+			"get": c.Int("cmd_get"),
+			"set": c.Int("cmd_set"),
 		},
 		"read": s.Object{
 			"bytes": c.Int("bytes_read"),


### PR DESCRIPTION
I just created this here and thought to look at the code.

https://discuss.elastic.co/t/metricbeat-memcached-module-seems-to-mix-up-memcached-stats-cmd-get-and-memcached-stats-cmd-set/100732