### PR TITLE
Do not build internal metrics without CGO

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -89,6 +89,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Remove double slashes in Windows service script. {pull}6491[6491]
 - Fix infinite failure on Kubernetes watch {pull}6504[6504]
 - Ensure Kubernetes labels/annotations don't break mapping {pull}6490[6490]
+- Report ephemeral ID and uptime in monitoring events on all platforms {pull}6501[6501]
 
 *Auditbeat*
 

--- a/libbeat/cmd/instance/metrics.go
+++ b/libbeat/cmd/instance/metrics.go
@@ -1,5 +1,4 @@
-// +build darwin linux windows
-// +build cgo
+// +build darwin,cgo freebsd,cgo linux windows
 
 package instance
 
@@ -7,38 +6,31 @@ import (
 	"fmt"
 	"os"
 	"runtime"
-	"time"
-
-	"github.com/satori/go.uuid"
 
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/metric/system/cpu"
 	"github.com/elastic/beats/libbeat/metric/system/process"
 	"github.com/elastic/beats/libbeat/monitoring"
-	"github.com/elastic/beats/libbeat/monitoring/report/log"
 )
 
 var (
 	beatProcessStats *process.Stats
-	ephemeralID      uuid.UUID
+	systemMetrics    *monitoring.Registry
 )
 
 func init() {
-	beatMetrics := monitoring.Default.NewRegistry("beat")
+	systemMetrics = monitoring.Default.NewRegistry("system")
+}
+
+func setupMetrics(name string) error {
 	monitoring.NewFunc(beatMetrics, "memstats", reportMemStats, monitoring.Report)
 	monitoring.NewFunc(beatMetrics, "cpu", reportBeatCPU, monitoring.Report)
-	monitoring.NewFunc(beatMetrics, "info", reportInfo, monitoring.Report)
 
-	systemMetrics := monitoring.Default.NewRegistry("system")
 	monitoring.NewFunc(systemMetrics, "cpu", reportSystemCPUUsage, monitoring.Report)
 	if runtime.GOOS != "windows" {
 		monitoring.NewFunc(systemMetrics, "load", reportSystemLoadAverage, monitoring.Report)
 	}
 
-	ephemeralID = uuid.NewV4()
-}
-
-func setupMetrics(name string) error {
 	beatProcessStats = &process.Stats{
 		Procs:        []string{name},
 		EnvWhitelist: nil,
@@ -89,19 +81,6 @@ func getRSSSize() (uint64, error) {
 		return 0, fmt.Errorf("error converting Resident Set Size to uint64: %v", iRss)
 	}
 	return rss, nil
-}
-
-func reportInfo(_ monitoring.Mode, V monitoring.Visitor) {
-	V.OnRegistryStart()
-	defer V.OnRegistryFinished()
-
-	delta := time.Since(log.StartTime)
-	uptime := int64(delta / time.Millisecond)
-	monitoring.ReportNamespace(V, "uptime", func() {
-		monitoring.ReportInt(V, "ms", uptime)
-	})
-
-	monitoring.ReportString(V, "ephemeral_id", ephemeralID.String())
 }
 
 func reportBeatCPU(_ monitoring.Mode, V monitoring.Visitor) {

--- a/libbeat/cmd/instance/metrics_common.go
+++ b/libbeat/cmd/instance/metrics_common.go
@@ -1,0 +1,35 @@
+package instance
+
+import (
+	"time"
+
+	"github.com/satori/go.uuid"
+
+	"github.com/elastic/beats/libbeat/monitoring"
+	"github.com/elastic/beats/libbeat/monitoring/report/log"
+)
+
+var (
+	ephemeralID uuid.UUID
+	beatMetrics *monitoring.Registry
+)
+
+func init() {
+	beatMetrics = monitoring.Default.NewRegistry("beat")
+	monitoring.NewFunc(beatMetrics, "info", reportInfo, monitoring.Report)
+
+	ephemeralID = uuid.NewV4()
+}
+
+func reportInfo(_ monitoring.Mode, V monitoring.Visitor) {
+	V.OnRegistryStart()
+	defer V.OnRegistryFinished()
+
+	delta := time.Since(log.StartTime)
+	uptime := int64(delta / time.Millisecond)
+	monitoring.ReportNamespace(V, "uptime", func() {
+		monitoring.ReportInt(V, "ms", uptime)
+	})
+
+	monitoring.ReportString(V, "ephemeral_id", ephemeralID.String())
+}

--- a/libbeat/cmd/instance/metrics_other.go
+++ b/libbeat/cmd/instance/metrics_other.go
@@ -1,20 +1,12 @@
-// +build !darwin,!linux,!cgo darwin,!cgo freebsd,!cgo openbsd
+// +build !darwin !cgo
+// +build !freebsd !cgo
+// +build !linux,!windows
 
 package instance
 
 import (
-	"github.com/satori/go.uuid"
-
 	"github.com/elastic/beats/libbeat/logp"
 )
-
-var (
-	ephemeralID uuid.UUID
-)
-
-func init() {
-	ephemeralID = uuid.NewV4()
-}
 
 func setupMetrics(name string) error {
 	logp.Warn("Metrics not implemented for this OS.")

--- a/libbeat/cmd/instance/metrics_other.go
+++ b/libbeat/cmd/instance/metrics_other.go
@@ -2,7 +2,19 @@
 
 package instance
 
-import "github.com/elastic/beats/libbeat/logp"
+import (
+	"github.com/satori/go.uuid"
+
+	"github.com/elastic/beats/libbeat/logp"
+)
+
+var (
+	ephemeralID uuid.UUID
+)
+
+func init() {
+	ephemeralID = uuid.NewV4()
+}
 
 func setupMetrics(name string) error {
 	logp.Warn("Metrics not implemented for this OS.")

--- a/libbeat/cmd/instance/metrics_other.go
+++ b/libbeat/cmd/instance/metrics_other.go
@@ -1,4 +1,4 @@
-// +build !darwin,!linux,!windows darwin,!cgo linux,!cgo windows,!cgo
+// +build !darwin,!linux,!cgo darwin,!cgo freebsd,!cgo openbsd
 
 package instance
 


### PR DESCRIPTION
Gosigar only requires CGO for Darwin, FreeBSD and OpenBSD. If someone compiles Beats on these platforms without CGO, metrics are not supported.

Add ephemeral ID to Beats which don't report internal memory usage, etc. So it can still show up in Monitoring UI.