### PR TITLE
Use match.Matcher for checking heartbeat response bodies #5981

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -29,6 +29,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 *Heartbeat*
 
 - Made the URL field of heartbeat aggregatable. {pull}6263[6263]
+- Use `match.Matcher` for checking heartbeat response bodies with regular expressions. {pull}6539[6539]
 
 *Metricbeat*
 

--- a/heartbeat/docs/heartbeat-options.asciidoc
+++ b/heartbeat/docs/heartbeat-options.asciidoc
@@ -469,13 +469,13 @@ contains JSON:
 - type: http
   schedule: '@every 5s'
   urls: ["https://myhost:80"]
-check.request:
-  method: GET
-  headers:
-    'X-API-Key': '12345-mykey-67890'
-check.response:
-  status: 200
-  body: '{"status": "ok"}'
+  check.request:
+    method: GET
+    headers:
+      'X-API-Key': '12345-mykey-67890'
+  check.response:
+    status: 200
+    body: '{"status": "ok"}'
 -------------------------------------------------------------------------------
 
 The following configuration shows how to check the response for multiple regex
@@ -486,15 +486,15 @@ patterns:
 - type: http
   schedule: '@every 5s'
   urls: ["https://myhost:80"]
-check.request:
-  method: GET
-  headers:
-    'X-API-Key': '12345-mykey-67890'
-check.response:
-  status: 200
-  body:
-    - hello
-    - world
+  check.request:
+    method: GET
+    headers:
+      'X-API-Key': '12345-mykey-67890'
+  check.response:
+    status: 200
+    body:
+      - hello
+      - world
 -------------------------------------------------------------------------------
 
 The following configuration shows how to check the response with a multiline
@@ -505,13 +505,13 @@ regex:
 - type: http
   schedule: '@every 5s'
   urls: ["https://myhost:80"]
-check.request:
-  method: GET
-  headers:
-    'X-API-Key': '12345-mykey-67890'
-check.response:
-  status: 200
-  body: '(?s)first.*second.*third'
+  check.request:
+    method: GET
+    headers:
+      'X-API-Key': '12345-mykey-67890'
+  check.response:
+    status: 200
+    body: '(?s)first.*second.*third'
 -------------------------------------------------------------------------------
 
 

--- a/heartbeat/docs/heartbeat-options.asciidoc
+++ b/heartbeat/docs/heartbeat-options.asciidoc
@@ -459,7 +459,7 @@ Under `check.response`, specify these options:
 *`status`*:: The expected status code. If this setting is not configured or
 it's set to 0, any status code other than 404 is accepted.
 *`headers`*:: The required response headers.
-*`body`*:: The required response body content.
+*`body`*:: A list of regular expressions to match the the body output. Only a single expression needs to match.
 
 The following configuration shows how to check the response when the body
 contains JSON:
@@ -476,6 +476,42 @@ check.request:
 check.response:
   status: 200
   body: '{"status": "ok"}'
+-------------------------------------------------------------------------------
+
+The following configuration shows how to check the response for multiple regex
+patterns:
+
+[source,yaml]
+-------------------------------------------------------------------------------
+- type: http
+  schedule: '@every 5s'
+  urls: ["https://myhost:80"]
+check.request:
+  method: GET
+  headers:
+    'X-API-Key': '12345-mykey-67890'
+check.response:
+  status: 200
+  body:
+    - hello
+    - world
+-------------------------------------------------------------------------------
+
+The following configuration shows how to check the response with a multiline
+regex:
+
+[source,yaml]
+-------------------------------------------------------------------------------
+- type: http
+  schedule: '@every 5s'
+  urls: ["https://myhost:80"]
+check.request:
+  method: GET
+  headers:
+    'X-API-Key': '12345-mykey-67890'
+check.response:
+  status: 200
+  body: '(?s)first.*second.*third'
 -------------------------------------------------------------------------------
 
 

--- a/heartbeat/monitors/active/http/check.go
+++ b/heartbeat/monitors/active/http/check.go
@@ -1,12 +1,12 @@
 package http
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"net/http"
+
+	"github.com/elastic/beats/libbeat/common/match"
 )
 
 type RespCheck func(*http.Response) error
@@ -29,7 +29,7 @@ func makeValidateResponse(config *responseParameters) RespCheck {
 	}
 
 	if len(config.RecvBody) > 0 {
-		checks = append(checks, checkBody([]byte(config.RecvBody)))
+		checks = append(checks, checkBody(config.RecvBody))
 	}
 
 	return checkAll(checks...)
@@ -84,18 +84,17 @@ func checkHeaders(headers map[string]string) RespCheck {
 	}
 }
 
-func checkBody(body []byte) RespCheck {
+func checkBody(body []match.Matcher) RespCheck {
 	return func(r *http.Response) error {
-		// read up to len(body)+1 bytes for comparing content to be equal
-		in := io.LimitReader(r.Body, int64(len(body))+1)
-		content, err := ioutil.ReadAll(in)
+		content, err := ioutil.ReadAll(r.Body)
 		if err != nil {
 			return err
 		}
-
-		if !bytes.Equal(body, content) {
-			return errBodyMismatch
+		for _, m := range body {
+			if m.MatchString(string(content)) {
+				return nil
+			}
 		}
-		return nil
+		return errBodyMismatch
 	}
 }

--- a/heartbeat/monitors/active/http/check.go
+++ b/heartbeat/monitors/active/http/check.go
@@ -91,7 +91,7 @@ func checkBody(body []match.Matcher) RespCheck {
 			return err
 		}
 		for _, m := range body {
-			if m.MatchString(string(content)) {
+			if m.Match(content) {
 				return nil
 			}
 		}

--- a/heartbeat/monitors/active/http/check_test.go
+++ b/heartbeat/monitors/active/http/check_test.go
@@ -15,33 +15,33 @@ func TestCheckBody(t *testing.T) {
 	var matchTests = []struct {
 		description string
 		body        string
-		patterns    []match.Matcher
+		patterns    []string
 		result      bool
 	}{
 		{
 			"Single regex that matches",
 			"ok",
-			[]match.Matcher{match.MustCompile("ok")},
+			[]string{"ok"},
 			true,
 		},
 		{
 			"Regex matching json example",
 			`{"status": "ok"}`,
-			[]match.Matcher{match.MustCompile(`{"status": "ok"}`)},
+			[]string{`{"status": "ok"}`},
 			true,
 		},
 		{
 			"Regex matching first line of multiline body string",
 			`first line
 			second line`,
-			[]match.Matcher{match.MustCompile("first")},
+			[]string{"first"},
 			true,
 		},
 		{
 			"Regex matching lastline of multiline body string",
 			`first line
 			second line`,
-			[]match.Matcher{match.MustCompile("second")},
+			[]string{"second"},
 			true,
 		},
 		{
@@ -49,7 +49,7 @@ func TestCheckBody(t *testing.T) {
 			`first line
 			second line
 			third line`,
-			[]match.Matcher{match.MustCompile("(?s)first.*second.*third")},
+			[]string{"(?s)first.*second.*third"},
 			true,
 		},
 		{
@@ -57,25 +57,25 @@ func TestCheckBody(t *testing.T) {
 			`first line
 			second line
 			third line`,
-			[]match.Matcher{match.MustCompile("(?s)first.*fourth.*third")},
+			[]string{"(?s)first.*fourth.*third"},
 			false,
 		},
 		{
 			"Single regex that doesn't match",
 			"ok",
-			[]match.Matcher{match.MustCompile("notok")},
+			[]string{"notok"},
 			false,
 		},
 		{
 			"Multiple regex match where at least one must match",
 			"ok",
-			[]match.Matcher{match.MustCompile("ok"), match.MustCompile("yay")},
+			[]string{"ok", "yay"},
 			true,
 		},
 		{
 			"Multiple regex match where none of the patterns match",
 			"ok",
-			[]match.Matcher{match.MustCompile("notok"), match.MustCompile("yay")},
+			[]string{"notok", "yay"},
 			false,
 		},
 	}
@@ -92,7 +92,11 @@ func TestCheckBody(t *testing.T) {
 				log.Fatal(err)
 			}
 
-			check := checkBody(test.patterns)(res)
+			patterns := []match.Matcher{}
+			for _, pattern := range test.patterns {
+				patterns = append(patterns, match.MustCompile(pattern))
+			}
+			check := checkBody(patterns)(res)
 
 			if result := (check == nil); result != test.result {
 				if test.result {

--- a/heartbeat/monitors/active/http/check_test.go
+++ b/heartbeat/monitors/active/http/check_test.go
@@ -1,0 +1,106 @@
+package http
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/elastic/beats/libbeat/common/match"
+)
+
+func TestCheckBody(t *testing.T) {
+
+	var matchTests = []struct {
+		description string
+		body        string
+		patterns    []match.Matcher
+		result      bool
+	}{
+		{
+			"Single regex that matches",
+			"ok",
+			[]match.Matcher{match.MustCompile("ok")},
+			true,
+		},
+		{
+			"Regex matching json example",
+			`{"status": "ok"}`,
+			[]match.Matcher{match.MustCompile(`{"status": "ok"}`)},
+			true,
+		},
+		{
+			"Regex matching first line of multiline body string",
+			`first line
+			second line`,
+			[]match.Matcher{match.MustCompile("first")},
+			true,
+		},
+		{
+			"Regex matching lastline of multiline body string",
+			`first line
+			second line`,
+			[]match.Matcher{match.MustCompile("second")},
+			true,
+		},
+		{
+			"Regex matching multiple lines of multiline body string",
+			`first line
+			second line
+			third line`,
+			[]match.Matcher{match.MustCompile("(?s)first.*second.*third")},
+			true,
+		},
+		{
+			"Regex not matching multiple lines of multiline body string",
+			`first line
+			second line
+			third line`,
+			[]match.Matcher{match.MustCompile("(?s)first.*fourth.*third")},
+			false,
+		},
+		{
+			"Single regex that doesn't match",
+			"ok",
+			[]match.Matcher{match.MustCompile("notok")},
+			false,
+		},
+		{
+			"Multiple regex match where at least one must match",
+			"ok",
+			[]match.Matcher{match.MustCompile("ok"), match.MustCompile("yay")},
+			true,
+		},
+		{
+			"Multiple regex match where none of the patterns match",
+			"ok",
+			[]match.Matcher{match.MustCompile("notok"), match.MustCompile("yay")},
+			false,
+		},
+	}
+
+	for _, test := range matchTests {
+		t.Run(test.description, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				fmt.Fprintln(w, test.body)
+			}))
+			defer ts.Close()
+
+			res, err := http.Get(ts.URL)
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			check := checkBody(test.patterns)(res)
+
+			if result := (check == nil); result != test.result {
+				if test.result {
+					t.Fatalf("Expected at least one of patterns: %s to match body: %s", test.patterns, test.body)
+				} else {
+					t.Fatalf("Did not expect patterns: %s to match body: %s", test.patterns, test.body)
+				}
+			}
+		})
+	}
+}

--- a/heartbeat/monitors/active/http/config.go
+++ b/heartbeat/monitors/active/http/config.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/elastic/beats/libbeat/common/match"
 	"github.com/elastic/beats/libbeat/outputs"
 
 	"github.com/elastic/beats/heartbeat/monitors"
@@ -52,7 +53,7 @@ type responseParameters struct {
 	// expected HTTP response configuration
 	Status      uint16            `config:"status" verify:"min=0, max=699"`
 	RecvHeaders map[string]string `config:"headers"`
-	RecvBody    string            `config:"body"`
+	RecvBody    []match.Matcher   `config:"body"`
 }
 
 type compressionConfig struct {
@@ -74,7 +75,7 @@ var defaultConfig = Config{
 		Response: responseParameters{
 			Status:      0,
 			RecvHeaders: nil,
-			RecvBody:    "",
+			RecvBody:    []match.Matcher{},
 		},
 	},
 }


### PR DESCRIPTION
The current behaviour of `check.response.body` is to match the entire response body. This works great for simple examples however doesn't work so great when you want to find a small string in a large body.

As discussed in #5981 I have modified the `check.response.body` parameter to expect a regex pattern (`match.Matcher`) instead of the entire body string to match. 

The awesome thing is this remained fully backwards compatible with the old body check method without any config changes even when using the json example in the docs :)

Another nice enhancement that I added was the use of [subtests](https://blog.golang.org/subtests). I originally copied some tests from another beat and was disappointed to find out that it would stop as soon as a test case failed and not run all of them. Subtests allows you to run all tests using the table driven pattern with the output and behaviour of writing multiple tests.

```
❯ go test github.com/elastic/beats/heartbeat/monitors/active/http -v
=== RUN   TestCheckBody
=== RUN   TestCheckBody/Single_regex_that_matches
=== RUN   TestCheckBody/Regex_matching_json_example
=== RUN   TestCheckBody/Regex_matching_first_line_of_multiline_body_string
=== RUN   TestCheckBody/Regex_matching_lastline_of_multiline_body_string
=== RUN   TestCheckBody/Regex_matching_multiple_lines_of_multiline_body_string
=== RUN   TestCheckBody/Regex_not_matching_multiple_lines_of_multiline_body_string
=== RUN   TestCheckBody/Single_regex_that_doesn't_match
=== RUN   TestCheckBody/Multiple_regex_match_where_at_least_one_must_match
=== RUN   TestCheckBody/Multiple_regex_match_where_none_of_the_patterns_match
--- PASS: TestCheckBody (0.00s)
    --- PASS: TestCheckBody/Single_regex_that_matches (0.00s)
    --- PASS: TestCheckBody/Regex_matching_json_example (0.00s)
    --- PASS: TestCheckBody/Regex_matching_first_line_of_multiline_body_string (0.00s)
    --- PASS: TestCheckBody/Regex_matching_lastline_of_multiline_body_string (0.00s)
    --- PASS: TestCheckBody/Regex_matching_multiple_lines_of_multiline_body_string (0.00s)
    --- PASS: TestCheckBody/Regex_not_matching_multiple_lines_of_multiline_body_string (0.00s)
    --- PASS: TestCheckBody/Single_regex_that_doesn't_match (0.00s)
    --- PASS: TestCheckBody/Multiple_regex_match_where_at_least_one_must_match (0.00s)
    --- PASS: TestCheckBody/Multiple_regex_match_where_none_of_the_patterns_match (0.00s)
=== RUN   TestSplitHostnamePort
--- PASS: TestSplitHostnamePort (0.00s)
PASS
ok  	github.com/elastic/beats/heartbeat/monitors/active/http	0.019s
```