### PR TITLE
Cherry-pick #5902 to 6.1: metricbeat: fix zookeeper fetching file descriptor info incorrectly

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -124,6 +124,7 @@ https://github.com/elastic/beats/compare/v6.0.1...v6.1.0[View commits]
 - Change `MySQL active connections` visualization title to `MySQL total connections`. {issue}4812[4812]
 - Fix `ProcState` on Linux and FreeBSD when process names contain parentheses. {pull}5775[5775]
 - Fix incorrect `Mem.Used` calculation under linux. {pull}5775[5775]
+- Fix `open_file_descriptor_count` and `max_file_descriptor_count` lost in zookeeper module {pull}5902[5902]
 
 *Packetbeat*
 

--- a/metricbeat/module/zookeeper/mntr/data.go
+++ b/metricbeat/module/zookeeper/mntr/data.go
@@ -65,7 +65,7 @@ func eventMapping(response io.Reader) common.MapStr {
 	}
 
 	// only available on Unix platforms
-	if _, ok := fullEvent["open_file_descriptor_count"]; ok {
+	if _, ok := fullEvent["zk_open_file_descriptor_count"]; ok {
 		schemaUnix.ApplyTo(event, fullEvent)
 	}
 


### PR DESCRIPTION
Cherry-pick of PR #5902 to 6.1 branch. Original message: 


Use `zk_open_file_descriptor_count` instead of `open_file_descriptor_count` to check whether the zookeeper is running on Unix platforms.

Because the output variable is `zk_open_file_descriptor_count` depending on the doc [ZooKeeper Administrator's Guide](http://zookeeper.apache.org/doc/current/zookeeperAdmin.html#sc_zkCommands)