### PR TITLE
Prepare 6.0.1 release

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -8,7 +8,7 @@
 // Template, add newest changes here
 
 === Beats version HEAD
-https://github.com/elastic/beats/compare/v6.0.0...master[Check the HEAD diff]
+https://github.com/elastic/beats/compare/v6.0.1...6.0[Check the HEAD diff]
 
 ==== Breaking changes
 
@@ -30,22 +30,13 @@ https://github.com/elastic/beats/compare/v6.0.0...master[Check the HEAD diff]
 
 *Affecting all Beats*
 
-- Fix documentation links in README.md files. {pull}5710[5710]
-- Fix `add_docker_metadata` dropping some containers. {pull}5788[5788]
-
 *Auditbeat*
 
 *Filebeat*
 
 *Heartbeat*
 
-- Fix the "HTTP up status" visualization. {pull}5564[5564]
-
 *Metricbeat*
-
-- Fix map overwrite in docker diskio module. {issue}5582[5582]
-- Fix connection leak in mongodb module. {issue}5688[5688]
-- Fix the include top N processes feature for cases where there are fewer processes than N. {pull}5729[5729]
 
 *Packetbeat*
 
@@ -85,6 +76,28 @@ https://github.com/elastic/beats/compare/v6.0.0...master[Check the HEAD diff]
 
 
 ////////////////////////////////////////////////////////////
+
+[[release-notes-6.0.1]]
+=== Beats version 6.0.1
+https://github.com/elastic/beats/compare/v6.0.0...v6.0.1[View commits]
+
+==== Bugfixes
+
+*Affecting all Beats*
+
+- Fix documentation links in README.md files. {pull}5710[5710]
+- Fix `add_docker_metadata` dropping some containers. {pull}5788[5788]
+
+*Heartbeat*
+
+- Fix the "HTTP up status" visualization. {pull}5564[5564]
+
+*Metricbeat*
+
+- Fix map overwrite in docker diskio module. {issue}5582[5582]
+- Fix connection leak in mongodb module. {issue}5688[5688]
+- Fix the include top N processes feature for cases where there are fewer
+  processes than N. {pull}5729[5729]
 
 include::libbeat/docs/release-notes/6.0.0.asciidoc[]
 

--- a/deploy/kubernetes/filebeat-kubernetes.yaml
+++ b/deploy/kubernetes/filebeat-kubernetes.yaml
@@ -70,7 +70,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: filebeat
-        image: docker.elastic.co/beats/filebeat:6.0.0
+        image: docker.elastic.co/beats/filebeat:6.0.1
         args: [
           "-c", "/etc/filebeat.yml",
           "-e",

--- a/deploy/kubernetes/metricbeat-kubernetes.yaml
+++ b/deploy/kubernetes/metricbeat-kubernetes.yaml
@@ -93,7 +93,7 @@ spec:
       hostNetwork: true
       containers:
       - name: metricbeat
-        image: docker.elastic.co/beats/metricbeat:6.0.0
+        image: docker.elastic.co/beats/metricbeat:6.0.1
         args: [
           "-c", "/etc/metricbeat.yml",
           "-e",
@@ -202,7 +202,7 @@ spec:
     spec:
       containers:
       - name: metricbeat
-        image: docker.elastic.co/beats/metricbeat:6.0.0
+        image: docker.elastic.co/beats/metricbeat:6.0.1
         args: [
           "-c", "/etc/metricbeat.yml",
           "-e",

--- a/libbeat/_meta/kibana/default/index-pattern/libbeat.json
+++ b/libbeat/_meta/kibana/default/index-pattern/libbeat.json
@@ -1,5 +1,5 @@
 {
-  "version": "6.0.0", 
+  "version": "6.0.1", 
   "objects": [
     {
       "attributes": {

--- a/libbeat/docs/release.asciidoc
+++ b/libbeat/docs/release.asciidoc
@@ -8,6 +8,7 @@ This section summarizes the changes in each release. Also read
 <<breaking-changes>> for more detail about changes that affect
 upgrade.
 
+* <<release-notes-6.0.1>>
 * <<release-notes-6.0.0>>
 * <<release-notes-6.0.0-ga>>
 * <<release-notes-6.0.0-rc2>>

--- a/libbeat/docs/version.asciidoc
+++ b/libbeat/docs/version.asciidoc
@@ -1,4 +1,4 @@
-:stack-version: 6.0.0
+:stack-version: 6.0.1
 :doc-branch: 6.0
 :go-version: 1.8.3
 :release-state: released

--- a/testing/environments/args.yml
+++ b/testing/environments/args.yml
@@ -6,5 +6,5 @@ services:
     build:
       args:
         DOWNLOAD_URL: https://snapshots.elastic.co/downloads
-        ELASTIC_VERSION: 6.0.0-SNAPSHOT
-        CACHE_BUST: 20170720
+        ELASTIC_VERSION: 6.0.1-SNAPSHOT
+        CACHE_BUST: 20171201


### PR DESCRIPTION
- Close changelog
- Bump testing environment version
- Run make update
- Bump stack version in docs