### PR TITLE
Filebeat module generator: add missing file

### DIFF
--- a/filebeat/scripts/generator/module/main.go
+++ b/filebeat/scripts/generator/module/main.go
@@ -22,7 +22,7 @@ func generateModule(module, modulesPath, beatsPath string) error {
 
 	replace := map[string]string{"module": module}
 	templatesPath := path.Join(beatsPath, "scripts", "module")
-	filesToCopy := []string{path.Join("_meta", "fields.yml"), path.Join("_meta", "docs.asciidoc"), path.Join("module.yml")}
+	filesToCopy := []string{path.Join("_meta", "fields.yml"), path.Join("_meta", "docs.asciidoc"), path.Join("_meta", "config.yml"), path.Join("module.yml")}
 	generator.CopyTemplates(templatesPath, modulePath, filesToCopy, replace)
 	if err != nil {
 		return err

--- a/filebeat/scripts/module/_meta/config.yml
+++ b/filebeat/scripts/module/_meta/config.yml
@@ -1,0 +1,8 @@
+- module: {{ module }}
+  # All logs
+  {{ fileset }}:
+    enabled: true
+
+    # Set custom paths for the log files. If left empty,
+    # Filebeat will choose the paths depending on your OS.
+    #var.paths:


### PR DESCRIPTION
`_meta/config.yml` was missing from the generator. Now it is added, so configuration can be generated using `make update`.