### PR TITLE
Add script for promoting doc branch and version

### DIFF
--- a/dev-tools/promote_docs
+++ b/dev-tools/promote_docs
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+import argparse
+from subprocess import check_call
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Used to promote doc version and branch. Doesn't commit changes.")
+    parser.add_argument("version",
+                        help="The new docs version")
+    parser.add_argument("branch",
+                        help="The new docs branch")
+    args = parser.parse_args()
+    version = args.version
+    branch = args.branch
+
+    # make sure we have no dirty files in this branch (might throw off `make update`)
+    check_call("git clean -dfx", shell=True)
+
+    # edit the file
+    with open("libbeat/docs/version.asciidoc", "r") as f:
+        lines = f.readlines()
+    for i, line in enumerate(lines):
+        if line.startswith(":stack-version:"):
+            lines[i] = ":stack-version: {}\n".format(version)
+        if line.startswith(":branch:"):
+          lines[i] = ":branch: {}\n".format(branch)
+        if line.startswith(":doc-branch:"):
+          lines[i] = ":doc-branch: {}\n".format(branch)
+    with open("libbeat/docs/version.asciidoc", "w") as f:
+        f.writelines(lines)
+
+    check_call("make update", shell=True)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
We could also have this script set the release state, but typically we bump the version and branch before we set the release state.

@tsg Just made some simple changes to modify your script to work here. Not sure if we want this script to do all the same stuff. I got some errors when I ran this, but they were the same errors I saw for your set_docs_version script, so I dunno if they are an issue.