### PR TITLE
Update error message to reflect correct flow value allowed

### DIFF
--- a/packetbeat/flows/worker.go
+++ b/packetbeat/flows/worker.go
@@ -19,7 +19,7 @@ type flowsProcessor struct {
 }
 
 var (
-	ErrInvalidTimeout = errors.New("timeout must not >= 1s")
+	ErrInvalidTimeout = errors.New("timeout must not <= 1s")
 	ErrInvalidPeriod  = errors.New("report period must be -1 or >= 1s")
 )
 


### PR DESCRIPTION
The error currently is:
`timeout must not >= 1s`

However, the validation is:
`if timeout < oneSecond {
		return nil, ErrInvalidTimeout
	}`

Error should read:
`timeout must not <= 1s`