### PR TITLE
Feature: TCP Input

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -49,6 +49,8 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
   the system test. {pull}6121[6121]
 - Add IIS module to parse access log and error log. {pull}6127[6127]
 - Remove the undefined `username` option from the Redis input and clarify the documentation. {pull}6662[6662]
+- Refactor the usage of prospector to input in the YAML reference {pull}6121[6121]
+- Addition of the TCP input {pull}6266[6266]
 
 *Heartbeat*
 

--- a/filebeat/_meta/common.reference.p2.yml
+++ b/filebeat/_meta/common.reference.p2.yml
@@ -240,6 +240,20 @@ filebeat.inputs:
   # Maximum size of the message received over UDP
   #max_message_size: 10240
 
+#------------------------------ TCP prospector --------------------------------
+# Experimental: Config options for the TCP input
+#- type: tcp
+  #enabled: false
+
+  # The host and port to receive the new event
+  #host: "localhost:9000"
+
+  # Character used to split new message
+  #line_delimiter: "\n"
+
+  # Maximum size in bytes of the message received over TCP
+  #max_message_size: 20971520
+
 #========================== Filebeat autodiscover ==============================
 
 # Autodiscover allows you to detect changes in the system and spawn new modules

--- a/filebeat/docs/filebeat-options.asciidoc
+++ b/filebeat/docs/filebeat-options.asciidoc
@@ -14,7 +14,7 @@ and configuring modules.
 To configure {beatname_uc} manually (instead of using
 <<{beatname_lc}-modules-overview,modules>>), you specify a list of inputs in the
 +{beatname_lc}.inputs+ section of the +{beatname_lc}.yml+. Inputs specify how
-{beatname_uc} locates and processes input data.  
+{beatname_uc} locates and processes input data.
 
 The list is a http://yaml.org/[YAML] array, so each input begins with
 a dash (`-`). You can specify multiple inputs, and you can specify the same
@@ -47,6 +47,7 @@ You can configure {beatname_uc} to use the following inputs:
 * <<{beatname_lc}-input-redis>>
 * <<{beatname_lc}-input-udp>>
 * <<{beatname_lc}-input-docker>>
+* <<{beatname_lc}-input-tcp>>
 
 
 
@@ -59,3 +60,5 @@ include::inputs/input-redis.asciidoc[]
 include::inputs/input-udp.asciidoc[]
 
 include::inputs/input-docker.asciidoc[]
+
+include::inputs/input-tcp.asciidoc[]

--- a/filebeat/docs/inputs/input-tcp.asciidoc
+++ b/filebeat/docs/inputs/input-tcp.asciidoc
@@ -1,0 +1,55 @@
+:type: tcp
+
+[id="{beatname_lc}-input-{type}"]
+=== TCP input
+
+++++
+<titleabbrev>TCP</titleabbrev>
+++++
+
+Use the `TCP` input to read events over TCP.
+
+Example configuration:
+
+["source","yaml",subs="attributes"]
+----
+{beatname_lc}.inputs:
+- type: tcp
+  max_message_size: 10240
+  host: "localhost:9000"
+----
+
+
+==== Configuration options
+
+The `tcp` input supports the following configuration options plus the
+<<{beatname_lc}-input-{type}-common-options>> described later.
+
+[float]
+[id="{beatname_lc}-input-{type}-max-message-size"]
+==== `max_message_size`
+
+The maximum size of the message received over TCP. The default is `20971520`.
+
+[float]
+[id="{beatname_lc}-input-{type}-host"]
+==== `host`
+
+The host and TCP port to listen on for event streams.
+
+[float]
+[id="{beatname_lc}-input-{type}-line-delimiter"]
+==== `line_delimiter`
+
+Specify the characters used to split the incoming events. The default is '\n'.
+
+[float]
+[id="{beatname_lc}-input-{type}-timeout"]
+==== `timeout`
+
+The number of seconds of inactivity before a remote connection is closed. The default is `300`.
+
+[id="{beatname_lc}-input-{type}-common-options"]
+include::../inputs/input-common-options.asciidoc[]
+
+:type!:

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -535,6 +535,20 @@ filebeat.inputs:
   # Maximum size of the message received over UDP
   #max_message_size: 10240
 
+#------------------------------ TCP prospector --------------------------------
+# Experimental: Config options for the TCP input
+#- type: tcp
+  #enabled: false
+
+  # The host and port to receive the new event
+  #host: "localhost:9000"
+
+  # Character used to split new message
+  #line_delimiter: "\n"
+
+  # Maximum size in bytes of the message received over TCP
+  #max_message_size: 20971520
+
 #========================== Filebeat autodiscover ==============================
 
 # Autodiscover allows you to detect changes in the system and spawn new modules

--- a/filebeat/include/list.go
+++ b/filebeat/include/list.go
@@ -12,5 +12,6 @@ import (
 	_ "github.com/elastic/beats/filebeat/input/log"
 	_ "github.com/elastic/beats/filebeat/input/redis"
 	_ "github.com/elastic/beats/filebeat/input/stdin"
+	_ "github.com/elastic/beats/filebeat/input/tcp"
 	_ "github.com/elastic/beats/filebeat/input/udp"
 )

--- a/filebeat/input/tcp/client.go
+++ b/filebeat/input/tcp/client.go
@@ -43,7 +43,7 @@ func NewClient(
 		timeout:        timeout,
 		metadata: common.MapStr{
 			"hostnames":  remoteHosts(conn),
-			"ip_address": c.conn.RemoteAddr().String(),
+			"ip_address": conn.RemoteAddr().String(),
 		},
 	}
 

--- a/filebeat/input/tcp/client.go
+++ b/filebeat/input/tcp/client.go
@@ -1,0 +1,115 @@
+package tcp
+
+import (
+	"bufio"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+
+	"github.com/elastic/beats/filebeat/harvester"
+	"github.com/elastic/beats/filebeat/util"
+	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/logp"
+)
+
+// Client is a remote client.
+type Client struct {
+	conn           net.Conn
+	forwarder      *harvester.Forwarder
+	done           chan struct{}
+	metadata       common.MapStr
+	splitFunc      bufio.SplitFunc
+	maxReadMessage int64
+	timeout        time.Duration
+}
+
+// NewClient returns a new client instance for the remote connection.
+func NewClient(
+	conn net.Conn,
+	forwarder *harvester.Forwarder,
+	splitFunc bufio.SplitFunc,
+	maxReadMessage int64,
+	timeout time.Duration,
+) *Client {
+	client := &Client{
+		conn:           conn,
+		forwarder:      forwarder,
+		done:           make(chan struct{}),
+		splitFunc:      splitFunc,
+		maxReadMessage: maxReadMessage,
+		timeout:        timeout,
+	}
+	client.cacheMetadata()
+	return client
+}
+
+// Handle is reading message from the specified TCP socket.
+func (c *Client) Handle() error {
+	r := NewMeteredReader(NewDeadlineReader(c.conn, c.timeout), c.maxReadMessage)
+	buf := bufio.NewReader(r)
+	scanner := bufio.NewScanner(buf)
+	scanner.Split(c.splitFunc)
+
+	for scanner.Scan() {
+		if scanner.Err() != nil {
+			// we are forcing a close on the socket, lets ignore any error that could happen.
+			select {
+			case <-c.done:
+				break
+			default:
+			}
+			// This is a user defined limit and we should notify the user.
+			if IsMaxReadBufferErr(scanner.Err()) {
+				logp.Err("tcp client error: %s", scanner.Err())
+			}
+			return errors.Wrap(scanner.Err(), "tcp client error")
+		}
+		r.Reset()
+		c.forwarder.Send(c.createEvent(scanner.Text()))
+	}
+	return nil
+}
+
+// Close stops reading from the socket and close the connection.
+func (c *Client) Close() {
+	close(c.done)
+	c.conn.Close()
+}
+
+func (c *Client) createEvent(rawString string) *util.Data {
+	data := util.NewData()
+	data.Event = beat.Event{
+		Timestamp: time.Now(),
+		Meta:      c.metadata,
+		Fields: common.MapStr{
+			"message": rawString,
+		},
+	}
+	return data
+}
+
+// GetRemoteHosts take the IP address of the client and try to resolve the name, if it fails we
+// fallback to the IP, IP can resolve to multiple hostname.
+func (c *Client) getRemoteHosts() []string {
+	ip := c.conn.RemoteAddr().String()
+	idx := strings.Index(ip, ":")
+	if idx == -1 {
+		return []string{ip}
+	}
+	ip = ip[0:idx]
+	hosts, err := net.LookupAddr(ip)
+	if err != nil {
+		hosts = []string{ip}
+	}
+	return hosts
+}
+
+func (c *Client) cacheMetadata() {
+	c.metadata = common.MapStr{
+		"hostnames":  c.getRemoteHosts(),
+		"ip_address": c.conn.RemoteAddr().String(),
+	}
+}

--- a/filebeat/input/tcp/client.go
+++ b/filebeat/input/tcp/client.go
@@ -48,7 +48,7 @@ func NewClient(
 
 // Handle is reading message from the specified TCP socket.
 func (c *Client) Handle() error {
-	r := NewMeteredReader(NewDeadlineReader(c.conn, c.timeout), c.maxReadMessage)
+	r := NewResetableLimitedReader(NewDeadlineReader(c.conn, c.timeout), c.maxReadMessage)
 	buf := bufio.NewReader(r)
 	scanner := bufio.NewScanner(buf)
 	scanner.Split(c.splitFunc)

--- a/filebeat/input/tcp/client.go
+++ b/filebeat/input/tcp/client.go
@@ -41,8 +41,12 @@ func NewClient(
 		splitFunc:      splitFunc,
 		maxReadMessage: maxReadMessage,
 		timeout:        timeout,
+		metadata: common.MapStr{
+			"hostnames":  remoteHosts(conn),
+			"ip_address": c.conn.RemoteAddr().String(),
+		},
 	}
-	client.cacheMetadata()
+
 	return client
 }
 
@@ -94,8 +98,8 @@ func (c *Client) createEvent(rawString string) *util.Data {
 
 // GetRemoteHosts take the IP address of the client and try to resolve the name, if it fails we
 // fallback to the IP, IP can resolve to multiple hostname.
-func (c *Client) getRemoteHosts() []string {
-	ip := c.conn.RemoteAddr().String()
+func remoteHosts(conn net.Conn) []string {
+	ip := conn.RemoteAddr().String()
 	idx := strings.Index(ip, ":")
 	if idx == -1 {
 		return []string{ip}
@@ -106,11 +110,4 @@ func (c *Client) getRemoteHosts() []string {
 		hosts = []string{ip}
 	}
 	return hosts
-}
-
-func (c *Client) cacheMetadata() {
-	c.metadata = common.MapStr{
-		"hostnames":  c.getRemoteHosts(),
-		"ip_address": c.conn.RemoteAddr().String(),
-	}
 }

--- a/filebeat/input/tcp/config.go
+++ b/filebeat/input/tcp/config.go
@@ -1,0 +1,25 @@
+package tcp
+
+import (
+	"time"
+
+	"github.com/elastic/beats/filebeat/harvester"
+)
+
+type config struct {
+	harvester.ForwarderConfig `config:",inline"`
+	Host                      string        `config:"host"`
+	LineDelimiter             string        `config:"line_delimiter" validate:"nonzero"`
+	Timeout                   time.Duration `config:"timeout" validate:"nonzero,positive"`
+	MaxMessageSize            int64         `config:"max_message_size" validate:"nonzero,positive"`
+}
+
+var defaultConfig = config{
+	ForwarderConfig: harvester.ForwarderConfig{
+		Type: "tcp",
+	},
+	LineDelimiter:  "\n",
+	Host:           "localhost:9000",
+	Timeout:        time.Second * 5 * 60,
+	MaxMessageSize: 20 * 1024 * 1024,
+}

--- a/filebeat/input/tcp/config.go
+++ b/filebeat/input/tcp/config.go
@@ -20,6 +20,6 @@ var defaultConfig = config{
 	},
 	LineDelimiter:  "\n",
 	Host:           "localhost:9000",
-	Timeout:        time.Second * 5 * 60,
+	Timeout:        time.Minute * 5,
 	MaxMessageSize: 20 * 1024 * 1024,
 }

--- a/filebeat/input/tcp/config.go
+++ b/filebeat/input/tcp/config.go
@@ -11,7 +11,7 @@ type config struct {
 	Host                      string        `config:"host"`
 	LineDelimiter             string        `config:"line_delimiter" validate:"nonzero"`
 	Timeout                   time.Duration `config:"timeout" validate:"nonzero,positive"`
-	MaxMessageSize            int64         `config:"max_message_size" validate:"nonzero,positive"`
+	MaxMessageSize            uint64        `config:"max_message_size" validate:"nonzero,positive"`
 }
 
 var defaultConfig = config{

--- a/filebeat/input/tcp/config.go
+++ b/filebeat/input/tcp/config.go
@@ -8,7 +8,7 @@ import (
 
 type config struct {
 	harvester.ForwarderConfig `config:",inline"`
-	Host                      string        `config:"host"`
+	Host                      string        `config:"host" validate:"required"`
 	LineDelimiter             string        `config:"line_delimiter" validate:"nonzero"`
 	Timeout                   time.Duration `config:"timeout" validate:"nonzero,positive"`
 	MaxMessageSize            uint64        `config:"max_message_size" validate:"nonzero,positive"`
@@ -19,7 +19,6 @@ var defaultConfig = config{
 		Type: "tcp",
 	},
 	LineDelimiter:  "\n",
-	Host:           "localhost:9000",
 	Timeout:        time.Minute * 5,
 	MaxMessageSize: 20 * 1024 * 1024,
 }

--- a/filebeat/input/tcp/conn.go
+++ b/filebeat/input/tcp/conn.go
@@ -15,12 +15,12 @@ var ErrMaxReadBuffer = errors.New("max read buffer reached")
 // error when we reach the limit.
 type MeteredReader struct {
 	reader        io.Reader
-	maxReadBuffer int64
-	byteRead      int64
+	maxReadBuffer uint64
+	byteRead      uint64
 }
 
 // NewMeteredReader returns a new MeteredReader
-func NewMeteredReader(reader io.Reader, maxReadBuffer int64) *MeteredReader {
+func NewMeteredReader(reader io.Reader, maxReadBuffer uint64) *MeteredReader {
 	return &MeteredReader{
 		reader:        reader,
 		maxReadBuffer: maxReadBuffer,
@@ -33,7 +33,7 @@ func (m *MeteredReader) Read(p []byte) (n int, err error) {
 		return 0, ErrMaxReadBuffer
 	}
 	n, err = m.reader.Read(p)
-	m.byteRead += int64(n)
+	m.byteRead += uint64(n)
 	return
 }
 

--- a/filebeat/input/tcp/conn.go
+++ b/filebeat/input/tcp/conn.go
@@ -1,0 +1,72 @@
+package tcp
+
+import (
+	"io"
+	"net"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// ErrMaxReadBuffer returns when too many bytes was read on the io.Reader
+var ErrMaxReadBuffer = errors.New("max read buffer reached")
+
+// MeteredReader is based on LimitedReader but allow to reset the byte read and return a specific
+// error when we reach the limit.
+type MeteredReader struct {
+	reader        io.Reader
+	maxReadBuffer int64
+	byteRead      int64
+}
+
+// NewMeteredReader returns a new MeteredReader
+func NewMeteredReader(reader io.Reader, maxReadBuffer int64) *MeteredReader {
+	return &MeteredReader{
+		reader:        reader,
+		maxReadBuffer: maxReadBuffer,
+	}
+}
+
+// Read reads the specified amount of byte
+func (m *MeteredReader) Read(p []byte) (n int, err error) {
+	if m.byteRead >= m.maxReadBuffer {
+		return 0, ErrMaxReadBuffer
+	}
+	n, err = m.reader.Read(p)
+	m.byteRead += int64(n)
+	return
+}
+
+// Reset resets the number of byte read
+func (m *MeteredReader) Reset() {
+	m.byteRead = 0
+}
+
+// IsMaxReadBufferErr returns true when the error is ErrMaxReadBuffer
+func IsMaxReadBufferErr(err error) bool {
+	return err == ErrMaxReadBuffer
+}
+
+// DeadlineReader allow read to a io.Reader to timeout, the timeout is refreshed on every read.
+type DeadlineReader struct {
+	conn    net.Conn
+	timeout time.Duration
+}
+
+// NewDeadlineReader returns a new DeadlineReader
+func NewDeadlineReader(c net.Conn, timeout time.Duration) *DeadlineReader {
+	return &DeadlineReader{
+		conn:    c,
+		timeout: timeout,
+	}
+}
+
+// Read reads the number of bytes from the reader
+func (d *DeadlineReader) Read(p []byte) (n int, err error) {
+	d.refresh()
+	return d.conn.Read(p)
+}
+
+func (d *DeadlineReader) refresh() {
+	d.conn.SetDeadline(time.Now().Add(d.timeout))
+}

--- a/filebeat/input/tcp/conn.go
+++ b/filebeat/input/tcp/conn.go
@@ -11,24 +11,24 @@ import (
 // ErrMaxReadBuffer returns when too many bytes was read on the io.Reader
 var ErrMaxReadBuffer = errors.New("max read buffer reached")
 
-// MeteredReader is based on LimitedReader but allow to reset the byte read and return a specific
+// ResetableLimitedReader is based on LimitedReader but allow to reset the byte read and return a specific
 // error when we reach the limit.
-type MeteredReader struct {
+type ResetableLimitedReader struct {
 	reader        io.Reader
 	maxReadBuffer uint64
 	byteRead      uint64
 }
 
-// NewMeteredReader returns a new MeteredReader
-func NewMeteredReader(reader io.Reader, maxReadBuffer uint64) *MeteredReader {
-	return &MeteredReader{
+// NewResetableLimitedReader returns a new ResetableLimitedReader
+func NewResetableLimitedReader(reader io.Reader, maxReadBuffer uint64) *ResetableLimitedReader {
+	return &ResetableLimitedReader{
 		reader:        reader,
 		maxReadBuffer: maxReadBuffer,
 	}
 }
 
 // Read reads the specified amount of byte
-func (m *MeteredReader) Read(p []byte) (n int, err error) {
+func (m *ResetableLimitedReader) Read(p []byte) (n int, err error) {
 	if m.byteRead >= m.maxReadBuffer {
 		return 0, ErrMaxReadBuffer
 	}
@@ -38,7 +38,7 @@ func (m *MeteredReader) Read(p []byte) (n int, err error) {
 }
 
 // Reset resets the number of byte read
-func (m *MeteredReader) Reset() {
+func (m *ResetableLimitedReader) Reset() {
 	m.byteRead = 0
 }
 

--- a/filebeat/input/tcp/conn_test.go
+++ b/filebeat/input/tcp/conn_test.go
@@ -12,7 +12,7 @@ func TestMeteredReader(t *testing.T) {
 
 	t.Run("WhenMaxReadIsReachedInMultipleRead", func(t *testing.T) {
 		r := strings.NewReader(randomString(maxReadBuffer * 2))
-		m := NewMeteredReader(r, int64(maxReadBuffer))
+		m := NewMeteredReader(r, uint64(maxReadBuffer))
 		toRead := make([]byte, maxReadBuffer)
 		_, err := m.Read(toRead)
 		assert.NoError(t, err)
@@ -23,7 +23,7 @@ func TestMeteredReader(t *testing.T) {
 
 	t.Run("WhenMaxReadIsNotReached", func(t *testing.T) {
 		r := strings.NewReader(randomString(maxReadBuffer * 2))
-		m := NewMeteredReader(r, int64(maxReadBuffer))
+		m := NewMeteredReader(r, uint64(maxReadBuffer))
 		toRead := make([]byte, maxReadBuffer)
 		_, err := m.Read(toRead)
 		assert.NoError(t, err)
@@ -31,7 +31,7 @@ func TestMeteredReader(t *testing.T) {
 
 	t.Run("WhenResetIsCalled", func(t *testing.T) {
 		r := strings.NewReader(randomString(maxReadBuffer * 2))
-		m := NewMeteredReader(r, int64(maxReadBuffer))
+		m := NewMeteredReader(r, uint64(maxReadBuffer))
 		toRead := make([]byte, maxReadBuffer)
 		_, err := m.Read(toRead)
 		assert.NoError(t, err)

--- a/filebeat/input/tcp/conn_test.go
+++ b/filebeat/input/tcp/conn_test.go
@@ -7,12 +7,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestMeteredReader(t *testing.T) {
+func TestResetableLimitedReader(t *testing.T) {
 	maxReadBuffer := 400
 
 	t.Run("WhenMaxReadIsReachedInMultipleRead", func(t *testing.T) {
 		r := strings.NewReader(randomString(maxReadBuffer * 2))
-		m := NewMeteredReader(r, uint64(maxReadBuffer))
+		m := NewResetableLimitedReader(r, uint64(maxReadBuffer))
 		toRead := make([]byte, maxReadBuffer)
 		_, err := m.Read(toRead)
 		assert.NoError(t, err)
@@ -23,7 +23,7 @@ func TestMeteredReader(t *testing.T) {
 
 	t.Run("WhenMaxReadIsNotReached", func(t *testing.T) {
 		r := strings.NewReader(randomString(maxReadBuffer * 2))
-		m := NewMeteredReader(r, uint64(maxReadBuffer))
+		m := NewResetableLimitedReader(r, uint64(maxReadBuffer))
 		toRead := make([]byte, maxReadBuffer)
 		_, err := m.Read(toRead)
 		assert.NoError(t, err)
@@ -31,7 +31,7 @@ func TestMeteredReader(t *testing.T) {
 
 	t.Run("WhenResetIsCalled", func(t *testing.T) {
 		r := strings.NewReader(randomString(maxReadBuffer * 2))
-		m := NewMeteredReader(r, uint64(maxReadBuffer))
+		m := NewResetableLimitedReader(r, uint64(maxReadBuffer))
 		toRead := make([]byte, maxReadBuffer)
 		_, err := m.Read(toRead)
 		assert.NoError(t, err)

--- a/filebeat/input/tcp/conn_test.go
+++ b/filebeat/input/tcp/conn_test.go
@@ -1,0 +1,43 @@
+package tcp
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMeteredReader(t *testing.T) {
+	maxReadBuffer := 400
+
+	t.Run("WhenMaxReadIsReachedInMultipleRead", func(t *testing.T) {
+		r := strings.NewReader(randomString(maxReadBuffer * 2))
+		m := NewMeteredReader(r, int64(maxReadBuffer))
+		toRead := make([]byte, maxReadBuffer)
+		_, err := m.Read(toRead)
+		assert.NoError(t, err)
+		toRead = make([]byte, 300)
+		_, err = m.Read(toRead)
+		assert.Equal(t, ErrMaxReadBuffer, err)
+	})
+
+	t.Run("WhenMaxReadIsNotReached", func(t *testing.T) {
+		r := strings.NewReader(randomString(maxReadBuffer * 2))
+		m := NewMeteredReader(r, int64(maxReadBuffer))
+		toRead := make([]byte, maxReadBuffer)
+		_, err := m.Read(toRead)
+		assert.NoError(t, err)
+	})
+
+	t.Run("WhenResetIsCalled", func(t *testing.T) {
+		r := strings.NewReader(randomString(maxReadBuffer * 2))
+		m := NewMeteredReader(r, int64(maxReadBuffer))
+		toRead := make([]byte, maxReadBuffer)
+		_, err := m.Read(toRead)
+		assert.NoError(t, err)
+		m.Reset()
+		toRead = make([]byte, 300)
+		_, err = m.Read(toRead)
+		assert.NoError(t, err)
+	})
+}

--- a/filebeat/input/tcp/harvester.go
+++ b/filebeat/input/tcp/harvester.go
@@ -1,0 +1,157 @@
+package tcp
+
+import (
+	"bufio"
+	"bytes"
+	"net"
+	"sync"
+
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/logp"
+
+	"github.com/elastic/beats/filebeat/harvester"
+)
+
+// Harvester represent a TCP server
+type Harvester struct {
+	sync.RWMutex
+	forwarder *harvester.Forwarder
+	config    config
+	server    net.Listener
+	clients   map[*Client]struct{}
+	wg        sync.WaitGroup
+	done      chan struct{}
+	splitFunc bufio.SplitFunc
+}
+
+// NewHarvester creates a new harvester that will forward events
+func NewHarvester(
+	forwarder *harvester.Forwarder,
+	cfg *common.Config,
+) (*Harvester, error) {
+
+	config := defaultConfig
+	err := cfg.Unpack(&config)
+	if err != nil {
+		return nil, err
+	}
+
+	server, err := net.Listen("tcp", config.Host)
+	if err != nil {
+		return nil, err
+	}
+
+	sf := splitFunc([]byte(config.LineDelimiter))
+	return &Harvester{
+		config:    config,
+		forwarder: forwarder,
+		clients:   make(map[*Client]struct{}, 0),
+		done:      make(chan struct{}),
+		server:    server,
+		splitFunc: sf,
+	}, nil
+}
+
+// Run start and run a new TCP listener to receive new data
+func (h *Harvester) Run() error {
+	logp.Info("Started listening for incoming TCP connection on: %s:", h.config.Host)
+	for {
+		conn, err := h.server.Accept()
+		if err != nil {
+			select {
+			case <-h.done:
+				return nil
+			default:
+				logp.Debug("tcp", "Can not accept the connection", err)
+				continue
+			}
+		}
+
+		client := NewClient(
+			conn,
+			h.forwarder,
+			h.splitFunc,
+			h.config.MaxMessageSize,
+			h.config.Timeout,
+		)
+		logp.Debug(
+			"tcp",
+			"New client, remote: %s (total clients: %d)",
+			conn.RemoteAddr(),
+			h.clientsCount(),
+		)
+		h.wg.Add(1)
+		go func() {
+			defer conn.Close()
+
+			h.registerClient(client)
+			err := client.Handle()
+			if err != nil {
+				logp.Debug("tcp", "Client error", err)
+			}
+			h.unregisterClient(client)
+			logp.Debug(
+				"tcp",
+				"Client disconnected, remote: %s (total clients: %d)",
+				conn.RemoteAddr(),
+				h.clientsCount(),
+			)
+			h.wg.Done()
+		}()
+	}
+}
+
+// Stop stops accepting new incoming TCP connection and close any active clients
+func (h *Harvester) Stop() {
+	logp.Info("Stopping TCP harvester")
+	close(h.done)
+	h.server.Close()
+
+	logp.Debug("tcp", "Closing remote connections")
+	for _, client := range h.allClients() {
+		client.Close()
+	}
+	h.wg.Wait()
+	logp.Debug("tcp", "Remote connections closed")
+}
+
+func (h *Harvester) registerClient(client *Client) {
+	h.Lock()
+	defer h.Unlock()
+	h.clients[client] = struct{}{}
+}
+
+func (h *Harvester) unregisterClient(client *Client) {
+	h.Lock()
+	defer h.Unlock()
+	delete(h.clients, client)
+}
+
+func (h *Harvester) allClients() []*Client {
+	h.RLock()
+	defer h.RUnlock()
+	currentClients := make([]*Client, len(h.clients))
+	idx := 0
+	for client := range h.clients {
+		currentClients[idx] = client
+		idx++
+	}
+	return currentClients
+}
+
+func (h *Harvester) clientsCount() int {
+	h.RLock()
+	defer h.RUnlock()
+	return len(h.clients)
+}
+
+func splitFunc(lineDelimiter []byte) bufio.SplitFunc {
+	ld := []byte(lineDelimiter)
+	if bytes.Equal(ld, []byte("\n")) {
+		// This will work for most usecases and will also strip \r if present.
+		// CustomDelimiter, need to match completely and the delimiter will be completely removed from the
+		// returned byte slice
+		return bufio.ScanLines
+	}
+	return scanDelimiter(ld)
+}

--- a/filebeat/input/tcp/harvester.go
+++ b/filebeat/input/tcp/harvester.go
@@ -54,7 +54,7 @@ func NewHarvester(
 
 // Run start and run a new TCP listener to receive new data
 func (h *Harvester) Run() error {
-	logp.Info("Started listening for incoming TCP connection on: %s:", h.config.Host)
+	logp.Info("Started listening for incoming TCP connection on: %s", h.config.Host)
 	for {
 		conn, err := h.server.Accept()
 		if err != nil {
@@ -62,7 +62,7 @@ func (h *Harvester) Run() error {
 			case <-h.done:
 				return nil
 			default:
-				logp.Debug("tcp", "Can not accept the connection", err)
+				logp.Debug("tcp", "Can not accept the connection: %s", err)
 				continue
 			}
 		}
@@ -87,7 +87,7 @@ func (h *Harvester) Run() error {
 			h.registerClient(client)
 			err := client.Handle()
 			if err != nil {
-				logp.Debug("tcp", "Client error", err)
+				logp.Debug("tcp", "Client error: %s", err)
 			}
 			h.unregisterClient(client)
 			logp.Debug(

--- a/filebeat/input/tcp/harvester.go
+++ b/filebeat/input/tcp/harvester.go
@@ -75,21 +75,25 @@ func (h *Harvester) Run() error {
 		)
 		h.wg.Add(1)
 		go func() {
+			defer logp.Recover("recovering from a tcp client crash")
+
+			defer h.wg.Done()
 			defer conn.Close()
 
 			h.registerClient(client)
+			defer h.unregisterClient(client)
+
 			err := client.Handle()
 			if err != nil {
 				logp.Debug("tcp", "Client error: %s", err)
 			}
-			h.unregisterClient(client)
+
 			logp.Debug(
 				"tcp",
 				"Client disconnected, remote: %s (total clients: %d)",
 				conn.RemoteAddr(),
 				h.clientsCount(),
 			)
-			h.wg.Done()
 		}()
 	}
 }

--- a/filebeat/input/tcp/harvester.go
+++ b/filebeat/input/tcp/harvester.go
@@ -6,7 +6,6 @@ import (
 	"net"
 	"sync"
 
-	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 
 	"github.com/elastic/beats/filebeat/harvester"
@@ -16,7 +15,7 @@ import (
 type Harvester struct {
 	sync.RWMutex
 	forwarder *harvester.Forwarder
-	config    config
+	config    *config
 	server    net.Listener
 	clients   map[*Client]struct{}
 	wg        sync.WaitGroup
@@ -27,14 +26,8 @@ type Harvester struct {
 // NewHarvester creates a new harvester that will forward events
 func NewHarvester(
 	forwarder *harvester.Forwarder,
-	cfg *common.Config,
+	config *config,
 ) (*Harvester, error) {
-
-	config := defaultConfig
-	err := cfg.Unpack(&config)
-	if err != nil {
-		return nil, err
-	}
 
 	server, err := net.Listen("tcp", config.Host)
 	if err != nil {

--- a/filebeat/input/tcp/harvester_test.go
+++ b/filebeat/input/tcp/harvester_test.go
@@ -212,9 +212,12 @@ func TestReceiveNewEventsConcurrently(t *testing.T) {
 	defer close(ch)
 	to := newTestingOutlet(ch)
 	forwarder := harvester.NewForwarder(to)
-	cfg := common.NewConfig()
+	cfg, err := common.NewConfigFrom(map[string]interface{}{"host": "localhost:9000"})
+	if !assert.NoError(t, err) {
+		return
+	}
 	config := defaultConfig
-	err := cfg.Unpack(&config)
+	err = cfg.Unpack(&config)
 	if !assert.NoError(t, err) {
 		return
 	}

--- a/filebeat/input/tcp/harvester_test.go
+++ b/filebeat/input/tcp/harvester_test.go
@@ -52,8 +52,8 @@ func TestErrorOnEmptyLineDelimiter(t *testing.T) {
 	}
 
 	c, _ := common.NewConfigFrom(cfg)
-	forwarder := harvester.NewForwarder(nil)
-	_, err := NewHarvester(forwarder, c)
+	config := defaultConfig
+	err := c.Unpack(&config)
 	assert.Error(t, err)
 }
 
@@ -63,8 +63,16 @@ func TestOverrideHostAndPort(t *testing.T) {
 		"host": host,
 	}
 	c, _ := common.NewConfigFrom(cfg)
+	config := defaultConfig
+	err := c.Unpack(&config)
+	if !assert.NoError(t, err) {
+		return
+	}
 	forwarder := harvester.NewForwarder(nil)
-	harvester, err := NewHarvester(forwarder, c)
+	harvester, err := NewHarvester(forwarder, &config)
+	if !assert.NoError(t, err) {
+		return
+	}
 	defer harvester.Stop()
 	go func() {
 		err := harvester.Run()
@@ -83,7 +91,15 @@ func TestReceiveNewEventsConcurrently(t *testing.T) {
 	to := newTestingOutlet(ch)
 	forwarder := harvester.NewForwarder(to)
 	cfg := common.NewConfig()
-	harvester, err := NewHarvester(forwarder, cfg)
+	config := defaultConfig
+	err := cfg.Unpack(&config)
+	if !assert.NoError(t, err) {
+		return
+	}
+	harvester, err := NewHarvester(forwarder, &config)
+	if !assert.NoError(t, err) {
+		return
+	}
 	defer harvester.Stop()
 	if !assert.NoError(t, err) {
 		return
@@ -220,7 +236,12 @@ func TestReceiveEventsAndMetadata(t *testing.T) {
 			forwarder := harvester.NewForwarder(to)
 			test.cfg["host"] = fmt.Sprintf("localhost:%d", port)
 			cfg, _ := common.NewConfigFrom(test.cfg)
-			harvester, err := NewHarvester(forwarder, cfg)
+			config := defaultConfig
+			err := cfg.Unpack(&config)
+			if !assert.NoError(t, err) {
+				return
+			}
+			harvester, err := NewHarvester(forwarder, &config)
 			if !assert.NoError(t, err) {
 				return
 			}

--- a/filebeat/input/tcp/harvester_test.go
+++ b/filebeat/input/tcp/harvester_test.go
@@ -1,0 +1,266 @@
+package tcp
+
+import (
+	"fmt"
+	"math/rand"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/filebeat/harvester"
+	"github.com/elastic/beats/filebeat/util"
+	"github.com/elastic/beats/libbeat/common"
+)
+
+type testingOutlet struct {
+	ch chan *util.Data
+}
+
+func (o *testingOutlet) OnEvent(data *util.Data) bool {
+	o.ch <- data
+	return true
+}
+
+func newTestingOutlet(ch chan *util.Data) *testingOutlet {
+	return &testingOutlet{ch: ch}
+}
+
+// This could be extracted into testing utils and we could add some unicode chars to the charsets.
+func randomString(l int) string {
+	charsets := []byte("abcdefghijklmnopqrstuvwzyzABCDEFGHIJKLMNOPQRSTUVWZYZ0123456789")
+	message := make([]byte, l)
+	for i := range message {
+		message[i] = charsets[rand.Intn(len(charsets))]
+	}
+	return string(message)
+}
+
+func generateMessages(c int, l int) []string {
+	messages := make([]string, c)
+	for i := range messages {
+		messages[i] = randomString(l)
+	}
+	return messages
+}
+
+func TestErrorOnEmptyLineDelimiter(t *testing.T) {
+	cfg := map[string]interface{}{
+		"line_delimiter": "",
+	}
+
+	c, _ := common.NewConfigFrom(cfg)
+	forwarder := harvester.NewForwarder(nil)
+	_, err := NewHarvester(forwarder, c)
+	assert.Error(t, err)
+}
+
+func TestOverrideHostAndPort(t *testing.T) {
+	host := "127.0.0.1:10000"
+	cfg := map[string]interface{}{
+		"host": host,
+	}
+	c, _ := common.NewConfigFrom(cfg)
+	forwarder := harvester.NewForwarder(nil)
+	harvester, err := NewHarvester(forwarder, c)
+	defer harvester.Stop()
+	go func() {
+		err := harvester.Run()
+		assert.NoError(t, err)
+	}()
+	conn, err := net.Dial("tcp", host)
+	defer conn.Close()
+	assert.NoError(t, err)
+}
+
+func TestReceiveNewEventsConcurrently(t *testing.T) {
+	workers := 4
+	eventsCount := 100
+	ch := make(chan *util.Data, eventsCount*workers)
+	defer close(ch)
+	to := newTestingOutlet(ch)
+	forwarder := harvester.NewForwarder(to)
+	cfg := common.NewConfig()
+	harvester, err := NewHarvester(forwarder, cfg)
+	defer harvester.Stop()
+	if !assert.NoError(t, err) {
+		return
+	}
+	go func() {
+		err := harvester.Run()
+		assert.NoError(t, err)
+	}()
+
+	samples := generateMessages(eventsCount, 1024)
+	for w := 0; w < workers; w++ {
+		go func() {
+			conn, err := net.Dial("tcp", "localhost:9000")
+			defer conn.Close()
+			assert.NoError(t, err)
+			for _, sample := range samples {
+				fmt.Fprintln(conn, sample)
+			}
+		}()
+	}
+
+	var events []*util.Data
+	for len(events) < eventsCount*workers {
+		select {
+		case event := <-ch:
+			events = append(events, event)
+		case <-time.After(time.Second * 10):
+			t.Fatal("timeout when waiting on channel")
+			return
+		}
+	}
+}
+
+func TestReceiveEventsAndMetadata(t *testing.T) {
+	expectedMessages := generateMessages(5, 100)
+	largeMessages := generateMessages(10, 4096)
+
+	tests := []struct {
+		name             string
+		cfg              map[string]interface{}
+		expectedMessages []string
+		messageSent      string
+	}{
+		{
+			name:             "NewLine",
+			cfg:              map[string]interface{}{},
+			expectedMessages: expectedMessages,
+			messageSent:      strings.Join(expectedMessages, "\n"),
+		},
+		{
+			name:             "NewLineWithCR",
+			cfg:              map[string]interface{}{},
+			expectedMessages: expectedMessages,
+			messageSent:      strings.Join(expectedMessages, "\r\n"),
+		},
+		{
+			name: "CustomDelimiter",
+			cfg: map[string]interface{}{
+				"line_delimiter": ";",
+			},
+			expectedMessages: expectedMessages,
+			messageSent:      strings.Join(expectedMessages, ";"),
+		},
+		{
+			name: "MultipleCharsCustomDelimiter",
+			cfg: map[string]interface{}{
+				"line_delimiter": "<END>",
+			},
+			expectedMessages: expectedMessages,
+			messageSent:      strings.Join(expectedMessages, "<END>"),
+		},
+		{
+			name: "SingleCharCustomDelimiterMessageWithoutBoudaries",
+			cfg: map[string]interface{}{
+				"line_delimiter": ";",
+			},
+			expectedMessages: []string{"hello"},
+			messageSent:      "hello",
+		},
+		{
+			name: "MultipleCharCustomDelimiterMessageWithoutBoundaries",
+			cfg: map[string]interface{}{
+				"line_delimiter": "<END>",
+			},
+			expectedMessages: []string{"hello"},
+			messageSent:      "hello",
+		},
+		{
+			name: "NewLineMessageWithoutBoundaries",
+			cfg: map[string]interface{}{
+				"line_delimiter": "\n",
+			},
+			expectedMessages: []string{"hello"},
+			messageSent:      "hello",
+		},
+		{
+			name: "NewLineLargeMessagePayload",
+			cfg: map[string]interface{}{
+				"line_delimiter": "\n",
+			},
+			expectedMessages: largeMessages,
+			messageSent:      strings.Join(largeMessages, "\n"),
+		},
+		{
+			name: "CustomLargeMessagePayload",
+			cfg: map[string]interface{}{
+				"line_delimiter": ";",
+			},
+			expectedMessages: largeMessages,
+			messageSent:      strings.Join(largeMessages, ";"),
+		},
+		{
+			name:             "MaxReadBufferReached",
+			cfg:              map[string]interface{}{},
+			expectedMessages: []string{},
+			messageSent:      randomString(900000),
+		},
+		{
+			name: "MaxReadBufferReachedUserConfigured",
+			cfg: map[string]interface{}{
+				"max_read_message": 50000,
+			},
+			expectedMessages: []string{},
+			messageSent:      randomString(600000),
+		},
+	}
+
+	port := 9000
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ch := make(chan *util.Data, len(test.expectedMessages))
+			defer close(ch)
+			to := newTestingOutlet(ch)
+			forwarder := harvester.NewForwarder(to)
+			test.cfg["host"] = fmt.Sprintf("localhost:%d", port)
+			cfg, _ := common.NewConfigFrom(test.cfg)
+			harvester, err := NewHarvester(forwarder, cfg)
+			if !assert.NoError(t, err) {
+				return
+			}
+			defer func() {
+				harvester.Stop()
+			}()
+			go func() {
+				err := harvester.Run()
+				assert.NoError(t, err)
+			}()
+
+			conn, err := net.Dial("tcp", fmt.Sprintf("localhost:%d", port))
+			assert.NoError(t, err)
+			fmt.Fprint(conn, test.messageSent)
+			conn.Close()
+
+			var events []*util.Data
+
+			for len(events) < len(test.expectedMessages) {
+				select {
+				case event := <-ch:
+					events = append(events, event)
+				case <-time.After(time.Second * 10):
+					t.Fatal("could not drain all the elements")
+					return
+				}
+			}
+
+			for idx, e := range events {
+				event := e.GetEvent()
+				message, err := event.GetValue("message")
+				assert.NoError(t, err)
+				assert.Equal(t, test.expectedMessages[idx], message)
+				meta := e.GetMetadata()
+				_, ok := meta["hostnames"]
+				assert.True(t, ok)
+				_, ok = meta["ip_address"]
+				assert.True(t, ok)
+			}
+		})
+		port++
+	}
+}

--- a/filebeat/input/tcp/input.go
+++ b/filebeat/input/tcp/input.go
@@ -1,0 +1,72 @@
+package tcp
+
+import (
+	"github.com/elastic/beats/filebeat/channel"
+	"github.com/elastic/beats/filebeat/harvester"
+	"github.com/elastic/beats/filebeat/input"
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
+	"github.com/elastic/beats/libbeat/logp"
+)
+
+func init() {
+	err := input.Register("tcp", NewInput)
+	if err != nil {
+		panic(err)
+	}
+}
+
+// Input for TCP connection
+type Input struct {
+	harvester *Harvester
+	started   bool
+	outlet    channel.Outleter
+}
+
+// NewInput creates a new TCP input
+func NewInput(cfg *common.Config, outlet channel.Factory, context input.Context) (input.Input, error) {
+	cfgwarn.Experimental("TCP input type is used")
+
+	out, err := outlet(cfg, context.DynamicFields)
+	if err != nil {
+		return nil, err
+	}
+
+	forwarder := harvester.NewForwarder(out)
+	harvester, err := NewHarvester(forwarder, cfg)
+	if err != nil {
+		return nil, err
+	}
+	return &Input{
+		outlet:    out,
+		harvester: harvester,
+		started:   false,
+	}, nil
+}
+
+// Run start a TCP input
+func (p *Input) Run() {
+	if !p.started {
+		logp.Info("Starting TCP input")
+		p.started = true
+
+		go func() {
+			defer p.outlet.Close()
+			err := p.harvester.Run()
+			if err != nil {
+				logp.Err("Error running TCP harvester, error: %s", err)
+			}
+		}()
+	}
+}
+
+// Stop stops TCP server
+func (p *Input) Stop() {
+	logp.Info("Stopping TCP input")
+	p.harvester.Stop()
+}
+
+// Wait stop the current harvester
+func (p *Input) Wait() {
+	p.Stop()
+}

--- a/filebeat/input/tcp/scan.go
+++ b/filebeat/input/tcp/scan.go
@@ -1,0 +1,31 @@
+package tcp
+
+import (
+	"bufio"
+	"bytes"
+)
+
+// ScanDelimiter return a function to split line using a custom delimiter, the delimiter
+// is stripped from the returned value.
+func scanDelimiter(delimiter []byte) bufio.SplitFunc {
+	return func(data []byte, eof bool) (int, []byte, error) {
+		if eof && len(data) == 0 {
+			return 0, nil, nil
+		}
+		if i := bytes.Index(data, delimiter); i >= 0 {
+			return i + len(delimiter), dropDelimiter(data[0:i], delimiter), nil
+		}
+		if eof {
+			return len(data), dropDelimiter(data, delimiter), nil
+		}
+		return 0, nil, nil
+	}
+}
+
+func dropDelimiter(data []byte, delimiter []byte) []byte {
+	if len(data) > len(delimiter) &&
+		bytes.Equal(data[len(data)-len(delimiter):len(data)], delimiter) {
+		return data[0 : len(data)-len(delimiter)]
+	}
+	return data
+}

--- a/filebeat/input/tcp/scan_test.go
+++ b/filebeat/input/tcp/scan_test.go
@@ -1,0 +1,91 @@
+package tcp
+
+import (
+	"bufio"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCustomDelimiter(t *testing.T) {
+	tests := []struct {
+		name      string
+		text      string
+		expected  []string
+		delimiter []byte
+	}{
+		{
+			name: "Multiple chars delimiter",
+			text: "hello<END>bonjour<END>hola<END>hey",
+			expected: []string{
+				"hello",
+				"bonjour",
+				"hola",
+				"hey",
+			},
+			delimiter: []byte("<END>"),
+		},
+		{
+			name: "Multiple chars delimiter with half starting delimiter",
+			text: "hello<END>bonjour<ENDhola<END>hey",
+			expected: []string{
+				"hello",
+				"bonjour<ENDhola",
+				"hey",
+			},
+			delimiter: []byte("<END>"),
+		},
+		{
+			name: "Multiple chars delimiter with half ending delimiter",
+			text: "hello<END>END>hola<END>hey",
+			expected: []string{
+				"hello",
+				"END>hola",
+				"hey",
+			},
+			delimiter: []byte("<END>"),
+		},
+		{
+			name: "Delimiter end of string",
+			text: "hello<END>bonjour<END>hola<END>hey<END>",
+			expected: []string{
+				"hello",
+				"bonjour",
+				"hola",
+				"hey",
+			},
+			delimiter: []byte("<END>"),
+		},
+		{
+			name: "Single char delimiter",
+			text: "hello;bonjour;hola;hey",
+			expected: []string{
+				"hello",
+				"bonjour",
+				"hola",
+				"hey",
+			},
+			delimiter: []byte(";"),
+		},
+		{
+			name:      "Empty string",
+			text:      "",
+			expected:  []string(nil),
+			delimiter: []byte(";"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			buf := strings.NewReader(test.text)
+			scanner := bufio.NewScanner(buf)
+			scanner.Split(scanDelimiter(test.delimiter))
+			var elements []string
+			for scanner.Scan() {
+				elements = append(elements, scanner.Text())
+			}
+			assert.EqualValues(t, test.expected, elements)
+		})
+	}
+}

--- a/filebeat/tests/system/test_tcp.py
+++ b/filebeat/tests/system/test_tcp.py
@@ -1,0 +1,68 @@
+from filebeat import BaseTest
+import socket
+
+
+class Test(BaseTest):
+    """
+    Test filebeat TCP input
+    """
+
+    def test_tcp_with_newline_delimiter(self):
+        """
+        Test TCP input with a new line delimiter
+        """
+        self.send_events_with_delimiter("\n")
+
+    def test_tcp_with_custom_char_delimiter(self):
+        """
+        Test TCP input with a custom single char delimiter
+        """
+        self.send_events_with_delimiter(";")
+
+    def test_tcp_with_custom_word_delimiter(self):
+        """
+        Test TCP input with a custom single char delimiter
+        """
+        self.send_events_with_delimiter("<END>")
+
+    def send_events_with_delimiter(self, delimiter):
+        host = "127.0.0.1"
+        port = 8080
+        input_raw = """
+- type: tcp
+  host: "{}:{}"
+  enabled: true
+"""
+
+        # Use default of \n and stripping \r
+        if delimiter is not "":
+            input_raw += "\n  line_delimiter: {}".format(delimiter)
+
+        input_raw = input_raw.format(host, port)
+
+        self.render_config_template(
+            input_raw=input_raw,
+            inputs=False,
+        )
+
+        filebeat = self.start_beat()
+
+        self.wait_until(lambda: self.log_contains("Started listening for incoming TCP connection"))
+
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)  # TCP
+        sock.connect((host, port))
+
+        for n in range(0, 2):
+            sock.send("Hello World: " + str(n) + delimiter)
+
+        self.wait_until(lambda: self.output_count(lambda x: x >= 2))
+
+        filebeat.check_kill_and_wait()
+
+        output = self.read_output()
+
+        assert len(output) == 2
+        assert output[0]["prospector.type"] == "tcp"
+        assert output[0]["input.type"] == "tcp"
+
+        sock.close()


### PR DESCRIPTION
Allow to receive new events via TCP, this will create a new event per
line and add some useful information about the connected client to the
evant. This input is marked as **experimental**.

This input expose the following settings:

- `line_delimiter`: The characters used to split incoming events, by
default it will split on `\n` and will also strip both `\n` and `\r`.
You can also use any characters like `;` and you can also used multiple
characters delimiter like `<END>`, the delimiter tokens will always be
removed from the string.

- `max_read_buffer`: This is a number of bytes that a client can buffer
in memory before finding a new message, if the limit is reached the
connection is killed and the event is logged. This is to prevent rogue
clients to DoS attack by consuming all the available memory. The default
values is 20971520.

- `timeout`: The server will close any client that reach this inactivity
timeout.

**TODO**
I've an almost TLS support done, but this PR was getting pretty big and I still have the tests to write so I've excluded it.

Ref: #5862 