### PR TITLE
Support openLinkInCurrentTab in Kibana Index Pattern.

### DIFF
--- a/libbeat/common/field.go
+++ b/libbeat/common/field.go
@@ -41,12 +41,13 @@ type Field struct {
 	Aggregatable *bool  `config:"aggregatable"`
 	Script       string `config:"script"`
 	// Kibana params
-	Pattern         string              `config:"pattern"`
-	InputFormat     string              `config:"input_format"`
-	OutputFormat    string              `config:"output_format"`
-	OutputPrecision *int                `config:"output_precision"`
-	LabelTemplate   string              `config:"label_template"`
-	UrlTemplate     []VersionizedString `config:"url_template"`
+	Pattern              string              `config:"pattern"`
+	InputFormat          string              `config:"input_format"`
+	OutputFormat         string              `config:"output_format"`
+	OutputPrecision      *int                `config:"output_precision"`
+	LabelTemplate        string              `config:"label_template"`
+	UrlTemplate          []VersionizedString `config:"url_template"`
+	OpenLinkInCurrentTab *bool               `config:"open_link_in_current_tab"`
 
 	Path string
 }

--- a/libbeat/kibana/transform.go
+++ b/libbeat/kibana/transform.go
@@ -155,6 +155,7 @@ func addParams(format *common.MapStr, version *common.Version, f common.Field) {
 	addFormatParam(format, "outputFormat", f.OutputFormat)
 	addFormatParam(format, "outputPrecision", f.OutputPrecision)
 	addFormatParam(format, "labelTemplate", f.LabelTemplate)
+	addFormatParam(format, "openLinkInCurrentTab", f.OpenLinkInCurrentTab)
 	addVersionedFormatParam(format, version, "urlTemplate", f.UrlTemplate)
 }
 
@@ -167,6 +168,11 @@ func addFormatParam(f *common.MapStr, key string, val interface{}) {
 		}
 	case *int:
 		if v := val.(*int); v != nil {
+			createParam(f)
+			(*f)["params"].(common.MapStr)[key] = *v
+		}
+	case *bool:
+		if v := val.(*bool); v != nil {
 			createParam(f)
 			(*f)["params"].(common.MapStr)[key] = *v
 		}

--- a/libbeat/kibana/transform_test.go
+++ b/libbeat/kibana/transform_test.go
@@ -242,6 +242,8 @@ func TestTransformMisc(t *testing.T) {
 func TestTransformFieldFormatMap(t *testing.T) {
 	precision := 3
 	version620, _ := common.NewVersion("6.2.0")
+	truthy := true
+	falsy := false
 
 	tests := []struct {
 		commonField common.Field
@@ -295,17 +297,19 @@ func TestTransformFieldFormatMap(t *testing.T) {
 		},
 		{
 			commonField: common.Field{
-				Name:        "c",
-				Format:      "url",
-				Pattern:     "[^-]",
-				InputFormat: "string",
+				Name:                 "c",
+				Format:               "url",
+				Pattern:              "[^-]",
+				InputFormat:          "string",
+				OpenLinkInCurrentTab: &falsy,
 			},
 			expected: common.MapStr{
 				"c": common.MapStr{
 					"id": "url",
 					"params": common.MapStr{
-						"pattern":     "[^-]",
-						"inputFormat": "string",
+						"pattern":              "[^-]",
+						"inputFormat":          "string",
+						"openLinkInCurrentTab": false,
 					},
 				},
 			},
@@ -322,13 +326,14 @@ func TestTransformFieldFormatMap(t *testing.T) {
 		{
 			version: version620,
 			commonField: common.Field{
-				Name:            "c",
-				Format:          "url",
-				Pattern:         "[^-]",
-				InputFormat:     "string",
-				OutputFormat:    "float",
-				OutputPrecision: &precision,
-				LabelTemplate:   "lblT",
+				Name:                 "c",
+				Format:               "url",
+				Pattern:              "[^-]",
+				OpenLinkInCurrentTab: &truthy,
+				InputFormat:          "string",
+				OutputFormat:         "float",
+				OutputPrecision:      &precision,
+				LabelTemplate:        "lblT",
 				UrlTemplate: []common.VersionizedString{
 					{MinVersion: "5.0.0", Value: "5x.urlTemplate"},
 					{MinVersion: "6.0.0", Value: "6x.urlTemplate"},
@@ -338,12 +343,13 @@ func TestTransformFieldFormatMap(t *testing.T) {
 				"c": common.MapStr{
 					"id": "url",
 					"params": common.MapStr{
-						"pattern":         "[^-]",
-						"inputFormat":     "string",
-						"outputFormat":    "float",
-						"outputPrecision": 3,
-						"labelTemplate":   "lblT",
-						"urlTemplate":     "6x.urlTemplate",
+						"pattern":              "[^-]",
+						"inputFormat":          "string",
+						"outputFormat":         "float",
+						"outputPrecision":      3,
+						"labelTemplate":        "lblT",
+						"urlTemplate":          "6x.urlTemplate",
+						"openLinkInCurrentTab": true,
 					},
 				},
 			},


### PR DESCRIPTION
This field is necessary to allow opening links in the same tab. The setting is supported by Kibana >= 6.1. according to @simianhacker. 
Opening links in the same tab allows to preserve selected timeframes for dashboards.

@makwarth fyi - this is a pre-condition for https://github.com/elastic/apm-server/issues/266