### PR TITLE
Cherry-pick #5381 to 6.0: Disable command line flags for module reloading

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -41,6 +41,8 @@ https://github.com/elastic/beats/compare/v6.0.0-rc1...master[Check the HEAD diff
 - Fix default paths for redis 4.0.1 logs on macOS {pull}5173[5173] 
 
 *Filebeat*
+- Fix default paths for redis 4.0.1 logs on macOS {pull}5173[5173]
+- Fix Filebeat not starting if command line and modules configs are used together. {issue}5376[5376]
 
 *Heartbeat*
 

--- a/filebeat/beater/filebeat.go
+++ b/filebeat/beater/filebeat.go
@@ -51,7 +51,7 @@ func New(b *beat.Beat, rawConfig *common.Config) (beat.Beater, error) {
 		return nil, err
 	}
 
-	moduleRegistry, err := fileset.NewModuleRegistry(config.Modules, b.Info.Version)
+	moduleRegistry, err := fileset.NewModuleRegistry(config.Modules, b.Info.Version, true)
 	if err != nil {
 		return nil, err
 	}

--- a/filebeat/fileset/factory.go
+++ b/filebeat/fileset/factory.go
@@ -44,7 +44,7 @@ func NewFactory(outlet channel.OutleterFactory, registrar *registrar.Registrar, 
 // Create creates a module based on a config
 func (f *Factory) Create(c *common.Config) (cfgfile.Runner, error) {
 	// Start a registry of one module:
-	m, err := NewModuleRegistry([]*common.Config{c}, f.beatVersion)
+	m, err := NewModuleRegistry([]*common.Config{c}, f.beatVersion, false)
 	if err != nil {
 		return nil, err
 	}

--- a/filebeat/fileset/modules.go
+++ b/filebeat/fileset/modules.go
@@ -87,7 +87,7 @@ func newModuleRegistry(modulesPath string,
 }
 
 // NewModuleRegistry reads and loads the configured module into the registry.
-func NewModuleRegistry(moduleConfigs []*common.Config, beatVersion string) (*ModuleRegistry, error) {
+func NewModuleRegistry(moduleConfigs []*common.Config, beatVersion string, init bool) (*ModuleRegistry, error) {
 	modulesPath := paths.Resolve(paths.Home, "module")
 
 	stat, err := os.Stat(modulesPath)
@@ -96,9 +96,13 @@ func NewModuleRegistry(moduleConfigs []*common.Config, beatVersion string) (*Mod
 		return &ModuleRegistry{}, nil // empty registry, no error
 	}
 
-	modulesCLIList, modulesOverrides, err := getModulesCLIConfig()
-	if err != nil {
-		return nil, err
+	var modulesCLIList []string
+	var modulesOverrides *ModuleOverrides
+	if init {
+		modulesCLIList, modulesOverrides, err = getModulesCLIConfig()
+		if err != nil {
+			return nil, err
+		}
 	}
 	mcfgs := []*ModuleConfig{}
 	for _, moduleConfig := range moduleConfigs {
@@ -108,7 +112,9 @@ func NewModuleRegistry(moduleConfigs []*common.Config, beatVersion string) (*Mod
 		}
 		mcfgs = append(mcfgs, mcfg)
 	}
+
 	mcfgs, err = appendWithoutDuplicates(mcfgs, modulesCLIList)
+
 	if err != nil {
 		return nil, err
 	}

--- a/filebeat/fileset/modules_test.go
+++ b/filebeat/fileset/modules_test.go
@@ -346,7 +346,7 @@ func TestMissingModuleFolder(t *testing.T) {
 		load(t, map[string]interface{}{"module": "nginx"}),
 	}
 
-	reg, err := NewModuleRegistry(configs, "5.2.0")
+	reg, err := NewModuleRegistry(configs, "5.2.0", true)
 	assert.NoError(t, err)
 	assert.NotNil(t, reg)
 


### PR DESCRIPTION
Cherry-pick of PR #5381 to 6.0 branch. Original message: 

Command line flags were taken into account during module reloading which lead to the issue the modules were loaded on startup and when loading from the files.

Closes https://github.com/elastic/beats/issues/5376