### PR TITLE
Fix process cgroup memory values

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -93,6 +93,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Fix `open_file_descriptor_count` and `max_file_descriptor_count` lost in zookeeper module {pull}5902[5902]
 - Fix kubernetes `state_pod` `status.phase` so that the active phase is returned instead of `unknown`. {pull}5980[5980]
 - Fix error collecting network_names in Vsphere module. {pull}5962[5962]
+- Fix process cgroup memory metrics for memsw, kmem, and kmem_tcp. {issue}6033[6033]
 
 *Packetbeat*
 

--- a/metricbeat/module/system/process/cgroup.go
+++ b/metricbeat/module/system/process/cgroup.go
@@ -117,14 +117,14 @@ func cgroupMemoryToMapStr(memory *cgroup.MemorySubsystem) common.MapStr {
 
 	addMemData := func(key string, m common.MapStr, data cgroup.MemoryData) {
 		m[key] = common.MapStr{
-			"failures": memory.Mem.FailCount,
+			"failures": data.FailCount,
 			"limit": common.MapStr{
-				"bytes": memory.Mem.Limit,
+				"bytes": data.Limit,
 			},
 			"usage": common.MapStr{
-				"bytes": memory.Mem.Usage,
+				"bytes": data.Usage,
 				"max": common.MapStr{
-					"bytes": memory.Mem.MaxUsage,
+					"bytes": data.MaxUsage,
 				},
 			},
 		}


### PR DESCRIPTION
The mem values were being reported for the memsw, kmem, and kmem_tcp values.

Fixes #6033