### PR TITLE
Cherry-pick #5286 to 6.0: Fix minor typos

### DIFF
--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -370,7 +370,7 @@ func (b *Beat) handleFlags() error {
 	flag.Parse()
 
 	if printVersion {
-		cfgwarn.Deprecate("6.0", "-version flag has been deprectad, use version subcommand")
+		cfgwarn.Deprecate("6.0", "-version flag has been deprecated, use version subcommand")
 		fmt.Printf("%s version %s (%s), libbeat %s\n",
 			b.Info.Beat, b.Info.Version, runtime.GOARCH, version.GetDefaultVersion())
 		return beat.GracefulExit

--- a/libbeat/cmd/run.go
+++ b/libbeat/cmd/run.go
@@ -34,8 +34,8 @@ func genRunCmd(name, version string, beatCreator beat.Creator, runFlags *pflag.F
 	runCmd.Flags().AddGoFlag(flag.CommandLine.Lookup("configtest"))
 	runCmd.Flags().AddGoFlag(flag.CommandLine.Lookup("version"))
 
-	runCmd.Flags().MarkDeprecated("version", "version flag has been deprectad, use version subcommand")
-	runCmd.Flags().MarkDeprecated("configtest", "configtest flag has been deprectad, use test config subcommand")
+	runCmd.Flags().MarkDeprecated("version", "version flag has been deprecated, use version subcommand")
+	runCmd.Flags().MarkDeprecated("configtest", "configtest flag has been deprecated, use test config subcommand")
 
 	if runFlags != nil {
 		runCmd.Flags().AddFlagSet(runFlags)


### PR DESCRIPTION
Cherry-pick of PR #5286 to 6.0 branch. Original message: 

`deprectad` -> `deprecated`