### PR TITLE
Do not clean ignored files in merge_pr script

### DIFF
--- a/dev-tools/merge_pr
+++ b/dev-tools/merge_pr
@@ -25,7 +25,7 @@ def main():
                                       "Continue? [y/n]: ") != "y":
             return 1
         check_call("git reset --hard", shell=True)
-        check_call("git clean -dfx", shell=True)
+        check_call("git clean -df", shell=True)
         check_call("git fetch", shell=True)
 
         check_call("git checkout {}".format(args.from_branch), shell=True)


### PR DESCRIPTION
The merge_pr script did also remove all git ignored files. This lead to issues with the IDE and some of my test files like `filebeat.dev.yml` were also removed. We removed this in the past from cherrypick_pr so I assume its ok to also remove it here.