### PR TITLE
Allow for more than one index file in docs folders.

### DIFF
--- a/script/build_docs.sh
+++ b/script/build_docs.sh
@@ -17,17 +17,19 @@ else
     echo "$docs_dir already exists. Not cloning."
 fi
 
+index_list="$(find ${GOPATH%%:*}/src/$path -name 'index.asciidoc')"
+for index in $index_list
+do
+  echo "Building docs for ${name}..."
+  echo "Index document: ${index}"
+  index_path=$(basename $(dirname $index))
+  echo "Index path: $index_path"
 
-index="${GOPATH%%:*}/src/${path}/index.asciidoc"
-
-echo "Building docs for ${name}..."
-echo "Index document: ${index}"
-
-dest_dir="$html_dir/${name}"
-mkdir -p "$dest_dir"
-params="--chunk=1"
-if [ "$PREVIEW" = "1" ]; then
-  params="--chunk=1 -open chunk=1 -open"
-fi
-$docs_dir/build_docs.pl $params --doc "$index" -out "$dest_dir"
-
+  dest_dir="$html_dir/${name}/${index_path}"
+  mkdir -p "$dest_dir"
+  params="--chunk=1"
+  if [ "$PREVIEW" = "1" ]; then
+    params="--chunk=1 -open chunk=1 -open"
+  fi
+  $docs_dir/build_docs.pl $params --doc "$index" -out "$dest_dir"
+done


### PR DESCRIPTION
In the APM project we have multiple entrypoints for documentation within subdirectories of the docs folder. When running `make docs` locally currently only one of two entry point documents is built. 
This change allows to have multiple `index.asciidoc` documents within the `docs` folder and subdirectories. 