### PR TITLE
Cherry-pick #5303 to 6.0: Make cleanup more reliable

### DIFF
--- a/dev-tools/jenkins_ci.sh
+++ b/dev-tools/jenkins_ci.sh
@@ -28,7 +28,8 @@ export PYTHON_ENV="${TEMP_PYTHON_ENV}/python-env"
 cleanup() {
   echo "Running cleanup..."
   rm -rf $TEMP_PYTHON_ENV
-  make stop-environment fix-permissions
+  make stop-environment || true
+  make fix-permissions || true
   echo "Killing all running containers..."
   docker ps -q | xargs -r docker kill || true
   echo "Cleaning stopped docker containers and dangling images/networks/volumes..."


### PR DESCRIPTION
Cherry-pick of PR #5303 to 6.0 branch. Original message: 

Currently some jenkins job do not properly cleanup. This change should make the cleanup more reliable by separating the fix-permissions command and and make sure it also runs if stop-environment was not successful.