### PR TITLE
Add Beats state reporting

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -172,6 +172,7 @@ https://github.com/elastic/beats/compare/v6.2.3...master[Check the HEAD diff]
 - Add support to disable html escaping in outputs. {pull}7445[7445]
 - Refactor error handing in schema.Apply(). {pull}7335[7335]
 - Add additional types to kubernetes metadata {pull}7457[7457]
+- Add module state reporting for X-Pack Monitoring. {pull}7075[7075]
 
 *Auditbeat*
 

--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -1143,6 +1143,9 @@ logging.files:
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
 
+  #stats.period: 10s
+  #state.period: 1m
+
 #================================ HTTP Endpoint ======================================
 # Each beat can expose internal metrics through a HTTP endpoint. For security
 # reasons the endpoint is disabled by default. This feature is currently experimental.

--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -1143,7 +1143,7 @@ logging.files:
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
 
-  #metric.period: 10s
+  #metrics.period: 10s
   #state.period: 1m
 
 #================================ HTTP Endpoint ======================================

--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -1143,7 +1143,7 @@ logging.files:
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
 
-  #stats.period: 10s
+  #metric.period: 10s
   #state.period: 1m
 
 #================================ HTTP Endpoint ======================================

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -1803,7 +1803,7 @@ logging.files:
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
 
-  #stats.period: 10s
+  #metric.period: 10s
   #state.period: 1m
 
 #================================ HTTP Endpoint ======================================

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -1803,6 +1803,9 @@ logging.files:
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
 
+  #stats.period: 10s
+  #state.period: 1m
+
 #================================ HTTP Endpoint ======================================
 # Each beat can expose internal metrics through a HTTP endpoint. For security
 # reasons the endpoint is disabled by default. This feature is currently experimental.

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -1803,7 +1803,7 @@ logging.files:
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
 
-  #metric.period: 10s
+  #metrics.period: 10s
   #state.period: 1m
 
 #================================ HTTP Endpoint ======================================

--- a/heartbeat/heartbeat.reference.yml
+++ b/heartbeat/heartbeat.reference.yml
@@ -1252,7 +1252,7 @@ logging.files:
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
 
-  #stats.period: 10s
+  #metric.period: 10s
   #state.period: 1m
 
 #================================ HTTP Endpoint ======================================

--- a/heartbeat/heartbeat.reference.yml
+++ b/heartbeat/heartbeat.reference.yml
@@ -1252,7 +1252,7 @@ logging.files:
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
 
-  #metric.period: 10s
+  #metrics.period: 10s
   #state.period: 1m
 
 #================================ HTTP Endpoint ======================================

--- a/heartbeat/heartbeat.reference.yml
+++ b/heartbeat/heartbeat.reference.yml
@@ -1252,6 +1252,9 @@ logging.files:
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
 
+  #stats.period: 10s
+  #state.period: 1m
+
 #================================ HTTP Endpoint ======================================
 # Each beat can expose internal metrics through a HTTP endpoint. For security
 # reasons the endpoint is disabled by default. This feature is currently experimental.

--- a/libbeat/_meta/config.reference.yml
+++ b/libbeat/_meta/config.reference.yml
@@ -1038,7 +1038,7 @@ logging.files:
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
 
-  #stats.period: 10s
+  #metric.period: 10s
   #state.period: 1m
 
 #================================ HTTP Endpoint ======================================

--- a/libbeat/_meta/config.reference.yml
+++ b/libbeat/_meta/config.reference.yml
@@ -1038,6 +1038,9 @@ logging.files:
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
 
+  #stats.period: 10s
+  #state.period: 1m
+
 #================================ HTTP Endpoint ======================================
 # Each beat can expose internal metrics through a HTTP endpoint. For security
 # reasons the endpoint is disabled by default. This feature is currently experimental.

--- a/libbeat/_meta/config.reference.yml
+++ b/libbeat/_meta/config.reference.yml
@@ -1038,7 +1038,7 @@ logging.files:
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
 
-  #metric.period: 10s
+  #metrics.period: 10s
   #state.period: 1m
 
 #================================ HTTP Endpoint ======================================

--- a/libbeat/api/server.go
+++ b/libbeat/api/server.go
@@ -41,6 +41,7 @@ func Start(cfg *common.Config) {
 
 		// register handlers
 		mux.HandleFunc("/", rootHandler())
+		mux.HandleFunc("/state", stateHandler)
 		mux.HandleFunc("/stats", statsHandler)
 		mux.HandleFunc("/dataset", datasetHandler)
 
@@ -61,10 +62,19 @@ func rootHandler() func(http.ResponseWriter, *http.Request) {
 
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 
-		data := monitoring.CollectStructSnapshot(monitoring.GetNamespace("state").GetRegistry(), monitoring.Full, false)
+		data := monitoring.CollectStructSnapshot(monitoring.GetNamespace("info").GetRegistry(), monitoring.Full, false)
 
 		print(w, data, r.URL)
 	}
+}
+
+// stateHandler reports state metrics
+func stateHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+
+	data := monitoring.CollectStructSnapshot(monitoring.GetNamespace("state").GetRegistry(), monitoring.Full, false)
+
+	print(w, data, r.URL)
 }
 
 // statsHandler report expvar and all libbeat/monitoring metrics

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -166,8 +166,7 @@ func Run(name, idxPrefix, version string, bt beat.Creator) error {
 			return err
 		}
 
-		registry := monitoring.NewRegistry()
-		monitoring.GetNamespace("state").SetRegistry(registry)
+		registry := monitoring.GetNamespace("info").GetRegistry()
 		monitoring.NewString(registry, "version").Set(b.Info.Version)
 		monitoring.NewString(registry, "beat").Set(b.Info.Beat)
 		monitoring.NewString(registry, "name").Set(b.Info.Name)

--- a/libbeat/monitoring/report/elasticsearch/client.go
+++ b/libbeat/monitoring/report/elasticsearch/client.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/monitoring/report"
 	esout "github.com/elastic/beats/libbeat/outputs/elasticsearch"
 	"github.com/elastic/beats/libbeat/publisher"
@@ -38,7 +39,6 @@ var (
 	actMonitoringBeats = common.MapStr{
 		"index": common.MapStr{
 			"_index":   "",
-			"_type":    "beats_stats",
 			"_routing": nil,
 		},
 	}
@@ -97,7 +97,34 @@ func (c *publishClient) Close() error {
 func (c *publishClient) Publish(batch publisher.Batch) error {
 	events := batch.Events()
 	bulk := make([]interface{}, 0, 2*len(events))
+
+	var params map[string]string
 	for _, event := range events {
+
+		// Extract time
+		t, err := event.Content.Meta.GetValue("type")
+		if err != nil {
+			logp.Err("Type not available in monitoring reported. Please report this error: %s", err)
+			continue
+		}
+
+		params = map[string]string{}
+		// Copy params
+		for k, v := range c.params {
+			params[k] = v
+		}
+		// Extract potential additional params
+		p, err := event.Content.Meta.GetValue("params")
+		if err == nil {
+			p2, ok := p.(map[string]string)
+			if ok {
+				for k, v := range p2 {
+					params[k] = v
+				}
+			}
+		}
+		actMonitoringBeats.Put("index._type", t)
+
 		bulk = append(bulk,
 			actMonitoringBeats, report.Event{
 				Timestamp: event.Content.Timestamp,
@@ -105,7 +132,7 @@ func (c *publishClient) Publish(batch publisher.Batch) error {
 			})
 	}
 
-	_, err := c.es.BulkWith("_xpack", "monitoring", c.params, nil, bulk)
+	_, err := c.es.BulkWith("_xpack", "monitoring", params, nil, bulk)
 	if err != nil {
 		batch.Retry()
 		return err

--- a/libbeat/monitoring/report/elasticsearch/client.go
+++ b/libbeat/monitoring/report/elasticsearch/client.go
@@ -98,7 +98,6 @@ func (c *publishClient) Publish(batch publisher.Batch) error {
 	events := batch.Events()
 	var failed []publisher.Event
 	var reason error
-	var params map[string]string
 	for _, event := range events {
 
 		// Extract time
@@ -108,7 +107,7 @@ func (c *publishClient) Publish(batch publisher.Batch) error {
 			continue
 		}
 
-		params = map[string]string{}
+		var params = map[string]string{}
 		// Copy params
 		for k, v := range c.params {
 			params[k] = v

--- a/libbeat/monitoring/report/elasticsearch/config.go
+++ b/libbeat/monitoring/report/elasticsearch/config.go
@@ -37,7 +37,8 @@ type config struct {
 	TLS              *tlscommon.Config `config:"ssl"`
 	MaxRetries       int               `config:"max_retries"`
 	Timeout          time.Duration     `config:"timeout"`
-	Period           time.Duration     `config:"period"`
+	StatsPeriod      time.Duration     `config:"stats.period"`
+	StatePeriod      time.Duration     `config:"state.period"`
 	BulkMaxSize      int               `config:"bulk_max_size" validate:"min=0"`
 	BufferSize       int               `config:"buffer_size"`
 	Tags             []string          `config:"tags"`
@@ -55,7 +56,8 @@ var defaultConfig = config{
 	TLS:              nil,
 	MaxRetries:       3,
 	Timeout:          60 * time.Second,
-	Period:           10 * time.Second,
+	StatsPeriod:      10 * time.Second,
+	StatePeriod:      1 * time.Minute,
 	BulkMaxSize:      50,
 	BufferSize:       50,
 	Tags:             nil,

--- a/libbeat/monitoring/report/elasticsearch/config.go
+++ b/libbeat/monitoring/report/elasticsearch/config.go
@@ -37,7 +37,7 @@ type config struct {
 	TLS              *tlscommon.Config `config:"ssl"`
 	MaxRetries       int               `config:"max_retries"`
 	Timeout          time.Duration     `config:"timeout"`
-	StatsPeriod      time.Duration     `config:"stats.period"`
+	MetricPeriod     time.Duration     `config:"metric.period"`
 	StatePeriod      time.Duration     `config:"state.period"`
 	BulkMaxSize      int               `config:"bulk_max_size" validate:"min=0"`
 	BufferSize       int               `config:"buffer_size"`
@@ -56,7 +56,7 @@ var defaultConfig = config{
 	TLS:              nil,
 	MaxRetries:       3,
 	Timeout:          60 * time.Second,
-	StatsPeriod:      10 * time.Second,
+	MetricPeriod:     10 * time.Second,
 	StatePeriod:      1 * time.Minute,
 	BulkMaxSize:      50,
 	BufferSize:       50,

--- a/libbeat/monitoring/report/elasticsearch/config.go
+++ b/libbeat/monitoring/report/elasticsearch/config.go
@@ -37,7 +37,7 @@ type config struct {
 	TLS              *tlscommon.Config `config:"ssl"`
 	MaxRetries       int               `config:"max_retries"`
 	Timeout          time.Duration     `config:"timeout"`
-	MetricPeriod     time.Duration     `config:"metric.period"`
+	MetricsPeriod    time.Duration     `config:"metrics.period"`
 	StatePeriod      time.Duration     `config:"state.period"`
 	BulkMaxSize      int               `config:"bulk_max_size" validate:"min=0"`
 	BufferSize       int               `config:"buffer_size"`
@@ -56,7 +56,7 @@ var defaultConfig = config{
 	TLS:              nil,
 	MaxRetries:       3,
 	Timeout:          60 * time.Second,
-	MetricPeriod:     10 * time.Second,
+	MetricsPeriod:    10 * time.Second,
 	StatePeriod:      1 * time.Minute,
 	BulkMaxSize:      50,
 	BufferSize:       50,

--- a/libbeat/monitoring/report/elasticsearch/elasticsearch.go
+++ b/libbeat/monitoring/report/elasticsearch/elasticsearch.go
@@ -43,7 +43,6 @@ import (
 type reporter struct {
 	done *stopper
 
-	period     time.Duration
 	checkRetry time.Duration
 
 	// event metadata
@@ -102,7 +101,6 @@ func makeReporter(beat beat.Info, cfg *common.Config) (report.Reporter, error) {
 	for k, v := range config.Params {
 		params[k] = v
 	}
-	params["interval"] = config.Period.String()
 
 	out := outputs.Group{
 		Clients:   nil,
@@ -129,7 +127,7 @@ func makeReporter(beat beat.Info, cfg *common.Config) (report.Reporter, error) {
 		}), nil
 	}
 
-	monitoring := monitoring.Default.NewRegistry("xpack.monitoring")
+	monitoring := monitoring.Default.GetRegistry("xpack.monitoring")
 
 	pipeline, err := pipeline.New(
 		beat,
@@ -150,7 +148,6 @@ func makeReporter(beat beat.Info, cfg *common.Config) (report.Reporter, error) {
 
 	r := &reporter{
 		done:       newStopper(),
-		period:     config.Period,
 		beatMeta:   makeMeta(beat),
 		tags:       config.Tags,
 		checkRetry: checkRetry,
@@ -158,7 +155,7 @@ func makeReporter(beat beat.Info, cfg *common.Config) (report.Reporter, error) {
 		client:     client,
 		out:        out,
 	}
-	go r.initLoop()
+	go r.initLoop(config)
 	return r, nil
 }
 
@@ -168,7 +165,7 @@ func (r *reporter) Stop() {
 	r.pipeline.Close()
 }
 
-func (r *reporter) initLoop() {
+func (r *reporter) initLoop(c config) {
 	debugf("Start monitoring endpoint init loop.")
 	defer debugf("Finish monitoring endpoint init loop.")
 
@@ -199,15 +196,16 @@ func (r *reporter) initLoop() {
 	logp.Info("Successfully connected to X-Pack Monitoring endpoint.")
 
 	// Start collector and send loop if monitoring endpoint has been found.
-	go r.snapshotLoop()
+	go r.snapshotLoop("state", c.StatePeriod)
+	go r.snapshotLoop("stats", c.StatsPeriod)
 }
 
-func (r *reporter) snapshotLoop() {
-	ticker := time.NewTicker(r.period)
+func (r *reporter) snapshotLoop(namespace string, period time.Duration) {
+	ticker := time.NewTicker(period)
 	defer ticker.Stop()
 
-	logp.Info("Start monitoring metrics snapshot loop.")
-	defer logp.Info("Stop monitoring metrics snapshot loop.")
+	logp.Info("Start monitoring %s metrics snapshot loop with period %s.", namespace, period)
+	defer logp.Info("Stop monitoring %s metrics snapshot loop.", namespace)
 
 	for {
 		var ts time.Time
@@ -218,7 +216,7 @@ func (r *reporter) snapshotLoop() {
 		case ts = <-ticker.C:
 		}
 
-		snapshot := makeSnapshot(monitoring.Default)
+		snapshot := makeSnapshot(monitoring.GetNamespace(namespace).GetRegistry())
 		if snapshot == nil {
 			debugf("Empty snapshot.")
 			continue
@@ -226,15 +224,19 @@ func (r *reporter) snapshotLoop() {
 
 		fields := common.MapStr{
 			"beat":    r.beatMeta,
-			"metrics": snapshot,
+			namespace: snapshot,
 		}
 		if len(r.tags) > 0 {
 			fields["tags"] = r.tags
 		}
-
 		r.client.Publish(beat.Event{
 			Timestamp: ts,
 			Fields:    fields,
+			Meta: common.MapStr{
+				"type":        "beats_" + namespace,
+				"interval_ms": period * time.Millisecond,
+				"params":      map[string]string{"interval": period.String()},
+			},
 		})
 	}
 }

--- a/libbeat/monitoring/report/elasticsearch/elasticsearch.go
+++ b/libbeat/monitoring/report/elasticsearch/elasticsearch.go
@@ -197,7 +197,7 @@ func (r *reporter) initLoop(c config) {
 
 	// Start collector and send loop if monitoring endpoint has been found.
 	go r.snapshotLoop("state", c.StatePeriod)
-	go r.snapshotLoop("stats", c.MetricPeriod)
+	go r.snapshotLoop("stats", c.MetricsPeriod)
 }
 
 func (r *reporter) snapshotLoop(namespace string, period time.Duration) {

--- a/libbeat/monitoring/report/elasticsearch/elasticsearch.go
+++ b/libbeat/monitoring/report/elasticsearch/elasticsearch.go
@@ -197,7 +197,7 @@ func (r *reporter) initLoop(c config) {
 
 	// Start collector and send loop if monitoring endpoint has been found.
 	go r.snapshotLoop("state", c.StatePeriod)
-	go r.snapshotLoop("stats", c.StatsPeriod)
+	go r.snapshotLoop("stats", c.MetricPeriod)
 }
 
 func (r *reporter) snapshotLoop(namespace string, period time.Duration) {

--- a/libbeat/monitoring/report/elasticsearch/elasticsearch.go
+++ b/libbeat/monitoring/report/elasticsearch/elasticsearch.go
@@ -25,6 +25,8 @@ import (
 	"strings"
 	"time"
 
+	"strconv"
+
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/transport/tlscommon"
@@ -234,8 +236,9 @@ func (r *reporter) snapshotLoop(namespace string, period time.Duration) {
 			Fields:    fields,
 			Meta: common.MapStr{
 				"type":        "beats_" + namespace,
-				"interval_ms": period * time.Millisecond,
-				"params":      map[string]string{"interval": period.String()},
+				"interval_ms": int64(period / time.Millisecond),
+				// Converting to seconds as interval only accepts `s` as unit
+				"params": map[string]string{"interval": strconv.Itoa(int(period/time.Second)) + "s"},
 			},
 		})
 	}

--- a/libbeat/monitoring/snapshot.go
+++ b/libbeat/monitoring/snapshot.go
@@ -22,10 +22,11 @@ import "strings"
 // FlatSnapshot represents a flatten snapshot of all metrics.
 // Names in the tree will be joined with `.` .
 type FlatSnapshot struct {
-	Bools   map[string]bool
-	Ints    map[string]int64
-	Floats  map[string]float64
-	Strings map[string]string
+	Bools        map[string]bool
+	Ints         map[string]int64
+	Floats       map[string]float64
+	Strings      map[string]string
+	StringSlices map[string][]string
 }
 
 type flatSnapshotVisitor struct {
@@ -68,10 +69,11 @@ func CollectFlatSnapshot(r *Registry, mode Mode, expvar bool) FlatSnapshot {
 
 func MakeFlatSnapshot() FlatSnapshot {
 	return FlatSnapshot{
-		Bools:   map[string]bool{},
-		Ints:    map[string]int64{},
-		Floats:  map[string]float64{},
-		Strings: map[string]string{},
+		Bools:        map[string]bool{},
+		Ints:         map[string]int64{},
+		Floats:       map[string]float64{},
+		Strings:      map[string]string{},
+		StringSlices: map[string][]string{},
 	}
 }
 
@@ -142,6 +144,10 @@ func (vs *flatSnapshotVisitor) OnFloat(f float64) {
 	vs.snapshot.Floats[vs.getName()] = f
 }
 
+func (vs *flatSnapshotVisitor) OnStringSlice(f []string) {
+	vs.snapshot.StringSlices[vs.getName()] = f
+}
+
 func newStructSnapshotVisitor() *structSnapshotVisitor {
 	vs := &structSnapshotVisitor{}
 	vs.key.stack = vs.key.stack0[:0]
@@ -179,6 +185,11 @@ func (s *structSnapshotVisitor) OnString(str string) { s.setValue(str) }
 func (s *structSnapshotVisitor) OnBool(b bool)       { s.setValue(b) }
 func (s *structSnapshotVisitor) OnInt(i int64)       { s.setValue(i) }
 func (s *structSnapshotVisitor) OnFloat(f float64)   { s.setValue(f) }
+func (s *structSnapshotVisitor) OnStringSlice(f []string) {
+	c := make([]string, len(f))
+	copy(c, f)
+	s.setValue(c)
+}
 
 func (s *structSnapshotVisitor) setValue(v interface{}) {
 	if s.event.current == nil {

--- a/libbeat/monitoring/visitor.go
+++ b/libbeat/monitoring/visitor.go
@@ -28,6 +28,7 @@ type ValueVisitor interface {
 	OnBool(b bool)
 	OnInt(i int64)
 	OnFloat(f float64)
+	OnStringSlice(f []string)
 }
 
 type RegistryVisitor interface {
@@ -66,4 +67,9 @@ func ReportInt(V Visitor, name string, value int64) {
 func ReportFloat(V Visitor, name string, value float64) {
 	V.OnKey(name)
 	V.OnFloat(value)
+}
+
+func ReportStringSlice(V Visitor, name string, value []string) {
+	V.OnKey(name)
+	V.OnStringSlice(value)
 }

--- a/libbeat/monitoring/visitor_kv.go
+++ b/libbeat/monitoring/visitor_kv.go
@@ -52,8 +52,9 @@ func (vs *KeyValueVisitor) dropName() {
 	vs.level = vs.level[:len(vs.level)-1]
 }
 
-func (vs *KeyValueVisitor) OnString(s string) { vs.cb(vs.getName(), s) }
-func (vs *KeyValueVisitor) OnBool(b bool)     { vs.cb(vs.getName(), b) }
-func (vs *KeyValueVisitor) OnNil()            { vs.cb(vs.getName(), nil) }
-func (vs *KeyValueVisitor) OnInt(i int64)     { vs.cb(vs.getName(), i) }
-func (vs *KeyValueVisitor) OnFloat(f float64) { vs.cb(vs.getName(), f) }
+func (vs *KeyValueVisitor) OnString(s string)        { vs.cb(vs.getName(), s) }
+func (vs *KeyValueVisitor) OnBool(b bool)            { vs.cb(vs.getName(), b) }
+func (vs *KeyValueVisitor) OnNil()                   { vs.cb(vs.getName(), nil) }
+func (vs *KeyValueVisitor) OnInt(i int64)            { vs.cb(vs.getName(), i) }
+func (vs *KeyValueVisitor) OnFloat(f float64)        { vs.cb(vs.getName(), f) }
+func (vs *KeyValueVisitor) OnStringSlice(f []string) { vs.cb(vs.getName(), f) }

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -1679,6 +1679,9 @@ logging.files:
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
 
+  #stats.period: 10s
+  #state.period: 1m
+
 #================================ HTTP Endpoint ======================================
 # Each beat can expose internal metrics through a HTTP endpoint. For security
 # reasons the endpoint is disabled by default. This feature is currently experimental.

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -1679,7 +1679,7 @@ logging.files:
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
 
-  #metric.period: 10s
+  #metrics.period: 10s
   #state.period: 1m
 
 #================================ HTTP Endpoint ======================================

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -1679,7 +1679,7 @@ logging.files:
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
 
-  #stats.period: 10s
+  #metric.period: 10s
   #state.period: 1m
 
 #================================ HTTP Endpoint ======================================

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -1515,7 +1515,7 @@ logging.files:
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
 
-  #metric.period: 10s
+  #metrics.period: 10s
   #state.period: 1m
 
 #================================ HTTP Endpoint ======================================

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -1515,6 +1515,9 @@ logging.files:
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
 
+  #stats.period: 10s
+  #state.period: 1m
+
 #================================ HTTP Endpoint ======================================
 # Each beat can expose internal metrics through a HTTP endpoint. For security
 # reasons the endpoint is disabled by default. This feature is currently experimental.

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -1515,7 +1515,7 @@ logging.files:
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
 
-  #stats.period: 10s
+  #metric.period: 10s
   #state.period: 1m
 
 #================================ HTTP Endpoint ======================================

--- a/winlogbeat/winlogbeat.reference.yml
+++ b/winlogbeat/winlogbeat.reference.yml
@@ -1067,7 +1067,7 @@ logging.files:
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
 
-  #stats.period: 10s
+  #metric.period: 10s
   #state.period: 1m
 
 #================================ HTTP Endpoint ======================================

--- a/winlogbeat/winlogbeat.reference.yml
+++ b/winlogbeat/winlogbeat.reference.yml
@@ -1067,6 +1067,9 @@ logging.files:
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
 
+  #stats.period: 10s
+  #state.period: 1m
+
 #================================ HTTP Endpoint ======================================
 # Each beat can expose internal metrics through a HTTP endpoint. For security
 # reasons the endpoint is disabled by default. This feature is currently experimental.

--- a/winlogbeat/winlogbeat.reference.yml
+++ b/winlogbeat/winlogbeat.reference.yml
@@ -1067,7 +1067,7 @@ logging.files:
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
 
-  #metric.period: 10s
+  #metrics.period: 10s
   #state.period: 1m
 
 #================================ HTTP Endpoint ======================================


### PR DESCRIPTION
Currently in monitoring or the API endpoint it's not visible which modules are running. This PR adds and endpoint `/state` which shows the following data:

```
{
  "module": {
    "count": 3,
    "names": [
      "system"
    ]
  }
}
```

The names are a unique list of module names that are running and the count is a total of all the modules that are running. In the above case it's 3 as the system module is started by default 3 times with different configs / periods. Currently this reporting only works for Metricbeat.

The same state metrics are reported to X-Pack Monitoring. The data is reported every minute by default.

Additional changes:

* Introduce ArraySlice support in metrics
* Improve namespace handling to prevent races
* Add monitoring reporter for state endpoint
* Add config options for reporting frequency. The old config option was removed. I don't consider this a breaking change as the old option was never document and not intended to be changed.