### PR TITLE
Update testing version for 6.0 branch

### DIFF
--- a/metricbeat/module/elasticsearch/_meta/Dockerfile
+++ b/metricbeat/module/elasticsearch/_meta/Dockerfile
@@ -1,2 +1,2 @@
-FROM docker.elastic.co/elasticsearch/elasticsearch:6.0.0-beta1
+FROM docker.elastic.co/elasticsearch/elasticsearch:6.0.1
 HEALTHCHECK --interval=1s --retries=90 CMD curl -f http://localhost:9200

--- a/testing/environments/args.yml
+++ b/testing/environments/args.yml
@@ -7,4 +7,4 @@ services:
       args:
         DOWNLOAD_URL: https://snapshots.elastic.co/downloads
         ELASTIC_VERSION: 6.0.1-SNAPSHOT
-        CACHE_BUST: 20171201
+        CACHE_BUST: 20171212


### PR DESCRIPTION
* Change CACHE_BUST to fetch most recent version.
* Change version against which the Metricbeat ES module is tested to 6.0