### PR TITLE
Prepare 5.6.5 release

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -8,7 +8,7 @@
 // Template, add newest changes here
 
 === Beats version HEAD
-https://github.com/elastic/beats/compare/v5.6.4...5.6[Check the HEAD diff]
+https://github.com/elastic/beats/compare/v5.6.5...5.6[Check the HEAD diff]
 
 ==== Breaking changes
 
@@ -28,16 +28,11 @@ https://github.com/elastic/beats/compare/v5.6.4...5.6[Check the HEAD diff]
 
 *Affecting all Beats*
 
-- Fix duplicate batches of events in retry queue. {pull}5520[5520]
-
 *Filebeat*
 
 *Heartbeat*
 
 *Metricbeat*
-
-- Clarify meaning of percentages reported by system core metricset. {pull}5565[5565]
-- Fix map overwrite in docker diskio module. {issue}5582[5582]
 
 *Packetbeat*
 
@@ -86,6 +81,21 @@ https://github.com/elastic/beats/compare/v5.6.4...5.6[Check the HEAD diff]
 *Winlogbeat*
 
 ////////////////////////////////////////////////////////////
+
+[[release-notes-5.6.5]]
+=== Beats version 5.6.5
+https://github.com/elastic/beats/compare/v5.6.4...v5.6.5[View commits]
+
+==== Bugfixes
+
+*Affecting all Beats*
+
+- Fix duplicate batches of events in retry queue. {pull}5520[5520]
+
+*Metricbeat*
+
+- Clarify meaning of percentages reported by system core metricset. {pull}5565[5565]
+- Fix map overwrite in docker diskio module. {issue}5582[5582]
 
 [[release-notes-5.6.4]]
 === Beats version 5.6.4

--- a/libbeat/docs/release.asciidoc
+++ b/libbeat/docs/release.asciidoc
@@ -6,6 +6,7 @@
 --
 This section summarizes the changes in each release.
 
+* <<release-notes-5.6.5>>
 * <<release-notes-5.6.4>>
 * <<release-notes-5.6.3>>
 * <<release-notes-5.6.2>>

--- a/libbeat/docs/version.asciidoc
+++ b/libbeat/docs/version.asciidoc
@@ -1,4 +1,4 @@
-:stack-version: 5.6.4
+:stack-version: 5.6.5
 :doc-branch: 5.6
 :go-version: 1.7.6
 :release-state: released

--- a/testing/environments/args.yml
+++ b/testing/environments/args.yml
@@ -6,4 +6,4 @@ services:
     build:
       args:
         DOWNLOAD_URL: https://snapshots.elastic.co/downloads
-        ELASTIC_VERSION: 5.6.4-SNAPSHOT
+        ELASTIC_VERSION: 5.6.5-SNAPSHOT


### PR DESCRIPTION
- Close changelog
- Bump testing environment version
- Bump stack version in docs