### PR TITLE
Fix timings in `kubernetes` module cache cleaning

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -144,6 +144,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Fix namespace disambiguation in Kubernetes state_* metricsets. {issue}6281[6281]
 - Fix Kubernetes overview dashboard views for non default time ranges. {issue}6395{6395}
 - Fix Windows perfmon metricset so that it sends metrics when an error occurs. {pull}6542[6542]
+- Fix Kubernetes calculated fields store. {pull}6564{6564}
 
 *Packetbeat*
 

--- a/metricbeat/module/kubernetes/util/metrics_cache_test.go
+++ b/metricbeat/module/kubernetes/util/metrics_cache_test.go
@@ -9,10 +9,17 @@ import (
 
 func TestTimeout(t *testing.T) {
 	// Mocknotonic time:
-	fakeTime := time.Now().Unix()
+	fakeTimeCh := make(chan int64)
+	go func() {
+		fakeTime := time.Now().Unix()
+		for {
+			fakeTime++
+			fakeTimeCh <- fakeTime
+		}
+	}()
+
 	now = func() time.Time {
-		fakeTime++
-		return time.Unix(fakeTime, 0)
+		return time.Unix(<-fakeTimeCh, 0)
 	}
 
 	// Blocking sleep:


### PR DESCRIPTION
We have an in-memory cache of some metrics from `kube-state-metrics`. We reuse them from the `container` metricset to calculate % resource usage (current usage vs limit/request).

This PR fixes an issue in that cache, it was evicting some entries too soon, so some of the containers missed the calculated metrics.

Tests have been refactored to avoid timings issues too