### PR TITLE
Move loadbalance example under loadbalance section

### DIFF
--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -432,6 +432,14 @@ load balances published events onto all Logstash hosts. If set to false,
 the output plugin sends all events to only one host (determined at random) and
 will switch to another host if the selected one becomes unresponsive. The default value is false.
 
+["source","yaml",subs="attributes"]
+------------------------------------------------------------------------------
+output.logstash:
+  hosts: ["localhost:5044", "localhost:5045"]
+  loadbalance: true
+  index: {beatname_lc}
+------------------------------------------------------------------------------
+
 ===== `ttl`
 
 Time to live for a connection to Logstash after which the connection will be re-established.
@@ -443,14 +451,6 @@ instances.  Specifying a TTL of 0 will disable this feature.
 The default value is 0.
 
 NOTE: The "ttl" option is not yet supported on an async Logstash client (one with the "pipelining" option set).
-
-["source","yaml",subs="attributes"]
-------------------------------------------------------------------------------
-output.logstash:
-  hosts: ["localhost:5044", "localhost:5045"]
-  loadbalance: true
-  index: {beatname_lc}
-------------------------------------------------------------------------------
 
 ===== `pipelining`
 


### PR DESCRIPTION
Looks like it ended up in the wrong section during some doc reorganization