### PR TITLE
Fix Auditbeat yml permissions

### DIFF
--- a/dev-tools/packer/xgo-scripts/before_build.sh
+++ b/dev-tools/packer/xgo-scripts/before_build.sh
@@ -18,6 +18,7 @@ cp fields.yml $PREFIX/fields.yml
 # linux
 cp $BEAT_NAME.yml $PREFIX/$BEAT_NAME-linux.yml
 chmod 0600 $PREFIX/$BEAT_NAME-linux.yml
+chmod 0600 $PREFIX/$BEAT_NAME-linux-386.yml || true
 cp $BEAT_NAME.reference.yml $PREFIX/$BEAT_NAME-linux.reference.yml
 rm -rf $PREFIX/modules.d-linux
 cp -r modules.d/ $PREFIX/modules.d-linux || true


### PR DESCRIPTION
A side effect of the #6207 was that the `auditbeat.yml` permissions where
changed to 644, instead of the required 600. This was caught by the package tests,
but those currently break the unified build.