### PR TITLE
Cherry-pick #6318 to 6.2: Wrong assertions and types conversion on the logstash slow plain format.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -87,6 +87,10 @@ https://github.com/elastic/beats/compare/v6.2.1...v6.2.2[View commits]
 
 - Add logging when monitoring cannot connect to Elasticsearch. {pull}6365[6365]
 
+*Filebeat*
+
+- Fix a conversion issue for time related fields in the Logstash module for the slowlog
+  fileset. {issue}6317[6317]
 
 [[release-notes-6.2.1]]
 === Beats version 6.2.1

--- a/filebeat/module/logstash/slowlog/ingest/pipeline-plain.json
+++ b/filebeat/module/logstash/slowlog/ingest/pipeline-plain.json
@@ -57,13 +57,13 @@
         {
             "convert": {
                 "field": "logstash.slowlog.took_in_nanos",
-                "type": "auto"
+                "type": "long"
             }
         },
         {
             "convert": {
                 "field": "logstash.slowlog.took_in_millis",
-                "type": "auto"
+                "type": "long"
             }
         }
     ]

--- a/filebeat/module/logstash/slowlog/test/slowlog-plain.log
+++ b/filebeat/module/logstash/slowlog/test/slowlog-plain.log
@@ -1,2 +1,1 @@
 [2017-10-30T09:57:58,243][WARN ][slowlog.logstash.filters.sleep] event processing time {:plugin_params=>{"time"=>3, "id"=>"e4e12a4e3082615c5427079bf4250dbfa338ebac10f8ea9912d7b98a14f56b8c"}, :took_in_nanos=>3027675106, :took_in_millis=>3027, :event=>"{\"@version\":\"1\",\"@timestamp\":\"2017-10-30T13:57:55.130Z\",\"host\":\"sashimi\",\"sequence\":0,\"message\":\"Hello world!\"}"}
-

--- a/filebeat/module/logstash/slowlog/test/slowlog-plain.log-expected.json
+++ b/filebeat/module/logstash/slowlog/test/slowlog-plain.log-expected.json
@@ -24,7 +24,7 @@
                     "plugin_params": "{\"time\"=>3, \"id\"=>\"e4e12a4e3082615c5427079bf4250dbfa338ebac10f8ea9912d7b98a14f56b8c\"}",
                     "plugin_type": "filters",
                     "took_in_millis": 3027,
-                    "took_in_nanos": 3027675140.0
+                    "took_in_nanos": 3027675106
                 }
             },
             "offset": 383,


### PR DESCRIPTION
Cherry-pick of PR #6318 to 6.2 branch. Original message:

We were doing an autoconvert vs a long convert and somehow it change the
logic and the assertions.

Fixes: #6317