### PR TITLE
Revert docker compose in travis to 1.11.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
   global:
     # Cross-compile for amd64 only to speed up testing.
     - GOX_FLAGS="-arch amd64"
-    - DOCKER_COMPOSE_VERSION=1.21.0
+    - DOCKER_COMPOSE_VERSION=1.11.1
     - GO_VERSION="$(cat .go-version)"
     - TRAVIS_ETCD_VERSION=v3.2.8
 


### PR DESCRIPTION
Issues appeared in libbeat testsuite after upgrading to docker compose 1.21.0 regarding communication problems with the logstash container.

Reverting by now to 1.11.1 as it seems to work on this version, we'll evaluate to upgrade to newer versions in the future.