### PR TITLE
Prepare 6.2.1 release

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -8,7 +8,7 @@
 // Template, add newest changes here
 
 === Beats version HEAD
-https://github.com/elastic/beats/compare/v6.2.0...6.2[Check the HEAD diff]
+https://github.com/elastic/beats/compare/v6.2.1...6.2[Check the HEAD diff]
 
 ==== Breaking changes
 
@@ -76,6 +76,12 @@ https://github.com/elastic/beats/compare/v6.2.0...6.2[Check the HEAD diff]
 
 
 ////////////////////////////////////////////////////////////
+
+[[release-notes-6.2.1]]
+=== Beats version 6.2.1
+https://github.com/elastic/beats/compare/v6.2.0...v6.2.1[View commits]
+
+No changes in this release.
 
 [[release-notes-6.2.0]]
 === Beats version 6.2.0

--- a/deploy/kubernetes/filebeat-kubernetes.yaml
+++ b/deploy/kubernetes/filebeat-kubernetes.yaml
@@ -67,7 +67,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: filebeat
-        image: docker.elastic.co/beats/filebeat:6.2.0
+        image: docker.elastic.co/beats/filebeat:6.2.1
         args: [
           "-c", "/etc/filebeat.yml",
           "-e",

--- a/deploy/kubernetes/metricbeat-kubernetes.yaml
+++ b/deploy/kubernetes/metricbeat-kubernetes.yaml
@@ -93,7 +93,7 @@ spec:
       hostNetwork: true
       containers:
       - name: metricbeat
-        image: docker.elastic.co/beats/metricbeat:6.2.0
+        image: docker.elastic.co/beats/metricbeat:6.2.1
         args: [
           "-c", "/etc/metricbeat.yml",
           "-e",
@@ -202,7 +202,7 @@ spec:
     spec:
       containers:
       - name: metricbeat
-        image: docker.elastic.co/beats/metricbeat:6.2.0
+        image: docker.elastic.co/beats/metricbeat:6.2.1
         args: [
           "-c", "/etc/metricbeat.yml",
           "-e",

--- a/libbeat/docs/release.asciidoc
+++ b/libbeat/docs/release.asciidoc
@@ -8,6 +8,7 @@ This section summarizes the changes in each release. Also read
 <<breaking-changes>> for more detail about changes that affect
 upgrade.
 
+* <<release-notes-6.2.1>>
 * <<release-notes-6.2.0>>
 * <<release-notes-6.1.3>>
 * <<release-notes-6.1.2>>

--- a/libbeat/docs/version.asciidoc
+++ b/libbeat/docs/version.asciidoc
@@ -1,4 +1,4 @@
-:stack-version: 6.2.0
+:stack-version: 6.2.1
 :doc-branch: 6.2
 :go-version: 1.9.2
 :release-state: released

--- a/testing/environments/args.yml
+++ b/testing/environments/args.yml
@@ -6,5 +6,5 @@ services:
     build:
       args:
         DOWNLOAD_URL: https://snapshots.elastic.co/downloads
-        ELASTIC_VERSION: 6.2.0-SNAPSHOT
+        ELASTIC_VERSION: 6.2.1-SNAPSHOT
         CACHE_BUST: 20180108


### PR DESCRIPTION
Contains docs updates, so it should only be merged on the day of the
release.