### PR TITLE
Fix filesystem used percentage

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -116,6 +116,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Change kubernetes.node.cpu.allocatable.cores to float. {pull}6130[6130]
 - Fix system process metricset for kernel processes. {issue}5700[5700]
 - Fix panic in http dependent modules when invalid config was used.
+- Fix system.filesystem.used.pct value to match what df reports. {issue}5494[5494]
 
 *Packetbeat*
 

--- a/metricbeat/module/system/filesystem/helper.go
+++ b/metricbeat/module/system/filesystem/helper.go
@@ -74,7 +74,7 @@ func AddFileSystemUsedPercentage(f *FileSystemStat) {
 		return
 	}
 
-	perc := float64(f.Used) / float64(f.Total)
+	perc := float64(f.Used) / float64(f.Used+f.Avail)
 	f.UsedPercent = common.Round(perc, common.DefaultDecimalPlacesCount)
 }
 


### PR DESCRIPTION
The used percentage reported by Metricbeat does not match what is reported by `df`. Metricbeat's computation of the `system.filesystem.used.pct` value was based on the total number of bytes, but df uses the total number of bytes available to the unprivileged user.

| FS       | Blocks      | Used        | Available  | Use % | Mount | Metricbeat Used % After This Change | Before This Change |
|----------|-------------|-------------|------------|-------|-------|-------------------------------------|--------------------|
| /dev/vda | 21137846272 | 16992858112 | 3071246336 | 85    | /     | 0.846928312                         | 0.8039067885       |

Fixes #5494