### PR TITLE
Cherry-pick #6138 to 6.2: Auditbeat GA cleanup

### DIFF
--- a/auditbeat/docs/breaking.asciidoc
+++ b/auditbeat/docs/breaking.asciidoc
@@ -1,0 +1,126 @@
+[[auditbeat-breaking-changes]]
+== Breaking changes in 6.2
+
+As a general rule, we strive to keep backwards compatibility between minor
+versions (e.g.  6.x to 6.y) so you can upgrade without any configuration file
+changes, but there are breaking changes between the earlier beta releases and
+the 6.2 GA release.
+
+There are changes that affect both the configuration and the event schema.
+
+[float]
+=== Configuration Changes
+
+The audit module has been renamed and is now two separate modules: the
+<<auditbeat-module-auditd,auditd module>> and the
+<<auditbeat-module-file_integrity,file_integrity module>>. You must update your
+configuration to use these modules.
+
+The `kernel` metricset has become the <<auditbeat-module-auditd,auditd module>>.
+
+.Old Config
+[source,yaml]
+----
+- module: audit
+  metricsets: ["kernel"]
+  kernel.resolve_ids: true
+  kernel.failure_mode: silent
+  kernel.backlog_limit: 8196
+  kernel.rate_limit: 0
+  kernel.include_raw_message: false
+  kernel.include_warnings: false
+  kernel.audit_rules: |
+    # Rules
+----
+
+.New Config
+[source,yaml]
+----
+- module: auditd
+  resolve_ids: true
+  failure_mode: silent
+  backlog_limit: 8196
+  rate_limit: 0
+  include_raw_message: false
+  include_warnings: false
+  audit_rules: |
+    # Rules
+----
+
+The `file` metricset has become the
+<<auditbeat-module-file_integrity,file_integrity module>>.
+
+.Old Config
+[source,yaml]
+----
+- module: audit
+  metricsets: [file]
+  file.paths:
+  - /bin
+  - /usr/bin
+  - /sbin
+  - /usr/sbin
+  - /etc
+  file.scan_at_start: true
+  file.scan_rate_per_sec: 50 MiB
+  file.max_file_size: 100 MiB
+  file.hash_types: [sha1]
+----
+
+.New Config
+[source,yaml]
+----
+- module: file_integrity
+  paths:
+  - /bin
+  - /usr/bin
+  - /sbin
+  - /usr/sbin
+  - /etc
+  scan_at_start: true
+  scan_rate_per_sec: 50 MiB
+  max_file_size: 100 MiB
+  hash_types: [sha1]
+  recursive: false <1>
+----
+<1> `recursive` is a new option in 6.2 and is disabled by default. Set the value
+to true to watch for changes in all sub-directories.
+
+[float]
+=== Event Schema Changes
+
+Most field names were changed in 6.2. We wanted to rename the modules and use
+common field names for similar data types across all the modules. The table
+below provides a summary of the field changes.
+
+In Kibana you need to <<load-kibana-dashboards,import>> the latest dashboards
+that work with the new event format. The new dashboards will not work with data
+produced by older versions of Auditbeat.
+
+.Renamed Fields
+[frame="topbot",options="header"]
+|======================
+|Old Field|New Field
+|`metricset.module`        |`event.module`
+|`metricset.name`          |_Removed_
+|`audit.kernel.action`     |`event.action`
+|`audit.kernel.category`   |`event.category`
+|`audit.kernel.record_type`|`event.type`
+|`audit.kernel.key`        |`tags`
+|`audit.kernel.actor.attrs`|`user`
+|`audit.kernel.actor`      |`auditd.summary.actor`
+|`audit.kernel.thing`      |`auditd.summary.object`
+|`audit.kernel.how`        |`auditd.summary.how`
+|`audit.kernel.socket`     |`auditd.data.socket`, `source`, `destination`
+footnote:[Based on the syscall type either the `source` or `destination` may
+also be populated.]
+|`audit.kernel.data.*`     |`process.*` footnote:[Fields related to a process
+will be moved under the `process` namespace.]
+|`audit.kernel.data.*`     |`file.*` footnote:[Fields related to a file will be
+moved under the `file` namespace.]
+|`audit.kernel.data`       |`auditd.data`
+|`audit.file.action`       |`event.action`
+|`audit.file.hash`         |`hash`
+|`audit.file`              |`file`
+|======================
+

--- a/auditbeat/docs/index.asciidoc
+++ b/auditbeat/docs/index.asciidoc
@@ -19,6 +19,8 @@ include::./getting-started.asciidoc[]
 
 include::../../libbeat/docs/repositories.asciidoc[]
 
+include::./breaking.asciidoc[]
+
 include::./setting-up-running.asciidoc[]
 
 include::./configuring-howto.asciidoc[]

--- a/auditbeat/module/auditd/audit_linux.go
+++ b/auditbeat/module/auditd/audit_linux.go
@@ -11,7 +11,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/monitoring"
 	"github.com/elastic/beats/metricbeat/mb"
@@ -56,8 +55,6 @@ type MetricSet struct {
 
 // New constructs a new MetricSet.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	cfgwarn.Beta("The %v module is a beta feature", moduleName)
-
 	config := defaultConfig
 	if err := base.Module().UnpackConfig(&config); err != nil {
 		return nil, errors.Wrap(err, "failed to unpack the auditd config")
@@ -167,7 +164,7 @@ func (ms *MetricSet) addRules(reporter mb.PushReporterV2) error {
 			// Treat rule add errors as warnings and continue.
 			err = errors.Wrapf(err, "failed to add audit rule '%v'", rule.flags)
 			reporter.Error(err)
-			ms.log.Warnw("Failure adding audit rule", err)
+			ms.log.Warnw("Failure adding audit rule", "error", err)
 			failCount++
 		}
 	}

--- a/auditbeat/module/file_integrity/_meta/kibana/6/dashboard/auditbeat-file-integrity.json
+++ b/auditbeat/module/file_integrity/_meta/kibana/6/dashboard/auditbeat-file-integrity.json
@@ -14,8 +14,8 @@
       },
       "id": "AV0tVcg6g1PYniApZa-v",
       "type": "visualization",
-      "updated_at": "2018-01-16T23:26:19.186Z",
-      "version": 3
+      "updated_at": "2018-01-22T15:54:25.278Z",
+      "version": 6
     },
     {
       "attributes": {
@@ -31,8 +31,8 @@
       },
       "id": "AV0tV05vg1PYniApZbA2",
       "type": "visualization",
-      "updated_at": "2018-01-16T23:26:32.206Z",
-      "version": 3
+      "updated_at": "2018-01-22T15:54:25.278Z",
+      "version": 6
     },
     {
       "attributes": {
@@ -48,8 +48,8 @@
       },
       "id": "AV0tWL-Yg1PYniApZbCs",
       "type": "visualization",
-      "updated_at": "2018-01-16T23:27:54.841Z",
-      "version": 3
+      "updated_at": "2018-01-22T15:54:25.278Z",
+      "version": 6
     },
     {
       "attributes": {
@@ -65,8 +65,8 @@
       },
       "id": "AV0tWSdXg1PYniApZbDU",
       "type": "visualization",
-      "updated_at": "2018-01-16T23:27:45.309Z",
-      "version": 3
+      "updated_at": "2018-01-22T15:54:25.278Z",
+      "version": 6
     },
     {
       "attributes": {
@@ -82,25 +82,25 @@
       },
       "id": "AV0tW0djg1PYniApZbGL",
       "type": "visualization",
-      "updated_at": "2018-01-16T23:28:06.060Z",
-      "version": 3
+      "updated_at": "2018-01-22T15:54:25.278Z",
+      "version": 6
     },
     {
       "attributes": {
         "description": "",
         "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\n  \"index\": \"auditbeat-*\",\n  \"query\": {\n    \"query\": \"file.mode:/0..[2367]/\",\n    \"language\": \"lucene\"\n  },\n  \"filter\": []\n}"
+          "searchSourceJSON": "{\"index\":\"auditbeat-*\",\"query\":{\"query\":\"file.mode:/0..[2367]/ NOT file.type:symlink\",\"language\":\"lucene\"},\"filter\":[]}"
         },
         "savedSearchId": "a380a060-cb44-11e7-9835-2f31fe08873b",
         "title": "World Writable File Count [Auditbeat File Integrity]",
-        "uiStateJSON": "{\n  \"vis\": {\n    \"defaultColors\": {\n      \"0 - 100\": \"rgb(0,104,55)\"\n    }\n  }\n}",
+        "uiStateJSON": "{\"vis\":{\"defaultColors\":{\"0 - 100\":\"rgb(0,104,55)\"}}}",
         "version": 1,
-        "visState": "{\n  \"title\": \"World Writable File Count [Auditbeat File Integrity]\",\n  \"type\": \"metric\",\n  \"params\": {\n    \"addTooltip\": true,\n    \"addLegend\": false,\n    \"type\": \"gauge\",\n    \"gauge\": {\n      \"verticalSplit\": false,\n      \"autoExtend\": false,\n      \"percentageMode\": false,\n      \"gaugeType\": \"Metric\",\n      \"gaugeStyle\": \"Full\",\n      \"backStyle\": \"Full\",\n      \"orientation\": \"vertical\",\n      \"colorSchema\": \"Green to Red\",\n      \"gaugeColorMode\": \"None\",\n      \"useRange\": false,\n      \"colorsRange\": [\n        {\n          \"from\": 0,\n          \"to\": 100\n        }\n      ],\n      \"invertColors\": false,\n      \"labels\": {\n        \"show\": false,\n        \"color\": \"black\"\n      },\n      \"scale\": {\n        \"show\": false,\n        \"labels\": false,\n        \"color\": \"#333\",\n        \"width\": 2\n      },\n      \"type\": \"simple\",\n      \"style\": {\n        \"fontSize\": \"23\",\n        \"bgFill\": \"#000\",\n        \"bgColor\": false,\n        \"labelColor\": false,\n        \"subText\": \"\"\n      }\n    }\n  },\n  \"aggs\": [\n    {\n      \"id\": \"1\",\n      \"enabled\": true,\n      \"type\": \"cardinality\",\n      \"schema\": \"metric\",\n      \"params\": {\n        \"field\": \"file.inode\",\n        \"customLabel\": \"World Writable Files\"\n      }\n    }\n  ]\n}"
+        "visState": "{\"title\":\"World Writable File Count [Auditbeat File Integrity]\",\"type\":\"metric\",\"params\":{\"addTooltip\":true,\"addLegend\":false,\"type\":\"metric\",\"metric\":{\"percentageMode\":false,\"colorSchema\":\"Green to Red\",\"useRange\":false,\"colorsRange\":[{\"from\":0,\"to\":100}],\"invertColors\":false,\"labels\":{\"show\":false,\"color\":\"black\"},\"style\":{\"fontSize\":\"23\",\"bgFill\":\"#000\",\"bgColor\":false,\"labelColor\":false,\"subText\":\"\"},\"metricColorMode\":\"None\"}},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"cardinality\",\"schema\":\"metric\",\"params\":{\"field\":\"file.inode\",\"customLabel\":\"World Writable Files\"}}]}"
       },
       "id": "AV0tY6jwg1PYniApZbRY",
       "type": "visualization",
-      "updated_at": "2018-01-16T23:28:16.492Z",
-      "version": 3
+      "updated_at": "2018-01-22T17:48:29.232Z",
+      "version": 7
     },
     {
       "attributes": {
@@ -116,8 +116,8 @@
       },
       "id": "AV0tav8Ag1PYniApZbbK",
       "type": "visualization",
-      "updated_at": "2018-01-16T23:26:57.647Z",
-      "version": 3
+      "updated_at": "2018-01-22T15:54:25.278Z",
+      "version": 6
     },
     {
       "attributes": {
@@ -133,8 +133,8 @@
       },
       "id": "AV0tbcUdg1PYniApZbe1",
       "type": "visualization",
-      "updated_at": "2018-01-16T23:27:09.798Z",
-      "version": 3
+      "updated_at": "2018-01-22T15:54:25.278Z",
+      "version": 6
     },
     {
       "attributes": {
@@ -150,8 +150,8 @@
       },
       "id": "AV0tc_xZg1PYniApZbnL",
       "type": "visualization",
-      "updated_at": "2018-01-16T23:26:44.392Z",
-      "version": 3
+      "updated_at": "2018-01-22T15:54:25.278Z",
+      "version": 6
     },
     {
       "attributes": {
@@ -167,8 +167,8 @@
       },
       "id": "AV0tes4Eg1PYniApZbwV",
       "type": "visualization",
-      "updated_at": "2018-01-16T23:27:31.392Z",
-      "version": 3
+      "updated_at": "2018-01-22T15:54:25.278Z",
+      "version": 6
     },
     {
       "attributes": {
@@ -184,8 +184,8 @@
       },
       "id": "AV0te0TCg1PYniApZbw9",
       "type": "visualization",
-      "updated_at": "2018-01-16T23:27:20.556Z",
-      "version": 3
+      "updated_at": "2018-01-22T15:54:25.278Z",
+      "version": 6
     },
     {
       "attributes": {
@@ -207,8 +207,8 @@
       },
       "id": "a380a060-cb44-11e7-9835-2f31fe08873b",
       "type": "search",
-      "updated_at": "2018-01-16T23:25:56.544Z",
-      "version": 3
+      "updated_at": "2018-01-22T15:54:25.278Z",
+      "version": 6
     },
     {
       "attributes": {
@@ -225,9 +225,9 @@
       },
       "id": "AV0tXkjYg1PYniApZbKP",
       "type": "dashboard",
-      "updated_at": "2018-01-17T00:03:43.718Z",
-      "version": 3
+      "updated_at": "2018-01-22T15:54:25.278Z",
+      "version": 6
     }
   ],
-  "version": "7.0.0-alpha1-SNAPSHOT"
+  "version": "6.1.2"
 }

--- a/auditbeat/module/file_integrity/metricset.go
+++ b/auditbeat/module/file_integrity/metricset.go
@@ -9,7 +9,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/auditbeat/datastore"
-	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/mb/parse"
@@ -60,8 +59,6 @@ type MetricSet struct {
 
 // New returns a new file.MetricSet.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	cfgwarn.Beta("The %v module is an beta feature", moduleName)
-
 	config := defaultConfig
 	if err := base.Module().UnpackConfig(&config); err != nil {
 		return nil, err


### PR DESCRIPTION
Cherry-pick of PR #6138 to 6.2 branch. Original message: 

Fix issues affecting the latest version of Auditbeat.

- Add filter to omit symlinks from "World Writeable File Count" viz.
- Remove cfgwarn.Beta from Auditbeat modules.
- Adding missing structured logging key name to an Auditbeat warning.
- Add breaking changes documentation for Auditbeat 6.2