### PR TITLE
Add support for CRI logs format

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -164,6 +164,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Add option to convert the timestamps to UTC in the system module. {pull}5647[5647]
 - Add Logstash module support for main log and the slow log, support the plain text or structured JSON format {pull}5481[5481]
 - Add stream filtering when using `docker` prospector. {pull}6057[6057]
+- Add support for CRI logs format. {issue}5630[5630]
 
 *Heartbeat*
 

--- a/filebeat/harvester/reader/docker_json.go
+++ b/filebeat/harvester/reader/docker_json.go
@@ -8,6 +8,7 @@ import (
 	"github.com/elastic/beats/libbeat/common"
 
 	"github.com/pkg/errors"
+	"strings"
 )
 
 // DockerJSON processor renames a given field
@@ -23,12 +24,67 @@ type dockerLog struct {
 	Stream    string `json:"stream"`
 }
 
+type crioLog struct {
+	Timestamp time.Time
+	Stream    string
+	Log       []byte
+}
+
 // NewDockerJSON creates a new reader renaming a field
 func NewDockerJSON(r Reader, stream string) *DockerJSON {
 	return &DockerJSON{
 		stream: stream,
 		reader: r,
 	}
+}
+
+// parseCRILog parses logs in CRI log format.
+// CRI log format example :
+// 2017-09-12T22:32:21.212861448Z stdout 2017-09-12 22:32:21.212 [INFO][88] table.go 710: Invalidating dataplane cache
+func parseCRILog(b []byte, msg *crioLog, message Message) (Message, error) {
+	log := string(b)
+	ts, err := time.Parse(time.RFC3339, strings.Fields(log)[0])
+	if err != nil {
+		return message, errors.Wrap(err, "parsing CRI timestamp")
+	}
+
+	stream := strings.Fields(log)[1]
+	// Anything after stream.
+	logMessage := strings.Fields(log)[2:]
+	msg.Timestamp = ts
+	msg.Stream = stream
+	msg.Log = []byte(strings.Join(logMessage, " "))
+	message.AddFields(common.MapStr{
+		"stream": msg.Stream,
+	})
+	message.Content = msg.Log
+	message.Ts = ts
+
+	return message, nil
+}
+
+// parseDockerJSONLog parses logs in Docker JSON log format.
+// Docker JSON log format example:
+// {"log":"1:M 09 Nov 13:27:36.276 # User requested shutdown...\n","stream":"stdout"}
+func parseDockerJSONLog(b []byte, msg *dockerLog, message Message) (Message, error) {
+	dec := json.NewDecoder(bytes.NewReader(b))
+	if err := dec.Decode(&msg); err != nil {
+		return message, errors.Wrap(err, "decoding docker JSON")
+	}
+
+	// Parse timestamp
+	ts, err := time.Parse(time.RFC3339, msg.Timestamp)
+	if err != nil {
+		return message, errors.Wrap(err, "parsing docker timestamp")
+	}
+
+	message.AddFields(common.MapStr{
+		"stream": msg.Stream,
+	})
+	message.Content = []byte(msg.Log)
+	message.Ts = ts
+
+	return message, nil
 }
 
 // Next returns the next line.
@@ -39,27 +95,19 @@ func (p *DockerJSON) Next() (Message, error) {
 			return message, err
 		}
 
-		var line dockerLog
-		dec := json.NewDecoder(bytes.NewReader(message.Content))
-		if err = dec.Decode(&line); err != nil {
-			return message, errors.Wrap(err, "decoding docker JSON")
+		var dockerLine dockerLog
+		var crioLine crioLog
+
+		if strings.HasPrefix(string(message.Content), "{") {
+			message, err = parseDockerJSONLog(message.Content, &dockerLine, message)
+		} else {
+			message, err = parseCRILog(message.Content, &crioLine, message)
 		}
 
-		if p.stream != "all" && p.stream != line.Stream {
+		if p.stream != "all" && p.stream != dockerLine.Stream && p.stream != crioLine.Stream {
 			continue
 		}
 
-		// Parse timestamp
-		ts, err := time.Parse(time.RFC3339, line.Timestamp)
-		if err != nil {
-			return message, errors.Wrap(err, "parsing docker timestamp")
-		}
-
-		message.AddFields(common.MapStr{
-			"stream": line.Stream,
-		})
-		message.Content = []byte(line.Log)
-		message.Ts = ts
-		return message, nil
+		return message, err
 	}
 }

--- a/filebeat/harvester/reader/docker_json.go
+++ b/filebeat/harvester/reader/docker_json.go
@@ -51,12 +51,9 @@ func parseCRILog(message Message, msg *crioLog) (Message, error) {
 		return message, errors.Wrap(err, "parsing CRI timestamp")
 	}
 
-	stream := log[1]
-	// Anything after stream.
-	logMessage := log[2:]
 	msg.Timestamp = ts
-	msg.Stream = stream
-	msg.Log = []byte(strings.Join(logMessage, " "))
+	msg.Stream = log[1]
+	msg.Log = []byte(log[2])
 	message.AddFields(common.MapStr{
 		"stream": msg.Stream,
 	})

--- a/filebeat/harvester/reader/docker_json.go
+++ b/filebeat/harvester/reader/docker_json.go
@@ -3,12 +3,12 @@ package reader
 import (
 	"bytes"
 	"encoding/json"
+	"strings"
 	"time"
 
 	"github.com/elastic/beats/libbeat/common"
 
 	"github.com/pkg/errors"
-	"strings"
 )
 
 // DockerJSON processor renames a given field

--- a/filebeat/harvester/reader/docker_json_test.go
+++ b/filebeat/harvester/reader/docker_json_test.go
@@ -32,11 +32,27 @@ func TestDockerJSON(t *testing.T) {
 			stream:        "all",
 			expectedError: true,
 		},
+		// Wrong CRI
+		{
+			input:         [][]byte{[]byte(`{this is not JSON nor CRI`)},
+			stream:        "all",
+			expectedError: true,
+		},
 		// Missing time
 		{
 			input:         [][]byte{[]byte(`{"log":"1:M 09 Nov 13:27:36.276 # User requested shutdown...\n","stream":"stdout"}`)},
 			stream:        "all",
 			expectedError: true,
+		},
+		// CRI log
+		{
+			input:  [][]byte{[]byte(`2017-09-12T22:32:21.212861448Z stdout 2017-09-12 22:32:21.212 [INFO][88] table.go 710: Invalidating dataplane cache`)},
+			stream: "all",
+			expectedMessage: Message{
+				Content: []byte("2017-09-12 22:32:21.212 [INFO][88] table.go 710: Invalidating dataplane cache"),
+				Fields:  common.MapStr{"stream": "stdout"},
+				Ts:      time.Date(2017, 9, 12, 22, 32, 21, 212861448, time.UTC),
+			},
 		},
 		// Filtering stream
 		{
@@ -50,6 +66,20 @@ func TestDockerJSON(t *testing.T) {
 				Content: []byte("unfiltered\n"),
 				Fields:  common.MapStr{"stream": "stderr"},
 				Ts:      time.Date(2017, 11, 9, 13, 27, 36, 277747246, time.UTC),
+			},
+		},
+		// Filtering stream
+		{
+			input: [][]byte{
+				[]byte(`2017-10-12T13:32:21.232861448Z stdout 2017-10-12 13:32:21.212 [INFO][88] table.go 710: Invalidating dataplane cache`),
+				[]byte(`2017-11-12T23:32:21.212771448Z stderr 2017-11-12 23:32:21.212 [ERROR][77] table.go 111: error`),
+				[]byte(`2017-12-12T10:32:21.212864448Z stdout 2017-12-12 10:32:21.212 [WARN][88] table.go 222: Warn`),
+			},
+			stream: "stderr",
+			expectedMessage: Message{
+				Content: []byte("2017-11-12 23:32:21.212 [ERROR][77] table.go 111: error"),
+				Fields:  common.MapStr{"stream": "stderr"},
+				Ts:      time.Date(2017, 11, 12, 23, 32, 21, 212771448, time.UTC),
 			},
 		},
 	}

--- a/filebeat/harvester/reader/docker_json_test.go
+++ b/filebeat/harvester/reader/docker_json_test.go
@@ -34,6 +34,12 @@ func TestDockerJSON(t *testing.T) {
 		},
 		// Wrong CRI
 		{
+			input:         [][]byte{[]byte(`2017-09-12T22:32:21.212861448Z stdout`)},
+			stream:        "all",
+			expectedError: true,
+		},
+		// Wrong CRI
+		{
 			input:         [][]byte{[]byte(`{this is not JSON nor CRI`)},
 			stream:        "all",
 			expectedError: true,


### PR DESCRIPTION
Adds support for CRI logs format, also created tests for specific CRI logs.
Autodiscovery by looking at first char and it will invoke CRI or Docker log parser depending on it.
Solution for #5630