### PR TITLE
Metricbeat: RabbitMQ/Queue disk reads and writes count keys made optional

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -79,6 +79,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Fix Kubernetes calculated fields store. {pull}6564{6564}
 - Exclude bind mounts in fsstat and filesystem metricsets. {pull}6819[6819]
 - Don't stop Metricbeat if aerospike server is down. {pull}6874[6874]
+- disk reads and write count metrics in RabbitMQ queue metricset made optional. {issue}6876[6876]
 
 *Packetbeat*
 

--- a/metricbeat/module/rabbitmq/queue/data.go
+++ b/metricbeat/module/rabbitmq/queue/data.go
@@ -46,10 +46,10 @@ var (
 		},
 		"disk": s.Object{
 			"reads": s.Object{
-				"count": c.Int("disk_reads"),
+				"count": c.Int("disk_reads", s.Optional),
 			},
 			"writes": s.Object{
-				"count": c.Int("disk_writes"),
+				"count": c.Int("disk_writes", s.Optional),
 			},
 		},
 	}


### PR DESCRIPTION
disk_reads and disk_writes keys of rabbitmq management plugin
aren't available at times, throwing error.

Signed-off-by: Jaipradeesh <jaipradeesh@gmail.com>