### PR TITLE
Disable x-pack for filebeat tests

### DIFF
--- a/filebeat/Makefile
+++ b/filebeat/Makefile
@@ -3,6 +3,7 @@ BEAT_TITLE?=Filebeat
 BEAT_DESCRIPTION?=Filebeat sends log files to Logstash or directly to Elasticsearch.
 SYSTEM_TESTS?=true
 TEST_ENVIRONMENT?=true
+TESTING_ENVIRONMENT?=snapshot-noxpack
 GOX_FLAGS=-arch="amd64 386 arm ppc64 ppc64le"
 ES_BEATS?=..
 

--- a/testing/environments/Makefile
+++ b/testing/environments/Makefile
@@ -1,9 +1,11 @@
 ENV?=snapshot.yml
 BASE_COMMAND=docker-compose -f ${ENV} -f local.yml
 
-start:
-	# This is run every time to make sure the environment is up-to-date
+build:
 	${BASE_COMMAND} build
+
+start: build
+	# This is run every time to make sure the environment is up-to-date
 	${BASE_COMMAND} run beat bash
 
 stop:


### PR DESCRIPTION
For filebeat integration tests x-pack is not required.

* Introduce separate build command in environment Makefile