### PR TITLE
Make `collector` default prometheus metricset

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -258,6 +258,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Allow to disable labels `dedot` in Docker module, in favor of a safe way to keep dots. {pull}6490[6490]
 - Add experimental module to collect metrics from munin nodes. {pull}6517[6517]
 - Add support for wildcards and explicit metrics grouping in jolokia/jmx. {pull}6462[6462]
+- Set `collector` as default metricset in Prometheus module. {pull}6636[6636]
 
 *Packetbeat*
 

--- a/metricbeat/module/prometheus/collector/collector.go
+++ b/metricbeat/module/prometheus/collector/collector.go
@@ -24,9 +24,10 @@ var (
 )
 
 func init() {
-	if err := mb.Registry.AddMetricSet("prometheus", "collector", New, hostParser); err != nil {
-		panic(err)
-	}
+	mb.Registry.MustAddMetricSet("prometheus", "collector", New,
+		mb.WithHostParser(hostParser),
+		mb.DefaultMetricSet(),
+	)
 }
 
 type MetricSet struct {


### PR DESCRIPTION
This change makes prometheus collector the default metricset, so there is no need to declare it when using it by hand or in autodiscover:

```
metricbeat.modules:
  - module: prometheus
    period: 10s
    hosts: ["localhost:9090"]
    metrics_path: /metrics
```

