### PR TITLE
Make logstash node system test more stable

### DIFF
--- a/metricbeat/module/logstash/_meta/Dockerfile
+++ b/metricbeat/module/logstash/_meta/Dockerfile
@@ -1,4 +1,5 @@
 FROM docker.elastic.co/logstash/logstash:6.0.0
 
+COPY healthcheck.sh /
 ENV XPACK_MONITORING_ENABLED=FALSE
-HEALTHCHECK --interval=1s --retries=90 CMD curl -f http://localhost:9600/_node/stats
+HEALTHCHECK --interval=1s --retries=90 CMD sh /healthcheck.sh

--- a/metricbeat/module/logstash/_meta/healthcheck.sh
+++ b/metricbeat/module/logstash/_meta/healthcheck.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# Check that both endpoints are available
+curl -f http://localhost:9600/_node || exit 1
+curl -f http://localhost:9600/_node/stats || exit 1
+curl -f http://localhost:9600/_node/stats | grep '"in":' || exit 1

--- a/metricbeat/module/logstash/node/node_integration_test.go
+++ b/metricbeat/module/logstash/node/node_integration_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 func TestFetch(t *testing.T) {
-
 	compose.EnsureUpWithTimeout(t, 120, "logstash")
 
 	f := mbtest.NewEventFetcher(t, logstash.GetConfig("node"))

--- a/metricbeat/tests/system/test_logstash.py
+++ b/metricbeat/tests/system/test_logstash.py
@@ -1,6 +1,7 @@
 import os
 import metricbeat
 import unittest
+import time
 
 
 class Test(metricbeat.BaseTest):
@@ -20,6 +21,7 @@ class Test(metricbeat.BaseTest):
             "hosts": self.get_hosts(),
             "period": "1s",
         }])
+        time.sleep(1)
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0, max_timeout=20)
         proc.check_kill_and_wait()
@@ -33,7 +35,7 @@ class Test(metricbeat.BaseTest):
         self.assert_fields_are_documented(evt)
 
     @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
-    def test_node(self):
+    def test_node_stats(self):
         """
         logstash node_stats metricset test
         """

--- a/metricbeat/tests/system/test_logstash.py
+++ b/metricbeat/tests/system/test_logstash.py
@@ -21,7 +21,6 @@ class Test(metricbeat.BaseTest):
             "hosts": self.get_hosts(),
             "period": "1s",
         }])
-        time.sleep(1)
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0, max_timeout=20)
         proc.check_kill_and_wait()


### PR DESCRIPTION
Introduce a 1 sec timeout to help the service to get available and return all fields.