### PR TITLE
Prepare 5.6.8 release

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -8,7 +8,7 @@
 // Template, add newest changes here
 
 === Beats version HEAD
-https://github.com/elastic/beats/compare/v5.6.7...5.6[Check the HEAD diff]
+https://github.com/elastic/beats/compare/v5.6.8...5.6[Check the HEAD diff]
 
 ==== Breaking changes
 
@@ -37,11 +37,6 @@ https://github.com/elastic/beats/compare/v5.6.7...5.6[Check the HEAD diff]
 *Packetbeat*
 
 *Winlogbeat*
-
-- Fix the registry file. It was not correctly storing event log names, and
-  upon restart it would begin reading at the start of each event log. {issue}5813[5813]
-- Fix config validation to allow `event_logs.processors`. [pull]6217[6217]
-- Fixed a crash under Windows 2003 and XP when an event had less insert strings than required by its format string. {pull}6247[6247]
 
 ==== Added
 
@@ -86,6 +81,17 @@ https://github.com/elastic/beats/compare/v5.6.7...5.6[Check the HEAD diff]
 *Winlogbeat*
 
 ////////////////////////////////////////////////////////////
+
+[[release-notes-5.6.8]]
+=== Beats version 5.6.8
+https://github.com/elastic/beats/compare/v5.6.7...v5.6.8[View commits]
+
+==== Bugfixes
+
+*Winlogbeat*
+
+- Fixed a crash under Windows 2003 and XP when an event had less insert strings than required by its format string. {pull}6247[6247]
+
 
 [[release-notes-5.6.7]]
 === Beats version 5.6.7

--- a/libbeat/docs/release.asciidoc
+++ b/libbeat/docs/release.asciidoc
@@ -6,6 +6,7 @@
 --
 This section summarizes the changes in each release.
 
+* <<release-notes-5.6.8>>
 * <<release-notes-5.6.7>>
 * <<release-notes-5.6.6>>
 * <<release-notes-5.6.5>>

--- a/libbeat/docs/version.asciidoc
+++ b/libbeat/docs/version.asciidoc
@@ -1,4 +1,4 @@
-:stack-version: 5.6.7
+:stack-version: 5.6.8
 :doc-branch: 5.6
 :go-version: 1.7.6
 :release-state: released

--- a/testing/environments/args.yml
+++ b/testing/environments/args.yml
@@ -6,4 +6,4 @@ services:
     build:
       args:
         DOWNLOAD_URL: https://snapshots.elastic.co/downloads
-        ELASTIC_VERSION: 5.6.7-SNAPSHOT
+        ELASTIC_VERSION: 5.6.8-SNAPSHOT


### PR DESCRIPTION
Contains docs version bump, so this should be merged in the day of the release.