### PR TITLE
Fix flaky reload tests

### DIFF
--- a/metricbeat/tests/system/config/metricbeat.yml.j2
+++ b/metricbeat/tests/system/config/metricbeat.yml.j2
@@ -143,7 +143,7 @@ processors:
 
 queue.mem:
   events: 4096
-  flush.min_events: 8
+  flush.min_events: {{ flush_min_events|default(8) }}
   flush.timeout: 0.1s
 
 #================================ Outputs =====================================

--- a/metricbeat/tests/system/test_reload.py
+++ b/metricbeat/tests/system/test_reload.py
@@ -24,6 +24,7 @@ class Test(metricbeat.BaseTest):
         self.render_config_template(
             reload=True,
             reload_path=self.working_dir + "/configs/*.yml",
+            flush_min_events=1,
         )
         proc = self.start_beat()
 
@@ -49,6 +50,7 @@ class Test(metricbeat.BaseTest):
         self.render_config_template(
             reload=True,
             reload_path=self.working_dir + "/configs/*.yml",
+            flush_min_events=1,
         )
         os.mkdir(self.working_dir + "/configs/")
 


### PR DESCRIPTION
Because of the new publisher, sometimes events were still written to disk after the reloading stopped message. This is fixed by setting the flush size to 1 so events are immidiately flushed.