### PR TITLE
Output template in error message

### DIFF
--- a/libbeat/template/load.go
+++ b/libbeat/template/load.go
@@ -67,7 +67,7 @@ func (l *Loader) Load() error {
 
 		err = l.LoadTemplate(tmpl.GetName(), output)
 		if err != nil {
-			return fmt.Errorf("could not load template: %v\nTemplate is:\n%s", err, output)
+			return fmt.Errorf("could not load template. Elasticsearh returned: %v. Template is: %s", err, output)
 		}
 	} else {
 		logp.Info("Template already exists and will not be overwritten.")

--- a/libbeat/template/load.go
+++ b/libbeat/template/load.go
@@ -67,7 +67,7 @@ func (l *Loader) Load() error {
 
 		err = l.LoadTemplate(tmpl.GetName(), output)
 		if err != nil {
-			return fmt.Errorf("could not load template: %v", err)
+			return fmt.Errorf("could not load template: %v\nTemplate is:\n%s", err, output)
 		}
 	} else {
 		logp.Info("Template already exists and will not be overwritten.")


### PR DESCRIPTION
When there is an error in the generated template, the error message (returned by Elasticsearch server) is not enough to debug,
Having the content of the generated template displayed in the console helps to troubleshoot errors.