### PR TITLE
Cherry-pick #6921 to 6.2: Ensure the dashboard zip is sane

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -32,11 +32,6 @@ https://github.com/elastic/beats/compare/v6.2.4...6.2[Check the HEAD diff]
 
 *Affecting all Beats*
 
-- Fix panic when Events containing a float32 value are normalized. {pull}6129[6129]
-- Fix `setup.dashboards.always_kibana` when using Kibana 5.6. {issue}6090[6090]
-- Fix for kafka logger. {pull}6430[6430]
-- Remove double slashes in Windows service script. {pull}6491[6491]
-- Ensure Kubernetes labels/annotations don't break mapping {pull}6490[6490]
 - Ensure that the dashboard zip files can't contain files outside of the kibana directory. {pull}6921[6921]
 
 *Auditbeat*

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -32,6 +32,13 @@ https://github.com/elastic/beats/compare/v6.2.4...6.2[Check the HEAD diff]
 
 *Affecting all Beats*
 
+- Fix panic when Events containing a float32 value are normalized. {pull}6129[6129]
+- Fix `setup.dashboards.always_kibana` when using Kibana 5.6. {issue}6090[6090]
+- Fix for kafka logger. {pull}6430[6430]
+- Remove double slashes in Windows service script. {pull}6491[6491]
+- Ensure Kubernetes labels/annotations don't break mapping {pull}6490[6490]
+- Ensure that the dashboard zip files can't contain files outside of the kibana directory. {pull}6921[6921]
+
 *Auditbeat*
 
 *Filebeat*

--- a/libbeat/dashboards/importer.go
+++ b/libbeat/dashboards/importer.go
@@ -119,6 +119,16 @@ func (imp Importer) unzip(archive, target string) error {
 	unzipFile := func(file *zip.File) error {
 		filePath := filepath.Join(target, file.Name)
 
+		// check that the resulting file path is indeed under target
+		// Note that Rel calls Clean.
+		relPath, err := filepath.Rel(target, filePath)
+		if err != nil {
+			return err
+		}
+		if strings.HasPrefix(filepath.ToSlash(relPath), "../") {
+			return fmt.Errorf("Zip file contains files outside of the target directory: %s", relPath)
+		}
+
 		if file.FileInfo().IsDir() {
 			return os.MkdirAll(filePath, file.Mode())
 		}


### PR DESCRIPTION
Cherry-pick of PR #6921 to 6.2 branch. Original message: 

This adds a check that all files from the dashboard zip file
are pointing to the right target, and don't override other configs.