### PR TITLE
Wrong assertions and types conversion on the logstash slow plain format.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -92,6 +92,8 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Fix `recursive_globe.enabled` option. {pull}5443[5443]
 - Change pipeline delimiter to `{<` and `>}`. {pull}5702[5702]
 - Fix variable name for `convert_timezone` in the system module. {pull}5936[5936]
+- Fix a conversion issue for time related fields in the Logstash module for the slowlog
+  fileset. {issue}6317[6317]
 
 *Heartbeat*
 

--- a/filebeat/module/logstash/slowlog/ingest/pipeline-plain.json
+++ b/filebeat/module/logstash/slowlog/ingest/pipeline-plain.json
@@ -57,13 +57,13 @@
         {
             "convert": {
                 "field": "logstash.slowlog.took_in_nanos",
-                "type": "auto"
+                "type": "long"
             }
         },
         {
             "convert": {
                 "field": "logstash.slowlog.took_in_millis",
-                "type": "auto"
+                "type": "long"
             }
         }
     ]

--- a/filebeat/module/logstash/slowlog/test/slowlog-plain.log
+++ b/filebeat/module/logstash/slowlog/test/slowlog-plain.log
@@ -1,2 +1,1 @@
 [2017-10-30T09:57:58,243][WARN ][slowlog.logstash.filters.sleep] event processing time {:plugin_params=>{"time"=>3, "id"=>"e4e12a4e3082615c5427079bf4250dbfa338ebac10f8ea9912d7b98a14f56b8c"}, :took_in_nanos=>3027675106, :took_in_millis=>3027, :event=>"{\"@version\":\"1\",\"@timestamp\":\"2017-10-30T13:57:55.130Z\",\"host\":\"sashimi\",\"sequence\":0,\"message\":\"Hello world!\"}"}
-

--- a/filebeat/module/logstash/slowlog/test/slowlog-plain.log-expected.json
+++ b/filebeat/module/logstash/slowlog/test/slowlog-plain.log-expected.json
@@ -24,7 +24,7 @@
                     "plugin_params": "{\"time\"=>3, \"id\"=>\"e4e12a4e3082615c5427079bf4250dbfa338ebac10f8ea9912d7b98a14f56b8c\"}",
                     "plugin_type": "filters",
                     "took_in_millis": 3027,
-                    "took_in_nanos": 3027675140.0
+                    "took_in_nanos": 3027675106
                 }
             },
             "offset": 383,


### PR DESCRIPTION
We were doing an autoconvert vs a long convert and somehow it change the
logic and the assertions.

Fixes: #6317