### PR TITLE
process: change debug selector to "processes"

### DIFF
--- a/libbeat/metric/system/process/process.go
+++ b/libbeat/metric/system/process/process.go
@@ -378,7 +378,7 @@ func (procStats *Stats) Get() ([]common.MapStr, error) {
 
 		process, err := newProcess(pid, cmdline, env)
 		if err != nil {
-			logp.Debug("metricbeat", "Skip process pid=%d: %v", pid, err)
+			logp.Debug("processes", "Skip process pid=%d: %v", pid, err)
 			continue
 		}
 


### PR DESCRIPTION
The selector is changed to "processes" instead of "metricbeat" to be consistent all over the package.