### PR TITLE
Add logging when monitoring cannot connect

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -23,6 +23,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
   keystore {pull}6098[6098]
 - De dot keys of labels and annotations in kubernetes meta processors to prevent collisions. {pull}6203[6203]
 - The default value for pipelining is reduced to 2 to avoid high memory in the Logstash beats input. {pull}6250[6250]
+- Add logging when monitoring cannot connect to Elasticsearch. {pull}xxx[xxx]
 
 *Auditbeat*
 

--- a/libbeat/monitoring/report/elasticsearch/elasticsearch.go
+++ b/libbeat/monitoring/report/elasticsearch/elasticsearch.go
@@ -159,6 +159,7 @@ func (r *reporter) initLoop() {
 		client := r.out.Clients[rand.Intn(len(r.out.Clients))].(outputs.NetworkClient)
 		err := client.Connect()
 		if err == nil {
+			logp.Err("Monitoring could not connect to elasticsearch, failed with %v", err)
 			closing(client)
 			break
 		}


### PR DESCRIPTION
Currently when the monitoring can not connect to Elasticsearch no errors
is show in the log making this issue really hard to debug, this change
the behavior to send any error to the log.

Fixes: #6327