### PR TITLE
Cherry-pick #6219 to 6.2: Ensure autodiscover events are processed in order

### DIFF
--- a/filebeat/beater/autodiscover.go
+++ b/filebeat/beater/autodiscover.go
@@ -45,12 +45,7 @@ func (m *AutodiscoverAdapter) Create(c *common.Config, meta *common.MapStrPointe
 	return m.prospectorFactory.Create(c, meta)
 }
 
-// StartFilter returns the bus filter to retrieve runner start triggering events
-func (m *AutodiscoverAdapter) StartFilter() []string {
-	return []string{"start", "config"}
-}
-
-// StopFilter returns the bus filter to retrieve runner stop triggering events
-func (m *AutodiscoverAdapter) StopFilter() []string {
-	return []string{"stop", "config"}
+// EventFilter returns the bus filter to retrieve runner start/stop triggering events
+func (m *AutodiscoverAdapter) EventFilter() []string {
+	return []string{"config"}
 }

--- a/libbeat/autodiscover/autodiscover.go
+++ b/libbeat/autodiscover/autodiscover.go
@@ -27,11 +27,8 @@ type Adapter interface {
 	// RunnerFactory provides runner creation by feeding valid configs
 	cfgfile.RunnerFactory
 
-	// StartFilter returns the bus filter to retrieve runner start triggering events
-	StartFilter() []string
-
-	// StopFilter returns the bus filter to retrieve runner stop triggering events
-	StopFilter() []string
+	// EventFilter returns the bus filter to retrieve runner start/stop triggering events
+	EventFilter() []string
 }
 
 // Autodiscover process, it takes a beat adapter and user config and runs autodiscover process, spawning
@@ -43,8 +40,7 @@ type Autodiscover struct {
 	runners   *cfgfile.Registry
 	meta      *meta.Map
 
-	startListener bus.Listener
-	stopListener  bus.Listener
+	listener bus.Listener
 }
 
 // NewAutodiscover instantiates and returns a new Autodiscover manager
@@ -79,105 +75,111 @@ func (a *Autodiscover) Start() {
 	}
 
 	logp.Info("Starting autodiscover manager")
-	a.startListener = a.bus.Subscribe(a.adapter.StartFilter()...)
-	a.stopListener = a.bus.Subscribe(a.adapter.StopFilter()...)
+	a.listener = a.bus.Subscribe(a.adapter.EventFilter()...)
 
 	for _, provider := range a.providers {
 		provider.Start()
 	}
 
-	go a.startWorker()
-	go a.stopWorker()
+	go a.worker()
 }
 
-func (a *Autodiscover) startWorker() {
-	for event := range a.startListener.Events() {
+func (a *Autodiscover) worker() {
+	for event := range a.listener.Events() {
 		// This will happen on Stop:
 		if event == nil {
 			return
 		}
 
-		configs, err := a.adapter.CreateConfig(event)
-		if err != nil {
-			logp.Debug(debugK, "Could not generate config from event %v: %v", event, err)
-			continue
+		if _, ok := event["start"]; ok {
+			a.handleStart(event)
 		}
-		logp.Debug(debugK, "Got a start event: %v, generated configs: %+v", event, configs)
-
-		meta := getMeta(event)
-		for _, config := range configs {
-			rawCfg := map[string]interface{}{}
-			err := config.Unpack(rawCfg)
-
-			hash, err := hashstructure.Hash(rawCfg, nil)
-			if err != nil {
-				logp.Debug(debugK, "Could not hash config %v: %v", config, err)
-				continue
-			}
-
-			err = a.adapter.CheckConfig(config)
-			if err != nil {
-				logp.Debug(debugK, "Check failed for config %v: %v, won't start runner", config, err)
-				continue
-			}
-
-			// Update meta no matter what
-			dynFields := a.meta.Store(hash, meta)
-
-			if a.runners.Has(hash) {
-				logp.Debug(debugK, "Config %v is already running", config)
-				continue
-			}
-
-			runner, err := a.adapter.Create(config, &dynFields)
-			if err != nil {
-				logp.Debug(debugK, "Failed to create runner with config %v: %v", config, err)
-				continue
-			}
-
-			logp.Info("Autodiscover starting runner: %s", runner)
-			a.runners.Add(hash, runner)
-			runner.Start()
+		if _, ok := event["stop"]; ok {
+			a.handleStop(event)
 		}
 	}
 }
 
-func (a *Autodiscover) stopWorker() {
-	for event := range a.stopListener.Events() {
-		// This will happen on Stop:
-		if event == nil {
-			return
-		}
+func (a *Autodiscover) handleStart(event bus.Event) {
+	configs, err := a.adapter.CreateConfig(event)
+	if err != nil {
+		logp.Debug(debugK, "Could not generate config from event %v: %v", event, err)
+		return
+	}
+	logp.Debug(debugK, "Got a start event: %v, generated configs: %+v", event, configs)
 
-		configs, err := a.adapter.CreateConfig(event)
-		if err != nil {
-			logp.Debug(debugK, "Could not generate config from event %v: %v", event, err)
+	meta := getMeta(event)
+	for _, config := range configs {
+		rawCfg := map[string]interface{}{}
+		if err := config.Unpack(rawCfg); err != nil {
+			logp.Debug(debugK, "Error unpacking config: %v", err)
 			continue
 		}
-		logp.Debug(debugK, "Got a stop event: %v, generated configs: %+v", event, configs)
 
-		for _, config := range configs {
-			rawCfg := map[string]interface{}{}
-			err := config.Unpack(rawCfg)
+		hash, err := hashstructure.Hash(rawCfg, nil)
+		if err != nil {
+			logp.Debug(debugK, "Could not hash config %v: %v", config, err)
+			continue
+		}
 
-			hash, err := hashstructure.Hash(rawCfg, nil)
-			if err != nil {
-				logp.Debug(debugK, "Could not hash config %v: %v", config, err)
-				continue
-			}
+		err = a.adapter.CheckConfig(config)
+		if err != nil {
+			logp.Debug(debugK, "Check failed for config %v: %v, won't start runner", config, err)
+			continue
+		}
 
-			if !a.runners.Has(hash) {
-				logp.Debug(debugK, "Config %v is not running", config)
-				continue
-			}
+		// Update meta no matter what
+		dynFields := a.meta.Store(hash, meta)
 
-			if runner := a.runners.Get(hash); runner != nil {
-				logp.Info("Autodiscover stopping runner: %s", runner)
-				runner.Stop()
-				a.runners.Remove(hash)
-			} else {
-				logp.Debug(debugK, "Runner not found for stopping: %s", hash)
-			}
+		if a.runners.Has(hash) {
+			logp.Debug(debugK, "Config %v is already running", config)
+			continue
+		}
+
+		runner, err := a.adapter.Create(config, &dynFields)
+		if err != nil {
+			logp.Debug(debugK, "Failed to create runner with config %v: %v", config, err)
+			continue
+		}
+
+		logp.Info("Autodiscover starting runner: %s", runner)
+		a.runners.Add(hash, runner)
+		runner.Start()
+	}
+}
+
+func (a *Autodiscover) handleStop(event bus.Event) {
+	configs, err := a.adapter.CreateConfig(event)
+	if err != nil {
+		logp.Debug(debugK, "Could not generate config from event %v: %v", event, err)
+		return
+	}
+	logp.Debug(debugK, "Got a stop event: %v, generated configs: %+v", event, configs)
+
+	for _, config := range configs {
+		rawCfg := map[string]interface{}{}
+		if err := config.Unpack(rawCfg); err != nil {
+			logp.Debug(debugK, "Error unpacking config: %v", err)
+			continue
+		}
+
+		hash, err := hashstructure.Hash(rawCfg, nil)
+		if err != nil {
+			logp.Debug(debugK, "Could not hash config %v: %v", config, err)
+			continue
+		}
+
+		if !a.runners.Has(hash) {
+			logp.Debug(debugK, "Config %v is not running", config)
+			continue
+		}
+
+		if runner := a.runners.Get(hash); runner != nil {
+			logp.Info("Autodiscover stopping runner: %s", runner)
+			runner.Stop()
+			a.runners.Remove(hash)
+		} else {
+			logp.Debug(debugK, "Runner not found for stopping: %s", hash)
 		}
 	}
 }
@@ -204,8 +206,7 @@ func (a *Autodiscover) Stop() {
 	}
 
 	// Stop listening for events
-	a.startListener.Stop()
-	a.stopListener.Stop()
+	a.listener.Stop()
 
 	// Stop providers
 	for _, provider := range a.providers {

--- a/libbeat/autodiscover/providers/kubernetes/kubernetes.go
+++ b/libbeat/autodiscover/providers/kubernetes/kubernetes.go
@@ -105,11 +105,15 @@ func (p *Provider) emit(event bus.Event, flag string) {
 	}
 
 	host := pod.Status.PodIP
+	containerIDs := map[string]string{}
 
 	// Emit pod container IDs
 	for _, c := range append(pod.Status.ContainerStatuses, pod.Status.InitContainerStatuses...) {
+		cid := c.GetContainerID()
+		containerIDs[c.Name] = cid
+
 		cmeta := common.MapStr{
-			"id":    c.GetContainerID(),
+			"id":    cid,
 			"name":  c.Name,
 			"image": c.Image,
 		}
@@ -135,6 +139,7 @@ func (p *Provider) emit(event bus.Event, flag string) {
 	// Emit pod ports
 	for _, c := range pod.Spec.Containers {
 		cmeta := common.MapStr{
+			"id":    containerIDs[c.Name],
 			"name":  c.Name,
 			"image": c.Image,
 		}

--- a/metricbeat/beater/autodiscover.go
+++ b/metricbeat/beater/autodiscover.go
@@ -40,12 +40,7 @@ func (m *AutodiscoverAdapter) Create(c *common.Config, meta *common.MapStrPointe
 	return m.factory.Create(c, meta)
 }
 
-// StartFilter returns the bus filter to retrieve runner start triggering events
-func (m *AutodiscoverAdapter) StartFilter() []string {
-	return []string{"start", "config"}
-}
-
-// StopFilter returns the bus filter to retrieve runner stop triggering events
-func (m *AutodiscoverAdapter) StopFilter() []string {
-	return []string{"stop", "config"}
+// EventFilter returns the bus filter to retrieve runner start/stop triggering events
+func (m *AutodiscoverAdapter) EventFilter() []string {
+	return []string{"config"}
 }


### PR DESCRIPTION
Cherry-pick of PR #6219 to 6.2 branch. Original message: 

We need to read start/stop events from a single queue to ensure they are
processed in order.

Before this change, in some edge cases, when updates spawn stop/start
events, autodiscover was processing the start event before stop, leading
to an undesired state: no running config for an existing pod.