### PR TITLE
Cherry-pick #6567 to 6.2: Fix config reload example

### DIFF
--- a/auditbeat/docs/reload-configuration.asciidoc
+++ b/auditbeat/docs/reload-configuration.asciidoc
@@ -5,8 +5,8 @@ beta[]
 
 You can configure {beatname_uc} to dynamically reload configuration files when
 there are changes. To do this, you specify a path
-(https://golang.org/pkg/path/filepath/#Glob[Glob]) to watch for module
-configuration changes. When the files found by the Glob change, new modules are
+(https://golang.org/pkg/path/filepath/#Glob[glob]) to watch for module
+configuration changes. When the files found by the glob change, new modules are
 started/stopped according to changes in the configuration files.
 
 To enable dynamic config reloading, you specify the `path` and `reload` options
@@ -20,7 +20,7 @@ auditbeat.config.modules:
   reload.period: 10s
 ------------------------------------------------------------------------------
 
-*`path`*:: A Glob that defines the files to check for changes.
+*`path`*:: A glob that defines the files to check for changes.
 
 *`reload.enabled`*:: When set to `true`, enables dynamic config reload.
 
@@ -29,13 +29,11 @@ set the `period` to less than 1s because the modification time of files is often
 stored in seconds. Setting the `period` to less than 1s will result in
 unnecessary overhead.
 
-Each file found by the Glob must contain a list of one or more module
+Each file found by the glob must contain a list of one or more module
 definitions. For example:
 
 [source,yaml]
 ------------------------------------------------------------------------------
-auditbeat.modules:
-
 - module: file_integrity
   paths:
   - /www/wordpress


### PR DESCRIPTION
Cherry-pick of PR #6567 to 6.2 branch. Original message: 

Remove `auditbeat.modules:` from config reload example file. And change Glob to glob.