### PR TITLE
Reduce log level of urllib3 in metricbeat tests

### DIFF
--- a/metricbeat/tests/system/metricbeat.py
+++ b/metricbeat/tests/system/metricbeat.py
@@ -11,6 +11,9 @@ COMMON_FIELDS = ["@timestamp", "beat", "metricset.name", "metricset.host",
 
 INTEGRATION_TESTS = os.environ.get('INTEGRATION_TESTS', False)
 
+import logging
+logging.getLogger("urllib3").setLevel(logging.WARNING)
+
 
 class BaseTest(TestCase):
 


### PR DESCRIPTION
Logs of failing tests are usually flooded by not very useful urllib3 messages, reduce log level.