### PR TITLE
Cherry-pick #5189 to 6.0: cms_get and cmd_set mixed up in memcached module

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -35,20 +35,11 @@ https://github.com/elastic/beats/compare/v6.0.0-rc1...master[Check the HEAD diff
 *Filebeat*
 
 *Filebeat*
-- Fix default paths for redis 4.0.1 logs on macOS {pull}5173[5173]
 
 *Heartbeat*
 
 *Metricbeat*
 
-- Support `npipe` protocol (Windows) in Docker module. {pull}4751[4751]
-- Added missing mongodb configuration file to the `modules.d` folder. {pull}4870[4870]
-- Fix wrong MySQL CRUD queries timelion visualization {pull}4857[4857]
-- Add new metrics to CPU metricsset {pull}4969[4969]
-- Fix a memory allocation issue where more memory was allocated than needed in the windows-perfmon metricset. {issue}5035[5035]
-- Don't start metricbeat if external modules config is wrong and reload is disabled {pull}5053[5053]
-- Fix kubernetes events module to be able to index time fields properly. {issue}5093[5093]
-- The MongoDB module now connects on each fetch, to avoid stopping the whole Metricbeat instance if MongoDB is not up when starting. {pull}5120[5120]
 - Fixed `cmd_set` and `cmd_get` being mixed in the Memcache module. {pull}5189[5189]
 
 *Packetbeat*

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -35,10 +35,21 @@ https://github.com/elastic/beats/compare/v6.0.0-rc1...master[Check the HEAD diff
 *Filebeat*
 
 *Filebeat*
+- Fix default paths for redis 4.0.1 logs on macOS {pull}5173[5173]
 
 *Heartbeat*
 
 *Metricbeat*
+
+- Support `npipe` protocol (Windows) in Docker module. {pull}4751[4751]
+- Added missing mongodb configuration file to the `modules.d` folder. {pull}4870[4870]
+- Fix wrong MySQL CRUD queries timelion visualization {pull}4857[4857]
+- Add new metrics to CPU metricsset {pull}4969[4969]
+- Fix a memory allocation issue where more memory was allocated than needed in the windows-perfmon metricset. {issue}5035[5035]
+- Don't start metricbeat if external modules config is wrong and reload is disabled {pull}5053[5053]
+- Fix kubernetes events module to be able to index time fields properly. {issue}5093[5093]
+- The MongoDB module now connects on each fetch, to avoid stopping the whole Metricbeat instance if MongoDB is not up when starting. {pull}5120[5120]
+- Fixed `cmd_set` and `cmd_get` being mixed in the Memcache module. {pull}5189[5189]
 
 *Packetbeat*
 

--- a/metricbeat/module/memcached/stats/data.go
+++ b/metricbeat/module/memcached/stats/data.go
@@ -21,8 +21,8 @@ var (
 			"misses": c.Int("get_misses"),
 		},
 		"cmd": s.Object{
-			"get": c.Int("cmd_set"),
-			"set": c.Int("cmd_get"),
+			"get": c.Int("cmd_get"),
+			"set": c.Int("cmd_set"),
 		},
 		"read": s.Object{
 			"bytes": c.Int("bytes_read"),


### PR DESCRIPTION
Cherry-pick of PR #5189 to 6.0 branch. Original message: 

I just created this here and thought to look at the code.

https://discuss.elastic.co/t/metricbeat-memcached-module-seems-to-mix-up-memcached-stats-cmd-get-and-memcached-stats-cmd-set/100732