### PR TITLE
Metricbeat - Vsphere module - Fix Error collecting network_names 

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -87,6 +87,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Fix mongodb session consistency mode to allow command execution on secondary nodes. {issue}4689[4689]
 - Fix `open_file_descriptor_count` and `max_file_descriptor_count` lost in zookeeper module {pull}5902[5902]
 - Fix kubernetes `state_pod` `status.phase` so that the active phase is returned instead of `unknown`. {pull}5980[5980]
+- Fix error collecting network_names in Vsphere module. {pull}5962[5962]
 
 *Packetbeat*
 

--- a/metricbeat/module/vsphere/datastore/datastore.go
+++ b/metricbeat/module/vsphere/datastore/datastore.go
@@ -57,7 +57,7 @@ func (m *MetricSet) Fetch() ([]common.MapStr, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	events := []common.MapStr{}
+	var events []common.MapStr
 
 	client, err := govmomi.NewClient(ctx, m.HostURL, m.Insecure)
 	if err != nil {


### PR DESCRIPTION
The messages occurs because virtualmachine have "distributed port group" instead of "network". It was already fixed in "host" and now it was made the same in "virtualmachine".

Closes #5961