### PR TITLE
Enable plugins on darwin/go1.10

### DIFF
--- a/libbeat/plugin/cli.go
+++ b/libbeat/plugin/cli.go
@@ -1,4 +1,5 @@
-//+build linux,go1.8,cgo
+//+build linux,go1.8 darwin,go1.10
+//+build cgo
 
 package plugin
 

--- a/libbeat/plugin/cli_stub.go
+++ b/libbeat/plugin/cli_stub.go
@@ -1,4 +1,4 @@
-//+build !linux !go1.8 !cgo
+//+build linux,!go1.8 darwin,!go1.10 !linux,!darwin !cgo
 
 package plugin
 

--- a/libbeat/plugin/load.go
+++ b/libbeat/plugin/load.go
@@ -1,4 +1,5 @@
-//+build linux,go1.8,cgo
+//+build linux,go1.8 darwin,go1.10
+//+build cgo
 
 package plugin
 

--- a/libbeat/plugin/load_stub.go
+++ b/libbeat/plugin/load_stub.go
@@ -1,4 +1,4 @@
-//+build !linux !go1.8 !cgo
+//+build linux,!go1.8 darwin,!go1.10 !linux,!darwin !cgo
 
 package plugin
 


### PR DESCRIPTION
Plugins are now also supported on Macs with Go 1.10 (https://tip.golang.org/doc/go1.10#compiler)

Related to https://github.com/elastic/beats/pull/3217