### PR TITLE
Add test for error checking in ML

### DIFF
--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -105,7 +105,7 @@ func init() {
 	initRand()
 
 	flag.BoolVar(&printVersion, "version", false, "Print the version and exit")
-	flag.BoolVar(&setup, "setup", false, "Load the sample Kibana dashboards")
+	flag.BoolVar(&setup, "setup", false, "Load sample Kibana dashboards and setup Machine Learning")
 }
 
 // initRand initializes the runtime random number generator seed using

--- a/libbeat/dashboards/importer.go
+++ b/libbeat/dashboards/importer.go
@@ -71,7 +71,7 @@ func (imp Importer) ImportDashboard(file string) error {
 }
 
 func (imp Importer) ImportFile(fileType string, file string) error {
-	imp.loader.statusMsg("Import %s from %s\n", fileType, file)
+	imp.loader.statusMsg("Import %s from %s", fileType, file)
 
 	if fileType == "dashboard" {
 		return imp.loader.ImportDashboard(file)

--- a/libbeat/ml-importer/importer.go
+++ b/libbeat/ml-importer/importer.go
@@ -211,7 +211,7 @@ func checkResponse(r []byte) error {
 	for _, feed := range resp.Datafeeds {
 		if !feed.Success {
 			if strings.HasPrefix(feed.Error.Msg, "[resource_already_exists_exception]") {
-				logp.Debug("machine-learning", "Datafeed already exists: %s", feed.ID)
+				logp.Debug("machine-learning", "Datafeed already exists: %s, error: %s", feed.ID, feed.Error.Msg)
 				continue
 			}
 			errs = append(errs, errors.Errorf(feed.Error.Msg))
@@ -219,7 +219,7 @@ func checkResponse(r []byte) error {
 	}
 	for _, job := range resp.Jobs {
 		if strings.HasPrefix(job.Error.Msg, "[resource_already_exists_exception]") {
-			logp.Debug("machine-learning", "Job already exists: %s", job.ID)
+			logp.Debug("machine-learning", "Job already exists: %s, error: %s", job.ID, job.Error.Msg)
 			continue
 		}
 		if !job.Success {
@@ -229,7 +229,7 @@ func checkResponse(r []byte) error {
 	for _, dashboard := range resp.Kibana.Dashboard {
 		if !dashboard.Success {
 			if dashboard.Exists || strings.Contains(dashboard.Error.Message, "version conflict, document already exists") {
-				logp.Debug("machine-learning", "Dashboard already exists: %s", dashboard.ID)
+				logp.Debug("machine-learning", "Dashboard already exists: %s, error: %s", dashboard.ID, dashboard.Error.Message)
 			} else {
 				errs = append(errs, errors.Errorf("error while setting up dashboard: %s", dashboard.ID))
 			}
@@ -240,7 +240,7 @@ func checkResponse(r []byte) error {
 			if search.Exists || strings.Contains(search.Error.Message, "version conflict, document already exists") {
 				logp.Debug("machine-learning", "Search already exists: %s", search.ID)
 			} else {
-				errs = append(errs, errors.Errorf("error while setting up search: %s", search.ID))
+				errs = append(errs, errors.Errorf("error while setting up search: %s, error: %s", search.ID, search.Error.Message))
 			}
 		}
 	}
@@ -249,7 +249,7 @@ func checkResponse(r []byte) error {
 			if visualization.Exists || strings.Contains(visualization.Error.Message, "version conflict, document already exists") {
 				logp.Debug("machine-learning", "Visualization already exists: %s", visualization.ID)
 			} else {
-				errs = append(errs, errors.Errorf("error while setting up visualization: %s", visualization.ID))
+				errs = append(errs, errors.Errorf("error while setting up visualization: %s, error: %s", visualization.ID, visualization.Error.Message))
 			}
 		}
 	}

--- a/libbeat/ml-importer/importer.go
+++ b/libbeat/ml-importer/importer.go
@@ -228,10 +228,8 @@ func checkResponse(r []byte) error {
 	}
 	for _, dashboard := range resp.Kibana.Dashboard {
 		if !dashboard.Success {
-			if dashboard.Exists {
+			if dashboard.Exists || strings.Contains(dashboard.Error.Message, "version conflict, document already exists") {
 				logp.Debug("machine-learning", "Dashboard already exists: %s", dashboard.ID)
-			} else if strings.Contains(dashboard.Error.Message, "version conflict, document already exists") {
-				continue
 			} else {
 				errs = append(errs, errors.Errorf("error while setting up dashboard: %s", dashboard.ID))
 			}
@@ -239,10 +237,8 @@ func checkResponse(r []byte) error {
 	}
 	for _, search := range resp.Kibana.Search {
 		if !search.Success {
-			if search.Exists {
+			if search.Exists || strings.Contains(search.Error.Message, "version conflict, document already exists") {
 				logp.Debug("machine-learning", "Search already exists: %s", search.ID)
-			} else if strings.Contains(search.Error.Message, "version conflict, document already exists") {
-				continue
 			} else {
 				errs = append(errs, errors.Errorf("error while setting up search: %s", search.ID))
 			}
@@ -250,10 +246,8 @@ func checkResponse(r []byte) error {
 	}
 	for _, visualization := range resp.Kibana.Visualization {
 		if !visualization.Success {
-			if visualization.Exists {
+			if visualization.Exists || strings.Contains(visualization.Error.Message, "version conflict, document already exists") {
 				logp.Debug("machine-learning", "Visualization already exists: %s", visualization.ID)
-			} else if strings.Contains(visualization.Error.Message, "version conflict, document already exists") {
-				continue
 			} else {
 				errs = append(errs, errors.Errorf("error while setting up visualization: %s", visualization.ID))
 			}


### PR DESCRIPTION
A new end-to-end test is added to catch if the format of the error messages change for setting Machine Learning up. During development a few minor things were discovered and fixed:
* unnecessary new line after debug logs of dashboard loading
* `--setup` flags description was out of date
* more cases of already existing ML objects

Follow up of #6604 