### PR TITLE
Do cleanup on Jenkins before build starts

### DIFF
--- a/dev-tools/common.bash
+++ b/dev-tools/common.bash
@@ -92,3 +92,15 @@ jenkins_setup() {
   export TEMP_PYTHON_ENV=$(mktemp -d)
   export PYTHON_ENV="${TEMP_PYTHON_ENV}/python-env"
 }
+
+cleanup() {
+  echo "Running cleanup..."
+  rm -rf $TEMP_PYTHON_ENV
+  make stop-environment || true
+  make fix-permissions || true
+  echo "Killing all running containers..."
+  docker ps -q | xargs -r docker kill || true
+  echo "Cleaning stopped docker containers and dangling images/networks/volumes..."
+  docker system prune -f || true
+  echo "Cleanup complete."
+}

--- a/dev-tools/jenkins_ci.sh
+++ b/dev-tools/jenkins_ci.sh
@@ -16,17 +16,9 @@ source ./dev-tools/common.bash
 
 jenkins_setup
 
-cleanup() {
-  echo "Running cleanup..."
-  rm -rf $TEMP_PYTHON_ENV
-  make stop-environment || true
-  make fix-permissions || true
-  echo "Killing all running containers..."
-  docker ps -q | xargs -r docker kill || true
-  echo "Cleaning stopped docker containers and dangling images/networks/volumes..."
-  docker system prune -f || true
-  echo "Cleanup complete."
-}
+# Cleanup before starting build in case some previous build was canceled and did not fully clean up
+cleanup
+
 trap cleanup EXIT
 
 rm -rf ${GOPATH}/pkg


### PR DESCRIPTION
This should solve the issue that in case a build is canceled, the cleanup is interrupted and not fully finished and leaves files behind which break the following build. See https://github.com/elastic/beats/issues/5746

* Move cleanup function to common.bash