### PR TITLE
Set default shards to 1 in all our configs

### DIFF
--- a/auditbeat/_meta/common.p2.yml
+++ b/auditbeat/_meta/common.p2.yml
@@ -1,6 +1,6 @@
 
 #==================== Elasticsearch template setting ==========================
 setup.template.settings:
-  index.number_of_shards: 3
+  index.number_of_shards: 1
   #index.codec: best_compression
   #_source.enabled: false

--- a/auditbeat/auditbeat.yml
+++ b/auditbeat/auditbeat.yml
@@ -49,7 +49,7 @@ auditbeat.modules:
 
 #==================== Elasticsearch template setting ==========================
 setup.template.settings:
-  index.number_of_shards: 3
+  index.number_of_shards: 1
   #index.codec: best_compression
   #_source.enabled: false
 

--- a/filebeat/_meta/common.p2.yml
+++ b/filebeat/_meta/common.p2.yml
@@ -69,6 +69,6 @@ filebeat.config.modules:
 #==================== Elasticsearch template setting ==========================
 
 setup.template.settings:
-  index.number_of_shards: 3
+  index.number_of_shards: 1
   #index.codec: best_compression
   #_source.enabled: false

--- a/filebeat/filebeat.yml
+++ b/filebeat/filebeat.yml
@@ -78,7 +78,7 @@ filebeat.config.modules:
 #==================== Elasticsearch template setting ==========================
 
 setup.template.settings:
-  index.number_of_shards: 3
+  index.number_of_shards: 1
   #index.codec: best_compression
   #_source.enabled: false
 

--- a/libbeat/docs/template-config.asciidoc
+++ b/libbeat/docs/template-config.asciidoc
@@ -65,7 +65,7 @@ setup.template.name: "{beatname_lc}"
 setup.template.fields: "fields.yml"
 setup.template.overwrite: false
 setup.template.settings:
-  index.number_of_shards: 1
+  index.number_of_shards: 3
   index.number_of_replicas: 1
 ----------------------------------------------------------------------
 

--- a/packetbeat/_meta/beat.yml
+++ b/packetbeat/_meta/beat.yml
@@ -101,6 +101,6 @@ packetbeat.protocols:
 #==================== Elasticsearch template setting ==========================
 
 setup.template.settings:
-  index.number_of_shards: 3
+  index.number_of_shards: 1
   #index.codec: best_compression
   #_source.enabled: false

--- a/packetbeat/packetbeat.yml
+++ b/packetbeat/packetbeat.yml
@@ -101,7 +101,7 @@ packetbeat.protocols:
 #==================== Elasticsearch template setting ==========================
 
 setup.template.settings:
-  index.number_of_shards: 3
+  index.number_of_shards: 1
   #index.codec: best_compression
   #_source.enabled: false
 

--- a/winlogbeat/_meta/beat.yml
+++ b/winlogbeat/_meta/beat.yml
@@ -26,6 +26,6 @@ winlogbeat.event_logs:
 #==================== Elasticsearch template setting ==========================
 
 setup.template.settings:
-  index.number_of_shards: 3
+  index.number_of_shards: 1
   #index.codec: best_compression
   #_source.enabled: false

--- a/winlogbeat/winlogbeat.yml
+++ b/winlogbeat/winlogbeat.yml
@@ -26,7 +26,7 @@ winlogbeat.event_logs:
 #==================== Elasticsearch template setting ==========================
 
 setup.template.settings:
-  index.number_of_shards: 3
+  index.number_of_shards: 1
   #index.codec: best_compression
   #_source.enabled: false
 


### PR DESCRIPTION
Elasticsearch is moving to having 1 shard by default: https://github.com/elastic/elasticsearch/pull/30539

We already set shards to 1 in our Metricbeat and Heartbeat configurations, but we were
explicitly setting it to 3 in the other configs. I changed to be 1 everywhere. I went
for a change that still contains the number of shards in the Beat config, rather than
just rely on the ES default, so that Beats 7.0 behave the same even when talking to ES 6.x.