### PR TITLE
Backport of #6106: Fix metrics of elasticsearch

### DIFF
--- a/libbeat/outputs/elasticsearch/client.go
+++ b/libbeat/outputs/elasticsearch/client.go
@@ -201,6 +201,7 @@ func NewClient(
 
 		compressionLevel: compression,
 		proxyURL:         s.Proxy,
+		observer:         s.Observer,
 	}
 
 	client.Connection.onConnectCallback = func() error {


### PR DESCRIPTION
libbeat: initialize stats observer in NewClient of ES

(cherry picked from commit d8bd52d95c2f5b394b379fd7bfa04521997fc62e)