### PR TITLE
Migrate: modules yaml and their json expected file to use the input and the input.type field

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -40,6 +40,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
   one. This change also affect YAML configuration. {pull}6078[6078]
 - Refactor the Redis prospector to use the input interface {pull}6116[6116]
 - Refactor the UDP prospector to use the input interface {pull}6118[6118]
+- Refactor the usage of prospector to input in the YAML reference {pull}6121[6121]
 
 *Heartbeat*
 

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -24,9 +24,9 @@ filebeat.modules:
     # Convert the timestamp to UTC. Requires Elasticsearch >= 6.1.
     #var.convert_timezone: false
 
-    # Prospector configuration (advanced). Any prospector configuration option
+    # Input configuration (advanced). Any input configuration option
     # can be added under this section.
-    #prospector:
+    #input:
 
   # Authorization logs
   #auth:
@@ -39,9 +39,9 @@ filebeat.modules:
     # Convert the timestamp to UTC. Requires Elasticsearch >= 6.1.
     #var.convert_timezone: false
 
-    # Prospector configuration (advanced). Any prospector configuration option
+    # Input configuration (advanced). Any input configuration option
     # can be added under this section.
-    #prospector:
+    #input:
 
 #------------------------------- Apache2 Module ------------------------------
 #- module: apache2
@@ -53,9 +53,9 @@ filebeat.modules:
     # Filebeat will choose the paths depending on your OS.
     #var.paths:
 
-    # Prospector configuration (advanced). Any prospector configuration option
+    # Input configuration (advanced). Any input configuration option
     # can be added under this section.
-    #prospector:
+    #input:
 
   # Error logs
   #error:
@@ -65,9 +65,9 @@ filebeat.modules:
     # Filebeat will choose the paths depending on your OS.
     #var.paths:
 
-    # Prospector configuration (advanced). Any prospector configuration option
+    # Input configuration (advanced). Any input configuration option
     # can be added under this section.
-    #prospector:
+    #input:
 
 #------------------------------- Auditd Module -------------------------------
 #- module: auditd
@@ -78,9 +78,9 @@ filebeat.modules:
     # Filebeat will choose the paths depending on your OS.
     #var.paths:
 
-    # Prospector configuration (advanced). Any prospector configuration option
+    # Input configuration (advanced). Any input configuration option
     # can be added under this section.
-    #prospector:
+    #input:
 
 #------------------------------- Icinga Module -------------------------------
 #- module: icinga
@@ -92,9 +92,9 @@ filebeat.modules:
     # Filebeat will choose the paths depending on your OS.
     #var.paths:
 
-    # Prospector configuration (advanced). Any prospector configuration option
+    # Input configuration (advanced). Any input configuration option
     # can be added under this section.
-    #prospector:
+    #input:
 
   # Debug logs
   #debug:
@@ -104,9 +104,9 @@ filebeat.modules:
     # Filebeat will choose the paths depending on your OS.
     #var.paths:
 
-    # Prospector configuration (advanced). Any prospector configuration option
+    # Input configuration (advanced). Any input configuration option
     # can be added under this section.
-    #prospector:
+    #input:
 
   # Startup logs
   #startup:
@@ -116,9 +116,9 @@ filebeat.modules:
     # Filebeat will choose the paths depending on your OS.
     #var.paths:
 
-    # Prospector configuration (advanced). Any prospector configuration option
+    # Input configuration (advanced). Any input configuration option
     # can be added under this section.
-    #prospector:
+    #input:
 
 #-------------------------------- Kafka Module -------------------------------
 - module: kafka
@@ -162,9 +162,9 @@ filebeat.modules:
     # Filebeat will choose the paths depending on your OS.
     #var.paths:
 
-    # Prospector configuration (advanced). Any prospector configuration option
+    # Input configuration (advanced). Any input configuration option
     # can be added under this section.
-    #prospector:
+    #input:
 
   # Slow logs
   #slowlog:
@@ -174,9 +174,9 @@ filebeat.modules:
     # Filebeat will choose the paths depending on your OS.
     #var.paths:
 
-    # Prospector configuration (advanced). Any prospector configuration option
+    # Input configuration (advanced). Any input configuration option
     # can be added under this section.
-    #prospector:
+    #input:
 
 #-------------------------------- Nginx Module -------------------------------
 #- module: nginx
@@ -200,9 +200,9 @@ filebeat.modules:
     # Filebeat will choose the paths depending on your OS.
     #var.paths:
 
-    # Prospector configuration (advanced). Any prospector configuration option
+    # Input configuration (advanced). Any input configuration option
     # can be added under this section.
-    #prospector:
+    #input:
 
 #------------------------------- Osquery Module ------------------------------
 - module: osquery
@@ -228,9 +228,9 @@ filebeat.modules:
     # Filebeat will choose the paths depending on your OS.
     #var.paths:
 
-    # Prospector configuration (advanced). Any prospector configuration option
+    # Input configuration (advanced). Any input configuration option
     # can be added under this section.
-    #prospector:
+    #input:
 
 #-------------------------------- Redis Module -------------------------------
 #- module: redis
@@ -262,9 +262,9 @@ filebeat.modules:
     # Filebeat will choose the paths depending on your OS.
     #var.paths:
 
-    # Prospector configuration (advanced). Any prospector configuration option
+    # Input configuration (advanced). Any input configuration option
     # can be added under this section.
-    #prospector:
+    #input:
 
 
 #=========================== Filebeat prospectors =============================

--- a/filebeat/module/apache2/_meta/config.reference.yml
+++ b/filebeat/module/apache2/_meta/config.reference.yml
@@ -7,9 +7,9 @@
     # Filebeat will choose the paths depending on your OS.
     #var.paths:
 
-    # Prospector configuration (advanced). Any prospector configuration option
+    # Input configuration (advanced). Any input configuration option
     # can be added under this section.
-    #prospector:
+    #input:
 
   # Error logs
   #error:
@@ -19,6 +19,6 @@
     # Filebeat will choose the paths depending on your OS.
     #var.paths:
 
-    # Prospector configuration (advanced). Any prospector configuration option
+    # Input configuration (advanced). Any input configuration option
     # can be added under this section.
-    #prospector:
+    #input:

--- a/filebeat/module/apache2/access/manifest.yml
+++ b/filebeat/module/apache2/access/manifest.yml
@@ -12,7 +12,7 @@ var:
       - "C:/Program Files/Apache Software Foundation/Apache2.*/logs/access.log*"
 
 ingest_pipeline: ingest/default.json
-prospector: config/access.yml
+input: config/access.yml
 
 requires.processors:
 - name: user_agent

--- a/filebeat/module/apache2/access/test/test.log-expected.json
+++ b/filebeat/module/apache2/access/test/test.log-expected.json
@@ -33,6 +33,9 @@
             },
             "prospector": {
                 "type": "log"
+            },
+            "input": {
+                "type": "log"
             }
         },
         "fields": {
@@ -89,6 +92,9 @@
             },
             "prospector": {
                 "type": "log"
+            },
+            "input": {
+                "type": "log"
             }
         },
         "fields": {
@@ -127,6 +133,9 @@
                 "source_type": "apache2-access"
             },
             "prospector": {
+                "type": "log"
+            },
+            "input": {
                 "type": "log"
             }
         },
@@ -175,6 +184,9 @@
             },
             "offset": 443,
             "prospector": {
+                "type": "log"
+            },
+            "input": {
                 "type": "log"
             },
             "read_timestamp": "2017-05-29T19:34:14.378Z",

--- a/filebeat/module/apache2/error/manifest.yml
+++ b/filebeat/module/apache2/error/manifest.yml
@@ -11,4 +11,4 @@ var:
       - "C:/Program Files/Apache Software Foundation/Apache2.*/logs/error.log*"
 
 ingest_pipeline: ingest/pipeline.json
-prospector: config/error.yml
+input: config/error.yml

--- a/filebeat/module/apache2/error/test/test.log-expected.json
+++ b/filebeat/module/apache2/error/test/test.log-expected.json
@@ -23,6 +23,9 @@
             "prospector": {
                 "type": "log"
             },
+            "input": {
+                "type": "log"
+            },
             "source": "module/apache2/error/test/test.log",
             "fields": {
                 "pipeline_id": "apache2-error-pipeline",
@@ -56,6 +59,9 @@
             "prospector": {
                 "type": "log"
             },
+            "input": {
+                "type": "log"
+            },
             "source": "module/apache2/error/test/test.log",
             "fields": {
                 "pipeline_id": "apache2-error-pipeline",
@@ -84,6 +90,9 @@
                 "version": "6.0.0-alpha1"
             },
             "prospector": {
+                "type": "log"
+            },
+            "input": {
                 "type": "log"
             },
             "source": "module/apache2/error/test/test.log",

--- a/filebeat/module/auditd/_meta/config.reference.yml
+++ b/filebeat/module/auditd/_meta/config.reference.yml
@@ -6,6 +6,6 @@
     # Filebeat will choose the paths depending on your OS.
     #var.paths:
 
-    # Prospector configuration (advanced). Any prospector configuration option
+    # Input configuration (advanced). Any input configuration option
     # can be added under this section.
-    #prospector:
+    #input:

--- a/filebeat/module/auditd/log/manifest.yml
+++ b/filebeat/module/auditd/log/manifest.yml
@@ -8,7 +8,7 @@ var:
     os.windows: []
 
 ingest_pipeline: ingest/pipeline.json
-prospector: config/log.yml
+input: config/log.yml
 
 requires.processors:
 - name: geoip

--- a/filebeat/module/auditd/log/test/test.log-expected.json
+++ b/filebeat/module/auditd/log/test/test.log-expected.json
@@ -10,6 +10,9 @@
             "prospector": {
                 "type": "log"
             },
+            "input": {
+                "type": "log"
+            },
             "source": "/Users/me/go/src/github.com/elastic/beats/filebeat/module/auditd/log/test/test.log",
             "fileset": {
                 "module": "auditd",
@@ -47,6 +50,9 @@
         "_source": {
             "offset": 534,
             "prospector": {
+                "type": "log"
+            },
+            "input": {
                 "type": "log"
             },
             "source": "/Users/me/go/src/github.com/elastic/beats/filebeat/module/auditd/log/test/test.log",

--- a/filebeat/module/icinga/_meta/config.reference.yml
+++ b/filebeat/module/icinga/_meta/config.reference.yml
@@ -7,9 +7,9 @@
     # Filebeat will choose the paths depending on your OS.
     #var.paths:
 
-    # Prospector configuration (advanced). Any prospector configuration option
+    # Input configuration (advanced). Any input configuration option
     # can be added under this section.
-    #prospector:
+    #input:
 
   # Debug logs
   #debug:
@@ -19,9 +19,9 @@
     # Filebeat will choose the paths depending on your OS.
     #var.paths:
 
-    # Prospector configuration (advanced). Any prospector configuration option
+    # Input configuration (advanced). Any input configuration option
     # can be added under this section.
-    #prospector:
+    #input:
 
   # Startup logs
   #startup:
@@ -31,6 +31,6 @@
     # Filebeat will choose the paths depending on your OS.
     #var.paths:
 
-    # Prospector configuration (advanced). Any prospector configuration option
+    # Input configuration (advanced). Any input configuration option
     # can be added under this section.
-    #prospector:
+    #input:

--- a/filebeat/module/icinga/debug/manifest.yml
+++ b/filebeat/module/icinga/debug/manifest.yml
@@ -10,4 +10,4 @@ var:
       - c:/programdata/icinga2/var/log/icinga2/debug.log*
 
 ingest_pipeline: ingest/pipeline.json
-prospector: config/debug.yml
+input: config/debug.yml

--- a/filebeat/module/icinga/debug/test/test.log-expected.json
+++ b/filebeat/module/icinga/debug/test/test.log-expected.json
@@ -15,6 +15,9 @@
             "prospector": {
                 "type": "log"
             },
+            "input": {
+                "type": "log"
+            },
             "icinga": {
                 "debug": {
                     "severity": "debug",
@@ -53,6 +56,9 @@
             "prospector": {
                 "type": "log"
             },
+            "input": {
+                "type": "log"
+            },
             "icinga": {
                 "debug": {
                     "severity": "debug",
@@ -89,6 +95,9 @@
                 "version": "5.3.0"
             },
             "prospector": {
+                "type": "log"
+            },
+            "input": {
                 "type": "log"
             },
             "icinga": {

--- a/filebeat/module/icinga/main/manifest.yml
+++ b/filebeat/module/icinga/main/manifest.yml
@@ -10,4 +10,4 @@ var:
       - c:/programdata/icinga2/var/log/icinga2/icinga2.log*
 
 ingest_pipeline: ingest/pipeline.json
-prospector: config/main.yml
+input: config/main.yml

--- a/filebeat/module/icinga/main/test/test.log-expected.json
+++ b/filebeat/module/icinga/main/test/test.log-expected.json
@@ -15,6 +15,9 @@
             "prospector": {
                 "type": "log"
             },
+            "input": {
+                "type": "log"
+            },
             "icinga": {
                 "main": {
                     "severity": "warning",
@@ -53,6 +56,9 @@
             "prospector": {
                 "type": "log"
             },
+            "input": {
+                "type": "log"
+            },
             "icinga": {
                 "main": {
                     "severity": "information",
@@ -89,6 +95,9 @@
                 "version": "5.3.0"
             },
             "prospector": {
+                "type": "log"
+            },
+            "input": {
                 "type": "log"
             },
             "icinga": {

--- a/filebeat/module/icinga/startup/manifest.yml
+++ b/filebeat/module/icinga/startup/manifest.yml
@@ -10,4 +10,4 @@ var:
       - c:/programdata/icinga2/var/log/icinga2/startup.log
 
 ingest_pipeline: ingest/pipeline.json
-prospector: config/startup.yml
+input: config/startup.yml

--- a/filebeat/module/icinga/startup/test/test.log-expected.json
+++ b/filebeat/module/icinga/startup/test/test.log-expected.json
@@ -15,6 +15,9 @@
             "prospector": {
                 "type": "log"
             },
+            "input": {
+                "type": "log"
+            },
             "icinga": {
                 "startup": {
                     "severity": "information",
@@ -51,6 +54,9 @@
                 "version": "5.3.0"
             },
             "prospector": {
+                "type": "log"
+            },
+            "input": {
                 "type": "log"
             },
             "icinga": {

--- a/filebeat/module/kafka/log/manifest.yml
+++ b/filebeat/module/kafka/log/manifest.yml
@@ -11,4 +11,4 @@ var:
       - "{{.kafka_home}}/logs/kafka-*.log*"
 
 ingest_pipeline: ingest/pipeline.json
-prospector: config/log.yml
+input: config/log.yml

--- a/filebeat/module/kafka/log/test/controller.log-expected.json
+++ b/filebeat/module/kafka/log/test/controller.log-expected.json
@@ -25,6 +25,9 @@
       "prospector": {
         "type": "log"
       },
+      "input": {
+        "type": "log"
+      },
       "source": "/home/n/go/src/github.com/elastic/beats/filebeat/module/kafka/log/test/controller.log",
       "fileset": {
         "module": "kafka",
@@ -46,7 +49,7 @@
       1501847065113
     ]
   },
-  
+
   {
     "_index": "filebeat-7.0.0-alpha1-2017.08.11",
     "_type": "doc",
@@ -73,6 +76,9 @@
       "prospector": {
         "type": "log"
       },
+      "input": {
+        "type": "log"
+      },
       "source": "/home/n/go/src/github.com/elastic/beats/filebeat/module/kafka/log/test/controller.log",
       "message": "[2017-08-04 11:44:25,112] INFO [Controller-0-to-broker-0-send-thread]: Shutting down (kafka.controller.RequestSendThread)",
       "fileset": {
@@ -94,7 +100,7 @@
       1501847065112
     ]
   },
-  
+
   {
     "_index": "filebeat-7.0.0-alpha1-2017.08.11",
     "_type": "doc",
@@ -121,6 +127,9 @@
       "prospector": {
         "type": "log"
       },
+      "input": {
+        "type": "log"
+      },
       "source": "/home/n/go/src/github.com/elastic/beats/filebeat/module/kafka/log/test/controller.log",
       "message": "[2017-08-04 11:44:25,112] INFO [Controller-0-to-broker-0-send-thread]: Stopped (kafka.controller.RequestSendThread)",
       "fileset": {
@@ -142,7 +151,7 @@
       1501847065112
     ]
   },
-  
+
   {
     "_index": "filebeat-7.0.0-alpha1-2017.08.11",
     "_type": "doc",
@@ -169,6 +178,9 @@
       "prospector": {
         "type": "log"
       },
+      "input": {
+        "type": "log"
+      },
       "source": "/home/n/go/src/github.com/elastic/beats/filebeat/module/kafka/log/test/controller.log",
       "fileset": {
         "module": "kafka",
@@ -190,7 +202,7 @@
       1501847065111
     ]
   },
-  
+
   {
     "_index": "filebeat-7.0.0-alpha1-2017.08.11",
     "_type": "doc",
@@ -217,6 +229,9 @@
       "prospector": {
         "type": "log"
       },
+      "input": {
+        "type": "log"
+      },
       "source": "/home/n/go/src/github.com/elastic/beats/filebeat/module/kafka/log/test/controller.log",
       "fileset": {
         "module": "kafka",
@@ -238,7 +253,7 @@
       1501847065105
     ]
   },
-  
+
   {
     "_index": "filebeat-7.0.0-alpha1-2017.08.11",
     "_type": "doc",
@@ -265,6 +280,9 @@
       "prospector": {
         "type": "log"
       },
+      "input": {
+        "type": "log"
+      },
       "source": "/home/n/go/src/github.com/elastic/beats/filebeat/module/kafka/log/test/controller.log",
       "message": "[2017-08-04 11:44:25,100] DEBUG [Controller 0]: De-registering IsrChangeNotificationListener (kafka.controller.KafkaController)",
       "fileset": {
@@ -286,7 +304,7 @@
       1501847065100
     ]
   },
-  
+
   {
     "_index": "filebeat-7.0.0-alpha1-2017.08.11",
     "_type": "doc",
@@ -313,6 +331,9 @@
       "prospector": {
         "type": "log"
       },
+      "input": {
+        "type": "log"
+      },
       "source": "/home/n/go/src/github.com/elastic/beats/filebeat/module/kafka/log/test/controller.log",
       "message": "[2017-08-04 11:44:25,099] DEBUG [Controller 0]: Controller resigning, broker id 0 (kafka.controller.KafkaController)",
       "fileset": {
@@ -334,7 +355,7 @@
       1501847065099
     ]
   },
-  
+
   {
     "_index": "filebeat-7.0.0-alpha1-2017.08.11",
     "_type": "doc",
@@ -361,6 +382,9 @@
       "prospector": {
         "type": "log"
       },
+      "input": {
+        "type": "log"
+      },
       "source": "/home/n/go/src/github.com/elastic/beats/filebeat/module/kafka/log/test/controller.log",
       "fileset": {
         "module": "kafka",
@@ -382,7 +406,7 @@
       1501847065097
     ]
   },
-  
+
   {
     "_index": "filebeat-7.0.0-alpha1-2017.08.11",
     "_type": "doc",
@@ -409,6 +433,9 @@
       "prospector": {
         "type": "log"
       },
+      "input": {
+        "type": "log"
+      },
       "source": "/home/n/go/src/github.com/elastic/beats/filebeat/module/kafka/log/test/controller.log",
       "message": "[2017-08-04 11:44:25,095] INFO [controller-event-thread]: Stopped (kafka.controller.ControllerEventManager$ControllerEventThread)",
       "fileset": {
@@ -430,7 +457,7 @@
       1501847065095
     ]
   },
-  
+
   {
     "_index": "filebeat-7.0.0-alpha1-2017.08.11",
     "_type": "doc",
@@ -457,6 +484,9 @@
       "prospector": {
         "type": "log"
       },
+      "input": {
+        "type": "log"
+      },
       "source": "/home/n/go/src/github.com/elastic/beats/filebeat/module/kafka/log/test/controller.log",
       "message": "[2017-08-04 11:44:25,094] INFO [controller-event-thread]: Shutting down (kafka.controller.ControllerEventManager$ControllerEventThread)",
       "fileset": {
@@ -478,7 +508,7 @@
       1501847065094
     ]
   },
-  
+
   {
     "_index": "filebeat-7.0.0-alpha1-2017.08.11",
     "_type": "doc",
@@ -505,6 +535,9 @@
       "prospector": {
         "type": "log"
       },
+      "input": {
+        "type": "log"
+      },
       "source": "/home/n/go/src/github.com/elastic/beats/filebeat/module/kafka/log/test/controller.log",
       "message": "[2017-08-04 11:44:22,588] DEBUG [Controller 0]: Live brokers:  (kafka.controller.KafkaController)",
       "fileset": {
@@ -526,7 +559,7 @@
       1501847062588
     ]
   },
-  
+
   {
     "_index": "filebeat-7.0.0-alpha1-2017.08.11",
     "_type": "doc",
@@ -553,6 +586,9 @@
       "prospector": {
         "type": "log"
       },
+      "input": {
+        "type": "log"
+      },
       "source": "/home/n/go/src/github.com/elastic/beats/filebeat/module/kafka/log/test/controller.log",
       "message": "[2017-08-04 10:48:21,165] INFO [Partition state machine on Controller 0]: Invoking state change to OnlinePartition for partitions  (kafka.controller.PartitionStateMachine)",
       "fileset": {
@@ -574,7 +610,7 @@
       1501843701165
     ]
   },
-  
+
   {
     "_index": "filebeat-7.0.0-alpha1-2017.08.11",
     "_type": "doc",
@@ -601,6 +637,9 @@
       "prospector": {
         "type": "log"
       },
+      "input": {
+        "type": "log"
+      },
       "source": "/home/n/go/src/github.com/elastic/beats/filebeat/module/kafka/log/test/controller.log",
       "fileset": {
         "module": "kafka",
@@ -622,7 +661,7 @@
       1501843701157
     ]
   },
-  
+
   {
     "_index": "filebeat-7.0.0-alpha1-2017.08.11",
     "_type": "doc",
@@ -649,6 +688,9 @@
       "prospector": {
         "type": "log"
       },
+      "input": {
+        "type": "log"
+      },
       "source": "/home/n/go/src/github.com/elastic/beats/filebeat/module/kafka/log/test/controller.log",
       "message": "[2017-08-04 10:48:21,156] INFO [Partition state machine on Controller 0]: Started partition state machine with initial state -> Map() (kafka.controller.PartitionStateMachine)",
       "fileset": {
@@ -670,7 +712,7 @@
       1501843701156
     ]
   },
-  
+
   {
     "_index": "filebeat-7.0.0-alpha1-2017.08.11",
     "_type": "doc",
@@ -697,6 +739,9 @@
       "prospector": {
         "type": "log"
       },
+      "input": {
+        "type": "log"
+      },
       "source": "/home/n/go/src/github.com/elastic/beats/filebeat/module/kafka/log/test/controller.log",
       "message": "[2017-08-04 10:48:21,154] INFO [Replica state machine on controller 0]: Started replica state machine with initial state -> Map() (kafka.controller.ReplicaStateMachine)",
       "fileset": {
@@ -718,7 +763,7 @@
       1501843701154
     ]
   },
-  
+
   {
     "_index": "filebeat-7.0.0-alpha1-2017.08.11",
     "_type": "doc",
@@ -745,6 +790,9 @@
       "prospector": {
         "type": "log"
       },
+      "input": {
+        "type": "log"
+      },
       "source": "/home/n/go/src/github.com/elastic/beats/filebeat/module/kafka/log/test/controller.log",
       "fileset": {
         "module": "kafka",
@@ -766,7 +814,7 @@
       1501843701085
     ]
   },
-  
+
   {
     "_index": "filebeat-7.0.0-alpha1-2017.08.11",
     "_type": "doc",
@@ -793,6 +841,9 @@
       "prospector": {
         "type": "log"
       },
+      "input": {
+        "type": "log"
+      },
       "source": "/home/n/go/src/github.com/elastic/beats/filebeat/module/kafka/log/test/controller.log",
       "message": "[2017-08-04 10:48:21,082] INFO [Controller 0]: Controller 0 incremented epoch to 1 (kafka.controller.KafkaController)",
       "fileset": {
@@ -814,7 +865,7 @@
       1501843701082
     ]
   },
-  
+
   {
     "_index": "filebeat-7.0.0-alpha1-2017.08.11",
     "_type": "doc",
@@ -841,6 +892,9 @@
       "prospector": {
         "type": "log"
       },
+      "input": {
+        "type": "log"
+      },
       "source": "/home/n/go/src/github.com/elastic/beats/filebeat/module/kafka/log/test/controller.log",
       "message": "[2017-08-04 10:48:21,064] INFO [Controller 0]: Broker 0 starting become controller state transition (kafka.controller.KafkaController)",
       "fileset": {
@@ -862,7 +916,7 @@
       1501843701064
     ]
   },
-  
+
   {
     "_index": "filebeat-7.0.0-alpha1-2017.08.11",
     "_type": "doc",
@@ -889,6 +943,9 @@
       "prospector": {
         "type": "log"
       },
+      "input": {
+        "type": "log"
+      },
       "source": "/home/n/go/src/github.com/elastic/beats/filebeat/module/kafka/log/test/controller.log",
       "fileset": {
         "module": "kafka",
@@ -910,7 +967,7 @@
       1501843701063
     ]
   },
-  
+
   {
     "_index": "filebeat-7.0.0-alpha1-2017.08.11",
     "_type": "doc",
@@ -935,6 +992,9 @@
         "version": "7.0.0-alpha1"
       },
       "prospector": {
+        "type": "log"
+      },
+      "input": {
         "type": "log"
       },
       "source": "/home/n/go/src/github.com/elastic/beats/filebeat/module/kafka/log/test/controller.log",

--- a/filebeat/module/kafka/log/test/server.log-expected.json
+++ b/filebeat/module/kafka/log/test/server.log-expected.json
@@ -25,6 +25,9 @@
       "prospector": {
         "type": "log"
       },
+      "input": {
+        "type": "log"
+      },
       "source": "/home/n/go/src/github.com/elastic/beats/filebeat/module/kafka/log/test/server.log",
       "fileset": {
         "module": "kafka",
@@ -46,7 +49,7 @@
       1501843701167
     ]
   },
-  
+
   {
     "_index": "filebeat-7.0.0-alpha1-2017.08.11",
     "_type": "doc",
@@ -73,6 +76,9 @@
       "prospector": {
         "type": "log"
       },
+      "input": {
+        "type": "log"
+      },
       "source": "/home/n/go/src/github.com/elastic/beats/filebeat/module/kafka/log/test/server.log",
       "fileset": {
         "module": "kafka",
@@ -94,7 +100,7 @@
       1501843701162
     ]
   },
-  
+
   {
     "_index": "filebeat-7.0.0-alpha1-2017.08.11",
     "_type": "doc",
@@ -121,6 +127,9 @@
       "prospector": {
         "type": "log"
       },
+      "input": {
+        "type": "log"
+      },
       "source": "/home/n/go/src/github.com/elastic/beats/filebeat/module/kafka/log/test/server.log",
       "fileset": {
         "module": "kafka",
@@ -142,7 +151,7 @@
       1501843701127
     ]
   },
-  
+
   {
     "_index": "filebeat-7.0.0-alpha1-2017.08.11",
     "_type": "doc",
@@ -169,6 +178,9 @@
       "prospector": {
         "type": "log"
       },
+      "input": {
+        "type": "log"
+      },
       "source": "/home/n/go/src/github.com/elastic/beats/filebeat/module/kafka/log/test/server.log",
       "message": "[2017-08-04 10:48:21,095] INFO [Group Metadata Manager on Broker 0]: Removed 0 expired offsets in 1 milliseconds. (kafka.coordinator.group.GroupMetadataManager)",
       "fileset": {
@@ -190,7 +202,7 @@
       1501843701095
     ]
   },
-  
+
   {
     "_index": "filebeat-7.0.0-alpha1-2017.08.11",
     "_type": "doc",
@@ -217,6 +229,9 @@
       "prospector": {
         "type": "log"
       },
+      "input": {
+        "type": "log"
+      },
       "source": "/home/n/go/src/github.com/elastic/beats/filebeat/module/kafka/log/test/server.log",
       "message": "[2017-08-04 10:48:21,063] INFO Result of znode creation is: OK (kafka.utils.ZKCheckedEphemeral)",
       "fileset": {
@@ -238,7 +253,7 @@
       1501843701063
     ]
   },
-  
+
   {
     "_index": "filebeat-7.0.0-alpha1-2017.08.11",
     "_type": "doc",
@@ -265,6 +280,9 @@
       "prospector": {
         "type": "log"
       },
+      "input": {
+        "type": "log"
+      },
       "source": "/home/n/go/src/github.com/elastic/beats/filebeat/module/kafka/log/test/server.log",
       "message": "[2017-08-04 10:48:21,062] INFO [ExpirationReaper-0-Heartbeat]: Starting (kafka.server.DelayedOperationPurgatory$ExpiredOperationReaper)",
       "fileset": {
@@ -286,7 +304,7 @@
       1501843701062
     ]
   },
-  
+
   {
     "_index": "filebeat-7.0.0-alpha1-2017.08.11",
     "_type": "doc",
@@ -313,6 +331,9 @@
       "prospector": {
         "type": "log"
       },
+      "input": {
+        "type": "log"
+      },
       "source": "/home/n/go/src/github.com/elastic/beats/filebeat/module/kafka/log/test/server.log",
       "message": "[2017-08-04 10:48:20,873] INFO Loading logs. (kafka.log.LogManager)",
       "fileset": {
@@ -334,7 +355,7 @@
       1501843700873
     ]
   },
-  
+
   {
     "_index": "filebeat-7.0.0-alpha1-2017.08.11",
     "_type": "doc",
@@ -361,6 +382,9 @@
       "prospector": {
         "type": "log"
       },
+      "input": {
+        "type": "log"
+      },
       "source": "/home/n/go/src/github.com/elastic/beats/filebeat/module/kafka/log/test/server.log",
       "fileset": {
         "module": "kafka",
@@ -382,7 +406,7 @@
       1501843700866
     ]
   },
-  
+
   {
     "_index": "filebeat-7.0.0-alpha1-2017.08.11",
     "_type": "doc",
@@ -409,6 +433,9 @@
       "prospector": {
         "type": "log"
       },
+      "input": {
+        "type": "log"
+      },
       "source": "/home/n/go/src/github.com/elastic/beats/filebeat/module/kafka/log/test/server.log",
       "message": "[2017-08-04 10:48:20,800] INFO [ThrottledRequestReaper-Fetch]: Starting (kafka.server.ClientQuotaManager$ThrottledRequestReaper)",
       "fileset": {
@@ -430,7 +457,7 @@
       1501843700800
     ]
   },
-  
+
   {
     "_index": "filebeat-7.0.0-alpha1-2017.08.11",
     "_type": "doc",
@@ -457,6 +484,9 @@
       "prospector": {
         "type": "log"
       },
+      "input": {
+        "type": "log"
+      },
       "source": "/home/n/go/src/github.com/elastic/beats/filebeat/module/kafka/log/test/server.log",
       "message": "[2017-08-04 10:48:20,748] WARN No meta.properties file under dir /tmp/kafka-logs/meta.properties (kafka.server.BrokerMetadataCheckpoint)",
       "fileset": {
@@ -478,7 +508,7 @@
       1501843700748
     ]
   },
-  
+
   {
     "_index": "filebeat-7.0.0-alpha1-2017.08.11",
     "_type": "doc",
@@ -505,6 +535,9 @@
       "prospector": {
         "type": "log"
       },
+      "input": {
+        "type": "log"
+      },
       "source": "/home/n/go/src/github.com/elastic/beats/filebeat/module/kafka/log/test/server.log",
       "fileset": {
         "module": "kafka",
@@ -526,7 +559,7 @@
       1501843700458
     ]
   },
-  
+
   {
     "_index": "filebeat-7.0.0-alpha1-2017.08.11",
     "_type": "doc",
@@ -553,6 +586,9 @@
       "prospector": {
         "type": "log"
       },
+      "input": {
+        "type": "log"
+      },
       "source": "/home/n/go/src/github.com/elastic/beats/filebeat/module/kafka/log/test/server.log",
       "message": "[2017-08-04 10:48:20,457] INFO Session establishment complete on server localhost/0:0:0:0:0:0:0:1:2181, sessionid = 0x15dabf8d4140000, negotiated timeout = 6000 (org.apache.zookeeper.ClientCnxn)",
       "fileset": {
@@ -574,7 +610,7 @@
       1501843700457
     ]
   },
-  
+
   {
     "_index": "filebeat-7.0.0-alpha1-2017.08.11",
     "_type": "doc",
@@ -601,6 +637,9 @@
       "prospector": {
         "type": "log"
       },
+      "input": {
+        "type": "log"
+      },
       "source": "/home/n/go/src/github.com/elastic/beats/filebeat/module/kafka/log/test/server.log",
       "message": "[2017-08-04 10:48:20,420] INFO Socket connection established to localhost/0:0:0:0:0:0:0:1:2181, initiating session (org.apache.zookeeper.ClientCnxn)",
       "fileset": {
@@ -622,7 +661,7 @@
       1501843700420
     ]
   },
-  
+
   {
     "_index": "filebeat-7.0.0-alpha1-2017.08.11",
     "_type": "doc",
@@ -649,6 +688,9 @@
       "prospector": {
         "type": "log"
       },
+      "input": {
+        "type": "log"
+      },
       "source": "/home/n/go/src/github.com/elastic/beats/filebeat/module/kafka/log/test/server.log",
       "message": "[2017-08-04 10:48:20,415] INFO Opening socket connection to server localhost/0:0:0:0:0:0:0:1:2181. Will not attempt to authenticate using SASL (unknown error) (org.apache.zookeeper.ClientCnxn)",
       "fileset": {
@@ -670,7 +712,7 @@
       1501843700415
     ]
   },
-  
+
   {
     "_index": "filebeat-7.0.0-alpha1-2017.08.11",
     "_type": "doc",
@@ -697,6 +739,9 @@
       "prospector": {
         "type": "log"
       },
+      "input": {
+        "type": "log"
+      },
       "source": "/home/n/go/src/github.com/elastic/beats/filebeat/module/kafka/log/test/server.log",
       "message": "[2017-08-04 10:48:20,413] INFO Waiting for keeper state SyncConnected (org.I0Itec.zkclient.ZkClient)",
       "fileset": {
@@ -718,7 +763,7 @@
       1501843700413
     ]
   },
-  
+
   {
     "_index": "filebeat-7.0.0-alpha1-2017.08.11",
     "_type": "doc",
@@ -745,6 +790,9 @@
       "prospector": {
         "type": "log"
       },
+      "input": {
+        "type": "log"
+      },
       "source": "/home/n/go/src/github.com/elastic/beats/filebeat/module/kafka/log/test/server.log",
       "message": "[2017-08-04 10:48:20,401] INFO Initiating client connection, connectString=localhost:2181 sessionTimeout=6000 watcher=org.I0Itec.zkclient.ZkClient@5ffead27 (org.apache.zookeeper.ZooKeeper)",
       "fileset": {
@@ -766,7 +814,7 @@
       1501843700401
     ]
   },
-  
+
   {
     "_index": "filebeat-7.0.0-alpha1-2017.08.11",
     "_type": "doc",
@@ -793,6 +841,9 @@
       "prospector": {
         "type": "log"
       },
+      "input": {
+        "type": "log"
+      },
       "source": "/home/n/go/src/github.com/elastic/beats/filebeat/module/kafka/log/test/server.log",
       "message": "[2017-08-04 10:48:20,400] INFO Client environment:java.compiler=<NA> (org.apache.zookeeper.ZooKeeper)",
       "fileset": {
@@ -814,7 +865,7 @@
       1501843700400
     ]
   },
-  
+
   {
     "_index": "filebeat-7.0.0-alpha1-2017.08.11",
     "_type": "doc",
@@ -841,6 +892,9 @@
       "prospector": {
         "type": "log"
       },
+      "input": {
+        "type": "log"
+      },
       "source": "/home/n/go/src/github.com/elastic/beats/filebeat/module/kafka/log/test/server.log",
       "message": "[2017-08-04 10:48:20,400] INFO Client environment:java.io.tmpdir=/tmp (org.apache.zookeeper.ZooKeeper)",
       "fileset": {
@@ -862,7 +916,7 @@
       1501843700400
     ]
   },
-  
+
   {
     "_index": "filebeat-7.0.0-alpha1-2017.08.11",
     "_type": "doc",
@@ -889,6 +943,9 @@
       "prospector": {
         "type": "log"
       },
+      "input": {
+        "type": "log"
+      },
       "source": "/home/n/go/src/github.com/elastic/beats/filebeat/module/kafka/log/test/server.log",
       "message": "[2017-08-04 10:48:20,379] INFO Connecting to zookeeper on localhost:2181 (kafka.server.KafkaServer)",
       "fileset": {
@@ -910,7 +967,7 @@
       1501843700379
     ]
   },
-  
+
   {
     "_index": "filebeat-7.0.0-alpha1-2017.08.11",
     "_type": "doc",
@@ -935,6 +992,9 @@
         "version": "7.0.0-alpha1"
       },
       "prospector": {
+        "type": "log"
+      },
+      "input": {
         "type": "log"
       },
       "source": "/home/n/go/src/github.com/elastic/beats/filebeat/module/kafka/log/test/server.log",

--- a/filebeat/module/kafka/log/test/state-change.log-expected.json
+++ b/filebeat/module/kafka/log/test/state-change.log-expected.json
@@ -25,6 +25,9 @@
       "prospector": {
         "type": "log"
       },
+      "input": {
+        "type": "log"
+      },
       "source": "/home/n/go/src/github.com/elastic/beats/filebeat/module/kafka/log/test/state-change.log",
       "message": "[2017-08-04 10:48:21,428] TRACE Controller 0 epoch 1 received response {error_code=0} for a request sent to broker baldur:9092 (id: 0 rack: null) (state.change.logger)",
       "fileset": {

--- a/filebeat/module/logstash/log/manifest.yml
+++ b/filebeat/module/logstash/log/manifest.yml
@@ -10,4 +10,4 @@ var:
       - c:/programdata/logstash/logs/logstash-{{.format}}*.log
 
 ingest_pipeline: ingest/pipeline-{{.format}}.json
-prospector: config/log.yml
+input: config/log.yml

--- a/filebeat/module/logstash/log/test/logstash-plain.log-expected.json
+++ b/filebeat/module/logstash/log/test/logstash-plain.log-expected.json
@@ -25,6 +25,9 @@
             "prospector": {
                 "type": "log"
             },
+            "input": {
+                "type": "log"
+            },
             "read_timestamp": "2017-10-30T19:40:38.780Z",
             "source": "/tmp/logstash-plain.log"
         },

--- a/filebeat/module/logstash/slowlog/manifest.yml
+++ b/filebeat/module/logstash/slowlog/manifest.yml
@@ -10,4 +10,4 @@ var:
       - c:/programdata/logstash/logs/logstash-slowlog-{{.format}}*.log
 
 ingest_pipeline: ingest/pipeline-{{.format}}.json
-prospector: config/slowlog.yml
+input: config/slowlog.yml

--- a/filebeat/module/logstash/slowlog/test/slowlog-plain.log-expected.json
+++ b/filebeat/module/logstash/slowlog/test/slowlog-plain.log-expected.json
@@ -31,6 +31,9 @@
             "prospector": {
                 "type": "log"
             },
+            "input": {
+                "type": "log"
+            },
             "read_timestamp": "2017-11-21T05:34:25.435Z",
             "source": "/Users/ph/go/src/github.com/elastic/beats/filebeat/module/logstash/slowlog/test/slowlog-plain.log"
         },

--- a/filebeat/module/mysql/_meta/config.reference.yml
+++ b/filebeat/module/mysql/_meta/config.reference.yml
@@ -7,9 +7,9 @@
     # Filebeat will choose the paths depending on your OS.
     #var.paths:
 
-    # Prospector configuration (advanced). Any prospector configuration option
+    # Input configuration (advanced). Any input configuration option
     # can be added under this section.
-    #prospector:
+    #input:
 
   # Slow logs
   #slowlog:
@@ -19,6 +19,6 @@
     # Filebeat will choose the paths depending on your OS.
     #var.paths:
 
-    # Prospector configuration (advanced). Any prospector configuration option
+    # Input configuration (advanced). Any input configuration option
     # can be added under this section.
-    #prospector:
+    #input:

--- a/filebeat/module/mysql/error/manifest.yml
+++ b/filebeat/module/mysql/error/manifest.yml
@@ -11,4 +11,4 @@ var:
       - "c:/programdata/MySQL/MySQL Server*/error.log*"
 
 ingest_pipeline: ingest/pipeline.json
-prospector: config/error.yml
+input: config/error.yml

--- a/filebeat/module/mysql/slowlog/manifest.yml
+++ b/filebeat/module/mysql/slowlog/manifest.yml
@@ -11,4 +11,4 @@ var:
       - "c:/programdata/MySQL/MySQL Server*/mysql-slow.log*"
 
 ingest_pipeline: ingest/pipeline.json
-prospector: config/slowlog.yml
+input: config/slowlog.yml

--- a/filebeat/module/nginx/_meta/config.reference.yml
+++ b/filebeat/module/nginx/_meta/config.reference.yml
@@ -19,6 +19,6 @@
     # Filebeat will choose the paths depending on your OS.
     #var.paths:
 
-    # Prospector configuration (advanced). Any prospector configuration option
+    # Input configuration (advanced). Any input configuration option
     # can be added under this section.
-    #prospector:
+    #input:

--- a/filebeat/module/nginx/access/manifest.yml
+++ b/filebeat/module/nginx/access/manifest.yml
@@ -10,7 +10,7 @@ var:
       - c:/programdata/nginx/logs/*access.log*
 
 ingest_pipeline: ingest/default.json
-prospector: config/nginx-access.yml
+input: config/nginx-access.yml
 
 machine_learning:
 - name: response_code

--- a/filebeat/module/nginx/access/test/test.log-expected.json
+++ b/filebeat/module/nginx/access/test/test.log-expected.json
@@ -54,6 +54,9 @@
       "prospector" : {
         "type" : "log"
       },
+      "input" : {
+        "type" : "log"
+      },
       "read_timestamp" : "2017-05-29T22:28:06.246Z",
       "source" : "/Users/tsg/src/github.com/elastic/beats/filebeat/module/nginx/access/test/test.log",
       "fileset" : {
@@ -102,6 +105,9 @@
         "version" : "6.0.0-alpha2"
       },
       "prospector" : {
+        "type" : "log"
+      },
+      "" : {
         "type" : "log"
       },
       "read_timestamp" : "2017-05-29T22:28:06.246Z",
@@ -165,6 +171,9 @@
       "prospector" : {
         "type" : "log"
       },
+      "input" : {
+        "type" : "log"
+      },
       "read_timestamp" : "2017-05-29T22:28:06.246Z",
       "source" : "/Users/tsg/src/github.com/elastic/beats/filebeat/module/nginx/access/test/test.log",
       "fileset" : {
@@ -216,6 +225,9 @@
         "version" : "6.0.0-alpha2"
       },
       "prospector" : {
+        "type" : "log"
+      },
+      "input" : {
         "type" : "log"
       },
       "read_timestamp" : "2017-05-29T22:28:06.245Z",
@@ -278,6 +290,9 @@
       "prospector" : {
         "type" : "log"
       },
+      "input" : {
+        "type" : "log"
+      },
       "read_timestamp" : "2017-05-29T22:28:06.246Z",
       "source" : "/Users/tsg/src/github.com/elastic/beats/filebeat/module/nginx/access/test/test.log",
       "fileset" : {
@@ -335,6 +350,9 @@
         "version" : "6.0.0-alpha2"
       },
       "prospector" : {
+        "type" : "log"
+      },
+      "input" : {
         "type" : "log"
       },
       "read_timestamp" : "2017-05-29T22:28:06.246Z",

--- a/filebeat/module/nginx/error/manifest.yml
+++ b/filebeat/module/nginx/error/manifest.yml
@@ -10,4 +10,4 @@ var:
       - c:/programdata/nginx/logs/error.log*
 
 ingest_pipeline: ingest/pipeline.json
-prospector: config/nginx-error.yml
+input: config/nginx-error.yml

--- a/filebeat/module/osquery/result/manifest.yml
+++ b/filebeat/module/osquery/result/manifest.yml
@@ -14,4 +14,4 @@ var:
 
 
 ingest_pipeline: ingest/pipeline.json
-prospector: config/result.yml
+input: config/result.yml

--- a/filebeat/module/osquery/result/test/test.log-expected.json
+++ b/filebeat/module/osquery/result/test/test.log-expected.json
@@ -43,6 +43,9 @@
 	  "prospector": {
 		"type": "log"
 	  },
+	  "input": {
+		"type": "log"
+	  },
 	  "source": "/Users/tsg/src/github.com/elastic/beats/filebeat/module/osquery/result/test/test.log",
 	  "fileset": {
 		"module": "osquery",

--- a/filebeat/module/postgresql/_meta/config.reference.yml
+++ b/filebeat/module/postgresql/_meta/config.reference.yml
@@ -7,6 +7,6 @@
     # Filebeat will choose the paths depending on your OS.
     #var.paths:
 
-    # Prospector configuration (advanced). Any prospector configuration option
+    # Input configuration (advanced). Any input configuration option
     # can be added under this section.
-    #prospector:
+    #input:

--- a/filebeat/module/postgresql/log/manifest.yml
+++ b/filebeat/module/postgresql/log/manifest.yml
@@ -10,4 +10,4 @@ var:
       - "c:/Program Files/PostgreSQL/*/logs/*.log*"
 
 ingest_pipeline: ingest/pipeline.json
-prospector: config/log.yml
+input: config/log.yml

--- a/filebeat/module/postgresql/log/test/postgresql-9.6-debian-with-slowlog.log-expected.json
+++ b/filebeat/module/postgresql/log/test/postgresql-9.6-debian-with-slowlog.log-expected.json
@@ -25,6 +25,9 @@
       "prospector": {
         "type": "log"
       },
+      "input": {
+        "type": "log"
+      },
       "source": "/home/n/go/src/github.com/elastic/beats/filebeat/module/postgresql/log/test/postgresql-9.6-debian.log",
       "message": "2017-07-31 13:36:42.585 CEST [4974] LOG:  database system was shut down at 2017-06-17 16:58:04 CEST",
       "fileset": {
@@ -41,7 +44,7 @@
       1501508202585
     ]
   },
-  
+
   {
     "_index": "filebeat-7.0.0-alpha1-2017.08.01",
     "_type": "doc",
@@ -68,6 +71,9 @@
       "prospector": {
         "type": "log"
       },
+      "input": {
+        "type": "log"
+      },
       "source": "/home/n/go/src/github.com/elastic/beats/filebeat/module/postgresql/log/test/postgresql-9.6-debian.log",
       "message": "2017-07-31 13:36:42.605 CEST [4974] LOG:  MultiXact member wraparound protections are now enabled",
       "fileset": {
@@ -84,7 +90,7 @@
       1501508202605
     ]
   },
-  
+
   {
     "_index": "filebeat-7.0.0-alpha1-2017.08.01",
     "_type": "doc",
@@ -111,6 +117,9 @@
       "prospector": {
         "type": "log"
       },
+      "input": {
+        "type": "log"
+      },
       "source": "/home/n/go/src/github.com/elastic/beats/filebeat/module/postgresql/log/test/postgresql-9.6-debian.log",
       "message": "2017-07-31 13:36:42.615 CEST [4978] LOG:  autovacuum launcher started",
       "fileset": {
@@ -127,7 +136,7 @@
       1501508202615
     ]
   },
-  
+
   {
     "_index": "filebeat-7.0.0-alpha1-2017.08.01",
     "_type": "doc",
@@ -154,6 +163,9 @@
       "prospector": {
         "type": "log"
       },
+      "input": {
+        "type": "log"
+      },
       "source": "/home/n/go/src/github.com/elastic/beats/filebeat/module/postgresql/log/test/postgresql-9.6-debian.log",
       "message": "2017-07-31 13:36:42.616 CEST [4973] LOG:  database system is ready to accept connections",
       "fileset": {
@@ -170,7 +182,7 @@
       1501508202616
     ]
   },
-  
+
   {
     "_index": "filebeat-7.0.0-alpha1-2017.08.01",
     "_type": "doc",
@@ -199,6 +211,9 @@
       "prospector": {
         "type": "log"
       },
+      "input": {
+        "type": "log"
+      },
       "source": "/home/n/go/src/github.com/elastic/beats/filebeat/module/postgresql/log/test/postgresql-9.6-debian.log",
       "fileset": {
         "module": "postgresql",
@@ -215,7 +230,7 @@
       1501508202956
     ]
   },
-  
+
   {
     "_index": "filebeat-7.0.0-alpha1-2017.08.01",
     "_type": "doc",
@@ -245,6 +260,9 @@
       "prospector": {
         "type": "log"
       },
+      "input": {
+        "type": "log"
+      },
       "source": "/home/n/go/src/github.com/elastic/beats/filebeat/module/postgresql/log/test/postgresql-9.6-debian.log",
       "fileset": {
         "module": "postgresql",
@@ -261,7 +279,7 @@
       1501508203557
     ]
   },
-  
+
   {
     "_index": "filebeat-7.0.0-alpha1-2017.08.01",
     "_type": "doc",
@@ -291,6 +309,9 @@
       "prospector": {
         "type": "log"
       },
+      "input": {
+        "type": "log"
+      },
       "source": "/home/n/go/src/github.com/elastic/beats/filebeat/module/postgresql/log/test/postgresql-9.6-debian.log",
       "message": "2017-07-31 13:36:44.104 CEST [4986] postgres@postgres LOG:  duration: 2.895 ms  statement: SELECT d.datname as \"Name\",\n\t       pg_catalog.pg_get_userbyid(d.datdba) as \"Owner\",\n\t       pg_catalog.pg_encoding_to_char(d.encoding) as \"Encoding\",\n\t       d.datcollate as \"Collate\",\n\t       d.datctype as \"Ctype\",\n\t       pg_catalog.array_to_string(d.datacl, E'\\n') AS \"Access privileges\"\n\tFROM pg_catalog.pg_database d\n\tORDER BY 1;",
       "fileset": {
@@ -307,7 +328,7 @@
       1501508204104
     ]
   },
-  
+
   {
     "_index": "filebeat-7.0.0-alpha1-2017.08.01",
     "_type": "doc",
@@ -337,6 +358,9 @@
       "prospector": {
         "type": "log"
       },
+      "input": {
+        "type": "log"
+      },
       "source": "/home/n/go/src/github.com/elastic/beats/filebeat/module/postgresql/log/test/postgresql-9.6-debian.log",
       "fileset": {
         "module": "postgresql",
@@ -353,7 +377,7 @@
       1501508204642
     ]
   },
-  
+
   {
     "_index": "filebeat-7.0.0-alpha1-2017.08.01",
     "_type": "doc",
@@ -382,6 +406,9 @@
       "prospector": {
         "type": "log"
       },
+      "input": {
+        "type": "log"
+      },
       "source": "/home/n/go/src/github.com/elastic/beats/filebeat/module/postgresql/log/test/postgresql-9.6-debian.log",
       "message": "2017-07-31 13:39:16.249 CEST [5407] postgres@users FATAL:  database \"users\" does not exist",
       "fileset": {
@@ -398,7 +425,7 @@
       1501508356249
     ]
   },
-  
+
   {
     "_index": "filebeat-7.0.0-alpha1-2017.08.01",
     "_type": "doc",
@@ -427,6 +454,9 @@
       "prospector": {
         "type": "log"
       },
+      "input": {
+        "type": "log"
+      },
       "source": "/home/n/go/src/github.com/elastic/beats/filebeat/module/postgresql/log/test/postgresql-9.6-debian.log",
       "fileset": {
         "module": "postgresql",
@@ -443,7 +473,7 @@
       1501508357945
     ]
   },
-  
+
   {
     "_index": "filebeat-7.0.0-alpha1-2017.08.01",
     "_type": "doc",
@@ -473,6 +503,9 @@
       "prospector": {
         "type": "log"
       },
+      "input": {
+        "type": "log"
+      },
       "source": "/home/n/go/src/github.com/elastic/beats/filebeat/module/postgresql/log/test/postgresql-9.6-debian.log",
       "message": "2017-07-31 13:39:21.025 CEST [5404] postgres@postgres LOG:  duration: 37.598 ms  statement: SELECT n.nspname as \"Schema\",\n\t  c.relname as \"Name\",\n\t  CASE c.relkind WHEN 'r' THEN 'table' WHEN 'v' THEN 'view' WHEN 'm' THEN 'materialized view' WHEN 'i' THEN 'index' WHEN 'S' THEN 'sequence' WHEN 's' THEN 'special' WHEN 'f' THEN 'foreign table' END as \"Type\",\n\t  pg_catalog.pg_get_userbyid(c.relowner) as \"Owner\"\n\tFROM pg_catalog.pg_class c\n\t     LEFT JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace\n\tWHERE c.relkind IN ('r','')\n\t      AND n.nspname <> 'pg_catalog'\n\t      AND n.nspname <> 'information_schema'\n\t      AND n.nspname !~ '^pg_toast'\n\t  AND pg_catalog.pg_table_is_visible(c.oid)\n\tORDER BY 1,2;",
       "fileset": {
@@ -489,7 +522,7 @@
       1501508361025
     ]
   },
-  
+
   {
     "_index": "filebeat-7.0.0-alpha1-2017.08.01",
     "_type": "doc",
@@ -519,6 +552,9 @@
       "prospector": {
         "type": "log"
       },
+      "input": {
+        "type": "log"
+      },
       "source": "/home/n/go/src/github.com/elastic/beats/filebeat/module/postgresql/log/test/postgresql-9.6-debian.log",
       "message": "2017-07-31 13:39:31.619 CEST [5502] postgres@clients LOG:  duration: 9.482 ms  statement: select * from clients;",
       "fileset": {
@@ -535,7 +571,7 @@
       1501508371619
     ]
   },
-  
+
   {
     "_index": "filebeat-7.0.0-alpha1-2017.08.01",
     "_type": "doc",
@@ -565,6 +601,9 @@
       "prospector": {
         "type": "log"
       },
+      "input": {
+        "type": "log"
+      },
       "source": "/home/n/go/src/github.com/elastic/beats/filebeat/module/postgresql/log/test/postgresql-9.6-debian.log",
       "fileset": {
         "module": "postgresql",
@@ -581,7 +620,7 @@
       1501508380147
     ]
   },
-  
+
   {
     "_index": "filebeat-7.0.0-alpha1-2017.08.01",
     "_type": "doc",
@@ -611,6 +650,9 @@
       "prospector": {
         "type": "log"
       },
+      "input": {
+        "type": "log"
+      },
       "source": "/home/n/go/src/github.com/elastic/beats/filebeat/module/postgresql/log/test/postgresql-9.6-debian.log",
       "message": "2017-07-31 13:40:54.310 CEST [5502] postgres@clients LOG:  duration: 26.082 ms  statement: SELECT n.nspname as \"Schema\",\n\t  c.relname as \"Name\",\n\t  CASE c.relkind WHEN 'r' THEN 'table' WHEN 'v' THEN 'view' WHEN 'm' THEN 'materialized view' WHEN 'i' THEN 'index' WHEN 'S' THEN 'sequence' WHEN 's' THEN 'special' WHEN 'f' THEN 'foreign table' END as \"Type\",\n\t  pg_catalog.pg_get_userbyid(c.relowner) as \"Owner\"\n\tFROM pg_catalog.pg_class c\n\t     LEFT JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace\n\tWHERE c.relkind IN ('r','')\n\t      AND n.nspname <> 'pg_catalog'\n\t      AND n.nspname <> 'information_schema'\n\t      AND n.nspname !~ '^pg_toast'\n\t  AND pg_catalog.pg_table_is_visible(c.oid)\n\tORDER BY 1,2;",
       "fileset": {
@@ -627,7 +669,7 @@
       1501508454310
     ]
   },
-  
+
   {
     "_index": "filebeat-7.0.0-alpha1-2017.08.01",
     "_type": "doc",
@@ -657,6 +699,9 @@
       "prospector": {
         "type": "log"
       },
+      "input": {
+        "type": "log"
+      },
       "source": "/home/n/go/src/github.com/elastic/beats/filebeat/module/postgresql/log/test/postgresql-9.6-debian.log",
       "message": "2017-07-31 13:43:22.645 CEST [5502] postgres@clients LOG:  duration: 36.162 ms  statement: create table cats(name varchar(50) primary key, toy varchar (50) not null, born timestamp not null);",
       "fileset": {
@@ -673,7 +718,7 @@
       1501508602645
     ]
   },
-  
+
   {
     "_index": "filebeat-7.0.0-alpha1-2017.08.01",
     "_type": "doc",
@@ -703,6 +748,9 @@
       "prospector": {
         "type": "log"
       },
+      "input": {
+        "type": "log"
+      },
       "source": "/home/n/go/src/github.com/elastic/beats/filebeat/module/postgresql/log/test/postgresql-9.6-debian.log",
       "fileset": {
         "module": "postgresql",
@@ -719,7 +767,7 @@
       1501508762670
     ]
   },
-  
+
   {
     "_index": "filebeat-7.0.0-alpha1-2017.08.01",
     "_type": "doc",
@@ -749,6 +797,9 @@
       "prospector": {
         "type": "log"
       },
+      "input": {
+        "type": "log"
+      },
       "source": "/home/n/go/src/github.com/elastic/beats/filebeat/module/postgresql/log/test/postgresql-9.6-debian.log",
       "message": "2017-07-31 13:46:23.016 CEST [5502] postgres@clients LOG:  duration: 5.156 ms  statement: insert into cats(name, toy, born) values('frida', 'horse', now());",
       "fileset": {
@@ -765,7 +816,7 @@
       1501508783016
     ]
   },
-  
+
   {
     "_index": "filebeat-7.0.0-alpha1-2017.08.01",
     "_type": "doc",
@@ -793,6 +844,9 @@
         "version": "7.0.0-alpha1"
       },
       "prospector": {
+        "type": "log"
+      },
+      "input": {
         "type": "log"
       },
       "source": "/home/n/go/src/github.com/elastic/beats/filebeat/module/postgresql/log/test/postgresql-9.6-debian.log",

--- a/filebeat/module/system/_meta/config.reference.yml
+++ b/filebeat/module/system/_meta/config.reference.yml
@@ -10,9 +10,9 @@
     # Convert the timestamp to UTC. Requires Elasticsearch >= 6.1.
     #var.convert_timezone: false
 
-    # Prospector configuration (advanced). Any prospector configuration option
+    # Input configuration (advanced). Any input configuration option
     # can be added under this section.
-    #prospector:
+    #input:
 
   # Authorization logs
   #auth:
@@ -25,6 +25,6 @@
     # Convert the timestamp to UTC. Requires Elasticsearch >= 6.1.
     #var.convert_timezone: false
 
-    # Prospector configuration (advanced). Any prospector configuration option
+    # Input configuration (advanced). Any input configuration option
     # can be added under this section.
-    #prospector:
+    #input:

--- a/filebeat/module/system/auth/manifest.yml
+++ b/filebeat/module/system/auth/manifest.yml
@@ -19,4 +19,4 @@ var:
       value: false
 
 ingest_pipeline: ingest/pipeline.json
-prospector: config/auth.yml
+input: config/auth.yml

--- a/filebeat/module/system/auth/test/test.log-expected.json
+++ b/filebeat/module/system/auth/test/test.log-expected.json
@@ -29,6 +29,9 @@
             "prospector": {
                 "type": "log"
             },
+            "input": {
+                "type": "log"
+            },
             "source": "/Users/tsg/src/github.com/elastic/beats/filebeat/module/system/auth/test/test.log",
             "fileset": {
                 "module": "system",
@@ -63,6 +66,9 @@
                 "version": "6.0.0-alpha1"
             },
             "prospector": {
+                "type": "log"
+            },
+            "input": {
                 "type": "log"
             },
             "source": "/Users/tsg/src/github.com/elastic/beats/filebeat/module/system/auth/test/test.log",
@@ -100,6 +106,9 @@
             "prospector": {
                 "type": "log"
             },
+            "input": {
+                "type": "log"
+            },
             "source": "/Users/tsg/src/github.com/elastic/beats/filebeat/module/system/auth/test/test.log",
             "fileset": {
                 "module": "system",
@@ -131,6 +140,9 @@
                 "version": "6.0.0-alpha1"
             },
             "prospector": {
+                "type": "log"
+            },
+            "input": {
                 "type": "log"
             },
             "source": "/Users/tsg/src/github.com/elastic/beats/filebeat/module/system/auth/test/test.log",
@@ -170,6 +182,9 @@
             "prospector": {
                 "type": "log"
             },
+            "input": {
+                "type": "log"
+            },
             "source": "/Users/tsg/src/github.com/elastic/beats/filebeat/module/system/auth/test/test.log",
             "fileset": {
                 "module": "system",
@@ -202,6 +217,9 @@
                 "version": "6.0.0-alpha1"
             },
             "prospector": {
+                "type": "log"
+            },
+            "input": {
                 "type": "log"
             },
             "source": "/Users/tsg/src/github.com/elastic/beats/filebeat/module/system/auth/test/test.log",
@@ -241,6 +259,9 @@
             "prospector": {
                 "type": "log"
             },
+            "input": {
+                "type": "log"
+            },
             "source": "/Users/tsg/src/github.com/elastic/beats/filebeat/module/system/auth/test/test.log",
             "fileset": {
                 "module": "system",
@@ -277,6 +298,9 @@
                 "version": "6.0.0-alpha1"
             },
             "prospector": {
+                "type": "log"
+            },
+            "input": {
                 "type": "log"
             },
             "source": "/Users/tsg/src/github.com/elastic/beats/filebeat/module/system/auth/test/test.log",
@@ -326,6 +350,9 @@
             "prospector": {
                 "type": "log"
             },
+            "input": {
+                "type": "log"
+            },
             "source": "/Users/tsg/src/github.com/elastic/beats/filebeat/module/system/auth/test/test.log",
             "fileset": {
                 "module": "system",
@@ -360,6 +387,9 @@
                 "version": "6.0.0-alpha1"
             },
             "prospector": {
+                "type": "log"
+            },
+            "input": {
                 "type": "log"
             },
             "source": "/Users/tsg/src/github.com/elastic/beats/filebeat/module/system/auth/test/test.log",

--- a/filebeat/module/system/syslog/manifest.yml
+++ b/filebeat/module/system/syslog/manifest.yml
@@ -17,4 +17,4 @@ var:
       value: false
 
 ingest_pipeline: ingest/pipeline.json
-prospector: config/syslog.yml
+input: config/syslog.yml

--- a/filebeat/module/system/syslog/test/darwin-syslog-sample.log-expected.json
+++ b/filebeat/module/system/syslog/test/darwin-syslog-sample.log-expected.json
@@ -24,6 +24,9 @@
             "prospector": {
                 "type": "log"
             },
+            "input": {
+                "type": "log"
+            },
             "source": "module/system/syslog/test/darwin-syslog-sample.log",
             "fields": {
                 "source_type": "system-syslog"
@@ -55,6 +58,9 @@
             "prospector": {
                 "type": "log"
             },
+            "input": {
+                "type": "log"
+            },
             "source": "module/system/syslog/test/darwin-syslog-sample.log",
             "fields": {
                 "source_type": "system-syslog"
@@ -81,6 +87,9 @@
                 "version": "6.0.0-alpha1"
             },
             "prospector": {
+                "type": "log"
+            },
+            "input": {
                 "type": "log"
             },
             "source": "/Users/tsg/src/github.com/elastic/beats/filebeat/module/system/syslog/test/darwin-syslog-sample.log",

--- a/filebeat/module/traefik/_meta/config.reference.yml
+++ b/filebeat/module/traefik/_meta/config.reference.yml
@@ -7,6 +7,6 @@
     # Filebeat will choose the paths depending on your OS.
     #var.paths:
 
-    # Prospector configuration (advanced). Any prospector configuration option
+    # Input configuration (advanced). Any input configuration option
     # can be added under this section.
-    #prospector:
+    #input:

--- a/filebeat/module/traefik/access/manifest.yml
+++ b/filebeat/module/traefik/access/manifest.yml
@@ -10,7 +10,7 @@ var:
       - c:/programdata/traefik/logs/*access.log*
 
 ingest_pipeline: ingest/pipeline.json
-prospector: config/traefik-access.yml
+input: config/traefik-access.yml
 
 requires.processors:
 - name: user_agent

--- a/filebeat/module/traefik/access/tests/test.log-expected.json
+++ b/filebeat/module/traefik/access/tests/test.log-expected.json
@@ -47,6 +47,9 @@
             "prospector": {
                 "type": "log"
             },
+            "input": {
+                "type": "log"
+            },
             "read_timestamp": "2017-10-09T18:56:25.032Z",
             "source": "/var/log/traefik/access.log",
             "fileset": {
@@ -101,6 +104,9 @@
                 "version": "7.0.0-alpha1"
             },
             "prospector": {
+                "type": "log"
+            },
+            "input": {
                 "type": "log"
             },
             "read_timestamp": "2017-10-09T18:56:25.031Z",


### PR DESCRIPTION
Migrate: modules yaml and their json expected file to use the input and `input.type` field
require: #6078