### PR TITLE
Fix attribute order

### DIFF
--- a/auditbeat/docs/index.asciidoc
+++ b/auditbeat/docs/index.asciidoc
@@ -4,12 +4,12 @@ include::../../libbeat/docs/version.asciidoc[]
 
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
-include::../../libbeat/docs/shared-beats-attributes.asciidoc[]
-
 :version: {stack-version}
 :beatname_lc: auditbeat
 :beatname_uc: Auditbeat
 :beatname_pkg: {beatname_lc}
+
+include::../../libbeat/docs/shared-beats-attributes.asciidoc[]
 
 include::./overview.asciidoc[]
 

--- a/docs/devguide/index.asciidoc
+++ b/docs/devguide/index.asciidoc
@@ -3,21 +3,10 @@
 
 include::../../libbeat/docs/version.asciidoc[]
 
-:libbeat: http://www.elastic.co/guide/en/beats/libbeat/{doc-branch}
-:packetbeat: http://www.elastic.co/guide/en/beats/packetbeat/{doc-branch}
-:metricbeat: http://www.elastic.co/guide/en/beats/metricbeat/{doc-branch}
-:filebeat: http://www.elastic.co/guide/en/beats/filebeat/{doc-branch}
-:winlogbeat: http://www.elastic.co/guide/en/beats/winlogbeat/{doc-branch}
-:heartbeat: http://www.elastic.co/guide/en/beats/heartbeat/{doc-branch}
-:securitydoc: https://www.elastic.co/guide/en/x-pack/{doc-branch}
-:logstashdoc: https://www.elastic.co/guide/en/logstash/{doc-branch}
 :beatname_lc: beatname
 :beatname_uc: a Beat
-:security: X-Pack Security
-:ES-version: {stack-version}
-:LS-version: {stack-version}
-:Kibana-version: {stack-version}
-:dashboards: https://artifacts.elastic.co/downloads/beats/beats-dashboards/beats-dashboards-{stack-version}.zip
+
+include::../../libbeat/docs/shared-beats-attributes.asciidoc[]
 
 include::./contributing.asciidoc[]
 

--- a/filebeat/docs/index.asciidoc
+++ b/filebeat/docs/index.asciidoc
@@ -4,12 +4,12 @@ include::../../libbeat/docs/version.asciidoc[]
 
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
-include::../../libbeat/docs/shared-beats-attributes.asciidoc[]
-
 :version: {stack-version}
 :beatname_lc: filebeat
 :beatname_uc: Filebeat
 :beatname_pkg: {beatname_lc}
+
+include::../../libbeat/docs/shared-beats-attributes.asciidoc[]
 
 include::./overview.asciidoc[]
 

--- a/heartbeat/docs/index.asciidoc
+++ b/heartbeat/docs/index.asciidoc
@@ -4,12 +4,12 @@ include::../../libbeat/docs/version.asciidoc[]
 
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
-include::../../libbeat/docs/shared-beats-attributes.asciidoc[]
-
 :version: {stack-version}
 :beatname_lc: heartbeat
 :beatname_uc: Heartbeat
 :beatname_pkg: heartbeat-elastic
+
+include::../../libbeat/docs/shared-beats-attributes.asciidoc[]
 
 include::./overview.asciidoc[]
 

--- a/libbeat/docs/index.asciidoc
+++ b/libbeat/docs/index.asciidoc
@@ -5,11 +5,11 @@ include::./version.asciidoc[]
 
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
-include::../../libbeat/docs/shared-beats-attributes.asciidoc[]
-
 :beatname_lc: beatname
 :beatname_uc: a Beat
 :beatname_pkg: {beatname_lc}
+
+include::../../libbeat/docs/shared-beats-attributes.asciidoc[]
 
 include::./overview.asciidoc[]
 

--- a/metricbeat/docs/index.asciidoc
+++ b/metricbeat/docs/index.asciidoc
@@ -4,13 +4,12 @@ include::../../libbeat/docs/version.asciidoc[]
 
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
-include::../../libbeat/docs/shared-beats-attributes.asciidoc[]
-
 :version: {stack-version}
 :beatname_lc: metricbeat
 :beatname_uc: Metricbeat
 :beatname_pkg: {beatname_lc}
 
+include::../../libbeat/docs/shared-beats-attributes.asciidoc[]
 
 include::./overview.asciidoc[]
 

--- a/packetbeat/docs/index.asciidoc
+++ b/packetbeat/docs/index.asciidoc
@@ -4,13 +4,12 @@ include::../../libbeat/docs/version.asciidoc[]
 
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
-include::../../libbeat/docs/shared-beats-attributes.asciidoc[]
-
 :version: {stack-version}
 :beatname_lc: packetbeat
 :beatname_uc: Packetbeat
 :beatname_pkg: {beatname_lc}
 
+include::../../libbeat/docs/shared-beats-attributes.asciidoc[]
 
 include::./overview.asciidoc[]
 

--- a/winlogbeat/docs/index.asciidoc
+++ b/winlogbeat/docs/index.asciidoc
@@ -4,12 +4,12 @@ include::../../libbeat/docs/version.asciidoc[]
 
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
-include::../../libbeat/docs/shared-beats-attributes.asciidoc[]
-
 :version: {stack-version}
 :beatname_lc: winlogbeat
 :beatname_uc: Winlogbeat
 :beatname_pkg: {beatname_lc}
+
+include::../../libbeat/docs/shared-beats-attributes.asciidoc[]
 
 include::./overview.asciidoc[]
 


### PR DESCRIPTION
Well, I goofed. The include statement for the shared attributes needs to appear after the file that defines `beatname_l`c because the `dockerimage` attribute has a dependency on `beatname_lc`. 

Because the doc build didn't complain, I didn't realize there was an issue until I saw an extra space in some of the docker commands. The commands had a space *instead* of the docker image name. 

This issue only exists in master because the PR that cherry-picks these changes is not merged yet.