### PR TITLE
Fix template loading bug with empty fields

### DIFF
--- a/libbeat/template/processor.go
+++ b/libbeat/template/processor.go
@@ -20,6 +20,10 @@ var (
 func (p *Processor) process(fields common.Fields, path string, output common.MapStr) error {
 	for _, field := range fields {
 
+		if field.Name == "" {
+			continue
+		}
+
 		field.Path = path
 		var mapping common.MapStr
 
@@ -69,7 +73,6 @@ func (p *Processor) process(fields common.Fields, path string, output common.Map
 				return err
 			}
 			mapping["properties"] = properties
-
 		default:
 			mapping = p.other(&field)
 		}


### PR DESCRIPTION
Because of a recent change to the fields.yml where an entry can only contain `release: beta` for example but no field name, the template generator created empty fields for it without a name which were invalid elasticsearch template. This change skipps entry without a name during template generation.