### PR TITLE
Fixed logging format for kafka ouput logger

### DIFF
--- a/libbeat/outputs/kafka/log.go
+++ b/libbeat/outputs/kafka/log.go
@@ -9,11 +9,11 @@ import (
 type kafkaLogger struct{}
 
 func (kl kafkaLogger) Print(v ...interface{}) {
-	kl.Log("kafka message: %v", v)
+	kl.Log("kafka message: %v", v...)
 }
 
 func (kl kafkaLogger) Printf(format string, v ...interface{}) {
-	kl.Log(format, v)
+	kl.Log(format, v...)
 }
 
 func (kl kafkaLogger) Println(v ...interface{}) {


### PR DESCRIPTION
Hi, guys! 
I got incorrect error message:

```
2018-02-13T14:41:04.979Z	INFO	kafka/log.go:36	producer/broker/[[5 %!d(string=topic_name) 4]] state change to [closed] on %!s(MISSING)/%!d(MISSING)
```

and found this typo.

relates_to: https://github.com/elastic/beats/pull/5397
Thanks!