### PR TITLE
Support compression in fileout

### DIFF
--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -907,6 +907,11 @@ output.elasticsearch:
   # Permissions to use for file creation. The default is 0600.
   #permissions: 0600
 
+  # Compression algorithm for output file. Files are compressed when they are
+  # rotated as per the condition defined above. Supported values are 'none' and
+  # 'gzip'. The default is 'none', which is no compression.
+  #compression: 'none'
+
 
 #----------------------------- Console output ---------------------------------
 #output.console:

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -1606,6 +1606,11 @@ output.elasticsearch:
   # Permissions to use for file creation. The default is 0600.
   #permissions: 0600
 
+  # Compression algorithm for output file. Files are compressed when they are
+  # rotated as per the condition defined above. Supported values are 'none' and
+  # 'gzip'. The default is 'none', which is no compression.
+  #compression: 'none'
+
 
 #----------------------------- Console output ---------------------------------
 #output.console:

--- a/heartbeat/heartbeat.reference.yml
+++ b/heartbeat/heartbeat.reference.yml
@@ -1051,6 +1051,11 @@ output.elasticsearch:
   # Permissions to use for file creation. The default is 0600.
   #permissions: 0600
 
+  # Compression algorithm for output file. Files are compressed when they are
+  # rotated as per the condition defined above. Supported values are 'none' and
+  # 'gzip'. The default is 'none', which is no compression.
+  #compression: 'none'
+
 
 #----------------------------- Console output ---------------------------------
 #output.console:

--- a/journalbeat/journalbeat.reference.yml
+++ b/journalbeat/journalbeat.reference.yml
@@ -847,6 +847,11 @@ output.elasticsearch:
   # Permissions to use for file creation. The default is 0600.
   #permissions: 0600
 
+  # Compression algorithm for output file. Files are compressed when they are
+  # rotated as per the condition defined above. Supported values are 'none' and
+  # 'gzip'. The default is 'none', which is no compression.
+  #compression: 'none'
+
 
 #----------------------------- Console output ---------------------------------
 #output.console:

--- a/libbeat/_meta/config.reference.yml
+++ b/libbeat/_meta/config.reference.yml
@@ -795,6 +795,11 @@ output.elasticsearch:
   # Permissions to use for file creation. The default is 0600.
   #permissions: 0600
 
+  # Compression algorithm for output file. Files are compressed when they are
+  # rotated as per the condition defined above. Supported values are 'none' and
+  # 'gzip'. The default is 'none', which is no compression.
+  #compression: 'none'
+
 
 #----------------------------- Console output ---------------------------------
 #output.console:

--- a/libbeat/outputs/fileout/config.go
+++ b/libbeat/outputs/fileout/config.go
@@ -29,6 +29,7 @@ type config struct {
 	Filename      string       `config:"filename"`
 	RotateEveryKb uint         `config:"rotate_every_kb" validate:"min=1"`
 	NumberOfFiles uint         `config:"number_of_files"`
+	Compression   string       `config:"compression"`
 	Codec         codec.Config `config:"codec"`
 	Permissions   uint32       `config:"permissions"`
 }
@@ -38,6 +39,7 @@ var (
 		NumberOfFiles: 7,
 		RotateEveryKb: 10 * 1024,
 		Permissions:   0600,
+		Compression:   file.NoCompression,
 	}
 )
 

--- a/libbeat/outputs/fileout/config.go
+++ b/libbeat/outputs/fileout/config.go
@@ -25,13 +25,13 @@ import (
 )
 
 type config struct {
-	Path          string       `config:"path"`
-	Filename      string       `config:"filename"`
-	RotateEveryKb uint         `config:"rotate_every_kb" validate:"min=1"`
-	NumberOfFiles uint         `config:"number_of_files"`
-	Compression   string       `config:"compression"`
-	Codec         codec.Config `config:"codec"`
-	Permissions   uint32       `config:"permissions"`
+	Path          string               `config:"path"`
+	Filename      string               `config:"filename"`
+	RotateEveryKb uint                 `config:"rotate_every_kb" validate:"min=1"`
+	NumberOfFiles uint                 `config:"number_of_files"`
+	Compression   file.CompressionType `config:"compression"`
+	Codec         codec.Config         `config:"codec"`
+	Permissions   uint32               `config:"permissions"`
 }
 
 var (

--- a/libbeat/outputs/fileout/file.go
+++ b/libbeat/outputs/fileout/file.go
@@ -85,6 +85,7 @@ func (out *fileOutput) init(beat beat.Info, c config) error {
 		file.MaxBackups(c.NumberOfFiles),
 		file.Permissions(os.FileMode(c.Permissions)),
 		file.WithLogger(logp.NewLogger("rotator").With(logp.Namespace("rotator"))),
+		file.Compression(c.Compression),
 	)
 	if err != nil {
 		return err
@@ -96,8 +97,8 @@ func (out *fileOutput) init(beat beat.Info, c config) error {
 	}
 
 	logp.Info("Initialized file output. "+
-		"path=%v max_size_bytes=%v max_backups=%v permissions=%v",
-		path, c.RotateEveryKb*1024, c.NumberOfFiles, os.FileMode(c.Permissions))
+		"path=%v max_size_bytes=%v max_backups=%v permissions=%v compression=%v",
+		path, c.RotateEveryKb*1024, c.NumberOfFiles, os.FileMode(c.Permissions), c.Compression)
 
 	return nil
 }

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -1524,6 +1524,11 @@ output.elasticsearch:
   # Permissions to use for file creation. The default is 0600.
   #permissions: 0600
 
+  # Compression algorithm for output file. Files are compressed when they are
+  # rotated as per the condition defined above. Supported values are 'none' and
+  # 'gzip'. The default is 'none', which is no compression.
+  #compression: 'none'
+
 
 #----------------------------- Console output ---------------------------------
 #output.console:

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -1275,6 +1275,11 @@ output.elasticsearch:
   # Permissions to use for file creation. The default is 0600.
   #permissions: 0600
 
+  # Compression algorithm for output file. Files are compressed when they are
+  # rotated as per the condition defined above. Supported values are 'none' and
+  # 'gzip'. The default is 'none', which is no compression.
+  #compression: 'none'
+
 
 #----------------------------- Console output ---------------------------------
 #output.console:

--- a/winlogbeat/winlogbeat.reference.yml
+++ b/winlogbeat/winlogbeat.reference.yml
@@ -828,6 +828,11 @@ output.elasticsearch:
   # Permissions to use for file creation. The default is 0600.
   #permissions: 0600
 
+  # Compression algorithm for output file. Files are compressed when they are
+  # rotated as per the condition defined above. Supported values are 'none' and
+  # 'gzip'. The default is 'none', which is no compression.
+  #compression: 'none'
+
 
 #----------------------------- Console output ---------------------------------
 #output.console:

--- a/x-pack/auditbeat/auditbeat.reference.yml
+++ b/x-pack/auditbeat/auditbeat.reference.yml
@@ -958,6 +958,11 @@ output.elasticsearch:
   # Permissions to use for file creation. The default is 0600.
   #permissions: 0600
 
+  # Compression algorithm for output file. Files are compressed when they are
+  # rotated as per the condition defined above. Supported values are 'none' and
+  # 'gzip'. The default is 'none', which is no compression.
+  #compression: 'none'
+
 
 #----------------------------- Console output ---------------------------------
 #output.console:

--- a/x-pack/auditbeat/tests/system/auditbeat_xpack.py
+++ b/x-pack/auditbeat/tests/system/auditbeat_xpack.py
@@ -1,10 +1,9 @@
+from metricbeat import BaseTest as MetricbeatTest
 import jinja2
 import os
 import sys
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../../metricbeat/tests/system')))
-
-from metricbeat import BaseTest as MetricbeatTest
 
 
 class AuditbeatXPackTest(MetricbeatTest):

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -1754,6 +1754,11 @@ output.elasticsearch:
   # Permissions to use for file creation. The default is 0600.
   #permissions: 0600
 
+  # Compression algorithm for output file. Files are compressed when they are
+  # rotated as per the condition defined above. Supported values are 'none' and
+  # 'gzip'. The default is 'none', which is no compression.
+  #compression: 'none'
+
 
 #----------------------------- Console output ---------------------------------
 #output.console:

--- a/x-pack/filebeat/tests/system/test_xpack_modules.py
+++ b/x-pack/filebeat/tests/system/test_xpack_modules.py
@@ -1,9 +1,8 @@
+import test_modules
 import os
 import sys
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '../../../../filebeat/tests/system'))
-
-import test_modules
 
 
 class XPackTest(test_modules.Test):

--- a/x-pack/functionbeat/functionbeat.reference.yml
+++ b/x-pack/functionbeat/functionbeat.reference.yml
@@ -966,6 +966,11 @@ output.elasticsearch:
   # Permissions to use for file creation. The default is 0600.
   #permissions: 0600
 
+  # Compression algorithm for output file. Files are compressed when they are
+  # rotated as per the condition defined above. Supported values are 'none' and
+  # 'gzip'. The default is 'none', which is no compression.
+  #compression: 'none'
+
 
 #----------------------------- Console output ---------------------------------
 #output.console:

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -1588,6 +1588,11 @@ output.elasticsearch:
   # Permissions to use for file creation. The default is 0600.
   #permissions: 0600
 
+  # Compression algorithm for output file. Files are compressed when they are
+  # rotated as per the condition defined above. Supported values are 'none' and
+  # 'gzip'. The default is 'none', which is no compression.
+  #compression: 'none'
+
 
 #----------------------------- Console output ---------------------------------
 #output.console:

--- a/x-pack/metricbeat/tests/system/xpack_metricbeat.py
+++ b/x-pack/metricbeat/tests/system/xpack_metricbeat.py
@@ -1,9 +1,8 @@
+import metricbeat
 import os
 import sys
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '../../../../metricbeat/tests/system'))
-
-import metricbeat
 
 
 class XPackTest(metricbeat.BaseTest):

--- a/x-pack/winlogbeat/winlogbeat.reference.yml
+++ b/x-pack/winlogbeat/winlogbeat.reference.yml
@@ -840,6 +840,11 @@ output.elasticsearch:
   # Permissions to use for file creation. The default is 0600.
   #permissions: 0600
 
+  # Compression algorithm for output file. Files are compressed when they are
+  # rotated as per the condition defined above. Supported values are 'none' and
+  # 'gzip'. The default is 'none', which is no compression.
+  #compression: 'none'
+
 
 #----------------------------- Console output ---------------------------------
 #output.console:


### PR DESCRIPTION
Closes #6288 

Adds `gzip` compression support to file output. Compression is controlled by `compression` key under `output.file`

We can add support for more compression formats when they are available in Go core, or use another third party lib.