### PR TITLE
Avoid unneeded runner restarts when using config reloading

### DIFF
--- a/libbeat/cfgfile/list.go
+++ b/libbeat/cfgfile/list.go
@@ -79,7 +79,10 @@ func (r *RunnerList) Reload(configs []*ConfigWithMeta) error {
 
 	// Start new runners
 	for hash, config := range startList {
-		runner, err := r.factory.Create(r.pipeline, config.Config, config.Meta)
+		// Pass a copy of the config to the factory, this way if the factory modifies it,
+		// that doesn't affect the hash of the original one.
+		c, _ := common.NewConfigFrom(config.Config)
+		runner, err := r.factory.Create(r.pipeline, c, config.Meta)
 		if err != nil {
 			r.logger.Errorf("Error creating runner from config: %s", err)
 			errs = append(errs, errors.Wrap(err, "Error creating runner from config"))


### PR DESCRIPTION
Introduced by #7172, some inputs/modules may modify the passed
configuration, this results on a effective change on the hash of
the config. Before this change, the reload process was taking a running
config as a not running config. Resulting on a stop/start after the
first run.

Failing example, before this change:

First run (add 1 config):
```
2018-06-01T02:08:20.184+0200    DEBUG   [autodiscover] cfgfile/list.go:53      Starting reload procedure, current runners: 0
2018-06-01T02:08:20.185+0200    INFO    cfgfile/list.go:143 map[type:docker containers:map[ids:[56322b70c8a3712494e559381c7b8a6ce62a6495e33630628e6624b75b5a7505]]]
2018-06-01T02:08:20.185+0200    INFO    cfgfile/list.go:144     Hash: %!s(uint64=12172188027786936243)
2018-06-01T02:08:20.185+0200    DEBUG   [autodiscover] cfgfile/list.go:71      Start list: 1, Stop list: 0
```

Second run (add another config, the first one gets restarted):
```
2018-06-01T02:08:20.185+0200    DEBUG   [autodiscover] cfgfile/list.go:53      Starting reload procedure, current runners: 1
2018-06-01T02:08:20.185+0200    INFO    cfgfile/list.go:143 map[paths:[/var/lib/docker/containers/56322b70c8a3712494e559381c7b8a6ce62a6495e33630628e6624b75b5a7505/*.log] docker-json:map[stream:all partial:true] type:docker containers:map[ids:[56322b70c8a3712494e559381c7b8a6ce62a6495e33630628e6624b75b5a7505]]]
2018-06-01T02:08:20.185+0200    INFO    cfgfile/list.go:144     Hash: %!s(uint64=12741034856879725532)
2018-06-01T02:08:20.185+0200    INFO    cfgfile/list.go:143 map[type:docker containers:map[ids:[a626e25679abd2b9af161277f1beee96c1bba6b9412771d17da7ebfacca640a7]]]
2018-06-01T02:08:20.185+0200    INFO    cfgfile/list.go:144     Hash: %!s(uint64=7080456881540055745)
2018-06-01T02:08:20.185+0200    DEBUG   [autodiscover] cfgfile/list.go:71      Start list: 2, Stop list: 1
```