### PR TITLE
Change crosscompile target to depend on gox as default

### DIFF
--- a/filebeat/Makefile
+++ b/filebeat/Makefile
@@ -3,7 +3,6 @@ BEAT_TITLE?=Filebeat
 BEAT_DESCRIPTION?=Filebeat sends log files to Logstash or directly to Elasticsearch.
 SYSTEM_TESTS?=true
 TEST_ENVIRONMENT?=true
-GOX_FLAGS=-arch="amd64 386 arm ppc64 ppc64le"
 ES_BEATS?=..
 
 include ${ES_BEATS}/libbeat/scripts/Makefile

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -52,8 +52,8 @@ NOSETESTS_OPTIONS?=--process-timeout=$(TIMEOUT) --with-timer -v --with-xunit --x
 TEST_ENVIRONMENT?=false ## @testing if true, "make testsuite" runs integration tests and system tests in a dockerized test environment
 SYSTEM_TESTS?=false ## @testing if true, "make test" and "make testsuite" run unit tests and system tests
 STRESS_TESTS?=false ## @testing if true, "make test" and "make testsuite" run also run the stress tests
-GOX_OS?=linux darwin windows freebsd netbsd openbsd ## @Building List of all OS to be supported by "make crosscompile".
-GOX_OSARCH?=!darwin/arm !darwin/arm64 !darwin/386 ## @building Space separated list of GOOS/GOARCH pairs to build by "make crosscompile".
+GOX_OS?=## @Building List of all OS to be supported by "make crosscompile".
+GOX_OSARCH?=## @building Space separated list of GOOS/GOARCH pairs to build by "make crosscompile".
 GOX_FLAGS?= ## @building Additional flags to append to the gox command used by "make crosscompile".
 # XXX: Should be switched back to `snapshot` once the Elasticsearch
 # snapshots are working. https://github.com/elastic/beats/pull/6416


### PR DESCRIPTION
With https://github.com/mitchellh/gox/pull/96 gox has been update to support all the platforms for 1.10. Instead of depending on our self defined list as default this changes to dependn on gox defaults.

The difference on platforms built by default looks as following:

Removed:
```
-->     linux/ppc64: github.com/elastic/beats/filebeat
-->   linux/ppc64le: github.com/elastic/beats/filebeat
-->     linux/arm64: github.com/elastic/beats/filebeat
```

Added:
```
-->      darwin/386: github.com/elastic/beats/filebeat
```

It's still possible as before to overwrite these defaults in each Beat.

The gox platforms depend on the go version used. Because of this updating the Go version on our side could bring new platforms. But as we version the go version as part of the repo we would detect this directly. Having said that, recently not new platforms have been added.

This PR also changes the defaults for Filebeat to depend on the gox defaults.