### PR TITLE
Fix template path for system tests

### DIFF
--- a/libbeat/tests/system/beat/beat.py
+++ b/libbeat/tests/system/beat/beat.py
@@ -198,7 +198,7 @@ class TestCase(unittest.TestCase, ComposeMixin):
         if template_name is None:
             template_name = self.beat_name
 
-        template_path = os.path.join("./tests/system/config", template_name + ".yml.j2")
+        template_path = "./tests/system/config/" + template_name + ".yml.j2"
 
         if output is None:
             output = self.beat_name + ".yml"


### PR DESCRIPTION
This broke by the change in #5820 for Windows. This reverts it to the old format as it seems `self.template_env.get_template(...)` expects a path without forward slashes under Windows too.