### PR TITLE
Update file_integrity logging

### DIFF
--- a/auditbeat/module/file_integrity/action.go
+++ b/auditbeat/module/file_integrity/action.go
@@ -83,6 +83,9 @@ func (action Action) String() string {
 	return strings.Join(list, "|")
 }
 
+// MarshalText marshals the Action to a textual representation of itself.
+func (action Action) MarshalText() ([]byte, error) { return []byte(action.String()), nil }
+
 func resolveActionOrder(action Action, existedBefore, existsNow bool) ActionArray {
 	if action == None {
 		return nil

--- a/auditbeat/module/file_integrity/event.go
+++ b/auditbeat/module/file_integrity/event.go
@@ -7,7 +7,6 @@ import (
 	"crypto/sha256"
 	"crypto/sha512"
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
 	"hash"
 	"io"
@@ -92,13 +91,13 @@ func (d Digest) MarshalText() ([]byte, error) { return []byte(d.String()), nil }
 
 // Event describe the filesystem change and includes metadata about the file.
 type Event struct {
-	Timestamp  time.Time           // Time of event.
-	Path       string              // The path associated with the event.
-	TargetPath string              // Target path for symlinks.
-	Info       *Metadata           // File metadata (if the file exists).
-	Source     Source              // Source of the event.
-	Action     Action              // Action (like created, updated).
-	Hashes     map[HashType]Digest // File hashes.
+	Timestamp  time.Time           `json:"timestamp"`             // Time of event.
+	Path       string              `json:"path"`                  // The path associated with the event.
+	TargetPath string              `json:"target_path,omitempty"` // Target path for symlinks.
+	Info       *Metadata           `json:"info"`                  // File metadata (if the file exists).
+	Source     Source              `json:"source"`                // Source of the event.
+	Action     Action              `json:"action"`                // Action (like created, updated).
+	Hashes     map[HashType]Digest `json:"hash,omitempty"`        // File hashes.
 
 	// Metadata
 	rtt    time.Duration // Time taken to collect the info.
@@ -107,20 +106,20 @@ type Event struct {
 
 // Metadata contains file metadata.
 type Metadata struct {
-	Inode  uint64
-	UID    uint32
-	GID    uint32
-	SID    string
-	Owner  string
-	Group  string
-	Size   uint64
-	MTime  time.Time   // Last modification time.
-	CTime  time.Time   // Last metadata change time.
-	Type   Type        // File type (dir, file, symlink).
-	Mode   os.FileMode // Permissions
-	SetUID bool        // setuid bit (POSIX only)
-	SetGID bool        // setgid bit (POSIX only)
-	Origin []string    // External origin info for the file (MacOS only)
+	Inode  uint64      `json:"inode"`
+	UID    uint32      `json:"uid"`
+	GID    uint32      `json:"gid"`
+	SID    string      `json:"sid"`
+	Owner  string      `json:"owner"`
+	Group  string      `json:"group"`
+	Size   uint64      `json:"size"`
+	MTime  time.Time   `json:"mtime"`  // Last modification time.
+	CTime  time.Time   `json:"ctime"`  // Last metadata change time.
+	Type   Type        `json:"type"`   // File type (dir, file, symlink).
+	Mode   os.FileMode `json:"mode"`   // Permissions
+	SetUID bool        `json:"setuid"` // setuid bit (POSIX only)
+	SetGID bool        `json:"setgid"` // setgid bit (POSIX only)
+	Origin []string    `json:"origin"` // External origin info for the file (MacOS only)
 }
 
 // NewEventFromFileInfo creates a new Event based on data from a os.FileInfo
@@ -195,11 +194,6 @@ func NewEvent(
 	}
 	err = errors.Wrap(err, "failed to lstat")
 	return NewEventFromFileInfo(path, info, err, action, source, maxFileSize, hashTypes)
-}
-
-func (e *Event) String() string {
-	data, _ := json.Marshal(e)
-	return string(data)
 }
 
 func buildMetricbeatEvent(e *Event, existedBefore bool) mb.Event {

--- a/auditbeat/module/file_integrity/event_test.go
+++ b/auditbeat/module/file_integrity/event_test.go
@@ -31,7 +31,7 @@ func testEvent() *Event {
 			MTime:  testEventTime,
 			SetGID: true,
 		},
-		Hashes: map[HashType][]byte{
+		Hashes: map[HashType]Digest{
 			SHA1:   mustDecodeHex("abcd"),
 			SHA256: mustDecodeHex("1234"),
 		},
@@ -109,7 +109,7 @@ func TestDiffEvents(t *testing.T) {
 
 	t.Run("different hash values", func(t *testing.T) {
 		e := testEvent()
-		e.Hashes = map[HashType][]byte{
+		e.Hashes = map[HashType]Digest{
 			SHA1:   mustDecodeHex("ef"),
 			SHA256: mustDecodeHex("1234"),
 		}
@@ -121,7 +121,7 @@ func TestDiffEvents(t *testing.T) {
 
 	t.Run("updated hashes and metadata", func(t *testing.T) {
 		e := testEvent()
-		e.Hashes = map[HashType][]byte{
+		e.Hashes = map[HashType]Digest{
 			SHA1:   mustDecodeHex("ef"),
 			SHA256: mustDecodeHex("1234"),
 		}
@@ -154,7 +154,7 @@ func TestDiffEvents(t *testing.T) {
 func TestHashFile(t *testing.T) {
 	t.Run("valid hashes", func(t *testing.T) {
 		// Computed externally.
-		expectedHashes := map[HashType][]byte{
+		expectedHashes := map[HashType]Digest{
 			BLAKE2B_256: mustDecodeHex("0f0cc1f0ea4ef962d6a150ae0b77bc320b57ed24e1609b933fa2274484f59145"),
 			BLAKE2B_384: mustDecodeHex("b819d90f648da6effff2393acb1884d2638642b3524c329832c073c9364149fcdedb522914ef9c2c92f007a42366139a"),
 			BLAKE2B_512: mustDecodeHex("fc13029e8a5ce67ad5a70f0cc659a4b30df9d791b125835e434606c6127ee37ebbc8b216389682ddfa84380789db09f2535d2a9837454414ea3ff00ec0801150"),

--- a/auditbeat/module/file_integrity/flatbuffers.go
+++ b/auditbeat/module/file_integrity/flatbuffers.go
@@ -52,7 +52,7 @@ func fbEncodeEvent(b *flatbuffers.Builder, e *Event) []byte {
 	return b.FinishedBytes()
 }
 
-func fbWriteHash(b *flatbuffers.Builder, hashes map[HashType][]byte) flatbuffers.UOffsetT {
+func fbWriteHash(b *flatbuffers.Builder, hashes map[HashType]Digest) flatbuffers.UOffsetT {
 	if len(hashes) == 0 {
 		return 0
 	}
@@ -252,13 +252,13 @@ func fbDecodeMetadata(e *schema.Event) *Metadata {
 	return rtn
 }
 
-func fbDecodeHash(e *schema.Event) map[HashType][]byte {
+func fbDecodeHash(e *schema.Event) map[HashType]Digest {
 	hash := e.Hashes(nil)
 	if hash == nil {
 		return nil
 	}
 
-	rtn := map[HashType][]byte{}
+	rtn := map[HashType]Digest{}
 	for _, hashType := range validHashes {
 		var length int
 		var producer func(i int) int8

--- a/libbeat/logp/encoding.go
+++ b/libbeat/logp/encoding.go
@@ -1,8 +1,6 @@
 package logp
 
 import (
-	"time"
-
 	"go.uber.org/zap/zapcore"
 )
 
@@ -16,7 +14,7 @@ var baseEncodingConfig = zapcore.EncoderConfig{
 	LineEnding:     zapcore.DefaultLineEnding,
 	EncodeLevel:    zapcore.LowercaseLevelEncoder,
 	EncodeTime:     zapcore.ISO8601TimeEncoder,
-	EncodeDuration: millisecondsDurationEncoder,
+	EncodeDuration: zapcore.NanosDurationEncoder,
 	EncodeCaller:   zapcore.ShortCallerEncoder,
 	EncodeName:     zapcore.FullNameEncoder,
 }
@@ -47,10 +45,6 @@ func syslogEncoderConfig() zapcore.EncoderConfig {
 	// Time is added by syslog.
 	c.TimeKey = ""
 	return c
-}
-
-func millisecondsDurationEncoder(d time.Duration, enc zapcore.PrimitiveArrayEncoder) {
-	enc.AppendFloat64(float64(d) / float64(time.Millisecond))
 }
 
 func bracketedNameEncoder(loggerName string, enc zapcore.PrimitiveArrayEncoder) {


### PR DESCRIPTION
- Use nanoseconds for logging time.Duration

- Add Digest type implementing TextMarshaler

  This adds `type Digest []byte` for representing the result of a hash function.

  This new type implements the Stringer and TextMarshaler interfaces so that the digest value is represented as a hexadecimal string.

- Update file_integrity metricset logging