### PR TITLE
Add metricset.period to each metricbeat event

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -205,6 +205,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Release config reloading feature as GA. {pull}6891[6891]
 - Add experimental Elasticsearch index metricset. {pull}6881[6881]
 - Add dashboards and visualizations for haproxy metrics. {pull}6934[6934]
+- Add metricset.period field. {pull}6929[6929]
 
 *Packetbeat*
 

--- a/metricbeat/_meta/fields.common.yml
+++ b/metricbeat/_meta/fields.common.yml
@@ -28,6 +28,11 @@
       description: >
         Namespace of dynamic metricsets.
 
+    - name: metricset.period
+      type: long
+      description: >
+        Current data collection period for this events in micro seconds.
+
     - name: type
       required: true
       example: metricsets

--- a/metricbeat/docs/fields.asciidoc
+++ b/metricbeat/docs/fields.asciidoc
@@ -1852,6 +1852,16 @@ Namespace of dynamic metricsets.
 
 --
 
+*`metricset.period`*::
++
+--
+type: long
+
+Current data collection period for this events in micro seconds.
+
+
+--
+
 *`type`*::
 +
 --

--- a/metricbeat/mb/event.go
+++ b/metricbeat/mb/event.go
@@ -24,6 +24,7 @@ type Event struct {
 	Error     error         // Error that occurred while collecting the event data.
 	Host      string        // Host from which the data was collected.
 	Took      time.Duration // Amount of time it took to collect the event data.
+	Period    time.Duration // Period that is set to retrieve the events
 }
 
 // BeatEvent returns a new beat.Event containing the data this Event. It does
@@ -96,6 +97,9 @@ func AddMetricSetInfo(module, metricset string, event *Event) {
 	}
 	if event.Took > 0 {
 		info["rtt"] = event.Took / time.Microsecond
+	}
+	if event.Period > 0 {
+		info["period"] = event.Period / time.Microsecond
 	}
 	if event.Namespace != "" {
 		info["namespace"] = event.Namespace

--- a/metricbeat/mb/module/example_test.go
+++ b/metricbeat/mb/module/example_test.go
@@ -81,6 +81,7 @@ func ExampleWrapper() {
 	//   "metricset": {
 	//     "module": "fake",
 	//     "name": "eventfetcher",
+	//     "period": 10000000,
 	//     "rtt": 111
 	//   }
 	// }

--- a/metricbeat/mb/module/wrapper.go
+++ b/metricbeat/mb/module/wrapper.go
@@ -308,6 +308,9 @@ func (r reporterV2) Event(event mb.Event) bool {
 	if event.Took == 0 && !r.start.IsZero() {
 		event.Took = time.Since(r.start)
 	}
+	if r.msw.Module().Config().Period > 0 {
+		event.Period = r.msw.Module().Config().Period
+	}
 
 	if event.Timestamp.IsZero() {
 		if !r.start.IsZero() {

--- a/metricbeat/mb/testing/data_generator.go
+++ b/metricbeat/mb/testing/data_generator.go
@@ -102,6 +102,7 @@ func StandardizeEvent(ms mb.MetricSet, e mb.Event, modifiers ...mb.EventModifier
 	e.Timestamp = startTime
 	e.Took = 115 * time.Microsecond
 	e.Host = ms.Host()
+	e.Period = 10 * time.Second
 	if e.Namespace == "" {
 		e.Namespace = ms.Registration().Namespace
 	}


### PR DESCRIPTION
Having the period as part of each event makes it possible for Kibana or ML to predict when the next event is potentially missing or delayed based on the period of the previous events. It can always be that the period changed but as soon as the next event comes in, this can be used as the new expected period.

Only the schedule events will contain the `metricset.period` field.