### PR TITLE
Bump docs version for 6.0.0-rc2

### DIFF
--- a/libbeat/docs/version.asciidoc
+++ b/libbeat/docs/version.asciidoc
@@ -1,4 +1,4 @@
-:stack-version: 6.0.0-rc1
+:stack-version: 6.0.0-rc2
 :doc-branch: 6.0
 :go-version: 1.8.3
 :release-state: prerelease


### PR DESCRIPTION
This should only be merged in the day of the release.