### PR TITLE
Fix Metricbat running on Docker docs

### DIFF
--- a/metricbeat/docs/running-on-docker.asciidoc
+++ b/metricbeat/docs/running-on-docker.asciidoc
@@ -19,7 +19,7 @@ docker run \
   --volume=/sys/fs/cgroup:/hostfs/sys/fs/cgroup:ro \ <2>
   --volume=/:/hostfs:ro \ <3>
   --net=host <4>
-  {dockerimage} -system.hostfs=/hostfs
+  {dockerimage} metricbeat -system.hostfs=/hostfs
 ----
 
 <1> Metricbeat's <<metricbeat-module-system,system module>> collects much of its data through the Linux proc


### PR DESCRIPTION
Full command was needed in 5.x version