### PR TITLE
Fix issue that wrong config panics http metricsets

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -112,6 +112,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Fix kafka OffsetFetch request missing topic and partition parameters. {pull}5880[5880]
 - Change kubernetes.node.cpu.allocatable.cores to float. {pull}6130[6130]
 - Fix system process metricset for kernel processes. {issue}5700[5700]
+- Fix panic in http dependent modules when invalid config was used.
 
 *Packetbeat*
 

--- a/metricbeat/helper/http.go
+++ b/metricbeat/helper/http.go
@@ -25,14 +25,14 @@ type HTTP struct {
 }
 
 // NewHTTP creates new http helper
-func NewHTTP(base mb.BaseMetricSet) *HTTP {
+func NewHTTP(base mb.BaseMetricSet) (*HTTP, error) {
 	config := struct {
 		TLS     *outputs.TLSConfig `config:"ssl"`
 		Timeout time.Duration      `config:"timeout"`
 		Headers map[string]string  `config:"headers"`
 	}{}
 	if err := base.Module().UnpackConfig(&config); err != nil {
-		return nil
+		return nil, err
 	}
 
 	if config.Headers == nil {
@@ -41,7 +41,7 @@ func NewHTTP(base mb.BaseMetricSet) *HTTP {
 
 	tlsConfig, err := outputs.LoadTLSConfig(config.TLS)
 	if err != nil {
-		return nil
+		return nil, err
 	}
 
 	var dialer, tlsDialer transport.Dialer
@@ -49,7 +49,7 @@ func NewHTTP(base mb.BaseMetricSet) *HTTP {
 	dialer = transport.NetDialer(config.Timeout)
 	tlsDialer, err = transport.TLSDialer(dialer, tlsConfig, config.Timeout)
 	if err != nil {
-		return nil
+		return nil, err
 	}
 
 	return &HTTP{
@@ -65,7 +65,7 @@ func NewHTTP(base mb.BaseMetricSet) *HTTP {
 		method:  "GET",
 		uri:     base.HostData().SanitizedURI,
 		body:    nil,
-	}
+	}, nil
 }
 
 // FetchResponse fetches a response for the http metricset.

--- a/metricbeat/helper/prometheus.go
+++ b/metricbeat/helper/prometheus.go
@@ -15,9 +15,12 @@ type Prometheus struct {
 }
 
 // NewPrometheusClient creates new prometheus helper
-func NewPrometheusClient(base mb.BaseMetricSet) *Prometheus {
-	http := NewHTTP(base)
-	return &Prometheus{*http}
+func NewPrometheusClient(base mb.BaseMetricSet) (*Prometheus, error) {
+	http, err := NewHTTP(base)
+	if err != nil {
+		return nil, err
+	}
+	return &Prometheus{*http}, nil
 }
 
 // GetFamilies requests metric families from prometheus endpoint and returns them

--- a/metricbeat/module/apache/status/status.go
+++ b/metricbeat/module/apache/status/status.go
@@ -48,9 +48,13 @@ type MetricSet struct {
 
 // New creates new instance of MetricSet.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
+	http, err := helper.NewHTTP(base)
+	if err != nil {
+		return nil, err
+	}
 	return &MetricSet{
 		base,
-		helper.NewHTTP(base),
+		http,
 	}, nil
 }
 

--- a/metricbeat/module/ceph/cluster_disk/cluster_disk.go
+++ b/metricbeat/module/ceph/cluster_disk/cluster_disk.go
@@ -34,7 +34,10 @@ type MetricSet struct {
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	cfgwarn.Beta("The ceph cluster_disk metricset is beta")
 
-	http := helper.NewHTTP(base)
+	http, err := helper.NewHTTP(base)
+	if err != nil {
+		return nil, err
+	}
 	http.SetHeader("Accept", "application/json")
 
 	return &MetricSet{

--- a/metricbeat/module/ceph/cluster_health/cluster_health.go
+++ b/metricbeat/module/ceph/cluster_health/cluster_health.go
@@ -34,7 +34,10 @@ type MetricSet struct {
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	cfgwarn.Beta("The ceph cluster_health metricset is beta")
 
-	http := helper.NewHTTP(base)
+	http, err := helper.NewHTTP(base)
+	if err != nil {
+		return nil, err
+	}
 	http.SetHeader("Accept", "application/json")
 
 	return &MetricSet{

--- a/metricbeat/module/ceph/cluster_status/cluster_status.go
+++ b/metricbeat/module/ceph/cluster_status/cluster_status.go
@@ -34,7 +34,10 @@ type MetricSet struct {
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	cfgwarn.Beta("The ceph cluster_status metricset is beta")
 
-	http := helper.NewHTTP(base)
+	http, err := helper.NewHTTP(base)
+	if err != nil {
+		return nil, err
+	}
 	http.SetHeader("Accept", "application/json")
 
 	return &MetricSet{

--- a/metricbeat/module/ceph/monitor_health/monitor_health.go
+++ b/metricbeat/module/ceph/monitor_health/monitor_health.go
@@ -34,7 +34,10 @@ type MetricSet struct {
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	cfgwarn.Beta("The ceph monitor_health metricset is beta")
 
-	http := helper.NewHTTP(base)
+	http, err := helper.NewHTTP(base)
+	if err != nil {
+		return nil, err
+	}
 	http.SetHeader("Accept", "application/json")
 
 	return &MetricSet{

--- a/metricbeat/module/ceph/osd_df/osd_df.go
+++ b/metricbeat/module/ceph/osd_df/osd_df.go
@@ -34,7 +34,10 @@ type MetricSet struct {
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	cfgwarn.Beta("The ceph osd_df metricset is experimental")
 
-	http := helper.NewHTTP(base)
+	http, err := helper.NewHTTP(base)
+	if err != nil {
+		return nil, err
+	}
 	http.SetHeader("Accept", "application/json")
 
 	return &MetricSet{

--- a/metricbeat/module/ceph/osd_tree/osd_tree.go
+++ b/metricbeat/module/ceph/osd_tree/osd_tree.go
@@ -34,7 +34,10 @@ type MetricSet struct {
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	cfgwarn.Beta("The ceph osd_tree metricset is beta")
 
-	http := helper.NewHTTP(base)
+	http, err := helper.NewHTTP(base)
+	if err != nil {
+		return nil, err
+	}
 	http.SetHeader("Accept", "application/json")
 
 	return &MetricSet{

--- a/metricbeat/module/ceph/pool_disk/pool_disk.go
+++ b/metricbeat/module/ceph/pool_disk/pool_disk.go
@@ -34,7 +34,10 @@ type MetricSet struct {
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	cfgwarn.Experimental("The ceph pool_disk metricset is experimental")
 
-	http := helper.NewHTTP(base)
+	http, err := helper.NewHTTP(base)
+	if err != nil {
+		return nil, err
+	}
 	http.SetHeader("Accept", "application/json")
 
 	return &MetricSet{

--- a/metricbeat/module/couchbase/bucket/bucket.go
+++ b/metricbeat/module/couchbase/bucket/bucket.go
@@ -38,9 +38,13 @@ type MetricSet struct {
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	cfgwarn.Beta("The couchbase bucket metricset is beta")
 
+	http, err := helper.NewHTTP(base)
+	if err != nil {
+		return nil, err
+	}
 	return &MetricSet{
 		BaseMetricSet: base,
-		http:          helper.NewHTTP(base),
+		http:          http,
 	}, nil
 }
 

--- a/metricbeat/module/couchbase/cluster/cluster.go
+++ b/metricbeat/module/couchbase/cluster/cluster.go
@@ -38,9 +38,13 @@ type MetricSet struct {
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	cfgwarn.Beta("The couchbase cluster metricset is beta")
 
+	http, err := helper.NewHTTP(base)
+	if err != nil {
+		return nil, err
+	}
 	return &MetricSet{
 		BaseMetricSet: base,
-		http:          helper.NewHTTP(base),
+		http:          http,
 	}, nil
 }
 

--- a/metricbeat/module/couchbase/node/node.go
+++ b/metricbeat/module/couchbase/node/node.go
@@ -38,9 +38,13 @@ type MetricSet struct {
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	cfgwarn.Beta("The couchbase node metricset is beta")
 
+	http, err := helper.NewHTTP(base)
+	if err != nil {
+		return nil, err
+	}
 	return &MetricSet{
 		BaseMetricSet: base,
-		http:          helper.NewHTTP(base),
+		http:          http,
 	}, nil
 }
 

--- a/metricbeat/module/dropwizard/collector/collector.go
+++ b/metricbeat/module/dropwizard/collector/collector.go
@@ -56,9 +56,13 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 		return nil, err
 	}
 
+	http, err := helper.NewHTTP(base)
+	if err != nil {
+		return nil, err
+	}
 	return &MetricSet{
 		BaseMetricSet: base,
-		http:          helper.NewHTTP(base),
+		http:          http,
 		namespace:     config.Namespace,
 	}, nil
 }

--- a/metricbeat/module/elasticsearch/node/node.go
+++ b/metricbeat/module/elasticsearch/node/node.go
@@ -35,9 +35,13 @@ type MetricSet struct {
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	cfgwarn.Beta("The elasticsearch node metricset is beta")
 
+	http, err := helper.NewHTTP(base)
+	if err != nil {
+		return nil, err
+	}
 	return &MetricSet{
 		base,
-		helper.NewHTTP(base),
+		http,
 	}, nil
 }
 

--- a/metricbeat/module/elasticsearch/node_stats/node_stats.go
+++ b/metricbeat/module/elasticsearch/node_stats/node_stats.go
@@ -35,9 +35,13 @@ type MetricSet struct {
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	cfgwarn.Beta("The elasticsearch node_stats metricset is beta")
 
+	http, err := helper.NewHTTP(base)
+	if err != nil {
+		return nil, err
+	}
 	return &MetricSet{
 		base,
-		helper.NewHTTP(base),
+		http,
 	}, nil
 }
 

--- a/metricbeat/module/etcd/leader/leader.go
+++ b/metricbeat/module/etcd/leader/leader.go
@@ -38,9 +38,13 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 		return nil, err
 	}
 
+	http, err := helper.NewHTTP(base)
+	if err != nil {
+		return nil, err
+	}
 	return &MetricSet{
 		base,
-		helper.NewHTTP(base),
+		http,
 	}, nil
 }
 

--- a/metricbeat/module/etcd/self/self.go
+++ b/metricbeat/module/etcd/self/self.go
@@ -39,9 +39,13 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 		return nil, err
 	}
 
+	http, err := helper.NewHTTP(base)
+	if err != nil {
+		return nil, err
+	}
 	return &MetricSet{
 		base,
-		helper.NewHTTP(base),
+		http,
 	}, nil
 }
 

--- a/metricbeat/module/etcd/store/store.go
+++ b/metricbeat/module/etcd/store/store.go
@@ -39,9 +39,13 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 		return nil, err
 	}
 
+	http, err := helper.NewHTTP(base)
+	if err != nil {
+		return nil, err
+	}
 	return &MetricSet{
 		base,
-		helper.NewHTTP(base),
+		http,
 	}, nil
 }
 

--- a/metricbeat/module/golang/expvar/expvar.go
+++ b/metricbeat/module/golang/expvar/expvar.go
@@ -54,9 +54,13 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 		return nil, err
 	}
 
+	http, err := helper.NewHTTP(base)
+	if err != nil {
+		return nil, err
+	}
 	return &MetricSet{
 		BaseMetricSet: base,
-		http:          helper.NewHTTP(base),
+		http:          http,
 		namespace:     config.Namespace,
 	}, nil
 }

--- a/metricbeat/module/golang/heap/heap.go
+++ b/metricbeat/module/golang/heap/heap.go
@@ -50,9 +50,13 @@ type MetricSet struct {
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	cfgwarn.Experimental("The golang heap metricset is experimental")
 
+	http, err := helper.NewHTTP(base)
+	if err != nil {
+		return nil, err
+	}
 	return &MetricSet{
 		BaseMetricSet: base,
-		http:          helper.NewHTTP(base),
+		http:          http,
 	}, nil
 }
 

--- a/metricbeat/module/http/json/json.go
+++ b/metricbeat/module/http/json/json.go
@@ -78,7 +78,10 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 		return nil, err
 	}
 
-	http := helper.NewHTTP(base)
+	http, err := helper.NewHTTP(base)
+	if err != nil {
+		return nil, err
+	}
 	http.SetMethod(config.Method)
 	http.SetBody([]byte(config.Body))
 

--- a/metricbeat/module/jolokia/jmx/jmx.go
+++ b/metricbeat/module/jolokia/jmx/jmx.go
@@ -65,7 +65,10 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 		return nil, err
 	}
 
-	http := helper.NewHTTP(base)
+	http, err := helper.NewHTTP(base)
+	if err != nil {
+		return nil, err
+	}
 	http.SetMethod("POST")
 	http.SetBody(body)
 

--- a/metricbeat/module/kibana/status/status.go
+++ b/metricbeat/module/kibana/status/status.go
@@ -33,9 +33,14 @@ type MetricSet struct {
 // New create a new instance of the MetricSet
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	cfgwarn.Beta("The kafka partition metricset is beta")
+
+	http, err := helper.NewHTTP(base)
+	if err != nil {
+		return nil, err
+	}
 	return &MetricSet{
 		base,
-		helper.NewHTTP(base),
+		http,
 	}, nil
 }
 

--- a/metricbeat/module/kubernetes/container/container.go
+++ b/metricbeat/module/kubernetes/container/container.go
@@ -41,9 +41,13 @@ type MetricSet struct {
 // Part of new is also setting up the configuration by processing additional
 // configuration entries if needed.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
+	http, err := helper.NewHTTP(base)
+	if err != nil {
+		return nil, err
+	}
 	return &MetricSet{
 		BaseMetricSet: base,
-		http:          helper.NewHTTP(base),
+		http:          http,
 	}, nil
 }
 

--- a/metricbeat/module/kubernetes/node/node.go
+++ b/metricbeat/module/kubernetes/node/node.go
@@ -40,9 +40,13 @@ type MetricSet struct {
 // Part of new is also setting up the configuration by processing additional
 // configuration entries if needed.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
+	http, err := helper.NewHTTP(base)
+	if err != nil {
+		return nil, err
+	}
 	return &MetricSet{
 		BaseMetricSet: base,
-		http:          helper.NewHTTP(base),
+		http:          http,
 	}, nil
 }
 

--- a/metricbeat/module/kubernetes/pod/pod.go
+++ b/metricbeat/module/kubernetes/pod/pod.go
@@ -41,9 +41,13 @@ type MetricSet struct {
 // Part of new is also setting up the configuration by processing additional
 // configuration entries if needed.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
+	http, err := helper.NewHTTP(base)
+	if err != nil {
+		return nil, err
+	}
 	return &MetricSet{
 		BaseMetricSet: base,
-		http:          helper.NewHTTP(base),
+		http:          http,
 	}, nil
 }
 

--- a/metricbeat/module/kubernetes/state_container/state_container.go
+++ b/metricbeat/module/kubernetes/state_container/state_container.go
@@ -40,9 +40,13 @@ type MetricSet struct {
 // Part of new is also setting up the configuration by processing additional
 // configuration entries if needed.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
+	prometheus, err := helper.NewPrometheusClient(base)
+	if err != nil {
+		return nil, err
+	}
 	return &MetricSet{
 		BaseMetricSet: base,
-		prometheus:    helper.NewPrometheusClient(base),
+		prometheus:    prometheus,
 	}, nil
 }
 

--- a/metricbeat/module/kubernetes/state_deployment/state_deployment.go
+++ b/metricbeat/module/kubernetes/state_deployment/state_deployment.go
@@ -40,9 +40,13 @@ type MetricSet struct {
 // Part of new is also setting up the configuration by processing additional
 // configuration entries if needed.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
+	prometheus, err := helper.NewPrometheusClient(base)
+	if err != nil {
+		return nil, err
+	}
 	return &MetricSet{
 		BaseMetricSet: base,
-		prometheus:    helper.NewPrometheusClient(base),
+		prometheus:    prometheus,
 	}, nil
 }
 

--- a/metricbeat/module/kubernetes/state_node/state_node.go
+++ b/metricbeat/module/kubernetes/state_node/state_node.go
@@ -40,9 +40,13 @@ type MetricSet struct {
 // Part of new is also setting up the configuration by processing additional
 // configuration entries if needed.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
+	prometheus, err := helper.NewPrometheusClient(base)
+	if err != nil {
+		return nil, err
+	}
 	return &MetricSet{
 		BaseMetricSet: base,
-		prometheus:    helper.NewPrometheusClient(base),
+		prometheus:    prometheus,
 	}, nil
 }
 

--- a/metricbeat/module/kubernetes/state_pod/state_pod.go
+++ b/metricbeat/module/kubernetes/state_pod/state_pod.go
@@ -40,9 +40,13 @@ type MetricSet struct {
 // Part of new is also setting up the configuration by processing additional
 // configuration entries if needed.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
+	prometheus, err := helper.NewPrometheusClient(base)
+	if err != nil {
+		return nil, err
+	}
 	return &MetricSet{
 		BaseMetricSet: base,
-		prometheus:    helper.NewPrometheusClient(base),
+		prometheus:    prometheus,
 	}, nil
 }
 

--- a/metricbeat/module/kubernetes/state_replicaset/state_replicaset.go
+++ b/metricbeat/module/kubernetes/state_replicaset/state_replicaset.go
@@ -40,9 +40,13 @@ type MetricSet struct {
 // Part of new is also setting up the configuration by processing additional
 // configuration entries if needed.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
+	prometheus, err := helper.NewPrometheusClient(base)
+	if err != nil {
+		return nil, err
+	}
 	return &MetricSet{
 		BaseMetricSet: base,
-		prometheus:    helper.NewPrometheusClient(base),
+		prometheus:    prometheus,
 	}, nil
 }
 

--- a/metricbeat/module/kubernetes/system/system.go
+++ b/metricbeat/module/kubernetes/system/system.go
@@ -40,9 +40,13 @@ type MetricSet struct {
 // Part of new is also setting up the configuration by processing additional
 // configuration entries if needed.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
+	http, err := helper.NewHTTP(base)
+	if err != nil {
+		return nil, err
+	}
 	return &MetricSet{
 		BaseMetricSet: base,
-		http:          helper.NewHTTP(base),
+		http:          http,
 	}, nil
 }
 

--- a/metricbeat/module/kubernetes/volume/volume.go
+++ b/metricbeat/module/kubernetes/volume/volume.go
@@ -40,9 +40,13 @@ type MetricSet struct {
 // Part of new is also setting up the configuration by processing additional
 // configuration entries if needed.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
+	http, err := helper.NewHTTP(base)
+	if err != nil {
+		return nil, err
+	}
 	return &MetricSet{
 		BaseMetricSet: base,
-		http:          helper.NewHTTP(base),
+		http:          http,
 	}, nil
 }
 

--- a/metricbeat/module/logstash/node/node.go
+++ b/metricbeat/module/logstash/node/node.go
@@ -33,9 +33,13 @@ type MetricSet struct {
 // New create a new instance of the MetricSet
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	cfgwarn.Experimental("The logstash node metricset is experimental")
+	http, err := helper.NewHTTP(base)
+	if err != nil {
+		return nil, err
+	}
 	return &MetricSet{
 		base,
-		helper.NewHTTP(base),
+		http,
 	}, nil
 }
 

--- a/metricbeat/module/logstash/node_stats/node_stats.go
+++ b/metricbeat/module/logstash/node_stats/node_stats.go
@@ -34,9 +34,13 @@ type MetricSet struct {
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	cfgwarn.Experimental("The logstash node_stats metricset is experimental")
 
+	http, err := helper.NewHTTP(base)
+	if err != nil {
+		return nil, err
+	}
 	return &MetricSet{
 		base,
-		helper.NewHTTP(base),
+		http,
 	}, nil
 }
 

--- a/metricbeat/module/nginx/stubstatus/stubstatus.go
+++ b/metricbeat/module/nginx/stubstatus/stubstatus.go
@@ -40,9 +40,13 @@ type MetricSet struct {
 
 // New creates new instance of MetricSet
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
+	http, err := helper.NewHTTP(base)
+	if err != nil {
+		return nil, err
+	}
 	return &MetricSet{
 		BaseMetricSet: base,
-		http:          helper.NewHTTP(base),
+		http:          http,
 	}, nil
 }
 

--- a/metricbeat/module/php_fpm/pool/pool.go
+++ b/metricbeat/module/php_fpm/pool/pool.go
@@ -41,9 +41,13 @@ type MetricSet struct {
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	cfgwarn.Beta("The php_fpm pool metricset is beta")
 
+	http, err := helper.NewHTTP(base)
+	if err != nil {
+		return nil, err
+	}
 	return &MetricSet{
 		base,
-		helper.NewHTTP(base),
+		http,
 	}, nil
 }
 

--- a/metricbeat/module/prometheus/collector/collector.go
+++ b/metricbeat/module/prometheus/collector/collector.go
@@ -46,9 +46,14 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 		return nil, err
 	}
 
+	prometheus, err := helper.NewPrometheusClient(base)
+	if err != nil {
+		return nil, err
+	}
+
 	return &MetricSet{
 		BaseMetricSet: base,
-		prometheus:    helper.NewPrometheusClient(base),
+		prometheus:    prometheus,
 		namespace:     config.Namespace,
 	}, nil
 }

--- a/metricbeat/module/prometheus/stats/stats.go
+++ b/metricbeat/module/prometheus/stats/stats.go
@@ -36,9 +36,13 @@ type MetricSet struct {
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	cfgwarn.Beta("The prometheus stats metricset is beta")
 
+	http, err := helper.NewHTTP(base)
+	if err != nil {
+		return nil, err
+	}
 	return &MetricSet{
 		BaseMetricSet: base,
-		http:          helper.NewHTTP(base),
+		http:          http,
 	}, nil
 }
 

--- a/metricbeat/module/rabbitmq/node/node.go
+++ b/metricbeat/module/rabbitmq/node/node.go
@@ -34,7 +34,10 @@ type MetricSet struct {
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	cfgwarn.Experimental("The rabbitmq node metricset is experimental")
 
-	http := helper.NewHTTP(base)
+	http, err := helper.NewHTTP(base)
+	if err != nil {
+		return nil, err
+	}
 	http.SetHeader("Accept", "application/json")
 
 	return &MetricSet{

--- a/metricbeat/module/rabbitmq/queue/queue.go
+++ b/metricbeat/module/rabbitmq/queue/queue.go
@@ -34,7 +34,10 @@ type MetricSet struct {
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	cfgwarn.Experimental("The rabbitmq queue metricset is experimental")
 
-	http := helper.NewHTTP(base)
+	http, err := helper.NewHTTP(base)
+	if err != nil {
+		return nil, err
+	}
 	http.SetHeader("Accept", "application/json")
 
 	return &MetricSet{


### PR DESCRIPTION
When setting an invalide http config in a metricbeat module / metricset it could happen that the metricset paniced. The reason is that the error when unpacking the config was not properly returned and handled which lead to an empty http instance.

This PR changes the behaviour to return the errors which can then be handled by the metricsets. The issue also affects all metricsets which were based on the prometheus helper.

Closes https://github.com/elastic/beats/issues/6192