### PR TITLE
Cherry-pick #7192 to 6.3: Update default value for flush.timeout and flush.min_events

### DIFF
--- a/libbeat/docs/queueconfig.asciidoc
+++ b/libbeat/docs/queueconfig.asciidoc
@@ -66,7 +66,7 @@ Minimum number of events required for publishing. If this value is set to 0, the
 output can start publishing events without additional waiting times. Otherwise
 the output has to wait for more events to become available.
 
-The default value is 0.
+The default value is 2048.
 
 [float]
 ===== `flush.timeout`
@@ -74,5 +74,5 @@ The default value is 0.
 Maximum wait time for `flush.min_events` to be fulfilled. If set to 0s, events
 will be immediately available for consumption.
 
-The default values is 0s.
+The default value is 1s.
 


### PR DESCRIPTION
Cherry-pick of PR #7192 to 6.3 branch. Original message: 

Checking the code, it seems the default `flush.timeout` is `1s` - https://github.com/elastic/beats/blob/v6.2.4/libbeat/publisher/queue/memqueue/config.go#L14-L18 - instead of `0s` . Change needs some dev review to confirm!