### PR TITLE
Set reference config as config for docs

### DIFF
--- a/metricbeat/docs/modules/aerospike.asciidoc
+++ b/metricbeat/docs/modules/aerospike.asciidoc
@@ -25,6 +25,9 @@ in <<configuration-metricbeat>>. Here is an example configuration:
 ----
 metricbeat.modules:
 - module: aerospike
+  metricsets: ["namespace"]
+  enabled: true
+  period: 10s
   hosts: ["localhost:3000"]
 ----
 

--- a/metricbeat/docs/modules/apache.asciidoc
+++ b/metricbeat/docs/modules/apache.asciidoc
@@ -33,7 +33,21 @@ in <<configuration-metricbeat>>. Here is an example configuration:
 ----
 metricbeat.modules:
 - module: apache
+  metricsets: ["status"]
+  period: 10s
+  enabled: true
+
+  # Apache hosts
   hosts: ["http://127.0.0.1"]
+
+  # Path to server status. Default server-status
+  #server_status_path: "server-status"
+
+  # Username of hosts.  Empty by default
+  #username: username
+
+  # Password of hosts. Empty by default
+  #password: password
 ----
 
 This module supports TLS connection when using `ssl` config field, as described in <<configuration-ssl>>.

--- a/metricbeat/docs/modules/ceph.asciidoc
+++ b/metricbeat/docs/modules/ceph.asciidoc
@@ -21,12 +21,10 @@ in <<configuration-metricbeat>>. Here is an example configuration:
 ----
 metricbeat.modules:
 - module: ceph
-  metricsets: ["cluster_health", "cluster_status", "monitor_health"]
+  metricsets: ["cluster_disk", "cluster_health", "monitor_health", "pool_disk", "osd_tree"]
   period: 10s
-
-- module: ceph
-  metricsets: ["cluster_disk", "osd_tree", "pool_disk"]
-  period: 1m
+  hosts: ["localhost:5000"]
+  enabled: true
 ----
 
 This module supports TLS connection when using `ssl` config field, as described in <<configuration-ssl>>.

--- a/metricbeat/docs/modules/couchbase.asciidoc
+++ b/metricbeat/docs/modules/couchbase.asciidoc
@@ -21,7 +21,10 @@ in <<configuration-metricbeat>>. Here is an example configuration:
 ----
 metricbeat.modules:
 - module: couchbase
+  metricsets: ["bucket", "cluster", "node"]
+  period: 10s
   hosts: ["localhost:8091"]
+  enabled: true
 ----
 
 This module supports TLS connection when using `ssl` config field, as described in <<configuration-ssl>>.

--- a/metricbeat/docs/modules/docker.asciidoc
+++ b/metricbeat/docs/modules/docker.asciidoc
@@ -29,10 +29,27 @@ in <<configuration-metricbeat>>. Here is an example configuration:
 ----
 metricbeat.modules:
 - module: docker
+  metricsets:
+    - "container"
+    - "cpu"
+    - "diskio"
+    - "healthcheck"
+    - "info"
+    #- "image"
+    - "memory"
+    - "network"
   hosts: ["unix:///var/run/docker.sock"]
+  period: 10s
+  enabled: true
 
   # Replace dots in labels with `_`. Set to false to keep dots
   labels.dedot: true
+
+  # To connect to Docker over TLS you must specify a client and CA certificate.
+  #ssl:
+    #certificate_authority: "/etc/pki/root/ca.pem"
+    #certificate:           "/etc/pki/client/cert.pem"
+    #key:                   "/etc/pki/client/cert.key"
 ----
 
 [float]

--- a/metricbeat/docs/modules/dropwizard.asciidoc
+++ b/metricbeat/docs/modules/dropwizard.asciidoc
@@ -21,9 +21,12 @@ in <<configuration-metricbeat>>. Here is an example configuration:
 ----
 metricbeat.modules:
 - module: dropwizard
+  metricsets: ["collector"]
+  period: 10s
   hosts: ["localhost:8080"]
   metrics_path: /metrics/metrics
   namespace: example
+  enabled: true
 ----
 
 This module supports TLS connection when using `ssl` config field, as described in <<configuration-ssl>>.

--- a/metricbeat/docs/modules/elasticsearch.asciidoc
+++ b/metricbeat/docs/modules/elasticsearch.asciidoc
@@ -22,6 +22,8 @@ in <<configuration-metricbeat>>. Here is an example configuration:
 ----
 metricbeat.modules:
 - module: elasticsearch
+  metricsets: ["node", "node_stats"]
+  period: 10s
   hosts: ["localhost:9200"]
 ----
 

--- a/metricbeat/docs/modules/etcd.asciidoc
+++ b/metricbeat/docs/modules/etcd.asciidoc
@@ -22,6 +22,8 @@ in <<configuration-metricbeat>>. Here is an example configuration:
 ----
 metricbeat.modules:
 - module: etcd
+  metricsets: ["leader", "self", "store"]
+  period: 10s
   hosts: ["localhost:2379"]
 ----
 

--- a/metricbeat/docs/modules/graphite.asciidoc
+++ b/metricbeat/docs/modules/graphite.asciidoc
@@ -22,6 +22,27 @@ in <<configuration-metricbeat>>. Here is an example configuration:
 ----
 metricbeat.modules:
 - module: graphite
+  metricsets: ["server"]
+  enabled: true
+
+  # Host address to listen on. Default localhost.
+  #host: localhost
+
+  # Listening port. Default 2003.
+  #port: 2003
+
+  # Protocol to listen on. This can be udp or tcp. Default udp.
+  #protocol: "udp"
+
+  # Receive buffer size in bytes
+  #receive_buffer_size: 1024
+
+  #templates:
+  #  - filter: "test.*.bash.*" # This would match metrics like test.localhost.bash.stats
+  #    namespace: "test"
+  #    template: ".host.shell.metric*" # test.localhost.bash.stats would become metric=stats and tags host=localhost,shell=bash
+  #    delimiter: "_"
+
 ----
 
 [float]

--- a/metricbeat/docs/modules/haproxy.asciidoc
+++ b/metricbeat/docs/modules/haproxy.asciidoc
@@ -56,7 +56,10 @@ in <<configuration-metricbeat>>. Here is an example configuration:
 ----
 metricbeat.modules:
 - module: haproxy
+  metricsets: ["info", "stat"]
+  period: 10s
   hosts: ["tcp://127.0.0.1:14567"]
+  enabled: true
 ----
 
 [float]

--- a/metricbeat/docs/modules/kafka.asciidoc
+++ b/metricbeat/docs/modules/kafka.asciidoc
@@ -22,7 +22,31 @@ in <<configuration-metricbeat>>. Here is an example configuration:
 ----
 metricbeat.modules:
 - module: kafka
+  metricsets: ["consumergroup", "partition"]
+  period: 10s
   hosts: ["localhost:9092"]
+  enabled: true
+
+  #client_id: metricbeat
+  #retries: 3
+  #backoff: 250ms
+
+  # List of Topics to query metadata for. If empty, all topics will be queried.
+  #topics: []
+
+  # Optional SSL. By default is off.
+  # List of root certificates for HTTPS server verifications
+  #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
+
+  # Certificate for SSL client authentication
+  #ssl.certificate: "/etc/pki/client/cert.pem"
+
+  # Client Certificate Key
+  #ssl.key: "/etc/pki/client/cert.key"
+
+  # SASL authentication
+  #username: ""
+  #password: ""
 ----
 
 [float]

--- a/metricbeat/docs/modules/kibana.asciidoc
+++ b/metricbeat/docs/modules/kibana.asciidoc
@@ -22,7 +22,10 @@ in <<configuration-metricbeat>>. Here is an example configuration:
 ----
 metricbeat.modules:
 - module: kibana
+  metricsets: ["status"]
+  period: 10s
   hosts: ["localhost:5601"]
+  enabled: default
 ----
 
 This module supports TLS connection when using `ssl` config field, as described in <<configuration-ssl>>.

--- a/metricbeat/docs/modules/kubernetes.asciidoc
+++ b/metricbeat/docs/modules/kubernetes.asciidoc
@@ -24,6 +24,7 @@ in <<configuration-metricbeat>>. Here is an example configuration:
 [source,yaml]
 ----
 metricbeat.modules:
+# Node metrics, from kubelet:
 - module: kubernetes
   metricsets:
     - container
@@ -31,7 +32,31 @@ metricbeat.modules:
     - pod
     - system
     - volume
+  period: 10s
   hosts: ["localhost:10255"]
+  enabled: true
+  #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
+  #ssl.certificate: "/etc/pki/client/cert.pem"
+  #ssl.key: "/etc/pki/client/cert.key"
+
+# State metrics from kube-state-metrics service:
+- module: kubernetes
+  enabled: true
+  metricsets:
+    - state_node
+    - state_deployment
+    - state_replicaset
+    - state_statefulset
+    - state_pod
+    - state_container
+  period: 10s
+  hosts: ["kube-state-metrics:8080"]
+
+# Kubernetes events
+- module: kubernetes
+  enabled: true
+  metricsets:
+    - event
 ----
 
 This module supports TLS connection when using `ssl` config field, as described in <<configuration-ssl>>.

--- a/metricbeat/docs/modules/logstash.asciidoc
+++ b/metricbeat/docs/modules/logstash.asciidoc
@@ -22,6 +22,9 @@ in <<configuration-metricbeat>>. Here is an example configuration:
 ----
 metricbeat.modules:
 - module: logstash
+  metricsets: ["node", "node_stats"]
+  enabled: true
+  period: 10s
   hosts: ["localhost:9600"]
 ----
 

--- a/metricbeat/docs/modules/memcached.asciidoc
+++ b/metricbeat/docs/modules/memcached.asciidoc
@@ -22,7 +22,10 @@ in <<configuration-metricbeat>>. Here is an example configuration:
 ----
 metricbeat.modules:
 - module: memcached
+  metricsets: ["stats"]
+  period: 10s
   hosts: ["localhost:11211"]
+  enabled: true
 ----
 
 [float]

--- a/metricbeat/docs/modules/mongodb.asciidoc
+++ b/metricbeat/docs/modules/mongodb.asciidoc
@@ -66,7 +66,22 @@ in <<configuration-metricbeat>>. Here is an example configuration:
 ----
 metricbeat.modules:
 - module: mongodb
+  metricsets: ["dbstats", "status"]
+  period: 10s
+  enabled: true
+
+  # The hosts must be passed as MongoDB URLs in the format:
+  # [mongodb://][user:pass@]host[:port].
+  # The username and password can also be set using the respective configuration
+  # options. The credentials in the URL take precedence over the username and
+  # password configuration options.
   hosts: ["localhost:27017"]
+
+  # Username to use when connecting to MongoDB. Empty by default.
+  #username: user
+
+  # Password to use when connecting to MongoDB. Empty by default.
+  #password: pass
 ----
 
 [float]

--- a/metricbeat/docs/modules/munin.asciidoc
+++ b/metricbeat/docs/modules/munin.asciidoc
@@ -24,6 +24,9 @@ in <<configuration-metricbeat>>. Here is an example configuration:
 ----
 metricbeat.modules:
 - module: munin
+  metricsets: ["node"]
+  enabled: true
+  period: 10s
   hosts: ["localhost:4949"]
   node.namespace: node
 ----

--- a/metricbeat/docs/modules/mysql.asciidoc
+++ b/metricbeat/docs/modules/mysql.asciidoc
@@ -56,7 +56,22 @@ in <<configuration-metricbeat>>. Here is an example configuration:
 ----
 metricbeat.modules:
 - module: mysql
-  hosts: ["tcp(127.0.0.1:3306)/"]
+  metricsets: ["status"]
+  period: 10s
+
+  # Host DSN should be defined as "user:pass@tcp(127.0.0.1:3306)/"
+  # The username and password can either be set in the DSN or using the username
+  # and password config options. Those specified in the DSN take precedence.
+  hosts: ["root:secret@tcp(127.0.0.1:3306)/"]
+
+  # Username of hosts. Empty by default.
+  #username: root
+
+  # Password of hosts. Empty by default.
+  #password: secret
+
+  # By setting raw to true, all raw fields from the status metricset will be added to the event.
+  #raw: false
 ----
 
 [float]

--- a/metricbeat/docs/modules/nginx.asciidoc
+++ b/metricbeat/docs/modules/nginx.asciidoc
@@ -34,7 +34,15 @@ in <<configuration-metricbeat>>. Here is an example configuration:
 ----
 metricbeat.modules:
 - module: nginx
+  metricsets: ["stubstatus"]
+  enabled: true
+  period: 10s
+
+  # Nginx hosts
   hosts: ["http://127.0.0.1"]
+
+  # Path to server status. Default server-status
+  server_status_path: "server-status"
 ----
 
 This module supports TLS connection when using `ssl` config field, as described in <<configuration-ssl>>.

--- a/metricbeat/docs/modules/php_fpm.asciidoc
+++ b/metricbeat/docs/modules/php_fpm.asciidoc
@@ -50,6 +50,10 @@ in <<configuration-metricbeat>>. Here is an example configuration:
 ----
 metricbeat.modules:
 - module: php_fpm
+  metricsets: ["pool"]
+  enabled: true
+  period: 10s
+  status_path: "/status"
   hosts: ["localhost:8080"]
 ----
 

--- a/metricbeat/docs/modules/postgresql.asciidoc
+++ b/metricbeat/docs/modules/postgresql.asciidoc
@@ -66,7 +66,30 @@ in <<configuration-metricbeat>>. Here is an example configuration:
 ----
 metricbeat.modules:
 - module: postgresql
+  enabled: true
+  metricsets:
+    # Stats about every PostgreSQL database
+    - database
+
+    # Stats about the background writer process's activity
+    - bgwriter
+
+    # Stats about every PostgreSQL process
+    - activity
+
+  period: 10s
+
+  # The host must be passed as PostgreSQL URL. Example:
+  # postgres://localhost:5432?sslmode=disable
+  # The available parameters are documented here:
+  # https://godoc.org/github.com/lib/pq#hdr-Connection_String_Parameters
   hosts: ["postgres://localhost:5432"]
+
+  # Username to use when connecting to PostgreSQL. Empty by default.
+  #username: user
+
+  # Password to use when connecting to PostgreSQL. Empty by default.
+  #password: pass
 ----
 
 [float]

--- a/metricbeat/docs/modules/prometheus.asciidoc
+++ b/metricbeat/docs/modules/prometheus.asciidoc
@@ -23,8 +23,19 @@ in <<configuration-metricbeat>>. Here is an example configuration:
 ----
 metricbeat.modules:
 - module: prometheus
+  metricsets: ["stats"]
+  enabled: true
   period: 10s
   hosts: ["localhost:9090"]
+  #metrics_path: /metrics
+  #namespace: example
+
+- module: prometheus
+  metricsets: ["collector"]
+  enabled: true
+  period: 10s
+  hosts: ["localhost:9090"]
+  #metrics_path: /metrics
   #namespace: example
 ----
 

--- a/metricbeat/docs/modules/rabbitmq.asciidoc
+++ b/metricbeat/docs/modules/rabbitmq.asciidoc
@@ -22,7 +22,13 @@ in <<configuration-metricbeat>>. Here is an example configuration:
 ----
 metricbeat.modules:
 - module: rabbitmq
+  metricsets: ["node", "queue", "connection"]
+  enabled: true
+  period: 10s
   hosts: ["localhost:15672"]
+
+  #username: guest
+  #password: guest
 ----
 
 This module supports TLS connection when using `ssl` config field, as described in <<configuration-ssl>>.

--- a/metricbeat/docs/modules/redis.asciidoc
+++ b/metricbeat/docs/modules/redis.asciidoc
@@ -43,7 +43,35 @@ in <<configuration-metricbeat>>. Here is an example configuration:
 ----
 metricbeat.modules:
 - module: redis
+  metricsets: ["info", "keyspace"]
+  enabled: true
+  period: 10s
+
+  # Redis hosts
   hosts: ["127.0.0.1:6379"]
+
+  # Timeout after which time a metricset should return an error
+  # Timeout is by default defined as period, as a fetch of a metricset
+  # should never take longer then period, as otherwise calls can pile up.
+  #timeout: 1s
+
+  # Optional fields to be added to each event
+  #fields:
+  #  datacenter: west
+
+  # Network type to be used for redis connection. Default: tcp
+  #network: tcp
+
+  # Max number of concurrent connections. Default: 10
+  #maxconn: 10
+
+  # Filters can be used to reduce the number of fields sent.
+  #processors:
+  #  - include_fields:
+  #      fields: ["beat", "metricset", "redis.info.stats"]
+
+  # Redis AUTH password. Empty by default.
+  #password: foobared
 ----
 
 [float]

--- a/metricbeat/docs/modules/system.asciidoc
+++ b/metricbeat/docs/modules/system.asciidoc
@@ -29,35 +29,74 @@ in <<configuration-metricbeat>>. Here is an example configuration:
 ----
 metricbeat.modules:
 - module: system
-  process.include_top_n:
-    by_cpu: 5      # include top 5 processes by CPU
-    by_memory: 5   # include top 5 processes by memory
-
-#- module: system
-#  metricsets:
-#    - core
-#    - diskio
-#    - socket
-
-- module: system
-  period: 1m
   metricsets:
-    - filesystem
-    - fsstat
-  processors:
-  - drop_event.when.regexp:
-      system.filesystem.mount_point: '^/(sys|cgroup|proc|dev|etc|host|lib)($|/)'
+    - cpu             # CPU usage
+    - filesystem      # File system usage for each mountpoint
+    - fsstat          # File system summary metrics
+    - load            # CPU load averages
+    - memory          # Memory usage
+    - network         # Network IO
+    - process         # Per process metrics
+    - process_summary # Process summary
+    - uptime          # System Uptime
+    #- core           # Per CPU core usage
+    #- diskio         # Disk IO
+    #- raid           # Raid
+    #- socket         # Sockets and connection info (linux only)
+  enabled: true
+  period: 10s
+  processes: ['.*']
 
-- module: system
-  period: 15m
-  metricsets:
-    - uptime
+  # Configure the metric types that are included by these metricsets.
+  cpu.metrics:  ["percentages"]  # The other available options are normalized_percentages and ticks.
+  core.metrics: ["percentages"]  # The other available option is ticks.
 
-#- module: system
-#  period: 5m
-#  metricsets:
-#    - raid
-#  raid.mount_point: '/'
+  # A list of filesystem types to ignore. The filesystem metricset will not
+  # collect data from filesystems matching any of the specified types, and
+  # fsstats will not include data from these filesystems in its summary stats.
+  #filesystem.ignore_types: []
+
+  # These options allow you to filter out all processes that are not
+  # in the top N by CPU or memory, in order to reduce the number of documents created.
+  # If both the `by_cpu` and `by_memory` options are used, the union of the two sets
+  # is included.
+  #process.include_top_n:
+
+    # Set to false to disable this feature and include all processes
+    #enabled: true
+
+    # How many processes to include from the top by CPU. The processes are sorted
+    # by the `system.process.cpu.total.pct` field.
+    #by_cpu: 0
+
+    # How many processes to include from the top by memory. The processes are sorted
+    # by the `system.process.memory.rss.bytes` field.
+    #by_memory: 0
+
+  # If false, cmdline of a process is not cached.
+  #process.cmdline.cache.enabled: true
+
+  # Enable collection of cgroup metrics from processes on Linux.
+  #process.cgroups.enabled: true
+
+  # A list of regular expressions used to whitelist environment variables
+  # reported with the process metricset's events. Defaults to empty.
+  #process.env.whitelist: []
+
+  # Include the cumulative CPU tick values with the process metrics. Defaults
+  # to false.
+  #process.include_cpu_ticks: false
+
+  # Raid mount point to monitor
+  #raid.mount_point: '/'
+
+  # Configure reverse DNS lookup on remote IP addresses in the socket metricset.
+  #socket.reverse_lookup.enabled: false
+  #socket.reverse_lookup.success_ttl: 60s
+  #socket.reverse_lookup.failure_ttl: 60s
+
+  # Diskio configurations
+  #diskio.include_devices: []
 ----
 
 [float]

--- a/metricbeat/docs/modules/uwsgi.asciidoc
+++ b/metricbeat/docs/modules/uwsgi.asciidoc
@@ -39,6 +39,9 @@ in <<configuration-metricbeat>>. Here is an example configuration:
 ----
 metricbeat.modules:
 - module: uwsgi
+  metricsets: ["status"]
+  enable: true
+  period: 10s
   hosts: ["tcp://127.0.0.1:9191"]
 ----
 

--- a/metricbeat/docs/modules/vsphere.asciidoc
+++ b/metricbeat/docs/modules/vsphere.asciidoc
@@ -22,6 +22,8 @@ in <<configuration-metricbeat>>. Here is an example configuration:
 ----
 metricbeat.modules:
 - module: vsphere
+  enabled: true
+  metricsets: ["datastore", "host", "virtualmachine"]
   period: 10s
   hosts: ["https://localhost/sdk"]
 
@@ -31,7 +33,6 @@ metricbeat.modules:
   insecure: false
   # Get custom fields when using virtualmachine metric set. Default false.
   # get_custom_fields: false
-  
 ----
 
 [float]

--- a/metricbeat/docs/modules/windows.asciidoc
+++ b/metricbeat/docs/modules/windows.asciidoc
@@ -21,6 +21,19 @@ in <<configuration-metricbeat>>. Here is an example configuration:
 ----
 metricbeat.modules:
 - module: windows
+  metricsets: ["perfmon"]
+  enabled: true
+  period: 10s
+  perfmon.ignore_non_existent_counters: true
+  perfmon.counters:
+  #  - instance_label: processor.name
+  #    instance_name: total
+  #    measurement_label: processor.time.total.pct
+  #    query: '\Processor Information(_Total)\% Processor Time'
+
+- module: windows
+  metricsets: ["service"]
+  enabled: true
   period: 60s
 ----
 

--- a/metricbeat/docs/modules/zookeeper.asciidoc
+++ b/metricbeat/docs/modules/zookeeper.asciidoc
@@ -25,6 +25,8 @@ in <<configuration-metricbeat>>. Here is an example configuration:
 ----
 metricbeat.modules:
 - module: zookeeper
+  enabled: true
+  metricsets: ["mntr"]
   period: 10s
   hosts: ["localhost:2181"]
 ----

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -81,7 +81,7 @@ metricbeat.modules:
   # If both the `by_cpu` and `by_memory` options are used, the union of the two sets
   # is included.
   #process.include_top_n:
-    #
+
     # Set to false to disable this feature and include all processes
     #enabled: true
 

--- a/metricbeat/module/system/_meta/config.reference.yml
+++ b/metricbeat/module/system/_meta/config.reference.yml
@@ -31,7 +31,7 @@
   # If both the `by_cpu` and `by_memory` options are used, the union of the two sets
   # is included.
   #process.include_top_n:
-    #
+
     # Set to false to disable this feature and include all processes
     #enabled: true
 

--- a/metricbeat/scripts/docs_collector.py
+++ b/metricbeat/scripts/docs_collector.py
@@ -59,7 +59,10 @@ This file is generated! See scripts/docs_collector.py
         modules_list[module]["dashboards"] = os.path.exists(module_meta_path + "/kibana")
         modules_list[module]["metricsets"] = {}
 
-        config_file = module_meta_path + "/config.yml"
+        config_file = module_meta_path + "/config.reference.yml"
+
+        if os.path.isfile(config_file) == False:
+            config_file = module_meta_path + "/config.yml"
 
         # Add example config file
         if os.path.isfile(config_file) == True:


### PR DESCRIPTION
Having the reference file as example config in the docs has the advantage that all config options are shown.