### PR TITLE
Update testing version for 6.1 branch

### DIFF
--- a/metricbeat/module/elasticsearch/_meta/Dockerfile
+++ b/metricbeat/module/elasticsearch/_meta/Dockerfile
@@ -1,2 +1,2 @@
-FROM docker.elastic.co/elasticsearch/elasticsearch:6.0.0-beta1
+FROM docker.elastic.co/elasticsearch/elasticsearch:6.0.0
 HEALTHCHECK --interval=1s --retries=90 CMD curl -f http://localhost:9200

--- a/metricbeat/module/logstash/node/node_integration_test.go
+++ b/metricbeat/module/logstash/node/node_integration_test.go
@@ -4,6 +4,7 @@ package node
 
 import (
 	"testing"
+	"time"
 
 	"github.com/elastic/beats/libbeat/tests/compose"
 	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
@@ -16,6 +17,7 @@ func TestFetch(t *testing.T) {
 
 	compose.EnsureUpWithTimeout(t, 120, "logstash")
 
+	time.Sleep(1 * time.Second)
 	f := mbtest.NewEventFetcher(t, logstash.GetConfig("node"))
 	event, err := f.Fetch()
 	if !assert.NoError(t, err) {

--- a/testing/environments/args.yml
+++ b/testing/environments/args.yml
@@ -7,4 +7,4 @@ services:
       args:
         DOWNLOAD_URL: https://snapshots.elastic.co/downloads
         ELASTIC_VERSION: 6.1.0-SNAPSHOT
-        CACHE_BUST: 20170911
+        CACHE_BUST: 20171201


### PR DESCRIPTION
* Change CACHE_BUST to fetch most recent version.
* Change version against which the Metricbeat ES module is tested to 6.0
* Add 1 second timeout to node test to make it more stable