### PR TITLE
Cherry-pick #5449 to 6.0: Make python tests not executables

### DIFF
--- a/filebeat/tests/system/test_prospector.py
+++ b/filebeat/tests/system/test_prospector.py
@@ -3,6 +3,7 @@
 from filebeat import BaseTest
 import os
 import time
+import unittest
 
 from beat.beat import Proc
 
@@ -582,6 +583,7 @@ class Test(BaseTest):
         # Make sure there is only one entry, means it didn't follow the symlink
         assert len(data) == 1
 
+    @unittest.skip("Flaky due to race. Opened https://github.com/elastic/beats/issues/5458")
     def test_harvester_limit(self):
         """
         Test if harvester_limit applies
@@ -714,8 +716,3 @@ class Test(BaseTest):
             name="output contains 'entry2'")
 
         filebeat.check_kill_and_wait()
-
-
-if __name__ == '__main__':
-    import unittest
-    unittest.main()

--- a/filebeat/tests/system/test_registrar.py
+++ b/filebeat/tests/system/test_registrar.py
@@ -1384,8 +1384,3 @@ class Test(BaseTest):
                 "inode": stat.st_ino,
                 "device": stat.st_dev,
             }, file_state_os)
-
-
-if __name__ == '__main__':
-    import unittest
-    unittest.main()

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -61,6 +61,7 @@ BUILDID?=$(shell git rev-parse HEAD) ## @Building The build ID
 VIRTUALENV_PARAMS?=
 INTEGRATION_TESTS?=
 FIND=. ${PYTHON_ENV}/bin/activate; find . -type f -not -path "*/vendor/*" -not -path "*/build/*" -not -path "*/.git/*"
+PERM_EXEC=$(shell [ `uname -s` = "Darwin" ] && echo "+111" || echo "/a+x")
 
 # Cross compiling targets
 CGO?=true ## @building if true, Build with C Go support
@@ -104,6 +105,7 @@ check: python-env ## @build Checks project and source code if everything is acco
 	@go get $(GOIMPORTS_REPO)
 	@goimports -local ${GOIMPORTS_LOCAL_PREFIX} -l ${GOFILES_NOVENDOR} | (! grep . -q) || (echo "Code differs from goimports' style" && false)
 	@${FIND} -name *.py -exec autopep8 -d --max-line-length 120  {} \; | (! grep . -q) || (echo "Code differs from autopep8's style" && false)
+	@${FIND} -wholename "*tests/system/test_*.py" -perm ${PERM_EXEC} -exec false {} + || (echo "Python test files shouldn't be executable, otherwise nose doesn't find them" && false)
 
 .PHONY: fmt
 fmt: python-env ## @build Runs `goimports -l -w` and `autopep8`on the project's source code, modifying any files that do not match its style.


### PR DESCRIPTION
Cherry-pick of PR #5449 to 6.0 branch. Original message: 

Turns out that if a `test_*.py` file is executable, nosetests
doesn't pick it up, so the tests are not executed on Linux/Mac.
This was the case with two files in Filebeat.

This adds a `make check` check to look for such files, so this
doesn't happen in the future.