### PR TITLE
Make template processing methods public

### DIFF
--- a/libbeat/template/processor.go
+++ b/libbeat/template/processor.go
@@ -18,7 +18,7 @@ var (
 // This includes all entries without special handling for different versions.
 // Currently this is:
 // long, geo_point, date, short, byte, float, double, boolean
-func (p *Processor) process(fields common.Fields, path string, output common.MapStr) error {
+func (p *Processor) Process(fields common.Fields, path string, output common.MapStr) error {
 	for _, field := range fields {
 
 		if field.Name == "" {
@@ -70,7 +70,7 @@ func (p *Processor) process(fields common.Fields, path string, output common.Map
 				}
 			}
 
-			if err := p.process(field.Fields, newPath, properties); err != nil {
+			if err := p.Process(field.Fields, newPath, properties); err != nil {
 				return err
 			}
 			mapping["properties"] = properties
@@ -183,7 +183,7 @@ func (p *Processor) text(f *common.Field) common.MapStr {
 
 	if len(f.MultiFields) > 0 {
 		fields := common.MapStr{}
-		p.process(f.MultiFields, "", fields)
+		p.Process(f.MultiFields, "", fields)
 		properties["fields"] = fields
 	}
 

--- a/libbeat/template/processor.go
+++ b/libbeat/template/processor.go
@@ -7,6 +7,7 @@ import (
 	"github.com/elastic/beats/libbeat/common"
 )
 
+// Processor struct to process fields to template
 type Processor struct {
 	EsVersion common.Version
 }
@@ -15,9 +16,7 @@ var (
 	defaultScalingFactor = 1000
 )
 
-// This includes all entries without special handling for different versions.
-// Currently this is:
-// long, geo_point, date, short, byte, float, double, boolean
+// Process recursively processes the given fields and writes the template in the given output
 func (p *Processor) Process(fields common.Fields, path string, output common.MapStr) error {
 	for _, field := range fields {
 

--- a/libbeat/template/processor_test.go
+++ b/libbeat/template/processor_test.go
@@ -330,7 +330,7 @@ func TestPropertiesCombine(t *testing.T) {
 	}
 
 	p := Processor{EsVersion: *version}
-	err = p.process(fields, "", output)
+	err = p.Process(fields, "", output)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -378,7 +378,7 @@ func TestProcessNoName(t *testing.T) {
 	}
 
 	p := Processor{EsVersion: *version}
-	err = p.process(fields, "", output)
+	err = p.Process(fields, "", output)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libbeat/template/template.go
+++ b/libbeat/template/template.go
@@ -111,10 +111,10 @@ func (t *Template) Load(file string) (common.MapStr, error) {
 	// Start processing at the root
 	properties := common.MapStr{}
 	processor := Processor{EsVersion: t.esVersion}
-	if err := processor.process(fields, "", properties); err != nil {
+	if err := processor.Process(fields, "", properties); err != nil {
 		return nil, err
 	}
-	output := t.generate(properties, dynamicTemplates)
+	output := t.Generate(properties, dynamicTemplates)
 
 	return output, nil
 }
@@ -131,7 +131,7 @@ func (t *Template) GetPattern() string {
 
 // generate generates the full template
 // The default values are taken from the default variable.
-func (t *Template) generate(properties common.MapStr, dynamicTemplates []common.MapStr) common.MapStr {
+func (t *Template) Generate(properties common.MapStr, dynamicTemplates []common.MapStr) common.MapStr {
 	// Add base dynamic template
 	var dynamicTemplateBase = common.MapStr{
 		"strings_as_keyword": common.MapStr{

--- a/libbeat/template/template.go
+++ b/libbeat/template/template.go
@@ -129,7 +129,7 @@ func (t *Template) GetPattern() string {
 	return t.pattern
 }
 
-// generate generates the full template
+// Generate generates the full template
 // The default values are taken from the default variable.
 func (t *Template) Generate(properties common.MapStr, dynamicTemplates []common.MapStr) common.MapStr {
 	// Add base dynamic template

--- a/libbeat/template/template_test.go
+++ b/libbeat/template/template_test.go
@@ -20,7 +20,7 @@ func TestNumberOfRoutingShards(t *testing.T) {
 	template, err := New(beatVersion, beatName, "6.1.0", config)
 	assert.NoError(t, err)
 
-	data := template.generate(nil, nil)
+	data := template.Generate(nil, nil)
 	shards, err := data.GetValue("settings.index.number_of_routing_shards")
 	assert.NoError(t, err)
 
@@ -30,7 +30,7 @@ func TestNumberOfRoutingShards(t *testing.T) {
 	template, err = New(beatVersion, beatName, "6.0.0", config)
 	assert.NoError(t, err)
 
-	data = template.generate(nil, nil)
+	data = template.Generate(nil, nil)
 	shards, err = data.GetValue("settings.index.number_of_routing_shards")
 	assert.Error(t, err)
 	assert.Equal(t, nil, shards)
@@ -50,7 +50,7 @@ func TestNumberOfRoutingShardsOverwrite(t *testing.T) {
 	template, err := New(beatVersion, beatName, "6.1.0", config)
 	assert.NoError(t, err)
 
-	data := template.generate(nil, nil)
+	data := template.Generate(nil, nil)
 	shards, err := data.GetValue("settings.index.number_of_routing_shards")
 	assert.NoError(t, err)
 


### PR DESCRIPTION
As the template processing methods are private, using it from an external tool was not possible. There is some further cleanup needed to fully reuse the template generation methods externally to not have mention of Beats in the index pattern but this is a first step.