### PR TITLE
Load ML using Kibana API

### DIFF
--- a/filebeat/beater/filebeat.go
+++ b/filebeat/beater/filebeat.go
@@ -15,6 +15,7 @@ import (
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/monitoring"
 	"github.com/elastic/beats/libbeat/outputs/elasticsearch"
+	"github.com/elastic/beats/libbeat/setup/kibana"
 
 	fbautodiscover "github.com/elastic/beats/filebeat/autodiscover"
 	"github.com/elastic/beats/filebeat/channel"
@@ -120,8 +121,8 @@ func New(b *beat.Beat, rawConfig *common.Config) (beat.Beater, error) {
 	}
 
 	// register `setup` callback for ML jobs
-	b.SetupMLCallback = func(b *beat.Beat) error {
-		return fb.loadModulesML(b)
+	b.SetupMLCallback = func(b *beat.Beat, kibanaConfig *common.Config) error {
+		return fb.loadModulesML(b, kibanaConfig)
 	}
 	return fb, nil
 }
@@ -144,9 +145,10 @@ func (fb *Filebeat) loadModulesPipelines(b *beat.Beat) error {
 	return nil
 }
 
-func (fb *Filebeat) loadModulesML(b *beat.Beat) error {
-	logp.Debug("machine-learning", "Setting up ML jobs for modules")
+func (fb *Filebeat) loadModulesML(b *beat.Beat, kibanaConfig *common.Config) error {
 	var errs multierror.Errors
+
+	logp.Debug("machine-learning", "Setting up ML jobs for modules")
 
 	if b.Config.Output.Name() != "elasticsearch" {
 		logp.Warn("Filebeat is unable to load the Xpack Machine Learning configurations for the" +
@@ -159,7 +161,22 @@ func (fb *Filebeat) loadModulesML(b *beat.Beat) error {
 	if err != nil {
 		return errors.Errorf("Error creating Elasticsearch client: %v", err)
 	}
-	if err := fb.moduleRegistry.LoadML(esClient); err != nil {
+
+	if kibanaConfig == nil {
+		kibanaConfig = common.NewConfig()
+	}
+
+	kibanaClient, err := kibana.NewKibanaClient(kibanaConfig)
+	if err != nil {
+		return errors.Errorf("Error creating Kibana client: %v", err)
+	}
+
+	kibanaVersion, err := common.NewVersion(kibanaClient.GetVersion())
+	if err != nil {
+		return err
+	}
+
+	if err := setupMLBasedOnVersion(fb.moduleRegistry, esClient, kibanaClient, kibanaVersion); err != nil {
 		errs = append(errs, err)
 	}
 
@@ -185,13 +202,28 @@ func (fb *Filebeat) loadModulesML(b *beat.Beat) error {
 				continue
 			}
 
-			if err := set.LoadML(esClient); err != nil {
+			if err := setupMLBasedOnVersion(set, esClient, kibanaClient, kibanaVersion); err != nil {
 				errs = append(errs, err)
 			}
+
 		}
 	}
 
 	return errs.Err()
+}
+
+func setupMLBasedOnVersion(reg *fileset.ModuleRegistry, esClient *elasticsearch.Client, kibanaClient *kibana.Client, kibanaVersion *common.Version) error {
+	if isElasticsearchLoads(kibanaVersion) {
+		return reg.LoadML(esClient)
+	}
+	return reg.SetupML(esClient, kibanaClient)
+}
+
+func isElasticsearchLoads(kibanaVersion *common.Version) bool {
+	if kibanaVersion.Major < 6 && kibanaVersion.Minor < 1 {
+		return true
+	}
+	return false
 }
 
 // Run allows the beater to be run as a beat.

--- a/filebeat/beater/filebeat.go
+++ b/filebeat/beater/filebeat.go
@@ -220,7 +220,7 @@ func setupMLBasedOnVersion(reg *fileset.ModuleRegistry, esClient *elasticsearch.
 }
 
 func isElasticsearchLoads(kibanaVersion *common.Version) bool {
-	if kibanaVersion.Major < 6 && kibanaVersion.Minor < 1 {
+	if kibanaVersion.Major < 6 || kibanaVersion.Major == 6 && kibanaVersion.Minor < 1 {
 		return true
 	}
 	return false

--- a/filebeat/fileset/modules.go
+++ b/filebeat/fileset/modules.go
@@ -498,7 +498,8 @@ func (reg *ModuleRegistry) SetupML(esClient PipelineLoader, kibanaClient *kibana
 	}
 
 	for module, fileset := range modules {
-		err := mlimporter.SetupModule(kibanaClient, module, fileset)
+		prefix := fmt.Sprintf("filebeat-%s-%s-", module, fileset)
+		err := mlimporter.SetupModule(kibanaClient, module, prefix)
 		if err != nil {
 			return errors.Errorf("Error setting up ML for %s: %v", module, err)
 		}

--- a/filebeat/fileset/modules.go
+++ b/filebeat/fileset/modules.go
@@ -486,7 +486,7 @@ func (reg *ModuleRegistry) SetupML(esClient PipelineLoader, kibanaClient *kibana
 		return nil
 	}
 
-	var modules map[string]string
+	modules := make(map[string]string)
 	if reg.Empty() {
 		modules = mlimporter.AvailableModules
 	} else {

--- a/filebeat/fileset/modules.go
+++ b/filebeat/fileset/modules.go
@@ -510,6 +510,7 @@ func (reg *ModuleRegistry) Empty() bool {
 	return count == 0
 }
 
+// ModuleNames returns the names of modules in the ModuleRegistry.
 func (reg *ModuleRegistry) ModuleNames() []string {
 	var modules []string
 	for m := range reg.registry {

--- a/filebeat/fileset/modules.go
+++ b/filebeat/fileset/modules.go
@@ -486,11 +486,14 @@ func (reg *ModuleRegistry) SetupML(esClient PipelineLoader, kibanaClient *kibana
 		return nil
 	}
 
-	for module := range reg.registry {
-		if module == "" {
-			return errors.Errorf("No module is specified")
-		}
+	var modules []string
+	if reg.Empty() {
+		modules = mlimporter.AvailableModules
+	} else {
+		modules = reg.ModuleNames()
+	}
 
+	for _, module := range modules {
 		err := mlimporter.SetupModule(kibanaClient, module)
 		if err != nil {
 			return errors.Errorf("Error setting up ML for %s: %v", module, err)
@@ -505,4 +508,12 @@ func (reg *ModuleRegistry) Empty() bool {
 		count += len(filesets)
 	}
 	return count == 0
+}
+
+func (reg *ModuleRegistry) ModuleNames() []string {
+	var modules []string
+	for m := range reg.registry {
+		modules = append(modules, m)
+	}
+	return modules
 }

--- a/filebeat/fileset/modules.go
+++ b/filebeat/fileset/modules.go
@@ -17,6 +17,11 @@ import (
 	"github.com/elastic/beats/libbeat/setup/kibana"
 )
 
+var availableMLModules = map[string]string{
+	"apache2": "access",
+	"nginx":   "access",
+}
+
 type ModuleRegistry struct {
 	registry map[string]map[string]*Fileset // module -> fileset -> Fileset
 }
@@ -488,10 +493,10 @@ func (reg *ModuleRegistry) SetupML(esClient PipelineLoader, kibanaClient *kibana
 
 	modules := make(map[string]string)
 	if reg.Empty() {
-		modules = mlimporter.AvailableModules
+		modules = availableMLModules
 	} else {
 		for _, module := range reg.ModuleNames() {
-			if fileset, ok := mlimporter.AvailableModules[module]; ok {
+			if fileset, ok := availableMLModules[module]; ok {
 				modules[module] = fileset
 			}
 		}

--- a/filebeat/fileset/modules.go
+++ b/filebeat/fileset/modules.go
@@ -486,7 +486,7 @@ func (reg *ModuleRegistry) SetupML(esClient PipelineLoader, kibanaClient *kibana
 		return nil
 	}
 
-	for module, _ := range reg.registry {
+	for module := range reg.registry {
 		if module == "" {
 			return errors.Errorf("No module is specified")
 		}

--- a/libbeat/beat/beat.go
+++ b/libbeat/beat/beat.go
@@ -54,4 +54,4 @@ type BeatConfig struct {
 
 // SetupMLCallback can be used by the Beat to register MachineLearning configurations
 // for the enabled modules.
-type SetupMLCallback func(*Beat) error
+type SetupMLCallback func(*Beat, *common.Config) error

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -303,7 +303,7 @@ func (b *Beat) launch(bt beat.Creator) error {
 		return err
 	}
 	if setup && b.SetupMLCallback != nil {
-		err = b.SetupMLCallback(&b.Beat)
+		err = b.SetupMLCallback(&b.Beat, b.Config.Kibana)
 		if err != nil {
 			return err
 		}
@@ -394,7 +394,7 @@ func (b *Beat) Setup(bt beat.Creator, template, dashboards, machineLearning bool
 		}
 
 		if machineLearning && b.SetupMLCallback != nil {
-			err = b.SetupMLCallback(&b.Beat)
+			err = b.SetupMLCallback(&b.Beat, b.Config.Kibana)
 			if err != nil {
 				return err
 			}

--- a/libbeat/ml-importer/importer.go
+++ b/libbeat/ml-importer/importer.go
@@ -41,12 +41,13 @@ type MLLoader interface {
 	GetVersion() string
 }
 
-// MLLoader is a subset of the Kibana client API capable of setting up ML objects.
+// MLSetupper is a subset of the Kibana client API capable of setting up ML objects.
 type MLSetupper interface {
 	Request(method, path string, params url.Values, body io.Reader) (int, []byte, error)
 	GetVersion() string
 }
 
+// MLResponse stores the relevant parts of the response from Kibana to check for errors.
 type MLResponse struct {
 	Datafeeds []struct {
 		ID      string
@@ -174,7 +175,7 @@ func HaveXpackML(esClient MLLoader) (bool, error) {
 	return xpack.Features.ML.Available && xpack.Features.ML.Enabled, nil
 }
 
-// SetupModules creates ML jobs, data feeds and dashboards for modules.
+// SetupModule creates ML jobs, data feeds and dashboards for modules.
 func SetupModule(kibanaClient MLSetupper, module string) error {
 	setupURL := fmt.Sprintf(kibanaSetupModuleURL, module)
 	prefix := fmt.Sprintf("{\"prefix\": \"filebeat_%s_\"}", module)

--- a/libbeat/ml-importer/importer.go
+++ b/libbeat/ml-importer/importer.go
@@ -182,12 +182,12 @@ func HaveXpackML(esClient MLLoader) (bool, error) {
 }
 
 // SetupModule creates ML jobs, data feeds and dashboards for modules.
-func SetupModule(kibanaClient MLSetupper, module, fileset string) error {
+func SetupModule(kibanaClient MLSetupper, module, prefix string) error {
 	setupURL := fmt.Sprintf(kibanaSetupModuleURL, module)
-	prefix := fmt.Sprintf("{\"prefix\": \"filebeat-%s-%s-\"}", module, fileset)
-	status, response, err := kibanaClient.Request("POST", setupURL, nil, strings.NewReader(prefix))
+	prefixPayload := fmt.Sprintf("{\"prefix\": \"%s\"}", prefix)
+	status, response, err := kibanaClient.Request("POST", setupURL, nil, strings.NewReader(prefixPayload))
 	if status != 200 {
-		return errors.Errorf("cannot set up ML for module: %s/%s %v", module, fileset, status)
+		return errors.Errorf("cannot set up ML with prefix: %s", prefix)
 	}
 	if err != nil {
 		return err

--- a/libbeat/ml-importer/importer.go
+++ b/libbeat/ml-importer/importer.go
@@ -22,12 +22,6 @@ var (
 	kibanaGetModuleURL   = "/api/ml/modules/get_module/%s"
 	kibanaRecognizeURL   = "/api/ml/modules/recognize/%s"
 	kibanaSetupModuleURL = "/api/ml/modules/setup/%s"
-
-	// AvailableModules is the list of modules available in ML
-	AvailableModules = map[string]string{
-		"apache2": "access",
-		"nginx":   "access",
-	}
 )
 
 // MLConfig contains the required configuration for loading one job and the associated

--- a/libbeat/ml-importer/importer.go
+++ b/libbeat/ml-importer/importer.go
@@ -24,9 +24,9 @@ var (
 	kibanaSetupModuleURL = "/api/ml/modules/setup/%s"
 
 	// AvailableModules is the list of modules available in ML
-	AvailableModules = []string{
-		"apache2",
-		"nginx",
+	AvailableModules = map[string]string{
+		"apache2": "access",
+		"nginx":   "access",
 	}
 )
 
@@ -182,12 +182,12 @@ func HaveXpackML(esClient MLLoader) (bool, error) {
 }
 
 // SetupModule creates ML jobs, data feeds and dashboards for modules.
-func SetupModule(kibanaClient MLSetupper, module string) error {
+func SetupModule(kibanaClient MLSetupper, module, fileset string) error {
 	setupURL := fmt.Sprintf(kibanaSetupModuleURL, module)
-	prefix := fmt.Sprintf("{\"prefix\": \"filebeat_%s_\"}", module)
+	prefix := fmt.Sprintf("{\"prefix\": \"filebeat-%s-%s-\"}", module, fileset)
 	status, response, err := kibanaClient.Request("POST", setupURL, nil, strings.NewReader(prefix))
 	if status != 200 {
-		return errors.Errorf("cannot set up ML for module: %s %v", module, status)
+		return errors.Errorf("cannot set up ML for module: %s/%s %v", module, fileset, status)
 	}
 	if err != nil {
 		return err

--- a/libbeat/ml-importer/importer.go
+++ b/libbeat/ml-importer/importer.go
@@ -22,6 +22,11 @@ var (
 	kibanaGetModuleURL   = "/api/ml/modules/get_module/%s"
 	kibanaRecognizeURL   = "/api/ml/modules/recognize/%s"
 	kibanaSetupModuleURL = "/api/ml/modules/setup/%s"
+
+	AvailableModules = []string{
+		"apache2",
+		"nginx",
+	}
 )
 
 // MLConfig contains the required configuration for loading one job and the associated

--- a/libbeat/ml-importer/importer.go
+++ b/libbeat/ml-importer/importer.go
@@ -23,6 +23,7 @@ var (
 	kibanaRecognizeURL   = "/api/ml/modules/recognize/%s"
 	kibanaSetupModuleURL = "/api/ml/modules/setup/%s"
 
+	// AvailableModules is the list of modules available in ML
 	AvailableModules = []string{
 		"apache2",
 		"nginx",

--- a/libbeat/outputs/elasticsearch/estest/estest.go
+++ b/libbeat/outputs/elasticsearch/estest/estest.go
@@ -14,7 +14,7 @@ func GetTestingElasticsearch(t internal.TestLogger) *elasticsearch.Client {
 		URL:              internal.GetURL(),
 		Index:            outil.MakeSelector(),
 		Username:         internal.GetUser(),
-		Password:         internal.GetUser(),
+		Password:         internal.GetPass(),
 		Timeout:          60 * time.Second,
 		CompressionLevel: 3,
 	}, nil)


### PR DESCRIPTION
Since Kibana 6.1 new ML API is available to load jobs, datafeeds, etc. Thus, it's not necessary to store ML configs in Beats and load them using `setup`.
From now on if Filebeat connects to a Kibana 6.1 or newer the Kibana API is called. If Kibana is older than 6.1, Filebeat loads the ML config from the repo, as it's done in previous versions.

Setting up ML for nginx:
```
./filebeat setup --machine-learning -modules=nginx
```