### PR TITLE
Remove spurious ID method

### DIFF
--- a/filebeat/fileset/factory.go
+++ b/filebeat/fileset/factory.go
@@ -110,6 +110,3 @@ func (p *prospectorsRunner) Stop() {
 		prospector.Stop()
 	}
 }
-func (p *prospectorsRunner) ID() uint64 {
-	return p.id
-}


### PR DESCRIPTION
ID was removed from the Runner interface some time ago, this code is
not used anymore