### PR TITLE
Cherry-pick #5729 to 6.1: Fix the include top N processes feature for cases where there are fewer processes than N

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -63,6 +63,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Change `MySQL active connections` visualization title to `MySQL total connections`. {issue}4812[4812]
 - Fix map overwrite in docker diskio module. {issue}5582[5582]
 - Fix connection leak in mongodb module. {issue}5688[5688]
+- Fix the include top N processes feature for cases where there are fewer processes than N. {pull}5729[5729]
 
 *Packetbeat*
 

--- a/metricbeat/module/system/process/helper.go
+++ b/metricbeat/module/system/process/helper.go
@@ -408,17 +408,27 @@ func (procStats *ProcStats) includeTopProcesses(processes []Process) []Process {
 
 	var result []Process
 	if procStats.IncludeTop.ByCPU > 0 {
+		numProcs := procStats.IncludeTop.ByCPU
+		if len(processes) < procStats.IncludeTop.ByCPU {
+			numProcs = len(processes)
+		}
+
 		sort.Slice(processes, func(i, j int) bool {
 			return processes[i].cpuTotalPct > processes[j].cpuTotalPct
 		})
-		result = append(result, processes[:procStats.IncludeTop.ByCPU]...)
+		result = append(result, processes[:numProcs]...)
 	}
 
 	if procStats.IncludeTop.ByMemory > 0 {
+		numProcs := procStats.IncludeTop.ByMemory
+		if len(processes) < procStats.IncludeTop.ByMemory {
+			numProcs = len(processes)
+		}
+
 		sort.Slice(processes, func(i, j int) bool {
 			return processes[i].Mem.Resident > processes[j].Mem.Resident
 		})
-		for _, proc := range processes[:procStats.IncludeTop.ByMemory] {
+		for _, proc := range processes[:numProcs] {
 			if !isProcessInSlice(result, &proc) {
 				result = append(result, proc)
 			}

--- a/metricbeat/module/system/process/helper_test.go
+++ b/metricbeat/module/system/process/helper_test.go
@@ -272,6 +272,31 @@ func TestIncludeTopProcesses(t *testing.T) {
 			Cfg:          includeTopConfig{Enabled: true},
 			ExpectedPids: []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
 		},
+		{
+			Name:         "top 12 by cpu (out of 10)",
+			Cfg:          includeTopConfig{Enabled: true, ByCPU: 12},
+			ExpectedPids: []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+		},
+		{
+			Name:         "top 12 by cpu and top 14 memory (out of 10)",
+			Cfg:          includeTopConfig{Enabled: true, ByCPU: 12, ByMemory: 14},
+			ExpectedPids: []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+		},
+		{
+			Name:         "top 14 by cpu and top 12 memory (out of 10)",
+			Cfg:          includeTopConfig{Enabled: true, ByCPU: 14, ByMemory: 12},
+			ExpectedPids: []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+		},
+		{
+			Name:         "top 1 by cpu and top 3 memory",
+			Cfg:          includeTopConfig{Enabled: true, ByCPU: 1, ByMemory: 3},
+			ExpectedPids: []int{5, 7, 8},
+		},
+		{
+			Name:         "top 3 by cpu and top 1 memory",
+			Cfg:          includeTopConfig{Enabled: true, ByCPU: 3, ByMemory: 1},
+			ExpectedPids: []int{7, 8, 10},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Cherry-pick of PR #5729 to 6.1 branch. Original message: 

In case include top N specified more processes then there were processes available an index out of bound panic was thrown. This is a use case that can especially happen in docker environments with few processes.

This needs backport to 6.0 and 6.1