### PR TITLE
Update shirou/gopsutil to support golang 1.9.4

### DIFF
--- a/vendor/github.com/shirou/gopsutil/disk/disk_darwin_cgo.go
+++ b/vendor/github.com/shirou/gopsutil/disk/disk_darwin_cgo.go
@@ -5,7 +5,7 @@ package disk
 
 /*
 #cgo CFLAGS: -mmacosx-version-min=10.10 -DMACOSX_DEPLOYMENT_TARGET=10.10
-#cgo LDFLAGS: -mmacosx-version-min=10.10 -lobjc -framework Foundation -framework IOKit
+#cgo LDFLAGS: -lobjc -framework Foundation -framework IOKit
 #include <stdint.h>
 
 // ### enough?


### PR DESCRIPTION
# IMPORTANT This PR need to be merged after the release of 6.2.2.

With the hardening going on with `go get` on 1.9.4, the ldflags defined
for darwin on gopsutil was causing the build to fail.

The `-mmacosx-version-min=10.10` is not whitelisted for LDFLAGS only for
CFLAGS.

This PR fix the issue with [homebrew](https://github.com/Homebrew/homebrew-core/pull/23847) that force a local compilation with Golang 1.9.4, since 6.2.x is compiled with 1.9.2 our distribution don't run into any issues from of the `go get`  changes from the lastest golang release.