### PR TITLE
Metricbeat: Add reference config and default metricset to kvm module

### DIFF
--- a/metricbeat/docs/modules/kvm.asciidoc
+++ b/metricbeat/docs/modules/kvm.asciidoc
@@ -24,7 +24,7 @@ in <<configuration-metricbeat>>. Here is an example configuration:
 metricbeat.modules:
 - module: kvm
   metricsets: ["dommemstat"]
-  enabled: false
+  enabled: true
   period: 10s
   hosts: ["localhost"]
 

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -369,7 +369,7 @@ metricbeat.modules:
 #--------------------------------- kvm Module --------------------------------
 - module: kvm
   metricsets: ["dommemstat"]
-  enabled: false
+  enabled: true
   period: 10s
   hosts: ["localhost"]
 

--- a/metricbeat/module/kvm/_meta/config.reference.yml
+++ b/metricbeat/module/kvm/_meta/config.reference.yml
@@ -1,0 +1,8 @@
+- module: kvm
+  metricsets: ["dommemstat"]
+  enabled: true
+  period: 10s
+  hosts: ["localhost"]
+
+  # Timeout to connect to Libvirt server
+  #timeout: 1s

--- a/metricbeat/module/kvm/_meta/config.yml
+++ b/metricbeat/module/kvm/_meta/config.yml
@@ -1,8 +1,2 @@
 - module: kvm
-  metricsets: ["dommemstat"]
-  enabled: false
-  period: 10s
   hosts: ["localhost"]
-
-  # Timeout to connect to Libvirt server
-  #timeout: 1s

--- a/metricbeat/module/kvm/dommemstat/dommemstat.go
+++ b/metricbeat/module/kvm/dommemstat/dommemstat.go
@@ -29,7 +29,9 @@ const (
 // the MetricSet for each host defined in the module's configuration. After the
 // MetricSet has been created then Fetch will begin to be called periodically.
 func init() {
-	mb.Registry.MustAddMetricSet("kvm", "dommemstat", New)
+	mb.Registry.MustAddMetricSet("kvm", "dommemstat", New,
+		mb.DefaultMetricSet(),
+	)
 }
 
 // MetricSet holds any configuration or state information. It must implement

--- a/metricbeat/modules.d/kvm.yml.disabled
+++ b/metricbeat/modules.d/kvm.yml.disabled
@@ -1,8 +1,2 @@
 - module: kvm
-  metricsets: ["dommemstat"]
-  enabled: false
-  period: 10s
   hosts: ["localhost"]
-
-  # Timeout to connect to Libvirt server
-  #timeout: 1s


### PR DESCRIPTION
Follow-up of #6265 