### PR TITLE
Cherry-pick #5894 to 6.0: Filter packages in Jenkins Powershell

### DIFF
--- a/dev-tools/jenkins_ci.sh
+++ b/dev-tools/jenkins_ci.sh
@@ -19,12 +19,18 @@ jenkins_setup
 cleanup() {
   echo "Running cleanup..."
   rm -rf $TEMP_PYTHON_ENV
-  make stop-environment || true
-  make fix-permissions || true
-  echo "Killing all running containers..."
-  docker ps -q | xargs -r docker kill || true
-  echo "Cleaning stopped docker containers and dangling images/networks/volumes..."
-  docker system prune -f || true
+
+  if docker info > /dev/null ; then
+    make stop-environment || true
+    make fix-permissions || true
+    echo "Killing all running containers..."
+    ids=$(docker ps -q)
+    if [ -n "$ids" ]; then
+      docker kill $ids
+    fi  
+    echo "Cleaning stopped docker containers and dangling images/networks/volumes..."
+    docker system prune -f || true
+  fi
   echo "Cleanup complete."
 }
 trap cleanup EXIT


### PR DESCRIPTION
Cherry-pick of PR #5894 to 6.0 branch. Original message: 

This filters the packages used to create the beatname.test binary used in system tests. We needed to filter the tools in scripts/cmd because the code should not be included in the test binary.