### PR TITLE
Cherry-pick #6217 to 6.2: Fix event_logs.processors config being rejected

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -292,6 +292,7 @@ https://github.com/elastic/beats/compare/v6.0.1...v6.1.0[View commits]
 
 - Fix the registry file. It was not correctly storing event log names, and
   upon restart it would begin reading at the start of each event log. {issue}5813[5813]
+- Fix config validation to allow `event_logs.processors`. [pull]6217[6217]
 
 ==== Added
 

--- a/winlogbeat/eventlog/factory.go
+++ b/winlogbeat/eventlog/factory.go
@@ -10,7 +10,8 @@ import (
 	"github.com/elastic/beats/libbeat/common"
 )
 
-var commonConfigKeys = []string{"api", "name", "fields", "fields_under_root", "tags"}
+var commonConfigKeys = []string{"api", "name", "fields", "fields_under_root",
+	"tags", "processors"}
 
 // ConfigCommon is the common configuration data used to instantiate a new
 // EventLog. Each implementation is free to support additional configuration

--- a/winlogbeat/tests/system/config/winlogbeat.yml.j2
+++ b/winlogbeat/tests/system/config/winlogbeat.yml.j2
@@ -44,6 +44,11 @@ winlogbeat.event_logs:
     {%- if log.invalid is defined %}
     invalid: {{ log.invalid }}
     {% endif %}
+    {% if log.extras -%}
+    {% for k, v in log.extras.items() -%}
+    {{ k }}: {{ v }}
+    {% endfor %}
+    {% endif -%}
   {% endfor -%}
 {% endif %}
 

--- a/winlogbeat/tests/system/test_eventlogging.py
+++ b/winlogbeat/tests/system/test_eventlogging.py
@@ -183,3 +183,30 @@ class Test(WriteReadTest):
         self.assertIn(self.providerName, event_logs)
         record_number = event_logs[self.providerName]["record_number"]
         self.assertGreater(record_number, 0)
+
+    def test_processors(self):
+        """
+        eventlogging - Processors are applied
+        """
+        self.write_event_log("Hello world!")
+
+        config = {
+            "event_logs": [
+                {
+                    "name": self.providerName,
+                    "api": self.api,
+                    "extras": {
+                        "processors": [
+                            {
+                                "drop_fields": {
+                                    "fields": ["message"],
+                                }
+                            }
+                        ],
+                    },
+                }
+            ]
+        }
+        evts = self.read_events(config)
+        self.assertTrue(len(evts), 1)
+        self.assertNotIn("message", evts[0])

--- a/winlogbeat/tests/system/test_wineventlog.py
+++ b/winlogbeat/tests/system/test_wineventlog.py
@@ -321,3 +321,30 @@ class Test(WriteReadTest):
         self.assertIn(self.providerName, event_logs)
         record_number = event_logs[self.providerName]["record_number"]
         self.assertGreater(record_number, 0)
+
+    def test_processors(self):
+        """
+        wineventlog - Processors are applied
+        """
+        self.write_event_log("Hello world!")
+
+        config = {
+            "event_logs": [
+                {
+                    "name": self.providerName,
+                    "api": self.api,
+                    "extras": {
+                        "processors": [
+                            {
+                                "drop_fields": {
+                                    "fields": ["message"],
+                                }
+                            }
+                        ],
+                    },
+                }
+            ]
+        }
+        evts = self.read_events(config)
+        self.assertTrue(len(evts), 1)
+        self.assertNotIn("message", evts[0])


### PR DESCRIPTION
Cherry-pick of PR #6217 to 6.2 branch. Original message: 

The `event_logs.processors` keyword was being rejected as invalid config by Winlogbeat. This fixes the issue by adding "processors" as an allowed configuration key for `event_logs` and adds a system test case.