### PR TITLE
corrected format of used metricsets

### DIFF
--- a/metricbeat/docs/modules/vsphere.asciidoc
+++ b/metricbeat/docs/modules/vsphere.asciidoc
@@ -19,7 +19,7 @@ in <<configuration-metricbeat>>. Here is an example configuration:
 ----
 metricbeat.modules:
 - module: vsphere
-  metricsets: ["datastore, host, virtualmachine"]
+  metricsets: ["datastore", "host", "virtualmachine"]
   period: 10s
   hosts: ["https://localhost/sdk"]
 


### PR DESCRIPTION
when using 
`metricsets: ["datastore, host, virtualmachine"]`
metricbeat considers that one metricset (and fails)
`metricsets:["datastore", "host", "virtualmachine"]`
resolves correctly to 3 metricsets