### PR TITLE
Fix fileset generator config.yml naming

### DIFF
--- a/filebeat/scripts/generator/fileset/main.go
+++ b/filebeat/scripts/generator/fileset/main.go
@@ -23,7 +23,10 @@ func generateFileset(module, fileset, modulesPath, beatsPath string) error {
 	replace := map[string]string{"module": module, "fileset": fileset}
 	templatesPath := path.Join(beatsPath, "scripts", "fileset")
 	filesToCopy := []string{path.Join("config", "config.yml"), path.Join("ingest", "pipeline.json"), "manifest.yml"}
-	generator.CopyTemplates(templatesPath, filesetPath, filesToCopy, replace)
+	err = generator.CopyTemplates(templatesPath, filesetPath, filesToCopy, replace)
+	if err != nil {
+		return err
+	}
 	if err != nil {
 		return err
 	}

--- a/filebeat/scripts/generator/fileset/main.go
+++ b/filebeat/scripts/generator/fileset/main.go
@@ -27,6 +27,7 @@ func generateFileset(module, fileset, modulesPath, beatsPath string) error {
 	if err != nil {
 		return err
 	}
+	err = generator.RenameConfigYml(modulesPath, module, fileset)
 	if err != nil {
 		return err
 	}

--- a/filebeat/scripts/generator/generator.go
+++ b/filebeat/scripts/generator/generator.go
@@ -85,3 +85,11 @@ func readTemplate(template string, replace map[string]string) ([]byte, error) {
 
 	return c, nil
 }
+
+// RenameConfigYml renemas config.yml to the name of the fileset, otherwise Filebeat refuses to start
+func RenameConfigYml(modulesPath, module, fileset string) error {
+	old := path.Join(modulesPath, "module", module, fileset, "config", "config.yml")
+	new := path.Join(modulesPath, "module", module, fileset, "config", fileset+".yml")
+
+	return os.Rename(old, new)
+}


### PR DESCRIPTION
Previously, the generator created a config file named `config.yml`. This returned the following error in case of cat/bat fileset:
```
Exiting: Error getting config for fielset cat/bat: Error reading input file config/bat.yml: open /home/n/go/src/github.com/elastic/beats/filebeat/module/cat/bat/config/bat.yml: no such file or directory
```
From now on the config file is generated as `{{filesetname}}.yml`.

I also added a missing error check to the script.