### PR TITLE
Set namespace as default metricset in Aerospike module

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -265,6 +265,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Add support for wildcards and explicit metrics grouping in jolokia/jmx. {pull}6462[6462]
 - Set `collector` as default metricset in Prometheus module. {pull}6636[6636]
 - Set default metricsets in vSphere module. {pull}6676[6676]
+- Set `namespace` as default metricset in Aerospike module. {pull}6669[6669]
 
 *Packetbeat*
 

--- a/metricbeat/docs/modules/aerospike.asciidoc
+++ b/metricbeat/docs/modules/aerospike.asciidoc
@@ -7,7 +7,7 @@ This file is generated! See scripts/docs_collector.py
 
 beta[]
 
-The Aerospike module uses the http://www.aerospike.com/docs/reference/info[Info command] to collect metrics.
+The Aerospike module uses the http://www.aerospike.com/docs/reference/info[Info command] to collect metrics. The default metricset is `namespace`.
 
 [float]
 === Compatibility
@@ -25,9 +25,6 @@ in <<configuration-metricbeat>>. Here is an example configuration:
 ----
 metricbeat.modules:
 - module: aerospike
-  metricsets: ["namespace"]
-  enabled: false
-  period: 10s
   hosts: ["localhost:3000"]
 ----
 

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -117,7 +117,7 @@ metricbeat.modules:
 #------------------------------ Aerospike Module -----------------------------
 - module: aerospike
   metricsets: ["namespace"]
-  enabled: false
+  enabled: true
   period: 10s
   hosts: ["localhost:3000"]
 

--- a/metricbeat/module/aerospike/_meta/config.reference.yml
+++ b/metricbeat/module/aerospike/_meta/config.reference.yml
@@ -1,0 +1,5 @@
+- module: aerospike
+  metricsets: ["namespace"]
+  enabled: true
+  period: 10s
+  hosts: ["localhost:3000"]

--- a/metricbeat/module/aerospike/_meta/config.yml
+++ b/metricbeat/module/aerospike/_meta/config.yml
@@ -1,5 +1,2 @@
 - module: aerospike
-  metricsets: ["namespace"]
-  enabled: false
-  period: 10s
   hosts: ["localhost:3000"]

--- a/metricbeat/module/aerospike/_meta/docs.asciidoc
+++ b/metricbeat/module/aerospike/_meta/docs.asciidoc
@@ -1,4 +1,4 @@
-The Aerospike module uses the http://www.aerospike.com/docs/reference/info[Info command] to collect metrics.
+The Aerospike module uses the http://www.aerospike.com/docs/reference/info[Info command] to collect metrics. The default metricset is `namespace`.
 
 [float]
 === Compatibility

--- a/metricbeat/module/aerospike/namespace/namespace.go
+++ b/metricbeat/module/aerospike/namespace/namespace.go
@@ -16,9 +16,9 @@ import (
 // init registers the MetricSet with the central registry.
 // The New method will be called after the setup of the module and before starting to fetch data
 func init() {
-	if err := mb.Registry.AddMetricSet("aerospike", "namespace", New); err != nil {
-		panic(err)
-	}
+	mb.Registry.MustAddMetricSet("aerospike", "namespace", New,
+		mb.DefaultMetricSet(),
+	)
 }
 
 // MetricSet type defines all fields of the MetricSet

--- a/metricbeat/modules.d/aerospike.yml.disabled
+++ b/metricbeat/modules.d/aerospike.yml.disabled
@@ -1,5 +1,2 @@
 - module: aerospike
-  metricsets: ["namespace"]
-  enabled: false
-  period: 10s
   hosts: ["localhost:3000"]


### PR DESCRIPTION
* Remove metricset config from short config
* Document default