### PR TITLE
Flag experimental and beta modules in the docs

### DIFF
--- a/metricbeat/docs/fields.asciidoc
+++ b/metricbeat/docs/fields.asciidoc
@@ -2946,7 +2946,7 @@ format: bytes
 [[exported-fields-etcd]]
 == Etcd fields
 
-[]experimental
+experimental[]
 etcd Module
 
 
@@ -3486,7 +3486,7 @@ Bytes in non-idle span.
 [[exported-fields-graphite]]
 == graphite fields
 
-[]experimental
+experimental[]
 graphite Module
 
 

--- a/metricbeat/docs/modules/aerospike.asciidoc
+++ b/metricbeat/docs/modules/aerospike.asciidoc
@@ -5,6 +5,8 @@ This file is generated! See scripts/docs_collector.py
 [[metricbeat-module-aerospike]]
 == Aerospike module
 
+experimental[]
+
 The Aerospike module uses the http://www.aerospike.com/docs/reference/info[Info command] to collect metrics.
 
 [float]

--- a/metricbeat/docs/modules/dropwizard.asciidoc
+++ b/metricbeat/docs/modules/dropwizard.asciidoc
@@ -5,6 +5,8 @@ This file is generated! See scripts/docs_collector.py
 [[metricbeat-module-dropwizard]]
 == Dropwizard module
 
+beta[]
+
 This is the http://dropwizard.io[Dropwizard] module.
 
 

--- a/metricbeat/docs/modules/elasticsearch.asciidoc
+++ b/metricbeat/docs/modules/elasticsearch.asciidoc
@@ -5,6 +5,8 @@ This file is generated! See scripts/docs_collector.py
 [[metricbeat-module-elasticsearch]]
 == Elasticsearch module
 
+experimental[]
+
 The Elasticsearch module contains a minimal set of metrics to enable monitoring of Elasticsearch across multiple versions. To monitor more Elasticsearch metrics, use our {monitoringdoc}/xpack-monitoring.html[X-Pack monitoring] which is available under a free basic license.
 
 

--- a/metricbeat/docs/modules/golang.asciidoc
+++ b/metricbeat/docs/modules/golang.asciidoc
@@ -5,6 +5,8 @@ This file is generated! See scripts/docs_collector.py
 [[metricbeat-module-golang]]
 == Golang module
 
+experimental[]
+
 The golang module collects metrics by submitting HTTP GET requests to https://golang.org/pkg/expvar/[golang-expvar-api].
 
 

--- a/metricbeat/docs/modules/graphite.asciidoc
+++ b/metricbeat/docs/modules/graphite.asciidoc
@@ -5,6 +5,8 @@ This file is generated! See scripts/docs_collector.py
 [[metricbeat-module-graphite]]
 == graphite Module
 
+experimental[]
+
 This is the graphite Module.
 
 

--- a/metricbeat/docs/modules/http.asciidoc
+++ b/metricbeat/docs/modules/http.asciidoc
@@ -5,6 +5,8 @@ This file is generated! See scripts/docs_collector.py
 [[metricbeat-module-http]]
 == HTTP module
 
+beta[]
+
 The HTTP module is a Metricbeat module used to call arbitrary HTTP endpoints for which a dedicated Metricbeat module is not available.
 
 Multiple endpoints can be configured which are polled in a regular interval and the result is shipped to the configured output channel. It is recommended to install a Metricbeat instance on each host from which data should be fetched.

--- a/metricbeat/docs/modules/kibana.asciidoc
+++ b/metricbeat/docs/modules/kibana.asciidoc
@@ -5,6 +5,8 @@ This file is generated! See scripts/docs_collector.py
 [[metricbeat-module-kibana]]
 == Kibana module
 
+experimental[]
+
 The Kibana module only tracks the high-level metrics. To monitor more Kibana metrics, use our {monitoringdoc}/xpack-monitoring.html[X-Pack monitoring] which is available under a free basic license.
 
 

--- a/metricbeat/docs/modules/mongodb.asciidoc
+++ b/metricbeat/docs/modules/mongodb.asciidoc
@@ -5,6 +5,8 @@ This file is generated! See scripts/docs_collector.py
 [[metricbeat-module-mongodb]]
 == MongoDB module
 
+experimental[]
+
 This module periodically fetches metrics from https://www.mongodb.com[MongoDB]
 servers.
 

--- a/metricbeat/docs/modules/rabbitmq.asciidoc
+++ b/metricbeat/docs/modules/rabbitmq.asciidoc
@@ -5,6 +5,8 @@ This file is generated! See scripts/docs_collector.py
 [[metricbeat-module-rabbitmq]]
 == RabbitMQ module
 
+experimental[]
+
 The RabbitMQ module uses http://www.rabbitmq.com/management.html[HTTP API] created by the management plugin to collect metrics.
 
 

--- a/metricbeat/docs/modules/vsphere.asciidoc
+++ b/metricbeat/docs/modules/vsphere.asciidoc
@@ -5,6 +5,8 @@ This file is generated! See scripts/docs_collector.py
 [[metricbeat-module-vsphere]]
 == vSphere module
 
+experimental[]
+
 The vSphere module uses the https://github.com/vmware/govmomi[Govmomi] library to collect metrics from any Vmware SDK URL (ESXi/VCenter). This library is built for and tested against ESXi and vCenter 5.5, 6.0 and 6.5.
 
 

--- a/metricbeat/docs/modules/windows.asciidoc
+++ b/metricbeat/docs/modules/windows.asciidoc
@@ -5,6 +5,8 @@ This file is generated! See scripts/docs_collector.py
 [[metricbeat-module-windows]]
 == Windows module
 
+beta[]
+
 This is the Windows module.
 
 

--- a/metricbeat/module/aerospike/_meta/docs.asciidoc
+++ b/metricbeat/module/aerospike/_meta/docs.asciidoc
@@ -1,5 +1,7 @@
 == Aerospike module
 
+experimental[]
+
 The Aerospike module uses the http://www.aerospike.com/docs/reference/info[Info command] to collect metrics.
 
 [float]

--- a/metricbeat/module/ceph/cluster_disk/_meta/docs.asciidoc
+++ b/metricbeat/module/ceph/cluster_disk/_meta/docs.asciidoc
@@ -1,3 +1,5 @@
 === Ceph cluster_disk metricset
 
+experimental[]
+
 This is the `cluster_disk` metricset of the Ceph module.

--- a/metricbeat/module/ceph/cluster_health/_meta/docs.asciidoc
+++ b/metricbeat/module/ceph/cluster_health/_meta/docs.asciidoc
@@ -1,3 +1,5 @@
 === Ceph cluster_health metricset
 
+beta[]
+
 This is the `cluster_health` metricset of the Ceph module.

--- a/metricbeat/module/ceph/cluster_status/_meta/docs.asciidoc
+++ b/metricbeat/module/ceph/cluster_status/_meta/docs.asciidoc
@@ -1,3 +1,3 @@
-=== Ceph cluster_health metricset
+=== Ceph cluster_status metricset
 
 This is the `cluster_status` metricset of the Ceph module.

--- a/metricbeat/module/ceph/monitor_health/_meta/docs.asciidoc
+++ b/metricbeat/module/ceph/monitor_health/_meta/docs.asciidoc
@@ -1,3 +1,5 @@
 === Ceph monitor_health metricset
 
+beta[]
+
 This is the `monitor_health` metricset of the Ceph module.

--- a/metricbeat/module/ceph/pool_disk/_meta/docs.asciidoc
+++ b/metricbeat/module/ceph/pool_disk/_meta/docs.asciidoc
@@ -1,3 +1,5 @@
 === Ceph pool_disk metricset
 
+experimental[]
+
 This is the `pool_disk` metricset of the Ceph module.

--- a/metricbeat/module/dropwizard/_meta/docs.asciidoc
+++ b/metricbeat/module/dropwizard/_meta/docs.asciidoc
@@ -1,4 +1,6 @@
 == Dropwizard module
 
+beta[]
+
 This is the http://dropwizard.io[Dropwizard] module.
 

--- a/metricbeat/module/elasticsearch/_meta/docs.asciidoc
+++ b/metricbeat/module/elasticsearch/_meta/docs.asciidoc
@@ -1,3 +1,5 @@
 == Elasticsearch module
 
+experimental[]
+
 The Elasticsearch module contains a minimal set of metrics to enable monitoring of Elasticsearch across multiple versions. To monitor more Elasticsearch metrics, use our {monitoringdoc}/xpack-monitoring.html[X-Pack monitoring] which is available under a free basic license.

--- a/metricbeat/module/etcd/_meta/fields.yml
+++ b/metricbeat/module/etcd/_meta/fields.yml
@@ -1,7 +1,7 @@
 - key: etcd
   title: "Etcd"
   description: >
-    []experimental
+    experimental[]
 
     etcd Module
   fields:

--- a/metricbeat/module/golang/_meta/docs.asciidoc
+++ b/metricbeat/module/golang/_meta/docs.asciidoc
@@ -1,3 +1,5 @@
 == Golang module
 
+experimental[]
+
 The golang module collects metrics by submitting HTTP GET requests to https://golang.org/pkg/expvar/[golang-expvar-api].

--- a/metricbeat/module/graphite/_meta/docs.asciidoc
+++ b/metricbeat/module/graphite/_meta/docs.asciidoc
@@ -1,4 +1,6 @@
 == graphite Module
 
+experimental[]
+
 This is the graphite Module.
 

--- a/metricbeat/module/graphite/_meta/fields.yml
+++ b/metricbeat/module/graphite/_meta/fields.yml
@@ -1,7 +1,7 @@
 - key: graphite
   title: "graphite"
   description: >
-    []experimental
+    experimental[]
 
     graphite Module
   fields:

--- a/metricbeat/module/http/_meta/docs.asciidoc
+++ b/metricbeat/module/http/_meta/docs.asciidoc
@@ -1,5 +1,7 @@
 == HTTP module
 
+beta[]
+
 The HTTP module is a Metricbeat module used to call arbitrary HTTP endpoints for which a dedicated Metricbeat module is not available.
 
 Multiple endpoints can be configured which are polled in a regular interval and the result is shipped to the configured output channel. It is recommended to install a Metricbeat instance on each host from which data should be fetched.

--- a/metricbeat/module/kibana/_meta/docs.asciidoc
+++ b/metricbeat/module/kibana/_meta/docs.asciidoc
@@ -1,3 +1,5 @@
 == Kibana module
 
+experimental[]
+
 The Kibana module only tracks the high-level metrics. To monitor more Kibana metrics, use our {monitoringdoc}/xpack-monitoring.html[X-Pack monitoring] which is available under a free basic license.

--- a/metricbeat/module/kubernetes/container/_meta/docs.asciidoc
+++ b/metricbeat/module/kubernetes/container/_meta/docs.asciidoc
@@ -1,3 +1,5 @@
 === Kubernetes container metricset
 
+beta[]
+
 This is the `container` metricset of the Kubernetes module.

--- a/metricbeat/module/kubernetes/event/_meta/docs.asciidoc
+++ b/metricbeat/module/kubernetes/event/_meta/docs.asciidoc
@@ -1,3 +1,5 @@
 === Kubernetes event metricset
 
+experimental[]
+
 This is the `event` metricset of the Kubernetes module.

--- a/metricbeat/module/kubernetes/node/_meta/docs.asciidoc
+++ b/metricbeat/module/kubernetes/node/_meta/docs.asciidoc
@@ -1,3 +1,5 @@
 === Kubernetes node metricset
 
+beta[]
+
 This is the `node` metricset of the Kubernetes module.

--- a/metricbeat/module/kubernetes/pod/_meta/docs.asciidoc
+++ b/metricbeat/module/kubernetes/pod/_meta/docs.asciidoc
@@ -1,3 +1,5 @@
 === Kubernetes pod metricset
 
+beta[]
+
 This is the `pod` metricset of the Kubernetes module.

--- a/metricbeat/module/kubernetes/state_container/_meta/docs.asciidoc
+++ b/metricbeat/module/kubernetes/state_container/_meta/docs.asciidoc
@@ -1,3 +1,5 @@
 === Kubernetes state_container metricset
 
+beta[]
+
 This is the `state_container` metricset of the Kubernetes module.

--- a/metricbeat/module/kubernetes/state_deployment/_meta/docs.asciidoc
+++ b/metricbeat/module/kubernetes/state_deployment/_meta/docs.asciidoc
@@ -1,3 +1,5 @@
 === Kubernetes state_deployment metricset
 
+beta[]
+
 This is the `state_deployment` metricset of the Kubernetes module.

--- a/metricbeat/module/kubernetes/state_node/_meta/docs.asciidoc
+++ b/metricbeat/module/kubernetes/state_node/_meta/docs.asciidoc
@@ -1,3 +1,5 @@
 === Kubernetes state_node metricset
 
+beta[]
+
 This is the `state_node` metricset of the Kubernetes module.

--- a/metricbeat/module/kubernetes/state_pod/_meta/docs.asciidoc
+++ b/metricbeat/module/kubernetes/state_pod/_meta/docs.asciidoc
@@ -1,3 +1,5 @@
 === Kubernetes state_pod metricset
 
+beta[]
+
 This is the `state_pod` metricset of the Kubernetes module.

--- a/metricbeat/module/kubernetes/state_replicaset/_meta/docs.asciidoc
+++ b/metricbeat/module/kubernetes/state_replicaset/_meta/docs.asciidoc
@@ -1,3 +1,5 @@
 === Kubernetes state_replicaset metricset
 
+beta[]
+
 This is the `state_replicaset` metricset of the Kubernetes module.

--- a/metricbeat/module/kubernetes/system/_meta/docs.asciidoc
+++ b/metricbeat/module/kubernetes/system/_meta/docs.asciidoc
@@ -1,3 +1,5 @@
 === Kubernetes system metricset
 
+beta[]
+
 This is the `system` metricset of the Kubernetes module.

--- a/metricbeat/module/kubernetes/volume/_meta/docs.asciidoc
+++ b/metricbeat/module/kubernetes/volume/_meta/docs.asciidoc
@@ -1,3 +1,5 @@
 === Kubernetes volume metricset
 
+beta[]
+
 This is the `volume` metricset of the Kubernetes module.

--- a/metricbeat/module/mongodb/_meta/docs.asciidoc
+++ b/metricbeat/module/mongodb/_meta/docs.asciidoc
@@ -1,5 +1,7 @@
 == MongoDB module
 
+experimental[]
+
 This module periodically fetches metrics from https://www.mongodb.com[MongoDB]
 servers.
 

--- a/metricbeat/module/rabbitmq/_meta/docs.asciidoc
+++ b/metricbeat/module/rabbitmq/_meta/docs.asciidoc
@@ -1,4 +1,6 @@
 == RabbitMQ module
 
+experimental[]
+
 The RabbitMQ module uses http://www.rabbitmq.com/management.html[HTTP API] created by the management plugin to collect metrics.
 

--- a/metricbeat/module/vsphere/_meta/docs.asciidoc
+++ b/metricbeat/module/vsphere/_meta/docs.asciidoc
@@ -1,4 +1,6 @@
 == vSphere module
 
+experimental[]
+
 The vSphere module uses the https://github.com/vmware/govmomi[Govmomi] library to collect metrics from any Vmware SDK URL (ESXi/VCenter). This library is built for and tested against ESXi and vCenter 5.5, 6.0 and 6.5.
 

--- a/metricbeat/module/windows/_meta/docs.asciidoc
+++ b/metricbeat/module/windows/_meta/docs.asciidoc
@@ -1,3 +1,5 @@
 == Windows module
 
+beta[]
+
 This is the Windows module.


### PR DESCRIPTION
@monicasarbu I've updated docs to reflect the status of the modules shown here.

https://github.com/elastic/beats/issues/4579

A couple of questions: 
* should the ES module be flagged as experimental? beta?
* the list doesn't mention the aerospike or graphite modules. How should those be flagged? 

