### PR TITLE
How Filebeat works not up-to-date on prospector types.

### DIFF
--- a/filebeat/docs/filebeat-options.asciidoc
+++ b/filebeat/docs/filebeat-options.asciidoc
@@ -34,6 +34,7 @@ filebeat.prospectors:
 === Configuration options
 
 [float]
+[[prospector-type]]
 ==== `type`
 
 One of the following input types:

--- a/filebeat/docs/how-filebeat-works.asciidoc
+++ b/filebeat/docs/how-filebeat-works.asciidoc
@@ -39,7 +39,7 @@ filebeat.prospectors:
     - /var/path2/*.log
 -------------------------------------------------------------------------------------
 
-Filebeat currently supports two `prospector` types: `log` and `stdin`. Each prospector type can be defined multiple times. The `log` prospector checks each file to see whether a harvester needs to be started, whether one is already running, or whether the file can be ignored (see <<ignore-older,`ignore_older`>>). New lines are only picked up if the size of the file has changed since the harvester was closed.
+Filebeat currently supports <<prospector-type,several `prospector` types>>. Each prospector type can be defined multiple times. The `log` prospector checks each file to see whether a harvester needs to be started, whether one is already running, or whether the file can be ignored (see <<ignore-older,`ignore_older`>>). New lines are only picked up if the size of the file has changed since the harvester was closed.
 
 NOTE: Filebeat prospectors can only read local files. There is no functionality to connect to remote hosts to read stored files or logs.
 
@@ -78,4 +78,3 @@ to disk and rotated faster than they can be processed by Filebeat, or if files
 are deleted while the output is unavailable, data might be lost. On Linux, it's
 also possible for Filebeat to skip lines as the result of inode reuse. See
 <<faq>> for more details about the inode reuse issue.
-


### PR DESCRIPTION
Updated paragraph saying that 'there are only 2 prospectors log and stdin'. Added anchors to link 'How Filebeat works' section and 'Prospector types' section