### PR TITLE
Cherry-pick #6415 to 6.2: Fix Kubernetes dashboard views for non default time ranges

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -42,6 +42,8 @@ https://github.com/elastic/beats/compare/v6.2.2...6.2[Check the HEAD diff]
 
 *Metricbeat*
 
+- Fix Kubernetes overview dashboard views for non default time ranges. {issue}6395{6395}
+
 *Packetbeat*
 
 *Winlogbeat*
@@ -275,16 +277,6 @@ https://github.com/elastic/beats/compare/v6.0.1...v6.1.0[View commits]
 - Fix `ProcState` on Linux and FreeBSD when process names contain parentheses. {pull}5775[5775]
 - Fix incorrect `Mem.Used` calculation under linux. {pull}5775[5775]
 - Fix `open_file_descriptor_count` and `max_file_descriptor_count` lost in zookeeper module {pull}5902[5902]
-- Fix kubernetes `state_pod` `status.phase` so that the active phase is returned instead of `unknown`. {pull}5980[5980]
-- Fix error collecting network_names in Vsphere module. {pull}5962[5962]
-- Fix process cgroup memory metrics for memsw, kmem, and kmem_tcp. {issue}6033[6033]
-- Fix kafka OffsetFetch request missing topic and partition parameters. {pull}5880[5880]
-- Change kubernetes.node.cpu.allocatable.cores to float. {pull}6130[6130]
-- Fix system process metricset for kernel processes. {issue}5700[5700]
-- Fix panic in http dependent modules when invalid config was used.
-- Fix system.filesystem.used.pct value to match what df reports. {issue}5494[5494]
-- Fix namespace disambiguation in Kubernetes state_* metricsets. {issue}6281[6281]
-- Fix Kubernetes overview dashboard views for non default time ranges. {issue}6395{6395}
 
 *Packetbeat*
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -275,6 +275,16 @@ https://github.com/elastic/beats/compare/v6.0.1...v6.1.0[View commits]
 - Fix `ProcState` on Linux and FreeBSD when process names contain parentheses. {pull}5775[5775]
 - Fix incorrect `Mem.Used` calculation under linux. {pull}5775[5775]
 - Fix `open_file_descriptor_count` and `max_file_descriptor_count` lost in zookeeper module {pull}5902[5902]
+- Fix kubernetes `state_pod` `status.phase` so that the active phase is returned instead of `unknown`. {pull}5980[5980]
+- Fix error collecting network_names in Vsphere module. {pull}5962[5962]
+- Fix process cgroup memory metrics for memsw, kmem, and kmem_tcp. {issue}6033[6033]
+- Fix kafka OffsetFetch request missing topic and partition parameters. {pull}5880[5880]
+- Change kubernetes.node.cpu.allocatable.cores to float. {pull}6130[6130]
+- Fix system process metricset for kernel processes. {issue}5700[5700]
+- Fix panic in http dependent modules when invalid config was used.
+- Fix system.filesystem.used.pct value to match what df reports. {issue}5494[5494]
+- Fix namespace disambiguation in Kubernetes state_* metricsets. {issue}6281[6281]
+- Fix Kubernetes overview dashboard views for non default time ranges. {issue}6395{6395}
 
 *Packetbeat*
 

--- a/metricbeat/module/kubernetes/_meta/kibana/6/dashboard/Metricbeat-kubernetes-overview.json
+++ b/metricbeat/module/kubernetes/_meta/kibana/6/dashboard/Metricbeat-kubernetes-overview.json
@@ -4,21 +4,17 @@
       "attributes": {
         "description": "",
         "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query_string\":{\"query\":\"*\"}},\"filter\":[]}"
+          "searchSourceJSON": "{\"query\":{\"query\":{\"query_string\":{\"query\":\"*\"}},\"language\":\"lucene\"},\"filter\":[]}"
         },
         "title": "Available pods per deployment [Metricbeat Kubernetes]",
         "uiStateJSON": "{}",
         "version": 1,
-        "visState": "{\"title\":\"Available pods per deployment [Metricbeat Kubernetes]\",\"type\":\"metrics\",\"params\":{\"axis_formatter\":\"number\",\"axis_position\":\"left\",\"filter\":\"metricset.module:kubernetes AND metricset.name:state_deployment\",\"id\":\"117fadf0-30df-11e7-8df8-6d3604a72912\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"series\":[{\"axis_position\":\"right\",\"chart_type\":\"line\",\"color\":\"rgba(104,188,0,1)\",\"fill\":0.5,\"formatter\":\"number\",\"id\":\"64456840-30df-11e7-8df8-6d3604a72912\",\"label\":\"Available pods\",\"line_width\":1,\"metrics\":[{\"field\":\"kubernetes.deployment.replicas.available\",\"id\":\"64456841-30df-11e7-8df8-6d3604a72912\",\"type\":\"sum\"}],\"point_size\":1,\"seperate_axis\":0,\"split_filters\":[{\"color\":\"#68BC00\",\"id\":\"53d35ad0-30df-11e7-8df8-6d3604a72912\"}],\"split_mode\":\"terms\",\"stacked\":\"stacked\",\"terms_field\":\"kubernetes.deployment.name\",\"terms_size\":\"10000\"}],\"show_legend\":1,\"time_field\":\"@timestamp\",\"type\":\"timeseries\"},\"aggs\":[],\"listeners\":{}}"
+        "visState": "{\"title\":\"Available pods per deployment [Metricbeat Kubernetes]\",\"type\":\"metrics\",\"params\":{\"axis_formatter\":\"number\",\"axis_position\":\"left\",\"filter\":\"metricset.module:kubernetes AND metricset.name:state_deployment\",\"id\":\"117fadf0-30df-11e7-8df8-6d3604a72912\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"series\":[{\"axis_position\":\"right\",\"chart_type\":\"line\",\"color\":\"rgba(104,188,0,1)\",\"fill\":0.5,\"formatter\":\"number\",\"id\":\"64456840-30df-11e7-8df8-6d3604a72912\",\"label\":\"Available pods\",\"line_width\":1,\"metrics\":[{\"field\":\"kubernetes.deployment.replicas.available\",\"id\":\"64456841-30df-11e7-8df8-6d3604a72912\",\"type\":\"avg\"}],\"point_size\":1,\"seperate_axis\":0,\"split_filters\":[{\"color\":\"#68BC00\",\"id\":\"53d35ad0-30df-11e7-8df8-6d3604a72912\"}],\"split_mode\":\"terms\",\"stacked\":\"stacked\",\"terms_field\":\"kubernetes.deployment.name\",\"terms_size\":\"10000\"}],\"show_legend\":1,\"time_field\":\"@timestamp\",\"type\":\"timeseries\",\"show_grid\":1},\"aggs\":[]}"
       },
-      "col": 7,
       "id": "022a54c0-2bf5-11e7-859b-f78b612cde28",
-      "panelIndex": 1,
-      "row": 1,
-      "size_x": 6,
-      "size_y": 3,
       "type": "visualization",
-      "version": 2
+      "updated_at": "2018-03-11T20:59:01.845Z",
+      "version": 4
     },
     {
       "attributes": {
@@ -31,14 +27,10 @@
         "version": 1,
         "visState": "{\"title\":\"CPU usage by node  [Metricbeat Kubernetes]\",\"type\":\"metrics\",\"params\":{\"id\":\"0d5c6b10-2bf2-11e7-859b-f78b612cde28\",\"type\":\"timeseries\",\"series\":[{\"id\":\"0d5c9220-2bf2-11e7-859b-f78b612cde28\",\"color\":\"#68BC00\",\"split_mode\":\"terms\",\"metrics\":[{\"id\":\"0d5c9221-2bf2-11e7-859b-f78b612cde28\",\"type\":\"sum\",\"field\":\"kubernetes.container.cpu.usage.nanocores\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"0.0a\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":\"0.5\",\"stacked\":\"none\",\"terms_field\":\"kubernetes.node.name\",\"terms_size\":\"10000\",\"terms_order_by\":\"0d5c9221-2bf2-11e7-859b-f78b612cde28\",\"value_template\":\"{{value}} nanocores\",\"override_index_pattern\":0,\"series_interval\":\"10s\",\"series_time_field\":\"@timestamp\"},{\"id\":\"22f65d40-31a7-11e7-84cc-096d2b38e6e5\",\"color\":\"rgba(211,49,21,1)\",\"split_mode\":\"terms\",\"metrics\":[{\"id\":\"22f65d41-31a7-11e7-84cc-096d2b38e6e5\",\"type\":\"avg\",\"field\":\"kubernetes.node.cpu.capacity.cores\"},{\"script\":\"params.cores * 1000000000\",\"id\":\"4af4c390-34d6-11e7-be88-cb6a123dc1bb\",\"type\":\"calculation\",\"variables\":[{\"id\":\"4cd32080-34d6-11e7-be88-cb6a123dc1bb\",\"name\":\"cores\",\"field\":\"22f65d41-31a7-11e7-84cc-096d2b38e6e5\"}]}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"0.0a\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":\"0\",\"fill\":\"0\",\"stacked\":\"none\",\"terms_field\":\"kubernetes.node.name\",\"terms_size\":\"10000\",\"terms_order_by\":\"22f65d41-31a7-11e7-84cc-096d2b38e6e5\",\"value_template\":\"{{value}} nanocores\",\"hide_in_legend\":1,\"label\":\"\",\"override_index_pattern\":0,\"series_interval\":\"10s\",\"series_time_field\":\"@timestamp\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"show_legend\":1,\"background_color_rules\":[{\"id\":\"12c1f2f0-2bf2-11e7-859b-f78b612cde28\"}],\"bar_color_rules\":[{\"id\":\"1373ddd0-2bf2-11e7-859b-f78b612cde28\"}],\"gauge_color_rules\":[{\"id\":\"140e4910-2bf2-11e7-859b-f78b612cde28\"}],\"gauge_width\":10,\"gauge_inner_width\":10,\"gauge_style\":\"half\",\"filter\":\"metricset.module:kubernetes AND (metricset.name:container OR metricset.name:state_node)\"},\"aggs\":[],\"listeners\":{}}"
       },
-      "col": 1,
       "id": "44f12b40-2bf4-11e7-859b-f78b612cde28",
-      "panelIndex": 2,
-      "row": 7,
-      "size_x": 6,
-      "size_y": 3,
       "type": "visualization",
-      "version": 2
+      "updated_at": "2018-03-01T18:58:07.906Z",
+      "version": 3
     },
     {
       "attributes": {
@@ -51,14 +43,10 @@
         "version": 1,
         "visState": "{\"title\":\"Kubernetes - Deployments\",\"type\":\"metrics\",\"params\":{\"id\":\"4c4690b0-30e0-11e7-8df8-6d3604a72912\",\"type\":\"metric\",\"series\":[{\"id\":\"4c4690b1-30e0-11e7-8df8-6d3604a72912\",\"color\":\"#68BC00\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"4c4690b2-30e0-11e7-8df8-6d3604a72912\",\"type\":\"cardinality\",\"field\":\"kubernetes.deployment.name\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"terms_field\":\"kubernetes.deployment.name\",\"label\":\"Deployments\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"show_legend\":1,\"filter\":\"metricset.module:kubernetes AND metricset.name:state_deployment\",\"background_color_rules\":[{\"id\":\"67ee7da0-30e0-11e7-8df8-6d3604a72912\"}],\"bar_color_rules\":[{\"id\":\"68cdba10-30e0-11e7-8df8-6d3604a72912\"}],\"gauge_color_rules\":[{\"id\":\"69765620-30e0-11e7-8df8-6d3604a72912\"}],\"gauge_width\":10,\"gauge_inner_width\":10,\"gauge_style\":\"half\"},\"aggs\":[],\"listeners\":{}}"
       },
-      "col": 4,
       "id": "cd059410-2bfb-11e7-859b-f78b612cde28",
-      "panelIndex": 5,
-      "row": 1,
-      "size_x": 3,
-      "size_y": 3,
       "type": "visualization",
-      "version": 1
+      "updated_at": "2018-03-01T18:58:07.906Z",
+      "version": 3
     },
     {
       "attributes": {
@@ -71,34 +59,26 @@
         "version": 1,
         "visState": "{\"title\":\"Kubernetes - Desired pods\",\"type\":\"metrics\",\"params\":{\"id\":\"2fe9d3b0-30d5-11e7-8df8-6d3604a72912\",\"type\":\"metric\",\"series\":[{\"id\":\"2fe9d3b1-30d5-11e7-8df8-6d3604a72912\",\"color\":\"#68BC00\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"54cf79a0-30d5-11e7-8df8-6d3604a72912\",\"type\":\"sum\",\"field\":\"kubernetes.deployment.replicas.desired\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"label\":\"Desired Pods\",\"override_index_pattern\":1,\"series_time_field\":\"@timestamp\",\"series_interval\":\"10s\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"show_legend\":1,\"background_color_rules\":[{\"id\":\"508ffb30-30d5-11e7-8df8-6d3604a72912\"}],\"gauge_color_rules\":[{\"id\":\"50f9b980-30d5-11e7-8df8-6d3604a72912\"}],\"gauge_width\":\"10\",\"gauge_inner_width\":\"10\",\"gauge_style\":\"half\",\"bar_color_rules\":[{\"id\":\"674d83b0-30d5-11e7-8df8-6d3604a72912\"}],\"gauge_max\":\"5\",\"filter\":\"metricset.module:kubernetes AND metricset.name:state_deployment\"},\"aggs\":[],\"listeners\":{}}"
       },
-      "col": 1,
       "id": "e1018b90-2bfb-11e7-859b-f78b612cde28",
-      "panelIndex": 6,
-      "row": 4,
-      "size_x": 2,
-      "size_y": 3,
       "type": "visualization",
-      "version": 1
+      "updated_at": "2018-03-01T18:58:07.906Z",
+      "version": 3
     },
     {
       "attributes": {
         "description": "",
         "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query_string\":{\"query\":\"*\"}},\"filter\":[]}"
+          "searchSourceJSON": "{\"query\":{\"query\":{\"query_string\":{\"query\":\"*\"}},\"language\":\"lucene\"},\"filter\":[]}"
         },
         "title": "Memory usage by node  [Metricbeat Kubernetes]",
         "uiStateJSON": "{}",
         "version": 1,
-        "visState": "{\"title\":\"Memory usage by node  [Metricbeat Kubernetes]\",\"type\":\"metrics\",\"params\":{\"id\":\"0d5c6b10-2bf2-11e7-859b-f78b612cde28\",\"type\":\"timeseries\",\"series\":[{\"id\":\"0d5c9220-2bf2-11e7-859b-f78b612cde28\",\"color\":\"#68BC00\",\"split_mode\":\"terms\",\"metrics\":[{\"id\":\"0d5c9221-2bf2-11e7-859b-f78b612cde28\",\"type\":\"sum\",\"field\":\"kubernetes.container.memory.usage.bytes\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"bytes\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"terms_field\":\"kubernetes.node.name\",\"terms_size\":\"10000\",\"terms_order_by\":\"0d5c9221-2bf2-11e7-859b-f78b612cde28\"},{\"id\":\"8ba3b270-31a7-11e7-84cc-096d2b38e6e5\",\"color\":\"rgba(211,49,21,1)\",\"split_mode\":\"terms\",\"metrics\":[{\"id\":\"8ba3b271-31a7-11e7-84cc-096d2b38e6e5\",\"type\":\"sum\",\"field\":\"kubernetes.node.memory.capacity.bytes\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"bytes\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":\"0\",\"fill\":\"0\",\"stacked\":\"none\",\"terms_field\":\"kubernetes.node.name\",\"terms_size\":\"10000\",\"terms_order_by\":\"8ba3b271-31a7-11e7-84cc-096d2b38e6e5\",\"hide_in_legend\":1,\"label\":\"Node capacity\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"show_legend\":1,\"background_color_rules\":[{\"id\":\"12c1f2f0-2bf2-11e7-859b-f78b612cde28\"}],\"bar_color_rules\":[{\"id\":\"1373ddd0-2bf2-11e7-859b-f78b612cde28\"}],\"gauge_color_rules\":[{\"id\":\"140e4910-2bf2-11e7-859b-f78b612cde28\"}],\"gauge_width\":10,\"gauge_inner_width\":10,\"gauge_style\":\"half\",\"filter\":\"metricset.module:kubernetes AND (metricset.name:container OR metricset.name:state_node)\"},\"aggs\":[],\"listeners\":{}}"
+        "visState": "{\"title\":\"Memory usage by node  [Metricbeat Kubernetes]\",\"type\":\"metrics\",\"params\":{\"id\":\"0d5c6b10-2bf2-11e7-859b-f78b612cde28\",\"type\":\"timeseries\",\"series\":[{\"id\":\"0d5c9220-2bf2-11e7-859b-f78b612cde28\",\"color\":\"#68BC00\",\"split_mode\":\"terms\",\"metrics\":[{\"id\":\"0d5c9221-2bf2-11e7-859b-f78b612cde28\",\"type\":\"sum\",\"field\":\"kubernetes.container.memory.usage.bytes\"},{\"id\":\"9f0cf900-1ffb-11e8-81f2-43be86397500\",\"type\":\"cumulative_sum\",\"field\":\"0d5c9221-2bf2-11e7-859b-f78b612cde28\"},{\"unit\":\"10s\",\"id\":\"a926e130-1ffb-11e8-81f2-43be86397500\",\"type\":\"derivative\",\"field\":\"9f0cf900-1ffb-11e8-81f2-43be86397500\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"bytes\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"terms_field\":\"kubernetes.node.name\",\"terms_size\":\"10000\",\"terms_order_by\":\"0d5c9221-2bf2-11e7-859b-f78b612cde28\"},{\"id\":\"8ba3b270-31a7-11e7-84cc-096d2b38e6e5\",\"color\":\"rgba(211,49,21,1)\",\"split_mode\":\"terms\",\"metrics\":[{\"id\":\"8ba3b271-31a7-11e7-84cc-096d2b38e6e5\",\"type\":\"sum\",\"field\":\"kubernetes.node.memory.capacity.bytes\"},{\"id\":\"d1fb2670-1ffb-11e8-81f2-43be86397500\",\"type\":\"cumulative_sum\",\"field\":\"8ba3b271-31a7-11e7-84cc-096d2b38e6e5\"},{\"unit\":\"10s\",\"id\":\"dc8b01f0-1ffb-11e8-81f2-43be86397500\",\"type\":\"derivative\",\"field\":\"d1fb2670-1ffb-11e8-81f2-43be86397500\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"bytes\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":\"0\",\"fill\":\"0\",\"stacked\":\"none\",\"terms_field\":\"kubernetes.node.name\",\"terms_size\":\"10000\",\"terms_order_by\":\"8ba3b271-31a7-11e7-84cc-096d2b38e6e5\",\"hide_in_legend\":1,\"label\":\"Node capacity\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"show_legend\":1,\"background_color_rules\":[{\"id\":\"12c1f2f0-2bf2-11e7-859b-f78b612cde28\"}],\"bar_color_rules\":[{\"id\":\"1373ddd0-2bf2-11e7-859b-f78b612cde28\"}],\"gauge_color_rules\":[{\"id\":\"140e4910-2bf2-11e7-859b-f78b612cde28\"}],\"gauge_width\":10,\"gauge_inner_width\":10,\"gauge_style\":\"half\",\"filter\":\"metricset.module:kubernetes AND (metricset.name:container OR metricset.name:state_node)\",\"show_grid\":1},\"aggs\":[]}"
       },
-      "col": 7,
       "id": "d6564360-2bfc-11e7-859b-f78b612cde28",
-      "panelIndex": 7,
-      "row": 7,
-      "size_x": 6,
-      "size_y": 3,
       "type": "visualization",
-      "version": 2
+      "updated_at": "2018-03-04T23:15:29.035Z",
+      "version": 4
     },
     {
       "attributes": {
@@ -111,14 +91,10 @@
         "version": 1,
         "visState": "{\"title\":\"Network in by node  [Metricbeat Kubernetes]\",\"type\":\"metrics\",\"params\":{\"id\":\"0d5c6b10-2bf2-11e7-859b-f78b612cde28\",\"type\":\"timeseries\",\"series\":[{\"id\":\"0d5c9220-2bf2-11e7-859b-f78b612cde28\",\"color\":\"rgba(104,188,0,1)\",\"split_mode\":\"terms\",\"metrics\":[{\"id\":\"0d5c9221-2bf2-11e7-859b-f78b612cde28\",\"type\":\"sum\",\"field\":\"kubernetes.pod.network.rx.bytes\"},{\"unit\":\"\",\"id\":\"494fc310-2bf7-11e7-859b-f78b612cde28\",\"type\":\"derivative\",\"field\":\"0d5c9221-2bf2-11e7-859b-f78b612cde28\"},{\"unit\":\"\",\"id\":\"37c72a70-3598-11e7-aa4a-8313a0c92a88\",\"type\":\"positive_only\",\"field\":\"494fc310-2bf7-11e7-859b-f78b612cde28\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"bytes\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"stacked\",\"terms_field\":\"kubernetes.node.name\",\"terms_size\":\"100000\",\"terms_order_by\":\"0d5c9221-2bf2-11e7-859b-f78b612cde28\",\"label\":\"\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"show_legend\":1,\"background_color_rules\":[{\"id\":\"12c1f2f0-2bf2-11e7-859b-f78b612cde28\"}],\"bar_color_rules\":[{\"id\":\"1373ddd0-2bf2-11e7-859b-f78b612cde28\"}],\"gauge_color_rules\":[{\"id\":\"140e4910-2bf2-11e7-859b-f78b612cde28\"}],\"gauge_width\":10,\"gauge_inner_width\":10,\"gauge_style\":\"half\",\"filter\":\"metricset.module:kubernetes AND metricset.name:pod\"},\"aggs\":[],\"listeners\":{}}"
       },
-      "col": 7,
       "id": "16fa4470-2bfd-11e7-859b-f78b612cde28",
-      "panelIndex": 8,
-      "row": 10,
-      "size_x": 6,
-      "size_y": 3,
       "type": "visualization",
-      "version": 2
+      "updated_at": "2018-03-01T18:58:07.906Z",
+      "version": 3
     },
     {
       "attributes": {
@@ -131,14 +107,10 @@
         "version": 1,
         "visState": "{\"title\":\"Network out by node  [Metricbeat Kubernetes]\",\"type\":\"metrics\",\"params\":{\"id\":\"0d5c6b10-2bf2-11e7-859b-f78b612cde28\",\"type\":\"timeseries\",\"series\":[{\"id\":\"0d5c9220-2bf2-11e7-859b-f78b612cde28\",\"color\":\"rgba(104,188,0,1)\",\"split_mode\":\"terms\",\"metrics\":[{\"id\":\"0d5c9221-2bf2-11e7-859b-f78b612cde28\",\"type\":\"sum\",\"field\":\"kubernetes.pod.network.tx.bytes\"},{\"unit\":\"\",\"id\":\"494fc310-2bf7-11e7-859b-f78b612cde28\",\"type\":\"derivative\",\"field\":\"0d5c9221-2bf2-11e7-859b-f78b612cde28\"},{\"unit\":\"\",\"id\":\"244c70e0-3598-11e7-aa4a-8313a0c92a88\",\"type\":\"positive_only\",\"field\":\"494fc310-2bf7-11e7-859b-f78b612cde28\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"bytes\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"stacked\",\"terms_field\":\"kubernetes.node.name\",\"terms_size\":\"10000\",\"terms_order_by\":\"0d5c9221-2bf2-11e7-859b-f78b612cde28\",\"label\":\"\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"show_legend\":1,\"background_color_rules\":[{\"id\":\"12c1f2f0-2bf2-11e7-859b-f78b612cde28\"}],\"bar_color_rules\":[{\"id\":\"1373ddd0-2bf2-11e7-859b-f78b612cde28\"}],\"gauge_color_rules\":[{\"id\":\"140e4910-2bf2-11e7-859b-f78b612cde28\"}],\"gauge_width\":10,\"gauge_inner_width\":10,\"gauge_style\":\"half\",\"filter\":\"metricset.module:kubernetes AND metricset.name:pod\"},\"aggs\":[],\"listeners\":{}}"
       },
-      "col": 1,
       "id": "294546b0-30d6-11e7-8df8-6d3604a72912",
-      "panelIndex": 9,
-      "row": 10,
-      "size_x": 6,
-      "size_y": 3,
       "type": "visualization",
-      "version": 2
+      "updated_at": "2018-03-01T18:58:07.906Z",
+      "version": 3
     },
     {
       "attributes": {
@@ -151,14 +123,10 @@
         "version": 1,
         "visState": "{\"title\":\"Kubernetes - Nodes\",\"type\":\"metrics\",\"params\":{\"id\":\"4c4690b0-30e0-11e7-8df8-6d3604a72912\",\"type\":\"metric\",\"series\":[{\"id\":\"4c4690b1-30e0-11e7-8df8-6d3604a72912\",\"color\":\"#68BC00\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"4c4690b2-30e0-11e7-8df8-6d3604a72912\",\"type\":\"cardinality\",\"field\":\"kubernetes.node.name\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"terms_field\":\"kubernetes.deployment.name\",\"label\":\"Nodes\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"show_legend\":1,\"filter\":\"metricset.module:kubernetes AND metricset.name:state_node\",\"background_color_rules\":[{\"id\":\"67ee7da0-30e0-11e7-8df8-6d3604a72912\"}],\"bar_color_rules\":[{\"id\":\"68cdba10-30e0-11e7-8df8-6d3604a72912\"}],\"gauge_color_rules\":[{\"id\":\"69765620-30e0-11e7-8df8-6d3604a72912\"}],\"gauge_width\":10,\"gauge_inner_width\":10,\"gauge_style\":\"half\"},\"aggs\":[],\"listeners\":{}}"
       },
-      "col": 1,
       "id": "408fccf0-30d6-11e7-8df8-6d3604a72912",
-      "panelIndex": 10,
-      "row": 1,
-      "size_x": 3,
-      "size_y": 3,
       "type": "visualization",
-      "version": 1
+      "updated_at": "2018-03-01T18:58:07.906Z",
+      "version": 3
     },
     {
       "attributes": {
@@ -171,34 +139,26 @@
         "version": 1,
         "visState": "{\"title\":\"Top CPU intensive pods  [Metricbeat Kubernetes]\",\"type\":\"metrics\",\"params\":{\"id\":\"5d3692a0-2bfc-11e7-859b-f78b612cde28\",\"type\":\"top_n\",\"series\":[{\"id\":\"5d3692a1-2bfc-11e7-859b-f78b612cde28\",\"color\":\"#68BC00\",\"split_mode\":\"terms\",\"metrics\":[{\"id\":\"5d3692a2-2bfc-11e7-859b-f78b612cde28\",\"type\":\"sum\",\"field\":\"kubernetes.container.cpu.usage.core.ns\"},{\"unit\":\"1s\",\"id\":\"6c905240-2bfc-11e7-859b-f78b612cde28\",\"type\":\"derivative\",\"field\":\"5d3692a2-2bfc-11e7-859b-f78b612cde28\"},{\"unit\":\"\",\"id\":\"9a51f710-359d-11e7-aa4a-8313a0c92a88\",\"type\":\"positive_only\",\"field\":\"6c905240-2bfc-11e7-859b-f78b612cde28\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"0.0 a\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"terms_field\":\"kubernetes.pod.name\",\"terms_order_by\":\"5d3692a2-2bfc-11e7-859b-f78b612cde28\",\"value_template\":\"{{value}} ns\",\"offset_time\":\"\",\"override_index_pattern\":0}],\"time_field\":\"@timestamp\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"show_legend\":1,\"bar_color_rules\":[{\"id\":\"802104d0-2bfc-11e7-859b-f78b612cde28\"}],\"filter\":\"metricset.module:kubernetes AND metricset.name:container\"},\"aggs\":[],\"listeners\":{}}"
       },
-      "col": 1,
       "id": "58e644f0-30d6-11e7-8df8-6d3604a72912",
-      "panelIndex": 11,
-      "row": 13,
-      "size_x": 6,
-      "size_y": 3,
       "type": "visualization",
-      "version": 2
+      "updated_at": "2018-03-01T18:58:07.906Z",
+      "version": 3
     },
     {
       "attributes": {
         "description": "",
         "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query_string\":{\"query\":\"*\"}},\"filter\":[]}"
+          "searchSourceJSON": "{\"query\":{\"query\":{\"query_string\":{\"query\":\"*\"}},\"language\":\"lucene\"},\"filter\":[]}"
         },
         "title": "Top memory intensive pods  [Metricbeat Kubernetes]",
         "uiStateJSON": "{}",
         "version": 1,
-        "visState": "{\"title\":\"Top memory intensive pods  [Metricbeat Kubernetes]\",\"type\":\"metrics\",\"params\":{\"id\":\"5d3692a0-2bfc-11e7-859b-f78b612cde28\",\"type\":\"top_n\",\"series\":[{\"id\":\"5d3692a1-2bfc-11e7-859b-f78b612cde28\",\"color\":\"#68BC00\",\"split_mode\":\"terms\",\"metrics\":[{\"id\":\"5d3692a2-2bfc-11e7-859b-f78b612cde28\",\"type\":\"sum\",\"field\":\"kubernetes.container.memory.usage.bytes\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"bytes\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"terms_field\":\"kubernetes.pod.name\",\"terms_order_by\":\"5d3692a2-2bfc-11e7-859b-f78b612cde28\",\"value_template\":\"\",\"offset_time\":\"\",\"override_index_pattern\":0,\"terms_size\":\"10\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"show_legend\":1,\"bar_color_rules\":[{\"id\":\"802104d0-2bfc-11e7-859b-f78b612cde28\"}],\"filter\":\"metricset.module:kubernetes AND metricset.name:container\"},\"aggs\":[],\"listeners\":{}}"
+        "visState": "{\"title\":\"Top memory intensive pods  [Metricbeat Kubernetes]\",\"type\":\"metrics\",\"params\":{\"id\":\"5d3692a0-2bfc-11e7-859b-f78b612cde28\",\"type\":\"top_n\",\"series\":[{\"id\":\"5d3692a1-2bfc-11e7-859b-f78b612cde28\",\"color\":\"#68BC00\",\"split_mode\":\"terms\",\"metrics\":[{\"id\":\"5d3692a2-2bfc-11e7-859b-f78b612cde28\",\"type\":\"sum\",\"field\":\"kubernetes.container.memory.usage.bytes\"},{\"id\":\"3972e9f0-256f-11e8-84e6-87221f87ae3b\",\"type\":\"cumulative_sum\",\"field\":\"5d3692a2-2bfc-11e7-859b-f78b612cde28\"},{\"unit\":\"10s\",\"id\":\"3e9fd5a0-256f-11e8-84e6-87221f87ae3b\",\"type\":\"derivative\",\"field\":\"3972e9f0-256f-11e8-84e6-87221f87ae3b\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"bytes\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"terms_field\":\"kubernetes.pod.name\",\"terms_order_by\":\"5d3692a2-2bfc-11e7-859b-f78b612cde28\",\"value_template\":\"\",\"offset_time\":\"\",\"override_index_pattern\":0,\"terms_size\":\"10\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"show_legend\":1,\"bar_color_rules\":[{\"id\":\"802104d0-2bfc-11e7-859b-f78b612cde28\"}],\"filter\":\"metricset.module:kubernetes AND metricset.name:container\",\"show_grid\":1},\"aggs\":[]}"
       },
-      "col": 7,
       "id": "a4c9d360-30df-11e7-8df8-6d3604a72912",
-      "panelIndex": 12,
-      "row": 13,
-      "size_x": 6,
-      "size_y": 3,
       "type": "visualization",
-      "version": 2
+      "updated_at": "2018-03-11T21:00:49.028Z",
+      "version": 4
     },
     {
       "attributes": {
@@ -211,34 +171,26 @@
         "version": 1,
         "visState": "{\"title\":\"Kubernetes - Unavailable pods\",\"type\":\"metrics\",\"params\":{\"id\":\"2fe9d3b0-30d5-11e7-8df8-6d3604a72912\",\"type\":\"metric\",\"series\":[{\"id\":\"2fe9d3b1-30d5-11e7-8df8-6d3604a72912\",\"color\":\"#68BC00\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"54cf79a0-30d5-11e7-8df8-6d3604a72912\",\"type\":\"sum\",\"field\":\"kubernetes.deployment.replicas.unavailable\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"label\":\"Unavailable Pods\",\"override_index_pattern\":1,\"series_interval\":\"10s\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"show_legend\":1,\"background_color_rules\":[{\"id\":\"508ffb30-30d5-11e7-8df8-6d3604a72912\"}],\"gauge_color_rules\":[{\"id\":\"50f9b980-30d5-11e7-8df8-6d3604a72912\"}],\"gauge_width\":\"10\",\"gauge_inner_width\":\"10\",\"gauge_style\":\"half\",\"bar_color_rules\":[{\"id\":\"674d83b0-30d5-11e7-8df8-6d3604a72912\"}],\"gauge_max\":\"\",\"filter\":\"metricset.module:kubernetes AND metricset.name:state_deployment\"},\"aggs\":[],\"listeners\":{}}"
       },
-      "col": 5,
       "id": "174a6ad0-30e0-11e7-8df8-6d3604a72912",
-      "panelIndex": 13,
-      "row": 4,
-      "size_x": 2,
-      "size_y": 3,
       "type": "visualization",
-      "version": 1
+      "updated_at": "2018-03-01T18:58:07.906Z",
+      "version": 3
     },
     {
       "attributes": {
         "description": "",
         "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query_string\":{\"query\":\"*\"}},\"filter\":[]}"
+          "searchSourceJSON": "{\"query\":{\"query\":{\"query_string\":{\"query\":\"*\"}},\"language\":\"lucene\"},\"filter\":[]}"
         },
         "title": "Unavailable pods per deployment [Metricbeat Kubernetes]",
         "uiStateJSON": "{}",
         "version": 1,
-        "visState": "{\"title\":\"Unavailable pods per deployment [Metricbeat Kubernetes]\",\"type\":\"metrics\",\"params\":{\"id\":\"117fadf0-30df-11e7-8df8-6d3604a72912\",\"type\":\"timeseries\",\"series\":[{\"id\":\"64456840-30df-11e7-8df8-6d3604a72912\",\"color\":\"rgba(254,146,0,1)\",\"split_mode\":\"terms\",\"metrics\":[{\"id\":\"64456841-30df-11e7-8df8-6d3604a72912\",\"type\":\"sum\",\"field\":\"kubernetes.deployment.replicas.unavailable\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"stacked\",\"split_filters\":[{\"color\":\"#68BC00\",\"id\":\"53d35ad0-30df-11e7-8df8-6d3604a72912\"}],\"terms_field\":\"kubernetes.deployment.name\",\"label\":\"Unavailable pods\",\"terms_size\":\"10000\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"show_legend\":1,\"filter\":\"metricset.module:kubernetes AND metricset.name:state_deployment\"},\"aggs\":[],\"listeners\":{}}"
+        "visState": "{\"title\":\"Unavailable pods per deployment [Metricbeat Kubernetes]\",\"type\":\"metrics\",\"params\":{\"id\":\"117fadf0-30df-11e7-8df8-6d3604a72912\",\"type\":\"timeseries\",\"series\":[{\"id\":\"64456840-30df-11e7-8df8-6d3604a72912\",\"color\":\"rgba(254,146,0,1)\",\"split_mode\":\"terms\",\"metrics\":[{\"id\":\"64456841-30df-11e7-8df8-6d3604a72912\",\"type\":\"avg\",\"field\":\"kubernetes.deployment.replicas.unavailable\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"stacked\",\"split_filters\":[{\"color\":\"#68BC00\",\"id\":\"53d35ad0-30df-11e7-8df8-6d3604a72912\"}],\"terms_field\":\"kubernetes.deployment.name\",\"label\":\"Unavailable pods\",\"terms_size\":\"10000\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"show_legend\":1,\"filter\":\"metricset.module:kubernetes AND metricset.name:state_deployment\",\"show_grid\":1},\"aggs\":[]}"
       },
-      "col": 7,
       "id": "7aac4fd0-30e0-11e7-8df8-6d3604a72912",
-      "panelIndex": 14,
-      "row": 4,
-      "size_x": 6,
-      "size_y": 3,
       "type": "visualization",
-      "version": 2
+      "updated_at": "2018-03-11T20:59:18.668Z",
+      "version": 4
     },
     {
       "attributes": {
@@ -251,33 +203,29 @@
         "version": 1,
         "visState": "{\"title\":\"Kubernetes - Available pods\",\"type\":\"metrics\",\"params\":{\"id\":\"2fe9d3b0-30d5-11e7-8df8-6d3604a72912\",\"type\":\"metric\",\"series\":[{\"id\":\"2fe9d3b1-30d5-11e7-8df8-6d3604a72912\",\"color\":\"#68BC00\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"54cf79a0-30d5-11e7-8df8-6d3604a72912\",\"type\":\"sum\",\"field\":\"kubernetes.deployment.replicas.available\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"label\":\"Available Pods\",\"override_index_pattern\":1,\"series_time_field\":\"@timestamp\",\"series_index_pattern\":\"*\",\"series_interval\":\"10s\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"show_legend\":1,\"background_color_rules\":[{\"id\":\"508ffb30-30d5-11e7-8df8-6d3604a72912\"}],\"gauge_color_rules\":[{\"id\":\"50f9b980-30d5-11e7-8df8-6d3604a72912\"}],\"gauge_width\":\"10\",\"gauge_inner_width\":\"10\",\"gauge_style\":\"half\",\"bar_color_rules\":[{\"id\":\"674d83b0-30d5-11e7-8df8-6d3604a72912\"}],\"gauge_max\":\"5\",\"filter\":\"metricset.module:kubernetes AND metricset.name:state_deployment\"},\"aggs\":[],\"listeners\":{}}"
       },
-      "col": 3,
       "id": "da1ff7c0-30ed-11e7-b9e5-2b5b07213ab3",
-      "panelIndex": 15,
-      "row": 4,
-      "size_x": 2,
-      "size_y": 3,
       "type": "visualization",
-      "version": 1
+      "updated_at": "2018-03-01T18:58:07.906Z",
+      "version": 3
     },
     {
       "attributes": {
         "description": "",
         "hits": 0,
         "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[{\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}}}],\"highlightAll\":true,\"version\":true}"
+          "searchSourceJSON": "{\"filter\":[],\"highlightAll\":true,\"version\":true,\"query\":{\"language\":\"lucene\",\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}}}}"
         },
-        "optionsJSON": "{\"darkTheme\":false}",
-        "panelsJSON": "[{\"col\":7,\"id\":\"022a54c0-2bf5-11e7-859b-f78b612cde28\",\"panelIndex\":1,\"row\":1,\"size_x\":6,\"size_y\":3,\"type\":\"visualization\"},{\"col\":1,\"id\":\"44f12b40-2bf4-11e7-859b-f78b612cde28\",\"panelIndex\":2,\"row\":7,\"size_x\":6,\"size_y\":3,\"type\":\"visualization\"},{\"col\":4,\"id\":\"cd059410-2bfb-11e7-859b-f78b612cde28\",\"panelIndex\":5,\"row\":1,\"size_x\":3,\"size_y\":3,\"type\":\"visualization\"},{\"col\":1,\"id\":\"e1018b90-2bfb-11e7-859b-f78b612cde28\",\"panelIndex\":6,\"row\":4,\"size_x\":2,\"size_y\":3,\"type\":\"visualization\"},{\"col\":7,\"id\":\"d6564360-2bfc-11e7-859b-f78b612cde28\",\"panelIndex\":7,\"row\":7,\"size_x\":6,\"size_y\":3,\"type\":\"visualization\"},{\"col\":7,\"id\":\"16fa4470-2bfd-11e7-859b-f78b612cde28\",\"panelIndex\":8,\"row\":10,\"size_x\":6,\"size_y\":3,\"type\":\"visualization\"},{\"col\":1,\"id\":\"294546b0-30d6-11e7-8df8-6d3604a72912\",\"panelIndex\":9,\"row\":10,\"size_x\":6,\"size_y\":3,\"type\":\"visualization\"},{\"col\":1,\"id\":\"408fccf0-30d6-11e7-8df8-6d3604a72912\",\"panelIndex\":10,\"row\":1,\"size_x\":3,\"size_y\":3,\"type\":\"visualization\"},{\"col\":1,\"id\":\"58e644f0-30d6-11e7-8df8-6d3604a72912\",\"panelIndex\":11,\"row\":13,\"size_x\":6,\"size_y\":3,\"type\":\"visualization\"},{\"col\":7,\"id\":\"a4c9d360-30df-11e7-8df8-6d3604a72912\",\"panelIndex\":12,\"row\":13,\"size_x\":6,\"size_y\":3,\"type\":\"visualization\"},{\"col\":5,\"id\":\"174a6ad0-30e0-11e7-8df8-6d3604a72912\",\"panelIndex\":13,\"row\":4,\"size_x\":2,\"size_y\":3,\"type\":\"visualization\"},{\"col\":7,\"id\":\"7aac4fd0-30e0-11e7-8df8-6d3604a72912\",\"panelIndex\":14,\"row\":4,\"size_x\":6,\"size_y\":3,\"type\":\"visualization\"},{\"col\":3,\"id\":\"da1ff7c0-30ed-11e7-b9e5-2b5b07213ab3\",\"panelIndex\":15,\"row\":4,\"size_x\":2,\"size_y\":3,\"type\":\"visualization\"}]",
+        "optionsJSON": "{\"darkTheme\":false,\"useMargins\":false}",
+        "panelsJSON": "[{\"gridData\":{\"h\":3,\"i\":\"1\",\"w\":6,\"x\":6,\"y\":0},\"id\":\"022a54c0-2bf5-11e7-859b-f78b612cde28\",\"panelIndex\":\"1\",\"type\":\"visualization\",\"version\":\"6.2.2\"},{\"gridData\":{\"h\":3,\"i\":\"2\",\"w\":6,\"x\":0,\"y\":6},\"id\":\"44f12b40-2bf4-11e7-859b-f78b612cde28\",\"panelIndex\":\"2\",\"type\":\"visualization\",\"version\":\"6.2.2\"},{\"gridData\":{\"h\":3,\"i\":\"5\",\"w\":3,\"x\":3,\"y\":0},\"id\":\"cd059410-2bfb-11e7-859b-f78b612cde28\",\"panelIndex\":\"5\",\"type\":\"visualization\",\"version\":\"6.2.2\"},{\"gridData\":{\"h\":3,\"i\":\"6\",\"w\":2,\"x\":0,\"y\":3},\"id\":\"e1018b90-2bfb-11e7-859b-f78b612cde28\",\"panelIndex\":\"6\",\"type\":\"visualization\",\"version\":\"6.2.2\"},{\"gridData\":{\"h\":3,\"i\":\"7\",\"w\":6,\"x\":6,\"y\":6},\"id\":\"d6564360-2bfc-11e7-859b-f78b612cde28\",\"panelIndex\":\"7\",\"type\":\"visualization\",\"version\":\"6.2.2\"},{\"gridData\":{\"h\":3,\"i\":\"8\",\"w\":6,\"x\":6,\"y\":9},\"id\":\"16fa4470-2bfd-11e7-859b-f78b612cde28\",\"panelIndex\":\"8\",\"type\":\"visualization\",\"version\":\"6.2.2\"},{\"gridData\":{\"h\":3,\"i\":\"9\",\"w\":6,\"x\":0,\"y\":9},\"id\":\"294546b0-30d6-11e7-8df8-6d3604a72912\",\"panelIndex\":\"9\",\"type\":\"visualization\",\"version\":\"6.2.2\"},{\"gridData\":{\"h\":3,\"i\":\"10\",\"w\":3,\"x\":0,\"y\":0},\"id\":\"408fccf0-30d6-11e7-8df8-6d3604a72912\",\"panelIndex\":\"10\",\"type\":\"visualization\",\"version\":\"6.2.2\"},{\"gridData\":{\"h\":3,\"i\":\"11\",\"w\":6,\"x\":0,\"y\":12},\"id\":\"58e644f0-30d6-11e7-8df8-6d3604a72912\",\"panelIndex\":\"11\",\"type\":\"visualization\",\"version\":\"6.2.2\"},{\"gridData\":{\"h\":3,\"i\":\"12\",\"w\":6,\"x\":6,\"y\":12},\"id\":\"a4c9d360-30df-11e7-8df8-6d3604a72912\",\"panelIndex\":\"12\",\"type\":\"visualization\",\"version\":\"6.2.2\"},{\"gridData\":{\"h\":3,\"i\":\"13\",\"w\":2,\"x\":4,\"y\":3},\"id\":\"174a6ad0-30e0-11e7-8df8-6d3604a72912\",\"panelIndex\":\"13\",\"type\":\"visualization\",\"version\":\"6.2.2\"},{\"gridData\":{\"h\":3,\"i\":\"14\",\"w\":6,\"x\":6,\"y\":3},\"id\":\"7aac4fd0-30e0-11e7-8df8-6d3604a72912\",\"panelIndex\":\"14\",\"type\":\"visualization\",\"version\":\"6.2.2\"},{\"gridData\":{\"h\":3,\"i\":\"15\",\"w\":2,\"x\":2,\"y\":3},\"id\":\"da1ff7c0-30ed-11e7-b9e5-2b5b07213ab3\",\"panelIndex\":\"15\",\"type\":\"visualization\",\"version\":\"6.2.2\"}]",
         "timeRestore": false,
         "title": "[Metricbeat Kubernetes] Overview",
-        "uiStateJSON": "{}",
         "version": 1
       },
       "id": "AV4RGUqo5NkDleZmzKuZ",
       "type": "dashboard",
-      "version": 3
+      "updated_at": "2018-03-11T21:00:58.354Z",
+      "version": 4
     }
   ],
-  "version": "5.6.0-SNAPSHOT"
+  "version": "6.2.2"
 }


### PR DESCRIPTION
Cherry-pick of PR #6415 to 6.2 branch. Original message: 

When switching to bigger time ranges, some of the visualizations in the dashboard
broke due to some wrong calculations.

I have updated them to work with any time range.

Before this change:

![before](https://user-images.githubusercontent.com/299804/37258527-bb90d4ce-2579-11e8-9400-0875d7fa841d.png)

After this change:

![after](https://user-images.githubusercontent.com/299804/37258530-c03896f6-2579-11e8-835f-9e45eab8a4bc.png)

Fixes #6395 