### PR TITLE
Use the tudorg/xgo-base image from docker hub

### DIFF
--- a/dev-tools/packer/docker/xgo-image/build.sh
+++ b/dev-tools/packer/docker/xgo-image/build.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-docker build --rm=true -t tudorg/xgo-base base/ && \
+docker pull tudorg/xgo-base:v20180222 && \
     docker build --rm=true -t tudorg/xgo-1.9.4 go-1.9.4/ &&
     docker build --rm=true -t tudorg/beats-builder beats-builder

--- a/dev-tools/packer/docker/xgo-image/push_image.md
+++ b/dev-tools/packer/docker/xgo-image/push_image.md
@@ -1,0 +1,16 @@
+XXX: this should be temporary until we can use the Elastic Registry.
+
+To update the `tudorg/xgo-base` image on Docker HUB, do the following:
+
+* `docker login` with your docker hub credentials. Feel free to publish the image
+  to your own account if Tudor is not available.
+
+* Build the image: `docker build --rm=true -t tudorg/xgo-base base/`
+
+* List the images: `docker images`
+
+* Tag it: `docker tag <image_id> tudorg/xgo-base:$(date '+v%Y%m%d')`
+
+* Push: `docker push tudorg/xgo-base`
+
+* Update `build.sh` to use the new image/tag


### PR DESCRIPTION
Another attempt to fix the transient packaging error. I pushed the
tudorg/xgo-base image to Docker Hub and have the build script pull it
from there, rather than building it locally.

This should reduce the amount of network dependencies and speed up the
build as well.

Same could be done for xgo-base-deb, but this part is currently more
critical.