### PR TITLE
Ignore kibana directory in libbeat

### DIFF
--- a/libbeat/.gitignore
+++ b/libbeat/.gitignore
@@ -28,3 +28,4 @@ _testmain.go
 /libbeat.yml
 /libbeat.reference.yml
 /docs/fields.asciidoc
+_meta/kibana


### PR DESCRIPTION
The index pattern are also generated for libbeat but should be ignored. A recent change removed the pattern from version control but did not add it to gitignore.