### PR TITLE
Make the `export config` report any errors to the user.

### DIFF
--- a/libbeat/cmd/export/config.go
+++ b/libbeat/cmd/export/config.go
@@ -8,38 +8,41 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/elastic/beats/libbeat/cmd/instance"
+	"github.com/elastic/beats/libbeat/common/cli"
 )
 
+// GenExportConfigCmd write to stdout the current configuration in the YAML format.
 func GenExportConfigCmd(name, idxPrefix, beatVersion string) *cobra.Command {
 	return &cobra.Command{
 		Use:   "config",
 		Short: "Export current config to stdout",
-		Run: func(cmd *cobra.Command, args []string) {
-			b, err := instance.NewBeat(name, idxPrefix, beatVersion)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "Error initializing beat: %s\n", err)
-				os.Exit(1)
-			}
-
-			err = b.Init()
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "Error initializing beat: %s\n", err)
-				os.Exit(1)
-			}
-
-			var config map[string]interface{}
-			err = b.RawConfig.Unpack(&config)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "Error unpacking config")
-				os.Exit(1)
-			}
-			res, err := yaml.Marshal(config)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "Error converting config to YAML format")
-				os.Exit(1)
-			}
-
-			os.Stdout.Write(res)
-		},
+		Run: cli.RunWith(func(cmd *cobra.Command, args []string) error {
+			return exportConfig(name, idxPrefix, beatVersion)
+		}),
 	}
+}
+
+func exportConfig(name, idxPrefix, beatVersion string) error {
+	b, err := instance.NewBeat(name, idxPrefix, beatVersion)
+	if err != nil {
+		return fmt.Errorf("error initializing beat: %s", err)
+	}
+
+	err = b.Init()
+	if err != nil {
+		return fmt.Errorf("error initializing beat: %s", err)
+	}
+
+	var config map[string]interface{}
+	err = b.RawConfig.Unpack(&config)
+	if err != nil {
+		return fmt.Errorf("error unpacking config, error: %s", err)
+	}
+	res, err := yaml.Marshal(config)
+	if err != nil {
+		return fmt.Errorf("Error converting config to YAML format, error: %s", err)
+	}
+
+	os.Stdout.Write(res)
+	return nil
 }


### PR DESCRIPTION
Change the behavior of the command to display any errors when unpacking
the value to the map or when marshalling the configuration to YAML.

Also we now wrap the method into the `cli.RunWith`