### PR TITLE
Fix metricbeat test util RunPushMetricSetV2

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -74,6 +74,8 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Fixed an issue where the proctitle value was being truncated.
 - Fixed an issue where values were incorrectly interpretted as hex data.
 - Fixed parsing of the `key` value when multiple keys are present.
+- Fix possible resource leak if file_integrity module is used with config
+  reloading on Windows or Linux. {pull}6198[6198]
 
 *Filebeat*
 


### PR DESCRIPTION
A test case could become deadlocked waiting to write to a channel. This would happen if the metricset under test attempted to publish events after the event consumer was stopped. Now when the metricset publishes to the stopped Reporter it will return false just as the real Reporter does in Metricbeat.

I also identified a resource leak while stress testing Auditbeat on Windows. The file_integrity module's fsnotify reader was not being closed when the done channel was closed. This would only affect Windows/Linux users that were constantly reloading their file_integrity config with config reloading.