### PR TITLE
Fix snapshot builds for 5.6

### DIFF
--- a/dev-tools/packer/Makefile
+++ b/dev-tools/packer/Makefile
@@ -41,7 +41,7 @@ package-dashboards:
 
 .PHONY: deps
 deps:
-	go get -u github.com/tsg/gotpl
+	cd ../vendor/github.com/tsg/gotpl; go install
 
 .PHONY: xgo-image
 xgo-image:

--- a/dev-tools/packer/Makefile
+++ b/dev-tools/packer/Makefile
@@ -41,7 +41,7 @@ package-dashboards:
 
 .PHONY: deps
 deps:
-	cd ../vendor/github.com/tsg/gotpl; go install
+	go get -u github.com/tsg/gotpl
 
 .PHONY: xgo-image
 xgo-image:

--- a/dev-tools/packer/docker/xgo-image-deb6/base/Dockerfile
+++ b/dev-tools/packer/docker/xgo-image-deb6/base/Dockerfile
@@ -24,7 +24,7 @@ RUN chmod +x $FETCH
 # Make sure apt-get is up to date and dependent packages are installed
 RUN \
   apt-get -o Acquire::Check-Valid-Until=false update && \
-  apt-get install -y automake autogen build-essential ca-certificates \
+  apt-get install -y --force-yes automake autogen build-essential ca-certificates \
     gcc-multilib \
     clang llvm-dev  libtool libxml2-dev uuid-dev libssl-dev pkg-config \
     patch make xz-utils cpio wget unzip git mercurial bzr rsync --no-install-recommends

--- a/dev-tools/packer/docker/xgo-image-deb6/beats-builder/Dockerfile
+++ b/dev-tools/packer/docker/xgo-image-deb6/beats-builder/Dockerfile
@@ -12,7 +12,7 @@ RUN \
 	rm libpcap0.8-dev*.deb
 RUN \
 	apt-get -o Acquire::Check-Valid-Until=false update && \
-	apt-get install -y libpcap0.8-dev
+	apt-get install -y --force-yes libpcap0.8-dev
 
 
 # Old git version which does not support proxy with go get directly, and git cloning


### PR DESCRIPTION
This partially reverts #6461 in the 5.6 branch. It looks like the release-manager
uses a reasonably new Golang in the master/6.x branch but still uses go1.6 in
the 5.6 branch. That causes problems when using the vendor folder, so i reverted
to the old `go get`. It's more susceptible to transient errors, but that was stable
for quite long.

Also added `--force-yes` on the debian6 apt-gets, to avoid the key error. I didn't
investigate if the backport of the deb7 change would be possible. If yes, that would
be preferable, but I leave to @andrewkroh.