### PR TITLE
Use `--mount` over `-v` syntax

### DIFF
--- a/libbeat/docs/shared-docker.asciidoc
+++ b/libbeat/docs/shared-docker.asciidoc
@@ -28,20 +28,20 @@ code can be found on
 ==== Configure {beatname_uc} on Docker
 
 The Docker image provides several methods for configuring {beatname_uc}. The
-conventional approach is to provide a configuration file via a bind-mounted
-volume, but it's also possible to create a custom image with your
+conventional approach is to provide a configuration file via a bind mount, but 
+it's also possible to create a custom image with your
 configuration included.
 
 [float]
 ===== Bind-mounted configuration
 
-One way to configure {beatname_uc} on Docker is to provide +{beatname_lc}.yml+ via bind-mounting.
-With +docker run+, the bind-mount can be specified like this:
+One way to configure {beatname_uc} on Docker is to provide +{beatname_lc}.yml+ via a bind mount.
+With +docker run+, the bind mount can be specified like this:
 
 ["source", "sh", subs="attributes"]
 --------------------------------------------
 docker run \
-  -v ~/{beatname_lc}.yml:/usr/share/{beatname_lc}/{beatname_lc}.yml \
+  --mount type=bind,source="$(pwd)"/{beatname_lc}.yml,target=/usr/share/{beatname_lc}/{beatname_lc}.yml \
   {dockerimage}
 --------------------------------------------
 

--- a/metricbeat/docs/running-on-docker.asciidoc
+++ b/metricbeat/docs/running-on-docker.asciidoc
@@ -15,9 +15,9 @@ host machine from within the container.
 ["source","sh",subs="attributes"]
 ----
 docker run \
-  --volume=/proc:/hostfs/proc:ro \ <1>
-  --volume=/sys/fs/cgroup:/hostfs/sys/fs/cgroup:ro \ <2>
-  --volume=/:/hostfs:ro \ <3>
+  --mount type=bind,source=/proc,target=/hostfs/proc,readonly \ <1>
+  --mount type=bind,source=/sys/fs/cgroup,target=/hostfs/sys/fs/cgroup,readonly \ <2>
+  --mount type=bind,source=/,target=/hostfs,readonly \ <3>
   --net=host <4>
   {dockerimage} -system.hostfs=/hostfs
 ----


### PR DESCRIPTION
Reference https://docs.docker.com/storage/bind-mounts/

The `--mount` syntax is encouraged over the legacy `-v` syntax.

Also, eliminate the world "volume", because *a bind mount is not a volume*. A bind mount is a mount. A volume mount is a mount. A tmpfs mount is a mount (see https://docs.docker.com/storage/#choose-the-right-type-of-mount). These are the three types of mounts. Using the `--mount` syntax over the `-v` helps avoid this confusion.

Also, I changed the example to `$(pwd)` like they have it at https://docs.docker.com/storage/bind-mounts/#choosing-the--v-or---mount-flag because I was having trouble with `$(~)`, it didn't work for some reason (using bash)... Bind mounts require a fully qualified path (which is actually how the original example worked too because the `~` expands in the shell but in my changes the `~` would not expand because it is not the first character in the argument (not really sure how it works, but my example works))