### PR TITLE
Introduce environment variable to skip compose starting environment

### DIFF
--- a/libbeat/tests/compose/compose.go
+++ b/libbeat/tests/compose/compose.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 	"time"
 
+	"strconv"
+
 	"github.com/docker/libcompose/docker"
 	"github.com/docker/libcompose/docker/ctx"
 	"github.com/docker/libcompose/project"
@@ -44,11 +46,11 @@ func EnsureUp(t *testing.T, services ...string) {
 // Wait for `timeout` seconds for health
 func EnsureUpWithTimeout(t *testing.T, timeout int, services ...string) {
 	// The NO_COMPOSE env variables makes it possible to skip the starting of the environment.
-	// This is useful it the service is already running locally.
-	noCompose := os.Getenv("NO_COMPOSE")
-	if noCompose == "1" {
+	// This is useful if the service is already running locally.
+	if noCompose, err := strconv.ParseBool(os.Getenv("NO_COMPOSE")); err == nil && noCompose {
 		return
 	}
+
 	compose, err := getComposeProject()
 	if err != nil {
 		t.Fatal(err)

--- a/libbeat/tests/compose/compose.go
+++ b/libbeat/tests/compose/compose.go
@@ -43,6 +43,12 @@ func EnsureUp(t *testing.T, services ...string) {
 // EnsureUpWithTimeout starts all the requested services (must be defined in docker-compose.yml)
 // Wait for `timeout` seconds for health
 func EnsureUpWithTimeout(t *testing.T, timeout int, services ...string) {
+	// The NO_COMPOSE env variables makes it possible to skip the starting of the environment.
+	// This is useful it the service is already running locally.
+	noCompose := os.Getenv("NO_COMPOSE")
+	if noCompose == "1" {
+		return
+	}
 	compose, err := getComposeProject()
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
By default the golang integration tests in metricbeat use docker compose to start their own environment for testing. This is useful for quick and automated testing. But in some cases a local instance of the service is used for developing and testing a metricset. This PR introduces the `NO_COMPOSE` environment variable which can be used to skip the starting of the service with compose.

To generate data for logstash.node_stats metricset from a local LS instance, the following command can be used:

```
NO_COMPOSE=1 go test -tags=integration github.com/elastic/beats/metricbeat/module/logstash/node_stats/... -data
```