### PR TITLE
Fix OutputPrecision in kibana-index-generation script.

### DIFF
--- a/libbeat/common/field.go
+++ b/libbeat/common/field.go
@@ -43,7 +43,7 @@ type Field struct {
 	Pattern         string `config:"pattern"`
 	InputFormat     string `config:"input_format"`
 	OutputFormat    string `config:"output_format"`
-	OutputPrecision string `config:"output_precision"`
+	OutputPrecision *int   `config:"output_precision"`
 	LabelTemplate   string `config:"label_template"`
 	UrlTemplate     string `config:"url_template"`
 

--- a/libbeat/kibana/index_pattern_generator_test.go
+++ b/libbeat/kibana/index_pattern_generator_test.go
@@ -172,7 +172,7 @@ func testGenerate(t *testing.T, beatDir string, tests []map[string]string) {
 		for _, e := range fieldsExisting {
 			idx := find(fieldsCreated, e["name"].(string))
 			assert.NotEqual(t, -1, idx)
-			assert.Equal(t, fieldsCreated[idx], e)
+			assert.Equal(t, e, fieldsCreated[idx])
 		}
 	}
 }

--- a/libbeat/kibana/transform.go
+++ b/libbeat/kibana/transform.go
@@ -120,13 +120,13 @@ func transformField(f common.Field) (common.MapStr, common.MapStr) {
 
 		if f.Format != "" {
 			format["id"] = f.Format
-			addFormatParam(&format, "inputFormat", f.InputFormat)
-			addFormatParam(&format, "outputFormat", f.OutputFormat)
-			addFormatParam(&format, "outputPrecision", f.OutputPrecision)
-			addFormatParam(&format, "labelTemplate", f.LabelTemplate)
-			addFormatParam(&format, "urlTemplate", f.UrlTemplate)
+			addStringFormatParam(&format, "inputFormat", f.InputFormat)
+			addStringFormatParam(&format, "outputFormat", f.OutputFormat)
+			addIntPFormatParam(&format, "outputPrecision", f.OutputPrecision)
+			addStringFormatParam(&format, "labelTemplate", f.LabelTemplate)
+			addStringFormatParam(&format, "urlTemplate", f.UrlTemplate)
 		}
-		addFormatParam(&format, "pattern", f.Pattern)
+		addStringFormatParam(&format, "pattern", f.Pattern)
 	}
 
 	return field, format
@@ -159,7 +159,7 @@ func getVal(valP *bool, def bool) bool {
 	return def
 }
 
-func addFormatParam(f *common.MapStr, key string, val string) {
+func addStringFormatParam(f *common.MapStr, key string, val string) {
 	if val == "" {
 		return
 	}
@@ -167,6 +167,16 @@ func addFormatParam(f *common.MapStr, key string, val string) {
 		(*f)["params"] = common.MapStr{}
 	}
 	(*f)["params"].(common.MapStr)[key] = val
+}
+
+func addIntPFormatParam(f *common.MapStr, key string, valP *int) {
+	if valP == nil {
+		return
+	}
+	if (*f)["params"] == nil {
+		(*f)["params"] = common.MapStr{}
+	}
+	(*f)["params"].(common.MapStr)[key] = *valP
 }
 
 var (

--- a/libbeat/kibana/transform_test.go
+++ b/libbeat/kibana/transform_test.go
@@ -207,6 +207,7 @@ func TestTransformMisc(t *testing.T) {
 }
 
 func TestTransformFieldFormatMap(t *testing.T) {
+	precision := 3
 	tests := []struct {
 		commonField common.Field
 		expected    common.MapStr
@@ -289,7 +290,7 @@ func TestTransformFieldFormatMap(t *testing.T) {
 				Pattern:         "[^-]",
 				InputFormat:     "string",
 				OutputFormat:    "float",
-				OutputPrecision: "3",
+				OutputPrecision: &precision,
 				LabelTemplate:   "lblT",
 				UrlTemplate:     "urlT",
 			},
@@ -300,7 +301,7 @@ func TestTransformFieldFormatMap(t *testing.T) {
 						"pattern":         "[^-]",
 						"inputFormat":     "string",
 						"outputFormat":    "float",
-						"outputPrecision": "3",
+						"outputPrecision": 3,
 						"labelTemplate":   "lblT",
 						"urlTemplate":     "urlT",
 					},


### PR DESCRIPTION
The current implementation treats the `OutputPrecision` as a `String`, but it actually should be an `Integer`. This is a bugfix for that.