### PR TITLE
Refactor http.server metricset 

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -44,6 +44,7 @@ https://github.com/elastic/beats/compare/v6.2.3...master[Check the HEAD diff]
 - Fixed typo in values for `state_container` `status.phase`, from `terminate` to `terminated`. {pull}6916[6916]
 - RabbitMQ management plugin path is now configured at the module level instead of having to do it in each of the metricsets. New `management_path_prefix` option should be used now {pull}7074[7074]
 - RabbitMQ node metricset only collects metrics of the instance it connects to, `node.collect: cluster` can be used to collect all nodes as before. {issue}6556[6556] {pull}6971[6971]
+- Change http/server metricset to put events by default under http.server and prefix config options with server.. {pull}7100[7100]
 
 *Packetbeat*
 

--- a/metricbeat/helper/server/http/http.go
+++ b/metricbeat/helper/server/http/http.go
@@ -62,7 +62,7 @@ func (h *HttpServer) Start() error {
 
 		logp.Info("Starting http server on %s", h.server.Addr)
 		err := h.server.ListenAndServe()
-		if err != nil {
+		if err != nil && err != http.ErrServerClosed {
 			logp.Critical("Unable to start HTTP server due to error: %v", err)
 		}
 	}()

--- a/metricbeat/module/http/server/_meta/docs.asciidoc
+++ b/metricbeat/module/http/server/_meta/docs.asciidoc
@@ -1,1 +1,15 @@
 This is the server metricset of the module http.
+
+Events sent to the http endpoint will be put by default under the `http.server` prefix. To change this use the `server.paths`
+config options. In the example below every request to `/foo` will be put under `http.foo`.
+
+["source","yaml",subs="attributes"]
+------------------------------------------------------------------------------
+- module: http
+  metricsets: ["server"]
+  host: "localhost"
+  port: "8080"
+  server.paths:
+    - path: "/foo"
+      namespace: "foo"
+------------------------------------------------------------------------------

--- a/metricbeat/module/http/server/config.go
+++ b/metricbeat/module/http/server/config.go
@@ -7,8 +7,8 @@ import (
 )
 
 type HttpServerConfig struct {
-	Paths       []PathConfig `config:"paths"`
-	DefaultPath PathConfig   `config:"default_path"`
+	Paths       []PathConfig `config:"server.paths"`
+	DefaultPath PathConfig   `config:"server.default_path"`
 }
 
 type PathConfig struct {
@@ -21,7 +21,7 @@ func defaultHttpServerConfig() HttpServerConfig {
 	return HttpServerConfig{
 		DefaultPath: PathConfig{
 			Path:      "/",
-			Namespace: "http",
+			Namespace: "server",
 		},
 	}
 }

--- a/metricbeat/tests/system/config/metricbeat.yml.j2
+++ b/metricbeat/tests/system/config/metricbeat.yml.j2
@@ -41,6 +41,10 @@ metricbeat.modules:
   metrics_path: {{ m.path }}
   {% endif -%}
 
+  {% if m.port -%}
+  port: {{ m.port }}
+  {% endif -%}
+
   {% if m.timeout -%}
   timeout: {{ m.timeout }}
   {% endif -%}

--- a/metricbeat/tests/system/test_http.py
+++ b/metricbeat/tests/system/test_http.py
@@ -20,7 +20,7 @@ class Test(metricbeat.BaseTest):
         self.render_config_template(modules=[{
             "name": "http",
             "metricsets": ["json"],
-            "hosts": self.get_hosts(),
+            "hosts": [self.get_host()],
             "period": "5s",
             "namespace": "test",
         }])
@@ -55,7 +55,7 @@ class Test(metricbeat.BaseTest):
 
         self.wait_until(lambda: self.log_contains("Starting http server on localhost:8080"))
 
-        requests.post('http://localhost:8080/', json={'hello': 'world'}, headers={'Content-Type': 'application/json'})
+        requests.post(self.get_host(), json={'hello': 'world'}, headers={'Content-Type': 'application/json'})
         self.wait_until(lambda: self.output_lines() > 0)
         proc.check_kill_and_wait()
         self.assert_no_logged_warnings()
@@ -73,6 +73,5 @@ class Test(metricbeat.BaseTest):
 
         self.assert_fields_are_documented(evt)
 
-    def get_hosts(self):
-        return ["http://" + os.getenv('HTTP_HOST', 'localhost') + ':' +
-                os.getenv('HTTP_PORT', '8080')]
+    def get_host(self):
+        return "http://" + os.getenv('HTTP_HOST', 'localhost') + ':' + os.getenv('HTTP_PORT', '8080')

--- a/metricbeat/tests/system/test_http.py
+++ b/metricbeat/tests/system/test_http.py
@@ -49,10 +49,9 @@ class Test(metricbeat.BaseTest):
         self.render_config_template(modules=[{
             "name": "http",
             "metricsets": ["server"],
+            "port": 8082,
         }])
         proc = self.start_beat()
-        time.sleep(5)
-
         self.wait_until(lambda: self.log_contains("Starting http server on "))
 
         time.sleep(2)
@@ -75,4 +74,4 @@ class Test(metricbeat.BaseTest):
         self.assert_fields_are_documented(evt)
 
     def get_host(self):
-        return "http://" + os.getenv('HTTP_HOST', 'localhost') + ':' + os.getenv('HTTP_PORT', '8080')
+        return "http://" + os.getenv('HTTP_HOST', 'localhost') + ':' + os.getenv('HTTP_PORT', '8082')

--- a/metricbeat/tests/system/test_http.py
+++ b/metricbeat/tests/system/test_http.py
@@ -55,6 +55,7 @@ class Test(metricbeat.BaseTest):
 
         self.wait_until(lambda: self.log_contains("Starting http server on "))
 
+        time.sleep(2)
         requests.post(self.get_host(), json={'hello': 'world'}, headers={'Content-Type': 'application/json'})
         self.wait_until(lambda: self.output_lines() > 0)
         proc.check_kill_and_wait()

--- a/metricbeat/tests/system/test_http.py
+++ b/metricbeat/tests/system/test_http.py
@@ -53,7 +53,7 @@ class Test(metricbeat.BaseTest):
         proc = self.start_beat()
         time.sleep(5)
 
-        self.wait_until(lambda: self.log_contains("Starting http server on localhost:8080"))
+        self.wait_until(lambda: self.log_contains("Starting http server on "))
 
         requests.post(self.get_host(), json={'hello': 'world'}, headers={'Content-Type': 'application/json'})
         self.wait_until(lambda: self.output_lines() > 0)

--- a/metricbeat/tests/system/test_http.py
+++ b/metricbeat/tests/system/test_http.py
@@ -46,16 +46,18 @@ class Test(metricbeat.BaseTest):
         """
         http server metricset test
         """
+        port = 8082
+        host = "localhost"
         self.render_config_template(modules=[{
             "name": "http",
             "metricsets": ["server"],
-            "port": 8082,
+            "port": port,
+            "host": host,
         }])
         proc = self.start_beat()
         self.wait_until(lambda: self.log_contains("Starting http server on "))
-
-        time.sleep(2)
-        requests.post(self.get_host(), json={'hello': 'world'}, headers={'Content-Type': 'application/json'})
+        requests.post("http://" + host + ":" + str(port),
+                      json={'hello': 'world'}, headers={'Content-Type': 'application/json'})
         self.wait_until(lambda: self.output_lines() > 0)
         proc.check_kill_and_wait()
         self.assert_no_logged_warnings()
@@ -74,4 +76,4 @@ class Test(metricbeat.BaseTest):
         self.assert_fields_are_documented(evt)
 
     def get_host(self):
-        return "http://" + os.getenv('HTTP_HOST', 'localhost') + ':' + os.getenv('HTTP_PORT', '8082')
+        return "http://" + os.getenv('HTTP_HOST', 'localhost') + ':' + os.getenv('HTTP_PORT', '8080')


### PR DESCRIPTION
This PR cleans up the http.server metricset which fixes a bug but also has breaking changes.

Breaking changes:

* Before events were put under `http.http` prefix by default which was not intended. Now it is `http.server` by default.
* Config options for the metricset are prefixed now by `server.` as we have for other metricsets.

Further changes

* Metricset now uses PushReporterV2 interface
* System test added to confirm data structure
* Add more docs