### PR TITLE
Create module overview page for Metricbeat

### DIFF
--- a/metricbeat/docs/modules_list.asciidoc
+++ b/metricbeat/docs/modules_list.asciidoc
@@ -2,37 +2,122 @@
 This file is generated! See scripts/docs_collector.py
 ////
 
-  * <<metricbeat-module-aerospike,Aerospike>>
-  * <<metricbeat-module-apache,Apache>>
-  * <<metricbeat-module-ceph,Ceph>>
-  * <<metricbeat-module-couchbase,Couchbase>>
-  * <<metricbeat-module-docker,Docker>>
-  * <<metricbeat-module-dropwizard,Dropwizard>>
-  * <<metricbeat-module-elasticsearch,Elasticsearch>>
-  * <<metricbeat-module-etcd,Etcd>>
-  * <<metricbeat-module-golang,Golang>>
-  * <<metricbeat-module-graphite,Graphite>>
-  * <<metricbeat-module-haproxy,HAProxy>>
-  * <<metricbeat-module-http,HTTP>>
-  * <<metricbeat-module-jolokia,Jolokia>>
-  * <<metricbeat-module-kafka,Kafka>>
-  * <<metricbeat-module-kibana,Kibana>>
-  * <<metricbeat-module-kubernetes,Kubernetes>>
-  * <<metricbeat-module-logstash,Logstash>>
-  * <<metricbeat-module-memcached,Memcached>>
-  * <<metricbeat-module-mongodb,MongoDB>>
-  * <<metricbeat-module-mysql,MySQL>>
-  * <<metricbeat-module-nginx,Nginx>>
-  * <<metricbeat-module-php_fpm,PHP_FPM>>
-  * <<metricbeat-module-postgresql,PostgreSQL>>
-  * <<metricbeat-module-prometheus,Prometheus>>
-  * <<metricbeat-module-rabbitmq,RabbitMQ>>
-  * <<metricbeat-module-redis,Redis>>
-  * <<metricbeat-module-system,System>>
-  * <<metricbeat-module-vsphere,vSphere>>
-  * <<metricbeat-module-windows,Windows>>
-  * <<metricbeat-module-zookeeper,ZooKeeper>>
-
+[options="header"]
+|========================
+|Modules   |Metricsets   
+|<<metricbeat-module-aerospike,Aerospike>>  beta[]   |    
+.1+|   |<<metricbeat-metricset-aerospike-namespace,namespace>> beta[]  
+|<<metricbeat-module-apache,Apache>>     |    
+.1+|   |<<metricbeat-metricset-apache-status,status>>   
+|<<metricbeat-module-ceph,Ceph>>  beta[]   |    
+.6+|   |<<metricbeat-metricset-ceph-cluster_disk,cluster_disk>> beta[]  
+|<<metricbeat-metricset-ceph-cluster_health,cluster_health>> beta[]  
+|<<metricbeat-metricset-ceph-cluster_status,cluster_status>> beta[]  
+|<<metricbeat-metricset-ceph-monitor_health,monitor_health>> beta[]  
+|<<metricbeat-metricset-ceph-osd_tree,osd_tree>> beta[]  
+|<<metricbeat-metricset-ceph-pool_disk,pool_disk>> beta[]  
+|<<metricbeat-module-couchbase,Couchbase>>  beta[]   |    
+.3+|   |<<metricbeat-metricset-couchbase-bucket,bucket>> beta[]  
+|<<metricbeat-metricset-couchbase-cluster,cluster>> beta[]  
+|<<metricbeat-metricset-couchbase-node,node>> beta[]  
+|<<metricbeat-module-docker,Docker>>  beta[]   |    
+.8+|   |<<metricbeat-metricset-docker-container,container>> beta[]  
+|<<metricbeat-metricset-docker-cpu,cpu>> beta[]  
+|<<metricbeat-metricset-docker-diskio,diskio>> beta[]  
+|<<metricbeat-metricset-docker-healthcheck,healthcheck>> beta[]  
+|<<metricbeat-metricset-docker-image,image>> beta[]  
+|<<metricbeat-metricset-docker-info,info>> beta[]  
+|<<metricbeat-metricset-docker-memory,memory>> beta[]  
+|<<metricbeat-metricset-docker-network,network>> beta[]  
+|<<metricbeat-module-dropwizard,Dropwizard>>  beta[]   |    
+.1+|   |<<metricbeat-metricset-dropwizard-collector,collector>> beta[]  
+|<<metricbeat-module-elasticsearch,Elasticsearch>>  beta[]   |    
+.2+|   |<<metricbeat-metricset-elasticsearch-node,node>> beta[]  
+|<<metricbeat-metricset-elasticsearch-node_stats,node_stats>> beta[]  
+|<<metricbeat-module-etcd,Etcd>>  beta[]   |    
+.3+|   |<<metricbeat-metricset-etcd-leader,leader>> beta[]  
+|<<metricbeat-metricset-etcd-self,self>> beta[]  
+|<<metricbeat-metricset-etcd-store,store>> beta[]  
+|<<metricbeat-module-golang,Golang>>  experimental[]   |    
+.2+|   |<<metricbeat-metricset-golang-expvar,expvar>> experimental[]  
+|<<metricbeat-metricset-golang-heap,heap>> experimental[]  
+|<<metricbeat-module-graphite,Graphite>>  beta[]   |    
+.1+|   |<<metricbeat-metricset-graphite-server,server>> beta[]  
+|<<metricbeat-module-haproxy,HAProxy>>     |    
+.2+|   |<<metricbeat-metricset-haproxy-info,info>>   
+|<<metricbeat-metricset-haproxy-stat,stat>>   
+|<<metricbeat-module-http,HTTP>>  beta[]   |    
+.2+|   |<<metricbeat-metricset-http-json,json>> beta[]  
+|<<metricbeat-metricset-http-server,server>> experimental[]  
+|<<metricbeat-module-jolokia,Jolokia>>  beta[]   |    
+.1+|   |<<metricbeat-metricset-jolokia-jmx,jmx>> beta[]  
+|<<metricbeat-module-kafka,Kafka>>  beta[]   |    
+.2+|   |<<metricbeat-metricset-kafka-consumergroup,consumergroup>> beta[]  
+|<<metricbeat-metricset-kafka-partition,partition>> beta[]  
+|<<metricbeat-module-kibana,Kibana>>  beta[]   |    
+.1+|   |<<metricbeat-metricset-kibana-status,status>> beta[]  
+|<<metricbeat-module-kubernetes,Kubernetes>>  beta[]   |    
+.11+|   |<<metricbeat-metricset-kubernetes-container,container>> beta[]  
+|<<metricbeat-metricset-kubernetes-event,event>> experimental[]  
+|<<metricbeat-metricset-kubernetes-node,node>> beta[]  
+|<<metricbeat-metricset-kubernetes-pod,pod>> beta[]  
+|<<metricbeat-metricset-kubernetes-state_container,state_container>> beta[]  
+|<<metricbeat-metricset-kubernetes-state_deployment,state_deployment>> beta[]  
+|<<metricbeat-metricset-kubernetes-state_node,state_node>> beta[]  
+|<<metricbeat-metricset-kubernetes-state_pod,state_pod>> beta[]  
+|<<metricbeat-metricset-kubernetes-state_replicaset,state_replicaset>> beta[]  
+|<<metricbeat-metricset-kubernetes-system,system>> beta[]  
+|<<metricbeat-metricset-kubernetes-volume,volume>> beta[]  
+|<<metricbeat-module-logstash,Logstash>>  experimental[]   |    
+.2+|   |<<metricbeat-metricset-logstash-node,node>> experimental[]  
+|<<metricbeat-metricset-logstash-node_stats,node_stats>> experimental[]  
+|<<metricbeat-module-memcached,Memcached>>  beta[]   |    
+.1+|   |<<metricbeat-metricset-memcached-stats,stats>> beta[]  
+|<<metricbeat-module-mongodb,MongoDB>>  beta[]   |    
+.2+|   |<<metricbeat-metricset-mongodb-dbstats,dbstats>> beta[]  
+|<<metricbeat-metricset-mongodb-status,status>> beta[]  
+|<<metricbeat-module-mysql,MySQL>>     |    
+.1+|   |<<metricbeat-metricset-mysql-status,status>>   
+|<<metricbeat-module-nginx,Nginx>>     |    
+.1+|   |<<metricbeat-metricset-nginx-stubstatus,stubstatus>>   
+|<<metricbeat-module-php_fpm,PHP_FPM>>  beta[]   |    
+.1+|   |<<metricbeat-metricset-php_fpm-pool,pool>> beta[]  
+|<<metricbeat-module-postgresql,PostgreSQL>>     |    
+.3+|   |<<metricbeat-metricset-postgresql-activity,activity>>   
+|<<metricbeat-metricset-postgresql-bgwriter,bgwriter>>   
+|<<metricbeat-metricset-postgresql-database,database>>   
+|<<metricbeat-module-prometheus,Prometheus>>  beta[]   |    
+.2+|   |<<metricbeat-metricset-prometheus-collector,collector>> beta[]  
+|<<metricbeat-metricset-prometheus-stats,stats>> beta[]  
+|<<metricbeat-module-rabbitmq,RabbitMQ>>  beta[]   |    
+.2+|   |<<metricbeat-metricset-rabbitmq-node,node>> beta[]  
+|<<metricbeat-metricset-rabbitmq-queue,queue>> beta[]  
+|<<metricbeat-module-redis,Redis>>     |    
+.2+|   |<<metricbeat-metricset-redis-info,info>>   
+|<<metricbeat-metricset-redis-keyspace,keyspace>>   
+|<<metricbeat-module-system,System>>     |    
+.12+|   |<<metricbeat-metricset-system-core,core>>   
+|<<metricbeat-metricset-system-cpu,cpu>>   
+|<<metricbeat-metricset-system-diskio,diskio>>   
+|<<metricbeat-metricset-system-filesystem,filesystem>>   
+|<<metricbeat-metricset-system-fsstat,fsstat>>   
+|<<metricbeat-metricset-system-load,load>>   
+|<<metricbeat-metricset-system-memory,memory>>   
+|<<metricbeat-metricset-system-network,network>>   
+|<<metricbeat-metricset-system-process,process>>   
+|<<metricbeat-metricset-system-process_summary,process_summary>>   
+|<<metricbeat-metricset-system-socket,socket>> beta[]  
+|<<metricbeat-metricset-system-uptime,uptime>>   
+|<<metricbeat-module-vsphere,vSphere>>  beta[]   |    
+.3+|   |<<metricbeat-metricset-vsphere-datastore,datastore>> beta[]  
+|<<metricbeat-metricset-vsphere-host,host>> beta[]  
+|<<metricbeat-metricset-vsphere-virtualmachine,virtualmachine>> beta[]  
+|<<metricbeat-module-windows,Windows>>  beta[]   |    
+.2+|   |<<metricbeat-metricset-windows-perfmon,perfmon>> beta[]  
+|<<metricbeat-metricset-windows-service,service>> beta[]  
+|<<metricbeat-module-zookeeper,ZooKeeper>>     |    
+.1+|   |<<metricbeat-metricset-zookeeper-mntr,mntr>>   
+|================================
 
 --
 

--- a/metricbeat/scripts/docs_collector.py
+++ b/metricbeat/scripts/docs_collector.py
@@ -53,7 +53,10 @@ This file is generated! See scripts/docs_collector.py
         with open(module_doc) as f:
             module_file += f.read()
 
-        modules_list[module] = title
+        modules_list[module] = {}
+        modules_list[module]["title"] = title
+        modules_list[module]["release"] = release
+        modules_list[module]["metricsets"] = {}
 
         config_file = beat_path + "/config.yml"
 
@@ -103,6 +106,10 @@ in <<configuration-metricbeat>>. Here is an example configuration:
             link = "<<" + link_name + "," + metricset + ">>"
             reference = "[[" + link_name + "]]"
 
+            modules_list[module]["metricsets"][metricset] = {}
+            modules_list[module]["metricsets"][metricset]["title"] = metricset
+            modules_list[module]["metricsets"][metricset]["link"] = link
+
             module_links += "* " + link + "\n\n"
 
             module_includes += "include::" + module + "/" + metricset + ".asciidoc[]\n\n"
@@ -125,6 +132,8 @@ in <<configuration-metricbeat>>. Here is an example configuration:
             release = get_release(metricset_fields)
             if release != "ga":
                 metricset_file += "{}[]\n\n".format(get_release(metricset_fields))
+
+            modules_list[module]["metricsets"][metricset]["release"] = release
 
             metricset_file += 'include::../../../module/' + module + '/' + metricset + '/_meta/docs.asciidoc[]' + "\n"
 
@@ -162,12 +171,36 @@ For a description of each field in the metricset, see the
             f.write(module_file)
 
     module_list_output = generated_note
-    for m, title in sorted(six.iteritems(modules_list)):
-        module_list_output += "  * <<metricbeat-module-" + m + "," + title + ">>\n"
+
+    module_list_output += '[options="header"]\n'
+    module_list_output += '|========================\n'
+    module_list_output += '|Modules   |Metricsets   \n'
+
+    for key, m in sorted(six.iteritems(modules_list)):
+
+        release_label = ""
+        if m["release"] != "ga":
+            release_label = m["release"] + "[]"
+
+        module_list_output += '|{} {}   |{}    \n'.format("<<metricbeat-module-" +
+                                                          key + "," + m["title"] + ">> ", release_label, "")
+
+        # Make sure empty entry row spans over all metricset rows for this module
+        module_list_output += '.{}+|   '.format(len(m["metricsets"]))
+
+        for key, ms in sorted(six.iteritems(m["metricsets"])):
+
+            release_label = ""
+            if ms["release"] != "ga":
+                release_label = ms["release"] + "[]"
+
+            module_list_output += '|{} {}  \n'.format(ms["link"], release_label)
+
+    module_list_output += '|================================'
 
     module_list_output += "\n\n--\n\n"
-    for m, title in sorted(six.iteritems(modules_list)):
-        module_list_output += "include::modules/" + m + ".asciidoc[]\n"
+    for key, m in sorted(six.iteritems(modules_list)):
+        module_list_output += "include::modules/" + key + ".asciidoc[]\n"
 
     # Write module link list
     with open(os.path.abspath("docs") + "/modules_list.asciidoc", 'w') as f:


### PR DESCRIPTION
This creates a module overview page which lists each Module with its metricsets and the release stats of the Module and Metricsets. The goal is to give an simple overview over all modules and metricsets and what release stage they are in.

An Screenshot on how it looks can be found below:

![screen shot 2017-11-27 at 15 58 45](https://user-images.githubusercontent.com/244900/33251619-2e1a3412-d38c-11e7-8558-3635daa4eff0.png)

@dedemorton Any input on how you would like to have this table or other format you would suggest?