### PR TITLE
Backport to 6.1: Update elastic/gosigar to v0.6.0 (#5775)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -124,7 +124,6 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Add basic Logstash module. {pull}5540[5540]
 - Add dashboard for Windows service metricset. {pull}5603[5603]
 - Add experimental Docker autodiscover functionality. {pull}5245[5245]
-- Add field network_names of hosts and virtual machines. {issue}5646[5646]
 - Update gosigar to v0.6.0. {pull}5775[5775]
 
 *Packetbeat*

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -65,6 +65,8 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Fix map overwrite in docker diskio module. {issue}5582[5582]
 - Fix connection leak in mongodb module. {issue}5688[5688]
 - Fix the include top N processes feature for cases where there are fewer processes than N. {pull}5729[5729]
+- Fix `ProcState` on Linux and FreeBSD when process names contain parentheses. {pull}5775[5775]
+- Fix incorrect `Mem.Used` calculation under linux. {pull}5775[5775]
 
 *Packetbeat*
 
@@ -122,6 +124,8 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Add basic Logstash module. {pull}5540[5540]
 - Add dashboard for Windows service metricset. {pull}5603[5603]
 - Add experimental Docker autodiscover functionality. {pull}5245[5245]
+- Add field network_names of hosts and virtual machines. {issue}5646[5646]
+- Update gosigar to v0.6.0. {pull}5775[5775]
 
 *Packetbeat*
 

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -370,8 +370,8 @@ Apache License 2.0
 
 --------------------------------------------------------------------
 Dependency: github.com/elastic/gosigar
-Version: v0.5.0
-Revision: 306d51981789ccc65e5f1431d5c0d78d8c368f1b
+Version: v0.6.0
+Revision: 5cb8fed1ceb7f0fd69e4ad61c715a80601dddfd2
 License type (autodetected): Apache-2.0
 ./vendor/github.com/elastic/gosigar/LICENSE:
 --------------------------------------------------------------------

--- a/vendor/github.com/elastic/gosigar/CHANGELOG.md
+++ b/vendor/github.com/elastic/gosigar/CHANGELOG.md
@@ -2,15 +2,21 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased]
+## [0.6.0]
 
 ### Added
+- Added method stubs to enable compilation for operating systems that are not
+  supported by gosigar. All methods return `ErrNotImplemented` on these unsupported
+  operating systems. #83
+- FreeBSD returns `ErrNotImplemented` for `ProcTime.Get`. #83
 
 ### Changed
-
-### Deprecated
+- OpenBSD returns `ErrNotImplemented` for `ProcTime.Get` instead of `nil`. #83
+- Fixed incorrect `Mem.Used` calculation under linux. #82
+- Fixed `ProcState` on Linux and FreeBSD when process names contain parentheses. #81
 
 ### Removed
+- Remove NetBSD build from sigar_unix.go as it is not supported by gosigar. #83
 
 ## [0.5.0]
 

--- a/vendor/github.com/elastic/gosigar/sigar_freebsd.go
+++ b/vendor/github.com/elastic/gosigar/sigar_freebsd.go
@@ -4,6 +4,7 @@ package gosigar
 
 import (
 	"io/ioutil"
+	"runtime"
 	"strconv"
 	"strings"
 	"unsafe"
@@ -105,4 +106,8 @@ func parseCpuStat(self *Cpu, line string) error {
 	self.Sys, _ = strtoull(fields[3])
 	self.Idle, _ = strtoull(fields[4])
 	return nil
+}
+
+func (self *ProcTime) Get(pid int) error {
+	return ErrNotImplemented{runtime.GOOS}
 }

--- a/vendor/github.com/elastic/gosigar/sigar_openbsd.go
+++ b/vendor/github.com/elastic/gosigar/sigar_openbsd.go
@@ -370,7 +370,7 @@ func (self *ProcMem) Get(pid int) error {
 }
 
 func (self *ProcTime) Get(pid int) error {
-	return nil
+	return ErrNotImplemented{runtime.GOOS}
 }
 
 func (self *ProcExe) Get(pid int) error {

--- a/vendor/github.com/elastic/gosigar/sigar_stub.go
+++ b/vendor/github.com/elastic/gosigar/sigar_stub.go
@@ -1,0 +1,35 @@
+// +build !darwin,!freebsd,!linux,!openbsd,!windows
+
+package gosigar
+
+import (
+	"runtime"
+)
+
+func (c *Cpu) Get() error {
+	return ErrNotImplemented{runtime.GOOS}
+}
+
+func (l *LoadAverage) Get() error {
+	return ErrNotImplemented{runtime.GOOS}
+}
+
+func (m *Mem) Get() error {
+	return ErrNotImplemented{runtime.GOOS}
+}
+
+func (s *Swap) Get() error {
+	return ErrNotImplemented{runtime.GOOS}
+}
+
+func (f *FDUsage) Get() error {
+	return ErrNotImplemented{runtime.GOOS}
+}
+
+func (p *ProcTime) Get(int) error {
+	return ErrNotImplemented{runtime.GOOS}
+}
+
+func (self *FileSystemUsage) Get(path string) error {
+	return ErrNotImplemented{runtime.GOOS}
+}

--- a/vendor/github.com/elastic/gosigar/sigar_unix.go
+++ b/vendor/github.com/elastic/gosigar/sigar_unix.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2012 VMware, Inc.
 
-// +build darwin freebsd linux netbsd
+// +build darwin freebsd linux
 
 package gosigar
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1,6 +1,6 @@
 {
 	"comment": "",
-	"ignore": "test",
+	"ignore": "test github.com/elastic/beats/metricbeat/module github.com/elastic/beats/dev-tools",
 	"package": [
 		{
 			"checksumSHA1": "AzjRkOQtVBTwIw4RJLTygFhJs3s=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1,6 +1,6 @@
 {
 	"comment": "",
-	"ignore": "test github.com/elastic/beats/metricbeat/module github.com/elastic/beats/dev-tools",
+	"ignore": "test",
 	"package": [
 		{
 			"checksumSHA1": "AzjRkOQtVBTwIw4RJLTygFhJs3s=",
@@ -479,36 +479,36 @@
 			"revisionTime": "2017-02-07T06:38:51Z"
 		},
 		{
-			"checksumSHA1": "XCXFL46ybPz+NgKH+Pm9hW87wNA=",
+			"checksumSHA1": "VxEaRgCf+HRL7Sv5stNL9xprK/8=",
 			"path": "github.com/elastic/gosigar",
-			"revision": "306d51981789ccc65e5f1431d5c0d78d8c368f1b",
-			"revisionTime": "2017-10-12T15:04:52Z",
-			"version": "v0.5.0",
-			"versionExact": "v0.5.0"
+			"revision": "5cb8fed1ceb7f0fd69e4ad61c715a80601dddfd2",
+			"revisionTime": "2017-11-17T13:55:06Z",
+			"version": "v0.6.0",
+			"versionExact": "v0.6.0"
 		},
 		{
 			"checksumSHA1": "jE0nhsyuGyQ7vWoyBRPEU63mQ4g=",
 			"path": "github.com/elastic/gosigar/cgroup",
 			"revision": "306d51981789ccc65e5f1431d5c0d78d8c368f1b",
 			"revisionTime": "2017-10-12T15:04:52Z",
-			"version": "v0.5.0",
-			"versionExact": "v0.5.0"
+			"version": "v0.6.0",
+			"versionExact": "v0.6.0"
 		},
 		{
 			"checksumSHA1": "2VhOsaR4sv3S79HO6X+6dEphNKU=",
 			"path": "github.com/elastic/gosigar/sys/linux",
 			"revision": "306d51981789ccc65e5f1431d5c0d78d8c368f1b",
 			"revisionTime": "2017-10-12T15:04:52Z",
-			"version": "v0.5.0",
-			"versionExact": "v0.5.0"
+			"version": "v0.6.0",
+			"versionExact": "v0.6.0"
 		},
 		{
 			"checksumSHA1": "qDsgp2kAeI9nhj565HUScaUyjU4=",
 			"path": "github.com/elastic/gosigar/sys/windows",
 			"revision": "306d51981789ccc65e5f1431d5c0d78d8c368f1b",
 			"revisionTime": "2017-10-12T15:04:52Z",
-			"version": "v0.5.0",
-			"versionExact": "v0.5.0"
+			"version": "v0.6.0",
+			"versionExact": "v0.6.0"
 		},
 		{
 			"checksumSHA1": "P0CvGmmAM8uYPSE2ix4th/L9c/8=",


### PR DESCRIPTION
This includes two fixes for metricbeat:
- Fix `ProcState` on Linux and FreeBSD when process names contain parentheses.
- Fix incorrect `Mem.Used` calculation under linux.

(cherry picked from commit f1227c9f3ef5a88002265085e5d5361f151a0a92)