### PR TITLE
Set `stubstatus` as default metricset for nginx module

### DIFF
--- a/metricbeat/docs/modules/nginx.asciidoc
+++ b/metricbeat/docs/modules/nginx.asciidoc
@@ -7,6 +7,8 @@ This file is generated! See scripts/docs_collector.py
 
 This module periodically fetches metrics from https://nginx.org/[Nginx] servers.
 
+The default metricset is `stubstatus`.
+
 
 [float]
 === Compatibility
@@ -32,14 +34,7 @@ in <<configuration-metricbeat>>. Here is an example configuration:
 ----
 metricbeat.modules:
 - module: nginx
-  metricsets: ["stubstatus"]
-  period: 10s
-
-  # Nginx hosts
   hosts: ["http://127.0.0.1"]
-
-  # Path to server status. Default server-status
-  #server_status_path: "server-status"
 ----
 
 This module supports TLS connection when using `ssl` config field, as described in <<configuration-ssl>>.

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -408,16 +408,16 @@ metricbeat.modules:
   #raw: false
 
 #-------------------------------- Nginx Module -------------------------------
-#- module: nginx
-  #metricsets: ["stubstatus"]
-  #enabled: true
-  #period: 10s
+- module: nginx
+  metricsets: ["stubstatus"]
+  enabled: true
+  period: 10s
 
   # Nginx hosts
-  #hosts: ["http://127.0.0.1"]
+  hosts: ["http://127.0.0.1"]
 
   # Path to server status. Default server-status
-  #server_status_path: "server-status"
+  server_status_path: "server-status"
 
 #------------------------------- PHP_FPM Module ------------------------------
 - module: php_fpm

--- a/metricbeat/module/nginx/_meta/config.reference.yml
+++ b/metricbeat/module/nginx/_meta/config.reference.yml
@@ -1,10 +1,10 @@
-#- module: nginx
-  #metricsets: ["stubstatus"]
-  #enabled: true
-  #period: 10s
+- module: nginx
+  metricsets: ["stubstatus"]
+  enabled: true
+  period: 10s
 
   # Nginx hosts
-  #hosts: ["http://127.0.0.1"]
+  hosts: ["http://127.0.0.1"]
 
   # Path to server status. Default server-status
-  #server_status_path: "server-status"
+  server_status_path: "server-status"

--- a/metricbeat/module/nginx/_meta/config.yml
+++ b/metricbeat/module/nginx/_meta/config.yml
@@ -1,9 +1,2 @@
 - module: nginx
-  metricsets: ["stubstatus"]
-  period: 10s
-
-  # Nginx hosts
   hosts: ["http://127.0.0.1"]
-
-  # Path to server status. Default server-status
-  #server_status_path: "server-status"

--- a/metricbeat/module/nginx/_meta/docs.asciidoc
+++ b/metricbeat/module/nginx/_meta/docs.asciidoc
@@ -1,5 +1,7 @@
 This module periodically fetches metrics from https://nginx.org/[Nginx] servers.
 
+The default metricset is `stubstatus`.
+
 
 [float]
 === Compatibility

--- a/metricbeat/module/nginx/stubstatus/stubstatus.go
+++ b/metricbeat/module/nginx/stubstatus/stubstatus.go
@@ -26,9 +26,10 @@ var (
 )
 
 func init() {
-	if err := mb.Registry.AddMetricSet("nginx", "stubstatus", New, hostParser); err != nil {
-		panic(err)
-	}
+	mb.Registry.MustAddMetricSet("nginx", "stubstatus", New,
+		mb.WithHostParser(hostParser),
+		mb.DefaultMetricSet(),
+	)
 }
 
 // MetricSet for fetching Nginx stub status.

--- a/metricbeat/modules.d/nginx.yml.disabled
+++ b/metricbeat/modules.d/nginx.yml.disabled
@@ -1,9 +1,2 @@
 - module: nginx
-  metricsets: ["stubstatus"]
-  period: 10s
-
-  # Nginx hosts
   hosts: ["http://127.0.0.1"]
-
-  # Path to server status. Default server-status
-  #server_status_path: "server-status"


### PR DESCRIPTION
See #6668 