### PR TITLE
Use sha1 instead of sha256 and fix libpcap

### DIFF
--- a/dev-tools/packer/docker/xgo-image-deb6/beats-builder/gopacket_pcap.patch
+++ b/dev-tools/packer/docker/xgo-image-deb6/beats-builder/gopacket_pcap.patch
@@ -7,10 +7,10 @@ index f5612e6..0c77efa 100644
 
  /*
 -#cgo linux LDFLAGS: -lpcap
-+#cgo linux,386 CFLAGS: -I /libpcap/i386/usr/include/
-+#cgo linux,386 LDFLAGS: /libpcap/i386/usr/lib/libpcap.a
-+#cgo linux,amd64 CFLAGS: -I /libpcap/amd64/libpcap-1.8.1
-+#cgo linux,amd64 LDFLAGS: /libpcap/amd64/libpcap-1.8.1/libpcap.a
++#cgo linux,386 CFLAGS: -I/libpcap/i386/usr/include/
++#cgo linux,386 LDFLAGS: -L/libpcap/i386/usr/lib/ -lpcap
++#cgo linux,amd64 CFLAGS: -I/libpcap/amd64/libpcap-1.8.1
++#cgo linux,amd64 LDFLAGS: -L/libpcap/amd64/libpcap-1.8.1 -lpcap
  #cgo freebsd LDFLAGS: -lpcap
  #cgo openbsd LDFLAGS: -lpcap
  #cgo darwin LDFLAGS: -lpcap
@@ -18,9 +18,9 @@ index f5612e6..0c77efa 100644
 -#cgo windows CFLAGS: -I C:/WpdPack/Include
 -#cgo windows,386 LDFLAGS: -L C:/WpdPack/Lib -lwpcap
 -#cgo windows,amd64 LDFLAGS: -L C:/WpdPack/Lib/x64 -lwpcap
-+#cgo windows CFLAGS: -I /libpcap/win/WpdPack/Include
-+#cgo windows,386 LDFLAGS: -L /libpcap/win/WpdPack/Lib -lwpcap
-+#cgo windows,amd64 LDFLAGS: -L /libpcap/win/WpdPack/Lib/x64 -lwpcap
++#cgo windows CFLAGS: -I/libpcap/win/WpdPack/Include
++#cgo windows,386 LDFLAGS: -L/libpcap/win/WpdPack/Lib -lwpcap
++#cgo windows,amd64 LDFLAGS: -L/libpcap/win/WpdPack/Lib/x64 -lwpcap
  #include <stdlib.h>
  #include <pcap.h>
 

--- a/dev-tools/packer/docker/xgo-image-deb6/go-1.9.4/Dockerfile
+++ b/dev-tools/packer/docker/xgo-image-deb6/go-1.9.4/Dockerfile
@@ -10,6 +10,6 @@ MAINTAINER Tudor Golubenco <tudor@elastic.co>
 # Configure the root Go distribution and bootstrap based on it
 RUN \
   export ROOT_DIST="https://storage.googleapis.com/golang/go1.9.4.linux-amd64.tar.gz" && \
-  export ROOT_DIST_SHA1="15b0937615809f87321a457bb1265f946f9f6e736c563d6c5e0bd2c22e44f779" && \
+  export ROOT_DIST_SHA1="ed1bd37c356338a5a04923c183931a96687f202e" && \
   \
   $BOOTSTRAP_PURE

--- a/dev-tools/packer/docker/xgo-image/go-1.9.4/Dockerfile
+++ b/dev-tools/packer/docker/xgo-image/go-1.9.4/Dockerfile
@@ -10,6 +10,6 @@ MAINTAINER Tudor Golubenco <tudor@elastic.co>
 # Configure the root Go distribution and bootstrap based on it
 RUN \
   export ROOT_DIST="https://storage.googleapis.com/golang/go1.9.4.linux-amd64.tar.gz" && \
-  export ROOT_DIST_SHA1="15b0937615809f87321a457bb1265f946f9f6e736c563d6c5e0bd2c22e44f779" && \
+  export ROOT_DIST_SHA1="ed1bd37c356338a5a04923c183931a96687f202e" && \
   \
   $BOOTSTRAP_PURE


### PR DESCRIPTION
We will eventually need to update to sha256 in out build but this was a
bit more involved. We also fix the LDFlags usable on our pcap build on
linux.