### PR TITLE
Add link to relnotes that points to breaking changes

### DIFF
--- a/libbeat/docs/release-notes/6.0.0.asciidoc
+++ b/libbeat/docs/release-notes/6.0.0.asciidoc
@@ -3,6 +3,8 @@
 
 The list below covers the changes during the 6.0.0-alpha1, -alpha2, -beta1, -beta2, -rc1 and -rc2 releases.
 
+Also read <<breaking-changes-6.0>> for more detail about changes that affect
+upgrade.
 
 ==== Breaking changes
 

--- a/libbeat/docs/release.asciidoc
+++ b/libbeat/docs/release.asciidoc
@@ -4,7 +4,9 @@
 == Release notes
 
 --
-This section summarizes the changes in each release.
+This section summarizes the changes in each release. Also read
+<<breaking-changes>> for more detail about changes that affect
+upgrade.
 
 * <<release-notes-6.0.0>>
 * <<release-notes-6.0.0-ga>>


### PR DESCRIPTION
I can't remember if these files are generated, but we need to add links that point to the lengthier description of breaking changes.