### PR TITLE
fsnotify-backed recursive watcher for Linux

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -110,6 +110,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 
 - Add support for SHA3 hash algorithms to the file integrity module. {issue}5345[5345]
 - Add dashboards for Linux audit framework events (overview, executions, sockets). {pull}5516[5516]
+- Add support for recursive file watches under macOS {pull}5575[5575] and Linux. {pull}5833[5833]
 
 *Filebeat*
 

--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -92,6 +92,9 @@ auditbeat.modules:
   # sha3_384 and sha3_512. Default is sha1.
   file.hash_types: [sha1]
 
+  # Detect changes to files included in subdirectories. Disabled by default.
+  file.recursive: false
+
 
 #================================ General ======================================
 

--- a/auditbeat/module/audit/_meta/config.yml.tpl
+++ b/auditbeat/module/audit/_meta/config.yml.tpl
@@ -85,4 +85,7 @@
   # sha224, sha256, sha384, sha512, sha512_224, sha512_256, sha3_224, sha3_256,
   # sha3_384 and sha3_512. Default is sha1.
   file.hash_types: [sha1]
+
+  # Detect changes to files included in subdirectories. Disabled by default.
+  file.recursive: false
   {{- end }}

--- a/auditbeat/module/audit/file/_meta/docs.asciidoc
+++ b/auditbeat/module/audit/file/_meta/docs.asciidoc
@@ -23,11 +23,11 @@ The operating system features that power this feature are as follows.
 
 * Linux - `inotify` is used, and therefore the kernel must have inotify support.
 Inotify was initially merged into the 2.6.13 Linux kernel.
-* macOS (Darwin) - `kqueue` is used. It requires one file descriptor for each
-file so please check the `ulimit` values used with {beatname_uc}. The FSEvents
-API was considered for the implementation, but FSEvents coalesces multiple
-notifications into a single event which is inconsistent with the metricset's
-behavior on other operating systems.
+* macOS (Darwin) - Uses the `FSEvents` API, present since macOS 10.5. This API
+coalesces multiple changes to a file into a single event. {beatname_uc} translates
+this coalesced changes into a meaningful sequence of actions. However,
+in rare situations the reported events may have a different ordering than what
+actually happened.
 * Windows - `ReadDirectoryChangesW` is used.
 
 The file metricset should not be used to monitor paths on network file systems.
@@ -53,11 +53,11 @@ Linux.
   file.scan_rate_per_sec: 50 MiB
   file.max_file_size: 100 MiB
   file.hash_types: [sha1]
+  file.recursive: false
 ----
 
-*`file.paths`*:: A list of paths (directories or files) to watch. The watches
-are non-recursive and globs are not supported. The specified paths should exist
-when the metricset is started.
+*`file.paths`*:: A list of paths (directories or files) to watch. Globs are
+not supported. The specified paths should exist when the metricset is started.
 
 *`file.scan_at_start`*:: A boolean value that controls if {beatname_uc} scans
 over the configured file paths at startup and send events for the files
@@ -84,4 +84,10 @@ a suffix to the value. The supported units are `b` (default), `kib`, `kb`, `mib`
 
 *`file.hash_types`*:: A list of hash types to compute when the file changes.
 The supported hash types are md5, sha1, sha224, sha256, sha384, sha512,
-sha512_224, sha512_256, sha3_224, sha3_256, sha3_384 and sha3_512. The default value is sha1.
+sha512_224, sha512_256, sha3_224, sha3_256, sha3_384 and sha3_512. The default
+value is sha1.
+
+*`file.recursive`*:: By default, the watches set to the paths specified in
+`file.paths` are not recursive. This means that only changes to the contents
+of this directories are watched. If `file.recursive` is set to `true`, the file
+metric will watch for changes on this directories and all their subdirectories.

--- a/auditbeat/module/audit/file/monitor/filetree.go
+++ b/auditbeat/module/audit/file/monitor/filetree.go
@@ -1,0 +1,142 @@
+package monitor
+
+import (
+	"fmt"
+	"os"
+	path_pkg "path"
+	"strings"
+)
+
+// VisitOrder is a two-valued flag used to control how directories are visited.
+type VisitOrder int8
+
+const (
+	// PreOrder has directories visited before their contents.
+	PreOrder VisitOrder = iota
+	// PostOrder has directories visited after their contents.
+	PostOrder
+)
+
+var (
+	// PathSeparator can be used to override the operating system separator.
+	PathSeparator = string(os.PathSeparator)
+)
+
+// FileTree represents a directory in a filesystem-tree structure.
+type FileTree map[string]FileTree
+
+// VisitFunc is the type for a callback to visit the entries on a directory
+// and its subdirectories.
+type VisitFunc func(path string, isDir bool) error
+
+// AddFile adds a file to a FileTree. If the path includes subdirectories
+// they are created as necessary.
+func (tree FileTree) AddFile(path string) error {
+	return tree.add(path_pkg.Clean(path), nil)
+}
+
+// AddDir adds a directory to a FileTree. If the path includes subdirectories
+// they are created as necessary.
+func (tree FileTree) AddDir(path string) error {
+	return tree.add(path_pkg.Clean(path), FileTree{})
+}
+
+// Remove an entry from a FileTree.
+func (tree FileTree) Remove(path string) error {
+	components := strings.Split(path, PathSeparator)
+	last := -1
+	for pos := len(components) - 1; pos >= 0; pos-- {
+		if len(components[pos]) != 0 {
+			last = pos
+			break
+		}
+	}
+	if last > 0 {
+		subtree, err := tree.getByComponents(path, components[:last])
+		if err != nil {
+			return err
+		}
+		delete(subtree, components[last])
+	}
+	return nil
+}
+
+// Visit calls the callback function for the given path and recursively all its
+// contents, if a directory path is passed.
+func (tree FileTree) Visit(path string, order VisitOrder, fn VisitFunc) error {
+	entry, err := tree.At(path)
+	if err != nil {
+		return err
+	}
+	return entry.visitDirRecursive(path_pkg.Clean(path), order, fn)
+}
+
+// At returns a new FileTree rooted at the given path.
+func (tree FileTree) At(path string) (FileTree, error) {
+	return tree.getByComponents(path, strings.Split(path, PathSeparator))
+}
+
+func (tree FileTree) add(path string, value FileTree) error {
+	components := strings.Split(path, PathSeparator)
+	dir, last := tree, len(components)-1
+	for i := 0; i < last; i++ {
+		if len(components[i]) == 0 {
+			continue
+		}
+		if next, exists := dir[components[i]]; exists {
+			if next == nil {
+				return fmt.Errorf("directory expected: '%s' in %s", components[i], path)
+			}
+			dir = next
+		} else {
+			newDir := FileTree{}
+			dir[components[i]] = newDir
+			dir = newDir
+		}
+	}
+	dir[components[last]] = value
+	return nil
+}
+
+func (tree FileTree) getByComponents(path string, components []string) (FileTree, error) {
+	dir, exists := tree, false
+	for _, item := range components {
+		if len(item) != 0 {
+			if dir == nil {
+				// previous component is a file, not a directory
+				return nil, fmt.Errorf("path component %s is a file: %s", item, path)
+			}
+			if dir, exists = dir[item]; !exists {
+				return nil, fmt.Errorf("path component %s not found in %s", item, path)
+			}
+		}
+	}
+	return dir, nil
+}
+
+func (tree FileTree) visitDirRecursive(path string, order VisitOrder, fn VisitFunc) error {
+	if tree == nil {
+		return fn(path, false)
+	}
+	if order == PreOrder {
+		if err := fn(path, true); err != nil {
+			return err
+		}
+	}
+	for name, content := range tree {
+		fullpath := path_pkg.Join(path, name)
+		if content == nil {
+			if err := fn(fullpath, false); err != nil {
+				return err
+			}
+		} else {
+			if err := content.visitDirRecursive(fullpath, order, fn); err != nil {
+				return err
+			}
+		}
+	}
+	if order == PostOrder {
+		return fn(path, true)
+	}
+	return nil
+}

--- a/auditbeat/module/audit/file/monitor/filetree_test.go
+++ b/auditbeat/module/audit/file/monitor/filetree_test.go
@@ -1,0 +1,219 @@
+package monitor
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type visitParams struct {
+	path  string
+	isDir bool
+}
+
+func init() {
+	PathSeparator = "/"
+}
+
+func TestVisit(t *testing.T) {
+	tree := FileTree{}
+	assertNoError(t, tree.AddFile("/usr/bin/python"))
+	assertNoError(t, tree.AddFile("/usr/bin/tar"))
+	assertNoError(t, tree.AddFile("/usr/lib/libz.a"))
+	assertNoError(t, tree.AddDir("/tmp/"))
+
+	for testIdx, testData := range []struct {
+		dir    string
+		result []string
+		isDir  []bool
+	}{
+		{"/",
+			[]string{"/", "/tmp", "/usr", "/usr/bin", "/usr/bin/python", "/usr/bin/tar", "/usr/lib", "/usr/lib/libz.a"},
+			[]bool{true, true, true, true, false, false, true, false}},
+		{"/usr",
+			[]string{"/usr", "/usr/bin", "/usr/bin/python", "/usr/bin/tar", "/usr/lib", "/usr/lib/libz.a"},
+			[]bool{true, true, false, false, true, false}},
+		{"/usr/bin",
+			[]string{"/usr/bin", "/usr/bin/python", "/usr/bin/tar"},
+			[]bool{true, false, false}},
+		{"/usr/lib",
+			[]string{"/usr/lib", "/usr/lib/libz.a"},
+			[]bool{true, false}},
+		{"/tmp/",
+			[]string{"/tmp"},
+			[]bool{true}},
+		{"/usr/bin/python",
+			[]string{"/usr/bin/python"},
+			[]bool{false}},
+	} {
+		for _, order := range []VisitOrder{PreOrder, PostOrder} {
+			failMsg := fmt.Sprintf("test entry %d for path '%s' order:%v", testIdx, testData.dir, order)
+			calls := map[string]bool{}
+			ncalls := 0
+
+			err := tree.Visit(testData.dir, order, func(path string, isDir bool) error {
+				calls[path] = isDir
+				ncalls++
+				return nil
+			})
+			assertNoError(t, err)
+
+			assert.Equal(t, len(testData.result), ncalls, failMsg)
+			assert.Equal(t, len(testData.result), len(calls), failMsg)
+			keys := make([]string, len(calls))
+			flags := make([]bool, len(calls))
+			i := 0
+			for k := range calls {
+				keys[i] = k
+				i++
+			}
+			sort.Strings(keys)
+			for idx, val := range keys {
+				flags[idx] = calls[val]
+			}
+			assert.Equal(t, testData.result, keys, failMsg)
+			assert.Equal(t, testData.isDir, flags, failMsg)
+		}
+	}
+}
+
+func TestVisitOrder(t *testing.T) {
+	tree := FileTree{}
+	assertNoError(t, tree.AddFile("/a/b/file"))
+
+	expected := []visitParams{
+		{"/", true},
+		{"/a", true},
+		{"/a/b", true},
+		{"/a/b/file", false},
+	}
+
+	for _, order := range []VisitOrder{PreOrder, PostOrder} {
+		var result []visitParams
+		err := tree.Visit("/", order, func(path string, isDir bool) error {
+			result = append(result, visitParams{path, isDir})
+			return nil
+		})
+		assertNoError(t, err)
+
+		assert.Equal(t, expected, result)
+
+		for a, b := 0, len(expected)-1; a < b; a++ {
+			expected[a], expected[b] = expected[b], expected[a]
+			b--
+		}
+	}
+}
+
+func TestVisitError(t *testing.T) {
+	tree := FileTree{}
+	assertNoError(t, tree.AddFile("/foo"))
+	assert.Error(t, tree.Visit("/bar", PreOrder, func(path string, isDir bool) error {
+		return nil
+	}))
+}
+
+func TestVisitCancel(t *testing.T) {
+	tree := FileTree{}
+	assertNoError(t, tree.AddFile("/a/b/file"))
+
+	myErr := errors.New("some error")
+
+	for idx, test := range []struct {
+		order    VisitOrder
+		cancel   string
+		expected []visitParams
+	}{
+		{PreOrder, "/a", []visitParams{
+			{"/", true}}},
+		{PostOrder, "/a", []visitParams{
+			{"/a/b/file", false},
+			{"/a/b", true}}},
+		{PreOrder, "/a/b/file", []visitParams{
+			{"/", true},
+			{"/a", true},
+			{"/a/b", true}}},
+	} {
+		failMsg := fmt.Sprintf("test at index %d", idx)
+		var result []visitParams
+		err := tree.Visit("/", test.order, func(path string, isDir bool) error {
+			if path == test.cancel {
+				return myErr
+			}
+			result = append(result, visitParams{path, isDir})
+			return nil
+		})
+		assert.Equal(t, myErr, err, failMsg)
+		assert.Equal(t, test.expected, result, failMsg)
+	}
+}
+
+func TestFilesAsDir(t *testing.T) {
+	tree := FileTree{}
+	assertNoError(t, tree.AddFile("/foo"))
+	assert.Error(t, tree.AddFile("/foo/bar"))
+	assert.Error(t, tree.Visit("/foo/bar", PreOrder, func(path string, isDir bool) error {
+		return nil
+	}))
+}
+
+func TestRemove(t *testing.T) {
+	tree := FileTree{}
+	assertNoError(t, tree.AddFile("/usr/bin/python"))
+	assertNoError(t, tree.AddFile("/usr/bin/tar"))
+	assertNoError(t, tree.AddFile("/usr/lib/libz.a"))
+	assertNoError(t, tree.AddDir("/tmp/"))
+
+	assertNoError(t, tree.Remove("/tmp"))
+	assertNoError(t, tree.Remove("/usr/lib"))
+	assertNoError(t, tree.Remove("/usr/bin/python"))
+
+	expected := []visitParams{
+		{"/", true},
+		{"/usr", true},
+		{"/usr/bin", true},
+		{"/usr/bin/tar", false},
+	}
+
+	var result []visitParams
+	err := tree.Visit("/", PreOrder, func(path string, isDir bool) error {
+		result = append(result, visitParams{path, isDir})
+		return nil
+	})
+	assertNoError(t, err)
+	assert.Equal(t, expected, result)
+
+	assert.Error(t, tree.Remove("/usr/src/linux"))
+}
+
+func TestAt(t *testing.T) {
+	tree := FileTree{}
+	assertNoError(t, tree.AddFile("/usr/bin/python"))
+	assertNoError(t, tree.AddFile("/usr/bin/tar"))
+	assertNoError(t, tree.AddFile("/usr/lib/libz.a"))
+	assertNoError(t, tree.AddDir("/tmp/"))
+
+	expected := []visitParams{
+		{"/", true},
+		{"/bin", true},
+		{"/bin/python", false},
+		{"/bin/tar", false},
+		{"/lib", true},
+		{"/lib/libz.a", false},
+	}
+
+	var result []visitParams
+	subtree, err := tree.At("/usr")
+	assertNoError(t, err)
+	err = subtree.Visit("/", PostOrder, func(path string, isDir bool) error {
+		result = append(result, visitParams{path, isDir})
+		return nil
+	})
+	assertNoError(t, err)
+
+	sort.Slice(result, func(i, j int) bool { return result[i].path < result[j].path })
+	assert.Equal(t, expected, result)
+}

--- a/auditbeat/module/audit/file/monitor/monitor.go
+++ b/auditbeat/module/audit/file/monitor/monitor.go
@@ -1,0 +1,28 @@
+package monitor
+
+import (
+	"github.com/fsnotify/fsnotify"
+)
+
+// Watcher is an interface for a file watcher akin to fsnotify.Watcher
+// with an additional Start method.
+type Watcher interface {
+	Add(path string) error
+	Close() error
+	EventChannel() <-chan fsnotify.Event
+	ErrorChannel() <-chan error
+	Start() error
+}
+
+// New creates a new Watcher backed by fsnotify with optional recursive
+// logic.
+func New(recursive bool) (Watcher, error) {
+	fsnotify, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, err
+	}
+	if recursive {
+		return newRecursiveWatcher(fsnotify), nil
+	}
+	return (*nonRecursiveWatcher)(fsnotify), nil
+}

--- a/auditbeat/module/audit/file/monitor/monitor_test.go
+++ b/auditbeat/module/audit/file/monitor/monitor_test.go
@@ -1,0 +1,233 @@
+package monitor
+
+import (
+	"errors"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNonRecursive(t *testing.T) {
+	dir, err := ioutil.TempDir("", "monitor")
+	assertNoError(t, err)
+	// under macOS, temp dir has a symlink in the path (/var -> /private/var)
+	// and the path returned in events has the symlink resolved
+	if runtime.GOOS == "darwin" {
+		if dirAlt, err := filepath.EvalSymlinks(dir); err == nil {
+			dir = dirAlt
+		}
+	}
+	defer os.RemoveAll(dir)
+
+	watcher, err := New(false)
+	assertNoError(t, err)
+
+	assertNoError(t, watcher.Add(dir))
+
+	assertNoError(t, watcher.Start())
+
+	testDirOps(t, dir, watcher)
+
+	subdir := filepath.Join(dir, "subdir")
+	os.Mkdir(subdir, 0750)
+
+	ev, err := readTimeout(watcher.EventChannel())
+	assertNoError(t, err)
+	assert.Equal(t, subdir, ev.Name)
+	assert.Equal(t, fsnotify.Create, ev.Op)
+
+	// subdirs are not watched
+	subfile := filepath.Join(subdir, "file.dat")
+	assertNoError(t, ioutil.WriteFile(subfile, []byte("foo"), 0640))
+
+	_, err = readTimeout(watcher.EventChannel())
+	assert.Error(t, err)
+	assert.Equal(t, errReadTimeout, err)
+
+	assertNoError(t, watcher.Close())
+}
+
+func TestRecursive(t *testing.T) {
+	dir, err := ioutil.TempDir("", "monitor")
+	assertNoError(t, err)
+	// under macOS, temp dir has a symlink in the path (/var -> /private/var)
+	// and the path returned in events has the symlink resolved
+	if runtime.GOOS == "darwin" {
+		if dirAlt, err := filepath.EvalSymlinks(dir); err == nil {
+			dir = dirAlt
+		}
+	}
+	defer os.RemoveAll(dir)
+
+	watcher, err := New(true)
+	assertNoError(t, err)
+
+	assertNoError(t, watcher.Add(dir))
+
+	assertNoError(t, watcher.Start())
+
+	testDirOps(t, dir, watcher)
+
+	subdir := filepath.Join(dir, "subdir")
+	os.Mkdir(subdir, 0750)
+
+	ev, err := readTimeout(watcher.EventChannel())
+	assertNoError(t, err)
+	assert.Equal(t, subdir, ev.Name)
+	assert.Equal(t, fsnotify.Create, ev.Op)
+
+	testDirOps(t, subdir, watcher)
+
+	assertNoError(t, watcher.Close())
+}
+
+func TestRecursiveNoFollowSymlink(t *testing.T) {
+	// fsnotify has a bug in darwin were it is following symlinks
+	// see: https://github.com/fsnotify/fsnotify/issues/227
+	if runtime.GOOS == "darwin" {
+		t.Skip("This test fails under macOS due to a bug in fsnotify")
+	}
+
+	// Create a watched dir
+
+	dir, err := ioutil.TempDir("", "monitor")
+	assertNoError(t, err)
+	// under macOS, temp dir has a symlink in the path (/var -> /private/var)
+	// and the path returned in events has the symlink resolved
+	if runtime.GOOS == "darwin" {
+		if dirAlt, err := filepath.EvalSymlinks(dir); err == nil {
+			dir = dirAlt
+		}
+	}
+	defer os.RemoveAll(dir)
+
+	// Create a separate dir
+
+	linkedDir, err := ioutil.TempDir("", "linked")
+	assertNoError(t, err)
+	defer os.RemoveAll(linkedDir)
+
+	// Add a symbolic link from watched dir to the other
+
+	symLink := filepath.Join(dir, "link")
+	assertNoError(t, os.Symlink(linkedDir, symLink))
+
+	// Start the watcher
+
+	watcher, err := New(true)
+	assertNoError(t, err)
+
+	assertNoError(t, watcher.Add(dir))
+	assertNoError(t, watcher.Start())
+
+	// Create a file in the other dir
+
+	file := filepath.Join(linkedDir, "not.seen")
+	assertNoError(t, ioutil.WriteFile(file, []byte("hello"), 0640))
+
+	// No event is received
+	ev, err := readTimeout(watcher.EventChannel())
+	assert.Equal(t, errReadTimeout, err)
+	if err == nil {
+		t.Fatalf("Expected timeout, got event %+v", ev)
+	}
+	assertNoError(t, watcher.Close())
+}
+
+func testDirOps(t *testing.T, dir string, watcher Watcher) {
+	fpath := filepath.Join(dir, "file.txt")
+	fpath2 := filepath.Join(dir, "file2.txt")
+
+	// Create
+	assertNoError(t, ioutil.WriteFile(fpath, []byte("hello"), 0640))
+
+	ev, err := readTimeout(watcher.EventChannel())
+	assertNoError(t, err)
+	assert.Equal(t, fpath, ev.Name)
+	assert.Equal(t, fsnotify.Create, ev.Op)
+
+	// Update
+	// Repeat the write if no event is received. Under macOS often
+	// the write fails to generate a write event for non-recursive watcher
+	for i := 0; i < 3; i++ {
+		f, err := os.OpenFile(fpath, os.O_RDWR|os.O_APPEND, 0640)
+		assertNoError(t, err)
+		f.WriteString(" world\n")
+		f.Sync()
+		f.Close()
+
+		ev, err = readTimeout(watcher.EventChannel())
+		if err == nil || err != errReadTimeout {
+			break
+		}
+	}
+	assertNoError(t, err)
+	assert.Equal(t, fpath, ev.Name)
+	assert.Equal(t, fsnotify.Write, ev.Op)
+
+	// Move
+	err = os.Rename(fpath, fpath2)
+	assertNoError(t, err)
+
+	evRename, err := readTimeout(watcher.EventChannel())
+	assertNoError(t, err)
+	// Sometimes a duplicate Write can be received under Linux, skip
+	if evRename.Op == fsnotify.Write {
+		evRename, err = readTimeout(watcher.EventChannel())
+	}
+	evCreate, err := readTimeout(watcher.EventChannel())
+	assertNoError(t, err)
+
+	if evRename.Op != fsnotify.Rename {
+		evRename, evCreate = evCreate, evRename
+	}
+
+	assert.Equal(t, fpath, evRename.Name)
+	assert.Equal(t, fsnotify.Rename, evRename.Op)
+
+	assert.Equal(t, fpath2, evCreate.Name)
+	assert.Equal(t, fsnotify.Create, evCreate.Op)
+
+	// Delete
+	err = os.Remove(fpath2)
+	assertNoError(t, err)
+
+	ev, err = readTimeout(watcher.EventChannel())
+	assertNoError(t, err)
+
+	// Windows: A write to the parent directory sneaks in
+	if ev.Op == fsnotify.Write && ev.Name == dir {
+		ev, err = readTimeout(watcher.EventChannel())
+		assertNoError(t, err)
+	}
+	assert.Equal(t, fpath2, ev.Name)
+	assert.Equal(t, fsnotify.Remove, ev.Op)
+}
+
+var errReadTimeout = errors.New("read timeout")
+
+// helper to read from channel
+func readTimeout(c <-chan fsnotify.Event) (fsnotify.Event, error) {
+	select {
+	case <-time.After(3 * time.Second):
+		return fsnotify.Event{}, errReadTimeout
+
+	case msg, ok := <-c:
+		if !ok {
+			return fsnotify.Event{}, errors.New("channel closed")
+		}
+		return msg, nil
+	}
+}
+
+func assertNoError(t *testing.T, err error) {
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/auditbeat/module/audit/file/monitor/nonrecursive.go
+++ b/auditbeat/module/audit/file/monitor/nonrecursive.go
@@ -1,0 +1,25 @@
+package monitor
+
+import "github.com/fsnotify/fsnotify"
+
+type nonRecursiveWatcher fsnotify.Watcher
+
+func (*nonRecursiveWatcher) Start() error {
+	return nil
+}
+
+func (watcher *nonRecursiveWatcher) Add(path string) error {
+	return (*fsnotify.Watcher)(watcher).Add(path)
+}
+
+func (watcher *nonRecursiveWatcher) Close() error {
+	return (*fsnotify.Watcher)(watcher).Close()
+}
+
+func (watcher *nonRecursiveWatcher) EventChannel() <-chan fsnotify.Event {
+	return (*fsnotify.Watcher)(watcher).Events
+}
+
+func (watcher *nonRecursiveWatcher) ErrorChannel() <-chan error {
+	return (*fsnotify.Watcher)(watcher).Errors
+}

--- a/auditbeat/module/audit/file/monitor/recursive.go
+++ b/auditbeat/module/audit/file/monitor/recursive.go
@@ -1,0 +1,127 @@
+package monitor
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/pkg/errors"
+)
+
+type recursiveWatcher struct {
+	inner  *fsnotify.Watcher
+	tree   FileTree
+	eventC chan fsnotify.Event
+	done   chan bool
+}
+
+func newRecursiveWatcher(inner *fsnotify.Watcher) *recursiveWatcher {
+	return &recursiveWatcher{
+		inner:  inner,
+		tree:   FileTree{},
+		eventC: make(chan fsnotify.Event, 1),
+	}
+}
+
+func (watcher *recursiveWatcher) Start() error {
+	watcher.done = make(chan bool, 1)
+	go watcher.forwardEvents()
+	return nil
+}
+
+func (watcher *recursiveWatcher) Add(path string) error {
+	return watcher.addRecursive(path)
+}
+
+func (watcher *recursiveWatcher) Close() error {
+	if watcher.done != nil {
+		// has been Started(), goroutine takes care of cleanup
+		close(watcher.done)
+		return nil
+	}
+	// not started
+	return watcher.close()
+}
+
+func (watcher *recursiveWatcher) EventChannel() <-chan fsnotify.Event {
+	return watcher.eventC
+}
+
+func (watcher *recursiveWatcher) ErrorChannel() <-chan error {
+	return watcher.inner.Errors
+}
+
+func (watcher *recursiveWatcher) addRecursive(path string) error {
+	return filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return errors.Wrap(err, "file tree recursion failed")
+		}
+		if info.IsDir() {
+			if err = watcher.tree.AddDir(path); err == nil {
+				err = watcher.inner.Add(path)
+			}
+		} else {
+			err = watcher.tree.AddFile(path)
+		}
+		return err
+	})
+}
+
+func (watcher *recursiveWatcher) close() error {
+	close(watcher.eventC)
+	return watcher.inner.Close()
+}
+
+func (watcher *recursiveWatcher) forwardEvents() error {
+	defer watcher.close()
+
+	for {
+		select {
+		case <-watcher.done:
+			return nil
+
+		case event, ok := <-watcher.inner.Events:
+			if !ok {
+				return nil
+			}
+			if event.Name == "" {
+				continue
+			}
+			switch event.Op {
+			case fsnotify.Create:
+				if err := watcher.addRecursive(event.Name); err != nil {
+					watcher.inner.Errors <- errors.Wrapf(err, "unable to recurse path '%s'", event.Name)
+					continue
+				}
+				watcher.tree.Visit(event.Name, PreOrder, func(path string, _ bool) error {
+					watcher.eventC <- fsnotify.Event{
+						Name: path,
+						Op:   event.Op,
+					}
+					return nil
+				})
+
+			case fsnotify.Remove:
+				watcher.tree.Visit(event.Name, PostOrder, func(path string, _ bool) error {
+					watcher.eventC <- fsnotify.Event{
+						Name: path,
+						Op:   event.Op,
+					}
+					return nil
+				})
+				watcher.tree.Remove(event.Name)
+
+			// Handling rename (move) as a special case to give this recursion
+			// the same semantics as macOS FSEvents:
+			// - Removal of a dir notifies removal for all files inside it
+			// - Moving a dir away sends only one notification for this dir
+			case fsnotify.Rename:
+				watcher.tree.Remove(event.Name)
+				fallthrough
+
+			default:
+				watcher.eventC <- event
+			}
+		}
+	}
+}


### PR DESCRIPTION
Adds a wrapper on top of fsnotify that allows placing recursive watches on directories.

Exhibits similar behavior to FSEvents:
- Copying a directory into a watched dir sends notifications for the whole new tree.
- Moving a directory into a watched dir only sends a notification for the new directory.

Same for removal vs moving out of a watched dir.

Issue #5421 