### PR TITLE
Optimize filebeat state ID generation

### DIFF
--- a/libbeat/common/file/file_other.go
+++ b/libbeat/common/file/file_other.go
@@ -3,8 +3,8 @@
 package file
 
 import (
-	"fmt"
 	"os"
+	"strconv"
 	"syscall"
 )
 
@@ -32,7 +32,11 @@ func (fs StateOS) IsSame(state StateOS) bool {
 }
 
 func (fs StateOS) String() string {
-	return fmt.Sprintf("%d-%d", fs.Inode, fs.Device)
+	var buf [64]byte
+	current := strconv.AppendUint(buf[:0], fs.Inode, 10)
+	current = append(current, '-')
+	current = strconv.AppendUint(current, fs.Device, 10)
+	return string(current)
 }
 
 // ReadOpen opens a file for reading only

--- a/libbeat/common/file/file_other_test.go
+++ b/libbeat/common/file/file_other_test.go
@@ -4,6 +4,7 @@ package file
 
 import (
 	"io/ioutil"
+	"math"
 	"os"
 	"runtime"
 	"testing"
@@ -46,5 +47,23 @@ func TestGetOSFileStateStat(t *testing.T) {
 		assert.True(t, state.Device >= 0, "Device %d", state.Device)
 	} else {
 		assert.True(t, state.Device > 0, "Device %d", state.Device)
+	}
+}
+
+func BenchmarkStateString(b *testing.B) {
+	var samples [50]uint64
+	for i, v := 0, uint64(0); i < len(samples); i, v = i+1, v+math.MaxUint64/uint64(len(samples)) {
+		samples[i] = v
+	}
+
+	for i := 0; i < b.N; i++ {
+		for _, inode := range samples {
+			for _, device := range samples {
+				st := StateOS{Inode: inode, Device: device}
+				if st.String() == "" {
+					b.Fatal("empty state string")
+				}
+			}
+		}
 	}
 }

--- a/libbeat/common/file/file_windows.go
+++ b/libbeat/common/file/file_windows.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"strconv"
 	"syscall"
 )
 
@@ -43,7 +44,13 @@ func (fs StateOS) IsSame(state StateOS) bool {
 }
 
 func (fs StateOS) String() string {
-	return fmt.Sprintf("%d-%d-%d", fs.IdxHi, fs.IdxLo, fs.Vol)
+	var buf [92]byte
+	current := strconv.AppendUint(buf[:0], fs.IdxHi, 10)
+	current = append(current, '-')
+	current = strconv.AppendUint(current, fs.IdxLo, 10)
+	current = append(current, '-')
+	current = strconv.AppendUint(current, fs.Vol, 10)
+	return string(current)
 }
 
 // ReadOpen opens a file for reading only


### PR DESCRIPTION
use append operations (StringBuilder pattern) instead of fmt.Sprintf to
reduce allocation overhead when generating the id.

The benchmark generates 2500 ids per run. As the ID is a string, one
at least one allocation per ID is required. Results show the change cuts
allocations by 3.

```
benchmark                  old ns/op     new ns/op     delta
BenchmarkStateString-4     633983        274193        -56.75%
BenchmarkStateString-4     634008        275098        -56.61%
BenchmarkStateString-4     627028        273854        -56.33%
BenchmarkStateString-4     629635        275542        -56.24%
BenchmarkStateString-4     625108        284221        -54.53%
BenchmarkStateString-4     632816        272703        -56.91%
BenchmarkStateString-4     633756        275215        -56.57%
BenchmarkStateString-4     671575        273220        -59.32%
BenchmarkStateString-4     663687        272034        -59.01%
BenchmarkStateString-4     629798        279793        -55.57%

benchmark                  old allocs     new allocs     delta
BenchmarkStateString-4     7400           2500           -66.22%
BenchmarkStateString-4     7400           2500           -66.22%
BenchmarkStateString-4     7400           2500           -66.22%
BenchmarkStateString-4     7400           2500           -66.22%
BenchmarkStateString-4     7400           2500           -66.22%
BenchmarkStateString-4     7400           2500           -66.22%
BenchmarkStateString-4     7400           2500           -66.22%
BenchmarkStateString-4     7400           2500           -66.22%
BenchmarkStateString-4     7400           2500           -66.22%
BenchmarkStateString-4     7400           2500           -66.22%

benchmark                  old bytes     new bytes     delta
BenchmarkStateString-4     157619        118388        -24.89%
BenchmarkStateString-4     157623        118387        -24.89%
BenchmarkStateString-4     157630        118387        -24.90%
BenchmarkStateString-4     157631        118387        -24.90%
BenchmarkStateString-4     157631        118387        -24.90%
BenchmarkStateString-4     157631        118387        -24.90%
BenchmarkStateString-4     157631        118387        -24.90%
BenchmarkStateString-4     157631        118387        -24.90%
BenchmarkStateString-4     157631        118387        -24.90%
BenchmarkStateString-4     157630        118387        -24.90%
```