### PR TITLE
Fix panic in log harvester error handling

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -57,6 +57,8 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 
 *Filebeat*
 
+- Fix panic when log prospector configuration fails to load. {issue}6800[6800]
+
 *Heartbeat*
 
 *Metricbeat*

--- a/filebeat/input/log/input.go
+++ b/filebeat/input/log/input.go
@@ -585,7 +585,9 @@ func (p *Input) createHarvester(state file.State, onTerminate func()) (*Harveste
 		},
 		outlet,
 	)
-	h.onTerminate = onTerminate
+	if err == nil {
+		h.onTerminate = onTerminate
+	}
 	return h, err
 }
 


### PR DESCRIPTION
When the log harvester initialisation fails (i.e. due to wrong configuration), it causes a panic instead of reporting the error.

Fixes #6800