### PR TITLE
Only read go version from .go-version file

### DIFF
--- a/dev-tools/common.bash
+++ b/dev-tools/common.bash
@@ -86,11 +86,7 @@ jenkins_setup() {
   # Setup Go.
   export GOPATH=${WORKSPACE}
   export PATH=${GOPATH}/bin:${PATH}
-  if [ -f ".go-version" ]; then
-    eval "$(gvm $(cat .go-version))"
-  else
-    eval "$(gvm 1.7.5)"
-  fi
+  eval "$(gvm $(cat .go-version))"
 
   # Workaround for Python virtualenv path being too long.
   export TEMP_PYTHON_ENV=$(mktemp -d)

--- a/dev-tools/jenkins_ci.ps1
+++ b/dev-tools/jenkins_ci.ps1
@@ -15,11 +15,7 @@ function Exec
 # Setup Go.
 $env:GOPATH = $env:WORKSPACE
 $env:PATH = "$env:GOPATH\bin;C:\tools\mingw64\bin;$env:PATH"
-if (Test-Path -PathType leaf .go-version) {
-    & gvm --format=powershell $(Get-Content .go-version) | Invoke-Expression
-} else {
-    & gvm --format=powershell 1.7.5 | Invoke-Expression
-}
+& gvm --format=powershell $(Get-Content .go-version) | Invoke-Expression
 
 if (Test-Path "$env:beat") {
     cd "$env:beat"


### PR DESCRIPTION
Remove default golang version as not needed anymore. All repos / branches have now a .go-version file.