### PR TITLE
Provide 32-bit Sample Config for Auditbeat

### DIFF
--- a/auditbeat/module/auditd/_meta/config.yml.tpl
+++ b/auditbeat/module/auditd/_meta/config.yml.tpl
@@ -17,17 +17,19 @@
     ## Create file watches (-w) or syscall audits (-a or -A). Uncomment these
     ## examples or add your own rules.
 
+    {{ if eq .goarch "amd64" -}}
     ## If you are on a 64 bit platform, everything should be running
     ## in 64 bit mode. This rule will detect any use of the 32 bit syscalls
     ## because this might be a sign of someone exploiting a hole in the 32
     ## bit API.
     #-a always,exit -F arch=b32 -S all -F key=32bit-abi
 
+    {{ end -}}
     ## Executions.
-    #-a always,exit -F arch=b64 -S execve,execveat -k exec
+    #-a always,exit -F arch=b{{.arch_bits}} -S execve,execveat -k exec
 
     ## External access (warning: these can be expensive to audit).
-    #-a always,exit -F arch=b64 -S accept,bind,connect -F key=external-access
+    #-a always,exit -F arch=b{{.arch_bits}} -S accept,bind,connect -F key=external-access
 
     ## Identity changes.
     #-w /etc/group -p wa -k identity
@@ -35,6 +37,6 @@
     #-w /etc/gshadow -p wa -k identity
 
     ## Unauthorized access attempts.
-    #-a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -k access
-    #-a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -k access
+    #-a always,exit -F arch=b{{.arch_bits}} -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -k access
+    #-a always,exit -F arch=b{{.arch_bits}} -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -k access
 {{ end -}}

--- a/auditbeat/scripts/generate_config.go
+++ b/auditbeat/scripts/generate_config.go
@@ -18,6 +18,7 @@ const defaultGlob = "module/*/_meta/config*.yml.tpl"
 
 var (
 	goos      = flag.String("os", runtime.GOOS, "generate config specific to the specified operating system")
+	goarch    = flag.String("arch", runtime.GOARCH, "generate config specific to the specified CPU architecture")
 	reference = flag.Bool("ref", false, "generate a reference config")
 	concat    = flag.Bool("concat", false, "concatenate all configs instead writing individual files")
 )
@@ -40,9 +41,20 @@ func getConfig(file string) ([]byte, error) {
 		return nil, errors.Wrapf(err, "failed reading %v", file)
 	}
 
+	var archBits string
+	switch *goarch {
+	case "i386":
+		archBits = "32"
+	case "amd64":
+		archBits = "64"
+	default:
+		return nil, fmt.Errorf("supporting only i386 and amd64 architecture")
+	}
 	data := map[string]interface{}{
+		"goarch":    *goarch,
 		"goos":      *goos,
 		"reference": *reference,
+		"arch_bits": archBits,
 	}
 	buf := new(bytes.Buffer)
 	if err = tpl.Execute(buf, data); err != nil {


### PR DESCRIPTION
Generate auditbeat sample rules according to the given CPU architecture: `amd64` or `i386`.

By default, this value is set to the running machine's CPU architecture which is retrieved from `runtime.GOARCH`.

closes #6156 