### PR TITLE
Add temp hack to fix auditbeat packaging

### DIFF
--- a/vendor/github.com/fsnotify/fsevents/wrap.go
+++ b/vendor/github.com/fsnotify/fsevents/wrap.go
@@ -35,7 +35,7 @@ import (
 )
 
 // eventIDSinceNow is a sentinel to begin watching events "since now".
-const eventIDSinceNow = uint64(C.kFSEventStreamEventIdSinceNow + (1 << 64))
+const eventIDSinceNow = uint64(C.kFSEventStreamEventIdSinceNow)
 
 // LatestEventID returns the most recently generated event ID, system-wide.
 func LatestEventID() uint64 {


### PR DESCRIPTION
This takes the fix https://github.com/elastic/fsevents/pull/2 and overwrites it directly in our vendor directory. This is a temporary fix until the vendoring is updated to our dependency but should bring our builds and packaging back to green.