### PR TITLE
Increase compose timeout to 300s

### DIFF
--- a/libbeat/tests/compose/compose.go
+++ b/libbeat/tests/compose/compose.go
@@ -39,7 +39,7 @@ var oldRegexp = regexp.MustCompile("minute")
 // EnsureUp starts all the requested services (must be defined in docker-compose.yml)
 // with a default timeout of 60 seconds
 func EnsureUp(t *testing.T, services ...string) {
-	EnsureUpWithTimeout(t, 60, services...)
+	EnsureUpWithTimeout(t, 300, services...)
 }
 
 // EnsureUpWithTimeout starts all the requested services (must be defined in docker-compose.yml)

--- a/libbeat/tests/system/beat/compose.py
+++ b/libbeat/tests/system/beat/compose.py
@@ -23,7 +23,7 @@ class ComposeMixin(object):
     COMPOSE_PROJECT_DIR = '.'
 
     # timeout waiting for health (seconds)
-    COMPOSE_TIMEOUT = 60
+    COMPOSE_TIMEOUT = 300
 
     @classmethod
     def compose_up(cls):

--- a/metricbeat/module/dropwizard/collector/collector_integration_test.go
+++ b/metricbeat/module/dropwizard/collector/collector_integration_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestFetch(t *testing.T) {
-	compose.EnsureUpWithTimeout(t, 300, "dropwizard")
+	compose.EnsureUp(t, "dropwizard")
 
 	f := mbtest.NewEventsFetcher(t, getConfig())
 	events, err := f.Fetch()

--- a/metricbeat/module/logstash/node/node_integration_test.go
+++ b/metricbeat/module/logstash/node/node_integration_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestFetch(t *testing.T) {
-	compose.EnsureUpWithTimeout(t, 120, "logstash")
+	compose.EnsureUp(t, "logstash")
 
 	f := mbtest.NewEventFetcher(t, logstash.GetConfig("node"))
 	event, err := f.Fetch()

--- a/metricbeat/module/logstash/node_stats/node_stats_integration_test.go
+++ b/metricbeat/module/logstash/node_stats/node_stats_integration_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestFetch(t *testing.T) {
-	compose.EnsureUpWithTimeout(t, 300, "logstash")
+	compose.EnsureUp(t, "logstash")
 
 	f := mbtest.NewEventFetcher(t, logstash.GetConfig("node_stats"))
 	event, err := f.Fetch()

--- a/metricbeat/tests/system/test_ceph.py
+++ b/metricbeat/tests/system/test_ceph.py
@@ -8,7 +8,6 @@ import time
 class Test(metricbeat.BaseTest):
 
     COMPOSE_SERVICES = ['ceph']
-    COMPOSE_TIMEOUT = 300
     FIELDS = ["ceph"]
 
     @parameterized.expand([

--- a/metricbeat/tests/system/test_kubernetes.py
+++ b/metricbeat/tests/system/test_kubernetes.py
@@ -8,7 +8,6 @@ KUBERNETES_FIELDS = metricbeat.COMMON_FIELDS + ["kubernetes"]
 class Test(metricbeat.BaseTest):
 
     COMPOSE_SERVICES = ['kubernetes']  # 'kubestate']
-    COMPOSE_TIMEOUT = 300
 
     @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
     def test_kubelet_node(self):

--- a/metricbeat/tests/system/test_logstash.py
+++ b/metricbeat/tests/system/test_logstash.py
@@ -7,7 +7,6 @@ import time
 class Test(metricbeat.BaseTest):
 
     COMPOSE_SERVICES = ['logstash']
-    COMPOSE_TIMEOUT = 300
 
     @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
     def test_node(self):


### PR DESCRIPTION
Increasing the default compose timeout in Golang and Pythont tests to 300s. We had several tests overwriting already so instead of having lots of timeouts configured I prefer to set the default higher as in most cases it will not have any impact. Only service left that overwrites the default is Kibana.