### PR TITLE
Fix SSL config generation for metrics builder

### DIFF
--- a/metricbeat/autodiscover/builder/metrics/metrics.go
+++ b/metricbeat/autodiscover/builder/metrics/metrics.go
@@ -83,15 +83,13 @@ func (m *metricAnnotations) CreateConfig(event bus.Event) []*common.Config {
 		"timeout":    tout,
 		"period":     ival,
 		"enabled":    true,
+		"ssl":        sslConf,
 	}
 
 	if ns != "" {
 		moduleConfig["namespace"] = ns
 	}
 
-	for k, v := range sslConf {
-		moduleConfig.Put(k, v)
-	}
 	logp.Debug("metrics.builder", "generated config: %v", moduleConfig.String())
 
 	// Create config object


### PR DESCRIPTION
Minor fix to correct the way SSL config is generated for metricbeat module configurations.