### PR TITLE
Unify default module configurations

### DIFF
--- a/metricbeat/Makefile
+++ b/metricbeat/Makefile
@@ -10,6 +10,7 @@ ES_BEATS?=..
 GOX_OS=netbsd linux windows
 GOX_FLAGS=-arch="amd64 386 arm ppc64 ppc64le"
 
+DOCS_BRANCH=$(shell grep doc-branch ../libbeat/docs/version.asciidoc | cut -c 14-)
 
 include ${ES_BEATS}/libbeat/scripts/Makefile
 
@@ -41,8 +42,8 @@ configs: python-env
 	@cat ${ES_BEATS}/metricbeat/_meta/setup.yml >> _meta/beat.yml
 	@cat ${ES_BEATS}/metricbeat/_meta/common.reference.yml > _meta/beat.reference.yml
 	@${PYTHON_ENV}/bin/python ${ES_BEATS}/script/config_collector.py --beat ${BEAT_NAME} --full $(PWD) >> _meta/beat.reference.yml
-	@rm -rf modules.d && mkdir -p modules.d
-	@for MODULE in `find module -maxdepth 1 -mindepth 1 -type d -exec basename {} \;`; do cp -a $(PWD)/module/$$MODULE/_meta/config.yml modules.d/$$MODULE.yml.disabled; done
+	@rm -rf modules.d
+	${PYTHON_ENV}/bin/python ${ES_BEATS}/metricbeat/scripts/modules_collector.py --docs_branch=$(DOCS_BRANCH)
 	@chmod go-w modules.d/*
 	@# Enable system by default:
 	@if [ -f modules.d/system.yml.disabled ]; then mv modules.d/system.yml.disabled modules.d/system.yml; fi

--- a/metricbeat/docs/modules/golang.asciidoc
+++ b/metricbeat/docs/modules/golang.asciidoc
@@ -20,9 +20,9 @@ in <<configuration-metricbeat>>. Here is an example configuration:
 ----
 metricbeat.modules:
 - module: golang
-  metricsets:
-    - expvar
-    - heap
+#  metricsets:
+#    - expvar
+#    - heap
   period: 10s
   hosts: ["localhost:6060"]
   heap.path: "/debug/vars"

--- a/metricbeat/docs/modules/golang.asciidoc
+++ b/metricbeat/docs/modules/golang.asciidoc
@@ -20,9 +20,9 @@ in <<configuration-metricbeat>>. Here is an example configuration:
 ----
 metricbeat.modules:
 - module: golang
-#  metricsets:
-#    - expvar
-#    - heap
+  #metricsets:
+  #  - expvar
+  #  - heap
   period: 10s
   hosts: ["localhost:6060"]
   heap.path: "/debug/vars"

--- a/metricbeat/docs/modules/golang.asciidoc
+++ b/metricbeat/docs/modules/golang.asciidoc
@@ -20,7 +20,9 @@ in <<configuration-metricbeat>>. Here is an example configuration:
 ----
 metricbeat.modules:
 - module: golang
-  metricsets: ["expvar","heap"]
+  metricsets:
+    - expvar
+    - heap
   period: 10s
   hosts: ["localhost:6060"]
   heap.path: "/debug/vars"

--- a/metricbeat/docs/modules/http.asciidoc
+++ b/metricbeat/docs/modules/http.asciidoc
@@ -26,7 +26,8 @@ in <<configuration-metricbeat>>. Here is an example configuration:
 ----
 metricbeat.modules:
 - module: http
-  metricsets: ["json"]
+  #metricsets:
+  #  - json
   period: 10s
   hosts: ["localhost:80"]
   namespace: "json_namespace"
@@ -39,15 +40,16 @@ metricbeat.modules:
   #dedot.enabled: false
 
 - module: http
-  metricsets: ["server"]
+  #metricsets:
+  #  - server
   host: "localhost"
   port: "8080"
   enabled: false
-#  paths:
-#    - path: "/foo"
-#      namespace: "foo"
-#      fields: # added to the the response in root. overwrites existing fields
-#        key: "value"
+  #paths:
+  #  - path: "/foo"
+  #    namespace: "foo"
+  #    fields: # added to the the response in root. overwrites existing fields
+  #      key: "value"
 ----
 
 This module supports TLS connection when using `ssl` config field, as described in <<configuration-ssl>>.

--- a/metricbeat/docs/modules/jolokia.asciidoc
+++ b/metricbeat/docs/modules/jolokia.asciidoc
@@ -19,29 +19,29 @@ in <<configuration-metricbeat>>. Here is an example configuration:
 ----
 metricbeat.modules:
 - module: jolokia
-#  metricsets: ["jmx"]
+  #metricsets: ["jmx"]
   period: 10s
   hosts: ["localhost"]
   namespace: "metrics"
-#  path: "/jolokia/?ignoreErrors=true&canonicalNaming=false"
+  #path: "/jolokia/?ignoreErrors=true&canonicalNaming=false"
   jmx.mappings:
-    # - mbean: 'java.lang:type=Runtime'
-    #   attributes:
-    #     - attr: Uptime
-    #       field: uptime
-    # - mbean: 'java.lang:type=Memory'
-    #   attributes:
-    #     - attr: HeapMemoryUsage
-    #       field: memory.heap_usage
-    #     - attr: NonHeapMemoryUsage
-    #       field: memory.non_heap_usage
+    #- mbean: 'java.lang:type=Runtime'
+    #  attributes:
+    #    - attr: Uptime
+    #      field: uptime
+    #- mbean: 'java.lang:type=Memory'
+    #  attributes:
+    #    - attr: HeapMemoryUsage
+    #      field: memory.heap_usage
+    #    - attr: NonHeapMemoryUsage
+    #      field: memory.non_heap_usage
     # GC Metrics - this depends on what is available on your JVM
-    # - mbean: 'java.lang:type=GarbageCollector,name=ConcurrentMarkSweep'
-    #   attributes:
-    #     - attr: CollectionTime
-    #       field: gc.cms_collection_time
-    #     - attr: CollectionCount
-    #       field: gc.cms_collection_count
+    #- mbean: 'java.lang:type=GarbageCollector,name=ConcurrentMarkSweep'
+    #  attributes:
+    #    - attr: CollectionTime
+    #      field: gc.cms_collection_time
+    #    - attr: CollectionCount
+    #      field: gc.cms_collection_count
 
   jmx.application:
   jmx.instance:

--- a/metricbeat/docs/modules/jolokia.asciidoc
+++ b/metricbeat/docs/modules/jolokia.asciidoc
@@ -19,11 +19,11 @@ in <<configuration-metricbeat>>. Here is an example configuration:
 ----
 metricbeat.modules:
 - module: jolokia
-  metricsets: ["jmx"]
+#  metricsets: ["jmx"]
   period: 10s
   hosts: ["localhost"]
   namespace: "metrics"
-  #path: "/jolokia/?ignoreErrors=true&canonicalNaming=false"
+#  path: "/jolokia/?ignoreErrors=true&canonicalNaming=false"
   jmx.mappings:
     # - mbean: 'java.lang:type=Runtime'
     #   attributes:

--- a/metricbeat/docs/modules/jolokia.asciidoc
+++ b/metricbeat/docs/modules/jolokia.asciidoc
@@ -23,17 +23,18 @@ metricbeat.modules:
   period: 10s
   hosts: ["localhost"]
   namespace: "metrics"
+  #path: "/jolokia/?ignoreErrors=true&canonicalNaming=false"
   jmx.mappings:
-    - mbean: 'java.lang:type=Runtime'
-      attributes:
-        - attr: Uptime
-          field: uptime
-    - mbean: 'java.lang:type=Memory'
-      attributes:
-        - attr: HeapMemoryUsage
-          field: memory.heap_usage
-        - attr: NonHeapMemoryUsage
-          field: memory.non_heap_usage
+    # - mbean: 'java.lang:type=Runtime'
+    #   attributes:
+    #     - attr: Uptime
+    #       field: uptime
+    # - mbean: 'java.lang:type=Memory'
+    #   attributes:
+    #     - attr: HeapMemoryUsage
+    #       field: memory.heap_usage
+    #     - attr: NonHeapMemoryUsage
+    #       field: memory.non_heap_usage
     # GC Metrics - this depends on what is available on your JVM
     # - mbean: 'java.lang:type=GarbageCollector,name=ConcurrentMarkSweep'
     #   attributes:
@@ -41,6 +42,9 @@ metricbeat.modules:
     #       field: gc.cms_collection_time
     #     - attr: CollectionCount
     #       field: gc.cms_collection_count
+
+  jmx.application:
+  jmx.instance:
 ----
 
 This module supports TLS connection when using `ssl` config field, as described in <<configuration-ssl>>.

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -210,7 +210,9 @@ metricbeat.modules:
 
 #------------------------------- Golang Module -------------------------------
 - module: golang
-  metricsets: ["expvar","heap"]
+  metricsets:
+    - expvar
+    - heap
   period: 10s
   hosts: ["localhost:6060"]
   heap.path: "/debug/vars"
@@ -280,17 +282,18 @@ metricbeat.modules:
   period: 10s
   hosts: ["localhost"]
   namespace: "metrics"
+  #path: "/jolokia/?ignoreErrors=true&canonicalNaming=false"
   jmx.mappings:
-    - mbean: 'java.lang:type=Runtime'
-      attributes:
-        - attr: Uptime
-          field: uptime
-    - mbean: 'java.lang:type=Memory'
-      attributes:
-        - attr: HeapMemoryUsage
-          field: memory.heap_usage
-        - attr: NonHeapMemoryUsage
-          field: memory.non_heap_usage
+    # - mbean: 'java.lang:type=Runtime'
+    #   attributes:
+    #     - attr: Uptime
+    #       field: uptime
+    # - mbean: 'java.lang:type=Memory'
+    #   attributes:
+    #     - attr: HeapMemoryUsage
+    #       field: memory.heap_usage
+    #     - attr: NonHeapMemoryUsage
+    #       field: memory.non_heap_usage
     # GC Metrics - this depends on what is available on your JVM
     # - mbean: 'java.lang:type=GarbageCollector,name=ConcurrentMarkSweep'
     #   attributes:
@@ -298,6 +301,9 @@ metricbeat.modules:
     #       field: gc.cms_collection_time
     #     - attr: CollectionCount
     #       field: gc.cms_collection_count
+
+  jmx.application:
+  jmx.instance:
 
 #-------------------------------- Kafka Module -------------------------------
 - module: kafka

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -210,9 +210,9 @@ metricbeat.modules:
 
 #------------------------------- Golang Module -------------------------------
 - module: golang
-#  metricsets:
-#    - expvar
-#    - heap
+  #metricsets:
+  #  - expvar
+  #  - heap
   period: 10s
   hosts: ["localhost:6060"]
   heap.path: "/debug/vars"
@@ -253,7 +253,8 @@ metricbeat.modules:
 
 #-------------------------------- HTTP Module --------------------------------
 - module: http
-  metricsets: ["json"]
+  #metricsets:
+  #  - json
   period: 10s
   hosts: ["localhost:80"]
   namespace: "json_namespace"
@@ -266,41 +267,42 @@ metricbeat.modules:
   #dedot.enabled: false
 
 - module: http
-  metricsets: ["server"]
+  #metricsets:
+  #  - server
   host: "localhost"
   port: "8080"
   enabled: false
-#  paths:
-#    - path: "/foo"
-#      namespace: "foo"
-#      fields: # added to the the response in root. overwrites existing fields
-#        key: "value"
+  #paths:
+  #  - path: "/foo"
+  #    namespace: "foo"
+  #    fields: # added to the the response in root. overwrites existing fields
+  #      key: "value"
 
 #------------------------------- Jolokia Module ------------------------------
 - module: jolokia
-#  metricsets: ["jmx"]
+  #metricsets: ["jmx"]
   period: 10s
   hosts: ["localhost"]
   namespace: "metrics"
-#  path: "/jolokia/?ignoreErrors=true&canonicalNaming=false"
+  #path: "/jolokia/?ignoreErrors=true&canonicalNaming=false"
   jmx.mappings:
-    # - mbean: 'java.lang:type=Runtime'
-    #   attributes:
-    #     - attr: Uptime
-    #       field: uptime
-    # - mbean: 'java.lang:type=Memory'
-    #   attributes:
-    #     - attr: HeapMemoryUsage
-    #       field: memory.heap_usage
-    #     - attr: NonHeapMemoryUsage
-    #       field: memory.non_heap_usage
+    #- mbean: 'java.lang:type=Runtime'
+    #  attributes:
+    #    - attr: Uptime
+    #      field: uptime
+    #- mbean: 'java.lang:type=Memory'
+    #  attributes:
+    #    - attr: HeapMemoryUsage
+    #      field: memory.heap_usage
+    #    - attr: NonHeapMemoryUsage
+    #      field: memory.non_heap_usage
     # GC Metrics - this depends on what is available on your JVM
-    # - mbean: 'java.lang:type=GarbageCollector,name=ConcurrentMarkSweep'
-    #   attributes:
-    #     - attr: CollectionTime
-    #       field: gc.cms_collection_time
-    #     - attr: CollectionCount
-    #       field: gc.cms_collection_count
+    #- mbean: 'java.lang:type=GarbageCollector,name=ConcurrentMarkSweep'
+    #  attributes:
+    #    - attr: CollectionTime
+    #      field: gc.cms_collection_time
+    #    - attr: CollectionCount
+    #      field: gc.cms_collection_count
 
   jmx.application:
   jmx.instance:

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -210,9 +210,9 @@ metricbeat.modules:
 
 #------------------------------- Golang Module -------------------------------
 - module: golang
-  metricsets:
-    - expvar
-    - heap
+#  metricsets:
+#    - expvar
+#    - heap
   period: 10s
   hosts: ["localhost:6060"]
   heap.path: "/debug/vars"
@@ -278,11 +278,11 @@ metricbeat.modules:
 
 #------------------------------- Jolokia Module ------------------------------
 - module: jolokia
-  metricsets: ["jmx"]
+#  metricsets: ["jmx"]
   period: 10s
   hosts: ["localhost"]
   namespace: "metrics"
-  #path: "/jolokia/?ignoreErrors=true&canonicalNaming=false"
+#  path: "/jolokia/?ignoreErrors=true&canonicalNaming=false"
   jmx.mappings:
     # - mbean: 'java.lang:type=Runtime'
     #   attributes:

--- a/metricbeat/module/aerospike/_meta/config.yml
+++ b/metricbeat/module/aerospike/_meta/config.yml
@@ -1,4 +1,4 @@
 - module: aerospike
-  metricsets: ["namespace"]
+#  metricsets: ["namespace"]
   period: 10s
   hosts: ["localhost:3000"]

--- a/metricbeat/module/aerospike/_meta/config.yml
+++ b/metricbeat/module/aerospike/_meta/config.yml
@@ -1,4 +1,5 @@
 - module: aerospike
-#  metricsets: ["namespace"]
+  #metricsets:
+  #  - namespace
   period: 10s
   hosts: ["localhost:3000"]

--- a/metricbeat/module/aerospike/_meta/config.yml
+++ b/metricbeat/module/aerospike/_meta/config.yml
@@ -1,2 +1,4 @@
 - module: aerospike
+  metricsets: ["namespace"]
+  period: 10s
   hosts: ["localhost:3000"]

--- a/metricbeat/module/apache/_meta/config.yml
+++ b/metricbeat/module/apache/_meta/config.yml
@@ -1,2 +1,4 @@
 - module: apache
+  metricsets: ["status"]
+  period: 10s
   hosts: ["http://127.0.0.1"]

--- a/metricbeat/module/apache/_meta/config.yml
+++ b/metricbeat/module/apache/_meta/config.yml
@@ -1,4 +1,5 @@
 - module: apache
-#  metricsets: ["status"]
+  #metricsets:
+  #  - status
   period: 10s
   hosts: ["http://127.0.0.1"]

--- a/metricbeat/module/apache/_meta/config.yml
+++ b/metricbeat/module/apache/_meta/config.yml
@@ -1,4 +1,4 @@
 - module: apache
-  metricsets: ["status"]
+#  metricsets: ["status"]
   period: 10s
   hosts: ["http://127.0.0.1"]

--- a/metricbeat/module/ceph/_meta/config.yml
+++ b/metricbeat/module/ceph/_meta/config.yml
@@ -1,16 +1,16 @@
 - module: ceph
-#  metricsets:
-#    - cluster_health
-#    - cluster_status
-#    - monitor_health
+  #metricsets:
+  #  - cluster_health
+  #  - cluster_status
+  #  - monitor_health
   period: 10s
   hosts: ["localhost:5000"]
 
 - module: ceph
-#  metricsets:
-#    - cluster_disk
-#    - osd_tree
-#    - osd_df
-#    - pool_disk
+  #metricsets:
+  #  - cluster_disk
+  #  - osd_tree
+  #  - osd_df
+  #  - pool_disk
   period: 1m
   hosts: ["localhost:5000"]

--- a/metricbeat/module/ceph/_meta/config.yml
+++ b/metricbeat/module/ceph/_meta/config.yml
@@ -1,7 +1,16 @@
 - module: ceph
-  metricsets: ["cluster_health", "cluster_status", "monitor_health"]
+  metricsets:
+    - cluster_health
+    - cluster_status
+    - monitor_health
   period: 10s
+  hosts: ["localhost:5000"]
 
 - module: ceph
-  metricsets: ["cluster_disk", "osd_tree", "pool_disk"]
+  metricsets:
+    - cluster_disk
+    - osd_tree
+    - osd_df
+    - pool_disk
   period: 1m
+  hosts: ["localhost:5000"]

--- a/metricbeat/module/ceph/_meta/config.yml
+++ b/metricbeat/module/ceph/_meta/config.yml
@@ -1,16 +1,16 @@
 - module: ceph
-  metricsets:
-    - cluster_health
-    - cluster_status
-    - monitor_health
+#  metricsets:
+#    - cluster_health
+#    - cluster_status
+#    - monitor_health
   period: 10s
   hosts: ["localhost:5000"]
 
 - module: ceph
-  metricsets:
-    - cluster_disk
-    - osd_tree
-    - osd_df
-    - pool_disk
+#  metricsets:
+#    - cluster_disk
+#    - osd_tree
+#    - osd_df
+#    - pool_disk
   period: 1m
   hosts: ["localhost:5000"]

--- a/metricbeat/module/couchbase/_meta/config.yml
+++ b/metricbeat/module/couchbase/_meta/config.yml
@@ -1,2 +1,7 @@
 - module: couchbase
+  metricsets:
+    - bucket
+    - cluster
+    - node
+  period: 10s
   hosts: ["localhost:8091"]

--- a/metricbeat/module/couchbase/_meta/config.yml
+++ b/metricbeat/module/couchbase/_meta/config.yml
@@ -1,7 +1,7 @@
 - module: couchbase
-#  metricsets:
-#    - bucket
-#    - cluster
-#    - node
+  #metricsets:
+  #  - bucket
+  #  - cluster
+  #  - node
   period: 10s
   hosts: ["localhost:8091"]

--- a/metricbeat/module/couchbase/_meta/config.yml
+++ b/metricbeat/module/couchbase/_meta/config.yml
@@ -1,7 +1,7 @@
 - module: couchbase
-  metricsets:
-    - bucket
-    - cluster
-    - node
+#  metricsets:
+#    - bucket
+#    - cluster
+#    - node
   period: 10s
   hosts: ["localhost:8091"]

--- a/metricbeat/module/docker/_meta/config.yml
+++ b/metricbeat/module/docker/_meta/config.yml
@@ -1,5 +1,20 @@
 - module: docker
+  metricsets:
+    - container
+    - cpu
+    - diskio
+    - healthcheck
+    - info
+    - memory
+    - network
+  period: 10s
   hosts: ["unix:///var/run/docker.sock"]
 
   # Replace dots in labels with `_`. Set to false to keep dots
   labels.dedot: true
+
+  # To connect to Docker over TLS you must specify a client and CA certificate.
+  #ssl:
+    #certificate_authority: "/etc/pki/root/ca.pem"
+    #certificate:           "/etc/pki/client/cert.pem"
+    #key:                   "/etc/pki/client/cert.key"

--- a/metricbeat/module/docker/_meta/config.yml
+++ b/metricbeat/module/docker/_meta/config.yml
@@ -1,12 +1,12 @@
 - module: docker
-#  metricsets:
-#    - container
-#    - cpu
-#    - diskio
-#    - healthcheck
-#    - info
-#    - memory
-#    - network
+  #metricsets:
+  #  - container
+  #  - cpu
+  #  - diskio
+  #  - healthcheck
+  #  - info
+  #  - memory
+  #  - network
   period: 10s
   hosts: ["unix:///var/run/docker.sock"]
 

--- a/metricbeat/module/docker/_meta/config.yml
+++ b/metricbeat/module/docker/_meta/config.yml
@@ -1,12 +1,12 @@
 - module: docker
-  metricsets:
-    - container
-    - cpu
-    - diskio
-    - healthcheck
-    - info
-    - memory
-    - network
+#  metricsets:
+#    - container
+#    - cpu
+#    - diskio
+#    - healthcheck
+#    - info
+#    - memory
+#    - network
   period: 10s
   hosts: ["unix:///var/run/docker.sock"]
 

--- a/metricbeat/module/dropwizard/_meta/config.yml
+++ b/metricbeat/module/dropwizard/_meta/config.yml
@@ -1,4 +1,6 @@
 - module: dropwizard
+  metricsets: ["collector"]
+  period: 10s
   hosts: ["localhost:8080"]
   metrics_path: /metrics/metrics
   namespace: example

--- a/metricbeat/module/dropwizard/_meta/config.yml
+++ b/metricbeat/module/dropwizard/_meta/config.yml
@@ -1,5 +1,6 @@
 - module: dropwizard
-#  metricsets: ["collector"]
+  #metricsets:
+  #  - collector
   period: 10s
   hosts: ["localhost:8080"]
   metrics_path: /metrics/metrics

--- a/metricbeat/module/dropwizard/_meta/config.yml
+++ b/metricbeat/module/dropwizard/_meta/config.yml
@@ -1,5 +1,5 @@
 - module: dropwizard
-  metricsets: ["collector"]
+#  metricsets: ["collector"]
   period: 10s
   hosts: ["localhost:8080"]
   metrics_path: /metrics/metrics

--- a/metricbeat/module/elasticsearch/_meta/config.yml
+++ b/metricbeat/module/elasticsearch/_meta/config.yml
@@ -1,6 +1,6 @@
 - module: elasticsearch
-  metricsets:
-    - node
-    - node_stats
+#  metricsets:
+#    - node
+#    - node_stats
   period: 10s
   hosts: ["localhost:9200"]

--- a/metricbeat/module/elasticsearch/_meta/config.yml
+++ b/metricbeat/module/elasticsearch/_meta/config.yml
@@ -1,6 +1,6 @@
 - module: elasticsearch
-#  metricsets:
-#    - node
-#    - node_stats
+  #metricsets:
+  #  - node
+  #  - node_stats
   period: 10s
   hosts: ["localhost:9200"]

--- a/metricbeat/module/elasticsearch/_meta/config.yml
+++ b/metricbeat/module/elasticsearch/_meta/config.yml
@@ -1,2 +1,6 @@
 - module: elasticsearch
+  metricsets:
+    - node
+    - node_stats
+  period: 10s
   hosts: ["localhost:9200"]

--- a/metricbeat/module/etcd/_meta/config.yml
+++ b/metricbeat/module/etcd/_meta/config.yml
@@ -1,7 +1,7 @@
 - module: etcd
-#  metricsets:
-#    - leader
-#    - self
-#    - store
+  #metricsets:
+  #  - leader
+  #  - self
+  #  - store
   period: 10s
   hosts: ["localhost:2379"]

--- a/metricbeat/module/etcd/_meta/config.yml
+++ b/metricbeat/module/etcd/_meta/config.yml
@@ -1,2 +1,7 @@
 - module: etcd
+  metricsets:
+    - leader
+    - self
+    - store
+  period: 10s
   hosts: ["localhost:2379"]

--- a/metricbeat/module/etcd/_meta/config.yml
+++ b/metricbeat/module/etcd/_meta/config.yml
@@ -1,7 +1,7 @@
 - module: etcd
-  metricsets:
-    - leader
-    - self
-    - store
+#  metricsets:
+#    - leader
+#    - self
+#    - store
   period: 10s
   hosts: ["localhost:2379"]

--- a/metricbeat/module/golang/_meta/config.yml
+++ b/metricbeat/module/golang/_meta/config.yml
@@ -1,7 +1,7 @@
 - module: golang
-  metricsets:
-    - expvar
-    - heap
+#  metricsets:
+#    - expvar
+#    - heap
   period: 10s
   hosts: ["localhost:6060"]
   heap.path: "/debug/vars"

--- a/metricbeat/module/golang/_meta/config.yml
+++ b/metricbeat/module/golang/_meta/config.yml
@@ -1,7 +1,7 @@
 - module: golang
-#  metricsets:
-#    - expvar
-#    - heap
+  #metricsets:
+  #  - expvar
+  #  - heap
   period: 10s
   hosts: ["localhost:6060"]
   heap.path: "/debug/vars"

--- a/metricbeat/module/golang/_meta/config.yml
+++ b/metricbeat/module/golang/_meta/config.yml
@@ -1,5 +1,7 @@
 - module: golang
-  metricsets: ["expvar","heap"]
+  metricsets:
+    - expvar
+    - heap
   period: 10s
   hosts: ["localhost:6060"]
   heap.path: "/debug/vars"

--- a/metricbeat/module/graphite/_meta/config.yml
+++ b/metricbeat/module/graphite/_meta/config.yml
@@ -1,1 +1,8 @@
 - module: graphite
+  metricsets: ["server"]
+#  protocol: "udp"
+#  templates:
+#    - filter: "test.*.bash.*" # This would match metrics like test.localhost.bash.stats
+#      namespace: "test"
+#      template: ".host.shell.metric*" # test.localhost.bash.stats would become metric=stats and tags host=localhost,shell=bash
+#      delimiter: "_"

--- a/metricbeat/module/graphite/_meta/config.yml
+++ b/metricbeat/module/graphite/_meta/config.yml
@@ -1,5 +1,5 @@
 - module: graphite
-  metricsets: ["server"]
+#  metricsets: ["server"]
 #  protocol: "udp"
 #  templates:
 #    - filter: "test.*.bash.*" # This would match metrics like test.localhost.bash.stats

--- a/metricbeat/module/graphite/_meta/config.yml
+++ b/metricbeat/module/graphite/_meta/config.yml
@@ -1,8 +1,9 @@
 - module: graphite
-#  metricsets: ["server"]
-#  protocol: "udp"
-#  templates:
-#    - filter: "test.*.bash.*" # This would match metrics like test.localhost.bash.stats
-#      namespace: "test"
-#      template: ".host.shell.metric*" # test.localhost.bash.stats would become metric=stats and tags host=localhost,shell=bash
-#      delimiter: "_"
+  #metricsets:
+  #  - server
+  #protocol: "udp"
+  #templates:
+  #  - filter: "test.*.bash.*" # This would match metrics like test.localhost.bash.stats
+  #    namespace: "test"
+  #    template: ".host.shell.metric*" # test.localhost.bash.stats would become metric=stats and tags host=localhost,shell=bash
+  #    delimiter: "_"

--- a/metricbeat/module/haproxy/_meta/config.yml
+++ b/metricbeat/module/haproxy/_meta/config.yml
@@ -1,2 +1,6 @@
 - module: haproxy
+  metricsets:
+    - info
+    - stat
+  period: 10s
   hosts: ["tcp://127.0.0.1:14567"]

--- a/metricbeat/module/haproxy/_meta/config.yml
+++ b/metricbeat/module/haproxy/_meta/config.yml
@@ -1,6 +1,6 @@
 - module: haproxy
-#  metricsets:
-#    - info
-#    - stat
+  #metricsets:
+  #  - info
+  #  - stat
   period: 10s
   hosts: ["tcp://127.0.0.1:14567"]

--- a/metricbeat/module/haproxy/_meta/config.yml
+++ b/metricbeat/module/haproxy/_meta/config.yml
@@ -1,6 +1,6 @@
 - module: haproxy
-  metricsets:
-    - info
-    - stat
+#  metricsets:
+#    - info
+#    - stat
   period: 10s
   hosts: ["tcp://127.0.0.1:14567"]

--- a/metricbeat/module/http/_meta/config.yml
+++ b/metricbeat/module/http/_meta/config.yml
@@ -1,5 +1,6 @@
 - module: http
-  metricsets: ["json"]
+  #metricsets:
+  #  - json
   period: 10s
   hosts: ["localhost:80"]
   namespace: "json_namespace"
@@ -12,12 +13,13 @@
   #dedot.enabled: false
 
 - module: http
-  metricsets: ["server"]
+  #metricsets:
+  #  - server
   host: "localhost"
   port: "8080"
   enabled: false
-#  paths:
-#    - path: "/foo"
-#      namespace: "foo"
-#      fields: # added to the the response in root. overwrites existing fields
-#        key: "value"
+  #paths:
+  #  - path: "/foo"
+  #    namespace: "foo"
+  #    fields: # added to the the response in root. overwrites existing fields
+  #      key: "value"

--- a/metricbeat/module/jolokia/_meta/config.yml
+++ b/metricbeat/module/jolokia/_meta/config.yml
@@ -3,17 +3,18 @@
   period: 10s
   hosts: ["localhost"]
   namespace: "metrics"
+  #path: "/jolokia/?ignoreErrors=true&canonicalNaming=false"
   jmx.mappings:
-    - mbean: 'java.lang:type=Runtime'
-      attributes:
-        - attr: Uptime
-          field: uptime
-    - mbean: 'java.lang:type=Memory'
-      attributes:
-        - attr: HeapMemoryUsage
-          field: memory.heap_usage
-        - attr: NonHeapMemoryUsage
-          field: memory.non_heap_usage
+    # - mbean: 'java.lang:type=Runtime'
+    #   attributes:
+    #     - attr: Uptime
+    #       field: uptime
+    # - mbean: 'java.lang:type=Memory'
+    #   attributes:
+    #     - attr: HeapMemoryUsage
+    #       field: memory.heap_usage
+    #     - attr: NonHeapMemoryUsage
+    #       field: memory.non_heap_usage
     # GC Metrics - this depends on what is available on your JVM
     # - mbean: 'java.lang:type=GarbageCollector,name=ConcurrentMarkSweep'
     #   attributes:
@@ -21,3 +22,6 @@
     #       field: gc.cms_collection_time
     #     - attr: CollectionCount
     #       field: gc.cms_collection_count
+
+  jmx.application:
+  jmx.instance:

--- a/metricbeat/module/jolokia/_meta/config.yml
+++ b/metricbeat/module/jolokia/_meta/config.yml
@@ -1,9 +1,9 @@
 - module: jolokia
-  metricsets: ["jmx"]
+#  metricsets: ["jmx"]
   period: 10s
   hosts: ["localhost"]
   namespace: "metrics"
-  #path: "/jolokia/?ignoreErrors=true&canonicalNaming=false"
+#  path: "/jolokia/?ignoreErrors=true&canonicalNaming=false"
   jmx.mappings:
     # - mbean: 'java.lang:type=Runtime'
     #   attributes:

--- a/metricbeat/module/jolokia/_meta/config.yml
+++ b/metricbeat/module/jolokia/_meta/config.yml
@@ -1,27 +1,27 @@
 - module: jolokia
-#  metricsets: ["jmx"]
+  #metricsets: ["jmx"]
   period: 10s
   hosts: ["localhost"]
   namespace: "metrics"
-#  path: "/jolokia/?ignoreErrors=true&canonicalNaming=false"
+  #path: "/jolokia/?ignoreErrors=true&canonicalNaming=false"
   jmx.mappings:
-    # - mbean: 'java.lang:type=Runtime'
-    #   attributes:
-    #     - attr: Uptime
-    #       field: uptime
-    # - mbean: 'java.lang:type=Memory'
-    #   attributes:
-    #     - attr: HeapMemoryUsage
-    #       field: memory.heap_usage
-    #     - attr: NonHeapMemoryUsage
-    #       field: memory.non_heap_usage
+    #- mbean: 'java.lang:type=Runtime'
+    #  attributes:
+    #    - attr: Uptime
+    #      field: uptime
+    #- mbean: 'java.lang:type=Memory'
+    #  attributes:
+    #    - attr: HeapMemoryUsage
+    #      field: memory.heap_usage
+    #    - attr: NonHeapMemoryUsage
+    #      field: memory.non_heap_usage
     # GC Metrics - this depends on what is available on your JVM
-    # - mbean: 'java.lang:type=GarbageCollector,name=ConcurrentMarkSweep'
-    #   attributes:
-    #     - attr: CollectionTime
-    #       field: gc.cms_collection_time
-    #     - attr: CollectionCount
-    #       field: gc.cms_collection_count
+    #- mbean: 'java.lang:type=GarbageCollector,name=ConcurrentMarkSweep'
+    #  attributes:
+    #    - attr: CollectionTime
+    #      field: gc.cms_collection_time
+    #    - attr: CollectionCount
+    #      field: gc.cms_collection_count
 
   jmx.application:
   jmx.instance:

--- a/metricbeat/module/kafka/_meta/config.yml
+++ b/metricbeat/module/kafka/_meta/config.yml
@@ -1,7 +1,7 @@
 - module: kafka
-#  metricsets:
-#    - partition
-#    - consumergroup
+  #metricsets:
+  #  - partition
+  #  - consumergroup
   period: 10s
   hosts: ["localhost:9092"]
 

--- a/metricbeat/module/kafka/_meta/config.yml
+++ b/metricbeat/module/kafka/_meta/config.yml
@@ -1,7 +1,7 @@
 - module: kafka
-  metricsets:
-    - partition
-    - consumergroup
+#  metricsets:
+#    - partition
+#    - consumergroup
   period: 10s
   hosts: ["localhost:9092"]
 

--- a/metricbeat/module/kafka/_meta/config.yml
+++ b/metricbeat/module/kafka/_meta/config.yml
@@ -1,2 +1,27 @@
 - module: kafka
+  metricsets:
+    - partition
+    - consumergroup
+  period: 10s
   hosts: ["localhost:9092"]
+
+  #client_id: metricbeat
+  #retries: 3
+  #backoff: 250ms
+
+  # List of Topics to query metadata for. If empty, all topics will be queried.
+  #topics: []
+
+  # Optional SSL. By default is off.
+  # List of root certificates for HTTPS server verifications
+  #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
+
+  # Certificate for SSL client authentication
+  #ssl.certificate: "/etc/pki/client/cert.pem"
+
+  # Client Certificate Key
+  #ssl.key: "/etc/pki/client/cert.key"
+
+  # SASL authentication
+  #username: ""
+  #password: ""

--- a/metricbeat/module/kibana/_meta/config.yml
+++ b/metricbeat/module/kibana/_meta/config.yml
@@ -1,4 +1,4 @@
 - module: kibana
-  metricsets: ["status"]
+#  metricsets: ["status"]
   period: 10s
   hosts: ["localhost:5601"]

--- a/metricbeat/module/kibana/_meta/config.yml
+++ b/metricbeat/module/kibana/_meta/config.yml
@@ -1,4 +1,5 @@
 - module: kibana
-#  metricsets: ["status"]
+  #metricsets:
+  #  - status
   period: 10s
   hosts: ["localhost:5601"]

--- a/metricbeat/module/kibana/_meta/config.yml
+++ b/metricbeat/module/kibana/_meta/config.yml
@@ -1,2 +1,4 @@
 - module: kibana
+  metricsets: ["status"]
+  period: 10s
   hosts: ["localhost:5601"]

--- a/metricbeat/module/kubernetes/_meta/config.yml
+++ b/metricbeat/module/kubernetes/_meta/config.yml
@@ -1,11 +1,11 @@
 # Node metrics, from kubelet:
 - module: kubernetes
-  metricsets:
-    - node
-    - system
-    - pod
-    - container
-    - volume
+#  metricsets:
+#    - node
+#    - system
+#    - pod
+#    - container
+#    - volume
   period: 10s
   hosts: ["localhost:10255"]
   #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]

--- a/metricbeat/module/kubernetes/_meta/config.yml
+++ b/metricbeat/module/kubernetes/_meta/config.yml
@@ -1,11 +1,11 @@
 # Node metrics, from kubelet:
 - module: kubernetes
-#  metricsets:
-#    - node
-#    - system
-#    - pod
-#    - container
-#    - volume
+  #metricsets:
+  #  - node
+  #  - system
+  #  - pod
+  #  - container
+  #  - volume
   period: 10s
   hosts: ["localhost:10255"]
   #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
@@ -13,18 +13,18 @@
   #ssl.key: "/etc/pki/client/cert.key"
 
 # State metrics from kube-state-metrics service:
-# - module: kubernetes
-#   metricsets:
-#     - state_node
-#     - state_deployment
-#     - state_replicaset
-#     - state_statefulset
-#     - state_pod
-#     - state_container
-#   period: 10s
-#   hosts: ["kube-state-metrics:8080"]
+#- module: kubernetes
+#  metricsets:
+#    - state_node
+#    - state_deployment
+#    - state_replicaset
+#    - state_statefulset
+#    - state_pod
+#    - state_container
+#  period: 10s
+#  hosts: ["kube-state-metrics:8080"]
 
 # Kubernetes events
-# - module: kubernetes
-#   metricsets:
-#     - event
+#- module: kubernetes
+#  metricsets:
+#    - event

--- a/metricbeat/module/kubernetes/_meta/config.yml
+++ b/metricbeat/module/kubernetes/_meta/config.yml
@@ -1,8 +1,30 @@
+# Node metrics, from kubelet:
 - module: kubernetes
   metricsets:
-    - container
     - node
-    - pod
     - system
+    - pod
+    - container
     - volume
+  period: 10s
   hosts: ["localhost:10255"]
+  #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
+  #ssl.certificate: "/etc/pki/client/cert.pem"
+  #ssl.key: "/etc/pki/client/cert.key"
+
+# State metrics from kube-state-metrics service:
+# - module: kubernetes
+#   metricsets:
+#     - state_node
+#     - state_deployment
+#     - state_replicaset
+#     - state_statefulset
+#     - state_pod
+#     - state_container
+#   period: 10s
+#   hosts: ["kube-state-metrics:8080"]
+
+# Kubernetes events
+# - module: kubernetes
+#   metricsets:
+#     - event

--- a/metricbeat/module/kvm/_meta/config.yml
+++ b/metricbeat/module/kvm/_meta/config.yml
@@ -1,2 +1,4 @@
 - module: kvm
+  metricsets: ["dommemstat"]
+  period: 10s
   hosts: ["localhost"]

--- a/metricbeat/module/kvm/_meta/config.yml
+++ b/metricbeat/module/kvm/_meta/config.yml
@@ -1,4 +1,5 @@
 - module: kvm
-#  metricsets: ["dommemstat"]
+  #metricsets:
+  #  - dommemstat
   period: 10s
   hosts: ["localhost"]

--- a/metricbeat/module/kvm/_meta/config.yml
+++ b/metricbeat/module/kvm/_meta/config.yml
@@ -1,4 +1,4 @@
 - module: kvm
-  metricsets: ["dommemstat"]
+#  metricsets: ["dommemstat"]
   period: 10s
   hosts: ["localhost"]

--- a/metricbeat/module/logstash/_meta/config.yml
+++ b/metricbeat/module/logstash/_meta/config.yml
@@ -1,6 +1,6 @@
 - module: logstash
-  metricsets:
-    - node
-    - node_stats
+#  metricsets:
+#    - node
+#    - node_stats
   period: 10s
   hosts: ["localhost:9600"]

--- a/metricbeat/module/logstash/_meta/config.yml
+++ b/metricbeat/module/logstash/_meta/config.yml
@@ -1,2 +1,6 @@
 - module: logstash
+  metricsets:
+    - node
+    - node_stats
+  period: 10s
   hosts: ["localhost:9600"]

--- a/metricbeat/module/logstash/_meta/config.yml
+++ b/metricbeat/module/logstash/_meta/config.yml
@@ -1,6 +1,6 @@
 - module: logstash
-#  metricsets:
-#    - node
-#    - node_stats
+  #metricsets:
+  #  - node
+  #  - node_stats
   period: 10s
   hosts: ["localhost:9600"]

--- a/metricbeat/module/memcached/_meta/config.yml
+++ b/metricbeat/module/memcached/_meta/config.yml
@@ -1,4 +1,4 @@
 - module: memcached
-  metricsets: ["stats"]
+#  metricsets: ["stats"]
   period: 10s
   hosts: ["localhost:11211"]

--- a/metricbeat/module/memcached/_meta/config.yml
+++ b/metricbeat/module/memcached/_meta/config.yml
@@ -1,2 +1,4 @@
 - module: memcached
+  metricsets: ["stats"]
+  period: 10s
   hosts: ["localhost:11211"]

--- a/metricbeat/module/mongodb/_meta/config.yml
+++ b/metricbeat/module/mongodb/_meta/config.yml
@@ -1,7 +1,7 @@
 - module: mongodb
-#  metricsets:
-#    - dbstats
-#    - status
+  #metricsets:
+  #  - dbstats
+  #  - status
   period: 10s
 
   # The hosts must be passed as MongoDB URLs in the format:

--- a/metricbeat/module/mongodb/_meta/config.yml
+++ b/metricbeat/module/mongodb/_meta/config.yml
@@ -1,2 +1,18 @@
 - module: mongodb
+  metricsets:
+    - dbstats
+    - status
+  period: 10s
+
+  # The hosts must be passed as MongoDB URLs in the format:
+  # [mongodb://][user:pass@]host[:port].
+  # The username and password can also be set using the respective configuration
+  # options. The credentials in the URL take precedence over the username and
+  # password configuration options.
   hosts: ["localhost:27017"]
+
+  # Username to use when connecting to MongoDB. Empty by default.
+  #username: user
+
+  # Password to use when connecting to MongoDB. Empty by default.
+  #password: pass

--- a/metricbeat/module/mongodb/_meta/config.yml
+++ b/metricbeat/module/mongodb/_meta/config.yml
@@ -1,7 +1,7 @@
 - module: mongodb
-  metricsets:
-    - dbstats
-    - status
+#  metricsets:
+#    - dbstats
+#    - status
   period: 10s
 
   # The hosts must be passed as MongoDB URLs in the format:

--- a/metricbeat/module/munin/_meta/config.yml
+++ b/metricbeat/module/munin/_meta/config.yml
@@ -1,5 +1,6 @@
 - module: munin
-#  metricsets: ["node"]
+  #metricsets:
+  #  - node
   period: 10s
   hosts: ["localhost:4949"]
   node.namespace: node

--- a/metricbeat/module/munin/_meta/config.yml
+++ b/metricbeat/module/munin/_meta/config.yml
@@ -1,3 +1,5 @@
 - module: munin
+  metricsets: ["node"]
+  period: 10s
   hosts: ["localhost:4949"]
   node.namespace: node

--- a/metricbeat/module/munin/_meta/config.yml
+++ b/metricbeat/module/munin/_meta/config.yml
@@ -1,5 +1,5 @@
 - module: munin
-  metricsets: ["node"]
+#  metricsets: ["node"]
   period: 10s
   hosts: ["localhost:4949"]
   node.namespace: node

--- a/metricbeat/module/mysql/_meta/config.yml
+++ b/metricbeat/module/mysql/_meta/config.yml
@@ -1,2 +1,17 @@
 - module: mysql
-  hosts: ["tcp(127.0.0.1:3306)/"]
+  metricsets: ["status"]
+  period: 10s
+
+  # Host DSN should be defined as "user:pass@tcp(127.0.0.1:3306)/"
+  # The username and password can either be set in the DSN or using the username
+  # and password config options. Those specified in the DSN take precedence.
+  hosts: ["root:secret@tcp(127.0.0.1:3306)/"]
+
+  # Username of hosts. Empty by default.
+  #username: root
+
+  # Password of hosts. Empty by default.
+  #password: secret
+
+  # By setting raw to true, all raw fields from the status metricset will be added to the event.
+  #raw: false

--- a/metricbeat/module/mysql/_meta/config.yml
+++ b/metricbeat/module/mysql/_meta/config.yml
@@ -1,5 +1,6 @@
 - module: mysql
-#  metricsets: ["status"]
+  #metricsets:
+  #  - status
   period: 10s
 
   # Host DSN should be defined as "user:pass@tcp(127.0.0.1:3306)/"
@@ -12,6 +13,3 @@
 
   # Password of hosts. Empty by default.
   #password: secret
-
-  # By setting raw to true, all raw fields from the status metricset will be added to the event.
-  #raw: false

--- a/metricbeat/module/mysql/_meta/config.yml
+++ b/metricbeat/module/mysql/_meta/config.yml
@@ -1,5 +1,5 @@
 - module: mysql
-  metricsets: ["status"]
+#  metricsets: ["status"]
   period: 10s
 
   # Host DSN should be defined as "user:pass@tcp(127.0.0.1:3306)/"

--- a/metricbeat/module/nginx/_meta/config.yml
+++ b/metricbeat/module/nginx/_meta/config.yml
@@ -1,2 +1,9 @@
 - module: nginx
+  metricsets: ["stubstatus"]
+  period: 10s
+
+  # Nginx hosts
   hosts: ["http://127.0.0.1"]
+
+  # Path to server status. Default server-status
+  #server_status_path: "server-status"

--- a/metricbeat/module/nginx/_meta/config.yml
+++ b/metricbeat/module/nginx/_meta/config.yml
@@ -1,5 +1,6 @@
 - module: nginx
-#  metricsets: ["stubstatus"]
+  #metricsets:
+  #  - stubstatus
   period: 10s
 
   # Nginx hosts

--- a/metricbeat/module/nginx/_meta/config.yml
+++ b/metricbeat/module/nginx/_meta/config.yml
@@ -1,5 +1,5 @@
 - module: nginx
-  metricsets: ["stubstatus"]
+#  metricsets: ["stubstatus"]
   period: 10s
 
   # Nginx hosts

--- a/metricbeat/module/php_fpm/_meta/config.yml
+++ b/metricbeat/module/php_fpm/_meta/config.yml
@@ -1,2 +1,5 @@
 - module: php_fpm
+  metricsets: ["pool"]
+  period: 10s
   hosts: ["localhost:8080"]
+  status_path: "/status"

--- a/metricbeat/module/php_fpm/_meta/config.yml
+++ b/metricbeat/module/php_fpm/_meta/config.yml
@@ -1,5 +1,6 @@
 - module: php_fpm
-#  metricsets: ["pool"]
+  #metricsets:
+  #  - pool
   period: 10s
   hosts: ["localhost:8080"]
   status_path: "/status"

--- a/metricbeat/module/php_fpm/_meta/config.yml
+++ b/metricbeat/module/php_fpm/_meta/config.yml
@@ -1,5 +1,5 @@
 - module: php_fpm
-  metricsets: ["pool"]
+#  metricsets: ["pool"]
   period: 10s
   hosts: ["localhost:8080"]
   status_path: "/status"

--- a/metricbeat/module/postgresql/_meta/config.yml
+++ b/metricbeat/module/postgresql/_meta/config.yml
@@ -1,2 +1,24 @@
 - module: postgresql
+  metricsets:
+    # Stats about every PostgreSQL database
+    - database
+
+    # Stats about the background writer process's activity
+    - bgwriter
+
+    # Stats about every PostgreSQL process
+    - activity
+
+  period: 10s
+
+  # The host must be passed as PostgreSQL URL. Example:
+  # postgres://localhost:5432?sslmode=disable
+  # The available parameters are documented here:
+  # https://godoc.org/github.com/lib/pq#hdr-Connection_String_Parameters
   hosts: ["postgres://localhost:5432"]
+
+  # Username to use when connecting to PostgreSQL. Empty by default.
+  #username: user
+
+  # Password to use when connecting to PostgreSQL. Empty by default.
+  #password: pass

--- a/metricbeat/module/postgresql/_meta/config.yml
+++ b/metricbeat/module/postgresql/_meta/config.yml
@@ -1,14 +1,11 @@
 - module: postgresql
-  metricsets:
-    # Stats about every PostgreSQL database
-    - database
-
-    # Stats about the background writer process's activity
-    - bgwriter
-
-    # Stats about every PostgreSQL process
-    - activity
-
+#  metricsets:
+#    # Stats about every PostgreSQL database
+#    - database
+#    # Stats about the background writer process's activity
+#    - bgwriter
+#    # Stats about every PostgreSQL process
+#    - activity
   period: 10s
 
   # The host must be passed as PostgreSQL URL. Example:

--- a/metricbeat/module/postgresql/_meta/config.yml
+++ b/metricbeat/module/postgresql/_meta/config.yml
@@ -1,11 +1,11 @@
 - module: postgresql
-#  metricsets:
-#    # Stats about every PostgreSQL database
-#    - database
-#    # Stats about the background writer process's activity
-#    - bgwriter
-#    # Stats about every PostgreSQL process
-#    - activity
+  #metricsets:
+  #  # Stats about every PostgreSQL database
+  #  - database
+  #  # Stats about the background writer process's activity
+  #  - bgwriter
+  #  # Stats about every PostgreSQL process
+  #  - activity
   period: 10s
 
   # The host must be passed as PostgreSQL URL. Example:

--- a/metricbeat/module/postgresql/_meta/config.yml
+++ b/metricbeat/module/postgresql/_meta/config.yml
@@ -1,21 +1,9 @@
 - module: postgresql
   #metricsets:
-  #  # Stats about every PostgreSQL database
   #  - database
-  #  # Stats about the background writer process's activity
   #  - bgwriter
-  #  # Stats about every PostgreSQL process
   #  - activity
   period: 10s
-
-  # The host must be passed as PostgreSQL URL. Example:
-  # postgres://localhost:5432?sslmode=disable
-  # The available parameters are documented here:
-  # https://godoc.org/github.com/lib/pq#hdr-Connection_String_Parameters
   hosts: ["postgres://localhost:5432"]
-
-  # Username to use when connecting to PostgreSQL. Empty by default.
   #username: user
-
-  # Password to use when connecting to PostgreSQL. Empty by default.
   #password: pass

--- a/metricbeat/module/prometheus/_meta/config.yml
+++ b/metricbeat/module/prometheus/_meta/config.yml
@@ -1,5 +1,6 @@
 - module: prometheus
-#  metricsets: ["stats"]
+  #metricsets:
+  #  - stats
   period: 10s
   hosts: ["localhost:9090"]
   metrics_path: /metrics

--- a/metricbeat/module/prometheus/_meta/config.yml
+++ b/metricbeat/module/prometheus/_meta/config.yml
@@ -1,5 +1,5 @@
 - module: prometheus
-  metricsets: ["stats"]
+#  metricsets: ["stats"]
   period: 10s
   hosts: ["localhost:9090"]
   metrics_path: /metrics

--- a/metricbeat/module/prometheus/_meta/config.yml
+++ b/metricbeat/module/prometheus/_meta/config.yml
@@ -1,4 +1,6 @@
 - module: prometheus
+  metricsets: ["stats"]
   period: 10s
   hosts: ["localhost:9090"]
+  metrics_path: /metrics
   #namespace: example

--- a/metricbeat/module/rabbitmq/_meta/config.yml
+++ b/metricbeat/module/rabbitmq/_meta/config.yml
@@ -1,8 +1,8 @@
 - module: rabbitmq
-#  metricsets:
-#    - node
-#    - queue
-#    - connection
+  #metricsets:
+  #  - node
+  #  - queue
+  #  - connection
   period: 10s
   hosts: ["localhost:15672"]
 

--- a/metricbeat/module/rabbitmq/_meta/config.yml
+++ b/metricbeat/module/rabbitmq/_meta/config.yml
@@ -1,2 +1,10 @@
 - module: rabbitmq
+  metricsets:
+    - node
+    - queue
+    - connection
+  period: 10s
   hosts: ["localhost:15672"]
+
+  username: guest
+  password: guest

--- a/metricbeat/module/rabbitmq/_meta/config.yml
+++ b/metricbeat/module/rabbitmq/_meta/config.yml
@@ -1,8 +1,8 @@
 - module: rabbitmq
-  metricsets:
-    - node
-    - queue
-    - connection
+#  metricsets:
+#    - node
+#    - queue
+#    - connection
   period: 10s
   hosts: ["localhost:15672"]
 

--- a/metricbeat/module/rabbitmq/_meta/config.yml
+++ b/metricbeat/module/rabbitmq/_meta/config.yml
@@ -5,6 +5,5 @@
   #  - connection
   period: 10s
   hosts: ["localhost:15672"]
-
-  username: guest
-  password: guest
+  #username: guest
+  #password: guest

--- a/metricbeat/module/redis/_meta/config.yml
+++ b/metricbeat/module/redis/_meta/config.yml
@@ -1,7 +1,7 @@
 - module: redis
-#  metricsets:
-#    - info
-#    - keyspace
+  #metricsets:
+  #  - info
+  #  - keyspace
   period: 10s
 
   # Redis hosts

--- a/metricbeat/module/redis/_meta/config.yml
+++ b/metricbeat/module/redis/_meta/config.yml
@@ -1,2 +1,31 @@
 - module: redis
+  metricsets:
+    - info
+    - keyspace
+  period: 10s
+
+  # Redis hosts
   hosts: ["127.0.0.1:6379"]
+
+  # Timeout after which time a metricset should return an error
+  # Timeout is by default defined as period, as a fetch of a metricset
+  # should never take longer then period, as otherwise calls can pile up.
+  #timeout: 1s
+
+  # Optional fields to be added to each event
+  #fields:
+  #  datacenter: west
+
+  # Network type to be used for redis connection. Default: tcp
+  #network: tcp
+
+  # Max number of concurrent connections. Default: 10
+  #maxconn: 10
+
+  # Filters can be used to reduce the number of fields sent.
+  #processors:
+  #  - include_fields:
+  #      fields: ["beat", "metricset", "redis.info.stats"]
+
+  # Redis AUTH password. Empty by default.
+  #password: foobared

--- a/metricbeat/module/redis/_meta/config.yml
+++ b/metricbeat/module/redis/_meta/config.yml
@@ -1,7 +1,7 @@
 - module: redis
-  metricsets:
-    - info
-    - keyspace
+#  metricsets:
+#    - info
+#    - keyspace
   period: 10s
 
   # Redis hosts

--- a/metricbeat/module/redis/_meta/config.yml
+++ b/metricbeat/module/redis/_meta/config.yml
@@ -7,25 +7,11 @@
   # Redis hosts
   hosts: ["127.0.0.1:6379"]
 
-  # Timeout after which time a metricset should return an error
-  # Timeout is by default defined as period, as a fetch of a metricset
-  # should never take longer then period, as otherwise calls can pile up.
-  #timeout: 1s
-
-  # Optional fields to be added to each event
-  #fields:
-  #  datacenter: west
-
   # Network type to be used for redis connection. Default: tcp
   #network: tcp
 
   # Max number of concurrent connections. Default: 10
   #maxconn: 10
-
-  # Filters can be used to reduce the number of fields sent.
-  #processors:
-  #  - include_fields:
-  #      fields: ["beat", "metricset", "redis.info.stats"]
 
   # Redis AUTH password. Empty by default.
   #password: foobared

--- a/metricbeat/module/system/_meta/config.yml
+++ b/metricbeat/module/system/_meta/config.yml
@@ -28,8 +28,8 @@
   metricsets:
     - uptime
 
-# - module: system
-#   period: 5m
-#   metricsets:
-#     - raid
-#   raid.mount_point: '/'
+#- module: system
+#  period: 5m
+#  metricsets:
+#    - raid
+#  raid.mount_point: '/'

--- a/metricbeat/module/system/_meta/config.yml
+++ b/metricbeat/module/system/_meta/config.yml
@@ -1,13 +1,19 @@
 - module: system
+  period: 10s
+  metricsets:
+    - cpu
+    - load
+    - memory
+    - network
+    - process
+    - process_summary
+    #- core
+    #- diskio
+    #- socket
+  processes: ['.*']
   process.include_top_n:
     by_cpu: 5      # include top 5 processes by CPU
     by_memory: 5   # include top 5 processes by memory
-
-#- module: system
-#  metricsets:
-#    - core
-#    - diskio
-#    - socket
 
 - module: system
   period: 1m
@@ -23,8 +29,8 @@
   metricsets:
     - uptime
 
-#- module: system
-#  period: 5m
-#  metricsets:
-#    - raid
-#  raid.mount_point: '/'
+# - module: system
+#   period: 5m
+#   metricsets:
+#     - raid
+#   raid.mount_point: '/'

--- a/metricbeat/module/system/_meta/config.yml
+++ b/metricbeat/module/system/_meta/config.yml
@@ -10,7 +10,6 @@
     #- core
     #- diskio
     #- socket
-  processes: ['.*']
   process.include_top_n:
     by_cpu: 5      # include top 5 processes by CPU
     by_memory: 5   # include top 5 processes by memory

--- a/metricbeat/module/uwsgi/_meta/config.yml
+++ b/metricbeat/module/uwsgi/_meta/config.yml
@@ -1,2 +1,4 @@
 - module: uwsgi
+  metricsets: ["status"]
+  period: 10s
   hosts: ["tcp://127.0.0.1:9191"]

--- a/metricbeat/module/uwsgi/_meta/config.yml
+++ b/metricbeat/module/uwsgi/_meta/config.yml
@@ -1,4 +1,4 @@
 - module: uwsgi
-  metricsets: ["status"]
+#  metricsets: ["status"]
   period: 10s
   hosts: ["tcp://127.0.0.1:9191"]

--- a/metricbeat/module/uwsgi/_meta/config.yml
+++ b/metricbeat/module/uwsgi/_meta/config.yml
@@ -1,4 +1,5 @@
 - module: uwsgi
-#  metricsets: ["status"]
+  #metricsets:
+  #  - status
   period: 10s
   hosts: ["tcp://127.0.0.1:9191"]

--- a/metricbeat/module/vsphere/_meta/config.yml
+++ b/metricbeat/module/vsphere/_meta/config.yml
@@ -1,4 +1,5 @@
 - module: vsphere
+  metricsets: ["datastore", "host", "virtualmachine"]
   period: 10s
   hosts: ["https://localhost/sdk"]
 

--- a/metricbeat/module/vsphere/_meta/config.yml
+++ b/metricbeat/module/vsphere/_meta/config.yml
@@ -1,8 +1,8 @@
 - module: vsphere
-#  metricsets:
-#    - datastore
-#    - host
-#    - virtualmachine
+  #metricsets:
+  #  - datastore
+  #  - host
+  #  - virtualmachine
   period: 10s
   hosts: ["https://localhost/sdk"]
 

--- a/metricbeat/module/vsphere/_meta/config.yml
+++ b/metricbeat/module/vsphere/_meta/config.yml
@@ -1,5 +1,8 @@
 - module: vsphere
-  metricsets: ["datastore", "host", "virtualmachine"]
+#  metricsets:
+#    - datastore
+#    - host
+#    - virtualmachine
   period: 10s
   hosts: ["https://localhost/sdk"]
 
@@ -9,4 +12,3 @@
   insecure: false
   # Get custom fields when using virtualmachine metric set. Default false.
   # get_custom_fields: false
-  

--- a/metricbeat/module/windows/_meta/config.yml
+++ b/metricbeat/module/windows/_meta/config.yml
@@ -1,5 +1,5 @@
 - module: windows
-  metricsets: ["service"]
+#  metricsets: ["service"]
   period: 1m
 
 #- module: windows

--- a/metricbeat/module/windows/_meta/config.yml
+++ b/metricbeat/module/windows/_meta/config.yml
@@ -1,8 +1,20 @@
 - module: windows
-  metricsets: ["perfmon"]
-  period: 10s
-  perfmon.counters:
-
-- module: windows
   metricsets: ["service"]
   period: 1m
+
+#- module: windows
+#  metricsets: ["perfmon"]
+#  period: 10s
+#  perfmon.counters:
+#    - instance_label: processor.name
+#      instance_name: total
+#      measurement_label: processor.time.total.pct
+#      query: '\Processor Information(_Total)\% Processor Time'
+#
+#    - instance_label: physical_disk.name
+#      measurement_label: physical_disk.write.per_sec
+#      query: '\PhysicalDisk(*)\Disk Writes/sec'
+#
+#    - instance_label: physical_disk.name
+#      measurement_label: physical_disk.write.time.pct
+#      query: '\PhysicalDisk(*)\% Disk Write Time'

--- a/metricbeat/module/windows/_meta/config.yml
+++ b/metricbeat/module/windows/_meta/config.yml
@@ -1,9 +1,11 @@
 - module: windows
-#  metricsets: ["service"]
+  #metricsets:
+  #  - service
   period: 1m
 
 #- module: windows
-#  metricsets: ["perfmon"]
+#  metricsets:
+#    - perfmon
 #  period: 10s
 #  perfmon.counters:
 #    - instance_label: processor.name

--- a/metricbeat/module/windows/_meta/config.yml
+++ b/metricbeat/module/windows/_meta/config.yml
@@ -1,2 +1,8 @@
 - module: windows
-  period: 60s
+  metricsets: ["perfmon"]
+  period: 10s
+  perfmon.counters:
+
+- module: windows
+  metricsets: ["service"]
+  period: 1m

--- a/metricbeat/module/zookeeper/_meta/config.yml
+++ b/metricbeat/module/zookeeper/_meta/config.yml
@@ -1,4 +1,5 @@
 - module: zookeeper
-#  metricsets: ["mntr"]
+  #metricsets:
+  #  - mntr
   period: 10s
   hosts: ["localhost:2181"]

--- a/metricbeat/module/zookeeper/_meta/config.yml
+++ b/metricbeat/module/zookeeper/_meta/config.yml
@@ -1,3 +1,4 @@
 - module: zookeeper
+  metricsets: ["mntr"]
   period: 10s
   hosts: ["localhost:2181"]

--- a/metricbeat/module/zookeeper/_meta/config.yml
+++ b/metricbeat/module/zookeeper/_meta/config.yml
@@ -1,4 +1,4 @@
 - module: zookeeper
-  metricsets: ["mntr"]
+#  metricsets: ["mntr"]
   period: 10s
   hosts: ["localhost:2181"]

--- a/metricbeat/modules.d/aerospike.yml.disabled
+++ b/metricbeat/modules.d/aerospike.yml.disabled
@@ -2,6 +2,6 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-aerospike.html
 
 - module: aerospike
-  metricsets: ["namespace"]
+#  metricsets: ["namespace"]
   period: 10s
   hosts: ["localhost:3000"]

--- a/metricbeat/modules.d/aerospike.yml.disabled
+++ b/metricbeat/modules.d/aerospike.yml.disabled
@@ -1,2 +1,4 @@
 - module: aerospike
+  metricsets: ["namespace"]
+  period: 10s
   hosts: ["localhost:3000"]

--- a/metricbeat/modules.d/aerospike.yml.disabled
+++ b/metricbeat/modules.d/aerospike.yml.disabled
@@ -1,3 +1,6 @@
+# Module: aerospike
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-aerospike.html
+
 - module: aerospike
   metricsets: ["namespace"]
   period: 10s

--- a/metricbeat/modules.d/aerospike.yml.disabled
+++ b/metricbeat/modules.d/aerospike.yml.disabled
@@ -2,6 +2,7 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-aerospike.html
 
 - module: aerospike
-#  metricsets: ["namespace"]
+  #metricsets:
+  #  - namespace
   period: 10s
   hosts: ["localhost:3000"]

--- a/metricbeat/modules.d/apache.yml.disabled
+++ b/metricbeat/modules.d/apache.yml.disabled
@@ -1,2 +1,4 @@
 - module: apache
+  metricsets: ["status"]
+  period: 10s
   hosts: ["http://127.0.0.1"]

--- a/metricbeat/modules.d/apache.yml.disabled
+++ b/metricbeat/modules.d/apache.yml.disabled
@@ -1,3 +1,6 @@
+# Module: apache
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-apache.html
+
 - module: apache
   metricsets: ["status"]
   period: 10s

--- a/metricbeat/modules.d/apache.yml.disabled
+++ b/metricbeat/modules.d/apache.yml.disabled
@@ -2,6 +2,6 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-apache.html
 
 - module: apache
-  metricsets: ["status"]
+#  metricsets: ["status"]
   period: 10s
   hosts: ["http://127.0.0.1"]

--- a/metricbeat/modules.d/apache.yml.disabled
+++ b/metricbeat/modules.d/apache.yml.disabled
@@ -2,6 +2,7 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-apache.html
 
 - module: apache
-#  metricsets: ["status"]
+  #metricsets:
+  #  - status
   period: 10s
   hosts: ["http://127.0.0.1"]

--- a/metricbeat/modules.d/ceph.yml.disabled
+++ b/metricbeat/modules.d/ceph.yml.disabled
@@ -2,18 +2,18 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-ceph.html
 
 - module: ceph
-  metricsets:
-    - cluster_health
-    - cluster_status
-    - monitor_health
+#  metricsets:
+#    - cluster_health
+#    - cluster_status
+#    - monitor_health
   period: 10s
   hosts: ["localhost:5000"]
 
 - module: ceph
-  metricsets:
-    - cluster_disk
-    - osd_tree
-    - osd_df
-    - pool_disk
+#  metricsets:
+#    - cluster_disk
+#    - osd_tree
+#    - osd_df
+#    - pool_disk
   period: 1m
   hosts: ["localhost:5000"]

--- a/metricbeat/modules.d/ceph.yml.disabled
+++ b/metricbeat/modules.d/ceph.yml.disabled
@@ -2,18 +2,18 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-ceph.html
 
 - module: ceph
-#  metricsets:
-#    - cluster_health
-#    - cluster_status
-#    - monitor_health
+  #metricsets:
+  #  - cluster_health
+  #  - cluster_status
+  #  - monitor_health
   period: 10s
   hosts: ["localhost:5000"]
 
 - module: ceph
-#  metricsets:
-#    - cluster_disk
-#    - osd_tree
-#    - osd_df
-#    - pool_disk
+  #metricsets:
+  #  - cluster_disk
+  #  - osd_tree
+  #  - osd_df
+  #  - pool_disk
   period: 1m
   hosts: ["localhost:5000"]

--- a/metricbeat/modules.d/ceph.yml.disabled
+++ b/metricbeat/modules.d/ceph.yml.disabled
@@ -1,7 +1,16 @@
 - module: ceph
-  metricsets: ["cluster_health", "cluster_status", "monitor_health"]
+  metricsets:
+    - cluster_health
+    - cluster_status
+    - monitor_health
   period: 10s
+  hosts: ["localhost:5000"]
 
 - module: ceph
-  metricsets: ["cluster_disk", "osd_tree", "pool_disk"]
+  metricsets:
+    - cluster_disk
+    - osd_tree
+    - osd_df
+    - pool_disk
   period: 1m
+  hosts: ["localhost:5000"]

--- a/metricbeat/modules.d/ceph.yml.disabled
+++ b/metricbeat/modules.d/ceph.yml.disabled
@@ -1,3 +1,6 @@
+# Module: ceph
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-ceph.html
+
 - module: ceph
   metricsets:
     - cluster_health

--- a/metricbeat/modules.d/couchbase.yml.disabled
+++ b/metricbeat/modules.d/couchbase.yml.disabled
@@ -1,2 +1,7 @@
 - module: couchbase
+  metricsets:
+    - bucket
+    - cluster
+    - node
+  period: 10s
   hosts: ["localhost:8091"]

--- a/metricbeat/modules.d/couchbase.yml.disabled
+++ b/metricbeat/modules.d/couchbase.yml.disabled
@@ -2,9 +2,9 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-couchbase.html
 
 - module: couchbase
-  metricsets:
-    - bucket
-    - cluster
-    - node
+#  metricsets:
+#    - bucket
+#    - cluster
+#    - node
   period: 10s
   hosts: ["localhost:8091"]

--- a/metricbeat/modules.d/couchbase.yml.disabled
+++ b/metricbeat/modules.d/couchbase.yml.disabled
@@ -2,9 +2,9 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-couchbase.html
 
 - module: couchbase
-#  metricsets:
-#    - bucket
-#    - cluster
-#    - node
+  #metricsets:
+  #  - bucket
+  #  - cluster
+  #  - node
   period: 10s
   hosts: ["localhost:8091"]

--- a/metricbeat/modules.d/couchbase.yml.disabled
+++ b/metricbeat/modules.d/couchbase.yml.disabled
@@ -1,3 +1,6 @@
+# Module: couchbase
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-couchbase.html
+
 - module: couchbase
   metricsets:
     - bucket

--- a/metricbeat/modules.d/docker.yml.disabled
+++ b/metricbeat/modules.d/docker.yml.disabled
@@ -1,5 +1,20 @@
 - module: docker
+  metricsets:
+    - container
+    - cpu
+    - diskio
+    - healthcheck
+    - info
+    - memory
+    - network
+  period: 10s
   hosts: ["unix:///var/run/docker.sock"]
 
   # Replace dots in labels with `_`. Set to false to keep dots
   labels.dedot: true
+
+  # To connect to Docker over TLS you must specify a client and CA certificate.
+  #ssl:
+    #certificate_authority: "/etc/pki/root/ca.pem"
+    #certificate:           "/etc/pki/client/cert.pem"
+    #key:                   "/etc/pki/client/cert.key"

--- a/metricbeat/modules.d/docker.yml.disabled
+++ b/metricbeat/modules.d/docker.yml.disabled
@@ -2,14 +2,14 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-docker.html
 
 - module: docker
-#  metricsets:
-#    - container
-#    - cpu
-#    - diskio
-#    - healthcheck
-#    - info
-#    - memory
-#    - network
+  #metricsets:
+  #  - container
+  #  - cpu
+  #  - diskio
+  #  - healthcheck
+  #  - info
+  #  - memory
+  #  - network
   period: 10s
   hosts: ["unix:///var/run/docker.sock"]
 

--- a/metricbeat/modules.d/docker.yml.disabled
+++ b/metricbeat/modules.d/docker.yml.disabled
@@ -2,14 +2,14 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-docker.html
 
 - module: docker
-  metricsets:
-    - container
-    - cpu
-    - diskio
-    - healthcheck
-    - info
-    - memory
-    - network
+#  metricsets:
+#    - container
+#    - cpu
+#    - diskio
+#    - healthcheck
+#    - info
+#    - memory
+#    - network
   period: 10s
   hosts: ["unix:///var/run/docker.sock"]
 

--- a/metricbeat/modules.d/docker.yml.disabled
+++ b/metricbeat/modules.d/docker.yml.disabled
@@ -1,3 +1,6 @@
+# Module: docker
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-docker.html
+
 - module: docker
   metricsets:
     - container

--- a/metricbeat/modules.d/dropwizard.yml.disabled
+++ b/metricbeat/modules.d/dropwizard.yml.disabled
@@ -1,4 +1,6 @@
 - module: dropwizard
+  metricsets: ["collector"]
+  period: 10s
   hosts: ["localhost:8080"]
   metrics_path: /metrics/metrics
   namespace: example

--- a/metricbeat/modules.d/dropwizard.yml.disabled
+++ b/metricbeat/modules.d/dropwizard.yml.disabled
@@ -1,3 +1,6 @@
+# Module: dropwizard
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-dropwizard.html
+
 - module: dropwizard
   metricsets: ["collector"]
   period: 10s

--- a/metricbeat/modules.d/dropwizard.yml.disabled
+++ b/metricbeat/modules.d/dropwizard.yml.disabled
@@ -2,7 +2,8 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-dropwizard.html
 
 - module: dropwizard
-#  metricsets: ["collector"]
+  #metricsets:
+  #  - collector
   period: 10s
   hosts: ["localhost:8080"]
   metrics_path: /metrics/metrics

--- a/metricbeat/modules.d/dropwizard.yml.disabled
+++ b/metricbeat/modules.d/dropwizard.yml.disabled
@@ -2,7 +2,7 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-dropwizard.html
 
 - module: dropwizard
-  metricsets: ["collector"]
+#  metricsets: ["collector"]
   period: 10s
   hosts: ["localhost:8080"]
   metrics_path: /metrics/metrics

--- a/metricbeat/modules.d/elasticsearch.yml.disabled
+++ b/metricbeat/modules.d/elasticsearch.yml.disabled
@@ -2,8 +2,8 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-elasticsearch.html
 
 - module: elasticsearch
-  metricsets:
-    - node
-    - node_stats
+#  metricsets:
+#    - node
+#    - node_stats
   period: 10s
   hosts: ["localhost:9200"]

--- a/metricbeat/modules.d/elasticsearch.yml.disabled
+++ b/metricbeat/modules.d/elasticsearch.yml.disabled
@@ -2,8 +2,8 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-elasticsearch.html
 
 - module: elasticsearch
-#  metricsets:
-#    - node
-#    - node_stats
+  #metricsets:
+  #  - node
+  #  - node_stats
   period: 10s
   hosts: ["localhost:9200"]

--- a/metricbeat/modules.d/elasticsearch.yml.disabled
+++ b/metricbeat/modules.d/elasticsearch.yml.disabled
@@ -1,3 +1,6 @@
+# Module: elasticsearch
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-elasticsearch.html
+
 - module: elasticsearch
   metricsets:
     - node

--- a/metricbeat/modules.d/elasticsearch.yml.disabled
+++ b/metricbeat/modules.d/elasticsearch.yml.disabled
@@ -1,2 +1,6 @@
 - module: elasticsearch
+  metricsets:
+    - node
+    - node_stats
+  period: 10s
   hosts: ["localhost:9200"]

--- a/metricbeat/modules.d/etcd.yml.disabled
+++ b/metricbeat/modules.d/etcd.yml.disabled
@@ -2,9 +2,9 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-etcd.html
 
 - module: etcd
-#  metricsets:
-#    - leader
-#    - self
-#    - store
+  #metricsets:
+  #  - leader
+  #  - self
+  #  - store
   period: 10s
   hosts: ["localhost:2379"]

--- a/metricbeat/modules.d/etcd.yml.disabled
+++ b/metricbeat/modules.d/etcd.yml.disabled
@@ -1,3 +1,6 @@
+# Module: etcd
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-etcd.html
+
 - module: etcd
   metricsets:
     - leader

--- a/metricbeat/modules.d/etcd.yml.disabled
+++ b/metricbeat/modules.d/etcd.yml.disabled
@@ -2,9 +2,9 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-etcd.html
 
 - module: etcd
-  metricsets:
-    - leader
-    - self
-    - store
+#  metricsets:
+#    - leader
+#    - self
+#    - store
   period: 10s
   hosts: ["localhost:2379"]

--- a/metricbeat/modules.d/etcd.yml.disabled
+++ b/metricbeat/modules.d/etcd.yml.disabled
@@ -1,2 +1,7 @@
 - module: etcd
+  metricsets:
+    - leader
+    - self
+    - store
+  period: 10s
   hosts: ["localhost:2379"]

--- a/metricbeat/modules.d/golang.yml.disabled
+++ b/metricbeat/modules.d/golang.yml.disabled
@@ -2,9 +2,9 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-golang.html
 
 - module: golang
-  metricsets:
-    - expvar
-    - heap
+#  metricsets:
+#    - expvar
+#    - heap
   period: 10s
   hosts: ["localhost:6060"]
   heap.path: "/debug/vars"

--- a/metricbeat/modules.d/golang.yml.disabled
+++ b/metricbeat/modules.d/golang.yml.disabled
@@ -1,3 +1,6 @@
+# Module: golang
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-golang.html
+
 - module: golang
   metricsets:
     - expvar

--- a/metricbeat/modules.d/golang.yml.disabled
+++ b/metricbeat/modules.d/golang.yml.disabled
@@ -1,5 +1,7 @@
 - module: golang
-  metricsets: ["expvar","heap"]
+  metricsets:
+    - expvar
+    - heap
   period: 10s
   hosts: ["localhost:6060"]
   heap.path: "/debug/vars"

--- a/metricbeat/modules.d/golang.yml.disabled
+++ b/metricbeat/modules.d/golang.yml.disabled
@@ -2,9 +2,9 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-golang.html
 
 - module: golang
-#  metricsets:
-#    - expvar
-#    - heap
+  #metricsets:
+  #  - expvar
+  #  - heap
   period: 10s
   hosts: ["localhost:6060"]
   heap.path: "/debug/vars"

--- a/metricbeat/modules.d/graphite.yml.disabled
+++ b/metricbeat/modules.d/graphite.yml.disabled
@@ -1,1 +1,8 @@
 - module: graphite
+  metricsets: ["server"]
+#  protocol: "udp"
+#  templates:
+#    - filter: "test.*.bash.*" # This would match metrics like test.localhost.bash.stats
+#      namespace: "test"
+#      template: ".host.shell.metric*" # test.localhost.bash.stats would become metric=stats and tags host=localhost,shell=bash
+#      delimiter: "_"

--- a/metricbeat/modules.d/graphite.yml.disabled
+++ b/metricbeat/modules.d/graphite.yml.disabled
@@ -2,10 +2,11 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-graphite.html
 
 - module: graphite
-#  metricsets: ["server"]
-#  protocol: "udp"
-#  templates:
-#    - filter: "test.*.bash.*" # This would match metrics like test.localhost.bash.stats
-#      namespace: "test"
-#      template: ".host.shell.metric*" # test.localhost.bash.stats would become metric=stats and tags host=localhost,shell=bash
-#      delimiter: "_"
+  #metricsets:
+  #  - server
+  #protocol: "udp"
+  #templates:
+  #  - filter: "test.*.bash.*" # This would match metrics like test.localhost.bash.stats
+  #    namespace: "test"
+  #    template: ".host.shell.metric*" # test.localhost.bash.stats would become metric=stats and tags host=localhost,shell=bash
+  #    delimiter: "_"

--- a/metricbeat/modules.d/graphite.yml.disabled
+++ b/metricbeat/modules.d/graphite.yml.disabled
@@ -2,7 +2,7 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-graphite.html
 
 - module: graphite
-  metricsets: ["server"]
+#  metricsets: ["server"]
 #  protocol: "udp"
 #  templates:
 #    - filter: "test.*.bash.*" # This would match metrics like test.localhost.bash.stats

--- a/metricbeat/modules.d/graphite.yml.disabled
+++ b/metricbeat/modules.d/graphite.yml.disabled
@@ -1,3 +1,6 @@
+# Module: graphite
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-graphite.html
+
 - module: graphite
   metricsets: ["server"]
 #  protocol: "udp"

--- a/metricbeat/modules.d/haproxy.yml.disabled
+++ b/metricbeat/modules.d/haproxy.yml.disabled
@@ -1,2 +1,6 @@
 - module: haproxy
+  metricsets:
+    - info
+    - stat
+  period: 10s
   hosts: ["tcp://127.0.0.1:14567"]

--- a/metricbeat/modules.d/haproxy.yml.disabled
+++ b/metricbeat/modules.d/haproxy.yml.disabled
@@ -2,8 +2,8 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-haproxy.html
 
 - module: haproxy
-#  metricsets:
-#    - info
-#    - stat
+  #metricsets:
+  #  - info
+  #  - stat
   period: 10s
   hosts: ["tcp://127.0.0.1:14567"]

--- a/metricbeat/modules.d/haproxy.yml.disabled
+++ b/metricbeat/modules.d/haproxy.yml.disabled
@@ -1,3 +1,6 @@
+# Module: haproxy
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-haproxy.html
+
 - module: haproxy
   metricsets:
     - info

--- a/metricbeat/modules.d/haproxy.yml.disabled
+++ b/metricbeat/modules.d/haproxy.yml.disabled
@@ -2,8 +2,8 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-haproxy.html
 
 - module: haproxy
-  metricsets:
-    - info
-    - stat
+#  metricsets:
+#    - info
+#    - stat
   period: 10s
   hosts: ["tcp://127.0.0.1:14567"]

--- a/metricbeat/modules.d/http.yml.disabled
+++ b/metricbeat/modules.d/http.yml.disabled
@@ -1,3 +1,6 @@
+# Module: http
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-http.html
+
 - module: http
   metricsets: ["json"]
   period: 10s

--- a/metricbeat/modules.d/http.yml.disabled
+++ b/metricbeat/modules.d/http.yml.disabled
@@ -2,7 +2,8 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-http.html
 
 - module: http
-  metricsets: ["json"]
+  #metricsets:
+  #  - json
   period: 10s
   hosts: ["localhost:80"]
   namespace: "json_namespace"
@@ -15,12 +16,13 @@
   #dedot.enabled: false
 
 - module: http
-  metricsets: ["server"]
+  #metricsets:
+  #  - server
   host: "localhost"
   port: "8080"
   enabled: false
-#  paths:
-#    - path: "/foo"
-#      namespace: "foo"
-#      fields: # added to the the response in root. overwrites existing fields
-#        key: "value"
+  #paths:
+  #  - path: "/foo"
+  #    namespace: "foo"
+  #    fields: # added to the the response in root. overwrites existing fields
+  #      key: "value"

--- a/metricbeat/modules.d/jolokia.yml.disabled
+++ b/metricbeat/modules.d/jolokia.yml.disabled
@@ -2,11 +2,11 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-jolokia.html
 
 - module: jolokia
-  metricsets: ["jmx"]
+#  metricsets: ["jmx"]
   period: 10s
   hosts: ["localhost"]
   namespace: "metrics"
-  #path: "/jolokia/?ignoreErrors=true&canonicalNaming=false"
+#  path: "/jolokia/?ignoreErrors=true&canonicalNaming=false"
   jmx.mappings:
     # - mbean: 'java.lang:type=Runtime'
     #   attributes:

--- a/metricbeat/modules.d/jolokia.yml.disabled
+++ b/metricbeat/modules.d/jolokia.yml.disabled
@@ -1,3 +1,6 @@
+# Module: jolokia
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-jolokia.html
+
 - module: jolokia
   metricsets: ["jmx"]
   period: 10s

--- a/metricbeat/modules.d/jolokia.yml.disabled
+++ b/metricbeat/modules.d/jolokia.yml.disabled
@@ -3,17 +3,18 @@
   period: 10s
   hosts: ["localhost"]
   namespace: "metrics"
+  #path: "/jolokia/?ignoreErrors=true&canonicalNaming=false"
   jmx.mappings:
-    - mbean: 'java.lang:type=Runtime'
-      attributes:
-        - attr: Uptime
-          field: uptime
-    - mbean: 'java.lang:type=Memory'
-      attributes:
-        - attr: HeapMemoryUsage
-          field: memory.heap_usage
-        - attr: NonHeapMemoryUsage
-          field: memory.non_heap_usage
+    # - mbean: 'java.lang:type=Runtime'
+    #   attributes:
+    #     - attr: Uptime
+    #       field: uptime
+    # - mbean: 'java.lang:type=Memory'
+    #   attributes:
+    #     - attr: HeapMemoryUsage
+    #       field: memory.heap_usage
+    #     - attr: NonHeapMemoryUsage
+    #       field: memory.non_heap_usage
     # GC Metrics - this depends on what is available on your JVM
     # - mbean: 'java.lang:type=GarbageCollector,name=ConcurrentMarkSweep'
     #   attributes:
@@ -21,3 +22,6 @@
     #       field: gc.cms_collection_time
     #     - attr: CollectionCount
     #       field: gc.cms_collection_count
+
+  jmx.application:
+  jmx.instance:

--- a/metricbeat/modules.d/jolokia.yml.disabled
+++ b/metricbeat/modules.d/jolokia.yml.disabled
@@ -2,29 +2,29 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-jolokia.html
 
 - module: jolokia
-#  metricsets: ["jmx"]
+  #metricsets: ["jmx"]
   period: 10s
   hosts: ["localhost"]
   namespace: "metrics"
-#  path: "/jolokia/?ignoreErrors=true&canonicalNaming=false"
+  #path: "/jolokia/?ignoreErrors=true&canonicalNaming=false"
   jmx.mappings:
-    # - mbean: 'java.lang:type=Runtime'
-    #   attributes:
-    #     - attr: Uptime
-    #       field: uptime
-    # - mbean: 'java.lang:type=Memory'
-    #   attributes:
-    #     - attr: HeapMemoryUsage
-    #       field: memory.heap_usage
-    #     - attr: NonHeapMemoryUsage
-    #       field: memory.non_heap_usage
+    #- mbean: 'java.lang:type=Runtime'
+    #  attributes:
+    #    - attr: Uptime
+    #      field: uptime
+    #- mbean: 'java.lang:type=Memory'
+    #  attributes:
+    #    - attr: HeapMemoryUsage
+    #      field: memory.heap_usage
+    #    - attr: NonHeapMemoryUsage
+    #      field: memory.non_heap_usage
     # GC Metrics - this depends on what is available on your JVM
-    # - mbean: 'java.lang:type=GarbageCollector,name=ConcurrentMarkSweep'
-    #   attributes:
-    #     - attr: CollectionTime
-    #       field: gc.cms_collection_time
-    #     - attr: CollectionCount
-    #       field: gc.cms_collection_count
+    #- mbean: 'java.lang:type=GarbageCollector,name=ConcurrentMarkSweep'
+    #  attributes:
+    #    - attr: CollectionTime
+    #      field: gc.cms_collection_time
+    #    - attr: CollectionCount
+    #      field: gc.cms_collection_count
 
   jmx.application:
   jmx.instance:

--- a/metricbeat/modules.d/kafka.yml.disabled
+++ b/metricbeat/modules.d/kafka.yml.disabled
@@ -2,9 +2,9 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-kafka.html
 
 - module: kafka
-  metricsets:
-    - partition
-    - consumergroup
+#  metricsets:
+#    - partition
+#    - consumergroup
   period: 10s
   hosts: ["localhost:9092"]
 

--- a/metricbeat/modules.d/kafka.yml.disabled
+++ b/metricbeat/modules.d/kafka.yml.disabled
@@ -1,3 +1,6 @@
+# Module: kafka
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-kafka.html
+
 - module: kafka
   metricsets:
     - partition

--- a/metricbeat/modules.d/kafka.yml.disabled
+++ b/metricbeat/modules.d/kafka.yml.disabled
@@ -1,2 +1,27 @@
 - module: kafka
+  metricsets:
+    - partition
+    - consumergroup
+  period: 10s
   hosts: ["localhost:9092"]
+
+  #client_id: metricbeat
+  #retries: 3
+  #backoff: 250ms
+
+  # List of Topics to query metadata for. If empty, all topics will be queried.
+  #topics: []
+
+  # Optional SSL. By default is off.
+  # List of root certificates for HTTPS server verifications
+  #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
+
+  # Certificate for SSL client authentication
+  #ssl.certificate: "/etc/pki/client/cert.pem"
+
+  # Client Certificate Key
+  #ssl.key: "/etc/pki/client/cert.key"
+
+  # SASL authentication
+  #username: ""
+  #password: ""

--- a/metricbeat/modules.d/kafka.yml.disabled
+++ b/metricbeat/modules.d/kafka.yml.disabled
@@ -2,9 +2,9 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-kafka.html
 
 - module: kafka
-#  metricsets:
-#    - partition
-#    - consumergroup
+  #metricsets:
+  #  - partition
+  #  - consumergroup
   period: 10s
   hosts: ["localhost:9092"]
 

--- a/metricbeat/modules.d/kibana.yml.disabled
+++ b/metricbeat/modules.d/kibana.yml.disabled
@@ -2,6 +2,7 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-kibana.html
 
 - module: kibana
-#  metricsets: ["status"]
+  #metricsets:
+  #  - status
   period: 10s
   hosts: ["localhost:5601"]

--- a/metricbeat/modules.d/kibana.yml.disabled
+++ b/metricbeat/modules.d/kibana.yml.disabled
@@ -1,3 +1,6 @@
+# Module: kibana
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-kibana.html
+
 - module: kibana
   metricsets: ["status"]
   period: 10s

--- a/metricbeat/modules.d/kibana.yml.disabled
+++ b/metricbeat/modules.d/kibana.yml.disabled
@@ -2,6 +2,6 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-kibana.html
 
 - module: kibana
-  metricsets: ["status"]
+#  metricsets: ["status"]
   period: 10s
   hosts: ["localhost:5601"]

--- a/metricbeat/modules.d/kibana.yml.disabled
+++ b/metricbeat/modules.d/kibana.yml.disabled
@@ -1,2 +1,4 @@
 - module: kibana
+  metricsets: ["status"]
+  period: 10s
   hosts: ["localhost:5601"]

--- a/metricbeat/modules.d/kubernetes.yml.disabled
+++ b/metricbeat/modules.d/kubernetes.yml.disabled
@@ -3,12 +3,12 @@
 
 # Node metrics, from kubelet:
 - module: kubernetes
-  metricsets:
-    - node
-    - system
-    - pod
-    - container
-    - volume
+#  metricsets:
+#    - node
+#    - system
+#    - pod
+#    - container
+#    - volume
   period: 10s
   hosts: ["localhost:10255"]
   #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]

--- a/metricbeat/modules.d/kubernetes.yml.disabled
+++ b/metricbeat/modules.d/kubernetes.yml.disabled
@@ -3,12 +3,12 @@
 
 # Node metrics, from kubelet:
 - module: kubernetes
-#  metricsets:
-#    - node
-#    - system
-#    - pod
-#    - container
-#    - volume
+  #metricsets:
+  #  - node
+  #  - system
+  #  - pod
+  #  - container
+  #  - volume
   period: 10s
   hosts: ["localhost:10255"]
   #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
@@ -16,18 +16,18 @@
   #ssl.key: "/etc/pki/client/cert.key"
 
 # State metrics from kube-state-metrics service:
-# - module: kubernetes
-#   metricsets:
-#     - state_node
-#     - state_deployment
-#     - state_replicaset
-#     - state_statefulset
-#     - state_pod
-#     - state_container
-#   period: 10s
-#   hosts: ["kube-state-metrics:8080"]
+#- module: kubernetes
+#  metricsets:
+#    - state_node
+#    - state_deployment
+#    - state_replicaset
+#    - state_statefulset
+#    - state_pod
+#    - state_container
+#  period: 10s
+#  hosts: ["kube-state-metrics:8080"]
 
 # Kubernetes events
-# - module: kubernetes
-#   metricsets:
-#     - event
+#- module: kubernetes
+#  metricsets:
+#    - event

--- a/metricbeat/modules.d/kubernetes.yml.disabled
+++ b/metricbeat/modules.d/kubernetes.yml.disabled
@@ -1,8 +1,30 @@
+# Node metrics, from kubelet:
 - module: kubernetes
   metricsets:
-    - container
     - node
-    - pod
     - system
+    - pod
+    - container
     - volume
+  period: 10s
   hosts: ["localhost:10255"]
+  #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
+  #ssl.certificate: "/etc/pki/client/cert.pem"
+  #ssl.key: "/etc/pki/client/cert.key"
+
+# State metrics from kube-state-metrics service:
+# - module: kubernetes
+#   metricsets:
+#     - state_node
+#     - state_deployment
+#     - state_replicaset
+#     - state_statefulset
+#     - state_pod
+#     - state_container
+#   period: 10s
+#   hosts: ["kube-state-metrics:8080"]
+
+# Kubernetes events
+# - module: kubernetes
+#   metricsets:
+#     - event

--- a/metricbeat/modules.d/kubernetes.yml.disabled
+++ b/metricbeat/modules.d/kubernetes.yml.disabled
@@ -1,3 +1,6 @@
+# Module: kubernetes
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-kubernetes.html
+
 # Node metrics, from kubelet:
 - module: kubernetes
   metricsets:

--- a/metricbeat/modules.d/kvm.yml.disabled
+++ b/metricbeat/modules.d/kvm.yml.disabled
@@ -1,2 +1,4 @@
 - module: kvm
+  metricsets: ["dommemstat"]
+  period: 10s
   hosts: ["localhost"]

--- a/metricbeat/modules.d/kvm.yml.disabled
+++ b/metricbeat/modules.d/kvm.yml.disabled
@@ -2,6 +2,6 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-kvm.html
 
 - module: kvm
-  metricsets: ["dommemstat"]
+#  metricsets: ["dommemstat"]
   period: 10s
   hosts: ["localhost"]

--- a/metricbeat/modules.d/kvm.yml.disabled
+++ b/metricbeat/modules.d/kvm.yml.disabled
@@ -2,6 +2,7 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-kvm.html
 
 - module: kvm
-#  metricsets: ["dommemstat"]
+  #metricsets:
+  #  - dommemstat
   period: 10s
   hosts: ["localhost"]

--- a/metricbeat/modules.d/kvm.yml.disabled
+++ b/metricbeat/modules.d/kvm.yml.disabled
@@ -1,3 +1,6 @@
+# Module: kvm
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-kvm.html
+
 - module: kvm
   metricsets: ["dommemstat"]
   period: 10s

--- a/metricbeat/modules.d/logstash.yml.disabled
+++ b/metricbeat/modules.d/logstash.yml.disabled
@@ -2,8 +2,8 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-logstash.html
 
 - module: logstash
-#  metricsets:
-#    - node
-#    - node_stats
+  #metricsets:
+  #  - node
+  #  - node_stats
   period: 10s
   hosts: ["localhost:9600"]

--- a/metricbeat/modules.d/logstash.yml.disabled
+++ b/metricbeat/modules.d/logstash.yml.disabled
@@ -1,3 +1,6 @@
+# Module: logstash
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-logstash.html
+
 - module: logstash
   metricsets:
     - node

--- a/metricbeat/modules.d/logstash.yml.disabled
+++ b/metricbeat/modules.d/logstash.yml.disabled
@@ -2,8 +2,8 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-logstash.html
 
 - module: logstash
-  metricsets:
-    - node
-    - node_stats
+#  metricsets:
+#    - node
+#    - node_stats
   period: 10s
   hosts: ["localhost:9600"]

--- a/metricbeat/modules.d/logstash.yml.disabled
+++ b/metricbeat/modules.d/logstash.yml.disabled
@@ -1,2 +1,6 @@
 - module: logstash
+  metricsets:
+    - node
+    - node_stats
+  period: 10s
   hosts: ["localhost:9600"]

--- a/metricbeat/modules.d/memcached.yml.disabled
+++ b/metricbeat/modules.d/memcached.yml.disabled
@@ -1,2 +1,4 @@
 - module: memcached
+  metricsets: ["stats"]
+  period: 10s
   hosts: ["localhost:11211"]

--- a/metricbeat/modules.d/memcached.yml.disabled
+++ b/metricbeat/modules.d/memcached.yml.disabled
@@ -2,6 +2,6 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-memcached.html
 
 - module: memcached
-  metricsets: ["stats"]
+#  metricsets: ["stats"]
   period: 10s
   hosts: ["localhost:11211"]

--- a/metricbeat/modules.d/memcached.yml.disabled
+++ b/metricbeat/modules.d/memcached.yml.disabled
@@ -1,3 +1,6 @@
+# Module: memcached
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-memcached.html
+
 - module: memcached
   metricsets: ["stats"]
   period: 10s

--- a/metricbeat/modules.d/mongodb.yml.disabled
+++ b/metricbeat/modules.d/mongodb.yml.disabled
@@ -2,9 +2,9 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-mongodb.html
 
 - module: mongodb
-  metricsets:
-    - dbstats
-    - status
+#  metricsets:
+#    - dbstats
+#    - status
   period: 10s
 
   # The hosts must be passed as MongoDB URLs in the format:

--- a/metricbeat/modules.d/mongodb.yml.disabled
+++ b/metricbeat/modules.d/mongodb.yml.disabled
@@ -2,9 +2,9 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-mongodb.html
 
 - module: mongodb
-#  metricsets:
-#    - dbstats
-#    - status
+  #metricsets:
+  #  - dbstats
+  #  - status
   period: 10s
 
   # The hosts must be passed as MongoDB URLs in the format:

--- a/metricbeat/modules.d/mongodb.yml.disabled
+++ b/metricbeat/modules.d/mongodb.yml.disabled
@@ -1,3 +1,6 @@
+# Module: mongodb
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-mongodb.html
+
 - module: mongodb
   metricsets:
     - dbstats

--- a/metricbeat/modules.d/mongodb.yml.disabled
+++ b/metricbeat/modules.d/mongodb.yml.disabled
@@ -1,2 +1,18 @@
 - module: mongodb
+  metricsets:
+    - dbstats
+    - status
+  period: 10s
+
+  # The hosts must be passed as MongoDB URLs in the format:
+  # [mongodb://][user:pass@]host[:port].
+  # The username and password can also be set using the respective configuration
+  # options. The credentials in the URL take precedence over the username and
+  # password configuration options.
   hosts: ["localhost:27017"]
+
+  # Username to use when connecting to MongoDB. Empty by default.
+  #username: user
+
+  # Password to use when connecting to MongoDB. Empty by default.
+  #password: pass

--- a/metricbeat/modules.d/munin.yml.disabled
+++ b/metricbeat/modules.d/munin.yml.disabled
@@ -2,7 +2,7 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-munin.html
 
 - module: munin
-  metricsets: ["node"]
+#  metricsets: ["node"]
   period: 10s
   hosts: ["localhost:4949"]
   node.namespace: node

--- a/metricbeat/modules.d/munin.yml.disabled
+++ b/metricbeat/modules.d/munin.yml.disabled
@@ -1,3 +1,6 @@
+# Module: munin
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-munin.html
+
 - module: munin
   metricsets: ["node"]
   period: 10s

--- a/metricbeat/modules.d/munin.yml.disabled
+++ b/metricbeat/modules.d/munin.yml.disabled
@@ -1,3 +1,5 @@
 - module: munin
+  metricsets: ["node"]
+  period: 10s
   hosts: ["localhost:4949"]
   node.namespace: node

--- a/metricbeat/modules.d/munin.yml.disabled
+++ b/metricbeat/modules.d/munin.yml.disabled
@@ -2,7 +2,8 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-munin.html
 
 - module: munin
-#  metricsets: ["node"]
+  #metricsets:
+  #  - node
   period: 10s
   hosts: ["localhost:4949"]
   node.namespace: node

--- a/metricbeat/modules.d/mysql.yml.disabled
+++ b/metricbeat/modules.d/mysql.yml.disabled
@@ -1,2 +1,17 @@
 - module: mysql
-  hosts: ["tcp(127.0.0.1:3306)/"]
+  metricsets: ["status"]
+  period: 10s
+
+  # Host DSN should be defined as "user:pass@tcp(127.0.0.1:3306)/"
+  # The username and password can either be set in the DSN or using the username
+  # and password config options. Those specified in the DSN take precedence.
+  hosts: ["root:secret@tcp(127.0.0.1:3306)/"]
+
+  # Username of hosts. Empty by default.
+  #username: root
+
+  # Password of hosts. Empty by default.
+  #password: secret
+
+  # By setting raw to true, all raw fields from the status metricset will be added to the event.
+  #raw: false

--- a/metricbeat/modules.d/mysql.yml.disabled
+++ b/metricbeat/modules.d/mysql.yml.disabled
@@ -2,7 +2,8 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-mysql.html
 
 - module: mysql
-#  metricsets: ["status"]
+  #metricsets:
+  #  - status
   period: 10s
 
   # Host DSN should be defined as "user:pass@tcp(127.0.0.1:3306)/"
@@ -15,6 +16,3 @@
 
   # Password of hosts. Empty by default.
   #password: secret
-
-  # By setting raw to true, all raw fields from the status metricset will be added to the event.
-  #raw: false

--- a/metricbeat/modules.d/mysql.yml.disabled
+++ b/metricbeat/modules.d/mysql.yml.disabled
@@ -2,7 +2,7 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-mysql.html
 
 - module: mysql
-  metricsets: ["status"]
+#  metricsets: ["status"]
   period: 10s
 
   # Host DSN should be defined as "user:pass@tcp(127.0.0.1:3306)/"

--- a/metricbeat/modules.d/mysql.yml.disabled
+++ b/metricbeat/modules.d/mysql.yml.disabled
@@ -1,3 +1,6 @@
+# Module: mysql
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-mysql.html
+
 - module: mysql
   metricsets: ["status"]
   period: 10s

--- a/metricbeat/modules.d/nginx.yml.disabled
+++ b/metricbeat/modules.d/nginx.yml.disabled
@@ -1,3 +1,6 @@
+# Module: nginx
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-nginx.html
+
 - module: nginx
   metricsets: ["stubstatus"]
   period: 10s

--- a/metricbeat/modules.d/nginx.yml.disabled
+++ b/metricbeat/modules.d/nginx.yml.disabled
@@ -1,2 +1,9 @@
 - module: nginx
+  metricsets: ["stubstatus"]
+  period: 10s
+
+  # Nginx hosts
   hosts: ["http://127.0.0.1"]
+
+  # Path to server status. Default server-status
+  #server_status_path: "server-status"

--- a/metricbeat/modules.d/nginx.yml.disabled
+++ b/metricbeat/modules.d/nginx.yml.disabled
@@ -2,7 +2,7 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-nginx.html
 
 - module: nginx
-  metricsets: ["stubstatus"]
+#  metricsets: ["stubstatus"]
   period: 10s
 
   # Nginx hosts

--- a/metricbeat/modules.d/nginx.yml.disabled
+++ b/metricbeat/modules.d/nginx.yml.disabled
@@ -2,7 +2,8 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-nginx.html
 
 - module: nginx
-#  metricsets: ["stubstatus"]
+  #metricsets:
+  #  - stubstatus
   period: 10s
 
   # Nginx hosts

--- a/metricbeat/modules.d/php_fpm.yml.disabled
+++ b/metricbeat/modules.d/php_fpm.yml.disabled
@@ -2,7 +2,7 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-php_fpm.html
 
 - module: php_fpm
-  metricsets: ["pool"]
+#  metricsets: ["pool"]
   period: 10s
   hosts: ["localhost:8080"]
   status_path: "/status"

--- a/metricbeat/modules.d/php_fpm.yml.disabled
+++ b/metricbeat/modules.d/php_fpm.yml.disabled
@@ -1,2 +1,5 @@
 - module: php_fpm
+  metricsets: ["pool"]
+  period: 10s
   hosts: ["localhost:8080"]
+  status_path: "/status"

--- a/metricbeat/modules.d/php_fpm.yml.disabled
+++ b/metricbeat/modules.d/php_fpm.yml.disabled
@@ -2,7 +2,8 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-php_fpm.html
 
 - module: php_fpm
-#  metricsets: ["pool"]
+  #metricsets:
+  #  - pool
   period: 10s
   hosts: ["localhost:8080"]
   status_path: "/status"

--- a/metricbeat/modules.d/php_fpm.yml.disabled
+++ b/metricbeat/modules.d/php_fpm.yml.disabled
@@ -1,3 +1,6 @@
+# Module: php_fpm
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-php_fpm.html
+
 - module: php_fpm
   metricsets: ["pool"]
   period: 10s

--- a/metricbeat/modules.d/postgresql.yml.disabled
+++ b/metricbeat/modules.d/postgresql.yml.disabled
@@ -1,3 +1,6 @@
+# Module: postgresql
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-postgresql.html
+
 - module: postgresql
   metricsets:
     # Stats about every PostgreSQL database

--- a/metricbeat/modules.d/postgresql.yml.disabled
+++ b/metricbeat/modules.d/postgresql.yml.disabled
@@ -2,13 +2,13 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-postgresql.html
 
 - module: postgresql
-#  metricsets:
-#    # Stats about every PostgreSQL database
-#    - database
-#    # Stats about the background writer process's activity
-#    - bgwriter
-#    # Stats about every PostgreSQL process
-#    - activity
+  #metricsets:
+  #  # Stats about every PostgreSQL database
+  #  - database
+  #  # Stats about the background writer process's activity
+  #  - bgwriter
+  #  # Stats about every PostgreSQL process
+  #  - activity
   period: 10s
 
   # The host must be passed as PostgreSQL URL. Example:

--- a/metricbeat/modules.d/postgresql.yml.disabled
+++ b/metricbeat/modules.d/postgresql.yml.disabled
@@ -1,2 +1,24 @@
 - module: postgresql
+  metricsets:
+    # Stats about every PostgreSQL database
+    - database
+
+    # Stats about the background writer process's activity
+    - bgwriter
+
+    # Stats about every PostgreSQL process
+    - activity
+
+  period: 10s
+
+  # The host must be passed as PostgreSQL URL. Example:
+  # postgres://localhost:5432?sslmode=disable
+  # The available parameters are documented here:
+  # https://godoc.org/github.com/lib/pq#hdr-Connection_String_Parameters
   hosts: ["postgres://localhost:5432"]
+
+  # Username to use when connecting to PostgreSQL. Empty by default.
+  #username: user
+
+  # Password to use when connecting to PostgreSQL. Empty by default.
+  #password: pass

--- a/metricbeat/modules.d/postgresql.yml.disabled
+++ b/metricbeat/modules.d/postgresql.yml.disabled
@@ -2,16 +2,13 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-postgresql.html
 
 - module: postgresql
-  metricsets:
-    # Stats about every PostgreSQL database
-    - database
-
-    # Stats about the background writer process's activity
-    - bgwriter
-
-    # Stats about every PostgreSQL process
-    - activity
-
+#  metricsets:
+#    # Stats about every PostgreSQL database
+#    - database
+#    # Stats about the background writer process's activity
+#    - bgwriter
+#    # Stats about every PostgreSQL process
+#    - activity
   period: 10s
 
   # The host must be passed as PostgreSQL URL. Example:

--- a/metricbeat/modules.d/postgresql.yml.disabled
+++ b/metricbeat/modules.d/postgresql.yml.disabled
@@ -3,22 +3,10 @@
 
 - module: postgresql
   #metricsets:
-  #  # Stats about every PostgreSQL database
   #  - database
-  #  # Stats about the background writer process's activity
   #  - bgwriter
-  #  # Stats about every PostgreSQL process
   #  - activity
   period: 10s
-
-  # The host must be passed as PostgreSQL URL. Example:
-  # postgres://localhost:5432?sslmode=disable
-  # The available parameters are documented here:
-  # https://godoc.org/github.com/lib/pq#hdr-Connection_String_Parameters
   hosts: ["postgres://localhost:5432"]
-
-  # Username to use when connecting to PostgreSQL. Empty by default.
   #username: user
-
-  # Password to use when connecting to PostgreSQL. Empty by default.
   #password: pass

--- a/metricbeat/modules.d/prometheus.yml.disabled
+++ b/metricbeat/modules.d/prometheus.yml.disabled
@@ -2,7 +2,8 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-prometheus.html
 
 - module: prometheus
-#  metricsets: ["stats"]
+  #metricsets:
+  #  - stats
   period: 10s
   hosts: ["localhost:9090"]
   metrics_path: /metrics

--- a/metricbeat/modules.d/prometheus.yml.disabled
+++ b/metricbeat/modules.d/prometheus.yml.disabled
@@ -1,3 +1,6 @@
+# Module: prometheus
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-prometheus.html
+
 - module: prometheus
   metricsets: ["stats"]
   period: 10s

--- a/metricbeat/modules.d/prometheus.yml.disabled
+++ b/metricbeat/modules.d/prometheus.yml.disabled
@@ -2,7 +2,7 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-prometheus.html
 
 - module: prometheus
-  metricsets: ["stats"]
+#  metricsets: ["stats"]
   period: 10s
   hosts: ["localhost:9090"]
   metrics_path: /metrics

--- a/metricbeat/modules.d/prometheus.yml.disabled
+++ b/metricbeat/modules.d/prometheus.yml.disabled
@@ -1,4 +1,6 @@
 - module: prometheus
+  metricsets: ["stats"]
   period: 10s
   hosts: ["localhost:9090"]
+  metrics_path: /metrics
   #namespace: example

--- a/metricbeat/modules.d/rabbitmq.yml.disabled
+++ b/metricbeat/modules.d/rabbitmq.yml.disabled
@@ -2,10 +2,10 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-rabbitmq.html
 
 - module: rabbitmq
-#  metricsets:
-#    - node
-#    - queue
-#    - connection
+  #metricsets:
+  #  - node
+  #  - queue
+  #  - connection
   period: 10s
   hosts: ["localhost:15672"]
 

--- a/metricbeat/modules.d/rabbitmq.yml.disabled
+++ b/metricbeat/modules.d/rabbitmq.yml.disabled
@@ -2,10 +2,10 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-rabbitmq.html
 
 - module: rabbitmq
-  metricsets:
-    - node
-    - queue
-    - connection
+#  metricsets:
+#    - node
+#    - queue
+#    - connection
   period: 10s
   hosts: ["localhost:15672"]
 

--- a/metricbeat/modules.d/rabbitmq.yml.disabled
+++ b/metricbeat/modules.d/rabbitmq.yml.disabled
@@ -1,2 +1,10 @@
 - module: rabbitmq
+  metricsets:
+    - node
+    - queue
+    - connection
+  period: 10s
   hosts: ["localhost:15672"]
+
+  username: guest
+  password: guest

--- a/metricbeat/modules.d/rabbitmq.yml.disabled
+++ b/metricbeat/modules.d/rabbitmq.yml.disabled
@@ -8,6 +8,5 @@
   #  - connection
   period: 10s
   hosts: ["localhost:15672"]
-
-  username: guest
-  password: guest
+  #username: guest
+  #password: guest

--- a/metricbeat/modules.d/rabbitmq.yml.disabled
+++ b/metricbeat/modules.d/rabbitmq.yml.disabled
@@ -1,3 +1,6 @@
+# Module: rabbitmq
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-rabbitmq.html
+
 - module: rabbitmq
   metricsets:
     - node

--- a/metricbeat/modules.d/redis.yml.disabled
+++ b/metricbeat/modules.d/redis.yml.disabled
@@ -10,25 +10,11 @@
   # Redis hosts
   hosts: ["127.0.0.1:6379"]
 
-  # Timeout after which time a metricset should return an error
-  # Timeout is by default defined as period, as a fetch of a metricset
-  # should never take longer then period, as otherwise calls can pile up.
-  #timeout: 1s
-
-  # Optional fields to be added to each event
-  #fields:
-  #  datacenter: west
-
   # Network type to be used for redis connection. Default: tcp
   #network: tcp
 
   # Max number of concurrent connections. Default: 10
   #maxconn: 10
-
-  # Filters can be used to reduce the number of fields sent.
-  #processors:
-  #  - include_fields:
-  #      fields: ["beat", "metricset", "redis.info.stats"]
 
   # Redis AUTH password. Empty by default.
   #password: foobared

--- a/metricbeat/modules.d/redis.yml.disabled
+++ b/metricbeat/modules.d/redis.yml.disabled
@@ -1,2 +1,31 @@
 - module: redis
+  metricsets:
+    - info
+    - keyspace
+  period: 10s
+
+  # Redis hosts
   hosts: ["127.0.0.1:6379"]
+
+  # Timeout after which time a metricset should return an error
+  # Timeout is by default defined as period, as a fetch of a metricset
+  # should never take longer then period, as otherwise calls can pile up.
+  #timeout: 1s
+
+  # Optional fields to be added to each event
+  #fields:
+  #  datacenter: west
+
+  # Network type to be used for redis connection. Default: tcp
+  #network: tcp
+
+  # Max number of concurrent connections. Default: 10
+  #maxconn: 10
+
+  # Filters can be used to reduce the number of fields sent.
+  #processors:
+  #  - include_fields:
+  #      fields: ["beat", "metricset", "redis.info.stats"]
+
+  # Redis AUTH password. Empty by default.
+  #password: foobared

--- a/metricbeat/modules.d/redis.yml.disabled
+++ b/metricbeat/modules.d/redis.yml.disabled
@@ -2,9 +2,9 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-redis.html
 
 - module: redis
-#  metricsets:
-#    - info
-#    - keyspace
+  #metricsets:
+  #  - info
+  #  - keyspace
   period: 10s
 
   # Redis hosts

--- a/metricbeat/modules.d/redis.yml.disabled
+++ b/metricbeat/modules.d/redis.yml.disabled
@@ -2,9 +2,9 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-redis.html
 
 - module: redis
-  metricsets:
-    - info
-    - keyspace
+#  metricsets:
+#    - info
+#    - keyspace
   period: 10s
 
   # Redis hosts

--- a/metricbeat/modules.d/redis.yml.disabled
+++ b/metricbeat/modules.d/redis.yml.disabled
@@ -1,3 +1,6 @@
+# Module: redis
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-redis.html
+
 - module: redis
   metricsets:
     - info

--- a/metricbeat/modules.d/system.yml
+++ b/metricbeat/modules.d/system.yml
@@ -31,8 +31,8 @@
   metricsets:
     - uptime
 
-# - module: system
-#   period: 5m
-#   metricsets:
-#     - raid
-#   raid.mount_point: '/'
+#- module: system
+#  period: 5m
+#  metricsets:
+#    - raid
+#  raid.mount_point: '/'

--- a/metricbeat/modules.d/system.yml
+++ b/metricbeat/modules.d/system.yml
@@ -1,13 +1,19 @@
 - module: system
+  period: 10s
+  metricsets:
+    - cpu
+    - load
+    - memory
+    - network
+    - process
+    - process_summary
+    #- core
+    #- diskio
+    #- socket
+  processes: ['.*']
   process.include_top_n:
     by_cpu: 5      # include top 5 processes by CPU
     by_memory: 5   # include top 5 processes by memory
-
-#- module: system
-#  metricsets:
-#    - core
-#    - diskio
-#    - socket
 
 - module: system
   period: 1m
@@ -23,8 +29,8 @@
   metricsets:
     - uptime
 
-#- module: system
-#  period: 5m
-#  metricsets:
-#    - raid
-#  raid.mount_point: '/'
+# - module: system
+#   period: 5m
+#   metricsets:
+#     - raid
+#   raid.mount_point: '/'

--- a/metricbeat/modules.d/system.yml
+++ b/metricbeat/modules.d/system.yml
@@ -1,3 +1,6 @@
+# Module: system
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-system.html
+
 - module: system
   period: 10s
   metricsets:

--- a/metricbeat/modules.d/system.yml
+++ b/metricbeat/modules.d/system.yml
@@ -10,7 +10,6 @@
     #- core
     #- diskio
     #- socket
-  processes: ['.*']
   process.include_top_n:
     by_cpu: 5      # include top 5 processes by CPU
     by_memory: 5   # include top 5 processes by memory

--- a/metricbeat/modules.d/uwsgi.yml.disabled
+++ b/metricbeat/modules.d/uwsgi.yml.disabled
@@ -1,2 +1,4 @@
 - module: uwsgi
+  metricsets: ["status"]
+  period: 10s
   hosts: ["tcp://127.0.0.1:9191"]

--- a/metricbeat/modules.d/uwsgi.yml.disabled
+++ b/metricbeat/modules.d/uwsgi.yml.disabled
@@ -2,6 +2,7 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-uwsgi.html
 
 - module: uwsgi
-#  metricsets: ["status"]
+  #metricsets:
+  #  - status
   period: 10s
   hosts: ["tcp://127.0.0.1:9191"]

--- a/metricbeat/modules.d/uwsgi.yml.disabled
+++ b/metricbeat/modules.d/uwsgi.yml.disabled
@@ -1,3 +1,6 @@
+# Module: uwsgi
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-uwsgi.html
+
 - module: uwsgi
   metricsets: ["status"]
   period: 10s

--- a/metricbeat/modules.d/uwsgi.yml.disabled
+++ b/metricbeat/modules.d/uwsgi.yml.disabled
@@ -2,6 +2,6 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-uwsgi.html
 
 - module: uwsgi
-  metricsets: ["status"]
+#  metricsets: ["status"]
   period: 10s
   hosts: ["tcp://127.0.0.1:9191"]

--- a/metricbeat/modules.d/vsphere.yml.disabled
+++ b/metricbeat/modules.d/vsphere.yml.disabled
@@ -1,4 +1,5 @@
 - module: vsphere
+  metricsets: ["datastore", "host", "virtualmachine"]
   period: 10s
   hosts: ["https://localhost/sdk"]
 

--- a/metricbeat/modules.d/vsphere.yml.disabled
+++ b/metricbeat/modules.d/vsphere.yml.disabled
@@ -2,7 +2,10 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-vsphere.html
 
 - module: vsphere
-  metricsets: ["datastore", "host", "virtualmachine"]
+#  metricsets:
+#    - datastore
+#    - host
+#    - virtualmachine
   period: 10s
   hosts: ["https://localhost/sdk"]
 
@@ -12,4 +15,3 @@
   insecure: false
   # Get custom fields when using virtualmachine metric set. Default false.
   # get_custom_fields: false
-  

--- a/metricbeat/modules.d/vsphere.yml.disabled
+++ b/metricbeat/modules.d/vsphere.yml.disabled
@@ -2,10 +2,10 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-vsphere.html
 
 - module: vsphere
-#  metricsets:
-#    - datastore
-#    - host
-#    - virtualmachine
+  #metricsets:
+  #  - datastore
+  #  - host
+  #  - virtualmachine
   period: 10s
   hosts: ["https://localhost/sdk"]
 

--- a/metricbeat/modules.d/vsphere.yml.disabled
+++ b/metricbeat/modules.d/vsphere.yml.disabled
@@ -1,3 +1,6 @@
+# Module: vsphere
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-vsphere.html
+
 - module: vsphere
   metricsets: ["datastore", "host", "virtualmachine"]
   period: 10s

--- a/metricbeat/modules.d/windows.yml.disabled
+++ b/metricbeat/modules.d/windows.yml.disabled
@@ -2,7 +2,7 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-windows.html
 
 - module: windows
-  metricsets: ["service"]
+#  metricsets: ["service"]
   period: 1m
 
 #- module: windows

--- a/metricbeat/modules.d/windows.yml.disabled
+++ b/metricbeat/modules.d/windows.yml.disabled
@@ -1,8 +1,20 @@
 - module: windows
-  metricsets: ["perfmon"]
-  period: 10s
-  perfmon.counters:
-
-- module: windows
   metricsets: ["service"]
   period: 1m
+
+#- module: windows
+#  metricsets: ["perfmon"]
+#  period: 10s
+#  perfmon.counters:
+#    - instance_label: processor.name
+#      instance_name: total
+#      measurement_label: processor.time.total.pct
+#      query: '\Processor Information(_Total)\% Processor Time'
+#
+#    - instance_label: physical_disk.name
+#      measurement_label: physical_disk.write.per_sec
+#      query: '\PhysicalDisk(*)\Disk Writes/sec'
+#
+#    - instance_label: physical_disk.name
+#      measurement_label: physical_disk.write.time.pct
+#      query: '\PhysicalDisk(*)\% Disk Write Time'

--- a/metricbeat/modules.d/windows.yml.disabled
+++ b/metricbeat/modules.d/windows.yml.disabled
@@ -2,11 +2,13 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-windows.html
 
 - module: windows
-#  metricsets: ["service"]
+  #metricsets:
+  #  - service
   period: 1m
 
 #- module: windows
-#  metricsets: ["perfmon"]
+#  metricsets:
+#    - perfmon
 #  period: 10s
 #  perfmon.counters:
 #    - instance_label: processor.name

--- a/metricbeat/modules.d/windows.yml.disabled
+++ b/metricbeat/modules.d/windows.yml.disabled
@@ -1,3 +1,6 @@
+# Module: windows
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-windows.html
+
 - module: windows
   metricsets: ["service"]
   period: 1m

--- a/metricbeat/modules.d/windows.yml.disabled
+++ b/metricbeat/modules.d/windows.yml.disabled
@@ -1,2 +1,8 @@
 - module: windows
-  period: 60s
+  metricsets: ["perfmon"]
+  period: 10s
+  perfmon.counters:
+
+- module: windows
+  metricsets: ["service"]
+  period: 1m

--- a/metricbeat/modules.d/zookeeper.yml.disabled
+++ b/metricbeat/modules.d/zookeeper.yml.disabled
@@ -2,6 +2,6 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-zookeeper.html
 
 - module: zookeeper
-  metricsets: ["mntr"]
+#  metricsets: ["mntr"]
   period: 10s
   hosts: ["localhost:2181"]

--- a/metricbeat/modules.d/zookeeper.yml.disabled
+++ b/metricbeat/modules.d/zookeeper.yml.disabled
@@ -1,3 +1,4 @@
 - module: zookeeper
+  metricsets: ["mntr"]
   period: 10s
   hosts: ["localhost:2181"]

--- a/metricbeat/modules.d/zookeeper.yml.disabled
+++ b/metricbeat/modules.d/zookeeper.yml.disabled
@@ -2,6 +2,7 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-zookeeper.html
 
 - module: zookeeper
-#  metricsets: ["mntr"]
+  #metricsets:
+  #  - mntr
   period: 10s
   hosts: ["localhost:2181"]

--- a/metricbeat/modules.d/zookeeper.yml.disabled
+++ b/metricbeat/modules.d/zookeeper.yml.disabled
@@ -1,3 +1,6 @@
+# Module: zookeeper
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-zookeeper.html
+
 - module: zookeeper
   metricsets: ["mntr"]
   period: 10s

--- a/metricbeat/scripts/modules_collector.py
+++ b/metricbeat/scripts/modules_collector.py
@@ -1,0 +1,48 @@
+import os
+import argparse
+import yaml
+import six
+
+# Collects module configs to modules.d
+
+
+def collect(docs_branch):
+
+    base_dir = "module"
+    path = os.path.abspath("module")
+
+    # TODO add module release status if beta or experimental
+    header = """# Module: {module}
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/{docs_branch}/metricbeat-module-{module}.html
+
+"""
+
+    # Create directory for module confs
+    os.mkdir(os.path.abspath('modules.d'))
+
+    # Iterate over all modules
+    for module in sorted(os.listdir(base_dir)):
+
+        module_conf = path + '/' + module + '/_meta/config.yml'
+        if os.path.isfile(module_conf) == False:
+            continue
+
+        module_file = header.format(module=module, docs_branch=docs_branch)
+
+        with open(module_conf) as f:
+            module_file += f.read()
+
+        # Write disabled module conf
+        with open(os.path.abspath('modules.d/') + '/' + module + '.yml.disabled', 'w') as f:
+            f.write(module_file)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Collects modules confs")
+    parser.add_argument("--docs_branch", help="Docs branch")
+
+    args = parser.parse_args()
+    docs_branch = args.docs_branch
+
+    collect(docs_branch)


### PR DESCRIPTION
Since we split module configurations into modules.d folder, we can keep
configurations more verbose, so users have a quick reference when
opening them for editing.

This change unifies configuration files using the followin rules:

 * Write at least the following settings, in this order: `module`,
 `metricsets`, `period`, `hosts`.
 * Default metricsets list shown as it helps to know what's the list,
 or disable just one. Inline if there is only one metricset, one line
 per metricset if there is more than one.
 * Some modules have exceptions and include more definitions, or different
 defaults.
 * Comments are allowed (and encouraged), both to explain a setting and
 to suggest a full configuration.
 * `enabled` setting is not shown at all, modules are enabled by using
 `metricbeat modules enable <module name>`. Use comments to suggest
 settings that are disabled by default.