### PR TITLE
Disable modules in the filebeat.reference.yml file

### DIFF
--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -83,10 +83,10 @@ filebeat.modules:
     #input:
 
 #---------------------------- elasticsearch Module ---------------------------
-- module: elasticsearch
+#- module: elasticsearch
   # Server log
-  server:
-    enabled: true
+  #server:
+    #enabled: true
 
     # Set custom paths for the log files. If left empty,
     # Filebeat will choose the paths depending on your OS.
@@ -157,10 +157,10 @@ filebeat.modules:
     #input:
 
 #-------------------------------- Kafka Module -------------------------------
-- module: kafka
+#- module: kafka
   # All logs
-  log:
-    enabled: true
+  #log:
+    #enabled: true
 
     # Set custom paths for Kafka. If left empty,
     # Filebeat will look under /opt.
@@ -172,10 +172,10 @@ filebeat.modules:
 
 
 #------------------------------- kibana Module -------------------------------
-- module: kibana
+#- module: kibana
   # All logs
-  log:
-    enabled: true
+  #log:
+    #enabled: true
 
     # Set custom paths for the log files. If left empty,
     # Filebeat will choose the paths depending on your OS.
@@ -265,9 +265,9 @@ filebeat.modules:
     #input:
 
 #------------------------------- Osquery Module ------------------------------
-- module: osquery
-  result:
-    enabled: true
+#- module: osquery
+  #result:
+    #enabled: true
 
     # Set custom paths for the log files. If left empty,
     # Filebeat will choose the paths depending on your OS.

--- a/filebeat/module/elasticsearch/_meta/config.reference.yml
+++ b/filebeat/module/elasticsearch/_meta/config.reference.yml
@@ -1,0 +1,8 @@
+#- module: elasticsearch
+  # Server log
+  #server:
+    #enabled: true
+
+    # Set custom paths for the log files. If left empty,
+    # Filebeat will choose the paths depending on your OS.
+    #var.paths:

--- a/filebeat/module/kafka/_meta/config.reference.yml
+++ b/filebeat/module/kafka/_meta/config.reference.yml
@@ -1,0 +1,13 @@
+#- module: kafka
+  # All logs
+  #log:
+    #enabled: true
+
+    # Set custom paths for Kafka. If left empty,
+    # Filebeat will look under /opt.
+    #var.kafka_home:
+
+    # Set custom paths for the log files. If left empty,
+    # Filebeat will choose the paths depending on your OS.
+    #var.paths:
+

--- a/filebeat/module/kibana/_meta/config.reference.yml
+++ b/filebeat/module/kibana/_meta/config.reference.yml
@@ -1,0 +1,8 @@
+#- module: kibana
+  # All logs
+  #log:
+    #enabled: true
+
+    # Set custom paths for the log files. If left empty,
+    # Filebeat will choose the paths depending on your OS.
+    #var.paths:

--- a/filebeat/module/osquery/_meta/config.reference.yml
+++ b/filebeat/module/osquery/_meta/config.reference.yml
@@ -1,6 +1,6 @@
-- module: osquery
-  result:
-    enabled: true
+#- module: osquery
+  #result:
+    #enabled: true
 
     # Set custom paths for the log files. If left empty,
     # Filebeat will choose the paths depending on your OS.


### PR DESCRIPTION
If you create a new module with only a `_meta/config.yml`, the content
of this file will be used for the filebeat reference, usually this file
is uncommented.

This means the following module: Kibana, Elasticsearch, osquery, and Kafka
were enabled by default. Since the Elasticsearch module requires a
configured paths, Filebeat was throwing an error.

I've created a specific commented config.reference.yml for each of the
module.

**Questions**

Should we make the generator create a default config.reference.yml?