### PR TITLE
Update filebeat-options.asciidoc

### DIFF
--- a/filebeat/docs/reference/configuration/filebeat-options.asciidoc
+++ b/filebeat/docs/reference/configuration/filebeat-options.asciidoc
@@ -14,7 +14,6 @@ filebeat.prospectors:
 - input_type: log
   paths:
     - /var/log/apache/httpd-*.log
-  document_type: apache
 
 - input_type: log
   paths:


### PR DESCRIPTION
Removing  document_type configuration option in prospector example, as the same page lists it as being deprecated.