### PR TITLE
Prepare 5.6.4 release

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -8,7 +8,7 @@
 // Template, add newest changes here
 
 === Beats version HEAD
-https://github.com/elastic/beats/compare/v5.6.3...5.6[Check the HEAD diff]
+https://github.com/elastic/beats/compare/v5.6.4...5.6[Check the HEAD diff]
 
 ==== Breaking changes
 
@@ -28,8 +28,6 @@ https://github.com/elastic/beats/compare/v5.6.3...5.6[Check the HEAD diff]
 
 *Affecting all Beats*
 
-- Fix race condition in internal logging rotator. {pull}4519[4519]
-
 *Filebeat*
 
 *Heartbeat*
@@ -38,16 +36,11 @@ https://github.com/elastic/beats/compare/v5.6.3...5.6[Check the HEAD diff]
 
 *Packetbeat*
 
-- Fix missing length check in the PostgreSQL module. {pull}5457[5457]
-
 *Winlogbeat*
 
 ==== Added
 
 *Affecting all Beats*
-
-- Add support for enabling TLS renegotiation. {issue}4386[4386]
-- Add setting to enable/disable the slow start in logstash output. {pull}5400[5400]
 
 *Filebeat*
 
@@ -88,6 +81,27 @@ https://github.com/elastic/beats/compare/v5.6.3...5.6[Check the HEAD diff]
 *Winlogbeat*
 
 ////////////////////////////////////////////////////////////
+
+[[release-notes-5.6.4]]
+=== Beats version 5.6.4
+https://github.com/elastic/beats/compare/v5.6.3...v5.6.4[View commits]
+
+==== Bugfixes
+
+*Affecting all Beats*
+
+- Fix race condition in internal logging rotator. {pull}4519[4519]
+
+*Packetbeat*
+
+- Fix missing length check in the PostgreSQL module. {pull}5457[5457]
+
+==== Added
+
+*Affecting all Beats*
+
+- Add support for enabling TLS renegotiation. {issue}4386[4386]
+- Add setting to enable/disable the slow start in logstash output. {pull}5400[5400]
 
 [[release-notes-5.6.3]]
 === Beats version 5.6.3

--- a/libbeat/docs/release.asciidoc
+++ b/libbeat/docs/release.asciidoc
@@ -6,6 +6,7 @@
 --
 This section summarizes the changes in each release.
 
+* <<release-notes-5.6.4>>
 * <<release-notes-5.6.3>>
 * <<release-notes-5.6.2>>
 * <<release-notes-5.6.1>>

--- a/libbeat/docs/version.asciidoc
+++ b/libbeat/docs/version.asciidoc
@@ -1,4 +1,4 @@
-:stack-version: 5.6.3
+:stack-version: 5.6.4
 :doc-branch: 5.6
 :go-version: 1.7.6
 :release-state: released

--- a/testing/environments/args.yml
+++ b/testing/environments/args.yml
@@ -6,4 +6,4 @@ services:
     build:
       args:
         DOWNLOAD_URL: https://snapshots.elastic.co/downloads
-        ELASTIC_VERSION: 5.6.3-SNAPSHOT
+        ELASTIC_VERSION: 5.6.4-SNAPSHOT


### PR DESCRIPTION
* Close changelog
* Bump docs version
* Update testing env