### PR TITLE
Fix examples by removing old syntax

### DIFF
--- a/filebeat/docs/filebeat-filtering.asciidoc
+++ b/filebeat/docs/filebeat-filtering.asciidoc
@@ -68,7 +68,8 @@ The following configuration decodes the inner JSON object:
 [source,yaml]
 -----------------------------------------------------
 filebeat.prospectors:
-- paths:
+- type: log
+  paths:
     - input.json
   json.keys_under_root: true
 

--- a/filebeat/docs/filebeat-options.asciidoc
+++ b/filebeat/docs/filebeat-options.asciidoc
@@ -100,7 +100,8 @@ The following example configures Filebeat to drop any lines that start with "DBG
 [source,yaml]
 -------------------------------------------------------------------------------------
 filebeat.prospectors:
-- paths:
+- type: log
+  paths:
     - /var/log/myapp/*.log
   exclude_lines: ['^DBG']
 -------------------------------------------------------------------------------------
@@ -120,7 +121,8 @@ The following example configures Filebeat to export any lines that start with "E
 [source,yaml]
 -------------------------------------------------------------------------------------
 filebeat.prospectors:
-- paths:
+- type: log
+  paths:
     - /var/log/myapp/*.log
   include_lines: ['^ERR', '^WARN']
 -------------------------------------------------------------------------------------
@@ -167,7 +169,8 @@ Example:
 [source,yaml]
 --------------------------------------------------------------------------------
 filebeat.prospectors:
-- paths: ["/var/log/app/*.json"]
+- type: log
+  paths: ["/var/log/app/*.json"]
   tags: ["json"]
 --------------------------------------------------------------------------------
 
@@ -187,7 +190,8 @@ will be overwritten by the value declared here.
 [source,yaml]
 --------------------------------------------------------------------------------
 filebeat.prospectors:
-- paths: ["/var/log/app/*.log"]
+- type: log
+  paths: ["/var/log/app/*.log"]
   fields:
     app_id: query_engine_12
 --------------------------------------------------------------------------------

--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -257,10 +257,12 @@ Example elasticsearch output with `pipelines`:
 ["source","yaml"]
 ------------------------------------------------------------------------------
 filebeat.prospectors:
-- paths: ["/var/log/app/normal/*.log"]
+- type: log
+  paths: ["/var/log/app/normal/*.log"]
   fields:
     type: "normal"
-- paths: ["/var/log/app/critical/*.log"]
+- type: log
+  paths: ["/var/log/app/critical/*.log"]
   fields:
     type: "critical"
 


### PR DESCRIPTION
I noticed while working on a different PR that some of our examples use the old way of specifying paths. Maybe this still works for backwards compatibility (?), but it's potentially confusing for users.

I noticed that testfilebeat/tests/system/config/filebeat_inputs.yml.j2 also uses the old syntax, but I didn't fix it because I don't know if that test is still used.

Please eyeball the examples carefully. I didn't run them to test because the change seemed small.