### PR TITLE
Elevate to debug level only if -d is specified

### DIFF
--- a/libbeat/logp/configure/logging.go
+++ b/libbeat/logp/configure/logging.go
@@ -48,7 +48,7 @@ func applyFlags(cfg *logp.Config) {
 	}
 
 	// Elevate level if selectors are specified on the CLI.
-	if len(cfg.Selectors) > 0 {
+	if len(debugSelectors) > 0 {
 		cfg.Level = logp.DebugLevel
 	}
 }


### PR DESCRIPTION
If any debug selectors were specified the logging level was being elevated to DEBUG.  This makes it elevate the level only if a selector was specified on the CLI with `-d selector`.