### PR TITLE
Fix out of bounds access in packetbeat's HTTP parser

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -91,6 +91,8 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 
 *Packetbeat*
 
+- Fix an out of bounds access in HTTP parser caused by malformed request. {pull}6997[6997]
+
 *Winlogbeat*
 
 - Fixed a crash under Windows 2003 and XP when an event had less insert strings than required by its format string. {pull}6247[6247]

--- a/packetbeat/protos/http/http_parser.go
+++ b/packetbeat/protos/http/http_parser.go
@@ -181,9 +181,10 @@ func (*parser) parseHTTPLine(s *stream, m *message) (cont, ok, complete bool) {
 		m.method = common.NetString(fline[:afterMethodIdx])
 		m.requestURI = common.NetString(fline[afterMethodIdx+1 : afterRequestURIIdx])
 
-		if bytes.Equal(fline[afterRequestURIIdx+1:afterRequestURIIdx+len(constHTTPVersion)+1], constHTTPVersion) {
+		versionIdx := afterRequestURIIdx + len(constHTTPVersion) + 1
+		if len(fline) > versionIdx && bytes.Equal(fline[afterRequestURIIdx+1:versionIdx], constHTTPVersion) {
 			m.isRequest = true
-			version = fline[afterRequestURIIdx+len(constHTTPVersion)+1:]
+			version = fline[versionIdx:]
 		} else {
 			if isDebug {
 				debugf("Couldn't understand HTTP version: %s", fline)


### PR DESCRIPTION
A broken HTTP request caused the parser to report a panic.

Fixes #6409