### PR TITLE
Cherry-pick #5200 to 6.0: Fix packetbeat flaky tests

### DIFF
--- a/packetbeat/beater/packetbeat.go
+++ b/packetbeat/beater/packetbeat.go
@@ -177,6 +177,12 @@ func (pb *packetbeat) Run(b *beat.Beat) error {
 	}()
 
 	defer pb.transPub.Stop()
+
+	timeout := pb.config.ShutdownTimeout
+	if timeout > 0 {
+		defer time.Sleep(timeout)
+	}
+
 	if pb.flows != nil {
 		pb.flows.Start()
 		defer pb.flows.Stop()
@@ -202,11 +208,6 @@ func (pb *packetbeat) Run(b *beat.Beat) error {
 	default:
 	case err := <-errC:
 		return err
-	}
-
-	timeout := pb.config.ShutdownTimeout
-	if timeout > 0 {
-		time.Sleep(timeout)
 	}
 
 	return nil


### PR DESCRIPTION
Cherry-pick of PR #5200 to 6.0 branch. Original message: 

Moved the shutdown timeout after stopping the flows, but before stopping
the transaction publishing. It needs to be after stopping the flows because
the tests rely on the shutdown sequence to create flow reports.