### PR TITLE
Make Kibana client reusable

### DIFF
--- a/filebeat/beater/filebeat.go
+++ b/filebeat/beater/filebeat.go
@@ -13,10 +13,10 @@ import (
 	"github.com/elastic/beats/libbeat/cfgfile"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/cfgwarn"
+	"github.com/elastic/beats/libbeat/kibana"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/monitoring"
 	"github.com/elastic/beats/libbeat/outputs/elasticsearch"
-	"github.com/elastic/beats/libbeat/setup/kibana"
 
 	fbautodiscover "github.com/elastic/beats/filebeat/autodiscover"
 	"github.com/elastic/beats/filebeat/channel"

--- a/filebeat/fileset/modules.go
+++ b/filebeat/fileset/modules.go
@@ -11,10 +11,10 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/kibana"
 	"github.com/elastic/beats/libbeat/logp"
 	mlimporter "github.com/elastic/beats/libbeat/ml-importer"
 	"github.com/elastic/beats/libbeat/paths"
-	"github.com/elastic/beats/libbeat/setup/kibana"
 )
 
 var availableMLModules = map[string]string{

--- a/libbeat/dashboards/kibana_loader.go
+++ b/libbeat/dashboards/kibana_loader.go
@@ -9,8 +9,8 @@ import (
 	"time"
 
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/kibana"
 	"github.com/elastic/beats/libbeat/logp"
-	"github.com/elastic/beats/libbeat/setup/kibana"
 )
 
 var importAPI = "/api/kibana/dashboards/import"

--- a/libbeat/kibana/client_config.go
+++ b/libbeat/kibana/client_config.go
@@ -6,7 +6,8 @@ import (
 	"github.com/elastic/beats/libbeat/common/transport/tlscommon"
 )
 
-type kibanaConfig struct {
+// ClientConfig to connect to Kibana
+type ClientConfig struct {
 	Protocol string            `config:"protocol"`
 	Host     string            `config:"host"`
 	Path     string            `config:"path"`
@@ -17,7 +18,7 @@ type kibanaConfig struct {
 }
 
 var (
-	defaultKibanaConfig = kibanaConfig{
+	defaultClientConfig = ClientConfig{
 		Protocol: "http",
 		Host:     "localhost:5601",
 		Path:     "",

--- a/libbeat/kibana/client_test.go
+++ b/libbeat/kibana/client_test.go
@@ -20,7 +20,7 @@ func TestErrorJson(t *testing.T) {
 		URL:  kibanaTs.URL,
 		http: http.DefaultClient,
 	}
-	code, _, err := conn.Request(http.MethodPost, "", url.Values{}, nil)
+	code, _, err := conn.Request(http.MethodPost, "", url.Values{}, nil, nil)
 	assert.Equal(t, http.StatusOK, code)
 	assert.Error(t, err)
 }
@@ -35,7 +35,7 @@ func TestErrorBadJson(t *testing.T) {
 		URL:  kibanaTs.URL,
 		http: http.DefaultClient,
 	}
-	code, _, err := conn.Request(http.MethodPost, "", url.Values{}, nil)
+	code, _, err := conn.Request(http.MethodPost, "", url.Values{}, nil, nil)
 	assert.Equal(t, http.StatusOK, code)
 	assert.Error(t, err)
 }
@@ -43,6 +43,9 @@ func TestErrorBadJson(t *testing.T) {
 func TestSuccess(t *testing.T) {
 	kibanaTs := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(`{"objects":[{"id":"test-*","type":"index-pattern","updated_at":"2018-01-24T19:04:13.371Z","version":1}]}`))
+
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		assert.Equal(t, "bar", r.Header.Get("foo"))
 	}))
 	defer kibanaTs.Close()
 
@@ -50,7 +53,7 @@ func TestSuccess(t *testing.T) {
 		URL:  kibanaTs.URL,
 		http: http.DefaultClient,
 	}
-	code, _, err := conn.Request(http.MethodPost, "", url.Values{}, nil)
+	code, _, err := conn.Request(http.MethodPost, "", url.Values{}, http.Header{"foo": []string{"bar"}}, nil)
 	assert.Equal(t, http.StatusOK, code)
 	assert.NoError(t, err)
 }

--- a/libbeat/ml-importer/importer.go
+++ b/libbeat/ml-importer/importer.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net/http"
 	"net/url"
 	"strings"
 
@@ -43,7 +44,7 @@ type MLLoader interface {
 
 // MLSetupper is a subset of the Kibana client API capable of setting up ML objects.
 type MLSetupper interface {
-	Request(method, path string, params url.Values, body io.Reader) (int, []byte, error)
+	Request(method, path string, params url.Values, headers http.Header, body io.Reader) (int, []byte, error)
 	GetVersion() string
 }
 
@@ -188,7 +189,7 @@ func HaveXpackML(esClient MLLoader) (bool, error) {
 func SetupModule(kibanaClient MLSetupper, module, prefix string) error {
 	setupURL := fmt.Sprintf(kibanaSetupModuleURL, module)
 	prefixPayload := fmt.Sprintf("{\"prefix\": \"%s\"}", prefix)
-	status, response, err := kibanaClient.Request("POST", setupURL, nil, strings.NewReader(prefixPayload))
+	status, response, err := kibanaClient.Request("POST", setupURL, nil, nil, strings.NewReader(prefixPayload))
 	if status != 200 {
 		return errors.Errorf("cannot set up ML with prefix: %s", prefix)
 	}


### PR DESCRIPTION
This change moves Kibana client to a common place in libbeat, it also makes client config public and adds support for headers passing.