### PR TITLE
Unify handling of root and extracted key for dissect

### DIFF
--- a/libbeat/processors/dissect/processor.go
+++ b/libbeat/processors/dissect/processor.go
@@ -8,11 +8,8 @@ import (
 	"github.com/elastic/beats/libbeat/processors"
 )
 
-type mapperFunc func(e *beat.Event, m common.MapStr) (*beat.Event, error)
-
 type processor struct {
 	config config
-	mapper mapperFunc
 }
 
 func init() {
@@ -26,12 +23,6 @@ func newProcessor(c *common.Config) (processors.Processor, error) {
 		return nil, err
 	}
 	p := &processor{config: config}
-
-	if config.TargetPrefix == "" {
-		p.mapper = p.mapToRoot
-	} else {
-		p.mapper = p.mapToField
-	}
 
 	return p, nil
 }
@@ -61,30 +52,22 @@ func (p *processor) Run(event *beat.Event) (*beat.Event, error) {
 	return event, nil
 }
 
-func (p *processor) mapToRoot(event *beat.Event, m common.MapStr) (*beat.Event, error) {
+func (p *processor) mapper(event *beat.Event, m common.MapStr) (*beat.Event, error) {
 	copy := event.Fields.Clone()
 
+	prefix := ""
+	if p.config.TargetPrefix != "" {
+		prefix = p.config.TargetPrefix + "."
+	}
 	for k, v := range m {
 		if _, err := event.GetValue(k); err == common.ErrKeyNotFound {
-			event.PutValue(k, v)
+			event.PutValue(prefix+k, v)
 		} else {
 			event.Fields = copy
 			return event, fmt.Errorf("cannot override existing key: `%s`", k)
 		}
 	}
 
-	return event, nil
-}
-
-func (p *processor) mapToField(event *beat.Event, m common.MapStr) (*beat.Event, error) {
-	if _, err := event.GetValue(p.config.TargetPrefix); err != nil && err != common.ErrKeyNotFound {
-		return event, fmt.Errorf("cannot override existing key: `%s`", p.config.TargetPrefix)
-	}
-
-	_, err := event.PutValue(p.config.TargetPrefix, m)
-	if err != nil {
-		return event, err
-	}
 	return event, nil
 }
 

--- a/libbeat/processors/dissect/processor_test.go
+++ b/libbeat/processors/dissect/processor_test.go
@@ -49,14 +49,14 @@ func TestProcessor(t *testing.T) {
 			values: map[string]string{"new_target.key": "world"},
 		},
 		{
-			name: "set map under a root key",
+			name: "extract to already existing namespace not conflicting",
 			c: map[string]interface{}{
 				"tokenizer":     "hello %{key} %{key2}",
 				"target_prefix": "extracted",
 				"field":         "message",
 			},
-			fields: common.MapStr{"message": "hello world super", "extracted": "not hello"},
-			values: map[string]string{"extracted.key": "world", "extracted.key2": "super"},
+			fields: common.MapStr{"message": "hello world super", "extracted": common.MapStr{"not": "hello"}},
+			values: map[string]string{"extracted.key": "world", "extracted.key2": "super", "extracted.not": "hello"},
 		},
 	}
 
@@ -109,24 +109,47 @@ func TestFieldDoesntExist(t *testing.T) {
 }
 
 func TestFieldAlreadyExist(t *testing.T) {
-	t.Run("root prefix", func(t *testing.T) {
-		c, err := common.NewConfigFrom(map[string]interface{}{
-			"tokenizer":     "hello %{key}",
-			"target_prefix": "",
+	tests := []struct {
+		name      string
+		tokenizer string
+		prefix    string
+		fields    common.MapStr
+	}{
+		{
+			name:      "no prefix",
+			tokenizer: "hello %{key}",
+			prefix:    "",
+			fields:    common.MapStr{"message": "hello world", "key": "exists"},
+		},
+		{
+			name:      "with prefix",
+			tokenizer: "hello %{key}",
+			prefix:    "extracted",
+			fields:    common.MapStr{"message": "hello world", "extracted": "exists"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c, err := common.NewConfigFrom(map[string]interface{}{
+				"tokenizer":     test.tokenizer,
+				"target_prefix": test.prefix,
+			})
+
+			if !assert.NoError(t, err) {
+				return
+			}
+
+			processor, err := newProcessor(c)
+			if !assert.NoError(t, err) {
+				return
+			}
+
+			e := beat.Event{Fields: test.fields}
+			_, err = processor.Run(&e)
+			if !assert.Error(t, err) {
+				return
+			}
 		})
-		if !assert.NoError(t, err) {
-			return
-		}
-
-		processor, err := newProcessor(c)
-		if !assert.NoError(t, err) {
-			return
-		}
-
-		e := beat.Event{Fields: common.MapStr{"message": "hello world", "key": "exist"}}
-		_, err = processor.Run(&e)
-		if !assert.Error(t, err) {
-			return
-		}
-	})
+	}
 }

--- a/libbeat/processors/dissect/processor_test.go
+++ b/libbeat/processors/dissect/processor_test.go
@@ -127,6 +127,12 @@ func TestFieldAlreadyExist(t *testing.T) {
 			prefix:    "extracted",
 			fields:    common.MapStr{"message": "hello world", "extracted": "exists"},
 		},
+		{
+			name:      "with conflicting key in prefix",
+			tokenizer: "hello %{key}",
+			prefix:    "extracted",
+			fields:    common.MapStr{"message": "hello world", "extracted": common.MapStr{"key": "exists"}},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Previously for keys put under root the dots were expanded to objects but the ones with a target were not. This unifies the code that all keys are prefixed.