### PR TITLE
Cherry-pick #6365 to 6.2: Add logging when monitoring cannot connect

### DIFF
--- a/libbeat/monitoring/report/elasticsearch/elasticsearch.go
+++ b/libbeat/monitoring/report/elasticsearch/elasticsearch.go
@@ -161,6 +161,8 @@ func (r *reporter) initLoop() {
 		if err == nil {
 			closing(client)
 			break
+		} else {
+			logp.Err("Monitoring could not connect to elasticsearch, failed with %v", err)
 		}
 
 		select {


### PR DESCRIPTION
Cherry-pick of PR #6365 to 6.2 branch. Original message:

Currently when the monitoring can not connect to Elasticsearch no errors
is show in the log making this issue really hard to debug, this change
the behavior to send any error to the log.

Fixes: #6327

(cherry picked from commit b4c92f839aef9418c172413a652ef3554a1efa05)