### PR TITLE
Use default frequency and query_delay in ML datafeeds

### DIFF
--- a/filebeat/module/nginx/access/machine_learning/datafeed_low_request_rate.json
+++ b/filebeat/module/nginx/access/machine_learning/datafeed_low_request_rate.json
@@ -1,7 +1,5 @@
 {
     "job_id": "JOB_ID",
-    "query_delay": "60s",
-    "frequency": "450s",
     "indexes": [
       "filebeat-*"
     ],

--- a/filebeat/module/nginx/access/machine_learning/datafeed_remote_ip_request_rate.json
+++ b/filebeat/module/nginx/access/machine_learning/datafeed_remote_ip_request_rate.json
@@ -1,7 +1,5 @@
 {
     "job_id": "JOB_ID",
-    "query_delay": "60s",
-    "frequency": "600s",
     "indexes": [
       "filebeat-*"
     ],

--- a/filebeat/module/nginx/access/machine_learning/datafeed_remote_ip_url_count.json
+++ b/filebeat/module/nginx/access/machine_learning/datafeed_remote_ip_url_count.json
@@ -1,7 +1,5 @@
 {
     "job_id": "JOB_ID",
-    "query_delay": "60s",
-    "frequency": "600s",
     "indexes": [
       "filebeat-*"
     ],

--- a/filebeat/module/nginx/access/machine_learning/datafeed_response_code.json
+++ b/filebeat/module/nginx/access/machine_learning/datafeed_response_code.json
@@ -1,7 +1,5 @@
 {
     "job_id": "JOB_ID",
-    "query_delay": "60s",
-    "frequency": "450s",
     "indexes": [
       "filebeat-*"
     ],

--- a/filebeat/module/nginx/access/machine_learning/datafeed_visitor_rate.json
+++ b/filebeat/module/nginx/access/machine_learning/datafeed_visitor_rate.json
@@ -1,7 +1,5 @@
 {
     "job_id": "JOB_ID",
-    "query_delay": "60s",
-    "frequency": "450s",
     "indexes": [
       "filebeat-*"
     ],

--- a/filebeat/module/traefik/access/machine_learning/datafeed_low_request_rate.json
+++ b/filebeat/module/traefik/access/machine_learning/datafeed_low_request_rate.json
@@ -1,7 +1,5 @@
 {
     "job_id": "JOB_ID",
-    "query_delay": "60s",
-    "frequency": "450s",
     "indexes": [
       "filebeat-*"
     ],

--- a/filebeat/module/traefik/access/machine_learning/datafeed_remote_ip_request_rate.json
+++ b/filebeat/module/traefik/access/machine_learning/datafeed_remote_ip_request_rate.json
@@ -1,7 +1,5 @@
 {
     "job_id": "JOB_ID",
-    "query_delay": "60s",
-    "frequency": "600s",
     "indexes": [
       "filebeat-*"
     ],

--- a/filebeat/module/traefik/access/machine_learning/datafeed_remote_ip_url_count.json
+++ b/filebeat/module/traefik/access/machine_learning/datafeed_remote_ip_url_count.json
@@ -1,7 +1,5 @@
 {
     "job_id": "JOB_ID",
-    "query_delay": "60s",
-    "frequency": "600s",
     "indexes": [
       "filebeat-*"
     ],

--- a/filebeat/module/traefik/access/machine_learning/datafeed_response_code.json
+++ b/filebeat/module/traefik/access/machine_learning/datafeed_response_code.json
@@ -1,7 +1,5 @@
 {
     "job_id": "JOB_ID",
-    "query_delay": "60s",
-    "frequency": "450s",
     "indexes": [
       "filebeat-*"
     ],

--- a/filebeat/module/traefik/access/machine_learning/datafeed_visitor_rate.json
+++ b/filebeat/module/traefik/access/machine_learning/datafeed_visitor_rate.json
@@ -1,7 +1,5 @@
 {
     "job_id": "JOB_ID",
-    "query_delay": "60s",
-    "frequency": "450s",
     "indexes": [
       "filebeat-*"
     ],


### PR DESCRIPTION
There is no need to set explicitly `frequency` and `query_delay`
parameters for ML datafeeds. The current values are the default
values but a change in the way datafeeds with aggregations work
makes those frequencies invalid settings. Also, in the future the
smart defaults might evolve, so using them will leverage such
improvements.