### PR TITLE
Print container logs when compose up fails in tests

### DIFF
--- a/libbeat/tests/system/beat/compose.py
+++ b/libbeat/tests/system/beat/compose.py
@@ -30,27 +30,54 @@ class ComposeMixin(object):
         """
         Ensure *only* the services defined under `COMPOSE_SERVICES` are running and healthy
         """
-        if INTEGRATION_TESTS and cls.COMPOSE_SERVICES:
-            cls.compose_project().up(
+        if not INTEGRATION_TESTS or not cls.COMPOSE_SERVICES:
+            return
+
+        def print_logs(container):
+            print("---- " + container.name_without_project)
+            print(container.logs())
+            print("----")
+
+        def is_healthy(container):
+            return container.inspect()['State']['Health']['Status'] == 'healthy'
+
+        project = cls.compose_project()
+        project.up(
+            service_names=cls.COMPOSE_SERVICES,
+            do_build=BuildAction.force,
+            timeout=30)
+
+        # Wait for them to be healthy
+        start = time.time()
+        while True:
+            containers = project.containers(
                 service_names=cls.COMPOSE_SERVICES,
-                do_build=BuildAction.force,
-                timeout=30)
+                stopped=True)
 
-            # Wait for them to be healthy
-            healthy = False
-            seconds = cls.COMPOSE_TIMEOUT
-            while not healthy and seconds > 0:
-                print("Seconds: %d".format(seconds))
-                seconds -= 1
-                time.sleep(1)
-                healthy = True
-                for container in cls.compose_project().containers(service_names=cls.COMPOSE_SERVICES):
-                    if container.inspect()['State']['Health']['Status'] != 'healthy':
-                        healthy = False
-                        break
+            healthy = True
+            for container in containers:
+                if not container.is_running:
+                    print_logs(container)
+                    raise Exception(
+                        "Container %s unexpectedly finished on startup" %
+                        container.name_without_project)
+                if not is_healthy(container):
+                    healthy = False
+                    break
 
-            if not healthy:
-                raise Exception('Timeout while waiting for healthy docker-compose services')
+            if healthy:
+                break
+
+            time.sleep(1)
+            timeout = time.time() - start > cls.COMPOSE_TIMEOUT
+            if timeout:
+                for container in containers:
+                    if not is_healthy(container):
+                        print_logs(container)
+                raise Exception(
+                    "Timeout while waiting for healthy "
+                    "docker-compose services: %s" %
+                    ','.join(cls.COMPOSE_SERVICES))
 
     @classmethod
     def compose_down(cls):


### PR DESCRIPTION
Print container logs when compose up fails in test, and make it fail fast if container stops while waiting it to be healthy.

Splitted PR from #6773 