### PR TITLE
Create directories automatically in export_dashboards

### DIFF
--- a/dev-tools/cmd/dashboards/export_dashboards.go
+++ b/dev-tools/cmd/dashboards/export_dashboards.go
@@ -142,8 +142,12 @@ func main() {
 
 		for _, dashboard := range dashboards {
 			fmt.Printf("id=%s, name=%s\n", dashboard["id"], dashboard["file"])
-			err := Export(client, *kibanaURL, dashboard["id"], path.Join(path.Dir(*ymlFile),
-				"_meta/kibana/6/dashboard", dashboard["file"]))
+			directory := path.Join(path.Dir(*ymlFile), "_meta/kibana/6/dashboard")
+			err := os.MkdirAll(directory, 0755)
+			if err != nil {
+				fmt.Printf("ERROR: fail to create directory %s: %v", directory, err)
+			}
+			err = Export(client, *kibanaURL, dashboard["id"], path.Join(directory, dashboard["file"]))
 			if err != nil {
 				fmt.Printf("ERROR: fail to export the dashboards: %s\n", err)
 			}


### PR DESCRIPTION
When called with the `-yml` option, the `dev-tools/export_dashboards.go`
program now creates the tree structure for you (i.e. `_meta/kibana/6/dashboard`).
It used to exit with an error if the directory didn't yet exist, which caused
a small annoyance when creating a FB module.