### PR TITLE
Log structured monitoring metrics

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -110,6 +110,8 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Moved `ip_port` indexer for `add_kubernetes_metadata` to all beats. {pull}5707[5707]
 - `ip_port` indexer now index both IP and IP:port pairs. {pull}5721[5721]
 - Add the ability to write structured logs. {pull}5901[5901]
+- Use structured logging for the metrics that are periodically logged via the
+  `logging.metrics` feature. {pull}5915[5915]
 
 *Auditbeat*
 

--- a/libbeat/monitoring/report/log/log.go
+++ b/libbeat/monitoring/report/log/log.go
@@ -1,7 +1,6 @@
 package log
 
 import (
-	"sort"
 	"sync"
 	"time"
 
@@ -162,28 +161,17 @@ func snapshotLen(s monitoring.FlatSnapshot) int {
 func toKeyValuePairs(s monitoring.FlatSnapshot) []interface{} {
 	data := make(common.MapStr, snapshotLen(s))
 	for k, v := range s.Bools {
-		data[k] = v
+		data.Put(k, v)
 	}
 	for k, v := range s.Floats {
-		data[k] = v
+		data.Put(k, v)
 	}
 	for k, v := range s.Ints {
-		data[k] = v
+		data.Put(k, v)
 	}
 	for k, v := range s.Strings {
-		data[k] = v
+		data.Put(k, v)
 	}
 
-	keys := make([]string, 0, len(data))
-	for k := range data {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-
-	metrics := make([]interface{}, 0, 2*len(data)+2)
-	metrics = append(metrics, logp.Namespace("monitoring"), logp.Namespace("metrics"))
-	for _, key := range keys {
-		metrics = append(metrics, key, data[key])
-	}
-	return metrics
+	return []interface{}{logp.Namespace("monitoring"), logp.Reflect("metrics", data)}
 }

--- a/libbeat/tests/system/test_base.py
+++ b/libbeat/tests/system/test_base.py
@@ -168,11 +168,11 @@ class Test(BaseTest):
         )
         proc = self.start_beat(logging_args=["-e"])
         self.wait_until(
-            lambda: self.log_contains("Non-zero metrics in the last 100ms:"),
+            lambda: self.log_contains("Non-zero metrics in the last 100ms"),
             max_timeout=2)
         proc.check_kill_and_wait()
         self.wait_until(
-            lambda: self.log_contains("Total non-zero metrics:"),
+            lambda: self.log_contains("Total non-zero metrics"),
             max_timeout=2)
 
     def test_persistent_uuid(self):


### PR DESCRIPTION
- Use structured logging for the metrics that are periodically logged.

- Add beat.info.uptime.ms to the list of gauges so that the total value is always reported rather than a difference.

- Made a change to ensure that only non-zero counter values are reported at shutdown (this was bug introduced in my last refactoring). Note that zero-value gauges are reported which kind of makes the "Total non-zero metrics" message misleading.

Log samples:

```
2017-12-19T11:57:21.086-0500	INFO	[monitoring]	log/log.go:79	Starting metrics logging every 3s
2017-12-19T11:57:24.087-0500	INFO	[monitoring]	log/log.go:106	Non-zero metrics in the last 3s	{"monitoring": {"metrics": {"beat":{"info":{"uptime":{"ms":3004}},"memstats":{"gc_next":4194304,"memory_alloc":2298976,"memory_total":12648056}},"libbeat":{"config":{"module":{"running":0}},"output":{"type":"elasticsearch"},"pipeline":{"clients":1,"events":{"active":1,"published":1,"total":1}}},"metricbeat":{"file_integrity":{"file":{"events":1,"success":1}}}}}}
2017-12-19T11:57:25.305-0500	INFO	[monitoring]	log/log.go:114	Total non-zero metrics	{"monitoring": {"metrics": {"beat":{"info":{"uptime":{"ms":4222}},"memstats":{"gc_next":4194304,"memory_alloc":3336376,"memory_total":20548168}},"libbeat":{"config":{"module":{"running":0}},"output":{"type":"elasticsearch"},"pipeline":{"clients":0,"events":{"active":1,"published":1,"total":1}}}}}}
2017-12-19T11:57:25.305-0500	INFO	[monitoring]	log/log.go:115	Uptime: 4.226912514s
2017-12-19T11:57:25.305-0500	INFO	[monitoring]	log/log.go:92	Stopping metrics logging.
```

To show the key structure more clearly here is a pretty-printed version of the logged JSON metrics.

```
{
  "monitoring": {
    "metrics": {
      "beat": {
        "info": {
          "uptime": {
            "ms": 4222
          }
        },
        "memstats": {
          "gc_next": 4194304,
          "memory_alloc": 3336376,
          "memory_total": 20548168
        }
      },
      "libbeat": {
        "config": {
          "module": {
            "running": 0
          }
        },
        "output": {
          "type": "elasticsearch"
        },
        "pipeline": {
          "clients": 0,
          "events": {
            "active": 1,
            "published": 1,
            "total": 1
          }
        }
      }
    }
  }
}
```