### PR TITLE
Remove changeme password from the docs

### DIFF
--- a/auditbeat/docs/index.asciidoc
+++ b/auditbeat/docs/index.asciidoc
@@ -2,6 +2,8 @@
 
 include::../../libbeat/docs/version.asciidoc[]
 
+include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
+
 :libbeat: http://www.elastic.co/guide/en/beats/libbeat/{doc-branch}
 :kibana-ref: https://www.elastic.co/guide/en/kibana/{doc-branch}
 :beatsdevguide: http://www.elastic.co/guide/en/beats/devguide/{doc-branch}

--- a/filebeat/docs/index.asciidoc
+++ b/filebeat/docs/index.asciidoc
@@ -2,6 +2,8 @@
 
 include::../../libbeat/docs/version.asciidoc[]
 
+include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
+
 :libbeat: http://www.elastic.co/guide/en/beats/libbeat/{doc-branch}
 :kibana-ref: https://www.elastic.co/guide/en/kibana/{doc-branch}
 :beatsdevguide: http://www.elastic.co/guide/en/beats/devguide/{doc-branch}

--- a/heartbeat/docs/index.asciidoc
+++ b/heartbeat/docs/index.asciidoc
@@ -2,6 +2,8 @@
 
 include::../../libbeat/docs/version.asciidoc[]
 
+include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
+
 :libbeat: http://www.elastic.co/guide/en/beats/libbeat/{doc-branch}
 :kibana-ref: https://www.elastic.co/guide/en/kibana/{doc-branch}
 :beatsdevguide: http://www.elastic.co/guide/en/beats/devguide/{doc-branch}

--- a/libbeat/docs/breaking.asciidoc
+++ b/libbeat/docs/breaking.asciidoc
@@ -119,14 +119,14 @@ following command:
 
 ["source","sh",subs="attributes"]
 ----
-./scripts/import_dashboards -user elastic -pass changeme
+./scripts/import_dashboards -user elastic -pass {pwd}
 ----
 
 Can be replaced with:
 
 ["source","sh",subs="attributes"]
 ----
-./filebeat setup -E "output.elasticsearch.username=elastic" -E "output.elasticsearch.password=changeme"
+./filebeat setup -E "output.elasticsearch.username=elastic" -E "output.elasticsearch.password={pwd}"
 ----
 
 Note that the `-E` flags are only required if the Elasticsearch output is not

--- a/libbeat/docs/index.asciidoc
+++ b/libbeat/docs/index.asciidoc
@@ -3,6 +3,8 @@
 
 include::./version.asciidoc[]
 
+include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
+
 :packetbeat: http://www.elastic.co/guide/en/beats/packetbeat/{doc-branch}
 :metricbeat: http://www.elastic.co/guide/en/beats/metricbeat/{doc-branch}
 :filebeat: http://www.elastic.co/guide/en/beats/filebeat/{doc-branch}

--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -1101,22 +1101,26 @@ output.console:
 [[configure-cloud-id]]
 === Configure the output for the Elastic Cloud
 
+++++
+<titleabbrev>Cloud</titleabbrev>
+++++
+
 {beatname_uc} comes with two settings that simplify the output configuration
 when used together with https://cloud.elastic.co/[Elastic Cloud]. When defined,
 these setting overwrite settings from other parts in the configuration.
 
 Example:
 
-[source,yaml]
+["source","yaml",subs="attributes"]
 ------------------------------------------------------------------------------
 cloud.id: "staging:dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyRjZWM2ZjI2MWE3NGJmMjRjZTMzYmI4ODExYjg0Mjk0ZiRjNmMyY2E2ZDA0MjI0OWFmMGNjN2Q3YTllOTYyNTc0Mw=="
-cloud.auth: "elastic:changeme"
+cloud.auth: "elastic:{pwd}"
 ------------------------------------------------------------------------------
 
 These settings can be also specified at the command line, like this:
 
 
-["source","sh",subs="attributes,callouts"]
+["source","sh",subs="attributes"]
 ------------------------------------------------------------------------------
 {beatname_lc} -e -E cloud.id="<cloud-id>" -E cloud.auth="<cloud.auth>"
 ------------------------------------------------------------------------------

--- a/metricbeat/docs/index.asciidoc
+++ b/metricbeat/docs/index.asciidoc
@@ -2,6 +2,8 @@
 
 include::../../libbeat/docs/version.asciidoc[]
 
+include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
+
 :libbeat: http://www.elastic.co/guide/en/beats/libbeat/{doc-branch}
 :kibana-ref: https://www.elastic.co/guide/en/kibana/{doc-branch}
 :beatsdevguide: http://www.elastic.co/guide/en/beats/devguide/{doc-branch}

--- a/packetbeat/docs/index.asciidoc
+++ b/packetbeat/docs/index.asciidoc
@@ -2,6 +2,8 @@
 
 include::../../libbeat/docs/version.asciidoc[]
 
+include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
+
 :libbeat: http://www.elastic.co/guide/en/beats/libbeat/{doc-branch}
 :kibana-ref: https://www.elastic.co/guide/en/kibana/{doc-branch}
 :beatsdevguide: http://www.elastic.co/guide/en/beats/devguide/{doc-branch}

--- a/winlogbeat/docs/index.asciidoc
+++ b/winlogbeat/docs/index.asciidoc
@@ -2,6 +2,8 @@
 
 include::../../libbeat/docs/version.asciidoc[]
 
+include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
+
 :libbeat: http://www.elastic.co/guide/en/beats/libbeat/{doc-branch}
 :kibana-ref: https://www.elastic.co/guide/en/kibana/{doc-branch}
 :beatsdevguide: http://www.elastic.co/guide/en/beats/devguide/{doc-branch}


### PR DESCRIPTION
The following PR needs to be merged before #5214: https://github.com/elastic/docs/pull/239

I'm including the shared attributes to use the pwd attribute in our docs. However, the paths in our docs are still set in the individual book indexes. We will move to the shared attributes eventually.