### PR TITLE
Fix out of bounds access to slice in MongoDB parser

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -140,6 +140,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Fix mysql SQL parser to trim `\r` from Windows Server `SELECT\r\n\t1`. {pull}5572[5572]
 - Fix corruption when parsing repeated headers in an HTTP request or response. {pull}6325[6325]
 - Fix panic when parsing partial AMQP messages. {pull}6384[6384]
+- Fix out of bounds access to slice in MongoDB parser. {pull}6256[6256]
 
 *Winlogbeat*
 

--- a/packetbeat/protos/mongodb/mongodb_parser.go
+++ b/packetbeat/protos/mongodb/mongodb_parser.go
@@ -341,6 +341,9 @@ func (d *decoder) readDocument() (bson.M, error) {
 	start := d.i
 	documentLength, err := d.readInt32()
 	d.i = start + documentLength
+	if len(d.in) < d.i {
+		return nil, errors.New("document out of bounds")
+	}
 
 	documentMap := bson.M{}
 


### PR DESCRIPTION
Ignore MongoDB message and drop the TCP stream if a malformed query / response is received, instead of logging a panic.

Closes #5188