### PR TITLE
[WIP] Event scheduling interfaces

### DIFF
--- a/libbeat/beat/pipeline.go
+++ b/libbeat/beat/pipeline.go
@@ -24,6 +24,12 @@ type Client interface {
 type ClientConfig struct {
 	PublishMode PublishMode
 
+	// SchedulingPolicies group configures a shared scheduling group.
+	SchedulingGroup string
+
+	// SchedulingPolicies add additional local event scheduling to a Client.
+	SchedulingPolicies []SchedulingPolicy
+
 	// EventMetadata configures additional fields/tags to be added to published events.
 	EventMetadata common.EventMetadata
 
@@ -102,6 +108,18 @@ type PipelineACKHandler struct {
 
 type ProcessorList interface {
 	All() []Processor
+}
+
+type SchedulingPolicy interface {
+	Connect(ctx Context) (SchedulingHandler, error)
+}
+
+type SchedulingHandler interface {
+	OnEvent(Event) (Event, error)
+}
+
+type Context interface {
+	Done() <-chan struct{}
 }
 
 // Processor defines the minimal required interface for processor, that can be

--- a/libbeat/monitoring/report/elasticsearch/elasticsearch.go
+++ b/libbeat/monitoring/report/elasticsearch/elasticsearch.go
@@ -116,6 +116,7 @@ func makeReporter(beat beat.Info, cfg *common.Config) (report.Reporter, error) {
 	pipeline, err := pipeline.New(
 		beat,
 		monitoring,
+		nil,
 		queueFactory, out, pipeline.Settings{
 			WaitClose:     0,
 			WaitCloseMode: pipeline.NoWaitOnClose,

--- a/libbeat/publisher/includes/includes.go
+++ b/libbeat/publisher/includes/includes.go
@@ -5,6 +5,9 @@ import (
 	_ "github.com/elastic/beats/libbeat/publisher/queue/memqueue"
 	_ "github.com/elastic/beats/libbeat/publisher/queue/spool"
 
+	// import event scheduling policies
+	_ "github.com/elastic/beats/libbeat/publisher/scheduling/ratelimit"
+
 	// load supported output plugins
 	_ "github.com/elastic/beats/libbeat/outputs/console"
 	_ "github.com/elastic/beats/libbeat/outputs/elasticsearch"

--- a/libbeat/publisher/pipeline/config.go
+++ b/libbeat/publisher/pipeline/config.go
@@ -7,6 +7,7 @@ import (
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/processors"
+	"github.com/elastic/beats/libbeat/publisher/scheduling"
 )
 
 // Config object for loading a pipeline instance via Load.
@@ -14,6 +15,8 @@ type Config struct {
 	// Event processing configurations
 	common.EventMetadata `config:",inline"`      // Fields and tags to add to each event.
 	Processors           processors.PluginConfig `config:"processors"`
+
+	Scheduling scheduling.Config `config:"scheduling"`
 
 	// Event queue
 	Queue common.ConfigNamespace `config:"queue"`

--- a/libbeat/publisher/pipeline/module.go
+++ b/libbeat/publisher/pipeline/module.go
@@ -12,6 +12,7 @@ import (
 	"github.com/elastic/beats/libbeat/outputs"
 	"github.com/elastic/beats/libbeat/processors"
 	"github.com/elastic/beats/libbeat/publisher/queue"
+	"github.com/elastic/beats/libbeat/publisher/scheduling"
 )
 
 // Global pipeline module for loading the main pipeline from a configuration object
@@ -40,6 +41,11 @@ func Load(
 	processors, err := processors.New(config.Processors)
 	if err != nil {
 		return nil, fmt.Errorf("error initializing processors: %v", err)
+	}
+
+	sched, err := scheduling.Load(config.Scheduling)
+	if err != nil {
+		return nil, fmt.Errorf("error initializing event scheduling: %v", err)
 	}
 
 	name := beatInfo.Name
@@ -73,7 +79,7 @@ func Load(
 		return nil, err
 	}
 
-	p, err := New(beatInfo, reg, queueBuilder, out, settings)
+	p, err := New(beatInfo, reg, sched, queueBuilder, out, settings)
 	if err != nil {
 		return nil, err
 	}

--- a/libbeat/publisher/pipeline/policy.go
+++ b/libbeat/publisher/pipeline/policy.go
@@ -1,0 +1,22 @@
+package pipeline
+
+import (
+	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/publisher/scheduling"
+)
+
+type wrapPolicy struct {
+	beat.SchedulingPolicy
+}
+
+func wrapPolicies(ps []beat.SchedulingPolicy) []scheduling.Policy {
+	policies := make([]scheduling.Policy, len(ps))
+	for i, p := range ps {
+		policies[i] = wrapPolicy{p}
+	}
+	return policies
+}
+
+func (p wrapPolicy) Connect(ctx scheduling.Context) (scheduling.Handler, error) {
+	return p.SchedulingPolicy.Connect(ctx)
+}

--- a/libbeat/publisher/scheduling/client.go
+++ b/libbeat/publisher/scheduling/client.go
@@ -15,7 +15,17 @@ func newClient(ctx *context, handler []Handler) *Client {
 }
 
 func (c *Client) Close() {
+	type closingHandler interface {
+		Close()
+	}
+
 	c.ctx.Close()
+
+	for _, h := range c.handlers {
+		if c, ok := h.(closingHandler); ok {
+			c.Close()
+		}
+	}
 }
 
 func (c *Client) OnEvent(evt beat.Event) (beat.Event, error) {

--- a/libbeat/publisher/scheduling/client.go
+++ b/libbeat/publisher/scheduling/client.go
@@ -1,0 +1,36 @@
+package scheduling
+
+import "github.com/elastic/beats/libbeat/beat"
+
+type Client struct {
+	ctx      *context
+	handlers []Handler
+}
+
+func newClient(ctx *context, handler []Handler) *Client {
+	return &Client{
+		ctx:      ctx,
+		handlers: handler,
+	}
+}
+
+func (c *Client) Close() {
+	c.ctx.Close()
+}
+
+func (c *Client) OnEvent(evt beat.Event) (beat.Event, error) {
+	if !c.ctx.Active() {
+		return evt, SigClose
+	}
+
+	for _, h := range c.handlers {
+		var err error
+
+		evt, err = h.OnEvent(evt)
+		if err != nil {
+			return evt, err
+		}
+	}
+
+	return evt, nil
+}

--- a/libbeat/publisher/scheduling/config.go
+++ b/libbeat/publisher/scheduling/config.go
@@ -1,0 +1,14 @@
+package scheduling
+
+import "github.com/elastic/beats/libbeat/common"
+
+// Config defines global scheduling configurations.
+type Config struct {
+	Groups   map[string][]common.ConfigNamespace `config:"groups"`
+	Policies []common.ConfigNamespace            `config:"policies"`
+}
+
+type LocalConfig struct {
+	Group    string                   `config:"group"`
+	Policies []common.ConfigNamespace `config:"policies"`
+}

--- a/libbeat/publisher/scheduling/config.go
+++ b/libbeat/publisher/scheduling/config.go
@@ -4,8 +4,13 @@ import "github.com/elastic/beats/libbeat/common"
 
 // Config defines global scheduling configurations.
 type Config struct {
-	Groups   map[string][]common.ConfigNamespace `config:"groups"`
-	Policies []common.ConfigNamespace            `config:"policies"`
+	Groups   map[string]GroupConfig   `config:"groups"`
+	Policies []common.ConfigNamespace `config:"policies"`
+}
+
+type GroupConfig struct {
+	Parent   string                   `config:"parent"`
+	Policies []common.ConfigNamespace `config:"policies"`
 }
 
 type LocalConfig struct {

--- a/libbeat/publisher/scheduling/ctx.go
+++ b/libbeat/publisher/scheduling/ctx.go
@@ -1,0 +1,33 @@
+package scheduling
+
+import "github.com/elastic/beats/libbeat/common/atomic"
+
+type Context interface {
+	Done() <-chan struct{}
+}
+
+type context struct {
+	done   chan struct{}
+	active atomic.Bool
+}
+
+func newContext() *context {
+	return &context{
+		done:   make(chan struct{}),
+		active: atomic.MakeBool(true),
+	}
+}
+
+func (c *context) Close() {
+	if c.active.CAS(true, false) {
+		close(c.done)
+	}
+}
+
+func (c *context) Done() <-chan struct{} {
+	return c.done
+}
+
+func (c *context) Active() bool {
+	return c.active.Load()
+}

--- a/libbeat/publisher/scheduling/load.go
+++ b/libbeat/publisher/scheduling/load.go
@@ -1,0 +1,87 @@
+package scheduling
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/common"
+)
+
+type beatPolicy struct {
+	Policy
+}
+
+func Load(c Config) (*Scheduling, error) {
+	global, err := LoadPolicies(c.Policies)
+	if err != nil {
+		return nil, err
+	}
+
+	groups := make(map[string][]Policy, len(c.Groups))
+	for name, cfgs := range c.Groups {
+		policies, err := LoadPolicies(cfgs)
+		if err != nil {
+			return nil, fmt.Errorf("error configuring scheduling group '%v': %v", name, err)
+		}
+
+		groups[name] = policies
+	}
+
+	return &Scheduling{
+		groups: groups,
+		global: global,
+	}, nil
+}
+
+func LoadPolicies(cfgs []common.ConfigNamespace) ([]Policy, error) {
+	policies := make([]Policy, len(cfgs))
+	for i, cfg := range cfgs {
+		p, err := LoadPolicy(cfg)
+		if err != nil {
+			return nil, err
+		}
+
+		policies[i] = p
+	}
+
+	return policies, nil
+}
+
+func LoadLocal(cfg LocalConfig) (string, []beat.SchedulingPolicy, error) {
+	policies, err := LoadLocalPolicies(cfg.Policies)
+	return cfg.Group, policies, err
+}
+
+func LoadLocalPolicies(cfgs []common.ConfigNamespace) ([]beat.SchedulingPolicy, error) {
+	policies := make([]beat.SchedulingPolicy, len(cfgs))
+	for i, cfg := range cfgs {
+		p, err := LoadPolicy(cfg)
+		if err != nil {
+			return nil, err
+		}
+
+		policies[i] = beatPolicy{p}
+	}
+
+	return policies, nil
+}
+
+func LoadPolicy(cfg common.ConfigNamespace) (Policy, error) {
+	if !cfg.IsSet() {
+		return nil, errors.New("policy is not set")
+	}
+
+	name := cfg.Name()
+	factory := PolicyRegistry.Find(name)
+	if factory == nil {
+		return nil, fmt.Errorf("unknown policy '%v'", name)
+	}
+
+	settings := cfg.Config()
+	return factory(settings)
+}
+
+func (p beatPolicy) Connect(h beat.Context) (beat.SchedulingHandler, error) {
+	return p.Policy.Connect(h)
+}

--- a/libbeat/publisher/scheduling/load.go
+++ b/libbeat/publisher/scheduling/load.go
@@ -18,14 +18,17 @@ func Load(c Config) (*Scheduling, error) {
 		return nil, err
 	}
 
-	groups := make(map[string][]Policy, len(c.Groups))
-	for name, cfgs := range c.Groups {
-		policies, err := LoadPolicies(cfgs)
+	groups := make(map[string]Group, len(c.Groups))
+	for name, grp := range c.Groups {
+		policies, err := LoadPolicies(grp.Policies)
 		if err != nil {
 			return nil, fmt.Errorf("error configuring scheduling group '%v': %v", name, err)
 		}
 
-		groups[name] = policies
+		groups[name] = Group{
+			parent:   grp.Parent,
+			policies: policies,
+		}
 	}
 
 	return &Scheduling{

--- a/libbeat/publisher/scheduling/load.go
+++ b/libbeat/publisher/scheduling/load.go
@@ -79,6 +79,7 @@ func LoadPolicy(cfg common.ConfigNamespace) (Policy, error) {
 	}
 
 	settings := cfg.Config()
+	settings.PrintDebugf("policy '%v' config =>", name)
 	return factory(settings)
 }
 

--- a/libbeat/publisher/scheduling/policy.go
+++ b/libbeat/publisher/scheduling/policy.go
@@ -13,4 +13,7 @@ type Policy interface {
 
 type Handler interface {
 	OnEvent(beat.Event) (beat.Event, error)
+
+	// optional: run on (*scheduling.Client).Close
+	// Close()
 }

--- a/libbeat/publisher/scheduling/policy.go
+++ b/libbeat/publisher/scheduling/policy.go
@@ -1,0 +1,16 @@
+package scheduling
+
+import (
+	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/common"
+)
+
+type PolicyFactory func(cfg *common.Config) (Policy, error)
+
+type Policy interface {
+	Connect(ctx Context) (Handler, error)
+}
+
+type Handler interface {
+	OnEvent(beat.Event) (beat.Event, error)
+}

--- a/libbeat/publisher/scheduling/ratelimit/config.go
+++ b/libbeat/publisher/scheduling/ratelimit/config.go
@@ -3,7 +3,7 @@ package ratelimit
 import "errors"
 
 type config struct {
-	EventsPerSecond uint `config:"events_pre_second" validate:"min=1"`
+	EventsPerSecond uint `config:"events_per_second" validate:"min=1"`
 	Shared          bool `config:"shared"`
 }
 

--- a/libbeat/publisher/scheduling/ratelimit/config.go
+++ b/libbeat/publisher/scheduling/ratelimit/config.go
@@ -1,0 +1,22 @@
+package ratelimit
+
+import "errors"
+
+type config struct {
+	EventsPerSecond uint `config:"events_pre_second" validate:"min=1"`
+	Shared          bool `config:"shared"`
+}
+
+func defaultConfig() config {
+	return config{
+		Shared: true,
+	}
+}
+
+func (c *config) Validate() error {
+	if c.EventsPerSecond == 0 {
+		return errors.New("events_per_second must be > 0")
+	}
+
+	return nil
+}

--- a/libbeat/publisher/scheduling/ratelimit/local.go
+++ b/libbeat/publisher/scheduling/ratelimit/local.go
@@ -1,0 +1,35 @@
+package ratelimit
+
+import (
+	"time"
+
+	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/publisher/scheduling"
+)
+
+type localHandler struct {
+	ctx    scheduling.Context
+	ticker *time.Ticker
+}
+
+func newLocalHandler(ctx scheduling.Context, eps uint) *localHandler {
+	interval := 1 * time.Second / time.Duration(eps)
+	ticker := time.NewTicker(interval)
+	return &localHandler{
+		ticker: ticker,
+		ctx:    ctx,
+	}
+}
+
+func (h *localHandler) Close() {
+	h.ticker.Stop()
+}
+
+func (h *localHandler) OnEvent(evt beat.Event) (beat.Event, error) {
+	select {
+	case <-h.ctx.Done(): // unblock on close and return closing signal
+		return evt, scheduling.SigClose
+	case <-h.ticker.C: // take token
+		return evt, nil
+	}
+}

--- a/libbeat/publisher/scheduling/ratelimit/ratelimit.go
+++ b/libbeat/publisher/scheduling/ratelimit/ratelimit.go
@@ -1,0 +1,44 @@
+package ratelimit
+
+import (
+	"time"
+
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/publisher/scheduling"
+)
+
+type policy struct {
+	eps    uint
+	ticker *time.Ticker
+	shared bool
+}
+
+func init() {
+	scheduling.PolicyRegistry.Register("ratelimit", create)
+}
+
+func create(cfg *common.Config) (scheduling.Policy, error) {
+	config := defaultConfig()
+	if err := cfg.Unpack(&config); err != nil {
+		return nil, err
+	}
+
+	var ticker *time.Ticker
+	if config.Shared {
+		interval := 1 * time.Second / time.Duration(config.EventsPerSecond)
+		ticker = time.NewTicker(interval)
+	}
+
+	return &policy{
+		eps:    config.EventsPerSecond,
+		ticker: ticker,
+		shared: config.Shared,
+	}, nil
+}
+
+func (p *policy) Connect(ctx scheduling.Context) (scheduling.Handler, error) {
+	if !p.shared {
+		return newLocalHandler(ctx, p.eps), nil
+	}
+	return newSharedHandler(ctx, p.ticker), nil
+}

--- a/libbeat/publisher/scheduling/ratelimit/shared.go
+++ b/libbeat/publisher/scheduling/ratelimit/shared.go
@@ -1,0 +1,26 @@
+package ratelimit
+
+import (
+	"time"
+
+	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/publisher/scheduling"
+)
+
+type sharedHandler struct {
+	ctx    scheduling.Context
+	ticker *time.Ticker
+}
+
+func newSharedHandler(ctx scheduling.Context, ticker *time.Ticker) *sharedHandler {
+	return &sharedHandler{ctx: ctx, ticker: ticker}
+}
+
+func (h *sharedHandler) OnEvent(evt beat.Event) (beat.Event, error) {
+	select {
+	case <-h.ctx.Done(): // unblock on local close and return closing signal
+		return evt, scheduling.SigClose
+	case <-h.ticker.C: // take token
+		return evt, nil
+	}
+}

--- a/libbeat/publisher/scheduling/registry.go
+++ b/libbeat/publisher/scheduling/registry.go
@@ -1,0 +1,31 @@
+package scheduling
+
+import (
+	"fmt"
+	"sync"
+)
+
+type policyRegistry struct {
+	reg map[string]PolicyFactory
+	mu  sync.Mutex
+}
+
+var PolicyRegistry = &policyRegistry{}
+
+func (p *policyRegistry) Register(name string, factory PolicyFactory) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if _, exist := p.reg[name]; exist {
+		panic(fmt.Sprintf("policy '%v' already registered", name))
+	}
+
+	p.reg[name] = factory
+}
+
+func (p *policyRegistry) Find(name string) PolicyFactory {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	return p.reg[name]
+}

--- a/libbeat/publisher/scheduling/registry.go
+++ b/libbeat/publisher/scheduling/registry.go
@@ -10,7 +10,9 @@ type policyRegistry struct {
 	mu  sync.Mutex
 }
 
-var PolicyRegistry = &policyRegistry{}
+var PolicyRegistry = &policyRegistry{
+	reg: map[string]PolicyFactory{},
+}
 
 func (p *policyRegistry) Register(name string, factory PolicyFactory) {
 	p.mu.Lock()

--- a/libbeat/publisher/scheduling/scheduling.go
+++ b/libbeat/publisher/scheduling/scheduling.go
@@ -1,0 +1,71 @@
+package scheduling
+
+import (
+	"fmt"
+)
+
+type Scheduling struct {
+	groups map[string][]Policy
+	global []Policy
+}
+
+func (s *Scheduling) Connect(group string, local []Policy) (*Client, error) {
+
+	var groupPolicies []Policy
+	var global []Policy
+
+	if group != "" {
+		var exist bool
+
+		var groups map[string][]Policy
+		if s != nil {
+			groups = s.groups
+		}
+
+		groupPolicies, exist = groups[group]
+		if !exist {
+			return nil, fmt.Errorf("scheduling group '%v' does not exist", group)
+		}
+	}
+
+	if s != nil {
+		global = s.global
+	}
+
+	total := len(local) + len(groupPolicies) + len(global)
+	if total == 0 {
+		return nil, nil
+	}
+
+	ctx := newContext()
+	handlers := make([]Handler, 0, total)
+	createHandlers := func(policies []Policy) error {
+		for _, policy := range policies {
+			handler, err := policy.Connect(ctx)
+			if err != nil {
+				return fmt.Errorf("policy initialization failed: %v", err)
+			}
+
+			handlers = append(handlers, handler)
+		}
+
+		return nil
+	}
+
+	err := createHandlers(local)
+	if err != nil {
+		return nil, fmt.Errorf("local %v", err)
+	}
+
+	err = createHandlers(groupPolicies)
+	if err != nil {
+		return nil, fmt.Errorf("group %v", err)
+	}
+
+	err = createHandlers(global)
+	if err != nil {
+		return nil, fmt.Errorf("global %v", err)
+	}
+
+	return newClient(ctx, handlers), nil
+}

--- a/libbeat/publisher/scheduling/signal.go
+++ b/libbeat/publisher/scheduling/signal.go
@@ -1,0 +1,42 @@
+package scheduling
+
+type (
+	SigDropEvent struct{}
+
+	SigCloseClient struct{}
+)
+
+var SigDrop = &SigDropEvent{}
+var SigClose = &SigCloseClient{}
+
+func (sig *SigDropEvent) IsClose() bool { return false }
+func (sig *SigDropEvent) IsDrop() bool  { return true }
+func (sig *SigDropEvent) Error() string { return "signal: event drop" }
+
+func (sig *SigCloseClient) IsClose() bool { return true }
+func (sig *SigCloseClient) IsDrop() bool  { return true }
+func (sig *SigCloseClient) Error() string { return "signal: closing" }
+
+func IsDropSignal(err error) bool {
+	type ifc interface {
+		IsDrop() bool
+	}
+
+	if sig, ok := err.(ifc); ok {
+		return sig.IsDrop()
+	}
+
+	return false
+}
+
+func IsCloseSignal(err error) bool {
+	type ifc interface {
+		IsClose() bool
+	}
+
+	if sig, ok := err.(ifc); ok {
+		return sig.IsClose()
+	}
+
+	return false
+}

--- a/metricbeat/mb/module/connector.go
+++ b/metricbeat/mb/module/connector.go
@@ -4,19 +4,23 @@ import (
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/processors"
+	"github.com/elastic/beats/libbeat/publisher/scheduling"
 )
 
 // Connector configures and establishes a beat.Client for publishing events
 // to the publisher pipeline.
 type Connector struct {
-	pipeline      beat.Pipeline
-	processors    *processors.Processors
-	eventMeta     common.EventMetadata
-	dynamicFields *common.MapStrPointer
+	pipeline           beat.Pipeline
+	processors         *processors.Processors
+	eventMeta          common.EventMetadata
+	dynamicFields      *common.MapStrPointer
+	schedulingGroup    string
+	schedulingPolicies []beat.SchedulingPolicy
 }
 
 type connectorConfig struct {
 	Processors           processors.PluginConfig `config:"processors"`
+	Scheduling           scheduling.LocalConfig  `config:"scheduling"`
 	common.EventMetadata `config:",inline"`      // Fields and tags to add to events.
 }
 
@@ -31,18 +35,27 @@ func NewConnector(pipeline beat.Pipeline, c *common.Config, dynFields *common.Ma
 		return nil, err
 	}
 
+	schedGroup, schedPolicies, err := scheduling.LoadLocal(config.Scheduling)
+	if err != nil {
+		return nil, err
+	}
+
 	return &Connector{
-		pipeline:      pipeline,
-		processors:    processors,
-		eventMeta:     config.EventMetadata,
-		dynamicFields: dynFields,
+		pipeline:           pipeline,
+		processors:         processors,
+		eventMeta:          config.EventMetadata,
+		dynamicFields:      dynFields,
+		schedulingGroup:    schedGroup,
+		schedulingPolicies: schedPolicies,
 	}, nil
 }
 
 func (c *Connector) Connect() (beat.Client, error) {
 	return c.pipeline.ConnectWith(beat.ClientConfig{
-		EventMetadata: c.eventMeta,
-		Processor:     c.processors,
-		DynamicFields: c.dynamicFields,
+		SchedulingGroup:    c.schedulingGroup,
+		SchedulingPolicies: c.schedulingPolicies,
+		EventMetadata:      c.eventMeta,
+		Processor:          c.processors,
+		DynamicFields:      c.dynamicFields,
 	})
 }


### PR DESCRIPTION
The changes in this PR add support for configurable event scheduling in libbeat. Event scheduling will be applied when a beat publishes an event. Users configure policies like rate limiting and others, which will be applied to event publishing, before the event processors are executed.

![beats pipeline with scheduling](https://user-images.githubusercontent.com/75886/39938664-f6c829e8-5553-11e8-9040-86a5cce05bda.png)

Policies can be local or have shared state. Thanks to shared state, policies like rate limiting can affect a group of workers/publishers.

A policy implementation is free to create back-pressure by blocking event publishing or drop/modify events.

Besides introducing interfaces and configuration support, a simple `ratelimit` policy is provided in this PR. The current implementation is only for demonstration purposes (sample code) and not recommended for production. The rate limiter supports full local rate limiting (per `beat.Client` connection), but also a shared mode. With shared mode, the total bandwidth enforced by the rate limiter will be shared between all `beat.Client` instances.

Scheduling can be defined locally per input/module instance, per `group` and even globally, per beat. A scheduling group can also have a parent group. The policies are concatenated in this order: local, group, [parent group], global.

Scheduling 'groups' are used to configured shared resources between multiple workers/data sources.

Sample config:

```
filebeat.inputs:
- ...
  scheduling.policies:
  - ratelimit.events_per_second: 800
- ...
  scheduling.group: A
  scheduling.policies:
  - ratelimit:
      events_per_second: 100
      shared: false
- ...
  scheduling.group: A
  - ratelimit:
      events_per_second: 500
      shared: false

# per group policies
scheduling.groups:
  A.policies:
  - ratelimit.events_per_second: 800

# global policies
scheduling.policies:
- ratelimit:
    events_per_second: 1000
```

With this sample configuration, the beats global bandwidth is limited to 1000eps. The first input's bandwidth is limited to 800eps. If the first input creates multiple workers/harvesters, the bandwidth of 800eps will be shared by all harvesters. Due to `shared: false`, each harvester created by input 2 will have a bandwidth limit of 100eps. Input 3 enforces a limit of 500eps per harvester. Due to input 2 and 3 joining the scheduling group `A`, the total shared bandwidth of all harvesters started by input 2 and 3 is limited to 800eps.

Tasks:
- [x] introduce event scheduling
- [x] support for defining shared scheduling groups
- [x] add support to filebeat inputs to configure local policies
- [ ] add support to filebeat modules to configure local policies
- [x] add support to metricbeat/auditbeat modules/metricsets to configure local policies
- [ ] add support to heartbeat to configure local policies
- [ ] add support to packetbeat to configure local policies
- [ ] support for passing additional settings from local policies to parent groups on `Connect`.