### PR TITLE
Add traefik module

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -152,6 +152,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...v6.0.0-rc1[View commits]
 - Changed the number of shards in the default configuration to 3. {issue}5095[5095]
 - Don't start filebeat if external modules/prospectors config is wrong and reload is disabled {pull}5053[5053]
 - Add `filebeat.registry_flush` setting, to delay the registry updates. {pull}5146[5146]
+- Add traefik module {pull}5372[5372]
 
 *Heartbeat*
 

--- a/filebeat/docs/fields.asciidoc
+++ b/filebeat/docs/fields.asciidoc
@@ -26,6 +26,7 @@ grouped in the following categories:
 * <<exported-fields-postgresql>>
 * <<exported-fields-redis>>
 * <<exported-fields-system>>
+* <<exported-fields-traefik>>
 
 --
 [[exported-fields-apache2]]
@@ -1843,4 +1844,252 @@ The PID of the process that sent the syslog message.
 
 The message in the log line.
 
+
+[[exported-fields-traefik]]
+== Traefik fields
+
+Module for parsing the Traefik log files.
+
+
+
+[float]
+== traefik fields
+
+Fields from the Traefik log files.
+
+
+
+[float]
+== access fields
+
+Contains fields for the Traefik access logs.
+
+
+
+[float]
+=== `traefik.access.remote_ip`
+
+type: keyword
+
+Client IP address.
+
+
+[float]
+=== `traefik.access.user_name`
+
+type: keyword
+
+The user name used when basic authentication is used.
+
+
+[float]
+=== `traefik.access.method`
+
+type: keyword
+
+example: GET
+
+The request HTTP method.
+
+
+[float]
+=== `traefik.access.url`
+
+type: keyword
+
+The request HTTP URL.
+
+
+[float]
+=== `traefik.access.http_version`
+
+type: keyword
+
+The HTTP version.
+
+
+[float]
+=== `traefik.access.response_code`
+
+type: long
+
+The HTTP response code.
+
+
+[float]
+=== `traefik.access.body_sent.bytes`
+
+type: long
+
+format: bytes
+
+The number of bytes of the server response body.
+
+
+[float]
+=== `traefik.access.referrer`
+
+type: keyword
+
+The HTTP referrer.
+
+
+[float]
+=== `traefik.access.agent`
+
+type: text
+
+Contains the un-parsed user agent string. Only present if the user agent Elasticsearch plugin is not available or not used.
+
+
+[float]
+== user_agent fields
+
+Contains the parsed User agent field. Only present if the user agent Elasticsearch plugin is available and used.
+
+
+
+[float]
+=== `traefik.access.user_agent.device`
+
+type: keyword
+
+The name of the physical device.
+
+
+[float]
+=== `traefik.access.user_agent.major`
+
+type: long
+
+The major version of the user agent.
+
+
+[float]
+=== `traefik.access.user_agent.minor`
+
+type: long
+
+The minor version of the user agent.
+
+
+[float]
+=== `traefik.access.user_agent.patch`
+
+type: keyword
+
+The patch version of the user agent.
+
+
+[float]
+=== `traefik.access.user_agent.name`
+
+type: keyword
+
+example: Chrome
+
+The name of the user agent.
+
+
+[float]
+=== `traefik.access.user_agent.os`
+
+type: keyword
+
+The name of the operating system.
+
+
+[float]
+=== `traefik.access.user_agent.os_major`
+
+type: long
+
+The major version of the operating system.
+
+
+[float]
+=== `traefik.access.user_agent.os_minor`
+
+type: long
+
+The minor version of the operating system.
+
+
+[float]
+=== `traefik.access.user_agent.os_name`
+
+type: keyword
+
+The name of the operating system.
+
+
+[float]
+== geoip fields
+
+Contains GeoIP information gathered based on the remote_ip field. Only present if the GeoIP Elasticsearch plugin is available and used.
+
+
+
+[float]
+=== `traefik.access.geoip.continent_name`
+
+type: keyword
+
+The name of the continent.
+
+
+[float]
+=== `traefik.access.geoip.country_iso_code`
+
+type: keyword
+
+Country ISO code.
+
+
+[float]
+=== `traefik.access.geoip.location`
+
+type: geo_point
+
+The longitude and latitude.
+
+
+[float]
+=== `traefik.access.geoip.region_name`
+
+type: keyword
+
+The region name.
+
+
+[float]
+=== `traefik.access.geoip.city_name`
+
+type: keyword
+
+The city name.
+
+
+[float]
+=== `traefik.access.request_count`
+
+type: long
+
+The number of requests
+
+
+[float]
+=== `traefik.access.frontend_name`
+
+type: text
+
+The name of the frontend used
+
+
+[float]
+=== `traefik.access.backend_url`
+
+type: text
+
+The url of the backend where request is forwarded
 

--- a/filebeat/docs/modules/traefik.asciidoc
+++ b/filebeat/docs/modules/traefik.asciidoc
@@ -1,0 +1,16 @@
+////
+This file is generated! See scripts/docs_collector.py
+////
+
+[[filebeat-module-traefik]]
+== Traefik module
+
+This is the traefik module.
+
+
+[float]
+=== Fields
+
+For a description of each field in the metricset, see the
+<<exported-fields-traefik,exported fields>> section.
+

--- a/filebeat/docs/modules_list.asciidoc
+++ b/filebeat/docs/modules_list.asciidoc
@@ -12,6 +12,7 @@ This file is generated! See scripts/docs_collector.py
   * <<filebeat-module-postgresql>>
   * <<filebeat-module-redis>>
   * <<filebeat-module-system>>
+  * <<filebeat-module-traefik>>
 
 
 --
@@ -26,3 +27,4 @@ include::modules/nginx.asciidoc[]
 include::modules/postgresql.asciidoc[]
 include::modules/redis.asciidoc[]
 include::modules/system.asciidoc[]
+include::modules/traefik.asciidoc[]

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -215,6 +215,20 @@ filebeat.modules:
     # Optional, the password to use when connecting to Redis.
     #var.password:
 
+#------------------------------- Traefik Module ------------------------------
+#- module: traefik
+  # Access logs
+  #access:
+    #enabled: true
+
+    # Set custom paths for the log files. If left empty,
+    # Filebeat will choose the paths depending on your OS.
+    #var.paths:
+
+    # Prospector configuration (advanced). Any prospector configuration option
+    # can be added under this section.
+    #prospector:
+
 
 #=========================== Filebeat prospectors =============================
 

--- a/filebeat/module/traefik/_meta/config.reference.yml
+++ b/filebeat/module/traefik/_meta/config.reference.yml
@@ -1,0 +1,12 @@
+#- module: traefik
+  # Access logs
+  #access:
+    #enabled: true
+
+    # Set custom paths for the log files. If left empty,
+    # Filebeat will choose the paths depending on your OS.
+    #var.paths:
+
+    # Prospector configuration (advanced). Any prospector configuration option
+    # can be added under this section.
+    #prospector:

--- a/filebeat/module/traefik/_meta/config.yml
+++ b/filebeat/module/traefik/_meta/config.yml
@@ -1,0 +1,8 @@
+- module: traefik
+  # Access logs
+  access:
+    enabled: true
+
+    # Set custom paths for the log files. If left empty,
+    # Filebeat will choose the paths depending on your OS.
+    #var.paths:

--- a/filebeat/module/traefik/_meta/docs.asciidoc
+++ b/filebeat/module/traefik/_meta/docs.asciidoc
@@ -1,0 +1,3 @@
+== Traefik module
+
+This is the traefik module.

--- a/filebeat/module/traefik/_meta/fields.yml
+++ b/filebeat/module/traefik/_meta/fields.yml
@@ -1,0 +1,10 @@
+- key: traefik
+  title: "Traefik"
+  description: >
+    Module for parsing the Traefik log files.
+  fields:
+    - name: traefik
+      type: group
+      description: >
+        Fields from the Traefik log files.
+      fields:

--- a/filebeat/module/traefik/_meta/kibana/5.x/dashboard/Filebeat-Traefik-Dashboard.json
+++ b/filebeat/module/traefik/_meta/kibana/5.x/dashboard/Filebeat-Traefik-Dashboard.json
@@ -1,0 +1,13 @@
+{
+  "hits": 0,
+  "timeRestore": false,
+  "description": "",
+  "title": "Filebeat Traefik Dashboard",
+  "uiStateJSON": "{\"P-4\":{\"vis\":{\"legendOpen\":true}},\"P-8\":{\"mapCenter\":[50.51342652633956,-0.17578125]}}",
+  "panelsJSON": "[{\"col\":1,\"id\":\"Traefik-Access-Browsers\",\"panelIndex\":3,\"row\":10,\"size_x\":4,\"size_y\":4,\"type\":\"visualization\"},{\"col\":5,\"id\":\"Traefik-Access-OSes\",\"panelIndex\":4,\"row\":10,\"size_x\":4,\"size_y\":4,\"type\":\"visualization\"},{\"col\":1,\"id\":\"New-Visualization\",\"panelIndex\":5,\"row\":4,\"size_x\":12,\"size_y\":3,\"type\":\"visualization\"},{\"col\":1,\"id\":\"Traefik-Access-Response-codes-by-top-URLs\",\"panelIndex\":6,\"row\":7,\"size_x\":12,\"size_y\":3,\"type\":\"visualization\"},{\"col\":9,\"id\":\"Sent-sizes\",\"panelIndex\":7,\"row\":10,\"size_x\":4,\"size_y\":4,\"type\":\"visualization\"},{\"col\":1,\"id\":\"Traefik-Access-Map\",\"panelIndex\":8,\"row\":1,\"size_x\":12,\"size_y\":3,\"type\":\"visualization\"}]",
+  "optionsJSON": "{\"darkTheme\":false}",
+  "version": 1,
+  "kibanaSavedObjectMeta": {
+    "searchSourceJSON": "{\"filter\":[{\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}}}]}"
+  }
+}

--- a/filebeat/module/traefik/_meta/kibana/5.x/dashboard/ML-Traefik-Access-Remote-IP-Count-Explorer.json
+++ b/filebeat/module/traefik/_meta/kibana/5.x/dashboard/ML-Traefik-Access-Remote-IP-Count-Explorer.json
@@ -1,0 +1,13 @@
+{
+  "hits": 0,
+  "timeRestore": false,
+  "description": "",
+  "title": "ML Traefik Access Remote IP Count Explorer",
+  "uiStateJSON": "{\"P-3\":{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":null,\"direction\":null}}}},\"P-5\":{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":null,\"direction\":null}}}}}",
+  "panelsJSON": "[{\"size_x\":6,\"size_y\":3,\"panelIndex\":1,\"type\":\"visualization\",\"id\":\"ML-Traefik-Access-Remote-IP-Timechart\",\"col\":1,\"row\":1},{\"size_x\":6,\"size_y\":3,\"panelIndex\":2,\"type\":\"visualization\",\"id\":\"ML-Traefik-Access-Response-Code-Timechart\",\"col\":7,\"row\":1},{\"size_x\":6,\"size_y\":3,\"panelIndex\":3,\"type\":\"visualization\",\"id\":\"ML-Traefik-Access-Top-Remote-IPs-Table\",\"col\":1,\"row\":4},{\"size_x\":6,\"size_y\":3,\"panelIndex\":4,\"type\":\"visualization\",\"id\":\"ML-Traefik-Access-Map\",\"col\":7,\"row\":4},{\"size_x\":12,\"size_y\":9,\"panelIndex\":5,\"type\":\"visualization\",\"id\":\"ML-Traefik-Access-Top-URLs-Table\",\"col\":1,\"row\":7}]",
+  "optionsJSON": "{\"darkTheme\":false}",
+  "version": 1,
+  "kibanaSavedObjectMeta": {
+    "searchSourceJSON": "{\"filter\":[{\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}}}],\"highlightAll\":true,\"version\":true}"
+  }
+}

--- a/filebeat/module/traefik/_meta/kibana/5.x/dashboard/ML-Traefik-Remote-IP-URL-Explorer.json
+++ b/filebeat/module/traefik/_meta/kibana/5.x/dashboard/ML-Traefik-Remote-IP-URL-Explorer.json
@@ -1,0 +1,13 @@
+{
+  "hits": 0,
+  "timeRestore": false,
+  "description": "",
+  "title": "ML Traefik Access Remote IP URL Explorer",
+  "uiStateJSON": "{\"P-2\":{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":null,\"direction\":null}}}},\"P-3\":{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":null,\"direction\":null}}}},\"P-5\":{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":null,\"direction\":null}}}}}",
+  "panelsJSON": "[{\"col\":1,\"id\":\"ML-Traefik-Access-Unique-Count-URL-Timechart\",\"panelIndex\":1,\"row\":1,\"size_x\":6,\"size_y\":3,\"type\":\"visualization\"},{\"col\":7,\"id\":\"ML-Traefik-Access-Response-Code-Timechart\",\"panelIndex\":2,\"row\":1,\"size_x\":6,\"size_y\":3,\"type\":\"visualization\"},{\"col\":1,\"id\":\"ML-Traefik-Access-Top-Remote-IPs-Table\",\"panelIndex\":3,\"row\":4,\"size_x\":6,\"size_y\":3,\"type\":\"visualization\"},{\"col\":7,\"id\":\"ML-Traefik-Access-Map\",\"panelIndex\":4,\"row\":4,\"size_x\":6,\"size_y\":3,\"type\":\"visualization\"},{\"size_x\":12,\"size_y\":8,\"panelIndex\":5,\"type\":\"visualization\",\"id\":\"ML-Traefik-Access-Top-URLs-Table\",\"col\":1,\"row\":7}]",
+  "optionsJSON": "{\"darkTheme\":false}",
+  "version": 1,
+  "kibanaSavedObjectMeta": {
+    "searchSourceJSON": "{\"filter\":[{\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}}}],\"highlightAll\":true,\"version\":true}"
+  }
+}

--- a/filebeat/module/traefik/_meta/kibana/5.x/search/Filebeat-Traefik-module.json
+++ b/filebeat/module/traefik/_meta/kibana/5.x/search/Filebeat-Traefik-module.json
@@ -1,0 +1,16 @@
+{
+  "sort": [
+    "@timestamp",
+    "desc"
+  ],
+  "hits": 0,
+  "description": "",
+  "title": "Filebeat Traefik module",
+  "version": 1,
+  "kibanaSavedObjectMeta": {
+    "searchSourceJSON": "{\"index\":\"filebeat-*\",\"query\":{\"query_string\":{\"query\":\"_exists_:traefik\",\"analyze_wildcard\":true}},\"filter\":[],\"highlight\":{\"pre_tags\":[\"@kibana-highlighted-field@\"],\"post_tags\":[\"@/kibana-highlighted-field@\"],\"fields\":{\"*\":{}},\"require_field_match\":false,\"fragment_size\":2147483647}}"
+  },
+  "columns": [
+    "_source"
+  ]
+}

--- a/filebeat/module/traefik/_meta/kibana/5.x/search/ML-Filebeat-Traefik-Access.json
+++ b/filebeat/module/traefik/_meta/kibana/5.x/search/ML-Filebeat-Traefik-Access.json
@@ -1,0 +1,16 @@
+{
+  "sort": [
+    "@timestamp",
+    "desc"
+  ],
+  "hits": 0,
+  "description": "Filebeat Traefik Access Data",
+  "title": "ML Traefik Access Data",
+  "version": 1,
+  "kibanaSavedObjectMeta": {
+    "searchSourceJSON": "{\"index\":\"filebeat-*\",\"query\":{\"query_string\":{\"query\":\"_exists_:traefik.access\",\"analyze_wildcard\":true}},\"filter\":[],\"highlight\":{\"pre_tags\":[\"@kibana-highlighted-field@\"],\"post_tags\":[\"@/kibana-highlighted-field@\"],\"fields\":{\"*\":{}},\"require_field_match\":false,\"fragment_size\":2147483647}}"
+  },
+  "columns": [
+    "_source"
+  ]
+}

--- a/filebeat/module/traefik/_meta/kibana/5.x/visualization/ML-Traefik-Access-Map.json
+++ b/filebeat/module/traefik/_meta/kibana/5.x/visualization/ML-Traefik-Access-Map.json
@@ -1,0 +1,11 @@
+{
+  "visState": "{\"aggs\":[{\"enabled\":true,\"id\":\"1\",\"params\":{},\"schema\":\"metric\",\"type\":\"count\"},{\"enabled\":true,\"id\":\"2\",\"params\":{\"autoPrecision\":true,\"field\":\"traefik.access.geoip.location\"},\"schema\":\"segment\",\"type\":\"geohash_grid\"}],\"listeners\":{},\"params\":{\"addTooltip\":true,\"heatBlur\":15,\"heatMaxZoom\":16,\"heatMinOpacity\":0.1,\"heatNormalizeData\":true,\"heatRadius\":25,\"isDesaturated\":true,\"legendPosition\":\"bottomright\",\"mapCenter\":[15,5],\"mapType\":\"Scaled Circle Markers\",\"mapZoom\":2,\"wms\":{\"enabled\":false,\"options\":{\"attribution\":\"Maps provided by USGS\",\"format\":\"image/png\",\"layers\":\"0\",\"styles\":\"\",\"transparent\":true,\"version\":\"1.3.0\"},\"url\":\"https://basemap.nationalmap.gov/arcgis/services/USGSTopo/MapServer/WMSServer\"}},\"title\":\"ML Traefik Access Map\",\"type\":\"tile_map\"}",
+  "description": "",
+  "title": "ML Traefik Access Map",
+  "uiStateJSON": "{\n  \"mapCenter\": [\n    12.039320557540572,\n    -0.17578125\n  ]\n}",
+  "version": 1,
+  "savedSearchId": "ML-Filebeat-Traefik-Access",
+  "kibanaSavedObjectMeta": {
+    "searchSourceJSON": "{\"filter\":[]}"
+  }
+}

--- a/filebeat/module/traefik/_meta/kibana/5.x/visualization/ML-Traefik-Access-Remote-IP-Timechart.json
+++ b/filebeat/module/traefik/_meta/kibana/5.x/visualization/ML-Traefik-Access-Remote-IP-Timechart.json
@@ -1,0 +1,11 @@
+{
+  "visState": "{\"title\":\"ML Traefik Access Remote IP Timechart\",\"type\":\"area\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per 5 minutes\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"right\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Count\"},\"drawLinesBetweenPoints\":true,\"interpolate\":\"linear\",\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"area\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"auto\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}},{\"id\":\"3\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"group\",\"params\":{\"field\":\"traefik.access.remote_ip\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}",
+  "description": "",
+  "title": "ML Traefik Access Remote IP Timechart",
+  "uiStateJSON": "{\"vis\":{\"legendOpen\":false}}",
+  "version": 1,
+  "savedSearchId": "ML-Filebeat-Traefik-Access",
+  "kibanaSavedObjectMeta": {
+    "searchSourceJSON": "{}"
+  }
+}

--- a/filebeat/module/traefik/_meta/kibana/5.x/visualization/ML-Traefik-Access-Response-Code-Timechart.json
+++ b/filebeat/module/traefik/_meta/kibana/5.x/visualization/ML-Traefik-Access-Response-Code-Timechart.json
@@ -1,0 +1,11 @@
+{
+  "visState": "{\"title\":\"ML Traefik Access Response Code Timechart\",\"type\":\"histogram\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"scale\":\"linear\",\"mode\":\"stacked\",\"times\":[],\"addTimeMarker\":false,\"defaultYExtents\":false,\"setYExtents\":false,\"yAxis\":{}},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"auto\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}},{\"id\":\"3\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"group\",\"params\":{\"field\":\"traefik.access.response_code\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}",
+  "description": "",
+  "title": "ML Traefik Access Response Code Timechart",
+  "uiStateJSON": "{\n  \"vis\": {\n    \"colors\": {\n      \"200\": \"#7EB26D\",\n      \"404\": \"#614D93\"\n    }\n  }\n}",
+  "version": 1,
+  "savedSearchId": "ML-Filebeat-Traefik-Access",
+  "kibanaSavedObjectMeta": {
+    "searchSourceJSON": "{\"filter\":[]}"
+  }
+}

--- a/filebeat/module/traefik/_meta/kibana/5.x/visualization/ML-Traefik-Access-Top-Remote-IPs-Table.json
+++ b/filebeat/module/traefik/_meta/kibana/5.x/visualization/ML-Traefik-Access-Top-Remote-IPs-Table.json
@@ -1,0 +1,11 @@
+{
+  "visState": "{\"title\":\"ML Traefik Access Top Remote IPs Table\",\"type\":\"table\",\"params\":{\"perPage\":10,\"showPartialRows\":false,\"showMeticsAtAllLevels\":false,\"sort\":{\"columnIndex\":null,\"direction\":null},\"showTotal\":false,\"totalFunc\":\"sum\"},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"traefik.access.remote_ip\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}",
+  "description": "",
+  "title": "ML Traefik Access Top Remote IPs Table",
+  "uiStateJSON": "{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":null,\"direction\":null}}}}",
+  "version": 1,
+  "savedSearchId": "ML-Filebeat-Traefik-Access",
+  "kibanaSavedObjectMeta": {
+    "searchSourceJSON": "{}"
+  }
+}

--- a/filebeat/module/traefik/_meta/kibana/5.x/visualization/ML-Traefik-Access-Top-URLs-Table.json
+++ b/filebeat/module/traefik/_meta/kibana/5.x/visualization/ML-Traefik-Access-Top-URLs-Table.json
@@ -1,0 +1,11 @@
+{
+  "visState": "{\"title\":\"ML Traefik Access Top URLs Table\",\"type\":\"table\",\"params\":{\"perPage\":100,\"showPartialRows\":false,\"showMeticsAtAllLevels\":false,\"sort\":{\"columnIndex\":null,\"direction\":null},\"showTotal\":false,\"totalFunc\":\"sum\"},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"traefik.access.url\",\"size\":1000,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}",
+  "description": "",
+  "title": "ML Traefik Access Top URLs Table",
+  "uiStateJSON": "{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":null,\"direction\":null}}}}",
+  "version": 1,
+  "savedSearchId": "ML-Filebeat-Traefik-Access",
+  "kibanaSavedObjectMeta": {
+    "searchSourceJSON": "{}"
+  }
+}

--- a/filebeat/module/traefik/_meta/kibana/5.x/visualization/ML-Traefik-Access-Unique-Count-URL-Timechart.json
+++ b/filebeat/module/traefik/_meta/kibana/5.x/visualization/ML-Traefik-Access-Unique-Count-URL-Timechart.json
@@ -1,0 +1,11 @@
+{
+  "visState": "{\"title\":\"ML Traefik Access Unique Count URL Timechart\",\"type\":\"line\",\"params\":{\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"type\":\"category\",\"position\":\"bottom\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\"},\"labels\":{\"show\":true,\"truncate\":100},\"title\":{\"text\":\"@timestamp per day\"}}],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"name\":\"LeftAxis-1\",\"type\":\"value\",\"position\":\"left\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\",\"mode\":\"normal\"},\"labels\":{\"show\":true,\"rotate\":0,\"filter\":false,\"truncate\":100},\"title\":{\"text\":\"Unique count of traefik.access.url\"}}],\"seriesParams\":[{\"show\":true,\"mode\":\"normal\",\"type\":\"line\",\"drawLinesBetweenPoints\":true,\"showCircles\":true,\"interpolate\":\"linear\",\"lineWidth\":2,\"data\":{\"id\":\"1\",\"label\":\"Unique count of traefik.access.url\"},\"valueAxis\":\"ValueAxis-1\"}],\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"showCircles\":true,\"interpolate\":\"linear\",\"scale\":\"linear\",\"drawLinesBetweenPoints\":true,\"radiusRatio\":9,\"times\":[],\"addTimeMarker\":false,\"defaultYExtents\":false,\"setYExtents\":false},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"cardinality\",\"schema\":\"metric\",\"params\":{\"field\":\"traefik.access.url\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"auto\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
+  "description": "",
+  "title": "ML Traefik Access Unique Count URL Timechart",
+  "uiStateJSON": "{}",
+  "version": 1,
+  "savedSearchId": "ML-Filebeat-Traefik-Access",
+  "kibanaSavedObjectMeta": {
+    "searchSourceJSON": "{}"
+  }
+}

--- a/filebeat/module/traefik/_meta/kibana/5.x/visualization/New-Visualization.json
+++ b/filebeat/module/traefik/_meta/kibana/5.x/visualization/New-Visualization.json
@@ -1,0 +1,11 @@
+{
+  "visState": "{\n  \"title\": \"New Visualization\",\n  \"type\": \"histogram\",\n  \"params\": {\n    \"shareYAxis\": true,\n    \"addTooltip\": true,\n    \"addLegend\": true,\n    \"legendPosition\": \"right\",\n    \"scale\": \"linear\",\n    \"mode\": \"stacked\",\n    \"times\": [],\n    \"addTimeMarker\": false,\n    \"defaultYExtents\": false,\n    \"setYExtents\": false,\n    \"yAxis\": {}\n  },\n  \"aggs\": [\n    {\n      \"id\": \"1\",\n      \"enabled\": true,\n      \"type\": \"count\",\n      \"schema\": \"metric\",\n      \"params\": {}\n    },\n    {\n      \"id\": \"2\",\n      \"enabled\": true,\n      \"type\": \"date_histogram\",\n      \"schema\": \"segment\",\n      \"params\": {\n        \"field\": \"@timestamp\",\n        \"interval\": \"auto\",\n        \"customInterval\": \"2h\",\n        \"min_doc_count\": 1,\n        \"extended_bounds\": {}\n      }\n    },\n    {\n      \"id\": \"3\",\n      \"enabled\": true,\n      \"type\": \"terms\",\n      \"schema\": \"group\",\n      \"params\": {\n        \"field\": \"traefik.access.response_code\",\n        \"size\": 5,\n        \"order\": \"desc\",\n        \"orderBy\": \"1\"\n      }\n    }\n  ],\n  \"listeners\": {}\n}",
+  "description": "",
+  "title": "Traefik Access over time",
+  "uiStateJSON": "{\n  \"vis\": {\n    \"colors\": {\n      \"200\": \"#7EB26D\",\n      \"404\": \"#614D93\"\n    }\n  }\n}",
+  "version": 1,
+  "savedSearchId": "Filebeat-Traefik-module",
+  "kibanaSavedObjectMeta": {
+    "searchSourceJSON": "{\n  \"filter\": []\n}"
+  }
+}

--- a/filebeat/module/traefik/_meta/kibana/5.x/visualization/Sent-sizes.json
+++ b/filebeat/module/traefik/_meta/kibana/5.x/visualization/Sent-sizes.json
@@ -1,0 +1,10 @@
+{
+  "visState": "{\n  \"title\": \"Sent sizes\",\n  \"type\": \"line\",\n  \"params\": {\n    \"shareYAxis\": true,\n    \"addTooltip\": true,\n    \"addLegend\": true,\n    \"legendPosition\": \"right\",\n    \"showCircles\": true,\n    \"smoothLines\": true,\n    \"interpolate\": \"linear\",\n    \"scale\": \"linear\",\n    \"drawLinesBetweenPoints\": true,\n    \"radiusRatio\": \"17\",\n    \"times\": [],\n    \"addTimeMarker\": false,\n    \"defaultYExtents\": false,\n    \"setYExtents\": false,\n    \"yAxis\": {}\n  },\n  \"aggs\": [\n    {\n      \"id\": \"1\",\n      \"enabled\": true,\n      \"type\": \"sum\",\n      \"schema\": \"metric\",\n      \"params\": {\n        \"field\": \"traefik.access.body_sent.bytes\",\n        \"customLabel\": \"Data sent\"\n      }\n    },\n    {\n      \"id\": \"2\",\n      \"enabled\": true,\n      \"type\": \"date_histogram\",\n      \"schema\": \"segment\",\n      \"params\": {\n        \"field\": \"@timestamp\",\n        \"interval\": \"auto\",\n        \"customInterval\": \"2h\",\n        \"min_doc_count\": 1,\n        \"extended_bounds\": {}\n      }\n    },\n    {\n      \"id\": \"3\",\n      \"enabled\": true,\n      \"type\": \"count\",\n      \"schema\": \"radius\",\n      \"params\": {}\n    }\n  ],\n  \"listeners\": {}\n}",
+  "description": "",
+  "title": "Traefik Sent Byte Size",
+  "uiStateJSON": "{}",
+  "version": 1,
+  "kibanaSavedObjectMeta": {
+    "searchSourceJSON": "{\n  \"filter\": [],\n  \"index\": \"filebeat-*\",\n  \"query\": {\n    \"query_string\": {\n      \"query\": \"_exists_:traefik.access\",\n      \"analyze_wildcard\": true\n    }\n  },\n  \"highlight\": {\n    \"pre_tags\": [\n      \"@kibana-highlighted-field@\"\n    ],\n    \"post_tags\": [\n      \"@/kibana-highlighted-field@\"\n    ],\n    \"fields\": {\n      \"*\": {}\n    },\n    \"require_field_match\": false,\n    \"fragment_size\": 2147483647\n  }\n}"
+  }
+}

--- a/filebeat/module/traefik/_meta/kibana/5.x/visualization/Traefik-Access-Browsers.json
+++ b/filebeat/module/traefik/_meta/kibana/5.x/visualization/Traefik-Access-Browsers.json
@@ -1,0 +1,10 @@
+{
+  "visState": "{\"title\":\"Traefik Access Browsers\",\"type\":\"pie\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"bottom\",\"isDonut\":true},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"traefik.access.user_agent.name\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\"}},{\"id\":\"3\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"traefik.access.user_agent.major\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}",
+  "description": "",
+  "title": "Traefik Access Browsers",
+  "uiStateJSON": "{}",
+  "version": 1,
+  "kibanaSavedObjectMeta": {
+    "searchSourceJSON": "{\"index\":\"filebeat-*\",\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}},\"filter\":[]}"
+  }
+}

--- a/filebeat/module/traefik/_meta/kibana/5.x/visualization/Traefik-Access-Map.json
+++ b/filebeat/module/traefik/_meta/kibana/5.x/visualization/Traefik-Access-Map.json
@@ -1,0 +1,11 @@
+{
+  "visState": "{\"aggs\":[{\"enabled\":true,\"id\":\"1\",\"params\":{},\"schema\":\"metric\",\"type\":\"count\"},{\"enabled\":true,\"id\":\"2\",\"params\":{\"autoPrecision\":true,\"field\":\"traefik.access.geoip.location\"},\"schema\":\"segment\",\"type\":\"geohash_grid\"}],\"listeners\":{},\"params\":{\"addTooltip\":true,\"heatBlur\":15,\"heatMaxZoom\":16,\"heatMinOpacity\":0.1,\"heatNormalizeData\":true,\"heatRadius\":25,\"isDesaturated\":true,\"legendPosition\":\"bottomright\",\"mapCenter\":[15,5],\"mapType\":\"Scaled Circle Markers\",\"mapZoom\":2,\"wms\":{\"enabled\":false,\"options\":{\"attribution\":\"Maps provided by USGS\",\"format\":\"image/png\",\"layers\":\"0\",\"styles\":\"\",\"transparent\":true,\"version\":\"1.3.0\"},\"url\":\"https://basemap.nationalmap.gov/arcgis/services/USGSTopo/MapServer/WMSServer\"}},\"title\":\"Traefik Access Map\",\"type\":\"tile_map\"}",
+  "description": "",
+  "title": "Traefik Access Map",
+  "uiStateJSON": "{\"mapCenter\":[12.039320557540572,-0.17578125]}",
+  "version": 1,
+  "savedSearchId": "Filebeat-Traefik-module",
+  "kibanaSavedObjectMeta": {
+    "searchSourceJSON": "{\"filter\":[]}"
+  }
+}

--- a/filebeat/module/traefik/_meta/kibana/5.x/visualization/Traefik-Access-OSes.json
+++ b/filebeat/module/traefik/_meta/kibana/5.x/visualization/Traefik-Access-OSes.json
@@ -1,0 +1,10 @@
+{
+  "visState": "{\"title\":\"Traefik Access OSes\",\"type\":\"pie\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"bottom\",\"isDonut\":true},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"traefik.access.user_agent.os_name\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\"}},{\"id\":\"3\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"traefik.access.user_agent.os_major\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}",
+  "description": "",
+  "title": "Traefik Access OSes",
+  "uiStateJSON": "{}",
+  "version": 1,
+  "kibanaSavedObjectMeta": {
+    "searchSourceJSON": "{\"index\":\"filebeat-*\",\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}},\"filter\":[]}"
+  }
+}

--- a/filebeat/module/traefik/_meta/kibana/5.x/visualization/Traefik-Access-Response-codes-by-top-URLs.json
+++ b/filebeat/module/traefik/_meta/kibana/5.x/visualization/Traefik-Access-Response-codes-by-top-URLs.json
@@ -1,0 +1,10 @@
+{
+  "visState": "{\"title\":\"Traefik Access Response codes by top URLs\",\"type\":\"pie\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"isDonut\":false},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"split\",\"params\":{\"field\":\"traefik.access.url\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\",\"row\":false}},{\"id\":\"3\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"traefik.access.response_code\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}",
+  "description": "",
+  "title": "Traefik Access Response codes by top URLs",
+  "uiStateJSON": "{\"vis\":{\"colors\":{\"200\":\"#629E51\",\"404\":\"#0A50A1\"}}}",
+  "version": 1,
+  "kibanaSavedObjectMeta": {
+    "searchSourceJSON": "{\"index\":\"filebeat-*\",\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}},\"filter\":[]}"
+  }
+}

--- a/filebeat/module/traefik/_meta/kibana/default/dashboard/Filebeat-traefik-overview.json
+++ b/filebeat/module/traefik/_meta/kibana/default/dashboard/Filebeat-traefik-overview.json
@@ -1,0 +1,136 @@
+{
+  "objects": [
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\n  \"index\": \"filebeat-*\",\n  \"query\": {\n    \"query_string\": {\n      \"query\": \"*\",\n      \"analyze_wildcard\": true\n    }\n  },\n  \"filter\": []\n}"
+        },
+        "title": "Browsers breakdown [Filebeat Traefik]",
+        "uiStateJSON": "{}",
+        "version": 1,
+        "visState": "{\n  \"title\": \"Traefik Access Browsers\",\n  \"type\": \"pie\",\n  \"params\": {\n    \"shareYAxis\": true,\n    \"addTooltip\": true,\n    \"addLegend\": true,\n    \"legendPosition\": \"bottom\",\n    \"isDonut\": true\n  },\n  \"aggs\": [\n    {\n      \"id\": \"1\",\n      \"enabled\": true,\n      \"type\": \"count\",\n      \"schema\": \"metric\",\n      \"params\": {}\n    },\n    {\n      \"id\": \"2\",\n      \"enabled\": true,\n      \"type\": \"terms\",\n      \"schema\": \"segment\",\n      \"params\": {\n        \"field\": \"traefik.access.user_agent.name\",\n        \"size\": 5,\n        \"order\": \"desc\",\n        \"orderBy\": \"1\"\n      }\n    },\n    {\n      \"id\": \"3\",\n      \"enabled\": true,\n      \"type\": \"terms\",\n      \"schema\": \"segment\",\n      \"params\": {\n        \"field\": \"traefik.access.user_agent.major\",\n        \"size\": 5,\n        \"order\": \"desc\",\n        \"orderBy\": \"1\"\n      }\n    }\n  ],\n  \"listeners\": {}\n}"
+      },
+      "id": "Traefik-Access-Browsers",
+      "type": "visualization",
+      "version": 2
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\n  \"index\": \"filebeat-*\",\n  \"query\": {\n    \"query_string\": {\n      \"query\": \"*\",\n      \"analyze_wildcard\": true\n    }\n  },\n  \"filter\": []\n}"
+        },
+        "title": "Operating systems breakdown [Filebeat Traefik]",
+        "uiStateJSON": "{}",
+        "version": 1,
+        "visState": "{\n  \"title\": \"Traefik Access OSes\",\n  \"type\": \"pie\",\n  \"params\": {\n    \"shareYAxis\": true,\n    \"addTooltip\": true,\n    \"addLegend\": true,\n    \"legendPosition\": \"bottom\",\n    \"isDonut\": true\n  },\n  \"aggs\": [\n    {\n      \"id\": \"1\",\n      \"enabled\": true,\n      \"type\": \"count\",\n      \"schema\": \"metric\",\n      \"params\": {}\n    },\n    {\n      \"id\": \"2\",\n      \"enabled\": true,\n      \"type\": \"terms\",\n      \"schema\": \"segment\",\n      \"params\": {\n        \"field\": \"traefik.access.user_agent.os_name\",\n        \"size\": 5,\n        \"order\": \"desc\",\n        \"orderBy\": \"1\"\n      }\n    },\n    {\n      \"id\": \"3\",\n      \"enabled\": true,\n      \"type\": \"terms\",\n      \"schema\": \"segment\",\n      \"params\": {\n        \"field\": \"traefik.access.user_agent.os_major\",\n        \"size\": 5,\n        \"order\": \"desc\",\n        \"orderBy\": \"1\"\n      }\n    }\n  ],\n  \"listeners\": {}\n}"
+      },
+      "id": "Traefik-Access-OSes",
+      "type": "visualization",
+      "version": 2
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\n  \"filter\": []\n}"
+        },
+        "savedSearchId": "Filebeat-Traefik-module",
+        "title": "Response codes over time [Filebeat Traefik]",
+        "uiStateJSON": "{\n  \"vis\": {\n    \"colors\": {\n      \"200\": \"#7EB26D\",\n      \"404\": \"#614D93\"\n    }\n  }\n}",
+        "version": 1,
+        "visState": "{\n  \"title\": \"New Visualization\",\n  \"type\": \"histogram\",\n  \"params\": {\n    \"shareYAxis\": true,\n    \"addTooltip\": true,\n    \"addLegend\": true,\n    \"legendPosition\": \"right\",\n    \"scale\": \"linear\",\n    \"mode\": \"stacked\",\n    \"times\": [],\n    \"addTimeMarker\": false,\n    \"defaultYExtents\": false,\n    \"setYExtents\": false,\n    \"yAxis\": {}\n  },\n  \"aggs\": [\n    {\n      \"id\": \"1\",\n      \"enabled\": true,\n      \"type\": \"count\",\n      \"schema\": \"metric\",\n      \"params\": {}\n    },\n    {\n      \"id\": \"2\",\n      \"enabled\": true,\n      \"type\": \"date_histogram\",\n      \"schema\": \"segment\",\n      \"params\": {\n        \"field\": \"@timestamp\",\n        \"interval\": \"auto\",\n        \"customInterval\": \"2h\",\n        \"min_doc_count\": 1,\n        \"extended_bounds\": {}\n      }\n    },\n    {\n      \"id\": \"3\",\n      \"enabled\": true,\n      \"type\": \"terms\",\n      \"schema\": \"group\",\n      \"params\": {\n        \"field\": \"traefik.access.response_code\",\n        \"size\": 5,\n        \"order\": \"desc\",\n        \"orderBy\": \"1\"\n      }\n    }\n  ],\n  \"listeners\": {}\n}"
+      },
+      "id": "New-Visualization",
+      "type": "visualization",
+      "version": 2
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\n  \"index\": \"filebeat-*\",\n  \"query\": {\n    \"query_string\": {\n      \"query\": \"*\",\n      \"analyze_wildcard\": true\n    }\n  },\n  \"filter\": []\n}"
+        },
+        "title": "Response codes by top URLs [Filebeat Traefik]",
+        "uiStateJSON": "{\n  \"vis\": {\n    \"colors\": {\n      \"200\": \"#629E51\",\n      \"404\": \"#0A50A1\"\n    }\n  }\n}",
+        "version": 1,
+        "visState": "{\n  \"title\": \"Traefik Access Response codes by top URLs\",\n  \"type\": \"pie\",\n  \"params\": {\n    \"shareYAxis\": true,\n    \"addTooltip\": true,\n    \"addLegend\": true,\n    \"legendPosition\": \"right\",\n    \"isDonut\": false\n  },\n  \"aggs\": [\n    {\n      \"id\": \"1\",\n      \"enabled\": true,\n      \"type\": \"count\",\n      \"schema\": \"metric\",\n      \"params\": {}\n    },\n    {\n      \"id\": \"2\",\n      \"enabled\": true,\n      \"type\": \"terms\",\n      \"schema\": \"split\",\n      \"params\": {\n        \"field\": \"traefik.access.url\",\n        \"size\": 5,\n        \"order\": \"desc\",\n        \"orderBy\": \"1\",\n        \"row\": false\n      }\n    },\n    {\n      \"id\": \"3\",\n      \"enabled\": true,\n      \"type\": \"terms\",\n      \"schema\": \"segment\",\n      \"params\": {\n        \"field\": \"traefik.access.response_code\",\n        \"size\": 5,\n        \"order\": \"desc\",\n        \"orderBy\": \"1\"\n      }\n    }\n  ],\n  \"listeners\": {}\n}"
+      },
+      "id": "Traefik-Access-Response-codes-by-top-URLs",
+      "type": "visualization",
+      "version": 2
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\n  \"filter\": [],\n  \"index\": \"filebeat-*\",\n  \"query\": {\n    \"query_string\": {\n      \"query\": \"_exists_:traefik.access\",\n      \"analyze_wildcard\": true\n    }\n  },\n  \"highlight\": {\n    \"pre_tags\": [\n      \"@kibana-highlighted-field@\"\n    ],\n    \"post_tags\": [\n      \"@/kibana-highlighted-field@\"\n    ],\n    \"fields\": {\n      \"*\": {}\n    },\n    \"require_field_match\": false,\n    \"fragment_size\": 2147483647\n  }\n}"
+        },
+        "title": "Sent Byte Size [Filebeat Traefik]",
+        "uiStateJSON": "{}",
+        "version": 1,
+        "visState": "{\n  \"title\": \"Sent sizes\",\n  \"type\": \"line\",\n  \"params\": {\n    \"shareYAxis\": true,\n    \"addTooltip\": true,\n    \"addLegend\": true,\n    \"legendPosition\": \"right\",\n    \"showCircles\": true,\n    \"smoothLines\": true,\n    \"interpolate\": \"linear\",\n    \"scale\": \"linear\",\n    \"drawLinesBetweenPoints\": true,\n    \"radiusRatio\": \"17\",\n    \"times\": [],\n    \"addTimeMarker\": false,\n    \"defaultYExtents\": false,\n    \"setYExtents\": false,\n    \"yAxis\": {}\n  },\n  \"aggs\": [\n    {\n      \"id\": \"1\",\n      \"enabled\": true,\n      \"type\": \"sum\",\n      \"schema\": \"metric\",\n      \"params\": {\n        \"field\": \"traefik.access.body_sent.bytes\",\n        \"customLabel\": \"Data sent\"\n      }\n    },\n    {\n      \"id\": \"2\",\n      \"enabled\": true,\n      \"type\": \"date_histogram\",\n      \"schema\": \"segment\",\n      \"params\": {\n        \"field\": \"@timestamp\",\n        \"interval\": \"auto\",\n        \"customInterval\": \"2h\",\n        \"min_doc_count\": 1,\n        \"extended_bounds\": {}\n      }\n    },\n    {\n      \"id\": \"3\",\n      \"enabled\": true,\n      \"type\": \"count\",\n      \"schema\": \"radius\",\n      \"params\": {}\n    }\n  ],\n  \"listeners\": {}\n}"
+      },
+      "id": "Sent-sizes",
+      "type": "visualization",
+      "version": 2
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\n  \"filter\": []\n}"
+        },
+        "savedSearchId": "Filebeat-Traefik-module",
+        "title": "Access Map [Filebeat Traefik]",
+        "uiStateJSON": "{\n  \"mapCenter\": [\n    12.039320557540572,\n    -0.17578125\n  ]\n}",
+        "version": 1,
+        "visState": "{\n  \"aggs\": [\n    {\n      \"enabled\": true,\n      \"id\": \"1\",\n      \"params\": {},\n      \"schema\": \"metric\",\n      \"type\": \"count\"\n    },\n    {\n      \"enabled\": true,\n      \"id\": \"2\",\n      \"params\": {\n        \"autoPrecision\": true,\n        \"field\": \"traefik.access.geoip.location\"\n      },\n      \"schema\": \"segment\",\n      \"type\": \"geohash_grid\"\n    }\n  ],\n  \"listeners\": {},\n  \"params\": {\n    \"addTooltip\": true,\n    \"heatBlur\": 15,\n    \"heatMaxZoom\": 16,\n    \"heatMinOpacity\": 0.1,\n    \"heatNormalizeData\": true,\n    \"heatRadius\": 25,\n    \"isDesaturated\": true,\n    \"legendPosition\": \"bottomright\",\n    \"mapCenter\": [\n      15,\n      5\n    ],\n    \"mapType\": \"Scaled Circle Markers\",\n    \"mapZoom\": 2,\n    \"wms\": {\n      \"enabled\": false,\n      \"options\": {\n        \"attribution\": \"Maps provided by USGS\",\n        \"format\": \"image/png\",\n        \"layers\": \"0\",\n        \"styles\": \"\",\n        \"transparent\": true,\n        \"version\": \"1.3.0\"\n      },\n      \"url\": \"https://basemap.nationalmap.gov/arcgis/services/USGSTopo/MapServer/WMSServer\"\n    }\n  },\n  \"title\": \"Traefik Access Map\",\n  \"type\": \"tile_map\"\n}"
+      },
+      "id": "Traefik-Access-Map",
+      "type": "visualization",
+      "version": 2
+    },
+    {
+      "attributes": {
+        "columns": [
+          "_source"
+        ],
+        "description": "",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\n  \"index\": \"filebeat-*\",\n  \"query\": {\n    \"query_string\": {\n      \"query\": \"_exists_:traefik\",\n      \"analyze_wildcard\": true\n    }\n  },\n  \"filter\": [],\n  \"highlight\": {\n    \"pre_tags\": [\n      \"@kibana-highlighted-field@\"\n    ],\n    \"post_tags\": [\n      \"@/kibana-highlighted-field@\"\n    ],\n    \"fields\": {\n      \"*\": {}\n    },\n    \"require_field_match\": false,\n    \"fragment_size\": 2147483647\n  }\n}"
+        },
+        "sort": [
+          "@timestamp",
+          "desc"
+        ],
+        "title": "Traefik logs [Filebeat Traefik]",
+        "version": 1
+      },
+      "id": "Filebeat-Traefik-module",
+      "type": "search",
+      "version": 2
+    },
+    {
+      "attributes": {
+        "description": "Dashboard for the Filebeat Traefik module",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\n  \"filter\": [\n    {\n      \"query\": {\n        \"query_string\": {\n          \"analyze_wildcard\": true,\n          \"query\": \"*\"\n        }\n      }\n    }\n  ]\n}"
+        },
+        "optionsJSON": "{\n  \"darkTheme\": false\n}",
+        "panelsJSON": "[{\"col\":1,\"id\":\"Traefik-Access-Browsers\",\"panelIndex\":3,\"row\":10,\"size_x\":4,\"size_y\":4,\"type\":\"visualization\"},{\"col\":5,\"id\":\"Traefik-Access-OSes\",\"panelIndex\":4,\"row\":10,\"size_x\":4,\"size_y\":4,\"type\":\"visualization\"},{\"col\":1,\"id\":\"New-Visualization\",\"panelIndex\":5,\"row\":4,\"size_x\":12,\"size_y\":3,\"type\":\"visualization\"},{\"col\":1,\"id\":\"Traefik-Access-Response-codes-by-top-URLs\",\"panelIndex\":6,\"row\":7,\"size_x\":12,\"size_y\":3,\"type\":\"visualization\"},{\"col\":9,\"id\":\"Sent-sizes\",\"panelIndex\":7,\"row\":10,\"size_x\":4,\"size_y\":4,\"type\":\"visualization\"},{\"id\":\"Traefik-Access-Map\",\"type\":\"visualization\",\"panelIndex\":8,\"size_x\":12,\"size_y\":3,\"col\":1,\"row\":1}]",
+        "timeRestore": false,
+        "title": "[Filebeat Traefik] Access logs",
+        "uiStateJSON": "{\n  \"P-4\": {\n    \"vis\": {\n      \"legendOpen\": true\n    }\n  },\n  \"P-8\": {\n    \"mapCenter\": [\n      50.51342652633956,\n      -0.17578125\n    ]\n  }\n}",
+        "version": 1
+      },
+      "id": "Filebeat-Traefik-Dashboard",
+      "type": "dashboard",
+      "version": 3
+    }
+  ],
+  "version": "6.0.0-beta1-SNAPSHOT"
+}

--- a/filebeat/module/traefik/_meta/kibana/default/dashboard/ml-traefik-access-remote-ip-count-explorer.json
+++ b/filebeat/module/traefik/_meta/kibana/default/dashboard/ml-traefik-access-remote-ip-count-explorer.json
@@ -1,0 +1,124 @@
+{
+  "objects": [
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{}"
+        },
+        "savedSearchId": "ML-Filebeat-Traefik-Access",
+        "title": "Remote IP Timechart [Filebeat Traefik] [ML]",
+        "uiStateJSON": "{\n  \"vis\": {\n    \"legendOpen\": false\n  }\n}",
+        "version": 1,
+        "visState": "{\n  \"title\": \"ML Traefik Access Remote IP Timechart\",\n  \"type\": \"area\",\n  \"params\": {\n    \"addLegend\": true,\n    \"addTimeMarker\": false,\n    \"addTooltip\": true,\n    \"categoryAxes\": [\n      {\n        \"id\": \"CategoryAxis-1\",\n        \"labels\": {\n          \"show\": true,\n          \"truncate\": 100\n        },\n        \"position\": \"bottom\",\n        \"scale\": {\n          \"type\": \"linear\"\n        },\n        \"show\": true,\n        \"style\": {},\n        \"title\": {\n          \"text\": \"@timestamp per 5 minutes\"\n        },\n        \"type\": \"category\"\n      }\n    ],\n    \"defaultYExtents\": false,\n    \"drawLinesBetweenPoints\": true,\n    \"grid\": {\n      \"categoryLines\": false,\n      \"style\": {\n        \"color\": \"#eee\"\n      }\n    },\n    \"interpolate\": \"linear\",\n    \"legendPosition\": \"right\",\n    \"radiusRatio\": 9,\n    \"scale\": \"linear\",\n    \"seriesParams\": [\n      {\n        \"data\": {\n          \"id\": \"1\",\n          \"label\": \"Count\"\n        },\n        \"drawLinesBetweenPoints\": true,\n        \"interpolate\": \"linear\",\n        \"mode\": \"stacked\",\n        \"show\": \"true\",\n        \"showCircles\": true,\n        \"type\": \"area\",\n        \"valueAxis\": \"ValueAxis-1\"\n      }\n    ],\n    \"setYExtents\": false,\n    \"showCircles\": true,\n    \"times\": [],\n    \"valueAxes\": [\n      {\n        \"id\": \"ValueAxis-1\",\n        \"labels\": {\n          \"filter\": false,\n          \"rotate\": 0,\n          \"show\": true,\n          \"truncate\": 100\n        },\n        \"name\": \"LeftAxis-1\",\n        \"position\": \"left\",\n        \"scale\": {\n          \"mode\": \"normal\",\n          \"type\": \"linear\"\n        },\n        \"show\": true,\n        \"style\": {},\n        \"title\": {},\n        \"type\": \"value\"\n      }\n    ]\n  },\n  \"aggs\": [\n    {\n      \"id\": \"1\",\n      \"enabled\": true,\n      \"type\": \"count\",\n      \"schema\": \"metric\",\n      \"params\": {}\n    },\n    {\n      \"id\": \"2\",\n      \"enabled\": true,\n      \"type\": \"date_histogram\",\n      \"schema\": \"segment\",\n      \"params\": {\n        \"field\": \"@timestamp\",\n        \"interval\": \"auto\",\n        \"customInterval\": \"2h\",\n        \"min_doc_count\": 1,\n        \"extended_bounds\": {}\n      }\n    },\n    {\n      \"id\": \"3\",\n      \"enabled\": true,\n      \"type\": \"terms\",\n      \"schema\": \"group\",\n      \"params\": {\n        \"field\": \"traefik.access.remote_ip\",\n        \"size\": 5,\n        \"order\": \"desc\",\n        \"orderBy\": \"1\"\n      }\n    }\n  ],\n  \"listeners\": {}\n}"
+      },
+      "id": "ML-Traefik-Access-Remote-IP-Timechart",
+      "type": "visualization",
+      "version": 2
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\n  \"filter\": []\n}"
+        },
+        "savedSearchId": "ML-Filebeat-Traefik-Access",
+        "title": "Response Code Timechart [Filebeat Traefik] [ML]",
+        "uiStateJSON": "{\n  \"vis\": {\n    \"colors\": {\n      \"200\": \"#7EB26D\",\n      \"404\": \"#614D93\"\n    }\n  }\n}",
+        "version": 1,
+        "visState": "{\n  \"title\": \"ML Traefik Access Response Code Timechart\",\n  \"type\": \"histogram\",\n  \"params\": {\n    \"shareYAxis\": true,\n    \"addTooltip\": true,\n    \"addLegend\": true,\n    \"legendPosition\": \"right\",\n    \"scale\": \"linear\",\n    \"mode\": \"stacked\",\n    \"times\": [],\n    \"addTimeMarker\": false,\n    \"defaultYExtents\": false,\n    \"setYExtents\": false,\n    \"yAxis\": {}\n  },\n  \"aggs\": [\n    {\n      \"id\": \"1\",\n      \"enabled\": true,\n      \"type\": \"count\",\n      \"schema\": \"metric\",\n      \"params\": {}\n    },\n    {\n      \"id\": \"2\",\n      \"enabled\": true,\n      \"type\": \"date_histogram\",\n      \"schema\": \"segment\",\n      \"params\": {\n        \"field\": \"@timestamp\",\n        \"interval\": \"auto\",\n        \"customInterval\": \"2h\",\n        \"min_doc_count\": 1,\n        \"extended_bounds\": {}\n      }\n    },\n    {\n      \"id\": \"3\",\n      \"enabled\": true,\n      \"type\": \"terms\",\n      \"schema\": \"group\",\n      \"params\": {\n        \"field\": \"traefik.access.response_code\",\n        \"size\": 5,\n        \"order\": \"desc\",\n        \"orderBy\": \"1\"\n      }\n    }\n  ],\n  \"listeners\": {}\n}"
+      },
+      "id": "ML-Traefik-Access-Response-Code-Timechart",
+      "type": "visualization",
+      "version": 3
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{}"
+        },
+        "savedSearchId": "ML-Filebeat-Traefik-Access",
+        "title": "Top Remote IPs [Filebeat Traefik] [ML]",
+        "uiStateJSON": "{\n  \"vis\": {\n    \"params\": {\n      \"sort\": {\n        \"columnIndex\": null,\n        \"direction\": null\n      }\n    }\n  }\n}",
+        "version": 1,
+        "visState": "{\n  \"title\": \"ML Traefik Access Top Remote IPs Table\",\n  \"type\": \"table\",\n  \"params\": {\n    \"perPage\": 10,\n    \"showPartialRows\": false,\n    \"showMeticsAtAllLevels\": false,\n    \"sort\": {\n      \"columnIndex\": null,\n      \"direction\": null\n    },\n    \"showTotal\": false,\n    \"totalFunc\": \"sum\"\n  },\n  \"aggs\": [\n    {\n      \"id\": \"1\",\n      \"enabled\": true,\n      \"type\": \"count\",\n      \"schema\": \"metric\",\n      \"params\": {}\n    },\n    {\n      \"id\": \"2\",\n      \"enabled\": true,\n      \"type\": \"terms\",\n      \"schema\": \"bucket\",\n      \"params\": {\n        \"field\": \"traefik.access.remote_ip\",\n        \"size\": 5,\n        \"order\": \"desc\",\n        \"orderBy\": \"1\"\n      }\n    }\n  ],\n  \"listeners\": {}\n}"
+      },
+      "id": "ML-Traefik-Access-Top-Remote-IPs-Table",
+      "type": "visualization",
+      "version": 3
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\n  \"filter\": []\n}"
+        },
+        "savedSearchId": "ML-Filebeat-Traefik-Access",
+        "title": "Access Map [Filebeat Traefik] [ML]",
+        "uiStateJSON": "{\n  \"mapCenter\": [\n    12.039320557540572,\n    -0.17578125\n  ]\n}",
+        "version": 1,
+        "visState": "{\n  \"aggs\": [\n    {\n      \"enabled\": true,\n      \"id\": \"1\",\n      \"params\": {},\n      \"schema\": \"metric\",\n      \"type\": \"count\"\n    },\n    {\n      \"enabled\": true,\n      \"id\": \"2\",\n      \"params\": {\n        \"autoPrecision\": true,\n        \"field\": \"traefik.access.geoip.location\"\n      },\n      \"schema\": \"segment\",\n      \"type\": \"geohash_grid\"\n    }\n  ],\n  \"listeners\": {},\n  \"params\": {\n    \"addTooltip\": true,\n    \"heatBlur\": 15,\n    \"heatMaxZoom\": 16,\n    \"heatMinOpacity\": 0.1,\n    \"heatNormalizeData\": true,\n    \"heatRadius\": 25,\n    \"isDesaturated\": true,\n    \"legendPosition\": \"bottomright\",\n    \"mapCenter\": [\n      15,\n      5\n    ],\n    \"mapType\": \"Scaled Circle Markers\",\n    \"mapZoom\": 2,\n    \"wms\": {\n      \"enabled\": false,\n      \"options\": {\n        \"attribution\": \"Maps provided by USGS\",\n        \"format\": \"image/png\",\n        \"layers\": \"0\",\n        \"styles\": \"\",\n        \"transparent\": true,\n        \"version\": \"1.3.0\"\n      },\n      \"url\": \"https://basemap.nationalmap.gov/arcgis/services/USGSTopo/MapServer/WMSServer\"\n    }\n  },\n  \"title\": \"ML Traefik Access Map\",\n  \"type\": \"tile_map\"\n}"
+      },
+      "id": "ML-Traefik-Access-Map",
+      "type": "visualization",
+      "version": 3
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{}"
+        },
+        "savedSearchId": "ML-Filebeat-Traefik-Access",
+        "title": "Top URLs [Filebeat Traefik] [ML]",
+        "uiStateJSON": "{\n  \"vis\": {\n    \"params\": {\n      \"sort\": {\n        \"columnIndex\": null,\n        \"direction\": null\n      }\n    }\n  }\n}",
+        "version": 1,
+        "visState": "{\n  \"title\": \"ML Traefik Access Top URLs Table\",\n  \"type\": \"table\",\n  \"params\": {\n    \"perPage\": 100,\n    \"showPartialRows\": false,\n    \"showMeticsAtAllLevels\": false,\n    \"sort\": {\n      \"columnIndex\": null,\n      \"direction\": null\n    },\n    \"showTotal\": false,\n    \"totalFunc\": \"sum\"\n  },\n  \"aggs\": [\n    {\n      \"id\": \"1\",\n      \"enabled\": true,\n      \"type\": \"count\",\n      \"schema\": \"metric\",\n      \"params\": {}\n    },\n    {\n      \"id\": \"2\",\n      \"enabled\": true,\n      \"type\": \"terms\",\n      \"schema\": \"bucket\",\n      \"params\": {\n        \"field\": \"traefik.access.url\",\n        \"size\": 1000,\n        \"order\": \"desc\",\n        \"orderBy\": \"1\"\n      }\n    }\n  ],\n  \"listeners\": {}\n}"
+      },
+      "id": "ML-Traefik-Access-Top-URLs-Table",
+      "type": "visualization",
+      "version": 3
+    },
+    {
+      "attributes": {
+        "columns": [
+          "_source"
+        ],
+        "description": "Filebeat Traefik Access Data",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\n  \"index\": \"filebeat-*\",\n  \"query\": {\n    \"query_string\": {\n      \"query\": \"_exists_:traefik.access\",\n      \"analyze_wildcard\": true\n    }\n  },\n  \"filter\": [],\n  \"highlight\": {\n    \"pre_tags\": [\n      \"@kibana-highlighted-field@\"\n    ],\n    \"post_tags\": [\n      \"@/kibana-highlighted-field@\"\n    ],\n    \"fields\": {\n      \"*\": {}\n    },\n    \"require_field_match\": false,\n    \"fragment_size\": 2147483647\n  }\n}"
+        },
+        "sort": [
+          "@timestamp",
+          "desc"
+        ],
+        "title": "ML Access Data [Filebeat Traefik]",
+        "version": 1
+      },
+      "id": "ML-Filebeat-Traefik-Access",
+      "type": "search",
+      "version": 3
+    },
+    {
+      "attributes": {
+        "description": "Machine learning dashboard, for the Filebeat Traefik module",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\n  \"filter\": [\n    {\n      \"query\": {\n        \"query_string\": {\n          \"analyze_wildcard\": true,\n          \"query\": \"*\"\n        }\n      }\n    }\n  ],\n  \"highlightAll\": true,\n  \"version\": true\n}"
+        },
+        "optionsJSON": "{\n  \"darkTheme\": false\n}",
+        "panelsJSON": "[\n  {\n    \"size_x\": 6,\n    \"size_y\": 3,\n    \"panelIndex\": 1,\n    \"type\": \"visualization\",\n    \"id\": \"ML-Traefik-Access-Remote-IP-Timechart\",\n    \"col\": 1,\n    \"row\": 1\n  },\n  {\n    \"size_x\": 6,\n    \"size_y\": 3,\n    \"panelIndex\": 2,\n    \"type\": \"visualization\",\n    \"id\": \"ML-Traefik-Access-Response-Code-Timechart\",\n    \"col\": 7,\n    \"row\": 1\n  },\n  {\n    \"size_x\": 6,\n    \"size_y\": 3,\n    \"panelIndex\": 3,\n    \"type\": \"visualization\",\n    \"id\": \"ML-Traefik-Access-Top-Remote-IPs-Table\",\n    \"col\": 1,\n    \"row\": 4\n  },\n  {\n    \"size_x\": 6,\n    \"size_y\": 3,\n    \"panelIndex\": 4,\n    \"type\": \"visualization\",\n    \"id\": \"ML-Traefik-Access-Map\",\n    \"col\": 7,\n    \"row\": 4\n  },\n  {\n    \"size_x\": 12,\n    \"size_y\": 9,\n    \"panelIndex\": 5,\n    \"type\": \"visualization\",\n    \"id\": \"ML-Traefik-Access-Top-URLs-Table\",\n    \"col\": 1,\n    \"row\": 7\n  }\n]",
+        "timeRestore": false,
+        "title": "[Filebeat Traefik] [ML]  Remote IP Count Explorer",
+        "uiStateJSON": "{\n  \"P-3\": {\n    \"vis\": {\n      \"params\": {\n        \"sort\": {\n          \"columnIndex\": null,\n          \"direction\": null\n        }\n      }\n    }\n  },\n  \"P-5\": {\n    \"vis\": {\n      \"params\": {\n        \"sort\": {\n          \"columnIndex\": null,\n          \"direction\": null\n        }\n      }\n    }\n  }\n}",
+        "version": 1
+      },
+      "id": "ML-Traefik-Access-Remote-IP-Count-Explorer",
+      "type": "dashboard",
+      "version": 3
+    }
+  ],
+  "version": "6.0.0-beta1-SNAPSHOT"
+}

--- a/filebeat/module/traefik/_meta/kibana/default/dashboard/ml-traefik-remote-ip-url-explorer.json
+++ b/filebeat/module/traefik/_meta/kibana/default/dashboard/ml-traefik-remote-ip-url-explorer.json
@@ -1,0 +1,124 @@
+{
+  "objects": [
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{}"
+        },
+        "savedSearchId": "ML-Filebeat-Traefik-Access",
+        "title": "Unique Count URL Timechart [Filebeat Traefik] [ML]",
+        "uiStateJSON": "{}",
+        "version": 1,
+        "visState": "{\n  \"title\": \"ML Traefik Access Unique Count URL Timechart\",\n  \"type\": \"line\",\n  \"params\": {\n    \"grid\": {\n      \"categoryLines\": false,\n      \"style\": {\n        \"color\": \"#eee\"\n      }\n    },\n    \"categoryAxes\": [\n      {\n        \"id\": \"CategoryAxis-1\",\n        \"type\": \"category\",\n        \"position\": \"bottom\",\n        \"show\": true,\n        \"style\": {},\n        \"scale\": {\n          \"type\": \"linear\"\n        },\n        \"labels\": {\n          \"show\": true,\n          \"truncate\": 100\n        },\n        \"title\": {\n          \"text\": \"@timestamp per day\"\n        }\n      }\n    ],\n    \"valueAxes\": [\n      {\n        \"id\": \"ValueAxis-1\",\n        \"name\": \"LeftAxis-1\",\n        \"type\": \"value\",\n        \"position\": \"left\",\n        \"show\": true,\n        \"style\": {},\n        \"scale\": {\n          \"type\": \"linear\",\n          \"mode\": \"normal\"\n        },\n        \"labels\": {\n          \"show\": true,\n          \"rotate\": 0,\n          \"filter\": false,\n          \"truncate\": 100\n        },\n        \"title\": {\n          \"text\": \"Unique count of traefik.access.url\"\n        }\n      }\n    ],\n    \"seriesParams\": [\n      {\n        \"show\": true,\n        \"mode\": \"normal\",\n        \"type\": \"line\",\n        \"drawLinesBetweenPoints\": true,\n        \"showCircles\": true,\n        \"interpolate\": \"linear\",\n        \"lineWidth\": 2,\n        \"data\": {\n          \"id\": \"1\",\n          \"label\": \"Unique count of traefik.access.url\"\n        },\n        \"valueAxis\": \"ValueAxis-1\"\n      }\n    ],\n    \"addTooltip\": true,\n    \"addLegend\": true,\n    \"legendPosition\": \"right\",\n    \"showCircles\": true,\n    \"interpolate\": \"linear\",\n    \"scale\": \"linear\",\n    \"drawLinesBetweenPoints\": true,\n    \"radiusRatio\": 9,\n    \"times\": [],\n    \"addTimeMarker\": false,\n    \"defaultYExtents\": false,\n    \"setYExtents\": false\n  },\n  \"aggs\": [\n    {\n      \"id\": \"1\",\n      \"enabled\": true,\n      \"type\": \"cardinality\",\n      \"schema\": \"metric\",\n      \"params\": {\n        \"field\": \"traefik.access.url\"\n      }\n    },\n    {\n      \"id\": \"2\",\n      \"enabled\": true,\n      \"type\": \"date_histogram\",\n      \"schema\": \"segment\",\n      \"params\": {\n        \"field\": \"@timestamp\",\n        \"interval\": \"auto\",\n        \"customInterval\": \"2h\",\n        \"min_doc_count\": 1,\n        \"extended_bounds\": {}\n      }\n    }\n  ],\n  \"listeners\": {}\n}"
+      },
+      "id": "ML-Traefik-Access-Unique-Count-URL-Timechart",
+      "type": "visualization",
+      "version": 2
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\n  \"filter\": []\n}"
+        },
+        "savedSearchId": "ML-Filebeat-Traefik-Access",
+        "title": "Response Code Timechart [Filebeat Traefik] [ML]",
+        "uiStateJSON": "{\n  \"vis\": {\n    \"colors\": {\n      \"200\": \"#7EB26D\",\n      \"404\": \"#614D93\"\n    }\n  }\n}",
+        "version": 1,
+        "visState": "{\n  \"title\": \"ML Traefik Access Response Code Timechart\",\n  \"type\": \"histogram\",\n  \"params\": {\n    \"shareYAxis\": true,\n    \"addTooltip\": true,\n    \"addLegend\": true,\n    \"legendPosition\": \"right\",\n    \"scale\": \"linear\",\n    \"mode\": \"stacked\",\n    \"times\": [],\n    \"addTimeMarker\": false,\n    \"defaultYExtents\": false,\n    \"setYExtents\": false,\n    \"yAxis\": {}\n  },\n  \"aggs\": [\n    {\n      \"id\": \"1\",\n      \"enabled\": true,\n      \"type\": \"count\",\n      \"schema\": \"metric\",\n      \"params\": {}\n    },\n    {\n      \"id\": \"2\",\n      \"enabled\": true,\n      \"type\": \"date_histogram\",\n      \"schema\": \"segment\",\n      \"params\": {\n        \"field\": \"@timestamp\",\n        \"interval\": \"auto\",\n        \"customInterval\": \"2h\",\n        \"min_doc_count\": 1,\n        \"extended_bounds\": {}\n      }\n    },\n    {\n      \"id\": \"3\",\n      \"enabled\": true,\n      \"type\": \"terms\",\n      \"schema\": \"group\",\n      \"params\": {\n        \"field\": \"traefik.access.response_code\",\n        \"size\": 5,\n        \"order\": \"desc\",\n        \"orderBy\": \"1\"\n      }\n    }\n  ],\n  \"listeners\": {}\n}"
+      },
+      "id": "ML-Traefik-Access-Response-Code-Timechart",
+      "type": "visualization",
+      "version": 3
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{}"
+        },
+        "savedSearchId": "ML-Filebeat-Traefik-Access",
+        "title": "Top Remote IPs [Filebeat Traefik] [ML]",
+        "uiStateJSON": "{\n  \"vis\": {\n    \"params\": {\n      \"sort\": {\n        \"columnIndex\": null,\n        \"direction\": null\n      }\n    }\n  }\n}",
+        "version": 1,
+        "visState": "{\n  \"title\": \"ML Traefik Access Top Remote IPs Table\",\n  \"type\": \"table\",\n  \"params\": {\n    \"perPage\": 10,\n    \"showPartialRows\": false,\n    \"showMeticsAtAllLevels\": false,\n    \"sort\": {\n      \"columnIndex\": null,\n      \"direction\": null\n    },\n    \"showTotal\": false,\n    \"totalFunc\": \"sum\"\n  },\n  \"aggs\": [\n    {\n      \"id\": \"1\",\n      \"enabled\": true,\n      \"type\": \"count\",\n      \"schema\": \"metric\",\n      \"params\": {}\n    },\n    {\n      \"id\": \"2\",\n      \"enabled\": true,\n      \"type\": \"terms\",\n      \"schema\": \"bucket\",\n      \"params\": {\n        \"field\": \"traefik.access.remote_ip\",\n        \"size\": 5,\n        \"order\": \"desc\",\n        \"orderBy\": \"1\"\n      }\n    }\n  ],\n  \"listeners\": {}\n}"
+      },
+      "id": "ML-Traefik-Access-Top-Remote-IPs-Table",
+      "type": "visualization",
+      "version": 3
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\n  \"filter\": []\n}"
+        },
+        "savedSearchId": "ML-Filebeat-Traefik-Access",
+        "title": "Access Map [Filebeat Traefik] [ML]",
+        "uiStateJSON": "{\n  \"mapCenter\": [\n    12.039320557540572,\n    -0.17578125\n  ]\n}",
+        "version": 1,
+        "visState": "{\n  \"aggs\": [\n    {\n      \"enabled\": true,\n      \"id\": \"1\",\n      \"params\": {},\n      \"schema\": \"metric\",\n      \"type\": \"count\"\n    },\n    {\n      \"enabled\": true,\n      \"id\": \"2\",\n      \"params\": {\n        \"autoPrecision\": true,\n        \"field\": \"traefik.access.geoip.location\"\n      },\n      \"schema\": \"segment\",\n      \"type\": \"geohash_grid\"\n    }\n  ],\n  \"listeners\": {},\n  \"params\": {\n    \"addTooltip\": true,\n    \"heatBlur\": 15,\n    \"heatMaxZoom\": 16,\n    \"heatMinOpacity\": 0.1,\n    \"heatNormalizeData\": true,\n    \"heatRadius\": 25,\n    \"isDesaturated\": true,\n    \"legendPosition\": \"bottomright\",\n    \"mapCenter\": [\n      15,\n      5\n    ],\n    \"mapType\": \"Scaled Circle Markers\",\n    \"mapZoom\": 2,\n    \"wms\": {\n      \"enabled\": false,\n      \"options\": {\n        \"attribution\": \"Maps provided by USGS\",\n        \"format\": \"image/png\",\n        \"layers\": \"0\",\n        \"styles\": \"\",\n        \"transparent\": true,\n        \"version\": \"1.3.0\"\n      },\n      \"url\": \"https://basemap.nationalmap.gov/arcgis/services/USGSTopo/MapServer/WMSServer\"\n    }\n  },\n  \"title\": \"ML Traefik Access Map\",\n  \"type\": \"tile_map\"\n}"
+      },
+      "id": "ML-Traefik-Access-Map",
+      "type": "visualization",
+      "version": 3
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{}"
+        },
+        "savedSearchId": "ML-Filebeat-Traefik-Access",
+        "title": "Top URLs [Filebeat Traefik] [ML]",
+        "uiStateJSON": "{\n  \"vis\": {\n    \"params\": {\n      \"sort\": {\n        \"columnIndex\": null,\n        \"direction\": null\n      }\n    }\n  }\n}",
+        "version": 1,
+        "visState": "{\n  \"title\": \"ML Traefik Access Top URLs Table\",\n  \"type\": \"table\",\n  \"params\": {\n    \"perPage\": 100,\n    \"showPartialRows\": false,\n    \"showMeticsAtAllLevels\": false,\n    \"sort\": {\n      \"columnIndex\": null,\n      \"direction\": null\n    },\n    \"showTotal\": false,\n    \"totalFunc\": \"sum\"\n  },\n  \"aggs\": [\n    {\n      \"id\": \"1\",\n      \"enabled\": true,\n      \"type\": \"count\",\n      \"schema\": \"metric\",\n      \"params\": {}\n    },\n    {\n      \"id\": \"2\",\n      \"enabled\": true,\n      \"type\": \"terms\",\n      \"schema\": \"bucket\",\n      \"params\": {\n        \"field\": \"traefik.access.url\",\n        \"size\": 1000,\n        \"order\": \"desc\",\n        \"orderBy\": \"1\"\n      }\n    }\n  ],\n  \"listeners\": {}\n}"
+      },
+      "id": "ML-Traefik-Access-Top-URLs-Table",
+      "type": "visualization",
+      "version": 3
+    },
+    {
+      "attributes": {
+        "columns": [
+          "_source"
+        ],
+        "description": "Filebeat Traefik Access Data",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\n  \"index\": \"filebeat-*\",\n  \"query\": {\n    \"query_string\": {\n      \"query\": \"_exists_:traefik.access\",\n      \"analyze_wildcard\": true\n    }\n  },\n  \"filter\": [],\n  \"highlight\": {\n    \"pre_tags\": [\n      \"@kibana-highlighted-field@\"\n    ],\n    \"post_tags\": [\n      \"@/kibana-highlighted-field@\"\n    ],\n    \"fields\": {\n      \"*\": {}\n    },\n    \"require_field_match\": false,\n    \"fragment_size\": 2147483647\n  }\n}"
+        },
+        "sort": [
+          "@timestamp",
+          "desc"
+        ],
+        "title": "ML Access Data [Filebeat Traefik]",
+        "version": 1
+      },
+      "id": "ML-Filebeat-Traefik-Access",
+      "type": "search",
+      "version": 3
+    },
+    {
+      "attributes": {
+        "description": "Machine Learning dashboard for the Filebeat Traefik module",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\n  \"filter\": [\n    {\n      \"query\": {\n        \"query_string\": {\n          \"analyze_wildcard\": true,\n          \"query\": \"*\"\n        }\n      }\n    }\n  ],\n  \"highlightAll\": true,\n  \"version\": true\n}"
+        },
+        "optionsJSON": "{\n  \"darkTheme\": false\n}",
+        "panelsJSON": "[\n  {\n    \"col\": 1,\n    \"id\": \"ML-Traefik-Access-Unique-Count-URL-Timechart\",\n    \"panelIndex\": 1,\n    \"row\": 1,\n    \"size_x\": 6,\n    \"size_y\": 3,\n    \"type\": \"visualization\"\n  },\n  {\n    \"col\": 7,\n    \"id\": \"ML-Traefik-Access-Response-Code-Timechart\",\n    \"panelIndex\": 2,\n    \"row\": 1,\n    \"size_x\": 6,\n    \"size_y\": 3,\n    \"type\": \"visualization\"\n  },\n  {\n    \"col\": 1,\n    \"id\": \"ML-Traefik-Access-Top-Remote-IPs-Table\",\n    \"panelIndex\": 3,\n    \"row\": 4,\n    \"size_x\": 6,\n    \"size_y\": 3,\n    \"type\": \"visualization\"\n  },\n  {\n    \"col\": 7,\n    \"id\": \"ML-Traefik-Access-Map\",\n    \"panelIndex\": 4,\n    \"row\": 4,\n    \"size_x\": 6,\n    \"size_y\": 3,\n    \"type\": \"visualization\"\n  },\n  {\n    \"size_x\": 12,\n    \"size_y\": 8,\n    \"panelIndex\": 5,\n    \"type\": \"visualization\",\n    \"id\": \"ML-Traefik-Access-Top-URLs-Table\",\n    \"col\": 1,\n    \"row\": 7\n  }\n]",
+        "timeRestore": false,
+        "title": "[Filebeat Traefik] [ML] Remote IP URL Explorer",
+        "uiStateJSON": "{\n  \"P-2\": {\n    \"vis\": {\n      \"params\": {\n        \"sort\": {\n          \"columnIndex\": null,\n          \"direction\": null\n        }\n      }\n    }\n  },\n  \"P-3\": {\n    \"vis\": {\n      \"params\": {\n        \"sort\": {\n          \"columnIndex\": null,\n          \"direction\": null\n        }\n      }\n    }\n  },\n  \"P-5\": {\n    \"vis\": {\n      \"params\": {\n        \"sort\": {\n          \"columnIndex\": null,\n          \"direction\": null\n        }\n      }\n    }\n  }\n}",
+        "version": 1
+      },
+      "id": "ML-Traefik-Remote-IP-URL-Explorer",
+      "type": "dashboard",
+      "version": 4
+    }
+  ],
+  "version": "6.0.0-beta1-SNAPSHOT"
+}

--- a/filebeat/module/traefik/access/_meta/fields.yml
+++ b/filebeat/module/traefik/access/_meta/fields.yml
@@ -1,0 +1,126 @@
+- name: access
+  type: group
+  description: >
+    Contains fields for the Traefik access logs.
+  fields:
+    - name: remote_ip
+      type: keyword
+      description: >
+        Client IP address.
+    - name: user_name
+      type: keyword
+      description: >
+        The user name used when basic authentication is used.
+    - name: method
+      type: keyword
+      example: GET
+      description: >
+        The request HTTP method.
+    - name: url
+      type: keyword
+      description: >
+        The request HTTP URL.
+    - name: http_version
+      type: keyword
+      description: >
+        The HTTP version.
+    - name: response_code
+      type: long
+      description: >
+        The HTTP response code.
+    - name: body_sent.bytes
+      type: long
+      format: bytes
+      description: >
+        The number of bytes of the server response body.
+    - name: referrer
+      type: keyword
+      description: >
+        The HTTP referrer.
+    - name: agent
+      type: text
+      description: >
+        Contains the un-parsed user agent string. Only present if the user
+        agent Elasticsearch plugin is not available or not used.
+    - name: user_agent
+      type: group
+      description: >
+        Contains the parsed User agent field. Only present if the user
+        agent Elasticsearch plugin is available and used.
+      fields:
+        - name: device
+          type: keyword
+          description: >
+            The name of the physical device.
+        - name: major
+          type: long
+          description: >
+            The major version of the user agent.
+        - name: minor
+          type: long
+          description: >
+            The minor version of the user agent.
+        - name: patch
+          type: keyword
+          description: >
+            The patch version of the user agent.
+        - name: name
+          type: keyword
+          example: Chrome
+          description: >
+            The name of the user agent.
+        - name: os
+          type: keyword
+          description: >
+            The name of the operating system.
+        - name: os_major
+          type: long
+          description: >
+            The major version of the operating system.
+        - name: os_minor
+          type: long
+          description: >
+            The minor version of the operating system.
+        - name: os_name
+          type: keyword
+          description: >
+            The name of the operating system.
+    - name: geoip
+      type: group
+      description: >
+        Contains GeoIP information gathered based on the remote_ip field.
+        Only present if the GeoIP Elasticsearch plugin is available and
+        used.
+      fields:
+        - name: continent_name
+          type: keyword
+          description: >
+            The name of the continent.
+        - name: country_iso_code
+          type: keyword
+          description: >
+            Country ISO code.
+        - name: location
+          type: geo_point
+          description: >
+            The longitude and latitude.
+        - name: region_name
+          type: keyword
+          description: >
+            The region name.
+        - name: city_name
+          type: keyword
+          description: >
+            The city name.
+    - name: request_count
+      type: long
+      description: >
+        The number of requests
+    - name: frontend_name
+      type: text
+      description: >
+        The name of the frontend used
+    - name: backend_url
+      type: text
+      description:
+        The url of the backend where request is forwarded

--- a/filebeat/module/traefik/access/config/traefik-access.yml
+++ b/filebeat/module/traefik/access/config/traefik-access.yml
@@ -1,0 +1,6 @@
+type: log
+paths:
+{{ range $i, $path := .paths }}
+ - {{$path}}
+{{ end }}
+exclude_files: [".gz$"]

--- a/filebeat/module/traefik/access/ingest/pipeline.json
+++ b/filebeat/module/traefik/access/ingest/pipeline.json
@@ -1,0 +1,52 @@
+{
+    "description": "Pipeline for parsing Traefik access logs. Requires the geoip and user_agent plugins.",
+    "processors": [{
+        "grok": {
+            "field": "message",
+            "patterns":[
+                "%{IPORHOST:traefik.access.remote_ip} - %{DATA:traefik.access.user_name} \\[%{HTTPDATE:traefik.access.time}\\] \"%{WORD:traefik.access.method} %{DATA:traefik.access.url} HTTP/%{NUMBER:traefik.access.http_version}\" %{NUMBER:traefik.access.response_code} (?:%{NUMBER:traefik.access.body_sent.bytes}|-)( \"%{DATA:traefik.access.referrer}\")?( \"%{DATA:traefik.access.agent}\")?(?:%{NUMBER:traefik.access.request_count}|-)?( \"%{DATA:traefik.access.frontend_name}\")?( \"%{DATA:traefik.access.backend_url}\")?"
+            ],
+            "ignore_missing": true
+        }
+    },{
+        "remove":{
+            "field": "message"
+        }
+    }, {
+        "rename": {
+            "field": "@timestamp",
+            "target_field": "read_timestamp"
+        }
+    }, {
+        "date": {
+            "field": "traefik.access.time",
+            "target_field": "@timestamp",
+            "formats": ["dd/MMM/YYYY:H:m:s Z"]
+        }
+    }, {
+        "remove": {
+            "field": "traefik.access.time"
+        }
+    }, {
+        "user_agent": {
+            "field": "traefik.access.agent",
+            "target_field": "traefik.access.user_agent",
+            "ignore_failure": true
+        }
+    }, {
+        "remove": {
+            "field": "traefik.access.agent"
+        }
+    }, {
+        "geoip": {
+            "field": "traefik.access.remote_ip",
+            "target_field": "traefik.access.geoip"
+        }
+    }],
+    "on_failure" : [{
+        "set" : {
+            "field" : "error.message",
+            "value" : "{{ _ingest.on_failure_message }}"
+        }
+    }]
+}

--- a/filebeat/module/traefik/access/machine_learning/datafeed_low_request_rate.json
+++ b/filebeat/module/traefik/access/machine_learning/datafeed_low_request_rate.json
@@ -1,0 +1,37 @@
+{
+    "job_id": "JOB_ID",
+    "query_delay": "60s",
+    "frequency": "450s",
+    "indexes": [
+      "filebeat-*"
+    ],
+    "query": {
+      "bool": {
+        "filter": [
+          { "term":  { "fileset.module": "traefik" } },
+          { "term":  { "fileset.name": "access" } }
+        ]
+      }
+    },
+    "aggregations": {
+      "buckets": {
+        "date_histogram": {
+          "field": "@timestamp",
+          "interval": 900000,
+          "offset": 0,
+          "order": {
+            "_key": "asc"
+          },
+          "keyed": false,
+          "min_doc_count": 0
+        },
+        "aggregations": {
+          "@timestamp": {
+            "max": {
+              "field": "@timestamp"
+            }
+          }
+        }
+      }
+    }
+}

--- a/filebeat/module/traefik/access/machine_learning/datafeed_remote_ip_request_rate.json
+++ b/filebeat/module/traefik/access/machine_learning/datafeed_remote_ip_request_rate.json
@@ -1,0 +1,16 @@
+{
+    "job_id": "JOB_ID",
+    "query_delay": "60s",
+    "frequency": "600s",
+    "indexes": [
+      "filebeat-*"
+    ],
+    "query": {
+      "bool": {
+        "filter": [
+          { "term":  { "fileset.module": "traefik" } },
+          { "term":  { "fileset.name": "access" } }
+        ]
+      }
+    }
+}

--- a/filebeat/module/traefik/access/machine_learning/datafeed_remote_ip_url_count.json
+++ b/filebeat/module/traefik/access/machine_learning/datafeed_remote_ip_url_count.json
@@ -1,0 +1,16 @@
+{
+    "job_id": "JOB_ID",
+    "query_delay": "60s",
+    "frequency": "600s",
+    "indexes": [
+      "filebeat-*"
+    ],
+    "query": {
+      "bool": {
+        "filter": [
+          { "term":  { "fileset.module": "traefik" } },
+          { "term":  { "fileset.name": "access" } }
+        ]
+      }
+    }
+}

--- a/filebeat/module/traefik/access/machine_learning/datafeed_response_code.json
+++ b/filebeat/module/traefik/access/machine_learning/datafeed_response_code.json
@@ -1,0 +1,16 @@
+{
+    "job_id": "JOB_ID",
+    "query_delay": "60s",
+    "frequency": "450s",
+    "indexes": [
+      "filebeat-*"
+    ],
+    "query": {
+      "bool": {
+        "filter": [
+          { "term":  { "fileset.module": "traefik" } },
+          { "term":  { "fileset.name": "access" } }
+        ]
+      }
+    }
+}

--- a/filebeat/module/traefik/access/machine_learning/datafeed_visitor_rate.json
+++ b/filebeat/module/traefik/access/machine_learning/datafeed_visitor_rate.json
@@ -1,0 +1,42 @@
+{
+    "job_id": "JOB_ID",
+    "query_delay": "60s",
+    "frequency": "450s",
+    "indexes": [
+      "filebeat-*"
+    ],
+    "query": {
+      "bool": {
+        "filter": [
+          { "term":  { "fileset.module": "traefik" } },
+          { "term":  { "fileset.name": "access" } }
+        ]
+      }
+    },
+    "aggregations": {
+      "buckets": {
+        "date_histogram": {
+          "field": "@timestamp",
+          "interval": 900000,
+          "offset": 0,
+          "order": {
+            "_key": "asc"
+          },
+          "keyed": false,
+          "min_doc_count": 0
+        },
+        "aggregations": {
+          "@timestamp": {
+            "max": {
+              "field": "@timestamp"
+            }
+          },
+          "dc_remote_ips": {
+            "cardinality": {
+              "field": "traefik.access.remote_ip"
+            }
+          }
+        }
+      }
+    }
+}

--- a/filebeat/module/traefik/access/machine_learning/low_request_rate.json
+++ b/filebeat/module/traefik/access/machine_learning/low_request_rate.json
@@ -1,0 +1,30 @@
+{
+  "description": "Traefik Access Logs: Detect low request rate",
+  "analysis_config" : {
+    "bucket_span": "15m",
+    "summary_count_field_name": "doc_count",
+    "detectors": [
+      {
+        "detector_description": "traefik_access_low_request_rate",
+        "function": "low_count",
+        "detector_rules": []
+      }
+    ],
+    "influencers": []
+  },
+  "data_description": {
+    "time_field": "@timestamp",
+    "time_format": "epoch_ms"
+  },
+  "model_plot_config": {
+    "enabled": true
+  },
+  "custom_settings": {
+    "custom_urls": [
+      {
+        "url_name": "Raw Data",
+        "url_value": "kibana#/discover/ML-Filebeat-Traefik-Access?_g=(refreshInterval:(display:Off,pause:!f,value:0),time:(from:\u0027$earliest$\u0027,mode:absolute,to:\u0027$latest$\u0027))&_a=(columns:!(_source),filters:!(),index:\u0027filebeat-*\u0027,interval:auto,query:(query_string:(analyze_wildcard:!t,query:\u0027*\u0027)),sort:!(\u0027@timestamp\u0027,desc))"
+      }
+    ]
+  }
+}

--- a/filebeat/module/traefik/access/machine_learning/remote_ip_request_rate.json
+++ b/filebeat/module/traefik/access/machine_learning/remote_ip_request_rate.json
@@ -1,0 +1,33 @@
+{
+  "description": "Traefik Access Logs: Detect unusual remote_ips - high request rates",
+  "analysis_config" : {
+    "bucket_span": "1h",
+    "detectors": [
+        {
+        "detector_description": "traefik_access_remote_ip_high_count",
+        "function": "high_count",
+        "over_field_name": "traefik.access.remote_ip",
+        "detector_rules": []
+      }
+    ],
+    "influencers": [
+      "traefik.access.remote_ip"
+    ]
+  },
+  "data_description": {
+    "time_field": "@timestamp",
+    "time_format": "epoch_ms"
+  },
+  "custom_settings": {
+    "custom_urls": [
+      {
+        "url_name": "Count Explorer",
+        "url_value": "kibana#/dashboard/ML-Traefik-Access-Remote-IP-Count-Explorer?_g=(refreshInterval:(display:Off,pause:!f,value:0),time:(from:\u0027$earliest$\u0027,mode:absolute,to:\u0027$latest$\u0027))&_a=(description:\u0027\u0027,filters:!((\u0027$state\u0027:(store:appState),meta:(alias:!n,disabled:!f,index:\u0027filebeat-*\u0027,key:traefik.access.remote_ip,negate:!f,type:phrase,value:\u0027$traefik.access.remote_ip$\u0027),query:(match:(traefik.access.remote_ip:(query:\u0027$traefik.access.remote_ip$\u0027,type:phrase))))),options:(darkTheme:!f),panels:!((col:1,id:ML-Traefik-Access-Remote-IP-Timechart,panelIndex:1,row:1,size_x:6,size_y:3,type:visualization),(col:7,id:ML-Traefik-Access-Response-Code-Timechart,panelIndex:2,row:1,size_x:6,size_y:3,type:visualization),(col:1,id:ML-Traefik-Access-Top-Remote-IPs-Table,panelIndex:3,row:4,size_x:6,size_y:3,type:visualization),(col:7,id:ML-Traefik-Access-Map,panelIndex:4,row:4,size_x:6,size_y:3,type:visualization),(col:1,id:ML-Traefik-Access-Top-URLs-Table,panelIndex:5,row:7,size_x:12,size_y:9,type:visualization)),query:(query_string:(analyze_wildcard:!t,query:\u0027*\u0027)),timeRestore:!f,title:\u0027ML%20Traefik%20Access%20Remote%20IP%20Count%20Explorer\u0027,uiState:(P-3:(vis:(params:(sort:(columnIndex:!n,direction:!n)))),P-5:(vis:(params:(sort:(columnIndex:!n,direction:!n))))),viewMode:view)"
+      },
+      {
+        "url_name": "Raw Data",
+        "url_value": "kibana#/discover/ML-Filebeat-Traefik-Access?_g=(refreshInterval:(display:Off,pause:!f,value:0),time:(from:\u0027$earliest$\u0027,mode:absolute,to:\u0027$latest$\u0027))&_a=(columns:!(_source),filters:!((\u0027$state\u0027:(store:appState),meta:(alias:!n,disabled:!f,index:\u0027filebeat-*\u0027,key:traefik.access.remote_ip,negate:!f,type:phrase,value:\u0027$traefik.access.remote_ip$\u0027),query:(match:(traefik.access.remote_ip:(query:\u0027$traefik.access.remote_ip$\u0027,type:phrase))))),index:\u0027filebeat-*\u0027,interval:auto,query:(query_string:(analyze_wildcard:!t,query:\u0027*\u0027)),sort:!(\u0027@timestamp\u0027,desc))"
+      }
+    ]
+  }
+}

--- a/filebeat/module/traefik/access/machine_learning/remote_ip_url_count.json
+++ b/filebeat/module/traefik/access/machine_learning/remote_ip_url_count.json
@@ -1,0 +1,34 @@
+{
+  "description": "Traefik Access Logs: Detect unusual remote_ips - high distinct count of urls",
+  "analysis_config" : {
+    "bucket_span": "1h",
+    "detectors": [
+        {
+        "detector_description": "traefik_access_remote_ip_high_dc_url",
+        "function": "high_distinct_count",
+        "field_name": "traefik.access.url",
+        "over_field_name": "traefik.access.remote_ip",
+        "detector_rules": []
+      }
+    ],
+    "influencers": [
+      "traefik.access.remote_ip"
+    ]
+  },
+  "data_description": {
+    "time_field": "@timestamp",
+    "time_format": "epoch_ms"
+  },
+  "custom_settings": {
+    "custom_urls": [
+      {
+        "url_name": "URL Explorer",
+        "url_value": "kibana#/dashboard/ML-Traefik-Remote-IP-URL-Explorer?_g=(refreshInterval:(display:Off,pause:!f,value:0),time:(from:\u0027$earliest$\u0027,mode:absolute,to:\u0027$latest$\u0027))&_a=(description:\u0027\u0027,filters:!((\u0027$state\u0027:(store:appState),meta:(alias:!n,disabled:!f,index:\u0027filebeat-*\u0027,key:traefik.access.remote_ip,negate:!f,type:phrase,value:\u0027$traefik.access.remote_ip$\u0027),query:(match:(traefik.access.remote_ip:(query:\u0027$traefik.access.remote_ip$\u0027,type:phrase))))),options:(darkTheme:!f),panels:!((col:1,id:ML-Traefik-Access-Unique-Count-URL-Timechart,panelIndex:1,row:1,size_x:6,size_y:3,type:visualization),(col:7,id:ML-Traefik-Access-Response-Code-Timechart,panelIndex:2,row:1,size_x:6,size_y:3,type:visualization),(col:1,id:ML-Traefik-Access-Top-Remote-IPs-Table,panelIndex:3,row:4,size_x:6,size_y:3,type:visualization),(col:7,id:ML-Traefik-Access-Map,panelIndex:4,row:4,size_x:6,size_y:3,type:visualization),(col:1,id:ML-Traefik-Access-Top-URLs-Table,panelIndex:5,row:7,size_x:12,size_y:8,type:visualization)),query:(query_string:(analyze_wildcard:!t,query:\u0027*\u0027)),timeRestore:!f,title:\u0027ML%20Traefik%20Access%20Remote%20IP%20URL%20Explorer\u0027,uiState:(P-2:(vis:(params:(sort:(columnIndex:!n,direction:!n)))),P-3:(vis:(params:(sort:(columnIndex:!n,direction:!n)))),P-5:(vis:(params:(sort:(columnIndex:!n,direction:!n))))),viewMode:view)"
+      },
+      {
+        "url_name": "Raw Data",
+        "url_value": "kibana#/discover/ML-Filebeat-Traefik-Access?_g=(refreshInterval:(display:Off,pause:!f,value:0),time:(from:\u0027$earliest$\u0027,mode:absolute,to:\u0027$latest$\u0027))&_a=(columns:!(_source),filters:!((\u0027$state\u0027:(store:appState),meta:(alias:!n,disabled:!f,index:\u0027filebeat-*\u0027,key:traefik.access.remote_ip,negate:!f,type:phrase,value:\u0027$traefik.access.remote_ip$\u0027),query:(match:(traefik.access.remote_ip:(query:\u0027$traefik.access.remote_ip$\u0027,type:phrase))))),index:\u0027filebeat-*\u0027,interval:auto,query:(query_string:(analyze_wildcard:!t,query:\u0027*\u0027)),sort:!(\u0027@timestamp\u0027,desc))"
+      }
+    ]
+  }
+}

--- a/filebeat/module/traefik/access/machine_learning/response_code.json
+++ b/filebeat/module/traefik/access/machine_learning/response_code.json
@@ -1,0 +1,37 @@
+{
+  "description": "Traefik Access Logs: Detect unusual response_code rates",
+  "analysis_config" : {
+    "bucket_span": "15m",
+    "detectors": [
+        {
+        "detector_description": "traefik_access_response_code_rate",
+        "function": "count",
+        "partition_field_name": "traefik.access.response_code",
+        "detector_rules": []
+      }
+    ],
+    "influencers": [
+      "traefik.access.response_code",
+      "traefik.access.remote_ip"
+    ]
+  },
+  "data_description": {
+    "time_field": "@timestamp",
+    "time_format": "epoch_ms"
+  },
+  "model_plot_config": {
+    "enabled": true
+  },
+  "custom_settings": {
+    "custom_urls": [
+      {
+        "url_name": "Count Explorer",
+        "url_value": "kibana#/dashboard/ML-Traefik-Access-Remote-IP-Count-Explorer?_g=(refreshInterval:(display:Off,pause:!f,value:0),time:(from:\u0027$earliest$\u0027,mode:absolute,to:\u0027$latest$\u0027))&_a=(description:\u0027\u0027,filters:!((\u0027$state\u0027:(store:appState),meta:(alias:!n,disabled:!f,index:\u0027filebeat-*\u0027,key:traefik.access.response_code,negate:!f,type:phrase,value:\u0027$traefik.access.response_code$\u0027),query:(match:(traefik.access.response_code:(query:\u0027$traefik.access.response_code$\u0027,type:phrase))))),options:(darkTheme:!f),panels:!((col:1,id:ML-Traefik-Access-Remote-IP-Timechart,panelIndex:1,row:1,size_x:6,size_y:3,type:visualization),(col:7,id:ML-Traefik-Access-Response-Code-Timechart,panelIndex:2,row:1,size_x:6,size_y:3,type:visualization),(col:1,id:ML-Traefik-Access-Top-Remote-IPs-Table,panelIndex:3,row:4,size_x:6,size_y:3,type:visualization),(col:7,id:ML-Traefik-Access-Map,panelIndex:4,row:4,size_x:6,size_y:3,type:visualization),(col:1,id:ML-Traefik-Access-Top-URLs-Table,panelIndex:5,row:7,size_x:12,size_y:9,type:visualization)),query:(query_string:(analyze_wildcard:!t,query:\u0027*\u0027)),timeRestore:!f,title:\u0027ML%20Traefik%20Access%20Remote%20IP%20Count%20Explorer\u0027,uiState:(P-3:(vis:(params:(sort:(columnIndex:!n,direction:!n)))),P-5:(vis:(params:(sort:(columnIndex:!n,direction:!n))))),viewMode:view)"
+      },
+      {
+        "url_name": "Raw Data",
+        "url_value": "kibana#/discover/ML-Filebeat-Traefik-Access?_g=(refreshInterval:(display:Off,pause:!f,value:0),time:(from:\u0027$earliest$\u0027,mode:absolute,to:\u0027$latest$\u0027))&_a=(columns:!(_source),filters:!((\u0027$state\u0027:(store:appState),meta:(alias:!n,disabled:!f,index:\u0027filebeat-*\u0027,key:traefik.access.response_code,negate:!f,type:phrase,value:\u0027$traefik.access.response_code$\u0027),query:(match:(traefik.access.response_code:(query:\u0027$traefik.access.response_code$\u0027,type:phrase))))),index:\u0027filebeat-*\u0027,interval:auto,query:(query_string:(analyze_wildcard:!t,query:\u0027_exists_:traefik.access\u0027)),sort:!(\u0027@timestamp\u0027,desc))"
+      }
+    ]
+  }
+}

--- a/filebeat/module/traefik/access/machine_learning/visitor_rate.json
+++ b/filebeat/module/traefik/access/machine_learning/visitor_rate.json
@@ -1,0 +1,30 @@
+{
+  "description": "Traefik Access Logs: Detect unusual visitor rate",
+  "analysis_config" : {
+    "bucket_span": "15m",
+    "summary_count_field_name": "dc_remote_ips",
+    "detectors": [
+      {
+        "detector_description": "traefik_access_visitor_rate",
+        "function": "non_zero_count",
+        "detector_rules": []
+      }
+    ],
+    "influencers": []
+  },
+  "data_description": {
+    "time_field": "@timestamp",
+    "time_format": "epoch_ms"
+  },
+  "model_plot_config": {
+    "enabled": true
+  },
+  "custom_settings": {
+    "custom_urls": [
+      {
+        "url_name": "Raw Data",
+        "url_value": "kibana#/discover/ML-Filebeat-Traefik-Access?_g=(refreshInterval:(display:Off,pause:!f,value:0),time:(from:\u0027$earliest$\u0027,mode:absolute,to:\u0027$latest$\u0027))&_a=(columns:!(_source),filters:!(),index:\u0027filebeat-*\u0027,interval:auto,query:(query_string:(analyze_wildcard:!t,query:\u0027*\u0027)),sort:!(\u0027@timestamp\u0027,desc))"
+      }
+    ]
+  }
+}

--- a/filebeat/module/traefik/access/manifest.yml
+++ b/filebeat/module/traefik/access/manifest.yml
@@ -1,0 +1,19 @@
+module_version: 1.0
+
+var:
+  - name: paths
+    default:
+      - /var/log/traefik/access.log*
+    os.darwin:
+      - /usr/local/traefik/access.log*
+    os.windows:
+      - c:/programdata/traefik/logs/*access.log*
+
+ingest_pipeline: ingest/pipeline.json
+prospector: config/traefik-access.yml
+
+requires.processors:
+- name: user_agent
+  plugin: ingest-user-agent
+- name: geoip
+  plugin: ingest-geoip

--- a/filebeat/module/traefik/access/tests/test.log
+++ b/filebeat/module/traefik/access/tests/test.log
@@ -1,0 +1,2 @@
+192.168.33.1 - - [02/Oct/2017:20:22:07 +0000] "GET /ui/favicons/favicon-16x16.png HTTP/1.1" 304 0 "http://example.com/login" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.100 Safari/537.36" 262 "Host-host-1" "http://172.19.0.3:5601" 2ms
+85.181.35.98 - - [02/Oct/2017:20:22:08 +0000] "GET /ui/favicons/favicon.ico HTTP/1.1" 304 0 "http://example.com/login" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.100 Safari/537.36" 271 "Host-host1 "http://172.19.0.3:5601" 3ms

--- a/filebeat/module/traefik/access/tests/test.log-expected.json
+++ b/filebeat/module/traefik/access/tests/test.log-expected.json
@@ -1,0 +1,122 @@
+[
+    {
+        "_index": "filebeat-2017.10",
+        "_type": "doc",
+        "_id": "AV8CftO9KnxqdH7bMrjU",
+        "_version": 1,
+        "_score": null,
+        "_source": {
+            "@timestamp": "2017-10-02T20:22:08.000Z",
+            "offset": 552,
+            "traefik": {
+                "access": {
+                    "referrer": "http://example.com/login",
+                    "response_code": "304",
+                    "remote_ip": "85.181.35.98",
+                    "geoip": {
+                        "continent_name": "Europe",
+                        "country_iso_code": "DE",
+                        "location": {
+                            "lon": 9,
+                            "lat": 51
+                        }
+                    },
+                    "method": "GET",
+                    "user_name": "-",
+                    "http_version": "1.1",
+                    "body_sent": {
+                        "bytes": "0"
+                    },
+                    "url": "/ui/favicons/favicon.ico",
+                    "user_agent": {
+                        "patch": "3163",
+                        "major": "61",
+                        "minor": "0",
+                        "os": "Linux",
+                        "name": "Chrome",
+                        "os_name": "Linux",
+                        "device": "Other"
+                    }
+                }
+            },
+            "beat": {
+                "hostname": "MM-XPS-15",
+                "name": "MM-XPS-15",
+                "version": "7.0.0-alpha1"
+            },
+            "prospector": {
+                "type": "log"
+            },
+            "read_timestamp": "2017-10-09T18:56:25.032Z",
+            "source": "/var/log/traefik/access.log",
+            "fileset": {
+                "module": "traefik",
+                "name": "access"
+            }
+        },
+        "fields": {
+            "@timestamp": [
+                1506975728000
+            ]
+        },
+        "sort": [
+            1506975728000
+        ]
+    },
+    {
+        "_index": "filebeat-2017.10",
+        "_type": "doc",
+        "_id": "AV8CftO9KnxqdH7bMrjT",
+        "_version": 1,
+        "_score": null,
+        "_source": {
+            "@timestamp": "2017-10-02T20:22:07.000Z",
+            "offset": 280,
+            "traefik": {
+                "access": {
+                    "referrer": "http://example.com/login",
+                    "response_code": "304",
+                    "remote_ip": "192.168.33.1",
+                    "method": "GET",
+                    "user_name": "-",
+                    "http_version": "1.1",
+                    "body_sent": {
+                        "bytes": "0"
+                    },
+                    "url": "/ui/favicons/favicon-16x16.png",
+                    "user_agent": {
+                        "patch": "3163",
+                        "major": "61",
+                        "minor": "0",
+                        "os": "Linux",
+                        "name": "Chrome",
+                        "os_name": "Linux",
+                        "device": "Other"
+                    }
+                }
+            },
+            "beat": {
+                "hostname": "MM-XPS-15",
+                "name": "MM-XPS-15",
+                "version": "7.0.0-alpha1"
+            },
+            "prospector": {
+                "type": "log"
+            },
+            "read_timestamp": "2017-10-09T18:56:25.031Z",
+            "source": "/var/log/traefik/access.log",
+            "fileset": {
+                "module": "traefik",
+                "name": "access"
+            }
+        },
+        "fields": {
+            "@timestamp": [
+                1506975727000
+            ]
+        },
+        "sort": [
+            1506975727000
+        ]
+    }
+]

--- a/filebeat/module/traefik/module.yml
+++ b/filebeat/module/traefik/module.yml
@@ -1,0 +1,12 @@
+dashboards:
+- id: filebeat-traefik-overview
+  file: Filebeat-traefik-overview.json
+
+- id: filebeat-traefik-logs
+  file: Filebeat-traefik-logs.json
+
+- id: ML-Traefik-Access-Remote-IP-Count-Explorer
+  file: ml-traefik-access-remote-ip-count-explorer.json
+
+- id: ML-Traefik-Remote-IP-URL-Explorer
+  file: ml-traefik-remote-ip-url-explorer.json

--- a/filebeat/modules.d/traefik.yml.disabled
+++ b/filebeat/modules.d/traefik.yml.disabled
@@ -1,0 +1,8 @@
+- module: traefik
+  # Access logs
+  access:
+    enabled: true
+
+    # Set custom paths for the log files. If left empty,
+    # Filebeat will choose the paths depending on your OS.
+    #var.paths:


### PR DESCRIPTION
This commit introduces the [Træfik](https://traefik.io) module for Filebeat. It is capable
of processing access logs of Træfik