### PR TITLE
[DOCS] Fixes certutil command name

### DIFF
--- a/libbeat/docs/shared-ssl-logstash-config.asciidoc
+++ b/libbeat/docs/shared-ssl-logstash-config.asciidoc
@@ -19,8 +19,8 @@ To use SSL mutual authentication:
 {beatname_uc} and Logstash. Creating a correct SSL/TLS infrastructure is outside the scope of this
 document. There are many online resources available that describe how to create certificates.
 +
-TIP: If you are using X-Pack, you can use the
-{elasticsearch}/certutil.html[certutil tool] to generate certificates.
+TIP: If you are using {xpack}, you can use the
+{elasticsearch}/certutil.html[elasticsearch-certutil tool] to generate certificates.
 
 . Configure {beatname_uc} to use SSL. In the +{beatname_lc}.yml+ config file, specify the following settings under
 `ssl`:


### PR DESCRIPTION
This PR updates the command name from "certutil" to "elasticsearch-certutil". 