### PR TITLE
support multiple passwords for redis output

### DIFF
--- a/libbeat/outputs/hosts.go
+++ b/libbeat/outputs/hosts.go
@@ -33,3 +33,17 @@ func ReadHostList(cfg *common.Config) ([]string, error) {
 
 	return hosts, nil
 }
+
+// OriginalHostList returns the list  of hosts to connect to as specified by
+func OriginalHostList(cfg *common.Config) ([]string, error) {
+	config := struct {
+		Hosts []string `config:"hosts"  validate:"required"`
+	}{}
+
+	err := cfg.Unpack(&config)
+	if err != nil {
+		return nil, err
+	}
+
+	return config.Hosts, nil
+}

--- a/libbeat/outputs/redis/config.go
+++ b/libbeat/outputs/redis/config.go
@@ -12,7 +12,7 @@ import (
 )
 
 type redisConfig struct {
-	Password    string                `config:"password"`
+	Password    []string              `config:"password"`
 	Index       string                `config:"index"`
 	Key         string                `config:"key"`
 	Port        int                   `config:"port"`


### PR DESCRIPTION
This PR add ability to specify multiple passwords for redis. Users now should add a list of passwords instead of one.
- if no password is specified then we suppose a no auth
- if one password is specified we consider it as a default password
- we map each password with host in case of multiple passwords. if the number of hosts and password doesn't match, we fail