### PR TITLE
Cherry-pick #6307 to 6.2: fix packetbeat devices command

### DIFF
--- a/packetbeat/docs/packetbeat-options.asciidoc
+++ b/packetbeat/docs/packetbeat-options.asciidoc
@@ -88,7 +88,7 @@ run Packetbeat with the following command:
 
 ["source","sh",subs="attributes,callouts"]
 ----------------------------------------------------------------------
-packetbeat -devices
+packetbeat devices
 ----------------------------------------------------------------------
 
 This command returns a list that looks something like the following:


### PR DESCRIPTION
Cherry-pick of PR #6307 to 6.2 branch. Original message: 

The `-devices` flag is not valid, at least with Packetbeat 6.2, it yields:

```
/usr/share/packetbeat/bin/packetbeat -devices
Error: unknown flag: --devices
```

The command is `packetbeat devices`