### PR TITLE
Make WatcherDie tests less flaky

### DIFF
--- a/libbeat/common/docker/watcher_test.go
+++ b/libbeat/common/docker/watcher_test.go
@@ -216,8 +216,16 @@ func TestWatcherDie(t *testing.T) {
 		time.Sleep(50 * time.Millisecond)
 	}
 
-	// Now it should get removed
-	time.Sleep(300 * time.Millisecond)
+	// Checks a max of 10s for the watcher containers to be updated
+	for i := 0; i < 100; i++ {
+		// Now it should get removed
+		time.Sleep(100 * time.Millisecond)
+
+		if len(watcher.Containers()) == 0 {
+			break
+		}
+	}
+
 	assert.Equal(t, 0, len(watcher.Containers()))
 }
 


### PR DESCRIPTION
Now the test checks up to 10s if the containers were actually updated.