### PR TITLE
Cherry-pick #6165 to 6.2: Add a dev-tools/set_docs_version script

### DIFF
--- a/dev-tools/set_docs_version
+++ b/dev-tools/set_docs_version
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+import argparse
+from subprocess import check_call
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Used to set the current docs version. Doesn't commit changes.")
+    parser.add_argument("version",
+                        help="The new docs version")
+    args = parser.parse_args()
+    version = args.version
+
+    # make sure we have no dirty files in this branch (might throw off `make update`)
+    check_call("git clean -dfx", shell=True)
+
+    # edit the file
+    with open("libbeat/docs/version.asciidoc", "r") as f:
+        lines = f.readlines()
+    for i, line in enumerate(lines):
+        if line.startswith(":stack-version:"):
+            lines[i] = ":stack-version: {}\n".format(version)
+    with open("libbeat/docs/version.asciidoc", "w") as f:
+        f.writelines(lines)
+
+    check_call("make update", shell=True)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Cherry-pick of PR #6165 to 6.2 branch. Original message: 

Similar to the `dev-toosl/set_version` script. At the moment, it
edits the `version.asciidoc` file and runs `make update`.