### PR TITLE
Use safemapstr.Put for docker labels

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -65,6 +65,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Add filtering option by exact device names in system.diskio. `diskio.include_devices`. {pull}6085[6085]
 - Fix dealing with new process status codes in Linux kernel 4.14+. {pull}6306[6306]
 - Add config option for windows/perfmon metricset to ignore non existent counters. {pull}6432[6432]
+- Docker module labels dots are no longer removed, so resulting events will contain original label keys. {pull}6545[6545]
 
 *Packetbeat*
 
@@ -142,6 +143,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Fix system.filesystem.used.pct value to match what df reports. {issue}5494[5494]
 - Fix namespace disambiguation in Kubernetes state_* metricsets. {issue}6281[6281]
 - Fix Kubernetes overview dashboard views for non default time ranges. {issue}6395{6395}
+- Ensure Docker labels don't break mapping. {pull}6490[6490]
 
 *Packetbeat*
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -65,7 +65,6 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Add filtering option by exact device names in system.diskio. `diskio.include_devices`. {pull}6085[6085]
 - Fix dealing with new process status codes in Linux kernel 4.14+. {pull}6306[6306]
 - Add config option for windows/perfmon metricset to ignore non existent counters. {pull}6432[6432]
-- Docker module labels dots are no longer removed, so resulting events will contain original label keys. {pull}6545[6545]
 
 *Packetbeat*
 
@@ -143,7 +142,6 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Fix system.filesystem.used.pct value to match what df reports. {issue}5494[5494]
 - Fix namespace disambiguation in Kubernetes state_* metricsets. {issue}6281[6281]
 - Fix Kubernetes overview dashboard views for non default time ranges. {issue}6395{6395}
-- Ensure Docker labels don't break mapping. {pull}6490[6490]
 
 *Packetbeat*
 
@@ -249,6 +247,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Add support for array in http/json metricset. {pull}6480[6480]
 - Making the jolokia/jmx module GA. {pull}6143[6143]
 - Making the MongoDB module GA. {pull}6554[6554]
+- Allow to disable labels `dedot` in Docker module, in favor of a safe way to keep dots. {pull}6490[6490]
 
 *Packetbeat*
 

--- a/metricbeat/docs/modules/docker.asciidoc
+++ b/metricbeat/docs/modules/docker.asciidoc
@@ -34,7 +34,7 @@ metricbeat.modules:
   period: 10s
 
   # Replace dots in labels with `_`. Set to false to keep dots
-  dedot: true
+  labels.dedot: true
 
   # To connect to Docker over TLS you must specify a client and CA certificate.
   #ssl:

--- a/metricbeat/docs/modules/docker.asciidoc
+++ b/metricbeat/docs/modules/docker.asciidoc
@@ -33,6 +33,9 @@ metricbeat.modules:
   hosts: ["unix:///var/run/docker.sock"]
   period: 10s
 
+  # Replace dots in labels with `_`. Set to false to keep dots
+  dedot: true
+
   # To connect to Docker over TLS you must specify a client and CA certificate.
   #ssl:
     #certificate_authority: "/etc/pki/root/ca.pem"

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -156,6 +156,9 @@ metricbeat.modules:
   hosts: ["unix:///var/run/docker.sock"]
   period: 10s
 
+  # Replace dots in labels with `_`. Set to false to keep dots
+  dedot: true
+
   # To connect to Docker over TLS you must specify a client and CA certificate.
   #ssl:
     #certificate_authority: "/etc/pki/root/ca.pem"

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -157,7 +157,7 @@ metricbeat.modules:
   period: 10s
 
   # Replace dots in labels with `_`. Set to false to keep dots
-  dedot: true
+  labels.dedot: true
 
   # To connect to Docker over TLS you must specify a client and CA certificate.
   #ssl:

--- a/metricbeat/module/docker/_meta/config.yml
+++ b/metricbeat/module/docker/_meta/config.yml
@@ -4,7 +4,7 @@
   period: 10s
 
   # Replace dots in labels with `_`. Set to false to keep dots
-  dedot: true
+  labels.dedot: true
 
   # To connect to Docker over TLS you must specify a client and CA certificate.
   #ssl:

--- a/metricbeat/module/docker/_meta/config.yml
+++ b/metricbeat/module/docker/_meta/config.yml
@@ -3,6 +3,9 @@
   hosts: ["unix:///var/run/docker.sock"]
   period: 10s
 
+  # Replace dots in labels with `_`. Set to false to keep dots
+  dedot: true
+
   # To connect to Docker over TLS you must specify a client and CA certificate.
   #ssl:
     #certificate_authority: "/etc/pki/root/ca.pem"

--- a/metricbeat/module/docker/config.go
+++ b/metricbeat/module/docker/config.go
@@ -1,7 +1,15 @@
 package docker
 
 type Config struct {
-	TLS *TLSConfig `config:"ssl"`
+	TLS   *TLSConfig `config:"ssl"`
+	DeDot bool       `config:"dedot"`
+}
+
+// DefaultConfig returns default module config
+func DefaultConfig() Config {
+	return Config{
+		DeDot: true,
+	}
 }
 
 type TLSConfig struct {

--- a/metricbeat/module/docker/config.go
+++ b/metricbeat/module/docker/config.go
@@ -2,7 +2,7 @@ package docker
 
 type Config struct {
 	TLS   *TLSConfig `config:"ssl"`
-	DeDot bool       `config:"dedot"`
+	DeDot bool       `config:"labels.dedot"`
 }
 
 // DefaultConfig returns default module config

--- a/metricbeat/module/docker/container/container.go
+++ b/metricbeat/module/docker/container/container.go
@@ -20,11 +20,12 @@ func init() {
 type MetricSet struct {
 	mb.BaseMetricSet
 	dockerClient *client.Client
+	dedot        bool
 }
 
 // New creates a new instance of the docker container MetricSet.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	config := docker.Config{}
+	config := docker.DefaultConfig()
 	if err := base.Module().UnpackConfig(&config); err != nil {
 		return nil, err
 	}
@@ -37,6 +38,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	return &MetricSet{
 		BaseMetricSet: base,
 		dockerClient:  client,
+		dedot:         config.DeDot,
 	}, nil
 }
 
@@ -48,5 +50,5 @@ func (m *MetricSet) Fetch() ([]common.MapStr, error) {
 	if err != nil {
 		return nil, err
 	}
-	return eventsMapping(containers), nil
+	return eventsMapping(containers, m.dedot), nil
 }

--- a/metricbeat/module/docker/container/data.go
+++ b/metricbeat/module/docker/container/data.go
@@ -9,15 +9,15 @@ import (
 	"github.com/elastic/beats/metricbeat/module/docker"
 )
 
-func eventsMapping(containersList []types.Container) []common.MapStr {
+func eventsMapping(containersList []types.Container, dedot bool) []common.MapStr {
 	myEvents := []common.MapStr{}
 	for _, container := range containersList {
-		myEvents = append(myEvents, eventMapping(&container))
+		myEvents = append(myEvents, eventMapping(&container, dedot))
 	}
 	return myEvents
 }
 
-func eventMapping(cont *types.Container) common.MapStr {
+func eventMapping(cont *types.Container, dedot bool) common.MapStr {
 	event := common.MapStr{
 		"created":      common.Time(time.Unix(cont.Created, 0)),
 		"id":           cont.ID,
@@ -32,7 +32,7 @@ func eventMapping(cont *types.Container) common.MapStr {
 		"status": cont.Status,
 	}
 
-	labels := docker.DeDotLabels(cont.Labels)
+	labels := docker.DeDotLabels(cont.Labels, dedot)
 
 	if len(labels) > 0 {
 		event["labels"] = labels

--- a/metricbeat/module/docker/cpu/cpu.go
+++ b/metricbeat/module/docker/cpu/cpu.go
@@ -18,11 +18,12 @@ type MetricSet struct {
 	mb.BaseMetricSet
 	cpuService   *CPUService
 	dockerClient *client.Client
+	dedot        bool
 }
 
 // New creates a new instance of the docker cpu MetricSet.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	config := docker.Config{}
+	config := docker.DefaultConfig()
 	if err := base.Module().UnpackConfig(&config); err != nil {
 		return nil, err
 	}
@@ -36,6 +37,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 		BaseMetricSet: base,
 		dockerClient:  client,
 		cpuService:    &CPUService{},
+		dedot:         config.DeDot,
 	}, nil
 }
 
@@ -46,6 +48,6 @@ func (m *MetricSet) Fetch() ([]common.MapStr, error) {
 		return nil, err
 	}
 
-	formattedStats := m.cpuService.getCPUStatsList(stats)
+	formattedStats := m.cpuService.getCPUStatsList(stats, m.dedot)
 	return eventsMapping(formattedStats), nil
 }

--- a/metricbeat/module/docker/cpu/helper.go
+++ b/metricbeat/module/docker/cpu/helper.go
@@ -33,13 +33,13 @@ func (c *CPUService) getCPUStatsList(rawStats []docker.Stat, dedot bool) []CPUSt
 	formattedStats := []CPUStats{}
 
 	for _, stats := range rawStats {
-		formattedStats = append(formattedStats, c.getCpuStats(&stats, dedot))
+		formattedStats = append(formattedStats, c.getCPUStats(&stats, dedot))
 	}
 
 	return formattedStats
 }
 
-func (c *CPUService) getCpuStats(myRawStat *docker.Stat, dedot bool) CPUStats {
+func (c *CPUService) getCPUStats(myRawStat *docker.Stat, dedot bool) CPUStats {
 	return CPUStats{
 		Time:                        common.Time(myRawStat.Stats.Read),
 		Container:                   docker.NewContainer(myRawStat.Container, dedot),

--- a/metricbeat/module/docker/cpu/helper.go
+++ b/metricbeat/module/docker/cpu/helper.go
@@ -29,20 +29,20 @@ func NewCpuService() *CPUService {
 	return &CPUService{}
 }
 
-func (c *CPUService) getCPUStatsList(rawStats []docker.Stat) []CPUStats {
+func (c *CPUService) getCPUStatsList(rawStats []docker.Stat, dedot bool) []CPUStats {
 	formattedStats := []CPUStats{}
 
 	for _, stats := range rawStats {
-		formattedStats = append(formattedStats, c.getCpuStats(&stats))
+		formattedStats = append(formattedStats, c.getCpuStats(&stats, dedot))
 	}
 
 	return formattedStats
 }
 
-func (c *CPUService) getCpuStats(myRawStat *docker.Stat) CPUStats {
+func (c *CPUService) getCpuStats(myRawStat *docker.Stat, dedot bool) CPUStats {
 	return CPUStats{
 		Time:                        common.Time(myRawStat.Stats.Read),
-		Container:                   docker.NewContainer(myRawStat.Container),
+		Container:                   docker.NewContainer(myRawStat.Container, dedot),
 		PerCpuUsage:                 perCpuUsage(&myRawStat.Stats),
 		TotalUsage:                  totalUsage(&myRawStat.Stats),
 		UsageInKernelmode:           myRawStat.Stats.CPUStats.CPUUsage.UsageInKernelmode,

--- a/metricbeat/module/docker/diskio/diskio.go
+++ b/metricbeat/module/docker/diskio/diskio.go
@@ -18,11 +18,12 @@ type MetricSet struct {
 	mb.BaseMetricSet
 	blkioService *BLkioService
 	dockerClient *client.Client
+	dedot        bool
 }
 
 // New create a new instance of the docker diskio MetricSet.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	config := docker.Config{}
+	config := docker.DefaultConfig()
 	if err := base.Module().UnpackConfig(&config); err != nil {
 		return nil, err
 	}
@@ -38,6 +39,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 		blkioService: &BLkioService{
 			BlkioSTatsPerContainer: make(map[string]BlkioRaw),
 		},
+		dedot: config.DeDot,
 	}, nil
 }
 
@@ -48,6 +50,6 @@ func (m *MetricSet) Fetch() ([]common.MapStr, error) {
 		return nil, err
 	}
 
-	formattedStats := m.blkioService.getBlkioStatsList(stats)
+	formattedStats := m.blkioService.getBlkioStatsList(stats, m.dedot)
 	return eventsMapping(formattedStats), nil
 }

--- a/metricbeat/module/docker/diskio/diskio_test.go
+++ b/metricbeat/module/docker/diskio/diskio_test.go
@@ -44,7 +44,7 @@ func TestDeltaMultipleContainers(t *testing.T) {
 	apiContainer2.Container = &containers[1]
 	apiContainer2.Stats.BlkioStats.IoServicedRecursive = append(apiContainer2.Stats.BlkioStats.IoServicedRecursive, metrics)
 	dockerStats := []docker.Stat{apiContainer1, apiContainer2}
-	stats := blkioService.getBlkioStatsList(dockerStats)
+	stats := blkioService.getBlkioStatsList(dockerStats, true)
 	totals := make([]float64, 2)
 	for _, stat := range stats {
 		totals[0] = stat.totals
@@ -54,7 +54,7 @@ func TestDeltaMultipleContainers(t *testing.T) {
 	dockerStats[0].Stats.Read = dockerStats[0].Stats.Read.Add(time.Second * 10)
 	dockerStats[1].Stats.BlkioStats.IoServicedRecursive[0].Value = 1000
 	dockerStats[1].Stats.Read = dockerStats[0].Stats.Read.Add(time.Second * 10)
-	stats = blkioService.getBlkioStatsList(dockerStats)
+	stats = blkioService.getBlkioStatsList(dockerStats, true)
 	for _, stat := range stats {
 		totals[1] = stat.totals
 		if stat.totals < totals[0] {
@@ -66,7 +66,7 @@ func TestDeltaMultipleContainers(t *testing.T) {
 	dockerStats[0].Stats.BlkioStats.IoServicedRecursive[0].Value = 2000
 	dockerStats[1].Stats.BlkioStats.IoServicedRecursive[0].Value = 2000
 	dockerStats[1].Stats.Read = dockerStats[0].Stats.Read.Add(time.Second * 15)
-	stats = blkioService.getBlkioStatsList(dockerStats)
+	stats = blkioService.getBlkioStatsList(dockerStats, true)
 	for _, stat := range stats {
 		if stat.totals < totals[1] || stat.totals < totals[0] {
 			t.Errorf("getBlkioStatsList(%v) => %v, want value bigger than %v", dockerStats, stat.totals, totals[1])
@@ -98,7 +98,7 @@ func TestDeltaOneContainer(t *testing.T) {
 	apiContainer.Container = &containers
 	apiContainer.Stats.BlkioStats.IoServicedRecursive = append(apiContainer.Stats.BlkioStats.IoServicedRecursive, metrics)
 	dockerStats := []docker.Stat{apiContainer}
-	stats := blkioService.getBlkioStatsList(dockerStats)
+	stats := blkioService.getBlkioStatsList(dockerStats, true)
 	totals := make([]float64, 2)
 	for _, stat := range stats {
 		totals[0] = stat.totals
@@ -106,7 +106,7 @@ func TestDeltaOneContainer(t *testing.T) {
 
 	dockerStats[0].Stats.BlkioStats.IoServicedRecursive[0].Value = 1000
 	dockerStats[0].Stats.Read = dockerStats[0].Stats.Read.Add(time.Second * 10)
-	stats = blkioService.getBlkioStatsList(dockerStats)
+	stats = blkioService.getBlkioStatsList(dockerStats, true)
 	for _, stat := range stats {
 		if stat.totals < totals[0] {
 			t.Errorf("getBlkioStatsList(%v) => %v, want value bigger than %v", dockerStats, stat.totals, totals[0])
@@ -115,7 +115,7 @@ func TestDeltaOneContainer(t *testing.T) {
 
 	dockerStats[0].Stats.BlkioStats.IoServicedRecursive[0].Value = 2000
 	dockerStats[0].Stats.Read = dockerStats[0].Stats.Read.Add(time.Second * 15)
-	stats = blkioService.getBlkioStatsList(dockerStats)
+	stats = blkioService.getBlkioStatsList(dockerStats, true)
 	for _, stat := range stats {
 		if stat.totals < totals[1] || stat.totals < totals[0] {
 			t.Errorf("getBlkioStatsList(%v) => %v, want value bigger than %v", dockerStats, stat.totals, totals[1])

--- a/metricbeat/module/docker/diskio/helper.go
+++ b/metricbeat/module/docker/diskio/helper.go
@@ -33,25 +33,25 @@ type BLkioService struct {
 	BlkioSTatsPerContainer map[string]BlkioRaw
 }
 
-func (io *BLkioService) getBlkioStatsList(rawStats []docker.Stat) []BlkioStats {
+func (io *BLkioService) getBlkioStatsList(rawStats []docker.Stat, dedot bool) []BlkioStats {
 	formattedStats := []BlkioStats{}
 	if io.BlkioSTatsPerContainer == nil {
 		io.BlkioSTatsPerContainer = make(map[string]BlkioRaw)
 	}
 	for _, myRawStats := range rawStats {
-		formattedStats = append(formattedStats, io.getBlkioStats(&myRawStats))
+		formattedStats = append(formattedStats, io.getBlkioStats(&myRawStats, dedot))
 	}
 
 	return formattedStats
 }
 
-func (io *BLkioService) getBlkioStats(myRawStat *docker.Stat) BlkioStats {
+func (io *BLkioService) getBlkioStats(myRawStat *docker.Stat, dedot bool) BlkioStats {
 	newBlkioStats := io.getNewStats(myRawStat.Stats.Read, myRawStat.Stats.BlkioStats.IoServicedRecursive)
 	oldBlkioStats, exist := io.BlkioSTatsPerContainer[myRawStat.Container.ID]
 
 	myBlkioStats := BlkioStats{
 		Time:      myRawStat.Stats.Read,
-		Container: docker.NewContainer(myRawStat.Container),
+		Container: docker.NewContainer(myRawStat.Container, dedot),
 	}
 
 	if exist {

--- a/metricbeat/module/docker/healthcheck/data.go
+++ b/metricbeat/module/docker/healthcheck/data.go
@@ -42,7 +42,7 @@ func eventMapping(cont *types.Container, m *MetricSet) common.MapStr {
 
 	return common.MapStr{
 		mb.ModuleDataKey: common.MapStr{
-			"container": docker.NewContainer(cont).ToMapStr(),
+			"container": docker.NewContainer(cont, m.dedot).ToMapStr(),
 		},
 		"status":        container.State.Health.Status,
 		"failingstreak": container.State.Health.FailingStreak,

--- a/metricbeat/module/docker/healthcheck/healthcheck.go
+++ b/metricbeat/module/docker/healthcheck/healthcheck.go
@@ -20,11 +20,12 @@ func init() {
 type MetricSet struct {
 	mb.BaseMetricSet
 	dockerClient *client.Client
+	dedot        bool
 }
 
 // New creates a new instance of the docker healthcheck MetricSet.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	config := docker.Config{}
+	config := docker.DefaultConfig()
 	if err := base.Module().UnpackConfig(&config); err != nil {
 		return nil, err
 	}
@@ -37,6 +38,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	return &MetricSet{
 		BaseMetricSet: base,
 		dockerClient:  client,
+		dedot:         config.DeDot,
 	}, nil
 }
 

--- a/metricbeat/module/docker/helper.go
+++ b/metricbeat/module/docker/helper.go
@@ -27,6 +27,9 @@ func (c *Container) ToMapStr() common.MapStr {
 	return m
 }
 
+// NewContainer converts Docker API container to an internal structure, it applies
+// dedot to container labels if dedot is true, or stores them in a nested way if it's
+// false
 func NewContainer(container *types.Container, dedot bool) *Container {
 	return &Container{
 		ID:     container.ID,

--- a/metricbeat/module/docker/helper.go
+++ b/metricbeat/module/docker/helper.go
@@ -6,6 +6,7 @@ import (
 	"github.com/docker/docker/api/types"
 
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/safemapstr"
 )
 
 type Container struct {
@@ -48,14 +49,12 @@ func ExtractContainerName(names []string) string {
 }
 
 // DeDotLabels returns a new common.MapStr containing a copy of the labels
-// where the dots in each label name have been changed to an underscore.
+// where the dots have been converted into nested structure, avoiding
+// possible mapping errors
 func DeDotLabels(labels map[string]string) common.MapStr {
 	outputLabels := common.MapStr{}
 	for k, v := range labels {
-		// This is necessary so that ES does not interpret '.' fields as new
-		// nested JSON objects, and also makes this compatible with ES 2.x.
-		label := common.DeDot(k)
-		outputLabels.Put(label, v)
+		safemapstr.Put(outputLabels, k, v)
 	}
 
 	return outputLabels

--- a/metricbeat/module/docker/helper_test.go
+++ b/metricbeat/module/docker/helper_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/elastic/beats/libbeat/common"
+
 	"github.com/stretchr/testify/assert"
 )
 

--- a/metricbeat/module/docker/helper_test.go
+++ b/metricbeat/module/docker/helper_test.go
@@ -1,0 +1,42 @@
+package docker
+
+import (
+	"testing"
+
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDeDotLabels(t *testing.T) {
+	labels := map[string]string{
+		"com.docker.swarm.task":      "",
+		"com.docker.swarm.task.id":   "1",
+		"com.docker.swarm.task.name": "foobar",
+	}
+
+	t.Run("dedot enabled", func(t *testing.T) {
+		result := DeDotLabels(labels, true)
+		assert.Equal(t, common.MapStr{
+			"com_docker_swarm_task":      "",
+			"com_docker_swarm_task_id":   "1",
+			"com_docker_swarm_task_name": "foobar",
+		}, result)
+	})
+
+	t.Run("dedot disabled", func(t *testing.T) {
+		result := DeDotLabels(labels, false)
+		assert.Equal(t, common.MapStr{
+			"com": common.MapStr{
+				"docker": common.MapStr{
+					"swarm": common.MapStr{
+						"task": common.MapStr{
+							"value": "",
+							"id":    "1",
+							"name":  "foobar",
+						},
+					},
+				},
+			},
+		}, result)
+	})
+}

--- a/metricbeat/module/docker/image/data.go
+++ b/metricbeat/module/docker/image/data.go
@@ -9,15 +9,15 @@ import (
 	"github.com/elastic/beats/metricbeat/module/docker"
 )
 
-func eventsMapping(imagesList []types.ImageSummary) []common.MapStr {
+func eventsMapping(imagesList []types.ImageSummary, dedot bool) []common.MapStr {
 	events := []common.MapStr{}
 	for _, image := range imagesList {
-		events = append(events, eventMapping(&image))
+		events = append(events, eventMapping(&image, dedot))
 	}
 	return events
 }
 
-func eventMapping(image *types.ImageSummary) common.MapStr {
+func eventMapping(image *types.ImageSummary, dedot bool) common.MapStr {
 	event := common.MapStr{
 		"id": common.MapStr{
 			"current": image.ID,
@@ -31,7 +31,7 @@ func eventMapping(image *types.ImageSummary) common.MapStr {
 		"tags": image.RepoTags,
 	}
 	if len(image.Labels) > 0 {
-		labels := docker.DeDotLabels(image.Labels)
+		labels := docker.DeDotLabels(image.Labels, dedot)
 		event["labels"] = labels
 	}
 	return event

--- a/metricbeat/module/docker/image/data.go
+++ b/metricbeat/module/docker/image/data.go
@@ -30,8 +30,8 @@ func eventMapping(image *types.ImageSummary) common.MapStr {
 		},
 		"tags": image.RepoTags,
 	}
-	labels := docker.DeDotLabels(image.Labels)
-	if len(labels) > 0 {
+	if len(image.Labels) > 0 {
+		labels := docker.DeDotLabels(image.Labels)
 		event["labels"] = labels
 	}
 	return event

--- a/metricbeat/module/docker/image/image.go
+++ b/metricbeat/module/docker/image/image.go
@@ -26,13 +26,14 @@ func init() {
 type MetricSet struct {
 	mb.BaseMetricSet
 	dockerClient *client.Client
+	dedot        bool
 }
 
 // New create a new instance of the MetricSet
 // Part of new is also setting up the configuration by processing additional
 // configuration entries if needed.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	config := docker.Config{}
+	config := docker.DefaultConfig()
 	if err := base.Module().UnpackConfig(&config); err != nil {
 		return nil, err
 	}
@@ -45,6 +46,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	return &MetricSet{
 		BaseMetricSet: base,
 		dockerClient:  client,
+		dedot:         config.DeDot,
 	}, nil
 }
 
@@ -57,5 +59,5 @@ func (m *MetricSet) Fetch() ([]common.MapStr, error) {
 		return nil, err
 	}
 
-	return eventsMapping(images), nil
+	return eventsMapping(images, m.dedot), nil
 }

--- a/metricbeat/module/docker/memory/helper.go
+++ b/metricbeat/module/docker/memory/helper.go
@@ -19,20 +19,20 @@ type MemoryData struct {
 
 type MemoryService struct{}
 
-func (s *MemoryService) getMemoryStatsList(rawStats []docker.Stat) []MemoryData {
+func (s *MemoryService) getMemoryStatsList(rawStats []docker.Stat, dedot bool) []MemoryData {
 	formattedStats := []MemoryData{}
 	for _, myRawStats := range rawStats {
-		formattedStats = append(formattedStats, s.GetMemoryStats(myRawStats))
+		formattedStats = append(formattedStats, s.GetMemoryStats(myRawStats, dedot))
 	}
 
 	return formattedStats
 }
 
-func (s *MemoryService) GetMemoryStats(myRawStat docker.Stat) MemoryData {
+func (s *MemoryService) GetMemoryStats(myRawStat docker.Stat, dedot bool) MemoryData {
 	totalRSS := myRawStat.Stats.MemoryStats.Stats["total_rss"]
 	return MemoryData{
 		Time:      common.Time(myRawStat.Stats.Read),
-		Container: docker.NewContainer(myRawStat.Container),
+		Container: docker.NewContainer(myRawStat.Container, dedot),
 		Failcnt:   myRawStat.Stats.MemoryStats.Failcnt,
 		Limit:     myRawStat.Stats.MemoryStats.Limit,
 		MaxUsage:  myRawStat.Stats.MemoryStats.MaxUsage,

--- a/metricbeat/module/docker/memory/helper.go
+++ b/metricbeat/module/docker/memory/helper.go
@@ -22,13 +22,13 @@ type MemoryService struct{}
 func (s *MemoryService) getMemoryStatsList(rawStats []docker.Stat, dedot bool) []MemoryData {
 	formattedStats := []MemoryData{}
 	for _, myRawStats := range rawStats {
-		formattedStats = append(formattedStats, s.GetMemoryStats(myRawStats, dedot))
+		formattedStats = append(formattedStats, s.getMemoryStats(myRawStats, dedot))
 	}
 
 	return formattedStats
 }
 
-func (s *MemoryService) GetMemoryStats(myRawStat docker.Stat, dedot bool) MemoryData {
+func (s *MemoryService) getMemoryStats(myRawStat docker.Stat, dedot bool) MemoryData {
 	totalRSS := myRawStat.Stats.MemoryStats.Stats["total_rss"]
 	return MemoryData{
 		Time:      common.Time(myRawStat.Stats.Read),

--- a/metricbeat/module/docker/memory/memory.go
+++ b/metricbeat/module/docker/memory/memory.go
@@ -18,11 +18,12 @@ type MetricSet struct {
 	mb.BaseMetricSet
 	memoryService *MemoryService
 	dockerClient  *client.Client
+	dedot         bool
 }
 
 // New creates a new instance of the docker memory MetricSet.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	config := docker.Config{}
+	config := docker.DefaultConfig()
 	if err := base.Module().UnpackConfig(&config); err != nil {
 		return nil, err
 	}
@@ -36,6 +37,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 		BaseMetricSet: base,
 		memoryService: &MemoryService{},
 		dockerClient:  client,
+		dedot:         config.DeDot,
 	}, nil
 }
 
@@ -46,6 +48,6 @@ func (m *MetricSet) Fetch() ([]common.MapStr, error) {
 		return nil, err
 	}
 
-	memoryStats := m.memoryService.getMemoryStatsList(stats)
+	memoryStats := m.memoryService.getMemoryStatsList(stats, m.dedot)
 	return eventsMapping(memoryStats), nil
 }

--- a/metricbeat/module/docker/memory/memory_test.go
+++ b/metricbeat/module/docker/memory/memory_test.go
@@ -69,7 +69,7 @@ func TestMemoryService_GetMemoryStats(t *testing.T) {
 		},
 	}
 	//WHEN
-	rawStats := memoryService.GetMemoryStats(memoryRawStats, false)
+	rawStats := memoryService.getMemoryStats(memoryRawStats, false)
 	event := eventMapping(&rawStats)
 	//THEN
 	assert.True(t, equalEvent(expectedEvent, event))

--- a/metricbeat/module/docker/memory/memory_test.go
+++ b/metricbeat/module/docker/memory/memory_test.go
@@ -17,8 +17,9 @@ func TestMemoryService_GetMemoryStats(t *testing.T) {
 	//Container  + dockerstats
 	containerID := "containerID"
 	labels := map[string]string{
-		"label1": "val1",
-		"label2": "val2",
+		"label1":     "val1",
+		"label2":     "val2",
+		"label2.foo": "val3",
 	}
 	container := types.Container{
 		ID:         containerID,
@@ -42,9 +43,15 @@ func TestMemoryService_GetMemoryStats(t *testing.T) {
 	expectedEvent := common.MapStr{
 		"_module": common.MapStr{
 			"container": common.MapStr{
-				"id":     containerID,
-				"name":   "name1",
-				"labels": docker.DeDotLabels(labels),
+				"id":   containerID,
+				"name": "name1",
+				"labels": common.MapStr{
+					"label1": "val1",
+					"label2": common.MapStr{
+						"foo":   "val3",
+						"value": "val2",
+					},
+				},
 			},
 		},
 		"fail": common.MapStr{

--- a/metricbeat/module/docker/memory/memory_test.go
+++ b/metricbeat/module/docker/memory/memory_test.go
@@ -69,7 +69,7 @@ func TestMemoryService_GetMemoryStats(t *testing.T) {
 		},
 	}
 	//WHEN
-	rawStats := memoryService.GetMemoryStats(memoryRawStats)
+	rawStats := memoryService.GetMemoryStats(memoryRawStats, false)
 	event := eventMapping(&rawStats)
 	//THEN
 	assert.True(t, equalEvent(expectedEvent, event))

--- a/metricbeat/module/docker/network/helper.go
+++ b/metricbeat/module/docker/network/helper.go
@@ -49,23 +49,23 @@ type NetStats struct {
 	TxPackets     float64
 }
 
-func (n *NetService) getNetworkStatsPerContainer(rawStats []docker.Stat) []NetStats {
+func (n *NetService) getNetworkStatsPerContainer(rawStats []docker.Stat, dedot bool) []NetStats {
 	formattedStats := []NetStats{}
 	for _, myStats := range rawStats {
 		for nameInterface, rawnNetStats := range myStats.Stats.Networks {
-			formattedStats = append(formattedStats, n.getNetworkStats(nameInterface, &rawnNetStats, &myStats))
+			formattedStats = append(formattedStats, n.getNetworkStats(nameInterface, &rawnNetStats, &myStats, dedot))
 		}
 	}
 
 	return formattedStats
 }
 
-func (n *NetService) getNetworkStats(nameInterface string, rawNetStats *types.NetworkStats, myRawstats *docker.Stat) NetStats {
+func (n *NetService) getNetworkStats(nameInterface string, rawNetStats *types.NetworkStats, myRawstats *docker.Stat, dedot bool) NetStats {
 	newNetworkStats := createNetRaw(myRawstats.Stats.Read, rawNetStats)
 	oldNetworkStat, exist := n.NetworkStatPerContainer[myRawstats.Container.ID][nameInterface]
 
 	netStats := NetStats{
-		Container:     docker.NewContainer(myRawstats.Container),
+		Container:     docker.NewContainer(myRawstats.Container, dedot),
 		Time:          myRawstats.Stats.Read,
 		NameInterface: nameInterface,
 	}

--- a/metricbeat/module/docker/network/network.go
+++ b/metricbeat/module/docker/network/network.go
@@ -18,11 +18,12 @@ type MetricSet struct {
 	mb.BaseMetricSet
 	netService   *NetService
 	dockerClient *client.Client
+	dedot        bool
 }
 
 // New creates a new instance of the docker network MetricSet.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	config := docker.Config{}
+	config := docker.DefaultConfig()
 	if err := base.Module().UnpackConfig(&config); err != nil {
 		return nil, err
 	}
@@ -38,6 +39,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 		netService: &NetService{
 			NetworkStatPerContainer: make(map[string]map[string]NetRaw),
 		},
+		dedot: config.DeDot,
 	}, nil
 }
 
@@ -48,6 +50,6 @@ func (m *MetricSet) Fetch() ([]common.MapStr, error) {
 		return nil, err
 	}
 
-	formattedStats := m.netService.getNetworkStatsPerContainer(stats)
+	formattedStats := m.netService.getNetworkStatsPerContainer(stats, m.dedot)
 	return eventsMapping(formattedStats), nil
 }

--- a/metricbeat/modules.d/docker.yml.disabled
+++ b/metricbeat/modules.d/docker.yml.disabled
@@ -4,7 +4,7 @@
   period: 10s
 
   # Replace dots in labels with `_`. Set to false to keep dots
-  dedot: true
+  labels.dedot: true
 
   # To connect to Docker over TLS you must specify a client and CA certificate.
   #ssl:

--- a/metricbeat/modules.d/docker.yml.disabled
+++ b/metricbeat/modules.d/docker.yml.disabled
@@ -3,6 +3,9 @@
   hosts: ["unix:///var/run/docker.sock"]
   period: 10s
 
+  # Replace dots in labels with `_`. Set to false to keep dots
+  dedot: true
+
   # To connect to Docker over TLS you must specify a client and CA certificate.
   #ssl:
     #certificate_authority: "/etc/pki/root/ca.pem"


### PR DESCRIPTION
Docker module is "dedoting" labels, this change allows to disable that and make use of `safemapstr.Put` to store labels in a nested way. Config looks like this:

```
- module: docker
  metricsets: ["container", "cpu", "diskio", "healthcheck", "info", "memory", "network"]
  hosts: ["unix:///var/run/docker.sock"]
  period: 10s

  # Replace dots in labels with `_`. Set to false to keep dots
  labels.dedot: true
```