### PR TITLE
Fix unstable ceph tests

### DIFF
--- a/metricbeat/module/ceph/_meta/Dockerfile
+++ b/metricbeat/module/ceph/_meta/Dockerfile
@@ -3,5 +3,11 @@ FROM ceph/demo:tag-build-master-jewel-centos-7
 ENV MON_IP 0.0.0.0
 ENV CEPH_PUBLIC_NETWORK 0.0.0.0/0
 
-HEALTHCHECK --interval=1s --retries=90 CMD ceph --status | grep HEALTH_OK
+RUN yum -q install -y jq && yum clean all && rm -fr /var/cache/yum
+
+# Wait for the health endpoint to have monitors information
+HEALTHCHECK --interval=1s --retries=300 \
+  CMD curl -s -H "Accept: application/json" localhost:5000/api/v0.1/health \
+        | jq .output.health.health_services[0].mons[0] \
+        | grep health
 EXPOSE 5000

--- a/metricbeat/tests/system/test_ceph.py
+++ b/metricbeat/tests/system/test_ceph.py
@@ -6,6 +6,7 @@ import unittest
 class Test(metricbeat.BaseTest):
 
     COMPOSE_SERVICES = ['ceph']
+    COMPOSE_TIMEOUT = 300
 
     @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
     def test_cluster_disk(self):
@@ -26,6 +27,10 @@ class Test(metricbeat.BaseTest):
         self.assertTrue(len(output) >= 1)
         evt = output[0]
         print evt
+
+        self.assertTrue("error" not in evt)
+        self.assertTrue("ceph" in evt)
+        self.assertTrue("cluster_disk" in evt["ceph"])
 
         self.assert_fields_are_documented(evt)
 
@@ -49,6 +54,10 @@ class Test(metricbeat.BaseTest):
         evt = output[0]
         print evt
 
+        self.assertTrue("error" not in evt)
+        self.assertTrue("ceph" in evt)
+        self.assertTrue("cluster_health" in evt["ceph"])
+
         self.assert_fields_are_documented(evt)
 
     @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
@@ -71,6 +80,10 @@ class Test(metricbeat.BaseTest):
         evt = output[0]
         print evt
 
+        self.assertTrue("error" not in evt)
+        self.assertTrue("ceph" in evt)
+        self.assertTrue("monitor_health" in evt["ceph"])
+
         self.assert_fields_are_documented(evt)
 
     @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
@@ -92,6 +105,10 @@ class Test(metricbeat.BaseTest):
         self.assertTrue(len(output) >= 1)
         evt = output[0]
         print evt
+
+        self.assertTrue("error" not in evt)
+        self.assertTrue("ceph" in evt)
+        self.assertTrue("pool_disk" in evt["ceph"])
 
         self.assert_fields_are_documented(evt)
 


### PR DESCRIPTION
Ceph docker healtcheck only waited to have a response to `ceph --status`, but at this moment monitor health information can be still unavailable, what makes `test_monitor_health` to fail. Healthcheck checks now that the health endpoint has information about monitors, this can take about one minute, so compose timeout has been increased for these tests.

Some additional assertions have been also added to check not only that events are received but also that they don't contain errors.