### PR TITLE
Remove unused TESTING_ENVIRONMENT varible from metricbeat

### DIFF
--- a/metricbeat/Makefile
+++ b/metricbeat/Makefile
@@ -4,7 +4,6 @@ BEAT_TITLE?=Metricbeat
 BEAT_DESCRIPTION?=Metricbeat is a lightweight shipper for metrics.
 SYSTEM_TESTS?=true
 TEST_ENVIRONMENT?=true
-TESTING_ENVIRONMENT?=snapshot-noxpack
 ES_BEATS?=..
 
 # Metricbeat can only be cross-compiled on platforms not requiring CGO.


### PR DESCRIPTION
Since the change in metricbeat that each integration test knows its own dependencies and sets up the dependencies the variable TESTING_ENVIRONMENTS had no affect anymore in metricbeat. As the variable was still there but did not have any affect, this PR removes the variable.