### PR TITLE
Change testing to use 6.3 snapshot

### DIFF
--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -62,7 +62,7 @@ GOX_OSARCH?=!darwin/arm !darwin/arm64 !darwin/386 ## @building Space separated l
 GOX_FLAGS?= ## @building Additional flags to append to the gox command used by "make crosscompile".
 # XXX: Should be switched back to `snapshot` once the Elasticsearch
 # snapshots are working. https://github.com/elastic/beats/pull/6416
-TESTING_ENVIRONMENT?=latest## @testing The name of the environment under test
+TESTING_ENVIRONMENT?=snapshot## @testing The name of the environment under test
 BEAT_VERSION=$(shell head -n 1 ${ES_BEATS}/libbeat/docs/version.asciidoc | cut -c 17- )
 COMMIT_ID=$(shell git rev-parse HEAD)
 DOCKER_COMPOSE_PROJECT_NAME?=${BEAT_NAME}${TESTING_ENVIRONMENT}${COMMIT_ID} ## @testing The name of the docker-compose project used by the integration and system tests

--- a/testing/environments/args.yml
+++ b/testing/environments/args.yml
@@ -5,6 +5,6 @@ services:
   args:
     build:
       args:
-        DOWNLOAD_URL: https://snapshots.elastic.co/downloads
-        ELASTIC_VERSION: 6.3.0-SNAPSHOT
+        DOWNLOAD_URL: https://staging.elastic.co/6.3.0-6de43690/downloads
+        ELASTIC_VERSION: 6.3.0
         CACHE_BUST: 20180424


### PR DESCRIPTION
Reenabling shapshot tests and using most recent staging build for 6.3.