### PR TITLE
Change config reloading options in the short config

### DIFF
--- a/deploy/kubernetes/filebeat-kubernetes.yaml
+++ b/deploy/kubernetes/filebeat-kubernetes.yaml
@@ -14,11 +14,11 @@ data:
         # Mounted `filebeat-prospectors` configmap:
         path: ${path.config}/prospectors.d/*.yml
         # Reload prospectors configs as they change:
-        reload.enabled: false
+        reload.enabled: true
       modules:
         path: ${path.config}/modules.d/*.yml
         # Reload module configs as they change:
-        reload.enabled: false
+        reload.enabled: true
 
     processors:
       - add_cloud_metadata:

--- a/deploy/kubernetes/filebeat/filebeat-configmap.yaml
+++ b/deploy/kubernetes/filebeat/filebeat-configmap.yaml
@@ -14,11 +14,11 @@ data:
         # Mounted `filebeat-prospectors` configmap:
         path: ${path.config}/prospectors.d/*.yml
         # Reload prospectors configs as they change:
-        reload.enabled: false
+        reload.enabled: true
       modules:
         path: ${path.config}/modules.d/*.yml
         # Reload module configs as they change:
-        reload.enabled: false
+        reload.enabled: true
 
     processors:
       - add_cloud_metadata:

--- a/deploy/kubernetes/metricbeat-kubernetes.yaml
+++ b/deploy/kubernetes/metricbeat-kubernetes.yaml
@@ -13,7 +13,7 @@ data:
       # Mounted `metricbeat-daemonset-modules` configmap:
       path: ${path.config}/modules.d/*.yml
       # Reload module configs as they change:
-      reload.enabled: false
+      reload.enabled: true
 
     processors:
       - add_cloud_metadata:

--- a/deploy/kubernetes/metricbeat/metricbeat-daemonset-configmap.yaml
+++ b/deploy/kubernetes/metricbeat/metricbeat-daemonset-configmap.yaml
@@ -13,7 +13,7 @@ data:
       # Mounted `metricbeat-daemonset-modules` configmap:
       path: ${path.config}/modules.d/*.yml
       # Reload module configs as they change:
-      reload.enabled: false
+      reload.enabled: true
 
     processors:
       - add_cloud_metadata:

--- a/filebeat/_meta/common.p2.yml
+++ b/filebeat/_meta/common.p2.yml
@@ -61,7 +61,7 @@ filebeat.config.modules:
   path: ${path.config}/modules.d/*.yml
 
   # Set to true to enable config reloading
-  reload.enabled: false
+  reload.enabled: true
 
   # Period on which files under path should be checked for changes
   #reload.period: 10s

--- a/filebeat/_meta/common.reference.p2.yml
+++ b/filebeat/_meta/common.reference.p2.yml
@@ -329,10 +329,10 @@ filebeat.inputs:
   #inputs:
     #enabled: false
     #path: inputs.d/*.yml
-    #reload.enabled: true
+    #reload.enabled: false
     #reload.period: 10s
   #modules:
     #enabled: false
     #path: modules.d/*.yml
-    #reload.enabled: true
+    #reload.enabled: false
     #reload.period: 10s

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -638,12 +638,12 @@ filebeat.inputs:
   #inputs:
     #enabled: false
     #path: inputs.d/*.yml
-    #reload.enabled: true
+    #reload.enabled: false
     #reload.period: 10s
   #modules:
     #enabled: false
     #path: modules.d/*.yml
-    #reload.enabled: true
+    #reload.enabled: false
     #reload.period: 10s
 
 #================================ General ======================================

--- a/filebeat/filebeat.yml
+++ b/filebeat/filebeat.yml
@@ -70,7 +70,7 @@ filebeat.config.modules:
   path: ${path.config}/modules.d/*.yml
 
   # Set to true to enable config reloading
-  reload.enabled: false
+  reload.enabled: true
 
   # Period on which files under path should be checked for changes
   #reload.period: 10s

--- a/metricbeat/_meta/setup.yml
+++ b/metricbeat/_meta/setup.yml
@@ -6,7 +6,7 @@ metricbeat.config.modules:
   path: ${path.config}/modules.d/*.yml
 
   # Set to true to enable config reloading
-  reload.enabled: false
+  reload.enabled: true
 
   # Period on which files under path should be checked for changes
   #reload.period: 10s

--- a/metricbeat/metricbeat.yml
+++ b/metricbeat/metricbeat.yml
@@ -14,7 +14,7 @@ metricbeat.config.modules:
   path: ${path.config}/modules.d/*.yml
 
   # Set to true to enable config reloading
-  reload.enabled: false
+  reload.enabled: true
 
   # Period on which files under path should be checked for changes
   #reload.period: 10s


### PR DESCRIPTION
Config reloading has gone through several release cycles and no major issues have shown up. We should make reloading GA.

There are several changes in this PR:

* Config reloading is made GA but in the code it's disabled by default as otherwise this would be a breaking change
* Enabling config reloading in our short config. This will make it easier for new users to use commands like `metricbeat modules enable system` as they will work out of the box.
* Change reloading to true in K8s files. Not sure if we treat this as a breaking change?