### PR TITLE
Make the close_timeout test bit more reliable

### DIFF
--- a/filebeat/tests/system/test_harvester.py
+++ b/filebeat/tests/system/test_harvester.py
@@ -405,6 +405,9 @@ class Test(BaseTest):
         for n in range(0, iterations1):
             file.write("example data")
             file.write("\n")
+            # Make sure some contents are written to disk so the harvested is able to read it.
+            file.flush()
+            os.fsync(file)
             time.sleep(0.001)
 
         file.close()


### PR DESCRIPTION
The current implementation was failing on fairly new hardware, the test
is changed a bit and should be more reliable concerning the timing
issue.

Before starting filebeat, we add a few initial messages into the logs, so
the logs get pickup up in the first scan, then we sleep a little longer
than a frequency scan. After we write a few more lines to the logs.

To make sure that logs are available we force a flush and a sync on
disk.