### PR TITLE
Fix README.md link in packages

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -30,6 +30,8 @@ https://github.com/elastic/beats/compare/v6.0.0...master[Check the HEAD diff]
 
 *Affecting all Beats*
 
+- Fix documentation links in README.md files. {pull}5710[5710]
+
 *Auditbeat*
 
 *Filebeat*

--- a/dev-tools/packer/xgo-scripts/before_build.sh
+++ b/dev-tools/packer/xgo-scripts/before_build.sh
@@ -54,7 +54,8 @@ fi
 cat ${ES_BEATS}/libbeat/docs/version.asciidoc >> ${PREFIX}/package.yml
 
 # Make variable naming of doc-branch compatible with gotpl. Generate and copy README.md into homedir
-sed -i -e 's/:doc-branch/doc_branch/g' ${PREFIX}/package.yml
+# Add " to the version as gotpl interprets 6.0 as 6
+sed -i -e 's/:doc-branch: \([0-9]*.[0-9]*\)/doc_branch: "\1" /g' ${PREFIX}/package.yml
 
 # Create README file
 /go/bin/gotpl /templates/readme.md.j2 < ${PREFIX}/package.yml > ${PREFIX}/homedir/README.md


### PR DESCRIPTION
The links in the README.md file are broken for the 6.0 release. The reason is that gotpl interprets 6.0 and makes 6 out of it. Add "..." around fixes the issue.