### PR TITLE
fix type in config.go: "more then"

### DIFF
--- a/libbeat/common/config.go
+++ b/libbeat/common/config.go
@@ -277,7 +277,7 @@ func (ns *ConfigNamespace) Unpack(cfg *Config) error {
 		}
 
 		if ns.name != "" {
-			return errors.New("more then one namespace configured")
+			return errors.New("more than one namespace configured")
 		}
 
 		ns.name = name


### PR DESCRIPTION
fix typo "more then" => "more than"