### PR TITLE
Set node as default metricset for munin

### DIFF
--- a/metricbeat/docs/modules/munin.asciidoc
+++ b/metricbeat/docs/modules/munin.asciidoc
@@ -11,6 +11,7 @@ experimental[]
 
 This is the munin module.
 
+The default metricset is `node`.
 
 
 [float]
@@ -23,9 +24,6 @@ in <<configuration-metricbeat>>. Here is an example configuration:
 ----
 metricbeat.modules:
 - module: munin
-  metricsets: ["node"]
-  enabled: false
-  period: 10s
   hosts: ["localhost:4949"]
   node.namespace: node
 ----

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -383,7 +383,7 @@ metricbeat.modules:
 #-------------------------------- Munin Module -------------------------------
 - module: munin
   metricsets: ["node"]
-  enabled: false
+  enabled: true
   period: 10s
   hosts: ["localhost:4949"]
   node.namespace: node

--- a/metricbeat/module/munin/_meta/config.reference.yml
+++ b/metricbeat/module/munin/_meta/config.reference.yml
@@ -1,3 +1,6 @@
 - module: munin
+  metricsets: ["node"]
+  enabled: true
+  period: 10s
   hosts: ["localhost:4949"]
   node.namespace: node

--- a/metricbeat/module/munin/_meta/config.yml
+++ b/metricbeat/module/munin/_meta/config.yml
@@ -1,6 +1,3 @@
 - module: munin
-  metricsets: ["node"]
-  enabled: false
-  period: 10s
   hosts: ["localhost:4949"]
   node.namespace: node

--- a/metricbeat/module/munin/_meta/docs.asciidoc
+++ b/metricbeat/module/munin/_meta/docs.asciidoc
@@ -2,3 +2,4 @@
 
 This is the munin module.
 
+The default metricset is `node`.

--- a/metricbeat/module/munin/node/node.go
+++ b/metricbeat/module/munin/node/node.go
@@ -14,7 +14,9 @@ import (
 // the MetricSet for each host defined in the module's configuration. After the
 // MetricSet has been created then Fetch will begin to be called periodically.
 func init() {
-	mb.Registry.MustAddMetricSet("munin", "node", New)
+	mb.Registry.MustAddMetricSet("munin", "node", New,
+		mb.DefaultMetricSet(),
+	)
 }
 
 // MetricSet holds any configuration or state information. It must implement


### PR DESCRIPTION
The assumption here is that the port 4949 is the default port that a local service will expose the munin protocol. And for the namespace we manually set `node` as the default.