### PR TITLE
 Go vet complains on composite literal uses unkeyed fields

### DIFF
--- a/libbeat/template/processor_test.go
+++ b/libbeat/template/processor_test.go
@@ -138,19 +138,19 @@ func TestProcessor(t *testing.T) {
 			},
 		},
 		{
-			output: p.object(&common.Field{Dynamic: common.DynamicType{false}}),
+			output: p.object(&common.Field{Dynamic: common.DynamicType{Value:false}}),
 			expected: common.MapStr{
 				"dynamic": false, "type": "object",
 			},
 		},
 		{
-			output: p.object(&common.Field{Dynamic: common.DynamicType{true}}),
+			output: p.object(&common.Field{Dynamic: common.DynamicType{Value:true}}),
 			expected: common.MapStr{
 				"dynamic": true, "type": "object",
 			},
 		},
 		{
-			output: p.object(&common.Field{Dynamic: common.DynamicType{"strict"}}),
+			output: p.object(&common.Field{Dynamic: common.DynamicType{Value:"strict"}}),
 			expected: common.MapStr{
 				"dynamic": "strict", "type": "object",
 			},


### PR DESCRIPTION
This was found with #5687, this problems does not seems to be triggered on the CI, only on my local environment when I run `make check`, I am running `go 1.9.2`, I will do a bit more check on the CI to see why this is not triggered.

```
Checking file template/config.go
Checking file template/load.go
Checking file template/processor.go
Checking file template/template.go
Checking file template/processor_test.go
template/processor_test.go:141: github.com/elastic/beats/libbeat/common.DynamicType composite literal uses unkeyed fields
template/processor_test.go:147: github.com/elastic/beats/libbeat/common.DynamicType composite literal uses unkeyed fields
template/processor_test.go:153: github.com/elastic/beats/libbeat/common.DynamicType composite literal uses unkeyed fields
Checking file template/template_test.go
exit status 1
```