### PR TITLE
Use the right sha1 for the golang distribution

### DIFF
--- a/dev-tools/packer/docker/xgo-image/go-1.10.2/Dockerfile
+++ b/dev-tools/packer/docker/xgo-image/go-1.10.2/Dockerfile
@@ -10,6 +10,6 @@ MAINTAINER Tudor Golubenco <tudor@elastic.co>
 # Configure the root Go distribution and bootstrap based on it
 RUN \
   export ROOT_DIST="https://storage.googleapis.com/golang/go1.10.2.linux-amd64.tar.gz" && \
-  export ROOT_DIST_SHA1="c48994946c0d3349baf2d973ed6decb15ca" && \
+  export ROOT_DIST_SHA1="77f0ac48994946c0d3349baf2d973ed6decb15ca" && \
   \
   $BOOTSTRAP_PURE


### PR DESCRIPTION
Fix the master package test, not sure why I did have the right sha1, it was truncated.