### PR TITLE
Allow user to locally obfuscate secret in a keystore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 coverage.out
 .python-version
 beat.db
+*.keystore
 
 # Editor swap files
 *.swp

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -18,6 +18,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Addition and update of the following libraries: pbkdf2, terminal, windows, unix {pull}5735[5735]
 - Update the command line library cobra and add support for zsh completion {pull}5761[5761]
 - The log format may differ due to logging library changes. {pull}5901[5901]
+- Adding a local keystore to allow user to obfuscate password {pull}5687[5687]
 
 *Auditbeat*
 

--- a/filebeat/tests/system/config/filebeat.yml.j2
+++ b/filebeat/tests/system/config/filebeat.yml.j2
@@ -212,3 +212,8 @@ output.file:
 path:
   data: {{path_data}}
 {% endif %}
+
+{% if keystore_path %}
+#================================ keystore =====================================
+keystore.path: {{keystore_path}}
+{% endif %}

--- a/filebeat/tests/system/test_keystore.py
+++ b/filebeat/tests/system/test_keystore.py
@@ -1,0 +1,74 @@
+import os
+from os import path
+
+from filebeat import BaseTest
+from beat.beat import Proc
+
+
+class TestKeystore(BaseTest):
+    """
+    Test Keystore variable replacement
+    """
+
+    def setUp(self):
+        super(BaseTest, self).setUp()
+        self.keystore_path = self.working_dir + "/data/keystore"
+
+    def test_keystore_with_present_key(self):
+        """
+        Test that we correctly do string replacement with values from the keystore
+        """
+
+        key = "elasticsearch_host"
+        secret = "myeleasticsearchsecrethost"
+
+        self.render_config_template(keystore_path=self.keystore_path, elasticsearch={
+            'host': "${%s}:9200" % key
+        })
+
+        exit_code = self.run_beat(extra_args=["keystore", "create"])
+        assert exit_code == 0
+
+        self.add_secret(key, secret, True)
+        proc = self.start_beat()
+        self.wait_until(lambda: self.log_contains("myeleasticsearchsecrethost"))
+        assert self.log_contains(secret)
+        proc.kill_and_wait()
+
+    def test_keystore_with_key_not_present(self):
+        """
+        Test that we return the template key when the key doesn't exist
+        """
+        key = "do_not_exist_elasticsearch_host"
+
+        self.render_config_template(keystore_path=self.keystore_path, elasticsearch={
+            'host': "${%s}:9200" % key
+        })
+
+        exit_code = self.run_beat()
+        assert self.log_contains(
+            "missing field accessing 'output.elasticsearch.hosts.0'")
+        assert exit_code == 1
+
+    def add_secret(self, key, value="hello world\n", force=False):
+        """
+        Add new secret using the --stdin option
+        """
+        args = [self.test_binary,
+                "-systemTest",
+                "-test.coverprofile",
+                os.path.join(self.working_dir, "coverage.cov"),
+                "-c", os.path.join(self.working_dir, self.beat_name + ".yml"),
+                "-e", "-v", "-d", "*",
+                "keystore", "add", key, "--stdin",
+                ]
+
+        if force:
+            args.append("--force")
+
+        proc = Proc(args, os.path.join(self.working_dir, self.beat_name + ".log"))
+
+        os.write(proc.stdin_write, value)
+        os.close(proc.stdin_write)
+
+        return proc.start().wait()

--- a/libbeat/cmd/keystore.go
+++ b/libbeat/cmd/keystore.go
@@ -1,0 +1,246 @@
+package cmd
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+	"syscall"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	tml "golang.org/x/crypto/ssh/terminal"
+
+	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/cmd/instance"
+	"github.com/elastic/beats/libbeat/common/cli"
+	"github.com/elastic/beats/libbeat/common/terminal"
+	"github.com/elastic/beats/libbeat/keystore"
+)
+
+func getKeystore(name, version string) (keystore.Keystore, error) {
+	b, err := instance.NewBeat(name, "", version)
+
+	if err != nil {
+		return nil, fmt.Errorf("error initializing beat: %s", err)
+	}
+
+	if err = b.Init(); err != nil {
+		return nil, fmt.Errorf("error initializing beat: %s", err)
+	}
+
+	return b.Keystore(), nil
+}
+
+// genKeystoreCmd initialize the Keystore command to manage the Keystore
+// with the following subcommands:
+//  - create
+//  - add
+//  - remove
+//  - list
+func genKeystoreCmd(
+	name, idxPrefix, version string,
+	beatCreator beat.Creator,
+	runFlags *pflag.FlagSet,
+) *cobra.Command {
+	keystoreCmd := cobra.Command{
+		Use:   "keystore",
+		Short: "Manage secrets keystore",
+	}
+
+	keystoreCmd.AddCommand(genCreateKeystoreCmd(name, version))
+	keystoreCmd.AddCommand(genAddKeystoreCmd(name, version))
+	keystoreCmd.AddCommand(genRemoveKeystoreCmd(name, version))
+	keystoreCmd.AddCommand(genListKeystoreCmd(name, version))
+
+	return &keystoreCmd
+}
+
+func genCreateKeystoreCmd(name, version string) *cobra.Command {
+	var flagForce bool
+	command := &cobra.Command{
+		Use:   "create",
+		Short: "Create keystore",
+		Run: cli.RunWith(func(cmd *cobra.Command, args []string) error {
+			return createKeystore(name, version, flagForce)
+		}),
+	}
+	command.Flags().BoolVar(&flagForce, "force", false, "override the existing keystore")
+	return command
+}
+
+func genAddKeystoreCmd(name, version string) *cobra.Command {
+	var flagForce bool
+	var flagStdin bool
+	command := &cobra.Command{
+		Use:   "add",
+		Short: "Add secret",
+		Run: cli.RunWith(func(cmd *cobra.Command, args []string) error {
+			store, err := getKeystore(name, version)
+			if err != nil {
+				return err
+			}
+			return addKey(store, args, flagForce, flagStdin)
+		}),
+	}
+	command.Flags().BoolVar(&flagStdin, "stdin", false, "Use the stdin as the source of the secret")
+	command.Flags().BoolVar(&flagForce, "force", false, "Override the existing key")
+	return command
+}
+
+func genRemoveKeystoreCmd(name, version string) *cobra.Command {
+	return &cobra.Command{
+		Use:   "remove",
+		Short: "remove secret",
+		Run: cli.RunWith(func(cmd *cobra.Command, args []string) error {
+			store, err := getKeystore(name, version)
+			if err != nil {
+				return err
+			}
+			return removeKey(store, args)
+		}),
+	}
+}
+
+func genListKeystoreCmd(name, version string) *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List keystore",
+		Run: cli.RunWith(func(cmd *cobra.Command, args []string) error {
+			store, err := getKeystore(name, version)
+			if err != nil {
+				return err
+			}
+			return list(store)
+		}),
+	}
+}
+
+func createKeystore(name, version string, force bool) error {
+	store, err := getKeystore(name, version)
+	if err != nil {
+		return err
+	}
+
+	if store.IsPersisted() == true && force == false {
+		response := terminal.PromptYesNo("A keystore already exists, Overwrite?", true)
+		if response == true {
+			err := store.Create(true)
+			if err != nil {
+				return fmt.Errorf("error creating the keystore: %s", err)
+			}
+		} else {
+			fmt.Println("Exiting without creating keystore.")
+			return nil
+		}
+	} else {
+		err := store.Create(true)
+		if err != nil {
+			return fmt.Errorf("Error creating the keystore: %s", err)
+		}
+	}
+	fmt.Printf("Created %s keystore\n", name)
+	return nil
+}
+
+func addKey(store keystore.Keystore, keys []string, force, stdin bool) error {
+	if len(keys) == 0 {
+		return errors.New("failed to create the secret: no key provided")
+	}
+
+	if len(keys) > 1 {
+		return fmt.Errorf("could not create secret for: %s, you can only provide one key per invocation", keys)
+	}
+
+	if store.IsPersisted() == false {
+		if force == false {
+			answer := terminal.PromptYesNo("The keystore does not exist. Do you want to create it?", false)
+			if answer == false {
+				return errors.New("exiting without creating keystore")
+			}
+		}
+		err := store.Create(true)
+		if err != nil {
+			return fmt.Errorf("could not create keystore, error: %s", err)
+		}
+		fmt.Println("Created keystore")
+	}
+
+	key := strings.TrimSpace(keys[0])
+	value, err := store.Retrieve(key)
+	if value != nil && force == false {
+		if stdin == true {
+			return fmt.Errorf("the settings %s already exist in the keystore use `--force` to replace it", key)
+		}
+		answer := terminal.PromptYesNo(fmt.Sprintf("Setting %s already exists, Overwrite?", key), false)
+		if answer == false {
+			fmt.Println("Exiting without modifying keystore.")
+			return nil
+		}
+	}
+
+	var keyValue []byte
+	if stdin {
+		reader := bufio.NewReader(os.Stdin)
+		keyValue, err = ioutil.ReadAll(reader)
+		if err != nil {
+			return fmt.Errorf("could not read input from stdin")
+		}
+	} else {
+		fmt.Printf("Enter value for %s: ", key)
+		keyValue, err = tml.ReadPassword(int(syscall.Stdin))
+		fmt.Println()
+		if err != nil {
+			return fmt.Errorf("could not read value from the input, error: %s", err)
+		}
+	}
+
+	store.Store(key, keyValue)
+	err = store.Save()
+
+	if err == nil {
+		fmt.Println("Successfully updated the keystore")
+	} else {
+		return fmt.Errorf("fail to add the key to the Keystore: %s", err)
+	}
+	return nil
+}
+
+func removeKey(store keystore.Keystore, keys []string) error {
+	if len(keys) == 0 {
+		return errors.New("you must supply at least one key to remove")
+	}
+
+	if store.IsPersisted() == false {
+		return errors.New("the keystore doesn't exist. Use the 'create' command to create one")
+	}
+
+	for _, key := range keys {
+		key = strings.TrimSpace(key)
+		_, err := store.Retrieve(key)
+		if err != nil {
+			return fmt.Errorf("could not find key '%v' in the keystore", key)
+		}
+
+		store.Delete(key)
+		err = store.Save()
+		if err != nil {
+			return fmt.Errorf("could not update the keystore with the changes, key: %s, error: %v", key, err)
+		}
+		fmt.Printf("successfully removed key: %s\n", key)
+	}
+	return nil
+}
+
+func list(store keystore.Keystore) error {
+	keys, err := store.List()
+	if err != nil {
+		return fmt.Errorf("could not read values from the keystore, error: %s", err)
+	}
+	for _, key := range keys {
+		fmt.Println(key)
+	}
+	return nil
+}

--- a/libbeat/cmd/root.go
+++ b/libbeat/cmd/root.go
@@ -32,6 +32,7 @@ type BeatsRootCmd struct {
 	CompletionCmd *cobra.Command
 	ExportCmd     *cobra.Command
 	TestCmd       *cobra.Command
+	KeystoreCmd   *cobra.Command
 }
 
 // GenRootCmd returns the root command to use for your beat. It takes
@@ -67,6 +68,7 @@ func GenRootCmdWithIndexPrefixWithRunFlags(name, indexPrefix, version string, be
 	rootCmd.CompletionCmd = genCompletionCmd(name, version, rootCmd)
 	rootCmd.ExportCmd = genExportCmd(name, indexPrefix, version)
 	rootCmd.TestCmd = genTestCmd(name, version, beatCreator)
+	rootCmd.KeystoreCmd = genKeystoreCmd(name, indexPrefix, version, beatCreator, runFlags)
 
 	// Root command is an alias for run
 	rootCmd.Run = rootCmd.RunCmd.Run
@@ -97,6 +99,7 @@ func GenRootCmdWithIndexPrefixWithRunFlags(name, indexPrefix, version string, be
 	rootCmd.AddCommand(rootCmd.CompletionCmd)
 	rootCmd.AddCommand(rootCmd.ExportCmd)
 	rootCmd.AddCommand(rootCmd.TestCmd)
+	rootCmd.AddCommand(rootCmd.KeystoreCmd)
 
 	return rootCmd
 }

--- a/libbeat/common/bytes.go
+++ b/libbeat/common/bytes.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"bytes"
+	"crypto/rand"
 	"errors"
 	"fmt"
 )
@@ -45,4 +46,16 @@ func ReadString(s []byte) (string, error) {
 	}
 	res := string(s[:i])
 	return res, nil
+}
+
+// RandomBytes return a slice of random bytes of the defined length
+func RandomBytes(length int) ([]byte, error) {
+	r := make([]byte, length)
+	_, err := rand.Read(r)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return r, nil
 }

--- a/libbeat/common/bytes_test.go
+++ b/libbeat/common/bytes_test.go
@@ -3,6 +3,7 @@
 package common
 
 import (
+	"bytes"
 	"errors"
 	"testing"
 
@@ -218,4 +219,23 @@ func TestReadString(t *testing.T) {
 		assert.Equal(t, test.Err, err)
 		assert.Equal(t, test.Output, res)
 	}
+}
+
+func TestRandomBytesLength(t *testing.T) {
+	r1, _ := RandomBytes(5)
+	assert.Equal(t, len(r1), 5)
+
+	r2, _ := RandomBytes(4)
+	assert.Equal(t, len(r2), 4)
+	assert.NotEqual(t, string(r1[:]), string(r2[:]))
+}
+
+func TestRandomBytes(t *testing.T) {
+	v1, err := RandomBytes(10)
+	assert.NoError(t, err)
+	v2, err := RandomBytes(10)
+	assert.NoError(t, err)
+
+	// unlikely to get 2 times the same results
+	assert.False(t, bytes.Equal(v1, v2))
 }

--- a/libbeat/common/config.go
+++ b/libbeat/common/config.go
@@ -96,6 +96,11 @@ func NewConfigWithYAML(in []byte, source string) (*Config, error) {
 	return fromConfig(c), err
 }
 
+// OverwriteConfigOpts allow to change the globally set config option
+func OverwriteConfigOpts(options []ucfg.Option) {
+	configOpts = options
+}
+
 func LoadFile(path string) (*Config, error) {
 	if IsStrictPerms() {
 		if err := ownerHasExclusiveWritePerms(path); err != nil {

--- a/libbeat/common/terminal/terminal.go
+++ b/libbeat/common/terminal/terminal.go
@@ -1,0 +1,53 @@
+package terminal
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// ReadInput Capture user input for a question
+func ReadInput() (string, error) {
+	reader := bufio.NewReader(os.Stdin)
+
+	input, err := reader.ReadString('\n')
+	if err != nil {
+		return "", err
+	}
+
+	return strings.TrimSuffix(input, "\n"), nil
+}
+
+// PromptYesNo Returns true if the user has enterred Y or YES, capitalization is ignored, we are
+// matching elasticsearch behavior
+func PromptYesNo(prompt string, defaultAnswer bool) bool {
+	var defaultYNprompt string
+
+	if defaultAnswer == true {
+		defaultYNprompt = "[Y/n]"
+	} else {
+		defaultYNprompt = "[y/N]"
+	}
+
+	fmt.Printf("%s %s: ", prompt, defaultYNprompt)
+
+	for {
+		input, err := ReadInput()
+		if err != nil {
+			panic("could not read from input")
+		}
+
+		response := strings.TrimSpace(input)
+		response = strings.ToLower(response)
+		if response == "" {
+			return defaultAnswer
+		} else if response == "y" || response == "yes" {
+			return true
+		} else if response == "n" || response == "no" {
+			return false
+		}
+
+		fmt.Printf("Did not understand the answer '%s'\n", input)
+	}
+}

--- a/libbeat/keystore/config.go
+++ b/libbeat/keystore/config.go
@@ -1,0 +1,10 @@
+package keystore
+
+// Config Define keystore configurable options
+type Config struct {
+	Path string `config:"path"`
+}
+
+var defaultConfig = Config{
+	Path: "",
+}

--- a/libbeat/keystore/file_keystore.go
+++ b/libbeat/keystore/file_keystore.go
@@ -1,0 +1,380 @@
+package keystore
+
+import (
+	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/sha512"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+
+	"golang.org/x/crypto/pbkdf2"
+
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/file"
+)
+
+const (
+	filePermission = 0600
+
+	// Encryption Related constants
+	iVLength        = 12
+	saltLength      = 64
+	iterationsCount = 10000
+	keyLength       = 32
+)
+
+// Version of the keystore format, will be added at the beginning of the file.
+var version = []byte("v1")
+
+// FileKeystore Allows to store key / secrets pair securely into an encrypted local file.
+type FileKeystore struct {
+	sync.RWMutex
+	Path     string
+	secrets  map[string]serializableSecureString
+	dirty    bool
+	password *SecureString
+}
+
+// Allow the original SecureString type to be correctly serialized to json.
+type serializableSecureString struct {
+	*SecureString
+	Value []byte `json:"value"`
+}
+
+// NewFileKeystore returns an new File based keystore or an error, currently users cannot set their
+// own password on the keystore, the default password will be an empty string. When the keystore
+// is initialied the secrets are automatically loaded into memory.
+func NewFileKeystore(keystoreFile string) (Keystore, error) {
+	return NewFileKeystoreWithPassword(keystoreFile, NewSecureString([]byte("")))
+}
+
+// NewFileKeystoreWithPassword return a new File based keystore or an error, allow to define what
+// password to use to create the keystore.
+func NewFileKeystoreWithPassword(keystoreFile string, password *SecureString) (Keystore, error) {
+	keystore := FileKeystore{
+		Path:     keystoreFile,
+		dirty:    false,
+		password: password,
+		secrets:  make(map[string]serializableSecureString),
+	}
+
+	err := keystore.load()
+	if err != nil {
+		return nil, err
+	}
+
+	return &keystore, nil
+}
+
+// Retrieve return a SecureString instance that will contains both the key and the secret.
+func (k *FileKeystore) Retrieve(key string) (*SecureString, error) {
+	k.RLock()
+	defer k.RUnlock()
+
+	secret, ok := k.secrets[key]
+	if !ok {
+		return nil, ErrKeyDoesntExists
+	}
+	return NewSecureString(secret.Value), nil
+}
+
+// Store add the key pair to the secret store and mark the store as dirty.
+func (k *FileKeystore) Store(key string, value []byte) error {
+	k.Lock()
+	defer k.Unlock()
+
+	k.secrets[key] = serializableSecureString{Value: value}
+	k.dirty = true
+	return nil
+}
+
+// Delete an existing key from the store and mark the store as dirty.
+func (k *FileKeystore) Delete(key string) error {
+	k.Lock()
+	defer k.Unlock()
+
+	delete(k.secrets, key)
+	k.dirty = true
+	return nil
+}
+
+// Save persists the in memory data to disk if needed.
+func (k *FileKeystore) Save() error {
+	k.Lock()
+	err := k.doSave(true)
+	k.Unlock()
+	return err
+}
+
+// List return the availables keys.
+func (k *FileKeystore) List() ([]string, error) {
+	k.RLock()
+	defer k.RUnlock()
+
+	keys := make([]string, 0, len(k.secrets))
+	for key := range k.secrets {
+		keys = append(keys, key)
+	}
+
+	return keys, nil
+}
+
+// GetConfig returns common.Config representation of the key / secret pair to be merged with other
+// loaded configuration.
+func (k *FileKeystore) GetConfig() (*common.Config, error) {
+	k.RLock()
+	defer k.RUnlock()
+
+	configHash := make(map[string]interface{})
+	for key, secret := range k.secrets {
+		configHash[key] = string(secret.Value)
+	}
+
+	return common.NewConfigFrom(configHash)
+}
+
+// Create create an empty keystore, if the store already exist we will return an error.
+func (k *FileKeystore) Create(override bool) error {
+	k.Lock()
+	k.secrets = make(map[string]serializableSecureString)
+	k.dirty = true
+	err := k.doSave(override)
+	k.Unlock()
+	return err
+}
+
+// IsPersisted return if the keystore is physically persisted on disk.
+func (k *FileKeystore) IsPersisted() bool {
+	k.Lock()
+	defer k.Unlock()
+
+	// We just check if the file is present on disk, we don't need to do any validation
+	// for a file based keystore, since all the keys will be fetched when we initialize the object
+	// if the file is invalid it will already fails. Creating a new FileKeystore will raise
+	// any errors concerning the permissions
+	f, err := os.OpenFile(k.Path, os.O_RDONLY, filePermission)
+	if err != nil {
+		return false
+	}
+	f.Close()
+	return true
+}
+
+// doSave lock/unlocking of the ressource need to be done by the caller.
+func (k *FileKeystore) doSave(override bool) error {
+	if k.dirty == false {
+		return nil
+	}
+
+	temporaryPath := fmt.Sprintf("%s.tmp", k.Path)
+
+	w := new(bytes.Buffer)
+	jsonEncoder := json.NewEncoder(w)
+	if err := jsonEncoder.Encode(k.secrets); err != nil {
+		return fmt.Errorf("cannot serialize the keystore before saving it to disk: %v", err)
+	}
+
+	encrypted, err := k.encrypt(w)
+	if err != nil {
+		return fmt.Errorf("cannot encrypt the keystore: %v", err)
+	}
+
+	flags := os.O_RDWR | os.O_CREATE
+	if override {
+		flags |= os.O_TRUNC
+	} else {
+		flags |= os.O_EXCL
+	}
+
+	f, err := os.OpenFile(temporaryPath, flags, filePermission)
+	if err != nil {
+		return fmt.Errorf("cannot open file to save the keystore to '%s', error: %s", k.Path, err)
+	}
+
+	f.Write(version)
+	base64Encoder := base64.NewEncoder(base64.StdEncoding, f)
+	io.Copy(base64Encoder, encrypted)
+	base64Encoder.Close()
+	f.Sync()
+	f.Close()
+
+	err = file.SafeFileRotate(k.Path, temporaryPath)
+	if err != nil {
+		os.Remove(temporaryPath)
+		return fmt.Errorf("cannot replace the existing keystore, with the new keystore file at '%s', error: %s", k.Path, err)
+	}
+	os.Remove(temporaryPath)
+
+	k.dirty = false
+	return nil
+}
+
+func (k *FileKeystore) load() error {
+	k.Lock()
+	defer k.Unlock()
+
+	f, err := os.OpenFile(k.Path, os.O_RDONLY, filePermission)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	defer f.Close()
+
+	if common.IsStrictPerms() {
+		if err := k.checkPermissions(k.Path); err != nil {
+			return err
+		}
+	}
+
+	raw, err := ioutil.ReadAll(f)
+	if err != nil {
+		return err
+	}
+
+	v := raw[0:len(version)]
+	if !bytes.Equal(v, version) {
+		return fmt.Errorf("keystore format doesn't match expected version: '%s' got '%s'", version, v)
+	}
+
+	base64Content := raw[len(version):]
+	if len(base64Content) == 0 {
+		return fmt.Errorf("corrupt or empty keystore")
+	}
+
+	base64Decoder := base64.NewDecoder(base64.StdEncoding, bytes.NewReader(base64Content))
+	plaintext, err := k.decrypt(base64Decoder)
+	if err != nil {
+		return fmt.Errorf("could not decrypt the keystore: %v", err)
+	}
+	jsonDecoder := json.NewDecoder(plaintext)
+	return jsonDecoder.Decode(&k.secrets)
+}
+
+// Encrypt the data payload using a derived keys and the AES-256-GCM algorithm.
+func (k *FileKeystore) encrypt(reader io.Reader) (io.Reader, error) {
+	// randomly generate the salt and the initialization vector, this information will be saved
+	// on disk in the file as part of the header
+	iv, err := common.RandomBytes(iVLength)
+
+	if err != nil {
+		return nil, err
+	}
+
+	salt, err := common.RandomBytes(saltLength)
+	if err != nil {
+		return nil, err
+	}
+
+	// Stretch the user provided key
+	password, _ := k.password.Get()
+	passwordBytes := pbkdf2.Key(password, salt, iterationsCount, keyLength, sha512.New)
+
+	// Select AES-256: because len(passwordBytes) == 32 bytes
+	block, err := aes.NewCipher(passwordBytes)
+	if err != nil {
+		return nil, fmt.Errorf("could not create the keystore cipher to encrypt, error: %s", err)
+	}
+
+	aesgcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("could not create the keystore cipher to encrypt, error: %s", err)
+	}
+
+	data, err := ioutil.ReadAll(reader)
+	if err != nil {
+		return nil, fmt.Errorf("could not read unencrypted data, error: %s", err)
+	}
+
+	encodedBytes := aesgcm.Seal(nil, iv, data, nil)
+
+	// Generate the payload with all the additional information required to decrypt the
+	// output format of the document: VERSION|SALT|IV|PAYLOAD
+	buf := bytes.NewBuffer(salt)
+	buf.Write(iv)
+	buf.Write(encodedBytes)
+
+	return buf, nil
+}
+
+// should receive an io.reader...
+func (k *FileKeystore) decrypt(reader io.Reader) (io.Reader, error) {
+	data, err := ioutil.ReadAll(reader)
+	if err != nil {
+		return nil, fmt.Errorf("could not read all the data from the encrypted file, error: %s", err)
+	}
+
+	if len(data) < saltLength+iVLength+1 {
+		return nil, fmt.Errorf("missing information in the file for decrypting the keystore")
+	}
+
+	// extract the necessary information to decrypt the data from the data payload
+	salt := data[0:saltLength]
+	iv := data[saltLength : saltLength+iVLength]
+	encodedBytes := data[saltLength+iVLength:]
+
+	password, _ := k.password.Get()
+	passwordBytes := pbkdf2.Key(password, salt, iterationsCount, keyLength, sha512.New)
+
+	block, err := aes.NewCipher(passwordBytes)
+	if err != nil {
+		return nil, fmt.Errorf("could not create the keystore cipher to decrypt the data: %s", err)
+	}
+
+	aesgcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("could not create the keystore cipher to decrypt the data: %s", err)
+	}
+
+	decodedBytes, err := aesgcm.Open(nil, iv, encodedBytes, nil)
+	if err != nil {
+		return nil, fmt.Errorf("could not decrypt keystore data: %s", err)
+	}
+
+	return bytes.NewReader(decodedBytes), nil
+}
+
+// checkPermission enforces permission on the keystore file itself, the file should have strict
+// permission (0600) and the keystore should refuses to start if its not the case.
+func (k *FileKeystore) checkPermissions(f string) error {
+	if runtime.GOOS == "windows" {
+		return nil
+	}
+
+	info, err := file.Stat(f)
+	if err != nil {
+		return err
+	}
+
+	euid := os.Geteuid()
+	fileUID, _ := info.UID()
+	perm := info.Mode().Perm()
+
+	if fileUID != 0 && euid != fileUID {
+		return fmt.Errorf(`config file ("%v") must be owned by the beat user `+
+			`(uid=%v) or root`, f, euid)
+	}
+
+	// Test if group or other have write permissions.
+	if perm != filePermission {
+		nameAbs, err := filepath.Abs(f)
+		if err != nil {
+			nameAbs = f
+		}
+		return fmt.Errorf(`file ("%v") can only be writable and readable by the `+
+			`owner but the permissions are "%v" (to fix the permissions use: `+
+			`'chmod go-wrx %v')`,
+			f, perm, nameAbs)
+	}
+
+	return nil
+}

--- a/libbeat/keystore/file_keystore_test.go
+++ b/libbeat/keystore/file_keystore_test.go
@@ -1,0 +1,293 @@
+package keystore
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/docker/docker/pkg/ioutils"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/libbeat/common"
+)
+
+var keyValue = "output.elasticsearch.password"
+var secretValue = []byte("secret")
+
+func TestCanCreateAKeyStore(t *testing.T) {
+	path := GetTemporaryKeystoreFile()
+	defer os.Remove(path)
+
+	keystore, err := NewFileKeystore(path)
+	assert.NoError(t, err)
+	assert.Nil(t, keystore.Store(keyValue, secretValue))
+	assert.Nil(t, keystore.Save())
+}
+
+func TestCanReadAnExistingKeyStoreWithEmptyString(t *testing.T) {
+	path := GetTemporaryKeystoreFile()
+	defer os.Remove(path)
+
+	CreateAnExistingKeystore(path)
+
+	keystoreRead, err := NewFileKeystore(path)
+	assert.NoError(t, err)
+
+	secure, err := keystoreRead.Retrieve(keyValue)
+	assert.NoError(t, err)
+
+	v, err := secure.Get()
+	assert.NoError(t, err)
+	assert.Equal(t, v, secretValue)
+}
+
+func TestCanDeleteAKeyFromTheStoreAndPersistChanges(t *testing.T) {
+	path := GetTemporaryKeystoreFile()
+	defer os.Remove(path)
+
+	CreateAnExistingKeystore(path)
+
+	keystore, _ := NewFileKeystore(path)
+	_, err := keystore.Retrieve(keyValue)
+	assert.NoError(t, err)
+
+	keystore.Delete(keyValue)
+	_, err = keystore.Retrieve(keyValue)
+	assert.Error(t, err)
+
+	_ = keystore.Save()
+	newKeystore, err := NewFileKeystore(path)
+	_, err = newKeystore.Retrieve(keyValue)
+	assert.Error(t, err)
+}
+
+func TestFilePermissionOnCreate(t *testing.T) {
+	// Skip check on windows
+	if runtime.GOOS == "windows" {
+		t.Skip("Permission check is not running on windows")
+	}
+	if !common.IsStrictPerms() {
+		t.Skip("Skipping test because strict.perms is disabled")
+	}
+
+	path := GetTemporaryKeystoreFile()
+	defer os.Remove(path)
+	CreateAnExistingKeystore(path)
+
+	stats, err := os.Stat(path)
+	assert.NoError(t, err)
+	permissions := stats.Mode().Perm()
+	if permissions != 0600 {
+		t.Fatalf("Expecting the file what only readable/writable by the owner, permission found: %v", permissions)
+	}
+}
+
+func TestFilePermissionOnUpdate(t *testing.T) {
+	// Skip check on windows
+	if runtime.GOOS == "windows" {
+		t.Skip("Permission check is not running on windows")
+	}
+	if !common.IsStrictPerms() {
+		t.Skip("Skipping test because strict.perms is disabled")
+	}
+
+	path := GetTemporaryKeystoreFile()
+	defer os.Remove(path)
+
+	keystore := CreateAnExistingKeystore(path)
+	err := keystore.Store("newkey", []byte("newsecret"))
+	assert.NoError(t, err)
+	err = keystore.Save()
+	assert.NoError(t, err)
+	stats, err := os.Stat(path)
+	assert.NoError(t, err)
+	permissions := stats.Mode().Perm()
+	if permissions != 0600 {
+		t.Fatalf("Expecting the file what only readable/writable by the owner, permission found: %v", permissions)
+	}
+}
+
+func TestFilePermissionOnLoadWhenStrictIsOn(t *testing.T) {
+	// Skip check on windows
+	if runtime.GOOS == "windows" {
+		t.Skip("Permission check is not running on windows")
+	}
+
+	if !common.IsStrictPerms() {
+		t.Skip("Skipping test because strict.perms is disabled")
+	}
+
+	path := GetTemporaryKeystoreFile()
+	defer os.Remove(path)
+
+	// Create a world readable keystore file
+	fd, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0666)
+	assert.NoError(t, err)
+	fd.WriteString("bad permission")
+	assert.NoError(t, fd.Close())
+	_, err = NewFileKeystore(path)
+	assert.Error(t, err)
+}
+
+func TestReturnsUsedKeysInTheStore(t *testing.T) {
+	path := GetTemporaryKeystoreFile()
+	defer os.Remove(path)
+
+	keystore := CreateAnExistingKeystore(path)
+
+	keys, err := keystore.List()
+
+	assert.NoError(t, err)
+	assert.Equal(t, len(keys), 1)
+	assert.Equal(t, keys[0], keyValue)
+}
+
+func TestCannotDecryptKeyStoreWithWrongPassword(t *testing.T) {
+	path := GetTemporaryKeystoreFile()
+	defer os.Remove(path)
+
+	keystore, err := NewFileKeystoreWithPassword(path, NewSecureString([]byte("password")))
+	keystore.Store("hello", []byte("world"))
+	keystore.Save()
+
+	_, err = NewFileKeystoreWithPassword(path, NewSecureString([]byte("wrongpassword")))
+	if assert.Error(t, err, "should fail to decrypt the keystore") {
+		m := `could not decrypt the keystore: could not decrypt keystore data: ` +
+			`cipher: message authentication failed`
+		assert.Equal(t, err, fmt.Errorf(m))
+	}
+}
+
+func TestUserDefinedPasswordUTF8(t *testing.T) {
+	createAndReadKeystoreWithPassword(t, []byte("mysecret¥¥password"))
+}
+
+func TestUserDefinedPasswordASCII(t *testing.T) {
+	createAndReadKeystoreWithPassword(t, []byte("mysecret"))
+}
+
+func TestSecretWithUTF8EncodedSecret(t *testing.T) {
+	content := []byte("ありがとうございます") // translation: thank you
+	createAndReadKeystoreSecret(t, []byte("mysuperpassword"), "mykey", content)
+}
+
+func TestSecretWithASCIIEncodedSecret(t *testing.T) {
+	content := []byte("good news everyone") // translation: thank you
+	createAndReadKeystoreSecret(t, []byte("mysuperpassword"), "mykey", content)
+}
+
+func TestGetConfig(t *testing.T) {
+	path := GetTemporaryKeystoreFile()
+	defer os.Remove(path)
+
+	keystore := CreateAnExistingKeystore(path)
+
+	// Add a bit more data of different type
+	keystore.Store("super.nested", []byte("hello"))
+	keystore.Save()
+
+	cfg, err := keystore.GetConfig()
+	assert.NotNil(t, cfg)
+	assert.NoError(t, err)
+
+	secret, err := cfg.String("output.elasticsearch.password", 0)
+	assert.NoError(t, err)
+	assert.Equal(t, secret, "secret")
+
+	port, err := cfg.String("super.nested", 0)
+	assert.Equal(t, port, "hello")
+}
+
+func TestShouldRaiseAndErrorWhenVersionDontMatch(t *testing.T) {
+	temporaryPath := GetTemporaryKeystoreFile()
+	defer os.Remove(temporaryPath)
+
+	badVersion := `v2D/EQwnDNO7yZsjsRFVWGgbkZudhPxVhBkaQAVud66+tK4HRdfPrNrNNgSmhioDGrQ0z/VZpvbw68gb0G
+	G2QHxlP5s4HGRU/GQge3Nsnx0+kDIcb/37gPN1D1TOPHSiRrzzPn2vInmgaLUfEgBgoa9tuXLZEKdh3JPh/q`
+
+	f, err := os.OpenFile(temporaryPath, os.O_CREATE|os.O_WRONLY, 0600)
+	assert.NoError(t, err)
+	f.WriteString(badVersion)
+	err = f.Close()
+	assert.NoError(t, err)
+
+	_, err = NewFileKeystoreWithPassword(temporaryPath, NewSecureString([]byte("")))
+	if assert.Error(t, err, "Expect version check error") {
+		assert.Equal(t, err, fmt.Errorf("keystore format doesn't match expected version: 'v1' got 'v2'"))
+	}
+}
+
+func TestMissingEncryptedBlock(t *testing.T) {
+	temporaryPath := GetTemporaryKeystoreFile()
+	defer os.Remove(temporaryPath)
+
+	badVersion := "v1"
+
+	f, err := os.OpenFile(temporaryPath, os.O_CREATE|os.O_WRONLY, 0600)
+	assert.NoError(t, err)
+	f.WriteString(badVersion)
+	err = f.Close()
+	assert.NoError(t, err)
+
+	_, err = NewFileKeystoreWithPassword(temporaryPath, NewSecureString([]byte("")))
+	if assert.Error(t, err) {
+		assert.Equal(t, err, fmt.Errorf("corrupt or empty keystore"))
+	}
+}
+
+func createAndReadKeystoreSecret(t *testing.T, password []byte, key string, value []byte) {
+	path := GetTemporaryKeystoreFile()
+	defer os.Remove(path)
+
+	keystore, err := NewFileKeystoreWithPassword(path, NewSecureString(password))
+	assert.Nil(t, err)
+
+	keystore.Store(key, value)
+	keystore.Save()
+
+	newStore, err := NewFileKeystoreWithPassword(path, NewSecureString(password))
+	s, _ := newStore.Retrieve(key)
+	v, _ := s.Get()
+	assert.Equal(t, v, value)
+}
+
+func createAndReadKeystoreWithPassword(t *testing.T, password []byte) {
+	path := GetTemporaryKeystoreFile()
+	defer os.Remove(path)
+
+	keystore, err := NewFileKeystoreWithPassword(path, NewSecureString(password))
+	assert.NoError(t, err)
+
+	keystore.Store("hello", []byte("world"))
+	keystore.Save()
+
+	newStore, err := NewFileKeystoreWithPassword(path, NewSecureString(password))
+	s, _ := newStore.Retrieve("hello")
+	v, _ := s.Get()
+
+	assert.Equal(t, v, []byte("world"))
+}
+
+// CreateAnExistingKeystore creates a keystore with an existing key
+/// `output.elasticsearch.password` with the value `secret`.
+func CreateAnExistingKeystore(path string) Keystore {
+	keystore, err := NewFileKeystore(path)
+	// Fail fast in the test suite
+	if err != nil {
+		panic(err)
+	}
+	keystore.Store(keyValue, secretValue)
+	keystore.Save()
+	return keystore
+}
+
+// GetTemporaryKeystoreFile create a temporary file on disk to save the keystore.
+func GetTemporaryKeystoreFile() string {
+	path, err := ioutils.TempDir("", "testing")
+	if err != nil {
+		panic(err)
+	}
+	return filepath.Join(path, "keystore")
+}

--- a/libbeat/keystore/keystore.go
+++ b/libbeat/keystore/keystore.go
@@ -1,0 +1,116 @@
+package keystore
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/logp"
+	ucfg "github.com/elastic/go-ucfg"
+)
+
+var (
+	// ErrAlreadyExists is returned when the file already exist at the location.
+	ErrAlreadyExists = errors.New("cannot create a new keystore a valid keystore already exist at the location")
+
+	// ErrKeyDoesntExists is returned when the key doesn't exist in the store
+	ErrKeyDoesntExists = errors.New("cannot retrieve the key")
+)
+
+// Keystore implement a way to securely saves and retrieves secrets to be used in the configuration
+// Currently all credentials are loaded upfront and are not lazy retrieved, we will eventually move
+// to that concept, so we can deal with tokens that has a limited duration or can be revoked by a
+// remote keystore.
+type Keystore interface {
+	// Store add keys to the keystore, wont be persisted until we save.
+	Store(key string, secret []byte) error
+
+	// Retrieve returns a SecureString instance of the searched key or an error.
+	Retrieve(key string) (*SecureString, error)
+
+	// Delete removes a specific key from the keystore.
+	Delete(key string) error
+
+	// List returns the list of keys in the keystore, return an empty list if none is found.
+	List() ([]string, error)
+
+	// GetConfig returns the key value pair in the config format to be merged with other configuration.
+	GetConfig() (*common.Config, error)
+
+	// Create Allow to create an empty keystore.
+	Create(override bool) error
+
+	// IsPersisted check if the current keystore is persisted.
+	IsPersisted() bool
+
+	// Save persist the changes to the keystore.
+	Save() error
+}
+
+// Factory Create the right keystore with the configured options.
+func Factory(cfg *common.Config, defaultPath string) (Keystore, error) {
+	config := defaultConfig
+
+	if cfg == nil {
+		cfg = common.NewConfig()
+	}
+	err := cfg.Unpack(&config)
+
+	if err != nil {
+		return nil, fmt.Errorf("could not read keystore configuration, err: %v", err)
+	}
+
+	if config.Path == "" {
+		config.Path = defaultPath
+	}
+
+	logp.Debug("keystore", "Loading file keystore from %s", config.Path)
+	keystore, err := NewFileKeystore(config.Path)
+	return keystore, err
+}
+
+// ResolverFromConfig create a resolver from a configuration.
+func ResolverFromConfig(cfg *common.Config, dataPath string) (func(string) (string, error), error) {
+	keystore, err := Factory(cfg, dataPath)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return ResolverWrap(keystore), nil
+}
+
+// ResolverWrap wrap a config resolver around an existing keystore.
+func ResolverWrap(keystore Keystore) func(string) (string, error) {
+	return func(keyName string) (string, error) {
+		key, err := keystore.Retrieve(keyName)
+
+		if err != nil {
+			// If we cannot find the key, its a non fatal error
+			// and we pass to other resolver.
+			if err == ErrKeyDoesntExists {
+				return "", ucfg.ErrMissing
+			}
+			return "", err
+		}
+
+		v, err := key.Get()
+		if err != nil {
+			return "", err
+		}
+
+		logp.Debug("keystore", "accessing key '%s' from the keystore", keyName)
+		return string(v), nil
+	}
+}
+
+// ConfigOpts returns ucfg config options with a resolver linked to the current keystore.
+// TODO: Refactor to allow insert into the config option array without having to redefine everything
+func ConfigOpts(keystore Keystore) []ucfg.Option {
+	return []ucfg.Option{
+		ucfg.PathSep("."),
+		ucfg.Resolve(ResolverWrap(keystore)),
+		ucfg.ResolveEnv,
+		ucfg.VarExp,
+	}
+}

--- a/libbeat/keystore/keystore_test.go
+++ b/libbeat/keystore/keystore_test.go
@@ -1,0 +1,33 @@
+package keystore
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	ucfg "github.com/elastic/go-ucfg"
+)
+
+func TestResolverWhenTheKeyDoesntExist(t *testing.T) {
+	path := GetTemporaryKeystoreFile()
+	defer os.Remove(path)
+
+	keystore := CreateAnExistingKeystore(path)
+
+	resolver := ResolverWrap(keystore)
+	_, err := resolver("donotexist")
+	assert.Equal(t, err, ucfg.ErrMissing)
+}
+
+func TestResolverWhenTheKeyExist(t *testing.T) {
+	path := GetTemporaryKeystoreFile()
+	defer os.Remove(path)
+
+	keystore := CreateAnExistingKeystore(path)
+
+	resolver := ResolverWrap(keystore)
+	v, err := resolver("output.elasticsearch.password")
+	assert.NoError(t, err)
+	assert.Equal(t, v, "secret")
+}

--- a/libbeat/keystore/secure_string.go
+++ b/libbeat/keystore/secure_string.go
@@ -1,0 +1,32 @@
+package keystore
+
+// SecureString Initial implementation for a SecureString representation in
+// beats, currently we keep the password into a Bytes array, we need to implement a way
+// to safely clean that array.
+//
+// Investigate memguard: https://github.com/awnumar/memguard
+type SecureString struct {
+	value []byte
+}
+
+// NewSecureString return a struct representing a secrets string.
+func NewSecureString(value []byte) *SecureString {
+	return &SecureString{
+		value: value,
+	}
+}
+
+// Get returns the byte value of the secret, or an error if we cannot return it.
+func (s *SecureString) Get() ([]byte, error) {
+	return s.value, nil
+}
+
+// String custom string implementation to make sure we don't bleed this struct into a string.
+func (s SecureString) String() string {
+	return "<SecureString>"
+}
+
+// GoString implements the GoStringer interface to hide the secret value.
+func (s SecureString) GoString() string {
+	return s.String()
+}

--- a/libbeat/keystore/secure_string_test.go
+++ b/libbeat/keystore/secure_string_test.go
@@ -1,0 +1,38 @@
+package keystore
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var secret = []byte("mysecret")
+
+func TestGet(t *testing.T) {
+	s := NewSecureString(secret)
+	v, err := s.Get()
+	assert.Equal(t, secret, v)
+	assert.Nil(t, err)
+}
+
+func TestStringMarshalingS(t *testing.T) {
+	s := NewSecureString(secret)
+	v := fmt.Sprintf("%s", s)
+
+	assert.Equal(t, v, "<SecureString>")
+}
+
+func TestStringMarshalingF(t *testing.T) {
+	s := NewSecureString(secret)
+	v := fmt.Sprintf("%v", s)
+
+	assert.Equal(t, v, "<SecureString>")
+}
+
+func TestStringGoStringerMarshaling(t *testing.T) {
+	s := NewSecureString(secret)
+	v := fmt.Sprintf("%#v", s)
+
+	assert.Equal(t, v, "<SecureString>")
+}

--- a/libbeat/tests/system/config/mockbeat.yml.j2
+++ b/libbeat/tests/system/config/mockbeat.yml.j2
@@ -79,4 +79,9 @@ setup.template:
 logging.metrics.period: {{ metrics_period }}
 {%- endif %}
 
+{% if keystore_path %}
+#================================ keystore =====================================
+keystore.path: {{keystore_path}}
+{% endif %}
+
 # vim: set ft=jinja:

--- a/libbeat/tests/system/keystore.py
+++ b/libbeat/tests/system/keystore.py
@@ -1,0 +1,32 @@
+from base import BaseTest
+import os
+from beat.beat import Proc
+
+
+class KeystoreBase(BaseTest):
+    """
+    KeystoreBase provides a simple way to add secrets to an existing store
+    """
+
+    def add_secret(self, key, value="hello world\n", force=False):
+        """
+        Add new secret using the --stdin option
+        """
+        args = [self.test_binary,
+                "-systemTest",
+                "-test.coverprofile",
+                os.path.join(self.working_dir, "coverage.cov"),
+                "-c", os.path.join(self.working_dir, "mockbeat.yml"),
+                "-e", "-v", "-d", "*",
+                "keystore", "add", key, "--stdin",
+                ]
+
+        if force:
+            args.append("--force")
+
+        proc = Proc(args, os.path.join(self.working_dir, "mockbeat.log"))
+
+        os.write(proc.stdin_write, value)
+        os.close(proc.stdin_write)
+
+        return proc.start().wait()

--- a/libbeat/tests/system/test_cmd_keystore.py
+++ b/libbeat/tests/system/test_cmd_keystore.py
@@ -1,0 +1,144 @@
+from os import path
+import os
+import hashlib
+
+from keystore import KeystoreBase
+
+
+class TestCommandKeystore(KeystoreBase):
+    """
+    Test keystore subcommand
+
+    """
+
+    def setUp(self):
+        super(TestCommandKeystore, self).setUp()
+
+        self.keystore_path = self.working_dir + "/data/keystore"
+
+        self.render_config_template(keystore_path=self.keystore_path)
+
+        if path.exists(self.keystore_path):
+            os.Remove(self.keystore_path)
+
+    def test_keystore_create(self):
+        """
+        test keystore create command
+        """
+        exit_code = self.run_beat(extra_args=["keystore", "create"])
+
+        assert exit_code == 0
+        assert path.exists(self.keystore_path)
+
+    def test_keystore_create_force(self):
+        """
+        Allow to override
+        """
+
+        self.run_beat(extra_args=["keystore", "create"])
+
+        assert path.exists(self.keystore_path)
+        digest_before = hashlib.sha256(
+            open(self.keystore_path, 'rb').read()).digest()
+
+        exit_code = self.run_beat(extra_args=["keystore", "create", "--force"])
+        digest_after = hashlib.sha256(
+            open(self.keystore_path, 'rb').read()).digest()
+
+        assert exit_code == 0
+        assert digest_before != digest_after
+
+    def test_keystore_remove_no_key_no_keystore(self):
+        """
+        Remove a key that doesn't exist when the keystore doesn't exist
+        """
+        exit_code = self.run_beat(extra_args=["keystore", "remove", "mykey"])
+        assert exit_code == 1
+        assert "The filebeat keystore doesn't exist."
+
+    def test_keystore_remove_non_existing_key(self):
+        """
+        Remove a key that doesn't exist in the keystore
+        """
+        self.run_beat(extra_args=["keystore", "create"])
+
+        exit_code = self.run_beat(extra_args=["keystore", "remove", "mykey"])
+        assert exit_code == 1
+
+    def test_keystore_remove_existing_key(self):
+        """
+        Remove an key present in the keystore
+        """
+        self.run_beat(extra_args=["keystore", "create"])
+
+        self.add_secret("mykey")
+        exit_code = self.run_beat(extra_args=["keystore", "remove", "mykey"])
+
+        assert exit_code == 0
+
+    def test_keystore_remove_multiples_existing_keys(self):
+        """
+        Remove an key present in the keystore
+        """
+
+        self.run_beat(extra_args=["keystore", "create"])
+
+        self.add_secret("willnotdelete")
+        self.add_secret("myawesomekey")
+        self.add_secret("mysuperkey")
+
+        exit_code = self.run_beat(
+            extra_args=["keystore", "remove", "mysuperkey", "myawesomekey"])
+
+        assert exit_code == 0
+
+        exit_code = self.run_beat(extra_args=["keystore", "list"])
+
+        assert exit_code == 0
+
+    def test_keystore_list(self):
+        """
+        list the available keys
+        """
+
+        self.run_beat(extra_args=["keystore", "create"])
+
+        self.add_secret("willnotdelete")
+        self.add_secret("myawesomekey")
+        self.add_secret("mysuperkey")
+
+        exit_code = self.run_beat(extra_args=["keystore", "list"])
+
+        assert exit_code == 0
+
+        assert self.log_contains("willnotdelete")
+        assert self.log_contains("myawesomekey")
+        assert self.log_contains("mysuperkey")
+
+    def test_keystore_list_keys_on_an_empty_keystore(self):
+        """
+        List keys on an empty keystore should not return anything
+        """
+        exit_code = self.run_beat(extra_args=["keystore", "list"])
+        assert exit_code == 0
+
+    def test_keystore_add_secret_from_stdin(self):
+        """
+        Add a secret to the store using stdin
+        """
+        self.run_beat(extra_args=["keystore", "create"])
+        exit_code = self.add_secret("willnotdelete")
+
+        assert exit_code == 0
+
+    def test_keystore_update_force(self):
+        """
+        Update an existing key using the --force flag
+        """
+        self.run_beat(extra_args=["keystore", "create"])
+
+        self.add_secret("superkey")
+
+        exit_code = self.add_secret("mysuperkey", "hello", True)
+
+        assert exit_code == 0

--- a/libbeat/tests/system/test_keystore.py
+++ b/libbeat/tests/system/test_keystore.py
@@ -1,0 +1,51 @@
+import os
+from os import path
+
+from base import BaseTest
+from keystore import KeystoreBase
+
+
+class TestKeystore(KeystoreBase):
+    """
+    Test Keystore variable replacement
+    """
+
+    def setUp(self):
+        super(BaseTest, self).setUp()
+        self.keystore_path = self.working_dir + "/data/keystore"
+
+        if path.exists(self.keystore_path):
+            os.Remove(self.keystore_path)
+
+    def test_keystore_with_present_key(self):
+        """
+        Test that we correctly to string replacement with values from the keystore
+        """
+
+        key = "elasticsearch_host"
+        secret = "myeleasticsearchsecrethost"
+
+        self.render_config_template(keystore_path=self.keystore_path, elasticsearch={
+            'hosts': "${%s}:9200" % key
+        })
+
+        exit_code = self.run_beat(extra_args=["keystore", "create"])
+        assert exit_code == 0
+
+        self.add_secret(key, secret)
+        proc = self.start_beat()
+        self.wait_until(lambda: self.log_contains("no such host"))
+        assert self.log_contains(secret)
+        proc.check_kill_and_wait()
+
+    def test_keystore_with_key_not_present(self):
+        key = "elasticsearch_host"
+
+        self.render_config_template(keystore_path=self.keystore_path, elasticsearch={
+            'hosts': "${%s}:9200" % key
+        })
+
+        exit_code = self.run_beat()
+        assert self.log_contains(
+            "missing field accessing 'output.elasticsearch.hosts'")
+        assert exit_code == 1


### PR DESCRIPTION
This PR allow users to define sensitive information into an obfuscated data store on disk instead of having them defined in plaintext in the yaml configuration.

This add a few users facing commands:

```sh
# create new keystore to disk 
beat keystore create

# add a new key to the store.
beat keystore add output.elasticsearch.password

# remove a key from the store
beat keystore remove output.elasticsearch.password

# list the configured keys without the sensitive information
beat keystore list
```

The current implementation doesn't allow user to configure the secret with a custom password, this will come in future improvements of this feature.


### How to use it

You can reference keys from the keystore using the same syntax that we use for the environment variables. 

```yaml
password: "${output.elasticsearch.password}"
```

When we unpack the configuration we will resolve the variables using the following priority:

- Keystore
- Environment variable
- variable expansion

### TODO before review
- [x] **Fix the checker that prevent the tests from passing on travis :D**
- [x] Manual testing
- [x] Split the library update vs this PR, update of the library was needed for a few encryption and terminal improvement.
- [x] fix the suite, the make testsuite fails locally for me.
- [x] movee the CLI test into libbeat
- ~~[ ] raise an error if we try override a config defined in the yaml file. (Another PR)~~
- [x] add testing around the merging of configs
- [ ] Add doc (Done in another PR)
- [x] implement templating 


This is the initial version, I don't expect it to be pluggable with every system, but some of the things are in place to make it pluggable.(ie: interface/factory)

closes: #3982 