### PR TITLE
libbeat: Stop autodiscover runners in a goroutine

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -63,6 +63,7 @@ https://github.com/elastic/beats/compare/v6.2.3...master[Check the HEAD diff]
 - Fix error if lz4 compression is used with the kafka output. {pull}7025[7025]
 - Preserve the event when source matching fails in `add_docker_metadata`. {pull}7133[7133]
 - Negotiate Docker API version from our client instead of using a hardcoded one. {pull}7165[7165]
+- Fix delays on autodiscovery events handling caused by blocking runner stops. {pull}7170[7170]
 
 *Auditbeat*
 

--- a/libbeat/autodiscover/autodiscover.go
+++ b/libbeat/autodiscover/autodiscover.go
@@ -177,8 +177,12 @@ func (a *Autodiscover) handleStop(event bus.Event) {
 		}
 
 		if runner := a.runners.Get(hash); runner != nil {
+			// Stop can block, we run it asyncrhonously to avoid blocking
+			// the whole events loop. The runner hash is removed in any case
+			// so an equivalent configuration can be added again while this
+			// one stops, and a duplicated event don't try to stop it twice.
 			logp.Info("Autodiscover stopping runner: %s", runner)
-			runner.Stop()
+			go runner.Stop()
 			a.runners.Remove(hash)
 		} else {
 			logp.Debug(debugK, "Runner not found for stopping: %s", hash)


### PR DESCRIPTION
Stopping runners can be a blocking operation, what can block the
autodiscover event loop. Run it in a goroutine so events can continue
being handled.