### PR TITLE
Optional pipeline and output metrics

### DIFF
--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -24,6 +24,7 @@ import (
 	"github.com/elastic/beats/libbeat/common/file"
 	"github.com/elastic/beats/libbeat/dashboards"
 	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/monitoring"
 	"github.com/elastic/beats/libbeat/monitoring/report"
 	"github.com/elastic/beats/libbeat/outputs/elasticsearch"
 	"github.com/elastic/beats/libbeat/paths"
@@ -203,8 +204,13 @@ func (b *Beat) createBeater(bt beat.Creator) (beat.Beater, error) {
 		return nil, err
 	}
 
+	reg := monitoring.Default.GetRegistry("libbeat")
+	if reg == nil {
+		reg = monitoring.Default.NewRegistry("libbeat")
+	}
+
 	debugf("Initializing output plugins")
-	pipeline, err := pipeline.Load(b.Info, b.Config.Pipeline, b.Config.Output)
+	pipeline, err := pipeline.Load(b.Info, reg, b.Config.Pipeline, b.Config.Output)
 	if err != nil {
 		return nil, fmt.Errorf("error initializing publisher: %v", err)
 	}

--- a/libbeat/outputs/console/console_test.go
+++ b/libbeat/outputs/console/console_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/fmtstr"
+	"github.com/elastic/beats/libbeat/outputs"
 	"github.com/elastic/beats/libbeat/outputs/codec"
 	"github.com/elastic/beats/libbeat/outputs/codec/format"
 	"github.com/elastic/beats/libbeat/outputs/codec/json"
@@ -104,7 +105,7 @@ func TestConsoleOutput(t *testing.T) {
 
 func run(codec codec.Codec, batches ...publisher.Batch) (string, error) {
 	return withStdout(func() {
-		c, _ := newConsole("test", nil, codec)
+		c, _ := newConsole("test", outputs.NewNilObserver(), codec)
 		for _, b := range batches {
 			c.Publish(b)
 		}

--- a/libbeat/outputs/elasticsearch/client.go
+++ b/libbeat/outputs/elasticsearch/client.go
@@ -40,7 +40,7 @@ type Client struct {
 	compressionLevel int
 	proxyURL         *url.URL
 
-	stats *outputs.Stats
+	observer outputs.Observer
 }
 
 // ClientSettings contains the settings for a client.
@@ -55,7 +55,7 @@ type ClientSettings struct {
 	Pipeline           *outil.Selector
 	Timeout            time.Duration
 	CompressionLevel   int
-	Stats              *outputs.Stats
+	Observer           outputs.Observer
 }
 
 type connectCallback func(client *Client) error
@@ -131,7 +131,7 @@ func NewClient(
 		return nil, err
 	}
 
-	if st := s.Stats; st != nil {
+	if st := s.Observer; st != nil {
 		dialer = transport.StatsDialer(dialer, st)
 		tlsDialer = transport.StatsDialer(tlsDialer, st)
 	}
@@ -243,7 +243,7 @@ func (client *Client) publishEvents(
 	data []publisher.Event,
 ) ([]publisher.Event, error) {
 	begin := time.Now()
-	st := client.stats
+	st := client.observer
 
 	if st != nil {
 		st.NewBatch(len(data))
@@ -291,7 +291,7 @@ func (client *Client) publishEvents(
 	}
 
 	failed := len(failedEvents)
-	if st := client.stats; st != nil {
+	if st := client.observer; st != nil {
 		acked := len(data) - failed
 
 		st.Acked(acked)

--- a/libbeat/outputs/elasticsearch/client_integration_test.go
+++ b/libbeat/outputs/elasticsearch/client_integration_test.go
@@ -248,7 +248,7 @@ func connectTestEs(t *testing.T, cfg interface{}) (outputs.Client, *Client) {
 		t.Fatal(err)
 	}
 
-	output, err := makeES(beat.Info{Beat: "libbeat"}, nil, config)
+	output, err := makeES(beat.Info{Beat: "libbeat"}, outputs.NewNilObserver(), config)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libbeat/outputs/elasticsearch/elasticsearch.go
+++ b/libbeat/outputs/elasticsearch/elasticsearch.go
@@ -49,7 +49,7 @@ func RegisterConnectCallback(callback connectCallback) {
 
 func makeES(
 	beat beat.Info,
-	stats *outputs.Stats,
+	observer outputs.Observer,
 	cfg *common.Config,
 ) (outputs.Group, error) {
 	if !cfg.HasField("bulk_max_size") {
@@ -135,7 +135,7 @@ func makeES(
 			Headers:          config.Headers,
 			Timeout:          config.Timeout,
 			CompressionLevel: config.CompressionLevel,
-			Stats:            stats,
+			Observer:         observer,
 		}, &connectCallbackRegistry)
 		if err != nil {
 			return outputs.Fail(err)

--- a/libbeat/outputs/fileout/file.go
+++ b/libbeat/outputs/fileout/file.go
@@ -14,16 +14,16 @@ func init() {
 }
 
 type fileOutput struct {
-	beat    beat.Info
-	stats   *outputs.Stats
-	rotator logp.FileRotator
-	codec   codec.Codec
+	beat     beat.Info
+	observer outputs.Observer
+	rotator  logp.FileRotator
+	codec    codec.Codec
 }
 
 // New instantiates a new file output instance.
 func makeFileout(
 	beat beat.Info,
-	stats *outputs.Stats,
+	observer outputs.Observer,
 	cfg *common.Config,
 ) (outputs.Group, error) {
 	config := defaultConfig
@@ -34,7 +34,7 @@ func makeFileout(
 	// disable bulk support in publisher pipeline
 	cfg.SetInt("bulk_max_size", -1, -1)
 
-	fo := &fileOutput{beat: beat, stats: stats}
+	fo := &fileOutput{beat: beat, observer: observer}
 	if err := fo.init(beat, config); err != nil {
 		return outputs.Fail(err)
 	}
@@ -95,7 +95,7 @@ func (out *fileOutput) Publish(
 ) error {
 	defer batch.ACK()
 
-	st := out.stats
+	st := out.observer
 	events := batch.Events()
 	st.NewBatch(len(events))
 
@@ -117,7 +117,7 @@ func (out *fileOutput) Publish(
 
 		err = out.rotator.WriteLine(serializedEvent)
 		if err != nil {
-			st.WriteError()
+			st.WriteError(err)
 
 			if event.Guaranteed() {
 				logp.Critical("Writing event to file failed with: %v", err)

--- a/libbeat/outputs/kafka/kafka.go
+++ b/libbeat/outputs/kafka/kafka.go
@@ -113,7 +113,7 @@ func kafkaMetricsRegistry() gometrics.Registry {
 
 func makeKafka(
 	beat beat.Info,
-	stats *outputs.Stats,
+	observer outputs.Observer,
 	cfg *common.Config,
 ) (outputs.Group, error) {
 	debugf("initialize kafka output")
@@ -148,7 +148,7 @@ func makeKafka(
 		return outputs.Fail(err)
 	}
 
-	client, err := newKafkaClient(stats, hosts, beat.Beat, config.Key, topic, codec, libCfg)
+	client, err := newKafkaClient(observer, hosts, beat.Beat, config.Key, topic, codec, libCfg)
 	if err != nil {
 		return outputs.Fail(err)
 	}

--- a/libbeat/outputs/kafka/kafka_integration_test.go
+++ b/libbeat/outputs/kafka/kafka_integration_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/fmtstr"
 	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/outputs"
 	"github.com/elastic/beats/libbeat/outputs/outest"
 
 	_ "github.com/elastic/beats/libbeat/outputs/codec/format"
@@ -185,7 +186,7 @@ func TestKafkaPublish(t *testing.T) {
 		}
 
 		t.Run(name, func(t *testing.T) {
-			grp, err := makeKafka(beat.Info{Beat: "libbeat"}, nil, cfg)
+			grp, err := makeKafka(beat.Info{Beat: "libbeat"}, outputs.NewNilObserver(), cfg)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/libbeat/outputs/logstash/async_test.go
+++ b/libbeat/outputs/logstash/async_test.go
@@ -36,7 +36,7 @@ func makeAsyncTestClient(conn *transport.Client) testClientDriver {
 	config := defaultConfig
 	config.Timeout = 1 * time.Second
 	config.Pipelining = 3
-	client, err := newAsyncClient(beat.Info{}, conn, nil, &config)
+	client, err := newAsyncClient(beat.Info{}, conn, outputs.NewNilObserver(), &config)
 	if err != nil {
 		panic(err)
 	}

--- a/libbeat/outputs/logstash/logstash.go
+++ b/libbeat/outputs/logstash/logstash.go
@@ -21,7 +21,7 @@ func init() {
 
 func makeLogstash(
 	beat beat.Info,
-	stats *outputs.Stats,
+	observer outputs.Observer,
 	cfg *common.Config,
 ) (outputs.Group, error) {
 	if !cfg.HasField("index") {
@@ -47,7 +47,7 @@ func makeLogstash(
 		Timeout: config.Timeout,
 		Proxy:   &config.Proxy,
 		TLS:     tls,
-		Stats:   stats,
+		Stats:   observer,
 	}
 
 	clients := make([]outputs.NetworkClient, len(hosts))
@@ -60,9 +60,9 @@ func makeLogstash(
 		}
 
 		if config.Pipelining > 0 {
-			client, err = newAsyncClient(beat, conn, stats, config)
+			client, err = newAsyncClient(beat, conn, observer, config)
 		} else {
-			client, err = newSyncClient(beat, conn, stats, config)
+			client, err = newSyncClient(beat, conn, observer, config)
 		}
 		if err != nil {
 			return outputs.Fail(err)

--- a/libbeat/outputs/logstash/logstash_integration_test.go
+++ b/libbeat/outputs/logstash/logstash_integration_test.go
@@ -158,7 +158,7 @@ func newTestElasticsearchOutput(t *testing.T, test string) *testOutputer {
 		"template.enabled": false,
 	})
 
-	grp, err := plugin(beat.Info{Beat: "libbeat"}, nil, config)
+	grp, err := plugin(beat.Info{Beat: "libbeat"}, outputs.NewNilObserver(), config)
 	if err != nil {
 		t.Fatalf("init elasticsearch output plugin failed: %v", err)
 	}

--- a/libbeat/outputs/logstash/sync.go
+++ b/libbeat/outputs/logstash/sync.go
@@ -13,23 +13,23 @@ import (
 
 type syncClient struct {
 	*transport.Client
-	client *v2.SyncClient
-	stats  *outputs.Stats
-	win    *window
-	ttl    time.Duration
-	ticker *time.Ticker
+	client   *v2.SyncClient
+	observer outputs.Observer
+	win      *window
+	ttl      time.Duration
+	ticker   *time.Ticker
 }
 
 func newSyncClient(
 	beat beat.Info,
 	conn *transport.Client,
-	stats *outputs.Stats,
+	observer outputs.Observer,
 	config *Config,
 ) (*syncClient, error) {
 	c := &syncClient{
-		Client: conn,
-		stats:  stats,
-		ttl:    config.TTL,
+		Client:   conn,
+		observer: observer,
+		ttl:      config.TTL,
 	}
 
 	if config.SlowStart {
@@ -83,7 +83,7 @@ func (c *syncClient) reconnect() error {
 
 func (c *syncClient) Publish(batch publisher.Batch) error {
 	events := batch.Events()
-	st := c.stats
+	st := c.observer
 
 	st.NewBatch(len(events))
 

--- a/libbeat/outputs/logstash/sync_test.go
+++ b/libbeat/outputs/logstash/sync_test.go
@@ -49,7 +49,7 @@ func makeTestClient(conn *transport.Client) testClientDriver {
 	config := defaultConfig
 	config.Timeout = 1 * time.Second
 	config.TTL = 5 * time.Second
-	client, err := newSyncClient(beat.Info{}, conn, nil, &config)
+	client, err := newSyncClient(beat.Info{}, conn, outputs.NewNilObserver(), &config)
 	if err != nil {
 		panic(err)
 	}

--- a/libbeat/outputs/metrics.go
+++ b/libbeat/outputs/metrics.go
@@ -2,9 +2,8 @@ package outputs
 
 import "github.com/elastic/beats/libbeat/monitoring"
 
-// Stats provides a common type used by outputs to report common events.
-// The output events will update a set of unified output metrics in the
-// underlying monitoring.Registry.
+// Stats implements the Observer interface, for collecting metrics on common
+// outputs events.
 type Stats struct {
 	//
 	// Output event stats
@@ -26,6 +25,9 @@ type Stats struct {
 	readErrors *monitoring.Uint // total number of errors while waiting for response on output
 }
 
+// NewStats creates a new Stats instance using a backing monitoring registry.
+// This function will create and register a number of metrics with the registry passed.
+// The registry must not be null.
 func NewStats(reg *monitoring.Registry) *Stats {
 	return &Stats{
 		batches: monitoring.NewUint(reg, "events.batches"),
@@ -42,6 +44,7 @@ func NewStats(reg *monitoring.Registry) *Stats {
 	}
 }
 
+// NewBatch updates active batch and event metrics.
 func (s *Stats) NewBatch(n int) {
 	if s != nil {
 		s.batches.Inc()
@@ -50,6 +53,7 @@ func (s *Stats) NewBatch(n int) {
 	}
 }
 
+// Acked updates active and acked event metrics.
 func (s *Stats) Acked(n int) {
 	if s != nil {
 		s.acked.Add(uint64(n))
@@ -57,6 +61,7 @@ func (s *Stats) Acked(n int) {
 	}
 }
 
+// Failed updates active and failed event metrics.
 func (s *Stats) Failed(n int) {
 	if s != nil {
 		s.failed.Add(uint64(n))
@@ -64,6 +69,10 @@ func (s *Stats) Failed(n int) {
 	}
 }
 
+// Dropped updates total number of event drops as reported by the output.
+// Outputs will only report dropped events on fatal errors which lead to the
+// event not being publishabel. For example encoding errors or total event size
+// being bigger then maximum supported event size.
 func (s *Stats) Dropped(n int) {
 	// number of dropped events (e.g. encoding failures)
 	if s != nil {
@@ -71,30 +80,35 @@ func (s *Stats) Dropped(n int) {
 	}
 }
 
+// Cancelled updates the active event metrics.
 func (s *Stats) Cancelled(n int) {
 	if s != nil {
 		s.active.Sub(uint64(n))
 	}
 }
 
+// WriteError increases the write I/O error metrics.
 func (s *Stats) WriteError(err error) {
 	if s != nil {
 		s.writeErrors.Inc()
 	}
 }
 
+// WriteBytes updates the total number of bytes written/send by an output.
 func (s *Stats) WriteBytes(n int) {
 	if s != nil {
 		s.writeBytes.Add(uint64(n))
 	}
 }
 
+// ReadError increases the read I/O error metrics.
 func (s *Stats) ReadError(err error) {
 	if s != nil {
 		s.readErrors.Inc()
 	}
 }
 
+// ReadBytes updates the total number of bytes read/received by an output.
 func (s *Stats) ReadBytes(n int) {
 	if s != nil {
 		s.readBytes.Add(uint64(n))

--- a/libbeat/outputs/metrics.go
+++ b/libbeat/outputs/metrics.go
@@ -26,8 +26,8 @@ type Stats struct {
 	readErrors *monitoring.Uint // total number of errors while waiting for response on output
 }
 
-func MakeStats(reg *monitoring.Registry) Stats {
-	return Stats{
+func NewStats(reg *monitoring.Registry) *Stats {
+	return &Stats{
 		batches: monitoring.NewUint(reg, "events.batches"),
 		events:  monitoring.NewUint(reg, "events.total"),
 		acked:   monitoring.NewUint(reg, "events.acked"),
@@ -77,7 +77,7 @@ func (s *Stats) Cancelled(n int) {
 	}
 }
 
-func (s *Stats) WriteError() {
+func (s *Stats) WriteError(err error) {
 	if s != nil {
 		s.writeErrors.Inc()
 	}
@@ -89,7 +89,7 @@ func (s *Stats) WriteBytes(n int) {
 	}
 }
 
-func (s *Stats) ReadError() {
+func (s *Stats) ReadError(err error) {
 	if s != nil {
 		s.readErrors.Inc()
 	}

--- a/libbeat/outputs/observer.go
+++ b/libbeat/outputs/observer.go
@@ -1,0 +1,27 @@
+package outputs
+
+type Observer interface {
+	NewBatch(int)     // report new batch being processed with number of events
+	Acked(int)        // report number of acked events
+	Failed(int)       // report number of failed events
+	Dropped(int)      // report number of dropped events
+	Cancelled(int)    // report number of cancelled events
+	WriteError(error) // report an I/O error on write
+	WriteBytes(int)   // report number of bytes being written
+	ReadError(error)  // report an I/O error on read
+	ReadBytes(int)    // report number of bytes being read
+}
+
+type emptyObserver struct{}
+
+var nilObserver = (*emptyObserver)(nil)
+
+func (*emptyObserver) NewBatch(int)     {}
+func (*emptyObserver) Acked(int)        {}
+func (*emptyObserver) Failed(int)       {}
+func (*emptyObserver) Dropped(int)      {}
+func (*emptyObserver) Cancelled(int)    {}
+func (*emptyObserver) WriteError(error) {}
+func (*emptyObserver) WriteBytes(int)   {}
+func (*emptyObserver) ReadError(error)  {}
+func (*emptyObserver) ReadBytes(int)    {}

--- a/libbeat/outputs/observer.go
+++ b/libbeat/outputs/observer.go
@@ -16,6 +16,10 @@ type emptyObserver struct{}
 
 var nilObserver = (*emptyObserver)(nil)
 
+func NewNilObserver() Observer {
+	return nilObserver
+}
+
 func (*emptyObserver) NewBatch(int)     {}
 func (*emptyObserver) Acked(int)        {}
 func (*emptyObserver) Failed(int)       {}

--- a/libbeat/outputs/observer.go
+++ b/libbeat/outputs/observer.go
@@ -1,5 +1,7 @@
 package outputs
 
+// Observer provides an interface used by outputs to report common events on
+// documents/events being published and I/O workload.
 type Observer interface {
 	NewBatch(int)     // report new batch being processed with number of events
 	Acked(int)        // report number of acked events
@@ -16,6 +18,7 @@ type emptyObserver struct{}
 
 var nilObserver = (*emptyObserver)(nil)
 
+// NewNilObserver returns an oberserver implementation, ignoring all events.
 func NewNilObserver() Observer {
 	return nilObserver
 }

--- a/libbeat/outputs/output_reg.go
+++ b/libbeat/outputs/output_reg.go
@@ -13,7 +13,7 @@ var outputReg = map[string]Factory{}
 // Factory is used by output plugins to build an output instance
 type Factory func(
 	beat beat.Info,
-	stats *Stats,
+	stats Observer,
 	cfg *common.Config) (Group, error)
 
 // Group configures and combines multiple clients into load-balanced group of clients
@@ -38,7 +38,7 @@ func FindFactory(name string) Factory {
 }
 
 // Load creates and configures a output Group using a configuration object..
-func Load(info beat.Info, stats *Stats, name string, config *common.Config) (Group, error) {
+func Load(info beat.Info, stats Observer, name string, config *common.Config) (Group, error) {
 	factory := FindFactory(name)
 	if factory == nil {
 		return Group{}, fmt.Errorf("output type %v undefined", name)
@@ -48,5 +48,8 @@ func Load(info beat.Info, stats *Stats, name string, config *common.Config) (Gro
 		return Fail(err)
 	}
 
+	if stats == nil {
+		stats = nilObserver
+	}
 	return factory(info, stats, config)
 }

--- a/libbeat/outputs/output_reg.go
+++ b/libbeat/outputs/output_reg.go
@@ -49,7 +49,7 @@ func Load(info beat.Info, stats Observer, name string, config *common.Config) (G
 	}
 
 	if stats == nil {
-		stats = nilObserver
+		stats = NewNilObserver()
 	}
 	return factory(info, stats, config)
 }

--- a/libbeat/outputs/redis/redis.go
+++ b/libbeat/outputs/redis/redis.go
@@ -30,7 +30,7 @@ func init() {
 
 func makeRedis(
 	beat beat.Info,
-	stats *outputs.Stats,
+	observer outputs.Observer,
 	cfg *common.Config,
 ) (outputs.Group, error) {
 	config := defaultConfig
@@ -89,7 +89,7 @@ func makeRedis(
 		Timeout: config.Timeout,
 		Proxy:   &config.Proxy,
 		TLS:     tls,
-		Stats:   stats,
+		Stats:   observer,
 	}
 
 	clients := make([]outputs.NetworkClient, len(hosts))
@@ -104,7 +104,7 @@ func makeRedis(
 			return outputs.Fail(err)
 		}
 
-		clients[i] = newClient(conn, stats, config.Timeout,
+		clients[i] = newClient(conn, observer, config.Timeout,
 			config.Password, config.Db, key, dataType, config.Index, enc)
 	}
 

--- a/libbeat/outputs/redis/redis_integration_test.go
+++ b/libbeat/outputs/redis/redis_integration_test.go
@@ -260,7 +260,7 @@ func newRedisTestingOutput(t *testing.T, cfg map[string]interface{}) *client {
 		t.Fatalf("redis output module not registered")
 	}
 
-	out, err := plugin(beat.Info{Beat: "libbeat"}, nil, config)
+	out, err := plugin(beat.Info{Beat: "libbeat"}, outputs.NewNilObserver(), config)
 	if err != nil {
 		t.Fatalf("Failed to initialize redis output: %v", err)
 	}

--- a/libbeat/outputs/transport/stats.go
+++ b/libbeat/outputs/transport/stats.go
@@ -5,10 +5,10 @@ import (
 )
 
 type IOStatser interface {
-	WriteError()
+	WriteError(err error)
 	WriteBytes(int)
 
-	ReadError()
+	ReadError(err error)
 	ReadBytes(int)
 }
 
@@ -26,7 +26,7 @@ func StatsDialer(d Dialer, s IOStatser) Dialer {
 func (s *statsConn) Read(b []byte) (int, error) {
 	n, err := s.Conn.Read(b)
 	if err != nil {
-		s.stats.ReadError()
+		s.stats.ReadError(err)
 	}
 	s.stats.ReadBytes(n)
 	return n, err
@@ -35,7 +35,7 @@ func (s *statsConn) Read(b []byte) (int, error) {
 func (s *statsConn) Write(b []byte) (int, error) {
 	n, err := s.Conn.Write(b)
 	if err != nil {
-		s.stats.WriteError()
+		s.stats.WriteError(err)
 	}
 	s.stats.WriteBytes(n)
 	return n, err


### PR DESCRIPTION
- initialize libbeat metrics for pipeline on beat instance
- introduce outputs.Oberserver to be passed to outputs instead of
  outputs.Stats
- pass nilObserver to outputs, if metrics are disabled
- pass metrics registry to pipeline loader