### PR TITLE
Pass cacert file with the correct type to the elasticsearch loader

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -28,6 +28,8 @@ https://github.com/elastic/beats/compare/v5.6.8...5.6[Check the HEAD diff]
 
 *Affecting all Beats*
 
+- Fix a type issue when specifying certicate authority when using the `import_dashboards` command. {pull}6678[6678]
+
 *Filebeat*
 
 *Heartbeat*

--- a/libbeat/dashboards/import_dashboards.go
+++ b/libbeat/dashboards/import_dashboards.go
@@ -167,7 +167,7 @@ func ImportDashboards() error {
 	}
 
 	if len(cl.opt.CertificateAuthority) > 0 {
-		tlsConfig["certificate_authorities"] = fmt.Sprintf("[%s]", cl.opt.CertificateAuthority)
+		tlsConfig["certificate_authorities"] = []string{cl.opt.CertificateAuthority}
 	}
 
 	if len(tlsConfig) > 0 {

--- a/metricbeat/module/prometheus/_meta/Dockerfile
+++ b/metricbeat/module/prometheus/_meta/Dockerfile
@@ -1,3 +1,3 @@
-FROM  prom/prometheus
-
+FROM prom/prometheus:v1.5.1
+HEALTHCHECK --interval=1s --retries=90 CMD nc -w 1 localhost 9090 </dev/null
 EXPOSE 9090

--- a/testing/environments/args.yml
+++ b/testing/environments/args.yml
@@ -6,4 +6,4 @@ services:
     build:
       args:
         DOWNLOAD_URL: https://snapshots.elastic.co/downloads
-        ELASTIC_VERSION: 5.6.8-SNAPSHOT
+        ELASTIC_VERSION: 5.6.9-SNAPSHOT

--- a/testing/environments/latest.yml
+++ b/testing/environments/latest.yml
@@ -17,7 +17,7 @@ services:
       context: docker/logstash
       dockerfile: Dockerfile
       args:
-        ELASTIC_VERSION: 5.4.1
+        ELASTIC_VERSION: 5.6.8
         DOWNLOAD_URL: https://artifacts.elastic.co/downloads
     environment:
       - ES_HOST=elasticsearch


### PR DESCRIPTION
We were sending the cacert as `[/tmp/cacert]` instead of
[]string{"/tmp/cacert"} making the Elasticsearch loader crash with a
file not found.