### PR TITLE
Cherry-pick #5202 to 6.0: Update `beta` messages for config reload

### DIFF
--- a/filebeat/crawler/crawler.go
+++ b/filebeat/crawler/crawler.go
@@ -11,7 +11,6 @@ import (
 	"github.com/elastic/beats/filebeat/registrar"
 	"github.com/elastic/beats/libbeat/cfgfile"
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/libbeat/logp"
 )
 
@@ -53,8 +52,6 @@ func (c *Crawler) Start(r *registrar.Registrar, configProspectors *common.Config
 	}
 
 	if configProspectors.Enabled() {
-		cfgwarn.Beta("Loading separate prospectors is enabled.")
-
 		c.prospectorsReloader = cfgfile.NewReloader(configProspectors)
 		prospectorsFactory := prospector.NewFactory(c.out, r, c.beatDone)
 		if err := c.prospectorsReloader.Check(prospectorsFactory); err != nil {
@@ -67,8 +64,6 @@ func (c *Crawler) Start(r *registrar.Registrar, configProspectors *common.Config
 	}
 
 	if configModules.Enabled() {
-		cfgwarn.Beta("Loading separate modules is enabled.")
-
 		c.modulesReloader = cfgfile.NewReloader(configModules)
 		modulesFactory := fileset.NewFactory(c.out, r, c.beatVersion, pipelineLoaderFactory, c.beatDone)
 		if err := c.modulesReloader.Check(modulesFactory); err != nil {

--- a/libbeat/cfgfile/reload.go
+++ b/libbeat/cfgfile/reload.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/monitoring"
 	"github.com/elastic/beats/libbeat/paths"
@@ -71,6 +72,10 @@ func NewReloader(cfg *common.Config) *Reloader {
 	path := config.Path
 	if !filepath.IsAbs(path) {
 		path = paths.Resolve(paths.Config, path)
+	}
+
+	if config.Reload.Enabled {
+		cfgwarn.Beta("Dynamic config reload is enabled.")
 	}
 
 	return &Reloader{


### PR DESCRIPTION
Cherry-pick of PR #5202 to 6.0 branch. Original message: 

Unless I'm wrong we marked loading confs from separate files as stable, while keeping config reload in beta