### PR TITLE
Cherry-pick #5618 to 6.0: Adjust generated CSV dependency file

### DIFF
--- a/dev-tools/generate_notice.py
+++ b/dev-tools/generate_notice.py
@@ -118,11 +118,18 @@ def write_notice_file(f, beat, copyright, dependencies):
 
 
 def write_csv_file(csvwriter, dependencies):
-    csvwriter.writerow(["Dependency", "Version", "Revision", "License type (autodetected)", "License text"])
+    csvwriter.writerow(["name", "url", "version", "revision", "license"])
     for key in sorted(dependencies, key=str.lower):
         for lib in dependencies[key]:
-            csvwriter.writerow([key, lib.get("version", ""), lib.get("revision", ""),
-                                lib["license_summary"], lib["license_contents"]])
+            csvwriter.writerow([key, get_url(key), lib.get("version", ""), lib.get("revision", ""),
+                                lib["license_summary"]])
+
+
+def get_url(repo):
+    words = repo.split("/")
+    if words[0] != "github.com":
+        return repo
+    return "https://github.com/{}/{}".format(words[1], words[2])
 
 
 def create_notice(filename, beat, copyright, vendor_dirs, csvfile):


### PR DESCRIPTION
Cherry-pick of PR #5618 to 6.0 branch. Original message: 

Applies common schema for the CSV report that we generate for the dependencies.

The following fields are created:
 * name
 * url
 * version
 * revision
 * license (short name)

The only change in logic is getting a valid URL from Github sub-projects.

The CSV report can be created with:

```
python ./dev-tools/generate_notice.py . --csv dependencies.csv
```

Closes #5463.