### PR TITLE
Fix folder for the 5.x version of the dashboards

### DIFF
--- a/libbeat/dashboards/importer.go
+++ b/libbeat/dashboards/importer.go
@@ -249,7 +249,7 @@ func (imp Importer) ImportKibanaDir(dir string) error {
 
 	versionPath := "default"
 	if imp.version.Major == 5 {
-		versionPath = "5x"
+		versionPath = "5.x"
 	}
 
 	dir = path.Join(dir, versionPath)


### PR DESCRIPTION
It was changed to '5x', I think by mistake, in #5352.