### PR TITLE
Add events to RBAC profile

### DIFF
--- a/deploy/kubernetes/filebeat-kubernetes.yaml
+++ b/deploy/kubernetes/filebeat-kubernetes.yaml
@@ -148,6 +148,7 @@ rules:
   resources:
   - namespaces
   - pods
+  - events
   verbs:
   - get
   - watch


### PR DESCRIPTION
Filebeat needs the permission to watch pods 
```
2018-03-14T16:06:52.977Z        INFO    kubernetes/watcher.go:140       kubernetes: Watching API for pod events
018-03-14T16:06:52.978Z        ERROR   kubernetes/watcher.go:145       kubernetes: Watching API error kubernetes api: Failure 403 pods is forbidden: User "system:serviceaccount:kube-system:filebeat" cannot watch pods at the cluster scope
```