### PR TITLE
add allow_failures for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -127,6 +127,9 @@ jobs:
         - TARGETS="-C deploy/kubernetes test"
         - TRAVIS_KUBE_VERSION=v1.8.0
       stage: test
+  allow_failures:
+    - env: TARGETS="-C filebeat testsuite"
+    - env: TARGETS="-C libbeat testsuite"
 
 addons:
   apt:


### PR DESCRIPTION
As I see, for now there is a lot of PR do not pass CI, since there is timeouts for some tests.

There is several ways to fix it:

1. Increase timeout

2. Reorganize tests to avoid job fail because of timeout

3. Setup allow_failures in travis

All this three ways better than how it work now (fail by timeout). First way impossible to do, since looks like timeouts hardcoded inside travis.

Second way the best option, but needs time.

So, this PR implement third way as a trade of. After merge this PR, there is can be issue created to reorganize tests and drop "allow_failures".

ps. Also test build take so much time, I think there is must be "fast" tests. Or think about speedup tests.