### PR TITLE
Cherry-pick #6877 to 6.3: Commit registry writes to stable storage to avoid corrupt registry files

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -66,6 +66,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Fix panic when log prospector configuration fails to load. {issue}6800[6800]
 - Fix memory leak in log prospector when files cannot be read. {issue}6797[6797]
 - Add raw JSON to message field when JSON parsing fails. {issue}6516[6516]
+- Commit registry writes to stable storage to avoid corrupt registry files. {pull}6877[6877]
 
 *Heartbeat*
 - Fix race due to updates of shared a map, that was not supposed to be shared between multiple go-routines. {issue}6616[6616]

--- a/filebeat/registrar/registrar.go
+++ b/filebeat/registrar/registrar.go
@@ -280,6 +280,8 @@ func (r *Registrar) writeRegistry() error {
 		return err
 	}
 
+	// Commit the changes to storage to avoid corrupt registry files
+	f.Sync()
 	// Directly close file because of windows
 	f.Close()
 


### PR DESCRIPTION
Cherry-pick of PR #6877 to 6.3 branch. Original message: 

Called `Sync` before closing the file in order to flush everything to disk before closing the registry file.

Closes #6792 