### PR TITLE
Do not build internal metrics without CGO (#6501)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -280,6 +280,7 @@ https://github.com/elastic/beats/compare/v6.0.1...v6.1.0[View commits]
 - Fix console color output for Windows. {issue}5611[5611]
 - Fix logstash output debug message. {pull}5799{5799]
 - Fix isolation of modules when merging local and global field settings. {issue}5795[5795]
+- Report ephemeral ID and uptime in monitoring events on all platforms {pull}6501[6501]
 
 *Filebeat*
 

--- a/libbeat/cmd/instance/metrics.go
+++ b/libbeat/cmd/instance/metrics.go
@@ -1,5 +1,4 @@
-// +build darwin linux windows
-// +build cgo
+// +build darwin,cgo freebsd,cgo linux windows
 
 package instance
 
@@ -7,38 +6,31 @@ import (
 	"fmt"
 	"os"
 	"runtime"
-	"time"
-
-	"github.com/satori/go.uuid"
 
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/metric/system/cpu"
 	"github.com/elastic/beats/libbeat/metric/system/process"
 	"github.com/elastic/beats/libbeat/monitoring"
-	"github.com/elastic/beats/libbeat/monitoring/report/log"
 )
 
 var (
 	beatProcessStats *process.Stats
-	ephemeralID      uuid.UUID
+	systemMetrics    *monitoring.Registry
 )
 
 func init() {
-	beatMetrics := monitoring.Default.NewRegistry("beat")
+	systemMetrics = monitoring.Default.NewRegistry("system")
+}
+
+func setupMetrics(name string) error {
 	monitoring.NewFunc(beatMetrics, "memstats", reportMemStats, monitoring.Report)
 	monitoring.NewFunc(beatMetrics, "cpu", reportBeatCPU, monitoring.Report)
-	monitoring.NewFunc(beatMetrics, "info", reportInfo, monitoring.Report)
 
-	systemMetrics := monitoring.Default.NewRegistry("system")
 	monitoring.NewFunc(systemMetrics, "cpu", reportSystemCPUUsage, monitoring.Report)
 	if runtime.GOOS != "windows" {
 		monitoring.NewFunc(systemMetrics, "load", reportSystemLoadAverage, monitoring.Report)
 	}
 
-	ephemeralID = uuid.NewV4()
-}
-
-func setupMetrics(name string) error {
 	beatProcessStats = &process.Stats{
 		Procs:        []string{name},
 		EnvWhitelist: nil,
@@ -89,19 +81,6 @@ func getRSSSize() (uint64, error) {
 		return 0, fmt.Errorf("error converting Resident Set Size to uint64: %v", iRss)
 	}
 	return rss, nil
-}
-
-func reportInfo(_ monitoring.Mode, V monitoring.Visitor) {
-	V.OnRegistryStart()
-	defer V.OnRegistryFinished()
-
-	delta := time.Since(log.StartTime)
-	uptime := int64(delta / time.Millisecond)
-	monitoring.ReportNamespace(V, "uptime", func() {
-		monitoring.ReportInt(V, "ms", uptime)
-	})
-
-	monitoring.ReportString(V, "ephemeral_id", ephemeralID.String())
 }
 
 func reportBeatCPU(_ monitoring.Mode, V monitoring.Visitor) {

--- a/libbeat/cmd/instance/metrics_common.go
+++ b/libbeat/cmd/instance/metrics_common.go
@@ -1,0 +1,35 @@
+package instance
+
+import (
+	"time"
+
+	"github.com/satori/go.uuid"
+
+	"github.com/elastic/beats/libbeat/monitoring"
+	"github.com/elastic/beats/libbeat/monitoring/report/log"
+)
+
+var (
+	ephemeralID uuid.UUID
+	beatMetrics *monitoring.Registry
+)
+
+func init() {
+	beatMetrics = monitoring.Default.NewRegistry("beat")
+	monitoring.NewFunc(beatMetrics, "info", reportInfo, monitoring.Report)
+
+	ephemeralID = uuid.NewV4()
+}
+
+func reportInfo(_ monitoring.Mode, V monitoring.Visitor) {
+	V.OnRegistryStart()
+	defer V.OnRegistryFinished()
+
+	delta := time.Since(log.StartTime)
+	uptime := int64(delta / time.Millisecond)
+	monitoring.ReportNamespace(V, "uptime", func() {
+		monitoring.ReportInt(V, "ms", uptime)
+	})
+
+	monitoring.ReportString(V, "ephemeral_id", ephemeralID.String())
+}

--- a/libbeat/cmd/instance/metrics_other.go
+++ b/libbeat/cmd/instance/metrics_other.go
@@ -1,8 +1,12 @@
-// +build !darwin,!linux,!windows darwin,!cgo linux,!cgo windows,!cgo
+// +build !darwin !cgo
+// +build !freebsd !cgo
+// +build !linux,!windows
 
 package instance
 
-import "github.com/elastic/beats/libbeat/logp"
+import (
+	"github.com/elastic/beats/libbeat/logp"
+)
 
 func setupMetrics(name string) error {
 	logp.Warn("Metrics not implemented for this OS.")


### PR DESCRIPTION
Backports the following commits to 6.2:
* libbeat: build internal metrics on windows and linux without cgo
* libbeat: add ephemeral id even if no internal memory metrics is reported
* fix incorrect build tags && create common file for all platforms

PR #6501 