### PR TITLE
Add "Discuss Forum URL" to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -8,4 +8,5 @@ See https://www.elastic.co/community/security for more information.
 For confirmed bugs, please report:
 - Version: 
 - Operating System: 
+- Discuss Forum URL:
 - Steps to Reproduce: 


### PR DESCRIPTION
From Disucss we ask users to open a new issue in Github issue, but sometimes they don't link back to Discuss which causes confusion on our part.