### PR TITLE
Filebeat module fields.yml generator fix

### DIFF
--- a/filebeat/scripts/generator/fields/main.go
+++ b/filebeat/scripts/generator/fields/main.go
@@ -155,8 +155,22 @@ func accumulatePatterns(grok interface{}) ([]string, error) {
 func accumulateRemoveFields(remove interface{}, out []string) []string {
 	for k, v := range remove.(map[string]interface{}) {
 		if k == "field" {
-			vs := v.(string)
-			return append(out, vs)
+			switch vs := v.(type) {
+			case string:
+				return append(out, vs)
+			case []string:
+				for _, vv := range vs {
+					out = append(out, vv)
+				}
+			case []interface{}:
+				for _, vv := range vs {
+					vvs := vv.(string)
+					out = append(out, vvs)
+				}
+			default:
+				return out
+
+			}
 		}
 	}
 	return out

--- a/filebeat/scripts/generator/fields/main_test.go
+++ b/filebeat/scripts/generator/fields/main_test.go
@@ -12,6 +12,11 @@ type FieldsGeneratorTestCase struct {
 	fields   []*fieldYml
 }
 
+type RemoveProcessorTestCase struct {
+	processor map[string]interface{}
+	fields    []string
+}
+
 func TestFieldsGenerator(t *testing.T) {
 	tests := []FieldsGeneratorTestCase{
 		FieldsGeneratorTestCase{
@@ -157,5 +162,40 @@ func TestFieldsGeneratorKnownLimitations(t *testing.T) {
 
 		f := generateFields(fs, false)
 		assert.False(t, reflect.DeepEqual(f, tc.fields))
+	}
+}
+
+func TestRemoveProcessor(t *testing.T) {
+	tests := []RemoveProcessorTestCase{
+		RemoveProcessorTestCase{
+			processor: map[string]interface{}{
+				"field": []string{},
+			},
+			fields: []string{},
+		},
+		RemoveProcessorTestCase{
+			processor: map[string]interface{}{
+				"field": []interface{}{},
+			},
+			fields: []string{},
+		},
+		RemoveProcessorTestCase{
+			processor: map[string]interface{}{
+				"field": "prospector.type",
+			},
+			fields: []string{"prospector.type"},
+		},
+		RemoveProcessorTestCase{
+			processor: map[string]interface{}{
+				"field": []string{"prospector.type", "input.type"},
+			},
+			fields: []string{"prospector.type", "input.type"},
+		},
+	}
+
+	for _, tc := range tests {
+		out := []string{}
+		res := accumulateRemoveFields(tc.processor, out)
+		assert.True(t, reflect.DeepEqual(res, tc.fields))
 	}
 }


### PR DESCRIPTION
Previously, `remove` Ingest processors only supported string values. Thus, a correct pipeline with an array under `remove` lead to panic. From now on, both single string and string array is supported by the generator.

Closes #6970 