### PR TITLE
Updated dependency `github.com/tsg/gopacket`

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -152,6 +152,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Fix corruption when parsing repeated headers in an HTTP request or response. {pull}6325[6325]
 - Fix panic when parsing partial AMQP messages. {pull}6384[6384]
 - Fix out of bounds access to slice in MongoDB parser. {pull}6256[6256]
+- Fix sniffer hanging on exit under Linux. {pull}6535[6535]
 
 *Winlogbeat*
 

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -3107,7 +3107,7 @@ OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 --------------------------------------------------------------------
 Dependency: github.com/tsg/gopacket
-Revision: 8e703b9968693c15f25cabb6ba8be4370cf431d0
+Revision: f289b3ea3e41a01b2822be9caf5f40c01fdda05c
 License type (autodetected): BSD-3-Clause
 ./vendor/github.com/tsg/gopacket/LICENSE:
 --------------------------------------------------------------------

--- a/vendor/github.com/tsg/gopacket/layers/lldp.go
+++ b/vendor/github.com/tsg/gopacket/layers/lldp.go
@@ -9,6 +9,7 @@ package layers
 import (
 	"encoding/binary"
 	"fmt"
+
 	"github.com/tsg/gopacket"
 )
 
@@ -737,7 +738,7 @@ func decodeLinkLayerDiscovery(data []byte, p gopacket.PacketBuilder) error {
 	for len(vData) > 0 {
 		nbit := vData[0] & 0x01
 		t := LLDPTLVType(vData[0] >> 1)
-		val := LinkLayerDiscoveryValue{Type: t, Length: uint16(nbit<<8 + vData[1])}
+		val := LinkLayerDiscoveryValue{Type: t, Length: uint16(nbit)<<8 + uint16(vData[1])}
 		if val.Length > 0 {
 			val.Value = vData[2 : val.Length+2]
 		}

--- a/vendor/github.com/tsg/gopacket/pcap/pcap_poll_common.go
+++ b/vendor/github.com/tsg/gopacket/pcap/pcap_poll_common.go
@@ -1,0 +1,18 @@
+// +build !linux
+
+package pcap
+
+/*
+#include <pcap/pcap.h>
+*/
+import "C"
+
+type packetPoll struct{}
+
+func NewPacketPoll(_ *C.pcap_t, _ C.int) *packetPoll {
+	return nil
+}
+
+func (t *packetPoll) AwaitForPackets() bool {
+	return true
+}

--- a/vendor/github.com/tsg/gopacket/pcap/pcap_poll_linux.go
+++ b/vendor/github.com/tsg/gopacket/pcap/pcap_poll_linux.go
@@ -1,0 +1,52 @@
+// +build linux
+
+package pcap
+
+/*
+#include <linux/if_packet.h>
+#include <poll.h>
+#include <pcap/pcap.h>
+*/
+import "C"
+import "syscall"
+
+// packetPoll holds all the parameters required to use poll(2) on the pcap
+// file descriptor.
+type packetPoll struct {
+	pollfd  C.struct_pollfd
+	timeout C.int
+}
+
+func captureIsTPacketV3(fildes int) bool {
+	version, err := syscall.GetsockoptInt(fildes, syscall.SOL_PACKET, C.PACKET_VERSION)
+	return err == nil && version == C.TPACKET_V3
+}
+
+// NewPacketPoll returns a new packetPoller if the pcap handle requires it
+// in order to timeout effectively when no packets are received. This is only
+// necessary when TPACKET_V3 interface is used to receive packets.
+func NewPacketPoll(ptr *C.pcap_t, timeout C.int) *packetPoll {
+	fildes := C.pcap_fileno(ptr)
+	if !captureIsTPacketV3(int(fildes)) {
+		return nil
+	}
+	return &packetPoll{
+		pollfd: C.struct_pollfd{
+			fd:      fildes,
+			events:  C.POLLIN,
+			revents: 0,
+		},
+		timeout: timeout,
+	}
+}
+
+func (t *packetPoll) AwaitForPackets() bool {
+	if t != nil {
+		t.pollfd.revents = 0
+		// block until the capture file descriptor is readable or a timeout
+		// happens.
+		n, err := C.poll(&t.pollfd, 1, t.timeout)
+		return err != nil || n != 0
+	}
+	return true
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1194,8 +1194,8 @@
 		{
 			"checksumSHA1": "M0S9278lG9Fztu+ZUsLUi40GDJU=",
 			"path": "github.com/tsg/gopacket",
-			"revision": "8e703b9968693c15f25cabb6ba8be4370cf431d0",
-			"revisionTime": "2016-08-17T18:24:57Z"
+			"revision": "f289b3ea3e41a01b2822be9caf5f40c01fdda05c",
+			"revisionTime": "2018-03-16T21:03:30Z"
 		},
 		{
 			"checksumSHA1": "STY8i3sZLdZfFcKiyOdpV852nls=",


### PR DESCRIPTION
Addresses packetbeat termination problems with both af_packet and pcap captures.

Fixes #6535