### PR TITLE
Move pre-commit hook to second command in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,14 +16,14 @@ REVIEWDOG_REPO=github.com/haya14busa/reviewdog/cmd/reviewdog
 # Runs complete testsuites (unit, system, integration) for all beats with coverage and race detection.
 # Also it builds the docs and the generators
 
+.PHONY: testsuite
+testsuite:
+	@$(foreach var,$(PROJECTS),$(MAKE) -C $(var) testsuite || exit 1;)
+
 .PHONY: setup-commit-hook
 setup-commit-hook:
 	@cp script/pre_commit.sh .git/hooks/pre-commit
 	@chmod 751 .git/hooks/pre-commit
-
-.PHONY: testsuite
-testsuite:
-	@$(foreach var,$(PROJECTS),$(MAKE) -C $(var) testsuite || exit 1;)
 
 stop-environments:
 	@$(foreach var,$(PROJECTS_ENV),$(MAKE) -C $(var) stop-environment || exit 0;)


### PR DESCRIPTION
Because the pre-commit hook was the first command in the beats Makefile, this was the standard command that was executed when running make. Before the default command was the teestsuite. I move the pre-commit hook now after the testsuite to make the default working as before.