### PR TITLE
Bump version to 6.2.0 in the 6.x branch

### DIFF
--- a/deploy/kubernetes/filebeat-kubernetes.yaml
+++ b/deploy/kubernetes/filebeat-kubernetes.yaml
@@ -70,7 +70,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: filebeat
-        image: docker.elastic.co/beats/filebeat:6.1.0
+        image: docker.elastic.co/beats/filebeat:6.2.0
         args: [
           "-c", "/etc/filebeat.yml",
           "-e",

--- a/deploy/kubernetes/metricbeat-kubernetes.yaml
+++ b/deploy/kubernetes/metricbeat-kubernetes.yaml
@@ -93,7 +93,7 @@ spec:
       hostNetwork: true
       containers:
       - name: metricbeat
-        image: docker.elastic.co/beats/metricbeat:6.1.0
+        image: docker.elastic.co/beats/metricbeat:6.2.0
         args: [
           "-c", "/etc/metricbeat.yml",
           "-e",
@@ -202,7 +202,7 @@ spec:
     spec:
       containers:
       - name: metricbeat
-        image: docker.elastic.co/beats/metricbeat:6.1.0
+        image: docker.elastic.co/beats/metricbeat:6.2.0
         args: [
           "-c", "/etc/metricbeat.yml",
           "-e",

--- a/dev-tools/packer/version.yml
+++ b/dev-tools/packer/version.yml
@@ -1,1 +1,1 @@
-version: "6.1.0"
+version: "6.2.0"

--- a/libbeat/_meta/kibana/default/index-pattern/libbeat.json
+++ b/libbeat/_meta/kibana/default/index-pattern/libbeat.json
@@ -12,5 +12,5 @@
       "version": 1
     }
   ],
-  "version": "6.1.0"
+  "version": "6.2.0"
 }

--- a/libbeat/docs/version.asciidoc
+++ b/libbeat/docs/version.asciidoc
@@ -1,4 +1,4 @@
-:stack-version: 6.1.0
+:stack-version: 6.2.0
 :doc-branch: master
 :go-version: 1.9.2
 :release-state: unreleased

--- a/libbeat/version/version.go
+++ b/libbeat/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const defaultBeatVersion = "6.1.0"
+const defaultBeatVersion = "6.2.0"


### PR DESCRIPTION
This will be the next release from this branch. Since the branch is not released,
we can already set the docs version as well.