### PR TITLE
bump elastic stack tests to 6.2.2

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -87,6 +87,10 @@ https://github.com/elastic/beats/compare/v6.2.1...v6.2.2[View commits]
 
 - Add logging when monitoring cannot connect to Elasticsearch. {pull}6365[6365]
 
+*Filebeat*
+
+- Fix a conversion issue for time related fields in the Logstash module for the slowlog
+  fileset. {issue}6317[6317]
 
 [[release-notes-6.2.1]]
 === Beats version 6.2.1

--- a/filebeat/module/logstash/slowlog/ingest/pipeline-plain.json
+++ b/filebeat/module/logstash/slowlog/ingest/pipeline-plain.json
@@ -57,13 +57,13 @@
         {
             "convert": {
                 "field": "logstash.slowlog.took_in_nanos",
-                "type": "auto"
+                "type": "long"
             }
         },
         {
             "convert": {
                 "field": "logstash.slowlog.took_in_millis",
-                "type": "auto"
+                "type": "long"
             }
         }
     ]

--- a/filebeat/module/logstash/slowlog/test/slowlog-plain.log
+++ b/filebeat/module/logstash/slowlog/test/slowlog-plain.log
@@ -1,2 +1,1 @@
 [2017-10-30T09:57:58,243][WARN ][slowlog.logstash.filters.sleep] event processing time {:plugin_params=>{"time"=>3, "id"=>"e4e12a4e3082615c5427079bf4250dbfa338ebac10f8ea9912d7b98a14f56b8c"}, :took_in_nanos=>3027675106, :took_in_millis=>3027, :event=>"{\"@version\":\"1\",\"@timestamp\":\"2017-10-30T13:57:55.130Z\",\"host\":\"sashimi\",\"sequence\":0,\"message\":\"Hello world!\"}"}
-

--- a/filebeat/module/logstash/slowlog/test/slowlog-plain.log-expected.json
+++ b/filebeat/module/logstash/slowlog/test/slowlog-plain.log-expected.json
@@ -24,7 +24,7 @@
                     "plugin_params": "{\"time\"=>3, \"id\"=>\"e4e12a4e3082615c5427079bf4250dbfa338ebac10f8ea9912d7b98a14f56b8c\"}",
                     "plugin_type": "filters",
                     "took_in_millis": 3027,
-                    "took_in_nanos": 3027675140.0
+                    "took_in_nanos": 3027675106
                 }
             },
             "offset": 383,

--- a/testing/environments/args.yml
+++ b/testing/environments/args.yml
@@ -6,5 +6,5 @@ services:
     build:
       args:
         DOWNLOAD_URL: https://snapshots.elastic.co/downloads
-        ELASTIC_VERSION: 6.2.1-SNAPSHOT
-        CACHE_BUST: 20180108
+        ELASTIC_VERSION: 6.2.2-SNAPSHOT
+        CACHE_BUST: 20180208

--- a/testing/environments/docker/kibana/Dockerfile
+++ b/testing/environments/docker/kibana/Dockerfile
@@ -6,7 +6,7 @@ EXPOSE 5601
 
 ### Beats specific args ####
 ARG DOWNLOAD_URL=https://snapshots.elastic.co/downloads
-ARG ELASTIC_VERSION=7.0.0-alpha1-SNAPSHOT
+ARG ELASTIC_VERSION=6.2.2-SNAPSHOT
 ARG CACHE_BUST=1
 ARG XPACK=1
 


### PR DESCRIPTION
Tests are failing since the update to 6.2.2 - `6.2.1-SNAPSHOT` is no longer available.  The kibana tests are failing too though I can't tell why - the url hit for the snapshot seems valid - should those be on 6.2.2 in the 6.2 branch anyway?