### PR TITLE
Fix setup.dashboards.always_kibana when using Kibana 5.6

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -66,6 +66,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Fix logstash output debug message. {pull}5799{5799]
 - Fix isolation of modules when merging local and global field settings. {issue}5795[5795]
 - Fix panic when Events containing a float32 value are normalized. {pull}6129[6129]
+- Fix `setup.dashboards.always_kibana` when using Kibana 5.6. {issue}6090[6090]
 
 *Auditbeat*
 

--- a/libbeat/setup/kibana/client.go
+++ b/libbeat/setup/kibana/client.go
@@ -199,10 +199,6 @@ func (client *Client) SetVersion() error {
 				client.Connection.URL, truncateString(result), err5x, err)
 		}
 		client.version = kibanaVersion5x.Version
-
-		return fmt.Errorf("fail to unmarshal the response from GET %s/api/status: %v. Response: %s",
-			client.Connection.URL, err, truncateString(result))
-
 	} else {
 
 		client.version = kibanaVersion.Version.Number


### PR DESCRIPTION
In order to handle the different Kibana /api/status response formats in 5.x and 6.x the client attempts to parse it as 6.x and then falls back to the 5.x format on error. However if it was successful at parsing it was a 5.x response type is still always reported that an error had occurred.

Fixes #6090