### PR TITLE
Fix conditions checking on autodiscover Docker labels

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -83,6 +83,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Fix panic when Events containing a float32 value are normalized. {pull}6129[6129]
 - Fix `setup.dashboards.always_kibana` when using Kibana 5.6. {issue}6090[6090]
 - Update Golang 1.9.4 {pull}6326[6326]
+- Fix conditions checking on autodiscover Docker labels. {pull}6412[6412]
 
 *Auditbeat*
 

--- a/libbeat/autodiscover/providers/docker/docker.go
+++ b/libbeat/autodiscover/providers/docker/docker.go
@@ -92,12 +92,17 @@ func (d *Provider) emitContainer(event bus.Event, flag string) {
 		host = container.IPAddresses[0]
 	}
 
+	labelMap := common.MapStr{}
+	for k, v := range container.Labels {
+		labelMap[k] = v
+	}
+
 	meta := common.MapStr{
 		"container": common.MapStr{
 			"id":     container.ID,
 			"name":   container.Name,
 			"image":  container.Image,
-			"labels": container.Labels,
+			"labels": labelMap,
 		},
 	}
 

--- a/libbeat/autodiscover/providers/docker/docker_integration_test.go
+++ b/libbeat/autodiscover/providers/docker/docker_integration_test.go
@@ -34,7 +34,9 @@ func TestDockerStart(t *testing.T) {
 	defer listener.Stop()
 
 	// Start
-	ID, err := d.ContainerStart("busybox", "echo", "Hi!")
+	cmd := []string{"echo", "Hi!"}
+	labels := map[string]string{"label": "value"}
+	ID, err := d.ContainerStart("busybox", cmd, labels)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -69,7 +71,7 @@ func checkEvent(t *testing.T, listener bus.Listener, start bool) {
 				assert.Nil(t, getValue(e, "start"))
 			}
 			assert.Equal(t, getValue(e, "docker.container.image"), "busybox")
-			assert.Equal(t, getValue(e, "docker.container.labels"), map[string]string{})
+			assert.Equal(t, getValue(e, "docker.container.labels"), common.MapStr{"label": "value"})
 			assert.NotNil(t, getValue(e, "docker.container.id"))
 			assert.NotNil(t, getValue(e, "docker.container.name"))
 			assert.NotNil(t, getValue(e, "host"))

--- a/libbeat/tests/docker/docker.go
+++ b/libbeat/tests/docker/docker.go
@@ -20,15 +20,16 @@ func NewClient() (Client, error) {
 }
 
 // ContainerStart pulls and starts the given container
-func (c Client) ContainerStart(image string, cmd ...string) (string, error) {
+func (c Client) ContainerStart(image string, cmd []string, labels map[string]string) (string, error) {
 	ctx := context.Background()
 	if _, err := c.cli.ImagePull(ctx, image, types.ImagePullOptions{}); err != nil {
 		return "", err
 	}
 
 	resp, err := c.cli.ContainerCreate(ctx, &container.Config{
-		Image: image,
-		Cmd:   cmd,
+		Image:  image,
+		Cmd:    cmd,
+		Labels: labels,
 	}, nil, nil, "")
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Type was wrong (map[string]string instead of MapStr) so autodiscover conditions on Docker labels were not being processed.