### PR TITLE
Do not fail recursive watches due to unaccessible subdir

### DIFF
--- a/auditbeat/module/file_integrity/monitor/monitor_test.go
+++ b/auditbeat/module/file_integrity/monitor/monitor_test.go
@@ -2,6 +2,7 @@ package monitor
 
 import (
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -37,7 +38,7 @@ func TestNonRecursive(t *testing.T) {
 	subdir := filepath.Join(dir, "subdir")
 	os.Mkdir(subdir, 0750)
 
-	ev, err := readTimeout(watcher.EventChannel())
+	ev, err := readTimeout(watcher)
 	assertNoError(t, err)
 	assert.Equal(t, subdir, ev.Name)
 	assert.Equal(t, fsnotify.Create, ev.Op)
@@ -46,7 +47,7 @@ func TestNonRecursive(t *testing.T) {
 	subfile := filepath.Join(subdir, "file.dat")
 	assertNoError(t, ioutil.WriteFile(subfile, []byte("foo"), 0640))
 
-	_, err = readTimeout(watcher.EventChannel())
+	_, err = readTimeout(watcher)
 	assert.Error(t, err)
 	assert.Equal(t, errReadTimeout, err)
 
@@ -77,7 +78,7 @@ func TestRecursive(t *testing.T) {
 	subdir := filepath.Join(dir, "subdir")
 	os.Mkdir(subdir, 0750)
 
-	ev, err := readTimeout(watcher.EventChannel())
+	ev, err := readTimeout(watcher)
 	assertNoError(t, err)
 	assert.Equal(t, subdir, ev.Name)
 	assert.Equal(t, fsnotify.Create, ev.Op)
@@ -132,12 +133,107 @@ func TestRecursiveNoFollowSymlink(t *testing.T) {
 	assertNoError(t, ioutil.WriteFile(file, []byte("hello"), 0640))
 
 	// No event is received
-	ev, err := readTimeout(watcher.EventChannel())
+	ev, err := readTimeout(watcher)
 	assert.Equal(t, errReadTimeout, err)
 	if err == nil {
 		t.Fatalf("Expected timeout, got event %+v", ev)
 	}
 	assertNoError(t, watcher.Close())
+}
+
+func TestRecursiveSubdirPermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping permissions test on Windows")
+	}
+
+	// Create dir to be watched
+
+	dir, err := ioutil.TempDir("", "monitor")
+	assertNoError(t, err)
+	if runtime.GOOS == "darwin" {
+		if dirAlt, err := filepath.EvalSymlinks(dir); err == nil {
+			dir = dirAlt
+		}
+	}
+	defer os.RemoveAll(dir)
+
+	// Create not watched dir
+
+	outDir, err := ioutil.TempDir("", "non-watched")
+	assertNoError(t, err)
+	if runtime.GOOS == "darwin" {
+		if dirAlt, err := filepath.EvalSymlinks(outDir); err == nil {
+			outDir = dirAlt
+		}
+	}
+	defer os.RemoveAll(outDir)
+
+	// Populate not watched subdir
+
+	for _, name := range []string{"a", "b", "c"} {
+		path := filepath.Join(outDir, name)
+		assertNoError(t, os.Mkdir(path, 0755))
+		assertNoError(t, ioutil.WriteFile(filepath.Join(path, name), []byte("Hello"), 0644))
+	}
+
+	// Make a subdir not accessible
+
+	assertNoError(t, os.Chmod(filepath.Join(outDir, "b"), 0))
+
+	// Setup watched on watched dir
+
+	watcher, err := New(true)
+	assertNoError(t, err)
+
+	assertNoError(t, watcher.Add(dir))
+	assertNoError(t, watcher.Start())
+	defer func() {
+		assertNoError(t, watcher.Close())
+	}()
+
+	// No event is received
+
+	ev, err := readTimeout(watcher)
+	assert.Equal(t, errReadTimeout, err)
+	if err != errReadTimeout {
+		t.Fatalf("Expected timeout, got event %+v", ev)
+	}
+
+	// Move the outside directory into the watched
+
+	dest := filepath.Join(dir, "subdir")
+	assertNoError(t, os.Rename(outDir, dest))
+
+	// Receive all events
+
+	var evs []fsnotify.Event
+	for {
+		// No event is received
+		ev, err := readTimeout(watcher)
+		if err == errReadTimeout {
+			break
+		}
+		assertNoError(t, err)
+		evs = append(evs, ev)
+	}
+
+	// Verify that events for all accessible files are received
+	// File "b/b" is missing because a watch to b couldn't be installed
+
+	expected := map[string]fsnotify.Op{
+		dest: fsnotify.Create,
+		filepath.Join(dest, "a"):   fsnotify.Create,
+		filepath.Join(dest, "a/a"): fsnotify.Create,
+		filepath.Join(dest, "b"):   fsnotify.Create,
+		filepath.Join(dest, "c"):   fsnotify.Create,
+		filepath.Join(dest, "c/c"): fsnotify.Create,
+	}
+	assert.Len(t, evs, len(expected))
+	for _, ev := range evs {
+		op, found := expected[ev.Name]
+		assert.True(t, found, ev.Name)
+		assert.Equal(t, op, ev.Op)
+	}
 }
 
 func testDirOps(t *testing.T, dir string, watcher Watcher) {
@@ -147,7 +243,7 @@ func testDirOps(t *testing.T, dir string, watcher Watcher) {
 	// Create
 	assertNoError(t, ioutil.WriteFile(fpath, []byte("hello"), 0640))
 
-	ev, err := readTimeout(watcher.EventChannel())
+	ev, err := readTimeout(watcher)
 	assertNoError(t, err)
 	assert.Equal(t, fpath, ev.Name)
 	assert.Equal(t, fsnotify.Create, ev.Op)
@@ -162,7 +258,7 @@ func testDirOps(t *testing.T, dir string, watcher Watcher) {
 		f.Sync()
 		f.Close()
 
-		ev, err = readTimeout(watcher.EventChannel())
+		ev, err = readTimeout(watcher)
 		if err == nil || err != errReadTimeout {
 			break
 		}
@@ -175,13 +271,13 @@ func testDirOps(t *testing.T, dir string, watcher Watcher) {
 	err = os.Rename(fpath, fpath2)
 	assertNoError(t, err)
 
-	evRename, err := readTimeout(watcher.EventChannel())
+	evRename, err := readTimeout(watcher)
 	assertNoError(t, err)
 	// Sometimes a duplicate Write can be received under Linux, skip
 	if evRename.Op == fsnotify.Write {
-		evRename, err = readTimeout(watcher.EventChannel())
+		evRename, err = readTimeout(watcher)
 	}
-	evCreate, err := readTimeout(watcher.EventChannel())
+	evCreate, err := readTimeout(watcher)
 	assertNoError(t, err)
 
 	if evRename.Op != fsnotify.Rename {
@@ -198,12 +294,12 @@ func testDirOps(t *testing.T, dir string, watcher Watcher) {
 	err = os.Remove(fpath2)
 	assertNoError(t, err)
 
-	ev, err = readTimeout(watcher.EventChannel())
+	ev, err = readTimeout(watcher)
 	assertNoError(t, err)
 
 	// Windows: A write to the parent directory sneaks in
 	if ev.Op == fsnotify.Write && ev.Name == dir {
-		ev, err = readTimeout(watcher.EventChannel())
+		ev, err = readTimeout(watcher)
 		assertNoError(t, err)
 	}
 	assert.Equal(t, fpath2, ev.Name)
@@ -213,16 +309,23 @@ func testDirOps(t *testing.T, dir string, watcher Watcher) {
 var errReadTimeout = errors.New("read timeout")
 
 // helper to read from channel
-func readTimeout(c <-chan fsnotify.Event) (fsnotify.Event, error) {
-	select {
-	case <-time.After(3 * time.Second):
-		return fsnotify.Event{}, errReadTimeout
+func readTimeout(watcher Watcher) (fsnotify.Event, error) {
+	timer := time.NewTimer(3 * time.Second)
+	defer timer.Stop()
+	for {
+		select {
+		case <-timer.C:
+			return fsnotify.Event{}, errReadTimeout
 
-	case msg, ok := <-c:
-		if !ok {
-			return fsnotify.Event{}, errors.New("channel closed")
+		case msg, ok := <-watcher.EventChannel():
+			if !ok {
+				return fsnotify.Event{}, errors.New("channel closed")
+			}
+			return msg, nil
+
+		case err := <-watcher.ErrorChannel():
+			fmt.Printf("readTimeout got error: %v\n", err)
 		}
-		return msg, nil
 	}
 }
 


### PR DESCRIPTION
 When some subdirectory of a watched dir can't be watched (inaccessible due to permissions for example), do not fail to watch the whole tree.

Fixes #5911 