### PR TITLE
Update running-on-docker.asciidoc

### DIFF
--- a/metricbeat/docs/running-on-docker.asciidoc
+++ b/metricbeat/docs/running-on-docker.asciidoc
@@ -19,7 +19,7 @@ docker run \
   --volume=/sys/fs/cgroup:/hostfs/sys/fs/cgroup:ro \ <2>
   --volume=/:/hostfs:ro \ <3>
   --net=host <4>
-  {dockerimage} -system.hostfs=/hostfs
+  {dockerimage} -e -system.hostfs=/hostfs
 ----
 
 <1> Metricbeat's <<metricbeat-module-system,system module>> collects much of its data through the Linux proc

--- a/metricbeat/docs/running-on-docker.asciidoc
+++ b/metricbeat/docs/running-on-docker.asciidoc
@@ -18,7 +18,7 @@ docker run \
   --volume=/proc:/hostfs/proc:ro \ <1>
   --volume=/sys/fs/cgroup:/hostfs/sys/fs/cgroup:ro \ <2>
   --volume=/:/hostfs:ro \ <3>
-  --net=host <4>
+  --net=host \ <4>
   {dockerimage} -e -system.hostfs=/hostfs
 ----
 


### PR DESCRIPTION
-e option was missing

See https://discuss.elastic.co/t/running-metricbeat-in-docker-and-monitoring-the-host-system-does-not-work-with-command-from-documentation/119821