### PR TITLE
Update logging from auditd module

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -138,7 +138,7 @@ Vagrant.configure(2) do |config|
 
     c.vm.provision "shell", inline: $unixProvision, privileged: false
     c.vm.provision "shell", inline: $linuxGvmProvision, privileged: false
-    config.vm.provision "shell", inline: "dnf install -y make gcc python-pip python-virtualenv git"
+    c.vm.provision "shell", inline: "dnf install -y make gcc python-pip python-virtualenv git"
 
     c.vm.synced_folder ".", "/vagrant", type: "virtualbox"
   end

--- a/auditbeat/module/auditd/audit_linux_test.go
+++ b/auditbeat/module/auditd/audit_linux_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/beats/auditbeat/core"
+	"github.com/elastic/beats/libbeat/logp"
 	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
 	"github.com/elastic/go-libaudit"
 	"github.com/elastic/procfs"
@@ -25,6 +26,8 @@ var audit = flag.Bool("audit", false, "interact with the real audit framework")
 var userLoginMsg = `type=USER_LOGIN msg=audit(1492896301.818:19955): pid=12635 uid=0 auid=4294967295 ses=4294967295 msg='op=login acct=28696E76616C6964207573657229 exe="/usr/sbin/sshd" hostname=? addr=179.38.151.221 terminal=sshd res=failed'`
 
 func TestData(t *testing.T) {
+	logp.TestingSetup()
+
 	// Create a mock netlink client that provides the expected responses.
 	mock := NewMock().
 		// Get Status response for initClient
@@ -65,6 +68,7 @@ func TestUnicastClient(t *testing.T) {
 		t.Skip("-audit was not specified")
 	}
 
+	logp.TestingSetup()
 	FailIfAuditdIsRunning(t)
 
 	c := map[string]interface{}{
@@ -109,6 +113,7 @@ func TestMulticastClient(t *testing.T) {
 		t.Skip("no multicast support")
 	}
 
+	logp.TestingSetup()
 	FailIfAuditdIsRunning(t)
 
 	c := map[string]interface{}{

--- a/metricbeat/mb/testing/modules.go
+++ b/metricbeat/mb/testing/modules.go
@@ -269,7 +269,10 @@ func RunPushMetricSetV2(timeout time.Duration, waitEvents int, metricSet mb.Push
 			select {
 			case <-timer.C:
 				return
-			case e := <-r.eventsC:
+			case e, ok := <-r.eventsC:
+				if !ok {
+					return
+				}
 				events = append(events, e)
 				if waitEvents > 0 && waitEvents <= len(events) {
 					return


### PR DESCRIPTION
Use `logp.Logger` for all logging from the auditd module. I also increased the logging level for two statements because they will be useful for troubleshooting (without having to ask users to re-run with debug enabled).