### PR TITLE
Filebeat registrar update optimizations

### DIFF
--- a/filebeat/input/file/state.go
+++ b/filebeat/input/file/state.go
@@ -122,7 +122,7 @@ func (s *States) Cleanup() (int, int) {
 		}
 
 		expired := (state.TTL > 0 && currentTime.Sub(state.Timestamp) > state.TTL)
-		if !canExpire && expired {
+		if !canExpire && !expired {
 			continue
 		}
 

--- a/filebeat/input/file/state.go
+++ b/filebeat/input/file/state.go
@@ -56,52 +56,53 @@ func (s *State) IsEmpty() bool {
 
 // States handles list of FileState
 type States struct {
-	states []State
+	states map[string]State
 	sync.RWMutex
 }
 
 func NewStates() *States {
 	return &States{
-		states: []State{},
+		states: map[string]State{},
 	}
 }
 
 // Update updates a state. If previous state didn't exist, new one is created
 func (s *States) Update(newState State) {
+	s.UpdateWithTimestamp(newState, time.Now())
+}
+
+// UpdateWithTimestamp updates a state, using the passed timestamp. If the
+// previous state didn't exist, a new entry is created.
+func (s *States) UpdateWithTimestamp(newState State, ts time.Time) {
 	s.Lock()
 	defer s.Unlock()
 
-	index, _ := s.findPrevious(newState)
-	newState.Timestamp = time.Now()
+	// ensure ID is set, so it won't be generated in find and on insert
+	id := newState.ID()
 
-	if index >= 0 {
-		s.states[index] = newState
-	} else {
-		// No existing state found, add new one
-		s.states = append(s.states, newState)
-		logp.Debug("input", "New state added for %s", newState.Source)
+	if logp.IsDebug("input") {
+		_, exists := s.findPrevious(newState)
+		if !exists {
+			logp.Debug("input", "New state added for %s", newState.Source)
+		}
 	}
+
+	newState.Timestamp = ts
+	s.states[id] = newState
 }
 
 func (s *States) FindPrevious(newState State) State {
 	s.RLock()
 	defer s.RUnlock()
-	_, state := s.findPrevious(newState)
+	state, _ := s.findPrevious(newState)
 	return state
 }
 
 // findPreviousState returns the previous state fo the file
 // In case no previous state exists, index -1 is returned
-func (s *States) findPrevious(newState State) (int, State) {
-	// TODO: This could be made potentially more performance by using an index (harvester id) and only use iteration as fall back
-	for index, oldState := range s.states {
-		// This is using the FileStateOS for comparison as FileInfo identifiers can only be fetched for existing files
-		if oldState.IsEqual(&newState) {
-			return index, oldState
-		}
-	}
-
-	return -1, State{}
+func (s *States) findPrevious(newState State) (State, bool) {
+	state, exists := s.states[newState.ID()]
+	return state, exists
 }
 
 // Cleanup cleans up the state array. All states which are older then `older` are removed
@@ -113,24 +114,21 @@ func (s *States) Cleanup() int {
 	statesBefore := len(s.states)
 
 	currentTime := time.Now()
-	states := s.states[:0]
-
-	for _, state := range s.states {
-
+	for id, state := range s.states {
 		expired := (state.TTL > 0 && currentTime.Sub(state.Timestamp) > state.TTL)
-
-		if state.TTL == 0 || expired {
-			if state.Finished {
-				logp.Debug("state", "State removed for %v because of older: %v", state.Source, state.TTL)
-				continue // drop state
-			} else {
-				logp.Err("State for %s should have been dropped, but couldn't as state is not finished.", state.Source)
-			}
+		if !(state.TTL == 0 || expired) {
+			continue
 		}
 
-		states = append(states, state) // in-place copy old state
+		if !state.Finished {
+			logp.Err("State for %s should have been dropped, but couldn't as state is not finished.", state.Source)
+			continue
+		}
+
+		// drop state
+		delete(s.states, id)
+		logp.Debug("state", "State removed for %v because of older: %v", state.Source, state.TTL)
 	}
-	s.states = states
 
 	return statesBefore - len(s.states)
 }
@@ -148,22 +146,37 @@ func (s *States) GetStates() []State {
 	s.RLock()
 	defer s.RUnlock()
 
-	newStates := make([]State, len(s.states))
-	copy(newStates, s.states)
+	newStates, i := make([]State, len(s.states)), 0
+	for _, state := range s.states {
+		newStates[i], i = state, i+1
+	}
 
 	return newStates
+}
+
+// GetIndexedStates returns a copy of the states, indexed by ID.
+func (s *States) GetIndexedStates() map[string]State {
+	m := make(map[string]State, len(s.states))
+	for k, v := range s.states {
+		m[k] = v
+	}
+	return m
 }
 
 // SetStates overwrites all internal states with the given states array
 func (s *States) SetStates(states []State) {
 	s.Lock()
 	defer s.Unlock()
-	s.states = states
+	newStates := make(map[string]State, len(states))
+	for _, state := range states {
+		newStates[state.ID()] = state
+	}
+	s.states = newStates
 }
 
 // Copy create a new copy of the states object
 func (s *States) Copy() *States {
 	states := NewStates()
-	states.states = s.GetStates()
+	states.states = s.GetIndexedStates()
 	return states
 }

--- a/filebeat/input/file/state_test.go
+++ b/filebeat/input/file/state_test.go
@@ -10,34 +10,35 @@ import (
 )
 
 var cleanupTests = []struct {
+	title        string
 	state        State
 	countBefore  int
 	cleanupCount int
 	countAfter   int
 }{
 	{
-		// Finished and TTL set to 0
+		"Finished and TTL set to 0",
 		State{
 			TTL:      0,
 			Finished: true,
 		}, 1, 1, 0,
 	},
 	{
-		// Unfinished but TTL set to 0
+		"Unfinished but TTL set to 0",
 		State{
 			TTL:      0,
 			Finished: false,
 		}, 1, 0, 1,
 	},
 	{
-		// TTL = -1 means not expiring
+		"TTL = -1 means not expiring",
 		State{
 			TTL:      -1,
 			Finished: true,
 		}, 1, 0, 1,
 	},
 	{
-		// Expired and finished
+		"Expired and finished",
 		State{
 			TTL:       1 * time.Second,
 			Timestamp: time.Now().Add(-2 * time.Second),
@@ -45,7 +46,7 @@ var cleanupTests = []struct {
 		}, 1, 1, 0,
 	},
 	{
-		// Expired but unfinished
+		"Expired but unfinished",
 		State{
 			TTL:       1 * time.Second,
 			Timestamp: time.Now().Add(-2 * time.Second),
@@ -56,11 +57,15 @@ var cleanupTests = []struct {
 
 func TestCleanup(t *testing.T) {
 	for _, test := range cleanupTests {
-		states := NewStates()
-		states.SetStates([]State{test.state})
+		test := test
+		t.Run(test.title, func(t *testing.T) {
+			states := NewStates()
+			states.SetStates([]State{test.state})
 
-		assert.Equal(t, test.countBefore, states.Count())
-		assert.Equal(t, test.cleanupCount, states.Cleanup())
-		assert.Equal(t, test.countAfter, states.Count())
+			assert.Equal(t, test.countBefore, states.Count())
+			cleanupCount, _ := states.Cleanup()
+			assert.Equal(t, test.cleanupCount, cleanupCount)
+			assert.Equal(t, test.countAfter, states.Count())
+		})
 	}
 }

--- a/filebeat/input/file/state_test.go
+++ b/filebeat/input/file/state_test.go
@@ -57,7 +57,7 @@ var cleanupTests = []struct {
 func TestCleanup(t *testing.T) {
 	for _, test := range cleanupTests {
 		states := NewStates()
-		states.states = append(states.states, test.state)
+		states.SetStates([]State{test.state})
 
 		assert.Equal(t, test.countBefore, states.Count())
 		assert.Equal(t, test.cleanupCount, states.Cleanup())

--- a/filebeat/input/log/input.go
+++ b/filebeat/input/log/input.go
@@ -164,7 +164,7 @@ func (p *Input) Run() {
 	// It is important that a first scan is run before cleanup to make sure all new states are read first
 	if p.config.CleanInactive > 0 || p.config.CleanRemoved {
 		beforeCount := p.states.Count()
-		cleanedStates := p.states.Cleanup()
+		cleanedStates, _ := p.states.Cleanup()
 		logp.Debug("input", "input states cleaned up. Before: %d, After: %d", beforeCount, beforeCount-cleanedStates)
 	}
 

--- a/filebeat/input/log/input.go
+++ b/filebeat/input/log/input.go
@@ -78,7 +78,7 @@ func NewInput(
 		harvesters:  harvester.NewRegistry(),
 		outlet:      out,
 		stateOutlet: stateOut,
-		states:      &file.States{},
+		states:      file.NewStates(),
 		done:        context.Done,
 	}
 

--- a/filebeat/input/log/input_other_test.go
+++ b/filebeat/input/log/input_other_test.go
@@ -131,7 +131,7 @@ func TestInit(t *testing.T) {
 			config: config{
 				Paths: test.paths,
 			},
-			states: &file.States{},
+			states: file.NewStates(),
 			outlet: TestOutlet{},
 		}
 

--- a/filebeat/registrar/registrar.go
+++ b/filebeat/registrar/registrar.go
@@ -199,8 +199,9 @@ func (r *Registrar) onEvents(states []file.State) {
 func (r *Registrar) processEventStates(states []file.State) {
 	logp.Debug("registrar", "Processing %d events", len(states))
 
+	ts := time.Now()
 	for i := range states {
-		r.states.Update(states[i])
+		r.states.UpdateWithTimestamp(states[i], ts)
 		statesUpdate.Add(1)
 	}
 }

--- a/filebeat/registrar/registrar.go
+++ b/filebeat/registrar/registrar.go
@@ -148,16 +148,28 @@ func (r *Registrar) Start() error {
 
 func (r *Registrar) Run() {
 	logp.Debug("registrar", "Starting Registrar")
-	// Writes registry on shutdown
-	defer func() {
-		r.writeRegistry()
-		r.wg.Done()
-	}()
 
 	var (
 		timer  *time.Timer
 		flushC <-chan time.Time
+
+		// Set to true if any events can be gc'ed.
+		gcEnabled = false
+
+		// Set to true if gcEnabled and new set of events of have been send
+		// to the registry. We must not clean the registry if beat is blocked by outputs.
+		gcRequired = false
 	)
+
+	// Writes registry on shutdown
+	defer func() {
+		if gcRequired {
+			gcEnabled = r.gcStates()
+			gcRequired = false
+		}
+		r.writeRegistry()
+		r.wg.Done()
+	}()
 
 	for {
 		select {
@@ -167,15 +179,38 @@ func (r *Registrar) Run() {
 		case <-flushC:
 			flushC = nil
 			timer.Stop()
+			if gcRequired {
+				gcEnabled = r.gcStates()
+				gcRequired = false
+			}
 			r.flushRegistry()
 		case states := <-r.Channel:
 			r.onEvents(states)
+
+			// Check if any new states will require to be cleaned at some point.
+			// Enable state gc if so.
+			if !gcEnabled {
+				for i := range states {
+					if states[i].TTL >= 0 {
+						gcEnabled = true
+						break
+					}
+				}
+			}
+
+			gcRequired = gcEnabled
+
 			if r.flushTimeout <= 0 {
+				if gcRequired {
+					gcEnabled = r.gcStates()
+					gcRequired = false
+				}
 				r.flushRegistry()
 			} else if flushC == nil {
 				timer = time.NewTimer(r.flushTimeout)
 				flushC = timer.C
 			}
+
 		}
 	}
 }
@@ -183,16 +218,20 @@ func (r *Registrar) Run() {
 // onEvents processes events received from the publisher pipeline
 func (r *Registrar) onEvents(states []file.State) {
 	r.processEventStates(states)
-
-	beforeCount := r.states.Count()
-	cleanedStates := r.states.Cleanup()
-	statesCleanup.Add(int64(cleanedStates))
-
 	r.bufferedStateUpdates += len(states)
+}
+
+func (r *Registrar) gcStates() bool {
+	beforeCount := r.states.Count()
+
+	cleanedStates, numCanExpire := r.states.Cleanup()
+	statesCleanup.Add(int64(cleanedStates))
 
 	logp.Debug("registrar",
 		"Registrar states cleaned up. Before: %d, After: %d",
 		beforeCount, beforeCount-cleanedStates)
+
+	return numCanExpire > 0
 }
 
 // processEventStates gets the states from the events and writes them to the registrar state

--- a/libbeat/common/file/file_other.go
+++ b/libbeat/common/file/file_other.go
@@ -3,8 +3,8 @@
 package file
 
 import (
-	"fmt"
 	"os"
+	"strconv"
 	"syscall"
 )
 
@@ -32,7 +32,11 @@ func (fs StateOS) IsSame(state StateOS) bool {
 }
 
 func (fs StateOS) String() string {
-	return fmt.Sprintf("%d-%d", fs.Inode, fs.Device)
+	var buf [64]byte
+	current := strconv.AppendUint(buf[:0], fs.Inode, 10)
+	current = append(current, '-')
+	current = strconv.AppendUint(current, fs.Device, 10)
+	return string(current)
 }
 
 // ReadOpen opens a file for reading only

--- a/libbeat/common/file/file_windows.go
+++ b/libbeat/common/file/file_windows.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"strconv"
 	"syscall"
 )
 
@@ -43,7 +44,13 @@ func (fs StateOS) IsSame(state StateOS) bool {
 }
 
 func (fs StateOS) String() string {
-	return fmt.Sprintf("%d-%d-%d", fs.IdxHi, fs.IdxLo, fs.Vol)
+	var buf [92]byte
+	current := strconv.AppendUint(buf[:0], fs.IdxHi, 10)
+	current = append(current, '-')
+	current = strconv.AppendUint(current, fs.IdxLo, 10)
+	current = append(current, '-')
+	current = strconv.AppendUint(current, fs.Vol, 10)
+	return string(current)
 }
 
 // ReadOpen opens a file for reading only


### PR DESCRIPTION
- replace fmt.Sprintf in file state ID generation with append/strconv
  operations on stack allocated buffer
- change file state registry to use map[string]State instead of []State
- use time.Now() only once if registrar updates multiple states
- gc old state in registry file on flush only:
  - allow gc input states only if any events processed by registrar are eligible to be gc'ed
  - still make sure no state gc, if no events have been processed by registrar