### PR TITLE
metricbeat: add more node_stats metrics in elasticseach module

### DIFF
--- a/metricbeat/docs/fields.asciidoc
+++ b/metricbeat/docs/fields.asciidoc
@@ -2798,6 +2798,93 @@ Total size of the store in bytes.
 
 
 [float]
+=== `elasticsearch.node.stats.indices.fielddata.memory.bytes`
+
+type: long
+
+Bytes of memory used by fielddata.
+
+
+[float]
+=== `elasticsearch.node.stats.indices.search.query.total`
+
+type: long
+
+Total count of query.
+
+
+[float]
+=== `elasticsearch.node.stats.indices.search.query.current`
+
+type: long
+
+Current count of query.
+
+
+[float]
+=== `elasticsearch.node.stats.indices.search.query.ms`
+
+type: long
+
+The taked millisecond of query.
+
+
+[float]
+=== `elasticsearch.node.stats.indices.indexing.index.total`
+
+type: long
+
+Total count of indexing index.
+
+
+[float]
+=== `elasticsearch.node.stats.indices.indexing.index.current`
+
+type: long
+
+Current count of indexing index.
+
+
+[float]
+=== `elasticsearch.node.stats.indices.indexing.index.ms`
+
+type: long
+
+The taked millisecond of indexing index.
+
+
+[float]
+== jvm.mem.heap fields
+
+JVM memory heap
+
+
+
+[float]
+=== `elasticsearch.node.stats.jvm.mem.heap.used.bytes`
+
+type: long
+
+JVM memory heap used bytes.
+
+
+[float]
+=== `elasticsearch.node.stats.jvm.mem.heap.max.bytes`
+
+type: long
+
+JVM memory heap max bytes.
+
+
+[float]
+=== `elasticsearch.node.stats.jvm.mem.heap.percent`
+
+type: long
+
+JVM memory heap used percent.         
+
+
+[float]
 == jvm.mem.pools fields
 
 JVM memory pool stats
@@ -2952,6 +3039,7 @@ Old collection gc.
 
 type: long
 
+Old collection count
 
 
 [float]
@@ -2959,6 +3047,7 @@ type: long
 
 type: long
 
+Old collection millisecond
 
 
 [float]
@@ -2973,6 +3062,7 @@ Young collection gc.
 
 type: long
 
+Young collection count
 
 
 [float]
@@ -2980,6 +3070,7 @@ type: long
 
 type: long
 
+Young collection millisecond
 
 
 [float]
@@ -2996,6 +3087,7 @@ type: long
 
 format: bytes
 
+The total disk space in bytes.
 
 
 [float]
@@ -3005,6 +3097,7 @@ type: long
 
 format: bytes
 
+The disk space free in bytes.
 
 
 [float]
@@ -3014,6 +3107,109 @@ type: long
 
 format: bytes
 
+The disk space available in bytes.
+
+
+[float]
+== threadpool fields
+
+Node threadpool stats
+
+
+
+[float]
+=== `elasticsearch.node.stats.threadpool.bulk.active`
+
+type: long
+
+The count of bulk threads.
+
+
+[float]
+=== `elasticsearch.node.stats.threadpool.bulk.queue`
+
+type: long
+
+The length of bulk queue.
+
+
+[float]
+=== `elasticsearch.node.stats.threadpool.bulk.rejected`
+
+type: long
+
+The count of rejected bulk.
+
+
+[float]
+=== `elasticsearch.node.stats.threadpool.index.active`
+
+type: long
+
+The count of index threads.
+
+
+[float]
+=== `elasticsearch.node.stats.threadpool.index.queue`
+
+type: long
+
+The length of index queue.
+
+
+[float]
+=== `elasticsearch.node.stats.threadpool.index.rejected`
+
+type: long
+
+The count of rejected index.
+
+
+[float]
+=== `elasticsearch.node.stats.threadpool.search.active`
+
+type: long
+
+The count of search threads.
+
+
+[float]
+=== `elasticsearch.node.stats.threadpool.search.queue`
+
+type: long
+
+The length of search queue.
+
+
+[float]
+=== `elasticsearch.node.stats.threadpool.search.rejected`
+
+type: long
+
+The count of rejected bulk.
+
+
+[float]
+== transport fields
+
+Node network transport stats
+
+
+
+[float]
+=== `elasticsearch.node.stats.transport.rx.bytes`
+
+type: long
+
+The bytes of network received.
+
+
+[float]
+=== `elasticsearch.node.stats.transport.tx.bytes`
+
+type: long
+
+The bytes of network sent.
 
 
 [[exported-fields-etcd]]

--- a/metricbeat/module/elasticsearch/node_stats/_meta/data.json
+++ b/metricbeat/module/elasticsearch/node_stats/_meta/data.json
@@ -1,118 +1,171 @@
 {
-    "@timestamp": "2017-10-12T08:05:34.853Z",
-    "beat": {
-        "hostname": "host.example.com",
-        "name": "host.example.com"
+    "@timestamp":"2017-10-12T08:05:34.853Z",
+    "beat":{
+        "hostname":"host.example.com",
+        "name":"host.example.com"
     },
-    "elasticsearch": {
-        "cluster": {
-            "name": "docker-cluster"
+    "elasticsearch":{
+        "cluster":{
+            "name":"docker-cluster"
         },
-        "node": {
-            "name": "ab1_1Gw3Rtax_2l78Gq_CQ",
-            "stats": {
-                "fs": {
-                    "summary": {
-                        "available": {
-                            "bytes": 50680381440
-                        },
-                        "free": {
-                            "bytes": 54133080064
-                        },
-                        "total": {
-                            "bytes": 67371577344
-                        }
+        "node":{
+            "name":"ab1_1Gw3Rtax_2l78Gq_CQ",
+            "stats":{
+                "transport":{
+                    "rx":{
+                        "bytes":69499143153
+                    },
+                    "tx":{
+                        "bytes":65533488888
                     }
                 },
-                "indices": {
-                    "docs": {
-                        "count": 52,
-                        "deleted": 4
-                    },
-                    "segments": {
-                        "count": 3,
-                        "memory": {
-                            "bytes": 20655
-                        }
-                    },
-                    "store": {
-                        "size": {
-                            "bytes": 107559
-                        }
-                    }
-                },
-                "jvm": {
-                    "gc": {
-                        "collectors": {
-                            "old": {
-                                "collection": {
-                                    "count": 7,
-                                    "ms": 3801
+                "jvm":{
+                    "mem":{
+                        "heap":{
+                            "used":4086798088,
+                            "max":8476557312,
+                            "percent":48
+                        },
+                        "pools":{
+                            "survivor":{
+                                "peak":{
+                                    "bytes":113377280
+                                },
+                                "peak_max":{
+                                    "bytes":113377280
+                                },
+                                "used":{
+                                    "bytes":5231000
+                                },
+                                "max":{
+                                    "bytes":113377280
                                 }
                             },
-                            "young": {
-                                "collection": {
-                                    "count": 56,
-                                    "ms": 14782
+                            "old":{
+                                "peak":{
+                                    "bytes":3458832248
+                                },
+                                "peak_max":{
+                                    "bytes":7455834112
+                                },
+                                "used":{
+                                    "bytes":3458832248
+                                },
+                                "max":{
+                                    "bytes":7455834112
+                                }
+                            },
+                            "young":{
+                                "peak_max":{
+                                    "bytes":907345920
+                                },
+                                "used":{
+                                    "bytes":622734840
+                                },
+                                "max":{
+                                    "bytes":907345920
+                                },
+                                "peak":{
+                                    "bytes":907345920
                                 }
                             }
                         }
                     },
-                    "mem": {
-                        "pools": {
-                            "old": {
-                                "max": {
-                                    "bytes": 62914560
-                                },
-                                "peak": {
-                                    "bytes": 53816432
-                                },
-                                "peak_max": {
-                                    "bytes": 62914560
-                                },
-                                "used": {
-                                    "bytes": 40017472
+                    "gc":{
+                        "collectors":{
+                            "young":{
+                                "collection":{
+                                    "ms":52937,
+                                    "count":2959
                                 }
                             },
-                            "survivor": {
-                                "max": {
-                                    "bytes": 3145728
-                                },
-                                "peak": {
-                                    "bytes": 3145728
-                                },
-                                "peak_max": {
-                                    "bytes": 3145728
-                                },
-                                "used": {
-                                    "bytes": 3145728
-                                }
-                            },
-                            "young": {
-                                "max": {
-                                    "bytes": 25165824
-                                },
-                                "peak": {
-                                    "bytes": 25165824
-                                },
-                                "peak_max": {
-                                    "bytes": 25165824
-                                },
-                                "used": {
-                                    "bytes": 21071064
+                            "old":{
+                                "collection":{
+                                    "count":2,
+                                    "ms":239
                                 }
                             }
+                        }
+                    }
+                },
+                "indices":{
+                    "docs":{
+                        "count":141386725,
+                        "deleted":97241
+                    },
+                    "store":{
+                        "size":{
+                            "bytes":39412567584
+                        }
+                    },
+                    "segments":{
+                        "count":2614,
+                        "memory":{
+                            "bytes":139939375
+                        }
+                    },
+                    "fielddata":{
+                        "memory":{
+                            "bytes":500960
+                        }
+                    },
+                    "search":{
+                        "query":{
+                            "time":{
+                                "millis":656046
+                            },
+                            "total":320583,
+                            "current":0
+                        }
+                    },
+                    "indexing":{
+                        "index":{
+                            "current":0,
+                            "time":{
+                                "millis":160646
+                            },
+                            "total":508447
+                        }
+                    }
+                },
+                "threadpool":{
+                    "bulk":{
+                        "rejected":0,
+                        "queue":0,
+                        "active":0
+                    },
+                    "search":{
+                        "active":0,
+                        "rejected":0,
+                        "queue":0
+                    },
+                    "index":{
+                        "queue":0,
+                        "active":0,
+                        "rejected":0
+                    }
+                },
+                "fs":{
+                    "summary":{
+                        "total":{
+                            "bytes":316928753664
+                        },
+                        "free":{
+                            "bytes":276802535424
+                        },
+                        "available":{
+                            "bytes":260679843840
                         }
                     }
                 }
             }
         }
     },
-    "metricset": {
-        "host": "elasticsearch:9200",
-        "module": "elasticsearch",
-        "name": "node_stats",
-        "namespace": "node.stats",
-        "rtt": 115
+    "metricset":{
+        "host":"elasticsearch:9200",
+        "module":"elasticsearch",
+        "name":"node_stats",
+        "namespace":"node.stats",
+        "rtt":115
     }
 }

--- a/metricbeat/module/elasticsearch/node_stats/_meta/fields.yml
+++ b/metricbeat/module/elasticsearch/node_stats/_meta/fields.yml
@@ -30,6 +30,53 @@
           type: long
           description: >
             Total size of the store in bytes.
+        - name: fielddata.memory.bytes
+          type: long
+          description: >
+            Bytes of memory used by fielddata.
+        - name: search.query.total
+          type: long
+          description: >
+            Total count of query.
+        - name: search.query.current
+          type: long
+          description: >
+            Current count of query.
+        - name: search.query.ms
+          type: long
+          description: >
+            The taked millisecond of query.
+        - name: indexing.index.total
+          type: long
+          description: >
+            Total count of indexing index.
+        - name: indexing.index.current
+          type: long
+          description: >
+            Current count of indexing index.
+        - name: indexing.index.ms
+          type: long
+          description: >
+            The taked millisecond of indexing index.
+
+    - name: jvm.mem.heap
+      type: group
+      description: >
+        JVM memory heap
+      fields:
+        - name: used.bytes
+          type: long
+          description: >
+            JVM memory heap used bytes.
+        - name: max.bytes
+          type: long
+          description: >
+            JVM memory heap max bytes.
+        - name: percent
+          type: long
+          description: >
+            JVM memory heap used percent.         
+    
     - name: jvm.mem.pools
       type: group
       description: >
@@ -124,9 +171,11 @@
             - name: count
               type: long
               description: >
+                Old collection count
             - name: ms
               type: long
               description: >
+                Old collection millisecond
         - name: young.collection
           type: group
           description: >
@@ -135,9 +184,11 @@
             - name: count
               type: long
               description: >
+                Young collection count
             - name: ms
               type: long
               description: >
+                Young collection millisecond
 
     - name: fs.summary
       type: group
@@ -148,11 +199,70 @@
           type: long
           format: bytes
           description: >
+            The total disk space in bytes.
         - name: free.bytes
           type: long
           format: bytes
           description: >
+            The disk space free in bytes.
         - name: available.bytes
           type: long
           format: bytes
           description: >
+            The disk space available in bytes.
+
+    - name: threadpool
+      type: group
+      description: >
+        Node threadpool stats
+      fields: 
+        - name: bulk.active
+          type: long
+          description: >
+            The count of bulk threads.
+        - name: bulk.queue
+          type: long
+          description: >
+            The length of bulk queue.
+        - name: bulk.rejected
+          type: long
+          description: >
+            The count of rejected bulk.
+        - name: index.active
+          type: long
+          description: >
+            The count of index threads.
+        - name: index.queue
+          type: long
+          description: >
+            The length of index queue.
+        - name: index.rejected
+          type: long
+          description: >
+            The count of rejected index.
+        - name: search.active
+          type: long
+          description: >
+            The count of search threads.
+        - name: search.queue
+          type: long
+          description: >
+            The length of search queue.
+        - name: search.rejected
+          type: long
+          description: >
+            The count of rejected bulk.
+    
+    - name: transport
+      type: group
+      description: >
+        Node network transport stats
+      fields: 
+        - name: rx.bytes
+          type: long
+          description: >
+            The bytes of network received.
+        - name: tx.bytes
+          type: long
+          description: >
+            The bytes of network sent.

--- a/metricbeat/module/elasticsearch/node_stats/data.go
+++ b/metricbeat/module/elasticsearch/node_stats/data.go
@@ -13,6 +13,15 @@ var (
 	schema = s.Schema{
 		"jvm": c.Dict("jvm", s.Schema{
 			"mem": c.Dict("mem", s.Schema{
+				"heap": s.Object{
+					"used": s.Object{
+						"bytes": c.Int("heap_used_in_bytes"),
+					},
+					"max": s.Object{
+						"bytes": c.Int("heap_max_in_bytes"),
+					},
+					"percent": c.Int("heap_used_percent"),
+				},
 				"pools": c.Dict("pools", s.Schema{
 					"young":    c.Dict("young", poolSchema),
 					"survivor": c.Dict("survivor", poolSchema),
@@ -42,6 +51,42 @@ var (
 					"bytes": c.Int("memory_in_bytes"),
 				},
 			}),
+			"fielddata": c.Dict("fielddata", s.Schema{
+				"memory": s.Object{
+					"bytes": c.Int("memory_size_in_bytes"),
+				},
+			}),
+			"search": c.Dict("search", s.Schema{
+				"query": s.Object{
+					"total":   c.Int("query_total"),
+					"current": c.Int("query_current"),
+					"ms":      c.Int("query_time_in_millis"),
+				},
+			}),
+			"indexing": c.Dict("indexing", s.Schema{
+				"index": s.Object{
+					"total":   c.Int("index_total"),
+					"current": c.Int("index_current"),
+					"ms":      c.Int("index_time_in_millis"),
+				},
+			}),
+		}),
+		"threadpool": c.Dict("thread_pool", s.Schema{
+			"index": c.Dict("index", s.Schema{
+				"queue":    c.Int("queue"),
+				"active":   c.Int("active"),
+				"rejected": c.Int("rejected"),
+			}),
+			"bulk": c.Dict("bulk", s.Schema{
+				"queue":    c.Int("queue"),
+				"active":   c.Int("active"),
+				"rejected": c.Int("rejected"),
+			}),
+			"search": c.Dict("search", s.Schema{
+				"queue":    c.Int("queue"),
+				"active":   c.Int("active"),
+				"rejected": c.Int("rejected"),
+			}),
 		}),
 		"fs": c.Dict("fs", s.Schema{
 			"summary": c.Dict("total", s.Schema{
@@ -55,6 +100,14 @@ var (
 					"bytes": c.Int("available_in_bytes"),
 				},
 			}),
+		}),
+		"transport": c.Dict("transport", s.Schema{
+			"rx": s.Object{
+				"bytes": c.Int("rx_size_in_bytes"),
+			},
+			"tx": s.Object{
+				"bytes": c.Int("tx_size_in_bytes"),
+			},
 		}),
 	}
 


### PR DESCRIPTION
metricbeat: add more node_stats metrics in elasticseach module

node_stats:

- indices.fielddata.memory.bytes
- indices.search.query.total
- indices.search.query.current
- indices.search.query.time.millis
- indices.indexing.index.total
- indices.indexing.index.current
- indices.indexing.index.time.millis
- threadpool.bulk.active
- threadpool.bulk.queue
- threadpool.bulk.rejected
- threadpool.index.active
- threadpool.index.queue
- threadpool.index.rejected
- threadpool.search.active
- threadpool.search.queue
- threadpool.search.rejected
- transport.rx.bytes
- transport.tx.bytes

These metrics is necesarry to learn about elaticsearch node running info append on the doc [Monitoring Individual Nodes](https://www.elastic.co/guide/en/elasticsearch/guide/master/_monitoring_individual_nodes.html#_monitoring_individual_nodes) in [Elasticsearch - The Definitive Guide](https://www.elastic.co/guide/en/elasticsearch/guide/master/index.html)