### PR TITLE
Disable fsnotify recursive test under Darwin

### DIFF
--- a/auditbeat/module/file_integrity/monitor/monitor_test.go
+++ b/auditbeat/module/file_integrity/monitor/monitor_test.go
@@ -56,6 +56,14 @@ func TestNonRecursive(t *testing.T) {
 }
 
 func TestRecursive(t *testing.T) {
+	if runtime.GOOS == "darwin" {
+		// This test races on Darwin because internal races in the kqueue
+		// implementation of fsnotify when a watch is added in response to
+		// a subdirectory created inside a watched directory.
+		// This race doesn't affect auditbeat because the file_integrity module
+		// under Darwin uses fsevents instead of kqueue.
+		t.Skip("Disabled on Darwin")
+	}
 	dir, err := ioutil.TempDir("", "monitor")
 	assertNoError(t, err)
 	// under macOS, temp dir has a symlink in the path (/var -> /private/var)


### PR DESCRIPTION
A race has been discovered in the kqueue implementation of fsnotify which causes installation of a watch to a subdirectory of an already watched directory to fail occasionally.

Disabled the test because Auditbeat doesn't use fsnotify under Darwin, so there is no point on testing it anyway.

From my investigation it resulted that sometimes a directory creation event from the kernel is received twice. In Auditbeat, we react to the first one by adding a watch to the directory. Once the second event arrives, fsnotify overwrites the watch with an internal one, as it needs to install a watch on every file and directory it monitors. This second watch registers to receive events from the kernel when the directory is moved or deleted, but ignores when files are added to the directory.
