### PR TITLE
Suppress system load error messages on Windows

### DIFF
--- a/libbeat/cmd/instance/metrics.go
+++ b/libbeat/cmd/instance/metrics.go
@@ -30,8 +30,10 @@ func init() {
 	monitoring.NewFunc(beatMetrics, "info", reportInfo, monitoring.Report)
 
 	systemMetrics := monitoring.Default.NewRegistry("system")
-	monitoring.NewFunc(systemMetrics, "load", reportSystemLoadAverage, monitoring.Report)
 	monitoring.NewFunc(systemMetrics, "cpu", reportSystemCPUUsage, monitoring.Report)
+	if runtime.GOOS != "windows" {
+		monitoring.NewFunc(systemMetrics, "load", reportSystemLoadAverage, monitoring.Report)
+	}
 
 	ephemeralID = uuid.NewV4()
 }


### PR DESCRIPTION
The following error message showed up in the logs of a Beat on Windows, because system load is not implemented:
```
{
 "level": "error",
 "timestamp": "2018-01-23T09:39:50.787-0800",
 "caller": "instance/metrics.go:147",
 "message": "Error retrieving load average: not implemented on windows"
}
```

As it is not supported by Windows, the error message is unnecessary. The metrics is not included in the monitoring events of a Beat on a Windows. So the expected `N/A` can show up in the charts.

I separated the `reportSystemLoadAverage` function of metrics into three parts. One includes the function that registers the reporter function built for all supported platforms. But sending the event is only implemented on Darwin and Linux, thus it's in `metrics_darwin_linux`. For Windows the function does not do anything. 