### PR TITLE
Make dialer based job creation of TCP monitor reusable

### DIFF
--- a/heartbeat/monitors/active/dialchain/builder.go
+++ b/heartbeat/monitors/active/dialchain/builder.go
@@ -1,0 +1,196 @@
+package dialchain
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"time"
+
+	"github.com/elastic/beats/heartbeat/monitors"
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/outputs/transport"
+)
+
+// Builder maintains a DialerChain for building dialers and dialer based
+// monitoring jobs.
+// The builder ensures a constant address is being used, for any host
+// configured. This ensures the upper network layers (e.g. TLS) correctly see
+// and process the original hostname.
+type Builder struct {
+	template         *DialerChain
+	addrIndex        int
+	resolveViaSocks5 bool
+}
+
+// BuilderSettings configures the layers of the dialer chain to be constructed
+// by a Builder.
+type BuilderSettings struct {
+	Timeout time.Duration
+	Socks5  transport.ProxyConfig
+	TLS     *transport.TLSConfig
+}
+
+// Endpoint configures a host with all port numbers to be monitored by a dialer
+// based job.
+type Endpoint struct {
+	Host  string
+	Ports []uint16
+}
+
+// NewBuilder creates a new Builder for constructing dialers.
+func NewBuilder(settings BuilderSettings) (*Builder, error) {
+	d := &DialerChain{
+		Net: netDialer(settings.Timeout),
+	}
+	resolveViaSocks5 := false
+	withProxy := settings.Socks5.URL != ""
+	if withProxy {
+		d.AddLayer(SOCKS5Layer(&settings.Socks5))
+		resolveViaSocks5 = !settings.Socks5.LocalResolve
+	}
+
+	// insert empty placeholder, so address can be replaced in dialer chain
+	// by replacing this placeholder dialer
+	idx := len(d.Layers)
+	d.AddLayer(IDLayer())
+
+	// add tls layer doing the TLS handshake based on the original address
+	if tls := settings.TLS; tls != nil {
+		d.AddLayer(TLSLayer(tls, settings.Timeout))
+	}
+
+	// validate dialerchain
+	if err := d.TestBuild(); err != nil {
+		return nil, err
+	}
+
+	return &Builder{
+		template:         d,
+		addrIndex:        idx,
+		resolveViaSocks5: resolveViaSocks5,
+	}, nil
+}
+
+// AddLayer adds another custom network layer to the dialer chain.
+func (b *Builder) AddLayer(l Layer) {
+	b.template.AddLayer(l)
+}
+
+// Build create a new dialer, that will always use the constant address, no matter
+// which address is used to connect using the dialer.
+// The dialer chain will add per layer information to the given event.
+func (b *Builder) Build(addr string, event common.MapStr) (transport.Dialer, error) {
+	// clone template, as multiple instance of a dialer can exist at the same time
+	dchain := b.template.Clone()
+
+	// fix the final dialers TCP-level address
+	dchain.Layers[b.addrIndex] = ConstAddrLayer(addr)
+
+	// create dialer chain with event to add per network layer information
+	d, err := dchain.Build(event)
+	return d, err
+}
+
+// Run executes the given function with a new dialer instance.
+func (b *Builder) Run(
+	addr string,
+	fn func(transport.Dialer) (common.MapStr, error),
+) (common.MapStr, error) {
+	event := common.MapStr{}
+	dialer, err := b.Build(addr, event)
+	if err != nil {
+		return nil, err
+	}
+
+	results, err := fn(dialer)
+	event.DeepUpdate(results)
+	return event, err
+}
+
+// MakeDialerJobs creates a set of monitoring jobs. The jobs behavior depends
+// on the builder, endpoint and mode configurations, normally set by user
+// configuration.  The task to execute the actual 'ping' receives the dialer
+// and the address pair (<hostname>:<port>), required to be used, to ping the
+// correctly resolved endpoint.
+func MakeDialerJobs(
+	b *Builder,
+	typ, scheme string,
+	endpoints []Endpoint,
+	mode monitors.IPSettings,
+	fn func(dialer transport.Dialer, addr string) (common.MapStr, error),
+) ([]monitors.Job, error) {
+	var jobs []monitors.Job
+	for _, endpoint := range endpoints {
+		endpointJobs, err := makeEndpointJobs(b, typ, scheme, endpoint, mode, fn)
+		if err != nil {
+			return nil, err
+		}
+		jobs = append(jobs, endpointJobs...)
+	}
+
+	return jobs, nil
+}
+
+func makeEndpointJobs(
+	b *Builder,
+	typ, scheme string,
+	endpoint Endpoint,
+	mode monitors.IPSettings,
+	fn func(transport.Dialer, string) (common.MapStr, error),
+) ([]monitors.Job, error) {
+
+	fields := common.MapStr{
+		"monitor": common.MapStr{
+			"host":   endpoint.Host,
+			"scheme": scheme,
+		},
+	}
+
+	// Check if SOCKS5 is configured, with relying on the socks5 proxy
+	// in resolving the actual IP.
+	// Create one job for every port number configured.
+	if b.resolveViaSocks5 {
+		jobs := make([]monitors.Job, len(endpoint.Ports))
+		for i, port := range endpoint.Ports {
+			jobName := jobName(typ, scheme, endpoint.Host, []uint16{port})
+			address := net.JoinHostPort(endpoint.Host, strconv.Itoa(int(port)))
+			settings := monitors.MakeJobSetting(jobName).WithFields(fields)
+			jobs[i] = monitors.MakeSimpleJob(settings, func() (common.MapStr, error) {
+				return b.Run(address, func(dialer transport.Dialer) (common.MapStr, error) {
+					return fn(dialer, address)
+				})
+			})
+		}
+		return jobs, nil
+	}
+
+	// Create job that first resolves one or multiple IP (depending on
+	// config.Mode) in order to create one continuation Task per IP.
+	jobName := jobName(typ, scheme, endpoint.Host, endpoint.Ports)
+	settings := monitors.MakeHostJobSettings(jobName, endpoint.Host, mode).WithFields(fields)
+	job, err := monitors.MakeByHostJob(settings,
+		monitors.MakePingAllIPPortFactory(endpoint.Ports,
+			func(ip *net.IPAddr, port uint16) (common.MapStr, error) {
+				// use address from resolved IP
+				portStr := strconv.Itoa(int(port))
+				ipAddr := net.JoinHostPort(ip.String(), portStr)
+				hostAddr := net.JoinHostPort(endpoint.Host, portStr)
+				return b.Run(ipAddr, func(dialer transport.Dialer) (common.MapStr, error) {
+					return fn(dialer, hostAddr)
+				})
+			}))
+	if err != nil {
+		return nil, err
+	}
+	return []monitors.Job{job}, nil
+}
+
+func jobName(typ, jobType, host string, ports []uint16) string {
+	var h string
+	if len(ports) == 1 {
+		h = fmt.Sprintf("%v:%v", host, ports[0])
+	} else {
+		h = fmt.Sprintf("%v:%v", host, ports)
+	}
+	return fmt.Sprintf("%v-%v@%v", typ, jobType, h)
+}

--- a/heartbeat/monitors/active/dialchain/net.go
+++ b/heartbeat/monitors/active/dialchain/net.go
@@ -3,6 +3,7 @@ package dialchain
 import (
 	"fmt"
 	"net"
+	"strconv"
 	"time"
 
 	"github.com/elastic/beats/heartbeat/look"
@@ -13,8 +14,8 @@ import (
 
 // TCPDialer creates a new NetDialer with constant event fields and default
 // connection timeout.
-// The fields parameter holds additional constants to be added to the final event
-// structure.
+// The fields parameter holds additional constants to be added to the final
+// event structure.
 //
 // The dialer will update the active events with:
 //
@@ -30,8 +31,8 @@ func TCPDialer(to time.Duration) NetDialer {
 
 // UDPDialer creates a new NetDialer with constant event fields and default
 // connection timeout.
-// The fields parameter holds additional constants to be added to the final event
-// structure.
+// The fields parameter holds additional constants to be added to the final
+// event structure.
 //
 // The dialer will update the active events with:
 //
@@ -63,6 +64,16 @@ func netDialer(timeout time.Duration) NetDialer {
 			if err != nil {
 				return nil, err
 			}
+
+			portNum, err := strconv.Atoi(port)
+			if err != nil || portNum < 0 || portNum > (1<<16) {
+				return nil, fmt.Errorf("invalid port number '%v' used", port)
+			}
+			event.DeepUpdate(common.MapStr{
+				namespace: common.MapStr{
+					"port": uint16(portNum),
+				},
+			})
 
 			addresses, err := net.LookupHost(host)
 			if err != nil {

--- a/heartbeat/monitors/active/tcp/task.go
+++ b/heartbeat/monitors/active/tcp/task.go
@@ -1,122 +1,21 @@
 package tcp
 
 import (
-	"fmt"
-	"net"
-	"strconv"
 	"time"
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/outputs/transport"
 
 	"github.com/elastic/beats/heartbeat/look"
-	"github.com/elastic/beats/heartbeat/monitors"
-	"github.com/elastic/beats/heartbeat/monitors/active/dialchain"
 	"github.com/elastic/beats/heartbeat/reason"
 )
-
-func newTCPMonitorHostJob(
-	scheme, host string, port uint16,
-	tls *transport.TLSConfig,
-	config *Config,
-) (monitors.Job, error) {
-	typ := config.Name
-	timeout := config.Timeout
-	jobName := jobName(typ, jobType(scheme), host, []uint16{port})
-	validator := makeValidateConn(config)
-	pingAddr := net.JoinHostPort(host, strconv.Itoa(int(port)))
-
-	taskDialer, err := buildDialerChain(scheme, tls, config)
-	if err != nil {
-		return nil, err
-	}
-
-	settings := monitors.MakeJobSetting(jobName).WithFields(common.MapStr{
-		"monitor": common.MapStr{
-			"host":   host,
-			"scheme": scheme,
-		},
-		"tcp": common.MapStr{
-			"port": port,
-		},
-	})
-
-	return monitors.MakeSimpleJob(settings, func() (common.MapStr, error) {
-		event := common.MapStr{}
-		dialer, err := taskDialer.Build(event)
-		if err != nil {
-			return event, err
-		}
-
-		results, err := pingHost(dialer, pingAddr, timeout, validator)
-		event.DeepUpdate(results)
-		return event, err
-	}), nil
-}
-
-func newTCPMonitorIPsJob(
-	addr connURL,
-	tls *transport.TLSConfig,
-	config *Config,
-) (monitors.Job, error) {
-	typ := config.Name
-	timeout := config.Timeout
-	jobType := jobType(addr.Scheme)
-	jobName := jobName(typ, jobType, addr.Host, addr.Ports)
-	validator := makeValidateConn(config)
-
-	dialerFactory, err := buildHostDialerChainFactory(addr.Scheme, tls, config)
-	if err != nil {
-		return nil, err
-	}
-
-	settings := monitors.MakeHostJobSettings(jobName, addr.Host, config.Mode)
-	settings = settings.WithFields(common.MapStr{
-		"monitor": common.MapStr{
-			"scheme": addr.Scheme,
-		},
-	})
-
-	debugf("Make TCP job: %v:%v", addr.Host, addr.Ports)
-	pingFactory := createPingFactory(dialerFactory, addr, timeout, validator)
-	return monitors.MakeByHostJob(settings, pingFactory)
-}
-
-func createPingFactory(
-	makeDialerChain func(string) *dialchain.DialerChain,
-	addr connURL,
-	timeout time.Duration,
-	validator ConnCheck,
-) func(*net.IPAddr) monitors.TaskRunner {
-	return monitors.MakePingAllIPPortFactory(addr.Ports,
-		func(ip *net.IPAddr, port uint16) (common.MapStr, error) {
-			ipStr := ip.String()
-			host := net.JoinHostPort(ipStr, strconv.Itoa(int(port)))
-			pingAddr := net.JoinHostPort(addr.Host, strconv.Itoa(int(port)))
-
-			event := common.MapStr{
-				"tcp": common.MapStr{
-					"port": port,
-				},
-			}
-
-			dialer, err := makeDialerChain(host).Build(event)
-			if err != nil {
-				return event, err
-			}
-
-			results, err := pingHost(dialer, pingAddr, timeout, validator)
-			event.DeepUpdate(results)
-			return event, err
-		})
-}
 
 func pingHost(
 	dialer transport.Dialer,
 	host string,
 	timeout time.Duration,
 	validator ConnCheck,
-) (common.MapStr, reason.Reason) {
+) (common.MapStr, error) {
 	start := time.Now()
 	deadline := start.Add(timeout)
 
@@ -155,78 +54,4 @@ func pingHost(
 		event["error"] = reason.FailValidate(err)
 	}
 	return event, nil
-}
-
-func isTLSAddr(scheme string) bool {
-	return scheme == "tls" || scheme == "ssl"
-}
-
-func jobType(scheme string) string {
-	switch scheme {
-	case "tls", "ssl":
-		return scheme
-	}
-	return "plain"
-}
-
-func jobName(typ, jobType, host string, ports []uint16) string {
-	var h string
-	if len(ports) == 1 {
-		h = fmt.Sprintf("%v:%v", host, ports[0])
-	} else {
-		h = fmt.Sprintf("%v:%v", host, ports)
-	}
-	return fmt.Sprintf("%v-%v@%v", typ, jobType, h)
-}
-
-func buildDialerChain(
-	scheme string,
-	tls *transport.TLSConfig,
-	config *Config,
-) (*dialchain.DialerChain, error) {
-	d := &dialchain.DialerChain{
-		Net: dialchain.TCPDialer(config.Timeout),
-	}
-
-	withProxy := config.Socks5.URL != ""
-	if withProxy {
-		d.AddLayer(dialchain.SOCKS5Layer(&config.Socks5))
-	}
-
-	// insert empty placeholder, so address can be replaced in dialer chain
-	// by replacing this placeholder dialer
-	d.AddLayer(dialchain.IDLayer())
-
-	if isTLSAddr(scheme) {
-		d.AddLayer(dialchain.TLSLayer(tls, config.Timeout))
-	}
-
-	if err := d.TestBuild(); err != nil {
-		return nil, err
-	}
-	return d, nil
-}
-
-func buildHostDialerChainFactory(
-	scheme string,
-	tls *transport.TLSConfig,
-	config *Config,
-) (func(string) *dialchain.DialerChain, error) {
-	template, err := buildDialerChain(scheme, tls, config)
-	if err != nil {
-		return nil, err
-	}
-
-	withProxy := config.Socks5.URL != ""
-	addrIndex := 0
-	if withProxy {
-		addrIndex = 1
-	}
-
-	return func(addr string) *dialchain.DialerChain {
-		// replace IDLayer placeholder in template with ConstAddrLayer
-		d := template.Clone()
-		d.Layers[addrIndex] = dialchain.ConstAddrLayer(addr)
-		return d
-	}, nil
 }


### PR DESCRIPTION
By making the job creation more reusable, new UDP/TCP based service can
be added, without having to introduce too much boilerplate code to
required to generate the correct job types.

- introduce dialchain.Builder and dialchain.MakeDialerJobs to create
  jobs based one common connection settings:
  - SOCKS5 proxy
  - ssl/tls settings
  - host + list of ports
  - ip resolve settings (one job per host vs. job per IP host resolves to)
- ensure TCP dialer itself adds the `tcp.port` field to an event