### PR TITLE
Remove flush interval from Kafka run script

### DIFF
--- a/metricbeat/module/kafka/_meta/run.sh
+++ b/metricbeat/module/kafka/_meta/run.sh
@@ -21,7 +21,7 @@ mkdir -p ${KAFKA_LOGS_DIR}
 ${KAFKA_HOME}/bin/kafka-server-start.sh ${KAFKA_HOME}/config/server.properties \
     --override delete.topic.enable=true --override advertised.host.name=${KAFKA_ADVERTISED_HOST} \
     --override listeners=PLAINTEXT://0.0.0.0:9092 \
-    --override logs.dir=${KAFKA_LOGS_DIR} --override log.flush.interval.ms=200 &
+    --override logs.dir=${KAFKA_LOGS_DIR} &
 
 wait_for_port 9092
 


### PR DESCRIPTION
The very short flush interval caused the container sometimes to crash. Removing it should make tests more stable.