### PR TITLE
Readd crosscompile builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,11 +63,10 @@ jobs:
       env: TARGETS="-C libbeat testsuite"
       go: $GO_VERSION
       stage: test
-      # Skip tests: see https://github.com/elastic/beats/issues/5984
-      #    - os: linux
-      #      env: TARGETS="-C libbeat crosscompile"
-      #      go: $GO_VERSION
-      #      stage: test
+    - os: linux
+      env: TARGETS="-C libbeat crosscompile"
+      go: $GO_VERSION
+      stage: test
     - os: linux
       env: TARGETS="-C libbeat stress-tests"
       go: $GO_VERSION
@@ -82,11 +81,10 @@ jobs:
       env: TARGETS="TEST_ENVIRONMENT=0 -C metricbeat testsuite"
       go: $GO_VERSION
       stage: test
-      # Skip tests: see https://github.com/elastic/beats/issues/5984
-      #    - os: linux
-      #      env: TARGETS="-C metricbeat crosscompile"
-      #      go: $GO_VERSION
-      #      stage: test
+    - os: linux
+      env: TARGETS="-C metricbeat crosscompile"
+      go: $GO_VERSION
+      stage: test
 
     # Packetbeat
     - os: linux

--- a/libbeat/cmd/instance/metrics.go
+++ b/libbeat/cmd/instance/metrics.go
@@ -1,3 +1,6 @@
+// +build darwin linux windows
+// +build cgo
+
 package instance
 
 import (

--- a/libbeat/cmd/instance/metrics_other.go
+++ b/libbeat/cmd/instance/metrics_other.go
@@ -1,0 +1,10 @@
+// +build !darwin,!linux,!windows darwin,!cgo linux,!cgo windows,!cgo
+
+package instance
+
+import "github.com/elastic/beats/libbeat/logp"
+
+func setupMetrics(name string) error {
+	logp.Warn("Metrics not implemented for this OS.")
+	return nil
+}

--- a/libbeat/metric/system/cpu/cpu.go
+++ b/libbeat/metric/system/cpu/cpu.go
@@ -1,3 +1,5 @@
+// +build darwin freebsd linux openbsd windows
+
 package cpu
 
 import (

--- a/libbeat/metric/system/cpu/doc.go
+++ b/libbeat/metric/system/cpu/doc.go
@@ -1,0 +1,1 @@
+package cpu

--- a/libbeat/metric/system/memory/doc.go
+++ b/libbeat/metric/system/memory/doc.go
@@ -1,0 +1,1 @@
+package memory

--- a/libbeat/metric/system/memory/memory.go
+++ b/libbeat/metric/system/memory/memory.go
@@ -1,3 +1,5 @@
+// +build darwin freebsd linux openbsd windows
+
 package memory
 
 import (

--- a/libbeat/metric/system/process/process.go
+++ b/libbeat/metric/system/process/process.go
@@ -1,3 +1,5 @@
+// +build darwin freebsd linux windows
+
 package process
 
 import (


### PR DESCRIPTION
In #5545 the crosscompile builds were disable because they didn't work with the changes. This PR reenables the crosscompiling by making the following changes:

* Introduce build flags for the metrics. Currently only build on darwin, linux, windows
* Readd build flags to cpu and memory. They were removed in the previous PR but not sure why.
* Uncomment crosscompile builds for travis

This only brings back the previous behaviour. Additional changes should be made to support monitoring also on missing platforms.

See #5984