### PR TITLE
Implement logic for disabled groups

### DIFF
--- a/libbeat/kibana/testdata/fields.yml
+++ b/libbeat/kibana/testdata/fields.yml
@@ -5,6 +5,13 @@
     Contains common beat fields available in all event types.
   fields:
 
+    - name: group_disabled
+      type: group
+      enabled: false
+      fields:
+        - name: message
+          type: text
+
     - name: beat.name
       description: >
         The name of the Beat sending the log messages. If the Beat name is

--- a/libbeat/kibana/transform.go
+++ b/libbeat/kibana/transform.go
@@ -59,7 +59,9 @@ func (t *Transformer) transformFields(commonFields common.Fields, path string) {
 		}
 
 		if f.Type == "group" {
-			t.transformFields(f.Fields, f.Path)
+			if f.Enabled == nil || *f.Enabled {
+				t.transformFields(f.Fields, f.Path)
+			}
 		} else {
 			// set default values (as done in python script)
 			t.keys[f.Path] = true


### PR DESCRIPTION
If a group is set to `enable: false` to not add it or fields within its namespace to the kibana index pattern.