### PR TITLE
Backport: Add support to disable Logstash slow start

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -43,6 +43,7 @@ https://github.com/elastic/beats/compare/v5.6.3...5.6[Check the HEAD diff]
 *Affecting all Beats*
 
 - Add support for enabling TLS renegotiation. {issue}4386[4386]
+- Add setting to enable/disable the slow start in logstash output. {pull}5400[5400]
 
 *Filebeat*
 

--- a/filebeat/filebeat.full.yml
+++ b/filebeat/filebeat.full.yml
@@ -589,6 +589,11 @@ output.elasticsearch:
   # new batches.
   #pipelining: 0
 
+  # If enabled only a subset of events in a batch of events is transferred per
+  # transaction.  The number of events to be sent increases up to `bulk_max_size`
+  # if no error is encountered.
+  #slow_start: false
+
   # Optional index name. The default index name is set to name of the beat
   # in all lowercase.
   #index: 'filebeat'

--- a/heartbeat/heartbeat.full.yml
+++ b/heartbeat/heartbeat.full.yml
@@ -424,6 +424,11 @@ output.elasticsearch:
   # new batches.
   #pipelining: 0
 
+  # If enabled only a subset of events in a batch of events is transferred per
+  # transaction.  The number of events to be sent increases up to `bulk_max_size`
+  # if no error is encountered.
+  #slow_start: false
+
   # Optional index name. The default index name is set to name of the beat
   # in all lowercase.
   #index: 'heartbeat'

--- a/libbeat/_meta/config.full.yml
+++ b/libbeat/_meta/config.full.yml
@@ -226,6 +226,11 @@ output.elasticsearch:
   # new batches.
   #pipelining: 0
 
+  # If enabled only a subset of events in a batch of events is transferred per
+  # transaction.  The number of events to be sent increases up to `bulk_max_size`
+  # if no error is encountered.
+  #slow_start: false
+
   # Optional index name. The default index name is set to name of the beat
   # in all lowercase.
   #index: 'beatname'

--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -580,6 +580,14 @@ Beats that publish single events (such as Packetbeat) send each event directly t
 Elasticsearch. Beats that publish data in batches (such as Filebeat) send events in batches based on the
 spooler size.
 
+===== `slow_start`
+
+If enabled only a subset of events in a batch of events is transferred per transaction.
+The number of events to be sent increases up to `bulk_max_size` if no error is encountered.
+On error the number of events per transaction is reduced again.
+
+The default is `false`.
+
 [[kafka-output]]
 === Kafka Output
 

--- a/libbeat/outputs/logstash/async_test.go
+++ b/libbeat/outputs/logstash/async_test.go
@@ -59,13 +59,13 @@ func TestAsync(t *testing.T) {
 	}
 }
 
-func makeAsyncTestClient(settings map[string]interface{}) func(*transport.Client) testClientDriver {
-	return func(conn *transport.Client) testClientDriver {
-		return newAsyncTestDriver(newAsyncTestClient(conn, settings))
+func makeAsyncTestClient(settings map[string]interface{}) func(*transport.Client, string) testClientDriver {
+	return func(conn *transport.Client, host string) testClientDriver {
+		return newAsyncTestDriver(newAsyncTestClient(conn, host, settings))
 	}
 }
 
-func newAsyncTestClient(conn *transport.Client, settings map[string]interface{}) *asyncClient {
+func newAsyncTestClient(conn *transport.Client, host string, settings map[string]interface{}) *asyncClient {
 	config, err := common.NewConfigFrom(settings)
 	if err != nil {
 		panic(err)
@@ -81,7 +81,7 @@ func newAsyncTestClient(conn *transport.Client, settings map[string]interface{})
 		panic(err)
 	}
 
-	c, err := newAsyncLumberjackClient(conn, &lsCfg)
+	c, err := newAsyncLumberjackClient(conn, host, &lsCfg)
 	if err != nil {
 		panic(err)
 	}

--- a/libbeat/outputs/logstash/client_test.go
+++ b/libbeat/outputs/logstash/client_test.go
@@ -44,9 +44,21 @@ type testDriverCommand struct {
 	data []outputs.Data
 }
 
-func newLumberjackTestClient(conn *transport.Client) *client {
-	c, err := newLumberjackClient(conn, 3,
-		testMaxWindowSize, 100*time.Millisecond, "test")
+func newLumberjackTestClient(conn *transport.Client, settings map[string]interface{}) *client {
+	config, err := common.NewConfigFrom(settings)
+	if err != nil {
+		panic(err)
+	}
+
+	lsCfg := defaultConfig
+	lsCfg.Index = "test"
+	lsCfg.BulkMaxSize = testMaxWindowSize
+	lsCfg.Timeout = 100 * time.Millisecond
+	if err := config.Unpack(&lsCfg); err != nil {
+		panic(err)
+	}
+
+	c, err := newLumberjackClient(conn, &lsCfg)
 	if err != nil {
 		panic(err)
 	}

--- a/libbeat/outputs/logstash/client_test.go
+++ b/libbeat/outputs/logstash/client_test.go
@@ -32,7 +32,7 @@ type testClientDriver interface {
 	Returns() []testClientReturn
 }
 
-type clientFactory func(*transport.Client) testClientDriver
+type clientFactory func(*transport.Client, string) testClientDriver
 
 type testClientReturn struct {
 	n   int
@@ -44,7 +44,7 @@ type testDriverCommand struct {
 	data []outputs.Data
 }
 
-func newLumberjackTestClient(conn *transport.Client, settings map[string]interface{}) *client {
+func newLumberjackTestClient(conn *transport.Client, host string, settings map[string]interface{}) *client {
 	config, err := common.NewConfigFrom(settings)
 	if err != nil {
 		panic(err)
@@ -58,7 +58,7 @@ func newLumberjackTestClient(conn *transport.Client, settings map[string]interfa
 		panic(err)
 	}
 
-	c, err := newLumberjackClient(conn, &lsCfg)
+	c, err := newLumberjackClient(conn, host, &lsCfg)
 	if err != nil {
 		panic(err)
 	}
@@ -78,7 +78,7 @@ func testSendZero(t *testing.T, factory clientFactory) {
 		t.Fatalf("Failed to connect server and client: %v", err)
 	}
 
-	client := factory(transp)
+	client := factory(transp, server.Addr())
 	defer sock.Close()
 	defer transp.Close()
 
@@ -104,7 +104,7 @@ func testSimpleEvent(t *testing.T, factory clientFactory) {
 	if err != nil {
 		t.Fatalf("Failed to connect: %v", err)
 	}
-	client := factory(transp)
+	client := factory(transp, mock.Addr())
 	defer transp.Close()
 	defer client.Stop()
 
@@ -133,7 +133,7 @@ func testStructuredEvent(t *testing.T, factory clientFactory) {
 	if err != nil {
 		t.Fatalf("Failed to connect: %v", err)
 	}
-	client := factory(transp)
+	client := factory(transp, mock.Addr())
 	defer transp.Close()
 	defer client.Stop()
 
@@ -183,7 +183,7 @@ func testMultiFailMaxTimeouts(t *testing.T, factory clientFactory) {
 	if err != nil {
 		t.Fatalf("Failed to connect: %v", err)
 	}
-	client := factory(transp)
+	client := factory(transp, mock.Addr())
 	defer transp.Close()
 	defer client.Stop()
 

--- a/libbeat/outputs/logstash/common_test.go
+++ b/libbeat/outputs/logstash/common_test.go
@@ -1,13 +1,18 @@
 package logstash
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/elastic/beats/libbeat/logp"
 )
 
+var enableLoggingOnce sync.Once
+
 func enableLogging(selectors []string) {
 	if testing.Verbose() {
-		logp.LogInit(logp.LOG_DEBUG, "", false, true, selectors)
+		enableLoggingOnce.Do(func() {
+			logp.LogInit(logp.LOG_DEBUG, "", false, true, selectors)
+		})
 	}
 }

--- a/libbeat/outputs/logstash/config.go
+++ b/libbeat/outputs/logstash/config.go
@@ -12,6 +12,7 @@ type logstashConfig struct {
 	Port             int                   `config:"port"`
 	LoadBalance      bool                  `config:"loadbalance"`
 	BulkMaxSize      int                   `config:"bulk_max_size"`
+	SlowStart        bool                  `config:"slow_start"`
 	Timeout          time.Duration         `config:"timeout"`
 	Pipelining       int                   `config:"pipelining"        validate:"min=0"`
 	CompressionLevel int                   `config:"compression_level" validate:"min=0, max=9"`
@@ -25,6 +26,7 @@ var (
 		Port:             10200,
 		LoadBalance:      false,
 		BulkMaxSize:      2048,
+		SlowStart:        false,
 		CompressionLevel: 3,
 		Timeout:          30 * time.Second,
 		MaxRetries:       3,

--- a/libbeat/outputs/logstash/logstash.go
+++ b/libbeat/outputs/logstash/logstash.go
@@ -137,16 +137,12 @@ func makeClientFactory(
 	cfg *logstashConfig,
 	tcfg *transport.Config,
 ) modeutil.ClientFactory {
-	compressLvl := cfg.CompressionLevel
-	maxBulkSz := cfg.BulkMaxSize
-	to := cfg.Timeout
-
 	return func(host string) (mode.ProtocolClient, error) {
 		t, err := transport.NewClient(tcfg, "tcp", host, cfg.Port)
 		if err != nil {
 			return nil, err
 		}
-		return newLumberjackClient(t, compressLvl, maxBulkSz, to, cfg.Index)
+		return newLumberjackClient(t, cfg)
 	}
 }
 
@@ -154,17 +150,12 @@ func makeAsyncClientFactory(
 	cfg *logstashConfig,
 	tcfg *transport.Config,
 ) modeutil.AsyncClientFactory {
-	compressLvl := cfg.CompressionLevel
-	maxBulkSz := cfg.BulkMaxSize
-	queueSize := cfg.Pipelining - 1
-	to := cfg.Timeout
-
 	return func(host string) (mode.AsyncProtocolClient, error) {
 		t, err := transport.NewClient(tcfg, "tcp", host, cfg.Port)
 		if err != nil {
 			return nil, err
 		}
-		return newAsyncLumberjackClient(t, queueSize, compressLvl, maxBulkSz, to, cfg.Index)
+		return newAsyncLumberjackClient(t, cfg)
 	}
 }
 

--- a/libbeat/outputs/logstash/logstash.go
+++ b/libbeat/outputs/logstash/logstash.go
@@ -5,6 +5,7 @@ package logstash
 
 import (
 	"expvar"
+	"fmt"
 	"time"
 
 	"github.com/elastic/go-lumber/log"
@@ -142,7 +143,7 @@ func makeClientFactory(
 		if err != nil {
 			return nil, err
 		}
-		return newLumberjackClient(t, cfg)
+		return newLumberjackClient(t, fmt.Sprintf("%v:%v", host, cfg.Port), cfg)
 	}
 }
 
@@ -155,7 +156,7 @@ func makeAsyncClientFactory(
 		if err != nil {
 			return nil, err
 		}
-		return newAsyncLumberjackClient(t, cfg)
+		return newAsyncLumberjackClient(t, fmt.Sprintf("%v:%v", host, cfg.Port), cfg)
 	}
 }
 

--- a/libbeat/outputs/logstash/sync_test.go
+++ b/libbeat/outputs/logstash/sync_test.go
@@ -44,9 +44,9 @@ func newClientServerTCP(t *testing.T, to time.Duration) *clientServer {
 	return &clientServer{transptest.NewMockServerTCP(t, to, "", nil)}
 }
 
-func makeTestClient(settings map[string]interface{}) func(*transport.Client) testClientDriver {
-	return func(conn *transport.Client) testClientDriver {
-		return newClientTestDriver(newLumberjackTestClient(conn, settings))
+func makeTestClient(settings map[string]interface{}) func(*transport.Client, string) testClientDriver {
+	return func(conn *transport.Client, host string) testClientDriver {
+		return newClientTestDriver(newLumberjackTestClient(conn, host, settings))
 	}
 }
 

--- a/libbeat/outputs/logstash/sync_test.go
+++ b/libbeat/outputs/logstash/sync_test.go
@@ -25,27 +25,29 @@ type clientServer struct {
 }
 
 func TestClientSendZero(t *testing.T) {
-	testSendZero(t, makeTestClient)
+	testSendZero(t, makeTestClient(nil))
 }
 
 func TestClientSimpleEvent(t *testing.T) {
-	testSimpleEvent(t, makeTestClient)
+	testSimpleEvent(t, makeTestClient(nil))
 }
 
 func TestClientStructuredEvent(t *testing.T) {
-	testStructuredEvent(t, makeTestClient)
+	testStructuredEvent(t, makeTestClient(nil))
 }
 
 func TestClientMultiFailMaxTimeouts(t *testing.T) {
-	testMultiFailMaxTimeouts(t, makeTestClient)
+	testMultiFailMaxTimeouts(t, makeTestClient(nil))
 }
 
 func newClientServerTCP(t *testing.T, to time.Duration) *clientServer {
 	return &clientServer{transptest.NewMockServerTCP(t, to, "", nil)}
 }
 
-func makeTestClient(conn *transport.Client) testClientDriver {
-	return newClientTestDriver(newLumberjackTestClient(conn))
+func makeTestClient(settings map[string]interface{}) func(*transport.Client) testClientDriver {
+	return func(conn *transport.Client) testClientDriver {
+		return newClientTestDriver(newLumberjackTestClient(conn, settings))
+	}
 }
 
 func newClientTestDriver(client mode.ProtocolClient) *testSyncDriver {

--- a/libbeat/outputs/logstash/window.go
+++ b/libbeat/outputs/logstash/window.go
@@ -11,6 +11,12 @@ type window struct {
 	maxWindowSize   int
 }
 
+func newWindower(start, max int) *window {
+	w := &window{}
+	w.init(start, max)
+	return w
+}
+
 func (w *window) init(start, max int) {
 	*w = window{
 		windowSize:    int32(start),

--- a/metricbeat/metricbeat.full.yml
+++ b/metricbeat/metricbeat.full.yml
@@ -537,6 +537,11 @@ output.elasticsearch:
   # new batches.
   #pipelining: 0
 
+  # If enabled only a subset of events in a batch of events is transferred per
+  # transaction.  The number of events to be sent increases up to `bulk_max_size`
+  # if no error is encountered.
+  #slow_start: false
+
   # Optional index name. The default index name is set to name of the beat
   # in all lowercase.
   #index: 'metricbeat'

--- a/packetbeat/packetbeat.full.yml
+++ b/packetbeat/packetbeat.full.yml
@@ -680,6 +680,11 @@ output.elasticsearch:
   # new batches.
   #pipelining: 0
 
+  # If enabled only a subset of events in a batch of events is transferred per
+  # transaction.  The number of events to be sent increases up to `bulk_max_size`
+  # if no error is encountered.
+  #slow_start: false
+
   # Optional index name. The default index name is set to name of the beat
   # in all lowercase.
   #index: 'packetbeat'

--- a/winlogbeat/winlogbeat.full.yml
+++ b/winlogbeat/winlogbeat.full.yml
@@ -255,6 +255,11 @@ output.elasticsearch:
   # new batches.
   #pipelining: 0
 
+  # If enabled only a subset of events in a batch of events is transferred per
+  # transaction.  The number of events to be sent increases up to `bulk_max_size`
+  # if no error is encountered.
+  #slow_start: false
+
   # Optional index name. The default index name is set to name of the beat
   # in all lowercase.
   #index: 'winlogbeat'


### PR DESCRIPTION
- add 'slow_start' setting used to enable/disable slow_start
- disable 'slow_start' by default
- fix race in logstash testing by initializing debug logging only once
- update async tests so different set of settings can be added more easily
