### PR TITLE
Cherry-pick #6152 to 6.2: Add link to auditbeat breaking changes

### DIFF
--- a/libbeat/docs/breaking.asciidoc
+++ b/libbeat/docs/breaking.asciidoc
@@ -7,6 +7,12 @@ changes, but there are breaking changes between major versions (e.g. 5.x to
 6.y). Migrating directly between non consecutive major versions (e.g. 1.x to
 6.x) is not recommended.
 
+See the following topics for a description of breaking changes:
+
+* <<breaking-changes-6.0>>
+* {auditbeat}/auditbeat-breaking-changes.html[Breaking changes in Auditbeat 6.2]
+
+
 [[breaking-changes-6.0]]
 === Breaking changes in 6.0
 

--- a/libbeat/docs/shared-beats-attributes.asciidoc
+++ b/libbeat/docs/shared-beats-attributes.asciidoc
@@ -6,6 +6,7 @@
 :heartbeat: http://www.elastic.co/guide/en/beats/heartbeat/{doc-branch}
 :filebeat: http://www.elastic.co/guide/en/beats/filebeat/{doc-branch}
 :winlogbeat: http://www.elastic.co/guide/en/beats/winlogbeat/{doc-branch}
+:auditbeat: http://www.elastic.co/guide/en/beats/auditbeat/{doc-branch}
 :logstashdoc: https://www.elastic.co/guide/en/logstash/{doc-branch}
 :elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/{doc-branch}
 :elasticsearch-plugins: https://www.elastic.co/guide/en/elasticsearch/plugins/{doc-branch}


### PR DESCRIPTION
Cherry-pick of PR #6152 to 6.2 branch. Original message: 

This might fail CI the first time around because the new auditbeat topic hasn't been published by the doc build yet.