### PR TITLE
document_type is deprecated

### DIFF
--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -556,7 +556,7 @@ output.kafka:
   hosts: ["kafka1:9092", "kafka2:9092", "kafka3:9092"]
 
   # message topic selection + partitioning
-  topic: '%{[type]}'
+  topic: '%{[kafka_topic]}'
   partition.round_robin:
     reachable_only: false
 
@@ -608,7 +608,7 @@ The password for connecting to Kafka.
 ===== `topic`
 
 The Kafka topic used for produced events. The setting can be a format string
-using any event field. To set the topic from document type use `%{[type]}`.
+using any event field. You can create a custom field in the prospector with `fields_under_root: true` and reference back to it here.
 
 ===== `topics`
 


### PR DESCRIPTION
As written in https://www.elastic.co/guide/en/beats/libbeat/6.0/breaking-changes-6.0.html#breaking-changes-types , the document_type is gone. This works:

    filebeat.prospectors:
    - type: log
      paths:
      - /var/log/log1.log
      fields:
        kafka_topic: elk1
      fields_under_root: true
    - type: log
      paths:
      - /var/log/log2.log
      fields:
        kafka_topic: elk2
      fields_under_root: true
    output.kafka:
      hosts: ["kafka1:9092", "kafka2:9092", "kafka3:9092"]
      topic: '%{[kafka_topic]}'