### PR TITLE
Change pipeline delimiter to {< and >}

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -51,6 +51,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Fix race condition when limiting the number of harvesters running in parallel {issue}5458[5458]
 - Fix relative paths in the prospector definitions. {pull}5443[5433]
 - Fix `recursive_globe.enabled` option. {pull}5443[5443]
+- Change pipeline delimiter to `{<` and `>}`. {pull}5702[5702]
 
 *Heartbeat*
 

--- a/filebeat/fileset/fileset.go
+++ b/filebeat/fileset/fileset.go
@@ -226,12 +226,12 @@ func resolveVariable(vars map[string]interface{}, value interface{}) (interface{
 }
 
 // applyTemplate applies a Golang text/template. If specialDelims is set to true,
-// the delimiters are set to `{%` and `%}` instead of `{{` and `}}`. These are easier to use
+// the delimiters are set to `{<` and `>}` instead of `{{` and `}}`. These are easier to use
 // in pipeline definitions.
 func applyTemplate(vars map[string]interface{}, templateString string, specialDelims bool) (string, error) {
 	tpl := template.New("text")
 	if specialDelims {
-		tpl = tpl.Delims("{%", "%}")
+		tpl = tpl.Delims("{<", ">}")
 	}
 	tpl, err := tpl.Parse(templateString)
 	if err != nil {

--- a/filebeat/module/system/auth/ingest/pipeline.json
+++ b/filebeat/module/system/auth/ingest/pipeline.json
@@ -32,7 +32,7 @@
 					"MMM  d HH:mm:ss",
 					"MMM dd HH:mm:ss"
         ],
-        {% if .convert_timezone %}"timezone": "{{ beat.timezone }}",{% end %}
+        {< if .convert_timezone >}"timezone": "{{ beat.timezone }}",{< end >}
         "ignore_failure": true
       }
     },

--- a/filebeat/module/system/syslog/ingest/pipeline.json
+++ b/filebeat/module/system/syslog/ingest/pipeline.json
@@ -27,7 +27,7 @@
 					"MMM  d HH:mm:ss",
 					"MMM dd HH:mm:ss"
         ],
-        {% if .convert_timezone %}"timezone": "{{ beat.timezone }}",{% end %}
+        {< if .convert_timezone >}"timezone": "{{ beat.timezone }}",{< end >}
         "ignore_failure": true
       }
     }


### PR DESCRIPTION
The new delimiters are `{<` and `>}`. These are not likely to turn up regexes or Grok pattern. Regexes between `{` and `}` metacharacters include numbers and comma. Grok patterns include letters inside `%{` and `}`. Also, it is not likely that someone would compare anything which ends with `{` or starts with `}`.

Previously used `{%` and `%}` were more likely to cause problems as Grok patterns start with `%{`.

Fixes #5701