### PR TITLE
Cherry-pick #4519 to 5.6: Fix race condition in logging

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -28,7 +28,6 @@ https://github.com/elastic/beats/compare/v5.6.3...5.6[Check the HEAD diff]
 
 *Affecting all Beats*
 
-- Don't stop with error loading the ES template if the ES output is not enabled. {pull}4436[4436]
 - Fix race condition in internal logging rotator. {pull}4519[4519]
 
 *Filebeat*

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -28,6 +28,9 @@ https://github.com/elastic/beats/compare/v5.6.3...5.6[Check the HEAD diff]
 
 *Affecting all Beats*
 
+- Don't stop with error loading the ES template if the ES output is not enabled. {pull}4436[4436]
+- Fix race condition in internal logging rotator. {pull}4519[4519]
+
 *Filebeat*
 
 *Heartbeat*

--- a/libbeat/logp/file_rotator_test.go
+++ b/libbeat/logp/file_rotator_test.go
@@ -161,3 +161,32 @@ func TestConfigSane(t *testing.T) {
 	assert.NotNil(t, rotator.CheckIfConfigSane())
 
 }
+
+func TestRaceConditions(t *testing.T) {
+	// Make sure concurrent `WriteLine` calls don't end up in race conditions around `rotator.current`
+	if testing.Verbose() {
+		LogInit(LOG_DEBUG, "", false, true, []string{"rotator"})
+	}
+
+	dir, err := ioutil.TempDir("", "test_rotator_")
+	if err != nil {
+		t.Errorf("Error: %s", err.Error())
+		return
+	}
+
+	Debug("rotator", "Directory: %s", dir)
+
+	rotateeverybytes := uint64(10)
+	keepfiles := 20
+
+	rotator := FileRotator{
+		Path:             dir,
+		Name:             "testbeat",
+		RotateEveryBytes: &rotateeverybytes,
+		KeepFiles:        &keepfiles,
+	}
+
+	for i := 0; i < 1000; i++ {
+		go rotator.WriteLine([]byte(string(i)))
+	}
+}


### PR DESCRIPTION
Cherry-pick of PR #4519 to 5.6 branch. Original message: 

`logp.FileRotator` had an issue when `WriteLines` is called concurrently. Added a RWLock to protect both `rotator.current` and `rotator.currentSize`