### PR TITLE
Cherrypick to 6.2: Fix typo in keystore CLI example

### DIFF
--- a/libbeat/docs/keystore.asciidoc
+++ b/libbeat/docs/keystore.asciidoc
@@ -35,7 +35,7 @@ For example, imagine that the keystore contains a key called `ES_PWD` with the
 value `yourelasticsearchpassword`:
 
 * In the configuration file, use `output.elasticsearch.password: "${ES_PWD}"`
-* On the command line, use: `-E "output.elasticsearch.password=$\{ES_PWD}"`
+* On the command line, use: `-E "output.elasticsearch.password=\${ES_PWD}"`
 
 When {beatname_uc} unpacks the configuration, it resolves keys before resolving
 environment variables and other variables.


### PR DESCRIPTION
Cherrypicks https://github.com/elastic/beats/pull/7249/commits/79f9b7ea2d11c385a2f309d8cfbf303d28be4ccf