### PR TITLE
[DOCS] Upgrade branch to 6.2

### DIFF
--- a/libbeat/docs/version.asciidoc
+++ b/libbeat/docs/version.asciidoc
@@ -1,5 +1,5 @@
 :stack-version: 6.2.0
-:doc-branch: master
+:doc-branch: 6.2
 :go-version: 1.9.2
 :release-state: unreleased
 :python: 2.7.9

--- a/libbeat/docs/version.asciidoc
+++ b/libbeat/docs/version.asciidoc
@@ -5,4 +5,4 @@
 :python: 2.7.9
 :docker: 1.12
 :docker-compose: 1.11
-:branch: 6.x
+:branch: 6.2


### PR DESCRIPTION
This PR changes the "branch" attribute from 6.x to 6.2. 