### PR TITLE
Fixed docker diskio bug due to reseting of map.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -69,6 +69,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Fix the loading of 5.x dashboards. {issue}5277[5277]
 - Fix the fetching of process information when some data is missing under MacOS X. {issue}5337[5337]
 - Change `MySQL active connections` visualization title to `MySQL total connections`. {issue}4812[4812]
+- Fix map overwrite in docker diskio module. {issue}5582[5582]
 
 *Packetbeat*
 

--- a/metricbeat/module/docker/diskio/diskio_test.go
+++ b/metricbeat/module/docker/diskio/diskio_test.go
@@ -45,7 +45,7 @@ func TestDeltaMultipleContainers(t *testing.T) {
 	apiContainer2.Stats.BlkioStats.IOServicedRecursive = append(apiContainer2.Stats.BlkioStats.IOServicedRecursive, metrics)
 	dockerStats := []docker.Stat{apiContainer1, apiContainer2}
 	stats := blkioService.getBlkioStatsList(dockerStats)
-	totals := make([]float64, 2, 2)
+	totals := make([]float64, 2)
 	for _, stat := range stats {
 		totals[0] = stat.totals
 	}

--- a/metricbeat/module/docker/diskio/diskio_test.go
+++ b/metricbeat/module/docker/diskio/diskio_test.go
@@ -99,7 +99,7 @@ func TestDeltaOneContainer(t *testing.T) {
 	apiContainer.Stats.BlkioStats.IOServicedRecursive = append(apiContainer.Stats.BlkioStats.IOServicedRecursive, metrics)
 	dockerStats := []docker.Stat{apiContainer}
 	stats := blkioService.getBlkioStatsList(dockerStats)
-	totals := make([]float64, 2, 2)
+	totals := make([]float64, 2)
 	for _, stat := range stats {
 		totals[0] = stat.totals
 	}

--- a/metricbeat/module/docker/diskio/diskio_test.go
+++ b/metricbeat/module/docker/diskio/diskio_test.go
@@ -43,9 +43,7 @@ func TestDeltaMultipleContainers(t *testing.T) {
 	apiContainer2.Stats.Read = time.Now()
 	apiContainer2.Container = containers[1]
 	apiContainer2.Stats.BlkioStats.IOServicedRecursive = append(apiContainer2.Stats.BlkioStats.IOServicedRecursive, metrics)
-	dockerStats := make([]docker.Stat, 0)
-	dockerStats = append(dockerStats, apiContainer1)
-	dockerStats = append(dockerStats, apiContainer2)
+	dockerStats := []docker.Stat{apiContainer1, apiContainer2}
 	stats := blkioService.getBlkioStatsList(dockerStats)
 	totals := make([]float64, 2, 2)
 	for _, stat := range stats {
@@ -99,8 +97,7 @@ func TestDeltaOneContainer(t *testing.T) {
 	apiContainer.Stats.Read = time.Now()
 	apiContainer.Container = containers
 	apiContainer.Stats.BlkioStats.IOServicedRecursive = append(apiContainer.Stats.BlkioStats.IOServicedRecursive, metrics)
-	dockerStats := make([]docker.Stat, 0)
-	dockerStats = append(dockerStats, apiContainer)
+	dockerStats := []docker.Stat{apiContainer}
 	stats := blkioService.getBlkioStatsList(dockerStats)
 	totals := make([]float64, 2, 2)
 	for _, stat := range stats {

--- a/metricbeat/module/docker/diskio/diskio_test.go
+++ b/metricbeat/module/docker/diskio/diskio_test.go
@@ -1,13 +1,131 @@
 package diskio
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
+
+	"github.com/elastic/beats/metricbeat/module/docker"
+
+	dc "github.com/fsouza/go-dockerclient"
 )
 
 var blkioService BLkioService
 var oldBlkioRaw = make([]BlkioRaw, 3)
 var newBlkioRaw = make([]BlkioRaw, 3)
+
+func TestDeltaMultipleContainers(t *testing.T) {
+	var apiContainer1 docker.Stat
+	var apiContainer2 docker.Stat
+	metrics := dc.BlkioStatsEntry{
+		Major: 123,
+		Minor: 123,
+		Op:    "Total",
+		Value: 123,
+	}
+	jsonContainers := `[
+     {
+             "Id": "8dfafdbc3a40",
+			 "Names": ["container"]
+     },{
+             "Id": "8dfafdbc3a41",
+			 "Names": ["container1"]
+     }]`
+	var containers []dc.APIContainers
+	err := json.Unmarshal([]byte(jsonContainers), &containers)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	apiContainer1.Stats.Read = time.Now()
+	apiContainer1.Container = containers[0]
+	apiContainer1.Stats.BlkioStats.IOServicedRecursive = append(apiContainer1.Stats.BlkioStats.IOServicedRecursive, metrics)
+	apiContainer2.Stats.Read = time.Now()
+	apiContainer2.Container = containers[1]
+	apiContainer2.Stats.BlkioStats.IOServicedRecursive = append(apiContainer2.Stats.BlkioStats.IOServicedRecursive, metrics)
+	dockerStats := make([]docker.Stat, 0)
+	dockerStats = append(dockerStats, apiContainer1)
+	dockerStats = append(dockerStats, apiContainer2)
+	stats := blkioService.getBlkioStatsList(dockerStats)
+	totals := make([]float64, 2, 2)
+	for _, stat := range stats {
+		totals[0] = stat.totals
+	}
+
+	dockerStats[0].Stats.BlkioStats.IOServicedRecursive[0].Value = 1000
+	dockerStats[0].Stats.Read = dockerStats[0].Stats.Read.Add(time.Second * 10)
+	dockerStats[1].Stats.BlkioStats.IOServicedRecursive[0].Value = 1000
+	dockerStats[1].Stats.Read = dockerStats[0].Stats.Read.Add(time.Second * 10)
+	stats = blkioService.getBlkioStatsList(dockerStats)
+	for _, stat := range stats {
+		totals[1] = stat.totals
+		if stat.totals < totals[0] {
+			t.Errorf("getBlkioStatsList(%v) => %v, want value bigger than %v", dockerStats, stat.totals, totals[0])
+		}
+	}
+
+	dockerStats[0].Stats.Read = dockerStats[0].Stats.Read.Add(time.Second * 15)
+	dockerStats[0].Stats.BlkioStats.IOServicedRecursive[0].Value = 2000
+	dockerStats[1].Stats.BlkioStats.IOServicedRecursive[0].Value = 2000
+	dockerStats[1].Stats.Read = dockerStats[0].Stats.Read.Add(time.Second * 15)
+	stats = blkioService.getBlkioStatsList(dockerStats)
+	for _, stat := range stats {
+		if stat.totals < totals[1] || stat.totals < totals[0] {
+			t.Errorf("getBlkioStatsList(%v) => %v, want value bigger than %v", dockerStats, stat.totals, totals[1])
+		}
+	}
+
+}
+
+func TestDeltaOneContainer(t *testing.T) {
+	var apiContainer docker.Stat
+	metrics := dc.BlkioStatsEntry{
+		Major: 123,
+		Minor: 123,
+		Op:    "Total",
+		Value: 123,
+	}
+	jsonContainers := `
+     {
+             "Id": "8dfafdbc3a40",
+			 "Names": ["container"]
+     }`
+	var containers dc.APIContainers
+	err := json.Unmarshal([]byte(jsonContainers), &containers)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	apiContainer.Stats.Read = time.Now()
+	apiContainer.Container = containers
+	apiContainer.Stats.BlkioStats.IOServicedRecursive = append(apiContainer.Stats.BlkioStats.IOServicedRecursive, metrics)
+	dockerStats := make([]docker.Stat, 0)
+	dockerStats = append(dockerStats, apiContainer)
+	stats := blkioService.getBlkioStatsList(dockerStats)
+	totals := make([]float64, 2, 2)
+	for _, stat := range stats {
+		totals[0] = stat.totals
+	}
+
+	dockerStats[0].Stats.BlkioStats.IOServicedRecursive[0].Value = 1000
+	dockerStats[0].Stats.Read = dockerStats[0].Stats.Read.Add(time.Second * 10)
+	stats = blkioService.getBlkioStatsList(dockerStats)
+	for _, stat := range stats {
+		if stat.totals < totals[0] {
+			t.Errorf("getBlkioStatsList(%v) => %v, want value bigger than %v", dockerStats, stat.totals, totals[0])
+		}
+	}
+
+	dockerStats[0].Stats.BlkioStats.IOServicedRecursive[0].Value = 2000
+	dockerStats[0].Stats.Read = dockerStats[0].Stats.Read.Add(time.Second * 15)
+	stats = blkioService.getBlkioStatsList(dockerStats)
+	for _, stat := range stats {
+		if stat.totals < totals[1] || stat.totals < totals[0] {
+			t.Errorf("getBlkioStatsList(%v) => %v, want value bigger than %v", dockerStats, stat.totals, totals[1])
+		}
+	}
+
+}
 
 func TestWritePs(t *testing.T) {
 	oldWritePs := []uint64{220, 951, 0}

--- a/metricbeat/module/docker/diskio/helper.go
+++ b/metricbeat/module/docker/diskio/helper.go
@@ -35,7 +35,9 @@ type BLkioService struct {
 
 func (io *BLkioService) getBlkioStatsList(rawStats []docker.Stat) []BlkioStats {
 	formattedStats := []BlkioStats{}
-
+	if io.BlkioSTatsPerContainer == nil {
+		io.BlkioSTatsPerContainer = make(map[string]BlkioRaw)
+	}
 	for _, myRawStats := range rawStats {
 		formattedStats = append(formattedStats, io.getBlkioStats(&myRawStats))
 	}
@@ -56,8 +58,6 @@ func (io *BLkioService) getBlkioStats(myRawStat *docker.Stat) BlkioStats {
 		myBlkioStats.reads = io.getReadPs(&oldBlkioStats, &newBlkioStats)
 		myBlkioStats.writes = io.getWritePs(&oldBlkioStats, &newBlkioStats)
 		myBlkioStats.totals = io.getTotalPs(&oldBlkioStats, &newBlkioStats)
-	} else {
-		io.BlkioSTatsPerContainer = make(map[string]BlkioRaw)
 	}
 
 	io.BlkioSTatsPerContainer[myRawStat.Container.ID] = newBlkioStats


### PR DESCRIPTION
Issue explaining this bug https://github.com/elastic/beats/issues/5568 general idea is if 2+ containers the map is overwritten every time and no delta metrics are pushed