### PR TITLE
Update go-structform

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -3491,8 +3491,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------
 Dependency: github.com/urso/go-structform
-Version: v0.0.1
-Revision: a59a4e97c96431f4ad25ed3bd027981f2e0ff5c2
+Version: v0.0.2
+Revision: 844d7d44009e9e8c0f08016fc4dab64e136ca040
 License type (autodetected): Apache-2.0
 ./vendor/github.com/urso/go-structform/LICENSE:
 --------------------------------------------------------------------

--- a/vendor/github.com/urso/go-structform/CHANGELOG.md
+++ b/vendor/github.com/urso/go-structform/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+This project adheres to [Semantic Versioning](http://semver.org/).
+
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+## [0.0.2]
+
+### Added
+- Add struct tag option ",omitempty".
+- Add StringConvVisitor converting all primitive values to strings.
+- Move and export object visitor into visitors package
+
+### Fixed
+- Fix invalid pointer indirections in struct to array/map.
+
+[Unreleased]: https://github.com/elastic/go-ucfg/compare/v0.0.2...HEAD
+[0.0.2]: https://github.com/elastic/go-ucfg/compare/v0.0.1...v0.0.2

--- a/vendor/github.com/urso/go-structform/gotype/error.go
+++ b/vendor/github.com/urso/go-structform/gotype/error.go
@@ -25,6 +25,8 @@ var (
 	errExpectedArray            = errors.New("expected array")
 	errExpectedObject           = errors.New("expected object")
 	errExpectedObjectValue      = errors.New("expected object value")
+	errExpectedObjectClose      = errors.New("missing object close")
+	errInlineAndOmitEmpty       = errors.New("inline and omitempty must not be set at the same time")
 )
 
 func errTODO() error {

--- a/vendor/github.com/urso/go-structform/gotype/fold_arr.go
+++ b/vendor/github.com/urso/go-structform/gotype/fold_arr.go
@@ -7,7 +7,6 @@ import (
 )
 
 var (
-	// reFoldArrAny  = liftFold([]interface{}(nil), visitArrInterface)
 	reFoldArrBool    = liftFold([]bool(nil), foldArrBool)
 	reFoldArrInt     = liftFold([]int(nil), foldArrInt)
 	reFoldArrInt8    = liftFold([]int8(nil), foldArrInt8)
@@ -25,13 +24,6 @@ var (
 )
 
 var tArrayAny = reflect.TypeOf([]interface{}(nil))
-
-func reFoldArrAny(c *foldContext, v reflect.Value) error {
-	if v.Type().Name() != "" {
-		v = v.Convert(tArrayAny)
-	}
-	return foldArrInterface(c, v.Interface())
-}
 
 func foldArrInterface(C *foldContext, v interface{}) error {
 	a := v.([]interface{})

--- a/vendor/github.com/urso/go-structform/gotype/fold_inline.go
+++ b/vendor/github.com/urso/go-structform/gotype/fold_inline.go
@@ -1,16 +1,11 @@
 package gotype
 
 import (
-	"errors"
 	"reflect"
 
-	structform "github.com/urso/go-structform"
+	"github.com/urso/go-structform"
+	"github.com/urso/go-structform/visitors"
 )
-
-type expectObjVisitor struct {
-	active visitor
-	depth  int
-}
 
 // getReflectFoldMapKeys implements inline fold of a map[string]X type,
 // not reporting object start/end events
@@ -76,7 +71,7 @@ func getReflectFoldInlineInterface(C *foldContext, t reflect.Type) (reFoldFn, er
 func embeddObjReFold(C *foldContext, objFold reFoldFn) reFoldFn {
 	var (
 		ctx = *C
-		vs  = &expectObjVisitor{}
+		vs  = visitors.NewExpectObjVisitor(nil)
 	)
 
 	ctx.visitor = structform.EnsureExtVisitor(vs).(visitor)
@@ -86,188 +81,13 @@ func embeddObjReFold(C *foldContext, objFold reFoldFn) reFoldFn {
 			return nil
 		}
 
-		vs.active = C.visitor
-		defer func() { vs.active = nil }()
-
-		vs.depth = 0
-		if err := objFold(&ctx, rv); err != nil {
-			return err
+		vs.SetActive(C.visitor)
+		err := objFold(&ctx, rv)
+		if err == nil && !vs.Done() {
+			err = errExpectedObjectClose
 		}
 
-		if vs.depth != 0 {
-			return errors.New("missing object close")
-		}
-
-		return nil
-	}
-}
-
-func (v *expectObjVisitor) OnObjectStart(len int, baseType structform.BaseType) error {
-	v.depth++
-	if v.depth == 1 {
-		return nil
-	}
-	return v.active.OnObjectStart(len, baseType)
-}
-
-func (v *expectObjVisitor) OnObjectFinished() error {
-	v.depth--
-	if v.depth == 0 {
-		return nil
-	}
-	return v.active.OnObjectFinished()
-}
-
-func (v *expectObjVisitor) OnKey(s string) error {
-	if err := v.check(); err != nil {
+		vs.SetActive(nil)
 		return err
 	}
-	return v.active.OnKey(s)
-}
-
-func (v *expectObjVisitor) OnArrayStart(len int, baseType structform.BaseType) error {
-	if err := v.check(); err != nil {
-		return err
-	}
-	return v.active.OnArrayStart(len, baseType)
-}
-
-func (v *expectObjVisitor) OnArrayFinished() error {
-	if err := v.check(); err != nil {
-		return err
-	}
-	return v.active.OnArrayFinished()
-}
-
-func (v *expectObjVisitor) OnNil() error {
-	if err := v.check(); err != nil {
-		return err
-	}
-	return v.active.OnNil()
-}
-
-func (v *expectObjVisitor) OnBool(b bool) error {
-	if err := v.check(); err != nil {
-		return err
-	}
-	return v.active.OnBool(b)
-}
-
-func (v *expectObjVisitor) OnString(s string) error {
-	if err := v.check(); err != nil {
-		return err
-	}
-	return v.active.OnString(s)
-}
-
-func (v *expectObjVisitor) OnInt8(i int8) error {
-	if err := v.check(); err != nil {
-		return err
-	}
-	return v.active.OnInt8(i)
-}
-
-func (v *expectObjVisitor) OnInt16(i int16) error {
-	if err := v.check(); err != nil {
-		return err
-	}
-	return v.active.OnInt16(i)
-}
-
-func (v *expectObjVisitor) OnInt32(i int32) error {
-	if err := v.check(); err != nil {
-		return err
-	}
-	return v.active.OnInt32(i)
-}
-
-func (v *expectObjVisitor) OnInt64(i int64) error {
-	if err := v.check(); err != nil {
-		return err
-	}
-	return v.active.OnInt64(i)
-}
-
-func (v *expectObjVisitor) OnInt(i int) error {
-	if err := v.check(); err != nil {
-		return err
-	}
-	return v.active.OnInt(i)
-}
-
-func (v *expectObjVisitor) OnByte(b byte) error {
-	if err := v.check(); err != nil {
-		return err
-	}
-	return v.active.OnByte(b)
-}
-
-func (v *expectObjVisitor) OnUint8(u uint8) error {
-	if err := v.check(); err != nil {
-		return err
-	}
-	return v.active.OnUint8(u)
-}
-
-func (v *expectObjVisitor) OnUint16(u uint16) error {
-	if err := v.check(); err != nil {
-		return err
-	}
-	return v.active.OnUint16(u)
-}
-
-func (v *expectObjVisitor) OnUint32(u uint32) error {
-	if err := v.check(); err != nil {
-		return err
-	}
-	return v.active.OnUint32(u)
-}
-
-func (v *expectObjVisitor) OnUint64(u uint64) error {
-	if err := v.check(); err != nil {
-		return err
-	}
-	return v.active.OnUint64(u)
-}
-
-func (v *expectObjVisitor) OnUint(u uint) error {
-	if err := v.check(); err != nil {
-		return err
-	}
-	return v.active.OnUint(u)
-}
-
-func (v *expectObjVisitor) OnFloat32(f float32) error {
-	if err := v.check(); err != nil {
-		return err
-	}
-	return v.active.OnFloat32(f)
-}
-
-func (v *expectObjVisitor) OnFloat64(f float64) error {
-	if err := v.check(); err != nil {
-		return err
-	}
-	return v.active.OnFloat64(f)
-}
-
-func (v *expectObjVisitor) OnStringRef(s []byte) error {
-	if err := v.check(); err != nil {
-		return err
-	}
-	return v.active.OnStringRef(s)
-}
-
-func (v *expectObjVisitor) OnKeyRef(s []byte) error {
-	if err := v.check(); err != nil {
-		return err
-	}
-	return v.active.OnKeyRef(s)
-}
-
-func (v *expectObjVisitor) check() error {
-	if v.depth == 0 {
-		return errors.New("inline object is no object")
-	}
-	return nil
 }

--- a/vendor/github.com/urso/go-structform/gotype/fold_map.go
+++ b/vendor/github.com/urso/go-structform/gotype/fold_map.go
@@ -7,7 +7,6 @@ import (
 )
 
 var (
-	// reflectMapAny     = reflectCast(map[string]interface{}(nil), visitMapInterface)
 	reFoldMapBool    = liftFold(map[string]bool(nil), foldMapBool)
 	reFoldMapInt     = liftFold(map[string]int(nil), foldMapInt)
 	reFoldMapInt8    = liftFold(map[string]int8(nil), foldMapInt8)
@@ -25,13 +24,6 @@ var (
 )
 
 var tMapAny = reflect.TypeOf(map[string]interface{}(nil))
-
-func reflectMapAny(C *foldContext, v reflect.Value) error {
-	if v.Type().Name() != "" {
-		v = v.Convert(tArrayAny)
-	}
-	return foldMapInterface(C, v.Interface())
-}
 
 func foldMapInterface(C *foldContext, v interface{}) error {
 	m := v.(map[string]interface{})

--- a/vendor/github.com/urso/go-structform/gotype/fold_map_inline.yml
+++ b/vendor/github.com/urso/go-structform/gotype/fold_map_inline.yml
@@ -1,0 +1,64 @@
+import:
+  - types.yml
+
+main: |
+  package gotype
+
+  import (
+    "reflect"
+
+    stunsafe "github.com/urso/go-structform/internal/unsafe"
+  )
+
+  var _mapInlineMapping = map[reflect.Type]reFoldFn{
+    {{ range data.primitiveTypes }}
+      {{- $t := capitalize . -}}
+    t{{ $t }}: foldMapInline{{ $t }},
+    {{ end }}
+  }
+
+  func getMapInlineByPrimitiveElem(t reflect.Type) reFoldFn {
+    if t == tInterface {
+      return foldMapInlineInterface
+    }
+    return _mapInlineMapping[t]
+  }
+
+  func foldMapInlineInterface(C *foldContext, v reflect.Value) (err error) {
+    ptr := unsafe.Pointer(v.Pointer())
+    if ptr == nil {
+      return nil
+    }
+
+    m := *((*map[string]interface{})(unsafe.Pointer(&ptr)))
+    for k, v := range m {
+      if err = C.OnKey(k); err != nil {
+        return err
+      }
+      if err = foldInterfaceValue(C, v); err != nil {
+        return err
+      }
+    }
+    return
+  }
+
+  {{ range data.primitiveTypes }}
+    {{ $t := capitalize . }}
+    func foldMapInline{{ $t }}(C *foldContext, v reflect.Value) (err error) {
+      ptr := unsafe.Pointer(v.Pointer())
+      if ptr == nil {
+        return nil
+      }
+
+      m := *((*map[string]{{ . }})(unsafe.Pointer(&ptr)))
+      for k, v := range m {
+        if err = C.OnKey(k); err != nil {
+          return err
+        }
+        if err = C.On{{ $t }}(v); err != nil {
+          return err
+        }
+      }
+      return
+    }
+  {{ end }}

--- a/vendor/github.com/urso/go-structform/gotype/fold_refl_sel.yml
+++ b/vendor/github.com/urso/go-structform/gotype/fold_refl_sel.yml
@@ -1,0 +1,30 @@
+import:
+  - types.yml
+
+main: |
+  package gotype
+
+  var _reflPrimitivesMapping = map[reflect.Type]reFoldFn{
+    {{ range data.primitiveTypes }}
+      {{ $t := capitalize . }}
+      t{{ $t }}: reFold{{ $t }},
+      reflect.SliceOf(t{{ $t }}): reFoldArr{{ $t }},
+      reflect.MapOf(tString, t{{ $t }}): reFoldMap{{ $t }},
+    {{ end }}
+  }
+
+  func getReflectFoldPrimitive(t reflect.Type) reFoldFn {
+    return _reflPrimitivesMapping[t]
+  }
+
+  func getReflectFoldPrimitiveKind(t reflect.Type) (reFoldFn, error) {
+    switch t.Kind() {
+    {{ range data.primitiveTypes }}
+      {{ $t := capitalize . }}
+      case reflect.{{ $t }}:
+        return reFold{{ $t }}, nil
+    {{ end }}
+    default:
+      return nil, errUnsupported
+    }
+  }

--- a/vendor/github.com/urso/go-structform/gotype/stacks.yml
+++ b/vendor/github.com/urso/go-structform/gotype/stacks.yml
@@ -1,0 +1,48 @@
+data.stacks:
+- name: unfolderStack
+  type: unfolder
+- name: reflectValueStack
+  type: reflect.Value
+- name: ptrStack
+  init: 'nil'
+  type: unsafe.Pointer
+- name: keyStack
+  type: string
+  init: '""'
+- name: idxStack
+  type: int
+  init: -1
+- name: structformTypeStack
+  type: structform.BaseType
+  init: structform.AnyType
+
+main: |
+  package gotype
+
+  {{ range .stacks }}
+  type {{ .name }} struct {
+    current {{ .type  }}
+    stack []{{ .type }}
+    stack0 [{{ if .size0 }}{{ .size0 }}{{ else }}32{{ end }}]{{ .type }}
+  }
+  {{ end }}
+  
+  {{ range .stacks }}
+  func (s *{{ .name }}) init({{ if isnil .init }}v {{ .type }}{{end}}) {
+    s.current = {{ if isnil .init }}v{{ else }}{{ .init }}{{end}}
+    s.stack = s.stack0[:0]
+  }
+  
+  func (s *{{ .name }}) push(v {{ .type }}) {
+    s.stack = append(s.stack, s.current)
+    s.current = v
+  }
+  
+  func (s *{{ .name }}) pop() {{ .type }} {
+    old := s.current
+    last := len(s.stack) - 1
+    s.current = s.stack[last]
+    s.stack = s.stack[:last]
+    return old
+  }
+  {{ end }}

--- a/vendor/github.com/urso/go-structform/gotype/tags.go
+++ b/vendor/github.com/urso/go-structform/gotype/tags.go
@@ -3,10 +3,14 @@ package gotype
 import "strings"
 
 type tagOptions struct {
-	squash bool
+	squash    bool
+	omitEmpty bool
 }
 
-var defaultTagOptions = tagOptions{}
+var defaultTagOptions = tagOptions{
+	squash:    false,
+	omitEmpty: false,
+}
 
 func parseTags(tag string) (string, tagOptions) {
 	s := strings.Split(tag, ",")
@@ -18,6 +22,8 @@ func parseTags(tag string) (string, tagOptions) {
 		switch strings.TrimSpace(opt) {
 		case "squash", "inline":
 			opts.squash = true
+		case "omitempty":
+			opts.omitEmpty = true
 		}
 	}
 	return strings.TrimSpace(s[0]), opts

--- a/vendor/github.com/urso/go-structform/gotype/types.yml
+++ b/vendor/github.com/urso/go-structform/gotype/types.yml
@@ -1,0 +1,51 @@
+data.numTypes: [
+    uint, uint8, uint16, uint32, uint64,
+    int, int8, int16, int32, int64,
+    float32, float64
+  ]
+
+data.primitiveTypes: [
+    bool,
+    string,
+    uint, uint8, uint16, uint32, uint64,
+    int, int8, int16, int32, int64,
+    float32, float64
+  ]
+
+data.mapTypes:
+  AnyType: 'interface{}'
+  ByteType: uint8
+  StringType: string
+  BoolType: bool
+  ZeroType: 'interface{}'
+  IntType: int
+  Int8Type: int8
+  Int16Type: int16
+  Int32Type: int32
+  Int64Type: int64
+  UintType: uint
+  Uint8Type: uint8
+  Uint16Type: uint16
+  Uint32Type: uint32
+  Uint64Type: uint64
+  Float32Type: float32
+  Float64Type: float64
+
+data.mapReflTypes:
+  AnyType: tInterface
+  ByteType: tByte
+  StringType: tString
+  BoolType: tBool
+  ZeroType: tInterface
+  IntType: tInt
+  Int8Type: tInt8
+  Int16Type: tInt16
+  Int32Type: tInt32
+  Int64Type: tInt64
+  UintType: tUint
+  Uint8Type: tUint8
+  Uint16Type: tUint16
+  Uint32Type: tUint32
+  Uint64Type: tUint64
+  Float32Type: tFloat32
+  Float64Type: tFloat64

--- a/vendor/github.com/urso/go-structform/gotype/unfold_arr.yml
+++ b/vendor/github.com/urso/go-structform/gotype/unfold_arr.yml
@@ -1,0 +1,155 @@
+import:
+  - unfold_templates.yml
+
+main: |
+  package gotype
+
+  import "github.com/urso/go-structform"
+
+  {{/* defined 'lifted' pointer slice unfolders into reflection based unfolders */}}
+  var (
+    unfolderReflArrIfc = liftGoUnfolder(newUnfolderArrIfc())
+    {{ range data.primitiveTypes }}
+    {{ $t := capitalize . }}
+      unfolderReflArr{{ $t }} = liftGoUnfolder(newUnfolderArr{{ $t }}())
+    {{ end }}
+  )
+
+  {{/* define pointer based unfolder types */}}
+  {{ invoke "makeTypeWithName" "name" "Ifc" "type" "interface{}" }}
+  {{ template "makeType" "bool" }}
+  {{ template "makeType" "string" }}
+  {{ range .numTypes }}
+    {{ template "makeType" . }}
+  {{ end }}
+
+  {{/* create visitor callbacks */}}
+  {{ invoke "onIfcFns" "name" "unfolderArrIfc" "fn" "append" }}
+  {{ invoke "onBoolFns" "name" "unfolderArrBool" "fn" "append" }}
+  {{ invoke "onStringFns" "name" "unfolderArrString" "fn" "append" }}
+  {{ range .numTypes }}
+    {{ $type := . }}
+    {{ $name := capitalize $type | printf "unfolderArr%v" }}
+    {{ invoke "onNumberFns" "name" $name "type" $type "fn" "append" }}
+  {{ end }}
+
+  {{ template "arrIfc" }}
+
+
+# makeTypeWithName(name, type)
+templates.makeTypeWithName: |
+  {{ $type := .type }}
+  {{ $name := capitalize .name | printf "unfolderArr%v" }}
+  {{ $startName := capitalize .name | printf "unfoldArrStart%v" }}
+
+  {{ invoke "makeUnfoldType" "name" $name  }}
+  {{ invoke "makeUnfoldType" "name" $startName "base" "unfolderErrArrayStart" }} 
+
+  func (u *{{ $name }} ) initState(ctx *unfoldCtx, ptr unsafe.Pointer) {
+    ctx.unfolder.push(u)
+    ctx.unfolder.push(new{{ $startName | capitalize}}())
+    ctx.idx.push(0)
+    ctx.ptr.push(ptr)
+  }
+
+  func (u * {{ $name }} ) cleanup(ctx *unfoldCtx) {
+    ctx.unfolder.pop()
+    ctx.idx.pop()
+    ctx.ptr.pop()
+  }
+
+  func (u * {{ $startName }}) cleanup(ctx *unfoldCtx) {
+    ctx.unfolder.pop()
+  }
+
+  func (u *{{ $startName }} ) ptr(ctx *unfoldCtx) *[]{{ $type }} {
+    return (*[]{{ $type }})(ctx.ptr.current)
+  }
+
+  func (u *{{ $name }} ) ptr(ctx *unfoldCtx) *[]{{ $type }} {
+    return (*[]{{ $type }})(ctx.ptr.current)
+  }
+
+  func (u *{{ $startName }}) OnArrayStart(ctx *unfoldCtx, l int, baseType structform.BaseType) error {
+    to := u.ptr(ctx)
+    if l < 0 {
+      l = 0
+    }
+
+    if *to == nil && l > 0 {
+      *to = make([]{{ $type }}, l)
+    } else if l < len(*to) {
+      *to = (*to)[:l]
+    }
+
+    u.cleanup(ctx)
+    return nil
+  }
+
+  func (u *{{ $name }} ) OnArrayFinished(ctx *unfoldCtx) error {
+    u.cleanup(ctx)
+    return nil
+  }
+
+  func (u *{{ $name }} ) append(ctx *unfoldCtx, v {{ $type }}) error {
+    idx := &ctx.idx
+    to := u.ptr(ctx)
+    if len(*to) <= idx.current {
+      *to = append(*to, v)
+    } else {
+      (*to)[idx.current] = v
+    }
+
+    idx.current++
+    return nil
+  }
+
+templates.arrIfc: |
+
+  func unfoldIfcStartSubArray(ctx *unfoldCtx, l int, baseType structform.BaseType) error {
+    _, ptr, unfolder := makeArrayPtr(ctx, l, baseType)
+    ctx.ptr.push(ptr) // store pointer for use in 'Finish'
+    ctx.baseType.push(baseType)
+    unfolder.initState(ctx, ptr)
+    return ctx.unfolder.current.OnArrayStart(ctx, l, baseType)
+  }
+
+  func unfoldIfcFinishSubArray(ctx *unfoldCtx) (interface{}, error) {
+    child := ctx.ptr.pop()
+    bt := ctx.baseType.pop()
+    switch bt {
+    {{ range $bt, $gt := data.mapTypes }}
+    case structform.{{ $bt }}:
+      ctx.buf.release()
+      return *(*[]{{ $gt }})(child), nil
+    {{ end }}
+    default:
+      return nil, errTODO()
+    }
+  }
+
+  func makeArrayPtr(ctx *unfoldCtx, l int, bt structform.BaseType) (interface{}, unsafe.Pointer, ptrUnfolder) {
+    switch bt {
+    {{ range $bt, $gt := data.mapTypes }}
+    case structform.{{ $bt }}:
+      sz := unsafe.Sizeof([]{{ $gt }}{})
+      ptr := ctx.buf.alloc(int(sz))
+      to := (*[]{{ $gt }})(ptr)
+
+      if l > 0 {
+        *to = make([]{{ $gt }}, l)
+      }
+
+      {{ if or (eq $bt "AnyType")  (eq $bt "ZeroType") }}
+        unfolder := newUnfolderArrIfc()
+      {{ else }}
+        unfolder := newUnfolderArr{{ $gt | capitalize }}()
+      {{ end }}
+      return to, ptr, unfolder
+
+    {{ end }}
+    default:
+      panic("invalid type code")
+      return nil, nil, nil
+    }
+  }

--- a/vendor/github.com/urso/go-structform/gotype/unfold_err.yml
+++ b/vendor/github.com/urso/go-structform/gotype/unfold_err.yml
@@ -1,0 +1,46 @@
+import:
+  - unfold_templates.yml
+
+data.errorUnfolders:
+  unfolderNoTarget: errNotInitialized
+  unfolderErrUnknown: errUnsupported
+  unfolderErrArrayStart: errExpectedArray
+  unfolderErrObjectStart: errExpectedObject
+  unfolderErrExpectKey: errExpectedObjectKey
+
+main: |
+  package gotype
+
+  {{ range $name, $err := data.errorUnfolders }}
+  type {{ $name }} struct {}
+  {{ end }}
+
+  {{ range $name, $err := data.errorUnfolders }}
+
+  func (*{{ $name }}) OnNil(*unfoldCtx) error { return {{ $err }} }
+  func (*{{ $name }}) OnBool(*unfoldCtx, bool) error { return {{ $err }} }
+  func (*{{ $name }}) OnString(*unfoldCtx, string) error { return {{ $err }} }
+  func (*{{ $name }}) OnStringRef(*unfoldCtx, []byte) error { return {{ $err }} }
+  func (*{{ $name }}) OnInt8(*unfoldCtx, int8) error { return {{ $err }} }
+  func (*{{ $name }}) OnInt16(*unfoldCtx, int16) error { return {{ $err }} }
+  func (*{{ $name }}) OnInt32(*unfoldCtx, int32) error { return {{ $err }} }
+  func (*{{ $name }}) OnInt64(*unfoldCtx, int64) error { return {{ $err }} }
+  func (*{{ $name }}) OnInt(*unfoldCtx, int) error { return {{ $err }} }
+  func (*{{ $name }}) OnByte(*unfoldCtx, byte) error { return {{ $err }} }
+  func (*{{ $name }}) OnUint8(*unfoldCtx, uint8) error { return {{ $err }} }
+  func (*{{ $name }}) OnUint16(*unfoldCtx, uint16) error { return {{ $err }} }
+  func (*{{ $name }}) OnUint32(*unfoldCtx, uint32) error { return {{ $err }} }
+  func (*{{ $name }}) OnUint64(*unfoldCtx, uint64) error { return {{ $err }} }
+  func (*{{ $name }}) OnUint(*unfoldCtx, uint) error { return {{ $err }} }
+  func (*{{ $name }}) OnFloat32(*unfoldCtx, float32) error { return {{ $err }} }
+  func (*{{ $name }}) OnFloat64(*unfoldCtx, float64) error { return {{ $err }} }
+  func (*{{ $name }}) OnArrayStart(*unfoldCtx, int, structform.BaseType) error { return {{ $err }} }
+  func (*{{ $name }}) OnArrayFinished(*unfoldCtx) error { return {{ $err }} }
+  func (*{{ $name }}) OnChildArrayDone(*unfoldCtx) error { return {{ $err }} }
+  func (*{{ $name }}) OnObjectStart(*unfoldCtx, int, structform.BaseType) error { return {{ $err }} }
+  func (*{{ $name }}) OnObjectFinished(*unfoldCtx) error { return {{ $err }} }
+  func (*{{ $name }}) OnKey(*unfoldCtx, string) error { return {{ $err }} }
+  func (*{{ $name }}) OnKeyRef(*unfoldCtx, []byte) error { return {{ $err }} }
+  func (*{{ $name }}) OnChildObjectDone(*unfoldCtx) error { return {{ $err }} }
+
+  {{ end }}

--- a/vendor/github.com/urso/go-structform/gotype/unfold_ignore.yml
+++ b/vendor/github.com/urso/go-structform/gotype/unfold_ignore.yml
@@ -1,0 +1,90 @@
+main: |
+  package gotype
+
+  {{ invoke "makeIgnoreType" "type" "" }}
+
+  func (*unfolderIgnore) onValue(ctx *unfoldCtx) error {
+    ctx.unfolder.pop()
+    return nil
+  }
+
+  {{ invoke "makeIgnoreType" "type" "Arr" }}
+
+  func (*unfolderIgnoreArr) onValue(ctx *unfoldCtx) error {
+    return nil
+  }
+
+  func (*unfolderIgnoreArr) OnArrayFinished(ctx *unfoldCtx) error {
+    ctx.unfolder.pop()
+    return nil
+  }
+
+  {{ invoke "makeIgnoreType" "type" "Obj" }}
+
+  func (*unfolderIgnoreObj) onValue(ctx *unfoldCtx) error {
+    return nil
+  }
+
+  func (*unfolderIgnoreObj) OnObjectFinished(ctx *unfoldCtx) error {
+    ctx.unfolder.pop()
+    return nil
+  }
+
+templates.makeIgnoreType: |
+  {{ $type := .type }}
+  {{ $tUnfolder := printf "unfolderIgnore%v" $type }}
+
+  type unfoldIgnore{{ $type }}Value struct {}
+  type unfoldIgnore{{ $type }}Ptr struct {}
+  type {{ $tUnfolder }} struct {
+    unfolderErrUnknown
+  }
+
+  var (
+    _singletonUnfoldIgnore{{ $type }}Value = &unfoldIgnore{{ $type }}Value{}
+    _singletonUnfoldIgnore{{ $type }}Ptr = &unfoldIgnore{{ $type }}Ptr{}
+    _singleton{{ $tUnfolder }} = &{{ $tUnfolder }}{}
+  )
+
+  func (*unfoldIgnore{{ $type }}Value) initState(ctx *unfoldCtx, _ reflect.Value) {
+    ctx.unfolder.push(_singleton{{ $tUnfolder }})
+  }
+
+  func (*unfoldIgnore{{ $type }}Ptr) initState(ctx *unfoldCtx, _ unsafe.Pointer) {
+    ctx.unfolder.push(_singleton{{ $tUnfolder }})
+  }
+
+  func (u *{{ $tUnfolder }}) OnNil(ctx *unfoldCtx) error { return u.onValue(ctx) }
+  func (u *{{ $tUnfolder }}) OnBool(ctx *unfoldCtx, _ bool) error { return u.onValue(ctx) }
+  func (u *{{ $tUnfolder }}) OnString(ctx *unfoldCtx, _ string) error { return u.onValue(ctx) }
+  func (u *{{ $tUnfolder }}) OnInt8(ctx *unfoldCtx, _ int8) error { return u.onValue(ctx) }
+  func (u *{{ $tUnfolder }}) OnInt16(ctx *unfoldCtx, _ int16) error { return u.onValue(ctx) }
+  func (u *{{ $tUnfolder }}) OnInt32(ctx *unfoldCtx, _ int32) error { return u.onValue(ctx) }
+  func (u *{{ $tUnfolder }}) OnInt64(ctx *unfoldCtx, _ int64) error { return u.onValue(ctx) }
+  func (u *{{ $tUnfolder }}) OnInt(ctx *unfoldCtx, _ int) error { return u.onValue(ctx) }
+  func (u *{{ $tUnfolder }}) OnByte(ctx *unfoldCtx, _ byte) error { return u.onValue(ctx) }
+  func (u *{{ $tUnfolder }}) OnUint8(ctx *unfoldCtx, _ uint8) error { return u.onValue(ctx) }
+  func (u *{{ $tUnfolder }}) OnUint16(ctx *unfoldCtx, _ uint16) error { return u.onValue(ctx) }
+  func (u *{{ $tUnfolder }}) OnUint32(ctx *unfoldCtx, _ uint32) error { return u.onValue(ctx) }
+  func (u *{{ $tUnfolder }}) OnUint64(ctx *unfoldCtx, _ uint64) error { return u.onValue(ctx) }
+  func (u *{{ $tUnfolder }}) OnUint(ctx *unfoldCtx, _ uint) error { return u.onValue(ctx) }
+  func (u *{{ $tUnfolder }}) OnFloat32(ctx *unfoldCtx, _ float32) error { return u.onValue(ctx) }
+  func (u *{{ $tUnfolder }}) OnFloat64(ctx *unfoldCtx, _ float64) error { return u.onValue(ctx) }
+
+  func (u *{{ $tUnfolder }}) OnArrayStart(ctx *unfoldCtx, _ int, _ structform.BaseType) error {
+    _singletonUnfoldIgnoreArrPtr.initState(ctx, nil)
+    return nil
+  }
+
+  func (u *{{ $tUnfolder }}) OnChildArrayDone(ctx *unfoldCtx) error {
+    return u.onValue(ctx)
+  }
+
+  func (u *{{ $tUnfolder }}) OnObjectStart(ctx *unfoldCtx, _ int, _ structform.BaseType) error {
+    _singletonUnfoldIgnoreObjPtr.initState(ctx, nil)
+    return nil
+  }
+
+  func (u *{{ $tUnfolder }}) OnChildObjectDone(ctx *unfoldCtx) error {
+    return u.onValue(ctx)
+  }

--- a/vendor/github.com/urso/go-structform/gotype/unfold_lookup_go.yml
+++ b/vendor/github.com/urso/go-structform/gotype/unfold_lookup_go.yml
@@ -1,0 +1,145 @@
+import:
+  - unfold_templates.yml
+
+main: |
+  package gotype
+
+  func lookupGoTypeUnfolder(to interface{}) (unsafe.Pointer, ptrUnfolder) {
+    switch ptr := to.(type) {
+      case *interface{}:
+        return unsafe.Pointer(ptr), newUnfolderIfc()
+      case *[]interface{}:
+        return unsafe.Pointer(ptr), newUnfolderArrIfc()
+      case *map[string]interface{}:
+        return unsafe.Pointer(ptr), newUnfolderMapIfc()
+
+      {{ range data.primitiveTypes }}
+      case *{{ . }}:
+        return unsafe.Pointer(ptr), newUnfolder{{ . | capitalize }}()
+      case *[]{{ . }}:
+        return unsafe.Pointer(ptr), newUnfolderArr{{ . | capitalize }}()
+      case *map[string]{{ . }}:
+        return unsafe.Pointer(ptr), newUnfolderMap{{ . | capitalize }}()
+      {{ end }}
+    default:
+      return nil, nil
+    }
+  }
+
+  func lookupGoPtrUnfolder(t reflect.Type) (ptrUnfolder) {
+    switch t.Kind() {
+    case reflect.Interface:
+      return newUnfolderIfc()
+    {{ range data.primitiveTypes }}
+      case reflect.{{ . | capitalize }}:
+        return newUnfolder{{ . | capitalize }}()
+    {{ end }}
+
+    case reflect.Slice:
+      et := t.Elem()
+      switch et.Kind() {
+      case reflect.Interface:
+        return newUnfolderArrIfc()
+      {{ range data.primitiveTypes }}
+        case reflect.{{ . | capitalize }}:
+          return newUnfolderArr{{ . | capitalize }}()
+      {{ end }}
+      }
+
+    case reflect.Map:
+      if t.Key().Kind() != reflect.String {
+        return nil
+      }
+
+      et := t.Elem()
+      switch et.Kind() {
+      case reflect.Interface:
+        return newUnfolderMapIfc()
+      {{ range data.primitiveTypes }}
+        case reflect.{{ . | capitalize }}:
+          return newUnfolderMap{{ . | capitalize }}()
+      {{ end }}
+      }
+
+    }
+
+    return nil
+  }
+
+  func lookupReflUnfolder(ctx *unfoldCtx, t reflect.Type) (reflUnfolder, error) {
+    if f := unfoldRegistry.find(t); f != nil {
+      return f, nil
+    }
+
+    f, err := buildReflUnfolder(ctx, t)
+    if err != nil {
+      return nil, err
+    }
+
+    unfoldRegistry.set(t, f)
+    return f, nil
+  }
+
+  func buildReflUnfolder(ctx *unfoldCtx, t reflect.Type) (reflUnfolder, error) {
+    // we always expect a pointer
+    bt := t.Elem()
+
+    switch bt.Kind() {
+    case reflect.Interface:
+      return unfolderReflIfc, nil
+    {{ range data.primitiveTypes }}
+    case reflect.{{ . | capitalize }}:
+      return unfolderRefl{{ . | capitalize }}, nil
+    {{ end }}
+
+    case reflect.Array:
+      return nil, errTODO()
+
+    case reflect.Ptr:
+      unfolderElem, err := lookupReflUnfolder(ctx, bt)
+      if err != nil {
+        return nil, err
+      }
+      return newUnfolderReflPtr(unfolderElem), nil
+
+    case reflect.Slice:
+      et := bt.Elem()
+      switch et.Kind() {
+      case reflect.Interface:
+        return unfolderReflArrIfc, nil
+      {{ range data.primitiveTypes }}
+      case reflect.{{ . | capitalize }}:
+        return unfolderReflArr{{ . | capitalize }}, nil
+      {{ end }}
+      }
+
+      unfolderElem, err := lookupReflUnfolder(ctx, reflect.PtrTo(et))
+      if err != nil {
+        return nil, err
+      }
+      return newUnfolderReflSlice(unfolderElem), nil
+
+    case reflect.Map:
+      et := bt.Elem()
+      switch et.Kind() {
+      case reflect.Interface:
+        return unfolderReflMapIfc, nil
+      {{ range data.primitiveTypes }}
+      case reflect.{{ . | capitalize }}:
+        return unfolderReflMap{{ . | capitalize }}, nil
+      {{ end }}
+      }
+
+      unfolderElem, err := lookupReflUnfolder(ctx, reflect.PtrTo(et))
+      if err != nil {
+        return nil, err
+      }
+      return newUnfolderReflMap(unfolderElem), nil
+
+    case reflect.Struct:
+      return createUnfolderReflStruct(ctx, t)
+
+     default:
+       return nil, errTODO()
+    }
+  }

--- a/vendor/github.com/urso/go-structform/gotype/unfold_map.yml
+++ b/vendor/github.com/urso/go-structform/gotype/unfold_map.yml
@@ -1,0 +1,145 @@
+import:
+  - unfold_templates.yml
+
+main: |
+  package gotype
+
+  import "github.com/urso/go-structform"
+
+  {{/* defined 'lifted' pointer map unfolders into reflection based unfolders */}}
+  var (
+    unfolderReflMapIfc = liftGoUnfolder(newUnfolderMapIfc())
+    {{ range data.primitiveTypes }}
+    {{ $t := capitalize . }}
+      unfolderReflMap{{ $t }} = liftGoUnfolder(newUnfolderMap{{ $t }}())
+    {{ end }}
+  )
+
+  {{/* define pointer based unfolder types */}}
+  {{ invoke "makeTypeWithName" "name" "Ifc" "type" "interface{}" }}
+  {{ template "makeType" "bool" }}
+  {{ template "makeType" "string" }}
+  {{ range .numTypes }}
+    {{ template "makeType" . }}
+  {{ end }}
+
+  {{/* create value visitor callbacks */}}
+  {{ invoke "onIfcFns" "name" "unfolderMapIfc" "fn" "put" }}
+  {{ invoke "onBoolFns" "name" "unfolderMapBool" "fn" "put" }}
+  {{ invoke "onStringFns" "name" "unfolderMapString" "fn" "put" }}
+  {{ range .numTypes }}
+    {{ $type := . }}
+    {{ $name := capitalize $type | printf "unfolderMap%v" }}
+    {{ invoke "onNumberFns" "name" $name "type" $type "fn" "put" }}
+  {{ end }}
+
+  {{ template "mapIfc" }}
+
+
+# makeTypeWithName(name, type)
+templates.makeTypeWithName: |
+  {{ $type := .type }}
+  {{ $name := capitalize .name | printf "unfolderMap%v" }}
+  {{ $startName := capitalize .name | printf "unfoldMapStart%v" }}
+  {{ $keyName := capitalize .name | printf "unfoldMapKey%v" }}
+
+  {{ invoke "makeUnfoldType" "name" $name }}
+  {{ invoke "makeUnfoldType" "name" $startName "base" "unfolderErrObjectStart" }}
+  {{ invoke "makeUnfoldType" "name" $keyName "base" "unfolderErrExpectKey" }}
+
+  func (u *{{ $name }} ) initState(ctx *unfoldCtx, ptr unsafe.Pointer) {
+    ctx.unfolder.push(new{{ $keyName | capitalize}}())
+    ctx.unfolder.push(new{{ $startName | capitalize}}())
+    ctx.ptr.push(ptr)
+  }
+
+  func (u * {{ $keyName }} ) cleanup(ctx *unfoldCtx) {
+    ctx.unfolder.pop()
+    ctx.ptr.pop()
+  }
+
+  func (u * {{ $startName }}) cleanup(ctx *unfoldCtx) {
+    ctx.unfolder.pop()
+  }
+
+
+  func (u *{{ $name }} ) ptr(ctx *unfoldCtx) *map[string]{{ $type }} {
+    return (*map[string]{{ $type }})(ctx.ptr.current)
+  }
+
+
+  func (u *{{ $startName }} ) OnObjectStart(ctx *unfoldCtx, l int, baseType structform.BaseType) error {
+    // TODO: validate baseType
+
+    u.cleanup(ctx)
+    return nil
+  }
+
+  func (u *{{ $keyName }} ) OnKeyRef(ctx *unfoldCtx, key []byte) error {
+    return u.OnKey(ctx, ctx.keyCache.get(key))
+  }
+
+  func (u *{{ $keyName }} ) OnKey(ctx *unfoldCtx, key string) error {
+    ctx.key.push(key)
+    ctx.unfolder.current = new{{ $name | capitalize }}()
+    return nil
+  }
+
+  func (u *{{ $keyName }} ) OnObjectFinished(ctx *unfoldCtx) error {
+    u.cleanup(ctx)
+    return nil
+  }
+
+  func (u *{{ $name }} ) put(ctx *unfoldCtx, v {{ $type }}) error {
+    to := u.ptr(ctx)
+    if *to == nil {
+      *to = map[string]{{ $type }}{}
+    }
+    (*to)[ctx.key.pop()] = v
+
+    ctx.unfolder.current = new{{ $keyName | capitalize }}()
+    return nil
+  }
+
+templates.mapIfc: |
+  func unfoldIfcStartSubMap(ctx *unfoldCtx, l int, baseType structform.BaseType) error {
+    _, ptr, unfolder := makeMapPtr(ctx, l, baseType)
+    ctx.ptr.push(ptr)
+    ctx.baseType.push(baseType)
+    unfolder.initState(ctx, ptr)
+    return ctx.unfolder.current.OnObjectStart(ctx, l, baseType)
+  }
+
+  func unfoldIfcFinishSubMap(ctx *unfoldCtx) (interface{}, error) {
+    child := ctx.ptr.pop()
+    bt := ctx.baseType.pop()
+    switch bt {
+    {{ range $bt, $gt := data.mapTypes }}
+    case structform.{{ $bt }}:
+      ctx.buf.release()
+      return *(*map[string]{{ $gt }})(child), nil
+    {{ end }}
+    default:
+      return nil, errTODO()
+    }
+  }
+
+  func makeMapPtr(ctx *unfoldCtx, l int, bt structform.BaseType) (interface{}, unsafe.Pointer, ptrUnfolder) {
+    switch bt {
+    {{ range $bt, $gt := data.mapTypes }}
+    case structform.{{ $bt }}:
+      sz := unsafe.Sizeof(map[string]{{ $gt }}{})
+      ptr := ctx.buf.alloc(int(sz))
+      to := (*map[string]{{ $gt }})(ptr)
+      {{ if or (eq $bt "AnyType")  (eq $bt "ZeroType") }}
+        unfolder := newUnfolderMapIfc()
+      {{ else }}
+        unfolder := newUnfolderMap{{ $gt | capitalize }}()
+      {{ end }}
+      return to, ptr, unfolder
+    {{ end }}
+    default:
+      panic("invalid type code")
+      return nil, nil, nil
+    }
+  }

--- a/vendor/github.com/urso/go-structform/gotype/unfold_primitive.yml
+++ b/vendor/github.com/urso/go-structform/gotype/unfold_primitive.yml
@@ -1,0 +1,72 @@
+import:
+  - unfold_templates.yml
+
+main: |
+  package gotype
+
+  var (
+  {{/* defined 'lifted' pointer primitive unfolders into reflection based unfolders */}}
+    unfolderReflIfc = liftGoUnfolder(newUnfolderIfc())
+    {{ range data.primitiveTypes }}
+    {{ $t := capitalize . }}
+      unfolderRefl{{ $t }} = liftGoUnfolder(newUnfolder{{ $t }}())
+    {{ end }}
+  )
+
+  {{/* define pointer based unfolder types */}}
+  {{ invoke "makeTypeWithName" "name" "ifc" "type" "interface{}" }}
+  {{ template "makeType" "bool" }}
+  {{ template "makeType" "string" }}
+  {{ range .numTypes }} 
+    {{ template "makeType" . }}
+  {{ end }}
+
+  {{/* create value visitor callbacks */}}
+  {{ invoke "onIfcFns" "name" "unfolderIfc" "fn" "assign" }}
+  {{ invoke "onBoolFns" "name" "unfolderBool" "fn" "assign" }}
+  {{ invoke "onStringFns" "name" "unfolderString" "fn" "assign" }}
+  {{ range .numTypes }}
+    {{ $type := . }}
+    {{ $name := capitalize . | printf "unfolder%v" }}
+    {{ invoke "onNumberFns" "name" $name "type" $type "fn" "assign" }}
+  {{ end }}
+
+  /*
+  func (*unfolderIfc) OnArrayStart(ctx *unfoldCtx, l int, bt structform.BaseType) error {
+    return unfoldIfcStartSubArray(ctx, l, bt)
+  }
+
+  func (u *unfolderIfc) OnChildArrayDone(ctx *unfoldCtx) error {
+    v, err := unfoldIfcFinishSubArray(ctx)
+    if err == nil {
+      err = u.assign(ctx, v)
+    }
+    return err
+  }
+  */
+
+# makeTypeWithName(name, type, [base])
+templates.makeTypeWithName: |
+  {{ $type := .type }}
+  {{ $name := capitalize .name | printf "unfolder%v" }}
+  {{ invoke "makeUnfoldType" "type" $type "name" $name "base" .base }}
+
+  func (u *{{ $name }} ) initState(ctx *unfoldCtx, ptr unsafe.Pointer) {
+    ctx.unfolder.push(u)
+    ctx.ptr.push(ptr)
+  }
+
+  func (u *{{ $name }} ) cleanup(ctx *unfoldCtx) {
+    ctx.unfolder.pop()
+    ctx.ptr.pop()
+  }
+
+  func (u *{{ $name }} ) ptr(ctx *unfoldCtx) *{{ $type }} {
+    return (*{{ $type }})(ctx.ptr.current)
+  }
+
+  func (u *{{ $name }}) assign(ctx *unfoldCtx, v {{ $type }}) error {
+    *u.ptr(ctx) = v
+    u.cleanup(ctx)
+    return nil
+  }

--- a/vendor/github.com/urso/go-structform/gotype/unfold_refl.yml
+++ b/vendor/github.com/urso/go-structform/gotype/unfold_refl.yml
@@ -1,0 +1,121 @@
+import:
+  - unfold_templates.yml
+
+main: |
+  package gotype
+
+  func (u *unfolderReflSlice) OnNil(ctx *unfoldCtx) error {
+    u.prepare(ctx)
+    return nil
+  }
+
+  {{ invoke "makeReflPrimitives" "type" "unfolderReflSlice" }}
+  {{ invoke "makeReflChildArrays" "type" "unfolderReflSlice" }}
+  {{ invoke "makeReflChildObjects" "type" "unfolderReflSlice" }}
+
+  func (u *unfolderReflMapOnElem) OnNil(ctx *unfoldCtx) error {
+    ptr := ctx.value.current
+    m := ptr.Elem()
+    v := reflect.Zero(m.Type().Elem())
+    m.SetMapIndex(reflect.ValueOf(ctx.key.pop()), v)
+
+    ctx.unfolder.current = u.shared.waitKey
+    return nil
+  }
+
+  {{ invoke "makeReflPrimitives" "type" "unfolderReflMapOnElem" "process" "process" }}
+  {{ invoke "makeReflChildArrays" "type" "unfolderReflMapOnElem" "process" "process" }}
+  {{ invoke "makeReflChildObjects" "type" "unfolderReflMapOnElem" "process" "process" "error" "errExpectedObjectValue" }}
+
+  func (u *unfolderReflPtr) OnNil(ctx *unfoldCtx) error {
+    ptr := ctx.value.current
+    v := ptr.Elem()
+    v.Set(reflect.Zero(v.Type()))
+    u.cleanup(ctx)
+    return nil
+  }
+
+  {{ invoke "makeReflPrimitives" "type" "unfolderReflPtr" "process" "process" }}
+  {{ invoke "makeReflChildArrays" "type" "unfolderReflPtr" "process" "process" }}
+  {{ invoke "makeReflChildObjects" "type" "unfolderReflPtr" "process" "process" }}
+
+# makeReflPrimitiveCallbacks(type, [process])
+templates.makeReflPrimitives: |
+  {{ $type := .type}}
+  {{ $process := .process }}
+
+  func (u *{{ $type }}) OnByte(ctx *unfoldCtx, v byte) error {
+    elem := u.prepare(ctx)
+    u.elem.initState(ctx, elem)
+    err := ctx.unfolder.current.OnByte(ctx, v)
+    {{ if $process }}
+    if err == nil {
+      u.{{ $process }}(ctx)
+    }
+    {{ end }}
+    return err
+  }
+
+  func (u *{{ $type }}) OnStringRef(ctx *unfoldCtx, v []byte) error {
+    return u.OnString(ctx, string(v))
+  }
+
+  {{ range data.primitiveTypes }}
+    func (u *{{ $type }}) On{{ . | capitalize}}(ctx *unfoldCtx, v {{ . }}) error {
+      elem := u.prepare(ctx)
+      u.elem.initState(ctx, elem)
+      err := ctx.unfolder.current.On{{ . | capitalize }}(ctx, v)
+      {{ if $process }}
+      if err == nil {
+        u.{{ $process }}(ctx)
+      }
+      {{ end }}
+      return err
+    }
+  {{ end }}
+
+# makeReflChildArrays(type, [process])
+templates.makeReflChildArrays: |
+  {{ $type := .type}}
+  {{ $process := .process }}
+
+  func (u *{{ $type }}) OnArrayStart(ctx *unfoldCtx, l int, bt structform.BaseType) error {
+    elem := u.prepare(ctx)
+    u.elem.initState(ctx, elem)
+    return ctx.unfolder.current.OnArrayStart(ctx, l, bt)
+  }
+
+  func (u *{{ $type }}) OnChildArrayDone(ctx *unfoldCtx) error {
+    {{ if $process }}
+      u.{{ $process }}(ctx)
+    {{ end }}
+    return nil
+  }
+
+# makeReflChildObjects(type, [process], [error])
+templates.makeReflChildObjects: |
+  {{ $type := .type}}
+  {{ $process := .process }}
+  {{ $error := default "errUnsupported" .error }}
+
+  func (u *{{ $type }}) OnObjectStart(ctx *unfoldCtx, l int, bt structform.BaseType) error {
+    elem := u.prepare(ctx)
+    u.elem.initState(ctx, elem)
+    return ctx.unfolder.current.OnObjectStart(ctx, l, bt)
+  }
+
+  func (u *{{ $type }}) OnKey(_ *unfoldCtx, _ string) error {
+    return {{ $error }}
+  }
+
+  func (u *{{ $type }}) OnKeyRef(_ *unfoldCtx, _ []byte) error {
+    return {{ $error }}
+  }
+
+  func (u *{{ $type }}) OnChildObjectDone(ctx *unfoldCtx) error {
+    {{ if $process }}
+      u.{{ $process }}(ctx)
+    {{ end }}
+    return nil
+  }
+  

--- a/vendor/github.com/urso/go-structform/gotype/unfold_struct.go
+++ b/vendor/github.com/urso/go-structform/gotype/unfold_struct.go
@@ -116,7 +116,7 @@ func makeFieldUnfolder(ctx *unfoldCtx, st reflect.StructField) (fieldUnfolder, e
 		if su, ok := ru.(*unfolderStruct); ok {
 			fu.initState = su.initStatePtr
 		} else {
-			fu.initState = wrapReflUnfolder(targetType, ru)
+			fu.initState = wrapReflUnfolder(st.Type, ru)
 		}
 	}
 
@@ -125,7 +125,7 @@ func makeFieldUnfolder(ctx *unfoldCtx, st reflect.StructField) (fieldUnfolder, e
 
 func wrapReflUnfolder(t reflect.Type, ru reflUnfolder) func(*unfoldCtx, unsafe.Pointer) {
 	return func(ctx *unfoldCtx, ptr unsafe.Pointer) {
-		v := reflect.NewAt(reflect.PtrTo(t), ptr)
+		v := reflect.NewAt(t, ptr)
 		ru.initState(ctx, v)
 	}
 }

--- a/vendor/github.com/urso/go-structform/gotype/unfold_templates.yml
+++ b/vendor/github.com/urso/go-structform/gotype/unfold_templates.yml
@@ -1,0 +1,102 @@
+import:
+  - "types.yml"
+
+# makeUnfoldType(name, [.base])
+templates.makeUnfoldType: |
+  {{ $name := .name }}
+  {{ $base := default "unfolderErrUnknown" .base }}
+
+  type {{ $name }} struct {
+    {{ $base }}
+  }
+
+  var _singleton{{ $name | capitalize }} = &{{ $name }}{}
+
+  func new{{ $name | capitalize }}() *{{ $name }} {
+    return _singleton{{ $name | capitalize }}
+  }
+
+# makeType(.)  -> invokes makeTypeWithName(name, type)
+templates.makeType: |
+  {{ invoke "makeTypeWithName" "name" (capitalize .) "type" . }}
+
+# makeBoolFns(name, fn)
+templates.onBoolFns: |
+  {{ invoke "onNil" "name" .name "fn" .fn "default" "false" }}
+  {{ invoke "onBool" "name" .name "fn" .fn }}
+
+# makeStringFns(name, fn)
+templates.onStringFns: |
+  {{ invoke "onNil" "name" .name "fn" .fn "default" "\"\"" }}
+  {{ invoke "onString" "name" .name "fn" .fn }}
+
+# makeNumberFns(name, fn)
+templates.onNumberFns: |
+  {{ invoke "onNil" "name" .name "fn" .fn "default" "0" }}
+  {{ invoke "onNumber" "name" .name "type" .type "fn" .fn }}
+
+# onIfcFns(name, fn)
+templates.onIfcFns: |
+  {{ invoke "onNil" "name" .name "fn" .fn "default" "nil" }}
+  {{ invoke "onBool" "name" .name "fn" .fn }}
+  {{ invoke "onString" "name" .name "fn" .fn }}
+  {{ invoke "onNumber" "name" .name "type" "(interface{})" "fn" .fn }}
+
+  func (*{{ .name }} ) OnArrayStart(ctx *unfoldCtx, l int, bt structform.BaseType) error {
+    return unfoldIfcStartSubArray(ctx, l, bt)
+  }
+
+  func (u *{{ .name }}) OnChildArrayDone(ctx *unfoldCtx) error {
+    v, err := unfoldIfcFinishSubArray(ctx)
+    if err == nil {
+      err = u.{{ .fn }}(ctx, v)
+    }
+    return err
+  }
+
+  func (*{{ .name }}) OnObjectStart(ctx *unfoldCtx, l int, bt structform.BaseType) error {
+    return unfoldIfcStartSubMap(ctx, l, bt)
+  }
+
+  func (u *{{ .name }}) OnChildObjectDone(ctx *unfoldCtx) error {
+    v, err := unfoldIfcFinishSubMap(ctx)
+    if err == nil {
+      err = u.{{ .fn }}(ctx, v)
+    }
+    return err
+  }
+
+
+# onBool(name, fn)
+templates.onBool: |
+  func (u *{{ .name }}) OnBool(ctx *unfoldCtx, v bool) error { return u.{{ .fn }} (ctx, v) }
+
+# onString(name, fn)
+templates.onString: |
+  func (u *{{ .name }}) OnString(ctx *unfoldCtx, v string) error { return u.{{ .fn }} (ctx, v) }
+  func (u *{{ .name }}) OnStringRef(ctx *unfoldCtx, v []byte) error {
+    return u.OnString(ctx, string(v))
+  }
+
+
+# onNil(name, fn, default)
+templates.onNil: |
+  func (u *{{ .name }}) OnNil(ctx *unfoldCtx) error {
+    return u.{{ .fn }}(ctx, {{ .default }})
+  }
+
+
+# onNumber(name, fn, type)
+templates.onNumber: |
+  {{ $name := .name }}
+  {{ $fn := .fn }}
+  {{ $type := .type }}
+
+  func (u *{{ $name }}) OnByte(ctx *unfoldCtx, v byte) error {
+    return u.{{ $fn }}(ctx, {{ $type }}(v))
+  }
+  {{ range $t := data.numTypes }}
+    func (u *{{ $name }}) On{{ $t | capitalize}}(ctx *unfoldCtx, v {{ $t }}) error {
+      return u.{{ $fn }}(ctx, {{ $type }}(v))
+    }
+  {{ end }}

--- a/vendor/github.com/urso/go-structform/visitors/expect_obj.go
+++ b/vendor/github.com/urso/go-structform/visitors/expect_obj.go
@@ -1,0 +1,195 @@
+package visitors
+
+import (
+	"errors"
+
+	structform "github.com/urso/go-structform"
+)
+
+type ExpectObjVisitor struct {
+	active structform.ExtVisitor
+	depth  int
+}
+
+func NewExpectObjVisitor(target structform.ExtVisitor) *ExpectObjVisitor {
+	return &ExpectObjVisitor{active: target}
+}
+
+func (e *ExpectObjVisitor) SetActive(a structform.ExtVisitor) {
+	e.active = a
+	e.depth = 0
+}
+
+func (e *ExpectObjVisitor) Done() bool {
+	return e.depth == 0
+}
+
+func (v *ExpectObjVisitor) OnObjectStart(len int, baseType structform.BaseType) error {
+	v.depth++
+	if v.depth == 1 {
+		return nil
+	}
+	return v.active.OnObjectStart(len, baseType)
+}
+
+func (v *ExpectObjVisitor) OnObjectFinished() error {
+	v.depth--
+	if v.depth == 0 {
+		return nil
+	}
+	return v.active.OnObjectFinished()
+}
+
+func (v *ExpectObjVisitor) OnKey(s string) error {
+	if err := v.check(); err != nil {
+		return err
+	}
+	return v.active.OnKey(s)
+}
+
+func (v *ExpectObjVisitor) OnArrayStart(len int, baseType structform.BaseType) error {
+	if err := v.check(); err != nil {
+		return err
+	}
+	return v.active.OnArrayStart(len, baseType)
+}
+
+func (v *ExpectObjVisitor) OnArrayFinished() error {
+	if err := v.check(); err != nil {
+		return err
+	}
+	return v.active.OnArrayFinished()
+}
+
+func (v *ExpectObjVisitor) OnNil() error {
+	if err := v.check(); err != nil {
+		return err
+	}
+	return v.active.OnNil()
+}
+
+func (v *ExpectObjVisitor) OnBool(b bool) error {
+	if err := v.check(); err != nil {
+		return err
+	}
+	return v.active.OnBool(b)
+}
+
+func (v *ExpectObjVisitor) OnString(s string) error {
+	if err := v.check(); err != nil {
+		return err
+	}
+	return v.active.OnString(s)
+}
+
+func (v *ExpectObjVisitor) OnInt8(i int8) error {
+	if err := v.check(); err != nil {
+		return err
+	}
+	return v.active.OnInt8(i)
+}
+
+func (v *ExpectObjVisitor) OnInt16(i int16) error {
+	if err := v.check(); err != nil {
+		return err
+	}
+	return v.active.OnInt16(i)
+}
+
+func (v *ExpectObjVisitor) OnInt32(i int32) error {
+	if err := v.check(); err != nil {
+		return err
+	}
+	return v.active.OnInt32(i)
+}
+
+func (v *ExpectObjVisitor) OnInt64(i int64) error {
+	if err := v.check(); err != nil {
+		return err
+	}
+	return v.active.OnInt64(i)
+}
+
+func (v *ExpectObjVisitor) OnInt(i int) error {
+	if err := v.check(); err != nil {
+		return err
+	}
+	return v.active.OnInt(i)
+}
+
+func (v *ExpectObjVisitor) OnByte(b byte) error {
+	if err := v.check(); err != nil {
+		return err
+	}
+	return v.active.OnByte(b)
+}
+
+func (v *ExpectObjVisitor) OnUint8(u uint8) error {
+	if err := v.check(); err != nil {
+		return err
+	}
+	return v.active.OnUint8(u)
+}
+
+func (v *ExpectObjVisitor) OnUint16(u uint16) error {
+	if err := v.check(); err != nil {
+		return err
+	}
+	return v.active.OnUint16(u)
+}
+
+func (v *ExpectObjVisitor) OnUint32(u uint32) error {
+	if err := v.check(); err != nil {
+		return err
+	}
+	return v.active.OnUint32(u)
+}
+
+func (v *ExpectObjVisitor) OnUint64(u uint64) error {
+	if err := v.check(); err != nil {
+		return err
+	}
+	return v.active.OnUint64(u)
+}
+
+func (v *ExpectObjVisitor) OnUint(u uint) error {
+	if err := v.check(); err != nil {
+		return err
+	}
+	return v.active.OnUint(u)
+}
+
+func (v *ExpectObjVisitor) OnFloat32(f float32) error {
+	if err := v.check(); err != nil {
+		return err
+	}
+	return v.active.OnFloat32(f)
+}
+
+func (v *ExpectObjVisitor) OnFloat64(f float64) error {
+	if err := v.check(); err != nil {
+		return err
+	}
+	return v.active.OnFloat64(f)
+}
+
+func (v *ExpectObjVisitor) OnStringRef(s []byte) error {
+	if err := v.check(); err != nil {
+		return err
+	}
+	return v.active.OnStringRef(s)
+}
+
+func (v *ExpectObjVisitor) OnKeyRef(s []byte) error {
+	if err := v.check(); err != nil {
+		return err
+	}
+	return v.active.OnKeyRef(s)
+}
+
+func (v *ExpectObjVisitor) check() error {
+	if v.depth == 0 {
+		return errors.New("inline object is no object")
+	}
+	return nil
+}

--- a/vendor/github.com/urso/go-structform/visitors/stringer.go
+++ b/vendor/github.com/urso/go-structform/visitors/stringer.go
@@ -1,0 +1,111 @@
+package visitors
+
+import (
+	"fmt"
+
+	structform "github.com/urso/go-structform"
+)
+
+type StringConvVisitor struct {
+	active structform.ExtVisitor
+}
+
+func NewStringConvVisitor(target structform.ExtVisitor) *StringConvVisitor {
+	return &StringConvVisitor{target}
+}
+
+func (v *StringConvVisitor) SetActive(a structform.ExtVisitor) {
+	v.active = a
+}
+
+func (v *StringConvVisitor) OnObjectStart(l int, t structform.BaseType) error {
+	return v.active.OnObjectStart(l, t)
+}
+
+func (v *StringConvVisitor) OnObjectFinished() error {
+	return v.active.OnObjectFinished()
+}
+
+func (v *StringConvVisitor) OnKey(s string) error {
+	return v.active.OnKey(s)
+}
+
+func (v *StringConvVisitor) OnKeyRef(s []byte) error {
+	return v.active.OnKeyRef(s)
+}
+
+func (v *StringConvVisitor) OnArrayStart(l int, t structform.BaseType) error {
+	return v.active.OnArrayStart(l, t)
+}
+
+func (v *StringConvVisitor) OnArrayFinished() error {
+	return v.active.OnArrayFinished()
+}
+
+func (v *StringConvVisitor) OnNil() error {
+	return v.OnString("")
+}
+
+func (v *StringConvVisitor) OnBool(b bool) error {
+	t := "false"
+	if b {
+		t = "true"
+	}
+	return v.OnString(t)
+}
+
+func (v *StringConvVisitor) OnString(s string) error {
+	return v.active.OnString(s)
+}
+
+func (v *StringConvVisitor) OnStringRef(b []byte) error {
+	return v.active.OnStringRef(b)
+}
+
+func (v *StringConvVisitor) OnInt8(i int8) error {
+	return v.OnInt64(int64(i))
+}
+
+func (v *StringConvVisitor) OnInt16(i int16) error {
+	return v.OnInt64(int64(i))
+}
+
+func (v *StringConvVisitor) OnInt32(i int32) error {
+	return v.OnInt64(int64(i))
+}
+
+func (v *StringConvVisitor) OnInt64(i int64) error {
+	return v.OnString(fmt.Sprintf("%v", i))
+}
+
+func (v *StringConvVisitor) OnInt(i int) error {
+	return v.OnInt64(int64(i))
+}
+
+func (v *StringConvVisitor) OnUint8(i uint8) error {
+	return v.OnUint64(uint64(i))
+}
+
+func (v *StringConvVisitor) OnUint16(i uint16) error {
+	return v.OnUint64(uint64(i))
+}
+
+func (v *StringConvVisitor) OnUint32(i uint32) error {
+	return v.OnUint64(uint64(i))
+}
+
+func (v *StringConvVisitor) OnUint64(i uint64) error {
+	return v.OnString(fmt.Sprintf("%v", i))
+}
+
+func (v *StringConvVisitor) OnUint(i uint) error {
+	return v.OnUint64(uint64(i))
+}
+
+func (v *StringConvVisitor) OnFloat32(f float32) error {
+	return v.OnString(fmt.Sprintf("%v", f))
+}
+
+func (v *StringConvVisitor) OnFloat64(f float64) error {
+	return v.OnString(fmt.Sprintf("%v", f))
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1001,12 +1001,76 @@
 			"revisionTime": "2016-08-17T18:24:57Z"
 		},
 		{
-			"checksumSHA1": "jvqovQm7I5xa3e6TCAxWh/fLNKs=",
+			"checksumSHA1": "ci7skUhpD1VwkoR0tKVdggTkYrE=",
 			"path": "github.com/urso/go-structform",
-			"revision": "a59a4e97c96431f4ad25ed3bd027981f2e0ff5c2",
-			"revisionTime": "2017-07-17T20:28:29Z",
-			"version": "v0.0.1",
-			"versionExact": "v0.0.1"
+			"revision": "844d7d44009e9e8c0f08016fc4dab64e136ca040",
+			"revisionTime": "2017-12-05T17:32:58Z",
+			"version": "v0.0.2",
+			"versionExact": "v0.0.2"
+		},
+		{
+			"checksumSHA1": "da75fv5z2n4AHmTzUWLBs7pNkog=",
+			"path": "github.com/urso/go-structform/cborl",
+			"revision": "844d7d44009e9e8c0f08016fc4dab64e136ca040",
+			"revisionTime": "2017-12-05T17:32:58Z",
+			"version": "v0.0.2",
+			"versionExact": "v0.0.2"
+		},
+		{
+			"checksumSHA1": "AkYoBxV+Imq2EBwNcb53hEGh7sQ=",
+			"path": "github.com/urso/go-structform/gotype",
+			"revision": "844d7d44009e9e8c0f08016fc4dab64e136ca040",
+			"revisionTime": "2017-12-05T17:32:58Z",
+			"version": "v0.0.2",
+			"versionExact": "v0.0.2"
+		},
+		{
+			"checksumSHA1": "25sJtDsLVmS+aCILjB8zm/JBgPs=",
+			"path": "github.com/urso/go-structform/internal/gen",
+			"revision": "844d7d44009e9e8c0f08016fc4dab64e136ca040",
+			"revisionTime": "2017-12-05T17:32:58Z",
+			"version": "v0.0.2",
+			"versionExact": "v0.0.2"
+		},
+		{
+			"checksumSHA1": "m9H8/w6okS+8ixvkq+eYLd/Kk3g=",
+			"path": "github.com/urso/go-structform/internal/unsafe",
+			"revision": "844d7d44009e9e8c0f08016fc4dab64e136ca040",
+			"revisionTime": "2017-12-05T17:32:58Z",
+			"version": "v0.0.2",
+			"versionExact": "v0.0.2"
+		},
+		{
+			"checksumSHA1": "UXf4TzYK1UB8xAa6Phy9CvkvWL0=",
+			"path": "github.com/urso/go-structform/json",
+			"revision": "844d7d44009e9e8c0f08016fc4dab64e136ca040",
+			"revisionTime": "2017-12-05T17:32:58Z",
+			"version": "v0.0.2",
+			"versionExact": "v0.0.2"
+		},
+		{
+			"checksumSHA1": "SVGAVpMy8NbNCI7GVBLCKuJ7JNQ=",
+			"path": "github.com/urso/go-structform/sftest",
+			"revision": "844d7d44009e9e8c0f08016fc4dab64e136ca040",
+			"revisionTime": "2017-12-05T17:32:58Z",
+			"version": "v0.0.2",
+			"versionExact": "v0.0.2"
+		},
+		{
+			"checksumSHA1": "ttk3rguPusHM0+Pkp5diTbps/18=",
+			"path": "github.com/urso/go-structform/ubjson",
+			"revision": "844d7d44009e9e8c0f08016fc4dab64e136ca040",
+			"revisionTime": "2017-12-05T17:32:58Z",
+			"version": "v0.0.2",
+			"versionExact": "v0.0.2"
+		},
+		{
+			"checksumSHA1": "MytQct/960akBAZm7xmbpi2BKGs=",
+			"path": "github.com/urso/go-structform/visitors",
+			"revision": "844d7d44009e9e8c0f08016fc4dab64e136ca040",
+			"revisionTime": "2017-12-05T17:32:58Z",
+			"version": "v0.0.2",
+			"versionExact": "v0.0.2"
 		},
 		{
 			"checksumSHA1": "Und+nhgN1YsNWvd0aDYO+0cMcAo=",


### PR DESCRIPTION
Update to v0.0.2

### Added
- Add struct tag option ",omitempty".
- Add StringConvVisitor converting all primitive values to strings.
- Move and export object visitor into visitors package

### Fixed
- Fix invalid pointer indirections in struct to array/map.