### PR TITLE
Document backoff options

### DIFF
--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -375,14 +375,15 @@ output.elasticsearch:
   # The default is 50.
   #bulk_max_size: 50
 
-  # The number of seconds to wait before attempting to connect to Elasticsearch
-  # after an initial connection error. The default is 1s. If additional errors
-  # occur, the wait time is increased exponentially for each try until
-  # backoff.max is met.
+  # The number of seconds to wait before trying to reconnect to Elasticsearch
+  # after a network error. After waiting backoff.init seconds, the Beat
+  # tries to reconnect. If the attempt fails, the backoff timer is increased
+  # exponentially up to backoff.max. After a successful connection, the backoff
+  # timer is reset. The default is 1s.
   #backoff.init: 1s
 
   # The maximum number of seconds to wait before attempting to connect to
-  # Elasticsearch after a connection error. The default is 60s.
+  # Elasticsearch after a network error. The default is 60s.
   #backoff.max: 60s
 
   # Configure http request timeout before failing a request to Elasticsearch.
@@ -458,14 +459,15 @@ output.elasticsearch:
   # if no error is encountered.
   #slow_start: false
 
-  # The number of seconds to wait before attempting to connect to Logstash
-  # after an initial connection error. The default is 1s. If additional errors
-  # occur, the wait time is increased exponentially for each try until
-  # backoff.max is met.
+  # The number of seconds to wait before trying to reconnect to Logstash
+  # after a network error. After waiting backoff.init seconds, the Beat
+  # tries to reconnect. If the attempt fails, the backoff timer is increased
+  # exponentially up to backoff.max. After a successful connection, the backoff
+  # timer is reset. The default is 1s.
   #backoff.init: 1s
 
   # The maximum number of seconds to wait before attempting to connect to
-  # Logstash after a connection error. The default is 60s.
+  # Logstash after a network error. The default is 60s.
   #backoff.max: 60s
 
   # Optional index name. The default index name is set to auditbeat

--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -375,7 +375,17 @@ output.elasticsearch:
   # The default is 50.
   #bulk_max_size: 50
 
-  # Configure http request timeout before failing an request to Elasticsearch.
+  # The number of seconds to wait before attempting to connect to Elasticsearch
+  # after an initial connection error. The default is 1s. If additional errors
+  # occur, the wait time is increased exponentially for each try until
+  # backoff.max is met.
+  #backoff.init: 1s
+
+  # The maximum number of seconds to wait before attempting to connect to
+  # Elasticsearch after a connection error. The default is 60s.
+  #backoff.max: 60s
+
+  # Configure http request timeout before failing a request to Elasticsearch.
   #timeout: 90
 
   # Use SSL settings for HTTPS.
@@ -439,7 +449,7 @@ output.elasticsearch:
   # Optional load balance the events between the Logstash hosts. Default is false.
   #loadbalance: false
 
-  # Number of batches to be sent asynchronously to logstash while processing
+  # Number of batches to be sent asynchronously to Logstash while processing
   # new batches.
   #pipelining: 2
 
@@ -447,6 +457,16 @@ output.elasticsearch:
   # transaction.  The number of events to be sent increases up to `bulk_max_size`
   # if no error is encountered.
   #slow_start: false
+
+  # The number of seconds to wait before attempting to connect to Logstash
+  # after an initial connection error. The default is 1s. If additional errors
+  # occur, the wait time is increased exponentially for each try until
+  # backoff.max is met.
+  #backoff.init: 1s
+
+  # The maximum number of seconds to wait before attempting to connect to
+  # Logstash after a connection error. The default is 60s.
+  #backoff.max: 60s
 
   # Optional index name. The default index name is set to auditbeat
   # in all lowercase.

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -1011,7 +1011,17 @@ output.elasticsearch:
   # The default is 50.
   #bulk_max_size: 50
 
-  # Configure http request timeout before failing an request to Elasticsearch.
+  # The number of seconds to wait before attempting to connect to Elasticsearch
+  # after an initial connection error. The default is 1s. If additional errors
+  # occur, the wait time is increased exponentially for each try until
+  # backoff.max is met.
+  #backoff.init: 1s
+
+  # The maximum number of seconds to wait before attempting to connect to
+  # Elasticsearch after a connection error. The default is 60s.
+  #backoff.max: 60s
+
+  # Configure http request timeout before failing a request to Elasticsearch.
   #timeout: 90
 
   # Use SSL settings for HTTPS.
@@ -1075,7 +1085,7 @@ output.elasticsearch:
   # Optional load balance the events between the Logstash hosts. Default is false.
   #loadbalance: false
 
-  # Number of batches to be sent asynchronously to logstash while processing
+  # Number of batches to be sent asynchronously to Logstash while processing
   # new batches.
   #pipelining: 2
 
@@ -1083,6 +1093,16 @@ output.elasticsearch:
   # transaction.  The number of events to be sent increases up to `bulk_max_size`
   # if no error is encountered.
   #slow_start: false
+
+  # The number of seconds to wait before attempting to connect to Logstash
+  # after an initial connection error. The default is 1s. If additional errors
+  # occur, the wait time is increased exponentially for each try until
+  # backoff.max is met.
+  #backoff.init: 1s
+
+  # The maximum number of seconds to wait before attempting to connect to
+  # Logstash after a connection error. The default is 60s.
+  #backoff.max: 60s
 
   # Optional index name. The default index name is set to filebeat
   # in all lowercase.

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -1011,14 +1011,15 @@ output.elasticsearch:
   # The default is 50.
   #bulk_max_size: 50
 
-  # The number of seconds to wait before attempting to connect to Elasticsearch
-  # after an initial connection error. The default is 1s. If additional errors
-  # occur, the wait time is increased exponentially for each try until
-  # backoff.max is met.
+  # The number of seconds to wait before trying to reconnect to Elasticsearch
+  # after a network error. After waiting backoff.init seconds, the Beat
+  # tries to reconnect. If the attempt fails, the backoff timer is increased
+  # exponentially up to backoff.max. After a successful connection, the backoff
+  # timer is reset. The default is 1s.
   #backoff.init: 1s
 
   # The maximum number of seconds to wait before attempting to connect to
-  # Elasticsearch after a connection error. The default is 60s.
+  # Elasticsearch after a network error. The default is 60s.
   #backoff.max: 60s
 
   # Configure http request timeout before failing a request to Elasticsearch.
@@ -1094,14 +1095,15 @@ output.elasticsearch:
   # if no error is encountered.
   #slow_start: false
 
-  # The number of seconds to wait before attempting to connect to Logstash
-  # after an initial connection error. The default is 1s. If additional errors
-  # occur, the wait time is increased exponentially for each try until
-  # backoff.max is met.
+  # The number of seconds to wait before trying to reconnect to Logstash
+  # after a network error. After waiting backoff.init seconds, the Beat
+  # tries to reconnect. If the attempt fails, the backoff timer is increased
+  # exponentially up to backoff.max. After a successful connection, the backoff
+  # timer is reset. The default is 1s.
   #backoff.init: 1s
 
   # The maximum number of seconds to wait before attempting to connect to
-  # Logstash after a connection error. The default is 60s.
+  # Logstash after a network error. The default is 60s.
   #backoff.max: 60s
 
   # Optional index name. The default index name is set to filebeat

--- a/heartbeat/heartbeat.reference.yml
+++ b/heartbeat/heartbeat.reference.yml
@@ -484,14 +484,15 @@ output.elasticsearch:
   # The default is 50.
   #bulk_max_size: 50
 
-  # The number of seconds to wait before attempting to connect to Elasticsearch
-  # after an initial connection error. The default is 1s. If additional errors
-  # occur, the wait time is increased exponentially for each try until
-  # backoff.max is met.
+  # The number of seconds to wait before trying to reconnect to Elasticsearch
+  # after a network error. After waiting backoff.init seconds, the Beat
+  # tries to reconnect. If the attempt fails, the backoff timer is increased
+  # exponentially up to backoff.max. After a successful connection, the backoff
+  # timer is reset. The default is 1s.
   #backoff.init: 1s
 
   # The maximum number of seconds to wait before attempting to connect to
-  # Elasticsearch after a connection error. The default is 60s.
+  # Elasticsearch after a network error. The default is 60s.
   #backoff.max: 60s
 
   # Configure http request timeout before failing a request to Elasticsearch.
@@ -567,14 +568,15 @@ output.elasticsearch:
   # if no error is encountered.
   #slow_start: false
 
-  # The number of seconds to wait before attempting to connect to Logstash
-  # after an initial connection error. The default is 1s. If additional errors
-  # occur, the wait time is increased exponentially for each try until
-  # backoff.max is met.
+  # The number of seconds to wait before trying to reconnect to Logstash
+  # after a network error. After waiting backoff.init seconds, the Beat
+  # tries to reconnect. If the attempt fails, the backoff timer is increased
+  # exponentially up to backoff.max. After a successful connection, the backoff
+  # timer is reset. The default is 1s.
   #backoff.init: 1s
 
   # The maximum number of seconds to wait before attempting to connect to
-  # Logstash after a connection error. The default is 60s.
+  # Logstash after a network error. The default is 60s.
   #backoff.max: 60s
 
   # Optional index name. The default index name is set to heartbeat

--- a/heartbeat/heartbeat.reference.yml
+++ b/heartbeat/heartbeat.reference.yml
@@ -484,7 +484,17 @@ output.elasticsearch:
   # The default is 50.
   #bulk_max_size: 50
 
-  # Configure http request timeout before failing an request to Elasticsearch.
+  # The number of seconds to wait before attempting to connect to Elasticsearch
+  # after an initial connection error. The default is 1s. If additional errors
+  # occur, the wait time is increased exponentially for each try until
+  # backoff.max is met.
+  #backoff.init: 1s
+
+  # The maximum number of seconds to wait before attempting to connect to
+  # Elasticsearch after a connection error. The default is 60s.
+  #backoff.max: 60s
+
+  # Configure http request timeout before failing a request to Elasticsearch.
   #timeout: 90
 
   # Use SSL settings for HTTPS.
@@ -548,7 +558,7 @@ output.elasticsearch:
   # Optional load balance the events between the Logstash hosts. Default is false.
   #loadbalance: false
 
-  # Number of batches to be sent asynchronously to logstash while processing
+  # Number of batches to be sent asynchronously to Logstash while processing
   # new batches.
   #pipelining: 2
 
@@ -556,6 +566,16 @@ output.elasticsearch:
   # transaction.  The number of events to be sent increases up to `bulk_max_size`
   # if no error is encountered.
   #slow_start: false
+
+  # The number of seconds to wait before attempting to connect to Logstash
+  # after an initial connection error. The default is 1s. If additional errors
+  # occur, the wait time is increased exponentially for each try until
+  # backoff.max is met.
+  #backoff.init: 1s
+
+  # The maximum number of seconds to wait before attempting to connect to
+  # Logstash after a connection error. The default is 60s.
+  #backoff.max: 60s
 
   # Optional index name. The default index name is set to heartbeat
   # in all lowercase.

--- a/libbeat/_meta/config.reference.yml
+++ b/libbeat/_meta/config.reference.yml
@@ -270,7 +270,17 @@ output.elasticsearch:
   # The default is 50.
   #bulk_max_size: 50
 
-  # Configure http request timeout before failing an request to Elasticsearch.
+  # The number of seconds to wait before attempting to connect to Elasticsearch
+  # after an initial connection error. The default is 1s. If additional errors
+  # occur, the wait time is increased exponentially for each try until
+  # backoff.max is met.
+  #backoff.init: 1s
+
+  # The maximum number of seconds to wait before attempting to connect to
+  # Elasticsearch after a connection error. The default is 60s.
+  #backoff.max: 60s
+
+  # Configure http request timeout before failing a request to Elasticsearch.
   #timeout: 90
 
   # Use SSL settings for HTTPS.
@@ -334,7 +344,7 @@ output.elasticsearch:
   # Optional load balance the events between the Logstash hosts. Default is false.
   #loadbalance: false
 
-  # Number of batches to be sent asynchronously to logstash while processing
+  # Number of batches to be sent asynchronously to Logstash while processing
   # new batches.
   #pipelining: 2
 
@@ -342,6 +352,16 @@ output.elasticsearch:
   # transaction.  The number of events to be sent increases up to `bulk_max_size`
   # if no error is encountered.
   #slow_start: false
+
+  # The number of seconds to wait before attempting to connect to Logstash
+  # after an initial connection error. The default is 1s. If additional errors
+  # occur, the wait time is increased exponentially for each try until
+  # backoff.max is met.
+  #backoff.init: 1s
+
+  # The maximum number of seconds to wait before attempting to connect to
+  # Logstash after a connection error. The default is 60s.
+  #backoff.max: 60s
 
   # Optional index name. The default index name is set to beat-index-prefix
   # in all lowercase.

--- a/libbeat/_meta/config.reference.yml
+++ b/libbeat/_meta/config.reference.yml
@@ -270,14 +270,15 @@ output.elasticsearch:
   # The default is 50.
   #bulk_max_size: 50
 
-  # The number of seconds to wait before attempting to connect to Elasticsearch
-  # after an initial connection error. The default is 1s. If additional errors
-  # occur, the wait time is increased exponentially for each try until
-  # backoff.max is met.
+  # The number of seconds to wait before trying to reconnect to Elasticsearch
+  # after a network error. After waiting backoff.init seconds, the Beat
+  # tries to reconnect. If the attempt fails, the backoff timer is increased
+  # exponentially up to backoff.max. After a successful connection, the backoff
+  # timer is reset. The default is 1s.
   #backoff.init: 1s
 
   # The maximum number of seconds to wait before attempting to connect to
-  # Elasticsearch after a connection error. The default is 60s.
+  # Elasticsearch after a network error. The default is 60s.
   #backoff.max: 60s
 
   # Configure http request timeout before failing a request to Elasticsearch.
@@ -353,14 +354,15 @@ output.elasticsearch:
   # if no error is encountered.
   #slow_start: false
 
-  # The number of seconds to wait before attempting to connect to Logstash
-  # after an initial connection error. The default is 1s. If additional errors
-  # occur, the wait time is increased exponentially for each try until
-  # backoff.max is met.
+  # The number of seconds to wait before trying to reconnect to Logstash
+  # after a network error. After waiting backoff.init seconds, the Beat
+  # tries to reconnect. If the attempt fails, the backoff timer is increased
+  # exponentially up to backoff.max. After a successful connection, the backoff
+  # timer is reset. The default is 1s.
   #backoff.init: 1s
 
   # The maximum number of seconds to wait before attempting to connect to
-  # Logstash after a connection error. The default is 60s.
+  # Logstash after a network error. The default is 60s.
   #backoff.max: 60s
 
   # Optional index name. The default index name is set to beat-index-prefix

--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -317,6 +317,18 @@ Setting `bulk_max_size` to values less than or equal to 0 disables the
 splitting of batches. When splitting is disabled, the queue decides on the
 number of events to be contained in a batch.
 
+===== `backoff.init`
+
+The number of seconds to wait before attempting to connect to Elasticsearch
+after an initial connection error. The default is 1s. If additional errors
+occur, the wait time is increased exponentially for each try until `backoff.max`
+is met.
+
+===== `backoff.max`
+
+The maximum number of seconds to wait before attempting to connect to
+Elasticsearch after a connection error. The default is 60s.
+
 ===== `timeout`
 
 The http request timeout in seconds for the Elasticsearch request. The default is 90.
@@ -580,6 +592,18 @@ The number of events to be sent increases up to `bulk_max_size` if no error is e
 On error the number of events per transaction is reduced again.
 
 The default is `false`.
+
+===== `backoff.init`
+
+The number of seconds to wait before attempting to connect to Logstash
+after an initial connection error. The default is 1s. If additional errors
+occur, the wait time is increased exponentially for each try until `backoff.max`
+is met.
+
+===== `backoff.max`
+
+The maximum number of seconds to wait before attempting to connect to
+Logstash after a connection error. The default is 60s.
 
 [[kafka-output]]
 === Configure the Kafka output

--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -319,15 +319,17 @@ number of events to be contained in a batch.
 
 ===== `backoff.init`
 
-The number of seconds to wait before attempting to connect to Elasticsearch
-after an initial connection error. The default is 1s. If additional errors
-occur, the wait time is increased exponentially for each try until `backoff.max`
-is met.
+The number of seconds to wait before trying to reconnect to Elasticsearch after
+a network error. After waiting `backoff.init` seconds, {beatname_uc} tries to
+reconnect. If the attempt fails, the backoff timer is increased exponentially up
+to `backoff.max`. After a successful connection, the backoff timer is reset. The
+default is 1s.
+
 
 ===== `backoff.max`
 
 The maximum number of seconds to wait before attempting to connect to
-Elasticsearch after a connection error. The default is 60s.
+Elasticsearch after a network error. The default is 60s.
 
 ===== `timeout`
 
@@ -595,15 +597,16 @@ The default is `false`.
 
 ===== `backoff.init`
 
-The number of seconds to wait before attempting to connect to Logstash
-after an initial connection error. The default is 1s. If additional errors
-occur, the wait time is increased exponentially for each try until `backoff.max`
-is met.
+The number of seconds to wait before trying to reconnect to Logstash after
+a network error. After waiting `backoff.init` seconds, {beatname_uc} tries to
+reconnect. If the attempt fails, the backoff timer is increased exponentially up
+to `backoff.max`. After a successful connection, the backoff timer is reset. The
+default is 1s.
 
 ===== `backoff.max`
 
 The maximum number of seconds to wait before attempting to connect to
-Logstash after a connection error. The default is 60s.
+Logstash after a network error. The default is 60s.
 
 [[kafka-output]]
 === Configure the Kafka output

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -888,14 +888,15 @@ output.elasticsearch:
   # The default is 50.
   #bulk_max_size: 50
 
-  # The number of seconds to wait before attempting to connect to Elasticsearch
-  # after an initial connection error. The default is 1s. If additional errors
-  # occur, the wait time is increased exponentially for each try until
-  # backoff.max is met.
+  # The number of seconds to wait before trying to reconnect to Elasticsearch
+  # after a network error. After waiting backoff.init seconds, the Beat
+  # tries to reconnect. If the attempt fails, the backoff timer is increased
+  # exponentially up to backoff.max. After a successful connection, the backoff
+  # timer is reset. The default is 1s.
   #backoff.init: 1s
 
   # The maximum number of seconds to wait before attempting to connect to
-  # Elasticsearch after a connection error. The default is 60s.
+  # Elasticsearch after a network error. The default is 60s.
   #backoff.max: 60s
 
   # Configure http request timeout before failing a request to Elasticsearch.
@@ -971,14 +972,15 @@ output.elasticsearch:
   # if no error is encountered.
   #slow_start: false
 
-  # The number of seconds to wait before attempting to connect to Logstash
-  # after an initial connection error. The default is 1s. If additional errors
-  # occur, the wait time is increased exponentially for each try until
-  # backoff.max is met.
+  # The number of seconds to wait before trying to reconnect to Logstash
+  # after a network error. After waiting backoff.init seconds, the Beat
+  # tries to reconnect. If the attempt fails, the backoff timer is increased
+  # exponentially up to backoff.max. After a successful connection, the backoff
+  # timer is reset. The default is 1s.
   #backoff.init: 1s
 
   # The maximum number of seconds to wait before attempting to connect to
-  # Logstash after a connection error. The default is 60s.
+  # Logstash after a network error. The default is 60s.
   #backoff.max: 60s
 
   # Optional index name. The default index name is set to metricbeat

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -888,7 +888,17 @@ output.elasticsearch:
   # The default is 50.
   #bulk_max_size: 50
 
-  # Configure http request timeout before failing an request to Elasticsearch.
+  # The number of seconds to wait before attempting to connect to Elasticsearch
+  # after an initial connection error. The default is 1s. If additional errors
+  # occur, the wait time is increased exponentially for each try until
+  # backoff.max is met.
+  #backoff.init: 1s
+
+  # The maximum number of seconds to wait before attempting to connect to
+  # Elasticsearch after a connection error. The default is 60s.
+  #backoff.max: 60s
+
+  # Configure http request timeout before failing a request to Elasticsearch.
   #timeout: 90
 
   # Use SSL settings for HTTPS.
@@ -952,7 +962,7 @@ output.elasticsearch:
   # Optional load balance the events between the Logstash hosts. Default is false.
   #loadbalance: false
 
-  # Number of batches to be sent asynchronously to logstash while processing
+  # Number of batches to be sent asynchronously to Logstash while processing
   # new batches.
   #pipelining: 2
 
@@ -960,6 +970,16 @@ output.elasticsearch:
   # transaction.  The number of events to be sent increases up to `bulk_max_size`
   # if no error is encountered.
   #slow_start: false
+
+  # The number of seconds to wait before attempting to connect to Logstash
+  # after an initial connection error. The default is 1s. If additional errors
+  # occur, the wait time is increased exponentially for each try until
+  # backoff.max is met.
+  #backoff.init: 1s
+
+  # The maximum number of seconds to wait before attempting to connect to
+  # Logstash after a connection error. The default is 60s.
+  #backoff.max: 60s
 
   # Optional index name. The default index name is set to metricbeat
   # in all lowercase.

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -747,7 +747,17 @@ output.elasticsearch:
   # The default is 50.
   #bulk_max_size: 50
 
-  # Configure http request timeout before failing an request to Elasticsearch.
+  # The number of seconds to wait before attempting to connect to Elasticsearch
+  # after an initial connection error. The default is 1s. If additional errors
+  # occur, the wait time is increased exponentially for each try until
+  # backoff.max is met.
+  #backoff.init: 1s
+
+  # The maximum number of seconds to wait before attempting to connect to
+  # Elasticsearch after a connection error. The default is 60s.
+  #backoff.max: 60s
+
+  # Configure http request timeout before failing a request to Elasticsearch.
   #timeout: 90
 
   # Use SSL settings for HTTPS.
@@ -811,7 +821,7 @@ output.elasticsearch:
   # Optional load balance the events between the Logstash hosts. Default is false.
   #loadbalance: false
 
-  # Number of batches to be sent asynchronously to logstash while processing
+  # Number of batches to be sent asynchronously to Logstash while processing
   # new batches.
   #pipelining: 2
 
@@ -819,6 +829,16 @@ output.elasticsearch:
   # transaction.  The number of events to be sent increases up to `bulk_max_size`
   # if no error is encountered.
   #slow_start: false
+
+  # The number of seconds to wait before attempting to connect to Logstash
+  # after an initial connection error. The default is 1s. If additional errors
+  # occur, the wait time is increased exponentially for each try until
+  # backoff.max is met.
+  #backoff.init: 1s
+
+  # The maximum number of seconds to wait before attempting to connect to
+  # Logstash after a connection error. The default is 60s.
+  #backoff.max: 60s
 
   # Optional index name. The default index name is set to packetbeat
   # in all lowercase.

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -747,14 +747,15 @@ output.elasticsearch:
   # The default is 50.
   #bulk_max_size: 50
 
-  # The number of seconds to wait before attempting to connect to Elasticsearch
-  # after an initial connection error. The default is 1s. If additional errors
-  # occur, the wait time is increased exponentially for each try until
-  # backoff.max is met.
+  # The number of seconds to wait before trying to reconnect to Elasticsearch
+  # after a network error. After waiting backoff.init seconds, the Beat
+  # tries to reconnect. If the attempt fails, the backoff timer is increased
+  # exponentially up to backoff.max. After a successful connection, the backoff
+  # timer is reset. The default is 1s.
   #backoff.init: 1s
 
   # The maximum number of seconds to wait before attempting to connect to
-  # Elasticsearch after a connection error. The default is 60s.
+  # Elasticsearch after a network error. The default is 60s.
   #backoff.max: 60s
 
   # Configure http request timeout before failing a request to Elasticsearch.
@@ -830,14 +831,15 @@ output.elasticsearch:
   # if no error is encountered.
   #slow_start: false
 
-  # The number of seconds to wait before attempting to connect to Logstash
-  # after an initial connection error. The default is 1s. If additional errors
-  # occur, the wait time is increased exponentially for each try until
-  # backoff.max is met.
+  # The number of seconds to wait before trying to reconnect to Logstash
+  # after a network error. After waiting backoff.init seconds, the Beat
+  # tries to reconnect. If the attempt fails, the backoff timer is increased
+  # exponentially up to backoff.max. After a successful connection, the backoff
+  # timer is reset. The default is 1s.
   #backoff.init: 1s
 
   # The maximum number of seconds to wait before attempting to connect to
-  # Logstash after a connection error. The default is 60s.
+  # Logstash after a network error. The default is 60s.
   #backoff.max: 60s
 
   # Optional index name. The default index name is set to packetbeat

--- a/winlogbeat/winlogbeat.reference.yml
+++ b/winlogbeat/winlogbeat.reference.yml
@@ -299,7 +299,17 @@ output.elasticsearch:
   # The default is 50.
   #bulk_max_size: 50
 
-  # Configure http request timeout before failing an request to Elasticsearch.
+  # The number of seconds to wait before attempting to connect to Elasticsearch
+  # after an initial connection error. The default is 1s. If additional errors
+  # occur, the wait time is increased exponentially for each try until
+  # backoff.max is met.
+  #backoff.init: 1s
+
+  # The maximum number of seconds to wait before attempting to connect to
+  # Elasticsearch after a connection error. The default is 60s.
+  #backoff.max: 60s
+
+  # Configure http request timeout before failing a request to Elasticsearch.
   #timeout: 90
 
   # Use SSL settings for HTTPS.
@@ -363,7 +373,7 @@ output.elasticsearch:
   # Optional load balance the events between the Logstash hosts. Default is false.
   #loadbalance: false
 
-  # Number of batches to be sent asynchronously to logstash while processing
+  # Number of batches to be sent asynchronously to Logstash while processing
   # new batches.
   #pipelining: 2
 
@@ -371,6 +381,16 @@ output.elasticsearch:
   # transaction.  The number of events to be sent increases up to `bulk_max_size`
   # if no error is encountered.
   #slow_start: false
+
+  # The number of seconds to wait before attempting to connect to Logstash
+  # after an initial connection error. The default is 1s. If additional errors
+  # occur, the wait time is increased exponentially for each try until
+  # backoff.max is met.
+  #backoff.init: 1s
+
+  # The maximum number of seconds to wait before attempting to connect to
+  # Logstash after a connection error. The default is 60s.
+  #backoff.max: 60s
 
   # Optional index name. The default index name is set to winlogbeat
   # in all lowercase.

--- a/winlogbeat/winlogbeat.reference.yml
+++ b/winlogbeat/winlogbeat.reference.yml
@@ -299,14 +299,15 @@ output.elasticsearch:
   # The default is 50.
   #bulk_max_size: 50
 
-  # The number of seconds to wait before attempting to connect to Elasticsearch
-  # after an initial connection error. The default is 1s. If additional errors
-  # occur, the wait time is increased exponentially for each try until
-  # backoff.max is met.
+  # The number of seconds to wait before trying to reconnect to Elasticsearch
+  # after a network error. After waiting backoff.init seconds, the Beat
+  # tries to reconnect. If the attempt fails, the backoff timer is increased
+  # exponentially up to backoff.max. After a successful connection, the backoff
+  # timer is reset. The default is 1s.
   #backoff.init: 1s
 
   # The maximum number of seconds to wait before attempting to connect to
-  # Elasticsearch after a connection error. The default is 60s.
+  # Elasticsearch after a network error. The default is 60s.
   #backoff.max: 60s
 
   # Configure http request timeout before failing a request to Elasticsearch.
@@ -382,14 +383,15 @@ output.elasticsearch:
   # if no error is encountered.
   #slow_start: false
 
-  # The number of seconds to wait before attempting to connect to Logstash
-  # after an initial connection error. The default is 1s. If additional errors
-  # occur, the wait time is increased exponentially for each try until
-  # backoff.max is met.
+  # The number of seconds to wait before trying to reconnect to Logstash
+  # after a network error. After waiting backoff.init seconds, the Beat
+  # tries to reconnect. If the attempt fails, the backoff timer is increased
+  # exponentially up to backoff.max. After a successful connection, the backoff
+  # timer is reset. The default is 1s.
   #backoff.init: 1s
 
   # The maximum number of seconds to wait before attempting to connect to
-  # Logstash after a connection error. The default is 60s.
+  # Logstash after a network error. The default is 60s.
   #backoff.max: 60s
 
   # Optional index name. The default index name is set to winlogbeat


### PR DESCRIPTION
Adds backup options for LS and ES outputs (closes https://github.com/elastic/beats/issues/5419)

NOTE: I wasn't sure quite where to add the options in the yaml file.

Do we want to say anything about the backoff factor used here? Probably not since it's not configurable?