### PR TITLE
metricbeat: fetch offset info from primary partiton instead of replica partition

### DIFF
--- a/metricbeat/docs/fields.asciidoc
+++ b/metricbeat/docs/fields.asciidoc
@@ -4839,30 +4839,6 @@ Leader id (broker).
 
 
 [float]
-=== `kafka.partition.partition.isr`
-
-type: array
-
-List of isr ids.
-
-
-[float]
-=== `kafka.partition.partition.replica`
-
-type: long
-
-Replica id (broker).
-
-
-[float]
-=== `kafka.partition.partition.insync_replica`
-
-type: boolean
-
-Indicates if replica is included in the in-sync replicate set (ISR).
-
-
-[float]
 === `kafka.partition.partition.error.code`
 
 type: long

--- a/metricbeat/module/kafka/partition/_meta/data.json
+++ b/metricbeat/module/kafka/partition/_meta/data.json
@@ -16,9 +16,7 @@
             },
             "partition": {
                 "id": 0,
-                "insync_replica": true,
-                "leader": 0,
-                "replica": 0
+                "leader": 0
             },
             "topic": {
                 "name": "foo-1512631793-855878006"

--- a/metricbeat/module/kafka/partition/_meta/fields.yml
+++ b/metricbeat/module/kafka/partition/_meta/fields.yml
@@ -32,19 +32,6 @@
           type: long
           description: >
             Leader id (broker).
-        - name: isr
-          type: array
-          description: >
-            List of isr ids.
-        - name: replica
-          type: long
-          description: >
-            Replica id (broker).
-
-        - name: insync_replica
-          type: boolean
-          description: >
-            Indicates if replica is included in the in-sync replicate set (ISR).
 
         - name: error.code
           type: long


### PR DESCRIPTION
fetch topic offset info from primary partition, because of the follow reasons:
- 1. The offset information of primary partiton is enough for learning about topic offset;
- 2. When the replica count of partiton is 0, you can not get anything from replica partiton;
- 3. When the replica count of partiton is more than 1, you will generate replica record from replica partiton list;
- 4. You do not need to set `replica_id` parameter in ListOffsets request and just set it `-1` appending on the [Kafka protocol guide](http://kafka.apache.org/protocol.html#The_Messages_ListOffsets)