### PR TITLE
Clarify naming of multiline settings

### DIFF
--- a/filebeat/docs/multiline.asciidoc
+++ b/filebeat/docs/multiline.asciidoc
@@ -1,9 +1,11 @@
 [[multiline-examples]]
 == Manage multiline messages
 
-The files harvested by {beatname_uc} may contain messages that span multiple lines of text. In order to correctly handle
-these multiline events, you need to configure `multiline` settings in the +{beatname_lc}.yml+ file to specify which
-lines are part of a single event.
+The files harvested by {beatname_uc} may contain messages that span multiple
+lines of text. For example, multiline messages are common in files that contain
+Java stack traces. In order to correctly handle these multiline events, you need
+to configure `multiline` settings in the +{beatname_lc}.yml+ file to specify
+which lines are part of a single event.
 
 IMPORTANT: If you are sending multiline events to Logstash, use the options described here to handle multiline events
 before sending the event data to Logstash. Trying to implement multiline event handling in Logstash (for example, by
@@ -12,16 +14,12 @@ using the Logstash multiline codec) may result in the mixing of streams and corr
 Also read <<yaml-tips>> and <<regexp-support>> to avoid common mistakes.
 
 [float]
-[[multiline-options]]
+[[multiline]]
 === Configuration options
 
-You can specify the following options in the `filebeat.prospectors` section of the +{beatname_lc}.yml+ config file:
-
-[float]
-[[multiline]]
-==== `multiline`
-
-Options that control how Filebeat deals with log messages that span multiple lines. Multiline messages are common in files that contain Java stack traces.
+You can specify the following options in the `filebeat.prospectors` section of
+the +{beatname_lc}.yml+ config file to control how Filebeat deals with messages
+that span multiple lines. 
 
 The following example shows how to configure Filebeat to handle a multiline message where the first line of the message begins with a bracket (`[`).
 
@@ -44,17 +42,16 @@ Filebeat takes all the lines that do not start with `[` and combines them with t
     at org.elasticsearch.action.admin.indices.delete.TransportDeleteIndexAction.checkBlock(TransportDeleteIndexAction.java:75)
 -------------------------------------------------------------------------------------
 
-You specify the following settings under `multiline` to control how Filebeat combines the lines in the message:
 
-*`pattern`*:: Specifies the regular expression pattern to match. Note that the regexp patterns supported by Filebeat
+*`multiline.pattern`*:: Specifies the regular expression pattern to match. Note that the regexp patterns supported by Filebeat
 differ somewhat from the patterns supported by Logstash. See <<regexp-support>> for a list of supported regexp patterns.
 Depending on how you configure other multiline options, lines that match the specified regular expression are considered
 either continuations of a previous line or the start of a new multiline event. You can set the `negate` option to negate
 the pattern.
 
-*`negate`*:: Defines whether the pattern is negated. The default is `false`.
+*`multiline.negate`*:: Defines whether the pattern is negated. The default is `false`.
 
-*`match`*:: Specifies how Filebeat combines matching lines into an event. The settings are `after` or `before`. The behavior of these settings depends on what you specify for `negate`:
+*`multiline.match`*:: Specifies how Filebeat combines matching lines into an event. The settings are `after` or `before`. The behavior of these settings depends on what you specify for `negate`:
 +
 [options="header"]
 |=======================
@@ -67,13 +64,13 @@ the pattern.
 +
 NOTE: The `after` setting is equivalent to `previous` in https://www.elastic.co/guide/en/logstash/current/plugins-codecs-multiline.html[Logstash], and `before` is equivalent to `next`.
 
-*`flush_pattern`*:: Specifies a regular expression, in which the current multiline will be flushed from memory, ending the multline-message.
+*`multiline.flush_pattern`*:: Specifies a regular expression, in which the current multiline will be flushed from memory, ending the multline-message.
 
-*`max_lines`*:: The maximum number of lines that can be combined into one event. If
+*`multiline.max_lines`*:: The maximum number of lines that can be combined into one event. If
 the multiline message contains more than `max_lines`, any additional
 lines are discarded. The default is 500.
 
-*`timeout`*:: After the specified timeout, Filebeat sends the multiline event even if no new pattern is found to start a new event. The default is 5s.
+*`multiline.timeout`*:: After the specified timeout, Filebeat sends the multiline event even if no new pattern is found to start a new event. The default is 5s.
 
 
 === Examples of multiline configuration
@@ -205,13 +202,13 @@ multiline.match: after
 multiline.flush_pattern: 'End event'
 -------------------------------------------------------------------------------------
 
-The 'flush_pattern' option, specifies a regex at which the current multiline will be flushed. If you think of the 'pattern' option specifying the beginning of an event, the 'flush_pattern' option will specify the end or last line of the event.
+The `flush_pattern` option, specifies a regex at which the current multiline will be flushed. If you think of the `pattern` option specifying the beginning of an event, the `flush_pattern` option will specify the end or last line of the event.
 
 === Test your regexp pattern for multiline
 
 To make it easier for you to test the regexp patterns in your multiline config, we've created a
 https://play.golang.org/p/uAd5XHxscu[Go Playground]. You can simply plug in the regexp pattern along with
-the `negate` setting that you plan to use, and paste a sample message between the content backticks (` `).
+the `multiline.negate` setting that you plan to use, and paste a sample message between the content backticks (` `).
 Then click Run, and you'll see which lines in the message match your specified configuration. For example:
 
 image:images/go-playground.png[]


### PR DESCRIPTION
I've added `multiline` to the config option names shown in this topic because I noticed on the Beats forum that users were mistakenly using `timeout` instead of `multiline.timeout`. This simple fix should help to disambiguate the options. In cases where the syntax is clear, I've left the shorter form of the names.

I've also reworked some of the intro text that was a bit redundant.