### PR TITLE
Update URL to -oss artifacts

### DIFF
--- a/testing/environments/docker/elasticsearch/download.sh
+++ b/testing/environments/docker/elasticsearch/download.sh
@@ -5,7 +5,7 @@ if [ -z ${DOWNLOAD_URL+x} ]; then echo "DOWNLOAD_URL is unset"; exit 1; fi
 if [ -z ${ELASTIC_VERSION+x} ]; then echo "ELASTIC_VERSION is unset"; exit 1; fi
 if [ -z ${IMAGE_FLAVOR+x} ]; then echo "IMAGE_FLAVOR is unset"; exit 1; fi
 
-url=${DOWNLOAD_URL}/elasticsearch/elasticsearch-oss/elasticsearch-oss-${ELASTIC_VERSION}.tar.gz
+url=${DOWNLOAD_URL}/elasticsearch/elasticsearch-oss-${ELASTIC_VERSION}.tar.gz
 if [ "${IMAGE_FLAVOR}" = "x-pack" ]; then
   url=${DOWNLOAD_URL}/elasticsearch/elasticsearch-${ELASTIC_VERSION}.tar.gz
 fi

--- a/testing/environments/docker/kibana/download.sh
+++ b/testing/environments/docker/kibana/download.sh
@@ -5,7 +5,7 @@ if [ -z ${DOWNLOAD_URL+x} ]; then echo "DOWNLOAD_URL is unset"; exit 1; fi
 if [ -z ${ELASTIC_VERSION+x} ]; then echo "ELASTIC_VERSION is unset"; exit 1; fi
 if [ -z ${IMAGE_FLAVOR+x} ]; then echo "IMAGE_FLAVOR is unset"; exit 1; fi
 
-url=${DOWNLOAD_URL}/kibana/kibana-oss/kibana-oss-${ELASTIC_VERSION}-linux-x86_64.tar.gz
+url=${DOWNLOAD_URL}/kibana/kibana-oss-${ELASTIC_VERSION}-linux-x86_64.tar.gz
 if [ "${IMAGE_FLAVOR}" = "x-pack" ]; then
   url=${DOWNLOAD_URL}/kibana/kibana-${ELASTIC_VERSION}-linux-x86_64.tar.gz
 fi

--- a/testing/environments/docker/logstash/download.sh
+++ b/testing/environments/docker/logstash/download.sh
@@ -5,7 +5,7 @@ if [ -z ${DOWNLOAD_URL+x} ]; then echo "DOWNLOAD_URL is unset"; exit 1; fi
 if [ -z ${ELASTIC_VERSION+x} ]; then echo "ELASTIC_VERSION is unset"; exit 1; fi
 if [ -z ${IMAGE_FLAVOR+x} ]; then echo "IMAGE_FLAVOR is unset"; exit 1; fi
 
-url=${DOWNLOAD_URL}/logstash/logstash-oss/logstash-oss-${ELASTIC_VERSION}.tar.gz
+url=${DOWNLOAD_URL}/logstash/logstash-oss-${ELASTIC_VERSION}.tar.gz
 if [ "${IMAGE_FLAVOR}" = "x-pack" ]; then
   url=${DOWNLOAD_URL}/logstash/logstash-${ELASTIC_VERSION}.tar.gz
 fi


### PR DESCRIPTION
The URL to ES, LS, and Kibana OSS artifacts have changed. These
are used in the snapshot-noxpack environment.