### PR TITLE
Remove topic about apt/yum from the platform reference

### DIFF
--- a/libbeat/docs/index.asciidoc
+++ b/libbeat/docs/index.asciidoc
@@ -34,8 +34,6 @@ include::./gettingstarted.asciidoc[]
 
 include::./installing-beats.asciidoc[]
 
-include::./repositories.asciidoc[]
-
 include::./breaking.asciidoc[]
 
 include::./upgrading.asciidoc[]


### PR DESCRIPTION
The docs for each Beat now include a topic about installing from the apt/yum repositories, and the product pages link to the correct docs, so there's no reason to continue providing this content in the Platform Reference. It's better for users to see the installation steps within the context of other info about installing and configuring the Beat.

Closes https://github.com/elastic/beats/issues/3764