### PR TITLE
Packetbeat: add COMMAND, COMMANDREPLY mongodb opcodes

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -82,6 +82,15 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 
 *Packetbeat*
 
+- Fix http status phrase parsing not allow spaces. {pull}5312[5312]
+- Fix http parse to allow to parse get request with space in the URI. {pull}5495[5495]
+- Fix mysql SQL parser to trim `\r` from Windows Server `SELECT\r\n\t1`. {pull}5572[5572]
+- Fix corruption when parsing repeated headers in an HTTP request or response. {pull}6325[6325]
+- Fix panic when parsing partial AMQP messages. {pull}6384[6384]
+- Fix out of bounds access to slice in MongoDB parser. {pull}6256[6256]
+- Fix sniffer hanging on exit under Linux. {pull}6535[6535]
+- Adds OP_COMMAND and OP_COMMANDREPLY to MongoDB response(opcode parse/check) whitelist. {pull}6440[6440]
+
 *Winlogbeat*
 
 - Fixed a crash under Windows 2003 and XP when an event had less insert strings than required by its format string. {pull}6247[6247]

--- a/packetbeat/protos/mongodb/mongodb_parser.go
+++ b/packetbeat/protos/mongodb/mongodb_parser.go
@@ -77,6 +77,12 @@ func mongodbMessageParser(s *stream) (bool, bool) {
 	case opKillCursor:
 		s.message.method = "killCursors"
 		return opKillCursorsParse(d, s.message)
+	case opCommand:
+		s.message.method = "command"
+		return opCommandParse(d, s.message)
+	case opCommandreply:
+		s.message.method = "commandreply"
+		return opCommandreplyParse(d, s.message)
 	}
 
 	return false, false
@@ -272,6 +278,18 @@ func opDeleteParse(d *decoder, m *mongodbMessage) (bool, bool) {
 
 func opKillCursorsParse(d *decoder, m *mongodbMessage) (bool, bool) {
 	// TODO ? Or not, content is not very interesting.
+	return true, true
+}
+
+func opCommandParse(d *decoder, m *mongodbMessage) (bool, bool) {
+	// TODO ? Or not, content is not very interesting.
+	// Changed in version 3.6: Deprecated and may be removed in a future release of MongoDB.
+	return true, true
+}
+
+func opCommandreplyParse(d *decoder, m *mongodbMessage) (bool, bool) {
+	// TODO ? Or not, content is not very interesting.
+	// Changed in version 3.6: Deprecated and may be removed in a future release of MongoDB.
 	return true, true
 }
 

--- a/packetbeat/protos/mongodb/mongodb_structs.go
+++ b/packetbeat/protos/mongodb/mongodb_structs.go
@@ -83,15 +83,17 @@ type transaction struct {
 type opCode int32
 
 const (
-	opReply      opCode = 1
-	opMsg        opCode = 1000
-	opUpdate     opCode = 2001
-	opInsert     opCode = 2002
-	opReserved   opCode = 2003
-	opQuery      opCode = 2004
-	opGetMore    opCode = 2005
-	opDelete     opCode = 2006
-	opKillCursor opCode = 2007
+	opReply        opCode = 1
+	opMsg          opCode = 1000
+	opUpdate       opCode = 2001
+	opInsert       opCode = 2002
+	opReserved     opCode = 2003
+	opQuery        opCode = 2004
+	opGetMore      opCode = 2005
+	opDelete       opCode = 2006
+	opKillCursor   opCode = 2007
+	opCommand      opCode = 2010
+	opCommandreply opCode = 2011
 )
 
 // List of valid mongodb wire protocol operation codes
@@ -106,6 +108,8 @@ var opCodeNames = map[opCode]string{
 	2005: "OP_GET_MORE",
 	2006: "OP_DELETE",
 	2007: "OP_KILL_CURSORS",
+	2010: "OP_COMMAND",
+	2011: "OP_COMMANDREPLY",
 }
 
 func validOpcode(o opCode) bool {


### PR DESCRIPTION
Ref: https://github.com/elastic/beats/issues/6191

r? @adriansr 

Signed-off-by: Jaipradeesh <jaipradeesh@gmail.com>