### PR TITLE
Exclude stress test on Windows as it currently breaks the build

### DIFF
--- a/libbeat/scripts/cmd/stress_pipeline/main.go
+++ b/libbeat/scripts/cmd/stress_pipeline/main.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package main
 
 import (


### PR DESCRIPTION
As on Windows currently all packages are included for testing, the -E flag is discovered twice. This excludes the stress_pipeline file to bring the builds / tests back to green. Windows tests should also use specific packages https://github.com/elastic/beats/blob/master/dev-tools/jenkins_ci.ps1#L55 This is mainly a temporary fix.