### PR TITLE
Cherry-pick #7051 to 6.3: Add host.name in the events

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -17,7 +17,6 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Rename beat.cpu.*.time metrics to beat.cpu.*.time.ms. {pull}6449[6449]
 - Mark `system.syslog.message` and `system.auth.message` as `text` instead of `keyword`. {pull}6589[6589]
 - Allow override of dynamic template `match_mapping_type` for fields with object_type. {pull}6691[6691]
-- Set default kafka version to 1.0.0 in kafka output. Older versions are still supported by configuring the `version` setting. {pull}7025[7025]
 - Add `host.name` field to all events, to avoid mapping conflicts. This could be breaking Logstash configs if you rely on the `host` field being a string. {pull}7051[7051]
 
 *Auditbeat*

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -17,6 +17,8 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Rename beat.cpu.*.time metrics to beat.cpu.*.time.ms. {pull}6449[6449]
 - Mark `system.syslog.message` and `system.auth.message` as `text` instead of `keyword`. {pull}6589[6589]
 - Allow override of dynamic template `match_mapping_type` for fields with object_type. {pull}6691[6691]
+- Set default kafka version to 1.0.0 in kafka output. Older versions are still supported by configuring the `version` setting. {pull}7025[7025]
+- Add `host.name` field to all events, to avoid mapping conflicts. This could be breaking Logstash configs if you rely on the `host` field being a string. {pull}7051[7051]
 
 *Auditbeat*
 

--- a/dev-tools/jenkins_ci.ps1
+++ b/dev-tools/jenkins_ci.ps1
@@ -36,13 +36,14 @@ exec { go get -u github.com/jstemmer/go-junit-report }
 echo "Building $env:beat"
 exec { go build } "Build FAILURE"
 
+# always build the libbeat fields
+cp ..\libbeat\_meta\fields.common.yml ..\libbeat\_meta\fields.generated.yml
+cat ..\libbeat\processors\*\_meta\fields.yml | Out-File -append -encoding UTF8 -filepath ..\libbeat\_meta\fields.generated.yml
+cp ..\libbeat\_meta\fields.generated.yml ..\libbeat\fields.yml
+
 if ($env:beat -eq "metricbeat") {
     cp .\_meta\fields.common.yml .\_meta\fields.generated.yml
     python .\scripts\fields_collector.py | out-file -append -encoding UTF8 -filepath .\_meta\fields.generated.yml
-} elseif ($env:beat -eq "libbeat") {
-    cp .\_meta\fields.common.yml .\_meta\fields.generated.yml
-    cat processors\*\_meta\fields.yml | Out-File -append -encoding UTF8 -filepath .\_meta\fields.generated.yml
-    cp .\_meta\fields.generated.yml .\fields.yml
 }
 
 echo "Unit testing $env:beat"

--- a/libbeat/publisher/pipeline/module.go
+++ b/libbeat/publisher/pipeline/module.go
@@ -50,10 +50,15 @@ func Load(
 		Processors:    processors,
 		Annotations: Annotations{
 			Event: config.EventMetadata,
-			Beat: common.MapStr{
-				"name":     name,
-				"hostname": beatInfo.Hostname,
-				"version":  beatInfo.Version,
+			Builtin: common.MapStr{
+				"beat": common.MapStr{
+					"name":     name,
+					"hostname": beatInfo.Hostname,
+					"version":  beatInfo.Version,
+				},
+				"host": common.MapStr{
+					"name": name,
+				},
 			},
 		},
 	}

--- a/libbeat/publisher/pipeline/pipeline.go
+++ b/libbeat/publisher/pipeline/pipeline.go
@@ -62,9 +62,9 @@ type pipelineProcessors struct {
 	// The pipeline its processor settings for
 	// constructing the clients complete processor
 	// pipeline on connect.
-	beatsMeta common.MapStr
-	fields    common.MapStr
-	tags      []string
+	builtinMeta common.MapStr
+	fields      common.MapStr
+	tags        []string
 
 	processors beat.Processor
 
@@ -91,8 +91,8 @@ type Settings struct {
 // processors, so all processors configured with the pipeline or client will see
 // the same/complete event.
 type Annotations struct {
-	Beat  common.MapStr
-	Event common.EventMetadata
+	Event   common.EventMetadata
+	Builtin common.MapStr
 }
 
 // WaitCloseMode enumerates the possible behaviors of WaitClose in a pipeline.
@@ -401,8 +401,8 @@ func makePipelineProcessors(
 		p.processors = tmp
 	}
 
-	if meta := annotations.Beat; meta != nil {
-		p.beatsMeta = common.MapStr{"beat": meta}
+	if meta := annotations.Builtin; meta != nil {
+		p.builtinMeta = meta
 	}
 
 	if em := annotations.Event; len(em.Fields) > 0 {

--- a/libbeat/publisher/pipeline/processor.go
+++ b/libbeat/publisher/pipeline/processor.go
@@ -99,8 +99,8 @@ func newProcessorPipeline(
 	// setup 5: client processor list
 	processors.add(localProcessors)
 
-	// setup 6: add beats metadata
-	if meta := global.beatsMeta; len(meta) > 0 {
+	// setup 6: add beats and host metadata
+	if meta := global.builtinMeta; len(meta) > 0 {
 		processors.add(makeAddFieldsProcessor("beatsMeta", meta, needsCopy))
 	}
 

--- a/metricbeat/tests/system/metricbeat.py
+++ b/metricbeat/tests/system/metricbeat.py
@@ -7,7 +7,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '../../../libbeat/tests/
 from beat.beat import TestCase
 
 COMMON_FIELDS = ["@timestamp", "beat", "metricset.name", "metricset.host",
-                 "metricset.module", "metricset.rtt"]
+                 "metricset.module", "metricset.rtt", "host.name"]
 
 INTEGRATION_TESTS = os.environ.get('INTEGRATION_TESTS', False)
 

--- a/metricbeat/tests/system/test_processors.py
+++ b/metricbeat/tests/system/test_processors.py
@@ -35,7 +35,7 @@ class Test(metricbeat.BaseTest):
         print(evt.keys())
         self.assertItemsEqual(self.de_dot([
             'beat', '@timestamp', 'system', 'metricset.module',
-            'metricset.rtt', 'metricset.name'
+            'metricset.rtt', 'metricset.name', 'host'
         ]), evt.keys())
         cpu = evt["system"]["cpu"]
         print(cpu.keys())


### PR DESCRIPTION
Cherry-pick of PR #7051 to 6.3 branch. Original message: 

As a solution for #7050, we're adding a `host.name` field to
all events. This is duplicate information from `beat.name`,
but is used to avoid the mapping conflict and to slowly
introduce the "host as an object" approach.

To remove the duplication, you can remove `beat.name` like this:

    processors:
      - drop_fields.fields: ["beat.name"]

Closes #7050.