### PR TITLE
Cherry-pick #6306 to 6.2: [metricbeat] Fix errors in process summary on latest Linux kernels

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -248,6 +248,11 @@ https://github.com/elastic/beats/compare/v6.1.3...v6.2.0[View commits]
 - Docker and Kubernetes modules are now GA, instead of Beta. {pull}6105[6105]
 - Support haproxy stats gathering using http (additionaly to tcp socket). {pull}5819[5819]
 - Support to optionally 'de dot' keys in http/json metricset to prevent collisions. {pull}5957[5957]
+- De dot keys in jolokia/jmx metricset to prevent collisions. {pull}5957[5957]
+- Support to optionally 'de dot' keys in http/json metricset to prevent collisions. {pull}5970[5970]
+- De dot keys in kubernetes/event metricset to prevent collisions. {pull}6203[6203]
+- Fix the default configuration for Logstash to include the default port. {pull}6279[6279]
+- Fix dealing with new process status codes in Linux kernel 4.14+. {pull}6306[6306]
 
 *Packetbeat*
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -38,6 +38,9 @@ https://github.com/elastic/beats/compare/v6.2.4...6.2[Check the HEAD diff]
 
 *Filebeat*
 
+- Fix panic when log prospector configuration fails to load. {issue}6800[6800]
+- Fix memory leak in log prospector when files cannot be read. {issue}6797[6797]
+
 *Heartbeat*
 - Fix race due to updates of shared a map, that was not supposed to be shared between multiple go-routines. {issue}6616[6616]
 

--- a/filebeat/prospector/log/prospector.go
+++ b/filebeat/prospector/log/prospector.go
@@ -572,10 +572,21 @@ func (p *Prospector) isCleanInactive(state file.State) bool {
 	return false
 }
 
+// subOutletWrap returns a factory method that will wrap the passed outlet
+// in a SubOutlet and memoize the result so the wrapping is done only once.
+func subOutletWrap(outlet channel.Outleter) func() channel.Outleter {
+	var subOutlet channel.Outleter
+	return func() channel.Outleter {
+		if subOutlet == nil {
+			subOutlet = channel.SubOutlet(outlet)
+		}
+		return subOutlet
+	}
+}
+
 // createHarvester creates a new harvester instance from the given state
 func (p *Prospector) createHarvester(state file.State, onTerminate func()) (*Harvester, error) {
 	// Each wraps the outlet, for closing the outlet individually
-	outlet := channel.SubOutlet(p.outlet)
 	h, err := NewHarvester(
 		p.cfg,
 		state,
@@ -583,7 +594,7 @@ func (p *Prospector) createHarvester(state file.State, onTerminate func()) (*Har
 		func(d *util.Data) bool {
 			return p.stateOutlet.OnEvent(d)
 		},
-		outlet,
+		subOutletWrap(p.outlet),
 	)
 	if err == nil {
 		h.onTerminate = onTerminate

--- a/filebeat/prospector/stdin/prospector.go
+++ b/filebeat/prospector/stdin/prospector.go
@@ -73,7 +73,9 @@ func (p *Prospector) createHarvester(state file.State) (*log.Harvester, error) {
 	h, err := log.NewHarvester(
 		p.cfg,
 		state, nil, nil,
-		p.outlet,
+		func() channel.Outleter {
+			return p.outlet
+		},
 	)
 
 	return h, err

--- a/metricbeat/module/system/process_summary/process_summary.go
+++ b/metricbeat/module/system/process_summary/process_summary.go
@@ -71,6 +71,8 @@ func (m *MetricSet) Fetch() (common.MapStr, error) {
 			summary.running++
 		case 'D':
 			summary.idle++
+		case 'I':
+			summary.idle++
 		case 'T':
 			summary.stopped++
 		case 'Z':


### PR DESCRIPTION
Cherry-pick of PR #6306 to 6.2 branch. Original message: 

On Linux 4.14 and 4.15, metricbeat logs large numbers of errors such as

```
2018/02/07 11:19:46.284926 process_summary.go:79: ERR Unknown state <73> for process with pid 4
```

All affected processes appear to be kernel threads.

`<73>` translates into `I`, which is a new status code introduced into the
`/proc/<pid>/stat` output in kernel commit
https://github.com/torvalds/linux/commit/06eb61844d841d0032a9950ce7f8e783ee49c0d0

For backwards compatibility, the old and new codes are now used to increment
the count of idle processes reported in the summary.

Fixes #6305.