### PR TITLE
Add targets to crosscompile auditbeat and test on OS X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,14 @@ jobs:
       env: TARGETS="-C auditbeat testsuite"
       go: $GO_VERSION
       stage: test
+    - os: osx
+      env: TARGETS="-C auditbeat testsuite"
+      go: $GO_VERSION
+      stage: test
+    - os: linux
+      env: TARGETS="-C auditbeat crosscompile"
+      go: $GO_VERSION
+      stage: test
 
     # Libbeat
     - os: linux

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,11 @@ test:
 unit:
 	@$(foreach var,$(PROJECTS),$(MAKE) -C $(var) unit || exit 1;)
 
+# Crosscompile all beats.
+.PHONY: crosscompile
+crosscompile:
+	@$(foreach var,filebeat winlogbeat metricbeat heartbeat auditbeat,$(MAKE) -C $(var) crosscompile || exit 1;)
+
 .PHONY: coverage-report
 coverage-report:
 	@mkdir -p $(COVERAGE_DIR)

--- a/auditbeat/Makefile
+++ b/auditbeat/Makefile
@@ -3,6 +3,7 @@ BEAT_TITLE=Auditbeat
 BEAT_DESCRIPTION=Audit the activities of users and processes on your system.
 SYSTEM_TESTS=false
 TEST_ENVIRONMENT=false
+GOX_OS?=linux darwin windows ## @Building List of all OS to be supported by "make crosscompile".
 
 # Path to the libbeat Makefile
 -include ../libbeat/scripts/Makefile

--- a/auditbeat/Makefile
+++ b/auditbeat/Makefile
@@ -3,7 +3,7 @@ BEAT_TITLE=Auditbeat
 BEAT_DESCRIPTION=Audit the activities of users and processes on your system.
 SYSTEM_TESTS=false
 TEST_ENVIRONMENT=false
-GOX_OS?=linux darwin windows ## @Building List of all OS to be supported by "make crosscompile".
+GOX_OS?=linux windows ## @Building List of all OS to be supported by "make crosscompile".
 
 # Path to the libbeat Makefile
 -include ../libbeat/scripts/Makefile


### PR DESCRIPTION
For travis tests were added to run the testsuite also on OS X on travis and a crosscompile target was added for auditbeat. Having auditbeat built on OS X should prevent issues like https://github.com/elastic/beats/issues/5783.

In addition a global crosscompile target was added which should be used in Jenkins in the future. It does not use the BEATS array because packetbeat cannot be just crosscompiled on each machine for the different platforms because of the pcap dependencies. Currently the list of beats is hardcoded.