### PR TITLE
Cherry-pick #5711 to 6.0: fix connection leak in the mongodb module

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -43,6 +43,7 @@ https://github.com/elastic/beats/compare/v6.0.0...master[Check the HEAD diff]
 *Metricbeat*
 
 - Fix map overwrite in docker diskio module. {issue}5582[5582]
+- Fix connection leak in mongodb module. {issue}5688[5688]
 
 *Packetbeat*
 

--- a/metricbeat/module/mongodb/dbstats/dbstats.go
+++ b/metricbeat/module/mongodb/dbstats/dbstats.go
@@ -61,6 +61,7 @@ func (m *MetricSet) Fetch() ([]common.MapStr, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer mongoSession.Close()
 
 	// Get the list of databases names, which we'll use to call db.stats() on each
 	dbNames, err := mongoSession.DatabaseNames()

--- a/metricbeat/module/mongodb/status/status.go
+++ b/metricbeat/module/mongodb/status/status.go
@@ -59,6 +59,7 @@ func (m *MetricSet) Fetch() (common.MapStr, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer mongoSession.Close()
 
 	result := map[string]interface{}{}
 	if err := mongoSession.DB("admin").Run(bson.D{{Name: "serverStatus", Value: 1}}, &result); err != nil {


### PR DESCRIPTION
Cherry-pick of PR #5711 to 6.0 branch. Original message: 

Fixes #5688 