### PR TITLE
Cherry-pick #6260 to 6.1: Fix typo - change from "perdiod to period"

### DIFF
--- a/metricbeat/docs/reload-configuration.asciidoc
+++ b/metricbeat/docs/reload-configuration.asciidoc
@@ -29,7 +29,7 @@ definitions. For example:
 - module: system
   metricsets: ["cpu"]
   enabled: false
-  perdiod: 1s
+  period: 1s
 
 - module: system
   metricsets: ["network"]


### PR DESCRIPTION
Cherry-pick of PR #6260 to 6.1 branch. Original message: Fix typo - change from "perdiod to period"

