### PR TITLE
Support influxdb output

### DIFF
--- a/libbeat/outputs/influxdb/client.go
+++ b/libbeat/outputs/influxdb/client.go
@@ -1,0 +1,203 @@
+package influxdb
+
+import (
+	"time"
+  "fmt"
+  influxdb "github.com/influxdata/influxdb/client/v2"
+
+	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/outputs"
+	"github.com/elastic/beats/libbeat/publisher"
+)
+
+type client struct {
+	conn   influxdb.Client
+	stats    *outputs.Stats
+  addr     string
+  username        string
+	password        string
+	db       string
+	measurement     string
+	timePrecision   string
+  tagFields      []string
+  tagFieldsHash  map[string]int
+  timeField       string
+}
+
+
+
+func newClient(
+	stats *outputs.Stats,
+  addr string,
+  user string,
+	pass string,
+	db string, 
+	measurement string,
+  timePrecision string,
+  tagFields []string,
+  timeField string,
+) *client {
+
+  hash := make(map[string]int)
+  for _, f := range tagFields {
+    if f != "" {
+      hash[f] = 1
+    }
+  }
+  
+	return &client{
+		stats:    stats,
+    addr:     addr,
+    username: user,
+		password: pass,
+		db:       db,
+    measurement: measurement,
+    timePrecision: timePrecision,
+    tagFields: tagFields,
+    tagFieldsHash: hash,
+    timeField: timeField,
+	}
+}
+
+func (c *client) Connect() error {
+  var err error
+	debugf("connect")
+
+	c.conn, err = influxdb.NewHTTPClient(influxdb.HTTPConfig{
+    Addr: c.addr,
+    Username: c.username,
+    Password: c.password,
+  })
+  if err != nil {
+			logp.Err("Failed to create HTTP conn to influxdb: %v", err)
+      return err
+  }
+
+	logp.Info("Client to influxdb has created: %v", c.addr)
+  
+	return err
+}
+
+
+func (c *client) Close() error {
+	debugf("close connection")
+  return c.conn.Close()
+}
+
+func (c *client) Publish(batch publisher.Batch) error {
+	if c == nil {
+		panic("no client")
+	}
+	if batch == nil {
+		panic("no batch")
+	}
+
+	events := batch.Events()
+	c.stats.NewBatch(len(events))
+	rest, err := c.publish(events)
+	if rest != nil {
+		c.stats.Failed(len(rest))
+		batch.RetryEvents(rest)
+	}
+	return err
+}
+
+
+func (c *client) publish(data []publisher.Event) ([]publisher.Event, error) {
+  var err error
+
+	okEvents, serialized := c.serializeEvents(data)
+	// logp.Info("Number of points: %v", len(serialized))
+
+	c.stats.Dropped(len(data) - len(okEvents))
+
+	if (len(serialized)) == 0 {
+		return nil, nil
+	}
+
+
+  bp, _ := influxdb.NewBatchPoints(influxdb.BatchPointsConfig{
+     Database:  c.db,
+     Precision: c.timePrecision,
+  })
+
+
+  for i := 0; i < len(serialized); i++ {
+    pt := serialized[i]
+    bp.AddPoint(pt)
+  }
+
+  err = c.conn.Write(bp)
+
+
+	if err != nil {
+		logp.Err("Failed to write to influxdb: %v", err)
+		return okEvents, err
+
+	}
+
+	c.stats.Acked(len(okEvents))
+	return nil, nil
+}
+
+func (c *client) scanFields(originFields map[string]interface{}) (map[string]string, map[string]interface{}) {
+  tags := make(map[string]string)
+  fields := make(map[string]interface{})
+  
+  for k, _ := range originFields {
+    _, ok := c.tagFieldsHash[k]
+    if !ok {
+      fields[k] = originFields[k]
+      continue
+    }
+
+    // This field is a tag, need to check wether is a string 
+    switch v := originFields[k].(type) {
+      case string:
+        tags[k] = v
+      case int, int8, int16, int32, int64:
+        tags[k] = fmt.Sprintf("%d", v)
+      default:
+        logp.Warn("Unsupported tag type: %v(%T)", v, v)
+    }
+  }
+
+  return tags, fields
+
+}
+
+
+func (c *client) serializeEvents(
+	data []publisher.Event,
+) ([]publisher.Event, []*influxdb.Point) {
+  i := 0
+	succeeded := data
+	to := make([]*influxdb.Point, 0, len(data))
+  
+
+	for _, d := range data {
+    t := d.Content.Timestamp
+    if timestamp,ok := d.Content.Fields[c.timeField]; ok {
+      if v, ok := timestamp.(int64); ok {
+        t = time.Unix(v, 0)
+      }
+    }
+
+    tags, fields := c.scanFields(d.Content.Fields)
+
+		point, err := influxdb.NewPoint(c.measurement, tags, fields, t)
+		if err != nil {
+			logp.Err("Encoding event failed with error: %v", err)
+			goto failLoop
+		}
+
+		to = append(to, point)
+		i++
+	}
+	return succeeded, to
+
+failLoop:
+	succeeded = data[:i]
+	// rest := data[i+1:]
+	return succeeded, to
+}

--- a/libbeat/outputs/influxdb/client.go
+++ b/libbeat/outputs/influxdb/client.go
@@ -2,8 +2,8 @@ package influxdb
 
 import (
 	"time"
-  "fmt"
-  influxdb "github.com/influxdata/influxdb/client/v2"
+ 	"fmt"
+ 	influxdb "github.com/influxdata/influxdb/client/v2"
 
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/outputs"
@@ -13,65 +13,65 @@ import (
 type client struct {
 	conn   influxdb.Client
 	stats    *outputs.Stats
-  addr     string
-  username        string
+ 	addr     string
+ 	username        string
 	password        string
 	db       string
 	measurement     string
 	timePrecision   string
-  tagFields      []string
-  tagFieldsHash  map[string]int
-  timeField       string
+ 	tagFields      []string
+ 	tagFieldsHash  map[string]int
+ 	timeField       string
 }
 
 
 
 func newClient(
 	stats *outputs.Stats,
-  addr string,
-  user string,
+ 	addr string,
+ 	user string,
 	pass string,
 	db string, 
 	measurement string,
-  timePrecision string,
-  tagFields []string,
-  timeField string,
+ 	timePrecision string,
+ 	tagFields []string,
+ 	timeField string,
 ) *client {
 
-  hash := make(map[string]int)
-  for _, f := range tagFields {
-    if f != "" {
-      hash[f] = 1
-    }
-  }
+ 	hash := make(map[string]int)
+ 	for _, f := range tagFields {
+ 		if f != "" {
+ 			hash[f] = 1
+ 		}
+ 	}
   
 	return &client{
 		stats:    stats,
-    addr:     addr,
-    username: user,
+ 		addr:     addr,
+ 		username: user,
 		password: pass,
 		db:       db,
-    measurement: measurement,
-    timePrecision: timePrecision,
-    tagFields: tagFields,
-    tagFieldsHash: hash,
-    timeField: timeField,
+ 		measurement: measurement,
+ 		timePrecision: timePrecision,
+ 		tagFields: tagFields,
+ 		tagFieldsHash: hash,
+ 		timeField: timeField,
 	}
 }
 
 func (c *client) Connect() error {
-  var err error
+ 	var err error
 	debugf("connect")
 
 	c.conn, err = influxdb.NewHTTPClient(influxdb.HTTPConfig{
-    Addr: c.addr,
-    Username: c.username,
-    Password: c.password,
-  })
-  if err != nil {
-			logp.Err("Failed to create HTTP conn to influxdb: %v", err)
-      return err
-  }
+		Addr: c.addr,
+		Username: c.username,
+		Password: c.password,
+	})
+ 	if err != nil {
+		logp.Err("Failed to create HTTP conn to influxdb: %v", err)
+      		return err
+ 	}
 
 	logp.Info("Client to influxdb has created: %v", c.addr)
   
@@ -104,7 +104,7 @@ func (c *client) Publish(batch publisher.Batch) error {
 
 
 func (c *client) publish(data []publisher.Event) ([]publisher.Event, error) {
-  var err error
+ 	var err error
 
 	okEvents, serialized := c.serializeEvents(data)
 	// logp.Info("Number of points: %v", len(serialized))
@@ -116,18 +116,18 @@ func (c *client) publish(data []publisher.Event) ([]publisher.Event, error) {
 	}
 
 
-  bp, _ := influxdb.NewBatchPoints(influxdb.BatchPointsConfig{
-     Database:  c.db,
-     Precision: c.timePrecision,
-  })
+ 	bp, _ := influxdb.NewBatchPoints(influxdb.BatchPointsConfig{
+ 		Database:  c.db,
+ 		Precision: c.timePrecision,
+	})
 
 
-  for i := 0; i < len(serialized); i++ {
-    pt := serialized[i]
-    bp.AddPoint(pt)
-  }
+ 	for i := 0; i < len(serialized); i++ {
+		pt := serialized[i]
+		bp.AddPoint(pt)
+	}
 
-  err = c.conn.Write(bp)
+	err = c.conn.Write(bp)
 
 
 	if err != nil {
@@ -141,28 +141,28 @@ func (c *client) publish(data []publisher.Event) ([]publisher.Event, error) {
 }
 
 func (c *client) scanFields(originFields map[string]interface{}) (map[string]string, map[string]interface{}) {
-  tags := make(map[string]string)
-  fields := make(map[string]interface{})
+	tags := make(map[string]string)
+	fields := make(map[string]interface{})
   
-  for k, _ := range originFields {
-    _, ok := c.tagFieldsHash[k]
-    if !ok {
-      fields[k] = originFields[k]
-      continue
-    }
+	for k, _ := range originFields {
+		_, ok := c.tagFieldsHash[k]
+		if !ok {
+			fields[k] = originFields[k]
+			continue
+		}
 
-    // This field is a tag, need to check wether is a string 
-    switch v := originFields[k].(type) {
-      case string:
-        tags[k] = v
-      case int, int8, int16, int32, int64:
-        tags[k] = fmt.Sprintf("%d", v)
-      default:
-        logp.Warn("Unsupported tag type: %v(%T)", v, v)
-    }
-  }
+		// This field is a tag, need to check wether is a string 
+		switch v := originFields[k].(type) {
+		case string:
+			tags[k] = v
+		case int, int8, int16, int32, int64:
+			tags[k] = fmt.Sprintf("%d", v)
+		default:
+        		logp.Warn("Unsupported tag type: %v(%T)", v, v)
+		}
+	}
 
-  return tags, fields
+	return tags, fields
 
 }
 
@@ -170,33 +170,34 @@ func (c *client) scanFields(originFields map[string]interface{}) (map[string]str
 func (c *client) serializeEvents(
 	data []publisher.Event,
 ) ([]publisher.Event, []*influxdb.Point) {
-  i := 0
+	i := 0
 	succeeded := data
 	to := make([]*influxdb.Point, 0, len(data))
   
 
 	for _, d := range data {
-    t := d.Content.Timestamp
-    if timestamp,ok := d.Content.Fields[c.timeField]; ok {
-      if v, ok := timestamp.(int64); ok {
-        t = time.Unix(v, 0)
-      }
-    }
-
-    tags, fields := c.scanFields(d.Content.Fields)
-
-		point, err := influxdb.NewPoint(c.measurement, tags, fields, t)
-		if err != nil {
-			logp.Err("Encoding event failed with error: %v", err)
-			goto failLoop
+	t := d.Content.Timestamp
+	if timestamp,ok := d.Content.Fields[c.timeField]; ok {
+		if v, ok := timestamp.(int64); ok {
+			t = time.Unix(v, 0)
 		}
+	}
 
-		to = append(to, point)
+	tags, fields := c.scanFields(d.Content.Fields)
+
+	point, err := influxdb.NewPoint(c.measurement, tags, fields, t)
+	if err != nil {
+		logp.Err("Encoding event failed with error: %v", err)
+		goto end
+	}
+
+	to = append(to, point)
 		i++
 	}
+
 	return succeeded, to
 
-failLoop:
+end:
 	succeeded = data[:i]
 	// rest := data[i+1:]
 	return succeeded, to

--- a/libbeat/outputs/influxdb/client.go
+++ b/libbeat/outputs/influxdb/client.go
@@ -11,17 +11,17 @@ import (
 )
 
 type client struct {
-	conn   influxdb.Client
-	stats    *outputs.Stats
- 	addr     string
+	conn  		influxdb.Client
+	stats  		*outputs.Stats
+ 	addr		string
  	username        string
 	password        string
-	db       string
+	db		string
 	measurement     string
 	timePrecision   string
- 	tagFields      []string
- 	tagFieldsHash  map[string]int
- 	timeField       string
+ 	tagFields	[]string
+ 	tagFieldsHash	map[string]int
+ 	timeField	string
 }
 
 
@@ -81,7 +81,7 @@ func (c *client) Connect() error {
 
 func (c *client) Close() error {
 	debugf("close connection")
-  return c.conn.Close()
+	return c.conn.Close()
 }
 
 func (c *client) Publish(batch publisher.Batch) error {

--- a/libbeat/outputs/influxdb/config.go
+++ b/libbeat/outputs/influxdb/config.go
@@ -1,0 +1,35 @@
+package influxdb
+
+import (
+	"github.com/elastic/beats/libbeat/outputs"
+)
+
+type influxdbConfig struct {
+	Username    string                `config:"username"`
+	Password    string                `config:"password"`
+	Addr        string                `config:"addr"`
+	BulkMaxSize int                   `config:"bulk_max_size"`
+	MaxRetries  int                   `config:"max_retries"`
+	TLS         *outputs.TLSConfig    `config:"ssl"`
+	Db          string                `config:"db"`
+	Measurement string                `config:"measurement"`
+  TimePrecision string              `config:"time_precision"`
+  SendAsTags  []string              `config:"send_as_tags"` 
+  SendAsTime  string                `config:"send_as_time"` 
+}
+
+var (
+	defaultConfig = influxdbConfig{
+		Addr:        "http://localhost:8086",
+		MaxRetries:  3,
+		TLS:         nil,
+		Db:          "test_db",
+    Measurement: "test",
+    TimePrecision: "s",
+    BulkMaxSize: 2048,
+	}
+)
+
+func (c *influxdbConfig) Validate() error {
+	return nil
+}

--- a/libbeat/outputs/influxdb/config.go
+++ b/libbeat/outputs/influxdb/config.go
@@ -13,9 +13,9 @@ type influxdbConfig struct {
 	TLS         *outputs.TLSConfig    `config:"ssl"`
 	Db          string                `config:"db"`
 	Measurement string                `config:"measurement"`
-  TimePrecision string              `config:"time_precision"`
-  SendAsTags  []string              `config:"send_as_tags"` 
-  SendAsTime  string                `config:"send_as_time"` 
+ 	TimePrecision string              `config:"time_precision"`
+ 	SendAsTags  []string              `config:"send_as_tags"` 
+ 	SendAsTime  string                `config:"send_as_time"` 
 }
 
 var (
@@ -24,9 +24,9 @@ var (
 		MaxRetries:  3,
 		TLS:         nil,
 		Db:          "test_db",
-    Measurement: "test",
-    TimePrecision: "s",
-    BulkMaxSize: 2048,
+ 		Measurement: "test",
+ 		TimePrecision: "s",
+ 		BulkMaxSize: 2048,
 	}
 )
 

--- a/libbeat/outputs/influxdb/influxdb.go
+++ b/libbeat/outputs/influxdb/influxdb.go
@@ -26,7 +26,7 @@ func makeInfluxdb(
 	stats *outputs.Stats,
 	cfg *common.Config,
 ) (outputs.Group, error) {
-  var err error
+	var err error
 	config := defaultConfig
 	if err = cfg.Unpack(&config); err != nil {
 		return outputs.Fail(err)
@@ -39,8 +39,8 @@ func makeInfluxdb(
 	}
 
 
-  client := newClient(stats, config.Addr, config.Username, config.Password, 
-      config.Db, config.Measurement, config.TimePrecision, config.SendAsTags, config.SendAsTime)
+	client := newClient(stats, config.Addr, config.Username, config.Password, 
+	   config.Db, config.Measurement, config.TimePrecision, config.SendAsTags, config.SendAsTime)
 
 	return outputs.Success(config.BulkMaxSize, config.MaxRetries, client)
 }

--- a/libbeat/outputs/influxdb/influxdb.go
+++ b/libbeat/outputs/influxdb/influxdb.go
@@ -15,17 +15,6 @@ type influxdbOut struct {
 
 var debugf = logp.MakeDebug("influxdb")
 
-const (
-	defaultWaitRetry    = 1 * time.Second
-	defaultMaxWaitRetry = 60 * time.Second
-)
-
-
-type fieldRole int
-const (
-  fieldRoleTag = iota
-  fieldRoleTime = iota
-)
 
 func init() {
 	outputs.RegisterType("influxdb", makeInfluxdb)

--- a/libbeat/outputs/influxdb/influxdb.go
+++ b/libbeat/outputs/influxdb/influxdb.go
@@ -1,0 +1,57 @@
+package influxdb
+
+import (
+	"time"
+
+	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/outputs"
+)
+
+type influxdbOut struct {
+	beat beat.Info
+}
+
+var debugf = logp.MakeDebug("influxdb")
+
+const (
+	defaultWaitRetry    = 1 * time.Second
+	defaultMaxWaitRetry = 60 * time.Second
+)
+
+
+type fieldRole int
+const (
+  fieldRoleTag = iota
+  fieldRoleTime = iota
+)
+
+func init() {
+	outputs.RegisterType("influxdb", makeInfluxdb)
+}
+
+
+func makeInfluxdb(
+	beat beat.Info,
+	stats *outputs.Stats,
+	cfg *common.Config,
+) (outputs.Group, error) {
+  var err error
+	config := defaultConfig
+	if err = cfg.Unpack(&config); err != nil {
+		return outputs.Fail(err)
+	}
+
+
+	_, err = outputs.LoadTLSConfig(config.TLS)
+	if err != nil {
+		return outputs.Fail(err)
+	}
+
+
+  client := newClient(stats, config.Addr, config.Username, config.Password, 
+      config.Db, config.Measurement, config.TimePrecision, config.SendAsTags, config.SendAsTime)
+
+	return outputs.Success(config.BulkMaxSize, config.MaxRetries, client)
+}

--- a/libbeat/outputs/influxdb/influxdb.go
+++ b/libbeat/outputs/influxdb/influxdb.go
@@ -1,8 +1,6 @@
 package influxdb
 
 import (
-	"time"
-
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"

--- a/libbeat/publisher/includes/includes.go
+++ b/libbeat/publisher/includes/includes.go
@@ -8,6 +8,7 @@ import (
 	_ "github.com/elastic/beats/libbeat/outputs/kafka"
 	_ "github.com/elastic/beats/libbeat/outputs/logstash"
 	_ "github.com/elastic/beats/libbeat/outputs/redis"
+	_ "github.com/elastic/beats/libbeat/outputs/influxdb"
 
 	// load support output codec
 	_ "github.com/elastic/beats/libbeat/outputs/codec/format"


### PR DESCRIPTION
Support influxdb output, example configure like this:

```
output.influxdb:                                                                                                           
  enabled: true
  addr: 'http://10.190.200.154:8086'
  username: 'root'
  password: 'root'
  db: 'rdp_test_db'
  measurement: 'metrics'
  # These fields will be send as tags
  send_as_tags: ["endpoint", "metricName"]
  # This field will be used as time of the datapoint  
  send_as_time: "timestamp"
  time_precision: 's' 
```