### PR TITLE
Index pod IP too in `ip_port` kubernetes indexer

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -90,6 +90,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Add number_of_routing_shards config set to 30 {pull}5570[5570]
 - Set log level for kafka output. {pull}5397[5397]
 - Moved `ip_port` indexer for `add_kubernetes_metadata` to all beats. {pull}5707[5707]
+- `ip_port` indexer now index both IP and IP:port pairs. {pull}5721[5721]
 
 *Auditbeat*
 

--- a/libbeat/processors/add_kubernetes_metadata/indexers.go
+++ b/libbeat/processors/add_kubernetes_metadata/indexers.go
@@ -269,7 +269,14 @@ func (h *IPPortIndexer) GetMetadata(pod *Pod) []MetadataIndex {
 	if pod.Status.PodIP == "" {
 		return metadata
 	}
-	for i := 0; i < len(hostPorts); i++ {
+
+	// Add pod IP
+	metadata = append(metadata, MetadataIndex{
+		Index: pod.Status.PodIP,
+		Data:  commonMeta,
+	})
+
+	for i := 1; i < len(hostPorts); i++ {
 		dobreak := false
 		containerMeta := commonMeta.Clone()
 		for _, container := range pod.Spec.Containers {
@@ -291,7 +298,6 @@ func (h *IPPortIndexer) GetMetadata(pod *Pod) []MetadataIndex {
 			if dobreak {
 				break
 			}
-
 		}
 
 		metadata = append(metadata, MetadataIndex{
@@ -311,18 +317,18 @@ func (h *IPPortIndexer) GetIndexes(pod *Pod) []string {
 	if ip == "" {
 		return hostPorts
 	}
+
+	// Add pod IP
+	hostPorts = append(hostPorts, ip)
+
 	for _, container := range pod.Spec.Containers {
 		ports := container.Ports
 
 		for _, port := range ports {
 			if port.ContainerPort != int64(0) {
 				hostPorts = append(hostPorts, fmt.Sprintf("%s:%d", ip, port.ContainerPort))
-			} else {
-				hostPorts = append(hostPorts, ip)
 			}
-
 		}
-
 	}
 
 	return hostPorts

--- a/libbeat/processors/add_kubernetes_metadata/indexers_test.go
+++ b/libbeat/processors/add_kubernetes_metadata/indexers_test.go
@@ -268,8 +268,16 @@ func TestIpPortIndexer(t *testing.T) {
 
 	indexers := ipIndexer.GetMetadata(&pod)
 	indices := ipIndexer.GetIndexes(&pod)
-	assert.Equal(t, len(indexers), 0)
-	assert.Equal(t, len(indices), 0)
+
+	assert.Equal(t, 1, len(indexers))
+	assert.Equal(t, 1, len(indices))
+	assert.Equal(t, ip, indices[0])
+	assert.Equal(t, ip, indexers[0].Index)
+
+	// Meta doesn't have container info
+	_, err = indexers[0].Data.GetValue("kubernetes.container.name")
+	assert.NotNil(t, err)
+
 	expected := common.MapStr{
 		"pod": common.MapStr{
 			"name": "testpod",
@@ -291,15 +299,18 @@ func TestIpPortIndexer(t *testing.T) {
 			},
 		},
 	}
-	expected["container"] = common.MapStr{"name": container}
 
 	indexers = ipIndexer.GetMetadata(&pod)
-	assert.Equal(t, len(indexers), 1)
-	assert.Equal(t, indexers[0].Index, fmt.Sprintf("%s:%d", ip, port))
+	assert.Equal(t, 2, len(indexers))
+	assert.Equal(t, ip, indexers[0].Index)
+	assert.Equal(t, fmt.Sprintf("%s:%d", ip, port), indexers[1].Index)
 
 	indices = ipIndexer.GetIndexes(&pod)
-	assert.Equal(t, len(indices), 1)
-	assert.Equal(t, indices[0], fmt.Sprintf("%s:%d", ip, port))
+	assert.Equal(t, 2, len(indices))
+	assert.Equal(t, ip, indices[0])
+	assert.Equal(t, fmt.Sprintf("%s:%d", ip, port), indices[1])
 
 	assert.Equal(t, expected.String(), indexers[0].Data.String())
+	expected["container"] = common.MapStr{"name": container}
+	assert.Equal(t, expected.String(), indexers[1].Data.String())
 }


### PR DESCRIPTION
Before this change, it only indexed ip:port combination, but in some cases, we want to have IP only, as source port may not be exported