### PR TITLE
Add cluster config parameter to kubernetes metagenerator

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -206,6 +206,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Add appender support to autodiscover {pull}6469[6469]
 - Add add_host_metadata processor {pull}5968[5968]
 - Retry configuration to load dashboards if Kibana is not reachable when the beat starts. {pull}6560[6560]
+- Add cluster config parameter to kubernetes metagenerator {pull}6728[6728]
 
 *Auditbeat*
 

--- a/auditbeat/docs/fields.asciidoc
+++ b/auditbeat/docs/fields.asciidoc
@@ -2593,6 +2593,14 @@ Kubernetes metadata added by the kubernetes processor
 
 
 [float]
+=== `kubernetes.cluster.name`
+
+type: keyword
+
+Kubernetes cluster name
+
+
+[float]
 === `kubernetes.pod.name`
 
 type: keyword

--- a/filebeat/docs/fields.asciidoc
+++ b/filebeat/docs/fields.asciidoc
@@ -1359,6 +1359,14 @@ Kubernetes metadata added by the kubernetes processor
 
 
 [float]
+=== `kubernetes.cluster.name`
+
+type: keyword
+
+Kubernetes cluster name
+
+
+[float]
 === `kubernetes.pod.name`
 
 type: keyword

--- a/heartbeat/docs/fields.asciidoc
+++ b/heartbeat/docs/fields.asciidoc
@@ -531,6 +531,14 @@ Kubernetes metadata added by the kubernetes processor
 
 
 [float]
+=== `kubernetes.cluster.name`
+
+type: keyword
+
+Kubernetes cluster name
+
+
+[float]
 === `kubernetes.pod.name`
 
 type: keyword

--- a/libbeat/autodiscover/providers/kubernetes/config.go
+++ b/libbeat/autodiscover/providers/kubernetes/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	SyncPeriod     time.Duration `config:"sync_period"`
 	CleanupTimeout time.Duration `config:"cleanup_timeout"`
 
+	Cluster            string   `config:"cluster"`
 	IncludeLabels      []string `config:"include_labels"`
 	ExcludeLabels      []string `config:"exclude_labels"`
 	IncludeAnnotations []string `config:"include_annotations"`
@@ -30,6 +31,7 @@ type Config struct {
 func defaultConfig() *Config {
 	return &Config{
 		InCluster:      true,
+		Cluster:        "default",
 		SyncPeriod:     1 * time.Second,
 		CleanupTimeout: 60 * time.Second,
 		Prefix:         "co.elastic",

--- a/libbeat/autodiscover/providers/kubernetes/kubernetes.go
+++ b/libbeat/autodiscover/providers/kubernetes/kubernetes.go
@@ -43,7 +43,7 @@ func AutodiscoverBuilder(bus bus.Bus, c *common.Config) (autodiscover.Provider, 
 		return nil, err
 	}
 
-	metagen := kubernetes.NewMetaGenerator(config.IncludeAnnotations, config.IncludeLabels, config.ExcludeLabels)
+	metagen := kubernetes.NewMetaGenerator(config.Cluster, config.IncludeAnnotations, config.IncludeLabels, config.ExcludeLabels)
 
 	config.Host = kubernetes.DiscoverKubernetesNode(config.Host, config.InCluster, client)
 

--- a/libbeat/common/kubernetes/metadata.go
+++ b/libbeat/common/kubernetes/metadata.go
@@ -16,14 +16,16 @@ type MetaGenerator interface {
 
 type metaGenerator struct {
 	annotations   []string
+	cluster       string
 	labels        []string
 	labelsExclude []string
 }
 
 // NewMetaGenerator initializes and returns a new kubernetes metadata generator
-func NewMetaGenerator(annotations, labels, labelsExclude []string) MetaGenerator {
+func NewMetaGenerator(cluster string, annotations, labels, labelsExclude []string) MetaGenerator {
 	return &metaGenerator{
 		annotations:   annotations,
+		cluster:       cluster,
 		labels:        labels,
 		labelsExclude: labelsExclude,
 	}
@@ -47,6 +49,9 @@ func (g *metaGenerator) PodMetadata(pod *Pod) common.MapStr {
 
 	annotationsMap := generateMapSubset(pod.Metadata.Annotations, g.annotations)
 	meta := common.MapStr{
+		"cluster": common.MapStr{
+			"name": g.cluster,
+		},
 		"pod": common.MapStr{
 			"name": pod.Metadata.Name,
 		},

--- a/libbeat/common/kubernetes/metadata_test.go
+++ b/libbeat/common/kubernetes/metadata_test.go
@@ -24,6 +24,8 @@ func TestPodMetadataDeDot(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		assert.Equal(t, NewMetaGenerator(nil, nil, nil).PodMetadata(test.pod)["labels"], test.meta["labels"])
+		meta := NewMetaGenerator("default", nil, nil, nil)
+		assert.Equal(t, meta.PodMetadata(test.pod)["labels"], test.meta["labels"])
+		assert.Equal(t, meta.PodMetadata(test.pod)["cluster"].(common.MapStr)["name"], "default")
 	}
 }

--- a/libbeat/processors/add_kubernetes_metadata/_meta/fields.yml
+++ b/libbeat/processors/add_kubernetes_metadata/_meta/fields.yml
@@ -8,6 +8,11 @@
     - name: kubernetes
       type: group
       fields:
+        - name: cluster.name
+          type: keyword
+          description: >
+            Kubernetes cluster name
+
         - name: pod.name
           type: keyword
           description: >

--- a/libbeat/processors/add_kubernetes_metadata/config.go
+++ b/libbeat/processors/add_kubernetes_metadata/config.go
@@ -9,6 +9,7 @@ import (
 type kubeAnnotatorConfig struct {
 	InCluster  bool          `config:"in_cluster"`
 	KubeConfig string        `config:"kube_config"`
+	Cluster    string        `config:"cluster"`
 	Host       string        `config:"host"`
 	Namespace  string        `config:"namespace"`
 	SyncPeriod time.Duration `config:"sync_period"`
@@ -33,6 +34,7 @@ type PluginConfig []map[string]common.Config
 func defaultKubernetesAnnotatorConfig() kubeAnnotatorConfig {
 	return kubeAnnotatorConfig{
 		InCluster:       true,
+		Cluster:         "default",
 		SyncPeriod:      1 * time.Second,
 		CleanupTimeout:  60 * time.Second,
 		DefaultMatchers: Enabled{true},

--- a/libbeat/processors/add_kubernetes_metadata/indexers_test.go
+++ b/libbeat/processors/add_kubernetes_metadata/indexers_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/elastic/beats/libbeat/common/kubernetes"
 )
 
-var metagen = kubernetes.NewMetaGenerator([]string{}, []string{}, []string{})
+var metagen = kubernetes.NewMetaGenerator("default", []string{}, []string{}, []string{})
 
 func TestPodIndexer(t *testing.T) {
 	var testConfig = common.NewConfig()
@@ -38,6 +38,9 @@ func TestPodIndexer(t *testing.T) {
 	assert.Equal(t, indexers[0].Index, fmt.Sprintf("%s/%s", ns, podName))
 
 	expected := common.MapStr{
+		"cluster": common.MapStr{
+			"name": "default",
+		},
 		"pod": common.MapStr{
 			"name": "testpod",
 		},
@@ -87,6 +90,9 @@ func TestContainerIndexer(t *testing.T) {
 	assert.Equal(t, len(indexers), 0)
 	assert.Equal(t, len(indices), 0)
 	expected := common.MapStr{
+		"cluster": common.MapStr{
+			"name": "default",
+		},
 		"pod": common.MapStr{
 			"name": "testpod",
 		},
@@ -170,7 +176,7 @@ func TestFilteredGenMeta(t *testing.T) {
 	rawAnnotations := indexers[0].Data["annotations"]
 	assert.Nil(t, rawAnnotations)
 
-	filteredGen := kubernetes.NewMetaGenerator([]string{"a"}, []string{"foo"}, []string{})
+	filteredGen := kubernetes.NewMetaGenerator("default", []string{"a"}, []string{"foo"}, []string{})
 	podIndexer, err = NewPodNameIndexer(*testConfig, filteredGen)
 	assert.Nil(t, err)
 
@@ -201,7 +207,7 @@ func TestFilteredGenMeta(t *testing.T) {
 func TestFilteredGenMetaExclusion(t *testing.T) {
 	var testConfig = common.NewConfig()
 
-	filteredGen := kubernetes.NewMetaGenerator([]string{}, []string{}, []string{"x"})
+	filteredGen := kubernetes.NewMetaGenerator("default", []string{}, []string{}, []string{"x"})
 	podIndexer, err := NewPodNameIndexer(*testConfig, filteredGen)
 	assert.Nil(t, err)
 
@@ -283,6 +289,9 @@ func TestIpPortIndexer(t *testing.T) {
 	assert.NotNil(t, err)
 
 	expected := common.MapStr{
+		"cluster": common.MapStr{
+			"name": "default",
+		},
 		"pod": common.MapStr{
 			"name": "testpod",
 		},

--- a/libbeat/processors/add_kubernetes_metadata/kubernetes.go
+++ b/libbeat/processors/add_kubernetes_metadata/kubernetes.go
@@ -65,7 +65,7 @@ func newKubernetesAnnotator(cfg *common.Config) (processors.Processor, error) {
 		Indexing.RUnlock()
 	}
 
-	metaGen := kubernetes.NewMetaGenerator(config.IncludeAnnotations, config.IncludeLabels, config.ExcludeLabels)
+	metaGen := kubernetes.NewMetaGenerator(config.Cluster, config.IncludeAnnotations, config.IncludeLabels, config.ExcludeLabels)
 	indexers := NewIndexers(config.Indexers, metaGen)
 
 	matchers := NewMatchers(config.Matchers)

--- a/metricbeat/docs/fields.asciidoc
+++ b/metricbeat/docs/fields.asciidoc
@@ -5061,6 +5061,14 @@ Kubernetes metadata added by the kubernetes processor
 
 
 [float]
+=== `kubernetes.cluster.name`
+
+type: keyword
+
+Kubernetes cluster name
+
+
+[float]
 === `kubernetes.pod.name`
 
 type: keyword

--- a/packetbeat/docs/fields.asciidoc
+++ b/packetbeat/docs/fields.asciidoc
@@ -2016,6 +2016,14 @@ Kubernetes metadata added by the kubernetes processor
 
 
 [float]
+=== `kubernetes.cluster.name`
+
+type: keyword
+
+Kubernetes cluster name
+
+
+[float]
 === `kubernetes.pod.name`
 
 type: keyword

--- a/winlogbeat/docs/fields.asciidoc
+++ b/winlogbeat/docs/fields.asciidoc
@@ -541,6 +541,14 @@ Kubernetes metadata added by the kubernetes processor
 
 
 [float]
+=== `kubernetes.cluster.name`
+
+type: keyword
+
+Kubernetes cluster name
+
+
+[float]
 === `kubernetes.pod.name`
 
 type: keyword


### PR DESCRIPTION
This PR allows `autodiscover.kubernetes` and `processors.add_kubernetes_metadata` to add a `cluster` parameter to the configuration. This config would be used by `kubernetes.MetadataGenerator` to add `kubernetes.cluster.name` as a field when using the above said two. The default is set to `default`. Allowing Beats to autoname clusters would be difficult as each node runs Beats and there would need to be communication between all the Beats. We can start with a configured default and move to a more automated way if and when Kubernetes exposes cluster names via API. 