### PR TITLE
Metricbeat: Support wildcards in jolokia (#6453)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -257,6 +257,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Making the MongoDB module GA. {pull}6554[6554]
 - Allow to disable labels `dedot` in Docker module, in favor of a safe way to keep dots. {pull}6490[6490]
 - Add experimental module to collect metrics from munin nodes. {pull}6517[6517]
+- Add support for wildcards and explicit metrics grouping in jolokia/jmx. {pull}6462[6462]
 
 *Packetbeat*
 

--- a/metricbeat/module/jolokia/jmx/_meta/docs.asciidoc
+++ b/metricbeat/module/jolokia/jmx/_meta/docs.asciidoc
@@ -22,6 +22,7 @@ mapping:
       attributes:
         - attr: Uptime
           field: uptime
+          event: uptime
 ---
 
 In case the underlying attribute is an object (e.g. see HeapMemoryUsage attribute in java.lang:type=Memory) its
@@ -34,8 +35,10 @@ All metrics from a single mapping will be POSTed to the defined host/port and se
 To make it possible to differentiate between metrics from multiple similar applications running on the same host,
 please configure multiple modules.
 
-When wildcards are used, an event will be sent to Elastic for each matching mbean, in that case a `mbean` field is
-added.
+When wildcards are used, an event will be sent to Elastic for each matching mbean, in that case a `mbean` field is added.
+
+Optionally, an `event` name can be added to each attribute, this makes all metrics with the same `event`
+to be grouped in the same event when being sent to Elastic.
 
 It is required to set a namespace in the general module config section.
 

--- a/metricbeat/module/jolokia/jmx/_meta/docs.asciidoc
+++ b/metricbeat/module/jolokia/jmx/_meta/docs.asciidoc
@@ -34,11 +34,14 @@ All metrics from a single mapping will be POSTed to the defined host/port and se
 To make it possible to differentiate between metrics from multiple similar applications running on the same host,
 please configure multiple modules.
 
+When wildcards are used, an event will be sent to Elastic for each matching mbean, in that case a `mbean` field is
+added.
+
 It is required to set a namespace in the general module config section.
 
 [float]
 === Limitations
-No authentication against Jolokia is supported yet. No wildcards in Jolokia requests supported yet.
+No authentication against Jolokia is supported yet.
 All Jolokia requests have canonicalNaming set to false (details see here: https://jolokia.org/reference/html/protocol.html).
 
 

--- a/metricbeat/module/jolokia/jmx/_meta/test/jolokia_response_wildcard.json
+++ b/metricbeat/module/jolokia/jmx/_meta/test/jolokia_response_wildcard.json
@@ -1,0 +1,24 @@
+[
+    {
+        "value": {
+            "Catalina:name=\"http-bio-8080\",type=ThreadPool": {
+                "maxConnections": 200,
+                "port": 8080
+            },
+            "Catalina:name=\"ajp-bio-8009\",type=ThreadPool": {
+                "maxConnections": 200,
+                "port": 8009
+            }
+        },
+        "request": {
+            "type": "read",
+            "attribute": [
+                "port",
+            "maxConnections"
+                ],
+            "mbean": "Catalina:name=*,type=ThreadPool"
+        },
+        "status": 200,
+        "timestamp": 1520469345
+    }
+]

--- a/metricbeat/module/jolokia/jmx/config.go
+++ b/metricbeat/module/jolokia/jmx/config.go
@@ -10,6 +10,7 @@ type JMXMapping struct {
 type Attribute struct {
 	Attr  string
 	Field string
+	Event string
 }
 
 // RequestBlock is used to build the request blocks of the following format:
@@ -37,8 +38,22 @@ type RequestBlock struct {
 	Attribute []string `json:"attribute"`
 }
 
-func buildRequestBodyAndMapping(mappings []JMXMapping) ([]byte, map[string]string, error) {
-	responseMapping := map[string]string{}
+type attributeMappingKey struct {
+	mbean, attr string
+}
+
+// AttributeMapping contains the mapping information between attributes in Jolokia
+// responses and fields in metricbeat events
+type AttributeMapping map[attributeMappingKey]Attribute
+
+// Get the mapping options for the attribute of an mbean
+func (m AttributeMapping) Get(mbean, attr string) (Attribute, bool) {
+	a, found := m[attributeMappingKey{mbean, attr}]
+	return a, found
+}
+
+func buildRequestBodyAndMapping(mappings []JMXMapping) ([]byte, AttributeMapping, error) {
+	responseMapping := make(AttributeMapping)
 	var blocks []RequestBlock
 
 	for _, mapping := range mappings {
@@ -49,7 +64,7 @@ func buildRequestBodyAndMapping(mappings []JMXMapping) ([]byte, map[string]strin
 
 		for _, attribute := range mapping.Attributes {
 			rb.Attribute = append(rb.Attribute, attribute.Attr)
-			responseMapping[mapping.MBean+"_"+attribute.Attr] = attribute.Field
+			responseMapping[attributeMappingKey{mapping.MBean, attribute.Attr}] = attribute
 		}
 		blocks = append(blocks, rb)
 	}

--- a/metricbeat/module/jolokia/jmx/data_test.go
+++ b/metricbeat/module/jolokia/jmx/data_test.go
@@ -20,13 +20,19 @@ func TestEventMapper(t *testing.T) {
 
 	assert.Nil(t, err)
 
-	var mapping = map[string]string{
-		"java.lang:type=Runtime_Uptime":                                            "uptime",
-		"java.lang:type=GarbageCollector,name=ConcurrentMarkSweep_CollectionTime":  "gc.cms_collection_time",
-		"java.lang:type=GarbageCollector,name=ConcurrentMarkSweep_CollectionCount": "gc.cms_collection_count",
-		"java.lang:type=Memory_HeapMemoryUsage":                                    "memory.heap_usage",
-		"java.lang:type=Memory_NonHeapMemoryUsage":                                 "memory.non_heap_usage",
-		"org.springframework.boot:type=Endpoint,name=metricsEndpoint_Metrics":      "metrics",
+	var mapping = AttributeMapping{
+		attributeMappingKey{"java.lang:type=Runtime", "Uptime"}: Attribute{
+			Attr: "Uptime", Field: "uptime"},
+		attributeMappingKey{"java.lang:type=GarbageCollector,name=ConcurrentMarkSweep", "CollectionTime"}: Attribute{
+			Attr: "CollectionTime", Field: "gc.cms_collection_time"},
+		attributeMappingKey{"java.lang:type=GarbageCollector,name=ConcurrentMarkSweep", "CollectionCount"}: Attribute{
+			Attr: "CollectionCount", Field: "gc.cms_collection_count"},
+		attributeMappingKey{"java.lang:type=Memory", "HeapMemoryUsage"}: Attribute{
+			Attr: "HeapMemoryUsage", Field: "memory.heap_usage"},
+		attributeMappingKey{"java.lang:type=Memory", "NonHeapMemoryUsage"}: Attribute{
+			Attr: "NonHEapMemoryUsage", Field: "memory.non_heap_usage"},
+		attributeMappingKey{"org.springframework.boot:type=Endpoint,name=metricsEndpoint", "Metrics"}: Attribute{
+			Attr: "Metrics", Field: "metrics"},
 	}
 
 	events, err := eventMapping(jolokiaResponse, mapping)
@@ -65,6 +71,71 @@ func TestEventMapper(t *testing.T) {
 	assert.ElementsMatch(t, expected, events)
 }
 
+func TestEventGroupingMapper(t *testing.T) {
+	absPath, err := filepath.Abs("./_meta/test")
+
+	assert.NotNil(t, absPath)
+	assert.Nil(t, err)
+
+	jolokiaResponse, err := ioutil.ReadFile(absPath + "/jolokia_response.json")
+
+	assert.Nil(t, err)
+
+	var mapping = AttributeMapping{
+		attributeMappingKey{"java.lang:type=Runtime", "Uptime"}: Attribute{
+			Attr: "Uptime", Field: "uptime"},
+		attributeMappingKey{"java.lang:type=GarbageCollector,name=ConcurrentMarkSweep", "CollectionTime"}: Attribute{
+			Attr: "CollectionTime", Field: "gc.cms_collection_time", Event: "gc"},
+		attributeMappingKey{"java.lang:type=GarbageCollector,name=ConcurrentMarkSweep", "CollectionCount"}: Attribute{
+			Attr: "CollectionCount", Field: "gc.cms_collection_count", Event: "gc"},
+		attributeMappingKey{"java.lang:type=Memory", "HeapMemoryUsage"}: Attribute{
+			Attr: "HeapMemoryUsage", Field: "memory.heap_usage", Event: "memory"},
+		attributeMappingKey{"java.lang:type=Memory", "NonHeapMemoryUsage"}: Attribute{
+			Attr: "NonHEapMemoryUsage", Field: "memory.non_heap_usage", Event: "memory"},
+		attributeMappingKey{"org.springframework.boot:type=Endpoint,name=metricsEndpoint", "Metrics"}: Attribute{
+			Attr: "Metrics", Field: "metrics"},
+	}
+
+	events, err := eventMapping(jolokiaResponse, mapping)
+	assert.Nil(t, err)
+
+	expected := []common.MapStr{
+		{
+			"uptime": float64(47283),
+			"metrics": map[string]interface{}{
+				"atomikos_nbTransactions": float64(0),
+				"classes":                 float64(18857),
+				"classes_loaded":          float64(19127),
+				"classes_unloaded":        float64(270),
+			},
+		},
+		{
+			"gc": common.MapStr{
+				"cms_collection_time":  float64(53),
+				"cms_collection_count": float64(1),
+			},
+		},
+		{
+			"memory": common.MapStr{
+				"heap_usage": map[string]interface{}{
+					"init":      float64(1073741824),
+					"committed": float64(1037959168),
+					"max":       float64(1037959168),
+					"used":      float64(227420472),
+				},
+				"non_heap_usage": map[string]interface{}{
+					"init":      float64(2555904),
+					"committed": float64(53477376),
+					"max":       float64(-1),
+					"used":      float64(50519768),
+				},
+			},
+		},
+	}
+
+	assert.ElementsMatch(t, expected, events)
+}
+
 func TestEventMapperWithWildcard(t *testing.T) {
 	absPath, err := filepath.Abs("./_meta/test")
 
@@ -75,9 +146,11 @@ func TestEventMapperWithWildcard(t *testing.T) {
 
 	assert.Nil(t, err)
 
-	var mapping = map[string]string{
-		"Catalina:name=*,type=ThreadPool_port":           "port",
-		"Catalina:name=*,type=ThreadPool_maxConnections": "max_connections",
+	var mapping = AttributeMapping{
+		attributeMappingKey{"Catalina:name=*,type=ThreadPool", "port"}: Attribute{
+			Attr: "port", Field: "port"},
+		attributeMappingKey{"Catalina:name=*,type=ThreadPool", "maxConnections"}: Attribute{
+			Attr: "maxConnections", Field: "max_connections"},
 	}
 
 	events, err := eventMapping(jolokiaResponse, mapping)
@@ -94,6 +167,49 @@ func TestEventMapperWithWildcard(t *testing.T) {
 			"mbean":           "Catalina:name=\"ajp-bio-8009\",type=ThreadPool",
 			"max_connections": float64(200),
 			"port":            float64(8009),
+		},
+	}
+
+	assert.ElementsMatch(t, expected, events)
+}
+
+func TestEventGroupingMapperWithWildcard(t *testing.T) {
+	absPath, err := filepath.Abs("./_meta/test")
+
+	assert.NotNil(t, absPath)
+	assert.Nil(t, err)
+
+	jolokiaResponse, err := ioutil.ReadFile(absPath + "/jolokia_response_wildcard.json")
+
+	assert.Nil(t, err)
+
+	var mapping = AttributeMapping{
+		attributeMappingKey{"Catalina:name=*,type=ThreadPool", "port"}: Attribute{
+			Attr: "port", Field: "port", Event: "port"},
+		attributeMappingKey{"Catalina:name=*,type=ThreadPool", "maxConnections"}: Attribute{
+			Attr: "maxConnections", Field: "max_connections", Event: "network"},
+	}
+
+	events, err := eventMapping(jolokiaResponse, mapping)
+	assert.Nil(t, err)
+	assert.Equal(t, 4, len(events))
+
+	expected := []common.MapStr{
+		{
+			"mbean": "Catalina:name=\"http-bio-8080\",type=ThreadPool",
+			"port":  float64(8080),
+		},
+		{
+			"mbean":           "Catalina:name=\"http-bio-8080\",type=ThreadPool",
+			"max_connections": float64(200),
+		},
+		{
+			"mbean": "Catalina:name=\"ajp-bio-8009\",type=ThreadPool",
+			"port":  float64(8009),
+		},
+		{
+			"mbean":           "Catalina:name=\"ajp-bio-8009\",type=ThreadPool",
+			"max_connections": float64(200),
 		},
 	}
 

--- a/metricbeat/module/jolokia/jmx/jmx.go
+++ b/metricbeat/module/jolokia/jmx/jmx.go
@@ -37,7 +37,7 @@ var (
 // MetricSet type defines all fields of the MetricSet
 type MetricSet struct {
 	mb.BaseMetricSet
-	mapping   map[string]string
+	mapping   AttributeMapping
 	namespace string
 	http      *helper.HTTP
 	log       *logp.Logger

--- a/metricbeat/module/jolokia/jmx/jmx_integration_test.go
+++ b/metricbeat/module/jolokia/jmx/jmx_integration_test.go
@@ -16,22 +16,22 @@ func TestFetch(t *testing.T) {
 	compose.EnsureUp(t, "jolokia")
 
 	for _, config := range getConfigs() {
-		f := mbtest.NewEventFetcher(t, config)
-		event, err := f.Fetch()
+		f := mbtest.NewEventsFetcher(t, config)
+		events, err := f.Fetch()
 		if !assert.NoError(t, err) {
 			t.FailNow()
 		}
-		t.Logf("%s/%s event: %+v", f.Module().Name(), f.Name(), event)
-		if len(event) <= 1 {
-			t.Fatal("Empty event")
+		t.Logf("%s/%s events: %+v", f.Module().Name(), f.Name(), events)
+		if len(events) == 0 || len(events[0]) <= 1 {
+			t.Fatal("Empty events")
 		}
 	}
 }
 
 func TestData(t *testing.T) {
 	for _, config := range getConfigs() {
-		f := mbtest.NewEventFetcher(t, config)
-		err := mbtest.WriteEvent(f, t)
+		f := mbtest.NewEventsFetcher(t, config)
+		err := mbtest.WriteEvents(f, t)
 		if err != nil {
 			t.Fatal("write", err)
 		}

--- a/metricbeat/module/jolokia/jmx/jmx_integration_test.go
+++ b/metricbeat/module/jolokia/jmx/jmx_integration_test.go
@@ -15,62 +15,91 @@ import (
 func TestFetch(t *testing.T) {
 	compose.EnsureUp(t, "jolokia")
 
-	f := mbtest.NewEventFetcher(t, getConfig())
-	event, err := f.Fetch()
-	if !assert.NoError(t, err) {
-		t.FailNow()
+	for _, config := range getConfigs() {
+		f := mbtest.NewEventFetcher(t, config)
+		event, err := f.Fetch()
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+		t.Logf("%s/%s event: %+v", f.Module().Name(), f.Name(), event)
+		if len(event) <= 1 {
+			t.Fatal("Empty event")
+		}
 	}
-
-	t.Logf("%s/%s event: %+v", f.Module().Name(), f.Name(), event)
 }
 
 func TestData(t *testing.T) {
-	f := mbtest.NewEventFetcher(t, getConfig())
-	err := mbtest.WriteEvent(f, t)
-	if err != nil {
-		t.Fatal("write", err)
+	for _, config := range getConfigs() {
+		f := mbtest.NewEventFetcher(t, config)
+		err := mbtest.WriteEvent(f, t)
+		if err != nil {
+			t.Fatal("write", err)
+		}
 	}
 }
 
-func getConfig() map[string]interface{} {
-	return map[string]interface{}{
-		"module":     "jolokia",
-		"metricsets": []string{"jmx"},
-		"hosts":      []string{getEnvHost() + ":" + getEnvPort()},
-		"namespace":  "testnamespace",
-		"jmx.mappings": []map[string]interface{}{
-			{
-				"mbean": "java.lang:type=Runtime",
-				"attributes": []map[string]string{
-					{
-						"attr":  "Uptime",
-						"field": "uptime",
+func getConfigs() []map[string]interface{} {
+	return []map[string]interface{}{
+		{
+			"module":     "jolokia",
+			"metricsets": []string{"jmx"},
+			"hosts":      []string{getEnvHost() + ":" + getEnvPort()},
+			"namespace":  "testnamespace",
+			"jmx.mappings": []map[string]interface{}{
+				{
+					"mbean": "java.lang:type=Runtime",
+					"attributes": []map[string]string{
+						{
+							"attr":  "Uptime",
+							"field": "uptime",
+						},
+					},
+				},
+				{
+					"mbean": "java.lang:type=GarbageCollector,name=ConcurrentMarkSweep",
+					"attributes": []map[string]string{
+						{
+							"attr":  "CollectionTime",
+							"field": "gc.cms_collection_time",
+						},
+						{
+							"attr":  "CollectionCount",
+							"field": "gc.cms_collection_count",
+						},
+					},
+				},
+				{
+					"mbean": "java.lang:type=Memory",
+					"attributes": []map[string]string{
+						{
+							"attr":  "HeapMemoryUsage",
+							"field": "memory.heap_usage",
+						},
+						{
+							"attr":  "NonHeapMemoryUsage",
+							"field": "memory.non_heap_usage",
+						},
 					},
 				},
 			},
-			{
-				"mbean": "java.lang:type=GarbageCollector,name=ConcurrentMarkSweep",
-				"attributes": []map[string]string{
-					{
-						"attr":  "CollectionTime",
-						"field": "gc.cms_collection_time",
-					},
-					{
-						"attr":  "CollectionCount",
-						"field": "gc.cms_collection_count",
-					},
-				},
-			},
-			{
-				"mbean": "java.lang:type=Memory",
-				"attributes": []map[string]string{
-					{
-						"attr":  "HeapMemoryUsage",
-						"field": "memory.heap_usage",
-					},
-					{
-						"attr":  "NonHeapMemoryUsage",
-						"field": "memory.non_heap_usage",
+		},
+		{
+			"module":     "jolokia",
+			"metricsets": []string{"jmx"},
+			"hosts":      []string{getEnvHost() + ":" + getEnvPort()},
+			"namespace":  "testnamespace",
+			"jmx.mappings": []map[string]interface{}{
+				{
+					"mbean": "Catalina:name=*,type=ThreadPool",
+					"attributes": []map[string]string{
+						{
+							"attr":  "maxConnections",
+							"field": "max_connections",
+						},
+						{
+							"attr":  "port",
+							"field": "port",
+						},
 					},
 				},
 			},


### PR DESCRIPTION
Partially support wildcards in jolokia. This would cover the case of #6453 where wildcard is used to match one of two possible names. In a more general case this implementation is incomplete because if multiple mbeans match, their field mapping will collide and only one value will be stored.

To solve this I see two options:

1. Generate an event for each matching mbean, so each event has a field with the name of the mbean. For example, current events are like this:
```
{
  "port": 8080,
  "max_connections": 200,
  "_namespace": "testnamespace"
}
```
New events would contain also the mbean, so with a wildcard these events could be generated:
```
{
  "port": 8080,
  "max_connections": 200,
  "mbean": "Catalina:name=\"http-bio-8080\",type=ThreadPool",
  "_namespace": "testnamespace"
}

{
  "port": 8009,
  "max_connections": 200,
  "mbean": "Catalina:name=\"ajp-bio-8009\",type=ThreadPool",
  "_namespace": "testnamespace"
}
```



2. Add a regular expression or similar to the attributes mapping that can be used to fill placeholders in the field name, e.g:
```
jmx.mappings:
       mbean: 'Catalina:name=*,type=ThreadPool'
       attributes:
                  attr: maxConnections
                  field: "${name}.max_connections"
                  mbeanFields: 'Catalina:name=(?P<name>[^,]),type=ThreadPool'
```
Would generate events like this one:
```
{
  "http-bio-8080": {
    "port": 8080,
    "max_connections": 200
  },
  "ajp-bio-8009": {
    "port": 8009,
    "max_connections": 200
  },
  "_namespace": "testnamespace"
}
```
I think option 1 is more intuitive, but I'm not sure if generating multiple events fits with the general design of the module, opinions?