### PR TITLE
Fix mapping for ceph num_remapped_pgs field

### DIFF
--- a/metricbeat/docs/fields.asciidoc
+++ b/metricbeat/docs/fields.asciidoc
@@ -1065,7 +1065,7 @@ Shows how many osds are on the state of IN
 
 
 [float]
-=== `ceph.cluster_status.osd.num_in_osds`
+=== `ceph.cluster_status.osd.num_remapped_pgs`
 
 type: long
 

--- a/metricbeat/module/ceph/cluster_status/_meta/fields.yml
+++ b/metricbeat/module/ceph/cluster_status/_meta/fields.yml
@@ -103,7 +103,7 @@
       type: long
       description: >
         Shows how many osds are on the state of IN
-    - name: osd.num_in_osds
+    - name: osd.num_remapped_pgs
       type: long
       description: >
         Shows how many osds are on the state of REMAPPED


### PR DESCRIPTION
The field num_remapped_pgs was mapped as num_in_osds which lead to a field defined twice and the mapping of the field did not exist.

@simitt Thanks for finding this