### PR TITLE
Cherry-pick #7230 to 6.3: Fix system process CPU ticks field mapping

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -37,6 +37,8 @@ https://github.com/elastic/beats/compare/v6.3.0...6.3[Check the HEAD diff]
 
 *Metricbeat*
 
+- Fix field mapping for the system process CPU ticks fields. {pull}7230[7230]
+
 *Packetbeat*
 
 *Winlogbeat*

--- a/metricbeat/docs/fields.asciidoc
+++ b/metricbeat/docs/fields.asciidoc
@@ -13594,7 +13594,7 @@ The environment variables used to start the process. The data is available on Fr
 CPU-specific statistics per process.
 
 
-*`system.process.cpu.user`*::
+*`system.process.cpu.user.ticks`*::
 +
 --
 type: long
@@ -13638,7 +13638,7 @@ The percentage of CPU time spent by the process since the last event. This value
 
 --
 
-*`system.process.cpu.system`*::
+*`system.process.cpu.system.ticks`*::
 +
 --
 type: long

--- a/metricbeat/module/system/process/_meta/fields.yml
+++ b/metricbeat/module/system/process/_meta/fields.yml
@@ -52,7 +52,7 @@
       prefix: "[float]"
       description: CPU-specific statistics per process.
       fields:
-        - name: user
+        - name: user.ticks
           type: long
           description: >
             The amount of CPU time the process spent in user space.
@@ -73,7 +73,7 @@
             The percentage of CPU time spent by the process since the last event.
             This value is normalized by the number of CPU cores and it ranges
             from 0 to 100%.
-        - name: system
+        - name: system.ticks
           type: long
           description: >
             The amount of CPU time the process spent in kernel space.

--- a/metricbeat/tests/system/test_system.py
+++ b/metricbeat/tests/system/test_system.py
@@ -377,7 +377,8 @@ class Test(metricbeat.BaseTest):
             "metricsets": ["process"],
             "period": "5s",
             "extras": {
-                "process.env.whitelist": ["PATH"]
+                "process.env.whitelist": ["PATH"],
+                "process.include_cpu_ticks": True,
             }
         }])
         proc = self.start_beat()


### PR DESCRIPTION
Cherry-pick of PR #7230 to 6.3 branch. Original message: 

Enabling `process.include_cpu_ticks: true` would cause an Elasticsearch mapping conflict because the `.ticks` fields for user and system were not defined in the fields.yml.