### PR TITLE
Speed up system tests by caching yaml output

### DIFF
--- a/libbeat/tests/system/beat/beat.py
+++ b/libbeat/tests/system/beat/beat.py
@@ -9,6 +9,7 @@ import signal
 import sys
 import time
 import yaml
+import hashlib
 from datetime import datetime, timedelta
 
 from .compose import ComposeMixin
@@ -18,6 +19,8 @@ BEAT_REQUIRED_FIELDS = ["@timestamp",
                         "beat.name", "beat.hostname", "beat.version"]
 
 INTEGRATION_TESTS = os.environ.get('INTEGRATION_TESTS', False)
+
+yaml_cache = {}
 
 
 class TimeoutError(Exception):
@@ -487,6 +490,8 @@ class TestCase(unittest.TestCase, ComposeMixin):
         if not os.path.isfile(fields_doc):
             fields_doc = self.beat_path + "/_meta/fields.yml"
 
+        global yaml_cache
+
         # TODO: Make fields_doc path more generic to work with beat-generator
         with open(fields_doc, "r") as f:
             path = os.path.abspath(os.path.dirname(__file__) + "../../../../_meta/fields.generated.yml")
@@ -495,9 +500,15 @@ class TestCase(unittest.TestCase, ComposeMixin):
             with open(path) as f2:
                 content = f2.read()
 
-            #content = "fields:\n"
             content += f.read()
-            doc = yaml.load(content)
+
+            hash = hashlib.md5(content).hexdigest()
+            doc = ""
+            if hash in yaml_cache:
+                doc = yaml_cache[hash]
+            else:
+                doc = yaml.safe_load(content)
+                yaml_cache[hash] = doc
 
             fields = []
             dictfields = []


### PR DESCRIPTION
`yaml.load()` took each time up to 1.5s when loading the full fields.yml. This heavily slowed down the tests as the yaml file was loaded each time and event was checked if all fields are documented. This change introduces a cache for the output from the `yaml.load` based on an md5 hash.

test_system before

```
nosetests test_system.py:Test.test_network -v
----------------------------------------------------------------------
Ran 1 test in 8.948s

OK
(python-env) ruflin:system ruflin$ nosetests test_system.py -v
Test core system output. ... ok
Test core system output. ... ok
Test cpu system output. ... ok
Test cpu_ticks configuration option. ... ok
Test system/diskio output. ... SKIP: os
Test system/diskio output on linux. ... SKIP: os
Test system/filesystem output. ... ok
Test system/fsstat output. ... ok
Test system load. ... ok
Test system memory output. ... ok
Test system/network output. ... ok
Test system/process output. ... ok
Checks that the per proc stats are found in the output and ... ok
Test system/process_summary output. ... ok

----------------------------------------------------------------------
Ran 14 tests in 396.891s
```

test_system after

```
----------------------------------------------------------------------
Ran 14 tests in 396.891s

OK (SKIP=2)
(python-env) ruflin:system ruflin$ nosetests test_system.py -v
Test core system output. ... ok
Test core system output. ... ok
Test cpu system output. ... ok
Test cpu_ticks configuration option. ... ok
Test system/diskio output. ... SKIP: os
Test system/diskio output on linux. ... SKIP: os
Test system/filesystem output. ... ok
Test system/fsstat output. ... ok
Test system load. ... ok
Test system memory output. ... ok
Test system/network output. ... ok
Test system/process output. ... ok
Checks that the per proc stats are found in the output and ... ok
Test system/process_summary output. ... ok

----------------------------------------------------------------------
Ran 14 tests in 6.515s
```