### PR TITLE
Fix kibana tests

### DIFF
--- a/metricbeat/docker-compose.yml
+++ b/metricbeat/docker-compose.yml
@@ -73,8 +73,6 @@ services:
 
   kibana:
     build: ./module/kibana/_meta
-    depends_on:
-      - elasticsearch
 
   kubernetes:
     build: ./module/kubernetes/_meta


### PR DESCRIPTION
Some jobs fail due to an error resolving `kibana` host on Docker. This PR tries to solve that