### PR TITLE
Fix crash in TLS event generation [6.1]

### DIFF
--- a/packetbeat/protos/tls/tls.go
+++ b/packetbeat/protos/tls/tls.go
@@ -248,6 +248,8 @@ func (plugin *tlsPlugin) createEvent(conn *tlsConnectionData) beat.Event {
 	if server.parser.hello != nil {
 		serverHello = server.parser.hello
 		tls["server_hello"] = serverHello.toMap()
+	} else {
+		serverHello = emptyHello
 	}
 	if cert, chain := getCerts(client.parser.certificates, plugin.includeRawCertificates); cert != nil {
 		tls["client_certificate"] = cert


### PR DESCRIPTION
#5803 backported to 6.1