### PR TITLE
Remove unnecessary double-slashes in Windows script

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -83,6 +83,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Update Golang 1.9.4 {pull}6326[6326]
 - Fix conditions checking on autodiscover Docker labels. {pull}6412[6412]
 - Fix for kafka logger. {pull}6430[6430]
+- Remove double slashes in Windows service script. {pull}6491[6491]
 
 *Auditbeat*
 

--- a/dev-tools/packer/platforms/windows/install-service.ps1.j2
+++ b/dev-tools/packer/platforms/windows/install-service.ps1.j2
@@ -11,4 +11,4 @@ $workdir = Split-Path $MyInvocation.MyCommand.Path
 # create new service
 New-Service -name {{.beat_name}} `
   -displayName {{.beat_name}} `
-  -binaryPathName "`"$workdir\\{{.beat_name}}.exe`" -c `"$workdir\\{{.beat_name}}.yml`" -path.home `"$workdir`" -path.data `"C:\\ProgramData\\{{.beat_name}}`" -path.logs `"C:\\ProgramData\\{{.beat_name}}\logs`""
+  -binaryPathName "`"$workdir\{{.beat_name}}.exe`" -c `"$workdir\{{.beat_name}}.yml`" -path.home `"$workdir`" -path.data `"C:\ProgramData\{{.beat_name}}`" -path.logs `"C:\ProgramData\{{.beat_name}}\logs`""


### PR DESCRIPTION
The install-service.ps1 script is escaping backslashes inside a string but that is unnecessary in PowerShell, resulting in double-slashes inside paths for the service configuration.

This is only a cosmetic fix.