### PR TITLE
Cherry-pick #6034 to 6.1: Fix process cgroup memory values

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -41,6 +41,8 @@ https://github.com/elastic/beats/compare/v6.1.1...6.1[Check the HEAD diff]
 
 *Metricbeat*
 
+- Fix process cgroup memory metrics for memsw, kmem, and kmem_tcp. {issue}6033[6033]
+
 *Packetbeat*
 
 *Winlogbeat*

--- a/metricbeat/module/system/process/cgroup.go
+++ b/metricbeat/module/system/process/cgroup.go
@@ -117,14 +117,14 @@ func cgroupMemoryToMapStr(memory *cgroup.MemorySubsystem) common.MapStr {
 
 	addMemData := func(key string, m common.MapStr, data cgroup.MemoryData) {
 		m[key] = common.MapStr{
-			"failures": memory.Mem.FailCount,
+			"failures": data.FailCount,
 			"limit": common.MapStr{
-				"bytes": memory.Mem.Limit,
+				"bytes": data.Limit,
 			},
 			"usage": common.MapStr{
-				"bytes": memory.Mem.Usage,
+				"bytes": data.Usage,
 				"max": common.MapStr{
-					"bytes": memory.Mem.MaxUsage,
+					"bytes": data.MaxUsage,
 				},
 			},
 		}


### PR DESCRIPTION
Cherry-pick of PR #6034 to 6.1 branch. Original message: 

The mem values were being reported for the memsw, kmem, and kmem_tcp values.

Fixes #6033