### PR TITLE
Backport to 6.0: Multiple doc changes (#5784 #5786 #5841 #5848 #5850)

### DIFF
--- a/auditbeat/docs/index.asciidoc
+++ b/auditbeat/docs/index.asciidoc
@@ -10,8 +10,8 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :filebeat: http://www.elastic.co/guide/en/beats/filebeat/{doc-branch}
 :logstashdoc: https://www.elastic.co/guide/en/logstash/{doc-branch}
 :elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/{doc-branch}
-:securitydoc: https://www.elastic.co/guide/en/x-pack/current
-:monitoringdoc: https://www.elastic.co/guide/en/x-pack/current
+:securitydoc: https://www.elastic.co/guide/en/x-pack/{doc-branch}
+:monitoringdoc: https://www.elastic.co/guide/en/x-pack/{doc-branch}
 :version: {stack-version}
 :beatname_lc: auditbeat
 :beatname_uc: Auditbeat

--- a/auditbeat/module/audit/kernel/_meta/docs.asciidoc
+++ b/auditbeat/module/audit/kernel/_meta/docs.asciidoc
@@ -24,6 +24,46 @@ metricset will buffer the messages in order to combine related messages into a
 single event even if they arrive interleaved or out of order.
 
 [float]
+=== Useful commands
+
+When running {beatname_uc} with the `kernel` metricset enabled, you might find
+that other monitoring systems interfere with {beatname_uc}.
+
+For example, you might encounter errors if another process, such as `auditd`, is
+registered to receive data from the Linux Audit Framework. You can use these
+commands to see if the `auditd` service is running and stop it:
+
+* See if `auditd` is running:
++
+[source,shell]
+-----
+service auditd status
+-----
+
+* Stop the `auditd` service:
++
+[source,shell]
+-----
+service auditd stop
+-----
+
+* Disable `auditd` from starting on boot:
++
+[source,shell]
+-----
+chkconfig auditd off
+-----
+
+To save CPU usage and disk space, you can use this command to stop `journald`
+from listening to audit messages:
+
+[source,shell]
+-----
+systemctl mask systemd-journald-audit.socket
+-----
+
+
+[float]
 === Configuration options
 
 This metricset has some configuration options for tuning its behavior. The

--- a/docs/devguide/index.asciidoc
+++ b/docs/devguide/index.asciidoc
@@ -9,7 +9,7 @@ include::../../libbeat/docs/version.asciidoc[]
 :filebeat: http://www.elastic.co/guide/en/beats/filebeat/{doc-branch}
 :winlogbeat: http://www.elastic.co/guide/en/beats/winlogbeat/{doc-branch}
 :heartbeat: http://www.elastic.co/guide/en/beats/heartbeat/{doc-branch}
-:securitydoc: https://www.elastic.co/guide/en/x-pack/5.2
+:securitydoc: https://www.elastic.co/guide/en/x-pack/{doc-branch}
 :logstashdoc: https://www.elastic.co/guide/en/logstash/{doc-branch}
 :beatname_lc: beatname
 :beatname_uc: a Beat

--- a/filebeat/docs/index.asciidoc
+++ b/filebeat/docs/index.asciidoc
@@ -14,7 +14,7 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :logstashdoc: https://www.elastic.co/guide/en/logstash/{doc-branch}
 :elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/{doc-branch}
 :elasticsearch-plugins: https://www.elastic.co/guide/en/elasticsearch/plugins/{doc-branch}
-:securitydoc: https://www.elastic.co/guide/en/x-pack/current
+:securitydoc: https://www.elastic.co/guide/en/x-pack/{doc-branch}
 :version: {stack-version}
 :beatname_lc: filebeat
 :beatname_uc: Filebeat

--- a/heartbeat/docs/index.asciidoc
+++ b/heartbeat/docs/index.asciidoc
@@ -13,7 +13,7 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :winlogbeat: http://www.elastic.co/guide/en/beats/winlogbeat/{doc-branch}
 :logstashdoc: https://www.elastic.co/guide/en/logstash/{doc-branch}
 :elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/{doc-branch}
-:securitydoc: https://www.elastic.co/guide/en/x-pack/current
+:securitydoc: https://www.elastic.co/guide/en/x-pack/{doc-branch}
 :downloads: https://artifacts.elastic.co/downloads/beats
 :version: {stack-version}
 :beatname_lc: heartbeat

--- a/libbeat/docs/config-file-format.asciidoc
+++ b/libbeat/docs/config-file-format.asciidoc
@@ -77,11 +77,11 @@ For example this setting:
 
 output:
   elasticsearch:
-    index: 'beat-%{+yyyy.MM.dd}'
+    index: 'beat-%{[beat.version]}-%{+yyyy.MM.dd}'
 
 ------------------------------------------------------------------------------
 
-gets collapsed into `output.elasticsearch.index: 'beat-%{+yyyy.MM.dd}'`. The
+gets collapsed into `output.elasticsearch.index: 'beat-%{[beat.version]}-%{+yyyy.MM.dd}'`. The
 full name of a setting is based on all parent structures involved.
 
 Lists create numeric names starting with 0.

--- a/libbeat/docs/index.asciidoc
+++ b/libbeat/docs/index.asciidoc
@@ -34,8 +34,6 @@ include::./gettingstarted.asciidoc[]
 
 include::./installing-beats.asciidoc[]
 
-include::./repositories.asciidoc[]
-
 include::./breaking.asciidoc[]
 
 include::./upgrading.asciidoc[]

--- a/libbeat/docs/index.asciidoc
+++ b/libbeat/docs/index.asciidoc
@@ -11,7 +11,7 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :winlogbeat: http://www.elastic.co/guide/en/beats/winlogbeat/{doc-branch}
 :heartbeat: http://www.elastic.co/guide/en/beats/heartbeat/{doc-branch}
 :beatsdevguide: http://www.elastic.co/guide/en/beats/devguide/{doc-branch}
-:securitydoc: https://www.elastic.co/guide/en/x-pack/5.2
+:securitydoc: https://www.elastic.co/guide/en/x-pack/{doc-branch}
 :logstashdoc: https://www.elastic.co/guide/en/logstash/{doc-branch}
 :elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/{doc-branch}
 :stack-ref: http://www.elastic.co/guide/en/elastic-stack/{doc-branch}

--- a/libbeat/docs/index.asciidoc
+++ b/libbeat/docs/index.asciidoc
@@ -14,6 +14,7 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :securitydoc: https://www.elastic.co/guide/en/x-pack/5.2
 :logstashdoc: https://www.elastic.co/guide/en/logstash/{doc-branch}
 :elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/{doc-branch}
+:stack-ref: http://www.elastic.co/guide/en/elastic-stack/{doc-branch}
 :beatname_lc: beatname
 :beatname_uc: a Beat
 :security: X-Pack Security

--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -42,7 +42,7 @@ Example configuration:
 
 output.elasticsearch:
   hosts: ["http://localhost:9200"]
-  index: "{beatname_lc}"
+  index: "{beatname_lc}-%{[beat.version]}-%{+yyyy.MM.dd}"
   ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
   ssl.certificate: "/etc/pki/client/cert.pem"
   ssl.key: "/etc/pki/client/cert.key"
@@ -175,9 +175,17 @@ then proxy environment variables are used. See the
 https://golang.org/pkg/net/http/#ProxyFromEnvironment[golang documentation]
 for more information about the environment variables.
 
+[[index-option-es]]
 ===== `index`
 
-The index name to write events to. The default is "{beatname_lc}-%{+yyyy.MM.dd}" (for example, "{beatname_lc}-2015.04.26").
+The index name to write events to. The default is
++"{beatname_lc}-%\{[beat.version]\}-%\{+yyyy.MM.dd\}"+ (for example,
++"{beatname_lc}-{version}-2017.04.26"+). If you change this setting, you also
+need to configure the `setup.template.name` and `setup.template.pattern` options
+(see <<configuration-template>>). If you are using the pre-built Kibana
+dashboards, you also need to set the `setup.dashboards.index` option (see
+<<configuration-dashboards>>).
+
 
 ===== `indices`
 
@@ -202,12 +210,12 @@ Examples elasticsearch output with `indices`:
 ------------------------------------------------------------------------------
 output.elasticsearch:
   hosts: ["http://localhost:9200"]
-  index: "logs-%{+yyyy.MM.dd}"
+  index: "logs-%{[beat.version]}-%{+yyyy.MM.dd}"
   indices:
-    - index: "critical-%{+yyyy.MM.dd}"
+    - index: "critical-%{[beat.version]}-%{+yyyy.MM.dd}"
       when.contains:
         message: "CRITICAL"
-    - index: "error-%{+yyyy.MM.dd}"
+    - index: "error-%{[beat.version]}-%{+yyyy.MM.dd}"
       when.contains:
         message: "ERR"
 ------------------------------------------------------------------------------
@@ -247,7 +255,7 @@ filebeat.prospectors:
 
 output.elasticsearch:
   hosts: ["http://localhost:9200"]
-  index: "filebeat-%{+yyyy.MM.dd}"
+  index: "filebeat-%{[beat.version]}-%{+yyyy.MM.dd}"
   pipelines:
     - pipeline: critical_pipeline
       when.equals:
@@ -365,9 +373,9 @@ output {
 ------------------------------------------------------------------------------
 <1> `%{[@metadata][beat]}` sets the first part of the index name to the value
 of the `beat` metadata field, `%{[@metadata][version]}` sets the second part to
-the beat's version, and `%{+YYYY.MM.dd}` sets the third part of the
+the Beat's version, and `%{+YYYY.MM.dd}` sets the third part of the
 name to a date based on the Logstash `@timestamp` field. For example:
-+{beatname_lc}-{stack-version}-2017.03.29+.
++{beatname_lc}-{version}-2017.03.29+.
 
 Events indexed into Elasticsearch with the Logstash configuration shown here
 will be similar to events directly indexed by Beats into Elasticsearch.
@@ -487,9 +495,9 @@ that when a proxy is used the name resolution occurs on the proxy server.
 [[logstash-index]]
 ===== `index`
 
-The index root name to write events to. The default is the Beat name.
-For example "{beatname_lc}" generates "[{beatname_lc}-]YYYY.MM.DD" indexes (for example,
-"{beatname_lc}-2015.04.26").
+The index root name to write events to. The default is the Beat name. For
+example +"{beatname_lc}"+ generates +"[{beatname_lc}-]{version}-YYYY.MM.DD"+
+indices (for example, +"{beatname_lc}-{version}-2017.04.26"+).
 
 ===== `ssl`
 

--- a/libbeat/docs/shared-note-sudo.asciidoc
+++ b/libbeat/docs/shared-note-sudo.asciidoc
@@ -1,0 +1,5 @@
+[TIP]
+=========================
+Use `sudo` to run this command if the config file is owned by `root`.
+
+=========================

--- a/libbeat/docs/shared-template-load.asciidoc
+++ b/libbeat/docs/shared-template-load.asciidoc
@@ -27,44 +27,78 @@ after successfully connecting to Elasticsearch. If the template already exists,
 it's not overwritten unless you configure {beatname_uc} to do so.
 
 You can disable automatic template loading, or load your own template, by
-configuring template loading optons in the {beatname_uc} configuration file.
+configuring template loading options in the {beatname_uc} configuration file.
+
+You can also set options to change the name of the index and index template.
 
 NOTE: A connection to Elasticsearch is required to load the index template. If
-the output is Logstash, you must load the template manually.
+the output is Logstash, you must
+<<load-template-manually,load the template manually>>. 
 
 For more information, see:
 
-* <<load-template-auto>> - supported for Elasticsearch output only
+* <<load-template-auto>> 
 * <<load-template-manually>> - required for Logstash output
 
 [[load-template-auto]]
 ==== Configure template loading
 
 By default, {beatname_uc} automatically loads the recommended template file,
-+fields.yml+, if Elasticsearch output is enabled. You can configure
-{beatname_lc} to load a different template by adjusting the
-`setup.template.name` and `setup.template.fields` options in +{beatname_lc}.yml+
-file:
++fields.yml+, if the Elasticsearch output is enabled. You can change the
+defaults in the +{beatname_lc}.yml+ config file to:
 
-["source","yaml",subs="attributes,callouts"]
-----------------------------------------------------------------------
-setup.template.name: "{beatname_lc}"
+* **Load a different template**
++
+[source,yaml]
+-----
+setup.template.name: "your_template_name"
 setup.template.fields: "path/to/fields.yml"
-setup.template.overwrite: false
-----------------------------------------------------------------------
+-----
++
+If the template already exists, it’s not overwritten unless you configure
+{beatname_uc} to do so.
 
+* **Overwrite an existing template**
++
+[source,yaml]
+-----
+setup.template.overwrite: true
+-----
 
-If a template already exists in the index, it is not overwritten. To overwrite
-an existing template, set `setup.template.overwrite: true` in the configuration
-file.
+* **Disable automatic template loading** 
++
+[source,yaml]
+-----
+setup.template.enabled: false
+-----
++
+If you disable automatic template loading, you need to
+<<load-template-manually,load the template manually>>.
 
-To disable automatic template loading, set `setup.template.enabled: false`. If
-you disable automatic template loading, you need to load the template manually.
+* **Change the index name**
++
+By default, {beatname_uc} writes events to indices named
++{beatname_lc}-{version}-yyyy.MM.dd+, where `yyyy.MM.dd` is the date when the
+events were indexed. To use a different name, you set the
+<<index-option-es,`index`>> option in the Elasticsearch output. The value
+that you specify should include the root name of the index plus version and
+date information. You also need to configure the `setup.template.name` and
+`setup.template.pattern` options to match the new name. For example:
++
+["source","sh",subs="attributes,callouts"]
+-----
+output.elasticsearch.index: "customname-%{[beat.version]}-%{+yyyy.MM.dd}"
+setup.template.name: "customname"
+setup.template.pattern: "customname-*"
+setup.dashboards.index: "customname-*" <1>
+-----
+<1> If you plan to
+<<load-kibana-dashboards, set up the Kibana dashboards>>, also set
+this option to overwrite the index name defined in the dashboards and index
+pattern.
 
 See <<configuration-template>> for the full list of configuration options.
 
-The options for auto loading the template are not supported if Logstash output
-is enabled.
 
 [[load-template-manually]]
 ==== Load the template manually
@@ -72,10 +106,8 @@ is enabled.
 To load the template manually, run the <<setup-command,`setup`>> command. A
 connection to Elasticsearch is required. If Logstash output is enabled, you need
 to temporarily disable the Logstash output and enable Elasticsearch by using the
-`-E` option.
-
-The examples here assume that Logstash output is enabled. You can omit the `-E`
-flags if Elasticsearch output is already enabled.
+`-E` option. The examples here assume that Logstash output is enabled. You can
+omit the `-E` flags if Elasticsearch output is already enabled.
 
 If you are connecting to a secured Elasticsearch cluster, make sure you've
 configured credentials as described in <<{beatname_lc}-configuration>>.
@@ -83,7 +115,7 @@ configured credentials as described in <<{beatname_lc}-configuration>>.
 If the host running {beatname_uc} does not have direct connectivity to
 Elasticsearch, see <<load-template-manually-alternate>>.
 
-To load the template:
+To load the template: 
 
 ifdef::allplatforms[]
 
@@ -154,8 +186,8 @@ PS > Invoke-RestMethod -Method Delete "http://localhost:9200/{beatname_lc}-*"
 ----------------------------------------------------------------------
 
 
-This command deletes all indexes that match the pattern +{beatname_lc}-*+.
-Before running this command, make sure you want to delete all indexes that match
+This command deletes all indices that match the pattern +{beatname_lc}-*+.
+Before running this command, make sure you want to delete all indices that match
 the pattern.
 
 [[load-template-manually-alternate]]

--- a/libbeat/docs/template-config.asciidoc
+++ b/libbeat/docs/template-config.asciidoc
@@ -2,17 +2,45 @@
 
 == Load the Elasticsearch index template
 
-The `setup.template` section of the +{beatname_lc}.yml+ config file specifies the
-{elasticsearch}/indices-templates.html[index template] to use for setting mappings in
-Elasticsearch.
+The `setup.template` section of the +{beatname_lc}.yml+ config file specifies
+the {elasticsearch}/indices-templates.html[index template] to use for setting
+mappings in Elasticsearch. If template loading is enabled (the default),
+{beatname_uc} loads the index template automatically after successfully
+connecting to Elasticsearch.
 
-You can adjust the following settings to load your own template or overwrite an existing one:
+NOTE: A connection to Elasticsearch is required to load the index template. If
+the output is Logstash, you must <<load-template-manually,load the template
+manually>>.
+
+You can adjust the following settings to load your own template or overwrite an
+existing one.
 
 *`setup.template.enabled`*:: Set to false to disable template loading. If set this to false,
 you must <<load-template-manually,load the template manually>>.
 
-*`setup.template.name`*:: The name of the template. The default is +{beatname_lc}+. The version of the Beat will always be appended to the given name
-so the final name is `filebeat-%{[beat.version]}`
+*`setup.template.name`*:: The name of the template. The default is
++{beatname_lc}+. The Beat version is always appended to the given
+name, so the final name is +{beatname_lc}-%\{[beat.version]\}+.
+
+// Maintainers: a backslash character is required to escape curly braces and
+// asterisks in inline code examples that contain asciidoc attributes. You'll
+// note that a backslash does not appear before the asterisk
+// in +{beatname_lc}-%\{[beat.version]\}-*+. This is intentional and formats
+// the example as expected.
+
+*`setup.template.pattern`*:: The template pattern to apply to the default index
+settings. The default pattern is +{beatname_lc}-\*+. The Beat version is always
+included in the pattern, so the final pattern is
++{beatname_lc}-%\{[beat.version]\}-*+. The wildcard character `-*` is used to
+match all daily indices.
++
+Example:
++
+["source","yaml",subs="attributes"]
+----------------------------------------------------------------------
+setup.template.name: "{beatname_lc}"
+setup.template.pattern: "{beatname_lc}-*"
+----------------------------------------------------------------------
 
 *`setup.template.fields`*:: The path to the YAML file describing the fields. The default is +fields.yml+. If a
 relative path is set, it is considered relative to the config path. See the <<directory-layout>>
@@ -27,7 +55,7 @@ see the Elasticsearch {elasticsearch}/mapping.html[mapping reference].
 +
 Example:
 +
-["source","yaml",subs="attributes,callouts"]
+["source","yaml",subs="attributes"]
 ----------------------------------------------------------------------
 setup.template.name: "{beatname_lc}"
 setup.template.fields: "fields.yml"
@@ -42,7 +70,7 @@ please see the Elasticsearch {elasticsearch}/mapping-source-field.html[reference
 +
 Example:
 +
-["source","yaml",subs="attributes,callouts"]
+["source","yaml",subs="attributes"]
 ----------------------------------------------------------------------
 setup.template.name: "{beatname_lc}"
 setup.template.fields: "fields.yml"

--- a/libbeat/docs/upgrading.asciidoc
+++ b/libbeat/docs/upgrading.asciidoc
@@ -7,6 +7,11 @@ This section gives general recommendations for upgrading the Beats:
 * <<upgrading-5-to-6>>
 * <<upgrade-mapping-template>>
 
+If you're upgrading other products in the stack, also read the
+{stack-ref}/index.html[Elastic Stack Installation and Upgrade Guide]. Want an
+upgrade list that's tailored to your stack? Try out our
+{upgrade_guide}[Interactive Upgrade Guide].
+
 [[upgrading-minor-versions]]
 === Upgrade between minor versions
 

--- a/metricbeat/docs/index.asciidoc
+++ b/metricbeat/docs/index.asciidoc
@@ -10,7 +10,7 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :filebeat: http://www.elastic.co/guide/en/beats/filebeat/{doc-branch}
 :logstashdoc: https://www.elastic.co/guide/en/logstash/{doc-branch}
 :elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/{doc-branch}
-:securitydoc: https://www.elastic.co/guide/en/x-pack/current
+:securitydoc: https://www.elastic.co/guide/en/x-pack/{doc-branch}
 :version: {stack-version}
 :beatname_lc: metricbeat
 :beatname_uc: Metricbeat

--- a/packetbeat/docs/index.asciidoc
+++ b/packetbeat/docs/index.asciidoc
@@ -13,7 +13,7 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :winlogbeat: http://www.elastic.co/guide/en/beats/winlogbeat/{doc-branch}
 :logstashdoc: https://www.elastic.co/guide/en/logstash/{doc-branch}
 :elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/{doc-branch}
-:securitydoc: https://www.elastic.co/guide/en/x-pack/current
+:securitydoc: https://www.elastic.co/guide/en/x-pack/{doc-branch}
 :kibanadoc: https://www.elastic.co/guide/en/kibana/{doc-branch}
 :plugindoc: https://www.elastic.co/guide/en/elasticsearch/plugins/{doc-branch}
 :version: {stack-version}

--- a/winlogbeat/docs/index.asciidoc
+++ b/winlogbeat/docs/index.asciidoc
@@ -13,7 +13,7 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :winlogbeat: http://www.elastic.co/guide/en/beats/winlogbeat/{doc-branch}
 :logstashdoc: https://www.elastic.co/guide/en/logstash/{doc-branch}
 :elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/{doc-branch}
-:securitydoc: https://www.elastic.co/guide/en/x-pack/current
+:securitydoc: https://www.elastic.co/guide/en/x-pack/{doc-branch}
 :version: {stack-version}
 :beatname_lc: winlogbeat
 :beatname_uc: Winlogbeat


### PR DESCRIPTION
Cherrypicks the following doc PRs into the 6.0 branch:

#5784
#5786
#5841
#5848
#5850