### PR TITLE
Better error handling in fsnotify recursive monitor

### DIFF
--- a/auditbeat/module/file_integrity/monitor/monitor_test.go
+++ b/auditbeat/module/file_integrity/monitor/monitor_test.go
@@ -181,7 +181,7 @@ func TestRecursiveSubdirPermissions(t *testing.T) {
 
 	assertNoError(t, os.Chmod(filepath.Join(outDir, "b"), 0))
 
-	// Setup watched on watched dir
+	// Setup watches on watched dir
 
 	watcher, err := New(true)
 	assertNoError(t, err)


### PR DESCRIPTION
When the recursive `file_monitor` is scanning a directory, it will ignore paths that include an error. This is wrong, as sometimes those paths can still be processed. For example, a directory might not be readable, but the user wants to receive an event when it is created, even if its contents can't be known.

This has been uncovered by recent changes in how directory errors are reported by `filepath.Walk`, introduced in Go 1.10. Previously `walkFn` would be called twice. Once without an error (when the directory has been found during scan of the parent directory), and the second time with an error (when access to the directory is attempted).

Fixes auditbeat test failure in #6948