### PR TITLE
Indicate that Beats monitoring requires ES 6.2 or later

### DIFF
--- a/libbeat/docs/monitoring/monitoring-beats.asciidoc
+++ b/libbeat/docs/monitoring/monitoring-beats.asciidoc
@@ -16,6 +16,9 @@
 
 [partintro]
 --
+
+NOTE: {monitoring} for {beatname_uc} requires {es} 6.2 or later.
+
 {monitoring} enables you to easily monitor {beatname_uc} from {kib}. For more
 information, see
 {xpack-ref}/xpack-monitoring.html[Monitoring the Elastic Stack] and


### PR DESCRIPTION
Fixes issue #6329 

The attributes get rendered as:

![image](https://user-images.githubusercontent.com/14206422/37858918-21891b76-2ec9-11e8-8ad4-2592fb5bb195.png)
