### PR TITLE
[WIP] Add testing of template

### DIFF
--- a/libbeat/tests/system/beat/beat.py
+++ b/libbeat/tests/system/beat/beat.py
@@ -155,7 +155,7 @@ class TestCase(unittest.TestCase, ComposeMixin):
                    cmd=None,
                    config=None,
                    output=None,
-                   logging_args=["-e", "-v", "-d", "*"],
+                   logging_args=["-e", "-v", "-d", "\"*\""],
                    extra_args=[]):
         """
         Starts beat and returns the process handle. The

--- a/metricbeat/tests/system/config/metricbeat.yml.j2
+++ b/metricbeat/tests/system/config/metricbeat.yml.j2
@@ -167,12 +167,29 @@ queue.mem:
 # Configure what outputs to use when sending the data collected by the beat.
 # Multiple outputs may be used.
 
-#------------------------------- File output ----------------------------------
-output.file:
-  path: {{ output_file_path|default(beat.working_dir + "/output") }}
-  filename: "{{ output_file_filename|default("metricbeat") }}"
-  rotate_every_kb: 1000
-  #number_of_files: 7
+#-------------------------------  output ----------------------------------
+output:
+  {% if elasticsearch -%}
+  elasticsearch:
+    {% for k, v in elasticsearch.items() -%}
+    {{ k }}: {{ v }}
+    {% endfor -%}
+  {%- endif %}
+
+  # File as output
+  # Options
+  # path: where to save the files
+  # filename: name of the files
+  # rotate_every_kb: maximum size of the files in path
+  # number of files: maximum number of files in path
+  {% if not (console or elasticsearch) -%}
+  file:
+    path: {{ output_file_path|default(beat.working_dir + "/output") }}
+    filename: "{{ output_file_filename|default("metricbeat") }}"
+    rotate_every_kb: 1000
+    #number_of_files: 7
+  {%- endif %}
+
 
 {% if path_data %}
 #================================ Paths =====================================


### PR DESCRIPTION
@exekias I wanted to use `metricbeat setup --template` to make sure we directly know in the future when we break a template for ES. Unfortunately the below code does not work because it seems `setup` is not part of the testing binary (or is swallowed somehow). Any idea here?