### PR TITLE
Travis doesn't do apt-get update anymore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -130,6 +130,7 @@ jobs:
 
 addons:
   apt:
+    update: true
     packages:
       - python-virtualenv
       - libpcap-dev


### PR DESCRIPTION
I still think we want to make sure our stack tests with the latest
available debian packages. To go back to the previous behavior we have
to explicitely enabled it in our .travis.yml.

Warning from Travis:

```
Running apt-get update by default has been disabled.
You can opt into running apt-get update by setting this in your .travis.yml file:
  apt:
    update: true
```