### PR TITLE
Harden file integrity flaky test

### DIFF
--- a/auditbeat/tests/system/test_file_integrity.py
+++ b/auditbeat/tests/system/test_file_integrity.py
@@ -111,6 +111,8 @@ class Test(BaseTest):
             self.wait_log_contains("\"deleted\"")
             self.wait_log_contains("\"path\": \"{0}\"".format(escape_path(subdir)), ignore_case=True)
             self.wait_output(3)
+            self.wait_until(lambda: any(
+                'file.path' in obj and obj['file.path'].lower() == subdir.lower() for obj in self.read_output()))
 
             proc.check_kill_and_wait()
             self.assert_no_logged_warnings()
@@ -169,6 +171,8 @@ class Test(BaseTest):
 
             self.wait_log_contains("\"path\": \"{0}\"".format(escape_path(file2)), ignore_case=True)
             self.wait_output(4)
+            self.wait_until(lambda: any(
+                'file.path' in obj and obj['file.path'].lower() == subdir2.lower() for obj in self.read_output()))
 
             proc.check_kill_and_wait()
             self.assert_no_logged_warnings()


### PR DESCRIPTION
The file integrity system test depends on auditbeat's file output to validate functionality. This output is sometimes too slow and causes random CI failures.

This patch makes sure that all the required events are written to the file output before stopping auditbeat.

---

I'm leaving this here so it can be merged if we see any flakiness in the file_integrity test. I saw the original test fail under Linux when run enough times in a loop, always with `Dir '{0}' not found`.

Related to #6893 