### PR TITLE
Fix conditional coding and keystore CLI example

### DIFF
--- a/libbeat/docs/command-reference.asciidoc
+++ b/libbeat/docs/command-reference.asciidoc
@@ -11,7 +11,6 @@
 
 
 // These attributes are used to resolve short descriptions
-
 :global-flags: Also see <<global-flags,Global flags>>.
 
 :export-command-short-desc: Exports the configuration or index template to stdout
@@ -22,10 +21,10 @@
 
 ifeval::["{has_ml_jobs}"=="yes"]
 :setup-command-short-desc: Sets up the initial environment, including the index template, Kibana dashboards (when available), and machine learning jobs (when available)
-else::[]
-:setup-command-short-desc: Sets up the initial environment, including the index template, Kibana dashboards (when available)
 endif::[]
-
+ifeval::["{has_ml_jobs}"!="yes"]
+:setup-command-short-desc: Sets up the initial environment, including the index template and Kibana dashboards (when available)
+endif::[]
 :test-command-short-desc: Tests the configuration
 :version-command-short-desc: Shows information about the current version
 

--- a/libbeat/docs/keystore.asciidoc
+++ b/libbeat/docs/keystore.asciidoc
@@ -35,7 +35,7 @@ For example, imagine that the keystore contains a key called `ES_PWD` with the
 value `yourelasticsearchpassword`:
 
 * In the configuration file, use `output.elasticsearch.password: "${ES_PWD}"`
-* On the command line, use: `-E "output.elasticsearch.password=${ES_PWD}"`
+* On the command line, use: `-E "output.elasticsearch.password=$\{ES_PWD}"`
 
 When {beatname_uc} unpacks the configuration, it resolves keys before resolving
 environment variables and other variables.


### PR DESCRIPTION
Fixes conditional coding introduced by backport (https://github.com/elastic/beats/commit/29df70d700ee513c328ccf9ec734e7f196ea910f#diff-dbc3375d3e67b2b366ab28f712c00f9d)--`if/else` statements are not valid in asciidoc. The docs in master and 6.3 are OK.

Also fixes the keystore example that shows how to specify a key on the command line (adds backslash to prevent env var evaluation by the shell). This commit needs to be backported/forwardported to other branches.