### PR TITLE
[6.2] Fix panic in log harvester error handling

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -36,6 +36,8 @@ https://github.com/elastic/beats/compare/v6.2.2...6.2[Check the HEAD diff]
 
 *Filebeat*
 
+- Fix panic when log prospector configuration fails to load. {issue}6800[6800]
+
 *Heartbeat*
 
 *Metricbeat*

--- a/filebeat/prospector/log/prospector.go
+++ b/filebeat/prospector/log/prospector.go
@@ -584,7 +584,9 @@ func (p *Prospector) createHarvester(state file.State, onTerminate func()) (*Har
 		},
 		outlet,
 	)
-	h.onTerminate = onTerminate
+	if err == nil {
+		h.onTerminate = onTerminate
+	}
 	return h, err
 }
 


### PR DESCRIPTION
When the log harvester initialisation fails (i.e. due to wrong configuration), it causes a panic instead of reporting the error.

Fixes #6800