### PR TITLE
add_kubernetes_metadata: Do not process nil pod events

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -32,6 +32,8 @@ https://github.com/elastic/beats/compare/v6.2.2...6.2[Check the HEAD diff]
 
 *Affecting all Beats*
 
+- Avoid panic errors when processing nil Pod events in add_kubernetes_metadata. {issue}6372[6372]
+
 *Auditbeat*
 
 *Filebeat*

--- a/libbeat/processors/add_kubernetes_metadata/kubernetes.go
+++ b/libbeat/processors/add_kubernetes_metadata/kubernetes.go
@@ -168,8 +168,8 @@ func (k *kubernetesAnnotator) worker() {
 // Run pod actions while handling errors
 func processEvent(f func(pod *kubernetes.Pod), event bus.Event) {
 	pod, ok := event["pod"].(*kubernetes.Pod)
-	if !ok {
-		logp.Err("Couldn't get a pod from watcher event")
+	if !ok || pod == nil {
+		logp.Err("Couldn't get a pod from watcher event: %v", event)
 		return
 	}
 	f(pod)


### PR DESCRIPTION
While the root cause is unclear, this change adds defensive code against
nil Pod processing errors. It also adds more logging to debug this
further.

Fixes #6372