### PR TITLE
Reformat module docs

### DIFF
--- a/filebeat/docs/modules/kafka.asciidoc
+++ b/filebeat/docs/modules/kafka.asciidoc
@@ -69,10 +69,10 @@ include::../include/config-option-intro.asciidoc[]
 // REVIEWERS: I've added a description because this variable appears in the
 // kafka.yml file. However, I don't understand how it works.
 
-*`var.kafka_home`*::
+//*`var.kafka_home`*::
 
-The home path for Kafka. If this variable is not set,  {beatname_uc} looks under
-`/opt`.
+//The home path for Kafka. If this variable is not set,  {beatname_uc} looks under
+//`/opt`.
 
 include::../include/var-paths.asciidoc[]
 

--- a/filebeat/docs/modules/kafka.asciidoc
+++ b/filebeat/docs/modules/kafka.asciidoc
@@ -47,21 +47,16 @@ file to override the default paths for logs:
 
 // REVIEWERS: I must be doing something wrong with the config settings. The
 // above config works, but when I try to specify var.kafka_home, it doesn't
-// seem to have any effect. I can't seem to specify var.paths from the command
-// line either. Can someone please provide the correct config for the
-// above example plus the correct command to issue to run the moduel and
-// set var.paths correctly?
+// seem to have any effect. 
 
 
 To specify the same settings at the command line, you use:
 
 ["source","sh",subs="attributes"]
 -----
-./{beatname_lc} -M "kafka.log.var.paths=
+./{beatname_lc} --modules {modulename} -M "kafka.log.var.paths=[/path/to/logs/controller.log*, /path/to/logs/server.log*, /path/to/logs/state-change.log*, /path/to/logs/kafka-*.log*]"
 -----
 
-
-The command in the example assumes that you have already enabled the +{modulename}+ module. 
 
 //set the fileset name used in the included example
 :fileset_ex: log

--- a/filebeat/docs/modules/kafka.asciidoc
+++ b/filebeat/docs/modules/kafka.asciidoc
@@ -3,30 +3,83 @@ This file is generated! See scripts/docs_collector.py
 ////
 
 [[filebeat-module-kafka]]
+:modulename: kafka
+
 == Kafka module
 
-This module collects and parses the logs created by https://kafka.apache.org/[Kafka].
+The +{modulename}+ module collects and parses the logs created by
+https://kafka.apache.org/[Kafka].
+
+include::../include/what-happens.asciidoc[]
 
 [float]
 === Compatibility
 
-The Kafka module was tested with logs from versions 2.11.
+The +{modulename}+ module was tested with logs from versions 2.11.
+
+include::../include/running-modules.asciidoc[]
 
 [float]
-=== Dashboard
+=== Example dashboard
 
-This module comes with a sample dashboard to see Kafka logs and stacktraces.
+This module comes with a sample dashboard to see Kafka logs and stack traces.
 
+[role="screenshot"]
 image::./images/filebeat-kafka-logs-overview.png[]
 
-[float]
-=== Logs fileset settings
+include::../include/configuring-intro.asciidoc[]
+
+The following example shows how to set paths in the +modules.d/{modulename}.yml+
+file to override the default paths for logs:
+
+["source","yaml",subs="attributes"]
+-----
+- module: kafka
+  log:
+    enabled: true
+    var.paths:
+      - "/path/to/logs/controller.log*"
+      - "/path/to/logs/server.log*"
+      - "/path/to/logs/state-change.log*"
+      - "/path/to/logs/kafka-*.log*"
+-----
+
+
+// REVIEWERS: I must be doing something wrong with the config settings. The
+// above config works, but when I try to specify var.kafka_home, it doesn't
+// seem to have any effect. I can't seem to specify var.paths from the command
+// line either. Can someone please provide the correct config for the
+// above example plus the correct command to issue to run the moduel and
+// set var.paths correctly?
+
+
+To specify the same settings at the command line, you use:
+
+["source","sh",subs="attributes"]
+-----
+./{beatname_lc} -M "kafka.log.var.paths=
+-----
+
+
+The command in the example assumes that you have already enabled the +{modulename}+ module. 
+
+//set the fileset name used in the included example
+:fileset_ex: log
+
+include::../include/config-option-intro.asciidoc[]
 
 [float]
-==== var.paths
+==== `log` fileset settings
 
-An array of paths where to look for the log files. If left empty, Filebeat
-will choose the paths depending on your operating systems.
+// REVIEWERS: I've added a description because this variable appears in the
+// kafka.yml file. However, I don't understand how it works.
+
+*`var.kafka_home`*::
+
+The home path for Kafka. If this variable is not set,  {beatname_uc} looks under
+`/opt`.
+
+include::../include/var-paths.asciidoc[]
 
 
 [float]

--- a/filebeat/docs/modules/logstash.asciidoc
+++ b/filebeat/docs/modules/logstash.asciidoc
@@ -4,7 +4,7 @@ This file is generated! See scripts/docs_collector.py
 
 [[filebeat-module-logstash]]
 :modulename: logstash
-== logstash module
+== Logstash module
 
 The +{modulename}+ module parse logstash regular logs and the slow log, it will support the plain text format
 and the JSON format (--log.format json). The default is the plain text format.
@@ -13,12 +13,12 @@ include::../include/what-happens.asciidoc[]
 
 The +{modulename}+ module has two filesets:
 
-* The `log` fileset collects and parses the logs that logstash writes to disk.
+* The `log` fileset collects and parses the logs that Logstash writes to disk.
 * The `slowlog` fileset parses the logstash slowlog.
 
 
-For the `slowlog` fileset, make sure to configure logstash slowlog option
-link:https://www.elastic.co/guide/en/logstash/current/logging.html#_slowlog
+For the `slowlog` fileset, make sure to configure the
+{logstashdoc}/logging.html#_slowlog[Logstash slowlog option].
 
 [float]
 === Compatibility
@@ -30,11 +30,14 @@ The Logstash `slowlog` fileset was tested with logs from Logstash 5.6 and 6.0
 include::../include/running-modules.asciidoc[]
 
 [float]
-===  This module comes with a two sample dashboard
+===  Example dashboards
+
+This module comes with two sample dashboards.
 
 [role="screenshot"]
 image::./images/kibana-logstash-log.png[]
 
+[role="screenshot"]
 image::./images/kibana-logstash-slowlog.png[]
 
 include::../include/configuring-intro.asciidoc[]
@@ -78,7 +81,8 @@ include::../include/var-paths.asciidoc[]
 
 *`var.format`*::
 
-The configured Logstash log format, possible values are: `json` or `plain`, by default it will use the `plain` format.
+The configured Logstash log format. Possible values are: `json` or `plain`. The
+default is `plain`.
 
 [float]
 ==== `slowlog` fileset settings
@@ -87,7 +91,8 @@ include::../include/var-paths.asciidoc[]
 
 *`var.format`*::
 
-The configured Logstash log format, possible values are: `json` or `plain`, by default it will use the `plain` format.
+The configured Logstash log format. Possible values are: `json` or `plain`. The
+default is `plain`.
 
 
 [float]

--- a/filebeat/docs/modules/logstash.asciidoc
+++ b/filebeat/docs/modules/logstash.asciidoc
@@ -66,8 +66,6 @@ To specify the same settings at the command line, you use:
 -----
 
 
-
-
 //set the fileset name used in the included example
 :fileset_ex: log
 

--- a/filebeat/docs/modules/postgresql.asciidoc
+++ b/filebeat/docs/modules/postgresql.asciidoc
@@ -54,11 +54,9 @@ To specify the same settings at the command line, you use:
 
 ["source","sh",subs="attributes"]
 -----
-./{beatname_lc} -M "postgresql.log.var.paths=[/path/to/log/postgres/*.log*]"
+./{beatname_lc} --modules {modulename} -M "postgresql.log.var.paths=[/path/to/log/postgres/*.log*]"
 -----
 
-
-The command in the example assumes that you have already enabled the +{modulename}+ module.
 
 //set the fileset name used in the included example
 :fileset_ex: log

--- a/filebeat/docs/modules/postgresql.asciidoc
+++ b/filebeat/docs/modules/postgresql.asciidoc
@@ -3,36 +3,73 @@ This file is generated! See scripts/docs_collector.py
 ////
 
 [[filebeat-module-postgresql]]
+:modulename: postgresql
+
 == PostgreSQL module
 
-This module collects and parses the logs created by https://www.postgresql.org/[PostgreSQL].
+The +{modulename}+ module  collects and parses logs created by
+https://www.postgresql.org/[PostgreSQL].
+
+include::../include/what-happens.asciidoc[]
 
 [float]
 === Compatibility
 
-The PostgreSQL module was tested with logs from versions 9.5 on Ubuntu and 9.6 on Debian.
+The +{modulename}+ module was tested with logs from versions 9.5 on Ubuntu and 9.6
+on Debian.
+
+include::../include/running-modules.asciidoc[]
 
 [float]
-=== Dashboard
+=== Example dashboards
 
 This module comes with two sample dashboards.
 
-The first dashboard is for regulars logs.
+The first dashboard is for regular logs.
 
+[role="screenshot"]
 image::./images/filebeat-postgresql-overview.png[]
 
 The second one shows the slowlogs of PostgreSQL.
 
+[role="screenshot"]
 image::./images/filebeat-postgresql-slowlog-overview.png[]
 
-[float]
-=== Logs fileset settings
+include::../include/configuring-intro.asciidoc[]
+
+The following example shows how to set paths in the +modules.d/{modulename}.yml+
+file to override the default paths for PostgreSQL logs:
+
+
+["source","yaml",subs="attributes"]
+-----
+- module: postgresql
+  log:
+    enabled: true
+    var.paths: ["/path/to/log/postgres/*.log*"]
+-----
+
+
+To specify the same settings at the command line, you use:
+
+["source","sh",subs="attributes"]
+-----
+./{beatname_lc} -M "postgresql.log.var.paths=[/path/to/log/postgres/*.log*]"
+-----
+
+
+The command in the example assumes that you have already enabled the +{modulename}+ module.
+
+//set the fileset name used in the included example
+:fileset_ex: log
+
+include::../include/config-option-intro.asciidoc[]
 
 [float]
-==== var.paths
+==== `log` fileset settings
 
-An array of paths where to look for the log files. If left empty, Filebeat
-will choose the paths depending on your operating systems.
+include::../include/var-paths.asciidoc[]
+
 
 
 [float]

--- a/filebeat/module/kafka/_meta/docs.asciidoc
+++ b/filebeat/module/kafka/_meta/docs.asciidoc
@@ -42,21 +42,16 @@ file to override the default paths for logs:
 
 // REVIEWERS: I must be doing something wrong with the config settings. The
 // above config works, but when I try to specify var.kafka_home, it doesn't
-// seem to have any effect. I can't seem to specify var.paths from the command
-// line either. Can someone please provide the correct config for the
-// above example plus the correct command to issue to run the moduel and
-// set var.paths correctly?
+// seem to have any effect. 
 
 
 To specify the same settings at the command line, you use:
 
 ["source","sh",subs="attributes"]
 -----
-./{beatname_lc} -M "kafka.log.var.paths=
+./{beatname_lc} --modules {modulename} -M "kafka.log.var.paths=[/path/to/logs/controller.log*, /path/to/logs/server.log*, /path/to/logs/state-change.log*, /path/to/logs/kafka-*.log*]"
 -----
 
-
-The command in the example assumes that you have already enabled the +{modulename}+ module. 
 
 //set the fileset name used in the included example
 :fileset_ex: log

--- a/filebeat/module/kafka/_meta/docs.asciidoc
+++ b/filebeat/module/kafka/_meta/docs.asciidoc
@@ -64,9 +64,9 @@ include::../include/config-option-intro.asciidoc[]
 // REVIEWERS: I've added a description because this variable appears in the
 // kafka.yml file. However, I don't understand how it works.
 
-*`var.kafka_home`*::
+//*`var.kafka_home`*::
 
-The home path for Kafka. If this variable is not set,  {beatname_uc} looks under
-`/opt`.
+//The home path for Kafka. If this variable is not set,  {beatname_uc} looks under
+//`/opt`.
 
 include::../include/var-paths.asciidoc[]

--- a/filebeat/module/kafka/_meta/docs.asciidoc
+++ b/filebeat/module/kafka/_meta/docs.asciidoc
@@ -1,24 +1,77 @@
+:modulename: kafka
+
 == Kafka module
 
-This module collects and parses the logs created by https://kafka.apache.org/[Kafka].
+The +{modulename}+ module collects and parses the logs created by
+https://kafka.apache.org/[Kafka].
+
+include::../include/what-happens.asciidoc[]
 
 [float]
 === Compatibility
 
-The Kafka module was tested with logs from versions 2.11.
+The +{modulename}+ module was tested with logs from versions 2.11.
+
+include::../include/running-modules.asciidoc[]
 
 [float]
-=== Dashboard
+=== Example dashboard
 
-This module comes with a sample dashboard to see Kafka logs and stacktraces.
+This module comes with a sample dashboard to see Kafka logs and stack traces.
 
+[role="screenshot"]
 image::./images/filebeat-kafka-logs-overview.png[]
 
-[float]
-=== Logs fileset settings
+include::../include/configuring-intro.asciidoc[]
+
+The following example shows how to set paths in the +modules.d/{modulename}.yml+
+file to override the default paths for logs:
+
+["source","yaml",subs="attributes"]
+-----
+- module: kafka
+  log:
+    enabled: true
+    var.paths:
+      - "/path/to/logs/controller.log*"
+      - "/path/to/logs/server.log*"
+      - "/path/to/logs/state-change.log*"
+      - "/path/to/logs/kafka-*.log*"
+-----
+
+
+// REVIEWERS: I must be doing something wrong with the config settings. The
+// above config works, but when I try to specify var.kafka_home, it doesn't
+// seem to have any effect. I can't seem to specify var.paths from the command
+// line either. Can someone please provide the correct config for the
+// above example plus the correct command to issue to run the moduel and
+// set var.paths correctly?
+
+
+To specify the same settings at the command line, you use:
+
+["source","sh",subs="attributes"]
+-----
+./{beatname_lc} -M "kafka.log.var.paths=
+-----
+
+
+The command in the example assumes that you have already enabled the +{modulename}+ module. 
+
+//set the fileset name used in the included example
+:fileset_ex: log
+
+include::../include/config-option-intro.asciidoc[]
 
 [float]
-==== var.paths
+==== `log` fileset settings
 
-An array of paths where to look for the log files. If left empty, Filebeat
-will choose the paths depending on your operating systems.
+// REVIEWERS: I've added a description because this variable appears in the
+// kafka.yml file. However, I don't understand how it works.
+
+*`var.kafka_home`*::
+
+The home path for Kafka. If this variable is not set,  {beatname_uc} looks under
+`/opt`.
+
+include::../include/var-paths.asciidoc[]

--- a/filebeat/module/logstash/_meta/docs.asciidoc
+++ b/filebeat/module/logstash/_meta/docs.asciidoc
@@ -61,8 +61,6 @@ To specify the same settings at the command line, you use:
 -----
 
 
-
-
 //set the fileset name used in the included example
 :fileset_ex: log
 

--- a/filebeat/module/logstash/_meta/docs.asciidoc
+++ b/filebeat/module/logstash/_meta/docs.asciidoc
@@ -1,5 +1,5 @@
 :modulename: logstash
-== logstash module
+== Logstash module
 
 The +{modulename}+ module parse logstash regular logs and the slow log, it will support the plain text format
 and the JSON format (--log.format json). The default is the plain text format.
@@ -8,12 +8,12 @@ include::../include/what-happens.asciidoc[]
 
 The +{modulename}+ module has two filesets:
 
-* The `log` fileset collects and parses the logs that logstash writes to disk.
+* The `log` fileset collects and parses the logs that Logstash writes to disk.
 * The `slowlog` fileset parses the logstash slowlog.
 
 
-For the `slowlog` fileset, make sure to configure logstash slowlog option
-link:https://www.elastic.co/guide/en/logstash/current/logging.html#_slowlog
+For the `slowlog` fileset, make sure to configure the
+{logstashdoc}/logging.html#_slowlog[Logstash slowlog option].
 
 [float]
 === Compatibility
@@ -25,11 +25,14 @@ The Logstash `slowlog` fileset was tested with logs from Logstash 5.6 and 6.0
 include::../include/running-modules.asciidoc[]
 
 [float]
-===  This module comes with a two sample dashboard
+===  Example dashboards
+
+This module comes with two sample dashboards.
 
 [role="screenshot"]
 image::./images/kibana-logstash-log.png[]
 
+[role="screenshot"]
 image::./images/kibana-logstash-slowlog.png[]
 
 include::../include/configuring-intro.asciidoc[]
@@ -73,7 +76,8 @@ include::../include/var-paths.asciidoc[]
 
 *`var.format`*::
 
-The configured Logstash log format, possible values are: `json` or `plain`, by default it will use the `plain` format.
+The configured Logstash log format. Possible values are: `json` or `plain`. The
+default is `plain`.
 
 [float]
 ==== `slowlog` fileset settings
@@ -82,4 +86,5 @@ include::../include/var-paths.asciidoc[]
 
 *`var.format`*::
 
-The configured Logstash log format, possible values are: `json` or `plain`, by default it will use the `plain` format.
+The configured Logstash log format. Possible values are: `json` or `plain`. The
+default is `plain`.

--- a/filebeat/module/postgresql/_meta/docs.asciidoc
+++ b/filebeat/module/postgresql/_meta/docs.asciidoc
@@ -1,30 +1,67 @@
+:modulename: postgresql
+
 == PostgreSQL module
 
-This module collects and parses the logs created by https://www.postgresql.org/[PostgreSQL].
+The +{modulename}+ module  collects and parses logs created by
+https://www.postgresql.org/[PostgreSQL].
+
+include::../include/what-happens.asciidoc[]
 
 [float]
 === Compatibility
 
-The PostgreSQL module was tested with logs from versions 9.5 on Ubuntu and 9.6 on Debian.
+The +{modulename}+ module was tested with logs from versions 9.5 on Ubuntu and 9.6
+on Debian.
+
+include::../include/running-modules.asciidoc[]
 
 [float]
-=== Dashboard
+=== Example dashboards
 
 This module comes with two sample dashboards.
 
-The first dashboard is for regulars logs.
+The first dashboard is for regular logs.
 
+[role="screenshot"]
 image::./images/filebeat-postgresql-overview.png[]
 
 The second one shows the slowlogs of PostgreSQL.
 
+[role="screenshot"]
 image::./images/filebeat-postgresql-slowlog-overview.png[]
 
-[float]
-=== Logs fileset settings
+include::../include/configuring-intro.asciidoc[]
+
+The following example shows how to set paths in the +modules.d/{modulename}.yml+
+file to override the default paths for PostgreSQL logs:
+
+
+["source","yaml",subs="attributes"]
+-----
+- module: postgresql
+  log:
+    enabled: true
+    var.paths: ["/path/to/log/postgres/*.log*"]
+-----
+
+
+To specify the same settings at the command line, you use:
+
+["source","sh",subs="attributes"]
+-----
+./{beatname_lc} -M "postgresql.log.var.paths=[/path/to/log/postgres/*.log*]"
+-----
+
+
+The command in the example assumes that you have already enabled the +{modulename}+ module.
+
+//set the fileset name used in the included example
+:fileset_ex: log
+
+include::../include/config-option-intro.asciidoc[]
 
 [float]
-==== var.paths
+==== `log` fileset settings
 
-An array of paths where to look for the log files. If left empty, Filebeat
-will choose the paths depending on your operating systems.
+include::../include/var-paths.asciidoc[]
+

--- a/filebeat/module/postgresql/_meta/docs.asciidoc
+++ b/filebeat/module/postgresql/_meta/docs.asciidoc
@@ -49,11 +49,9 @@ To specify the same settings at the command line, you use:
 
 ["source","sh",subs="attributes"]
 -----
-./{beatname_lc} -M "postgresql.log.var.paths=[/path/to/log/postgres/*.log*]"
+./{beatname_lc} --modules {modulename} -M "postgresql.log.var.paths=[/path/to/log/postgres/*.log*]"
 -----
 
-
-The command in the example assumes that you have already enabled the +{modulename}+ module.
 
 //set the fileset name used in the included example
 :fileset_ex: log


### PR DESCRIPTION
I've converted the format of the remaining modules in 6.1 to include steps for running the module and config examples.

I need help with the Kafka module config because it didn't work completely (please see and respond to my notes to REVIEWERS).

Also, I haven't done anything with the Traefik module because it doesn't have docs. Should I add docs for that one?