### PR TITLE
Ensure the dashboard zip is sane

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -53,6 +53,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Fix for kafka logger. {pull}6430[6430]
 - Remove double slashes in Windows service script. {pull}6491[6491]
 - Ensure Kubernetes labels/annotations don't break mapping {pull}6490[6490]
+- Ensure that the dashboard zip files can't contain files outside of the kibana directory. {pull}6921[6921]
 
 *Auditbeat*
 

--- a/libbeat/dashboards/importer.go
+++ b/libbeat/dashboards/importer.go
@@ -126,7 +126,7 @@ func (imp Importer) unzip(archive, target string) error {
 			return err
 		}
 		if strings.HasPrefix(filepath.ToSlash(relPath), "../") {
-			return fmt.Errorf("Zip file contains files outside of directory target: %s", relPath)
+			return fmt.Errorf("Zip file contains files outside of the target directory: %s", relPath)
 		}
 
 		if file.FileInfo().IsDir() {

--- a/libbeat/dashboards/importer.go
+++ b/libbeat/dashboards/importer.go
@@ -119,6 +119,16 @@ func (imp Importer) unzip(archive, target string) error {
 	unzipFile := func(file *zip.File) error {
 		filePath := filepath.Join(target, file.Name)
 
+		// check that the resulting file path is indeed under target
+		// Note that Rel calls Clean.
+		relPath, err := filepath.Rel(target, filePath)
+		if err != nil {
+			return err
+		}
+		if strings.HasPrefix(filepath.ToSlash(relPath), "../") {
+			return fmt.Errorf("Zip file contains files outside of directory target: %s", relPath)
+		}
+
 		if file.FileInfo().IsDir() {
 			return os.MkdirAll(filePath, file.Mode())
 		}


### PR DESCRIPTION
This adds a check that all files from the dashboard zip file
are pointing to the right target, and don't override other configs.