### PR TITLE
Cherry-pick #7079 to 6.3: Update modules s/prospector(s)/input(s)

### DIFF
--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -130,9 +130,9 @@ filebeat.modules:
     # Filebeat will choose the paths depending on your OS.
     #var.paths:
 
-    # Prospector configuration (advanced). Any prospector configuration option
+    # Input configuration (advanced). Any input configuration option
     # can be added under this section.
-    #prospector:
+    #input:
 
   # Error logs
   #error:
@@ -142,9 +142,9 @@ filebeat.modules:
     # Filebeat will choose the paths depending on your OS.
     #var.paths:
 
-    # Prospector configuration (advanced). Any prospector configuration option
+    # Input configuration (advanced). Any input configuration option
     # can be added under this section.
-    #prospector:
+    #input:
 
 #-------------------------------- Kafka Module -------------------------------
 - module: kafka
@@ -228,9 +228,9 @@ filebeat.modules:
     # Filebeat will choose the paths depending on your OS.
     #var.paths:
 
-    # Prospector configuration (advanced). Any prospector configuration option
+    # Input configuration (advanced). Any input configuration option
     # can be added under this section.
-    #prospector:
+    #input:
 
   # Error logs
   #error:

--- a/filebeat/module/iis/_meta/config.reference.yml
+++ b/filebeat/module/iis/_meta/config.reference.yml
@@ -7,9 +7,9 @@
     # Filebeat will choose the paths depending on your OS.
     #var.paths:
 
-    # Prospector configuration (advanced). Any prospector configuration option
+    # Input configuration (advanced). Any input configuration option
     # can be added under this section.
-    #prospector:
+    #input:
 
   # Error logs
   #error:
@@ -19,6 +19,6 @@
     # Filebeat will choose the paths depending on your OS.
     #var.paths:
 
-    # Prospector configuration (advanced). Any prospector configuration option
+    # Input configuration (advanced). Any input configuration option
     # can be added under this section.
-    #prospector:
+    #input:

--- a/filebeat/module/iis/access/manifest.yml
+++ b/filebeat/module/iis/access/manifest.yml
@@ -10,7 +10,7 @@ var:
       - C:/inetpub/logs/LogFiles/*/*.log
 
 ingest_pipeline: ingest/default.json
-prospector: config/iis-access.yml
+input: config/iis-access.yml
 
 requires.processors:
 - name: user_agent

--- a/filebeat/module/iis/access/test/test.log-expected.json
+++ b/filebeat/module/iis/access/test/test.log-expected.json
@@ -50,6 +50,9 @@
       "prospector": {
         "type": "log"
       },
+      "input": {
+        "type": "log"
+      },
       "read_timestamp": "2018-01-20T17:19:39.236Z",
       "source": "/go/src/github.com/elastic/beats/filebeat/module/iis/access/test/test.log",
       "fileset": {
@@ -105,6 +108,9 @@
         "version": "6.1.3-alpha1"
       },
       "prospector": {
+        "type": "log"
+      },
+      "input": {
         "type": "log"
       },
       "read_timestamp": "2018-01-20T17:19:39.237Z",
@@ -175,6 +181,9 @@
         "version": "6.1.3-alpha1"
       },
       "prospector": {
+        "type": "log"
+      },
+      "input": {
         "type": "log"
       },
       "read_timestamp": "2018-01-20T17:19:39.237Z",

--- a/filebeat/module/iis/error/manifest.yml
+++ b/filebeat/module/iis/error/manifest.yml
@@ -10,7 +10,7 @@ var:
       - c:/Windows/System32/LogFiles/HTTPERR/*.log
 
 ingest_pipeline: ingest/default.json
-prospector: config/iis-error.yml
+input: config/iis-error.yml
 
 requires.processors:
 - name: geoip

--- a/filebeat/module/iis/error/test/test.log-expected.json
+++ b/filebeat/module/iis/error/test/test.log-expected.json
@@ -29,8 +29,11 @@
       "prospector": {
         "type": "log"
       },
+      "input": {
+        "type": "log"
+      },
       "read_timestamp": "2018-01-20T17:19:39.229Z",
-      "source": "/go/src/github.com/elastic/beats/filebeat/module/iis/error/test/test.log",      
+      "source": "/go/src/github.com/elastic/beats/filebeat/module/iis/error/test/test.log",
       "fileset": {
         "module": "iis",
         "name": "error"
@@ -78,8 +81,11 @@
       "prospector": {
         "type": "log"
       },
+      "input": {
+        "type": "log"
+      },
       "read_timestamp": "2018-01-20T17:19:39.229Z",
-      "source": "/go/src/github.com/elastic/beats/filebeat/module/iis/error/test/test.log",      
+      "source": "/go/src/github.com/elastic/beats/filebeat/module/iis/error/test/test.log",
       "fileset": {
         "module": "iis",
         "name": "error"
@@ -127,6 +133,9 @@
       "prospector": {
         "type": "log"
       },
+      "input": {
+        "type": "log"
+      },
       "read_timestamp": "2018-01-20T17:19:39.229Z",
       "source": "/go/src/github.com/elastic/beats/filebeat/module/iis/error/test/test.log",
       "fileset": {
@@ -170,6 +179,9 @@
         "version": "6.1.3-alpha1"
       },
       "prospector": {
+        "type": "log"
+      },
+      "input": {
         "type": "log"
       },
       "read_timestamp": "2018-01-20T17:19:39.229Z",

--- a/filebeat/module/mongodb/log/manifest.yml
+++ b/filebeat/module/mongodb/log/manifest.yml
@@ -8,4 +8,4 @@ var:
       - c:\data\log\mongod.log
 
 ingest_pipeline: ingest/pipeline.json
-prospector: config/log.yml
+input: config/log.yml

--- a/filebeat/module/nginx/_meta/config.reference.yml
+++ b/filebeat/module/nginx/_meta/config.reference.yml
@@ -7,9 +7,9 @@
     # Filebeat will choose the paths depending on your OS.
     #var.paths:
 
-    # Prospector configuration (advanced). Any prospector configuration option
+    # Input configuration (advanced). Any input configuration option
     # can be added under this section.
-    #prospector:
+    #input:
 
   # Error logs
   #error:

--- a/filebeat/scripts/fileset/manifest.yml
+++ b/filebeat/scripts/fileset/manifest.yml
@@ -10,4 +10,4 @@ var:
       - c:/programdata/example/logs/test.log*
 
 ingest_pipeline: ingest/pipeline.json
-prospector: config/{fileset}.yml
+input: config/{fileset}.yml


### PR DESCRIPTION
Cherry-pick of PR #7079 to 6.3 branch. Original message: 

Some modules and yaml reference were still referencing prospectors
instead of inputs, I have also updated the fileset manifest to make sure
it uses the new naming.

closes: #6642