### PR TITLE
Check float metrics against gauges list

### DIFF
--- a/libbeat/monitoring/report/log/log.go
+++ b/libbeat/monitoring/report/log/log.go
@@ -154,7 +154,9 @@ func makeDeltaSnapshot(prev, cur monitoring.FlatSnapshot) monitoring.FlatSnapsho
 	}
 
 	for k, f := range cur.Floats {
-		if p := prev.Floats[k]; p != f {
+		if _, found := gauges[k]; found {
+			delta.Floats[k] = f
+		} else if p := prev.Floats[k]; p != f {
 			delta.Floats[k] = f - p
 		}
 	}

--- a/libbeat/monitoring/report/log/log_test.go
+++ b/libbeat/monitoring/report/log/log_test.go
@@ -18,11 +18,19 @@ var (
 			"count": 10,
 			"gone":  1,
 		},
+		Floats: map[string]float64{
+			"system.load.1": 2.0,
+			"float_counter": 1,
+		},
 	}
 	curSnap = monitoring.FlatSnapshot{
 		Ints: map[string]int64{
 			"count": 20,
 			"new":   1,
+		},
+		Floats: map[string]float64{
+			"system.load.1": 1.2,
+			"float_counter": 3,
 		},
 	}
 )
@@ -40,6 +48,8 @@ func TestMakeDeltaSnapshot(t *testing.T) {
 	delta := makeDeltaSnapshot(prevSnap, curSnap)
 	assert.EqualValues(t, 10, delta.Ints["count"])
 	assert.EqualValues(t, 1, delta.Ints["new"])
+	assert.EqualValues(t, 1.2, delta.Floats["system.load.1"])
+	assert.EqualValues(t, 2, delta.Floats["float_counter"])
 	assert.NotContains(t, delta.Ints, "gone")
 }
 


### PR DESCRIPTION
Float metrics were not checked against the list of gauge values so the CPU and Load metrics were logged incorrectly. By default the difference between the current and last value are reported in the logs. But if a value is whitelisted as a gauge then it reports the raw value instead. Only the int values were being checked. Now the float64 values are checked too.