### PR TITLE
made changes to support repeating flush pattern

### DIFF
--- a/filebeat/harvester/reader/multiline.go
+++ b/filebeat/harvester/reader/multiline.go
@@ -203,12 +203,19 @@ func (mlr *Multiline) readNext() (Message, error) {
 		if mlr.flushMatcher != nil {
 			endPatternReached := (mlr.flushMatcher.Match(message.Content))
 
-			if (endPatternReached == true && !mlr.lastMatch) || (mlr.lastMatch && !endPatternReached && mlr.flushMatchedAlready) {
+			if endPatternReached == true && !mlr.lastMatch {
 				// return collected multiline event and
 				// empty buffer for new multiline event
 				mlr.addLine(message)
 				msg := mlr.finalize()
 				mlr.resetState()
+				return msg, nil
+			}
+
+			if mlr.lastMatch && mlr.flushMatchedAlready && !endPatternReached {
+				msg := mlr.finalize()
+				mlr.load(message)
+				mlr.flushMatchedAlready = false
 				return msg, nil
 			}
 

--- a/filebeat/harvester/reader/multiline_config.go
+++ b/filebeat/harvester/reader/multiline_config.go
@@ -14,6 +14,7 @@ type MultilineConfig struct {
 	Pattern      *match.Matcher `config:"pattern" validate:"required"`
 	Timeout      *time.Duration `config:"timeout" validate:"positive"`
 	FlushPattern *match.Matcher `config:"flush_pattern"`
+	LastMatch    bool           `config:"last_match"`
 }
 
 func (c *MultilineConfig) Validate() error {

--- a/filebeat/harvester/reader/multiline_test.go
+++ b/filebeat/harvester/reader/multiline_test.go
@@ -131,6 +131,24 @@ func TestMultilineBeforeNegateOKWithEmptyLine(t *testing.T) {
 	)
 }
 
+func TestMultilineRepeatingFlushPattern(t *testing.T) {
+	flushMatcher := match.MustCompile(`EventEnd`)
+	pattern := match.MustCompile(`EventStart`)
+
+	testMultilineOK(t,
+		MultilineConfig{
+			Pattern:      &pattern,
+			Negate:       true,
+			Match:        "after",
+			FlushPattern: &flushMatcher,
+			LastMatch:    true,
+		},
+		2, //first two non-matching lines, will be merged to one event
+		"EventStart\nEventId: 1\nEventEnd\nEventEnd\nEventEnd\nEventEnd\n",
+		"EventStart\nEventId: 2\nEventEnd\nEventEnd\nEventEnd\n",
+	)
+}
+
 func testMultilineOK(t *testing.T, cfg MultilineConfig, events int, expected ...string) {
 	_, buf := createLineBuffer(expected...)
 	reader := createMultilineTestReader(t, buf, cfg)


### PR DESCRIPTION
Made changes to support cases where the flush pattern could repeat and they need to be combined as one multiline message

For example,
date some message
   repeating line 1
   repeating line 2
   repeating line n

If the need is to combine all of the above lines as 1 multiline event, it could be supported with additional flag that the flush pattern is a repeating one.