### PR TITLE
Add support for keyword multifields

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -137,6 +137,7 @@ https://github.com/elastic/beats/compare/v6.2.3...master[Check the HEAD diff]
 - Add Kibana module with log fileset. {pull}7052[7052]
 - Add default_fields to Elasticsearch template when connecting to Elasticsearch >= 7.0. {pull}7015[7015]
 - Add support for loading a template.json file directly instead of using fields.yml. {pull}7039[7039]
+- Add support for keyword multifields in field.yml. {pull}7131[7131]
 
 *Auditbeat*
 

--- a/libbeat/template/processor.go
+++ b/libbeat/template/processor.go
@@ -157,6 +157,13 @@ func (p *Processor) keyword(f *common.Field) common.MapStr {
 		property["ignore_above"] = 1024
 		property["index"] = "not_analyzed"
 	}
+
+	if len(f.MultiFields) > 0 {
+		fields := common.MapStr{}
+		p.Process(f.MultiFields, "", fields)
+		property["fields"] = fields
+	}
+
 	return property
 }
 

--- a/libbeat/template/processor_test.go
+++ b/libbeat/template/processor_test.go
@@ -119,6 +119,37 @@ func TestProcessor(t *testing.T) {
 			},
 		},
 		{
+			output: p.keyword(&common.Field{Type: "keyword", MultiFields: common.Fields{common.Field{Name: "analyzed", Type: "text", Norms: true}}}),
+			expected: common.MapStr{
+				"type":         "keyword",
+				"ignore_above": 1024,
+				"fields": common.MapStr{
+					"analyzed": common.MapStr{
+						"type": "text",
+					},
+				},
+			},
+		},
+		{
+			output: p.text(&common.Field{Type: "text", MultiFields: common.Fields{
+				common.Field{Name: "raw", Type: "keyword"},
+				common.Field{Name: "indexed", Type: "text"},
+			}, Norms: true}),
+			expected: common.MapStr{
+				"type": "text",
+				"fields": common.MapStr{
+					"raw": common.MapStr{
+						"type":         "keyword",
+						"ignore_above": 1024,
+					},
+					"indexed": common.MapStr{
+						"type":  "text",
+						"norms": false,
+					},
+				},
+			},
+		},
+		{
 			output: p.text(&common.Field{Type: "text", MultiFields: common.Fields{
 				common.Field{Name: "raw", Type: "keyword"},
 				common.Field{Name: "indexed", Type: "text"},


### PR DESCRIPTION
Before a multifield was only possible if the top level field was text. Now it can also be keyword.