### PR TITLE
Downgrade Docker-py to 3.1.4 to workaround and issue with Context and Path of Dockerfile.

### DIFF
--- a/libbeat/tests/system/requirements.txt
+++ b/libbeat/tests/system/requirements.txt
@@ -9,3 +9,4 @@ requests
 autopep8
 six
 docker-compose
+docker==3.1.4


### PR DESCRIPTION
We have seen a few errors concerning [Dockerfile not found](https://github.com/docker/docker-py/issues/1980) during Metricbeat integration suite. All the errors were originating from the Apache 2.4.14 build of the dockerfile.

Downgrading to 3.1.4 of the docker library fix the problem.