### PR TITLE
Detect error during requesting status info from Kibana

### DIFF
--- a/filebeat/beater/filebeat.go
+++ b/filebeat/beater/filebeat.go
@@ -204,7 +204,7 @@ func (fb *Filebeat) loadModulesML(b *beat.Beat, kibanaConfig *common.Config) err
 
 	kibanaVersion, err := common.NewVersion(kibanaClient.GetVersion())
 	if err != nil {
-		return err
+		return errors.Errorf("Error checking Kibana version: %v", err)
 	}
 
 	if err := setupMLBasedOnVersion(fb.moduleRegistry, esClient, kibanaClient, kibanaVersion); err != nil {

--- a/libbeat/setup/kibana/client.go
+++ b/libbeat/setup/kibana/client.go
@@ -179,8 +179,8 @@ func (client *Client) SetVersion() error {
 		Version string `json:"version"`
 	}
 
-	_, result, err := client.Connection.Request("GET", "/api/status", nil, nil)
-	if err != nil {
+	code, result, err := client.Connection.Request("GET", "/api/status", nil, nil)
+	if err != nil || code >= 400 {
 		return fmt.Errorf("HTTP GET request to /api/status fails: %v. Response: %s.",
 			err, truncateString(result))
 	}

--- a/libbeat/setup/kibana/client.go
+++ b/libbeat/setup/kibana/client.go
@@ -118,7 +118,7 @@ func NewKibanaClient(cfg *common.Config) (*Client, error) {
 	}
 
 	if err = client.SetVersion(); err != nil {
-		return nil, fmt.Errorf("fail to get the Kibana version:%v", err)
+		return nil, fmt.Errorf("fail to get the Kibana version: %v", err)
 	}
 
 	return client, nil


### PR DESCRIPTION
Previously, if Kibana returned an error during requesting its status info using `/api/status`, it failed silently and the version info was empty. This caused problems during detecting the version info of Kibana for loading ML jobs, leading to cryptic error message: `Exiting: Passed version is not semver:`.

From now on, Kibana response errors are detected by checking the response code. So the following error message is displayed now:
```
Exiting: Error creating Kibana client: fail to get the Kibana version: HTTP GET request to /api/status fails: <nil>. Response: {"statusCode":401,"error":"Unautho
rized","message":"[security_exception] failed to authenticate user [elastic], with { header={ WWW-Authenticate=\"Basic realm=\\\"security\\\" charset=\\\"UTF-8\
\\"\" } }"}.
```