### PR TITLE
Fix Filebeat module generator substitution

### DIFF
--- a/filebeat/scripts/module/_meta/config.yml
+++ b/filebeat/scripts/module/_meta/config.yml
@@ -1,6 +1,6 @@
-- module: {{ module }}
+- module: {module}
   # All logs
-  {{ fileset }}:
+  {fileset}:
     enabled: true
 
     # Set custom paths for the log files. If left empty,


### PR DESCRIPTION
Strings `{{ module }}` and `{{ fileset }}` in fileset templates are not substituted. It's because the correct format is `{module}` and `{fileset}`. I changed the format strings accordingly.

This was discovered in #7052 