### PR TITLE
Set foundation for testing against 6.0 builds

### DIFF
--- a/testing/environments/5.x.yml
+++ b/testing/environments/5.x.yml
@@ -1,10 +1,9 @@
-# This is the latest released environment.
+# This is the latest stable 5x release environment.
 
 version: '2.1'
 services:
   elasticsearch:
-    # TODO: For 6.3 remove "-platinum".
-    image: docker.elastic.co/elasticsearch/elasticsearch-platinum:6.2.4
+    image: docker.elastic.co/elasticsearch/elasticsearch:5.6.9
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9200"]
       retries: 300
@@ -17,7 +16,7 @@ services:
       - "xpack.security.enabled=false"
 
   logstash:
-    image: docker.elastic.co/logstash/logstash:6.2.4
+    image: docker.elastic.co/logstash/logstash:5.6.9
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9600/_node/stats"]
       retries: 300
@@ -27,7 +26,7 @@ services:
     - ./docker/logstash/pki:/etc/pki:ro
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:6.2.4
+    image: docker.elastic.co/kibana/kibana:5.6.9
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:5601"]
       retries: 300

--- a/testing/environments/6.0.yml
+++ b/testing/environments/6.0.yml
@@ -1,11 +1,13 @@
-# This is the latest stable 5x release environment.
+# This is the latest 6.0 environment.
 
 version: '2.1'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:5.6.9
+    image: docker.elastic.co/elasticsearch/elasticsearch-platinum:6.0.1
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9200"]
+      retries: 300
+      interval: 1s
     environment:
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
       - "network.host="
@@ -14,15 +16,19 @@ services:
       - "xpack.security.enabled=false"
 
   logstash:
-    image: docker.elastic.co/logstash/logstash:5.6.9
+    image: docker.elastic.co/logstash/logstash:6.0.1
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9600/_node/stats"]
+      retries: 300
+      interval: 1s
     volumes:
     - ./docker/logstash/pipeline:/usr/share/logstash/pipeline:ro
     - ./docker/logstash/pki:/etc/pki:ro
 
+
   kibana:
-    image: docker.elastic.co/kibana/kibana:5.6.9
+    image: docker.elastic.co/kibana/kibana:6.0.1
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:5601"]
-      retries: 6
+      retries: 300
+      interval: 1s


### PR DESCRIPTION
This adds the environment for testing against 6.0. I did a run on against this build and a few of the `load_integration_test.go` failed and some kafka tests (not sure if related). This PR does not fix these tests but provides the foundation to start testing against it.

To run tests against this environment, the tests have to be started as following:

```
TESTING_ENVIRONMENT=6.0 make testsuite
```

More changes:

* Rename 50.yml to 5.0.yml
* Add proper timeouts and intervals to the healthchecks