### PR TITLE
Enable debug logging for docker watcher tests

### DIFF
--- a/libbeat/common/docker/watcher.go
+++ b/libbeat/common/docker/watcher.go
@@ -305,7 +305,7 @@ func (w *watcher) cleanupWorker() {
 			w.RLock()
 			for key, lastSeen := range w.deleted {
 				if lastSeen.Before(timeout) {
-					logp.Debug("docker", "Removing container %s after cool down timeout")
+					logp.Debug("docker", "Removing container %s after cool down timeout", key)
 					toDelete = append(toDelete, key)
 				}
 			}

--- a/libbeat/common/docker/watcher_test.go
+++ b/libbeat/common/docker/watcher_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/docker/docker/api/types/events"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
+
+	"github.com/elastic/beats/libbeat/logp"
 )
 
 type MockClient struct {
@@ -219,6 +221,10 @@ func TestWatcherDie(t *testing.T) {
 }
 
 func runWatcher(t *testing.T, kill bool, containers [][]types.Container, events []interface{}) *watcher {
+	if testing.Verbose() {
+		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"*"})
+	}
+
 	client := &MockClient{
 		containers: containers,
 		events:     events,


### PR DESCRIPTION
Enable debug logging from the test cases to aid in debugging. And fixed one logger statement that was missing an argument.