### PR TITLE
Set default metricsets in Docker module

### DIFF
--- a/metricbeat/docs/modules/docker.asciidoc
+++ b/metricbeat/docs/modules/docker.asciidoc
@@ -5,7 +5,7 @@ This file is generated! See scripts/docs_collector.py
 [[metricbeat-module-docker]]
 == Docker module
 
-This module fetches metrics from https://www.docker.com/[Docker] containers.
+This module fetches metrics from https://www.docker.com/[Docker] containers. The default metricsets are: `container`, `cpu`, `diskio`, `healthcheck`, `info`, `memory` and `network`. The `image` metricset is not enabled by default.
 
 The Docker module is currently not tested on Windows.
 
@@ -29,18 +29,10 @@ in <<configuration-metricbeat>>. Here is an example configuration:
 ----
 metricbeat.modules:
 - module: docker
-  metricsets: ["container", "cpu", "diskio", "healthcheck", "info", "memory", "network"]
   hosts: ["unix:///var/run/docker.sock"]
-  period: 10s
 
   # Replace dots in labels with `_`. Set to false to keep dots
   labels.dedot: true
-
-  # To connect to Docker over TLS you must specify a client and CA certificate.
-  #ssl:
-    #certificate_authority: "/etc/pki/root/ca.pem"
-    #certificate:           "/etc/pki/client/cert.pem"
-    #key:                   "/etc/pki/client/cert.key"
 ----
 
 [float]

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -153,9 +153,18 @@ metricbeat.modules:
 
 #------------------------------- Docker Module -------------------------------
 - module: docker
-  metricsets: ["container", "cpu", "diskio", "healthcheck", "info", "memory", "network"]
+  metricsets:
+    - "container"
+    - "cpu"
+    - "diskio"
+    - "healthcheck"
+    - "info"
+    #- "image"
+    - "memory"
+    - "network"
   hosts: ["unix:///var/run/docker.sock"]
   period: 10s
+  enabled: true
 
   # Replace dots in labels with `_`. Set to false to keep dots
   labels.dedot: true

--- a/metricbeat/module/docker/_meta/config.reference.yml
+++ b/metricbeat/module/docker/_meta/config.reference.yml
@@ -1,0 +1,22 @@
+- module: docker
+  metricsets:
+    - "container"
+    - "cpu"
+    - "diskio"
+    - "healthcheck"
+    - "info"
+    #- "image"
+    - "memory"
+    - "network"
+  hosts: ["unix:///var/run/docker.sock"]
+  period: 10s
+  enabled: true
+
+  # Replace dots in labels with `_`. Set to false to keep dots
+  labels.dedot: true
+
+  # To connect to Docker over TLS you must specify a client and CA certificate.
+  #ssl:
+    #certificate_authority: "/etc/pki/root/ca.pem"
+    #certificate:           "/etc/pki/client/cert.pem"
+    #key:                   "/etc/pki/client/cert.key"

--- a/metricbeat/module/docker/_meta/config.yml
+++ b/metricbeat/module/docker/_meta/config.yml
@@ -1,13 +1,5 @@
 - module: docker
-  metricsets: ["container", "cpu", "diskio", "healthcheck", "info", "memory", "network"]
   hosts: ["unix:///var/run/docker.sock"]
-  period: 10s
 
   # Replace dots in labels with `_`. Set to false to keep dots
   labels.dedot: true
-
-  # To connect to Docker over TLS you must specify a client and CA certificate.
-  #ssl:
-    #certificate_authority: "/etc/pki/root/ca.pem"
-    #certificate:           "/etc/pki/client/cert.pem"
-    #key:                   "/etc/pki/client/cert.key"

--- a/metricbeat/module/docker/_meta/docs.asciidoc
+++ b/metricbeat/module/docker/_meta/docs.asciidoc
@@ -1,4 +1,4 @@
-This module fetches metrics from https://www.docker.com/[Docker] containers.
+This module fetches metrics from https://www.docker.com/[Docker] containers. The default metricsets are: `container`, `cpu`, `diskio`, `healthcheck`, `info`, `memory` and `network`. The `image` metricset is not enabled by default.
 
 The Docker module is currently not tested on Windows.
 

--- a/metricbeat/module/docker/container/container.go
+++ b/metricbeat/module/docker/container/container.go
@@ -12,9 +12,10 @@ import (
 )
 
 func init() {
-	if err := mb.Registry.AddMetricSet("docker", "container", New, docker.HostParser); err != nil {
-		panic(err)
-	}
+	mb.Registry.MustAddMetricSet("docker", "container", New,
+		mb.WithHostParser(docker.HostParser),
+		mb.DefaultMetricSet(),
+	)
 }
 
 type MetricSet struct {

--- a/metricbeat/module/docker/cpu/cpu.go
+++ b/metricbeat/module/docker/cpu/cpu.go
@@ -9,9 +9,10 @@ import (
 )
 
 func init() {
-	if err := mb.Registry.AddMetricSet("docker", "cpu", New, docker.HostParser); err != nil {
-		panic(err)
-	}
+	mb.Registry.MustAddMetricSet("docker", "cpu", New,
+		mb.WithHostParser(docker.HostParser),
+		mb.DefaultMetricSet(),
+	)
 }
 
 type MetricSet struct {

--- a/metricbeat/module/docker/diskio/diskio.go
+++ b/metricbeat/module/docker/diskio/diskio.go
@@ -9,9 +9,10 @@ import (
 )
 
 func init() {
-	if err := mb.Registry.AddMetricSet("docker", "diskio", New, docker.HostParser); err != nil {
-		panic(err)
-	}
+	mb.Registry.MustAddMetricSet("docker", "diskio", New,
+		mb.WithHostParser(docker.HostParser),
+		mb.DefaultMetricSet(),
+	)
 }
 
 type MetricSet struct {

--- a/metricbeat/module/docker/healthcheck/healthcheck.go
+++ b/metricbeat/module/docker/healthcheck/healthcheck.go
@@ -12,9 +12,10 @@ import (
 )
 
 func init() {
-	if err := mb.Registry.AddMetricSet("docker", "healthcheck", New, docker.HostParser); err != nil {
-		panic(err)
-	}
+	mb.Registry.MustAddMetricSet("docker", "healthcheck", New,
+		mb.WithHostParser(docker.HostParser),
+		mb.DefaultMetricSet(),
+	)
 }
 
 type MetricSet struct {

--- a/metricbeat/module/docker/image/image.go
+++ b/metricbeat/module/docker/image/image.go
@@ -14,9 +14,9 @@ import (
 // init registers the MetricSet with the central registry.
 // The New method will be called after the setup of the module and before starting to fetch data
 func init() {
-	if err := mb.Registry.AddMetricSet("docker", "image", New); err != nil {
-		panic(err)
-	}
+	mb.Registry.MustAddMetricSet("docker", "image", New,
+		mb.WithHostParser(docker.HostParser),
+	)
 }
 
 // MetricSet type defines all fields of the MetricSet

--- a/metricbeat/module/docker/info/info.go
+++ b/metricbeat/module/docker/info/info.go
@@ -11,9 +11,10 @@ import (
 )
 
 func init() {
-	if err := mb.Registry.AddMetricSet("docker", "info", New, docker.HostParser); err != nil {
-		panic(err)
-	}
+	mb.Registry.MustAddMetricSet("docker", "info", New,
+		mb.WithHostParser(docker.HostParser),
+		mb.DefaultMetricSet(),
+	)
 }
 
 type MetricSet struct {

--- a/metricbeat/module/docker/memory/memory.go
+++ b/metricbeat/module/docker/memory/memory.go
@@ -9,9 +9,10 @@ import (
 )
 
 func init() {
-	if err := mb.Registry.AddMetricSet("docker", "memory", New, docker.HostParser); err != nil {
-		panic(err)
-	}
+	mb.Registry.MustAddMetricSet("docker", "memory", New,
+		mb.WithHostParser(docker.HostParser),
+		mb.DefaultMetricSet(),
+	)
 }
 
 type MetricSet struct {

--- a/metricbeat/module/docker/network/network.go
+++ b/metricbeat/module/docker/network/network.go
@@ -9,9 +9,10 @@ import (
 )
 
 func init() {
-	if err := mb.Registry.AddMetricSet("docker", "network", New, docker.HostParser); err != nil {
-		panic(err)
-	}
+	mb.Registry.MustAddMetricSet("docker", "network", New,
+		mb.WithHostParser(docker.HostParser),
+		mb.DefaultMetricSet(),
+	)
 }
 
 type MetricSet struct {

--- a/metricbeat/modules.d/docker.yml.disabled
+++ b/metricbeat/modules.d/docker.yml.disabled
@@ -1,13 +1,5 @@
 - module: docker
-  metricsets: ["container", "cpu", "diskio", "healthcheck", "info", "memory", "network"]
   hosts: ["unix:///var/run/docker.sock"]
-  period: 10s
 
   # Replace dots in labels with `_`. Set to false to keep dots
   labels.dedot: true
-
-  # To connect to Docker over TLS you must specify a client and CA certificate.
-  #ssl:
-    #certificate_authority: "/etc/pki/root/ca.pem"
-    #certificate:           "/etc/pki/client/cert.pem"
-    #key:                   "/etc/pki/client/cert.key"


### PR DESCRIPTION
The following metricests are set as default: `container`, `cpu`, `diskio`, `healthcheck`, `info`, `memory` and `network`. `image` is not set as default.