### PR TITLE
Change to snapshot testing for Elastic Stack

### DIFF
--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -62,7 +62,7 @@ GOX_OSARCH?=!darwin/arm !darwin/arm64 !darwin/386 ## @building Space separated l
 GOX_FLAGS?= ## @building Additional flags to append to the gox command used by "make crosscompile".
 # XXX: Should be switched back to `snapshot` once the Elasticsearch
 # snapshots are working. https://github.com/elastic/beats/pull/6416
-TESTING_ENVIRONMENT?=latest## @testing The name of the environment under test
+TESTING_ENVIRONMENT?=snapshot## @testing The name of the environment under test
 BEAT_VERSION=$(shell head -n 1 ${ES_BEATS}/libbeat/docs/version.asciidoc | cut -c 17- )
 COMMIT_ID=$(shell git rev-parse HEAD)
 DOCKER_COMPOSE_PROJECT_NAME?=${BEAT_NAME}${TESTING_ENVIRONMENT//-}${COMMIT_ID} ## @testing The name of the docker-compose project used by the integration and system tests

--- a/metricbeat/module/logstash/node_stats/node_stats_integration_test.go
+++ b/metricbeat/module/logstash/node_stats/node_stats_integration_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestFetch(t *testing.T) {
-	compose.EnsureUpWithTimeout(t, 120, "logstash")
+	compose.EnsureUpWithTimeout(t, 300, "logstash")
 
 	f := mbtest.NewEventFetcher(t, logstash.GetConfig("node_stats"))
 	event, err := f.Fetch()

--- a/metricbeat/tests/system/test_logstash.py
+++ b/metricbeat/tests/system/test_logstash.py
@@ -7,8 +7,7 @@ import time
 class Test(metricbeat.BaseTest):
 
     COMPOSE_SERVICES = ['logstash']
-
-    COMPOSE_TIMEOUT = 120
+    COMPOSE_TIMEOUT = 300
 
     @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
     def test_node(self):

--- a/testing/environments/args.yml
+++ b/testing/environments/args.yml
@@ -7,4 +7,4 @@ services:
       args:
         DOWNLOAD_URL: https://snapshots.elastic.co/downloads
         ELASTIC_VERSION: 7.0.0-alpha1-SNAPSHOT
-        CACHE_BUST: 20180424
+        CACHE_BUST: 20180501


### PR DESCRIPTION
As the snapshot builds were not working we switched to the latest environments for the tests. Now that the snapshots are running again this change can be reverted.