### PR TITLE
Cosmetic/type changes to  fields.yml and fields.common.yml

### DIFF
--- a/heartbeat/_meta/fields.common.yml
+++ b/heartbeat/_meta/fields.common.yml
@@ -25,7 +25,7 @@
 
         - name: duration
           type: group
-          description: total monitoring test duration
+          description: Total monitoring test duration
           fields:
             - name: us
               type: long

--- a/heartbeat/monitors/active/http/_meta/fields.yml
+++ b/heartbeat/monitors/active/http/_meta/fields.yml
@@ -69,7 +69,7 @@
               type: group
               description:
                 Time required between sending the start of sending the HTTP
-                request and first by from HTTP response being read. Duration
+                request and first byte from HTTP response being read. Duration
                 based on already available network connection.
               fields:
                 - name: us


### PR DESCRIPTION
Cosmetic changes to have capital case for first letter of duration description  in heartbeat/_meta/fields.common.yml
Typo fix for response_header's description in heartbeat/monitors/active/http/_meta/fields.yml