### PR TITLE
Fix flaky node_stats Logstash tests

### DIFF
--- a/metricbeat/module/logstash/_meta/Dockerfile
+++ b/metricbeat/module/logstash/_meta/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/logstash/logstash:6.0.0-rc2
+FROM docker.elastic.co/logstash/logstash:6.0.0
 
 ENV XPACK_MONITORING_ENABLED=FALSE
-HEALTHCHECK --interval=1s --retries=90 CMD curl -f http://localhost:9600
+HEALTHCHECK --interval=1s --retries=90 CMD curl -f http://localhost:9600/_node/stats

--- a/metricbeat/module/logstash/node_stats/node_stats_integration_test.go
+++ b/metricbeat/module/logstash/node_stats/node_stats_integration_test.go
@@ -13,8 +13,6 @@ import (
 )
 
 func TestFetch(t *testing.T) {
-	t.Skipf("Test is currently skipped as `node_stats` test is flaky.")
-
 	compose.EnsureUpWithTimeout(t, 120, "logstash")
 
 	f := mbtest.NewEventFetcher(t, logstash.GetConfig("node_stats"))


### PR DESCRIPTION
Update healthcheck to use _node/stats instead. As soon as this returns a 200 all endpoints should work as expected. See elastic/logstash#8004.

* Remove skipped tests
* Update LS image to latest stable version

Closes #5712