### PR TITLE
Add x-pack data for Elasticsearch shard metricset

### DIFF
--- a/metricbeat/module/elasticsearch/shard/data.go
+++ b/metricbeat/module/elasticsearch/shard/data.go
@@ -11,17 +11,19 @@ import (
 
 var (
 	schema = s.Schema{
-		"state":   c.Str("state"),
-		"primary": c.Bool("primary"),
-		"node":    c.Str("node"),
-		"index":   c.Str("index"),
-		"shard":   c.Int("number"),
+		"state":           c.Str("state"),
+		"primary":         c.Bool("primary"),
+		"node":            c.Str("node"),
+		"index":           c.Str("index"),
+		"shard":           c.Int("number"),
+		"relocating_node": c.Str("relocating_node"),
 	}
 )
 
 type stateStruct struct {
 	ClusterName  string `json:"cluster_name"`
 	StateID      string `json:"state_uuid"`
+	MasterNode   string `json:"master_node"`
 	RoutingTable struct {
 		Indices map[string]struct {
 			Shards map[string][]map[string]interface{} `json:"shards"`

--- a/metricbeat/module/elasticsearch/shard/data_xpack.go
+++ b/metricbeat/module/elasticsearch/shard/data_xpack.go
@@ -1,0 +1,71 @@
+package shard
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/metricbeat/mb"
+	"github.com/elastic/beats/metricbeat/module/elasticsearch"
+)
+
+func eventsMappingXPack(r mb.ReporterV2, m *MetricSet, content []byte) {
+	stateData := &stateStruct{}
+	err := json.Unmarshal(content, stateData)
+	if err != nil {
+		r.Error(err)
+		return
+	}
+
+	nodeInfo, err := elasticsearch.GetNodeInfo(m.HTTP, m.HostData().SanitizedURI+statePath, stateData.MasterNode)
+	if err != nil {
+		r.Error(err)
+		return
+	}
+
+	// TODO: This is currently needed because the cluser_uuid is `na` in stateData in case not the full state is requested.
+	// Will be fixed in: https://github.com/elastic/elasticsearch/pull/30656
+	clusterID, err := elasticsearch.GetClusterID(m.HTTP, m.HostData().SanitizedURI+statePath, stateData.MasterNode)
+	if err != nil {
+		r.Error(err)
+		return
+	}
+
+	sourceNode := common.MapStr{
+		"uuid":              stateData.MasterNode,
+		"host":              nodeInfo.Host,
+		"transport_address": nodeInfo.TransportAddress,
+		"ip":                nodeInfo.IP,
+		// This seems to be in the x-pack data a subset of the cluster_uuid not the name?
+		"name":      stateData.ClusterName,
+		"timestamp": common.Time(time.Now()),
+	}
+
+	for _, index := range stateData.RoutingTable.Indices {
+		for _, shards := range index.Shards {
+			for _, shard := range shards {
+				event := mb.Event{}
+				fields, _ := schema.Apply(shard)
+
+				fields["shard"] = fields["number"]
+				delete(fields, "number")
+
+				event.RootFields = common.MapStr{}
+
+				event.RootFields = common.MapStr{
+					"timestamp":    time.Now(),
+					"cluster_uuid": clusterID,
+					"interval_ms":  m.Module().Config().Period.Nanoseconds() / 1000 / 1000,
+					"type":         "shards",
+					"source_node":  sourceNode,
+					"shard":        fields,
+					"state_uuid":   stateData.StateID,
+				}
+				event.Index = ".monitoring-es-6-mb"
+
+				r.Event(event)
+
+			}
+		}
+	}
+}

--- a/metricbeat/module/elasticsearch/shard/shard.go
+++ b/metricbeat/module/elasticsearch/shard/shard.go
@@ -2,55 +2,51 @@ package shard
 
 import (
 	"github.com/elastic/beats/libbeat/common/cfgwarn"
-	"github.com/elastic/beats/metricbeat/helper"
 	"github.com/elastic/beats/metricbeat/mb"
-	"github.com/elastic/beats/metricbeat/mb/parse"
+	"github.com/elastic/beats/metricbeat/module/elasticsearch"
 )
 
 func init() {
 	mb.Registry.MustAddMetricSet("elasticsearch", "shard", New,
-		mb.WithHostParser(hostParser),
+		mb.WithHostParser(elasticsearch.HostParser),
 		mb.DefaultMetricSet(),
 		mb.WithNamespace("elasticsearch.shard"),
 	)
 }
 
-var (
-	hostParser = parse.URLHostParserBuilder{
-		DefaultScheme: "http",
-		PathConfigKey: "path",
-		// Get the stats from the local node
-		DefaultPath: "_cluster/state/version,master_node,routing_table",
-	}.Build()
+const (
+	// Get the stats from the local node
+	statePath = "/_cluster/state/version,master_node,routing_table"
 )
 
 // MetricSet type defines all fields of the MetricSet
 type MetricSet struct {
-	mb.BaseMetricSet
-	http *helper.HTTP
+	*elasticsearch.MetricSet
 }
 
 // New create a new instance of the MetricSet
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	cfgwarn.Beta("The elasticsearch shard metricset is beta")
 
-	http, err := helper.NewHTTP(base)
+	// Get the stats from the local node
+	ms, err := elasticsearch.NewMetricSet(base, statePath)
 	if err != nil {
 		return nil, err
 	}
-	return &MetricSet{
-		BaseMetricSet: base,
-		http:          http,
-	}, nil
+	return &MetricSet{MetricSet: ms}, nil
 }
 
 // Fetch methods implements the data gathering and data conversion to the right format
 func (m *MetricSet) Fetch(r mb.ReporterV2) {
-	content, err := m.http.FetchContent()
+	content, err := m.HTTP.FetchContent()
 	if err != nil {
 		r.Error(err)
 		return
 	}
 
-	eventsMapping(r, content)
+	if m.XPack {
+		eventsMappingXPack(r, m, content)
+	} else {
+		eventsMapping(r, content)
+	}
 }


### PR DESCRIPTION
* Introduces GetNodeInfo method to fetch additional info about the node. This should become obsolete in the future.
* Refactor shard metricset to use module level hostParser and metricset.

The xpack feature works but will need further testing with new builds of Elasticsearch. The plan is to test all xpack metricsets together when they are all done and do further tweaks.