### PR TITLE
Cherry-pick #7080 to 6.3: Update kubernetes examples configuration to use inputs

### DIFF
--- a/deploy/kubernetes/filebeat-kubernetes.yaml
+++ b/deploy/kubernetes/filebeat-kubernetes.yaml
@@ -10,10 +10,10 @@ metadata:
 data:
   filebeat.yml: |-
     filebeat.config:
-      prospectors:
-        # Mounted `filebeat-prospectors` configmap:
-        path: ${path.config}/prospectors.d/*.yml
-        # Reload prospectors configs as they change:
+      inputs:
+        # Mounted `filebeat-inputs` configmap:
+        path: ${path.config}/inputs.d/*.yml
+        # Reload inputs configs as they change:
         reload.enabled: false
       modules:
         path: ${path.config}/modules.d/*.yml
@@ -34,7 +34,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: filebeat-prospectors
+  name: filebeat-inputs
   namespace: kube-system
   labels:
     k8s-app: filebeat
@@ -98,8 +98,8 @@ spec:
           mountPath: /etc/filebeat.yml
           readOnly: true
           subPath: filebeat.yml
-        - name: prospectors
-          mountPath: /usr/share/filebeat/prospectors.d
+        - name: inputs
+          mountPath: /usr/share/filebeat/inputs.d
           readOnly: true
         - name: data
           mountPath: /usr/share/filebeat/data
@@ -114,10 +114,10 @@ spec:
       - name: varlibdockercontainers
         hostPath:
           path: /var/lib/docker/containers
-      - name: prospectors
+      - name: inputs
         configMap:
           defaultMode: 0600
-          name: filebeat-prospectors
+          name: filebeat-inputs
       # We set an `emptyDir` here to ensure the manifest will deploy correctly.
       # It's recommended to change this to a `hostPath` folder, to ensure internal data
       # files survive pod changes (ie: version upgrade)

--- a/deploy/kubernetes/filebeat/README.md
+++ b/deploy/kubernetes/filebeat/README.md
@@ -8,7 +8,7 @@ By deploying filebeat as a [DaemonSet](https://kubernetes.io/docs/concepts/workl
 we ensure we get a running filebeat daemon on each node of the cluster.
 
 Docker logs host folder (`/var/lib/docker/containers`) is mounted on the
-filebeat container. Filebeat will start a prospector for these files and start
+filebeat container. Filebeat will start an input for these files and start
 harvesting them as they appear.
 
 Everything is deployed under `kube-system` namespace, you can change that by

--- a/deploy/kubernetes/filebeat/filebeat-configmap.yaml
+++ b/deploy/kubernetes/filebeat/filebeat-configmap.yaml
@@ -10,10 +10,10 @@ metadata:
 data:
   filebeat.yml: |-
     filebeat.config:
-      prospectors:
-        # Mounted `filebeat-prospectors` configmap:
-        path: ${path.config}/prospectors.d/*.yml
-        # Reload prospectors configs as they change:
+      inputs:
+        # Mounted `filebeat-inputs` configmap:
+        path: ${path.config}/inputs.d/*.yml
+        # Reload inputs configs as they change:
         reload.enabled: false
       modules:
         path: ${path.config}/modules.d/*.yml
@@ -34,7 +34,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: filebeat-prospectors
+  name: filebeat-inputs
   namespace: kube-system
   labels:
     k8s-app: filebeat

--- a/deploy/kubernetes/filebeat/filebeat-daemonset.yaml
+++ b/deploy/kubernetes/filebeat/filebeat-daemonset.yaml
@@ -48,8 +48,8 @@ spec:
           mountPath: /etc/filebeat.yml
           readOnly: true
           subPath: filebeat.yml
-        - name: prospectors
-          mountPath: /usr/share/filebeat/prospectors.d
+        - name: inputs
+          mountPath: /usr/share/filebeat/inputs.d
           readOnly: true
         - name: data
           mountPath: /usr/share/filebeat/data
@@ -64,10 +64,10 @@ spec:
       - name: varlibdockercontainers
         hostPath:
           path: /var/lib/docker/containers
-      - name: prospectors
+      - name: inputs
         configMap:
           defaultMode: 0600
-          name: filebeat-prospectors
+          name: filebeat-inputs
       # We set an `emptyDir` here to ensure the manifest will deploy correctly.
       # It's recommended to change this to a `hostPath` folder, to ensure internal data
       # files survive pod changes (ie: version upgrade)


### PR DESCRIPTION
Cherry-pick of PR #7080 to 6.3 branch. Original message: 

When we made the rename of the prospectors to input we overlooked the update of
the kubernetes examples files and readme.

Ref #6642