### PR TITLE
Remove prospector validation as not needed anymore

### DIFF
--- a/filebeat/harvester/util.go
+++ b/filebeat/harvester/util.go
@@ -10,14 +10,6 @@ const (
 	UdpType   = "udp"
 )
 
-// ValidType of valid input types
-var ValidType = map[string]struct{}{
-	StdinType: {},
-	LogType:   {},
-	RedisType: {},
-	UdpType:   {},
-}
-
 // MatchAny checks if the text matches any of the regular expressions
 func MatchAny(matchers []match.Matcher, text string) bool {
 	for _, m := range matchers {

--- a/filebeat/prospector/log/config.go
+++ b/filebeat/prospector/log/config.go
@@ -138,11 +138,6 @@ func (c *config) Validate() error {
 	}
 
 	// Harvester
-	// Check input type
-	if _, ok := harvester.ValidType[c.Type]; !ok {
-		return fmt.Errorf("Invalid input type: %v", c.Type)
-	}
-
 	if c.JSON != nil && len(c.JSON.MessageKey) == 0 &&
 		c.Multiline != nil {
 		return fmt.Errorf("When using the JSON decoder and multiline together, you need to specify a message_key value")

--- a/filebeat/prospector/registry.go
+++ b/filebeat/prospector/registry.go
@@ -39,7 +39,7 @@ func Register(name string, factory Factory) error {
 
 func GetFactory(name string) (Factory, error) {
 	if _, exists := registry[name]; !exists {
-		return nil, fmt.Errorf("Error retrieving factory for prospector '%v'", name)
+		return nil, fmt.Errorf("Error creating prospector. No such prospector type exist: '%v'", name)
 	}
 	return registry[name], nil
 }

--- a/filebeat/prospector/registry_test.go
+++ b/filebeat/prospector/registry_test.go
@@ -52,6 +52,6 @@ func TestGetNonExistentFactory(t *testing.T) {
 	f, err := GetFactory("noSuchFactory")
 	assert.Nil(t, f)
 	if assert.Error(t, err) {
-		assert.Equal(t, "Error retrieving factory for prospector 'noSuchFactory'", err.Error())
+		assert.Equal(t, "Error creating prospector. No such prospector type exist: 'noSuchFactory'", err.Error())
 	}
 }


### PR DESCRIPTION
Since the prospector are now registered through init, the validation is not needed anymore as in case a prospector type does not exist, and error is returned anyway. The harvester types are still needed because several harvesters use the log harvester.