### PR TITLE
Do not require template if index change and template disabled

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -43,6 +43,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Fix `fields.yml` lookup when using `export template` with a custom `path.config` param. {issue}5089[5089]
 - Remove runner creation from every reload check {pull}5141[5141]
 - Remove ID() from Runner interface {issue}5153[5153]
+- Do not require template if index change and template disabled {pull}5319[5319]
 
 *Auditbeat*
 

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -575,7 +575,7 @@ func (b *Beat) registerTemplateLoading() error {
 			return err
 		}
 
-		if esCfg.Index != "" && (cfg.Name == "" || cfg.Pattern == "") {
+		if esCfg.Index != "" && (cfg.Name == "" || cfg.Pattern == "") && (b.Config.Template == nil || b.Config.Template.Enabled()) {
 			return fmt.Errorf("setup.template.name and setup.template.pattern have to be set if index name is modified.")
 		}
 


### PR DESCRIPTION
If the elasticsearch index name is changed, its required to set a template. The error message was also shown when template itself are disabled. This is now changed that if templates are disabled, no error is returned.

Closes https://github.com/elastic/beats/issues/5308