### PR TITLE
Auditbeat: Add backpressure_strategy option (#7157)

### DIFF
--- a/auditbeat/module/auditd/audit_linux.go
+++ b/auditbeat/module/auditd/audit_linux.go
@@ -161,7 +161,7 @@ func (ms *MetricSet) Run(reporter mb.PushReporterV2) {
 	// By default (stream_buffer_consumers=0) use as many consumers as local CPUs
 	// with a max of `maxDefaultStreamBufferConsumers`
 	if numConsumers == 0 {
-		if numConsumers = runtime.NumCPU(); numConsumers > maxDefaultStreamBufferConsumers {
+		if numConsumers = runtime.GOMAXPROCS(-1); numConsumers > maxDefaultStreamBufferConsumers {
 			numConsumers = maxDefaultStreamBufferConsumers
 		}
 	}

--- a/auditbeat/module/auditd/audit_linux.go
+++ b/auditbeat/module/auditd/audit_linux.go
@@ -142,9 +142,7 @@ func (ms *MetricSet) Run(reporter mb.PushReporterV2) {
 				case <-reporter.Done():
 					return
 				case <-timer.C:
-					if seq, err := ms.client.GetStatusAsync(false); err == nil {
-						ms.log.Debugf("sent async status request seq=%d", seq)
-					} else {
+					if _, err := ms.client.GetStatusAsync(false); err != nil {
 						ms.log.Error("get async status request failed:", err)
 					}
 				case status := <-statusC:

--- a/auditbeat/module/auditd/audit_linux.go
+++ b/auditbeat/module/auditd/audit_linux.go
@@ -44,6 +44,7 @@ var (
 	reassemblerGapsMetric = monitoring.NewInt(auditdMetrics, "reassembler_seq_gaps")
 	kernelLostMetric      = monitoring.NewInt(auditdMetrics, "kernel_lost")
 	userspaceLostMetric   = monitoring.NewInt(auditdMetrics, "userspace_lost")
+	receivedMetric        = monitoring.NewInt(auditdMetrics, "received_msgs")
 )
 
 func init() {
@@ -89,6 +90,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	reassemblerGapsMetric.Set(0)
 	kernelLostMetric.Set(0)
 	userspaceLostMetric.Set(0)
+	receivedMetric.Set(0)
 
 	return &MetricSet{
 		BaseMetricSet:        base,
@@ -362,7 +364,7 @@ func (ms *MetricSet) receiveEvents(done <-chan struct{}) (<-chan []*auparse.Audi
 			if filterRecordType(raw.Type) {
 				continue
 			}
-
+			receivedMetric.Inc()
 			if err := reassembler.Push(raw.Type, raw.Data); err != nil {
 				ms.log.Debugw("Dropping audit message",
 					"record_type", raw.Type,

--- a/auditbeat/module/auditd/audit_linux.go
+++ b/auditbeat/module/auditd/audit_linux.go
@@ -41,7 +41,7 @@ const (
 
 var (
 	auditdMetrics         = monitoring.Default.NewRegistry(moduleName)
-	reassemblerlostMetric = monitoring.NewInt(auditdMetrics, "reassembler_lost")
+	reassemblerGapsMetric = monitoring.NewInt(auditdMetrics, "reassembler_seq_gaps")
 	kernelLostMetric      = monitoring.NewInt(auditdMetrics, "kernel_lost")
 	userspaceLostMetric   = monitoring.NewInt(auditdMetrics, "userspace_lost")
 )
@@ -86,7 +86,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 		return nil, errors.Wrap(err, "failed to create audit client")
 	}
 
-	reassemblerlostMetric.Set(0)
+	reassemblerGapsMetric.Set(0)
 	kernelLostMetric.Set(0)
 	userspaceLostMetric.Set(0)
 
@@ -638,7 +638,7 @@ func (s *stream) ReassemblyComplete(msgs []*auparse.AuditMessage) {
 }
 
 func (s *stream) EventsLost(count int) {
-	reassemblerlostMetric.Inc()
+	reassemblerGapsMetric.Add(int64(count))
 }
 
 // nonBlockingStream behaves as stream above, except that it will never block

--- a/auditbeat/module/auditd/audit_linux_test.go
+++ b/auditbeat/module/auditd/audit_linux_test.go
@@ -56,7 +56,7 @@ func TestData(t *testing.T) {
 		// Get Status response for initClient
 		returnACK().returnStatus().
 		// Send expected ACKs for initialization
-		returnACK().returnACK().returnACK().returnACK().
+		returnACK().returnACK().returnACK().returnACK().returnACK().
 		// Send a single audit message from the kernel.
 		returnMessage(userLoginMsg)
 

--- a/auditbeat/module/auditd/config.go
+++ b/auditbeat/module/auditd/config.go
@@ -33,6 +33,11 @@ type Config struct {
 	ReassemblerMaxInFlight uint32        `config:"reassembler.max_in_flight"`
 	ReassemblerTimeout     time.Duration `config:"reassembler.timeout"`
 	StreamBufferQueueSize  uint32        `config:"reassembler.queue_size"`
+	// BackpressureStrategy defines the strategy used to mitigate backpressure
+	// propagating to the kernel causing audited processes to block until
+	// Auditbeat can keep-up.
+	// One of "user-space", "kernel", "both", "none", "auto" (default)
+	BackpressureStrategy string `config:"backpressure_strategy"`
 }
 
 type auditRule struct {

--- a/auditbeat/module/auditd/config.go
+++ b/auditbeat/module/auditd/config.go
@@ -134,5 +134,5 @@ var defaultConfig = Config{
 	Warnings:               false,
 	ReassemblerMaxInFlight: 50,
 	ReassemblerTimeout:     2 * time.Second,
-	StreamBufferQueueSize:  64,
+	StreamBufferQueueSize:  8192,
 }

--- a/auditbeat/module/auditd/config.go
+++ b/auditbeat/module/auditd/config.go
@@ -37,7 +37,8 @@ type Config struct {
 	// propagating to the kernel causing audited processes to block until
 	// Auditbeat can keep-up.
 	// One of "user-space", "kernel", "both", "none", "auto" (default)
-	BackpressureStrategy string `config:"backpressure_strategy"`
+	BackpressureStrategy  string `config:"backpressure_strategy"`
+	StreamBufferConsumers int    `config:"stream_buffer_consumers"`
 }
 
 type auditRule struct {
@@ -135,4 +136,5 @@ var defaultConfig = Config{
 	ReassemblerMaxInFlight: 50,
 	ReassemblerTimeout:     2 * time.Second,
 	StreamBufferQueueSize:  8192,
+	StreamBufferConsumers:  0,
 }


### PR DESCRIPTION
This adds a new configuration option, "backpressure_strategy" to the auditd module in auditbeat. It allows setting different ways in which auditbeat can mitigate or avoid backpressure to propagate into the kernel and having an impact on audited processes.

The possible values are:
- `kernel`: Auditbeat will set the backlog_wait_time in the kernel's audit framework to 0. This causes events to be discarded in kernel if the audit backlog queue fills to capacity. Requires a 3.14 kernel or newer.
- `userspace`: Auditbeat will drop events when there is backpressure from the publishing pipeline.
- `both`: `kernel` and `userspace` strategies at the same time.
- `auto` (default): The `kernel` strategy will be used if supported. Otherwise will fall back to `userspace`.
- `none`: No backpressure mitigation measures will be enabled.

Closes #7157