### PR TITLE
Support dashboard loading without Elasticsearch

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -14,7 +14,6 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 
 *Affecting all Beats*
 
-- Determine log level for kafka output. {pull}5397[5397]
 - Support dashboard loading without Elasticseach {pull}5653[5653]
 
 *Auditbeat*

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -14,6 +14,9 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 
 *Affecting all Beats*
 
+- Determine log level for kafka output. {pull}5397[5397]
+- Support dashboard loading without Elasticseach {pull}5653[5653]
+
 *Auditbeat*
 
 - Changed `audit.file.path` to be a multi-field so that path is searchable. {pull}5625[5625]

--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -722,6 +722,9 @@ output.elasticsearch:
 # dashboards and index pattern. Example: testbeat-*
 #setup.dashboards.index:
 
+# Force loading of dashboards using the Kibana API without querying Elasticsearch for the version
+#always_kibana: false
+
 #============================== Template =====================================
 
 # A template is used to set the mapping in Elasticsearch

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -1150,6 +1150,9 @@ output.elasticsearch:
 # dashboards and index pattern. Example: testbeat-*
 #setup.dashboards.index:
 
+# Force loading of dashboards using the Kibana API without querying Elasticsearch for the version
+#always_kibana: false
+
 #============================== Template =====================================
 
 # A template is used to set the mapping in Elasticsearch

--- a/heartbeat/heartbeat.reference.yml
+++ b/heartbeat/heartbeat.reference.yml
@@ -842,6 +842,9 @@ output.elasticsearch:
 # dashboards and index pattern. Example: testbeat-*
 #setup.dashboards.index:
 
+# Force loading of dashboards using the Kibana API without querying Elasticsearch for the version
+#always_kibana: false
+
 #============================== Template =====================================
 
 # A template is used to set the mapping in Elasticsearch

--- a/libbeat/_meta/config.reference.yml
+++ b/libbeat/_meta/config.reference.yml
@@ -628,6 +628,9 @@ output.elasticsearch:
 # dashboards and index pattern. Example: testbeat-*
 #setup.dashboards.index:
 
+# Force loading of dashboards using the Kibana API without querying Elasticsearch for the version
+#always_kibana: false
+
 #============================== Template =====================================
 
 # A template is used to set the mapping in Elasticsearch

--- a/libbeat/dashboards/config.go
+++ b/libbeat/dashboards/config.go
@@ -10,10 +10,12 @@ type Config struct {
 	URL            string `config:"url"`
 	OnlyDashboards bool   `config:"only_dashboards"`
 	OnlyIndex      bool   `config:"only_index"`
+	AlwaysKibana   bool   `config:"always_kibana"`
 }
 
 var defaultConfig = Config{
-	KibanaIndex: ".kibana",
+	KibanaIndex:  ".kibana",
+	AlwaysKibana: false,
 }
 var (
 	defaultDirectory = "kibana"

--- a/libbeat/docs/dashboardsconfig.asciidoc
+++ b/libbeat/docs/dashboardsconfig.asciidoc
@@ -91,3 +91,9 @@ is `".kibana"`
 
 The Elasticsearch index name. This setting overwrites the index name defined
 in the dashboards and index pattern. Example: `"testbeat-*"`
+
+[float]
+==== `setup.dashboards.always_kibana`
+
+Force loading of dashboards using the Kibana API without querying Elasticsearch for the version
+The default is `false`.

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -1109,6 +1109,9 @@ output.elasticsearch:
 # dashboards and index pattern. Example: testbeat-*
 #setup.dashboards.index:
 
+# Force loading of dashboards using the Kibana API without querying Elasticsearch for the version
+#always_kibana: false
+
 #============================== Template =====================================
 
 # A template is used to set the mapping in Elasticsearch

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -1096,6 +1096,9 @@ output.elasticsearch:
 # dashboards and index pattern. Example: testbeat-*
 #setup.dashboards.index:
 
+# Force loading of dashboards using the Kibana API without querying Elasticsearch for the version
+#always_kibana: false
+
 #============================== Template =====================================
 
 # A template is used to set the mapping in Elasticsearch

--- a/winlogbeat/winlogbeat.reference.yml
+++ b/winlogbeat/winlogbeat.reference.yml
@@ -657,6 +657,9 @@ output.elasticsearch:
 # dashboards and index pattern. Example: testbeat-*
 #setup.dashboards.index:
 
+# Force loading of dashboards using the Kibana API without querying Elasticsearch for the version
+#always_kibana: false
+
 #============================== Template =====================================
 
 # A template is used to set the mapping in Elasticsearch


### PR DESCRIPTION
Make it possible to import dashboards without Elasticsearch using Kibana API.

Usage
```
$ ./metricbeat setup --dashboards --force-kibana
```
The flag `force-kibana` can be specified only when dashboards are loaded.
```
$ ./metricbeat --template --force-kibana
Error setting up beat: --force-kibana is only used in case of dashboard loading
```

The name of the flag is not the best. I am open to proposals.

Based on a discussion over IRC.