### PR TITLE
Add monitoring settings to reference configuration

### DIFF
--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -293,7 +293,7 @@ output.elasticsearch:
   # Configure http request timeout before failing an request to Elasticsearch.
   #timeout: 90
 
-  # Use SSL settings for HTTPS. Default is true.
+  # Use SSL settings for HTTPS.
   #ssl.enabled: true
 
   # Configure SSL verification mode. If `none` is configured, all server hosts
@@ -897,9 +897,11 @@ logging.files:
 # Set to true to enable the monitoring reporter.
 #xpack.monitoring.enabled: false
 
-# Uncomment to send the metrics to Elasticsearch. Any setting that is not set is
-# automatically inherited from the output configuration, so if you want to use the
-# same cluster for monitoring data, you can simply uncomment the following line.
+# Uncomment to send the metrics to Elasticsearch. Most settings from the
+# Elasticsearch output are accepted here as well. Any setting that is not set is
+# automatically inherited from the Elasticsearch output configuration, so if you
+# have the Elasticsearch output configured, you can simply uncomment the
+# following line, and leave the rest commented out.
 #xpack.monitoring.elasticsearch:
 
   # Array of hosts to connect to.
@@ -940,7 +942,7 @@ logging.files:
   # Configure http request timeout before failing an request to Elasticsearch.
   #timeout: 90
 
-  # Use SSL settings for HTTPS. Default is true.
+  # Use SSL settings for HTTPS.
   #ssl.enabled: true
 
   # Configure SSL verification mode. If `none` is configured, all server hosts

--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -889,6 +889,93 @@ logging.files:
 #logging.json: false
 
 
+#============================== Xpack Monitoring =====================================
+# auditbeat can export internal metrics to a central Elasticsearch monitoring cluster.
+# This requires xpack monitoring to be enabled in Elasticsearch.
+# The reporting is disabled by default.
+
+# Set to true to enable the monitoring reporter.
+#xpack.monitoring.enabled: false
+
+# Uncomment to send the metrics to Elasticsearch. Any setting that is not set is
+# automatically inherited from the output configuration, so if you want to use the
+# same cluster for monitoring data, you can simply uncomment the following line.
+#xpack.monitoring.elasticsearch:
+
+  # Array of hosts to connect to.
+  # Scheme and port can be left out and will be set to the default (http and 9200)
+  # In case you specify and additional path, the scheme is required: http://localhost:9200/path
+  # IPv6 addresses should always be defined as: https://[2001:db8::1]:9200
+  #hosts: ["localhost:9200"]
+
+  # Set gzip compression level.
+  #compression_level: 0
+
+  # Optional protocol and basic auth credentials.
+  #protocol: "https"
+  #username: "beats_system"
+  #password: "changeme"
+
+  # Dictionary of HTTP parameters to pass within the url with index operations.
+  #parameters:
+    #param1: value1
+    #param2: value2
+
+  # Custom HTTP headers to add to each request
+  #headers:
+  #  X-My-Header: Contents of the header
+
+  # Proxy server url
+  #proxy_url: http://proxy:3128
+
+  # The number of times a particular Elasticsearch index operation is attempted. If
+  # the indexing operation doesn't succeed after this many retries, the events are
+  # dropped. The default is 3.
+  #max_retries: 3
+
+  # The maximum number of events to bulk in a single Elasticsearch bulk API index request.
+  # The default is 50.
+  #bulk_max_size: 50
+
+  # Configure http request timeout before failing an request to Elasticsearch.
+  #timeout: 90
+
+  # Use SSL settings for HTTPS. Default is true.
+  #ssl.enabled: true
+
+  # Configure SSL verification mode. If `none` is configured, all server hosts
+  # and certificates will be accepted. In this mode, SSL based connections are
+  # susceptible to man-in-the-middle attacks. Use only for testing. Default is
+  # `full`.
+  #ssl.verification_mode: full
+
+  # List of supported/valid TLS versions. By default all TLS versions 1.0 up to
+  # 1.2 are enabled.
+  #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
+
+  # SSL configuration. By default is off.
+  # List of root certificates for HTTPS server verifications
+  #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
+
+  # Certificate for SSL client authentication
+  #ssl.certificate: "/etc/pki/client/cert.pem"
+
+  # Client Certificate Key
+  #ssl.key: "/etc/pki/client/cert.key"
+
+  # Optional passphrase for decrypting the Certificate Key.
+  #ssl.key_passphrase: ''
+
+  # Configure cipher suites to be used for SSL connections
+  #ssl.cipher_suites: []
+
+  # Configure curve types for ECDHE based cipher suites
+  #ssl.curve_types: []
+
+  # Configure what types of renegotiation are supported. Valid options are
+  # never, once, and freely. Default is never.
+  #ssl.renegotiation: never
+
 #================================ HTTP Endpoint ======================================
 # Each beat can expose internal metrics through a HTTP endpoint. For security
 # reasons the endpoint is disabled by default. This feature is currently experimental.

--- a/auditbeat/auditbeat.yml
+++ b/auditbeat/auditbeat.yml
@@ -155,8 +155,8 @@ output.elasticsearch:
 #xpack.monitoring.enabled: false
 
 # Uncomment to send the metrics to Elasticsearch. Most settings from the
-# elasticsearch output are accepted here as well. Any setting that is not set is
-# automatically inherited from the output configuration, so if you want to use
-# the same cluster for monitoring data, you can simply uncomment the following
-# line.
+# Elasticsearch output are accepted here as well. Any setting that is not set is
+# automatically inherited from the Elasticsearch output configuration, so if you
+# have the Elasticsearch output configured, you can simply uncomment the
+# following line.
 #xpack.monitoring.elasticsearch:

--- a/auditbeat/auditbeat.yml
+++ b/auditbeat/auditbeat.yml
@@ -145,3 +145,18 @@ output.elasticsearch:
 # To enable all selectors use ["*"]. Examples of other selectors are "beat",
 # "publish", "service".
 #logging.selectors: ["*"]
+
+#============================== Xpack Monitoring ===============================
+# auditbeat can export internal metrics to a central Elasticsearch monitoring
+# cluster.  This requires xpack monitoring to be enabled in Elasticsearch.  The
+# reporting is disabled by default.
+
+# Set to true to enable the monitoring reporter.
+#xpack.monitoring.enabled: false
+
+# Uncomment to send the metrics to Elasticsearch. Most settings from the
+# elasticsearch output are accepted here as well. Any setting that is not set is
+# automatically inherited from the output configuration, so if you want to use
+# the same cluster for monitoring data, you can simply uncomment the following
+# line.
+#xpack.monitoring.elasticsearch:

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -1337,6 +1337,93 @@ logging.files:
 #logging.json: false
 
 
+#============================== Xpack Monitoring =====================================
+# filebeat can export internal metrics to a central Elasticsearch monitoring cluster.
+# This requires xpack monitoring to be enabled in Elasticsearch.
+# The reporting is disabled by default.
+
+# Set to true to enable the monitoring reporter.
+#xpack.monitoring.enabled: false
+
+# Uncomment to send the metrics to Elasticsearch. Any setting that is not set is
+# automatically inherited from the output configuration, so if you want to use the
+# same cluster for monitoring data, you can simply uncomment the following line.
+#xpack.monitoring.elasticsearch:
+
+  # Array of hosts to connect to.
+  # Scheme and port can be left out and will be set to the default (http and 9200)
+  # In case you specify and additional path, the scheme is required: http://localhost:9200/path
+  # IPv6 addresses should always be defined as: https://[2001:db8::1]:9200
+  #hosts: ["localhost:9200"]
+
+  # Set gzip compression level.
+  #compression_level: 0
+
+  # Optional protocol and basic auth credentials.
+  #protocol: "https"
+  #username: "beats_system"
+  #password: "changeme"
+
+  # Dictionary of HTTP parameters to pass within the url with index operations.
+  #parameters:
+    #param1: value1
+    #param2: value2
+
+  # Custom HTTP headers to add to each request
+  #headers:
+  #  X-My-Header: Contents of the header
+
+  # Proxy server url
+  #proxy_url: http://proxy:3128
+
+  # The number of times a particular Elasticsearch index operation is attempted. If
+  # the indexing operation doesn't succeed after this many retries, the events are
+  # dropped. The default is 3.
+  #max_retries: 3
+
+  # The maximum number of events to bulk in a single Elasticsearch bulk API index request.
+  # The default is 50.
+  #bulk_max_size: 50
+
+  # Configure http request timeout before failing an request to Elasticsearch.
+  #timeout: 90
+
+  # Use SSL settings for HTTPS. Default is true.
+  #ssl.enabled: true
+
+  # Configure SSL verification mode. If `none` is configured, all server hosts
+  # and certificates will be accepted. In this mode, SSL based connections are
+  # susceptible to man-in-the-middle attacks. Use only for testing. Default is
+  # `full`.
+  #ssl.verification_mode: full
+
+  # List of supported/valid TLS versions. By default all TLS versions 1.0 up to
+  # 1.2 are enabled.
+  #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
+
+  # SSL configuration. By default is off.
+  # List of root certificates for HTTPS server verifications
+  #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
+
+  # Certificate for SSL client authentication
+  #ssl.certificate: "/etc/pki/client/cert.pem"
+
+  # Client Certificate Key
+  #ssl.key: "/etc/pki/client/cert.key"
+
+  # Optional passphrase for decrypting the Certificate Key.
+  #ssl.key_passphrase: ''
+
+  # Configure cipher suites to be used for SSL connections
+  #ssl.cipher_suites: []
+
+  # Configure curve types for ECDHE based cipher suites
+  #ssl.curve_types: []
+
+  # Configure what types of renegotiation are supported. Valid options are
+  # never, once, and freely. Default is never.
+  #ssl.renegotiation: never
+
 #================================ HTTP Endpoint ======================================
 # Each beat can expose internal metrics through a HTTP endpoint. For security
 # reasons the endpoint is disabled by default. This feature is currently experimental.

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -741,7 +741,7 @@ output.elasticsearch:
   # Configure http request timeout before failing an request to Elasticsearch.
   #timeout: 90
 
-  # Use SSL settings for HTTPS. Default is true.
+  # Use SSL settings for HTTPS.
   #ssl.enabled: true
 
   # Configure SSL verification mode. If `none` is configured, all server hosts
@@ -1345,9 +1345,11 @@ logging.files:
 # Set to true to enable the monitoring reporter.
 #xpack.monitoring.enabled: false
 
-# Uncomment to send the metrics to Elasticsearch. Any setting that is not set is
-# automatically inherited from the output configuration, so if you want to use the
-# same cluster for monitoring data, you can simply uncomment the following line.
+# Uncomment to send the metrics to Elasticsearch. Most settings from the
+# Elasticsearch output are accepted here as well. Any setting that is not set is
+# automatically inherited from the Elasticsearch output configuration, so if you
+# have the Elasticsearch output configured, you can simply uncomment the
+# following line, and leave the rest commented out.
 #xpack.monitoring.elasticsearch:
 
   # Array of hosts to connect to.
@@ -1388,7 +1390,7 @@ logging.files:
   # Configure http request timeout before failing an request to Elasticsearch.
   #timeout: 90
 
-  # Use SSL settings for HTTPS. Default is true.
+  # Use SSL settings for HTTPS.
   #ssl.enabled: true
 
   # Configure SSL verification mode. If `none` is configured, all server hosts

--- a/filebeat/filebeat.yml
+++ b/filebeat/filebeat.yml
@@ -184,8 +184,8 @@ output.elasticsearch:
 #xpack.monitoring.enabled: false
 
 # Uncomment to send the metrics to Elasticsearch. Most settings from the
-# elasticsearch output are accepted here as well. Any setting that is not set is
-# automatically inherited from the output configuration, so if you want to use
-# the same cluster for monitoring data, you can simply uncomment the following
-# line.
+# Elasticsearch output are accepted here as well. Any setting that is not set is
+# automatically inherited from the Elasticsearch output configuration, so if you
+# have the Elasticsearch output configured, you can simply uncomment the
+# following line.
 #xpack.monitoring.elasticsearch:

--- a/filebeat/filebeat.yml
+++ b/filebeat/filebeat.yml
@@ -174,3 +174,18 @@ output.elasticsearch:
 # To enable all selectors use ["*"]. Examples of other selectors are "beat",
 # "publish", "service".
 #logging.selectors: ["*"]
+
+#============================== Xpack Monitoring ===============================
+# filebeat can export internal metrics to a central Elasticsearch monitoring
+# cluster.  This requires xpack monitoring to be enabled in Elasticsearch.  The
+# reporting is disabled by default.
+
+# Set to true to enable the monitoring reporter.
+#xpack.monitoring.enabled: false
+
+# Uncomment to send the metrics to Elasticsearch. Most settings from the
+# elasticsearch output are accepted here as well. Any setting that is not set is
+# automatically inherited from the output configuration, so if you want to use
+# the same cluster for monitoring data, you can simply uncomment the following
+# line.
+#xpack.monitoring.elasticsearch:

--- a/heartbeat/heartbeat.reference.yml
+++ b/heartbeat/heartbeat.reference.yml
@@ -402,7 +402,7 @@ output.elasticsearch:
   # Configure http request timeout before failing an request to Elasticsearch.
   #timeout: 90
 
-  # Use SSL settings for HTTPS. Default is true.
+  # Use SSL settings for HTTPS.
   #ssl.enabled: true
 
   # Configure SSL verification mode. If `none` is configured, all server hosts
@@ -1006,9 +1006,11 @@ logging.files:
 # Set to true to enable the monitoring reporter.
 #xpack.monitoring.enabled: false
 
-# Uncomment to send the metrics to Elasticsearch. Any setting that is not set is
-# automatically inherited from the output configuration, so if you want to use the
-# same cluster for monitoring data, you can simply uncomment the following line.
+# Uncomment to send the metrics to Elasticsearch. Most settings from the
+# Elasticsearch output are accepted here as well. Any setting that is not set is
+# automatically inherited from the Elasticsearch output configuration, so if you
+# have the Elasticsearch output configured, you can simply uncomment the
+# following line, and leave the rest commented out.
 #xpack.monitoring.elasticsearch:
 
   # Array of hosts to connect to.
@@ -1049,7 +1051,7 @@ logging.files:
   # Configure http request timeout before failing an request to Elasticsearch.
   #timeout: 90
 
-  # Use SSL settings for HTTPS. Default is true.
+  # Use SSL settings for HTTPS.
   #ssl.enabled: true
 
   # Configure SSL verification mode. If `none` is configured, all server hosts

--- a/heartbeat/heartbeat.reference.yml
+++ b/heartbeat/heartbeat.reference.yml
@@ -998,6 +998,93 @@ logging.files:
 #logging.json: false
 
 
+#============================== Xpack Monitoring =====================================
+# heartbeat can export internal metrics to a central Elasticsearch monitoring cluster.
+# This requires xpack monitoring to be enabled in Elasticsearch.
+# The reporting is disabled by default.
+
+# Set to true to enable the monitoring reporter.
+#xpack.monitoring.enabled: false
+
+# Uncomment to send the metrics to Elasticsearch. Any setting that is not set is
+# automatically inherited from the output configuration, so if you want to use the
+# same cluster for monitoring data, you can simply uncomment the following line.
+#xpack.monitoring.elasticsearch:
+
+  # Array of hosts to connect to.
+  # Scheme and port can be left out and will be set to the default (http and 9200)
+  # In case you specify and additional path, the scheme is required: http://localhost:9200/path
+  # IPv6 addresses should always be defined as: https://[2001:db8::1]:9200
+  #hosts: ["localhost:9200"]
+
+  # Set gzip compression level.
+  #compression_level: 0
+
+  # Optional protocol and basic auth credentials.
+  #protocol: "https"
+  #username: "beats_system"
+  #password: "changeme"
+
+  # Dictionary of HTTP parameters to pass within the url with index operations.
+  #parameters:
+    #param1: value1
+    #param2: value2
+
+  # Custom HTTP headers to add to each request
+  #headers:
+  #  X-My-Header: Contents of the header
+
+  # Proxy server url
+  #proxy_url: http://proxy:3128
+
+  # The number of times a particular Elasticsearch index operation is attempted. If
+  # the indexing operation doesn't succeed after this many retries, the events are
+  # dropped. The default is 3.
+  #max_retries: 3
+
+  # The maximum number of events to bulk in a single Elasticsearch bulk API index request.
+  # The default is 50.
+  #bulk_max_size: 50
+
+  # Configure http request timeout before failing an request to Elasticsearch.
+  #timeout: 90
+
+  # Use SSL settings for HTTPS. Default is true.
+  #ssl.enabled: true
+
+  # Configure SSL verification mode. If `none` is configured, all server hosts
+  # and certificates will be accepted. In this mode, SSL based connections are
+  # susceptible to man-in-the-middle attacks. Use only for testing. Default is
+  # `full`.
+  #ssl.verification_mode: full
+
+  # List of supported/valid TLS versions. By default all TLS versions 1.0 up to
+  # 1.2 are enabled.
+  #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
+
+  # SSL configuration. By default is off.
+  # List of root certificates for HTTPS server verifications
+  #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
+
+  # Certificate for SSL client authentication
+  #ssl.certificate: "/etc/pki/client/cert.pem"
+
+  # Client Certificate Key
+  #ssl.key: "/etc/pki/client/cert.key"
+
+  # Optional passphrase for decrypting the Certificate Key.
+  #ssl.key_passphrase: ''
+
+  # Configure cipher suites to be used for SSL connections
+  #ssl.cipher_suites: []
+
+  # Configure curve types for ECDHE based cipher suites
+  #ssl.curve_types: []
+
+  # Configure what types of renegotiation are supported. Valid options are
+  # never, once, and freely. Default is never.
+  #ssl.renegotiation: never
+
 #================================ HTTP Endpoint ======================================
 # Each beat can expose internal metrics through a HTTP endpoint. For security
 # reasons the endpoint is disabled by default. This feature is currently experimental.

--- a/heartbeat/heartbeat.yml
+++ b/heartbeat/heartbeat.yml
@@ -121,3 +121,18 @@ output.elasticsearch:
 # To enable all selectors use ["*"]. Examples of other selectors are "beat",
 # "publish", "service".
 #logging.selectors: ["*"]
+
+#============================== Xpack Monitoring ===============================
+# heartbeat can export internal metrics to a central Elasticsearch monitoring
+# cluster.  This requires xpack monitoring to be enabled in Elasticsearch.  The
+# reporting is disabled by default.
+
+# Set to true to enable the monitoring reporter.
+#xpack.monitoring.enabled: false
+
+# Uncomment to send the metrics to Elasticsearch. Most settings from the
+# elasticsearch output are accepted here as well. Any setting that is not set is
+# automatically inherited from the output configuration, so if you want to use
+# the same cluster for monitoring data, you can simply uncomment the following
+# line.
+#xpack.monitoring.elasticsearch:

--- a/heartbeat/heartbeat.yml
+++ b/heartbeat/heartbeat.yml
@@ -131,8 +131,8 @@ output.elasticsearch:
 #xpack.monitoring.enabled: false
 
 # Uncomment to send the metrics to Elasticsearch. Most settings from the
-# elasticsearch output are accepted here as well. Any setting that is not set is
-# automatically inherited from the output configuration, so if you want to use
-# the same cluster for monitoring data, you can simply uncomment the following
-# line.
+# Elasticsearch output are accepted here as well. Any setting that is not set is
+# automatically inherited from the Elasticsearch output configuration, so if you
+# have the Elasticsearch output configured, you can simply uncomment the
+# following line.
 #xpack.monitoring.elasticsearch:

--- a/libbeat/_meta/config.reference.yml
+++ b/libbeat/_meta/config.reference.yml
@@ -784,6 +784,93 @@ logging.files:
 #logging.json: false
 
 
+#============================== Xpack Monitoring =====================================
+# beatname can export internal metrics to a central Elasticsearch monitoring cluster.
+# This requires xpack monitoring to be enabled in Elasticsearch.
+# The reporting is disabled by default.
+
+# Set to true to enable the monitoring reporter.
+#xpack.monitoring.enabled: false
+
+# Uncomment to send the metrics to Elasticsearch. Any setting that is not set is
+# automatically inherited from the output configuration, so if you want to use the
+# same cluster for monitoring data, you can simply uncomment the following line.
+#xpack.monitoring.elasticsearch:
+
+  # Array of hosts to connect to.
+  # Scheme and port can be left out and will be set to the default (http and 9200)
+  # In case you specify and additional path, the scheme is required: http://localhost:9200/path
+  # IPv6 addresses should always be defined as: https://[2001:db8::1]:9200
+  #hosts: ["localhost:9200"]
+
+  # Set gzip compression level.
+  #compression_level: 0
+
+  # Optional protocol and basic auth credentials.
+  #protocol: "https"
+  #username: "beats_system"
+  #password: "changeme"
+
+  # Dictionary of HTTP parameters to pass within the url with index operations.
+  #parameters:
+    #param1: value1
+    #param2: value2
+
+  # Custom HTTP headers to add to each request
+  #headers:
+  #  X-My-Header: Contents of the header
+
+  # Proxy server url
+  #proxy_url: http://proxy:3128
+
+  # The number of times a particular Elasticsearch index operation is attempted. If
+  # the indexing operation doesn't succeed after this many retries, the events are
+  # dropped. The default is 3.
+  #max_retries: 3
+
+  # The maximum number of events to bulk in a single Elasticsearch bulk API index request.
+  # The default is 50.
+  #bulk_max_size: 50
+
+  # Configure http request timeout before failing an request to Elasticsearch.
+  #timeout: 90
+
+  # Use SSL settings for HTTPS. Default is true.
+  #ssl.enabled: true
+
+  # Configure SSL verification mode. If `none` is configured, all server hosts
+  # and certificates will be accepted. In this mode, SSL based connections are
+  # susceptible to man-in-the-middle attacks. Use only for testing. Default is
+  # `full`.
+  #ssl.verification_mode: full
+
+  # List of supported/valid TLS versions. By default all TLS versions 1.0 up to
+  # 1.2 are enabled.
+  #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
+
+  # SSL configuration. By default is off.
+  # List of root certificates for HTTPS server verifications
+  #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
+
+  # Certificate for SSL client authentication
+  #ssl.certificate: "/etc/pki/client/cert.pem"
+
+  # Client Certificate Key
+  #ssl.key: "/etc/pki/client/cert.key"
+
+  # Optional passphrase for decrypting the Certificate Key.
+  #ssl.key_passphrase: ''
+
+  # Configure cipher suites to be used for SSL connections
+  #ssl.cipher_suites: []
+
+  # Configure curve types for ECDHE based cipher suites
+  #ssl.curve_types: []
+
+  # Configure what types of renegotiation are supported. Valid options are
+  # never, once, and freely. Default is never.
+  #ssl.renegotiation: never
+
 #================================ HTTP Endpoint ======================================
 # Each beat can expose internal metrics through a HTTP endpoint. For security
 # reasons the endpoint is disabled by default. This feature is currently experimental.

--- a/libbeat/_meta/config.reference.yml
+++ b/libbeat/_meta/config.reference.yml
@@ -188,7 +188,7 @@ output.elasticsearch:
   # Configure http request timeout before failing an request to Elasticsearch.
   #timeout: 90
 
-  # Use SSL settings for HTTPS. Default is true.
+  # Use SSL settings for HTTPS.
   #ssl.enabled: true
 
   # Configure SSL verification mode. If `none` is configured, all server hosts
@@ -792,9 +792,11 @@ logging.files:
 # Set to true to enable the monitoring reporter.
 #xpack.monitoring.enabled: false
 
-# Uncomment to send the metrics to Elasticsearch. Any setting that is not set is
-# automatically inherited from the output configuration, so if you want to use the
-# same cluster for monitoring data, you can simply uncomment the following line.
+# Uncomment to send the metrics to Elasticsearch. Most settings from the
+# Elasticsearch output are accepted here as well. Any setting that is not set is
+# automatically inherited from the Elasticsearch output configuration, so if you
+# have the Elasticsearch output configured, you can simply uncomment the
+# following line, and leave the rest commented out.
 #xpack.monitoring.elasticsearch:
 
   # Array of hosts to connect to.
@@ -835,7 +837,7 @@ logging.files:
   # Configure http request timeout before failing an request to Elasticsearch.
   #timeout: 90
 
-  # Use SSL settings for HTTPS. Default is true.
+  # Use SSL settings for HTTPS.
   #ssl.enabled: true
 
   # Configure SSL verification mode. If `none` is configured, all server hosts

--- a/libbeat/_meta/config.yml
+++ b/libbeat/_meta/config.yml
@@ -101,8 +101,8 @@ output.elasticsearch:
 #xpack.monitoring.enabled: false
 
 # Uncomment to send the metrics to Elasticsearch. Most settings from the
-# elasticsearch output are accepted here as well. Any setting that is not set is
-# automatically inherited from the output configuration, so if you want to use
-# the same cluster for monitoring data, you can simply uncomment the following
-# line.
+# Elasticsearch output are accepted here as well. Any setting that is not set is
+# automatically inherited from the Elasticsearch output configuration, so if you
+# have the Elasticsearch output configured, you can simply uncomment the
+# following line.
 #xpack.monitoring.elasticsearch:

--- a/libbeat/_meta/config.yml
+++ b/libbeat/_meta/config.yml
@@ -91,3 +91,18 @@ output.elasticsearch:
 # To enable all selectors use ["*"]. Examples of other selectors are "beat",
 # "publish", "service".
 #logging.selectors: ["*"]
+
+#============================== Xpack Monitoring ===============================
+# beatname can export internal metrics to a central Elasticsearch monitoring
+# cluster.  This requires xpack monitoring to be enabled in Elasticsearch.  The
+# reporting is disabled by default.
+
+# Set to true to enable the monitoring reporter.
+#xpack.monitoring.enabled: false
+
+# Uncomment to send the metrics to Elasticsearch. Most settings from the
+# elasticsearch output are accepted here as well. Any setting that is not set is
+# automatically inherited from the output configuration, so if you want to use
+# the same cluster for monitoring data, you can simply uncomment the following
+# line.
+#xpack.monitoring.elasticsearch:

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -1273,6 +1273,93 @@ logging.files:
 #logging.json: false
 
 
+#============================== Xpack Monitoring =====================================
+# metricbeat can export internal metrics to a central Elasticsearch monitoring cluster.
+# This requires xpack monitoring to be enabled in Elasticsearch.
+# The reporting is disabled by default.
+
+# Set to true to enable the monitoring reporter.
+#xpack.monitoring.enabled: false
+
+# Uncomment to send the metrics to Elasticsearch. Any setting that is not set is
+# automatically inherited from the output configuration, so if you want to use the
+# same cluster for monitoring data, you can simply uncomment the following line.
+#xpack.monitoring.elasticsearch:
+
+  # Array of hosts to connect to.
+  # Scheme and port can be left out and will be set to the default (http and 9200)
+  # In case you specify and additional path, the scheme is required: http://localhost:9200/path
+  # IPv6 addresses should always be defined as: https://[2001:db8::1]:9200
+  #hosts: ["localhost:9200"]
+
+  # Set gzip compression level.
+  #compression_level: 0
+
+  # Optional protocol and basic auth credentials.
+  #protocol: "https"
+  #username: "beats_system"
+  #password: "changeme"
+
+  # Dictionary of HTTP parameters to pass within the url with index operations.
+  #parameters:
+    #param1: value1
+    #param2: value2
+
+  # Custom HTTP headers to add to each request
+  #headers:
+  #  X-My-Header: Contents of the header
+
+  # Proxy server url
+  #proxy_url: http://proxy:3128
+
+  # The number of times a particular Elasticsearch index operation is attempted. If
+  # the indexing operation doesn't succeed after this many retries, the events are
+  # dropped. The default is 3.
+  #max_retries: 3
+
+  # The maximum number of events to bulk in a single Elasticsearch bulk API index request.
+  # The default is 50.
+  #bulk_max_size: 50
+
+  # Configure http request timeout before failing an request to Elasticsearch.
+  #timeout: 90
+
+  # Use SSL settings for HTTPS. Default is true.
+  #ssl.enabled: true
+
+  # Configure SSL verification mode. If `none` is configured, all server hosts
+  # and certificates will be accepted. In this mode, SSL based connections are
+  # susceptible to man-in-the-middle attacks. Use only for testing. Default is
+  # `full`.
+  #ssl.verification_mode: full
+
+  # List of supported/valid TLS versions. By default all TLS versions 1.0 up to
+  # 1.2 are enabled.
+  #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
+
+  # SSL configuration. By default is off.
+  # List of root certificates for HTTPS server verifications
+  #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
+
+  # Certificate for SSL client authentication
+  #ssl.certificate: "/etc/pki/client/cert.pem"
+
+  # Client Certificate Key
+  #ssl.key: "/etc/pki/client/cert.key"
+
+  # Optional passphrase for decrypting the Certificate Key.
+  #ssl.key_passphrase: ''
+
+  # Configure cipher suites to be used for SSL connections
+  #ssl.cipher_suites: []
+
+  # Configure curve types for ECDHE based cipher suites
+  #ssl.curve_types: []
+
+  # Configure what types of renegotiation are supported. Valid options are
+  # never, once, and freely. Default is never.
+  #ssl.renegotiation: never
+
 #================================ HTTP Endpoint ======================================
 # Each beat can expose internal metrics through a HTTP endpoint. For security
 # reasons the endpoint is disabled by default. This feature is currently experimental.

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -677,7 +677,7 @@ output.elasticsearch:
   # Configure http request timeout before failing an request to Elasticsearch.
   #timeout: 90
 
-  # Use SSL settings for HTTPS. Default is true.
+  # Use SSL settings for HTTPS.
   #ssl.enabled: true
 
   # Configure SSL verification mode. If `none` is configured, all server hosts
@@ -1281,9 +1281,11 @@ logging.files:
 # Set to true to enable the monitoring reporter.
 #xpack.monitoring.enabled: false
 
-# Uncomment to send the metrics to Elasticsearch. Any setting that is not set is
-# automatically inherited from the output configuration, so if you want to use the
-# same cluster for monitoring data, you can simply uncomment the following line.
+# Uncomment to send the metrics to Elasticsearch. Most settings from the
+# Elasticsearch output are accepted here as well. Any setting that is not set is
+# automatically inherited from the Elasticsearch output configuration, so if you
+# have the Elasticsearch output configured, you can simply uncomment the
+# following line, and leave the rest commented out.
 #xpack.monitoring.elasticsearch:
 
   # Array of hosts to connect to.
@@ -1324,7 +1326,7 @@ logging.files:
   # Configure http request timeout before failing an request to Elasticsearch.
   #timeout: 90
 
-  # Use SSL settings for HTTPS. Default is true.
+  # Use SSL settings for HTTPS.
   #ssl.enabled: true
 
   # Configure SSL verification mode. If `none` is configured, all server hosts

--- a/metricbeat/metricbeat.yml
+++ b/metricbeat/metricbeat.yml
@@ -128,8 +128,8 @@ output.elasticsearch:
 #xpack.monitoring.enabled: false
 
 # Uncomment to send the metrics to Elasticsearch. Most settings from the
-# elasticsearch output are accepted here as well. Any setting that is not set is
-# automatically inherited from the output configuration, so if you want to use
-# the same cluster for monitoring data, you can simply uncomment the following
-# line.
+# Elasticsearch output are accepted here as well. Any setting that is not set is
+# automatically inherited from the Elasticsearch output configuration, so if you
+# have the Elasticsearch output configured, you can simply uncomment the
+# following line.
 #xpack.monitoring.elasticsearch:

--- a/metricbeat/metricbeat.yml
+++ b/metricbeat/metricbeat.yml
@@ -118,3 +118,18 @@ output.elasticsearch:
 # To enable all selectors use ["*"]. Examples of other selectors are "beat",
 # "publish", "service".
 #logging.selectors: ["*"]
+
+#============================== Xpack Monitoring ===============================
+# metricbeat can export internal metrics to a central Elasticsearch monitoring
+# cluster.  This requires xpack monitoring to be enabled in Elasticsearch.  The
+# reporting is disabled by default.
+
+# Set to true to enable the monitoring reporter.
+#xpack.monitoring.enabled: false
+
+# Uncomment to send the metrics to Elasticsearch. Most settings from the
+# elasticsearch output are accepted here as well. Any setting that is not set is
+# automatically inherited from the output configuration, so if you want to use
+# the same cluster for monitoring data, you can simply uncomment the following
+# line.
+#xpack.monitoring.elasticsearch:

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -656,7 +656,7 @@ output.elasticsearch:
   # Configure http request timeout before failing an request to Elasticsearch.
   #timeout: 90
 
-  # Use SSL settings for HTTPS. Default is true.
+  # Use SSL settings for HTTPS.
   #ssl.enabled: true
 
   # Configure SSL verification mode. If `none` is configured, all server hosts
@@ -1260,9 +1260,11 @@ logging.files:
 # Set to true to enable the monitoring reporter.
 #xpack.monitoring.enabled: false
 
-# Uncomment to send the metrics to Elasticsearch. Any setting that is not set is
-# automatically inherited from the output configuration, so if you want to use the
-# same cluster for monitoring data, you can simply uncomment the following line.
+# Uncomment to send the metrics to Elasticsearch. Most settings from the
+# Elasticsearch output are accepted here as well. Any setting that is not set is
+# automatically inherited from the Elasticsearch output configuration, so if you
+# have the Elasticsearch output configured, you can simply uncomment the
+# following line, and leave the rest commented out.
 #xpack.monitoring.elasticsearch:
 
   # Array of hosts to connect to.
@@ -1303,7 +1305,7 @@ logging.files:
   # Configure http request timeout before failing an request to Elasticsearch.
   #timeout: 90
 
-  # Use SSL settings for HTTPS. Default is true.
+  # Use SSL settings for HTTPS.
   #ssl.enabled: true
 
   # Configure SSL verification mode. If `none` is configured, all server hosts

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -1252,6 +1252,93 @@ logging.files:
 #logging.json: false
 
 
+#============================== Xpack Monitoring =====================================
+# packetbeat can export internal metrics to a central Elasticsearch monitoring cluster.
+# This requires xpack monitoring to be enabled in Elasticsearch.
+# The reporting is disabled by default.
+
+# Set to true to enable the monitoring reporter.
+#xpack.monitoring.enabled: false
+
+# Uncomment to send the metrics to Elasticsearch. Any setting that is not set is
+# automatically inherited from the output configuration, so if you want to use the
+# same cluster for monitoring data, you can simply uncomment the following line.
+#xpack.monitoring.elasticsearch:
+
+  # Array of hosts to connect to.
+  # Scheme and port can be left out and will be set to the default (http and 9200)
+  # In case you specify and additional path, the scheme is required: http://localhost:9200/path
+  # IPv6 addresses should always be defined as: https://[2001:db8::1]:9200
+  #hosts: ["localhost:9200"]
+
+  # Set gzip compression level.
+  #compression_level: 0
+
+  # Optional protocol and basic auth credentials.
+  #protocol: "https"
+  #username: "beats_system"
+  #password: "changeme"
+
+  # Dictionary of HTTP parameters to pass within the url with index operations.
+  #parameters:
+    #param1: value1
+    #param2: value2
+
+  # Custom HTTP headers to add to each request
+  #headers:
+  #  X-My-Header: Contents of the header
+
+  # Proxy server url
+  #proxy_url: http://proxy:3128
+
+  # The number of times a particular Elasticsearch index operation is attempted. If
+  # the indexing operation doesn't succeed after this many retries, the events are
+  # dropped. The default is 3.
+  #max_retries: 3
+
+  # The maximum number of events to bulk in a single Elasticsearch bulk API index request.
+  # The default is 50.
+  #bulk_max_size: 50
+
+  # Configure http request timeout before failing an request to Elasticsearch.
+  #timeout: 90
+
+  # Use SSL settings for HTTPS. Default is true.
+  #ssl.enabled: true
+
+  # Configure SSL verification mode. If `none` is configured, all server hosts
+  # and certificates will be accepted. In this mode, SSL based connections are
+  # susceptible to man-in-the-middle attacks. Use only for testing. Default is
+  # `full`.
+  #ssl.verification_mode: full
+
+  # List of supported/valid TLS versions. By default all TLS versions 1.0 up to
+  # 1.2 are enabled.
+  #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
+
+  # SSL configuration. By default is off.
+  # List of root certificates for HTTPS server verifications
+  #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
+
+  # Certificate for SSL client authentication
+  #ssl.certificate: "/etc/pki/client/cert.pem"
+
+  # Client Certificate Key
+  #ssl.key: "/etc/pki/client/cert.key"
+
+  # Optional passphrase for decrypting the Certificate Key.
+  #ssl.key_passphrase: ''
+
+  # Configure cipher suites to be used for SSL connections
+  #ssl.cipher_suites: []
+
+  # Configure curve types for ECDHE based cipher suites
+  #ssl.curve_types: []
+
+  # Configure what types of renegotiation are supported. Valid options are
+  # never, once, and freely. Default is never.
+  #ssl.renegotiation: never
+
 #================================ HTTP Endpoint ======================================
 # Each beat can expose internal metrics through a HTTP endpoint. For security
 # reasons the endpoint is disabled by default. This feature is currently experimental.

--- a/packetbeat/packetbeat.yml
+++ b/packetbeat/packetbeat.yml
@@ -207,8 +207,8 @@ output.elasticsearch:
 #xpack.monitoring.enabled: false
 
 # Uncomment to send the metrics to Elasticsearch. Most settings from the
-# elasticsearch output are accepted here as well. Any setting that is not set is
-# automatically inherited from the output configuration, so if you want to use
-# the same cluster for monitoring data, you can simply uncomment the following
-# line.
+# Elasticsearch output are accepted here as well. Any setting that is not set is
+# automatically inherited from the Elasticsearch output configuration, so if you
+# have the Elasticsearch output configured, you can simply uncomment the
+# following line.
 #xpack.monitoring.elasticsearch:

--- a/packetbeat/packetbeat.yml
+++ b/packetbeat/packetbeat.yml
@@ -197,3 +197,18 @@ output.elasticsearch:
 # To enable all selectors use ["*"]. Examples of other selectors are "beat",
 # "publish", "service".
 #logging.selectors: ["*"]
+
+#============================== Xpack Monitoring ===============================
+# packetbeat can export internal metrics to a central Elasticsearch monitoring
+# cluster.  This requires xpack monitoring to be enabled in Elasticsearch.  The
+# reporting is disabled by default.
+
+# Set to true to enable the monitoring reporter.
+#xpack.monitoring.enabled: false
+
+# Uncomment to send the metrics to Elasticsearch. Most settings from the
+# elasticsearch output are accepted here as well. Any setting that is not set is
+# automatically inherited from the output configuration, so if you want to use
+# the same cluster for monitoring data, you can simply uncomment the following
+# line.
+#xpack.monitoring.elasticsearch:

--- a/testing/environments/args.yml
+++ b/testing/environments/args.yml
@@ -7,4 +7,4 @@ services:
       args:
         DOWNLOAD_URL: https://snapshots.elastic.co/downloads
         ELASTIC_VERSION: 7.0.0-alpha1-SNAPSHOT
-        CACHE_BUST: 20180103
+        CACHE_BUST: 20180104

--- a/winlogbeat/winlogbeat.reference.yml
+++ b/winlogbeat/winlogbeat.reference.yml
@@ -217,7 +217,7 @@ output.elasticsearch:
   # Configure http request timeout before failing an request to Elasticsearch.
   #timeout: 90
 
-  # Use SSL settings for HTTPS. Default is true.
+  # Use SSL settings for HTTPS.
   #ssl.enabled: true
 
   # Configure SSL verification mode. If `none` is configured, all server hosts
@@ -821,9 +821,11 @@ logging.files:
 # Set to true to enable the monitoring reporter.
 #xpack.monitoring.enabled: false
 
-# Uncomment to send the metrics to Elasticsearch. Any setting that is not set is
-# automatically inherited from the output configuration, so if you want to use the
-# same cluster for monitoring data, you can simply uncomment the following line.
+# Uncomment to send the metrics to Elasticsearch. Most settings from the
+# Elasticsearch output are accepted here as well. Any setting that is not set is
+# automatically inherited from the Elasticsearch output configuration, so if you
+# have the Elasticsearch output configured, you can simply uncomment the
+# following line, and leave the rest commented out.
 #xpack.monitoring.elasticsearch:
 
   # Array of hosts to connect to.
@@ -864,7 +866,7 @@ logging.files:
   # Configure http request timeout before failing an request to Elasticsearch.
   #timeout: 90
 
-  # Use SSL settings for HTTPS. Default is true.
+  # Use SSL settings for HTTPS.
   #ssl.enabled: true
 
   # Configure SSL verification mode. If `none` is configured, all server hosts

--- a/winlogbeat/winlogbeat.reference.yml
+++ b/winlogbeat/winlogbeat.reference.yml
@@ -813,6 +813,93 @@ logging.files:
 #logging.json: false
 
 
+#============================== Xpack Monitoring =====================================
+# winlogbeat can export internal metrics to a central Elasticsearch monitoring cluster.
+# This requires xpack monitoring to be enabled in Elasticsearch.
+# The reporting is disabled by default.
+
+# Set to true to enable the monitoring reporter.
+#xpack.monitoring.enabled: false
+
+# Uncomment to send the metrics to Elasticsearch. Any setting that is not set is
+# automatically inherited from the output configuration, so if you want to use the
+# same cluster for monitoring data, you can simply uncomment the following line.
+#xpack.monitoring.elasticsearch:
+
+  # Array of hosts to connect to.
+  # Scheme and port can be left out and will be set to the default (http and 9200)
+  # In case you specify and additional path, the scheme is required: http://localhost:9200/path
+  # IPv6 addresses should always be defined as: https://[2001:db8::1]:9200
+  #hosts: ["localhost:9200"]
+
+  # Set gzip compression level.
+  #compression_level: 0
+
+  # Optional protocol and basic auth credentials.
+  #protocol: "https"
+  #username: "beats_system"
+  #password: "changeme"
+
+  # Dictionary of HTTP parameters to pass within the url with index operations.
+  #parameters:
+    #param1: value1
+    #param2: value2
+
+  # Custom HTTP headers to add to each request
+  #headers:
+  #  X-My-Header: Contents of the header
+
+  # Proxy server url
+  #proxy_url: http://proxy:3128
+
+  # The number of times a particular Elasticsearch index operation is attempted. If
+  # the indexing operation doesn't succeed after this many retries, the events are
+  # dropped. The default is 3.
+  #max_retries: 3
+
+  # The maximum number of events to bulk in a single Elasticsearch bulk API index request.
+  # The default is 50.
+  #bulk_max_size: 50
+
+  # Configure http request timeout before failing an request to Elasticsearch.
+  #timeout: 90
+
+  # Use SSL settings for HTTPS. Default is true.
+  #ssl.enabled: true
+
+  # Configure SSL verification mode. If `none` is configured, all server hosts
+  # and certificates will be accepted. In this mode, SSL based connections are
+  # susceptible to man-in-the-middle attacks. Use only for testing. Default is
+  # `full`.
+  #ssl.verification_mode: full
+
+  # List of supported/valid TLS versions. By default all TLS versions 1.0 up to
+  # 1.2 are enabled.
+  #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
+
+  # SSL configuration. By default is off.
+  # List of root certificates for HTTPS server verifications
+  #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
+
+  # Certificate for SSL client authentication
+  #ssl.certificate: "/etc/pki/client/cert.pem"
+
+  # Client Certificate Key
+  #ssl.key: "/etc/pki/client/cert.key"
+
+  # Optional passphrase for decrypting the Certificate Key.
+  #ssl.key_passphrase: ''
+
+  # Configure cipher suites to be used for SSL connections
+  #ssl.cipher_suites: []
+
+  # Configure curve types for ECDHE based cipher suites
+  #ssl.curve_types: []
+
+  # Configure what types of renegotiation are supported. Valid options are
+  # never, once, and freely. Default is never.
+  #ssl.renegotiation: never
+
 #================================ HTTP Endpoint ======================================
 # Each beat can expose internal metrics through a HTTP endpoint. For security
 # reasons the endpoint is disabled by default. This feature is currently experimental.

--- a/winlogbeat/winlogbeat.yml
+++ b/winlogbeat/winlogbeat.yml
@@ -122,3 +122,18 @@ output.elasticsearch:
 # To enable all selectors use ["*"]. Examples of other selectors are "beat",
 # "publish", "service".
 #logging.selectors: ["*"]
+
+#============================== Xpack Monitoring ===============================
+# winlogbeat can export internal metrics to a central Elasticsearch monitoring
+# cluster.  This requires xpack monitoring to be enabled in Elasticsearch.  The
+# reporting is disabled by default.
+
+# Set to true to enable the monitoring reporter.
+#xpack.monitoring.enabled: false
+
+# Uncomment to send the metrics to Elasticsearch. Most settings from the
+# elasticsearch output are accepted here as well. Any setting that is not set is
+# automatically inherited from the output configuration, so if you want to use
+# the same cluster for monitoring data, you can simply uncomment the following
+# line.
+#xpack.monitoring.elasticsearch:

--- a/winlogbeat/winlogbeat.yml
+++ b/winlogbeat/winlogbeat.yml
@@ -132,8 +132,8 @@ output.elasticsearch:
 #xpack.monitoring.enabled: false
 
 # Uncomment to send the metrics to Elasticsearch. Most settings from the
-# elasticsearch output are accepted here as well. Any setting that is not set is
-# automatically inherited from the output configuration, so if you want to use
-# the same cluster for monitoring data, you can simply uncomment the following
-# line.
+# Elasticsearch output are accepted here as well. Any setting that is not set is
+# automatically inherited from the Elasticsearch output configuration, so if you
+# have the Elasticsearch output configured, you can simply uncomment the
+# following line.
 #xpack.monitoring.elasticsearch:


### PR DESCRIPTION
Note that monitoring is disabled by default in Beats.

Related to #6235.