### PR TITLE
Use minikube on travis for K8S integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
     - GOX_FLAGS="-arch amd64"
     - DOCKER_COMPOSE_VERSION=1.11.1
     - GO_VERSION="$(cat .go-version)"
-    - TRAVIS_ETCD_VERSION=v3.2.8
+    - TRAVIS_MINIKUBE_VERSION=v0.25.2
 
 jobs:
   include:
@@ -113,19 +113,31 @@ jobs:
       install: deploy/kubernetes/.travis/setup.sh
       env:
         - TARGETS="-C deploy/kubernetes test"
-        - TRAVIS_KUBE_VERSION=v1.6.11
+        - TRAVIS_K8S_VERSION=v1.6.4
       stage: test
     - os: linux
       install: deploy/kubernetes/.travis/setup.sh
       env:
         - TARGETS="-C deploy/kubernetes test"
-        - TRAVIS_KUBE_VERSION=v1.7.7
+        - TRAVIS_K8S_VERSION=v1.7.5
       stage: test
     - os: linux
       install: deploy/kubernetes/.travis/setup.sh
       env:
         - TARGETS="-C deploy/kubernetes test"
-        - TRAVIS_KUBE_VERSION=v1.8.0
+        - TRAVIS_K8S_VERSION=v1.8.0
+      stage: test
+    - os: linux
+      install: deploy/kubernetes/.travis/setup.sh
+      env:
+        - TARGETS="-C deploy/kubernetes test"
+        - TRAVIS_K8S_VERSION=v1.9.4
+      stage: test
+    - os: linux
+      install: deploy/kubernetes/.travis/setup.sh
+      env:
+        - TARGETS="-C deploy/kubernetes test"
+        - TRAVIS_K8S_VERSION=v1.10.0
       stage: test
 
 addons:

--- a/deploy/kubernetes/.travis/setup.sh
+++ b/deploy/kubernetes/.travis/setup.sh
@@ -3,59 +3,13 @@
 
 set -x
 
-# set docker0 to promiscuous mode
-sudo ip link set docker0 promisc on
+export CHANGE_MINIKUBE_NONE_USER=true
 
-# install etcd
-wget https://github.com/coreos/etcd/releases/download/$TRAVIS_ETCD_VERSION/etcd-$TRAVIS_ETCD_VERSION-linux-amd64.tar.gz
-tar xzf etcd-$TRAVIS_ETCD_VERSION-linux-amd64.tar.gz
-sudo mv etcd-$TRAVIS_ETCD_VERSION-linux-amd64/etcd /usr/local/bin/etcd
-rm etcd-$TRAVIS_ETCD_VERSION-linux-amd64.tar.gz
-rm -rf etcd-$TRAVIS_ETCD_VERSION-linux-amd64
+curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/$TRAVIS_K8S_VERSION/bin/linux/amd64/kubectl && \
+      chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+curl -Lo minikube https://storage.googleapis.com/minikube/releases/$TRAVIS_MINIKUBE_VERSION/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
+sudo minikube start --vm-driver=none --kubernetes-version=$TRAVIS_K8S_VERSION --logtostderr
+minikube update-context
+JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; \
+        until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done
 
-# download kubectl
-wget https://storage.googleapis.com/kubernetes-release/release/$TRAVIS_KUBE_VERSION/bin/linux/amd64/kubectl
-chmod +x kubectl
-sudo mv kubectl /usr/local/bin/kubectl
-
-# download kubernetes
-git clone https://github.com/kubernetes/kubernetes $HOME/kubernetes
-
-# install cfssl
-go get -u github.com/cloudflare/cfssl/cmd/...
-
-pushd $HOME/kubernetes
-  git checkout $TRAVIS_KUBE_VERSION
-  kubectl config set-credentials myself --username=admin --password=admin
-  kubectl config set-context local --cluster=local --user=myself
-  kubectl config set-cluster local --server=http://localhost:8080
-  kubectl config use-context local
-
-  # start kubernetes in the background
-  sudo PATH=$PATH:/home/travis/.gimme/versions/go1.7.linux.amd64/bin/go \
-       KUBE_ENABLE_CLUSTER_DNS=true \
-       hack/local-up-cluster.sh &
-popd
-
-# Wait until kube is up and running
-TIMEOUT=0
-TIMEOUT_COUNT=800
-until $(curl --output /dev/null --silent http://localhost:8080) || [ $TIMEOUT -eq $TIMEOUT_COUNT ]; do
-  echo "Kube is not up yet"
-  let TIMEOUT=TIMEOUT+1
-  sleep 1
-done
-
-if [ $TIMEOUT -eq $TIMEOUT_COUNT ]; then
-  echo "Kubernetes is not up and running"
-  exit 1
-fi
-
-echo "Kubernetes is deployed and reachable"
-
-# Try and sleep before issuing chown. Currently, Kubernetes is started by
-# a command that is run in the background. Technically Kubernetes could be
-# up and running, but those files might not exist yet as the previous command
-# could create them after Kube starts successfully.
-sleep 30
-sudo chown -R $USER:$USER $HOME/.kube


### PR DESCRIPTION
This change introduces minikube on travis for tests. This will allow us to perform integration tests for k8s related code. At the moment we only test that deploy manifests are valid, we can now add more tests on top of this.

This also adds latest k8s versions to the test matrix.