### PR TITLE
[Metricbeat] Step down from strong consistency mongodb sessions

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -73,6 +73,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Fix the include top N processes feature for cases where there are fewer processes than N. {pull}5729[5729]
 - Fix `ProcState` on Linux and FreeBSD when process names contain parentheses. {pull}5775[5775]
 - Fix incorrect `Mem.Used` calculation under linux. {pull}5775[5775]
+- Fix mongodb session consistency mode to allow command execution on secondary nodes. {issue}4689[4689]
 
 *Packetbeat*
 

--- a/metricbeat/module/mongodb/mongodb.go
+++ b/metricbeat/module/mongodb/mongodb.go
@@ -82,5 +82,8 @@ func NewDirectSession(dialInfo *mgo.DialInfo) (*mgo.Session, error) {
 		return nil, err
 	}
 
+	// Relax consistency mode so reading from a secondary is allowed
+	session.SetMode(mgo.Monotonic, true)
+
 	return session, nil
 }


### PR DESCRIPTION
Allow for low consistency session so connections to secondary nodes are allowed to read data.

Fixes #4689