### PR TITLE
Backout deb fpm changes

### DIFF
--- a/dev-tools/packer/platforms/debian/run.sh.j2
+++ b/dev-tools/packer/platforms/debian/run.sh.j2
@@ -7,6 +7,10 @@ cd /build
 # the init scripts needs to have the right name
 cp ${RUNID}.init /tmp/{{.beat_pkg_name}}.init
 
+# create script to reload systemd config
+echo "#!/bin/bash" > /tmp/systemd-daemon-reload.sh
+echo "systemctl daemon-reload 2> /dev/null || true" >> /tmp/systemd-daemon-reload.sh
+
 # add SNAPSHOT if it was requested
 VERSION="{{.version}}"
 if [ "$SNAPSHOT" = "yes" ]; then
@@ -23,7 +27,7 @@ FPM_ARGS=(
         --description "{{.beat_description}}"
         --url {{.beat_url}}
         --deb-init /tmp/{{.beat_pkg_name}}.init
-        --deb-systemd ${RUNID}.service
+        --after-install /tmp/systemd-daemon-reload.sh
         --config-files /etc/{{.beat_name}}/{{.beat_name}}.yml
         homedir/=/usr/share/{{.beat_name}}
         beatname-${RUNID}.sh=/usr/bin/{{.beat_name}}
@@ -31,6 +35,7 @@ FPM_ARGS=(
         {{.beat_name}}-linux.yml=/etc/{{.beat_name}}/{{.beat_name}}.yml
         {{.beat_name}}-linux.reference.yml=/etc/{{.beat_name}}/{{.beat_name}}.reference.yml
         fields.yml=/etc/{{.beat_name}}/fields.yml
+        ${RUNID}.service=/lib/systemd/system/{{.beat_pkg_name}}.service
         god-linux-{{.arch}}=/usr/share/{{.beat_name}}/bin/{{.beat_name}}-god
   )
 

--- a/dev-tools/packer/platforms/debian/run.sh.j2
+++ b/dev-tools/packer/platforms/debian/run.sh.j2
@@ -4,9 +4,8 @@
 set -e
 cd /build
 
-# the init script and systemd unit file need to have the right name
+# the init scripts needs to have the right name
 cp ${RUNID}.init /tmp/{{.beat_pkg_name}}.init
-cp ${RUNID}.service /tmp/{{.beat_pkg_name}}.service
 
 # add SNAPSHOT if it was requested
 VERSION="{{.version}}"
@@ -24,7 +23,7 @@ FPM_ARGS=(
         --description "{{.beat_description}}"
         --url {{.beat_url}}
         --deb-init /tmp/{{.beat_pkg_name}}.init
-        --deb-systemd /tmp/{{.beat_pkg_name}}.service
+        --deb-systemd ${RUNID}.service
         --config-files /etc/{{.beat_name}}/{{.beat_name}}.yml
         homedir/=/usr/share/{{.beat_name}}
         beatname-${RUNID}.sh=/usr/bin/{{.beat_name}}


### PR DESCRIPTION
This backouts changes in #5086 and #5174. From testing the resulting packages it turns out that after that change the post-rm and pre-install scripts are significantly different. This results in at least one change in behaviour: the service is started automatically at install time, which is not the case in 6.0. There could be more changes in behaviour as well, so I'd like to play it safe and backout the changes for now.

Closes #5477.