### PR TITLE
 Update export_dashboard script to export full dashboard json doc

### DIFF
--- a/libbeat/kibana/dashboard.go
+++ b/libbeat/kibana/dashboard.go
@@ -13,7 +13,7 @@ func RemoveIndexPattern(data []byte) (common.MapStr, error) {
 	var kbResult struct {
 		// Has to be defined as interface instead of Type directly as it has to be assigned again
 		// and otherwise would not contain the full content.
-		Objects []interface{}
+		Objects []common.MapStr
 	}
 
 	var result common.MapStr
@@ -32,11 +32,11 @@ func RemoveIndexPattern(data []byte) (common.MapStr, error) {
 	var objs []interface{}
 
 	for _, obj := range kbResult.Objects {
-		t, ok := obj.(map[string]interface{})["type"].(string)
-		if !ok {
+		v, err := obj.GetValue("type")
+		if err != nil {
 			return nil, fmt.Errorf("type key not found or not string")
 		}
-		if t != "index-pattern" {
+		if v != "index-pattern" {
 			objs = append(objs, obj)
 		}
 	}


### PR DESCRIPTION
In #7239 support to export a dashboard is a added to each Beat. This is expected to be used by users. The export_dashboard script from the Beats repository is expected by the Devs and contributors which want to add new dashboards.

In #7224 the dashboards are modified to be stored with decoded json objects for better versioning. This change modifies the export dashboard script so it generates the same decoded output so no additional conversion is needed.

Note: The export_dashboard script could need some cleanup but I didn't tackle this in this PR and leave it for later to keep the change to a minimum.