### PR TITLE
Document modules SSL parameters

### DIFF
--- a/metricbeat/docs/modules/apache.asciidoc
+++ b/metricbeat/docs/modules/apache.asciidoc
@@ -40,6 +40,8 @@ metricbeat.modules:
   hosts: ["http://127.0.0.1"]
 ----
 
+This module supports TLS connection when using `ssl` config field, as described in <<configuration-ssl>>.
+
 [float]
 === Metricsets
 

--- a/metricbeat/docs/modules/ceph.asciidoc
+++ b/metricbeat/docs/modules/ceph.asciidoc
@@ -26,6 +26,8 @@ metricbeat.modules:
   hosts: ["localhost:5000"]
 ----
 
+This module supports TLS connection when using `ssl` config field, as described in <<configuration-ssl>>.
+
 [float]
 === Metricsets
 

--- a/metricbeat/docs/modules/couchbase.asciidoc
+++ b/metricbeat/docs/modules/couchbase.asciidoc
@@ -26,6 +26,8 @@ metricbeat.modules:
   hosts: ["localhost:8091"]
 ----
 
+This module supports TLS connection when using `ssl` config field, as described in <<configuration-ssl>>.
+
 [float]
 === Metricsets
 

--- a/metricbeat/docs/modules/dropwizard.asciidoc
+++ b/metricbeat/docs/modules/dropwizard.asciidoc
@@ -28,6 +28,8 @@ metricbeat.modules:
   namespace: example
 ----
 
+This module supports TLS connection when using `ssl` config field, as described in <<configuration-ssl>>.
+
 [float]
 === Metricsets
 

--- a/metricbeat/docs/modules/elasticsearch.asciidoc
+++ b/metricbeat/docs/modules/elasticsearch.asciidoc
@@ -25,6 +25,8 @@ metricbeat.modules:
   hosts: ["localhost:9200"]
 ----
 
+This module supports TLS connection when using `ssl` config field, as described in <<configuration-ssl>>.
+
 [float]
 === Metricsets
 

--- a/metricbeat/docs/modules/etcd.asciidoc
+++ b/metricbeat/docs/modules/etcd.asciidoc
@@ -28,6 +28,8 @@ metricbeat.modules:
 
 ----
 
+This module supports TLS connection when using `ssl` config field, as described in <<configuration-ssl>>.
+
 [float]
 === Metricsets
 

--- a/metricbeat/docs/modules/golang.asciidoc
+++ b/metricbeat/docs/modules/golang.asciidoc
@@ -29,6 +29,8 @@ metricbeat.modules:
     path: "/debug/vars"
 ----
 
+This module supports TLS connection when using `ssl` config field, as described in <<configuration-ssl>>.
+
 [float]
 === Metricsets
 

--- a/metricbeat/docs/modules/http.asciidoc
+++ b/metricbeat/docs/modules/http.asciidoc
@@ -50,6 +50,8 @@ metricbeat.modules:
 #        key: "value"
 ----
 
+This module supports TLS connection when using `ssl` config field, as described in <<configuration-ssl>>.
+
 [float]
 === Metricsets
 

--- a/metricbeat/docs/modules/jolokia.asciidoc
+++ b/metricbeat/docs/modules/jolokia.asciidoc
@@ -31,6 +31,8 @@ metricbeat.modules:
   jmx.instance:
 ----
 
+This module supports TLS connection when using `ssl` config field, as described in <<configuration-ssl>>.
+
 [float]
 === Metricsets
 

--- a/metricbeat/docs/modules/kibana.asciidoc
+++ b/metricbeat/docs/modules/kibana.asciidoc
@@ -25,6 +25,8 @@ metricbeat.modules:
   hosts: ["localhost:5601"]
 ----
 
+This module supports TLS connection when using `ssl` config field, as described in <<configuration-ssl>>.
+
 [float]
 === Metricsets
 

--- a/metricbeat/docs/modules/kubernetes.asciidoc
+++ b/metricbeat/docs/modules/kubernetes.asciidoc
@@ -54,6 +54,8 @@ metricbeat.modules:
     - event
 ----
 
+This module supports TLS connection when using `ssl` config field, as described in <<configuration-ssl>>.
+
 [float]
 === Metricsets
 

--- a/metricbeat/docs/modules/logstash.asciidoc
+++ b/metricbeat/docs/modules/logstash.asciidoc
@@ -28,6 +28,8 @@ metricbeat.modules:
 
 ----
 
+This module supports TLS connection when using `ssl` config field, as described in <<configuration-ssl>>.
+
 [float]
 === Metricsets
 

--- a/metricbeat/docs/modules/nginx.asciidoc
+++ b/metricbeat/docs/modules/nginx.asciidoc
@@ -35,6 +35,8 @@ metricbeat.modules:
   #server_status_path: "server-status"
 ----
 
+This module supports TLS connection when using `ssl` config field, as described in <<configuration-ssl>>.
+
 [float]
 === Metricsets
 

--- a/metricbeat/docs/modules/php_fpm.asciidoc
+++ b/metricbeat/docs/modules/php_fpm.asciidoc
@@ -54,6 +54,8 @@ metricbeat.modules:
   hosts: ["localhost:8080"]
 ----
 
+This module supports TLS connection when using `ssl` config field, as described in <<configuration-ssl>>.
+
 [float]
 === Metricsets
 

--- a/metricbeat/docs/modules/prometheus.asciidoc
+++ b/metricbeat/docs/modules/prometheus.asciidoc
@@ -28,6 +28,8 @@ metricbeat.modules:
   #namespace: example
 ----
 
+This module supports TLS connection when using `ssl` config field, as described in <<configuration-ssl>>.
+
 [float]
 === Metricsets
 

--- a/metricbeat/docs/modules/rabbitmq.asciidoc
+++ b/metricbeat/docs/modules/rabbitmq.asciidoc
@@ -29,6 +29,8 @@ metricbeat.modules:
   password: guest
 ----
 
+This module supports TLS connection when using `ssl` config field, as described in <<configuration-ssl>>.
+
 [float]
 === Metricsets
 

--- a/metricbeat/module/apache/_meta/fields.yml
+++ b/metricbeat/module/apache/_meta/fields.yml
@@ -4,6 +4,7 @@
     Apache HTTPD server metricsets collected from the Apache web server.
   short_config: false
   release: ga
+  settings: ["ssl"]
   fields:
     - name: apache
       type: group

--- a/metricbeat/module/ceph/_meta/fields.yml
+++ b/metricbeat/module/ceph/_meta/fields.yml
@@ -4,6 +4,7 @@
     Ceph module
   short_config: false
   release: beta
+  settings: ["ssl"]
   fields:
     - name: ceph
       type: group

--- a/metricbeat/module/couchbase/_meta/fields.yml
+++ b/metricbeat/module/couchbase/_meta/fields.yml
@@ -4,6 +4,7 @@
     Metrics collected from Couchbase servers.
   short_config: false
   release: beta
+  settings: ["ssl"]
   fields:
     - name: couchbase
       type: group

--- a/metricbeat/module/dropwizard/_meta/fields.yml
+++ b/metricbeat/module/dropwizard/_meta/fields.yml
@@ -3,6 +3,7 @@
   description: >
     Stats collected from Dropwizard.
   release: beta
+  settings: ["ssl"]
   short_config: false
   fields:
     - name: dropwizard

--- a/metricbeat/module/elasticsearch/_meta/fields.yml
+++ b/metricbeat/module/elasticsearch/_meta/fields.yml
@@ -3,6 +3,7 @@
   description: >
     Elasticsearch module
   release: beta
+  settings: ["ssl"]
   short_config: false
   fields:
     - name: elasticsearch

--- a/metricbeat/module/etcd/_meta/fields.yml
+++ b/metricbeat/module/etcd/_meta/fields.yml
@@ -3,6 +3,7 @@
   description: >
     etcd Module
   release: beta
+  settings: ["ssl"]
   fields:
     - name: etcd
       type: group

--- a/metricbeat/module/golang/_meta/fields.yml
+++ b/metricbeat/module/golang/_meta/fields.yml
@@ -4,6 +4,7 @@
     Golang module
   short_config: false
   release: experimental
+  settings: ["ssl"]
   fields:
     - name: golang
       type: group

--- a/metricbeat/module/http/_meta/fields.yml
+++ b/metricbeat/module/http/_meta/fields.yml
@@ -3,6 +3,7 @@
   description: >
     HTTP module
   release: beta
+  settings: ["ssl"]
   fields:
     - name: http
       type: group

--- a/metricbeat/module/jolokia/_meta/fields.yml
+++ b/metricbeat/module/jolokia/_meta/fields.yml
@@ -4,6 +4,7 @@
     Jolokia module
   short_config: false
   release: beta
+  settings: ["ssl"]
   fields:
     - name: jolokia
       type: group

--- a/metricbeat/module/kibana/_meta/fields.yml
+++ b/metricbeat/module/kibana/_meta/fields.yml
@@ -4,6 +4,7 @@
     Kibana module
   short_config: false
   release: beta
+  settings: ["ssl"]
   fields:
     - name: kibana
       type: group

--- a/metricbeat/module/kubernetes/_meta/fields.yml
+++ b/metricbeat/module/kubernetes/_meta/fields.yml
@@ -3,6 +3,7 @@
   description: >
     Kubernetes metrics
   release: beta
+  settings: ["ssl"]
   short_config: false
   fields:
     - name: kubernetes

--- a/metricbeat/module/logstash/_meta/fields.yml
+++ b/metricbeat/module/logstash/_meta/fields.yml
@@ -3,10 +3,9 @@
   description: >
     Logstash module
   release: experimental
+  settings: ["ssl"]
   fields:
     - name: logstash
       type: group
       description: >
       fields:
-
-

--- a/metricbeat/module/nginx/_meta/fields.yml
+++ b/metricbeat/module/nginx/_meta/fields.yml
@@ -4,6 +4,7 @@
     Nginx server status metrics collected from various modules.
   short_config: false
   release: ga
+  settings: ["ssl"]
   fields:
     - name: nginx
       type: group

--- a/metricbeat/module/php_fpm/_meta/fields.yml
+++ b/metricbeat/module/php_fpm/_meta/fields.yml
@@ -6,6 +6,7 @@
     PHP-FPM server status metrics collected from PHP-FPM.
   short_config: false
   release: beta
+  settings: ["ssl"]
   fields:
     - name: php_fpm
       type: group

--- a/metricbeat/module/prometheus/_meta/fields.yml
+++ b/metricbeat/module/prometheus/_meta/fields.yml
@@ -4,6 +4,7 @@
     Stats collected from Prometheus.
   short_config: false
   release: beta
+  settings: ["ssl"]
   fields:
     - name: prometheus
       type: group

--- a/metricbeat/module/rabbitmq/_meta/fields.yml
+++ b/metricbeat/module/rabbitmq/_meta/fields.yml
@@ -3,6 +3,7 @@
   description: >
     RabbitMQ module
   release: beta
+  settings: ["ssl"]
   fields:
     - name: rabbitmq
       type: group

--- a/metricbeat/scripts/docs_collector.py
+++ b/metricbeat/scripts/docs_collector.py
@@ -83,6 +83,10 @@ in <<configuration-metricbeat>>. Here is an example configuration:
 
             module_file += "----\n\n"
 
+        # HTTP helper
+        if 'ssl' in get_settings(module_fields):
+            module_file += "This module supports TLS connection when using `ssl` config field, as described in <<configuration-ssl>>.\n\n"
+
         # Add metricsets title as below each metricset adds its link
         module_file += "[float]\n"
         module_file += "=== Metricsets\n\n"
@@ -208,7 +212,6 @@ For a description of each field in the metricset, see the
 
 
 def get_release(fields):
-
     # Fetch release flag from fields. Default if not set is experimental
     release = "experimental"
     if "release" in fields:
@@ -217,6 +220,11 @@ def get_release(fields):
             raise Exception("Invalid release config: {}".format(release))
 
     return release
+
+
+def get_settings(fields):
+    # Get the list of common settings flags
+    return fields.get('settings', [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds a pointer to SSL settings doc to all modules that support it, it's defined in module `fields.yml` file. I kept space for future common settings parameters, just in case we add something after SSL.

Closes #5827 
Closes #4268