### PR TITLE
Update link to support matrix

### DIFF
--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -81,7 +81,9 @@ output.elasticsearch:
 
 ==== Compatibility
 
-This output works with all compatible versions of Elasticsearch. See "Supported Beats Versions" in the https://www.elastic.co/support/matrix#show_compatibility[Elastic Support Matrix].
+This output works with all compatible versions of Elasticsearch. See the
+https://www.elastic.co/support/matrix#matrix_compatibility[Elastic Support
+Matrix].
 
 ==== Configuration options
 
@@ -401,7 +403,9 @@ will be similar to events directly indexed by Beats into Elasticsearch.
 
 ==== Compatibility
 
-This output works with all compatible versions of Logstash. See "Supported Beats Versions" in the https://www.elastic.co/support/matrix#show_compatibility[Elastic Support Matrix].
+This output works with all compatible versions of Logstash. See the
+https://www.elastic.co/support/matrix#matrix_compatibility[Elastic Support
+Matrix].
 
 ==== Configuration options
 


### PR DESCRIPTION
They changed some anchors in the support matrix. The links still resolve, but don't point to the precise location.