### PR TITLE
Move Logstash node_stats under node.stats

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -73,6 +73,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Support apache status pages for versions older than 2.4.16. {pull}6450[6450]
 - Add support for huge pages on Linux. {pull}6436[6436]
 - Refactor docker CPU calculations to be more consistent with `docker stats`. {pull}6608[6608]
+- Update logstash.node_stats metricset to write data under `logstash.node.stats.*`. {pull}[]
 
 *Packetbeat*
 

--- a/metricbeat/docs/fields.asciidoc
+++ b/metricbeat/docs/fields.asciidoc
@@ -6512,7 +6512,7 @@ Pid
 
 
 [float]
-== node_stats fields
+== node.stats fields
 
 node_stats metrics.
 
@@ -6526,7 +6526,7 @@ Events stats
 
 
 [float]
-=== `logstash.node_stats.events.in`
+=== `logstash.node.stats.events.in`
 
 type: long
 
@@ -6534,7 +6534,7 @@ Incoming events counter.
 
 
 [float]
-=== `logstash.node_stats.events.out`
+=== `logstash.node.stats.events.out`
 
 type: long
 
@@ -6542,7 +6542,7 @@ Outgoing events counter.
 
 
 [float]
-=== `logstash.node_stats.events.filtered`
+=== `logstash.node.stats.events.filtered`
 
 type: long
 

--- a/metricbeat/mb/testing/data_generator.go
+++ b/metricbeat/mb/testing/data_generator.go
@@ -78,9 +78,11 @@ func StandardizeEvent(ms mb.MetricSet, e mb.Event, modifiers ...mb.EventModifier
 	}
 
 	e.Timestamp = startTime
-	e.Namespace = ms.Registration().Namespace
 	e.Took = 115 * time.Microsecond
 	e.Host = ms.Host()
+	if e.Namespace == "" {
+		e.Namespace = ms.Registration().Namespace
+	}
 
 	fullEvent := e.BeatEvent(ms.Module().Name(), ms.Name(), modifiers...)
 

--- a/metricbeat/module/logstash/_meta/Dockerfile
+++ b/metricbeat/module/logstash/_meta/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/logstash/logstash:6.0.0
+FROM docker.elastic.co/logstash/logstash:6.2.3
 
 COPY healthcheck.sh /
 ENV XPACK_MONITORING_ENABLED=FALSE

--- a/metricbeat/module/logstash/node/_meta/data.json
+++ b/metricbeat/module/logstash/node/_meta/data.json
@@ -6,12 +6,12 @@
     },
     "logstash": {
         "node": {
-            "host": "4318d3c307b3",
+            "host": "5256c6d0f05a",
             "jvm": {
                 "pid": 1,
-                "version": "1.8.0_151"
+                "version": "1.8.0_161"
             },
-            "version": "6.0.0-rc2"
+            "version": "6.2.3"
         }
     },
     "metricset": {

--- a/metricbeat/module/logstash/node_stats/_meta/data.json
+++ b/metricbeat/module/logstash/node_stats/_meta/data.json
@@ -5,11 +5,13 @@
         "name": "host.example.com"
     },
     "logstash": {
-        "node_stats": {
-            "events": {
-                "filtered": 0,
-                "in": 0,
-                "out": 0
+        "node": {
+            "stats": {
+                "events": {
+                    "filtered": 0,
+                    "in": 0,
+                    "out": 0
+                }
             }
         }
     },
@@ -17,6 +19,7 @@
         "host": "127.0.0.1:9600",
         "module": "logstash",
         "name": "node_stats",
+        "namespace": "logstash.node.stats",
         "rtt": 115
     }
 }

--- a/metricbeat/module/logstash/node_stats/_meta/fields.yml
+++ b/metricbeat/module/logstash/node_stats/_meta/fields.yml
@@ -1,4 +1,4 @@
-- name: node_stats
+- name: node.stats
   type: group
   description: >
     node_stats metrics.

--- a/metricbeat/module/logstash/node_stats/node_stats.go
+++ b/metricbeat/module/logstash/node_stats/node_stats.go
@@ -8,12 +8,19 @@ import (
 	"github.com/elastic/beats/metricbeat/mb/parse"
 )
 
+const (
+	moduleName    = "logstash"
+	metricsetName = "node_stats"
+	namespace     = "logstash.node.stats"
+)
+
 // init registers the MetricSet with the central registry.
 // The New method will be called after the setup of the module and before starting to fetch data
 func init() {
-	if err := mb.Registry.AddMetricSet("logstash", "node_stats", New, hostParser); err != nil {
-		panic(err)
-	}
+	mb.Registry.MustAddMetricSet(moduleName, metricsetName, New,
+		mb.WithHostParser(hostParser),
+		mb.WithNamespace(namespace),
+	)
 }
 
 var (


### PR DESCRIPTION
* This is the same as for elasticsearch
* Update data.json accordingly
* Update Logstash version to 6.2.3
* Update data.json generator to support namespace setting