### PR TITLE
Update go-ucfg to fix an issue with cyclic reference

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -364,8 +364,8 @@ Apache License 2.0
 
 --------------------------------------------------------------------
 Dependency: github.com/elastic/go-ucfg
-Version: v0.5.0
-Revision: bda09c7b9afc6263a3fd592fcd7063d03f6acf0f
+Version: v0.5.1
+Revision: 0ba28e36add27704e6b49a7ed8557989a8f4a635
 License type (autodetected): Apache-2.0
 ./vendor/github.com/elastic/go-ucfg/LICENSE:
 --------------------------------------------------------------------

--- a/vendor/github.com/elastic/go-ucfg/CHANGELOG.md
+++ b/vendor/github.com/elastic/go-ucfg/CHANGELOG.md
@@ -14,6 +14,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+## [0.5.1]
+
+### Fixed
+- Fix: an issue with the Cyclic reference algorithm when a direct reference was pointing
+  to another reference. #100
+
 ## [0.5.0]
 
 ### Added
@@ -183,7 +189,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Introduced CHANGELOG.md for documenting changes to ucfg.
 
 
-[Unreleased]: https://github.com/elastic/go-ucfg/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/elastic/go-ucfg/compare/v0.5.1...HEAD
+[0.5.1]: https://github.com/elastic/go-ucfg/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/elastic/go-ucfg/compare/v0.4.6...v0.5.0
 [0.4.6]: https://github.com/elastic/go-ucfg/compare/v0.4.5...v0.4.6
 [0.4.5]: https://github.com/elastic/go-ucfg/compare/v0.4.4...v0.4.5

--- a/vendor/github.com/elastic/go-ucfg/reify.go
+++ b/vendor/github.com/elastic/go-ucfg/reify.go
@@ -576,11 +576,14 @@ func doReifyPrimitive(
 		tRegexp:   reifyRegexp,
 	}
 
+	previous := opts.opts.activeFields
+	opts.opts.activeFields = NewFieldSet(previous)
 	valT, err := val.typ(opts.opts)
 	if err != nil {
 		ctx := val.Context()
 		return reflect.Value{}, raisePathErr(err, val.meta(), "", ctx.path("."))
 	}
+	opts.opts.activeFields = previous
 
 	// try primitive conversion
 	kind := baseType.Kind()

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -445,12 +445,12 @@
 			"revisionTime": "2016-06-17T14:03:01Z"
 		},
 		{
-			"checksumSHA1": "FPMs2e/K5HRqZyFvU/VTioGBnwk=",
+			"checksumSHA1": "61XUpyQ3zWnJ7Tlj0xLsHtnzwJY=",
 			"path": "github.com/elastic/go-ucfg",
-			"revision": "bda09c7b9afc6263a3fd592fcd7063d03f6acf0f",
-			"revisionTime": "2018-01-22T22:35:02Z",
-			"version": "v0.5.0",
-			"versionExact": "v0.5.0"
+			"revision": "0ba28e36add27704e6b49a7ed8557989a8f4a635",
+			"revisionTime": "2018-01-30T20:43:55Z",
+			"version": "v0.5.1",
+			"versionExact": "v0.5.1"
 		},
 		{
 			"checksumSHA1": "8cr5YhslUMgpvF2JebYvKC+Ezr4=",


### PR DESCRIPTION
When a field was referencing a field which is a reference of another and its not a
cyclic reference the algorithm was detecting it as a cyclic reference
when we were reify the values into the struct.

We have fixed the issue in https://github.com/elastic/go-ucfg/pull/100

Fixes: #6214