### PR TITLE
Remove arch from test audit rules

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -345,8 +345,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 --------------------------------------------------------------------
 Dependency: github.com/elastic/go-libaudit
-Version: v0.1.0
-Revision: 4a806edf821706e315ef7d4f3b5d0cac6d638b34
+Version: v0.1.1
+Revision: bc9f53eaa23bfe3fbf023ab5ec7523336b4d9b2f
 License type (autodetected): Apache-2.0
 ./vendor/github.com/elastic/go-libaudit/LICENSE:
 --------------------------------------------------------------------

--- a/auditbeat/module/auditd/config_linux_test.go
+++ b/auditbeat/module/auditd/config_linux_test.go
@@ -14,7 +14,7 @@ audit_rules: |
   # Comments and empty lines are ignored.
   -w /etc/passwd -p wa -k auth
 
-  -a always,exit -F arch=b64 -S execve -k exec`
+  -a always,exit -S execve -k exec`
 
 	config, err := parseConfig(t, data)
 	if err != nil {
@@ -26,7 +26,7 @@ audit_rules: |
 	}
 	assert.EqualValues(t, []string{
 		"-w /etc/passwd -p wa -k auth",
-		"-a always,exit -F arch=b64 -S execve -k exec",
+		"-a always,exit -S execve -k exec",
 	}, commands(rules))
 }
 
@@ -35,7 +35,7 @@ func TestConfigValidateWithError(t *testing.T) {
 audit_rules: |
   -x bad -F flag
   -a always,exit -w /etc/passwd
-  -a always,exit -F arch=b64 -S fake -k exec`
+  -a always,exit -S fake -k exec`
 
 	_, err := parseConfig(t, data)
 	if err == nil {

--- a/vendor/github.com/elastic/go-libaudit/CHANGELOG.md
+++ b/vendor/github.com/elastic/go-libaudit/CHANGELOG.md
@@ -2,6 +2,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.1.1]
+
+- rules - Detect s390 or s390x as the runtime architecture (GOOS) and
+  automatically use the appropriate syscall name to number table without
+  requiring the rule to explicitly specify an arch (`-F arch=s390x`). #23
+
 ## [0.1.0]
 
 ### Changed

--- a/vendor/github.com/elastic/go-libaudit/rule/rule.go
+++ b/vendor/github.com/elastic/go-libaudit/rule/rule.go
@@ -560,7 +560,7 @@ func getArch(arch string) (string, uint32, error) {
 	return realArch, archValue, nil
 }
 
-// getRuntimeArch returns the programs arch (not the machines arch).
+// getRuntimeArch returns the program's arch (not the machine's arch).
 func getRuntimeArch() (string, error) {
 	var arch string
 	switch runtime.GOARCH {
@@ -574,6 +574,10 @@ func getRuntimeArch() (string, error) {
 		arch = "x86_64"
 	case "ppc64", "ppc64le":
 		arch = "ppc"
+	case "s390":
+		arch = "s390"
+	case "s390x":
+		arch = "s390x"
 	case "mips", "mipsle", "mips64", "mips64le":
 		fallthrough
 	default:

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -369,44 +369,44 @@
 			"revisionTime": "2016-08-05T00:47:13Z"
 		},
 		{
-			"checksumSHA1": "FmPMalgdsaNNmghFB2DWm8fJjVA=",
+			"checksumSHA1": "xnqOjimkuBpJ7ecRgl04tAHomIw=",
 			"path": "github.com/elastic/go-libaudit",
-			"revision": "4a806edf821706e315ef7d4f3b5d0cac6d638b34",
-			"revisionTime": "2018-03-28T14:46:34Z",
-			"version": "v0.1.0",
-			"versionExact": "v0.1.0"
+			"revision": "bc9f53eaa23bfe3fbf023ab5ec7523336b4d9b2f",
+			"revisionTime": "2018-04-05T19:19:11Z",
+			"version": "v0.1.1",
+			"versionExact": "v0.1.1"
 		},
 		{
 			"checksumSHA1": "uu4544BCRlonueK+mB7549opucs=",
 			"path": "github.com/elastic/go-libaudit/aucoalesce",
-			"revision": "4a806edf821706e315ef7d4f3b5d0cac6d638b34",
-			"revisionTime": "2018-03-28T14:46:34Z",
-			"version": "v0.1.0",
-			"versionExact": "v0.1.0"
+			"revision": "bc9f53eaa23bfe3fbf023ab5ec7523336b4d9b2f",
+			"revisionTime": "2018-04-05T19:19:11Z",
+			"version": "v0.1.1",
+			"versionExact": "v0.1.1"
 		},
 		{
 			"checksumSHA1": "+L/ZGneCw2zrkK5Vlto9UB3LaEk=",
 			"path": "github.com/elastic/go-libaudit/auparse",
-			"revision": "4a806edf821706e315ef7d4f3b5d0cac6d638b34",
-			"revisionTime": "2018-03-28T14:46:34Z",
-			"version": "v0.1.0",
-			"versionExact": "v0.1.0"
+			"revision": "bc9f53eaa23bfe3fbf023ab5ec7523336b4d9b2f",
+			"revisionTime": "2018-04-05T19:19:11Z",
+			"version": "v0.1.1",
+			"versionExact": "v0.1.1"
 		},
 		{
-			"checksumSHA1": "H0rnscnKHbkjmXc4whC3gtIPR0c=",
+			"checksumSHA1": "aItCMksfjRftKVKgTd8Ro3yBB/0=",
 			"path": "github.com/elastic/go-libaudit/rule",
-			"revision": "4a806edf821706e315ef7d4f3b5d0cac6d638b34",
-			"revisionTime": "2018-03-28T14:46:34Z",
-			"version": "v0.1.0",
-			"versionExact": "v0.1.0"
+			"revision": "bc9f53eaa23bfe3fbf023ab5ec7523336b4d9b2f",
+			"revisionTime": "2018-04-05T19:19:11Z",
+			"version": "v0.1.1",
+			"versionExact": "v0.1.1"
 		},
 		{
 			"checksumSHA1": "36UaYid29Kyhrsa5D8N6BoM8dVw=",
 			"path": "github.com/elastic/go-libaudit/rule/flags",
-			"revision": "4a806edf821706e315ef7d4f3b5d0cac6d638b34",
-			"revisionTime": "2018-03-28T14:46:34Z",
-			"version": "v0.1.0",
-			"versionExact": "v0.1.0"
+			"revision": "bc9f53eaa23bfe3fbf023ab5ec7523336b4d9b2f",
+			"revisionTime": "2018-04-05T19:19:11Z",
+			"version": "v0.1.1",
+			"versionExact": "v0.1.1"
 		},
 		{
 			"checksumSHA1": "3jizmlZPCyo6FAZY8Trk9jA8NH4=",


### PR DESCRIPTION
The audit rules in the tests contain "-F arch=b64" which makes them valid only for a few architectures ("aarch64", "x86_64", "ppc"). By removing the filter Auditbeat will automatically use the GOOS architecture in determining how to translate the syscall name to the appropriate syscall number (syscall numbers are architecture specific).
