### PR TITLE
SELinux policy draft for beats

### DIFF
--- a/selinux/auditbeat.fc
+++ b/selinux/auditbeat.fc
@@ -1,0 +1,8 @@
+/etc/rc\.d/init\.d/auditbeat			--	gen_context(system_u:object_r:auditbeat_initrc_exec_t,s0)
+/lib/systemd/system/auditbeat.service		--	gen_context(system_u:object_r:auditbeat_unit_file_t,s0)
+
+/usr/bin/auditbeat				--	gen_context(system_u:object_r:auditbeat_exec_t,s0)
+/usr/share/auditbeat/bin/auditbeat		--	gen_context(system_u:object_r:auditbeat_exec_t,s0)
+
+/var/lib/auditbeat(/.*)?			--	gen_context(system_u:object_r:auditbeat_var_lib_t,s0)
+/var/log/auditbeat(/.*)?			--	gen_context(system_u:object_r:auditbeat_log_t,s0)

--- a/selinux/auditbeat.if
+++ b/selinux/auditbeat.if
@@ -1,0 +1,271 @@
+
+## <summary>policy for auditbeat</summary>
+
+########################################
+## <summary>
+##	Execute auditbeat_exec_t in the auditbeat domain.
+## </summary>
+## <param name="domain">
+## <summary>
+##	Domain allowed to transition.
+## </summary>
+## </param>
+#
+interface(`auditbeat_domtrans',`
+	gen_require(`
+		type auditbeat_t, auditbeat_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	domtrans_pattern($1, auditbeat_exec_t, auditbeat_t)
+')
+
+######################################
+## <summary>
+##	Execute auditbeat in the caller domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`auditbeat_exec',`
+	gen_require(`
+		type auditbeat_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	can_exec($1, auditbeat_exec_t)
+')
+
+########################################
+## <summary>
+##	Execute auditbeat server in the auditbeat domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`auditbeat_initrc_domtrans',`
+	gen_require(`
+		type auditbeat_initrc_exec_t;
+	')
+
+	init_labeled_script_domtrans($1, auditbeat_initrc_exec_t)
+')
+########################################
+## <summary>
+##	Read auditbeat's log files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`auditbeat_read_log',`
+	gen_require(`
+		type auditbeat_log_t;
+	')
+
+	logging_search_logs($1)
+	read_files_pattern($1, auditbeat_log_t, auditbeat_log_t)
+')
+
+########################################
+## <summary>
+##	Append to auditbeat log files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`auditbeat_append_log',`
+	gen_require(`
+		type auditbeat_log_t;
+	')
+
+	logging_search_logs($1)
+	append_files_pattern($1, auditbeat_log_t, auditbeat_log_t)
+')
+
+########################################
+## <summary>
+##	Manage auditbeat log files
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`auditbeat_manage_log',`
+	gen_require(`
+		type auditbeat_log_t;
+	')
+
+	logging_search_logs($1)
+	manage_dirs_pattern($1, auditbeat_log_t, auditbeat_log_t)
+	manage_files_pattern($1, auditbeat_log_t, auditbeat_log_t)
+	manage_lnk_files_pattern($1, auditbeat_log_t, auditbeat_log_t)
+')
+
+########################################
+## <summary>
+##	Search auditbeat lib directories.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`auditbeat_search_lib',`
+	gen_require(`
+		type auditbeat_var_lib_t;
+	')
+
+	allow $1 auditbeat_var_lib_t:dir search_dir_perms;
+	files_search_var_lib($1)
+')
+
+########################################
+## <summary>
+##	Read auditbeat lib files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`auditbeat_read_lib_files',`
+	gen_require(`
+		type auditbeat_var_lib_t;
+	')
+
+	files_search_var_lib($1)
+	read_files_pattern($1, auditbeat_var_lib_t, auditbeat_var_lib_t)
+')
+
+########################################
+## <summary>
+##	Manage auditbeat lib files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`auditbeat_manage_lib_files',`
+	gen_require(`
+		type auditbeat_var_lib_t;
+	')
+
+	files_search_var_lib($1)
+	manage_files_pattern($1, auditbeat_var_lib_t, auditbeat_var_lib_t)
+')
+
+########################################
+## <summary>
+##	Manage auditbeat lib directories.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`auditbeat_manage_lib_dirs',`
+	gen_require(`
+		type auditbeat_var_lib_t;
+	')
+
+	files_search_var_lib($1)
+	manage_dirs_pattern($1, auditbeat_var_lib_t, auditbeat_var_lib_t)
+')
+
+########################################
+## <summary>
+##	Execute auditbeat server in the auditbeat domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+#
+interface(`auditbeat_systemctl',`
+	gen_require(`
+		type auditbeat_t;
+		type auditbeat_unit_file_t;
+	')
+
+	systemd_exec_systemctl($1)
+        systemd_read_fifo_file_passwd_run($1)
+	allow $1 auditbeat_unit_file_t:file read_file_perms;
+	allow $1 auditbeat_unit_file_t:service manage_service_perms;
+
+	ps_process_pattern($1, auditbeat_t)
+')
+
+
+########################################
+## <summary>
+##	All of the rules required to administrate
+##	an auditbeat environment
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`auditbeat_admin',`
+	gen_require(`
+		type auditbeat_t;
+		type auditbeat_initrc_exec_t;
+		type auditbeat_log_t;
+		type auditbeat_var_lib_t;
+	type auditbeat_unit_file_t;
+	')
+
+	allow $1 auditbeat_t:process { signal_perms };
+	ps_process_pattern($1, auditbeat_t)
+
+    tunable_policy(`deny_ptrace',`',`
+        allow $1 auditbeat_t:process ptrace;
+    ')
+
+	auditbeat_initrc_domtrans($1)
+	domain_system_change_exemption($1)
+	role_transition $2 auditbeat_initrc_exec_t system_r;
+	allow $2 system_r;
+
+	logging_search_logs($1)
+	admin_pattern($1, auditbeat_log_t)
+
+	files_search_var_lib($1)
+	admin_pattern($1, auditbeat_var_lib_t)
+
+	auditbeat_systemctl($1)
+	admin_pattern($1, auditbeat_unit_file_t)
+	allow $1 auditbeat_unit_file_t:service all_service_perms;
+	optional_policy(`
+		systemd_passwd_agent_exec($1)
+		systemd_read_fifo_file_passwd_run($1)
+	')
+')

--- a/selinux/auditbeat.te
+++ b/selinux/auditbeat.te
@@ -1,0 +1,39 @@
+policy_module(auditbeat, 1.0.0)
+
+require {
+  attribute beats_type;
+  attribute beats_log_type;
+  attribute beats_var_lib_type;
+
+  class capability { audit_control dac_override };
+  class file { create rename unlink write };
+  class netlink_audit_socket { bind create getattr nlmsg_read nlmsg_readpriv nlmsg_write };
+}
+
+type auditbeat_t;
+typeattribute auditbeat_t beats_type;
+
+type auditbeat_exec_t;
+init_daemon_domain(auditbeat_t, auditbeat_exec_t)
+
+type auditbeat_log_t;
+typeattribute auditbeat_log_t beats_log_type;
+logging_log_file(auditbeat_log_t)
+logging_log_filetrans(auditbeat_t, auditbeat_log_t, { dir file lnk_file })
+
+type auditbeat_var_lib_t;
+typeattribute auditbeat_var_lib_t beats_var_lib_type;
+files_type(auditbeat_var_lib_t)
+files_var_lib_filetrans(auditbeat_t, auditbeat_var_lib_t, { dir file lnk_file })
+
+type auditbeat_unit_file_t;
+systemd_unit_file(auditbeat_unit_file_t)
+
+type auditbeat_initrc_exec_t;
+init_script_file(auditbeat_initrc_exec_t)
+
+files_read_all_files(auditbeat_t)
+files_read_all_symlinks(auditbeat_t)
+
+allow auditbeat_t self:capability { audit_control dac_override };
+allow auditbeat_t self:netlink_audit_socket { bind create getattr nlmsg_read nlmsg_readpriv nlmsg_write };

--- a/selinux/beats-selinux.spec
+++ b/selinux/beats-selinux.spec
@@ -1,0 +1,123 @@
+# vim: sw=4:ts=4:et
+%define relabel_files() \
+restorecon -R /%{_lib}/systemd/system;                \
+restorecon -R %{_datadir}/filebeat/bin;               \
+restorecon -R %{_datadir}/journalbeat/bin;            \
+restorecon -R %{_datadir}/auditbeat/bin;              \
+restorecon -R %{_bindir};                             \
+restorecon -R %{_sharedstatedir}/auditbeat;           \
+restorecon -R %{_localstatedir}/log/auditbeat;        \
+restorecon -R %{_sharedstatedir}/filebeat;            \
+restorecon -R %{_localstatedir}/log/filebeat;         \
+restorecon -R %{_sharedstatedir}/journalbeat;         \
+restorecon -R %{_localstatedir}/log/journalbeat;
+
+Name:               beats-selinux
+Version:            1.0
+Release:            1%{?dist}
+Summary:            SELinux policy module for various beats
+
+Group:              System Environment/Base     
+License:            GPLv2+  
+URL:                https://git.im.jku.at/summary/packages!beats-selinux.git
+Source0:            beats.te
+Source1:            beats.if
+Source2:            filebeat.te
+Source3:            filebeat.fc
+Source4:            filebeat.if
+Source5:            auditbeat.te
+Source6:            auditbeat.fc
+Source7:            auditbeat.if
+Source8:            journalbeat.te
+Source9:            journalbeat.fc
+Source10:           journalbeat.if
+
+BuildRequires:      selinux-policy-devel >= 3.13
+BuildConflicts:     selinux-policy-devel < 3.13
+BuildRequires:      policycoreutils-devel
+Requires:           policycoreutils
+Requires:           libselinux-utils
+Requires:           selinux-policy >= 3.13
+Conflicts:          selinux-policy < 3.13
+Requires(post):     policycoreutils, policycoreutils-python 
+Requires(postun):     policycoreutils, policycoreutils-python 
+BuildArch:          noarch
+
+%description
+This package installs and sets up the SELinux policy security module for beats.
+
+%prep
+%setup -c -n %{name} -T
+cp %{SOURCE0} %{SOURCE1} %{SOURCE2} %{SOURCE3} \
+   %{SOURCE4} %{SOURCE5} %{SOURCE6} %{SOURCE7} \
+   %{SOURCE8} %{SOURCE9} %{SOURCE10} \
+ .
+
+%build
+make -f /usr/share/selinux/devel/Makefile beats.pp || exit
+make -f /usr/share/selinux/devel/Makefile filebeat.pp || exit
+make -f /usr/share/selinux/devel/Makefile journalbeat.pp || exit
+make -f /usr/share/selinux/devel/Makefile auditbeat.pp || exit
+
+%install
+install -d %{buildroot}%{_datadir}/selinux/packages
+install -m 644 beats.pp %{buildroot}%{_datadir}/selinux/packages
+install -m 644 filebeat.pp %{buildroot}%{_datadir}/selinux/packages
+install -m 644 journalbeat.pp %{buildroot}%{_datadir}/selinux/packages
+install -m 644 auditbeat.pp %{buildroot}%{_datadir}/selinux/packages
+install -d %{buildroot}%{_datadir}/selinux/devel/include/contrib
+install -m 644 filebeat.if %{buildroot}%{_datadir}/selinux/devel/include/contrib/
+install -m 644 journalbeat.if %{buildroot}%{_datadir}/selinux/devel/include/contrib/
+install -m 644 auditbeat.if %{buildroot}%{_datadir}/selinux/devel/include/contrib/
+install -m 644 beats.if %{buildroot}%{_datadir}/selinux/devel/include/contrib/
+install -d %{buildroot}/etc/selinux/targeted/contexts/users/
+
+%post
+semodule -n -i %{_datadir}/selinux/packages/beats.pp
+semodule -n -i %{_datadir}/selinux/packages/filebeat.pp
+semodule -n -i %{_datadir}/selinux/packages/journalbeat.pp
+semodule -n -i %{_datadir}/selinux/packages/auditbeat.pp
+
+if /usr/sbin/selinuxenabled ; then
+    /usr/sbin/load_policy
+    %relabel_files
+fi;
+
+semanage port -p tcp -t logstash_port_t -a 5044
+semanage port -p tcp -t kafka_port_t -a 9092
+semanage port -p tcp -t elasticsearch_port_t -a 9200
+exit 0
+ 
+%postun
+if [ $1 -eq 0 ]; then
+    semanage port -p tcp -t logstash_port_t -d 5044
+    semanage port -p tcp -t kafka_port_t -d 9092
+    semanage port -p tcp -t elasticsearch_port_t -d 9200
+
+    semodule -n -r filebeat
+    semodule -n -r journalbeat
+    semodule -n -r auditbeat
+    semodule -n -r beats
+
+    if /usr/sbin/selinuxenabled ; then
+       /usr/sbin/load_policy
+       %relabel_files
+    fi;
+fi;
+exit 0
+
+%files
+%defattr(-,root,root,-)
+%{_datadir}/selinux/packages/beats.pp
+%{_datadir}/selinux/packages/filebeat.pp
+%{_datadir}/selinux/packages/journalbeat.pp
+%{_datadir}/selinux/packages/auditbeat.pp
+%{_datadir}/selinux/devel/include/contrib/beats.if
+%{_datadir}/selinux/devel/include/contrib/filebeat.if
+%{_datadir}/selinux/devel/include/contrib/journalbeat.if
+%{_datadir}/selinux/devel/include/contrib/auditbeat.if
+
+%changelog
+* Wed Jan 17 2018 fuero <fuerob@gmail.com> - 1.0-1
+- Initial version
+

--- a/selinux/beats.if
+++ b/selinux/beats.if
@@ -1,0 +1,53 @@
+########################################
+## <summary>
+##      Make a TCP connection to the logstash port.
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+#
+interface(`beats_tcp_connect_logstash_port',`
+        gen_require(`
+                type logstash_port_t;
+        ')
+
+        allow $1 logstash_port_t:tcp_socket name_connect;
+')
+
+########################################
+## <summary>
+##      Make a TCP connection to the kafka port.
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+#
+interface(`beats_tcp_connect_kafka_port',`
+        gen_require(`
+                type kafka_port_t;
+        ')
+
+        allow $1 kafka_port_t:tcp_socket name_connect;
+')
+
+########################################
+## <summary>
+##      Make a TCP connection to the elasticsearch port.
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+#
+interface(`beats_tcp_connect_elasticsearch_port',`
+        gen_require(`
+                type elasticsearch_port_t;
+        ')
+
+        allow $1 elasticsearch_port_t:tcp_socket name_connect;
+')

--- a/selinux/beats.te
+++ b/selinux/beats.te
@@ -1,0 +1,54 @@
+policy_module(beats, 1.0.0)
+
+#
+# Rules for all *beat log collectors
+#   inherit by assigning a type attribute
+#
+
+type logstash_port_t;
+type kafka_port_t;
+type elasticsearch_port_t;
+
+attribute beats_type;
+attribute beats_cache_type;
+attribute beats_var_lib_type;
+attribute beats_log_type;
+
+corenet_port(logstash_port_t)
+corenet_port(kafka_port_t)
+corenet_port(elasticsearch_port_t)
+
+allow beats_type self:fifo_file rw_fifo_file_perms;
+allow beats_type self:unix_stream_socket create_stream_socket_perms;
+allow beats_type self:capability2 block_suspend;
+
+domain_use_interactive_fds(beats_type)
+files_read_etc_files(beats_type)
+
+miscfiles_read_localization(beats_type)
+miscfiles_read_generic_certs(beats_type)
+
+kernel_read_net_sysctls(beats_type)
+
+sysnet_dns_name_resolve(beats_type)
+corenet_tcp_bind_generic_node(beats_type)
+
+corenet_tcp_connect_redis_port(beats_type)
+# semanage port -p tcp -t logstash_port_t -a 5044
+beats_tcp_connect_logstash_port(beats_type)
+# semanage port -p tcp -t kafka_port_t -a 9092
+beats_tcp_connect_kafka_port(beats_type)
+# semanage port -p tcp -t elasticsearch_port_t -a 9200
+beats_tcp_connect_elasticsearch_port(beats_type)
+
+manage_dirs_pattern(beats_type, beats_cache_type, beats_cache_type)
+manage_files_pattern(beats_type, beats_cache_type, beats_cache_type)
+manage_lnk_files_pattern(beats_type, beats_cache_type, beats_cache_type)
+
+manage_dirs_pattern(beats_type, beats_var_lib_type, beats_var_lib_type)
+manage_files_pattern(beats_type, beats_var_lib_type, beats_var_lib_type)
+manage_lnk_files_pattern(beats_type, beats_var_lib_type, beats_var_lib_type)
+
+manage_dirs_pattern(beats_type, beats_log_type, beats_log_type)
+manage_files_pattern(beats_type, beats_log_type, beats_log_type)
+manage_lnk_files_pattern(beats_type, beats_log_type, beats_log_type)

--- a/selinux/filebeat.fc
+++ b/selinux/filebeat.fc
@@ -1,0 +1,8 @@
+/etc/rc\.d/init\.d/filebeat	--	gen_context(system_u:object_r:filebeat_initrc_exec_t,s0)
+
+/lib/systemd/system/filebeat.service		--	gen_context(system_u:object_r:filebeat_unit_file_t,s0)
+
+/usr/share/filebeat/bin/filebeat		--	gen_context(system_u:object_r:filebeat_exec_t,s0)
+
+/var/lib/filebeat(/.*)?		--	gen_context(system_u:object_r:filebeat_var_lib_t,s0)
+/var/log/filebeat(/.*)?		--	gen_context(system_u:object_r:filebeat_log_t,s0)

--- a/selinux/filebeat.if
+++ b/selinux/filebeat.if
@@ -1,0 +1,271 @@
+
+## <summary>policy for filebeat</summary>
+
+########################################
+## <summary>
+##	Execute filebeat_exec_t in the filebeat domain.
+## </summary>
+## <param name="domain">
+## <summary>
+##	Domain allowed to transition.
+## </summary>
+## </param>
+#
+interface(`filebeat_domtrans',`
+	gen_require(`
+		type filebeat_t, filebeat_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	domtrans_pattern($1, filebeat_exec_t, filebeat_t)
+')
+
+######################################
+## <summary>
+##	Execute filebeat in the caller domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`filebeat_exec',`
+	gen_require(`
+		type filebeat_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	can_exec($1, filebeat_exec_t)
+')
+
+########################################
+## <summary>
+##	Execute filebeat server in the filebeat domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`filebeat_initrc_domtrans',`
+	gen_require(`
+		type filebeat_initrc_exec_t;
+	')
+
+	init_labeled_script_domtrans($1, filebeat_initrc_exec_t)
+')
+########################################
+## <summary>
+##	Read filebeat's log files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`filebeat_read_log',`
+	gen_require(`
+		type filebeat_log_t;
+	')
+
+	logging_search_logs($1)
+	read_files_pattern($1, filebeat_log_t, filebeat_log_t)
+')
+
+########################################
+## <summary>
+##	Append to filebeat log files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`filebeat_append_log',`
+	gen_require(`
+		type filebeat_log_t;
+	')
+
+	logging_search_logs($1)
+	append_files_pattern($1, filebeat_log_t, filebeat_log_t)
+')
+
+########################################
+## <summary>
+##	Manage filebeat log files
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`filebeat_manage_log',`
+	gen_require(`
+		type filebeat_log_t;
+	')
+
+	logging_search_logs($1)
+	manage_dirs_pattern($1, filebeat_log_t, filebeat_log_t)
+	manage_files_pattern($1, filebeat_log_t, filebeat_log_t)
+	manage_lnk_files_pattern($1, filebeat_log_t, filebeat_log_t)
+')
+
+########################################
+## <summary>
+##	Search filebeat lib directories.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`filebeat_search_lib',`
+	gen_require(`
+		type filebeat_var_lib_t;
+	')
+
+	allow $1 filebeat_var_lib_t:dir search_dir_perms;
+	files_search_var_lib($1)
+')
+
+########################################
+## <summary>
+##	Read filebeat lib files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`filebeat_read_lib_files',`
+	gen_require(`
+		type filebeat_var_lib_t;
+	')
+
+	files_search_var_lib($1)
+	read_files_pattern($1, filebeat_var_lib_t, filebeat_var_lib_t)
+')
+
+########################################
+## <summary>
+##	Manage filebeat lib files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`filebeat_manage_lib_files',`
+	gen_require(`
+		type filebeat_var_lib_t;
+	')
+
+	files_search_var_lib($1)
+	manage_files_pattern($1, filebeat_var_lib_t, filebeat_var_lib_t)
+')
+
+########################################
+## <summary>
+##	Manage filebeat lib directories.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`filebeat_manage_lib_dirs',`
+	gen_require(`
+		type filebeat_var_lib_t;
+	')
+
+	files_search_var_lib($1)
+	manage_dirs_pattern($1, filebeat_var_lib_t, filebeat_var_lib_t)
+')
+
+########################################
+## <summary>
+##	Execute filebeat server in the filebeat domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+#
+interface(`filebeat_systemctl',`
+	gen_require(`
+		type filebeat_t;
+		type filebeat_unit_file_t;
+	')
+
+	systemd_exec_systemctl($1)
+        systemd_read_fifo_file_passwd_run($1)
+	allow $1 filebeat_unit_file_t:file read_file_perms;
+	allow $1 filebeat_unit_file_t:service manage_service_perms;
+
+	ps_process_pattern($1, filebeat_t)
+')
+
+
+########################################
+## <summary>
+##	All of the rules required to administrate
+##	an filebeat environment
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`filebeat_admin',`
+	gen_require(`
+		type filebeat_t;
+		type filebeat_initrc_exec_t;
+		type filebeat_log_t;
+		type filebeat_var_lib_t;
+	type filebeat_unit_file_t;
+	')
+
+	allow $1 filebeat_t:process { signal_perms };
+	ps_process_pattern($1, filebeat_t)
+
+    tunable_policy(`deny_ptrace',`',`
+        allow $1 filebeat_t:process ptrace;
+    ')
+
+	filebeat_initrc_domtrans($1)
+	domain_system_change_exemption($1)
+	role_transition $2 filebeat_initrc_exec_t system_r;
+	allow $2 system_r;
+
+	logging_search_logs($1)
+	admin_pattern($1, filebeat_log_t)
+
+	files_search_var_lib($1)
+	admin_pattern($1, filebeat_var_lib_t)
+
+	filebeat_systemctl($1)
+	admin_pattern($1, filebeat_unit_file_t)
+	allow $1 filebeat_unit_file_t:service all_service_perms;
+	optional_policy(`
+		systemd_passwd_agent_exec($1)
+		systemd_read_fifo_file_passwd_run($1)
+	')
+')

--- a/selinux/filebeat.te
+++ b/selinux/filebeat.te
@@ -1,0 +1,40 @@
+policy_module(filebeat, 1.0.0)
+
+require {
+  attribute beats_type;
+  attribute beats_log_type;
+  attribute beats_var_lib_type;
+}
+
+type filebeat_t;
+typeattribute filebeat_t beats_type;
+
+type filebeat_exec_t;
+init_daemon_domain(filebeat_t, filebeat_exec_t)
+
+type filebeat_log_t;
+typeattribute filebeat_log_t beats_log_type;
+logging_log_file(filebeat_log_t)
+logging_log_filetrans(filebeat_t, filebeat_log_t, { dir file lnk_file })
+
+type filebeat_var_lib_t;
+typeattribute filebeat_var_lib_t beats_var_lib_type;
+files_type(filebeat_var_lib_t)
+files_var_lib_filetrans(filebeat_t, filebeat_var_lib_t, { dir file lnk_file })
+
+type filebeat_unit_file_t;
+systemd_unit_file(filebeat_unit_file_t)
+
+type filebeat_initrc_exec_t;
+init_script_file(filebeat_initrc_exec_t)
+
+gen_tunable(filebeat_can_read_all_logs, true)
+tunable_policy(`filebeat_can_read_all_logs', `
+    logging_read_all_logs(filebeat_t)
+    logging_read_audit_log(filebeat_t)    
+')
+
+gen_tunable(filebeat_can_manage_all_logs, false)
+tunable_policy(`filebeat_can_manage_all_logs', `
+    logging_manage_all_logs(filebeat_t)
+')

--- a/selinux/journalbeat.fc
+++ b/selinux/journalbeat.fc
@@ -1,0 +1,6 @@
+/usr/bin/journalbeat					--	gen_context(system_u:object_r:journalbeat_exec_t,s0)
+
+/usr/lib/systemd/system/journalbeat.service		--	gen_context(system_u:object_r:journalbeat_unit_file_t,s0)
+
+/var/lib/journalbeat(/.*)?				--	gen_context(system_u:object_r:journalbeat_var_lib_t,s0)
+/var/log/journalbeat(/.*)?				--	gen_context(system_u:object_r:journalbeat_log_t,s0)

--- a/selinux/journalbeat.if
+++ b/selinux/journalbeat.if
@@ -1,0 +1,185 @@
+
+## <summary>policy for journalbeat</summary>
+
+########################################
+## <summary>
+##	Execute journalbeat_exec_t in the journalbeat domain.
+## </summary>
+## <param name="domain">
+## <summary>
+##	Domain allowed to transition.
+## </summary>
+## </param>
+#
+interface(`journalbeat_domtrans',`
+	gen_require(`
+		type journalbeat_t, journalbeat_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	domtrans_pattern($1, journalbeat_exec_t, journalbeat_t)
+')
+
+######################################
+## <summary>
+##	Execute journalbeat in the caller domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`journalbeat_exec',`
+	gen_require(`
+		type journalbeat_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	can_exec($1, journalbeat_exec_t)
+')
+
+########################################
+## <summary>
+##	Search journalbeat cache directories.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`journalbeat_search_cache',`
+	gen_require(`
+		type journalbeat_cache_t;
+	')
+
+	allow $1 journalbeat_cache_t:dir search_dir_perms;
+	files_search_var($1)
+')
+
+########################################
+## <summary>
+##	Read journalbeat cache files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`journalbeat_read_cache_files',`
+	gen_require(`
+		type journalbeat_cache_t;
+	')
+
+	files_search_var($1)
+	read_files_pattern($1, journalbeat_cache_t, journalbeat_cache_t)
+')
+
+########################################
+## <summary>
+##	Create, read, write, and delete
+##	journalbeat cache files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`journalbeat_manage_cache_files',`
+	gen_require(`
+		type journalbeat_cache_t;
+	')
+
+	files_search_var($1)
+	manage_files_pattern($1, journalbeat_cache_t, journalbeat_cache_t)
+')
+
+########################################
+## <summary>
+##	Manage journalbeat cache dirs.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`journalbeat_manage_cache_dirs',`
+	gen_require(`
+		type journalbeat_cache_t;
+	')
+
+	files_search_var($1)
+	manage_dirs_pattern($1, journalbeat_cache_t, journalbeat_cache_t)
+')
+
+########################################
+## <summary>
+##	Execute journalbeat server in the journalbeat domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+#
+interface(`journalbeat_systemctl',`
+	gen_require(`
+		type journalbeat_t;
+		type journalbeat_unit_file_t;
+	')
+
+	systemd_exec_systemctl($1)
+        systemd_read_fifo_file_passwd_run($1)
+	allow $1 journalbeat_unit_file_t:file read_file_perms;
+	allow $1 journalbeat_unit_file_t:service manage_service_perms;
+
+	ps_process_pattern($1, journalbeat_t)
+')
+
+
+########################################
+## <summary>
+##	All of the rules required to administrate
+##	an journalbeat environment
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`journalbeat_admin',`
+	gen_require(`
+		type journalbeat_t;
+		type journalbeat_cache_t;
+	type journalbeat_unit_file_t;
+	')
+
+	allow $1 journalbeat_t:process { signal_perms };
+	ps_process_pattern($1, journalbeat_t)
+
+    tunable_policy(`deny_ptrace',`',`
+        allow $1 journalbeat_t:process ptrace;
+    ')
+
+	files_search_var($1)
+	admin_pattern($1, journalbeat_cache_t)
+
+	journalbeat_systemctl($1)
+	admin_pattern($1, journalbeat_unit_file_t)
+	allow $1 journalbeat_unit_file_t:service all_service_perms;
+	optional_policy(`
+		systemd_passwd_agent_exec($1)
+		systemd_read_fifo_file_passwd_run($1)
+	')
+')

--- a/selinux/journalbeat.te
+++ b/selinux/journalbeat.te
@@ -1,0 +1,36 @@
+policy_module(journalbeat, 1.0.0)
+
+#####
+# Beats Boilerplate
+
+require {
+  attribute beats_type;
+  attribute beats_var_lib_type;
+  attribute beats_log_type;
+}
+
+type journalbeat_t;
+typeattribute journalbeat_t beats_type;
+
+type journalbeat_exec_t;
+init_daemon_domain(journalbeat_t, journalbeat_exec_t)
+
+type journalbeat_log_t;
+typeattribute journalbeat_log_t beats_log_type;
+logging_log_file(journalbeat_log_t)
+logging_log_filetrans(journalbeat_t, journalbeat_log_t, { dir file lnk_file })
+
+type journalbeat_var_lib_t;
+typeattribute journalbeat_var_lib_t beats_var_lib_type;
+files_type(journalbeat_var_lib_t)
+files_var_lib_filetrans(journalbeat_t, journalbeat_var_lib_t, { dir file lnk_file })
+
+type journalbeat_unit_file_t;
+systemd_unit_file(journalbeat_unit_file_t)
+
+#
+#####
+
+logging_read_syslog_pid(journalbeat_t)
+#init_stream_connect(journalbeat_t)
+init_read_var_lib_files(journalbeat_t)


### PR DESCRIPTION
[Triggered by this discussion](https://discuss.elastic.co/t/confining-beats-aka-selinux-policy-for-beats-on-el/116043) I'm proposing this as a draft for a EL SELinux policy confining the various beats from this repository. I've started with filebeat, auditbeat, and [journalbeat](https://github.com/mheese/journalbeat).

I've added the spec file for the RPM as well, and tested this on CentOS Linux release 7.4.1708 (Core).