### PR TITLE
filebeat keep the deleted files

### DIFF
--- a/filebeat/input/log/harvester.go
+++ b/filebeat/input/log/harvester.go
@@ -523,7 +523,7 @@ func (h *Harvester) newLogFileReader() (reader.Reader, error) {
 	// TODO: NewLineReader uses additional buffering to deal with encoding and testing
 	//       for new lines in input stream. Simple 8-bit based encodings, or plain
 	//       don't require 'complicated' logic.
-	h.log, err = NewLog(h.source, h.config.LogConfig)
+	h.log, err = NewLog(h.source, h.state.FileStateOS, h.config.LogConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/filebeat/input/log/log.go
+++ b/filebeat/input/log/log.go
@@ -7,15 +7,14 @@ import (
 
 	"github.com/elastic/beats/filebeat/harvester"
 	"github.com/elastic/beats/filebeat/input/file"
+	filehelper "github.com/elastic/beats/libbeat/common/file"
 	"github.com/elastic/beats/libbeat/logp"
-
-	file_helper "github.com/elastic/beats/libbeat/common/file"
 )
 
 // Log contains all log related data
 type Log struct {
 	fs           harvester.Source
-	stateOS      file_helper.StateOS
+	stateOS      filehelper.StateOS
 	offset       int64
 	config       LogConfig
 	lastTimeRead time.Time
@@ -26,7 +25,7 @@ type Log struct {
 // NewLog creates a new log instance to read log sources
 func NewLog(
 	fs harvester.Source,
-	stateOS file_helper.StateOS,
+	stateOS filehelper.StateOS,
 	config LogConfig,
 ) (*Log, error) {
 	var offset int64
@@ -143,7 +142,7 @@ func (f *Log) errorChecks(err error) error {
 		stat, statErr := os.Stat(f.fs.Name())
 
 		// Error means file does not exist, or if inode has changed, then file was removed.
-		if statErr != nil || !file_helper.GetOSState(stat).IsSame(f.stateOS) {
+		if statErr != nil || !filehelper.GetOSState(stat).IsSame(f.stateOS) {
 			return ErrRemoved
 		}
 	}


### PR DESCRIPTION
Found on my centos,  filebeat takes some have been deleted file handle, resulting in there are lots of ghost files and disk space is not released.

Then I read the code, and find there may be something wrong:
  Application in log rotation, will delete the old log file, or directly to compressed archive the old file, then create a new file with the same name. And filebeat is according to the file name if there is to determine whether a file is removed.
https://github.com/elastic/beats/blob/800d95f0c8362fe4ac0dc02117fa03523d03d3df/filebeat/input/log/log.go#L136-L144

## Reproduce
Using a command simulate continuous writting a log file , if delete it, will create and write again.
`while true;do echo "I'm a test log" >> /tmp/test.log && sleep 1; done`

Running filebeat with the filebeat.yml.
filebeat.yml:
```
filebeat.prospectors:

- type: log

  enabled: true

  paths:
    - /tmp/test.log

output.file:
  path: "/tmp/"
  filename: filebeat_test.log
```
run filebeat:
```
$ ./filebeat &
[1] 2485
$ ps -ef| grep filebeat
apps      2485  5223  0 16:04 pts/19   00:00:00 ./filebeat
apps      2693  5223  0 16:04 pts/19   00:00:00 grep filebeat
$ ll /proc/2485/fd
total 0
lrwx------ 1 apps apps 64 May 24 16:05 0 -> /dev/pts/19
lrwx------ 1 apps apps 64 May 24 16:05 1 -> /dev/pts/19
lrwx------ 1 apps apps 64 May 24 16:04 2 -> /dev/pts/19
lr-x------ 1 apps apps 64 May 24 16:05 3 -> /dev/urandom
lr-x------ 1 apps apps 64 May 24 16:05 4 -> eventpoll:[3219478084]
l-wx------ 1 apps apps 64 May 24 16:05 5 -> /tmp/filebeat-6.2.4-linux-x86_64/logs/filebeat
lr-x------ 1 apps apps 64 May 24 16:05 6 -> /tmp/test.log
l-wx------ 1 apps apps 64 May 24 16:05 7 -> /tmp/filebeat_test.log
```
remove /tmp/test.log or zip test.log, simulate the rotation
```
$ rm /tmp/test.log
$ ll /proc/2485/fd
total 0
lrwx------ 1 apps apps 64 May 24 16:05 0 -> /dev/pts/19
lrwx------ 1 apps apps 64 May 24 16:05 1 -> /dev/pts/19
lrwx------ 1 apps apps 64 May 24 16:04 2 -> /dev/pts/19
lr-x------ 1 apps apps 64 May 24 16:05 3 -> /dev/urandom
lr-x------ 1 apps apps 64 May 24 16:05 4 -> eventpoll:[3219478084]
l-wx------ 1 apps apps 64 May 24 16:05 5 -> /tmp/filebeat-6.2.4-linux-x86_64/logs/filebeat
lr-x------ 1 apps apps 64 May 24 16:05 6 -> /tmp/test.log (deleted)
l-wx------ 1 apps apps 64 May 24 16:05 7 -> /tmp/filebeat_test.log
lr-x------ 1 apps apps 64 May 24 16:05 8 -> /tmp/test.log
```
rm /tmp/test.log more times
![image](https://user-images.githubusercontent.com/7902470/40532915-93ac4b7e-6033-11e8-962e-19dfb3733bed.png)


