### PR TITLE
Filter packages in Jenkins Powershell

### DIFF
--- a/dev-tools/jenkins_ci.ps1
+++ b/dev-tools/jenkins_ci.ps1
@@ -52,6 +52,9 @@ exec { Get-Content build/TEST-go-unit.out | go-junit-report.exe -set-exit-code |
 echo "System testing $env:beat"
 # TODO (elastic/beats#5050): Use a vendored copy of this.
 exec { go get github.com/docker/libcompose }
-exec { go test -race -c -cover -covermode=atomic -coverpkg ./... }
+# Get a CSV list of package names.
+$packages = $(go list ./... | select-string -Pattern "/vendor/" -NotMatch | select-string -Pattern "/scripts/cmd/" -NotMatch)
+$packages = ($packages|group|Select -ExpandProperty Name) -join ","
+exec { go test -race -c -cover -covermode=atomic -coverpkg $packages }
 exec { cd tests/system }
 exec { nosetests --with-timer --with-xunit --xunit-file=../../build/TEST-system.xml } "System test FAILURE"

--- a/dev-tools/jenkins_ci.sh
+++ b/dev-tools/jenkins_ci.sh
@@ -19,12 +19,18 @@ jenkins_setup
 cleanup() {
   echo "Running cleanup..."
   rm -rf $TEMP_PYTHON_ENV
-  make stop-environment || true
-  make fix-permissions || true
-  echo "Killing all running containers..."
-  docker ps -q | xargs -r docker kill || true
-  echo "Cleaning stopped docker containers and dangling images/networks/volumes..."
-  docker system prune -f || true
+
+  if docker info > /dev/null ; then
+    make stop-environment || true
+    make fix-permissions || true
+    echo "Killing all running containers..."
+    ids=$(docker ps -q)
+    if [ -n "$ids" ]; then
+      docker kill $ids
+    fi  
+    echo "Cleaning stopped docker containers and dangling images/networks/volumes..."
+    docker system prune -f || true
+  fi
   echo "Cleanup complete."
 }
 trap cleanup EXIT

--- a/libbeat/scripts/cmd/stress_pipeline/main.go
+++ b/libbeat/scripts/cmd/stress_pipeline/main.go
@@ -1,5 +1,3 @@
-// +build !windows
-
 package main
 
 import (


### PR DESCRIPTION
This filters the packages used to create the beatname.test binary used in system tests. We needed to filter the tools in scripts/cmd because the code should not be included in the test binary.