### PR TITLE
Fix metrics of elasticsearch

### DIFF
--- a/libbeat/outputs/elasticsearch/client.go
+++ b/libbeat/outputs/elasticsearch/client.go
@@ -201,6 +201,7 @@ func NewClient(
 
 		compressionLevel: compression,
 		proxyURL:         s.Proxy,
+		observer:         s.Observer,
 	}
 
 	client.Connection.onConnectCallback = func() error {


### PR DESCRIPTION
It turns out that the stats observer was not passed to the new Elasticseach client. Now it is fixed.

Closes #6135 