### PR TITLE
Use default metricsets in hints based autodiscover

### DIFF
--- a/metricbeat/autodiscover/builder/hints/config.go
+++ b/metricbeat/autodiscover/builder/hints/config.go
@@ -1,11 +1,15 @@
 package hints
 
+import "github.com/elastic/beats/metricbeat/mb"
+
 type config struct {
-	Key string `config:"key"`
+	Key      string `config:"key"`
+	Registry *mb.Register
 }
 
 func defaultConfig() config {
 	return config{
-		Key: "metrics",
+		Key:      "metrics",
+		Registry: mb.Registry,
 	}
 }

--- a/metricbeat/autodiscover/builder/hints/metrics_test.go
+++ b/metricbeat/autodiscover/builder/hints/metrics_test.go
@@ -12,12 +12,13 @@ import (
 
 func TestGenerateHints(t *testing.T) {
 	tests := []struct {
-		event  bus.Event
-		len    int
-		result common.MapStr
+		message string
+		event   bus.Event
+		len     int
+		result  common.MapStr
 	}{
-		// Empty event hints should return empty config
 		{
+			message: "Empty event hints should return empty config",
 			event: bus.Event{
 				"host": "1.2.3.4",
 				"kubernetes": common.MapStr{
@@ -36,8 +37,8 @@ func TestGenerateHints(t *testing.T) {
 			len:    0,
 			result: common.MapStr{},
 		},
-		// Hints without host should return nothing
 		{
+			message: "Hints without host should return nothing",
 			event: bus.Event{
 				"hints": common.MapStr{
 					"metrics": common.MapStr{
@@ -48,8 +49,8 @@ func TestGenerateHints(t *testing.T) {
 			len:    0,
 			result: common.MapStr{},
 		},
-		// Only module hint should return all metricsets
 		{
+			message: "Only module hint should return all metricsets",
 			event: bus.Event{
 				"host": "1.2.3.4",
 				"hints": common.MapStr{
@@ -67,8 +68,8 @@ func TestGenerateHints(t *testing.T) {
 				"enabled":    true,
 			},
 		},
-		// metricsets hint works
 		{
+			message: "metricsets hint works",
 			event: bus.Event{
 				"host": "1.2.3.4",
 				"hints": common.MapStr{
@@ -87,8 +88,8 @@ func TestGenerateHints(t *testing.T) {
 				"enabled":    true,
 			},
 		},
-		// Only module, it should return defaults
 		{
+			message: "Only module, it should return defaults",
 			event: bus.Event{
 				"host": "1.2.3.4",
 				"hints": common.MapStr{
@@ -106,8 +107,8 @@ func TestGenerateHints(t *testing.T) {
 				"enabled":    true,
 			},
 		},
-		// Module, namespace, host hint should return valid config without port should not return hosts
 		{
+			message: "Module, namespace, host hint should return valid config without port should not return hosts",
 			event: bus.Event{
 				"host": "1.2.3.4",
 				"hints": common.MapStr{
@@ -128,8 +129,8 @@ func TestGenerateHints(t *testing.T) {
 				"enabled":    true,
 			},
 		},
-		// Module, namespace, host hint should return valid config
 		{
+			message: "Module, namespace, host hint should return valid config",
 			event: bus.Event{
 				"host": "1.2.3.4",
 				"port": 9090,
@@ -170,9 +171,9 @@ func TestGenerateHints(t *testing.T) {
 		if test.len != 0 {
 			config := common.MapStr{}
 			err := cfgs[0].Unpack(&config)
-			assert.Nil(t, err)
+			assert.Nil(t, err, test.message)
 
-			assert.Equal(t, config, test.result)
+			assert.Equal(t, config, test.result, test.message)
 		}
 
 	}

--- a/metricbeat/docs/autodiscover-hints.asciidoc
+++ b/metricbeat/docs/autodiscover-hints.asciidoc
@@ -29,8 +29,10 @@ annotations:
 
 The above annotations are used to spin up a Prometheus collector metricset and it polls the
 parent container on port `9090` at a 1 minute interval and the container named `sidecar` on
-port `8080` every 10 minutes. Hints can also be provided for the following module configuration
-parameters:
+port `8080` every 10 minutes. If no metricsets parameter is given, Metricbeat will use default
+metricsets of the module, or all metricsets if there is no default list.
+
+Hints can also be provided for the following module configuration parameters:
 
 ["source","yaml",subs="attributes"]
 -------------------------------------------------------------------------------------

--- a/metricbeat/mb/builders.go
+++ b/metricbeat/mb/builders.go
@@ -146,7 +146,7 @@ func newBaseMetricSets(r *Register, m Module) ([]BaseMetricSet, error) {
 	metricSetNames := m.Config().MetricSets
 	if len(metricSetNames) == 0 {
 		var err error
-		metricSetNames, err = r.defaultMetricSets(m.Name())
+		metricSetNames, err = r.DefaultMetricSets(m.Name())
 		if err != nil {
 			return nil, errors.Errorf("no metricsets configured for module '%s'", m.Name())
 		}

--- a/metricbeat/mb/registry.go
+++ b/metricbeat/mb/registry.go
@@ -217,10 +217,10 @@ func (r *Register) metricSetRegistration(module, name string) (MetricSetRegistra
 	return registration, nil
 }
 
-// defaultMetricSets returns the names of the default MetricSets for a module.
+// DefaultMetricSets returns the names of the default MetricSets for a module.
 // An error is returned if no default MetricSet is declared or the module does
 // not exist.
-func (r *Register) defaultMetricSets(module string) ([]string, error) {
+func (r *Register) DefaultMetricSets(module string) ([]string, error) {
 	r.lock.RLock()
 	defer r.lock.RUnlock()
 

--- a/metricbeat/mb/registry_test.go
+++ b/metricbeat/mb/registry_test.go
@@ -195,7 +195,7 @@ func TestDefaultMetricSet(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	names, err := registry.defaultMetricSets(moduleName)
+	names, err := registry.DefaultMetricSets(moduleName)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
When using hints in Metricbeat, follow this pattern:

 - If `metricsets` hint is given, use it
 - If not, use module default metricsets
 - If no default metricsets, use all module metricsets