### PR TITLE
Cherry-pick #5307 to 6.0: Fix data race accessing watched containers

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -30,6 +30,8 @@ https://github.com/elastic/beats/compare/v6.0.0-rc1...master[Check the HEAD diff
 
 *Affecting all Beats*
 
+- Fix data race accessing watched containers. {issue}5147[5147]
+
 *Auditbeat*
 
 *Filebeat*

--- a/libbeat/processors/add_docker_metadata/watcher.go
+++ b/libbeat/processors/add_docker_metadata/watcher.go
@@ -108,10 +108,11 @@ func NewWatcherWithClient(client Client, cleanupTimeout time.Duration) (*watcher
 func (w *watcher) Container(ID string) *Container {
 	w.RLock()
 	container := w.containers[ID]
+	_, ok := w.deleted[ID]
 	w.RUnlock()
 
 	// Update last access time if it's deleted
-	if _, ok := w.deleted[ID]; ok {
+	if ok {
 		w.Lock()
 		w.deleted[ID] = time.Now()
 		w.Unlock()


### PR DESCRIPTION
Cherry-pick of PR #5307 to 6.0 branch. Original message: 

Fixes #5147