### PR TITLE
[6.x] Make normalization processor optional (#6513)

### DIFF
--- a/libbeat/beat/event.go
+++ b/libbeat/beat/event.go
@@ -12,11 +12,10 @@ import (
 // The `Meta`-fields can be used to pass additional meta-data to the outputs.
 // Output can optionally publish a subset of Meta, or ignore Meta.
 type Event struct {
-	Timestamp  time.Time
-	Meta       common.MapStr
-	Fields     common.MapStr
-	Private    interface{} // for beats private use
-	Normalized bool
+	Timestamp time.Time
+	Meta      common.MapStr
+	Fields    common.MapStr
+	Private   interface{} // for beats private use
 }
 
 var (

--- a/libbeat/beat/pipeline.go
+++ b/libbeat/beat/pipeline.go
@@ -50,6 +50,10 @@ type ClientConfig struct {
 	// Events configures callbacks for common client callbacks
 	Events ClientEventer
 
+	// By default events are normalized within processor pipeline,
+	// if the normalization step should be skipped set this to true.
+	SkipNormalization bool
+
 	// ACK handler strategies.
 	// Note: ack handlers are run in another go-routine owned by the publisher pipeline.
 	//       They should not block for to long, to not block the internal buffers for

--- a/libbeat/publisher/pipeline/processor.go
+++ b/libbeat/publisher/pipeline/processor.go
@@ -55,8 +55,10 @@ func newProcessorPipeline(
 
 	needsCopy := global.alwaysCopy || localProcessors != nil || global.processors != nil
 
-	// setup 1: generalize/normalize output (P)
-	processors.add(generalizeProcessor)
+	if !config.SkipNormalization {
+		// setup 1: generalize/normalize output (P)
+		processors.add(generalizeProcessor)
+	}
 
 	// setup 2: add Meta from client config (C)
 	if m := clientMeta; len(m) > 0 {
@@ -175,9 +177,6 @@ var generalizeProcessor = newProcessor("generalizeEvent", func(event *beat.Event
 	if len(event.Fields) == 0 {
 		return nil, nil
 	}
-	if event.Normalized {
-		return event, nil
-	}
 
 	fields := common.ConvertToGenericEvent(event.Fields)
 	if fields == nil {
@@ -186,7 +185,6 @@ var generalizeProcessor = newProcessor("generalizeEvent", func(event *beat.Event
 	}
 
 	event.Fields = fields
-	event.Normalized = true
 	return event, nil
 })
 

--- a/libbeat/publisher/pipeline/processor_test.go
+++ b/libbeat/publisher/pipeline/processor_test.go
@@ -15,10 +15,9 @@ func TestProcessors(t *testing.T) {
 	info := beat.Info{}
 
 	type local struct {
-		config     beat.ClientConfig
-		events     []common.MapStr
-		expected   []common.MapStr
-		normalized bool
+		config   beat.ClientConfig
+		events   []common.MapStr
+		expected []common.MapStr
 	}
 
 	tests := []struct {
@@ -50,12 +49,11 @@ func TestProcessors(t *testing.T) {
 			},
 			[]local{
 				{
-					config: beat.ClientConfig{},
+					config: beat.ClientConfig{SkipNormalization: true},
 					events: []common.MapStr{{"value": "abc", "user": nil}},
 					expected: []common.MapStr{
 						{"value": "abc", "user": nil, "global": 1, "tags": []string{"tag"}},
 					},
-					normalized: true,
 				},
 			},
 		},
@@ -318,9 +316,8 @@ func TestProcessors(t *testing.T) {
 					actual := make([]common.MapStr, len(local.events))
 					for i, event := range local.events {
 						out, _ := program.Run(&beat.Event{
-							Timestamp:  time.Now(),
-							Fields:     event,
-							Normalized: local.normalized,
+							Timestamp: time.Now(),
+							Fields:    event,
 						})
 						actual[i] = out.Fields
 					}


### PR DESCRIPTION
Backports the following commits to 6.x:
 - Make normalization processor optional  (#6513)