### PR TITLE
Describe accurate default val in libbeat reference.yml.

### DIFF
--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -139,7 +139,8 @@ auditbeat.modules:
 
     # Hints the minimum number of events stored in the queue,
     # before providing a batch of events to the outputs.
-    # A value of 0 (the default) ensures events are immediately available
+    # The default value is set to 2048.
+    # A value of 0 ensures events are immediately available
     # to be sent to the outputs.
     #flush.min_events: 2048
 

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -613,7 +613,8 @@ filebeat.inputs:
 
     # Hints the minimum number of events stored in the queue,
     # before providing a batch of events to the outputs.
-    # A value of 0 (the default) ensures events are immediately available
+    # The default value is set to 2048.
+    # A value of 0 ensures events are immediately available
     # to be sent to the outputs.
     #flush.min_events: 2048
 

--- a/heartbeat/heartbeat.reference.yml
+++ b/heartbeat/heartbeat.reference.yml
@@ -248,7 +248,8 @@ heartbeat.scheduler:
 
     # Hints the minimum number of events stored in the queue,
     # before providing a batch of events to the outputs.
-    # A value of 0 (the default) ensures events are immediately available
+    # The default value is set to 2048.
+    # A value of 0 ensures events are immediately available
     # to be sent to the outputs.
     #flush.min_events: 2048
 

--- a/libbeat/_meta/config.reference.yml
+++ b/libbeat/_meta/config.reference.yml
@@ -34,7 +34,8 @@
 
     # Hints the minimum number of events stored in the queue,
     # before providing a batch of events to the outputs.
-    # A value of 0 (the default) ensures events are immediately available
+    # The default value is set to 2048.
+    # A value of 0 ensures events are immediately available
     # to be sent to the outputs.
     #flush.min_events: 2048
 

--- a/libbeat/docs/queueconfig.asciidoc
+++ b/libbeat/docs/queueconfig.asciidoc
@@ -28,7 +28,7 @@ If no flush interval and no number of events to flush is configured,
 all events published to this queue will be directly consumed by the outputs.
 To enforce spooling in the queue, set the `flush.min_events` and `flush.timeout` options.
 
-By default `flush.min.events` is set to 1024 and `flush.timeout` is set to 1s.
+By default `flush.min.events` is set to 2048 and `flush.timeout` is set to 1s.
 
 The output's `bulk_max_size` setting limits the number of events being processed at once.
 

--- a/libbeat/docs/queueconfig.asciidoc
+++ b/libbeat/docs/queueconfig.asciidoc
@@ -22,15 +22,19 @@ queue.mem:
 === Configure the memory qeueue
 
 The memory queue keeps all events in memory. It is the only queue type
-supported right now.  By default no flush interval is configured. All events
-published to this queue will be directly consumed by the outputs.
+supported right now. 
+
+If no flush interval and no number of events to flush is configured, 
+all events published to this queue will be directly consumed by the outputs.
+To enforce spooling in the queue, set the `flush.min_events` and `flush.timeout` options.
+
+By default `flush.min.events` is set to 1024 and `flush.timeout` is set to 1s.
+
 The output's `bulk_max_size` setting limits the number of events being processed at once.
 
 The memory queue waits for the output to acknowledge or drop events. If
 the queue is full, no new events can be inserted into the memeory queue. Only
 after the signal from the output will the queue free up space for more events to be accepted.
-
-To enforce spooling in the queue, set the `flush.min_events` and `flush.timeout` options.
 
 This sample configuration forwards events to the output if 512 events are
 available or the oldest available event is already waiting for 5s in the queue:

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -527,7 +527,8 @@ metricbeat.modules:
 
     # Hints the minimum number of events stored in the queue,
     # before providing a batch of events to the outputs.
-    # A value of 0 (the default) ensures events are immediately available
+    # The default value is set to 2048.
+    # A value of 0 ensures events are immediately available
     # to be sent to the outputs.
     #flush.min_events: 2048
 

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -502,7 +502,8 @@ packetbeat.protocols:
 
     # Hints the minimum number of events stored in the queue,
     # before providing a batch of events to the outputs.
-    # A value of 0 (the default) ensures events are immediately available
+    # The default value is set to 2048.
+    # A value of 0 ensures events are immediately available
     # to be sent to the outputs.
     #flush.min_events: 2048
 

--- a/winlogbeat/winlogbeat.reference.yml
+++ b/winlogbeat/winlogbeat.reference.yml
@@ -63,7 +63,8 @@ winlogbeat.event_logs:
 
     # Hints the minimum number of events stored in the queue,
     # before providing a batch of events to the outputs.
-    # A value of 0 (the default) ensures events are immediately available
+    # The default value is set to 2048.
+    # A value of 0 ensures events are immediately available
     # to be sent to the outputs.
     #flush.min_events: 2048
 


### PR DESCRIPTION
Default val for `queue.mem.flush.min_events` is 2048 instead of 0.