### PR TITLE
Support MySQL 5.7.19 by mysql/slowlog

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -140,6 +140,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Release config reloading feature as GA. {pull}6891[6891]
 - Add support human friendly size for the UDP input. {pull}6886[6886]
 - Add Syslog input to ingest RFC3164 Events via TCP and UDP {pull}6842[6842]
+- Support MySQL 5.7.19 by mysql/slowlog {pull}6969[6969]
 
 *Heartbeat*
 

--- a/filebeat/module/mysql/slowlog/ingest/pipeline.json
+++ b/filebeat/module/mysql/slowlog/ingest/pipeline.json
@@ -4,7 +4,7 @@
     "grok": {
       "field": "message",
       "patterns":[
-        "^# User@Host: %{USER:mysql.slowlog.user}(\\[[^\\]]+\\])? @ %{HOSTNAME:mysql.slowlog.host} \\[(%{IP:mysql.slowlog.ip})?\\](\\s*Id:\\s* %{NUMBER:mysql.slowlog.id})?\n# Query_time: %{NUMBER:mysql.slowlog.query_time.sec}\\s* Lock_time: %{NUMBER:mysql.slowlog.lock_time.sec}\\s* Rows_sent: %{NUMBER:mysql.slowlog.rows_sent}\\s* Rows_examined: %{NUMBER:mysql.slowlog.rows_examined}\n(SET timestamp=%{NUMBER:mysql.slowlog.timestamp};\n)?%{GREEDYMULTILINE:mysql.slowlog.query}"
+        "^# User@Host: %{USER:mysql.slowlog.user}(\\[[^\\]]+\\])? @ (%{HOSTNAME:mysql.slowlog.host})? \\[(%{IP:mysql.slowlog.ip})?\\](\\s*Id:\\s* %{NUMBER:mysql.slowlog.id})?\n# Query_time: %{NUMBER:mysql.slowlog.query_time.sec}\\s* Lock_time: %{NUMBER:mysql.slowlog.lock_time.sec}\\s* Rows_sent: %{NUMBER:mysql.slowlog.rows_sent}\\s* Rows_examined: %{NUMBER:mysql.slowlog.rows_examined}\n(SET timestamp=%{NUMBER:mysql.slowlog.timestamp};\n)?%{GREEDYMULTILINE:mysql.slowlog.query}"
         ],
       "pattern_definitions" : {
         "GREEDYMULTILINE" : "(.|\n)*"

--- a/filebeat/module/mysql/slowlog/test/mysql-debian-5.7.19.log
+++ b/filebeat/module/mysql/slowlog/test/mysql-debian-5.7.19.log
@@ -1,0 +1,5 @@
+# User@Host: root[root] @  [172.17.0.11]  Id:     5
+# Query_time: 0.000100  Lock_time: 0.000033 Rows_sent: 101  Rows_examined: 101
+SET timestamp=1524768632;
+SELECT intcol1,charcol1 FROM t1;
+# Time: 2018-04-26T18:50:32.437295Z


### PR DESCRIPTION
* Make `mysql.slowlog.host` optional.
* Rename `@timestamp` to `read_timestamp` before transforming logs timestamp.

Output of pipeline tester:
```
$ ./scripts/tester/execute_pipeline --pipeline "module/mysql/slowlog/ingest/pipeline.json" \
--log '# User@Host: root[root] @  [172.17.0.11]  Id:     5
# Query_time: 0.000100  Lock_time: 0.000033 Rows_sent: 101  Rows_examined: 101
SET timestamp=1524768632;
SELECT intcol1,charcol1 FROM t1;
# Time: 2018-04-26T18:50:32.437295Z' \
--verbose
{
  "docs": [
    {
      "doc": {
        "_id": "id",
        "_index": "index",
        "_ingest": {
          "timestamp": "2018-04-27T20:06:01.986Z"
        },
        "_source": {
          "@timestamp": "2018-04-26T18:50:32.000Z",
          "mysql": {
            "slowlog": {
              "id": "5",
              "ip": "172.17.0.11",
              "lock_time": {
                "sec": "0.000033"
              },
              "query": "SELECT intcol1,charcol1 FROM t1;\n# Time: 2018-04-26T18:50:32.437295Z",
              "query_time": {
                "sec": "0.000100"
              },
              "rows_examined": "101",
              "rows_sent": "101",
              "timestamp": "1524768632",
              "user": "root"
            }
          },
          "read_timestamp": "2018-04-27T20:06:01.974Z"
        },
        "_type": "doc"
      }
    }
  ]
}
```

Closes #6882 
Closes #6492 