### PR TITLE
Fix leaks in filebeat log harvester

### DIFF
--- a/filebeat/channel/util.go
+++ b/filebeat/channel/util.go
@@ -22,13 +22,20 @@ func SubOutlet(out Outleter) Outleter {
 		res:    make(chan bool, 1),
 	}
 
-	go func() {
-		for event := range s.ch {
-			s.res <- out.OnEvent(event)
-		}
-	}()
+	go s.drainLoop(out)
 
 	return s
+}
+
+func (o *subOutlet) drainLoop(out Outleter) {
+	for {
+		select {
+		case <-o.done:
+			return
+		case event := <-o.ch:
+			o.res <- out.OnEvent(event)
+		}
+	}
 }
 
 func (o *subOutlet) Close() error {

--- a/filebeat/input/log/harvester.go
+++ b/filebeat/input/log/harvester.go
@@ -144,6 +144,7 @@ func (h *Harvester) ID() uuid.UUID {
 func (h *Harvester) Setup() error {
 	err := h.open()
 	if err != nil {
+		h.stop()
 		return fmt.Errorf("Harvester setup failed. Unexpected file opening error: %s", err)
 	}
 
@@ -152,6 +153,7 @@ func (h *Harvester) Setup() error {
 		if h.source != nil {
 			h.source.Close()
 		}
+		h.stop()
 		return fmt.Errorf("Harvester setup failed. Unexpected encoding line reader error: %s", err)
 	}
 


### PR DESCRIPTION
Two independent but related causes of goroutine leaks have been found in filebeat:

- channel.SubOutlet fails to terminate an internal goroutine, which keeps references to the SubOutlet itself and the Outlet being wrapped, preventing them from being freed.

- log.Harvester constructor receives an Outlet which is closed by Harvester.Stop() or internally after Harvester.Run() is invoked. When Harvester.Setup() fails, Stop() is not called, causing a leak. A CloseOnSignal() util is also leaked for the same reasons, which adds another goroutine leak.

Fixes #6797