### PR TITLE
New beat info: ephemeral_id

### DIFF
--- a/libbeat/cmd/instance/metrics.go
+++ b/libbeat/cmd/instance/metrics.go
@@ -8,6 +8,8 @@ import (
 	"runtime"
 	"time"
 
+	"github.com/satori/go.uuid"
+
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/metric/system/cpu"
 	"github.com/elastic/beats/libbeat/metric/system/process"
@@ -18,6 +20,7 @@ import (
 var (
 	cpuMonitor       *cpu.Monitor
 	beatProcessStats *process.Stats
+	ephemeralID      uuid.UUID
 )
 
 func init() {
@@ -29,6 +32,8 @@ func init() {
 	systemMetrics := monitoring.Default.NewRegistry("system")
 	monitoring.NewFunc(systemMetrics, "load", reportSystemLoadAverage, monitoring.Report)
 	monitoring.NewFunc(systemMetrics, "cpu", reportSystemCPUUsage, monitoring.Report)
+
+	ephemeralID = uuid.NewV4()
 }
 
 func setupMetrics(name string) error {
@@ -67,6 +72,7 @@ func reportInfo(_ monitoring.Mode, V monitoring.Visitor) {
 	delta := time.Since(log.StartTime)
 	uptime := int64(delta / time.Millisecond)
 	monitoring.ReportInt(V, "uptime.ms", uptime)
+	monitoring.ReportString(V, "ephemeral_id", ephemeralID.String())
 }
 
 func reportBeatCPU(_ monitoring.Mode, V monitoring.Visitor) {

--- a/libbeat/monitoring/report/log/log.go
+++ b/libbeat/monitoring/report/log/log.go
@@ -41,6 +41,11 @@ var gauges = map[string]bool{
 	"system.load.norm.15":            true,
 }
 
+// TODO: Change this when gauges are refactored, too.
+var strConsts = map[string]bool{
+	"beat.info.ephemeral_id": true,
+}
+
 var (
 	// StartTime is the time that the process was started.
 	StartTime = time.Now()
@@ -141,7 +146,9 @@ func makeDeltaSnapshot(prev, cur monitoring.FlatSnapshot) monitoring.FlatSnapsho
 	}
 
 	for k, s := range cur.Strings {
-		if p, ok := prev.Strings[k]; !ok || p != s {
+		if _, found := strConsts[k]; found {
+			delta.Strings[k] = s
+		} else if p, ok := prev.Strings[k]; !ok || p != s {
 			delta.Strings[k] = s
 		}
 	}


### PR DESCRIPTION
New "metric" is added: `beat.info.ephemeral_id`. I am open to alternative names for this.
This ID is generated every time the Beat starts/restarts. It does not change when the config is reloaded.

I also added `strConsts` list which contains strings which should be added to the monitoring events even if it is unchange. This solution is the same as the current `gauges` list.