### PR TITLE
Cherry-pick #5616 to 6.0: Update filters to processors

### DIFF
--- a/metricbeat/module/system/filesystem/_meta/docs.asciidoc
+++ b/metricbeat/module/system/filesystem/_meta/docs.asciidoc
@@ -37,9 +37,9 @@ metricbeat.modules:
 ----
 
 Another strategy to deal with these filesystems is to configure a `drop_event`
-filter that matches the `mount_point` using a regular expression. This type of
-filtering occurs after the data has been collected so it can be less efficient
-than the previous method.
+processor that matches the `mount_point` using a regular expression. This type
+of filtering occurs after the data has been collected so it can be less
+efficient than the previous method.
 
 [source,yaml]
 ----
@@ -47,6 +47,7 @@ metricbeat.modules:
   - module: system
     period: 30s
     metricsets: ["filesystem"]
-    filters:
-      - drop_event.when.regexp.mount_point: '^/(sys|cgroup|proc|dev|etc|host)($|/)'
+    processors:
+    - drop_event.when.regexp:
+        system.filesystem.mount_point: '^/(sys|cgroup|proc|dev|etc|host)($|/)'
 ----


### PR DESCRIPTION
Cherry-pick of PR #5616 to 6.0 branch. Original message: 

Update the example in the filesystem metricset documentation to use processors instead of filters.