### PR TITLE
Mention file permissions in topics about config loading and reloading

### DIFF
--- a/filebeat/docs/filebeat-modules-options.asciidoc
+++ b/filebeat/docs/filebeat-modules-options.asciidoc
@@ -16,6 +16,8 @@ Filebeat provides a few different ways to enable modules. You can:
 * <<enable-modules-cli>>
 * <<enable-modules-config-file>>
 
+include::../../libbeat/docs/shared-note-file-permissions.asciidoc[]
+
 When you enable modules, you can also
 <<specify-variable-settings,specify variable settings>> to change the default
 behavior of the modules, and you can specify

--- a/filebeat/docs/reload-configuration.asciidoc
+++ b/filebeat/docs/reload-configuration.asciidoc
@@ -6,6 +6,8 @@ which allows you to separate your configuration into multiple smaller
 configuration files. See the <<load-prospector-config>> and the
 <<load-module-config>> sections for details.
 
+include::../../libbeat/docs/shared-note-file-permissions.asciidoc[]
+
 [float]
 [[load-prospector-config]]
 === Prospector config
@@ -40,25 +42,28 @@ definitions. For example:
 
 WARNING: It is critical that two running prospectors DO NOT have overlapping
 file paths defined. If more than one prospector harvests the same file at the
-same time, it can lead to unexpected behaviour.
+same time, it can lead to unexpected behavior.
 
 [float]
 [[load-module-config]]
 === Module config
 
 For module configurations, you specify the `path` option in the
-`filebeat.config.modules` section of the +{beatname_lc}.yml+ file. For example:
+`filebeat.config.modules` section of the +{beatname_lc}.yml+ file. By default,
+Filebeat loads the module configurations enabled in the
+<<enable-modules-d-configs,`modules.d`>> directory. For example:
 
 [source,yaml]
 ------------------------------------------------------------------------------
 filebeat.config.modules:
   enabled: true
-  path: prospectors.d/*.yml <1>
+  path: ${path.config}/modules.d/*.yml
 ------------------------------------------------------------------------------
 
-<1> If you change the path setting to look for config changes in a different
-directory, you will not be able to use the <<modules-command,`modules`>> command
-to enable and disable module configurations.
+
+The `path` setting must point to the `modules.d` directory if you want to use
+the <<modules-command,`modules`>> command to enable and disable module
+configurations.
 
 Each file found by the Glob must contain a list of one or more module
 definitions. For example:
@@ -73,6 +78,7 @@ definitions. For example:
     enabled: true
     var.paths: [/var/log/apache2/error.log*]
 ------------------------------------------------------------------------------
+
 
 === Live reloading
 
@@ -109,3 +115,5 @@ filebeat.config.prospectors:
 set the `period` to less than 1s because the modification time of files is often
 stored in seconds. Setting the `period` to less than 1s will result in
 unnecessary overhead.
+
+include::../../libbeat/docs/shared-note-file-permissions.asciidoc[]

--- a/libbeat/docs/config-file-format.asciidoc
+++ b/libbeat/docs/config-file-format.asciidoc
@@ -289,8 +289,8 @@ NOTE: This section does not apply to Windows or other non-POSIX operating system
 On systems with POSIX file permissions, all Beats configuration files are
 subject to ownership and file permission checks. The purpose of these checks is
 to prevent unauthorized users from providing or modifying configurations that
-are run by the Beat. The owner of the configuration file must be either `root`
-or the user who is executing the Beat process. The permissions on the file must
+are run by the Beat. The owner of the configuration files must be either `root`
+or the user who is executing the Beat process. The permissions on each file must
 disallow writes by anyone other than the owner.
 
 When installed via an RPM or DEB package, the config file at
@@ -317,6 +317,9 @@ permissions use: 'chmod go-w /etc/{beatname}/{beatname}.yml')
 
 To correct this problem, use `chmod go-w /etc/{beatname}/{beatname}.yml` to
 remove write privileges from anyone other than the owner.
+
+Other config files, such as the files in the `modules.d` directory, are subject
+to the same ownership and file permission checks. 
 
 ==== Disabling strict permission checks
 

--- a/libbeat/docs/shared-note-file-permissions.asciidoc
+++ b/libbeat/docs/shared-note-file-permissions.asciidoc
@@ -1,0 +1,4 @@
+NOTE: On systems with POSIX file permissions, all Beats configuration files are
+subject to ownership and file permission checks. For more information, see
+{libbeat}/config-file-permissions.html[Config File Ownership and Permissions] in
+the _Beats Platform Reference_.

--- a/metricbeat/docs/metricbeat-options.asciidoc
+++ b/metricbeat/docs/metricbeat-options.asciidoc
@@ -6,6 +6,8 @@ Metricbeat provides a couple different ways to enable modules and metricsets:
 * <<enable-modules-d-configs>>
 * <<enable-modules-config-file>>
 
+include::../../libbeat/docs/shared-note-file-permissions.asciidoc[]
+
 [float]
 [[enable-modules-d-configs]]
 === Enable module configs in the `modules.d` directory

--- a/metricbeat/docs/reload-configuration.asciidoc
+++ b/metricbeat/docs/reload-configuration.asciidoc
@@ -4,15 +4,22 @@
 Metricbeat can load external configuration files for modules, which allows you
 to separate your configuration into multiple smaller configuration files. To use
 this, you specify the `path` option under `metricbeat.config.modules` in the
-main `metricbeat.yml` configuration file. For example:
+main `metricbeat.yml` configuration file. By default, Metricbeat loads the
+module configurations enabled in the <<enable-modules-d-configs,`modules.d`>>
+directory. For example:
 
 [source,yaml]
 ------------------------------------------------------------------------------
 metricbeat.config.modules:
-  path: configs/*.yml
+  path: ${path.config}/modules.d/*.yml
 ------------------------------------------------------------------------------
 
+
 `path`:: A Glob that defines the files to check for changes.
++
+This setting must point to the `modules.d` directory if you want to use the
+<<modules-command,`modules`>> command to enable and disable module
+configurations.
 
 Each file found by the Glob must contain a list of one or more module
 definitions. For example:
@@ -29,6 +36,9 @@ definitions. For example:
   enabled: true
   period: 10s
 ------------------------------------------------------------------------------
+
+
+include::../../libbeat/docs/shared-note-file-permissions.asciidoc[]
 
 === Live reloading
 
@@ -47,21 +57,29 @@ the Metricbeat configuration frequently to specify which modules are needed and
 which hosts must be monitored.
 
 To enable dynamic config reloading, you specify the `path` and `reload` options
-under `metricbeat.config.modules` in the main `metricbeat.yml` config file.
-For example:
+under `metricbeat.config.modules` in the main `metricbeat.yml` config file. For
+example:
 
 [source,yaml]
 ------------------------------------------------------------------------------
 metricbeat.config.modules:
-  path: configs/*.yml
+  path: ${path.config}/modules.d/*.yml
   reload.enabled: true
   reload.period: 10s
 ------------------------------------------------------------------------------
 
+
 `path`:: A Glob that defines the files to check for changes.
++
+This setting must point to the `modules.d` directory if you want to use the
+<<modules-command,`modules`>> command to enable and disable module
+configurations. 
+
 `reload.enabled`:: When set to `true`, enables dynamic config reload.
+
 `reload.period`:: Specifies how often the files are checked for changes. Do not
 set the `period` to less than 1s because the modification time of files is often
 stored in seconds. Setting the `period` to less than 1s will result in
 unnecessary overhead.
 
+include::../../libbeat/docs/shared-note-file-permissions.asciidoc[]


### PR DESCRIPTION
Fixes issues https://github.com/elastic/beats/issues/4189 and https://github.com/elastic/beats/issues/4783

Also fixed examples to show `modules.d` as the default directory for module configs.