### PR TITLE
Stop if autodiscover configuration is wrong

### DIFF
--- a/libbeat/autodiscover/providers/kubernetes/kubernetes.go
+++ b/libbeat/autodiscover/providers/kubernetes/kubernetes.go
@@ -64,20 +64,20 @@ func AutodiscoverBuilder(bus bus.Bus, c *common.Config) (autodiscover.Provider, 
 
 	var builders autodiscover.Builders
 	for _, bcfg := range config.Builders {
-		if builder, err := autodiscover.Registry.BuildBuilder(bcfg); err != nil {
-			logp.Info("kubernetes: failed to construct autodiscover builder due to error: %v", err)
-		} else {
-			builders = append(builders, builder)
+		builder, err := autodiscover.Registry.BuildBuilder(bcfg)
+		if err != nil {
+			return nil, err
 		}
+		builders = append(builders, builder)
 	}
 
 	var appenders autodiscover.Appenders
 	for _, acfg := range config.Appenders {
-		if appender, err := autodiscover.Registry.BuildAppender(acfg); err != nil {
-			logp.Info("kubernetes: failed to construct autodiscover appender due to error: %v", err)
-		} else {
-			appenders = append(appenders, appender)
+		appender, err := autodiscover.Registry.BuildAppender(acfg)
+		if err != nil {
+			return nil, err
 		}
+		appenders = append(appenders, appender)
 	}
 
 	p := &Provider{

--- a/metricbeat/tests/system/test_autodiscover.py
+++ b/metricbeat/tests/system/test_autodiscover.py
@@ -41,6 +41,7 @@ class TestAutodiscover(metricbeat.BaseTest):
         container = docker_client.containers.run('memcached:1.5.3', detach=True)
 
         self.wait_until(lambda: self.log_contains('Autodiscover starting runner: memcached'))
+        sleep(2)
 
         container.stop()
         self.wait_until(lambda: self.log_contains('Autodiscover stopping runner: memcached'))
@@ -80,6 +81,7 @@ class TestAutodiscover(metricbeat.BaseTest):
         container = docker_client.containers.run('memcached:1.5.3', labels=labels, detach=True)
 
         self.wait_until(lambda: self.log_contains('Autodiscover starting runner: memcached'))
+        sleep(2)
 
         container.stop()
         self.wait_until(lambda: self.log_contains('Autodiscover stopping runner: memcached'))

--- a/metricbeat/tests/system/test_autodiscover.py
+++ b/metricbeat/tests/system/test_autodiscover.py
@@ -15,7 +15,7 @@ class TestAutodiscover(metricbeat.BaseTest):
                      "integration test not available on 2.x")
     def test_docker(self):
         """
-        Test docker autodiscover starts modules
+        Test docker autodiscover starts modules from templates
         """
         import docker
         docker_client = docker.from_env()
@@ -41,7 +41,6 @@ class TestAutodiscover(metricbeat.BaseTest):
         container = docker_client.containers.run('memcached:1.5.3', detach=True)
 
         self.wait_until(lambda: self.log_contains('Autodiscover starting runner: memcached'))
-        sleep(2)
 
         container.stop()
         self.wait_until(lambda: self.log_contains('Autodiscover stopping runner: memcached'))
@@ -52,4 +51,42 @@ class TestAutodiscover(metricbeat.BaseTest):
         # Check metadata is added
         assert output[0]['docker']['container']['image'] == 'memcached:1.5.3'
         assert output[0]['docker']['container']['labels'] == {}
+        assert 'name' in output[0]['docker']['container']
+
+    @unittest.skipIf(not INTEGRATION_TESTS or
+                     os.getenv("TESTING_ENVIRONMENT") == "2x",
+                     "integration test not available on 2.x")
+    def test_docker_labels(self):
+        """
+        Test docker autodiscover starts modules from labels
+        """
+        import docker
+        docker_client = docker.from_env()
+
+        self.render_config_template(
+            autodiscover={
+                'docker': {
+                    'builders': '- type: metrics',
+                },
+            },
+        )
+
+        proc = self.start_beat()
+        docker_client.images.pull('memcached:1.5.3')
+        labels = {
+            'co.elastic.metrics/module': 'memcached',
+            'co.elastic.metrics/hosts': "'${data.host}:11211'",
+        }
+        container = docker_client.containers.run('memcached:1.5.3', labels=labels, detach=True)
+
+        self.wait_until(lambda: self.log_contains('Autodiscover starting runner: memcached'))
+
+        container.stop()
+        self.wait_until(lambda: self.log_contains('Autodiscover stopping runner: memcached'))
+
+        output = self.read_output_json()
+        proc.check_kill_and_wait()
+
+        # Check metadata is added
+        assert output[0]['docker']['container']['image'] == 'memcached:1.5.3'
         assert 'name' in output[0]['docker']['container']


### PR DESCRIPTION
This change stops the beat if the configuration for builders or appenders is wrong.

I also added a new integration test on label based autodiscover