### PR TITLE
Refactor prometheus endpoint parsing to look similar to upstream prometheus

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -223,6 +223,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Docker and Kubernetes modules are now GA, instead of Beta. {pull}6105[6105]
 - Add pct calculated fields for Pod and container CPU and memory usages. {pull}6158[6158]
 - Add statefulset support to Kubernetes module. {pull}6236[6236]
+- Refactor prometheus endpoint parsing to look similar to upstream prometheus {pull}6332[6332]
 
 *Packetbeat*
 

--- a/metricbeat/helper/prometheus.go
+++ b/metricbeat/helper/prometheus.go
@@ -2,11 +2,12 @@ package helper
 
 import (
 	"fmt"
-
-	"github.com/elastic/beats/metricbeat/mb"
+	"io"
 
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
+
+	"github.com/elastic/beats/metricbeat/mb"
 )
 
 // Prometheus helper retrieves prometheus formatted metrics
@@ -42,10 +43,14 @@ func (p *Prometheus) GetFamilies() ([]*dto.MetricFamily, error) {
 	}
 
 	families := []*dto.MetricFamily{}
-	for err == nil {
+	for {
 		mf := &dto.MetricFamily{}
 		err = decoder.Decode(mf)
-		if err == nil {
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+		} else {
 			families = append(families, mf)
 		}
 	}


### PR DESCRIPTION
I have changed the prometheus helper to parse in a manner similar to how it is done upstream. This would make it easier to know if a prometheus endpoint is wrong or if the issue comes from our Beats parsing logic.

Upstream sample link: https://github.com/prometheus/common/blob/master/expfmt/bench_test.go