### PR TITLE
Add support for copy_to to fields.yml

### DIFF
--- a/libbeat/common/field.go
+++ b/libbeat/common/field.go
@@ -32,6 +32,7 @@ type Field struct {
 	Dynamic        DynamicType `config:"dynamic"`
 	Index          *bool       `config:"index"`
 	DocValues      *bool       `config:"doc_values"`
+	CopyTo         string      `config:"copy_to"`
 
 	// Kibana specific
 	Analyzed     *bool  `config:"analyzed"`
@@ -65,6 +66,7 @@ func (d *DynamicType) Unpack(s string) error {
 	}
 	return nil
 }
+
 func LoadFieldsYaml(path string) (Fields, error) {
 	keys := []Field{}
 

--- a/libbeat/template/processor.go
+++ b/libbeat/template/processor.go
@@ -255,5 +255,9 @@ func getDefaultProperties(f *common.Field) common.MapStr {
 	if f.DocValues != nil {
 		properties["doc_values"] = *f.DocValues
 	}
+
+	if f.CopyTo != "" {
+		properties["copy_to"] = f.CopyTo
+	}
 	return properties
 }

--- a/libbeat/template/processor_test.go
+++ b/libbeat/template/processor_test.go
@@ -51,6 +51,13 @@ func TestProcessor(t *testing.T) {
 			},
 		},
 		{
+			output: p.integer(&common.Field{Type: "long", CopyTo: "hello.world"}),
+			expected: common.MapStr{
+				"type":    "long",
+				"copy_to": "hello.world",
+			},
+		},
+		{
 			output:   p.array(&common.Field{Type: "array"}),
 			expected: common.MapStr{},
 		},


### PR DESCRIPTION
This allows to use the `copy_to` feature in the Elasticsearch index template: https://www.elastic.co/guide/en/elasticsearch/reference/current/copy-to.html Like this one field can be copied to an other name if needed.