### PR TITLE
Add a warning message about emptyDir in Kubernetes manifests

### DIFF
--- a/deploy/kubernetes/filebeat-kubernetes.yaml
+++ b/deploy/kubernetes/filebeat-kubernetes.yaml
@@ -118,6 +118,9 @@ spec:
         configMap:
           defaultMode: 0600
           name: filebeat-prospectors
+      # We set an `emptyDir` here to ensure the manifest will deploy correctly.
+      # It's recommended to change this to a `hostPath` folder, to ensure internal data
+      # files survive pod changes (ie: version upgrade)
       - name: data
         emptyDir: {}
 ---

--- a/deploy/kubernetes/filebeat/filebeat-daemonset.yaml
+++ b/deploy/kubernetes/filebeat/filebeat-daemonset.yaml
@@ -68,5 +68,8 @@ spec:
         configMap:
           defaultMode: 0600
           name: filebeat-prospectors
+      # We set an `emptyDir` here to ensure the manifest will deploy correctly.
+      # It's recommended to change this to a `hostPath` folder, to ensure internal data
+      # files survive pod changes (ie: version upgrade)
       - name: data
         emptyDir: {}

--- a/deploy/kubernetes/metricbeat-kubernetes.yaml
+++ b/deploy/kubernetes/metricbeat-kubernetes.yaml
@@ -158,6 +158,9 @@ spec:
         configMap:
           defaultMode: 0600
           name: metricbeat-daemonset-modules
+      # We set an `emptyDir` here to ensure the manifest will deploy correctly.
+      # It's recommended to change this to a `hostPath` folder, to ensure internal data
+      # files survive pod changes (ie: version upgrade)
       - name: data
         emptyDir: {}
 ---

--- a/deploy/kubernetes/metricbeat/metricbeat-daemonset.yaml
+++ b/deploy/kubernetes/metricbeat/metricbeat-daemonset.yaml
@@ -84,5 +84,8 @@ spec:
         configMap:
           defaultMode: 0600
           name: metricbeat-daemonset-modules
+      # We set an `emptyDir` here to ensure the manifest will deploy correctly.
+      # It's recommended to change this to a `hostPath` folder, to ensure internal data
+      # files survive pod changes (ie: version upgrade)
       - name: data
         emptyDir: {}


### PR DESCRIPTION
We would normally use `hostPath` to store beats data folder in the host.
This ensures data survives beats redeployments (for instance, a version
upgrade).

The problem is there is no way to set a safe default value ensuring it's
a writable dir in the host. That's why we set `emptyDir` as a safe default.

This PR adds a comment explaining that for awareness.