### PR TITLE
Cherry-pick #6347 to 6.2: Defer registry state cleanup

### DIFF
--- a/filebeat/tests/system/test_harvester.py
+++ b/filebeat/tests/system/test_harvester.py
@@ -276,7 +276,7 @@ class Test(BaseTest):
         # Wait until state is written
         self.wait_until(
             lambda: self.log_contains(
-                "Registrar states cleaned up"),
+                "Registrar state updates processed"),
             max_timeout=15)
 
         filebeat.check_kill_and_wait()


### PR DESCRIPTION
Cherry-pick of PR #6347 to 6.2 branch. Original message: 

- Defer registrar state gc until the registry needs to be written.
- when updating regitrar states from batch, ensure all updated states will
have same timestamp.

Depends on #6346 