### PR TITLE
Log absolute values for gauges internal metrics

### DIFF
--- a/libbeat/logp/metrics.go
+++ b/libbeat/logp/metrics.go
@@ -56,6 +56,23 @@ func snapshotMetrics() monitoring.FlatSnapshot {
 	return monitoring.CollectFlatSnapshot(monitoring.Default, monitoring.Full, true)
 }
 
+// List of metrics that are gauges, so that we know for which to
+// _not_ subtract the previous value in the output.
+// TODO: Replace this with a proper solution that uses the metric
+// type from where it is defined. See:
+// https://github.com/elastic/beats/issues/5433
+var gauges = map[string]bool{
+	"libbeat.pipeline.events.active": true,
+	"libbeat.pipeline.clients":       true,
+	"libbeat.config.module.running":  true,
+	"registrar.states.current":       true,
+	"filebeat.harvester.running":     true,
+	"filebeat.harvester.open_files":  true,
+	"beat.memstats.memory_total":     true,
+	"beat.memstats.memory_alloc":     true,
+	"beat.memstats.gc_next":          true,
+}
+
 func snapshotDelta(prev, cur monitoring.FlatSnapshot) map[string]interface{} {
 	out := map[string]interface{}{}
 
@@ -72,8 +89,12 @@ func snapshotDelta(prev, cur monitoring.FlatSnapshot) map[string]interface{} {
 	}
 
 	for k, i := range cur.Ints {
-		if p := prev.Ints[k]; p != i {
-			out[k] = i - p
+		if _, found := gauges[k]; found {
+			out[k] = i
+		} else {
+			if p := prev.Ints[k]; p != i {
+				out[k] = i - p
+			}
 		}
 	}
 


### PR DESCRIPTION
We currently don't have a way for the internal Beats metrics to register
themselves as counters or gauges, so the logging code that prints the
values every 30s assumes they are all counters and prints the difference
since the last update.

This issue has became more pressing in 6.0 because we now have several
common gauges. This PR implements a temporary hack that lists these gauges
in logging code. A follow up PR will create a proper solution for the next
release.

Part of #5433.