### PR TITLE
elasticsearch: show event being indexed in case of failure

### DIFF
--- a/libbeat/outputs/elasticsearch/client.go
+++ b/libbeat/outputs/elasticsearch/client.go
@@ -462,7 +462,7 @@ func bulkCollectPublishFails(
 
 		if status < 500 && status != 429 {
 			// hard failure, don't collect
-			logp.Warn("Can not index event (status=%v): %s", status, msg)
+			logp.Warn("Cannot index event %#v (status=%v): %s", data[i], status, msg)
 			continue
 		}
 


### PR DESCRIPTION
If there are multiple failures it is useful to keep track of them.