### PR TITLE
New metric: uptime

### DIFF
--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -82,11 +82,14 @@ type beatConfig struct {
 var (
 	printVersion bool
 	setup        bool
+	startTime    time.Time
 )
 
 var debugf = logp.MakeDebug("beat")
 
 func init() {
+	startTime = time.Now()
+
 	initRand()
 
 	flag.BoolVar(&printVersion, "version", false, "Print the version and exit")
@@ -421,7 +424,7 @@ func (b *Beat) configure() error {
 		return fmt.Errorf("error setting default paths: %v", err)
 	}
 
-	err = logp.Init(b.Info.Beat, &b.Config.Logging)
+	err = logp.Init(b.Info.Beat, startTime, &b.Config.Logging)
 	if err != nil {
 		return fmt.Errorf("error initializing logging: %v", err)
 	}

--- a/libbeat/cmd/instance/metrics.go
+++ b/libbeat/cmd/instance/metrics.go
@@ -2,11 +2,14 @@ package instance
 
 import (
 	"runtime"
+	"time"
 
 	"github.com/elastic/beats/libbeat/monitoring"
 )
 
 type memstatsVar struct{}
+
+type fixedstatsVar struct{}
 
 var (
 	metrics = monitoring.Default.NewRegistry("beat")
@@ -15,6 +18,9 @@ var (
 func init() {
 	var ms memstatsVar
 	metrics.Add("memstats", ms, monitoring.Reported)
+
+	var fs fixedstatsVar
+	metrics.Add("info", fs, monitoring.Reported)
 }
 
 func (memstatsVar) Visit(m monitoring.Mode, V monitoring.Visitor) {
@@ -29,4 +35,13 @@ func (memstatsVar) Visit(m monitoring.Mode, V monitoring.Visitor) {
 		monitoring.ReportInt(V, "memory_alloc", int64(stats.Alloc))
 		monitoring.ReportInt(V, "gc_next", int64(stats.NextGC))
 	}
+}
+
+func (fixedstatsVar) Visit(m monitoring.Mode, V monitoring.Visitor) {
+	uptime := int64(time.Now().Sub(startTime).Seconds())
+
+	V.OnRegistryStart()
+	defer V.OnRegistryFinished()
+
+	monitoring.ReportInt(V, "uptime", uptime)
 }

--- a/libbeat/cmd/instance/metrics.go
+++ b/libbeat/cmd/instance/metrics.go
@@ -32,6 +32,7 @@ func reportInfo(_ monitoring.Mode, V monitoring.Visitor) {
 	V.OnRegistryStart()
 	defer V.OnRegistryFinished()
 
-	uptime := int64(time.Since(startTime).Seconds()) * 1000
+	delta := time.Since(startTime)
+	uptime := int64(delta.Seconds())*1000 + int64(delta.Nanoseconds()/1000000)
 	monitoring.ReportInt(V, "uptime.ms", uptime)
 }

--- a/libbeat/logp/logp.go
+++ b/libbeat/logp/logp.go
@@ -42,8 +42,6 @@ var (
 )
 
 func init() {
-	startTime = time.Now()
-
 	// Adds logging specific flags: -v, -e and -d.
 	verbose = flag.Bool("v", false, "Log at INFO level")
 	toStderr = flag.Bool("e", false, "Log to stderr and disable syslog/file output")
@@ -78,7 +76,7 @@ func HandleFlags(name string) error {
 // flags to initialize the Logging systems. After calling this function,
 // standard output is always enabled. You can make it respect the command
 // line flag with a later SetStderr call.
-func Init(name string, config *Logging) error {
+func Init(name string, start time.Time, config *Logging) error {
 	// reset settings from HandleFlags
 	_log = logger{
 		JSON: config.JSON,
@@ -126,6 +124,8 @@ func Init(name string, config *Logging) error {
 		toSyslog = false
 		toFiles = false
 	}
+
+	startTime = start
 
 	LogInit(Priority(logLevel), "", toSyslog, true, debugSelectors)
 	if len(debugSelectors) > 0 {

--- a/libbeat/logp/metrics.go
+++ b/libbeat/logp/metrics.go
@@ -49,7 +49,7 @@ func LogTotalExpvars(cfg *Logging) {
 	zero := monitoring.MakeFlatSnapshot()
 	metrics := formatMetrics(snapshotDelta(zero, snapshotMetrics()))
 	Info("Total non-zero values: %s", metrics)
-	Info("Uptime: %s", time.Now().Sub(startTime))
+	Info("Uptime: %s", time.Since(startTime))
 }
 
 func snapshotMetrics() monitoring.FlatSnapshot {


### PR DESCRIPTION
Uptime is exposed as a metric called `beat.info.uptime`. Its value is the number of seconds passed since start. @tsullivan 

I have changed the architecture a bit. `startTime` is initialized in `instance/beat.go`. Then later this time is passed to `logp` thorugh `logp.Init`. Thus, `logp` can display uptime when the Beat stops.

I am still having a problem with the value of the metric. It the event it shows 30 always.
```
INFO Non-zero metrics in the last 30s:
beat.info.uptime=30
beat.memstats.memory_alloc=11440
beat.memstats.memory_total=11440
```
But when I check the value it seems to be correct.

I opened the PR so the architecture could be validated until I fix the problem.