### PR TITLE
log to stderr as default, use '-q' flag to disable it.

### DIFF
--- a/libbeat/cmd/root.go
+++ b/libbeat/cmd/root.go
@@ -78,7 +78,7 @@ func GenRootCmdWithIndexPrefixWithRunFlags(name, indexPrefix, version string, be
 	rootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("c"))
 	rootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("d"))
 	rootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("v"))
-	rootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("e"))
+	rootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("q"))
 	rootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("path.config"))
 	rootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("path.data"))
 	rootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("path.logs"))

--- a/libbeat/logp/configure/logging.go
+++ b/libbeat/logp/configure/logging.go
@@ -11,13 +11,13 @@ import (
 // CLI flags for configuring logging.
 var (
 	verbose        bool
-	toStderr       bool
+	beQuiet       bool
 	debugSelectors []string
 )
 
 func init() {
 	flag.BoolVar(&verbose, "v", false, "Log at INFO level")
-	flag.BoolVar(&toStderr, "e", false, "Log to stderr and disable syslog/file output")
+	flag.BoolVar(&beQuiet, "q", false, "Don't log to stderr and enable syslog/file output")
 	common.StringArrVarFlag(nil, &debugSelectors, "d", "Enable certain debug selectors")
 }
 
@@ -37,7 +37,7 @@ func Logging(beatName string, cfg *common.Config) error {
 }
 
 func applyFlags(cfg *logp.Config) {
-	if toStderr {
+	if !beQuiet {
 		cfg.ToStderr = true
 	}
 	if cfg.Level > logp.InfoLevel && verbose {


### PR DESCRIPTION
Log to stderr as default, use '-q' flag to disable it.
Fix issue [#6134](https://github.com/elastic/beats/issues/6134)