### PR TITLE
Start simplify system tests

### DIFF
--- a/auditbeat/tests/system/test_base.py
+++ b/auditbeat/tests/system/test_base.py
@@ -24,7 +24,7 @@ class Test(BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.log_contains("start running"))
         proc.check_kill_and_wait()
-        self.assert_no_logged_warnings()
+        self.assert_no_logged_warnings('"error": "failed to stat: lstat file.example: no such file or directory"')
 
         # Ensure all Beater stages are used.
         assert self.log_contains("Setup Beat: auditbeat")

--- a/metricbeat/module/elasticsearch/test_elasticsearch.py
+++ b/metricbeat/module/elasticsearch/test_elasticsearch.py
@@ -2,6 +2,7 @@ import re
 import sys
 import os
 import unittest
+from elasticsearch import Elasticsearch, TransportError
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '../../tests/system'))
 
@@ -11,28 +12,30 @@ import metricbeat
 class Test(metricbeat.BaseTest):
 
     COMPOSE_SERVICES = ['elasticsearch']
+    FIELDS = ["elasticsearch"]
 
     @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
     def test_node(self):
         """
         elasticsearch node metricset test
         """
-        self.check_metricset("elasticsearch", "node", self.get_hosts())
+        self.check_metricset("elasticsearch", "node", self.get_hosts(), self.FIELDS)
 
     @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
     def test_node_stats(self):
         """
         elasticsearch node_stats metricset test
         """
-        self.check_metricset("elasticsearch", "node_stats", self.get_hosts())
+        self.check_metricset("elasticsearch", "node_stats", self.get_hosts(), self.FIELDS + ["service.name"])
 
     @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
     def test_index(self):
         """
         elasticsearch index metricset test
         """
-        # TODO: need to create an index first to get stats
-        self.check_metricset("elasticsearch", "index", self.get_hosts())
+        es = Elasticsearch(self.get_hosts())
+        es.indices.create(index='test-index', ignore=400)
+        self.check_metricset("elasticsearch", "index", self.get_hosts(), self.FIELDS + ["service.name"])
 
     def get_hosts(self):
         return [os.getenv('ES_HOST', 'localhost') + ':' +

--- a/metricbeat/tests/system/metricbeat.py
+++ b/metricbeat/tests/system/metricbeat.py
@@ -65,7 +65,7 @@ class BaseTest(TestCase):
         """
         log = self.get_log()
 
-        pattern = self.build_log_regex("[cfgwarn]")
+        pattern = self.build_log_regex("\[cfgwarn\]")
         log = pattern.sub("", log)
 
         # Jenkins runs as a Windows service and when Jenkins executes these
@@ -77,12 +77,12 @@ class BaseTest(TestCase):
             for r in replace:
                 pattern = self.build_log_regex(r)
                 log = pattern.sub("", log)
-        self.assertNotRegexpMatches(log, "ERROR|WARN")
+        self.assertNotRegexpMatches(log, "\tERROR\t|\tWARN\t")
 
     def build_log_regex(self, message):
         return re.compile(r"^.*\t(?:ERROR|WARN)\t.*" + message + r".*$", re.MULTILINE)
 
-    def check_metricset(self, module, metricset, hosts):
+    def check_metricset(self, module, metricset, hosts, fields=[]):
         """
         Method to test a metricset for its fields
         """
@@ -93,7 +93,7 @@ class BaseTest(TestCase):
             "period": "1s",
         }])
         proc = self.start_beat()
-        self.wait_until(lambda: self.output_lines() > 0, max_timeout=20)
+        self.wait_until(lambda: self.output_lines() > 0)
         proc.check_kill_and_wait()
         self.assert_no_logged_warnings()
 
@@ -101,5 +101,8 @@ class BaseTest(TestCase):
         self.assertTrue(len(output) >= 1)
         evt = output[0]
         print(evt)
+
+        fields = COMMON_FIELDS + fields
+        self.assertItemsEqual(self.de_dot(fields), evt.keys())
 
         self.assert_fields_are_documented(evt)

--- a/metricbeat/tests/system/requirements.txt
+++ b/metricbeat/tests/system/requirements.txt
@@ -1,1 +1,3 @@
 kafka-python==1.4.2
+parameterized==0.6.1
+elasticsearch==6.2.0

--- a/metricbeat/tests/system/test_aerospike.py
+++ b/metricbeat/tests/system/test_aerospike.py
@@ -1,13 +1,11 @@
 import os
 import metricbeat
 import unittest
-from nose.plugins.attrib import attr
-
-AEROSPIKE_FIELDS = metricbeat.COMMON_FIELDS + ["aerospike"]
 
 
 class Test(metricbeat.BaseTest):
 
+    FIELDS = ["aerospike"]
     COMPOSE_SERVICES = ['aerospike']
 
     @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
@@ -15,24 +13,7 @@ class Test(metricbeat.BaseTest):
         """
         aerospike namespace metricset test
         """
-        self.render_config_template(modules=[{
-            "name": "aerospike",
-            "metricsets": ["namespace"],
-            "hosts": self.get_hosts(),
-            "period": "1s"
-        }])
-        proc = self.start_beat()
-        self.wait_until(lambda: self.output_lines() > 0)
-        proc.check_kill_and_wait()
-        self.assert_no_logged_warnings()
-
-        output = self.read_output_json()
-        self.assertEqual(len(output), 1)
-        evt = output[0]
-
-        self.assertItemsEqual(self.de_dot(AEROSPIKE_FIELDS), evt.keys())
-
-        self.assert_fields_are_documented(evt)
+        self.check_metricset("aerospike", "namespace", self.get_hosts(), self.FIELDS)
 
     def get_hosts(self):
         return [os.getenv('AEROSPIKE_HOST', 'localhost') + ':' +

--- a/metricbeat/tests/system/test_ceph.py
+++ b/metricbeat/tests/system/test_ceph.py
@@ -1,116 +1,28 @@
 import os
 import metricbeat
 import unittest
+from parameterized import parameterized
+import time
 
 
 class Test(metricbeat.BaseTest):
 
     COMPOSE_SERVICES = ['ceph']
     COMPOSE_TIMEOUT = 300
+    FIELDS = ["ceph"]
 
+    @parameterized.expand([
+        "cluster_disk",
+        "cluster_health",
+        "monitor_health",
+        "pool_disk",
+    ])
     @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
-    def test_cluster_disk(self):
+    def test_ceph(self, metricset):
         """
-        ceph cluster_disk metricset test
+        ceph metricsets tests
         """
-        self.render_config_template(modules=[{
-            "name": "ceph",
-            "metricsets": ["cluster_disk"],
-            "hosts": self.get_hosts(),
-            "period": "1s"
-        }])
-        proc = self.start_beat()
-        self.wait_until(lambda: self.output_lines() > 0, max_timeout=20)
-        proc.check_kill_and_wait()
-
-        output = self.read_output_json()
-        self.assertTrue(len(output) >= 1)
-        evt = output[0]
-        print evt
-
-        self.assertTrue("error" not in evt)
-        self.assertTrue("ceph" in evt)
-        self.assertTrue("cluster_disk" in evt["ceph"])
-
-        self.assert_fields_are_documented(evt)
-
-    @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
-    def test_cluster_health(self):
-        """
-        ceph cluster_health metricset test
-        """
-        self.render_config_template(modules=[{
-            "name": "ceph",
-            "metricsets": ["cluster_health"],
-            "hosts": self.get_hosts(),
-            "period": "1s"
-        }])
-        proc = self.start_beat()
-        self.wait_until(lambda: self.output_lines() > 0, max_timeout=20)
-        proc.check_kill_and_wait()
-
-        output = self.read_output_json()
-        self.assertTrue(len(output) >= 1)
-        evt = output[0]
-        print evt
-
-        self.assertTrue("error" not in evt)
-        self.assertTrue("ceph" in evt)
-        self.assertTrue("cluster_health" in evt["ceph"])
-
-        self.assert_fields_are_documented(evt)
-
-    @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
-    def test_monitor_health(self):
-        """
-        ceph monitor_health metricset test
-        """
-        self.render_config_template(modules=[{
-            "name": "ceph",
-            "metricsets": ["monitor_health"],
-            "hosts": self.get_hosts(),
-            "period": "1s"
-        }])
-        proc = self.start_beat()
-        self.wait_until(lambda: self.output_lines() > 0, max_timeout=20)
-        proc.check_kill_and_wait()
-
-        output = self.read_output_json()
-        self.assertTrue(len(output) >= 1)
-        evt = output[0]
-        print evt
-
-        self.assertTrue("error" not in evt)
-        self.assertTrue("ceph" in evt)
-        self.assertTrue("monitor_health" in evt["ceph"])
-
-        self.assert_fields_are_documented(evt)
-
-    @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
-    def test_pool_disk(self):
-        """
-        ceph pool_disk metricset test
-        """
-        self.render_config_template(modules=[{
-            "name": "ceph",
-            "metricsets": ["pool_disk"],
-            "hosts": self.get_hosts(),
-            "period": "1s"
-        }])
-        proc = self.start_beat()
-        self.wait_until(lambda: self.output_lines() > 0, max_timeout=20)
-        proc.check_kill_and_wait()
-
-        output = self.read_output_json()
-        self.assertTrue(len(output) >= 1)
-        evt = output[0]
-        print evt
-
-        self.assertTrue("error" not in evt)
-        self.assertTrue("ceph" in evt)
-        self.assertTrue("pool_disk" in evt["ceph"])
-
-        self.assert_fields_are_documented(evt)
+        self.check_metricset("ceph", metricset, self.get_hosts(), self.FIELDS)
 
     def get_hosts(self):
         return [os.getenv('CEPH_HOST', 'localhost') + ':' +

--- a/metricbeat/tests/system/test_couchbase.py
+++ b/metricbeat/tests/system/test_couchbase.py
@@ -1,80 +1,25 @@
 import os
 import metricbeat
 import unittest
+from parameterized import parameterized
 
 
 class Test(metricbeat.BaseTest):
 
     COMPOSE_SERVICES = ['couchbase']
+    FIELDS = ['couchbase']
 
+    @parameterized.expand([
+        ("bucket"),
+        ("cluster"),
+        ("node"),
+    ])
     @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
-    def test_bucket(self):
+    def test_couchbase(self, metricset):
         """
-        couchbase bucket metricset test
+        couchbase metricsets tests
         """
-        self.render_config_template(modules=[{
-            "name": "couchbase",
-            "metricsets": ["bucket"],
-            "hosts": self.get_hosts(),
-            "period": "1s"
-        }])
-        proc = self.start_beat()
-        self.wait_until(lambda: self.output_lines() > 0, max_timeout=20)
-        proc.check_kill_and_wait()
-        self.assert_no_logged_warnings()
-
-        output = self.read_output_json()
-        self.assertTrue(len(output) >= 1)
-        evt = output[0]
-        print evt
-
-        self.assert_fields_are_documented(evt)
-
-    @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
-    def test_cluster(self):
-        """
-        couchbase cluster metricset test
-        """
-        self.render_config_template(modules=[{
-            "name": "couchbase",
-            "metricsets": ["cluster"],
-            "hosts": self.get_hosts(),
-            "period": "1s"
-        }])
-        proc = self.start_beat()
-        self.wait_until(lambda: self.output_lines() > 0, max_timeout=20)
-        proc.check_kill_and_wait()
-        self.assert_no_logged_warnings()
-
-        output = self.read_output_json()
-        self.assertTrue(len(output) >= 1)
-        evt = output[0]
-        print evt
-
-        self.assert_fields_are_documented(evt)
-
-    @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
-    def test_node(self):
-        """
-        couchbase node metricset test
-        """
-        self.render_config_template(modules=[{
-            "name": "couchbase",
-            "metricsets": ["node"],
-            "hosts": self.get_hosts(),
-            "period": "1s"
-        }])
-        proc = self.start_beat()
-        self.wait_until(lambda: self.output_lines() > 0, max_timeout=20)
-        proc.check_kill_and_wait()
-        self.assert_no_logged_warnings()
-
-        output = self.read_output_json()
-        self.assertTrue(len(output) >= 1)
-        evt = output[0]
-        print evt
-
-        self.assert_fields_are_documented(evt)
+        self.check_metricset("couchbase", metricset, self.get_hosts(), self.FIELDS)
 
     def get_hosts(self):
         return [os.getenv('COUCHBASE_HOST', 'localhost') + ':' +

--- a/metricbeat/tests/system/test_kibana.py
+++ b/metricbeat/tests/system/test_kibana.py
@@ -7,7 +7,6 @@ from nose.plugins.skip import SkipTest
 class Test(metricbeat.BaseTest):
 
     COMPOSE_SERVICES = ['elasticsearch', 'kibana']
-
     COMPOSE_TIMEOUT = 600
 
     @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")

--- a/metricbeat/tests/system/test_kubernetes.py
+++ b/metricbeat/tests/system/test_kubernetes.py
@@ -8,6 +8,7 @@ KUBERNETES_FIELDS = metricbeat.COMMON_FIELDS + ["kubernetes"]
 class Test(metricbeat.BaseTest):
 
     COMPOSE_SERVICES = ['kubernetes']  # 'kubestate']
+    COMPOSE_TIMEOUT = 300
 
     @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
     def test_kubelet_node(self):


### PR DESCRIPTION
The idea of this PR is to start to play around with ways to simplify our system tests are remove most of the duplicated code.

* Use check_metricset method for aerospike test
* Add fields check to check_metricset method
* Use parameterized for ceph and couchbase tests

Further fixes:

* Increase timeout for k8s tests
* Fix regexp to remove cfgwarn warnings. The removal removed all WARN / ERROR messages.
* Fix flaky auditbeat test by skipping the error message.