### PR TITLE
Add ARM build to our packaging

### DIFF
--- a/dev-tools/packer/Makefile
+++ b/dev-tools/packer/Makefile
@@ -34,6 +34,10 @@ beat_abspath=${BEATS_GOPATH}/src/${BEAT_PATH}
 	ARCH=386 BEAT=$(@D) BUILD_DIR=${BUILD_DIR} UPLOAD_DIR=${UPLOAD_DIR} BEAT_PATH=$(beat_abspath) BUILDID=$(BUILDID) SNAPSHOT=$(SNAPSHOT) $(packer_absdir)/platforms/binary/build.sh
 	ARCH=amd64 BEAT=$(@D) BUILD_DIR=${BUILD_DIR} UPLOAD_DIR=${UPLOAD_DIR} BEAT_PATH=$(beat_abspath) BUILDID=$(BUILDID) SNAPSHOT=$(SNAPSHOT) $(packer_absdir)/platforms/binary/build.sh
 
+%/arm:
+	echo Creating ARM packages for $(@D)
+	ARCH=arm BEAT=$(@D) BUILD_DIR=${BUILD_DIR} BEAT_PATH=$(beat_abspath) BUILDID=$(BUILDID) SNAPSHOT=$(SNAPSHOT) $(packer_absdir)/platforms/binary/build.sh
+
 .PHONY: package-dashboards
 package-dashboards:
 	echo Creating the Dashboards package

--- a/dev-tools/packer/archs/arm.yml
+++ b/dev-tools/packer/archs/arm.yml
@@ -1,0 +1,2 @@
+arch: 'arm'
+bin_arch: arm

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -79,9 +79,10 @@ PERM_EXEC?=$(shell [ `uname -s` = "Darwin" ] && echo "+111" || echo "/a+x")
 
 # Cross compiling targets
 CGO?=true ## @building if true, Build with C Go support
-TARGETS?="windows/amd64 windows/386 darwin/amd64" ## @building list of platforms/architecture to be built by "make package"
+TARGETS?="windows/amd64 windows/386 darwin/amd64 linux/arm" ## @building list of platforms/architecture to be built by "make package"
 TARGETS_OLD?="linux/amd64 linux/386" ## @building list of Debian6 architecture to be built by "make package" when CGO is true
-PACKAGES?=${BEAT_NAME}/deb ${BEAT_NAME}/rpm ${BEAT_NAME}/darwin ${BEAT_NAME}/win ${BEAT_NAME}/bin ## @Building List of OS to be supported by "make package"
+PACKAGES?=${BEAT_NAME}/deb ${BEAT_NAME}/rpm ${BEAT_NAME}/darwin ${BEAT_NAME}/win ${BEAT_NAME}/bin ${BEAT_NAME}/arm ## @Building List of OS to be supported by "make package"
+PACKAGES_EXPERIMENTAL?=${BEAT_NAME}/arm ## @Building List of experimental OS by "make package". Only build when SNAPSHOT=yes
 SNAPSHOT?=yes ## @Building If yes, builds a snapshot version
 BEATS_BUILDER_IMAGE?=tudorg/beats-builder ## @Building Name of the docker image to use when packaging the application
 BEATS_BUILDER_DEB_IMAGE?=tudorg/beats-builder-deb7 ## @Building Name of the docker image to use when packaging the application for Debian 7
@@ -95,6 +96,10 @@ ifeq ($(RACE_DETECTOR),1)
 	RACE=-race
 endif
 
+# Only build experimental targets for snapshots
+ifeq ($(SNAPSHOT),no)
+	PACKAGES_EXPERIMENTAL=""
+endif
 
 ### BUILDING ###
 
@@ -502,7 +507,8 @@ package: update package-setup
 		$(MAKE) prepare-package; \
 	fi
 
-	SNAPSHOT=${SNAPSHOT} BUILDID=${BUILDID} BEAT_PATH=${BEAT_PATH} BUILD_DIR=${PKG_BUILD_DIR} UPLOAD_DIR=${PKG_UPLOAD_DIR} $(MAKE) -C ${ES_BEATS}/dev-tools/packer ${PACKAGES} ${BUILD_DIR}/upload/build_id.txt
+	SNAPSHOT=${SNAPSHOT} BUILDID=${BUILDID} BEAT_PATH=${BEAT_PATH} BUILD_DIR=${PKG_BUILD_DIR} UPLOAD_DIR=${PKG_UPLOAD_DIR} $(MAKE) -C ${ES_BEATS}/dev-tools/packer ${PACKAGES} ${PACKAGES_EXPERIMENTAL} ${BUILD_DIR}/upload/build_id.txt
+
 	$(MAKE) fix-permissions
 	echo "Finished packages for ${BEAT_NAME}"
 

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -97,7 +97,7 @@ ifeq ($(RACE_DETECTOR),1)
 endif
 
 # Only build experimental targets for snapshots
-ifeq ($(SNAPSHOT),no)
+ifneq ($(SNAPSHOT),yes)
 	PACKAGES_EXPERIMENTAL=""
 endif
 

--- a/packetbeat/Makefile
+++ b/packetbeat/Makefile
@@ -7,6 +7,9 @@ ES_BEATS?=..
 
 include ${ES_BEATS}/libbeat/scripts/Makefile
 
+TARGETS?="windows/amd64 windows/386 darwin/amd64 " ## @building list of platforms/architecture to be built by "make package"
+PACKAGES?=${BEAT_NAME}/deb ${BEAT_NAME}/rpm ${BEAT_NAME}/darwin ${BEAT_NAME}/win ${BEAT_NAME}/bin ## @Building List of OS to be supported by "make package"
+
 # This is called by the beats packer before building starts
 .PHONY: before-build
 before-build:


### PR DESCRIPTION
For my own need I played around with packaging arm in a tar.gz. The following changes to the packaging make ARM builds available for all Beats except packetbeat. The ARM build is disabled for packetbeat. Not sure if pcap is the issue: google/gopacket#100

The environment variable `PACKAGES_EXPERIMENTAL` is introduced to make sure ARM packages are at the moment only built for SNAPSHOT builds and not when `SNAPSHOT=no`. Like this is should not have any effect on the current packaging.

This change does not mean ARM is supported but it allows us to get more testing on it.