### PR TITLE
Add links to docs about ssl settings

### DIFF
--- a/heartbeat/docs/heartbeat-options.asciidoc
+++ b/heartbeat/docs/heartbeat-options.asciidoc
@@ -252,8 +252,8 @@ A list of hosts to ping. The entries in the list can be:
 
 * A plain host name, such as `localhost`, or an IP address. If you specify this
 option, you must also specify a value for <<monitor-tcp-ports,`ports`>>.  If the
-monitor is configured to use SSL, Heartbeat establishes an SSL/TLS-based
-connection. Otherwise, it establishes a plain TCP connection.
+monitor is <<configuration-ssl,configured to use SSL>>, Heartbeat establishes an
+SSL/TLS-based connection. Otherwise, it establishes a plain TCP connection.
 * A hostname and port, such as `localhost:12345`. Heartbeat connects
 to the port on the specified host. If the monitor is
 <<configuration-ssl,configured to use SSL>>, Heartbeat establishes an
@@ -360,6 +360,8 @@ Example configuration:
 -------------------------------------------------------------------------------
 
 
+Also see <<configuration-ssl>> for a full description of the `ssl` options.
+
 [float]
 [[monitor-http-options]]
 === HTTP options
@@ -428,6 +430,8 @@ Example configuration:
     supported_protocols: ["TLSv1.0", "TLSv1.1", "TLSv1.2"]
 -------------------------------------------------------------------------------
 
+
+Also see <<configuration-ssl>> for a full description of the `ssl` options.
 
 [float]
 [[monitor-http-check]]

--- a/libbeat/docs/shared-ssl-config.asciidoc
+++ b/libbeat/docs/shared-ssl-config.asciidoc
@@ -1,9 +1,13 @@
 [[configuration-ssl]]
 == Specify SSL settings
 
-You can specify SSL options for any <<configuring-output,output>> that supports
-SSL. You can also specify SSL options when you
-<<setup-kibana-endpoint,set up the Kibana endpoint>>.
+You can specify SSL options when you configure:
+
+* <<configuring-output,outputs>> that support SSL
+* the <<setup-kibana-endpoint,Kibana endpoint>>
+ifeval::["{beatname_lc}"=="heartbeat"]
+* <<configuration-heartbeat-options,{beatname_uc} monitors>> that support SSL
+endif::[]
 
 Example output config with SSL enabled:
 
@@ -28,8 +32,26 @@ setup.kibana.protocol: "https"
 setup.kibana.ssl.enabled: true
 setup.kibana.ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
 setup.kibana.ssl.certificate: "/etc/pki/client/cert.pem"
-setup.kibana.ssl.key: "/etc/pki/client/cert.key
+setup.kibana.ssl.key: "/etc/pki/client/cert.key"
 ----
+
+
+ifeval::["{beatname_lc}"=="heartbeat"]
+Example monitor with SSL enabled:
+
+[source,yaml]
+-------------------------------------------------------------------------------
+heartbeat.monitors:
+- type: tcp
+  schedule: '@every 5s'
+  hosts: ["myhost"]
+  ports: [80, 9200, 5044]
+  ssl:
+    certificate_authorities: ['/etc/ca.crt']
+    supported_protocols: ["TLSv1.0", "TLSv1.1", "TLSv1.2"]
+-------------------------------------------------------------------------------
+endif::[]
+
 
 [float]
 === Configuration options


### PR DESCRIPTION
Closes https://github.com/elastic/beats/issues/5599

I also think users are getting confused because there's too much content in one topic, so I've also opened an issue to restructure the docs a bit and make it easier to find stuff: https://github.com/elastic/beats/issues/7234