### PR TITLE
Cherry-pick #6306 to 6.2: [metricbeat] Fix errors in process summary on latest Linux kernels

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -245,6 +245,7 @@ https://github.com/elastic/beats/compare/v6.1.3...v6.2.0[View commits]
 - Docker and Kubernetes modules are now GA, instead of Beta. {pull}6105[6105]
 - Support haproxy stats gathering using http (additionaly to tcp socket). {pull}5819[5819]
 - Support to optionally 'de dot' keys in http/json metricset to prevent collisions. {pull}5957[5957]
+- Fix dealing with new process status codes in Linux kernel 4.14+. {pull}6306[6306]
 
 *Packetbeat*
 

--- a/metricbeat/module/system/process_summary/process_summary.go
+++ b/metricbeat/module/system/process_summary/process_summary.go
@@ -71,6 +71,8 @@ func (m *MetricSet) Fetch() (common.MapStr, error) {
 			summary.running++
 		case 'D':
 			summary.idle++
+		case 'I':
+			summary.idle++
 		case 'T':
 			summary.stopped++
 		case 'Z':


### PR DESCRIPTION
Cherry-pick of PR #6306 to 6.2 branch. Original message: 

On Linux 4.14 and 4.15, metricbeat logs large numbers of errors such as

```
2018/02/07 11:19:46.284926 process_summary.go:79: ERR Unknown state <73> for process with pid 4
```

All affected processes appear to be kernel threads.

`<73>` translates into `I`, which is a new status code introduced into the
`/proc/<pid>/stat` output in kernel commit
https://github.com/torvalds/linux/commit/06eb61844d841d0032a9950ce7f8e783ee49c0d0

For backwards compatibility, the old and new codes are now used to increment
the count of idle processes reported in the summary.

Fixes #6305.