### PR TITLE
Cherry-pick #5157 to master: Update outputconfig.asciidoc

### DIFF
--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -14,7 +14,8 @@
 == Configure the output
 
 You configure {beatname_uc} to write to a specific output by setting options
-in the `output` section of the +{beatname_lc}.yml+ config file.
+in the `output` section of the +{beatname_lc}.yml+ config file. Only a single
+output may be defined.
 
 The following topics describe how to configure each supported output:
 


### PR DESCRIPTION
Cherry-pick of PR #5157 to master branch. Original message: 

Made it clear that we only support a single output config directive.

Only applies from 6.0 onwards.