### PR TITLE
Remove test for comparing short / long config

### DIFF
--- a/metricbeat/tests/system/test_config.py
+++ b/metricbeat/tests/system/test_config.py
@@ -8,63 +8,6 @@ import time
 
 class ConfigTest(metricbeat.BaseTest):
 
-    @unittest.skip("This is test is currently skipped as it is flaky every time log messages change.")
-    @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
-    @attr('integration')
-    def test_compare_config(self):
-        """
-        Compare full and short config output
-        """
-
-        # Copy over full and normal config
-
-        self.copy_files(["metricbeat.yml", "metricbeat.reference.yml"],
-                        source_dir="../../",
-                        target_dir=".")
-
-        proc = self.start_beat(config="metricbeat.yml", output="short.log",
-                               extra_args=["-E", "output.elasticsearch.hosts=['" + self.get_host() + "']"])
-        time.sleep(1)
-        proc.check_kill_and_wait()
-
-        proc = self.start_beat(config="metricbeat.reference.yml", output="full.log",
-                               extra_args=["-E", "output.elasticsearch.hosts=['" + self.get_host() + "']"])
-        time.sleep(1)
-        proc.check_kill_and_wait()
-
-        # Fetch first 27 lines
-        # Remove timestamp
-
-        shortLog = []
-        with open(os.path.join(self.working_dir, "short.log"), "r") as f:
-            for i in range(27):
-                # Remove 27 chars of timestamp
-                shortLog.append(f.next()[27:])
-
-        fullLog = []
-        with open(os.path.join(self.working_dir, "full.log"), "r") as f:
-            for i in range(27):
-                # Remove 27 chars of timestamp
-                fullLog.append(f.next()[27:])
-
-        same = True
-
-        for i in range(27):
-            shortLine = shortLog[i]
-            fullLine = fullLog[i]
-
-            if shortLine not in fullLog:
-                print(shortLine)
-                print(fullLine)
-                same = False
-
-            if fullLine not in shortLog:
-                print(shortLine)
-                print(fullLine)
-                same = False
-
-        assert same == True
-
     def test_invalid_config_with_removed_settings(self):
         """
         Checks if metricbeat fails to load a module if remove settings have been used:


### PR DESCRIPTION
This was an attempt long ago to compare short and long (now reference) config to make sure they stay in sync. Since then lots of change happened and they differ much more so this test has become obsolete.