### PR TITLE
[DOCS] Fixes URL for Stack Overview

### DIFF
--- a/libbeat/docs/shared-beats-attributes.asciidoc
+++ b/libbeat/docs/shared-beats-attributes.asciidoc
@@ -10,8 +10,8 @@
 :logstashdoc: https://www.elastic.co/guide/en/logstash/{doc-branch}
 :elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/{doc-branch}
 :elasticsearch-plugins: https://www.elastic.co/guide/en/elasticsearch/plugins/{doc-branch}
-:securitydoc: https://www.elastic.co/guide/en/x-pack/{doc-branch}
-:monitoringdoc: https://www.elastic.co/guide/en/x-pack/{doc-branch}
+:securitydoc: https://www.elastic.co/guide/en/elastic-stack-overview/{doc-branch}
+:monitoringdoc: https://www.elastic.co/guide/en/elastic-stack-overview/{doc-branch}
 :security: X-Pack Security
 :dashboards: https://artifacts.elastic.co/downloads/beats/beats-dashboards/beats-dashboards-{stack-version}.zip
 :dockerimage: docker.elastic.co/beats/{beatname_lc}:{version}


### PR DESCRIPTION
This PR updates the URLs for the new location of the monitoring and security information in 6.3, 6.x, and master branches. 