### PR TITLE
Fix event formatting with missing params (#6234)

### DIFF
--- a/winlogbeat/sys/eventlogging/eventlogging_windows_test.go
+++ b/winlogbeat/sys/eventlogging/eventlogging_windows_test.go
@@ -1,0 +1,57 @@
+package eventlogging
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMaxParam(t *testing.T) {
+	for _, data := range []struct {
+		s   string
+		max int
+	}{
+		{"", 0},
+		{"0", 0},
+		{"hello %0", 0},
+		{"The service %1 failed to %2", 2},
+		{"%3 %2 %1", 3},
+		{"%", 0},
+		{"8%%%33%0%%99", 33},
+		{"The program %1 %6 on host %7 failed to %2 on %3 %4 due to %5", 7},
+		{"%12345", 12345},
+	} {
+		max, err := getMaxInsertArgument(stringToUTF16Bytes(data.s))
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.Equal(t, data.max, max, data.s)
+	}
+}
+
+func TestBadMaxParam(t *testing.T) {
+	for _, data := range []struct {
+		s   []byte
+		err string
+	}{
+		{[]byte{}, "utf16 string is not terminated"},
+		{[]byte{0}, "utf16 string has odd length"},
+		{[]byte{0, 1}, "utf16 string is not terminated"},
+		{[]byte{1, 0}, "utf16 string is not terminated"},
+		{[]byte{1, 0, 0}, "utf16 string has odd length"},
+	} {
+		max, err := getMaxInsertArgument(data.s)
+		assert.NotNil(t, err, data.s)
+		assert.Equal(t, 0, max)
+		assert.Equal(t, data.err, err.Error(), data.s)
+	}
+}
+
+func stringToUTF16Bytes(s string) []byte {
+	n := len(s)
+	result := make([]byte, 2*n+2)
+	for idx, chr := range s {
+		result[idx*2] = byte(chr)
+	}
+	return result
+}


### PR DESCRIPTION
There was a crash in the eventlogging module used in legacy Windows versions (XP and 2003 server). It is necessary to account for the case where an event contains fewer parameters than required by its format string.

<strike>This patch also opportunistically adds the ability to lookup event descriptions in the system message table, as a last resort when a message can't be found in the message files specified in the registry.</strike> (feature removed for now)

Closes #6234