### PR TITLE
Fix for #5644 - Clone from github caused build_before to fail

### DIFF
--- a/dev-tools/packer/docker/xgo-image/base/build.sh
+++ b/dev-tools/packer/docker/xgo-image/base/build.sh
@@ -50,6 +50,7 @@ if [ "$SOURCE" != "" ]; then
 else
         mkdir -p $GOPATH/src/${GIT_REPO}
         cd $GOPATH/src/${GIT_REPO}
+	cd ..
         echo "Fetching main git repository ${GIT_REPO} in folder $GOPATH/src/${GIT_REPO}"
         git clone https://${GIT_REPO}.git
 fi


### PR DESCRIPTION
The clone from Githup repo (when source == '') goes into $GOPATH/src/${GIT_REPO} which is beats folder. It should be rather at github.com/elastic folder.
This bug causes the build_before.sh to fail during Make.