### PR TITLE
Change heading for include_fields processor to accurately describe the processor

### DIFF
--- a/libbeat/docs/processors-using.asciidoc
+++ b/libbeat/docs/processors-using.asciidoc
@@ -488,7 +488,7 @@ NOTE: If you define an empty list of fields under `drop_fields`, then no fields
 are dropped.
 
 [[include-fields]]
-=== Add additional fields to events
+=== Keep fields from events
 
 The `include_fields` processor specifies which fields to export if a certain
 condition is fulfilled. The condition is optional. If it's missing, the


### PR DESCRIPTION
Changed the title because the existing title is misleading.