### PR TITLE
Fix generator tests

### DIFF
--- a/generator/beat/{beat}/Makefile
+++ b/generator/beat/{beat}/Makefile
@@ -5,7 +5,7 @@ BEAT_URL=https://${BEAT_PATH}
 SYSTEM_TESTS=false
 TEST_ENVIRONMENT=false
 ES_BEATS?=./vendor/github.com/elastic/beats
-GOPACKAGES=$(shell govendor list +local)
+GOPACKAGES=$(shell govendor list -no-status +local)
 PREFIX?=.
 NOTICE_FILE=NOTICE
 

--- a/generator/beat/{beat}/beater/{beat}.go.tmpl
+++ b/generator/beat/{beat}/beater/{beat}.go.tmpl
@@ -52,8 +52,8 @@ func (bt *{Beat}) Run(b *beat.Beat) error {
 		event := beat.Event{
 			Timestamp: time.Now(),
 			Fields: common.MapStr{
-				"type":       b.Info.Name,
-				"counter":    counter,
+				"type":    b.Info.Name,
+				"counter": counter,
 			},
 		}
 		bt.client.Publish(event)

--- a/generator/common/Makefile
+++ b/generator/common/Makefile
@@ -13,14 +13,14 @@ test: prepare-test
 	export GOPATH=${PWD}/build ; \
 	export PATH=${PATH}:${PWD}/build/bin; \
 	cd ${BEAT_PATH} ; \
-	make copy-vendor ; \
-	${PREPARE_COMMAND}  \
-	make check ; \
-	make update ; \
-	make ; \
+	make copy-vendor || exit 1  ; \
+	${PREPARE_COMMAND} \
+	make check || exit 1 ; \
+	make update || exit 1 ; \
+	make || exit 1 ; \
 	make unit
 
-prepare-test: python-env
+prepare-test:: python-env
 	# Makes sure to use current version of beats for testing
 	mkdir -p ${BUILD_DIR}/src/github.com/elastic/beats/
 	rsync -a --exclude=build ${PWD}/../../* ${BUILD_DIR}/src/github.com/elastic/beats/

--- a/generator/metricbeat/Makefile
+++ b/generator/metricbeat/Makefile
@@ -3,12 +3,7 @@ PREPARE_COMMAND=MODULE=elastic METRICSET=test make create-metricset ;
 
 include ../common/Makefile
 
-prepare-test: python-env
-	mkdir -p ${BUILD_DIR}/src/github.com/elastic/beats/
-	rsync -a --exclude=build ${PWD}/../../* ${BUILD_DIR}/src/github.com/elastic/beats/
+prepare-test:: python-env
 
 	mkdir -p ${BEAT_PATH}/scripts
 	rsync -a --exclude=build ${PWD}/../../metricbeat/scripts/generate_imports_helper.py ${BEAT_PATH}/scripts
-
-	export GOPATH=${PWD}/build ; \
-	. ${PYTHON_ENV}/bin/activate && python ${PWD}/build/src/github.com/elastic/beats/script/generate.py --type=${BEAT_TYPE} --project_name=Testbeat --github_name=ruflin --beat_path=beatpath/testbeat --full_name="Nicolas Ruflin"

--- a/generator/metricbeat/{beat}/Makefile
+++ b/generator/metricbeat/{beat}/Makefile
@@ -4,7 +4,7 @@ BEAT_URL=https://${BEAT_PATH}
 SYSTEM_TESTS=false
 TEST_ENVIRONMENT=false
 ES_BEATS?=./vendor/github.com/elastic/beats
-GOPACKAGES=$(shell govendor list +local)
+GOPACKAGES=$(shell govendor list -no-status +local)
 PREFIX?=.
 NOTICE_FILE=NOTICE
 


### PR DESCRIPTION
* Remove issues that tests were failing but still were green by adding exit part
* Make it possible to have multiple prepare-tests to not have errors for metricbeat tests
* Fix fmt problem in beat
* Clean up redundant Makefile commands

Closes https://github.com/elastic/beats/issues/5550