### PR TITLE
Remove config_dir from reference config and update docs

### DIFF
--- a/filebeat/_meta/common.reference.p2.yml
+++ b/filebeat/_meta/common.reference.p2.yml
@@ -291,11 +291,6 @@ filebeat.inputs:
 # everytime a new Elasticsearch connection is established.
 #filebeat.overwrite_pipelines: false
 
-# These config files must have the full filebeat config part inside, but only
-# the input part is processed. All global options like spool_size are ignored.
-# The config_dir MUST point to a different directory then where the main filebeat config file is in.
-#filebeat.config_dir:
-
 # How long filebeat waits on shutdown for the publisher to finish.
 # Default is 0, not waiting.
 #filebeat.shutdown_timeout: 0

--- a/filebeat/docs/filebeat-general-options.asciidoc
+++ b/filebeat/docs/filebeat-general-options.asciidoc
@@ -53,6 +53,8 @@ filebeat.registry_file_permissions: 0600
 [float]
 ==== `config_dir`
 
+deprecated[6.0.0, Use <<load-input-config>> instead.]
+
 The full path to the directory that contains additional input configuration files.
 Each configuration file must end with `.yml`. Each config file must also specify the full Filebeat
 config hierarchy even though only the `inputs` part of each file is processed. All global

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -600,11 +600,6 @@ filebeat.inputs:
 # everytime a new Elasticsearch connection is established.
 #filebeat.overwrite_pipelines: false
 
-# These config files must have the full filebeat config part inside, but only
-# the input part is processed. All global options like spool_size are ignored.
-# The config_dir MUST point to a different directory then where the main filebeat config file is in.
-#filebeat.config_dir:
-
 # How long filebeat waits on shutdown for the publisher to finish.
 # Default is 0, not waiting.
 #filebeat.shutdown_timeout: 0


### PR DESCRIPTION
filebeat.config_dir was deprecated in 6.0 in the code and a warning is logged. Unfortunately the docs were never updated. This adds the deprecation notice to the docs and removes the config option from the reference file.