### PR TITLE
Move crawler to the new input package instead of prospector

### DIFF
--- a/filebeat/crawler/crawler.go
+++ b/filebeat/crawler/crawler.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/elastic/beats/filebeat/channel"
 	"github.com/elastic/beats/filebeat/fileset"
+	"github.com/elastic/beats/filebeat/input"
 	"github.com/elastic/beats/filebeat/input/file"
-	input "github.com/elastic/beats/filebeat/prospector"
 	"github.com/elastic/beats/filebeat/registrar"
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/cfgfile"


### PR DESCRIPTION
This file was missed when doing the prospector to input refactor,
nothing was harmed because of type aliasing.