### PR TITLE
Remove mention of Windows XP from docs

### DIFF
--- a/auditbeat/docs/getting-started.asciidoc
+++ b/auditbeat/docs/getting-started.asciidoc
@@ -123,8 +123,7 @@ https://www.elastic.co/downloads/beats/{beatname_lc}[downloads page].
 . Rename the +{beatname_lc}-<version>-windows+ directory to +{beatname_uc}+.
 
 . Open a PowerShell prompt as an Administrator (right-click the PowerShell icon
-and select *Run As Administrator*). If you are running Windows XP, you may need
-to download and install PowerShell.
+and select *Run As Administrator*).
 
 . From the PowerShell prompt, run the following commands to install {beatname_uc}
 as a Windows service:

--- a/filebeat/docs/getting-started.asciidoc
+++ b/filebeat/docs/getting-started.asciidoc
@@ -122,7 +122,7 @@ https://www.elastic.co/downloads/beats/filebeat[downloads page].
 
 . Rename the `filebeat-<version>-windows` directory to `Filebeat`.
 
-. Open a PowerShell prompt as an Administrator (right-click the PowerShell icon and select *Run As Administrator*). If you are running Windows XP, you may need to download and install PowerShell.
+. Open a PowerShell prompt as an Administrator (right-click the PowerShell icon and select *Run As Administrator*).
 
 . From the PowerShell prompt, run the following commands to install Filebeat as a
 Windows service:

--- a/heartbeat/docs/getting-started.asciidoc
+++ b/heartbeat/docs/getting-started.asciidoc
@@ -130,8 +130,7 @@ https://www.elastic.co/downloads/beats/heartbeat[downloads page].
 . Rename the +heartbeat-<version>-windows+ directory to +Heartbeat+.
 
 . Open a PowerShell prompt as an Administrator (right-click the PowerShell icon
-and select *Run As Administrator*). If you are running Windows XP, you may need
-to download and install PowerShell.
+and select *Run As Administrator*).
 
 . From the PowerShell prompt, run the following commands to install Heartbeat as
 a Windows service:

--- a/libbeat/docs/dashboards.asciidoc
+++ b/libbeat/docs/dashboards.asciidoc
@@ -67,8 +67,7 @@ endif::[]
 endif::allplatforms[]
 
 Open a PowerShell prompt as an Administrator (right-click the PowerShell icon
-and select *Run As Administrator*). If you are running Windows XP, you may need
-to download and install PowerShell.
+and select *Run As Administrator*).
 
 From the PowerShell prompt, change to the directory where you installed {beatname_uc},
 and run:

--- a/libbeat/docs/shared-template-load.asciidoc
+++ b/libbeat/docs/shared-template-load.asciidoc
@@ -176,8 +176,7 @@ endif::[]
 endif::allplatforms[]
 
 Open a PowerShell prompt as an Administrator (right-click the PowerShell icon
-and select *Run As Administrator*). If you are running Windows XP, you may need
-to download and install PowerShell.
+and select *Run As Administrator*).
 
 From the PowerShell prompt, change to the directory where you installed {beatname_uc},
 and run:

--- a/metricbeat/docs/gettingstarted.asciidoc
+++ b/metricbeat/docs/gettingstarted.asciidoc
@@ -130,8 +130,7 @@ https://www.elastic.co/downloads/beats/metricbeat[downloads page].
 . Rename the `metricbeat-<version>-windows` directory to `Metricbeat`.
 
 . Open a PowerShell prompt as an Administrator (right-click the PowerShell icon
-and select *Run As Administrator*). If you are running Windows XP, you may need
-to download and install PowerShell.
+and select *Run As Administrator*).
 
 . From the PowerShell prompt, run the following commands to install Metricbeat
 as a Windows service:

--- a/packetbeat/docs/gettingstarted.asciidoc
+++ b/packetbeat/docs/gettingstarted.asciidoc
@@ -126,7 +126,7 @@ https://www.elastic.co/downloads/beats/packetbeat[downloads page].
 
 . Rename the `packetbeat-<version>-windows` directory to `Packetbeat`.
 
-. Open a PowerShell prompt as an Administrator (right-click the PowerShell icon and select *Run As Administrator*). If you are running Windows XP, you may need to download and install PowerShell.
+. Open a PowerShell prompt as an Administrator (right-click the PowerShell icon and select *Run As Administrator*).
 
 . From the PowerShell prompt, run the following commands to install Packetbeat as a Windows service:
 +

--- a/winlogbeat/_meta/fields.yml
+++ b/winlogbeat/_meta/fields.yml
@@ -10,7 +10,7 @@
         "wineventlog" for the Windows Event Log API or "eventlogging" for the
         Event Logging API.
 
-        The Event Logging API was designed for Windows Server 2003, Windows XP,
+        The Event Logging API was designed for Windows Server 2003
         or Windows 2000 operating systems. In Windows Vista, the event logging
         infrastructure was redesigned. On Windows Vista or later operating
         systems, the Windows Event Log API is used. Winlogbeat automatically

--- a/winlogbeat/docs/fields.asciidoc
+++ b/winlogbeat/docs/fields.asciidoc
@@ -215,7 +215,7 @@ Contains common fields available in all event types.
 required: True
 
 The event log API type used to read the record. The possible values are "wineventlog" for the Windows Event Log API or "eventlogging" for the Event Logging API.
-The Event Logging API was designed for Windows Server 2003, Windows XP, or Windows 2000 operating systems. In Windows Vista, the event logging infrastructure was redesigned. On Windows Vista or later operating systems, the Windows Event Log API is used. Winlogbeat automatically detects which API to use for reading event logs.
+The Event Logging API was designed for Windows Server 2003 or Windows 2000 operating systems. In Windows Vista, the event logging infrastructure was redesigned. On Windows Vista or later operating systems, the Windows Event Log API is used. Winlogbeat automatically detects which API to use for reading event logs.
 
 
 --

--- a/winlogbeat/docs/getting-started.asciidoc
+++ b/winlogbeat/docs/getting-started.asciidoc
@@ -29,8 +29,7 @@ https://www.elastic.co/downloads/beats/winlogbeat[downloads page].
 . Extract the contents into `C:\Program Files`.
 . Rename the `winlogbeat-<version>` directory to `Winlogbeat`.
 . Open a PowerShell prompt as an Administrator (right-click on the PowerShell
-icon and select Run As Administrator). If you are running Windows XP, you may
-need to download and install PowerShell.
+icon and select Run As Administrator).
 . From the PowerShell prompt, run the following commands to install the service.
 
 ["source","sh",subs="attributes,callouts"]

--- a/winlogbeat/docs/overview.asciidoc
+++ b/winlogbeat/docs/overview.asciidoc
@@ -5,7 +5,7 @@
 ++++
 
 Winlogbeat ships Windows event logs to Elasticsearch or Logstash. You can
-install it as a Windows service on Windows XP or later.
+install it as a Windows service.
 
 Winlogbeat reads from one or more event logs using Windows APIs, filters the
 events based on user-configured criteria, then sends the event data to the


### PR DESCRIPTION
Closes #6987 

Removes all references to XP in the docs (expect in old changelog/release notes entries). 

Should I backport this to 6.2 (in addition to 6.3)?