### PR TITLE
Catch duplicate keys in integration tests

### DIFF
--- a/libbeat/tests/system/beat/beat.py
+++ b/libbeat/tests/system/beat/beat.py
@@ -227,7 +227,8 @@ class TestCase(unittest.TestCase, ComposeMixin):
                     break
 
                 try:
-                    jsons.append(self.flatten_object(json.loads(line, object_pairs_hook=self.json_raise_on_duplicates), []))
+                    jsons.append(self.flatten_object(json.loads(
+                        line, object_pairs_hook=self.json_raise_on_duplicates), []))
                 except:
                     print("Fail to load the json {}".format(line))
                     raise
@@ -260,9 +261,9 @@ class TestCase(unittest.TestCase, ComposeMixin):
         d = {}
         for k, v in ordered_pairs:
             if k in d:
-               raise ValueError("duplicate key: %r" % (k,))
+                raise ValueError("duplicate key: %r" % (k,))
             else:
-               d[k] = v
+                d[k] = v
         return d
 
     def copy_files(self, files, source_dir="files/"):

--- a/libbeat/tests/system/beat/beat.py
+++ b/libbeat/tests/system/beat/beat.py
@@ -227,7 +227,7 @@ class TestCase(unittest.TestCase, ComposeMixin):
                     break
 
                 try:
-                    jsons.append(self.flatten_object(json.loads(line), []))
+                    jsons.append(self.flatten_object(json.loads(line, object_pairs_hook=self.json_raise_on_duplicates), []))
                 except:
                     print("Fail to load the json {}".format(line))
                     raise
@@ -249,10 +249,21 @@ class TestCase(unittest.TestCase, ComposeMixin):
                     # hit EOF
                     break
 
-                event = json.loads(line)
+                event = json.loads(line, object_pairs_hook=self.json_raise_on_duplicates)
                 del event['@metadata']
                 jsons.append(event)
         return jsons
+
+    def json_raise_on_duplicates(self, ordered_pairs):
+        """Reject duplicate keys. To be used as a custom hook in JSON unmarshaling
+           to error out in case of any duplicates in the keys."""
+        d = {}
+        for k, v in ordered_pairs:
+            if k in d:
+               raise ValueError("duplicate key: %r" % (k,))
+            else:
+               d[k] = v
+        return d
 
     def copy_files(self, files, source_dir="files/"):
         for file_ in files:


### PR DESCRIPTION
This enabled duplicate key detection when we read the results in
the system tests. This makes sure that if we ever have a duplicate key
like in #5440 we will notice.

Part of #5437.