### PR TITLE
Cherry-pick #5910 to 6.0: Allow TEST_ENVIRONMENT to be externally disabled

### DIFF
--- a/libbeat/Makefile
+++ b/libbeat/Makefile
@@ -1,5 +1,5 @@
 BEAT_NAME=libbeat
-TEST_ENVIRONMENT=true
+TEST_ENVIRONMENT?=true
 SYSTEM_TESTS=true
 
 include scripts/Makefile


### PR DESCRIPTION
Cherry-pick of PR #5910 to 6.0 branch. Original message: 

Builds that set TEST_ENVIRONMENT=0 should be able to override this
value in order to avoid Docker usage.