### PR TITLE
Bump docs version for 5.6.3 in the 5.6 branch

### DIFF
--- a/libbeat/docs/version.asciidoc
+++ b/libbeat/docs/version.asciidoc
@@ -1,4 +1,4 @@
-:stack-version: 5.6.2
+:stack-version: 5.6.3
 :doc-branch: 5.6
 :go-version: 1.7.6
 :release-state: released


### PR DESCRIPTION
Please only merge this one on the day of the release.