### PR TITLE
Workaround for bug in virtualenv tool on (at least) Amazon Linux.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,6 +153,7 @@ notice: python-env
 python-env:
 	@test -d $(PYTHON_ENV) || virtualenv $(VIRTUALENV_PARAMS) $(PYTHON_ENV)
 	@$(PYTHON_ENV)/bin/pip install -q --upgrade pip autopep8 six
+	# Work around pip bug. See: https://github.com/pypa/pip/issues/4464
 	@find $(PYTHON_ENV) -type d -name dist-packages -exec sh -c "echo dist-packages > {}.pth" ';'
 
 # Tests if apm works with the current code

--- a/Makefile
+++ b/Makefile
@@ -153,6 +153,7 @@ notice: python-env
 python-env:
 	@test -d $(PYTHON_ENV) || virtualenv $(VIRTUALENV_PARAMS) $(PYTHON_ENV)
 	@$(PYTHON_ENV)/bin/pip install -q --upgrade pip autopep8 six
+	@find $(PYTHON_ENV) -type d -name dist-packages -exec sh -c "echo dist-packages > {}.pth" ';'
 
 # Tests if apm works with the current code
 .PHONY: test-apm

--- a/generator/common/Makefile
+++ b/generator/common/Makefile
@@ -44,6 +44,7 @@ test-build: test
 python-env:
 	@test -d ${PYTHON_ENV} || virtualenv ${PYTHON_ENV}
 	@${PYTHON_ENV}/bin/pip install --upgrade pip PyYAML
+	# Work around pip bug. See: https://github.com/pypa/pip/issues/4464
 	@find $(PYTHON_ENV) -type d -name dist-packages -exec sh -c "echo dist-packages > {}.pth" ';'
 
 # Cleans up environment

--- a/generator/common/Makefile
+++ b/generator/common/Makefile
@@ -44,6 +44,7 @@ test-build: test
 python-env:
 	@test -d ${PYTHON_ENV} || virtualenv ${PYTHON_ENV}
 	@${PYTHON_ENV}/bin/pip install --upgrade pip PyYAML
+	@find $(PYTHON_ENV) -type d -name dist-packages -exec sh -c "echo dist-packages > {}.pth" ';'
 
 # Cleans up environment
 .PHONY: clean

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -230,7 +230,7 @@ python-env: ${ES_BEATS}/libbeat/tests/system/requirements.txt
 	else \
 		. ${PYTHON_ENV}/bin/activate && pip install ${PIP_INSTALL_PARAMS} -qUr ${ES_BEATS}/libbeat/tests/system/requirements.txt ; \
 	fi
-
+	find ${PYTHON_ENV} -type d -name 'dist-packages' -exec sh -c "echo dist-packages > {}.pth" ';'
 
 .PHONY: test
 test: ## @testing Runs unit and system tests without coverage reports
@@ -261,8 +261,8 @@ testsuite: clean update
 	# Runs system and system integration tests if SYSTEM_TESTS is set to true
 	if [ $(SYSTEM_TESTS) = true ]; then \
 		if [ $(TEST_ENVIRONMENT) = true ]; then \
-        	$(MAKE) system-tests-environment; \
-    	else \
+			$(MAKE) system-tests-environment; \
+		else \
 			$(MAKE) system-tests; \
 		fi \
 	fi

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -230,6 +230,7 @@ python-env: ${ES_BEATS}/libbeat/tests/system/requirements.txt
 	else \
 		. ${PYTHON_ENV}/bin/activate && pip install ${PIP_INSTALL_PARAMS} -qUr ${ES_BEATS}/libbeat/tests/system/requirements.txt ; \
 	fi
+	# Work around pip bug. See: https://github.com/pypa/pip/issues/4464
 	find ${PYTHON_ENV} -type d -name 'dist-packages' -exec sh -c "echo dist-packages > {}.pth" ';'
 
 .PHONY: test


### PR DESCRIPTION
On (at least) Amazon Linux, the [virtualenv](https://virtualenv.pypa.io/en/stable/) tool configures python with the following `sys.path` directories:

- `''`
- `'${PYTHON_ENV}/local/lib64/python2.7/site-packages'`
- `'${PYTHON_ENV}/local/lib/python2.7/site-packages'`
- `'${PYTHON_ENV}/lib64/python2.7'`
- `'${PYTHON_ENV}/lib/python2.7'`
- `'${PYTHON_ENV}/lib64/python2.7/site-packages'`
- `'${PYTHON_ENV}/lib/python2.7/site-packages'`
- `'${PYTHON_ENV}/lib64/python2.7/lib-dynload'`
- `'${PYTHON_ENV}/local/lib/python2.7/dist-packages'`
- `'${PYTHON_ENV}/local/lib/python2.7/dist-packages'`
- `'${PYTHON_ENV}/lib/python2.7/dist-packages'`
- `'/usr/lib64/python2.7'`
- `'/usr/lib/python2.7'`

However, running `pip install PyYAML` in that same virtualenv will install the `yaml` module in the `${PYTHON_ENV}/lib64/python2.7/dist-packages` directory, which is not on the search path.

As a work-around, this patch adds `dist-packages` directories to the search path by creating `dist-packages.pth` files.

I am open to alternative suggestions.

I have opened issue #6699 and topic [#126126](https://discuss.elastic.co/t/jenkins-build-fails-on-at-least-amazon-linux/126126) for discussion.