### PR TITLE
Remove dependency on gopkg.in

### DIFF
--- a/dev-tools/packer/Makefile
+++ b/dev-tools/packer/Makefile
@@ -41,7 +41,7 @@ package-dashboards:
 
 .PHONY: deps
 deps:
-	go get -u github.com/tsg/gotpl
+	cd ../vendor/github.com/tsg/gotpl; go install
 
 .PHONY: xgo-image
 xgo-image:

--- a/dev-tools/packer/docker/xgo-image/.gitignore
+++ b/dev-tools/packer/docker/xgo-image/.gitignore
@@ -1,0 +1,2 @@
+beats-builder/yaml.v2
+beats-builder/gotpl

--- a/dev-tools/packer/docker/xgo-image/beats-builder/Dockerfile
+++ b/dev-tools/packer/docker/xgo-image/beats-builder/Dockerfile
@@ -25,7 +25,10 @@ RUN \
 	rm `basename $WPDPACK_URL`
 
 # Load gotpl
-RUN go get github.com/tsg/gotpl
+ADD yaml.v2 /go/src/gopkg.in/yaml.v2
+ADD gotpl /go/src/github.com/tsg/gotpl
+RUN cd /go/src/github.com/tsg/gotpl && \
+  go install
 
 # Add patch for gopacket.
 ADD gopacket_pcap.patch /gopacket_pcap.patch

--- a/dev-tools/packer/docker/xgo-image/build.sh
+++ b/dev-tools/packer/docker/xgo-image/build.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+cp -r ../../../vendor/gopkg.in/yaml.v2 beats-builder/yaml.v2
+cp -r ../../../vendor/github.com/tsg/gotpl beats-builder/gotpl
 docker pull tudorg/xgo-base:v20180222 && \
     docker build --rm=true -t tudorg/xgo-1.9.4 go-1.9.4/ &&
     docker build --rm=true -t tudorg/beats-builder beats-builder


### PR DESCRIPTION
This removes the remaining `go get` for gotpl, by using the vendored
copy. This should get rid of our dependency on the gopkg.in service.