### PR TITLE
Fix repo steps in the Beats platform ref

### DIFF
--- a/libbeat/docs/index.asciidoc
+++ b/libbeat/docs/index.asciidoc
@@ -21,6 +21,7 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :LS-version: {stack-version}
 :Kibana-version: {stack-version}
 :dashboards: https://artifacts.elastic.co/downloads/beats/beats-dashboards/beats-dashboards-{stack-version}.zip
+:beatname_pkg: {beatname_lc}
 
 include::./overview.asciidoc[]
 


### PR DESCRIPTION
This PR fixes an issue where the steps for installing from the repositories were not showing up in the Beats platform ref.

Why did this happen? The `beatname_pkg` attribute was introduced, but never included in libbeat. When asciidoc finds an attribute it cannot resolve, it omits the entire line on which the attribute appears.

I plan to move all the Beats attributes to the [shared file](https://github.com/elastic/docs/tree/master/shared) in the docs repo but have not done that yet because it requires some rework to make our attribute names consistent with other books in the library. The shared file is relatively new, so there are still other projects that are not using it yet.

