### PR TITLE
provide fpm deps

### DIFF
--- a/dev-tools/packer/docker/fpm-image/Dockerfile
+++ b/dev-tools/packer/docker/fpm-image/Dockerfile
@@ -6,6 +6,6 @@ MAINTAINER Tudor Golubenco <tudor@elastic.co>
 RUN \
     apt-get update && \
     apt-get install -y --no-install-recommends \
-        build-essential ruby-dev rpm zip dos2unix libgmp3-dev
+        autoconf build-essential libffi-dev ruby-dev rpm zip dos2unix libgmp3-dev
 
 RUN gem install fpm -v 1.9.2


### PR DESCRIPTION
Stil unclear what changed, but `make package` is failing first with:
```
08:13:49 Running autoreconf for libffi
08:13:49 /var/lib/gems/2.3.0/gems/ffi-1.9.21/ext/ffi_c/libffi/autogen.sh: 2: exec: autoreconf: not found
08:13:49 libffi.mk:6: recipe for target '"/var/lib/gems/2.3.0/gems/ffi-1.9.21/ext/ffi_c/libffi-x86_64-linux-gnu"/.libs/libffi_convenience.a' failed
08:13:49 make: *** ["/var/lib/gems/2.3.0/gems/ffi-1.9.21/ext/ffi_c/libffi-x86_64-linux-gnu"/.libs/libffi_convenience.a] Error 127
08:13:49 
08:13:49 make failed, exit code 2
08:13:49 
08:13:49 Gem files will remain installed in /var/lib/gems/2.3.0/gems/ffi-1.9.21 for inspection.
08:13:49 Results logged to /var/lib/gems/2.3.0/extensions/x86_64-linux/2.3.0/ffi-1.9.21/gem_make.out
08:13:49 The command '/bin/sh -c gem install fpm -v 1.9.2' returned a non-zero code: 1
08:13:49 make[1]: *** [fpm-image] Error 1
08:13:49 Makefile:55: recipe for target 'fpm-image' failed
```

and then once that's satisfied, with:
```
ERROR:  Error installing fpm:
	ERROR: Failed to build gem native extension.

    current directory: /var/lib/gems/2.3.0/gems/ffi-1.9.21/ext/ffi_c
/usr/bin/ruby2.3 -r ./siteconf20180207-3460-sqz6pt.rb extconf.rb
checking for ffi.h... no
checking for ffi.h in /usr/local/include,/usr/include/ffi... no
...
autoreconf: /usr/bin/autoconf failed with exit status: 1
libffi.mk:6: recipe for target '"/var/lib/gems/2.3.0/gems/ffi-1.9.21/ext/ffi_c/libffi-x86_64-linux-gnu"/.libs/libffi_convenience.a' failed
make: *** ["/var/lib/gems/2.3.0/gems/ffi-1.9.21/ext/ffi_c/libffi-x86_64-linux-gnu"/.libs/libffi_convenience.a] Error 1
```