### PR TITLE
Close changelog 5.6.2

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -8,7 +8,7 @@
 // Template, add newest changes here
 
 === Beats version HEAD
-https://github.com/elastic/beats/compare/v5.6.1...master[Check the HEAD diff]
+https://github.com/elastic/beats/compare/v5.6.2...5.6[Check the HEAD diff]
 
 ==== Breaking changes
 
@@ -81,6 +81,12 @@ https://github.com/elastic/beats/compare/v5.6.1...master[Check the HEAD diff]
 *Winlogbeat*
 
 ////////////////////////////////////////////////////////////
+
+[[release-notes-5.6.2]]
+=== Beats version 5.6.2
+https://github.com/elastic/beats/compare/v5.6.1...v5.6.2[View commits]
+
+No changes in this release.
 
 [[release-notes-5.6.1]]
 === Beats version 5.6.1

--- a/libbeat/docs/release.asciidoc
+++ b/libbeat/docs/release.asciidoc
@@ -6,6 +6,8 @@
 --
 This section summarizes the changes in each release.
 
+* <<release-notes-5.6.2>>
+* <<release-notes-5.6.1>>
 * <<release-notes-5.6.0>>
 * <<release-notes-5.5.3>>
 * <<release-notes-5.5.2>>

--- a/libbeat/docs/version.asciidoc
+++ b/libbeat/docs/version.asciidoc
@@ -1,4 +1,4 @@
-:stack-version: 5.6.1
+:stack-version: 5.6.2
 :doc-branch: 5.6
 :go-version: 1.7.6
 :release-state: released

--- a/testing/environments/args.yml
+++ b/testing/environments/args.yml
@@ -6,4 +6,4 @@ services:
     build:
       args:
         DOWNLOAD_URL: https://snapshots.elastic.co/downloads
-        ELASTIC_VERSION: 5.6.1-SNAPSHOT
+        ELASTIC_VERSION: 5.6.2-SNAPSHOT


### PR DESCRIPTION
This closes the (empty) changelog for 5.6.2, and also updates the testing
env and the docs version.