### PR TITLE
UDP inputs now uses human friendly size to define MaxMessageSize

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -127,6 +127,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Add Ingest pipeline loading to setup. {pull}6814[6814]
 - Add support of log_format combined to NGINX access logs. {pull}6858[6858]
 - Release config reloading feature as GA.
+- Add support human friendly size for the UDP input. {pull}6886[6886]
 
 *Heartbeat*
 

--- a/filebeat/_meta/common.reference.p2.yml
+++ b/filebeat/_meta/common.reference.p2.yml
@@ -239,7 +239,7 @@ filebeat.inputs:
   #enabled: false
 
   # Maximum size of the message received over UDP
-  #max_message_size: 10240
+  #max_message_size: 10KiB
 
 #------------------------------ TCP prospector --------------------------------
 # Experimental: Config options for the TCP input

--- a/filebeat/docs/inputs/input-udp.asciidoc
+++ b/filebeat/docs/inputs/input-udp.asciidoc
@@ -15,7 +15,7 @@ Example configuration:
 ----
 {beatname_lc}.inputs:
 - type: udp
-  max_message_size: 10240
+  max_message_size: 10KiB
   host: "localhost:8080"
 ----
 
@@ -29,13 +29,13 @@ The `udp` input supports the following configuration options plus the
 [id="{beatname_lc}-input-{type}-max-message-size"]
 ==== `max_message_size`
 
-The maximum size of the message received over UDP. The default is `10240`.
+The maximum size of the message received over UDP. The default is `10KiB`.
 
 [float]
 [id="{beatname_lc}-input-{type}-host"]
 ==== `host`
 
-The host and UDP port to listen on for event streams. 
+The host and UDP port to listen on for event streams.
 
 [id="{beatname_lc}-input-{type}-common-options"]
 include::../inputs/input-common-options.asciidoc[]

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -548,7 +548,7 @@ filebeat.inputs:
   #enabled: false
 
   # Maximum size of the message received over UDP
-  #max_message_size: 10240
+  #max_message_size: 10KiB
 
 #------------------------------ TCP prospector --------------------------------
 # Experimental: Config options for the TCP input

--- a/filebeat/input/udp/config.go
+++ b/filebeat/input/udp/config.go
@@ -3,6 +3,8 @@ package udp
 import (
 	"time"
 
+	"github.com/dustin/go-humanize"
+
 	"github.com/elastic/beats/filebeat/harvester"
 	"github.com/elastic/beats/filebeat/inputsource/udp"
 )
@@ -12,7 +14,7 @@ var defaultConfig = config{
 		Type: "udp",
 	},
 	Config: udp.Config{
-		MaxMessageSize: 10240,
+		MaxMessageSize: 10 * humanize.KiByte,
 		// TODO: What should be default port?
 		Host: "localhost:8080",
 		// TODO: What should be the default timeout?

--- a/filebeat/inputsource/tcp/client.go
+++ b/filebeat/inputsource/tcp/client.go
@@ -18,7 +18,7 @@ type client struct {
 	done           chan struct{}
 	metadata       Metadata
 	splitFunc      bufio.SplitFunc
-	maxReadMessage uint64
+	maxMessageSize uint64
 	timeout        time.Duration
 }
 
@@ -36,7 +36,7 @@ func newClient(
 		callback:       callback,
 		done:           make(chan struct{}),
 		splitFunc:      splitFunc,
-		maxReadMessage: maxReadMessage,
+		maxMessageSize: maxReadMessage,
 		timeout:        timeout,
 		metadata: Metadata{
 			RemoteAddr: conn.RemoteAddr(),
@@ -46,7 +46,7 @@ func newClient(
 }
 
 func (c *client) handle() error {
-	r := NewResetableLimitedReader(NewDeadlineReader(c.conn, c.timeout), c.maxReadMessage)
+	r := NewResetableLimitedReader(NewDeadlineReader(c.conn, c.timeout), c.maxMessageSize)
 	buf := bufio.NewReader(r)
 	scanner := bufio.NewScanner(buf)
 	scanner.Split(c.splitFunc)

--- a/filebeat/inputsource/tcp/client.go
+++ b/filebeat/inputsource/tcp/client.go
@@ -18,7 +18,7 @@ type client struct {
 	done           chan struct{}
 	metadata       Metadata
 	splitFunc      bufio.SplitFunc
-	maxReadMessage size
+	maxReadMessage uint64
 	timeout        time.Duration
 }
 
@@ -27,7 +27,7 @@ func newClient(
 	log *logp.Logger,
 	callback CallbackFunc,
 	splitFunc bufio.SplitFunc,
-	maxReadMessage size,
+	maxReadMessage uint64,
 	timeout time.Duration,
 ) *client {
 	client := &client{
@@ -46,7 +46,7 @@ func newClient(
 }
 
 func (c *client) handle() error {
-	r := NewResetableLimitedReader(NewDeadlineReader(c.conn, c.timeout), uint64(c.maxReadMessage))
+	r := NewResetableLimitedReader(NewDeadlineReader(c.conn, c.timeout), c.maxReadMessage)
 	buf := bufio.NewReader(r)
 	scanner := bufio.NewScanner(buf)
 	scanner.Split(c.splitFunc)

--- a/filebeat/inputsource/tcp/config.go
+++ b/filebeat/inputsource/tcp/config.go
@@ -4,17 +4,15 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/dustin/go-humanize"
+	"github.com/elastic/beats/libbeat/common/cfgtype"
 )
-
-type size uint64
 
 // Config exposes the tcp configuration.
 type Config struct {
-	Host           string        `config:"host"`
-	LineDelimiter  string        `config:"line_delimiter" validate:"nonzero"`
-	Timeout        time.Duration `config:"timeout" validate:"nonzero,positive"`
-	MaxMessageSize size          `config:"max_message_size" validate:"nonzero,positive"`
+	Host           string           `config:"host"`
+	LineDelimiter  string           `config:"line_delimiter" validate:"nonzero"`
+	Timeout        time.Duration    `config:"timeout" validate:"nonzero,positive"`
+	MaxMessageSize cfgtype.ByteSize `config:"max_message_size" validate:"nonzero,positive"`
 }
 
 // Validate validates the Config option for the tcp input.
@@ -22,15 +20,5 @@ func (c *Config) Validate() error {
 	if len(c.Host) == 0 {
 		return fmt.Errorf("need to specify the host using the `host:port` syntax")
 	}
-	return nil
-}
-
-func (s *size) Unpack(value string) error {
-	sz, err := humanize.ParseBytes(value)
-	if err != nil {
-		return err
-	}
-
-	*s = size(sz)
 	return nil
 }

--- a/filebeat/inputsource/tcp/server.go
+++ b/filebeat/inputsource/tcp/server.go
@@ -89,7 +89,7 @@ func (s *Server) run() {
 			s.log,
 			s.callback,
 			s.splitFunc,
-			s.config.MaxMessageSize,
+			uint64(s.config.MaxMessageSize),
 			s.config.Timeout,
 		)
 

--- a/filebeat/inputsource/udp/config.go
+++ b/filebeat/inputsource/udp/config.go
@@ -1,0 +1,14 @@
+package udp
+
+import (
+	"time"
+
+	"github.com/elastic/beats/libbeat/common/cfgtype"
+)
+
+// Config options for the UDPServer
+type Config struct {
+	Host           string           `config:"host"`
+	MaxMessageSize cfgtype.ByteSize `config:"max_message_size" validate:"positive,nonzero"`
+	Timeout        time.Duration    `config:"timeout"`
+}

--- a/filebeat/inputsource/udp/server.go
+++ b/filebeat/inputsource/udp/server.go
@@ -20,13 +20,6 @@ type Metadata struct {
 	Truncated  bool
 }
 
-// Config options for the UDPServer
-type Config struct {
-	Host           string        `config:"host"`
-	MaxMessageSize int           `config:"max_message_size" validate:"positive,nonzero"`
-	Timeout        time.Duration `config:"timeout"`
-}
-
 // Server creates a simple UDP Server and listen to a specific host:port and will send any
 // event received to the callback method.
 type Server struct {

--- a/libbeat/common/cfgtype/byte_size.go
+++ b/libbeat/common/cfgtype/byte_size.go
@@ -1,0 +1,36 @@
+package cfgtype
+
+import (
+	"unicode"
+
+	"github.com/dustin/go-humanize"
+
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
+)
+
+// ByteSize defines a new configuration option that will parse `go-humanize` compatible values into a
+// int64 when the suffix is valid or will fallback to bytes.
+type ByteSize int64
+
+// Unpack converts a size defined from a human readable format into bytes.
+func (s *ByteSize) Unpack(v string) error {
+	sz, err := humanize.ParseBytes(v)
+	if isRawBytes(v) {
+		cfgwarn.Deprecate("7.0", "size now requires a unit (KiB, MiB, etc...), current value: %s.", v)
+	}
+	if err != nil {
+		return err
+	}
+
+	*s = ByteSize(sz)
+	return nil
+}
+
+func isRawBytes(v string) bool {
+	for _, c := range v {
+		if !unicode.IsDigit(c) {
+			return false
+		}
+	}
+	return true
+}

--- a/libbeat/common/cfgtype/byte_size_test.go
+++ b/libbeat/common/cfgtype/byte_size_test.go
@@ -1,0 +1,37 @@
+package cfgtype
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnpack(t *testing.T) {
+	tests := []struct {
+		name     string
+		s        string
+		expected ByteSize
+	}{
+		{
+			name:     "friendly human value",
+			s:        "1KiB",
+			expected: ByteSize(1024),
+		},
+		{
+			name:     "raw bytes",
+			s:        "2024",
+			expected: ByteSize(2024),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			s := ByteSize(0)
+			err := s.Unpack(test.s)
+			if !assert.NoError(t, err) {
+				return
+			}
+			assert.Equal(t, test.expected, s)
+		})
+	}
+}

--- a/libbeat/publisher/queue/spool/config.go
+++ b/libbeat/publisher/queue/spool/config.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/dustin/go-humanize"
 	"github.com/joeshaw/multierror"
+
+	"github.com/elastic/beats/libbeat/common/cfgtype"
 )
 
 type config struct {
@@ -18,18 +20,18 @@ type config struct {
 }
 
 type pathConfig struct {
-	Path        string      `config:"path"`
-	Permissions os.FileMode `config:"permissions"`
-	MaxSize     size        `config:"size"`
-	PageSize    size        `config:"page_size"`
-	Prealloc    bool        `config:"prealloc"`
+	Path        string           `config:"path"`
+	Permissions os.FileMode      `config:"permissions"`
+	MaxSize     cfgtype.ByteSize `config:"size"`
+	PageSize    cfgtype.ByteSize `config:"page_size"`
+	Prealloc    bool             `config:"prealloc"`
 }
 
 type writeConfig struct {
-	BufferSize   size          `config:"buffer_size"`
-	FlushEvents  time.Duration `config:"flush.events"`
-	FlushTimeout time.Duration `config:"flush.timeout"`
-	Codec        codecID       `config:"codec"`
+	BufferSize   cfgtype.ByteSize `config:"buffer_size"`
+	FlushEvents  time.Duration    `config:"flush.events"`
+	FlushTimeout time.Duration    `config:"flush.timeout"`
+	Codec        codecID          `config:"codec"`
 }
 
 type readConfig struct {
@@ -56,8 +58,6 @@ func defaultConfig() config {
 		},
 	}
 }
-
-type size uint64
 
 func (c *pathConfig) Validate() error {
 	var errs multierror.Errors
@@ -92,16 +92,6 @@ func (c *writeConfig) Validate() error {
 }
 
 func (c *readConfig) Validate() error {
-	return nil
-}
-
-func (s *size) Unpack(value string) error {
-	sz, err := humanize.ParseBytes(value)
-	if err != nil {
-		return err
-	}
-
-	*s = size(sz)
 	return nil
 }
 


### PR DESCRIPTION
Uses go-humanize to parse values for `MaxMessageSize` and fallback to
raw bytes if no suffix is found. Also create a new type for future
configuration named `common.Size` that will take care of correctly
unpacking values.