### PR TITLE
Fix flaky Filebeat test on Windows

### DIFF
--- a/filebeat/tests/system/test_crawler.py
+++ b/filebeat/tests/system/test_crawler.py
@@ -470,6 +470,9 @@ class Test(BaseTest):
             f.write("hello world 2\n")
             f.flush()
 
+        # Sleep 1 second to make sure the file is persisted on disk and timestamp is in the past
+        time.sleep(1)
+
         filebeat = self.start_beat()
         self.wait_until(
             lambda: self.log_contains(


### PR DESCRIPTION
It seems as the file was persisted and then beats started sometime the timestamp of the file was identical to now so ignore_older did not apply. Now waiting 1s for the beat to start should solve this issue.