### PR TITLE
Minor Update

### DIFF
--- a/metricbeat/module/jolokia/jmx/_meta/test/config.yml
+++ b/metricbeat/module/jolokia/jmx/_meta/test/config.yml
@@ -15,7 +15,7 @@ metricbeat.modules:
       attributes:
         - attr: Uptime
           field: uptime
-    - mbean: 'java.lang:type=GarbageCollector,name=ConcurrentMarkSweep'
+    - mbean: 'java.lang:name=ConcurrentMarkSweep,type=GarbageCollector'
       attributes:
         - attr: CollectionTime
           field: gc.cms_collection_time


### PR DESCRIPTION
With older version, I getting error message : 2 errors: metric key 'java.lang:name=ConcurrentMarkSweep,type=GarbageCollector_CollectionTime' not found in response; metric key 'java.lang:name=ConcurrentMarkSweep,type=GarbageCollector_CollectionCount' not found in response

Changing the mbean name - like first name and then type is working.