### PR TITLE
Log prospector configured paths at INFO level

### DIFF
--- a/filebeat/prospector/log/prospector.go
+++ b/filebeat/prospector/log/prospector.go
@@ -108,7 +108,7 @@ func NewProspector(
 		return nil, err
 	}
 
-	logp.Debug("prospector", "File Configs: %v", p.config.Paths)
+	logp.Info("Configured paths: %v", p.config.Paths)
 
 	return p, nil
 }

--- a/filebeat/prospector/prospector.go
+++ b/filebeat/prospector/prospector.go
@@ -84,7 +84,7 @@ func New(
 // Start starts the prospector
 func (p *Prospector) Start() {
 	p.wg.Add(1)
-	logp.Info("Starting prospector of type: %v; ID: %d ", p.config.Type, p.ID)
+	logp.Debug("prospector", "Starting prospector of type: %v; ID: %d ", p.config.Type, p.ID)
 
 	onceWg := sync.WaitGroup{}
 	if p.Once {

--- a/filebeat/prospector/prospector.go
+++ b/filebeat/prospector/prospector.go
@@ -84,7 +84,7 @@ func New(
 // Start starts the prospector
 func (p *Prospector) Start() {
 	p.wg.Add(1)
-	logp.Debug("prospector", "Starting prospector of type: %v; ID: %d ", p.config.Type, p.ID)
+	logp.Debug("prospector", "Starting prospector of type: %v; ID: %d", p.config.Type, p.ID)
 
 	onceWg := sync.WaitGroup{}
 	if p.Once {

--- a/filebeat/registrar/registrar.go
+++ b/filebeat/registrar/registrar.go
@@ -85,7 +85,7 @@ func (r *Registrar) Init() error {
 		return fmt.Errorf("Registry file path is not a regular file: %s", r.registryFile)
 	}
 
-	logp.Info("Registry file set to: %s", r.registryFile)
+	logp.Debug("registrar", "Registry file set to: %s", r.registryFile)
 
 	return nil
 }
@@ -147,7 +147,7 @@ func (r *Registrar) Start() error {
 }
 
 func (r *Registrar) Run() {
-	logp.Info("Starting Registrar")
+	logp.Debug("registrar", "Starting Registrar")
 	// Writes registry on shutdown
 	defer func() {
 		r.writeRegistry()


### PR DESCRIPTION
I found myself enabling `-d "prospector"` quite often to
check the configured paths, so I thought upgrading it to INFO level is
going to be beneficial for users.

As I didn't want to increase verbosity, I looked for other Info messages that
could be Debug messages, and demoded a couple that where redundant (same information
printed in another Info message) or a little to obscure to print all the time (the ID
of the prospector).