### PR TITLE
Clean pkg before vet

### DIFF
--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -103,7 +103,7 @@ crosscompile: $(GOFILES)
 
 .PHONY: check
 check: python-env ## @build Checks project and source code if everything is according to standard
-	@rm -rf ${GOPATH}/pkg/*/github.com/elastic/beats # TODO go 1.9 supports `-source` flag in go vet, remove this in favor of the flag
+	find ${GOPATH}
 	@go vet ${GOPACKAGES}
 	@go get $(GOIMPORTS_REPO)
 	@goimports -local ${GOIMPORTS_LOCAL_PREFIX} -l ${GOFILES_NOVENDOR} | (! grep .) || (echo "Code differs from goimports' style ^" && false)

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -103,6 +103,7 @@ crosscompile: $(GOFILES)
 
 .PHONY: check
 check: python-env ## @build Checks project and source code if everything is according to standard
+	@rm -rf ${GOPATH}/pkg/*/github.com/elastic/beats # TODO go 1.9 supports `-source` flag in go vet, remove this in favor of the flag
 	@go vet ${GOPACKAGES}
 	@go get $(GOIMPORTS_REPO)
 	@goimports -local ${GOIMPORTS_LOCAL_PREFIX} -l ${GOFILES_NOVENDOR} | (! grep .) || (echo "Code differs from goimports' style ^" && false)


### PR DESCRIPTION
This ensure we ignore cached compiled packages when doing vet, some
changes break type checking from the previous version.

In go 1.9 vet has a `-source` flag. From vet doc at https://golang.org/cmd/vet/:

  By default vet uses the object files generated by 'go install
  some/pkg' to typecheck the code. If the -source flag is provided, vet
  uses only source code.`