### PR TITLE
Enable system tests for auditbeat

### DIFF
--- a/auditbeat/Dockerfile
+++ b/auditbeat/Dockerfile
@@ -1,0 +1,17 @@
+FROM golang:1.9.2
+MAINTAINER Nicolas Ruflin <ruflin@elastic.co>
+
+RUN set -x && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+         netcat python-pip virtualenv && \
+    apt-get clean
+
+RUN pip install --upgrade setuptools
+
+# Setup work environment
+ENV AUDITBEAT_PATH /go/src/github.com/elastic/beats/auditbeat
+
+RUN mkdir -p $AUDITBEAT_PATH/build/coverage
+WORKDIR $AUDITBEAT_PATH
+HEALTHCHECK CMD exit 0

--- a/auditbeat/Makefile
+++ b/auditbeat/Makefile
@@ -1,13 +1,15 @@
 BEAT_NAME=auditbeat
 BEAT_TITLE=Auditbeat
 BEAT_DESCRIPTION=Audit the activities of users and processes on your system.
-SYSTEM_TESTS=false
-TEST_ENVIRONMENT=false
+SYSTEM_TESTS=true
+TEST_ENVIRONMENT?=true
 GOX_OS?=linux windows ## @Building List of all OS to be supported by "make crosscompile".
 DEV_OS?=linux
+TESTING_ENVIRONMENT?=snapshot-noxpack
+ES_BEATS?=..
 
 # Path to the libbeat Makefile
--include ../libbeat/scripts/Makefile
+include ${ES_BEATS}/libbeat/scripts/Makefile
 
 # This is called by the beats packer before building starts
 .PHONY: before-build

--- a/auditbeat/docker-compose.yml
+++ b/auditbeat/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '2.1'
+services:
+  beat:
+    build: ${PWD}/.
+    depends_on:
+      - proxy_dep
+    env_file:
+      - ${PWD}/build/test.env
+    working_dir: /go/src/github.com/elastic/beats/auditbeat
+    volumes:
+      - ${PWD}/..:/go/src/github.com/elastic/beats/
+    command: make
+
+  # This is a proxy used to block beats until all services are healthy.
+  # See: https://github.com/docker/compose/issues/4369
+  proxy_dep:
+    image: busybox
+    depends_on:
+      elasticsearch: { condition: service_healthy }
+
+  elasticsearch:
+    extends:
+      file: ../testing/environments/${TESTING_ENVIRONMENT}.yml
+      service: elasticsearch

--- a/auditbeat/docker-compose.yml
+++ b/auditbeat/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '2.1'
 services:
   beat:
     build: ${PWD}/.

--- a/auditbeat/docker-compose.yml
+++ b/auditbeat/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2'
 services:
   beat:
     build: ${PWD}/.

--- a/auditbeat/module/file_integrity/monitor/filetree_test.go
+++ b/auditbeat/module/file_integrity/monitor/filetree_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package monitor
 
 import (

--- a/auditbeat/module/file_integrity/monitor/monitor_test.go
+++ b/auditbeat/module/file_integrity/monitor/monitor_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package monitor
 
 import (

--- a/auditbeat/tests/system/auditbeat.py
+++ b/auditbeat/tests/system/auditbeat.py
@@ -1,14 +1,14 @@
 import os
 import sys
 
-sys.path.append('../../../libbeat/tests/system')
-from beat.beat import TestCase
+sys.path.append('../../../metricbeat/tests/system')
+from metricbeat import BaseTest as MetricbeatTest
 
 
-class BaseTest(TestCase):
+class BaseTest(MetricbeatTest):
     @classmethod
     def setUpClass(self):
         self.beat_name = "auditbeat"
         self.beat_path = os.path.abspath(
             os.path.join(os.path.dirname(__file__), "../../"))
-        super(BaseTest, self).setUpClass()
+        super(MetricbeatTest, self).setUpClass()

--- a/auditbeat/tests/system/test_base.py
+++ b/auditbeat/tests/system/test_base.py
@@ -7,15 +7,18 @@ from beat.beat import INTEGRATION_TESTS
 
 
 class Test(BaseTest):
-    @unittest.skipUnless(re.match("(?i)linux", sys.platform), "os")
     def test_start_stop(self):
         """
         Auditbeat starts and stops without error.
         """
-        self.render_config_template(modules=[{
-            "name": "audit",
-            "metricsets": ["kernel"],
-        }])
+        self.render_config_template(
+            modules=[{
+                "name": "file_integrity",
+                "extras": {
+                    "paths": ["file.example"],
+                }
+            }],
+        )
         proc = self.start_beat()
         self.wait_until(lambda: self.log_contains("start running"))
         proc.check_kill_and_wait()
@@ -35,11 +38,10 @@ class Test(BaseTest):
 
         self.render_config_template(
             modules=[{
-                "name": "audit",
-                "metricsets": ["file"],
+                "name": "file_integrity",
                 "extras": {
-                    "file.paths": ["file.example"],
-                },
+                    "paths": ["file.example"],
+                }
             }],
             elasticsearch={"host": self.get_elasticsearch_url()})
         exit_code = self.run_beat(extra_args=["setup", "--template"])

--- a/metricbeat/docker-compose.yml
+++ b/metricbeat/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '2.1'
 services:
   beat:
     build: ${PWD}/.

--- a/metricbeat/docker-compose.yml
+++ b/metricbeat/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2'
 services:
   beat:
     build: ${PWD}/.


### PR DESCRIPTION
* There were system tests and system integration tests for auditbeat but so far they were not run.
* Integration tests enabled
* Module config changed to module that works on more systems. Limitation for linux removed.

This is prerequisite for https://github.com/elastic/beats/pull/5938