### PR TITLE
Update kafka container for output tests

### DIFF
--- a/testing/environments/docker/kafka/Dockerfile
+++ b/testing/environments/docker/kafka/Dockerfile
@@ -1,3 +1,25 @@
-FROM spotify/kafka
-RUN apt-get update && apt-get install -y netcat
-HEALTHCHECK CMD nc -z localhost 9092
+FROM debian:stretch
+
+ENV KAFKA_HOME /kafka
+# The advertised host is kafka. This means it will not work if container is started locally and connected from localhost to it
+ENV KAFKA_ADVERTISED_HOST kafka
+ENV KAFKA_LOGS_DIR="/kafka-logs"
+ENV KAFKA_VERSION 0.10.2.1
+ENV _JAVA_OPTIONS "-Djava.net.preferIPv4Stack=true"
+ENV TERM=linux
+
+RUN apt-get update && apt-get install -y curl openjdk-8-jre-headless netcat
+
+RUN mkdir -p ${KAFKA_LOGS_DIR} && mkdir -p ${KAFKA_HOME} && curl -s -o $INSTALL_DIR/kafka.tgz \
+    "http://ftp.wayne.edu/apache/kafka/${KAFKA_VERSION}/kafka_2.11-${KAFKA_VERSION}.tgz" && \
+    tar xzf ${INSTALL_DIR}/kafka.tgz -C ${KAFKA_HOME} --strip-components 1
+
+ADD run.sh /run.sh
+
+EXPOSE 9092
+EXPOSE 2181
+
+# Healtcheck creates an empty topic foo. As soon as a topic is created, it assumes broke is available
+HEALTHCHECK --interval=1s --retries=90 CMD ${KAFKA_HOME}/bin/kafka-topics.sh --zookeeper=127.0.0.1:2181 --create --partitions 1 --topic "foo" --replication-factor 1
+
+ENTRYPOINT ["/run.sh"]

--- a/testing/environments/docker/kafka/Dockerfile
+++ b/testing/environments/docker/kafka/Dockerfile
@@ -15,11 +15,12 @@ RUN mkdir -p ${KAFKA_LOGS_DIR} && mkdir -p ${KAFKA_HOME} && curl -s -o $INSTALL_
     tar xzf ${INSTALL_DIR}/kafka.tgz -C ${KAFKA_HOME} --strip-components 1
 
 ADD run.sh /run.sh
+ADD healthcheck.sh /healthcheck.sh
 
 EXPOSE 9092
 EXPOSE 2181
 
 # Healtcheck creates an empty topic foo. As soon as a topic is created, it assumes broke is available
-HEALTHCHECK --interval=1s --retries=90 CMD ${KAFKA_HOME}/bin/kafka-topics.sh --zookeeper=127.0.0.1:2181 --create --partitions 1 --topic "foo" --replication-factor 1
+HEALTHCHECK --interval=1s --retries=90 CMD /healthcheck.sh
 
 ENTRYPOINT ["/run.sh"]

--- a/testing/environments/docker/kafka/healthcheck.sh
+++ b/testing/environments/docker/kafka/healthcheck.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+TOPIC="foo-`date '+%s-%N'`"
+
+${KAFKA_HOME}/bin/kafka-topics.sh --zookeeper=127.0.0.1:2181 --create --partitions 1 --topic "${TOPIC}" --replication-factor 1
+rc=$?
+if [[ $rc != 0 ]]; then
+	exit $rc
+fi
+
+${KAFKA_HOME}/bin/kafka-topic.sh --zookeeper=127.0.0.1:2181 --delete --topic "${TOPIC}"
+exit 0

--- a/testing/environments/docker/kafka/run.sh
+++ b/testing/environments/docker/kafka/run.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+wait_for_port() {
+    count=20
+    port=$1
+    while ! nc -z localhost $port && [[ $count -ne 0 ]]; do
+        count=$(( $count - 1 ))
+        [[ $count -eq 0 ]] && return 1
+        sleep 0.5
+    done
+    # just in case, one more time
+    nc -z localhost $port
+}
+
+echo "Starting ZooKeeper"
+${KAFKA_HOME}/bin/zookeeper-server-start.sh ${KAFKA_HOME}/config/zookeeper.properties &
+wait_for_port 2181
+
+echo "Starting Kafka broker"
+mkdir -p ${KAFKA_LOGS_DIR}
+${KAFKA_HOME}/bin/kafka-server-start.sh ${KAFKA_HOME}/config/server.properties \
+    --override delete.topic.enable=true --override advertised.host.name=${KAFKA_ADVERTISED_HOST} \
+    --override listeners=PLAINTEXT://0.0.0.0:9092 \
+    --override logs.dir=${KAFKA_LOGS_DIR} --override log.flush.interval.ms=200 &
+
+wait_for_port 9092
+
+echo "Kafka load status code $?"
+
+# Make sure the container keeps running
+tail -f /dev/null


### PR DESCRIPTION
- based on container used by LS (as done in #5549)
- Use healthcheck which creates a random topic to make sure broker is available

metricbeat module tests and testing/environment (only used by libbeat?) each have their own docker setup for common services. This PR copies the container setup from metricbeat. At some point we should see if we can reuse some of the complex container setups like kafka.