### PR TITLE
Update filebeat-options.asciidoc

### DIFF
--- a/filebeat/docs/reference/configuration/filebeat-options.asciidoc
+++ b/filebeat/docs/reference/configuration/filebeat-options.asciidoc
@@ -14,7 +14,7 @@ filebeat.prospectors:
 - input_type: log
   paths:
     - /var/log/apache/httpd-*.log
-  document_type: apache
+  tags: ["apache"]
 
 - input_type: log
   paths:


### PR DESCRIPTION
This document states that setting "document_type" is deprecated, yet it proposes to use it in the example at the top of the page. I've changed it so that it adds an "apache" tag instead.