### PR TITLE
Cherry-pick #5549 to 6.0: Test new Kafka setup for more stable builds

### DIFF
--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -157,7 +157,8 @@ unit: ## @testing Runs the unit tests without coverage reports.
 integration-tests: ## @testing Run integration tests. Unit tests are run as part of the integration tests.
 integration-tests: prepare-tests
 	rm -f docker-compose.yml.lock
-	$(COVERAGE_TOOL) -tags=integration $(RACE) -coverprofile=${COVERAGE_DIR}/integration.cov  ${GOPACKAGES}
+	go test -i ${GOPACKAGES}
+	$(COVERAGE_TOOL) -tags=integration $(RACE) -coverprofile=${COVERAGE_DIR}/integration.cov ${GOPACKAGES}
 
 #
 .PHONY: integration-tests-environment

--- a/metricbeat/module/kafka/_meta/Dockerfile
+++ b/metricbeat/module/kafka/_meta/Dockerfile
@@ -1,9 +1,25 @@
-# TODO: No tags currently exist for this image. Tags should be used whever possible
-# as otherwise builds are not identical over time.
-FROM spotify/kafka
+FROM debian:stretch
 
-HEALTHCHECK --interval=1s --retries=90 CMD /opt/kafka_*/bin/kafka-topics.sh --zookeeper localhost:2181 --list
+ENV KAFKA_HOME /kafka
+# The advertised host is kafka. This means it will not work if container is started locally and connected from localhost to it
+ENV KAFKA_ADVERTISED_HOST kafka
+ENV KAFKA_LOGS_DIR="/kafka-logs"
+ENV KAFKA_VERSION 0.10.2.1
+ENV _JAVA_OPTIONS "-Djava.net.preferIPv4Stack=true"
+ENV TERM=linux
 
-EXPOSE 2181 9092
+RUN apt-get update && apt-get install -y curl openjdk-8-jre-headless netcat
 
-ENV ADVERTISED_HOST kafka
+RUN mkdir -p ${KAFKA_LOGS_DIR} && mkdir -p ${KAFKA_HOME} && curl -s -o $INSTALL_DIR/kafka.tgz \
+    "http://ftp.wayne.edu/apache/kafka/${KAFKA_VERSION}/kafka_2.11-${KAFKA_VERSION}.tgz" && \
+    tar xzf ${INSTALL_DIR}/kafka.tgz -C ${KAFKA_HOME} --strip-components 1
+
+ADD run.sh /run.sh
+
+EXPOSE 9092
+EXPOSE 2181
+
+# Healtcheck creates an empty topic foo. As soon as a topic is created, it assumes broke is available
+HEALTHCHECK --interval=1s --retries=90 CMD ${KAFKA_HOME}/bin/kafka-topics.sh --zookeeper=127.0.0.1:2181 --create --partitions 1 --topic "foo" --replication-factor 1
+
+ENTRYPOINT ["/run.sh"]

--- a/metricbeat/module/kafka/_meta/run.sh
+++ b/metricbeat/module/kafka/_meta/run.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+wait_for_port() {
+    count=20
+    port=$1
+    while ! nc -z localhost $port && [[ $count -ne 0 ]]; do
+        count=$(( $count - 1 ))
+        [[ $count -eq 0 ]] && return 1
+        sleep 0.5
+    done
+    # just in case, one more time
+    nc -z localhost $port
+}
+
+echo "Starting ZooKeeper"
+${KAFKA_HOME}/bin/zookeeper-server-start.sh ${KAFKA_HOME}/config/zookeeper.properties &
+wait_for_port 2181
+
+echo "Starting Kafka broker"
+mkdir -p ${KAFKA_LOGS_DIR}
+${KAFKA_HOME}/bin/kafka-server-start.sh ${KAFKA_HOME}/config/server.properties \
+    --override delete.topic.enable=true --override advertised.host.name=${KAFKA_ADVERTISED_HOST} \
+    --override listeners=PLAINTEXT://0.0.0.0:9092 \
+    --override logs.dir=${KAFKA_LOGS_DIR} --override log.flush.interval.ms=200 &
+
+wait_for_port 9092
+
+echo "Kafka load status code $?"
+
+# Make sure the container keeps running
+tail -f /dev/null

--- a/metricbeat/module/kafka/partition/partition_integration_test.go
+++ b/metricbeat/module/kafka/partition/partition_integration_test.go
@@ -37,7 +37,7 @@ func TestData(t *testing.T) {
 }
 
 func TestTopic(t *testing.T) {
-	t.Skipf("Skip test as currently too flaky")
+
 	compose.EnsureUp(t, "kafka")
 
 	if testing.Verbose() {
@@ -108,6 +108,11 @@ func generateKafkaData(t *testing.T, topic string) {
 
 	config := sarama.NewConfig()
 	config.Producer.Return.Successes = true
+	// Retry for 10 seconds
+	config.Producer.Retry.Max = 20
+	config.Producer.Retry.Backoff = 500 * time.Millisecond
+	config.Metadata.Retry.Max = 20
+	config.Metadata.Retry.Backoff = 500 * time.Millisecond
 	client, err := sarama.NewClient([]string{getTestKafkaHost()}, config)
 	if err != nil {
 		t.Errorf("%s", err)

--- a/metricbeat/tests/system/test_kafka.py
+++ b/metricbeat/tests/system/test_kafka.py
@@ -15,9 +15,6 @@ class Test(metricbeat.BaseTest):
         kafka partition metricset test
         """
 
-        # Currently skip test as it's too flaky
-        raise SkipTest
-
         self.create_topic()
 
         self.render_config_template(modules=[{
@@ -38,8 +35,11 @@ class Test(metricbeat.BaseTest):
         self.assert_fields_are_documented(evt)
 
     def create_topic(self):
+
         from kafka import KafkaProducer
-        producer = KafkaProducer(bootstrap_servers=self.get_hosts()[0])
+
+        producer = KafkaProducer(bootstrap_servers=self.get_hosts()[
+            0], retries=20, retry_backoff_ms=500, api_version=("0.10"))
         producer.send('foobar', b'some_message_bytes')
 
     def get_hosts(self):


### PR DESCRIPTION
Cherry-pick of PR #5549 to 6.0 branch. Original message: 

* Use Docker image from Logstash team. This allows us to specify the exact version on Kafka which is tested and be in control of the image.
* Use healthcheck which creates a random topic to make sure broker is available
* Change config options in golang and python tests to make sure sending events is retried
* Fix version in python to a specific kafka version which is in sync with the docker image