### PR TITLE
Metricbeat, include the logstash port in the metricbeat configuration

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -53,6 +53,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - De dot keys in jolokia/jmx metricset to prevent collisions. {pull}5957[5957]
 - Support to optionally 'de dot' keys in http/json metricset to prevent collisions. {pull}5970[5970]
 - De dot keys in kubernetes/event metricset to prevent collisions. {pull}6203[6203]
+- Fix the default configuration for Logstash to include the default port. {pull}6279[6279]
 
 *Packetbeat*
 

--- a/metricbeat/docs/modules/logstash.asciidoc
+++ b/metricbeat/docs/modules/logstash.asciidoc
@@ -24,7 +24,7 @@ metricbeat.modules:
   metricsets: ["node", "node_stats"]
   enabled: false
   period: 10s
-  hosts: ["localhost"]
+  hosts: ["localhost:9600"]
 
 ----
 

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -312,7 +312,7 @@ metricbeat.modules:
   metricsets: ["node", "node_stats"]
   enabled: false
   period: 10s
-  hosts: ["localhost"]
+  hosts: ["localhost:9600"]
 
 
 #------------------------------ Memcached Module -----------------------------

--- a/metricbeat/module/logstash/_meta/config.yml
+++ b/metricbeat/module/logstash/_meta/config.yml
@@ -2,5 +2,5 @@
   metricsets: ["node", "node_stats"]
   enabled: false
   period: 10s
-  hosts: ["localhost"]
+  hosts: ["localhost:9600"]
 

--- a/metricbeat/modules.d/logstash.yml.disabled
+++ b/metricbeat/modules.d/logstash.yml.disabled
@@ -2,5 +2,5 @@
   metricsets: ["node", "node_stats"]
   enabled: false
   period: 10s
-  hosts: ["localhost"]
+  hosts: ["localhost:9600"]
 


### PR DESCRIPTION
The YAML for the Logstash module did not include the port, this was
making the module unable to retrieve stats from the logstash host.

Fixes: #6274