### PR TITLE
Cherry-pick #6687 to 6.2: Add hex decoding to name field in audit path records

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -32,6 +32,8 @@ https://github.com/elastic/beats/compare/v6.2.2...6.2[Check the HEAD diff]
 
 *Auditbeat*
 
+- Add hex decoding for the name field in audit path records. {pull}6687[6687]
+
 *Filebeat*
 
 *Heartbeat*

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -342,8 +342,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 --------------------------------------------------------------------
 Dependency: github.com/elastic/go-libaudit
-Version: v0.0.7
-Revision: c139147102117edd4175a74ce071e4cc7982259a
+Version: v0.1.0
+Revision: 4a806edf821706e315ef7d4f3b5d0cac6d638b34
 License type (autodetected): Apache-2.0
 ./vendor/github.com/elastic/go-libaudit/LICENSE:
 --------------------------------------------------------------------

--- a/vendor/github.com/elastic/go-libaudit/CHANGELOG.md
+++ b/vendor/github.com/elastic/go-libaudit/CHANGELOG.md
@@ -2,6 +2,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.1.0]
+
+### Changed
+
+- auparse - Fixed an issue where the name value was not being hex decoded from
+  PATH records. #20
+
 ## [0.0.7]
  
 ### Added

--- a/vendor/github.com/elastic/go-libaudit/auparse/auparse.go
+++ b/vendor/github.com/elastic/go-libaudit/auparse/auparse.go
@@ -353,6 +353,7 @@ func enrichData(msg *AuditMessage) error {
 		}
 	case AUDIT_PATH:
 		parseSELinuxContext("obj", msg.fields)
+		hexDecode("name", msg.fields)
 	case AUDIT_USER_LOGIN:
 		// acct only exists in failed logins.
 		hexDecode("acct", msg.fields)

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -367,44 +367,44 @@
 			"revisionTime": "2016-08-05T00:47:13Z"
 		},
 		{
-			"checksumSHA1": "yxowcZEI5Qx1xwu9TI+L5NS87Sw=",
+			"checksumSHA1": "FmPMalgdsaNNmghFB2DWm8fJjVA=",
 			"path": "github.com/elastic/go-libaudit",
-			"revision": "c139147102117edd4175a74ce071e4cc7982259a",
-			"revisionTime": "2018-01-18T05:11:38Z",
-			"version": "v0.0.7",
-			"versionExact": "v0.0.7"
+			"revision": "4a806edf821706e315ef7d4f3b5d0cac6d638b34",
+			"revisionTime": "2018-03-28T14:46:34Z",
+			"version": "v0.1.0",
+			"versionExact": "v0.1.0"
 		},
 		{
-			"checksumSHA1": "n8bRlhOdmfREBoCgStzHWGWiwSY=",
+			"checksumSHA1": "uu4544BCRlonueK+mB7549opucs=",
 			"path": "github.com/elastic/go-libaudit/aucoalesce",
-			"revision": "df0d4981f3fce65ffd3d7411dfec3e03231b491c",
-			"revisionTime": "2017-09-07T20:19:58Z",
-			"version": "v0.0.6",
-			"versionExact": "v0.0.6"
+			"revision": "4a806edf821706e315ef7d4f3b5d0cac6d638b34",
+			"revisionTime": "2018-03-28T14:46:34Z",
+			"version": "v0.1.0",
+			"versionExact": "v0.1.0"
 		},
 		{
-			"checksumSHA1": "eUIiDm0pSFKNKjWme5s3PtWEoSU=",
+			"checksumSHA1": "+L/ZGneCw2zrkK5Vlto9UB3LaEk=",
 			"path": "github.com/elastic/go-libaudit/auparse",
-			"revision": "df0d4981f3fce65ffd3d7411dfec3e03231b491c",
-			"revisionTime": "2017-09-07T20:19:58Z",
-			"version": "v0.0.6",
-			"versionExact": "v0.0.6"
+			"revision": "4a806edf821706e315ef7d4f3b5d0cac6d638b34",
+			"revisionTime": "2018-03-28T14:46:34Z",
+			"version": "v0.1.0",
+			"versionExact": "v0.1.0"
 		},
 		{
 			"checksumSHA1": "H0rnscnKHbkjmXc4whC3gtIPR0c=",
 			"path": "github.com/elastic/go-libaudit/rule",
-			"revision": "df0d4981f3fce65ffd3d7411dfec3e03231b491c",
-			"revisionTime": "2017-09-07T20:19:58Z",
-			"version": "v0.0.6",
-			"versionExact": "v0.0.6"
+			"revision": "4a806edf821706e315ef7d4f3b5d0cac6d638b34",
+			"revisionTime": "2018-03-28T14:46:34Z",
+			"version": "v0.1.0",
+			"versionExact": "v0.1.0"
 		},
 		{
 			"checksumSHA1": "36UaYid29Kyhrsa5D8N6BoM8dVw=",
 			"path": "github.com/elastic/go-libaudit/rule/flags",
-			"revision": "df0d4981f3fce65ffd3d7411dfec3e03231b491c",
-			"revisionTime": "2017-09-07T20:19:58Z",
-			"version": "v0.0.6",
-			"versionExact": "v0.0.6"
+			"revision": "4a806edf821706e315ef7d4f3b5d0cac6d638b34",
+			"revisionTime": "2018-03-28T14:46:34Z",
+			"version": "v0.1.0",
+			"versionExact": "v0.1.0"
 		},
 		{
 			"checksumSHA1": "3jizmlZPCyo6FAZY8Trk9jA8NH4=",


### PR DESCRIPTION
Cherry-pick of PR #6687 to 6.2 branch. Original message: 

This updates go-libaudit to v0.1.0 which contains a fix for elastic/go-libaudit#20.