### PR TITLE
[metricbeat] [kubernetes] Make sure the active phase status is retrieved for kubernetes pods in state_pod

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -84,6 +84,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Fix incorrect `Mem.Used` calculation under linux. {pull}5775[5775]
 - Fix mongodb session consistency mode to allow command execution on secondary nodes. {issue}4689[4689]
 - Fix `open_file_descriptor_count` and `max_file_descriptor_count` lost in zookeeper module {pull}5902[5902]
+- Fix kubernetes `state_pod` `status.phase` so that the active phase is returned instead of `unknown`. {pull}5980[5980]
 
 *Packetbeat*
 

--- a/metricbeat/module/kubernetes/_meta/test/kube-state-metrics
+++ b/metricbeat/module/kubernetes/_meta/test/kube-state-metrics
@@ -273,7 +273,9 @@ kube_pod_info{host_ip="192.168.99.100",namespace="kube-system",node="minikube",p
 kube_pod_info{host_ip="192.168.99.100",namespace="kube-system",node="minikube",pod="tiller-deploy-3067024529-9lpmb",pod_ip="172.17.0.2"} 1
 # HELP kube_pod_status_phase The pods current phase.
 # TYPE kube_pod_status_phase gauge
-kube_pod_status_phase{namespace="default",phase="Running",pod="jumpy-owl-redis-3481028193-s78x9"} 1
+kube_pod_status_phase{namespace="default",phase="Running",pod="jumpy-owl-redis-3481028193-s78x9"} 0
+kube_pod_status_phase{namespace="default",phase="Succeeded",pod="jumpy-owl-redis-3481028193-s78x9"} 1
+kube_pod_status_phase{namespace="default",phase="Unknown",pod="jumpy-owl-redis-3481028193-s78x9"} 0
 kube_pod_status_phase{namespace="jenkins",phase="Running",pod="wise-lynx-jenkins-1616735317-svn6k"} 1
 kube_pod_status_phase{namespace="kube-system",phase="Pending",pod="kube-state-metrics-1303537707-mnzbp"} 1
 kube_pod_status_phase{namespace="kube-system",phase="Running",pod="kube-addon-manager-minikube"} 1

--- a/metricbeat/module/kubernetes/state_pod/data.go
+++ b/metricbeat/module/kubernetes/state_pod/data.go
@@ -41,7 +41,9 @@ func eventMapping(families []*dto.MetricFamily) ([]common.MapStr, error) {
 				}
 
 			case "kube_pod_status_phase":
-				event.Put("status.phase", strings.ToLower(util.GetLabel(metric, "phase")))
+				if metric.GetGauge().GetValue() == 1 {
+					event.Put("status.phase", strings.ToLower(util.GetLabel(metric, "phase")))
+				}
 
 			case "kube_pod_status_ready":
 				if metric.GetGauge().GetValue() == 1 {

--- a/metricbeat/module/kubernetes/state_pod/state_pod_test.go
+++ b/metricbeat/module/kubernetes/state_pod/state_pod_test.go
@@ -54,7 +54,7 @@ func TestEventMapping(t *testing.T) {
 		"host_ip": "192.168.99.100",
 		"ip":      "172.17.0.4",
 
-		"status.phase":     "running",
+		"status.phase":     "succeeded",
 		"status.ready":     "false",
 		"status.scheduled": "true",
 	}


### PR DESCRIPTION
For `kube_pod_status_phase` there are multiple metrics for each status phase with identical metric names but different phase labels. The test data only contained a single status phase so it was working perfectly, however when there are multiple status phases the code was always picking `unknown` for all pods in `state_pod`. 

```
kube_pod_status_phase{namespace="test-namespace",phase="Failed",pod="test-pod"} 0
kube_pod_status_phase{namespace="test-namespace",phase="Pending",pod="test-pod"} 0
kube_pod_status_phase{namespace="test-namespace",phase="Running",pod="test-pod"} 0
kube_pod_status_phase{namespace="test-namespace",phase="Succeeded",pod="test-pod"} 1
kube_pod_status_phase{namespace="test-namespace",phase="Unknown",pod="test-pod"} 0

```

Oddly enough `container_pod` isn't affected by this since it **does** have seperate metrics per status phase
```
kube_pod_container_status_ready{container="test-container",namespace="test-namespace",pod="test-pod"} 0
kube_pod_container_status_restarts{container="test-container",namespace="test-namespace",pod="test-pod"} 0
kube_pod_container_status_running{container="test-container",namespace="test-namespace",pod="test-pod"} 0
kube_pod_container_status_terminated{container="test-container",namespace="test-namespace",pod="test-pod"} 1
kube_pod_container_status_waiting{container="test-container",namespace="test-namespace",pod="test-pod"} 0
```