### PR TITLE
Tentative fix to auditbeat test panic under macOS

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -515,7 +515,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 --------------------------------------------------------------------
 Dependency: github.com/fsnotify/fsevents
-Revision: 70114c7d2e1e4d1ae5179b285d65ea21aae111cc
+Revision: 4d5197691b054c220286f7c6ea167de9753d902d
 License type (autodetected): BSD-3-Clause
 ./vendor/github.com/fsnotify/fsevents/LICENSE:
 --------------------------------------------------------------------

--- a/vendor/github.com/fsnotify/fsevents/wrap.go
+++ b/vendor/github.com/fsnotify/fsevents/wrap.go
@@ -229,6 +229,7 @@ func (es *EventStream) start(paths []string, callbackInfo uintptr) {
 	go func() {
 		runtime.LockOSThread()
 		es.rlref = CFRunLoopRef(C.CFRunLoopGetCurrent())
+		C.CFRetain(C.CFTypeRef(es.rlref))
 		C.FSEventStreamScheduleWithRunLoop(es.stream, C.CFRunLoopRef(es.rlref), C.kCFRunLoopDefaultMode)
 		C.FSEventStreamStart(es.stream)
 		close(started)
@@ -266,4 +267,5 @@ func stop(stream FSEventStreamRef, rlref CFRunLoopRef) {
 	C.FSEventStreamInvalidate(stream)
 	C.FSEventStreamRelease(stream)
 	C.CFRunLoopStop(C.CFRunLoopRef(rlref))
+	C.CFRelease(C.CFTypeRef(rlref))
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -955,11 +955,11 @@
 			"versionExact": "v1.5.0"
 		},
 		{
-			"checksumSHA1": "ZRP2NldqpFv4H1VsE70PEeqVjaw=",
+			"checksumSHA1": "TmMTaJIWueXrKneUOKMOgq75fKE=",
 			"origin": "github.com/elastic/fsevents",
 			"path": "github.com/fsnotify/fsevents",
-			"revision": "70114c7d2e1e4d1ae5179b285d65ea21aae111cc",
-			"revisionTime": "2018-04-06T06:16:07Z",
+			"revision": "4d5197691b054c220286f7c6ea167de9753d902d",
+			"revisionTime": "2018-05-02T14:11:16Z",
 			"tree": true
 		},
 		{


### PR DESCRIPTION
This aims to fix a rare crash in CI where auditbeat's unit tests panic (SIGSEGV) inside a call to `CFRunLoopStop()` in fsevents' Stop method.

This is the panic stack trace:
```
12:58:43 [signal SIGSEGV: segmentation violation code=0x1 addr=0xb01dfacedebac1e pc=0x7fffd3aceeef]
12:58:43 
12:58:43 runtime stack:
12:58:43 runtime.throw(0x46a980c, 0x2a)
12:58:43 	/var/lib/jenkins/.gvm/versions/go1.10.1.darwin.amd64/src/runtime/panic.go:616 +0x81
12:58:43 runtime.sigpanic()
12:58:43 	/var/lib/jenkins/.gvm/versions/go1.10.1.darwin.amd64/src/runtime/signal_unix.go:372 +0x28e
12:58:43 
12:58:43 goroutine 95 [syscall]:
12:58:43 runtime.cgocall(0x45a4180, 0xc42020dba8, 0x29)
12:58:43 	/var/lib/jenkins/.gvm/versions/go1.10.1.darwin.amd64/src/runtime/cgocall.go:128 +0x74 fp=0xc42020db68 sp=0xc42020db30 pc=0x40046d4
12:58:43 github.com/elastic/beats/vendor/github.com/fsnotify/fsevents._Cfunc_CFRunLoopStop(0x6800900)
12:58:43 	_cgo_gotypes.go:246 +0x63 fp=0xc42020dba8 sp=0xc42020db68 pc=0x44aabf3
12:58:43 github.com/elastic/beats/vendor/github.com/fsnotify/fsevents.stop.func4(0x6800900)
12:58:43 	/var/lib/jenkins/workspace/elastic+beats+pull-request+multijob-darwin/beat/auditbeat/label/macosx/src/github.com/elastic/beats/vendor/github.com/fsnotify/fsevents/wrap.go:268 +0x8a fp=0xc42020dbe8 sp=0xc42020dba8 pc=0x44ae36a
12:58:43 github.com/elastic/beats/vendor/github.com/fsnotify/fsevents.stop(0x56017b0, 0x6800900)
12:58:43 	/var/lib/jenkins/workspace/elastic+beats+pull-request+multijob-darwin/beat/auditbeat/label/macosx/src/github.com/elastic/beats/vendor/github.com/fsnotify/fsevents/wrap.go:268 +0x63 fp=0xc42020dc00 sp=0xc42020dbe8 pc=0x44ad383
12:58:43 github.com/elastic/beats/vendor/github.com/fsnotify/fsevents.(*EventStream).Stop(0xc420192b00)
12:58:43 	/var/lib/jenkins/workspace/elastic+beats+pull-request+multijob-darwin/beat/auditbeat/label/macosx/src/github.com/elastic/beats/vendor/github.com/fsnotify/fsevents/fsevents.go:175 +0xd9 fp=0xc42020dc28 sp=0xc42020dc00 pc=0x44aa6e9
12:58:43 github.com/elastic/beats/auditbeat/module/file_integrity.(*fsreader).consumeEvents(0xc420172900, 0xc4201a4c60)
12:58:43 	/var/lib/jenkins/workspace/elastic+beats+pull-request+multijob-darwin/beat/auditbeat/label/macosx/src/github.com/elastic/beats/auditbeat/module/file_integrity/eventreader_fsevents.go:136 +0x86f fp=0xc42020dfd0 sp=0xc42020dc28 pc=0x454a9ff
12:58:43 runtime.goexit()
12:58:43 	/var/lib/jenkins/.gvm/versions/go1.10.1.darwin.amd64/src/runtime/asm_amd64.s:2361 +0x1 fp=0xc42020dfd8 sp=0xc42020dfd0 pc=0x40652c1
12:58:43 created by github.com/elastic/beats/auditbeat/module/file_integrity.(*fsreader).Start
12:58:43 	/var/lib/jenkins/workspace/elastic+beats+pull-request+multijob-darwin/beat/auditbeat/label/macosx/src/github.com/elastic/beats/auditbeat/module/file_integrity/eventreader_fsevents.go:121 +0xaf
```
