### PR TITLE
Fix system process metricset for kernel processes

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -111,6 +111,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Fix process cgroup memory metrics for memsw, kmem, and kmem_tcp. {issue}6033[6033]
 - Fix kafka OffsetFetch request missing topic and partition parameters. {pull}5880[5880]
 - Change kubernetes.node.cpu.allocatable.cores to float. {pull}6130[6130]
+- Fix system process metricset for kernel processes. {issue}5700[5700]
 
 *Packetbeat*
 

--- a/libbeat/metric/system/process/process.go
+++ b/libbeat/metric/system/process/process.go
@@ -76,7 +76,7 @@ func newProcess(pid int, cmdline string, env common.MapStr) (*Process, error) {
 	}
 
 	exe := sigar.ProcExe{}
-	if err := exe.Get(pid); err != nil && !sigar.IsNotImplemented(err) && !os.IsPermission(err) {
+	if err := exe.Get(pid); err != nil && !sigar.IsNotImplemented(err) && !os.IsPermission(err) && !os.IsNotExist(err) {
 		return nil, fmt.Errorf("error getting process exe for pid=%d: %v", pid, err)
 	}
 


### PR DESCRIPTION
On Linux, kernel processes don't have an exe on disk so the `/proc/[PID]/exe` symlink is broken. When Metricbeat tries to read the symlink it gets an error and it skips the whole process. This adds a check for ENOENT and ignores the error which allows kernel processes to be reported by Metricbeat. This is the error that it fixes.

    2018-01-30T20:31:02.512Z	DEBUG	[processes]	process/process.go:443	Skip process pid=12113: error getting process exe for pid=12113: readlink /proc/12113/exe: no such file or directory

Fixes #5700