### PR TITLE
Make cherrypick_pr and open_pr scripts add version labels

### DIFF
--- a/dev-tools/cherrypick_pr
+++ b/dev-tools/cherrypick_pr
@@ -2,6 +2,7 @@
 """Cherry pick and backport a PR"""
 
 import sys
+import os
 import argparse
 from os.path import expanduser
 import re
@@ -148,8 +149,22 @@ def main():
         # remove needs backport label from the original PR
         session.delete(base + "/issues/{}/labels/needs_backport".format(args.pr_number))
 
+        # get version and set a version label on the original PR
+        version = get_version(os.getcwd())
+        if version:
+            session.post(
+                base + "/issues/{}/labels".format(args.pr_number), json=["v" + version])
+
         print("\nDone. PR created: {}".format(new_pr["html_url"]))
         print("Please go and check it and add the review tags")
+
+def get_version(beats_dir):
+    pattern = re.compile(r'(const\s|)\w*(v|V)ersion\s=\s"(?P<version>.*)"')
+    with open(os.path.join(beats_dir, "libbeat/version/version.go"), "r") as f:
+        for line in f:
+            match = pattern.match(line)
+            if match:
+                return match.group('version')
 
 
 if __name__ == "__main__":

--- a/dev-tools/open_pr
+++ b/dev-tools/open_pr
@@ -2,6 +2,7 @@
 """Open a PR from the current branch"""
 
 import sys
+import os
 import argparse
 import requests
 import re
@@ -54,6 +55,11 @@ def main():
     if args.wip:
         lables += "in progress"
 
+    # get version and set a version label on the original PR
+    version = get_version(os.getcwd())
+    if version:
+        labels.append("v" + version)
+
     print("Branch: {}".format(args.branch))
     print("Remote: {}".format(args.remote))
     print("Local branch: {}".format(local_branch))
@@ -96,6 +102,15 @@ def main():
 
     print("\nDone. PR created: {}".format(new_pr["html_url"]))
     print("Please go and review it for the message and labels.")
+
+
+def get_version(beats_dir):
+    pattern = re.compile(r'(const\s|)\w*(v|V)ersion\s=\s"(?P<version>.*)"')
+    with open(os.path.join(beats_dir, "libbeat/version/version.go"), "r") as f:
+        for line in f:
+            match = pattern.match(line)
+            if match:
+                return match.group('version')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When cherry-picking, automatically reads the version from the target branch
and adds it as a label to the original PR.

When opening a new PR, automatically add the version label.