### PR TITLE
replace smart quotes to improve license detection

### DIFF
--- a/dev-tools/generate_notice.py
+++ b/dev-tools/generate_notice.py
@@ -215,6 +215,8 @@ MPL_LICENSE_TITLES = [
 def detect_license_summary(content):
     # replace all white spaces with a single space
     content = re.sub(r"\s+", ' ', content)
+    # replace smart quotes with less intelligent ones
+    content = content.replace(b'\xe2\x80\x9c', '"').replace(b'\xe2\x80\x9d', '"')
     if any(sentence in content[0:1000] for sentence in APACHE2_LICENSE_TITLES):
         return "Apache-2.0"
     if any(sentence in content[0:1000] for sentence in MIT_LICENSES):


### PR DESCRIPTION
One of the packages in apm has smart quotes in its license, preventing correct detection.  This resolve that single case.

before:
```
Permission is hereby granted, free of charge, to any person obtaining a copy of
this software and associated documentation files (the “Software”), 
```
-> `UNKNOWN`

after:
```
Permission is hereby granted, free of charge, to any person obtaining a copy of
this software and associated documentation files (the "Software"), 
```
-> `MIT`