### PR TITLE
Add Ingest pipeline loading to setup

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -117,6 +117,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Add json.ignore_decoding_error config to not log json decoding erors. {issue}6547[6547]
 - Make registry file permission configurable. {pull}6455[6455]
 - Add MongoDB module. {pull}6283[6238]
+- Add Ingest pipeline loading to setup. {pull}6814[6814]
 
 *Heartbeat*
 

--- a/filebeat/_meta/common.reference.p2.yml
+++ b/filebeat/_meta/common.reference.p2.yml
@@ -1,4 +1,4 @@
-#=========================== Filebeat inputs =============================
+ new#=========================== Filebeat inputs =============================
 
 # List of inputs to fetch data.
 filebeat.inputs:
@@ -285,6 +285,10 @@ filebeat.inputs:
 # Must be a valid Unix-style file permissions mask expressed in octal notation.
 # This option is not supported on Windows.
 #filebeat.registry_file_permissions: 0600
+
+# By default Ingest pipelines are not updated. If this option is enabled Filebeat updates
+# pipelines everytime a new Elasticsearch connection is established.
+#filebeat.update_pipelines: false
 
 # These config files must have the full filebeat config part inside, but only
 # the input part is processed. All global options like spool_size are ignored.

--- a/filebeat/_meta/common.reference.p2.yml
+++ b/filebeat/_meta/common.reference.p2.yml
@@ -287,9 +287,9 @@ filebeat.inputs:
 #filebeat.registry_file_permissions: 0600
 
 # By default Ingest pipelines are not updated if a pipeline with the same ID
-# already exists. If this option is enabled Filebeat updates pipelines everytime
-# a new Elasticsearch connection is established.
-#filebeat.update_pipelines: false
+# already exists. If this option is enabled Filebeat overwrites pipelines
+# everytime a new Elasticsearch connection is established.
+#filebeat.overwrite_pipelines: false
 
 # These config files must have the full filebeat config part inside, but only
 # the input part is processed. All global options like spool_size are ignored.

--- a/filebeat/_meta/common.reference.p2.yml
+++ b/filebeat/_meta/common.reference.p2.yml
@@ -286,8 +286,9 @@ filebeat.inputs:
 # This option is not supported on Windows.
 #filebeat.registry_file_permissions: 0600
 
-# By default Ingest pipelines are not updated. If this option is enabled Filebeat updates
-# pipelines everytime a new Elasticsearch connection is established.
+# By default Ingest pipelines are not updated if a pipeline with the same ID
+# already exists. If this option is enabled Filebeat updates pipelines everytime
+# a new Elasticsearch connection is established.
 #filebeat.update_pipelines: false
 
 # These config files must have the full filebeat config part inside, but only

--- a/filebeat/_meta/common.reference.p2.yml
+++ b/filebeat/_meta/common.reference.p2.yml
@@ -1,4 +1,4 @@
- new#=========================== Filebeat inputs =============================
+#=========================== Filebeat inputs =============================
 
 # List of inputs to fetch data.
 filebeat.inputs:

--- a/filebeat/beater/filebeat.go
+++ b/filebeat/beater/filebeat.go
@@ -35,8 +35,7 @@ const pipelinesWarning = "Filebeat is unable to load the Ingest Node pipelines f
 	" can ignore this warning."
 
 var (
-	once            = flag.Bool("once", false, "Run filebeat only once until all harvesters reach EOF")
-	updatePipelines = flag.Bool("update-pipelines", false, "Update Ingest pipelines")
+	once = flag.Bool("once", false, "Run filebeat only once until all harvesters reach EOF")
 )
 
 // Filebeat is a beater object. Contains all objects needed to run the beat
@@ -141,7 +140,7 @@ func (fb *Filebeat) loadModulesPipelines(b *beat.Beat) error {
 	// register pipeline loading to happen every time a new ES connection is
 	// established
 	callback := func(esClient *elasticsearch.Client) error {
-		return fb.moduleRegistry.LoadPipelines(esClient, *updatePipelines)
+		return fb.moduleRegistry.LoadPipelines(esClient, updatePipelines)
 	}
 	elasticsearch.RegisterConnectCallback(callback)
 
@@ -314,11 +313,11 @@ func (fb *Filebeat) Run(b *beat.Beat) error {
 		logp.Warn(pipelinesWarning)
 	}
 
-	if *updatePipelines {
+	if config.UpdatePipelines {
 		logp.Debug("modules", "Existing Ingest pipelines will be updated")
 	}
 
-	err = crawler.Start(registrar, config.ConfigInput, config.ConfigModules, pipelineLoaderFactory, *updatePipelines)
+	err = crawler.Start(registrar, config.ConfigInput, config.ConfigModules, pipelineLoaderFactory, config.UpdatePipelines)
 	if err != nil {
 		crawler.Stop()
 		return err

--- a/filebeat/cmd/root.go
+++ b/filebeat/cmd/root.go
@@ -20,7 +20,6 @@ func init() {
 	var runFlags = pflag.NewFlagSet(Name, pflag.ExitOnError)
 	runFlags.AddGoFlag(flag.CommandLine.Lookup("once"))
 	runFlags.AddGoFlag(flag.CommandLine.Lookup("modules"))
-	runFlags.AddGoFlag(flag.CommandLine.Lookup("update-pipelines"))
 
 	RootCmd = cmd.GenRootCmdWithRunFlags(Name, "", beater.New, runFlags)
 	RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("M"))

--- a/filebeat/config/config.go
+++ b/filebeat/config/config.go
@@ -34,6 +34,7 @@ type Config struct {
 	ConfigProspector        *common.Config       `config:"config.prospectors"`
 	ConfigModules           *common.Config       `config:"config.modules"`
 	Autodiscover            *autodiscover.Config `config:"autodiscover"`
+	UpdatePipelines         bool                 `config:"update_pipelines"`
 }
 
 var (
@@ -41,6 +42,7 @@ var (
 		RegistryFile:            "registry",
 		RegistryFilePermissions: 0600,
 		ShutdownTimeout:         0,
+		UpdatePipelines:         false,
 	}
 )
 

--- a/filebeat/config/config.go
+++ b/filebeat/config/config.go
@@ -34,7 +34,7 @@ type Config struct {
 	ConfigProspector        *common.Config       `config:"config.prospectors"`
 	ConfigModules           *common.Config       `config:"config.modules"`
 	Autodiscover            *autodiscover.Config `config:"autodiscover"`
-	UpdatePipelines         bool                 `config:"update_pipelines"`
+	OverwritePipelines      bool                 `config:"overwrite_pipelines"`
 }
 
 var (
@@ -42,7 +42,7 @@ var (
 		RegistryFile:            "registry",
 		RegistryFilePermissions: 0600,
 		ShutdownTimeout:         0,
-		UpdatePipelines:         false,
+		OverwritePipelines:      false,
 	}
 )
 

--- a/filebeat/crawler/crawler.go
+++ b/filebeat/crawler/crawler.go
@@ -43,7 +43,7 @@ func New(out channel.Factory, inputConfigs []*common.Config, beatVersion string,
 
 // Start starts the crawler with all inputs
 func (c *Crawler) Start(r *registrar.Registrar, configInputs *common.Config,
-	configModules *common.Config, pipelineLoaderFactory fileset.PipelineLoaderFactory, updatePipelines bool) error {
+	configModules *common.Config, pipelineLoaderFactory fileset.PipelineLoaderFactory, overwritePipelines bool) error {
 
 	logp.Info("Loading Inputs: %v", len(c.inputConfigs))
 
@@ -67,7 +67,7 @@ func (c *Crawler) Start(r *registrar.Registrar, configInputs *common.Config,
 		}()
 	}
 
-	c.ModulesFactory = fileset.NewFactory(c.out, r, c.beatVersion, pipelineLoaderFactory, updatePipelines, c.beatDone)
+	c.ModulesFactory = fileset.NewFactory(c.out, r, c.beatVersion, pipelineLoaderFactory, overwritePipelines, c.beatDone)
 	if configModules.Enabled() {
 		c.modulesReloader = cfgfile.NewReloader(configModules)
 		if err := c.modulesReloader.Check(c.ModulesFactory); err != nil {

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -307,7 +307,7 @@ filebeat.modules:
     #input:
 
 
-#=========================== Filebeat inputs =============================
+ new#=========================== Filebeat inputs =============================
 
 # List of inputs to fetch data.
 filebeat.inputs:
@@ -594,6 +594,10 @@ filebeat.inputs:
 # Must be a valid Unix-style file permissions mask expressed in octal notation.
 # This option is not supported on Windows.
 #filebeat.registry_file_permissions: 0600
+
+# By default Ingest pipelines are not updated. If this option is enabled Filebeat updates
+# pipelines everytime a new Elasticsearch connection is established.
+#filebeat.update_pipelines: false
 
 # These config files must have the full filebeat config part inside, but only
 # the input part is processed. All global options like spool_size are ignored.

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -596,9 +596,9 @@ filebeat.inputs:
 #filebeat.registry_file_permissions: 0600
 
 # By default Ingest pipelines are not updated if a pipeline with the same ID
-# already exists. If this option is enabled Filebeat updates pipelines everytime
-# a new Elasticsearch connection is established.
-#filebeat.update_pipelines: false
+# already exists. If this option is enabled Filebeat overwrites pipelines
+# everytime a new Elasticsearch connection is established.
+#filebeat.overwrite_pipelines: false
 
 # These config files must have the full filebeat config part inside, but only
 # the input part is processed. All global options like spool_size are ignored.

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -595,8 +595,9 @@ filebeat.inputs:
 # This option is not supported on Windows.
 #filebeat.registry_file_permissions: 0600
 
-# By default Ingest pipelines are not updated. If this option is enabled Filebeat updates
-# pipelines everytime a new Elasticsearch connection is established.
+# By default Ingest pipelines are not updated if a pipeline with the same ID
+# already exists. If this option is enabled Filebeat updates pipelines everytime
+# a new Elasticsearch connection is established.
 #filebeat.update_pipelines: false
 
 # These config files must have the full filebeat config part inside, but only

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -307,7 +307,7 @@ filebeat.modules:
     #input:
 
 
- new#=========================== Filebeat inputs =============================
+#=========================== Filebeat inputs =============================
 
 # List of inputs to fetch data.
 filebeat.inputs:

--- a/filebeat/fileset/factory.go
+++ b/filebeat/fileset/factory.go
@@ -18,7 +18,7 @@ type Factory struct {
 	registrar             *registrar.Registrar
 	beatVersion           string
 	pipelineLoaderFactory PipelineLoaderFactory
-	updatePipelines       bool
+	overwritePipelines    bool
 	beatDone              chan struct{}
 }
 
@@ -28,19 +28,19 @@ type inputsRunner struct {
 	moduleRegistry        *ModuleRegistry
 	inputs                []*input.Runner
 	pipelineLoaderFactory PipelineLoaderFactory
-	updatePipelines       bool
+	overwritePipelines    bool
 }
 
 // NewFactory instantiates a new Factory
 func NewFactory(outlet channel.Factory, registrar *registrar.Registrar, beatVersion string,
-	pipelineLoaderFactory PipelineLoaderFactory, updatePipelines bool, beatDone chan struct{}) *Factory {
+	pipelineLoaderFactory PipelineLoaderFactory, overwritePipelines bool, beatDone chan struct{}) *Factory {
 	return &Factory{
 		outlet:                outlet,
 		registrar:             registrar,
 		beatVersion:           beatVersion,
 		beatDone:              beatDone,
 		pipelineLoaderFactory: pipelineLoaderFactory,
-		updatePipelines:       updatePipelines,
+		overwritePipelines:    overwritePipelines,
 	}
 }
 
@@ -79,7 +79,7 @@ func (f *Factory) Create(c *common.Config, meta *common.MapStrPointer) (cfgfile.
 		moduleRegistry:        m,
 		inputs:                inputs,
 		pipelineLoaderFactory: f.pipelineLoaderFactory,
-		updatePipelines:       f.updatePipelines,
+		overwritePipelines:    f.overwritePipelines,
 	}, nil
 }
 
@@ -91,7 +91,7 @@ func (p *inputsRunner) Start() {
 		if err != nil {
 			logp.Err("Error loading pipeline: %s", err)
 		} else {
-			err := p.moduleRegistry.LoadPipelines(pipelineLoader, p.updatePipelines)
+			err := p.moduleRegistry.LoadPipelines(pipelineLoader, p.overwritePipelines)
 			if err != nil {
 				// Log error and continue
 				logp.Err("Error loading pipeline: %s", err)
@@ -100,7 +100,7 @@ func (p *inputsRunner) Start() {
 
 		// Callback:
 		callback := func(esClient *elasticsearch.Client) error {
-			return p.moduleRegistry.LoadPipelines(esClient, p.updatePipelines)
+			return p.moduleRegistry.LoadPipelines(esClient, p.overwritePipelines)
 		}
 		elasticsearch.RegisterConnectCallback(callback)
 	}

--- a/filebeat/fileset/modules.go
+++ b/filebeat/fileset/modules.go
@@ -263,7 +263,7 @@ func (reg *ModuleRegistry) InfoString() string {
 	var result string
 	for module, filesets := range reg.registry {
 		var filesetNames string
-		for name, _ := range filesets {
+		for name := range filesets {
 			if filesetNames != "" {
 				filesetNames += ", "
 			}

--- a/filebeat/fileset/modules.go
+++ b/filebeat/fileset/modules.go
@@ -257,44 +257,6 @@ func (reg *ModuleRegistry) GetInputConfigs() ([]*common.Config, error) {
 	return result, nil
 }
 
-// PipelineLoader factory builds and returns a PipelineLoader
-type PipelineLoaderFactory func() (PipelineLoader, error)
-
-// PipelineLoader is a subset of the Elasticsearch client API capable of loading
-// the pipelines.
-type PipelineLoader interface {
-	LoadJSON(path string, json map[string]interface{}) ([]byte, error)
-	Request(method, path string, pipeline string, params map[string]string, body interface{}) (int, []byte, error)
-	GetVersion() string
-}
-
-// LoadPipelines loads the pipelines for each configured fileset.
-func (reg *ModuleRegistry) LoadPipelines(esClient PipelineLoader, forceUpdate bool) error {
-	for module, filesets := range reg.registry {
-		for name, fileset := range filesets {
-			// check that all the required Ingest Node plugins are available
-			requiredProcessors := fileset.GetRequiredProcessors()
-			logp.Debug("modules", "Required processors: %s", requiredProcessors)
-			if len(requiredProcessors) > 0 {
-				err := checkAvailableProcessors(esClient, requiredProcessors)
-				if err != nil {
-					return fmt.Errorf("Error loading pipeline for fileset %s/%s: %v", module, name, err)
-				}
-			}
-
-			pipelineID, content, err := fileset.GetPipeline(esClient.GetVersion())
-			if err != nil {
-				return fmt.Errorf("Error getting pipeline for fileset %s/%s: %v", module, name, err)
-			}
-			err = loadPipeline(esClient, pipelineID, content, forceUpdate)
-			if err != nil {
-				return fmt.Errorf("Error loading pipeline for fileset %s/%s: %v", module, name, err)
-			}
-		}
-	}
-	return nil
-}
-
 // InfoString returns the enabled modules and filesets in a single string, ready to
 // be shown to the user
 func (reg *ModuleRegistry) InfoString() string {
@@ -372,87 +334,6 @@ func checkAvailableProcessors(esClient PipelineLoader, requiredProcessors []Proc
 	}
 
 	return nil
-}
-
-func loadPipeline(esClient PipelineLoader, pipelineID string, content map[string]interface{}, forceUpdate bool) error {
-	path := "/_ingest/pipeline/" + pipelineID
-	if !forceUpdate {
-		status, _, _ := esClient.Request("GET", path, "", nil, nil)
-		if status == 200 {
-			logp.Debug("modules", "Pipeline %s already loaded", pipelineID)
-			return nil
-		}
-	}
-	body, err := esClient.LoadJSON(path, content)
-	if err != nil {
-		return interpretError(err, body)
-	}
-	logp.Info("Elasticsearch pipeline with ID '%s' loaded", pipelineID)
-	return nil
-}
-
-func interpretError(initialErr error, body []byte) error {
-	var response struct {
-		Error struct {
-			RootCause []struct {
-				Type   string `json:"type"`
-				Reason string `json:"reason"`
-				Header struct {
-					ProcessorType string `json:"processor_type"`
-				} `json:"header"`
-				Index string `json:"index"`
-			} `json:"root_cause"`
-		} `json:"error"`
-	}
-	err := json.Unmarshal(body, &response)
-	if err != nil {
-		// this might be ES < 2.0. Do a best effort to check for ES 1.x
-		var response1x struct {
-			Error string `json:"error"`
-		}
-		err1x := json.Unmarshal(body, &response1x)
-		if err1x == nil && response1x.Error != "" {
-			return fmt.Errorf("The Filebeat modules require Elasticsearch >= 5.0. "+
-				"This is the response I got from Elasticsearch: %s", body)
-		}
-
-		return fmt.Errorf("couldn't load pipeline: %v. Additionally, error decoding response body: %s",
-			initialErr, body)
-	}
-
-	// missing plugins?
-	if len(response.Error.RootCause) > 0 &&
-		response.Error.RootCause[0].Type == "parse_exception" &&
-		strings.HasPrefix(response.Error.RootCause[0].Reason, "No processor type exists with name") &&
-		response.Error.RootCause[0].Header.ProcessorType != "" {
-
-		plugins := map[string]string{
-			"geoip":      "ingest-geoip",
-			"user_agent": "ingest-user-agent",
-		}
-		plugin, ok := plugins[response.Error.RootCause[0].Header.ProcessorType]
-		if !ok {
-			return fmt.Errorf("This module requires an Elasticsearch plugin that provides the %s processor. "+
-				"Please visit the Elasticsearch documentation for instructions on how to install this plugin. "+
-				"Response body: %s", response.Error.RootCause[0].Header.ProcessorType, body)
-		}
-
-		return fmt.Errorf("This module requires the %s plugin to be installed in Elasticsearch. "+
-			"You can install it using the following command in the Elasticsearch home directory:\n"+
-			"    sudo bin/elasticsearch-plugin install %s", plugin, plugin)
-	}
-
-	// older ES version?
-	if len(response.Error.RootCause) > 0 &&
-		response.Error.RootCause[0].Type == "invalid_index_name_exception" &&
-		response.Error.RootCause[0].Index == "_ingest" {
-
-		return fmt.Errorf("The Ingest Node functionality seems to be missing from Elasticsearch. "+
-			"The Filebeat modules require Elasticsearch >= 5.0. "+
-			"This is the response I got from Elasticsearch: %s", body)
-	}
-
-	return fmt.Errorf("couldn't load pipeline: %v. Response body: %s", initialErr, body)
 }
 
 // LoadML loads the machine-learning configurations into Elasticsearch, if X-Pack is available

--- a/filebeat/fileset/pipelines.go
+++ b/filebeat/fileset/pipelines.go
@@ -8,7 +8,7 @@ import (
 	"github.com/elastic/beats/libbeat/logp"
 )
 
-// PipelineLoader factory builds and returns a PipelineLoader
+// PipelineLoaderFactory builds and returns a PipelineLoader
 type PipelineLoaderFactory func() (PipelineLoader, error)
 
 // PipelineLoader is a subset of the Elasticsearch client API capable of loading
@@ -21,7 +21,6 @@ type PipelineLoader interface {
 
 // LoadPipelines loads the pipelines for each configured fileset.
 func (reg *ModuleRegistry) LoadPipelines(esClient PipelineLoader, forceUpdate bool) error {
-	fmt.Println("itten")
 	for module, filesets := range reg.registry {
 		for name, fileset := range filesets {
 			// check that all the required Ingest Node plugins are available

--- a/filebeat/fileset/pipelines.go
+++ b/filebeat/fileset/pipelines.go
@@ -20,7 +20,7 @@ type PipelineLoader interface {
 }
 
 // LoadPipelines loads the pipelines for each configured fileset.
-func (reg *ModuleRegistry) LoadPipelines(esClient PipelineLoader, forceUpdate bool) error {
+func (reg *ModuleRegistry) LoadPipelines(esClient PipelineLoader, overwrite bool) error {
 	for module, filesets := range reg.registry {
 		for name, fileset := range filesets {
 			// check that all the required Ingest Node plugins are available
@@ -37,7 +37,7 @@ func (reg *ModuleRegistry) LoadPipelines(esClient PipelineLoader, forceUpdate bo
 			if err != nil {
 				return fmt.Errorf("Error getting pipeline for fileset %s/%s: %v", module, name, err)
 			}
-			err = loadPipeline(esClient, pipelineID, content, forceUpdate)
+			err = loadPipeline(esClient, pipelineID, content, overwrite)
 			if err != nil {
 				return fmt.Errorf("Error loading pipeline for fileset %s/%s: %v", module, name, err)
 			}
@@ -46,9 +46,9 @@ func (reg *ModuleRegistry) LoadPipelines(esClient PipelineLoader, forceUpdate bo
 	return nil
 }
 
-func loadPipeline(esClient PipelineLoader, pipelineID string, content map[string]interface{}, forceUpdate bool) error {
+func loadPipeline(esClient PipelineLoader, pipelineID string, content map[string]interface{}, overwrite bool) error {
 	path := "/_ingest/pipeline/" + pipelineID
-	if !forceUpdate {
+	if !overwrite {
 		status, _, _ := esClient.Request("GET", path, "", nil, nil)
 		if status == 200 {
 			logp.Debug("modules", "Pipeline %s already loaded", pipelineID)

--- a/filebeat/fileset/pipelines.go
+++ b/filebeat/fileset/pipelines.go
@@ -1,0 +1,129 @@
+package fileset
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/elastic/beats/libbeat/logp"
+)
+
+// PipelineLoader factory builds and returns a PipelineLoader
+type PipelineLoaderFactory func() (PipelineLoader, error)
+
+// PipelineLoader is a subset of the Elasticsearch client API capable of loading
+// the pipelines.
+type PipelineLoader interface {
+	LoadJSON(path string, json map[string]interface{}) ([]byte, error)
+	Request(method, path string, pipeline string, params map[string]string, body interface{}) (int, []byte, error)
+	GetVersion() string
+}
+
+// LoadPipelines loads the pipelines for each configured fileset.
+func (reg *ModuleRegistry) LoadPipelines(esClient PipelineLoader, forceUpdate bool) error {
+	fmt.Println("itten")
+	for module, filesets := range reg.registry {
+		for name, fileset := range filesets {
+			// check that all the required Ingest Node plugins are available
+			requiredProcessors := fileset.GetRequiredProcessors()
+			logp.Debug("modules", "Required processors: %s", requiredProcessors)
+			if len(requiredProcessors) > 0 {
+				err := checkAvailableProcessors(esClient, requiredProcessors)
+				if err != nil {
+					return fmt.Errorf("Error loading pipeline for fileset %s/%s: %v", module, name, err)
+				}
+			}
+
+			pipelineID, content, err := fileset.GetPipeline(esClient.GetVersion())
+			if err != nil {
+				return fmt.Errorf("Error getting pipeline for fileset %s/%s: %v", module, name, err)
+			}
+			err = loadPipeline(esClient, pipelineID, content, forceUpdate)
+			if err != nil {
+				return fmt.Errorf("Error loading pipeline for fileset %s/%s: %v", module, name, err)
+			}
+		}
+	}
+	return nil
+}
+
+func loadPipeline(esClient PipelineLoader, pipelineID string, content map[string]interface{}, forceUpdate bool) error {
+	path := "/_ingest/pipeline/" + pipelineID
+	if !forceUpdate {
+		status, _, _ := esClient.Request("GET", path, "", nil, nil)
+		if status == 200 {
+			logp.Debug("modules", "Pipeline %s already loaded", pipelineID)
+			return nil
+		}
+	}
+	body, err := esClient.LoadJSON(path, content)
+	if err != nil {
+		return interpretError(err, body)
+	}
+	logp.Info("Elasticsearch pipeline with ID '%s' loaded", pipelineID)
+	return nil
+}
+
+func interpretError(initialErr error, body []byte) error {
+	var response struct {
+		Error struct {
+			RootCause []struct {
+				Type   string `json:"type"`
+				Reason string `json:"reason"`
+				Header struct {
+					ProcessorType string `json:"processor_type"`
+				} `json:"header"`
+				Index string `json:"index"`
+			} `json:"root_cause"`
+		} `json:"error"`
+	}
+	err := json.Unmarshal(body, &response)
+	if err != nil {
+		// this might be ES < 2.0. Do a best effort to check for ES 1.x
+		var response1x struct {
+			Error string `json:"error"`
+		}
+		err1x := json.Unmarshal(body, &response1x)
+		if err1x == nil && response1x.Error != "" {
+			return fmt.Errorf("The Filebeat modules require Elasticsearch >= 5.0. "+
+				"This is the response I got from Elasticsearch: %s", body)
+		}
+
+		return fmt.Errorf("couldn't load pipeline: %v. Additionally, error decoding response body: %s",
+			initialErr, body)
+	}
+
+	// missing plugins?
+	if len(response.Error.RootCause) > 0 &&
+		response.Error.RootCause[0].Type == "parse_exception" &&
+		strings.HasPrefix(response.Error.RootCause[0].Reason, "No processor type exists with name") &&
+		response.Error.RootCause[0].Header.ProcessorType != "" {
+
+		plugins := map[string]string{
+			"geoip":      "ingest-geoip",
+			"user_agent": "ingest-user-agent",
+		}
+		plugin, ok := plugins[response.Error.RootCause[0].Header.ProcessorType]
+		if !ok {
+			return fmt.Errorf("This module requires an Elasticsearch plugin that provides the %s processor. "+
+				"Please visit the Elasticsearch documentation for instructions on how to install this plugin. "+
+				"Response body: %s", response.Error.RootCause[0].Header.ProcessorType, body)
+		}
+
+		return fmt.Errorf("This module requires the %s plugin to be installed in Elasticsearch. "+
+			"You can install it using the following command in the Elasticsearch home directory:\n"+
+			"    sudo bin/elasticsearch-plugin install %s", plugin, plugin)
+	}
+
+	// older ES version?
+	if len(response.Error.RootCause) > 0 &&
+		response.Error.RootCause[0].Type == "invalid_index_name_exception" &&
+		response.Error.RootCause[0].Index == "_ingest" {
+
+		return fmt.Errorf("The Ingest Node functionality seems to be missing from Elasticsearch. "+
+			"The Filebeat modules require Elasticsearch >= 5.0. "+
+			"This is the response I got from Elasticsearch: %s", body)
+	}
+
+	return fmt.Errorf("couldn't load pipeline: %v. Response body: %s", initialErr, body)
+}

--- a/libbeat/beat/beat.go
+++ b/libbeat/beat/beat.go
@@ -38,6 +38,7 @@ type Beat struct {
 	SetupMLCallback SetupMLCallback // setup callback for ML job configs
 	InSetupCmd      bool            // this is set to true when the `setup` command is called
 
+	UpdatePipelinesCallback UpdatePipelinesCallback // ingest pipeline loader callback
 	// XXX: remove Config from public interface.
 	//      It's currently used by filebeat modules to setup the Ingest Node
 	//      pipeline and ML jobs.
@@ -55,3 +56,7 @@ type BeatConfig struct {
 // SetupMLCallback can be used by the Beat to register MachineLearning configurations
 // for the enabled modules.
 type SetupMLCallback func(*Beat, *common.Config) error
+
+// UpdatePipelinesCallback can be used by the Beat to register Ingest pipeline loader
+// for the enabled modules.
+type UpdatePipelinesCallback func(*common.Config) error

--- a/libbeat/beat/beat.go
+++ b/libbeat/beat/beat.go
@@ -38,7 +38,7 @@ type Beat struct {
 	SetupMLCallback SetupMLCallback // setup callback for ML job configs
 	InSetupCmd      bool            // this is set to true when the `setup` command is called
 
-	UpdatePipelinesCallback UpdatePipelinesCallback // ingest pipeline loader callback
+	OverwritePipelinesCallback OverwritePipelinesCallback // ingest pipeline loader callback
 	// XXX: remove Config from public interface.
 	//      It's currently used by filebeat modules to setup the Ingest Node
 	//      pipeline and ML jobs.
@@ -57,6 +57,6 @@ type BeatConfig struct {
 // for the enabled modules.
 type SetupMLCallback func(*Beat, *common.Config) error
 
-// UpdatePipelinesCallback can be used by the Beat to register Ingest pipeline loader
+// OverwritePipelinesCallback can be used by the Beat to register Ingest pipeline loader
 // for the enabled modules.
-type UpdatePipelinesCallback func(*common.Config) error
+type OverwritePipelinesCallback func(*common.Config) error

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -404,9 +404,9 @@ func (b *Beat) Setup(bt beat.Creator, template, dashboards, machineLearning, pip
 			fmt.Println("Loaded machine learning job configurations")
 		}
 
-		if pipelines && b.UpdatePipelinesCallback != nil {
+		if pipelines && b.OverwritePipelinesCallback != nil {
 			esConfig := b.Config.Output.Config()
-			err = b.UpdatePipelinesCallback(esConfig)
+			err = b.OverwritePipelinesCallback(esConfig)
 			if err != nil {
 				return err
 			}

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -341,7 +341,7 @@ func (b *Beat) TestConfig(bt beat.Creator) error {
 }
 
 // Setup registers ES index template and kibana dashboards
-func (b *Beat) Setup(bt beat.Creator, template, dashboards, machineLearning bool) error {
+func (b *Beat) Setup(bt beat.Creator, template, dashboards, machineLearning, pipelines bool) error {
 	return handleError(func() error {
 		err := b.Init()
 		if err != nil {
@@ -402,6 +402,16 @@ func (b *Beat) Setup(bt beat.Creator, template, dashboards, machineLearning bool
 				return err
 			}
 			fmt.Println("Loaded machine learning job configurations")
+		}
+
+		if pipelines && b.UpdatePipelinesCallback != nil {
+			esConfig := b.Config.Output.Config()
+			err = b.UpdatePipelinesCallback(esConfig)
+			if err != nil {
+				return err
+			}
+
+			fmt.Println("Loaded Ingest pipelines")
 		}
 
 		return nil

--- a/libbeat/cmd/setup.go
+++ b/libbeat/cmd/setup.go
@@ -19,6 +19,7 @@ func genSetupCmd(name, idxPrefix, version string, beatCreator beat.Creator) *cob
  * Index mapping template in Elasticsearch to ensure fields are mapped.
  * Kibana dashboards (where available).
  * ML jobs (where available).
+ * Ingest pipelines (where available).
 `,
 		Run: func(cmd *cobra.Command, args []string) {
 			beat, err := instance.NewBeat(name, idxPrefix, version)
@@ -30,15 +31,16 @@ func genSetupCmd(name, idxPrefix, version string, beatCreator beat.Creator) *cob
 			template, _ := cmd.Flags().GetBool("template")
 			dashboards, _ := cmd.Flags().GetBool("dashboards")
 			machineLearning, _ := cmd.Flags().GetBool("machine-learning")
+			pipelines, _ := cmd.Flags().GetBool("pipelines")
 
 			// No flags: setup all
-			if !template && !dashboards && !machineLearning {
+			if !template && !dashboards && !machineLearning && !pipelines {
 				template = true
 				dashboards = true
 				machineLearning = true
 			}
 
-			if err = beat.Setup(beatCreator, template, dashboards, machineLearning); err != nil {
+			if err = beat.Setup(beatCreator, template, dashboards, machineLearning, pipelines); err != nil {
 				os.Exit(1)
 			}
 		},
@@ -47,6 +49,7 @@ func genSetupCmd(name, idxPrefix, version string, beatCreator beat.Creator) *cob
 	setup.Flags().Bool("template", false, "Setup index template only")
 	setup.Flags().Bool("dashboards", false, "Setup dashboards only")
 	setup.Flags().Bool("machine-learning", false, "Setup machine learning job configurations only")
+	setup.Flags().Bool("pipelines", false, "Setup Ingest pipelines only")
 
 	return &setup
 }


### PR DESCRIPTION
### 1. Update pipeline config option

The yet unreleased flag `--update-pipelines` is removed. Instead of this a new config option is introduced which does the same thing. Its name is `filebeat.overwrite_pipelines`. By default it is set to `false`.

```yml
# By default Ingest pipelines are not updated. If this option is enabled Filebeat updates
# pipelines everytime a new Elasticsearch connection is established.
filebeat.update_pipelines: false
```

### 2. Load pipelines using `setup`
Furthermore, it's possible to load Ingest pipelines using the command `setup`. Please note, only configured pipelines are loaded. To make sure users don't lose events pipeline loading before sending messages is kept.

Closes #6808 