### PR TITLE
Fixes autodiscover's appender configuration example

### DIFF
--- a/libbeat/docs/shared-autodiscover.asciidoc
+++ b/libbeat/docs/shared-autodiscover.asciidoc
@@ -157,9 +157,9 @@ metricbeat.autodiscover:
         ...
   appenders:
     - type: config
-      - condition.equals:
-          kubernetes.labels.app: "prometheus"
-        config:
-          fields:
-            type: monitoring
+      condition.equals:
+        kubernetes.labels.app: "prometheus"
+      config:
+        fields:
+          type: monitoring
 -------------------------------------------------------------------------------------


### PR DESCRIPTION
The current `YAML` representation in the configuration is invalid, this
PR fixes the alignment.

Reported in https://discuss.elastic.co/t/filebeat-autodiscovery-appenders/126009

@exekias @vjsamuel I think this should be correct format from what I see in the code?