### PR TITLE
Reduce mapping size by relying more on dynamic typing

### DIFF
--- a/libbeat/template/processor.go
+++ b/libbeat/template/processor.go
@@ -34,12 +34,14 @@ func (p *Processor) process(fields common.Fields, path string, output common.Map
 			mapping = p.scaledFloat(&field)
 		case "half_float":
 			mapping = p.halfFloat(&field)
-		case "integer":
-			mapping = p.integer(&field)
+		case "integer", "long":
+			// don't explicitly include the integers, ES automatically detects them
+			//mapping = p.integer(&field)
 		case "text":
 			mapping = p.text(&field)
 		case "", "keyword":
-			mapping = p.keyword(&field)
+			// don't explicitly include the keywords, let the dynamic rule handle them
+			//mapping = p.keyword(&field)
 		case "object":
 			mapping = p.object(&field)
 		case "array":
@@ -72,7 +74,9 @@ func (p *Processor) process(fields common.Fields, path string, output common.Map
 			if err := p.process(field.Fields, newPath, properties); err != nil {
 				return err
 			}
-			mapping["properties"] = properties
+			if len(properties) > 0 {
+				mapping["properties"] = properties
+			}
 		default:
 			mapping = p.other(&field)
 		}


### PR DESCRIPTION
Opening this for discussion. I hit the Metricbeat query exception when running against Kibana master (https://github.com/elastic/beats/issues/5275), and as a workaround I used this patch to use dynamic mappings for keywords and logs. The code change is trivial (see diff) and solved the issues while I didn't notice any other regression in my unscientific testing. This might also solve the slowdown on the Discover page that was experienced by some users.

The patch causes a reduction of the template from 7K lines to 1k lines.

What I'd like to discuss:

* Are there objections with implementing this in 6.x, with potentially reverting it for 7.0 when we have a better solution (e.g. index per module)?
* What tests should we make to make sure this doesn't break anything?
* How could we check that the slowdown in Discovery gets improved.