### PR TITLE
Cherry-pick #6007 to 6.1: Check err param in filepath.WalkFunc

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -32,6 +32,9 @@ https://github.com/elastic/beats/compare/v6.1.1...6.1[Check the HEAD diff]
 
 *Auditbeat*
 
+- Add an error check to the file integrity scanner to prevent a panic when
+  there is an error reading file info via lstat. {issue}6005[6005]
+
 *Filebeat*
 
 *Heartbeat*

--- a/auditbeat/module/audit/file/scanner.go
+++ b/auditbeat/module/audit/file/scanner.go
@@ -106,6 +106,14 @@ func (s *scanner) walkDir(dir string) error {
 	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
 		defer func() { startTime = time.Now() }()
 
+		if err != nil {
+			if !os.IsNotExist(err) {
+				logp.Warn("%v Scanner is skipping a path=%v because of an error: %v",
+					s.logPrefix, path, err)
+			}
+			return nil
+		}
+
 		event := s.newScanEvent(path, info, err)
 		event.rtt = time.Since(startTime)
 		select {


### PR DESCRIPTION
Cherry-pick of PR #6007 to 6.1 branch. Original message: 

There was a missing error check in the file_integrity module's scanner that could result in a panic.

Fixes #6005