### PR TITLE
include build time and revision in version information

### DIFF
--- a/libbeat/cmd/version.go
+++ b/libbeat/cmd/version.go
@@ -22,8 +22,13 @@ func genVersionCmd(name, beatVersion string) *cobra.Command {
 					return fmt.Errorf("error initializing beat: %s", err)
 				}
 
-				fmt.Printf("%s version %s (%s), libbeat %s\n",
-					beat.Info.Beat, beat.Info.Version, runtime.GOARCH, version.GetDefaultVersion())
+				buildTime := "unknown"
+				if bt := version.BuildTime(); !bt.IsZero() {
+					buildTime = bt.String()
+				}
+				fmt.Printf("%s version %s (%s), libbeat %s [%s built %s]\n",
+					beat.Info.Beat, beat.Info.Version, runtime.GOARCH, version.GetDefaultVersion(),
+					version.Commit(), buildTime)
 				return nil
 			}),
 	}

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -36,7 +36,8 @@ COVERAGE_TOOL?=${BEAT_GOPATH}/bin/gotestcover
 COVERAGE_TOOL_REPO?=github.com/elastic/beats/vendor/github.com/pierrre/gotestcover
 TESTIFY_TOOL_REPO?=github.com/elastic/beats/vendor/github.com/stretchr/testify
 LIBCOMPOSE_TOOL_REPO?=github.com/docker/libcompose
-GOBUILD_FLAGS?=-i
+NOW=$(shell date -u '+%Y-%m-%dT%H:%M:%SZ')
+GOBUILD_FLAGS?=-i -ldflags "-X github.com/elastic/beats/libbeat/version.buildTime=$(NOW) -X github.com/elastic/beats/libbeat/version.commit=$(COMMIT_ID)"
 GOIMPORTS=goimports
 GOIMPORTS_REPO?=golang.org/x/tools/cmd/goimports
 GOIMPORTS_LOCAL_PREFIX?=github.com/elastic

--- a/libbeat/version/version.go
+++ b/libbeat/version/version.go
@@ -1,3 +1,25 @@
 package version
 
+import "time"
+
 const defaultBeatVersion = "7.0.0-alpha1"
+
+var (
+	buildTime = "unknown"
+	commit    = "unknown"
+)
+
+// BuildTime exposes the compile-time build time information.
+// It will represent the zero time instant if parsing fails.
+func BuildTime() time.Time {
+	t, err := time.Parse(time.RFC3339, buildTime)
+	if err != nil {
+		return time.Time{}
+	}
+	return t
+}
+
+// Commit exposes the compile-time commit hash.
+func Commit() string {
+	return commit
+}


### PR DESCRIPTION
I couldn't find a clever way to hook up tests for this, here's one way to verify the changes:
```
$ cd $GOPATH/src/github.com/elastic/beats/auditbeat
$ make -B
./auditbego build -i -ldflags "-X github.com/elastic/beats/libbeat/version.buildTime=2018-01-03T01:07:04 -X github.com/elastic/beats/libbeat/version.commit=65a82579ddc7fa34a82cf554e6ef4adcbf24bdfa"
at version
$ ./auditbeat version
auditbeat version 7.0.0-alpha1 (amd64), libbeat 7.0.0-alpha1 [65a82579ddc7fa34a82cf554e6ef4adcbf24bdfa built 2018-01-03T01:07:04]
```

I got caught up for awhile getting this to work for apps that vendor libbeat, like apm-server.  This worked there, note the `github.com/elastic/apm-server/vendor/` prefix:
```
$ cd $GOPATH/src/github.com/elastic/apm-serve
$ go build -i -ldflags "-X github.com/elastic/apm-server/vendor/github.com/elastic/beats/libbeat/version.buildTime=2018-01-03T01:00:47 -X github.com/elastic/apm-server/vendor/github.com/elastic/beats/libbeat/version.commit=c066b5885efb57decafbee9fbbb532b4e2041529"
$ ./apm-server version
apm-server version 7.0.0-alpha1 (amd64), libbeat 7.0.0-alpha1 [c066b5885efb57decafbee9fbbb532b4e2041529 built 2018-01-03T01:00:47]
```