### PR TITLE
Cherry-pick #5592 to 6.0: Fix sredis test container not starting up

### DIFF
--- a/testing/environments/docker/sredis/Dockerfile
+++ b/testing/environments/docker/sredis/Dockerfile
@@ -5,6 +5,10 @@ RUN apk add --no-cache stunnel
 COPY stunnel.conf /etc/stunnel/stunnel.conf
 COPY pki /etc/pki
 
+RUN chmod 600 /etc/stunnel/stunnel.conf; \
+	chmod 600 /etc/pki/tls/certs/*; \
+	chmod 600 /etc/pki/tls/private/*;
+
 HEALTHCHECK CMD nc -z localhost 6380
 EXPOSE 6380
 

--- a/testing/environments/docker/sredis/stunnel.conf
+++ b/testing/environments/docker/sredis/stunnel.conf
@@ -1,8 +1,7 @@
 foreground=yes
 
-cert=/etc/pki/tls/certs/sredis.crt
-key=/etc/pki/tls/private/sredis.key
-
 [redis]
-accept=6380
+accept=:::6380
 connect=redis:6379
+key=/etc/pki/tls/private/sredis.key
+cert=/etc/pki/tls/certs/sredis.crt


### PR DESCRIPTION
Cherry-pick of PR #5592 to 6.0 branch. Original message: 

Restrict permissions on certificate and key files

Explicitely use IPv6 port. IPv6 port should be accessible via IPv4 as well ->
- tell config to bind to ipv6 port
- does not require binding to a host