### PR TITLE
Fix autodiscovery config hashing

### DIFF
--- a/libbeat/autodiscover/autodiscover.go
+++ b/libbeat/autodiscover/autodiscover.go
@@ -106,7 +106,11 @@ func (a *Autodiscover) startWorker() {
 
 		meta := getMeta(event)
 		for _, config := range configs {
-			hash, err := hashstructure.Hash(config, nil)
+
+			rawCfg := map[string]interface{}{}
+			err := config.Unpack(rawCfg)
+
+			hash, err := hashstructure.Hash(rawCfg, nil)
 			if err != nil {
 				logp.Debug(debugK, "Could not hash config %v: %v", config, err)
 				continue
@@ -154,7 +158,10 @@ func (a *Autodiscover) stopWorker() {
 		logp.Debug(debugK, "Got a stop event: %v, generated configs: %+v", event, configs)
 
 		for _, config := range configs {
-			hash, err := hashstructure.Hash(config, nil)
+			rawCfg := map[string]interface{}{}
+			err := config.Unpack(rawCfg)
+
+			hash, err := hashstructure.Hash(rawCfg, nil)
 			if err != nil {
 				logp.Debug(debugK, "Could not hash config %v: %v", config, err)
 				continue

--- a/libbeat/autodiscover/autodiscover.go
+++ b/libbeat/autodiscover/autodiscover.go
@@ -106,7 +106,6 @@ func (a *Autodiscover) startWorker() {
 
 		meta := getMeta(event)
 		for _, config := range configs {
-
 			rawCfg := map[string]interface{}{}
 			err := config.Unpack(rawCfg)
 

--- a/libbeat/autodiscover/autodiscover_test.go
+++ b/libbeat/autodiscover/autodiscover_test.go
@@ -243,4 +243,7 @@ func TestAutodiscoverHash(t *testing.T) {
 	assert.Equal(t, runners[0].meta.Get()["foo"], "bar")
 	assert.True(t, runners[0].started)
 	assert.False(t, runners[0].stopped)
+	assert.Equal(t, runners[1].meta.Get()["foo"], "bar")
+	assert.True(t, runners[1].started)
+	assert.False(t, runners[1].stopped)
 }


### PR DESCRIPTION
The config hash was created based on a cfg object instead of the unpacked object. This has the affect that all hashs are equal and new objects are not loaded. We already hit the same issue in reloading and have the same fix there.

@exekias FYI