### PR TITLE
Rename host.hostname to host.name in processor

### DIFF
--- a/auditbeat/docs/fields.asciidoc
+++ b/auditbeat/docs/fields.asciidoc
@@ -2537,7 +2537,7 @@ Info collected for the host machine.
 
 
 [float]
-=== `host.hostname`
+=== `host.name`
 
 type: keyword
 

--- a/filebeat/docs/fields.asciidoc
+++ b/filebeat/docs/fields.asciidoc
@@ -657,7 +657,7 @@ Info collected for the host machine.
 
 
 [float]
-=== `host.hostname`
+=== `host.name`
 
 type: keyword
 

--- a/heartbeat/docs/fields.asciidoc
+++ b/heartbeat/docs/fields.asciidoc
@@ -306,7 +306,7 @@ Info collected for the host machine.
 
 
 [float]
-=== `host.hostname`
+=== `host.name`
 
 type: keyword
 

--- a/libbeat/docs/processors-using.asciidoc
+++ b/libbeat/docs/processors-using.asciidoc
@@ -673,7 +673,7 @@ The fields added to the event are looking as following:
 {
    "host":{
       "architecture":"x86_64",
-      "hostname":"example-host",
+      "name":"example-host",
       "id":"",
       "os":{
          "family":"darwin",

--- a/libbeat/processors/add_host_metadata/_meta/fields.yml
+++ b/libbeat/processors/add_host_metadata/_meta/fields.yml
@@ -7,7 +7,7 @@
     - name: host
       type: group
       fields:
-        - name: hostname
+        - name: name
           type: keyword
           description: >
             Hostname.

--- a/libbeat/processors/add_host_metadata/add_host_metadata.go
+++ b/libbeat/processors/add_host_metadata/add_host_metadata.go
@@ -48,7 +48,7 @@ func (p *addHostMetadata) loadData() {
 	if p.lastUpdate.Add(cacheExpiration).Before(time.Now()) {
 		p.data = common.MapStr{
 			"host": common.MapStr{
-				"hostname":     p.info.Hostname,
+				"name":         p.info.Hostname,
 				"architecture": p.info.Architecture,
 				"os": common.MapStr{
 					"platform": p.info.OS.Platform,

--- a/metricbeat/docs/fields.asciidoc
+++ b/metricbeat/docs/fields.asciidoc
@@ -4571,7 +4571,7 @@ Info collected for the host machine.
 
 
 [float]
-=== `host.hostname`
+=== `host.name`
 
 type: keyword
 

--- a/packetbeat/docs/fields.asciidoc
+++ b/packetbeat/docs/fields.asciidoc
@@ -1833,7 +1833,7 @@ Info collected for the host machine.
 
 
 [float]
-=== `host.hostname`
+=== `host.name`
 
 type: keyword
 

--- a/winlogbeat/docs/fields.asciidoc
+++ b/winlogbeat/docs/fields.asciidoc
@@ -485,7 +485,7 @@ Info collected for the host machine.
 
 
 [float]
-=== `host.hostname`
+=== `host.name`
 
 type: keyword
 


### PR DESCRIPTION
host.name is nicer then host.hostname. This is not a breaking change as the processor was not release yet.