### PR TITLE
Prevent warning in Auditbeat's system tests

### DIFF
--- a/auditbeat/tests/system/test_base.py
+++ b/auditbeat/tests/system/test_base.py
@@ -3,7 +3,7 @@ import sys
 import os
 import shutil
 import unittest
-from auditbeat import BaseTest
+from auditbeat import *
 from elasticsearch import Elasticsearch
 from beat.beat import INTEGRATION_TESTS
 
@@ -13,44 +13,47 @@ class Test(BaseTest):
         """
         Auditbeat starts and stops without error.
         """
-        self.render_config_template(
-            modules=[{
-                "name": "file_integrity",
-                "extras": {
-                    "paths": ["file.example"],
-                }
-            }],
-        )
-        proc = self.start_beat()
-        self.wait_until(lambda: self.log_contains("start running"))
-        proc.check_kill_and_wait()
-        self.assert_no_logged_warnings('"error": "failed to stat: lstat file.example: no such file or directory"')
+        dirs = [self.temp_dir("auditbeat_test")]
+        with PathCleanup(dirs):
+            self.render_config_template(
+                modules=[{
+                    "name": "file_integrity",
+                    "extras": {
+                        "paths": dirs,
+                    }
+                }],
+            )
+            proc = self.start_beat()
+            self.wait_until(lambda: self.log_contains("start running"))
+            proc.check_kill_and_wait()
+            self.assert_no_logged_warnings()
 
-        # Ensure all Beater stages are used.
-        assert self.log_contains("Setup Beat: auditbeat")
-        assert self.log_contains("auditbeat start running")
-        assert self.log_contains("auditbeat stopped")
+            # Ensure all Beater stages are used.
+            assert self.log_contains("Setup Beat: auditbeat")
+            assert self.log_contains("auditbeat start running")
+            assert self.log_contains("auditbeat stopped")
 
     @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_template(self):
         """
         Test that the template can be loaded with `setup --template`
         """
-        es = Elasticsearch([self.get_elasticsearch_url()])
+        dirs = [self.temp_dir("auditbeat_test")]
+        with PathCleanup(dirs):
+            es = Elasticsearch([self.get_elasticsearch_url()])
 
-        self.render_config_template(
-            modules=[{
-                "name": "file_integrity",
-                "extras": {
-                    "paths": ["file.example"],
-                }
-            }],
-            elasticsearch={"host": self.get_elasticsearch_url()})
-        exit_code = self.run_beat(extra_args=["setup", "--template"])
+            self.render_config_template(
+                modules=[{
+                    "name": "file_integrity",
+                    "extras": {
+                        "paths": dirs,
+                    }
+                }],
+                elasticsearch={"host": self.get_elasticsearch_url()})
+            self.run_beat(extra_args=["setup", "--template"], exit_code=0)
 
-        assert exit_code == 0
-        assert self.log_contains('Loaded index template')
-        assert len(es.cat.templates(name='auditbeat-*', h='name')) > 0
+            assert self.log_contains('Loaded index template')
+            assert len(es.cat.templates(name='auditbeat-*', h='name')) > 0
 
     @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_dashboards(self):
@@ -58,21 +61,22 @@ class Test(BaseTest):
         Test that the dashboards can be loaded with `setup --dashboards`
         """
 
-        kibana_dir = os.path.join(self.beat_path, "_meta", "kibana")
-        shutil.copytree(kibana_dir, os.path.join(self.working_dir, "kibana"))
+        dirs = [self.temp_dir("auditbeat_test")]
+        with PathCleanup(dirs):
+            kibana_dir = os.path.join(self.beat_path, "_meta", "kibana")
+            shutil.copytree(kibana_dir, os.path.join(self.working_dir, "kibana"))
 
-        es = Elasticsearch([self.get_elasticsearch_url()])
-        self.render_config_template(
-            modules=[{
-                "name": "file_integrity",
-                "extras": {
-                    "paths": ["file.example"],
-                }
-            }],
-            elasticsearch={"host": self.get_elasticsearch_url()},
-            kibana={"host": self.get_kibana_url()},
-        )
-        exit_code = self.run_beat(extra_args=["setup", "--dashboards"])
+            es = Elasticsearch([self.get_elasticsearch_url()])
+            self.render_config_template(
+                modules=[{
+                    "name": "file_integrity",
+                    "extras": {
+                        "paths": dirs,
+                    }
+                }],
+                elasticsearch={"host": self.get_elasticsearch_url()},
+                kibana={"host": self.get_kibana_url()},
+            )
+            self.run_beat(extra_args=["setup", "--dashboards"], exit_code=0)
 
-        assert exit_code == 0
-        assert self.log_contains("Kibana dashboards successfully loaded.")
+            assert self.log_contains("Kibana dashboards successfully loaded.")


### PR DESCRIPTION
Cleanup the tests so there is no need to ignore a particular warning printed in the logs.

This was necessary after the logged warnings regexp was fixed in #6906