### PR TITLE
Update Ingest pipelines if enabled

### DIFF
--- a/docs/devguide/modules-dev-guide.asciidoc
+++ b/docs/devguide/modules-dev-guide.asciidoc
@@ -322,6 +322,9 @@ While developing the pipeline definition, we recommend making use of the
 {elasticsearch}/simulate-pipeline-api.html[Simulate Pipeline API] for testing
 and quick iteration.
 
+By default Filebeat does not update Ingest pipelines if already loaded. If you want to force updating your pipeline
+during development, use `--update-pipelines` flag. This uploads pipelines even if they are already available on the node.
+
 [float]
 ==== _meta/fields.yml
 

--- a/filebeat/beater/filebeat.go
+++ b/filebeat/beater/filebeat.go
@@ -33,7 +33,8 @@ const pipelinesWarning = "Filebeat is unable to load the Ingest Node pipelines f
 	" can ignore this warning."
 
 var (
-	once = flag.Bool("once", false, "Run filebeat only once until all harvesters reach EOF")
+	once            = flag.Bool("once", false, "Run filebeat only once until all harvesters reach EOF")
+	updatePipelines = flag.Bool("update-pipelines", false, "Update Ingest pipelines")
 )
 
 // Filebeat is a beater object. Contains all objects needed to run the beat
@@ -136,7 +137,7 @@ func (fb *Filebeat) loadModulesPipelines(b *beat.Beat) error {
 	// register pipeline loading to happen every time a new ES connection is
 	// established
 	callback := func(esClient *elasticsearch.Client) error {
-		return fb.moduleRegistry.LoadPipelines(esClient)
+		return fb.moduleRegistry.LoadPipelines(esClient, *updatePipelines)
 	}
 	elasticsearch.RegisterConnectCallback(callback)
 
@@ -278,7 +279,11 @@ func (fb *Filebeat) Run(b *beat.Beat) error {
 		logp.Warn(pipelinesWarning)
 	}
 
-	err = crawler.Start(registrar, config.ConfigInput, config.ConfigModules, pipelineLoaderFactory)
+	if *updatePipelines {
+		logp.Debug("modules", "Existing Ingest pipelines will be updated")
+	}
+
+	err = crawler.Start(registrar, config.ConfigInput, config.ConfigModules, pipelineLoaderFactory, *updatePipelines)
 	if err != nil {
 		crawler.Stop()
 		return err

--- a/filebeat/cmd/root.go
+++ b/filebeat/cmd/root.go
@@ -20,6 +20,7 @@ func init() {
 	var runFlags = pflag.NewFlagSet(Name, pflag.ExitOnError)
 	runFlags.AddGoFlag(flag.CommandLine.Lookup("once"))
 	runFlags.AddGoFlag(flag.CommandLine.Lookup("modules"))
+	runFlags.AddGoFlag(flag.CommandLine.Lookup("update-pipelines"))
 
 	RootCmd = cmd.GenRootCmdWithRunFlags(Name, "", beater.New, runFlags)
 	RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("M"))

--- a/filebeat/crawler/crawler.go
+++ b/filebeat/crawler/crawler.go
@@ -43,7 +43,7 @@ func New(out channel.Factory, inputConfigs []*common.Config, beatVersion string,
 
 // Start starts the crawler with all inputs
 func (c *Crawler) Start(r *registrar.Registrar, configInputs *common.Config,
-	configModules *common.Config, pipelineLoaderFactory fileset.PipelineLoaderFactory) error {
+	configModules *common.Config, pipelineLoaderFactory fileset.PipelineLoaderFactory, updatePipelines bool) error {
 
 	logp.Info("Loading Inputs: %v", len(c.inputConfigs))
 
@@ -67,7 +67,7 @@ func (c *Crawler) Start(r *registrar.Registrar, configInputs *common.Config,
 		}()
 	}
 
-	c.ModulesFactory = fileset.NewFactory(c.out, r, c.beatVersion, pipelineLoaderFactory, c.beatDone)
+	c.ModulesFactory = fileset.NewFactory(c.out, r, c.beatVersion, pipelineLoaderFactory, updatePipelines, c.beatDone)
 	if configModules.Enabled() {
 		c.modulesReloader = cfgfile.NewReloader(configModules)
 		if err := c.modulesReloader.Check(c.ModulesFactory); err != nil {

--- a/filebeat/fileset/factory.go
+++ b/filebeat/fileset/factory.go
@@ -18,6 +18,7 @@ type Factory struct {
 	registrar             *registrar.Registrar
 	beatVersion           string
 	pipelineLoaderFactory PipelineLoaderFactory
+	updatePipelines       bool
 	beatDone              chan struct{}
 }
 
@@ -27,17 +28,19 @@ type inputsRunner struct {
 	moduleRegistry        *ModuleRegistry
 	inputs                []*input.Runner
 	pipelineLoaderFactory PipelineLoaderFactory
+	updatePipelines       bool
 }
 
 // NewFactory instantiates a new Factory
 func NewFactory(outlet channel.Factory, registrar *registrar.Registrar, beatVersion string,
-	pipelineLoaderFactory PipelineLoaderFactory, beatDone chan struct{}) *Factory {
+	pipelineLoaderFactory PipelineLoaderFactory, updatePipelines bool, beatDone chan struct{}) *Factory {
 	return &Factory{
 		outlet:                outlet,
 		registrar:             registrar,
 		beatVersion:           beatVersion,
 		beatDone:              beatDone,
 		pipelineLoaderFactory: pipelineLoaderFactory,
+		updatePipelines:       updatePipelines,
 	}
 }
 
@@ -76,6 +79,7 @@ func (f *Factory) Create(c *common.Config, meta *common.MapStrPointer) (cfgfile.
 		moduleRegistry:        m,
 		inputs:                inputs,
 		pipelineLoaderFactory: f.pipelineLoaderFactory,
+		updatePipelines:       f.updatePipelines,
 	}, nil
 }
 
@@ -87,7 +91,7 @@ func (p *inputsRunner) Start() {
 		if err != nil {
 			logp.Err("Error loading pipeline: %s", err)
 		} else {
-			err := p.moduleRegistry.LoadPipelines(pipelineLoader)
+			err := p.moduleRegistry.LoadPipelines(pipelineLoader, p.updatePipelines)
 			if err != nil {
 				// Log error and continue
 				logp.Err("Error loading pipeline: %s", err)
@@ -96,7 +100,7 @@ func (p *inputsRunner) Start() {
 
 		// Callback:
 		callback := func(esClient *elasticsearch.Client) error {
-			return p.moduleRegistry.LoadPipelines(esClient)
+			return p.moduleRegistry.LoadPipelines(esClient, p.updatePipelines)
 		}
 		elasticsearch.RegisterConnectCallback(callback)
 	}

--- a/filebeat/fileset/modules_integration_test.go
+++ b/filebeat/fileset/modules_integration_test.go
@@ -34,7 +34,7 @@ func TestLoadPipeline(t *testing.T) {
 		},
 	}
 
-	err := loadPipeline(client, "my-pipeline-id", content)
+	err := loadPipeline(client, "my-pipeline-id", content, false)
 	assert.NoError(t, err)
 
 	status, _, err := client.Request("GET", "/_ingest/pipeline/my-pipeline-id", "", nil, nil)
@@ -43,9 +43,17 @@ func TestLoadPipeline(t *testing.T) {
 
 	// loading again shouldn't actually update the pipeline
 	content["description"] = "describe pipeline 2"
-	err = loadPipeline(client, "my-pipeline-id", content)
+	err = loadPipeline(client, "my-pipeline-id", content, false)
 	assert.NoError(t, err)
+	checkUploadedPipeline(t, client, "describe pipeline")
 
+	// loading again updates the pipeline
+	err = loadPipeline(client, "my-pipeline-id", content, true)
+	assert.NoError(t, err)
+	checkUploadedPipeline(t, client, "describe pipeline 2")
+}
+
+func checkUploadedPipeline(t *testing.T, client *elasticsearch.Client, expectedDescription string) {
 	status, response, err := client.Request("GET", "/_ingest/pipeline/my-pipeline-id", "", nil, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, 200, status)
@@ -53,7 +61,7 @@ func TestLoadPipeline(t *testing.T) {
 	var res map[string]interface{}
 	err = json.Unmarshal(response, &res)
 	if assert.NoError(t, err) {
-		assert.Equal(t, "describe pipeline", res["my-pipeline-id"].(map[string]interface{})["description"], string(response))
+		assert.Equal(t, expectedDescription, res["my-pipeline-id"].(map[string]interface{})["description"], string(response))
 	}
 }
 
@@ -78,7 +86,7 @@ func TestSetupNginx(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = reg.LoadPipelines(client)
+	err = reg.LoadPipelines(client, false)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
New flag is introduced: `--update-pipelines`.

It is quite uncomfortable to delete Ingest pipelines manually before testing a small change. So during development no one cares if pipelines are updated by Filebeat unnecessarily. Or if someone does he/she can stick with the default behaviour by not specifying `--update-pipelines`.

It is intended to be used during module development or testing pipeline changes.
It should not be used when running Beats in production, because it's unnecessary to update pipelines every time a Beat is started.