### PR TITLE
Cherry-pick #5457 to 6.0: Fix missing length check in PgSQL

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -40,6 +40,9 @@ https://github.com/elastic/beats/compare/v6.0.0-rc2...master[Check the HEAD diff
 
 *Packetbeat*
 
+- Fix http status phrase parsing not allow spaces. {pull}5312[5312]
+- Fix missing length check in the PostgreSQL module. {pull}5457[5457]
+
 *Winlogbeat*
 
 ==== Added

--- a/libbeat/docs/version.asciidoc
+++ b/libbeat/docs/version.asciidoc
@@ -1,4 +1,4 @@
-:stack-version: 6.0.0-rc1
+:stack-version: 6.0.0-rc2
 :doc-branch: 6.0
 :go-version: 1.8.3
 :release-state: prerelease

--- a/packetbeat/protos/pgsql/parse.go
+++ b/packetbeat/protos/pgsql/parse.go
@@ -377,6 +377,9 @@ func pgsqlFieldsParser(s *pgsqlStream, buf []byte) error {
 		off += 4
 
 		// read format (int16)
+		if len(buf) < off+2 {
+			return errFieldBufferShort
+		}
 		format := common.BytesNtohs(buf[off : off+2])
 		off += 2
 		fieldsFormat = append(fieldsFormat, byte(format))


### PR DESCRIPTION
Cherry-pick of PR #5457 to 6.0 branch. Original message: 

There was a length check missing.