### PR TITLE
carry the 'worker' default from load balancing

### DIFF
--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -125,6 +125,8 @@ The number of workers per configured host publishing events to Elasticsearch. Th
 is best used with load balancing mode enabled. Example: If you have 2 hosts and
 3 workers, in total 6 workers are started (3 for each host).
 
+The default value is 1.
+
 ===== `username`
 
 The basic authentication username for connecting to Elasticsearch.


### PR DESCRIPTION
This default was missing; it's [listed on the load balancing page as having a default of 1.](https://www.elastic.co/guide/en/beats/filebeat/current/load-balancing.html)

cc @ruflin, redo PR of #6168 against master.