### PR TITLE
Remove `-` char from docker-compose project name

### DIFF
--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -65,7 +65,7 @@ GOX_FLAGS?= ## @building Additional flags to append to the gox command used by "
 TESTING_ENVIRONMENT?=latest## @testing The name of the environment under test
 BEAT_VERSION=$(shell head -n 1 ${ES_BEATS}/libbeat/docs/version.asciidoc | cut -c 17- )
 COMMIT_ID=$(shell git rev-parse HEAD)
-DOCKER_COMPOSE_PROJECT_NAME?=${BEAT_NAME}${TESTING_ENVIRONMENT}${COMMIT_ID} ## @testing The name of the docker-compose project used by the integration and system tests
+DOCKER_COMPOSE_PROJECT_NAME?=${BEAT_NAME}${TESTING_ENVIRONMENT//-}${COMMIT_ID} ## @testing The name of the docker-compose project used by the integration and system tests
 DOCKER_COMPOSE?=TESTING_ENVIRONMENT=${TESTING_ENVIRONMENT} ES_BEATS=${ES_BEATS} docker-compose -p ${DOCKER_COMPOSE_PROJECT_NAME} -f docker-compose.yml
 DOCKER_CACHE?=1 ## @miscellaneous If set to 0, all docker images are created without cache
 GOPACKAGES_COMMA_SEP=$(subst $(space),$(comma),$(strip ${GOPACKAGES}))


### PR DESCRIPTION
New docker-compose version ignores these chars, but libcompose is still
using them. To avoid errors we remove it from the name.

master is currently not affected, but this remove ensures this same
issue doesn't bite us in the future