### PR TITLE
Docs version bump 5.6.9

### DIFF
--- a/libbeat/docs/version.asciidoc
+++ b/libbeat/docs/version.asciidoc
@@ -1,4 +1,4 @@
-:stack-version: 5.6.8
+:stack-version: 5.6.9
 :doc-branch: 5.6
 :go-version: 1.7.6
 :release-state: released


### PR DESCRIPTION
Should be merged on the day of the release.