### PR TITLE
Cherry-pick #5193 to 6.0: Remove multiple output comment from config

### DIFF
--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -190,8 +190,7 @@ auditbeat.modules:
 
 #================================ Outputs ======================================
 
-# Configure what outputs to use when sending the data collected by the beat.
-# Multiple outputs may be used.
+# Configure what output to use when sending the data collected by the beat.
 
 #-------------------------- Elasticsearch output -------------------------------
 output.elasticsearch:

--- a/auditbeat/auditbeat.yml
+++ b/auditbeat/auditbeat.yml
@@ -90,8 +90,7 @@ setup.kibana:
 
 #================================ Outputs =====================================
 
-# Configure what outputs to use when sending the data collected by the beat.
-# Multiple outputs may be used.
+# Configure what output to use when sending the data collected by the beat.
 
 #-------------------------- Elasticsearch output ------------------------------
 output.elasticsearch:

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -581,8 +581,7 @@ filebeat.prospectors:
 
 #================================ Outputs ======================================
 
-# Configure what outputs to use when sending the data collected by the beat.
-# Multiple outputs may be used.
+# Configure what output to use when sending the data collected by the beat.
 
 #-------------------------- Elasticsearch output -------------------------------
 output.elasticsearch:

--- a/filebeat/filebeat.yml
+++ b/filebeat/filebeat.yml
@@ -137,8 +137,7 @@ setup.kibana:
 
 #================================ Outputs =====================================
 
-# Configure what outputs to use when sending the data collected by the beat.
-# Multiple outputs may be used.
+# Configure what output to use when sending the data collected by the beat.
 
 #-------------------------- Elasticsearch output ------------------------------
 output.elasticsearch:

--- a/heartbeat/heartbeat.reference.yml
+++ b/heartbeat/heartbeat.reference.yml
@@ -339,8 +339,7 @@ heartbeat.scheduler:
 
 #================================ Outputs ======================================
 
-# Configure what outputs to use when sending the data collected by the beat.
-# Multiple outputs may be used.
+# Configure what output to use when sending the data collected by the beat.
 
 #-------------------------- Elasticsearch output -------------------------------
 output.elasticsearch:

--- a/heartbeat/heartbeat.yml
+++ b/heartbeat/heartbeat.yml
@@ -84,8 +84,7 @@ setup.kibana:
 
 #================================ Outputs =====================================
 
-# Configure what outputs to use when sending the data collected by the beat.
-# Multiple outputs may be used.
+# Configure what output to use when sending the data collected by the beat.
 
 #-------------------------- Elasticsearch output ------------------------------
 output.elasticsearch:

--- a/libbeat/_meta/config.reference.yml
+++ b/libbeat/_meta/config.reference.yml
@@ -125,8 +125,7 @@
 
 #================================ Outputs ======================================
 
-# Configure what outputs to use when sending the data collected by the beat.
-# Multiple outputs may be used.
+# Configure what output to use when sending the data collected by the beat.
 
 #-------------------------- Elasticsearch output -------------------------------
 output.elasticsearch:

--- a/libbeat/_meta/config.yml
+++ b/libbeat/_meta/config.yml
@@ -54,8 +54,7 @@ setup.kibana:
 
 #================================ Outputs =====================================
 
-# Configure what outputs to use when sending the data collected by the beat.
-# Multiple outputs may be used.
+# Configure what output to use when sending the data collected by the beat.
 
 #-------------------------- Elasticsearch output ------------------------------
 output.elasticsearch:

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -545,8 +545,7 @@ metricbeat.modules:
 
 #================================ Outputs ======================================
 
-# Configure what outputs to use when sending the data collected by the beat.
-# Multiple outputs may be used.
+# Configure what output to use when sending the data collected by the beat.
 
 #-------------------------- Elasticsearch output -------------------------------
 output.elasticsearch:

--- a/metricbeat/metricbeat.yml
+++ b/metricbeat/metricbeat.yml
@@ -81,8 +81,7 @@ setup.kibana:
 
 #================================ Outputs =====================================
 
-# Configure what outputs to use when sending the data collected by the beat.
-# Multiple outputs may be used.
+# Configure what output to use when sending the data collected by the beat.
 
 #-------------------------- Elasticsearch output ------------------------------
 output.elasticsearch:

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -577,8 +577,7 @@ packetbeat.protocols:
 
 #================================ Outputs ======================================
 
-# Configure what outputs to use when sending the data collected by the beat.
-# Multiple outputs may be used.
+# Configure what output to use when sending the data collected by the beat.
 
 #-------------------------- Elasticsearch output -------------------------------
 output.elasticsearch:

--- a/packetbeat/packetbeat.yml
+++ b/packetbeat/packetbeat.yml
@@ -155,8 +155,7 @@ setup.kibana:
 
 #================================ Outputs =====================================
 
-# Configure what outputs to use when sending the data collected by the beat.
-# Multiple outputs may be used.
+# Configure what output to use when sending the data collected by the beat.
 
 #-------------------------- Elasticsearch output ------------------------------
 output.elasticsearch:

--- a/winlogbeat/winlogbeat.reference.yml
+++ b/winlogbeat/winlogbeat.reference.yml
@@ -154,8 +154,7 @@ winlogbeat.event_logs:
 
 #================================ Outputs ======================================
 
-# Configure what outputs to use when sending the data collected by the beat.
-# Multiple outputs may be used.
+# Configure what output to use when sending the data collected by the beat.
 
 #-------------------------- Elasticsearch output -------------------------------
 output.elasticsearch:

--- a/winlogbeat/winlogbeat.yml
+++ b/winlogbeat/winlogbeat.yml
@@ -85,8 +85,7 @@ setup.kibana:
 
 #================================ Outputs =====================================
 
-# Configure what outputs to use when sending the data collected by the beat.
-# Multiple outputs may be used.
+# Configure what output to use when sending the data collected by the beat.
 
 #-------------------------- Elasticsearch output ------------------------------
 output.elasticsearch:


### PR DESCRIPTION
Cherry-pick of PR #5193 to 6.0 branch. Original message: 

Remove comment stating that multiple outputs can be used.