### PR TITLE
Fixing mapping error for mlockall in the Metricbeat Elasticsearch module

### DIFF
--- a/metricbeat/docs/fields.asciidoc
+++ b/metricbeat/docs/fields.asciidoc
@@ -2543,7 +2543,7 @@ Non-Heap max used by the JVM in bytes.
 [float]
 === `elasticsearch.node.process.mlockall`
 
-type: bool
+type: boolean
 
 If process locked in memory.
 

--- a/metricbeat/module/elasticsearch/node/_meta/fields.yml
+++ b/metricbeat/module/elasticsearch/node/_meta/fields.yml
@@ -15,7 +15,7 @@
       type: group
       description: >
         JVM Info.
-      fields:  
+      fields:
         - name: version
           type: keyword
           description: >
@@ -41,6 +41,6 @@
           description: >
             Non-Heap max used by the JVM in bytes.
     - name: process.mlockall
-      type: bool
+      type: boolean
       description: >
         If process locked in memory.


### PR DESCRIPTION
This PR fixes the mapping type for `process.mlockall` field for the Metricbeat Elasticsearch module.  Currently this value is set to `bool` which is not valid, this PR sets it to `boolean`.