### PR TITLE
Fix snapshot packaging for packetbeat and winlogbeat

### DIFF
--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -98,7 +98,7 @@ endif
 
 # Only build experimental targets for snapshots
 ifneq ($(SNAPSHOT),yes)
-	PACKAGES_EXPERIMENTAL=""
+	PACKAGES_EXPERIMENTAL=
 endif
 
 ### BUILDING ###

--- a/packetbeat/Makefile
+++ b/packetbeat/Makefile
@@ -5,10 +5,12 @@ SYSTEM_TESTS?=true
 TEST_ENVIRONMENT=false
 ES_BEATS?=..
 
+TARGETS?="windows/amd64 windows/386 darwin/amd64"## @building list of platforms/architecture to be built by "make package"
+PACKAGES?=${BEAT_NAME}/deb ${BEAT_NAME}/rpm ${BEAT_NAME}/darwin ${BEAT_NAME}/win ${BEAT_NAME}/bin ## @Building List of OS to be supported by "make package"
+PACKAGES_EXPERIMENTAL=
+
 include ${ES_BEATS}/libbeat/scripts/Makefile
 
-TARGETS?="windows/amd64 windows/386 darwin/amd64 " ## @building list of platforms/architecture to be built by "make package"
-PACKAGES?=${BEAT_NAME}/deb ${BEAT_NAME}/rpm ${BEAT_NAME}/darwin ${BEAT_NAME}/win ${BEAT_NAME}/bin ## @Building List of OS to be supported by "make package"
 
 # This is called by the beats packer before building starts
 .PHONY: before-build

--- a/winlogbeat/Makefile
+++ b/winlogbeat/Makefile
@@ -5,8 +5,9 @@ SYSTEM_TESTS=true
 TEST_ENVIRONMENT=false
 
 GOX_OS=windows
-TARGETS="windows/amd64 windows/386"
+TARGETS?="windows/amd64 windows/386"
 PACKAGES=winlogbeat/win
+PACKAGES_EXPERIMENTAL=
 
 CGO=false		# don't need Cgo in Winlogbeat
 
@@ -23,3 +24,4 @@ before-build:
 # Collects all dependencies and then calls update
 .PHONY: collect
 collect:
+


### PR DESCRIPTION
arm builds were excluded for the builds which were run without SNAPSHOT param. But for the builds with SNAPSHOT=yes the PACKAGES_EXPERIMENTAL were not overwritten in packetbeat and winlogbeat.

* Change order of defining `TARGETS` and include Makefile as otherwise variable is overwritten