### PR TITLE
Fix CPU usage report in process.GetOne

### DIFF
--- a/libbeat/metric/system/process/process.go
+++ b/libbeat/metric/system/process/process.go
@@ -402,6 +402,7 @@ func (procStats *Stats) GetOne(pid int) (common.MapStr, error) {
 	}
 
 	e := procStats.getProcessEvent(p)
+	procStats.ProcsMap = newProcs
 
 	return e, nil
 }


### PR DESCRIPTION
I added the missing line of updating the state.
However, it still produces 0 from time to time. Reporting CPU usage has to be done differently as @andrewkroh  and @urso pointed it out.

I am opening the PR, because at least the total CPU usage since start in `beat.cpu.total. value` is correct. So calculating CPU usage percentage can be done in different applications.