### PR TITLE
Auditd module: New metric for kernel lost events

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -373,8 +373,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 --------------------------------------------------------------------
 Dependency: github.com/elastic/go-libaudit
-Version: v0.2.1
-Revision: 55225d06b15c74082f9a7af75aa4284dbe48d20a
+Version: v0.3.0
+Revision: c18782ee4f957de48620718231d20ca12c8dc4e9
 License type (autodetected): Apache-2.0
 ./vendor/github.com/elastic/go-libaudit/LICENSE.txt:
 --------------------------------------------------------------------

--- a/vendor/github.com/elastic/go-libaudit/CHANGELOG.md
+++ b/vendor/github.com/elastic/go-libaudit/CHANGELOG.md
@@ -2,6 +2,33 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+
+## [0.3.0]
+
+### Added
+
+- Added support for setting the kernel's backlog wait time via the new
+  SetBacklogWaitTime function. #34
+- New method `GetStatusAsync` to perform asynchronous status checks. #37
+
+### Changed
+
+- AuditClient `Close()` is now safe to call more than once. #35
+
+### Deprecated
+
+### Removed
+
 ## [0.2.1]
 
 ### Added

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -369,12 +369,12 @@
 			"revisionTime": "2016-08-05T00:47:13Z"
 		},
 		{
-			"checksumSHA1": "hAB/G2FIWYwg3Rujgpt6UPtHMis=",
+			"checksumSHA1": "qghOCT8VCZFNPvu8/LCmletBKd8=",
 			"path": "github.com/elastic/go-libaudit",
-			"revision": "55225d06b15c74082f9a7af75aa4284dbe48d20a",
-			"revisionTime": "2018-05-03T13:36:58Z",
-			"version": "v0.2.1",
-			"versionExact": "v0.2.1"
+			"revision": "c18782ee4f957de48620718231d20ca12c8dc4e9",
+			"revisionTime": "2018-05-25T13:51:51Z",
+			"version": "v0.3.0",
+			"versionExact": "v0.3.0"
 		},
 		{
 			"checksumSHA1": "3V0tnqlCgmCXnbocuTqUKluynm8=",


### PR DESCRIPTION
The `auditd` module exports a new metric, `kernel_lost`, that accounts for the events dropped by the kernel's audit framework.

The original `lost` metric has been renamed to `reassembler_lost`.
