### PR TITLE
Handle certificate generation with password for testing purpose

### DIFF
--- a/libbeat/outputs/logstash/logstash_test.go
+++ b/libbeat/outputs/logstash/logstash_test.go
@@ -2,7 +2,6 @@ package logstash
 
 import (
 	"fmt"
-	"net"
 	"os"
 	"testing"
 	"time"
@@ -41,10 +40,10 @@ func TestLogstashTLS(t *testing.T) {
 	enableLogging([]string{"*"})
 
 	certName := "ca_test"
-	ip := net.IP{127, 0, 0, 1}
+	ip := "127.0.0.1"
 
 	timeout := 2 * time.Second
-	transptest.GenCertsForIPIfMIssing(t, ip, certName)
+	transptest.GenCertForTestingPurpose(t, ip, certName, "")
 	server := transptest.NewMockServerTLS(t, timeout, certName, nil)
 
 	// create lumberjack output client
@@ -59,10 +58,10 @@ func TestLogstashTLS(t *testing.T) {
 
 func TestLogstashInvalidTLSInsecure(t *testing.T) {
 	certName := "ca_invalid_test"
-	ip := net.IP{1, 2, 3, 4}
+	ip := "1.2.3.4"
 
 	timeout := 2 * time.Second
-	transptest.GenCertsForIPIfMIssing(t, ip, certName)
+	transptest.GenCertForTestingPurpose(t, ip, certName, "")
 	server := transptest.NewMockServerTLS(t, timeout, certName, nil)
 
 	config := map[string]interface{}{

--- a/libbeat/outputs/transport/transptest/testing_test.go
+++ b/libbeat/outputs/transport/transptest/testing_test.go
@@ -52,7 +52,7 @@ func TestTransportReconnectsOnConnect(t *testing.T) {
 
 	certName := "ca_test"
 	timeout := 2 * time.Second
-	GenCertsForIPIfMIssing(t, net.IP{127, 0, 0, 1}, certName)
+	GenCertForTestingPurpose(t, "127.0.0.1", certName, "")
 
 	testServer(t, &config, func(t *testing.T, makeServer MockServerFactory, proxy *transport.ProxyConfig) {
 		server := makeServer(t, timeout, certName, proxy)
@@ -89,7 +89,7 @@ func TestTransportFailConnectUnknownAddress(t *testing.T) {
 	defer l.Close()
 
 	certName := "ca_test"
-	GenCertsForIPIfMIssing(t, net.IP{127, 0, 0, 1}, certName)
+	GenCertForTestingPurpose(t, "127.0.0.1", certName, "")
 
 	invalidAddr := "invalid.dns.fqdn-unknown.invalid:100"
 
@@ -123,7 +123,7 @@ func TestTransportClosedOnWriteReadError(t *testing.T) {
 
 	certName := "ca_test"
 	timeout := 2 * time.Second
-	GenCertsForIPIfMIssing(t, net.IP{127, 0, 0, 1}, certName)
+	GenCertForTestingPurpose(t, "127.0.0.1", certName, "")
 
 	testServer(t, &config, func(t *testing.T, makeServer MockServerFactory, proxy *transport.ProxyConfig) {
 		server := makeServer(t, timeout, certName, proxy)


### PR DESCRIPTION
Change made on GenCertsForIPIfMIssing function:
- Rename the function to GenCertForTestingPurpose
- Replace ip parameter by host, can be an ip or a dns name
- Add password parameter to generate encrypted private key