### PR TITLE
Cherry-pick #5769 to 6.1: Fix default host to localhost for Kibana dashboard loading

### DIFF
--- a/libbeat/dashboards/dashboards.go
+++ b/libbeat/dashboards/dashboards.go
@@ -46,10 +46,6 @@ func ImportDashboards(
 		kibanaConfig = common.NewConfig()
 	}
 
-	if !kibanaConfig.HasField("host") {
-		// fallback to the beats hostname (localhost) if host is not configured
-		kibanaConfig.SetString("host", -1, hostname)
-	}
 	if esConfig.Enabled() {
 		username, _ := esConfig.String("username", -1)
 		password, _ := esConfig.String("password", -1)

--- a/libbeat/setup/kibana/config.go
+++ b/libbeat/setup/kibana/config.go
@@ -19,7 +19,7 @@ type kibanaConfig struct {
 var (
 	defaultKibanaConfig = kibanaConfig{
 		Protocol: "http",
-		Host:     "",
+		Host:     "localhost:5601",
 		Path:     "",
 		Username: "",
 		Password: "",


### PR DESCRIPTION
Cherry-pick of PR #5769 to 6.1 branch. Original message: 

On my machine when loading dashboards with `metricbeat setup dashboards` it tried to load the dashboards to `ruflin:5601` as my host name is `ruflin`. But it should load it to localhost by default.

The identification of the hostname / beat.name was added to replace it in the host dashboards with the actual host name. This was also applied to the hostname of the instance it should be loaded to. I think this was unintentional. This PR sets the default to localhost.