### PR TITLE
Invalidate build cache

### DIFF
--- a/testing/environments/args.yml
+++ b/testing/environments/args.yml
@@ -7,4 +7,4 @@ services:
       args:
         DOWNLOAD_URL: https://snapshots.elastic.co/downloads
         ELASTIC_VERSION: 6.2.0-SNAPSHOT
-        CACHE_BUST: 20170911
+        CACHE_BUST: 20180108


### PR DESCRIPTION
In https://github.com/elastic/beats/pull/5992 I tried to change back some of the geoip lookup fields. But it seems the changes are also in 6.2 if the cache is invalidated. Trying to only invalidate the cache instead.