### PR TITLE
Fields generator: support anonymous patterns in Grok

### DIFF
--- a/filebeat/scripts/generator/fields/main.go
+++ b/filebeat/scripts/generator/fields/main.go
@@ -77,6 +77,13 @@ func newFieldYml(name, typeName string, noDoc bool) *fieldYml {
 func newField(lp string) field {
 	lp = lp[1 : len(lp)-1]
 	ee := strings.Split(lp, ":")
+	if len(ee) != 2 {
+		return field{
+			Type:     ee[0],
+			Elements: nil,
+		}
+	}
+
 	e := strings.Split(ee[1], ".")
 	return field{
 		Type:     ee[0],
@@ -120,6 +127,9 @@ func getElementsFromPatterns(patterns []string) ([]field, error) {
 		pp := r.FindAllString(lp, -1)
 		for _, p := range pp {
 			f := newField(p)
+			if f.Elements == nil {
+				continue
+			}
 			fs = addNewField(fs, f)
 		}
 
@@ -267,7 +277,11 @@ func generateField(out []*fieldYml, field field, index, count int, noDoc bool) [
 func generateFields(f []field, noDoc bool) []*fieldYml {
 	var out []*fieldYml
 	for _, ff := range f {
-		out = generateField(out, ff, 1, len(ff.Elements), noDoc)
+		index := 1
+		if len(ff.Elements) == 1 {
+			index = 0
+		}
+		out = generateField(out, ff, index, len(ff.Elements), noDoc)
 	}
 	return out
 }


### PR DESCRIPTION
Previously patterns which did not have field name like `HAPROXYHTTP` in
```
"patterns": [
"%{HAPROXYHTTP}",
"%{HAPROXYTCP}",
"%{SYSLOGTIMESTAMP:syslog_timestamp} %{IPORHOST:syslog_server} %{SYSLOGPROG}: %{IP:client_ip}:%{INT:client_port} \[%{HAPROXYDATE:accept_date}\] %{NOTSPACE:backend_name}/%{NOTSPACE:server_name} %{GREEDYDATA:error}"
]
```
were not supported.

Now it is changed and the following fields.yml is generated:
```
- name: syslog_timestamp
  description: Please add description
  example: Please add example
  type: text
- name: syslog_server
  description: Please add description
  example: Please add example
  type: keyword
- name: client_ip
  description: Please add description
  example: Please add example
- name: client_port
  description: Please add description
  example: Please add example
- name: accept_date
  description: Please add description
  example: Please add example
- name: backend_name
  description: Please add description
  example: Please add example
- name: server_name
  description: Please add description
  example: Please add example
- name: error
  description: Please add description
  example: Please add example
  type: text
```