### PR TITLE
Small improvement to unit-test error output for Filebeat

### DIFF
--- a/filebeat/config/config_test.go
+++ b/filebeat/config/config_test.go
@@ -92,7 +92,8 @@ func TestMergeConfigFiles(t *testing.T) {
 	assert.Equal(t, 2, len(files))
 
 	config := &Config{}
-	mergeConfigFiles(files, config)
+	err = mergeConfigFiles(files, config)
+	assert.NoError(t, err)
 
 	assert.Equal(t, 4, len(config.Inputs))
 }


### PR DESCRIPTION
Based on the discussion that happened here: https://discuss.elastic.co/t/dev-environment-testsuite-failing-on-filebeat/130265/5

Improve test output by adding an assert to show possible errors during filebeats' TestMergeConfigFiles unit test.