### PR TITLE
Cherry-pick #6240 to 6.2: Logging fixes for verbosity

### DIFF
--- a/libbeat/logp/config.go
+++ b/libbeat/logp/config.go
@@ -5,7 +5,7 @@ package logp
 type Config struct {
 	Beat      string   `config:",ignore"`   // Name of the Beat (for default file name).
 	JSON      bool     `config:"json"`      // Write logs as JSON.
-	Level     Level    `config:"level"`     // Logging level (error, warn, info, debug).
+	Level     Level    `config:"level"`     // Logging level (error, warning, info, debug).
 	Selectors []string `config:"selectors"` // Selectors for debug level logging.
 
 	toObserver  bool

--- a/libbeat/logp/configure/logging.go
+++ b/libbeat/logp/configure/logging.go
@@ -40,7 +40,7 @@ func applyFlags(cfg *logp.Config) {
 	if toStderr {
 		cfg.ToStderr = true
 	}
-	if cfg.Level > logp.InfoLevel {
+	if cfg.Level > logp.InfoLevel && verbose {
 		cfg.Level = logp.InfoLevel
 	}
 	for _, selectors := range debugSelectors {

--- a/libbeat/logp/core_test.go
+++ b/libbeat/logp/core_test.go
@@ -81,12 +81,12 @@ func TestGlobalLoggerLevel(t *testing.T) {
 		assert.Equal(t, "info", logs[0].Message)
 	}
 
-	Warn("warn")
+	Warn("warning")
 	logs = ObserverLogs().TakeAll()
 	if assert.Len(t, logs, 1) {
 		assert.Equal(t, zap.WarnLevel, logs[0].Level)
 		assert.Equal(t, "", logs[0].LoggerName)
-		assert.Equal(t, "warn", logs[0].Message)
+		assert.Equal(t, "warning", logs[0].Message)
 	}
 
 	Err("error")

--- a/libbeat/logp/level.go
+++ b/libbeat/logp/level.go
@@ -24,7 +24,7 @@ const (
 var levelStrings = map[Level]string{
 	DebugLevel:    "debug",
 	InfoLevel:     "info",
-	WarnLevel:     "warn",
+	WarnLevel:     "warning",
 	ErrorLevel:    "error",
 	CriticalLevel: "critical",
 }


### PR DESCRIPTION
Cherry-pick of PR #6240 to 6.2 branch. Original message: 

* Add a check for the `verbose` flag, before going back to Info.
* Revert to using `warning` in the configuration instead of `warn`. It seems that
  we have always used `warning`.

Fixes #6239.