### PR TITLE
Allow `_` and `-` in Filebeat module name hints

### DIFF
--- a/filebeat/autodiscover/builder/hints/logs.go
+++ b/filebeat/autodiscover/builder/hints/logs.go
@@ -25,7 +25,7 @@ const (
 )
 
 // validModuleNames to sanitize user input
-var validModuleNames = regexp.MustCompile("[^a-zA-Z0-9]+")
+var validModuleNames = regexp.MustCompile("[^a-zA-Z0-9\\_\\-]+")
 
 type logHints struct {
 	Key      string


### PR DESCRIPTION
Follow up of #6899, this change allows module names with `_` or `-` chars, just in case we add some in the future.