### PR TITLE
Update docs 

### DIFF
--- a/libbeat/docs/shared-configuring.asciidoc
+++ b/libbeat/docs/shared-configuring.asciidoc
@@ -1,24 +1,22 @@
 //Added conditional coding to support Beats that don't offer all of these install options
 
+To configure {beatname_uc}, you edit the configuration file. 
+
 ifeval::["{beatname_lc}"!="auditbeat"]
-
-To configure {beatname_uc}, you edit the configuration file. For rpm and deb,
-you'll find the configuration file at +/etc/{beatname_lc}/{beatname_lc}.yml+. Under
-Docker, it's located at +/usr/share/{beatname_lc}/{beatname_lc}.yml+. For mac and win,
-look in the archive that you just extracted. There’s also a full example
-configuration file called +{beatname_lc}.reference.yml+ that shows all non-deprecated
-options.
-
+For rpm and deb, you'll find the configuration file at +/etc/{beatname_lc}/{beatname_lc}.yml+. 
+For mac and win, look in the archive that you just extracted.
+Under Docker, it's located at +/usr/share/{beatname_lc}/{beatname_lc}.yml+.
 endif::[]
 
 ifeval::["{beatname_lc}"=="auditbeat"]
+For rpm and deb, you'll find the configuration file at +/etc/{beatname_lc}/{beatname_lc}.yml+. 
+For mac and win, look in the archive that you just extracted.
+endif::[]
 
-To configure {beatname_uc}, you edit the configuration file. For rpm and deb,
-you'll find the configuration file at +/etc/{beatname_lc}/{beatname_lc}.yml+.
-For mac and win, look in the archive that you just extracted. There’s also a
-full example configuration file called +{beatname_lc}.reference.yml+ that shows
-all non-deprecated options.
 
+ifeval::["{beatname_lc}"!="apm-server"]
+There’s also a full example configuration file called +{beatname_lc}.reference.yml+ 
+that shows all non-deprecated options.
 endif::[]
 
 TIP: See the


### PR DESCRIPTION
* Only refer to `beat.reference.yml` in the official docs for the beats that actually have a `reference.yml`. 
* Add missing config option `output.elasticsearch.ssl.client_authentication` to `reference.yml` files that has been documented already on the official beats docs pages. 