### PR TITLE
Remove references to [type] field

### DIFF
--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -564,7 +564,7 @@ output.kafka:
   hosts: ["kafka1:9092", "kafka2:9092", "kafka3:9092"]
 
   # message topic selection + partitioning
-  topic: '%{[type]}'
+  topic: '%{[fields.log_topic]}'
   partition.round_robin:
     reachable_only: false
 
@@ -616,7 +616,16 @@ The password for connecting to Kafka.
 ===== `topic`
 
 The Kafka topic used for produced events. The setting can be a format string
-using any event field. To set the topic from document type use `%{[type]}`.
+using any event field. For example, you can use the
+<<libbeat-configuration-fields,`fields`>> configuration option to add a custom
+field called `log_topic` to the event, and then set `topic` to the value of the
+custom field:
+
+[source,yaml]
+-----
+topic: '%{[fields.log_topic]}'
+-----
+
 
 ===== `topics`
 
@@ -851,7 +860,7 @@ output.redis:
     - key: "debug_list"  # send to debug_list if `message` field contains DEBUG
       when.contains:
         message: "DEBUG"
-    - key: "%{[type]}"
+    - key: "%{[fields.list]}"
       mapping:
         "http": "frontend_list"
         "nginx": "frontend_list"


### PR DESCRIPTION
We missed these references when we removed the type field in 6.0.

A user noticed and mentioned the problem here: https://discuss.elastic.co/t/conditional-topics-not-work-since-document-type-is-deprecated-how-to-use-type-in-kafka-ouput/109499/2