### PR TITLE
Use last resource version when watching kubernetes events

### DIFF
--- a/libbeat/common/kubernetes/watcher.go
+++ b/libbeat/common/kubernetes/watcher.go
@@ -131,7 +131,7 @@ func (p *podWatcher) Start() error {
 func (p *podWatcher) watch() {
 	for {
 		logp.Info("kubernetes: %s", "Watching API for pod events")
-		watcher, err := p.client.WatchPods(p.ctx, "", p.nodeFilter)
+		watcher, err := p.client.WatchPods(p.ctx, "", p.nodeFilter, k8s.ResourceVersion(p.lastResourceVersion))
 		if err != nil {
 			//watch pod failures should be logged and gracefully failed over as metadata retrieval
 			//should never stop.
@@ -147,6 +147,9 @@ func (p *podWatcher) watch() {
 				watcher.Close()
 				break
 			}
+
+			// Update last resource version
+			p.lastResourceVersion = apiPod.Metadata.GetResourceVersion()
 
 			pod := GetPod(apiPod)
 			if pod.Metadata.DeletionTimestamp != "" {


### PR DESCRIPTION
This will avoid duplicated events when watching for pod events. Duplicated events don't affect `add_kubernetes_metadata` but can cause issues when used by autodiscover, as procesing a start/stop event twice can lead to undesired status. For instance, without this change it's common to get a list of start-stop-start events for running pods during startup.

master is not affected as this code was refactored