### PR TITLE
Update vendored fsevents to use elastic fork

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -443,7 +443,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 --------------------------------------------------------------------
 Dependency: github.com/fsnotify/fsevents
-Revision: 3ceee05210c3babaa38cdc9181dabdcc83076a44
+Revision: 690cb784149d5facd7fe613c52757445c43afcde
 License type (autodetected): BSD-3-Clause
 ./vendor/github.com/fsnotify/fsevents/LICENSE:
 --------------------------------------------------------------------

--- a/vendor/github.com/fsnotify/fsevents/fsevents.go
+++ b/vendor/github.com/fsnotify/fsevents/fsevents.go
@@ -150,16 +150,18 @@ func (r *eventStreamRegistry) Delete(i uintptr) {
 
 // Start listening to an event stream.
 func (es *EventStream) Start() {
+	if es.Events == nil {
+		es.Events = make(chan []Event)
+	}
 
 	// register eventstream in the local registry for later lookup
 	// in C callback
 	cbInfo := registry.Add(es)
 	es.registryID = cbInfo
-	es.uuid = GetDeviceUUID(es.Device)
-	es.start(es.Paths, cbInfo)
-	if es.Events == nil {
-		es.Events = make(chan []Event)
+	if es.Device != 0 {
+		es.uuid = GetDeviceUUID(es.Device)
 	}
+	es.start(es.Paths, cbInfo)
 }
 
 // Flush events that have occurred but haven't been delivered.

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -705,10 +705,12 @@
 			"versionExact": "v1.5.0"
 		},
 		{
-			"checksumSHA1": "LI9vdJJ/cOBwVI4y/8NIWp2nW4U=",
+			"checksumSHA1": "dgmdG37hn1qma1kdpCaUJ6JltXk=",
+			"origin": "github.com/elastic/fsevents",
 			"path": "github.com/fsnotify/fsevents",
-			"revision": "3ceee05210c3babaa38cdc9181dabdcc83076a44",
-			"revisionTime": "2017-03-31T13:51:01Z"
+			"revision": "690cb784149d5facd7fe613c52757445c43afcde",
+			"revisionTime": "2017-12-04T13:54:51Z",
+			"tree": true
 		},
 		{
 			"checksumSHA1": "x2Km0Qy3WgJJnV19Zv25VwTJcBM=",


### PR DESCRIPTION
This PR makes vendored fsvents to use the changes in our fork while keeping the same import path.
