### PR TITLE
Use safe put for k8s metadata

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -88,6 +88,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Fix for kafka logger. {pull}6430[6430]
 - Remove double slashes in Windows service script. {pull}6491[6491]
 - Fix infinite failure on Kubernetes watch {pull}6504[6504]
+- Ensure Kubernetes labels/annotations don't break mapping {pull}6490[6490]
 
 *Auditbeat*
 

--- a/libbeat/common/kubernetes/metadata.go
+++ b/libbeat/common/kubernetes/metadata.go
@@ -1,6 +1,9 @@
 package kubernetes
 
-import "github.com/elastic/beats/libbeat/common"
+import (
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/safemapstr"
+)
 
 // MetaGenerator builds metadata objects for pods and containers
 type MetaGenerator interface {
@@ -31,7 +34,7 @@ func (g *metaGenerator) PodMetadata(pod *Pod) common.MapStr {
 	labelMap := common.MapStr{}
 	if len(g.labels) == 0 {
 		for k, v := range pod.Metadata.Labels {
-			labelMap[k] = v
+			safemapstr.Put(labelMap, k, v)
 		}
 	} else {
 		labelMap = generateMapSubset(pod.Metadata.Labels, g.labels)
@@ -54,11 +57,11 @@ func (g *metaGenerator) PodMetadata(pod *Pod) common.MapStr {
 	}
 
 	if len(labelMap) != 0 {
-		meta["labels"] = common.DeDotJSON(labelMap)
+		meta["labels"] = labelMap
 	}
 
 	if len(annotationsMap) != 0 {
-		meta["annotations"] = common.DeDotJSON(annotationsMap)
+		meta["annotations"] = annotationsMap
 	}
 
 	return meta
@@ -85,7 +88,7 @@ func generateMapSubset(input map[string]string, keys []string) common.MapStr {
 	for _, key := range keys {
 		value, ok := input[key]
 		if ok {
-			output[key] = value
+			safemapstr.Put(output, key, value)
 		}
 	}
 

--- a/libbeat/common/kubernetes/metadata_test.go
+++ b/libbeat/common/kubernetes/metadata_test.go
@@ -16,10 +16,10 @@ func TestPodMetadataDeDot(t *testing.T) {
 		{
 			pod: &Pod{
 				Metadata: ObjectMeta{
-					Labels: map[string]string{"a.key": "a.value"},
+					Labels: map[string]string{"a.key": "foo", "a": "bar"},
 				},
 			},
-			meta: common.MapStr{"labels": common.MapStr{"a_key": "a.value"}},
+			meta: common.MapStr{"labels": common.MapStr{"a": common.MapStr{"value": "bar", "key": "foo"}}},
 		},
 	}
 

--- a/metricbeat/module/kubernetes/event/event.go
+++ b/metricbeat/module/kubernetes/event/event.go
@@ -7,6 +7,7 @@ import (
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/libbeat/common/kubernetes"
+	"github.com/elastic/beats/libbeat/common/safemapstr"
 	"github.com/elastic/beats/metricbeat/mb"
 )
 
@@ -105,7 +106,7 @@ func generateMapStrFromEvent(eve *kubernetes.Event) common.MapStr {
 	if len(eve.Metadata.Labels) != 0 {
 		labels := make(common.MapStr, len(eve.Metadata.Labels))
 		for k, v := range eve.Metadata.Labels {
-			labels[common.DeDot(k)] = v
+			safemapstr.Put(labels, k, v)
 		}
 
 		eventMeta["labels"] = labels
@@ -114,7 +115,7 @@ func generateMapStrFromEvent(eve *kubernetes.Event) common.MapStr {
 	if len(eve.Metadata.Annotations) != 0 {
 		annotations := make(common.MapStr, len(eve.Metadata.Annotations))
 		for k, v := range eve.Metadata.Annotations {
-			annotations[common.DeDot(k)] = v
+			safemapstr.Put(annotations, k, v)
 		}
 
 		eventMeta["annotations"] = annotations


### PR DESCRIPTION
This makes use of https://github.com/elastic/beats/pull/6434 as an alternative to avoid mapping issues while keeping dots in metadata.