### PR TITLE
improve scaffold for common/mapstr

### DIFF
--- a/libbeat/common/mapstr_test.go
+++ b/libbeat/common/mapstr_test.go
@@ -473,6 +473,69 @@ func TestFlatten(t *testing.T) {
 	}
 }
 
+func TestGetStringValue(t *testing.T) {
+	m := MapStr{
+		"a": "b",
+		"b": "c",
+	}
+
+	assert.Equal(t, "b", m.GetStringValue("a"))
+	assert.Equal(t, "", m.GetStringValue("c"))
+}
+
+func TestGetInt64Value(t *testing.T) {
+	m := MapStr{
+		"int":       123456,
+		"float":     123456.0,
+		"short_int": 1,
+		"str_int":   "789",
+		"err_int":   "kkk",
+	}
+
+	assert.Equal(t, int64(123456), m.GetInt64Value("int"))
+	assert.Equal(t, int64(123456), m.GetInt64Value("float"))
+	assert.Equal(t, int64(1), m.GetInt64Value("short_int"))
+	assert.Equal(t, int64(789), m.GetInt64Value("str_int"))
+	assert.Equal(t, int64(0), m.GetInt64Value("err_int"))
+}
+
+func TestGetStringArray(t *testing.T) {
+	m := MapStr{
+		"a": []string{"b", "c"},
+	}
+	array := m.GetStringArray("a")
+	assert.Equal(t, 2, len(array))
+}
+
+func TestGetObjectArray(t *testing.T) {
+	str := fmt.Sprintf(`{
+		"a": [
+		{"i":"j"},
+		{"k":"n"}
+		]
+	}`)
+
+	m, err := MapStrUnmarshal([]byte(str))
+	assert.Nil(t, err)
+	array := m.GetObjectArray("a")
+	assert.Equal(t, 2, len(array))
+	assert.Equal(t, "j", array[0].GetStringValue("i"))
+
+	obj := MapStr{
+		"a": []MapStr{
+			MapStr{
+				"i": "j",
+			},
+			MapStr{
+				"k": "n",
+			},
+		},
+	}
+	array2 := obj.GetObjectArray("a")
+	assert.Equal(t, 2, len(array2))
+	assert.Equal(t, "j", array2[0].GetStringValue("i"))
+}
+
 func BenchmarkMapStrFlatten(b *testing.B) {
 	m := MapStr{
 		"test": 15,


### PR DESCRIPTION
the following functions try to walk the MapStr according to the key path, and return converted type instead of interface{}. easier to deal with json

- GetValueNoErr: return nil instead of err
- GetStringValue,GetStringValueWithDefault: return converted string or ""
- GetInt64Value,GetInt64ValueWithDefault,GetFloat64Value,GetFloat64ValueWithDefault: return converted numeric or 0
- GetObject,GetObjectWithDefault: return nested MapStr or nil
- GetObjectArray,GetStringArray: return []MapStr or []string or nil
- MapStrUnmarshal: unmarshal from []byte to MapStr
- MarshalBinary: encoding.BinaryMarshaler implementation