### PR TITLE
Set default metricsets for rabbitmq module

### DIFF
--- a/metricbeat/docs/modules/rabbitmq.asciidoc
+++ b/metricbeat/docs/modules/rabbitmq.asciidoc
@@ -9,6 +9,7 @@ beta[]
 
 The RabbitMQ module uses http://www.rabbitmq.com/management.html[HTTP API] created by the management plugin to collect metrics.
 
+The default metricsets are `connection`, `node` and `queue`.
 
 
 [float]
@@ -21,12 +22,7 @@ in <<configuration-metricbeat>>. Here is an example configuration:
 ----
 metricbeat.modules:
 - module: rabbitmq
-  metricsets: ["node", "queue", "connection"]
-  period: 10s
   hosts: ["localhost:15672"]
-
-  username: guest
-  password: guest
 ----
 
 This module supports TLS connection when using `ssl` config field, as described in <<configuration-ssl>>.

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -435,11 +435,12 @@ metricbeat.modules:
 #------------------------------ RabbitMQ Module ------------------------------
 - module: rabbitmq
   metricsets: ["node", "queue", "connection"]
+  enabled: true
   period: 10s
   hosts: ["localhost:15672"]
 
-  username: guest
-  password: guest
+  #username: guest
+  #password: guest
 
 #-------------------------------- Redis Module -------------------------------
 - module: redis

--- a/metricbeat/module/rabbitmq/_meta/config.reference.yml
+++ b/metricbeat/module/rabbitmq/_meta/config.reference.yml
@@ -1,0 +1,8 @@
+- module: rabbitmq
+  metricsets: ["node", "queue", "connection"]
+  enabled: true
+  period: 10s
+  hosts: ["localhost:15672"]
+
+  #username: guest
+  #password: guest

--- a/metricbeat/module/rabbitmq/_meta/config.yml
+++ b/metricbeat/module/rabbitmq/_meta/config.yml
@@ -1,7 +1,2 @@
 - module: rabbitmq
-  metricsets: ["node", "queue", "connection"]
-  period: 10s
   hosts: ["localhost:15672"]
-
-  username: guest
-  password: guest

--- a/metricbeat/module/rabbitmq/_meta/docs.asciidoc
+++ b/metricbeat/module/rabbitmq/_meta/docs.asciidoc
@@ -1,2 +1,3 @@
 The RabbitMQ module uses http://www.rabbitmq.com/management.html[HTTP API] created by the management plugin to collect metrics.
 
+The default metricsets are `connection`, `node` and `queue`.

--- a/metricbeat/module/rabbitmq/connection/connection.go
+++ b/metricbeat/module/rabbitmq/connection/connection.go
@@ -21,9 +21,10 @@ var (
 )
 
 func init() {
-	if err := mb.Registry.AddMetricSet("rabbitmq", "connection", New, hostParser); err != nil {
-		panic(err)
-	}
+	mb.Registry.MustAddMetricSet("rabbitmq", "connection", New,
+		mb.WithHostParser(hostParser),
+		mb.DefaultMetricSet(),
+	)
 }
 
 // MetricSet for fetching RabbitMQ connections.

--- a/metricbeat/module/rabbitmq/node/node.go
+++ b/metricbeat/module/rabbitmq/node/node.go
@@ -21,9 +21,10 @@ var (
 )
 
 func init() {
-	if err := mb.Registry.AddMetricSet("rabbitmq", "node", New, hostParser); err != nil {
-		panic(err)
-	}
+	mb.Registry.MustAddMetricSet("rabbitmq", "node", New,
+		mb.WithHostParser(hostParser),
+		mb.DefaultMetricSet(),
+	)
 }
 
 type MetricSet struct {
@@ -32,7 +33,7 @@ type MetricSet struct {
 }
 
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	cfgwarn.Experimental("The rabbitmq node metricset is experimental")
+	cfgwarn.Beta("The rabbitmq node metricset is beta")
 
 	http, err := helper.NewHTTP(base)
 	if err != nil {

--- a/metricbeat/module/rabbitmq/queue/queue.go
+++ b/metricbeat/module/rabbitmq/queue/queue.go
@@ -21,9 +21,10 @@ var (
 )
 
 func init() {
-	if err := mb.Registry.AddMetricSet("rabbitmq", "queue", New, hostParser); err != nil {
-		panic(err)
-	}
+	mb.Registry.MustAddMetricSet("rabbitmq", "queue", New,
+		mb.WithHostParser(hostParser),
+		mb.DefaultMetricSet(),
+	)
 }
 
 type MetricSet struct {
@@ -32,7 +33,7 @@ type MetricSet struct {
 }
 
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	cfgwarn.Experimental("The rabbitmq queue metricset is experimental")
+	cfgwarn.Beta("The rabbitmq queue metricset is beta")
 
 	http, err := helper.NewHTTP(base)
 	if err != nil {

--- a/metricbeat/modules.d/rabbitmq.yml.disabled
+++ b/metricbeat/modules.d/rabbitmq.yml.disabled
@@ -1,7 +1,2 @@
 - module: rabbitmq
-  metricsets: ["node", "queue", "connection"]
-  period: 10s
   hosts: ["localhost:15672"]
-
-  username: guest
-  password: guest


### PR DESCRIPTION
See #6668 

Warnings reporting modules as experimental have been changed to beta, so all metricsets are set as default.