### PR TITLE
revert `event.type` and use `input.type` instead

### DIFF
--- a/filebeat/_meta/fields.common.yml
+++ b/filebeat/_meta/fields.common.yml
@@ -33,9 +33,9 @@
       required: true
       description: >
         The input type from which the event was generated. This field is set to the value specified
-        for the `type` option in the input section of the Filebeat config file. (DEPRECATED: see `event.type`)
+        for the `type` option in the input section of the Filebeat config file. (DEPRECATED: see `input.type`)
 
-    - name: event.type
+    - name: input.type
       required: true
       description: >
         The input type from which the event was generated. This field is set to the value specified

--- a/filebeat/channel/factory.go
+++ b/filebeat/channel/factory.go
@@ -99,7 +99,7 @@ func (f *OutletFactory) Create(cfg *common.Config, dynFields *common.MapStrPoint
 		fields["prospector"] = common.MapStr{
 			"type": config.Type,
 		}
-		fields["event"] = common.MapStr{
+		fields["input"] = common.MapStr{
 			"type": config.Type,
 		}
 	}

--- a/filebeat/docs/fields.asciidoc
+++ b/filebeat/docs/fields.asciidoc
@@ -957,11 +957,11 @@ Log stream when reading container logs, can be 'stdout' or 'stderr'
 
 required: True
 
-The input type from which the event was generated. This field is set to the value specified for the `type` option in the input section of the Filebeat config file. (DEPRECATED: see `event.type`)
+The input type from which the event was generated. This field is set to the value specified for the `type` option in the input section of the Filebeat config file. (DEPRECATED: see `input.type`)
 
 
 [float]
-=== `event.type`
+=== `input.type`
 
 required: True
 


### PR DESCRIPTION
This commit revert the decision done in #6078 and will use`input.type` to replace the `prospector.type`

After discussing with @ruflin we have agreed that this change was done too soon before the ECS format was stable and we have decided to use `input.type` instead, so we don't block the `event.type` key when ECS finally land.