### PR TITLE
Move the "Starting udp prospector" in the start branch

### DIFF
--- a/filebeat/prospector/udp/prospector.go
+++ b/filebeat/prospector/udp/prospector.go
@@ -39,9 +39,8 @@ func NewProspector(cfg *common.Config, outlet channel.Factory, context prospecto
 }
 
 func (p *Prospector) Run() {
-	logp.Info("Starting udp prospector")
-
 	if !p.started {
+		logp.Info("Starting udp prospector")
 		p.started = true
 		go func() {
 			defer p.outlet.Close()


### PR DESCRIPTION
Instead of logging at the top level of the run method we should log
inside the branch where we start, if we don't do this the
message will be logged every time the Run()'s tick happen making this
prospector quite noisy.

This was discovered when working on https://github.com/elastic/beats/issues/5862