### PR TITLE
Move filebeat module tests to parameterized tests

### DIFF
--- a/libbeat/tests/system/requirements.txt
+++ b/libbeat/tests/system/requirements.txt
@@ -27,3 +27,4 @@ termcolor==1.1.0
 texttable==0.9.1
 urllib3==1.22
 websocket-client==0.47.0
+parameterized==0.6.1

--- a/metricbeat/tests/system/requirements.txt
+++ b/metricbeat/tests/system/requirements.txt
@@ -1,3 +1,2 @@
 kafka-python==1.4.2
-parameterized==0.6.1
 elasticsearch==6.2.0


### PR DESCRIPTION
With this change, each test file inside a fileset is executed as its own test. This will make debugging issues much easier and prevent the problem on CI that there is no output for too long. Also the outputs, configs etc. for each test are in a separate directory.