### PR TITLE
Increase Kibana timeout for tests

### DIFF
--- a/metricbeat/tests/system/test_kibana.py
+++ b/metricbeat/tests/system/test_kibana.py
@@ -8,7 +8,7 @@ class Test(metricbeat.BaseTest):
 
     COMPOSE_SERVICES = ['elasticsearch', 'kibana']
 
-    COMPOSE_TIMEOUT = 120
+    COMPOSE_TIMEOUT = 300
 
     @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
     def test_status(self):


### PR DESCRIPTION
Kibana can take quite some time to start in a slow / busy environment. Timeout is now increased to 5 minutes.