### PR TITLE
Enrich events with add_process_metadata

### DIFF
--- a/libbeat/processors/add_process_metadata/add_process_metadata.go
+++ b/libbeat/processors/add_process_metadata/add_process_metadata.go
@@ -1,0 +1,201 @@
+package add_process_metadata
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+
+	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/processors"
+)
+
+const name = "add_process_metadata"
+
+type Processor struct {
+	Config
+	log     *logp.Logger
+	cgroups *common.Cache
+}
+
+func New(c *common.Config) (processors.Processor, error) {
+	config := defaultConfig
+	err := c.Unpack(&config)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to unpack %v config", name)
+	}
+
+	log := logp.NewLogger(name)
+	cgroups := common.NewCacheWithRemovalListener(5*time.Minute, 100, func(k common.Key, v common.Value) {
+		log.Debugf("evicted cached cgroups for PID=%v", k)
+	})
+	cgroups.StartJanitor(5 * time.Second)
+
+	return &Processor{
+		Config:  config,
+		log:     logp.NewLogger(name),
+		cgroups: cgroups,
+	}, nil
+}
+
+func (p *Processor) Run(event *beat.Event) (*beat.Event, error) {
+	var cgroups map[string]string
+	for _, field := range p.PIDFields {
+		v, err := event.GetValue(field)
+		if err != nil {
+			continue
+		}
+
+		pid, ok := tryToInt(v)
+		if !ok {
+			p.log.Debugf("field %v is not a PID (type=%T, value=%v)", field, v, v)
+			continue
+		}
+
+		cgroups, err = p.getProcessCgroups(pid)
+		if err != nil && os.IsNotExist(errors.Cause(err)) {
+			continue
+		}
+		if err != nil {
+			p.log.Debugf("failed to get cgroups for pid=%v: %v", pid, err)
+		}
+
+		break
+	}
+
+	if len(cgroups) == 0 {
+		return event, nil
+	}
+
+	// Write data to targets.
+	for _, metadata := range p.Metadata {
+		switch metadata {
+		case ContainerID:
+			if cid := getContainerID(cgroups); cid != "" {
+				event.PutValue(p.ContainerIDTarget, cid)
+			}
+		case Cgroups:
+			event.PutValue(p.CgroupsTarget, cgroups)
+		}
+	}
+	return event, nil
+}
+
+func (p *Processor) String() string {
+	return fmt.Sprintf("add_process_metadata=[pid_fields=[%v], "+
+		"metadata_types=%v, target.container_id=%v target.cgroups=%v]",
+		strings.Join(p.PIDFields, ","),
+		p.Metadata,
+		p.ContainerIDTarget,
+		p.CgroupsTarget)
+}
+
+// getProcessCgroups returns a mapping of cgroup subsystem name to path. It
+// returns an error if it failed to retrieve the cgroup info.
+func (p *Processor) getProcessCgroups(pid int) (map[string]string, error) {
+	// TODO (andrewkroh): Add -system.host flag like Metricbeat has to specify
+	// where to find the host systems /proc mountpoint.
+
+	cgroups, ok := p.cgroups.Get(pid).(map[string]string)
+	if ok {
+		p.log.Debugf("using cached cgroups for pid=%v", pid)
+		return cgroups, nil
+	}
+
+	cgroups, err := processCgroupPaths("", pid)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to read cgroups for pid=%v", pid)
+	}
+
+	p.cgroups.Put(pid, cgroups)
+	return cgroups, nil
+}
+
+func tryToInt(number interface{}) (int, bool) {
+	var rtn int
+	switch v := number.(type) {
+	case int:
+		rtn = int(v)
+	case int8:
+		rtn = int(v)
+	case int16:
+		rtn = int(v)
+	case int32:
+		rtn = int(v)
+	case int64:
+		rtn = int(v)
+	case uint:
+		rtn = int(v)
+	case uint8:
+		rtn = int(v)
+	case uint16:
+		rtn = int(v)
+	case uint32:
+		rtn = int(v)
+	case uint64:
+		rtn = int(v)
+	case string:
+		var err error
+		rtn, err = strconv.Atoi(v)
+		if err != nil {
+			return 0, false
+		}
+	default:
+		return 0, false
+	}
+	return rtn, true
+}
+
+// processCgroupPaths returns the cgroups to which a process belongs and the
+// pathname of the cgroup relative to the mountpoint of the subsystem.
+func processCgroupPaths(rootfsMountpoint string, pid int) (map[string]string, error) {
+	if rootfsMountpoint == "" {
+		rootfsMountpoint = "/"
+	}
+
+	cgroup, err := os.Open(filepath.Join(rootfsMountpoint, "proc", strconv.Itoa(pid), "cgroup"))
+	if err != nil {
+		return nil, err
+	}
+	defer cgroup.Close()
+
+	paths := map[string]string{}
+	sc := bufio.NewScanner(cgroup)
+	for sc.Scan() {
+		// http://man7.org/linux/man-pages/man7/cgroups.7.html
+		// Format: hierarchy-ID:subsystem-list:cgroup-path
+		// Example:
+		// 2:cpu:/docker/b29faf21b7eff959f64b4192c34d5d67a707fe8561e9eaa608cb27693fba4242
+		line := sc.Text()
+
+		fields := strings.Split(line, ":")
+		if len(fields) != 3 {
+			continue
+		}
+
+		path := fields[2]
+		subsystems := strings.Split(fields[1], ",")
+		for _, subsystem := range subsystems {
+			paths[subsystem] = path
+		}
+	}
+
+	return paths, sc.Err()
+}
+
+func getContainerID(cgroups map[string]string) string {
+	for _, path := range cgroups {
+		if strings.HasPrefix(path, "/docker/") {
+			return filepath.Base(path)
+		}
+	}
+
+	return ""
+}

--- a/libbeat/processors/add_process_metadata/add_process_metadata_test.go
+++ b/libbeat/processors/add_process_metadata/add_process_metadata_test.go
@@ -1,0 +1,16 @@
+package add_process_metadata
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProcessorString(t *testing.T) {
+	p := &Processor{Config: defaultConfig}
+	p.PIDFields = []string{"process.pid", "process.ppid"}
+	assert.Equal(t, "add_process_metadata=[pid_fields=[process.pid,process.ppid], "+
+		"metadata_types=[container_id], target.container_id=docker.container.id "+
+		"target.cgroups=process.cgroups]",
+		p.String())
+}

--- a/libbeat/processors/add_process_metadata/config.go
+++ b/libbeat/processors/add_process_metadata/config.go
@@ -1,0 +1,55 @@
+package add_process_metadata
+
+import (
+	"fmt"
+	"strings"
+)
+
+type MetadataType uint32
+
+const (
+	ContainerID MetadataType = iota + 1
+	Cgroups
+)
+
+var metadataTypeNames = map[MetadataType]string{
+	ContainerID: "container_id",
+	Cgroups:     "cgroups",
+}
+
+func (t MetadataType) String() string {
+	name, found := metadataTypeNames[t]
+	if found {
+		return name
+	}
+	return fmt.Sprintf("unknown (%d)", t)
+}
+
+func (t *MetadataType) Unpack(s string) error {
+	s = strings.ToLower(s)
+	for typ, name := range metadataTypeNames {
+		if s == name {
+			*t = typ
+			return nil
+		}
+	}
+	return fmt.Errorf("invalid metadata type '%v'", s)
+}
+
+type Config struct {
+	// Metadata specifies what types of process information to capture.
+	Metadata []MetadataType `config:"metadata_types" validate:"required"`
+
+	// PIDFields specifies the field names that contain process IDs.
+	PIDFields []string `config:"pid_fields" validate:"required"`
+
+	// Targets
+	ContainerIDTarget string `config:"target.container_id"` // Target field for the container ID.
+	CgroupsTarget     string `config:"target.cgroups"`      // Target field for cgroup subsystems and paths.
+}
+
+var defaultConfig = Config{
+	Metadata:          []MetadataType{ContainerID},
+	ContainerIDTarget: "docker.container.id",
+	CgroupsTarget:     "process.cgroups",
+}

--- a/libbeat/processors/add_process_metadata/plugin/main.go
+++ b/libbeat/processors/add_process_metadata/plugin/main.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"github.com/elastic/beats/libbeat/plugin"
+	"github.com/elastic/beats/libbeat/processors"
+	"github.com/elastic/beats/libbeat/processors/add_process_metadata"
+)
+
+var Bundle = plugin.Bundle(
+	processors.Plugin("add_process_metadata", add_process_metadata.New),
+)


### PR DESCRIPTION
Combining the add_process_metadata processor with add_docker_metadata allows you to enrich events when you have a PID.

```
auditbeat.modules:
- module: audit
  metricsets: [kernel]
  kernel.audit_rules: |
    -a always,exit -F arch=b64 -S execve,execveat -k exec
  processors:
  - add_process_metadata:
      metadata_types: [container_id]
      pid_fields: ['audit.kernel.data.pid', 'audit.kernel.data.ppid']
      target.container_id: 'docker.container.id'
  - add_docker_metadata:
      match_fields: ['docker.container.id']
```
  
Download plugin: [add_process_metadata-linux-amd64-6.1.1.so.gz](https://github.com/elastic/beats/files/1604525/add_process_metadata-linux-amd64-6.1.1.so.gz)

Usage: `auditbeat --plugin /path/to/add_process_metadata-linux-amd64-6.1.1.so -e`

Output:

```
2018/01/04 20:03:36.475996 logger.go:29: DBG [add_process_metadata] using cached cgroups for pid=15233
2018/01/04 20:03:36.476171 processor.go:275: DBG [publish] Publish event: {
  "@timestamp": "2018-01-04T20:03:36.472Z",
  "@metadata": {
    "beat": "auditbeat",
    "type": "doc",
    "version": "6.1.1"
  },
  "audit": {
    "kernel": {
      "record_type": "syscall",
      "action": "executed",
      "paths": [
        {
          "nametype": "NORMAL",
          "ouid": "root",
          "rdev": "00:00",
          "dev": "00:2b",
          "inode": "21",
          "name": "/bin/cat",
          "ogid": "root",
          "item": "0",
          "mode": "0100755"
        }
      ],
      "thing": {
        "what": "file",
        "primary": "/bin/cat",
        "secondary": "21"
      },
      "category": "audit-rule",
      "how": "/bin/cat",
      "key": "exec",
      "sequence": 18067,
      "session": "unset",
      "data": {
        "fe": "0",
        "fi": "0000000000000000",
        "fver": "0",
        "a0": "123ef10",
        "a1": "123eec0",
        "a3": "8",
        "argc": "2",
        "exit": "0",
        "proctitle": "cat",
        "tty": "pts2",
        "cwd": "/",
        "new_pp": "00000000a80425fb",
        "old_pe": "00000000a80425fb",
        "pid": "23031",
        "ppid": "15233",
        "new_pi": "00000000a80425fb",
        "old_pi": "00000000a80425fb",
        "old_pp": "00000000a80425fb",
        "arch": "x86_64",
        "comm": "cat",
        "exe": "/bin/cat",
        "fp": "0000000000000000",
        "new_pe": "00000000a80425fb",
        "syscall": "execve",
        "a2": "123eed8",
        "cmdline": "\"cat\" \"/etc/gshadow\""
      },
      "actor": {
        "primary": "unset",
        "secondary": "root",
        "attrs": {
          "auid": "unset",
          "fsgid": "root",
          "fsuid": "root",
          "gid": "root",
          "sgid": "root",
          "egid": "root",
          "euid": "root",
          "suid": "root",
          "uid": "root"
        }
      },
      "result": "success"
    }
  },
  "metricset": {
    "module": "audit",
    "name": "kernel"
  },
  "docker": {
    "container": {
      "id": "5bee224b593f997d856e18615ac100494a75c7e57f092e104e9a79a70daa1748",
      "image": "busybox",
      "name": "pedantic_bardeen"
    }
  },
  "beat": {
    "version": "6.1.1",
    "name": "instance-1",
    "hostname": "instance-1"
  }
}
```
  