### PR TITLE
Cherry-pick #6166 to 6.2 Correctly propagate the error to the user when a `store` fails (#6166)

### DIFF
--- a/libbeat/cmd/keystore.go
+++ b/libbeat/cmd/keystore.go
@@ -196,14 +196,13 @@ func addKey(store keystore.Keystore, keys []string, force, stdin bool) error {
 			return fmt.Errorf("could not read value from the input, error: %s", err)
 		}
 	}
-
-	store.Store(key, keyValue)
-	err = store.Save()
-
-	if err == nil {
-		fmt.Println("Successfully updated the keystore")
+	if err = store.Store(key, keyValue); err != nil {
+		return fmt.Errorf("could not add the key in the keystore, error: %s", err)
+	}
+	if err = store.Save(); err != nil {
+		return fmt.Errorf("fail to save the keystore: %s", err)
 	} else {
-		return fmt.Errorf("fail to add the key to the Keystore: %s", err)
+		fmt.Println("Successfully updated the keystore")
 	}
 	return nil
 }


### PR DESCRIPTION
Backport of #6166

original message:

If storing a key to the keystore fails the error was not send back to
the user and the incomplete keystore was persisted to disk.

(cherry picked from commit 647c5ee2ada2f1e7738cf0b9c8b4be2e73047630)