### PR TITLE
Fix panic due to unaligned atomic uint64 access

### DIFF
--- a/filebeat/input/log/config.go
+++ b/filebeat/input/log/config.go
@@ -67,7 +67,7 @@ type config struct {
 	Paths          []string        `config:"paths"`
 	ScanFrequency  time.Duration   `config:"scan_frequency" validate:"min=0,nonzero"`
 	CleanRemoved   bool            `config:"clean_removed"`
-	HarvesterLimit uint64          `config:"harvester_limit" validate:"min=0"`
+	HarvesterLimit uint32          `config:"harvester_limit" validate:"min=0"`
 	Symlinks       bool            `config:"symlinks"`
 	TailFiles      bool            `config:"tail_files"`
 	RecursiveGlob  bool            `config:"recursive_glob.enabled"`

--- a/filebeat/input/log/prospector.go
+++ b/filebeat/input/log/prospector.go
@@ -46,7 +46,7 @@ type Prospector struct {
 	outlet        channel.Outleter
 	stateOutlet   channel.Outleter
 	done          chan struct{}
-	numHarvesters atomic.Uint64
+	numHarvesters atomic.Uint32
 }
 
 // NewProspector instantiates a new Log


### PR DESCRIPTION
There was a bug impacting 32-bit platforms where an atomic.Uint64
was not aligned to a 64 bit boundary, causing the log prospector
to panic on startup.

Instead of reordering the field to the start of the struct to guarantee
alignment, which is brittle, this patch just changes the harvester
limit to be a 32-bit unsigned integer.

Closes #6145 