### PR TITLE
Cherry-pick #5457 to 5.6: Fix missing length check in PgSQL

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -38,6 +38,8 @@ https://github.com/elastic/beats/compare/v5.6.3...5.6[Check the HEAD diff]
 
 *Packetbeat*
 
+- Fix missing length check in the PostgreSQL module. {pull}5457[5457]
+
 *Winlogbeat*
 
 ==== Added

--- a/packetbeat/protos/pgsql/parse.go
+++ b/packetbeat/protos/pgsql/parse.go
@@ -379,6 +379,9 @@ func pgsqlFieldsParser(s *pgsqlStream, buf []byte) error {
 		off += 4
 
 		// read format (int16)
+		if len(buf) < off+2 {
+			return errFieldBufferShort
+		}
 		format := common.BytesNtohs(buf[off : off+2])
 		off += 2
 		fieldsFormat = append(fieldsFormat, byte(format))


### PR DESCRIPTION
Cherry-pick of PR #5457 to 5.6 branch. Original message: 

There was a length check missing.