### PR TITLE
Ensure docs are build locally just as they are in prod

### DIFF
--- a/script/build_docs.sh
+++ b/script/build_docs.sh
@@ -25,7 +25,7 @@ echo "Index document: ${index}"
 
 dest_dir="$html_dir/${name}"
 mkdir -p "$dest_dir"
-params=""
+params="--chunk=1"
 if [ "$PREVIEW" = "1" ]; then
   params="--chunk=1 -open chunk=1 -open"
 fi


### PR DESCRIPTION
By default all headlines with level 1 (`==`) will get its own page.

When setting `--chunk=1`, all headlines with level 2 (`===`) will get its own page as well and will be shown in the ToC like so:

<img width="353" alt="screen shot 2017-09-19 at 08 58 49" src="https://user-images.githubusercontent.com/10602/30579672-ef19d5cc-9d19-11e7-897d-bb51e2fd2d37.png">
