### PR TITLE
Add auth fileset options

### DIFF
--- a/filebeat/docs/modules/system.asciidoc
+++ b/filebeat/docs/modules/system.asciidoc
@@ -68,6 +68,10 @@ include::../include/config-option-intro.asciidoc[]
 
 include::../include/var-paths.asciidoc[]
 
+[float]
+==== `auth` fileset settings
+
+include::../include/var-paths.asciidoc[]
 
 
 [float]

--- a/filebeat/docs/modules/system.asciidoc
+++ b/filebeat/docs/modules/system.asciidoc
@@ -18,6 +18,10 @@ include::../include/what-happens.asciidoc[]
 This module was tested with logs from OSes like Ubuntu 12.04, Centos 7, and
 macOS Sierra.
 
+This module requires the
+{elasticsearch-plugins}/ingest-user-agent.html[ingest-user-agent] and
+{elasticsearch-plugins}/ingest-geoip.html[ingest-geoip] Elasticsearch plugins.
+
 This module is not available for Windows.
 
 include::../include/running-modules.asciidoc[]

--- a/filebeat/module/system/_meta/docs.asciidoc
+++ b/filebeat/module/system/_meta/docs.asciidoc
@@ -63,3 +63,7 @@ include::../include/config-option-intro.asciidoc[]
 
 include::../include/var-paths.asciidoc[]
 
+[float]
+==== `auth` fileset settings
+
+include::../include/var-paths.asciidoc[]

--- a/filebeat/module/system/_meta/docs.asciidoc
+++ b/filebeat/module/system/_meta/docs.asciidoc
@@ -13,6 +13,10 @@ include::../include/what-happens.asciidoc[]
 This module was tested with logs from OSes like Ubuntu 12.04, Centos 7, and
 macOS Sierra.
 
+This module requires the
+{elasticsearch-plugins}/ingest-user-agent.html[ingest-user-agent] and
+{elasticsearch-plugins}/ingest-geoip.html[ingest-geoip] Elasticsearch plugins.
+
 This module is not available for Windows.
 
 include::../include/running-modules.asciidoc[]


### PR DESCRIPTION
The first commit adds the missing description for 6.0

This has been fixed in master with https://github.com/elastic/beats/commit/e125cf1daa98c7696ac42a2adf0f150b97a26dbf#diff-e429a0e021a0f063055c4128b317741b

The second commit updates the compatibility statement. This needs to a forward port.