### PR TITLE
Provide access to a global logp.Logger

### DIFF
--- a/libbeat/logp/core.go
+++ b/libbeat/logp/core.go
@@ -27,14 +27,16 @@ func init() {
 		selectors:    map[string]struct{}{},
 		rootLogger:   zap.NewNop(),
 		globalLogger: zap.NewNop(),
+		logger:       newLogger(zap.NewNop(), ""),
 	})
 }
 
 type coreLogger struct {
-	selectors    map[string]struct{}
-	rootLogger   *zap.Logger
-	globalLogger *zap.Logger
-	observedLogs *observer.ObservedLogs
+	selectors    map[string]struct{}    // Set of enabled debug selectors.
+	rootLogger   *zap.Logger            // Root logger without any options configured.
+	globalLogger *zap.Logger            // Logger used by legacy global functions (e.g. logp.Info).
+	logger       *Logger                // Logger that is the basis for all logp.Loggers.
+	observedLogs *observer.ObservedLogs // Contains events generated while in observation mode (a testing mode).
 }
 
 // Configure configures the logp package.
@@ -92,6 +94,7 @@ func Configure(cfg Config) error {
 		selectors:    selectors,
 		rootLogger:   root,
 		globalLogger: root.WithOptions(zap.AddCallerSkip(1)),
+		logger:       newLogger(root, ""),
 		observedLogs: observedLogs,
 	})
 	return nil

--- a/libbeat/logp/core_test.go
+++ b/libbeat/logp/core_test.go
@@ -187,3 +187,29 @@ func TestIsDebug(t *testing.T) {
 	assert.False(t, IsDebug("all"))
 	assert.True(t, IsDebug("only_this"))
 }
+
+func TestL(t *testing.T) {
+	if err := DevelopmentSetup(ToObserverOutput()); err != nil {
+		t.Fatal(err)
+	}
+
+	L().Infow("infow", "rate", 2)
+	logs := ObserverLogs().TakeAll()
+	if assert.Len(t, logs, 1) {
+		log := logs[0]
+		assert.Equal(t, zap.InfoLevel, log.Level)
+		assert.Equal(t, "", log.LoggerName)
+		assert.Equal(t, "infow", log.Message)
+		assert.Contains(t, log.ContextMap(), "rate")
+	}
+
+	const loggerName = "tester"
+	L().Named(loggerName).Warnf("warning %d", 1)
+	logs = ObserverLogs().TakeAll()
+	if assert.Len(t, logs, 1) {
+		log := logs[0]
+		assert.Equal(t, zap.WarnLevel, log.Level)
+		assert.Equal(t, loggerName, log.LoggerName)
+		assert.Equal(t, "warning 1", log.Message)
+	}
+}

--- a/libbeat/publisher/pipeline/log.go
+++ b/libbeat/publisher/pipeline/log.go
@@ -1,5 +1,0 @@
-package pipeline
-
-import "github.com/elastic/beats/libbeat/logp"
-
-var defaultLogger = logp.NewLogger("publish")

--- a/libbeat/publisher/pipeline/pipeline.go
+++ b/libbeat/publisher/pipeline/pipeline.go
@@ -141,7 +141,7 @@ func New(
 ) (*Pipeline, error) {
 	var err error
 
-	log := defaultLogger
+	log := logp.NewLogger("publish")
 	annotations := settings.Annotations
 	processors := settings.Processors
 	disabledOutput := settings.Disabled

--- a/libbeat/publisher/queue/memqueue/broker.go
+++ b/libbeat/publisher/queue/memqueue/broker.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/publisher/queue"
 )
 
@@ -100,10 +101,9 @@ func NewBroker(
 		minEvents = sz
 	}
 
-	logger := defaultLogger
 	b := &Broker{
 		done:   make(chan struct{}),
-		logger: logger,
+		logger: logp.NewLogger("memqueue"),
 
 		// broker API channels
 		events:    make(chan pushRequest, chanSize),

--- a/libbeat/publisher/queue/memqueue/log.go
+++ b/libbeat/publisher/queue/memqueue/log.go
@@ -1,12 +1,6 @@
 package memqueue
 
-import (
-	"github.com/elastic/beats/libbeat/logp"
-)
-
 type logger interface {
 	Debug(...interface{})
 	Debugf(string, ...interface{})
 }
-
-var defaultLogger logger = logp.NewLogger("memqueue")


### PR DESCRIPTION
This provides static contexts with access to a `logp.Logger` by calling `logp.L()`.

This also fixes the two instances where `logp.NewLogger` was called from a global context.