### PR TITLE
Check err param in filepath.WalkFunc

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -59,6 +59,9 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 
 *Auditbeat*
 
+- Add an error check to the file integrity scanner to prevent a panic when
+  there is an error reading file info via lstat. {issue}6005[6005]
+
 *Filebeat*
 
 - Add support for adding string tags {pull}5395{5395}

--- a/auditbeat/module/file_integrity/scanner.go
+++ b/auditbeat/module/file_integrity/scanner.go
@@ -101,6 +101,14 @@ func (s *scanner) walkDir(dir string) error {
 	errDone := errors.New("done")
 	startTime := time.Now()
 	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			if !os.IsNotExist(err) {
+				s.log.Warnw("Scanner is skipping a path because of an error",
+					"file_path", path, "error", err)
+			}
+			return nil
+		}
+
 		if s.config.IsExcludedPath(path) {
 			if info.IsDir() {
 				return filepath.SkipDir


### PR DESCRIPTION
There was a missing error check in the file_integrity module's scanner that could result in a panic.

Fixes #6005