### PR TITLE
Add more details to system socket metricset

### DIFF
--- a/metricbeat/docs/fields.asciidoc
+++ b/metricbeat/docs/fields.asciidoc
@@ -11971,6 +11971,16 @@ Name of the user running the process.
 
 
 [float]
+=== `system.socket.state`
+
+type: keyword
+
+example: ESTABLISHED
+
+Socket connection state, possible values are: ESTABLISHED, SYN_SENT, SYN_RECV, FIN_WAIT1, FIN_WAIT2, TIME_WAIT, CLOSED, CLOSE_WAIT, LAST_ACK, LISTEN, CLOSING.
+
+
+[float]
 == uptime fields
 
 `uptime` contains the operating system uptime metric.

--- a/metricbeat/module/system/socket/_meta/fields.yml
+++ b/metricbeat/module/system/socket/_meta/fields.yml
@@ -90,3 +90,11 @@
       type: keyword
       description: >
         Name of the user running the process.
+
+    - name: state
+      type: keyword
+      example: ESTABLISHED
+      description: >
+        Socket connection state, possible values are: ESTABLISHED, SYN_SENT,
+        SYN_RECV, FIN_WAIT1, FIN_WAIT2, TIME_WAIT, CLOSED, CLOSE_WAIT, LAST_ACK,
+        LISTEN, CLOSING.

--- a/metricbeat/module/system/socket/socket.go
+++ b/metricbeat/module/system/socket/socket.go
@@ -257,6 +257,7 @@ func (c *connection) ToMapStr() common.MapStr {
 			"id": c.UID,
 		},
 		"direction": c.Direction.String(),
+		"state":     getStateName(c.State),
 	}
 
 	if c.Username != "" {
@@ -301,4 +302,26 @@ func addOptionalString(m common.MapStr, key, value string) {
 		return
 	}
 	m[key] = value
+}
+
+func getStateName(state linux.TCPState) string {
+	name := tcpStateNames[state]
+	if name == "" {
+		name = "UNKNOWN"
+	}
+	return name
+}
+
+var tcpStateNames = map[linux.TCPState]string{
+	linux.TCP_ESTABLISHED: "ESTABLISHED",
+	linux.TCP_SYN_SENT:    "SYN_SENT",
+	linux.TCP_SYN_RECV:    "SYN_RECV",
+	linux.TCP_FIN_WAIT1:   "FIN_WAIT1",
+	linux.TCP_FIN_WAIT2:   "FIN_WAIT2",
+	linux.TCP_TIME_WAIT:   "TIME_WAIT",
+	linux.TCP_CLOSE:       "CLOSED",
+	linux.TCP_CLOSE_WAIT:  "CLOSE_WAIT",
+	linux.TCP_LAST_ACK:    "LAST_ACK",
+	linux.TCP_LISTEN:      "LISTEN",
+	linux.TCP_CLOSING:     "CLOSING",
 }


### PR DESCRIPTION
This PR adds connection state info and keep-alive details (if any) to socket metricset.

Closes #6646