### PR TITLE
Fix race-condition on RunPushMetricSetV2

### DIFF
--- a/metricbeat/mb/testing/modules.go
+++ b/metricbeat/mb/testing/modules.go
@@ -38,7 +38,6 @@ package testing
 
 import (
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -221,58 +220,64 @@ func NewPushMetricSetV2(t testing.TB, config interface{}) mb.PushMetricSetV2 {
 // capturingReporterV2 stores all the events and errors from a metricset's
 // Run method.
 type capturingReporterV2 struct {
-	Events []mb.Event
-	DoneC  chan struct{}
-	count  int32
+	doneC   chan struct{}
+	eventsC chan mb.Event
 }
 
 // Event stores the passed-in event into the events array
 func (r *capturingReporterV2) Event(event mb.Event) bool {
-	r.Events = append(r.Events, event)
-	atomic.AddInt32(&r.count, 1)
+	r.eventsC <- event
 	return true
 }
 
 // Error stores the given error into the errors array.
 func (r *capturingReporterV2) Error(err error) bool {
-	r.Events = append(r.Events, mb.Event{Error: err})
+	r.eventsC <- mb.Event{Error: err}
 	return true
 }
 
 // Done returns the Done channel for this reporter.
 func (r *capturingReporterV2) Done() <-chan struct{} {
-	return r.DoneC
-}
-
-func (r *capturingReporterV2) eventCount() int {
-	return int(atomic.LoadInt32(&r.count))
+	return r.doneC
 }
 
 // RunPushMetricSetV2 run the given push metricset for the specific amount of
 // time and returns all of the events and errors that occur during that period.
 func RunPushMetricSetV2(timeout time.Duration, waitEvents int, metricSet mb.PushMetricSetV2) []mb.Event {
-	r := &capturingReporterV2{DoneC: make(chan struct{})}
-	defer close(r.DoneC)
+	var (
+		r      = &capturingReporterV2{doneC: make(chan struct{}), eventsC: make(chan mb.Event)}
+		wg     sync.WaitGroup
+		events []mb.Event
+	)
+	wg.Add(2)
 
-	termC := make(chan struct{}, 1)
-
+	// Producer
 	go func() {
-		defer close(termC)
+		defer wg.Done()
+		defer close(r.eventsC)
 		metricSet.Run(r)
 	}()
 
-	timeoutC := time.After(timeout)
-	for {
-		select {
-		case <-termC:
-			return r.Events
-		case <-timeoutC:
-			return r.Events
-		default:
-			if waitEvents != 0 && waitEvents <= r.eventCount() {
-				return r.Events
+	// Consumer
+	go func() {
+		defer wg.Done()
+		defer close(r.doneC)
+
+		timer := time.NewTimer(timeout)
+		defer timer.Stop()
+		for {
+			select {
+			case <-timer.C:
+				return
+			case e := <-r.eventsC:
+				events = append(events, e)
+				if waitEvents > 0 && waitEvents <= len(events) {
+					return
+				}
 			}
-			time.Sleep(100 * time.Millisecond)
 		}
-	}
+	}()
+
+	wg.Wait()
+	return events
 }


### PR DESCRIPTION
This patch fixes a race condition in the metricset test helper RunPushMetricSetV2.

A previous patch already fixed some issues but there was another race-condition left where a returned slice of bytes could be appended to by a different thread.
