### PR TITLE
Fix VSphere config yml

### DIFF
--- a/metricbeat/docs/modules/vsphere.asciidoc
+++ b/metricbeat/docs/modules/vsphere.asciidoc
@@ -19,7 +19,7 @@ in <<configuration-metricbeat>>. Here is an example configuration:
 ----
 metricbeat.modules:
 - module: vsphere
-  metricsets: ["datastore, host, virtualmachine"]
+  metricsets: ["datastore", "host", "virtualmachine"]
   period: 10s
   hosts: ["https://localhost/sdk"]
 

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -425,7 +425,7 @@ metricbeat.modules:
 
 #------------------------------- vSphere Module ------------------------------
 - module: vsphere
-  metricsets: ["datastore", host", "virtualmachine"]
+  metricsets: ["datastore", "host", "virtualmachine"]
   period: 10s
   hosts: ["https://localhost/sdk"]
 

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -425,7 +425,7 @@ metricbeat.modules:
 
 #------------------------------- vSphere Module ------------------------------
 - module: vsphere
-  metricsets: ["datastore, host, virtualmachine"]
+  metricsets: ["datastore", host", "virtualmachine"]
   period: 10s
   hosts: ["https://localhost/sdk"]
 

--- a/metricbeat/module/vsphere/_meta/config.yml
+++ b/metricbeat/module/vsphere/_meta/config.yml
@@ -1,5 +1,5 @@
 - module: vsphere
-  metricsets: ["datastore, host, virtualmachine"]
+  metricsets: ["datastore", "host", "virtualmachine"]
   period: 10s
   hosts: ["https://localhost/sdk"]
 

--- a/metricbeat/modules.d/vsphere.yml.disabled
+++ b/metricbeat/modules.d/vsphere.yml.disabled
@@ -1,5 +1,5 @@
 - module: vsphere
-  metricsets: ["datastore, host, virtualmachine"]
+  metricsets: ["datastore", "host", "virtualmachine"]
   period: 10s
   hosts: ["https://localhost/sdk"]
 


### PR DESCRIPTION
The metricsets should be array of strings. Fixes #5403