### PR TITLE
Metricbeat: Remove duplicated filesystems in system module

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -189,6 +189,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Set `stubstatus` as default metricset for nginx module. {pull}6770[6770]
 - Added support for haproxy 1.7 and 1.8. {pull}6793[6793]
 - Add accumulated I/O stats to diskio in the line of `docker stats`. {pull}6701[6701]
+- Ignore virtual filesystem types by default in system module. {pull}6819[6819]
 
 *Packetbeat*
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -76,6 +76,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Fix namespace disambiguation in Kubernetes state_* metricsets. {issue}6281[6281]
 - Fix Windows perfmon metricset so that it sends metrics when an error occurs. {pull}6542[6542]
 - Fix Kubernetes calculated fields store. {pull}6564{6564}
+- Exclude bind mounts in fsstat and filesystem metricsets. {pull}6819[6819]
 
 *Packetbeat*
 

--- a/metricbeat/docs/fields.asciidoc
+++ b/metricbeat/docs/fields.asciidoc
@@ -12914,7 +12914,7 @@ The percentage of used disk space.
 [float]
 == fsstat fields
 
-`system.fsstat` contains filesystem metrics aggregated from all mounted filesystems, similar with what `df -a` prints out.
+`system.fsstat` contains filesystem metrics aggregated from all mounted filesystems.
 
 
 

--- a/metricbeat/docs/modules/system.asciidoc
+++ b/metricbeat/docs/modules/system.asciidoc
@@ -54,6 +54,9 @@ metricbeat.modules:
   # A list of filesystem types to ignore. The filesystem metricset will not
   # collect data from filesystems matching any of the specified types, and
   # fsstats will not include data from these filesystems in its summary stats.
+  # If not set, types associated to virtual filesystems are automatically
+  # added when this information is available in the system (e.g. the list of
+  # `nodev` types in `/proc/filesystem`).
   #filesystem.ignore_types: []
 
   # These options allow you to filter out all processes that are not

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -74,6 +74,9 @@ metricbeat.modules:
   # A list of filesystem types to ignore. The filesystem metricset will not
   # collect data from filesystems matching any of the specified types, and
   # fsstats will not include data from these filesystems in its summary stats.
+  # If not set, types associated to virtual filesystems are automatically
+  # added when this information is available in the system (e.g. the list of
+  # `nodev` types in `/proc/filesystem`).
   #filesystem.ignore_types: []
 
   # These options allow you to filter out all processes that are not

--- a/metricbeat/module/system/_meta/config.reference.yml
+++ b/metricbeat/module/system/_meta/config.reference.yml
@@ -24,6 +24,9 @@
   # A list of filesystem types to ignore. The filesystem metricset will not
   # collect data from filesystems matching any of the specified types, and
   # fsstats will not include data from these filesystems in its summary stats.
+  # If not set, types associated to virtual filesystems are automatically
+  # added when this information is available in the system (e.g. the list of
+  # `nodev` types in `/proc/filesystem`).
   #filesystem.ignore_types: []
 
   # These options allow you to filter out all processes that are not

--- a/metricbeat/module/system/filesystem/_meta/docs.asciidoc
+++ b/metricbeat/module/system/filesystem/_meta/docs.asciidoc
@@ -14,7 +14,9 @@ This metricset is available on:
 
 *`filesystem.ignore_types`* - A list of filesystem types to ignore. Metrics will
 not be collected from filesystems matching these types. This setting also
-affects the `fsstats` metricset.
+affects the `fsstats` metricset. If this option is not set, metricbeat ignores
+all types for virtual devices in systems where this information is available (e.g.
+all types marked as `nodev` in `/proc/filesystems` in Linux systems).
 
 [float]
 === Filtering

--- a/metricbeat/module/system/filesystem/filesystem.go
+++ b/metricbeat/module/system/filesystem/filesystem.go
@@ -3,6 +3,8 @@
 package filesystem
 
 import (
+	"strings"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/metricbeat/mb"
@@ -30,6 +32,13 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	var config Config
 	if err := base.Module().UnpackConfig(&config); err != nil {
 		return nil, err
+	}
+
+	if config.IgnoreTypes == nil {
+		config.IgnoreTypes = DefaultIgnoredTypes()
+	}
+	if len(config.IgnoreTypes) > 0 {
+		logp.Info("Ignoring filesystem types: %s", strings.Join(config.IgnoreTypes, ", "))
 	}
 
 	return &MetricSet{

--- a/metricbeat/module/system/filesystem/helper.go
+++ b/metricbeat/module/system/filesystem/helper.go
@@ -3,6 +3,7 @@
 package filesystem
 
 import (
+	"os"
 	"path/filepath"
 	"time"
 
@@ -53,7 +54,14 @@ func filterFileSystemList(fsList []sigar.FileSystem) []sigar.FileSystem {
 			continue
 		}
 
-		// If a block device is mounted multiple times (e.g. with bind mounts),
+		// If the device name is a directory, this is a bind mount or nullfs,
+		// don't count it as it'd be counting again its parent filesystem.
+		devFileInfo, _ := os.Stat(fs.DevName)
+		if devFileInfo != nil && devFileInfo.IsDir() {
+			continue
+		}
+
+		// If a block device is mounted multiple times (e.g. with some bind mounts),
 		// store it only once, and use the shorter mount point path.
 		if seen, found := devices[fs.DevName]; found {
 			if len(fs.DirName) < len(seen.DirName) {

--- a/metricbeat/module/system/filesystem/helper.go
+++ b/metricbeat/module/system/filesystem/helper.go
@@ -36,6 +36,11 @@ func GetFileSystemList() ([]sigar.FileSystem, error) {
 		return nil, err
 	}
 
+	if runtime.GOOS == "windows" {
+		// No filtering on Windows
+		return fss.List, nil
+	}
+
 	return filterFileSystemList(fss.List), nil
 }
 

--- a/metricbeat/module/system/filesystem/helper_test.go
+++ b/metricbeat/module/system/filesystem/helper_test.go
@@ -140,34 +140,6 @@ func TestFileSystemListFiltering(t *testing.T) {
 	}
 }
 
-func TestFileSystemListFilteringWindows(t *testing.T) {
-	if runtime.GOOS != "windows" {
-		t.Skip("These cases only need to work on windows")
-	}
-
-	cases := []struct {
-		description   string
-		fss, expected []sigar.FileSystem
-	}{
-		{
-			description: "Keep all filesystems in Windows",
-			fss: []sigar.FileSystem{
-				{DirName: "C:\\", DevName: "C:\\"},
-				{DirName: "D:\\", DevName: "D:\\"},
-			},
-			expected: []sigar.FileSystem{
-				{DirName: "C:\\", DevName: "C:\\"},
-				{DirName: "D:\\", DevName: "D:\\"},
-			},
-		},
-	}
-
-	for _, c := range cases {
-		filtered := filterFileSystemList(c.fss)
-		assert.ElementsMatch(t, c.expected, filtered, c.description)
-	}
-}
-
 func TestFilter(t *testing.T) {
 	in := []sigar.FileSystem{
 		{SysTypeName: "nfs"},

--- a/metricbeat/module/system/filesystem/helper_test.go
+++ b/metricbeat/module/system/filesystem/helper_test.go
@@ -66,7 +66,7 @@ func TestFileSystemListFiltering(t *testing.T) {
 			},
 		},
 		{
-			description: "Don't repeat devices, sortest of dir names should be used",
+			description: "Don't repeat devices, shortest of dir names should be used",
 			fss: []sigar.FileSystem{
 				{DirName: "/", DevName: "/dev/sda1"},
 				{DirName: "/bind", DevName: "/dev/sda1"},
@@ -76,7 +76,7 @@ func TestFileSystemListFiltering(t *testing.T) {
 			},
 		},
 		{
-			description: "Don't repeat devices, sortest of dir names should be used",
+			description: "Don't repeat devices, shortest of dir names should be used",
 			fss: []sigar.FileSystem{
 				{DirName: "/bind", DevName: "/dev/sda1"},
 				{DirName: "/", DevName: "/dev/sda1"},
@@ -97,7 +97,7 @@ func TestFileSystemListFiltering(t *testing.T) {
 			},
 		},
 		{
-			description: "Don't repeat devices, sortest of dir names should be used, keep tmpfs",
+			description: "Don't repeat devices, shortest of dir names should be used, keep tmpfs",
 			fss: []sigar.FileSystem{
 				{DirName: "/", DevName: "/dev/sda1"},
 				{DirName: "/bind", DevName: "/dev/sda1"},

--- a/metricbeat/module/system/fsstat/_meta/docs.asciidoc
+++ b/metricbeat/module/system/fsstat/_meta/docs.asciidoc
@@ -13,4 +13,6 @@ This metricset is available on:
 
 *`filesystem.ignore_types`* - A list of filesystem types to ignore. Metrics will
 not be collected from filesystems matching these types. This setting also
-affects the `filesystem` metricset.
+affects the `filesystem` metricset. If this option is not set, metricbeat ignores
+all types for virtual devices in systems where this information is available (e.g.
+all types marked as `nodev` in `/proc/filesystems` in Linux systems).

--- a/metricbeat/module/system/fsstat/_meta/fields.yml
+++ b/metricbeat/module/system/fsstat/_meta/fields.yml
@@ -2,7 +2,7 @@
   type: group
   description: >
     `system.fsstat` contains filesystem metrics aggregated from all mounted
-    filesystems, similar with what `df -a` prints out.
+    filesystems.
   release: ga
   fields:
     - name: count

--- a/metricbeat/module/system/fsstat/fsstat.go
+++ b/metricbeat/module/system/fsstat/fsstat.go
@@ -53,7 +53,6 @@ func (m *MetricSet) Fetch() (common.MapStr, error) {
 
 	// These values are optional and could also be calculated by Kibana
 	var totalFiles, totalSize, totalSizeFree, totalSizeUsed uint64
-	dict := map[string]bool{}
 
 	for _, fs := range fss {
 		stat, err := filesystem.GetFileSystemStat(fs)
@@ -63,18 +62,10 @@ func (m *MetricSet) Fetch() (common.MapStr, error) {
 		}
 		logp.Debug("fsstat", "filesystem: %s total=%d, used=%d, free=%d", stat.Mount, stat.Total, stat.Used, stat.Free)
 
-		if _, ok := dict[stat.Mount]; ok {
-			// ignore filesystem with the same mounting point
-			continue
-		}
-
 		totalFiles += stat.Files
 		totalSize += stat.Total
 		totalSizeFree += stat.Free
 		totalSizeUsed += stat.Used
-
-		dict[stat.Mount] = true
-
 	}
 
 	return common.MapStr{
@@ -83,7 +74,7 @@ func (m *MetricSet) Fetch() (common.MapStr, error) {
 			"used":  totalSizeUsed,
 			"total": totalSize,
 		},
-		"count":       len(dict),
+		"count":       len(fss),
 		"total_files": totalFiles,
 	}, nil
 }

--- a/metricbeat/module/system/fsstat/fsstat.go
+++ b/metricbeat/module/system/fsstat/fsstat.go
@@ -3,6 +3,8 @@
 package fsstat
 
 import (
+	"strings"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/metricbeat/mb"
@@ -31,6 +33,13 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	var config filesystem.Config
 	if err := base.Module().UnpackConfig(&config); err != nil {
 		return nil, err
+	}
+
+	if config.IgnoreTypes == nil {
+		config.IgnoreTypes = filesystem.DefaultIgnoredTypes()
+	}
+	if len(config.IgnoreTypes) > 0 {
+		logp.Info("Ignoring filesystem types: %s", strings.Join(config.IgnoreTypes, ", "))
 	}
 
 	return &MetricSet{


### PR DESCRIPTION
Mountpoints whose device name is the same absolute path are considered to be the same and are counted only once. The directory name used is the shorter between them. If the device of a filesystem is a directory, it is considered some kind of bind mount and is ignored. This avoids duplication of filesystems as can happen with bind mounts in Linux (#3384). This mimics the behaviour of `df` command.

There are still filesystems that can be counted twice if union filesystems are used (as aufs or overlay), but this can be controlled with the `filesystem.ignore_types` option. ~~Maybe we should blacklist them by default.~~ Update: For that, if the option is left empty, we fill the list of ignored types with all `nodev` devices in `/proc/filesystems` where this file exists.