### PR TITLE
chkconfig {beatname_lc} on is needed to start beat automatically

### DIFF
--- a/libbeat/docs/repositories.asciidoc
+++ b/libbeat/docs/repositories.asciidoc
@@ -150,6 +150,7 @@ sudo yum install {beatname_lc}
 ["source","sh",subs="attributes"]
 --------------------------------------------------
 sudo chkconfig --add {beatname_lc}
+sudo chkconfig {beatname_lc} on
 --------------------------------------------------
 
 endif::[]


### PR DESCRIPTION
chkconfig {beatname_lc} on is needed to start beat automatically during system boot