### PR TITLE
Fix for kafka logger

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -83,6 +83,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Fix `setup.dashboards.always_kibana` when using Kibana 5.6. {issue}6090[6090]
 - Update Golang 1.9.4 {pull}6326[6326]
 - Fix conditions checking on autodiscover Docker labels. {pull}6412[6412]
+- Fix for kafka logger. {pull}6430[6430]
 
 *Auditbeat*
 

--- a/libbeat/outputs/kafka/log.go
+++ b/libbeat/outputs/kafka/log.go
@@ -9,11 +9,11 @@ import (
 type kafkaLogger struct{}
 
 func (kl kafkaLogger) Print(v ...interface{}) {
-	kl.Log("kafka message: %v", v)
+	kl.Log("kafka message: %v", v...)
 }
 
 func (kl kafkaLogger) Printf(format string, v ...interface{}) {
-	kl.Log(format, v)
+	kl.Log(format, v...)
 }
 
 func (kl kafkaLogger) Println(v ...interface{}) {
@@ -31,8 +31,8 @@ func (kafkaLogger) Log(format string, v ...interface{}) {
 		}
 	}
 	if warn {
-		logp.Warn(format, v)
+		logp.Warn(format, v...)
 	} else {
-		logp.Info(format, v)
+		logp.Info(format, v...)
 	}
 }


### PR DESCRIPTION
The arguments are passed as slice (v) instead of a argument list (v...) which results in a wrong output in the log