### PR TITLE
Switch to debug logs for missing fields

### DIFF
--- a/libbeat/common/schema/schema.go
+++ b/libbeat/common/schema/schema.go
@@ -2,7 +2,6 @@ package schema
 
 import (
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/logp"
 )
 
 // Schema describes how a map[string]interface{} object can be parsed and converted into
@@ -37,8 +36,6 @@ func (conv Conv) Map(key string, event common.MapStr, data map[string]interface{
 		err := NewError(key, err.Error())
 		if conv.Optional {
 			err.SetType(OptionalType)
-		} else {
-			logp.Err("Error on field '%s': %v", key, err)
 		}
 
 		errs := NewErrors()
@@ -73,6 +70,7 @@ func (o Object) HasKey(key string) bool {
 // event map.
 func (s Schema) ApplyTo(event common.MapStr, data map[string]interface{}) (common.MapStr, *Errors) {
 	errors := applySchemaToEvent(event, data, s)
+	errors.Log()
 	return event, errors
 }
 


### PR DESCRIPTION
Currently every time a required field is missing in a metricset a log entry is created. This can create a lot of log messages. This is now a temporary fix to only log missing fields on debug level and log all missing fields in one message instead of having one for each field.

The logs still lack context as the schema does not know from which metricset it is called. Further improvements to follow.

The `ErrorDebug` method was removed as it was not used.