### PR TITLE
Print unknown MongoDB opcodes

### DIFF
--- a/packetbeat/protos/mongodb/mongodb_structs.go
+++ b/packetbeat/protos/mongodb/mongodb_structs.go
@@ -2,6 +2,7 @@ package mongodb
 
 // Represent a mongodb message being parsed
 import (
+	"fmt"
 	"time"
 
 	"github.com/elastic/beats/libbeat/common"
@@ -113,7 +114,10 @@ func validOpcode(o opCode) bool {
 }
 
 func (o opCode) String() string {
-	return opCodeNames[o]
+	if name, found := opCodeNames[o]; found {
+		return name
+	}
+	return fmt.Sprintf("(value=%d)", int32(o))
 }
 
 func awaitsReply(c opCode) bool {

--- a/packetbeat/protos/mongodb/mongodb_test.go
+++ b/packetbeat/protos/mongodb/mongodb_test.go
@@ -333,3 +333,15 @@ func TestMaxDocSize(t *testing.T) {
 
 	assert.Equal(t, "\"1234 ...\n\"123\"\n\"12\"", res["response"])
 }
+
+func TestOpCodeNames(t *testing.T) {
+	for _, testData := range []struct {
+		code     int32
+		expected string
+	}{
+		{1, "OP_REPLY"},
+		{-1, "(value=-1)"},
+	} {
+		assert.Equal(t, testData.expected, opCode(testData.code).String())
+	}
+}


### PR DESCRIPTION
When packetbeat encounters an unknown opcode it will print its value as a decimal integer instead of an empty string. Otherwise, it prints the following line in the log:

`2018/01/26 06:30:01.311175 mongodb_parser.go:42: ERR Unknown operation code:`

which is not very helpful. It has been changed to:

`2018/01/26 06:30:01.311175 mongodb_parser.go:42: ERR Unknown operation code: (value=nnn)`

Related to #6191 