### PR TITLE
Making http/json metrics GA

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -230,6 +230,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Add statefulset support to Kubernetes module. {pull}6236[6236]
 - Refactor prometheus endpoint parsing to look similar to upstream prometheus {pull}6332[6332]
 - Update prometheus dependencies to latest {pull}6333[6333]
+- Making the http/json metricset GA. {pull}6471[6471]
 
 *Packetbeat*
 

--- a/metricbeat/docs/modules/http.asciidoc
+++ b/metricbeat/docs/modules/http.asciidoc
@@ -5,8 +5,6 @@ This file is generated! See scripts/docs_collector.py
 [[metricbeat-module-http]]
 == HTTP module
 
-beta[]
-
 The HTTP module is a Metricbeat module used to call arbitrary HTTP endpoints for which a dedicated Metricbeat module is not available.
 
 Multiple endpoints can be configured which are polled in a regular interval and the result is shipped to the configured output channel. It is recommended to install a Metricbeat instance on each host from which data should be fetched.

--- a/metricbeat/docs/modules/http/json.asciidoc
+++ b/metricbeat/docs/modules/http/json.asciidoc
@@ -5,8 +5,6 @@ This file is generated! See scripts/docs_collector.py
 [[metricbeat-metricset-http-json]]
 === HTTP json metricset
 
-beta[]
-
 include::../../../module/http/json/_meta/docs.asciidoc[]
 
 

--- a/metricbeat/docs/modules_list.asciidoc
+++ b/metricbeat/docs/modules_list.asciidoc
@@ -47,8 +47,8 @@ This file is generated! See scripts/docs_collector.py
 |<<metricbeat-module-haproxy,HAProxy>>     |    
 .2+|   |<<metricbeat-metricset-haproxy-info,info>>   
 |<<metricbeat-metricset-haproxy-stat,stat>>   
-|<<metricbeat-module-http,HTTP>>  beta[]   |    
-.2+|   |<<metricbeat-metricset-http-json,json>> beta[]  
+|<<metricbeat-module-http,HTTP>>     |    
+.2+|   |<<metricbeat-metricset-http-json,json>>   
 |<<metricbeat-metricset-http-server,server>> experimental[]  
 |<<metricbeat-module-jolokia,Jolokia>>  beta[]   |    
 .1+|   |<<metricbeat-metricset-jolokia-jmx,jmx>> beta[]  

--- a/metricbeat/module/http/_meta/fields.yml
+++ b/metricbeat/module/http/_meta/fields.yml
@@ -2,7 +2,7 @@
   title: "HTTP"
   description: >
     HTTP module
-  release: beta
+  release: ga
   settings: ["ssl"]
   fields:
     - name: http

--- a/metricbeat/module/http/json/_meta/fields.yml
+++ b/metricbeat/module/http/json/_meta/fields.yml
@@ -2,5 +2,5 @@
   type: group
   description: >
     json metricset
-  release: beta
+  release: ga
   fields:

--- a/metricbeat/module/http/json/json.go
+++ b/metricbeat/module/http/json/json.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/metricbeat/helper"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/mb/parse"
@@ -57,7 +56,6 @@ type MetricSet struct {
 // Part of new is also setting up the configuration by processing additional
 // configuration entries if needed.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	cfgwarn.Beta("The http json metricset is in beta.")
 
 	config := struct {
 		Namespace       string `config:"namespace" validate:"required"`


### PR DESCRIPTION
This releases the http/json metricset as GA. The http/server release status was not changed.