### PR TITLE
Bump docs version 5.6.6

### DIFF
--- a/libbeat/docs/version.asciidoc
+++ b/libbeat/docs/version.asciidoc
@@ -1,4 +1,4 @@
-:stack-version: 5.6.5
+:stack-version: 5.6.6
 :doc-branch: 5.6
 :go-version: 1.7.6
 :release-state: released


### PR DESCRIPTION
Should only be merged on the release day.