### PR TITLE
Fix minor panic in http parser

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -163,6 +163,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Fix panic when parsing partial AMQP messages. {pull}6384[6384]
 - Fix out of bounds access to slice in MongoDB parser. {pull}6256[6256]
 - Fix sniffer hanging on exit under Linux. {pull}6535[6535]
+- Fix bounds check error in http parser causing a panic. {pull}6750[6750]
 
 *Winlogbeat*
 

--- a/packetbeat/protos/http/http_parser.go
+++ b/packetbeat/protos/http/http_parser.go
@@ -141,7 +141,7 @@ func (*parser) parseHTTPLine(s *stream, m *message) (cont, ok, complete bool) {
 	var version []byte
 	var err error
 	fline := s.data[s.parseOffset:i]
-	if len(fline) < 8 {
+	if len(fline) < 9 {
 		if isDebug {
 			debugf("First line too small")
 		}


### PR DESCRIPTION
There was a bounds check error in parsing HTTP responses. A malformed response line in the form "HTTP/1.1\r\n" would cause a panic when parsed.

Related to #6409