### PR TITLE
Replace references to X-Pack with attributes or remove them

### DIFF
--- a/docs/devguide/index.asciidoc
+++ b/docs/devguide/index.asciidoc
@@ -6,6 +6,8 @@ include::../../libbeat/docs/version.asciidoc[]
 :beatname_lc: beatname
 :beatname_uc: a Beat
 
+include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
+
 include::../../libbeat/docs/shared-beats-attributes.asciidoc[]
 
 include::./contributing.asciidoc[]

--- a/docs/devguide/newdashboards.asciidoc
+++ b/docs/devguide/newdashboards.asciidoc
@@ -85,7 +85,7 @@ import only the dashboards, use the `--dashboards` flag:
 
 Starting with Beats 6.0.0, the dashboards are no longer loaded directly into Elasticsearch. Instead, they are imported directly into Kibana.
 Thus, if your Kibana instance is not listening on localhost, or you enabled
-X-Pack for Kibana, you need to either configure the Kibana endpoint in
+{xpack} for Kibana, you need to either configure the Kibana endpoint in
 the config for the Beat, or pass the Kibana host and credentials as
 arguments to the `setup` command. For example:
 

--- a/libbeat/docs/https.asciidoc
+++ b/libbeat/docs/https.asciidoc
@@ -30,8 +30,8 @@ TIP: To obfuscate passwords and other sensitive settings, use the
 <<keystore,secrets keystore>>.
 
 Elasticsearch doesn't have built-in basic authentication, but you can achieve it
-either by using a web proxy or by using X-Pack to secure Elasticsearch. For more
-information, see the X-Pack documentation about
+either by using a web proxy or by using {xpack} to secure Elasticsearch. For more
+information, see the documentation about
 {securitydoc}/xpack-security.html[securing Elasticsearch] and <<securing-beats>>. 
 
 {beatname_uc} verifies the validity of the server certificates and only accepts trusted

--- a/libbeat/docs/security/basic-auth.asciidoc
+++ b/libbeat/docs/security/basic-auth.asciidoc
@@ -43,7 +43,7 @@ following request creates a ++{beat_default_index_prefix}_internal++ user that h
 ---------------------------------------------------------------
 POST /_xpack/security/user/{beat_default_index_prefix}_internal
 {
-  "password" : "x-pack-test-password",
+  "password" : "test-password",
   "roles" : [ "{beat_default_index_prefix}_writer"],
   "full_name" : "Internal {beatname_uc} User"
 }
@@ -76,7 +76,7 @@ output.elasticsearch:
     hosts: ["localhost:9200"]
     index: "{beat_default_index_prefix}"
     username: "{beat_default_index_prefix}_internal"
-    password: "x-pack-test-password"
+    password: "test-password"
 --------------------------------------------------
 
 .. To use PKI authentication, configure the `certificate` and

--- a/libbeat/docs/security/user-access.asciidoc
+++ b/libbeat/docs/security/user-access.asciidoc
@@ -39,7 +39,7 @@ example, the following request grants ++{beat_default_index_prefix}_user++ the
 ---------------------------------------------------------------
 POST /_xpack/security/user/{beat_default_index_prefix}_user
 {
-  "password" : "x-pack-test-password",
+  "password" : "test-password",
   "roles" : [ "{beat_default_index_prefix}_reader"],
   "full_name" : "{beatname_uc} User"
 }

--- a/libbeat/docs/shared-beats-attributes.asciidoc
+++ b/libbeat/docs/shared-beats-attributes.asciidoc
@@ -12,7 +12,6 @@
 :elasticsearch-plugins: https://www.elastic.co/guide/en/elasticsearch/plugins/{doc-branch}
 :securitydoc: https://www.elastic.co/guide/en/elastic-stack-overview/{doc-branch}
 :monitoringdoc: https://www.elastic.co/guide/en/elastic-stack-overview/{doc-branch}
-:security: X-Pack Security
 :dashboards: https://artifacts.elastic.co/downloads/beats/beats-dashboards/beats-dashboards-{stack-version}.zip
 :dockerimage: docker.elastic.co/beats/{beatname_lc}:{version}
 :dockergithub: https://github.com/elastic/beats-docker/tree/{doc-branch}

--- a/metricbeat/docs/modules/elasticsearch.asciidoc
+++ b/metricbeat/docs/modules/elasticsearch.asciidoc
@@ -7,7 +7,7 @@ This file is generated! See scripts/docs_collector.py
 
 beta[]
 
-The Elasticsearch module contains a minimal set of metrics to enable monitoring of Elasticsearch across multiple versions. To monitor more Elasticsearch metrics, use our {monitoringdoc}/xpack-monitoring.html[X-Pack monitoring] which is available under a free basic license.
+The Elasticsearch module contains a minimal set of metrics to enable monitoring of Elasticsearch across multiple versions. To monitor more Elasticsearch metrics, use our {monitoringdoc}/xpack-monitoring.html[monitoring] feature.
 
 The default metricsets are `node` and `node_stats`.
 

--- a/metricbeat/docs/modules/kibana.asciidoc
+++ b/metricbeat/docs/modules/kibana.asciidoc
@@ -7,7 +7,7 @@ This file is generated! See scripts/docs_collector.py
 
 beta[]
 
-The Kibana module only tracks the high-level metrics. To monitor more Kibana metrics, use our {monitoringdoc}/xpack-monitoring.html[X-Pack monitoring] which is available under a free basic license.
+The Kibana module only tracks the high-level metrics. To monitor more Kibana metrics, use our {monitoringdoc}/xpack-monitoring.html[monitoring] feature.
 
 The default metricset is `status`.
 

--- a/metricbeat/module/elasticsearch/_meta/docs.asciidoc
+++ b/metricbeat/module/elasticsearch/_meta/docs.asciidoc
@@ -1,3 +1,3 @@
-The Elasticsearch module contains a minimal set of metrics to enable monitoring of Elasticsearch across multiple versions. To monitor more Elasticsearch metrics, use our {monitoringdoc}/xpack-monitoring.html[X-Pack monitoring] which is available under a free basic license.
+The Elasticsearch module contains a minimal set of metrics to enable monitoring of Elasticsearch across multiple versions. To monitor more Elasticsearch metrics, use our {monitoringdoc}/xpack-monitoring.html[monitoring] feature.
 
 The default metricsets are `node` and `node_stats`.

--- a/metricbeat/module/kibana/_meta/docs.asciidoc
+++ b/metricbeat/module/kibana/_meta/docs.asciidoc
@@ -1,3 +1,3 @@
-The Kibana module only tracks the high-level metrics. To monitor more Kibana metrics, use our {monitoringdoc}/xpack-monitoring.html[X-Pack monitoring] which is available under a free basic license.
+The Kibana module only tracks the high-level metrics. To monitor more Kibana metrics, use our {monitoringdoc}/xpack-monitoring.html[monitoring] feature.
 
 The default metricset is `status`.


### PR DESCRIPTION
We're moving away from mentioning x-pack in the docs. The first step is to remove unnecessary mentions and to make sure we are using the [x-pack attribute](https://github.com/elastic/docs/blob/master/shared/attributes.asciidoc#L42) to resolve references. 

This needs to be backported to 6.3