### PR TITLE
Extract Kibana dashboards

### DIFF
--- a/libbeat/scripts/unpack_dashboards.py
+++ b/libbeat/scripts/unpack_dashboards.py
@@ -19,7 +19,9 @@ def transform_data(data, method):
             obj["attributes"]["visState"] = method(obj["attributes"]["visState"])
 
         if "kibanaSavedObjectMeta" in obj["attributes"] and "searchSourceJSON" in obj["attributes"]["kibanaSavedObjectMeta"]:
-            obj["attributes"]["kibanaSavedObjectMeta"]["searchSourceJSON"] = method(obj["attributes"]["kibanaSavedObjectMeta"]["searchSourceJSON"])
+            obj["attributes"]["kibanaSavedObjectMeta"]["searchSourceJSON"] = method(
+                obj["attributes"]["kibanaSavedObjectMeta"]["searchSourceJSON"])
+
 
 def transform_file(path, method):
     with open(path) as f:
@@ -27,6 +29,7 @@ def transform_file(path, method):
 
     transform_data(data, method)
     return data
+
 
 if __name__ == "__main__":
 

--- a/libbeat/scripts/unpack_dashboards.py
+++ b/libbeat/scripts/unpack_dashboards.py
@@ -1,0 +1,50 @@
+import json
+import sys
+import glob
+import argparse
+
+
+def transform_data(data, method):
+    for obj in data["objects"]:
+        if "uiStateJSON" in obj["attributes"]:
+            obj["attributes"]["uiStateJSON"] = method(obj["attributes"]["uiStateJSON"])
+
+        if "optionsJSON" in obj["attributes"]:
+            obj["attributes"]["optionsJSON"] = method(obj["attributes"]["optionsJSON"])
+
+        if "panelsJSON" in obj["attributes"]:
+            obj["attributes"]["panelsJSON"] = method(obj["attributes"]["panelsJSON"])
+
+        if "visState" in obj["attributes"]:
+            obj["attributes"]["visState"] = method(obj["attributes"]["visState"])
+
+        if "kibanaSavedObjectMeta" in obj["attributes"] and "searchSourceJSON" in obj["attributes"]["kibanaSavedObjectMeta"]:
+            obj["attributes"]["kibanaSavedObjectMeta"]["searchSourceJSON"] = method(obj["attributes"]["kibanaSavedObjectMeta"]["searchSourceJSON"])
+
+def transform_file(path, method):
+    with open(path) as f:
+        data = json.load(f)
+
+    transform_data(data, method)
+    return data
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(description="Convert dashboards")
+    parser.add_argument("--transform", help="Decode or encode", default="encode")
+    parser.add_argument("--glob", help="Glob pattern")
+
+    args = parser.parse_args()
+
+    paths = glob.glob(args.glob)
+
+    method = json.dumps
+    if args.transform == "decode":
+        method = json.loads
+
+    for path in paths:
+        data = transform_file(path, method)
+        new_data = json.dumps(data, sort_keys=True, indent=4)
+
+        with open(path, 'w') as f:
+            f.write(new_data)

--- a/metricbeat/Makefile
+++ b/metricbeat/Makefile
@@ -21,6 +21,9 @@ kibana:
 	@rm -rf _meta/kibana
 	@mkdir -p _meta/kibana
 	@-cp -r module/*/_meta/kibana _meta/
+	@-cp -r module/*/_meta/kibana _meta/
+	# Convert all dashboards to string
+	python ../libbeat/scripts/unpack_dashboards.py --glob="./_meta/kibana/6/dashboard/*.json"
 
 # Collects all module docs
 .PHONY: collect-docs

--- a/metricbeat/Makefile
+++ b/metricbeat/Makefile
@@ -22,8 +22,8 @@ kibana:
 	@mkdir -p _meta/kibana
 	@-cp -r module/*/_meta/kibana _meta/
 	@-cp -r module/*/_meta/kibana _meta/
-	# Convert all dashboards to string
-	python ../libbeat/scripts/unpack_dashboards.py --glob="./_meta/kibana/6/dashboard/*.json"
+	@# Convert all dashboards to string
+	@python ${ES_BEATS}/libbeat/scripts/unpack_dashboards.py --glob="./_meta/kibana/6/dashboard/*.json"
 
 # Collects all module docs
 .PHONY: collect-docs

--- a/metricbeat/module/apache/_meta/kibana/6/dashboard/Metricbeat-apache-overview.json
+++ b/metricbeat/module/apache/_meta/kibana/6/dashboard/Metricbeat-apache-overview.json
@@ -1,156 +1,781 @@
 {
-  "objects": [
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\n  \"filter\": []\n}"
-        },
-        "savedSearchId": "Apache-HTTPD",
-        "title": "CPU usage [Metricbeat Apache]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\n  \"title\": \"Apache HTTPD - CPU\",\n  \"type\": \"line\",\n  \"params\": {\n    \"shareYAxis\": true,\n    \"addTooltip\": true,\n    \"addLegend\": true,\n    \"showCircles\": true,\n    \"smoothLines\": false,\n    \"interpolate\": \"linear\",\n    \"scale\": \"linear\",\n    \"drawLinesBetweenPoints\": true,\n    \"radiusRatio\": 9,\n    \"times\": [],\n    \"addTimeMarker\": false,\n    \"defaultYExtents\": false,\n    \"setYExtents\": false,\n    \"yAxis\": {}\n  },\n  \"aggs\": [\n    {\n      \"id\": \"1\",\n      \"type\": \"avg\",\n      \"schema\": \"metric\",\n      \"params\": {\n        \"field\": \"apache.status.cpu.load\",\n        \"customLabel\": \"CPU load\"\n      }\n    },\n    {\n      \"id\": \"2\",\n      \"type\": \"date_histogram\",\n      \"schema\": \"segment\",\n      \"params\": {\n        \"field\": \"@timestamp\",\n        \"interval\": \"auto\",\n        \"customInterval\": \"2h\",\n        \"min_doc_count\": 1,\n        \"extended_bounds\": {}\n      }\n    },\n    {\n      \"id\": \"3\",\n      \"type\": \"terms\",\n      \"schema\": \"split\",\n      \"params\": {\n        \"field\": \"apache.status.hostname\",\n        \"size\": 5,\n        \"order\": \"desc\",\n        \"orderBy\": \"1\",\n        \"row\": true\n      }\n    },\n    {\n      \"id\": \"4\",\n      \"type\": \"avg\",\n      \"schema\": \"metric\",\n      \"params\": {\n        \"field\": \"apache.status.cpu.user\",\n        \"customLabel\": \"CPU user\"\n      }\n    },\n    {\n      \"id\": \"5\",\n      \"type\": \"avg\",\n      \"schema\": \"metric\",\n      \"params\": {\n        \"field\": \"apache.status.cpu.system\",\n        \"customLabel\": \"CPU system\"\n      }\n    },\n    {\n      \"id\": \"6\",\n      \"type\": \"avg\",\n      \"schema\": \"metric\",\n      \"params\": {\n        \"field\": \"apache.status.cpu.children_user\",\n        \"customLabel\": \"CPU children user\"\n      }\n    },\n    {\n      \"id\": \"7\",\n      \"type\": \"avg\",\n      \"schema\": \"metric\",\n      \"params\": {\n        \"field\": \"apache.status.cpu.children_system\",\n        \"customLabel\": \"CPU children system\"\n      }\n    }\n  ],\n  \"listeners\": {}\n}"
-      },
-      "id": "Apache-HTTPD-CPU",
-      "type": "visualization",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\n  \"filter\": []\n}"
-        },
-        "savedSearchId": "Apache-HTTPD",
-        "title": "Hostname list [Metricbeat Apache]",
-        "uiStateJSON": "{\n  \"vis\": {\n    \"params\": {\n      \"sort\": {\n        \"columnIndex\": null,\n        \"direction\": null\n      }\n    }\n  }\n}",
-        "version": 1,
-        "visState": "{\n  \"title\": \"Apache HTTPD - Hostname list\",\n  \"type\": \"table\",\n  \"params\": {\n    \"perPage\": 10,\n    \"showPartialRows\": false,\n    \"showMeticsAtAllLevels\": false,\n    \"sort\": {\n      \"columnIndex\": null,\n      \"direction\": null\n    }\n  },\n  \"aggs\": [\n    {\n      \"id\": \"1\",\n      \"type\": \"count\",\n      \"schema\": \"metric\",\n      \"params\": {\n        \"customLabel\": \"Events count\"\n      }\n    },\n    {\n      \"id\": \"2\",\n      \"type\": \"terms\",\n      \"schema\": \"bucket\",\n      \"params\": {\n        \"field\": \"apache.status.hostname\",\n        \"size\": 5,\n        \"order\": \"desc\",\n        \"orderBy\": \"1\",\n        \"customLabel\": \"Apache HTTD Hostname\"\n      }\n    }\n  ],\n  \"listeners\": {}\n}"
-      },
-      "id": "Apache-HTTPD-Hostname-list",
-      "type": "visualization",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\n  \"filter\": []\n}"
-        },
-        "savedSearchId": "Apache-HTTPD",
-        "title": "Load1/5/15 [Metricbeat Apache]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\n  \"title\": \"Apache HTTPD - Load1/5/15\",\n  \"type\": \"line\",\n  \"params\": {\n    \"shareYAxis\": true,\n    \"addTooltip\": true,\n    \"addLegend\": true,\n    \"showCircles\": true,\n    \"smoothLines\": false,\n    \"interpolate\": \"linear\",\n    \"scale\": \"linear\",\n    \"drawLinesBetweenPoints\": true,\n    \"radiusRatio\": 9,\n    \"times\": [],\n    \"addTimeMarker\": false,\n    \"defaultYExtents\": false,\n    \"setYExtents\": false,\n    \"yAxis\": {}\n  },\n  \"aggs\": [\n    {\n      \"id\": \"1\",\n      \"type\": \"avg\",\n      \"schema\": \"metric\",\n      \"params\": {\n        \"field\": \"apache.status.load.5\",\n        \"customLabel\": \"Load 5\"\n      }\n    },\n    {\n      \"id\": \"2\",\n      \"type\": \"date_histogram\",\n      \"schema\": \"segment\",\n      \"params\": {\n        \"field\": \"@timestamp\",\n        \"interval\": \"auto\",\n        \"customInterval\": \"2h\",\n        \"min_doc_count\": 1,\n        \"extended_bounds\": {}\n      }\n    },\n    {\n      \"id\": \"3\",\n      \"type\": \"avg\",\n      \"schema\": \"metric\",\n      \"params\": {\n        \"field\": \"apache.status.load.1\",\n        \"customLabel\": \"Load 1\"\n      }\n    },\n    {\n      \"id\": \"4\",\n      \"type\": \"avg\",\n      \"schema\": \"metric\",\n      \"params\": {\n        \"field\": \"apache.status.load.15\",\n        \"customLabel\": \"Load 15\"\n      }\n    },\n    {\n      \"id\": \"5\",\n      \"type\": \"terms\",\n      \"schema\": \"split\",\n      \"params\": {\n        \"field\": \"apache.status.hostname\",\n        \"size\": 5,\n        \"order\": \"desc\",\n        \"orderBy\": \"1\",\n        \"customLabel\": \"Hostname\",\n        \"row\": true\n      }\n    }\n  ],\n  \"listeners\": {}\n}"
-      },
-      "id": "Apache-HTTPD-Load1-slash-5-slash-15",
-      "type": "visualization",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\n  \"filter\": []\n}"
-        },
-        "savedSearchId": "Apache-HTTPD",
-        "title": "Scoreboard [Metricbeat Apache]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\n  \"title\": \"Apache HTTPD - Scoreboard\",\n  \"type\": \"line\",\n  \"params\": {\n    \"shareYAxis\": true,\n    \"addTooltip\": true,\n    \"addLegend\": true,\n    \"showCircles\": true,\n    \"smoothLines\": false,\n    \"interpolate\": \"linear\",\n    \"scale\": \"linear\",\n    \"drawLinesBetweenPoints\": true,\n    \"radiusRatio\": 9,\n    \"times\": [],\n    \"addTimeMarker\": false,\n    \"defaultYExtents\": false,\n    \"setYExtents\": false,\n    \"yAxis\": {}\n  },\n  \"aggs\": [\n    {\n      \"id\": \"1\",\n      \"type\": \"avg\",\n      \"schema\": \"metric\",\n      \"params\": {\n        \"field\": \"apache.status.scoreboard.closing_connection\",\n        \"customLabel\": \"Closing connection\"\n      }\n    },\n    {\n      \"id\": \"2\",\n      \"type\": \"date_histogram\",\n      \"schema\": \"segment\",\n      \"params\": {\n        \"field\": \"@timestamp\",\n        \"interval\": \"auto\",\n        \"customInterval\": \"2h\",\n        \"min_doc_count\": 1,\n        \"extended_bounds\": {}\n      }\n    },\n    {\n      \"id\": \"3\",\n      \"type\": \"terms\",\n      \"schema\": \"split\",\n      \"params\": {\n        \"field\": \"apache.status.hostname\",\n        \"size\": 5,\n        \"order\": \"desc\",\n        \"orderBy\": \"1\",\n        \"customLabel\": \"Hostname\",\n        \"row\": true\n      }\n    },\n    {\n      \"id\": \"4\",\n      \"type\": \"avg\",\n      \"schema\": \"metric\",\n      \"params\": {\n        \"field\": \"apache.status.scoreboard.dns_lookup\",\n        \"customLabel\": \"DNS lookup\"\n      }\n    },\n    {\n      \"id\": \"5\",\n      \"type\": \"avg\",\n      \"schema\": \"metric\",\n      \"params\": {\n        \"field\": \"apache.status.scoreboard.gracefully_finishing\",\n        \"customLabel\": \"Gracefully finishing\"\n      }\n    },\n    {\n      \"id\": \"6\",\n      \"type\": \"avg\",\n      \"schema\": \"metric\",\n      \"params\": {\n        \"field\": \"apache.status.scoreboard.idle_cleanup\",\n        \"customLabel\": \"Idle cleanup\"\n      }\n    },\n    {\n      \"id\": \"7\",\n      \"type\": \"avg\",\n      \"schema\": \"metric\",\n      \"params\": {\n        \"field\": \"apache.status.scoreboard.keepalive\",\n        \"customLabel\": \"Keepalive\"\n      }\n    },\n    {\n      \"id\": \"8\",\n      \"type\": \"avg\",\n      \"schema\": \"metric\",\n      \"params\": {\n        \"field\": \"apache.status.scoreboard.logging\",\n        \"customLabel\": \"Logging\"\n      }\n    },\n    {\n      \"id\": \"9\",\n      \"type\": \"avg\",\n      \"schema\": \"metric\",\n      \"params\": {\n        \"field\": \"apache.status.scoreboard.open_slot\",\n        \"customLabel\": \"Open slot\"\n      }\n    },\n    {\n      \"id\": \"10\",\n      \"type\": \"avg\",\n      \"schema\": \"metric\",\n      \"params\": {\n        \"field\": \"apache.status.scoreboard.reading_request\",\n        \"customLabel\": \"Reading request\"\n      }\n    },\n    {\n      \"id\": \"11\",\n      \"type\": \"avg\",\n      \"schema\": \"metric\",\n      \"params\": {\n        \"field\": \"apache.status.scoreboard.sending_reply\",\n        \"customLabel\": \"Sending reply\"\n      }\n    },\n    {\n      \"id\": \"12\",\n      \"type\": \"avg\",\n      \"schema\": \"metric\",\n      \"params\": {\n        \"field\": \"apache.status.scoreboard.starting_up\",\n        \"customLabel\": \"Starting up\"\n      }\n    },\n    {\n      \"id\": \"13\",\n      \"type\": \"avg\",\n      \"schema\": \"metric\",\n      \"params\": {\n        \"field\": \"apache.status.scoreboard.total\",\n        \"customLabel\": \"Total\"\n      }\n    },\n    {\n      \"id\": \"14\",\n      \"type\": \"avg\",\n      \"schema\": \"metric\",\n      \"params\": {\n        \"field\": \"apache.status.scoreboard.waiting_for_connection\",\n        \"customLabel\": \"Waiting for connection\"\n      }\n    }\n  ],\n  \"listeners\": {}\n}"
-      },
-      "id": "Apache-HTTPD-Scoreboard",
-      "type": "visualization",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\n  \"filter\": []\n}"
-        },
-        "savedSearchId": "Apache-HTTPD",
-        "title": "Total accesses and kbytes [Metricbeat Apache]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\n  \"title\": \"Apache HTTPD - Total accesses and kbytes\",\n  \"type\": \"metric\",\n  \"params\": {\n    \"handleNoResults\": true,\n    \"fontSize\": 60\n  },\n  \"aggs\": [\n    {\n      \"id\": \"1\",\n      \"type\": \"max\",\n      \"schema\": \"metric\",\n      \"params\": {\n        \"field\": \"apache.status.total_kbytes\",\n        \"customLabel\": \"Total kbytes\"\n      }\n    },\n    {\n      \"id\": \"2\",\n      \"type\": \"max\",\n      \"schema\": \"metric\",\n      \"params\": {\n        \"field\": \"apache.status.total_accesses\",\n        \"customLabel\": \"Total accesses\"\n      }\n    }\n  ],\n  \"listeners\": {}\n}"
-      },
-      "id": "Apache-HTTPD-Total-accesses-and-kbytes",
-      "type": "visualization",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\n  \"filter\": []\n}"
-        },
-        "savedSearchId": "Apache-HTTPD",
-        "title": "Uptime [Metricbeat Apache]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\n  \"title\": \"Apache HTTPD - Uptime\",\n  \"type\": \"metric\",\n  \"params\": {\n    \"handleNoResults\": true,\n    \"fontSize\": 60\n  },\n  \"aggs\": [\n    {\n      \"id\": \"1\",\n      \"type\": \"max\",\n      \"schema\": \"metric\",\n      \"params\": {\n        \"field\": \"apache.status.uptime.uptime\",\n        \"customLabel\": \"Uptime\"\n      }\n    },\n    {\n      \"id\": \"2\",\n      \"type\": \"max\",\n      \"schema\": \"metric\",\n      \"params\": {\n        \"field\": \"apache.status.uptime.server_uptime\",\n        \"customLabel\": \"Server uptime\"\n      }\n    }\n  ],\n  \"listeners\": {}\n}"
-      },
-      "id": "Apache-HTTPD-Uptime",
-      "type": "visualization",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\n  \"filter\": []\n}"
-        },
-        "savedSearchId": "Apache-HTTPD",
-        "title": "Workers [Metricbeat Apache]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\n  \"title\": \"Apache HTTPD - Workers\",\n  \"type\": \"line\",\n  \"params\": {\n    \"shareYAxis\": true,\n    \"addTooltip\": true,\n    \"addLegend\": true,\n    \"showCircles\": true,\n    \"smoothLines\": false,\n    \"interpolate\": \"linear\",\n    \"scale\": \"linear\",\n    \"drawLinesBetweenPoints\": true,\n    \"radiusRatio\": 9,\n    \"times\": [],\n    \"addTimeMarker\": false,\n    \"defaultYExtents\": false,\n    \"setYExtents\": false,\n    \"yAxis\": {}\n  },\n  \"aggs\": [\n    {\n      \"id\": \"1\",\n      \"type\": \"avg\",\n      \"schema\": \"metric\",\n      \"params\": {\n        \"field\": \"apache.status.workers.busy\",\n        \"customLabel\": \"Busy workers\"\n      }\n    },\n    {\n      \"id\": \"2\",\n      \"type\": \"date_histogram\",\n      \"schema\": \"segment\",\n      \"params\": {\n        \"field\": \"@timestamp\",\n        \"interval\": \"auto\",\n        \"customInterval\": \"2h\",\n        \"min_doc_count\": 1,\n        \"extended_bounds\": {}\n      }\n    },\n    {\n      \"id\": \"3\",\n      \"type\": \"terms\",\n      \"schema\": \"split\",\n      \"params\": {\n        \"field\": \"apache.status.hostname\",\n        \"size\": 5,\n        \"order\": \"desc\",\n        \"orderBy\": \"1\",\n        \"customLabel\": \"Hostname\",\n        \"row\": true\n      }\n    },\n    {\n      \"id\": \"4\",\n      \"type\": \"avg\",\n      \"schema\": \"metric\",\n      \"params\": {\n        \"field\": \"apache.status.workers.idle\",\n        \"customLabel\": \"Idle workers\"\n      }\n    }\n  ],\n  \"listeners\": {}\n}"
-      },
-      "id": "Apache-HTTPD-Workers",
-      "type": "visualization",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "columns": [
-          "_source"
-        ],
-        "description": "",
-        "hits": 0,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"index\":\"metricbeat-*\",\"query\":{\"query_string\":{\"query\":\"metricset.module: apache\",\"analyze_wildcard\":true}},\"filter\":[],\"highlight\":{\"pre_tags\":[\"@kibana-highlighted-field@\"],\"post_tags\":[\"@/kibana-highlighted-field@\"],\"fields\":{\"*\":{}},\"require_field_match\":false,\"fragment_size\":2147483647}}"
-        },
-        "sort": [
-          "@timestamp",
-          "desc"
-        ],
-        "title": "Apache HTTPD",
-        "version": 1
-      },
-      "id": "Apache-HTTPD",
-      "type": "search",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "hits": 0,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[],\"query\":{\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}},\"language\":\"lucene\"},\"highlightAll\":true,\"version\":true}"
-        },
-        "optionsJSON": "{\"darkTheme\":false}",
-        "panelsJSON": "[{\"id\":\"Apache-HTTPD-CPU\",\"type\":\"visualization\",\"panelIndex\":1,\"size_x\":6,\"size_y\":3,\"col\":7,\"row\":10},{\"id\":\"Apache-HTTPD-Hostname-list\",\"type\":\"visualization\",\"panelIndex\":2,\"size_x\":3,\"size_y\":3,\"col\":1,\"row\":1},{\"id\":\"Apache-HTTPD-Load1-slash-5-slash-15\",\"type\":\"visualization\",\"panelIndex\":3,\"size_x\":6,\"size_y\":3,\"col\":1,\"row\":10},{\"id\":\"Apache-HTTPD-Scoreboard\",\"type\":\"visualization\",\"panelIndex\":4,\"size_x\":12,\"size_y\":3,\"col\":1,\"row\":7},{\"id\":\"Apache-HTTPD-Total-accesses-and-kbytes\",\"type\":\"visualization\",\"panelIndex\":5,\"size_x\":6,\"size_y\":3,\"col\":7,\"row\":1},{\"id\":\"Apache-HTTPD-Uptime\",\"type\":\"visualization\",\"panelIndex\":6,\"size_x\":3,\"size_y\":3,\"col\":4,\"row\":1},{\"id\":\"Apache-HTTPD-Workers\",\"type\":\"visualization\",\"panelIndex\":7,\"size_x\":12,\"size_y\":3,\"col\":1,\"row\":4}]",
-        "timeRestore": false,
-        "title": "[Metricbeat Apache] Overview",
-        "uiStateJSON": "{\"P-2\":{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":null,\"direction\":null}}}},\"P-6\":{\"vis\":{\"defaultColors\":{\"0 - 100\":\"rgb(0,104,55)\"}}},\"P-5\":{\"vis\":{\"defaultColors\":{\"0 - 100\":\"rgb(0,104,55)\"}}}}",
-        "version": 1
-      },
-      "id": "Metricbeat-Apache-HTTPD-server-status",
-      "type": "dashboard",
-      "version": 3
-    }
-  ],
-  "version": "6.0.0-beta1-SNAPSHOT"
+    "objects": [
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Apache-HTTPD", 
+                "title": "CPU usage [Metricbeat Apache]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "CPU load", 
+                                "field": "apache.status.cpu.load"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "id": "3", 
+                            "params": {
+                                "field": "apache.status.hostname", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "row": true, 
+                                "size": 5
+                            }, 
+                            "schema": "split", 
+                            "type": "terms"
+                        }, 
+                        {
+                            "id": "4", 
+                            "params": {
+                                "customLabel": "CPU user", 
+                                "field": "apache.status.cpu.user"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "id": "5", 
+                            "params": {
+                                "customLabel": "CPU system", 
+                                "field": "apache.status.cpu.system"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "id": "6", 
+                            "params": {
+                                "customLabel": "CPU children user", 
+                                "field": "apache.status.cpu.children_user"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "id": "7", 
+                            "params": {
+                                "customLabel": "CPU children system", 
+                                "field": "apache.status.cpu.children_system"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "defaultYExtents": false, 
+                        "drawLinesBetweenPoints": true, 
+                        "interpolate": "linear", 
+                        "radiusRatio": 9, 
+                        "scale": "linear", 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "showCircles": true, 
+                        "smoothLines": false, 
+                        "times": [], 
+                        "yAxis": {}
+                    }, 
+                    "title": "Apache HTTPD - CPU", 
+                    "type": "line"
+                }
+            }, 
+            "id": "Apache-HTTPD-CPU", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Apache-HTTPD", 
+                "title": "Hostname list [Metricbeat Apache]", 
+                "uiStateJSON": {
+                    "vis": {
+                        "params": {
+                            "sort": {
+                                "columnIndex": null, 
+                                "direction": null
+                            }
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Events count"
+                            }, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "id": "2", 
+                            "params": {
+                                "customLabel": "Apache HTTD Hostname", 
+                                "field": "apache.status.hostname", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "bucket", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "perPage": 10, 
+                        "showMeticsAtAllLevels": false, 
+                        "showPartialRows": false, 
+                        "sort": {
+                            "columnIndex": null, 
+                            "direction": null
+                        }
+                    }, 
+                    "title": "Apache HTTPD - Hostname list", 
+                    "type": "table"
+                }
+            }, 
+            "id": "Apache-HTTPD-Hostname-list", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Apache-HTTPD", 
+                "title": "Load1/5/15 [Metricbeat Apache]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Load 5", 
+                                "field": "apache.status.load.5"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "id": "3", 
+                            "params": {
+                                "customLabel": "Load 1", 
+                                "field": "apache.status.load.1"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "id": "4", 
+                            "params": {
+                                "customLabel": "Load 15", 
+                                "field": "apache.status.load.15"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "id": "5", 
+                            "params": {
+                                "customLabel": "Hostname", 
+                                "field": "apache.status.hostname", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "row": true, 
+                                "size": 5
+                            }, 
+                            "schema": "split", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "defaultYExtents": false, 
+                        "drawLinesBetweenPoints": true, 
+                        "interpolate": "linear", 
+                        "radiusRatio": 9, 
+                        "scale": "linear", 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "showCircles": true, 
+                        "smoothLines": false, 
+                        "times": [], 
+                        "yAxis": {}
+                    }, 
+                    "title": "Apache HTTPD - Load1/5/15", 
+                    "type": "line"
+                }
+            }, 
+            "id": "Apache-HTTPD-Load1-slash-5-slash-15", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Apache-HTTPD", 
+                "title": "Scoreboard [Metricbeat Apache]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Closing connection", 
+                                "field": "apache.status.scoreboard.closing_connection"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "id": "3", 
+                            "params": {
+                                "customLabel": "Hostname", 
+                                "field": "apache.status.hostname", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "row": true, 
+                                "size": 5
+                            }, 
+                            "schema": "split", 
+                            "type": "terms"
+                        }, 
+                        {
+                            "id": "4", 
+                            "params": {
+                                "customLabel": "DNS lookup", 
+                                "field": "apache.status.scoreboard.dns_lookup"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "id": "5", 
+                            "params": {
+                                "customLabel": "Gracefully finishing", 
+                                "field": "apache.status.scoreboard.gracefully_finishing"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "id": "6", 
+                            "params": {
+                                "customLabel": "Idle cleanup", 
+                                "field": "apache.status.scoreboard.idle_cleanup"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "id": "7", 
+                            "params": {
+                                "customLabel": "Keepalive", 
+                                "field": "apache.status.scoreboard.keepalive"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "id": "8", 
+                            "params": {
+                                "customLabel": "Logging", 
+                                "field": "apache.status.scoreboard.logging"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "id": "9", 
+                            "params": {
+                                "customLabel": "Open slot", 
+                                "field": "apache.status.scoreboard.open_slot"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "id": "10", 
+                            "params": {
+                                "customLabel": "Reading request", 
+                                "field": "apache.status.scoreboard.reading_request"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "id": "11", 
+                            "params": {
+                                "customLabel": "Sending reply", 
+                                "field": "apache.status.scoreboard.sending_reply"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "id": "12", 
+                            "params": {
+                                "customLabel": "Starting up", 
+                                "field": "apache.status.scoreboard.starting_up"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "id": "13", 
+                            "params": {
+                                "customLabel": "Total", 
+                                "field": "apache.status.scoreboard.total"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "id": "14", 
+                            "params": {
+                                "customLabel": "Waiting for connection", 
+                                "field": "apache.status.scoreboard.waiting_for_connection"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "defaultYExtents": false, 
+                        "drawLinesBetweenPoints": true, 
+                        "interpolate": "linear", 
+                        "radiusRatio": 9, 
+                        "scale": "linear", 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "showCircles": true, 
+                        "smoothLines": false, 
+                        "times": [], 
+                        "yAxis": {}
+                    }, 
+                    "title": "Apache HTTPD - Scoreboard", 
+                    "type": "line"
+                }
+            }, 
+            "id": "Apache-HTTPD-Scoreboard", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Apache-HTTPD", 
+                "title": "Total accesses and kbytes [Metricbeat Apache]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Total kbytes", 
+                                "field": "apache.status.total_kbytes"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }, 
+                        {
+                            "id": "2", 
+                            "params": {
+                                "customLabel": "Total accesses", 
+                                "field": "apache.status.total_accesses"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "fontSize": 60, 
+                        "handleNoResults": true
+                    }, 
+                    "title": "Apache HTTPD - Total accesses and kbytes", 
+                    "type": "metric"
+                }
+            }, 
+            "id": "Apache-HTTPD-Total-accesses-and-kbytes", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Apache-HTTPD", 
+                "title": "Uptime [Metricbeat Apache]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Uptime", 
+                                "field": "apache.status.uptime.uptime"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }, 
+                        {
+                            "id": "2", 
+                            "params": {
+                                "customLabel": "Server uptime", 
+                                "field": "apache.status.uptime.server_uptime"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "fontSize": 60, 
+                        "handleNoResults": true
+                    }, 
+                    "title": "Apache HTTPD - Uptime", 
+                    "type": "metric"
+                }
+            }, 
+            "id": "Apache-HTTPD-Uptime", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Apache-HTTPD", 
+                "title": "Workers [Metricbeat Apache]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Busy workers", 
+                                "field": "apache.status.workers.busy"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "id": "3", 
+                            "params": {
+                                "customLabel": "Hostname", 
+                                "field": "apache.status.hostname", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "row": true, 
+                                "size": 5
+                            }, 
+                            "schema": "split", 
+                            "type": "terms"
+                        }, 
+                        {
+                            "id": "4", 
+                            "params": {
+                                "customLabel": "Idle workers", 
+                                "field": "apache.status.workers.idle"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "defaultYExtents": false, 
+                        "drawLinesBetweenPoints": true, 
+                        "interpolate": "linear", 
+                        "radiusRatio": 9, 
+                        "scale": "linear", 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "showCircles": true, 
+                        "smoothLines": false, 
+                        "times": [], 
+                        "yAxis": {}
+                    }, 
+                    "title": "Apache HTTPD - Workers", 
+                    "type": "line"
+                }
+            }, 
+            "id": "Apache-HTTPD-Workers", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "columns": [
+                    "_source"
+                ], 
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlight": {
+                            "fields": {
+                                "*": {}
+                            }, 
+                            "fragment_size": 2147483647, 
+                            "post_tags": [
+                                "@/kibana-highlighted-field@"
+                            ], 
+                            "pre_tags": [
+                                "@kibana-highlighted-field@"
+                            ], 
+                            "require_field_match": false
+                        }, 
+                        "index": "metricbeat-*", 
+                        "query": {
+                            "query_string": {
+                                "analyze_wildcard": true, 
+                                "query": "metricset.module: apache"
+                            }
+                        }
+                    }
+                }, 
+                "sort": [
+                    "@timestamp", 
+                    "desc"
+                ], 
+                "title": "Apache HTTPD", 
+                "version": 1
+            }, 
+            "id": "Apache-HTTPD", 
+            "type": "search", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "analyze_wildcard": true, 
+                                    "query": "*"
+                                }
+                            }
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false
+                }, 
+                "panelsJSON": [
+                    {
+                        "col": 7, 
+                        "id": "Apache-HTTPD-CPU", 
+                        "panelIndex": 1, 
+                        "row": 10, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "Apache-HTTPD-Hostname-list", 
+                        "panelIndex": 2, 
+                        "row": 1, 
+                        "size_x": 3, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "Apache-HTTPD-Load1-slash-5-slash-15", 
+                        "panelIndex": 3, 
+                        "row": 10, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "Apache-HTTPD-Scoreboard", 
+                        "panelIndex": 4, 
+                        "row": 7, 
+                        "size_x": 12, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 7, 
+                        "id": "Apache-HTTPD-Total-accesses-and-kbytes", 
+                        "panelIndex": 5, 
+                        "row": 1, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 4, 
+                        "id": "Apache-HTTPD-Uptime", 
+                        "panelIndex": 6, 
+                        "row": 1, 
+                        "size_x": 3, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "Apache-HTTPD-Workers", 
+                        "panelIndex": 7, 
+                        "row": 4, 
+                        "size_x": 12, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "[Metricbeat Apache] Overview", 
+                "uiStateJSON": {
+                    "P-2": {
+                        "vis": {
+                            "params": {
+                                "sort": {
+                                    "columnIndex": null, 
+                                    "direction": null
+                                }
+                            }
+                        }
+                    }, 
+                    "P-5": {
+                        "vis": {
+                            "defaultColors": {
+                                "0 - 100": "rgb(0,104,55)"
+                            }
+                        }
+                    }, 
+                    "P-6": {
+                        "vis": {
+                            "defaultColors": {
+                                "0 - 100": "rgb(0,104,55)"
+                            }
+                        }
+                    }
+                }, 
+                "version": 1
+            }, 
+            "id": "Metricbeat-Apache-HTTPD-server-status", 
+            "type": "dashboard", 
+            "version": 3
+        }
+    ], 
+    "version": "6.0.0-beta1-SNAPSHOT"
 }

--- a/metricbeat/module/docker/_meta/kibana/6/dashboard/Metricbeat-docker-overview.json
+++ b/metricbeat/module/docker/_meta/kibana/6/dashboard/Metricbeat-docker-overview.json
@@ -1,188 +1,1017 @@
 {
-  "objects": [
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[]}"
-        },
-        "savedSearchId": "Metricbeat-Docker",
-        "title": "Docker containers [Metricbeat Docker]",
-        "uiStateJSON": "{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":1,\"direction\":\"asc\"}}}}",
-        "version": 1,
-        "visState": "{\"aggs\":[{\"enabled\":true,\"id\":\"2\",\"params\":{\"customLabel\":\"Name\",\"field\":\"docker.container.name\",\"order\":\"desc\",\"orderBy\":\"1\",\"size\":5},\"schema\":\"bucket\",\"type\":\"terms\"},{\"enabled\":true,\"id\":\"3\",\"params\":{\"customLabel\":\"CPU usage (%)\",\"field\":\"docker.cpu.total.pct\"},\"schema\":\"metric\",\"type\":\"max\"},{\"enabled\":true,\"id\":\"4\",\"params\":{\"customLabel\":\"DiskIO\",\"field\":\"docker.diskio.total\"},\"schema\":\"metric\",\"type\":\"max\"},{\"enabled\":true,\"id\":\"5\",\"params\":{\"customLabel\":\"Mem (%)\",\"field\":\"docker.memory.usage.pct\"},\"schema\":\"metric\",\"type\":\"max\"},{\"enabled\":true,\"id\":\"6\",\"params\":{\"customLabel\":\"Mem RSS\",\"field\":\"docker.memory.rss.total\"},\"schema\":\"metric\",\"type\":\"max\"},{\"enabled\":true,\"id\":\"1\",\"params\":{\"customLabel\":\"Number of Containers\",\"field\":\"docker.container.id\"},\"schema\":\"metric\",\"type\":\"cardinality\"}],\"listeners\":{},\"params\":{\"perPage\":8,\"showMeticsAtAllLevels\":false,\"showPartialRows\":false,\"showTotal\":true,\"sort\":{\"columnIndex\":null,\"direction\":null},\"totalFunc\":\"sum\"},\"title\":\"Docker containers [Metricbeat Docker]\",\"type\":\"table\"}"
-      },
-      "col": 1,
-      "id": "Docker-containers",
-      "panelIndex": 1,
-      "row": 1,
-      "size_x": 7,
-      "size_y": 5,
-      "type": "visualization",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[]}"
-        },
-        "savedSearchId": "Metricbeat-Docker",
-        "title": "Number of Containers [Metricbeat Docker]",
-        "uiStateJSON": "{\"vis\":{\"defaultColors\":{\"0 - 100\":\"rgb(0,104,55)\"}}}",
-        "version": 1,
-        "visState": "{\"aggs\":[{\"enabled\":true,\"id\":\"2\",\"params\":{\"customLabel\":\"Running\",\"field\":\"docker.info.containers.running\"},\"schema\":\"metric\",\"type\":\"max\"},{\"enabled\":true,\"id\":\"3\",\"params\":{\"customLabel\":\"Paused\",\"field\":\"docker.info.containers.paused\"},\"schema\":\"metric\",\"type\":\"max\"},{\"enabled\":true,\"id\":\"4\",\"params\":{\"customLabel\":\"Stopped\",\"field\":\"docker.info.containers.stopped\"},\"schema\":\"metric\",\"type\":\"max\"}],\"listeners\":{},\"params\":{\"addLegend\":false,\"addTooltip\":true,\"fontSize\":\"36\",\"gauge\":{\"autoExtend\":false,\"backStyle\":\"Full\",\"colorSchema\":\"Green to Red\",\"colorsRange\":[{\"from\":0,\"to\":100}],\"gaugeColorMode\":\"None\",\"gaugeStyle\":\"Full\",\"gaugeType\":\"Metric\",\"invertColors\":false,\"labels\":{\"color\":\"black\",\"show\":true},\"orientation\":\"vertical\",\"percentageMode\":false,\"scale\":{\"color\":\"#333\",\"labels\":false,\"show\":false,\"width\":2},\"style\":{\"bgColor\":false,\"fontSize\":60,\"labelColor\":false,\"subText\":\"\"},\"type\":\"simple\",\"useRange\":false,\"verticalSplit\":false},\"handleNoResults\":true,\"type\":\"gauge\"},\"title\":\"Number of Containers [Metricbeat Docker]\",\"type\":\"metric\"}"
-      },
-      "col": 8,
-      "id": "Docker-Number-of-Containers",
-      "panelIndex": 2,
-      "row": 1,
-      "size_x": 5,
-      "size_y": 2,
-      "type": "visualization",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[]}"
-        },
-        "savedSearchId": "Metricbeat-Docker",
-        "title": "Docker containers per host [Metricbeat Docker]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Docker containers per host [Metricbeat Docker]\",\"type\":\"pie\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"bottom\",\"isDonut\":true},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"cardinality\",\"schema\":\"metric\",\"params\":{\"field\":\"docker.container.id\",\"customLabel\":\"Number of containers\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"beat.hostname\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"Hosts\"}}],\"listeners\":{}}"
-      },
-      "col": 8,
-      "id": "Docker-containers-per-host",
-      "panelIndex": 3,
-      "row": 3,
-      "size_x": 2,
-      "size_y": 3,
-      "type": "visualization",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[]}"
-        },
-        "savedSearchId": "Metricbeat-Docker",
-        "title": "Docker images and names [Metricbeat Docker]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Docker images and names [Metricbeat Docker]\",\"type\":\"pie\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"bottom\",\"isDonut\":true},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"docker.container.image\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\"}},{\"id\":\"3\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"docker.container.name\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}"
-      },
-      "col": 10,
-      "id": "Docker-images-and-names",
-      "panelIndex": 7,
-      "row": 3,
-      "size_x": 3,
-      "size_y": 3,
-      "type": "visualization",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[],\"index\":\"metricbeat-*\",\"highlight\":{\"pre_tags\":[\"@kibana-highlighted-field@\"],\"post_tags\":[\"@/kibana-highlighted-field@\"],\"fields\":{\"*\":{}},\"require_field_match\":false,\"fragment_size\":2147483647},\"query\":{\"query_string\":{\"query\":\"metricset.module:docker AND metricset.name:cpu\",\"analyze_wildcard\":true}}}"
-        },
-        "title": "CPU usage [Metricbeat Docker]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"aggs\":[{\"enabled\":true,\"id\":\"1\",\"params\":{\"customLabel\":\"Total CPU time\",\"field\":\"docker.cpu.total.pct\",\"percents\":[75]},\"schema\":\"metric\",\"type\":\"percentiles\"},{\"enabled\":true,\"id\":\"2\",\"params\":{\"customInterval\":\"2h\",\"extended_bounds\":{},\"field\":\"@timestamp\",\"interval\":\"auto\",\"min_doc_count\":1},\"schema\":\"segment\",\"type\":\"date_histogram\"},{\"enabled\":true,\"id\":\"3\",\"params\":{\"customLabel\":\"Container name\",\"field\":\"docker.container.name\",\"order\":\"desc\",\"orderBy\":\"1.75\",\"size\":5},\"schema\":\"group\",\"type\":\"terms\"}],\"listeners\":{},\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{},\"type\":\"category\"}],\"defaultYExtents\":false,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"mode\":\"stacked\",\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Count\"},\"drawLinesBetweenPoints\":true,\"interpolate\":\"linear\",\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"area\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"shareYAxis\":true,\"smoothLines\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Count\"},\"type\":\"value\"}],\"yAxis\":{}},\"title\":\"CPU usage [Metricbeat Docker]\",\"type\":\"area\"}"
-      },
-      "col": 1,
-      "id": "Docker-CPU-usage",
-      "panelIndex": 4,
-      "row": 6,
-      "size_x": 6,
-      "size_y": 3,
-      "type": "visualization",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[],\"index\":\"metricbeat-*\",\"highlight\":{\"pre_tags\":[\"@kibana-highlighted-field@\"],\"post_tags\":[\"@/kibana-highlighted-field@\"],\"fields\":{\"*\":{}},\"require_field_match\":false,\"fragment_size\":2147483647},\"query\":{\"query_string\":{\"query\":\"metricset.module:docker AND metricset.name:memory\",\"analyze_wildcard\":true}}}"
-        },
-        "title": "Memory usage [Metricbeat Docker]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"aggs\":[{\"enabled\":true,\"id\":\"1\",\"params\":{\"customLabel\":\"Memory\",\"field\":\"docker.memory.usage.total\"},\"schema\":\"metric\",\"type\":\"max\"},{\"enabled\":true,\"id\":\"2\",\"params\":{\"customInterval\":\"2h\",\"extended_bounds\":{},\"field\":\"@timestamp\",\"interval\":\"auto\",\"min_doc_count\":1},\"schema\":\"segment\",\"type\":\"date_histogram\"},{\"enabled\":true,\"id\":\"3\",\"params\":{\"customLabel\":\"Container name\",\"field\":\"docker.container.name\",\"order\":\"desc\",\"orderBy\":\"1\",\"size\":5},\"schema\":\"group\",\"type\":\"terms\"}],\"listeners\":{},\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{},\"type\":\"category\"}],\"defaultYExtents\":false,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"mode\":\"stacked\",\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Count\"},\"drawLinesBetweenPoints\":true,\"interpolate\":\"linear\",\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"area\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"shareYAxis\":true,\"smoothLines\":false,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Count\"},\"type\":\"value\"}],\"yAxis\":{}},\"title\":\"Memory usage [Metricbeat Docker]\",\"type\":\"area\"}"
-      },
-      "col": 7,
-      "id": "Docker-memory-usage",
-      "panelIndex": 5,
-      "row": 6,
-      "size_x": 6,
-      "size_y": 3,
-      "type": "visualization",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[],\"index\":\"metricbeat-*\",\"highlight\":{\"pre_tags\":[\"@kibana-highlighted-field@\"],\"post_tags\":[\"@/kibana-highlighted-field@\"],\"fields\":{\"*\":{}},\"require_field_match\":false,\"fragment_size\":2147483647},\"query\":{\"query_string\":{\"query\":\"metricset.module:docker AND metricset.name:network\",\"analyze_wildcard\":true}}}"
-        },
-        "title": "Network IO [Metricbeat Docker]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"aggs\":[{\"enabled\":true,\"id\":\"1\",\"params\":{\"customLabel\":\"IN bytes\",\"field\":\"docker.network.in.bytes\"},\"schema\":\"metric\",\"type\":\"max\"},{\"enabled\":true,\"id\":\"2\",\"params\":{\"customInterval\":\"2h\",\"extended_bounds\":{},\"field\":\"@timestamp\",\"interval\":\"auto\",\"min_doc_count\":1},\"schema\":\"segment\",\"type\":\"date_histogram\"},{\"enabled\":true,\"id\":\"3\",\"params\":{\"customLabel\":\"Container name\",\"field\":\"docker.container.name\",\"order\":\"desc\",\"orderBy\":\"1\",\"size\":5},\"schema\":\"group\",\"type\":\"terms\"},{\"enabled\":true,\"id\":\"4\",\"params\":{\"customLabel\":\"OUT bytes\",\"field\":\"docker.network.out.bytes\"},\"schema\":\"metric\",\"type\":\"max\"}],\"listeners\":{},\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{},\"type\":\"category\"}],\"defaultYExtents\":false,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"mode\":\"stacked\",\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Count\"},\"drawLinesBetweenPoints\":true,\"interpolate\":\"linear\",\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"area\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"shareYAxis\":true,\"smoothLines\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Count\"},\"type\":\"value\"}],\"yAxis\":{}},\"title\":\"Network IO [Metricbeat Docker]\",\"type\":\"area\"}"
-      },
-      "col": 1,
-      "id": "Docker-Network-IO",
-      "panelIndex": 6,
-      "row": 9,
-      "size_x": 12,
-      "size_y": 3,
-      "type": "visualization",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "columns": [
-          "_source"
-        ],
-        "description": "",
-        "hits": 0,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"index\":\"metricbeat-*\",\"filter\":[],\"highlight\":{\"pre_tags\":[\"@kibana-highlighted-field@\"],\"post_tags\":[\"@/kibana-highlighted-field@\"],\"fields\":{\"*\":{}},\"require_field_match\":false,\"fragment_size\":2147483647},\"query\":{\"query_string\":{\"query\":\"metricset.module:docker\",\"analyze_wildcard\":true}}}"
-        },
-        "sort": [
-          "@timestamp",
-          "desc"
-        ],
-        "title": "Metricbeat Docker",
-        "version": 1
-      },
-      "id": "Metricbeat-Docker",
-      "type": "search",
-      "version": 4
-    },
-    {
-      "attributes": {
-        "description": "",
-        "hits": 0,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[{\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}}}],\"highlightAll\":true,\"version\":true}"
-        },
-        "optionsJSON": "{\"darkTheme\":false}",
-        "panelsJSON": "[{\"col\":1,\"id\":\"Docker-containers\",\"panelIndex\":1,\"row\":1,\"size_x\":7,\"size_y\":5,\"type\":\"visualization\"},{\"col\":8,\"id\":\"Docker-Number-of-Containers\",\"panelIndex\":2,\"row\":1,\"size_x\":5,\"size_y\":2,\"type\":\"visualization\"},{\"col\":8,\"id\":\"Docker-containers-per-host\",\"panelIndex\":3,\"row\":3,\"size_x\":2,\"size_y\":3,\"type\":\"visualization\"},{\"col\":10,\"id\":\"Docker-images-and-names\",\"panelIndex\":7,\"row\":3,\"size_x\":3,\"size_y\":3,\"type\":\"visualization\"},{\"col\":1,\"id\":\"Docker-CPU-usage\",\"panelIndex\":4,\"row\":6,\"size_x\":6,\"size_y\":3,\"type\":\"visualization\"},{\"col\":7,\"id\":\"Docker-memory-usage\",\"panelIndex\":5,\"row\":6,\"size_x\":6,\"size_y\":3,\"type\":\"visualization\"},{\"col\":1,\"id\":\"Docker-Network-IO\",\"panelIndex\":6,\"row\":9,\"size_x\":12,\"size_y\":3,\"type\":\"visualization\"}]",
-        "timeRestore": false,
-        "title": "[Metricbeat Docker] Overview",
-        "uiStateJSON": "{\"P-1\":{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":1,\"direction\":\"asc\"}}}},\"P-2\":{\"vis\":{\"defaultColors\":{\"0 - 100\":\"rgb(0,104,55)\"}}},\"P-3\":{\"vis\":{\"legendOpen\":true}},\"P-5\":{\"vis\":{\"legendOpen\":true}},\"P-7\":{\"vis\":{\"legendOpen\":true}}}",
-        "version": 1
-      },
-      "id": "AV4REOpp5NkDleZmzKkE",
-      "type": "dashboard",
-      "version": 3
-    }
-  ],
-  "version": "5.6.0-SNAPSHOT"
+    "objects": [
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Metricbeat-Docker", 
+                "title": "Docker containers [Metricbeat Docker]", 
+                "uiStateJSON": {
+                    "vis": {
+                        "params": {
+                            "sort": {
+                                "columnIndex": 1, 
+                                "direction": "asc"
+                            }
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customLabel": "Name", 
+                                "field": "docker.container.name", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "bucket", 
+                            "type": "terms"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "customLabel": "CPU usage (%)", 
+                                "field": "docker.cpu.total.pct"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "4", 
+                            "params": {
+                                "customLabel": "DiskIO", 
+                                "field": "docker.diskio.total"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "5", 
+                            "params": {
+                                "customLabel": "Mem (%)", 
+                                "field": "docker.memory.usage.pct"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "6", 
+                            "params": {
+                                "customLabel": "Mem RSS", 
+                                "field": "docker.memory.rss.total"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Number of Containers", 
+                                "field": "docker.container.id"
+                            }, 
+                            "schema": "metric", 
+                            "type": "cardinality"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "perPage": 8, 
+                        "showMeticsAtAllLevels": false, 
+                        "showPartialRows": false, 
+                        "showTotal": true, 
+                        "sort": {
+                            "columnIndex": null, 
+                            "direction": null
+                        }, 
+                        "totalFunc": "sum"
+                    }, 
+                    "title": "Docker containers [Metricbeat Docker]", 
+                    "type": "table"
+                }
+            }, 
+            "col": 1, 
+            "id": "Docker-containers", 
+            "panelIndex": 1, 
+            "row": 1, 
+            "size_x": 7, 
+            "size_y": 5, 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Metricbeat-Docker", 
+                "title": "Number of Containers [Metricbeat Docker]", 
+                "uiStateJSON": {
+                    "vis": {
+                        "defaultColors": {
+                            "0 - 100": "rgb(0,104,55)"
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customLabel": "Running", 
+                                "field": "docker.info.containers.running"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "customLabel": "Paused", 
+                                "field": "docker.info.containers.paused"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "4", 
+                            "params": {
+                                "customLabel": "Stopped", 
+                                "field": "docker.info.containers.stopped"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": false, 
+                        "addTooltip": true, 
+                        "fontSize": "36", 
+                        "gauge": {
+                            "autoExtend": false, 
+                            "backStyle": "Full", 
+                            "colorSchema": "Green to Red", 
+                            "colorsRange": [
+                                {
+                                    "from": 0, 
+                                    "to": 100
+                                }
+                            ], 
+                            "gaugeColorMode": "None", 
+                            "gaugeStyle": "Full", 
+                            "gaugeType": "Metric", 
+                            "invertColors": false, 
+                            "labels": {
+                                "color": "black", 
+                                "show": true
+                            }, 
+                            "orientation": "vertical", 
+                            "percentageMode": false, 
+                            "scale": {
+                                "color": "#333", 
+                                "labels": false, 
+                                "show": false, 
+                                "width": 2
+                            }, 
+                            "style": {
+                                "bgColor": false, 
+                                "fontSize": 60, 
+                                "labelColor": false, 
+                                "subText": ""
+                            }, 
+                            "type": "simple", 
+                            "useRange": false, 
+                            "verticalSplit": false
+                        }, 
+                        "handleNoResults": true, 
+                        "type": "gauge"
+                    }, 
+                    "title": "Number of Containers [Metricbeat Docker]", 
+                    "type": "metric"
+                }
+            }, 
+            "col": 8, 
+            "id": "Docker-Number-of-Containers", 
+            "panelIndex": 2, 
+            "row": 1, 
+            "size_x": 5, 
+            "size_y": 2, 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Metricbeat-Docker", 
+                "title": "Docker containers per host [Metricbeat Docker]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Number of containers", 
+                                "field": "docker.container.id"
+                            }, 
+                            "schema": "metric", 
+                            "type": "cardinality"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customLabel": "Hosts", 
+                                "field": "beat.hostname", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTooltip": true, 
+                        "isDonut": true, 
+                        "legendPosition": "bottom", 
+                        "shareYAxis": true
+                    }, 
+                    "title": "Docker containers per host [Metricbeat Docker]", 
+                    "type": "pie"
+                }
+            }, 
+            "col": 8, 
+            "id": "Docker-containers-per-host", 
+            "panelIndex": 3, 
+            "row": 3, 
+            "size_x": 2, 
+            "size_y": 3, 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Metricbeat-Docker", 
+                "title": "Docker images and names [Metricbeat Docker]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "field": "docker.container.image", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "field": "docker.container.name", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTooltip": true, 
+                        "isDonut": true, 
+                        "legendPosition": "bottom", 
+                        "shareYAxis": true
+                    }, 
+                    "title": "Docker images and names [Metricbeat Docker]", 
+                    "type": "pie"
+                }
+            }, 
+            "col": 10, 
+            "id": "Docker-images-and-names", 
+            "panelIndex": 7, 
+            "row": 3, 
+            "size_x": 3, 
+            "size_y": 3, 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlight": {
+                            "fields": {
+                                "*": {}
+                            }, 
+                            "fragment_size": 2147483647, 
+                            "post_tags": [
+                                "@/kibana-highlighted-field@"
+                            ], 
+                            "pre_tags": [
+                                "@kibana-highlighted-field@"
+                            ], 
+                            "require_field_match": false
+                        }, 
+                        "index": "metricbeat-*", 
+                        "query": {
+                            "query_string": {
+                                "analyze_wildcard": true, 
+                                "query": "metricset.module:docker AND metricset.name:cpu"
+                            }
+                        }
+                    }
+                }, 
+                "title": "CPU usage [Metricbeat Docker]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Total CPU time", 
+                                "field": "docker.cpu.total.pct", 
+                                "percents": [
+                                    75
+                                ]
+                            }, 
+                            "schema": "metric", 
+                            "type": "percentiles"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "customLabel": "Container name", 
+                                "field": "docker.container.name", 
+                                "order": "desc", 
+                                "orderBy": "1.75", 
+                                "size": 5
+                            }, 
+                            "schema": "group", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "categoryAxes": [
+                            {
+                                "id": "CategoryAxis-1", 
+                                "labels": {
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "position": "bottom", 
+                                "scale": {
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {}, 
+                                "type": "category"
+                            }
+                        ], 
+                        "defaultYExtents": false, 
+                        "grid": {
+                            "categoryLines": false, 
+                            "style": {
+                                "color": "#eee"
+                            }
+                        }, 
+                        "interpolate": "linear", 
+                        "legendPosition": "top", 
+                        "mode": "stacked", 
+                        "scale": "linear", 
+                        "seriesParams": [
+                            {
+                                "data": {
+                                    "id": "1", 
+                                    "label": "Count"
+                                }, 
+                                "drawLinesBetweenPoints": true, 
+                                "interpolate": "linear", 
+                                "mode": "stacked", 
+                                "show": "true", 
+                                "showCircles": true, 
+                                "type": "area", 
+                                "valueAxis": "ValueAxis-1"
+                            }
+                        ], 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "smoothLines": true, 
+                        "times": [], 
+                        "valueAxes": [
+                            {
+                                "id": "ValueAxis-1", 
+                                "labels": {
+                                    "filter": false, 
+                                    "rotate": 0, 
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "name": "LeftAxis-1", 
+                                "position": "left", 
+                                "scale": {
+                                    "mode": "normal", 
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {
+                                    "text": "Count"
+                                }, 
+                                "type": "value"
+                            }
+                        ], 
+                        "yAxis": {}
+                    }, 
+                    "title": "CPU usage [Metricbeat Docker]", 
+                    "type": "area"
+                }
+            }, 
+            "col": 1, 
+            "id": "Docker-CPU-usage", 
+            "panelIndex": 4, 
+            "row": 6, 
+            "size_x": 6, 
+            "size_y": 3, 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlight": {
+                            "fields": {
+                                "*": {}
+                            }, 
+                            "fragment_size": 2147483647, 
+                            "post_tags": [
+                                "@/kibana-highlighted-field@"
+                            ], 
+                            "pre_tags": [
+                                "@kibana-highlighted-field@"
+                            ], 
+                            "require_field_match": false
+                        }, 
+                        "index": "metricbeat-*", 
+                        "query": {
+                            "query_string": {
+                                "analyze_wildcard": true, 
+                                "query": "metricset.module:docker AND metricset.name:memory"
+                            }
+                        }
+                    }
+                }, 
+                "title": "Memory usage [Metricbeat Docker]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Memory", 
+                                "field": "docker.memory.usage.total"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "customLabel": "Container name", 
+                                "field": "docker.container.name", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "group", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "categoryAxes": [
+                            {
+                                "id": "CategoryAxis-1", 
+                                "labels": {
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "position": "bottom", 
+                                "scale": {
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {}, 
+                                "type": "category"
+                            }
+                        ], 
+                        "defaultYExtents": false, 
+                        "grid": {
+                            "categoryLines": false, 
+                            "style": {
+                                "color": "#eee"
+                            }
+                        }, 
+                        "interpolate": "linear", 
+                        "legendPosition": "top", 
+                        "mode": "stacked", 
+                        "scale": "linear", 
+                        "seriesParams": [
+                            {
+                                "data": {
+                                    "id": "1", 
+                                    "label": "Count"
+                                }, 
+                                "drawLinesBetweenPoints": true, 
+                                "interpolate": "linear", 
+                                "mode": "stacked", 
+                                "show": "true", 
+                                "showCircles": true, 
+                                "type": "area", 
+                                "valueAxis": "ValueAxis-1"
+                            }
+                        ], 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "smoothLines": false, 
+                        "times": [], 
+                        "valueAxes": [
+                            {
+                                "id": "ValueAxis-1", 
+                                "labels": {
+                                    "filter": false, 
+                                    "rotate": 0, 
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "name": "LeftAxis-1", 
+                                "position": "left", 
+                                "scale": {
+                                    "mode": "normal", 
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {
+                                    "text": "Count"
+                                }, 
+                                "type": "value"
+                            }
+                        ], 
+                        "yAxis": {}
+                    }, 
+                    "title": "Memory usage [Metricbeat Docker]", 
+                    "type": "area"
+                }
+            }, 
+            "col": 7, 
+            "id": "Docker-memory-usage", 
+            "panelIndex": 5, 
+            "row": 6, 
+            "size_x": 6, 
+            "size_y": 3, 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlight": {
+                            "fields": {
+                                "*": {}
+                            }, 
+                            "fragment_size": 2147483647, 
+                            "post_tags": [
+                                "@/kibana-highlighted-field@"
+                            ], 
+                            "pre_tags": [
+                                "@kibana-highlighted-field@"
+                            ], 
+                            "require_field_match": false
+                        }, 
+                        "index": "metricbeat-*", 
+                        "query": {
+                            "query_string": {
+                                "analyze_wildcard": true, 
+                                "query": "metricset.module:docker AND metricset.name:network"
+                            }
+                        }
+                    }
+                }, 
+                "title": "Network IO [Metricbeat Docker]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "IN bytes", 
+                                "field": "docker.network.in.bytes"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "customLabel": "Container name", 
+                                "field": "docker.container.name", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "group", 
+                            "type": "terms"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "4", 
+                            "params": {
+                                "customLabel": "OUT bytes", 
+                                "field": "docker.network.out.bytes"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "categoryAxes": [
+                            {
+                                "id": "CategoryAxis-1", 
+                                "labels": {
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "position": "bottom", 
+                                "scale": {
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {}, 
+                                "type": "category"
+                            }
+                        ], 
+                        "defaultYExtents": false, 
+                        "grid": {
+                            "categoryLines": false, 
+                            "style": {
+                                "color": "#eee"
+                            }
+                        }, 
+                        "interpolate": "linear", 
+                        "legendPosition": "top", 
+                        "mode": "stacked", 
+                        "scale": "linear", 
+                        "seriesParams": [
+                            {
+                                "data": {
+                                    "id": "1", 
+                                    "label": "Count"
+                                }, 
+                                "drawLinesBetweenPoints": true, 
+                                "interpolate": "linear", 
+                                "mode": "stacked", 
+                                "show": "true", 
+                                "showCircles": true, 
+                                "type": "area", 
+                                "valueAxis": "ValueAxis-1"
+                            }
+                        ], 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "smoothLines": true, 
+                        "times": [], 
+                        "valueAxes": [
+                            {
+                                "id": "ValueAxis-1", 
+                                "labels": {
+                                    "filter": false, 
+                                    "rotate": 0, 
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "name": "LeftAxis-1", 
+                                "position": "left", 
+                                "scale": {
+                                    "mode": "normal", 
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {
+                                    "text": "Count"
+                                }, 
+                                "type": "value"
+                            }
+                        ], 
+                        "yAxis": {}
+                    }, 
+                    "title": "Network IO [Metricbeat Docker]", 
+                    "type": "area"
+                }
+            }, 
+            "col": 1, 
+            "id": "Docker-Network-IO", 
+            "panelIndex": 6, 
+            "row": 9, 
+            "size_x": 12, 
+            "size_y": 3, 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "columns": [
+                    "_source"
+                ], 
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlight": {
+                            "fields": {
+                                "*": {}
+                            }, 
+                            "fragment_size": 2147483647, 
+                            "post_tags": [
+                                "@/kibana-highlighted-field@"
+                            ], 
+                            "pre_tags": [
+                                "@kibana-highlighted-field@"
+                            ], 
+                            "require_field_match": false
+                        }, 
+                        "index": "metricbeat-*", 
+                        "query": {
+                            "query_string": {
+                                "analyze_wildcard": true, 
+                                "query": "metricset.module:docker"
+                            }
+                        }
+                    }
+                }, 
+                "sort": [
+                    "@timestamp", 
+                    "desc"
+                ], 
+                "title": "Metricbeat Docker", 
+                "version": 1
+            }, 
+            "id": "Metricbeat-Docker", 
+            "type": "search", 
+            "version": 4
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [
+                            {
+                                "query": {
+                                    "query_string": {
+                                        "analyze_wildcard": true, 
+                                        "query": "*"
+                                    }
+                                }
+                            }
+                        ], 
+                        "highlightAll": true, 
+                        "version": true
+                    }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false
+                }, 
+                "panelsJSON": [
+                    {
+                        "col": 1, 
+                        "id": "Docker-containers", 
+                        "panelIndex": 1, 
+                        "row": 1, 
+                        "size_x": 7, 
+                        "size_y": 5, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 8, 
+                        "id": "Docker-Number-of-Containers", 
+                        "panelIndex": 2, 
+                        "row": 1, 
+                        "size_x": 5, 
+                        "size_y": 2, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 8, 
+                        "id": "Docker-containers-per-host", 
+                        "panelIndex": 3, 
+                        "row": 3, 
+                        "size_x": 2, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 10, 
+                        "id": "Docker-images-and-names", 
+                        "panelIndex": 7, 
+                        "row": 3, 
+                        "size_x": 3, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "Docker-CPU-usage", 
+                        "panelIndex": 4, 
+                        "row": 6, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 7, 
+                        "id": "Docker-memory-usage", 
+                        "panelIndex": 5, 
+                        "row": 6, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "Docker-Network-IO", 
+                        "panelIndex": 6, 
+                        "row": 9, 
+                        "size_x": 12, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "[Metricbeat Docker] Overview", 
+                "uiStateJSON": {
+                    "P-1": {
+                        "vis": {
+                            "params": {
+                                "sort": {
+                                    "columnIndex": 1, 
+                                    "direction": "asc"
+                                }
+                            }
+                        }
+                    }, 
+                    "P-2": {
+                        "vis": {
+                            "defaultColors": {
+                                "0 - 100": "rgb(0,104,55)"
+                            }
+                        }
+                    }, 
+                    "P-3": {
+                        "vis": {
+                            "legendOpen": true
+                        }
+                    }, 
+                    "P-5": {
+                        "vis": {
+                            "legendOpen": true
+                        }
+                    }, 
+                    "P-7": {
+                        "vis": {
+                            "legendOpen": true
+                        }
+                    }
+                }, 
+                "version": 1
+            }, 
+            "id": "AV4REOpp5NkDleZmzKkE", 
+            "type": "dashboard", 
+            "version": 3
+        }
+    ], 
+    "version": "5.6.0-SNAPSHOT"
 }

--- a/metricbeat/module/golang/_meta/kibana/6/dashboard/Metricbeat-golang-overview.json
+++ b/metricbeat/module/golang/_meta/kibana/6/dashboard/Metricbeat-golang-overview.json
@@ -1,113 +1,297 @@
 {
-  "objects": [
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}},\"language\":\"lucene\"},\"filter\":[]}"
-        },
-        "title": "Heap Summary [Metricbeat Golang]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Heap Summary [Metricbeat Golang]\",\"type\":\"timelion\",\"params\":{\"expression\":\".es(index=\\\"metricbeat*\\\",metric=\\\"avg:golang.heap.system.total\\\").label(\\\"System Total Memory\\\").yaxis(label=\\\"Bytes\\\",units=bytes),.es(index=\\\"metricbeat*\\\",metric=\\\"min:golang.heap.allocations.allocated\\\").label(\\\"Bytes Allocated(min)\\\").movingaverage(30),.es(index=\\\"metricbeat*\\\",metric=\\\"max:golang.heap.allocations.allocated\\\").label(\\\"Bytes Allocated(max)\\\").movingaverage(30),.es(index=\\\"metricbeat*\\\",metric=\\\"avg:golang.heap.gc.next_gc_limit\\\").label(\\\"GC Limit\\\"),.es(index=\\\"metricbeat*\\\",metric=\\\"avg:golang.heap.gc.pause.count\\\").condition(lt,1, null).points().label(\\\"GC Cycles(count)\\\").yaxis(2,label=\\\"Count\\\")\",\"interval\":\"10s\"},\"aggs\":[]}"
-      },
-      "id": "58000780-f529-11e6-844d-b170e2f0a07e",
-      "type": "visualization",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}},\"language\":\"lucene\"},\"filter\":[]}"
-        },
-        "title": "Heap [Metricbeat Golang]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Heap [Metricbeat Golang]\",\"type\":\"timelion\",\"params\":{\"expression\":\".es(index=\\\"metricbeat*\\\",metric=\\\"avg:golang.heap.allocations.total\\\").label(\\\"Heap Total\\\").derivative().movingaverage(30).yaxis(label=\\\"Bytes\\\",units=bytes),.es(index=\\\"metricbeat*\\\",metric=\\\"avg:golang.heap.allocations.active\\\").label(\\\"Heap Inuse\\\").movingaverage(30),.es(index=\\\"metricbeat*\\\",metric=\\\"avg:golang.heap.allocations.allocated\\\").label(\\\"Heap Allocated\\\").movingaverage(30),.es(index=\\\"metricbeat*\\\",metric=\\\"avg:golang.heap.allocations.idle\\\").label(\\\"Heap Idle\\\").movingaverage(30)\",\"interval\":\"10s\"},\"aggs\":[]}"
-      },
-      "id": "95388680-f52a-11e6-969c-518c48c913e4",
-      "type": "visualization",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}},\"language\":\"lucene\"},\"filter\":[]}"
-        },
-        "title": "Objects [Metricbeat Golang]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Objects [Metricbeat Golang]\",\"type\":\"timelion\",\"params\":{\"expression\":\".es(index=\\\"metricbeat*\\\",metric=\\\"max:golang.heap.allocations.objects\\\").label(\\\"Object Count(avg)\\\").yaxis(1,label=\\\"Count\\\").movingaverage(30),.es(index=\\\"metricbeat*\\\",metric=\\\"max:golang.heap.allocations.total\\\").derivative().label(\\\"Allocation Rate\\\").yaxis(2,label=\\\"Rate\\\").movingaverage(30)\",\"interval\":\"10s\"},\"aggs\":[]}"
-      },
-      "id": "b59a5200-f52a-11e6-969c-518c48c913e4",
-      "type": "visualization",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}},\"language\":\"lucene\"},\"filter\":[]}"
-        },
-        "title": "System [Metricbeat Golang]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"System  [Metricbeat Golang]\",\"type\":\"timelion\",\"params\":{\"expression\":\".es(index=\\\"metricbeat*\\\",metric=\\\"avg:golang.heap.system.total\\\").label(\\\"System Total\\\").yaxis(label=\\\"Bytes\\\",units=bytes),.es(index=\\\"metricbeat*\\\",metric=\\\"avg:golang.heap.system.obtained\\\").label(\\\"System Obtained\\\"),.es(index=\\\"metricbeat*\\\",metric=\\\"avg:golang.heap.system.stack\\\").label(\\\"System Stack\\\"),.es(index=\\\"metricbeat*\\\",metric=\\\"avg:golang.heap.system.released\\\").label(\\\"System Released\\\")\",\"interval\":\"10s\"},\"aggs\":[]}"
-      },
-      "id": "9a9a8bf0-f52a-11e6-969c-518c48c913e4",
-      "type": "visualization",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}},\"language\":\"lucene\"},\"filter\":[]}"
-        },
-        "title": "GC count [Metricbeat Golang]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"GC count [Metricbeat Golang]\",\"type\":\"timelion\",\"params\":{\"expression\":\".es(index=\\\"metricbeat*\\\",metric=\\\"max:golang.heap.gc.pause.count\\\").label(\\\"GC Count\\\").bars().yaxis(label=\\\"Count\\\"),.es(index=\\\"metricbeat*\\\",metric=\\\"max:golang.heap.gc.total_count\\\").label(\\\"GC Rate\\\").derivative().movingaverage(30),.es(index=\\\"metricbeat*\\\",metric=\\\"max:golang.heap.gc.cpu_fraction\\\").label(\\\"CPU Fraction\\\").yaxis(2,label=\\\"Fraction\\\")\",\"interval\":\"10s\"},\"aggs\":[]}"
-      },
-      "id": "b046cb80-f52a-11e6-969c-518c48c913e4",
-      "type": "visualization",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}},\"language\":\"lucene\"},\"filter\":[]}"
-        },
-        "title": "GC durations [Metricbeat Golang]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"GC durations [Metricbeat Golang]\",\"type\":\"timelion\",\"params\":{\"expression\":\".es(index=\\\"metricbeat*\\\",metric=\\\"max:golang.heap.gc.pause.sum.ns\\\").bars().label(\\\"sum of GC Pause durations(ns)\\\").yaxis(label=\\\"Durations(ns)\\\"),.es(index=\\\"metricbeat*\\\",metric=\\\"max:golang.heap.gc.total_pause.ns\\\").derivative().movingaverage(30).label(\\\"Total GC Pause(ns) Rate\\\"),.es(index=\\\"metricbeat*\\\",metric=\\\"max:golang.heap.gc.pause.max.ns\\\").label(\\\"Max GC Pause(ns)\\\").movingaverage(30),.es(index=\\\"metricbeat*\\\",metric=\\\"avg:golang.heap.gc.pause.avg.ns\\\").label(\\\"Avg GC Pause(ns)\\\").movingaverage(30),.es(index=\\\"metricbeat*\\\",metric=\\\"max:golang.heap.gc.pause.count\\\").condition(lt,1, null).label(\\\"GC Pause count\\\").points().yaxis(2,label=\\\"Count\\\")\",\"interval\":\"10s\"},\"aggs\":[]}"
-      },
-      "id": "ab226b50-f52a-11e6-969c-518c48c913e4",
-      "type": "visualization",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "hits": 0,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[],\"query\":{\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}},\"language\":\"lucene\"},\"highlightAll\":true,\"version\":true}"
-        },
-        "optionsJSON": "{\"darkTheme\":false}",
-        "panelsJSON": "[{\"col\":1,\"id\":\"58000780-f529-11e6-844d-b170e2f0a07e\",\"panelIndex\":8,\"row\":1,\"size_x\":12,\"size_y\":3,\"type\":\"visualization\"},{\"col\":1,\"id\":\"95388680-f52a-11e6-969c-518c48c913e4\",\"panelIndex\":9,\"row\":4,\"size_x\":4,\"size_y\":4,\"type\":\"visualization\"},{\"col\":9,\"id\":\"b59a5200-f52a-11e6-969c-518c48c913e4\",\"panelIndex\":10,\"row\":4,\"size_x\":4,\"size_y\":4,\"type\":\"visualization\"},{\"col\":5,\"id\":\"9a9a8bf0-f52a-11e6-969c-518c48c913e4\",\"panelIndex\":11,\"row\":4,\"size_x\":4,\"size_y\":4,\"type\":\"visualization\"},{\"col\":7,\"id\":\"b046cb80-f52a-11e6-969c-518c48c913e4\",\"panelIndex\":12,\"row\":8,\"size_x\":6,\"size_y\":4,\"type\":\"visualization\"},{\"col\":1,\"id\":\"ab226b50-f52a-11e6-969c-518c48c913e4\",\"panelIndex\":13,\"row\":8,\"size_x\":6,\"size_y\":4,\"type\":\"visualization\"}]",
-        "timeRestore": false,
-        "title": "[Metricbeat Golang] Overview",
-        "uiStateJSON": "{}",
-        "version": 1
-      },
-      "id": "f2dc7320-f519-11e6-a3c9-9d1f7c42b045",
-      "type": "dashboard",
-      "version": 3
-    }
-  ],
-  "version": "6.0.0-beta1-SNAPSHOT"
+    "objects": [
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "analyze_wildcard": true, 
+                                    "query": "*"
+                                }
+                            }
+                        }
+                    }
+                }, 
+                "title": "Heap Summary [Metricbeat Golang]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "expression": ".es(index=\"metricbeat*\",metric=\"avg:golang.heap.system.total\").label(\"System Total Memory\").yaxis(label=\"Bytes\",units=bytes),.es(index=\"metricbeat*\",metric=\"min:golang.heap.allocations.allocated\").label(\"Bytes Allocated(min)\").movingaverage(30),.es(index=\"metricbeat*\",metric=\"max:golang.heap.allocations.allocated\").label(\"Bytes Allocated(max)\").movingaverage(30),.es(index=\"metricbeat*\",metric=\"avg:golang.heap.gc.next_gc_limit\").label(\"GC Limit\"),.es(index=\"metricbeat*\",metric=\"avg:golang.heap.gc.pause.count\").condition(lt,1, null).points().label(\"GC Cycles(count)\").yaxis(2,label=\"Count\")", 
+                        "interval": "10s"
+                    }, 
+                    "title": "Heap Summary [Metricbeat Golang]", 
+                    "type": "timelion"
+                }
+            }, 
+            "id": "58000780-f529-11e6-844d-b170e2f0a07e", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "analyze_wildcard": true, 
+                                    "query": "*"
+                                }
+                            }
+                        }
+                    }
+                }, 
+                "title": "Heap [Metricbeat Golang]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "expression": ".es(index=\"metricbeat*\",metric=\"avg:golang.heap.allocations.total\").label(\"Heap Total\").derivative().movingaverage(30).yaxis(label=\"Bytes\",units=bytes),.es(index=\"metricbeat*\",metric=\"avg:golang.heap.allocations.active\").label(\"Heap Inuse\").movingaverage(30),.es(index=\"metricbeat*\",metric=\"avg:golang.heap.allocations.allocated\").label(\"Heap Allocated\").movingaverage(30),.es(index=\"metricbeat*\",metric=\"avg:golang.heap.allocations.idle\").label(\"Heap Idle\").movingaverage(30)", 
+                        "interval": "10s"
+                    }, 
+                    "title": "Heap [Metricbeat Golang]", 
+                    "type": "timelion"
+                }
+            }, 
+            "id": "95388680-f52a-11e6-969c-518c48c913e4", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "analyze_wildcard": true, 
+                                    "query": "*"
+                                }
+                            }
+                        }
+                    }
+                }, 
+                "title": "Objects [Metricbeat Golang]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "expression": ".es(index=\"metricbeat*\",metric=\"max:golang.heap.allocations.objects\").label(\"Object Count(avg)\").yaxis(1,label=\"Count\").movingaverage(30),.es(index=\"metricbeat*\",metric=\"max:golang.heap.allocations.total\").derivative().label(\"Allocation Rate\").yaxis(2,label=\"Rate\").movingaverage(30)", 
+                        "interval": "10s"
+                    }, 
+                    "title": "Objects [Metricbeat Golang]", 
+                    "type": "timelion"
+                }
+            }, 
+            "id": "b59a5200-f52a-11e6-969c-518c48c913e4", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "analyze_wildcard": true, 
+                                    "query": "*"
+                                }
+                            }
+                        }
+                    }
+                }, 
+                "title": "System [Metricbeat Golang]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "expression": ".es(index=\"metricbeat*\",metric=\"avg:golang.heap.system.total\").label(\"System Total\").yaxis(label=\"Bytes\",units=bytes),.es(index=\"metricbeat*\",metric=\"avg:golang.heap.system.obtained\").label(\"System Obtained\"),.es(index=\"metricbeat*\",metric=\"avg:golang.heap.system.stack\").label(\"System Stack\"),.es(index=\"metricbeat*\",metric=\"avg:golang.heap.system.released\").label(\"System Released\")", 
+                        "interval": "10s"
+                    }, 
+                    "title": "System  [Metricbeat Golang]", 
+                    "type": "timelion"
+                }
+            }, 
+            "id": "9a9a8bf0-f52a-11e6-969c-518c48c913e4", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "analyze_wildcard": true, 
+                                    "query": "*"
+                                }
+                            }
+                        }
+                    }
+                }, 
+                "title": "GC count [Metricbeat Golang]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "expression": ".es(index=\"metricbeat*\",metric=\"max:golang.heap.gc.pause.count\").label(\"GC Count\").bars().yaxis(label=\"Count\"),.es(index=\"metricbeat*\",metric=\"max:golang.heap.gc.total_count\").label(\"GC Rate\").derivative().movingaverage(30),.es(index=\"metricbeat*\",metric=\"max:golang.heap.gc.cpu_fraction\").label(\"CPU Fraction\").yaxis(2,label=\"Fraction\")", 
+                        "interval": "10s"
+                    }, 
+                    "title": "GC count [Metricbeat Golang]", 
+                    "type": "timelion"
+                }
+            }, 
+            "id": "b046cb80-f52a-11e6-969c-518c48c913e4", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "analyze_wildcard": true, 
+                                    "query": "*"
+                                }
+                            }
+                        }
+                    }
+                }, 
+                "title": "GC durations [Metricbeat Golang]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "expression": ".es(index=\"metricbeat*\",metric=\"max:golang.heap.gc.pause.sum.ns\").bars().label(\"sum of GC Pause durations(ns)\").yaxis(label=\"Durations(ns)\"),.es(index=\"metricbeat*\",metric=\"max:golang.heap.gc.total_pause.ns\").derivative().movingaverage(30).label(\"Total GC Pause(ns) Rate\"),.es(index=\"metricbeat*\",metric=\"max:golang.heap.gc.pause.max.ns\").label(\"Max GC Pause(ns)\").movingaverage(30),.es(index=\"metricbeat*\",metric=\"avg:golang.heap.gc.pause.avg.ns\").label(\"Avg GC Pause(ns)\").movingaverage(30),.es(index=\"metricbeat*\",metric=\"max:golang.heap.gc.pause.count\").condition(lt,1, null).label(\"GC Pause count\").points().yaxis(2,label=\"Count\")", 
+                        "interval": "10s"
+                    }, 
+                    "title": "GC durations [Metricbeat Golang]", 
+                    "type": "timelion"
+                }
+            }, 
+            "id": "ab226b50-f52a-11e6-969c-518c48c913e4", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "analyze_wildcard": true, 
+                                    "query": "*"
+                                }
+                            }
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false
+                }, 
+                "panelsJSON": [
+                    {
+                        "col": 1, 
+                        "id": "58000780-f529-11e6-844d-b170e2f0a07e", 
+                        "panelIndex": 8, 
+                        "row": 1, 
+                        "size_x": 12, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "95388680-f52a-11e6-969c-518c48c913e4", 
+                        "panelIndex": 9, 
+                        "row": 4, 
+                        "size_x": 4, 
+                        "size_y": 4, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 9, 
+                        "id": "b59a5200-f52a-11e6-969c-518c48c913e4", 
+                        "panelIndex": 10, 
+                        "row": 4, 
+                        "size_x": 4, 
+                        "size_y": 4, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 5, 
+                        "id": "9a9a8bf0-f52a-11e6-969c-518c48c913e4", 
+                        "panelIndex": 11, 
+                        "row": 4, 
+                        "size_x": 4, 
+                        "size_y": 4, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 7, 
+                        "id": "b046cb80-f52a-11e6-969c-518c48c913e4", 
+                        "panelIndex": 12, 
+                        "row": 8, 
+                        "size_x": 6, 
+                        "size_y": 4, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "ab226b50-f52a-11e6-969c-518c48c913e4", 
+                        "panelIndex": 13, 
+                        "row": 8, 
+                        "size_x": 6, 
+                        "size_y": 4, 
+                        "type": "visualization"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "[Metricbeat Golang] Overview", 
+                "uiStateJSON": {}, 
+                "version": 1
+            }, 
+            "id": "f2dc7320-f519-11e6-a3c9-9d1f7c42b045", 
+            "type": "dashboard", 
+            "version": 3
+        }
+    ], 
+    "version": "6.0.0-beta1-SNAPSHOT"
 }

--- a/metricbeat/module/haproxy/_meta/kibana/6/dashboard/Metricbeat-haproxy-backend.json
+++ b/metricbeat/module/haproxy/_meta/kibana/6/dashboard/Metricbeat-haproxy-backend.json
@@ -1,23 +1,114 @@
 {
-  "objects": [
-    {
-      "attributes": {
-        "description": "",
-        "hits": 0,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"language\":\"lucene\",\"query\":\"\"},\"filter\":[],\"highlightAll\":true,\"version\":true}"
-        },
-        "optionsJSON": "{\"darkTheme\":false,\"hidePanelTitles\":false,\"useMargins\":true}",
-        "panelsJSON": "[{\"panelIndex\":\"1\",\"gridData\":{\"x\":0,\"y\":0,\"w\":6,\"h\":2,\"i\":\"1\"},\"id\":\"a64b4fd0-471c-11e8-bc13-1397384faad3\",\"type\":\"visualization\",\"version\":\"6.2.2\"},{\"panelIndex\":\"2\",\"gridData\":{\"x\":6,\"y\":0,\"w\":3,\"h\":2,\"i\":\"2\"},\"id\":\"794b6cd0-471d-11e8-bc13-1397384faad3\",\"type\":\"visualization\",\"version\":\"6.2.2\"},{\"panelIndex\":\"3\",\"gridData\":{\"x\":6,\"y\":2,\"w\":6,\"h\":4,\"i\":\"3\"},\"id\":\"bb0ab500-4735-11e8-bc13-1397384faad3\",\"type\":\"visualization\",\"version\":\"6.2.2\"},{\"panelIndex\":\"4\",\"gridData\":{\"x\":9,\"y\":0,\"w\":3,\"h\":2,\"i\":\"4\"},\"id\":\"40bed190-473b-11e8-bc13-1397384faad3\",\"type\":\"visualization\",\"version\":\"6.2.2\"},{\"panelIndex\":\"5\",\"gridData\":{\"x\":0,\"y\":2,\"w\":6,\"h\":2,\"i\":\"5\"},\"id\":\"0751ed00-479c-11e8-bc13-1397384faad3\",\"type\":\"visualization\",\"version\":\"6.2.2\"},{\"panelIndex\":\"6\",\"gridData\":{\"x\":0,\"y\":4,\"w\":6,\"h\":2,\"i\":\"6\"},\"version\":\"6.2.2\",\"type\":\"visualization\",\"id\":\"b3463670-47a1-11e8-bc13-1397384faad3\"}]",
-        "timeRestore": false,
-        "title": "[Metricbeat Haproxy] Backend",
-        "version": 1
-      },
-      "id": "9151c900-471d-11e8-bc13-1397384faad3",
-      "type": "dashboard",
-      "updated_at": "2018-04-24T18:31:25.838Z",
-      "version": 15
-    }
-  ],
-  "version": "6.2.2"
+    "objects": [
+        {
+            "attributes": {
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "query": {
+                            "language": "lucene", 
+                            "query": ""
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false, 
+                    "hidePanelTitles": false, 
+                    "useMargins": true
+                }, 
+                "panelsJSON": [
+                    {
+                        "gridData": {
+                            "h": 2, 
+                            "i": "1", 
+                            "w": 6, 
+                            "x": 0, 
+                            "y": 0
+                        }, 
+                        "id": "a64b4fd0-471c-11e8-bc13-1397384faad3", 
+                        "panelIndex": "1", 
+                        "type": "visualization", 
+                        "version": "6.2.2"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 2, 
+                            "i": "2", 
+                            "w": 3, 
+                            "x": 6, 
+                            "y": 0
+                        }, 
+                        "id": "794b6cd0-471d-11e8-bc13-1397384faad3", 
+                        "panelIndex": "2", 
+                        "type": "visualization", 
+                        "version": "6.2.2"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 4, 
+                            "i": "3", 
+                            "w": 6, 
+                            "x": 6, 
+                            "y": 2
+                        }, 
+                        "id": "bb0ab500-4735-11e8-bc13-1397384faad3", 
+                        "panelIndex": "3", 
+                        "type": "visualization", 
+                        "version": "6.2.2"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 2, 
+                            "i": "4", 
+                            "w": 3, 
+                            "x": 9, 
+                            "y": 0
+                        }, 
+                        "id": "40bed190-473b-11e8-bc13-1397384faad3", 
+                        "panelIndex": "4", 
+                        "type": "visualization", 
+                        "version": "6.2.2"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 2, 
+                            "i": "5", 
+                            "w": 6, 
+                            "x": 0, 
+                            "y": 2
+                        }, 
+                        "id": "0751ed00-479c-11e8-bc13-1397384faad3", 
+                        "panelIndex": "5", 
+                        "type": "visualization", 
+                        "version": "6.2.2"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 2, 
+                            "i": "6", 
+                            "w": 6, 
+                            "x": 0, 
+                            "y": 4
+                        }, 
+                        "id": "b3463670-47a1-11e8-bc13-1397384faad3", 
+                        "panelIndex": "6", 
+                        "type": "visualization", 
+                        "version": "6.2.2"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "[Metricbeat Haproxy] Backend", 
+                "version": 1
+            }, 
+            "id": "9151c900-471d-11e8-bc13-1397384faad3", 
+            "type": "dashboard", 
+            "updated_at": "2018-04-24T18:31:25.838Z", 
+            "version": 15
+        }
+    ], 
+    "version": "6.2.2"
 }

--- a/metricbeat/module/haproxy/_meta/kibana/6/dashboard/Metricbeat-haproxy-frontend.json
+++ b/metricbeat/module/haproxy/_meta/kibana/6/dashboard/Metricbeat-haproxy-frontend.json
@@ -1,23 +1,62 @@
 {
-  "objects": [
-    {
-      "attributes": {
-        "description": "",
-        "hits": 0,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query\":\"\",\"language\":\"lucene\"},\"filter\":[],\"highlightAll\":true,\"version\":true}"
-        },
-        "optionsJSON": "{\"darkTheme\":false,\"useMargins\":true,\"hidePanelTitles\":false}",
-        "panelsJSON": "[{\"panelIndex\":\"2\",\"gridData\":{\"x\":0,\"y\":0,\"w\":6,\"h\":3,\"i\":\"2\"},\"version\":\"6.2.2\",\"type\":\"visualization\",\"id\":\"a64b4fd0-471c-11e8-bc13-1397384faad3\"},{\"panelIndex\":\"3\",\"gridData\":{\"x\":6,\"y\":0,\"w\":6,\"h\":3,\"i\":\"3\"},\"version\":\"6.2.2\",\"type\":\"visualization\",\"id\":\"86159190-47c5-11e8-bc13-1397384faad3\"}]",
-        "timeRestore": false,
-        "title": "[Metricbeat Haproxy] Frontend",
-        "version": 1
-      },
-      "id": "d5878d00-47c5-11e8-bc13-1397384faad3",
-      "type": "dashboard",
-      "updated_at": "2018-04-24T18:32:51.945Z",
-      "version": 5
-    }
-  ],
-  "version": "6.2.2"
+    "objects": [
+        {
+            "attributes": {
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "query": {
+                            "language": "lucene", 
+                            "query": ""
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false, 
+                    "hidePanelTitles": false, 
+                    "useMargins": true
+                }, 
+                "panelsJSON": [
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "2", 
+                            "w": 6, 
+                            "x": 0, 
+                            "y": 0
+                        }, 
+                        "id": "a64b4fd0-471c-11e8-bc13-1397384faad3", 
+                        "panelIndex": "2", 
+                        "type": "visualization", 
+                        "version": "6.2.2"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "3", 
+                            "w": 6, 
+                            "x": 6, 
+                            "y": 0
+                        }, 
+                        "id": "86159190-47c5-11e8-bc13-1397384faad3", 
+                        "panelIndex": "3", 
+                        "type": "visualization", 
+                        "version": "6.2.2"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "[Metricbeat Haproxy] Frontend", 
+                "version": 1
+            }, 
+            "id": "d5878d00-47c5-11e8-bc13-1397384faad3", 
+            "type": "dashboard", 
+            "updated_at": "2018-04-24T18:32:51.945Z", 
+            "version": 5
+        }
+    ], 
+    "version": "6.2.2"
 }

--- a/metricbeat/module/haproxy/_meta/kibana/6/dashboard/Metricbeat-haproxy-http-backend.json
+++ b/metricbeat/module/haproxy/_meta/kibana/6/dashboard/Metricbeat-haproxy-http-backend.json
@@ -1,23 +1,140 @@
 {
-  "objects": [
-    {
-      "attributes": {
-        "description": "",
-        "hits": 0,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"language\":\"lucene\",\"query\":\"\"},\"filter\":[],\"highlightAll\":true,\"version\":true}"
-        },
-        "optionsJSON": "{\"darkTheme\":false,\"hidePanelTitles\":false,\"useMargins\":true}",
-        "panelsJSON": "[{\"panelIndex\":\"1\",\"gridData\":{\"x\":0,\"y\":5,\"w\":4,\"h\":2,\"i\":\"1\"},\"id\":\"a64b4fd0-471c-11e8-bc13-1397384faad3\",\"type\":\"visualization\",\"version\":\"6.2.2\"},{\"panelIndex\":\"2\",\"gridData\":{\"x\":9,\"y\":0,\"w\":3,\"h\":2,\"i\":\"2\"},\"id\":\"794b6cd0-471d-11e8-bc13-1397384faad3\",\"type\":\"visualization\",\"version\":\"6.2.2\"},{\"panelIndex\":\"3\",\"gridData\":{\"x\":6,\"y\":2,\"w\":6,\"h\":3,\"i\":\"3\"},\"id\":\"bb0ab500-4735-11e8-bc13-1397384faad3\",\"type\":\"visualization\",\"version\":\"6.2.2\"},{\"panelIndex\":\"4\",\"gridData\":{\"x\":6,\"y\":0,\"w\":3,\"h\":2,\"i\":\"4\"},\"id\":\"40bed190-473b-11e8-bc13-1397384faad3\",\"type\":\"visualization\",\"version\":\"6.2.2\"},{\"panelIndex\":\"5\",\"gridData\":{\"x\":4,\"y\":5,\"w\":4,\"h\":2,\"i\":\"5\"},\"id\":\"0751ed00-479c-11e8-bc13-1397384faad3\",\"type\":\"visualization\",\"version\":\"6.2.2\"},{\"panelIndex\":\"6\",\"gridData\":{\"x\":8,\"y\":5,\"w\":4,\"h\":2,\"i\":\"6\"},\"id\":\"b3463670-47a1-11e8-bc13-1397384faad3\",\"type\":\"visualization\",\"version\":\"6.2.2\"},{\"panelIndex\":\"7\",\"gridData\":{\"x\":0,\"y\":0,\"w\":6,\"h\":3,\"i\":\"7\"},\"id\":\"fcbdfa60-47bd-11e8-bc13-1397384faad3\",\"type\":\"visualization\",\"version\":\"6.2.2\"},{\"panelIndex\":\"8\",\"gridData\":{\"x\":0,\"y\":3,\"w\":6,\"h\":2,\"i\":\"8\"},\"version\":\"6.2.2\",\"type\":\"visualization\",\"id\":\"981d1040-47be-11e8-bc13-1397384faad3\"}]",
-        "timeRestore": false,
-        "title": "[Metricbeat Haproxy] HTTP backend",
-        "version": 1
-      },
-      "id": "0836a4b0-47bd-11e8-bc13-1397384faad3",
-      "type": "dashboard",
-      "updated_at": "2018-04-24T18:33:28.791Z",
-      "version": 6
-    }
-  ],
-  "version": "6.2.2"
+    "objects": [
+        {
+            "attributes": {
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "query": {
+                            "language": "lucene", 
+                            "query": ""
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false, 
+                    "hidePanelTitles": false, 
+                    "useMargins": true
+                }, 
+                "panelsJSON": [
+                    {
+                        "gridData": {
+                            "h": 2, 
+                            "i": "1", 
+                            "w": 4, 
+                            "x": 0, 
+                            "y": 5
+                        }, 
+                        "id": "a64b4fd0-471c-11e8-bc13-1397384faad3", 
+                        "panelIndex": "1", 
+                        "type": "visualization", 
+                        "version": "6.2.2"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 2, 
+                            "i": "2", 
+                            "w": 3, 
+                            "x": 9, 
+                            "y": 0
+                        }, 
+                        "id": "794b6cd0-471d-11e8-bc13-1397384faad3", 
+                        "panelIndex": "2", 
+                        "type": "visualization", 
+                        "version": "6.2.2"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "3", 
+                            "w": 6, 
+                            "x": 6, 
+                            "y": 2
+                        }, 
+                        "id": "bb0ab500-4735-11e8-bc13-1397384faad3", 
+                        "panelIndex": "3", 
+                        "type": "visualization", 
+                        "version": "6.2.2"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 2, 
+                            "i": "4", 
+                            "w": 3, 
+                            "x": 6, 
+                            "y": 0
+                        }, 
+                        "id": "40bed190-473b-11e8-bc13-1397384faad3", 
+                        "panelIndex": "4", 
+                        "type": "visualization", 
+                        "version": "6.2.2"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 2, 
+                            "i": "5", 
+                            "w": 4, 
+                            "x": 4, 
+                            "y": 5
+                        }, 
+                        "id": "0751ed00-479c-11e8-bc13-1397384faad3", 
+                        "panelIndex": "5", 
+                        "type": "visualization", 
+                        "version": "6.2.2"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 2, 
+                            "i": "6", 
+                            "w": 4, 
+                            "x": 8, 
+                            "y": 5
+                        }, 
+                        "id": "b3463670-47a1-11e8-bc13-1397384faad3", 
+                        "panelIndex": "6", 
+                        "type": "visualization", 
+                        "version": "6.2.2"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "7", 
+                            "w": 6, 
+                            "x": 0, 
+                            "y": 0
+                        }, 
+                        "id": "fcbdfa60-47bd-11e8-bc13-1397384faad3", 
+                        "panelIndex": "7", 
+                        "type": "visualization", 
+                        "version": "6.2.2"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 2, 
+                            "i": "8", 
+                            "w": 6, 
+                            "x": 0, 
+                            "y": 3
+                        }, 
+                        "id": "981d1040-47be-11e8-bc13-1397384faad3", 
+                        "panelIndex": "8", 
+                        "type": "visualization", 
+                        "version": "6.2.2"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "[Metricbeat Haproxy] HTTP backend", 
+                "version": 1
+            }, 
+            "id": "0836a4b0-47bd-11e8-bc13-1397384faad3", 
+            "type": "dashboard", 
+            "updated_at": "2018-04-24T18:33:28.791Z", 
+            "version": 6
+        }
+    ], 
+    "version": "6.2.2"
 }

--- a/metricbeat/module/haproxy/_meta/kibana/6/dashboard/Metricbeat-haproxy-http-frontend.json
+++ b/metricbeat/module/haproxy/_meta/kibana/6/dashboard/Metricbeat-haproxy-http-frontend.json
@@ -1,23 +1,75 @@
 {
-  "objects": [
-    {
-      "attributes": {
-        "description": "",
-        "hits": 0,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"language\":\"lucene\",\"query\":\"\"},\"filter\":[],\"highlightAll\":true,\"version\":true}"
-        },
-        "optionsJSON": "{\"darkTheme\":false,\"hidePanelTitles\":false,\"useMargins\":true}",
-        "panelsJSON": "[{\"panelIndex\":\"3\",\"gridData\":{\"x\":6,\"y\":3,\"w\":6,\"h\":3,\"i\":\"3\"},\"id\":\"86159190-47c5-11e8-bc13-1397384faad3\",\"type\":\"visualization\",\"version\":\"6.2.2\"},{\"panelIndex\":\"4\",\"gridData\":{\"x\":0,\"y\":0,\"w\":12,\"h\":3,\"i\":\"4\"},\"id\":\"fcbdfa60-47bd-11e8-bc13-1397384faad3\",\"type\":\"visualization\",\"version\":\"6.2.2\"},{\"panelIndex\":\"5\",\"gridData\":{\"x\":0,\"y\":3,\"w\":6,\"h\":3,\"i\":\"5\"},\"version\":\"6.2.2\",\"type\":\"visualization\",\"id\":\"30956d00-47d7-11e8-bc13-1397384faad3\"}]",
-        "timeRestore": false,
-        "title": "[Metricbeat Haproxy] HTTP frontend",
-        "version": 1
-      },
-      "id": "e9057ae0-47c5-11e8-bc13-1397384faad3",
-      "type": "dashboard",
-      "updated_at": "2018-04-24T18:34:15.954Z",
-      "version": 5
-    }
-  ],
-  "version": "6.2.2"
+    "objects": [
+        {
+            "attributes": {
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "query": {
+                            "language": "lucene", 
+                            "query": ""
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false, 
+                    "hidePanelTitles": false, 
+                    "useMargins": true
+                }, 
+                "panelsJSON": [
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "3", 
+                            "w": 6, 
+                            "x": 6, 
+                            "y": 3
+                        }, 
+                        "id": "86159190-47c5-11e8-bc13-1397384faad3", 
+                        "panelIndex": "3", 
+                        "type": "visualization", 
+                        "version": "6.2.2"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "4", 
+                            "w": 12, 
+                            "x": 0, 
+                            "y": 0
+                        }, 
+                        "id": "fcbdfa60-47bd-11e8-bc13-1397384faad3", 
+                        "panelIndex": "4", 
+                        "type": "visualization", 
+                        "version": "6.2.2"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "5", 
+                            "w": 6, 
+                            "x": 0, 
+                            "y": 3
+                        }, 
+                        "id": "30956d00-47d7-11e8-bc13-1397384faad3", 
+                        "panelIndex": "5", 
+                        "type": "visualization", 
+                        "version": "6.2.2"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "[Metricbeat Haproxy] HTTP frontend", 
+                "version": 1
+            }, 
+            "id": "e9057ae0-47c5-11e8-bc13-1397384faad3", 
+            "type": "dashboard", 
+            "updated_at": "2018-04-24T18:34:15.954Z", 
+            "version": 5
+        }
+    ], 
+    "version": "6.2.2"
 }

--- a/metricbeat/module/haproxy/_meta/kibana/6/dashboard/Metricbeat-haproxy-http-server.json
+++ b/metricbeat/module/haproxy/_meta/kibana/6/dashboard/Metricbeat-haproxy-http-server.json
@@ -1,23 +1,114 @@
 {
-  "objects": [
-    {
-      "attributes": {
-        "description": "",
-        "hits": 0,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"language\":\"lucene\",\"query\":\"haproxy.stat.service_name:\\\"nginx2\\\"\"},\"filter\":[],\"highlightAll\":true,\"version\":true}"
-        },
-        "optionsJSON": "{\"darkTheme\":false,\"hidePanelTitles\":false,\"useMargins\":true}",
-        "panelsJSON": "[{\"panelIndex\":\"5\",\"gridData\":{\"x\":0,\"y\":5,\"w\":6,\"h\":2,\"i\":\"5\"},\"id\":\"0751ed00-479c-11e8-bc13-1397384faad3\",\"type\":\"visualization\",\"version\":\"6.2.2\"},{\"panelIndex\":\"6\",\"gridData\":{\"x\":6,\"y\":3,\"w\":6,\"h\":2,\"i\":\"6\"},\"id\":\"b3463670-47a1-11e8-bc13-1397384faad3\",\"type\":\"visualization\",\"version\":\"6.2.2\"},{\"panelIndex\":\"7\",\"gridData\":{\"x\":0,\"y\":0,\"w\":6,\"h\":3,\"i\":\"7\"},\"id\":\"fcbdfa60-47bd-11e8-bc13-1397384faad3\",\"type\":\"visualization\",\"version\":\"6.2.2\"},{\"panelIndex\":\"8\",\"gridData\":{\"x\":0,\"y\":3,\"w\":6,\"h\":2,\"i\":\"8\"},\"id\":\"981d1040-47be-11e8-bc13-1397384faad3\",\"type\":\"visualization\",\"version\":\"6.2.2\"},{\"panelIndex\":\"10\",\"gridData\":{\"x\":6,\"y\":0,\"w\":6,\"h\":3,\"i\":\"10\"},\"id\":\"72e84b00-47e1-11e8-bc13-1397384faad3\",\"type\":\"visualization\",\"version\":\"6.2.2\"},{\"panelIndex\":\"11\",\"gridData\":{\"x\":6,\"y\":5,\"w\":6,\"h\":2,\"i\":\"11\"},\"version\":\"6.2.2\",\"type\":\"visualization\",\"id\":\"976b0910-47e4-11e8-bc13-1397384faad3\"}]",
-        "timeRestore": false,
-        "title": "[Metricbeat Haproxy] HTTP server",
-        "version": 1
-      },
-      "id": "8cc50a50-47e0-11e8-bc13-1397384faad3",
-      "type": "dashboard",
-      "updated_at": "2018-04-24T18:34:50.803Z",
-      "version": 9
-    }
-  ],
-  "version": "6.2.2"
+    "objects": [
+        {
+            "attributes": {
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "query": {
+                            "language": "lucene", 
+                            "query": "haproxy.stat.service_name:\"nginx2\""
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false, 
+                    "hidePanelTitles": false, 
+                    "useMargins": true
+                }, 
+                "panelsJSON": [
+                    {
+                        "gridData": {
+                            "h": 2, 
+                            "i": "5", 
+                            "w": 6, 
+                            "x": 0, 
+                            "y": 5
+                        }, 
+                        "id": "0751ed00-479c-11e8-bc13-1397384faad3", 
+                        "panelIndex": "5", 
+                        "type": "visualization", 
+                        "version": "6.2.2"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 2, 
+                            "i": "6", 
+                            "w": 6, 
+                            "x": 6, 
+                            "y": 3
+                        }, 
+                        "id": "b3463670-47a1-11e8-bc13-1397384faad3", 
+                        "panelIndex": "6", 
+                        "type": "visualization", 
+                        "version": "6.2.2"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "7", 
+                            "w": 6, 
+                            "x": 0, 
+                            "y": 0
+                        }, 
+                        "id": "fcbdfa60-47bd-11e8-bc13-1397384faad3", 
+                        "panelIndex": "7", 
+                        "type": "visualization", 
+                        "version": "6.2.2"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 2, 
+                            "i": "8", 
+                            "w": 6, 
+                            "x": 0, 
+                            "y": 3
+                        }, 
+                        "id": "981d1040-47be-11e8-bc13-1397384faad3", 
+                        "panelIndex": "8", 
+                        "type": "visualization", 
+                        "version": "6.2.2"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "10", 
+                            "w": 6, 
+                            "x": 6, 
+                            "y": 0
+                        }, 
+                        "id": "72e84b00-47e1-11e8-bc13-1397384faad3", 
+                        "panelIndex": "10", 
+                        "type": "visualization", 
+                        "version": "6.2.2"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 2, 
+                            "i": "11", 
+                            "w": 6, 
+                            "x": 6, 
+                            "y": 5
+                        }, 
+                        "id": "976b0910-47e4-11e8-bc13-1397384faad3", 
+                        "panelIndex": "11", 
+                        "type": "visualization", 
+                        "version": "6.2.2"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "[Metricbeat Haproxy] HTTP server", 
+                "version": 1
+            }, 
+            "id": "8cc50a50-47e0-11e8-bc13-1397384faad3", 
+            "type": "dashboard", 
+            "updated_at": "2018-04-24T18:34:50.803Z", 
+            "version": 9
+        }
+    ], 
+    "version": "6.2.2"
 }

--- a/metricbeat/module/haproxy/_meta/kibana/6/dashboard/Metricbeat-haproxy-overview.json
+++ b/metricbeat/module/haproxy/_meta/kibana/6/dashboard/Metricbeat-haproxy-overview.json
@@ -1,23 +1,91 @@
 {
-  "objects": [
-    {
-      "attributes": {
-        "description": "",
-        "hits": 0,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"language\":\"lucene\",\"query\":\"\"},\"filter\":[],\"highlightAll\":true,\"version\":true}"
-        },
-        "optionsJSON": "{\"darkTheme\":false,\"hidePanelTitles\":false,\"useMargins\":true}",
-        "panelsJSON": "[{\"panelIndex\":\"2\",\"gridData\":{\"x\":8,\"y\":2,\"w\":4,\"h\":6,\"i\":\"2\"},\"id\":\"79350d50-47db-11e8-bc13-1397384faad3\",\"title\":\"Servers\",\"type\":\"visualization\",\"version\":\"6.2.2\"},{\"panelIndex\":\"3\",\"gridData\":{\"x\":4,\"y\":2,\"w\":4,\"h\":6,\"i\":\"3\"},\"id\":\"8c8f0300-47dc-11e8-bc13-1397384faad3\",\"title\":\"Backends\",\"type\":\"visualization\",\"version\":\"6.2.2\"},{\"panelIndex\":\"4\",\"gridData\":{\"x\":0,\"y\":2,\"w\":4,\"h\":6,\"i\":\"4\"},\"id\":\"f1e27ed0-47dc-11e8-bc13-1397384faad3\",\"title\":\"Frontends\",\"type\":\"visualization\",\"version\":\"6.2.2\"},{\"panelIndex\":\"5\",\"gridData\":{\"x\":0,\"y\":0,\"w\":12,\"h\":2,\"i\":\"5\"},\"version\":\"6.2.2\",\"type\":\"visualization\",\"id\":\"a64b4fd0-471c-11e8-bc13-1397384faad3\"}]",
-        "timeRestore": false,
-        "title": "[Metricbeat Haproxy] Overview",
-        "version": 1
-      },
-      "id": "4b555c30-47dd-11e8-bc13-1397384faad3",
-      "type": "dashboard",
-      "updated_at": "2018-04-24T18:31:56.356Z",
-      "version": 3
-    }
-  ],
-  "version": "6.2.2"
+    "objects": [
+        {
+            "attributes": {
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "query": {
+                            "language": "lucene", 
+                            "query": ""
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false, 
+                    "hidePanelTitles": false, 
+                    "useMargins": true
+                }, 
+                "panelsJSON": [
+                    {
+                        "gridData": {
+                            "h": 6, 
+                            "i": "2", 
+                            "w": 4, 
+                            "x": 8, 
+                            "y": 2
+                        }, 
+                        "id": "79350d50-47db-11e8-bc13-1397384faad3", 
+                        "panelIndex": "2", 
+                        "title": "Servers", 
+                        "type": "visualization", 
+                        "version": "6.2.2"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 6, 
+                            "i": "3", 
+                            "w": 4, 
+                            "x": 4, 
+                            "y": 2
+                        }, 
+                        "id": "8c8f0300-47dc-11e8-bc13-1397384faad3", 
+                        "panelIndex": "3", 
+                        "title": "Backends", 
+                        "type": "visualization", 
+                        "version": "6.2.2"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 6, 
+                            "i": "4", 
+                            "w": 4, 
+                            "x": 0, 
+                            "y": 2
+                        }, 
+                        "id": "f1e27ed0-47dc-11e8-bc13-1397384faad3", 
+                        "panelIndex": "4", 
+                        "title": "Frontends", 
+                        "type": "visualization", 
+                        "version": "6.2.2"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 2, 
+                            "i": "5", 
+                            "w": 12, 
+                            "x": 0, 
+                            "y": 0
+                        }, 
+                        "id": "a64b4fd0-471c-11e8-bc13-1397384faad3", 
+                        "panelIndex": "5", 
+                        "type": "visualization", 
+                        "version": "6.2.2"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "[Metricbeat Haproxy] Overview", 
+                "version": 1
+            }, 
+            "id": "4b555c30-47dd-11e8-bc13-1397384faad3", 
+            "type": "dashboard", 
+            "updated_at": "2018-04-24T18:31:56.356Z", 
+            "version": 3
+        }
+    ], 
+    "version": "6.2.2"
 }

--- a/metricbeat/module/haproxy/_meta/kibana/6/dashboard/Metricbeat-haproxy-visualizations.json
+++ b/metricbeat/module/haproxy/_meta/kibana/6/dashboard/Metricbeat-haproxy-visualizations.json
@@ -1,245 +1,1341 @@
 {
-  "objects": [
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{}"
-        },
-        "title": "Connections [Metricbeat Haproxy]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Haproxy connections\",\"type\":\"metrics\",\"params\":{\"axis_formatter\":\"number\",\"axis_position\":\"left\",\"background_color_rules\":[{\"id\":\"4e35d500-471b-11e8-a520-3f46123ab5eb\"}],\"bar_color_rules\":[{\"id\":\"69899960-4719-11e8-a520-3f46123ab5eb\"}],\"filter\":\"haproxy.stat.component_type:(0 OR 1)\",\"gauge_color_rules\":[{\"id\":\"6f171ba0-4719-11e8-a520-3f46123ab5eb\"}],\"gauge_inner_width\":10,\"gauge_style\":\"half\",\"gauge_width\":10,\"id\":\"61ca57f0-469d-11e7-af02-69e470af7417\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"\",\"series\":[{\"axis_position\":\"right\",\"chart_type\":\"line\",\"color\":\"#68BC00\",\"fill\":0.5,\"filter\":\"\",\"formatter\":\"number\",\"id\":\"61ca57f1-469d-11e7-af02-69e470af7417\",\"label\":\"Number of connections\",\"line_width\":1,\"metrics\":[{\"field\":\"haproxy.stat.connection.total\",\"id\":\"61ca57f2-469d-11e7-af02-69e470af7417\",\"type\":\"sum\"},{\"field\":\"61ca57f2-469d-11e7-af02-69e470af7417\",\"id\":\"41ff3940-4719-11e8-a520-3f46123ab5eb\",\"type\":\"derivative\",\"unit\":\"\"},{\"unit\":\"\",\"id\":\"456a5fa0-4738-11e8-8633-8f8b3acf1566\",\"type\":\"positive_only\",\"field\":\"41ff3940-4719-11e8-a520-3f46123ab5eb\"}],\"point_size\":1,\"seperate_axis\":0,\"series_drop_last_bucket\":1,\"split_color_mode\":\"rainbow\",\"split_filters\":[{\"color\":\"#68BC00\",\"id\":\"0ceb7740-471a-11e8-a520-3f46123ab5eb\"}],\"split_mode\":\"terms\",\"stacked\":\"none\",\"terms_field\":\"haproxy.stat.proxy.name\"}],\"show_grid\":1,\"show_legend\":1,\"time_field\":\"@timestamp\",\"type\":\"timeseries\"},\"aggs\":[]}"
-      },
-      "id": "a64b4fd0-471c-11e8-bc13-1397384faad3",
-      "type": "visualization",
-      "updated_at": "2018-04-23T20:54:01.082Z",
-      "version": 3
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{}"
-        },
-        "title": "Active servers in backend [Metricbeat Haproxy]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Haproxy active servers in backend\",\"type\":\"metrics\",\"params\":{\"axis_formatter\":\"number\",\"axis_position\":\"left\",\"background_color_rules\":[{\"value\":0,\"color\":\"rgba(255,0,6,1)\",\"id\":\"1ec0dde0-471d-11e8-9876-09cc6c85f5f2\",\"opperator\":\"lte\"}],\"bar_color_rules\":[{\"id\":\"297160c0-471d-11e8-9876-09cc6c85f5f2\"}],\"filter\":\"haproxy.stat.component_type:(2 OR 3)\",\"gauge_color_rules\":[{\"gauge\":\"rgba(255,0,5,1)\",\"id\":\"4ce156a0-471d-11e8-9876-09cc6c85f5f2\",\"opperator\":\"lte\",\"text\":null,\"value\":0},{\"gauge\":\"rgba(255,196,0,1)\",\"id\":\"f8458a80-4721-11e8-b854-2f6d2b452362\",\"opperator\":\"lte\",\"value\":0.5}],\"gauge_inner_width\":10,\"gauge_max\":\"1\",\"gauge_style\":\"half\",\"gauge_width\":10,\"id\":\"61ca57f0-469d-11e7-af02-69e470af7417\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"series\":[{\"axis_position\":\"right\",\"chart_type\":\"line\",\"color\":\"#68BC00\",\"fill\":0.5,\"formatter\":\"number\",\"id\":\"61ca57f1-469d-11e7-af02-69e470af7417\",\"label\":\"Active servers\",\"line_width\":1,\"metrics\":[{\"denominator\":\"*\",\"field\":\"haproxy.stat.server.id\",\"id\":\"b754d060-471e-11e8-9876-09cc6c85f5f2\",\"metric_agg\":\"count\",\"numerator\":\"*\",\"script\":\"params.up / (params.down + params.up)\",\"type\":\"cardinality\",\"variables\":[{\"field\":\"61ca57f2-469d-11e7-af02-69e470af7417\",\"id\":\"cfd51780-471e-11e8-9d35-6baabcdce3dc\",\"name\":\"down\"},{\"field\":\"a049c420-471e-11e8-9876-09cc6c85f5f2\",\"id\":\"45e6ec00-471f-11e8-9d35-6baabcdce3dc\",\"name\":\"up\"}]}],\"point_size\":1,\"seperate_axis\":0,\"split_mode\":\"everything\",\"stacked\":\"none\",\"terms_field\":\"haproxy.stat.proxy.name\",\"filter\":\"haproxy.stat.status:UP\"},{\"id\":\"2cba9420-4724-11e8-b854-2f6d2b452362\",\"color\":\"#68BC00\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"2cba9421-4724-11e8-b854-2f6d2b452362\",\"type\":\"cardinality\",\"field\":\"haproxy.stat.server.id\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"label\":\"Total servers\"}],\"show_grid\":1,\"show_legend\":1,\"time_field\":\"@timestamp\",\"type\":\"metric\"},\"aggs\":[]}"
-      },
-      "id": "794b6cd0-471d-11e8-bc13-1397384faad3",
-      "type": "visualization",
-      "updated_at": "2018-04-23T21:36:57.634Z",
-      "version": 8
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{}"
-        },
-        "title": "Connections per server [Metricbeat Haproxy]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Haproxy connections per server\",\"type\":\"metrics\",\"params\":{\"id\":\"61ca57f0-469d-11e7-af02-69e470af7417\",\"type\":\"top_n\",\"series\":[{\"id\":\"61ca57f1-469d-11e7-af02-69e470af7417\",\"color\":\"#68BC00\",\"split_mode\":\"terms\",\"metrics\":[{\"id\":\"61ca57f2-469d-11e7-af02-69e470af7417\",\"type\":\"avg\",\"field\":\"haproxy.stat.connection.total\"},{\"unit\":\"\",\"id\":\"3ea29000-4735-11e8-b619-8f82b8185e96\",\"type\":\"derivative\",\"field\":\"61ca57f2-469d-11e7-af02-69e470af7417\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"terms_field\":\"haproxy.stat.service_name\",\"label\":\"Connections per server\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"show_legend\":1,\"show_grid\":1,\"filter\":\"haproxy.stat.component_type:(2 OR 3)\",\"bar_color_rules\":[{\"id\":\"978f2660-4735-11e8-b619-8f82b8185e96\"}],\"drilldown_url\":\"../app/kibana#/dashboard/8cc50a50-47e0-11e8-bc13-1397384faad3?_a=(query:(language:lucene,query:'haproxy.stat.service_name:\\\"{{ key }}\\\"'))\"},\"aggs\":[]}"
-      },
-      "id": "bb0ab500-4735-11e8-bc13-1397384faad3",
-      "type": "visualization",
-      "updated_at": "2018-04-24T17:12:35.298Z",
-      "version": 3
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{}"
-        },
-        "title": "Downtime seconds [Metricbeat Haproxy]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Haproxy downtime seconds\",\"type\":\"metrics\",\"params\":{\"axis_formatter\":\"number\",\"axis_position\":\"left\",\"id\":\"61ca57f0-469d-11e7-af02-69e470af7417\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"series\":[{\"axis_position\":\"right\",\"chart_type\":\"line\",\"color\":\"rgba(255,0,0,1)\",\"fill\":0.5,\"formatter\":\"number\",\"id\":\"61ca57f1-469d-11e7-af02-69e470af7417\",\"label\":\"Downtime\",\"line_width\":1,\"metrics\":[{\"field\":\"haproxy.stat.downtime\",\"id\":\"61ca57f2-469d-11e7-af02-69e470af7417\",\"type\":\"avg\"},{\"unit\":\"\",\"id\":\"91aa6a20-473a-11e8-8953-55bbe33e1362\",\"type\":\"derivative\",\"field\":\"61ca57f2-469d-11e7-af02-69e470af7417\"},{\"sigma\":\"\",\"id\":\"a8ce7ca0-473a-11e8-8953-55bbe33e1362\",\"type\":\"sum_bucket\",\"field\":\"91aa6a20-473a-11e8-8953-55bbe33e1362\"}],\"point_size\":1,\"seperate_axis\":0,\"split_mode\":\"terms\",\"stacked\":\"none\",\"terms_field\":\"haproxy.stat.proxy.name\",\"value_template\":\"{{value}}s\"}],\"show_grid\":1,\"show_legend\":1,\"time_field\":\"@timestamp\",\"type\":\"metric\",\"filter\":\"haproxy.stat.component_type:1\",\"background_color_rules\":[{\"id\":\"c86b8e00-4739-11e8-8953-55bbe33e1362\"}]},\"aggs\":[]}"
-      },
-      "id": "40bed190-473b-11e8-bc13-1397384faad3",
-      "type": "visualization",
-      "updated_at": "2018-04-23T21:29:04.708Z",
-      "version": 3
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{}"
-        },
-        "title": "Average time in queue [Metricbeat Haproxy]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Haproxy average time in queue\",\"type\":\"metrics\",\"params\":{\"id\":\"61ca57f0-469d-11e7-af02-69e470af7417\",\"type\":\"timeseries\",\"series\":[{\"id\":\"61ca57f1-469d-11e7-af02-69e470af7417\",\"color\":\"#68BC00\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"61ca57f2-469d-11e7-af02-69e470af7417\",\"type\":\"avg\",\"field\":\"haproxy.stat.queue.time.avg\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"label\":\"Average time in queue\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"show_legend\":1,\"show_grid\":1},\"aggs\":[]}"
-      },
-      "id": "b3463670-47a1-11e8-bc13-1397384faad3",
-      "type": "visualization",
-      "updated_at": "2018-04-24T09:27:25.783Z",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{}"
-        },
-        "title": "Traffic volume [Metricbeat Haproxy]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Haproxy traffic volume\",\"type\":\"metrics\",\"params\":{\"axis_formatter\":\"number\",\"axis_position\":\"left\",\"id\":\"61ca57f0-469d-11e7-af02-69e470af7417\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"\",\"series\":[{\"axis_position\":\"right\",\"chart_type\":\"line\",\"color\":\"rgba(164,221,0,1)\",\"fill\":\"0.5\",\"formatter\":\"bytes\",\"id\":\"61ca57f1-469d-11e7-af02-69e470af7417\",\"label\":\"Incoming\",\"line_width\":\"1\",\"metrics\":[{\"field\":\"haproxy.stat.in.bytes\",\"id\":\"61ca57f2-469d-11e7-af02-69e470af7417\",\"type\":\"sum\"},{\"unit\":\"\",\"id\":\"9814c420-47c4-11e8-994c-81d2daeb7c86\",\"type\":\"derivative\",\"field\":\"61ca57f2-469d-11e7-af02-69e470af7417\"}],\"point_size\":\"1\",\"seperate_axis\":0,\"split_mode\":\"everything\",\"stacked\":\"none\"},{\"axis_position\":\"right\",\"chart_type\":\"line\",\"color\":\"rgba(25,77,51,1)\",\"fill\":\"0.5\",\"formatter\":\"bytes\",\"id\":\"c89d1520-47c4-11e8-994c-81d2daeb7c86\",\"label\":\"Outgoing\",\"line_width\":\"1\",\"metrics\":[{\"field\":\"haproxy.stat.out.bytes\",\"id\":\"c89d6340-47c4-11e8-994c-81d2daeb7c86\",\"type\":\"sum\"},{\"unit\":\"\",\"id\":\"c89d6341-47c4-11e8-994c-81d2daeb7c86\",\"type\":\"derivative\",\"field\":\"c89d6340-47c4-11e8-994c-81d2daeb7c86\"}],\"point_size\":\"1\",\"seperate_axis\":0,\"split_mode\":\"everything\",\"stacked\":\"none\",\"override_index_pattern\":0}],\"show_grid\":1,\"show_legend\":1,\"time_field\":\"@timestamp\",\"type\":\"timeseries\"},\"aggs\":[]}"
-      },
-      "id": "86159190-47c5-11e8-bc13-1397384faad3",
-      "type": "visualization",
-      "updated_at": "2018-04-24T14:43:27.616Z",
-      "version": 3
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{}"
-        },
-        "title": "HTTP response codes [Metricbeat Haproxy]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Haproxy HTTP response codes\",\"type\":\"metrics\",\"params\":{\"id\":\"61ca57f0-469d-11e7-af02-69e470af7417\",\"type\":\"timeseries\",\"series\":[{\"id\":\"61ca57f1-469d-11e7-af02-69e470af7417\",\"color\":\"#68BC00\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"61ca57f2-469d-11e7-af02-69e470af7417\",\"type\":\"sum\",\"field\":\"haproxy.stat.response.http.2xx\"},{\"unit\":\"\",\"id\":\"973a6de0-47bd-11e8-b7ab-dff70b15977c\",\"type\":\"derivative\",\"field\":\"61ca57f2-469d-11e7-af02-69e470af7417\"},{\"unit\":\"\",\"id\":\"4971d580-47e5-11e8-b45e-f10c3845381c\",\"type\":\"positive_only\",\"field\":\"973a6de0-47bd-11e8-b7ab-dff70b15977c\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"label\":\"200s\"},{\"id\":\"aafd05e0-47bd-11e8-b7ab-dff70b15977c\",\"color\":\"rgba(64,240,0,1)\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"aafd05e1-47bd-11e8-b7ab-dff70b15977c\",\"type\":\"sum\",\"field\":\"haproxy.stat.response.http.3xx\"},{\"unit\":\"\",\"id\":\"aafd05e2-47bd-11e8-b7ab-dff70b15977c\",\"type\":\"derivative\",\"field\":\"aafd05e1-47bd-11e8-b7ab-dff70b15977c\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"label\":\"300s\"},{\"id\":\"c77191a0-47bd-11e8-b7ab-dff70b15977c\",\"color\":\"rgba(255,246,0,1)\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"c77191a1-47bd-11e8-b7ab-dff70b15977c\",\"type\":\"sum\",\"field\":\"haproxy.stat.response.http.4xx\"},{\"unit\":\"\",\"id\":\"c77191a2-47bd-11e8-b7ab-dff70b15977c\",\"type\":\"derivative\",\"field\":\"c77191a1-47bd-11e8-b7ab-dff70b15977c\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"label\":\"400s\"},{\"id\":\"d574e900-47bd-11e8-b7ab-dff70b15977c\",\"color\":\"rgba(255,0,4,1)\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"d574e901-47bd-11e8-b7ab-dff70b15977c\",\"type\":\"sum\",\"field\":\"haproxy.stat.response.http.5xx\"},{\"unit\":\"\",\"id\":\"d5753720-47bd-11e8-b7ab-dff70b15977c\",\"type\":\"derivative\",\"field\":\"d574e901-47bd-11e8-b7ab-dff70b15977c\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"label\":\"500s\"},{\"id\":\"e3b8a4c0-47bd-11e8-b7ab-dff70b15977c\",\"color\":\"rgba(0,251,255,1)\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"e3b8a4c1-47bd-11e8-b7ab-dff70b15977c\",\"type\":\"sum\",\"field\":\"haproxy.stat.response.http.other\"},{\"unit\":\"\",\"id\":\"e3b8a4c2-47bd-11e8-b7ab-dff70b15977c\",\"type\":\"derivative\",\"field\":\"e3b8a4c1-47bd-11e8-b7ab-dff70b15977c\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"label\":\"Other\"},{\"id\":\"f9217d40-47be-11e8-b7ab-dff70b15977c\",\"color\":\"rgba(15,20,25,1)\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"f9217d41-47be-11e8-b7ab-dff70b15977c\",\"type\":\"sum\",\"field\":\"haproxy.stat.response.errors\"},{\"unit\":\"\",\"id\":\"1b7d4400-47bf-11e8-b7ab-dff70b15977c\",\"type\":\"derivative\",\"field\":\"f9217d41-47be-11e8-b7ab-dff70b15977c\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"label\":\"Response errors\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"show_legend\":1,\"show_grid\":1},\"aggs\":[]}"
-      },
-      "id": "fcbdfa60-47bd-11e8-bc13-1397384faad3",
-      "type": "visualization",
-      "updated_at": "2018-04-24T17:31:30.169Z",
-      "version": 4
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{}"
-        },
-        "title": "Average response time [Metricbeat Haproxy]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Haproxy average response time\",\"type\":\"metrics\",\"params\":{\"id\":\"61ca57f0-469d-11e7-af02-69e470af7417\",\"type\":\"timeseries\",\"series\":[{\"id\":\"61ca57f1-469d-11e7-af02-69e470af7417\",\"color\":\"#68BC00\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"61ca57f2-469d-11e7-af02-69e470af7417\",\"type\":\"avg\",\"field\":\"haproxy.stat.response.time.avg\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"s,ms,0\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"label\":\"Average response time\",\"value_template\":\"{{value}}ms\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"show_legend\":1,\"show_grid\":1},\"aggs\":[]}"
-      },
-      "id": "981d1040-47be-11e8-bc13-1397384faad3",
-      "type": "visualization",
-      "updated_at": "2018-04-24T13:01:49.811Z",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{}"
-        },
-        "title": "Requests [Metricbeat Haproxy]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Haproxy requests\",\"type\":\"metrics\",\"params\":{\"id\":\"61ca57f0-469d-11e7-af02-69e470af7417\",\"type\":\"timeseries\",\"series\":[{\"id\":\"61ca57f1-469d-11e7-af02-69e470af7417\",\"color\":\"#68BC00\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"61ca57f2-469d-11e7-af02-69e470af7417\",\"type\":\"max\",\"field\":\"haproxy.stat.request.total\"},{\"unit\":\"\",\"id\":\"ad38e2c0-47d6-11e8-994c-81d2daeb7c86\",\"type\":\"derivative\",\"field\":\"61ca57f2-469d-11e7-af02-69e470af7417\"},{\"unit\":\"\",\"id\":\"b1ca03a0-47d6-11e8-994c-81d2daeb7c86\",\"type\":\"positive_only\",\"field\":\"ad38e2c0-47d6-11e8-994c-81d2daeb7c86\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"label\":\"Requests\"},{\"id\":\"c2f30500-47d6-11e8-994c-81d2daeb7c86\",\"color\":\"rgba(255,0,0,1)\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"c2f30501-47d6-11e8-994c-81d2daeb7c86\",\"type\":\"max\",\"field\":\"haproxy.stat.request.errors\"},{\"unit\":\"\",\"id\":\"c2f30502-47d6-11e8-994c-81d2daeb7c86\",\"type\":\"derivative\",\"field\":\"c2f30501-47d6-11e8-994c-81d2daeb7c86\"},{\"unit\":\"\",\"id\":\"c2f30503-47d6-11e8-994c-81d2daeb7c86\",\"type\":\"positive_only\",\"field\":\"c2f30502-47d6-11e8-994c-81d2daeb7c86\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"label\":\"Request errors\"},{\"id\":\"11968ce0-47d7-11e8-994c-81d2daeb7c86\",\"color\":\"rgba(0,0,0,1)\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"11968ce1-47d7-11e8-994c-81d2daeb7c86\",\"type\":\"max\",\"field\":\"haproxy.stat.request.denied\"},{\"unit\":\"\",\"id\":\"11968ce2-47d7-11e8-994c-81d2daeb7c86\",\"type\":\"derivative\",\"field\":\"11968ce1-47d7-11e8-994c-81d2daeb7c86\"},{\"unit\":\"\",\"id\":\"11968ce3-47d7-11e8-994c-81d2daeb7c86\",\"type\":\"positive_only\",\"field\":\"11968ce2-47d7-11e8-994c-81d2daeb7c86\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"label\":\"Denied requests\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"show_legend\":1,\"show_grid\":1},\"aggs\":[]}"
-      },
-      "id": "30956d00-47d7-11e8-bc13-1397384faad3",
-      "type": "visualization",
-      "updated_at": "2018-04-24T15:50:19.344Z",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{}"
-        },
-        "title": "Average connection time [Metricbeat Haproxy]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Haproxy average connection time\",\"type\":\"metrics\",\"params\":{\"id\":\"61ca57f0-469d-11e7-af02-69e470af7417\",\"type\":\"timeseries\",\"series\":[{\"id\":\"61ca57f1-469d-11e7-af02-69e470af7417\",\"color\":\"#68BC00\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"61ca57f2-469d-11e7-af02-69e470af7417\",\"type\":\"percentile\",\"field\":\"haproxy.stat.connection.time.avg\",\"percentiles\":[{\"value\":\"99\",\"percentile\":\"\",\"shade\":0.2,\"id\":\"9fa517e0-479b-11e8-9590-e34c5ed2dd95\",\"mode\":\"line\"},{\"value\":\"90\",\"percentile\":\"\",\"shade\":0.2,\"id\":\"daafd6e0-479b-11e8-9590-e34c5ed2dd95\",\"mode\":\"line\"},{\"value\":\"50\",\"percentile\":\"\",\"shade\":0.2,\"id\":\"e006b8c0-479b-11e8-9590-e34c5ed2dd95\",\"mode\":\"line\"}]}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":\"1\",\"point_size\":1,\"fill\":\"0.1\",\"stacked\":\"none\",\"terms_field\":\"haproxy.stat.service_name\",\"label\":\"Percentile\",\"split_color_mode\":\"gradient\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"show_legend\":1,\"show_grid\":1},\"aggs\":[]}"
-      },
-      "id": "0751ed00-479c-11e8-bc13-1397384faad3",
-      "type": "visualization",
-      "updated_at": "2018-04-24T08:51:34.252Z",
-      "version": 4
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{}"
-        },
-        "title": "Number of server connections [Metricbeat Haproxy]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Haproxy number of server connections\",\"type\":\"metrics\",\"params\":{\"id\":\"61ca57f0-469d-11e7-af02-69e470af7417\",\"type\":\"timeseries\",\"series\":[{\"id\":\"61ca57f1-469d-11e7-af02-69e470af7417\",\"color\":\"#68BC00\",\"split_mode\":\"terms\",\"metrics\":[{\"id\":\"61ca57f2-469d-11e7-af02-69e470af7417\",\"type\":\"sum\",\"field\":\"haproxy.stat.connection.total\"},{\"unit\":\"\",\"id\":\"22668d40-47e1-11e8-96ee-d767c73d008a\",\"type\":\"derivative\",\"field\":\"61ca57f2-469d-11e7-af02-69e470af7417\"},{\"unit\":\"\",\"id\":\"2a1d0a00-47e1-11e8-96ee-d767c73d008a\",\"type\":\"positive_only\",\"field\":\"22668d40-47e1-11e8-96ee-d767c73d008a\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"label\":\"Number of connections\",\"terms_field\":\"haproxy.stat.service_name\",\"filter\":\"haproxy.stat.component_type:(2 OR 3)\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"show_legend\":1,\"show_grid\":1},\"aggs\":[]}"
-      },
-      "id": "72e84b00-47e1-11e8-bc13-1397384faad3",
-      "type": "visualization",
-      "updated_at": "2018-04-24T17:05:00.128Z",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{}"
-        },
-        "title": "Healthcheck [Metricbeat Haproxy]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Haproxy healthcheck\",\"type\":\"metrics\",\"params\":{\"axis_formatter\":\"number\",\"axis_position\":\"left\",\"id\":\"61ca57f0-469d-11e7-af02-69e470af7417\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"series\":[{\"axis_position\":\"right\",\"chart_type\":\"line\",\"color\":\"rgba(255,0,4,1)\",\"fill\":0.5,\"formatter\":\"number\",\"id\":\"198f56e0-47e4-11e8-b45e-f10c3845381c\",\"label\":\"Down\",\"line_width\":1,\"metrics\":[{\"field\":\"haproxy.stat.downtime\",\"id\":\"198f56e1-47e4-11e8-b45e-f10c3845381c\",\"type\":\"sum\"},{\"unit\":\"\",\"sigma\":\"\",\"id\":\"dbf38560-47e6-11e8-b45e-f10c3845381c\",\"type\":\"derivative\",\"field\":\"198f56e1-47e4-11e8-b45e-f10c3845381c\"},{\"unit\":\"\",\"id\":\"62274b80-47e7-11e8-b45e-f10c3845381c\",\"type\":\"positive_only\",\"field\":\"dbf38560-47e6-11e8-b45e-f10c3845381c\"},{\"script\":\"(params.down \u003e 0) ? 1 : 0\",\"id\":\"7b7a7300-47e7-11e8-b45e-f10c3845381c\",\"type\":\"calculation\",\"variables\":[{\"id\":\"7e577b40-47e7-11e8-b45e-f10c3845381c\",\"name\":\"down\",\"field\":\"62274b80-47e7-11e8-b45e-f10c3845381c\"}]}],\"point_size\":1,\"seperate_axis\":1,\"split_mode\":\"everything\",\"stacked\":\"none\"},{\"axis_position\":\"right\",\"chart_type\":\"line\",\"color\":\"rgba(255,218,0,1)\",\"fill\":0.5,\"formatter\":\"ms,ms,0\",\"id\":\"61ca57f1-469d-11e7-af02-69e470af7417\",\"label\":\"Duration (ms)\",\"line_width\":1,\"metrics\":[{\"field\":\"haproxy.stat.check.duration\",\"id\":\"61ca57f2-469d-11e7-af02-69e470af7417\",\"type\":\"avg\"}],\"point_size\":1,\"seperate_axis\":0,\"split_mode\":\"everything\",\"stacked\":\"none\"}],\"show_grid\":1,\"show_legend\":1,\"time_field\":\"@timestamp\",\"type\":\"timeseries\"},\"aggs\":[]}"
-      },
-      "id": "976b0910-47e4-11e8-bc13-1397384faad3",
-      "type": "visualization",
-      "updated_at": "2018-04-24T17:49:15.393Z",
-      "version": 5
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{}"
-        },
-        "title": "Servers per connection [Metricbeat Haproxy]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Haproxy servers per connection\",\"type\":\"metrics\",\"params\":{\"id\":\"61ca57f0-469d-11e7-af02-69e470af7417\",\"type\":\"top_n\",\"series\":[{\"id\":\"61ca57f1-469d-11e7-af02-69e470af7417\",\"color\":\"#68BC00\",\"split_mode\":\"terms\",\"metrics\":[{\"id\":\"61ca57f2-469d-11e7-af02-69e470af7417\",\"type\":\"sum\",\"field\":\"haproxy.stat.connection.total\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"var_name\":\"\",\"terms_field\":\"haproxy.stat.service_name\",\"label\":\"Servers\",\"filter\":\"haproxy.stat.component_type:(2 OR 3)\",\"terms_order_by\":\"61ca57f2-469d-11e7-af02-69e470af7417\",\"terms_size\":\"20\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"show_legend\":1,\"show_grid\":1,\"bar_color_rules\":[{\"id\":\"50830800-47d9-11e8-9db9-274c7a5e25e4\"}],\"ignore_global_filter\":0,\"markdown\":\"{{#each _all}}\\n{{ label }}\\n\\n{{/each}}\",\"filter\":\"\",\"drilldown_url\":\"../app/kibana#/dashboard/8cc50a50-47e0-11e8-bc13-1397384faad3?_a=(query:(language:lucene,query:'haproxy.stat.service_name:\\\"{{ key }}\\\"'))\"},\"aggs\":[]}"
-      },
-      "id": "79350d50-47db-11e8-bc13-1397384faad3",
-      "type": "visualization",
-      "updated_at": "2018-04-24T17:11:53.619Z",
-      "version": 7
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{}"
-        },
-        "title": "Backends per connection [Metricbeat Haproxy]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Haproxy backends per connection\",\"type\":\"metrics\",\"params\":{\"axis_formatter\":\"number\",\"axis_position\":\"left\",\"bar_color_rules\":[{\"id\":\"4aeddd40-47dc-11e8-9db9-274c7a5e25e4\"}],\"drilldown_url\":\"../app/kibana#/dashboard/0836a4b0-47bd-11e8-bc13-1397384faad3?_a=(query:(language:lucene,query:'haproxy.stat.proxy.name:\\\"{{ key }}\\\"'))\",\"id\":\"61ca57f0-469d-11e7-af02-69e470af7417\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"series\":[{\"axis_position\":\"right\",\"chart_type\":\"line\",\"color\":\"#68BC00\",\"fill\":0.5,\"filter\":\"haproxy.stat.component_type:1\",\"formatter\":\"number\",\"id\":\"61ca57f1-469d-11e7-af02-69e470af7417\",\"label\":\"Backends\",\"line_width\":1,\"metrics\":[{\"field\":\"haproxy.stat.connection.total\",\"id\":\"61ca57f2-469d-11e7-af02-69e470af7417\",\"type\":\"sum\"}],\"point_size\":1,\"seperate_axis\":0,\"split_mode\":\"terms\",\"stacked\":\"none\",\"terms_field\":\"haproxy.stat.proxy.name\",\"terms_order_by\":\"61ca57f2-469d-11e7-af02-69e470af7417\",\"terms_size\":\"20\"}],\"show_grid\":1,\"show_legend\":1,\"time_field\":\"@timestamp\",\"type\":\"top_n\"},\"aggs\":[]}"
-      },
-      "id": "8c8f0300-47dc-11e8-bc13-1397384faad3",
-      "type": "visualization",
-      "updated_at": "2018-04-24T16:46:24.802Z",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{}"
-        },
-        "title": "Frontends per connection [Metricbeat Haproxy]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Haproxy frontends per connection\",\"type\":\"metrics\",\"params\":{\"id\":\"61ca57f0-469d-11e7-af02-69e470af7417\",\"type\":\"top_n\",\"series\":[{\"id\":\"61ca57f1-469d-11e7-af02-69e470af7417\",\"color\":\"#68BC00\",\"split_mode\":\"terms\",\"metrics\":[{\"id\":\"61ca57f2-469d-11e7-af02-69e470af7417\",\"type\":\"sum\",\"field\":\"haproxy.stat.connection.total\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"label\":\"Frontends\",\"terms_field\":\"haproxy.stat.proxy.name\",\"filter\":\"haproxy.stat.component_type:0\",\"terms_size\":\"20\",\"terms_order_by\":\"61ca57f2-469d-11e7-af02-69e470af7417\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"show_legend\":1,\"show_grid\":1,\"bar_color_rules\":[{\"id\":\"b81d8640-47dc-11e8-9a25-99b107967d82\"}],\"drilldown_url\":\"../app/kibana#/dashboard/e9057ae0-47c5-11e8-bc13-1397384faad3?_a=(query:(language:lucene,query:'haproxy.stat.proxy.name:\\\"{{ key }}\\\"'))\"},\"aggs\":[]}"
-      },
-      "id": "f1e27ed0-47dc-11e8-bc13-1397384faad3",
-      "type": "visualization",
-      "updated_at": "2018-04-24T16:54:16.639Z",
-      "version": 3
-    }
-  ],
-  "version": "6.2.2"
+    "objects": [
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Connections [Metricbeat Haproxy]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "background_color_rules": [
+                            {
+                                "id": "4e35d500-471b-11e8-a520-3f46123ab5eb"
+                            }
+                        ], 
+                        "bar_color_rules": [
+                            {
+                                "id": "69899960-4719-11e8-a520-3f46123ab5eb"
+                            }
+                        ], 
+                        "filter": "haproxy.stat.component_type:(0 OR 1)", 
+                        "gauge_color_rules": [
+                            {
+                                "id": "6f171ba0-4719-11e8-a520-3f46123ab5eb"
+                            }
+                        ], 
+                        "gauge_inner_width": 10, 
+                        "gauge_style": "half", 
+                        "gauge_width": 10, 
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "filter": "", 
+                                "formatter": "number", 
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
+                                "label": "Number of connections", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "haproxy.stat.connection.total", 
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "type": "sum"
+                                    }, 
+                                    {
+                                        "field": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "id": "41ff3940-4719-11e8-a520-3f46123ab5eb", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }, 
+                                    {
+                                        "field": "41ff3940-4719-11e8-a520-3f46123ab5eb", 
+                                        "id": "456a5fa0-4738-11e8-8633-8f8b3acf1566", 
+                                        "type": "positive_only", 
+                                        "unit": ""
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "series_drop_last_bucket": 1, 
+                                "split_color_mode": "rainbow", 
+                                "split_filters": [
+                                    {
+                                        "color": "#68BC00", 
+                                        "id": "0ceb7740-471a-11e8-a520-3f46123ab5eb"
+                                    }
+                                ], 
+                                "split_mode": "terms", 
+                                "stacked": "none", 
+                                "terms_field": "haproxy.stat.proxy.name"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "timeseries"
+                    }, 
+                    "title": "Haproxy connections", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "a64b4fd0-471c-11e8-bc13-1397384faad3", 
+            "type": "visualization", 
+            "updated_at": "2018-04-23T20:54:01.082Z", 
+            "version": 3
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Active servers in backend [Metricbeat Haproxy]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "background_color_rules": [
+                            {
+                                "color": "rgba(255,0,6,1)", 
+                                "id": "1ec0dde0-471d-11e8-9876-09cc6c85f5f2", 
+                                "opperator": "lte", 
+                                "value": 0
+                            }
+                        ], 
+                        "bar_color_rules": [
+                            {
+                                "id": "297160c0-471d-11e8-9876-09cc6c85f5f2"
+                            }
+                        ], 
+                        "filter": "haproxy.stat.component_type:(2 OR 3)", 
+                        "gauge_color_rules": [
+                            {
+                                "gauge": "rgba(255,0,5,1)", 
+                                "id": "4ce156a0-471d-11e8-9876-09cc6c85f5f2", 
+                                "opperator": "lte", 
+                                "text": null, 
+                                "value": 0
+                            }, 
+                            {
+                                "gauge": "rgba(255,196,0,1)", 
+                                "id": "f8458a80-4721-11e8-b854-2f6d2b452362", 
+                                "opperator": "lte", 
+                                "value": 0.5
+                            }
+                        ], 
+                        "gauge_inner_width": 10, 
+                        "gauge_max": "1", 
+                        "gauge_style": "half", 
+                        "gauge_width": 10, 
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "filter": "haproxy.stat.status:UP", 
+                                "formatter": "number", 
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
+                                "label": "Active servers", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "denominator": "*", 
+                                        "field": "haproxy.stat.server.id", 
+                                        "id": "b754d060-471e-11e8-9876-09cc6c85f5f2", 
+                                        "metric_agg": "count", 
+                                        "numerator": "*", 
+                                        "script": "params.up / (params.down + params.up)", 
+                                        "type": "cardinality", 
+                                        "variables": [
+                                            {
+                                                "field": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                                "id": "cfd51780-471e-11e8-9d35-6baabcdce3dc", 
+                                                "name": "down"
+                                            }, 
+                                            {
+                                                "field": "a049c420-471e-11e8-9876-09cc6c85f5f2", 
+                                                "id": "45e6ec00-471f-11e8-9d35-6baabcdce3dc", 
+                                                "name": "up"
+                                            }
+                                        ]
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none", 
+                                "terms_field": "haproxy.stat.proxy.name"
+                            }, 
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "formatter": "number", 
+                                "id": "2cba9420-4724-11e8-b854-2f6d2b452362", 
+                                "label": "Total servers", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "haproxy.stat.server.id", 
+                                        "id": "2cba9421-4724-11e8-b854-2f6d2b452362", 
+                                        "type": "cardinality"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "metric"
+                    }, 
+                    "title": "Haproxy active servers in backend", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "794b6cd0-471d-11e8-bc13-1397384faad3", 
+            "type": "visualization", 
+            "updated_at": "2018-04-23T21:36:57.634Z", 
+            "version": 8
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Connections per server [Metricbeat Haproxy]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "bar_color_rules": [
+                            {
+                                "id": "978f2660-4735-11e8-b619-8f82b8185e96"
+                            }
+                        ], 
+                        "drilldown_url": "../app/kibana#/dashboard/8cc50a50-47e0-11e8-bc13-1397384faad3?_a=(query:(language:lucene,query:'haproxy.stat.service_name:\"{{ key }}\"'))", 
+                        "filter": "haproxy.stat.component_type:(2 OR 3)", 
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "formatter": "number", 
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
+                                "label": "Connections per server", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "haproxy.stat.connection.total", 
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "type": "avg"
+                                    }, 
+                                    {
+                                        "field": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "id": "3ea29000-4735-11e8-b619-8f82b8185e96", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "terms", 
+                                "stacked": "none", 
+                                "terms_field": "haproxy.stat.service_name"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "top_n"
+                    }, 
+                    "title": "Haproxy connections per server", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "bb0ab500-4735-11e8-bc13-1397384faad3", 
+            "type": "visualization", 
+            "updated_at": "2018-04-24T17:12:35.298Z", 
+            "version": 3
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Downtime seconds [Metricbeat Haproxy]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "background_color_rules": [
+                            {
+                                "id": "c86b8e00-4739-11e8-8953-55bbe33e1362"
+                            }
+                        ], 
+                        "filter": "haproxy.stat.component_type:1", 
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(255,0,0,1)", 
+                                "fill": 0.5, 
+                                "formatter": "number", 
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
+                                "label": "Downtime", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "haproxy.stat.downtime", 
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "type": "avg"
+                                    }, 
+                                    {
+                                        "field": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "id": "91aa6a20-473a-11e8-8953-55bbe33e1362", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }, 
+                                    {
+                                        "field": "91aa6a20-473a-11e8-8953-55bbe33e1362", 
+                                        "id": "a8ce7ca0-473a-11e8-8953-55bbe33e1362", 
+                                        "sigma": "", 
+                                        "type": "sum_bucket"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "terms", 
+                                "stacked": "none", 
+                                "terms_field": "haproxy.stat.proxy.name", 
+                                "value_template": "{{value}}s"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "metric"
+                    }, 
+                    "title": "Haproxy downtime seconds", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "40bed190-473b-11e8-bc13-1397384faad3", 
+            "type": "visualization", 
+            "updated_at": "2018-04-23T21:29:04.708Z", 
+            "version": 3
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Average time in queue [Metricbeat Haproxy]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "formatter": "number", 
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
+                                "label": "Average time in queue", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "haproxy.stat.queue.time.avg", 
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "type": "avg"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "timeseries"
+                    }, 
+                    "title": "Haproxy average time in queue", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "b3463670-47a1-11e8-bc13-1397384faad3", 
+            "type": "visualization", 
+            "updated_at": "2018-04-24T09:27:25.783Z", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Traffic volume [Metricbeat Haproxy]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(164,221,0,1)", 
+                                "fill": "0.5", 
+                                "formatter": "bytes", 
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
+                                "label": "Incoming", 
+                                "line_width": "1", 
+                                "metrics": [
+                                    {
+                                        "field": "haproxy.stat.in.bytes", 
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "type": "sum"
+                                    }, 
+                                    {
+                                        "field": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "id": "9814c420-47c4-11e8-994c-81d2daeb7c86", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }
+                                ], 
+                                "point_size": "1", 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }, 
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(25,77,51,1)", 
+                                "fill": "0.5", 
+                                "formatter": "bytes", 
+                                "id": "c89d1520-47c4-11e8-994c-81d2daeb7c86", 
+                                "label": "Outgoing", 
+                                "line_width": "1", 
+                                "metrics": [
+                                    {
+                                        "field": "haproxy.stat.out.bytes", 
+                                        "id": "c89d6340-47c4-11e8-994c-81d2daeb7c86", 
+                                        "type": "sum"
+                                    }, 
+                                    {
+                                        "field": "c89d6340-47c4-11e8-994c-81d2daeb7c86", 
+                                        "id": "c89d6341-47c4-11e8-994c-81d2daeb7c86", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }
+                                ], 
+                                "override_index_pattern": 0, 
+                                "point_size": "1", 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "timeseries"
+                    }, 
+                    "title": "Haproxy traffic volume", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "86159190-47c5-11e8-bc13-1397384faad3", 
+            "type": "visualization", 
+            "updated_at": "2018-04-24T14:43:27.616Z", 
+            "version": 3
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "HTTP response codes [Metricbeat Haproxy]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "formatter": "number", 
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
+                                "label": "200s", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "haproxy.stat.response.http.2xx", 
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "type": "sum"
+                                    }, 
+                                    {
+                                        "field": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "id": "973a6de0-47bd-11e8-b7ab-dff70b15977c", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }, 
+                                    {
+                                        "field": "973a6de0-47bd-11e8-b7ab-dff70b15977c", 
+                                        "id": "4971d580-47e5-11e8-b45e-f10c3845381c", 
+                                        "type": "positive_only", 
+                                        "unit": ""
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }, 
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(64,240,0,1)", 
+                                "fill": 0.5, 
+                                "formatter": "number", 
+                                "id": "aafd05e0-47bd-11e8-b7ab-dff70b15977c", 
+                                "label": "300s", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "haproxy.stat.response.http.3xx", 
+                                        "id": "aafd05e1-47bd-11e8-b7ab-dff70b15977c", 
+                                        "type": "sum"
+                                    }, 
+                                    {
+                                        "field": "aafd05e1-47bd-11e8-b7ab-dff70b15977c", 
+                                        "id": "aafd05e2-47bd-11e8-b7ab-dff70b15977c", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }, 
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(255,246,0,1)", 
+                                "fill": 0.5, 
+                                "formatter": "number", 
+                                "id": "c77191a0-47bd-11e8-b7ab-dff70b15977c", 
+                                "label": "400s", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "haproxy.stat.response.http.4xx", 
+                                        "id": "c77191a1-47bd-11e8-b7ab-dff70b15977c", 
+                                        "type": "sum"
+                                    }, 
+                                    {
+                                        "field": "c77191a1-47bd-11e8-b7ab-dff70b15977c", 
+                                        "id": "c77191a2-47bd-11e8-b7ab-dff70b15977c", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }, 
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(255,0,4,1)", 
+                                "fill": 0.5, 
+                                "formatter": "number", 
+                                "id": "d574e900-47bd-11e8-b7ab-dff70b15977c", 
+                                "label": "500s", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "haproxy.stat.response.http.5xx", 
+                                        "id": "d574e901-47bd-11e8-b7ab-dff70b15977c", 
+                                        "type": "sum"
+                                    }, 
+                                    {
+                                        "field": "d574e901-47bd-11e8-b7ab-dff70b15977c", 
+                                        "id": "d5753720-47bd-11e8-b7ab-dff70b15977c", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }, 
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(0,251,255,1)", 
+                                "fill": 0.5, 
+                                "formatter": "number", 
+                                "id": "e3b8a4c0-47bd-11e8-b7ab-dff70b15977c", 
+                                "label": "Other", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "haproxy.stat.response.http.other", 
+                                        "id": "e3b8a4c1-47bd-11e8-b7ab-dff70b15977c", 
+                                        "type": "sum"
+                                    }, 
+                                    {
+                                        "field": "e3b8a4c1-47bd-11e8-b7ab-dff70b15977c", 
+                                        "id": "e3b8a4c2-47bd-11e8-b7ab-dff70b15977c", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }, 
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(15,20,25,1)", 
+                                "fill": 0.5, 
+                                "formatter": "number", 
+                                "id": "f9217d40-47be-11e8-b7ab-dff70b15977c", 
+                                "label": "Response errors", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "haproxy.stat.response.errors", 
+                                        "id": "f9217d41-47be-11e8-b7ab-dff70b15977c", 
+                                        "type": "sum"
+                                    }, 
+                                    {
+                                        "field": "f9217d41-47be-11e8-b7ab-dff70b15977c", 
+                                        "id": "1b7d4400-47bf-11e8-b7ab-dff70b15977c", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "timeseries"
+                    }, 
+                    "title": "Haproxy HTTP response codes", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "fcbdfa60-47bd-11e8-bc13-1397384faad3", 
+            "type": "visualization", 
+            "updated_at": "2018-04-24T17:31:30.169Z", 
+            "version": 4
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Average response time [Metricbeat Haproxy]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "formatter": "s,ms,0", 
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
+                                "label": "Average response time", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "haproxy.stat.response.time.avg", 
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "type": "avg"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none", 
+                                "value_template": "{{value}}ms"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "timeseries"
+                    }, 
+                    "title": "Haproxy average response time", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "981d1040-47be-11e8-bc13-1397384faad3", 
+            "type": "visualization", 
+            "updated_at": "2018-04-24T13:01:49.811Z", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Requests [Metricbeat Haproxy]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "formatter": "number", 
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
+                                "label": "Requests", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "haproxy.stat.request.total", 
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "type": "max"
+                                    }, 
+                                    {
+                                        "field": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "id": "ad38e2c0-47d6-11e8-994c-81d2daeb7c86", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }, 
+                                    {
+                                        "field": "ad38e2c0-47d6-11e8-994c-81d2daeb7c86", 
+                                        "id": "b1ca03a0-47d6-11e8-994c-81d2daeb7c86", 
+                                        "type": "positive_only", 
+                                        "unit": ""
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }, 
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(255,0,0,1)", 
+                                "fill": 0.5, 
+                                "formatter": "number", 
+                                "id": "c2f30500-47d6-11e8-994c-81d2daeb7c86", 
+                                "label": "Request errors", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "haproxy.stat.request.errors", 
+                                        "id": "c2f30501-47d6-11e8-994c-81d2daeb7c86", 
+                                        "type": "max"
+                                    }, 
+                                    {
+                                        "field": "c2f30501-47d6-11e8-994c-81d2daeb7c86", 
+                                        "id": "c2f30502-47d6-11e8-994c-81d2daeb7c86", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }, 
+                                    {
+                                        "field": "c2f30502-47d6-11e8-994c-81d2daeb7c86", 
+                                        "id": "c2f30503-47d6-11e8-994c-81d2daeb7c86", 
+                                        "type": "positive_only", 
+                                        "unit": ""
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }, 
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(0,0,0,1)", 
+                                "fill": 0.5, 
+                                "formatter": "number", 
+                                "id": "11968ce0-47d7-11e8-994c-81d2daeb7c86", 
+                                "label": "Denied requests", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "haproxy.stat.request.denied", 
+                                        "id": "11968ce1-47d7-11e8-994c-81d2daeb7c86", 
+                                        "type": "max"
+                                    }, 
+                                    {
+                                        "field": "11968ce1-47d7-11e8-994c-81d2daeb7c86", 
+                                        "id": "11968ce2-47d7-11e8-994c-81d2daeb7c86", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }, 
+                                    {
+                                        "field": "11968ce2-47d7-11e8-994c-81d2daeb7c86", 
+                                        "id": "11968ce3-47d7-11e8-994c-81d2daeb7c86", 
+                                        "type": "positive_only", 
+                                        "unit": ""
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "timeseries"
+                    }, 
+                    "title": "Haproxy requests", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "30956d00-47d7-11e8-bc13-1397384faad3", 
+            "type": "visualization", 
+            "updated_at": "2018-04-24T15:50:19.344Z", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Average connection time [Metricbeat Haproxy]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": "0.1", 
+                                "formatter": "number", 
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
+                                "label": "Percentile", 
+                                "line_width": "1", 
+                                "metrics": [
+                                    {
+                                        "field": "haproxy.stat.connection.time.avg", 
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "percentiles": [
+                                            {
+                                                "id": "9fa517e0-479b-11e8-9590-e34c5ed2dd95", 
+                                                "mode": "line", 
+                                                "percentile": "", 
+                                                "shade": 0.2, 
+                                                "value": "99"
+                                            }, 
+                                            {
+                                                "id": "daafd6e0-479b-11e8-9590-e34c5ed2dd95", 
+                                                "mode": "line", 
+                                                "percentile": "", 
+                                                "shade": 0.2, 
+                                                "value": "90"
+                                            }, 
+                                            {
+                                                "id": "e006b8c0-479b-11e8-9590-e34c5ed2dd95", 
+                                                "mode": "line", 
+                                                "percentile": "", 
+                                                "shade": 0.2, 
+                                                "value": "50"
+                                            }
+                                        ], 
+                                        "type": "percentile"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_color_mode": "gradient", 
+                                "split_mode": "everything", 
+                                "stacked": "none", 
+                                "terms_field": "haproxy.stat.service_name"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "timeseries"
+                    }, 
+                    "title": "Haproxy average connection time", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "0751ed00-479c-11e8-bc13-1397384faad3", 
+            "type": "visualization", 
+            "updated_at": "2018-04-24T08:51:34.252Z", 
+            "version": 4
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Number of server connections [Metricbeat Haproxy]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "filter": "haproxy.stat.component_type:(2 OR 3)", 
+                                "formatter": "number", 
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
+                                "label": "Number of connections", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "haproxy.stat.connection.total", 
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "type": "sum"
+                                    }, 
+                                    {
+                                        "field": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "id": "22668d40-47e1-11e8-96ee-d767c73d008a", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }, 
+                                    {
+                                        "field": "22668d40-47e1-11e8-96ee-d767c73d008a", 
+                                        "id": "2a1d0a00-47e1-11e8-96ee-d767c73d008a", 
+                                        "type": "positive_only", 
+                                        "unit": ""
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "terms", 
+                                "stacked": "none", 
+                                "terms_field": "haproxy.stat.service_name"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "timeseries"
+                    }, 
+                    "title": "Haproxy number of server connections", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "72e84b00-47e1-11e8-bc13-1397384faad3", 
+            "type": "visualization", 
+            "updated_at": "2018-04-24T17:05:00.128Z", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Healthcheck [Metricbeat Haproxy]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(255,0,4,1)", 
+                                "fill": 0.5, 
+                                "formatter": "number", 
+                                "id": "198f56e0-47e4-11e8-b45e-f10c3845381c", 
+                                "label": "Down", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "haproxy.stat.downtime", 
+                                        "id": "198f56e1-47e4-11e8-b45e-f10c3845381c", 
+                                        "type": "sum"
+                                    }, 
+                                    {
+                                        "field": "198f56e1-47e4-11e8-b45e-f10c3845381c", 
+                                        "id": "dbf38560-47e6-11e8-b45e-f10c3845381c", 
+                                        "sigma": "", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }, 
+                                    {
+                                        "field": "dbf38560-47e6-11e8-b45e-f10c3845381c", 
+                                        "id": "62274b80-47e7-11e8-b45e-f10c3845381c", 
+                                        "type": "positive_only", 
+                                        "unit": ""
+                                    }, 
+                                    {
+                                        "id": "7b7a7300-47e7-11e8-b45e-f10c3845381c", 
+                                        "script": "(params.down > 0) ? 1 : 0", 
+                                        "type": "calculation", 
+                                        "variables": [
+                                            {
+                                                "field": "62274b80-47e7-11e8-b45e-f10c3845381c", 
+                                                "id": "7e577b40-47e7-11e8-b45e-f10c3845381c", 
+                                                "name": "down"
+                                            }
+                                        ]
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 1, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }, 
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(255,218,0,1)", 
+                                "fill": 0.5, 
+                                "formatter": "ms,ms,0", 
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
+                                "label": "Duration (ms)", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "haproxy.stat.check.duration", 
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "type": "avg"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "timeseries"
+                    }, 
+                    "title": "Haproxy healthcheck", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "976b0910-47e4-11e8-bc13-1397384faad3", 
+            "type": "visualization", 
+            "updated_at": "2018-04-24T17:49:15.393Z", 
+            "version": 5
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Servers per connection [Metricbeat Haproxy]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "bar_color_rules": [
+                            {
+                                "id": "50830800-47d9-11e8-9db9-274c7a5e25e4"
+                            }
+                        ], 
+                        "drilldown_url": "../app/kibana#/dashboard/8cc50a50-47e0-11e8-bc13-1397384faad3?_a=(query:(language:lucene,query:'haproxy.stat.service_name:\"{{ key }}\"'))", 
+                        "filter": "", 
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
+                        "ignore_global_filter": 0, 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "markdown": "{{#each _all}}\n{{ label }}\n\n{{/each}}", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "filter": "haproxy.stat.component_type:(2 OR 3)", 
+                                "formatter": "number", 
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
+                                "label": "Servers", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "haproxy.stat.connection.total", 
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "type": "sum"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "terms", 
+                                "stacked": "none", 
+                                "terms_field": "haproxy.stat.service_name", 
+                                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                "terms_size": "20", 
+                                "var_name": ""
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "top_n"
+                    }, 
+                    "title": "Haproxy servers per connection", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "79350d50-47db-11e8-bc13-1397384faad3", 
+            "type": "visualization", 
+            "updated_at": "2018-04-24T17:11:53.619Z", 
+            "version": 7
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Backends per connection [Metricbeat Haproxy]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "bar_color_rules": [
+                            {
+                                "id": "4aeddd40-47dc-11e8-9db9-274c7a5e25e4"
+                            }
+                        ], 
+                        "drilldown_url": "../app/kibana#/dashboard/0836a4b0-47bd-11e8-bc13-1397384faad3?_a=(query:(language:lucene,query:'haproxy.stat.proxy.name:\"{{ key }}\"'))", 
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "filter": "haproxy.stat.component_type:1", 
+                                "formatter": "number", 
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
+                                "label": "Backends", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "haproxy.stat.connection.total", 
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "type": "sum"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "terms", 
+                                "stacked": "none", 
+                                "terms_field": "haproxy.stat.proxy.name", 
+                                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                "terms_size": "20"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "top_n"
+                    }, 
+                    "title": "Haproxy backends per connection", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "8c8f0300-47dc-11e8-bc13-1397384faad3", 
+            "type": "visualization", 
+            "updated_at": "2018-04-24T16:46:24.802Z", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Frontends per connection [Metricbeat Haproxy]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "bar_color_rules": [
+                            {
+                                "id": "b81d8640-47dc-11e8-9a25-99b107967d82"
+                            }
+                        ], 
+                        "drilldown_url": "../app/kibana#/dashboard/e9057ae0-47c5-11e8-bc13-1397384faad3?_a=(query:(language:lucene,query:'haproxy.stat.proxy.name:\"{{ key }}\"'))", 
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "filter": "haproxy.stat.component_type:0", 
+                                "formatter": "number", 
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
+                                "label": "Frontends", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "haproxy.stat.connection.total", 
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "type": "sum"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "terms", 
+                                "stacked": "none", 
+                                "terms_field": "haproxy.stat.proxy.name", 
+                                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                "terms_size": "20"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "top_n"
+                    }, 
+                    "title": "Haproxy frontends per connection", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "f1e27ed0-47dc-11e8-bc13-1397384faad3", 
+            "type": "visualization", 
+            "updated_at": "2018-04-24T16:54:16.639Z", 
+            "version": 3
+        }
+    ], 
+    "version": "6.2.2"
 }

--- a/metricbeat/module/kubernetes/_meta/kibana/6/dashboard/Metricbeat-kubernetes-apiserver.json
+++ b/metricbeat/module/kubernetes/_meta/kibana/6/dashboard/Metricbeat-kubernetes-apiserver.json
@@ -1,71 +1,335 @@
 {
-  "objects": [
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{}"
-        },
-        "title": "Kuberntes API Server: Top clients by number of requests",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Kuberntes API Server: Top clients by number of requests\",\"type\":\"metrics\",\"params\":{\"axis_formatter\":\"number\",\"axis_position\":\"left\",\"id\":\"61ca57f0-469d-11e7-af02-69e470af7417\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"5m\",\"series\":[{\"axis_position\":\"right\",\"chart_type\":\"line\",\"color\":\"rgba(104,188,0,1)\",\"fill\":0.5,\"formatter\":\"number\",\"id\":\"61ca57f1-469d-11e7-af02-69e470af7417\",\"line_width\":1,\"metrics\":[{\"field\":\"kubernetes.apiserver.request.count\",\"id\":\"61ca57f2-469d-11e7-af02-69e470af7417\",\"type\":\"sum\"},{\"unit\":\"\",\"id\":\"0e6ff4a0-5792-11e8-8bd0-2180975e72dd\",\"type\":\"derivative\",\"field\":\"61ca57f2-469d-11e7-af02-69e470af7417\"}],\"point_size\":1,\"seperate_axis\":0,\"split_mode\":\"terms\",\"stacked\":\"stacked\",\"filter\":\"\",\"terms_field\":\"kubernetes.apiserver.request.client\",\"split_filters\":[{\"color\":\"#68BC00\",\"id\":\"9e4b8030-5792-11e8-8bd0-2180975e72dd\"}],\"terms_order_by\":\"61ca57f2-469d-11e7-af02-69e470af7417\",\"terms_size\":\"10\",\"label\":\"Top clients by number of requests (5m)\"}],\"show_grid\":1,\"show_legend\":1,\"time_field\":\"@timestamp\",\"type\":\"top_n\",\"bar_color_rules\":[{\"id\":\"61a13010-5794-11e8-8bd0-2180975e72dd\"}]},\"aggs\":[]}"
-      },
-      "id": "7cbeb750-5794-11e8-afa2-e9067ea62228",
-      "type": "visualization",
-      "updated_at": "2018-05-14T18:23:10.501Z",
-      "version": 5
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{}"
-        },
-        "title": "Kubernetes API Server: Requests",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Kubernetes API Server: Requests\",\"type\":\"metrics\",\"params\":{\"id\":\"61ca57f0-469d-11e7-af02-69e470af7417\",\"type\":\"timeseries\",\"series\":[{\"id\":\"61ca57f1-469d-11e7-af02-69e470af7417\",\"color\":\"rgba(159,5,0,1)\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"61ca57f2-469d-11e7-af02-69e470af7417\",\"type\":\"sum\",\"field\":\"kubernetes.apiserver.request.latency.sum\"},{\"id\":\"a2185e50-57a0-11e8-af57-a1d645d2b569\",\"type\":\"sum\",\"field\":\"kubernetes.apiserver.request.count\"},{\"script\":\"params.sum / params.count\",\"id\":\"b09133d0-57a0-11e8-af57-a1d645d2b569\",\"type\":\"calculation\",\"variables\":[{\"id\":\"b27c8910-57a0-11e8-af57-a1d645d2b569\",\"field\":\"61ca57f2-469d-11e7-af02-69e470af7417\",\"name\":\"sum\"},{\"id\":\"b5fc8810-57a0-11e8-af57-a1d645d2b569\",\"name\":\"count\",\"field\":\"a2185e50-57a0-11e8-af57-a1d645d2b569\"}]}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"us,ms,2\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":\"0\",\"stacked\":\"none\",\"filter\":\"NOT (kubernetes.apiserver.request.verb: WATCH or kubernetes.apiserver.request.verb: CONNECT)\",\"value_template\":\"{{value}} ms\",\"label\":\"Avg response time\"},{\"id\":\"c0019340-57a1-11e8-a049-ff54cef064a2\",\"color\":\"rgba(22,165,165,1)\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"c001ba50-57a1-11e8-a049-ff54cef064a2\",\"type\":\"sum\",\"field\":\"kubernetes.apiserver.request.count\"},{\"unit\":\"\",\"id\":\"dc83b390-57a1-11e8-a049-ff54cef064a2\",\"type\":\"derivative\",\"field\":\"c001ba50-57a1-11e8-a049-ff54cef064a2\"}],\"seperate_axis\":1,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"label\":\"Requests rate\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"show_legend\":1,\"show_grid\":1},\"aggs\":[]}"
-      },
-      "id": "ec360ff0-57a0-11e8-afa2-e9067ea62228",
-      "type": "visualization",
-      "updated_at": "2018-05-14T18:21:27.515Z",
-      "version": 4
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{}"
-        },
-        "title": "Kuberntes API Server: Top clients by resource",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Kuberntes API Server: Top clients by resource\",\"type\":\"metrics\",\"params\":{\"axis_formatter\":\"number\",\"axis_position\":\"left\",\"id\":\"61ca57f0-469d-11e7-af02-69e470af7417\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"5m\",\"series\":[{\"axis_position\":\"right\",\"chart_type\":\"line\",\"color\":\"rgba(104,188,0,1)\",\"fill\":0.5,\"formatter\":\"number\",\"id\":\"61ca57f1-469d-11e7-af02-69e470af7417\",\"line_width\":1,\"metrics\":[{\"field\":\"kubernetes.apiserver.request.count\",\"id\":\"61ca57f2-469d-11e7-af02-69e470af7417\",\"type\":\"sum\"},{\"unit\":\"\",\"id\":\"0e6ff4a0-5792-11e8-8bd0-2180975e72dd\",\"type\":\"derivative\",\"field\":\"61ca57f2-469d-11e7-af02-69e470af7417\"}],\"point_size\":1,\"seperate_axis\":0,\"split_mode\":\"terms\",\"stacked\":\"stacked\",\"filter\":\"\",\"terms_field\":\"kubernetes.apiserver.request.resource\",\"split_filters\":[{\"color\":\"#68BC00\",\"id\":\"9e4b8030-5792-11e8-8bd0-2180975e72dd\"}],\"terms_order_by\":\"61ca57f2-469d-11e7-af02-69e470af7417\",\"terms_size\":\"10\",\"label\":\"Top clients by number of requests (5m)\",\"series_drop_last_bucket\":1,\"override_index_pattern\":0}],\"show_grid\":1,\"show_legend\":1,\"time_field\":\"@timestamp\",\"type\":\"top_n\",\"bar_color_rules\":[{\"id\":\"61a13010-5794-11e8-8bd0-2180975e72dd\"}]},\"aggs\":[]}"
-      },
-      "id": "95a7f110-57a2-11e8-afa2-e9067ea62228",
-      "type": "visualization",
-      "updated_at": "2018-05-14T18:23:50.093Z",
-      "version": 4
-    },
-    {
-      "attributes": {
-        "description": "",
-        "hits": 0,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"language\":\"lucene\",\"query\":\"\"},\"filter\":[],\"highlightAll\":true,\"version\":true}"
-        },
-        "optionsJSON": "{\"darkTheme\":false,\"hidePanelTitles\":false,\"useMargins\":false}",
-        "panelsJSON": "[{\"embeddableConfig\":{},\"gridData\":{\"h\":24,\"i\":\"1\",\"w\":24,\"x\":0,\"y\":22},\"id\":\"7cbeb750-5794-11e8-afa2-e9067ea62228\",\"panelIndex\":\"1\",\"type\":\"visualization\",\"version\":\"6.3.0\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":22,\"i\":\"3\",\"w\":48,\"x\":0,\"y\":0},\"id\":\"ec360ff0-57a0-11e8-afa2-e9067ea62228\",\"panelIndex\":\"3\",\"type\":\"visualization\",\"version\":\"6.3.0\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":24,\"i\":\"4\",\"w\":24,\"x\":24,\"y\":22},\"id\":\"95a7f110-57a2-11e8-afa2-e9067ea62228\",\"panelIndex\":\"4\",\"type\":\"visualization\",\"version\":\"6.3.0\"}]",
-        "timeRestore": false,
-        "title": "[Metricbeat Kubernetes] API server",
-        "version": 1
-      },
-      "id": "af7225b0-5794-11e8-afa2-e9067ea62228",
-      "type": "dashboard",
-      "updated_at": "2018-05-14T18:23:55.202Z",
-      "version": 5
-    }
-  ],
-  "version": "6.3.0"
+    "objects": [
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Kuberntes API Server: Top clients by number of requests", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "bar_color_rules": [
+                            {
+                                "id": "61a13010-5794-11e8-8bd0-2180975e72dd"
+                            }
+                        ], 
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "5m", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(104,188,0,1)", 
+                                "fill": 0.5, 
+                                "filter": "", 
+                                "formatter": "number", 
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
+                                "label": "Top clients by number of requests (5m)", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "kubernetes.apiserver.request.count", 
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "type": "sum"
+                                    }, 
+                                    {
+                                        "field": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "id": "0e6ff4a0-5792-11e8-8bd0-2180975e72dd", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_filters": [
+                                    {
+                                        "color": "#68BC00", 
+                                        "id": "9e4b8030-5792-11e8-8bd0-2180975e72dd"
+                                    }
+                                ], 
+                                "split_mode": "terms", 
+                                "stacked": "stacked", 
+                                "terms_field": "kubernetes.apiserver.request.client", 
+                                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                "terms_size": "10"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "top_n"
+                    }, 
+                    "title": "Kuberntes API Server: Top clients by number of requests", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "7cbeb750-5794-11e8-afa2-e9067ea62228", 
+            "type": "visualization", 
+            "updated_at": "2018-05-14T18:23:10.501Z", 
+            "version": 5
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Kubernetes API Server: Requests", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(159,5,0,1)", 
+                                "fill": "0", 
+                                "filter": "NOT (kubernetes.apiserver.request.verb: WATCH or kubernetes.apiserver.request.verb: CONNECT)", 
+                                "formatter": "us,ms,2", 
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
+                                "label": "Avg response time", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "kubernetes.apiserver.request.latency.sum", 
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "type": "sum"
+                                    }, 
+                                    {
+                                        "field": "kubernetes.apiserver.request.count", 
+                                        "id": "a2185e50-57a0-11e8-af57-a1d645d2b569", 
+                                        "type": "sum"
+                                    }, 
+                                    {
+                                        "id": "b09133d0-57a0-11e8-af57-a1d645d2b569", 
+                                        "script": "params.sum / params.count", 
+                                        "type": "calculation", 
+                                        "variables": [
+                                            {
+                                                "field": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                                "id": "b27c8910-57a0-11e8-af57-a1d645d2b569", 
+                                                "name": "sum"
+                                            }, 
+                                            {
+                                                "field": "a2185e50-57a0-11e8-af57-a1d645d2b569", 
+                                                "id": "b5fc8810-57a0-11e8-af57-a1d645d2b569", 
+                                                "name": "count"
+                                            }
+                                        ]
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none", 
+                                "value_template": "{{value}} ms"
+                            }, 
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(22,165,165,1)", 
+                                "fill": 0.5, 
+                                "formatter": "number", 
+                                "id": "c0019340-57a1-11e8-a049-ff54cef064a2", 
+                                "label": "Requests rate", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "kubernetes.apiserver.request.count", 
+                                        "id": "c001ba50-57a1-11e8-a049-ff54cef064a2", 
+                                        "type": "sum"
+                                    }, 
+                                    {
+                                        "field": "c001ba50-57a1-11e8-a049-ff54cef064a2", 
+                                        "id": "dc83b390-57a1-11e8-a049-ff54cef064a2", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 1, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "timeseries"
+                    }, 
+                    "title": "Kubernetes API Server: Requests", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "ec360ff0-57a0-11e8-afa2-e9067ea62228", 
+            "type": "visualization", 
+            "updated_at": "2018-05-14T18:21:27.515Z", 
+            "version": 4
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Kuberntes API Server: Top clients by resource", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "bar_color_rules": [
+                            {
+                                "id": "61a13010-5794-11e8-8bd0-2180975e72dd"
+                            }
+                        ], 
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "5m", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(104,188,0,1)", 
+                                "fill": 0.5, 
+                                "filter": "", 
+                                "formatter": "number", 
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
+                                "label": "Top clients by number of requests (5m)", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "kubernetes.apiserver.request.count", 
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "type": "sum"
+                                    }, 
+                                    {
+                                        "field": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "id": "0e6ff4a0-5792-11e8-8bd0-2180975e72dd", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }
+                                ], 
+                                "override_index_pattern": 0, 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "series_drop_last_bucket": 1, 
+                                "split_filters": [
+                                    {
+                                        "color": "#68BC00", 
+                                        "id": "9e4b8030-5792-11e8-8bd0-2180975e72dd"
+                                    }
+                                ], 
+                                "split_mode": "terms", 
+                                "stacked": "stacked", 
+                                "terms_field": "kubernetes.apiserver.request.resource", 
+                                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                "terms_size": "10"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "top_n"
+                    }, 
+                    "title": "Kuberntes API Server: Top clients by resource", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "95a7f110-57a2-11e8-afa2-e9067ea62228", 
+            "type": "visualization", 
+            "updated_at": "2018-05-14T18:23:50.093Z", 
+            "version": 4
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "query": {
+                            "language": "lucene", 
+                            "query": ""
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false, 
+                    "hidePanelTitles": false, 
+                    "useMargins": false
+                }, 
+                "panelsJSON": [
+                    {
+                        "embeddableConfig": {}, 
+                        "gridData": {
+                            "h": 24, 
+                            "i": "1", 
+                            "w": 24, 
+                            "x": 0, 
+                            "y": 22
+                        }, 
+                        "id": "7cbeb750-5794-11e8-afa2-e9067ea62228", 
+                        "panelIndex": "1", 
+                        "type": "visualization", 
+                        "version": "6.3.0"
+                    }, 
+                    {
+                        "embeddableConfig": {}, 
+                        "gridData": {
+                            "h": 22, 
+                            "i": "3", 
+                            "w": 48, 
+                            "x": 0, 
+                            "y": 0
+                        }, 
+                        "id": "ec360ff0-57a0-11e8-afa2-e9067ea62228", 
+                        "panelIndex": "3", 
+                        "type": "visualization", 
+                        "version": "6.3.0"
+                    }, 
+                    {
+                        "embeddableConfig": {}, 
+                        "gridData": {
+                            "h": 24, 
+                            "i": "4", 
+                            "w": 24, 
+                            "x": 24, 
+                            "y": 22
+                        }, 
+                        "id": "95a7f110-57a2-11e8-afa2-e9067ea62228", 
+                        "panelIndex": "4", 
+                        "type": "visualization", 
+                        "version": "6.3.0"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "[Metricbeat Kubernetes] API server", 
+                "version": 1
+            }, 
+            "id": "af7225b0-5794-11e8-afa2-e9067ea62228", 
+            "type": "dashboard", 
+            "updated_at": "2018-05-14T18:23:55.202Z", 
+            "version": 5
+        }
+    ], 
+    "version": "6.3.0"
 }

--- a/metricbeat/module/kubernetes/_meta/kibana/6/dashboard/Metricbeat-kubernetes-overview.json
+++ b/metricbeat/module/kubernetes/_meta/kibana/6/dashboard/Metricbeat-kubernetes-overview.json
@@ -1,231 +1,1387 @@
 {
-  "objects": [
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query\":{\"query_string\":{\"query\":\"*\"}},\"language\":\"lucene\"},\"filter\":[]}"
-        },
-        "title": "Available pods per deployment [Metricbeat Kubernetes]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Available pods per deployment [Metricbeat Kubernetes]\",\"type\":\"metrics\",\"params\":{\"axis_formatter\":\"number\",\"axis_position\":\"left\",\"filter\":\"metricset.module:kubernetes AND metricset.name:state_deployment\",\"id\":\"117fadf0-30df-11e7-8df8-6d3604a72912\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"series\":[{\"axis_position\":\"right\",\"chart_type\":\"line\",\"color\":\"rgba(104,188,0,1)\",\"fill\":0.5,\"formatter\":\"number\",\"id\":\"64456840-30df-11e7-8df8-6d3604a72912\",\"label\":\"Available pods\",\"line_width\":1,\"metrics\":[{\"field\":\"kubernetes.deployment.replicas.available\",\"id\":\"64456841-30df-11e7-8df8-6d3604a72912\",\"type\":\"avg\"}],\"point_size\":1,\"seperate_axis\":0,\"split_filters\":[{\"color\":\"#68BC00\",\"id\":\"53d35ad0-30df-11e7-8df8-6d3604a72912\"}],\"split_mode\":\"terms\",\"stacked\":\"stacked\",\"terms_field\":\"kubernetes.deployment.name\",\"terms_size\":\"10000\"}],\"show_legend\":1,\"time_field\":\"@timestamp\",\"type\":\"timeseries\",\"show_grid\":1},\"aggs\":[]}"
-      },
-      "id": "022a54c0-2bf5-11e7-859b-f78b612cde28",
-      "type": "visualization",
-      "updated_at": "2018-03-11T20:59:01.845Z",
-      "version": 4
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query_string\":{\"query\":\"*\"}},\"filter\":[]}"
-        },
-        "title": "CPU usage by node  [Metricbeat Kubernetes]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"CPU usage by node  [Metricbeat Kubernetes]\",\"type\":\"metrics\",\"params\":{\"id\":\"0d5c6b10-2bf2-11e7-859b-f78b612cde28\",\"type\":\"timeseries\",\"series\":[{\"id\":\"0d5c9220-2bf2-11e7-859b-f78b612cde28\",\"color\":\"#68BC00\",\"split_mode\":\"terms\",\"metrics\":[{\"id\":\"0d5c9221-2bf2-11e7-859b-f78b612cde28\",\"type\":\"sum\",\"field\":\"kubernetes.container.cpu.usage.nanocores\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"0.0a\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":\"0.5\",\"stacked\":\"none\",\"terms_field\":\"kubernetes.node.name\",\"terms_size\":\"10000\",\"terms_order_by\":\"0d5c9221-2bf2-11e7-859b-f78b612cde28\",\"value_template\":\"{{value}} nanocores\",\"override_index_pattern\":0,\"series_interval\":\"10s\",\"series_time_field\":\"@timestamp\"},{\"id\":\"22f65d40-31a7-11e7-84cc-096d2b38e6e5\",\"color\":\"rgba(211,49,21,1)\",\"split_mode\":\"terms\",\"metrics\":[{\"id\":\"22f65d41-31a7-11e7-84cc-096d2b38e6e5\",\"type\":\"avg\",\"field\":\"kubernetes.node.cpu.capacity.cores\"},{\"script\":\"params.cores * 1000000000\",\"id\":\"4af4c390-34d6-11e7-be88-cb6a123dc1bb\",\"type\":\"calculation\",\"variables\":[{\"id\":\"4cd32080-34d6-11e7-be88-cb6a123dc1bb\",\"name\":\"cores\",\"field\":\"22f65d41-31a7-11e7-84cc-096d2b38e6e5\"}]}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"0.0a\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":\"0\",\"fill\":\"0\",\"stacked\":\"none\",\"terms_field\":\"kubernetes.node.name\",\"terms_size\":\"10000\",\"terms_order_by\":\"22f65d41-31a7-11e7-84cc-096d2b38e6e5\",\"value_template\":\"{{value}} nanocores\",\"hide_in_legend\":1,\"label\":\"\",\"override_index_pattern\":0,\"series_interval\":\"10s\",\"series_time_field\":\"@timestamp\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"show_legend\":1,\"background_color_rules\":[{\"id\":\"12c1f2f0-2bf2-11e7-859b-f78b612cde28\"}],\"bar_color_rules\":[{\"id\":\"1373ddd0-2bf2-11e7-859b-f78b612cde28\"}],\"gauge_color_rules\":[{\"id\":\"140e4910-2bf2-11e7-859b-f78b612cde28\"}],\"gauge_width\":10,\"gauge_inner_width\":10,\"gauge_style\":\"half\",\"filter\":\"metricset.module:kubernetes AND (metricset.name:container OR metricset.name:state_node)\"},\"aggs\":[],\"listeners\":{}}"
-      },
-      "id": "44f12b40-2bf4-11e7-859b-f78b612cde28",
-      "type": "visualization",
-      "updated_at": "2018-03-01T18:58:07.906Z",
-      "version": 3
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query_string\":{\"query\":\"*\"}},\"filter\":[]}"
-        },
-        "title": "Kubernetes - Deployments",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Kubernetes - Deployments\",\"type\":\"metrics\",\"params\":{\"id\":\"4c4690b0-30e0-11e7-8df8-6d3604a72912\",\"type\":\"metric\",\"series\":[{\"id\":\"4c4690b1-30e0-11e7-8df8-6d3604a72912\",\"color\":\"#68BC00\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"4c4690b2-30e0-11e7-8df8-6d3604a72912\",\"type\":\"cardinality\",\"field\":\"kubernetes.deployment.name\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"terms_field\":\"kubernetes.deployment.name\",\"label\":\"Deployments\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"show_legend\":1,\"filter\":\"metricset.module:kubernetes AND metricset.name:state_deployment\",\"background_color_rules\":[{\"id\":\"67ee7da0-30e0-11e7-8df8-6d3604a72912\"}],\"bar_color_rules\":[{\"id\":\"68cdba10-30e0-11e7-8df8-6d3604a72912\"}],\"gauge_color_rules\":[{\"id\":\"69765620-30e0-11e7-8df8-6d3604a72912\"}],\"gauge_width\":10,\"gauge_inner_width\":10,\"gauge_style\":\"half\"},\"aggs\":[],\"listeners\":{}}"
-      },
-      "id": "cd059410-2bfb-11e7-859b-f78b612cde28",
-      "type": "visualization",
-      "updated_at": "2018-03-01T18:58:07.906Z",
-      "version": 3
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query_string\":{\"query\":\"*\"}},\"filter\":[]}"
-        },
-        "title": "Kubernetes - Desired pods",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Kubernetes - Desired pods\",\"type\":\"metrics\",\"params\":{\"id\":\"2fe9d3b0-30d5-11e7-8df8-6d3604a72912\",\"type\":\"metric\",\"series\":[{\"id\":\"2fe9d3b1-30d5-11e7-8df8-6d3604a72912\",\"color\":\"#68BC00\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"54cf79a0-30d5-11e7-8df8-6d3604a72912\",\"type\":\"sum\",\"field\":\"kubernetes.deployment.replicas.desired\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"label\":\"Desired Pods\",\"override_index_pattern\":1,\"series_time_field\":\"@timestamp\",\"series_interval\":\"10s\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"show_legend\":1,\"background_color_rules\":[{\"id\":\"508ffb30-30d5-11e7-8df8-6d3604a72912\"}],\"gauge_color_rules\":[{\"id\":\"50f9b980-30d5-11e7-8df8-6d3604a72912\"}],\"gauge_width\":\"10\",\"gauge_inner_width\":\"10\",\"gauge_style\":\"half\",\"bar_color_rules\":[{\"id\":\"674d83b0-30d5-11e7-8df8-6d3604a72912\"}],\"gauge_max\":\"5\",\"filter\":\"metricset.module:kubernetes AND metricset.name:state_deployment\"},\"aggs\":[],\"listeners\":{}}"
-      },
-      "id": "e1018b90-2bfb-11e7-859b-f78b612cde28",
-      "type": "visualization",
-      "updated_at": "2018-03-01T18:58:07.906Z",
-      "version": 3
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query\":{\"query_string\":{\"query\":\"*\"}},\"language\":\"lucene\"},\"filter\":[]}"
-        },
-        "title": "Memory usage by node  [Metricbeat Kubernetes]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Memory usage by node  [Metricbeat Kubernetes]\",\"type\":\"metrics\",\"params\":{\"id\":\"0d5c6b10-2bf2-11e7-859b-f78b612cde28\",\"type\":\"timeseries\",\"series\":[{\"id\":\"0d5c9220-2bf2-11e7-859b-f78b612cde28\",\"color\":\"#68BC00\",\"split_mode\":\"terms\",\"metrics\":[{\"id\":\"0d5c9221-2bf2-11e7-859b-f78b612cde28\",\"type\":\"sum\",\"field\":\"kubernetes.container.memory.usage.bytes\"},{\"id\":\"9f0cf900-1ffb-11e8-81f2-43be86397500\",\"type\":\"cumulative_sum\",\"field\":\"0d5c9221-2bf2-11e7-859b-f78b612cde28\"},{\"unit\":\"10s\",\"id\":\"a926e130-1ffb-11e8-81f2-43be86397500\",\"type\":\"derivative\",\"field\":\"9f0cf900-1ffb-11e8-81f2-43be86397500\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"bytes\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"terms_field\":\"kubernetes.node.name\",\"terms_size\":\"10000\",\"terms_order_by\":\"0d5c9221-2bf2-11e7-859b-f78b612cde28\"},{\"id\":\"8ba3b270-31a7-11e7-84cc-096d2b38e6e5\",\"color\":\"rgba(211,49,21,1)\",\"split_mode\":\"terms\",\"metrics\":[{\"id\":\"8ba3b271-31a7-11e7-84cc-096d2b38e6e5\",\"type\":\"sum\",\"field\":\"kubernetes.node.memory.capacity.bytes\"},{\"id\":\"d1fb2670-1ffb-11e8-81f2-43be86397500\",\"type\":\"cumulative_sum\",\"field\":\"8ba3b271-31a7-11e7-84cc-096d2b38e6e5\"},{\"unit\":\"10s\",\"id\":\"dc8b01f0-1ffb-11e8-81f2-43be86397500\",\"type\":\"derivative\",\"field\":\"d1fb2670-1ffb-11e8-81f2-43be86397500\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"bytes\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":\"0\",\"fill\":\"0\",\"stacked\":\"none\",\"terms_field\":\"kubernetes.node.name\",\"terms_size\":\"10000\",\"terms_order_by\":\"8ba3b271-31a7-11e7-84cc-096d2b38e6e5\",\"hide_in_legend\":1,\"label\":\"Node capacity\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"show_legend\":1,\"background_color_rules\":[{\"id\":\"12c1f2f0-2bf2-11e7-859b-f78b612cde28\"}],\"bar_color_rules\":[{\"id\":\"1373ddd0-2bf2-11e7-859b-f78b612cde28\"}],\"gauge_color_rules\":[{\"id\":\"140e4910-2bf2-11e7-859b-f78b612cde28\"}],\"gauge_width\":10,\"gauge_inner_width\":10,\"gauge_style\":\"half\",\"filter\":\"metricset.module:kubernetes AND (metricset.name:container OR metricset.name:state_node)\",\"show_grid\":1},\"aggs\":[]}"
-      },
-      "id": "d6564360-2bfc-11e7-859b-f78b612cde28",
-      "type": "visualization",
-      "updated_at": "2018-03-04T23:15:29.035Z",
-      "version": 4
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query_string\":{\"query\":\"*\"}},\"filter\":[]}"
-        },
-        "title": "Network in by node  [Metricbeat Kubernetes]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Network in by node  [Metricbeat Kubernetes]\",\"type\":\"metrics\",\"params\":{\"id\":\"0d5c6b10-2bf2-11e7-859b-f78b612cde28\",\"type\":\"timeseries\",\"series\":[{\"id\":\"0d5c9220-2bf2-11e7-859b-f78b612cde28\",\"color\":\"rgba(104,188,0,1)\",\"split_mode\":\"terms\",\"metrics\":[{\"id\":\"0d5c9221-2bf2-11e7-859b-f78b612cde28\",\"type\":\"sum\",\"field\":\"kubernetes.pod.network.rx.bytes\"},{\"unit\":\"\",\"id\":\"494fc310-2bf7-11e7-859b-f78b612cde28\",\"type\":\"derivative\",\"field\":\"0d5c9221-2bf2-11e7-859b-f78b612cde28\"},{\"unit\":\"\",\"id\":\"37c72a70-3598-11e7-aa4a-8313a0c92a88\",\"type\":\"positive_only\",\"field\":\"494fc310-2bf7-11e7-859b-f78b612cde28\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"bytes\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"stacked\",\"terms_field\":\"kubernetes.node.name\",\"terms_size\":\"100000\",\"terms_order_by\":\"0d5c9221-2bf2-11e7-859b-f78b612cde28\",\"label\":\"\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"show_legend\":1,\"background_color_rules\":[{\"id\":\"12c1f2f0-2bf2-11e7-859b-f78b612cde28\"}],\"bar_color_rules\":[{\"id\":\"1373ddd0-2bf2-11e7-859b-f78b612cde28\"}],\"gauge_color_rules\":[{\"id\":\"140e4910-2bf2-11e7-859b-f78b612cde28\"}],\"gauge_width\":10,\"gauge_inner_width\":10,\"gauge_style\":\"half\",\"filter\":\"metricset.module:kubernetes AND metricset.name:pod\"},\"aggs\":[],\"listeners\":{}}"
-      },
-      "id": "16fa4470-2bfd-11e7-859b-f78b612cde28",
-      "type": "visualization",
-      "updated_at": "2018-03-01T18:58:07.906Z",
-      "version": 3
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query_string\":{\"query\":\"*\"}},\"filter\":[]}"
-        },
-        "title": "Network out by node  [Metricbeat Kubernetes]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Network out by node  [Metricbeat Kubernetes]\",\"type\":\"metrics\",\"params\":{\"id\":\"0d5c6b10-2bf2-11e7-859b-f78b612cde28\",\"type\":\"timeseries\",\"series\":[{\"id\":\"0d5c9220-2bf2-11e7-859b-f78b612cde28\",\"color\":\"rgba(104,188,0,1)\",\"split_mode\":\"terms\",\"metrics\":[{\"id\":\"0d5c9221-2bf2-11e7-859b-f78b612cde28\",\"type\":\"sum\",\"field\":\"kubernetes.pod.network.tx.bytes\"},{\"unit\":\"\",\"id\":\"494fc310-2bf7-11e7-859b-f78b612cde28\",\"type\":\"derivative\",\"field\":\"0d5c9221-2bf2-11e7-859b-f78b612cde28\"},{\"unit\":\"\",\"id\":\"244c70e0-3598-11e7-aa4a-8313a0c92a88\",\"type\":\"positive_only\",\"field\":\"494fc310-2bf7-11e7-859b-f78b612cde28\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"bytes\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"stacked\",\"terms_field\":\"kubernetes.node.name\",\"terms_size\":\"10000\",\"terms_order_by\":\"0d5c9221-2bf2-11e7-859b-f78b612cde28\",\"label\":\"\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"show_legend\":1,\"background_color_rules\":[{\"id\":\"12c1f2f0-2bf2-11e7-859b-f78b612cde28\"}],\"bar_color_rules\":[{\"id\":\"1373ddd0-2bf2-11e7-859b-f78b612cde28\"}],\"gauge_color_rules\":[{\"id\":\"140e4910-2bf2-11e7-859b-f78b612cde28\"}],\"gauge_width\":10,\"gauge_inner_width\":10,\"gauge_style\":\"half\",\"filter\":\"metricset.module:kubernetes AND metricset.name:pod\"},\"aggs\":[],\"listeners\":{}}"
-      },
-      "id": "294546b0-30d6-11e7-8df8-6d3604a72912",
-      "type": "visualization",
-      "updated_at": "2018-03-01T18:58:07.906Z",
-      "version": 3
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query_string\":{\"query\":\"*\"}},\"filter\":[]}"
-        },
-        "title": "Kubernetes - Nodes",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Kubernetes - Nodes\",\"type\":\"metrics\",\"params\":{\"id\":\"4c4690b0-30e0-11e7-8df8-6d3604a72912\",\"type\":\"metric\",\"series\":[{\"id\":\"4c4690b1-30e0-11e7-8df8-6d3604a72912\",\"color\":\"#68BC00\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"4c4690b2-30e0-11e7-8df8-6d3604a72912\",\"type\":\"cardinality\",\"field\":\"kubernetes.node.name\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"terms_field\":\"kubernetes.deployment.name\",\"label\":\"Nodes\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"show_legend\":1,\"filter\":\"metricset.module:kubernetes AND metricset.name:state_node\",\"background_color_rules\":[{\"id\":\"67ee7da0-30e0-11e7-8df8-6d3604a72912\"}],\"bar_color_rules\":[{\"id\":\"68cdba10-30e0-11e7-8df8-6d3604a72912\"}],\"gauge_color_rules\":[{\"id\":\"69765620-30e0-11e7-8df8-6d3604a72912\"}],\"gauge_width\":10,\"gauge_inner_width\":10,\"gauge_style\":\"half\"},\"aggs\":[],\"listeners\":{}}"
-      },
-      "id": "408fccf0-30d6-11e7-8df8-6d3604a72912",
-      "type": "visualization",
-      "updated_at": "2018-03-01T18:58:07.906Z",
-      "version": 3
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query_string\":{\"query\":\"*\"}},\"filter\":[]}"
-        },
-        "title": "Top CPU intensive pods  [Metricbeat Kubernetes]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Top CPU intensive pods  [Metricbeat Kubernetes]\",\"type\":\"metrics\",\"params\":{\"id\":\"5d3692a0-2bfc-11e7-859b-f78b612cde28\",\"type\":\"top_n\",\"series\":[{\"id\":\"5d3692a1-2bfc-11e7-859b-f78b612cde28\",\"color\":\"#68BC00\",\"split_mode\":\"terms\",\"metrics\":[{\"id\":\"5d3692a2-2bfc-11e7-859b-f78b612cde28\",\"type\":\"sum\",\"field\":\"kubernetes.container.cpu.usage.core.ns\"},{\"unit\":\"1s\",\"id\":\"6c905240-2bfc-11e7-859b-f78b612cde28\",\"type\":\"derivative\",\"field\":\"5d3692a2-2bfc-11e7-859b-f78b612cde28\"},{\"unit\":\"\",\"id\":\"9a51f710-359d-11e7-aa4a-8313a0c92a88\",\"type\":\"positive_only\",\"field\":\"6c905240-2bfc-11e7-859b-f78b612cde28\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"0.0 a\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"terms_field\":\"kubernetes.pod.name\",\"terms_order_by\":\"5d3692a2-2bfc-11e7-859b-f78b612cde28\",\"value_template\":\"{{value}} ns\",\"offset_time\":\"\",\"override_index_pattern\":0}],\"time_field\":\"@timestamp\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"show_legend\":1,\"bar_color_rules\":[{\"id\":\"802104d0-2bfc-11e7-859b-f78b612cde28\"}],\"filter\":\"metricset.module:kubernetes AND metricset.name:container\"},\"aggs\":[],\"listeners\":{}}"
-      },
-      "id": "58e644f0-30d6-11e7-8df8-6d3604a72912",
-      "type": "visualization",
-      "updated_at": "2018-03-01T18:58:07.906Z",
-      "version": 3
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query\":{\"query_string\":{\"query\":\"*\"}},\"language\":\"lucene\"},\"filter\":[]}"
-        },
-        "title": "Top memory intensive pods  [Metricbeat Kubernetes]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Top memory intensive pods  [Metricbeat Kubernetes]\",\"type\":\"metrics\",\"params\":{\"id\":\"5d3692a0-2bfc-11e7-859b-f78b612cde28\",\"type\":\"top_n\",\"series\":[{\"id\":\"5d3692a1-2bfc-11e7-859b-f78b612cde28\",\"color\":\"#68BC00\",\"split_mode\":\"terms\",\"metrics\":[{\"id\":\"5d3692a2-2bfc-11e7-859b-f78b612cde28\",\"type\":\"sum\",\"field\":\"kubernetes.container.memory.usage.bytes\"},{\"id\":\"3972e9f0-256f-11e8-84e6-87221f87ae3b\",\"type\":\"cumulative_sum\",\"field\":\"5d3692a2-2bfc-11e7-859b-f78b612cde28\"},{\"unit\":\"10s\",\"id\":\"3e9fd5a0-256f-11e8-84e6-87221f87ae3b\",\"type\":\"derivative\",\"field\":\"3972e9f0-256f-11e8-84e6-87221f87ae3b\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"bytes\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"terms_field\":\"kubernetes.pod.name\",\"terms_order_by\":\"5d3692a2-2bfc-11e7-859b-f78b612cde28\",\"value_template\":\"\",\"offset_time\":\"\",\"override_index_pattern\":0,\"terms_size\":\"10\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"show_legend\":1,\"bar_color_rules\":[{\"id\":\"802104d0-2bfc-11e7-859b-f78b612cde28\"}],\"filter\":\"metricset.module:kubernetes AND metricset.name:container\",\"show_grid\":1},\"aggs\":[]}"
-      },
-      "id": "a4c9d360-30df-11e7-8df8-6d3604a72912",
-      "type": "visualization",
-      "updated_at": "2018-03-11T21:00:49.028Z",
-      "version": 4
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query_string\":{\"query\":\"*\"}},\"filter\":[]}"
-        },
-        "title": "Kubernetes - Unavailable pods",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Kubernetes - Unavailable pods\",\"type\":\"metrics\",\"params\":{\"id\":\"2fe9d3b0-30d5-11e7-8df8-6d3604a72912\",\"type\":\"metric\",\"series\":[{\"id\":\"2fe9d3b1-30d5-11e7-8df8-6d3604a72912\",\"color\":\"#68BC00\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"54cf79a0-30d5-11e7-8df8-6d3604a72912\",\"type\":\"sum\",\"field\":\"kubernetes.deployment.replicas.unavailable\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"label\":\"Unavailable Pods\",\"override_index_pattern\":1,\"series_interval\":\"10s\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"show_legend\":1,\"background_color_rules\":[{\"id\":\"508ffb30-30d5-11e7-8df8-6d3604a72912\"}],\"gauge_color_rules\":[{\"id\":\"50f9b980-30d5-11e7-8df8-6d3604a72912\"}],\"gauge_width\":\"10\",\"gauge_inner_width\":\"10\",\"gauge_style\":\"half\",\"bar_color_rules\":[{\"id\":\"674d83b0-30d5-11e7-8df8-6d3604a72912\"}],\"gauge_max\":\"\",\"filter\":\"metricset.module:kubernetes AND metricset.name:state_deployment\"},\"aggs\":[],\"listeners\":{}}"
-      },
-      "id": "174a6ad0-30e0-11e7-8df8-6d3604a72912",
-      "type": "visualization",
-      "updated_at": "2018-03-01T18:58:07.906Z",
-      "version": 3
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query\":{\"query_string\":{\"query\":\"*\"}},\"language\":\"lucene\"},\"filter\":[]}"
-        },
-        "title": "Unavailable pods per deployment [Metricbeat Kubernetes]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Unavailable pods per deployment [Metricbeat Kubernetes]\",\"type\":\"metrics\",\"params\":{\"id\":\"117fadf0-30df-11e7-8df8-6d3604a72912\",\"type\":\"timeseries\",\"series\":[{\"id\":\"64456840-30df-11e7-8df8-6d3604a72912\",\"color\":\"rgba(254,146,0,1)\",\"split_mode\":\"terms\",\"metrics\":[{\"id\":\"64456841-30df-11e7-8df8-6d3604a72912\",\"type\":\"avg\",\"field\":\"kubernetes.deployment.replicas.unavailable\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"stacked\",\"split_filters\":[{\"color\":\"#68BC00\",\"id\":\"53d35ad0-30df-11e7-8df8-6d3604a72912\"}],\"terms_field\":\"kubernetes.deployment.name\",\"label\":\"Unavailable pods\",\"terms_size\":\"10000\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"show_legend\":1,\"filter\":\"metricset.module:kubernetes AND metricset.name:state_deployment\",\"show_grid\":1},\"aggs\":[]}"
-      },
-      "id": "7aac4fd0-30e0-11e7-8df8-6d3604a72912",
-      "type": "visualization",
-      "updated_at": "2018-03-11T20:59:18.668Z",
-      "version": 4
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query_string\":{\"query\":\"*\"}},\"filter\":[]}"
-        },
-        "title": "Kubernetes - Available pods",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Kubernetes - Available pods\",\"type\":\"metrics\",\"params\":{\"id\":\"2fe9d3b0-30d5-11e7-8df8-6d3604a72912\",\"type\":\"metric\",\"series\":[{\"id\":\"2fe9d3b1-30d5-11e7-8df8-6d3604a72912\",\"color\":\"#68BC00\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"54cf79a0-30d5-11e7-8df8-6d3604a72912\",\"type\":\"sum\",\"field\":\"kubernetes.deployment.replicas.available\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"label\":\"Available Pods\",\"override_index_pattern\":1,\"series_time_field\":\"@timestamp\",\"series_index_pattern\":\"*\",\"series_interval\":\"10s\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"show_legend\":1,\"background_color_rules\":[{\"id\":\"508ffb30-30d5-11e7-8df8-6d3604a72912\"}],\"gauge_color_rules\":[{\"id\":\"50f9b980-30d5-11e7-8df8-6d3604a72912\"}],\"gauge_width\":\"10\",\"gauge_inner_width\":\"10\",\"gauge_style\":\"half\",\"bar_color_rules\":[{\"id\":\"674d83b0-30d5-11e7-8df8-6d3604a72912\"}],\"gauge_max\":\"5\",\"filter\":\"metricset.module:kubernetes AND metricset.name:state_deployment\"},\"aggs\":[],\"listeners\":{}}"
-      },
-      "id": "da1ff7c0-30ed-11e7-b9e5-2b5b07213ab3",
-      "type": "visualization",
-      "updated_at": "2018-03-01T18:58:07.906Z",
-      "version": 3
-    },
-    {
-      "attributes": {
-        "description": "",
-        "hits": 0,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[],\"highlightAll\":true,\"version\":true,\"query\":{\"language\":\"lucene\",\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}}}}"
-        },
-        "optionsJSON": "{\"darkTheme\":false,\"useMargins\":false}",
-        "panelsJSON": "[{\"gridData\":{\"h\":3,\"i\":\"1\",\"w\":6,\"x\":6,\"y\":0},\"id\":\"022a54c0-2bf5-11e7-859b-f78b612cde28\",\"panelIndex\":\"1\",\"type\":\"visualization\",\"version\":\"6.2.2\"},{\"gridData\":{\"h\":3,\"i\":\"2\",\"w\":6,\"x\":0,\"y\":6},\"id\":\"44f12b40-2bf4-11e7-859b-f78b612cde28\",\"panelIndex\":\"2\",\"type\":\"visualization\",\"version\":\"6.2.2\"},{\"gridData\":{\"h\":3,\"i\":\"5\",\"w\":3,\"x\":3,\"y\":0},\"id\":\"cd059410-2bfb-11e7-859b-f78b612cde28\",\"panelIndex\":\"5\",\"type\":\"visualization\",\"version\":\"6.2.2\"},{\"gridData\":{\"h\":3,\"i\":\"6\",\"w\":2,\"x\":0,\"y\":3},\"id\":\"e1018b90-2bfb-11e7-859b-f78b612cde28\",\"panelIndex\":\"6\",\"type\":\"visualization\",\"version\":\"6.2.2\"},{\"gridData\":{\"h\":3,\"i\":\"7\",\"w\":6,\"x\":6,\"y\":6},\"id\":\"d6564360-2bfc-11e7-859b-f78b612cde28\",\"panelIndex\":\"7\",\"type\":\"visualization\",\"version\":\"6.2.2\"},{\"gridData\":{\"h\":3,\"i\":\"8\",\"w\":6,\"x\":6,\"y\":9},\"id\":\"16fa4470-2bfd-11e7-859b-f78b612cde28\",\"panelIndex\":\"8\",\"type\":\"visualization\",\"version\":\"6.2.2\"},{\"gridData\":{\"h\":3,\"i\":\"9\",\"w\":6,\"x\":0,\"y\":9},\"id\":\"294546b0-30d6-11e7-8df8-6d3604a72912\",\"panelIndex\":\"9\",\"type\":\"visualization\",\"version\":\"6.2.2\"},{\"gridData\":{\"h\":3,\"i\":\"10\",\"w\":3,\"x\":0,\"y\":0},\"id\":\"408fccf0-30d6-11e7-8df8-6d3604a72912\",\"panelIndex\":\"10\",\"type\":\"visualization\",\"version\":\"6.2.2\"},{\"gridData\":{\"h\":3,\"i\":\"11\",\"w\":6,\"x\":0,\"y\":12},\"id\":\"58e644f0-30d6-11e7-8df8-6d3604a72912\",\"panelIndex\":\"11\",\"type\":\"visualization\",\"version\":\"6.2.2\"},{\"gridData\":{\"h\":3,\"i\":\"12\",\"w\":6,\"x\":6,\"y\":12},\"id\":\"a4c9d360-30df-11e7-8df8-6d3604a72912\",\"panelIndex\":\"12\",\"type\":\"visualization\",\"version\":\"6.2.2\"},{\"gridData\":{\"h\":3,\"i\":\"13\",\"w\":2,\"x\":4,\"y\":3},\"id\":\"174a6ad0-30e0-11e7-8df8-6d3604a72912\",\"panelIndex\":\"13\",\"type\":\"visualization\",\"version\":\"6.2.2\"},{\"gridData\":{\"h\":3,\"i\":\"14\",\"w\":6,\"x\":6,\"y\":3},\"id\":\"7aac4fd0-30e0-11e7-8df8-6d3604a72912\",\"panelIndex\":\"14\",\"type\":\"visualization\",\"version\":\"6.2.2\"},{\"gridData\":{\"h\":3,\"i\":\"15\",\"w\":2,\"x\":2,\"y\":3},\"id\":\"da1ff7c0-30ed-11e7-b9e5-2b5b07213ab3\",\"panelIndex\":\"15\",\"type\":\"visualization\",\"version\":\"6.2.2\"}]",
-        "timeRestore": false,
-        "title": "[Metricbeat Kubernetes] Overview",
-        "version": 1
-      },
-      "id": "AV4RGUqo5NkDleZmzKuZ",
-      "type": "dashboard",
-      "updated_at": "2018-03-11T21:00:58.354Z",
-      "version": 4
-    }
-  ],
-  "version": "6.2.2"
+    "objects": [
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "query": "*"
+                                }
+                            }
+                        }
+                    }
+                }, 
+                "title": "Available pods per deployment [Metricbeat Kubernetes]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "filter": "metricset.module:kubernetes AND metricset.name:state_deployment", 
+                        "id": "117fadf0-30df-11e7-8df8-6d3604a72912", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(104,188,0,1)", 
+                                "fill": 0.5, 
+                                "formatter": "number", 
+                                "id": "64456840-30df-11e7-8df8-6d3604a72912", 
+                                "label": "Available pods", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "kubernetes.deployment.replicas.available", 
+                                        "id": "64456841-30df-11e7-8df8-6d3604a72912", 
+                                        "type": "avg"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_filters": [
+                                    {
+                                        "color": "#68BC00", 
+                                        "id": "53d35ad0-30df-11e7-8df8-6d3604a72912"
+                                    }
+                                ], 
+                                "split_mode": "terms", 
+                                "stacked": "stacked", 
+                                "terms_field": "kubernetes.deployment.name", 
+                                "terms_size": "10000"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "timeseries"
+                    }, 
+                    "title": "Available pods per deployment [Metricbeat Kubernetes]", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "022a54c0-2bf5-11e7-859b-f78b612cde28", 
+            "type": "visualization", 
+            "updated_at": "2018-03-11T20:59:01.845Z", 
+            "version": 4
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "query_string": {
+                                "query": "*"
+                            }
+                        }
+                    }
+                }, 
+                "title": "CPU usage by node  [Metricbeat Kubernetes]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "listeners": {}, 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "background_color_rules": [
+                            {
+                                "id": "12c1f2f0-2bf2-11e7-859b-f78b612cde28"
+                            }
+                        ], 
+                        "bar_color_rules": [
+                            {
+                                "id": "1373ddd0-2bf2-11e7-859b-f78b612cde28"
+                            }
+                        ], 
+                        "filter": "metricset.module:kubernetes AND (metricset.name:container OR metricset.name:state_node)", 
+                        "gauge_color_rules": [
+                            {
+                                "id": "140e4910-2bf2-11e7-859b-f78b612cde28"
+                            }
+                        ], 
+                        "gauge_inner_width": 10, 
+                        "gauge_style": "half", 
+                        "gauge_width": 10, 
+                        "id": "0d5c6b10-2bf2-11e7-859b-f78b612cde28", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": "0.5", 
+                                "formatter": "0.0a", 
+                                "id": "0d5c9220-2bf2-11e7-859b-f78b612cde28", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "kubernetes.container.cpu.usage.nanocores", 
+                                        "id": "0d5c9221-2bf2-11e7-859b-f78b612cde28", 
+                                        "type": "sum"
+                                    }
+                                ], 
+                                "override_index_pattern": 0, 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "series_interval": "10s", 
+                                "series_time_field": "@timestamp", 
+                                "split_mode": "terms", 
+                                "stacked": "none", 
+                                "terms_field": "kubernetes.node.name", 
+                                "terms_order_by": "0d5c9221-2bf2-11e7-859b-f78b612cde28", 
+                                "terms_size": "10000", 
+                                "value_template": "{{value}} nanocores"
+                            }, 
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(211,49,21,1)", 
+                                "fill": "0", 
+                                "formatter": "0.0a", 
+                                "hide_in_legend": 1, 
+                                "id": "22f65d40-31a7-11e7-84cc-096d2b38e6e5", 
+                                "label": "", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "kubernetes.node.cpu.capacity.cores", 
+                                        "id": "22f65d41-31a7-11e7-84cc-096d2b38e6e5", 
+                                        "type": "avg"
+                                    }, 
+                                    {
+                                        "id": "4af4c390-34d6-11e7-be88-cb6a123dc1bb", 
+                                        "script": "params.cores * 1000000000", 
+                                        "type": "calculation", 
+                                        "variables": [
+                                            {
+                                                "field": "22f65d41-31a7-11e7-84cc-096d2b38e6e5", 
+                                                "id": "4cd32080-34d6-11e7-be88-cb6a123dc1bb", 
+                                                "name": "cores"
+                                            }
+                                        ]
+                                    }
+                                ], 
+                                "override_index_pattern": 0, 
+                                "point_size": "0", 
+                                "seperate_axis": 0, 
+                                "series_interval": "10s", 
+                                "series_time_field": "@timestamp", 
+                                "split_mode": "terms", 
+                                "stacked": "none", 
+                                "terms_field": "kubernetes.node.name", 
+                                "terms_order_by": "22f65d41-31a7-11e7-84cc-096d2b38e6e5", 
+                                "terms_size": "10000", 
+                                "value_template": "{{value}} nanocores"
+                            }
+                        ], 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "timeseries"
+                    }, 
+                    "title": "CPU usage by node  [Metricbeat Kubernetes]", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "44f12b40-2bf4-11e7-859b-f78b612cde28", 
+            "type": "visualization", 
+            "updated_at": "2018-03-01T18:58:07.906Z", 
+            "version": 3
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "query_string": {
+                                "query": "*"
+                            }
+                        }
+                    }
+                }, 
+                "title": "Kubernetes - Deployments", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "listeners": {}, 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "background_color_rules": [
+                            {
+                                "id": "67ee7da0-30e0-11e7-8df8-6d3604a72912"
+                            }
+                        ], 
+                        "bar_color_rules": [
+                            {
+                                "id": "68cdba10-30e0-11e7-8df8-6d3604a72912"
+                            }
+                        ], 
+                        "filter": "metricset.module:kubernetes AND metricset.name:state_deployment", 
+                        "gauge_color_rules": [
+                            {
+                                "id": "69765620-30e0-11e7-8df8-6d3604a72912"
+                            }
+                        ], 
+                        "gauge_inner_width": 10, 
+                        "gauge_style": "half", 
+                        "gauge_width": 10, 
+                        "id": "4c4690b0-30e0-11e7-8df8-6d3604a72912", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "formatter": "number", 
+                                "id": "4c4690b1-30e0-11e7-8df8-6d3604a72912", 
+                                "label": "Deployments", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "kubernetes.deployment.name", 
+                                        "id": "4c4690b2-30e0-11e7-8df8-6d3604a72912", 
+                                        "type": "cardinality"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none", 
+                                "terms_field": "kubernetes.deployment.name"
+                            }
+                        ], 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "metric"
+                    }, 
+                    "title": "Kubernetes - Deployments", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "cd059410-2bfb-11e7-859b-f78b612cde28", 
+            "type": "visualization", 
+            "updated_at": "2018-03-01T18:58:07.906Z", 
+            "version": 3
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "query_string": {
+                                "query": "*"
+                            }
+                        }
+                    }
+                }, 
+                "title": "Kubernetes - Desired pods", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "listeners": {}, 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "background_color_rules": [
+                            {
+                                "id": "508ffb30-30d5-11e7-8df8-6d3604a72912"
+                            }
+                        ], 
+                        "bar_color_rules": [
+                            {
+                                "id": "674d83b0-30d5-11e7-8df8-6d3604a72912"
+                            }
+                        ], 
+                        "filter": "metricset.module:kubernetes AND metricset.name:state_deployment", 
+                        "gauge_color_rules": [
+                            {
+                                "id": "50f9b980-30d5-11e7-8df8-6d3604a72912"
+                            }
+                        ], 
+                        "gauge_inner_width": "10", 
+                        "gauge_max": "5", 
+                        "gauge_style": "half", 
+                        "gauge_width": "10", 
+                        "id": "2fe9d3b0-30d5-11e7-8df8-6d3604a72912", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "formatter": "number", 
+                                "id": "2fe9d3b1-30d5-11e7-8df8-6d3604a72912", 
+                                "label": "Desired Pods", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "kubernetes.deployment.replicas.desired", 
+                                        "id": "54cf79a0-30d5-11e7-8df8-6d3604a72912", 
+                                        "type": "sum"
+                                    }
+                                ], 
+                                "override_index_pattern": 1, 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "series_interval": "10s", 
+                                "series_time_field": "@timestamp", 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }
+                        ], 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "metric"
+                    }, 
+                    "title": "Kubernetes - Desired pods", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "e1018b90-2bfb-11e7-859b-f78b612cde28", 
+            "type": "visualization", 
+            "updated_at": "2018-03-01T18:58:07.906Z", 
+            "version": 3
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "query": "*"
+                                }
+                            }
+                        }
+                    }
+                }, 
+                "title": "Memory usage by node  [Metricbeat Kubernetes]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "background_color_rules": [
+                            {
+                                "id": "12c1f2f0-2bf2-11e7-859b-f78b612cde28"
+                            }
+                        ], 
+                        "bar_color_rules": [
+                            {
+                                "id": "1373ddd0-2bf2-11e7-859b-f78b612cde28"
+                            }
+                        ], 
+                        "filter": "metricset.module:kubernetes AND (metricset.name:container OR metricset.name:state_node)", 
+                        "gauge_color_rules": [
+                            {
+                                "id": "140e4910-2bf2-11e7-859b-f78b612cde28"
+                            }
+                        ], 
+                        "gauge_inner_width": 10, 
+                        "gauge_style": "half", 
+                        "gauge_width": 10, 
+                        "id": "0d5c6b10-2bf2-11e7-859b-f78b612cde28", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "formatter": "bytes", 
+                                "id": "0d5c9220-2bf2-11e7-859b-f78b612cde28", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "kubernetes.container.memory.usage.bytes", 
+                                        "id": "0d5c9221-2bf2-11e7-859b-f78b612cde28", 
+                                        "type": "sum"
+                                    }, 
+                                    {
+                                        "field": "0d5c9221-2bf2-11e7-859b-f78b612cde28", 
+                                        "id": "9f0cf900-1ffb-11e8-81f2-43be86397500", 
+                                        "type": "cumulative_sum"
+                                    }, 
+                                    {
+                                        "field": "9f0cf900-1ffb-11e8-81f2-43be86397500", 
+                                        "id": "a926e130-1ffb-11e8-81f2-43be86397500", 
+                                        "type": "derivative", 
+                                        "unit": "10s"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "terms", 
+                                "stacked": "none", 
+                                "terms_field": "kubernetes.node.name", 
+                                "terms_order_by": "0d5c9221-2bf2-11e7-859b-f78b612cde28", 
+                                "terms_size": "10000"
+                            }, 
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(211,49,21,1)", 
+                                "fill": "0", 
+                                "formatter": "bytes", 
+                                "hide_in_legend": 1, 
+                                "id": "8ba3b270-31a7-11e7-84cc-096d2b38e6e5", 
+                                "label": "Node capacity", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "kubernetes.node.memory.capacity.bytes", 
+                                        "id": "8ba3b271-31a7-11e7-84cc-096d2b38e6e5", 
+                                        "type": "sum"
+                                    }, 
+                                    {
+                                        "field": "8ba3b271-31a7-11e7-84cc-096d2b38e6e5", 
+                                        "id": "d1fb2670-1ffb-11e8-81f2-43be86397500", 
+                                        "type": "cumulative_sum"
+                                    }, 
+                                    {
+                                        "field": "d1fb2670-1ffb-11e8-81f2-43be86397500", 
+                                        "id": "dc8b01f0-1ffb-11e8-81f2-43be86397500", 
+                                        "type": "derivative", 
+                                        "unit": "10s"
+                                    }
+                                ], 
+                                "point_size": "0", 
+                                "seperate_axis": 0, 
+                                "split_mode": "terms", 
+                                "stacked": "none", 
+                                "terms_field": "kubernetes.node.name", 
+                                "terms_order_by": "8ba3b271-31a7-11e7-84cc-096d2b38e6e5", 
+                                "terms_size": "10000"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "timeseries"
+                    }, 
+                    "title": "Memory usage by node  [Metricbeat Kubernetes]", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "d6564360-2bfc-11e7-859b-f78b612cde28", 
+            "type": "visualization", 
+            "updated_at": "2018-03-04T23:15:29.035Z", 
+            "version": 4
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "query_string": {
+                                "query": "*"
+                            }
+                        }
+                    }
+                }, 
+                "title": "Network in by node  [Metricbeat Kubernetes]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "listeners": {}, 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "background_color_rules": [
+                            {
+                                "id": "12c1f2f0-2bf2-11e7-859b-f78b612cde28"
+                            }
+                        ], 
+                        "bar_color_rules": [
+                            {
+                                "id": "1373ddd0-2bf2-11e7-859b-f78b612cde28"
+                            }
+                        ], 
+                        "filter": "metricset.module:kubernetes AND metricset.name:pod", 
+                        "gauge_color_rules": [
+                            {
+                                "id": "140e4910-2bf2-11e7-859b-f78b612cde28"
+                            }
+                        ], 
+                        "gauge_inner_width": 10, 
+                        "gauge_style": "half", 
+                        "gauge_width": 10, 
+                        "id": "0d5c6b10-2bf2-11e7-859b-f78b612cde28", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(104,188,0,1)", 
+                                "fill": 0.5, 
+                                "formatter": "bytes", 
+                                "id": "0d5c9220-2bf2-11e7-859b-f78b612cde28", 
+                                "label": "", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "kubernetes.pod.network.rx.bytes", 
+                                        "id": "0d5c9221-2bf2-11e7-859b-f78b612cde28", 
+                                        "type": "sum"
+                                    }, 
+                                    {
+                                        "field": "0d5c9221-2bf2-11e7-859b-f78b612cde28", 
+                                        "id": "494fc310-2bf7-11e7-859b-f78b612cde28", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }, 
+                                    {
+                                        "field": "494fc310-2bf7-11e7-859b-f78b612cde28", 
+                                        "id": "37c72a70-3598-11e7-aa4a-8313a0c92a88", 
+                                        "type": "positive_only", 
+                                        "unit": ""
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "terms", 
+                                "stacked": "stacked", 
+                                "terms_field": "kubernetes.node.name", 
+                                "terms_order_by": "0d5c9221-2bf2-11e7-859b-f78b612cde28", 
+                                "terms_size": "100000"
+                            }
+                        ], 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "timeseries"
+                    }, 
+                    "title": "Network in by node  [Metricbeat Kubernetes]", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "16fa4470-2bfd-11e7-859b-f78b612cde28", 
+            "type": "visualization", 
+            "updated_at": "2018-03-01T18:58:07.906Z", 
+            "version": 3
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "query_string": {
+                                "query": "*"
+                            }
+                        }
+                    }
+                }, 
+                "title": "Network out by node  [Metricbeat Kubernetes]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "listeners": {}, 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "background_color_rules": [
+                            {
+                                "id": "12c1f2f0-2bf2-11e7-859b-f78b612cde28"
+                            }
+                        ], 
+                        "bar_color_rules": [
+                            {
+                                "id": "1373ddd0-2bf2-11e7-859b-f78b612cde28"
+                            }
+                        ], 
+                        "filter": "metricset.module:kubernetes AND metricset.name:pod", 
+                        "gauge_color_rules": [
+                            {
+                                "id": "140e4910-2bf2-11e7-859b-f78b612cde28"
+                            }
+                        ], 
+                        "gauge_inner_width": 10, 
+                        "gauge_style": "half", 
+                        "gauge_width": 10, 
+                        "id": "0d5c6b10-2bf2-11e7-859b-f78b612cde28", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(104,188,0,1)", 
+                                "fill": 0.5, 
+                                "formatter": "bytes", 
+                                "id": "0d5c9220-2bf2-11e7-859b-f78b612cde28", 
+                                "label": "", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "kubernetes.pod.network.tx.bytes", 
+                                        "id": "0d5c9221-2bf2-11e7-859b-f78b612cde28", 
+                                        "type": "sum"
+                                    }, 
+                                    {
+                                        "field": "0d5c9221-2bf2-11e7-859b-f78b612cde28", 
+                                        "id": "494fc310-2bf7-11e7-859b-f78b612cde28", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }, 
+                                    {
+                                        "field": "494fc310-2bf7-11e7-859b-f78b612cde28", 
+                                        "id": "244c70e0-3598-11e7-aa4a-8313a0c92a88", 
+                                        "type": "positive_only", 
+                                        "unit": ""
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "terms", 
+                                "stacked": "stacked", 
+                                "terms_field": "kubernetes.node.name", 
+                                "terms_order_by": "0d5c9221-2bf2-11e7-859b-f78b612cde28", 
+                                "terms_size": "10000"
+                            }
+                        ], 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "timeseries"
+                    }, 
+                    "title": "Network out by node  [Metricbeat Kubernetes]", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "294546b0-30d6-11e7-8df8-6d3604a72912", 
+            "type": "visualization", 
+            "updated_at": "2018-03-01T18:58:07.906Z", 
+            "version": 3
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "query_string": {
+                                "query": "*"
+                            }
+                        }
+                    }
+                }, 
+                "title": "Kubernetes - Nodes", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "listeners": {}, 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "background_color_rules": [
+                            {
+                                "id": "67ee7da0-30e0-11e7-8df8-6d3604a72912"
+                            }
+                        ], 
+                        "bar_color_rules": [
+                            {
+                                "id": "68cdba10-30e0-11e7-8df8-6d3604a72912"
+                            }
+                        ], 
+                        "filter": "metricset.module:kubernetes AND metricset.name:state_node", 
+                        "gauge_color_rules": [
+                            {
+                                "id": "69765620-30e0-11e7-8df8-6d3604a72912"
+                            }
+                        ], 
+                        "gauge_inner_width": 10, 
+                        "gauge_style": "half", 
+                        "gauge_width": 10, 
+                        "id": "4c4690b0-30e0-11e7-8df8-6d3604a72912", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "formatter": "number", 
+                                "id": "4c4690b1-30e0-11e7-8df8-6d3604a72912", 
+                                "label": "Nodes", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "kubernetes.node.name", 
+                                        "id": "4c4690b2-30e0-11e7-8df8-6d3604a72912", 
+                                        "type": "cardinality"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none", 
+                                "terms_field": "kubernetes.deployment.name"
+                            }
+                        ], 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "metric"
+                    }, 
+                    "title": "Kubernetes - Nodes", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "408fccf0-30d6-11e7-8df8-6d3604a72912", 
+            "type": "visualization", 
+            "updated_at": "2018-03-01T18:58:07.906Z", 
+            "version": 3
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "query_string": {
+                                "query": "*"
+                            }
+                        }
+                    }
+                }, 
+                "title": "Top CPU intensive pods  [Metricbeat Kubernetes]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "listeners": {}, 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "bar_color_rules": [
+                            {
+                                "id": "802104d0-2bfc-11e7-859b-f78b612cde28"
+                            }
+                        ], 
+                        "filter": "metricset.module:kubernetes AND metricset.name:container", 
+                        "id": "5d3692a0-2bfc-11e7-859b-f78b612cde28", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "formatter": "0.0 a", 
+                                "id": "5d3692a1-2bfc-11e7-859b-f78b612cde28", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "kubernetes.container.cpu.usage.core.ns", 
+                                        "id": "5d3692a2-2bfc-11e7-859b-f78b612cde28", 
+                                        "type": "sum"
+                                    }, 
+                                    {
+                                        "field": "5d3692a2-2bfc-11e7-859b-f78b612cde28", 
+                                        "id": "6c905240-2bfc-11e7-859b-f78b612cde28", 
+                                        "type": "derivative", 
+                                        "unit": "1s"
+                                    }, 
+                                    {
+                                        "field": "6c905240-2bfc-11e7-859b-f78b612cde28", 
+                                        "id": "9a51f710-359d-11e7-aa4a-8313a0c92a88", 
+                                        "type": "positive_only", 
+                                        "unit": ""
+                                    }
+                                ], 
+                                "offset_time": "", 
+                                "override_index_pattern": 0, 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "terms", 
+                                "stacked": "none", 
+                                "terms_field": "kubernetes.pod.name", 
+                                "terms_order_by": "5d3692a2-2bfc-11e7-859b-f78b612cde28", 
+                                "value_template": "{{value}} ns"
+                            }
+                        ], 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "top_n"
+                    }, 
+                    "title": "Top CPU intensive pods  [Metricbeat Kubernetes]", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "58e644f0-30d6-11e7-8df8-6d3604a72912", 
+            "type": "visualization", 
+            "updated_at": "2018-03-01T18:58:07.906Z", 
+            "version": 3
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "query": "*"
+                                }
+                            }
+                        }
+                    }
+                }, 
+                "title": "Top memory intensive pods  [Metricbeat Kubernetes]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "bar_color_rules": [
+                            {
+                                "id": "802104d0-2bfc-11e7-859b-f78b612cde28"
+                            }
+                        ], 
+                        "filter": "metricset.module:kubernetes AND metricset.name:container", 
+                        "id": "5d3692a0-2bfc-11e7-859b-f78b612cde28", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "formatter": "bytes", 
+                                "id": "5d3692a1-2bfc-11e7-859b-f78b612cde28", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "kubernetes.container.memory.usage.bytes", 
+                                        "id": "5d3692a2-2bfc-11e7-859b-f78b612cde28", 
+                                        "type": "sum"
+                                    }, 
+                                    {
+                                        "field": "5d3692a2-2bfc-11e7-859b-f78b612cde28", 
+                                        "id": "3972e9f0-256f-11e8-84e6-87221f87ae3b", 
+                                        "type": "cumulative_sum"
+                                    }, 
+                                    {
+                                        "field": "3972e9f0-256f-11e8-84e6-87221f87ae3b", 
+                                        "id": "3e9fd5a0-256f-11e8-84e6-87221f87ae3b", 
+                                        "type": "derivative", 
+                                        "unit": "10s"
+                                    }
+                                ], 
+                                "offset_time": "", 
+                                "override_index_pattern": 0, 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "terms", 
+                                "stacked": "none", 
+                                "terms_field": "kubernetes.pod.name", 
+                                "terms_order_by": "5d3692a2-2bfc-11e7-859b-f78b612cde28", 
+                                "terms_size": "10", 
+                                "value_template": ""
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "top_n"
+                    }, 
+                    "title": "Top memory intensive pods  [Metricbeat Kubernetes]", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "a4c9d360-30df-11e7-8df8-6d3604a72912", 
+            "type": "visualization", 
+            "updated_at": "2018-03-11T21:00:49.028Z", 
+            "version": 4
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "query_string": {
+                                "query": "*"
+                            }
+                        }
+                    }
+                }, 
+                "title": "Kubernetes - Unavailable pods", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "listeners": {}, 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "background_color_rules": [
+                            {
+                                "id": "508ffb30-30d5-11e7-8df8-6d3604a72912"
+                            }
+                        ], 
+                        "bar_color_rules": [
+                            {
+                                "id": "674d83b0-30d5-11e7-8df8-6d3604a72912"
+                            }
+                        ], 
+                        "filter": "metricset.module:kubernetes AND metricset.name:state_deployment", 
+                        "gauge_color_rules": [
+                            {
+                                "id": "50f9b980-30d5-11e7-8df8-6d3604a72912"
+                            }
+                        ], 
+                        "gauge_inner_width": "10", 
+                        "gauge_max": "", 
+                        "gauge_style": "half", 
+                        "gauge_width": "10", 
+                        "id": "2fe9d3b0-30d5-11e7-8df8-6d3604a72912", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "formatter": "number", 
+                                "id": "2fe9d3b1-30d5-11e7-8df8-6d3604a72912", 
+                                "label": "Unavailable Pods", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "kubernetes.deployment.replicas.unavailable", 
+                                        "id": "54cf79a0-30d5-11e7-8df8-6d3604a72912", 
+                                        "type": "sum"
+                                    }
+                                ], 
+                                "override_index_pattern": 1, 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "series_interval": "10s", 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }
+                        ], 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "metric"
+                    }, 
+                    "title": "Kubernetes - Unavailable pods", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "174a6ad0-30e0-11e7-8df8-6d3604a72912", 
+            "type": "visualization", 
+            "updated_at": "2018-03-01T18:58:07.906Z", 
+            "version": 3
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "query": "*"
+                                }
+                            }
+                        }
+                    }
+                }, 
+                "title": "Unavailable pods per deployment [Metricbeat Kubernetes]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "filter": "metricset.module:kubernetes AND metricset.name:state_deployment", 
+                        "id": "117fadf0-30df-11e7-8df8-6d3604a72912", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(254,146,0,1)", 
+                                "fill": 0.5, 
+                                "formatter": "number", 
+                                "id": "64456840-30df-11e7-8df8-6d3604a72912", 
+                                "label": "Unavailable pods", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "kubernetes.deployment.replicas.unavailable", 
+                                        "id": "64456841-30df-11e7-8df8-6d3604a72912", 
+                                        "type": "avg"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_filters": [
+                                    {
+                                        "color": "#68BC00", 
+                                        "id": "53d35ad0-30df-11e7-8df8-6d3604a72912"
+                                    }
+                                ], 
+                                "split_mode": "terms", 
+                                "stacked": "stacked", 
+                                "terms_field": "kubernetes.deployment.name", 
+                                "terms_size": "10000"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "timeseries"
+                    }, 
+                    "title": "Unavailable pods per deployment [Metricbeat Kubernetes]", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "7aac4fd0-30e0-11e7-8df8-6d3604a72912", 
+            "type": "visualization", 
+            "updated_at": "2018-03-11T20:59:18.668Z", 
+            "version": 4
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "query_string": {
+                                "query": "*"
+                            }
+                        }
+                    }
+                }, 
+                "title": "Kubernetes - Available pods", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "listeners": {}, 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "background_color_rules": [
+                            {
+                                "id": "508ffb30-30d5-11e7-8df8-6d3604a72912"
+                            }
+                        ], 
+                        "bar_color_rules": [
+                            {
+                                "id": "674d83b0-30d5-11e7-8df8-6d3604a72912"
+                            }
+                        ], 
+                        "filter": "metricset.module:kubernetes AND metricset.name:state_deployment", 
+                        "gauge_color_rules": [
+                            {
+                                "id": "50f9b980-30d5-11e7-8df8-6d3604a72912"
+                            }
+                        ], 
+                        "gauge_inner_width": "10", 
+                        "gauge_max": "5", 
+                        "gauge_style": "half", 
+                        "gauge_width": "10", 
+                        "id": "2fe9d3b0-30d5-11e7-8df8-6d3604a72912", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "formatter": "number", 
+                                "id": "2fe9d3b1-30d5-11e7-8df8-6d3604a72912", 
+                                "label": "Available Pods", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "kubernetes.deployment.replicas.available", 
+                                        "id": "54cf79a0-30d5-11e7-8df8-6d3604a72912", 
+                                        "type": "sum"
+                                    }
+                                ], 
+                                "override_index_pattern": 1, 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "series_index_pattern": "*", 
+                                "series_interval": "10s", 
+                                "series_time_field": "@timestamp", 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }
+                        ], 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "metric"
+                    }, 
+                    "title": "Kubernetes - Available pods", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "da1ff7c0-30ed-11e7-b9e5-2b5b07213ab3", 
+            "type": "visualization", 
+            "updated_at": "2018-03-01T18:58:07.906Z", 
+            "version": 3
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "analyze_wildcard": true, 
+                                    "query": "*"
+                                }
+                            }
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false, 
+                    "useMargins": false
+                }, 
+                "panelsJSON": [
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "1", 
+                            "w": 6, 
+                            "x": 6, 
+                            "y": 0
+                        }, 
+                        "id": "022a54c0-2bf5-11e7-859b-f78b612cde28", 
+                        "panelIndex": "1", 
+                        "type": "visualization", 
+                        "version": "6.2.2"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "2", 
+                            "w": 6, 
+                            "x": 0, 
+                            "y": 6
+                        }, 
+                        "id": "44f12b40-2bf4-11e7-859b-f78b612cde28", 
+                        "panelIndex": "2", 
+                        "type": "visualization", 
+                        "version": "6.2.2"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "5", 
+                            "w": 3, 
+                            "x": 3, 
+                            "y": 0
+                        }, 
+                        "id": "cd059410-2bfb-11e7-859b-f78b612cde28", 
+                        "panelIndex": "5", 
+                        "type": "visualization", 
+                        "version": "6.2.2"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "6", 
+                            "w": 2, 
+                            "x": 0, 
+                            "y": 3
+                        }, 
+                        "id": "e1018b90-2bfb-11e7-859b-f78b612cde28", 
+                        "panelIndex": "6", 
+                        "type": "visualization", 
+                        "version": "6.2.2"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "7", 
+                            "w": 6, 
+                            "x": 6, 
+                            "y": 6
+                        }, 
+                        "id": "d6564360-2bfc-11e7-859b-f78b612cde28", 
+                        "panelIndex": "7", 
+                        "type": "visualization", 
+                        "version": "6.2.2"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "8", 
+                            "w": 6, 
+                            "x": 6, 
+                            "y": 9
+                        }, 
+                        "id": "16fa4470-2bfd-11e7-859b-f78b612cde28", 
+                        "panelIndex": "8", 
+                        "type": "visualization", 
+                        "version": "6.2.2"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "9", 
+                            "w": 6, 
+                            "x": 0, 
+                            "y": 9
+                        }, 
+                        "id": "294546b0-30d6-11e7-8df8-6d3604a72912", 
+                        "panelIndex": "9", 
+                        "type": "visualization", 
+                        "version": "6.2.2"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "10", 
+                            "w": 3, 
+                            "x": 0, 
+                            "y": 0
+                        }, 
+                        "id": "408fccf0-30d6-11e7-8df8-6d3604a72912", 
+                        "panelIndex": "10", 
+                        "type": "visualization", 
+                        "version": "6.2.2"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "11", 
+                            "w": 6, 
+                            "x": 0, 
+                            "y": 12
+                        }, 
+                        "id": "58e644f0-30d6-11e7-8df8-6d3604a72912", 
+                        "panelIndex": "11", 
+                        "type": "visualization", 
+                        "version": "6.2.2"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "12", 
+                            "w": 6, 
+                            "x": 6, 
+                            "y": 12
+                        }, 
+                        "id": "a4c9d360-30df-11e7-8df8-6d3604a72912", 
+                        "panelIndex": "12", 
+                        "type": "visualization", 
+                        "version": "6.2.2"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "13", 
+                            "w": 2, 
+                            "x": 4, 
+                            "y": 3
+                        }, 
+                        "id": "174a6ad0-30e0-11e7-8df8-6d3604a72912", 
+                        "panelIndex": "13", 
+                        "type": "visualization", 
+                        "version": "6.2.2"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "14", 
+                            "w": 6, 
+                            "x": 6, 
+                            "y": 3
+                        }, 
+                        "id": "7aac4fd0-30e0-11e7-8df8-6d3604a72912", 
+                        "panelIndex": "14", 
+                        "type": "visualization", 
+                        "version": "6.2.2"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "15", 
+                            "w": 2, 
+                            "x": 2, 
+                            "y": 3
+                        }, 
+                        "id": "da1ff7c0-30ed-11e7-b9e5-2b5b07213ab3", 
+                        "panelIndex": "15", 
+                        "type": "visualization", 
+                        "version": "6.2.2"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "[Metricbeat Kubernetes] Overview", 
+                "version": 1
+            }, 
+            "id": "AV4RGUqo5NkDleZmzKuZ", 
+            "type": "dashboard", 
+            "updated_at": "2018-03-11T21:00:58.354Z", 
+            "version": 4
+        }
+    ], 
+    "version": "6.2.2"
 }

--- a/metricbeat/module/mongodb/_meta/kibana/6/dashboard/Metricbeat-mongodb-overview.json
+++ b/metricbeat/module/mongodb/_meta/kibana/6/dashboard/Metricbeat-mongodb-overview.json
@@ -1,172 +1,1239 @@
 {
-  "objects": [
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[]}"
-        },
-        "savedSearchId": "MongoDB-search",
-        "title": "Hosts [Metricbeat MongoDB]",
-        "uiStateJSON": "{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":null,\"direction\":null}}}}",
-        "version": 1,
-        "visState": "{\"title\":\"Hosts [Metricbeat MongoDB]\",\"type\":\"table\",\"params\":{\"perPage\":10,\"showPartialRows\":false,\"showMeticsAtAllLevels\":false,\"sort\":{\"columnIndex\":null,\"direction\":null},\"showTotal\":false,\"totalFunc\":\"sum\"},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"mongodb.status.connections.current\",\"customLabel\":\"Number of connections\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"metricset.host\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\"}},{\"id\":\"3\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"mongodb.status.memory.bits\",\"customLabel\":\"Arch\"}},{\"id\":\"4\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"mongodb.status.memory.resident.mb\",\"customLabel\":\"Resident memory\"}},{\"id\":\"5\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"mongodb.status.memory.virtual.mb\",\"customLabel\":\"Virtual memory\"}}]}"
-      },
-      "id": "MongoDB-hosts",
-      "type": "visualization",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[]}"
-        },
-        "savedSearchId": "MongoDB-search",
-        "title": "Engine \u0026 Version [Metricbeat MongoDB]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Engine \u0026 Version [Metricbeat MongoDB]\",\"type\":\"pie\",\"params\":{\"addLegend\":true,\"addTooltip\":true,\"isDonut\":true,\"legendPosition\":\"bottom\",\"shareYAxis\":true,\"type\":\"pie\"},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"cardinality\",\"schema\":\"metric\",\"params\":{\"field\":\"metricset.host\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"mongodb.status.storage_engine.name\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"Engine\"}},{\"id\":\"3\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"mongodb.status.version\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"Version\"}}]}"
-      },
-      "id": "MongoDB-Engine-ampersand-Version",
-      "type": "visualization",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[]}"
-        },
-        "savedSearchId": "MongoDB-search",
-        "title": "Operation counters [Metricbeat MongoDB]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Operation counters [Metricbeat MongoDB]\",\"type\":\"area\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"bottom\",\"smoothLines\":false,\"scale\":\"linear\",\"interpolate\":\"linear\",\"mode\":\"stacked\",\"times\":[],\"addTimeMarker\":false,\"defaultYExtents\":false,\"setYExtents\":false,\"yAxis\":{},\"type\":\"area\",\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"type\":\"category\",\"position\":\"bottom\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\"},\"labels\":{\"show\":true,\"truncate\":100},\"title\":{}}],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"name\":\"LeftAxis-1\",\"type\":\"value\",\"position\":\"left\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\",\"mode\":\"normal\"},\"labels\":{\"show\":true,\"rotate\":0,\"filter\":false,\"truncate\":100},\"title\":{\"text\":\"Count\"}}],\"seriesParams\":[{\"show\":\"true\",\"type\":\"area\",\"mode\":\"stacked\",\"data\":{\"label\":\"Count\",\"id\":\"1\"},\"drawLinesBetweenPoints\":true,\"showCircles\":true,\"interpolate\":\"linear\",\"valueAxis\":\"ValueAxis-1\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"mongodb.status.opcounters.command\",\"customLabel\":\"command\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"auto\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}},{\"id\":\"3\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"mongodb.status.opcounters.delete\",\"customLabel\":\"delete\"}},{\"id\":\"4\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"mongodb.status.opcounters.getmore\",\"customLabel\":\"getmore\"}},{\"id\":\"5\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"mongodb.status.opcounters.insert\",\"customLabel\":\"insert\"}},{\"id\":\"6\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"mongodb.status.opcounters.query\",\"customLabel\":\"query\"}},{\"id\":\"7\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"mongodb.status.opcounters_replicated.update\",\"customLabel\":\"update\"}}]}"
-      },
-      "id": "MongoDB-operation-counters",
-      "type": "visualization",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[]}"
-        },
-        "savedSearchId": "MongoDB-search",
-        "title": "Concurrent transactions Read [Metricbeat MongoDB]",
-        "uiStateJSON": "{\"vis\":{\"colors\":{\"Read Available\":\"#508642\",\"Read Used\":\"#BF1B00\"}}}",
-        "version": 1,
-        "visState": "{\"title\":\"Concurrent transactions Read [Metricbeat MongoDB]\",\"type\":\"area\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"bottom\",\"smoothLines\":false,\"scale\":\"linear\",\"interpolate\":\"linear\",\"mode\":\"stacked\",\"times\":[],\"addTimeMarker\":false,\"defaultYExtents\":false,\"setYExtents\":false,\"yAxis\":{},\"type\":\"area\",\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"type\":\"category\",\"position\":\"bottom\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\"},\"labels\":{\"show\":true,\"truncate\":100},\"title\":{}}],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"name\":\"LeftAxis-1\",\"type\":\"value\",\"position\":\"left\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\",\"mode\":\"normal\"},\"labels\":{\"show\":true,\"rotate\":0,\"filter\":false,\"truncate\":100},\"title\":{\"text\":\"Count\"}}],\"seriesParams\":[{\"show\":\"true\",\"type\":\"area\",\"mode\":\"stacked\",\"data\":{\"label\":\"Count\",\"id\":\"1\"},\"drawLinesBetweenPoints\":true,\"showCircles\":true,\"interpolate\":\"linear\",\"valueAxis\":\"ValueAxis-1\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"mongodb.status.wired_tiger.concurrent_transactions.read.available\",\"customLabel\":\"Read Available\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"auto\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}},{\"id\":\"3\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"mongodb.status.wired_tiger.concurrent_transactions.read.out\",\"customLabel\":\"Read Used\"}}]}"
-      },
-      "id": "MongoDB-Concurrent-transactions-Read",
-      "type": "visualization",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[]}"
-        },
-        "savedSearchId": "MongoDB-search",
-        "title": "Concurrent transactions Write [Metricbeat MongoDB]",
-        "uiStateJSON": "{\"vis\":{\"colors\":{\"Write Available\":\"#629E51\",\"Write Used\":\"#BF1B00\"}}}",
-        "version": 1,
-        "visState": "{\"title\":\"Concurrent transactions Write [Metricbeat MongoDB]\",\"type\":\"area\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"defaultYExtents\":false,\"interpolate\":\"linear\",\"legendPosition\":\"bottom\",\"mode\":\"stacked\",\"scale\":\"linear\",\"setYExtents\":false,\"shareYAxis\":true,\"smoothLines\":false,\"times\":[],\"yAxis\":{},\"type\":\"area\",\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"type\":\"category\",\"position\":\"bottom\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\"},\"labels\":{\"show\":true,\"truncate\":100},\"title\":{}}],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"name\":\"LeftAxis-1\",\"type\":\"value\",\"position\":\"left\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\",\"mode\":\"normal\"},\"labels\":{\"show\":true,\"rotate\":0,\"filter\":false,\"truncate\":100},\"title\":{\"text\":\"Count\"}}],\"seriesParams\":[{\"show\":\"true\",\"type\":\"area\",\"mode\":\"stacked\",\"data\":{\"label\":\"Count\",\"id\":\"1\"},\"drawLinesBetweenPoints\":true,\"showCircles\":true,\"interpolate\":\"linear\",\"valueAxis\":\"ValueAxis-1\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"mongodb.status.wired_tiger.concurrent_transactions.write.available\",\"customLabel\":\"Write Available\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"auto\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}},{\"id\":\"3\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"mongodb.status.wired_tiger.concurrent_transactions.write.out\",\"customLabel\":\"Write Used\"}}]}"
-      },
-      "id": "MongoDB-Concurrent-transactions-Write",
-      "type": "visualization",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[]}"
-        },
-        "savedSearchId": "MongoDB-search",
-        "title": "Memory stats [Metricbeat MongoDB]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Memory stats [Metricbeat MongoDB]\",\"type\":\"line\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"bottom\",\"showCircles\":true,\"smoothLines\":false,\"interpolate\":\"linear\",\"scale\":\"log\",\"drawLinesBetweenPoints\":true,\"radiusRatio\":9,\"times\":[],\"addTimeMarker\":false,\"defaultYExtents\":false,\"setYExtents\":false,\"yAxis\":{},\"type\":\"line\",\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"type\":\"category\",\"position\":\"bottom\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\"},\"labels\":{\"show\":true,\"truncate\":100},\"title\":{}}],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"name\":\"LeftAxis-1\",\"type\":\"value\",\"position\":\"left\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\",\"mode\":\"normal\"},\"labels\":{\"show\":true,\"rotate\":0,\"filter\":false,\"truncate\":100},\"title\":{\"text\":\"Count\"}}],\"seriesParams\":[{\"show\":\"true\",\"type\":\"line\",\"mode\":\"normal\",\"data\":{\"label\":\"Count\",\"id\":\"1\"},\"valueAxis\":\"ValueAxis-1\",\"drawLinesBetweenPoints\":true,\"showCircles\":true}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"mongodb.status.memory.mapped.mb\",\"customLabel\":\"Mapped\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"auto\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}},{\"id\":\"3\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"mongodb.status.memory.mapped_with_journal.mb\",\"customLabel\":\"Mapped with journal\"}},{\"id\":\"4\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"mongodb.status.memory.resident.mb\",\"customLabel\":\"Rezident\"}},{\"id\":\"5\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"mongodb.status.memory.virtual.mb\",\"customLabel\":\"Virtual\"}}]}"
-      },
-      "id": "MongoDB-memory-stats",
-      "type": "visualization",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[]}"
-        },
-        "savedSearchId": "MongoDB-search",
-        "title": "Asserts [Metricbeat MongoDB]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Asserts [Metricbeat MongoDB]\",\"type\":\"area\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"bottom\",\"smoothLines\":false,\"scale\":\"linear\",\"interpolate\":\"linear\",\"mode\":\"stacked\",\"times\":[],\"addTimeMarker\":false,\"defaultYExtents\":false,\"setYExtents\":false,\"yAxis\":{},\"type\":\"area\",\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"type\":\"category\",\"position\":\"bottom\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\"},\"labels\":{\"show\":true,\"truncate\":100},\"title\":{}}],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"name\":\"LeftAxis-1\",\"type\":\"value\",\"position\":\"left\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\",\"mode\":\"normal\"},\"labels\":{\"show\":true,\"rotate\":0,\"filter\":false,\"truncate\":100},\"title\":{\"text\":\"Count\"}}],\"seriesParams\":[{\"show\":\"true\",\"type\":\"area\",\"mode\":\"stacked\",\"data\":{\"label\":\"Count\",\"id\":\"1\"},\"drawLinesBetweenPoints\":true,\"showCircles\":true,\"interpolate\":\"linear\",\"valueAxis\":\"ValueAxis-1\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"max\",\"schema\":\"metric\",\"params\":{\"field\":\"mongodb.status.asserts.msg\",\"customLabel\":\"message\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"auto\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}},{\"id\":\"3\",\"enabled\":true,\"type\":\"max\",\"schema\":\"metric\",\"params\":{\"field\":\"mongodb.status.asserts.regular\",\"customLabel\":\"regular\"}},{\"id\":\"4\",\"enabled\":true,\"type\":\"max\",\"schema\":\"metric\",\"params\":{\"field\":\"mongodb.status.asserts.rollovers\",\"customLabel\":\"rollover\"}},{\"id\":\"5\",\"enabled\":true,\"type\":\"max\",\"schema\":\"metric\",\"params\":{\"field\":\"mongodb.status.asserts.user\",\"customLabel\":\"user\"}},{\"id\":\"6\",\"enabled\":true,\"type\":\"max\",\"schema\":\"metric\",\"params\":{\"field\":\"mongodb.status.asserts.warning\",\"customLabel\":\"warning\"}}]}"
-      },
-      "id": "MongoDB-asserts",
-      "type": "visualization",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[]}"
-        },
-        "savedSearchId": "MongoDB-search",
-        "title": "WiredTiger Cache [Metricbeat MongoDB]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"WiredTiger Cache [Metricbeat MongoDB]\",\"type\":\"area\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"bottom\",\"smoothLines\":false,\"scale\":\"linear\",\"interpolate\":\"linear\",\"mode\":\"overlap\",\"times\":[],\"addTimeMarker\":false,\"defaultYExtents\":false,\"setYExtents\":false,\"yAxis\":{},\"type\":\"area\",\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"type\":\"category\",\"position\":\"bottom\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\"},\"labels\":{\"show\":true,\"truncate\":100},\"title\":{}}],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"name\":\"LeftAxis-1\",\"type\":\"value\",\"position\":\"left\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\",\"mode\":\"normal\"},\"labels\":{\"show\":true,\"rotate\":0,\"filter\":false,\"truncate\":100},\"title\":{\"text\":\"Count\"}}],\"seriesParams\":[{\"show\":\"true\",\"type\":\"area\",\"mode\":\"stacked\",\"data\":{\"label\":\"Count\",\"id\":\"1\"},\"drawLinesBetweenPoints\":true,\"showCircles\":true,\"interpolate\":\"linear\",\"valueAxis\":\"ValueAxis-1\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"mongodb.status.wired_tiger.cache.maximum.bytes\",\"customLabel\":\"max\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"auto\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}},{\"id\":\"3\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"mongodb.status.wired_tiger.cache.used.bytes\",\"customLabel\":\"used\"}},{\"id\":\"4\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"mongodb.status.wired_tiger.cache.dirty.bytes\",\"customLabel\":\"dirty\"}}]}"
-      },
-      "id": "MongoDB-WiredTiger-Cache",
-      "type": "visualization",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "columns": [
-          "_source"
-        ],
-        "description": "",
-        "hits": 0,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"index\":\"metricbeat-*\",\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"metricset.module:mongodb\"}},\"filter\":[],\"highlight\":{\"pre_tags\":[\"@kibana-highlighted-field@\"],\"post_tags\":[\"@/kibana-highlighted-field@\"],\"fields\":{\"*\":{}},\"require_field_match\":false,\"fragment_size\":2147483647}}"
-        },
-        "sort": [
-          "@timestamp",
-          "desc"
-        ],
-        "title": "MongoDB search",
-        "version": 1
-      },
-      "id": "MongoDB-search",
-      "type": "search",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "hits": 0,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[],\"query\":{\"language\":\"lucene\",\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}}},\"highlightAll\":true,\"version\":true}"
-        },
-        "optionsJSON": "{\"darkTheme\":false}",
-        "panelsJSON": "[{\"col\":1,\"id\":\"MongoDB-hosts\",\"panelIndex\":1,\"row\":1,\"size_x\":8,\"size_y\":3,\"type\":\"visualization\"},{\"col\":9,\"id\":\"MongoDB-Engine-ampersand-Version\",\"panelIndex\":4,\"row\":1,\"size_x\":4,\"size_y\":3,\"type\":\"visualization\"},{\"col\":1,\"id\":\"MongoDB-operation-counters\",\"panelIndex\":2,\"row\":4,\"size_x\":6,\"size_y\":3,\"type\":\"visualization\"},{\"col\":7,\"id\":\"MongoDB-Concurrent-transactions-Read\",\"panelIndex\":6,\"row\":4,\"size_x\":3,\"size_y\":3,\"type\":\"visualization\"},{\"col\":10,\"id\":\"MongoDB-Concurrent-transactions-Write\",\"panelIndex\":7,\"row\":4,\"size_x\":3,\"size_y\":3,\"type\":\"visualization\"},{\"col\":1,\"id\":\"MongoDB-memory-stats\",\"panelIndex\":5,\"row\":10,\"size_x\":12,\"size_y\":4,\"type\":\"visualization\"},{\"col\":7,\"id\":\"MongoDB-asserts\",\"panelIndex\":3,\"row\":7,\"size_x\":6,\"size_y\":3,\"type\":\"visualization\"},{\"col\":1,\"id\":\"MongoDB-WiredTiger-Cache\",\"panelIndex\":8,\"row\":7,\"size_x\":6,\"size_y\":3,\"type\":\"visualization\"}]",
-        "timeRestore": false,
-        "title": "[Metricbeat MongoDB] Overview",
-        "uiStateJSON": "{\"P-1\":{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":null,\"direction\":null}}}}}",
-        "version": 1
-      },
-      "id": "Metricbeat-MongoDB",
-      "type": "dashboard",
-      "version": 3
-    }
-  ],
-  "version": "6.0.0-beta1-SNAPSHOT"
+    "objects": [
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "MongoDB-search", 
+                "title": "Hosts [Metricbeat MongoDB]", 
+                "uiStateJSON": {
+                    "vis": {
+                        "params": {
+                            "sort": {
+                                "columnIndex": null, 
+                                "direction": null
+                            }
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Number of connections", 
+                                "field": "mongodb.status.connections.current"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "field": "metricset.host", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "bucket", 
+                            "type": "terms"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "customLabel": "Arch", 
+                                "field": "mongodb.status.memory.bits"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "4", 
+                            "params": {
+                                "customLabel": "Resident memory", 
+                                "field": "mongodb.status.memory.resident.mb"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "5", 
+                            "params": {
+                                "customLabel": "Virtual memory", 
+                                "field": "mongodb.status.memory.virtual.mb"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }
+                    ], 
+                    "params": {
+                        "perPage": 10, 
+                        "showMeticsAtAllLevels": false, 
+                        "showPartialRows": false, 
+                        "showTotal": false, 
+                        "sort": {
+                            "columnIndex": null, 
+                            "direction": null
+                        }, 
+                        "totalFunc": "sum"
+                    }, 
+                    "title": "Hosts [Metricbeat MongoDB]", 
+                    "type": "table"
+                }
+            }, 
+            "id": "MongoDB-hosts", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "MongoDB-search", 
+                "title": "Engine & Version [Metricbeat MongoDB]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "field": "metricset.host"
+                            }, 
+                            "schema": "metric", 
+                            "type": "cardinality"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customLabel": "Engine", 
+                                "field": "mongodb.status.storage_engine.name", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "customLabel": "Version", 
+                                "field": "mongodb.status.version", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "params": {
+                        "addLegend": true, 
+                        "addTooltip": true, 
+                        "isDonut": true, 
+                        "legendPosition": "bottom", 
+                        "shareYAxis": true, 
+                        "type": "pie"
+                    }, 
+                    "title": "Engine & Version [Metricbeat MongoDB]", 
+                    "type": "pie"
+                }
+            }, 
+            "id": "MongoDB-Engine-ampersand-Version", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "MongoDB-search", 
+                "title": "Operation counters [Metricbeat MongoDB]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "command", 
+                                "field": "mongodb.status.opcounters.command"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "customLabel": "delete", 
+                                "field": "mongodb.status.opcounters.delete"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "4", 
+                            "params": {
+                                "customLabel": "getmore", 
+                                "field": "mongodb.status.opcounters.getmore"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "5", 
+                            "params": {
+                                "customLabel": "insert", 
+                                "field": "mongodb.status.opcounters.insert"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "6", 
+                            "params": {
+                                "customLabel": "query", 
+                                "field": "mongodb.status.opcounters.query"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "7", 
+                            "params": {
+                                "customLabel": "update", 
+                                "field": "mongodb.status.opcounters_replicated.update"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }
+                    ], 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "categoryAxes": [
+                            {
+                                "id": "CategoryAxis-1", 
+                                "labels": {
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "position": "bottom", 
+                                "scale": {
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {}, 
+                                "type": "category"
+                            }
+                        ], 
+                        "defaultYExtents": false, 
+                        "grid": {
+                            "categoryLines": false, 
+                            "style": {
+                                "color": "#eee"
+                            }
+                        }, 
+                        "interpolate": "linear", 
+                        "legendPosition": "bottom", 
+                        "mode": "stacked", 
+                        "scale": "linear", 
+                        "seriesParams": [
+                            {
+                                "data": {
+                                    "id": "1", 
+                                    "label": "Count"
+                                }, 
+                                "drawLinesBetweenPoints": true, 
+                                "interpolate": "linear", 
+                                "mode": "stacked", 
+                                "show": "true", 
+                                "showCircles": true, 
+                                "type": "area", 
+                                "valueAxis": "ValueAxis-1"
+                            }
+                        ], 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "smoothLines": false, 
+                        "times": [], 
+                        "type": "area", 
+                        "valueAxes": [
+                            {
+                                "id": "ValueAxis-1", 
+                                "labels": {
+                                    "filter": false, 
+                                    "rotate": 0, 
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "name": "LeftAxis-1", 
+                                "position": "left", 
+                                "scale": {
+                                    "mode": "normal", 
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {
+                                    "text": "Count"
+                                }, 
+                                "type": "value"
+                            }
+                        ], 
+                        "yAxis": {}
+                    }, 
+                    "title": "Operation counters [Metricbeat MongoDB]", 
+                    "type": "area"
+                }
+            }, 
+            "id": "MongoDB-operation-counters", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "MongoDB-search", 
+                "title": "Concurrent transactions Read [Metricbeat MongoDB]", 
+                "uiStateJSON": {
+                    "vis": {
+                        "colors": {
+                            "Read Available": "#508642", 
+                            "Read Used": "#BF1B00"
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Read Available", 
+                                "field": "mongodb.status.wired_tiger.concurrent_transactions.read.available"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "customLabel": "Read Used", 
+                                "field": "mongodb.status.wired_tiger.concurrent_transactions.read.out"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }
+                    ], 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "categoryAxes": [
+                            {
+                                "id": "CategoryAxis-1", 
+                                "labels": {
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "position": "bottom", 
+                                "scale": {
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {}, 
+                                "type": "category"
+                            }
+                        ], 
+                        "defaultYExtents": false, 
+                        "grid": {
+                            "categoryLines": false, 
+                            "style": {
+                                "color": "#eee"
+                            }
+                        }, 
+                        "interpolate": "linear", 
+                        "legendPosition": "bottom", 
+                        "mode": "stacked", 
+                        "scale": "linear", 
+                        "seriesParams": [
+                            {
+                                "data": {
+                                    "id": "1", 
+                                    "label": "Count"
+                                }, 
+                                "drawLinesBetweenPoints": true, 
+                                "interpolate": "linear", 
+                                "mode": "stacked", 
+                                "show": "true", 
+                                "showCircles": true, 
+                                "type": "area", 
+                                "valueAxis": "ValueAxis-1"
+                            }
+                        ], 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "smoothLines": false, 
+                        "times": [], 
+                        "type": "area", 
+                        "valueAxes": [
+                            {
+                                "id": "ValueAxis-1", 
+                                "labels": {
+                                    "filter": false, 
+                                    "rotate": 0, 
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "name": "LeftAxis-1", 
+                                "position": "left", 
+                                "scale": {
+                                    "mode": "normal", 
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {
+                                    "text": "Count"
+                                }, 
+                                "type": "value"
+                            }
+                        ], 
+                        "yAxis": {}
+                    }, 
+                    "title": "Concurrent transactions Read [Metricbeat MongoDB]", 
+                    "type": "area"
+                }
+            }, 
+            "id": "MongoDB-Concurrent-transactions-Read", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "MongoDB-search", 
+                "title": "Concurrent transactions Write [Metricbeat MongoDB]", 
+                "uiStateJSON": {
+                    "vis": {
+                        "colors": {
+                            "Write Available": "#629E51", 
+                            "Write Used": "#BF1B00"
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Write Available", 
+                                "field": "mongodb.status.wired_tiger.concurrent_transactions.write.available"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "customLabel": "Write Used", 
+                                "field": "mongodb.status.wired_tiger.concurrent_transactions.write.out"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }
+                    ], 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "categoryAxes": [
+                            {
+                                "id": "CategoryAxis-1", 
+                                "labels": {
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "position": "bottom", 
+                                "scale": {
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {}, 
+                                "type": "category"
+                            }
+                        ], 
+                        "defaultYExtents": false, 
+                        "grid": {
+                            "categoryLines": false, 
+                            "style": {
+                                "color": "#eee"
+                            }
+                        }, 
+                        "interpolate": "linear", 
+                        "legendPosition": "bottom", 
+                        "mode": "stacked", 
+                        "scale": "linear", 
+                        "seriesParams": [
+                            {
+                                "data": {
+                                    "id": "1", 
+                                    "label": "Count"
+                                }, 
+                                "drawLinesBetweenPoints": true, 
+                                "interpolate": "linear", 
+                                "mode": "stacked", 
+                                "show": "true", 
+                                "showCircles": true, 
+                                "type": "area", 
+                                "valueAxis": "ValueAxis-1"
+                            }
+                        ], 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "smoothLines": false, 
+                        "times": [], 
+                        "type": "area", 
+                        "valueAxes": [
+                            {
+                                "id": "ValueAxis-1", 
+                                "labels": {
+                                    "filter": false, 
+                                    "rotate": 0, 
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "name": "LeftAxis-1", 
+                                "position": "left", 
+                                "scale": {
+                                    "mode": "normal", 
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {
+                                    "text": "Count"
+                                }, 
+                                "type": "value"
+                            }
+                        ], 
+                        "yAxis": {}
+                    }, 
+                    "title": "Concurrent transactions Write [Metricbeat MongoDB]", 
+                    "type": "area"
+                }
+            }, 
+            "id": "MongoDB-Concurrent-transactions-Write", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "MongoDB-search", 
+                "title": "Memory stats [Metricbeat MongoDB]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Mapped", 
+                                "field": "mongodb.status.memory.mapped.mb"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "customLabel": "Mapped with journal", 
+                                "field": "mongodb.status.memory.mapped_with_journal.mb"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "4", 
+                            "params": {
+                                "customLabel": "Rezident", 
+                                "field": "mongodb.status.memory.resident.mb"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "5", 
+                            "params": {
+                                "customLabel": "Virtual", 
+                                "field": "mongodb.status.memory.virtual.mb"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }
+                    ], 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "categoryAxes": [
+                            {
+                                "id": "CategoryAxis-1", 
+                                "labels": {
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "position": "bottom", 
+                                "scale": {
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {}, 
+                                "type": "category"
+                            }
+                        ], 
+                        "defaultYExtents": false, 
+                        "drawLinesBetweenPoints": true, 
+                        "grid": {
+                            "categoryLines": false, 
+                            "style": {
+                                "color": "#eee"
+                            }
+                        }, 
+                        "interpolate": "linear", 
+                        "legendPosition": "bottom", 
+                        "radiusRatio": 9, 
+                        "scale": "log", 
+                        "seriesParams": [
+                            {
+                                "data": {
+                                    "id": "1", 
+                                    "label": "Count"
+                                }, 
+                                "drawLinesBetweenPoints": true, 
+                                "mode": "normal", 
+                                "show": "true", 
+                                "showCircles": true, 
+                                "type": "line", 
+                                "valueAxis": "ValueAxis-1"
+                            }
+                        ], 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "showCircles": true, 
+                        "smoothLines": false, 
+                        "times": [], 
+                        "type": "line", 
+                        "valueAxes": [
+                            {
+                                "id": "ValueAxis-1", 
+                                "labels": {
+                                    "filter": false, 
+                                    "rotate": 0, 
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "name": "LeftAxis-1", 
+                                "position": "left", 
+                                "scale": {
+                                    "mode": "normal", 
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {
+                                    "text": "Count"
+                                }, 
+                                "type": "value"
+                            }
+                        ], 
+                        "yAxis": {}
+                    }, 
+                    "title": "Memory stats [Metricbeat MongoDB]", 
+                    "type": "line"
+                }
+            }, 
+            "id": "MongoDB-memory-stats", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "MongoDB-search", 
+                "title": "Asserts [Metricbeat MongoDB]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "message", 
+                                "field": "mongodb.status.asserts.msg"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "customLabel": "regular", 
+                                "field": "mongodb.status.asserts.regular"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "4", 
+                            "params": {
+                                "customLabel": "rollover", 
+                                "field": "mongodb.status.asserts.rollovers"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "5", 
+                            "params": {
+                                "customLabel": "user", 
+                                "field": "mongodb.status.asserts.user"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "6", 
+                            "params": {
+                                "customLabel": "warning", 
+                                "field": "mongodb.status.asserts.warning"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }
+                    ], 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "categoryAxes": [
+                            {
+                                "id": "CategoryAxis-1", 
+                                "labels": {
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "position": "bottom", 
+                                "scale": {
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {}, 
+                                "type": "category"
+                            }
+                        ], 
+                        "defaultYExtents": false, 
+                        "grid": {
+                            "categoryLines": false, 
+                            "style": {
+                                "color": "#eee"
+                            }
+                        }, 
+                        "interpolate": "linear", 
+                        "legendPosition": "bottom", 
+                        "mode": "stacked", 
+                        "scale": "linear", 
+                        "seriesParams": [
+                            {
+                                "data": {
+                                    "id": "1", 
+                                    "label": "Count"
+                                }, 
+                                "drawLinesBetweenPoints": true, 
+                                "interpolate": "linear", 
+                                "mode": "stacked", 
+                                "show": "true", 
+                                "showCircles": true, 
+                                "type": "area", 
+                                "valueAxis": "ValueAxis-1"
+                            }
+                        ], 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "smoothLines": false, 
+                        "times": [], 
+                        "type": "area", 
+                        "valueAxes": [
+                            {
+                                "id": "ValueAxis-1", 
+                                "labels": {
+                                    "filter": false, 
+                                    "rotate": 0, 
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "name": "LeftAxis-1", 
+                                "position": "left", 
+                                "scale": {
+                                    "mode": "normal", 
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {
+                                    "text": "Count"
+                                }, 
+                                "type": "value"
+                            }
+                        ], 
+                        "yAxis": {}
+                    }, 
+                    "title": "Asserts [Metricbeat MongoDB]", 
+                    "type": "area"
+                }
+            }, 
+            "id": "MongoDB-asserts", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "MongoDB-search", 
+                "title": "WiredTiger Cache [Metricbeat MongoDB]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "max", 
+                                "field": "mongodb.status.wired_tiger.cache.maximum.bytes"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "customLabel": "used", 
+                                "field": "mongodb.status.wired_tiger.cache.used.bytes"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "4", 
+                            "params": {
+                                "customLabel": "dirty", 
+                                "field": "mongodb.status.wired_tiger.cache.dirty.bytes"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }
+                    ], 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "categoryAxes": [
+                            {
+                                "id": "CategoryAxis-1", 
+                                "labels": {
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "position": "bottom", 
+                                "scale": {
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {}, 
+                                "type": "category"
+                            }
+                        ], 
+                        "defaultYExtents": false, 
+                        "grid": {
+                            "categoryLines": false, 
+                            "style": {
+                                "color": "#eee"
+                            }
+                        }, 
+                        "interpolate": "linear", 
+                        "legendPosition": "bottom", 
+                        "mode": "overlap", 
+                        "scale": "linear", 
+                        "seriesParams": [
+                            {
+                                "data": {
+                                    "id": "1", 
+                                    "label": "Count"
+                                }, 
+                                "drawLinesBetweenPoints": true, 
+                                "interpolate": "linear", 
+                                "mode": "stacked", 
+                                "show": "true", 
+                                "showCircles": true, 
+                                "type": "area", 
+                                "valueAxis": "ValueAxis-1"
+                            }
+                        ], 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "smoothLines": false, 
+                        "times": [], 
+                        "type": "area", 
+                        "valueAxes": [
+                            {
+                                "id": "ValueAxis-1", 
+                                "labels": {
+                                    "filter": false, 
+                                    "rotate": 0, 
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "name": "LeftAxis-1", 
+                                "position": "left", 
+                                "scale": {
+                                    "mode": "normal", 
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {
+                                    "text": "Count"
+                                }, 
+                                "type": "value"
+                            }
+                        ], 
+                        "yAxis": {}
+                    }, 
+                    "title": "WiredTiger Cache [Metricbeat MongoDB]", 
+                    "type": "area"
+                }
+            }, 
+            "id": "MongoDB-WiredTiger-Cache", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "columns": [
+                    "_source"
+                ], 
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlight": {
+                            "fields": {
+                                "*": {}
+                            }, 
+                            "fragment_size": 2147483647, 
+                            "post_tags": [
+                                "@/kibana-highlighted-field@"
+                            ], 
+                            "pre_tags": [
+                                "@kibana-highlighted-field@"
+                            ], 
+                            "require_field_match": false
+                        }, 
+                        "index": "metricbeat-*", 
+                        "query": {
+                            "query_string": {
+                                "analyze_wildcard": true, 
+                                "query": "metricset.module:mongodb"
+                            }
+                        }
+                    }
+                }, 
+                "sort": [
+                    "@timestamp", 
+                    "desc"
+                ], 
+                "title": "MongoDB search", 
+                "version": 1
+            }, 
+            "id": "MongoDB-search", 
+            "type": "search", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "analyze_wildcard": true, 
+                                    "query": "*"
+                                }
+                            }
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false
+                }, 
+                "panelsJSON": [
+                    {
+                        "col": 1, 
+                        "id": "MongoDB-hosts", 
+                        "panelIndex": 1, 
+                        "row": 1, 
+                        "size_x": 8, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 9, 
+                        "id": "MongoDB-Engine-ampersand-Version", 
+                        "panelIndex": 4, 
+                        "row": 1, 
+                        "size_x": 4, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "MongoDB-operation-counters", 
+                        "panelIndex": 2, 
+                        "row": 4, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 7, 
+                        "id": "MongoDB-Concurrent-transactions-Read", 
+                        "panelIndex": 6, 
+                        "row": 4, 
+                        "size_x": 3, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 10, 
+                        "id": "MongoDB-Concurrent-transactions-Write", 
+                        "panelIndex": 7, 
+                        "row": 4, 
+                        "size_x": 3, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "MongoDB-memory-stats", 
+                        "panelIndex": 5, 
+                        "row": 10, 
+                        "size_x": 12, 
+                        "size_y": 4, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 7, 
+                        "id": "MongoDB-asserts", 
+                        "panelIndex": 3, 
+                        "row": 7, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "MongoDB-WiredTiger-Cache", 
+                        "panelIndex": 8, 
+                        "row": 7, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "[Metricbeat MongoDB] Overview", 
+                "uiStateJSON": {
+                    "P-1": {
+                        "vis": {
+                            "params": {
+                                "sort": {
+                                    "columnIndex": null, 
+                                    "direction": null
+                                }
+                            }
+                        }
+                    }
+                }, 
+                "version": 1
+            }, 
+            "id": "Metricbeat-MongoDB", 
+            "type": "dashboard", 
+            "version": 3
+        }
+    ], 
+    "version": "6.0.0-beta1-SNAPSHOT"
 }

--- a/metricbeat/module/mysql/_meta/kibana/6/dashboard/Metricbeat-mysql-overview.json
+++ b/metricbeat/module/mysql/_meta/kibana/6/dashboard/Metricbeat-mysql-overview.json
@@ -1,135 +1,653 @@
 {
-  "objects": [
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{}"
-        },
-        "title": "Connections rate [Metricbeat MySQL]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Connections rate [Metricbeat MySQL]\",\"type\":\"metrics\",\"params\":{\"id\":\"61ca57f0-469d-11e7-af02-69e470af7417\",\"type\":\"timeseries\",\"series\":[{\"id\":\"61ca57f1-469d-11e7-af02-69e470af7417\",\"color\":\"#68BC00\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"61ca57f2-469d-11e7-af02-69e470af7417\",\"type\":\"avg\",\"field\":\"mysql.status.connections\"},{\"unit\":\"\",\"id\":\"aee9bbf0-f1f3-11e7-a752-236fe3270d99\",\"type\":\"derivative\",\"field\":\"61ca57f2-469d-11e7-af02-69e470af7417\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"label\":\"Connections rate\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"show_legend\":1,\"show_grid\":1,\"legend_position\":\"bottom\"},\"aggs\":[]}"
-      },
-      "id": "d7e6bee0-f1f3-11e7-85ab-594b1652e0d1",
-      "type": "visualization",
-      "updated_at": "2018-01-05T09:14:45.934Z",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{}"
-        },
-        "title": "Command rates [Metricbeat MySQL]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Command rates [Metricbeat MySQL]\",\"type\":\"metrics\",\"params\":{\"id\":\"61ca57f0-469d-11e7-af02-69e470af7417\",\"type\":\"timeseries\",\"series\":[{\"id\":\"61ca57f1-469d-11e7-af02-69e470af7417\",\"color\":\"#68BC00\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"61ca57f2-469d-11e7-af02-69e470af7417\",\"type\":\"avg\",\"field\":\"mysql.status.command.select\"},{\"unit\":\"\",\"id\":\"2d149f90-f1f4-11e7-a752-236fe3270d99\",\"type\":\"derivative\",\"field\":\"61ca57f2-469d-11e7-af02-69e470af7417\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":\"0.2\",\"stacked\":\"none\",\"label\":\"SELECT\"},{\"id\":\"3c2a2a40-f1f4-11e7-a752-236fe3270d99\",\"color\":\"rgba(104,204,202,1)\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"3c2a2a41-f1f4-11e7-a752-236fe3270d99\",\"type\":\"avg\",\"field\":\"mysql.status.command.insert\"},{\"unit\":\"\",\"id\":\"3c2a2a42-f1f4-11e7-a752-236fe3270d99\",\"type\":\"derivative\",\"field\":\"3c2a2a41-f1f4-11e7-a752-236fe3270d99\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":\"0.2\",\"stacked\":\"none\",\"label\":\"INSERT\"},{\"id\":\"485ce050-f1f4-11e7-a752-236fe3270d99\",\"color\":\"rgba(252,220,0,1)\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"485ce051-f1f4-11e7-a752-236fe3270d99\",\"type\":\"avg\",\"field\":\"mysql.status.command.update\"},{\"unit\":\"\",\"id\":\"485ce052-f1f4-11e7-a752-236fe3270d99\",\"type\":\"derivative\",\"field\":\"485ce051-f1f4-11e7-a752-236fe3270d99\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":\"0.2\",\"stacked\":\"none\",\"label\":\"UPDATE\"},{\"id\":\"543a4a70-f1f4-11e7-a752-236fe3270d99\",\"color\":\"rgba(244,78,59,1)\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"543a4a71-f1f4-11e7-a752-236fe3270d99\",\"type\":\"avg\",\"field\":\"mysql.status.command.delete\"},{\"unit\":\"\",\"id\":\"543a4a72-f1f4-11e7-a752-236fe3270d99\",\"type\":\"derivative\",\"field\":\"543a4a71-f1f4-11e7-a752-236fe3270d99\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":\"0.2\",\"stacked\":\"none\",\"label\":\"DELETE\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"show_legend\":1,\"show_grid\":1},\"aggs\":[]}"
-      },
-      "id": "695a4f90-f1f4-11e7-85ab-594b1652e0d1",
-      "type": "visualization",
-      "updated_at": "2018-01-05T09:14:45.934Z",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{}"
-        },
-        "title": "Running threads [Metricbeat MySQL]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Running threads [Metricbeat MySQL]\",\"type\":\"metrics\",\"params\":{\"id\":\"61ca57f0-469d-11e7-af02-69e470af7417\",\"type\":\"timeseries\",\"series\":[{\"id\":\"61ca57f1-469d-11e7-af02-69e470af7417\",\"color\":\"rgba(174,161,255,1)\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"61ca57f2-469d-11e7-af02-69e470af7417\",\"type\":\"avg\",\"field\":\"mysql.status.threads.running\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"label\":\"Running threads\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"show_legend\":1,\"show_grid\":1,\"legend_position\":\"bottom\"},\"aggs\":[]}"
-      },
-      "id": "124dce60-f1f5-11e7-85ab-594b1652e0d1",
-      "type": "visualization",
-      "updated_at": "2018-01-05T09:14:45.934Z",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{}"
-        },
-        "title": "Opened tables rate [Metricbeat MySQL]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Opened tables rate [Metricbeat MySQL]\",\"type\":\"metrics\",\"params\":{\"axis_formatter\":\"number\",\"axis_position\":\"left\",\"id\":\"61ca57f0-469d-11e7-af02-69e470af7417\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"legend_position\":\"bottom\",\"series\":[{\"axis_position\":\"right\",\"chart_type\":\"line\",\"color\":\"rgba(252,196,0,1)\",\"fill\":0.5,\"formatter\":\"number\",\"id\":\"61ca57f1-469d-11e7-af02-69e470af7417\",\"line_width\":1,\"metrics\":[{\"field\":\"mysql.status.opened_tables\",\"id\":\"61ca57f2-469d-11e7-af02-69e470af7417\",\"type\":\"avg\"},{\"unit\":\"\",\"id\":\"9972d250-f1f5-11e7-a752-236fe3270d99\",\"type\":\"derivative\",\"field\":\"61ca57f2-469d-11e7-af02-69e470af7417\"}],\"point_size\":1,\"seperate_axis\":0,\"split_mode\":\"everything\",\"stacked\":\"none\",\"label\":\"Opened tables rate\"}],\"show_grid\":1,\"show_legend\":1,\"time_field\":\"@timestamp\",\"type\":\"timeseries\"},\"aggs\":[]}"
-      },
-      "id": "aaa326b0-f1f5-11e7-85ab-594b1652e0d1",
-      "type": "visualization",
-      "updated_at": "2018-01-05T09:14:45.934Z",
-      "version": 3
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{}"
-        },
-        "title": "Threads created rate [Metricbeat MySQL]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Threads created rate [Metricbeat MySQL]\",\"type\":\"metrics\",\"params\":{\"axis_formatter\":\"number\",\"axis_position\":\"left\",\"id\":\"61ca57f0-469d-11e7-af02-69e470af7417\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"legend_position\":\"bottom\",\"series\":[{\"axis_position\":\"right\",\"chart_type\":\"line\",\"color\":\"rgba(123,100,255,1)\",\"fill\":0.5,\"formatter\":\"number\",\"id\":\"61ca57f1-469d-11e7-af02-69e470af7417\",\"line_width\":1,\"metrics\":[{\"field\":\"mysql.status.threads.created\",\"id\":\"61ca57f2-469d-11e7-af02-69e470af7417\",\"type\":\"avg\"},{\"unit\":\"\",\"id\":\"9972d250-f1f5-11e7-a752-236fe3270d99\",\"type\":\"derivative\",\"field\":\"61ca57f2-469d-11e7-af02-69e470af7417\"}],\"point_size\":1,\"seperate_axis\":0,\"split_mode\":\"everything\",\"stacked\":\"none\",\"label\":\"Threads created rate\"}],\"show_grid\":1,\"show_legend\":1,\"time_field\":\"@timestamp\",\"type\":\"timeseries\"},\"aggs\":[]}"
-      },
-      "id": "fb1f3f20-f1f5-11e7-85ab-594b1652e0d1",
-      "type": "visualization",
-      "updated_at": "2018-01-05T09:14:45.934Z",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{}"
-        },
-        "title": "Open files [Metricbeat MySQL]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Open files [Metricbeat MySQL]\",\"type\":\"metrics\",\"params\":{\"id\":\"61ca57f0-469d-11e7-af02-69e470af7417\",\"type\":\"timeseries\",\"series\":[{\"id\":\"61ca57f1-469d-11e7-af02-69e470af7417\",\"color\":\"rgba(22,165,165,1)\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"61ca57f2-469d-11e7-af02-69e470af7417\",\"type\":\"avg\",\"field\":\"mysql.status.open.files\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"label\":\"Open files\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"show_legend\":1,\"show_grid\":1,\"legend_position\":\"bottom\"},\"aggs\":[]}"
-      },
-      "id": "f5b35930-f1f6-11e7-85ab-594b1652e0d1",
-      "type": "visualization",
-      "updated_at": "2018-01-05T09:14:45.934Z",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{}"
-        },
-        "title": "Sent and received bytes rates [Metricbeat MySQL]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Sent and received bytes rates [Metricbeat MySQL]\",\"type\":\"metrics\",\"params\":{\"id\":\"61ca57f0-469d-11e7-af02-69e470af7417\",\"type\":\"timeseries\",\"series\":[{\"id\":\"2b1c2390-f1f7-11e7-a752-236fe3270d99\",\"color\":\"rgba(0,98,177,1)\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"2b1c2391-f1f7-11e7-a752-236fe3270d99\",\"type\":\"avg\",\"field\":\"mysql.status.bytes.received\"},{\"unit\":\"\",\"id\":\"2b1c2392-f1f7-11e7-a752-236fe3270d99\",\"type\":\"derivative\",\"field\":\"2b1c2391-f1f7-11e7-a752-236fe3270d99\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"label\":\"Received bytes\"},{\"id\":\"61ca57f1-469d-11e7-af02-69e470af7417\",\"color\":\"#68BC00\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"61ca57f2-469d-11e7-af02-69e470af7417\",\"type\":\"avg\",\"field\":\"mysql.status.bytes.sent\"},{\"unit\":\"\",\"id\":\"23cfda50-f1f7-11e7-a752-236fe3270d99\",\"type\":\"derivative\",\"field\":\"61ca57f2-469d-11e7-af02-69e470af7417\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"label\":\"Sent bytes\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"show_legend\":1,\"show_grid\":1,\"legend_position\":\"bottom\"},\"aggs\":[]}"
-      },
-      "id": "7404feb0-f1f7-11e7-85ab-594b1652e0d1",
-      "type": "visualization",
-      "updated_at": "2018-01-05T09:15:49.714Z",
-      "version": 3
-    },
-    {
-      "attributes": {
-        "description": "",
-        "hits": 0,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[],\"query\":{\"language\":\"lucene\",\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}}},\"highlightAll\":true,\"version\":true}"
-        },
-        "optionsJSON": "{\"darkTheme\":false,\"useMargins\":false}",
-        "panelsJSON": "[{\"panelIndex\":\"10\",\"gridData\":{\"x\":0,\"y\":3,\"w\":6,\"h\":3,\"i\":\"10\"},\"id\":\"d7e6bee0-f1f3-11e7-85ab-594b1652e0d1\",\"type\":\"visualization\",\"version\":\"6.2.4\"},{\"panelIndex\":\"11\",\"gridData\":{\"x\":0,\"y\":0,\"w\":12,\"h\":3,\"i\":\"11\"},\"id\":\"695a4f90-f1f4-11e7-85ab-594b1652e0d1\",\"type\":\"visualization\",\"version\":\"6.2.4\"},{\"panelIndex\":\"13\",\"gridData\":{\"x\":6,\"y\":3,\"w\":6,\"h\":3,\"i\":\"13\"},\"id\":\"124dce60-f1f5-11e7-85ab-594b1652e0d1\",\"type\":\"visualization\",\"version\":\"6.2.4\"},{\"panelIndex\":\"14\",\"gridData\":{\"x\":0,\"y\":6,\"w\":6,\"h\":3,\"i\":\"14\"},\"id\":\"aaa326b0-f1f5-11e7-85ab-594b1652e0d1\",\"type\":\"visualization\",\"version\":\"6.2.4\"},{\"panelIndex\":\"15\",\"gridData\":{\"x\":6,\"y\":6,\"w\":6,\"h\":3,\"i\":\"15\"},\"id\":\"fb1f3f20-f1f5-11e7-85ab-594b1652e0d1\",\"type\":\"visualization\",\"version\":\"6.2.4\"},{\"panelIndex\":\"16\",\"gridData\":{\"x\":6,\"y\":9,\"w\":6,\"h\":3,\"i\":\"16\"},\"id\":\"f5b35930-f1f6-11e7-85ab-594b1652e0d1\",\"type\":\"visualization\",\"version\":\"6.2.4\"},{\"panelIndex\":\"17\",\"gridData\":{\"x\":0,\"y\":9,\"w\":6,\"h\":3,\"i\":\"17\"},\"version\":\"6.2.4\",\"type\":\"visualization\",\"id\":\"7404feb0-f1f7-11e7-85ab-594b1652e0d1\"}]",
-        "timeRestore": false,
-        "title": "[Metricbeat MySQL] Overview",
-        "version": 1
-      },
-      "id": "66881e90-0006-11e7-bf7f-c9acc3d3e306",
-      "type": "dashboard",
-      "updated_at": "2018-01-05T09:14:45.934Z",
-      "version": 3
-    }
-  ],
-  "version": "6.2.4"
+    "objects": [
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Connections rate [Metricbeat MySQL]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "legend_position": "bottom", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "formatter": "number", 
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
+                                "label": "Connections rate", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "mysql.status.connections", 
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "type": "avg"
+                                    }, 
+                                    {
+                                        "field": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "id": "aee9bbf0-f1f3-11e7-a752-236fe3270d99", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "timeseries"
+                    }, 
+                    "title": "Connections rate [Metricbeat MySQL]", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "d7e6bee0-f1f3-11e7-85ab-594b1652e0d1", 
+            "type": "visualization", 
+            "updated_at": "2018-01-05T09:14:45.934Z", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Command rates [Metricbeat MySQL]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": "0.2", 
+                                "formatter": "number", 
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
+                                "label": "SELECT", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "mysql.status.command.select", 
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "type": "avg"
+                                    }, 
+                                    {
+                                        "field": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "id": "2d149f90-f1f4-11e7-a752-236fe3270d99", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }, 
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(104,204,202,1)", 
+                                "fill": "0.2", 
+                                "formatter": "number", 
+                                "id": "3c2a2a40-f1f4-11e7-a752-236fe3270d99", 
+                                "label": "INSERT", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "mysql.status.command.insert", 
+                                        "id": "3c2a2a41-f1f4-11e7-a752-236fe3270d99", 
+                                        "type": "avg"
+                                    }, 
+                                    {
+                                        "field": "3c2a2a41-f1f4-11e7-a752-236fe3270d99", 
+                                        "id": "3c2a2a42-f1f4-11e7-a752-236fe3270d99", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }, 
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(252,220,0,1)", 
+                                "fill": "0.2", 
+                                "formatter": "number", 
+                                "id": "485ce050-f1f4-11e7-a752-236fe3270d99", 
+                                "label": "UPDATE", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "mysql.status.command.update", 
+                                        "id": "485ce051-f1f4-11e7-a752-236fe3270d99", 
+                                        "type": "avg"
+                                    }, 
+                                    {
+                                        "field": "485ce051-f1f4-11e7-a752-236fe3270d99", 
+                                        "id": "485ce052-f1f4-11e7-a752-236fe3270d99", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }, 
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(244,78,59,1)", 
+                                "fill": "0.2", 
+                                "formatter": "number", 
+                                "id": "543a4a70-f1f4-11e7-a752-236fe3270d99", 
+                                "label": "DELETE", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "mysql.status.command.delete", 
+                                        "id": "543a4a71-f1f4-11e7-a752-236fe3270d99", 
+                                        "type": "avg"
+                                    }, 
+                                    {
+                                        "field": "543a4a71-f1f4-11e7-a752-236fe3270d99", 
+                                        "id": "543a4a72-f1f4-11e7-a752-236fe3270d99", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "timeseries"
+                    }, 
+                    "title": "Command rates [Metricbeat MySQL]", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "695a4f90-f1f4-11e7-85ab-594b1652e0d1", 
+            "type": "visualization", 
+            "updated_at": "2018-01-05T09:14:45.934Z", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Running threads [Metricbeat MySQL]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "legend_position": "bottom", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(174,161,255,1)", 
+                                "fill": 0.5, 
+                                "formatter": "number", 
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
+                                "label": "Running threads", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "mysql.status.threads.running", 
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "type": "avg"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "timeseries"
+                    }, 
+                    "title": "Running threads [Metricbeat MySQL]", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "124dce60-f1f5-11e7-85ab-594b1652e0d1", 
+            "type": "visualization", 
+            "updated_at": "2018-01-05T09:14:45.934Z", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Opened tables rate [Metricbeat MySQL]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "legend_position": "bottom", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(252,196,0,1)", 
+                                "fill": 0.5, 
+                                "formatter": "number", 
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
+                                "label": "Opened tables rate", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "mysql.status.opened_tables", 
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "type": "avg"
+                                    }, 
+                                    {
+                                        "field": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "id": "9972d250-f1f5-11e7-a752-236fe3270d99", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "timeseries"
+                    }, 
+                    "title": "Opened tables rate [Metricbeat MySQL]", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "aaa326b0-f1f5-11e7-85ab-594b1652e0d1", 
+            "type": "visualization", 
+            "updated_at": "2018-01-05T09:14:45.934Z", 
+            "version": 3
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Threads created rate [Metricbeat MySQL]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "legend_position": "bottom", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(123,100,255,1)", 
+                                "fill": 0.5, 
+                                "formatter": "number", 
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
+                                "label": "Threads created rate", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "mysql.status.threads.created", 
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "type": "avg"
+                                    }, 
+                                    {
+                                        "field": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "id": "9972d250-f1f5-11e7-a752-236fe3270d99", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "timeseries"
+                    }, 
+                    "title": "Threads created rate [Metricbeat MySQL]", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "fb1f3f20-f1f5-11e7-85ab-594b1652e0d1", 
+            "type": "visualization", 
+            "updated_at": "2018-01-05T09:14:45.934Z", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Open files [Metricbeat MySQL]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "legend_position": "bottom", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(22,165,165,1)", 
+                                "fill": 0.5, 
+                                "formatter": "number", 
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
+                                "label": "Open files", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "mysql.status.open.files", 
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "type": "avg"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "timeseries"
+                    }, 
+                    "title": "Open files [Metricbeat MySQL]", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "f5b35930-f1f6-11e7-85ab-594b1652e0d1", 
+            "type": "visualization", 
+            "updated_at": "2018-01-05T09:14:45.934Z", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Sent and received bytes rates [Metricbeat MySQL]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "legend_position": "bottom", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(0,98,177,1)", 
+                                "fill": 0.5, 
+                                "formatter": "number", 
+                                "id": "2b1c2390-f1f7-11e7-a752-236fe3270d99", 
+                                "label": "Received bytes", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "mysql.status.bytes.received", 
+                                        "id": "2b1c2391-f1f7-11e7-a752-236fe3270d99", 
+                                        "type": "avg"
+                                    }, 
+                                    {
+                                        "field": "2b1c2391-f1f7-11e7-a752-236fe3270d99", 
+                                        "id": "2b1c2392-f1f7-11e7-a752-236fe3270d99", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }, 
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "formatter": "number", 
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
+                                "label": "Sent bytes", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "mysql.status.bytes.sent", 
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "type": "avg"
+                                    }, 
+                                    {
+                                        "field": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "id": "23cfda50-f1f7-11e7-a752-236fe3270d99", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "timeseries"
+                    }, 
+                    "title": "Sent and received bytes rates [Metricbeat MySQL]", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "7404feb0-f1f7-11e7-85ab-594b1652e0d1", 
+            "type": "visualization", 
+            "updated_at": "2018-01-05T09:15:49.714Z", 
+            "version": 3
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "analyze_wildcard": true, 
+                                    "query": "*"
+                                }
+                            }
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false, 
+                    "useMargins": false
+                }, 
+                "panelsJSON": [
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "10", 
+                            "w": 6, 
+                            "x": 0, 
+                            "y": 3
+                        }, 
+                        "id": "d7e6bee0-f1f3-11e7-85ab-594b1652e0d1", 
+                        "panelIndex": "10", 
+                        "type": "visualization", 
+                        "version": "6.2.4"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "11", 
+                            "w": 12, 
+                            "x": 0, 
+                            "y": 0
+                        }, 
+                        "id": "695a4f90-f1f4-11e7-85ab-594b1652e0d1", 
+                        "panelIndex": "11", 
+                        "type": "visualization", 
+                        "version": "6.2.4"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "13", 
+                            "w": 6, 
+                            "x": 6, 
+                            "y": 3
+                        }, 
+                        "id": "124dce60-f1f5-11e7-85ab-594b1652e0d1", 
+                        "panelIndex": "13", 
+                        "type": "visualization", 
+                        "version": "6.2.4"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "14", 
+                            "w": 6, 
+                            "x": 0, 
+                            "y": 6
+                        }, 
+                        "id": "aaa326b0-f1f5-11e7-85ab-594b1652e0d1", 
+                        "panelIndex": "14", 
+                        "type": "visualization", 
+                        "version": "6.2.4"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "15", 
+                            "w": 6, 
+                            "x": 6, 
+                            "y": 6
+                        }, 
+                        "id": "fb1f3f20-f1f5-11e7-85ab-594b1652e0d1", 
+                        "panelIndex": "15", 
+                        "type": "visualization", 
+                        "version": "6.2.4"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "16", 
+                            "w": 6, 
+                            "x": 6, 
+                            "y": 9
+                        }, 
+                        "id": "f5b35930-f1f6-11e7-85ab-594b1652e0d1", 
+                        "panelIndex": "16", 
+                        "type": "visualization", 
+                        "version": "6.2.4"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "17", 
+                            "w": 6, 
+                            "x": 0, 
+                            "y": 9
+                        }, 
+                        "id": "7404feb0-f1f7-11e7-85ab-594b1652e0d1", 
+                        "panelIndex": "17", 
+                        "type": "visualization", 
+                        "version": "6.2.4"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "[Metricbeat MySQL] Overview", 
+                "version": 1
+            }, 
+            "id": "66881e90-0006-11e7-bf7f-c9acc3d3e306", 
+            "type": "dashboard", 
+            "updated_at": "2018-01-05T09:14:45.934Z", 
+            "version": 3
+        }
+    ], 
+    "version": "6.2.4"
 }

--- a/metricbeat/module/nginx/_meta/kibana/6/dashboard/metricbeat-nginx-overview.json
+++ b/metricbeat/module/nginx/_meta/kibana/6/dashboard/metricbeat-nginx-overview.json
@@ -1,103 +1,474 @@
 {
-  "objects": [
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{}"
-        },
-        "title": "Request Rate [Metricbeat Nginx]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Request Rate [Metricbeat Nginx]\",\"type\":\"metrics\",\"params\":{\"axis_formatter\":\"number\",\"axis_position\":\"left\",\"id\":\"61ca57f0-469d-11e7-af02-69e470af7417\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"series\":[{\"axis_position\":\"right\",\"chart_type\":\"line\",\"color\":\"#68BC00\",\"fill\":0.5,\"formatter\":\"number\",\"id\":\"61ca57f1-469d-11e7-af02-69e470af7417\",\"line_width\":1,\"metrics\":[{\"id\":\"61ca57f2-469d-11e7-af02-69e470af7417\",\"type\":\"avg\",\"field\":\"nginx.stubstatus.requests\"},{\"unit\":\"\",\"id\":\"396ec980-f1a1-11e7-95d0-8ddf041d42a2\",\"type\":\"derivative\",\"field\":\"61ca57f2-469d-11e7-af02-69e470af7417\"}],\"point_size\":1,\"seperate_axis\":0,\"split_mode\":\"everything\",\"stacked\":\"none\",\"label\":\"Request rate\"}],\"show_grid\":1,\"show_legend\":1,\"time_field\":\"@timestamp\",\"type\":\"timeseries\",\"legend_position\":\"bottom\"},\"aggs\":[]}"
-      },
-      "id": "555df8a0-f1a1-11e7-a9ef-93c69af7b129",
-      "type": "visualization",
-      "updated_at": "2018-01-04T22:48:58.542Z",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{}"
-        },
-        "title": "Accepts and Handled Rate [Metricbeat Nginx]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Accepts and Handled Rate [Metricbeat Nginx]\",\"type\":\"metrics\",\"params\":{\"axis_formatter\":\"number\",\"axis_position\":\"left\",\"id\":\"61ca57f0-469d-11e7-af02-69e470af7417\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"series\":[{\"axis_position\":\"right\",\"chart_type\":\"line\",\"color\":\"#68BC00\",\"fill\":\"0.5\",\"formatter\":\"number\",\"id\":\"61ca57f1-469d-11e7-af02-69e470af7417\",\"line_width\":1,\"metrics\":[{\"id\":\"61ca57f2-469d-11e7-af02-69e470af7417\",\"type\":\"avg\",\"field\":\"nginx.stubstatus.accepts\"},{\"unit\":\"\",\"id\":\"396ec980-f1a1-11e7-95d0-8ddf041d42a2\",\"type\":\"derivative\",\"field\":\"61ca57f2-469d-11e7-af02-69e470af7417\"}],\"point_size\":1,\"seperate_axis\":0,\"split_mode\":\"everything\",\"stacked\":\"none\",\"label\":\"Accepts rate\",\"split_color_mode\":\"gradient\"},{\"axis_position\":\"right\",\"chart_type\":\"line\",\"color\":\"rgba(0,156,224,1)\",\"fill\":\"0.9\",\"formatter\":\"number\",\"id\":\"56dd33b0-f1a3-11e7-95d0-8ddf041d42a2\",\"line_width\":1,\"metrics\":[{\"id\":\"56dd33b1-f1a3-11e7-95d0-8ddf041d42a2\",\"type\":\"avg\",\"field\":\"nginx.stubstatus.handled\"},{\"unit\":\"\",\"id\":\"56dd33b2-f1a3-11e7-95d0-8ddf041d42a2\",\"type\":\"derivative\",\"field\":\"56dd33b1-f1a3-11e7-95d0-8ddf041d42a2\"}],\"point_size\":\"3\",\"seperate_axis\":0,\"split_mode\":\"everything\",\"stacked\":\"none\",\"label\":\"Handled rate\"}],\"show_grid\":1,\"show_legend\":1,\"time_field\":\"@timestamp\",\"type\":\"timeseries\",\"legend_position\":\"bottom\",\"annotations\":[{\"id\":\"8644f980-f1a3-11e7-95d0-8ddf041d42a2\",\"color\":\"#F00\",\"index_pattern\":\"*\",\"time_field\":\"@timestamp\",\"icon\":\"fa-tag\",\"ignore_global_filters\":1,\"ignore_panel_filters\":1}]},\"aggs\":[]}"
-      },
-      "id": "a1d92240-f1a1-11e7-a9ef-93c69af7b129",
-      "type": "visualization",
-      "updated_at": "2018-01-04T23:07:23.056Z",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{}"
-        },
-        "title": "Drops Rate [Metricbeat Nginx]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Drops Rate [Metricbeat Nginx]\",\"type\":\"metrics\",\"params\":{\"axis_formatter\":\"number\",\"axis_position\":\"left\",\"id\":\"61ca57f0-469d-11e7-af02-69e470af7417\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"series\":[{\"axis_position\":\"right\",\"chart_type\":\"line\",\"color\":\"rgba(188,0,65,1)\",\"fill\":0.5,\"formatter\":\"number\",\"id\":\"61ca57f1-469d-11e7-af02-69e470af7417\",\"line_width\":1,\"metrics\":[{\"id\":\"61ca57f2-469d-11e7-af02-69e470af7417\",\"type\":\"avg\",\"field\":\"nginx.stubstatus.dropped\"},{\"unit\":\"\",\"id\":\"396ec980-f1a1-11e7-95d0-8ddf041d42a2\",\"type\":\"derivative\",\"field\":\"61ca57f2-469d-11e7-af02-69e470af7417\"}],\"point_size\":1,\"seperate_axis\":0,\"split_mode\":\"everything\",\"stacked\":\"none\",\"label\":\"Drops rate\"}],\"show_grid\":1,\"show_legend\":1,\"time_field\":\"@timestamp\",\"type\":\"timeseries\",\"legend_position\":\"bottom\"},\"aggs\":[]}"
-      },
-      "id": "d763a570-f1a1-11e7-a9ef-93c69af7b129",
-      "type": "visualization",
-      "updated_at": "2018-01-04T22:51:46.375Z",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{}"
-        },
-        "title": "Active connections [Metricbeat Nginx]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Active connections [Metricbeat Nginx]\",\"type\":\"metrics\",\"params\":{\"id\":\"61ca57f0-469d-11e7-af02-69e470af7417\",\"type\":\"timeseries\",\"series\":[{\"id\":\"61ca57f1-469d-11e7-af02-69e470af7417\",\"color\":\"#68BC00\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"61ca57f2-469d-11e7-af02-69e470af7417\",\"type\":\"avg\",\"field\":\"nginx.stubstatus.active\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"show_legend\":1,\"show_grid\":1,\"legend_position\":\"bottom\"},\"aggs\":[]}"
-      },
-      "id": "47a8e0f0-f1a4-11e7-a9ef-93c69af7b129",
-      "type": "visualization",
-      "updated_at": "2018-01-04T23:09:55.944Z",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{}"
-        },
-        "title": "Reading / Writing / Waiting Rates [Metricbeat Nginx]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Reading / Writing / Waiting Rates [Metricbeat Nginx]\",\"type\":\"metrics\",\"params\":{\"id\":\"61ca57f0-469d-11e7-af02-69e470af7417\",\"type\":\"timeseries\",\"series\":[{\"id\":\"61ca57f1-469d-11e7-af02-69e470af7417\",\"color\":\"#68BC00\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"61ca57f2-469d-11e7-af02-69e470af7417\",\"type\":\"avg\",\"field\":\"nginx.stubstatus.reading\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"label\":\"Reading\"},{\"id\":\"b1773680-f1a4-11e7-95d0-8ddf041d42a2\",\"color\":\"rgba(0,156,224,1)\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"b1773681-f1a4-11e7-95d0-8ddf041d42a2\",\"type\":\"avg\",\"field\":\"nginx.stubstatus.writing\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"label\":\"Writing\"},{\"id\":\"b68aa6c0-f1a4-11e7-95d0-8ddf041d42a2\",\"color\":\"rgba(252,220,0,1)\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"b68aa6c1-f1a4-11e7-95d0-8ddf041d42a2\",\"type\":\"avg\",\"field\":\"nginx.stubstatus.waiting\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"label\":\"Waiting\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"show_legend\":1,\"show_grid\":1,\"legend_position\":\"bottom\"},\"aggs\":[]}"
-      },
-      "id": "dcbffe30-f1a4-11e7-a9ef-93c69af7b129",
-      "type": "visualization",
-      "updated_at": "2018-01-04T23:13:23.859Z",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "Overview dashboard for the Nginx module in Metricbeat",
-        "hits": 0,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"language\":\"lucene\",\"query\":\"\"},\"filter\":[],\"highlightAll\":true,\"version\":true}"
-        },
-        "optionsJSON": "{\"darkTheme\":false,\"hidePanelTitles\":false,\"useMargins\":true}",
-        "panelsJSON": "[{\"panelIndex\":\"1\",\"gridData\":{\"x\":6,\"y\":0,\"w\":6,\"h\":3,\"i\":\"1\"},\"id\":\"555df8a0-f1a1-11e7-a9ef-93c69af7b129\",\"type\":\"visualization\",\"version\":\"6.2.4\"},{\"panelIndex\":\"2\",\"gridData\":{\"x\":6,\"y\":3,\"w\":6,\"h\":3,\"i\":\"2\"},\"id\":\"a1d92240-f1a1-11e7-a9ef-93c69af7b129\",\"type\":\"visualization\",\"version\":\"6.2.4\"},{\"panelIndex\":\"3\",\"gridData\":{\"x\":0,\"y\":3,\"w\":6,\"h\":3,\"i\":\"3\"},\"id\":\"d763a570-f1a1-11e7-a9ef-93c69af7b129\",\"type\":\"visualization\",\"version\":\"6.2.4\"},{\"panelIndex\":\"4\",\"gridData\":{\"x\":0,\"y\":0,\"w\":6,\"h\":3,\"i\":\"4\"},\"id\":\"47a8e0f0-f1a4-11e7-a9ef-93c69af7b129\",\"type\":\"visualization\",\"version\":\"6.2.4\"},{\"panelIndex\":\"5\",\"gridData\":{\"x\":0,\"y\":6,\"w\":12,\"h\":3,\"i\":\"5\"},\"version\":\"6.2.4\",\"type\":\"visualization\",\"id\":\"dcbffe30-f1a4-11e7-a9ef-93c69af7b129\"}]",
-        "timeRestore": false,
-        "title": "[Metricbeat Nginx] Overview",
-        "version": 1
-      },
-      "id": "023d2930-f1a5-11e7-a9ef-93c69af7b129",
-      "type": "dashboard",
-      "updated_at": "2018-01-04T23:14:26.755Z",
-      "version": 1
-    }
-  ],
-  "version": "6.2.4"
+    "objects": [
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Request Rate [Metricbeat Nginx]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "legend_position": "bottom", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "formatter": "number", 
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
+                                "label": "Request rate", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "nginx.stubstatus.requests", 
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "type": "avg"
+                                    }, 
+                                    {
+                                        "field": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "id": "396ec980-f1a1-11e7-95d0-8ddf041d42a2", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "timeseries"
+                    }, 
+                    "title": "Request Rate [Metricbeat Nginx]", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "555df8a0-f1a1-11e7-a9ef-93c69af7b129", 
+            "type": "visualization", 
+            "updated_at": "2018-01-04T22:48:58.542Z", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Accepts and Handled Rate [Metricbeat Nginx]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "annotations": [
+                            {
+                                "color": "#F00", 
+                                "icon": "fa-tag", 
+                                "id": "8644f980-f1a3-11e7-95d0-8ddf041d42a2", 
+                                "ignore_global_filters": 1, 
+                                "ignore_panel_filters": 1, 
+                                "index_pattern": "*", 
+                                "time_field": "@timestamp"
+                            }
+                        ], 
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "legend_position": "bottom", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": "0.5", 
+                                "formatter": "number", 
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
+                                "label": "Accepts rate", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "nginx.stubstatus.accepts", 
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "type": "avg"
+                                    }, 
+                                    {
+                                        "field": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "id": "396ec980-f1a1-11e7-95d0-8ddf041d42a2", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_color_mode": "gradient", 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }, 
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(0,156,224,1)", 
+                                "fill": "0.9", 
+                                "formatter": "number", 
+                                "id": "56dd33b0-f1a3-11e7-95d0-8ddf041d42a2", 
+                                "label": "Handled rate", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "nginx.stubstatus.handled", 
+                                        "id": "56dd33b1-f1a3-11e7-95d0-8ddf041d42a2", 
+                                        "type": "avg"
+                                    }, 
+                                    {
+                                        "field": "56dd33b1-f1a3-11e7-95d0-8ddf041d42a2", 
+                                        "id": "56dd33b2-f1a3-11e7-95d0-8ddf041d42a2", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }
+                                ], 
+                                "point_size": "3", 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "timeseries"
+                    }, 
+                    "title": "Accepts and Handled Rate [Metricbeat Nginx]", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "a1d92240-f1a1-11e7-a9ef-93c69af7b129", 
+            "type": "visualization", 
+            "updated_at": "2018-01-04T23:07:23.056Z", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Drops Rate [Metricbeat Nginx]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "legend_position": "bottom", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(188,0,65,1)", 
+                                "fill": 0.5, 
+                                "formatter": "number", 
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
+                                "label": "Drops rate", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "nginx.stubstatus.dropped", 
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "type": "avg"
+                                    }, 
+                                    {
+                                        "field": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "id": "396ec980-f1a1-11e7-95d0-8ddf041d42a2", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "timeseries"
+                    }, 
+                    "title": "Drops Rate [Metricbeat Nginx]", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "d763a570-f1a1-11e7-a9ef-93c69af7b129", 
+            "type": "visualization", 
+            "updated_at": "2018-01-04T22:51:46.375Z", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Active connections [Metricbeat Nginx]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "legend_position": "bottom", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "formatter": "number", 
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "nginx.stubstatus.active", 
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "type": "avg"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "timeseries"
+                    }, 
+                    "title": "Active connections [Metricbeat Nginx]", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "47a8e0f0-f1a4-11e7-a9ef-93c69af7b129", 
+            "type": "visualization", 
+            "updated_at": "2018-01-04T23:09:55.944Z", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Reading / Writing / Waiting Rates [Metricbeat Nginx]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "legend_position": "bottom", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "formatter": "number", 
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
+                                "label": "Reading", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "nginx.stubstatus.reading", 
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "type": "avg"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }, 
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(0,156,224,1)", 
+                                "fill": 0.5, 
+                                "formatter": "number", 
+                                "id": "b1773680-f1a4-11e7-95d0-8ddf041d42a2", 
+                                "label": "Writing", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "nginx.stubstatus.writing", 
+                                        "id": "b1773681-f1a4-11e7-95d0-8ddf041d42a2", 
+                                        "type": "avg"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }, 
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(252,220,0,1)", 
+                                "fill": 0.5, 
+                                "formatter": "number", 
+                                "id": "b68aa6c0-f1a4-11e7-95d0-8ddf041d42a2", 
+                                "label": "Waiting", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "nginx.stubstatus.waiting", 
+                                        "id": "b68aa6c1-f1a4-11e7-95d0-8ddf041d42a2", 
+                                        "type": "avg"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "timeseries"
+                    }, 
+                    "title": "Reading / Writing / Waiting Rates [Metricbeat Nginx]", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "dcbffe30-f1a4-11e7-a9ef-93c69af7b129", 
+            "type": "visualization", 
+            "updated_at": "2018-01-04T23:13:23.859Z", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "Overview dashboard for the Nginx module in Metricbeat", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "query": {
+                            "language": "lucene", 
+                            "query": ""
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false, 
+                    "hidePanelTitles": false, 
+                    "useMargins": true
+                }, 
+                "panelsJSON": [
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "1", 
+                            "w": 6, 
+                            "x": 6, 
+                            "y": 0
+                        }, 
+                        "id": "555df8a0-f1a1-11e7-a9ef-93c69af7b129", 
+                        "panelIndex": "1", 
+                        "type": "visualization", 
+                        "version": "6.2.4"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "2", 
+                            "w": 6, 
+                            "x": 6, 
+                            "y": 3
+                        }, 
+                        "id": "a1d92240-f1a1-11e7-a9ef-93c69af7b129", 
+                        "panelIndex": "2", 
+                        "type": "visualization", 
+                        "version": "6.2.4"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "3", 
+                            "w": 6, 
+                            "x": 0, 
+                            "y": 3
+                        }, 
+                        "id": "d763a570-f1a1-11e7-a9ef-93c69af7b129", 
+                        "panelIndex": "3", 
+                        "type": "visualization", 
+                        "version": "6.2.4"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "4", 
+                            "w": 6, 
+                            "x": 0, 
+                            "y": 0
+                        }, 
+                        "id": "47a8e0f0-f1a4-11e7-a9ef-93c69af7b129", 
+                        "panelIndex": "4", 
+                        "type": "visualization", 
+                        "version": "6.2.4"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "5", 
+                            "w": 12, 
+                            "x": 0, 
+                            "y": 6
+                        }, 
+                        "id": "dcbffe30-f1a4-11e7-a9ef-93c69af7b129", 
+                        "panelIndex": "5", 
+                        "type": "visualization", 
+                        "version": "6.2.4"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "[Metricbeat Nginx] Overview", 
+                "version": 1
+            }, 
+            "id": "023d2930-f1a5-11e7-a9ef-93c69af7b129", 
+            "type": "dashboard", 
+            "updated_at": "2018-01-04T23:14:26.755Z", 
+            "version": 1
+        }
+    ], 
+    "version": "6.2.4"
 }

--- a/metricbeat/module/rabbitmq/_meta/kibana/6/dashboard/Metricbeat-rabbitmq-overview.json
+++ b/metricbeat/module/rabbitmq/_meta/kibana/6/dashboard/Metricbeat-rabbitmq-overview.json
@@ -1,105 +1,460 @@
 {
-  "objects": [
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\n  \"filter\": []\n}"
-        },
-        "savedSearchId": "Metricbeat-Rabbitmq",
-        "title": "Memory Usage [Metricbeat RabbitMQ]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\n  \"title\": \"RabbitMQ Memory Usage\",\n  \"type\": \"line\",\n  \"params\": {\n    \"shareYAxis\": true,\n    \"addTooltip\": true,\n    \"addLegend\": true,\n    \"legendPosition\": \"top\",\n    \"showCircles\": false,\n    \"smoothLines\": true,\n    \"interpolate\": \"linear\",\n    \"scale\": \"linear\",\n    \"drawLinesBetweenPoints\": true,\n    \"radiusRatio\": 9,\n    \"times\": [],\n    \"addTimeMarker\": false,\n    \"defaultYExtents\": true,\n    \"setYExtents\": false,\n    \"yAxis\": {}\n  },\n  \"aggs\": [\n    {\n      \"id\": \"1\",\n      \"enabled\": true,\n      \"type\": \"max\",\n      \"schema\": \"metric\",\n      \"params\": {\n        \"field\": \"rabbitmq.node.mem.used.bytes\",\n        \"json\": \"\",\n        \"customLabel\": \"Used memory\"\n      }\n    },\n    {\n      \"id\": \"3\",\n      \"enabled\": true,\n      \"type\": \"date_histogram\",\n      \"schema\": \"segment\",\n      \"params\": {\n        \"field\": \"@timestamp\",\n        \"interval\": \"custom\",\n        \"customInterval\": \"30s\",\n        \"min_doc_count\": 1,\n        \"extended_bounds\": {}\n      }\n    },\n    {\n      \"id\": \"4\",\n      \"enabled\": true,\n      \"type\": \"terms\",\n      \"schema\": \"group\",\n      \"params\": {\n        \"field\": \"rabbitmq.node.name\",\n        \"size\": 5,\n        \"order\": \"desc\",\n        \"orderBy\": \"1\",\n        \"customLabel\": \"Node name\"\n      }\n    }\n  ],\n  \"listeners\": {}\n}"
-      },
-      "id": "RabbitMQ-Memory-Usage",
-      "type": "visualization",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\n  \"filter\": []\n}"
-        },
-        "savedSearchId": "Metricbeat-Rabbitmq",
-        "title": "Number of Nodes [Metricbeat RabbitMQ]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\n  \"title\": \"Rabbitmq-Number-of-Nodes\",\n  \"type\": \"metric\",\n  \"params\": {\n    \"handleNoResults\": true,\n    \"fontSize\": 60\n  },\n  \"aggs\": [\n    {\n      \"id\": \"1\",\n      \"enabled\": true,\n      \"type\": \"cardinality\",\n      \"schema\": \"metric\",\n      \"params\": {\n        \"field\": \"rabbitmq.node.name\",\n        \"customLabel\": \"RabbitMQ Nodes\"\n      }\n    }\n  ],\n  \"listeners\": {}\n}"
-      },
-      "id": "Rabbitmq-Number-of-Nodes",
-      "type": "visualization",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\n  \"filter\": []\n}"
-        },
-        "savedSearchId": "Metricbeat-Rabbitmq",
-        "title": "Erlang Process Usage [Metricbeat RabbitMQ]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\n  \"title\": \"RabbitMQ Erlang Process Usage\",\n  \"type\": \"line\",\n  \"params\": {\n    \"addLegend\": true,\n    \"addTimeMarker\": false,\n    \"addTooltip\": true,\n    \"defaultYExtents\": false,\n    \"drawLinesBetweenPoints\": true,\n    \"interpolate\": \"linear\",\n    \"legendPosition\": \"top\",\n    \"radiusRatio\": 9,\n    \"scale\": \"linear\",\n    \"setYExtents\": false,\n    \"shareYAxis\": true,\n    \"showCircles\": false,\n    \"smoothLines\": true,\n    \"times\": [],\n    \"yAxis\": {}\n  },\n  \"aggs\": [\n    {\n      \"id\": \"1\",\n      \"enabled\": true,\n      \"type\": \"max\",\n      \"schema\": \"metric\",\n      \"params\": {\n        \"field\": \"rabbitmq.node.proc.used\",\n        \"customLabel\": \"Used Process\"\n      }\n    },\n    {\n      \"id\": \"3\",\n      \"enabled\": true,\n      \"type\": \"date_histogram\",\n      \"schema\": \"segment\",\n      \"params\": {\n        \"field\": \"@timestamp\",\n        \"interval\": \"custom\",\n        \"customInterval\": \"30s\",\n        \"min_doc_count\": 1,\n        \"extended_bounds\": {}\n      }\n    },\n    {\n      \"id\": \"4\",\n      \"enabled\": true,\n      \"type\": \"terms\",\n      \"schema\": \"group\",\n      \"params\": {\n        \"field\": \"rabbitmq.node.name\",\n        \"size\": 5,\n        \"order\": \"desc\",\n        \"orderBy\": \"1\",\n        \"customLabel\": \"Node name\"\n      }\n    }\n  ],\n  \"listeners\": {}\n}"
-      },
-      "id": "RabbitMQ-Erlang-Process-Usage",
-      "type": "visualization",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[]}"
-        },
-        "savedSearchId": "Metricbeat-Rabbitmq",
-        "title": "Queue Index Operations [Metricbeat RabbitMQ]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Queue Index Operations [Metricbeat RabbitMQ]\",\"type\":\"line\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"top\",\"showCircles\":false,\"smoothLines\":false,\"interpolate\":\"linear\",\"scale\":\"linear\",\"drawLinesBetweenPoints\":true,\"radiusRatio\":9,\"times\":[],\"addTimeMarker\":false,\"defaultYExtents\":false,\"setYExtents\":false,\"yAxis\":{},\"type\":\"line\",\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"type\":\"category\",\"position\":\"bottom\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\"},\"labels\":{\"show\":true,\"truncate\":100},\"title\":{}}],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"name\":\"LeftAxis-1\",\"type\":\"value\",\"position\":\"left\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\",\"mode\":\"normal\"},\"labels\":{\"show\":true,\"rotate\":0,\"filter\":false,\"truncate\":100},\"title\":{\"text\":\"Count\"}}],\"seriesParams\":[{\"show\":\"true\",\"type\":\"line\",\"mode\":\"normal\",\"data\":{\"label\":\"Count\",\"id\":\"1\"},\"valueAxis\":\"ValueAxis-1\",\"drawLinesBetweenPoints\":true,\"showCircles\":true}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"max\",\"schema\":\"metric\",\"params\":{\"field\":\"rabbitmq.node.queue.index.read.count\",\"customLabel\":\"Queue Index Read\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"custom\",\"customInterval\":\"30s\",\"min_doc_count\":1,\"extended_bounds\":{}}},{\"id\":\"3\",\"enabled\":true,\"type\":\"max\",\"schema\":\"metric\",\"params\":{\"field\":\"rabbitmq.node.queue.index.journal_write.count\",\"customLabel\":\"Queue Index Jornal Write\"}},{\"id\":\"4\",\"enabled\":true,\"type\":\"max\",\"schema\":\"metric\",\"params\":{\"field\":\"rabbitmq.node.queue.index.write.count\",\"customLabel\":\"Queue Index Write\"}}]}"
-      },
-      "id": "RabbitMQ-Queue-Index-Operations",
-      "type": "visualization",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "hits": 0,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"index\":\"metricbeat-*\",\"filter\":[],\"highlight\":{\"pre_tags\":[\"@kibana-highlighted-field@\"],\"post_tags\":[\"@/kibana-highlighted-field@\"],\"fields\":{\"*\":{}},\"require_field_match\":false,\"fragment_size\":2147483647},\"query\":{\"query_string\":{\"query\":\"metricset.module:rabbitmq\",\"analyze_wildcard\":true}}}"
-        },
-        "sort": [
-          "@timestamp",
-          "desc"
-        ],
-        "title": "Metricbeat-Rabbitmq",
-        "version": 1
-      },
-      "id": "Metricbeat-Rabbitmq",
-      "type": "search",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "hits": 0,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[],\"highlightAll\":true,\"version\":true,\"query\":{\"language\":\"lucene\",\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}}}}"
-        },
-        "optionsJSON": "{\"darkTheme\":false}",
-        "panelsJSON": "[{\"col\":1,\"id\":\"RabbitMQ-Memory-Usage\",\"panelIndex\":8,\"row\":1,\"size_x\":6,\"size_y\":3,\"type\":\"visualization\"},{\"col\":8,\"id\":\"Rabbitmq-Number-of-Nodes\",\"panelIndex\":2,\"row\":1,\"size_x\":3,\"size_y\":3,\"type\":\"visualization\"},{\"col\":1,\"id\":\"RabbitMQ-Erlang-Process-Usage\",\"panelIndex\":10,\"row\":4,\"size_x\":6,\"size_y\":3,\"type\":\"visualization\"},{\"col\":7,\"id\":\"RabbitMQ-Queue-Index-Operations\",\"panelIndex\":9,\"row\":4,\"size_x\":6,\"size_y\":3,\"type\":\"visualization\"}]",
-        "timeRestore": false,
-        "title": "[Metricbeat RabbitMQ] Overview",
-        "uiStateJSON": "{\"P-2\":{\"vis\":{\"defaultColors\":{\"0 - 100\":\"rgb(0,104,55)\"}}}}",
-        "version": 1
-      },
-      "id": "AV4YobKIge1VCbKU_qVo",
-      "type": "dashboard",
-      "version": 2
-    }
-  ],
-  "version": "6.0.0-beta1-SNAPSHOT"
+    "objects": [
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Metricbeat-Rabbitmq", 
+                "title": "Memory Usage [Metricbeat RabbitMQ]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Used memory", 
+                                "field": "rabbitmq.node.mem.used.bytes", 
+                                "json": ""
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "customInterval": "30s", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "custom", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "4", 
+                            "params": {
+                                "customLabel": "Node name", 
+                                "field": "rabbitmq.node.name", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "group", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "defaultYExtents": true, 
+                        "drawLinesBetweenPoints": true, 
+                        "interpolate": "linear", 
+                        "legendPosition": "top", 
+                        "radiusRatio": 9, 
+                        "scale": "linear", 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "showCircles": false, 
+                        "smoothLines": true, 
+                        "times": [], 
+                        "yAxis": {}
+                    }, 
+                    "title": "RabbitMQ Memory Usage", 
+                    "type": "line"
+                }
+            }, 
+            "id": "RabbitMQ-Memory-Usage", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Metricbeat-Rabbitmq", 
+                "title": "Number of Nodes [Metricbeat RabbitMQ]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "RabbitMQ Nodes", 
+                                "field": "rabbitmq.node.name"
+                            }, 
+                            "schema": "metric", 
+                            "type": "cardinality"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "fontSize": 60, 
+                        "handleNoResults": true
+                    }, 
+                    "title": "Rabbitmq-Number-of-Nodes", 
+                    "type": "metric"
+                }
+            }, 
+            "id": "Rabbitmq-Number-of-Nodes", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Metricbeat-Rabbitmq", 
+                "title": "Erlang Process Usage [Metricbeat RabbitMQ]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Used Process", 
+                                "field": "rabbitmq.node.proc.used"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "customInterval": "30s", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "custom", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "4", 
+                            "params": {
+                                "customLabel": "Node name", 
+                                "field": "rabbitmq.node.name", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "group", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "defaultYExtents": false, 
+                        "drawLinesBetweenPoints": true, 
+                        "interpolate": "linear", 
+                        "legendPosition": "top", 
+                        "radiusRatio": 9, 
+                        "scale": "linear", 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "showCircles": false, 
+                        "smoothLines": true, 
+                        "times": [], 
+                        "yAxis": {}
+                    }, 
+                    "title": "RabbitMQ Erlang Process Usage", 
+                    "type": "line"
+                }
+            }, 
+            "id": "RabbitMQ-Erlang-Process-Usage", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Metricbeat-Rabbitmq", 
+                "title": "Queue Index Operations [Metricbeat RabbitMQ]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Queue Index Read", 
+                                "field": "rabbitmq.node.queue.index.read.count"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "30s", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "custom", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "customLabel": "Queue Index Jornal Write", 
+                                "field": "rabbitmq.node.queue.index.journal_write.count"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "4", 
+                            "params": {
+                                "customLabel": "Queue Index Write", 
+                                "field": "rabbitmq.node.queue.index.write.count"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }
+                    ], 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "categoryAxes": [
+                            {
+                                "id": "CategoryAxis-1", 
+                                "labels": {
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "position": "bottom", 
+                                "scale": {
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {}, 
+                                "type": "category"
+                            }
+                        ], 
+                        "defaultYExtents": false, 
+                        "drawLinesBetweenPoints": true, 
+                        "grid": {
+                            "categoryLines": false, 
+                            "style": {
+                                "color": "#eee"
+                            }
+                        }, 
+                        "interpolate": "linear", 
+                        "legendPosition": "top", 
+                        "radiusRatio": 9, 
+                        "scale": "linear", 
+                        "seriesParams": [
+                            {
+                                "data": {
+                                    "id": "1", 
+                                    "label": "Count"
+                                }, 
+                                "drawLinesBetweenPoints": true, 
+                                "mode": "normal", 
+                                "show": "true", 
+                                "showCircles": true, 
+                                "type": "line", 
+                                "valueAxis": "ValueAxis-1"
+                            }
+                        ], 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "showCircles": false, 
+                        "smoothLines": false, 
+                        "times": [], 
+                        "type": "line", 
+                        "valueAxes": [
+                            {
+                                "id": "ValueAxis-1", 
+                                "labels": {
+                                    "filter": false, 
+                                    "rotate": 0, 
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "name": "LeftAxis-1", 
+                                "position": "left", 
+                                "scale": {
+                                    "mode": "normal", 
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {
+                                    "text": "Count"
+                                }, 
+                                "type": "value"
+                            }
+                        ], 
+                        "yAxis": {}
+                    }, 
+                    "title": "Queue Index Operations [Metricbeat RabbitMQ]", 
+                    "type": "line"
+                }
+            }, 
+            "id": "RabbitMQ-Queue-Index-Operations", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlight": {
+                            "fields": {
+                                "*": {}
+                            }, 
+                            "fragment_size": 2147483647, 
+                            "post_tags": [
+                                "@/kibana-highlighted-field@"
+                            ], 
+                            "pre_tags": [
+                                "@kibana-highlighted-field@"
+                            ], 
+                            "require_field_match": false
+                        }, 
+                        "index": "metricbeat-*", 
+                        "query": {
+                            "query_string": {
+                                "analyze_wildcard": true, 
+                                "query": "metricset.module:rabbitmq"
+                            }
+                        }
+                    }
+                }, 
+                "sort": [
+                    "@timestamp", 
+                    "desc"
+                ], 
+                "title": "Metricbeat-Rabbitmq", 
+                "version": 1
+            }, 
+            "id": "Metricbeat-Rabbitmq", 
+            "type": "search", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "analyze_wildcard": true, 
+                                    "query": "*"
+                                }
+                            }
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false
+                }, 
+                "panelsJSON": [
+                    {
+                        "col": 1, 
+                        "id": "RabbitMQ-Memory-Usage", 
+                        "panelIndex": 8, 
+                        "row": 1, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 8, 
+                        "id": "Rabbitmq-Number-of-Nodes", 
+                        "panelIndex": 2, 
+                        "row": 1, 
+                        "size_x": 3, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "RabbitMQ-Erlang-Process-Usage", 
+                        "panelIndex": 10, 
+                        "row": 4, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 7, 
+                        "id": "RabbitMQ-Queue-Index-Operations", 
+                        "panelIndex": 9, 
+                        "row": 4, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "[Metricbeat RabbitMQ] Overview", 
+                "uiStateJSON": {
+                    "P-2": {
+                        "vis": {
+                            "defaultColors": {
+                                "0 - 100": "rgb(0,104,55)"
+                            }
+                        }
+                    }
+                }, 
+                "version": 1
+            }, 
+            "id": "AV4YobKIge1VCbKU_qVo", 
+            "type": "dashboard", 
+            "version": 2
+        }
+    ], 
+    "version": "6.0.0-beta1-SNAPSHOT"
 }

--- a/metricbeat/module/redis/_meta/kibana/6/dashboard/Metricbeat-redis-overview.json
+++ b/metricbeat/module/redis/_meta/kibana/6/dashboard/Metricbeat-redis-overview.json
@@ -1,191 +1,826 @@
 {
-  "objects": [
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[]}"
-        },
-        "savedSearchId": "Metricbeat-Redis",
-        "title": "Clients [Metricbeat Redis]",
-        "uiStateJSON": "{\"vis\":{\"defaultColors\":{\"0 - 100\":\"rgb(0,104,55)\"}}}",
-        "version": 1,
-        "visState": "{\"aggs\":[{\"enabled\":true,\"id\":\"1\",\"params\":{\"customLabel\":\"Connected clients\",\"field\":\"redis.info.clients.connected\"},\"schema\":\"metric\",\"type\":\"max\"}],\"listeners\":{},\"params\":{\"addLegend\":false,\"addTooltip\":true,\"fontSize\":60,\"gauge\":{\"autoExtend\":false,\"backStyle\":\"Full\",\"colorSchema\":\"Green to Red\",\"colorsRange\":[{\"from\":0,\"to\":100}],\"gaugeColorMode\":\"None\",\"gaugeStyle\":\"Full\",\"gaugeType\":\"Metric\",\"invertColors\":false,\"labels\":{\"color\":\"black\",\"show\":true},\"orientation\":\"vertical\",\"percentageMode\":false,\"scale\":{\"color\":\"#333\",\"labels\":false,\"show\":false,\"width\":2},\"style\":{\"bgColor\":false,\"fontSize\":60,\"labelColor\":false,\"subText\":\"\"},\"type\":\"simple\",\"useRange\":false,\"verticalSplit\":false},\"handleNoResults\":true,\"type\":\"gauge\"},\"title\":\"Clients [Metricbeat Redis]\",\"type\":\"metric\"}"
-      },
-      "col": 1,
-      "id": "Redis-Clients-Metrics",
-      "panelIndex": 2,
-      "row": 1,
-      "size_x": 3,
-      "size_y": 3,
-      "type": "visualization",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[]}"
-        },
-        "savedSearchId": "Metricbeat-Redis",
-        "title": "Connected clients [Metricbeat Redis]",
-        "uiStateJSON": "{\"vis\":{\"colors\":{\"Blocked\":\"#C15C17\"}}}",
-        "version": 1,
-        "visState": "{\"aggs\":[{\"enabled\":true,\"id\":\"1\",\"params\":{\"customLabel\":\"Connected\",\"field\":\"redis.info.clients.connected\"},\"schema\":\"metric\",\"type\":\"max\"},{\"enabled\":true,\"id\":\"2\",\"params\":{\"customInterval\":\"2h\",\"extended_bounds\":{},\"field\":\"@timestamp\",\"interval\":\"auto\",\"min_doc_count\":1},\"schema\":\"segment\",\"type\":\"date_histogram\"},{\"enabled\":true,\"id\":\"3\",\"params\":{\"customLabel\":\"Blocked\",\"field\":\"redis.info.clients.blocked\"},\"schema\":\"metric\",\"type\":\"max\"}],\"listeners\":{},\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{},\"type\":\"category\"}],\"defaultYExtents\":false,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"legendPosition\":\"right\",\"mode\":\"grouped\",\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Count\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"shareYAxis\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Count\"},\"type\":\"value\"}],\"yAxis\":{}},\"title\":\"Connected clients [Metricbeat Redis]\",\"type\":\"histogram\"}"
-      },
-      "col": 4,
-      "id": "Redis-Connected-clients",
-      "panelIndex": 1,
-      "row": 1,
-      "size_x": 5,
-      "size_y": 3,
-      "type": "visualization",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[]}"
-        },
-        "savedSearchId": "Metricbeat-Redis",
-        "title": "Hosts [Metricbeat Redis]",
-        "uiStateJSON": "{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":null,\"direction\":null}}}}",
-        "version": 1,
-        "visState": "{\"title\":\"Hosts [Metricbeat Redis]\",\"type\":\"table\",\"params\":{\"perPage\":10,\"showPartialRows\":false,\"showMeticsAtAllLevels\":false,\"sort\":{\"columnIndex\":null,\"direction\":null},\"showTotal\":false,\"totalFunc\":\"sum\"},\"aggs\":[{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"metricset.host\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\"}},{\"id\":\"3\",\"enabled\":true,\"type\":\"max\",\"schema\":\"metric\",\"params\":{\"field\":\"redis.info.server.uptime\",\"customLabel\":\"Uptime (s)\"}},{\"id\":\"6\",\"enabled\":true,\"type\":\"max\",\"schema\":\"metric\",\"params\":{\"field\":\"redis.info.server.process_id\",\"customLabel\":\"PID\"}},{\"id\":\"1\",\"enabled\":true,\"type\":\"max\",\"schema\":\"metric\",\"params\":{\"field\":\"redis.info.memory.used.peak\",\"customLabel\":\"Memory\"}},{\"id\":\"4\",\"enabled\":true,\"type\":\"max\",\"schema\":\"metric\",\"params\":{\"field\":\"redis.info.cpu.used.user\",\"customLabel\":\"CPU used (user)\"}},{\"id\":\"5\",\"enabled\":true,\"type\":\"max\",\"schema\":\"metric\",\"params\":{\"field\":\"redis.info.cpu.used.sys\",\"customLabel\":\"CPU used (system)\"}}],\"listeners\":{}}"
-      },
-      "col": 1,
-      "id": "Redis-hosts",
-      "panelIndex": 3,
-      "row": 4,
-      "size_x": 12,
-      "size_y": 2,
-      "type": "visualization",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[]}"
-        },
-        "savedSearchId": "Metricbeat-Redis",
-        "title": "Server Versions [Metricbeat Redis]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Server Versions [Metricbeat Redis]\",\"type\":\"pie\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"isDonut\":false},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"cardinality\",\"schema\":\"metric\",\"params\":{\"field\":\"metricset.host\",\"customLabel\":\"Hosts\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"redis.info.server.version\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"Multiplexing API\"}}],\"listeners\":{}}"
-      },
-      "col": 1,
-      "id": "Redis-Server-Versions",
-      "panelIndex": 4,
-      "row": 6,
-      "size_x": 4,
-      "size_y": 2,
-      "type": "visualization",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[]}"
-        },
-        "savedSearchId": "Metricbeat-Redis",
-        "title": "Server mode [Metricbeat Redis]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Server mode [Metricbeat Redis]\",\"type\":\"pie\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"isDonut\":false},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"cardinality\",\"schema\":\"metric\",\"params\":{\"field\":\"metricset.host\",\"customLabel\":\"Hosts\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"redis.info.server.mode\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"Server mode\"}}],\"listeners\":{}}"
-      },
-      "col": 5,
-      "id": "Redis-server-mode",
-      "panelIndex": 5,
-      "row": 6,
-      "size_x": 4,
-      "size_y": 2,
-      "type": "visualization",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[]}"
-        },
-        "savedSearchId": "Metricbeat-Redis",
-        "title": "Multiplexing API [Metricbeat Redis]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Multiplexing API [Metricbeat Redis]\",\"type\":\"pie\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"isDonut\":false},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"cardinality\",\"schema\":\"metric\",\"params\":{\"field\":\"metricset.host\",\"customLabel\":\"Hosts\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"redis.info.server.multiplexing_api\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"Multiplexing API\"}}],\"listeners\":{}}"
-      },
-      "col": 9,
-      "id": "Redis-multiplexing-API",
-      "panelIndex": 6,
-      "row": 6,
-      "size_x": 3,
-      "size_y": 2,
-      "type": "visualization",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[]}"
-        },
-        "savedSearchId": "Metricbeat-Redis",
-        "title": "Keyspaces [Metricbeat Redis]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"aggs\":[{\"enabled\":true,\"id\":\"1\",\"params\":{\"customLabel\":\"Number of keys\",\"field\":\"redis.keyspace.keys\"},\"schema\":\"metric\",\"type\":\"avg\"},{\"enabled\":true,\"id\":\"2\",\"params\":{\"customInterval\":\"2h\",\"extended_bounds\":{},\"field\":\"@timestamp\",\"interval\":\"auto\",\"min_doc_count\":1},\"schema\":\"segment\",\"type\":\"date_histogram\"},{\"enabled\":true,\"id\":\"3\",\"params\":{\"customLabel\":\"Keyspaces\",\"field\":\"redis.keyspace.id\",\"order\":\"desc\",\"orderBy\":\"1\",\"size\":5},\"schema\":\"group\",\"type\":\"terms\"}],\"listeners\":{},\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{},\"type\":\"category\"}],\"defaultYExtents\":false,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"right\",\"mode\":\"stacked\",\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Count\"},\"drawLinesBetweenPoints\":true,\"interpolate\":\"linear\",\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"area\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"shareYAxis\":true,\"smoothLines\":false,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Count\"},\"type\":\"value\"}],\"yAxis\":{}},\"title\":\"Keyspaces [Metricbeat Redis]\",\"type\":\"area\"}"
-      },
-      "col": 9,
-      "id": "Redis-Keyspaces",
-      "panelIndex": 7,
-      "row": 1,
-      "size_x": 4,
-      "size_y": 3,
-      "type": "visualization",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "columns": [
-          "_source"
-        ],
-        "description": "",
-        "hits": 0,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"index\":\"metricbeat-*\",\"filter\":[],\"highlight\":{\"pre_tags\":[\"@kibana-highlighted-field@\"],\"post_tags\":[\"@/kibana-highlighted-field@\"],\"fields\":{\"*\":{}},\"require_field_match\":false,\"fragment_size\":2147483647},\"query\":{\"query_string\":{\"query\":\"metricset.module:redis\",\"analyze_wildcard\":true}}}"
-        },
-        "sort": [
-          "@timestamp",
-          "desc"
-        ],
-        "title": "Metricbeat Redis",
-        "version": 1
-      },
-      "id": "Metricbeat-Redis",
-      "type": "search",
-      "version": 7
-    },
-    {
-      "attributes": {
-        "description": "",
-        "hits": 0,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[{\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}}}],\"highlightAll\":true,\"version\":true}"
-        },
-        "optionsJSON": "{\"darkTheme\":false}",
-        "panelsJSON": "[{\"col\":1,\"id\":\"Redis-Clients-Metrics\",\"panelIndex\":2,\"row\":1,\"size_x\":3,\"size_y\":3,\"type\":\"visualization\"},{\"col\":4,\"id\":\"Redis-Connected-clients\",\"panelIndex\":1,\"row\":1,\"size_x\":5,\"size_y\":3,\"type\":\"visualization\"},{\"col\":1,\"id\":\"Redis-hosts\",\"panelIndex\":3,\"row\":4,\"size_x\":12,\"size_y\":2,\"type\":\"visualization\"},{\"col\":1,\"id\":\"Redis-Server-Versions\",\"panelIndex\":4,\"row\":6,\"size_x\":4,\"size_y\":2,\"type\":\"visualization\"},{\"col\":5,\"id\":\"Redis-server-mode\",\"panelIndex\":5,\"row\":6,\"size_x\":4,\"size_y\":2,\"type\":\"visualization\"},{\"col\":9,\"id\":\"Redis-multiplexing-API\",\"panelIndex\":6,\"row\":6,\"size_x\":3,\"size_y\":2,\"type\":\"visualization\"},{\"col\":9,\"id\":\"Redis-Keyspaces\",\"panelIndex\":7,\"row\":1,\"size_x\":4,\"size_y\":3,\"type\":\"visualization\"}]",
-        "timeRestore": false,
-        "title": "[Metricbeat Redis] Overview",
-        "uiStateJSON": "{\"P-3\":{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":null,\"direction\":null}}}},\"P-4\":{\"vis\":{\"legendOpen\":true}},\"P-2\":{\"vis\":{\"defaultColors\":{\"0 - 100\":\"rgb(0,104,55)\"}}}}",
-        "version": 1
-      },
-      "id": "AV4YjZ5pux-M-tCAunxK",
-      "type": "dashboard",
-      "version": 1
-    }
-  ],
-  "version": "5.6.0-SNAPSHOT"
+    "objects": [
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Metricbeat-Redis", 
+                "title": "Clients [Metricbeat Redis]", 
+                "uiStateJSON": {
+                    "vis": {
+                        "defaultColors": {
+                            "0 - 100": "rgb(0,104,55)"
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Connected clients", 
+                                "field": "redis.info.clients.connected"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": false, 
+                        "addTooltip": true, 
+                        "fontSize": 60, 
+                        "gauge": {
+                            "autoExtend": false, 
+                            "backStyle": "Full", 
+                            "colorSchema": "Green to Red", 
+                            "colorsRange": [
+                                {
+                                    "from": 0, 
+                                    "to": 100
+                                }
+                            ], 
+                            "gaugeColorMode": "None", 
+                            "gaugeStyle": "Full", 
+                            "gaugeType": "Metric", 
+                            "invertColors": false, 
+                            "labels": {
+                                "color": "black", 
+                                "show": true
+                            }, 
+                            "orientation": "vertical", 
+                            "percentageMode": false, 
+                            "scale": {
+                                "color": "#333", 
+                                "labels": false, 
+                                "show": false, 
+                                "width": 2
+                            }, 
+                            "style": {
+                                "bgColor": false, 
+                                "fontSize": 60, 
+                                "labelColor": false, 
+                                "subText": ""
+                            }, 
+                            "type": "simple", 
+                            "useRange": false, 
+                            "verticalSplit": false
+                        }, 
+                        "handleNoResults": true, 
+                        "type": "gauge"
+                    }, 
+                    "title": "Clients [Metricbeat Redis]", 
+                    "type": "metric"
+                }
+            }, 
+            "col": 1, 
+            "id": "Redis-Clients-Metrics", 
+            "panelIndex": 2, 
+            "row": 1, 
+            "size_x": 3, 
+            "size_y": 3, 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Metricbeat-Redis", 
+                "title": "Connected clients [Metricbeat Redis]", 
+                "uiStateJSON": {
+                    "vis": {
+                        "colors": {
+                            "Blocked": "#C15C17"
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Connected", 
+                                "field": "redis.info.clients.connected"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "customLabel": "Blocked", 
+                                "field": "redis.info.clients.blocked"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "categoryAxes": [
+                            {
+                                "id": "CategoryAxis-1", 
+                                "labels": {
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "position": "bottom", 
+                                "scale": {
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {}, 
+                                "type": "category"
+                            }
+                        ], 
+                        "defaultYExtents": false, 
+                        "grid": {
+                            "categoryLines": false, 
+                            "style": {
+                                "color": "#eee"
+                            }
+                        }, 
+                        "legendPosition": "right", 
+                        "mode": "grouped", 
+                        "scale": "linear", 
+                        "seriesParams": [
+                            {
+                                "data": {
+                                    "id": "1", 
+                                    "label": "Count"
+                                }, 
+                                "drawLinesBetweenPoints": true, 
+                                "mode": "stacked", 
+                                "show": "true", 
+                                "showCircles": true, 
+                                "type": "histogram", 
+                                "valueAxis": "ValueAxis-1"
+                            }
+                        ], 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "times": [], 
+                        "valueAxes": [
+                            {
+                                "id": "ValueAxis-1", 
+                                "labels": {
+                                    "filter": false, 
+                                    "rotate": 0, 
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "name": "LeftAxis-1", 
+                                "position": "left", 
+                                "scale": {
+                                    "mode": "normal", 
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {
+                                    "text": "Count"
+                                }, 
+                                "type": "value"
+                            }
+                        ], 
+                        "yAxis": {}
+                    }, 
+                    "title": "Connected clients [Metricbeat Redis]", 
+                    "type": "histogram"
+                }
+            }, 
+            "col": 4, 
+            "id": "Redis-Connected-clients", 
+            "panelIndex": 1, 
+            "row": 1, 
+            "size_x": 5, 
+            "size_y": 3, 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Metricbeat-Redis", 
+                "title": "Hosts [Metricbeat Redis]", 
+                "uiStateJSON": {
+                    "vis": {
+                        "params": {
+                            "sort": {
+                                "columnIndex": null, 
+                                "direction": null
+                            }
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "field": "metricset.host", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "bucket", 
+                            "type": "terms"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "customLabel": "Uptime (s)", 
+                                "field": "redis.info.server.uptime"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "6", 
+                            "params": {
+                                "customLabel": "PID", 
+                                "field": "redis.info.server.process_id"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Memory", 
+                                "field": "redis.info.memory.used.peak"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "4", 
+                            "params": {
+                                "customLabel": "CPU used (user)", 
+                                "field": "redis.info.cpu.used.user"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "5", 
+                            "params": {
+                                "customLabel": "CPU used (system)", 
+                                "field": "redis.info.cpu.used.sys"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "perPage": 10, 
+                        "showMeticsAtAllLevels": false, 
+                        "showPartialRows": false, 
+                        "showTotal": false, 
+                        "sort": {
+                            "columnIndex": null, 
+                            "direction": null
+                        }, 
+                        "totalFunc": "sum"
+                    }, 
+                    "title": "Hosts [Metricbeat Redis]", 
+                    "type": "table"
+                }
+            }, 
+            "col": 1, 
+            "id": "Redis-hosts", 
+            "panelIndex": 3, 
+            "row": 4, 
+            "size_x": 12, 
+            "size_y": 2, 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Metricbeat-Redis", 
+                "title": "Server Versions [Metricbeat Redis]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Hosts", 
+                                "field": "metricset.host"
+                            }, 
+                            "schema": "metric", 
+                            "type": "cardinality"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customLabel": "Multiplexing API", 
+                                "field": "redis.info.server.version", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTooltip": true, 
+                        "isDonut": false, 
+                        "legendPosition": "right", 
+                        "shareYAxis": true
+                    }, 
+                    "title": "Server Versions [Metricbeat Redis]", 
+                    "type": "pie"
+                }
+            }, 
+            "col": 1, 
+            "id": "Redis-Server-Versions", 
+            "panelIndex": 4, 
+            "row": 6, 
+            "size_x": 4, 
+            "size_y": 2, 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Metricbeat-Redis", 
+                "title": "Server mode [Metricbeat Redis]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Hosts", 
+                                "field": "metricset.host"
+                            }, 
+                            "schema": "metric", 
+                            "type": "cardinality"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customLabel": "Server mode", 
+                                "field": "redis.info.server.mode", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTooltip": true, 
+                        "isDonut": false, 
+                        "legendPosition": "right", 
+                        "shareYAxis": true
+                    }, 
+                    "title": "Server mode [Metricbeat Redis]", 
+                    "type": "pie"
+                }
+            }, 
+            "col": 5, 
+            "id": "Redis-server-mode", 
+            "panelIndex": 5, 
+            "row": 6, 
+            "size_x": 4, 
+            "size_y": 2, 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Metricbeat-Redis", 
+                "title": "Multiplexing API [Metricbeat Redis]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Hosts", 
+                                "field": "metricset.host"
+                            }, 
+                            "schema": "metric", 
+                            "type": "cardinality"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customLabel": "Multiplexing API", 
+                                "field": "redis.info.server.multiplexing_api", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTooltip": true, 
+                        "isDonut": false, 
+                        "legendPosition": "right", 
+                        "shareYAxis": true
+                    }, 
+                    "title": "Multiplexing API [Metricbeat Redis]", 
+                    "type": "pie"
+                }
+            }, 
+            "col": 9, 
+            "id": "Redis-multiplexing-API", 
+            "panelIndex": 6, 
+            "row": 6, 
+            "size_x": 3, 
+            "size_y": 2, 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Metricbeat-Redis", 
+                "title": "Keyspaces [Metricbeat Redis]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Number of keys", 
+                                "field": "redis.keyspace.keys"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "customLabel": "Keyspaces", 
+                                "field": "redis.keyspace.id", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "group", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "categoryAxes": [
+                            {
+                                "id": "CategoryAxis-1", 
+                                "labels": {
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "position": "bottom", 
+                                "scale": {
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {}, 
+                                "type": "category"
+                            }
+                        ], 
+                        "defaultYExtents": false, 
+                        "grid": {
+                            "categoryLines": false, 
+                            "style": {
+                                "color": "#eee"
+                            }
+                        }, 
+                        "interpolate": "linear", 
+                        "legendPosition": "right", 
+                        "mode": "stacked", 
+                        "scale": "linear", 
+                        "seriesParams": [
+                            {
+                                "data": {
+                                    "id": "1", 
+                                    "label": "Count"
+                                }, 
+                                "drawLinesBetweenPoints": true, 
+                                "interpolate": "linear", 
+                                "mode": "stacked", 
+                                "show": "true", 
+                                "showCircles": true, 
+                                "type": "area", 
+                                "valueAxis": "ValueAxis-1"
+                            }
+                        ], 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "smoothLines": false, 
+                        "times": [], 
+                        "valueAxes": [
+                            {
+                                "id": "ValueAxis-1", 
+                                "labels": {
+                                    "filter": false, 
+                                    "rotate": 0, 
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "name": "LeftAxis-1", 
+                                "position": "left", 
+                                "scale": {
+                                    "mode": "normal", 
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {
+                                    "text": "Count"
+                                }, 
+                                "type": "value"
+                            }
+                        ], 
+                        "yAxis": {}
+                    }, 
+                    "title": "Keyspaces [Metricbeat Redis]", 
+                    "type": "area"
+                }
+            }, 
+            "col": 9, 
+            "id": "Redis-Keyspaces", 
+            "panelIndex": 7, 
+            "row": 1, 
+            "size_x": 4, 
+            "size_y": 3, 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "columns": [
+                    "_source"
+                ], 
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlight": {
+                            "fields": {
+                                "*": {}
+                            }, 
+                            "fragment_size": 2147483647, 
+                            "post_tags": [
+                                "@/kibana-highlighted-field@"
+                            ], 
+                            "pre_tags": [
+                                "@kibana-highlighted-field@"
+                            ], 
+                            "require_field_match": false
+                        }, 
+                        "index": "metricbeat-*", 
+                        "query": {
+                            "query_string": {
+                                "analyze_wildcard": true, 
+                                "query": "metricset.module:redis"
+                            }
+                        }
+                    }
+                }, 
+                "sort": [
+                    "@timestamp", 
+                    "desc"
+                ], 
+                "title": "Metricbeat Redis", 
+                "version": 1
+            }, 
+            "id": "Metricbeat-Redis", 
+            "type": "search", 
+            "version": 7
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [
+                            {
+                                "query": {
+                                    "query_string": {
+                                        "analyze_wildcard": true, 
+                                        "query": "*"
+                                    }
+                                }
+                            }
+                        ], 
+                        "highlightAll": true, 
+                        "version": true
+                    }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false
+                }, 
+                "panelsJSON": [
+                    {
+                        "col": 1, 
+                        "id": "Redis-Clients-Metrics", 
+                        "panelIndex": 2, 
+                        "row": 1, 
+                        "size_x": 3, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 4, 
+                        "id": "Redis-Connected-clients", 
+                        "panelIndex": 1, 
+                        "row": 1, 
+                        "size_x": 5, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "Redis-hosts", 
+                        "panelIndex": 3, 
+                        "row": 4, 
+                        "size_x": 12, 
+                        "size_y": 2, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "Redis-Server-Versions", 
+                        "panelIndex": 4, 
+                        "row": 6, 
+                        "size_x": 4, 
+                        "size_y": 2, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 5, 
+                        "id": "Redis-server-mode", 
+                        "panelIndex": 5, 
+                        "row": 6, 
+                        "size_x": 4, 
+                        "size_y": 2, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 9, 
+                        "id": "Redis-multiplexing-API", 
+                        "panelIndex": 6, 
+                        "row": 6, 
+                        "size_x": 3, 
+                        "size_y": 2, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 9, 
+                        "id": "Redis-Keyspaces", 
+                        "panelIndex": 7, 
+                        "row": 1, 
+                        "size_x": 4, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "[Metricbeat Redis] Overview", 
+                "uiStateJSON": {
+                    "P-2": {
+                        "vis": {
+                            "defaultColors": {
+                                "0 - 100": "rgb(0,104,55)"
+                            }
+                        }
+                    }, 
+                    "P-3": {
+                        "vis": {
+                            "params": {
+                                "sort": {
+                                    "columnIndex": null, 
+                                    "direction": null
+                                }
+                            }
+                        }
+                    }, 
+                    "P-4": {
+                        "vis": {
+                            "legendOpen": true
+                        }
+                    }
+                }, 
+                "version": 1
+            }, 
+            "id": "AV4YjZ5pux-M-tCAunxK", 
+            "type": "dashboard", 
+            "version": 1
+        }
+    ], 
+    "version": "5.6.0-SNAPSHOT"
 }

--- a/metricbeat/module/system/_meta/kibana/6/dashboard/Metricbeat-containers-overview.json
+++ b/metricbeat/module/system/_meta/kibana/6/dashboard/Metricbeat-containers-overview.json
@@ -1,83 +1,564 @@
 {
-  "objects": [
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"index\":\"metricbeat-*\",\"query\":{\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}},\"language\":\"lucene\"},\"filter\":[]}"
-        },
-        "title": "Container CPU usage [Metricbeat System]",
-        "uiStateJSON": "{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":null,\"direction\":null}}}}",
-        "version": 1,
-        "visState": "{\"title\":\"Container CPU usage [Metricbeat System]\",\"type\":\"table\",\"params\":{\"perPage\":10,\"showPartialRows\":false,\"showMeticsAtAllLevels\":false,\"sort\":{\"columnIndex\":null,\"direction\":null},\"showTotal\":false,\"totalFunc\":\"sum\"},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"max\",\"schema\":\"metric\",\"params\":{\"field\":\"system.process.cgroup.cpuacct.stats.user.ns\",\"customLabel\":\"CPU user\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"max\",\"schema\":\"metric\",\"params\":{\"field\":\"system.process.cgroup.cpu.cfs.quota.us\",\"customLabel\":\"CPU quota\"}},{\"id\":\"3\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"system.process.cgroup.id\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"Container ID\"}},{\"id\":\"4\",\"enabled\":true,\"type\":\"max\",\"schema\":\"metric\",\"params\":{\"field\":\"system.process.cgroup.cpu.stats.throttled.ns\",\"customLabel\":\"CPU throttling\"}},{\"id\":\"5\",\"enabled\":true,\"type\":\"max\",\"schema\":\"metric\",\"params\":{\"field\":\"system.process.cgroup.cpuacct.stats.system.ns\",\"customLabel\":\"CPU kernel\"}},{\"id\":\"6\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"system.process.name\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"Process name\"}}]}"
-      },
-      "id": "Container-CPU-usage",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}},\"language\":\"lucene\"},\"filter\":[]}"
-        },
-        "title": "System Navigation [Metricbeat System]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"System Navigation [Metricbeat System]\",\"type\":\"markdown\",\"params\":{\"markdown\":\"[System Overview](#/dashboard/Metricbeat-system-overview)  | [Host Overview](#/dashboard/79ffd6e0-faa0-11e6-947f-177f697178b8) |\\n[Containers overview](#/dashboard/CPU-slash-Memory-per-container)\",\"fontSize\":12},\"aggs\":[]}"
-      },
-      "id": "System-Navigation",
-      "type": "visualization",
-      "version": 3
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"index\":\"metricbeat-*\",\"query\":{\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}},\"language\":\"lucene\"},\"filter\":[]}"
-        },
-        "title": "Container Memory stats [Metricbeat System]",
-        "uiStateJSON": "{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":null,\"direction\":null}}}}",
-        "version": 1,
-        "visState": "{\"title\":\"Container Memory stats [Metricbeat System]\",\"type\":\"table\",\"params\":{\"perPage\":10,\"showMeticsAtAllLevels\":false,\"showPartialRows\":false,\"showTotal\":false,\"sort\":{\"columnIndex\":null,\"direction\":null},\"totalFunc\":\"sum\"},\"aggs\":[{\"id\":\"13\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"system.process.cgroup.memory.mem.usage.bytes\",\"customLabel\":\"Usage\"}},{\"id\":\"14\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"system.process.cgroup.memory.mem.usage.max.bytes\",\"customLabel\":\"Max usage\"}},{\"id\":\"1\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"system.process.cgroup.memory.stats.page_faults\",\"customLabel\":\"Page faults\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"system.process.cgroup.memory.stats.pages_in\",\"customLabel\":\"Pages in memory\"}},{\"id\":\"3\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"system.process.cgroup.memory.stats.pages_out\",\"customLabel\":\"Pages out of memory\"}},{\"id\":\"4\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"system.process.cgroup.id\",\"size\":50,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"Container ID\"}},{\"id\":\"5\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"system.process.cgroup.memory.stats.inactive_file.bytes\",\"customLabel\":\"Inactive files\"}},{\"id\":\"6\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"system.process.cgroup.memory.stats.major_page_faults\",\"customLabel\":\"# Major page faults\"}},{\"id\":\"8\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"system.process.name\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"Process name\"}},{\"id\":\"12\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"system.process.cgroup.memory.mem.failures\",\"customLabel\":\"Failures\"}},{\"id\":\"10\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"system.process.cgroup.memory.kmem_tcp.usage.bytes\",\"customLabel\":\"TCP buffers\"}},{\"id\":\"11\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"system.process.cgroup.memory.stats.rss_huge.bytes\",\"customLabel\":\"Huge pages\"}},{\"id\":\"7\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"system.process.cgroup.memory.stats.rss.bytes\",\"customLabel\":\"Swap caches\"}},{\"id\":\"15\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"system.process.cgroup.memory.stats.swap.bytes\",\"customLabel\":\"Swap usage\"}},{\"id\":\"16\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"system.process.cgroup.blkio.total.ios\",\"customLabel\":\"Block I/O\"}}]}"
-      },
-      "id": "Container-Memory-stats",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"index\":\"metricbeat-*\",\"query\":{\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}},\"language\":\"lucene\"},\"filter\":[]}"
-        },
-        "title": "Container Block IO [Metricbeat System]",
-        "uiStateJSON": "{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":null,\"direction\":null}}}}",
-        "version": 1,
-        "visState": "{\"title\":\"Container Block IO [Metricbeat System]\",\"type\":\"table\",\"params\":{\"perPage\":10,\"showMeticsAtAllLevels\":false,\"showPartialRows\":false,\"showTotal\":false,\"sort\":{\"columnIndex\":null,\"direction\":null},\"totalFunc\":\"sum\"},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"system.process.cgroup.blkio.total.bytes\",\"customLabel\":\"Total\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"system.process.cgroup.blkio.total.ios\",\"customLabel\":\"I/O\"}},{\"id\":\"3\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"system.process.cgroup.id\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"Container ID\"}},{\"id\":\"4\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"system.process.name\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"Process name\"}}]}"
-      },
-      "id": "Container-Block-IO",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "hits": 0,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[],\"highlightAll\":true,\"version\":true,\"query\":{\"language\":\"lucene\",\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}}}}"
-        },
-        "optionsJSON": "{\"darkTheme\":false}",
-        "panelsJSON": "[{\"col\":1,\"id\":\"Container-CPU-usage\",\"panelIndex\":2,\"row\":2,\"size_x\":12,\"size_y\":3,\"type\":\"visualization\"},{\"col\":1,\"id\":\"System-Navigation\",\"panelIndex\":3,\"row\":1,\"size_x\":12,\"size_y\":1,\"type\":\"visualization\"},{\"col\":1,\"id\":\"Container-Memory-stats\",\"panelIndex\":4,\"row\":5,\"size_x\":12,\"size_y\":3,\"type\":\"visualization\"},{\"col\":1,\"id\":\"Container-Block-IO\",\"panelIndex\":5,\"row\":8,\"size_x\":12,\"size_y\":4,\"type\":\"visualization\"}]",
-        "timeRestore": false,
-        "title": "[Metricbeat System] Containers overview",
-        "uiStateJSON": "{\"P-2\":{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":null,\"direction\":null}}}},\"P-4\":{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":null,\"direction\":null}}}},\"P-5\":{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":null,\"direction\":null}}}}}",
-        "version": 1
-      },
-      "id": "CPU-slash-Memory-per-container",
-      "type": "dashboard",
-      "version": 1
-    }
-  ],
-  "version": "6.0.0-rc1-SNAPSHOT"
+    "objects": [
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "index": "metricbeat-*", 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "analyze_wildcard": true, 
+                                    "query": "*"
+                                }
+                            }
+                        }
+                    }
+                }, 
+                "title": "Container CPU usage [Metricbeat System]", 
+                "uiStateJSON": {
+                    "vis": {
+                        "params": {
+                            "sort": {
+                                "columnIndex": null, 
+                                "direction": null
+                            }
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "CPU user", 
+                                "field": "system.process.cgroup.cpuacct.stats.user.ns"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customLabel": "CPU quota", 
+                                "field": "system.process.cgroup.cpu.cfs.quota.us"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "customLabel": "Container ID", 
+                                "field": "system.process.cgroup.id", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "bucket", 
+                            "type": "terms"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "4", 
+                            "params": {
+                                "customLabel": "CPU throttling", 
+                                "field": "system.process.cgroup.cpu.stats.throttled.ns"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "5", 
+                            "params": {
+                                "customLabel": "CPU kernel", 
+                                "field": "system.process.cgroup.cpuacct.stats.system.ns"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "6", 
+                            "params": {
+                                "customLabel": "Process name", 
+                                "field": "system.process.name", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "bucket", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "params": {
+                        "perPage": 10, 
+                        "showMeticsAtAllLevels": false, 
+                        "showPartialRows": false, 
+                        "showTotal": false, 
+                        "sort": {
+                            "columnIndex": null, 
+                            "direction": null
+                        }, 
+                        "totalFunc": "sum"
+                    }, 
+                    "title": "Container CPU usage [Metricbeat System]", 
+                    "type": "table"
+                }
+            }, 
+            "id": "Container-CPU-usage", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "analyze_wildcard": true, 
+                                    "query": "*"
+                                }
+                            }
+                        }
+                    }
+                }, 
+                "title": "System Navigation [Metricbeat System]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "fontSize": 12, 
+                        "markdown": "[System Overview](#/dashboard/Metricbeat-system-overview)  | [Host Overview](#/dashboard/79ffd6e0-faa0-11e6-947f-177f697178b8) |\n[Containers overview](#/dashboard/CPU-slash-Memory-per-container)"
+                    }, 
+                    "title": "System Navigation [Metricbeat System]", 
+                    "type": "markdown"
+                }
+            }, 
+            "id": "System-Navigation", 
+            "type": "visualization", 
+            "version": 3
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "index": "metricbeat-*", 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "analyze_wildcard": true, 
+                                    "query": "*"
+                                }
+                            }
+                        }
+                    }
+                }, 
+                "title": "Container Memory stats [Metricbeat System]", 
+                "uiStateJSON": {
+                    "vis": {
+                        "params": {
+                            "sort": {
+                                "columnIndex": null, 
+                                "direction": null
+                            }
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "13", 
+                            "params": {
+                                "customLabel": "Usage", 
+                                "field": "system.process.cgroup.memory.mem.usage.bytes"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "14", 
+                            "params": {
+                                "customLabel": "Max usage", 
+                                "field": "system.process.cgroup.memory.mem.usage.max.bytes"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Page faults", 
+                                "field": "system.process.cgroup.memory.stats.page_faults"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customLabel": "Pages in memory", 
+                                "field": "system.process.cgroup.memory.stats.pages_in"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "customLabel": "Pages out of memory", 
+                                "field": "system.process.cgroup.memory.stats.pages_out"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "4", 
+                            "params": {
+                                "customLabel": "Container ID", 
+                                "field": "system.process.cgroup.id", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 50
+                            }, 
+                            "schema": "bucket", 
+                            "type": "terms"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "5", 
+                            "params": {
+                                "customLabel": "Inactive files", 
+                                "field": "system.process.cgroup.memory.stats.inactive_file.bytes"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "6", 
+                            "params": {
+                                "customLabel": "# Major page faults", 
+                                "field": "system.process.cgroup.memory.stats.major_page_faults"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "8", 
+                            "params": {
+                                "customLabel": "Process name", 
+                                "field": "system.process.name", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "bucket", 
+                            "type": "terms"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "12", 
+                            "params": {
+                                "customLabel": "Failures", 
+                                "field": "system.process.cgroup.memory.mem.failures"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "10", 
+                            "params": {
+                                "customLabel": "TCP buffers", 
+                                "field": "system.process.cgroup.memory.kmem_tcp.usage.bytes"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "11", 
+                            "params": {
+                                "customLabel": "Huge pages", 
+                                "field": "system.process.cgroup.memory.stats.rss_huge.bytes"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "7", 
+                            "params": {
+                                "customLabel": "Swap caches", 
+                                "field": "system.process.cgroup.memory.stats.rss.bytes"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "15", 
+                            "params": {
+                                "customLabel": "Swap usage", 
+                                "field": "system.process.cgroup.memory.stats.swap.bytes"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "16", 
+                            "params": {
+                                "customLabel": "Block I/O", 
+                                "field": "system.process.cgroup.blkio.total.ios"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }
+                    ], 
+                    "params": {
+                        "perPage": 10, 
+                        "showMeticsAtAllLevels": false, 
+                        "showPartialRows": false, 
+                        "showTotal": false, 
+                        "sort": {
+                            "columnIndex": null, 
+                            "direction": null
+                        }, 
+                        "totalFunc": "sum"
+                    }, 
+                    "title": "Container Memory stats [Metricbeat System]", 
+                    "type": "table"
+                }
+            }, 
+            "id": "Container-Memory-stats", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "index": "metricbeat-*", 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "analyze_wildcard": true, 
+                                    "query": "*"
+                                }
+                            }
+                        }
+                    }
+                }, 
+                "title": "Container Block IO [Metricbeat System]", 
+                "uiStateJSON": {
+                    "vis": {
+                        "params": {
+                            "sort": {
+                                "columnIndex": null, 
+                                "direction": null
+                            }
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Total", 
+                                "field": "system.process.cgroup.blkio.total.bytes"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customLabel": "I/O", 
+                                "field": "system.process.cgroup.blkio.total.ios"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "customLabel": "Container ID", 
+                                "field": "system.process.cgroup.id", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "bucket", 
+                            "type": "terms"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "4", 
+                            "params": {
+                                "customLabel": "Process name", 
+                                "field": "system.process.name", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "bucket", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "params": {
+                        "perPage": 10, 
+                        "showMeticsAtAllLevels": false, 
+                        "showPartialRows": false, 
+                        "showTotal": false, 
+                        "sort": {
+                            "columnIndex": null, 
+                            "direction": null
+                        }, 
+                        "totalFunc": "sum"
+                    }, 
+                    "title": "Container Block IO [Metricbeat System]", 
+                    "type": "table"
+                }
+            }, 
+            "id": "Container-Block-IO", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "analyze_wildcard": true, 
+                                    "query": "*"
+                                }
+                            }
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false
+                }, 
+                "panelsJSON": [
+                    {
+                        "col": 1, 
+                        "id": "Container-CPU-usage", 
+                        "panelIndex": 2, 
+                        "row": 2, 
+                        "size_x": 12, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "System-Navigation", 
+                        "panelIndex": 3, 
+                        "row": 1, 
+                        "size_x": 12, 
+                        "size_y": 1, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "Container-Memory-stats", 
+                        "panelIndex": 4, 
+                        "row": 5, 
+                        "size_x": 12, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "Container-Block-IO", 
+                        "panelIndex": 5, 
+                        "row": 8, 
+                        "size_x": 12, 
+                        "size_y": 4, 
+                        "type": "visualization"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "[Metricbeat System] Containers overview", 
+                "uiStateJSON": {
+                    "P-2": {
+                        "vis": {
+                            "params": {
+                                "sort": {
+                                    "columnIndex": null, 
+                                    "direction": null
+                                }
+                            }
+                        }
+                    }, 
+                    "P-4": {
+                        "vis": {
+                            "params": {
+                                "sort": {
+                                    "columnIndex": null, 
+                                    "direction": null
+                                }
+                            }
+                        }
+                    }, 
+                    "P-5": {
+                        "vis": {
+                            "params": {
+                                "sort": {
+                                    "columnIndex": null, 
+                                    "direction": null
+                                }
+                            }
+                        }
+                    }
+                }, 
+                "version": 1
+            }, 
+            "id": "CPU-slash-Memory-per-container", 
+            "type": "dashboard", 
+            "version": 1
+        }
+    ], 
+    "version": "6.0.0-rc1-SNAPSHOT"
 }

--- a/metricbeat/module/system/_meta/kibana/6/dashboard/Metricbeat-host-overview.json
+++ b/metricbeat/module/system/_meta/kibana/6/dashboard/Metricbeat-host-overview.json
@@ -1,368 +1,2465 @@
 {
-  "objects": [
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\n  \"query\": {\n    \"query_string\": {\n      \"query\": \"*\"\n    }\n  },\n  \"filter\": []\n}"
-        },
-        "title": "Network Traffic (Packets) [Metricbeat System]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\n  \"title\": \"Mericbeat: Network Traffic (Packets)\",\n  \"type\": \"metrics\",\n  \"params\": {\n    \"id\": \"da1046f0-faa0-11e6-86b1-cd7735ff7e23\",\n    \"type\": \"timeseries\",\n    \"series\": [\n      {\n        \"id\": \"da1046f1-faa0-11e6-86b1-cd7735ff7e23\",\n        \"color\": \"rgba(0,156,224,1)\",\n        \"split_mode\": \"terms\",\n        \"metrics\": [\n          {\n            \"id\": \"da1046f2-faa0-11e6-86b1-cd7735ff7e23\",\n            \"type\": \"max\",\n            \"field\": \"system.network.in.packets\"\n          },\n          {\n            \"unit\": \"1s\",\n            \"id\": \"f41f9280-faa0-11e6-86b1-cd7735ff7e23\",\n            \"type\": \"derivative\",\n            \"field\": \"da1046f2-faa0-11e6-86b1-cd7735ff7e23\"\n          },\n          {\n            \"unit\": \"\",\n            \"id\": \"c0da3d80-1b93-11e7-8ada-3df93aab833e\",\n            \"type\": \"positive_only\",\n            \"field\": \"f41f9280-faa0-11e6-86b1-cd7735ff7e23\"\n          },\n          {\n            \"id\": \"ecaad010-2c2c-11e7-be71-3162da85303f\",\n            \"type\": \"series_agg\",\n            \"function\": \"sum\"\n          }\n        ],\n        \"seperate_axis\": 0,\n        \"axis_position\": \"right\",\n        \"formatter\": \"0.[00]a\",\n        \"chart_type\": \"line\",\n        \"line_width\": \"0\",\n        \"point_size\": \"0\",\n        \"fill\": \"1\",\n        \"stacked\": \"none\",\n        \"label\": \"Inbound\",\n        \"value_template\": \"{{value}}/s\",\n        \"terms_field\": \"system.network.name\"\n      },\n      {\n        \"id\": \"fbbd5720-faa0-11e6-86b1-cd7735ff7e23\",\n        \"color\": \"rgba(250,40,255,1)\",\n        \"split_mode\": \"terms\",\n        \"metrics\": [\n          {\n            \"id\": \"fbbd7e30-faa0-11e6-86b1-cd7735ff7e23\",\n            \"type\": \"max\",\n            \"field\": \"system.network.out.packets\"\n          },\n          {\n            \"unit\": \"1s\",\n            \"id\": \"fbbd7e31-faa0-11e6-86b1-cd7735ff7e23\",\n            \"type\": \"derivative\",\n            \"field\": \"fbbd7e30-faa0-11e6-86b1-cd7735ff7e23\"\n          },\n          {\n            \"script\": \"params.rate != null \u0026\u0026 params.rate \u003e 0 ? params.rate * -1 : null\",\n            \"id\": \"17e597a0-faa1-11e6-86b1-cd7735ff7e23\",\n            \"type\": \"calculation\",\n            \"variables\": [\n              {\n                \"id\": \"1940bad0-faa1-11e6-86b1-cd7735ff7e23\",\n                \"name\": \"rate\",\n                \"field\": \"fbbd7e31-faa0-11e6-86b1-cd7735ff7e23\"\n              }\n            ]\n          },\n          {\n            \"id\": \"fe5fbdc0-2c2c-11e7-be71-3162da85303f\",\n            \"type\": \"series_agg\",\n            \"function\": \"sum\"\n          }\n        ],\n        \"seperate_axis\": 0,\n        \"axis_position\": \"right\",\n        \"formatter\": \"0.[00]a\",\n        \"chart_type\": \"line\",\n        \"line_width\": \"0\",\n        \"point_size\": \"0\",\n        \"fill\": \"1\",\n        \"stacked\": \"none\",\n        \"label\": \"Outbound\",\n        \"value_template\": \"{{value}}/s\",\n        \"terms_field\": \"system.network.name\"\n      }\n    ],\n    \"time_field\": \"@timestamp\",\n    \"index_pattern\": \"*\",\n    \"interval\": \"auto\",\n    \"axis_position\": \"left\",\n    \"axis_formatter\": \"number\",\n    \"show_legend\": 1,\n    \"filter\": \"-system.network.name:l*\"\n  },\n  \"aggs\": [],\n  \"listeners\": {}\n}"
-      },
-      "id": "6b7b9a40-faa1-11e6-86b1-cd7735ff7e23",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query\":{\"query_string\":{\"query\":\"*\"}},\"language\":\"lucene\"},\"filter\":[]}"
-        },
-        "title": "System Load [Metricbeat System]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"System Load [Metricbeat System]\",\"type\":\"metrics\",\"params\":{\"id\":\"f6264ad0-1b14-11e7-b09e-037021c4f8df\",\"type\":\"timeseries\",\"series\":[{\"id\":\"f62671e0-1b14-11e7-b09e-037021c4f8df\",\"color\":\"rgba(115,216,255,1)\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"f62671e1-1b14-11e7-b09e-037021c4f8df\",\"type\":\"avg\",\"field\":\"system.load.1\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":\"3\",\"point_size\":1,\"fill\":\"0\",\"stacked\":\"none\",\"label\":\"1m\"},{\"id\":\"1c324850-1b15-11e7-b09e-037021c4f8df\",\"color\":\"rgba(0,156,224,1)\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"1c324851-1b15-11e7-b09e-037021c4f8df\",\"type\":\"avg\",\"field\":\"system.load.5\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":\"3\",\"point_size\":\"0\",\"fill\":\"0\",\"stacked\":\"none\",\"label\":\"5m\"},{\"id\":\"3287e740-1b15-11e7-b09e-037021c4f8df\",\"color\":\"rgba(0,98,177,1)\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"32880e50-1b15-11e7-b09e-037021c4f8df\",\"type\":\"avg\",\"field\":\"system.load.15\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":\"3\",\"point_size\":\"0\",\"fill\":\"0\",\"stacked\":\"none\",\"label\":\"15m\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"show_legend\":1,\"show_grid\":1},\"aggs\":[]}"
-      },
-      "id": "4d546850-1b15-11e7-b09e-037021c4f8df",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\n  \"query\": {\n    \"query_string\": {\n      \"query\": \"*\"\n    }\n  },\n  \"filter\": []\n}"
-        },
-        "title": "Network Traffic (Bytes) [Metricbeat System]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\n  \"title\": \"Mericbeat: Network Traffic (Bytes)\",\n  \"type\": \"metrics\",\n  \"params\": {\n    \"id\": \"da1046f0-faa0-11e6-86b1-cd7735ff7e23\",\n    \"type\": \"timeseries\",\n    \"series\": [\n      {\n        \"id\": \"da1046f1-faa0-11e6-86b1-cd7735ff7e23\",\n        \"color\": \"rgba(0,156,224,1)\",\n        \"split_mode\": \"terms\",\n        \"metrics\": [\n          {\n            \"id\": \"da1046f2-faa0-11e6-86b1-cd7735ff7e23\",\n            \"type\": \"max\",\n            \"field\": \"system.network.in.bytes\"\n          },\n          {\n            \"unit\": \"1s\",\n            \"id\": \"f41f9280-faa0-11e6-86b1-cd7735ff7e23\",\n            \"type\": \"derivative\",\n            \"field\": \"da1046f2-faa0-11e6-86b1-cd7735ff7e23\"\n          },\n          {\n            \"unit\": \"\",\n            \"id\": \"a87398e0-1b93-11e7-8ada-3df93aab833e\",\n            \"type\": \"positive_only\",\n            \"field\": \"f41f9280-faa0-11e6-86b1-cd7735ff7e23\"\n          },\n          {\n            \"id\": \"2d533df0-2c2d-11e7-be71-3162da85303f\",\n            \"type\": \"series_agg\",\n            \"function\": \"sum\"\n          }\n        ],\n        \"seperate_axis\": 0,\n        \"axis_position\": \"right\",\n        \"formatter\": \"bytes\",\n        \"chart_type\": \"line\",\n        \"line_width\": \"0\",\n        \"point_size\": \"0\",\n        \"fill\": \"1\",\n        \"stacked\": \"none\",\n        \"label\": \"Inbound \",\n        \"value_template\": \"{{value}}/s\",\n        \"terms_field\": \"system.network.name\"\n      },\n      {\n        \"id\": \"fbbd5720-faa0-11e6-86b1-cd7735ff7e23\",\n        \"color\": \"rgba(250,40,255,1)\",\n        \"split_mode\": \"terms\",\n        \"metrics\": [\n          {\n            \"id\": \"fbbd7e30-faa0-11e6-86b1-cd7735ff7e23\",\n            \"type\": \"max\",\n            \"field\": \"system.network.out.bytes\"\n          },\n          {\n            \"unit\": \"1s\",\n            \"id\": \"fbbd7e31-faa0-11e6-86b1-cd7735ff7e23\",\n            \"type\": \"derivative\",\n            \"field\": \"fbbd7e30-faa0-11e6-86b1-cd7735ff7e23\"\n          },\n          {\n            \"script\": \"params.rate != null \u0026\u0026 params.rate \u003e 0 ? params.rate * -1 : null\",\n            \"id\": \"17e597a0-faa1-11e6-86b1-cd7735ff7e23\",\n            \"type\": \"calculation\",\n            \"variables\": [\n              {\n                \"id\": \"1940bad0-faa1-11e6-86b1-cd7735ff7e23\",\n                \"name\": \"rate\",\n                \"field\": \"fbbd7e31-faa0-11e6-86b1-cd7735ff7e23\"\n              }\n            ]\n          },\n          {\n            \"id\": \"533da9b0-2c2d-11e7-be71-3162da85303f\",\n            \"type\": \"series_agg\",\n            \"function\": \"sum\"\n          }\n        ],\n        \"seperate_axis\": 0,\n        \"axis_position\": \"right\",\n        \"formatter\": \"bytes\",\n        \"chart_type\": \"line\",\n        \"line_width\": \"0\",\n        \"point_size\": \"0\",\n        \"fill\": \"1\",\n        \"stacked\": \"none\",\n        \"label\": \"Outbound \",\n        \"value_template\": \"{{value}}/s\",\n        \"terms_field\": \"system.network.name\"\n      }\n    ],\n    \"time_field\": \"@timestamp\",\n    \"index_pattern\": \"*\",\n    \"interval\": \"auto\",\n    \"axis_position\": \"left\",\n    \"axis_formatter\": \"number\",\n    \"show_legend\": 1,\n    \"filter\": \"-system.network.name:l*\"\n  },\n  \"aggs\": [],\n  \"listeners\": {}\n}"
-      },
-      "id": "089b85d0-1b16-11e7-b09e-037021c4f8df",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query\":{\"query_string\":{\"query\":\"*\"}},\"language\":\"lucene\"},\"filter\":[]}"
-        },
-        "title": "Memory Usage [Metricbeat System]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Memory Usage [Metricbeat System]\",\"type\":\"metrics\",\"params\":{\"id\":\"32f46f40-1b16-11e7-b09e-037021c4f8df\",\"type\":\"timeseries\",\"series\":[{\"id\":\"4ff61fd0-1b16-11e7-b09e-037021c4f8df\",\"color\":\"rgba(211,49,21,1)\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"4ff61fd1-1b16-11e7-b09e-037021c4f8df\",\"type\":\"avg\",\"field\":\"system.memory.actual.used.bytes\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"bytes\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":\"0\",\"fill\":\"1\",\"stacked\":\"stacked\",\"label\":\"Used\"},{\"id\":\"753a6080-1b16-11e7-b09e-037021c4f8df\",\"color\":\"rgba(0,156,224,1)\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"753a6081-1b16-11e7-b09e-037021c4f8df\",\"type\":\"avg\",\"field\":\"system.memory.actual.used.bytes\"},{\"id\":\"7c9d3f00-1b16-11e7-b09e-037021c4f8df\",\"type\":\"avg\",\"field\":\"system.memory.used.bytes\"},{\"script\":\"params.actual != null \u0026\u0026 params.used != null ? params.used - params.actual : null\",\"id\":\"869cc160-1b16-11e7-b09e-037021c4f8df\",\"type\":\"calculation\",\"variables\":[{\"id\":\"890f9620-1b16-11e7-b09e-037021c4f8df\",\"name\":\"actual\",\"field\":\"753a6081-1b16-11e7-b09e-037021c4f8df\"},{\"id\":\"8f3ab7f0-1b16-11e7-b09e-037021c4f8df\",\"name\":\"used\",\"field\":\"7c9d3f00-1b16-11e7-b09e-037021c4f8df\"}]}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"bytes\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":\"0\",\"fill\":\"1\",\"stacked\":\"stacked\",\"label\":\"Cache\"},{\"id\":\"32f46f41-1b16-11e7-b09e-037021c4f8df\",\"color\":\"#68BC00\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"32f46f42-1b16-11e7-b09e-037021c4f8df\",\"type\":\"avg\",\"field\":\"system.memory.free\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"bytes\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":\"0\",\"fill\":\"1\",\"stacked\":\"stacked\",\"label\":\"Free\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"show_legend\":1,\"show_grid\":1},\"aggs\":[]}"
-      },
-      "id": "bfa5e400-1b16-11e7-b09e-037021c4f8df",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query\":{\"query_string\":{\"query\":\"*\"}},\"language\":\"lucene\"},\"filter\":[]}"
-        },
-        "title": "Top Processes By CPU [Metricbeat System]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Top Processes By CPU [Metricbeat System]\",\"type\":\"metrics\",\"params\":{\"id\":\"5f5b8d50-1b18-11e7-b09e-037021c4f8df\",\"type\":\"top_n\",\"series\":[{\"id\":\"5f5b8d51-1b18-11e7-b09e-037021c4f8df\",\"color\":\"#68BC00\",\"split_mode\":\"terms\",\"metrics\":[{\"id\":\"5f5b8d52-1b18-11e7-b09e-037021c4f8df\",\"type\":\"avg\",\"field\":\"system.process.cpu.total.pct\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"percent\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"terms_field\":\"system.process.name\",\"terms_order_by\":\"5f5b8d52-1b18-11e7-b09e-037021c4f8df\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"show_legend\":1,\"bar_color_rules\":[{\"value\":0,\"id\":\"60e11be0-1b18-11e7-b09e-037021c4f8df\",\"bar_color\":\"rgba(104,188,0,1)\",\"opperator\":\"gte\"}],\"drilldown_url\":\"\",\"filter\":\"\",\"show_grid\":1},\"aggs\":[]}"
-      },
-      "id": "e0f001c0-1b18-11e7-b09e-037021c4f8df",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query\":{\"query_string\":{\"query\":\"*\"}},\"language\":\"lucene\"},\"filter\":[]}"
-        },
-        "title": "Processes By Memory [Metricbeat System]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Processes By Memory [Metricbeat System]\",\"type\":\"metrics\",\"params\":{\"id\":\"edfceb30-1b18-11e7-b09e-037021c4f8df\",\"type\":\"top_n\",\"series\":[{\"id\":\"edfceb31-1b18-11e7-b09e-037021c4f8df\",\"color\":\"#68BC00\",\"split_mode\":\"terms\",\"metrics\":[{\"id\":\"edfceb32-1b18-11e7-b09e-037021c4f8df\",\"type\":\"avg\",\"field\":\"system.process.memory.rss.pct\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"percent\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"terms_field\":\"system.process.name\",\"terms_order_by\":\"edfceb32-1b18-11e7-b09e-037021c4f8df\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"show_legend\":1,\"bar_color_rules\":[{\"value\":0,\"id\":\"efb9b660-1b18-11e7-b09e-037021c4f8df\",\"bar_color\":\"rgba(104,188,0,1)\",\"opperator\":\"gte\"},{\"value\":0.7,\"id\":\"17fcb820-1b19-11e7-b09e-037021c4f8df\",\"bar_color\":\"rgba(254,146,0,1)\",\"opperator\":\"gte\"},{\"value\":0.85,\"id\":\"1dd61070-1b19-11e7-b09e-037021c4f8df\",\"bar_color\":\"rgba(211,49,21,1)\",\"opperator\":\"gte\"}],\"drilldown_url\":\"\",\"filter\":\"\",\"show_grid\":1},\"aggs\":[]}"
-      },
-      "id": "2e224660-1b19-11e7-b09e-037021c4f8df",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query\":{\"query_string\":{\"query\":\"*\"}},\"language\":\"lucene\"},\"filter\":[]}"
-        },
-        "title": "CPU Usage [Metricbeat System]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"CPU Usage [Metricbeat System]\",\"type\":\"metrics\",\"params\":{\"id\":\"80a04950-1b19-11e7-b09e-037021c4f8df\",\"type\":\"timeseries\",\"series\":[{\"id\":\"80a04951-1b19-11e7-b09e-037021c4f8df\",\"color\":\"#68BC00\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"80a04952-1b19-11e7-b09e-037021c4f8df\",\"type\":\"avg\",\"field\":\"system.cpu.user.pct\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"percent\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":\"0\",\"fill\":\"1\",\"stacked\":\"stacked\",\"label\":\"user\"},{\"id\":\"993acf30-1b19-11e7-b09e-037021c4f8df\",\"color\":\"rgba(211,49,21,1)\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"993acf31-1b19-11e7-b09e-037021c4f8df\",\"type\":\"avg\",\"field\":\"system.cpu.system.pct\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"percent\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":\"0\",\"fill\":\"1\",\"stacked\":\"stacked\",\"label\":\"system\"},{\"id\":\"65ca35e0-1b1a-11e7-b09e-037021c4f8df\",\"color\":\"rgba(123,100,255,1)\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"65ca5cf0-1b1a-11e7-b09e-037021c4f8df\",\"type\":\"avg\",\"field\":\"system.cpu.nice.pct\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"percent\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":\"0\",\"fill\":\"1\",\"stacked\":\"stacked\",\"label\":\"nice\"},{\"id\":\"741b5f20-1b1a-11e7-b09e-037021c4f8df\",\"color\":\"rgba(226,115,0,1)\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"741b5f21-1b1a-11e7-b09e-037021c4f8df\",\"type\":\"avg\",\"field\":\"system.cpu.irq.pct\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"percent\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":\"0\",\"fill\":\"1\",\"stacked\":\"stacked\",\"label\":\"irq\"},{\"id\":\"2efc5d40-1b1a-11e7-b09e-037021c4f8df\",\"color\":\"rgba(176,188,0,1)\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"2efc5d41-1b1a-11e7-b09e-037021c4f8df\",\"type\":\"avg\",\"field\":\"system.cpu.softirq.pct\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"percent\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":\"0\",\"fill\":\"1\",\"stacked\":\"stacked\",\"label\":\"softirq\"},{\"id\":\"ae644a30-1b19-11e7-b09e-037021c4f8df\",\"color\":\"rgba(15,20,25,1)\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"ae644a31-1b19-11e7-b09e-037021c4f8df\",\"type\":\"avg\",\"field\":\"system.cpu.iowait.pct\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"percent\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":\"0\",\"fill\":\"1\",\"stacked\":\"stacked\",\"label\":\"iowait\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"show_legend\":1,\"show_grid\":1},\"aggs\":[]}"
-      },
-      "id": "ab2d1e90-1b1a-11e7-b09e-037021c4f8df",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query\":{\"query_string\":{\"query\":\"*\"}},\"language\":\"lucene\"},\"filter\":[]}"
-        },
-        "title": "Disk IO (Bytes) [Metricbeat System]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Disk IO (Bytes) [Metricbeat System]\",\"type\":\"metrics\",\"params\":{\"id\":\"d3c67db0-1b1a-11e7-b09e-037021c4f8df\",\"type\":\"timeseries\",\"series\":[{\"id\":\"d3c67db1-1b1a-11e7-b09e-037021c4f8df\",\"color\":\"rgba(22,165,165,1)\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"d3c67db2-1b1a-11e7-b09e-037021c4f8df\",\"type\":\"max\",\"field\":\"system.diskio.read.bytes\"},{\"unit\":\"1s\",\"id\":\"f55b9910-1b1a-11e7-b09e-037021c4f8df\",\"type\":\"derivative\",\"field\":\"d3c67db2-1b1a-11e7-b09e-037021c4f8df\"},{\"unit\":\"\",\"id\":\"dcbbb100-1b93-11e7-8ada-3df93aab833e\",\"type\":\"positive_only\",\"field\":\"f55b9910-1b1a-11e7-b09e-037021c4f8df\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"bytes\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":\"0\",\"fill\":\"1\",\"stacked\":\"none\",\"label\":\"reads\",\"value_template\":\"{{value}}/s\"},{\"id\":\"144124d0-1b1b-11e7-b09e-037021c4f8df\",\"color\":\"rgba(251,158,0,1)\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"144124d1-1b1b-11e7-b09e-037021c4f8df\",\"type\":\"max\",\"field\":\"system.diskio.write.bytes\"},{\"unit\":\"1s\",\"id\":\"144124d2-1b1b-11e7-b09e-037021c4f8df\",\"type\":\"derivative\",\"field\":\"144124d1-1b1b-11e7-b09e-037021c4f8df\"},{\"script\":\"params.rate \u003e 0 ? params.rate * -1 : 0\",\"id\":\"144124d4-1b1b-11e7-b09e-037021c4f8df\",\"type\":\"calculation\",\"variables\":[{\"id\":\"144124d3-1b1b-11e7-b09e-037021c4f8df\",\"name\":\"rate\",\"field\":\"144124d2-1b1b-11e7-b09e-037021c4f8df\"}]}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"bytes\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":\"0\",\"fill\":\"1\",\"stacked\":\"none\",\"label\":\"writes\",\"value_template\":\"{{value}}/s\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"show_legend\":1,\"filter\":\"\",\"show_grid\":1},\"aggs\":[]}"
-      },
-      "id": "4e4bb1e0-1b1b-11e7-b09e-037021c4f8df",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query\":{\"query_string\":{\"query\":\"*\"}},\"language\":\"lucene\"},\"filter\":[]}"
-        },
-        "title": "Load Gauge [Metricbeat System]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Load Gauge [Metricbeat System]\",\"type\":\"metrics\",\"params\":{\"id\":\"fdcc6180-1b90-11e7-bec4-a5e9ec5cab8b\",\"type\":\"gauge\",\"series\":[{\"id\":\"fdcc6181-1b90-11e7-bec4-a5e9ec5cab8b\",\"color\":\"#68BC00\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"fdcc6182-1b90-11e7-bec4-a5e9ec5cab8b\",\"type\":\"avg\",\"field\":\"system.load.5\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"label\":\"5m Load\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"show_legend\":1,\"background_color_rules\":[{\"id\":\"feefabd0-1b90-11e7-bec4-a5e9ec5cab8b\"}],\"gauge_color_rules\":[{\"id\":\"ffd94880-1b90-11e7-bec4-a5e9ec5cab8b\"}],\"gauge_width\":10,\"gauge_inner_width\":10,\"gauge_style\":\"half\",\"show_grid\":1},\"aggs\":[]}"
-      },
-      "id": "26732e20-1b91-11e7-bec4-a5e9ec5cab8b",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query\":{\"query_string\":{\"query\":\"*\"}},\"language\":\"lucene\"},\"filter\":[]}"
-        },
-        "title": "CPU Usage Gauge [Metricbeat System]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"CPU Usage Gauge [Metricbeat System]\",\"type\":\"metrics\",\"params\":{\"axis_formatter\":\"number\",\"axis_position\":\"left\",\"filter\":\"\",\"gauge_color_rules\":[{\"gauge\":\"rgba(104,188,0,1)\",\"id\":\"4ef2c3b0-1b91-11e7-bec4-a5e9ec5cab8b\",\"opperator\":\"gte\",\"value\":0},{\"gauge\":\"rgba(254,146,0,1)\",\"id\":\"e6561ae0-1b91-11e7-bec4-a5e9ec5cab8b\",\"opperator\":\"gte\",\"value\":0.7},{\"gauge\":\"rgba(211,49,21,1)\",\"id\":\"ec655040-1b91-11e7-bec4-a5e9ec5cab8b\",\"opperator\":\"gte\",\"value\":0.85}],\"gauge_inner_width\":10,\"gauge_max\":\"1\",\"gauge_style\":\"half\",\"gauge_width\":10,\"id\":\"4c9e2550-1b91-11e7-bec4-a5e9ec5cab8b\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"series\":[{\"axis_position\":\"right\",\"chart_type\":\"line\",\"color\":\"#68BC00\",\"fill\":0.5,\"formatter\":\"percent\",\"id\":\"4c9e2551-1b91-11e7-bec4-a5e9ec5cab8b\",\"label\":\"CPU Usage\",\"line_width\":1,\"metrics\":[{\"field\":\"system.cpu.user.pct\",\"id\":\"4c9e2552-1b91-11e7-bec4-a5e9ec5cab8b\",\"type\":\"avg\"},{\"field\":\"system.cpu.system.pct\",\"id\":\"225c2140-5fd7-11e7-a63a-a937b7c1a7e1\",\"type\":\"avg\"},{\"field\":\"system.cpu.cores\",\"id\":\"837a30c0-5fd7-11e7-a63a-a937b7c1a7e1\",\"type\":\"avg\"},{\"script\":\"params.n \u003e 0 ? (params.user+params.system)/params.n : null\",\"id\":\"587aa510-1b91-11e7-bec4-a5e9ec5cab8b\",\"type\":\"calculation\",\"variables\":[{\"field\":\"4c9e2552-1b91-11e7-bec4-a5e9ec5cab8b\",\"id\":\"5a19af10-1b91-11e7-bec4-a5e9ec5cab8b\",\"name\":\"user\"},{\"field\":\"225c2140-5fd7-11e7-a63a-a937b7c1a7e1\",\"id\":\"32b54f80-5fd7-11e7-a63a-a937b7c1a7e1\",\"name\":\"system\"},{\"field\":\"837a30c0-5fd7-11e7-a63a-a937b7c1a7e1\",\"id\":\"8ba6eef0-5fd7-11e7-a63a-a937b7c1a7e1\",\"name\":\"n\"}]}],\"point_size\":1,\"seperate_axis\":0,\"split_mode\":\"everything\",\"stacked\":\"none\"}],\"show_legend\":1,\"time_field\":\"@timestamp\",\"type\":\"gauge\",\"show_grid\":1},\"aggs\":[]}"
-      },
-      "id": "83e12df0-1b91-11e7-bec4-a5e9ec5cab8b",
-      "type": "visualization",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query\":{\"query_string\":{\"query\":\"*\"}},\"language\":\"lucene\"},\"filter\":[]}"
-        },
-        "title": "Memory Usage Gauge [Metricbeat System]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Memory Usage Gauge [Metricbeat System]\",\"type\":\"metrics\",\"params\":{\"id\":\"9f51b730-1b91-11e7-bec4-a5e9ec5cab8b\",\"type\":\"gauge\",\"series\":[{\"id\":\"9f51b731-1b91-11e7-bec4-a5e9ec5cab8b\",\"color\":\"#68BC00\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"9f51b732-1b91-11e7-bec4-a5e9ec5cab8b\",\"type\":\"avg\",\"field\":\"system.memory.actual.used.pct\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"percent\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"label\":\"Memory Usage\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"show_legend\":1,\"gauge_color_rules\":[{\"value\":0,\"id\":\"a0d522e0-1b91-11e7-bec4-a5e9ec5cab8b\",\"gauge\":\"rgba(104,188,0,1)\",\"opperator\":\"gte\"},{\"value\":0.7,\"id\":\"b45ad8f0-1b91-11e7-bec4-a5e9ec5cab8b\",\"gauge\":\"rgba(254,146,0,1)\",\"opperator\":\"gte\"},{\"value\":0.85,\"id\":\"c06e9550-1b91-11e7-bec4-a5e9ec5cab8b\",\"gauge\":\"rgba(211,49,21,1)\",\"opperator\":\"gte\"}],\"gauge_width\":10,\"gauge_inner_width\":10,\"gauge_style\":\"half\",\"gauge_max\":\"1\",\"filter\":\"\",\"show_grid\":1},\"aggs\":[]}"
-      },
-      "id": "d3166e80-1b91-11e7-bec4-a5e9ec5cab8b",
-      "type": "visualization",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query\":{\"query_string\":{\"query\":\"*\"}},\"language\":\"lucene\"},\"filter\":[]}"
-        },
-        "title": "Inbound Traffic [Metricbeat System]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Inbound Traffic [Metricbeat System]\",\"type\":\"metrics\",\"params\":{\"axis_formatter\":\"number\",\"axis_position\":\"left\",\"background_color_rules\":[{\"id\":\"0e346760-1b92-11e7-bec4-a5e9ec5cab8b\"}],\"filter\":\"-system.network.name:l*\",\"id\":\"0c761590-1b92-11e7-bec4-a5e9ec5cab8b\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"series\":[{\"axis_position\":\"right\",\"chart_type\":\"line\",\"color\":\"#68BC00\",\"fill\":0.5,\"formatter\":\"bytes\",\"id\":\"0c761591-1b92-11e7-bec4-a5e9ec5cab8b\",\"label\":\"Inbound Traffic\",\"line_width\":1,\"metrics\":[{\"field\":\"system.network.in.bytes\",\"id\":\"0c761592-1b92-11e7-bec4-a5e9ec5cab8b\",\"type\":\"max\"},{\"field\":\"0c761592-1b92-11e7-bec4-a5e9ec5cab8b\",\"id\":\"1d659060-1b92-11e7-bec4-a5e9ec5cab8b\",\"type\":\"derivative\",\"unit\":\"1s\"},{\"field\":\"1d659060-1b92-11e7-bec4-a5e9ec5cab8b\",\"id\":\"f2074f70-1b92-11e7-a416-41f5ccdba2e6\",\"type\":\"positive_only\",\"unit\":\"\"},{\"id\":\"c40e18f0-2c55-11e7-a0ad-277ce466684d\",\"type\":\"series_agg\",\"function\":\"sum\"}],\"point_size\":1,\"seperate_axis\":0,\"split_mode\":\"terms\",\"stacked\":\"none\",\"value_template\":\"{{value}}/s\",\"terms_field\":\"system.network.name\"},{\"axis_position\":\"right\",\"chart_type\":\"line\",\"color\":\"#68BC00\",\"fill\":0.5,\"formatter\":\"bytes\",\"id\":\"37f70440-1b92-11e7-bec4-a5e9ec5cab8b\",\"label\":\"Total Transferred\",\"line_width\":1,\"metrics\":[{\"field\":\"system.network.in.bytes\",\"id\":\"37f72b50-1b92-11e7-bec4-a5e9ec5cab8b\",\"type\":\"max\"},{\"field\":\"37f72b50-1b92-11e7-bec4-a5e9ec5cab8b\",\"id\":\"37f72b51-1b92-11e7-bec4-a5e9ec5cab8b\",\"type\":\"derivative\",\"unit\":\"\"},{\"unit\":\"\",\"id\":\"f9da2dd0-1b92-11e7-a416-41f5ccdba2e6\",\"type\":\"positive_only\",\"field\":\"37f72b51-1b92-11e7-bec4-a5e9ec5cab8b\"},{\"sigma\":\"\",\"field\":\"f9da2dd0-1b92-11e7-a416-41f5ccdba2e6\",\"id\":\"3e63c2f0-1b92-11e7-bec4-a5e9ec5cab8b\",\"type\":\"series_agg\",\"function\":\"overall_sum\"}],\"point_size\":1,\"seperate_axis\":0,\"split_mode\":\"terms\",\"stacked\":\"none\",\"value_template\":\"{{value}}\",\"terms_field\":\"system.network.name\"}],\"show_legend\":1,\"time_field\":\"@timestamp\",\"type\":\"metric\",\"show_grid\":1},\"aggs\":[]}"
-      },
-      "id": "522ee670-1b92-11e7-bec4-a5e9ec5cab8b",
-      "type": "visualization",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query\":{\"query_string\":{\"query\":\"*\"}},\"language\":\"lucene\"},\"filter\":[]}"
-        },
-        "title": "Outbound Traffic [Metricbeat System]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Outbound Traffic [Metricbeat System]\",\"type\":\"metrics\",\"params\":{\"axis_formatter\":\"number\",\"axis_position\":\"left\",\"background_color_rules\":[{\"id\":\"0e346760-1b92-11e7-bec4-a5e9ec5cab8b\"}],\"filter\":\"-system.network.name:l*\",\"id\":\"0c761590-1b92-11e7-bec4-a5e9ec5cab8b\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"series\":[{\"axis_position\":\"right\",\"chart_type\":\"line\",\"color\":\"#68BC00\",\"fill\":0.5,\"formatter\":\"bytes\",\"id\":\"0c761591-1b92-11e7-bec4-a5e9ec5cab8b\",\"label\":\"Outbound Traffic\",\"line_width\":1,\"metrics\":[{\"field\":\"system.network.out.bytes\",\"id\":\"0c761592-1b92-11e7-bec4-a5e9ec5cab8b\",\"type\":\"max\"},{\"field\":\"0c761592-1b92-11e7-bec4-a5e9ec5cab8b\",\"id\":\"1d659060-1b92-11e7-bec4-a5e9ec5cab8b\",\"type\":\"derivative\",\"unit\":\"1s\"},{\"field\":\"1d659060-1b92-11e7-bec4-a5e9ec5cab8b\",\"id\":\"f2074f70-1b92-11e7-a416-41f5ccdba2e6\",\"type\":\"positive_only\",\"unit\":\"\"},{\"id\":\"a1737470-2c55-11e7-a0ad-277ce466684d\",\"type\":\"series_agg\",\"function\":\"sum\"}],\"point_size\":1,\"seperate_axis\":0,\"split_mode\":\"terms\",\"stacked\":\"none\",\"value_template\":\"{{value}}/s\",\"terms_field\":\"system.network.name\"},{\"axis_position\":\"right\",\"chart_type\":\"line\",\"color\":\"#68BC00\",\"fill\":0.5,\"formatter\":\"bytes\",\"id\":\"37f70440-1b92-11e7-bec4-a5e9ec5cab8b\",\"label\":\"Total Transferred\",\"line_width\":1,\"metrics\":[{\"field\":\"system.network.out.bytes\",\"id\":\"37f72b50-1b92-11e7-bec4-a5e9ec5cab8b\",\"type\":\"max\"},{\"field\":\"37f72b50-1b92-11e7-bec4-a5e9ec5cab8b\",\"id\":\"37f72b51-1b92-11e7-bec4-a5e9ec5cab8b\",\"type\":\"derivative\",\"unit\":\"\"},{\"unit\":\"\",\"id\":\"f9da2dd0-1b92-11e7-a416-41f5ccdba2e6\",\"type\":\"positive_only\",\"field\":\"37f72b51-1b92-11e7-bec4-a5e9ec5cab8b\"},{\"sigma\":\"\",\"field\":\"f9da2dd0-1b92-11e7-a416-41f5ccdba2e6\",\"id\":\"3e63c2f0-1b92-11e7-bec4-a5e9ec5cab8b\",\"type\":\"series_agg\",\"function\":\"overall_sum\"}],\"point_size\":1,\"seperate_axis\":0,\"split_mode\":\"terms\",\"stacked\":\"none\",\"value_template\":\"{{value}}\",\"terms_field\":\"system.network.name\"}],\"show_legend\":1,\"time_field\":\"@timestamp\",\"type\":\"metric\",\"show_grid\":1},\"aggs\":[]}"
-      },
-      "id": "1aae9140-1b93-11e7-8ada-3df93aab833e",
-      "type": "visualization",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query\":{\"query_string\":{\"query\":\"*\"}},\"language\":\"lucene\"},\"filter\":[]}"
-        },
-        "title": "Disk Usage [Metricbeat System]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Disk Usage [Metricbeat System]\",\"type\":\"metrics\",\"params\":{\"axis_formatter\":\"number\",\"axis_position\":\"left\",\"bar_color_rules\":[{\"bar_color\":\"rgba(104,188,0,1)\",\"id\":\"bf525310-1b95-11e7-8ada-3df93aab833e\",\"opperator\":\"gte\",\"value\":0},{\"bar_color\":\"rgba(254,146,0,1)\",\"id\":\"125fc4c0-1b96-11e7-8ada-3df93aab833e\",\"opperator\":\"gte\",\"value\":0.7},{\"bar_color\":\"rgba(211,49,21,1)\",\"id\":\"1a5c7240-1b96-11e7-8ada-3df93aab833e\",\"opperator\":\"gte\",\"value\":0.85}],\"drilldown_url\":\"\",\"filter\":\"-system.filesystem.mount_point:\\\\/run* AND -system.filesystem.mount_point:\\\\/sys* AND -system.filesystem.mount_point:\\\\/dev* AND -system.filesystem.mount_point:\\\\/proc* AND -system.filesystem.mount_point:\\\\/var* AND -system.filesystem.mount_point:\\\\/boot\",\"id\":\"9f7e48a0-1b95-11e7-8ada-3df93aab833e\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"series\":[{\"axis_position\":\"right\",\"chart_type\":\"line\",\"color\":\"#68BC00\",\"fill\":0.5,\"formatter\":\"percent\",\"id\":\"9f7e48a1-1b95-11e7-8ada-3df93aab833e\",\"line_width\":1,\"metrics\":[{\"field\":\"system.filesystem.used.pct\",\"id\":\"9f7e48a2-1b95-11e7-8ada-3df93aab833e\",\"type\":\"avg\"}],\"point_size\":1,\"seperate_axis\":0,\"split_mode\":\"terms\",\"stacked\":\"none\",\"terms_field\":\"system.filesystem.mount_point\"}],\"show_legend\":1,\"time_field\":\"@timestamp\",\"type\":\"top_n\",\"show_grid\":1},\"aggs\":[]}"
-      },
-      "id": "34f97ee0-1b96-11e7-8ada-3df93aab833e",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}},\"language\":\"lucene\"},\"filter\":[]}"
-        },
-        "title": "System Navigation [Metricbeat System]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"System Navigation [Metricbeat System]\",\"type\":\"markdown\",\"params\":{\"markdown\":\"[System Overview](#/dashboard/Metricbeat-system-overview)  | [Host Overview](#/dashboard/79ffd6e0-faa0-11e6-947f-177f697178b8) |\\n[Containers overview](#/dashboard/CPU-slash-Memory-per-container)\",\"fontSize\":12},\"aggs\":[]}"
-      },
-      "id": "System-Navigation",
-      "type": "visualization",
-      "version": 3
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query\":{\"query_string\":{\"query\":\"*\"}},\"language\":\"lucene\"},\"filter\":[]}"
-        },
-        "title": "Swap usage [Metricbeat System]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Swap usage [Metricbeat System]\",\"type\":\"metrics\",\"params\":{\"id\":\"cee2fd20-4d59-11e7-aee5-fdc812cc3bec\",\"type\":\"gauge\",\"series\":[{\"id\":\"cee2fd21-4d59-11e7-aee5-fdc812cc3bec\",\"color\":\"#68BC00\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"cee2fd22-4d59-11e7-aee5-fdc812cc3bec\",\"type\":\"avg\",\"field\":\"system.memory.swap.used.pct\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"percent\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"label\":\"Swap usage\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"show_legend\":1,\"gauge_color_rules\":[{\"value\":0,\"id\":\"d17c1e90-4d59-11e7-aee5-fdc812cc3bec\",\"gauge\":\"rgba(104,188,0,1)\",\"opperator\":\"gte\"},{\"value\":0.7,\"id\":\"fc1d3490-4d59-11e7-aee5-fdc812cc3bec\",\"gauge\":\"rgba(251,158,0,1)\",\"opperator\":\"gte\"},{\"value\":0.85,\"id\":\"0e204240-4d5a-11e7-aee5-fdc812cc3bec\",\"gauge\":\"rgba(211,49,21,1)\",\"opperator\":\"gte\"}],\"gauge_width\":10,\"gauge_inner_width\":10,\"gauge_style\":\"half\",\"gauge_max\":\"\",\"filter\":\"\",\"show_grid\":1},\"aggs\":[]}"
-      },
-      "id": "19e123b0-4d5a-11e7-aee5-fdc812cc3bec",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query_string\":{\"query\":\"*\"}},\"filter\":[]}"
-        },
-        "title": "Memory usage vs total",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Memory usage vs total\",\"type\":\"metrics\",\"params\":{\"id\":\"6bc65720-4d5c-11e7-aa29-87a97a796de6\",\"type\":\"metric\",\"series\":[{\"id\":\"6bc65721-4d5c-11e7-aa29-87a97a796de6\",\"color\":\"#68BC00\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"6bc65722-4d5c-11e7-aa29-87a97a796de6\",\"type\":\"avg\",\"field\":\"system.memory.actual.used.bytes\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"bytes\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"label\":\"Memory usage\"},{\"id\":\"b8fe6820-4d5c-11e7-aa29-87a97a796de6\",\"color\":\"#68BC00\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"b8fe6821-4d5c-11e7-aa29-87a97a796de6\",\"type\":\"avg\",\"field\":\"system.memory.total\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"bytes\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"label\":\"Total Memory\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"show_legend\":1,\"background_color_rules\":[{\"id\":\"6f7618b0-4d5c-11e7-aa29-87a97a796de6\"}]},\"aggs\":[],\"listeners\":{}}"
-      },
-      "id": "d2e80340-4d5c-11e7-aa29-87a97a796de6",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query\":{\"query_string\":{\"query\":\"*\"}},\"language\":\"lucene\"},\"filter\":[]}"
-        },
-        "title": "Disk used [Metricbeat System]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Disk used [Metricbeat System]\",\"type\":\"metrics\",\"params\":{\"id\":\"4e4dc780-4d1d-11e7-b5f2-2b7c1895bf32\",\"type\":\"gauge\",\"series\":[{\"id\":\"4e4dee90-4d1d-11e7-b5f2-2b7c1895bf32\",\"color\":\"#68BC00\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"4e4dee91-4d1d-11e7-b5f2-2b7c1895bf32\",\"type\":\"avg\",\"field\":\"system.fsstat.total_size.used\"},{\"id\":\"57c96ee0-4d54-11e7-b5f2-2b7c1895bf32\",\"type\":\"avg\",\"field\":\"system.fsstat.total_size.total\"},{\"script\":\"params.total != null \u0026\u0026 params.total \u003e 0 ? params.used/params.total : null\",\"id\":\"6304cca0-4d54-11e7-b5f2-2b7c1895bf32\",\"type\":\"calculation\",\"variables\":[{\"id\":\"6da10430-4d54-11e7-b5f2-2b7c1895bf32\",\"field\":\"4e4dee91-4d1d-11e7-b5f2-2b7c1895bf32\",\"name\":\"used\"},{\"id\":\"73b8c510-4d54-11e7-b5f2-2b7c1895bf32\",\"name\":\"total\",\"field\":\"57c96ee0-4d54-11e7-b5f2-2b7c1895bf32\"}]}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"percent\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"label\":\"Disk used\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"show_legend\":1,\"gauge_color_rules\":[{\"value\":0,\"id\":\"51921d10-4d1d-11e7-b5f2-2b7c1895bf32\",\"gauge\":\"rgba(104,188,0,1)\",\"opperator\":\"gte\"},{\"value\":0.7,\"id\":\"f26de750-4d54-11e7-b5f2-2b7c1895bf32\",\"gauge\":\"rgba(251,158,0,1)\",\"opperator\":\"gte\"},{\"value\":0.85,\"id\":\"fa31d190-4d54-11e7-b5f2-2b7c1895bf32\",\"gauge\":\"rgba(211,49,21,1)\",\"opperator\":\"gte\"}],\"gauge_width\":10,\"gauge_inner_width\":10,\"gauge_style\":\"half\",\"gauge_max\":\"1\",\"filter\":\"\",\"show_grid\":1},\"aggs\":[]}"
-      },
-      "id": "825fdb80-4d1d-11e7-b5f2-2b7c1895bf32",
-      "type": "visualization",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query\":{\"query_string\":{\"query\":\"*\"}},\"language\":\"lucene\"},\"filter\":[]}"
-        },
-        "title": "Packetloss [Metricbeat System]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Packetloss [Metricbeat System]\",\"type\":\"metrics\",\"params\":{\"id\":\"6984af10-4d5d-11e7-aa29-87a97a796de6\",\"type\":\"metric\",\"series\":[{\"id\":\"6984af11-4d5d-11e7-aa29-87a97a796de6\",\"color\":\"#68BC00\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"6984af12-4d5d-11e7-aa29-87a97a796de6\",\"type\":\"max\",\"field\":\"system.network.in.dropped\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"label\":\"In Packetloss\"},{\"id\":\"ac2e6b30-4d5d-11e7-aa29-87a97a796de6\",\"color\":\"#68BC00\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"ac2e6b31-4d5d-11e7-aa29-87a97a796de6\",\"type\":\"max\",\"field\":\"system.network.out.dropped\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"label\":\"Out Packetloss\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"show_legend\":1,\"background_color_rules\":[{\"id\":\"6ba9b1f0-4d5d-11e7-aa29-87a97a796de6\"}],\"show_grid\":1},\"aggs\":[]}"
-      },
-      "id": "96976150-4d5d-11e7-aa29-87a97a796de6",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query\":{\"query_string\":{\"query\":\"*\"}},\"language\":\"lucene\"},\"filter\":[]}"
-        },
-        "title": "Interfaces by Incoming traffic [Metricbeat System]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Interfaces by Incoming traffic [Metricbeat System]\",\"type\":\"metrics\",\"params\":{\"id\":\"42ceae90-4d60-11e7-9a4c-ed99bbcaa42b\",\"type\":\"top_n\",\"series\":[{\"id\":\"42ced5a0-4d60-11e7-9a4c-ed99bbcaa42b\",\"color\":\"#68BC00\",\"split_mode\":\"terms\",\"metrics\":[{\"id\":\"42ced5a1-4d60-11e7-9a4c-ed99bbcaa42b\",\"type\":\"avg\",\"field\":\"system.network.in.bytes\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"bytes\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"label\":\"Interfaces by Incoming traffic\",\"terms_field\":\"system.network.name\",\"terms_order_by\":\"42ced5a1-4d60-11e7-9a4c-ed99bbcaa42b\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"show_legend\":1,\"bar_color_rules\":[{\"id\":\"44596d40-4d60-11e7-9a4c-ed99bbcaa42b\"}],\"show_grid\":1},\"aggs\":[]}"
-      },
-      "id": "99381c80-4d60-11e7-9a4c-ed99bbcaa42b",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query\":{\"query_string\":{\"query\":\"*\"}},\"language\":\"lucene\"},\"filter\":[]}"
-        },
-        "title": "Interfaces by Outgoing traffic [Metricbeat System]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Interfaces by Outgoing traffic [Metricbeat System]\",\"type\":\"metrics\",\"params\":{\"id\":\"9cdba910-4d60-11e7-9a4c-ed99bbcaa42b\",\"type\":\"top_n\",\"series\":[{\"id\":\"9cdba911-4d60-11e7-9a4c-ed99bbcaa42b\",\"color\":\"#68BC00\",\"split_mode\":\"terms\",\"metrics\":[{\"id\":\"9cdba912-4d60-11e7-9a4c-ed99bbcaa42b\",\"type\":\"avg\",\"field\":\"system.network.out.bytes\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"bytes\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"terms_field\":\"system.network.name\",\"terms_order_by\":\"9cdba912-4d60-11e7-9a4c-ed99bbcaa42b\",\"label\":\"Interfaces by Outgoing traffic\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"show_legend\":1,\"bar_color_rules\":[{\"id\":\"9db20be0-4d60-11e7-9a4c-ed99bbcaa42b\"}],\"show_grid\":1},\"aggs\":[]}"
-      },
-      "id": "c5e3cf90-4d60-11e7-9a4c-ed99bbcaa42b",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\n  \"index\": \"metricbeat-*\",\n  \"query\": {\n    \"query_string\": {\n      \"query\": \"*\",\n      \"analyze_wildcard\": true\n    }\n  },\n  \"filter\": []\n}"
-        },
-        "title": "Number of processes [Metricbeat System]",
-        "uiStateJSON": "{\n  \"vis\": {\n    \"defaultColors\": {\n      \"0 - 100\": \"rgb(0,104,55)\"\n    }\n  }\n}",
-        "version": 1,
-        "visState": "{\n  \"title\": \"Number of processes\",\n  \"type\": \"metric\",\n  \"params\": {\n    \"addLegend\": false,\n    \"addTooltip\": true,\n    \"gauge\": {\n      \"autoExtend\": false,\n      \"backStyle\": \"Full\",\n      \"colorSchema\": \"Green to Red\",\n      \"colorsRange\": [\n        {\n          \"from\": 0,\n          \"to\": 100\n        }\n      ],\n      \"gaugeColorMode\": \"None\",\n      \"gaugeStyle\": \"Full\",\n      \"gaugeType\": \"Metric\",\n      \"invertColors\": false,\n      \"labels\": {\n        \"color\": \"black\",\n        \"show\": true\n      },\n      \"orientation\": \"vertical\",\n      \"percentageMode\": false,\n      \"scale\": {\n        \"color\": \"#333\",\n        \"labels\": false,\n        \"show\": false,\n        \"width\": 2\n      },\n      \"style\": {\n        \"bgColor\": false,\n        \"bgFill\": \"#000\",\n        \"fontSize\": 60,\n        \"labelColor\": false,\n        \"subText\": \"\"\n      },\n      \"type\": \"simple\",\n      \"useRange\": false,\n      \"verticalSplit\": false\n    },\n    \"type\": \"gauge\"\n  },\n  \"aggs\": [\n    {\n      \"id\": \"1\",\n      \"enabled\": true,\n      \"type\": \"cardinality\",\n      \"schema\": \"metric\",\n      \"params\": {\n        \"field\": \"system.process.pid\",\n        \"customLabel\": \"Processes\"\n      }\n    }\n  ],\n  \"listeners\": {}\n}"
-      },
-      "id": "590a60f0-5d87-11e7-8884-1bb4c3b890e4",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{}"
-        },
-        "title": "Tip [Metricbeat System]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Tip [Metricbeat System]\",\"type\":\"markdown\",\"params\":{\"fontSize\":12,\"markdown\":\"**TIP:** To select another host, go to the [System Overview](#/dashboard/Metricbeat-system-overview) dashboard and double-click a host name.\"},\"aggs\":[]}"
-      },
-      "id": "3d65d450-a9c3-11e7-af20-67db8aecb295",
-      "type": "visualization",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "hits": 0,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[],\"highlightAll\":true,\"version\":true,\"query\":{\"language\":\"lucene\",\"query\":\"beat.name:\\\"CHANGEME_HOSTNAME\\\"\"}}"
-        },
-        "optionsJSON": "{\"darkTheme\":false}",
-        "panelsJSON": "[{\"col\":1,\"id\":\"6b7b9a40-faa1-11e6-86b1-cd7735ff7e23\",\"panelIndex\":1,\"row\":12,\"size_x\":6,\"size_y\":3,\"type\":\"visualization\"},{\"col\":7,\"id\":\"4d546850-1b15-11e7-b09e-037021c4f8df\",\"panelIndex\":2,\"row\":6,\"size_x\":6,\"size_y\":3,\"type\":\"visualization\"},{\"col\":7,\"id\":\"089b85d0-1b16-11e7-b09e-037021c4f8df\",\"panelIndex\":3,\"row\":12,\"size_x\":6,\"size_y\":3,\"type\":\"visualization\"},{\"col\":1,\"id\":\"bfa5e400-1b16-11e7-b09e-037021c4f8df\",\"panelIndex\":4,\"row\":9,\"size_x\":6,\"size_y\":3,\"type\":\"visualization\"},{\"col\":7,\"id\":\"e0f001c0-1b18-11e7-b09e-037021c4f8df\",\"panelIndex\":5,\"row\":15,\"size_x\":6,\"size_y\":3,\"type\":\"visualization\"},{\"col\":1,\"id\":\"2e224660-1b19-11e7-b09e-037021c4f8df\",\"panelIndex\":6,\"row\":15,\"size_x\":6,\"size_y\":3,\"type\":\"visualization\"},{\"col\":1,\"id\":\"ab2d1e90-1b1a-11e7-b09e-037021c4f8df\",\"panelIndex\":7,\"row\":6,\"size_x\":6,\"size_y\":3,\"type\":\"visualization\"},{\"col\":7,\"id\":\"4e4bb1e0-1b1b-11e7-b09e-037021c4f8df\",\"panelIndex\":8,\"row\":9,\"size_x\":6,\"size_y\":3,\"type\":\"visualization\"},{\"col\":5,\"id\":\"26732e20-1b91-11e7-bec4-a5e9ec5cab8b\",\"panelIndex\":9,\"row\":2,\"size_x\":2,\"size_y\":2,\"type\":\"visualization\"},{\"col\":1,\"id\":\"83e12df0-1b91-11e7-bec4-a5e9ec5cab8b\",\"panelIndex\":10,\"row\":2,\"size_x\":2,\"size_y\":2,\"type\":\"visualization\"},{\"col\":3,\"id\":\"d3166e80-1b91-11e7-bec4-a5e9ec5cab8b\",\"panelIndex\":11,\"row\":2,\"size_x\":2,\"size_y\":2,\"type\":\"visualization\"},{\"col\":7,\"id\":\"522ee670-1b92-11e7-bec4-a5e9ec5cab8b\",\"panelIndex\":12,\"row\":2,\"size_x\":2,\"size_y\":2,\"type\":\"visualization\"},{\"col\":9,\"id\":\"1aae9140-1b93-11e7-8ada-3df93aab833e\",\"panelIndex\":13,\"row\":2,\"size_x\":2,\"size_y\":2,\"type\":\"visualization\"},{\"col\":9,\"id\":\"34f97ee0-1b96-11e7-8ada-3df93aab833e\",\"panelIndex\":14,\"row\":4,\"size_x\":4,\"size_y\":2,\"type\":\"visualization\"},{\"col\":1,\"id\":\"System-Navigation\",\"panelIndex\":16,\"row\":1,\"size_x\":6,\"size_y\":1,\"type\":\"visualization\"},{\"col\":1,\"id\":\"19e123b0-4d5a-11e7-aee5-fdc812cc3bec\",\"panelIndex\":21,\"row\":4,\"size_x\":2,\"size_y\":2,\"type\":\"visualization\"},{\"col\":3,\"id\":\"d2e80340-4d5c-11e7-aa29-87a97a796de6\",\"panelIndex\":22,\"row\":4,\"size_x\":2,\"size_y\":2,\"type\":\"visualization\"},{\"col\":7,\"id\":\"825fdb80-4d1d-11e7-b5f2-2b7c1895bf32\",\"panelIndex\":23,\"row\":4,\"size_x\":2,\"size_y\":2,\"type\":\"visualization\"},{\"col\":11,\"id\":\"96976150-4d5d-11e7-aa29-87a97a796de6\",\"panelIndex\":25,\"row\":2,\"size_x\":2,\"size_y\":2,\"type\":\"visualization\"},{\"col\":1,\"id\":\"99381c80-4d60-11e7-9a4c-ed99bbcaa42b\",\"panelIndex\":27,\"row\":18,\"size_x\":6,\"size_y\":3,\"type\":\"visualization\"},{\"col\":7,\"id\":\"c5e3cf90-4d60-11e7-9a4c-ed99bbcaa42b\",\"panelIndex\":28,\"row\":18,\"size_x\":6,\"size_y\":3,\"type\":\"visualization\"},{\"col\":5,\"id\":\"590a60f0-5d87-11e7-8884-1bb4c3b890e4\",\"panelIndex\":29,\"row\":4,\"size_x\":2,\"size_y\":2,\"type\":\"visualization\"},{\"col\":7,\"id\":\"3d65d450-a9c3-11e7-af20-67db8aecb295\",\"panelIndex\":30,\"row\":1,\"size_x\":6,\"size_y\":1,\"type\":\"visualization\"}]",
-        "timeRestore": false,
-        "title": "[Metricbeat System] Host overview",
-        "uiStateJSON": "{\"P-29\":{\"vis\":{\"defaultColors\":{\"0 - 100\":\"rgb(0,104,55)\"}}}}",
-        "version": 1
-      },
-      "id": "79ffd6e0-faa0-11e6-947f-177f697178b8",
-      "type": "dashboard",
-      "version": 12
-    }
-  ],
-  "version": "6.0.0-rc1-SNAPSHOT"
+    "objects": [
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "query_string": {
+                                "query": "*"
+                            }
+                        }
+                    }
+                }, 
+                "title": "Network Traffic (Packets) [Metricbeat System]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "listeners": {}, 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "filter": "-system.network.name:l*", 
+                        "id": "da1046f0-faa0-11e6-86b1-cd7735ff7e23", 
+                        "index_pattern": "*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(0,156,224,1)", 
+                                "fill": "1", 
+                                "formatter": "0.[00]a", 
+                                "id": "da1046f1-faa0-11e6-86b1-cd7735ff7e23", 
+                                "label": "Inbound", 
+                                "line_width": "0", 
+                                "metrics": [
+                                    {
+                                        "field": "system.network.in.packets", 
+                                        "id": "da1046f2-faa0-11e6-86b1-cd7735ff7e23", 
+                                        "type": "max"
+                                    }, 
+                                    {
+                                        "field": "da1046f2-faa0-11e6-86b1-cd7735ff7e23", 
+                                        "id": "f41f9280-faa0-11e6-86b1-cd7735ff7e23", 
+                                        "type": "derivative", 
+                                        "unit": "1s"
+                                    }, 
+                                    {
+                                        "field": "f41f9280-faa0-11e6-86b1-cd7735ff7e23", 
+                                        "id": "c0da3d80-1b93-11e7-8ada-3df93aab833e", 
+                                        "type": "positive_only", 
+                                        "unit": ""
+                                    }, 
+                                    {
+                                        "function": "sum", 
+                                        "id": "ecaad010-2c2c-11e7-be71-3162da85303f", 
+                                        "type": "series_agg"
+                                    }
+                                ], 
+                                "point_size": "0", 
+                                "seperate_axis": 0, 
+                                "split_mode": "terms", 
+                                "stacked": "none", 
+                                "terms_field": "system.network.name", 
+                                "value_template": "{{value}}/s"
+                            }, 
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(250,40,255,1)", 
+                                "fill": "1", 
+                                "formatter": "0.[00]a", 
+                                "id": "fbbd5720-faa0-11e6-86b1-cd7735ff7e23", 
+                                "label": "Outbound", 
+                                "line_width": "0", 
+                                "metrics": [
+                                    {
+                                        "field": "system.network.out.packets", 
+                                        "id": "fbbd7e30-faa0-11e6-86b1-cd7735ff7e23", 
+                                        "type": "max"
+                                    }, 
+                                    {
+                                        "field": "fbbd7e30-faa0-11e6-86b1-cd7735ff7e23", 
+                                        "id": "fbbd7e31-faa0-11e6-86b1-cd7735ff7e23", 
+                                        "type": "derivative", 
+                                        "unit": "1s"
+                                    }, 
+                                    {
+                                        "id": "17e597a0-faa1-11e6-86b1-cd7735ff7e23", 
+                                        "script": "params.rate != null && params.rate > 0 ? params.rate * -1 : null", 
+                                        "type": "calculation", 
+                                        "variables": [
+                                            {
+                                                "field": "fbbd7e31-faa0-11e6-86b1-cd7735ff7e23", 
+                                                "id": "1940bad0-faa1-11e6-86b1-cd7735ff7e23", 
+                                                "name": "rate"
+                                            }
+                                        ]
+                                    }, 
+                                    {
+                                        "function": "sum", 
+                                        "id": "fe5fbdc0-2c2c-11e7-be71-3162da85303f", 
+                                        "type": "series_agg"
+                                    }
+                                ], 
+                                "point_size": "0", 
+                                "seperate_axis": 0, 
+                                "split_mode": "terms", 
+                                "stacked": "none", 
+                                "terms_field": "system.network.name", 
+                                "value_template": "{{value}}/s"
+                            }
+                        ], 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "timeseries"
+                    }, 
+                    "title": "Mericbeat: Network Traffic (Packets)", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "6b7b9a40-faa1-11e6-86b1-cd7735ff7e23", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "query": "*"
+                                }
+                            }
+                        }
+                    }
+                }, 
+                "title": "System Load [Metricbeat System]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "id": "f6264ad0-1b14-11e7-b09e-037021c4f8df", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(115,216,255,1)", 
+                                "fill": "0", 
+                                "formatter": "number", 
+                                "id": "f62671e0-1b14-11e7-b09e-037021c4f8df", 
+                                "label": "1m", 
+                                "line_width": "3", 
+                                "metrics": [
+                                    {
+                                        "field": "system.load.1", 
+                                        "id": "f62671e1-1b14-11e7-b09e-037021c4f8df", 
+                                        "type": "avg"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }, 
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(0,156,224,1)", 
+                                "fill": "0", 
+                                "formatter": "number", 
+                                "id": "1c324850-1b15-11e7-b09e-037021c4f8df", 
+                                "label": "5m", 
+                                "line_width": "3", 
+                                "metrics": [
+                                    {
+                                        "field": "system.load.5", 
+                                        "id": "1c324851-1b15-11e7-b09e-037021c4f8df", 
+                                        "type": "avg"
+                                    }
+                                ], 
+                                "point_size": "0", 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }, 
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(0,98,177,1)", 
+                                "fill": "0", 
+                                "formatter": "number", 
+                                "id": "3287e740-1b15-11e7-b09e-037021c4f8df", 
+                                "label": "15m", 
+                                "line_width": "3", 
+                                "metrics": [
+                                    {
+                                        "field": "system.load.15", 
+                                        "id": "32880e50-1b15-11e7-b09e-037021c4f8df", 
+                                        "type": "avg"
+                                    }
+                                ], 
+                                "point_size": "0", 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "timeseries"
+                    }, 
+                    "title": "System Load [Metricbeat System]", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "4d546850-1b15-11e7-b09e-037021c4f8df", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "query_string": {
+                                "query": "*"
+                            }
+                        }
+                    }
+                }, 
+                "title": "Network Traffic (Bytes) [Metricbeat System]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "listeners": {}, 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "filter": "-system.network.name:l*", 
+                        "id": "da1046f0-faa0-11e6-86b1-cd7735ff7e23", 
+                        "index_pattern": "*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(0,156,224,1)", 
+                                "fill": "1", 
+                                "formatter": "bytes", 
+                                "id": "da1046f1-faa0-11e6-86b1-cd7735ff7e23", 
+                                "label": "Inbound ", 
+                                "line_width": "0", 
+                                "metrics": [
+                                    {
+                                        "field": "system.network.in.bytes", 
+                                        "id": "da1046f2-faa0-11e6-86b1-cd7735ff7e23", 
+                                        "type": "max"
+                                    }, 
+                                    {
+                                        "field": "da1046f2-faa0-11e6-86b1-cd7735ff7e23", 
+                                        "id": "f41f9280-faa0-11e6-86b1-cd7735ff7e23", 
+                                        "type": "derivative", 
+                                        "unit": "1s"
+                                    }, 
+                                    {
+                                        "field": "f41f9280-faa0-11e6-86b1-cd7735ff7e23", 
+                                        "id": "a87398e0-1b93-11e7-8ada-3df93aab833e", 
+                                        "type": "positive_only", 
+                                        "unit": ""
+                                    }, 
+                                    {
+                                        "function": "sum", 
+                                        "id": "2d533df0-2c2d-11e7-be71-3162da85303f", 
+                                        "type": "series_agg"
+                                    }
+                                ], 
+                                "point_size": "0", 
+                                "seperate_axis": 0, 
+                                "split_mode": "terms", 
+                                "stacked": "none", 
+                                "terms_field": "system.network.name", 
+                                "value_template": "{{value}}/s"
+                            }, 
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(250,40,255,1)", 
+                                "fill": "1", 
+                                "formatter": "bytes", 
+                                "id": "fbbd5720-faa0-11e6-86b1-cd7735ff7e23", 
+                                "label": "Outbound ", 
+                                "line_width": "0", 
+                                "metrics": [
+                                    {
+                                        "field": "system.network.out.bytes", 
+                                        "id": "fbbd7e30-faa0-11e6-86b1-cd7735ff7e23", 
+                                        "type": "max"
+                                    }, 
+                                    {
+                                        "field": "fbbd7e30-faa0-11e6-86b1-cd7735ff7e23", 
+                                        "id": "fbbd7e31-faa0-11e6-86b1-cd7735ff7e23", 
+                                        "type": "derivative", 
+                                        "unit": "1s"
+                                    }, 
+                                    {
+                                        "id": "17e597a0-faa1-11e6-86b1-cd7735ff7e23", 
+                                        "script": "params.rate != null && params.rate > 0 ? params.rate * -1 : null", 
+                                        "type": "calculation", 
+                                        "variables": [
+                                            {
+                                                "field": "fbbd7e31-faa0-11e6-86b1-cd7735ff7e23", 
+                                                "id": "1940bad0-faa1-11e6-86b1-cd7735ff7e23", 
+                                                "name": "rate"
+                                            }
+                                        ]
+                                    }, 
+                                    {
+                                        "function": "sum", 
+                                        "id": "533da9b0-2c2d-11e7-be71-3162da85303f", 
+                                        "type": "series_agg"
+                                    }
+                                ], 
+                                "point_size": "0", 
+                                "seperate_axis": 0, 
+                                "split_mode": "terms", 
+                                "stacked": "none", 
+                                "terms_field": "system.network.name", 
+                                "value_template": "{{value}}/s"
+                            }
+                        ], 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "timeseries"
+                    }, 
+                    "title": "Mericbeat: Network Traffic (Bytes)", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "089b85d0-1b16-11e7-b09e-037021c4f8df", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "query": "*"
+                                }
+                            }
+                        }
+                    }
+                }, 
+                "title": "Memory Usage [Metricbeat System]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "id": "32f46f40-1b16-11e7-b09e-037021c4f8df", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(211,49,21,1)", 
+                                "fill": "1", 
+                                "formatter": "bytes", 
+                                "id": "4ff61fd0-1b16-11e7-b09e-037021c4f8df", 
+                                "label": "Used", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "system.memory.actual.used.bytes", 
+                                        "id": "4ff61fd1-1b16-11e7-b09e-037021c4f8df", 
+                                        "type": "avg"
+                                    }
+                                ], 
+                                "point_size": "0", 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "stacked"
+                            }, 
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(0,156,224,1)", 
+                                "fill": "1", 
+                                "formatter": "bytes", 
+                                "id": "753a6080-1b16-11e7-b09e-037021c4f8df", 
+                                "label": "Cache", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "system.memory.actual.used.bytes", 
+                                        "id": "753a6081-1b16-11e7-b09e-037021c4f8df", 
+                                        "type": "avg"
+                                    }, 
+                                    {
+                                        "field": "system.memory.used.bytes", 
+                                        "id": "7c9d3f00-1b16-11e7-b09e-037021c4f8df", 
+                                        "type": "avg"
+                                    }, 
+                                    {
+                                        "id": "869cc160-1b16-11e7-b09e-037021c4f8df", 
+                                        "script": "params.actual != null && params.used != null ? params.used - params.actual : null", 
+                                        "type": "calculation", 
+                                        "variables": [
+                                            {
+                                                "field": "753a6081-1b16-11e7-b09e-037021c4f8df", 
+                                                "id": "890f9620-1b16-11e7-b09e-037021c4f8df", 
+                                                "name": "actual"
+                                            }, 
+                                            {
+                                                "field": "7c9d3f00-1b16-11e7-b09e-037021c4f8df", 
+                                                "id": "8f3ab7f0-1b16-11e7-b09e-037021c4f8df", 
+                                                "name": "used"
+                                            }
+                                        ]
+                                    }
+                                ], 
+                                "point_size": "0", 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "stacked"
+                            }, 
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": "1", 
+                                "formatter": "bytes", 
+                                "id": "32f46f41-1b16-11e7-b09e-037021c4f8df", 
+                                "label": "Free", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "system.memory.free", 
+                                        "id": "32f46f42-1b16-11e7-b09e-037021c4f8df", 
+                                        "type": "avg"
+                                    }
+                                ], 
+                                "point_size": "0", 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "stacked"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "timeseries"
+                    }, 
+                    "title": "Memory Usage [Metricbeat System]", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "bfa5e400-1b16-11e7-b09e-037021c4f8df", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "query": "*"
+                                }
+                            }
+                        }
+                    }
+                }, 
+                "title": "Top Processes By CPU [Metricbeat System]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "bar_color_rules": [
+                            {
+                                "bar_color": "rgba(104,188,0,1)", 
+                                "id": "60e11be0-1b18-11e7-b09e-037021c4f8df", 
+                                "opperator": "gte", 
+                                "value": 0
+                            }
+                        ], 
+                        "drilldown_url": "", 
+                        "filter": "", 
+                        "id": "5f5b8d50-1b18-11e7-b09e-037021c4f8df", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "formatter": "percent", 
+                                "id": "5f5b8d51-1b18-11e7-b09e-037021c4f8df", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "system.process.cpu.total.pct", 
+                                        "id": "5f5b8d52-1b18-11e7-b09e-037021c4f8df", 
+                                        "type": "avg"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "terms", 
+                                "stacked": "none", 
+                                "terms_field": "system.process.name", 
+                                "terms_order_by": "5f5b8d52-1b18-11e7-b09e-037021c4f8df"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "top_n"
+                    }, 
+                    "title": "Top Processes By CPU [Metricbeat System]", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "e0f001c0-1b18-11e7-b09e-037021c4f8df", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "query": "*"
+                                }
+                            }
+                        }
+                    }
+                }, 
+                "title": "Processes By Memory [Metricbeat System]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "bar_color_rules": [
+                            {
+                                "bar_color": "rgba(104,188,0,1)", 
+                                "id": "efb9b660-1b18-11e7-b09e-037021c4f8df", 
+                                "opperator": "gte", 
+                                "value": 0
+                            }, 
+                            {
+                                "bar_color": "rgba(254,146,0,1)", 
+                                "id": "17fcb820-1b19-11e7-b09e-037021c4f8df", 
+                                "opperator": "gte", 
+                                "value": 0.7
+                            }, 
+                            {
+                                "bar_color": "rgba(211,49,21,1)", 
+                                "id": "1dd61070-1b19-11e7-b09e-037021c4f8df", 
+                                "opperator": "gte", 
+                                "value": 0.85
+                            }
+                        ], 
+                        "drilldown_url": "", 
+                        "filter": "", 
+                        "id": "edfceb30-1b18-11e7-b09e-037021c4f8df", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "formatter": "percent", 
+                                "id": "edfceb31-1b18-11e7-b09e-037021c4f8df", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "system.process.memory.rss.pct", 
+                                        "id": "edfceb32-1b18-11e7-b09e-037021c4f8df", 
+                                        "type": "avg"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "terms", 
+                                "stacked": "none", 
+                                "terms_field": "system.process.name", 
+                                "terms_order_by": "edfceb32-1b18-11e7-b09e-037021c4f8df"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "top_n"
+                    }, 
+                    "title": "Processes By Memory [Metricbeat System]", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "2e224660-1b19-11e7-b09e-037021c4f8df", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "query": "*"
+                                }
+                            }
+                        }
+                    }
+                }, 
+                "title": "CPU Usage [Metricbeat System]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "id": "80a04950-1b19-11e7-b09e-037021c4f8df", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": "1", 
+                                "formatter": "percent", 
+                                "id": "80a04951-1b19-11e7-b09e-037021c4f8df", 
+                                "label": "user", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "system.cpu.user.pct", 
+                                        "id": "80a04952-1b19-11e7-b09e-037021c4f8df", 
+                                        "type": "avg"
+                                    }
+                                ], 
+                                "point_size": "0", 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "stacked"
+                            }, 
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(211,49,21,1)", 
+                                "fill": "1", 
+                                "formatter": "percent", 
+                                "id": "993acf30-1b19-11e7-b09e-037021c4f8df", 
+                                "label": "system", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "system.cpu.system.pct", 
+                                        "id": "993acf31-1b19-11e7-b09e-037021c4f8df", 
+                                        "type": "avg"
+                                    }
+                                ], 
+                                "point_size": "0", 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "stacked"
+                            }, 
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(123,100,255,1)", 
+                                "fill": "1", 
+                                "formatter": "percent", 
+                                "id": "65ca35e0-1b1a-11e7-b09e-037021c4f8df", 
+                                "label": "nice", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "system.cpu.nice.pct", 
+                                        "id": "65ca5cf0-1b1a-11e7-b09e-037021c4f8df", 
+                                        "type": "avg"
+                                    }
+                                ], 
+                                "point_size": "0", 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "stacked"
+                            }, 
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(226,115,0,1)", 
+                                "fill": "1", 
+                                "formatter": "percent", 
+                                "id": "741b5f20-1b1a-11e7-b09e-037021c4f8df", 
+                                "label": "irq", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "system.cpu.irq.pct", 
+                                        "id": "741b5f21-1b1a-11e7-b09e-037021c4f8df", 
+                                        "type": "avg"
+                                    }
+                                ], 
+                                "point_size": "0", 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "stacked"
+                            }, 
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(176,188,0,1)", 
+                                "fill": "1", 
+                                "formatter": "percent", 
+                                "id": "2efc5d40-1b1a-11e7-b09e-037021c4f8df", 
+                                "label": "softirq", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "system.cpu.softirq.pct", 
+                                        "id": "2efc5d41-1b1a-11e7-b09e-037021c4f8df", 
+                                        "type": "avg"
+                                    }
+                                ], 
+                                "point_size": "0", 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "stacked"
+                            }, 
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(15,20,25,1)", 
+                                "fill": "1", 
+                                "formatter": "percent", 
+                                "id": "ae644a30-1b19-11e7-b09e-037021c4f8df", 
+                                "label": "iowait", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "system.cpu.iowait.pct", 
+                                        "id": "ae644a31-1b19-11e7-b09e-037021c4f8df", 
+                                        "type": "avg"
+                                    }
+                                ], 
+                                "point_size": "0", 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "stacked"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "timeseries"
+                    }, 
+                    "title": "CPU Usage [Metricbeat System]", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "ab2d1e90-1b1a-11e7-b09e-037021c4f8df", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "query": "*"
+                                }
+                            }
+                        }
+                    }
+                }, 
+                "title": "Disk IO (Bytes) [Metricbeat System]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "filter": "", 
+                        "id": "d3c67db0-1b1a-11e7-b09e-037021c4f8df", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(22,165,165,1)", 
+                                "fill": "1", 
+                                "formatter": "bytes", 
+                                "id": "d3c67db1-1b1a-11e7-b09e-037021c4f8df", 
+                                "label": "reads", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "system.diskio.read.bytes", 
+                                        "id": "d3c67db2-1b1a-11e7-b09e-037021c4f8df", 
+                                        "type": "max"
+                                    }, 
+                                    {
+                                        "field": "d3c67db2-1b1a-11e7-b09e-037021c4f8df", 
+                                        "id": "f55b9910-1b1a-11e7-b09e-037021c4f8df", 
+                                        "type": "derivative", 
+                                        "unit": "1s"
+                                    }, 
+                                    {
+                                        "field": "f55b9910-1b1a-11e7-b09e-037021c4f8df", 
+                                        "id": "dcbbb100-1b93-11e7-8ada-3df93aab833e", 
+                                        "type": "positive_only", 
+                                        "unit": ""
+                                    }
+                                ], 
+                                "point_size": "0", 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none", 
+                                "value_template": "{{value}}/s"
+                            }, 
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(251,158,0,1)", 
+                                "fill": "1", 
+                                "formatter": "bytes", 
+                                "id": "144124d0-1b1b-11e7-b09e-037021c4f8df", 
+                                "label": "writes", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "system.diskio.write.bytes", 
+                                        "id": "144124d1-1b1b-11e7-b09e-037021c4f8df", 
+                                        "type": "max"
+                                    }, 
+                                    {
+                                        "field": "144124d1-1b1b-11e7-b09e-037021c4f8df", 
+                                        "id": "144124d2-1b1b-11e7-b09e-037021c4f8df", 
+                                        "type": "derivative", 
+                                        "unit": "1s"
+                                    }, 
+                                    {
+                                        "id": "144124d4-1b1b-11e7-b09e-037021c4f8df", 
+                                        "script": "params.rate > 0 ? params.rate * -1 : 0", 
+                                        "type": "calculation", 
+                                        "variables": [
+                                            {
+                                                "field": "144124d2-1b1b-11e7-b09e-037021c4f8df", 
+                                                "id": "144124d3-1b1b-11e7-b09e-037021c4f8df", 
+                                                "name": "rate"
+                                            }
+                                        ]
+                                    }
+                                ], 
+                                "point_size": "0", 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none", 
+                                "value_template": "{{value}}/s"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "timeseries"
+                    }, 
+                    "title": "Disk IO (Bytes) [Metricbeat System]", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "4e4bb1e0-1b1b-11e7-b09e-037021c4f8df", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "query": "*"
+                                }
+                            }
+                        }
+                    }
+                }, 
+                "title": "Load Gauge [Metricbeat System]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "background_color_rules": [
+                            {
+                                "id": "feefabd0-1b90-11e7-bec4-a5e9ec5cab8b"
+                            }
+                        ], 
+                        "gauge_color_rules": [
+                            {
+                                "id": "ffd94880-1b90-11e7-bec4-a5e9ec5cab8b"
+                            }
+                        ], 
+                        "gauge_inner_width": 10, 
+                        "gauge_style": "half", 
+                        "gauge_width": 10, 
+                        "id": "fdcc6180-1b90-11e7-bec4-a5e9ec5cab8b", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "formatter": "number", 
+                                "id": "fdcc6181-1b90-11e7-bec4-a5e9ec5cab8b", 
+                                "label": "5m Load", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "system.load.5", 
+                                        "id": "fdcc6182-1b90-11e7-bec4-a5e9ec5cab8b", 
+                                        "type": "avg"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "gauge"
+                    }, 
+                    "title": "Load Gauge [Metricbeat System]", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "26732e20-1b91-11e7-bec4-a5e9ec5cab8b", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "query": "*"
+                                }
+                            }
+                        }
+                    }
+                }, 
+                "title": "CPU Usage Gauge [Metricbeat System]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "filter": "", 
+                        "gauge_color_rules": [
+                            {
+                                "gauge": "rgba(104,188,0,1)", 
+                                "id": "4ef2c3b0-1b91-11e7-bec4-a5e9ec5cab8b", 
+                                "opperator": "gte", 
+                                "value": 0
+                            }, 
+                            {
+                                "gauge": "rgba(254,146,0,1)", 
+                                "id": "e6561ae0-1b91-11e7-bec4-a5e9ec5cab8b", 
+                                "opperator": "gte", 
+                                "value": 0.7
+                            }, 
+                            {
+                                "gauge": "rgba(211,49,21,1)", 
+                                "id": "ec655040-1b91-11e7-bec4-a5e9ec5cab8b", 
+                                "opperator": "gte", 
+                                "value": 0.85
+                            }
+                        ], 
+                        "gauge_inner_width": 10, 
+                        "gauge_max": "1", 
+                        "gauge_style": "half", 
+                        "gauge_width": 10, 
+                        "id": "4c9e2550-1b91-11e7-bec4-a5e9ec5cab8b", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "formatter": "percent", 
+                                "id": "4c9e2551-1b91-11e7-bec4-a5e9ec5cab8b", 
+                                "label": "CPU Usage", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "system.cpu.user.pct", 
+                                        "id": "4c9e2552-1b91-11e7-bec4-a5e9ec5cab8b", 
+                                        "type": "avg"
+                                    }, 
+                                    {
+                                        "field": "system.cpu.system.pct", 
+                                        "id": "225c2140-5fd7-11e7-a63a-a937b7c1a7e1", 
+                                        "type": "avg"
+                                    }, 
+                                    {
+                                        "field": "system.cpu.cores", 
+                                        "id": "837a30c0-5fd7-11e7-a63a-a937b7c1a7e1", 
+                                        "type": "avg"
+                                    }, 
+                                    {
+                                        "id": "587aa510-1b91-11e7-bec4-a5e9ec5cab8b", 
+                                        "script": "params.n > 0 ? (params.user+params.system)/params.n : null", 
+                                        "type": "calculation", 
+                                        "variables": [
+                                            {
+                                                "field": "4c9e2552-1b91-11e7-bec4-a5e9ec5cab8b", 
+                                                "id": "5a19af10-1b91-11e7-bec4-a5e9ec5cab8b", 
+                                                "name": "user"
+                                            }, 
+                                            {
+                                                "field": "225c2140-5fd7-11e7-a63a-a937b7c1a7e1", 
+                                                "id": "32b54f80-5fd7-11e7-a63a-a937b7c1a7e1", 
+                                                "name": "system"
+                                            }, 
+                                            {
+                                                "field": "837a30c0-5fd7-11e7-a63a-a937b7c1a7e1", 
+                                                "id": "8ba6eef0-5fd7-11e7-a63a-a937b7c1a7e1", 
+                                                "name": "n"
+                                            }
+                                        ]
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "gauge"
+                    }, 
+                    "title": "CPU Usage Gauge [Metricbeat System]", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "83e12df0-1b91-11e7-bec4-a5e9ec5cab8b", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "query": "*"
+                                }
+                            }
+                        }
+                    }
+                }, 
+                "title": "Memory Usage Gauge [Metricbeat System]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "filter": "", 
+                        "gauge_color_rules": [
+                            {
+                                "gauge": "rgba(104,188,0,1)", 
+                                "id": "a0d522e0-1b91-11e7-bec4-a5e9ec5cab8b", 
+                                "opperator": "gte", 
+                                "value": 0
+                            }, 
+                            {
+                                "gauge": "rgba(254,146,0,1)", 
+                                "id": "b45ad8f0-1b91-11e7-bec4-a5e9ec5cab8b", 
+                                "opperator": "gte", 
+                                "value": 0.7
+                            }, 
+                            {
+                                "gauge": "rgba(211,49,21,1)", 
+                                "id": "c06e9550-1b91-11e7-bec4-a5e9ec5cab8b", 
+                                "opperator": "gte", 
+                                "value": 0.85
+                            }
+                        ], 
+                        "gauge_inner_width": 10, 
+                        "gauge_max": "1", 
+                        "gauge_style": "half", 
+                        "gauge_width": 10, 
+                        "id": "9f51b730-1b91-11e7-bec4-a5e9ec5cab8b", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "formatter": "percent", 
+                                "id": "9f51b731-1b91-11e7-bec4-a5e9ec5cab8b", 
+                                "label": "Memory Usage", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "system.memory.actual.used.pct", 
+                                        "id": "9f51b732-1b91-11e7-bec4-a5e9ec5cab8b", 
+                                        "type": "avg"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "gauge"
+                    }, 
+                    "title": "Memory Usage Gauge [Metricbeat System]", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "d3166e80-1b91-11e7-bec4-a5e9ec5cab8b", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "query": "*"
+                                }
+                            }
+                        }
+                    }
+                }, 
+                "title": "Inbound Traffic [Metricbeat System]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "background_color_rules": [
+                            {
+                                "id": "0e346760-1b92-11e7-bec4-a5e9ec5cab8b"
+                            }
+                        ], 
+                        "filter": "-system.network.name:l*", 
+                        "id": "0c761590-1b92-11e7-bec4-a5e9ec5cab8b", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "formatter": "bytes", 
+                                "id": "0c761591-1b92-11e7-bec4-a5e9ec5cab8b", 
+                                "label": "Inbound Traffic", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "system.network.in.bytes", 
+                                        "id": "0c761592-1b92-11e7-bec4-a5e9ec5cab8b", 
+                                        "type": "max"
+                                    }, 
+                                    {
+                                        "field": "0c761592-1b92-11e7-bec4-a5e9ec5cab8b", 
+                                        "id": "1d659060-1b92-11e7-bec4-a5e9ec5cab8b", 
+                                        "type": "derivative", 
+                                        "unit": "1s"
+                                    }, 
+                                    {
+                                        "field": "1d659060-1b92-11e7-bec4-a5e9ec5cab8b", 
+                                        "id": "f2074f70-1b92-11e7-a416-41f5ccdba2e6", 
+                                        "type": "positive_only", 
+                                        "unit": ""
+                                    }, 
+                                    {
+                                        "function": "sum", 
+                                        "id": "c40e18f0-2c55-11e7-a0ad-277ce466684d", 
+                                        "type": "series_agg"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "terms", 
+                                "stacked": "none", 
+                                "terms_field": "system.network.name", 
+                                "value_template": "{{value}}/s"
+                            }, 
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "formatter": "bytes", 
+                                "id": "37f70440-1b92-11e7-bec4-a5e9ec5cab8b", 
+                                "label": "Total Transferred", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "system.network.in.bytes", 
+                                        "id": "37f72b50-1b92-11e7-bec4-a5e9ec5cab8b", 
+                                        "type": "max"
+                                    }, 
+                                    {
+                                        "field": "37f72b50-1b92-11e7-bec4-a5e9ec5cab8b", 
+                                        "id": "37f72b51-1b92-11e7-bec4-a5e9ec5cab8b", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }, 
+                                    {
+                                        "field": "37f72b51-1b92-11e7-bec4-a5e9ec5cab8b", 
+                                        "id": "f9da2dd0-1b92-11e7-a416-41f5ccdba2e6", 
+                                        "type": "positive_only", 
+                                        "unit": ""
+                                    }, 
+                                    {
+                                        "field": "f9da2dd0-1b92-11e7-a416-41f5ccdba2e6", 
+                                        "function": "overall_sum", 
+                                        "id": "3e63c2f0-1b92-11e7-bec4-a5e9ec5cab8b", 
+                                        "sigma": "", 
+                                        "type": "series_agg"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "terms", 
+                                "stacked": "none", 
+                                "terms_field": "system.network.name", 
+                                "value_template": "{{value}}"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "metric"
+                    }, 
+                    "title": "Inbound Traffic [Metricbeat System]", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "522ee670-1b92-11e7-bec4-a5e9ec5cab8b", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "query": "*"
+                                }
+                            }
+                        }
+                    }
+                }, 
+                "title": "Outbound Traffic [Metricbeat System]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "background_color_rules": [
+                            {
+                                "id": "0e346760-1b92-11e7-bec4-a5e9ec5cab8b"
+                            }
+                        ], 
+                        "filter": "-system.network.name:l*", 
+                        "id": "0c761590-1b92-11e7-bec4-a5e9ec5cab8b", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "formatter": "bytes", 
+                                "id": "0c761591-1b92-11e7-bec4-a5e9ec5cab8b", 
+                                "label": "Outbound Traffic", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "system.network.out.bytes", 
+                                        "id": "0c761592-1b92-11e7-bec4-a5e9ec5cab8b", 
+                                        "type": "max"
+                                    }, 
+                                    {
+                                        "field": "0c761592-1b92-11e7-bec4-a5e9ec5cab8b", 
+                                        "id": "1d659060-1b92-11e7-bec4-a5e9ec5cab8b", 
+                                        "type": "derivative", 
+                                        "unit": "1s"
+                                    }, 
+                                    {
+                                        "field": "1d659060-1b92-11e7-bec4-a5e9ec5cab8b", 
+                                        "id": "f2074f70-1b92-11e7-a416-41f5ccdba2e6", 
+                                        "type": "positive_only", 
+                                        "unit": ""
+                                    }, 
+                                    {
+                                        "function": "sum", 
+                                        "id": "a1737470-2c55-11e7-a0ad-277ce466684d", 
+                                        "type": "series_agg"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "terms", 
+                                "stacked": "none", 
+                                "terms_field": "system.network.name", 
+                                "value_template": "{{value}}/s"
+                            }, 
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "formatter": "bytes", 
+                                "id": "37f70440-1b92-11e7-bec4-a5e9ec5cab8b", 
+                                "label": "Total Transferred", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "system.network.out.bytes", 
+                                        "id": "37f72b50-1b92-11e7-bec4-a5e9ec5cab8b", 
+                                        "type": "max"
+                                    }, 
+                                    {
+                                        "field": "37f72b50-1b92-11e7-bec4-a5e9ec5cab8b", 
+                                        "id": "37f72b51-1b92-11e7-bec4-a5e9ec5cab8b", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }, 
+                                    {
+                                        "field": "37f72b51-1b92-11e7-bec4-a5e9ec5cab8b", 
+                                        "id": "f9da2dd0-1b92-11e7-a416-41f5ccdba2e6", 
+                                        "type": "positive_only", 
+                                        "unit": ""
+                                    }, 
+                                    {
+                                        "field": "f9da2dd0-1b92-11e7-a416-41f5ccdba2e6", 
+                                        "function": "overall_sum", 
+                                        "id": "3e63c2f0-1b92-11e7-bec4-a5e9ec5cab8b", 
+                                        "sigma": "", 
+                                        "type": "series_agg"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "terms", 
+                                "stacked": "none", 
+                                "terms_field": "system.network.name", 
+                                "value_template": "{{value}}"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "metric"
+                    }, 
+                    "title": "Outbound Traffic [Metricbeat System]", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "1aae9140-1b93-11e7-8ada-3df93aab833e", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "query": "*"
+                                }
+                            }
+                        }
+                    }
+                }, 
+                "title": "Disk Usage [Metricbeat System]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "bar_color_rules": [
+                            {
+                                "bar_color": "rgba(104,188,0,1)", 
+                                "id": "bf525310-1b95-11e7-8ada-3df93aab833e", 
+                                "opperator": "gte", 
+                                "value": 0
+                            }, 
+                            {
+                                "bar_color": "rgba(254,146,0,1)", 
+                                "id": "125fc4c0-1b96-11e7-8ada-3df93aab833e", 
+                                "opperator": "gte", 
+                                "value": 0.7
+                            }, 
+                            {
+                                "bar_color": "rgba(211,49,21,1)", 
+                                "id": "1a5c7240-1b96-11e7-8ada-3df93aab833e", 
+                                "opperator": "gte", 
+                                "value": 0.85
+                            }
+                        ], 
+                        "drilldown_url": "", 
+                        "filter": "-system.filesystem.mount_point:\\/run* AND -system.filesystem.mount_point:\\/sys* AND -system.filesystem.mount_point:\\/dev* AND -system.filesystem.mount_point:\\/proc* AND -system.filesystem.mount_point:\\/var* AND -system.filesystem.mount_point:\\/boot", 
+                        "id": "9f7e48a0-1b95-11e7-8ada-3df93aab833e", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "formatter": "percent", 
+                                "id": "9f7e48a1-1b95-11e7-8ada-3df93aab833e", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "system.filesystem.used.pct", 
+                                        "id": "9f7e48a2-1b95-11e7-8ada-3df93aab833e", 
+                                        "type": "avg"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "terms", 
+                                "stacked": "none", 
+                                "terms_field": "system.filesystem.mount_point"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "top_n"
+                    }, 
+                    "title": "Disk Usage [Metricbeat System]", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "34f97ee0-1b96-11e7-8ada-3df93aab833e", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "analyze_wildcard": true, 
+                                    "query": "*"
+                                }
+                            }
+                        }
+                    }
+                }, 
+                "title": "System Navigation [Metricbeat System]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "fontSize": 12, 
+                        "markdown": "[System Overview](#/dashboard/Metricbeat-system-overview)  | [Host Overview](#/dashboard/79ffd6e0-faa0-11e6-947f-177f697178b8) |\n[Containers overview](#/dashboard/CPU-slash-Memory-per-container)"
+                    }, 
+                    "title": "System Navigation [Metricbeat System]", 
+                    "type": "markdown"
+                }
+            }, 
+            "id": "System-Navigation", 
+            "type": "visualization", 
+            "version": 3
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "query": "*"
+                                }
+                            }
+                        }
+                    }
+                }, 
+                "title": "Swap usage [Metricbeat System]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "filter": "", 
+                        "gauge_color_rules": [
+                            {
+                                "gauge": "rgba(104,188,0,1)", 
+                                "id": "d17c1e90-4d59-11e7-aee5-fdc812cc3bec", 
+                                "opperator": "gte", 
+                                "value": 0
+                            }, 
+                            {
+                                "gauge": "rgba(251,158,0,1)", 
+                                "id": "fc1d3490-4d59-11e7-aee5-fdc812cc3bec", 
+                                "opperator": "gte", 
+                                "value": 0.7
+                            }, 
+                            {
+                                "gauge": "rgba(211,49,21,1)", 
+                                "id": "0e204240-4d5a-11e7-aee5-fdc812cc3bec", 
+                                "opperator": "gte", 
+                                "value": 0.85
+                            }
+                        ], 
+                        "gauge_inner_width": 10, 
+                        "gauge_max": "", 
+                        "gauge_style": "half", 
+                        "gauge_width": 10, 
+                        "id": "cee2fd20-4d59-11e7-aee5-fdc812cc3bec", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "formatter": "percent", 
+                                "id": "cee2fd21-4d59-11e7-aee5-fdc812cc3bec", 
+                                "label": "Swap usage", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "system.memory.swap.used.pct", 
+                                        "id": "cee2fd22-4d59-11e7-aee5-fdc812cc3bec", 
+                                        "type": "avg"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "gauge"
+                    }, 
+                    "title": "Swap usage [Metricbeat System]", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "19e123b0-4d5a-11e7-aee5-fdc812cc3bec", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "query_string": {
+                                "query": "*"
+                            }
+                        }
+                    }
+                }, 
+                "title": "Memory usage vs total", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "listeners": {}, 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "background_color_rules": [
+                            {
+                                "id": "6f7618b0-4d5c-11e7-aa29-87a97a796de6"
+                            }
+                        ], 
+                        "id": "6bc65720-4d5c-11e7-aa29-87a97a796de6", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "formatter": "bytes", 
+                                "id": "6bc65721-4d5c-11e7-aa29-87a97a796de6", 
+                                "label": "Memory usage", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "system.memory.actual.used.bytes", 
+                                        "id": "6bc65722-4d5c-11e7-aa29-87a97a796de6", 
+                                        "type": "avg"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }, 
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "formatter": "bytes", 
+                                "id": "b8fe6820-4d5c-11e7-aa29-87a97a796de6", 
+                                "label": "Total Memory", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "system.memory.total", 
+                                        "id": "b8fe6821-4d5c-11e7-aa29-87a97a796de6", 
+                                        "type": "avg"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }
+                        ], 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "metric"
+                    }, 
+                    "title": "Memory usage vs total", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "d2e80340-4d5c-11e7-aa29-87a97a796de6", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "query": "*"
+                                }
+                            }
+                        }
+                    }
+                }, 
+                "title": "Disk used [Metricbeat System]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "filter": "", 
+                        "gauge_color_rules": [
+                            {
+                                "gauge": "rgba(104,188,0,1)", 
+                                "id": "51921d10-4d1d-11e7-b5f2-2b7c1895bf32", 
+                                "opperator": "gte", 
+                                "value": 0
+                            }, 
+                            {
+                                "gauge": "rgba(251,158,0,1)", 
+                                "id": "f26de750-4d54-11e7-b5f2-2b7c1895bf32", 
+                                "opperator": "gte", 
+                                "value": 0.7
+                            }, 
+                            {
+                                "gauge": "rgba(211,49,21,1)", 
+                                "id": "fa31d190-4d54-11e7-b5f2-2b7c1895bf32", 
+                                "opperator": "gte", 
+                                "value": 0.85
+                            }
+                        ], 
+                        "gauge_inner_width": 10, 
+                        "gauge_max": "1", 
+                        "gauge_style": "half", 
+                        "gauge_width": 10, 
+                        "id": "4e4dc780-4d1d-11e7-b5f2-2b7c1895bf32", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "formatter": "percent", 
+                                "id": "4e4dee90-4d1d-11e7-b5f2-2b7c1895bf32", 
+                                "label": "Disk used", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "system.fsstat.total_size.used", 
+                                        "id": "4e4dee91-4d1d-11e7-b5f2-2b7c1895bf32", 
+                                        "type": "avg"
+                                    }, 
+                                    {
+                                        "field": "system.fsstat.total_size.total", 
+                                        "id": "57c96ee0-4d54-11e7-b5f2-2b7c1895bf32", 
+                                        "type": "avg"
+                                    }, 
+                                    {
+                                        "id": "6304cca0-4d54-11e7-b5f2-2b7c1895bf32", 
+                                        "script": "params.total != null && params.total > 0 ? params.used/params.total : null", 
+                                        "type": "calculation", 
+                                        "variables": [
+                                            {
+                                                "field": "4e4dee91-4d1d-11e7-b5f2-2b7c1895bf32", 
+                                                "id": "6da10430-4d54-11e7-b5f2-2b7c1895bf32", 
+                                                "name": "used"
+                                            }, 
+                                            {
+                                                "field": "57c96ee0-4d54-11e7-b5f2-2b7c1895bf32", 
+                                                "id": "73b8c510-4d54-11e7-b5f2-2b7c1895bf32", 
+                                                "name": "total"
+                                            }
+                                        ]
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "gauge"
+                    }, 
+                    "title": "Disk used [Metricbeat System]", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "825fdb80-4d1d-11e7-b5f2-2b7c1895bf32", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "query": "*"
+                                }
+                            }
+                        }
+                    }
+                }, 
+                "title": "Packetloss [Metricbeat System]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "background_color_rules": [
+                            {
+                                "id": "6ba9b1f0-4d5d-11e7-aa29-87a97a796de6"
+                            }
+                        ], 
+                        "id": "6984af10-4d5d-11e7-aa29-87a97a796de6", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "formatter": "number", 
+                                "id": "6984af11-4d5d-11e7-aa29-87a97a796de6", 
+                                "label": "In Packetloss", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "system.network.in.dropped", 
+                                        "id": "6984af12-4d5d-11e7-aa29-87a97a796de6", 
+                                        "type": "max"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }, 
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "formatter": "number", 
+                                "id": "ac2e6b30-4d5d-11e7-aa29-87a97a796de6", 
+                                "label": "Out Packetloss", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "system.network.out.dropped", 
+                                        "id": "ac2e6b31-4d5d-11e7-aa29-87a97a796de6", 
+                                        "type": "max"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "metric"
+                    }, 
+                    "title": "Packetloss [Metricbeat System]", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "96976150-4d5d-11e7-aa29-87a97a796de6", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "query": "*"
+                                }
+                            }
+                        }
+                    }
+                }, 
+                "title": "Interfaces by Incoming traffic [Metricbeat System]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "bar_color_rules": [
+                            {
+                                "id": "44596d40-4d60-11e7-9a4c-ed99bbcaa42b"
+                            }
+                        ], 
+                        "id": "42ceae90-4d60-11e7-9a4c-ed99bbcaa42b", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "formatter": "bytes", 
+                                "id": "42ced5a0-4d60-11e7-9a4c-ed99bbcaa42b", 
+                                "label": "Interfaces by Incoming traffic", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "system.network.in.bytes", 
+                                        "id": "42ced5a1-4d60-11e7-9a4c-ed99bbcaa42b", 
+                                        "type": "avg"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "terms", 
+                                "stacked": "none", 
+                                "terms_field": "system.network.name", 
+                                "terms_order_by": "42ced5a1-4d60-11e7-9a4c-ed99bbcaa42b"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "top_n"
+                    }, 
+                    "title": "Interfaces by Incoming traffic [Metricbeat System]", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "99381c80-4d60-11e7-9a4c-ed99bbcaa42b", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "query": "*"
+                                }
+                            }
+                        }
+                    }
+                }, 
+                "title": "Interfaces by Outgoing traffic [Metricbeat System]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "bar_color_rules": [
+                            {
+                                "id": "9db20be0-4d60-11e7-9a4c-ed99bbcaa42b"
+                            }
+                        ], 
+                        "id": "9cdba910-4d60-11e7-9a4c-ed99bbcaa42b", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "formatter": "bytes", 
+                                "id": "9cdba911-4d60-11e7-9a4c-ed99bbcaa42b", 
+                                "label": "Interfaces by Outgoing traffic", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "system.network.out.bytes", 
+                                        "id": "9cdba912-4d60-11e7-9a4c-ed99bbcaa42b", 
+                                        "type": "avg"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "terms", 
+                                "stacked": "none", 
+                                "terms_field": "system.network.name", 
+                                "terms_order_by": "9cdba912-4d60-11e7-9a4c-ed99bbcaa42b"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "top_n"
+                    }, 
+                    "title": "Interfaces by Outgoing traffic [Metricbeat System]", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "c5e3cf90-4d60-11e7-9a4c-ed99bbcaa42b", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "index": "metricbeat-*", 
+                        "query": {
+                            "query_string": {
+                                "analyze_wildcard": true, 
+                                "query": "*"
+                            }
+                        }
+                    }
+                }, 
+                "title": "Number of processes [Metricbeat System]", 
+                "uiStateJSON": {
+                    "vis": {
+                        "defaultColors": {
+                            "0 - 100": "rgb(0,104,55)"
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Processes", 
+                                "field": "system.process.pid"
+                            }, 
+                            "schema": "metric", 
+                            "type": "cardinality"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": false, 
+                        "addTooltip": true, 
+                        "gauge": {
+                            "autoExtend": false, 
+                            "backStyle": "Full", 
+                            "colorSchema": "Green to Red", 
+                            "colorsRange": [
+                                {
+                                    "from": 0, 
+                                    "to": 100
+                                }
+                            ], 
+                            "gaugeColorMode": "None", 
+                            "gaugeStyle": "Full", 
+                            "gaugeType": "Metric", 
+                            "invertColors": false, 
+                            "labels": {
+                                "color": "black", 
+                                "show": true
+                            }, 
+                            "orientation": "vertical", 
+                            "percentageMode": false, 
+                            "scale": {
+                                "color": "#333", 
+                                "labels": false, 
+                                "show": false, 
+                                "width": 2
+                            }, 
+                            "style": {
+                                "bgColor": false, 
+                                "bgFill": "#000", 
+                                "fontSize": 60, 
+                                "labelColor": false, 
+                                "subText": ""
+                            }, 
+                            "type": "simple", 
+                            "useRange": false, 
+                            "verticalSplit": false
+                        }, 
+                        "type": "gauge"
+                    }, 
+                    "title": "Number of processes", 
+                    "type": "metric"
+                }
+            }, 
+            "id": "590a60f0-5d87-11e7-8884-1bb4c3b890e4", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Tip [Metricbeat System]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "fontSize": 12, 
+                        "markdown": "**TIP:** To select another host, go to the [System Overview](#/dashboard/Metricbeat-system-overview) dashboard and double-click a host name."
+                    }, 
+                    "title": "Tip [Metricbeat System]", 
+                    "type": "markdown"
+                }
+            }, 
+            "id": "3d65d450-a9c3-11e7-af20-67db8aecb295", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "query": {
+                            "language": "lucene", 
+                            "query": "beat.name:\"CHANGEME_HOSTNAME\""
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false
+                }, 
+                "panelsJSON": [
+                    {
+                        "col": 1, 
+                        "id": "6b7b9a40-faa1-11e6-86b1-cd7735ff7e23", 
+                        "panelIndex": 1, 
+                        "row": 12, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 7, 
+                        "id": "4d546850-1b15-11e7-b09e-037021c4f8df", 
+                        "panelIndex": 2, 
+                        "row": 6, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 7, 
+                        "id": "089b85d0-1b16-11e7-b09e-037021c4f8df", 
+                        "panelIndex": 3, 
+                        "row": 12, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "bfa5e400-1b16-11e7-b09e-037021c4f8df", 
+                        "panelIndex": 4, 
+                        "row": 9, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 7, 
+                        "id": "e0f001c0-1b18-11e7-b09e-037021c4f8df", 
+                        "panelIndex": 5, 
+                        "row": 15, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "2e224660-1b19-11e7-b09e-037021c4f8df", 
+                        "panelIndex": 6, 
+                        "row": 15, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "ab2d1e90-1b1a-11e7-b09e-037021c4f8df", 
+                        "panelIndex": 7, 
+                        "row": 6, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 7, 
+                        "id": "4e4bb1e0-1b1b-11e7-b09e-037021c4f8df", 
+                        "panelIndex": 8, 
+                        "row": 9, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 5, 
+                        "id": "26732e20-1b91-11e7-bec4-a5e9ec5cab8b", 
+                        "panelIndex": 9, 
+                        "row": 2, 
+                        "size_x": 2, 
+                        "size_y": 2, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "83e12df0-1b91-11e7-bec4-a5e9ec5cab8b", 
+                        "panelIndex": 10, 
+                        "row": 2, 
+                        "size_x": 2, 
+                        "size_y": 2, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 3, 
+                        "id": "d3166e80-1b91-11e7-bec4-a5e9ec5cab8b", 
+                        "panelIndex": 11, 
+                        "row": 2, 
+                        "size_x": 2, 
+                        "size_y": 2, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 7, 
+                        "id": "522ee670-1b92-11e7-bec4-a5e9ec5cab8b", 
+                        "panelIndex": 12, 
+                        "row": 2, 
+                        "size_x": 2, 
+                        "size_y": 2, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 9, 
+                        "id": "1aae9140-1b93-11e7-8ada-3df93aab833e", 
+                        "panelIndex": 13, 
+                        "row": 2, 
+                        "size_x": 2, 
+                        "size_y": 2, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 9, 
+                        "id": "34f97ee0-1b96-11e7-8ada-3df93aab833e", 
+                        "panelIndex": 14, 
+                        "row": 4, 
+                        "size_x": 4, 
+                        "size_y": 2, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "System-Navigation", 
+                        "panelIndex": 16, 
+                        "row": 1, 
+                        "size_x": 6, 
+                        "size_y": 1, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "19e123b0-4d5a-11e7-aee5-fdc812cc3bec", 
+                        "panelIndex": 21, 
+                        "row": 4, 
+                        "size_x": 2, 
+                        "size_y": 2, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 3, 
+                        "id": "d2e80340-4d5c-11e7-aa29-87a97a796de6", 
+                        "panelIndex": 22, 
+                        "row": 4, 
+                        "size_x": 2, 
+                        "size_y": 2, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 7, 
+                        "id": "825fdb80-4d1d-11e7-b5f2-2b7c1895bf32", 
+                        "panelIndex": 23, 
+                        "row": 4, 
+                        "size_x": 2, 
+                        "size_y": 2, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 11, 
+                        "id": "96976150-4d5d-11e7-aa29-87a97a796de6", 
+                        "panelIndex": 25, 
+                        "row": 2, 
+                        "size_x": 2, 
+                        "size_y": 2, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "99381c80-4d60-11e7-9a4c-ed99bbcaa42b", 
+                        "panelIndex": 27, 
+                        "row": 18, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 7, 
+                        "id": "c5e3cf90-4d60-11e7-9a4c-ed99bbcaa42b", 
+                        "panelIndex": 28, 
+                        "row": 18, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 5, 
+                        "id": "590a60f0-5d87-11e7-8884-1bb4c3b890e4", 
+                        "panelIndex": 29, 
+                        "row": 4, 
+                        "size_x": 2, 
+                        "size_y": 2, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 7, 
+                        "id": "3d65d450-a9c3-11e7-af20-67db8aecb295", 
+                        "panelIndex": 30, 
+                        "row": 1, 
+                        "size_x": 6, 
+                        "size_y": 1, 
+                        "type": "visualization"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "[Metricbeat System] Host overview", 
+                "uiStateJSON": {
+                    "P-29": {
+                        "vis": {
+                            "defaultColors": {
+                                "0 - 100": "rgb(0,104,55)"
+                            }
+                        }
+                    }
+                }, 
+                "version": 1
+            }, 
+            "id": "79ffd6e0-faa0-11e6-947f-177f697178b8", 
+            "type": "dashboard", 
+            "version": 12
+        }
+    ], 
+    "version": "6.0.0-rc1-SNAPSHOT"
 }

--- a/metricbeat/module/system/_meta/kibana/6/dashboard/Metricbeat-system-overview.json
+++ b/metricbeat/module/system/_meta/kibana/6/dashboard/Metricbeat-system-overview.json
@@ -1,173 +1,1158 @@
 {
-  "objects": [
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}},\"language\":\"lucene\"},\"filter\":[]}"
-        },
-        "title": "System Navigation [Metricbeat System]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"System Navigation [Metricbeat System]\",\"type\":\"markdown\",\"params\":{\"markdown\":\"[System Overview](#/dashboard/Metricbeat-system-overview)  | [Host Overview](#/dashboard/79ffd6e0-faa0-11e6-947f-177f697178b8) |\\n[Containers overview](#/dashboard/CPU-slash-Memory-per-container)\",\"fontSize\":12},\"aggs\":[]}"
-      },
-      "id": "System-Navigation",
-      "type": "visualization",
-      "version": 3
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"index\":\"metricbeat-*\",\"query\":{\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}},\"language\":\"lucene\"},\"filter\":[]}"
-        },
-        "title": "Number of hosts [Metricbeat System]",
-        "uiStateJSON": "{\"vis\":{\"defaultColors\":{\"0 - 100\":\"rgb(0,104,55)\"}}}",
-        "version": 1,
-        "visState": "{\"title\":\"Number of hosts [Metricbeat System]\",\"type\":\"metric\",\"params\":{\"addTooltip\":true,\"addLegend\":false,\"type\":\"gauge\",\"gauge\":{\"verticalSplit\":false,\"autoExtend\":false,\"percentageMode\":false,\"gaugeType\":\"Metric\",\"gaugeStyle\":\"Full\",\"backStyle\":\"Full\",\"orientation\":\"vertical\",\"colorSchema\":\"Green to Red\",\"gaugeColorMode\":\"None\",\"useRange\":false,\"colorsRange\":[{\"from\":0,\"to\":100}],\"invertColors\":false,\"labels\":{\"show\":false,\"color\":\"black\"},\"scale\":{\"show\":false,\"labels\":false,\"color\":\"#333\",\"width\":2},\"type\":\"simple\",\"style\":{\"fontSize\":\"63\",\"bgFill\":\"#000\",\"bgColor\":false,\"labelColor\":false,\"subText\":\"\"}}},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"cardinality\",\"schema\":\"metric\",\"params\":{\"field\":\"beat.name\",\"customLabel\":\"Number of hosts\"}}]}"
-      },
-      "id": "c6f2ffd0-4d17-11e7-a196-69b9a7a020a9",
-      "type": "visualization",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query\":{\"query_string\":{\"query\":\"*\"}},\"language\":\"lucene\"},\"filter\":[]}"
-        },
-        "title": "Top Hosts By Memory (Realtime) [Metricbeat System]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Top Hosts By Memory (Realtime) [Metricbeat System]\",\"type\":\"metrics\",\"params\":{\"id\":\"31e5afa0-1b1c-11e7-b09e-037021c4f8df\",\"type\":\"top_n\",\"series\":[{\"id\":\"31e5afa1-1b1c-11e7-b09e-037021c4f8df\",\"color\":\"#68BC00\",\"split_mode\":\"terms\",\"metrics\":[{\"id\":\"31e5afa2-1b1c-11e7-b09e-037021c4f8df\",\"type\":\"avg\",\"field\":\"system.memory.actual.used.pct\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"percent\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"terms_field\":\"beat.name\",\"terms_order_by\":\"31e5afa2-1b1c-11e7-b09e-037021c4f8df\",\"terms_size\":\"10\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"show_legend\":1,\"bar_color_rules\":[{\"value\":0,\"id\":\"33349dd0-1b1c-11e7-b09e-037021c4f8df\",\"bar_color\":\"rgba(104,188,0,1)\",\"opperator\":\"gte\"},{\"value\":0.6,\"id\":\"997dc440-1b1c-11e7-b09e-037021c4f8df\",\"bar_color\":\"rgba(254,146,0,1)\",\"opperator\":\"gte\"},{\"value\":0.85,\"id\":\"a10d7f20-1b1c-11e7-b09e-037021c4f8df\",\"bar_color\":\"rgba(211,49,21,1)\",\"opperator\":\"gte\"}],\"drilldown_url\":\"../app/kibana#/dashboard/79ffd6e0-faa0-11e6-947f-177f697178b8?_a=(query:(query_string:(analyze_wildcard:!t,query:'beat.name:\\\"{{key}}\\\"')))\",\"filter\":\"\",\"show_grid\":1},\"aggs\":[]}"
-      },
-      "id": "fe064790-1b1f-11e7-bec4-a5e9ec5cab8b",
-      "type": "visualization",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query\":{\"query_string\":{\"query\":\"*\"}},\"language\":\"lucene\"},\"filter\":[]}"
-        },
-        "title": "Top Hosts By CPU (Realtime) [Metricbeat System]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Top Hosts By CPU (Realtime) [Metricbeat System]\",\"type\":\"metrics\",\"params\":{\"id\":\"31e5afa0-1b1c-11e7-b09e-037021c4f8df\",\"type\":\"top_n\",\"series\":[{\"id\":\"31e5afa1-1b1c-11e7-b09e-037021c4f8df\",\"color\":\"#68BC00\",\"split_mode\":\"terms\",\"metrics\":[{\"id\":\"31e5afa2-1b1c-11e7-b09e-037021c4f8df\",\"type\":\"avg\",\"field\":\"system.cpu.user.pct\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"percent\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"terms_field\":\"beat.name\",\"terms_order_by\":\"31e5afa2-1b1c-11e7-b09e-037021c4f8df\",\"terms_size\":\"10\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"show_legend\":1,\"bar_color_rules\":[{\"value\":0,\"id\":\"33349dd0-1b1c-11e7-b09e-037021c4f8df\",\"bar_color\":\"rgba(104,188,0,1)\",\"opperator\":\"gte\"},{\"value\":0.6,\"id\":\"997dc440-1b1c-11e7-b09e-037021c4f8df\",\"bar_color\":\"rgba(254,146,0,1)\",\"opperator\":\"gte\"},{\"value\":0.85,\"id\":\"a10d7f20-1b1c-11e7-b09e-037021c4f8df\",\"bar_color\":\"rgba(211,49,21,1)\",\"opperator\":\"gte\"}],\"drilldown_url\":\"../app/kibana#/dashboard/79ffd6e0-faa0-11e6-947f-177f697178b8?_a=(query:(query_string:(analyze_wildcard:!t,query:'beat.name:\\\"{{key}}\\\"')))\",\"filter\":\"\",\"show_grid\":1},\"aggs\":[]}"
-      },
-      "id": "855899e0-1b1c-11e7-b09e-037021c4f8df",
-      "type": "visualization",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"index\":\"metricbeat-*\",\"query\":{\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}},\"language\":\"lucene\"},\"filter\":[]}"
-        },
-        "title": "Hosts histogram by CPU usage [Metricbeat System]",
-        "uiStateJSON": "{\"vis\":{\"defaultColors\":{\"0% - 5%\":\"rgb(247,252,245)\",\"5% - 10%\":\"rgb(199,233,192)\",\"10% - 15%\":\"rgb(116,196,118)\",\"15% - 20%\":\"rgb(35,139,69)\"}}}",
-        "version": 1,
-        "visState": "{\"title\":\"Hosts histogram by CPU usage [Metricbeat System]\",\"type\":\"heatmap\",\"params\":{\"addTooltip\":true,\"addLegend\":true,\"enableHover\":false,\"legendPosition\":\"right\",\"times\":[],\"colorsNumber\":4,\"colorSchema\":\"Greens\",\"setColorRange\":false,\"colorsRange\":[],\"invertColors\":false,\"percentageMode\":false,\"valueAxes\":[{\"show\":false,\"id\":\"ValueAxis-1\",\"type\":\"value\",\"scale\":{\"type\":\"linear\",\"defaultYExtents\":false},\"labels\":{\"show\":false,\"rotate\":0,\"color\":\"#555\"}}],\"type\":\"heatmap\"},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"system.cpu.user.pct\",\"customLabel\":\"CPU usage\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"auto\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}},{\"id\":\"3\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"group\",\"params\":{\"field\":\"beat.name\",\"size\":20,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"Hosts\"}}]}"
-      },
-      "id": "7cdb1330-4d1a-11e7-a196-69b9a7a020a9",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query\":{\"query_string\":{\"query\":\"*\"}},\"language\":\"lucene\"},\"filter\":[]}"
-        },
-        "title": "Inbound Traffic [Metricbeat System]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Inbound Traffic [Metricbeat System]\",\"type\":\"metrics\",\"params\":{\"axis_formatter\":\"number\",\"axis_position\":\"left\",\"background_color_rules\":[{\"id\":\"0e346760-1b92-11e7-bec4-a5e9ec5cab8b\"}],\"filter\":\"-system.network.name:l*\",\"id\":\"0c761590-1b92-11e7-bec4-a5e9ec5cab8b\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"series\":[{\"axis_position\":\"right\",\"chart_type\":\"line\",\"color\":\"#68BC00\",\"fill\":0.5,\"formatter\":\"bytes\",\"id\":\"0c761591-1b92-11e7-bec4-a5e9ec5cab8b\",\"label\":\"Inbound Traffic\",\"line_width\":1,\"metrics\":[{\"field\":\"system.network.in.bytes\",\"id\":\"0c761592-1b92-11e7-bec4-a5e9ec5cab8b\",\"type\":\"max\"},{\"field\":\"0c761592-1b92-11e7-bec4-a5e9ec5cab8b\",\"id\":\"1d659060-1b92-11e7-bec4-a5e9ec5cab8b\",\"type\":\"derivative\",\"unit\":\"1s\"},{\"field\":\"1d659060-1b92-11e7-bec4-a5e9ec5cab8b\",\"id\":\"f2074f70-1b92-11e7-a416-41f5ccdba2e6\",\"type\":\"positive_only\",\"unit\":\"\"},{\"id\":\"c40e18f0-2c55-11e7-a0ad-277ce466684d\",\"type\":\"series_agg\",\"function\":\"sum\"}],\"point_size\":1,\"seperate_axis\":0,\"split_mode\":\"terms\",\"stacked\":\"none\",\"value_template\":\"{{value}}/s\",\"terms_field\":\"system.network.name\"},{\"axis_position\":\"right\",\"chart_type\":\"line\",\"color\":\"#68BC00\",\"fill\":0.5,\"formatter\":\"bytes\",\"id\":\"37f70440-1b92-11e7-bec4-a5e9ec5cab8b\",\"label\":\"Total Transferred\",\"line_width\":1,\"metrics\":[{\"field\":\"system.network.in.bytes\",\"id\":\"37f72b50-1b92-11e7-bec4-a5e9ec5cab8b\",\"type\":\"max\"},{\"field\":\"37f72b50-1b92-11e7-bec4-a5e9ec5cab8b\",\"id\":\"37f72b51-1b92-11e7-bec4-a5e9ec5cab8b\",\"type\":\"derivative\",\"unit\":\"\"},{\"unit\":\"\",\"id\":\"f9da2dd0-1b92-11e7-a416-41f5ccdba2e6\",\"type\":\"positive_only\",\"field\":\"37f72b51-1b92-11e7-bec4-a5e9ec5cab8b\"},{\"sigma\":\"\",\"field\":\"f9da2dd0-1b92-11e7-a416-41f5ccdba2e6\",\"id\":\"3e63c2f0-1b92-11e7-bec4-a5e9ec5cab8b\",\"type\":\"series_agg\",\"function\":\"overall_sum\"}],\"point_size\":1,\"seperate_axis\":0,\"split_mode\":\"terms\",\"stacked\":\"none\",\"value_template\":\"{{value}}\",\"terms_field\":\"system.network.name\"}],\"show_legend\":1,\"time_field\":\"@timestamp\",\"type\":\"metric\",\"show_grid\":1},\"aggs\":[]}"
-      },
-      "id": "522ee670-1b92-11e7-bec4-a5e9ec5cab8b",
-      "type": "visualization",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query\":{\"query_string\":{\"query\":\"*\"}},\"language\":\"lucene\"},\"filter\":[]}"
-        },
-        "title": "Outbound Traffic [Metricbeat System]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Outbound Traffic [Metricbeat System]\",\"type\":\"metrics\",\"params\":{\"axis_formatter\":\"number\",\"axis_position\":\"left\",\"background_color_rules\":[{\"id\":\"0e346760-1b92-11e7-bec4-a5e9ec5cab8b\"}],\"filter\":\"-system.network.name:l*\",\"id\":\"0c761590-1b92-11e7-bec4-a5e9ec5cab8b\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"series\":[{\"axis_position\":\"right\",\"chart_type\":\"line\",\"color\":\"#68BC00\",\"fill\":0.5,\"formatter\":\"bytes\",\"id\":\"0c761591-1b92-11e7-bec4-a5e9ec5cab8b\",\"label\":\"Outbound Traffic\",\"line_width\":1,\"metrics\":[{\"field\":\"system.network.out.bytes\",\"id\":\"0c761592-1b92-11e7-bec4-a5e9ec5cab8b\",\"type\":\"max\"},{\"field\":\"0c761592-1b92-11e7-bec4-a5e9ec5cab8b\",\"id\":\"1d659060-1b92-11e7-bec4-a5e9ec5cab8b\",\"type\":\"derivative\",\"unit\":\"1s\"},{\"field\":\"1d659060-1b92-11e7-bec4-a5e9ec5cab8b\",\"id\":\"f2074f70-1b92-11e7-a416-41f5ccdba2e6\",\"type\":\"positive_only\",\"unit\":\"\"},{\"id\":\"a1737470-2c55-11e7-a0ad-277ce466684d\",\"type\":\"series_agg\",\"function\":\"sum\"}],\"point_size\":1,\"seperate_axis\":0,\"split_mode\":\"terms\",\"stacked\":\"none\",\"value_template\":\"{{value}}/s\",\"terms_field\":\"system.network.name\"},{\"axis_position\":\"right\",\"chart_type\":\"line\",\"color\":\"#68BC00\",\"fill\":0.5,\"formatter\":\"bytes\",\"id\":\"37f70440-1b92-11e7-bec4-a5e9ec5cab8b\",\"label\":\"Total Transferred\",\"line_width\":1,\"metrics\":[{\"field\":\"system.network.out.bytes\",\"id\":\"37f72b50-1b92-11e7-bec4-a5e9ec5cab8b\",\"type\":\"max\"},{\"field\":\"37f72b50-1b92-11e7-bec4-a5e9ec5cab8b\",\"id\":\"37f72b51-1b92-11e7-bec4-a5e9ec5cab8b\",\"type\":\"derivative\",\"unit\":\"\"},{\"unit\":\"\",\"id\":\"f9da2dd0-1b92-11e7-a416-41f5ccdba2e6\",\"type\":\"positive_only\",\"field\":\"37f72b51-1b92-11e7-bec4-a5e9ec5cab8b\"},{\"sigma\":\"\",\"field\":\"f9da2dd0-1b92-11e7-a416-41f5ccdba2e6\",\"id\":\"3e63c2f0-1b92-11e7-bec4-a5e9ec5cab8b\",\"type\":\"series_agg\",\"function\":\"overall_sum\"}],\"point_size\":1,\"seperate_axis\":0,\"split_mode\":\"terms\",\"stacked\":\"none\",\"value_template\":\"{{value}}\",\"terms_field\":\"system.network.name\"}],\"show_legend\":1,\"time_field\":\"@timestamp\",\"type\":\"metric\",\"show_grid\":1},\"aggs\":[]}"
-      },
-      "id": "1aae9140-1b93-11e7-8ada-3df93aab833e",
-      "type": "visualization",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query\":{\"query_string\":{\"query\":\"*\"}},\"language\":\"lucene\"},\"filter\":[]}"
-        },
-        "title": "Disk used [Metricbeat System]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Disk used [Metricbeat System]\",\"type\":\"metrics\",\"params\":{\"id\":\"4e4dc780-4d1d-11e7-b5f2-2b7c1895bf32\",\"type\":\"gauge\",\"series\":[{\"id\":\"4e4dee90-4d1d-11e7-b5f2-2b7c1895bf32\",\"color\":\"#68BC00\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"4e4dee91-4d1d-11e7-b5f2-2b7c1895bf32\",\"type\":\"avg\",\"field\":\"system.fsstat.total_size.used\"},{\"id\":\"57c96ee0-4d54-11e7-b5f2-2b7c1895bf32\",\"type\":\"avg\",\"field\":\"system.fsstat.total_size.total\"},{\"script\":\"params.total != null \u0026\u0026 params.total \u003e 0 ? params.used/params.total : null\",\"id\":\"6304cca0-4d54-11e7-b5f2-2b7c1895bf32\",\"type\":\"calculation\",\"variables\":[{\"id\":\"6da10430-4d54-11e7-b5f2-2b7c1895bf32\",\"field\":\"4e4dee91-4d1d-11e7-b5f2-2b7c1895bf32\",\"name\":\"used\"},{\"id\":\"73b8c510-4d54-11e7-b5f2-2b7c1895bf32\",\"name\":\"total\",\"field\":\"57c96ee0-4d54-11e7-b5f2-2b7c1895bf32\"}]}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"percent\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"label\":\"Disk used\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"show_legend\":1,\"gauge_color_rules\":[{\"value\":0,\"id\":\"51921d10-4d1d-11e7-b5f2-2b7c1895bf32\",\"gauge\":\"rgba(104,188,0,1)\",\"opperator\":\"gte\"},{\"value\":0.7,\"id\":\"f26de750-4d54-11e7-b5f2-2b7c1895bf32\",\"gauge\":\"rgba(251,158,0,1)\",\"opperator\":\"gte\"},{\"value\":0.85,\"id\":\"fa31d190-4d54-11e7-b5f2-2b7c1895bf32\",\"gauge\":\"rgba(211,49,21,1)\",\"opperator\":\"gte\"}],\"gauge_width\":10,\"gauge_inner_width\":10,\"gauge_style\":\"half\",\"gauge_max\":\"1\",\"filter\":\"\",\"show_grid\":1},\"aggs\":[]}"
-      },
-      "id": "825fdb80-4d1d-11e7-b5f2-2b7c1895bf32",
-      "type": "visualization",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query\":{\"query_string\":{\"query\":\"*\"}},\"language\":\"lucene\"},\"filter\":[]}"
-        },
-        "title": "Memory Usage Gauge [Metricbeat System]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Memory Usage Gauge [Metricbeat System]\",\"type\":\"metrics\",\"params\":{\"id\":\"9f51b730-1b91-11e7-bec4-a5e9ec5cab8b\",\"type\":\"gauge\",\"series\":[{\"id\":\"9f51b731-1b91-11e7-bec4-a5e9ec5cab8b\",\"color\":\"#68BC00\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"9f51b732-1b91-11e7-bec4-a5e9ec5cab8b\",\"type\":\"avg\",\"field\":\"system.memory.actual.used.pct\"}],\"seperate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"percent\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"label\":\"Memory Usage\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"show_legend\":1,\"gauge_color_rules\":[{\"value\":0,\"id\":\"a0d522e0-1b91-11e7-bec4-a5e9ec5cab8b\",\"gauge\":\"rgba(104,188,0,1)\",\"opperator\":\"gte\"},{\"value\":0.7,\"id\":\"b45ad8f0-1b91-11e7-bec4-a5e9ec5cab8b\",\"gauge\":\"rgba(254,146,0,1)\",\"opperator\":\"gte\"},{\"value\":0.85,\"id\":\"c06e9550-1b91-11e7-bec4-a5e9ec5cab8b\",\"gauge\":\"rgba(211,49,21,1)\",\"opperator\":\"gte\"}],\"gauge_width\":10,\"gauge_inner_width\":10,\"gauge_style\":\"half\",\"gauge_max\":\"1\",\"filter\":\"\",\"show_grid\":1},\"aggs\":[]}"
-      },
-      "id": "d3166e80-1b91-11e7-bec4-a5e9ec5cab8b",
-      "type": "visualization",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query\":{\"query_string\":{\"query\":\"*\"}},\"language\":\"lucene\"},\"filter\":[]}"
-        },
-        "title": "CPU Usage Gauge [Metricbeat System]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"CPU Usage Gauge [Metricbeat System]\",\"type\":\"metrics\",\"params\":{\"axis_formatter\":\"number\",\"axis_position\":\"left\",\"filter\":\"\",\"gauge_color_rules\":[{\"gauge\":\"rgba(104,188,0,1)\",\"id\":\"4ef2c3b0-1b91-11e7-bec4-a5e9ec5cab8b\",\"opperator\":\"gte\",\"value\":0},{\"gauge\":\"rgba(254,146,0,1)\",\"id\":\"e6561ae0-1b91-11e7-bec4-a5e9ec5cab8b\",\"opperator\":\"gte\",\"value\":0.7},{\"gauge\":\"rgba(211,49,21,1)\",\"id\":\"ec655040-1b91-11e7-bec4-a5e9ec5cab8b\",\"opperator\":\"gte\",\"value\":0.85}],\"gauge_inner_width\":10,\"gauge_max\":\"1\",\"gauge_style\":\"half\",\"gauge_width\":10,\"id\":\"4c9e2550-1b91-11e7-bec4-a5e9ec5cab8b\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"series\":[{\"axis_position\":\"right\",\"chart_type\":\"line\",\"color\":\"#68BC00\",\"fill\":0.5,\"formatter\":\"percent\",\"id\":\"4c9e2551-1b91-11e7-bec4-a5e9ec5cab8b\",\"label\":\"CPU Usage\",\"line_width\":1,\"metrics\":[{\"field\":\"system.cpu.user.pct\",\"id\":\"4c9e2552-1b91-11e7-bec4-a5e9ec5cab8b\",\"type\":\"avg\"},{\"field\":\"system.cpu.system.pct\",\"id\":\"225c2140-5fd7-11e7-a63a-a937b7c1a7e1\",\"type\":\"avg\"},{\"field\":\"system.cpu.cores\",\"id\":\"837a30c0-5fd7-11e7-a63a-a937b7c1a7e1\",\"type\":\"avg\"},{\"script\":\"params.n \u003e 0 ? (params.user+params.system)/params.n : null\",\"id\":\"587aa510-1b91-11e7-bec4-a5e9ec5cab8b\",\"type\":\"calculation\",\"variables\":[{\"field\":\"4c9e2552-1b91-11e7-bec4-a5e9ec5cab8b\",\"id\":\"5a19af10-1b91-11e7-bec4-a5e9ec5cab8b\",\"name\":\"user\"},{\"field\":\"225c2140-5fd7-11e7-a63a-a937b7c1a7e1\",\"id\":\"32b54f80-5fd7-11e7-a63a-a937b7c1a7e1\",\"name\":\"system\"},{\"field\":\"837a30c0-5fd7-11e7-a63a-a937b7c1a7e1\",\"id\":\"8ba6eef0-5fd7-11e7-a63a-a937b7c1a7e1\",\"name\":\"n\"}]}],\"point_size\":1,\"seperate_axis\":0,\"split_mode\":\"everything\",\"stacked\":\"none\"}],\"show_legend\":1,\"time_field\":\"@timestamp\",\"type\":\"gauge\",\"show_grid\":1},\"aggs\":[]}"
-      },
-      "id": "83e12df0-1b91-11e7-bec4-a5e9ec5cab8b",
-      "type": "visualization",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "hits": 0,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[],\"highlightAll\":true,\"version\":true,\"query\":{\"language\":\"lucene\",\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}}}}"
-        },
-        "optionsJSON": "{\"darkTheme\":false}",
-        "panelsJSON": "[{\"col\":1,\"id\":\"System-Navigation\",\"panelIndex\":9,\"row\":1,\"size_x\":12,\"size_y\":1,\"type\":\"visualization\"},{\"col\":1,\"id\":\"c6f2ffd0-4d17-11e7-a196-69b9a7a020a9\",\"panelIndex\":11,\"row\":2,\"size_x\":2,\"size_y\":2,\"type\":\"visualization\"},{\"col\":7,\"id\":\"fe064790-1b1f-11e7-bec4-a5e9ec5cab8b\",\"panelIndex\":12,\"row\":4,\"size_x\":6,\"size_y\":5,\"type\":\"visualization\"},{\"col\":1,\"id\":\"855899e0-1b1c-11e7-b09e-037021c4f8df\",\"panelIndex\":13,\"row\":4,\"size_x\":6,\"size_y\":5,\"type\":\"visualization\"},{\"col\":1,\"id\":\"7cdb1330-4d1a-11e7-a196-69b9a7a020a9\",\"panelIndex\":14,\"row\":9,\"size_x\":12,\"size_y\":6,\"type\":\"visualization\"},{\"col\":9,\"id\":\"522ee670-1b92-11e7-bec4-a5e9ec5cab8b\",\"panelIndex\":16,\"row\":2,\"size_x\":2,\"size_y\":2,\"type\":\"visualization\"},{\"col\":11,\"id\":\"1aae9140-1b93-11e7-8ada-3df93aab833e\",\"panelIndex\":17,\"row\":2,\"size_x\":2,\"size_y\":2,\"type\":\"visualization\"},{\"col\":7,\"id\":\"825fdb80-4d1d-11e7-b5f2-2b7c1895bf32\",\"panelIndex\":18,\"row\":2,\"size_x\":2,\"size_y\":2,\"type\":\"visualization\"},{\"col\":5,\"id\":\"d3166e80-1b91-11e7-bec4-a5e9ec5cab8b\",\"panelIndex\":19,\"row\":2,\"size_x\":2,\"size_y\":2,\"type\":\"visualization\"},{\"col\":3,\"id\":\"83e12df0-1b91-11e7-bec4-a5e9ec5cab8b\",\"panelIndex\":20,\"row\":2,\"size_x\":2,\"size_y\":2,\"type\":\"visualization\"}]",
-        "timeRestore": false,
-        "title": "[Metricbeat System] Overview",
-        "uiStateJSON": "{\"P-11\":{\"vis\":{\"defaultColors\":{\"0 - 100\":\"rgb(0,104,55)\"}}},\"P-12\":{\"vis\":{\"defaultColors\":{\"0 - 100\":\"rgb(0,104,55)\"}}},\"P-14\":{\"vis\":{\"defaultColors\":{\"0% - 15%\":\"rgb(247,252,245)\",\"15% - 30%\":\"rgb(199,233,192)\",\"30% - 45%\":\"rgb(116,196,118)\",\"45% - 60%\":\"rgb(35,139,69)\"}}},\"P-16\":{\"vis\":{\"defaultColors\":{\"0 - 100\":\"rgb(0,104,55)\"}}},\"P-2\":{\"vis\":{\"defaultColors\":{\"0 - 100\":\"rgb(0,104,55)\"}}},\"P-3\":{\"vis\":{\"defaultColors\":{\"0 - 100\":\"rgb(0,104,55)\"}}}}",
-        "version": 1
-      },
-      "id": "Metricbeat-system-overview",
-      "type": "dashboard",
-      "version": 2
-    }
-  ],
-  "version": "6.0.0-rc1-SNAPSHOT"
+    "objects": [
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "analyze_wildcard": true, 
+                                    "query": "*"
+                                }
+                            }
+                        }
+                    }
+                }, 
+                "title": "System Navigation [Metricbeat System]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "fontSize": 12, 
+                        "markdown": "[System Overview](#/dashboard/Metricbeat-system-overview)  | [Host Overview](#/dashboard/79ffd6e0-faa0-11e6-947f-177f697178b8) |\n[Containers overview](#/dashboard/CPU-slash-Memory-per-container)"
+                    }, 
+                    "title": "System Navigation [Metricbeat System]", 
+                    "type": "markdown"
+                }
+            }, 
+            "id": "System-Navigation", 
+            "type": "visualization", 
+            "version": 3
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "index": "metricbeat-*", 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "analyze_wildcard": true, 
+                                    "query": "*"
+                                }
+                            }
+                        }
+                    }
+                }, 
+                "title": "Number of hosts [Metricbeat System]", 
+                "uiStateJSON": {
+                    "vis": {
+                        "defaultColors": {
+                            "0 - 100": "rgb(0,104,55)"
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Number of hosts", 
+                                "field": "beat.name"
+                            }, 
+                            "schema": "metric", 
+                            "type": "cardinality"
+                        }
+                    ], 
+                    "params": {
+                        "addLegend": false, 
+                        "addTooltip": true, 
+                        "gauge": {
+                            "autoExtend": false, 
+                            "backStyle": "Full", 
+                            "colorSchema": "Green to Red", 
+                            "colorsRange": [
+                                {
+                                    "from": 0, 
+                                    "to": 100
+                                }
+                            ], 
+                            "gaugeColorMode": "None", 
+                            "gaugeStyle": "Full", 
+                            "gaugeType": "Metric", 
+                            "invertColors": false, 
+                            "labels": {
+                                "color": "black", 
+                                "show": false
+                            }, 
+                            "orientation": "vertical", 
+                            "percentageMode": false, 
+                            "scale": {
+                                "color": "#333", 
+                                "labels": false, 
+                                "show": false, 
+                                "width": 2
+                            }, 
+                            "style": {
+                                "bgColor": false, 
+                                "bgFill": "#000", 
+                                "fontSize": "63", 
+                                "labelColor": false, 
+                                "subText": ""
+                            }, 
+                            "type": "simple", 
+                            "useRange": false, 
+                            "verticalSplit": false
+                        }, 
+                        "type": "gauge"
+                    }, 
+                    "title": "Number of hosts [Metricbeat System]", 
+                    "type": "metric"
+                }
+            }, 
+            "id": "c6f2ffd0-4d17-11e7-a196-69b9a7a020a9", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "query": "*"
+                                }
+                            }
+                        }
+                    }
+                }, 
+                "title": "Top Hosts By Memory (Realtime) [Metricbeat System]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "bar_color_rules": [
+                            {
+                                "bar_color": "rgba(104,188,0,1)", 
+                                "id": "33349dd0-1b1c-11e7-b09e-037021c4f8df", 
+                                "opperator": "gte", 
+                                "value": 0
+                            }, 
+                            {
+                                "bar_color": "rgba(254,146,0,1)", 
+                                "id": "997dc440-1b1c-11e7-b09e-037021c4f8df", 
+                                "opperator": "gte", 
+                                "value": 0.6
+                            }, 
+                            {
+                                "bar_color": "rgba(211,49,21,1)", 
+                                "id": "a10d7f20-1b1c-11e7-b09e-037021c4f8df", 
+                                "opperator": "gte", 
+                                "value": 0.85
+                            }
+                        ], 
+                        "drilldown_url": "../app/kibana#/dashboard/79ffd6e0-faa0-11e6-947f-177f697178b8?_a=(query:(query_string:(analyze_wildcard:!t,query:'beat.name:\"{{key}}\"')))", 
+                        "filter": "", 
+                        "id": "31e5afa0-1b1c-11e7-b09e-037021c4f8df", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "formatter": "percent", 
+                                "id": "31e5afa1-1b1c-11e7-b09e-037021c4f8df", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "system.memory.actual.used.pct", 
+                                        "id": "31e5afa2-1b1c-11e7-b09e-037021c4f8df", 
+                                        "type": "avg"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "terms", 
+                                "stacked": "none", 
+                                "terms_field": "beat.name", 
+                                "terms_order_by": "31e5afa2-1b1c-11e7-b09e-037021c4f8df", 
+                                "terms_size": "10"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "top_n"
+                    }, 
+                    "title": "Top Hosts By Memory (Realtime) [Metricbeat System]", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "fe064790-1b1f-11e7-bec4-a5e9ec5cab8b", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "query": "*"
+                                }
+                            }
+                        }
+                    }
+                }, 
+                "title": "Top Hosts By CPU (Realtime) [Metricbeat System]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "bar_color_rules": [
+                            {
+                                "bar_color": "rgba(104,188,0,1)", 
+                                "id": "33349dd0-1b1c-11e7-b09e-037021c4f8df", 
+                                "opperator": "gte", 
+                                "value": 0
+                            }, 
+                            {
+                                "bar_color": "rgba(254,146,0,1)", 
+                                "id": "997dc440-1b1c-11e7-b09e-037021c4f8df", 
+                                "opperator": "gte", 
+                                "value": 0.6
+                            }, 
+                            {
+                                "bar_color": "rgba(211,49,21,1)", 
+                                "id": "a10d7f20-1b1c-11e7-b09e-037021c4f8df", 
+                                "opperator": "gte", 
+                                "value": 0.85
+                            }
+                        ], 
+                        "drilldown_url": "../app/kibana#/dashboard/79ffd6e0-faa0-11e6-947f-177f697178b8?_a=(query:(query_string:(analyze_wildcard:!t,query:'beat.name:\"{{key}}\"')))", 
+                        "filter": "", 
+                        "id": "31e5afa0-1b1c-11e7-b09e-037021c4f8df", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "formatter": "percent", 
+                                "id": "31e5afa1-1b1c-11e7-b09e-037021c4f8df", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "system.cpu.user.pct", 
+                                        "id": "31e5afa2-1b1c-11e7-b09e-037021c4f8df", 
+                                        "type": "avg"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "terms", 
+                                "stacked": "none", 
+                                "terms_field": "beat.name", 
+                                "terms_order_by": "31e5afa2-1b1c-11e7-b09e-037021c4f8df", 
+                                "terms_size": "10"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "top_n"
+                    }, 
+                    "title": "Top Hosts By CPU (Realtime) [Metricbeat System]", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "855899e0-1b1c-11e7-b09e-037021c4f8df", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "index": "metricbeat-*", 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "analyze_wildcard": true, 
+                                    "query": "*"
+                                }
+                            }
+                        }
+                    }
+                }, 
+                "title": "Hosts histogram by CPU usage [Metricbeat System]", 
+                "uiStateJSON": {
+                    "vis": {
+                        "defaultColors": {
+                            "0% - 5%": "rgb(247,252,245)", 
+                            "10% - 15%": "rgb(116,196,118)", 
+                            "15% - 20%": "rgb(35,139,69)", 
+                            "5% - 10%": "rgb(199,233,192)"
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "CPU usage", 
+                                "field": "system.cpu.user.pct"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "customLabel": "Hosts", 
+                                "field": "beat.name", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 20
+                            }, 
+                            "schema": "group", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "params": {
+                        "addLegend": true, 
+                        "addTooltip": true, 
+                        "colorSchema": "Greens", 
+                        "colorsNumber": 4, 
+                        "colorsRange": [], 
+                        "enableHover": false, 
+                        "invertColors": false, 
+                        "legendPosition": "right", 
+                        "percentageMode": false, 
+                        "setColorRange": false, 
+                        "times": [], 
+                        "type": "heatmap", 
+                        "valueAxes": [
+                            {
+                                "id": "ValueAxis-1", 
+                                "labels": {
+                                    "color": "#555", 
+                                    "rotate": 0, 
+                                    "show": false
+                                }, 
+                                "scale": {
+                                    "defaultYExtents": false, 
+                                    "type": "linear"
+                                }, 
+                                "show": false, 
+                                "type": "value"
+                            }
+                        ]
+                    }, 
+                    "title": "Hosts histogram by CPU usage [Metricbeat System]", 
+                    "type": "heatmap"
+                }
+            }, 
+            "id": "7cdb1330-4d1a-11e7-a196-69b9a7a020a9", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "query": "*"
+                                }
+                            }
+                        }
+                    }
+                }, 
+                "title": "Inbound Traffic [Metricbeat System]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "background_color_rules": [
+                            {
+                                "id": "0e346760-1b92-11e7-bec4-a5e9ec5cab8b"
+                            }
+                        ], 
+                        "filter": "-system.network.name:l*", 
+                        "id": "0c761590-1b92-11e7-bec4-a5e9ec5cab8b", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "formatter": "bytes", 
+                                "id": "0c761591-1b92-11e7-bec4-a5e9ec5cab8b", 
+                                "label": "Inbound Traffic", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "system.network.in.bytes", 
+                                        "id": "0c761592-1b92-11e7-bec4-a5e9ec5cab8b", 
+                                        "type": "max"
+                                    }, 
+                                    {
+                                        "field": "0c761592-1b92-11e7-bec4-a5e9ec5cab8b", 
+                                        "id": "1d659060-1b92-11e7-bec4-a5e9ec5cab8b", 
+                                        "type": "derivative", 
+                                        "unit": "1s"
+                                    }, 
+                                    {
+                                        "field": "1d659060-1b92-11e7-bec4-a5e9ec5cab8b", 
+                                        "id": "f2074f70-1b92-11e7-a416-41f5ccdba2e6", 
+                                        "type": "positive_only", 
+                                        "unit": ""
+                                    }, 
+                                    {
+                                        "function": "sum", 
+                                        "id": "c40e18f0-2c55-11e7-a0ad-277ce466684d", 
+                                        "type": "series_agg"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "terms", 
+                                "stacked": "none", 
+                                "terms_field": "system.network.name", 
+                                "value_template": "{{value}}/s"
+                            }, 
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "formatter": "bytes", 
+                                "id": "37f70440-1b92-11e7-bec4-a5e9ec5cab8b", 
+                                "label": "Total Transferred", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "system.network.in.bytes", 
+                                        "id": "37f72b50-1b92-11e7-bec4-a5e9ec5cab8b", 
+                                        "type": "max"
+                                    }, 
+                                    {
+                                        "field": "37f72b50-1b92-11e7-bec4-a5e9ec5cab8b", 
+                                        "id": "37f72b51-1b92-11e7-bec4-a5e9ec5cab8b", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }, 
+                                    {
+                                        "field": "37f72b51-1b92-11e7-bec4-a5e9ec5cab8b", 
+                                        "id": "f9da2dd0-1b92-11e7-a416-41f5ccdba2e6", 
+                                        "type": "positive_only", 
+                                        "unit": ""
+                                    }, 
+                                    {
+                                        "field": "f9da2dd0-1b92-11e7-a416-41f5ccdba2e6", 
+                                        "function": "overall_sum", 
+                                        "id": "3e63c2f0-1b92-11e7-bec4-a5e9ec5cab8b", 
+                                        "sigma": "", 
+                                        "type": "series_agg"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "terms", 
+                                "stacked": "none", 
+                                "terms_field": "system.network.name", 
+                                "value_template": "{{value}}"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "metric"
+                    }, 
+                    "title": "Inbound Traffic [Metricbeat System]", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "522ee670-1b92-11e7-bec4-a5e9ec5cab8b", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "query": "*"
+                                }
+                            }
+                        }
+                    }
+                }, 
+                "title": "Outbound Traffic [Metricbeat System]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "background_color_rules": [
+                            {
+                                "id": "0e346760-1b92-11e7-bec4-a5e9ec5cab8b"
+                            }
+                        ], 
+                        "filter": "-system.network.name:l*", 
+                        "id": "0c761590-1b92-11e7-bec4-a5e9ec5cab8b", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "formatter": "bytes", 
+                                "id": "0c761591-1b92-11e7-bec4-a5e9ec5cab8b", 
+                                "label": "Outbound Traffic", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "system.network.out.bytes", 
+                                        "id": "0c761592-1b92-11e7-bec4-a5e9ec5cab8b", 
+                                        "type": "max"
+                                    }, 
+                                    {
+                                        "field": "0c761592-1b92-11e7-bec4-a5e9ec5cab8b", 
+                                        "id": "1d659060-1b92-11e7-bec4-a5e9ec5cab8b", 
+                                        "type": "derivative", 
+                                        "unit": "1s"
+                                    }, 
+                                    {
+                                        "field": "1d659060-1b92-11e7-bec4-a5e9ec5cab8b", 
+                                        "id": "f2074f70-1b92-11e7-a416-41f5ccdba2e6", 
+                                        "type": "positive_only", 
+                                        "unit": ""
+                                    }, 
+                                    {
+                                        "function": "sum", 
+                                        "id": "a1737470-2c55-11e7-a0ad-277ce466684d", 
+                                        "type": "series_agg"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "terms", 
+                                "stacked": "none", 
+                                "terms_field": "system.network.name", 
+                                "value_template": "{{value}}/s"
+                            }, 
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "formatter": "bytes", 
+                                "id": "37f70440-1b92-11e7-bec4-a5e9ec5cab8b", 
+                                "label": "Total Transferred", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "system.network.out.bytes", 
+                                        "id": "37f72b50-1b92-11e7-bec4-a5e9ec5cab8b", 
+                                        "type": "max"
+                                    }, 
+                                    {
+                                        "field": "37f72b50-1b92-11e7-bec4-a5e9ec5cab8b", 
+                                        "id": "37f72b51-1b92-11e7-bec4-a5e9ec5cab8b", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }, 
+                                    {
+                                        "field": "37f72b51-1b92-11e7-bec4-a5e9ec5cab8b", 
+                                        "id": "f9da2dd0-1b92-11e7-a416-41f5ccdba2e6", 
+                                        "type": "positive_only", 
+                                        "unit": ""
+                                    }, 
+                                    {
+                                        "field": "f9da2dd0-1b92-11e7-a416-41f5ccdba2e6", 
+                                        "function": "overall_sum", 
+                                        "id": "3e63c2f0-1b92-11e7-bec4-a5e9ec5cab8b", 
+                                        "sigma": "", 
+                                        "type": "series_agg"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "terms", 
+                                "stacked": "none", 
+                                "terms_field": "system.network.name", 
+                                "value_template": "{{value}}"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "metric"
+                    }, 
+                    "title": "Outbound Traffic [Metricbeat System]", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "1aae9140-1b93-11e7-8ada-3df93aab833e", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "query": "*"
+                                }
+                            }
+                        }
+                    }
+                }, 
+                "title": "Disk used [Metricbeat System]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "filter": "", 
+                        "gauge_color_rules": [
+                            {
+                                "gauge": "rgba(104,188,0,1)", 
+                                "id": "51921d10-4d1d-11e7-b5f2-2b7c1895bf32", 
+                                "opperator": "gte", 
+                                "value": 0
+                            }, 
+                            {
+                                "gauge": "rgba(251,158,0,1)", 
+                                "id": "f26de750-4d54-11e7-b5f2-2b7c1895bf32", 
+                                "opperator": "gte", 
+                                "value": 0.7
+                            }, 
+                            {
+                                "gauge": "rgba(211,49,21,1)", 
+                                "id": "fa31d190-4d54-11e7-b5f2-2b7c1895bf32", 
+                                "opperator": "gte", 
+                                "value": 0.85
+                            }
+                        ], 
+                        "gauge_inner_width": 10, 
+                        "gauge_max": "1", 
+                        "gauge_style": "half", 
+                        "gauge_width": 10, 
+                        "id": "4e4dc780-4d1d-11e7-b5f2-2b7c1895bf32", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "formatter": "percent", 
+                                "id": "4e4dee90-4d1d-11e7-b5f2-2b7c1895bf32", 
+                                "label": "Disk used", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "system.fsstat.total_size.used", 
+                                        "id": "4e4dee91-4d1d-11e7-b5f2-2b7c1895bf32", 
+                                        "type": "avg"
+                                    }, 
+                                    {
+                                        "field": "system.fsstat.total_size.total", 
+                                        "id": "57c96ee0-4d54-11e7-b5f2-2b7c1895bf32", 
+                                        "type": "avg"
+                                    }, 
+                                    {
+                                        "id": "6304cca0-4d54-11e7-b5f2-2b7c1895bf32", 
+                                        "script": "params.total != null && params.total > 0 ? params.used/params.total : null", 
+                                        "type": "calculation", 
+                                        "variables": [
+                                            {
+                                                "field": "4e4dee91-4d1d-11e7-b5f2-2b7c1895bf32", 
+                                                "id": "6da10430-4d54-11e7-b5f2-2b7c1895bf32", 
+                                                "name": "used"
+                                            }, 
+                                            {
+                                                "field": "57c96ee0-4d54-11e7-b5f2-2b7c1895bf32", 
+                                                "id": "73b8c510-4d54-11e7-b5f2-2b7c1895bf32", 
+                                                "name": "total"
+                                            }
+                                        ]
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "gauge"
+                    }, 
+                    "title": "Disk used [Metricbeat System]", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "825fdb80-4d1d-11e7-b5f2-2b7c1895bf32", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "query": "*"
+                                }
+                            }
+                        }
+                    }
+                }, 
+                "title": "Memory Usage Gauge [Metricbeat System]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "filter": "", 
+                        "gauge_color_rules": [
+                            {
+                                "gauge": "rgba(104,188,0,1)", 
+                                "id": "a0d522e0-1b91-11e7-bec4-a5e9ec5cab8b", 
+                                "opperator": "gte", 
+                                "value": 0
+                            }, 
+                            {
+                                "gauge": "rgba(254,146,0,1)", 
+                                "id": "b45ad8f0-1b91-11e7-bec4-a5e9ec5cab8b", 
+                                "opperator": "gte", 
+                                "value": 0.7
+                            }, 
+                            {
+                                "gauge": "rgba(211,49,21,1)", 
+                                "id": "c06e9550-1b91-11e7-bec4-a5e9ec5cab8b", 
+                                "opperator": "gte", 
+                                "value": 0.85
+                            }
+                        ], 
+                        "gauge_inner_width": 10, 
+                        "gauge_max": "1", 
+                        "gauge_style": "half", 
+                        "gauge_width": 10, 
+                        "id": "9f51b730-1b91-11e7-bec4-a5e9ec5cab8b", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "formatter": "percent", 
+                                "id": "9f51b731-1b91-11e7-bec4-a5e9ec5cab8b", 
+                                "label": "Memory Usage", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "system.memory.actual.used.pct", 
+                                        "id": "9f51b732-1b91-11e7-bec4-a5e9ec5cab8b", 
+                                        "type": "avg"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "gauge"
+                    }, 
+                    "title": "Memory Usage Gauge [Metricbeat System]", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "d3166e80-1b91-11e7-bec4-a5e9ec5cab8b", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "query": "*"
+                                }
+                            }
+                        }
+                    }
+                }, 
+                "title": "CPU Usage Gauge [Metricbeat System]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "filter": "", 
+                        "gauge_color_rules": [
+                            {
+                                "gauge": "rgba(104,188,0,1)", 
+                                "id": "4ef2c3b0-1b91-11e7-bec4-a5e9ec5cab8b", 
+                                "opperator": "gte", 
+                                "value": 0
+                            }, 
+                            {
+                                "gauge": "rgba(254,146,0,1)", 
+                                "id": "e6561ae0-1b91-11e7-bec4-a5e9ec5cab8b", 
+                                "opperator": "gte", 
+                                "value": 0.7
+                            }, 
+                            {
+                                "gauge": "rgba(211,49,21,1)", 
+                                "id": "ec655040-1b91-11e7-bec4-a5e9ec5cab8b", 
+                                "opperator": "gte", 
+                                "value": 0.85
+                            }
+                        ], 
+                        "gauge_inner_width": 10, 
+                        "gauge_max": "1", 
+                        "gauge_style": "half", 
+                        "gauge_width": 10, 
+                        "id": "4c9e2550-1b91-11e7-bec4-a5e9ec5cab8b", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "formatter": "percent", 
+                                "id": "4c9e2551-1b91-11e7-bec4-a5e9ec5cab8b", 
+                                "label": "CPU Usage", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "system.cpu.user.pct", 
+                                        "id": "4c9e2552-1b91-11e7-bec4-a5e9ec5cab8b", 
+                                        "type": "avg"
+                                    }, 
+                                    {
+                                        "field": "system.cpu.system.pct", 
+                                        "id": "225c2140-5fd7-11e7-a63a-a937b7c1a7e1", 
+                                        "type": "avg"
+                                    }, 
+                                    {
+                                        "field": "system.cpu.cores", 
+                                        "id": "837a30c0-5fd7-11e7-a63a-a937b7c1a7e1", 
+                                        "type": "avg"
+                                    }, 
+                                    {
+                                        "id": "587aa510-1b91-11e7-bec4-a5e9ec5cab8b", 
+                                        "script": "params.n > 0 ? (params.user+params.system)/params.n : null", 
+                                        "type": "calculation", 
+                                        "variables": [
+                                            {
+                                                "field": "4c9e2552-1b91-11e7-bec4-a5e9ec5cab8b", 
+                                                "id": "5a19af10-1b91-11e7-bec4-a5e9ec5cab8b", 
+                                                "name": "user"
+                                            }, 
+                                            {
+                                                "field": "225c2140-5fd7-11e7-a63a-a937b7c1a7e1", 
+                                                "id": "32b54f80-5fd7-11e7-a63a-a937b7c1a7e1", 
+                                                "name": "system"
+                                            }, 
+                                            {
+                                                "field": "837a30c0-5fd7-11e7-a63a-a937b7c1a7e1", 
+                                                "id": "8ba6eef0-5fd7-11e7-a63a-a937b7c1a7e1", 
+                                                "name": "n"
+                                            }
+                                        ]
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "gauge"
+                    }, 
+                    "title": "CPU Usage Gauge [Metricbeat System]", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "83e12df0-1b91-11e7-bec4-a5e9ec5cab8b", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "analyze_wildcard": true, 
+                                    "query": "*"
+                                }
+                            }
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false
+                }, 
+                "panelsJSON": [
+                    {
+                        "col": 1, 
+                        "id": "System-Navigation", 
+                        "panelIndex": 9, 
+                        "row": 1, 
+                        "size_x": 12, 
+                        "size_y": 1, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "c6f2ffd0-4d17-11e7-a196-69b9a7a020a9", 
+                        "panelIndex": 11, 
+                        "row": 2, 
+                        "size_x": 2, 
+                        "size_y": 2, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 7, 
+                        "id": "fe064790-1b1f-11e7-bec4-a5e9ec5cab8b", 
+                        "panelIndex": 12, 
+                        "row": 4, 
+                        "size_x": 6, 
+                        "size_y": 5, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "855899e0-1b1c-11e7-b09e-037021c4f8df", 
+                        "panelIndex": 13, 
+                        "row": 4, 
+                        "size_x": 6, 
+                        "size_y": 5, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "7cdb1330-4d1a-11e7-a196-69b9a7a020a9", 
+                        "panelIndex": 14, 
+                        "row": 9, 
+                        "size_x": 12, 
+                        "size_y": 6, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 9, 
+                        "id": "522ee670-1b92-11e7-bec4-a5e9ec5cab8b", 
+                        "panelIndex": 16, 
+                        "row": 2, 
+                        "size_x": 2, 
+                        "size_y": 2, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 11, 
+                        "id": "1aae9140-1b93-11e7-8ada-3df93aab833e", 
+                        "panelIndex": 17, 
+                        "row": 2, 
+                        "size_x": 2, 
+                        "size_y": 2, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 7, 
+                        "id": "825fdb80-4d1d-11e7-b5f2-2b7c1895bf32", 
+                        "panelIndex": 18, 
+                        "row": 2, 
+                        "size_x": 2, 
+                        "size_y": 2, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 5, 
+                        "id": "d3166e80-1b91-11e7-bec4-a5e9ec5cab8b", 
+                        "panelIndex": 19, 
+                        "row": 2, 
+                        "size_x": 2, 
+                        "size_y": 2, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 3, 
+                        "id": "83e12df0-1b91-11e7-bec4-a5e9ec5cab8b", 
+                        "panelIndex": 20, 
+                        "row": 2, 
+                        "size_x": 2, 
+                        "size_y": 2, 
+                        "type": "visualization"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "[Metricbeat System] Overview", 
+                "uiStateJSON": {
+                    "P-11": {
+                        "vis": {
+                            "defaultColors": {
+                                "0 - 100": "rgb(0,104,55)"
+                            }
+                        }
+                    }, 
+                    "P-12": {
+                        "vis": {
+                            "defaultColors": {
+                                "0 - 100": "rgb(0,104,55)"
+                            }
+                        }
+                    }, 
+                    "P-14": {
+                        "vis": {
+                            "defaultColors": {
+                                "0% - 15%": "rgb(247,252,245)", 
+                                "15% - 30%": "rgb(199,233,192)", 
+                                "30% - 45%": "rgb(116,196,118)", 
+                                "45% - 60%": "rgb(35,139,69)"
+                            }
+                        }
+                    }, 
+                    "P-16": {
+                        "vis": {
+                            "defaultColors": {
+                                "0 - 100": "rgb(0,104,55)"
+                            }
+                        }
+                    }, 
+                    "P-2": {
+                        "vis": {
+                            "defaultColors": {
+                                "0 - 100": "rgb(0,104,55)"
+                            }
+                        }
+                    }, 
+                    "P-3": {
+                        "vis": {
+                            "defaultColors": {
+                                "0 - 100": "rgb(0,104,55)"
+                            }
+                        }
+                    }
+                }, 
+                "version": 1
+            }, 
+            "id": "Metricbeat-system-overview", 
+            "type": "dashboard", 
+            "version": 2
+        }
+    ], 
+    "version": "6.0.0-rc1-SNAPSHOT"
 }

--- a/metricbeat/module/uwsgi/_meta/kibana/6/dashboard/Metricbeat-uwsgi-overview.json
+++ b/metricbeat/module/uwsgi/_meta/kibana/6/dashboard/Metricbeat-uwsgi-overview.json
@@ -1,104 +1,188 @@
 {
-  "objects": [
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{}"
-        },
-        "title": "Overview [Metricbeat uWSGI]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"type\":\"timelion\",\"title\":\"Overview [Metricbeat uWSGI]\",\"params\":{\"expression\":\".es(metric=avg:uwsgi.status.total.requests).derivative().label('Requests').title('Overview of requests per period'),\\n.es(metric=avg:uwsgi.status.total.exceptions).derivative().label('Exceptions'),\\n.es(metric=max:uwsgi.status.worker.avg_rt).label('Average response time').yaxis(2)\",\"interval\":\"15s\"}}"
-      },
-      "id": "a5058e70-f0ae-11e7-b9ff-9f96241065de",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{}"
-        },
-        "title": "Memory usage [Metricbeat uWSGI]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"type\":\"timelion\",\"title\":\"Memory usage [Metricbeat uWSGI]\",\"params\":{\"expression\":\".es(metric=max:uwsgi.status.worker.rss).label('Currently used (rss)').title('Memory usage'),\\n.es(metric=max:uwsgi.status.worker.vsz).label('Assigned (vsz)').yaxis(2)\",\"interval\":\"15s\"}}"
-      },
-      "id": "ac7194b0-f0ae-11e7-b9ff-9f96241065de",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{}"
-        },
-        "title": "Workers [Metricbeat uWSGI]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"type\":\"timelion\",\"title\":\"Workers [Metricbeat uWSGI]\",\"params\":{\"expression\":\".es(split=uwsgi.status.core.id:16,metric=max:uwsgi.status.core.requests.total).derivative().bars().title('Requests handled by each thread (core) per period')\",\"interval\":\"15s\"}}"
-      },
-      "id": "8c5f96e0-f0ae-11e7-b9ff-9f96241065de",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{}"
-        },
-        "title": "Errors [Metricbeat uWSGI]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"type\":\"timelion\",\"title\":\"Errors [Metricbeat uWSGI]\",\"params\":{\"expression\":\".es(metric=max:uwsgi.status.total.read_errors).label('Read errors').title('Errors'),\\n.es(metric=max:uwsgi.status.total.write_errors).label('Write errors'),\\n.es(metric=max:uwsgi.status.worker.harakiri_count).label('Timeouted requests')\",\"interval\":\"15s\"}}"
-      },
-      "id": "ba4a80b0-f0ae-11e7-b9ff-9f96241065de",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "columns": [
-          "_source"
-        ],
-        "description": "",
-        "hits": 0,
-        "kibanaSavedObjectMeta": {
-            "searchSourceJSON": "{\"index\":\"metricbeat-*\",\"highlightAll\":true,\"version\":true,\"query\":{\"language\":\"lucene\",\"query\":\"metricset.module: uwsgi\"},\"filter\":[]}"
-        },
-        "sort": [
-          "@timestamp",
-          "desc"
-        ],
-        "title": "Metricbeat uWSGI status",
-        "version": 1
-      },
-      "id": "Metricbeat uWSGI status",
-      "type": "search",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "hits": 0,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"language\":\"lucene\",\"query\":\"\"},\"filter\":[],\"highlightAll\":true,\"version\":true}"
-        },
-        "optionsJSON": "{\"darkTheme\":false}",
-        "panelsJSON": "[{\"col\":1,\"id\":\"a5058e70-f0ae-11e7-b9ff-9f96241065de\",\"panelIndex\":1,\"row\":1,\"size_x\":6,\"size_y\":3,\"type\":\"visualization\"},{\"col\":7,\"id\":\"ac7194b0-f0ae-11e7-b9ff-9f96241065de\",\"panelIndex\":2,\"row\":1,\"size_x\":6,\"size_y\":3,\"type\":\"visualization\"},{\"col\":1,\"id\":\"8c5f96e0-f0ae-11e7-b9ff-9f96241065de\",\"panelIndex\":3,\"row\":4,\"size_x\":6,\"size_y\":3,\"type\":\"visualization\"},{\"col\":7,\"id\":\"ba4a80b0-f0ae-11e7-b9ff-9f96241065de\",\"panelIndex\":4,\"row\":4,\"size_x\":6,\"size_y\":3,\"type\":\"visualization\"}]",
-        "timeRestore": false,
-        "title": "[Metricbeat uWSGI] Overview",
-        "uiStateJSON": "{}",
-        "version": 1
-      },
-      "id": "32fca290-f0af-11e7-b9ff-9f96241065de",
-      "type": "dashboard",
-      "version": 1
-    }
-  ],
-  "version": "6.0.0-rc1"
+    "objects": [
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Overview [Metricbeat uWSGI]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "params": {
+                        "expression": ".es(metric=avg:uwsgi.status.total.requests).derivative().label('Requests').title('Overview of requests per period'),\n.es(metric=avg:uwsgi.status.total.exceptions).derivative().label('Exceptions'),\n.es(metric=max:uwsgi.status.worker.avg_rt).label('Average response time').yaxis(2)", 
+                        "interval": "15s"
+                    }, 
+                    "title": "Overview [Metricbeat uWSGI]", 
+                    "type": "timelion"
+                }
+            }, 
+            "id": "a5058e70-f0ae-11e7-b9ff-9f96241065de", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Memory usage [Metricbeat uWSGI]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "params": {
+                        "expression": ".es(metric=max:uwsgi.status.worker.rss).label('Currently used (rss)').title('Memory usage'),\n.es(metric=max:uwsgi.status.worker.vsz).label('Assigned (vsz)').yaxis(2)", 
+                        "interval": "15s"
+                    }, 
+                    "title": "Memory usage [Metricbeat uWSGI]", 
+                    "type": "timelion"
+                }
+            }, 
+            "id": "ac7194b0-f0ae-11e7-b9ff-9f96241065de", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Workers [Metricbeat uWSGI]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "params": {
+                        "expression": ".es(split=uwsgi.status.core.id:16,metric=max:uwsgi.status.core.requests.total).derivative().bars().title('Requests handled by each thread (core) per period')", 
+                        "interval": "15s"
+                    }, 
+                    "title": "Workers [Metricbeat uWSGI]", 
+                    "type": "timelion"
+                }
+            }, 
+            "id": "8c5f96e0-f0ae-11e7-b9ff-9f96241065de", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Errors [Metricbeat uWSGI]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "params": {
+                        "expression": ".es(metric=max:uwsgi.status.total.read_errors).label('Read errors').title('Errors'),\n.es(metric=max:uwsgi.status.total.write_errors).label('Write errors'),\n.es(metric=max:uwsgi.status.worker.harakiri_count).label('Timeouted requests')", 
+                        "interval": "15s"
+                    }, 
+                    "title": "Errors [Metricbeat uWSGI]", 
+                    "type": "timelion"
+                }
+            }, 
+            "id": "ba4a80b0-f0ae-11e7-b9ff-9f96241065de", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "columns": [
+                    "_source"
+                ], 
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "index": "metricbeat-*", 
+                        "query": {
+                            "language": "lucene", 
+                            "query": "metricset.module: uwsgi"
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "sort": [
+                    "@timestamp", 
+                    "desc"
+                ], 
+                "title": "Metricbeat uWSGI status", 
+                "version": 1
+            }, 
+            "id": "Metricbeat uWSGI status", 
+            "type": "search", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "query": {
+                            "language": "lucene", 
+                            "query": ""
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false
+                }, 
+                "panelsJSON": [
+                    {
+                        "col": 1, 
+                        "id": "a5058e70-f0ae-11e7-b9ff-9f96241065de", 
+                        "panelIndex": 1, 
+                        "row": 1, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 7, 
+                        "id": "ac7194b0-f0ae-11e7-b9ff-9f96241065de", 
+                        "panelIndex": 2, 
+                        "row": 1, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "8c5f96e0-f0ae-11e7-b9ff-9f96241065de", 
+                        "panelIndex": 3, 
+                        "row": 4, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 7, 
+                        "id": "ba4a80b0-f0ae-11e7-b9ff-9f96241065de", 
+                        "panelIndex": 4, 
+                        "row": 4, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "[Metricbeat uWSGI] Overview", 
+                "uiStateJSON": {}, 
+                "version": 1
+            }, 
+            "id": "32fca290-f0af-11e7-b9ff-9f96241065de", 
+            "type": "dashboard", 
+            "version": 1
+        }
+    ], 
+    "version": "6.0.0-rc1"
 }

--- a/metricbeat/module/windows/_meta/kibana/6/dashboard/metricbeat-windows-service.json
+++ b/metricbeat/module/windows/_meta/kibana/6/dashboard/metricbeat-windows-service.json
@@ -1,129 +1,760 @@
 {
-  "objects": [
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"index\":\"metricbeat-*\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
-        },
-        "title": "Service States [Metricbeat Windows]",
-        "uiStateJSON": "{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":null,\"direction\":null}}}}",
-        "version": 1,
-        "visState": "{\"aggs\":[{\"enabled\":true,\"id\":\"1\",\"params\":{\"aggregate\":\"concat\",\"customLabel\":\"Latest Report\",\"field\":\"@timestamp\",\"size\":1,\"sortField\":\"@timestamp\",\"sortOrder\":\"desc\"},\"schema\":\"metric\",\"type\":\"top_hits\"},{\"enabled\":true,\"id\":\"2\",\"params\":{\"customLabel\":\"Service\",\"field\":\"windows.service.display_name\",\"order\":\"asc\",\"orderBy\":\"_term\",\"size\":100},\"schema\":\"bucket\",\"type\":\"terms\"},{\"enabled\":true,\"id\":\"5\",\"params\":{\"customLabel\":\"Host\",\"field\":\"beat.name\",\"order\":\"desc\",\"orderBy\":\"_term\",\"size\":5},\"schema\":\"bucket\",\"type\":\"terms\"},{\"enabled\":true,\"id\":\"3\",\"params\":{\"customLabel\":\"State\",\"field\":\"windows.service.state\",\"order\":\"desc\",\"orderAgg\":{\"enabled\":true,\"id\":\"3-orderAgg\",\"params\":{\"field\":\"@timestamp\"},\"schema\":{\"aggFilter\":[\"!top_hits\",\"!percentiles\",\"!median\",\"!std_dev\",\"!derivative\",\"!moving_avg\",\"!serial_diff\",\"!cumulative_sum\",\"!avg_bucket\",\"!max_bucket\",\"!min_bucket\",\"!sum_bucket\"],\"deprecate\":false,\"editor\":false,\"group\":\"none\",\"hideCustomLabel\":true,\"max\":null,\"min\":0,\"name\":\"orderAgg\",\"params\":[],\"title\":\"Order Agg\"},\"type\":\"max\"},\"orderBy\":\"custom\",\"size\":1},\"schema\":\"bucket\",\"type\":\"terms\"},{\"enabled\":true,\"id\":\"4\",\"params\":{\"customLabel\":\"Startup Type\",\"field\":\"windows.service.start_type\",\"order\":\"desc\",\"orderAgg\":{\"enabled\":true,\"id\":\"4-orderAgg\",\"params\":{\"field\":\"@timestamp\"},\"schema\":{\"aggFilter\":[\"!top_hits\",\"!percentiles\",\"!median\",\"!std_dev\",\"!derivative\",\"!moving_avg\",\"!serial_diff\",\"!cumulative_sum\",\"!avg_bucket\",\"!max_bucket\",\"!min_bucket\",\"!sum_bucket\"],\"deprecate\":false,\"editor\":false,\"group\":\"none\",\"hideCustomLabel\":true,\"max\":null,\"min\":0,\"name\":\"orderAgg\",\"params\":[],\"title\":\"Order Agg\"},\"type\":\"max\"},\"orderBy\":\"custom\",\"size\":1},\"schema\":\"bucket\",\"type\":\"terms\"}],\"params\":{\"perPage\":10,\"showMeticsAtAllLevels\":false,\"showPartialRows\":false,\"showTotal\":false,\"sort\":{\"columnIndex\":null,\"direction\":null},\"totalFunc\":\"sum\"},\"title\":\"Service States [Metricbeat Windows]\",\"type\":\"table\"}"
-      },
-      "id": "eb8277d0-c98c-11e7-9835-2f31fe08873b",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
-        },
-        "savedSearchId": "b6b7ccc0-c98d-11e7-9835-2f31fe08873b",
-        "title": "Hosts [Metricbeat Windows]",
-        "uiStateJSON": "{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":null,\"direction\":null}}}}",
-        "version": 1,
-        "visState": "{\"title\":\"Hosts [Metricbeat Windows]\",\"type\":\"table\",\"params\":{\"perPage\":10,\"showPartialRows\":false,\"showMeticsAtAllLevels\":false,\"sort\":{\"columnIndex\":null,\"direction\":null},\"showTotal\":false,\"totalFunc\":\"sum\"},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"cardinality\",\"schema\":\"metric\",\"params\":{\"field\":\"windows.service.id\",\"customLabel\":\"Total Services\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"beat.name\",\"size\":100,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"Host\"}}]}"
-      },
-      "id": "23a5fff0-c98e-11e7-9835-2f31fe08873b",
-      "type": "visualization",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
-        },
-        "savedSearchId": "b6b7ccc0-c98d-11e7-9835-2f31fe08873b",
-        "title": "Startup States [Metricbeat Windows]",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Startup States [Metricbeat Windows]\",\"type\":\"pie\",\"params\":{\"type\":\"pie\",\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"isDonut\":true},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"cardinality\",\"schema\":\"metric\",\"params\":{\"field\":\"windows.service.id\",\"customLabel\":\"Service Count\"}},{\"id\":\"4\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"windows.service.start_type\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"Startup Type\"}},{\"id\":\"3\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"windows.service.state\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"State\"}}]}"
-      },
-      "id": "830c45f0-c991-11e7-9835-2f31fe08873b",
-      "type": "visualization",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
-        },
-        "savedSearchId": "b6b7ccc0-c98d-11e7-9835-2f31fe08873b",
-        "title": "Unique Services [Metricbeat Windows]",
-        "uiStateJSON": "{\"vis\":{\"defaultColors\":{\"0 - 100\":\"rgb(0,104,55)\"}}}",
-        "version": 1,
-        "visState": "{\"title\":\"Unique Services [Metricbeat Windows]\",\"type\":\"metric\",\"params\":{\"addTooltip\":true,\"addLegend\":false,\"type\":\"gauge\",\"gauge\":{\"verticalSplit\":false,\"autoExtend\":false,\"percentageMode\":false,\"gaugeType\":\"Metric\",\"gaugeStyle\":\"Full\",\"backStyle\":\"Full\",\"orientation\":\"vertical\",\"colorSchema\":\"Green to Red\",\"gaugeColorMode\":\"None\",\"useRange\":false,\"colorsRange\":[{\"from\":0,\"to\":100}],\"invertColors\":false,\"labels\":{\"show\":false,\"color\":\"black\"},\"scale\":{\"show\":false,\"labels\":false,\"color\":\"#333\",\"width\":2},\"type\":\"simple\",\"style\":{\"fontSize\":60,\"bgColor\":false,\"labelColor\":false,\"subText\":\"\"}}},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"cardinality\",\"schema\":\"metric\",\"params\":{\"field\":\"windows.service.id\",\"customLabel\":\"Services\"}}]}"
-      },
-      "id": "35f5ad60-c996-11e7-9835-2f31fe08873b",
-      "type": "visualization",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[{\"meta\":{\"index\":\"metricbeat-*\",\"negate\":false,\"disabled\":false,\"alias\":null,\"type\":\"exists\",\"key\":\"windows.service.exit_code\",\"value\":\"exists\"},\"exists\":{\"field\":\"windows.service.exit_code\"},\"$state\":{\"store\":\"appState\"}},{\"meta\":{\"index\":\"metricbeat-*\",\"negate\":true,\"disabled\":false,\"alias\":null,\"type\":\"phrase\",\"key\":\"windows.service.exit_code\",\"value\":\"0\",\"params\":{\"query\":\"0\",\"type\":\"phrase\"}},\"query\":{\"match\":{\"windows.service.exit_code\":{\"query\":\"0\",\"type\":\"phrase\"}}},\"$state\":{\"store\":\"appState\"}},{\"meta\":{\"index\":\"metricbeat-*\",\"negate\":true,\"disabled\":false,\"alias\":null,\"type\":\"phrase\",\"key\":\"windows.service.exit_code\",\"value\":\"ERROR_SERVICE_NEVER_STARTED\",\"params\":{\"query\":\"ERROR_SERVICE_NEVER_STARTED\",\"type\":\"phrase\"}},\"query\":{\"match\":{\"windows.service.exit_code\":{\"query\":\"ERROR_SERVICE_NEVER_STARTED\",\"type\":\"phrase\"}}},\"$state\":{\"store\":\"appState\"}}],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
-        },
-        "savedSearchId": "b6b7ccc0-c98d-11e7-9835-2f31fe08873b",
-        "title": "Non-zero Service Exit Codes [Metricbeat Windows]",
-        "uiStateJSON": "{\"vis\":{\"defaultColors\":{\"0 - 100\":\"rgb(0,104,55)\"}}}",
-        "version": 1,
-        "visState": "{\"title\":\"Non-zero Service Exit Codes [Metricbeat Windows]\",\"type\":\"metric\",\"params\":{\"addTooltip\":true,\"addLegend\":false,\"type\":\"gauge\",\"gauge\":{\"verticalSplit\":false,\"autoExtend\":false,\"percentageMode\":false,\"gaugeType\":\"Metric\",\"gaugeStyle\":\"Full\",\"backStyle\":\"Full\",\"orientation\":\"vertical\",\"colorSchema\":\"Green to Red\",\"gaugeColorMode\":\"None\",\"useRange\":false,\"colorsRange\":[{\"from\":0,\"to\":100}],\"invertColors\":false,\"labels\":{\"show\":false,\"color\":\"black\"},\"scale\":{\"show\":false,\"labels\":false,\"color\":\"#333\",\"width\":2},\"type\":\"simple\",\"style\":{\"fontSize\":60,\"bgColor\":false,\"labelColor\":false,\"subText\":\"\"}}},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"cardinality\",\"schema\":\"metric\",\"params\":{\"field\":\"windows.service.id\",\"customLabel\":\"Non-zero Exit Codes\"}}]}"
-      },
-      "id": "c36b2ba0-ca29-11e7-9835-2f31fe08873b",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "columns": [
-          "beat.name",
-          "windows.service.display_name",
-          "windows.service.state",
-          "windows.service.start_type",
-          "windows.service.uptime.ms",
-          "windows.service.pid",
-          "windows.service.exit_code"
-        ],
-        "description": "",
-        "hits": 0,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"index\":\"metricbeat-*\",\"highlightAll\":true,\"version\":true,\"query\":{\"query\":\"\",\"language\":\"lucene\"},\"filter\":[{\"meta\":{\"negate\":false,\"index\":\"metricbeat-*\",\"type\":\"phrase\",\"key\":\"metricset.module\",\"value\":\"windows\",\"params\":{\"query\":\"windows\",\"type\":\"phrase\"},\"disabled\":false,\"alias\":null},\"query\":{\"match\":{\"metricset.module\":{\"query\":\"windows\",\"type\":\"phrase\"}}},\"$state\":{\"store\":\"appState\"}},{\"meta\":{\"negate\":false,\"index\":\"metricbeat-*\",\"type\":\"phrase\",\"key\":\"metricset.name\",\"value\":\"service\",\"params\":{\"query\":\"service\",\"type\":\"phrase\"},\"disabled\":false,\"alias\":null},\"query\":{\"match\":{\"metricset.name\":{\"query\":\"service\",\"type\":\"phrase\"}}},\"$state\":{\"store\":\"appState\"}}]}"
-        },
-        "sort": [
-          "@timestamp",
-          "desc"
-        ],
-        "title": "Services [Metricbeat Windows]",
-        "version": 1
-      },
-      "id": "b6b7ccc0-c98d-11e7-9835-2f31fe08873b",
-      "type": "search",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "Overview of the Windows Service States",
-        "hits": 0,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"language\":\"lucene\",\"query\":\"\"},\"filter\":[],\"highlightAll\":true,\"version\":true}"
-        },
-        "optionsJSON": "{\"darkTheme\":false}",
-        "panelsJSON": "[{\"col\":4,\"id\":\"eb8277d0-c98c-11e7-9835-2f31fe08873b\",\"panelIndex\":1,\"row\":4,\"size_x\":9,\"size_y\":5,\"type\":\"visualization\"},{\"col\":1,\"id\":\"23a5fff0-c98e-11e7-9835-2f31fe08873b\",\"panelIndex\":2,\"row\":4,\"size_x\":3,\"size_y\":5,\"type\":\"visualization\"},{\"col\":1,\"id\":\"830c45f0-c991-11e7-9835-2f31fe08873b\",\"panelIndex\":3,\"row\":1,\"size_x\":4,\"size_y\":3,\"type\":\"visualization\"},{\"size_x\":4,\"size_y\":3,\"panelIndex\":4,\"type\":\"visualization\",\"id\":\"35f5ad60-c996-11e7-9835-2f31fe08873b\",\"col\":5,\"row\":1},{\"size_x\":4,\"size_y\":3,\"panelIndex\":5,\"type\":\"visualization\",\"id\":\"c36b2ba0-ca29-11e7-9835-2f31fe08873b\",\"col\":9,\"row\":1}]",
-        "timeRestore": false,
-        "title": "[Metricbeat Windows] Services",
-        "uiStateJSON": "{\"P-1\":{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":null,\"direction\":null}}}},\"P-2\":{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":null,\"direction\":null}}}},\"P-4\":{\"vis\":{\"defaultColors\":{\"0 - 100\":\"rgb(0,104,55)\"}}},\"P-5\":{\"vis\":{\"defaultColors\":{\"0 - 100\":\"rgb(0,104,55)\"}}}}",
-        "version": 1
-      },
-      "id": "d9eba730-c991-11e7-9835-2f31fe08873b",
-      "type": "dashboard",
-      "version": 6
-    }
-  ],
-  "version": "6.0.0"
+    "objects": [
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "index": "metricbeat-*", 
+                        "query": {
+                            "language": "lucene", 
+                            "query": ""
+                        }
+                    }
+                }, 
+                "title": "Service States [Metricbeat Windows]", 
+                "uiStateJSON": {
+                    "vis": {
+                        "params": {
+                            "sort": {
+                                "columnIndex": null, 
+                                "direction": null
+                            }
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "aggregate": "concat", 
+                                "customLabel": "Latest Report", 
+                                "field": "@timestamp", 
+                                "size": 1, 
+                                "sortField": "@timestamp", 
+                                "sortOrder": "desc"
+                            }, 
+                            "schema": "metric", 
+                            "type": "top_hits"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customLabel": "Service", 
+                                "field": "windows.service.display_name", 
+                                "order": "asc", 
+                                "orderBy": "_term", 
+                                "size": 100
+                            }, 
+                            "schema": "bucket", 
+                            "type": "terms"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "5", 
+                            "params": {
+                                "customLabel": "Host", 
+                                "field": "beat.name", 
+                                "order": "desc", 
+                                "orderBy": "_term", 
+                                "size": 5
+                            }, 
+                            "schema": "bucket", 
+                            "type": "terms"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "customLabel": "State", 
+                                "field": "windows.service.state", 
+                                "order": "desc", 
+                                "orderAgg": {
+                                    "enabled": true, 
+                                    "id": "3-orderAgg", 
+                                    "params": {
+                                        "field": "@timestamp"
+                                    }, 
+                                    "schema": {
+                                        "aggFilter": [
+                                            "!top_hits", 
+                                            "!percentiles", 
+                                            "!median", 
+                                            "!std_dev", 
+                                            "!derivative", 
+                                            "!moving_avg", 
+                                            "!serial_diff", 
+                                            "!cumulative_sum", 
+                                            "!avg_bucket", 
+                                            "!max_bucket", 
+                                            "!min_bucket", 
+                                            "!sum_bucket"
+                                        ], 
+                                        "deprecate": false, 
+                                        "editor": false, 
+                                        "group": "none", 
+                                        "hideCustomLabel": true, 
+                                        "max": null, 
+                                        "min": 0, 
+                                        "name": "orderAgg", 
+                                        "params": [], 
+                                        "title": "Order Agg"
+                                    }, 
+                                    "type": "max"
+                                }, 
+                                "orderBy": "custom", 
+                                "size": 1
+                            }, 
+                            "schema": "bucket", 
+                            "type": "terms"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "4", 
+                            "params": {
+                                "customLabel": "Startup Type", 
+                                "field": "windows.service.start_type", 
+                                "order": "desc", 
+                                "orderAgg": {
+                                    "enabled": true, 
+                                    "id": "4-orderAgg", 
+                                    "params": {
+                                        "field": "@timestamp"
+                                    }, 
+                                    "schema": {
+                                        "aggFilter": [
+                                            "!top_hits", 
+                                            "!percentiles", 
+                                            "!median", 
+                                            "!std_dev", 
+                                            "!derivative", 
+                                            "!moving_avg", 
+                                            "!serial_diff", 
+                                            "!cumulative_sum", 
+                                            "!avg_bucket", 
+                                            "!max_bucket", 
+                                            "!min_bucket", 
+                                            "!sum_bucket"
+                                        ], 
+                                        "deprecate": false, 
+                                        "editor": false, 
+                                        "group": "none", 
+                                        "hideCustomLabel": true, 
+                                        "max": null, 
+                                        "min": 0, 
+                                        "name": "orderAgg", 
+                                        "params": [], 
+                                        "title": "Order Agg"
+                                    }, 
+                                    "type": "max"
+                                }, 
+                                "orderBy": "custom", 
+                                "size": 1
+                            }, 
+                            "schema": "bucket", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "params": {
+                        "perPage": 10, 
+                        "showMeticsAtAllLevels": false, 
+                        "showPartialRows": false, 
+                        "showTotal": false, 
+                        "sort": {
+                            "columnIndex": null, 
+                            "direction": null
+                        }, 
+                        "totalFunc": "sum"
+                    }, 
+                    "title": "Service States [Metricbeat Windows]", 
+                    "type": "table"
+                }
+            }, 
+            "id": "eb8277d0-c98c-11e7-9835-2f31fe08873b", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "lucene", 
+                            "query": ""
+                        }
+                    }
+                }, 
+                "savedSearchId": "b6b7ccc0-c98d-11e7-9835-2f31fe08873b", 
+                "title": "Hosts [Metricbeat Windows]", 
+                "uiStateJSON": {
+                    "vis": {
+                        "params": {
+                            "sort": {
+                                "columnIndex": null, 
+                                "direction": null
+                            }
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Total Services", 
+                                "field": "windows.service.id"
+                            }, 
+                            "schema": "metric", 
+                            "type": "cardinality"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customLabel": "Host", 
+                                "field": "beat.name", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 100
+                            }, 
+                            "schema": "bucket", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "params": {
+                        "perPage": 10, 
+                        "showMeticsAtAllLevels": false, 
+                        "showPartialRows": false, 
+                        "showTotal": false, 
+                        "sort": {
+                            "columnIndex": null, 
+                            "direction": null
+                        }, 
+                        "totalFunc": "sum"
+                    }, 
+                    "title": "Hosts [Metricbeat Windows]", 
+                    "type": "table"
+                }
+            }, 
+            "id": "23a5fff0-c98e-11e7-9835-2f31fe08873b", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "lucene", 
+                            "query": ""
+                        }
+                    }
+                }, 
+                "savedSearchId": "b6b7ccc0-c98d-11e7-9835-2f31fe08873b", 
+                "title": "Startup States [Metricbeat Windows]", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Service Count", 
+                                "field": "windows.service.id"
+                            }, 
+                            "schema": "metric", 
+                            "type": "cardinality"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "4", 
+                            "params": {
+                                "customLabel": "Startup Type", 
+                                "field": "windows.service.start_type", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "customLabel": "State", 
+                                "field": "windows.service.state", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "params": {
+                        "addLegend": true, 
+                        "addTooltip": true, 
+                        "isDonut": true, 
+                        "legendPosition": "right", 
+                        "type": "pie"
+                    }, 
+                    "title": "Startup States [Metricbeat Windows]", 
+                    "type": "pie"
+                }
+            }, 
+            "id": "830c45f0-c991-11e7-9835-2f31fe08873b", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "lucene", 
+                            "query": ""
+                        }
+                    }
+                }, 
+                "savedSearchId": "b6b7ccc0-c98d-11e7-9835-2f31fe08873b", 
+                "title": "Unique Services [Metricbeat Windows]", 
+                "uiStateJSON": {
+                    "vis": {
+                        "defaultColors": {
+                            "0 - 100": "rgb(0,104,55)"
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Services", 
+                                "field": "windows.service.id"
+                            }, 
+                            "schema": "metric", 
+                            "type": "cardinality"
+                        }
+                    ], 
+                    "params": {
+                        "addLegend": false, 
+                        "addTooltip": true, 
+                        "gauge": {
+                            "autoExtend": false, 
+                            "backStyle": "Full", 
+                            "colorSchema": "Green to Red", 
+                            "colorsRange": [
+                                {
+                                    "from": 0, 
+                                    "to": 100
+                                }
+                            ], 
+                            "gaugeColorMode": "None", 
+                            "gaugeStyle": "Full", 
+                            "gaugeType": "Metric", 
+                            "invertColors": false, 
+                            "labels": {
+                                "color": "black", 
+                                "show": false
+                            }, 
+                            "orientation": "vertical", 
+                            "percentageMode": false, 
+                            "scale": {
+                                "color": "#333", 
+                                "labels": false, 
+                                "show": false, 
+                                "width": 2
+                            }, 
+                            "style": {
+                                "bgColor": false, 
+                                "fontSize": 60, 
+                                "labelColor": false, 
+                                "subText": ""
+                            }, 
+                            "type": "simple", 
+                            "useRange": false, 
+                            "verticalSplit": false
+                        }, 
+                        "type": "gauge"
+                    }, 
+                    "title": "Unique Services [Metricbeat Windows]", 
+                    "type": "metric"
+                }
+            }, 
+            "id": "35f5ad60-c996-11e7-9835-2f31fe08873b", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [
+                            {
+                                "$state": {
+                                    "store": "appState"
+                                }, 
+                                "exists": {
+                                    "field": "windows.service.exit_code"
+                                }, 
+                                "meta": {
+                                    "alias": null, 
+                                    "disabled": false, 
+                                    "index": "metricbeat-*", 
+                                    "key": "windows.service.exit_code", 
+                                    "negate": false, 
+                                    "type": "exists", 
+                                    "value": "exists"
+                                }
+                            }, 
+                            {
+                                "$state": {
+                                    "store": "appState"
+                                }, 
+                                "meta": {
+                                    "alias": null, 
+                                    "disabled": false, 
+                                    "index": "metricbeat-*", 
+                                    "key": "windows.service.exit_code", 
+                                    "negate": true, 
+                                    "params": {
+                                        "query": "0", 
+                                        "type": "phrase"
+                                    }, 
+                                    "type": "phrase", 
+                                    "value": "0"
+                                }, 
+                                "query": {
+                                    "match": {
+                                        "windows.service.exit_code": {
+                                            "query": "0", 
+                                            "type": "phrase"
+                                        }
+                                    }
+                                }
+                            }, 
+                            {
+                                "$state": {
+                                    "store": "appState"
+                                }, 
+                                "meta": {
+                                    "alias": null, 
+                                    "disabled": false, 
+                                    "index": "metricbeat-*", 
+                                    "key": "windows.service.exit_code", 
+                                    "negate": true, 
+                                    "params": {
+                                        "query": "ERROR_SERVICE_NEVER_STARTED", 
+                                        "type": "phrase"
+                                    }, 
+                                    "type": "phrase", 
+                                    "value": "ERROR_SERVICE_NEVER_STARTED"
+                                }, 
+                                "query": {
+                                    "match": {
+                                        "windows.service.exit_code": {
+                                            "query": "ERROR_SERVICE_NEVER_STARTED", 
+                                            "type": "phrase"
+                                        }
+                                    }
+                                }
+                            }
+                        ], 
+                        "query": {
+                            "language": "lucene", 
+                            "query": ""
+                        }
+                    }
+                }, 
+                "savedSearchId": "b6b7ccc0-c98d-11e7-9835-2f31fe08873b", 
+                "title": "Non-zero Service Exit Codes [Metricbeat Windows]", 
+                "uiStateJSON": {
+                    "vis": {
+                        "defaultColors": {
+                            "0 - 100": "rgb(0,104,55)"
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Non-zero Exit Codes", 
+                                "field": "windows.service.id"
+                            }, 
+                            "schema": "metric", 
+                            "type": "cardinality"
+                        }
+                    ], 
+                    "params": {
+                        "addLegend": false, 
+                        "addTooltip": true, 
+                        "gauge": {
+                            "autoExtend": false, 
+                            "backStyle": "Full", 
+                            "colorSchema": "Green to Red", 
+                            "colorsRange": [
+                                {
+                                    "from": 0, 
+                                    "to": 100
+                                }
+                            ], 
+                            "gaugeColorMode": "None", 
+                            "gaugeStyle": "Full", 
+                            "gaugeType": "Metric", 
+                            "invertColors": false, 
+                            "labels": {
+                                "color": "black", 
+                                "show": false
+                            }, 
+                            "orientation": "vertical", 
+                            "percentageMode": false, 
+                            "scale": {
+                                "color": "#333", 
+                                "labels": false, 
+                                "show": false, 
+                                "width": 2
+                            }, 
+                            "style": {
+                                "bgColor": false, 
+                                "fontSize": 60, 
+                                "labelColor": false, 
+                                "subText": ""
+                            }, 
+                            "type": "simple", 
+                            "useRange": false, 
+                            "verticalSplit": false
+                        }, 
+                        "type": "gauge"
+                    }, 
+                    "title": "Non-zero Service Exit Codes [Metricbeat Windows]", 
+                    "type": "metric"
+                }
+            }, 
+            "id": "c36b2ba0-ca29-11e7-9835-2f31fe08873b", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "columns": [
+                    "beat.name", 
+                    "windows.service.display_name", 
+                    "windows.service.state", 
+                    "windows.service.start_type", 
+                    "windows.service.uptime.ms", 
+                    "windows.service.pid", 
+                    "windows.service.exit_code"
+                ], 
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [
+                            {
+                                "$state": {
+                                    "store": "appState"
+                                }, 
+                                "meta": {
+                                    "alias": null, 
+                                    "disabled": false, 
+                                    "index": "metricbeat-*", 
+                                    "key": "metricset.module", 
+                                    "negate": false, 
+                                    "params": {
+                                        "query": "windows", 
+                                        "type": "phrase"
+                                    }, 
+                                    "type": "phrase", 
+                                    "value": "windows"
+                                }, 
+                                "query": {
+                                    "match": {
+                                        "metricset.module": {
+                                            "query": "windows", 
+                                            "type": "phrase"
+                                        }
+                                    }
+                                }
+                            }, 
+                            {
+                                "$state": {
+                                    "store": "appState"
+                                }, 
+                                "meta": {
+                                    "alias": null, 
+                                    "disabled": false, 
+                                    "index": "metricbeat-*", 
+                                    "key": "metricset.name", 
+                                    "negate": false, 
+                                    "params": {
+                                        "query": "service", 
+                                        "type": "phrase"
+                                    }, 
+                                    "type": "phrase", 
+                                    "value": "service"
+                                }, 
+                                "query": {
+                                    "match": {
+                                        "metricset.name": {
+                                            "query": "service", 
+                                            "type": "phrase"
+                                        }
+                                    }
+                                }
+                            }
+                        ], 
+                        "highlightAll": true, 
+                        "index": "metricbeat-*", 
+                        "query": {
+                            "language": "lucene", 
+                            "query": ""
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "sort": [
+                    "@timestamp", 
+                    "desc"
+                ], 
+                "title": "Services [Metricbeat Windows]", 
+                "version": 1
+            }, 
+            "id": "b6b7ccc0-c98d-11e7-9835-2f31fe08873b", 
+            "type": "search", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "Overview of the Windows Service States", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "query": {
+                            "language": "lucene", 
+                            "query": ""
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false
+                }, 
+                "panelsJSON": [
+                    {
+                        "col": 4, 
+                        "id": "eb8277d0-c98c-11e7-9835-2f31fe08873b", 
+                        "panelIndex": 1, 
+                        "row": 4, 
+                        "size_x": 9, 
+                        "size_y": 5, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "23a5fff0-c98e-11e7-9835-2f31fe08873b", 
+                        "panelIndex": 2, 
+                        "row": 4, 
+                        "size_x": 3, 
+                        "size_y": 5, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "830c45f0-c991-11e7-9835-2f31fe08873b", 
+                        "panelIndex": 3, 
+                        "row": 1, 
+                        "size_x": 4, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 5, 
+                        "id": "35f5ad60-c996-11e7-9835-2f31fe08873b", 
+                        "panelIndex": 4, 
+                        "row": 1, 
+                        "size_x": 4, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 9, 
+                        "id": "c36b2ba0-ca29-11e7-9835-2f31fe08873b", 
+                        "panelIndex": 5, 
+                        "row": 1, 
+                        "size_x": 4, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "[Metricbeat Windows] Services", 
+                "uiStateJSON": {
+                    "P-1": {
+                        "vis": {
+                            "params": {
+                                "sort": {
+                                    "columnIndex": null, 
+                                    "direction": null
+                                }
+                            }
+                        }
+                    }, 
+                    "P-2": {
+                        "vis": {
+                            "params": {
+                                "sort": {
+                                    "columnIndex": null, 
+                                    "direction": null
+                                }
+                            }
+                        }
+                    }, 
+                    "P-4": {
+                        "vis": {
+                            "defaultColors": {
+                                "0 - 100": "rgb(0,104,55)"
+                            }
+                        }
+                    }, 
+                    "P-5": {
+                        "vis": {
+                            "defaultColors": {
+                                "0 - 100": "rgb(0,104,55)"
+                            }
+                        }
+                    }
+                }, 
+                "version": 1
+            }, 
+            "id": "d9eba730-c991-11e7-9835-2f31fe08873b", 
+            "type": "dashboard", 
+            "version": 6
+        }
+    ], 
+    "version": "6.0.0"
 }


### PR DESCRIPTION
Currently when a PR is opened to change or add a dashboard the PR's are hard to review even if only a small detail was changed. The reasons is that the Kibana json objects contain json as string. The content inside these strings is valid JSON if it is decoded.

With this PR the dashboards in Metricbeat are modified that they contain the full decoded JSON objects instead of the string. Additional the JSON entries are sorted. This makes also the content of the visualisations readable, will create minimal diffs and allows to even apply small fixes on the code base. In addition we can now validate if it's valid JSON and introduce automatic scripts to remove potentially unneeded fields from the dashboards to clean them up.

All the existing dashboards were decoded with the following command:
```
python ../libbeat/scripts/unpack_dashboards.py --transform=decode --glob="/Users/ruflin/Dev/gopath/src/github.com/elastic/beats/metricbeat/module/*/_meta/kibana/6/dashboard/*.json"
```

This command has to be applied to dashboards exported from Kibana before adding them to the module directory.

To make sure the import still works as before, on collection of the dashboard they are converted back into the encoded format.

This change currently only applies to Metricbeat dashboards but could be applied to all.

