### PR TITLE
Rename *.time metrics to *.time_ms

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -23,6 +23,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - De dot keys of labels and annotations in kubernetes meta processors to prevent collisions. {pull}6203[6203]
 - The default value for pipelining is reduced to 2 to avoid high memory in the Logstash beats input. {pull}6250[6250]
 - Add logging when monitoring cannot connect to Elasticsearch. {pull}6365[6365]
+- Rename beat.cpu.*.time_ms metrics to beat.cpu.*.time.ms. {pull}6449[6449]
 
 *Auditbeat*
 

--- a/libbeat/cmd/instance/metrics.go
+++ b/libbeat/cmd/instance/metrics.go
@@ -122,16 +122,22 @@ func reportBeatCPU(_ monitoring.Mode, V monitoring.Visitor) {
 
 	monitoring.ReportNamespace(V, "user", func() {
 		monitoring.ReportInt(V, "ticks", int64(cpuTicks.User))
-		monitoring.ReportInt(V, "time", userTime)
+		monitoring.ReportNamespace(V, "time", func() {
+			monitoring.ReportInt(V, "ms", userTime)
+		})
 	})
 	monitoring.ReportNamespace(V, "system", func() {
 		monitoring.ReportInt(V, "ticks", int64(cpuTicks.System))
-		monitoring.ReportInt(V, "time", systemTime)
+		monitoring.ReportNamespace(V, "time", func() {
+			monitoring.ReportInt(V, "ms", systemTime)
+		})
 	})
 	monitoring.ReportNamespace(V, "total", func() {
 		monitoring.ReportFloat(V, "value", totalCPUUsage)
 		monitoring.ReportInt(V, "ticks", int64(cpuTicks.Total))
-		monitoring.ReportInt(V, "time", userTime+systemTime)
+		monitoring.ReportNamespace(V, "time", func() {
+			monitoring.ReportInt(V, "ms", userTime+systemTime)
+		})
 	})
 }
 


### PR DESCRIPTION
The following renames are done as requested by @tsullivan in https://github.com/elastic/x-pack-kibana/issues/4644#issuecomment-367526912:
`beat.cpu.system.time` -> `beat.cpu.system.time.ms`
`beat.cpu.user.time` -> `beat.cpu.user.time.ms`
`beat.cpu.total.time` -> `beat.cpu.total.time.ms`

I am not sure if it's ok to rename these metrics, as they are already released. I am closing if we decide against renaming.

EDIT: the following counters can be access like this: event["beat"]["cpu"]["user"]["time"]["ms"], etc.