### PR TITLE
Remove no_plugins option from tutorial

### DIFF
--- a/filebeat/docs/modules-overview.asciidoc
+++ b/filebeat/docs/modules-overview.asciidoc
@@ -132,17 +132,6 @@ filebeat.modules:
     var.paths: ["/var/log/nginx/access.log*"]
 ----------------------------------------------------------------------
 
-The Nginx `access` fileset also has a `pipeline` variables which allows
-selecting which of the available Ingest Node pipelines is used for parsing. At
-the moment, two such pipelines are available, one that requires the two ingest
-plugins (`ingest-geoip` and `ingest-user-agent`) and one that doesn't. If you
-cannot install the plugins, you can use the following:
-
-
-[source,shell]
-----------------------------------------------------------------------
-./filebeat -e -modules=nginx -M "nginx.access.var.pipeline=no_plugins"
-----------------------------------------------------------------------
 
 ==== Advanced settings
 


### PR DESCRIPTION
This section should have been removed along with https://github.com/elastic/beats/commit/a2ef3ae7b0a31c3fe1beff524082fb9cad55d587.

This PR needs a forwardport into 5.4, 5.5, and 5.6. 