### PR TITLE
Add logging when monitoring cannot connect

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -23,6 +23,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
   keystore {pull}6098[6098]
 - De dot keys of labels and annotations in kubernetes meta processors to prevent collisions. {pull}6203[6203]
 - The default value for pipelining is reduced to 2 to avoid high memory in the Logstash beats input. {pull}6250[6250]
+- Add logging when monitoring cannot connect to Elasticsearch. {pull}6365[6365]
 
 *Auditbeat*
 

--- a/libbeat/monitoring/report/elasticsearch/elasticsearch.go
+++ b/libbeat/monitoring/report/elasticsearch/elasticsearch.go
@@ -161,6 +161,8 @@ func (r *reporter) initLoop() {
 		if err == nil {
 			closing(client)
 			break
+		} else {
+			logp.Err("Monitoring could not connect to elasticsearch, failed with %v", err)
 		}
 
 		select {


### PR DESCRIPTION
Currently when the monitoring can not connect to Elasticsearch no errors
is show in the log making this issue really hard to debug, this change
the behavior to send any error to the log.

Fixes: #6327