### PR TITLE
http: Save the request or response body independently

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -311,6 +311,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - HTTP parses successfully on empty status phrase. {issue}6176[6176]
 - HTTP parser supports broken status line. {pull}6631[6631]
 - Fix high memory usage on HTTP body if body is not published. {pull}6680[6680]
+- Allow to capture the HTTP request or response bodies independently. {pull}6784[6784]
 
 *Winlogbeat*
 

--- a/packetbeat/_meta/beat.reference.yml
+++ b/packetbeat/_meta/beat.reference.yml
@@ -179,8 +179,17 @@ packetbeat.protocols:
   #send_all_headers: false
 
   # The list of content types for which Packetbeat includes the full HTTP
-  # payload in the response field.
+  # payload. If the request's or response's Content-Type matches any on this
+  # list, the full body will be included under the request or response field.
   #include_body_for: []
+
+  # The list of content types for which Packetbeat includes the full HTTP
+  # request payload.
+  #include_request_body_for: []
+
+  # The list of content types for which Packetbeat includes the full HTTP
+  # response payload.
+  #include_response_body_for: []
 
   # If the Cookie or Set-Cookie headers are sent, this option controls whether
   # they are split into individual values.

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -179,8 +179,17 @@ packetbeat.protocols:
   #send_all_headers: false
 
   # The list of content types for which Packetbeat includes the full HTTP
-  # payload in the response field.
+  # payload. If the request's or response's Content-Type matches any on this
+  # list, the full body will be included under the request or response field.
   #include_body_for: []
+
+  # The list of content types for which Packetbeat includes the full HTTP
+  # request payload.
+  #include_request_body_for: []
+
+  # The list of content types for which Packetbeat includes the full HTTP
+  # response payload.
+  #include_response_body_for: []
 
   # If the Cookie or Set-Cookie headers are sent, this option controls whether
   # they are split into individual values.

--- a/packetbeat/protos/http/config.go
+++ b/packetbeat/protos/http/config.go
@@ -7,15 +7,17 @@ import (
 )
 
 type httpConfig struct {
-	config.ProtocolCommon `config:",inline"`
-	SendAllHeaders        bool     `config:"send_all_headers"`
-	SendHeaders           []string `config:"send_headers"`
-	SplitCookie           bool     `config:"split_cookie"`
-	RealIPHeader          string   `config:"real_ip_header"`
-	IncludeBodyFor        []string `config:"include_body_for"`
-	HideKeywords          []string `config:"hide_keywords"`
-	RedactAuthorization   bool     `config:"redact_authorization"`
-	MaxMessageSize        int      `config:"max_message_size"`
+	config.ProtocolCommon  `config:",inline"`
+	SendAllHeaders         bool     `config:"send_all_headers"`
+	SendHeaders            []string `config:"send_headers"`
+	SplitCookie            bool     `config:"split_cookie"`
+	RealIPHeader           string   `config:"real_ip_header"`
+	IncludeBodyFor         []string `config:"include_body_for"`
+	IncludeRequestBodyFor  []string `config:"include_request_body_for"`
+	IncludeResponseBodyFor []string `config:"include_response_body_for"`
+	HideKeywords           []string `config:"hide_keywords"`
+	RedactAuthorization    bool     `config:"redact_authorization"`
+	MaxMessageSize         int      `config:"max_message_size"`
 }
 
 var (

--- a/packetbeat/protos/http/http.go
+++ b/packetbeat/protos/http/http.go
@@ -122,7 +122,12 @@ func (http *httpPlugin) setFromConfig(config *httpConfig) {
 	http.splitCookie = config.SplitCookie
 	http.parserConfig.realIPHeader = strings.ToLower(config.RealIPHeader)
 	http.transactionTimeout = config.TransactionTimeout
-	http.parserConfig.includeBodyFor = config.IncludeBodyFor
+	for _, list := range [][]string{config.IncludeBodyFor, config.IncludeRequestBodyFor} {
+		http.parserConfig.includeRequestBodyFor = append(http.parserConfig.includeRequestBodyFor, list...)
+	}
+	for _, list := range [][]string{config.IncludeBodyFor, config.IncludeResponseBodyFor} {
+		http.parserConfig.includeResponseBodyFor = append(http.parserConfig.includeResponseBodyFor, list...)
+	}
 	http.maxMessageSize = config.MaxMessageSize
 
 	if config.SendAllHeaders {


### PR DESCRIPTION
This patch adds two new configuration options to the http protocol plugin in packetbeat: `include_request_body_for` and `include_response_body_for`.  They work in a similar way to `include_body_for`, but apply only to the request or response bodies.

When `include_body_for` is also specified, the behavior is as follows:

  include_body_for: [A]
  include_request_body_for: [B]
  include_response_body_for: [C]

Requests bodies will be included if the content-type matches either A or B, and response bodies if it is A or C.