### PR TITLE
Set `pool` as default metricset for php_fpm module

### DIFF
--- a/metricbeat/docs/modules/php_fpm.asciidoc
+++ b/metricbeat/docs/modules/php_fpm.asciidoc
@@ -10,6 +10,8 @@ beta[]
 This module periodically fetches metrics from https://php-fpm.org[PHP-FPM]
 servers.
 
+The default metricset is `pool`.
+
 [float]
 === Module-specific configuration notes
 
@@ -48,9 +50,6 @@ in <<configuration-metricbeat>>. Here is an example configuration:
 ----
 metricbeat.modules:
 - module: php_fpm
-  metricsets: ["pool"]
-  period: 10s
-  status_path: "/status"
   hosts: ["localhost:8080"]
 ----
 

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -422,6 +422,7 @@ metricbeat.modules:
 #------------------------------- PHP_FPM Module ------------------------------
 - module: php_fpm
   metricsets: ["pool"]
+  enabled: true
   period: 10s
   status_path: "/status"
   hosts: ["localhost:8080"]

--- a/metricbeat/module/php_fpm/_meta/config.reference.yml
+++ b/metricbeat/module/php_fpm/_meta/config.reference.yml
@@ -1,0 +1,6 @@
+- module: php_fpm
+  metricsets: ["pool"]
+  enabled: true
+  period: 10s
+  status_path: "/status"
+  hosts: ["localhost:8080"]

--- a/metricbeat/module/php_fpm/_meta/config.yml
+++ b/metricbeat/module/php_fpm/_meta/config.yml
@@ -1,5 +1,2 @@
 - module: php_fpm
-  metricsets: ["pool"]
-  period: 10s
-  status_path: "/status"
   hosts: ["localhost:8080"]

--- a/metricbeat/module/php_fpm/_meta/docs.asciidoc
+++ b/metricbeat/module/php_fpm/_meta/docs.asciidoc
@@ -1,6 +1,8 @@
 This module periodically fetches metrics from https://php-fpm.org[PHP-FPM]
 servers.
 
+The default metricset is `pool`.
+
 [float]
 === Module-specific configuration notes
 

--- a/metricbeat/module/php_fpm/pool/pool.go
+++ b/metricbeat/module/php_fpm/pool/pool.go
@@ -13,9 +13,10 @@ import (
 
 // init registers the MetricSet with the central registry.
 func init() {
-	if err := mb.Registry.AddMetricSet("php_fpm", "pool", New, HostParser); err != nil {
-		panic(err)
-	}
+	mb.Registry.MustAddMetricSet("php_fpm", "pool", New,
+		mb.WithHostParser(hostParser),
+		mb.DefaultMetricSet(),
+	)
 }
 
 const (
@@ -23,8 +24,8 @@ const (
 	defaultPath   = "/status"
 )
 
-// HostParser is used for parsing the configured php-fpm hosts.
-var HostParser = parse.URLHostParserBuilder{
+// hostParser is used for parsing the configured php-fpm hosts.
+var hostParser = parse.URLHostParserBuilder{
 	DefaultScheme: defaultScheme,
 	DefaultPath:   defaultPath,
 	QueryParams:   "json",

--- a/metricbeat/modules.d/php_fpm.yml.disabled
+++ b/metricbeat/modules.d/php_fpm.yml.disabled
@@ -1,5 +1,2 @@
 - module: php_fpm
-  metricsets: ["pool"]
-  period: 10s
-  status_path: "/status"
   hosts: ["localhost:8080"]


### PR DESCRIPTION
See #6668 