### PR TITLE
Fix uptime value

### DIFF
--- a/libbeat/cmd/instance/metrics.go
+++ b/libbeat/cmd/instance/metrics.go
@@ -33,6 +33,6 @@ func reportInfo(_ monitoring.Mode, V monitoring.Visitor) {
 	defer V.OnRegistryFinished()
 
 	delta := time.Since(startTime)
-	uptime := int64(delta.Seconds())*1000 + int64(delta.Nanoseconds()/1000000)
+	uptime := int64(delta / time.Millisecond)
 	monitoring.ReportInt(V, "uptime.ms", uptime)
 }


### PR DESCRIPTION
Previously, uptime was duplicated due to a wrong formula.
`int64(delta.Seconds())*1000 + int64(delta.Nanoseconds()/1000000)` leads to duplicated value as it adds both converted value from seconds and nanoseconds.

Now simply the time in seconds is converted into milliseconds.
@urso WDYT?