### PR TITLE
Exclude common compression formats

### DIFF
--- a/filebeat/module/apache2/access/config/access.yml
+++ b/filebeat/module/apache2/access/config/access.yml
@@ -3,4 +3,4 @@ paths:
 {{ range $i, $path := .paths }}
  - {{$path}}
 {{ end }}
-exclude_files: [".gz$"]
+exclude_files: [".gz$", ".bz2$", ".xz$"]

--- a/filebeat/module/apache2/error/config/error.yml
+++ b/filebeat/module/apache2/error/config/error.yml
@@ -3,4 +3,4 @@ paths:
 {{ range $i, $path := .paths }}
  - {{$path}}
 {{ end }}
-exclude_files: [".gz$"]
+exclude_files: [".gz$", ".bz2$", ".xz$"]

--- a/filebeat/module/auditd/log/config/log.yml
+++ b/filebeat/module/auditd/log/config/log.yml
@@ -3,4 +3,4 @@ paths:
 {{ range $i, $path := .paths }}
  - {{$path}}
 {{ end }}
-exclude_files: [".gz$"]
+exclude_files: [".gz$", ".bz2$", ".xz$"]

--- a/filebeat/module/icinga/debug/config/debug.yml
+++ b/filebeat/module/icinga/debug/config/debug.yml
@@ -3,7 +3,7 @@ paths:
 {{ range $i, $path := .paths }}
  - {{$path}}
 {{ end }}
-exclude_files: [".gz$"]
+exclude_files: [".gz$", ".bz2$", ".xz$"]
 multiline:
   pattern: '^\['
   negate: true

--- a/filebeat/module/icinga/main/config/main.yml
+++ b/filebeat/module/icinga/main/config/main.yml
@@ -3,7 +3,7 @@ paths:
 {{ range $i, $path := .paths }}
  - {{$path}}
 {{ end }}
-exclude_files: [".gz$"]
+exclude_files: [".gz$", ".bz2$", ".xz$"]
 multiline:
   pattern: '^\['
   negate: true

--- a/filebeat/module/icinga/startup/config/startup.yml
+++ b/filebeat/module/icinga/startup/config/startup.yml
@@ -3,7 +3,7 @@ paths:
 {{ range $i, $path := .paths }}
  - {{$path}}
 {{ end }}
-exclude_files: [".gz$"]
+exclude_files: [".gz$", ".bz2$", ".xz$"]
 multiline:
   pattern: '^[a-z]*\/[a-zA-Z]*:'
   negate: true

--- a/filebeat/module/iis/access/config/iis-access.yml
+++ b/filebeat/module/iis/access/config/iis-access.yml
@@ -3,5 +3,5 @@ paths:
 {{ range $i, $path := .paths }}
  - {{$path}}
 {{ end }}
-exclude_files: [".gz$"]
+exclude_files: [".gz$", ".bz2$", ".xz$"]
 exclude_lines: ["^#"]

--- a/filebeat/module/iis/error/config/iis-error.yml
+++ b/filebeat/module/iis/error/config/iis-error.yml
@@ -3,5 +3,5 @@ paths:
 {{ range $i, $path := .paths }}
  - {{$path}}
 {{ end }}
-exclude_files: [".gz$"]
+exclude_files: [".gz$", ".bz2$", ".xz$"]
 exclude_lines: ["^#"]

--- a/filebeat/module/kafka/log/config/log.yml
+++ b/filebeat/module/kafka/log/config/log.yml
@@ -3,7 +3,7 @@ paths:
 {{ range $i, $path := .paths }}
  - {{$path}}
 {{ end }}
-exclude_files: [".gz$"]
+exclude_files: [".gz$", ".bz2$", ".xz$"]
 multiline:
   pattern: '^\['
   negate: true

--- a/filebeat/module/logstash/log/config/log.yml
+++ b/filebeat/module/logstash/log/config/log.yml
@@ -3,4 +3,4 @@ paths:
 {{ range $i, $path := .paths }}
  - {{$path}}
 {{ end }}
-exclude_files: [".gz$"]
+exclude_files: [".gz$", ".bz2$", ".xz$"]

--- a/filebeat/module/logstash/slowlog/config/slowlog.yml
+++ b/filebeat/module/logstash/slowlog/config/slowlog.yml
@@ -3,4 +3,4 @@ paths:
 {{ range $i, $path := .paths }}
  - {{$path}}
 {{ end }}
-exclude_files: [".gz$"]
+exclude_files: [".gz$", ".bz2$", ".xz$"]

--- a/filebeat/module/mongodb/log/config/log.yml
+++ b/filebeat/module/mongodb/log/config/log.yml
@@ -3,4 +3,4 @@ paths:
 {{ range $i, $path := .paths }}
  - {{$path}}
 {{ end }}
-exclude_files: [".gz$"]
+exclude_files: [".gz$", ".bz2$", ".xz$"]

--- a/filebeat/module/mysql/error/config/error.yml
+++ b/filebeat/module/mysql/error/config/error.yml
@@ -3,4 +3,4 @@ paths:
 {{ range $i, $path := .paths }}
  - {{$path}}
 {{ end }}
-exclude_files: [".gz$"]
+exclude_files: [".gz$", ".bz2$", ".xz$"]

--- a/filebeat/module/mysql/slowlog/config/slowlog.yml
+++ b/filebeat/module/mysql/slowlog/config/slowlog.yml
@@ -3,7 +3,7 @@ paths:
 {{ range $i, $path := .paths }}
  - {{$path}}
 {{ end }}
-exclude_files: ['.gz$']
+exclude_files: [".gz$", ".bz2$", ".xz$"]
 multiline:
   pattern: '^# User@Host: '
   negate: true

--- a/filebeat/module/nginx/access/config/nginx-access.yml
+++ b/filebeat/module/nginx/access/config/nginx-access.yml
@@ -3,4 +3,4 @@ paths:
 {{ range $i, $path := .paths }}
  - {{$path}}
 {{ end }}
-exclude_files: [".gz$"]
+exclude_files: [".gz$", ".bz2$", ".xz$"]

--- a/filebeat/module/nginx/error/config/nginx-error.yml
+++ b/filebeat/module/nginx/error/config/nginx-error.yml
@@ -3,4 +3,4 @@ paths:
 {{ range $i, $path := .paths }}
  - {{$path}}
 {{ end }}
-exclude_files: [".gz$"]
+exclude_files: [".gz$", ".bz2$", ".xz$"]

--- a/filebeat/module/osquery/result/config/result.yml
+++ b/filebeat/module/osquery/result/config/result.yml
@@ -3,6 +3,6 @@ paths:
 {{ range $i, $path := .paths }}
  - {{$path}}
 {{ end }}
-exclude_files: [".gz$"]
+exclude_files: [".gz$", ".bz2$", ".xz$"]
 json.overwrite_keys: true
 json.add_error_key: true

--- a/filebeat/module/postgresql/log/config/log.yml
+++ b/filebeat/module/postgresql/log/config/log.yml
@@ -3,7 +3,7 @@ paths:
 {{ range $i, $path := .paths }}
  - {{$path}}
 {{ end }}
-exclude_files: [".gz$"]
+exclude_files: [".gz$", ".bz2$", ".xz$"]
 multiline:
   pattern: '^[-0-9]* '
   negate: true

--- a/filebeat/module/redis/log/config/log.yml
+++ b/filebeat/module/redis/log/config/log.yml
@@ -3,5 +3,5 @@ paths:
 {{ range $i, $path := .paths }}
  - {{$path}}
 {{ end }}
-exclude_files: [".gz$"]
+exclude_files: [".gz$", ".bz2$", ".xz$"]
 exclude_lines: ["^\\s+[\\-`('.|_]"]  # drop asciiart lines\n

--- a/filebeat/module/system/auth/config/auth.yml
+++ b/filebeat/module/system/auth/config/auth.yml
@@ -3,7 +3,7 @@ paths:
 {{ range $i, $path := .paths }}
  - {{$path}}
 {{ end }}
-exclude_files: [".gz$"]
+exclude_files: [".gz$", ".bz2$", ".xz$"]
 multiline:
   pattern: "^\\s"
   match: after

--- a/filebeat/module/system/syslog/config/syslog.yml
+++ b/filebeat/module/system/syslog/config/syslog.yml
@@ -3,7 +3,7 @@ paths:
 {{ range $i, $path := .paths }}
  - {{$path}}
 {{ end }}
-exclude_files: [".gz$"]
+exclude_files: [".gz$", ".bz2$", ".xz$"]
 multiline:
   pattern: "^\\s"
   match: after

--- a/filebeat/module/traefik/access/config/traefik-access.yml
+++ b/filebeat/module/traefik/access/config/traefik-access.yml
@@ -3,4 +3,4 @@ paths:
 {{ range $i, $path := .paths }}
  - {{$path}}
 {{ end }}
-exclude_files: [".gz$"]
+exclude_files: [".gz$", ".bz2$", ".xz$"]

--- a/filebeat/scripts/fileset/config/config.yml
+++ b/filebeat/scripts/fileset/config/config.yml
@@ -3,4 +3,4 @@ paths:
 {{ range $i, $path := .paths }}
  - {{$path}}
 {{ end }}
-exclude_files: [".gz$"]
+exclude_files: [".gz$", ".bz2$", ".xz$"]

--- a/filebeat/tests/system/test_input.py
+++ b/filebeat/tests/system/test_input.py
@@ -111,13 +111,23 @@ class Test(BaseTest):
 
         self.render_config_template(
             path=os.path.abspath(self.working_dir) + "/log/*",
-            exclude_files=[".gz$"]
+            exclude_files=[".gz$", ".bz2$", ".xz$"]
         )
         os.mkdir(self.working_dir + "/log/")
 
         testfile = self.working_dir + "/log/test.gz"
         file = open(testfile, 'w')
         file.write("line in gz file\n")
+        file.close()
+
+        testfile = self.working_dir + "/log/test.bz2"
+        file = open(testfile, 'w')
+        file.write("line in bz2 file\n")
+        file.close()
+
+        testfile = self.working_dir + "/log/test.xz"
+        file = open(testfile, 'w')
+        file.write("line in xz file\n")
         file.close()
 
         testfile = self.working_dir + "/log/test.log"


### PR DESCRIPTION
Logrotate may be configured to use various compression formats other than
gzip, so exclude the most common.