### PR TITLE
Mark the system.syslog.message field as text

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -24,6 +24,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - The default value for pipelining is reduced to 2 to avoid high memory in the Logstash beats input. {pull}6250[6250]
 - Add logging when monitoring cannot connect to Elasticsearch. {pull}6365[6365]
 - Rename beat.cpu.*.time metrics to beat.cpu.*.time.ms. {pull}6449[6449]
+- Mark `system.syslog.message` and `system.auth.message` as `text` instead of `keyword`. {pull}6589[6589]
 
 *Auditbeat*
 

--- a/filebeat/docs/fields.asciidoc
+++ b/filebeat/docs/fields.asciidoc
@@ -2352,6 +2352,8 @@ The PID of the process that sent the auth message.
 [float]
 === `system.auth.message`
 
+type: text
+
 The message in the log line.
 
 
@@ -2589,6 +2591,8 @@ The PID of the process that sent the syslog message.
 
 [float]
 === `system.syslog.message`
+
+type: text
 
 The message in the log line.
 

--- a/filebeat/module/system/auth/_meta/fields.yml
+++ b/filebeat/module/system/auth/_meta/fields.yml
@@ -17,6 +17,7 @@
       description: >
         The PID of the process that sent the auth message.
     - name: message
+      type: text
       description: >
         The message in the log line.
     - name: user

--- a/filebeat/module/system/syslog/_meta/fields.yml
+++ b/filebeat/module/system/syslog/_meta/fields.yml
@@ -16,5 +16,6 @@
       description: >
         The PID of the process that sent the syslog message.
     - name: message
+      type: text
       description: >
         The message in the log line.


### PR DESCRIPTION
It was marked as a keyword, but that was a bug, because this field is
long and generally textual. I went for a breaking change instead of
making it a multi-field, because I don't see the use case of heaving
it as a keyword.