### PR TITLE
Uses sha512 instead of sha1 in the 6.0 branch

### DIFF
--- a/testing/environments/docker/elasticsearch/Dockerfile-snapshot
+++ b/testing/environments/docker/elasticsearch/Dockerfile-snapshot
@@ -21,8 +21,8 @@ WORKDIR /usr/share/elasticsearch
 
 # Download/extract defined ES version. busybox tar can't strip leading dir.
 RUN curl -L -o elasticsearch-${ELASTIC_VERSION}.tar.gz ${DOWNLOAD_URL}/elasticsearch/elasticsearch-${ELASTIC_VERSION}.tar.gz?c=${CACHE_BUST} && \
-    EXPECTED_SHA=$(wget -O - ${DOWNLOAD_URL}/elasticsearch/elasticsearch-${ELASTIC_VERSION}.tar.gz.sha1) && \
-    test $EXPECTED_SHA == $(sha1sum elasticsearch-${ELASTIC_VERSION}.tar.gz | awk '{print $1}') && \
+    EXPECTED_SHA=$(wget -O - ${DOWNLOAD_URL}/elasticsearch/elasticsearch-${ELASTIC_VERSION}.tar.gz.sha512) && \
+    test $EXPECTED_SHA == $(sha512sum elasticsearch-${ELASTIC_VERSION}.tar.gz | awk '{print $1}') && \
     tar zxf elasticsearch-${ELASTIC_VERSION}.tar.gz && \
     chown -R elasticsearch:elasticsearch elasticsearch-${ELASTIC_VERSION} && \
     mv elasticsearch-${ELASTIC_VERSION}/* . && \


### PR DESCRIPTION
This should fix the build errors.