### PR TITLE
Remove double `password` and `username` in the Redis input config opt…

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -48,6 +48,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Refactor the usage of prospector to input in the YAML reference and
   the system test. {pull}6121[6121]
 - Add IIS module to parse access log and error log. {pull}6127[6127]
+- Remove the undefined `username` option from the Redis input and clarify the documentation. {pull}6662[6662]
 
 *Heartbeat*
 

--- a/filebeat/_meta/common.reference.p2.yml
+++ b/filebeat/_meta/common.reference.p2.yml
@@ -213,10 +213,12 @@ filebeat.inputs:
 #------------------------- Redis slowlog input ---------------------------
 # Experimental: Config options for the redis slow log input
 #- type: redis
-  #hosts: ["localhost:6379"]
-  #username:
-  #password:
   #enabled: false
+
+  # List of hosts to pool to retrieve the slow log information.
+  #hosts: ["localhost:6379"]
+
+  # How often the input checks for redis slow log.
   #scan_frequency: 10s
 
   # Timeout after which time the input should return an error

--- a/filebeat/docs/inputs/input-redis.asciidoc
+++ b/filebeat/docs/inputs/input-redis.asciidoc
@@ -18,7 +18,6 @@ Example configuration:
 {beatname_lc}.inputs:
 - type: redis
   hosts: ["localhost:6379"]
-  username: "$\{redis_user\}"
   password: "$\{redis_pwd\}"
 ----
 
@@ -33,12 +32,6 @@ The `redis` input supports the following configuration options plus the
 ===== `hosts`
 
 The list of Redis hosts to connect to.
-
-[float]
-[[redis-username]]
-===== `username`
-
-The username to use when connecting to Redis.
 
 [float]
 [[redis-password]]
@@ -59,7 +52,7 @@ The default is `10s`.
 IMPORTANT: Redis slowlogs are not permanent. To ensure that all slowlog entries
 are collected, set `scan_frequency` to a value that allows {beatname_uc}
 sufficient time to connect to Redis, query the logs, and buffer them to the
-output within the specified interval. 
+output within the specified interval.
 
 [float]
 [[redis-timeout]]

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -508,10 +508,12 @@ filebeat.inputs:
 #------------------------- Redis slowlog input ---------------------------
 # Experimental: Config options for the redis slow log input
 #- type: redis
-  #hosts: ["localhost:6379"]
-  #username:
-  #password:
   #enabled: false
+
+  # List of hosts to pool to retrieve the slow log information.
+  #hosts: ["localhost:6379"]
+
+  # How often the input checks for redis slow log.
   #scan_frequency: 10s
 
   # Timeout after which time the input should return an error

--- a/filebeat/input/redis/config.go
+++ b/filebeat/input/redis/config.go
@@ -7,7 +7,6 @@ import (
 )
 
 var defaultConfig = config{
-
 	ForwarderConfig: harvester.ForwarderConfig{
 		Type: "redis",
 	},


### PR DESCRIPTION
…ions

- Remove a double password in the yml file.
- Remove mention of username in the configuration, nothing in the input
code uses thats.
- Remove space

Fixes: #6573