### PR TITLE
[6.2] http: support broken status line (#6631)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -368,6 +368,8 @@ https://github.com/elastic/beats/compare/v6.0.1...v6.1.0[View commits]
 *Packetbeat*
 
 - Add support for decoding the TLS envelopes. {pull}5476[5476]
+- HTTP parses successfully on empty status phrase. {issue}6176[6176]
+- HTTP parser supports broken status line. {pull}6631[6631]
 
 [[release-notes-6.0.1]]
 === Beats version 6.0.1

--- a/packetbeat/protos/http/http_parser.go
+++ b/packetbeat/protos/http/http_parser.go
@@ -212,15 +212,17 @@ func parseResponseStatus(s []byte) (uint16, []byte, error) {
 		debugf("parseResponseStatus: %s", s)
 	}
 
+	var phrase []byte
 	p := bytes.IndexByte(s, ' ')
 	if p == -1 {
-		return 0, nil, errors.New("Not able to identify status code")
+		p = len(s)
+	} else {
+		phrase = s[p+1:]
 	}
 	statusCode, err := parseInt(s[0:p])
 	if err != nil {
 		return 0, nil, fmt.Errorf("Unable to parse status code from [%s]", s)
 	}
-	phrase := s[p+1:]
 	return uint16(statusCode), phrase, nil
 }
 


### PR DESCRIPTION
User reports some HTTP servers may respond with a broken status line that's
missing a space between the status code and the optional status phrase. HTTP
clients tested already support this behavior. This patch adjusts the http
parser so that this deviation from the standard is accepted.

Fixes #6176