### PR TITLE
Close changelog for 6.0.0-GA

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -8,7 +8,7 @@
 // Template, add newest changes here
 
 === Beats version HEAD
-https://github.com/elastic/beats/compare/v6.0.0-rc2...master[Check the HEAD diff]
+https://github.com/elastic/beats/compare/v6.0.0...master[Check the HEAD diff]
 
 ==== Breaking changes
 
@@ -34,16 +34,11 @@ https://github.com/elastic/beats/compare/v6.0.0-rc2...master[Check the HEAD diff
 
 *Filebeat*
 
-- Fix machine learning jobs setup for dynamic modules. {pull}5509[5509]
-
 *Heartbeat*
 
 *Metricbeat*
 
 *Packetbeat*
-
-- Fix missing length check in the PostgreSQL module. {pull}5457[5457]
-- Fix panic in ACK handler if event is dropped on blocked queue {issue}5524[5524]
 
 *Winlogbeat*
 
@@ -55,13 +50,9 @@ https://github.com/elastic/beats/compare/v6.0.0-rc2...master[Check the HEAD diff
 
 *Filebeat*
 
-- Add Kubernetes manifests to deploy Filebeat. {pull}5349[5349]
-
 *Heartbeat*
 
 *Metricbeat*
-
-- Add Kubernetes manifests to deploy Metricbeat. {pull}5349[5349]
 
 *Packetbeat*
 
@@ -85,6 +76,34 @@ https://github.com/elastic/beats/compare/v6.0.0-rc2...master[Check the HEAD diff
 
 
 ////////////////////////////////////////////////////////////
+
+[[release-notes-6.0.0-ga]]
+=== Beats version 6.0.0-GA
+https://github.com/elastic/beats/compare/v6.0.0-rc2...v6.0.0[View commits]
+
+The list below covers the changes between 6.0.0-rc2 and 6.0.0 GA only.
+
+==== Bugfixes
+
+*Filebeat*
+
+- Fix machine learning jobs setup for dynamic modules. {pull}5509[5509]
+
+*Packetbeat*
+
+- Fix missing length check in the PostgreSQL module. {pull}5457[5457]
+- Fix panic in ACK handler if event is dropped on blocked queue {issue}5524[5524]
+
+==== Added
+
+*Filebeat*
+
+- Add Kubernetes manifests to deploy Filebeat. {pull}5349[5349]
+
+*Metricbeat*
+
+- Add Kubernetes manifests to deploy Metricbeat. {pull}5349[5349]
+
 
 [[release-notes-6.0.0-rc2]]
 === Beats version 6.0.0-rc2

--- a/libbeat/docs/release.asciidoc
+++ b/libbeat/docs/release.asciidoc
@@ -6,6 +6,7 @@
 --
 This section summarizes the changes in each release.
 
+* <<release-notes-6.0.0-ga>>
 * <<release-notes-6.0.0-rc2>>
 * <<release-notes-6.0.0-rc1>>
 * <<release-notes-6.0.0-beta2>>


### PR DESCRIPTION
This contains the release notes since Rc2. We still need to consolidate all the changes since 5.6.