### PR TITLE
Cherry-pick #5815 to 6.0: Fix Winlogbeat registry file

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -51,6 +51,9 @@ https://github.com/elastic/beats/compare/v6.0.0...master[Check the HEAD diff]
 
 *Winlogbeat*
 
+- Fix the registry file. It was not correctly storing event log names, and
+  upon restart it would begin reading at the start of each event log. {issue}5813[5813]
+
 ==== Added
 
 *Affecting all Beats*

--- a/winlogbeat/eventlog/eventlog.go
+++ b/winlogbeat/eventlog/eventlog.go
@@ -113,7 +113,7 @@ func (e Record) ToEvent() beat.Event {
 		Timestamp: e.TimeCreated.SystemTime,
 		Fields:    m,
 		Private: checkpoint.EventLogState{
-			Name:         e.API,
+			Name:         e.Channel,
 			RecordNumber: e.RecordID,
 			Timestamp:    e.TimeCreated.SystemTime,
 		},

--- a/winlogbeat/tests/system/test_eventlogging.py
+++ b/winlogbeat/tests/system/test_eventlogging.py
@@ -169,3 +169,17 @@ class Test(WriteReadTest):
         })
         self.assertTrue(len(evts), 1)
         self.assertEqual(evts[0]["message"], msg)
+
+    def test_registry_data(self):
+        """
+        eventlogging - Registry is updated
+        """
+        self.write_event_log("Hello world!")
+        evts = self.read_events()
+        self.assertTrue(len(evts), 1)
+
+        event_logs = self.read_registry()
+        self.assertTrue(len(event_logs.keys()), 1)
+        self.assertIn(self.providerName, event_logs)
+        record_number = event_logs[self.providerName]["record_number"]
+        self.assertGreater(record_number, 0)

--- a/winlogbeat/tests/system/test_wineventlog.py
+++ b/winlogbeat/tests/system/test_wineventlog.py
@@ -307,3 +307,17 @@ class Test(WriteReadTest):
         })
         self.assertTrue(len(evts), 1)
         self.assertEqual(evts[0]["message"], msg)
+
+    def test_registry_data(self):
+        """
+        wineventlog - Registry is updated
+        """
+        self.write_event_log("Hello world!")
+        evts = self.read_events()
+        self.assertTrue(len(evts), 1)
+
+        event_logs = self.read_registry()
+        self.assertTrue(len(event_logs.keys()), 1)
+        self.assertIn(self.providerName, event_logs)
+        record_number = event_logs[self.providerName]["record_number"]
+        self.assertGreater(record_number, 0)

--- a/winlogbeat/tests/system/winlogbeat.py
+++ b/winlogbeat/tests/system/winlogbeat.py
@@ -1,6 +1,7 @@
 import os
 import platform
 import sys
+import yaml
 
 if sys.platform.startswith("win"):
     import win32api
@@ -94,6 +95,22 @@ class WriteReadTest(BaseTest):
         proc.check_kill_and_wait()
 
         return self.read_output()
+
+    def read_registry(self):
+        f = open(os.path.join(self.working_dir, "data", ".winlogbeat.yml"), "r")
+        data = yaml.load(f)
+        self.assertIn("update_time", data)
+        self.assertIn("event_logs", data)
+
+        event_logs = {}
+        for event_log in data["event_logs"]:
+            self.assertIn("name", event_log)
+            self.assertIn("record_number", event_log)
+            self.assertIn("timestamp", event_log)
+            name = event_log["name"]
+            event_logs[name] = event_log
+
+        return event_logs
 
     def assert_common_fields(self, evt, msg=None, eventID=10, sid=None,
                              level="Information", extra=None):


### PR DESCRIPTION
Cherry-pick of PR #5815 to 6.0 branch. Original message: 

The registry file did not contain the event log name, and therefore resumption after restart did not work at all and Winlogbeat would start from the beginning. This fixes that issue.

Fixes #5813