### PR TITLE
Fix logstash defaults in output documentation

### DIFF
--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -447,7 +447,7 @@ output.logstash:
 Configures number of batches to be sent asynchronously to logstash while waiting
 for ACK from logstash. Output only becomes blocking once number of `pipelining`
 batches have been written. Pipelining is disabled if a values of 0 is
-configured. The default value is 0.
+configured. The default value is 5.
 
 [[port]]
 ===== `port`


### PR DESCRIPTION
With 6.0 the default pipeline setting is 5, not 0.

The reference config files already use the correct value.