### PR TITLE
TLS: Config flag to include raw certificates

### DIFF
--- a/packetbeat/_meta/beat.reference.yml
+++ b/packetbeat/_meta/beat.reference.yml
@@ -433,6 +433,10 @@ packetbeat.protocols:
   # certificate chains are sent to Elasticsearch. The default is true.
   #send_certificates: true
 
+  # If this option is enabled, the raw certificates will be stored
+  # in PEM format under the `raw` key. The default is false.
+  #include_raw_certificates: false
+
 #=========================== Monitored processes ==============================
 
 # Configure the processes to be monitored and how to find them. If a process is

--- a/packetbeat/_meta/fields.yml
+++ b/packetbeat/_meta/fields.yml
@@ -1898,6 +1898,14 @@
               description: >
                 The algorithm used for the certificate's signature.
 
+            - name: alternative_names
+              type: array
+              description: Subject Alternative Names for this certificate.
+
+            - name: raw
+              type: keyword
+              description: The raw certificate in PEM format.
+
             - name: subject
               type: group
               description: Subject represented by this certificate.
@@ -1921,10 +1929,6 @@
                 - name: common_name
                   type: keyword
                   description: Name or host name identified by the certificate.
-
-            - name: alternative_names
-              type: array
-              description: Subject Alternative Names for this certificate.
 
             - name: issuer
               type: group
@@ -1983,6 +1987,14 @@
               description: >
                 The algorithm used for the certificate's signature.
 
+            - name: alternative_names
+              type: array
+              description: Subject Alternative Names for this certificate.
+
+            - name: raw
+              type: keyword
+              description: The raw certificate in PEM format.
+
             - name: subject
               type: group
               description: Subject represented by this certificate.
@@ -2006,10 +2018,6 @@
                 - name: common_name
                   type: keyword
                   description: Name or host name identified by the certificate.
-
-            - name: alternative_names
-              type: array
-              description: Subject Alternative Names for this certificate.
 
             - name: issuer
               type: group
@@ -2035,7 +2043,10 @@
                   type: keyword
                   description: Name or host name identified by the certificate.
 
-
         - name: server_certificate_chain
           type: array
           description: Chain of trust for the server certificate.
+
+        - name: client_certificate_chain
+          type: array
+          description: Chain of trust for the client certificate.

--- a/packetbeat/docs/fields.asciidoc
+++ b/packetbeat/docs/fields.asciidoc
@@ -2944,6 +2944,20 @@ The algorithm used for the certificate's signature.
 
 
 [float]
+=== `tls.client_certificate.alternative_names`
+
+type: array
+
+Subject Alternative Names for this certificate.
+
+[float]
+=== `tls.client_certificate.raw`
+
+type: keyword
+
+The raw certificate in PEM format.
+
+[float]
 == subject fields
 
 Subject represented by this certificate.
@@ -2983,13 +2997,6 @@ Province or region within country.
 type: keyword
 
 Name or host name identified by the certificate.
-
-[float]
-=== `tls.client_certificate.alternative_names`
-
-type: array
-
-Subject Alternative Names for this certificate.
 
 [float]
 == issuer fields
@@ -3083,6 +3090,20 @@ The algorithm used for the certificate's signature.
 
 
 [float]
+=== `tls.server_certificate.alternative_names`
+
+type: array
+
+Subject Alternative Names for this certificate.
+
+[float]
+=== `tls.server_certificate.raw`
+
+type: keyword
+
+The raw certificate in PEM format.
+
+[float]
 == subject fields
 
 Subject represented by this certificate.
@@ -3122,13 +3143,6 @@ Province or region within country.
 type: keyword
 
 Name or host name identified by the certificate.
-
-[float]
-=== `tls.server_certificate.alternative_names`
-
-type: array
-
-Subject Alternative Names for this certificate.
 
 [float]
 == issuer fields
@@ -3177,6 +3191,13 @@ Name or host name identified by the certificate.
 type: array
 
 Chain of trust for the server certificate.
+
+[float]
+=== `tls.client_certificate_chain`
+
+type: array
+
+Chain of trust for the client certificate.
 
 [[exported-fields-trans_event]]
 == Transaction Event fields

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -433,6 +433,10 @@ packetbeat.protocols:
   # certificate chains are sent to Elasticsearch. The default is true.
   #send_certificates: true
 
+  # If this option is enabled, the raw certificates will be stored
+  # in PEM format under the `raw` key. The default is false.
+  #include_raw_certificates: false
+
 #=========================== Monitored processes ==============================
 
 # Configure the processes to be monitored and how to find them. If a process is

--- a/packetbeat/protos/tls/_meta/fields.yml
+++ b/packetbeat/protos/tls/_meta/fields.yml
@@ -148,6 +148,14 @@
               description: >
                 The algorithm used for the certificate's signature.
 
+            - name: alternative_names
+              type: array
+              description: Subject Alternative Names for this certificate.
+
+            - name: raw
+              type: keyword
+              description: The raw certificate in PEM format.
+
             - name: subject
               type: group
               description: Subject represented by this certificate.
@@ -171,10 +179,6 @@
                 - name: common_name
                   type: keyword
                   description: Name or host name identified by the certificate.
-
-            - name: alternative_names
-              type: array
-              description: Subject Alternative Names for this certificate.
 
             - name: issuer
               type: group
@@ -233,6 +237,14 @@
               description: >
                 The algorithm used for the certificate's signature.
 
+            - name: alternative_names
+              type: array
+              description: Subject Alternative Names for this certificate.
+
+            - name: raw
+              type: keyword
+              description: The raw certificate in PEM format.
+
             - name: subject
               type: group
               description: Subject represented by this certificate.
@@ -256,10 +268,6 @@
                 - name: common_name
                   type: keyword
                   description: Name or host name identified by the certificate.
-
-            - name: alternative_names
-              type: array
-              description: Subject Alternative Names for this certificate.
 
             - name: issuer
               type: group
@@ -285,7 +293,10 @@
                   type: keyword
                   description: Name or host name identified by the certificate.
 
-
         - name: server_certificate_chain
           type: array
           description: Chain of trust for the server certificate.
+
+        - name: client_certificate_chain
+          type: array
+          description: Chain of trust for the client certificate.

--- a/packetbeat/protos/tls/config.go
+++ b/packetbeat/protos/tls/config.go
@@ -6,8 +6,9 @@ import (
 )
 
 type tlsConfig struct {
-	config.ProtocolCommon `config:",inline"`
-	SendCertificates      bool `config:"send_certificates"`
+	config.ProtocolCommon  `config:",inline"`
+	SendCertificates       bool `config:"send_certificates"`
+	IncludeRawCertificates bool `config:"include_raw_certificates"`
 }
 
 var (
@@ -15,6 +16,7 @@ var (
 		ProtocolCommon: config.ProtocolCommon{
 			TransactionTimeout: protos.DefaultTransactionExpiration,
 		},
-		SendCertificates: true,
+		SendCertificates:       true,
+		IncludeRawCertificates: false,
 	}
 )

--- a/packetbeat/protos/tls/parse.go
+++ b/packetbeat/protos/tls/parse.go
@@ -4,6 +4,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/hex"
+	"encoding/pem"
 	"fmt"
 	"strings"
 	"time"
@@ -345,8 +346,6 @@ func (parser *parser) parseHandshake(handshakeType handshakeType, buffer bufferV
 	return true
 }
 
-// "{\"dst\":{\"IP\":\"192.168.0.2\",\"Port\":27017,\"Name\":\"\",\"Cmdline\":\"\",\"Proc\":\"\"},\"src\":{\"IP\":\"192.168.0.1\",\"Port\":6512,\"Name\":\"\",\"Cmdline\":\"\",\"Proc\":\"\"},\"status\":\"Error\",\"tls\":{\"client_certificate_requested\":false,\"client_hello\":{\"ciphers\":[\"(unknown:0x3a3a)\",\"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256\",\"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256\",\"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384\",\"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384\",\"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256\",\"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256\",\"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA\",\"TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA\",\"TLS_RSA_WITH_AES_128_GCM_SHA256\",\"TLS_RSA_WITH_AES_256_GCM_SHA384\",\"TLS_RSA_WITH_AES_128_CBC_SHA\",\"TLS_RSA_WITH_AES_256_CBC_SHA\",\"TLS_RSA_WITH_3DES_EDE_CBC_SHA\"],\"compression_methods\":[\"null\"],\"extensions\":{\"_unparsed_\":\"56026,renegotiation_info,23,status_request,18,16,30032,43690\",\"ec_points_formats\":\"uncompressed\",\"server_name_indication\":\"example.org\",\"session_ticket\":\"\",\"signature_algorithms\":\"ecdsa_secp256r1_sha256,rsa_pss_sha256,rsa_pkcs1_sha256,ecdsa_secp384r1_sha384,rsa_pss_sha384,rsa_pkcs1_sha384,rsa_pss_sha512,rsa_pkcs1_sha512,rsa_pkcs1_sha1\",\"supported_groups\":\"(unknown:0x6a6a),x25519,secp256r1,secp384r1\"},\"timestamp\":862445486,\"version\":\"3.3\"},\"handshake_completed\":false,\"resumed\":false},\"type\":\"tls\"}" (expected)
-// "{\"dst\":{\"IP\":\"192.168.0.2\",\"Port\":27017,\"Name\":\"\",\"Cmdline\":\"\",\"Proc\":\"\"},\"src\":{\"IP\":\"192.168.0.1\",\"Port\":6512,\"Name\":\"\",\"Cmdline\":\"\",\"Proc\":\"\"},\"status\":\"Error\",\"tls\":{\"client_certificate_requested\":false,\"client_hello\":{\"ciphers\":[\"(unknown:0x3a3a)\",\"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256\",\"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256\",\"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384\",\"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384\",\"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256\",\"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256\",\"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA\",\"TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA\",\"TLS_RSA_WITH_AES_128_GCM_SHA256\",\"TLS_RSA_WITH_AES_256_GCM_SHA384\",\"TLS_RSA_WITH_AES_128_CBC_SHA\",\"TLS_RSA_WITH_AES_256_CBC_SHA\",\"TLS_RSA_WITH_3DES_EDE_CBC_SHA\"],\"compression_method\":\"null\",\"extensions\":{\"_unparsed_\":\"56026,renegotiation_info,23,status_request,18,16,30032,43690\",\"ec_points_formats\":\"uncompressed\",\"server_name_indication\":\"example.org\",\"session_ticket\":\"\",\"signature_algorithms\":\"ecdsa_secp256r1_sha256,rsa_pss_sha256,rsa_pkcs1_sha256,ecdsa_secp384r1_sha384,rsa_pss_sha384,rsa_pkcs1_sha384,rsa_pss_sha512,rsa_pkcs1_sha512,rsa_pkcs1_sha1\",\"supported_groups\":\"(unknown:0x6a6a),x25519,secp256r1,secp384r1\"},\"timestamp\":862445486,\"version\":\"3.3\"},\"handshake_completed\":false,\"resumed\":false},\"type\":\"tls\"}" (actual)
 func parseHelloRequest(buffer bufferView) bool {
 	if buffer.length() != 0 {
 		logp.Warn("non-empty hello request")
@@ -489,7 +488,7 @@ func (version tlsVersion) String() string {
 	return fmt.Sprintf("%d.%d", version.major, version.minor)
 }
 
-func certToMap(cert *x509.Certificate) common.MapStr {
+func certToMap(cert *x509.Certificate, includeRaw bool) common.MapStr {
 	certMap := common.MapStr{
 		"signature_algorithm":  cert.SignatureAlgorithm.String(),
 		"public_key_algorithm": toString(cert.PublicKeyAlgorithm),
@@ -507,6 +506,13 @@ func certToMap(cert *x509.Certificate) common.MapStr {
 	}
 	if len(san) > 0 {
 		certMap["alternative_names"] = san
+	}
+	if includeRaw {
+		block := pem.Block{
+			Type:  "CERTIFICATE",
+			Bytes: cert.Raw,
+		}
+		certMap["raw"] = string(pem.EncodeToMemory(&block))
 	}
 	return certMap
 }


### PR DESCRIPTION
Use `tls.include_raw_certificates` to enable addition of the raw certificate
in PEM format to events. Default: false.

 #3604 

