### PR TITLE
Add CHANGELOG-developer file to cover internal changes

### DIFF
--- a/CHANGELOG-developer.asciidoc
+++ b/CHANGELOG-developer.asciidoc
@@ -3,7 +3,12 @@
 :issue: https://github.com/elastic/beats/issues/
 :pull: https://github.com/elastic/beats/pull/
 
-This changelog is intended for community Beats developers. It covers the major breaking changes to the interal API's in the official Beats and changes around developing a Beat like generators or `fields.yml`. Only the major changes will be covered in this changelog which are expected to affect community developers. Each breaking change added here should have an explanation on how other Beats should be migrated.
+This changelog is intended for community Beat developers. It covers the major
+breaking changes to the internal APIs in the official Beats and changes related
+to developing a Beat like code generators or `fields.yml`. Only the major
+changes will be covered in this changelog that are expected to affect community
+developers. Each breaking change added here should have an explanation on how
+other Beats should be migrated.
 
 Note: This changelog was only started after the 6.3 release.
 

--- a/CHANGELOG-developer.asciidoc
+++ b/CHANGELOG-developer.asciidoc
@@ -1,0 +1,18 @@
+// Use these for links to issue and pulls. Note issues and pulls redirect one to
+// each other on Github, so don't worry too much on using the right prefix.
+:issue: https://github.com/elastic/beats/issues/
+:pull: https://github.com/elastic/beats/pull/
+
+This changelog is intended for community Beats developers. It covers the major breaking changes to the interal API's in the official Beats and changes around developing a Beat like generators or `fields.yml`. Only the major changes will be covered in this changelog which are expected to affect community developers. Each breaking change added here should have an explanation on how other Beats should be migrated.
+
+Note: This changelog was only started after the 6.3 release.
+
+=== Beats version HEAD
+https://github.com/elastic/beats/compare/v6.3.0..master[Check the HEAD diff]
+
+The list below covers the major changes between 6.3.0 and master only.
+
+==== Breaking changes
+
+
+==== Added

--- a/docs/devguide/contributing.asciidoc
+++ b/docs/devguide/contributing.asciidoc
@@ -16,14 +16,18 @@ The process for contributing to any of the Elastic repositories is similar.
 [[contribution-steps]]
 === Contribution Steps
 
-. Please make sure you have signed our https://www.elastic.co/contributor-agreement/[Contributor License Agreement]. We are not asking you to assign
-copyright to us, but to give us the right to distribute your code without
-restriction. We ask this of all contributors in order to assure our users of the
-origin and continuing existence of the code. You only need to sign the CLA once.
+. Please make sure you have signed our
+https://www.elastic.co/contributor-agreement/[Contributor License Agreement]. We
+are not asking you to assign copyright to us, but to give us the right to
+distribute your code without restriction. We ask this of all contributors in
+order to assure our users of the origin and continuing existence of the code.
+You only need to sign the CLA once.
 
-. Send a pull request! Push your changes to your fork of the repository and https://help.github.com/articles/using-pull-requests[submit a pull request]. In
+. Send a pull request! Push your changes to your fork of the repository and
+https://help.github.com/articles/using-pull-requests[submit a pull request]. In
 the pull request, describe what your changes do and mention any bugs/issues
-related to the pull request. Please also add a changelog entry to https://github.com/elastic/beats/blob/master/CHANGELOG.asciidoc[CHANGELOG.asciidoc].
+related to the pull request. Please also add a changelog entry to
+https://github.com/elastic/beats/blob/master/CHANGELOG.asciidoc[CHANGELOG.asciidoc].
 
 [float]
 [[adding-new-beat]]
@@ -92,8 +96,9 @@ This command has the following dependencies:
 * Python >= {python}
 * https://virtualenv.pypa.io/en/latest/[virtualenv] for Python
 
-Virtualenv can be installed with the command `easy_install virtualenv` or `pip install virtualenv`.
-More details can be found https://virtualenv.pypa.io/en/latest/installation.html[here].
+Virtualenv can be installed with the command `easy_install virtualenv` or `pip
+install virtualenv`. More details can be found
+https://virtualenv.pypa.io/en/latest/installation.html[here].
 
 [float]
 [[running-testsuite]]
@@ -136,3 +141,10 @@ the govendor documentation on how to add or update vendored dependencies.
 
 In most cases `govendor fetch your/dependency@version +out` will get the job done.
 
+[float]
+[[changelog]]
+=== Changelog
+
+To keep up to date with changes to the official Beats for community developers,
+follow the developer changelog
+https://github.com/elastic/beats/blob/master/CHANGELOG-developer.md[here].


### PR DESCRIPTION
The CHANGELOG.asciidoc contains all user facing changes. During the development of Beats lots of internal changes are made to also public API methods. Some of these are used by community Beats. The CHANGELOG-developer.asciidoc is intended to cover these changes and explain how community beats can be migrated. Only a small subset of all API changes will be documented here.