### PR TITLE
Update github.com/elastic/go-libaudit

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -123,6 +123,8 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 
 - Added caching of UID and GID values to auditd module. {pull}6978[6978]
 - Updated syscall tables for Linux 4.16. {pull}6978[6978]
+- Added better error messages for when the auditd module fails due to the
+  Linux kernel not supporting auditing (CONFIG_AUDIT=n). {pull}7012[7012]
 
 *Filebeat*
 

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -373,8 +373,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 --------------------------------------------------------------------
 Dependency: github.com/elastic/go-libaudit
-Version: v0.2.0
-Revision: 7839a62a31ca608f5275da89bc75189b6845a52b
+Version: v0.2.1
+Revision: 55225d06b15c74082f9a7af75aa4284dbe48d20a
 License type (autodetected): Apache-2.0
 ./vendor/github.com/elastic/go-libaudit/LICENSE.txt:
 --------------------------------------------------------------------

--- a/vendor/github.com/elastic/go-libaudit/CHANGELOG.md
+++ b/vendor/github.com/elastic/go-libaudit/CHANGELOG.md
@@ -2,6 +2,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.2.1]
+
+### Added
+
+- Added better error messages for when `NewAuditClient` fails due to the
+  Linux kernel not supporting auditing (CONFIG_AUDIT=n). #32
+
 ## [0.2.0]
 
 ### Changed

--- a/vendor/github.com/elastic/go-libaudit/audit.go
+++ b/vendor/github.com/elastic/go-libaudit/audit.go
@@ -105,7 +105,12 @@ func newAuditClient(netlinkGroups uint32, resp io.Writer) (*AuditClient, error) 
 
 	netlink, err := NewNetlinkClient(syscall.NETLINK_AUDIT, netlinkGroups, buf, resp)
 	if err != nil {
-		return nil, err
+		switch err {
+		case syscall.EINVAL, syscall.EPROTONOSUPPORT, syscall.EAFNOSUPPORT:
+			return nil, errors.Wrap(err, "audit not supported by kernel")
+		default:
+			return nil, errors.Wrap(err, "failed to open audit netlink socket")
+		}
 	}
 
 	return &AuditClient{Netlink: netlink}, nil

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -369,44 +369,44 @@
 			"revisionTime": "2016-08-05T00:47:13Z"
 		},
 		{
-			"checksumSHA1": "+WyRdvGE4raLmW42Pmw3yDmktO8=",
+			"checksumSHA1": "hAB/G2FIWYwg3Rujgpt6UPtHMis=",
 			"path": "github.com/elastic/go-libaudit",
-			"revision": "7839a62a31ca608f5275da89bc75189b6845a52b",
-			"revisionTime": "2018-04-30T14:05:21Z",
-			"version": "v0.2.0",
-			"versionExact": "v0.2.0"
+			"revision": "55225d06b15c74082f9a7af75aa4284dbe48d20a",
+			"revisionTime": "2018-05-03T13:36:58Z",
+			"version": "v0.2.1",
+			"versionExact": "v0.2.1"
 		},
 		{
 			"checksumSHA1": "3V0tnqlCgmCXnbocuTqUKluynm8=",
 			"path": "github.com/elastic/go-libaudit/aucoalesce",
-			"revision": "7839a62a31ca608f5275da89bc75189b6845a52b",
-			"revisionTime": "2018-04-30T14:05:21Z",
-			"version": "v0.2.0",
-			"versionExact": "v0.2.0"
+			"revision": "55225d06b15c74082f9a7af75aa4284dbe48d20a",
+			"revisionTime": "2018-05-03T13:36:58Z",
+			"version": "v0.2.1",
+			"versionExact": "v0.2.1"
 		},
 		{
 			"checksumSHA1": "6OK3lLgocjmIUyLo8xNhYGpwE1E=",
 			"path": "github.com/elastic/go-libaudit/auparse",
-			"revision": "7839a62a31ca608f5275da89bc75189b6845a52b",
-			"revisionTime": "2018-04-30T14:05:21Z",
-			"version": "v0.2.0",
-			"versionExact": "v0.2.0"
+			"revision": "55225d06b15c74082f9a7af75aa4284dbe48d20a",
+			"revisionTime": "2018-05-03T13:36:58Z",
+			"version": "v0.2.1",
+			"versionExact": "v0.2.1"
 		},
 		{
 			"checksumSHA1": "Rr15sVPpJRQ+ggimmx3/0s1gUJc=",
 			"path": "github.com/elastic/go-libaudit/rule",
-			"revision": "7839a62a31ca608f5275da89bc75189b6845a52b",
-			"revisionTime": "2018-04-30T14:05:21Z",
-			"version": "v0.2.0",
-			"versionExact": "v0.2.0"
+			"revision": "55225d06b15c74082f9a7af75aa4284dbe48d20a",
+			"revisionTime": "2018-05-03T13:36:58Z",
+			"version": "v0.2.1",
+			"versionExact": "v0.2.1"
 		},
 		{
 			"checksumSHA1": "5C083BvwcAVSKquRXbxXa950/wE=",
 			"path": "github.com/elastic/go-libaudit/rule/flags",
-			"revision": "7839a62a31ca608f5275da89bc75189b6845a52b",
-			"revisionTime": "2018-04-30T14:05:21Z",
-			"version": "v0.2.0",
-			"versionExact": "v0.2.0"
+			"revision": "55225d06b15c74082f9a7af75aa4284dbe48d20a",
+			"revisionTime": "2018-05-03T13:36:58Z",
+			"version": "v0.2.1",
+			"versionExact": "v0.2.1"
 		},
 		{
 			"checksumSHA1": "3jizmlZPCyo6FAZY8Trk9jA8NH4=",


### PR DESCRIPTION
- Added better error messages for when the auditd module fails due to the
  Linux kernel not supporting auditing (CONFIG_AUDIT=n). elastic/go-libaudit#32