### PR TITLE
Cherry-pick #5319 to 6.0: Do not require template if index change and template disabled

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -33,6 +33,7 @@ https://github.com/elastic/beats/compare/v6.0.0-rc1...master[Check the HEAD diff
 *Affecting all Beats*
 
 - Fix data race accessing watched containers. {issue}5147[5147]
+- Do not require template if index change and template disabled {pull}5319[5319]
 
 *Auditbeat*
 

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -572,7 +572,7 @@ func (b *Beat) registerTemplateLoading() error {
 			return err
 		}
 
-		if esCfg.Index != "" && (cfg.Name == "" || cfg.Pattern == "") {
+		if esCfg.Index != "" && (cfg.Name == "" || cfg.Pattern == "") && (b.Config.Template == nil || b.Config.Template.Enabled()) {
 			return fmt.Errorf("setup.template.name and setup.template.pattern have to be set if index name is modified.")
 		}
 


### PR DESCRIPTION
Cherry-pick of PR #5319 to 6.0 branch. Original message: 

If the elasticsearch index name is changed, its required to set a template. The error message was also shown when template itself are disabled. This is now changed that if templates are disabled, no error is returned.

Closes https://github.com/elastic/beats/issues/5308