### PR TITLE
Backport: Cherrypick multiple PRs into 6.0

### DIFF
--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -812,5 +812,9 @@ logging.files:
   # Number of rotated log files to keep. Oldest files will be deleted first.
   #keepfiles: 7
 
+  # The permissions mask to apply when rotating log files. The default value is 0600.
+  # Must be a valid Unix-style file permissions mask expressed in octal notation.
+  #permissions: 0600
+
 # Set to true to log messages in json format.
 #logging.json: false

--- a/auditbeat/docs/index.asciidoc
+++ b/auditbeat/docs/index.asciidoc
@@ -2,6 +2,8 @@
 
 include::../../libbeat/docs/version.asciidoc[]
 
+include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
+
 :libbeat: http://www.elastic.co/guide/en/beats/libbeat/{doc-branch}
 :kibana-ref: https://www.elastic.co/guide/en/kibana/{doc-branch}
 :beatsdevguide: http://www.elastic.co/guide/en/beats/devguide/{doc-branch}

--- a/filebeat/docs/index.asciidoc
+++ b/filebeat/docs/index.asciidoc
@@ -2,6 +2,8 @@
 
 include::../../libbeat/docs/version.asciidoc[]
 
+include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
+
 :libbeat: http://www.elastic.co/guide/en/beats/libbeat/{doc-branch}
 :kibana-ref: https://www.elastic.co/guide/en/kibana/{doc-branch}
 :beatsdevguide: http://www.elastic.co/guide/en/beats/devguide/{doc-branch}

--- a/filebeat/docs/modules/redis.asciidoc
+++ b/filebeat/docs/modules/redis.asciidoc
@@ -9,8 +9,8 @@ experimental[]
 
 This module has two filesets:
 
-* The `log` fileset collects and parses the logs that Redis writes to disk.  The `slowlog` fileset
-* connects to Redis via the network and retrieves the slow logs
+* The `log` fileset collects and parses the logs that Redis writes to disk.  
+* The `slowlog` fileset connects to Redis via the network and retrieves the slow logs
   by using the `SLOWLOG` command.
 
 For the `log` fileset, make sure the `logfile` option is set in the Redis configuration file. For

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -1203,5 +1203,9 @@ logging.files:
   # Number of rotated log files to keep. Oldest files will be deleted first.
   #keepfiles: 7
 
+  # The permissions mask to apply when rotating log files. The default value is 0600.
+  # Must be a valid Unix-style file permissions mask expressed in octal notation.
+  #permissions: 0600
+
 # Set to true to log messages in json format.
 #logging.json: false

--- a/filebeat/module/redis/_meta/docs.asciidoc
+++ b/filebeat/module/redis/_meta/docs.asciidoc
@@ -4,8 +4,8 @@ experimental[]
 
 This module has two filesets:
 
-* The `log` fileset collects and parses the logs that Redis writes to disk.  The `slowlog` fileset
-* connects to Redis via the network and retrieves the slow logs
+* The `log` fileset collects and parses the logs that Redis writes to disk.  
+* The `slowlog` fileset connects to Redis via the network and retrieves the slow logs
   by using the `SLOWLOG` command.
 
 For the `log` fileset, make sure the `logfile` option is set in the Redis configuration file. For

--- a/heartbeat/docs/heartbeat-options.asciidoc
+++ b/heartbeat/docs/heartbeat-options.asciidoc
@@ -139,7 +139,7 @@ will be overwritten by the value declared here.
 [[monitor-fields-under-root]]
 ==== `fields_under_root`
 
-If this option is set to true, the custom <<monitor-fields>>
+If this option is set to true, the custom <<monitor-fields,fields>>
 are stored as top-level fields in the output document instead of being grouped
 under a `fields` sub-dictionary. If the custom field names conflict with other
 field names added by Heartbeat, then the custom fields overwrite the other

--- a/heartbeat/docs/index.asciidoc
+++ b/heartbeat/docs/index.asciidoc
@@ -2,6 +2,8 @@
 
 include::../../libbeat/docs/version.asciidoc[]
 
+include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
+
 :libbeat: http://www.elastic.co/guide/en/beats/libbeat/{doc-branch}
 :kibana-ref: https://www.elastic.co/guide/en/kibana/{doc-branch}
 :beatsdevguide: http://www.elastic.co/guide/en/beats/devguide/{doc-branch}

--- a/heartbeat/heartbeat.reference.yml
+++ b/heartbeat/heartbeat.reference.yml
@@ -961,5 +961,9 @@ logging.files:
   # Number of rotated log files to keep. Oldest files will be deleted first.
   #keepfiles: 7
 
+  # The permissions mask to apply when rotating log files. The default value is 0600.
+  # Must be a valid Unix-style file permissions mask expressed in octal notation.
+  #permissions: 0600
+
 # Set to true to log messages in json format.
 #logging.json: false

--- a/libbeat/_meta/config.reference.yml
+++ b/libbeat/_meta/config.reference.yml
@@ -747,5 +747,9 @@ logging.files:
   # Number of rotated log files to keep. Oldest files will be deleted first.
   #keepfiles: 7
 
+  # The permissions mask to apply when rotating log files. The default value is 0600.
+  # Must be a valid Unix-style file permissions mask expressed in octal notation.
+  #permissions: 0600
+
 # Set to true to log messages in json format.
 #logging.json: false

--- a/libbeat/docs/breaking.asciidoc
+++ b/libbeat/docs/breaking.asciidoc
@@ -119,14 +119,14 @@ following command:
 
 ["source","sh",subs="attributes"]
 ----
-./scripts/import_dashboards -user elastic -pass changeme
+./scripts/import_dashboards -user elastic -pass {pwd}
 ----
 
 Can be replaced with:
 
 ["source","sh",subs="attributes"]
 ----
-./filebeat setup -E "output.elasticsearch.username=elastic" -E "output.elasticsearch.password=changeme"
+./filebeat setup -E "output.elasticsearch.username=elastic" -E "output.elasticsearch.password={pwd}"
 ----
 
 Note that the `-E` flags are only required if the Elasticsearch output is not

--- a/libbeat/docs/communitybeats.asciidoc
+++ b/libbeat/docs/communitybeats.asciidoc
@@ -27,6 +27,7 @@ https://github.com/goomzee/cassandrabeat[cassandrabeat]:: Uses Cassandra's nodet
 https://github.com/hartfordfive/cloudflarebeat[cloudflarebeat]:: Indexes log entries from the Cloudflare Enterprise Log Share API.
 https://github.com/jarl-tornroos/cloudfrontbeat[cloudfrontbeat]:: Reads log events from Amazon Web Services https://aws.amazon.com/cloudfront/[CloudFront].
 https://github.com/aidan-/cloudtrailbeat[cloudtrailbeat]:: Reads events from Amazon Web Services' https://aws.amazon.com/cloudtrail/[CloudTrail].
+https://github.com/narmitech/cloudwatchmetricbeat[cloudwatchmetricbeat]::  A beat for Amazon Web Services' https://aws.amazon.com/cloudwatch/details/#other-aws-resource-monitoring[CloudWatch Metrics]. 
 https://github.com/e-travel/cloudwatchlogsbeat[cloudwatchlogsbeat]:: Reads log events from Amazon Web Services' https://aws.amazon.com/cloudwatch/details/#log-monitoring[CloudWatch Logs].
 https://github.com/raboof/connbeat[connbeat]:: Exposes metadata about TCP connections.
 https://github.com/Pravoru/consulbeat[consulbeat]:: Reads services health checks from consul and pushes them to Elastic.

--- a/libbeat/docs/index.asciidoc
+++ b/libbeat/docs/index.asciidoc
@@ -3,6 +3,8 @@
 
 include::./version.asciidoc[]
 
+include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
+
 :packetbeat: http://www.elastic.co/guide/en/beats/packetbeat/{doc-branch}
 :metricbeat: http://www.elastic.co/guide/en/beats/metricbeat/{doc-branch}
 :filebeat: http://www.elastic.co/guide/en/beats/filebeat/{doc-branch}

--- a/libbeat/docs/loggingconfig.asciidoc
+++ b/libbeat/docs/loggingconfig.asciidoc
@@ -40,12 +40,12 @@ the logging output configuration from the command line. See
 You can specify the following options in the `logging` section of the +{beatname_lc}.yml+ config file:
 
 [float]
-==== `to_syslog`
+==== `logging.to_syslog`
 
 When true, writes all logging output to the syslog.
 
 [float]
-==== `to_files`
+==== `logging.to_files`
 
 When true, writes all logging output to files. The log files are automatically
 rotated when the log file size limit is reached.
@@ -56,7 +56,7 @@ there will be no log file in the directory specified for logs.
 
 [float]
 [[level]]
-==== `level`
+==== `logging.level`
 
 Minimum log level. One of `debug`, `info`, `warning`, `error`, or `critical`.
 The default log level is `info`.
@@ -79,7 +79,7 @@ that are published. Also logs any warnings, errors, or critical errors.
 
 [float]
 [[selectors]]
-==== `selectors`
+==== `logging.selectors`
 
 The list of debugging-only selector tags used by different Beats components. Use `*`
 to enable debug output for all components. For example add `publish` to display
@@ -88,7 +88,7 @@ selectors can be overwritten using the `-d` command line option (`-d` also sets
 the debug log level).
 
 [float]
-==== `metrics.enabled`
+==== `logging.metrics.enabled`
 
 If enabled, {beatname_uc} periodically logs its internal metrics that have
 changed in the last period. For each metric that changed, the delta from the
@@ -107,47 +107,53 @@ metrics and for this reason they are also not documented.
 
 
 [float]
-==== `metrics.period`
+==== `logging.metrics.period`
 
 The period after which to log the internal metrics. The default is 30s.
 
 [float]
-==== `files.path`
+==== `logging.files.path`
 
 The directory that log files are written to. The default is the logs path. See the
 <<directory-layout>> section for details.
 
 [float]
-==== `files.name`
+==== `logging.files.name`
 
 The name of the file that logs are written to. By default, the name of the Beat
 is used.
 
 [float]
-==== `files.rotateeverybytes`
+==== `logging.files.rotateeverybytes`
 
 The maximum size of a log file. If the limit is reached, a new log file is generated.
 The default size limit is 10485760 (10 MB).
 
 [float]
-==== `files.keepfiles`
+==== `logging.files.keepfiles`
 
 The number of most recent rotated log files to keep on disk. Older files are
 deleted during log rotation. The default value is 7. The `keepfiles` options has to be
 in the range of 2 to 1024 files.
 
 [float]
-==== `files.permissions`
+==== `logging.files.permissions`
 
-The permission mask to apply when rotating log files. The default value is 0600. The
- `permissions` options must be a valid Unix-style file permissions mask expressed
+The permissions mask to apply when rotating log files. The default value is 0600. The
+ `permissions` option must be a valid Unix-style file permissions mask expressed
  in octal notation. In Go, numbers in octal notation must start with '0'.
 
 Examples:
+
 * 0644: give read and write access to the file owner, and read access to all others.
 * 0600: give read and write access to the file owner, and no access to all others.
 * 0664: give read and write access to the file owner and members of the group
 associated with the file, as well as read access to all other users.
+
+[float]
+==== `logging.json`
+
+When true, logs messages in JSON format. The default is false.
 
 [float]
 === Logging format

--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -1102,22 +1102,26 @@ output.console:
 [[configure-cloud-id]]
 === Configure the output for the Elastic Cloud
 
+++++
+<titleabbrev>Cloud</titleabbrev>
+++++
+
 {beatname_uc} comes with two settings that simplify the output configuration
 when used together with https://cloud.elastic.co/[Elastic Cloud]. When defined,
 these setting overwrite settings from other parts in the configuration.
 
 Example:
 
-[source,yaml]
+["source","yaml",subs="attributes"]
 ------------------------------------------------------------------------------
 cloud.id: "staging:dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyRjZWM2ZjI2MWE3NGJmMjRjZTMzYmI4ODExYjg0Mjk0ZiRjNmMyY2E2ZDA0MjI0OWFmMGNjN2Q3YTllOTYyNTc0Mw=="
-cloud.auth: "elastic:changeme"
+cloud.auth: "elastic:{pwd}"
 ------------------------------------------------------------------------------
 
 These settings can be also specified at the command line, like this:
 
 
-["source","sh",subs="attributes,callouts"]
+["source","sh",subs="attributes"]
 ------------------------------------------------------------------------------
 {beatname_lc} -e -E cloud.id="<cloud-id>" -E cloud.auth="<cloud.auth>"
 ------------------------------------------------------------------------------

--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -42,9 +42,6 @@ Example configuration:
 
 output.elasticsearch:
   hosts: ["http://localhost:9200"]
-  template.enabled: true
-  template.fields: "fields.yml"
-  template.overwrite: false
   index: "{beatname_lc}"
   ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
   ssl.certificate: "/etc/pki/client/cert.pem"

--- a/libbeat/docs/processors-using.asciidoc
+++ b/libbeat/docs/processors-using.asciidoc
@@ -410,7 +410,7 @@ processors:
      fields: ["field1", "field2", ...]
      process_array: false
      max_depth: 1
-     target:
+     target: ""
      overwrite_keys: false
 -----------------------------------------------------
 
@@ -423,7 +423,8 @@ arrays. The default is false.
 `target`:: (Optional) The field under which the decoded JSON will be written. By
 default the decoded JSON object replaces the string field from which it was
 read. To merge the decoded JSON fields into the root of the event, specify
-`target` with an empty value (`target:`).
+`target` with an empty string (`target: ""`). Note that the `null` value (`target:`)
+is treated as if the field was not set at all.
 `overwrite_keys`:: (Optional) A boolean that specifies whether keys that already
 exist in the event are overwritten by keys from the decoded JSON object. The
 default value is false.

--- a/metricbeat/docs/index.asciidoc
+++ b/metricbeat/docs/index.asciidoc
@@ -2,6 +2,8 @@
 
 include::../../libbeat/docs/version.asciidoc[]
 
+include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
+
 :libbeat: http://www.elastic.co/guide/en/beats/libbeat/{doc-branch}
 :kibana-ref: https://www.elastic.co/guide/en/kibana/{doc-branch}
 :beatsdevguide: http://www.elastic.co/guide/en/beats/devguide/{doc-branch}

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -1167,5 +1167,9 @@ logging.files:
   # Number of rotated log files to keep. Oldest files will be deleted first.
   #keepfiles: 7
 
+  # The permissions mask to apply when rotating log files. The default value is 0600.
+  # Must be a valid Unix-style file permissions mask expressed in octal notation.
+  #permissions: 0600
+
 # Set to true to log messages in json format.
 #logging.json: false

--- a/packetbeat/docs/index.asciidoc
+++ b/packetbeat/docs/index.asciidoc
@@ -2,6 +2,8 @@
 
 include::../../libbeat/docs/version.asciidoc[]
 
+include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
+
 :libbeat: http://www.elastic.co/guide/en/beats/libbeat/{doc-branch}
 :kibana-ref: https://www.elastic.co/guide/en/kibana/{doc-branch}
 :beatsdevguide: http://www.elastic.co/guide/en/beats/devguide/{doc-branch}

--- a/packetbeat/docs/packetbeat-options.asciidoc
+++ b/packetbeat/docs/packetbeat-options.asciidoc
@@ -369,7 +369,7 @@ will be overwritten by the value declared here.
 [float]
 ==== `fields_under_root`
 
-If this option is set to true, the custom <<packetbeat-configuration-flows-fields>>
+If this option is set to true, the custom <<packetbeat-configuration-flows-fields,fields>>
 are stored as top-level fields in the output document instead of being grouped
 under a `fields` sub-dictionary. If the custom field names conflict with other
 field names added by Packetbeat, then the custom fields overwrite the other
@@ -514,7 +514,7 @@ packetbeat.protocols:
 [[packetbeat-fields-under-root]]
 ==== `fields_under_root`
 
-If this option is set to true, the custom <<packetbeat-configuration-fields>>
+If this option is set to true, the custom <<packetbeat-configuration-fields,fields>>
 are stored as top-level fields in the output document instead of being grouped
 under a `fields` sub-dictionary. If the custom field names conflict with other
 field names added by Packetbeat, then the custom fields overwrite the other

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -1199,5 +1199,9 @@ logging.files:
   # Number of rotated log files to keep. Oldest files will be deleted first.
   #keepfiles: 7
 
+  # The permissions mask to apply when rotating log files. The default value is 0600.
+  # Must be a valid Unix-style file permissions mask expressed in octal notation.
+  #permissions: 0600
+
 # Set to true to log messages in json format.
 #logging.json: false

--- a/winlogbeat/docs/index.asciidoc
+++ b/winlogbeat/docs/index.asciidoc
@@ -2,6 +2,8 @@
 
 include::../../libbeat/docs/version.asciidoc[]
 
+include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
+
 :libbeat: http://www.elastic.co/guide/en/beats/libbeat/{doc-branch}
 :kibana-ref: https://www.elastic.co/guide/en/kibana/{doc-branch}
 :beatsdevguide: http://www.elastic.co/guide/en/beats/devguide/{doc-branch}

--- a/winlogbeat/docs/winlogbeat-options.asciidoc
+++ b/winlogbeat/docs/winlogbeat-options.asciidoc
@@ -335,7 +335,7 @@ winlogbeat.event_logs:
 [float]
 ==== `event_logs.fields_under_root`
 
-If this option is set to true, the custom <<winlogbeat-configuration-fields>>
+If this option is set to true, the custom <<winlogbeat-configuration-fields,fields>>
 are stored as top-level fields in the output document instead of being grouped
 under a `fields` sub-dictionary. If the custom field names conflict with other
 field names added by Winlogbeat, then the custom fields overwrite the other

--- a/winlogbeat/winlogbeat.reference.yml
+++ b/winlogbeat/winlogbeat.reference.yml
@@ -776,5 +776,9 @@ logging.files:
   # Number of rotated log files to keep. Oldest files will be deleted first.
   #keepfiles: 7
 
+  # The permissions mask to apply when rotating log files. The default value is 0600.
+  # Must be a valid Unix-style file permissions mask expressed in octal notation.
+  #permissions: 0600
+
 # Set to true to log messages in json format.
 #logging.json: false


### PR DESCRIPTION
Cherrypicks the following PRs:

https://github.com/elastic/beats/pull/4919 
https://github.com/elastic/beats/pull/4931
https://github.com/elastic/beats/pull/5118
https://github.com/elastic/beats/pull/5143
https://github.com/elastic/beats/pull/5214
https://github.com/elastic/beats/pull/5177

Also implements the following PR, which couldn't be cherry-picked easily due to refactoring that happened in 6.0:

https://github.com/elastic/beats/pull/4845