### PR TITLE
Make normalization processor optional.

### DIFF
--- a/libbeat/beat/event.go
+++ b/libbeat/beat/event.go
@@ -12,10 +12,11 @@ import (
 // The `Meta`-fields can be used to pass additional meta-data to the outputs.
 // Output can optionally publish a subset of Meta, or ignore Meta.
 type Event struct {
-	Timestamp time.Time
-	Meta      common.MapStr
-	Fields    common.MapStr
-	Private   interface{} // for beats private use
+	Timestamp  time.Time
+	Meta       common.MapStr
+	Fields     common.MapStr
+	Private    interface{} // for beats private use
+	Normalized bool
 }
 
 var (

--- a/libbeat/publisher/pipeline/processor.go
+++ b/libbeat/publisher/pipeline/processor.go
@@ -175,6 +175,9 @@ var generalizeProcessor = newProcessor("generalizeEvent", func(event *beat.Event
 	if len(event.Fields) == 0 {
 		return nil, nil
 	}
+	if event.Normalized {
+		return event, nil
+	}
 
 	fields := common.ConvertToGenericEvent(event.Fields)
 	if fields == nil {
@@ -183,6 +186,7 @@ var generalizeProcessor = newProcessor("generalizeEvent", func(event *beat.Event
 	}
 
 	event.Fields = fields
+	event.Normalized = true
 	return event, nil
 })
 

--- a/libbeat/publisher/pipeline/processor_test.go
+++ b/libbeat/publisher/pipeline/processor_test.go
@@ -15,9 +15,10 @@ func TestProcessors(t *testing.T) {
 	info := beat.Info{}
 
 	type local struct {
-		config   beat.ClientConfig
-		events   []common.MapStr
-		expected []common.MapStr
+		config     beat.ClientConfig
+		events     []common.MapStr
+		expected   []common.MapStr
+		normalized bool
 	}
 
 	tests := []struct {
@@ -34,10 +35,27 @@ func TestProcessors(t *testing.T) {
 			[]local{
 				{
 					config: beat.ClientConfig{},
-					events: []common.MapStr{{"value": "abc"}},
+					events: []common.MapStr{{"value": "abc", "user": nil}},
 					expected: []common.MapStr{
 						{"value": "abc", "global": 1, "tags": []string{"tag"}},
 					},
+				},
+			},
+		},
+		{
+			"no normalization",
+			pipelineProcessors{
+				fields: common.MapStr{"global": 1},
+				tags:   []string{"tag"},
+			},
+			[]local{
+				{
+					config: beat.ClientConfig{},
+					events: []common.MapStr{{"value": "abc", "user": nil}},
+					expected: []common.MapStr{
+						{"value": "abc", "user": nil, "global": 1, "tags": []string{"tag"}},
+					},
+					normalized: true,
 				},
 			},
 		},
@@ -300,8 +318,9 @@ func TestProcessors(t *testing.T) {
 					actual := make([]common.MapStr, len(local.events))
 					for i, event := range local.events {
 						out, _ := program.Run(&beat.Event{
-							Timestamp: time.Now(),
-							Fields:    event,
+							Timestamp:  time.Now(),
+							Fields:     event,
+							Normalized: local.normalized,
 						})
 						actual[i] = out.Fields
 					}


### PR DESCRIPTION
In case a beat.Event is marked to be normalized already,
do not run the normalization processor again.

implements #6418 