### PR TITLE
Check if seccomp is supported

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -398,7 +398,7 @@ Apache License 2.0
 
 --------------------------------------------------------------------
 Dependency: github.com/elastic/go-seccomp-bpf
-Revision: 5b8918a6690928ed0248e202b7367d8a926f2a93
+Revision: 5bed103a93993f24c58dd267faaab582f2373e31
 License type (autodetected): Apache-2.0
 ./vendor/github.com/elastic/go-seccomp-bpf/LICENSE.txt:
 --------------------------------------------------------------------

--- a/libbeat/common/seccomp/seccomp.go
+++ b/libbeat/common/seccomp/seccomp.go
@@ -72,6 +72,12 @@ func loadFilter(p *seccomp.Policy) {
 		return
 	}
 
+	if !seccomp.Supported() {
+		log.Info("Syscall filter could not be installed because the kernel " +
+			"does not support seccomp")
+		return
+	}
+
 	if p == nil {
 		log.Debug("No seccomp policy is defined")
 		return
@@ -83,10 +89,10 @@ func loadFilter(p *seccomp.Policy) {
 		Policy:     *p,
 	}
 
-	log.Debug("Loading syscall filter")
-	log = log.With("seccomp_filter", filter)
+	log.Debugw("Loading syscall filter", "seccomp_filter", filter)
 	if err := seccomp.LoadFilter(filter); err != nil {
-		log.Warnw("Syscall filter could not be installed", "error", err)
+		log.Warn("Syscall filter could not be installed", "error", err,
+			"seccomp_filter", filter)
 		return
 	}
 

--- a/vendor/github.com/elastic/go-seccomp-bpf/seccomp_linux.go
+++ b/vendor/github.com/elastic/go-seccomp-bpf/seccomp_linux.go
@@ -26,6 +26,17 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+// Supported returns true if the seccomp syscall is supported.
+func Supported() bool {
+	// Strict mode requires that flags be set to 0, but we are sending 1 so
+	// this will return EINVAL if the syscall exists and is allowed.
+	if err := seccomp(seccompSetModeStrict, 1, nil); err == syscall.EINVAL {
+		return true
+	}
+
+	return false
+}
+
 // SetNoNewPrivs will use prctl to set the calling thread's no_new_privs bit to
 // 1 (true). Once set, this bit cannot be unset.
 func SetNoNewPrivs() error {

--- a/vendor/github.com/elastic/go-seccomp-bpf/seccomp_unsupported.go
+++ b/vendor/github.com/elastic/go-seccomp-bpf/seccomp_unsupported.go
@@ -19,6 +19,13 @@
 
 package seccomp
 
+// Supported returns true if the seccomp syscall is supported.
+//
+// This is a stub for non-Linux systems. It always returns false.
+func Supported() bool {
+	return false
+}
+
 // SetNoNewPrivs will use prctl to set the calling thread's no_new_privs bit to
 // 1 (true). Once set, this bit cannot be unset.
 //

--- a/vendor/github.com/elastic/go-seccomp-bpf/zconstants.go
+++ b/vendor/github.com/elastic/go-seccomp-bpf/zconstants.go
@@ -23,6 +23,8 @@ package seccomp
 const prSetNoNewPrivs = 0x26
 
 const (
+	seccompSetModeStrict = 0
+
 	seccompSetModeFilter = 0x1
 )
 
@@ -38,7 +40,10 @@ const (
 	ActionAllow       Action = 0x7fff0000
 )
 
-const errnoEPERM = 0x1
+const (
+	errnoEPERM  = 0x1
+	errnoENOSYS = 0x26
+)
 
 const (
 	FilterFlagTSync FilterFlag = 0x1

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -445,16 +445,16 @@
 			"revisionTime": "2016-06-17T14:03:01Z"
 		},
 		{
-			"checksumSHA1": "kKIue9tf5+ugetNnbI8tdYSy1HI=",
+			"checksumSHA1": "TatpgVf9fhQp1GtNwSyNw5cgVKM=",
 			"path": "github.com/elastic/go-seccomp-bpf",
-			"revision": "5b8918a6690928ed0248e202b7367d8a926f2a93",
-			"revisionTime": "2018-05-15T03:39:52Z"
+			"revision": "5bed103a93993f24c58dd267faaab582f2373e31",
+			"revisionTime": "2018-05-17T07:14:48Z"
 		},
 		{
 			"checksumSHA1": "qTs7QT+GC2Dr4aFoLFHCkAOoVeU=",
 			"path": "github.com/elastic/go-seccomp-bpf/arch",
-			"revision": "5b8918a6690928ed0248e202b7367d8a926f2a93",
-			"revisionTime": "2018-05-15T03:39:52Z"
+			"revision": "5bed103a93993f24c58dd267faaab582f2373e31",
+			"revisionTime": "2018-05-17T07:14:48Z"
 		},
 		{
 			"path": "github.com/elastic/go-seccomp-bpf/cmd/seccomp-profile",
@@ -464,14 +464,14 @@
 		{
 			"checksumSHA1": "5vWvvnghiBzyFo+KnD9iRlRc5Uw=",
 			"path": "github.com/elastic/go-seccomp-bpf/cmd/seccomp-profiler",
-			"revision": "5b8918a6690928ed0248e202b7367d8a926f2a93",
-			"revisionTime": "2018-05-15T03:39:52Z"
+			"revision": "5bed103a93993f24c58dd267faaab582f2373e31",
+			"revisionTime": "2018-05-17T07:14:48Z"
 		},
 		{
 			"checksumSHA1": "386906x6hGeUDkGJ1Wk0kUWWA4Y=",
 			"path": "github.com/elastic/go-seccomp-bpf/cmd/seccomp-profiler/disasm",
-			"revision": "5b8918a6690928ed0248e202b7367d8a926f2a93",
-			"revisionTime": "2018-05-15T03:39:52Z"
+			"revision": "5bed103a93993f24c58dd267faaab582f2373e31",
+			"revisionTime": "2018-05-17T07:14:48Z"
 		},
 		{
 			"checksumSHA1": "AaEPt+KMknLXze11YOnBGKzP3aA=",


### PR DESCRIPTION
Rather than logging a warning when seccomp is not supported by the kernel this will log a simple info statement and bail out.

This also steps down the verbosity of the seccomp log message in the success case by not logging the filter. The filter will only be shown in debug mode.