### PR TITLE
Cherry-pick #7170 to 6.3: libbeat: Stop autodiscover runners in a goroutine

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -56,6 +56,7 @@ https://github.com/elastic/beats/compare/v6.0.0-beta2...master[Check the HEAD di
 - Ensure Kubernetes labels/annotations don't break mapping {pull}6490[6490]
 - Ensure that the dashboard zip files can't contain files outside of the kibana directory. {pull}6921[6921]
 - Fix map overwrite panics by cloning shared structs before doing the update. {pull}6947[6947]
+- Fix delays on autodiscovery events handling caused by blocking runner stops. {pull}7170[7170]
 
 *Auditbeat*
 

--- a/libbeat/autodiscover/autodiscover.go
+++ b/libbeat/autodiscover/autodiscover.go
@@ -174,8 +174,12 @@ func (a *Autodiscover) handleStop(event bus.Event) {
 		}
 
 		if runner := a.runners.Get(hash); runner != nil {
+			// Stop can block, we run it asyncrhonously to avoid blocking
+			// the whole events loop. The runner hash is removed in any case
+			// so an equivalent configuration can be added again while this
+			// one stops, and a duplicated event don't try to stop it twice.
 			logp.Info("Autodiscover stopping runner: %s", runner)
-			runner.Stop()
+			go runner.Stop()
 			a.runners.Remove(hash)
 		} else {
 			logp.Debug(debugK, "Runner not found for stopping: %s", hash)


### PR DESCRIPTION
Cherry-pick of PR #7170 to 6.3 branch. Original message: 

Stopping runners can be a blocking operation, what can block the
autodiscover event loop. Run it in a goroutine so events can continue
being handled.