### PR TITLE
Fix metrics cache tests timing issues

### DIFF
--- a/metricbeat/module/kubernetes/util/metrics_cache_test.go
+++ b/metricbeat/module/kubernetes/util/metrics_cache_test.go
@@ -31,7 +31,7 @@ func TestGetWithDefault(t *testing.T) {
 }
 
 func TestTimeout(t *testing.T) {
-	test := newValueMap(20 * time.Millisecond)
+	test := newValueMap(10 * time.Millisecond)
 
 	test.Set("foo", 3.14)
 	assert.Equal(t, 3.14, test.Get("foo"))


### PR DESCRIPTION
 reducing the TTL of values in the map will ensure it gets deleted before we check in the test here: https://github.com/elastic/beats/pull/6232/files#diff-38ea4eca361fafd71024ff75197a98d8R41

fixes #6228