### PR TITLE
Catch and log panics

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -146,6 +146,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Add the abilility for the add_docker_metadata process to enrich based on process ID. {pull}6100[6100]
 - The `add_docker_metadata` and `add_kubernetes_metadata` processors are now GA, instead of Beta. {pull}6105[6105]
 - The node name can be discovered automatically by machine-id matching when beat deployed outside kubernetes cluster. {pull}6146[6146]
+- Panics will be written to the logger before exiting. {pull}6199[6199]
 
 *Auditbeat*
 

--- a/libbeat/logp/core_test.go
+++ b/libbeat/logp/core_test.go
@@ -148,7 +148,7 @@ func TestLoggerLevel(t *testing.T) {
 }
 
 func TestRecover(t *testing.T) {
-	const recoveryExplanation = "Something went wrong."
+	const recoveryExplanation = "Something went wrong"
 	const cause = "unexpected condition"
 
 	DevelopmentSetup(ToObserverOutput())
@@ -160,8 +160,9 @@ func TestRecover(t *testing.T) {
 			assert.Equal(t, zap.ErrorLevel, log.Level)
 			assert.Equal(t, "logp/core_test.go",
 				strings.Split(log.Caller.TrimmedPath(), ":")[0])
-			assert.Contains(t, log.Message, recoveryExplanation)
-			assert.Contains(t, log.Message, cause)
+			assert.Contains(t, log.Message, recoveryExplanation+
+				". Recovering, but please report this.")
+			assert.Contains(t, log.ContextMap(), "panic")
 		}
 	}()
 

--- a/libbeat/logp/global.go
+++ b/libbeat/logp/global.go
@@ -83,8 +83,8 @@ func WTF(format string, v ...interface{}) {
 // Recover stops a panicking goroutine and logs an Error.
 func Recover(msg string) {
 	if r := recover(); r != nil {
-		msg := fmt.Sprintf("%s. Recovering, but please report this: %s.", msg, r)
+		msg := fmt.Sprintf("%s. Recovering, but please report this.", msg)
 		globalLogger().WithOptions(zap.AddCallerSkip(2)).
-			Error(msg, zap.Stack("stack"))
+			Error(msg, zap.Any("panic", r), zap.Stack("stack"))
 	}
 }

--- a/libbeat/logp/logger.go
+++ b/libbeat/logp/logger.go
@@ -51,6 +51,11 @@ func (l *Logger) Error(args ...interface{}) {
 	l.sugar.Error(args...)
 }
 
+// Fatal uses fmt.Sprint to construct and log a message, then calls os.Exit(1).
+func (l *Logger) Fatal(args ...interface{}) {
+	l.sugar.Fatal(args...)
+}
+
 // Panic uses fmt.Sprint to construct and log a message, then panics.
 func (l *Logger) Panic(args ...interface{}) {
 	l.sugar.Panic(args...)
@@ -82,6 +87,11 @@ func (l *Logger) Warnf(format string, args ...interface{}) {
 // Errorf uses fmt.Sprintf to log a templated message.
 func (l *Logger) Errorf(format string, args ...interface{}) {
 	l.sugar.Errorf(format, args...)
+}
+
+// Fatalf uses fmt.Sprintf to log a templated message, then calls os.Exit(1).
+func (l *Logger) Fatalf(format string, args ...interface{}) {
+	l.sugar.Fatalf(format, args...)
 }
 
 // Panicf uses fmt.Sprintf to log a templated message, then panics.
@@ -127,6 +137,15 @@ func (l *Logger) Warnw(msg string, keysAndValues ...interface{}) {
 // specify a type you can pass a Field such as logp.Stringer.
 func (l *Logger) Errorw(msg string, keysAndValues ...interface{}) {
 	l.sugar.Errorw(msg, keysAndValues...)
+}
+
+// Fatalw logs a message with some additional context, then calls os.Exit(1).
+// The additional context is added in the form of key-value pairs. The optimal
+// way to write the value to the log message will be inferred by the value's
+// type. To explicitly specify a type you can pass a Field such as
+// logp.Stringer.
+func (l *Logger) Fatalw(msg string, keysAndValues ...interface{}) {
+	l.sugar.Fatalw(msg, keysAndValues...)
 }
 
 // Panicw logs a message with some additional context, then panics. The


### PR DESCRIPTION
When a Beat exits due to panic the stack trace is written to stderr. For Beats running under service managers where the stdout/err are discarded this makes it problematic to debug (or even detect a panic).

This commit modifies the beat runner to catch (aka `recover`) the panicking main goroutine, log it with logp, flush the logger, then exit. This ensures that the panic is present in the log output.

Under normal circumstances (no error) the final log message from every Beat will be `<beatname> stopped.`. When there is a panic a l`evel=fatal` log line will be written that contains the panic message and a stack trace. For example:

```
{
  "level": "info",
  "timestamp": "2018-01-26T13:36:59.708-0500",
  "caller": "runtime/asm_amd64.s:510",
  "message": "auditbeat stopped."
}
{
  "level": "fatal",
  "timestamp": "2018-01-26T13:36:59.709-0500",
  "logger": "auditbeat",
  "caller": "instance/beat.go:134",
  "message": "Failed due to panic.",
  "panic": "Oh no, big problem!",
  "stack": "github.com/elastic/beats/libbeat/cmd/instance.Run.func1.1
	/Users/akroh/go/src/github.com/elastic/beats/libbeat/cmd/instance/beat.go:134
runtime.call32
	/Users/akroh/.gvm/versions/go1.9.2.darwin.amd64/src/runtime/asm_amd64.s:509
runtime.gopanic
	/Users/akroh/.gvm/versions/go1.9.2.darwin.amd64/src/runtime/panic.go:491
github.com/elastic/beats/libbeat/cmd/instance.(*Beat).launch
	/Users/akroh/go/src/github.com/elastic/beats/libbeat/cmd/instance/beat.go:315
github.com/elastic/beats/libbeat/cmd/instance.Run.func1
	/Users/akroh/go/src/github.com/elastic/beats/libbeat/cmd/instance/beat.go:142
github.com/elastic/beats/libbeat/cmd/instance.Run
	/Users/akroh/go/src/github.com/elastic/beats/libbeat/cmd/instance/beat.go:143
github.com/elastic/beats/libbeat/cmd.genRunCmd.func1
	/Users/akroh/go/src/github.com/elastic/beats/libbeat/cmd/run.go:19
github.com/elastic/beats/vendor/github.com/spf13/cobra.(*Command).execute
	/Users/akroh/go/src/github.com/elastic/beats/vendor/github.com/spf13/cobra/command.go:704
github.com/elastic/beats/vendor/github.com/spf13/cobra.(*Command).ExecuteC
	/Users/akroh/go/src/github.com/elastic/beats/vendor/github.com/spf13/cobra/command.go:785
github.com/elastic/beats/vendor/github.com/spf13/cobra.(*Command).Execute
	/Users/akroh/go/src/github.com/elastic/beats/vendor/github.com/spf13/cobra/command.go:738
main.main
	/Users/akroh/go/src/github.com/elastic/beats/auditbeat/main.go:14
runtime.main
	/Users/akroh/.gvm/versions/go1.9.2.darwin.amd64/src/runtime/proc.go:195"
}
```