### PR TITLE
Fix typo of split_cookie option packetbeat

### DIFF
--- a/packetbeat/docs/packetbeat-options.asciidoc
+++ b/packetbeat/docs/packetbeat-options.asciidoc
@@ -610,7 +610,7 @@ packetbeat.protocols:
   ports: [80, 8080, 8000, 5000, 8002]
   hide_keywords: ["pass", "password", "passwd"]
   send_headers: ["User-Agent", "Cookie", "Set-Cookie"]
-  split_coookie: true
+  split_cookie: true
   real_ip_header: "X-Forwarded-For"
 ------------------------------------------------------------------------------
 


### PR DESCRIPTION
Hi :)
I fixed typo in document.

split_coookie -> split_cookie