### PR TITLE
Auditbeat: Add exclude_files option to file integrity module

### DIFF
--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -73,7 +73,15 @@ auditbeat.modules:
   - /sbin
   - /usr/sbin
   - /etc
-  
+
+  # List of regular expressions to filter out notifications for unwanted files.
+  # Wrap in single quotes to workaround YAML escaping rules. By default no files
+  # are ignored.
+  exclude_files:
+  - '(?i)\.sw[nop]$'
+  - '~$'
+  - '/\.git($|/)'
+
   # Scan over the configured file paths at startup and send events for new or
   # modified files since the last time Auditbeat was running.
   scan_at_start: true

--- a/auditbeat/auditbeat.yml
+++ b/auditbeat/auditbeat.yml
@@ -44,7 +44,7 @@ auditbeat.modules:
   - /sbin
   - /usr/sbin
   - /etc
-  
+
 
 
 #==================== Elasticsearch template setting ==========================

--- a/auditbeat/docs/configuring-howto.asciidoc
+++ b/auditbeat/docs/configuring-howto.asciidoc
@@ -34,6 +34,7 @@ The following topics describe how to configure {beatname_uc}:
 * <<configuration-logging>>
 * <<using-environ-vars>>
 * <<yaml-tips>>
+* <<regexp-support>>
 * <<{beatname_lc}-reference-yml>>
 
 After changing configuration settings, you need to restart {beatname_uc} to
@@ -72,6 +73,8 @@ include::../../libbeat/docs/shared-env-vars.asciidoc[]
 :standalone:
 :allplatforms:
 include::../../libbeat/docs/yaml.asciidoc[]
+
+include::../../libbeat/docs/regexp.asciidoc[]
 
 include::../../libbeat/docs/reference-yml.asciidoc[]
 

--- a/auditbeat/docs/modules/file_integrity.asciidoc
+++ b/auditbeat/docs/modules/file_integrity.asciidoc
@@ -54,6 +54,10 @@ Linux.
   - /sbin
   - /usr/sbin
   - /etc
+  exclude_files:
+  - '(?i)\.sw[nop]$'
+  - '~$'
+  - '/\.git($|/)'
   scan_at_start: true
   scan_rate_per_sec: 50 MiB
   max_file_size: 100 MiB
@@ -63,6 +67,12 @@ Linux.
 
 *`paths`*:: A list of paths (directories or files) to watch. Globs are
 not supported. The specified paths should exist when the metricset is started.
+
+*`exclude_files`:: A list of regular expressions used to filter out events
+for unwanted files. By default, no files are excluded. See <<regexp-support>>
+for a list of supported regexp patterns. It is recommended to wrap regular
+expressions in single quotation marks to avoid issues with YAML escaping
+rules.
 
 *`scan_at_start`*:: A boolean value that controls if {beatname_uc} scans
 over the configured file paths at startup and send events for the files
@@ -94,8 +104,9 @@ value is sha1.
 
 *`recursive`*:: By default, the watches set to the paths specified in
 `paths` are not recursive. This means that only changes to the contents
-of this directories are watched. If `recursive` is set to `true`, the file
-metric will watch for changes on this directories and all their subdirectories.
+of this directories are watched. If `recursive` is set to `true`, the
+`file_integrity` module will watch for changes on this directories and all
+their subdirectories.
 
 
 [float]
@@ -115,6 +126,6 @@ auditbeat.modules:
   - /sbin
   - /usr/sbin
   - /etc
-  
+
 ----
 

--- a/auditbeat/docs/modules/file_integrity.asciidoc
+++ b/auditbeat/docs/modules/file_integrity.asciidoc
@@ -68,8 +68,9 @@ Linux.
 *`paths`*:: A list of paths (directories or files) to watch. Globs are
 not supported. The specified paths should exist when the metricset is started.
 
-*`exclude_files`:: A list of regular expressions used to filter out events
-for unwanted files. By default, no files are excluded. See <<regexp-support>>
+*`exclude_files`*:: A list of regular expressions used to filter out events
+for unwanted files. The expressions are matched against the full path of every
+file and directory. By default, no files are excluded. See <<regexp-support>>
 for a list of supported regexp patterns. It is recommended to wrap regular
 expressions in single quotation marks to avoid issues with YAML escaping
 rules.

--- a/auditbeat/module/auditd/audit_linux_test.go
+++ b/auditbeat/module/auditd/audit_linux_test.go
@@ -38,7 +38,7 @@ func TestData(t *testing.T) {
 	auditMetricSet.client.Close()
 	auditMetricSet.client = &libaudit.AuditClient{Netlink: mock}
 
-	events := mbtest.RunPushMetricSetV2(time.Second, ms)
+	events := mbtest.RunPushMetricSetV2(10*time.Second, 1, ms)
 	for _, e := range events {
 		if e.Error != nil {
 			t.Fatalf("received error: %+v", e.Error)
@@ -80,7 +80,7 @@ func TestUnicastClient(t *testing.T) {
 	time.AfterFunc(time.Second, func() { exec.Command("cat", "/proc/self/status").Output() })
 
 	ms := mbtest.NewPushMetricSetV2(t, c)
-	events := mbtest.RunPushMetricSetV2(5*time.Second, ms)
+	events := mbtest.RunPushMetricSetV2(5*time.Second, 0, ms)
 	for _, e := range events {
 		t.Log(e)
 
@@ -124,7 +124,7 @@ func TestMulticastClient(t *testing.T) {
 	time.AfterFunc(time.Second, func() { exec.Command("cat", "/proc/self/status").Output() })
 
 	ms := mbtest.NewPushMetricSetV2(t, c)
-	events := mbtest.RunPushMetricSetV2(5*time.Second, ms)
+	events := mbtest.RunPushMetricSetV2(5*time.Second, 0, ms)
 	for _, e := range events {
 		if e.Error != nil {
 			t.Fatalf("received error: %+v", e.Error)

--- a/auditbeat/module/file_integrity/_meta/config.yml.tpl
+++ b/auditbeat/module/file_integrity/_meta/config.yml.tpl
@@ -24,8 +24,26 @@
   - /sbin
   - /usr/sbin
   - /etc
-  {{ end -}}
-  {{ if .reference }}
+  {{- end }}
+{{ if .reference }}
+  # List of regular expressions to filter out notifications for unwanted files.
+  # Wrap in single quotes to workaround YAML escaping rules. By default no files
+  # are ignored.
+  {{ if eq .goos "darwin" -}}
+  exclude_files:
+  - '\.DS_Store$'
+  - '\.swp$'
+  {{ else if eq .goos "windows" -}}
+  exclude_files:
+  - '(?i)\.lnk$'
+  - '(?i)\.swp$'
+  {{ else -}}
+  exclude_files:
+  - '(?i)\.sw[nop]$'
+  - '~$'
+  - '/\.git($|/)'
+  {{- end }}
+
   # Scan over the configured file paths at startup and send events for new or
   # modified files since the last time Auditbeat was running.
   scan_at_start: true

--- a/auditbeat/module/file_integrity/_meta/docs.asciidoc
+++ b/auditbeat/module/file_integrity/_meta/docs.asciidoc
@@ -63,8 +63,9 @@ Linux.
 *`paths`*:: A list of paths (directories or files) to watch. Globs are
 not supported. The specified paths should exist when the metricset is started.
 
-*`exclude_files`:: A list of regular expressions used to filter out events
-for unwanted files. By default, no files are excluded. See <<regexp-support>>
+*`exclude_files`*:: A list of regular expressions used to filter out events
+for unwanted files. The expressions are matched against the full path of every
+file and directory. By default, no files are excluded. See <<regexp-support>>
 for a list of supported regexp patterns. It is recommended to wrap regular
 expressions in single quotation marks to avoid issues with YAML escaping
 rules.

--- a/auditbeat/module/file_integrity/_meta/docs.asciidoc
+++ b/auditbeat/module/file_integrity/_meta/docs.asciidoc
@@ -49,6 +49,10 @@ Linux.
   - /sbin
   - /usr/sbin
   - /etc
+  exclude_files:
+  - '(?i)\.sw[nop]$'
+  - '~$'
+  - '/\.git($|/)'
   scan_at_start: true
   scan_rate_per_sec: 50 MiB
   max_file_size: 100 MiB
@@ -58,6 +62,12 @@ Linux.
 
 *`paths`*:: A list of paths (directories or files) to watch. Globs are
 not supported. The specified paths should exist when the metricset is started.
+
+*`exclude_files`:: A list of regular expressions used to filter out events
+for unwanted files. By default, no files are excluded. See <<regexp-support>>
+for a list of supported regexp patterns. It is recommended to wrap regular
+expressions in single quotation marks to avoid issues with YAML escaping
+rules.
 
 *`scan_at_start`*:: A boolean value that controls if {beatname_uc} scans
 over the configured file paths at startup and send events for the files
@@ -89,5 +99,6 @@ value is sha1.
 
 *`recursive`*:: By default, the watches set to the paths specified in
 `paths` are not recursive. This means that only changes to the contents
-of this directories are watched. If `recursive` is set to `true`, the file
-metric will watch for changes on this directories and all their subdirectories.
+of this directories are watched. If `recursive` is set to `true`, the
+`file_integrity` module will watch for changes on this directories and all
+their subdirectories.

--- a/auditbeat/module/file_integrity/config.go
+++ b/auditbeat/module/file_integrity/config.go
@@ -50,8 +50,7 @@ type Config struct {
 	ScanRatePerSec      string          `config:"scan_rate_per_sec"`
 	ScanRateBytesPerSec uint64          `config:",ignore"`
 	Recursive           bool            `config:"recursive"` // Recursive enables recursive monitoring of directories.
-	Exclude             []string        `config:"exclude_files"`
-	ExcludeMatchers     []match.Matcher `config:",ignore"`
+	ExcludeFiles        []match.Matcher `config:"exclude_files"`
 }
 
 // Validate validates the config data and return an error explaining all the
@@ -91,14 +90,6 @@ nextHash:
 	c.ScanRateBytesPerSec, err = humanize.ParseBytes(c.ScanRatePerSec)
 	if err != nil {
 		errs = append(errs, errors.Wrap(err, "invalid scan_rate_per_sec value"))
-	}
-
-	for _, expr := range c.Exclude {
-		if matcher, err := match.Compile(expr); err == nil {
-			c.ExcludeMatchers = append(c.ExcludeMatchers, matcher)
-		} else {
-			errs = append(errs, errors.Wrap(err, "invalid exclude_files value"))
-		}
 	}
 	return errs.Err()
 }

--- a/auditbeat/module/file_integrity/config.go
+++ b/auditbeat/module/file_integrity/config.go
@@ -109,6 +109,16 @@ func deduplicate(in []string) []string {
 	return out
 }
 
+// IsExcludedPath checks if a path matches the exclude_files regular expressions.
+func (c *Config) IsExcludedPath(path string) bool {
+	for _, matcher := range c.ExcludeFiles {
+		if matcher.MatchString(path) {
+			return true
+		}
+	}
+	return false
+}
+
 var defaultConfig = Config{
 	HashTypes:        []HashType{SHA1},
 	MaxFileSize:      "100 MiB",

--- a/auditbeat/module/file_integrity/config.go
+++ b/auditbeat/module/file_integrity/config.go
@@ -8,6 +8,8 @@ import (
 	"github.com/dustin/go-humanize"
 	"github.com/joeshaw/multierror"
 	"github.com/pkg/errors"
+
+	"github.com/elastic/beats/libbeat/common/match"
 )
 
 // HashType identifies a cryptographic algorithm.
@@ -40,14 +42,16 @@ const (
 // Config contains the configuration parameters for the file integrity
 // metricset.
 type Config struct {
-	Paths               []string   `config:"paths" validate:"required"`
-	HashTypes           []HashType `config:"hash_types"`
-	MaxFileSize         string     `config:"max_file_size"`
-	MaxFileSizeBytes    uint64     `config:",ignore"`
-	ScanAtStart         bool       `config:"scan_at_start"`
-	ScanRatePerSec      string     `config:"scan_rate_per_sec"`
-	ScanRateBytesPerSec uint64     `config:",ignore"`
-	Recursive           bool       `config:"recursive"` // Recursive enables recursive monitoring of directories.
+	Paths               []string        `config:"paths" validate:"required"`
+	HashTypes           []HashType      `config:"hash_types"`
+	MaxFileSize         string          `config:"max_file_size"`
+	MaxFileSizeBytes    uint64          `config:",ignore"`
+	ScanAtStart         bool            `config:"scan_at_start"`
+	ScanRatePerSec      string          `config:"scan_rate_per_sec"`
+	ScanRateBytesPerSec uint64          `config:",ignore"`
+	Recursive           bool            `config:"recursive"` // Recursive enables recursive monitoring of directories.
+	Exclude             []string        `config:"exclude_files"`
+	ExcludeMatchers     []match.Matcher `config:",ignore"`
 }
 
 // Validate validates the config data and return an error explaining all the
@@ -89,6 +93,13 @@ nextHash:
 		errs = append(errs, errors.Wrap(err, "invalid scan_rate_per_sec value"))
 	}
 
+	for _, expr := range c.Exclude {
+		if matcher, err := match.Compile(expr); err == nil {
+			c.ExcludeMatchers = append(c.ExcludeMatchers, matcher)
+		} else {
+			errs = append(errs, errors.Wrap(err, "invalid exclude_files value"))
+		}
+	}
 	return errs.Err()
 }
 

--- a/auditbeat/module/file_integrity/config_test.go
+++ b/auditbeat/module/file_integrity/config_test.go
@@ -18,6 +18,7 @@ func TestConfig(t *testing.T) {
 		"hash_types":        []string{"md5", "sha256"},
 		"max_file_size":     "1 GiB",
 		"scan_rate_per_sec": "10MiB",
+		"exclude_files":     []string{`\.DS_Store$`, `\.swp$`},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -31,6 +32,9 @@ func TestConfig(t *testing.T) {
 	assert.Equal(t, []HashType{MD5, SHA256}, c.HashTypes)
 	assert.EqualValues(t, 1024*1024*1024, c.MaxFileSizeBytes)
 	assert.EqualValues(t, 1024*1024*10, c.ScanRateBytesPerSec)
+	assert.Len(t, c.ExcludeMatchers, 2)
+	assert.EqualValues(t, `\.DS_Store(?-m:$)`, c.ExcludeMatchers[0].String())
+	assert.EqualValues(t, `\.swp(?-m:$)`, c.ExcludeMatchers[1].String())
 }
 
 func TestConfigInvalid(t *testing.T) {
@@ -39,6 +43,7 @@ func TestConfigInvalid(t *testing.T) {
 		"hash_types":        []string{"crc32", "sha256", "hmac"},
 		"max_file_size":     "32 Hz",
 		"scan_rate_per_sec": "32mb/sec",
+		"exclude_files":     []string{`unmatched(`},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -57,7 +62,7 @@ func TestConfigInvalid(t *testing.T) {
 		if !ok {
 			t.Fatal("expected MultiError")
 		}
-		assert.Len(t, merr.Errors, 4)
+		assert.Len(t, merr.Errors, 5)
 		return
 	}
 

--- a/auditbeat/module/file_integrity/eventreader_fsevents.go
+++ b/auditbeat/module/file_integrity/eventreader_fsevents.go
@@ -131,8 +131,7 @@ func (r *fsreader) consumeEvents(done <-chan struct{}) {
 			return
 		case events := <-r.stream.Events:
 			for _, event := range events {
-				if !r.isWatched(event.Path) {
-					debugf("Ignoring FSEvents event: path=%v", event.Path)
+				if !r.isWatched(event.Path) || r.config.IsExcludedPath(event.Path) {
 					continue
 				}
 				debugf("Received FSEvents event: id=%d path=%v flags=%s",

--- a/auditbeat/module/file_integrity/eventreader_fsnotify.go
+++ b/auditbeat/module/file_integrity/eventreader_fsnotify.go
@@ -60,7 +60,7 @@ func (r *reader) consumeEvents() {
 	for {
 		select {
 		case event := <-r.watcher.EventChannel():
-			if event.Name == "" {
+			if event.Name == "" || r.config.IsExcludedPath(event.Name) {
 				continue
 			}
 			debugf("Received fsnotify event: path=%v action=%v",

--- a/auditbeat/module/file_integrity/metricset.go
+++ b/auditbeat/module/file_integrity/metricset.go
@@ -168,7 +168,7 @@ func (ms *MetricSet) init(reporter mb.PushReporterV2) bool {
 
 func (ms *MetricSet) reportEvent(reporter mb.PushReporterV2, event *Event) bool {
 	// ignore excluded paths
-	for _, matcher := range ms.config.ExcludeMatchers {
+	for _, matcher := range ms.config.ExcludeFiles {
 		if matcher.MatchString(event.Path) {
 			return false
 		}

--- a/auditbeat/module/file_integrity/metricset.go
+++ b/auditbeat/module/file_integrity/metricset.go
@@ -167,13 +167,6 @@ func (ms *MetricSet) init(reporter mb.PushReporterV2) bool {
 }
 
 func (ms *MetricSet) reportEvent(reporter mb.PushReporterV2, event *Event) bool {
-	// ignore excluded paths
-	for _, matcher := range ms.config.ExcludeFiles {
-		if matcher.MatchString(event.Path) {
-			return false
-		}
-	}
-
 	if len(event.errors) > 0 && logp.IsDebug(moduleName) {
 		debugf("Errors on event for %v with action=%v: %v",
 			event.Path, event.Action, event.errors)
@@ -230,8 +223,8 @@ func (ms *MetricSet) purgeDeleted(reporter mb.PushReporterV2) {
 
 		for _, e := range deleted {
 			// Don't persist!
-			if !reporter.Event(buildMetricbeatEvent(e, true)) {
-				return
+			if !ms.config.IsExcludedPath(e.Path) {
+				reporter.Event(buildMetricbeatEvent(e, true))
 			}
 		}
 	}

--- a/auditbeat/module/file_integrity/metricset.go
+++ b/auditbeat/module/file_integrity/metricset.go
@@ -167,6 +167,13 @@ func (ms *MetricSet) init(reporter mb.PushReporterV2) bool {
 }
 
 func (ms *MetricSet) reportEvent(reporter mb.PushReporterV2, event *Event) bool {
+	// ignore excluded paths
+	for _, matcher := range ms.config.ExcludeMatchers {
+		if matcher.MatchString(event.Path) {
+			return false
+		}
+	}
+
 	if len(event.errors) > 0 && logp.IsDebug(moduleName) {
 		debugf("Errors on event for %v with action=%v: %v",
 			event.Path, event.Action, event.errors)

--- a/auditbeat/module/file_integrity/metricset_test.go
+++ b/auditbeat/module/file_integrity/metricset_test.go
@@ -105,6 +105,68 @@ func TestDetectDeletedFiles(t *testing.T) {
 	}
 }
 
+func TestExcludedFiles(t *testing.T) {
+	defer setup(t)()
+
+	bucket, err := datastore.OpenBucket(bucketName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer bucket.Close()
+
+	dir, err := ioutil.TempDir("", "audit-file")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	dir, err = filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ms := mbtest.NewPushMetricSetV2(t, getConfig(dir))
+	capture := &mbtest.CapturingReporterV2{DoneC: make(chan struct{})}
+
+	go func() {
+		for _, f := range []string{"FILE.TXT", "FILE.TXT.SWP", "file.txt.swo", ".git/HEAD", ".gitignore"} {
+			file := filepath.Join(dir, f)
+			ioutil.WriteFile(file, []byte("hello world"), 0600)
+		}
+		for i := 0; i < 100 && len(capture.Events) < 3; i++ {
+			time.Sleep(time.Millisecond * 100)
+		}
+		close(capture.DoneC)
+	}()
+
+	ms.Run(capture)
+
+	events := capture.Events
+	for _, e := range events {
+		if e.Error != nil {
+			t.Fatalf("received error: %+v", e.Error)
+		}
+	}
+
+	if !assert.Len(t, events, 3) {
+		return
+	}
+
+	wanted := map[string]bool{
+		dir: true,
+		filepath.Join(dir, "FILE.TXT"):   true,
+		filepath.Join(dir, ".gitignore"): true,
+	}
+	for _, e := range events {
+		event := e.MetricSetFields
+		path, err := event.GetValue("path")
+		if assert.NoError(t, err) {
+			_, ok := wanted[path.(string)]
+			assert.True(t, ok)
+		}
+	}
+}
+
 func setup(t testing.TB) func() {
 	// path.data should be set so that the DB is written to a predictable location.
 	var err error
@@ -117,7 +179,8 @@ func setup(t testing.TB) func() {
 
 func getConfig(path string) map[string]interface{} {
 	return map[string]interface{}{
-		"module": "file_integrity",
-		"paths":  []string{path},
+		"module":        "file_integrity",
+		"paths":         []string{path},
+		"exclude_files": []string{`(?i)\.sw[nop]$`, `[/\\]\.git([/\\]|$)`},
 	}
 }

--- a/auditbeat/module/file_integrity/metricset_test.go
+++ b/auditbeat/module/file_integrity/metricset_test.go
@@ -148,14 +148,13 @@ func TestExcludedFiles(t *testing.T) {
 		}
 	}
 
-	if !assert.Len(t, events, 3) {
-		return
-	}
-
 	wanted := map[string]bool{
 		dir: true,
 		filepath.Join(dir, "FILE.TXT"):   true,
 		filepath.Join(dir, ".gitignore"): true,
+	}
+	if !assert.Len(t, events, len(wanted)) {
+		return
 	}
 	for _, e := range events {
 		event := e.MetricSetFields

--- a/auditbeat/module/file_integrity/scanner.go
+++ b/auditbeat/module/file_integrity/scanner.go
@@ -104,6 +104,12 @@ func (s *scanner) walkDir(dir string) error {
 	errDone := errors.New("done")
 	startTime := time.Now()
 	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if s.config.IsExcludedPath(path) {
+			if info.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
 		defer func() { startTime = time.Now() }()
 
 		event := s.newScanEvent(path, info, err)

--- a/metricbeat/mb/testing/modules.go
+++ b/metricbeat/mb/testing/modules.go
@@ -218,7 +218,7 @@ func NewPushMetricSetV2(t testing.TB, config interface{}) mb.PushMetricSetV2 {
 	return pushMetricSet
 }
 
-// CapturingReporterV2 stores all the events and errors from a metricset's
+// capturingReporterV2 stores all the events and errors from a metricset's
 // Run method.
 type capturingReporterV2 struct {
 	Events []mb.Event


### PR DESCRIPTION
Added a new config field, `exclude_files` consisting of regular expressions used to exclude files from monitoring by the file integrity module.

See #5342
