### PR TITLE
Avoid infinite loop in Kubernetes watcher

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -30,6 +30,8 @@ https://github.com/elastic/beats/compare/v6.2.0...6.2[Check the HEAD diff]
 
 *Affecting all Beats*
 
+- Fix infinite loop when event unmarshal fails in Kubernetes pod watcher. {pull}6353[6353]
+
 *Auditbeat*
 
 *Filebeat*

--- a/libbeat/common/kubernetes/watcher.go
+++ b/libbeat/common/kubernetes/watcher.go
@@ -14,6 +14,9 @@ import (
 	corev1 "github.com/ericchiang/k8s/api/v1"
 )
 
+// Max back off time for retries
+const maxBackoff = 30 * time.Second
+
 // Watcher reads Kubernetes events and keeps a list of known pods
 type Watcher interface {
 	// Start watching Kubernetes API for new containers
@@ -130,6 +133,9 @@ func (p *podWatcher) Start() error {
 }
 
 func (p *podWatcher) watch() {
+	// Failures counter, do exponential backoff on retries
+	var failures uint
+
 	for {
 		logp.Info("kubernetes: %s", "Watching API for pod events")
 		watcher, err := p.client.WatchPods(p.ctx, "", p.nodeFilter, k8s.ResourceVersion(p.lastResourceVersion))
@@ -137,7 +143,8 @@ func (p *podWatcher) watch() {
 			//watch pod failures should be logged and gracefully failed over as metadata retrieval
 			//should never stop.
 			logp.Err("kubernetes: Watching API error %v", err)
-			time.Sleep(time.Second)
+			backoff(failures)
+			failures++
 			continue
 		}
 
@@ -149,7 +156,8 @@ func (p *podWatcher) watch() {
 				// In case of EOF, stop watching and restart the process
 				if err == io.EOF || err == io.ErrUnexpectedEOF {
 					watcher.Close()
-					time.Sleep(time.Second)
+					backoff(failures)
+					failures++
 					break
 				}
 
@@ -157,8 +165,9 @@ func (p *podWatcher) watch() {
 				continue
 			}
 
-			// Update last resource version
+			// Update last resource version and reset failure counter
 			p.lastResourceVersion = apiPod.Metadata.GetResourceVersion()
+			failures = 0
 
 			pod := GetPod(apiPod)
 			if pod.Metadata.DeletionTimestamp != "" {
@@ -197,6 +206,14 @@ func (p *podWatcher) watch() {
 			}
 		}
 	}
+}
+
+func backoff(failures uint) {
+	wait := 1 << failures * time.Second
+	if wait > maxBackoff {
+		wait = maxBackoff
+	}
+	time.Sleep(wait)
 }
 
 // Check annotations flagged as deleted for their last access time, fully delete


### PR DESCRIPTION
In case of unmarshalling errors the Watcher was ending up in a infinite loop,
this code ignores those errors and only restarts the watcher in case of
EOF.

This was reproduced by @cdahlqvist:
```
2018-02-09T16:37:46.072Z	ERROR	kubernetes/watcher.go:146	kubernetes: Watching API error proto: wrong wireType = 6 for field ServiceAccountName
2018-02-09T16:37:46.072Z	INFO	kubernetes/watcher.go:133	kubernetes: Watching API for pod events
2018-02-09T16:37:46.130Z	ERROR	kubernetes/watcher.go:146	kubernetes: Watching API error proto: wrong wireType = 6 for field ServiceAccountName
2018-02-09T16:37:46.131Z	INFO	kubernetes/watcher.go:133	kubernetes: Watching API for pod events
2018-02-09T16:37:46.131Z	ERROR	kubernetes/watcher.go:146	kubernetes: Watching API error proto: wrong wireType = 6 for field ServiceAccountName
2018-02-09T16:37:46.131Z	INFO	 kubernetes/watcher.go:133	kubernetes: Watching API for pod events
```
Opening directly to 6.2 as master is not affected, after its refactoring and client update