### PR TITLE
Change `@timestamp` to `timestamp` in monitoring events

### DIFF
--- a/libbeat/monitoring/report/elasticsearch/client.go
+++ b/libbeat/monitoring/report/elasticsearch/client.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/monitoring/report"
 	esout "github.com/elastic/beats/libbeat/outputs/elasticsearch"
 	"github.com/elastic/beats/libbeat/publisher"
 	"github.com/elastic/beats/libbeat/testing"
@@ -83,8 +84,12 @@ func (c *publishClient) Publish(batch publisher.Batch) error {
 	events := batch.Events()
 	bulk := make([]interface{}, 0, 2*len(events))
 	for _, event := range events {
+		mEvent := report.Event{
+			Timestamp: event.Content.Timestamp,
+			Fields:    event.Content.Fields,
+		}
 		bulk = append(bulk,
-			actMonitoringBeats, event.Content,
+			actMonitoringBeats, mEvent,
 		)
 	}
 

--- a/libbeat/monitoring/report/elasticsearch/client.go
+++ b/libbeat/monitoring/report/elasticsearch/client.go
@@ -84,13 +84,11 @@ func (c *publishClient) Publish(batch publisher.Batch) error {
 	events := batch.Events()
 	bulk := make([]interface{}, 0, 2*len(events))
 	for _, event := range events {
-		mEvent := report.Event{
-			Timestamp: event.Content.Timestamp,
-			Fields:    event.Content.Fields,
-		}
 		bulk = append(bulk,
-			actMonitoringBeats, mEvent,
-		)
+			actMonitoringBeats, report.Event{
+				Timestamp: event.Content.Timestamp,
+				Fields:    event.Content.Fields,
+			})
 	}
 
 	_, err := c.es.BulkWith("_xpack", "monitoring", c.params, nil, bulk)

--- a/libbeat/monitoring/report/event.go
+++ b/libbeat/monitoring/report/event.go
@@ -1,0 +1,12 @@
+package report
+
+import (
+	"time"
+
+	"github.com/elastic/beats/libbeat/common"
+)
+
+type Event struct {
+	Timestamp time.Time     `struct:"timestamp"`
+	Fields    common.MapStr `struct:",inline"`
+}

--- a/libbeat/monitoring/report/event.go
+++ b/libbeat/monitoring/report/event.go
@@ -6,6 +6,10 @@ import (
 	"github.com/elastic/beats/libbeat/common"
 )
 
+// Event is the format of monitoring events.
+// A separate event is required as it has to be serialized differently.
+// The only difference between report.Event and beat.Event
+// is Timestamp is serialized as "timestamp" in monitoring.
 type Event struct {
 	Timestamp time.Time     `struct:"timestamp"`
 	Fields    common.MapStr `struct:",inline"`

--- a/libbeat/outputs/elasticsearch/enc_test.go
+++ b/libbeat/outputs/elasticsearch/enc_test.go
@@ -1,0 +1,46 @@
+package elasticsearch
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/monitoring/report"
+)
+
+func TestJSONEncoderMarshalBeatEvent(t *testing.T) {
+	encoder := newJSONEncoder(nil)
+	event := beat.Event{
+		Timestamp: time.Date(2017, time.November, 7, 12, 0, 0, 0, time.UTC),
+		Fields: common.MapStr{
+			"field1": "value1",
+		},
+	}
+
+	err := encoder.Marshal(event)
+	if err != nil {
+		t.Errorf("Error while marshaling beat.Event using JSONEncoder: %v", err)
+	}
+	assert.Equal(t, encoder.buf.String(), "{\"@timestamp\":\"2017-11-07T12:00:00.000Z\",\"field1\":\"value1\"}\n",
+		"Unexpected marshaled format of beat.Event")
+}
+
+func TestJSONEncoderMarshalMonitoringEvent(t *testing.T) {
+	encoder := newJSONEncoder(nil)
+	event := report.Event{
+		Timestamp: time.Date(2017, time.November, 7, 12, 0, 0, 0, time.UTC),
+		Fields: common.MapStr{
+			"field1": "value1",
+		},
+	}
+
+	err := encoder.Marshal(event)
+	if err != nil {
+		t.Errorf("Error while marshaling report.Event using JSONEncoder: %v", err)
+	}
+	assert.Equal(t, encoder.buf.String(), "{\"timestamp\":\"2017-11-07T12:00:00.000Z\",\"field1\":\"value1\"}\n",
+		"Unexpected marshaled format of report.Event")
+}


### PR DESCRIPTION
New event type is introduced to report metrics, because `@timestamp` has to be changed to `timestamp`.
It is tested. However, I hasn't seen the whole pipeline working together, because the other part does not support it yet.