### PR TITLE
Run `update` first in `make package` cmd.

### DIFF
--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -459,7 +459,7 @@ package-setup:
 
 .PHONY: package
 package: ## @packaging Create binary packages for the beat.
-package: update package-setup
+package: clean update package-setup
 
 	echo "Start building packages for ${BEAT_NAME}"
 

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -459,7 +459,7 @@ package-setup:
 
 .PHONY: package
 package: ## @packaging Create binary packages for the beat.
-package: package-setup
+package: update package-setup
 
 	echo "Start building packages for ${BEAT_NAME}"
 


### PR DESCRIPTION
Avoid failure based on missing files or setup that are be added by running `make
update`.
Closes https://github.com/elastic/apm-server/issues/355.