### PR TITLE
metricbeat: fix the `consumergroup` of kafka module incorrectly work

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -94,6 +94,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Fix kubernetes `state_pod` `status.phase` so that the active phase is returned instead of `unknown`. {pull}5980[5980]
 - Fix error collecting network_names in Vsphere module. {pull}5962[5962]
 - Fix process cgroup memory metrics for memsw, kmem, and kmem_tcp. {issue}6033[6033]
+- Fix kafka OffsetFetch request missing topic and partition parameters. {pull}5880[5880]
 
 *Packetbeat*
 

--- a/metricbeat/module/kafka/broker.go
+++ b/metricbeat/module/kafka/broker.go
@@ -230,10 +230,17 @@ func (b *Broker) DescribeGroups(
 	return groups, nil
 }
 
-func (b *Broker) FetchGroupOffsets(group string) (*sarama.OffsetFetchResponse, error) {
+// FetchGroupOffsets fetches the consume offset of group.
+// The partitions is a MAP mapping from topic name to partitionid array.
+func (b *Broker) FetchGroupOffsets(group string, partitions map[string][]int32) (*sarama.OffsetFetchResponse, error) {
 	requ := &sarama.OffsetFetchRequest{
 		ConsumerGroup: group,
 		Version:       1,
+	}
+	for topic, partition := range partitions {
+		for _, partitionID := range partition {
+			requ.AddPartition(topic, partitionID)
+		}
 	}
 	return b.broker.FetchOffset(requ)
 }

--- a/metricbeat/module/kafka/consumergroup/mock_test.go
+++ b/metricbeat/module/kafka/consumergroup/mock_test.go
@@ -125,6 +125,6 @@ func (c *mockClient) ListGroups() ([]string, error) { return c.listGroups() }
 func (c *mockClient) DescribeGroups(groups []string) (map[string]kafka.GroupDescription, error) {
 	return c.describeGroups(groups)
 }
-func (c *mockClient) FetchGroupOffsets(group string) (*sarama.OffsetFetchResponse, error) {
+func (c *mockClient) FetchGroupOffsets(group string, partitions map[string][]int32) (*sarama.OffsetFetchResponse, error) {
 	return c.fetchGroupOffsets(group)
 }

--- a/metricbeat/module/kafka/consumergroup/query.go
+++ b/metricbeat/module/kafka/consumergroup/query.go
@@ -1,8 +1,6 @@
 package consumergroup
 
 import (
-	"sync"
-
 	"github.com/Shopify/sarama"
 
 	"github.com/elastic/beats/libbeat/common"
@@ -13,7 +11,7 @@ import (
 type client interface {
 	ListGroups() ([]string, error)
 	DescribeGroups(group []string) (map[string]kafka.GroupDescription, error)
-	FetchGroupOffsets(group string) (*sarama.OffsetFetchResponse, error)
+	FetchGroupOffsets(group string, partitions map[string][]int32) (*sarama.OffsetFetchResponse, error)
 }
 
 func fetchGroupInfo(
@@ -22,9 +20,10 @@ func fetchGroupInfo(
 	groupsFilter, topicsFilter func(string) bool,
 ) error {
 	type result struct {
-		err   error
-		group string
-		off   *sarama.OffsetFetchResponse
+		err    error
+		group  string
+		assign map[string]map[int32]groupAssignment
+		off    *sarama.OffsetFetchResponse
 	}
 
 	groups, err := listGroups(b, groupsFilter)
@@ -38,51 +37,64 @@ func fetchGroupInfo(
 
 	debugf("known consumer groups: ", groups)
 
-	wg := sync.WaitGroup{}
-	results := make(chan result, len(groups))
-	for _, group := range groups {
-		group := group
+	assignments, err := fetchGroupAssignments(b, groups)
+	if err != nil {
+		logp.Err("failed to fetch kafka group assignments: %v", err)
+		return err
+	}
+	if len(assignments) == 0 {
+		return nil
+	}
 
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			resp, err := fetchGroupOffset(b, group, topicsFilter)
+	results := make(chan result)
+	waiting := 0
+	for group, topics := range assignments {
+		// generate the map topic to partitions
+		queryTopics := make(map[string][]int32)
+		for topic, partitions := range topics {
+			if topicsFilter != nil && !topicsFilter(topic) {
+				continue
+			}
+
+			// copy partition ids
+			count := len(partitions)
+			if count == 0 {
+				continue
+			}
+
+			ids, i := make([]int32, count), 0
+			for partition := range partitions {
+				ids[i], i = partition, i+1
+			}
+			queryTopics[topic] = ids
+		}
+
+		if len(queryTopics) == 0 {
+			continue
+		}
+
+		// fetch group offset
+		waiting++
+		go func(group string, partitions map[string][]int32, assign map[string]map[int32]groupAssignment) {
+			resp, err := fetchGroupOffset(b, group, partitions)
 			if err != nil {
 				logp.Err("failed to fetch '%v' group offset: %v", group, err)
 			}
-			results <- result{err, group, resp}
-		}()
+			results <- result{err, group, assign, resp}
+		}(group, queryTopics, topics)
 	}
 
-	go func() {
-		wg.Wait()
-		close(results)
-	}()
-
-	assignments, err := fetchGroupAssignments(b, groups)
-	if err != nil {
-		// wait for workers to stop and drop results
-		for range results {
+	for waiting > 0 {
+		ret := <-results
+		waiting--
+		if ret.err != nil && err == nil {
+			err = ret.err
+		}
+		if err != nil {
+			continue
 		}
 
-		return err
-	}
-
-	for ret := range results {
-		if err := ret.err; err != nil {
-			// wait for workers to stop and drop results
-			for range results {
-			}
-			return err
-		}
-
-		asgnGroup := assignments[ret.group]
 		for topic, partitions := range ret.off.Blocks {
-			var asgnTopic map[int32]groupAssignment
-			if asgnGroup != nil {
-				asgnTopic = asgnGroup[topic]
-			}
-
 			for partition, info := range partitions {
 				event := common.MapStr{
 					"id":        ret.group,
@@ -95,7 +107,7 @@ func fetchGroupInfo(
 					},
 				}
 
-				if asgnTopic != nil {
+				if asgnTopic, ok := ret.assign[topic]; ok {
 					if assignment, found := asgnTopic[partition]; found {
 						event["client"] = common.MapStr{
 							"id":        assignment.clientID,
@@ -108,9 +120,12 @@ func fetchGroupInfo(
 				emit(event)
 			}
 		}
+
 	}
 
-	return nil
+	close(results)
+
+	return err
 }
 
 func listGroups(b client, filter func(string) bool) ([]string, error) {
@@ -190,21 +205,11 @@ groupLoop:
 func fetchGroupOffset(
 	b client,
 	group string,
-	topics func(string) bool,
+	partitions map[string][]int32,
 ) (*sarama.OffsetFetchResponse, error) {
-	resp, err := b.FetchGroupOffsets(group)
+	resp, err := b.FetchGroupOffsets(group, partitions)
 	if err != nil {
 		return nil, err
-	}
-
-	if topics == nil {
-		return resp, err
-	}
-
-	for topic := range resp.Blocks {
-		if !topics(topic) {
-			delete(resp.Blocks, topic)
-		}
 	}
 
 	return resp, nil


### PR DESCRIPTION
The `consumergroup` fetch offset info by sending `OffsetFetch` request to Kafka.
But the `topic` and `partition` parameters missed in the sent `OffsetFetch` request.
These parameters is required, and kafka will do not response anything if they are missed.

This is Kafka protocol guide: http://kafka.apache.org/protocol.html#The_Messages_OffsetFetch