### PR TITLE
Support defining a `host` key in the headers

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -38,6 +38,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Fix data race accessing watched containers. {issue}5147[5147]
 - Remove ID() from Runner interface {issue}5153[5153]
 - Do not require template if index change and template disabled {pull}5319[5319]
+- Correctly send configured `Host` header to the remote server. {issue}4842[4842]
 
 *Auditbeat*
 

--- a/libbeat/outputs/elasticsearch/client.go
+++ b/libbeat/outputs/elasticsearch/client.go
@@ -713,6 +713,14 @@ func (conn *Connection) execHTTPRequest(req *http.Request) (int, []byte, error) 
 		req.Header.Add(name, value)
 	}
 
+	// The stlib will override the value in the header based on the configured `Host`
+	// on the request which default to the current machine.
+	//
+	// We use the normalized key header to retrieve the user configured value and assign it to the host.
+	if host := req.Header.Get("Host"); host != "" {
+		req.Host = host
+	}
+
 	resp, err := conn.http.Do(req)
 	if err != nil {
 		return 0, nil, err

--- a/libbeat/outputs/elasticsearch/client_test.go
+++ b/libbeat/outputs/elasticsearch/client_test.go
@@ -283,8 +283,12 @@ func TestClientWithHeaders(t *testing.T) {
 	// start a mock HTTP server
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "testing value", r.Header.Get("X-Test"))
-		requestCount++
+		// from the documentation: https://golang.org/pkg/net/http/
+		// For incoming requests, the Host header is promoted to the
+		// Request.Host field and removed from the Header map.
+		assert.Equal(t, "myhost.local", r.Host)
 		fmt.Fprintln(w, "Hello, client")
+		requestCount++
 	}))
 	defer ts.Close()
 
@@ -292,6 +296,7 @@ func TestClientWithHeaders(t *testing.T) {
 		URL:   ts.URL,
 		Index: outil.MakeSelector(outil.ConstSelectorExpr("test")),
 		Headers: map[string]string{
+			"host":   "myhost.local",
 			"X-Test": "testing value",
 		},
 	}, nil)


### PR DESCRIPTION
Its common to be able to define the host header in an http request,
sadly golang's standard library will clear any `Host` defined key in the
header maps with the value of the `req.Host`, which will default to host
of the current machine.

This commits allow users to set the `Host` header key and the code will
pass this values to the `req.Host` method, this will make sure that on the
other hand of the connection the value of the header will be the
expected.

If not explicit value is set we will default to the standard library
behavior.

Fixes: #4842