### PR TITLE
Increase timeout for Logstash node stats integrationt tests

### DIFF
--- a/metricbeat/module/logstash/node/node_integration_test.go
+++ b/metricbeat/module/logstash/node/node_integration_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestFetch(t *testing.T) {
-	compose.EnsureUpWithTimeout(t, 120, "logstash")
+	compose.EnsureUpWithTimeout(t, 300, "logstash")
 
 	f := mbtest.NewEventFetcher(t, logstash.GetConfig("node"))
 	event, err := f.Fetch()


### PR DESCRIPTION
This should get rid of flaky Logstash tests.