### PR TITLE
Fix `state_container` metrics when several containers have the same name

### DIFF
--- a/metricbeat/module/kubernetes/state_container/data.go
+++ b/metricbeat/module/kubernetes/state_container/data.go
@@ -23,7 +23,8 @@ func eventMapping(families []*dto.MetricFamily) ([]common.MapStr, error) {
 			}
 
 			namespace := util.GetLabel(metric, "namespace")
-			containerKey := namespace + "::" + container
+			pod := util.GetLabel(metric, "pod")
+			containerKey := namespace + "::" + pod + "::" + container
 			event, ok := eventsMap[containerKey]
 			if !ok {
 				event = common.MapStr{}


### PR DESCRIPTION
Most of this was fixed by https://github.com/elastic/beats/pull/6294,
but for the specific case of containers, their uniqueness is defined by
namespace + pod name. As several pods may have containers with the same
name.

Rest of metrics are not affected in the same way, and namespace should
be enough for them.

Not adding a CHANGELOG as #6294 wasn't released yet