### PR TITLE
Filebeat: Error out if no modules are enabled

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -109,7 +109,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Fix variable name for `convert_timezone` in the system module. {pull}5936[5936]
 - Fix a conversion issue for time related fields in the Logstash module for the slowlog
   fileset. {issue}6317[6317]
-
+- Error out if no modules are enabled and no dynamic configurations are in place. {pull}6538[6538]
 *Heartbeat*
 
 - Fix the "HTTP up status" visualization. {pull}5564[5564]

--- a/filebeat/beater/filebeat.go
+++ b/filebeat/beater/filebeat.go
@@ -118,6 +118,13 @@ func New(b *beat.Beat, rawConfig *common.Config) (beat.Beater, error) {
 		moduleRegistry: moduleRegistry,
 	}
 
+	dynamicConfig := cfgfile.DefaultDynamicConfig
+	fb.config.ConfigModules.Unpack(&dynamicConfig)
+
+	if config.ConfigModules.Enabled() && moduleRegistry.Empty() && !dynamicConfig.Reload.Enabled && config.Autodiscover == nil {
+		return nil, errors.New("modules feature configured but no modules are enabled and configuration reloading is disabled")
+	}
+
 	// register `setup` callback for ML jobs
 	b.SetupMLCallback = func(b *beat.Beat) error {
 		return fb.loadModulesML(b)

--- a/filebeat/tests/system/test_modules.py
+++ b/filebeat/tests/system/test_modules.py
@@ -70,6 +70,29 @@ class Test(BaseTest):
                         test_file=test_file,
                         cfgfile=cfgfile)
 
+    def test_shutdown_no_modules(self):
+        """
+        In case modules are configured but no modules are enabled filebeat must shut down and report an error
+        """
+
+        self.init()
+        cfgfile = os.path.join(self.working_dir, "filebeat.yml")
+        self.render_config_template(
+            template_name="filebeat_modules",
+            output=cfgfile,
+            index_name=self.index_name,
+            elasticsearch_url=self.elasticsearch_url
+        )
+
+        filebeat = self.start_beat()
+
+        self.wait_until(
+            lambda: self.log_contains(
+                "modules feature configured but no modules are enabled and configuration reloading is disabled"),
+            max_timeout=10)
+
+        filebeat.check_wait(exit_code=1)
+
     def _test_expected_events(self, module, test_file, res, objects):
         with open(test_file + "-expected.json", "r") as f:
             expected = json.load(f)

--- a/filebeat/tests/system/test_reload_modules.py
+++ b/filebeat/tests/system/test_reload_modules.py
@@ -170,6 +170,7 @@ class Test(BaseTest):
         self.render_config_template(
             reload_path=self.working_dir + "/configs/*.yml",
             reload_type="modules",
+            reload=True,
             inputs=False,
         )
 


### PR DESCRIPTION
Filebeat should error out when modules are configured
but not enabled and autodiscover is disabled.

Example scenario:
```
$ ./filebeat modules list
Enabled:

Disabled:
apache2
auditd
icinga
kafka
logstash
mysql
nginx
osquery
postgresql
redis
system
traefik
```

```
$ ./filebeat export config
filebeat:
  config:
    modules:
      path: ${path.config}/modules.d/*.yml
      reload:
        enabled: true
  prospectors:
  - enabled: false
    paths:
    - /var/log/*.log
    type: log

output.elasticsearch:
  # Array of hosts to connect to.
  hosts: ["localhost:9200"]
```

Signed-off-by: Jaipradeesh <jaipradeesh@gmail.com>