### PR TITLE
Ignore docker kill events in `add_docker_metadata` 

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -31,6 +31,7 @@ https://github.com/elastic/beats/compare/v6.0.0...master[Check the HEAD diff]
 *Affecting all Beats*
 
 - Fix documentation links in README.md files. {pull}5710[5710]
+- Fix `add_docker_metadata` dropping some containers. {pull}5788[5788]
 
 *Auditbeat*
 

--- a/libbeat/processors/add_docker_metadata/watcher.go
+++ b/libbeat/processors/add_docker_metadata/watcher.go
@@ -205,7 +205,7 @@ func (w *watcher) watch() {
 				}
 
 				// Delete
-				if event.Action == "die" || event.Action == "kill" {
+				if event.Action == "die" {
 					w.Lock()
 					w.deleted[event.Actor.ID] = time.Now()
 					w.Unlock()


### PR DESCRIPTION
Docker kill events are caused by any signal sent to the container, not only a SIGKILL, we can safely ignore all of them, as die will always happen for the case we are really interested in. 

Current code is removing forgetting metadata for containers that get a `kill` event, this PR fixes that.

6.1 and master are not affected, as kill was ignored already: https://github.com/elastic/beats/blob/6.1/libbeat/common/docker/watcher.go#L237

Context on the issue: https://discuss.elastic.co/t/filebeats-docker-metadata-watcher-losing-container-from-its-list-somehow/109897