### PR TITLE
Allow autodiscover to monitor unexposed ports

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -273,6 +273,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Set `service` as default metricset in Windows module. {pull}6675[6675]
 - Set all metricsets as default metricsets in uwsgi module. {pull}6688[6688]
 - Mark kubernetes.event metricset as beta. {pull}[]
+- Allow autodiscover to monitor unexposed ports {pull}6727[6727]
 
 *Packetbeat*
 

--- a/metricbeat/autodiscover/builder/hints/metrics.go
+++ b/metricbeat/autodiscover/builder/hints/metrics.go
@@ -136,7 +136,9 @@ func (m *metricHints) getHostsWithPort(hints common.MapStr, port int) []string {
 	// Only pick hosts that have ${data.port} or the port on current event. This will make
 	// sure that incorrect meta mapping doesn't happen
 	for _, h := range thosts {
-		if strings.Contains(h, "data.port") || strings.Contains(h, fmt.Sprintf(":%d", port)) {
+		if strings.Contains(h, "data.port") || strings.Contains(h, fmt.Sprintf(":%d", port)) ||
+			// Use the event that has no port config if there is a ${data.host}:9090 like input
+			(port == 0 && strings.Contains(h, "data.host")) {
 			result = append(result, h)
 		}
 	}

--- a/metricbeat/autodiscover/builder/hints/metrics_test.go
+++ b/metricbeat/autodiscover/builder/hints/metrics_test.go
@@ -109,7 +109,8 @@ func TestGenerateHints(t *testing.T) {
 			},
 		},
 		{
-			message: "Module, namespace, host hint should return valid config without port should not return hosts",
+			message: "Module, namespace, host hint should return valid config with port should return hosts for " +
+				"docker host network scenario",
 			event: bus.Event{
 				"host": "1.2.3.4",
 				"hints": common.MapStr{
@@ -128,6 +129,7 @@ func TestGenerateHints(t *testing.T) {
 				"timeout":    "3s",
 				"period":     "1m",
 				"enabled":    true,
+				"hosts":      []interface{}{"1.2.3.4:9090"},
 			},
 		},
 		{

--- a/metricbeat/docs/autodiscover-kubernetes-config.asciidoc
+++ b/metricbeat/docs/autodiscover-kubernetes-config.asciidoc
@@ -17,3 +17,6 @@ metricbeat.autodiscover:
 -------------------------------------------------------------------------------------
 
 This configuration launches a `prometheus` module for all containers of pods annotated `prometheus.io.scrape=true`.
+There are cases where the PodSpec does not expose a port. In such cases the host can be provided as `${data.host}:9090`
+directly. However, the metadata which is used to enrich the metric would not have information regarding the container since
+the discovery mechanism would not have information on which container the port maps to.


### PR DESCRIPTION
The metrics hint builder needs a slight change to allow monitoring of endpoints like `${data.host}:9090`. Currently it blocks such cases. For host network containers, there wouldnt be any port on the configuration as well. We would just spin up metricbeat modules, if port is 0 and the host hint has `data.host` on it.