### PR TITLE
[DOCS] Added beats_system user

### DIFF
--- a/auditbeat/docs/securing-auditbeat.asciidoc
+++ b/auditbeat/docs/securing-auditbeat.asciidoc
@@ -9,6 +9,7 @@ and other products in the Elastic stack:
 
 * <<securing-communication-elasticsearch>>
 * <<configuring-ssl-logstash>>
+* <<securing-beats>>
 
 //sets block macro for https.asciidoc included in next section
 

--- a/filebeat/docs/securing-filebeat.asciidoc
+++ b/filebeat/docs/securing-filebeat.asciidoc
@@ -8,6 +8,7 @@ The following topics describe how to secure communication between Filebeat and o
 
 * <<securing-communication-elasticsearch>>
 * <<configuring-ssl-logstash>>
+* <<securing-beats>>
 
 //sets block macro for https.asciidoc included in next section
 

--- a/heartbeat/docs/securing-heartbeat.asciidoc
+++ b/heartbeat/docs/securing-heartbeat.asciidoc
@@ -9,6 +9,7 @@ and other products in the Elastic stack:
 
 * <<securing-communication-elasticsearch>>
 * <<configuring-ssl-logstash>>
+* <<securing-beats>>
 
 //sets block macro for https.asciidoc included in next section
 

--- a/libbeat/docs/monitoring/monitoring-beats.asciidoc
+++ b/libbeat/docs/monitoring/monitoring-beats.asciidoc
@@ -24,8 +24,8 @@ information, see
 To configure {beatname_uc} to collect and send monitoring metrics:
 
 . Create a user that has appropriate authority to send system-level monitoring
-data to {es}. For example, you can use the built-in `logstash_system` user or
-assign the built-in `logstash_system` role to another user. For more
+data to {es}. For example, you can use the built-in `beats_system` user or
+assign the built-in `beats_system` role to another user. For more
 information, see
 {xpack-ref}/setting-up-authentication.html[Setting Up User Authentication] and
 {xpack-ref}/built-in-roles.html[Built-in Roles].
@@ -51,8 +51,8 @@ xpack.monitoring:
   enabled: true
   elasticsearch:
     hosts: ["https://example.com:9200", "https://example2.com:9200"]
-    username: elastic
-    password: changeme
+    username: beats_system
+    password: beatspassword
 --------------------
 
 --

--- a/libbeat/docs/security/beats-system.asciidoc
+++ b/libbeat/docs/security/beats-system.asciidoc
@@ -1,0 +1,23 @@
+[role="xpack"]
+[[beats-system-user]]
+=== Configuring the Built-In User for {beatname_uc}
+
+{security} provides built-in user credentials in {es} that have a fixed set of
+privileges. In 6.3.0 and later releases, there is a `beats_system` built-in user,
+which {beatname_uc} uses to store monitoring information in {es}.
+
+The initial passwords for all of the built-in users are set by using the
+`setup-passwords` tool in {es}. Thereafter, you can change the passwords by
+using the *Management > Users* page in Kibana or the
+{ref}/security-api-change-password.html[Change Password API].
+
+IMPORTANT: If you upgraded from {es} version 6.2 or earlier, you will not
+have set a password for the `beats_system` user. A user with the
+`manage_security` privilege must change the password for this built-in user.
+
+For more
+information, see:
+
+* {xpack-ref}/setting-up-authentication.html[Setting Up User Authentication]
+* {xpack-ref}/built-in-roles.html[Built-in Roles]
+* <<monitoring>>

--- a/libbeat/docs/security/securing-beats.asciidoc
+++ b/libbeat/docs/security/securing-beats.asciidoc
@@ -17,9 +17,13 @@ In addition to configuring authentication credentials for the {beatname_uc}
 itself, you need to grant authorized users permission to access the indices it
 creates. See <<beats-user-access>>.
 
+If you plan to monitor {beatname_uc} in Kibana, you must also 
+<<beats-system-user,configure the `beats_system` built-in user>>.
+
 For more information about {security}, see
 {xpack-ref}/xpack-security.html[Securing {es} and {kib}].
 
 include::basic-auth.asciidoc[]
 include::user-access.asciidoc[]
 include::tls.asciidoc[]
+include::beats-system.asciidoc[]

--- a/metricbeat/docs/securing-metricbeat.asciidoc
+++ b/metricbeat/docs/securing-metricbeat.asciidoc
@@ -9,6 +9,7 @@ The following topics describe how to secure communication between
 
 * <<securing-communication-elasticsearch>>
 * <<configuring-ssl-logstash>>
+* <<securing-beats>>
 
 //sets block macro for https.asciidoc included in next section
 

--- a/packetbeat/docs/securing-packetbeat.asciidoc
+++ b/packetbeat/docs/securing-packetbeat.asciidoc
@@ -8,6 +8,7 @@ The following topics describe how to secure communication between Packetbeat and
 
 * <<securing-communication-elasticsearch>>
 * <<configuring-ssl-logstash>>
+* <<securing-beats>>
 
 //sets block macro for https.asciidoc included in next section
 

--- a/winlogbeat/docs/securing-winlogbeat.asciidoc
+++ b/winlogbeat/docs/securing-winlogbeat.asciidoc
@@ -8,6 +8,7 @@ The following topics describe how to secure communication between Winlogbeat and
 
 * <<securing-communication-elasticsearch>>
 * <<configuring-ssl-logstash>>
+* <<securing-beats>>
 
 //sets block macro for https.asciidoc included in next section
 


### PR DESCRIPTION
This PR documents the new beats_system built-in user and how it is configured for use with X-Pack monitoring.