### PR TITLE
Allow specifying default metricsets

### DIFF
--- a/metricbeat/mb/example_metricset_test.go
+++ b/metricbeat/mb/example_metricset_test.go
@@ -14,9 +14,9 @@ var hostParser = parse.URLHostParserBuilder{
 
 func init() {
 	// Register the MetricSetFactory function for the "status" MetricSet.
-	if err := mb.Registry.AddMetricSet("someapp", "status", NewMetricSet, hostParser); err != nil {
-		panic(err)
-	}
+	mb.Registry.MustAddMetricSet("someapp", "status", NewMetricSet,
+		mb.WithHostParser(hostParser),
+	)
 }
 
 type MetricSet struct {

--- a/metricbeat/mb/mb.go
+++ b/metricbeat/mb/mb.go
@@ -214,7 +214,7 @@ type ModuleConfig struct {
 	Period     time.Duration `config:"period"     validate:"positive"`
 	Timeout    time.Duration `config:"timeout"    validate:"positive"`
 	Module     string        `config:"module"     validate:"required"`
-	MetricSets []string      `config:"metricsets" validate:"required"`
+	MetricSets []string      `config:"metricsets"`
 	Enabled    bool          `config:"enabled"`
 	Raw        bool          `config:"raw"`
 }

--- a/metricbeat/mb/mb_test.go
+++ b/metricbeat/mb/mb_test.go
@@ -68,19 +68,6 @@ func TestModuleConfig(t *testing.T) {
 		},
 		{
 			in: map[string]interface{}{
-				"module": "example",
-			},
-			err: "missing required field accessing 'metricsets'",
-		},
-		{
-			in: map[string]interface{}{
-				"module":     "example",
-				"metricsets": []string{},
-			},
-			err: "empty field accessing 'metricsets'",
-		},
-		{
-			in: map[string]interface{}{
 				"module":     "example",
 				"metricsets": []string{"test"},
 			},
@@ -172,6 +159,24 @@ func TestNewModulesDuplicateHosts(t *testing.T) {
 
 	_, _, err := NewModule(c, r)
 	assert.Error(t, err)
+}
+
+// TestNewModulesWithDefaultMetricSet verifies that the default MetricSet is
+// instantiated when no metricsets are specified in the config.
+func TestNewModulesWithDefaultMetricSet(t *testing.T) {
+	r := newTestRegistry(t, DefaultMetricSet())
+
+	c := newConfig(t, map[string]interface{}{
+		"module": moduleName,
+	})
+
+	_, metricSets, err := NewModule(c, r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if assert.Len(t, metricSets, 1) {
+		assert.Equal(t, metricSetName, metricSets[0].Name())
+	}
 }
 
 func TestNewModulesHostParser(t *testing.T) {
@@ -316,7 +321,7 @@ func TestNewBaseModuleFromModuleConfigStruct(t *testing.T) {
 	assert.Empty(t, baseModule.Config().Hosts)
 }
 
-func newTestRegistry(t testing.TB) *Register {
+func newTestRegistry(t testing.TB, metricSetOptions ...MetricSetOption) *Register {
 	r := NewRegister()
 
 	if err := r.AddModule(moduleName, DefaultModuleFactory); err != nil {
@@ -327,7 +332,7 @@ func newTestRegistry(t testing.TB) *Register {
 		return &testMetricSet{base}, nil
 	}
 
-	if err := r.AddMetricSet(moduleName, metricSetName, factory); err != nil {
+	if err := r.addMetricSet(moduleName, metricSetName, factory, metricSetOptions...); err != nil {
 		t.Fatal(err)
 	}
 

--- a/metricbeat/mb/registry_test.go
+++ b/metricbeat/mb/registry_test.go
@@ -101,7 +101,7 @@ func TestAddMetricSet(t *testing.T) {
 	}
 	f, found := registry.metricSets[moduleName][metricSetName]
 	assert.True(t, found, "metricset not found")
-	assert.NotNil(t, f, "factory fuction is nil")
+	assert.NotNil(t, f, "factory function is nil")
 }
 
 func TestModuleFactory(t *testing.T) {
@@ -149,6 +149,36 @@ func TestMetricSetFactory(t *testing.T) {
 		assert.NotNil(t, ms)
 		assert.NotNil(t, hp) // Can't compare functions in Go so just check for non-nil.
 	})
+
+	t.Run("with options HostParser", func(t *testing.T) {
+		registry := NewRegister()
+		hostParser := func(Module, string) (HostData, error) { return HostData{}, nil }
+		err := registry.addMetricSet(moduleName, metricSetName, fakeMetricSetFactory, WithHostParser(hostParser))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		ms, hp, err := registry.metricSetFactory(moduleName, metricSetName)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.NotNil(t, ms)
+		assert.NotNil(t, hp) // Can't compare functions in Go so just check for non-nil.
+	})
+}
+
+func TestDefaultMetricSet(t *testing.T) {
+	registry := NewRegister()
+	err := registry.addMetricSet(moduleName, metricSetName, fakeMetricSetFactory, DefaultMetricSet())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	names, err := registry.defaultMetricSets(moduleName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Contains(t, names, metricSetName)
 }
 
 func TestMetricSetQuery(t *testing.T) {


### PR DESCRIPTION
This is useful for modules containing a single metricset where you don't need the granularity of multiple metricsets. If `metricsets` isn't found in the config then the default MetricSets will be instantiated. If no defaults are defined for a module then an error is shown to the user (as was the case before this change when no `metricsets` were configured).

```
func init() {
	mb.Registry.MustAddMetricSet(moduleName, metricsetName, New,
		mb.DefaultMetricSet(),
		mb.WithHostParser(parse.EmptyHostParser),
	)
}
```