### PR TITLE
metricbeat: add more node metrics in elasticseach module

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -22,6 +22,9 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 
 *Metricbeat*
 
+- Rename `heap_init` field to `heap.init`. {pull}5320[5320]
+
+
 *Packetbeat*
 
 - Remove not-working `runoptions.uid` and `runoptions.gid` options in Packetbeat. {pull}5261[5261]

--- a/metricbeat/docs/fields.asciidoc
+++ b/metricbeat/docs/fields.asciidoc
@@ -2469,24 +2469,6 @@ node
 
 
 [float]
-=== `elasticsearch.node.jvm.memory.heap_init.bytes`
-
-type: long
-
-format: bytes
-
-Heap init used by the JVM in bytes.
-
-
-[float]
-=== `elasticsearch.node.jvm.version`
-
-type: keyword
-
-JVM version.
-
-
-[float]
 === `elasticsearch.node.name`
 
 type: keyword
@@ -2500,6 +2482,69 @@ Node name.
 type: keyword
 
 Node version.
+
+
+[float]
+== jvm fields
+
+JVM Info.
+
+
+
+[float]
+=== `elasticsearch.node.jvm.version`
+
+type: keyword
+
+JVM version.
+
+
+[float]
+=== `elasticsearch.node.jvm.memory.heap.init.bytes`
+
+type: long
+
+format: bytes
+
+Heap init used by the JVM in bytes.
+
+
+[float]
+=== `elasticsearch.node.jvm.memory.heap.max.bytes`
+
+type: long
+
+format: bytes
+
+Heap max used by the JVM in bytes.
+
+
+[float]
+=== `elasticsearch.node.jvm.memory.nonheap.init.bytes`
+
+type: long
+
+format: bytes
+
+Non-Heap init used by the JVM in bytes.
+
+
+[float]
+=== `elasticsearch.node.jvm.memory.nonheap.max.bytes`
+
+type: long
+
+format: bytes
+
+Non-Heap max used by the JVM in bytes.
+
+
+[float]
+=== `elasticsearch.node.process.mlockall`
+
+type: bool
+
+If process locked in memory.
 
 
 [float]

--- a/metricbeat/module/elasticsearch/node/_meta/data.json
+++ b/metricbeat/module/elasticsearch/node/_meta/data.json
@@ -9,16 +9,32 @@
             "name": "elasticsearch"
         },
         "node": {
-            "jvm": {
-                "memory": {
-                    "heap_init": {
-                        "bytes": 536870912
+            "name": "8zgOwJ24TMamDDH9amWINQ",
+            "version": "6.0.0-alpha1",
+            "jvm":{
+                "version":"1.8.0_60",
+                "memory":{
+                    "heap":{
+                        "init":{
+                            "bytes":268435456
+                        },
+                        "max":{
+                            "bytes":1038876672
+                        }
+                    },
+                    "nonheap":{
+                        "init":{
+                            "bytes":2555904
+                        },
+                        "max":{
+                            "bytes":0
+                        }
                     }
                 },
-                "version": "1.8.0_121"
-            },
-            "name": "8zgOwJ24TMamDDH9amWINQ",
-            "version": "6.0.0-alpha1"
+                "process":{
+                    "mlockall":true
+                }
+            }
         }
     },
     "metricset": {

--- a/metricbeat/module/elasticsearch/node/_meta/fields.yml
+++ b/metricbeat/module/elasticsearch/node/_meta/fields.yml
@@ -3,15 +3,6 @@
   description: >
     node
   fields:
-    - name: jvm.memory.heap_init.bytes
-      type: long
-      format: bytes
-      description: >
-        Heap init used by the JVM in bytes.
-    - name: jvm.version
-      type: keyword
-      description: >
-        JVM version.
     - name: name
       type: keyword
       description: >
@@ -20,3 +11,36 @@
       type: keyword
       description: >
         Node version.
+    - name: jvm
+      type: group
+      description: >
+        JVM Info.
+      fields:  
+        - name: version
+          type: keyword
+          description: >
+            JVM version.
+        - name: memory.heap.init.bytes
+          type: long
+          format: bytes
+          description: >
+            Heap init used by the JVM in bytes.
+        - name: memory.heap.max.bytes
+          type: long
+          format: bytes
+          description: >
+            Heap max used by the JVM in bytes.
+        - name: memory.nonheap.init.bytes
+          type: long
+          format: bytes
+          description: >
+            Non-Heap init used by the JVM in bytes.
+        - name: memory.nonheap.max.bytes
+          type: long
+          format: bytes
+          description: >
+            Non-Heap max used by the JVM in bytes.
+    - name: process.mlockall
+      type: bool
+      description: >
+        If process locked in memory.

--- a/metricbeat/module/elasticsearch/node/data.go
+++ b/metricbeat/module/elasticsearch/node/data.go
@@ -16,10 +16,26 @@ var (
 		"jvm": c.Dict("jvm", s.Schema{
 			"version": c.Str("version"),
 			"memory": c.Dict("mem", s.Schema{
-				"heap_init": s.Object{
-					"bytes": c.Int("heap_init_in_bytes"),
+				"heap": s.Object{
+					"init": s.Object{
+						"bytes": c.Int("heap_init_in_bytes"),
+					},
+					"max": s.Object{
+						"bytes": c.Int("heap_max_in_bytes"),
+					},
+				},
+				"nonheap": s.Object{
+					"init": s.Object{
+						"bytes": c.Int("non_heap_init_in_bytes"),
+					},
+					"max": s.Object{
+						"bytes": c.Int("non_heap_max_in_bytes"),
+					},
 				},
 			}),
+		}),
+		"process": c.Dict("process", s.Schema{
+			"mlockall": c.Bool("mlockall"),
 		}),
 	}
 )


### PR DESCRIPTION
metricbeat: add more node metrics in elastics each module

node:

- jvm.memory.heap.init
- jvm.memory.heap.max
- jvm.memory.nonheap.init
- jvm.memory.nonheap.max
- process.mlockall