### PR TITLE
TLS certificates include public key size

### DIFF
--- a/packetbeat/_meta/fields.yml
+++ b/packetbeat/_meta/fields.yml
@@ -1882,6 +1882,10 @@
                 The algorithm used for this certificate's public key.
                 One of RSA, DSA or ECDSA.
 
+            - name: public_key_size
+              type: long
+              description: Size of the public key.
+
             - name: signature_algorithm
               type: keyword
               description: >
@@ -1970,6 +1974,10 @@
               description: >
                 The algorithm used for this certificate's public key.
                 One of RSA, DSA or ECDSA.
+
+            - name: public_key_size
+              type: long
+              description: Size of the public key.
 
             - name: signature_algorithm
               type: keyword

--- a/packetbeat/docs/fields.asciidoc
+++ b/packetbeat/docs/fields.asciidoc
@@ -2920,6 +2920,13 @@ The algorithm used for this certificate's public key. One of RSA, DSA or ECDSA.
 
 
 [float]
+=== `tls.client_certificate.public_key_size`
+
+type: long
+
+Size of the public key.
+
+[float]
 === `tls.client_certificate.signature_algorithm`
 
 type: keyword
@@ -3064,6 +3071,13 @@ type: keyword
 
 The algorithm used for this certificate's public key. One of RSA, DSA or ECDSA.
 
+
+[float]
+=== `tls.server_certificate.public_key_size`
+
+type: long
+
+Size of the public key.
 
 [float]
 === `tls.server_certificate.signature_algorithm`

--- a/packetbeat/protos/tls/_meta/fields.yml
+++ b/packetbeat/protos/tls/_meta/fields.yml
@@ -132,6 +132,10 @@
                 The algorithm used for this certificate's public key.
                 One of RSA, DSA or ECDSA.
 
+            - name: public_key_size
+              type: long
+              description: Size of the public key.
+
             - name: signature_algorithm
               type: keyword
               description: >
@@ -220,6 +224,10 @@
               description: >
                 The algorithm used for this certificate's public key.
                 One of RSA, DSA or ECDSA.
+
+            - name: public_key_size
+              type: long
+              description: Size of the public key.
 
             - name: signature_algorithm
               type: keyword

--- a/packetbeat/protos/tls/parse_test.go
+++ b/packetbeat/protos/tls/parse_test.go
@@ -292,6 +292,7 @@ func TestCertificates(t *testing.T) {
 		"not_after":                   "2018-11-28 12:00:00 +0000 UTC",
 		"not_before":                  "2015-11-03 00:00:00 +0000 UTC",
 		"public_key_algorithm":        "RSA",
+		"public_key_size":             "2048",
 		"serial_number":               "19132437207909210467858529073412672688",
 		"signature_algorithm":         "SHA256-RSA",
 		"version":                     "3",


### PR DESCRIPTION
This adds a `public_key_size` entry to certificates that contains
the number of bits in the public key. RSA, DSA and ECDSA public keys
are supported. The value of this field is zero if the key size
cannot be determined.

Closes  #5804