### PR TITLE
Move elasticsearch module system tests to module

### DIFF
--- a/metricbeat/module/elasticsearch/test_elasticsearch.py
+++ b/metricbeat/module/elasticsearch/test_elasticsearch.py
@@ -1,6 +1,11 @@
+import re
+import sys
 import os
-import metricbeat
 import unittest
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '../../tests/system'))
+
+import metricbeat
 
 
 class Test(metricbeat.BaseTest):


### PR DESCRIPTION
Currently the tests for a module/metricset in Metricbeat are in the same go path but also under `tests/system` for the system tests. This makes it tricky to execute all tests for one module. There is a need to execute all tests for one module at once as all tests in a module potentially need the same service to be running. Having all tests together could make the execution of the tests more efficient as the service only has to be started once and potentially allows to horizontally scale the module tests as everything needed is in one place.

This change moves the system tests for the elasticsearch module to the metricset directory. Thanks to an earlier change tests can be execute from any directory and thanks to the changes from @exekias each test knows which environment it must start.
The test can now be started as following:

```
INTEGRATION_TESTS=1 nosetests module/elasticsearch/_meta/
```

The system tests for a module currently run 2 types of tests:

* Check if no errors are returned when executing the binary with the module enabled
* Check if the fields are documented

The check for if all fields are documented should be moved to Golang in the long term. We have now support to read fields.yml in Golang and apm-server already uses this verification today. The first part to verify if the binary works as expected and does not return any errors can be tricky to be moved to Golang and definitively see value for it. In the past we had the issue were a module was not compiled because it did match by accident one of the exclude patterns in the generators. This can only be detected with the final binary.

Tests if fields are documented should be moved to Golang and as they are almost identical for all modules / metricsets it should be possible to autogenerate them. apm-server already has today some checks in Golang for the fields.yml.

Initially I did split the tests for each metricset which makes it possible that a metricset is fully abstracted from the module so a module does not know directly about it's metricsets even for tests, but the change had the side affect that the service has to be started twice for the tests which slows it down.