### PR TITLE
Add QoS to Beats

### DIFF
--- a/filebeat/channel/factory.go
+++ b/filebeat/channel/factory.go
@@ -41,6 +41,8 @@ type prospectorOutletConfig struct {
 	// Output meta data settings
 	Pipeline string `config:"pipeline"` // ES Ingest pipeline name
 
+	// Priority to set for the prospector
+	Weight int `config:"weight" validate:"min=0, max=9"`
 }
 
 // NewOutletFactory creates a new outlet factory for
@@ -109,6 +111,7 @@ func (f *OutletFactory) Create(cfg *common.Config, dynFields *common.MapStrPoint
 		Fields:        fields,
 		Processor:     processors,
 		Events:        f.eventer,
+		Weight:        config.Weight,
 	})
 	if err != nil {
 		return nil, err

--- a/libbeat/beat/pipeline.go
+++ b/libbeat/beat/pipeline.go
@@ -69,6 +69,9 @@ type ClientConfig struct {
 	// ACKLastEvent reports the last ACKed event out of a batch of ACKed events only.
 	// Only the events 'Private' field will be reported.
 	ACKLastEvent func(interface{})
+
+	// Priority of the events that are being published by the client
+	Weight int
 }
 
 // ClientEventer provides access to internal client events.

--- a/libbeat/publisher/pipeline/module.go
+++ b/libbeat/publisher/pipeline/module.go
@@ -19,8 +19,6 @@ import (
 // command line flags
 var publishDisabled = false
 
-const defaultQueueType = "mem"
-
 func init() {
 	flag.BoolVar(&publishDisabled, "N", false, "Disable actual publishing for testing")
 }
@@ -116,22 +114,7 @@ func loadOutput(
 }
 
 func createQueueBuilder(config common.ConfigNamespace) (func(queue.Eventer) (queue.Queue, error), error) {
-	queueType := defaultQueueType
-	if b := config.Name(); b != "" {
-		queueType = b
-	}
-
-	queueFactory := queue.FindFactory(queueType)
-	if queueFactory == nil {
-		return nil, fmt.Errorf("'%v' is no valid queue type", queueType)
-	}
-
-	queueConfig := config.Config()
-	if queueConfig == nil {
-		queueConfig = common.NewConfig()
-	}
-
 	return func(eventer queue.Eventer) (queue.Queue, error) {
-		return queueFactory(eventer, queueConfig)
+		return queue.Load(eventer, config)
 	}, nil
 }

--- a/libbeat/publisher/pipeline/pipeline.go
+++ b/libbeat/publisher/pipeline/pipeline.go
@@ -311,6 +311,7 @@ func (p *Pipeline) ConnectWith(cfg beat.ClientConfig) (beat.Client, error) {
 		// Cancel events from queue if acker is configured
 		// and no pipeline-wide ACK handler is registered.
 		DropOnCancel: dropOnCancel && acker != nil && p.eventer.cb == nil,
+		Weight:       cfg.Weight,
 	}
 
 	if reportEvents || cfg.Events != nil {

--- a/libbeat/publisher/queue/heap.go
+++ b/libbeat/publisher/queue/heap.go
@@ -1,0 +1,102 @@
+package queue
+
+import (
+	"container/heap"
+	"sync"
+
+	"github.com/elastic/beats/libbeat/common"
+)
+
+// An item is something we manage in a priority queue.
+type item struct {
+	// The value of the item; arbitrary.
+	value interface{}
+
+	// The priority of the item in the queue.
+	priority common.Float
+
+	// The index of the item in the heap.
+	// The index is needed by update and is maintained by the heap.Interface methods.
+	index int
+}
+
+type items []*item
+
+func (it items) Len() int { return len(it) }
+
+func (it items) Less(i, j int) bool {
+	// We want Pop to give us the highest, not lowest, priority so we use greater than here.
+	return it[i].priority > it[j].priority
+}
+
+func (it items) Swap(i, j int) {
+	it[i], it[j] = it[j], it[i]
+	it[i].index = i
+	it[j].index = j
+}
+
+func (it *items) Push(x interface{}) {
+	n := len(*it)
+	item := x.(*item)
+	item.index = n
+	*it = append(*it, item)
+}
+
+func (it *items) Pop() interface{} {
+	old := *it
+	n := len(old)
+	item := old[n-1]
+	item.index = -1 // for safety
+	*it = old[0 : n-1]
+	return item
+}
+
+// A priorityQueue implements heap.Interface and holds items.
+type priorityQueue struct {
+	items items
+	sync.Mutex
+}
+
+func NewHeap() heap.Interface {
+	pq := &priorityQueue{
+		items: items{},
+	}
+
+	heap.Init(&pq.items)
+	return pq
+}
+
+func (pq *priorityQueue) Len() int {
+	pq.Lock()
+	defer pq.Unlock()
+
+	return pq.items.Len()
+}
+
+func (pq *priorityQueue) Less(i, j int) bool {
+	pq.Lock()
+	defer pq.Unlock()
+
+	return pq.items.Less(i, j)
+}
+
+func (pq *priorityQueue) Swap(i, j int) {
+	pq.Lock()
+	defer pq.Unlock()
+
+	pq.items.Swap(i, j)
+}
+
+func (pq *priorityQueue) Push(x interface{}) {
+	pq.Lock()
+	defer pq.Unlock()
+
+	heap.Push(&pq.items, x)
+}
+
+func (pq *priorityQueue) Pop() interface{} {
+	pq.Lock()
+	defer pq.Unlock()
+
+	return heap.Pop(&pq.items)
+}

--- a/libbeat/publisher/queue/heap_test.go
+++ b/libbeat/publisher/queue/heap_test.go
@@ -1,0 +1,34 @@
+package queue
+
+import (
+	"container/heap"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/libbeat/common"
+)
+
+func TestHeap(t *testing.T) {
+	h := NewHeap()
+	heap.Push(h, &item{
+		priority: 13,
+		value:    "foo",
+	})
+
+	heap.Push(h, &item{
+		priority: 15,
+		value:    "bar",
+	})
+
+	heap.Push(h, &item{
+		priority: 12,
+		value:    "xyz",
+	})
+
+	it := h.Pop().(*item)
+	assert.Equal(t, it.priority, common.Float(15))
+	assert.Equal(t, it.value, "bar")
+	assert.Equal(t, h.Pop().(*item).priority, common.Float(13))
+	assert.Equal(t, h.Pop().(*item).priority, common.Float(12))
+}

--- a/libbeat/publisher/queue/memqueue/broker.go
+++ b/libbeat/publisher/queue/memqueue/broker.go
@@ -209,6 +209,9 @@ func (l *chanList) concat(other *chanList) {
 		return
 	}
 
+	m := sync.Mutex{}
+	s := sync.NewCond(&m)
+	s.Signal()
 	l.tail.next = other.head
 	l.tail = other.tail
 }

--- a/libbeat/publisher/queue/qos.go
+++ b/libbeat/publisher/queue/qos.go
@@ -1,0 +1,112 @@
+package queue
+
+import (
+	"container/heap"
+	"time"
+
+	"github.com/elastic/beats/libbeat/common"
+)
+
+type Qoser interface {
+	// Release the process lock and give the processing time to the next available producer
+	ReleaseToken()
+
+	// Schedule picks the next producer who gets to produce to the queue
+	Schedule()
+
+	// Clone an instance of QoSer
+	CreateClient() QoserClient
+}
+
+type QoserClient interface {
+	// Add the producer in the wait queue based
+	RequestToken(*ProducerWrapper, int, time.Time)
+
+	// Wait until the next available slot
+	Wait()
+
+	// Send a signal to the producer to wake up
+	Awaken()
+}
+
+type weightedScheduler struct {
+	heap heap.Interface
+
+	notify chan struct{}
+}
+
+func NewWeightedScheduler() Qoser {
+	return &weightedScheduler{
+		heap:   NewHeap(),
+		notify: make(chan struct{}),
+	}
+}
+
+func (w *weightedScheduler) ReleaseToken() {
+	// Pop the most high priority producer
+	iface := w.heap.Pop()
+
+	if iface == nil {
+		return
+	}
+
+	if it, ok := iface.(*item); ok {
+		producer := it.value.(*ProducerWrapper)
+		// Notify the producer to wake up.
+		producer.Awaken()
+	}
+}
+
+func (w *weightedScheduler) Schedule() {
+	go func() {
+		for {
+			select {
+			case <-w.notify:
+				w.ReleaseToken()
+			}
+		}
+	}()
+}
+
+func (w *weightedScheduler) CreateClient() QoserClient {
+	return NewWeightedClient(w.heap, w.notify)
+}
+
+type weightedClient struct {
+	heap heap.Interface
+
+	cond   chan struct{}
+	notify chan struct{}
+}
+
+func NewWeightedClient(h heap.Interface, notify chan struct{}) QoserClient {
+	return &weightedClient{
+		heap:   h,
+		cond:   make(chan struct{}, 1),
+		notify: notify,
+	}
+}
+
+func (c *weightedClient) RequestToken(p *ProducerWrapper, weight int, time time.Time) {
+	// Calculate priority and add the producer into the queue
+	priority := c.computePriority(weight, time)
+	newItem := &item{
+		value:    p,
+		priority: priority,
+	}
+	c.heap.Push(newItem)
+	c.notify <- struct{}{}
+}
+
+func (c *weightedClient) Wait() {
+	<-c.cond
+}
+
+// TODO: Add the packet delivery logic after initial review
+func (c *weightedClient) computePriority(weight int, t time.Time) common.Float {
+	return common.Float(int64(weight))
+}
+
+func (c *weightedClient) Awaken() {
+	c.cond <- struct{}{}
+}

--- a/libbeat/publisher/queue/queue.go
+++ b/libbeat/publisher/queue/queue.go
@@ -60,6 +60,10 @@ type ProducerConfig struct {
 	// DropOnCancel is a hint to the queue to drop events if the producer disconnects
 	// via Cancel.
 	DropOnCancel bool
+
+	// Weight is the weight of the producer to determine the priority. Weight is a value
+	// between 0 and 9.
+	Weight int
 }
 
 // Producer interface to be used by the pipelines client to forward events to be

--- a/libbeat/publisher/queue/wrapper.go
+++ b/libbeat/publisher/queue/wrapper.go
@@ -1,0 +1,93 @@
+package queue
+
+import (
+	"sync"
+
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/publisher"
+)
+
+// Wraps Queue interface to add QoS functionality on top of it.
+type QueueWrapper struct {
+	q   Queue
+	qos Qoser
+}
+
+// TODO: Add config reading capability
+func NewQueueWrapper(q Queue, _ *common.Config) Queue {
+	if q != nil {
+		qw := &QueueWrapper{
+			q:   q,
+			qos: NewWeightedScheduler(),
+		}
+
+		qw.qos.Schedule()
+		return qw
+	}
+	return nil
+}
+
+func (q *QueueWrapper) BufferConfig() BufferConfig {
+	return q.q.BufferConfig()
+}
+
+func (q *QueueWrapper) Producer(cfg ProducerConfig) Producer {
+	return newProducerWrapper(q.q.Producer(cfg), cfg.Weight, q.qos)
+}
+
+func (q *QueueWrapper) Consumer() Consumer {
+	return q.q.Consumer()
+}
+
+func (q *QueueWrapper) Close() error {
+	return q.q.Close()
+}
+
+// Wraps Producer interface to add QoS functionality on top of it.
+type ProducerWrapper struct {
+	QoserClient
+	p Producer
+
+	wg     sync.WaitGroup
+	weight int
+}
+
+func newProducerWrapper(p Producer, weight int, qos Qoser) *ProducerWrapper {
+	if p != nil {
+		return &ProducerWrapper{
+			p:           p,
+			QoserClient: qos.CreateClient(),
+			weight:      weight,
+		}
+	}
+	return nil
+}
+
+func (p *ProducerWrapper) Publish(event publisher.Event) bool {
+	p.waitForPublish(event)
+	return p.p.Publish(event)
+}
+
+func (p *ProducerWrapper) TryPublish(event publisher.Event) bool {
+	p.waitForPublish(event)
+	return p.p.TryPublish(event)
+}
+
+func (p *ProducerWrapper) Cancel() int {
+	return p.p.Cancel()
+}
+
+func (p *ProducerWrapper) waitForPublish(event publisher.Event) {
+	p.wg.Add(1)
+	go func() {
+		// Request for time to publish the incoming Event
+		p.RequestToken(p, p.weight, event.Content.Timestamp)
+		// Wait for the producer to get a cycle to publish
+		p.Wait()
+		p.wg.Done()
+	}()
+
+	// Wait till the go-routine is done signifying that the scheduler has allocated
+	// time for the publisher to publish the event
+	p.wg.Wait()
+}


### PR DESCRIPTION
This PR allows users to add `weight` as a parameter to prospectors so that the QoS mechanism that has been implemented would prioritize producers and allow them to publish to the configured queue accordingly.