### PR TITLE
Improve logging for Size changes

### DIFF
--- a/filebeat/prospector/log/prospector.go
+++ b/filebeat/prospector/log/prospector.go
@@ -449,7 +449,7 @@ func (p *Prospector) harvestExistingFile(newState file.State, oldState file.Stat
 		// Resume harvesting of an old file we've stopped harvesting from
 		// This could also be an issue with force_close_older that a new harvester is started after each scan but not needed?
 		// One problem with comparing modTime is that it is in seconds, and scans can happen more then once a second
-		logp.Debug("prospector", "Resuming harvesting of file: %s, offset: %v", newState.Source, oldState.Offset)
+		logp.Debug("prospector", "Resuming harvesting of file: %s, offset: %d, new size: %d", newState.Source, oldState.Offset, newState.Fileinfo.Size())
 		err := p.startHarvester(newState, oldState.Offset)
 		if err != nil {
 			logp.Err("Harvester could not be started on existing file: %s, Err: %s", newState.Source, err)
@@ -459,7 +459,7 @@ func (p *Prospector) harvestExistingFile(newState file.State, oldState file.Stat
 
 	// File size was reduced -> truncated file
 	if oldState.Finished && newState.Fileinfo.Size() < oldState.Offset {
-		logp.Debug("prospector", "Old file was truncated. Starting from the beginning: %s", newState.Source)
+		logp.Debug("prospector", "Old file was truncated. Starting from the beginning: %s, offset: %d, new size: %d ", newState.Source, newState.Fileinfo.Size())
 		err := p.startHarvester(newState, 0)
 		if err != nil {
 			logp.Err("Harvester could not be started on truncated file: %s, Err: %s", newState.Source, err)


### PR DESCRIPTION
Right now in case the size changes of a file and it triggers reading a file again, in the debug log its not visibile what the new size is. This should make detecting issues like https://github.com/elastic/beats/issues/5179 easier.