### PR TITLE
Cherry-pick #5759 to 6.1: Fix WatcherDie test timings

### DIFF
--- a/libbeat/common/docker/watcher_test.go
+++ b/libbeat/common/docker/watcher_test.go
@@ -66,7 +66,7 @@ func TestWatcherInitialization(t *testing.T) {
 		},
 		nil)
 
-	assert.Equal(t, watcher.Containers(), map[string]*Container{
+	assert.Equal(t, map[string]*Container{
 		"0332dbd79e20": &Container{
 			ID:     "0332dbd79e20",
 			Name:   "containername",
@@ -79,7 +79,7 @@ func TestWatcherInitialization(t *testing.T) {
 			Image:  "nginx",
 			Labels: map[string]string{},
 		},
-	})
+	}, watcher.Containers())
 }
 
 func TestWatcherAddEvents(t *testing.T) {
@@ -119,7 +119,7 @@ func TestWatcherAddEvents(t *testing.T) {
 		},
 	)
 
-	assert.Equal(t, watcher.Containers(), map[string]*Container{
+	assert.Equal(t, map[string]*Container{
 		"0332dbd79e20": &Container{
 			ID:     "0332dbd79e20",
 			Name:   "containername",
@@ -132,7 +132,7 @@ func TestWatcherAddEvents(t *testing.T) {
 			Image:  "nginx",
 			Labels: map[string]string{"label": "value"},
 		},
-	})
+	}, watcher.Containers())
 }
 
 func TestWatcherUpdateEvent(t *testing.T) {
@@ -172,15 +172,15 @@ func TestWatcherUpdateEvent(t *testing.T) {
 		},
 	)
 
-	assert.Equal(t, watcher.Containers(), map[string]*Container{
+	assert.Equal(t, map[string]*Container{
 		"0332dbd79e20": &Container{
 			ID:     "0332dbd79e20",
 			Name:   "containername",
 			Image:  "busybox",
 			Labels: map[string]string{"label": "bar"},
 		},
-	})
-	assert.Equal(t, len(watcher.deleted), 0)
+	}, watcher.Containers())
+	assert.Equal(t, 0, len(watcher.deleted))
 }
 
 func TestWatcherDie(t *testing.T) {
@@ -205,17 +205,18 @@ func TestWatcherDie(t *testing.T) {
 			},
 		},
 	)
+	defer watcher.Stop()
 
 	// Check it doesn't get removed while we request meta for the container
 	for i := 0; i < 18; i++ {
 		watcher.Container("0332dbd79e20")
-		assert.Equal(t, len(watcher.Containers()), 1)
+		assert.Equal(t, 1, len(watcher.Containers()))
 		time.Sleep(50 * time.Millisecond)
 	}
 
 	// Now it should get removed
-	time.Sleep(150 * time.Millisecond)
-	assert.Equal(t, len(watcher.Containers()), 0)
+	time.Sleep(300 * time.Millisecond)
+	assert.Equal(t, 0, len(watcher.Containers()))
 }
 
 func runWatcher(t *testing.T, kill bool, containers [][]types.Container, events []interface{}) *watcher {
@@ -225,7 +226,7 @@ func runWatcher(t *testing.T, kill bool, containers [][]types.Container, events 
 		done:       make(chan interface{}),
 	}
 
-	watcher, err := NewWatcherWithClient(client, 100*time.Millisecond)
+	watcher, err := NewWatcherWithClient(client, 200*time.Millisecond)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Cherry-pick of PR #5759 to 6.1 branch. Original message: 

This change increases times in WatcherDie test, so it doesn't fail on slow machines 