### PR TITLE
Update documentation for newbeat.asciidoc

### DIFF
--- a/docs/devguide/newbeat.asciidoc
+++ b/docs/devguide/newbeat.asciidoc
@@ -474,9 +474,9 @@ package main
 
 import (
 	"os"
-	"github.com/spf13/cobra"
 
 	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/cmd"
 
 	"github.com/kimjmin/countbeat/beater"
 )


### PR DESCRIPTION
There was a missing package that I had trouble finding upgrading my beats from `5.x` to `6.x`