### PR TITLE
filebeat: Add vhost fields to apache2 module.

### DIFF
--- a/filebeat/docs/fields.asciidoc
+++ b/filebeat/docs/fields.asciidoc
@@ -52,6 +52,29 @@ Contains fields for the Apache2 HTTPD access logs.
 
 
 [float]
+== vhost fields
+
+Contains the parsed Virtual Host.
+
+
+
+[float]
+=== `apache2.access.vhost.name`
+
+type: keyword
+
+Virtual Host name.
+
+
+[float]
+=== `apache2.access.vhost.port`
+
+type: long
+
+Virtual Host port.
+
+
+[float]
 === `apache2.access.remote_ip`
 
 type: keyword

--- a/filebeat/module/apache2/access/_meta/fields.yml
+++ b/filebeat/module/apache2/access/_meta/fields.yml
@@ -3,6 +3,19 @@
   description: >
     Contains fields for the Apache2 HTTPD access logs.
   fields:
+    - name: vhost
+      type: group
+      description: >
+        Contains the parsed Virtual Host.
+      fields:
+        - name: name
+          type: keyword
+          description: >
+            Virtual Host name.
+        - name: port
+          type: long
+          description: >
+            Virtual Host port.
     - name: remote_ip
       type: keyword
       description: >

--- a/filebeat/module/apache2/access/ingest/default.json
+++ b/filebeat/module/apache2/access/ingest/default.json
@@ -4,7 +4,7 @@
     "grok": {
       "field": "message",
       "patterns":[
-        "%{IPORHOST:apache2.access.remote_ip} - %{DATA:apache2.access.user_name} \\[%{HTTPDATE:apache2.access.time}\\] \"%{WORD:apache2.access.method} %{DATA:apache2.access.url} HTTP/%{NUMBER:apache2.access.http_version}\" %{NUMBER:apache2.access.response_code} (?:%{NUMBER:apache2.access.body_sent.bytes}|-)( \"%{DATA:apache2.access.referrer}\")?( \"%{DATA:apache2.access.agent}\")?",
+        "(%{HOSTNAME:apache2.access.vhost.name}:%{POSINT:apache2.access.vhost.port} )?%{IPORHOST:apache2.access.remote_ip} - %{DATA:apache2.access.user_name} \\[%{HTTPDATE:apache2.access.time}\\] \"%{WORD:apache2.access.method} %{DATA:apache2.access.url} HTTP/%{NUMBER:apache2.access.http_version}\" %{NUMBER:apache2.access.response_code} (?:%{NUMBER:apache2.access.body_sent.bytes}|-)( \"%{DATA:apache2.access.referrer}\")?( \"%{DATA:apache2.access.agent}\")?",
         "%{IPORHOST:apache2.access.remote_ip} - %{DATA:apache2.access.user_name} \\[%{HTTPDATE:apache2.access.time}\\] \"-\" %{NUMBER:apache2.access.response_code} -"
         ],
       "ignore_missing": true


### PR DESCRIPTION
Fixes #4859 by adding two fields for the vhost part of a vhost_combined apache2 access log.

On recently installed apache 2.4 on Debian, this is the predefined log format for vhosts:

```
LogFormat "%v:%p %h %l %u %t \"%r\" %>s %O \"%{Referer}i\" \"%{User-Agent}i\"" vhost_combined
```

This change extracts the %v:%p part at the beginning.

I tried to add some test log in the `filebeat/module/apache2/access/test/` folder, but I do not seem to get it tested. And the integration test fails on some other error. Not linked to this change as far as I can tell.

/cc @ruflin 