### PR TITLE
Readd BEAT_VERSION to compose project

### DIFF
--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -65,7 +65,7 @@ GOX_FLAGS?= ## @building Additional flags to append to the gox command used by "
 TESTING_ENVIRONMENT?=snapshot## @testing The name of the environment under test
 BEAT_VERSION=$(shell head -n 1 ${ES_BEATS}/libbeat/docs/version.asciidoc | cut -c 17- )
 COMMIT_ID=$(shell git rev-parse HEAD)
-DOCKER_COMPOSE_PROJECT_NAME?=${BEAT_NAME}${TESTING_ENVIRONMENT//-}${COMMIT_ID} ## @testing The name of the docker-compose project used by the integration and system tests
+DOCKER_COMPOSE_PROJECT_NAME?=${BEAT_NAME}${TESTING_ENVIRONMENT//-}${BEAT_VERSION//-}${COMMIT_ID} ## @testing The name of the docker-compose project used by the integration and system tests
 DOCKER_COMPOSE?=TESTING_ENVIRONMENT=${TESTING_ENVIRONMENT} ES_BEATS=${ES_BEATS} docker-compose -p ${DOCKER_COMPOSE_PROJECT_NAME} -f docker-compose.yml
 DOCKER_CACHE?=1 ## @miscellaneous If set to 0, all docker images are created without cache
 GOPACKAGES_COMMA_SEP=$(subst $(space),$(comma),$(strip ${GOPACKAGES}))
@@ -357,7 +357,7 @@ import-dashboards: update ${BEAT_NAME}
 # Builds the environment to test beat
 .PHONY: build-image
 build-image: write-environment
-	${DOCKER_COMPOSE} build ${DOCKER_NOCACHE}
+	${DOCKER_COMPOSE} build ${DOCKER_NOCACHE} --pull --force-rm
 
 # Runs the environment so the redis and elasticsearch can also be used for local development
 # To use it for running the test, set ES_HOST and REDIS_HOST environment variable to the ip of your docker-machine.

--- a/testing/environments/Makefile
+++ b/testing/environments/Makefile
@@ -3,7 +3,7 @@ BASE_COMMAND=docker-compose -f ${ENV} -f local.yml
 
 start:
 	# This is run every time to make sure the environment is up-to-date
-	${BASE_COMMAND} build
+	${BASE_COMMAND} build --pull --force-rm
 	${BASE_COMMAND} run beat bash
 
 stop:


### PR DESCRIPTION
This was removed previously but potentially could cause issue if the same commit is in different branches and the projects were not cleaned up properly.

Further changes:

* `--pull` and `--force-rm` are added when building the image. The `--pull` flag ensures that for images which we didn't specify the exact version it is checked every time if a new version is available. The `--force-rm` removes intermediate containers after the build. This should lead to less obsolete intermediate containers on the CI workers.
* The error handling inside compose for Golang was improved to have error messages log in case of killing errors
* logstash and kibana were added to the services that are kept running. The assumption is that sometimes a race happened trying to start Logstash during shutdown