### PR TITLE
[6.2] Backport packetbeat fixes

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -308,6 +308,7 @@ https://github.com/elastic/beats/compare/v6.0.1...v6.1.0[View commits]
 - Fix http parse to allow to parse get request with space in the URI. {pull}5495[5495]
 - Fix mysql SQL parser to trim `\r` from Windows Server `SELECT\r\n\t1`. {pull}5572[5572]
 - Fix corruption when parsing repeated headers in an HTTP request or response. {pull}6325[6325]
+- Fix panic when parsing partial AMQP messages. {pull}6384[6384]
 
 *Winlogbeat*
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -311,6 +311,7 @@ https://github.com/elastic/beats/compare/v6.0.1...v6.1.0[View commits]
 - Fix panic when parsing partial AMQP messages. {pull}6384[6384]
 - Fix out of bounds access to slice in MongoDB parser. {pull}6256[6256]
 - Fix sniffer hanging on exit under Linux. {pull}6535[6535]
+- Fix bounds check error in http parser causing a panic. {pull}6750[6750]
 
 *Winlogbeat*
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -310,6 +310,7 @@ https://github.com/elastic/beats/compare/v6.0.1...v6.1.0[View commits]
 - Fix corruption when parsing repeated headers in an HTTP request or response. {pull}6325[6325]
 - Fix panic when parsing partial AMQP messages. {pull}6384[6384]
 - Fix out of bounds access to slice in MongoDB parser. {pull}6256[6256]
+- Fix sniffer hanging on exit under Linux. {pull}6535[6535]
 
 *Winlogbeat*
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -309,6 +309,7 @@ https://github.com/elastic/beats/compare/v6.0.1...v6.1.0[View commits]
 - Fix mysql SQL parser to trim `\r` from Windows Server `SELECT\r\n\t1`. {pull}5572[5572]
 - Fix corruption when parsing repeated headers in an HTTP request or response. {pull}6325[6325]
 - Fix panic when parsing partial AMQP messages. {pull}6384[6384]
+- Fix out of bounds access to slice in MongoDB parser. {pull}6256[6256]
 
 *Winlogbeat*
 

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -3259,7 +3259,7 @@ OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 --------------------------------------------------------------------
 Dependency: github.com/tsg/gopacket
-Revision: 8e703b9968693c15f25cabb6ba8be4370cf431d0
+Revision: f289b3ea3e41a01b2822be9caf5f40c01fdda05c
 License type (autodetected): BSD-3-Clause
 ./vendor/github.com/tsg/gopacket/LICENSE:
 --------------------------------------------------------------------

--- a/packetbeat/protos/amqp/amqp_parser.go
+++ b/packetbeat/protos/amqp/amqp_parser.go
@@ -72,7 +72,10 @@ func isProtocolHeader(data []byte) (isHeader bool, version string) {
 //func to read a frame header and check if it is valid and complete
 func readFrameHeader(data []byte) (ret *amqpFrame, err bool) {
 	var frame amqpFrame
-
+	if len(data) < 8 {
+		logp.Warn("Partial frame header, waiting for more data")
+		return nil, false
+	}
 	frame.size = binary.BigEndian.Uint32(data[3:7])
 	if len(data) < int(frame.size)+8 {
 		logp.Warn("Frame shorter than declared size, waiting for more data")

--- a/packetbeat/protos/amqp/amqp_test.go
+++ b/packetbeat/protos/amqp/amqp_test.go
@@ -89,6 +89,28 @@ func TestAmqp_FrameSize(t *testing.T) {
 	}
 }
 
+// Test that the parser doesn't panic on a partial message that includes
+// a client header
+func TestAmqp_PartialFrameSize(t *testing.T) {
+	logp.TestingSetup(logp.WithSelectors("amqp", "amqpdetailed"))
+
+	_, amqp := amqpModForTests()
+
+	//incomplete frame
+	data, err := hex.DecodeString("414d515000060606010000000000")
+	assert.Nil(t, err)
+
+	stream := &amqpStream{data: data, message: new(amqpMessage)}
+	ok, complete := amqp.amqpMessageParser(stream)
+
+	if !ok {
+		t.Errorf("Parsing should not raise an error")
+	}
+	if complete {
+		t.Errorf("message should not be complete")
+	}
+}
+
 func TestAmqp_WrongShortStringSize(t *testing.T) {
 	logp.TestingSetup(logp.WithSelectors("amqp", "amqpdetailed"))
 

--- a/packetbeat/protos/http/http_parser.go
+++ b/packetbeat/protos/http/http_parser.go
@@ -141,7 +141,7 @@ func (*parser) parseHTTPLine(s *stream, m *message) (cont, ok, complete bool) {
 	var version []byte
 	var err error
 	fline := s.data[s.parseOffset:i]
-	if len(fline) < 8 {
+	if len(fline) < 9 {
 		if isDebug {
 			debugf("First line too small")
 		}

--- a/packetbeat/protos/mongodb/mongodb_parser.go
+++ b/packetbeat/protos/mongodb/mongodb_parser.go
@@ -341,6 +341,9 @@ func (d *decoder) readDocument() (bson.M, error) {
 	start := d.i
 	documentLength, err := d.readInt32()
 	d.i = start + documentLength
+	if len(d.in) < d.i {
+		return nil, errors.New("document out of bounds")
+	}
 
 	documentMap := bson.M{}
 

--- a/packetbeat/protos/mongodb/mongodb_test.go
+++ b/packetbeat/protos/mongodb/mongodb_test.go
@@ -333,3 +333,29 @@ func TestMaxDocSize(t *testing.T) {
 
 	assert.Equal(t, "\"1234 ...\n\"123\"\n\"12\"", res["response"])
 }
+
+// Test for a (recovered) panic parsing document length in request/response messages
+func TestDocumentLengthBoundsChecked(t *testing.T) {
+	logp.TestingSetup(logp.WithSelectors("mongodb", "mongodbdetailed"))
+
+	_, mongodb := mongodbModForTests()
+
+	// request and response from tests/pcaps/mongo_one_row.pcap
+	reqData, err := hex.DecodeString(
+		// Request message with out of bounds document
+		"320000000a000000ffffffffd4070000" +
+			"00000000746573742e72667374617572" +
+			"616e7473000000000001000000" +
+			// Document length (including itself)
+			"06000000" +
+			// Document (1 byte instead of 2)
+			"00")
+	assert.Nil(t, err)
+
+	tcptuple := testTCPTuple()
+	req := protos.Packet{Payload: reqData}
+	private := protos.ProtocolData(new(mongodbConnectionData))
+
+	private = mongodb.Parse(&req, tcptuple, 0, private)
+	assert.NotNil(t, private, "mongodb parser recovered from a panic")
+}

--- a/vendor/github.com/tsg/gopacket/layers/lldp.go
+++ b/vendor/github.com/tsg/gopacket/layers/lldp.go
@@ -9,6 +9,7 @@ package layers
 import (
 	"encoding/binary"
 	"fmt"
+
 	"github.com/tsg/gopacket"
 )
 
@@ -737,7 +738,7 @@ func decodeLinkLayerDiscovery(data []byte, p gopacket.PacketBuilder) error {
 	for len(vData) > 0 {
 		nbit := vData[0] & 0x01
 		t := LLDPTLVType(vData[0] >> 1)
-		val := LinkLayerDiscoveryValue{Type: t, Length: uint16(nbit<<8 + vData[1])}
+		val := LinkLayerDiscoveryValue{Type: t, Length: uint16(nbit)<<8 + uint16(vData[1])}
 		if val.Length > 0 {
 			val.Value = vData[2 : val.Length+2]
 		}

--- a/vendor/github.com/tsg/gopacket/pcap/pcap_poll_common.go
+++ b/vendor/github.com/tsg/gopacket/pcap/pcap_poll_common.go
@@ -1,0 +1,18 @@
+// +build !linux
+
+package pcap
+
+/*
+#include <pcap/pcap.h>
+*/
+import "C"
+
+type packetPoll struct{}
+
+func NewPacketPoll(_ *C.pcap_t, _ C.int) *packetPoll {
+	return nil
+}
+
+func (t *packetPoll) AwaitForPackets() bool {
+	return true
+}

--- a/vendor/github.com/tsg/gopacket/pcap/pcap_poll_linux.go
+++ b/vendor/github.com/tsg/gopacket/pcap/pcap_poll_linux.go
@@ -1,0 +1,52 @@
+// +build linux
+
+package pcap
+
+/*
+#include <linux/if_packet.h>
+#include <poll.h>
+#include <pcap/pcap.h>
+*/
+import "C"
+import "syscall"
+
+// packetPoll holds all the parameters required to use poll(2) on the pcap
+// file descriptor.
+type packetPoll struct {
+	pollfd  C.struct_pollfd
+	timeout C.int
+}
+
+func captureIsTPacketV3(fildes int) bool {
+	version, err := syscall.GetsockoptInt(fildes, syscall.SOL_PACKET, C.PACKET_VERSION)
+	return err == nil && version == C.TPACKET_V3
+}
+
+// NewPacketPoll returns a new packetPoller if the pcap handle requires it
+// in order to timeout effectively when no packets are received. This is only
+// necessary when TPACKET_V3 interface is used to receive packets.
+func NewPacketPoll(ptr *C.pcap_t, timeout C.int) *packetPoll {
+	fildes := C.pcap_fileno(ptr)
+	if !captureIsTPacketV3(int(fildes)) {
+		return nil
+	}
+	return &packetPoll{
+		pollfd: C.struct_pollfd{
+			fd:      fildes,
+			events:  C.POLLIN,
+			revents: 0,
+		},
+		timeout: timeout,
+	}
+}
+
+func (t *packetPoll) AwaitForPackets() bool {
+	if t != nil {
+		t.pollfd.revents = 0
+		// block until the capture file descriptor is readable or a timeout
+		// happens.
+		n, err := C.poll(&t.pollfd, 1, t.timeout)
+		return err != nil || n != 0
+	}
+	return true
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -971,8 +971,8 @@
 		{
 			"checksumSHA1": "M0S9278lG9Fztu+ZUsLUi40GDJU=",
 			"path": "github.com/tsg/gopacket",
-			"revision": "8e703b9968693c15f25cabb6ba8be4370cf431d0",
-			"revisionTime": "2016-08-17T18:24:57Z"
+			"revision": "f289b3ea3e41a01b2822be9caf5f40c01fdda05c",
+			"revisionTime": "2018-03-16T21:03:30Z"
 		},
 		{
 			"checksumSHA1": "STY8i3sZLdZfFcKiyOdpV852nls=",


### PR DESCRIPTION
This backports packetbeat's fixes from master:

- AMQP: Fix panic during parse of partial message (#6384)
- Fix out of bounds access to slice in MongoDB parser (#6256)  fixes #5188
- Updated dependency `github.com/tsg/gopacket` (#6583) fixes #6535
- Fix minor panic in http parser (#6750)