### PR TITLE
Update doc and reference config for prometheus default metricset

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -265,7 +265,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Allow to disable labels `dedot` in Docker module, in favor of a safe way to keep dots. {pull}6490[6490]
 - Add experimental module to collect metrics from munin nodes. {pull}6517[6517]
 - Add support for wildcards and explicit metrics grouping in jolokia/jmx. {pull}6462[6462]
-- Set `collector` as default metricset in Prometheus module. {pull}6636[6636]
+- Set `collector` as default metricset in Prometheus module. {pull}6636[6636] {pull}6747[6747]
 - Set `mntr` as default metricset in Zookeeper module. {pull}6674[6674]
 - Set default metricsets in vSphere module. {pull}6676[6676]
 - Set `status` as default metricset in Apache module. {pull}6673[6673]

--- a/metricbeat/docs/modules/prometheus.asciidoc
+++ b/metricbeat/docs/modules/prometheus.asciidoc
@@ -10,6 +10,8 @@ beta[]
 This module periodically fetches metrics from
 https://prometheus.io/docs/[Prometheus].
 
+The default metricset is `collector`.
+
 
 [float]
 === Example configuration
@@ -21,10 +23,8 @@ in <<configuration-metricbeat>>. Here is an example configuration:
 ----
 metricbeat.modules:
 - module: prometheus
-  metricsets: ["stats"]
   period: 10s
   hosts: ["localhost:9090"]
-  metrics_path: /metrics
   #namespace: example
 ----
 

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -427,9 +427,18 @@ metricbeat.modules:
 #----------------------------- Prometheus Module -----------------------------
 - module: prometheus
   metricsets: ["stats"]
+  enabled: true
   period: 10s
   hosts: ["localhost:9090"]
-  metrics_path: /metrics
+  #metrics_path: /metrics
+  #namespace: example
+
+- module: prometheus
+  metricsets: ["collector"]
+  enabled: true
+  period: 10s
+  hosts: ["localhost:9090"]
+  #metrics_path: /metrics
   #namespace: example
 
 #------------------------------ RabbitMQ Module ------------------------------

--- a/metricbeat/module/prometheus/_meta/config.reference.yml
+++ b/metricbeat/module/prometheus/_meta/config.reference.yml
@@ -1,0 +1,15 @@
+- module: prometheus
+  metricsets: ["stats"]
+  enabled: true
+  period: 10s
+  hosts: ["localhost:9090"]
+  #metrics_path: /metrics
+  #namespace: example
+
+- module: prometheus
+  metricsets: ["collector"]
+  enabled: true
+  period: 10s
+  hosts: ["localhost:9090"]
+  #metrics_path: /metrics
+  #namespace: example

--- a/metricbeat/module/prometheus/_meta/config.yml
+++ b/metricbeat/module/prometheus/_meta/config.yml
@@ -1,6 +1,4 @@
 - module: prometheus
-  metricsets: ["stats"]
   period: 10s
   hosts: ["localhost:9090"]
-  metrics_path: /metrics
   #namespace: example

--- a/metricbeat/module/prometheus/_meta/docs.asciidoc
+++ b/metricbeat/module/prometheus/_meta/docs.asciidoc
@@ -1,2 +1,4 @@
 This module periodically fetches metrics from
 https://prometheus.io/docs/[Prometheus].
+
+The default metricset is `collector`.

--- a/metricbeat/module/prometheus/stats/stats.go
+++ b/metricbeat/module/prometheus/stats/stats.go
@@ -23,9 +23,9 @@ var (
 )
 
 func init() {
-	if err := mb.Registry.AddMetricSet("prometheus", "stats", New, hostParser); err != nil {
-		panic(err)
-	}
+	mb.Registry.MustAddMetricSet("prometheus", "stats", New,
+		mb.WithHostParser(hostParser),
+	)
 }
 
 type MetricSet struct {

--- a/metricbeat/modules.d/prometheus.yml.disabled
+++ b/metricbeat/modules.d/prometheus.yml.disabled
@@ -1,6 +1,4 @@
 - module: prometheus
-  metricsets: ["stats"]
   period: 10s
   hosts: ["localhost:9090"]
-  metrics_path: /metrics
   #namespace: example


### PR DESCRIPTION
Continuation of #6636 as part of #6668 

In reference config I leave the two blocks, for `collector` and `stats` because even when they have the same configuration, they look quite different and for different use cases (`collector` to collect metrics from exporters, `stats` to monitor a prometheus server).