### PR TITLE
Set `status` as default metricset in Apache module

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -265,6 +265,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Add support for wildcards and explicit metrics grouping in jolokia/jmx. {pull}6462[6462]
 - Set `collector` as default metricset in Prometheus module. {pull}6636[6636]
 - Set default metricsets in vSphere module. {pull}6676[6676]
+- Set `status` as default metricset in Apache module. {pull}[]
 
 *Packetbeat*
 

--- a/metricbeat/docs/modules/apache.asciidoc
+++ b/metricbeat/docs/modules/apache.asciidoc
@@ -6,7 +6,7 @@ This file is generated! See scripts/docs_collector.py
 == Apache module
 
 This module periodically fetches metrics from https://httpd.apache.org/[Apache
-HTTPD] servers.
+HTTPD] servers. The default metricset is `status`.
 
 [float]
 === Compatibility
@@ -33,10 +33,6 @@ in <<configuration-metricbeat>>. Here is an example configuration:
 ----
 metricbeat.modules:
 - module: apache
-  metricsets: ["status"]
-  period: 10s
-
-  # Apache hosts
   hosts: ["http://127.0.0.1"]
 ----
 

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -125,6 +125,7 @@ metricbeat.modules:
 - module: apache
   metricsets: ["status"]
   period: 10s
+  enabled: true
 
   # Apache hosts
   hosts: ["http://127.0.0.1"]

--- a/metricbeat/module/apache/_meta/config.reference.yml
+++ b/metricbeat/module/apache/_meta/config.reference.yml
@@ -1,6 +1,7 @@
 - module: apache
   metricsets: ["status"]
   period: 10s
+  enabled: true
 
   # Apache hosts
   hosts: ["http://127.0.0.1"]

--- a/metricbeat/module/apache/_meta/config.yml
+++ b/metricbeat/module/apache/_meta/config.yml
@@ -1,6 +1,2 @@
 - module: apache
-  metricsets: ["status"]
-  period: 10s
-
-  # Apache hosts
   hosts: ["http://127.0.0.1"]

--- a/metricbeat/module/apache/_meta/docs.asciidoc
+++ b/metricbeat/module/apache/_meta/docs.asciidoc
@@ -1,5 +1,5 @@
 This module periodically fetches metrics from https://httpd.apache.org/[Apache
-HTTPD] servers.
+HTTPD] servers. The default metricset is `status`.
 
 [float]
 === Compatibility

--- a/metricbeat/module/apache/status/status.go
+++ b/metricbeat/module/apache/status/status.go
@@ -35,9 +35,10 @@ var (
 )
 
 func init() {
-	if err := mb.Registry.AddMetricSet("apache", "status", New, hostParser); err != nil {
-		panic(err)
-	}
+	mb.Registry.MustAddMetricSet("apache", "status", New,
+		mb.WithHostParser(hostParser),
+		mb.DefaultMetricSet(),
+	)
 }
 
 // MetricSet for fetching Apache HTTPD server status.

--- a/metricbeat/modules.d/apache.yml.disabled
+++ b/metricbeat/modules.d/apache.yml.disabled
@@ -1,6 +1,2 @@
 - module: apache
-  metricsets: ["status"]
-  period: 10s
-
-  # Apache hosts
   hosts: ["http://127.0.0.1"]


### PR DESCRIPTION
The metricset config was removed from the short config as there is only 1 metricset anyway. No need for the user to configure this.