### PR TITLE
Cherry-pick #5715 to master: Fix README.md link in packages

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -42,6 +42,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Change add_kubernetes_metadata to attempt detection of namespace. {pull}5482[5482]
 - Avoid double slash when join url and path {pull}5517[5517]
 - Fix console color output for Windows. {issue}5611[5611]
+- Fix documentation links in README.md files. {pull}5710[5710]
 
 *Auditbeat*
 

--- a/dev-tools/packer/xgo-scripts/before_build.sh
+++ b/dev-tools/packer/xgo-scripts/before_build.sh
@@ -54,7 +54,8 @@ fi
 cat ${ES_BEATS}/libbeat/docs/version.asciidoc >> ${PREFIX}/package.yml
 
 # Make variable naming of doc-branch compatible with gotpl. Generate and copy README.md into homedir
-sed -i -e 's/:doc-branch/doc_branch/g' ${PREFIX}/package.yml
+# Add " to the version as gotpl interprets 6.0 as 6
+sed -i -e 's/:doc-branch: \([0-9]*.[0-9]*\)/doc_branch: "\1" /g' ${PREFIX}/package.yml
 
 # Create README file
 /go/bin/gotpl /templates/readme.md.j2 < ${PREFIX}/package.yml > ${PREFIX}/homedir/README.md


### PR DESCRIPTION
Cherry-pick of PR #5715 to master branch. Original message: 

The links in the README.md file are broken for the 6.0 release. The reason is that gotpl interprets 6.0 and makes 6 out of it. Add "..." around fixes the issue.