### PR TITLE
Skip flaky LS node_stats tests

### DIFF
--- a/metricbeat/module/logstash/node_stats/node_stats_integration_test.go
+++ b/metricbeat/module/logstash/node_stats/node_stats_integration_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestFetch(t *testing.T) {
+	t.Skipf("Test is currently skipped as `node_stats` test is flaky.")
 
 	compose.EnsureUpWithTimeout(t, 120, "logstash")
 


### PR DESCRIPTION
The node_stats integration tests is skipped as it is currently flaky.

The issue is tracked here and skipping tests should be removed as soon as issue is resolved: https://github.com/elastic/beats/issues/5712