### PR TITLE
Fix crash in TLS event generation

### DIFF
--- a/packetbeat/protos/tls/tls.go
+++ b/packetbeat/protos/tls/tls.go
@@ -260,6 +260,8 @@ func (plugin *tlsPlugin) createEvent(conn *tlsConnectionData) beat.Event {
 	if server.parser.hello != nil {
 		serverHello = server.parser.hello
 		tls["server_hello"] = serverHello.toMap()
+	} else {
+		serverHello = emptyHello
 	}
 	if cert, chain := getCerts(client.parser.certificates, plugin.includeRawCertificates); cert != nil {
 		tls["client_certificate"] = cert


### PR DESCRIPTION
A panic was raised when the server hello was missing
and the client hello contained a session ID.

Fixes #5801