### PR TITLE
Use local timezone for TZ conversion in the FB system module

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -111,6 +111,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Add Kubernetes manifests to deploy Filebeat. {pull}5349[5349]
 - Add experimental Docker `json-file` prospector . {pull}5402[5402]
 - Add experimental Docker autodiscover functionality. {pull}5245[5245]
+- Add option to convert the timestamps to UTC in the system module. {pull}5647[5647]
 
 *Heartbeat*
 

--- a/filebeat/docs/include/var-convert-timezone.asciidoc
+++ b/filebeat/docs/include/var-convert-timezone.asciidoc
@@ -1,0 +1,8 @@
+*`var.convert_timezone`*::
+
+If this option is enabled, Filebeat reads the local timezone and uses it at log
+parsing time to convert the timestamp to UTC. The local timezone is also added
+in each event in a dedicated field (`beat.timezone`). The conversion is only
+possible in Elasticsearch >= 6.1. If the Elasticsearch version is less than 6.1,
+the `beat.timezone` field is added, but the conversion to UTC is not made.  The
+default is `false`.

--- a/filebeat/docs/modules/system.asciidoc
+++ b/filebeat/docs/modules/system.asciidoc
@@ -33,7 +33,7 @@ image::./images/kibana-system.png[]
 include::../include/configuring-intro.asciidoc[]
 
 The following example shows how to set paths in the +modules.d/{modulename}.yml+
-file to override the default paths for the syslog and authorization logs: 
+file to override the default paths for the syslog and authorization logs:
 
 ["source","yaml",subs="attributes"]
 -----
@@ -55,7 +55,7 @@ To specify the same settings at the command line, you use:
 -----
 
 
-The command in the example assumes that you have already enabled the +{modulename}+ module. 
+The command in the example assumes that you have already enabled the +{modulename}+ module.
 
 //set the fileset name used in the included example
 :fileset_ex: syslog
@@ -67,6 +67,16 @@ include::../include/config-option-intro.asciidoc[]
 ==== `syslog` fileset settings
 
 include::../include/var-paths.asciidoc[]
+
+include::../include/var-convert-timezone.asciidoc[]
+
+[float]
+==== `auth` fileset settings
+
+include::../include/var-paths.asciidoc[]
+
+include::../include/var-convert-timezone.asciidoc[]
+
 
 
 

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -21,6 +21,9 @@ filebeat.modules:
     # Filebeat will choose the paths depending on your OS.
     #var.paths:
 
+    # Convert the timestamp to UTC. Requires Elasticsearch >= 6.1.
+    #convert_timezone: false
+
     # Prospector configuration (advanced). Any prospector configuration option
     # can be added under this section.
     #prospector:
@@ -32,6 +35,9 @@ filebeat.modules:
     # Set custom paths for the log files. If left empty,
     # Filebeat will choose the paths depending on your OS.
     #var.paths:
+
+    # Convert the timestamp to UTC. Requires Elasticsearch >= 6.1.
+    #convert_timezone: false
 
     # Prospector configuration (advanced). Any prospector configuration option
     # can be added under this section.

--- a/filebeat/fileset/fileset.go
+++ b/filebeat/fileset/fileset.go
@@ -164,7 +164,6 @@ func (fs *Fileset) evaluateVars() (map[string]interface{}, error) {
 // turnOffElasticsearchVars re-evaluates the variables that have `min_elasticsearch_version`
 // set.
 func (fs *Fileset) turnOffElasticsearchVars(vars map[string]interface{}, esVersion string) (map[string]interface{}, error) {
-
 	retVars := map[string]interface{}{}
 	for key, val := range vars {
 		retVars[key] = val
@@ -176,20 +175,20 @@ func (fs *Fileset) turnOffElasticsearchVars(vars map[string]interface{}, esVersi
 	}
 
 	for _, vals := range fs.manifest.Vars {
-		var exists bool
-		name, exists := vals["name"].(string)
-		if !exists {
+		var ok bool
+		name, ok := vals["name"].(string)
+		if !ok {
 			return nil, fmt.Errorf("Variable doesn't have a string 'name' key")
 		}
 
-		minESVersion, exists := vals["min_elasticsearch_version"].(map[string]interface{})
-		if exists {
+		minESVersion, ok := vals["min_elasticsearch_version"].(map[string]interface{})
+		if ok {
 			minVersion, err := common.NewVersion(minESVersion["version"].(string))
 			if err != nil {
 				return vars, fmt.Errorf("Error parsing version %s: %v", minESVersion["version"].(string), err)
 			}
 
-			logp.Debug("fileset", "Comparing ES version %s with %s", haveVersion, minVersion)
+			logp.Debug("fileset", "Comparing ES version %s with requirement of %s", haveVersion, minVersion)
 
 			if haveVersion.LessThan(minVersion) {
 				retVars[name] = minESVersion["value"]
@@ -331,7 +330,6 @@ func (fs *Fileset) getPipelineID(beatVersion string) (string, error) {
 
 // GetPipeline returns the JSON content of the Ingest Node pipeline that parses the logs.
 func (fs *Fileset) GetPipeline(esVersion string) (pipelineID string, content map[string]interface{}, err error) {
-
 	path, err := applyTemplate(fs.vars, fs.manifest.IngestPipeline, false)
 	if err != nil {
 		return "", nil, fmt.Errorf("Error expanding vars on the ingest pipeline path: %v", err)

--- a/filebeat/fileset/fileset.go
+++ b/filebeat/fileset/fileset.go
@@ -52,6 +52,11 @@ func New(
 	}, nil
 }
 
+// String returns the module and the name of the fileset.
+func (fs *Fileset) String() string {
+	return fs.mcfg.Module + "/" + fs.name
+}
+
 // Read reads the manifest file and evaluates the variables.
 func (fs *Fileset) Read(beatVersion string) error {
 	var err error
@@ -188,7 +193,7 @@ func (fs *Fileset) turnOffElasticsearchVars(vars map[string]interface{}, esVersi
 
 			if haveVersion.LessThan(minVersion) {
 				retVars[name] = minESVersion["value"]
-				logp.Info("Setting var %s to %v because Elasticsearch version is %s", name, minESVersion["value"], haveVersion)
+				logp.Info("Setting var %s (%s) to %v because Elasticsearch version is %s", name, fs, minESVersion["value"], haveVersion)
 			}
 		}
 	}
@@ -324,6 +329,7 @@ func (fs *Fileset) getPipelineID(beatVersion string) (string, error) {
 	return formatPipelineID(fs.mcfg.Module, fs.name, path, beatVersion), nil
 }
 
+// GetPipeline returns the JSON content of the Ingest Node pipeline that parses the logs.
 func (fs *Fileset) GetPipeline(esVersion string) (pipelineID string, content map[string]interface{}, err error) {
 
 	path, err := applyTemplate(fs.vars, fs.manifest.IngestPipeline, false)

--- a/filebeat/fileset/modules.go
+++ b/filebeat/fileset/modules.go
@@ -278,7 +278,7 @@ func (reg *ModuleRegistry) LoadPipelines(esClient PipelineLoader) error {
 				}
 			}
 
-			pipelineID, content, err := fileset.GetPipeline()
+			pipelineID, content, err := fileset.GetPipeline(esClient.GetVersion())
 			if err != nil {
 				return fmt.Errorf("Error getting pipeline for fileset %s/%s: %v", module, name, err)
 			}

--- a/filebeat/module/system/_meta/config.reference.yml
+++ b/filebeat/module/system/_meta/config.reference.yml
@@ -7,6 +7,9 @@
     # Filebeat will choose the paths depending on your OS.
     #var.paths:
 
+    # Convert the timestamp to UTC. Requires Elasticsearch >= 6.1.
+    #convert_timezone: false
+
     # Prospector configuration (advanced). Any prospector configuration option
     # can be added under this section.
     #prospector:
@@ -18,6 +21,9 @@
     # Set custom paths for the log files. If left empty,
     # Filebeat will choose the paths depending on your OS.
     #var.paths:
+
+    # Convert the timestamp to UTC. Requires Elasticsearch >= 6.1.
+    #convert_timezone: false
 
     # Prospector configuration (advanced). Any prospector configuration option
     # can be added under this section.

--- a/filebeat/module/system/_meta/config.yml
+++ b/filebeat/module/system/_meta/config.yml
@@ -7,6 +7,9 @@
     # Filebeat will choose the paths depending on your OS.
     #var.paths:
 
+    # Convert the timestamp to UTC. Requires Elasticsearch >= 6.1.
+    #convert_timezone: false
+
   # Authorization logs
   auth:
     enabled: true
@@ -14,3 +17,6 @@
     # Set custom paths for the log files. If left empty,
     # Filebeat will choose the paths depending on your OS.
     #var.paths:
+
+    # Convert the timestamp to UTC. Requires Elasticsearch >= 6.1.
+    #convert_timezone: false

--- a/filebeat/module/system/_meta/docs.asciidoc
+++ b/filebeat/module/system/_meta/docs.asciidoc
@@ -28,7 +28,7 @@ image::./images/kibana-system.png[]
 include::../include/configuring-intro.asciidoc[]
 
 The following example shows how to set paths in the +modules.d/{modulename}.yml+
-file to override the default paths for the syslog and authorization logs: 
+file to override the default paths for the syslog and authorization logs:
 
 ["source","yaml",subs="attributes"]
 -----
@@ -50,7 +50,7 @@ To specify the same settings at the command line, you use:
 -----
 
 
-The command in the example assumes that you have already enabled the +{modulename}+ module. 
+The command in the example assumes that you have already enabled the +{modulename}+ module.
 
 //set the fileset name used in the included example
 :fileset_ex: syslog
@@ -62,4 +62,14 @@ include::../include/config-option-intro.asciidoc[]
 ==== `syslog` fileset settings
 
 include::../include/var-paths.asciidoc[]
+
+include::../include/var-convert-timezone.asciidoc[]
+
+[float]
+==== `auth` fileset settings
+
+include::../include/var-paths.asciidoc[]
+
+include::../include/var-convert-timezone.asciidoc[]
+
 

--- a/filebeat/module/system/auth/config/auth.yml
+++ b/filebeat/module/system/auth/config/auth.yml
@@ -7,3 +7,7 @@ exclude_files: [".gz$"]
 multiline:
   pattern: "^\\s"
   match: after
+{{ if .convert_timezone }}
+processors:
+- add_locale: ~
+{{ end }}

--- a/filebeat/module/system/auth/ingest/pipeline.json
+++ b/filebeat/module/system/auth/ingest/pipeline.json
@@ -32,6 +32,7 @@
 					"MMM  d HH:mm:ss",
 					"MMM dd HH:mm:ss"
         ],
+        {% if .convert_timezone %}"timezone": "{{ beat.timezone }}",{% end %}
         "ignore_failure": true
       }
     },

--- a/filebeat/module/system/auth/manifest.yml
+++ b/filebeat/module/system/auth/manifest.yml
@@ -10,6 +10,13 @@ var:
       # ssh logs to files
       - /var/log/secure.log*
     os.windows: []
+  - name: convert_timezone
+    default: false
+    # if ES < 6.1.0, this flag switches to false automatically when evaluating the
+    # pipeline
+    min_elasticsearch_version:
+      version: 6.1.0
+      value: false
 
 ingest_pipeline: ingest/pipeline.json
 prospector: config/auth.yml

--- a/filebeat/module/system/syslog/config/syslog.yml
+++ b/filebeat/module/system/syslog/config/syslog.yml
@@ -7,3 +7,7 @@ exclude_files: [".gz$"]
 multiline:
   pattern: "^\\s"
   match: after
+{{ if .convert_timezone }}
+processors:
+- add_locale: ~
+{{ end }}

--- a/filebeat/module/system/syslog/ingest/pipeline.json
+++ b/filebeat/module/system/syslog/ingest/pipeline.json
@@ -19,7 +19,7 @@
         "field": "message"
       }
     },
-		{
+    {
       "date": {
         "field": "system.syslog.timestamp",
         "target_field": "@timestamp",
@@ -27,9 +27,10 @@
 					"MMM  d HH:mm:ss",
 					"MMM dd HH:mm:ss"
         ],
+        {% if .convert_timezone %}"timezone": "{{ beat.timezone }}",{% end %}
         "ignore_failure": true
       }
-		}
+    }
 	],
   "on_failure" : [{
     "set" : {

--- a/filebeat/module/system/syslog/manifest.yml
+++ b/filebeat/module/system/syslog/manifest.yml
@@ -10,6 +10,11 @@ var:
     os.windows: []
   - name: convert_timezone
     default: false
+    # if ES < 6.1.0, this flag switches to false automatically when evaluating the
+    # pipeline
+    min_elasticsearch_version:
+      version: 6.1.0
+      value: false
 
 ingest_pipeline: ingest/pipeline.json
 prospector: config/syslog.yml

--- a/filebeat/module/system/syslog/manifest.yml
+++ b/filebeat/module/system/syslog/manifest.yml
@@ -8,6 +8,8 @@ var:
     os.darwin:
       - /var/log/system.log*
     os.windows: []
+  - name: convert_timezone
+    default: false
 
 ingest_pipeline: ingest/pipeline.json
 prospector: config/syslog.yml

--- a/filebeat/modules.d/system.yml.disabled
+++ b/filebeat/modules.d/system.yml.disabled
@@ -7,6 +7,9 @@
     # Filebeat will choose the paths depending on your OS.
     #var.paths:
 
+    # Convert the timestamp to UTC. Requires Elasticsearch >= 6.1.
+    #convert_timezone: false
+
   # Authorization logs
   auth:
     enabled: true
@@ -14,3 +17,6 @@
     # Set custom paths for the log files. If left empty,
     # Filebeat will choose the paths depending on your OS.
     #var.paths:
+
+    # Convert the timestamp to UTC. Requires Elasticsearch >= 6.1.
+    #convert_timezone: false

--- a/testing/environments/latest.yml
+++ b/testing/environments/latest.yml
@@ -3,7 +3,7 @@
 version: '2.1'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:6.0.0-rc2
+    image: docker.elastic.co/elasticsearch/elasticsearch:6.0.0
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9200"]
     environment:
@@ -18,13 +18,13 @@ services:
       context: docker/logstash
       dockerfile: Dockerfile
       args:
-        ELASTIC_VERSION: 6.0.0-rc2
+        ELASTIC_VERSION: 6.0.0
         DOWNLOAD_URL: https://artifacts.elastic.co/downloads
     environment:
       - ES_HOST=elasticsearch
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:6.0.0-rc2
+    image: docker.elastic.co/kibana/kibana:6.0.0
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:5601"]
       retries: 6


### PR DESCRIPTION
This adds a `convert_timezone` fileset parameter that, when enabled,
does two things:

* Uses the `add_locale` processor in the FB proespector config
* Uses `{{ beat.timezone }}` as the `timezone` parameter for the
  date processor in the Ingest Node pipeline. This parameter accepts
  templates starting with ES 6.1.

For the moment the `convert_timezone` flag is off by default, to keep
backwards compatibility.

If ES is < 6.1, the flag is automatically considered off when creating the pipeline
(but the `add_locale` processor is still used).

Closes #3898.

For now this is only applied to the system module, but likely more
modules would benefit from this feature.

Todos:

* [x] Automatically disable the flag in case of ES < 6.1
* [x] Add the flag to the auth fileset as well
* [x] Tests
* [x] Document the new flag + Changelog