### PR TITLE
Add log output to Windows Event Log

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -113,6 +113,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Add the ability to write structured logs. {pull}5901[5901]
 - Use structured logging for the metrics that are periodically logged via the
   `logging.metrics` feature. {pull}5915[5915]
+- Add the ability to log to the Windows Event Log. {pull}5913[5813]
 
 *Auditbeat*
 

--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -831,12 +831,11 @@ setup.kibana:
 
 
 #================================ Logging ======================================
-# There are three options for the log output: syslog, file, stderr.
-# Under Windows systems, the log files are per default sent to the file output,
-# under all other system per default to syslog.
+# There are four options for the log output: file, stderr, syslog, eventlog
+# The file output is the default.
 
 # Sets log level. The default log level is info.
-# Available log levels are: critical, error, warning, info, debug
+# Available log levels are: error, warning, info, debug
 #logging.level: info
 
 # Enable debug output for selected components. To enable all selectors use ["*"]
@@ -845,7 +844,10 @@ setup.kibana:
 #logging.selectors: [ ]
 
 # Send all logging output to syslog. The default is false.
-#logging.to_syslog: true
+#logging.to_syslog: false
+
+# Send all logging output to Windows Event Logs. The default is false.
+#logging.to_eventlog: false
 
 # If enabled, auditbeat periodically logs its internal metrics that have changed
 # in the last period. For each metric that changed, the delta from the value at

--- a/auditbeat/auditbeat.yml
+++ b/auditbeat/auditbeat.yml
@@ -138,7 +138,7 @@ output.elasticsearch:
 #================================ Logging =====================================
 
 # Sets log level. The default log level is info.
-# Available log levels are: critical, error, warning, info, debug
+# Available log levels are: error, warning, info, debug
 #logging.level: debug
 
 # At debug level, you can selectively enable logging only for some components.

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -1266,12 +1266,11 @@ setup.kibana:
 
 
 #================================ Logging ======================================
-# There are three options for the log output: syslog, file, stderr.
-# Under Windows systems, the log files are per default sent to the file output,
-# under all other system per default to syslog.
+# There are four options for the log output: file, stderr, syslog, eventlog
+# The file output is the default.
 
 # Sets log level. The default log level is info.
-# Available log levels are: critical, error, warning, info, debug
+# Available log levels are: error, warning, info, debug
 #logging.level: info
 
 # Enable debug output for selected components. To enable all selectors use ["*"]
@@ -1280,7 +1279,10 @@ setup.kibana:
 #logging.selectors: [ ]
 
 # Send all logging output to syslog. The default is false.
-#logging.to_syslog: true
+#logging.to_syslog: false
+
+# Send all logging output to Windows Event Logs. The default is false.
+#logging.to_eventlog: false
 
 # If enabled, filebeat periodically logs its internal metrics that have changed
 # in the last period. For each metric that changed, the delta from the value at

--- a/filebeat/filebeat.yml
+++ b/filebeat/filebeat.yml
@@ -167,7 +167,7 @@ output.elasticsearch:
 #================================ Logging =====================================
 
 # Sets log level. The default log level is info.
-# Available log levels are: critical, error, warning, info, debug
+# Available log levels are: error, warning, info, debug
 #logging.level: debug
 
 # At debug level, you can selectively enable logging only for some components.

--- a/heartbeat/heartbeat.reference.yml
+++ b/heartbeat/heartbeat.reference.yml
@@ -941,12 +941,11 @@ setup.kibana:
 
 
 #================================ Logging ======================================
-# There are three options for the log output: syslog, file, stderr.
-# Under Windows systems, the log files are per default sent to the file output,
-# under all other system per default to syslog.
+# There are four options for the log output: file, stderr, syslog, eventlog
+# The file output is the default.
 
 # Sets log level. The default log level is info.
-# Available log levels are: critical, error, warning, info, debug
+# Available log levels are: error, warning, info, debug
 #logging.level: info
 
 # Enable debug output for selected components. To enable all selectors use ["*"]
@@ -955,7 +954,10 @@ setup.kibana:
 #logging.selectors: [ ]
 
 # Send all logging output to syslog. The default is false.
-#logging.to_syslog: true
+#logging.to_syslog: false
+
+# Send all logging output to Windows Event Logs. The default is false.
+#logging.to_eventlog: false
 
 # If enabled, heartbeat periodically logs its internal metrics that have changed
 # in the last period. For each metric that changed, the delta from the value at

--- a/heartbeat/heartbeat.yml
+++ b/heartbeat/heartbeat.yml
@@ -114,7 +114,7 @@ output.elasticsearch:
 #================================ Logging =====================================
 
 # Sets log level. The default log level is info.
-# Available log levels are: critical, error, warning, info, debug
+# Available log levels are: error, warning, info, debug
 #logging.level: debug
 
 # At debug level, you can selectively enable logging only for some components.

--- a/libbeat/_meta/config.reference.yml
+++ b/libbeat/_meta/config.reference.yml
@@ -727,12 +727,11 @@ setup.kibana:
 
 
 #================================ Logging ======================================
-# There are three options for the log output: syslog, file, stderr.
-# Under Windows systems, the log files are per default sent to the file output,
-# under all other system per default to syslog.
+# There are four options for the log output: file, stderr, syslog, eventlog
+# The file output is the default.
 
 # Sets log level. The default log level is info.
-# Available log levels are: critical, error, warning, info, debug
+# Available log levels are: error, warning, info, debug
 #logging.level: info
 
 # Enable debug output for selected components. To enable all selectors use ["*"]
@@ -741,7 +740,10 @@ setup.kibana:
 #logging.selectors: [ ]
 
 # Send all logging output to syslog. The default is false.
-#logging.to_syslog: true
+#logging.to_syslog: false
+
+# Send all logging output to Windows Event Logs. The default is false.
+#logging.to_eventlog: false
 
 # If enabled, beatname periodically logs its internal metrics that have changed
 # in the last period. For each metric that changed, the delta from the value at

--- a/libbeat/_meta/config.yml
+++ b/libbeat/_meta/config.yml
@@ -84,7 +84,7 @@ output.elasticsearch:
 #================================ Logging =====================================
 
 # Sets log level. The default log level is info.
-# Available log levels are: critical, error, warning, info, debug
+# Available log levels are: error, warning, info, debug
 #logging.level: debug
 
 # At debug level, you can selectively enable logging only for some components.

--- a/libbeat/docs/loggingconfig.asciidoc
+++ b/libbeat/docs/loggingconfig.asciidoc
@@ -45,6 +45,11 @@ You can specify the following options in the `logging` section of the
 When true, writes all logging output to the syslog.
 
 [float]
+==== `logging.to_eventlog`
+
+When true, writes all logging output to the Windows Event Log.
+
+[float]
 ==== `logging.to_files`
 
 When true, writes all logging output to files. The log files are automatically

--- a/libbeat/logp/config.go
+++ b/libbeat/logp/config.go
@@ -13,6 +13,7 @@ type Config struct {
 	ToStderr    bool `config:"to_stderr"`
 	ToSyslog    bool `config:"to_syslog"`
 	ToFiles     bool `config:"to_files"`
+	ToEventLog  bool `config:"to_eventlog"`
 
 	Files FileConfig `config:"files"`
 

--- a/libbeat/logp/core.go
+++ b/libbeat/logp/core.go
@@ -55,6 +55,8 @@ func Configure(cfg Config) error {
 		sink, err = makeStderrOutput(cfg)
 	case cfg.ToSyslog:
 		sink, err = makeSyslogOutput(cfg)
+	case cfg.ToEventLog:
+		sink, err = makeEventLogOutput(cfg)
 	case cfg.ToFiles:
 		fallthrough
 	default:
@@ -156,6 +158,10 @@ func makeDiscardOutput(cfg Config) (zapcore.Core, error) {
 
 func makeSyslogOutput(cfg Config) (zapcore.Core, error) {
 	return newSyslog(buildEncoder(cfg), cfg.Level.zapLevel())
+}
+
+func makeEventLogOutput(cfg Config) (zapcore.Core, error) {
+	return newEventLog(cfg.Beat, buildEncoder(cfg), cfg.Level.zapLevel())
 }
 
 func makeFileOutput(cfg Config) (zapcore.Core, error) {

--- a/libbeat/logp/encoding.go
+++ b/libbeat/logp/encoding.go
@@ -6,6 +6,21 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
+var baseEncodingConfig = zapcore.EncoderConfig{
+	TimeKey:        "timestamp",
+	LevelKey:       "level",
+	NameKey:        "logger",
+	CallerKey:      "caller",
+	MessageKey:     "message",
+	StacktraceKey:  "stacktrace",
+	LineEnding:     zapcore.DefaultLineEnding,
+	EncodeLevel:    zapcore.LowercaseLevelEncoder,
+	EncodeTime:     zapcore.ISO8601TimeEncoder,
+	EncodeDuration: millisecondsDurationEncoder,
+	EncodeCaller:   zapcore.ShortCallerEncoder,
+	EncodeName:     zapcore.FullNameEncoder,
+}
+
 func buildEncoder(cfg Config) zapcore.Encoder {
 	if cfg.JSON {
 		return zapcore.NewJSONEncoder(jsonEncoderConfig())
@@ -17,37 +32,14 @@ func buildEncoder(cfg Config) zapcore.Encoder {
 }
 
 func jsonEncoderConfig() zapcore.EncoderConfig {
-	return zapcore.EncoderConfig{
-		TimeKey:        "timestamp",
-		LevelKey:       "level",
-		NameKey:        "logger",
-		CallerKey:      "caller",
-		MessageKey:     "message",
-		StacktraceKey:  "stacktrace",
-		LineEnding:     zapcore.DefaultLineEnding,
-		EncodeLevel:    zapcore.LowercaseLevelEncoder,
-		EncodeTime:     zapcore.ISO8601TimeEncoder,
-		EncodeDuration: millisecondsDurationEncoder,
-		EncodeCaller:   zapcore.ShortCallerEncoder,
-		EncodeName:     zapcore.FullNameEncoder,
-	}
+	return baseEncodingConfig
 }
 
 func consoleEncoderConfig() zapcore.EncoderConfig {
-	return zapcore.EncoderConfig{
-		TimeKey:        "timestamp",
-		LevelKey:       "level",
-		NameKey:        "logger",
-		CallerKey:      "caller",
-		MessageKey:     "message",
-		StacktraceKey:  "stacktrace",
-		LineEnding:     zapcore.DefaultLineEnding,
-		EncodeLevel:    zapcore.CapitalLevelEncoder,
-		EncodeTime:     zapcore.ISO8601TimeEncoder,
-		EncodeDuration: millisecondsDurationEncoder,
-		EncodeCaller:   zapcore.ShortCallerEncoder,
-		EncodeName:     bracketedNameEncoder,
-	}
+	c := baseEncodingConfig
+	c.EncodeLevel = zapcore.CapitalLevelEncoder
+	c.EncodeName = bracketedNameEncoder
+	return c
 }
 
 func syslogEncoderConfig() zapcore.EncoderConfig {

--- a/libbeat/logp/eventlog_unsupported.go
+++ b/libbeat/logp/eventlog_unsupported.go
@@ -1,0 +1,12 @@
+// +build !windows
+
+package logp
+
+import (
+	"github.com/pkg/errors"
+	"go.uber.org/zap/zapcore"
+)
+
+func newEventLog(beatname string, encoder zapcore.Encoder, enab zapcore.LevelEnabler) (zapcore.Core, error) {
+	return nil, errors.New("eventlog is only supported on Windows")
+}

--- a/libbeat/logp/eventlog_windows.go
+++ b/libbeat/logp/eventlog_windows.go
@@ -1,0 +1,92 @@
+package logp
+
+import (
+	"strings"
+
+	"github.com/pkg/errors"
+	"go.uber.org/zap/zapcore"
+	"golang.org/x/sys/windows/svc/eventlog"
+)
+
+const (
+	// eventID is arbitrary but must be between [1-1000].
+	eventID  = 100
+	supports = eventlog.Error | eventlog.Warning | eventlog.Info
+)
+
+const alreadyExistsMsg = "registry key already exists"
+
+type eventLogCore struct {
+	zapcore.LevelEnabler
+	encoder zapcore.Encoder
+	fields  []zapcore.Field
+	log     *eventlog.Log
+}
+
+func newEventLog(appName string, encoder zapcore.Encoder, enab zapcore.LevelEnabler) (zapcore.Core, error) {
+	if appName == "" {
+		return nil, errors.New("appName cannot be empty")
+	}
+	appName = strings.Title(strings.ToLower(appName))
+
+	if err := eventlog.InstallAsEventCreate(appName, supports); err != nil {
+		if !strings.Contains(err.Error(), alreadyExistsMsg) {
+			return nil, errors.Wrap(err, "failed to setup eventlog")
+		}
+	}
+
+	log, err := eventlog.Open(appName)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to open eventlog")
+	}
+
+	return &eventLogCore{
+		LevelEnabler: enab,
+		encoder:      encoder,
+		log:          log,
+	}, nil
+}
+
+func (c *eventLogCore) With(fields []zapcore.Field) zapcore.Core {
+	clone := c.Clone()
+	clone.fields = append(clone.fields, fields...)
+	return clone
+}
+
+func (c *eventLogCore) Check(entry zapcore.Entry, checked *zapcore.CheckedEntry) *zapcore.CheckedEntry {
+	if c.Enabled(entry.Level) {
+		return checked.AddCore(entry, c)
+	}
+	return checked
+}
+
+func (c *eventLogCore) Write(entry zapcore.Entry, fields []zapcore.Field) error {
+	buffer, err := c.encoder.EncodeEntry(entry, fields)
+	if err != nil {
+		return errors.Wrap(err, "failed to encode entry")
+	}
+
+	msg := buffer.String()
+	switch entry.Level {
+	case zapcore.DebugLevel, zapcore.InfoLevel:
+		return c.log.Info(eventID, msg)
+	case zapcore.WarnLevel:
+		return c.log.Warning(eventID, msg)
+	case zapcore.ErrorLevel, zapcore.DPanicLevel, zapcore.PanicLevel, zapcore.FatalLevel:
+		return c.log.Error(eventID, msg)
+	default:
+		return errors.Errorf("unhandled log level: %v", entry.Level)
+	}
+}
+
+func (c *eventLogCore) Sync() error {
+	return nil
+}
+
+func (c *eventLogCore) Clone() *eventLogCore {
+	clone := *c
+	clone.encoder = c.encoder.Clone()
+	clone.fields = make([]zapcore.Field, len(c.fields), len(c.fields)+10)
+	copy(clone.fields, c.fields)
+	return &clone
+}

--- a/libbeat/logp/fields.go
+++ b/libbeat/logp/fields.go
@@ -38,7 +38,7 @@ var (
 	Int64s      = zap.Int64s
 	Namespace   = zap.Namespace
 	Reflect     = zap.Reflect
-	Stack       = zap.Reflect
+	Stack       = zap.Stack
 	String      = zap.String
 	Stringer    = zap.Stringer
 	Strings     = zap.Strings

--- a/libbeat/logp/syslog_unix.go
+++ b/libbeat/logp/syslog_unix.go
@@ -53,7 +53,7 @@ func (c *syslogCore) Write(entry zapcore.Entry, fields []zapcore.Field) error {
 	}
 
 	// Console encoder writes tabs which don't render nicely with syslog.
-	replaceTabsWithSpaces(buffer.Bytes(), 2)
+	replaceTabsWithSpaces(buffer.Bytes(), 4)
 
 	msg := buffer.String()
 	switch entry.Level {

--- a/libbeat/logp/syslog_unsupported.go
+++ b/libbeat/logp/syslog_unsupported.go
@@ -3,9 +3,10 @@
 package logp
 
 import (
+	"github.com/pkg/errors"
 	"go.uber.org/zap/zapcore"
 )
 
 func newSyslog(_ zapcore.Encoder, _ zapcore.LevelEnabler) (zapcore.Core, error) {
-	return zapcore.NewNopCore(), nil
+	return nil, errors.New("syslog is not supported on this OS")
 }

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -1209,12 +1209,11 @@ setup.kibana:
 
 
 #================================ Logging ======================================
-# There are three options for the log output: syslog, file, stderr.
-# Under Windows systems, the log files are per default sent to the file output,
-# under all other system per default to syslog.
+# There are four options for the log output: file, stderr, syslog, eventlog
+# The file output is the default.
 
 # Sets log level. The default log level is info.
-# Available log levels are: critical, error, warning, info, debug
+# Available log levels are: error, warning, info, debug
 #logging.level: info
 
 # Enable debug output for selected components. To enable all selectors use ["*"]
@@ -1223,7 +1222,10 @@ setup.kibana:
 #logging.selectors: [ ]
 
 # Send all logging output to syslog. The default is false.
-#logging.to_syslog: true
+#logging.to_syslog: false
+
+# Send all logging output to Windows Event Logs. The default is false.
+#logging.to_eventlog: false
 
 # If enabled, metricbeat periodically logs its internal metrics that have changed
 # in the last period. For each metric that changed, the delta from the value at

--- a/metricbeat/metricbeat.yml
+++ b/metricbeat/metricbeat.yml
@@ -111,7 +111,7 @@ output.elasticsearch:
 #================================ Logging =====================================
 
 # Sets log level. The default log level is info.
-# Available log levels are: critical, error, warning, info, debug
+# Available log levels are: error, warning, info, debug
 #logging.level: debug
 
 # At debug level, you can selectively enable logging only for some components.

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -1195,12 +1195,11 @@ setup.kibana:
 
 
 #================================ Logging ======================================
-# There are three options for the log output: syslog, file, stderr.
-# Under Windows systems, the log files are per default sent to the file output,
-# under all other system per default to syslog.
+# There are four options for the log output: file, stderr, syslog, eventlog
+# The file output is the default.
 
 # Sets log level. The default log level is info.
-# Available log levels are: critical, error, warning, info, debug
+# Available log levels are: error, warning, info, debug
 #logging.level: info
 
 # Enable debug output for selected components. To enable all selectors use ["*"]
@@ -1209,7 +1208,10 @@ setup.kibana:
 #logging.selectors: [ ]
 
 # Send all logging output to syslog. The default is false.
-#logging.to_syslog: true
+#logging.to_syslog: false
+
+# Send all logging output to Windows Event Logs. The default is false.
+#logging.to_eventlog: false
 
 # If enabled, packetbeat periodically logs its internal metrics that have changed
 # in the last period. For each metric that changed, the delta from the value at

--- a/packetbeat/packetbeat.yml
+++ b/packetbeat/packetbeat.yml
@@ -190,7 +190,7 @@ output.elasticsearch:
 #================================ Logging =====================================
 
 # Sets log level. The default log level is info.
-# Available log levels are: critical, error, warning, info, debug
+# Available log levels are: error, warning, info, debug
 #logging.level: debug
 
 # At debug level, you can selectively enable logging only for some components.

--- a/vendor/golang.org/x/sys/windows/svc/eventlog/install.go
+++ b/vendor/golang.org/x/sys/windows/svc/eventlog/install.go
@@ -1,0 +1,80 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build windows
+
+package eventlog
+
+import (
+	"errors"
+
+	"golang.org/x/sys/windows"
+	"golang.org/x/sys/windows/registry"
+)
+
+const (
+	// Log levels.
+	Info    = windows.EVENTLOG_INFORMATION_TYPE
+	Warning = windows.EVENTLOG_WARNING_TYPE
+	Error   = windows.EVENTLOG_ERROR_TYPE
+)
+
+const addKeyName = `SYSTEM\CurrentControlSet\Services\EventLog\Application`
+
+// Install modifies PC registry to allow logging with an event source src.
+// It adds all required keys and values to the event log registry key.
+// Install uses msgFile as the event message file. If useExpandKey is true,
+// the event message file is installed as REG_EXPAND_SZ value,
+// otherwise as REG_SZ. Use bitwise of log.Error, log.Warning and
+// log.Info to specify events supported by the new event source.
+func Install(src, msgFile string, useExpandKey bool, eventsSupported uint32) error {
+	appkey, err := registry.OpenKey(registry.LOCAL_MACHINE, addKeyName, registry.CREATE_SUB_KEY)
+	if err != nil {
+		return err
+	}
+	defer appkey.Close()
+
+	sk, alreadyExist, err := registry.CreateKey(appkey, src, registry.SET_VALUE)
+	if err != nil {
+		return err
+	}
+	defer sk.Close()
+	if alreadyExist {
+		return errors.New(addKeyName + `\` + src + " registry key already exists")
+	}
+
+	err = sk.SetDWordValue("CustomSource", 1)
+	if err != nil {
+		return err
+	}
+	if useExpandKey {
+		err = sk.SetExpandStringValue("EventMessageFile", msgFile)
+	} else {
+		err = sk.SetStringValue("EventMessageFile", msgFile)
+	}
+	if err != nil {
+		return err
+	}
+	err = sk.SetDWordValue("TypesSupported", eventsSupported)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// InstallAsEventCreate is the same as Install, but uses
+// %SystemRoot%\System32\EventCreate.exe as the event message file.
+func InstallAsEventCreate(src string, eventsSupported uint32) error {
+	return Install(src, "%SystemRoot%\\System32\\EventCreate.exe", true, eventsSupported)
+}
+
+// Remove deletes all registry elements installed by the correspondent Install.
+func Remove(src string) error {
+	appkey, err := registry.OpenKey(registry.LOCAL_MACHINE, addKeyName, registry.SET_VALUE)
+	if err != nil {
+		return err
+	}
+	defer appkey.Close()
+	return registry.DeleteKey(appkey, src)
+}

--- a/vendor/golang.org/x/sys/windows/svc/eventlog/log.go
+++ b/vendor/golang.org/x/sys/windows/svc/eventlog/log.go
@@ -1,0 +1,70 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build windows
+
+// Package eventlog implements access to Windows event log.
+//
+package eventlog
+
+import (
+	"errors"
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+// Log provides access to the system log.
+type Log struct {
+	Handle windows.Handle
+}
+
+// Open retrieves a handle to the specified event log.
+func Open(source string) (*Log, error) {
+	return OpenRemote("", source)
+}
+
+// OpenRemote does the same as Open, but on different computer host.
+func OpenRemote(host, source string) (*Log, error) {
+	if source == "" {
+		return nil, errors.New("Specify event log source")
+	}
+	var s *uint16
+	if host != "" {
+		s = syscall.StringToUTF16Ptr(host)
+	}
+	h, err := windows.RegisterEventSource(s, syscall.StringToUTF16Ptr(source))
+	if err != nil {
+		return nil, err
+	}
+	return &Log{Handle: h}, nil
+}
+
+// Close closes event log l.
+func (l *Log) Close() error {
+	return windows.DeregisterEventSource(l.Handle)
+}
+
+func (l *Log) report(etype uint16, eid uint32, msg string) error {
+	ss := []*uint16{syscall.StringToUTF16Ptr(msg)}
+	return windows.ReportEvent(l.Handle, etype, 0, eid, 0, 1, 0, &ss[0], nil)
+}
+
+// Info writes an information event msg with event id eid to the end of event log l.
+// When EventCreate.exe is used, eid must be between 1 and 1000.
+func (l *Log) Info(eid uint32, msg string) error {
+	return l.report(windows.EVENTLOG_INFORMATION_TYPE, eid, msg)
+}
+
+// Warning writes an warning event msg with event id eid to the end of event log l.
+// When EventCreate.exe is used, eid must be between 1 and 1000.
+func (l *Log) Warning(eid uint32, msg string) error {
+	return l.report(windows.EVENTLOG_WARNING_TYPE, eid, msg)
+}
+
+// Error writes an error event msg with event id eid to the end of event log l.
+// When EventCreate.exe is used, eid must be between 1 and 1000.
+func (l *Log) Error(eid uint32, msg string) error {
+	return l.report(windows.EVENTLOG_ERROR_TYPE, eid, msg)
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1287,6 +1287,12 @@
 			"revisionTime": "2016-06-14T22:52:37Z"
 		},
 		{
+			"checksumSHA1": "uVlUSSKplihZG7N+QJ6fzDZ4Kh8=",
+			"path": "golang.org/x/sys/windows/svc/eventlog",
+			"revision": "571f7bbbe08da2a8955aed9d4db316e78630e9a3",
+			"revisionTime": "2017-12-16T14:55:03Z"
+		},
+		{
 			"checksumSHA1": "oaglBTpGgEUgk7m92i6nuZbpicE=",
 			"path": "golang.org/x/text/encoding",
 			"revision": "2910a502d2bf9e43193af9d68ca516529614eed3",

--- a/winlogbeat/winlogbeat.reference.yml
+++ b/winlogbeat/winlogbeat.reference.yml
@@ -756,12 +756,11 @@ setup.kibana:
 
 
 #================================ Logging ======================================
-# There are three options for the log output: syslog, file, stderr.
-# Under Windows systems, the log files are per default sent to the file output,
-# under all other system per default to syslog.
+# There are four options for the log output: file, stderr, syslog, eventlog
+# The file output is the default.
 
 # Sets log level. The default log level is info.
-# Available log levels are: critical, error, warning, info, debug
+# Available log levels are: error, warning, info, debug
 #logging.level: info
 
 # Enable debug output for selected components. To enable all selectors use ["*"]
@@ -770,7 +769,10 @@ setup.kibana:
 #logging.selectors: [ ]
 
 # Send all logging output to syslog. The default is false.
-#logging.to_syslog: true
+#logging.to_syslog: false
+
+# Send all logging output to Windows Event Logs. The default is false.
+#logging.to_eventlog: false
 
 # If enabled, winlogbeat periodically logs its internal metrics that have changed
 # in the last period. For each metric that changed, the delta from the value at

--- a/winlogbeat/winlogbeat.yml
+++ b/winlogbeat/winlogbeat.yml
@@ -115,7 +115,7 @@ output.elasticsearch:
 #================================ Logging =====================================
 
 # Sets log level. The default log level is info.
-# Available log levels are: critical, error, warning, info, debug
+# Available log levels are: error, warning, info, debug
 #logging.level: debug
 
 # At debug level, you can selectively enable logging only for some components.


### PR DESCRIPTION
By setting `logging.to_eventlog: true` all log output will be written
to the Application log. The source name will be name of the Beat.