### PR TITLE
Modify generator to get version to generate passed

### DIFF
--- a/libbeat/dashboards/dashboards.go
+++ b/libbeat/dashboards/dashboards.go
@@ -80,7 +80,12 @@ func ImportDashboardsViaKibana(kibanaLoader *KibanaLoader) error {
 		return fmt.Errorf("Kibana API is not available in Kibana version %s", kibanaLoader.version)
 	}
 
-	importer, err := NewImporter("default", kibanaLoader.config, kibanaLoader)
+	version, err := common.NewVersion(kibanaLoader.version)
+	if err != nil {
+		return fmt.Errorf("Invalid Kibana version: %s", kibanaLoader.version)
+	}
+
+	importer, err := NewImporter(*version, kibanaLoader.config, kibanaLoader)
 	if err != nil {
 		return fmt.Errorf("fail to create a Kibana importer for loading the dashboards: %v", err)
 	}
@@ -98,7 +103,9 @@ func ImportDashboardsViaElasticsearch(esLoader *ElasticsearchLoader) error {
 		return fmt.Errorf("fail to create the kibana index: %v", err)
 	}
 
-	importer, err := NewImporter("5.x", esLoader.config, esLoader)
+	version, _ := common.NewVersion("5.0.0")
+
+	importer, err := NewImporter(*version, esLoader.config, esLoader)
 	if err != nil {
 		return fmt.Errorf("fail to create an Elasticsearch importer for loading the dashboards: %v", err)
 	}

--- a/libbeat/dashboards/es_loader_test.go
+++ b/libbeat/dashboards/es_loader_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/outputs/elasticsearch"
 )
@@ -38,8 +39,9 @@ func TestImporter(t *testing.T) {
 
 	assert.NoError(t, err)
 
-	imp, err := NewImporter("5.x", &dashboardsConfig, loader)
+	version, _ := common.NewVersion("5.0.0")
 
+	imp, err := NewImporter(*version, &dashboardsConfig, loader)
 	assert.NoError(t, err)
 
 	err = imp.Import()
@@ -71,8 +73,9 @@ func TestImporterEmptyBeat(t *testing.T) {
 		config: &dashboardsConfig,
 	}
 
-	imp, err := NewImporter("5.x", &dashboardsConfig, loader)
+	version, _ := common.NewVersion("5.0.0")
 
+	imp, err := NewImporter(*version, &dashboardsConfig, loader)
 	assert.NoError(t, err)
 
 	err = imp.Import()

--- a/libbeat/dashboards/importer.go
+++ b/libbeat/dashboards/importer.go
@@ -11,6 +11,8 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+
+	"github.com/elastic/beats/libbeat/common"
 )
 
 // MessageOutputter is a function type for injecting status logging
@@ -19,7 +21,7 @@ type MessageOutputter func(msg string, a ...interface{})
 
 type Importer struct {
 	cfg     *Config
-	version string
+	version common.Version
 
 	loader Loader
 }
@@ -31,7 +33,7 @@ type Loader interface {
 	Close() error
 }
 
-func NewImporter(version string, cfg *Config, loader Loader) (*Importer, error) {
+func NewImporter(version common.Version, cfg *Config, loader Loader) (*Importer, error) {
 	return &Importer{
 		cfg:     cfg,
 		version: version,
@@ -245,7 +247,12 @@ func (imp Importer) downloadFile(url string, target string) (string, error) {
 func (imp Importer) ImportKibanaDir(dir string) error {
 	var err error
 
-	dir = path.Join(dir, imp.version)
+	versionPath := "default"
+	if imp.version.Major == 5 {
+		versionPath = "5x"
+	}
+
+	dir = path.Join(dir, versionPath)
 
 	imp.loader.statusMsg("Importing directory %v", dir)
 

--- a/libbeat/kibana/index_pattern_generator.go
+++ b/libbeat/kibana/index_pattern_generator.go
@@ -47,20 +47,16 @@ func (i *IndexPatternGenerator) Generate() (string, error) {
 
 	var path string
 
-	if i.version.Major == 5 {
-		path, err = i.generate5x(commonFields)
+	if i.version.Major >= 6 {
+		path, err = i.genereteMinVersion6(commonFields)
 	} else {
-		path, err = i.generate6x(commonFields)
+		path, err = i.genereteMinVersion5(commonFields)
 	}
 
-	if err != nil {
-		return "", err
-	}
-
-	return path, nil
+	return path, err
 }
 
-func (i *IndexPatternGenerator) generate5x(fields common.Fields) (string, error) {
+func (i *IndexPatternGenerator) genereteMinVersion5(fields common.Fields) (string, error) {
 	version, _ := common.NewVersion("5.0.0")
 	transformed, err := generate(i.indexName, version, fields)
 	if err != nil {
@@ -72,7 +68,7 @@ func (i *IndexPatternGenerator) generate5x(fields common.Fields) (string, error)
 	return file5x, err
 }
 
-func (i *IndexPatternGenerator) generate6x(fields common.Fields) (string, error) {
+func (i *IndexPatternGenerator) genereteMinVersion6(fields common.Fields) (string, error) {
 	version, _ := common.NewVersion("6.0.0")
 	transformed, err := generate(i.indexName, version, fields)
 	if err != nil {

--- a/libbeat/kibana/index_pattern_generator.go
+++ b/libbeat/kibana/index_pattern_generator.go
@@ -48,17 +48,16 @@ func (i *IndexPatternGenerator) Generate() (string, error) {
 	var path string
 
 	if i.version.Major >= 6 {
-		path, err = i.genereteMinVersion6(commonFields)
+		path, err = i.generateMinVersion6(commonFields)
 	} else {
-		path, err = i.genereteMinVersion5(commonFields)
+		path, err = i.generateMinVersion5(commonFields)
 	}
 
 	return path, err
 }
 
-func (i *IndexPatternGenerator) genereteMinVersion5(fields common.Fields) (string, error) {
-	version, _ := common.NewVersion("5.0.0")
-	transformed, err := generate(i.indexName, version, fields)
+func (i *IndexPatternGenerator) generateMinVersion5(fields common.Fields) (string, error) {
+	transformed, err := generate(i.indexName, &i.version, fields)
 	if err != nil {
 		return "", err
 	}
@@ -68,9 +67,8 @@ func (i *IndexPatternGenerator) genereteMinVersion5(fields common.Fields) (strin
 	return file5x, err
 }
 
-func (i *IndexPatternGenerator) genereteMinVersion6(fields common.Fields) (string, error) {
-	version, _ := common.NewVersion("6.0.0")
-	transformed, err := generate(i.indexName, version, fields)
+func (i *IndexPatternGenerator) generateMinVersion6(fields common.Fields) (string, error) {
+	transformed, err := generate(i.indexName, &i.version, fields)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Having the version passed from external makes the generator more reusable and cleans up the internal code.

* Modify internal dashboard version to common.Version

This is a prerequisit for #5328 and will make the change less complex.