### PR TITLE
Add Pre-Commit hook.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,12 @@ REVIEWDOG_REPO=github.com/haya14busa/reviewdog/cmd/reviewdog
 
 # Runs complete testsuites (unit, system, integration) for all beats with coverage and race detection.
 # Also it builds the docs and the generators
+
+.PHONY: setup-commit-hook 
+setup-commit-hook:
+	@cp script/pre_commit.sh .git/hooks/pre-commit
+	@chmod 751 .git/hooks/pre-commit
+
 .PHONY: testsuite
 testsuite:
 	@$(foreach var,$(PROJECTS),$(MAKE) -C $(var) testsuite || exit 1;)

--- a/script/pre_commit.sh
+++ b/script/pre_commit.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -e
+
+echo "-- pre commit hook running"
+#return if no files staged for commit
+staged_files=$(git diff --name-only --cached)
+[ -z "$staged_files" ] && exit 0
+
+#run make cmds and check whether 
+#- unstaged files have changed
+#- make cmd fails
+unstaged_files=$(git diff --name-only)
+
+echo "---- lint"
+make lint
+
+echo "---- format"
+make fmt
+
+echo "---- misspell"
+make misspell
+
+unstaged_files_after=$(git diff --name-only)
+if [ "$unstaged_files" == "$unstaged_files_after"  ] ; then
+  exit 0
+fi;
+echo "Pre-Commit hook has failed, see changed files."
+exit 1


### PR DESCRIPTION
Since @tsg was mentioning a `lint bot` in PR #5300 I added this pre-commit handling. This script is not nearly as advanced as a lint bot, but I generally like pre-commit hooks and maybe someone else wants to also make use of it.

The script basically fetches the unstaged changes, then runs several commands and compares the unstaged changes again. If one of the commands fails or files were changed, it does not run the commit. This ofc does not work if someone changes a file while the commit hook is running. 

Running `make init` copies the script `script/pre_commit.sh` to the git pre-commit dir and makes it executable. Afterwards for every commit this hook is run automatically. If someone wants to get rid of the hook again, just remove the hook, `rm .git/hooks/pre-commit`. If the hook should be changed, just change the `script/pre-commit.sh` and run `make init` again.