### PR TITLE
Remove experimental banner

### DIFF
--- a/auditbeat/docs/page_header.html
+++ b/auditbeat/docs/page_header.html
@@ -1,4 +1,0 @@
-This functionality is experimental and may be changed or removed completely in a
-future release. Elastic will take a best effort approach to fix any issues, but
-experimental features are not subject to the support SLA of official GA
-features.


### PR DESCRIPTION
We want to remove this banner now that auditbeat is GA for 6.2, right?