### PR TITLE
Cherry-pick #5441 to master: Fix missing ACK in redis output

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -41,6 +41,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Remove ID() from Runner interface {issue}5153[5153]
 - Do not require template if index change and template disabled {pull}5319[5319]
 - Correctly send configured `Host` header to the remote server. {issue}4842[4842]
+- Fix missing ACK in redis output. {issue}5404[5404]
 
 *Auditbeat*
 

--- a/libbeat/outputs/redis/client.go
+++ b/libbeat/outputs/redis/client.go
@@ -128,7 +128,10 @@ func (c *client) Publish(batch publisher.Batch) error {
 	if rest != nil {
 		c.stats.Failed(len(rest))
 		batch.RetryEvents(rest)
+		return err
 	}
+
+	batch.ACK()
 	return err
 }
 


### PR DESCRIPTION
Cherry-pick of PR #5441 to master branch. Original message: 

Resolves: #5404 