### PR TITLE
Show separate commands for deb/rpm and mac

### DIFF
--- a/auditbeat/docs/index.asciidoc
+++ b/auditbeat/docs/index.asciidoc
@@ -4,20 +4,12 @@ include::../../libbeat/docs/version.asciidoc[]
 
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
-:libbeat: http://www.elastic.co/guide/en/beats/libbeat/{doc-branch}
-:kibana-ref: https://www.elastic.co/guide/en/kibana/{doc-branch}
-:beatsdevguide: http://www.elastic.co/guide/en/beats/devguide/{doc-branch}
-:filebeat: http://www.elastic.co/guide/en/beats/filebeat/{doc-branch}
-:logstashdoc: https://www.elastic.co/guide/en/logstash/{doc-branch}
-:elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/{doc-branch}
-:securitydoc: https://www.elastic.co/guide/en/x-pack/{doc-branch}
-:monitoringdoc: https://www.elastic.co/guide/en/x-pack/{doc-branch}
+include::../../libbeat/docs/shared-beats-attributes.asciidoc[]
+
 :version: {stack-version}
 :beatname_lc: auditbeat
 :beatname_uc: Auditbeat
 :beatname_pkg: {beatname_lc}
-:security: X-Pack Security
-:dockerimage: docker.elastic.co/beats/{beatname_lc}:{version}
 
 include::./overview.asciidoc[]
 

--- a/filebeat/docs/index.asciidoc
+++ b/filebeat/docs/index.asciidoc
@@ -4,25 +4,12 @@ include::../../libbeat/docs/version.asciidoc[]
 
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
-:libbeat: http://www.elastic.co/guide/en/beats/libbeat/{doc-branch}
-:kibana-ref: https://www.elastic.co/guide/en/kibana/{doc-branch}
-:beatsdevguide: http://www.elastic.co/guide/en/beats/devguide/{doc-branch}
-:packetbeat: http://www.elastic.co/guide/en/beats/packetbeat/{doc-branch}
-:metricbeat: http://www.elastic.co/guide/en/beats/metricbeat/{doc-branch}
-:filebeat: http://www.elastic.co/guide/en/beats/filebeat/{doc-branch}
-:winlogbeat: http://www.elastic.co/guide/en/beats/winlogbeat/{doc-branch}
-:logstashdoc: https://www.elastic.co/guide/en/logstash/{doc-branch}
-:elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/{doc-branch}
-:elasticsearch-plugins: https://www.elastic.co/guide/en/elasticsearch/plugins/{doc-branch}
-:securitydoc: https://www.elastic.co/guide/en/x-pack/{doc-branch}
+include::../../libbeat/docs/shared-beats-attributes.asciidoc[]
+
 :version: {stack-version}
 :beatname_lc: filebeat
 :beatname_uc: Filebeat
 :beatname_pkg: {beatname_lc}
-:security: X-Pack Security
-:dockerimage: docker.elastic.co/beats/{beatname_lc}:{version}
-:dockergithub: https://github.com/elastic/beats-docker/tree/{doc-branch}
-
 
 include::./overview.asciidoc[]
 

--- a/heartbeat/docs/index.asciidoc
+++ b/heartbeat/docs/index.asciidoc
@@ -4,25 +4,12 @@ include::../../libbeat/docs/version.asciidoc[]
 
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
-:libbeat: http://www.elastic.co/guide/en/beats/libbeat/{doc-branch}
-:kibana-ref: https://www.elastic.co/guide/en/kibana/{doc-branch}
-:beatsdevguide: http://www.elastic.co/guide/en/beats/devguide/{doc-branch}
-:packetbeat: http://www.elastic.co/guide/en/beats/packetbeat/{doc-branch}
-:metricbeat: http://www.elastic.co/guide/en/beats/metricbeat/{doc-branch}
-:filebeat: http://www.elastic.co/guide/en/beats/filebeat/{doc-branch}
-:winlogbeat: http://www.elastic.co/guide/en/beats/winlogbeat/{doc-branch}
-:logstashdoc: https://www.elastic.co/guide/en/logstash/{doc-branch}
-:elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/{doc-branch}
-:securitydoc: https://www.elastic.co/guide/en/x-pack/{doc-branch}
-:downloads: https://artifacts.elastic.co/downloads/beats
+include::../../libbeat/docs/shared-beats-attributes.asciidoc[]
+
 :version: {stack-version}
 :beatname_lc: heartbeat
 :beatname_uc: Heartbeat
 :beatname_pkg: heartbeat-elastic
-:security: X-Pack Security
-:dockerimage: docker.elastic.co/beats/{beatname_lc}:{version}
-:dockergithub: https://github.com/elastic/beats-docker/tree/{doc-branch}
-
 
 include::./overview.asciidoc[]
 

--- a/libbeat/docs/command-reference.asciidoc
+++ b/libbeat/docs/command-reference.asciidoc
@@ -33,12 +33,12 @@ for controlling global behaviors.
 
 ifeval::["{beatname_lc}"!="winlogbeat"]
 
-[NOTE]
+[TIP]
 =========================
-You may need to use `sudo` to run the following commands if you've:
+Use `sudo` to run the following commands if:
 
-* changed ownership of the config file to `root`
-* enabled the Beat to capture data that requires `root` access
+* the config file is owned by `root`, or
+* {beatname_uc} is configured to capture data that requires `root` access
 
 =========================
 

--- a/libbeat/docs/dashboards.asciidoc
+++ b/libbeat/docs/dashboards.asciidoc
@@ -28,25 +28,32 @@ Make sure Kibana is running before you perform this step. If you are accessing a
 secured Kibana instance, make sure you've configured credentials as described in
 <<{beatname_lc}-configuration>>.
 
-To set up the Kibana dashboards for {beatname_uc}:
+To set up the Kibana dashboards for {beatname_uc}, use the appropriate command
+for your system.
 
 ifdef::allplatforms[]
 
-*deb, rpm, and mac:*
+ifeval::["{requires-sudo}"=="yes"]
 
-From the directory where you installed {beatname_uc}, run:
+include::../../libbeat/docs/shared-note-sudo.asciidoc[]
 
-["source","sh",subs="attributes,callouts"]
+endif::[]
+
+*deb and rpm:*
+
+["source","sh",subs="attributes"]
+----------------------------------------------------------------------
+{beatname_lc} setup --dashboards
+----------------------------------------------------------------------
+
+
+*mac:*
+
+["source","sh",subs="attributes"]
 ----------------------------------------------------------------------
 ./{beatname_lc} setup --dashboards
 ----------------------------------------------------------------------
 
-ifeval::["{requires-sudo}"=="yes"]
-
-If you changed ownership of the config file to root, you'll need preface this
-command with `sudo`.
-
-endif::[]
 
 ifeval::["{beatname_lc}"!="auditbeat"]
 

--- a/libbeat/docs/faq-refresh-index.asciidoc
+++ b/libbeat/docs/faq-refresh-index.asciidoc
@@ -11,7 +11,7 @@ http.response.headers = {
         "content-type": "application/json"
 }
 ----------------------------------------------------------------------
-To fix this you need to {kibanadoc}/index-patterns.html#reload-fields[reload the index pattern] in Kibana under the Management->Index Patterns, and the index pattern will be
+To fix this you need to {kibana-ref}/index-patterns.html#reload-fields[reload the index pattern] in Kibana under the Management->Index Patterns, and the index pattern will be
 updated with a field for each key available in the dictionary:
 
 [source,shell]

--- a/libbeat/docs/index.asciidoc
+++ b/libbeat/docs/index.asciidoc
@@ -5,23 +5,10 @@ include::./version.asciidoc[]
 
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
-:packetbeat: http://www.elastic.co/guide/en/beats/packetbeat/{doc-branch}
-:metricbeat: http://www.elastic.co/guide/en/beats/metricbeat/{doc-branch}
-:filebeat: http://www.elastic.co/guide/en/beats/filebeat/{doc-branch}
-:winlogbeat: http://www.elastic.co/guide/en/beats/winlogbeat/{doc-branch}
-:heartbeat: http://www.elastic.co/guide/en/beats/heartbeat/{doc-branch}
-:beatsdevguide: http://www.elastic.co/guide/en/beats/devguide/{doc-branch}
-:securitydoc: https://www.elastic.co/guide/en/x-pack/{doc-branch}
-:logstashdoc: https://www.elastic.co/guide/en/logstash/{doc-branch}
-:elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/{doc-branch}
-:stack-ref: http://www.elastic.co/guide/en/elastic-stack/{doc-branch}
+include::../../libbeat/docs/shared-beats-attributes.asciidoc[]
+
 :beatname_lc: beatname
 :beatname_uc: a Beat
-:security: X-Pack Security
-:ES-version: {stack-version}
-:LS-version: {stack-version}
-:Kibana-version: {stack-version}
-:dashboards: https://artifacts.elastic.co/downloads/beats/beats-dashboards/beats-dashboards-{stack-version}.zip
 :beatname_pkg: {beatname_lc}
 
 include::./overview.asciidoc[]

--- a/libbeat/docs/shared-beats-attributes.asciidoc
+++ b/libbeat/docs/shared-beats-attributes.asciidoc
@@ -1,0 +1,21 @@
+:libbeat: http://www.elastic.co/guide/en/beats/libbeat/{doc-branch}
+:kibana-ref: https://www.elastic.co/guide/en/kibana/{doc-branch}
+:beatsdevguide: http://www.elastic.co/guide/en/beats/devguide/{doc-branch}
+:packetbeat: http://www.elastic.co/guide/en/beats/packetbeat/{doc-branch}
+:metricbeat: http://www.elastic.co/guide/en/beats/metricbeat/{doc-branch}
+:heartbeat: http://www.elastic.co/guide/en/beats/heartbeat/{doc-branch}
+:filebeat: http://www.elastic.co/guide/en/beats/filebeat/{doc-branch}
+:winlogbeat: http://www.elastic.co/guide/en/beats/winlogbeat/{doc-branch}
+:logstashdoc: https://www.elastic.co/guide/en/logstash/{doc-branch}
+:elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/{doc-branch}
+:elasticsearch-plugins: https://www.elastic.co/guide/en/elasticsearch/plugins/{doc-branch}
+:securitydoc: https://www.elastic.co/guide/en/x-pack/{doc-branch}
+:monitoringdoc: https://www.elastic.co/guide/en/x-pack/{doc-branch}
+:security: X-Pack Security
+:dashboards: https://artifacts.elastic.co/downloads/beats/beats-dashboards/beats-dashboards-{stack-version}.zip
+:dockerimage: docker.elastic.co/beats/{beatname_lc}:{version}
+:dockergithub: https://github.com/elastic/beats-docker/tree/{doc-branch}
+:downloads: https://artifacts.elastic.co/downloads/beats
+:ES-version: {stack-version}
+:LS-version: {stack-version}
+:Kibana-version: {stack-version}

--- a/libbeat/docs/shared-note-sudo.asciidoc
+++ b/libbeat/docs/shared-note-sudo.asciidoc
@@ -1,5 +1,1 @@
-[TIP]
-=========================
-Use `sudo` to run this command if the config file is owned by `root`.
-
-=========================
+NOTE: Use `sudo` to run these commands if the config file is owned by root.

--- a/libbeat/docs/shared-template-load.asciidoc
+++ b/libbeat/docs/shared-template-load.asciidoc
@@ -115,24 +115,30 @@ configured credentials as described in <<{beatname_lc}-configuration>>.
 If the host running {beatname_uc} does not have direct connectivity to
 Elasticsearch, see <<load-template-manually-alternate>>.
 
-To load the template: 
+To load the template, use the appropriate command for your system.
 
 ifdef::allplatforms[]
 
-*deb, rpm, and mac:*
+ifeval::["{requires-sudo}"=="yes"]
+
+include::./shared-note-sudo.asciidoc[]
+
+endif::[]
+
+*deb and rpm:*
+
+["source","sh",subs="attributes"]
+----
+{beatname_lc} setup --template -E output.logstash.enabled=false -E 'output.elasticsearch.hosts=["localhost:9200"]'
+----
+
+*mac:*
 
 ["source","sh",subs="attributes"]
 ----
 ./{beatname_lc} setup --template -E output.logstash.enabled=false -E 'output.elasticsearch.hosts=["localhost:9200"]'
 ----
 
-
-ifeval::["{requires-sudo}"=="yes"]
-
-If you changed ownership of the config file to root, you'll need preface this
-command with `sudo`.
-
-endif::[]
 
 ifeval::["{beatname_lc}"!="auditbeat"]
 
@@ -200,7 +206,14 @@ machine that does have connectivity, and then install the template manually.
 . Export the index template:
 +
 ifdef::allplatforms[]
-*deb, rpm, and mac:*
+*deb and rpm:*
++
+["source","sh",subs="attributes"]
+----
+{beatname_lc} export template > {beatname_lc}.template.json
+----
++
+*mac:*
 +
 ["source","sh",subs="attributes"]
 ----

--- a/metricbeat/docs/index.asciidoc
+++ b/metricbeat/docs/index.asciidoc
@@ -4,21 +4,12 @@ include::../../libbeat/docs/version.asciidoc[]
 
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
-:libbeat: http://www.elastic.co/guide/en/beats/libbeat/{doc-branch}
-:kibana-ref: https://www.elastic.co/guide/en/kibana/{doc-branch}
-:beatsdevguide: http://www.elastic.co/guide/en/beats/devguide/{doc-branch}
-:filebeat: http://www.elastic.co/guide/en/beats/filebeat/{doc-branch}
-:logstashdoc: https://www.elastic.co/guide/en/logstash/{doc-branch}
-:elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/{doc-branch}
-:securitydoc: https://www.elastic.co/guide/en/x-pack/{doc-branch}
+include::../../libbeat/docs/shared-beats-attributes.asciidoc[]
+
 :version: {stack-version}
 :beatname_lc: metricbeat
 :beatname_uc: Metricbeat
 :beatname_pkg: {beatname_lc}
-:security: X-Pack Security
-:monitoringdoc: https://www.elastic.co/guide/en/x-pack/current
-:dockerimage: docker.elastic.co/beats/{beatname_lc}:{version}
-:dockergithub: https://github.com/elastic/beats-docker/tree/{doc-branch}
 
 
 include::./overview.asciidoc[]

--- a/packetbeat/docs/index.asciidoc
+++ b/packetbeat/docs/index.asciidoc
@@ -4,25 +4,12 @@ include::../../libbeat/docs/version.asciidoc[]
 
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
-:libbeat: http://www.elastic.co/guide/en/beats/libbeat/{doc-branch}
-:kibana-ref: https://www.elastic.co/guide/en/kibana/{doc-branch}
-:beatsdevguide: http://www.elastic.co/guide/en/beats/devguide/{doc-branch}
-:packetbeat: http://www.elastic.co/guide/en/beats/packetbeat/{doc-branch}
-:metricbeat: http://www.elastic.co/guide/en/beats/metricbeat/{doc-branch}
-:filebeat: http://www.elastic.co/guide/en/beats/filebeat/{doc-branch}
-:winlogbeat: http://www.elastic.co/guide/en/beats/winlogbeat/{doc-branch}
-:logstashdoc: https://www.elastic.co/guide/en/logstash/{doc-branch}
-:elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/{doc-branch}
-:securitydoc: https://www.elastic.co/guide/en/x-pack/{doc-branch}
-:kibanadoc: https://www.elastic.co/guide/en/kibana/{doc-branch}
-:plugindoc: https://www.elastic.co/guide/en/elasticsearch/plugins/{doc-branch}
+include::../../libbeat/docs/shared-beats-attributes.asciidoc[]
+
 :version: {stack-version}
 :beatname_lc: packetbeat
 :beatname_uc: Packetbeat
 :beatname_pkg: {beatname_lc}
-:security: X-Pack Security
-:dockerimage: docker.elastic.co/beats/{beatname_lc}:{version}
-:dockergithub: https://github.com/elastic/beats-docker/tree/{doc-branch}
 
 
 include::./overview.asciidoc[]

--- a/packetbeat/docs/packetbeat-geoip.asciidoc
+++ b/packetbeat/docs/packetbeat-geoip.asciidoc
@@ -90,7 +90,7 @@ The event that's sent to Elasticsearch should now include a
 
 To visualize the location of your Packetbeat clients, you can either
 <<load-kibana-dashboards,set up the example Kibana dashboards>> (if
-you haven't already), or create a new {kibanadoc}/tilemap.html[Tile map] in
+you haven't already), or create a new {kibana-ref}/tilemap.html[Tile map] in
 Kibana and use the `client_geoip.location` field as the Geohash.
 
 image:./images/kibana-update-map.png[Update Packetbeat client location map in Kibana]

--- a/winlogbeat/docs/index.asciidoc
+++ b/winlogbeat/docs/index.asciidoc
@@ -4,21 +4,12 @@ include::../../libbeat/docs/version.asciidoc[]
 
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
-:libbeat: http://www.elastic.co/guide/en/beats/libbeat/{doc-branch}
-:kibana-ref: https://www.elastic.co/guide/en/kibana/{doc-branch}
-:beatsdevguide: http://www.elastic.co/guide/en/beats/devguide/{doc-branch}
-:packetbeat: http://www.elastic.co/guide/en/beats/packetbeat/{doc-branch}
-:metricbeat: http://www.elastic.co/guide/en/beats/metricbeat/{doc-branch}
-:filebeat: http://www.elastic.co/guide/en/beats/filebeat/{doc-branch}
-:winlogbeat: http://www.elastic.co/guide/en/beats/winlogbeat/{doc-branch}
-:logstashdoc: https://www.elastic.co/guide/en/logstash/{doc-branch}
-:elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/{doc-branch}
-:securitydoc: https://www.elastic.co/guide/en/x-pack/{doc-branch}
+include::../../libbeat/docs/shared-beats-attributes.asciidoc[]
+
 :version: {stack-version}
 :beatname_lc: winlogbeat
 :beatname_uc: Winlogbeat
 :beatname_pkg: {beatname_lc}
-:security: X-Pack Security
 
 include::./overview.asciidoc[]
 


### PR DESCRIPTION
The documentation was slightly incorrect wrt running the setup commands on rpm and deb because it showed a mac-specific syntax. This PR fixes the issue by adding a separate section for rpm and deb.

I've also done some refactoring of the asciidoc attributes (to move them to a shared file) because I was originally planning to add a new attribute. I decided that a new attribute was not required, but left the changes in this PR because it makes sense to centralize shared attributes.

I left the name and version-related attributes in the index files because they are either specific to each beat or I thought we might want more granular control over setting those attributes at some point in the future. Please let me know if I've put anything in the shared file that is not likely to be the same across all Beats in the future. 