### PR TITLE
Start pods watcher when autodiscover provider starts

### DIFF
--- a/libbeat/autodiscover/providers/kubernetes/kubernetes.go
+++ b/libbeat/autodiscover/providers/kubernetes/kubernetes.go
@@ -77,15 +77,14 @@ func AutodiscoverBuilder(bus bus.Bus, c *common.Config) (autodiscover.Provider, 
 		},
 	})
 
-	if err := watcher.Start(); err != nil {
-		return nil, err
-	}
-
 	return p, nil
 }
 
 // Start for Runner interface.
 func (p *Provider) Start() {
+	if err := p.watcher.Start(); err != nil {
+		logp.Err("Error starting kubernetes autodiscover provider: %s", err)
+	}
 }
 
 func (p *Provider) emit(pod *kubernetes.Pod, flag string) {


### PR DESCRIPTION
Pods watcher was starting too soon, so initial pods where not spawning
new autodiscover events, as autodiscover manager is not registered to
listen yet.

This only affects master, as it was recently refactored: #6159