### PR TITLE
Add missing default Kubernetes cleanup time

### DIFF
--- a/libbeat/autodiscover/providers/kubernetes/config.go
+++ b/libbeat/autodiscover/providers/kubernetes/config.go
@@ -24,7 +24,8 @@ type Config struct {
 
 func defaultConfig() *Config {
 	return &Config{
-		InCluster:  true,
-		SyncPeriod: 1 * time.Second,
+		InCluster:      true,
+		SyncPeriod:     1 * time.Second,
+		CleanupTimeout: 60 * time.Second,
 	}
 }


### PR DESCRIPTION
Without this, Kubernetes autodiscover cleanup goroutine would have an inifnite loop
consuming CPU.

A default cleanup time is necessary to ensure we sleep between cleans.

A bigger refactoring is in the works (https://github.com/elastic/beats/pull/6159), but this should fix master and 6.2