### PR TITLE
Wrap the CLI interface with a RunWith function

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -17,6 +17,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Support dashboard loading without Elasticseach {pull}5653[5653]
 - Addition and update of the following libraries: pbkdf2, terminal, windows, unix {pull}5735[5735]
 - Update the command line library cobra and add support for zsh completion {pull}5761[5761]
+- Allow cobra command function to be wrapped into a function that with handle error handling. {issue}5760[5760]
 
 *Auditbeat*
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -17,7 +17,6 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Support dashboard loading without Elasticseach {pull}5653[5653]
 - Addition and update of the following libraries: pbkdf2, terminal, windows, unix {pull}5735[5735]
 - Update the command line library cobra and add support for zsh completion {pull}5761[5761]
-- Allow cobra command function to be wrapped into a function that with handle error handling. {issue}5760[5760]
 
 *Auditbeat*
 

--- a/libbeat/cmd/version.go
+++ b/libbeat/cmd/version.go
@@ -2,12 +2,12 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 	"runtime"
 
 	"github.com/spf13/cobra"
 
 	"github.com/elastic/beats/libbeat/cmd/instance"
+	"github.com/elastic/beats/libbeat/common/cli"
 	"github.com/elastic/beats/libbeat/version"
 )
 
@@ -15,15 +15,16 @@ func genVersionCmd(name, beatVersion string) *cobra.Command {
 	return &cobra.Command{
 		Use:   "version",
 		Short: "Show current version info",
-		Run: func(cmd *cobra.Command, args []string) {
-			beat, err := instance.NewBeat(name, "", beatVersion)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "Error initializing beat: %s\n", err)
-				os.Exit(1)
-			}
+		Run: cli.RunWith(
+			func(_ *cobra.Command, args []string) error {
+				beat, err := instance.NewBeat(name, "", beatVersion)
+				if err != nil {
+					return fmt.Errorf("error initializing beat: %s", err)
+				}
 
-			fmt.Printf("%s version %s (%s), libbeat %s\n",
-				beat.Info.Beat, beat.Info.Version, runtime.GOARCH, version.GetDefaultVersion())
-		},
+				fmt.Printf("%s version %s (%s), libbeat %s\n",
+					beat.Info.Beat, beat.Info.Version, runtime.GOARCH, version.GetDefaultVersion())
+				return nil
+			}),
 	}
 }

--- a/libbeat/common/cli/cli.go
+++ b/libbeat/common/cli/cli.go
@@ -1,0 +1,20 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// RunWith wrap cli function with an error handler instead of having the code exit early.
+func RunWith(
+	fn func(cmd *cobra.Command, args []string) error,
+) func(cmd *cobra.Command, args []string) {
+	return func(cmd *cobra.Command, args []string) {
+		if err := fn(cmd, args); err != nil {
+			fmt.Fprintln(os.Stderr, err.Error())
+			os.Exit(1)
+		}
+	}
+}

--- a/libbeat/common/cli/cli_test.go
+++ b/libbeat/common/cli/cli_test.go
@@ -1,0 +1,61 @@
+package cli
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+func funcWithError() {
+	var cmd *cobra.Command
+	var args []string
+	RunWith(func(cmd *cobra.Command, args []string) error {
+		return fmt.Errorf("Something bad")
+	})(cmd, args)
+}
+
+func funcWithoutError() {
+	var cmd *cobra.Command
+	var args []string
+	RunWith(func(cmd *cobra.Command, args []string) error {
+		return nil
+	})(cmd, args)
+}
+
+// Example taken from slides from Andrew Gerrand
+// https://talks.golang.org/2014/testing.slide#23
+func TestExitWithError(t *testing.T) {
+	if os.Getenv("TEST_RUNWITH") == "1" {
+		funcWithError()
+		return
+	}
+	cmd := exec.Command(os.Args[0], "-test.run=TestExitWithError")
+	cmd.Env = append(os.Environ(), "TEST_RUNWITH=1")
+	bufError := new(bytes.Buffer)
+	cmd.Stderr = bufError
+	err := cmd.Run()
+	if assert.Error(t, err) {
+		assert.Equal(t, err.Error(), "exit status 1")
+	}
+	assert.Equal(t, "Something bad\n", bufError.String())
+}
+
+func TestExitWithoutError(t *testing.T) {
+	if os.Getenv("TEST_RUNWITH") == "1" {
+		funcWithoutError()
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestExitWithoutError")
+	cmd.Env = append(os.Environ(), "TEST_RUNWITH=1")
+	bufError := new(bytes.Buffer)
+	cmd.Stderr = bufError
+	err := cmd.Run()
+	assert.NoError(t, err)
+	assert.Equal(t, "", bufError.String())
+}


### PR DESCRIPTION
The wrapper expects to receive method to return an error if something
bad happens, the wrapper will take care of correctly outputting the error
to the stderr and also call os.Exit(1).

Fix: #5760 

~~**Don't review it yet; I am currently testing it in the keystore branch**~~


**Note** I only refactored the version command, I the other methods can be done in multiple PR as we see fit.
