### PR TITLE
Cherry-pick #6165 to 6.2: Add a dev-tools/set_docs_version script

### DIFF
--- a/dev-tools/packer/version.yml
+++ b/dev-tools/packer/version.yml
@@ -1,1 +1,1 @@
-version: "6.2.3"
+version: "6.2.4"

--- a/dev-tools/set_docs_version
+++ b/dev-tools/set_docs_version
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+import argparse
+from subprocess import check_call
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Used to set the current docs version. Doesn't commit changes.")
+    parser.add_argument("version",
+                        help="The new docs version")
+    args = parser.parse_args()
+    version = args.version
+
+    # make sure we have no dirty files in this branch (might throw off `make update`)
+    check_call("git clean -dfx", shell=True)
+
+    # edit the file
+    with open("libbeat/docs/version.asciidoc", "r") as f:
+        lines = f.readlines()
+    for i, line in enumerate(lines):
+        if line.startswith(":stack-version:"):
+            lines[i] = ":stack-version: {}\n".format(version)
+    with open("libbeat/docs/version.asciidoc", "w") as f:
+        f.writelines(lines)
+
+    check_call("make update", shell=True)
+
+if __name__ == "__main__":
+    main()

--- a/libbeat/version/version.go
+++ b/libbeat/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const defaultBeatVersion = "6.2.3"
+const defaultBeatVersion = "6.2.4"

--- a/packetbeat/docs/fields.asciidoc
+++ b/packetbeat/docs/fields.asciidoc
@@ -2926,13 +2926,6 @@ The algorithm used for this certificate's public key. One of RSA, DSA or ECDSA.
 
 
 [float]
-=== `tls.client_certificate.public_key_size`
-
-type: long
-
-Size of the public key.
-
-[float]
 === `tls.client_certificate.signature_algorithm`
 
 type: keyword
@@ -3079,13 +3072,6 @@ The algorithm used for this certificate's public key. One of RSA, DSA or ECDSA.
 
 
 [float]
-=== `tls.server_certificate.public_key_size`
-
-type: long
-
-Size of the public key.
-
-[float]
 === `tls.server_certificate.signature_algorithm`
 
 type: keyword
@@ -3209,34 +3195,6 @@ Chain of trust for the client certificate.
 type: keyword
 
 An array containing the TLS alert type for every alert received.
-
-
-[float]
-== fingerprints fields
-
-Fingerprints for this TLS session.
-
-
-[float]
-== ja3 fields
-
-JA3 TLS client fingerprint
-
-
-[float]
-=== `tls.fingerprints.ja3.hash`
-
-type: keyword
-
-The JA3 fingerprint hash for the client side.
-
-
-[float]
-=== `tls.fingerprints.ja3.str`
-
-type: keyword
-
-The JA3 string used to calculate the hash.
 
 
 [[exported-fields-trans_event]]


### PR DESCRIPTION
Cherry-pick of PR #6165 to 6.2 branch. Original message: 

Similar to the `dev-toosl/set_version` script. At the moment, it
edits the `version.asciidoc` file and runs `make update`.