### PR TITLE
Cherry-pick #6950 to 6.2: Fix heartbeat races on event updates

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -37,6 +37,7 @@ https://github.com/elastic/beats/compare/v6.2.4...6.2[Check the HEAD diff]
 *Filebeat*
 
 *Heartbeat*
+- Fix race due to updates of shared a map, that was not supposed to be shared between multiple go-routines. {issue}6616[6616]
 
 *Metricbeat*
 


### PR DESCRIPTION
Cherry-pick of PR #6950 to 6.2 branch. Original message: 

Resolves: #6616

Heartbeat has a many components, each adding fields to an existing
event. As events are created per 'TaskRun', this is normally fine. But
in case the TaskRunner branches of into multiple Sub-tasks, we will see
races on shared event structures. This is the case with multiple ports
in the http/tcp configuration or the IPAll setting (ping all known IPs
of a given domain).

Namespaces in an event can be potentially populated via globally shared
structures. This can also lead to unwanted updates or races.

This fix clones the event structure before continuing event updates, so
to remove the chance of races.

I did run some tests before and after the change, with the race detector enabled. No more race have been found with this change.