### PR TITLE
Cherry-pick #5436 to master: Fix double @timestamp key when using JSON decoding

### DIFF
--- a/filebeat/harvester/reader/json.go
+++ b/filebeat/harvester/reader/json.go
@@ -93,7 +93,7 @@ func createJSONError(message string) common.MapStr {
 // respecting the KeysUnderRoot and OverwriteKeys configuration options.
 // If MessageKey is defined, the Text value from the event always
 // takes precedence.
-func MergeJSONFields(data common.MapStr, jsonFields common.MapStr, text *string, config JSONConfig) {
+func MergeJSONFields(data common.MapStr, jsonFields common.MapStr, text *string, config JSONConfig) time.Time {
 	// The message key might have been modified by multiline
 	if len(config.MessageKey) > 0 && text != nil {
 		jsonFields[config.MessageKey] = *text
@@ -111,6 +111,7 @@ func MergeJSONFields(data common.MapStr, jsonFields common.MapStr, text *string,
 			case common.Time:
 				ts = time.Time(ts)
 			}
+			delete(data, "@timestamp")
 		}
 		event := &beat.Event{
 			Timestamp: ts,
@@ -118,9 +119,7 @@ func MergeJSONFields(data common.MapStr, jsonFields common.MapStr, text *string,
 		}
 		jsontransform.WriteJSONKeys(event, jsonFields, config.OverwriteKeys)
 
-		// if timestamp has been set -> add to data
-		if !event.Timestamp.IsZero() {
-			data["@timestamp"] = common.Time(event.Timestamp)
-		}
+		return event.Timestamp
 	}
+	return time.Time{}
 }


### PR DESCRIPTION
Cherry-pick of PR #5436 to master branch. Original message: 

The MergeJSONFields was adding the parsed @timestamp key to the fields,
instead of modifying it into the Event structure. This change makes it
return the new timestamp (or the empty Timestamp if no change required),
and the caller sets it into the event.