### PR TITLE
Autodiscover

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -108,6 +108,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Remove error log from runnerfactory as error is returned by API. {pull}5085[5085]
 - Add Kubernetes manifests to deploy Filebeat. {pull}5349[5349]
 - Add experimental Docker `json-file` prospector . {pull}5402[5402]
+- Add experimental Docker autodiscover functionality. {pull}5245[5245]
 
 *Heartbeat*
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -127,6 +127,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Add ceph osd tree infomation to metricbeat {pull}5498[5498]
 - Add basic Logstash module. {pull}5540[5540]
 - Add dashboard for Windows service metricset. {pull}5603[5603]
+- Add experimental Docker autodiscover functionality. {pull}5245[5245]
 
 *Packetbeat*
 

--- a/filebeat/_meta/common.reference.p2.yml
+++ b/filebeat/_meta/common.reference.p2.yml
@@ -238,6 +238,23 @@ filebeat.prospectors:
   # Maximum size of the message received over UDP
   #max_message_size: 10240
 
+#========================== Filebeat autodiscover ==============================
+
+# Autodiscover allows you to detect changes in the system and spawn new modules
+# or prospectors as they happen.
+
+#filebeat.autodiscover:
+  # List of enabled autodiscover providers
+#  providers:
+#    - type: docker
+#      templates:
+#        - condition:
+#            equals.docker.container.image: busybox
+#          config:
+#            - type: log
+#              paths:
+#                - /var/lib/docker/containers/${data.docker.container.id}/*.log
+
 #========================= Filebeat global options ============================
 
 # Name of the registry file. If a relative path is used, it is considered relative to the

--- a/filebeat/beater/autodiscover.go
+++ b/filebeat/beater/autodiscover.go
@@ -1,0 +1,56 @@
+package beater
+
+import (
+	"errors"
+
+	"github.com/elastic/beats/libbeat/cfgfile"
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/bus"
+)
+
+// AutodiscoverAdapter for Filebeat modules & prospectors
+type AutodiscoverAdapter struct {
+	prospectorFactory cfgfile.RunnerFactory
+	moduleFactory     cfgfile.RunnerFactory
+}
+
+// NewAutodiscoverAdapter builds and returns an autodiscover adapter for Filebeat modules & prospectors
+func NewAutodiscoverAdapter(prospectorFactory, moduleFactory cfgfile.RunnerFactory) *AutodiscoverAdapter {
+	return &AutodiscoverAdapter{
+		prospectorFactory: prospectorFactory,
+		moduleFactory:     moduleFactory,
+	}
+}
+
+// CreateConfig generates a valid list of configs from the given event, the received event will have all keys defined by `StartFilter`
+func (m *AutodiscoverAdapter) CreateConfig(e bus.Event) ([]*common.Config, error) {
+	config, ok := e["config"].([]*common.Config)
+	if !ok {
+		return nil, errors.New("Got a wrong value in event `config` key")
+	}
+	return config, nil
+}
+
+// CheckConfig tests given config to check if it will work or not, returns errors in case it won't work
+func (m *AutodiscoverAdapter) CheckConfig(c *common.Config) error {
+	// TODO implment config check for all modules
+	return nil
+}
+
+// Create a module or prospector from the given config
+func (m *AutodiscoverAdapter) Create(c *common.Config, meta *common.MapStrPointer) (cfgfile.Runner, error) {
+	if c.HasField("module") {
+		return m.moduleFactory.Create(c, meta)
+	}
+	return m.prospectorFactory.Create(c, meta)
+}
+
+// StartFilter returns the bus filter to retrieve runner start triggering events
+func (m *AutodiscoverAdapter) StartFilter() []string {
+	return []string{"start", "config"}
+}
+
+// StopFilter returns the bus filter to retrieve runner stop triggering events
+func (m *AutodiscoverAdapter) StopFilter() []string {
+	return []string{"stop", "config"}
+}

--- a/filebeat/channel/factory.go
+++ b/filebeat/channel/factory.go
@@ -67,7 +67,7 @@ func NewOutletFactory(
 // Prospectors and all harvesters use the same pipeline client instance.
 // This guarantees ordering between events as required by the registrar for
 // file.State updates
-func (f *OutletFactory) Create(cfg *common.Config) (Outleter, error) {
+func (f *OutletFactory) Create(cfg *common.Config, dynFields *common.MapStrPointer) (Outleter, error) {
 	config := prospectorOutletConfig{}
 	if err := cfg.Unpack(&config); err != nil {
 		return nil, err
@@ -104,6 +104,7 @@ func (f *OutletFactory) Create(cfg *common.Config) (Outleter, error) {
 	client, err := f.pipeline.ConnectWith(beat.ClientConfig{
 		PublishMode:   beat.GuaranteedSend,
 		EventMetadata: config.EventMetadata,
+		DynamicFields: dynFields,
 		Meta:          meta,
 		Fields:        fields,
 		Processor:     processors,

--- a/filebeat/channel/interface.go
+++ b/filebeat/channel/interface.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Factory is used to create a new Outlet instance
-type Factory func(*common.Config) (Outleter, error)
+type Factory func(*common.Config, *common.MapStrPointer) (Outleter, error)
 
 // Outleter is the outlet for a prospector
 type Outleter interface {

--- a/filebeat/config/config.go
+++ b/filebeat/config/config.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/elastic/beats/libbeat/autodiscover"
 	"github.com/elastic/beats/libbeat/cfgfile"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/cfgwarn"
@@ -20,14 +21,15 @@ const (
 )
 
 type Config struct {
-	Prospectors      []*common.Config `config:"prospectors"`
-	RegistryFile     string           `config:"registry_file"`
-	RegistryFlush    time.Duration    `config:"registry_flush"`
-	ConfigDir        string           `config:"config_dir"`
-	ShutdownTimeout  time.Duration    `config:"shutdown_timeout"`
-	Modules          []*common.Config `config:"modules"`
-	ConfigProspector *common.Config   `config:"config.prospectors"`
-	ConfigModules    *common.Config   `config:"config.modules"`
+	Prospectors      []*common.Config     `config:"prospectors"`
+	RegistryFile     string               `config:"registry_file"`
+	RegistryFlush    time.Duration        `config:"registry_flush"`
+	ConfigDir        string               `config:"config_dir"`
+	ShutdownTimeout  time.Duration        `config:"shutdown_timeout"`
+	Modules          []*common.Config     `config:"modules"`
+	ConfigProspector *common.Config       `config:"config.prospectors"`
+	ConfigModules    *common.Config       `config:"config.modules"`
+	Autodiscover     *autodiscover.Config `config:"autodiscover"`
 }
 
 var (

--- a/filebeat/docker-compose.yml
+++ b/filebeat/docker-compose.yml
@@ -13,6 +13,8 @@ services:
     working_dir: /go/src/github.com/elastic/beats/filebeat
     volumes:
       - ${PWD}/..:/go/src/github.com/elastic/beats/
+      # We launch docker containers to test docker autodiscover:
+      - /var/run/docker.sock:/var/run/docker.sock
     command: make
 
   # This is a proxy used to block beats until all services are healthy.

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -470,6 +470,23 @@ filebeat.prospectors:
   # Maximum size of the message received over UDP
   #max_message_size: 10240
 
+#========================== Filebeat autodiscover ==============================
+
+# Autodiscover allows you to detect changes in the system and spawn new modules
+# or prospectors as they happen.
+
+#filebeat.autodiscover:
+  # List of enabled autodiscover providers
+#  providers:
+#    - type: docker
+#      templates:
+#        - condition:
+#            equals.docker.container.image: busybox
+#          config:
+#            - type: log
+#              paths:
+#                - /var/lib/docker/containers/${data.docker.container.id}/*.log
+
 #========================= Filebeat global options ============================
 
 # Name of the registry file. If a relative path is used, it is considered relative to the

--- a/filebeat/fileset/factory.go
+++ b/filebeat/fileset/factory.go
@@ -42,7 +42,7 @@ func NewFactory(outlet channel.Factory, registrar *registrar.Registrar, beatVers
 }
 
 // Create creates a module based on a config
-func (f *Factory) Create(c *common.Config) (cfgfile.Runner, error) {
+func (f *Factory) Create(c *common.Config, meta *common.MapStrPointer) (cfgfile.Runner, error) {
 	// Start a registry of one module:
 	m, err := NewModuleRegistry([]*common.Config{c}, f.beatVersion, false)
 	if err != nil {
@@ -64,7 +64,7 @@ func (f *Factory) Create(c *common.Config) (cfgfile.Runner, error) {
 
 	prospectors := make([]*prospector.Prospector, len(pConfigs))
 	for i, pConfig := range pConfigs {
-		prospectors[i], err = prospector.New(pConfig, f.outlet, f.beatDone, f.registrar.GetStates())
+		prospectors[i], err = prospector.New(pConfig, f.outlet, f.beatDone, f.registrar.GetStates(), meta)
 		if err != nil {
 			logp.Err("Error creating prospector: %s", err)
 			return nil, err
@@ -109,4 +109,8 @@ func (p *prospectorsRunner) Stop() {
 	for _, prospector := range p.prospectors {
 		prospector.Stop()
 	}
+}
+
+func (p *prospectorsRunner) String() string {
+	return p.moduleRegistry.InfoString()
 }

--- a/filebeat/prospector/log/prospector.go
+++ b/filebeat/prospector/log/prospector.go
@@ -62,7 +62,7 @@ func NewProspector(
 	//  The outlet generated here is the underlying outlet, only closed
 	//  once all workers have been shut down.
 	//  For state updates and events, separate sub-outlets will be used.
-	out, err := outlet(cfg)
+	out, err := outlet(cfg, context.DynamicFields)
 	if err != nil {
 		return nil, err
 	}

--- a/filebeat/prospector/prospector.go
+++ b/filebeat/prospector/prospector.go
@@ -1,6 +1,7 @@
 package prospector
 
 import (
+	"fmt"
 	"sync"
 	"time"
 
@@ -36,6 +37,7 @@ func New(
 	outlet channel.Factory,
 	beatDone chan struct{},
 	states []file.State,
+	dynFields *common.MapStrPointer,
 ) (*Prospector, error) {
 	prospector := &Prospector{
 		config:   defaultConfig,
@@ -64,9 +66,10 @@ func New(
 	}
 
 	context := Context{
-		States:   states,
-		Done:     prospector.done,
-		BeatDone: prospector.beatDone,
+		States:        states,
+		Done:          prospector.done,
+		BeatDone:      prospector.beatDone,
+		DynamicFields: dynFields,
 	}
 	var prospectorer Prospectorer
 	prospectorer, err = f(conf, outlet, context)
@@ -140,4 +143,8 @@ func (p *Prospector) stop() {
 	} else {
 		p.prospectorer.Stop()
 	}
+}
+
+func (p *Prospector) String() string {
+	return fmt.Sprintf("prospector [type=%s, ID=%d]", p.config.Type, p.ID)
 }

--- a/filebeat/prospector/redis/prospector.go
+++ b/filebeat/prospector/redis/prospector.go
@@ -41,7 +41,7 @@ func NewProspector(cfg *common.Config, outletFactory channel.Factory, context pr
 		return nil, err
 	}
 
-	outlet, err := outletFactory(cfg)
+	outlet, err := outletFactory(cfg, context.DynamicFields)
 	if err != nil {
 		return nil, err
 	}

--- a/filebeat/prospector/registry.go
+++ b/filebeat/prospector/registry.go
@@ -10,9 +10,10 @@ import (
 )
 
 type Context struct {
-	States   []file.State
-	Done     chan struct{}
-	BeatDone chan struct{}
+	States        []file.State
+	Done          chan struct{}
+	BeatDone      chan struct{}
+	DynamicFields *common.MapStrPointer
 }
 
 type Factory func(config *common.Config, outletFactory channel.Factory, context Context) (Prospectorer, error)

--- a/filebeat/prospector/runnerfactory.go
+++ b/filebeat/prospector/runnerfactory.go
@@ -24,8 +24,8 @@ func NewRunnerFactory(outlet channel.Factory, registrar *registrar.Registrar, be
 }
 
 // Create creates a prospector based on a config
-func (r *RunnerFactory) Create(c *common.Config) (cfgfile.Runner, error) {
-	p, err := New(c, r.outlet, r.beatDone, r.registrar.GetStates())
+func (r *RunnerFactory) Create(c *common.Config, meta *common.MapStrPointer) (cfgfile.Runner, error) {
+	p, err := New(c, r.outlet, r.beatDone, r.registrar.GetStates(), meta)
 	if err != nil {
 		// In case of error with loading state, prospector is still returned
 		return p, err

--- a/filebeat/prospector/stdin/prospector.go
+++ b/filebeat/prospector/stdin/prospector.go
@@ -31,7 +31,7 @@ type Prospector struct {
 // NewStdin creates a new stdin prospector
 // This prospector contains one harvester which is reading from stdin
 func NewProspector(cfg *common.Config, outlet channel.Factory, context prospector.Context) (prospector.Prospectorer, error) {
-	out, err := outlet(cfg)
+	out, err := outlet(cfg, context.DynamicFields)
 	if err != nil {
 		return nil, err
 	}

--- a/filebeat/prospector/udp/prospector.go
+++ b/filebeat/prospector/udp/prospector.go
@@ -25,7 +25,7 @@ type Prospector struct {
 func NewProspector(cfg *common.Config, outlet channel.Factory, context prospector.Context) (prospector.Prospectorer, error) {
 	cfgwarn.Experimental("UDP prospector type is used")
 
-	out, err := outlet(cfg)
+	out, err := outlet(cfg, context.DynamicFields)
 	if err != nil {
 		return nil, err
 	}

--- a/filebeat/tests/system/config/filebeat.yml.j2
+++ b/filebeat/tests/system/config/filebeat.yml.j2
@@ -103,6 +103,22 @@ filebeat.config.{{ reload_type|default("prospectors") }}:
   {% endif -%}
 {% endif -%}
 
+#============================== Autodiscover ==================================
+
+{% if autodiscover %}
+filebeat.autodiscover:
+  providers:
+  {%- for provider, settings in autodiscover.items() %}
+  - type: {{provider}}
+    {%- if settings %}
+    {%- for k, v in settings.items() %}
+    {{k}}:
+      {{v | default([])}}
+    {%- endfor %}
+    {%- endif %}
+  {%- endfor %}
+{% endif %}
+
 #================================ General =====================================
 
 # The name of the shipper that publishes the network data. It can be used to group

--- a/filebeat/tests/system/test_autodiscover.py
+++ b/filebeat/tests/system/test_autodiscover.py
@@ -1,0 +1,55 @@
+import os
+import filebeat
+import unittest
+
+from beat.beat import INTEGRATION_TESTS
+
+
+class TestAutodiscover(filebeat.BaseTest):
+    """
+    Test filebeat autodiscover
+    """
+    @unittest.skipIf(not INTEGRATION_TESTS or
+                     os.getenv("TESTING_ENVIRONMENT") == "2x",
+                     "integration test not available on 2.x")
+    def test_docker(self):
+        """
+        Test docker autodiscover starts prospector
+        """
+        import docker
+        docker_client = docker.from_env()
+
+        self.render_config_template(
+            prospectors=False,
+            autodiscover={
+                'docker': {
+                    'templates': '''
+                      - condition:
+                          equals.docker.container.image: busybox
+                        config:
+                          - type: log
+                            paths:
+                              - %s/${data.docker.container.image}.log
+                    ''' % self.working_dir,
+                },
+            },
+        )
+
+        with open(os.path.join(self.working_dir, 'busybox.log'), 'wb') as f:
+            f.write('Busybox output 1\n')
+
+        proc = self.start_beat()
+        docker_client.images.pull('busybox')
+        docker_client.containers.run('busybox', 'sleep 1')
+
+        self.wait_until(lambda: self.log_contains('Autodiscover starting runner: prospector'))
+        self.wait_until(lambda: self.log_contains('Autodiscover stopping runner: prospector'))
+
+        output = self.read_output_json()
+        proc.check_kill_and_wait()
+
+        # Check metadata is added
+        assert output[0]['message'] == 'Busybox output 1'
+        assert output[0]['docker']['container']['image'] == 'busybox'
+        assert output[0]['docker']['container']['labels'] == {}
+        assert 'name' in output[0]['docker']['container']

--- a/libbeat/autodiscover/autodiscover.go
+++ b/libbeat/autodiscover/autodiscover.go
@@ -1,0 +1,215 @@
+package autodiscover
+
+import (
+	"github.com/elastic/beats/libbeat/autodiscover/meta"
+	"github.com/elastic/beats/libbeat/cfgfile"
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/bus"
+	"github.com/elastic/beats/libbeat/logp"
+
+	"github.com/mitchellh/hashstructure"
+)
+
+const debugK = "autodiscover"
+
+// TODO autodiscover providers config reload
+
+// Adapter must be implemented by the beat in order to provide Autodiscover
+type Adapter interface {
+	// TODO Hints
+
+	// CreateConfig generates a valid list of configs from the given event, the received event will have all keys defined by `StartFilter`
+	CreateConfig(bus.Event) ([]*common.Config, error)
+
+	// CheckConfig tests given config to check if it will work or not, returns errors in case it won't work
+	CheckConfig(*common.Config) error
+
+	// RunnerFactory provides runner creation by feeding valid configs
+	cfgfile.RunnerFactory
+
+	// StartFilter returns the bus filter to retrieve runner start triggering events
+	StartFilter() []string
+
+	// StopFilter returns the bus filter to retrieve runner stop triggering events
+	StopFilter() []string
+}
+
+// Autodiscover process, it takes a beat adapter and user config and runs autodiscover process, spawning
+// new modules when any configured providers does a match
+type Autodiscover struct {
+	bus       bus.Bus
+	adapter   Adapter
+	providers []Provider
+	runners   *cfgfile.Registry
+	meta      *meta.Map
+
+	startListener bus.Listener
+	stopListener  bus.Listener
+}
+
+// NewAutodiscover instantiates and returns a new Autodiscover manager
+func NewAutodiscover(name string, adapter Adapter, config *Config) (*Autodiscover, error) {
+	// Init Event bus
+	bus := bus.New(name)
+
+	// Init providers
+	var providers []Provider
+	for _, providerCfg := range config.Providers {
+		provider, err := ProviderRegistry.BuildProvider(bus, providerCfg)
+		if err != nil {
+			return nil, err
+		}
+		logp.Debug(debugK, "Configured autodiscover provider: %s", provider)
+		providers = append(providers, provider)
+	}
+
+	return &Autodiscover{
+		bus:       bus,
+		adapter:   adapter,
+		runners:   cfgfile.NewRegistry(),
+		providers: providers,
+		meta:      meta.NewMap(),
+	}, nil
+}
+
+// Start autodiscover process
+func (a *Autodiscover) Start() {
+	if a == nil {
+		return
+	}
+
+	logp.Info("Starting autodiscover manager")
+	a.startListener = a.bus.Subscribe(a.adapter.StartFilter()...)
+	a.stopListener = a.bus.Subscribe(a.adapter.StopFilter()...)
+
+	for _, provider := range a.providers {
+		provider.Start()
+	}
+
+	go a.startWorker()
+	go a.stopWorker()
+}
+
+func (a *Autodiscover) startWorker() {
+	for event := range a.startListener.Events() {
+		// This will happen on Stop:
+		if event == nil {
+			return
+		}
+
+		configs, err := a.adapter.CreateConfig(event)
+		if err != nil {
+			logp.Debug(debugK, "Could not generate config from event %v: %v", event, err)
+			continue
+		}
+		logp.Debug(debugK, "Got a start event: %v, generated configs: %+v", event, configs)
+
+		meta := getMeta(event)
+		for _, config := range configs {
+			hash, err := hashstructure.Hash(config, nil)
+			if err != nil {
+				logp.Debug(debugK, "Could not hash config %v: %v", config, err)
+				continue
+			}
+
+			err = a.adapter.CheckConfig(config)
+			if err != nil {
+				logp.Debug(debugK, "Check failed for config %v: %v, won't start runner", config, err)
+				continue
+			}
+
+			// Update meta no matter what
+			dynFields := a.meta.Store(hash, meta)
+
+			if a.runners.Has(hash) {
+				logp.Debug(debugK, "Config %v is already running", config)
+				continue
+			}
+
+			runner, err := a.adapter.Create(config, &dynFields)
+			if err != nil {
+				logp.Debug(debugK, "Failed to create runner with config %v: %v", config, err)
+				continue
+			}
+
+			logp.Info("Autodiscover starting runner: %s", runner)
+			a.runners.Add(hash, runner)
+			runner.Start()
+		}
+	}
+}
+
+func (a *Autodiscover) stopWorker() {
+	for event := range a.stopListener.Events() {
+		// This will happen on Stop:
+		if event == nil {
+			return
+		}
+
+		configs, err := a.adapter.CreateConfig(event)
+		if err != nil {
+			logp.Debug(debugK, "Could not generate config from event %v: %v", event, err)
+			continue
+		}
+		logp.Debug(debugK, "Got a stop event: %v, generated configs: %+v", event, configs)
+
+		for _, config := range configs {
+			hash, err := hashstructure.Hash(config, nil)
+			if err != nil {
+				logp.Debug(debugK, "Could not hash config %v: %v", config, err)
+				continue
+			}
+
+			if !a.runners.Has(hash) {
+				logp.Debug(debugK, "Config %v is not running", config)
+				continue
+			}
+
+			if runner := a.runners.Get(hash); runner != nil {
+				logp.Info("Autodiscover stopping runner: %s", runner)
+				runner.Stop()
+				a.runners.Remove(hash)
+			} else {
+				logp.Debug(debugK, "Runner not found for stopping: %s", hash)
+			}
+		}
+	}
+}
+
+func getMeta(event bus.Event) common.MapStr {
+	m := event["meta"]
+	if m == nil {
+		return nil
+	}
+
+	logp.Debug(debugK, "Got a meta field in the event")
+	meta, ok := m.(common.MapStr)
+	if !ok {
+		logp.Err("Got a wrong meta field for event %v", event)
+		return nil
+	}
+	return meta
+}
+
+// Stop autodiscover process
+func (a *Autodiscover) Stop() {
+	if a == nil {
+		return
+	}
+
+	// Stop listening for events
+	a.startListener.Stop()
+	a.stopListener.Stop()
+
+	// Stop providers
+	for _, provider := range a.providers {
+		provider.Stop()
+	}
+
+	// Stop runners
+	for hash, runner := range a.runners.CopyList() {
+		runner.Stop()
+		a.meta.Remove(hash)
+	}
+	logp.Info("Stopped autodiscover manager")
+}

--- a/libbeat/autodiscover/autodiscover_test.go
+++ b/libbeat/autodiscover/autodiscover_test.go
@@ -1,0 +1,188 @@
+// +build integration
+
+package autodiscover
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/elastic/beats/libbeat/cfgfile"
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/bus"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type mockRunner struct {
+	mutex            sync.Mutex
+	config           *common.Config
+	meta             *common.MapStrPointer
+	started, stopped bool
+}
+
+func (m *mockRunner) Start() {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.started = true
+}
+func (m *mockRunner) Stop() {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.stopped = true
+}
+func (m *mockRunner) Clone() *mockRunner {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	return &mockRunner{
+		config:  m.config,
+		meta:    m.meta,
+		started: m.started,
+		stopped: m.stopped,
+	}
+}
+
+type mockAdapter struct {
+	mutex   sync.Mutex
+	configs []*common.Config
+	runners []*mockRunner
+}
+
+// CreateConfig generates a valid list of configs from the given event, the received event will have all keys defined by `StartFilter`
+func (m *mockAdapter) CreateConfig(bus.Event) ([]*common.Config, error) {
+	return m.configs, nil
+}
+
+// CheckConfig tests given config to check if it will work or not, returns errors in case it won't work
+func (m *mockAdapter) CheckConfig(*common.Config) error {
+	return nil
+}
+
+func (m *mockAdapter) Create(config *common.Config, meta *common.MapStrPointer) (cfgfile.Runner, error) {
+	runner := &mockRunner{
+		config: config,
+		meta:   meta,
+	}
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.runners = append(m.runners, runner)
+	return runner, nil
+}
+
+func (m *mockAdapter) Runners() []*mockRunner {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	var res []*mockRunner
+	for _, r := range m.runners {
+		res = append(res, r.Clone())
+	}
+	return res
+}
+
+// StartFilter returns the bus filter to retrieve runner start triggering events
+func (m *mockAdapter) StartFilter() []string {
+	return []string{"start"}
+}
+
+// StopFilter returns the bus filter to retrieve runner stop triggering events
+func (m *mockAdapter) StopFilter() []string {
+	return []string{"stop"}
+}
+
+type mockProvider struct{}
+
+// Start the autodiscover process, send all configured events to the bus
+func (d *mockProvider) Start() {}
+
+// Stop the autodiscover process
+func (d *mockProvider) Stop() {}
+
+func (d *mockProvider) String() string {
+	return "mock"
+}
+
+func TestNilAutodiscover(t *testing.T) {
+	var autodiscover *Autodiscover
+	autodiscover.Start()
+	autodiscover.Stop()
+}
+
+func TestAutodiscover(t *testing.T) {
+	// Register mock autodiscover provider
+	busChan := make(chan bus.Bus, 1)
+	ProviderRegistry.AddProvider("mock", func(b bus.Bus, c *common.Config) (Provider, error) {
+		// intercept bus to mock events
+		busChan <- b
+
+		return &mockProvider{}, nil
+	})
+
+	// Create a mock adapter
+	runnerConfig, _ := common.NewConfigFrom(map[string]string{
+		"runner": "1",
+	})
+	adapter := mockAdapter{
+		configs: []*common.Config{runnerConfig},
+	}
+
+	// and settings:
+	providerConfig, _ := common.NewConfigFrom(map[string]string{
+		"type": "mock",
+	})
+	config := Config{
+		Providers: []*common.Config{providerConfig},
+	}
+
+	// Create autodiscover manager
+	autodiscover, err := NewAutodiscover("test", &adapter, &config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Start it
+	autodiscover.Start()
+	defer autodiscover.Stop()
+	eventBus := <-busChan
+
+	// Test start event
+	eventBus.Publish(bus.Event{
+		"start": true,
+		"meta": common.MapStr{
+			"foo": "bar",
+		},
+	})
+	time.Sleep(10 * time.Millisecond)
+	runners := adapter.Runners()
+	assert.Equal(t, len(runners), 1)
+	assert.Equal(t, runners[0].meta.Get()["foo"], "bar")
+	assert.True(t, runners[0].started)
+	assert.False(t, runners[0].stopped)
+
+	// Test update
+	eventBus.Publish(bus.Event{
+		"start": true,
+		"meta": common.MapStr{
+			"foo": "baz",
+		},
+	})
+	time.Sleep(10 * time.Millisecond)
+	runners = adapter.Runners()
+	assert.Equal(t, len(runners), 1)
+	assert.Equal(t, runners[0].meta.Get()["foo"], "baz") // meta is updated
+	assert.True(t, runners[0].started)
+	assert.False(t, runners[0].stopped)
+
+	// Test stop event
+	eventBus.Publish(bus.Event{
+		"stop": true,
+		"meta": common.MapStr{
+			"foo": "baz",
+		},
+	})
+	time.Sleep(10 * time.Millisecond)
+	runners = adapter.Runners()
+	assert.Equal(t, len(runners), 1)
+	assert.Equal(t, runners[0].meta.Get()["foo"], "baz")
+	assert.True(t, runners[0].started)
+	assert.True(t, runners[0].stopped)
+}

--- a/libbeat/autodiscover/config.go
+++ b/libbeat/autodiscover/config.go
@@ -1,0 +1,13 @@
+package autodiscover
+
+import "github.com/elastic/beats/libbeat/common"
+
+// Config settings for Autodiscover
+type Config struct {
+	Providers []*common.Config `config:"providers"`
+}
+
+// ProviderConfig settings
+type ProviderConfig struct {
+	Type string `config:"type"`
+}

--- a/libbeat/autodiscover/meta/meta.go
+++ b/libbeat/autodiscover/meta/meta.go
@@ -1,0 +1,50 @@
+package meta
+
+import (
+	"sync"
+
+	"github.com/elastic/beats/libbeat/common"
+)
+
+// Map stores a map of id -> MapStrPointer
+type Map struct {
+	mutex sync.RWMutex
+	meta  map[uint64]common.MapStrPointer
+}
+
+// NewMap instantiates and returns a new meta.Map
+func NewMap() *Map {
+	return &Map{
+		meta: make(map[uint64]common.MapStrPointer),
+	}
+}
+
+// Store inserts or updates given meta under the given id. Then it returns a MapStrPointer to it
+func (m *Map) Store(id uint64, meta common.MapStr) common.MapStrPointer {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	if meta == nil {
+		return common.MapStrPointer{}
+	}
+
+	p, ok := m.meta[id]
+	if !ok {
+		// create
+		p = common.NewMapStrPointer(meta)
+		m.meta[id] = p
+	} else {
+		// update
+		p.Set(meta)
+	}
+
+	return p
+}
+
+// Remove meta stored under the given id
+func (m *Map) Remove(id uint64) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	delete(m.meta, id)
+}

--- a/libbeat/autodiscover/meta/meta_test.go
+++ b/libbeat/autodiscover/meta/meta_test.go
@@ -1,0 +1,29 @@
+package meta
+
+import (
+	"testing"
+
+	"github.com/elastic/beats/libbeat/common"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStoreNil(t *testing.T) {
+	m := NewMap()
+	assert.Equal(t, common.MapStrPointer{}, m.Store(0, nil))
+}
+
+func TestStore(t *testing.T) {
+	m := NewMap()
+
+	// Store meta
+	res := m.Store(0, common.MapStr{"foo": "bar"})
+	assert.Equal(t, res.Get(), common.MapStr{"foo": "bar"})
+
+	// Update it
+	res = m.Store(0, common.MapStr{"foo": "baz"})
+	assert.Equal(t, res.Get(), common.MapStr{"foo": "baz"})
+
+	m.Remove(0)
+	assert.Equal(t, len(m.meta), 0)
+}

--- a/libbeat/autodiscover/provider.go
+++ b/libbeat/autodiscover/provider.go
@@ -1,0 +1,86 @@
+package autodiscover
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/elastic/beats/libbeat/cfgfile"
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/bus"
+	"github.com/elastic/beats/libbeat/logp"
+)
+
+// Provider for autodiscover
+type Provider interface {
+	cfgfile.Runner
+}
+
+// ProviderRegistry holds all known autodiscover providers, they must be added to it to enable them for use
+var ProviderRegistry = NewRegistry()
+
+// ProviderBuilder creates a new provider based on the given config and returns it
+type ProviderBuilder func(bus.Bus, *common.Config) (Provider, error)
+
+// Register of autodiscover providers
+type registry struct {
+	// Lock to control concurrent read/writes
+	lock sync.RWMutex
+	// A map of provider name to ProviderBuilder.
+	providers map[string]ProviderBuilder
+}
+
+// NewRegistry creates and returns a new Registry
+func NewRegistry() *registry {
+	return &registry{
+		providers: make(map[string]ProviderBuilder, 0),
+	}
+}
+
+// AddProvider registers a new ProviderBuilder
+func (r *registry) AddProvider(name string, provider ProviderBuilder) error {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	if name == "" {
+		return fmt.Errorf("provider name is required")
+	}
+
+	_, exists := r.providers[name]
+	if exists {
+		return fmt.Errorf("provider '%s' is already registered", name)
+	}
+
+	if provider == nil {
+		return fmt.Errorf("provider '%s' cannot be registered with a nil factory", name)
+	}
+
+	r.providers[name] = provider
+	logp.Debug(debugK, "Provider registered: %s", name)
+	return nil
+}
+
+// GetProvider returns the provider with the giving name, nil if it doesn't exist
+func (r *registry) GetProvider(name string) ProviderBuilder {
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+
+	name = strings.ToLower(name)
+	return r.providers[name]
+}
+
+// BuildProvider reads provider configuration and instatiate one
+func (r *registry) BuildProvider(bus bus.Bus, c *common.Config) (Provider, error) {
+	var config ProviderConfig
+	err := c.Unpack(&config)
+	if err != nil {
+		return nil, err
+	}
+
+	builder := r.GetProvider(config.Type)
+	if builder == nil {
+		return nil, fmt.Errorf("Unknown autodiscover provider %s", config.Type)
+	}
+
+	return builder(bus, c)
+}

--- a/libbeat/autodiscover/providers/docker/config.go
+++ b/libbeat/autodiscover/providers/docker/config.go
@@ -1,0 +1,19 @@
+package docker
+
+import (
+	"github.com/elastic/beats/libbeat/autodiscover/template"
+	"github.com/elastic/beats/libbeat/common/docker"
+)
+
+// Config for docker autodiscover provider
+type Config struct {
+	Host      string                  `config:"host"`
+	TLS       *docker.TLSConfig       `config:"ssl"`
+	Templates template.MapperSettings `config:"templates"`
+}
+
+func defaultConfig() *Config {
+	return &Config{
+		Host: "unix:///var/run/docker.sock",
+	}
+}

--- a/libbeat/autodiscover/providers/docker/docker.go
+++ b/libbeat/autodiscover/providers/docker/docker.go
@@ -1,0 +1,145 @@
+package docker
+
+import (
+	"github.com/elastic/beats/libbeat/autodiscover"
+	"github.com/elastic/beats/libbeat/autodiscover/template"
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/bus"
+	"github.com/elastic/beats/libbeat/common/docker"
+	"github.com/elastic/beats/libbeat/logp"
+)
+
+func init() {
+	autodiscover.ProviderRegistry.AddProvider("docker", AutodiscoverBuilder)
+}
+
+// Provider implements autodiscover provider for docker containers
+type Provider struct {
+	config        *Config
+	bus           bus.Bus
+	watcher       docker.Watcher
+	templates     *template.Mapper
+	stop          chan interface{}
+	startListener bus.Listener
+	stopListener  bus.Listener
+}
+
+// AutodiscoverBuilder builds and returns an autodiscover provider
+func AutodiscoverBuilder(bus bus.Bus, c *common.Config) (autodiscover.Provider, error) {
+	config := defaultConfig()
+	err := c.Unpack(&config)
+	if err != nil {
+		return nil, err
+	}
+
+	mapper, err := template.NewConfigMapper(config.Templates)
+	if err != nil {
+		return nil, err
+	}
+
+	watcher, err := docker.NewWatcher(config.Host, config.TLS)
+	if err != nil {
+		return nil, err
+	}
+
+	start := watcher.ListenStart()
+	stop := watcher.ListenStop()
+
+	if err := watcher.Start(); err != nil {
+		return nil, err
+	}
+
+	return &Provider{
+		config:        config,
+		bus:           bus,
+		templates:     mapper,
+		watcher:       watcher,
+		stop:          make(chan interface{}),
+		startListener: start,
+		stopListener:  stop,
+	}, nil
+}
+
+// Start the autodiscover process
+func (d *Provider) Start() {
+	go func() {
+		for {
+			select {
+			case <-d.stop:
+				d.startListener.Stop()
+				d.stopListener.Stop()
+				return
+
+			case event := <-d.startListener.Events():
+				d.emitContainer(event, "start")
+
+			case event := <-d.stopListener.Events():
+				d.emitContainer(event, "stop")
+			}
+		}
+	}()
+}
+
+func (d *Provider) emitContainer(event bus.Event, flag string) {
+	container, ok := event["container"].(*docker.Container)
+	if !ok {
+		logp.Err("Couldn't get a container from watcher event")
+		return
+	}
+
+	var host string
+	if len(container.IPAddresses) > 0 {
+		host = container.IPAddresses[0]
+	}
+
+	meta := common.MapStr{
+		"container": common.MapStr{
+			"id":     container.ID,
+			"name":   container.Name,
+			"image":  container.Image,
+			"labels": container.Labels,
+		},
+	}
+
+	// Emit container info
+	d.publish(bus.Event{
+		flag:     true,
+		"host":   host,
+		"docker": meta,
+		"meta": common.MapStr{
+			"docker": meta,
+		},
+	})
+
+	// Emit container private ports
+	for _, port := range container.Ports {
+		event := bus.Event{
+			flag:     true,
+			"host":   host,
+			"port":   port.PrivatePort,
+			"docker": meta,
+			"meta": common.MapStr{
+				"docker": meta,
+			},
+		}
+
+		d.publish(event)
+	}
+}
+
+func (d *Provider) publish(event bus.Event) {
+	// Try to match a config
+	if config := d.templates.GetConfig(event); config != nil {
+		event["config"] = config
+	}
+	d.bus.Publish(event)
+}
+
+// Stop the autodiscover process
+func (d *Provider) Stop() {
+	close(d.stop)
+}
+
+func (d *Provider) String() string {
+	return "docker"
+}

--- a/libbeat/autodiscover/providers/docker/docker_integration_test.go
+++ b/libbeat/autodiscover/providers/docker/docker_integration_test.go
@@ -1,0 +1,84 @@
+// +build integration
+
+package docker
+
+import (
+	"testing"
+	"time"
+
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/bus"
+	dk "github.com/elastic/beats/libbeat/tests/docker"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Test docker start emits an autodiscover event
+func TestDockerStart(t *testing.T) {
+	d, err := dk.NewClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	bus := bus.New("test")
+	config := common.NewConfig()
+	provider, err := AutodiscoverBuilder(bus, config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	provider.Start()
+	defer provider.Stop()
+
+	listener := bus.Subscribe()
+	defer listener.Stop()
+
+	// Start
+	ID, err := d.ContainerStart("busybox", "echo", "Hi!")
+	if err != nil {
+		t.Fatal(err)
+	}
+	checkEvent(t, listener, true)
+
+	// Kill
+	d.ContainerKill(ID)
+	checkEvent(t, listener, false)
+}
+
+func getValue(e bus.Event, key string) interface{} {
+	val, err := common.MapStr(e).GetValue(key)
+	if err != nil {
+		return nil
+	}
+	return val
+}
+
+func checkEvent(t *testing.T, listener bus.Listener, start bool) {
+	for {
+		select {
+		case e := <-listener.Events():
+			// Ignore any other container
+			if getValue(e, "docker.container.image") != "busybox" {
+				continue
+			}
+			if start {
+				assert.Equal(t, getValue(e, "start"), true)
+				assert.Nil(t, getValue(e, "stop"))
+			} else {
+				assert.Equal(t, getValue(e, "stop"), true)
+				assert.Nil(t, getValue(e, "start"))
+			}
+			assert.Equal(t, getValue(e, "docker.container.image"), "busybox")
+			assert.Equal(t, getValue(e, "docker.container.labels"), map[string]string{})
+			assert.NotNil(t, getValue(e, "docker.container.id"))
+			assert.NotNil(t, getValue(e, "docker.container.name"))
+			assert.NotNil(t, getValue(e, "host"))
+			assert.Equal(t, getValue(e, "docker"), getValue(e, "meta.docker"))
+			return
+
+		case <-time.After(10 * time.Second):
+			t.Fatal("Timeout waiting for provider events")
+			return
+		}
+	}
+}

--- a/libbeat/autodiscover/template/config.go
+++ b/libbeat/autodiscover/template/config.go
@@ -1,0 +1,102 @@
+package template
+
+import (
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/bus"
+	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/processors"
+
+	ucfg "github.com/elastic/go-ucfg"
+)
+
+// Mapper maps config templates with conditions, if a match happens on a discover event
+// the given template will be used as config
+type Mapper []*ConditionMap
+
+// ConditionMap maps a condition to the configs to use when it's triggered
+type ConditionMap struct {
+	Condition *processors.Condition
+	Configs   []*common.Config
+}
+
+// MapperSettings holds user settings to build Mapper
+type MapperSettings []*struct {
+	ConditionConfig *processors.ConditionConfig `config:"condition"`
+	Configs         []*common.Config            `config:"config"`
+}
+
+// NewConfigMapper builds a template Mapper from given settings
+func NewConfigMapper(configs MapperSettings) (*Mapper, error) {
+	var mapper Mapper
+	for _, c := range configs {
+		condition, err := processors.NewCondition(c.ConditionConfig)
+		if err != nil {
+			return nil, err
+		}
+		mapper = append(mapper, &ConditionMap{
+			Condition: condition,
+			Configs:   c.Configs,
+		})
+	}
+
+	return &mapper, nil
+}
+
+// Event adapts MapStr to processors.ValuesMap interface
+type Event common.MapStr
+
+// GetValue extracts given key from an Event
+func (e Event) GetValue(key string) (interface{}, error) {
+	val, err := common.MapStr(e).GetValue(key)
+	if err != nil {
+		return nil, err
+	}
+	return val, nil
+}
+
+// GetConfig returns a matching Config if any, nil otherwise
+func (c *Mapper) GetConfig(event bus.Event) []*common.Config {
+	var result []*common.Config
+
+	for _, mapping := range *c {
+		if mapping.Configs != nil && !mapping.Condition.Check(Event(event)) {
+			continue
+		}
+
+		// unpack input
+		vars, err := ucfg.NewFrom(map[string]interface{}{
+			"data": event,
+		})
+		if err != nil {
+			logp.Err("Error building config: %v", err)
+		}
+		opts := []ucfg.Option{
+			ucfg.PathSep("."),
+			ucfg.Env(vars),
+			ucfg.ResolveEnv,
+			ucfg.VarExp,
+		}
+		for _, config := range mapping.Configs {
+			c, err := ucfg.NewFrom(config, opts...)
+			if err != nil {
+				logp.Err("Error parsing config: %v", err)
+				continue
+			}
+			// Unpack config to process any vars in the template:
+			var unpacked map[string]interface{}
+			c.Unpack(&unpacked, opts...)
+			if err != nil {
+				logp.Err("Error unpacking config: %v", err)
+				continue
+			}
+			// Repack again:
+			res, err := common.NewConfigFrom(unpacked)
+			if err != nil {
+				logp.Err("Error creating config from unpack: %v", err)
+				continue
+			}
+			result = append(result, res)
+		}
+	}
+	return result
+}

--- a/libbeat/autodiscover/template/config_test.go
+++ b/libbeat/autodiscover/template/config_test.go
@@ -1,0 +1,67 @@
+package template
+
+import (
+	"testing"
+
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/bus"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfigsMapping(t *testing.T) {
+	config, _ := common.NewConfigFrom(map[string]interface{}{
+		"correct": "config",
+	})
+
+	tests := []struct {
+		mapping  string
+		event    bus.Event
+		expected []*common.Config
+	}{
+		// No match
+		{
+			mapping: `
+- condition.equals:
+    foo: 3
+  config:
+  - type: config1`,
+			event: bus.Event{
+				"foo": "no match",
+			},
+			expected: nil,
+		},
+		// Match config
+		{
+			mapping: `
+- condition.equals:
+    foo: 3
+  config:
+  - correct: config`,
+			event: bus.Event{
+				"foo": 3,
+			},
+			expected: []*common.Config{config},
+		},
+	}
+
+	for _, test := range tests {
+		var mappings MapperSettings
+		config, err := common.NewConfigWithYAML([]byte(test.mapping), "")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := config.Unpack(&mappings); err != nil {
+			t.Fatal(err)
+		}
+
+		mapper, err := NewConfigMapper(mappings)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		res := mapper.GetConfig(test.event)
+		assert.Equal(t, test.expected, res)
+	}
+}

--- a/libbeat/beat/pipeline.go
+++ b/libbeat/beat/pipeline.go
@@ -34,6 +34,9 @@ type ClientConfig struct {
 	// Fields provides additional 'global' fields to be added to every event
 	Fields common.MapStr
 
+	// DynamicFields provides additional fields to be added to every event, supporting live updates
+	DynamicFields *common.MapStrPointer
+
 	// Processors passes additional processor to the client, to be executed before
 	// the pipeline processors.
 	Processor ProcessorList

--- a/libbeat/cfgfile/reload.go
+++ b/libbeat/cfgfile/reload.go
@@ -46,7 +46,7 @@ type Reload struct {
 }
 
 type RunnerFactory interface {
-	Create(*common.Config) (Runner, error)
+	Create(config *common.Config, meta *common.MapStrPointer) (Runner, error)
 }
 
 type Runner interface {
@@ -114,7 +114,7 @@ func (rl *Reloader) Check(runnerFactory RunnerFactory) error {
 		if !c.Enabled() {
 			continue
 		}
-		_, err := runnerFactory.Create(c)
+		_, err := runnerFactory.Create(c, nil)
 		if err != nil {
 			return err
 		}
@@ -201,7 +201,7 @@ func (rl *Reloader) Run(runnerFactory RunnerFactory) {
 				// As module already exist, it must be removed from the stop list and not started
 				if !rl.registry.Has(hash) {
 					debugf("Add module to startlist: %v", hash)
-					runner, err := runnerFactory.Create(c)
+					runner, err := runnerFactory.Create(c, nil)
 					if err != nil {
 						logp.Err("Unable to create runner due to error: %v", err)
 						continue

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -44,6 +44,9 @@ import (
 	_ "github.com/elastic/beats/libbeat/processors/add_kubernetes_metadata"
 	_ "github.com/elastic/beats/libbeat/processors/add_locale"
 
+	// Register autodiscover providers
+	_ "github.com/elastic/beats/libbeat/autodiscover/providers/docker"
+
 	// Register default monitoring reporting
 	_ "github.com/elastic/beats/libbeat/monitoring/report/elasticsearch"
 )

--- a/libbeat/common/bus/bus.go
+++ b/libbeat/common/bus/bus.go
@@ -1,0 +1,102 @@
+package bus
+
+import (
+	"sync"
+
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/logp"
+)
+
+// Event sent to the bus
+type Event common.MapStr
+
+// Bus provides a common channel to emit and listen for Events
+type Bus interface {
+	// Publish an event to the bus
+	Publish(Event)
+
+	// Subscribe to all events, filter them to the ones containing *all* the keys in filter
+	Subscribe(filter ...string) Listener
+}
+
+// Listener retrieves Events from a Bus subscription until Stop is called
+type Listener interface {
+	// Events channel
+	Events() <-chan Event
+
+	// Stop listening and removes itself from the bus
+	Stop()
+}
+
+type bus struct {
+	sync.RWMutex
+	name      string
+	listeners []*listener
+}
+
+type listener struct {
+	filter  []string
+	channel chan Event
+	bus     *bus
+}
+
+// New initializes a new bus with the given name and returns it
+func New(name string) Bus {
+	return &bus{
+		name:      name,
+		listeners: make([]*listener, 0),
+	}
+}
+
+func (b *bus) Publish(e Event) {
+	b.RLock()
+	defer b.RUnlock()
+
+	logp.Debug("bus", "%s: %+v", b.name, e)
+	for _, listener := range b.listeners {
+		if listener.interested(e) {
+			listener.channel <- e
+		}
+	}
+}
+
+func (b *bus) Subscribe(filter ...string) Listener {
+	listener := &listener{
+		filter:  filter,
+		bus:     b,
+		channel: make(chan Event, 100),
+	}
+
+	b.Lock()
+	defer b.Unlock()
+	b.listeners = append(b.listeners, listener)
+
+	return listener
+}
+
+func (l *listener) Events() <-chan Event {
+	return l.channel
+}
+
+func (l *listener) Stop() {
+	l.bus.Lock()
+	defer l.bus.Unlock()
+
+	for i, listener := range l.bus.listeners {
+		if l == listener {
+			l.bus.listeners = append(l.bus.listeners[:i], l.bus.listeners[i+1:]...)
+		}
+	}
+
+	close(l.channel)
+}
+
+// Return true if listener is interested on the given event
+func (l *listener) interested(e Event) bool {
+	for _, key := range l.filter {
+		if _, ok := e[key]; !ok {
+			return false
+		}
+	}
+	return true
+}

--- a/libbeat/common/bus/bus_test.go
+++ b/libbeat/common/bus/bus_test.go
@@ -1,0 +1,86 @@
+package bus
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEmit(t *testing.T) {
+	bus := New("name")
+	listener := bus.Subscribe()
+
+	bus.Publish(Event{
+		"foo": "bar",
+	})
+
+	event := <-listener.Events()
+	assert.Equal(t, event["foo"], "bar")
+}
+
+func TestEmitOrder(t *testing.T) {
+	bus := New("name")
+	listener := bus.Subscribe()
+	bus.Publish(Event{"first": "event"})
+	bus.Publish(Event{"second": "event"})
+
+	event1 := <-listener.Events()
+	event2 := <-listener.Events()
+	assert.Equal(t, event1, Event{"first": "event"})
+	assert.Equal(t, event2, Event{"second": "event"})
+}
+
+func TestSubscribeFilter(t *testing.T) {
+	bus := New("name")
+	listener := bus.Subscribe("second")
+
+	bus.Publish(Event{"first": "event"})
+	bus.Publish(Event{"second": "event"})
+
+	event := <-listener.Events()
+	assert.Equal(t, event, Event{"second": "event"})
+}
+
+func TestMultipleListeners(t *testing.T) {
+	bus := New("name")
+	listener1 := bus.Subscribe("a")
+	listener2 := bus.Subscribe("a", "b")
+
+	bus.Publish(Event{"a": "event"})
+	bus.Publish(Event{"a": 1, "b": 2})
+
+	event1 := <-listener1.Events()
+	event2 := <-listener1.Events()
+	assert.Equal(t, event1, Event{"a": "event"})
+	assert.Equal(t, event2, Event{"a": 1, "b": 2})
+
+	event1 = <-listener2.Events()
+	assert.Equal(t, event1, Event{"a": 1, "b": 2})
+
+	select {
+	case event2 = <-listener2.Events():
+		t.Error("Got unexpected event:", event2)
+	default:
+	}
+}
+
+func TestListenerClose(t *testing.T) {
+	bus := New("name")
+	listener := bus.Subscribe()
+
+	bus.Publish(Event{"first": "event"})
+	bus.Publish(Event{"second": "event"})
+
+	listener.Stop()
+
+	bus.Publish(Event{"third": "event"})
+
+	event := <-listener.Events()
+	assert.Equal(t, event, Event{"first": "event"})
+	event = <-listener.Events()
+	assert.Equal(t, event, Event{"second": "event"})
+
+	// Channel was closed, we get an empty event
+	event = <-listener.Events()
+	assert.Equal(t, event, Event(nil))
+}

--- a/libbeat/common/mapstr_pointer.go
+++ b/libbeat/common/mapstr_pointer.go
@@ -1,0 +1,34 @@
+package common
+
+import (
+	"sync/atomic"
+	"unsafe"
+)
+
+// MapStrPointer stores a pointer to atomically get/set a MapStr object
+// This should give faster access for use cases with lots of reads and a few
+// changes.
+// It's imortant to note that modifying the map is not thread safe, only fully
+// replacing it.
+type MapStrPointer struct {
+	p *unsafe.Pointer
+}
+
+// NewMapStrPointer initializes and returns a pointer to the given MapStr
+func NewMapStrPointer(m MapStr) MapStrPointer {
+	pointer := unsafe.Pointer(&m)
+	return MapStrPointer{p: &pointer}
+}
+
+// Get returns the MapStr stored under this pointer
+func (m MapStrPointer) Get() MapStr {
+	if m.p == nil {
+		return nil
+	}
+	return *(*MapStr)(atomic.LoadPointer(m.p))
+}
+
+// Set stores a pointer the given MapStr, replacing any previous one
+func (m *MapStrPointer) Set(p MapStr) {
+	atomic.StorePointer(m.p, unsafe.Pointer(&p))
+}

--- a/libbeat/common/mapstr_pointer_test.go
+++ b/libbeat/common/mapstr_pointer_test.go
@@ -1,0 +1,39 @@
+package common
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMapStrPointer(t *testing.T) {
+	data := MapStr{
+		"foo": "bar",
+	}
+
+	p := NewMapStrPointer(data)
+	assert.Equal(t, p.Get(), data)
+
+	newData := MapStr{
+		"new": "data",
+	}
+	p.Set(newData)
+	assert.Equal(t, p.Get(), newData)
+}
+
+func BenchmarkMapStrPointer(b *testing.B) {
+	p := NewMapStrPointer(MapStr{"counter": 0})
+	go func() {
+		counter := 0
+		for {
+			counter++
+			p.Set(MapStr{"counter": counter})
+			time.Sleep(10 * time.Millisecond)
+		}
+	}()
+
+	for n := 0; n < b.N; n++ {
+		_ = p.Get()
+	}
+}

--- a/libbeat/docker-compose.yml
+++ b/libbeat/docker-compose.yml
@@ -24,6 +24,8 @@ services:
       - ${PWD}/build/test.env
     volumes:
       - ${PWD}/..:/go/src/github.com/elastic/beats/
+      # Used for docker integration tests:
+      - /var/run/docker.sock:/var/run/docker.sock
     working_dir: /go/src/github.com/elastic/beats/libbeat
     command: make
 

--- a/libbeat/processors/add_docker_metadata/add_docker_metadata.go
+++ b/libbeat/processors/add_docker_metadata/add_docker_metadata.go
@@ -7,6 +7,7 @@ import (
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/cfgwarn"
+	"github.com/elastic/beats/libbeat/common/docker"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/processors"
 	"github.com/elastic/beats/libbeat/processors/actions"
@@ -17,16 +18,16 @@ func init() {
 }
 
 type addDockerMetadata struct {
-	watcher         Watcher
+	watcher         docker.Watcher
 	fields          []string
 	sourceProcessor processors.Processor
 }
 
 func newDockerMetadataProcessor(cfg *common.Config) (processors.Processor, error) {
-	return buildDockerMetadataProcessor(cfg, NewWatcher)
+	return buildDockerMetadataProcessor(cfg, docker.NewWatcher)
 }
 
-func buildDockerMetadataProcessor(cfg *common.Config, watcherConstructor WatcherConstructor) (processors.Processor, error) {
+func buildDockerMetadataProcessor(cfg *common.Config, watcherConstructor docker.WatcherConstructor) (processors.Processor, error) {
 	cfgwarn.Beta("The add_docker_metadata processor is beta")
 
 	config := defaultConfig()

--- a/libbeat/processors/add_docker_metadata/add_docker_metadata_test.go
+++ b/libbeat/processors/add_docker_metadata/add_docker_metadata_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/bus"
+	"github.com/elastic/beats/libbeat/common/docker"
 )
 
 func TestInitialization(t *testing.T) {
@@ -65,8 +67,8 @@ func TestMatchContainer(t *testing.T) {
 	assert.NoError(t, err)
 
 	p, err := buildDockerMetadataProcessor(testConfig, MockWatcherFactory(
-		map[string]*Container{
-			"container_id": &Container{
+		map[string]*docker.Container{
+			"container_id": &docker.Container{
 				ID:    "container_id",
 				Image: "image",
 				Name:  "name",
@@ -106,8 +108,8 @@ func TestMatchSource(t *testing.T) {
 	assert.NoError(t, err)
 
 	p, err := buildDockerMetadataProcessor(testConfig, MockWatcherFactory(
-		map[string]*Container{
-			"FABADA": &Container{
+		map[string]*docker.Container{
+			"FABADA": &docker.Container{
 				ID:    "FABADA",
 				Image: "image",
 				Name:  "name",
@@ -149,8 +151,8 @@ func TestDisableSource(t *testing.T) {
 	assert.NoError(t, err)
 
 	p, err := buildDockerMetadataProcessor(testConfig, MockWatcherFactory(
-		map[string]*Container{
-			"FABADA": &Container{
+		map[string]*docker.Container{
+			"FABADA": &docker.Container{
 				ID:    "FABADA",
 				Image: "image",
 				Name:  "name",
@@ -174,17 +176,17 @@ func TestDisableSource(t *testing.T) {
 
 // Mock container watcher
 
-func MockWatcherFactory(containers map[string]*Container) WatcherConstructor {
+func MockWatcherFactory(containers map[string]*docker.Container) docker.WatcherConstructor {
 	if containers == nil {
-		containers = make(map[string]*Container)
+		containers = make(map[string]*docker.Container)
 	}
-	return func(host string, tls *TLSConfig) (Watcher, error) {
+	return func(host string, tls *docker.TLSConfig) (docker.Watcher, error) {
 		return &mockWatcher{containers: containers}, nil
 	}
 }
 
 type mockWatcher struct {
-	containers map[string]*Container
+	containers map[string]*docker.Container
 }
 
 func (m *mockWatcher) Start() error {
@@ -193,10 +195,18 @@ func (m *mockWatcher) Start() error {
 
 func (m *mockWatcher) Stop() {}
 
-func (m *mockWatcher) Container(ID string) *Container {
+func (m *mockWatcher) Container(ID string) *docker.Container {
 	return m.containers[ID]
 }
 
-func (m *mockWatcher) Containers() map[string]*Container {
+func (m *mockWatcher) Containers() map[string]*docker.Container {
 	return m.containers
+}
+
+func (m *mockWatcher) ListenStart() bus.Listener {
+	return nil
+}
+
+func (m *mockWatcher) ListenStop() bus.Listener {
+	return nil
 }

--- a/libbeat/processors/add_docker_metadata/config.go
+++ b/libbeat/processors/add_docker_metadata/config.go
@@ -1,25 +1,22 @@
 package add_docker_metadata
 
-import "time"
+import (
+	"time"
+
+	"github.com/elastic/beats/libbeat/common/docker"
+)
 
 // Config for docker processor
 type Config struct {
-	Host        string     `config:"host"`
-	TLS         *TLSConfig `config:"ssl"`
-	Fields      []string   `config:"match_fields"`
-	MatchSource bool       `config:"match_source"`
-	SourceIndex int        `config:"match_source_index"`
+	Host        string            `config:"host"`
+	TLS         *docker.TLSConfig `config:"ssl"`
+	Fields      []string          `config:"match_fields"`
+	MatchSource bool              `config:"match_source"`
+	SourceIndex int               `config:"match_source_index"`
 
 	// Annotations are kept after container is killled, until they haven't been accessed
 	// for a full `cleanup_timeout`:
 	CleanupTimeout time.Duration `config:"cleanup_timeout"`
-}
-
-// TLSConfig for docker socket connection
-type TLSConfig struct {
-	CA          string `config:"certificate_authority"`
-	Certificate string `config:"certificate"`
-	Key         string `config:"key"`
 }
 
 func defaultConfig() Config {

--- a/libbeat/tests/docker/docker.go
+++ b/libbeat/tests/docker/docker.go
@@ -1,0 +1,55 @@
+package docker
+
+import (
+	"context"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/client"
+)
+
+// Client for Docker
+type Client struct {
+	cli *client.Client
+}
+
+// NewClient builds and returns a docker Client
+func NewClient() (Client, error) {
+	c, err := client.NewEnvClient()
+	return Client{cli: c}, err
+}
+
+// ContainerStart pulls and starts the given container
+func (c Client) ContainerStart(image string, cmd ...string) (string, error) {
+	ctx := context.Background()
+	if _, err := c.cli.ImagePull(ctx, image, types.ImagePullOptions{}); err != nil {
+		return "", err
+	}
+
+	resp, err := c.cli.ContainerCreate(ctx, &container.Config{
+		Image: image,
+		Cmd:   cmd,
+	}, nil, nil, "")
+	if err != nil {
+		return "", err
+	}
+
+	if err := c.cli.ContainerStart(ctx, resp.ID, types.ContainerStartOptions{}); err != nil {
+		return "", err
+	}
+
+	return resp.ID, nil
+}
+
+// ContainerWait waits for a container to finish
+func (c Client) ContainerWait(ID string) error {
+	ctx := context.Background()
+	_, err := c.cli.ContainerWait(ctx, ID)
+	return err
+}
+
+// ContainerKill kills the given container
+func (c Client) ContainerKill(ID string) error {
+	ctx := context.Background()
+	return c.cli.ContainerKill(ctx, ID, "KILL")
+}

--- a/metricbeat/_meta/common.reference.yml
+++ b/metricbeat/_meta/common.reference.yml
@@ -25,3 +25,21 @@ metricbeat.config.modules:
 # Maximum amount of time to randomly delay the start of a metricset. Use 0 to
 # disable startup delay.
 metricbeat.max_start_delay: 10s
+
+#============================== Autodiscover ===================================
+
+# Autodiscover allows you to detect changes in the system and spawn new modules
+# as they happen.
+
+#metricbeat.autodiscover:
+  # List of enabled autodiscover providers
+#  providers:
+#    - type: docker
+#      templates:
+#        - condition:
+#            equals.docker.container.image: etcd
+#          config:
+#            - module: etcd
+#              metricsets: ["leader", "self", "store"]
+#              period: 10s
+#              hosts: ["${host}:2379"]

--- a/metricbeat/beater/autodiscover.go
+++ b/metricbeat/beater/autodiscover.go
@@ -1,0 +1,51 @@
+package beater
+
+import (
+	"errors"
+
+	"github.com/elastic/beats/libbeat/cfgfile"
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/bus"
+)
+
+// AutodiscoverAdapter for Metricbeat modules
+type AutodiscoverAdapter struct {
+	factory cfgfile.RunnerFactory
+}
+
+// NewAutodiscoverAdapter builds and returns an autodiscover adapter for Metricbeat modules
+func NewAutodiscoverAdapter(factory cfgfile.RunnerFactory) *AutodiscoverAdapter {
+	return &AutodiscoverAdapter{
+		factory: factory,
+	}
+}
+
+// CreateConfig generates a valid list of configs from the given event, the received event will have all keys defined by `StartFilter`
+func (m *AutodiscoverAdapter) CreateConfig(e bus.Event) ([]*common.Config, error) {
+	config, ok := e["config"].([]*common.Config)
+	if !ok {
+		return nil, errors.New("Got a wrong value in event `config` key")
+	}
+	return config, nil
+}
+
+// CheckConfig tests given config to check if it will work or not, returns errors in case it won't work
+func (m *AutodiscoverAdapter) CheckConfig(c *common.Config) error {
+	// TODO implment config check for all modules
+	return nil
+}
+
+// Create a module or prospector from the given config
+func (m *AutodiscoverAdapter) Create(c *common.Config, meta *common.MapStrPointer) (cfgfile.Runner, error) {
+	return m.factory.Create(c, meta)
+}
+
+// StartFilter returns the bus filter to retrieve runner start triggering events
+func (m *AutodiscoverAdapter) StartFilter() []string {
+	return []string{"start", "config"}
+}
+
+// StopFilter returns the bus filter to retrieve runner stop triggering events
+func (m *AutodiscoverAdapter) StopFilter() []string {
+	return []string{"stop", "config"}
+}

--- a/metricbeat/beater/config.go
+++ b/metricbeat/beater/config.go
@@ -3,15 +3,17 @@ package beater
 import (
 	"time"
 
+	"github.com/elastic/beats/libbeat/autodiscover"
 	"github.com/elastic/beats/libbeat/common"
 )
 
 // Config is the root of the Metricbeat configuration hierarchy.
 type Config struct {
 	// Modules is a list of module specific configuration data.
-	Modules       []*common.Config `config:"modules"`
-	ConfigModules *common.Config   `config:"config.modules"`
-	MaxStartDelay time.Duration    `config:"max_start_delay"` // Upper bound on the random startup delay for metricsets (use 0 to disable startup delay).
+	Modules       []*common.Config     `config:"modules"`
+	ConfigModules *common.Config       `config:"config.modules"`
+	MaxStartDelay time.Duration        `config:"max_start_delay"` // Upper bound on the random startup delay for metricsets (use 0 to disable startup delay).
+	Autodiscover  *autodiscover.Config `config:"autodiscover"`
 }
 
 var defaultConfig = Config{

--- a/metricbeat/beater/metricbeat.go
+++ b/metricbeat/beater/metricbeat.go
@@ -7,6 +7,7 @@ import (
 	"github.com/joeshaw/multierror"
 	"github.com/pkg/errors"
 
+	"github.com/elastic/beats/libbeat/autodiscover"
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/cfgfile"
 	"github.com/elastic/beats/libbeat/common"
@@ -21,9 +22,10 @@ import (
 
 // Metricbeat implements the Beater interface for metricbeat.
 type Metricbeat struct {
-	done    chan struct{}  // Channel used to initiate shutdown.
-	modules []staticModule // Active list of modules.
-	config  Config
+	done         chan struct{}  // Channel used to initiate shutdown.
+	modules      []staticModule // Active list of modules.
+	config       Config
+	autodiscover *autodiscover.Autodiscover
 }
 
 type staticModule struct {
@@ -41,7 +43,7 @@ func New(b *beat.Beat, rawConfig *common.Config) (beat.Beater, error) {
 		return nil, errors.Wrap(err, "error reading configuration file")
 	}
 
-	dynamicCfgEnabled := config.ConfigModules.Enabled()
+	dynamicCfgEnabled := config.ConfigModules.Enabled() || config.Autodiscover != nil
 	if !dynamicCfgEnabled && len(config.Modules) == 0 {
 		return nil, mb.ErrEmptyConfig
 	}
@@ -61,7 +63,7 @@ func New(b *beat.Beat, rawConfig *common.Config) (beat.Beater, error) {
 			failed = true
 		}
 
-		connector, err := module.NewConnector(b.Publisher, moduleCfg)
+		connector, err := module.NewConnector(b.Publisher, moduleCfg, nil)
 		if err != nil {
 			errs = append(errs, err)
 			failed = true
@@ -90,10 +92,22 @@ func New(b *beat.Beat, rawConfig *common.Config) (beat.Beater, error) {
 		return nil, mb.ErrAllModulesDisabled
 	}
 
+	var adiscover *autodiscover.Autodiscover
+	if config.Autodiscover != nil {
+		var err error
+		factory := module.NewFactory(config.MaxStartDelay, b.Publisher)
+		adapter := NewAutodiscoverAdapter(factory)
+		adiscover, err = autodiscover.NewAutodiscover("metricbeat", adapter, config.Autodiscover)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	mb := &Metricbeat{
-		done:    make(chan struct{}),
-		modules: modules,
-		config:  config,
+		done:         make(chan struct{}),
+		modules:      modules,
+		config:       config,
+		autodiscover: adiscover,
 	}
 	return mb, nil
 }
@@ -136,6 +150,16 @@ func (bt *Metricbeat) Run(b *beat.Beat) error {
 			defer wg.Done()
 			<-bt.done
 			moduleReloader.Stop()
+		}()
+	}
+
+	if bt.autodiscover != nil {
+		bt.autodiscover.Start()
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-bt.done
+			bt.autodiscover.Stop()
 		}()
 	}
 

--- a/metricbeat/mb/module/connector.go
+++ b/metricbeat/mb/module/connector.go
@@ -9,9 +9,10 @@ import (
 // Connector configures ann establishes a beat.Client for publishing events
 // to the publisher pipeline.
 type Connector struct {
-	pipeline   beat.Pipeline
-	processors *processors.Processors
-	eventMeta  common.EventMetadata
+	pipeline      beat.Pipeline
+	processors    *processors.Processors
+	eventMeta     common.EventMetadata
+	dynamicFields *common.MapStrPointer
 }
 
 type connectorConfig struct {
@@ -19,7 +20,7 @@ type connectorConfig struct {
 	common.EventMetadata `config:",inline"`      // Fields and tags to add to events.
 }
 
-func NewConnector(pipeline beat.Pipeline, c *common.Config) (*Connector, error) {
+func NewConnector(pipeline beat.Pipeline, c *common.Config, dynFields *common.MapStrPointer) (*Connector, error) {
 	config := connectorConfig{}
 	if err := c.Unpack(&config); err != nil {
 		return nil, err
@@ -31,9 +32,10 @@ func NewConnector(pipeline beat.Pipeline, c *common.Config) (*Connector, error) 
 	}
 
 	return &Connector{
-		pipeline:   pipeline,
-		processors: processors,
-		eventMeta:  config.EventMetadata,
+		pipeline:      pipeline,
+		processors:    processors,
+		eventMeta:     config.EventMetadata,
+		dynamicFields: dynFields,
 	}, nil
 }
 
@@ -41,5 +43,6 @@ func (c *Connector) Connect() (beat.Client, error) {
 	return c.pipeline.ConnectWith(beat.ClientConfig{
 		EventMetadata: c.eventMeta,
 		Processor:     c.processors,
+		DynamicFields: c.dynamicFields,
 	})
 }

--- a/metricbeat/mb/module/example_test.go
+++ b/metricbeat/mb/module/example_test.go
@@ -109,7 +109,7 @@ func ExampleRunner() {
 		return
 	}
 
-	connector, err := module.NewConnector(b.Publisher, config)
+	connector, err := module.NewConnector(b.Publisher, config, nil)
 	if err != nil {
 		return
 	}

--- a/metricbeat/mb/module/factory.go
+++ b/metricbeat/mb/module/factory.go
@@ -27,14 +27,14 @@ func NewFactory(maxStartDelay time.Duration, p beat.Pipeline) *Factory {
 	}
 }
 
-func (r *Factory) Create(c *common.Config) (cfgfile.Runner, error) {
+func (r *Factory) Create(c *common.Config, meta *common.MapStrPointer) (cfgfile.Runner, error) {
 	var errs multierror.Errors
 
 	err := cfgwarn.CheckRemoved5xSettings(c, "filters")
 	if err != nil {
 		errs = append(errs, err)
 	}
-	connector, err := NewConnector(r.pipeline, c)
+	connector, err := NewConnector(r.pipeline, c, meta)
 	if err != nil {
 		errs = append(errs, err)
 	}

--- a/metricbeat/mb/module/runner.go
+++ b/metricbeat/mb/module/runner.go
@@ -1,6 +1,7 @@
 package module
 
 import (
+	"fmt"
 	"sync"
 
 	"github.com/elastic/beats/libbeat/beat"
@@ -56,4 +57,8 @@ func (mr *runner) Stop() {
 		mr.client.Close()
 		mr.wg.Wait()
 	})
+}
+
+func (mr *runner) String() string {
+	return fmt.Sprintf("%s [metricsets=%d]", mr.mod.Name(), len(mr.mod.metricSets))
 }

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -26,6 +26,24 @@ metricbeat.config.modules:
 # disable startup delay.
 metricbeat.max_start_delay: 10s
 
+#============================== Autodiscover ===================================
+
+# Autodiscover allows you to detect changes in the system and spawn new modules
+# as they happen.
+
+#metricbeat.autodiscover:
+  # List of enabled autodiscover providers
+#  providers:
+#    - type: docker
+#      templates:
+#        - condition:
+#            equals.docker.container.image: etcd
+#          config:
+#            - module: etcd
+#              metricsets: ["leader", "self", "store"]
+#              period: 10s
+#              hosts: ["${host}:2379"]
+
 #==========================  Modules configuration ============================
 metricbeat.modules:
 

--- a/metricbeat/tests/system/config/metricbeat.yml.j2
+++ b/metricbeat/tests/system/config/metricbeat.yml.j2
@@ -139,6 +139,22 @@ processors:
 
 {%- endif %}
 
+#============================== Autodiscover ==================================
+
+{% if autodiscover %}
+metricbeat.autodiscover:
+  providers:
+  {%- for provider, settings in autodiscover.items() %}
+  - type: {{provider}}
+    {%- if settings %}
+    {%- for k, v in settings.items() %}
+    {{k}}:
+      {{v | default([])}}
+    {%- endfor %}
+    {%- endif %}
+  {%- endfor %}
+{% endif %}
+
 #================================ Queue =====================================
 
 queue.mem:

--- a/metricbeat/tests/system/test_autodiscover.py
+++ b/metricbeat/tests/system/test_autodiscover.py
@@ -1,0 +1,55 @@
+import os
+import metricbeat
+import unittest
+
+from time import sleep
+from beat.beat import INTEGRATION_TESTS
+
+
+class TestAutodiscover(metricbeat.BaseTest):
+    """
+    Test metricbeat autodiscover
+    """
+    @unittest.skipIf(not INTEGRATION_TESTS or
+                     os.getenv("TESTING_ENVIRONMENT") == "2x",
+                     "integration test not available on 2.x")
+    def test_docker(self):
+        """
+        Test docker autodiscover starts modules
+        """
+        import docker
+        docker_client = docker.from_env()
+
+        self.render_config_template(
+            autodiscover={
+                'docker': {
+                    'templates': '''
+                      - condition:
+                          equals.docker.container.image: memcached:1.5.3
+                        config:
+                          - module: memcached
+                            metricsets: ["stats"]
+                            period: 1s
+                            hosts: ["${data.host}:11211"]
+                    ''',
+                },
+            },
+        )
+
+        proc = self.start_beat()
+        docker_client.images.pull('memcached:1.5.3')
+        container = docker_client.containers.run('memcached:1.5.3', detach=True)
+
+        self.wait_until(lambda: self.log_contains('Autodiscover starting runner: memcached'))
+        sleep(2)
+
+        container.stop()
+        self.wait_until(lambda: self.log_contains('Autodiscover stopping runner: memcached'))
+
+        output = self.read_output_json()
+        proc.check_kill_and_wait()
+
+        # Check metadata is added
+        assert output[0]['docker']['container']['image'] == 'memcached:1.5.3'
+        assert output[0]['docker']['container']['labels'] == {}
+        assert 'name' in output[0]['docker']['container']


### PR DESCRIPTION
This PR adds support for Autodiscover, and implements a first provider for Docker.

### Autodiscover

Autodiscover allows the user to define different providers to watch for system changes and instantiate new modules as these happen.

Providers watch for changes and emit events to a common bus, then the autodiscovery process detect situations when there is something we can monitor and instantiate a modules for it.

Bus messages contain useful information about what providers see, with some common well-known optional fields (provider specific fields may also be present):

- host - service host
- port - service port
- config - recommended config for this instance (from the user or environment)

#### Docker provider

Docker provider watches for docker container events, it supports config mapping from container metadata -> config templates, so new modules are created when a container starts. The available data for a container (that you can use in the config template) is:

- host
- port
- docker.container.id
- docker.container.name
- docker.container.image
- docker.container.labels

#### Testing

This should be enough to monitor any present and future redis instances that run on docker:
```
metricbeat.autodiscover:
  providers:
    - type: docker
      templates:
        - condition:
            equals.docker.container.image: redis
          config:
            - module: redis
              metricsets: ["info", "keyspace"]
              hosts: "${data.host}:${data.port}"
```

Or reading redis logs only:
```
filebeat.autodiscover:
  providers:
    - type: docker
      templates:
        - condition:
            equals.docker.container.image: redis
          config:
            - type: log
              paths:
                - /var/lib/docker/containers/${data.docker.container.id}/*.log
```

You can launch it like this:
```
docker run -p 6379:6379 redis
```
This PR is in progress, with some missing parts:
- [x] Revisit Docker IP/port mapping, do we really need exposed ports? probably not
- [x] Add support in filebeat
- [x] Revisit bus implementation, use interfaces (instead of MapStr)?
- [x] Add docker metadata to modules discovered by docker provider
- [x] System tests
- [x] Update metricbeat and filebeat YAML files
- [ ] Docs