### PR TITLE
Increase health retries for LS image.

### DIFF
--- a/metricbeat/module/logstash/_meta/Dockerfile
+++ b/metricbeat/module/logstash/_meta/Dockerfile
@@ -2,4 +2,4 @@ FROM docker.elastic.co/logstash/logstash:6.2.4
 
 COPY healthcheck.sh /
 ENV XPACK_MONITORING_ENABLED=FALSE
-HEALTHCHECK --interval=1s --retries=90 CMD sh /healthcheck.sh
+HEALTHCHECK --interval=1s --retries=300 CMD sh /healthcheck.sh


### PR DESCRIPTION
It seems with 6.2.4 Logstash takes longer to start and sometimes exceeds the 90s set so far. This increases the checks to 300s.

One other odd / interesting thing I spotted during testing that the `events.in` metrics is `null` and not `0` on the first request. This should not cause issues on our side but its interesting to know.