### PR TITLE
Change auditbeat dashboards tests in 6.x to latest

### DIFF
--- a/auditbeat/Makefile
+++ b/auditbeat/Makefile
@@ -5,7 +5,7 @@ SYSTEM_TESTS=true
 TEST_ENVIRONMENT?=true
 GOX_OS?=linux windows ## @Building List of all OS to be supported by "make crosscompile".
 DEV_OS?=linux
-TESTING_ENVIRONMENT?=snapshot-noxpack
+TESTING_ENVIRONMENT?=latest
 ES_BEATS?=..
 
 # Path to the libbeat Makefile


### PR DESCRIPTION
Instead of using snapshots for the dashboards tests, latest is used. This enables xpack but should be quick as the images are already prebuilt. As dashboards are the only integration tests in auditbeat, this should not have any other effect.