### PR TITLE
Adjust the version compatibility in the doc

### DIFF
--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -14,7 +14,7 @@
 == Configure the output
 
 ifdef::only-elasticsearch[]
-You configure {beatname_uc} to write to Elasticsearch by setting options 
+You configure {beatname_uc} to write to Elasticsearch by setting options
 in the `output.elasticsearch` section of the +{beatname_lc}.yml+ config file
 endif::[]
 
@@ -601,7 +601,7 @@ NOTE: Events bigger than <<kafka-max_message_bytes,`max_message_bytes`>> will be
 
 ==== Compatibility
 
-This output works with Kafka 0.8, 0.9, and 0.10.
+This output works with Kafka 0.8, 0.9, 0.10 and 0.11.
 
 ==== Configuration options
 


### PR DESCRIPTION
The `Compatibility` was saying up to 0.10 and the `version` section was
up to 0.11. by looking at the code[1] it support up to 0.11.

[1] https://github.com/elastic/beats/blob/e3248ad3a80518eebefabe1c64eeb059ccb155d2/libbeat/outputs/kafka/kafka.go#L66-L92

Will do a followup for the master branch since the docs is not the same.