### PR TITLE
Add missing logger parameter to error message

### DIFF
--- a/filebeat/input/log/harvester.go
+++ b/filebeat/input/log/harvester.go
@@ -246,7 +246,7 @@ func (h *Harvester) Run() error {
 			case ErrInactive:
 				logp.Info("File is inactive: %s. Closing because close_inactive of %v reached.", h.state.Source, h.config.CloseInactive)
 			default:
-				logp.Err("Read line error: %s; File: ", err, h.state.Source)
+				logp.Err("Read line error: %v; File: %v", err, h.state.Source)
 			}
 			return nil
 		}


### PR DESCRIPTION
Fixes log messages like

`Read line error: decoding docker JSON: EOF; File: %!(EXTRA string=/var/lib/docker/containers/5ca40e68ff704127f3a8994912c67cdea77c50d9d6a4a99dd6e2fa5f3b433a19/5ca40e68ff704127f3a8994912c67cdea77c50d9d6a4a99dd6e2fa5f3b433a19-json.log)`