### PR TITLE
Enhance add_docker_metadata to enrich based on PID

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -134,6 +134,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Add the ability to log to the Windows Event Log. {pull}5913[5813]
 - Improve Elasticsearch output metrics to count number of dropped and duplicate (if event ID is given) events. {pull}5811[5811]
 - Add autodiscover for kubernetes. {pull}6055[6055]
+- Add the abilility for the add_docker_metadata process to enrich based on process ID. {pull}6100[6100]
 
 *Auditbeat*
 

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -370,8 +370,8 @@ Apache License 2.0
 
 --------------------------------------------------------------------
 Dependency: github.com/elastic/gosigar
-Version: v0.6.0
-Revision: 5cb8fed1ceb7f0fd69e4ad61c715a80601dddfd2
+Version: v0.7.0
+Revision: cdcbd8c3b8bf28ef6d8639ec1e45bf31d2745f2d
 License type (autodetected): Apache-2.0
 ./vendor/github.com/elastic/gosigar/LICENSE:
 --------------------------------------------------------------------

--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -202,6 +202,10 @@ auditbeat.modules:
 #- add_docker_metadata:
 #    host: "unix:///var/run/docker.sock"
 #    match_fields: ["system.process.cgroup.id"]
+#    match_pids: ["process.pid", "process.ppid"]
+#    match_source: true
+#    match_source_index: 4
+#    cleanup_timeout: 60
 #    # To connect to Docker over TLS you must specify a client and CA certificate.
 #    #ssl:
 #    #  certificate_authority: "/etc/pki/root/ca.pem"

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -650,6 +650,10 @@ filebeat.prospectors:
 #- add_docker_metadata:
 #    host: "unix:///var/run/docker.sock"
 #    match_fields: ["system.process.cgroup.id"]
+#    match_pids: ["process.pid", "process.ppid"]
+#    match_source: true
+#    match_source_index: 4
+#    cleanup_timeout: 60
 #    # To connect to Docker over TLS you must specify a client and CA certificate.
 #    #ssl:
 #    #  certificate_authority: "/etc/pki/root/ca.pem"

--- a/heartbeat/heartbeat.reference.yml
+++ b/heartbeat/heartbeat.reference.yml
@@ -311,6 +311,10 @@ heartbeat.scheduler:
 #- add_docker_metadata:
 #    host: "unix:///var/run/docker.sock"
 #    match_fields: ["system.process.cgroup.id"]
+#    match_pids: ["process.pid", "process.ppid"]
+#    match_source: true
+#    match_source_index: 4
+#    cleanup_timeout: 60
 #    # To connect to Docker over TLS you must specify a client and CA certificate.
 #    #ssl:
 #    #  certificate_authority: "/etc/pki/root/ca.pem"

--- a/libbeat/_meta/config.reference.yml
+++ b/libbeat/_meta/config.reference.yml
@@ -97,6 +97,10 @@
 #- add_docker_metadata:
 #    host: "unix:///var/run/docker.sock"
 #    match_fields: ["system.process.cgroup.id"]
+#    match_pids: ["process.pid", "process.ppid"]
+#    match_source: true
+#    match_source_index: 4
+#    cleanup_timeout: 60
 #    # To connect to Docker over TLS you must specify a client and CA certificate.
 #    #ssl:
 #    #  certificate_authority: "/etc/pki/root/ca.pem"

--- a/libbeat/docs/processors-using.asciidoc
+++ b/libbeat/docs/processors-using.asciidoc
@@ -616,6 +616,7 @@ processors:
 - add_docker_metadata:
     host: "unix:///var/run/docker.sock"
     #match_fields: ["system.process.cgroup.id"]
+    #match_pids: ["process.pid", "process.ppid"]
     #match_source: true
     #match_source_index: 4
     #cleanup_timeout: 60
@@ -629,13 +630,24 @@ processors:
 It has the following settings:
 
 `host`:: (Optional) Docker socket (UNIX or TCP socket). It uses
-  `unix:///var/run/docker.sock` by default.
-`match_fields`:: (Optional) A list of fields to match a container id, at least
-  one of them should hold a container id to get the event enriched.
-`match_source`:: (Optional) Match container id from a log path present in
-  `source` field. Enabled by default.
-`match_source_index`:: (Optional) Index in the source path split by / to look
-  for container id. It defaults to 4 to match
-  `/var/lib/docker/containers/<container_id>/*.log`
+`unix:///var/run/docker.sock` by default.
+
+`ssl`:: (Optional) SSL configuration to use when connecting to the Docker
+socket.
+
+`match_fields`:: (Optional) A list of fields to match a container ID, at least
+one of them should hold a container ID to get the event enriched.
+
+`match_pids`:: (Optional) A list of fields that contain process IDs. If the
+process is running in Docker then the event will be enriched. The default value
+is `["process.pid", "process.ppid"]`.
+
+`match_source`:: (Optional) Match container ID from a log path present in the
+`source` field. Enabled by default.
+
+`match_source_index`:: (Optional) Index in the source path split by `/` to look
+for container ID. It defaults to 4 to match
+`/var/lib/docker/containers/<container_id>/*.log`
+
 `cleanup_timeout`:: (Optional) Time of inactivity to consider we can clean and
 forget metadata for a container, 60s by default.

--- a/libbeat/processors/add_docker_metadata/add_docker_metadata.go
+++ b/libbeat/processors/add_docker_metadata/add_docker_metadata.go
@@ -2,7 +2,13 @@ package add_docker_metadata
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
 	"strings"
+	"time"
+
+	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
@@ -11,30 +17,43 @@ import (
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/processors"
 	"github.com/elastic/beats/libbeat/processors/actions"
+	"github.com/elastic/gosigar/cgroup"
 )
 
+const (
+	processorName         = "add_docker_metadata"
+	dockerContainerIDKey  = "docker.container.id"
+	cgroupCacheExpiration = 5 * time.Minute
+)
+
+// processGroupPaths returns the cgroups associated with a process. This enables
+// unit testing by allowing us to stub the OS interface.
+var processCgroupPaths = cgroup.ProcessCgroupPaths
+
 func init() {
-	processors.RegisterPlugin("add_docker_metadata", newDockerMetadataProcessor)
+	processors.RegisterPlugin(processorName, newDockerMetadataProcessor)
 }
 
 type addDockerMetadata struct {
+	log             *logp.Logger
 	watcher         docker.Watcher
 	fields          []string
 	sourceProcessor processors.Processor
+
+	pidFields []string      // Field names that contain PIDs.
+	cgroups   *common.Cache // Cache of PID (int) to cgropus (map[string]string).
+	hostFS    string        // Directory where /proc is found
 }
 
 func newDockerMetadataProcessor(cfg *common.Config) (processors.Processor, error) {
+	cfgwarn.Beta("The %v processor is beta", processorName)
 	return buildDockerMetadataProcessor(cfg, docker.NewWatcher)
 }
 
 func buildDockerMetadataProcessor(cfg *common.Config, watcherConstructor docker.WatcherConstructor) (processors.Processor, error) {
-	cfgwarn.Beta("The add_docker_metadata processor is beta")
-
 	config := defaultConfig()
-
-	err := cfg.Unpack(&config)
-	if err != nil {
-		return nil, fmt.Errorf("fail to unpack the add_docker_metadata configuration: %s", err)
+	if err := cfg.Unpack(&config); err != nil {
+		return nil, errors.Wrapf(err, "fail to unpack the %v configuration", processorName)
 	}
 
 	watcher, err := watcherConstructor(config.Host, config.TLS)
@@ -46,7 +65,7 @@ func buildDockerMetadataProcessor(cfg *common.Config, watcherConstructor docker.
 		return nil, err
 	}
 
-	// Use extract_field processor to get container id from source file path
+	// Use extract_field processor to get container ID from source file path.
 	var sourceProcessor processors.Processor
 	if config.MatchSource {
 		var procConf, _ = common.NewConfigFrom(map[string]interface{}{
@@ -59,41 +78,68 @@ func buildDockerMetadataProcessor(cfg *common.Config, watcherConstructor docker.
 		if err != nil {
 			return nil, err
 		}
-
-		// Ensure `docker.container.id` is matched:
-		config.Fields = append(config.Fields, "docker.container.id")
 	}
 
 	return &addDockerMetadata{
+		log:             logp.NewLogger(processorName),
 		watcher:         watcher,
 		fields:          config.Fields,
 		sourceProcessor: sourceProcessor,
+		pidFields:       config.MatchPIDs,
+		hostFS:          config.HostFS,
 	}, nil
+}
+
+func lazyCgroupCacheInit(d *addDockerMetadata) {
+	if d.cgroups == nil {
+		d.log.Debug("Initializing cgroup cache")
+		evictionListener := func(k common.Key, v common.Value) {
+			d.log.Debugf("Evicted cached cgroups for PID=%v", k)
+		}
+		d.cgroups = common.NewCacheWithRemovalListener(cgroupCacheExpiration, 100, evictionListener)
+		d.cgroups.StartJanitor(5 * time.Second)
+	}
 }
 
 func (d *addDockerMetadata) Run(event *beat.Event) (*beat.Event, error) {
 	var cid string
 	var err error
 
-	// Process source field
+	// Extract CID from the filepath contained in the "source" field.
 	if d.sourceProcessor != nil {
 		if event.Fields["source"] != nil {
 			event, err = d.sourceProcessor.Run(event)
 			if err != nil {
-				logp.Debug("docker", "Error while extracting container ID from source path: %v", err)
+				d.log.Debugf("Error while extracting container ID from source path: %v", err)
 				return event, nil
+			}
+
+			if v, err := event.GetValue(dockerContainerIDKey); err == nil {
+				cid, _ = v.(string)
 			}
 		}
 	}
 
-	for _, field := range d.fields {
-		value, err := event.GetValue(field)
-		if err != nil {
-			continue
+	// Lookup CID using process cgroup membership data.
+	if cid == "" && len(d.pidFields) > 0 {
+		if id := d.lookupContainerIDByPID(event); id != "" {
+			cid = id
+			event.PutValue(dockerContainerIDKey, cid)
 		}
+	}
 
-		if strValue, ok := value.(string); ok {
-			cid = strValue
+	// Lookup CID from the user defined field names.
+	if cid == "" && len(d.fields) > 0 {
+		for _, field := range d.fields {
+			value, err := event.GetValue(field)
+			if err != nil {
+				continue
+			}
+
+			if strValue, ok := value.(string); ok {
+				cid = strValue
+				break
+			}
 		}
 	}
 
@@ -122,12 +168,115 @@ func (d *addDockerMetadata) Run(event *beat.Event) (*beat.Event, error) {
 		meta.Put("container.name", container.Name)
 		event.Fields["docker"] = meta
 	} else {
-		logp.Debug("docker", "Container not found: %s", cid)
+		d.log.Debugf("Container not found: cid=%s", cid)
 	}
 
 	return event, nil
 }
 
 func (d *addDockerMetadata) String() string {
-	return "add_docker_metadata=[fields=" + strings.Join(d.fields, ", ") + "]"
+	return fmt.Sprintf("%v=[match_fields=[%v] match_pids=[%v]]",
+		processorName, strings.Join(d.fields, ", "), strings.Join(d.pidFields, ", "))
+}
+
+// lookupContainerIDByPID finds the container ID based on PID fields contained
+// in the event.
+func (d *addDockerMetadata) lookupContainerIDByPID(event *beat.Event) string {
+	var cgroups map[string]string
+	for _, field := range d.pidFields {
+		v, err := event.GetValue(field)
+		if err != nil {
+			continue
+		}
+
+		pid, ok := tryToInt(v)
+		if !ok {
+			d.log.Debugf("field %v is not a PID (type=%T, value=%v)", field, v, v)
+			continue
+		}
+
+		cgroups, err = d.getProcessCgroups(pid)
+		if err != nil && os.IsNotExist(errors.Cause(err)) {
+			continue
+		}
+		if err != nil {
+			d.log.Debugf("failed to get cgroups for pid=%v: %v", pid, err)
+		}
+
+		break
+	}
+
+	return getContainerIDFromCgroups(cgroups)
+}
+
+// getProcessCgroups returns a mapping of cgroup subsystem name to path. It
+// returns an error if it failed to retrieve the cgroup info.
+func (d *addDockerMetadata) getProcessCgroups(pid int) (map[string]string, error) {
+	// Initialize at time of first use.
+	lazyCgroupCacheInit(d)
+
+	cgroups, ok := d.cgroups.Get(pid).(map[string]string)
+	if ok {
+		d.log.Debugf("Using cached cgroups for pid=%v", pid)
+		return cgroups, nil
+	}
+
+	cgroups, err := processCgroupPaths(d.hostFS, pid)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to read cgroups for pid=%v", pid)
+	}
+
+	d.cgroups.Put(pid, cgroups)
+	return cgroups, nil
+}
+
+// getContainerIDFromCgroups checks all of the processes' paths to see if any
+// of them are associated with Docker. Docker uses /docker/<CID> when
+// naming cgroups and we use this to determine the container ID. If no container
+// ID is found then an empty string is returned.
+func getContainerIDFromCgroups(cgroups map[string]string) string {
+	for _, path := range cgroups {
+		if strings.HasPrefix(path, "/docker") {
+			return filepath.Base(path)
+		}
+	}
+
+	return ""
+}
+
+// tryToInt tries to coerce the given interface to an int. On success it returns
+// the int value and true.
+func tryToInt(number interface{}) (int, bool) {
+	var rtn int
+	switch v := number.(type) {
+	case int:
+		rtn = int(v)
+	case int8:
+		rtn = int(v)
+	case int16:
+		rtn = int(v)
+	case int32:
+		rtn = int(v)
+	case int64:
+		rtn = int(v)
+	case uint:
+		rtn = int(v)
+	case uint8:
+		rtn = int(v)
+	case uint16:
+		rtn = int(v)
+	case uint32:
+		rtn = int(v)
+	case uint64:
+		rtn = int(v)
+	case string:
+		var err error
+		rtn, err = strconv.Atoi(v)
+		if err != nil {
+			return 0, false
+		}
+	default:
+		return 0, false
+	}
+	return rtn, true
 }

--- a/libbeat/processors/add_docker_metadata/add_docker_metadata_test.go
+++ b/libbeat/processors/add_docker_metadata/add_docker_metadata_test.go
@@ -1,6 +1,8 @@
 package add_docker_metadata
 
 import (
+	"fmt"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,6 +12,27 @@ import (
 	"github.com/elastic/beats/libbeat/common/bus"
 	"github.com/elastic/beats/libbeat/common/docker"
 )
+
+func init() {
+	// Stub out the procfs.
+	processCgroupPaths = func(_ string, pid int) (map[string]string, error) {
+		switch pid {
+		case 1000:
+			return map[string]string{
+				"cpu": "/docker/FABADA",
+			}, nil
+		case 2000:
+			return map[string]string{
+				"memory": "/user.slice",
+			}, nil
+		case 3000:
+			// Parser error (hopefully this never happens).
+			return nil, fmt.Errorf("cgroup parse failure")
+		default:
+			return nil, os.ErrNotExist
+		}
+	}
+}
 
 func TestInitialization(t *testing.T) {
 	var testConfig = common.NewConfig()
@@ -172,6 +195,101 @@ func TestDisableSource(t *testing.T) {
 
 	// remains unchanged
 	assert.EqualValues(t, input, result.Fields)
+}
+
+func TestMatchPIDs(t *testing.T) {
+	p, err := buildDockerMetadataProcessor(common.NewConfig(), MockWatcherFactory(
+		map[string]*docker.Container{
+			"FABADA": &docker.Container{
+				ID:    "FABADA",
+				Image: "image",
+				Name:  "name",
+				Labels: map[string]string{
+					"a": "1",
+					"b": "2",
+				},
+			},
+		},
+	))
+	assert.NoError(t, err, "initializing add_docker_metadata processor")
+
+	dockerMetadata := common.MapStr{
+		"docker": common.MapStr{
+			"container": common.MapStr{
+				"id":    "FABADA",
+				"image": "image",
+				"labels": common.MapStr{
+					"a": "1",
+					"b": "2",
+				},
+				"name": "name",
+			},
+		},
+	}
+
+	t.Run("pid is not containerized", func(t *testing.T) {
+		input := common.MapStr{}
+		input.Put("process.pid", 2000)
+		input.Put("process.ppid", 1000)
+
+		expected := common.MapStr{}
+		expected.DeepUpdate(input)
+
+		result, err := p.Run(&beat.Event{Fields: input})
+		assert.NoError(t, err, "processing an event")
+		assert.EqualValues(t, expected, result.Fields)
+	})
+
+	t.Run("pid does not exist", func(t *testing.T) {
+		input := common.MapStr{}
+		input.Put("process.pid", 9999)
+
+		expected := common.MapStr{}
+		expected.DeepUpdate(input)
+
+		result, err := p.Run(&beat.Event{Fields: input})
+		assert.NoError(t, err, "processing an event")
+		assert.EqualValues(t, expected, result.Fields)
+	})
+
+	t.Run("pid is containerized", func(t *testing.T) {
+		fields := common.MapStr{}
+		fields.Put("process.pid", "1000")
+
+		expected := common.MapStr{}
+		expected.DeepUpdate(dockerMetadata)
+		expected.DeepUpdate(fields)
+
+		result, err := p.Run(&beat.Event{Fields: fields})
+		assert.NoError(t, err, "processing an event")
+		assert.EqualValues(t, expected, result.Fields)
+	})
+
+	t.Run("pid exited and ppid is containerized", func(t *testing.T) {
+		fields := common.MapStr{}
+		fields.Put("process.pid", 9999)
+		fields.Put("process.ppid", 1000)
+
+		expected := common.MapStr{}
+		expected.DeepUpdate(dockerMetadata)
+		expected.DeepUpdate(fields)
+
+		result, err := p.Run(&beat.Event{Fields: fields})
+		assert.NoError(t, err, "processing an event")
+		assert.EqualValues(t, expected, result.Fields)
+	})
+
+	t.Run("cgroup error", func(t *testing.T) {
+		fields := common.MapStr{}
+		fields.Put("process.pid", 3000)
+
+		expected := common.MapStr{}
+		expected.DeepUpdate(fields)
+
+		result, err := p.Run(&beat.Event{Fields: fields})
+		assert.NoError(t, err, "processing an event")
+		assert.EqualValues(t, expected, result.Fields)
+	})
 }
 
 // Mock container watcher

--- a/libbeat/processors/add_docker_metadata/config.go
+++ b/libbeat/processors/add_docker_metadata/config.go
@@ -6,16 +6,18 @@ import (
 	"github.com/elastic/beats/libbeat/common/docker"
 )
 
-// Config for docker processor
+// Config for docker processor.
 type Config struct {
-	Host        string            `config:"host"`
-	TLS         *docker.TLSConfig `config:"ssl"`
-	Fields      []string          `config:"match_fields"`
-	MatchSource bool              `config:"match_source"`
-	SourceIndex int               `config:"match_source_index"`
+	Host        string            `config:"host"`               // Docker socket (UNIX or TCP socket).
+	TLS         *docker.TLSConfig `config:"ssl"`                // TLS settings for connecting to Docker.
+	Fields      []string          `config:"match_fields"`       // A list of fields to match a container ID.
+	MatchSource bool              `config:"match_source"`       // Match container ID from a log path present in source field.
+	SourceIndex int               `config:"match_source_index"` // Index in the source path split by / to look for container ID.
+	MatchPIDs   []string          `config:"match_pids"`         // A list of fields containing process IDs (PIDs).
+	HostFS      string            `config:"system.hostfs"`      // Specifies the mount point of the host’s filesystem for use in monitoring a host from within a container.
 
-	// Annotations are kept after container is killled, until they haven't been accessed
-	// for a full `cleanup_timeout`:
+	// Annotations are kept after container is killed, until they haven't been
+	// accessed for a full `cleanup_timeout`:
 	CleanupTimeout time.Duration `config:"cleanup_timeout"`
 }
 
@@ -23,6 +25,7 @@ func defaultConfig() Config {
 	return Config{
 		Host:        "unix:///var/run/docker.sock",
 		MatchSource: true,
-		SourceIndex: 4,
+		SourceIndex: 4, // Use 4 to match the CID in /var/lib/docker/containers/<container_id>/*.log.
+		MatchPIDs:   []string{"process.pid", "process.ppid"},
 	}
 }

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -586,6 +586,10 @@ metricbeat.modules:
 #- add_docker_metadata:
 #    host: "unix:///var/run/docker.sock"
 #    match_fields: ["system.process.cgroup.id"]
+#    match_pids: ["process.pid", "process.ppid"]
+#    match_source: true
+#    match_source_index: 4
+#    cleanup_timeout: 60
 #    # To connect to Docker over TLS you must specify a client and CA certificate.
 #    #ssl:
 #    #  certificate_authority: "/etc/pki/root/ca.pem"

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -565,6 +565,10 @@ packetbeat.protocols:
 #- add_docker_metadata:
 #    host: "unix:///var/run/docker.sock"
 #    match_fields: ["system.process.cgroup.id"]
+#    match_pids: ["process.pid", "process.ppid"]
+#    match_source: true
+#    match_source_index: 4
+#    cleanup_timeout: 60
 #    # To connect to Docker over TLS you must specify a client and CA certificate.
 #    #ssl:
 #    #  certificate_authority: "/etc/pki/root/ca.pem"

--- a/vendor/github.com/elastic/gosigar/CHANGELOG.md
+++ b/vendor/github.com/elastic/gosigar/CHANGELOG.md
@@ -2,6 +2,19 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.7.0]
+
+### Added
+- Added method stubs for process handling for operating system that are not supported
+  by gosigar. All methods return `ErrNotImplemented` on such systems. #88
+
+### Fixed
+- Fix freebsd build by using the common version of Get(pid). #91
+
+### Changed
+- Fixed issues in cgroup package by adding missing error checks and closing
+  file handles. #92
+
 ## [0.6.0]
 
 ### Added

--- a/vendor/github.com/elastic/gosigar/cgroup/blkio.go
+++ b/vendor/github.com/elastic/gosigar/cgroup/blkio.go
@@ -246,7 +246,7 @@ func readBlkioValues(path ...string) ([]blkioValue, error) {
 		values = append(values, v)
 	}
 
-	return values, nil
+	return values, sc.Err()
 }
 
 func isColonOrSpace(r rune) bool {

--- a/vendor/github.com/elastic/gosigar/cgroup/cpu.go
+++ b/vendor/github.com/elastic/gosigar/cgroup/cpu.go
@@ -100,7 +100,7 @@ func cpuStat(path string, cpu *CPUSubsystem) error {
 		}
 	}
 
-	return nil
+	return sc.Err()
 }
 
 func cpuCFS(path string, cpu *CPUSubsystem) error {

--- a/vendor/github.com/elastic/gosigar/cgroup/cpuacct.go
+++ b/vendor/github.com/elastic/gosigar/cgroup/cpuacct.go
@@ -70,7 +70,7 @@ func cpuacctStat(path string, cpuacct *CPUAccountingSubsystem) error {
 		}
 	}
 
-	return nil
+	return sc.Err()
 }
 
 func cpuacctUsage(path string, cpuacct *CPUAccountingSubsystem) error {

--- a/vendor/github.com/elastic/gosigar/cgroup/memory.go
+++ b/vendor/github.com/elastic/gosigar/cgroup/memory.go
@@ -164,5 +164,5 @@ func memoryStats(path string, mem *MemorySubsystem) error {
 		}
 	}
 
-	return nil
+	return sc.Err()
 }

--- a/vendor/github.com/elastic/gosigar/cgroup/util.go
+++ b/vendor/github.com/elastic/gosigar/cgroup/util.go
@@ -130,6 +130,7 @@ func SupportedSubsystems(rootfsMountpoint string) (map[string]struct{}, error) {
 		}
 		return nil, err
 	}
+	defer cgroups.Close()
 
 	subsystemSet := map[string]struct{}{}
 	sc := bufio.NewScanner(cgroups)
@@ -163,7 +164,7 @@ func SupportedSubsystems(rootfsMountpoint string) (map[string]struct{}, error) {
 		subsystemSet[subsystem] = struct{}{}
 	}
 
-	return subsystemSet, nil
+	return subsystemSet, sc.Err()
 }
 
 // SubsystemMountpoints returns the mountpoints for each of the given subsystems.
@@ -178,6 +179,7 @@ func SubsystemMountpoints(rootfsMountpoint string, subsystems map[string]struct{
 	if err != nil {
 		return nil, err
 	}
+	defer mountinfo.Close()
 
 	mounts := map[string]string{}
 	sc := bufio.NewScanner(mountinfo)
@@ -220,7 +222,7 @@ func SubsystemMountpoints(rootfsMountpoint string, subsystems map[string]struct{
 		}
 	}
 
-	return mounts, nil
+	return mounts, sc.Err()
 }
 
 // ProcessCgroupPaths returns the cgroups to which a process belongs and the
@@ -234,6 +236,7 @@ func ProcessCgroupPaths(rootfsMountpoint string, pid int) (map[string]string, er
 	if err != nil {
 		return nil, err
 	}
+	defer cgroup.Close()
 
 	paths := map[string]string{}
 	sc := bufio.NewScanner(cgroup)
@@ -256,5 +259,5 @@ func ProcessCgroupPaths(rootfsMountpoint string, pid int) (map[string]string, er
 		}
 	}
 
-	return paths, nil
+	return paths, sc.Err()
 }

--- a/vendor/github.com/elastic/gosigar/sigar_freebsd.go
+++ b/vendor/github.com/elastic/gosigar/sigar_freebsd.go
@@ -4,7 +4,6 @@ package gosigar
 
 import (
 	"io/ioutil"
-	"runtime"
 	"strconv"
 	"strings"
 	"unsafe"
@@ -106,8 +105,4 @@ func parseCpuStat(self *Cpu, line string) error {
 	self.Sys, _ = strtoull(fields[3])
 	self.Idle, _ = strtoull(fields[4])
 	return nil
-}
-
-func (self *ProcTime) Get(pid int) error {
-	return ErrNotImplemented{runtime.GOOS}
 }

--- a/vendor/github.com/elastic/gosigar/sigar_stub.go
+++ b/vendor/github.com/elastic/gosigar/sigar_stub.go
@@ -33,3 +33,35 @@ func (p *ProcTime) Get(int) error {
 func (self *FileSystemUsage) Get(path string) error {
 	return ErrNotImplemented{runtime.GOOS}
 }
+
+func (self *CpuList) Get() error {
+	return ErrNotImplemented{runtime.GOOS}
+}
+
+func (p *ProcState) Get(int) error {
+	return ErrNotImplemented{runtime.GOOS}
+}
+
+func (p *ProcExe) Get(int) error {
+	return ErrNotImplemented{runtime.GOOS}
+}
+
+func (p *ProcMem) Get(int) error {
+	return ErrNotImplemented{runtime.GOOS}
+}
+
+func (p *ProcFDUsage) Get(int) error {
+	return ErrNotImplemented{runtime.GOOS}
+}
+
+func (p *ProcEnv) Get(int) error {
+	return ErrNotImplemented{runtime.GOOS}
+}
+
+func (p *ProcList) Get() error {
+	return ErrNotImplemented{runtime.GOOS}
+}
+
+func (p *ProcArgs) Get(int) error {
+	return ErrNotImplemented{runtime.GOOS}
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -479,36 +479,36 @@
 			"revisionTime": "2017-02-07T06:38:51Z"
 		},
 		{
-			"checksumSHA1": "VxEaRgCf+HRL7Sv5stNL9xprK/8=",
+			"checksumSHA1": "zI9rslrfjyPyysz15OKWNsObfQI=",
 			"path": "github.com/elastic/gosigar",
-			"revision": "5cb8fed1ceb7f0fd69e4ad61c715a80601dddfd2",
-			"revisionTime": "2017-11-17T13:55:06Z",
-			"version": "v0.6.0",
-			"versionExact": "v0.6.0"
+			"revision": "cdcbd8c3b8bf28ef6d8639ec1e45bf31d2745f2d",
+			"revisionTime": "2018-01-17T18:54:32Z",
+			"version": "v0.7.0",
+			"versionExact": "v0.7.0"
 		},
 		{
-			"checksumSHA1": "jE0nhsyuGyQ7vWoyBRPEU63mQ4g=",
+			"checksumSHA1": "TX9y4oPL5YmT4Gb/OU4GIPTdQB4=",
 			"path": "github.com/elastic/gosigar/cgroup",
-			"revision": "306d51981789ccc65e5f1431d5c0d78d8c368f1b",
-			"revisionTime": "2017-10-12T15:04:52Z",
-			"version": "v0.6.0",
-			"versionExact": "v0.6.0"
+			"revision": "cdcbd8c3b8bf28ef6d8639ec1e45bf31d2745f2d",
+			"revisionTime": "2018-01-17T18:54:32Z",
+			"version": "v0.7.0",
+			"versionExact": "v0.7.0"
 		},
 		{
 			"checksumSHA1": "2VhOsaR4sv3S79HO6X+6dEphNKU=",
 			"path": "github.com/elastic/gosigar/sys/linux",
-			"revision": "306d51981789ccc65e5f1431d5c0d78d8c368f1b",
-			"revisionTime": "2017-10-12T15:04:52Z",
-			"version": "v0.6.0",
-			"versionExact": "v0.6.0"
+			"revision": "cdcbd8c3b8bf28ef6d8639ec1e45bf31d2745f2d",
+			"revisionTime": "2018-01-17T18:54:32Z",
+			"version": "v0.7.0",
+			"versionExact": "v0.7.0"
 		},
 		{
 			"checksumSHA1": "qDsgp2kAeI9nhj565HUScaUyjU4=",
 			"path": "github.com/elastic/gosigar/sys/windows",
-			"revision": "306d51981789ccc65e5f1431d5c0d78d8c368f1b",
-			"revisionTime": "2017-10-12T15:04:52Z",
-			"version": "v0.6.0",
-			"versionExact": "v0.6.0"
+			"revision": "cdcbd8c3b8bf28ef6d8639ec1e45bf31d2745f2d",
+			"revisionTime": "2018-01-17T18:54:32Z",
+			"version": "v0.7.0",
+			"versionExact": "v0.7.0"
 		},
 		{
 			"checksumSHA1": "P0CvGmmAM8uYPSE2ix4th/L9c/8=",

--- a/winlogbeat/winlogbeat.reference.yml
+++ b/winlogbeat/winlogbeat.reference.yml
@@ -126,6 +126,10 @@ winlogbeat.event_logs:
 #- add_docker_metadata:
 #    host: "unix:///var/run/docker.sock"
 #    match_fields: ["system.process.cgroup.id"]
+#    match_pids: ["process.pid", "process.ppid"]
+#    match_source: true
+#    match_source_index: 4
+#    cleanup_timeout: 60
 #    # To connect to Docker over TLS you must specify a client and CA certificate.
 #    #ssl:
 #    #  certificate_authority: "/etc/pki/root/ca.pem"


### PR DESCRIPTION
This PR enhances `add_docker_metadata` with the ability to enrich events containing process IDs.

The processor uses cgroup membership data from `/proc/pid/cgroup` to determine if the process is running inside of a Docker container. It caches the PID -> CID mapping for 5 minutes (based on time of last access).

The default configuration sets `match_pids: [process.pid, process.ppid]`. It falls back to the PPID in case the process has exited before the processing occurs.