### PR TITLE
Revert the validation on dotted key in the keystore and add a cyclic reference test case

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -19,6 +19,8 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Update the command line library cobra and add support for zsh completion {pull}5761[5761]
 - The log format may differ due to logging library changes. {pull}5901[5901]
 - Adding a local keystore to allow user to obfuscate password {pull}5687[5687]
+- Update go-ucfg library to support top level key reference and cyclic key reference for the
+  keystore {pull}6098[6098]
 
 *Auditbeat*
 

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -361,7 +361,8 @@ Apache License 2.0
 
 --------------------------------------------------------------------
 Dependency: github.com/elastic/go-ucfg
-Revision: ec8488a52542c0c51e42e8ea204dcaff400bc644
+Version: v0.5.0
+Revision: bda09c7b9afc6263a3fd592fcd7063d03f6acf0f
 License type (autodetected): Apache-2.0
 ./vendor/github.com/elastic/go-ucfg/LICENSE:
 --------------------------------------------------------------------

--- a/libbeat/keystore/file_keystore.go
+++ b/libbeat/keystore/file_keystore.go
@@ -13,7 +13,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"sync"
 
 	"golang.org/x/crypto/pbkdf2"
@@ -89,9 +88,6 @@ func (k *FileKeystore) Retrieve(key string) (*SecureString, error) {
 
 // Store add the key pair to the secret store and mark the store as dirty.
 func (k *FileKeystore) Store(key string, value []byte) error {
-	if err := k.validateKey(key); err != nil {
-		return err
-	}
 	k.Lock()
 	defer k.Unlock()
 
@@ -385,12 +381,4 @@ func (k *FileKeystore) checkPermissions(f string) error {
 
 func (k *FileKeystore) hashPassword(password, salt []byte) []byte {
 	return pbkdf2.Key(password, salt, iterationsCount, keyLength, sha512.New)
-}
-
-func (k *FileKeystore) validateKey(key string) error {
-	if strings.IndexAny(key, ".") != -1 {
-		return fmt.Errorf("invalid key format. '.' in keys are not supported yet. key: %s", key)
-	}
-
-	return nil
 }

--- a/libbeat/keystore/file_keystore_test.go
+++ b/libbeat/keystore/file_keystore_test.go
@@ -13,20 +13,8 @@ import (
 	"github.com/elastic/beats/libbeat/common"
 )
 
-var keyValue = "output_elasticsearch_password"
+var keyValue = "output.elasticsearch.password"
 var secretValue = []byte("secret")
-
-func TestInvalidKey(t *testing.T) {
-	path := GetTemporaryKeystoreFile()
-	defer os.Remove(path)
-
-	keystore, err := NewFileKeystore(path)
-	assert.NoError(t, err)
-	err = keystore.Store("output.elasticsearch.password", secretValue)
-	if assert.Error(t, err) {
-		assert.Equal(t, err.Error(), "invalid key format. '.' in keys are not supported yet. key: output.elasticsearch.password")
-	}
-}
 
 func TestCanCreateAKeyStore(t *testing.T) {
 	path := GetTemporaryKeystoreFile()
@@ -197,18 +185,18 @@ func TestGetConfig(t *testing.T) {
 	keystore := CreateAnExistingKeystore(path)
 
 	// Add a bit more data of different type
-	keystore.Store("super_nested", []byte("hello"))
+	keystore.Store("super.nested", []byte("hello"))
 	keystore.Save()
 
 	cfg, err := keystore.GetConfig()
 	assert.NotNil(t, cfg)
 	assert.NoError(t, err)
 
-	secret, err := cfg.String("output_elasticsearch_password", 0)
+	secret, err := cfg.String("output.elasticsearch.password", 0)
 	assert.NoError(t, err)
 	assert.Equal(t, secret, "secret")
 
-	port, err := cfg.String("super_nested", 0)
+	port, err := cfg.String("super.nested", 0)
 	assert.Equal(t, port, "hello")
 }
 

--- a/libbeat/keystore/keystore_test.go
+++ b/libbeat/keystore/keystore_test.go
@@ -27,7 +27,7 @@ func TestResolverWhenTheKeyExist(t *testing.T) {
 	keystore := CreateAnExistingKeystore(path)
 
 	resolver := ResolverWrap(keystore)
-	v, err := resolver("output_elasticsearch_password")
+	v, err := resolver("output.elasticsearch.password")
 	assert.NoError(t, err)
 	assert.Equal(t, v, "secret")
 }

--- a/vendor/github.com/elastic/go-ucfg/CHANGELOG.md
+++ b/vendor/github.com/elastic/go-ucfg/CHANGELOG.md
@@ -14,6 +14,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+## [0.5.0]
+
+### Added
+- Detect cyclic reference and allow to search top level key with the other resolvers. #97
+- Allow to diff keys of two different configuration #93
+
 ## [0.4.6]
 
 ### Added
@@ -34,7 +40,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [0.4.4]
 
 ### Added
-- Add support for pure array config files #82 
+- Add support for pure array config files #82
 
 ### Changed
 - Invalid top-level types return non-critical error (no stack-trace) on merge #82
@@ -177,7 +183,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Introduced CHANGELOG.md for documenting changes to ucfg.
 
 
-[Unreleased]: https://github.com/elastic/go-ucfg/compare/v0.4.6...HEAD
+[Unreleased]: https://github.com/elastic/go-ucfg/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/elastic/go-ucfg/compare/v0.4.6...v0.5.0
 [0.4.6]: https://github.com/elastic/go-ucfg/compare/v0.4.5...v0.4.6
 [0.4.5]: https://github.com/elastic/go-ucfg/compare/v0.4.4...v0.4.5
 [0.4.4]: https://github.com/elastic/go-ucfg/compare/v0.4.3...v0.4.4

--- a/vendor/github.com/elastic/go-ucfg/error.go
+++ b/vendor/github.com/elastic/go-ucfg/error.go
@@ -44,6 +44,8 @@ type criticalError struct {
 var (
 	ErrMissing = errors.New("missing field")
 
+	ErrCyclicReference = errors.New("cyclic reference detected")
+
 	ErrDuplicateValidator = errors.New("validator already registered")
 
 	ErrTypeNoArray = errors.New("field is no array")
@@ -66,7 +68,7 @@ var (
 
 	ErrTODO = errors.New("TODO - implement me")
 
-	ErrDuplicateKeey = errors.New("duplicate key")
+	ErrDuplicateKey = errors.New("duplicate key")
 
 	ErrOverflow = errors.New("integer overflow")
 
@@ -161,7 +163,17 @@ func messagePath(reason error, meta *Meta, message, path string) string {
 }
 
 func raiseDuplicateKey(cfg *Config, name string) Error {
-	return raisePathErr(ErrDuplicateKeey, cfg.metadata, "", cfg.PathOf(name, "."))
+	return raisePathErr(ErrDuplicateKey, cfg.metadata, "", cfg.PathOf(name, "."))
+}
+
+func raiseCyclicErr(field string) Error {
+	message := fmt.Sprintf("cyclic reference detected for key: '%s'", field)
+
+	return baseError{
+		reason:  ErrCyclicReference,
+		class:   ErrConfig,
+		message: message,
+	}
 }
 
 func raiseMissing(c *Config, field string) Error {

--- a/vendor/github.com/elastic/go-ucfg/errpred.go
+++ b/vendor/github.com/elastic/go-ucfg/errpred.go
@@ -1,0 +1,24 @@
+package ucfg
+
+func isCyclicError(err error) bool {
+	switch v := err.(type) {
+	case Error:
+		return v.Reason() == ErrCyclicReference
+	}
+	return false
+}
+
+func isMissingError(err error) bool {
+	switch v := err.(type) {
+	case Error:
+		return v.Reason() == ErrMissing
+	}
+	return false
+}
+
+func criticalResolveError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return !(isCyclicError(err) || isMissingError(err))
+}

--- a/vendor/github.com/elastic/go-ucfg/fieldset.go
+++ b/vendor/github.com/elastic/go-ucfg/fieldset.go
@@ -1,0 +1,43 @@
+package ucfg
+
+type fieldSet struct {
+	fields map[string]struct{}
+	parent *fieldSet
+}
+
+func NewFieldSet(parent *fieldSet) *fieldSet {
+	return &fieldSet{
+		fields: map[string]struct{}{},
+		parent: parent,
+	}
+}
+
+func (s *fieldSet) Has(name string) (exists bool) {
+	if _, exists = s.fields[name]; !exists && s.parent != nil {
+		exists = s.parent.Has(name)
+	}
+	return
+}
+
+func (s *fieldSet) Add(name string) {
+	s.fields[name] = struct{}{}
+}
+
+func (s *fieldSet) AddNew(name string) (ok bool) {
+	if ok = !s.Has(name); ok {
+		s.Add(name)
+	}
+	return
+}
+
+func (s *fieldSet) Names() []string {
+	var names []string
+	for k := range s.fields {
+		names = append(names, k)
+	}
+
+	if s.parent != nil {
+		names = append(names, s.parent.Names()...)
+	}
+	return names
+}

--- a/vendor/github.com/elastic/go-ucfg/reify.go
+++ b/vendor/github.com/elastic/go-ucfg/reify.go
@@ -151,6 +151,9 @@ func reifyInto(opts *options, to reflect.Value, from *Config) Error {
 }
 
 func reifyMap(opts *options, to reflect.Value, from *Config) Error {
+	parentFields := opts.activeFields
+	defer func() { opts.activeFields = parentFields }()
+
 	if to.Type().Key().Kind() != reflect.String {
 		return raiseKeyInvalidTypeUnpack(to.Type(), from)
 	}
@@ -164,6 +167,7 @@ func reifyMap(opts *options, to reflect.Value, from *Config) Error {
 		to.Set(reflect.MakeMap(to.Type()))
 	}
 	for k, value := range fields {
+		opts.activeFields = NewFieldSet(parentFields)
 		key := reflect.ValueOf(k)
 
 		old := to.MapIndex(key)
@@ -186,6 +190,9 @@ func reifyMap(opts *options, to reflect.Value, from *Config) Error {
 }
 
 func reifyStruct(opts *options, orig reflect.Value, cfg *Config) Error {
+	parentFields := opts.activeFields
+	defer func() { opts.activeFields = parentFields }()
+
 	orig = chaseValuePointers(orig)
 
 	to := chaseValuePointers(reflect.New(chaseTypePointers(orig.Type())))
@@ -211,6 +218,8 @@ func reifyStruct(opts *options, orig reflect.Value, cfg *Config) Error {
 			if tagOpts.ignore {
 				continue
 			}
+
+			opts.activeFields = NewFieldSet(parentFields)
 
 			vField := to.Field(i)
 			validators, err := parseValidatorTags(stField.Tag.Get(opts.validatorTag))

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -443,10 +443,12 @@
 			"revisionTime": "2016-06-17T14:03:01Z"
 		},
 		{
-			"checksumSHA1": "6UaJp3hUpEJvcu7COoRNhHPlqfg=",
+			"checksumSHA1": "FPMs2e/K5HRqZyFvU/VTioGBnwk=",
 			"path": "github.com/elastic/go-ucfg",
-			"revision": "ec8488a52542c0c51e42e8ea204dcaff400bc644",
-			"revisionTime": "2017-02-07T06:38:51Z"
+			"revision": "bda09c7b9afc6263a3fd592fcd7063d03f6acf0f",
+			"revisionTime": "2018-01-22T22:35:02Z",
+			"version": "v0.5.0",
+			"versionExact": "v0.5.0"
 		},
 		{
 			"checksumSHA1": "8cr5YhslUMgpvF2JebYvKC+Ezr4=",


### PR DESCRIPTION
We are reverting the change in  0cdcf4f957f6acb8686b0ac5002b14fed636c4ba and we will allow dotted key in the keystore. We also add a system env test that add a cyclic reference use case.

This PR depends on https://github.com/elastic/go-ucfg/pull/97 allowing configuration to define cyclic references.