### PR TITLE
Fix docker autodiscover hint generation autodiscover logging

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -91,6 +91,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Fix infinite failure on Kubernetes watch {pull}6504[6504]
 - Ensure Kubernetes labels/annotations don't break mapping {pull}6490[6490]
 - Report ephemeral ID and uptime in monitoring events on all platforms {pull}6501[6501]
+- Fix docker autodiscover hint generation and autodiscover logging {pull}6590[6590]
 
 *Auditbeat*
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -91,7 +91,6 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Fix infinite failure on Kubernetes watch {pull}6504[6504]
 - Ensure Kubernetes labels/annotations don't break mapping {pull}6490[6490]
 - Report ephemeral ID and uptime in monitoring events on all platforms {pull}6501[6501]
-- Fix docker autodiscover hint generation and autodiscover logging {pull}6590[6590]
 
 *Auditbeat*
 

--- a/libbeat/autodiscover/appenders/registry.go
+++ b/libbeat/autodiscover/appenders/registry.go
@@ -23,7 +23,7 @@ func init() {
 	p.MustRegisterLoader(pluginKey, func(ifc interface{}) error {
 		app, ok := ifc.(appenderPlugin)
 		if !ok {
-			return errors.New("plugin does not match processor plugin type")
+			return errors.New("plugin does not match appender plugin type")
 		}
 
 		return autodiscover.Registry.AddAppender(app.name, app.appender)

--- a/libbeat/autodiscover/builder.go
+++ b/libbeat/autodiscover/builder.go
@@ -63,7 +63,7 @@ func (r *registry) BuildBuilder(c *common.Config) (Builder, error) {
 
 	builder := r.GetBuilder(config.Type)
 	if builder == nil {
-		return nil, fmt.Errorf("Unknown autodiscover builder %s", config.Type)
+		return nil, fmt.Errorf("unknown autodiscover builder %s", config.Type)
 	}
 
 	return builder(c)

--- a/libbeat/autodiscover/builder/helper_test.go
+++ b/libbeat/autodiscover/builder/helper_test.go
@@ -10,12 +10,12 @@ import (
 
 func TestGenerateHints(t *testing.T) {
 	tests := []struct {
-		annotations common.MapStr
+		annotations map[string]string
 		result      common.MapStr
 	}{
 		// Empty annotations should return empty hints
 		{
-			annotations: common.MapStr{},
+			annotations: map[string]string{},
 			result:      common.MapStr{},
 		},
 
@@ -25,11 +25,12 @@ func TestGenerateHints(t *testing.T) {
 		// not.to.include must not be part of hints
 		// period is annotated at both container and pod level. Container level value must be in hints
 		{
-			annotations: common.MapStr{
+			annotations: map[string]string{
 				"co.elastic.logs/multiline.pattern": "^test",
 				"co.elastic.metrics/module":         "prometheus",
 				"co.elastic.metrics/period":         "10s",
 				"co.elastic.metrics.foobar/period":  "15s",
+				"co.elastic.metrics.foobar1/period": "15s",
 				"not.to.include":                    "true",
 			},
 			result: common.MapStr{
@@ -47,6 +48,10 @@ func TestGenerateHints(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		assert.Equal(t, GenerateHints(test.annotations, "foobar", "co.elastic."), test.result)
+		annMap := common.MapStr{}
+		for k, v := range test.annotations {
+			annMap.Put(k, v)
+		}
+		assert.Equal(t, GenerateHints(annMap, "foobar", "co.elastic"), test.result)
 	}
 }

--- a/libbeat/autodiscover/builder/plugin.go
+++ b/libbeat/autodiscover/builder/plugin.go
@@ -23,7 +23,7 @@ func init() {
 	p.MustRegisterLoader(pluginKey, func(ifc interface{}) error {
 		b, ok := ifc.(builderPlugin)
 		if !ok {
-			return errors.New("plugin does not match processor plugin type")
+			return errors.New("plugin does not match builder plugin type")
 		}
 
 		return autodiscover.Registry.AddBuilder(b.name, b.builder)

--- a/libbeat/autodiscover/providers/docker/config.go
+++ b/libbeat/autodiscover/providers/docker/config.go
@@ -19,14 +19,14 @@ type Config struct {
 func defaultConfig() *Config {
 	return &Config{
 		Host:   "unix:///var/run/docker.sock",
-		Prefix: "co.elastic.",
+		Prefix: "co.elastic",
 	}
 }
 
 // Validate ensures correctness of config
 func (c *Config) Validate() {
-	// Make sure that prefix ends with a '.'
-	if c.Prefix[len(c.Prefix)-1] != '.' {
-		c.Prefix = c.Prefix + "."
+	// Make sure that prefix doesn't ends with a '.'
+	if c.Prefix[len(c.Prefix)-1] == '.' && c.Prefix != "." {
+		c.Prefix = c.Prefix[:len(c.Prefix)-2]
 	}
 }

--- a/libbeat/autodiscover/providers/docker/docker.go
+++ b/libbeat/autodiscover/providers/docker/docker.go
@@ -119,12 +119,8 @@ func (d *Provider) emitContainer(event bus.Event, flag string) {
 	}
 
 	labelMap := common.MapStr{}
-	labels := common.MapStr{}
 	for k, v := range container.Labels {
 		safemapstr.Put(labelMap, k, v)
-
-		// Needed for hint processing
-		labels[k] = v
 	}
 
 	meta := common.MapStr{
@@ -135,15 +131,12 @@ func (d *Provider) emitContainer(event bus.Event, flag string) {
 			"labels": labelMap,
 		},
 	}
-	dockerMeta := meta.Clone()
-	dockerMeta.Put("container.labels", labels)
-
 	// Without this check there would be overlapping configurations with and without ports.
 	if len(container.Ports) == 0 {
 		event := bus.Event{
 			flag:     true,
 			"host":   host,
-			"docker": dockerMeta,
+			"docker": meta,
 			"meta": common.MapStr{
 				"docker": meta,
 			},
@@ -158,7 +151,7 @@ func (d *Provider) emitContainer(event bus.Event, flag string) {
 			flag:     true,
 			"host":   host,
 			"port":   port.PrivatePort,
-			"docker": dockerMeta,
+			"docker": meta,
 			"meta": common.MapStr{
 				"docker": meta,
 			},

--- a/libbeat/autodiscover/providers/docker/docker_test.go
+++ b/libbeat/autodiscover/providers/docker/docker_test.go
@@ -47,10 +47,10 @@ func TestGenerateHints(t *testing.T) {
 					"container": common.MapStr{
 						"id":   "abc",
 						"name": "foobar",
-						"labels": common.MapStr{
+						"labels": getNestedAnnotations(common.MapStr{
 							"do.not.include":          "true",
 							"co.elastic.logs/disable": "true",
-						},
+						}),
 					},
 				},
 			},
@@ -59,10 +59,10 @@ func TestGenerateHints(t *testing.T) {
 					"container": common.MapStr{
 						"id":   "abc",
 						"name": "foobar",
-						"labels": common.MapStr{
+						"labels": getNestedAnnotations(common.MapStr{
 							"do.not.include":          "true",
 							"co.elastic.logs/disable": "true",
-						},
+						}),
 					},
 				},
 				"hints": common.MapStr{
@@ -82,4 +82,13 @@ func TestGenerateHints(t *testing.T) {
 	for _, test := range tests {
 		assert.Equal(t, p.generateHints(test.event), test.result)
 	}
+}
+
+func getNestedAnnotations(in common.MapStr) common.MapStr {
+	out := common.MapStr{}
+
+	for k, v := range in {
+		out.Put(k, v)
+	}
+	return out
 }

--- a/libbeat/autodiscover/providers/kubernetes/config.go
+++ b/libbeat/autodiscover/providers/kubernetes/config.go
@@ -31,14 +31,14 @@ func defaultConfig() *Config {
 		InCluster:      true,
 		SyncPeriod:     1 * time.Second,
 		CleanupTimeout: 60 * time.Second,
-		Prefix:         "co.elastic.",
+		Prefix:         "co.elastic",
 	}
 }
 
 // Validate ensures correctness of config
 func (c *Config) Validate() {
-	// Make sure that prefix ends with a '.'
-	if c.Prefix[len(c.Prefix)-1] != '.' {
-		c.Prefix = c.Prefix + "."
+	// Make sure that prefix doesn't ends with a '.'
+	if c.Prefix[len(c.Prefix)-1] == '.' && c.Prefix != "." {
+		c.Prefix = c.Prefix[:len(c.Prefix)-2]
 	}
 }

--- a/libbeat/autodiscover/providers/kubernetes/kubernetes.go
+++ b/libbeat/autodiscover/providers/kubernetes/kubernetes.go
@@ -64,7 +64,7 @@ func AutodiscoverBuilder(bus bus.Bus, c *common.Config) (autodiscover.Provider, 
 	var builders autodiscover.Builders
 	for _, bcfg := range config.Builders {
 		if builder, err := autodiscover.Registry.BuildBuilder(bcfg); err != nil {
-			logp.Warn("kubernetes", "failed to construct autodiscover builder due to error: %v", err)
+			logp.Info("kubernetes: failed to construct autodiscover builder due to error: %v", err)
 		} else {
 			builders = append(builders, builder)
 		}
@@ -73,7 +73,7 @@ func AutodiscoverBuilder(bus bus.Bus, c *common.Config) (autodiscover.Provider, 
 	var appenders autodiscover.Appenders
 	for _, acfg := range config.Appenders {
 		if appender, err := autodiscover.Registry.BuildAppender(acfg); err != nil {
-			logp.Warn("kubernetes", "failed to construct autodiscover appender due to error: %v", err)
+			logp.Info("kubernetes: failed to construct autodiscover appender due to error: %v", err)
 		} else {
 			appenders = append(appenders, appender)
 		}

--- a/libbeat/autodiscover/providers/kubernetes/kubernetes.go
+++ b/libbeat/autodiscover/providers/kubernetes/kubernetes.go
@@ -10,6 +10,7 @@ import (
 	"github.com/elastic/beats/libbeat/common/bus"
 	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/libbeat/common/kubernetes"
+	"github.com/elastic/beats/libbeat/common/safemapstr"
 	"github.com/elastic/beats/libbeat/logp"
 )
 
@@ -150,7 +151,7 @@ func (p *Provider) emitEvents(pod *kubernetes.Pod, flag string, containers []kub
 		// Pass annotations to all events so that it can be used in templating and by annotation builders.
 		annotations := common.MapStr{}
 		for k, v := range pod.GetMetadata().Annotations {
-			annotations[k] = v
+			safemapstr.Put(annotations, k, v)
 		}
 		kubemeta["annotations"] = annotations
 

--- a/libbeat/autodiscover/providers/kubernetes/kubernetes_test.go
+++ b/libbeat/autodiscover/providers/kubernetes/kubernetes_test.go
@@ -70,13 +70,13 @@ func TestGenerateHints(t *testing.T) {
 		{
 			event: bus.Event{
 				"kubernetes": common.MapStr{
-					"annotations": common.MapStr{
+					"annotations": getNestedAnnotations(common.MapStr{
 						"co.elastic.logs/multiline.pattern": "^test",
 						"co.elastic.metrics/module":         "prometheus",
 						"co.elastic.metrics/period":         "10s",
 						"co.elastic.metrics.foobar/period":  "15s",
 						"not.to.include":                    "true",
-					},
+					}),
 					"container": common.MapStr{
 						"name":    "foobar",
 						"id":      "abc",
@@ -86,13 +86,13 @@ func TestGenerateHints(t *testing.T) {
 			},
 			result: bus.Event{
 				"kubernetes": common.MapStr{
-					"annotations": common.MapStr{
+					"annotations": getNestedAnnotations(common.MapStr{
 						"co.elastic.logs/multiline.pattern": "^test",
 						"co.elastic.metrics/module":         "prometheus",
 						"not.to.include":                    "true",
 						"co.elastic.metrics/period":         "10s",
 						"co.elastic.metrics.foobar/period":  "15s",
-					},
+					}),
 					"container": common.MapStr{
 						"name":    "foobar",
 						"id":      "abc",
@@ -127,4 +127,13 @@ func TestGenerateHints(t *testing.T) {
 	for _, test := range tests {
 		assert.Equal(t, p.generateHints(test.event), test.result)
 	}
+}
+
+func getNestedAnnotations(in common.MapStr) common.MapStr {
+	out := common.MapStr{}
+
+	for k, v := range in {
+		out.Put(k, v)
+	}
+	return out
 }


### PR DESCRIPTION
In order to allow hint generation, there needs to be a MapStr of labels that isnt nested. This PR fixes that along with some logging.