### PR TITLE
Fix notice script string conversion

### DIFF
--- a/dev-tools/generate_notice.py
+++ b/dev-tools/generate_notice.py
@@ -216,7 +216,7 @@ def detect_license_summary(content):
     # replace all white spaces with a single space
     content = re.sub(r"\s+", ' ', content)
     # replace smart quotes with less intelligent ones
-    content = content.replace(b'\xe2\x80\x9c', '"').replace(b'\xe2\x80\x9d', '"')
+    content = content.replace(b'\xe2\x80\x9c'.decode("utf-8"), '"').replace(b'\xe2\x80\x9d'.decode("utf-8"), '"')
     if any(sentence in content[0:1000] for sentence in APACHE2_LICENSE_TITLES):
         return "Apache-2.0"
     if any(sentence in content[0:1000] for sentence in MIT_LICENSES):


### PR DESCRIPTION
When running the notice script I got the following error:

```
TypeError: replace() argument 1 must be str, not bytes
```

This fixes it by decoding the bytes to utf-8 and a string.