### PR TITLE
Fix duplicate batches in retry queue

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -28,7 +28,6 @@ https://github.com/elastic/beats/compare/v5.6.4...5.6[Check the HEAD diff]
 
 *Affecting all Beats*
 
-- Fix race condition in internal logging rotator. {pull}4519[4519]
 - Fix duplicate batches of events in retry queue. {pull}5520[5520]
 
 *Filebeat*

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -28,6 +28,9 @@ https://github.com/elastic/beats/compare/v5.6.4...5.6[Check the HEAD diff]
 
 *Affecting all Beats*
 
+- Fix race condition in internal logging rotator. {pull}4519[4519]
+- Fix duplicate batches of events in retry queue. {pull}5520[5520]
+
 *Filebeat*
 
 *Heartbeat*

--- a/libbeat/outputs/mode/modetest/callbacks.go
+++ b/libbeat/outputs/mode/modetest/callbacks.go
@@ -120,6 +120,7 @@ func AsyncPublishFailStartWith(
 	inc := makeCounter(n, err)
 	return func(cb func([]outputs.Data, error), data []outputs.Data) error {
 		if err := inc(); err != nil {
+			cb(data, err)
 			return err
 		}
 		return pub(cb, data)


### PR DESCRIPTION
On error in Logstash output sender, failed batches might get enqueued two
times. This can lead to multiple resends and ACKs for the same events.

In filebeat/winlogbeat, waiting for ACK from output, at most one ACK is
required. With potentially multiple ACKs (especially with multiple
consecutive IO errors) a deadlock in the outputs ACK handler can occur.

This PR ensures batches can not be returned to the retry queue via 2 code
paths (remove race between competing workers):
- async output worker does not return events back into retry queue
- async clients are required to always report retrieable errors via
callbacks
- add some more detailed debug logs to the LS output, that can help in
  identifiying ACKed batches still being retried