### PR TITLE
Cherry-pick #6824 to 6.2: Kubernetes deployment: Add ServiceAccount config to system metricbeat.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -22,6 +22,13 @@ https://github.com/elastic/beats/compare/v6.2.4...6.2[Check the HEAD diff]
 
 *Metricbeat*
 
+- Kubernetes deployment: Add ServiceAccount config to system metricbeat. {pull}6824[6824]
+- Kubernetes deployment: Add DNS Policy to system metricbeat. {pull}6656[6656]
+- De dot keys in kubernetes/event metricset to prevent collisions. {pull}6203[6203]
+- Add config option for windows/perfmon metricset to ignore non existent counters. {pull}6432[6432]
+- Refactor docker CPU calculations to be more consistent with `docker stats`. {pull}6608[6608]
+- Update logstash.node_stats metricset to write data under `logstash.node.stats.*`. {pull}6714[6714]
+
 *Packetbeat*
 
 *Winlogbeat*

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -22,13 +22,6 @@ https://github.com/elastic/beats/compare/v6.2.4...6.2[Check the HEAD diff]
 
 *Metricbeat*
 
-- Kubernetes deployment: Add ServiceAccount config to system metricbeat. {pull}6824[6824]
-- Kubernetes deployment: Add DNS Policy to system metricbeat. {pull}6656[6656]
-- De dot keys in kubernetes/event metricset to prevent collisions. {pull}6203[6203]
-- Add config option for windows/perfmon metricset to ignore non existent counters. {pull}6432[6432]
-- Refactor docker CPU calculations to be more consistent with `docker stats`. {pull}6608[6608]
-- Update logstash.node_stats metricset to write data under `logstash.node.stats.*`. {pull}6714[6714]
-
 *Packetbeat*
 
 *Winlogbeat*
@@ -60,6 +53,8 @@ https://github.com/elastic/beats/compare/v6.2.4...6.2[Check the HEAD diff]
 *Heartbeat*
 
 *Metricbeat*
+
+- Kubernetes deployment: Add ServiceAccount config to system metricbeat. {pull}6824[6824]
 
 *Packetbeat*
 

--- a/deploy/kubernetes/metricbeat-kubernetes.yaml
+++ b/deploy/kubernetes/metricbeat-kubernetes.yaml
@@ -200,6 +200,7 @@ spec:
         k8s-app: metricbeat
         kubernetes.io/cluster-service: "true"
     spec:
+      serviceAccountName: metricbeat
       containers:
       - name: metricbeat
         image: docker.elastic.co/beats/metricbeat:6.2.4

--- a/deploy/kubernetes/metricbeat/metricbeat-deployment.yaml
+++ b/deploy/kubernetes/metricbeat/metricbeat-deployment.yaml
@@ -14,6 +14,7 @@ spec:
         k8s-app: metricbeat
         kubernetes.io/cluster-service: "true"
     spec:
+      serviceAccountName: metricbeat
       containers:
       - name: metricbeat
         image: docker.elastic.co/beats/metricbeat:%VERSION%


### PR DESCRIPTION
Cherry-pick of PR #6824 to 6.2 branch. Original message: 

Without the SA, metricbeat is unable to get e.g event infos from kube-state-metrics