### PR TITLE
Add `Get` method to `cfgfile.Registry`

### DIFF
--- a/libbeat/cfgfile/registry.go
+++ b/libbeat/cfgfile/registry.go
@@ -2,40 +2,54 @@ package cfgfile
 
 import "sync"
 
+// Registry holds a list of Runners mapped by their unique hashes
 type Registry struct {
-	sync.Mutex
+	sync.RWMutex
 	List map[uint64]Runner
 }
 
+// NewRegistry returns a new empty Registry
 func NewRegistry() *Registry {
 	return &Registry{
 		List: map[uint64]Runner{},
 	}
 }
 
+// Add the given Runner to the list, indexed by a hash
 func (r *Registry) Add(hash uint64, m Runner) {
 	r.Lock()
 	defer r.Unlock()
 	r.List[hash] = m
 }
 
+// Remove the Runner with the given hash from the list
 func (r *Registry) Remove(hash uint64) {
 	r.Lock()
 	defer r.Unlock()
 	delete(r.List, hash)
 }
 
+// Has returns true if there is a Runner with the given hash
 func (r *Registry) Has(hash uint64) bool {
-	r.Lock()
-	defer r.Unlock()
+	r.RLock()
+	defer r.RUnlock()
 
 	_, ok := r.List[hash]
 	return ok
 }
 
+// Get returns the Runner with the given hash, or nil if it doesn't exist
+func (r *Registry) Get(hash uint64) Runner {
+	r.RLock()
+	defer r.RUnlock()
+
+	return r.List[hash]
+}
+
+// CopyList returns a static copy of the Runners map
 func (r *Registry) CopyList() map[uint64]Runner {
-	r.Lock()
-	defer r.Unlock()
+	r.RLock()
+	defer r.RUnlock()
 
 	// Create a copy of the list
 	list := map[uint64]Runner{}

--- a/libbeat/cfgfile/registry_test.go
+++ b/libbeat/cfgfile/registry_test.go
@@ -1,0 +1,48 @@
+package cfgfile
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type runner struct{ id int }
+
+func (runner) Start() {}
+func (runner) Stop()  {}
+
+func TestRegistryHas(t *testing.T) {
+	registry := NewRegistry()
+
+	registry.Add(1, runner{1})
+	assert.True(t, registry.Has(1))
+	assert.False(t, registry.Has(0))
+}
+
+func TestRegistryRemove(t *testing.T) {
+	registry := NewRegistry()
+
+	registry.Add(1, runner{1})
+	assert.True(t, registry.Has(1))
+
+	registry.Remove(1)
+	assert.False(t, registry.Has(1))
+}
+
+func TestRegistryGet(t *testing.T) {
+	registry := NewRegistry()
+
+	registry.Add(1, runner{1})
+	assert.Equal(t, registry.Get(1), runner{1})
+}
+
+func TestRegistryCopyList(t *testing.T) {
+	registry := NewRegistry()
+
+	registry.Add(1, runner{1})
+	registry.Add(2, runner{2})
+
+	list := registry.CopyList()
+	registry.Remove(1)
+	assert.Equal(t, len(list), 2)
+}


### PR DESCRIPTION
I'm extracting some of the helpers implemented in #5245 to smaller PRs, as suggested by @ruflin & @kvch 