### PR TITLE
Update filebeat kubernetes autodiscover documentation

### DIFF
--- a/filebeat/docs/autodiscover-kubernetes-config.asciidoc
+++ b/filebeat/docs/autodiscover-kubernetes-config.asciidoc
@@ -12,7 +12,7 @@ filebeat.autodiscover:
           config:
             - type: docker
               containers.ids:
-                - "${data.docker.container.id}"
+                - "${data.kubernetes.container.id}"
               exclude_lines: ["^\\s+[\\-`('.|_]"]  # drop asciiart lines
 -------------------------------------------------------------------------------------
 
@@ -36,5 +36,5 @@ filebeat.autodiscover:
                 prospector:
                   type: docker
                   containers.ids:
-                    - "${data.docker.container.id}"
+                    - "${data.kubernetes.container.id}"
 -------------------------------------------------------------------------------------


### PR DESCRIPTION
# What I did
I've updated the documentation to use **kubernetes.container.id** instead of **docker.container.id**.

# Why
The current documentation may work but its still confusing to rely on docker metadata when using kubernetes provider.

In addition, using the docker metada adds an unnecessary dependency to the docker metadata generator if we don't plan to use any specific docker attributes.

By removing this reference to docker, the add_docker_metadata processor and the access to the docker daemon are no longer needed.