### PR TITLE
Enhance testing of Metricbeat Elasticearch module

### DIFF
--- a/metricbeat/module/elasticsearch/index/data_test.go
+++ b/metricbeat/module/elasticsearch/index/data_test.go
@@ -17,23 +17,8 @@ var info = elasticsearch.Info{
 	ClusterName: "helloworld",
 }
 
-func TestIndex(t *testing.T) {
-	versions := []string{
-		"175", "201", "240", "512", "623",
-	}
-
-	_, err := ioutil.ReadFile("./_meta/test/output.json")
-	assert.NoError(t, err)
-
-	for _, v := range versions {
-		input, err := ioutil.ReadFile("./_meta/test/stats." + v + ".json")
-		assert.NoError(t, err)
-
-		reporter := &mbtest.CapturingReporterV2{}
-		eventsMapping(reporter, info, input)
-		assert.True(t, len(reporter.GetEvents()) >= 1)
-		assert.Equal(t, 0, len(reporter.GetErrors()))
-	}
+func TestMapper(t *testing.T) {
+	elasticsearch.TestMapperWithInfo(t, "../index/_meta/test/stats.*.json", eventsMapping)
 }
 
 func TestEmpty(t *testing.T) {

--- a/metricbeat/module/elasticsearch/index_summary/data_test.go
+++ b/metricbeat/module/elasticsearch/index_summary/data_test.go
@@ -17,23 +17,8 @@ var info = elasticsearch.Info{
 	ClusterName: "helloworld",
 }
 
-func TestIndex(t *testing.T) {
-	versions := []string{
-		"175", "201", "240", "512", "623",
-	}
-
-	_, err := ioutil.ReadFile("../index/_meta/test/output.json")
-	assert.NoError(t, err)
-
-	for _, v := range versions {
-		input, err := ioutil.ReadFile("../index/_meta/test/stats." + v + ".json")
-		assert.NoError(t, err)
-
-		reporter := &mbtest.CapturingReporterV2{}
-		eventMapping(reporter, info, input)
-		assert.True(t, len(reporter.GetEvents()) >= 1)
-		assert.Equal(t, 0, len(reporter.GetErrors()))
-	}
+func TestMapper(t *testing.T) {
+	elasticsearch.TestMapperWithInfo(t, "../index/_meta/test/stats.*.json", eventMapping)
 }
 
 func TestEmpty(t *testing.T) {

--- a/metricbeat/module/elasticsearch/node/data_test.go
+++ b/metricbeat/module/elasticsearch/node/data_test.go
@@ -4,33 +4,18 @@ package node
 
 import (
 	"io/ioutil"
-	"path/filepath"
 	"testing"
 
 	s "github.com/elastic/beats/libbeat/common/schema"
 	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/metricbeat/module/elasticsearch"
 )
 
 func TestGetMappings(t *testing.T) {
-	files, err := filepath.Glob("./_meta/test/node.*.json")
-	assert.NoError(t, err)
-
-	for _, f := range files {
-		content, err := ioutil.ReadFile(f)
-		assert.NoError(t, err)
-
-		reporter := &mbtest.CapturingReporterV2{}
-		errors := eventsMapping(reporter, content)
-		for _, errs := range errors {
-			if e, ok := errs.(*s.Errors); ok {
-				assert.False(t, e.HasRequiredErrors(), "mapping error: %s", e)
-			}
-		}
-		assert.True(t, len(reporter.GetEvents()) >= 1)
-		assert.Equal(t, 0, len(reporter.GetErrors()))
-	}
+	elasticsearch.TestMapper(t, "./_meta/test/node.*.json", eventsMapping)
 }
 
 func TestInvalid(t *testing.T) {

--- a/metricbeat/module/elasticsearch/node/node_test.go
+++ b/metricbeat/module/elasticsearch/node/node_test.go
@@ -1,0 +1,51 @@
+// +build !integration
+
+package node
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
+)
+
+func TestFetch(t *testing.T) {
+
+	files, err := filepath.Glob("./_meta/test/node.*.json")
+	assert.NoError(t, err)
+	// Makes sure glob matches at least 1 file
+	assert.True(t, len(files) > 0)
+
+	for _, f := range files {
+		t.Run(f, func(t *testing.T) {
+			response, err := ioutil.ReadFile(f)
+			assert.NoError(t, err)
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(200)
+				w.Header().Set("Content-Type", "application/json;")
+				w.Write([]byte(response))
+				assert.Equal(t, "/_nodes/_local", r.RequestURI)
+			}))
+			defer server.Close()
+
+			config := map[string]interface{}{
+				"module":     "elasticsearch",
+				"metricsets": []string{"node"},
+				"hosts":      []string{server.URL},
+			}
+			reporter := &mbtest.CapturingReporterV2{}
+
+			metricSet := mbtest.NewReportingMetricSetV2(t, config)
+			metricSet.Fetch(reporter)
+
+			e := mbtest.StandardizeEvent(metricSet, reporter.GetEvents()[0])
+			t.Logf("%s/%s event: %+v", metricSet.Module().Name(), metricSet.Name(), e.Fields.StringToPrint())
+		})
+	}
+}

--- a/metricbeat/module/elasticsearch/node_stats/data_test.go
+++ b/metricbeat/module/elasticsearch/node_stats/data_test.go
@@ -3,32 +3,11 @@
 package node_stats
 
 import (
-	"io/ioutil"
-	"path/filepath"
 	"testing"
 
-	s "github.com/elastic/beats/libbeat/common/schema"
-	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
-
-	"github.com/stretchr/testify/assert"
+	"github.com/elastic/beats/metricbeat/module/elasticsearch"
 )
 
 func TestStats(t *testing.T) {
-	files, err := filepath.Glob("./_meta/test/node_stats.*.json")
-	assert.NoError(t, err)
-
-	for _, f := range files {
-		input, err := ioutil.ReadFile(f)
-		assert.NoError(t, err)
-
-		reporter := &mbtest.CapturingReporterV2{}
-		errors := eventsMapping(reporter, input)
-		for _, errs := range errors {
-			if e, ok := errs.(*s.Errors); ok {
-				assert.False(t, e.HasRequiredErrors(), "mapping error: %s", e)
-			}
-		}
-		assert.True(t, len(reporter.GetEvents()) >= 1)
-		assert.Equal(t, 0, len(reporter.GetErrors()))
-	}
+	elasticsearch.TestMapper(t, "./_meta/test/node_stats.*.json", eventsMapping)
 }

--- a/metricbeat/module/elasticsearch/testing.go
+++ b/metricbeat/module/elasticsearch/testing.go
@@ -1,0 +1,70 @@
+// +build !integration
+
+package elasticsearch
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	s "github.com/elastic/beats/libbeat/common/schema"
+	"github.com/elastic/beats/metricbeat/mb"
+	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestMapper tests mapping methods
+func TestMapper(t *testing.T, glob string, mapper func(mb.ReporterV2, []byte) []error) {
+	files, err := filepath.Glob(glob)
+	assert.NoError(t, err)
+	// Makes sure glob matches at least 1 file
+	assert.True(t, len(files) > 0)
+
+	for _, f := range files {
+		t.Run(f, func(t *testing.T) {
+			input, err := ioutil.ReadFile(f)
+			assert.NoError(t, err)
+
+			reporter := &mbtest.CapturingReporterV2{}
+			errors := mapper(reporter, input)
+			for _, errs := range errors {
+				if e, ok := errs.(*s.Errors); ok {
+					assert.False(t, e.HasRequiredErrors(), "mapping error: %s", e)
+				}
+			}
+			assert.True(t, len(reporter.GetEvents()) >= 1)
+			assert.Equal(t, 0, len(reporter.GetErrors()))
+		})
+	}
+}
+
+// TestMapperWithInfo tests mapping methods with Info fields
+func TestMapperWithInfo(t *testing.T, glob string, mapper func(mb.ReporterV2, Info, []byte) []error) {
+	files, err := filepath.Glob(glob)
+	assert.NoError(t, err)
+	// Makes sure glob matches at least 1 file
+	assert.True(t, len(files) > 0)
+
+	info := Info{
+		ClusterID:   "1234",
+		ClusterName: "helloworld",
+	}
+
+	for _, f := range files {
+		t.Run(f, func(t *testing.T) {
+			input, err := ioutil.ReadFile(f)
+			assert.NoError(t, err)
+
+			reporter := &mbtest.CapturingReporterV2{}
+			errors := mapper(reporter, info, input)
+			for _, errs := range errors {
+				if e, ok := errs.(*s.Errors); ok {
+					assert.False(t, e.HasRequiredErrors(), "mapping error: %s", e)
+				}
+			}
+			assert.True(t, len(reporter.GetEvents()) >= 1)
+			assert.Equal(t, 0, len(reporter.GetErrors()))
+		})
+	}
+}


### PR DESCRIPTION
This PR is to have a few new ideas on how we could test across versions without running the services itself. This approach here does only work for services with an http endpoint.

* Standardise on 2 methods which are used to test the mapping
* Add http endpoint tests for `node` metricset. Could be used further.