### PR TITLE
Add support for space in get request

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -72,6 +72,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Fix http status phrase parsing not allow spaces. {pull}5312[5312]
 - Fix missing length check in the PostgreSQL module. {pull}5457[5457]
 - Fix panic in ACK handler if event is dropped on blocked queue {issue}5524[5524]
+- Fix http parse to allow to parse get request with space in the URI. {pull}5495[5495]
 
 *Winlogbeat*
 


### PR DESCRIPTION
This fix an issue when the http request contains a space instead of
breaking the line with `bytes.fields` we are finding the start and the end
of the URI using the `METHOD` verb and the `HTTP/{VERSION}`. This will
allow packet beat to record theses request instead of ignoring them.

Fixes: #4974