### PR TITLE
Cherry-pick #5487 to 6.0: Add `cloud.id` support to Kubernetes manifests

### DIFF
--- a/deploy/kubernetes/Makefile
+++ b/deploy/kubernetes/Makefile
@@ -1,7 +1,9 @@
 ALL=filebeat metricbeat
 BEAT_VERSION=$(shell head -n 1 ../../libbeat/docs/version.asciidoc | cut -c 17- )
 
-all: ${ALL:=-kubernetes.yaml}
+.PHONY: all $(ALL)
+
+all: $(ALL)
 
 test: all
 	for FILE in $(shell ls *-kubernetes.yaml); do \
@@ -12,10 +14,10 @@ test: all
 clean:
 	@for f in $(ALL); do rm -f "$$f-kubernetes.yaml"; done
 
-%-kubernetes.yaml: %/*.yaml
-	@echo "Generating $*-kubernetes.yaml"
-	@rm -f $*-kubernetes.yaml
-	@for f in $(shell ls $*/*.yaml); do \
-		sed "s/%VERSION%/${BEAT_VERSION}/g" $$f >> $*-kubernetes.yaml; \
-		echo --- >> $*-kubernetes.yaml; \
+$(ALL):
+	@echo "Generating $@-kubernetes.yaml"
+	@rm -f $@-kubernetes.yaml
+	@for f in $(shell ls $@/*.yaml); do \
+		sed "s/%VERSION%/${BEAT_VERSION}/g" $$f >> $@-kubernetes.yaml; \
+		echo --- >> $@-kubernetes.yaml; \
 	done

--- a/deploy/kubernetes/filebeat-kubernetes.yaml
+++ b/deploy/kubernetes/filebeat-kubernetes.yaml
@@ -23,6 +23,9 @@ data:
     processors:
       - add_cloud_metadata:
 
+    cloud.id: ${ELASTIC_CLOUD_ID}
+    cloud.auth: ${ELASTIC_CLOUD_AUTH}
+
     output.elasticsearch:
       hosts: ['${ELASTICSEARCH_HOST:elasticsearch}:${ELASTICSEARCH_PORT:9200}']
       username: ${ELASTICSEARCH_USERNAME}
@@ -81,6 +84,10 @@ spec:
           value: elastic
         - name: ELASTICSEARCH_PASSWORD
           value: changeme
+        - name: ELASTIC_CLOUD_ID
+          value:
+        - name: ELASTIC_CLOUD_AUTH
+          value:
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:

--- a/deploy/kubernetes/filebeat/filebeat-configmap.yaml
+++ b/deploy/kubernetes/filebeat/filebeat-configmap.yaml
@@ -23,6 +23,9 @@ data:
     processors:
       - add_cloud_metadata:
 
+    cloud.id: ${ELASTIC_CLOUD_ID}
+    cloud.auth: ${ELASTIC_CLOUD_AUTH}
+
     output.elasticsearch:
       hosts: ['${ELASTICSEARCH_HOST:elasticsearch}:${ELASTICSEARCH_PORT:9200}']
       username: ${ELASTICSEARCH_USERNAME}

--- a/deploy/kubernetes/filebeat/filebeat-daemonset.yaml
+++ b/deploy/kubernetes/filebeat/filebeat-daemonset.yaml
@@ -31,6 +31,10 @@ spec:
           value: elastic
         - name: ELASTICSEARCH_PASSWORD
           value: changeme
+        - name: ELASTIC_CLOUD_ID
+          value:
+        - name: ELASTIC_CLOUD_AUTH
+          value:
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:

--- a/deploy/kubernetes/metricbeat-kubernetes.yaml
+++ b/deploy/kubernetes/metricbeat-kubernetes.yaml
@@ -18,6 +18,9 @@ data:
     processors:
       - add_cloud_metadata:
 
+    cloud.id: ${ELASTIC_CLOUD_ID}
+    cloud.auth: ${ELASTIC_CLOUD_AUTH}
+
     output.elasticsearch:
       hosts: ['${ELASTICSEARCH_HOST:elasticsearch}:${ELASTICSEARCH_PORT:9200}']
       username: ${ELASTICSEARCH_USERNAME}
@@ -105,6 +108,10 @@ spec:
           value: elastic
         - name: ELASTICSEARCH_PASSWORD
           value: changeme
+        - name: ELASTIC_CLOUD_ID
+          value:
+        - name: ELASTIC_CLOUD_AUTH
+          value:
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -209,6 +216,10 @@ spec:
           value: elastic
         - name: ELASTICSEARCH_PASSWORD
           value: changeme
+        - name: ELASTIC_CLOUD_ID
+          value:
+        - name: ELASTIC_CLOUD_AUTH
+          value:
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:

--- a/deploy/kubernetes/metricbeat/metricbeat-daemonset-configmap.yaml
+++ b/deploy/kubernetes/metricbeat/metricbeat-daemonset-configmap.yaml
@@ -18,6 +18,9 @@ data:
     processors:
       - add_cloud_metadata:
 
+    cloud.id: ${ELASTIC_CLOUD_ID}
+    cloud.auth: ${ELASTIC_CLOUD_AUTH}
+
     output.elasticsearch:
       hosts: ['${ELASTICSEARCH_HOST:elasticsearch}:${ELASTICSEARCH_PORT:9200}']
       username: ${ELASTICSEARCH_USERNAME}

--- a/deploy/kubernetes/metricbeat/metricbeat-daemonset.yaml
+++ b/deploy/kubernetes/metricbeat/metricbeat-daemonset.yaml
@@ -34,6 +34,10 @@ spec:
           value: elastic
         - name: ELASTICSEARCH_PASSWORD
           value: changeme
+        - name: ELASTIC_CLOUD_ID
+          value:
+        - name: ELASTIC_CLOUD_AUTH
+          value:
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:

--- a/deploy/kubernetes/metricbeat/metricbeat-deployment.yaml
+++ b/deploy/kubernetes/metricbeat/metricbeat-deployment.yaml
@@ -30,6 +30,10 @@ spec:
           value: elastic
         - name: ELASTICSEARCH_PASSWORD
           value: changeme
+        - name: ELASTIC_CLOUD_ID
+          value:
+        - name: ELASTIC_CLOUD_AUTH
+          value:
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:

--- a/filebeat/docs/running-on-kubernetes.asciidoc
+++ b/filebeat/docs/running-on-kubernetes.asciidoc
@@ -58,7 +58,7 @@ To deploy Filebeat to Kubernetes just run:
 
 ["source", "sh", subs="attributes"]
 ------------------------------------------------
-kubectl deploy -f kubernetes/filebeat-kubernetes.yaml
+kubectl deploy -f filebeat-kubernetes.yaml
 ------------------------------------------------
 
 Then you should be able to check the status by running:

--- a/metricbeat/docs/running-on-kubernetes.asciidoc
+++ b/metricbeat/docs/running-on-kubernetes.asciidoc
@@ -65,7 +65,7 @@ To deploy Metricbeat to Kubernetes just run:
 
 ["source", "sh", subs="attributes"]
 ------------------------------------------------
-kubectl deploy -f kubernetes/metricbeat-kubernetes.yaml
+kubectl deploy -f metricbeat-kubernetes.yaml
 ------------------------------------------------
 
 Then you should be able to check the status by running:


### PR DESCRIPTION
Cherry-pick of PR #5487 to 6.0 branch. Original message: 

This change adds `ELASTIC_CLOUD_ID` and `ELASTIC_CLOUD_AUTH` env variables to Kubernetes manifests, so user can use those variables with cloud instead of the common `ELASTICSEARCH_*`.

When they are not used common ones will prevail

I also updated Makefile to always update YAML manifests