### PR TITLE
Cherry-pick #5532 to master: Fix panic if event is dropped by queue

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -70,6 +70,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 
 - Fix http status phrase parsing not allow spaces. {pull}5312[5312]
 - Fix missing length check in the PostgreSQL module. {pull}5457[5457]
+- Fix panic in ACK handler if event is dropped on blocked queue {issue}5524[5524]
 
 *Winlogbeat*
 

--- a/libbeat/publisher/queue/memqueue/broker.go
+++ b/libbeat/publisher/queue/memqueue/broker.go
@@ -200,6 +200,10 @@ func (l *chanList) prepend(ch *ackChan) {
 }
 
 func (l *chanList) concat(other *chanList) {
+	if other.head == nil {
+		return
+	}
+
 	if l.head == nil {
 		*l = *other
 		return


### PR DESCRIPTION
Cherry-pick of PR #5532 to master branch. Original message: 

Resolves: #5524 

- Only increase event seq-no if event has been pushed
- Fix invalid ACK list if empty list is given to concat
- Only execute ack handlers if number of events being ACKed > 0
- Add missing debug log when collecting first ACK in ACK list