### PR TITLE
Cherry-pick #5711 to 6.1: fix connection leak in the mongodb module

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -62,6 +62,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Fix the fetching of process information when some data is missing under MacOS X. {issue}5337[5337]
 - Change `MySQL active connections` visualization title to `MySQL total connections`. {issue}4812[4812]
 - Fix map overwrite in docker diskio module. {issue}5582[5582]
+- Fix connection leak in mongodb module. {issue}5688[5688]
 
 *Packetbeat*
 

--- a/metricbeat/module/mongodb/dbstats/dbstats.go
+++ b/metricbeat/module/mongodb/dbstats/dbstats.go
@@ -61,6 +61,7 @@ func (m *MetricSet) Fetch() ([]common.MapStr, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer mongoSession.Close()
 
 	// Get the list of databases names, which we'll use to call db.stats() on each
 	dbNames, err := mongoSession.DatabaseNames()

--- a/metricbeat/module/mongodb/status/status.go
+++ b/metricbeat/module/mongodb/status/status.go
@@ -63,6 +63,7 @@ func (m *MetricSet) Fetch() (common.MapStr, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer mongoSession.Close()
 
 	result := map[string]interface{}{}
 	if err := mongoSession.DB("admin").Run(bson.D{{Name: "serverStatus", Value: 1}}, &result); err != nil {


### PR DESCRIPTION
Cherry-pick of PR #5711 to 6.1 branch. Original message: 

Fixes #5688 