### PR TITLE
Document that Npcap must be installed in WinPCap compatible mode

### DIFF
--- a/packetbeat/docs/faq.asciidoc
+++ b/packetbeat/docs/faq.asciidoc
@@ -31,10 +31,12 @@ Packetbeat is unable to capture traffic from the loopback device (127.0.0.1 traf
 because the Windows TCP/IP stack does not implement a network loopback interface,
 making it difficult for Windows packet capture drivers like WinPcap to sniff traffic.
 
-As a workaround, you can try installing https://github.com/nmap/npcap/releases[Npcap],
-an update of WinPcap. Make sure that you restart Windows after installing Npcap.
-Npcap creates an Npcap Loopback Adapter that you can select if you want to capture
-loopback traffic.
+As a workaround, you can try installing
+https://github.com/nmap/npcap/releases[Npcap], an update of WinPcap. Make sure
+you install Npcap in WinPcap API-compatible mode (`/winpcap_mode=yes`), or
+{beatname_uc} will be unable to find the required DLLs. After installing Npcap,
+restart Windows. Npcap creates an Npcap Loopback Adapter that you can select if
+you want to capture loopback traffic.
 
 For the list of devices shown here, you would configure Packetbeat
 to use device `4`:


### PR DESCRIPTION
It looks like the latest release of Npcap installs in WinPcap API-compatible mode by default, so maybe this is no longer necessary? At any rate, doesn't hurt to add it to the docs.

Sorry it's taken me so long to add this. :-/

Closes issue #4364
