### PR TITLE
Invalidate Cache for test environment

### DIFF
--- a/metricbeat/module/elasticsearch/_meta/Dockerfile
+++ b/metricbeat/module/elasticsearch/_meta/Dockerfile
@@ -1,2 +1,2 @@
-FROM docker.elastic.co/elasticsearch/elasticsearch:6.0.0-beta1
+FROM docker.elastic.co/elasticsearch/elasticsearch:6.0.0
 HEALTHCHECK --interval=1s --retries=90 CMD curl -f http://localhost:9200

--- a/testing/environments/args.yml
+++ b/testing/environments/args.yml
@@ -7,4 +7,4 @@ services:
       args:
         DOWNLOAD_URL: https://snapshots.elastic.co/downloads
         ELASTIC_VERSION: 7.0.0-alpha1-SNAPSHOT
-        CACHE_BUST: 20171108
+        CACHE_BUST: 20171201


### PR DESCRIPTION
* Gets on Jenkins the most recent version of ES
* Update MB ES module to 6.0 stable release for testing