### PR TITLE
Packetbeat: add function restrict query size

### DIFF
--- a/packetbeat/protos/mysql/mysql.go
+++ b/packetbeat/protos/mysql/mysql.go
@@ -863,6 +863,16 @@ func (mysql *mysqlPlugin) publishTransaction(t *mysqlTransaction) {
 	})
 }
 
+func (mysql *mysqlPlugin) restrictQuerySize(msg *mysqlMessage, limit int) []byte {
+	length := len(msg.query)
+	var cutQuery []byte
+	if length >= limit {
+		cutQuery = []byte(msg.query)[:limit]
+	}
+
+	return cutQuery
+}
+
 func readLstring(data []byte, offset int) ([]byte, int, bool, error) {
 	length, off, complete, err := readLinteger(data, offset)
 	if err != nil {


### PR DESCRIPTION
Fix for https://github.com/elastic/beats/issues/96

- add function to restrict query size