### PR TITLE
Preserve runtime from container statuses in Kubernetes autodiscover

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -184,6 +184,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Panics will be written to the logger before exiting. {pull}6199[6199]
 - Add builder support for autodiscover and annotations builder {pull}6408[6408]
 - Add plugin support for autodiscover builders, providers {pull}6457[6457]
+- Preserve runtime from container statuses in Kubernetes autodiscover {pull}6456[6456]
 
 *Auditbeat*
 

--- a/libbeat/autodiscover/providers/kubernetes/kubernetes.go
+++ b/libbeat/autodiscover/providers/kubernetes/kubernetes.go
@@ -111,7 +111,7 @@ func (p *Provider) emitEvents(pod *kubernetes.Pod, flag string, containers []kub
 	containerstatuses []kubernetes.PodContainerStatus) {
 	host := pod.Status.PodIP
 
-	// Collect all container IDs and runtimes from status information. Kubernetes has both docker and rkt
+	// Collect all container IDs and runtimes from status information.
 	containerIDs := map[string]string{}
 	runtimes := map[string]string{}
 	for _, c := range containerstatuses {
@@ -207,14 +207,10 @@ func (p *Provider) generateHints(event bus.Event) bus.Event {
 
 	if rawCont, ok := kubeMeta["container"]; ok {
 		container = rawCont.(common.MapStr)
-		// This would end up adding a docker|rkt.container entry into the event. This would make sure
+		// This would end up adding a runtime entry into the event. This would make sure
 		// that there is not an attempt to spin up a docker input for a rkt container and when a
 		// rkt input exists it would be natively supported.
-		if runtime, ok := container["runtime"]; ok {
-			e[runtime.(string)] = common.MapStr{
-				"container": container,
-			}
-		}
+		e["container"] = container
 	}
 
 	cname := builder.GetContainerName(container)

--- a/libbeat/autodiscover/providers/kubernetes/kubernetes_test.go
+++ b/libbeat/autodiscover/providers/kubernetes/kubernetes_test.go
@@ -41,22 +41,25 @@ func TestGenerateHints(t *testing.T) {
 			event: bus.Event{
 				"kubernetes": common.MapStr{
 					"container": common.MapStr{
-						"name": "foobar",
-						"id":   "abc",
+						"name":    "foobar",
+						"id":      "abc",
+						"runtime": "rkt",
 					},
 				},
 			},
 			result: bus.Event{
 				"kubernetes": common.MapStr{
 					"container": common.MapStr{
-						"name": "foobar",
-						"id":   "abc",
+						"name":    "foobar",
+						"id":      "abc",
+						"runtime": "rkt",
 					},
 				},
-				"docker": common.MapStr{
+				"rkt": common.MapStr{
 					"container": common.MapStr{
-						"name": "foobar",
-						"id":   "abc",
+						"name":    "foobar",
+						"id":      "abc",
+						"runtime": "rkt",
 					},
 				},
 			},
@@ -77,8 +80,9 @@ func TestGenerateHints(t *testing.T) {
 						"not.to.include":                    "true",
 					},
 					"container": common.MapStr{
-						"name": "foobar",
-						"id":   "abc",
+						"name":    "foobar",
+						"id":      "abc",
+						"runtime": "docker",
 					},
 				},
 			},
@@ -92,8 +96,9 @@ func TestGenerateHints(t *testing.T) {
 						"co.elastic.metrics.foobar/period":  "15s",
 					},
 					"container": common.MapStr{
-						"name": "foobar",
-						"id":   "abc",
+						"name":    "foobar",
+						"id":      "abc",
+						"runtime": "docker",
 					},
 				},
 				"hints": common.MapStr{
@@ -109,8 +114,9 @@ func TestGenerateHints(t *testing.T) {
 				},
 				"docker": common.MapStr{
 					"container": common.MapStr{
-						"name": "foobar",
-						"id":   "abc",
+						"name":    "foobar",
+						"id":      "abc",
+						"runtime": "docker",
 					},
 				},
 			},

--- a/libbeat/autodiscover/providers/kubernetes/kubernetes_test.go
+++ b/libbeat/autodiscover/providers/kubernetes/kubernetes_test.go
@@ -55,12 +55,10 @@ func TestGenerateHints(t *testing.T) {
 						"runtime": "rkt",
 					},
 				},
-				"rkt": common.MapStr{
-					"container": common.MapStr{
-						"name":    "foobar",
-						"id":      "abc",
-						"runtime": "rkt",
-					},
+				"container": common.MapStr{
+					"name":    "foobar",
+					"id":      "abc",
+					"runtime": "rkt",
 				},
 			},
 		},
@@ -112,12 +110,10 @@ func TestGenerateHints(t *testing.T) {
 						"period": "15s",
 					},
 				},
-				"docker": common.MapStr{
-					"container": common.MapStr{
-						"name":    "foobar",
-						"id":      "abc",
-						"runtime": "docker",
-					},
+				"container": common.MapStr{
+					"name":    "foobar",
+					"id":      "abc",
+					"runtime": "docker",
 				},
 			},
 		},

--- a/libbeat/common/kubernetes/types.go
+++ b/libbeat/common/kubernetes/types.go
@@ -133,14 +133,20 @@ func (p *Pod) GetMetadata() *ObjectMeta {
 
 // GetContainerID parses the container ID to get the actual ID string
 func (s *PodContainerStatus) GetContainerID() string {
+	cID, _ := s.GetContainerIDWithRuntime()
+	return cID
+}
+
+// GetContainerIDWithRuntime parses the container ID to get the actual ID string
+func (s *PodContainerStatus) GetContainerIDWithRuntime() (string, string) {
 	cID := s.ContainerID
 	if cID != "" {
-		parts := strings.Split(cID, "//")
+		parts := strings.Split(cID, "://")
 		if len(parts) == 2 {
-			return parts[1]
+			return parts[1], parts[0]
 		}
 	}
-	return ""
+	return "", ""
 }
 
 // Event is kubernetes event

--- a/libbeat/common/kubernetes/types_test.go
+++ b/libbeat/common/kubernetes/types_test.go
@@ -35,3 +35,34 @@ func TestPodContainerStatus_GetContainerID(t *testing.T) {
 		assert.Equal(t, test.status.GetContainerID(), test.result)
 	}
 }
+
+func TestPodContainerStatus_GetContainerIDWithRuntime(t *testing.T) {
+	tests := []struct {
+		status *PodContainerStatus
+		result string
+	}{
+		// Check to see if x://y is parsed to return x as the runtime
+		{
+			status: &PodContainerStatus{
+				Name:        "foobar",
+				ContainerID: "docker://abc",
+				Image:       "foobar:latest",
+			},
+			result: "docker",
+		},
+		// Check to see if x://y is not the format then "" is returned
+		{
+			status: &PodContainerStatus{
+				Name:        "foobar",
+				ContainerID: "abc",
+				Image:       "foobar:latest",
+			},
+			result: "",
+		},
+	}
+
+	for _, test := range tests {
+		_, runtime := test.status.GetContainerIDWithRuntime()
+		assert.Equal(t, runtime, test.result)
+	}
+}


### PR DESCRIPTION
The initial implementation assumed always that containers come from docker. There are kube clusters that run `rkt` as the container runtime. Atleast we would not spin up docker prospectors/inputs by default when Beats is run in them and based on `rkt` behavior we can atleast manually set a config template on the `logs` builder config. 