### PR TITLE
Add modules.d layout to getting started and fix Windows command examples

### DIFF
--- a/libbeat/docs/dashboards.asciidoc
+++ b/libbeat/docs/dashboards.asciidoc
@@ -18,7 +18,7 @@ command (as described here) or
 +{beatname_lc}.yml+ config file.
 
 This requires a Kibana endpoint configuration. If you didn't already configure
-a Kibana endpoint, see <<{beatname_lc}-configuration,configured {beatname_uc}>> 
+a Kibana endpoint, see <<{beatname_lc}-configuration,configure {beatname_uc}>>. 
 
 Make sure Kibana is running before you perform this step. If you are accessing a
 secured Kibana instance, make sure you've configured credentials as described in

--- a/libbeat/docs/dashboards.asciidoc
+++ b/libbeat/docs/dashboards.asciidoc
@@ -73,7 +73,7 @@ to download and install PowerShell.
 From the PowerShell prompt, change to the directory where you installed {beatname_uc},
 and run:
 
-["source","sh",subs="attributes,callouts"]
+["source","sh",subs="attributes"]
 ----------------------------------------------------------------------
-PS > {beatname_lc} setup --dashboards
+PS > .{backslash}{beatname_lc}.exe setup --dashboards
 ----------------------------------------------------------------------

--- a/libbeat/docs/shared-configuring.asciidoc
+++ b/libbeat/docs/shared-configuring.asciidoc
@@ -21,6 +21,6 @@ all non-deprecated options.
 
 endif::[]
 
-See the
+TIP: See the
 {libbeat}/config-file-format.html[Config File Format] section of the
 _Beats Platform Reference_ for more about the structure of the config file.

--- a/libbeat/docs/shared-template-load.asciidoc
+++ b/libbeat/docs/shared-template-load.asciidoc
@@ -184,7 +184,7 @@ and run:
 
 ["source","sh",subs="attributes,callouts"]
 ----------------------------------------------------------------------
-PS > .{backslash}{beatname_lc} setup --template{disable_logstash} -E 'output.elasticsearch.hosts=["localhost:9200"]'
+PS > .{backslash}{beatname_lc}.exe setup --template{disable_logstash} -E 'output.elasticsearch.hosts=["localhost:9200"]'
 ----------------------------------------------------------------------
 
 

--- a/libbeat/docs/shared-template-load.asciidoc
+++ b/libbeat/docs/shared-template-load.asciidoc
@@ -182,7 +182,7 @@ to download and install PowerShell.
 From the PowerShell prompt, change to the directory where you installed {beatname_uc},
 and run:
 
-["source","sh",subs="attributes,callouts"]
+["source","sh",subs="attributes"]
 ----------------------------------------------------------------------
 PS > .{backslash}{beatname_lc}.exe setup --template{disable_logstash} -E 'output.elasticsearch.hosts=["localhost:9200"]'
 ----------------------------------------------------------------------
@@ -239,12 +239,12 @@ ifdef::allplatforms[]
 ./{beatname_lc} export template > {beatname_lc}.template.json
 ----
 +
-*win*:
+*win:*
 +
 endif::allplatforms[]
 ["source","sh",subs="attributes"]
 ----
-PS> .{backslash}{beatname_lc}.exe export template --es.version {stack-version} | Out-File -Encoding UTF8 {beatname_lc}.template.json
+PS > .{backslash}{beatname_lc}.exe export template --es.version {stack-version} | Out-File -Encoding UTF8 {beatname_lc}.template.json
 ----
 
 . Install the template:
@@ -256,7 +256,7 @@ PS> .{backslash}{beatname_lc}.exe export template --es.version {stack-version} |
 curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_template/{beatname_lc}-{stack-version} -d@{beatname_lc}.template.json
 ----
 +
-*win*:
+*win:*
 +
 ["source","sh",subs="attributes"]
 ----

--- a/metricbeat/docs/gettingstarted.asciidoc
+++ b/metricbeat/docs/gettingstarted.asciidoc
@@ -176,6 +176,8 @@ You can either enable the default module configurations defined in the
 +{beatname_lc}.yml+ file. The `modules.d` directory contains default
 configurations for all available {beatname_uc} modules. 
 +
+If you are using a Docker image, see <<running-on-docker>>.
++
 The following examples enable the `apache` and `mysql` configs in the
 `modules.d` directory :
 +
@@ -191,13 +193,6 @@ The following examples enable the `apache` and `mysql` configs in the
 ["source","sh",subs="attributes"]
 ----
 ./{beatname_lc} modules enable apache mysql
-----
-+
-*docker*:
-+
-["source","sh",subs="attributes"]
-----
-docker run docker.elastic.co/beats/{beatname_lc}:{version} modules enable apache mysql
 ----
 +
 *win:*
@@ -280,6 +275,8 @@ sudo service {beatname_lc} start
 ----------------------------------------------------------------------
 docker run {dockerimage}
 ----------------------------------------------------------------------
+
+Also see <<running-on-docker>>.
 
 *mac:*
 

--- a/metricbeat/docs/gettingstarted.asciidoc
+++ b/metricbeat/docs/gettingstarted.asciidoc
@@ -1,10 +1,10 @@
-[[metricbeat-getting-started]]
-== Getting started with Metricbeat
+[id="{beatname_lc}-getting-started"]
+== Getting started with {beatname_uc}
 
-Metricbeat helps you monitor your servers and the services they host by
+{beatname_uc} helps you monitor your servers and the services they host by
 collecting metrics from the operating system and services.
 
-To get started with your own Metricbeat setup, install and configure these
+To get started with your own {beatname_uc} setup, install and configure these
 related products:
 
  * Elasticsearch for storage and indexing the data.
@@ -13,25 +13,25 @@ related products:
 
 See {libbeat}/getting-started.html[Getting Started with Beats and the Elastic Stack] for more information.
 
-After installing the Elastic Stack, read the following topics to learn how to install, configure, and run Metricbeat:
+After installing the Elastic Stack, read the following topics to learn how to install, configure, and run {beatname_uc}:
 
-* <<metricbeat-installation>>
-* <<metricbeat-configuration>>
-* <<metricbeat-template>>
+* <<{beatname_lc}-installation>>
+* <<{beatname_lc}-configuration>>
+* <<{beatname_lc}-template>>
 * <<load-kibana-dashboards>>
-* <<metricbeat-starting>>
+* <<{beatname_lc}-starting>>
 * <<view-kibana-dashboards>>
 * <<setup-repositories>>
 
-[[metricbeat-installation]]
-=== Step 1: Install Metricbeat
+[id="{beatname_lc}-installation"]
+=== Step 1: Install {beatname_uc}
 
-You should install Metricbeat as close as possible to the service you want to
+You should install {beatname_uc} as close as possible to the service you want to
 monitor. For example, if you have four servers with MySQL running, it's
-recommended that you run Metricbeat on each server. This allows Metricbeat to
+recommended that you run {beatname_uc} on each server. This allows {beatname_uc} to
 access your service from localhost and does not cause any additional network
-traffic or prevent Metricbeat from collecting metrics when there are network
-problems. Metrics from multiple Metricbeat instances will be combined on the
+traffic or prevent {beatname_uc} from collecting metrics when there are network
+problems. Metrics from multiple {beatname_uc} instances will be combined on the
 Elasticsearch server.
 
 include::../../libbeat/docs/shared-download-and-install.asciidoc[]
@@ -47,10 +47,10 @@ endif::[]
 
 ifeval::["{release-state}"!="unreleased"]
 
-["source","sh",subs="attributes,callouts"]
+["source","sh",subs="attributes"]
 ------------------------------------------------
-curl -L -O https://artifacts.elastic.co/downloads/beats/metricbeat/metricbeat-{version}-amd64.deb
-sudo dpkg -i metricbeat-{version}-amd64.deb
+curl -L -O https://artifacts.elastic.co/downloads/beats/{beatname_lc}/{beatname_lc}-{version}-amd64.deb
+sudo dpkg -i {beatname_lc}-{version}-amd64.deb
 ------------------------------------------------
 
 endif::[]
@@ -66,10 +66,10 @@ endif::[]
 
 ifeval::["{release-state}"!="unreleased"]
 
-["source","sh",subs="attributes,callouts"]
+["source","sh",subs="attributes"]
 ------------------------------------------------
-curl -L -O https://artifacts.elastic.co/downloads/beats/metricbeat/metricbeat-{version}-x86_64.rpm
-sudo rpm -vi metricbeat-{version}-x86_64.rpm
+curl -L -O https://artifacts.elastic.co/downloads/beats/{beatname_lc}/{beatname_lc}-{version}-x86_64.rpm
+sudo rpm -vi {beatname_lc}-{version}-x86_64.rpm
 ------------------------------------------------
 
 endif::[]
@@ -85,10 +85,10 @@ endif::[]
 
 ifeval::["{release-state}"!="unreleased"]
 
-["source","sh",subs="attributes,callouts"]
+["source","sh",subs="attributes"]
 ------------------------------------------------
-curl -L -O https://artifacts.elastic.co/downloads/beats/metricbeat/metricbeat-{version}-darwin-x86_64.tar.gz
-tar xzvf metricbeat-{version}-darwin-x86_64.tar.gz
+curl -L -O https://artifacts.elastic.co/downloads/beats/{beatname_lc}/{beatname_lc}-{version}-darwin-x86_64.tar.gz
+tar xzvf {beatname_lc}-{version}-darwin-x86_64.tar.gz
 ------------------------------------------------
 
 endif::[]
@@ -122,37 +122,37 @@ endif::[]
 
 ifeval::["{release-state}"!="unreleased"]
 
-. Download the Metricbeat Windows zip file from the
-https://www.elastic.co/downloads/beats/metricbeat[downloads page].
+. Download the {beatname_uc} Windows zip file from the
+https://www.elastic.co/downloads/beats/{beatname_lc}[downloads page].
 
 . Extract the contents of the zip file into `C:\Program Files`.
 
-. Rename the `metricbeat-<version>-windows` directory to `Metricbeat`.
+. Rename the +{beatname_lc}-<version>-windows+` directory to +{beatname_uc}+.
 
 . Open a PowerShell prompt as an Administrator (right-click the PowerShell icon
 and select *Run As Administrator*). If you are running Windows XP, you may need
 to download and install PowerShell.
 
-. From the PowerShell prompt, run the following commands to install Metricbeat
+. From the PowerShell prompt, run the following commands to install {beatname_uc}
 as a Windows service:
 +
-[source,shell]
+["source","sh",subs="attributes"]
 ----------------------------------------------------------------------
-PS > cd 'C:\Program Files\Metricbeat'
-PS C:\Program Files\Metricbeat> .\install-service-metricbeat.ps1
+PS > cd 'C:{backslash}Program Files{backslash}{beatname_uc}'
+PS C:{backslash}Program Files{backslash}{beatname_uc}> .{backslash}install-service-{beatname_lc}.ps1
 ----------------------------------------------------------------------
 
 NOTE: If script execution is disabled on your system, you need to set the
 execution policy for the current session to allow the script to run. For
-example: `PowerShell.exe -ExecutionPolicy UnRestricted -File
-.\install-service-metricbeat.ps1`.
+example: +PowerShell.exe -ExecutionPolicy UnRestricted -File
+.{backslash}install-service-{beatname_lc}.ps1+.
 
 endif::[]
 
-Before starting Metricbeat, you should look at the configuration options in the
-configuration file, for example `C:\Program Files\Metricbeat\metricbeat.yml`.
+Before starting {beatname_uc}, you should look at the configuration options in the
+configuration file, for example +C:{backslash}Program Files{backslash}{beatname_uc}{backslash}{beatname_lc}.yml+.
 For more information about these options, see
-<<configuring-howto-metricbeat>>.
+<<configuring-howto-{beatname_lc}>>.
 
 [id="{beatname_lc}-configuration"]
 === Step 2: Configure {beatname_uc}
@@ -160,22 +160,21 @@ For more information about these options, see
 include::../../libbeat/docs/shared-configuring.asciidoc[]
 
 When you configure {beatname_uc}, you need to specify which
-<<metricbeat-modules,modules>> to run. {beatname_uc} uses modules to collect
+<<{beatname_lc}-modules,modules>> to run. {beatname_uc} uses modules to collect
 metrics. Each module defines the basic logic for collecting data from a specific
 service, such as Redis or MySQL. A module consists of metricsets that fetch and
-structure the data. Read <<how-metricbeat-works>> to learn more.
+structure the data. Read <<how-{beatname_lc}-works>> to learn more.
 
-To configure Metricbeat:
+To configure {beatname_uc}:
 
-. Enable the modules that you want to run.
+. Enable the modules that you want to run. If you accept the default
+configuration without enabling additional modules, {beatname_uc} collects system
+metrics only.
 +
 You can either enable the default module configurations defined in the
 `modules.d` directory (recommended), or add the module configs to the
-+{beatname_lc}.yml+ file.
-+
-The `modules.d` directory contains default configurations for all available
-{beatname_uc} modules. If you accept the default configuration without enabling
-additional modules, {beatname_uc} collects system metrics only.
++{beatname_lc}.yml+ file. The `modules.d` directory contains default
+configurations for all available {beatname_uc} modules. 
 +
 The following examples enable the `apache` and `mysql` configs in the
 `modules.d` directory :
@@ -198,14 +197,14 @@ The following examples enable the `apache` and `mysql` configs in the
 +
 ["source","sh",subs="attributes"]
 ----
-docker run docker.elastic.co/beats/metricbeat:{version} modules enable apache mysql
+docker run docker.elastic.co/beats/{beatname_lc}:{version} modules enable apache mysql
 ----
 +
-*win*:
+*win:*
 +
 ["source","sh",subs="attributes"]
 ----
-PS> .{backslash}{beatname_lc}.exe modules enable apache mysql
+PS > .{backslash}{beatname_lc}.exe modules enable apache mysql
 ----
 +
 See the <<modules-command>> to learn more about this command.
@@ -214,11 +213,11 @@ To change the default module configurations, modify the `.yml` files in the
 `modules.d` directory. See <<module-config-options>> for more about available
 settings.
 +
-See <<configuration-metricbeat>> if you want to add the module configs to the
+See <<configuration-{beatname_lc}>> if you want to add the module configs to the
 +{beatname_lc}.yml+ file rather than using the `modules.d` directory.
 
 . If you are sending output directly to Elasticsearch (and not using Logstash),
-set the IP address and port where Metricbeat can find the Elasticsearch
+set the IP address and port where {beatname_uc} can find the Elasticsearch
 installation. For example:
 +
 [source,yaml]
@@ -238,7 +237,7 @@ include::../../libbeat/docs/step-test-config.asciidoc[]
 
 include::../../libbeat/docs/step-look-at-config.asciidoc[]
 
-[[metricbeat-template]]
+[id="{beatname_lc}-template"]
 === Step 3: Load the index template in Elasticsearch
 
 :allplatforms:
@@ -250,16 +249,16 @@ include::../../libbeat/docs/shared-template-load.asciidoc[]
 :allplatforms:
 include::../../libbeat/docs/dashboards.asciidoc[]
 
-[[metricbeat-starting]]
-=== Step 5: Start Metricbeat
+[id="{beatname_lc}-starting"]
+=== Step 5: Start {beatname_uc}
 
-Run Metricbeat by issuing the appropriate command for your platform. If you
+Run {beatname_uc} by issuing the appropriate command for your platform. If you
 are accessing a secured Elasticsearch cluster, make sure you've configured
 credentials as described in <<{beatname_lc}-configuration>>.
 
-NOTE: If you use an init.d script to start Metricbeat on deb or rpm, you can't
+NOTE: If you use an init.d script to start {beatname_uc} on deb or rpm, you can't
 specify command line flags (see <<command-line-options>>). To specify flags,
-start Metricbeat in the foreground.
+start {beatname_uc} in the foreground.
 
 *deb:*
 
@@ -284,38 +283,38 @@ docker run {dockerimage}
 
 *mac:*
 
-[source,shell]
+["source","sh",subs="attributes,callouts"]
 ----------------------------------------------------------------------
-sudo chown root metricbeat.yml <1>
+sudo chown root {beatname_lc}.yml <1>
 sudo chown root modules.d/system.yml <1>
-sudo ./metricbeat -e -c metricbeat.yml -d "publish"
+sudo ./{beatname_lc} -e -c {beatname_lc}.yml -d "publish"
 ----------------------------------------------------------------------
-<1> You'll be running Metricbeat as root, so you need to change ownership of the
+<1> You'll be running {beatname_uc} as root, so you need to change ownership of the
 configuration file and any configurations enabled in the `modules.d` directory,
-or run Metricbeat with `-strict.perms=false` specified. See
+or run {beatname_uc} with `-strict.perms=false` specified. See
 {libbeat}/config-file-permissions.html[Config File Ownership and Permissions]
 in the _Beats Platform Reference_.
 
 *win:*
 
-[source,shell]
+["source","sh",subs="attributes"]
 ----------------------------------------------------------------------
-PS C:\Program Files\Metricbeat> Start-Service metricbeat
+PS C:{backslash}Program Files{backslash}{beatname_uc}> Start-Service {beatname_lc}
 ----------------------------------------------------------------------
 
-By default the log files are stored in `C:\ProgramData\metricbeat\Logs`.
+By default the log files are stored in +C:{backslash}ProgramData{backslash}{beatname_lc}{backslash}Logs+.
 
 NOTE: On Windows, statistics about system load and swap usage are currently
 not captured.
 
-==== Test the Metricbeat installation
+==== Test the {beatname_uc} installation
 
 To verify that your server's statistics are present in Elasticsearch, issue
 the following command:
 
-[source,shell]
+["source","sh",subs="attributes"]
 ----------------------------------------------------------------------
-curl -XGET 'http://localhost:9200/metricbeat-*/_search?pretty'
+curl -XGET 'http://localhost:9200/{beatname_lc}-*/_search?pretty'
 ----------------------------------------------------------------------
 
 Make sure that you replace `localhost:9200` with the address of your
@@ -337,4 +336,4 @@ The dashboards are provided as examples. We recommend that you
 {kibana-ref}/dashboard.html[customize] them to meet your needs.
 
 [role="screenshot"]
-image:./images/metricbeat_system_dashboard.png[Metricbeat Dashboard]
+image:./images/{beatname_lc}_system_dashboard.png[{beatname_uc} Dashboard]

--- a/metricbeat/docs/gettingstarted.asciidoc
+++ b/metricbeat/docs/gettingstarted.asciidoc
@@ -271,12 +271,7 @@ sudo service {beatname_lc} start
 
 *docker:*
 
-["source", "shell", subs="attributes"]
-----------------------------------------------------------------------
-docker run {dockerimage}
-----------------------------------------------------------------------
-
-Also see <<running-on-docker>>.
+See <<running-on-docker>>.
 
 *mac:*
 

--- a/metricbeat/docs/gettingstarted.asciidoc
+++ b/metricbeat/docs/gettingstarted.asciidoc
@@ -154,68 +154,72 @@ configuration file, for example `C:\Program Files\Metricbeat\metricbeat.yml`.
 For more information about these options, see
 <<configuring-howto-metricbeat>>.
 
-[[metricbeat-configuration]]
-=== Step 2: Configure Metricbeat
+[id="{beatname_lc}-configuration"]
+=== Step 2: Configure {beatname_uc}
 
 include::../../libbeat/docs/shared-configuring.asciidoc[]
 
-Metricbeat uses <<metricbeat-modules,modules>> to collect metrics. You configure
-each module individually. The following example shows the default configuration
-in the `metricbeat.yml` file. The system status module is enabled by default to
-collect metrics about your server, such as CPU usage, memory usage, network IO
-metrics, and process statistics:
-
-[source, shell]
--------------------------------------
-metricbeat.modules:
-- module: system
-  metricsets:
-    - cpu
-    - filesystem
-    - memory
-    - network
-    - process
-  enabled: true
-  period: 10s
-  processes: ['.*']
-  cpu_ticks: false
--------------------------------------
-
-The following example shows how to configure two modules: the system module
-and the Apache HTTPD module:
-
-[source, shell]
--------------------------------------
-metricbeat.modules:
-- module: system
-  metricsets:
-    - cpu
-    - filesystem
-    - memory
-    - network
-    - process
-  enabled: true
-  period: 10s
-  processes: ['.*']
-  cpu_ticks: false
-- module: apache
-  metricsets: ["status"]
-  enabled: true
-  period: 1s
-  hosts: ["http://127.0.0.1"]
--------------------------------------
+When you configure {beatname_uc}, you need to specify which
+<<metricbeat-modules,modules>> to run. {beatname_uc} uses modules to collect
+metrics. Each module defines the basic logic for collecting data from a specific
+service, such as Redis or MySQL. A module consists of metricsets that fetch and
+structure the data. Read <<how-metricbeat-works>> to learn more.
 
 To configure Metricbeat:
 
-. Define the Metricbeat modules that you want to enable. For each module, specify
-the metricsets that you want to collect. See <<configuring-howto-metricbeat>> for
-more details about configuring modules.
+. Enable the modules that you want to run.
 +
-If you accept the default configuration without specifying additional modules,
-Metricbeat will collect system metrics only.
+You can either enable the default module configurations defined in the
+`modules.d` directory (recommended), or add the module configs to the
++{beatname_lc}.yml+ file.
++
+The `modules.d` directory contains default configurations for all available
+{beatname_uc} modules. If you accept the default configuration without enabling
+additional modules, {beatname_uc} collects system metrics only.
++
+The following examples enable the `apache` and `mysql` configs in the
+`modules.d` directory :
++
+*deb and rpm:*
++
+["source","sh",subs="attributes"]
+----
+{beatname_lc} modules enable apache mysql
+----
++
+*mac:*
++
+["source","sh",subs="attributes"]
+----
+./{beatname_lc} modules enable apache mysql
+----
++
+*docker*:
++
+["source","sh",subs="attributes"]
+----
+docker run docker.elastic.co/beats/metricbeat:{version} modules enable apache mysql
+----
++
+*win*:
++
+["source","sh",subs="attributes"]
+----
+PS> .{backslash}{beatname_lc}.exe modules enable apache mysql
+----
++
+See the <<modules-command>> to learn more about this command.
++
+To change the default module configurations, modify the `.yml` files in the
+`modules.d` directory. See <<module-config-options>> for more about available
+settings.
++
+See <<configuration-metricbeat>> if you want to add the module configs to the
++{beatname_lc}.yml+ file rather than using the `modules.d` directory.
 
 . If you are sending output directly to Elasticsearch (and not using Logstash),
-set the IP address and port where Metricbeat can find the Elasticsearch installation:
+set the IP address and port where Metricbeat can find the Elasticsearch
+installation. For example:
 +
 [source,yaml]
 ----------------------------------------------------------------------
@@ -332,4 +336,5 @@ include::../../libbeat/docs/opendashboards.asciidoc[]
 The dashboards are provided as examples. We recommend that you
 {kibana-ref}/dashboard.html[customize] them to meet your needs.
 
+[role="screenshot"]
 image:./images/metricbeat_system_dashboard.png[Metricbeat Dashboard]

--- a/metricbeat/docs/metricbeat-options.asciidoc
+++ b/metricbeat/docs/metricbeat-options.asciidoc
@@ -157,8 +157,7 @@ The name of the module to run. For documentation about each module, see the
 
 A list of metricsets to execute. Make sure that you only list metricsets that
 are available in the module. It is not possible to reference metricsets from
-other modules. For a list of available metricsets, see the documentation for the
-module.
+other modules. For a list of available metricsets, see <<metricbeat-modules>>.
 
 [float]
 ==== `enabled`

--- a/metricbeat/docs/metricbeat-options.asciidoc
+++ b/metricbeat/docs/metricbeat-options.asciidoc
@@ -139,6 +139,7 @@ the `set2` metricset will be fetched every 2 minutes:
 
 
 [float]
+[[module-config-options]]
 === Standard config options
 
 You can specify the following options for any Metricbeat module. Some modules


### PR DESCRIPTION
Fixes https://github.com/elastic/beats/issues/5512 and https://github.com/elastic/beats/issues/6196

I've also changed the metricbeat getting started to use asciidoc attributes to resolve "metricbeat" and "Metricbeat". My goal is to convert all the topics over to using attributes, but I don't want to open a big PR for those changes because it's easier for me to check for mistakes if I make the changes in smaller batches. 

Question for reviewers:

One thing that's missing here is advice on enabling/disabling metricsets. Do we want to mention that step in the getting started, or leave users to read the configuration reference docs if they want to change the defaults?