### PR TITLE
Kubernetes deployment: Add ServiceAccount config to system metricbeat.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -33,6 +33,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 
 *Metricbeat*
 
+- Kubernetes deployment: Add ServiceAccount config to system metricbeat. {pull}6824[6824]
 - Kubernetes deployment: Add DNS Policy to system metricbeat. {pull}6656[6656]
 - De dot keys in kubernetes/event metricset to prevent collisions. {pull}6203[6203]
 - Add config option for windows/perfmon metricset to ignore non existent counters. {pull}6432[6432]

--- a/deploy/kubernetes/metricbeat-kubernetes.yaml
+++ b/deploy/kubernetes/metricbeat-kubernetes.yaml
@@ -204,6 +204,7 @@ spec:
         k8s-app: metricbeat
         kubernetes.io/cluster-service: "true"
     spec:
+      serviceAccountName: metricbeat
       containers:
       - name: metricbeat
         image: docker.elastic.co/beats/metricbeat:7.0.0-alpha1

--- a/deploy/kubernetes/metricbeat/metricbeat-deployment.yaml
+++ b/deploy/kubernetes/metricbeat/metricbeat-deployment.yaml
@@ -14,6 +14,7 @@ spec:
         k8s-app: metricbeat
         kubernetes.io/cluster-service: "true"
     spec:
+      serviceAccountName: metricbeat
       containers:
       - name: metricbeat
         image: docker.elastic.co/beats/metricbeat:%VERSION%


### PR DESCRIPTION
Without the SA, metricbeat is unable to get e.g event infos from kube-state-metrics