### PR TITLE
Bugfix/use make macro

### DIFF
--- a/generator/beat/{beat}/Makefile
+++ b/generator/beat/{beat}/Makefile
@@ -15,7 +15,7 @@ NOTICE_FILE=NOTICE
 # Initial beat setup
 .PHONY: setup
 setup: copy-vendor
-	make update
+	$(MAKE) update
 
 # Copy beats into vendor directory
 .PHONY: copy-vendor

--- a/generator/common/Makefile
+++ b/generator/common/Makefile
@@ -13,12 +13,12 @@ test: prepare-test
 	export GOPATH=${PWD}/build ; \
 	export PATH=${PATH}:${PWD}/build/bin; \
 	cd ${BEAT_PATH} ; \
-	make copy-vendor || exit 1  ; \
+	$(MAKE) copy-vendor || exit 1  ; \
 	${PREPARE_COMMAND} \
-	make check || exit 1 ; \
-	make update || exit 1 ; \
-	make || exit 1 ; \
-	make unit
+	$(MAKE) check || exit 1 ; \
+	$(MAKE) update || exit 1 ; \
+	$(MAKE) || exit 1 ; \
+	$(MAKE) unit
 
 prepare-test:: python-env
 	# Makes sure to use current version of beats for testing
@@ -36,8 +36,8 @@ test-build: test
 	cp -r ${PWD}/../../../dev-tools ${BEAT_PATH}/vendor/github.com/elastic/beats/
 
 	cd ${BEAT_PATH}/dev-tools/packer ; \
-	make deps ; \
-	make images
+	$(MAKE) deps ; \
+	$(MAKE) images
 
 # Sets up the virtual python environment
 .PHONY: python-env

--- a/generator/metricbeat/{beat}/Makefile
+++ b/generator/metricbeat/{beat}/Makefile
@@ -14,8 +14,8 @@ NOTICE_FILE=NOTICE
 # Initial beat setup
 .PHONY: setup
 setup: copy-vendor
-	make create-metricset
-	make collect
+	$(MAKE) create-metricset
+	$(MAKE) collect
 
 # Copy beats into vendor directory
 .PHONY: copy-vendor

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -64,7 +64,7 @@ BUILDID?=$(shell git rev-parse HEAD) ## @Building The build ID
 VIRTUALENV_PARAMS?=
 INTEGRATION_TESTS?=
 FIND=. ${PYTHON_ENV}/bin/activate; find . -type f -not -path "*/vendor/*" -not -path "*/build/*" -not -path "*/.git/*"
-PERM_EXEC=$(shell [ `uname -s` = "Darwin" ] && echo "+111" || echo "/a+x")
+PERM_EXEC?=$(shell [ `uname -s` = "Darwin" ] && echo "+111" || echo "/a+x")
 
 # Cross compiling targets
 CGO?=true ## @building if true, Build with C Go support


### PR DESCRIPTION
Arose from the conversation at [1]

This PR replaces direct `make` call in Makefiles by `$(MAKE)` macro.
It suppress warning message and it is good way to use make (cf [2].)

Note:

- The 2nd commit is logically independent of `$(MAKE)` fix, but it is needed to execute
  `make test` in `generator/` because I use GNU toolset on darwin. If it should be
  separate PR or abandoned, it's OK.
- The issue [1] originally found in 6.0 branch. I'm not sure what branching strategy this
  repository uses, please let me know if this PR should go to 6.0 branch.

[1] https://github.com/elastic/beats/issues/5662#issuecomment-346215133
[2] https://www.gnu.org/software/make/manual/html_node/MAKE-Variable.html#MAKE-Variable

Thanks.