### PR TITLE
Mark docs as released in the 6.2 branch

### DIFF
--- a/libbeat/docs/version.asciidoc
+++ b/libbeat/docs/version.asciidoc
@@ -1,7 +1,7 @@
 :stack-version: 6.2.0
 :doc-branch: 6.2
 :go-version: 1.9.2
-:release-state: unreleased
+:release-state: released
 :python: 2.7.9
 :docker: 1.12
 :docker-compose: 1.11


### PR DESCRIPTION
Should be merged in the day of the release.