### PR TITLE
Queuetest improvements

### DIFF
--- a/libbeat/publisher/queue/memqueue/queue_test.go
+++ b/libbeat/publisher/queue/memqueue/queue_test.go
@@ -54,7 +54,7 @@ func TestProducerCancelRemovesEvents(t *testing.T) {
 }
 
 func makeTestQueue(sz, minEvents int, flushTimeout time.Duration) queuetest.QueueFactory {
-	return func() queue.Queue {
+	return func(_ *testing.T) queue.Queue {
 		return NewBroker(Settings{
 			Events:         sz,
 			FlushMinEvents: minEvents,

--- a/libbeat/publisher/queue/queuetest/producer_cancel.go
+++ b/libbeat/publisher/queue/queuetest/producer_cancel.go
@@ -25,7 +25,7 @@ func TestProducerCancelRemovesEvents(t *testing.T, factory QueueFactory) {
 		)
 
 		log := NewTestLogger(t)
-		b := factory()
+		b := factory(t)
 		defer b.Close()
 
 		log.Debug("create first producer")

--- a/libbeat/publisher/queue/queuetest/queuetest.go
+++ b/libbeat/publisher/queue/queuetest/queuetest.go
@@ -8,7 +8,7 @@ import (
 	"github.com/elastic/beats/libbeat/publisher/queue"
 )
 
-type QueueFactory func() queue.Queue
+type QueueFactory func(t *testing.T) queue.Queue
 
 type workerFactory func(*sync.WaitGroup, interface{}, *TestLogger, queue.Queue) func()
 
@@ -49,7 +49,7 @@ func TestSingleProducerConsumer(
 			log := NewTestLogger(t)
 			log.Debug("run test: ", test.name)
 
-			queue := factory()
+			queue := factory(t)
 			defer func() {
 				err := queue.Close()
 				if err != nil {
@@ -192,7 +192,7 @@ func TestMultiProducerConsumer(
 			log := NewTestLogger(t)
 			log.Debug("run test: ", test.name)
 
-			queue := factory()
+			queue := factory(t)
 			defer func() {
 				err := queue.Close()
 				if err != nil {

--- a/libbeat/publisher/queue/queuetest/queuetest.go
+++ b/libbeat/publisher/queue/queuetest/queuetest.go
@@ -263,6 +263,7 @@ func makeProducer(
 				ACK: ackCB,
 			})
 			for i := 0; i < maxEvents; i++ {
+				log.Debug("publish event", i)
 				producer.Publish(makeEvent(makeFields(i)))
 			}
 
@@ -288,6 +289,7 @@ func multiConsumer(numConsumers, maxEvents, batchSize int) workerFactory {
 				consumers[i] = b.Consumer()
 			}
 
+			log.Debugf("consumer: wait for %v events\n", maxEvents)
 			events.Add(maxEvents)
 
 			for _, c := range consumers {
@@ -303,7 +305,10 @@ func multiConsumer(numConsumers, maxEvents, batchSize int) workerFactory {
 							return
 						}
 
-						for range batch.Events() {
+						collected := batch.Events()
+						log.Debug("consumer: process batch", len(collected))
+
+						for range collected {
 							events.Done()
 						}
 						batch.ACK()


### PR DESCRIPTION
This PR prepares some changes to the queuetest package, required for the spooling to disk.

- Pass testing.T instance to queue factory
- Have workers add debug logs to the test context
