### PR TITLE
Cherry-pick #6279 to 6.2: Metricbeat, include the logstash port in the metricbeat configuration

### DIFF
--- a/metricbeat/docs/modules/logstash.asciidoc
+++ b/metricbeat/docs/modules/logstash.asciidoc
@@ -24,7 +24,7 @@ metricbeat.modules:
   metricsets: ["node", "node_stats"]
   enabled: false
   period: 10s
-  hosts: ["localhost"]
+  hosts: ["localhost:9600"]
 
 ----
 

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -311,7 +311,7 @@ metricbeat.modules:
   metricsets: ["node", "node_stats"]
   enabled: false
   period: 10s
-  hosts: ["localhost"]
+  hosts: ["localhost:9600"]
 
 
 #------------------------------ Memcached Module -----------------------------

--- a/metricbeat/module/logstash/_meta/config.yml
+++ b/metricbeat/module/logstash/_meta/config.yml
@@ -2,5 +2,5 @@
   metricsets: ["node", "node_stats"]
   enabled: false
   period: 10s
-  hosts: ["localhost"]
+  hosts: ["localhost:9600"]
 

--- a/metricbeat/modules.d/logstash.yml.disabled
+++ b/metricbeat/modules.d/logstash.yml.disabled
@@ -2,5 +2,5 @@
   metricsets: ["node", "node_stats"]
   enabled: false
   period: 10s
-  hosts: ["localhost"]
+  hosts: ["localhost:9600"]
 


### PR DESCRIPTION
Cherry-pick of PR #6279 to 6.2 branch. Original message: 

The YAML for the Logstash module did not include the port, this was
making the module unable to retrieve stats from the logstash host.

Fixes: #6274