### PR TITLE
Remove ingest node directions from metricbeat docs

### DIFF
--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -223,7 +223,11 @@ output.elasticsearch:
   pipeline: my_pipeline_id
 ------------------------------------------------------------------------------
 
+ifeval::["{beatname_lc}"!="metricbeat"]
+
 For more information, see <<configuring-ingest-node>>.
+
+endif::[]
 
 ===== `pipelines`
 

--- a/metricbeat/docs/configuring-howto.asciidoc
+++ b/metricbeat/docs/configuring-howto.asciidoc
@@ -26,7 +26,6 @@ The following topics describe how to configure Metricbeat:
 * <<configuring-output>>
 * <<configuration-ssl>>
 * <<filtering-and-enhancing-data>>
-* <<configuring-ingest-node>>
 * <<configuration-path>>
 * <<setup-kibana-endpoint>>
 * <<configuration-dashboards>>
@@ -53,8 +52,6 @@ include::../../libbeat/docs/outputconfig.asciidoc[]
 include::../../libbeat/docs/shared-ssl-config.asciidoc[]
 
 include::./metricbeat-filtering.asciidoc[]
-
-include::../../libbeat/docs/shared-config-ingest.asciidoc[]
 
 include::../../libbeat/docs/shared-path-config.asciidoc[]
 


### PR DESCRIPTION
@monicasarbu  pointed out that it doesn't make sense to use ingest node with Metricbeat, so this PR removes the shared topic from the Metricbeat docs. 