### PR TITLE
Adds system test to Metricbeat to load dashboards

### DIFF
--- a/metricbeat/tests/system/config/metricbeat.yml.j2
+++ b/metricbeat/tests/system/config/metricbeat.yml.j2
@@ -162,6 +162,10 @@ queue.mem:
   flush.min_events: {{ flush_min_events|default(8) }}
   flush.timeout: 0.1s
 
+{% if kibana -%}
+setup.kibana.host: "{{ kibana.host }}"
+{%- endif %}
+
 #================================ Outputs =====================================
 
 # Configure what outputs to use when sending the data collected by the beat.

--- a/metricbeat/tests/system/test_base.py
+++ b/metricbeat/tests/system/test_base.py
@@ -2,6 +2,8 @@ import re
 import sys
 import unittest
 import time
+import os
+import shutil
 from metricbeat import BaseTest
 from elasticsearch import Elasticsearch
 from beat.beat import INTEGRATION_TESTS
@@ -9,7 +11,7 @@ from beat.beat import INTEGRATION_TESTS
 
 class Test(BaseTest):
 
-    COMPOSE_SERVICES = ['elasticsearch']
+    COMPOSE_SERVICES = ['elasticsearch', 'kibana']
 
     @unittest.skipUnless(re.match("(?i)win|linux|darwin|freebsd|openbsd", sys.platform), "os")
     def test_start_stop(self):
@@ -50,3 +52,27 @@ class Test(BaseTest):
         assert exit_code == 0
         assert self.log_contains('Loaded index template')
         assert len(es.cat.templates(name='metricbeat-*', h='name')) > 0
+
+    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
+    def test_dashboards(self):
+        """
+        Test that the dashboards can be loaded with `setup --dashboards`
+        """
+
+        kibana_dir = os.path.join(self.beat_path, "_meta", "kibana")
+        shutil.copytree(kibana_dir, os.path.join(self.working_dir, "kibana"))
+
+        es = Elasticsearch([self.get_elasticsearch_url()])
+        self.render_config_template(
+            modules=[{
+                "name": "apache",
+                "metricsets": ["status"],
+                "hosts": ["localhost"],
+            }],
+            elasticsearch={"host": self.get_elasticsearch_url()},
+            kibana={"host": self.get_kibana_url()},
+        )
+        exit_code = self.run_beat(extra_args=["setup", "--dashboards"])
+
+        assert exit_code == 0
+        assert self.log_contains("Kibana dashboards successfully loaded.")


### PR DESCRIPTION
This adds a test to the system tests to load all dashboards into Kibana throught the Kibana API.

In a follow up PR this should be added to all Beats.

@simianhacker This currently goes green even thought some of the dashboards actually contain invalid json (see https://github.com/elastic/beats/pull/5741#issuecomment-348081687). I wonder if we could check in the API if the content that is received is at least valid json?