### PR TITLE
Switch packer to sha512

### DIFF
--- a/dev-tools/packer/platforms/binary/run.sh.j2
+++ b/dev-tools/packer/platforms/binary/run.sh.j2
@@ -23,5 +23,5 @@ tar czvf upload/{{.beat_name}}-${VERSION}-linux-{{.bin_arch}}.tar.gz /{{.beat_na
 echo "Created upload/{{.beat_name}}-${VERSION}-linux-{{.bin_arch}}.tar.gz"
 
 cd upload
-sha1sum {{.beat_name}}-${VERSION}-linux-{{.bin_arch}}.tar.gz | awk '{print $1;}' > {{.beat_name}}-${VERSION}-linux-{{.bin_arch}}.tar.gz.sha1
-echo "Created upload/{{.beat_name}}-${VERSION}-linux-{{.bin_arch}}.tar.gz.sha1"
+sha512sum {{.beat_name}}-${VERSION}-linux-{{.bin_arch}}.tar.gz | awk '{print $1;}' > {{.beat_name}}-${VERSION}-linux-{{.bin_arch}}.tar.gz.sha512
+echo "Created upload/{{.beat_name}}-${VERSION}-linux-{{.bin_arch}}.tar.gz.sha512"

--- a/dev-tools/packer/platforms/binary/run.sh.j2
+++ b/dev-tools/packer/platforms/binary/run.sh.j2
@@ -23,5 +23,5 @@ tar czvf upload/{{.beat_name}}-${VERSION}-linux-{{.bin_arch}}.tar.gz /{{.beat_na
 echo "Created upload/{{.beat_name}}-${VERSION}-linux-{{.bin_arch}}.tar.gz"
 
 cd upload
-sha512sum {{.beat_name}}-${VERSION}-linux-{{.bin_arch}}.tar.gz | awk '{print $1;}' > {{.beat_name}}-${VERSION}-linux-{{.bin_arch}}.tar.gz.sha512
+sha512sum {{.beat_name}}-${VERSION}-linux-{{.bin_arch}}.tar.gz > {{.beat_name}}-${VERSION}-linux-{{.bin_arch}}.tar.gz.sha512
 echo "Created upload/{{.beat_name}}-${VERSION}-linux-{{.bin_arch}}.tar.gz.sha512"

--- a/dev-tools/packer/platforms/centos/run.sh.j2
+++ b/dev-tools/packer/platforms/centos/run.sh.j2
@@ -53,7 +53,7 @@ mkdir -p upload
 mv {{.beat_pkg_name}}-${RPM_VERSION}-1.{{.rpm_arch}}.rpm upload/{{.beat_name}}-${VERSION}-{{.rpm_arch}}.rpm
 echo "Created upload/{{.beat_name}}-${VERSION}-{{.rpm_arch}}.rpm"
 
-# create sha1 file
+# create sha512 file
 cd upload
-sha1sum {{.beat_name}}-${VERSION}-{{.rpm_arch}}.rpm | awk '{print $1;}' > {{.beat_name}}-${VERSION}-{{.rpm_arch}}.rpm.sha1
-echo "Created upload/{{.beat_name}}-${VERSION}-{{.rpm_arch}}.rpm.sha1"
+sha512sum {{.beat_name}}-${VERSION}-{{.rpm_arch}}.rpm | awk '{print $1;}' > {{.beat_name}}-${VERSION}-{{.rpm_arch}}.rpm.sha512
+echo "Created upload/{{.beat_name}}-${VERSION}-{{.rpm_arch}}.rpm.sha512"

--- a/dev-tools/packer/platforms/centos/run.sh.j2
+++ b/dev-tools/packer/platforms/centos/run.sh.j2
@@ -55,5 +55,5 @@ echo "Created upload/{{.beat_name}}-${VERSION}-{{.rpm_arch}}.rpm"
 
 # create sha512 file
 cd upload
-sha512sum {{.beat_name}}-${VERSION}-{{.rpm_arch}}.rpm | awk '{print $1;}' > {{.beat_name}}-${VERSION}-{{.rpm_arch}}.rpm.sha512
+sha512sum {{.beat_name}}-${VERSION}-{{.rpm_arch}}.rpm > {{.beat_name}}-${VERSION}-{{.rpm_arch}}.rpm.sha512
 echo "Created upload/{{.beat_name}}-${VERSION}-{{.rpm_arch}}.rpm.sha512"

--- a/dev-tools/packer/platforms/darwin/run.sh.j2
+++ b/dev-tools/packer/platforms/darwin/run.sh.j2
@@ -23,5 +23,5 @@ tar czvf upload/{{.beat_name}}-${VERSION}-darwin-x86_64.tar.gz /{{.beat_name}}-$
 echo "Created upload/{{.beat_name}}-${VERSION}-darwin-x86_64.tar.gz"
 
 cd upload
-sha1sum {{.beat_name}}-${VERSION}-darwin-x86_64.tar.gz | awk '{print $1;}' > {{.beat_name}}-${VERSION}-darwin-x86_64.tar.gz.sha1
-echo "Created upload/{{.beat_name}}-${VERSION}-darwin-x86_64.tar.gz.sha1"
+sha512sum {{.beat_name}}-${VERSION}-darwin-x86_64.tar.gz | awk '{print $1;}' > {{.beat_name}}-${VERSION}-darwin-x86_64.tar.gz.sha512
+echo "Created upload/{{.beat_name}}-${VERSION}-darwin-x86_64.tar.gz.sha512"

--- a/dev-tools/packer/platforms/darwin/run.sh.j2
+++ b/dev-tools/packer/platforms/darwin/run.sh.j2
@@ -23,5 +23,5 @@ tar czvf upload/{{.beat_name}}-${VERSION}-darwin-x86_64.tar.gz /{{.beat_name}}-$
 echo "Created upload/{{.beat_name}}-${VERSION}-darwin-x86_64.tar.gz"
 
 cd upload
-sha512sum {{.beat_name}}-${VERSION}-darwin-x86_64.tar.gz | awk '{print $1;}' > {{.beat_name}}-${VERSION}-darwin-x86_64.tar.gz.sha512
+sha512sum {{.beat_name}}-${VERSION}-darwin-x86_64.tar.gz > {{.beat_name}}-${VERSION}-darwin-x86_64.tar.gz.sha512
 echo "Created upload/{{.beat_name}}-${VERSION}-darwin-x86_64.tar.gz.sha512"

--- a/dev-tools/packer/platforms/dashboards/run.sh.j2
+++ b/dev-tools/packer/platforms/dashboards/run.sh.j2
@@ -19,5 +19,5 @@ zip -r upload/${BEAT_NAME:-beats}-dashboards-${VERSION}.zip /${BEAT_NAME:-beats}
 echo "Created upload/${BEAT_NAME:-beats}-dashboards-${VERSION}.zip"
 
 cd upload
-sha1sum ${BEAT_NAME:-beats}-dashboards-${VERSION}.zip | awk '{print $1;}' > ${BEAT_NAME:-beats}-dashboards-${VERSION}.zip.sha1
-echo "Created upload/${BEAT_NAME:-beats}-dashboards-${VERSION}.zip.sha1"
+sha512sum ${BEAT_NAME:-beats}-dashboards-${VERSION}.zip | awk '{print $1;}' > ${BEAT_NAME:-beats}-dashboards-${VERSION}.zip.sha512
+echo "Created upload/${BEAT_NAME:-beats}-dashboards-${VERSION}.zip.sha512"

--- a/dev-tools/packer/platforms/dashboards/run.sh.j2
+++ b/dev-tools/packer/platforms/dashboards/run.sh.j2
@@ -19,5 +19,5 @@ zip -r upload/${BEAT_NAME:-beats}-dashboards-${VERSION}.zip /${BEAT_NAME:-beats}
 echo "Created upload/${BEAT_NAME:-beats}-dashboards-${VERSION}.zip"
 
 cd upload
-sha512sum ${BEAT_NAME:-beats}-dashboards-${VERSION}.zip | awk '{print $1;}' > ${BEAT_NAME:-beats}-dashboards-${VERSION}.zip.sha512
+sha512sum ${BEAT_NAME:-beats}-dashboards-${VERSION}.zip > ${BEAT_NAME:-beats}-dashboards-${VERSION}.zip.sha512
 echo "Created upload/${BEAT_NAME:-beats}-dashboards-${VERSION}.zip.sha512"

--- a/dev-tools/packer/platforms/debian/run.sh.j2
+++ b/dev-tools/packer/platforms/debian/run.sh.j2
@@ -52,5 +52,5 @@ echo "Created upload/{{.beat_name}}-${VERSION}-{{.deb_arch}}.deb"
 
 # create sha512 file
 cd upload
-sha512sum {{.beat_name}}-${VERSION}-{{.deb_arch}}.deb | awk '{print $1;}' > {{.beat_name}}-${VERSION}-{{.deb_arch}}.deb.sha512
+sha512sum {{.beat_name}}-${VERSION}-{{.deb_arch}}.deb > {{.beat_name}}-${VERSION}-{{.deb_arch}}.deb.sha512
 echo "Created upload/{{.beat_name}}-${VERSION}-{{.deb_arch}}.deb.sha512"

--- a/dev-tools/packer/platforms/debian/run.sh.j2
+++ b/dev-tools/packer/platforms/debian/run.sh.j2
@@ -50,7 +50,7 @@ mkdir -p upload
 mv {{.beat_pkg_name}}_${VERSION}_{{.deb_arch}}.deb upload/{{.beat_name}}-${VERSION}-{{.deb_arch}}.deb
 echo "Created upload/{{.beat_name}}-${VERSION}-{{.deb_arch}}.deb"
 
-# create sha1 file
+# create sha512 file
 cd upload
-sha1sum {{.beat_name}}-${VERSION}-{{.deb_arch}}.deb | awk '{print $1;}' > {{.beat_name}}-${VERSION}-{{.deb_arch}}.deb.sha1
-echo "Created upload/{{.beat_name}}-${VERSION}-{{.deb_arch}}.deb.sha1"
+sha512sum {{.beat_name}}-${VERSION}-{{.deb_arch}}.deb | awk '{print $1;}' > {{.beat_name}}-${VERSION}-{{.deb_arch}}.deb.sha512
+echo "Created upload/{{.beat_name}}-${VERSION}-{{.deb_arch}}.deb.sha512"

--- a/dev-tools/packer/platforms/windows/run.sh.j2
+++ b/dev-tools/packer/platforms/windows/run.sh.j2
@@ -26,5 +26,5 @@ zip -r upload/{{.beat_name}}-${VERSION}-windows-{{.win_arch}}.zip /{{.beat_name}
 echo "Created upload/{{.beat_name}}-${VERSION}-windows-{{.win_arch}}.zip"
 
 cd upload
-sha1sum {{.beat_name}}-${VERSION}-windows-{{.win_arch}}.zip | awk '{print $1;}' > {{.beat_name}}-${VERSION}-windows-{{.win_arch}}.zip.sha1
-echo "Created upload/{{.beat_name}}-${VERSION}-windows-{{.win_arch}}.zip.sha1"
+sha512sum {{.beat_name}}-${VERSION}-windows-{{.win_arch}}.zip | awk '{print $1;}' > {{.beat_name}}-${VERSION}-windows-{{.win_arch}}.zip.sha512
+echo "Created upload/{{.beat_name}}-${VERSION}-windows-{{.win_arch}}.zip.sha512"

--- a/dev-tools/packer/platforms/windows/run.sh.j2
+++ b/dev-tools/packer/platforms/windows/run.sh.j2
@@ -26,5 +26,5 @@ zip -r upload/{{.beat_name}}-${VERSION}-windows-{{.win_arch}}.zip /{{.beat_name}
 echo "Created upload/{{.beat_name}}-${VERSION}-windows-{{.win_arch}}.zip"
 
 cd upload
-sha512sum {{.beat_name}}-${VERSION}-windows-{{.win_arch}}.zip | awk '{print $1;}' > {{.beat_name}}-${VERSION}-windows-{{.win_arch}}.zip.sha512
+sha512sum {{.beat_name}}-${VERSION}-windows-{{.win_arch}}.zip > {{.beat_name}}-${VERSION}-windows-{{.win_arch}}.zip.sha512
 echo "Created upload/{{.beat_name}}-${VERSION}-windows-{{.win_arch}}.zip.sha512"


### PR DESCRIPTION
The unified build process doesn't use these files, but updating them
from sha1 to sha512 to simplify the life of our own Jenkins testing.