### PR TITLE
Backport: Filebeat: Fix leak in log harvester (#6797)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -38,6 +38,9 @@ https://github.com/elastic/beats/compare/v6.2.4...6.2[Check the HEAD diff]
 
 *Filebeat*
 
+- Fix panic when log prospector configuration fails to load. {issue}6800[6800]
+- Fix memory leak in log prospector when files cannot be read. {issue}6797[6797]
+
 *Heartbeat*
 - Fix race due to updates of shared a map, that was not supposed to be shared between multiple go-routines. {issue}6616[6616]
 

--- a/filebeat/prospector/log/prospector.go
+++ b/filebeat/prospector/log/prospector.go
@@ -572,10 +572,21 @@ func (p *Prospector) isCleanInactive(state file.State) bool {
 	return false
 }
 
+// subOutletWrap returns a factory method that will wrap the passed outlet
+// in a SubOutlet and memoize the result so the wrapping is done only once.
+func subOutletWrap(outlet channel.Outleter) func() channel.Outleter {
+	var subOutlet channel.Outleter
+	return func() channel.Outleter {
+		if subOutlet == nil {
+			subOutlet = channel.SubOutlet(outlet)
+		}
+		return subOutlet
+	}
+}
+
 // createHarvester creates a new harvester instance from the given state
 func (p *Prospector) createHarvester(state file.State, onTerminate func()) (*Harvester, error) {
 	// Each wraps the outlet, for closing the outlet individually
-	outlet := channel.SubOutlet(p.outlet)
 	h, err := NewHarvester(
 		p.cfg,
 		state,
@@ -583,7 +594,7 @@ func (p *Prospector) createHarvester(state file.State, onTerminate func()) (*Har
 		func(d *util.Data) bool {
 			return p.stateOutlet.OnEvent(d)
 		},
-		outlet,
+		subOutletWrap(p.outlet),
 	)
 	if err == nil {
 		h.onTerminate = onTerminate

--- a/filebeat/prospector/stdin/prospector.go
+++ b/filebeat/prospector/stdin/prospector.go
@@ -73,7 +73,9 @@ func (p *Prospector) createHarvester(state file.State) (*log.Harvester, error) {
 	h, err := log.NewHarvester(
 		p.cfg,
 		state, nil, nil,
-		p.outlet,
+		func() channel.Outleter {
+			return p.outlet
+		},
 	)
 
 	return h, err


### PR DESCRIPTION
This patch reorganizes a little bit how the log harvester works, so that suboutlets are only created when the harvester is ready to use them (inside Run()), instead of being passed during constructor.

This prevents a memory leak caused by some internal goroutines not stopping if the harvester Setup() fails, for example when files cannot be read.

Fixes #6797