### PR TITLE
 Elasticsearch bulk request enhancements

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -120,6 +120,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Use structured logging for the metrics that are periodically logged via the
   `logging.metrics` feature. {pull}5915[5915]
 - Add the ability to log to the Windows Event Log. {pull}5913[5813]
+- Improve Elasticsearch output metrics to count number of dropped and duplicate (if event ID is given) events. {pull}5811[5811]
 
 *Auditbeat*
 

--- a/libbeat/beat/event.go
+++ b/libbeat/beat/event.go
@@ -22,6 +22,8 @@ var (
 	errNoTimestamp = errors.New("value is no timestamp")
 )
 
+// SetID overwrites the "id" field in the events metadata.
+// If Meta is nil, a new Meta dictionary is created.
 func (e *Event) SetID(id string) {
 	if e.Meta == nil {
 		e.Meta = common.MapStr{}

--- a/libbeat/beat/event.go
+++ b/libbeat/beat/event.go
@@ -22,6 +22,13 @@ var (
 	errNoTimestamp = errors.New("value is no timestamp")
 )
 
+func (e *Event) SetID(id string) {
+	if e.Meta == nil {
+		e.Meta = common.MapStr{}
+	}
+	e.Meta["id"] = id
+}
+
 func (e *Event) GetValue(key string) (interface{}, error) {
 	if key == "@timestamp" {
 		return e.Timestamp, nil

--- a/libbeat/outputs/elasticsearch/client_test.go
+++ b/libbeat/outputs/elasticsearch/client_test.go
@@ -84,7 +84,7 @@ func TestCollectPublishFailsNone(t *testing.T) {
 	}
 
 	reader := newJSONReader(response)
-	res := bulkCollectPublishFails(reader, events)
+	res, _ := bulkCollectPublishFails(reader, events)
 	assert.Equal(t, 0, len(res))
 }
 
@@ -102,7 +102,7 @@ func TestCollectPublishFailMiddle(t *testing.T) {
 	events := []publisher.Event{event, eventFail, event}
 
 	reader := newJSONReader(response)
-	res := bulkCollectPublishFails(reader, events)
+	res, _ := bulkCollectPublishFails(reader, events)
 	assert.Equal(t, 1, len(res))
 	if len(res) == 1 {
 		assert.Equal(t, eventFail, res[0])
@@ -122,7 +122,7 @@ func TestCollectPublishFailAll(t *testing.T) {
 	events := []publisher.Event{event, event, event}
 
 	reader := newJSONReader(response)
-	res := bulkCollectPublishFails(reader, events)
+	res, _ := bulkCollectPublishFails(reader, events)
 	assert.Equal(t, 3, len(res))
 	assert.Equal(t, events, res)
 }
@@ -163,7 +163,7 @@ func TestCollectPipelinePublishFail(t *testing.T) {
 	events := []publisher.Event{event}
 
 	reader := newJSONReader(response)
-	res := bulkCollectPublishFails(reader, events)
+	res, _ := bulkCollectPublishFails(reader, events)
 	assert.Equal(t, 1, len(res))
 	assert.Equal(t, events, res)
 }
@@ -224,7 +224,7 @@ func BenchmarkCollectPublishFailsNone(b *testing.B) {
 	reader := newJSONReader(nil)
 	for i := 0; i < b.N; i++ {
 		reader.init(response)
-		res := bulkCollectPublishFails(reader, events)
+		res, _ := bulkCollectPublishFails(reader, events)
 		if len(res) != 0 {
 			b.Fail()
 		}
@@ -247,7 +247,7 @@ func BenchmarkCollectPublishFailMiddle(b *testing.B) {
 	reader := newJSONReader(nil)
 	for i := 0; i < b.N; i++ {
 		reader.init(response)
-		res := bulkCollectPublishFails(reader, events)
+		res, _ := bulkCollectPublishFails(reader, events)
 		if len(res) != 1 {
 			b.Fail()
 		}
@@ -269,7 +269,7 @@ func BenchmarkCollectPublishFailAll(b *testing.B) {
 	reader := newJSONReader(nil)
 	for i := 0; i < b.N; i++ {
 		reader.init(response)
-		res := bulkCollectPublishFails(reader, events)
+		res, _ := bulkCollectPublishFails(reader, events)
 		if len(res) != 3 {
 			b.Fail()
 		}

--- a/libbeat/outputs/elasticsearch/client_test.go
+++ b/libbeat/outputs/elasticsearch/client_test.go
@@ -178,7 +178,7 @@ func TestGetIndexStandard(t *testing.T) {
 	indexSel := outil.MakeSelector(outil.FmtSelectorExpr(fmtstr, ""))
 
 	event := &beat.Event{Timestamp: ts, Fields: fields}
-	index := getIndex(event, indexSel)
+	index, _ := getIndex(event, indexSel)
 	assert.Equal(t, index, "beatname-"+extension)
 }
 
@@ -204,7 +204,7 @@ func TestGetIndexOverwrite(t *testing.T) {
 			"index": "dynamicindex",
 		},
 		Fields: fields}
-	index := getIndex(event, indexSel)
+	index, _ := getIndex(event, indexSel)
 	expected := "dynamicindex-" + extension
 	assert.Equal(t, expected, index)
 }

--- a/libbeat/outputs/observer.go
+++ b/libbeat/outputs/observer.go
@@ -7,6 +7,7 @@ type Observer interface {
 	Acked(int)        // report number of acked events
 	Failed(int)       // report number of failed events
 	Dropped(int)      // report number of dropped events
+	Duplicate(int)    // report number of events detected as duplicates (e.g. on resends)
 	Cancelled(int)    // report number of cancelled events
 	WriteError(error) // report an I/O error on write
 	WriteBytes(int)   // report number of bytes being written
@@ -25,6 +26,7 @@ func NewNilObserver() Observer {
 
 func (*emptyObserver) NewBatch(int)     {}
 func (*emptyObserver) Acked(int)        {}
+func (*emptyObserver) Duplicate(int)    {}
 func (*emptyObserver) Failed(int)       {}
 func (*emptyObserver) Dropped(int)      {}
 func (*emptyObserver) Cancelled(int)    {}


### PR DESCRIPTION
Requires: #5810 

- Log error and drop event if no index name can be computed (ES API
  returns error if index is empty)
- Set `_id` if event.Meta["id"] is set
- Use `index` action if no `id` is set and `create` if `id` is set.