### PR TITLE
Backport to 6.2: multiple doc changes (#6623,  #6650,  #6651,  #6652,  #6654, #6655, #6786, #6849, #6851)

### DIFF
--- a/docs/devguide/newbeat.asciidoc
+++ b/docs/devguide/newbeat.asciidoc
@@ -47,7 +47,7 @@ under `GOPATH`:
 [source,shell]
 ----------------------------------------------------------------------
 mkdir -p ${GOPATH}/src/github.com/elastic
-git clone https://github.com/elastic/beats ${GOPATH}/src/elastic/beats
+git clone https://github.com/elastic/beats ${GOPATH}/src/github.com/elastic/beats
 ----------------------------------------------------------------------
 
 To build your beat

--- a/docs/devguide/newbeat.asciidoc
+++ b/docs/devguide/newbeat.asciidoc
@@ -41,17 +41,16 @@ For general information about contributing to Beats, see <<beats-contributing>>.
 
 After you have https://golang.org/doc/install[installed Go] and set up the
 https://golang.org/doc/code.html#GOPATH[GOPATH] environment variable to point to
-your preferred workspace location, a simple way of getting the source code for
-Beats, including libbeat and the Beat generator, is to do:
+your preferred workspace location, clone the Beats repository in the correct location
+under `GOPATH`:
 
 [source,shell]
 ----------------------------------------------------------------------
-go get github.com/elastic/beats
+mkdir -p ${GOPATH}/src/github.com/elastic
+git clone https://github.com/elastic/beats ${GOPATH}/src/elastic/beats
 ----------------------------------------------------------------------
 
-When you run the command, all source files are downloaded to the
-`$GOPATH/src/github.com/elastic/beats` path. You can ignore the "no buildable Go source files" message because
-you will build the source later. By default `go get`  fetches the master branch. To build your beat
+To build your beat
 on a specific version of libbeat, check out the specific branch ({doc-branch} in the example below):
 
 ["source","sh",subs="attributes"]

--- a/filebeat/docs/filebeat-options.asciidoc
+++ b/filebeat/docs/filebeat-options.asciidoc
@@ -91,7 +91,7 @@ The `plain` encoding is special, because it does not validate or transform any i
 [[exclude-lines]]
 ==== `exclude_lines`
 
-A list of regular expressions to match the lines that you want Filebeat to exclude. Filebeat drops any lines that match a regular expression in the list. By default, no lines are dropped.
+A list of regular expressions to match the lines that you want Filebeat to exclude. Filebeat drops any lines that match a regular expression in the list. By default, no lines are dropped. Empty lines are ignored.
 
 If <<multiline,multiline>> is also specified, each multiline message is combined into a single line before the lines are filtered by `exclude_lines`.
 
@@ -111,7 +111,7 @@ See <<regexp-support>> for a list of supported regexp patterns.
 [[include-lines]]
 ==== `include_lines`
 
-A list of regular expressions to match the lines that you want Filebeat to include. Filebeat exports only the lines that match a regular expression in the list. By default, all lines are exported.
+A list of regular expressions to match the lines that you want Filebeat to include. Filebeat exports only the lines that match a regular expression in the list. By default, all lines are exported. Empty lines are ignored.
 
 If <<multiline,multiline>> is also specified, each multiline message is combined into a single line before the lines are filtered by `include_lines`.
 

--- a/filebeat/docs/modules/kafka.asciidoc
+++ b/filebeat/docs/modules/kafka.asciidoc
@@ -45,11 +45,6 @@ file to override the default paths for logs:
 -----
 
 
-// REVIEWERS: I must be doing something wrong with the config settings. The
-// above config works, but when I try to specify var.kafka_home, it doesn't
-// seem to have any effect. 
-
-
 To specify the same settings at the command line, you use:
 
 ["source","sh",subs="attributes"]
@@ -65,14 +60,6 @@ include::../include/config-option-intro.asciidoc[]
 
 [float]
 ==== `log` fileset settings
-
-// REVIEWERS: I've added a description because this variable appears in the
-// kafka.yml file. However, I don't understand how it works.
-
-//*`var.kafka_home`*::
-
-//The home path for Kafka. If this variable is not set,  {beatname_uc} looks under
-//`/opt`.
 
 include::../include/var-paths.asciidoc[]
 

--- a/filebeat/docs/modules/traefik.asciidoc
+++ b/filebeat/docs/modules/traefik.asciidoc
@@ -19,8 +19,6 @@ This module requires the
 {elasticsearch-plugins}/ingest-user-agent.html[ingest-user-agent] and
 {elasticsearch-plugins}/ingest-geoip.html[ingest-geoip] Elasticsearch plugins.
 
-//REVIEWERS: Do we need to say anything else about compatibility here?
-
 include::../include/running-modules.asciidoc[]
 
 [float]

--- a/filebeat/module/kafka/_meta/docs.asciidoc
+++ b/filebeat/module/kafka/_meta/docs.asciidoc
@@ -40,11 +40,6 @@ file to override the default paths for logs:
 -----
 
 
-// REVIEWERS: I must be doing something wrong with the config settings. The
-// above config works, but when I try to specify var.kafka_home, it doesn't
-// seem to have any effect. 
-
-
 To specify the same settings at the command line, you use:
 
 ["source","sh",subs="attributes"]
@@ -60,13 +55,5 @@ include::../include/config-option-intro.asciidoc[]
 
 [float]
 ==== `log` fileset settings
-
-// REVIEWERS: I've added a description because this variable appears in the
-// kafka.yml file. However, I don't understand how it works.
-
-//*`var.kafka_home`*::
-
-//The home path for Kafka. If this variable is not set,  {beatname_uc} looks under
-//`/opt`.
 
 include::../include/var-paths.asciidoc[]

--- a/filebeat/module/traefik/_meta/docs.asciidoc
+++ b/filebeat/module/traefik/_meta/docs.asciidoc
@@ -14,8 +14,6 @@ This module requires the
 {elasticsearch-plugins}/ingest-user-agent.html[ingest-user-agent] and
 {elasticsearch-plugins}/ingest-geoip.html[ingest-geoip] Elasticsearch plugins.
 
-//REVIEWERS: Do we need to say anything else about compatibility here?
-
 include::../include/running-modules.asciidoc[]
 
 [float]

--- a/libbeat/docs/keystore.asciidoc
+++ b/libbeat/docs/keystore.asciidoc
@@ -10,7 +10,11 @@
 //////////////////////////////////////////////////////////////////////////
 
 [[keystore]]
-=== Secrets keystore
+=== Secrets keystore for secure settings
+
+++++
+<titleabbrev>Secrets keystore</titleabbrev>
+++++
 
 When you configure {beatname_uc}, you might need to specify sensitive settings,
 such as passwords. Rather than relying on file system permissions to protect

--- a/libbeat/docs/monitoring/monitoring-beats.asciidoc
+++ b/libbeat/docs/monitoring/monitoring-beats.asciidoc
@@ -16,6 +16,9 @@
 
 [partintro]
 --
+
+NOTE: {monitoring} for {beatname_uc} requires {es} 6.2 or later.
+
 {monitoring} enables you to easily monitor {beatname_uc} from {kib}. For more
 information, see
 {xpack-ref}/xpack-monitoring.html[Monitoring the Elastic Stack] and

--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -81,7 +81,9 @@ output.elasticsearch:
 
 ==== Compatibility
 
-This output works with all compatible versions of Elasticsearch. See "Supported Beats Versions" in the https://www.elastic.co/support/matrix#show_compatibility[Elastic Support Matrix].
+This output works with all compatible versions of Elasticsearch. See the
+https://www.elastic.co/support/matrix#matrix_compatibility[Elastic Support
+Matrix].
 
 ==== Configuration options
 
@@ -399,7 +401,9 @@ will be similar to events directly indexed by Beats into Elasticsearch.
 
 ==== Compatibility
 
-This output works with all compatible versions of Logstash. See "Supported Beats Versions" in the https://www.elastic.co/support/matrix#show_compatibility[Elastic Support Matrix].
+This output works with all compatible versions of Logstash. See the
+https://www.elastic.co/support/matrix#matrix_compatibility[Elastic Support
+Matrix].
 
 ==== Configuration options
 

--- a/libbeat/docs/shared-config-ingest.asciidoc
+++ b/libbeat/docs/shared-config-ingest.asciidoc
@@ -10,18 +10,20 @@
 //////////////////////////////////////////////////////////////////////////
 
 [[configuring-ingest-node]]
-== Parse logs by using ingest node
+== Parse data by using ingest node
 
 When you use Elasticsearch for output, you can configure {beatname_uc} to use
-{elasticsearch}/ingest.html[ingest node] to pre-process documents
-before the actual indexing takes place in Elasticsearch. Ingest node is a convenient processing option when you
-want to do some extra processing on your data, but you do not require the full power of Logstash. For
-example, you can create an ingest node pipeline in Elasticsearch that consists of one processor
-that removes a field in a document followed by another processor that renames a field.
+{elasticsearch}/ingest.html[ingest node] to pre-process documents before the
+actual indexing takes place in Elasticsearch. Ingest node is a convenient
+processing option when you want to do some extra processing on your data, but
+you do not require the full power of Logstash. For example, you can create an
+ingest node pipeline in Elasticsearch that consists of one processor that
+removes a field in a document followed by another processor that renames a
+field.
 
-After defining the pipeline in Elasticsearch, you simply configure your Beat to use the pipeline. To configure
-{beatname_uc}, you specify the pipeline ID in the `parameters` option under `elasticsearch` in the
-+{beatname_lc}.yml+ file:
+After defining the pipeline in Elasticsearch, you simply configure {beatname_uc}
+to use the pipeline. To configure {beatname_uc}, you specify the pipeline ID in
+the `parameters` option under `elasticsearch` in the +{beatname_lc}.yml+ file:
 
 [source,yaml]
 ------------------------------------------------------------------------------
@@ -30,7 +32,8 @@ output.elasticsearch:
   pipeline: my_pipeline_id
 ------------------------------------------------------------------------------
 
-For example, let's say that you've defined the following pipeline in a file named `pipeline.json`:
+For example, let's say that you've defined the following pipeline in a file
+named `pipeline.json`:
 
 [source,json]
 ------------------------------------------------------------------------------
@@ -64,5 +67,5 @@ output.elasticsearch:
 
 When you run {beatname_uc}, the value of `beat.name` is converted to lowercase before indexing.
 
-For more information about defining a pre-processing pipeline, see the {elasticsearch}/ingest.html[Ingest Node]
-documentation.
+For more information about defining a pre-processing pipeline, see the
+{elasticsearch}/ingest.html[Ingest Node] documentation.

--- a/libbeat/docs/step-configure-credentials.asciidoc
+++ b/libbeat/docs/step-configure-credentials.asciidoc
@@ -11,12 +11,16 @@ output.elasticsearch:
   password: "elastic"
 setup.kibana:
   host: "mykibanahost:5601"
-  username: "elastic" <1>
+  username: "elastic" <1> <2>
   password: "elastic"
 ----
 <1> The `username` and `password` settings for Kibana are optional. If you don't
 specify credentials for Kibana, {beatname_uc} uses the `username` and `password`
 specified for the Elasticsearch output.
+
+<2> If you are planning to <<load-kibana-dashboards,set up the Kibana
+dashboards>>, the user must have the `kibana_user`
+{xpack-ref}/built-in-roles.html[built-in role] or equivalent privileges.
 --
 +
 Also see the security-related options described in <<setup-kibana-endpoint>> and


### PR DESCRIPTION
Cherrypicks the following PRs into the 6.2 branch:

https://github.com/elastic/beats/pull/6623
https://github.com/elastic/beats/pull/6650
https://github.com/elastic/beats/pull/6651
https://github.com/elastic/beats/pull/6652
https://github.com/elastic/beats/pull/6654
https://github.com/elastic/beats/pull/6655
https://github.com/elastic/beats/pull/6786 - **Please confirm this belongs in 6.2**
https://github.com/elastic/beats/pull/6849
https://github.com/elastic/beats/pull/6851
