### PR TITLE
Add Hackerbeat to community beats list

### DIFF
--- a/libbeat/docs/communitybeats.asciidoc
+++ b/libbeat/docs/communitybeats.asciidoc
@@ -43,6 +43,7 @@ https://github.com/FStelzer/flowbeat[flowbeat]:: Collects, parses, and indexes h
 https://github.com/GeneralElectric/GABeat[gabeat]:: Collects data from Google Analytics Realtime API.
 https://github.com/jlevesy/githubbeat[githubbeat]:: Easily monitors GitHub repository activity.
 https://github.com/hpcugent/gpfsbeat[gpfsbeat]:: Collects GPFS metric and quota information.
+https://github.com/ullaakut/hackerbeat[hackerbeat]:: Indexes the top stories of HackerNews into an ElasticSearch instance.
 https://github.com/YaSuenag/hsbeat[hsbeat]:: Reads all performance counters in Java HotSpot VM.
 https://github.com/christiangalsterer/httpbeat[httpbeat]:: Polls multiple HTTP(S) endpoints and sends the data to
 Logstash or Elasticsearch. Supports all HTTP methods and proxies.


### PR DESCRIPTION
*For now, this is a really basic beat, I made it just to try and see how to make one.*

## Functionality
[Hackerbeat](https://github.com/Ullaakut/Hackerbeat) currently only fetches the top 10 stories from Hackernews every minute (both of these values can be configured) and indexes them into ElasticSearch. Now even though that's fairly basic, it's already possible to make a few interesting graphs out of that data.

## Data structure
A HackerNews story is represented as:

```go
type story struct {
	ID    uint   `json:"id"`
	Score uint   `json:"score"`
	Time  uint   `json:"time"`
	Title string `json:"title"`
	By    string `json:"by"`
	URL   string `json:"url"`
}
```

## Potential uses of the gathered data
This means we can already make heatmaps of the most popular terms in story titles (since we can correlate titles and scores), see the average score per hour to analyze at which hour it's best to create a new HackerNews story, etc.

Now it could be interesting to expand this beat by indexing more information, such as top comments, job postings, polls, and all other entities that HackerNews has.

**Since the scope of this beat is really tiny at the moment, I would understand if this PR gets rejected for the sake of keeping high-quality beats in the community beats listing**, however, I thought making this PR could also be a good opportunity to share my tiny experiment!