### PR TITLE
Cherry-pick #5567 to 6.0: Improve test stability

### DIFF
--- a/libbeat/tests/compose/compose.go
+++ b/libbeat/tests/compose/compose.go
@@ -147,9 +147,10 @@ func (c *composeProject) KillOld(except []string) error {
 	return nil
 }
 
-// Lock acquires the lock (30s) timeout
+// Lock acquires the lock (300s) timeout
+// Normally it should only be seconds that the lock is used, but in some cases it can take longer.
 func (c *composeProject) Lock() {
-	seconds := 30
+	seconds := 300
 	for seconds > 0 {
 		file, err := os.OpenFile(c.file+".lock", os.O_CREATE|os.O_EXCL, 0500)
 		file.Close()
@@ -163,7 +164,7 @@ func (c *composeProject) Lock() {
 	}
 
 	// This should rarely happen as we lock for start only, less than a second
-	panic(errors.New("Timeout waiting for lock, please remove docker-comose.yml.lock"))
+	panic(errors.New("Timeout waiting for lock, please remove docker-compose.yml.lock"))
 }
 
 func (c *composeProject) Unlock() {

--- a/metricbeat/module/dropwizard/collector/collector_integration_test.go
+++ b/metricbeat/module/dropwizard/collector/collector_integration_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestFetch(t *testing.T) {
-	compose.EnsureUp(t, "dropwizard")
+	compose.EnsureUpWithTimeout(t, 300, "dropwizard")
 
 	f := mbtest.NewEventsFetcher(t, getConfig())
 	events, err := f.Fetch()

--- a/metricbeat/module/kafka/partition/partition_integration_test.go
+++ b/metricbeat/module/kafka/partition/partition_integration_test.go
@@ -37,6 +37,7 @@ func TestData(t *testing.T) {
 }
 
 func TestTopic(t *testing.T) {
+	t.Skipf("Skip test as currently too flaky")
 	compose.EnsureUp(t, "kafka")
 
 	if testing.Verbose() {

--- a/metricbeat/module/kibana/status/status_integration_test.go
+++ b/metricbeat/module/kibana/status/status_integration_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestFetch(t *testing.T) {
-	compose.EnsureUpWithTimeout(t, 120, "elasticsearch", "kibana")
+	compose.EnsureUpWithTimeout(t, 600, "elasticsearch", "kibana")
 
 	f := mbtest.NewEventFetcher(t, getConfig())
 	event, err := f.Fetch()

--- a/metricbeat/tests/system/test_kafka.py
+++ b/metricbeat/tests/system/test_kafka.py
@@ -2,6 +2,7 @@ import os
 import metricbeat
 import unittest
 from nose.plugins.attrib import attr
+from nose.plugins.skip import SkipTest
 
 
 class Test(metricbeat.BaseTest):
@@ -13,6 +14,10 @@ class Test(metricbeat.BaseTest):
         """
         kafka partition metricset test
         """
+
+        # Currently skip test as it's too flaky
+        raise SkipTest
+
         self.create_topic()
 
         self.render_config_template(modules=[{


### PR DESCRIPTION
Cherry-pick of PR #5567 to 6.0 branch. Original message: 

Currently CI is constantly failing because of flaky Kafka and sometimes Kibana tests. This skips the Kafka tests for now and increases the timeout for the Kibana tests. This should make our CI builds useful again and not constantly red.

For Kafka a follow up PR is here to remove the test skipping again and make it more stable.